### PR TITLE
feat: quote transcript text as a reference chip on the sent message

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-composer-attachment-owner-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-composer-attachment-owner-contract.test.ts
@@ -28,7 +28,7 @@ describe('AppShell composer attachment ownership', () => {
       readFile(resolve(RENDERER_ROOT, 'use-app-shell-composer-attachments.ts'), 'utf8'),
     ]);
 
-    assert.match(shell, /const ok = await send\(text, pending\)/);
+    assert.match(shell, /const ok = await send\(text, pending, \{[^}]*quotes/);
     assert.match(
       shell,
       /const sessionId = activeIdRef\.current;[\s\S]*window\.maka\.sessions\.compact\(sessionId\)/,

--- a/apps/desktop/src/main/__tests__/compact-routing-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/compact-routing-contract.test.ts
@@ -30,7 +30,7 @@ describe('/compact routing contract', () => {
     // returns early so /compact never falls through to the normal send path
     assert.match(send, /return true;/);
     // non-compact text still goes through the normal send path
-    assert.match(send, /const ok = await send\(text, pending\);/);
+    assert.match(send, /const ok = await send\(text, pending, \{[^}]*quotes/);
   });
 
   it('main sessions:compact IPC drives runtime.compactSession via streamEvents', async () => {

--- a/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-new-chat-model-picker-contract.test.ts
@@ -196,7 +196,7 @@ describe('home composer new-chat model picker', () => {
     assert.match(sendBlock, /upsertSessionSummary\(session\);/);
     assert.match(
       sendBlock,
-      /if \(newChatOwner && isNewChatSendSurfaceActive\(newChatOwner\)\) \{[\s\S]*setNavSelection\(\{ section: 'sessions', filter: 'chats' \}\);[\s\S]*setActiveId\(session\.id\);[\s\S]*showOptimisticUserMessage\(session\.id, turnId, text, sendResult\.attachments, \{ replaceCurrentMessages: true \}\);[\s\S]*\}/,
+      /if \(newChatOwner && isNewChatSendSurfaceActive\(newChatOwner\)\) \{[\s\S]*setNavSelection\(\{ section: 'sessions', filter: 'chats' \}\);[\s\S]*setActiveId\(session\.id\);[\s\S]*showOptimisticUserMessage\(session\.id, turnId, text, sendResult\.attachments, \{[\s\S]*?replaceCurrentMessages: true,[\s\S]*\}/,
       'newly-created sessions may only become active if the user is still on the original empty new-chat surface',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -194,6 +194,46 @@ describe('permission response IPC boundary', () => {
     );
   });
 
+  it('normalizes inline quotes and rejects malformed quote payloads', () => {
+    assert.deepEqual(
+      normalizeSessionSendCommand({
+        type: 'send',
+        text: 'explain this',
+        quotes: [
+          { text: 'the excerpt', label: '  助手回复  ', sourceTurnId: 'turn-9', extra: true },
+          { text: 'second' },
+        ],
+      }),
+      {
+        type: 'send',
+        text: 'explain this',
+        quotes: [
+          { text: 'the excerpt', label: '助手回复', sourceTurnId: 'turn-9' },
+          { text: 'second' },
+        ],
+      },
+    );
+    // An empty array carries no reference — drop the key rather than persisting
+    // `quotes: []` onto the message.
+    assert.deepEqual(
+      normalizeSessionSendCommand({ type: 'send', text: 'hi', quotes: [] }),
+      { type: 'send', text: 'hi' },
+    );
+    assert.throws(() => normalizeSessionSendCommand({ type: 'send', text: 'hi', quotes: {} }), /send quotes/);
+    assert.throws(
+      () => normalizeSessionSendCommand({ type: 'send', text: 'hi', quotes: Array(17).fill({ text: 'x' }) }),
+      /send quotes/,
+    );
+    assert.throws(
+      () => normalizeSessionSendCommand({ type: 'send', text: 'hi', quotes: [{ text: '' }] }),
+      /send quote text/,
+    );
+    assert.throws(
+      () => normalizeSessionSendCommand({ type: 'send', text: 'hi', quotes: [{ text: 'x', sourceTurnId: 1 }] }),
+      /send quote sourceTurnId/,
+    );
+  });
+
   it('normalizes stop session input and rejects malformed stop sources', () => {
     assert.deepEqual(normalizeStopSessionInput(undefined), {});
     assert.deepEqual(normalizeStopSessionInput({ source: 'stop_button', extra: true }), { source: 'stop_button' });
@@ -566,7 +606,7 @@ describe('permission response IPC boundary', () => {
     assert.match(sendBlock, /const turnId = crypto\.randomUUID\(\)/);
     assert.match(
       newSessionBranch,
-      /upsertSessionSummary\(session\)[\s\S]*window\.maka\.sessions\.send\(session\.id, \{\s*type: 'send',\s*turnId,\s*text,[\s\S]*if \(newChatOwner && isNewChatSendSurfaceActive\(newChatOwner\)\) \{[\s\S]*setNavSelection\(\{ section: 'sessions', filter: 'chats' \}\)[\s\S]*setActiveId\(session\.id\)[\s\S]*showOptimisticUserMessage\(session\.id, turnId, text, sendResult\.attachments, \{ replaceCurrentMessages: true \}\)[\s\S]*\}[\s\S]*if \(activeIdRef\.current === session\.id\) \{[\s\S]*refreshMessagesUntilTurn\(session\.id, turnId\)[\s\S]*\}[\s\S]*refreshSessions\(\)/,
+      /upsertSessionSummary\(session\)[\s\S]*window\.maka\.sessions\.send\(session\.id, \{\s*type: 'send',\s*turnId,\s*text,[\s\S]*if \(newChatOwner && isNewChatSendSurfaceActive\(newChatOwner\)\) \{[\s\S]*setNavSelection\(\{ section: 'sessions', filter: 'chats' \}\)[\s\S]*setActiveId\(session\.id\)[\s\S]*showOptimisticUserMessage\(session\.id, turnId, text, sendResult\.attachments, \{[\s\S]*?replaceCurrentMessages: true,[\s\S]*\}[\s\S]*if \(activeIdRef\.current === session\.id\) \{[\s\S]*refreshMessagesUntilTurn\(session\.id, turnId\)[\s\S]*\}[\s\S]*refreshSessions\(\)/,
       'normal Composer first-send must switch/show the new user turn only while the empty-chat surface still owns the async continuation',
     );
     assert.doesNotMatch(
@@ -581,7 +621,7 @@ describe('permission response IPC boundary', () => {
     );
     assert.match(
       existingSessionBranch,
-      /window\.maka\.sessions\.send\(sessionId, \{\s*type: 'send',\s*turnId,\s*text,[\s\S]*showOptimisticUserMessage\(sessionId, turnId, text, sendResult\.attachments\)[\s\S]*refreshMessagesUntilTurn\(sessionId, turnId\)/,
+      /window\.maka\.sessions\.send\(sessionId, \{\s*type: 'send',\s*turnId,\s*text,[\s\S]*showOptimisticUserMessage\(sessionId, turnId, text, sendResult\.attachments, \{[\s\S]*?\}\)[\s\S]*refreshMessagesUntilTurn\(sessionId, turnId\)/,
       'existing sessions should also show the user turn immediately before waiting for persisted storage',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-message-lifecycle-contract.test.ts
@@ -51,7 +51,7 @@ describe('active session message lifecycle contract', () => {
     );
     assert.match(
       src,
-      /setActiveId\(session\.id\);[\s\S]*?showOptimisticUserMessage\(session\.id, turnId, text, sendResult\.attachments, \{ replaceCurrentMessages: true \}\)/,
+      /setActiveId\(session\.id\);[\s\S]*?showOptimisticUserMessage\(session\.id, turnId, text, sendResult\.attachments, \{[\s\S]*?replaceCurrentMessages: true,/,
       'the new-session-then-send path lets the optimistic user message overwrite the setActiveId clear in the same React batch, so the first message survives until the real read lands',
     );
     assert.match(

--- a/apps/desktop/src/main/permission-response-guard.ts
+++ b/apps/desktop/src/main/permission-response-guard.ts
@@ -1,6 +1,7 @@
 import type {
   BranchFromTurnInput,
   PermissionResponse,
+  QuoteRef,
   RegenerateTurnInput,
   ReviseBeforeTurnInput,
   TurnOrchestration,
@@ -12,6 +13,9 @@ const MAX_PERMISSION_REQUEST_ID_LENGTH = 128;
 const MAX_TURN_ID_LENGTH = 128;
 const MAX_BRANCH_NAME_LENGTH = 200;
 const MAX_SESSION_SEND_TEXT_LENGTH = 128_000;
+const MAX_QUOTE_COUNT = 16;
+const MAX_QUOTE_TEXT_LENGTH = 32_000;
+const MAX_QUOTE_LABEL_LENGTH = 200;
 
 interface NormalizedSendSessionCommand {
   type: 'send';
@@ -19,6 +23,7 @@ interface NormalizedSendSessionCommand {
   text: string;
   attachmentItems?: unknown;
   turnOrchestration?: TurnOrchestration;
+  quotes?: QuoteRef[];
 }
 type NormalizedStopSessionInput = { source?: 'stop_button' };
 
@@ -111,6 +116,7 @@ export function normalizeSessionSendCommand(input: unknown): NormalizedSendSessi
     ...(value.turnOrchestration !== undefined
       ? { turnOrchestration: normalizeTurnOrchestration(value.turnOrchestration) }
       : {}),
+    ...normalizeOptionalQuotes(value.quotes),
   };
 }
 
@@ -120,6 +126,34 @@ function normalizeTurnOrchestration(input: unknown): TurnOrchestration {
     throw new Error('Invalid turn orchestration');
   }
   return { mode: value.mode, source: value.source };
+}
+
+function normalizeOptionalQuotes(input: unknown): { quotes?: QuoteRef[] } {
+  if (input === undefined) return {};
+  if (!Array.isArray(input) || input.length > MAX_QUOTE_COUNT) {
+    throw new Error('Invalid send quotes');
+  }
+  const quotes = input.map((entry) => {
+    const value = requireObject(entry, 'Invalid send quote');
+    const label =
+      value.label === undefined
+        ? undefined
+        : normalizeOptionalString(value.label, 'Invalid send quote label', MAX_QUOTE_LABEL_LENGTH);
+    const sourceTurnId =
+      value.sourceTurnId === undefined
+        ? undefined
+        : normalizeRequiredString(
+            value.sourceTurnId,
+            'Invalid send quote sourceTurnId',
+            MAX_TURN_ID_LENGTH,
+          );
+    return {
+      text: normalizeRequiredString(value.text, 'Invalid send quote text', MAX_QUOTE_TEXT_LENGTH),
+      ...(label ? { label } : {}),
+      ...(sourceTurnId ? { sourceTurnId } : {}),
+    };
+  });
+  return quotes.length > 0 ? { quotes } : {};
 }
 
 export function normalizeStopSessionInput(input: unknown): NormalizedStopSessionInput {

--- a/apps/desktop/src/main/session-send-resolve.ts
+++ b/apps/desktop/src/main/session-send-resolve.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import type { AttachmentRef, SessionHeader } from '@maka/core';
+import type { AttachmentRef, QuoteRef, SessionHeader } from '@maka/core';
 import type { ArtifactStore } from '@maka/storage';
 import { ingestAttachments, resolveIngestItems } from './attachment-ingest.js';
 import type { AttachmentApprovalRegistry } from './attachment-approval.js';
@@ -9,6 +9,8 @@ export interface SendCommandWithItems {
   turnId?: string;
   text: string;
   attachmentItems?: unknown;
+  /** Inline quoted excerpts; already normalized at the IPC boundary. */
+  quotes?: QuoteRef[];
 }
 
 /**

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -346,6 +346,7 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
           ? { turnOrchestration: sendCommand.turnOrchestration }
           : {}),
         ...(attachments.length > 0 ? { attachments } : {}),
+        ...(sendCommand.quotes ? { quotes: sendCommand.quotes } : {}),
       },
       {
         onRunStarted: async (_runId, header) => {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -196,6 +196,7 @@ export interface MakaBridge {
             text: string;
             attachmentItems?: RendererIngestInput[];
             turnOrchestration?: TurnOrchestration;
+            quotes?: import('@maka/core').QuoteRef[];
           },
     ): Promise<{ turnId: string; attachments: import('@maka/core').AttachmentRef[] }>;
     stop(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -107,6 +107,7 @@ import type {
   AttachmentRef,
   OnboardingMilestoneId,
   QuickChatMode,
+  QuoteRef,
 } from '@maka/core';
 
 type LocalMemoryMutationResult =
@@ -152,6 +153,7 @@ const makaBridge = {
             text: string;
             attachmentItems?: RendererIngestInput[];
             turnOrchestration?: TurnOrchestration;
+            quotes?: QuoteRef[];
           },
     ): Promise<{ turnId: string; attachments: AttachmentRef[] }> {
       if (command.type === 'send' && 'attachmentItems' in command && command.attachmentItems) {

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -2,6 +2,7 @@ import type {
   CollaborationMode,
   OrchestrationMode,
   PermissionResponse,
+  QuoteRef,
   SessionSummary,
   StoredMessage,
   ThinkingLevel,
@@ -112,7 +113,7 @@ export interface AppShellChatActions {
   send(
     text: string,
     pending?: readonly PendingAttachment[],
-    options?: { turnOrchestration?: TurnOrchestration },
+    options?: { turnOrchestration?: TurnOrchestration; quotes?: readonly QuoteRef[] },
   ): Promise<boolean>;
   respondToPermission(response: PermissionResponse): Promise<void>;
   respondToUserQuestion(response: UserQuestionResponse): Promise<void>;
@@ -202,6 +203,7 @@ export function createAppShellChatActions(deps: {
     turnId: string,
     text: string,
     attachments: readonly import('@maka/core').AttachmentRef[] = [],
+    quotes: readonly QuoteRef[] = [],
   ): StoredMessage {
     return {
       type: 'user',
@@ -210,6 +212,7 @@ export function createAppShellChatActions(deps: {
       ts: Date.now(),
       text,
       ...(attachments.length > 0 ? { attachments: [...attachments] } : {}),
+      ...(quotes.length > 0 ? { quotes: [...quotes] } : {}),
     };
   }
 
@@ -218,7 +221,10 @@ export function createAppShellChatActions(deps: {
     turnId: string,
     text: string,
     attachments: readonly import('@maka/core').AttachmentRef[] = [],
-    options: { replaceCurrentMessages?: boolean } = {},
+    options: {
+      replaceCurrentMessages?: boolean;
+      quotes?: readonly QuoteRef[];
+    } = {},
   ): void {
     if (activeIdRef.current !== sessionId) return;
     setMessageLoadErrorBySession((current) => {
@@ -229,7 +235,7 @@ export function createAppShellChatActions(deps: {
     });
     setMessages((current) => {
       if (current.some((message) => message.type === 'user' && message.turnId === turnId)) return current;
-      const next = optimisticUserMessage(turnId, text, attachments);
+      const next = optimisticUserMessage(turnId, text, attachments, options.quotes);
       return options.replaceCurrentMessages ? [next] : [...current, next];
     });
   }
@@ -266,8 +272,12 @@ export function createAppShellChatActions(deps: {
   async function send(
     text: string,
     pending?: readonly PendingAttachment[],
-    options: { turnOrchestration?: TurnOrchestration } = {},
+    options: {
+      turnOrchestration?: TurnOrchestration;
+      quotes?: readonly QuoteRef[];
+    } = {},
   ): Promise<boolean> {
+    const quotes = options.quotes;
     const initialSessionId = activeIdRef.current;
     const newChatOwner = initialSessionId ? null : captureComposerImportOwner();
     let optimisticSessionId: string | undefined;
@@ -303,11 +313,15 @@ export function createAppShellChatActions(deps: {
           text,
           ...(options.turnOrchestration ? { turnOrchestration: options.turnOrchestration } : {}),
           ...(attachmentItems ? { attachmentItems } : {}),
+          ...(quotes && quotes.length > 0 ? { quotes: [...quotes] } : {}),
         });
         if (newChatOwner && isNewChatSendSurfaceActive(newChatOwner)) {
           setNavSelection({ section: 'sessions', filter: 'chats' });
           setActiveId(session.id);
-          showOptimisticUserMessage(session.id, turnId, text, sendResult.attachments, { replaceCurrentMessages: true });
+          showOptimisticUserMessage(session.id, turnId, text, sendResult.attachments, {
+            replaceCurrentMessages: true,
+            ...(quotes && quotes.length > 0 ? { quotes } : {}),
+          });
         }
         if (activeIdRef.current === session.id) {
           await refreshMessagesUntilTurn(session.id, turnId);
@@ -327,8 +341,11 @@ export function createAppShellChatActions(deps: {
         text,
         ...(options.turnOrchestration ? { turnOrchestration: options.turnOrchestration } : {}),
         ...(attachmentItems ? { attachmentItems } : {}),
+        ...(quotes && quotes.length > 0 ? { quotes: [...quotes] } : {}),
       });
-      showOptimisticUserMessage(sessionId, turnId, text, sendResult.attachments);
+      showOptimisticUserMessage(sessionId, turnId, text, sendResult.attachments, {
+        ...(quotes && quotes.length > 0 ? { quotes } : {}),
+      });
       await refreshMessagesUntilTurn(sessionId, turnId);
       return true;
     } catch (error) {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -105,6 +105,7 @@ import {
 import { loadComposerDefaults, saveComposerDefaults } from './composer-defaults';
 import { useKeyedPendingRegistry } from './use-pending-action-registry';
 import { useAppShellComposerAttachments } from './use-app-shell-composer-attachments';
+import { useAppShellComposerQuotes } from './use-app-shell-composer-quotes';
 import { useComposerMentions } from './use-composer-mentions';
 import { useAppShellSessionWorkspace } from './use-app-shell-session-workspace';
 import { useShellExpertTeams } from './use-shell-expert-teams';
@@ -220,6 +221,9 @@ function AppShellContent({
     removeAttachment,
     clearSubmittedAttachments,
   } = useAppShellComposerAttachments({ draftKey: attachmentDraftKey, toastApi });
+  const { pendingQuotes, addQuote, removeQuote, clearQuotes } = useAppShellComposerQuotes({
+    draftKey: attachmentDraftKey,
+  });
   const [newChatPlanModeActive, setNewChatPlanModeActive] = useState(false);
   const [pendingCollaborationModeBySession, setPendingCollaborationModeBySession] = useState<Record<string, boolean>>({});
   const [newChatSwarmModeActive, setNewChatSwarmModeActive] = useState(false);
@@ -1153,18 +1157,23 @@ function AppShellContent({
         return changed;
       }
       const pending = pendingAttachments.length > 0 ? pendingAttachments : undefined;
+      const quotes = pendingQuotes.length > 0 ? pendingQuotes : undefined;
       const ok = await send(swarmCommand.task, pending, {
         turnOrchestration: { mode: 'swarm', source: 'slash_command' },
+        ...(quotes ? { quotes } : {}),
       });
       if (ok !== false && pending) clearSubmittedAttachments(pending);
+      if (ok !== false && quotes) clearQuotes();
       return ok;
     }
     const pending = pendingAttachments.length > 0 ? pendingAttachments : undefined;
     const expectedRevisionSessionId = revisionSend
       ? revisionDraftRef.current?.draftSessionId
       : undefined;
-    const ok = await send(text, pending);
+    const quotes = pendingQuotes.length > 0 ? pendingQuotes : undefined;
+    const ok = await send(text, pending, { ...(quotes ? { quotes } : {}) });
     if (ok !== false && pending) clearSubmittedAttachments(pending);
+    if (ok !== false && quotes) clearQuotes();
     if (ok !== false && revisionSend) {
       if (expectedRevisionSessionId) {
         composerRef.current?.clearDraft(expectedRevisionSessionId);
@@ -1713,6 +1722,10 @@ function AppShellContent({
                 onRevisionNavigate={openSessionInChat}
                 onNew={createSession}
                 onPromptSuggestion={(prompt) => composerRef.current?.appendText(prompt)}
+                onQuoteSelection={(selection) => {
+                  addQuote(selection);
+                  composerRef.current?.focus();
+                }}
                 onContinueDeepResearchHandoff={(run) => {
                   const prompt = buildDeepResearchImplementationPrompt(run);
                   void createSession().then(() => {
@@ -1805,6 +1818,9 @@ function AppShellContent({
                 onSearchMentionFiles={searchMentionFiles}
                 pendingAttachments={pendingAttachments}
                 onRemoveAttachment={removeAttachment}
+                pendingQuotes={pendingQuotes}
+                onRemoveQuote={removeQuote}
+                onPasteAsQuote={addQuote}
                 onPickAttachments={
                   revisionDraft && activeId === revisionDraft.draftSessionId
                     ? undefined

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -40,6 +40,7 @@
 @import "./styles/daily-review.css";
 @import "./styles/theme-glass.css";
 @import "./styles/prompt-rail.css";
+@import "./styles/quote-chip.css";
 
 @theme inline {
   --color-background: var(--background);

--- a/apps/desktop/src/renderer/styles/quote-chip.css
+++ b/apps/desktop/src/renderer/styles/quote-chip.css
@@ -1,0 +1,42 @@
+/* Select-text → quote chip (Codex/Cursor-style).
+   -------------------------------------------------------------------------
+   `.maka-quote-action`: the floating "引用" pill that appears above a text
+   selection in the transcript. Positioned via inline top/left (viewport coords
+   of the selection) and centered on the selection midpoint with
+   translateX(-50%). Low-key elevated pill that brightens on hover; uses
+   neutral state tokens and no cursor:pointer (CSS governance). */
+.maka-quote-action {
+  position: fixed;
+  transform: translateX(-50%);
+  z-index: var(--z-panel-action);
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-1);
+  padding: var(--space-1) var(--space-2-5);
+  border: var(--border-width-hairline) solid var(--border-strong);
+  border-radius: var(--radius-pill);
+  background: var(--background);
+  color: var(--foreground-secondary);
+  box-shadow: var(--shadow-medium);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  transition:
+    color var(--duration-quick) var(--ease-out-strong),
+    background var(--duration-quick) var(--ease-out-strong);
+  -webkit-app-region: no-drag;
+}
+
+.maka-quote-action:hover {
+  color: var(--foreground);
+  background: var(--state-hover-bg);
+}
+
+.maka-quote-action:active {
+  background: var(--state-selected-bg);
+}
+
+.maka-quote-action:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}

--- a/apps/desktop/src/renderer/use-app-shell-composer-quotes.ts
+++ b/apps/desktop/src/renderer/use-app-shell-composer-quotes.ts
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import type { QuoteRef } from '@maka/core';
+import {
+  appendPending,
+  clearPending,
+  removePending,
+  selectPending,
+  type PendingByKey,
+} from './app-shell-pending-attachments';
+
+/**
+ * Excerpts longer than this are truncated before staging. Kept equal to the
+ * `sessions:send` normalizer's per-quote cap so the renderer can never stage
+ * something the IPC boundary would reject on send.
+ */
+const MAX_QUOTE_CHARS = 32_000;
+
+/**
+ * Quoted excerpts staged for the next send, keyed by draft key so each session
+ * keeps its own (mirrors pending attachments). Cleared once the turn is sent.
+ */
+export function useAppShellComposerQuotes(options: { draftKey: string }) {
+  const [pendingByKey, setPendingByKey] = useState<PendingByKey<QuoteRef>>({});
+  const pendingQuotes = selectPending(pendingByKey, options.draftKey);
+
+  function addQuote(input: { text: string; turnId?: string; label?: string }): void {
+    const text = input.text.slice(0, MAX_QUOTE_CHARS).trim();
+    if (!text) return;
+    const ownerKey = options.draftKey;
+    const quote: QuoteRef = {
+      text,
+      ...(input.label ? { label: input.label } : {}),
+      ...(input.turnId ? { sourceTurnId: input.turnId } : {}),
+    };
+    setPendingByKey((map) => appendPending(map, ownerKey, [quote]));
+  }
+
+  function removeQuote(index: number): void {
+    const ownerKey = options.draftKey;
+    setPendingByKey((map) => removePending(map, ownerKey, index));
+  }
+
+  function clearQuotes(): void {
+    const ownerKey = options.draftKey;
+    setPendingByKey((map) => clearPending(map, ownerKey));
+  }
+
+  return { pendingQuotes, addQuote, removeQuote, clearQuotes };
+}

--- a/packages/core/src/backend-types.ts
+++ b/packages/core/src/backend-types.ts
@@ -8,7 +8,7 @@
  * implementation file.
  */
 
-import type { AttachmentRef, SessionEvent } from './events.js';
+import type { AttachmentRef, QuoteRef, SessionEvent } from './events.js';
 import type { RuntimeEvent } from './runtime-event.js';
 import type { StoredMessage, BackendKind } from './session.js';
 import type { PermissionResponse } from './permission.js';
@@ -40,6 +40,8 @@ export interface BackendSendInput {
   headAnchorRuntimeEvent?: RuntimeEvent;
   text: string;
   attachments?: AttachmentRef[];
+  /** Inline quoted excerpts folded into the model-facing user content. */
+  quotes?: QuoteRef[];
   /**
    * Prior conversation projected from the RuntimeEvent ledger into the
    * existing StoredMessage public shape. Adapters materialize this into the

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -63,6 +63,20 @@ export interface AttachmentRef {
   ref: StorageRef;
 }
 
+/**
+ * An inline quoted excerpt attached to a user message — e.g. text selected in
+ * the transcript and carried into a follow-up. Unlike {@link AttachmentRef}
+ * (file-backed), the quoted text lives inline: it renders as a chip on the user
+ * bubble (never as raw body text) and is folded into the model-facing content.
+ */
+export interface QuoteRef {
+  text: string;
+  /** Optional label shown on the chip (e.g. the source turn's role/preview). */
+  label?: string;
+  /** Provenance: the transcript turn the excerpt was selected from. */
+  sourceTurnId?: string;
+}
+
 // ============================================================================
 // Event union
 // ============================================================================

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -51,6 +51,7 @@ export type {
   AbortEvent,
   StorageRef,
   AttachmentRef,
+  QuoteRef,
   AttachmentIngestItem,
   CompleteStopReason,
   ContextBudgetExhaustedDetail,

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -14,7 +14,7 @@
  * projection, or ledger logic lives here. Those arrive in later nodes.
  */
 
-import type { AttachmentRef } from './events.js';
+import type { AttachmentRef, QuoteRef } from './events.js';
 import type { PermissionRequestPayload, PermissionResponse } from './permission.js';
 import type { UserQuestionRequest } from './user-question.js';
 import type {
@@ -126,6 +126,8 @@ export interface RuntimeEventTextContent {
    * into plain text.
    */
   attachments?: AttachmentRef[];
+  /** Inline quoted excerpts carried with the text turn (see QuoteRef). */
+  quotes?: QuoteRef[];
   /**
    * Marks a user message steered into a running turn at a step boundary.
    * `text` stays raw for UI/transcript projections; model-replay projections
@@ -376,7 +378,7 @@ const RUNTIME_EVENT_SHAPE = defineObjectShape<RuntimeEvent>()(
 );
 const TEXT_CONTENT_SHAPE = defineObjectShape<RuntimeEventTextContent>()(
   ['kind', 'text'],
-  ['displayText', 'attachments', 'steering'],
+  ['displayText', 'attachments', 'quotes', 'steering'],
 );
 const THINKING_CONTENT_SHAPE = defineObjectShape<RuntimeEventThinkingContent>()(
   ['kind', 'text'],

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -2,7 +2,7 @@
  * Inputs to runtime APIs (create session, send message, list/filter).
  */
 
-import type { AttachmentRef } from './events.js';
+import type { AttachmentRef, QuoteRef } from './events.js';
 import type { BackendKind, SessionBlockedReason, SessionStatus } from './session.js';
 import type { PermissionMode } from './permission.js';
 import type { ThinkingLevel } from './model-thinking.js';
@@ -59,6 +59,8 @@ export interface UserMessageInput {
   /** Trusted host-supplied orchestration override for this turn only. */
   turnOrchestration?: TurnOrchestration;
   attachments?: AttachmentRef[];
+  /** Inline quoted excerpts; folded into model content, rendered as chips. */
+  quotes?: QuoteRef[];
   parentRunId?: string;
   /** Child AgentRun whose durable conversation this child continues. */
   resumedFromRunId?: string;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -9,6 +9,7 @@
 import {
   TOOL_ACTIVITY_KINDS,
   type AttachmentRef,
+  type QuoteRef,
   type ToolActivityKind,
   type ToolResultContent,
 } from './events.js';
@@ -239,6 +240,8 @@ export interface UserMessage {
    */
   displayText?: string;
   attachments?: AttachmentRef[];
+  /** Inline quoted excerpts carried into this message; rendered as chips. */
+  quotes?: QuoteRef[];
   /** Non-user trigger source (automation fire). Lets the chat mark turns the
    *  user did not hand-type. Mirrors TurnOrigin in runtime-inputs. */
   origin?: { kind: 'automation'; automationId: string };
@@ -411,7 +414,7 @@ export interface SystemNoteMessage {
 
 const USER_MESSAGE_SHAPE = defineObjectShape<UserMessage>()(
   ['type', 'id', 'turnId', 'ts', 'text'],
-  ['displayText', 'attachments', 'origin'],
+  ['displayText', 'attachments', 'quotes', 'origin'],
 );
 const ASSISTANT_MESSAGE_SHAPE = defineObjectShape<AssistantMessage>()(
   ['type', 'id', 'turnId', 'ts', 'text', 'modelId'],

--- a/packages/runtime/src/__tests__/quote-ref-model-visibility.test.ts
+++ b/packages/runtime/src/__tests__/quote-ref-model-visibility.test.ts
@@ -1,0 +1,62 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import { formatTextWithInlineRefs } from '../model-history.js';
+
+/**
+ * A quote chip renders on the user bubble instead of raw body text, so the
+ * excerpt only reaches the model if the inline-ref fold puts it there. These
+ * pin that contract: the excerpt is model-visible, tagged, and folded from
+ * both call shapes (string + explicit refs, and a RuntimeEventTextContent).
+ */
+describe('inline quote refs are folded into model-facing text', () => {
+  it('appends a tagged block carrying the excerpt verbatim', () => {
+    const out = formatTextWithInlineRefs('translate this', {
+      quotes: [{ text: 'the quick brown fox' }],
+    });
+
+    assert.match(out, /^translate this/);
+    assert.match(out, /<quoted_excerpt>\nthe quick brown fox\n<\/quoted_excerpt>/);
+  });
+
+  it('carries the label and escapes a quote character that would break the tag', () => {
+    const out = formatTextWithInlineRefs('explain', {
+      quotes: [{ text: 'body', label: 'assistant "reply"' }],
+    });
+
+    assert.match(out, /<quoted_excerpt label="assistant 'reply'">/);
+    assert.doesNotMatch(out, /label="assistant "reply""/);
+  });
+
+  it('folds every quote and keeps attachments after them', () => {
+    const out = formatTextWithInlineRefs('compare', {
+      quotes: [{ text: 'first' }, { text: 'second' }],
+      attachments: [
+        {
+          kind: 'other',
+          name: 'notes.txt',
+          mimeType: 'text/plain',
+          bytes: 12,
+          ref: { kind: 'session_file', sessionId: 's1', relativePath: 'notes.txt' },
+        },
+      ],
+    });
+
+    assert.ok(out.indexOf('first') < out.indexOf('second'));
+    assert.ok(out.indexOf('second') < out.indexOf('[attachment: notes.txt'));
+  });
+
+  it('reads quotes off a RuntimeEventTextContent without explicit refs', () => {
+    const out = formatTextWithInlineRefs({
+      kind: 'text',
+      text: 'summarize',
+      quotes: [{ text: 'ledger excerpt', sourceTurnId: 'turn-7' }],
+    });
+
+    assert.match(out, /<quoted_excerpt>\nledger excerpt\n<\/quoted_excerpt>/);
+  });
+
+  it('leaves text untouched when the turn carries no refs', () => {
+    assert.equal(formatTextWithInlineRefs('plain turn'), 'plain turn');
+    assert.equal(formatTextWithInlineRefs('plain turn', { quotes: [] }), 'plain turn');
+  });
+});

--- a/packages/runtime/src/agent-flow.ts
+++ b/packages/runtime/src/agent-flow.ts
@@ -30,7 +30,7 @@
  * `RuntimeRunner -> AiSdkFlow` without a flag day.
  */
 
-import type { AttachmentRef } from '@maka/core/events';
+import type { AttachmentRef, QuoteRef } from '@maka/core/events';
 import type { SteeringLease } from '@maka/core/backend-types';
 import type { StoredMessage } from '@maka/core/session';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
@@ -63,6 +63,8 @@ export interface FlowInput {
   text: string;
   /** Optional attachments bound to the user message. */
   attachments?: AttachmentRef[];
+  /** Optional inline quoted excerpts bound to the user message. */
+  quotes?: QuoteRef[];
   /**
    * Prior conversation history for model-history projection. The flow does
    * not own the inclusion policy; it receives whatever the runner/gate

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -405,6 +405,7 @@ export class AgentRun {
         ...(this.input.userInput.attachments
           ? { attachments: this.input.userInput.attachments }
           : {}),
+        ...(this.input.userInput.quotes ? { quotes: this.input.userInput.quotes } : {}),
         context: begin.backendInput.context,
         ...(begin.backendInput.runtimeContext
           ? { runtimeContext: begin.backendInput.runtimeContext }
@@ -436,6 +437,7 @@ export class AgentRun {
       for await (const _runtimeEvent of flow.run(ctx, {
         text: begin.backendInput.text,
         ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),
+        ...(begin.backendInput.quotes ? { quotes: begin.backendInput.quotes } : {}),
         context: begin.backendInput.context,
         ...(begin.backendInput.runtimeContext
           ? { runtimeContext: begin.backendInput.runtimeContext }
@@ -501,6 +503,7 @@ export class AgentRun {
         ...(this.input.userInput.attachments
           ? { attachments: this.input.userInput.attachments }
           : {}),
+        ...(this.input.userInput.quotes ? { quotes: this.input.userInput.quotes } : {}),
         ...(this.input.userInput.origin ? { origin: this.input.userInput.origin } : {}),
       };
       await this.input.store.appendMessage(this.sessionId, userMsg);
@@ -542,6 +545,7 @@ export class AgentRun {
         ...(this.input.userInput.attachments
           ? { attachments: this.input.userInput.attachments }
           : {}),
+        ...(this.input.userInput.quotes ? { quotes: this.input.userInput.quotes } : {}),
         context: projectionContext,
         ...(priorRuntimeContext ? { runtimeContext: priorRuntimeContext.events } : {}),
       },
@@ -627,6 +631,7 @@ export class AgentRun {
       ...(this.input.userInput.attachments !== undefined
         ? { attachments: this.input.userInput.attachments }
         : {}),
+      ...(this.input.userInput.quotes !== undefined ? { quotes: this.input.userInput.quotes } : {}),
       ...(this.toolBoundaryProtocol ? { toolBoundaryProtocol: this.toolBoundaryProtocol } : {}),
     });
   }

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -42,6 +42,7 @@ import type {
   TokenUsageEvent,
   StorageRef,
   AttachmentRef,
+  QuoteRef,
 } from '@maka/core/events';
 import type {
   StoredMessage,
@@ -151,7 +152,7 @@ import {
   buildRuntimeEventModelReplayPlan,
   buildSteeringEnvelope,
   collectToolActivityTurnIds,
-  formatTextWithAttachmentRefs,
+  formatTextWithInlineRefs,
   steeringMessagesMissingFromBase,
   steeringModelMessage,
   steeringProviderOptions,
@@ -1118,7 +1119,7 @@ export class AiSdkBackend implements AgentBackend {
             ]);
         const currentUserContent = input.continuation
           ? undefined
-          : await this.buildCurrentUserContent(input.text, input.attachments);
+          : await this.buildCurrentUserContent(input.text, input.attachments, input.quotes);
         const messages =
           currentUserContent === undefined
             ? [...priorReplay.messages]
@@ -1157,7 +1158,10 @@ export class AiSdkBackend implements AgentBackend {
               priorRuntimeEventCount: priorReplay.runtimeEventCount,
               currentUserContent: input.continuation
                 ? ''
-                : formatTextWithAttachmentRefs(input.text, input.attachments),
+                : formatTextWithInlineRefs(input.text, {
+                    ...(input.attachments !== undefined ? { attachments: input.attachments } : {}),
+                    ...(input.quotes !== undefined ? { quotes: input.quotes } : {}),
+                  }),
               turnTailPrompt,
             }),
             requestShape: computeRequestShapeDiagnostic(
@@ -2680,20 +2684,12 @@ export class AiSdkBackend implements AgentBackend {
         // still presents steering exactly once, in its one provider form.
         const sidecar = steeringSidecar?.get(m.id);
         if (sidecar) {
-          out.push(
-            steeringModelMessage(
-              sidecar.eventId,
-              formatTextWithAttachmentRefs(m.text, m.attachments),
-            ),
-          );
+          out.push(steeringModelMessage(sidecar.eventId, formatTextWithInlineRefs(m.text, m)));
           continue;
         }
         out.push({
           role: 'user',
-          content: await this.appendImageParts(
-            formatTextWithAttachmentRefs(m.text, m.attachments),
-            m.attachments,
-          ),
+          content: await this.appendImageParts(formatTextWithInlineRefs(m.text, m), m.attachments),
         } as ModelMessage);
       }
       // A thinking/tool-only step projects an assistant row with empty text;
@@ -2833,8 +2829,15 @@ export class AiSdkBackend implements AgentBackend {
   private async buildCurrentUserContent(
     text: string,
     attachments?: AttachmentRef[],
+    quotes?: QuoteRef[],
   ): Promise<ModelMessage['content']> {
-    return this.appendImageParts(formatTextWithAttachmentRefs(text, attachments), attachments);
+    return this.appendImageParts(
+      formatTextWithInlineRefs(text, {
+        ...(attachments !== undefined ? { attachments } : {}),
+        ...(quotes !== undefined ? { quotes } : {}),
+      }),
+      attachments,
+    );
   }
 
   private async resolveSystemPrompt(): Promise<string | undefined> {

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -719,6 +719,7 @@ export class AiSdkFlow implements AgentFlow, AgentFlowControl {
           : {}),
         text: input.text,
         ...(input.attachments !== undefined ? { attachments: input.attachments } : {}),
+        ...(input.quotes !== undefined ? { quotes: input.quotes } : {}),
         context: input.context,
         ...(input.runtimeContext !== undefined ? { runtimeContext: input.runtimeContext } : {}),
         ...(input.continuation !== undefined ? { continuation: input.continuation } : {}),

--- a/packages/runtime/src/invocation-context.ts
+++ b/packages/runtime/src/invocation-context.ts
@@ -12,7 +12,7 @@
  * minted inside a flow stay 1:1 with the invocation that produced them.
  */
 
-import type { AttachmentRef } from '@maka/core/events';
+import type { AttachmentRef, QuoteRef } from '@maka/core/events';
 import type { SteeringLease } from '@maka/core/backend-types';
 import type { RuntimeEvent, RuntimeEventStatus } from '@maka/core/runtime-event';
 import type { StoredMessage } from '@maka/core/session';
@@ -82,6 +82,8 @@ export interface InvocationRequest {
   text: string;
   /** Optional attachments bound to this user turn. */
   attachments?: AttachmentRef[];
+  /** Optional inline quoted excerpts bound to this user turn. */
+  quotes?: QuoteRef[];
   /**
    * Prior conversation history resolved by the caller/gate. RuntimeRunner
    * passes this to AgentFlow as `context`, defaulting to [] so flows never

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -43,7 +43,7 @@ import {
   type RuntimeEventRole,
 } from '@maka/core/runtime-event';
 import { normalizeShellToolResultContent } from '@maka/core';
-import type { AttachmentRef } from '@maka/core/events';
+import type { AttachmentRef, QuoteRef } from '@maka/core/events';
 import type { ModelMessage } from 'ai';
 
 // ============================================================================
@@ -442,8 +442,8 @@ export function buildRuntimeEventModelReplayPlan(
           // A steered user event replays in its canonical provider form (the
           // envelope); the raw text is a UI/transcript projection only.
           content: steeringReplay
-            ? buildSteeringEnvelope(formatTextWithAttachmentRefs(event.content))
-            : formatTextWithAttachmentRefs(event.content),
+            ? buildSteeringEnvelope(formatTextWithInlineRefs(event.content))
+            : formatTextWithInlineRefs(event.content),
           ...(steeringReplay ? { steering: { eventId: event.id } } : {}),
           ...(event.content.attachments ? { attachments: event.content.attachments } : {}),
           // Model text carries its step id (the message id) so the materializer
@@ -695,8 +695,8 @@ export function buildTextModelMessagesFromRuntimeEvents(
     out.push({
       role,
       content: steering
-        ? buildSteeringEnvelope(formatTextWithAttachmentRefs(entry.content))
-        : formatTextWithAttachmentRefs(entry.content),
+        ? buildSteeringEnvelope(formatTextWithInlineRefs(entry.content))
+        : formatTextWithInlineRefs(entry.content),
       // Keep the structured identity even in the text-only shape: dedupe
       // against the live injection set works by ledger event id.
       ...(steering ? { providerOptions: steeringProviderOptions(entry.eventId) } : {}),
@@ -828,16 +828,37 @@ export function stripSteeringMessages(
   });
 }
 
-export function formatTextWithAttachmentRefs(
+/**
+ * Fold a user turn's inline references into its model-facing text. Attachments
+ * render as a name/type marker (their bytes, when the model can see them, are
+ * appended separately as image parts); quotes carry their excerpt inline, since
+ * a quote has no backing storage — the text IS the reference. Presentation
+ * layers render both as chips and never show this folded form.
+ */
+export function formatTextWithInlineRefs(
   textOrContent: string | RuntimeEventTextContent,
-  attachments?: AttachmentRef[],
+  refs?: { attachments?: AttachmentRef[]; quotes?: QuoteRef[] },
 ): string {
-  const text = typeof textOrContent === 'string' ? textOrContent : textOrContent.text;
-  const refs = typeof textOrContent === 'string' ? attachments : textOrContent.attachments;
-  if (!refs || refs.length === 0) return text;
-  return `${text}\n\n${formatAttachmentRefs(refs)}`;
+  const fromContent = typeof textOrContent !== 'string';
+  const text = fromContent ? textOrContent.text : textOrContent;
+  const attachments = fromContent ? textOrContent.attachments : refs?.attachments;
+  const quotes = fromContent ? textOrContent.quotes : refs?.quotes;
+  const blocks: string[] = [];
+  if (quotes && quotes.length > 0) blocks.push(formatQuoteRefs(quotes));
+  if (attachments && attachments.length > 0) blocks.push(formatAttachmentRefs(attachments));
+  if (blocks.length === 0) return text;
+  return [text, ...blocks].join('\n\n');
 }
 
 function formatAttachmentRefs(attachments: readonly AttachmentRef[]): string {
   return attachments.map((a) => `[attachment: ${a.name} (${a.mimeType})]`).join(' ');
+}
+
+function formatQuoteRefs(quotes: readonly QuoteRef[]): string {
+  return quotes
+    .map((q) => {
+      const label = q.label === undefined ? '' : ` label="${q.label.replace(/"/g, "'")}"`;
+      return `<quoted_excerpt${label}>\n${q.text}\n</quoted_excerpt>`;
+    })
+    .join('\n');
 }

--- a/packages/runtime/src/runtime-event-adapters.ts
+++ b/packages/runtime/src/runtime-event-adapters.ts
@@ -108,6 +108,9 @@ export function storedMessageToRuntimeEvent(
           ...(message.attachments !== undefined && message.attachments.length > 0
             ? { attachments: message.attachments }
             : {}),
+          ...(message.quotes !== undefined && message.quotes.length > 0
+            ? { quotes: message.quotes }
+            : {}),
         },
         refs: { storedMessageId: message.id },
       };
@@ -250,6 +253,9 @@ export function runtimeEventToStoredMessageDraft(
       ...(content.displayText !== undefined ? { displayText: content.displayText } : {}),
       ...(content.attachments !== undefined && content.attachments.length > 0
         ? { attachments: content.attachments }
+        : {}),
+      ...(content.quotes !== undefined && content.quotes.length > 0
+        ? { quotes: content.quotes }
         : {}),
     };
     return draft;

--- a/packages/runtime/src/runtime-event-backfill.ts
+++ b/packages/runtime/src/runtime-event-backfill.ts
@@ -94,6 +94,9 @@ export function backfillRuntimeEventsFromStoredMessages(
             ...(message.attachments !== undefined && message.attachments.length > 0
               ? { attachments: message.attachments }
               : {}),
+            ...(message.quotes !== undefined && message.quotes.length > 0
+              ? { quotes: message.quotes }
+              : {}),
           },
           actions: { stateDelta: recoveryState(now, message) },
           refs: { storedMessageId: message.id },

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -452,6 +452,9 @@ function projectText(
       ...(event.content.attachments !== undefined && event.content.attachments.length > 0
         ? { attachments: event.content.attachments }
         : {}),
+      ...(event.content.quotes !== undefined && event.content.quotes.length > 0
+        ? { quotes: event.content.quotes }
+        : {}),
     });
     return true;
   }
@@ -1149,6 +1152,7 @@ function semanticMessage(message: StoredMessage): unknown {
         text: message.text,
         displayText: message.displayText,
         attachments: message.attachments ?? [],
+        quotes: message.quotes ?? [],
       };
     case 'assistant':
       return {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -742,6 +742,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           : {}),
         text: input.text,
         ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),
+        ...(begin.backendInput.quotes ? { quotes: begin.backendInput.quotes } : {}),
         context: begin.backendInput.context,
         ...(begin.backendInput.runtimeContext !== undefined
           ? { runtimeContext: begin.backendInput.runtimeContext }

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -121,6 +121,7 @@ export interface InitialUserRuntimeEventInput {
   /** Human-facing view when it differs from `text`; see RuntimeEventTextContent. */
   displayText?: string;
   attachments?: InvocationRequest['attachments'];
+  quotes?: InvocationRequest['quotes'];
   toolBoundaryProtocol?: ToolBoundaryProtocol;
 }
 
@@ -188,7 +189,11 @@ export class RuntimeRunner {
       if (!request.runtimeContext) {
         throw new Error('Runtime continuation requires replay context');
       }
-      if (request.text.length > 0 || request.attachments !== undefined) {
+      if (
+        request.text.length > 0 ||
+        request.attachments !== undefined ||
+        request.quotes !== undefined
+      ) {
         throw new Error('Runtime continuation cannot carry a new user message or attachments');
       }
       assertRuntimeContinuationEnvelope({
@@ -281,6 +286,7 @@ export class RuntimeRunner {
           ...(ctx.branch ? { branch: ctx.branch } : {}),
           text: request.text,
           ...(request.attachments !== undefined ? { attachments: request.attachments } : {}),
+          ...(request.quotes !== undefined ? { quotes: request.quotes } : {}),
           ...(this.toolBoundaryProtocol ? { toolBoundaryProtocol: this.toolBoundaryProtocol } : {}),
         });
       events.push(userEvent);
@@ -486,6 +492,7 @@ export function buildInitialUserRuntimeEvent(input: InitialUserRuntimeEventInput
       ...(input.attachments !== undefined && input.attachments.length > 0
         ? { attachments: input.attachments }
         : {}),
+      ...(input.quotes !== undefined && input.quotes.length > 0 ? { quotes: input.quotes } : {}),
     },
     ...(input.toolBoundaryProtocol
       ? { actions: { runtimeProtocol: { toolBoundary: input.toolBoundaryProtocol } } }
@@ -525,6 +532,7 @@ function buildFlowInput(request: InvocationRequest): FlowInput {
     ...(request.runtimeContext !== undefined ? { runtimeContext: request.runtimeContext } : {}),
     ...(continuation !== undefined ? { continuation } : {}),
     ...(request.attachments !== undefined ? { attachments: request.attachments } : {}),
+    ...(request.quotes !== undefined ? { quotes: request.quotes } : {}),
     ...(request.pullSteering !== undefined ? { pullSteering: request.pullSteering } : {}),
     ...(request.ackSteering !== undefined ? { ackSteering: request.ackSteering } : {}),
     ...(request.nackSteering !== undefined ? { nackSteering: request.nackSteering } : {}),

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1491,6 +1491,7 @@ export class SessionManager {
       text: user.text,
       ...(user.displayText !== undefined ? { displayText: user.displayText } : {}),
       ...(user.attachments ? { attachments: user.attachments } : {}),
+      ...(user.quotes ? { quotes: user.quotes } : {}),
       parentTurnId: source.turnId,
       regeneratedFromTurnId: source.turnId,
     });

--- a/packages/ui/src/__tests__/composer-helpers.test.ts
+++ b/packages/ui/src/__tests__/composer-helpers.test.ts
@@ -1,11 +1,14 @@
 import { describe, it } from 'node:test';
 import assert from 'node:assert/strict';
 import {
+  isReferenceSizedPaste,
   navigateComposerHistory,
   readComposerDraft,
   reconcileHistorySync,
   rememberComposerDraft,
   rememberComposerHistoryEntry,
+  PASTE_AS_QUOTE_MIN_CHARS,
+  PASTE_AS_QUOTE_MIN_LINES,
   type ComposerHistoryState,
 } from '../composer-helpers.js';
 
@@ -203,5 +206,30 @@ describe('navigateComposerHistory', () => {
     }
     assert.equal(value, '原始输入');
     assert.deepEqual(state, { entries: ['one', 'two'], index: -1, savedDraft: '' });
+  });
+});
+
+// A reference-sized paste becomes a quote chip instead of flooding the
+// textarea. The threshold has to catch both shapes of reference material —
+// long prose (few lines, many characters) and logs/diffs (many short lines) —
+// without stealing an ordinary multi-line prompt the user is still writing.
+describe('isReferenceSizedPaste', () => {
+  it('leaves an ordinary prompt alone', () => {
+    assert.equal(isReferenceSizedPaste(''), false);
+    assert.equal(isReferenceSizedPaste('fix the failing test'), false);
+    assert.equal(isReferenceSizedPaste('line one\nline two\nline three'), false);
+  });
+
+  it('catches a wall of prose on the character bound', () => {
+    assert.equal(isReferenceSizedPaste('x'.repeat(PASTE_AS_QUOTE_MIN_CHARS - 1)), false);
+    assert.equal(isReferenceSizedPaste('x'.repeat(PASTE_AS_QUOTE_MIN_CHARS)), true);
+  });
+
+  it('catches a log or diff on the line bound while each line stays short', () => {
+    const lines = (count: number) => Array.from({ length: count }, () => 'ok').join('\n');
+    assert.equal(isReferenceSizedPaste(lines(PASTE_AS_QUOTE_MIN_LINES)), false);
+    const pasted = lines(PASTE_AS_QUOTE_MIN_LINES + 1);
+    assert.ok(pasted.length < PASTE_AS_QUOTE_MIN_CHARS, 'must trip the line bound, not the char bound');
+    assert.equal(isReferenceSizedPaste(pasted), true);
   });
 });

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -8,9 +8,10 @@ import { formatAbsoluteTimestamp, formatClockTime, turnAbortMarkerLabel } from '
 import { prepareSmoothStreamText, useSmoothStreamContent } from './smooth-stream.js';
 import { tokenizeFade, useStreamFade, type StreamFade } from './stream-fade.js';
 import { Button as UiButton, DialogContent, DialogRoot } from './ui.js';
-import type { AttachmentRef } from '@maka/core';
+import type { AttachmentRef, QuoteRef } from '@maka/core';
 import type { TurnTimelineItem, TurnViewModel } from './materialize.js';
 import { AttachmentFileCard } from './attachment-file-card.js';
+import { QuoteRefChip } from './quote-ref-chip.js';
 import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from './primitives/collapsible.js';
 import { Bubble, Marker, markerVariants, Message, TextShimmer } from './primitives/chat.js';
 import { Tooltip, TooltipTrigger, TooltipContent } from './primitives/tooltip.js';
@@ -97,6 +98,7 @@ const MessageBody = memo(function MessageBody(props: {
   text: string;
   ts?: number;
   attachments?: readonly AttachmentRef[];
+  quotes?: readonly QuoteRef[];
   onReadAttachmentBytes?: ReadAttachmentBytes;
   /** When set on a user message, show an edit affordance that starts a revision draft. */
   onEditUserMessage?: () => void;
@@ -121,6 +123,13 @@ const MessageBody = memo(function MessageBody(props: {
       <>
         <Bubble variant="user">
           <span>{props.text}</span>
+          {props.quotes && props.quotes.length > 0 ? (
+            <div className="maka-user-quotes flex flex-wrap items-start gap-1 mt-1">
+              {props.quotes.map((quote, index) => (
+                <QuoteRefChip key={`${quote.sourceTurnId ?? 'quote'}-${index}`} quote={quote} />
+              ))}
+            </div>
+          ) : null}
           {props.attachments && props.attachments.length > 0 ? (
             <div className="maka-user-attachments flex flex-wrap gap-1.5 mt-2">
               {props.attachments.map((attachment, index) => (
@@ -420,14 +429,19 @@ export const TurnView = memo(function TurnView(props: {
             text={turn.user.text}
             ts={turn.user.ts}
             attachments={turn.user.attachments}
+            quotes={turn.user.quotes}
             onReadAttachmentBytes={props.onReadAttachmentBytes}
             onEditUserMessage={
               props.onEditUserMessage && !turn.user.automationOrigin
                 ? () => props.onEditUserMessage?.(turn.turnId)
                 : undefined
             }
+            // A revision restages neither attachments nor quotes, so a turn
+            // carrying either can't be edited without silently dropping the
+            // reference the answer was grounded in.
             editDisabled={
               (turn.user.attachments?.length ?? 0) > 0 ||
+              (turn.user.quotes?.length ?? 0) > 0 ||
               props.editUserMessageTransformed === true ||
               props.editUserMessageDisabled === true ||
               turn.status === 'running' ||
@@ -436,11 +450,14 @@ export const TurnView = memo(function TurnView(props: {
             editDisabledReason={
               (turn.user.attachments?.length ?? 0) > 0
                 ? copy.editMessageDisabledAttachments
-                : props.editUserMessageTransformed
-                  ? copy.editMessageDisabledTransformedText
-                  : copy.editMessageDisabledRunning
+                : (turn.user.quotes?.length ?? 0) > 0
+                  ? copy.editMessageDisabledQuotes
+                  : props.editUserMessageTransformed
+                    ? copy.editMessageDisabledTransformedText
+                    : copy.editMessageDisabledRunning
             }
           />
+
         </Message>
       )}
       {turn.notes.map((note) => (

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -11,11 +11,13 @@ import {
   History,
   Target,
   Sparkles,
+  TextQuote,
 } from './icons.js';
 import { DeepResearchEmptyHero, EmptyChatHero } from './chat-empty-hero.js';
 import type { ChatModelChoice } from './chat-model-helpers.js';
 import { OverlayScrollArea } from './overlay-scroll-area.js';
 import { PromptAnchorRail } from './prompt-anchor-rail.js';
+import { useMessageSelectionQuote } from './use-message-selection-quote.js';
 import type {
   DeepResearchRun,
   ProviderType,
@@ -195,6 +197,13 @@ export function ChatView(props: {
   onReadAttachmentBytes?: ReadAttachmentBytes;
   onNew(): void;
   onPromptSuggestion?(prompt: string): void;
+  /**
+   * Codex/Cursor-style "quote this": when set, selecting text in the transcript
+   * surfaces a floating action that hands the excerpt (+ its turn) to the host,
+   * which stages it as a quote chip on the composer. Omitted by hosts that
+   * don't compose quotes.
+   */
+  onQuoteSelection?(input: { text: string; turnId?: string }): void;
 }) {
   const copy = getConversationCopy(useUiLocale()).chat;
   // chat + storedTools survive for the empty-state and streaming-bubble
@@ -332,6 +341,10 @@ export function ChatView(props: {
     target: props.scrollTargetTurn,
     behavior: props.scrollBehavior,
   });
+  const { quote: selectionQuote, clear: clearSelectionQuote } = useMessageSelectionQuote(
+    scrollRef,
+    Boolean(props.onQuoteSelection),
+  );
 
   if (!props.activeSession) {
     return (
@@ -543,6 +556,29 @@ export function ChatView(props: {
             <ArrowDown size={16} aria-hidden="true" />
           </BaseButton>
         )}
+        {selectionQuote && props.onQuoteSelection ? (
+          <button
+            type="button"
+            className="maka-quote-action"
+            style={{
+              top: `${Math.max(8, selectionQuote.rect.top - 42)}px`,
+              left: `${selectionQuote.rect.left + selectionQuote.rect.width / 2}px`,
+            }}
+            // Keep the live selection alive while clicking the action.
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => {
+              props.onQuoteSelection?.({
+                text: selectionQuote.text,
+                ...(selectionQuote.turnId ? { turnId: selectionQuote.turnId } : {}),
+              });
+              clearSelectionQuote();
+              window.getSelection()?.removeAllRanges();
+            }}
+          >
+            <TextQuote size={14} aria-hidden="true" />
+            {copy.quoteSelection}
+          </button>
+        ) : null}
       </div>
     </main>
   );

--- a/packages/ui/src/composer-helpers.ts
+++ b/packages/ui/src/composer-helpers.ts
@@ -163,3 +163,26 @@ export function reconcileHistorySync(
     restoreDraft: false,
   };
 }
+
+/**
+ * Paste size at which text becomes a quote chip instead of textarea content.
+ * Either bound alone is enough: a wall of prose trips the character bound, a
+ * pasted log or diff trips the line bound while staying short per line.
+ */
+export const PASTE_AS_QUOTE_MIN_CHARS = 1_000;
+export const PASTE_AS_QUOTE_MIN_LINES = 10;
+
+/**
+ * True when a paste is reference material (a log, a diff, a doc section) rather
+ * than something the user will keep editing inline. Reference-sized pastes are
+ * staged as a quote chip so they stay model-visible without flooding the
+ * composer; anything smaller is left alone, because the user is writing.
+ */
+export function isReferenceSizedPaste(text: string): boolean {
+  if (text.length >= PASTE_AS_QUOTE_MIN_CHARS) return true;
+  let lines = 1;
+  for (let i = 0; i < text.length; i++) {
+    if (text[i] === '\n' && ++lines > PASTE_AS_QUOTE_MIN_LINES) return true;
+  }
+  return false;
+}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -16,7 +16,7 @@ import { ChatModelSwitcher, ModelChipStatic, NewChatModelPicker } from './chat-m
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
 import { type ChatModelChoice, modelChoiceValue } from './chat-model-helpers.js';
-import { appendPromptContextDraft } from './composer-helpers.js';
+import { appendPromptContextDraft, isReferenceSizedPaste } from './composer-helpers.js';
 import { useComposerDraft } from './use-composer-draft.js';
 import { useComposerHistory } from './use-composer-history.js';
 import {
@@ -29,10 +29,11 @@ import {
 import { ComposerMentionPopup, mentionOptionId } from './composer-mention-popup.js';
 import { useMentionPopup } from './use-mention-popup.js';
 import { ComposerWorkspaceRow, type ComposerBranchPicker, type ComposerWorkspacePicker } from './composer-workspace-row.js';
-import type { AttachmentRef, PermissionMode, ProviderType, SessionSummary } from '@maka/core';
+import type { AttachmentRef, PermissionMode, ProviderType, QuoteRef, SessionSummary } from '@maka/core';
 import { Button as UiButton, Switch } from './ui.js';
 import { Textarea as UiTextarea } from './primitives/textarea.js';
 import { AttachmentFileCard } from './attachment-file-card.js';
+import { QuoteRefChip } from './quote-ref-chip.js';
 import { Kbd } from './primitives/kbd.js';
 import { PermissionModeSelect } from './permission-mode-menu.js';
 import { Menu, MenuItem, MenuPopup, MenuSub, MenuSubPopup, MenuSubTrigger, MenuTrigger } from './primitives/menu.js';
@@ -102,6 +103,15 @@ export const Composer = forwardRef<
     onAttachFilePaths?(files: File[]): void | Promise<void>;
     pendingAttachments?: readonly { displayName: string; kind: AttachmentRef['kind']; mimeType?: string; size: number }[];
     onRemoveAttachment?(index: number): void;
+    /** Quoted excerpts staged for the next send; rendered as removable chips. */
+    pendingQuotes?: readonly QuoteRef[];
+    onRemoveQuote?(index: number): void;
+    /**
+     * Stage a reference-sized paste as a quote chip rather than letting it
+     * flood the textarea. Omitted by hosts that don't compose quotes, in which
+     * case a large paste behaves like any other paste.
+     */
+    onPasteAsQuote?(input: { text: string; label?: string }): void;
     /** Built-in expert teams offered under 专家团 in the "+" menu. */
     expertTeams?: readonly { id: string; name: string; description?: string }[];
     /** Start a new expert-team session from the "+" menu. */
@@ -509,12 +519,30 @@ export const Composer = forwardRef<
     // + a typed cast so this compiles AND keeps working when the
     // browser does expose the flag.
     if (isChatInputComposing(event, compositionActiveRef.current)) return;
-    if (!hasPastedFiles(event)) return;
+    if (!hasPastedFiles(event)) {
+      pasteLongTextAsQuote(event);
+      return;
+    }
     if (!canAcceptDroppedFiles()) return;
     const files = Array.from(event.clipboardData.files);
     if (files.length === 0) return;
     event.preventDefault();
     void runImportAction('attach', () => props.onAttachFilePaths?.(files));
+  }
+
+  /**
+   * A paste this big is reference material (a log, a diff, a doc section), not
+   * a prompt the user is going to keep editing inline — so it becomes a quote
+   * chip instead of flooding the textarea, and the model still receives it
+   * verbatim. Below the threshold the paste stays a normal paste; the user is
+   * writing, not attaching.
+   */
+  function pasteLongTextAsQuote(event: ClipboardEvent<HTMLTextAreaElement>) {
+    if (!props.onPasteAsQuote || props.disabled) return;
+    const text = event.clipboardData.getData('text/plain');
+    if (!isReferenceSizedPaste(text)) return;
+    event.preventDefault();
+    props.onPasteAsQuote({ text, label: copy.pastedQuoteLabel });
   }
 
   useEffect(() => {
@@ -597,6 +625,19 @@ export const Composer = forwardRef<
         className="maka-composer-inner composerInner agents-parchment-paper-surface"
         data-streaming={props.streaming ? 'true' : undefined}
       >
+        {/* No px on the chip row: `.maka-composer-inner` already pads the card,
+            so an extra px-3 would sit the chips 12px right of the textarea. */}
+        {props.pendingQuotes && props.pendingQuotes.length > 0 ? (
+          <div className="flex flex-wrap items-start gap-1 pb-1">
+            {props.pendingQuotes.map((quote, index) => (
+              <QuoteRefChip
+                key={`${quote.sourceTurnId ?? 'quote'}-${index}`}
+                quote={quote}
+                onRemove={props.onRemoveQuote ? () => props.onRemoveQuote?.(index) : undefined}
+              />
+            ))}
+          </div>
+        ) : null}
         {props.pendingAttachments && props.pendingAttachments.length > 0 ? (
           <div className="flex flex-wrap gap-1.5 px-3 pt-2">
             {props.pendingAttachments.map((attachment, index) => (

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -58,6 +58,7 @@ export interface ConversationCopy {
   composer: {
     placeholder: string;
     textareaAriaLabel: string;
+    pastedQuoteLabel: string;
     awaitingPermission: string;
     sending: string;
     importing: string;
@@ -205,6 +206,7 @@ export interface ConversationCopy {
     editMessage: string;
     editMessageDisabledRunning: string;
     editMessageDisabledAttachments: string;
+    editMessageDisabledQuotes: string;
     editMessageDisabledTransformedText: string;
     copyThinking: string;
     imageAriaLabel: (name: string) => string;
@@ -218,6 +220,10 @@ export interface ConversationCopy {
     thinkingTruncatedTitle: string;
     outputTruncatedTitle: string;
     removeAttachmentAriaLabel: (name: string) => string;
+    quoteLabel: string;
+    quoteExpandAriaLabel: string;
+    quoteCollapseAriaLabel: string;
+    removeQuoteAriaLabel: string;
     aborted: string;
     abortedByStop: string;
   };
@@ -252,6 +258,7 @@ export interface ConversationCopy {
     loading: string;
     retryLoad: string;
     jumpLatest: string;
+    quoteSelection: string;
     noMessages: string;
     branchTitle: (name: string, beforeAbort: boolean) => string;
     branchLabel: (name: string, beforeAbort: boolean) => string;
@@ -319,7 +326,7 @@ const CONVERSATION_COPY = {
       startersAriaLabel: '深度研究起手式', starters: DEEP_RESEARCH_STARTER_PROMPTS,
     },
     composer: {
-      placeholder: '描述任务，@ 引用文件，/ 选择技能…', textareaAriaLabel: '消息输入框', awaitingPermission: '等待你确认权限…',
+      placeholder: '描述任务，@ 引用文件，/ 选择技能…', textareaAriaLabel: '消息输入框', pastedQuoteLabel: '粘贴的文本', awaitingPermission: '等待你确认权限…',
       sending: '正在发送…', importing: '正在导入…', sendLabel: '发送', stopLabel: '停止', stopping: '停止中…',
       streaming: 'Maka 正在回答…', processing: 'Maka 正在处理…', continuing: 'Maka 继续中…',
       interruptHint: '或点停止中断', addContext: '添加上下文', importText: '导入文本文件', attachFile: '附加文件', expertTeam: '专家团',
@@ -367,9 +374,9 @@ const CONVERSATION_COPY = {
       branchTitle: (branch) => branch ? `分支：${branch}` : '选择分支', branchAriaLabel: (branch) => branch ? `切换分支：${branch}` : '选择分支',
     },
     messages: {
-      you: '你', assistant: 'Maka', processing: '正在处理…', continuing: '继续中…', safeResumePending: '正在验证…', safeResume: '安全恢复', thinking: '深度思考', truncated: '已截断', copied: '已复制', copying: '复制中', copyFailed: '复制失败', copy: '复制', copyMessage: '复制消息', editMessage: '编辑并重发', editMessageDisabledRunning: '当前回答仍在进行中，结束后再编辑', editMessageDisabledAttachments: '包含附件的历史消息暂不支持编辑并重发', editMessageDisabledTransformedText: '通过显式技能发送的历史消息暂不支持编辑并重发', copyThinking: '复制思考过程',
+      you: '你', assistant: 'Maka', processing: '正在处理…', continuing: '继续中…', safeResumePending: '正在验证…', safeResume: '安全恢复', thinking: '深度思考', truncated: '已截断', copied: '已复制', copying: '复制中', copyFailed: '复制失败', copy: '复制', copyMessage: '复制消息', editMessage: '编辑并重发', editMessageDisabledRunning: '当前回答仍在进行中，结束后再编辑', editMessageDisabledAttachments: '包含附件的历史消息暂不支持编辑并重发', editMessageDisabledQuotes: '包含引用的历史消息暂不支持编辑并重发', editMessageDisabledTransformedText: '通过显式技能发送的历史消息暂不支持编辑并重发', copyThinking: '复制思考过程',
       imageAriaLabel: (name) => `查看图片 ${name}`, userAriaLabel: '你发送的消息', assistantAriaLabel: 'Maka 的回答', answerActionsAriaLabel: '本轮回答操作', sourceAriaLabel: '本轮回答的来源', derivativesAriaLabel: '本轮回答的衍生', automationTriggered: '定时任务触发', automationTitle: (id) => `由定时任务触发 · ${id}`,
-      thinkingTruncatedTitle: '部分 reasoning 已截断；显示的是最近的内容', outputTruncatedTitle: '助手输出已超过单次回合上限，超出部分未渲染。如需完整内容请重新生成或查看持久化的会话日志。', removeAttachmentAriaLabel: (name) => `移除 ${name}`, aborted: '(已中断)', abortedByStop: '(已中断 · 由停止按钮触发)',
+      thinkingTruncatedTitle: '部分 reasoning 已截断；显示的是最近的内容', outputTruncatedTitle: '助手输出已超过单次回合上限，超出部分未渲染。如需完整内容请重新生成或查看持久化的会话日志。', removeAttachmentAriaLabel: (name) => `移除 ${name}`, quoteLabel: '引用', quoteExpandAriaLabel: '展开引用全文', quoteCollapseAriaLabel: '收起引用', removeQuoteAriaLabel: '移除引用', aborted: '(已中断)', abortedByStop: '(已中断 · 由停止按钮触发)',
     },
     chat: {
       memory: '记忆', memoryAriaLabel: '本地记忆已启用', memoryTitle: '本地 MEMORY.md 已加入 agent 系统提示。点击进入设置 · 记忆管理。', deepResearch: '深度研究', deepResearchAriaLabel: '深度研究，只读探索', deepResearchTitle: '深度研究会话使用只读探索边界：先阅读和分析，默认不改文件。',
@@ -397,7 +404,7 @@ const CONVERSATION_COPY = {
         },
       },
       clearGoal: (condition, iteration, max, status) => `自主执行目标进行中：「${condition}」（第 ${iteration}/${max} 轮，${status}）。系统每轮后自动续行；点击可清除目标、停止续行。`, clearGoalAriaLabel: (iteration, max) => `清除自主执行目标（已进行 ${iteration}/${max} 轮）`, goalLabel: (iteration, max) => `目标 ${iteration}/${max} · 清除`,
-      loadFailed: '对话载入失败', loading: '载入中…', retryLoad: '重试载入', jumpLatest: '跳到最新消息', noMessages: '暂无消息',
+      loadFailed: '对话载入失败', loading: '载入中…', retryLoad: '重试载入', jumpLatest: '跳到最新消息', quoteSelection: '引用', noMessages: '暂无消息',
       branchTitle: (name, beforeAbort) => beforeAbort ? `从中断前分支自 ${name} · 点击跳回原会话` : `分自 ${name} · 点击跳回原会话`, branchLabel: (name, beforeAbort) => beforeAbort ? `从中断前分支自 ${name}` : `分自 ${name}`,
       revisionVersionsAriaLabel: '对话版本', revisionVersion: (current, total) => `版本 ${current} / ${total}`, previousRevision: '查看上一版本', nextRevision: '查看下一版本',
     },
@@ -454,7 +461,7 @@ const CONVERSATION_COPY = {
       ],
     },
     composer: {
-      placeholder: 'Describe a task, @ to reference files, / for skills…', textareaAriaLabel: 'Message input', awaitingPermission: 'Waiting for your permission decision…',
+      placeholder: 'Describe a task, @ to reference files, / for skills…', textareaAriaLabel: 'Message input', pastedQuoteLabel: 'Pasted text', awaitingPermission: 'Waiting for your permission decision…',
       sending: 'Sending…', importing: 'Importing…', sendLabel: 'Send', stopLabel: 'Stop', stopping: 'Stopping…',
       streaming: 'Maka is responding…', processing: 'Maka is working…', continuing: 'Maka is continuing…',
       interruptHint: 'or click Stop to interrupt', addContext: 'Add context', importText: 'Import text file', attachFile: 'Attach file', expertTeam: 'Expert team',
@@ -502,9 +509,9 @@ const CONVERSATION_COPY = {
       branchTitle: (branch) => branch ? `Branch: ${branch}` : 'Choose branch', branchAriaLabel: (branch) => branch ? `Switch branch: ${branch}` : 'Choose branch',
     },
     messages: {
-      you: 'You', assistant: 'Maka', processing: 'Working…', continuing: 'Continuing…', safeResumePending: 'Checking…', safeResume: 'Safe recovery', thinking: 'Thinking', truncated: 'Truncated', copied: 'Copied', copying: 'Copying', copyFailed: 'Copy failed', copy: 'Copy', copyMessage: 'Copy message', editMessage: 'Edit & resend', editMessageDisabledRunning: 'Wait for this answer to finish before editing', editMessageDisabledAttachments: 'Edit & resend does not yet support messages with attachments', editMessageDisabledTransformedText: 'Edit & resend does not yet support messages sent with an explicit skill', copyThinking: 'Copy reasoning',
+      you: 'You', assistant: 'Maka', processing: 'Working…', continuing: 'Continuing…', safeResumePending: 'Checking…', safeResume: 'Safe recovery', thinking: 'Thinking', truncated: 'Truncated', copied: 'Copied', copying: 'Copying', copyFailed: 'Copy failed', copy: 'Copy', copyMessage: 'Copy message', editMessage: 'Edit & resend', editMessageDisabledRunning: 'Wait for this answer to finish before editing', editMessageDisabledAttachments: 'Edit & resend does not yet support messages with attachments', editMessageDisabledQuotes: 'Edit & resend does not yet support messages with quotes', editMessageDisabledTransformedText: 'Edit & resend does not yet support messages sent with an explicit skill', copyThinking: 'Copy reasoning',
       imageAriaLabel: (name) => `View image ${name}`, userAriaLabel: 'Your message', assistantAriaLabel: "Maka's response", answerActionsAriaLabel: 'Response actions', sourceAriaLabel: 'Source of this response', derivativesAriaLabel: 'Responses derived from this one', automationTriggered: 'Triggered by automation', automationTitle: (id) => `Triggered by automation · ${id}`,
-      thinkingTruncatedTitle: 'Some reasoning was truncated; showing the most recent content', outputTruncatedTitle: 'The assistant output exceeded the per-turn limit. Regenerate it or inspect the persisted session log for the complete content.', removeAttachmentAriaLabel: (name) => `Remove ${name}`, aborted: '(Interrupted)', abortedByStop: '(Interrupted · Stop button)',
+      thinkingTruncatedTitle: 'Some reasoning was truncated; showing the most recent content', outputTruncatedTitle: 'The assistant output exceeded the per-turn limit. Regenerate it or inspect the persisted session log for the complete content.', removeAttachmentAriaLabel: (name) => `Remove ${name}`, quoteLabel: 'Quote', quoteExpandAriaLabel: 'Show the full quoted excerpt', quoteCollapseAriaLabel: 'Collapse the quoted excerpt', removeQuoteAriaLabel: 'Remove quote', aborted: '(Interrupted)', abortedByStop: '(Interrupted · Stop button)',
     },
     chat: {
       memory: 'Memory', memoryAriaLabel: 'Local memory enabled', memoryTitle: 'Local MEMORY.md is included in the agent system prompt. Click to manage it in Settings · Memory.', deepResearch: 'Deep Research', deepResearchAriaLabel: 'Deep Research, read-only exploration', deepResearchTitle: 'Deep Research uses a read-only boundary: inspect and analyze first, without changing files by default.',
@@ -532,7 +539,7 @@ const CONVERSATION_COPY = {
         },
       },
       clearGoal: (condition, iteration, max, status) => `Autonomous goal in progress: “${condition}” (iteration ${iteration}/${max}, ${status}). Maka continues after each iteration; click to clear the goal and stop continuing.`, clearGoalAriaLabel: (iteration, max) => `Clear autonomous goal after ${iteration}/${max} iterations`, goalLabel: (iteration, max) => `Goal ${iteration}/${max} · Clear`,
-      loadFailed: 'Conversation failed to load', loading: 'Loading…', retryLoad: 'Retry', jumpLatest: 'Jump to latest message', noMessages: 'No messages yet',
+      loadFailed: 'Conversation failed to load', loading: 'Loading…', retryLoad: 'Retry', jumpLatest: 'Jump to latest message', quoteSelection: 'Quote', noMessages: 'No messages yet',
       branchTitle: (name, beforeAbort) => beforeAbort ? `Branched before interruption from ${name} · Click to return` : `Branched from ${name} · Click to return`, branchLabel: (name, beforeAbort) => beforeAbort ? `Branched before interruption from ${name}` : `Branched from ${name}`,
       revisionVersionsAriaLabel: 'Conversation versions', revisionVersion: (current, total) => `Version ${current} of ${total}`, previousRevision: 'View previous version', nextRevision: 'View next version',
     },

--- a/packages/ui/src/icons.tsx
+++ b/packages/ui/src/icons.tsx
@@ -104,6 +104,7 @@ export {
   SunMoon,
   Target,
   Terminal,
+  TextQuote,
   Timer,
   Trash2,
   User,

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -5,7 +5,7 @@ import {
   STEP_LIMIT_NOTICE_TEXT,
   toolResultActivityStatus,
 } from '@maka/core';
-import type { AttachmentRef, ShellRunUpdate, StoredMessage, ToolActivityKind, ToolResultContent, TurnRecord, TurnStatus } from '@maka/core';
+import type { AttachmentRef, QuoteRef, ShellRunUpdate, StoredMessage, ToolActivityKind, ToolResultContent, TurnRecord, TurnStatus } from '@maka/core';
 import type { LiveTurnProjection } from './live-turn-projection.js';
 
 export { isCancelledToolResultContent, toolResultActivityStatus } from '@maka/core';
@@ -18,6 +18,8 @@ export interface ChatItem {
   ts?: number;
   /** User-message attachments projected from StoredMessage; absent on assistant/system rows. */
   attachments?: AttachmentRef[];
+  /** Inline quoted excerpts projected from StoredMessage; user rows only. */
+  quotes?: QuoteRef[];
   /** Present when the turn was fired by an automation, not hand-typed. */
   automationOrigin?: { automationId: string };
 }
@@ -111,6 +113,7 @@ export function materializeChat(messages: StoredMessage[]): ChatItem[] {
         text: message.displayText ?? message.text,
         ts: message.ts,
         ...(message.attachments && message.attachments.length > 0 ? { attachments: message.attachments } : {}),
+        ...(message.quotes && message.quotes.length > 0 ? { quotes: message.quotes } : {}),
       });
     }
     if (message.type === 'assistant') items.push({ id: message.id, role: 'assistant', text: message.text, ts: message.ts });
@@ -468,6 +471,7 @@ export function materializeTurns(messages: StoredMessage[]): TurnViewModel[] {
         text: message.displayText ?? message.text,
         ts: message.ts,
         ...(message.attachments && message.attachments.length > 0 ? { attachments: message.attachments } : {}),
+        ...(message.quotes && message.quotes.length > 0 ? { quotes: message.quotes } : {}),
         ...(message.origin?.kind === 'automation' ? { automationOrigin: { automationId: message.origin.automationId } } : {}),
       };
     } else if (message.type === 'assistant') {

--- a/packages/ui/src/quote-ref-chip.tsx
+++ b/packages/ui/src/quote-ref-chip.tsx
@@ -1,0 +1,88 @@
+import { useLayoutEffect, useRef, useState } from 'react';
+import { TextQuote, X } from './icons.js';
+import { cn } from './utils.js';
+import type { QuoteRef } from '@maka/core';
+import { useUiLocale } from './locale-context.js';
+import { getConversationCopy } from './conversation-copy.js';
+
+/**
+ * Inline quoted-excerpt chip, shown inside the composer (removable) and inside
+ * a sent user message (read-only). A single-line pill rather than a card: a
+ * quote is a *reference*, so it should read as one token beside the message
+ * instead of competing with it for vertical space.
+ *
+ * An excerpt too long for the pill stays clipped until the user asks for it —
+ * clicking expands the chip in place to the full text. The model receives the
+ * excerpt verbatim either way (formatTextWithInlineRefs); this is presentation
+ * only. Expandability is measured, not guessed from a character count, so it
+ * holds for CJK and latin alike.
+ *
+ * Keeping the chip on the sent message is deliberate — a quote the user can
+ * see before sending but not afterwards makes the turn unauditable.
+ */
+export function QuoteRefChip(props: {
+  quote: QuoteRef;
+  onRemove?: () => void;
+  className?: string;
+}) {
+  const copy = getConversationCopy(useUiLocale()).messages;
+  const [expanded, setExpanded] = useState(false);
+  const [clipped, setClipped] = useState(false);
+  const textRef = useRef<HTMLButtonElement>(null);
+  const label = props.quote.label;
+  const full = label ? `${label}: ${props.quote.text}` : props.quote.text;
+
+  useLayoutEffect(() => {
+    const el = textRef.current;
+    if (!el || expanded) return;
+    setClipped(el.scrollWidth > el.clientWidth + 1);
+  }, [expanded, props.quote.text, label]);
+
+  const canExpand = clipped || expanded;
+  return (
+    <span
+      className={cn(
+        'maka-quote-chip inline-flex gap-1 bg-[var(--foreground-alpha-6)] ring-1 ring-inset ring-[color:var(--foreground-alpha-12)] pl-2',
+        expanded
+          ? 'w-full max-w-full items-start rounded-md py-1'
+          : 'max-w-[15rem] items-center rounded-full py-0.5',
+        props.onRemove ? 'pr-0.5' : 'pr-2',
+        props.className,
+      )}
+      title={expanded ? undefined : full}
+    >
+      <TextQuote
+        className={cn('h-3 w-3 shrink-0 text-muted-foreground', expanded && 'mt-0.5')}
+        aria-hidden="true"
+      />
+      <button
+        ref={textRef}
+        type="button"
+        {...(canExpand
+          ? {
+              onClick: () => setExpanded((open) => !open),
+              'aria-expanded': expanded,
+              'aria-label': expanded ? copy.quoteCollapseAriaLabel : copy.quoteExpandAriaLabel,
+            }
+          : { tabIndex: -1 })}
+        className={cn(
+          'min-w-0 flex-1 text-left text-xs text-foreground-secondary',
+          expanded ? 'max-h-32 overflow-y-auto whitespace-pre-wrap break-words' : 'truncate',
+        )}
+      >
+        {label ? <span className="text-muted-foreground">{label} </span> : null}
+        {props.quote.text}
+      </button>
+      {props.onRemove && (
+        <button
+          type="button"
+          onClick={props.onRemove}
+          className="inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full text-muted-foreground hover:bg-[var(--foreground-alpha-10)] hover:text-foreground transition"
+          aria-label={copy.removeQuoteAriaLabel}
+        >
+          <X className="h-3 w-3" />
+        </button>
+      )}
+    </span>
+  );
+}

--- a/packages/ui/src/use-message-selection-quote.ts
+++ b/packages/ui/src/use-message-selection-quote.ts
@@ -1,0 +1,94 @@
+import { useCallback, useEffect, useState, type RefObject } from 'react';
+
+/**
+ * A live text selection inside the chat transcript, captured as a quotable
+ * excerpt for the "quote this" affordance (Codex/Cursor-style). The `rect` is
+ * the selection's viewport-space bounding box, used to position the floating
+ * action near the selection.
+ */
+export interface MessageSelectionQuote {
+  text: string;
+  /** `data-turn-id` of the turn the selection sits in, when resolvable. */
+  turnId?: string;
+  rect: { top: number; left: number; bottom: number; right: number; width: number };
+}
+
+/**
+ * Watches for a non-empty text selection within `scrollRef` (the messages
+ * container) and exposes it as a {@link MessageSelectionQuote}. The selection is
+ * cleared when it collapses or the container scrolls (its rect would be stale).
+ * Read-only: the hook never mutates the selection, so native copy still works.
+ *
+ * Listeners live on `document` and resolve `scrollRef.current` at event time —
+ * binding them to the element instead would capture whatever the ref held on
+ * the first effect run, and ChatView's empty state renders a different scroll
+ * area before the transcript one exists, so the affordance would stay dead for
+ * the rest of the session.
+ */
+export function useMessageSelectionQuote(
+  scrollRef: RefObject<HTMLElement | null>,
+  enabled: boolean,
+): { quote: MessageSelectionQuote | null; clear: () => void } {
+  const [quote, setQuote] = useState<MessageSelectionQuote | null>(null);
+  const clear = useCallback(() => setQuote(null), []);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    function computeQuote(): MessageSelectionQuote | null {
+      const root = scrollRef.current;
+      if (!root) return null;
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed || selection.rangeCount === 0) return null;
+      const text = selection.toString().replace(/\s+/g, ' ').trim();
+      if (!text) return null;
+      const range = selection.getRangeAt(0);
+      if (!root.contains(range.commonAncestorContainer)) return null;
+      let node: Node | null = range.commonAncestorContainer;
+      let turnId: string | undefined;
+      while (node && node !== root) {
+        if (node instanceof HTMLElement && node.dataset.turnId) {
+          turnId = node.dataset.turnId;
+          break;
+        }
+        node = node.parentNode;
+      }
+      const box = range.getBoundingClientRect();
+      if (box.width === 0 && box.height === 0) return null;
+      return {
+        text,
+        ...(turnId ? { turnId } : {}),
+        rect: {
+          top: box.top,
+          left: box.left,
+          bottom: box.bottom,
+          right: box.right,
+          width: box.width,
+        },
+      };
+    }
+
+    function refresh(): void {
+      setQuote(computeQuote());
+    }
+    function onSelectionChange(): void {
+      const selection = window.getSelection();
+      if (!selection || selection.isCollapsed) setQuote(null);
+    }
+
+    // mouseup finalizes a drag-select; keyup covers keyboard (shift+arrow)
+    // selection. Scroll is capture-phase because scroll events do not bubble.
+    document.addEventListener('mouseup', refresh);
+    document.addEventListener('keyup', refresh);
+    document.addEventListener('scroll', clear, { capture: true, passive: true });
+    document.addEventListener('selectionchange', onSelectionChange);
+    return () => {
+      document.removeEventListener('mouseup', refresh);
+      document.removeEventListener('keyup', refresh);
+      document.removeEventListener('scroll', clear, { capture: true });
+      document.removeEventListener('selectionchange', onSelectionChange);
+    };
+  }, [scrollRef, enabled, clear]);
+
+  return { quote, clear };
+}


### PR DESCRIPTION
## What

Select text in the transcript → a floating **引用** action stages it as a quote chip above the composer → the sent user bubble keeps that chip, while the model receives the excerpt inline. Pasting a reference-sized block into the composer stages a chip the same way instead of flooding the textarea.

Codex/Cursor-style, minus [openai/codex#22670](https://github.com/openai/codex/issues/22670) — the bug where a quote is visible before send but vanishes from history, which makes the turn unauditable afterwards. Keeping the chip *on the sent message* is the point of the design, not a detail.

## Design

`QuoteRef { text, label?, sourceTurnId? }` is the text-native counterpart to the file-backed `AttachmentRef` — there is no `StorageRef` because the text **is** the reference. It rides an optional `quotes` field on `UserMessage`, `UserMessageInput`, `RuntimeEventTextContent` and `BackendSendInput`, threaded alongside `attachments` through runner → run → flow → kernel and the RuntimeEvent projections (adapters / backfill / read-model), so chips survive reload and replay.

Model visibility reuses the attachment fold rather than adding a parallel path: `formatTextWithAttachmentRefs` becomes **`formatTextWithInlineRefs`** and appends a `<quoted_excerpt>` block before the attachment markers. Presentation layers render chips and never show the folded form — the same model-text/display-text split the skill envelope already relies on.

Renderer quotes are normalized at the IPC boundary (count / length caps, per-field validation) like every other `sessions:send` payload. The renderer's own staging cap is pinned to the same 32k as the normalizer so it can never stage something the boundary would reject on send.

## UI

- Chip is a single-line pill, not a card — a quote is a reference, so it reads as one token beside the message instead of competing with it for vertical space.
- Clicking an excerpt too long for the pill expands it in place. Expandability is **measured** (`scrollWidth` vs `clientWidth`), not inferred from a character count, so it is correct for CJK and latin alike.
- Paste threshold is `>= 1000 chars` **or** `> 10 lines`. Either bound alone is enough: prose trips the character bound, a log or diff trips the line bound while staying short per line. Below that, a paste stays a paste — the user is writing, not attaching.

## Verification

Driven live in the Electron app:

- select → pill → chip → send; the chip renders on the sent user bubble and survives a reload with its `sourceTurnId` provenance intact;
- **model visibility is demonstrated, not assumed** — pasted a 30-line release note containing one invented code word, then asked only "what is the deploy freeze code word?". The model answered with the code word, which exists nowhere but inside the pasted chip;
- a `/swarm` send now carries staged quotes too, so they cannot silently leak into the following turn.

Tests: core 1152, ui 210, desktop 2769 — all pass. New coverage for the inline-ref fold, the IPC quote normalizer, and the paste threshold's two bounds.
