### PR TITLE
feat: add swarm provider backpressure

### DIFF
--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -257,6 +257,7 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
       prepareChildAgentResume: (sourceRunId) =>
         getRuntime().prepareChildAgentResume(ctx.sessionId, sourceRunId),
       resumeChildAgent: (input) => getRuntime().resumeChildAgent(ctx.sessionId, input),
+      retryChildAgent: (input) => getRuntime().retryChildAgent(ctx.sessionId, input),
       listChildAgents: () => getRuntime().listChildAgents(ctx.sessionId),
       readChildAgentOutput: (input) => getRuntime().readChildAgentOutput(ctx.sessionId, input),
       providerOptions: buildProviderOptions(connection, model, ctx.header.thinkingLevel),

--- a/docs/agent-swarm.md
+++ b/docs/agent-swarm.md
@@ -100,6 +100,33 @@ signals active children, prevents locally queued items from starting, joins
 active work, and returns explicit cancelled rows for both started and
 never-started items.
 
+## Provider backpressure
+
+Swarm uses Kimi-compatible, batch-local rate-limit handling after the backend's
+ordinary request retry policy is exhausted:
+
+- launch up to five initial items, then admit one additional pending item every
+  700 ms;
+- when a child settles with `failureClass: RateLimit`, suspend that item and
+  requeue it at the front with a 3 s, 6 s, 12 s, ... retry delay;
+- reduce the batch's effective capacity by one (never below one), at most once
+  every 2 s;
+- after three minutes without another rate limit, recover capacity one slot at
+  a time;
+- if the rate-limited item is the only unfinished item, fail it instead of
+  leaving the foreground tool suspended indefinitely.
+
+A retry is a fresh child `AgentRun` linked through `retriedFromRunId`. It
+replays the safely materialized RuntimeEvent history and sends no second user
+prompt. This keeps each attempt inspectable while preventing duplicated task
+instructions. Artifacts from all attempts are retained in the final ordered
+item result, and parent cancellation still covers queued retries and active
+retry runs through the shared child-run permit pool.
+
+This mechanism is deliberately reactive and local to one Swarm call. It is not
+a provider-global RPM/TPM admission controller and does not coordinate capacity
+between independent sessions or processes.
+
 ## Presentation and evidence
 
 Desktop and CLI project the same settled `agent_swarm` result:
@@ -122,6 +149,8 @@ data fields:
 | --- | --- |
 | Tool-call admission rejection | `boundary: subagent_tool_admission` |
 | Local item queued or started | `swarmStage: item_queued` / `item_started`, `boundary: local_swarm_concurrency` |
+| Provider-limited item suspended | `swarmStage: item_suspended`, `failureClass: RateLimit`, plus attempt and retry delay |
+| Adaptive batch capacity | `swarmStage: capacity_changed`, direction, and effective capacity |
 | Waiting for shared capacity | `boundary: shared_child_run_permit`, `stage: waiting` |
 | Real child execution | `boundary: child_run_execution`, `stage: started` / `completed` |
 | Settled batch | `swarmStage: batch_completed` plus the aggregate projection |

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -325,6 +325,7 @@ describe('Maka CLI runtime bootstrap', () => {
         const backendInput = (backend as unknown as { input: AiSdkBackendInput }).input;
 
         assert.equal(typeof backendInput.spawnChildAgent, 'function');
+        assert.equal(typeof backendInput.retryChildAgent, 'function');
         assert.equal(typeof backendInput.listChildAgents, 'function');
         assert.equal(typeof backendInput.readChildAgentOutput, 'function');
         assert.deepEqual(backendInput.toolAvailability, {

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -607,6 +607,7 @@ export async function createMakaCliRuntimeContext(
             prepareChildAgentResume: (sourceRunId) =>
               runtime.prepareChildAgentResume(ctx.sessionId, sourceRunId),
             resumeChildAgent: (childInput) => runtime.resumeChildAgent(ctx.sessionId, childInput),
+            retryChildAgent: (childInput) => runtime.retryChildAgent(ctx.sessionId, childInput),
             listChildAgents: () => runtime.listChildAgents(ctx.sessionId),
             readChildAgentOutput: (childInput) =>
               runtime.readChildAgentOutput(ctx.sessionId, childInput),

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -68,6 +68,8 @@ export interface AgentRunHeader {
   parentRunId?: string;
   /** Immediate child AgentRun continued by this run. */
   resumedFromRunId?: string;
+  /** Immediate child AgentRun whose provider step is retried by this run. */
+  retriedFromRunId?: string;
   agentId?: string;
   agentName?: string;
   parentTurnId?: string;
@@ -173,6 +175,7 @@ const AGENT_RUN_HEADER_SHAPE = defineObjectShape<AgentRunHeader>()(
     'completedAt',
     'parentRunId',
     'resumedFromRunId',
+    'retriedFromRunId',
     'agentId',
     'agentName',
     'parentTurnId',
@@ -226,6 +229,7 @@ export function decodeAgentRunHeader(value: unknown): AgentRunHeader {
     [
       value.parentRunId,
       value.resumedFromRunId,
+      value.retriedFromRunId,
       value.agentId,
       value.agentName,
       value.parentTurnId,

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -62,6 +62,8 @@ export interface UserMessageInput {
   parentRunId?: string;
   /** Child AgentRun whose durable conversation this child continues. */
   resumedFromRunId?: string;
+  /** Immediate child AgentRun retried without appending another user prompt. */
+  retriedFromRunId?: string;
   agentId?: string;
   agentName?: string;
   parentTurnId?: string;

--- a/packages/headless/src/__tests__/runner.test.ts
+++ b/packages/headless/src/__tests__/runner.test.ts
@@ -418,6 +418,7 @@ describe('fail-closed (a model-backed backend does not run without isolation)', 
       assert.equal(contexts[0]?.config.id, 'real-cfg');
       assert.equal(contexts[0]?.task.id, 'real-task');
       assert.equal(typeof contexts[0]?.spawnChildAgent, 'function');
+      assert.equal(typeof contexts[0]?.retryChildAgent, 'function');
       assert.equal(typeof contexts[0]?.listChildAgents, 'function');
       assert.equal(typeof contexts[0]?.readChildAgentOutput, 'function');
       assert.ok(Array.isArray((await contexts[0]!.listChildAgents!(result.sessionId)).definitions));

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -789,6 +789,9 @@ export function buildAiSdkCellBackendRegistration(input: {
         resumeChildAgent: context.resumeChildAgent
           ? (childInput) => context.resumeChildAgent!(ctx.sessionId, childInput)
           : undefined,
+        retryChildAgent: context.retryChildAgent
+          ? (childInput) => context.retryChildAgent!(ctx.sessionId, childInput)
+          : undefined,
         listChildAgents: context.listChildAgents
           ? () => context.listChildAgents!(ctx.sessionId)
           : undefined,

--- a/packages/headless/src/session-capabilities.ts
+++ b/packages/headless/src/session-capabilities.ts
@@ -4,6 +4,7 @@ import type {
   AgentOutputResult,
   PrepareChildAgentResumeResult,
   ResumeChildAgentInput,
+  RetryChildAgentInput,
   SessionManager,
   SpawnChildAgentInput,
   SpawnChildAgentResult,
@@ -16,6 +17,7 @@ export interface HeadlessSessionCapabilities {
     sourceRunId: string,
   ): Promise<PrepareChildAgentResumeResult>;
   resumeChildAgent(sessionId: string, input: ResumeChildAgentInput): Promise<SpawnChildAgentResult>;
+  retryChildAgent(sessionId: string, input: RetryChildAgentInput): Promise<SpawnChildAgentResult>;
   listChildAgents(sessionId: string): Promise<AgentListResult>;
   readChildAgentOutput(sessionId: string, input: AgentOutputInput): Promise<AgentOutputResult>;
 }
@@ -39,6 +41,8 @@ export function createHeadlessSessionCapabilityBridge(): {
         await requireManager().prepareChildAgentResume(sessionId, sourceRunId),
       resumeChildAgent: async (sessionId, input) =>
         await requireManager().resumeChildAgent(sessionId, input),
+      retryChildAgent: async (sessionId, input) =>
+        await requireManager().retryChildAgent(sessionId, input),
       listChildAgents: async (sessionId) => await requireManager().listChildAgents(sessionId),
       readChildAgentOutput: async (sessionId, input) =>
         await requireManager().readChildAgentOutput(sessionId, input),

--- a/packages/runtime/src/__tests__/adaptive-swarm.test.ts
+++ b/packages/runtime/src/__tests__/adaptive-swarm.test.ts
@@ -1,0 +1,208 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  KIMI_STYLE_SWARM_POLICY,
+  runAdaptiveSwarm,
+  type AdaptiveSwarmPolicy,
+} from '../adaptive-swarm.js';
+
+const FAST_POLICY: AdaptiveSwarmPolicy = {
+  initialLaunchLimit: 2,
+  initialLaunchIntervalMs: 10,
+  rateLimitRetryBaseMs: 10,
+  rateLimitRetryFactor: 2,
+  capacityShrinkIntervalMs: 5,
+  capacityRecoveryIntervalMs: 30,
+};
+
+describe('runAdaptiveSwarm', () => {
+  test('keeps the Kimi-compatible production timing policy explicit', () => {
+    assert.deepEqual(KIMI_STYLE_SWARM_POLICY, {
+      initialLaunchLimit: 5,
+      initialLaunchIntervalMs: 700,
+      rateLimitRetryBaseMs: 3_000,
+      rateLimitRetryFactor: 2,
+      capacityShrinkIntervalMs: 2_000,
+      capacityRecoveryIntervalMs: 180_000,
+    });
+  });
+
+  test('launches an initial burst and then ramps pending work', async () => {
+    const gates = Array.from({ length: 4 }, () => deferred<void>());
+    const starts: number[] = [];
+    const pending = runAdaptiveSwarm(
+      [0, 1, 2, 3],
+      async (_item, context) => {
+        starts.push(context.index);
+        context.markReady();
+        await gates[context.index]!.promise;
+        return { status: 'fulfilled', value: context.index };
+      },
+      {
+        maxConcurrency: 4,
+        signal: new AbortController().signal,
+        policy: FAST_POLICY,
+      },
+    );
+
+    await waitFor(() => starts.length === 2);
+    assert.deepEqual(starts, [0, 1]);
+    await waitFor(() => starts.length === 3);
+    assert.deepEqual(starts, [0, 1, 2]);
+    await waitFor(() => starts.length === 4);
+    for (const gate of gates) gate.resolve();
+    assert.deepEqual(
+      (await pending).map((result) => result.status),
+      ['fulfilled', 'fulfilled', 'fulfilled', 'fulfilled'],
+    );
+  });
+
+  test('requeues a rate-limited item with its retry token and preserves order', async () => {
+    const attempts: Array<{ index: number; attempt: number; retry?: string }> = [];
+    const rateLimits: Array<{ attempt: number; retryDelayMs: number }> = [];
+    const siblingGate = deferred<void>();
+    const pending = runAdaptiveSwarm<number, string, string>(
+      [0, 1],
+      async (_item, context) => {
+        attempts.push({
+          index: context.index,
+          attempt: context.attempt,
+          ...(context.retry ? { retry: context.retry } : {}),
+        });
+        context.markReady();
+        if (context.index === 0 && context.attempt === 1) {
+          return { status: 'rate_limited', retry: 'run-rate-limited', reason: new Error('429') };
+        }
+        if (context.index === 1) await siblingGate.promise;
+        return { status: 'fulfilled', value: `value-${context.index}` };
+      },
+      {
+        maxConcurrency: 2,
+        signal: new AbortController().signal,
+        policy: FAST_POLICY,
+        onRateLimit: ({ attempt, retryDelayMs }) => rateLimits.push({ attempt, retryDelayMs }),
+      },
+    );
+
+    await waitFor(() => rateLimits.length === 1);
+    siblingGate.resolve();
+    await waitFor(() => attempts.some((attempt) => attempt.index === 0 && attempt.attempt === 2));
+    const results = await pending;
+    assert.deepEqual(attempts[2], { index: 0, attempt: 2, retry: 'run-rate-limited' });
+    assert.deepEqual(rateLimits, [{ attempt: 1, retryDelayMs: 10 }]);
+    assert.deepEqual(results, [
+      { index: 0, status: 'fulfilled', value: 'value-0' },
+      { index: 1, status: 'fulfilled', value: 'value-1' },
+    ]);
+  });
+
+  test('fails the last unfinished item instead of suspending forever', async () => {
+    let attempts = 0;
+    const results = await runAdaptiveSwarm<number, string, string>(
+      [0],
+      (_item, context) => {
+        attempts += 1;
+        context.markReady();
+        return { status: 'rate_limited', retry: 'run-0', reason: new Error('still 429') };
+      },
+      {
+        maxConcurrency: 1,
+        signal: new AbortController().signal,
+        policy: FAST_POLICY,
+      },
+    );
+
+    assert.equal(attempts, 1);
+    assert.equal(results[0]?.status, 'rejected');
+    assert.match(String(results[0]?.status === 'rejected' && results[0].reason), /still 429/);
+  });
+
+  test('shrinks capacity on rate limit and recovers after a quiet interval', async () => {
+    const gates = Array.from({ length: 4 }, () => deferred<void>());
+    const starts: Array<{ index: number; attempt: number }> = [];
+    const capacity: Array<{ direction: 'decreased' | 'increased'; capacity: number }> = [];
+    const pending = runAdaptiveSwarm<number, number, string>(
+      [0, 1, 2, 3],
+      async (_item, context) => {
+        starts.push({ index: context.index, attempt: context.attempt });
+        context.markReady();
+        if (context.index === 0 && context.attempt === 1) {
+          return { status: 'rate_limited', retry: 'run-0', reason: new Error('429') };
+        }
+        await gates[context.index]!.promise;
+        return { status: 'fulfilled', value: context.index };
+      },
+      {
+        maxConcurrency: 3,
+        signal: new AbortController().signal,
+        policy: FAST_POLICY,
+        onCapacityChanged: (event) => capacity.push(event),
+      },
+    );
+
+    await waitFor(() => capacity.some((event) => event.direction === 'decreased'));
+    gates[1]!.resolve();
+    await waitFor(() => starts.some((start) => start.index === 0 && start.attempt === 2));
+    await waitFor(() => capacity.some((event) => event.direction === 'increased'));
+    for (const gate of gates) gate.resolve();
+    await pending;
+
+    assert.deepEqual(capacity.slice(0, 2), [
+      { direction: 'decreased', capacity: 1 },
+      { direction: 'increased', capacity: 2 },
+    ]);
+  });
+
+  test('joins active work and cancels pending work with its parent', async () => {
+    const controller = new AbortController();
+    const starts: number[] = [];
+    const pending = runAdaptiveSwarm(
+      [0, 1, 2],
+      async (_item, context) => {
+        starts.push(context.index);
+        await onceAborted(context.signal);
+        return { status: 'fulfilled', value: context.index };
+      },
+      { maxConcurrency: 2, signal: controller.signal, policy: FAST_POLICY },
+    );
+    await waitFor(() => starts.length === 2);
+    controller.abort(new Error('parent stopped'));
+
+    const results = await pending;
+    assert.deepEqual(starts, [0, 1]);
+    assert.deepEqual(
+      results.map((result) => result.status),
+      ['cancelled', 'cancelled', 'cancelled'],
+    );
+  });
+});
+
+interface Deferred<Value> {
+  readonly promise: Promise<Value>;
+  resolve(value: Value): void;
+}
+
+function deferred<Value>(): Deferred<Value> {
+  let resolvePromise: ((value: Value) => void) | undefined;
+  return {
+    promise: new Promise<Value>((resolve) => {
+      resolvePromise = resolve;
+    }),
+    resolve: (value) => resolvePromise!(value),
+  };
+}
+
+function onceAborted(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) =>
+    signal.addEventListener('abort', () => resolve(), { once: true }),
+  );
+}
+
+async function waitFor(predicate: () => boolean, timeoutMs = 1_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for condition');
+    await new Promise<void>((resolve) => setImmediate(resolve));
+  }
+}

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -510,6 +510,69 @@ describe('AgentSwarm adapter', () => {
     assert.equal(result.items[1]?.failureClass, 'Error');
   });
 
+  test('retries provider rate limits without spawning the child prompt twice', async () => {
+    const traceEvents: TestTraceEvent[] = [];
+    const prompts: string[] = [];
+    const retrySources: string[] = [];
+    const siblingGate = deferred<SpawnChildAgentResult>();
+    const tool = buildAgentSwarmTool({
+      adaptiveSwarmPolicy: {
+        initialLaunchLimit: 2,
+        initialLaunchIntervalMs: 1,
+        rateLimitRetryBaseMs: 1,
+        rateLimitRetryFactor: 2,
+        capacityShrinkIntervalMs: 1,
+        capacityRecoveryIntervalMs: 100,
+      },
+    });
+    const pending = tool.impl(
+      { items: [swarmItem(0), swarmItem(1)], max_concurrency: 2 },
+      context({
+        emitRunTrace: (type, message, data) => traceEvents.push({ type, message, data }),
+        spawnChildAgent: async (input) => {
+          prompts.push(input.prompt);
+          const index = Number(input.prompt.slice('task-'.length));
+          await input.onReady?.({
+            turnId: `turn-${index}`,
+            agentId: input.spec.id,
+            agentName: input.spec.name,
+          });
+          if (index === 1) return await siblingGate.promise;
+          return {
+            ...childResult(0, 'failed'),
+            failureClass: 'RateLimit',
+            summary: 'provider 429',
+          };
+        },
+        retryChildAgent: async (input) => {
+          retrySources.push(input.sourceRunId);
+          await input.onReady?.({
+            turnId: 'turn-0-retry',
+            agentId: 'local-read',
+            agentName: 'Local Read',
+          });
+          return {
+            ...childResult(0),
+            turnId: 'turn-0-retry',
+            runId: 'run-0-retry',
+            artifactIds: ['artifact-retry'],
+          };
+        },
+      }),
+    );
+
+    await waitFor(() => traceEvents.some((event) => event.data?.swarmStage === 'item_suspended'));
+    siblingGate.resolve(childResult(1));
+    const result = await pending;
+
+    assert.deepEqual(prompts, ['task-0', 'task-1']);
+    assert.deepEqual(retrySources, ['run-0']);
+    assert.equal(result.status, 'completed');
+    assert.equal(result.items[0]?.runId, 'run-0-retry');
+    assert.deepEqual(result.items[0]?.artifactIds, ['artifact-0', 'artifact-retry']);
+    assert.ok(traceEvents.some((event) => event.data?.swarmStage === 'capacity_changed'));
+  });
+
   test('distinguishes active cancellation from items that never started', async () => {
     const controller = new AbortController();
     const tool = buildAgentSwarmTool();

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -6128,6 +6128,133 @@ describe('SessionManager permission mode updates', () => {
     );
   });
 
+  test('retryChildAgent replays a rate-limited child without appending its prompt again', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const sendInputs: BackendSendInput[] = [];
+    let childAttempt = 0;
+    backends.register('fake', (ctx) => ({
+      kind: 'fake' as const,
+      sessionId: ctx.sessionId,
+      async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+        childAttempt += 1;
+        sendInputs.push(input);
+        if (childAttempt <= 2) {
+          yield {
+            type: 'error',
+            id: `${input.turnId}-error`,
+            turnId: input.turnId,
+            ts: 1,
+            recoverable: true,
+            reason: 'RateLimit',
+            message: 'provider 429',
+          };
+          yield {
+            type: 'complete',
+            id: `${input.turnId}-complete`,
+            turnId: input.turnId,
+            ts: 2,
+            stopReason: 'error',
+          };
+          return;
+        }
+        yield {
+          type: 'text_delta',
+          id: `${input.turnId}-delta`,
+          turnId: input.turnId,
+          ts: 3,
+          messageId: `${input.turnId}-message`,
+          text: 'recovered',
+        };
+        yield {
+          type: 'complete',
+          id: `${input.turnId}-complete`,
+          turnId: input.turnId,
+          ts: 4,
+          stopReason: 'end_turn',
+        };
+      },
+      async stop(): Promise<void> {},
+      async respondToPermission(): Promise<void> {},
+      async dispose(): Promise<void> {},
+    }));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(6_843),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    const parentRun = makeRunHeader({
+      sessionId: session.id,
+      runId: 'parent-run',
+      turnId: 'parent-turn',
+      status: 'completed',
+      createdAt: 100,
+      updatedAt: 110,
+      completedAt: 110,
+    });
+    await seedRuntimeRun(runStore, parentRun, [
+      runtimeEvent({
+        id: 'parent-complete',
+        sessionId: session.id,
+        runId: parentRun.runId,
+        turnId: parentRun.turnId,
+        ts: 110,
+        status: 'completed',
+        actions: { endInvocation: true },
+      }),
+    ]);
+
+    const first = await manager.spawnChildAgent(session.id, {
+      turnId: 'child-rate-limited',
+      parentRunId: parentRun.runId,
+      spec: { id: LOCAL_READ_AGENT_ID, name: 'Reader', systemPrompt: 'read only' },
+      prompt: 'inspect auth',
+    });
+    expect(first.status).toBe('failed');
+    expect(first.failureClass).toBe('RateLimit');
+    if (!first.runId) throw new Error('rate-limited child run id was not recorded');
+
+    const second = await manager.retryChildAgent(session.id, {
+      parentRunId: parentRun.runId,
+      sourceRunId: first.runId,
+    });
+    expect(second.status).toBe('failed');
+    expect(second.failureClass).toBe('RateLimit');
+    if (!second.runId) throw new Error('second rate-limited child run id was not recorded');
+
+    const retried = await manager.retryChildAgent(session.id, {
+      parentRunId: parentRun.runId,
+      sourceRunId: second.runId,
+    });
+
+    expect(retried.status).toBe('completed');
+    expect(retried.retriedFromRunId).toBe(second.runId);
+    expect(sendInputs.map((input) => input.text)).toEqual(['inspect auth', '', '']);
+    expect(
+      sendInputs[2]?.runtimeContext?.some(
+        (event) =>
+          event.role === 'user' &&
+          event.content?.kind === 'text' &&
+          event.content.text === 'inspect auth',
+      ),
+    ).toBe(true);
+    const retryRun = await runStore.readRun(session.id, retried.runId!);
+    expect(retryRun.retriedFromRunId).toBe(second.runId);
+    expect(retryRun.continuationSource).toBe(undefined);
+    expect(
+      (await store.readMessages(session.id)).filter(
+        (message) => 'turnId' in message && message.turnId === retried.turnId,
+      ),
+    ).toEqual([]);
+  });
+
   test('the durable turn-ledger seam reaches parent runs but is withheld from child sessions', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/adaptive-swarm.ts
+++ b/packages/runtime/src/adaptive-swarm.ts
@@ -1,0 +1,482 @@
+export interface AdaptiveSwarmPolicy {
+  readonly initialLaunchLimit: number;
+  readonly initialLaunchIntervalMs: number;
+  readonly rateLimitRetryBaseMs: number;
+  readonly rateLimitRetryFactor: number;
+  readonly capacityShrinkIntervalMs: number;
+  readonly capacityRecoveryIntervalMs: number;
+}
+
+export const KIMI_STYLE_SWARM_POLICY: AdaptiveSwarmPolicy = {
+  initialLaunchLimit: 5,
+  initialLaunchIntervalMs: 700,
+  rateLimitRetryBaseMs: 3_000,
+  rateLimitRetryFactor: 2,
+  capacityShrinkIntervalMs: 2_000,
+  capacityRecoveryIntervalMs: 3 * 60 * 1_000,
+};
+
+export interface AdaptiveSwarmOptions {
+  readonly maxConcurrency: number;
+  readonly signal: AbortSignal;
+  readonly policy?: AdaptiveSwarmPolicy;
+  readonly now?: () => number;
+  readonly setTimer?: (callback: () => void, delayMs: number) => unknown;
+  readonly clearTimer?: (timer: unknown) => void;
+  readonly onRateLimit?: (event: AdaptiveSwarmRateLimitEvent) => void;
+  readonly onCapacityChanged?: (event: AdaptiveSwarmCapacityEvent) => void;
+}
+
+export interface AdaptiveSwarmWorkerContext<Retry> {
+  readonly index: number;
+  readonly signal: AbortSignal;
+  readonly attempt: number;
+  readonly retry: Retry | undefined;
+  markReady(): void;
+}
+
+export type AdaptiveSwarmAttemptResult<Output, Retry> =
+  | { readonly status: 'fulfilled'; readonly value: Output }
+  | { readonly status: 'rate_limited'; readonly retry: Retry; readonly reason: unknown };
+
+export type AdaptiveSwarmItemResult<Output> =
+  | { readonly index: number; readonly status: 'fulfilled'; readonly value: Output }
+  | { readonly index: number; readonly status: 'rejected'; readonly reason: unknown }
+  | { readonly index: number; readonly status: 'cancelled'; readonly reason: unknown };
+
+export interface AdaptiveSwarmRateLimitEvent {
+  readonly index: number;
+  readonly attempt: number;
+  readonly retryDelayMs: number;
+  readonly capacity: number;
+}
+
+export interface AdaptiveSwarmCapacityEvent {
+  readonly direction: 'decreased' | 'increased';
+  readonly capacity: number;
+}
+
+interface ItemState<Input, Retry> {
+  readonly index: number;
+  readonly item: Input;
+  attempt: number;
+  retry: Retry | undefined;
+  retryReadyAt: number;
+  started: boolean;
+}
+
+interface ActiveAttempt<Input, Retry> {
+  readonly state: ItemState<Input, Retry>;
+  ready: boolean;
+}
+
+/**
+ * Foreground all-settled scheduler with Kimi-style provider backpressure.
+ *
+ * Normal work launches in a five-item burst and then ramps one item at a time.
+ * The first provider rate limit stops that ramp, requeues the affected item,
+ * and switches to a capacity-controlled recovery phase. This scheduler owns
+ * timing and ordering only; callers own child lifecycle and retry identity.
+ */
+export function runAdaptiveSwarm<Input, Output, Retry>(
+  items: readonly Input[],
+  worker: (
+    item: Input,
+    context: AdaptiveSwarmWorkerContext<Retry>,
+  ) =>
+    | AdaptiveSwarmAttemptResult<Output, Retry>
+    | PromiseLike<AdaptiveSwarmAttemptResult<Output, Retry>>,
+  options: AdaptiveSwarmOptions,
+): Promise<readonly AdaptiveSwarmItemResult<Output>[]> {
+  assertOptions(options);
+  if (items.length === 0) return Promise.resolve([]);
+  return new AdaptiveSwarmScheduler(items, worker, options).run();
+}
+
+class AdaptiveSwarmScheduler<Input, Output, Retry> {
+  private readonly policy: AdaptiveSwarmPolicy;
+  private readonly now: () => number;
+  private readonly setTimer: (callback: () => void, delayMs: number) => unknown;
+  private readonly clearTimer: (timer: unknown) => void;
+  private readonly states: Array<ItemState<Input, Retry>>;
+  private readonly pending: Array<ItemState<Input, Retry>>;
+  private readonly active = new Set<ActiveAttempt<Input, Retry>>();
+  private readonly results: Array<AdaptiveSwarmItemResult<Output> | undefined>;
+  private normalLaunchCount = 0;
+  private normalRampReady = false;
+  private timer: unknown;
+  private settled = false;
+  private rateLimitMode = false;
+  private readyNormalLaunches = 0;
+  private rateLimitCapacity = 1;
+  private lastRateLimitAt: number | undefined;
+  private lastCapacityDecreaseAt: number | undefined;
+  private lastCapacityIncreaseAt: number | undefined;
+  private globalLaunchIntervalMs: number;
+  private nextRateLimitLaunchAt = 0;
+  private resolve: ((results: readonly AdaptiveSwarmItemResult<Output>[]) => void) | undefined;
+  private readonly onAbort = () => this.schedule();
+
+  constructor(
+    items: readonly Input[],
+    private readonly worker: (
+      item: Input,
+      context: AdaptiveSwarmWorkerContext<Retry>,
+    ) =>
+      | AdaptiveSwarmAttemptResult<Output, Retry>
+      | PromiseLike<AdaptiveSwarmAttemptResult<Output, Retry>>,
+    private readonly options: AdaptiveSwarmOptions,
+  ) {
+    this.policy = options.policy ?? KIMI_STYLE_SWARM_POLICY;
+    this.now = options.now ?? Date.now;
+    this.setTimer =
+      options.setTimer ?? ((callback, delayMs) => setTimeout(callback, Math.max(0, delayMs)));
+    this.clearTimer =
+      options.clearTimer ?? ((timer) => clearTimeout(timer as ReturnType<typeof setTimeout>));
+    this.globalLaunchIntervalMs = this.policy.rateLimitRetryBaseMs;
+    this.states = items.map((item, index) => ({
+      index,
+      item,
+      attempt: 0,
+      retry: undefined,
+      retryReadyAt: 0,
+      started: false,
+    }));
+    this.pending = [...this.states];
+    this.results = Array.from({ length: items.length });
+  }
+
+  run(): Promise<readonly AdaptiveSwarmItemResult<Output>[]> {
+    return new Promise((resolve) => {
+      this.resolve = resolve;
+      this.options.signal.addEventListener('abort', this.onAbort, { once: true });
+      this.schedule();
+    });
+  }
+
+  private schedule(): void {
+    if (this.settled) return;
+    if (this.options.signal.aborted) {
+      if (this.active.size > 0) return;
+      this.finishCancelled();
+      return;
+    }
+    if (this.results.every((result) => result !== undefined)) {
+      this.finish(this.results as Array<AdaptiveSwarmItemResult<Output>>);
+      return;
+    }
+    if (this.rateLimitMode) this.scheduleRateLimited();
+    else this.scheduleNormal();
+  }
+
+  private scheduleNormal(): void {
+    while (
+      this.normalLaunchCount < this.policy.initialLaunchLimit &&
+      this.pending.length > 0 &&
+      this.active.size < this.options.maxConcurrency
+    ) {
+      this.start(this.pending.shift()!);
+      this.normalLaunchCount += 1;
+    }
+    if (
+      this.normalLaunchCount >= this.policy.initialLaunchLimit &&
+      this.normalRampReady &&
+      this.pending.length > 0 &&
+      this.active.size < this.options.maxConcurrency
+    ) {
+      this.normalRampReady = false;
+      this.start(this.pending.shift()!);
+    }
+    if (
+      this.pending.length === 0 ||
+      this.active.size >= this.options.maxConcurrency ||
+      this.timer !== undefined
+    )
+      return;
+    this.timer = this.setTimer(() => {
+      this.timer = undefined;
+      this.normalRampReady = true;
+      this.schedule();
+    }, this.policy.initialLaunchIntervalMs);
+  }
+
+  private scheduleRateLimited(): void {
+    this.clearWakeup();
+    if (this.pending.length === 0) return;
+    const now = this.now();
+    this.recoverCapacity(now);
+    if (this.active.size >= this.rateLimitCapacity) {
+      this.wakeAt(this.nextCapacityRecoveryAt(), now);
+      return;
+    }
+
+    const nextAllowedAt = Math.max(this.nextRateLimitLaunchAt, this.nextPendingReadyAt());
+    const wakeupAt = Math.min(nextAllowedAt, this.nextCapacityRecoveryAt());
+    if (wakeupAt > now) {
+      this.wakeAt(wakeupAt, now);
+      return;
+    }
+    const pendingIndex = this.pending.findIndex((state) => state.retryReadyAt <= now);
+    if (pendingIndex < 0) return;
+    const [state] = this.pending.splice(pendingIndex, 1);
+    this.start(state!);
+    this.nextRateLimitLaunchAt = now + this.globalLaunchIntervalMs;
+    if (this.pending.length > 0) {
+      const next =
+        this.active.size >= this.rateLimitCapacity
+          ? this.nextCapacityRecoveryAt()
+          : Math.min(
+              Math.max(this.nextRateLimitLaunchAt, this.nextPendingReadyAt()),
+              this.nextCapacityRecoveryAt(),
+            );
+      this.wakeAt(next, now);
+    }
+  }
+
+  private start(state: ItemState<Input, Retry>): void {
+    if (this.settled || this.options.signal.aborted) return;
+    state.attempt += 1;
+    const active: ActiveAttempt<Input, Retry> = { state, ready: false };
+    this.active.add(active);
+    const markReady = () => {
+      if (active.ready || !this.active.has(active) || this.settled) return;
+      active.ready = true;
+      state.started = true;
+      if (!this.rateLimitMode) this.readyNormalLaunches += 1;
+      else {
+        this.globalLaunchIntervalMs = this.policy.rateLimitRetryBaseMs;
+        this.nextRateLimitLaunchAt = this.now() + this.globalLaunchIntervalMs;
+        this.schedule();
+      }
+    };
+    let attempt: Promise<AdaptiveSwarmAttemptResult<Output, Retry>>;
+    try {
+      attempt = Promise.resolve(
+        this.worker(state.item, {
+          index: state.index,
+          signal: this.options.signal,
+          attempt: state.attempt,
+          retry: state.retry,
+          markReady,
+        }),
+      );
+    } catch (error) {
+      attempt = Promise.reject(error);
+    }
+    void attempt.then(
+      (outcome) => this.handleOutcome(active, outcome),
+      (reason) => this.handleRejected(active, reason),
+    );
+  }
+
+  private handleOutcome(
+    active: ActiveAttempt<Input, Retry>,
+    outcome: AdaptiveSwarmAttemptResult<Output, Retry>,
+  ): void {
+    if (!this.active.delete(active) || this.settled) return;
+    if (this.options.signal.aborted) {
+      this.schedule();
+      return;
+    }
+    if (outcome.status === 'fulfilled') {
+      this.results[active.state.index] = {
+        index: active.state.index,
+        status: 'fulfilled',
+        value: outcome.value,
+      };
+    } else if (this.isOnlyUnfinished(active.state.index)) {
+      this.results[active.state.index] = {
+        index: active.state.index,
+        status: 'rejected',
+        reason: outcome.reason,
+      };
+    } else {
+      this.requeueRateLimited(active, outcome);
+    }
+    this.schedule();
+  }
+
+  private handleRejected(active: ActiveAttempt<Input, Retry>, reason: unknown): void {
+    if (!this.active.delete(active) || this.settled) return;
+    if (!this.options.signal.aborted) {
+      this.results[active.state.index] = {
+        index: active.state.index,
+        status: 'rejected',
+        reason,
+      };
+    }
+    this.schedule();
+  }
+
+  private requeueRateLimited(
+    active: ActiveAttempt<Input, Retry>,
+    outcome: Extract<AdaptiveSwarmAttemptResult<Output, Retry>, { status: 'rate_limited' }>,
+  ): void {
+    const state = active.state;
+    const now = this.now();
+    state.retry = outcome.retry;
+    const retryDelayMs =
+      this.policy.rateLimitRetryBaseMs *
+      this.policy.rateLimitRetryFactor ** Math.max(0, state.attempt - 1);
+    state.retryReadyAt = now + retryDelayMs;
+    this.pending.unshift(state);
+    this.lastRateLimitAt = now;
+    this.enterRateLimitMode(now);
+    if (!active.ready) {
+      this.globalLaunchIntervalMs = Math.max(this.globalLaunchIntervalMs * 2, retryDelayMs);
+      this.nextRateLimitLaunchAt = Math.max(
+        this.nextRateLimitLaunchAt,
+        now + this.globalLaunchIntervalMs,
+      );
+    } else {
+      this.nextRateLimitLaunchAt = Math.max(
+        this.nextRateLimitLaunchAt,
+        now + this.policy.rateLimitRetryBaseMs,
+      );
+    }
+    this.observe(() =>
+      this.options.onRateLimit?.({
+        index: state.index,
+        attempt: state.attempt,
+        retryDelayMs,
+        capacity: this.rateLimitCapacity,
+      }),
+    );
+  }
+
+  private enterRateLimitMode(now: number): void {
+    if (!this.rateLimitMode) {
+      this.rateLimitMode = true;
+      this.rateLimitCapacity = Math.max(
+        1,
+        Math.min(this.options.maxConcurrency, this.readyNormalLaunches),
+      );
+      this.nextRateLimitLaunchAt = Math.max(
+        this.nextRateLimitLaunchAt,
+        now + this.policy.rateLimitRetryBaseMs,
+      );
+      this.decreaseCapacity(now, true);
+      return;
+    }
+    this.decreaseCapacity(now, false);
+  }
+
+  private decreaseCapacity(now: number, force: boolean): void {
+    if (
+      !force &&
+      this.lastCapacityDecreaseAt !== undefined &&
+      now - this.lastCapacityDecreaseAt < this.policy.capacityShrinkIntervalMs
+    ) {
+      return;
+    }
+    const previous = this.rateLimitCapacity;
+    this.rateLimitCapacity = Math.max(1, previous - 1);
+    this.lastCapacityDecreaseAt = now;
+    if (this.rateLimitCapacity !== previous) {
+      this.observe(() =>
+        this.options.onCapacityChanged?.({
+          direction: 'decreased',
+          capacity: this.rateLimitCapacity,
+        }),
+      );
+    }
+  }
+
+  private recoverCapacity(now: number): void {
+    if (this.nextCapacityRecoveryAt() > now) return;
+    const previous = this.rateLimitCapacity;
+    this.rateLimitCapacity = Math.min(this.options.maxConcurrency, previous + 1);
+    this.lastCapacityIncreaseAt = now;
+    this.nextRateLimitLaunchAt = Math.min(this.nextRateLimitLaunchAt, now);
+    if (this.rateLimitCapacity !== previous) {
+      this.observe(() =>
+        this.options.onCapacityChanged?.({
+          direction: 'increased',
+          capacity: this.rateLimitCapacity,
+        }),
+      );
+    }
+  }
+
+  private nextCapacityRecoveryAt(): number {
+    if (this.pending.length === 0 || this.lastRateLimitAt === undefined) {
+      return Number.POSITIVE_INFINITY;
+    }
+    return (
+      Math.max(this.lastRateLimitAt, this.lastCapacityIncreaseAt ?? 0) +
+      this.policy.capacityRecoveryIntervalMs
+    );
+  }
+
+  private nextPendingReadyAt(): number {
+    return this.pending.reduce(
+      (next, state) => Math.min(next, state.retryReadyAt),
+      Number.POSITIVE_INFINITY,
+    );
+  }
+
+  private isOnlyUnfinished(index: number): boolean {
+    return this.results.every(
+      (result, resultIndex) => resultIndex === index || result !== undefined,
+    );
+  }
+
+  private wakeAfter(delayMs: number): void {
+    this.timer = this.setTimer(() => {
+      this.timer = undefined;
+      this.schedule();
+    }, delayMs);
+  }
+
+  private wakeAt(timestamp: number, now: number): void {
+    if (!Number.isFinite(timestamp) || timestamp <= now) return;
+    this.wakeAfter(timestamp - now);
+  }
+
+  private clearWakeup(): void {
+    if (this.timer === undefined) return;
+    this.clearTimer(this.timer);
+    this.timer = undefined;
+  }
+
+  private finishCancelled(): void {
+    const reason = this.options.signal.reason ?? new Error('Adaptive swarm cancelled');
+    this.finish(
+      this.results.map((result, index) => result ?? { index, status: 'cancelled', reason }),
+    );
+  }
+
+  private finish(results: readonly AdaptiveSwarmItemResult<Output>[]): void {
+    if (this.settled) return;
+    this.settled = true;
+    this.clearWakeup();
+    this.options.signal.removeEventListener('abort', this.onAbort);
+    this.resolve?.(results);
+  }
+
+  private observe(callback: () => void): void {
+    try {
+      callback();
+    } catch {
+      // Presentation and telemetry observers must not affect scheduling.
+    }
+  }
+}
+
+function assertOptions(options: AdaptiveSwarmOptions): void {
+  if (!Number.isSafeInteger(options.maxConcurrency) || options.maxConcurrency < 1) {
+    throw new RangeError('Adaptive swarm maxConcurrency must be a positive safe integer');
+  }
+  const policy = options.policy ?? KIMI_STYLE_SWARM_POLICY;
+  const positive = [
+    policy.initialLaunchLimit,
+    policy.initialLaunchIntervalMs,
+    policy.rateLimitRetryBaseMs,
+    policy.rateLimitRetryFactor,
+    policy.capacityShrinkIntervalMs,
+    policy.capacityRecoveryIntervalMs,
+  ];
+  if (positive.some((value) => !Number.isFinite(value) || value <= 0)) {
+    throw new RangeError('Adaptive swarm policy values must be positive finite numbers');
+  }
+}

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -83,6 +83,7 @@ export type AgentRunLineage = Partial<
     UserMessageInput,
     | 'parentRunId'
     | 'resumedFromRunId'
+    | 'retriedFromRunId'
     | 'parentTurnId'
     | 'retriedFromTurnId'
     | 'regeneratedFromTurnId'
@@ -209,6 +210,9 @@ export class AgentRun {
       ...(input.userInput.parentRunId ? { parentRunId: input.userInput.parentRunId } : {}),
       ...(input.userInput.resumedFromRunId
         ? { resumedFromRunId: input.userInput.resumedFromRunId }
+        : {}),
+      ...(input.userInput.retriedFromRunId
+        ? { retriedFromRunId: input.userInput.retriedFromRunId }
         : {}),
       ...(input.userInput.parentTurnId ? { parentTurnId: input.userInput.parentTurnId } : {}),
       ...(input.userInput.retriedFromTurnId

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -15,7 +15,11 @@ import {
   requireBuiltinAgentDefinitionByProfile,
   type AgentDefinition,
 } from './agent-catalog.js';
-import { runBoundedSwarm, type SwarmItemResult } from './bounded-swarm.js';
+import {
+  runAdaptiveSwarm,
+  type AdaptiveSwarmPolicy,
+  type AdaptiveSwarmItemResult,
+} from './adaptive-swarm.js';
 import type { SpawnChildAgentResult } from './session-manager.js';
 import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 
@@ -91,7 +95,7 @@ interface StartedChildRef {
 }
 
 export function buildAgentSwarmTool(
-  deps: { now?: () => number } = {},
+  deps: { now?: () => number; adaptiveSwarmPolicy?: AdaptiveSwarmPolicy } = {},
 ): MakaTool<AgentSwarmToolInput, AgentSwarmToolResult> {
   const now = deps.now ?? Date.now;
   return {
@@ -146,41 +150,72 @@ export function buildAgentSwarmTool(
       const childResults: Array<SpawnChildAgentResult | undefined> = Array.from({
         length: prepared.items.length,
       });
-      const rows = await runBoundedSwarm(
+      const artifactIds = prepared.items.map(() => new Set<string>());
+      const rows = await runAdaptiveSwarm<
+        PreparedAgentSwarmItem,
+        SpawnChildAgentResult,
+        { sourceRunId: string }
+      >(
         prepared.items,
-        async (item, { index }) => {
+        async (item, { index, attempt, retry, markReady }) => {
           traceAgentSwarm(ctx, 'tool_started', 'item_started', {
             itemId: item.itemId,
             index: item.index,
             profile: item.profile,
             mode: item.mode,
             ...(item.resumedFromRunId ? { resumedFromRunId: item.resumedFromRunId } : {}),
+            attempt,
+            retry: retry !== undefined,
             boundary: 'local_swarm_concurrency',
           });
           ctx.emitOutput(
             'stdout',
-            `Agent swarm item ${item.itemId} started: ${item.definition.name}\n`,
+            `Agent swarm item ${item.itemId} ${retry ? 'retry' : 'started'}: ${item.definition.name}\n`,
           );
           try {
             const onReady = ({ turnId, agentId, agentName }: StartedChildRef) => {
               readyRefs[index] = { turnId, agentId, agentName };
+              markReady();
             };
-            const result = (await (item.mode === 'resume'
-              ? ctx.resumeChildAgent!({
-                  sourceRunId: item.resumedFromRunId!,
-                  prompt: item.task,
-                  onReady,
-                })
-              : ctx.spawnChildAgent!({
-                  spec: {
-                    id: item.definition.id,
-                    name: item.definition.name,
-                    systemPrompt: item.definition.systemPrompt,
-                  },
-                  prompt: item.task,
-                  onReady,
-                }))) as SpawnChildAgentResult;
-            childResults[index] = result;
+            const result = retry
+              ? ctx.retryChildAgent
+                ? ((await ctx.retryChildAgent({
+                    sourceRunId: retry.sourceRunId,
+                    onReady,
+                  })) as SpawnChildAgentResult)
+                : (() => {
+                    throw new Error('retryChildAgent capability is unavailable');
+                  })()
+              : item.mode === 'resume'
+                ? ((await ctx.resumeChildAgent!({
+                    sourceRunId: item.resumedFromRunId!,
+                    prompt: item.task,
+                    onReady,
+                  })) as SpawnChildAgentResult)
+                : ((await ctx.spawnChildAgent!({
+                    spec: {
+                      id: item.definition.id,
+                      name: item.definition.name,
+                      systemPrompt: item.definition.systemPrompt,
+                    },
+                    prompt: item.task,
+                    onReady,
+                  })) as SpawnChildAgentResult);
+            for (const artifactId of result.artifactIds) artifactIds[index]!.add(artifactId);
+            const observedResult = { ...result, artifactIds: [...artifactIds[index]!] };
+            childResults[index] = observedResult;
+            if (
+              result.status === 'failed' &&
+              result.failureClass === 'RateLimit' &&
+              result.runId &&
+              ctx.retryChildAgent
+            ) {
+              return {
+                status: 'rate_limited' as const,
+                retry: { sourceRunId: result.runId },
+                reason: new ProviderRateLimitRetry(result),
+              };
+            }
             traceAgentSwarm(
               ctx,
               result.status === 'failed' ? 'tool_failed' : 'tool_completed',
@@ -202,7 +237,7 @@ export function buildAgentSwarmTool(
               result.status === 'failed' ? 'stderr' : 'stdout',
               `Agent swarm item ${item.itemId}: ${result.status}\n`,
             );
-            return result;
+            return { status: 'fulfilled' as const, value: observedResult };
           } catch (error) {
             traceAgentSwarm(ctx, 'tool_failed', 'item_completed', {
               itemId: item.itemId,
@@ -223,6 +258,29 @@ export function buildAgentSwarmTool(
         {
           maxConcurrency: prepared.maxConcurrency,
           signal: ctx.abortSignal,
+          ...(deps.adaptiveSwarmPolicy ? { policy: deps.adaptiveSwarmPolicy } : {}),
+          onRateLimit: ({ index, attempt, retryDelayMs, capacity }) => {
+            const item = prepared.items[index]!;
+            traceAgentSwarm(ctx, 'tool_started', 'item_suspended', {
+              itemId: item.itemId,
+              index,
+              profile: item.profile,
+              attempt,
+              retryDelayMs,
+              capacity,
+              failureClass: 'RateLimit',
+            });
+            ctx.emitOutput(
+              'stderr',
+              `Agent swarm item ${item.itemId} rate limited; retrying in ${retryDelayMs}ms\n`,
+            );
+          },
+          onCapacityChanged: ({ direction, capacity }) => {
+            traceAgentSwarm(ctx, 'tool_started', 'capacity_changed', {
+              direction,
+              capacity,
+            });
+          },
         },
       );
 
@@ -252,7 +310,14 @@ export function buildAgentSwarmTool(
 function traceAgentSwarm(
   ctx: MakaToolContext,
   type: 'tool_started' | 'tool_completed' | 'tool_failed',
-  stage: 'batch_started' | 'item_queued' | 'item_started' | 'item_completed' | 'batch_completed',
+  stage:
+    | 'batch_started'
+    | 'item_queued'
+    | 'item_started'
+    | 'item_suspended'
+    | 'capacity_changed'
+    | 'item_completed'
+    | 'batch_completed',
   data: Record<string, unknown>,
 ): void {
   ctx.emitRunTrace?.(type, `Agent swarm ${stage.replaceAll('_', ' ')}`, {
@@ -648,7 +713,7 @@ function expandAgentSwarmPromptTemplate(promptTemplate: string, item: string): s
 
 function mapAgentSwarmItem(
   item: PreparedAgentSwarmItem,
-  row: SwarmItemResult<SpawnChildAgentResult>,
+  row: AdaptiveSwarmItemResult<SpawnChildAgentResult>,
   ready: StartedChildRef | undefined,
   observed: SpawnChildAgentResult | undefined,
 ): AgentSwarmToolResult['items'][number] {
@@ -664,6 +729,9 @@ function mapAgentSwarmItem(
     );
   }
   if (row.status === 'rejected') {
+    if (observed) {
+      return mapChildResult(item, observed, 'failed');
+    }
     return {
       itemId: item.itemId,
       index: row.index,
@@ -694,6 +762,13 @@ function mapAgentSwarmItem(
     artifactIds: [],
     failureClass: 'ParentCancelled',
   };
+}
+
+class ProviderRateLimitRetry extends Error {
+  constructor(readonly result: SpawnChildAgentResult) {
+    super(result.summary || 'Child agent provider rate limited');
+    this.name = 'RateLimit';
+  }
 }
 
 function mapChildResult(

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -544,6 +544,17 @@ export interface AiSdkBackendInput {
   }) => Promise<unknown>;
   prepareChildAgentResume?: ToolRuntimeInput['prepareChildAgentResume'];
   resumeChildAgent?: ToolRuntimeInput['resumeChildAgent'];
+  retryChildAgent?: (input: {
+    parentRunId: string;
+    sourceRunId: string;
+    abortSignal: AbortSignal;
+    onReady?: (input: {
+      turnId: string;
+      agentId: string;
+      agentName: string;
+    }) => void | Promise<void>;
+    onEvent?: (event: SessionEvent) => void;
+  }) => Promise<unknown>;
   listChildAgents?: () => Promise<unknown>;
   readChildAgentOutput?: (input: {
     runId?: string;
@@ -762,6 +773,7 @@ export class AiSdkBackend implements AgentBackend {
       spawnChildAgent: input.spawnChildAgent,
       prepareChildAgentResume: input.prepareChildAgentResume,
       resumeChildAgent: input.resumeChildAgent,
+      retryChildAgent: input.retryChildAgent,
       listChildAgents: input.listChildAgents,
       readChildAgentOutput: input.readChildAgentOutput,
       getRunTrace: () => this.currentRunTrace,

--- a/packages/runtime/src/execution-inspect.ts
+++ b/packages/runtime/src/execution-inspect.ts
@@ -38,6 +38,7 @@ export interface AgentRunInspectIdentity {
   turnId: string;
   parentRunId?: string;
   resumedFromRunId?: string;
+  retriedFromRunId?: string;
   parentTurnId?: string;
   agentId?: string;
   status: AgentRunHeader['status'];
@@ -256,6 +257,7 @@ function inspectIdentity(header: AgentRunHeader): AgentRunInspectIdentity {
     turnId: header.turnId,
     ...(header.parentRunId ? { parentRunId: header.parentRunId } : {}),
     ...(header.resumedFromRunId ? { resumedFromRunId: header.resumedFromRunId } : {}),
+    ...(header.retriedFromRunId ? { retriedFromRunId: header.retriedFromRunId } : {}),
     ...(header.parentTurnId ? { parentTurnId: header.parentTurnId } : {}),
     ...(header.agentId ? { agentId: header.agentId } : {}),
     status: header.status,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -26,6 +26,7 @@ export type {
   ResumeChildAgentInput,
   SpawnChildAgentInput,
   SpawnChildAgentResult,
+  RetryChildAgentInput,
   AgentListItem,
   AgentListResult,
   AgentOutputInput,

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -88,6 +88,7 @@ export interface RuntimeKernelLike {
   resumeContinuation?(continuation: RuntimeContinuation): AsyncIterable<SessionEvent>;
   compactSession(sessionId: string, input?: CompactSessionInput): AsyncIterable<SessionEvent>;
   startChildTurn(sessionId: string, input: ChildAgentTurnInput): AsyncIterable<SessionEvent>;
+  startChildRetry?(sessionId: string, input: ChildAgentRetryInput): AsyncIterable<SessionEvent>;
   stopSession(sessionId: string, input?: StopSessionInput): Promise<void>;
   respondToPermission(sessionId: string, response: PermissionResponse): Promise<void>;
   respondToUserQuestion?(sessionId: string, response: UserQuestionResponse): Promise<void>;
@@ -110,6 +111,12 @@ export interface TurnStartOptions {
   userMessageId?: string;
   durability?: AgentRunDurability;
   onRunStarted?: (runId: string, initialHeader: SessionHeader) => void | Promise<void>;
+}
+
+export interface ChildAgentRetryInput {
+  parentRunId: string;
+  spec: ChildAgentTurnInput['spec'];
+  continuation: RuntimeContinuation;
 }
 
 /**
@@ -597,6 +604,87 @@ export class RuntimeKernel implements RuntimeKernelLike {
     yield* this.runAgentTurn(sessionId, userInput, run);
   }
 
+  async *startChildRetry(
+    sessionId: string,
+    input: ChildAgentRetryInput,
+  ): AsyncIterable<SessionEvent> {
+    const { continuation } = input;
+    if (continuation.sessionId !== sessionId) {
+      throw new Error('Child retry continuation belongs to a different session');
+    }
+    const parentHeader = await this.deps.store.readHeader(sessionId);
+    const definition = requireResolvedAgentDefinition(input.spec.id);
+    const availableChildTools = this.deps.childTools ?? [];
+    assertAgentDefinitionRunnable({
+      parentPermissionMode: parentHeader.permissionMode,
+      definition,
+      tools: availableChildTools,
+    });
+    const childTools = buildToolsForAgentDefinition(availableChildTools, definition);
+    const expertIdentity = parseExpertAgentId(definition.id);
+    const agentTeam: AgentTeamExecutionContext | undefined = expertIdentity
+      ? {
+          role: 'member',
+          teamId: expertIdentity.teamId,
+          agentId: definition.id,
+          parentRunId: input.parentRunId,
+        }
+      : undefined;
+    const childHeader: SessionHeader = {
+      ...parentHeader,
+      permissionMode: definition.permissionMode,
+      connectionLocked: true,
+    };
+    const userInput: UserMessageInput = {
+      turnId: continuation.turnId,
+      text: '',
+      parentRunId: input.parentRunId,
+      retriedFromRunId: continuation.sourceRunId,
+      agentId: definition.id,
+      agentName: definition.name,
+    };
+    const activeKey = childActiveKey(sessionId, continuation.turnId);
+    const run = new AgentRun({
+      sessionId,
+      header: childHeader,
+      userInput,
+      runId: continuation.runId,
+      invocationId: continuation.invocationId,
+      store: this.deps.store,
+      runStore: this.deps.runStore,
+      runtimeEventStore: this.deps.runtimeEventStore,
+      ...(runtimeToolBoundaryProtocol(this.deps, childHeader)
+        ? { toolBoundaryProtocol: runtimeToolBoundaryProtocol(this.deps, childHeader) }
+        : {}),
+      repairRunRuntimeLedger: this.deps.repairRunRuntimeLedger,
+      newId: this.deps.newId,
+      now: this.deps.now,
+      workspaceIdentity: continuation.safetySnapshot.workspaceIdentity,
+      effectiveOrchestration: resolveEffectiveOrchestration('default', undefined),
+      recordSessionMessages: false,
+      hooks: {
+        ensureActive: (targetSessionId, nextHeader) =>
+          this.ensureChildActive(
+            activeKey,
+            targetSessionId,
+            nextHeader,
+            definition.systemPrompt,
+            childTools,
+            agentTeam,
+          ),
+        registerRun: (active, activeRun) => this.registerRun(active, activeRun),
+        unregisterRun: (active, activeRun) => this.unregisterChildRun(activeKey, active, activeRun),
+        updateHeader: async (_targetSessionId, patch) => ({ ...childHeader, ...patch }),
+        updateStatus: async () => {},
+        appendTurnState: async () => {},
+      },
+    });
+
+    // A provider retry replays the source ledger without recording a second
+    // user prompt and without turning the child into a session continuation.
+    yield* this.runAgentContinuation(continuation, run, false);
+  }
+
   private async *runAgentTurn(
     sessionId: string,
     input: UserMessageInput,
@@ -788,13 +876,16 @@ export class RuntimeKernel implements RuntimeKernelLike {
   private async *runAgentContinuation(
     continuation: RuntimeContinuation,
     run: AgentRun,
+    persistContinuationSource = true,
   ): AsyncIterable<SessionEvent> {
     const sessionEvents = new AsyncEventQueue<SessionEvent>();
     const abortController = new AbortController();
     let flowDone = false;
     let begin: Awaited<ReturnType<AgentRun['beginContinuation']>>;
     try {
-      begin = await run.beginContinuation(continuation);
+      begin = persistContinuationSource
+        ? await run.beginContinuation(continuation)
+        : await run.beginOperation();
     } catch (error) {
       await run.recordFailure(error);
       await run.finalize();
@@ -834,7 +925,9 @@ export class RuntimeKernel implements RuntimeKernelLike {
       ...(run.toolBoundaryProtocol ? { toolBoundaryProtocol: run.toolBoundaryProtocol } : {}),
       commitContinuationStart: async (event) => {
         await run.recordRuntimeEvents([event], { requireTerminalWrite: true });
-        await this.deps.continuationFailpoint?.('after_continuation_start_committed');
+        if (persistContinuationSource) {
+          await this.deps.continuationFailpoint?.('after_continuation_start_committed');
+        }
       },
     });
     let runnerFailure: unknown;

--- a/packages/runtime/src/runtime-ledger-repair.ts
+++ b/packages/runtime/src/runtime-ledger-repair.ts
@@ -472,6 +472,7 @@ function headerLineage(header: AgentRunHeader): AgentRunLineage {
   return {
     ...(header.parentRunId ? { parentRunId: header.parentRunId } : {}),
     ...(header.resumedFromRunId ? { resumedFromRunId: header.resumedFromRunId } : {}),
+    ...(header.retriedFromRunId ? { retriedFromRunId: header.retriedFromRunId } : {}),
     ...(header.parentTurnId ? { parentTurnId: header.parentTurnId } : {}),
     ...(header.retriedFromTurnId ? { retriedFromTurnId: header.retriedFromTurnId } : {}),
     ...(header.regeneratedFromTurnId

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -118,6 +118,7 @@ import {
 import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import { requireResolvedAgentDefinition } from './expert-catalog.js';
 import {
+  buildResumePlanFromRuntimeEvents,
   RuntimeContinuationPlanner,
   type RuntimeContinuation,
   type RuntimeContinuationPlannerInput,
@@ -185,6 +186,16 @@ export interface SpawnChildAgentResult {
   eventCount: number;
   failureClass?: string;
   resumedFromRunId?: string;
+  retriedFromRunId?: string;
+}
+
+export interface RetryChildAgentInput {
+  parentRunId: string;
+  sourceRunId: string;
+  abortSignal?: AbortSignal;
+  onReady?: (input: { turnId: string; agentId: string; agentName: string }) => void | Promise<void>;
+  /** Presentation-only observer for projecting child activity into a parent surface. */
+  onEvent?: (event: SessionEvent) => void;
 }
 
 const CHILD_AGENT_SUMMARY_MAX_CHARS = 4_000;
@@ -1367,6 +1378,145 @@ export class SessionManager {
       eventCount: summary.eventCount,
       ...(failureClass ? { failureClass } : {}),
       ...(resumedFromRunId ? { resumedFromRunId } : {}),
+    };
+  }
+
+  async retryChildAgent(
+    sessionId: string,
+    input: RetryChildAgentInput,
+  ): Promise<SpawnChildAgentResult> {
+    if (!this.deps.runStore || !this.deps.runtimeEventStore) {
+      throw new Error('Child agent retry requires AgentRunStore and RuntimeEventStore');
+    }
+    const runs = await this.deps.runStore.listSessionRuns(sessionId);
+    const rawSourceRun = runs.find((run) => run.runId === input.sourceRunId);
+    if (!rawSourceRun) throw new Error('Child agent retry source run was not found');
+    const sourceRun = await this.effectiveRunHeaderFromRuntimeLedger(rawSourceRun);
+    if (!sourceRun.parentRunId || sourceRun.parentRunId !== input.parentRunId) {
+      throw new Error('Child agent retry source does not belong to the active parent run');
+    }
+    if (sourceRun.status !== 'failed' || sourceRun.failureClass !== 'RateLimit') {
+      throw new Error('Child agent retry source must be a provider rate-limit failure');
+    }
+    if (!sourceRun.agentId) throw new Error('Child agent retry source is missing its agent id');
+    const existingRetry = runs.find((run) => run.retriedFromRunId === sourceRun.runId);
+    if (existingRetry) {
+      throw new Error(`Child agent retry source already has a successor: ${existingRetry.runId}`);
+    }
+
+    const definition = requireResolvedAgentDefinition(sourceRun.agentId);
+    const replaySegments: RuntimeEvent[][] = [];
+    let chainRun: AgentRunHeader | undefined = rawSourceRun;
+    const visited = new Set<string>();
+    while (chainRun) {
+      if (visited.has(chainRun.runId))
+        throw new Error('Child agent retry lineage contains a cycle');
+      visited.add(chainRun.runId);
+      const events = await this.deps.runtimeEventStore.readRuntimeEvents(sessionId, chainRun.runId);
+      const plan = buildResumePlanFromRuntimeEvents(events);
+      if (plan.disposition !== 'safe_replay') {
+        throw new Error(`Child agent retry source is not safely replayable: ${chainRun.runId}`);
+      }
+      replaySegments.unshift(plan.replayRuntimeEvents);
+      const previousRunId: string | undefined =
+        chainRun.retriedFromRunId ?? chainRun.resumedFromRunId;
+      if (!previousRunId) break;
+      chainRun = runs.find((run) => run.runId === previousRunId);
+      if (!chainRun) throw new Error('Child agent retry lineage source is missing');
+    }
+
+    const sourceEvents = await this.deps.runtimeEventStore.readRuntimeEvents(
+      sessionId,
+      sourceRun.runId,
+    );
+    const sourcePlan = buildResumePlanFromRuntimeEvents(sourceEvents);
+    if (sourcePlan.disposition !== 'safe_replay') {
+      throw new Error('Child agent retry source is not safely replayable');
+    }
+    const sourceInvocationId = sourceRun.invocationId ?? sourceEvents[0]?.invocationId;
+    if (!sourceInvocationId) throw new Error('Child agent retry source has no invocation id');
+    const turnId = this.deps.newId();
+    const runId = this.deps.newId();
+    const invocationId = this.deps.newId();
+    const continuation: RuntimeContinuation = {
+      sessionId,
+      invocationId,
+      runId,
+      turnId,
+      sourceInvocationId,
+      sourceRunId: sourceRun.runId,
+      sourceTurnId: sourceRun.turnId,
+      sourceRuntimeEventHighWater: sourceEvents.length,
+      sourceRuntimeContext: sourcePlan.replayRuntimeEvents,
+      runtimeContext: replaySegments.flat(),
+      safetySnapshot: {
+        workspaceIdentity: sourceRun.workspaceIdentity ?? sourceRun.cwd,
+        backgroundOperationsSettled: true,
+        availableToolNames: [],
+      },
+    };
+
+    const startedAt = this.deps.now();
+    const summary = new ChildAgentSummaryAccumulator();
+    let aborted = input.abortSignal?.aborted === true;
+    await input.onReady?.({ turnId, agentId: definition.id, agentName: definition.name });
+    const startChildRetry = this.runtimeKernel.startChildRetry;
+    if (!startChildRetry) throw new Error('RuntimeKernel does not support child agent retry');
+    const iterator = startChildRetry
+      .call(this.runtimeKernel, sessionId, {
+        parentRunId: input.parentRunId,
+        spec: {
+          id: definition.id,
+          name: definition.name,
+          systemPrompt: definition.systemPrompt,
+        },
+        continuation,
+      })
+      [Symbol.asyncIterator]();
+    const onAbort = () => {
+      aborted = true;
+      void iterator.return?.();
+    };
+    if (input.abortSignal && !input.abortSignal.aborted) {
+      input.abortSignal.addEventListener('abort', onAbort, { once: true });
+    }
+    try {
+      while (!aborted) {
+        const next = await iterator.next();
+        if (next.done) break;
+        summary.add(next.value);
+        try {
+          input.onEvent?.(next.value);
+        } catch {
+          // A presentation observer must not change the child run outcome.
+        }
+      }
+    } finally {
+      input.abortSignal?.removeEventListener('abort', onAbort);
+      if (aborted) await iterator.return?.();
+    }
+
+    const completedAt = this.deps.now();
+    const run = await this.findRunByTurnId(sessionId, turnId);
+    const failureClass = run?.failureClass ?? summary.failureClass;
+    const artifacts = this.deps.listArtifactsForTurn
+      ? await this.deps.listArtifactsForTurn(sessionId, turnId)
+      : [];
+    return {
+      agentId: definition.id,
+      agentName: definition.name,
+      turnId,
+      ...(run?.runId ? { runId: run.runId } : { runId }),
+      retriedFromRunId: sourceRun.runId,
+      status: run ? agentRunStatusForSpawnResult(run.status) : summary.status(aborted),
+      permissionMode: definition.permissionMode,
+      summary: summary.text(),
+      artifactIds: artifacts.map((artifact) => artifact.id),
+      startedAt,
+      completedAt,
+      durationMs: Math.max(0, completedAt - startedAt),
+      eventCount: summary.eventCount,
+      ...(failureClass ? { failureClass } : {}),
     };
   }
 

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -186,6 +186,15 @@ export interface MakaToolContext {
     }) => void | Promise<void>;
     onEvent?: (event: SessionEvent) => void;
   }) => Promise<unknown>;
+  retryChildAgent?: (input: {
+    sourceRunId: string;
+    onReady?: (input: {
+      turnId: string;
+      agentId: string;
+      agentName: string;
+    }) => void | Promise<void>;
+    onEvent?: (event: SessionEvent) => void;
+  }) => Promise<unknown>;
   listChildAgents?: () => Promise<unknown>;
   readChildAgentOutput?: (input: {
     runId?: string;
@@ -284,6 +293,17 @@ export interface ToolRuntimeInput {
     parentRunId: string;
     sourceRunId: string;
     prompt: string;
+    abortSignal: AbortSignal;
+    onReady?: (input: {
+      turnId: string;
+      agentId: string;
+      agentName: string;
+    }) => void | Promise<void>;
+    onEvent?: (event: SessionEvent) => void;
+  }) => Promise<unknown>;
+  retryChildAgent?: (input: {
+    parentRunId: string;
+    sourceRunId: string;
     abortSignal: AbortSignal;
     onReady?: (input: {
       turnId: string;
@@ -1728,12 +1748,15 @@ export class ToolRuntime {
     trace: RunTraceLike | null;
     toolUseId: string;
     toolName: string;
-  }): Pick<MakaToolContext, 'spawnChildAgent' | 'prepareChildAgentResume' | 'resumeChildAgent'> {
+  }): Pick<
+    MakaToolContext,
+    'spawnChildAgent' | 'prepareChildAgentResume' | 'resumeChildAgent' | 'retryChildAgent'
+  > {
     const parentRunId = this.input.getCurrentRunId?.();
     if (!parentRunId) return {};
     const limiter = this.childAgentRunLimiter;
     const runWithPermit = async <T>(
-      mode: 'spawn' | 'resume',
+      mode: 'spawn' | 'resume' | 'retry',
       execute: () => Promise<T>,
     ): Promise<T> => {
       const waitingForPermit = limiter.activeCount >= limiter.capacity || limiter.waitingCount > 0;
@@ -1816,6 +1839,7 @@ export class ToolRuntime {
     const spawnChildAgent = this.input.spawnChildAgent;
     const prepareChildAgentResume = this.input.prepareChildAgentResume;
     const resumeChildAgent = this.input.resumeChildAgent;
+    const retryChildAgent = this.input.retryChildAgent;
     return {
       ...(spawnChildAgent
         ? {
@@ -1850,6 +1874,22 @@ export class ToolRuntime {
                     abortSignal: input.abortSignal,
                     ...(resumeInput.onReady ? { onReady: resumeInput.onReady } : {}),
                     ...(resumeInput.onEvent ? { onEvent: resumeInput.onEvent } : {}),
+                  }),
+              ),
+          }
+        : {}),
+      ...(retryChildAgent
+        ? {
+            retryChildAgent: async (retryInput) =>
+              await runWithPermit(
+                'retry',
+                async () =>
+                  await retryChildAgent({
+                    parentRunId,
+                    sourceRunId: retryInput.sourceRunId,
+                    abortSignal: input.abortSignal,
+                    ...(retryInput.onReady ? { onReady: retryInput.onReady } : {}),
+                    ...(retryInput.onEvent ? { onEvent: retryInput.onEvent } : {}),
                   }),
               ),
           }


### PR DESCRIPTION
## Summary

Adds Kimi-compatible provider backpressure to Maka's foreground `agent_swarm` execution.

- launch an initial five-item burst, then ramp pending items one every 700 ms
- requeue provider `RateLimit` failures with 3 s / 6 s / 12 s exponential delays
- shrink effective batch capacity on repeated limits and recover one slot after a three-minute quiet interval
- fail the final unfinished rate-limited item instead of suspending the foreground tool forever
- preserve ordered all-settled results, artifact evidence, shared child-run permits, and parent cancellation

## Child retry semantics

Provider retries do not spawn the task prompt again. Each retry creates a fresh child `AgentRun` linked by `retriedFromRunId`, safely reconstructs the complete RuntimeEvent replay chain, and calls the provider with an empty `text` plus the original user-anchored runtime context.

This keeps attempts independently inspectable without duplicating user instructions or misclassifying the retry as a session continuation. It coexists with explicit `resume_run_ids`: user-driven continuation remains linked by `resumedFromRunId` and sends its new prompt, while a provider retry can reconstruct history across both resume and retry ancestors without sending another prompt. Desktop, CLI, and Headless expose both capabilities through the same child-run capacity boundary.

## Observability

Adds `item_suspended` and `capacity_changed` Swarm trace stages, attempt and retry-delay metadata, retry lineage in execution inspection, and documentation of the exact policy and scope.

This is intentionally batch-local and reactive. It is not a global provider RPM/TPM admission controller.

Advances #1324 without closing it; the issue still tracks the remaining post-v1 enhancements.

## Validation

- `npm run typecheck` (including Desktop after rebuilding the newly updated UI package)
- Runtime targeted tests: 23/23 passed for adaptive scheduling, explicit child resume, and AgentSwarm behavior
- SessionManager regression: consecutive rate-limit retries replay the original prompt context without appending another prompt
- CLI and Headless capability wiring tests passed
- Runtime full suite before the upstream rebase: 2,346 passed, 7 skipped; two unrelated local macOS sandbox failures remained:
  - existing `/usr/local` executable-root assertion
  - Homebrew `rg` cannot load PCRE2 because the filesystem sandbox blocks the dylib
