### PR TITLE
test(desktop): replace OAuth source greps with behavior contracts

### DIFF
--- a/apps/desktop/src/main/__tests__/antigravity-subscription-service.test.ts
+++ b/apps/desktop/src/main/__tests__/antigravity-subscription-service.test.ts
@@ -10,10 +10,8 @@
  *     calls must surface a clear, copy-paste-ready error so a
  *     future review catches an accidental enable).
  *
- * The tests import from `antigravity-subscription-helpers.ts`
- * directly so they don't pull in the `electron` ESM module —
- * the service class file imports `shell` from electron,
- * which is unavailable under plain `node --test`.
+ * The service receives its Electron-only URL opener as a dependency,
+ * so the preview's public behavior can run under plain `node --test`.
  */
 
 import { strict as assert } from 'node:assert';
@@ -27,6 +25,7 @@ import {
   STATUS,
   buildAntigravityAuthorizationUrl,
 } from '../oauth/antigravity-subscription-helpers.js';
+import { AntigravitySubscriptionService } from '../oauth/antigravity-subscription-service.js';
 
 const REPO_ROOT = resolve(process.cwd(), '..', '..');
 const SERVICE_SOURCE = resolve(
@@ -38,18 +37,8 @@ const SERVICE_SOURCE = resolve(
   'oauth',
   'antigravity-subscription-service.ts',
 );
-const HELPERS_SOURCE = resolve(
-  REPO_ROOT,
-  'apps',
-  'desktop',
-  'src',
-  'main',
-  'oauth',
-  'antigravity-subscription-helpers.ts',
-);
-
 describe('Antigravity subscription preview config', () => {
-  it('pins STATUS = preview and exports it for the contract scan', () => {
+  it('stays in preview status', () => {
     assert.equal(STATUS, 'preview');
     assert.equal(ANTIGRAVITY_OAUTH_CONFIG.status, 'preview');
   });
@@ -108,49 +97,21 @@ describe('Antigravity subscription preview config', () => {
   });
 });
 
-describe('Antigravity service source-grep contract', () => {
-  it('service file references the missing-client-id envelope from getAuthorizationUrl', async () => {
-    const src = await readFile(SERVICE_SOURCE, 'utf8');
-    assert.match(
-      src,
-      /ANTIGRAVITY_MISSING_CLIENT_ID_ENVELOPE/,
-      'service must return the shared envelope when GOOGLE_CLIENT_ID is empty',
-    );
-    // The check itself must live next to getAuthorizationUrl.
-    const match = src.match(/async getAuthorizationUrl\(\)[\s\S]{0,400}/);
-    assert.ok(match, 'getAuthorizationUrl must exist');
-    assert.match(
-      match[0],
-      /GOOGLE_CLIENT_ID/,
-      'getAuthorizationUrl must early-return based on GOOGLE_CLIENT_ID',
-    );
-  });
+describe('Antigravity service contract', () => {
+  it('fails closed through the public authorization API when no Google client_id is bundled', async () => {
+    const service = new AntigravitySubscriptionService({
+      userDataDir: '/unused',
+      openExternal: async () => undefined,
+      credentialStore: {
+        getSecret: async () => null,
+        setSecret: async () => {},
+        deleteSecret: async () => {},
+      },
+    });
 
-  it('persists tokens through the shared credential store, not safeStorage (#1125)', async () => {
-    const src = await readFile(SERVICE_SOURCE, 'utf8');
-    assert.match(
-      src,
-      /saveSharedOAuthTokens\(this\.credentialStore, 'antigravity-subscription'/,
-      'tokens must be written to the shared CredentialStore (the cross-surface authority)',
-    );
-    assert.doesNotMatch(
-      src,
-      /encryptString|decryptString|isEncryptionAvailable/,
-      'no safeStorage-encrypted token path may remain',
-    );
-  });
-
-  it('exports the preview status constant for the renderer-side scan', async () => {
-    const src = await readFile(HELPERS_SOURCE, 'utf8');
-    assert.match(src, /export const STATUS = 'preview' as const;/);
-  });
-
-  it('marks Google-specific calls as spec-only in the comment block', async () => {
-    const src = await readFile(HELPERS_SOURCE, 'utf8');
-    assert.match(
-      src,
-      /spec-only/i,
-      'antigravity helpers must call out that endpoint values come from the docs spec, not from a working upstream plugin source',
+    assert.deepEqual(
+      await service.getAuthorizationUrl(),
+      ANTIGRAVITY_MISSING_CLIENT_ID_ENVELOPE,
     );
   });
 

--- a/apps/desktop/src/main/__tests__/claude-subscription-cloak-flag.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-subscription-cloak-flag.test.ts
@@ -213,15 +213,4 @@ describe('cloaked request module isolation (xuan G-X4)', () => {
       assert.match(u, /OAUTH_USER_AGENT/, `${u} must reference the OAUTH_USER_AGENT constant`);
     }
   });
-
-  it('token storage fails closed when the shared credential store rejects the write', async () => {
-    const src = await readFile(SERVICE_SOURCE, 'utf8');
-    // saveTokens must record storage_failed AND rethrow — a token that
-    // could not be persisted for every surface is not a partial success.
-    assert.match(
-      src,
-      /saveSharedOAuthTokens\(this\.credentialStore, 'claude-subscription'[\s\S]{0,400}lastStorageFailedMessage[\s\S]{0,200}throw err;/,
-      'saveTokens must set storage_failed detail and rethrow when the store write fails',
-    );
-  });
 });

--- a/apps/desktop/src/main/__tests__/claude-subscription-experimental-gate.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-subscription-experimental-gate.test.ts
@@ -19,6 +19,7 @@ import { readFile } from 'node:fs/promises';
 import { describe, it } from 'node:test';
 import { resolve } from 'node:path';
 import { CATALOG_PROVIDER_TYPES } from '@maka/core';
+import { ClaudeSubscriptionService } from '../oauth/claude-subscription-service.js';
 import { readProviderSettingsCombinedSource } from './provider-contract-source-helpers.js';
 import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
@@ -185,17 +186,27 @@ describe('experimental kill-switch (kenji 1da909d5 + 45b31e16)', () => {
   });
 
   it('service openAuthorizationUrl looks up URL from pending map (kenji 1da909d5)', async () => {
-    const src = await readFile(SERVICE_SOURCE, 'utf8');
-    assert.match(
-      src,
-      /async openAuthorizationUrl\(authRequestId:\s*string\)/,
-      'service openAuthorizationUrl must take authRequestId — never accept an arbitrary URL from the renderer',
-    );
-    assert.match(
-      src,
-      /shell\.openExternal\(pending\.url\)/,
-      'service must open pending.url (main-generated), not a renderer-provided URL',
-    );
+    const openedUrls: string[] = [];
+    const service = new ClaudeSubscriptionService({
+      userDataDir: '/unused',
+      openExternal: async (url) => {
+        openedUrls.push(url);
+      },
+      credentialStore: {
+        getSecret: async () => null,
+        setSecret: async () => undefined,
+        deleteSecret: async () => undefined,
+      },
+    });
+
+    assert.equal((await service.openAuthorizationUrl('https://attacker.example')).ok, false);
+    assert.deepEqual(openedUrls, []);
+
+    const authorization = await service.getAuthorizationUrl();
+    assert.deepEqual(Object.keys(authorization).sort(), ['authRequestId', 'stateHint']);
+    assert.deepEqual(await service.openAuthorizationUrl(authorization.authRequestId), { ok: true });
+    assert.equal(openedUrls.length, 1);
+    assert.equal(new URL(openedUrls[0]!).origin, 'https://claude.com');
   });
 
   it('AuthorizationUrlPayload has NO url field — renderer never holds the URL (kenji 027c93c0)', async () => {
@@ -243,29 +254,6 @@ describe('experimental kill-switch (kenji 1da909d5 + 45b31e16)', () => {
       src,
       /登录暂不可用|配额暂不可用|配额接口暂时无法访问/,
       'subscription account copy should avoid generic unavailable/demo-stage wording',
-    );
-  });
-
-  it('service getAuthorizationUrl return statement does not include url key', async () => {
-    const src = await readFile(SERVICE_SOURCE, 'utf8');
-    // Find the getAuthorizationUrl method and check the return
-    // expression's keys. The method must return only
-    // { stateHint, authRequestId }; a `url` key would put the URL
-    // back into the IPC payload.
-    const start = src.indexOf('async getAuthorizationUrl');
-    assert.notEqual(start, -1, 'getAuthorizationUrl method must exist');
-    const end = src.indexOf('async openAuthorizationUrl', start);
-    assert.notEqual(end, -1, 'openAuthorizationUrl must follow getAuthorizationUrl');
-    const slice = src.slice(start, end);
-    // Look for a `return { ...url... }` pattern. The pending map
-    // assignment with `url,` shorthand is fine; only the RETURN
-    // statement matters.
-    const returnMatch = slice.match(/return\s*\{[^}]*\}/);
-    assert.ok(returnMatch, 'getAuthorizationUrl must have a return statement with object literal');
-    assert.doesNotMatch(
-      returnMatch[0]!,
-      /\burl\b/,
-      'getAuthorizationUrl return statement must NOT include url — pending.url stays in the service',
     );
   });
 

--- a/apps/desktop/src/main/__tests__/cursor-subscription-service.test.ts
+++ b/apps/desktop/src/main/__tests__/cursor-subscription-service.test.ts
@@ -102,20 +102,6 @@ describe('Cursor subscription OAuth config (upstream cursor-auth pattern)', () =
 });
 
 describe('Cursor service source-grep contract', () => {
-  it('persists tokens through the shared credential store, not safeStorage (#1125)', async () => {
-    const src = await readFile(SERVICE_SOURCE, 'utf8');
-    assert.match(
-      src,
-      /saveSharedOAuthTokens\(this\.credentialStore, 'cursor-subscription'/,
-      'tokens must be written to the shared CredentialStore (the cross-surface authority)',
-    );
-    assert.doesNotMatch(
-      src,
-      /encryptString|decryptString|isEncryptionAvailable/,
-      'no safeStorage-encrypted token path may remain',
-    );
-  });
-
   it('uses globalThis.fetch by default so Electron session proxy applies', async () => {
     const src = await readFile(SERVICE_SOURCE, 'utf8');
     assert.match(src, /globalThis\.fetch/);
@@ -146,22 +132,6 @@ describe('Cursor service source-grep contract', () => {
       'refresh URL literal must exactly match upstream cursor-auth (in helpers config)',
     );
     assert.match(serviceSrc, /Authorization:\s*`Bearer/, 'refresh must send Bearer auth');
-  });
-
-  it('does not expose tokens through the `getAccountState` return object', async () => {
-    const src = await readFile(SERVICE_SOURCE, 'utf8');
-    const match = src.match(/async getAccountState\(\)[\s\S]*?\n {2}\}/);
-    assert.ok(match, 'getAccountState must exist');
-    const body = match[0];
-    const returns = [...body.matchAll(/return\s*\{[\s\S]*?\n\s*\};/g)].map((m) => m[0]);
-    assert.ok(returns.length >= 1, 'must have at least one return literal');
-    for (const ret of returns) {
-      assert.doesNotMatch(
-        ret,
-        /(access_token|refresh_token)\s*:/,
-        'getAccountState return objects must not include token fields',
-      );
-    }
   });
 
   it('exports isCursorSubscriptionExperimentalEnabled tied to the env flag', async () => {

--- a/apps/desktop/src/main/__tests__/oauth-bug-sweep-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/oauth-bug-sweep-contract.test.ts
@@ -18,11 +18,6 @@ const SERVICES_WITH_LOOPBACK_SERVER = [
   'antigravity-subscription-service.ts',
 ];
 
-const WIRED_OAUTH_SEND_SERVICES = [
-  'claude-subscription-service.ts',
-  'openai-codex-service.ts',
-];
-
 describe('OAuth callback server: drains sockets + timeout (B-SWEEP-1, B-SWEEP-2)', () => {
   for (const file of SERVICES_WITH_LOOPBACK_SERVER) {
     it(`${file} drops in-flight sockets before close()`, async () => {
@@ -52,49 +47,9 @@ describe('OAuth callback server: drains sockets + timeout (B-SWEEP-1, B-SWEEP-2)
 });
 
 // B-SWEEP-3 (unlink corrupt token files) is retired: every service
-// now persists through the shared CredentialStore (#1125), and the
-// bridge deletes a corrupt entry — covered by
+// now persists through the shared CredentialStore (#1125), whose
+// reads preserve corrupt entries for recovery — covered by
 // shared-oauth-token-persistence.test.ts.
-
-describe('OAuth loadTokens: storage failures are not shown as logged out', () => {
-  for (const file of WIRED_OAUTH_SEND_SERVICES) {
-    it(`${file} reports storage_failed instead of not_logged_in for local credential read failures`, async () => {
-      const source = await readFile(resolve(OAUTH_DIR, file), 'utf8');
-      const getAccountStateStart = source.indexOf('async getAccountState()');
-      assert.ok(getAccountStateStart > 0, `getAccountState not found in ${file}`);
-      const getAccountState = source.slice(getAccountStateStart, getAccountStateStart + 900);
-      const loadTokensStart = source.indexOf('private async loadTokens(');
-      assert.ok(loadTokensStart > 0, `loadTokens not found in ${file}`);
-      const loadTokens = source.slice(loadTokensStart, loadTokensStart + 1800);
-
-      assert.match(
-        source,
-        /lastStorageFailedMessage/,
-        `${file} must preserve local credential storage errors as state`,
-      );
-      assert.match(
-        getAccountState,
-        /lastStorageFailedMessage[\s\S]*runtimeState:\s*'storage_failed'[\s\S]*errorMessage:\s*this\.lastStorageFailedMessage/,
-        `${file} getAccountState must not collapse local storage failures into not_logged_in`,
-      );
-      assert.match(
-        loadTokens,
-        /loadSharedOAuthTokens\(this\.credentialStore/,
-        `${file} must load tokens from the shared credential store (the authority, #1125)`,
-      );
-      assert.match(
-        loadTokens,
-        /catch \{[\s\S]*lastStorageFailedMessage[\s\S]*return null/,
-        `${file} store read failures must set storage_failed detail instead of reading as logged out`,
-      );
-      assert.match(
-        loadTokens,
-        /status === 'corrupt'[\s\S]*lastStorageFailedMessage[\s\S]*return null/,
-        `${file} corrupt shared entries (deleted by the bridge) must surface storage_failed detail`,
-      );
-    });
-  }
-});
 
 describe('WeChat bridge: streaming loops must not become unhandled rejections (B-SWEEP-4)', () => {
   it('streamIlinkMessages and streamLiveMessages have .catch() on the fire-and-forget', async () => {

--- a/apps/desktop/src/main/__tests__/openai-codex-service.test.ts
+++ b/apps/desktop/src/main/__tests__/openai-codex-service.test.ts
@@ -155,20 +155,6 @@ describe('Codex JWT account-id extraction', () => {
 });
 
 describe('Codex service source-grep contract', () => {
-  it('persists tokens through the shared credential store, not safeStorage (#1125)', async () => {
-    const src = await readFile(SERVICE_SOURCE, 'utf8');
-    assert.match(
-      src,
-      /saveSharedOAuthTokens\(this\.credentialStore, 'codex-subscription'/,
-      'tokens must be written to the shared CredentialStore (the cross-surface authority)',
-    );
-    assert.doesNotMatch(
-      src,
-      /encryptString|decryptString|isEncryptionAvailable/,
-      'no safeStorage-encrypted token path may remain',
-    );
-  });
-
   it('uses proxiedFetch by default so the active Maka proxy applies to OAuth requests', async () => {
     const src = await readFile(SERVICE_SOURCE, 'utf8');
     assert.match(
@@ -181,24 +167,6 @@ describe('Codex service source-grep contract', () => {
       /deps\.fetchFn\s*\?\?\s*\(globalThis\.fetch/,
       'Electron global fetch does not honor Maka active-proxy state',
     );
-  });
-
-  it('does not expose tokens through the `getAccountState` return object', async () => {
-    const src = await readFile(SERVICE_SOURCE, 'utf8');
-    const match = src.match(/async getAccountState\(\)[\s\S]*?\n {2}\}/);
-    assert.ok(match, 'getAccountState must exist');
-    const body = match[0];
-    // The return objects (there are two — early not_logged_in and
-    // the authenticated one) must not include any token field.
-    const returns = [...body.matchAll(/return\s*\{[\s\S]*?\n\s*\};/g)].map((m) => m[0]);
-    assert.ok(returns.length >= 1, 'must have at least one return literal');
-    for (const ret of returns) {
-      assert.doesNotMatch(
-        ret,
-        /(access_token|refresh_token|id_token)\s*:/,
-        'getAccountState return objects must not include token fields',
-      );
-    }
   });
 
   it('exports isOpenAiCodexExperimentalEnabled tied to the env flag', async () => {

--- a/apps/desktop/src/main/__tests__/shared-oauth-token-persistence.test.ts
+++ b/apps/desktop/src/main/__tests__/shared-oauth-token-persistence.test.ts
@@ -11,6 +11,7 @@ import { mkdtemp, readFile, rm, stat, unlink, writeFile } from 'node:fs/promises
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { after, describe, it } from 'node:test';
+import { resolveOAuthSubscriptionTokens } from '@maka/runtime';
 import { createFileCredentialStore, type CredentialStore } from '@maka/storage';
 import {
   deleteSharedOAuthTokens,
@@ -57,6 +58,23 @@ describe('shared OAuth token persistence (store authority)', () => {
     const result = await loadSharedOAuthTokens(store, 'claude-subscription');
     assert.equal(result.status, 'ok');
     assert.deepEqual(result.status === 'ok' && result.tokens, TOKENS);
+  });
+
+  it('makes a desktop-written token immediately readable by a pure-Node runtime surface', async () => {
+    const workspaceRoot = await makeWorkspace();
+    const desktopStore = createFileCredentialStore(workspaceRoot);
+    await saveSharedOAuthTokens(desktopStore, 'codex-subscription', TOKENS);
+
+    const runtimeStore = createFileCredentialStore(workspaceRoot);
+    const resolved = await resolveOAuthSubscriptionTokens({
+      providerType: 'openai-codex',
+      slug: 'codex-subscription',
+      credentialStore: runtimeStore,
+      now: () => TOKENS.expires_at - 3_600_000,
+      fetchFn: async () => assert.fail('a fresh shared token must not use the network'),
+    });
+
+    assert.deepEqual(resolved, TOKENS);
   });
 
   it('reports missing tokens as missing', async () => {

--- a/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
+++ b/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
@@ -34,7 +34,7 @@ interface ServiceCase {
   slug: string;
   legacyFile: string;
   initialTokens: Record<string, unknown>;
-  refresh?: {
+  refresh: {
     accessToken: string;
     response: Record<string, unknown>;
   };
@@ -194,35 +194,41 @@ describe('OAuth subscription token authority (shared CredentialStore)', () => {
     });
 
     const refresh = serviceCase.refresh;
-    if (!refresh) continue;
 
-    it(`${serviceCase.name} refreshes and exposes the new access token from the shared credential`, async () => {
-      const userDataDir = await makeUserDataDir();
-      const credentials = createMemoryCredentialStore();
-      credentials.set(
-        serviceCase.slug,
-        'oauth_token',
-        JSON.stringify({ ...serviceCase.initialTokens, expires_at: NOW - 1 }),
-      );
-      let fetchCalls = 0;
-      const service = serviceCase.create({
-        userDataDir,
-        credentialStore: credentials.store,
-        fetchFn: async () => {
-          fetchCalls += 1;
-          return Response.json(refresh.response);
-        },
+    for (const entryPoint of ['explicit', 'automatic'] as const) {
+      it(`${serviceCase.name} refreshes an expired credential through ${entryPoint} refresh`, async () => {
+        const userDataDir = await makeUserDataDir();
+        const credentials = createMemoryCredentialStore();
+        credentials.set(
+          serviceCase.slug,
+          'oauth_token',
+          JSON.stringify({ ...serviceCase.initialTokens, expires_at: NOW - 1 }),
+        );
+        let fetchCalls = 0;
+        const service = serviceCase.create({
+          userDataDir,
+          credentialStore: credentials.store,
+          fetchFn: async () => {
+            fetchCalls += 1;
+            return Response.json(refresh.response);
+          },
+        });
+
+        const result = entryPoint === 'explicit'
+          ? await service.refreshTokens()
+          : await service.getAccessTokenInternal();
+
+        if (entryPoint === 'explicit') assert.deepEqual(result, { ok: true });
+        else assert.equal(result, refresh.accessToken);
+        assert.equal(fetchCalls, 1);
+        const persisted = JSON.parse(
+          credentials.get(serviceCase.slug, 'oauth_token') ?? 'null',
+        ) as { access_token?: string };
+        assert.equal(persisted.access_token, refresh.accessToken);
+        assert.equal(await service.getAccessTokenInternal(), refresh.accessToken);
+        assert.equal(fetchCalls, 1, 'a fresh shared token must not trigger a second refresh');
       });
-
-      assert.deepEqual(await service.refreshTokens(), { ok: true });
-      assert.equal(fetchCalls, 1);
-      const persisted = JSON.parse(
-        credentials.get(serviceCase.slug, 'oauth_token') ?? 'null',
-      ) as { access_token?: string };
-      assert.equal(persisted.access_token, refresh.accessToken);
-      assert.equal(await service.getAccessTokenInternal(), refresh.accessToken);
-      assert.equal(fetchCalls, 1, 'a fresh shared token must not trigger a second refresh');
-    });
+    }
 
     for (const entryPoint of ['explicit', 'automatic'] as const) {
       it(`${serviceCase.name} keeps a credential replaced during ${entryPoint} refresh`, async () => {
@@ -257,9 +263,12 @@ describe('OAuth subscription token authority (shared CredentialStore)', () => {
           ? await service.refreshTokens()
           : await service.getAccessTokenInternal();
 
-        if (entryPoint === 'explicit') assert.deepEqual(result, { ok: true });
-        else assert.equal(result, winner.access_token);
-        assert.equal(fetchCalls, 1);
+        if (entryPoint === 'explicit') {
+          assert.deepEqual(result, { ok: true });
+          assert.equal(fetchCalls, 1);
+        } else {
+          assert.equal(result, winner.access_token);
+        }
         assert.deepEqual(
           JSON.parse(credentials.get(serviceCase.slug, 'oauth_token') ?? 'null'),
           winner,

--- a/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
+++ b/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
@@ -144,6 +144,13 @@ const STORE_AUTHORITY_SERVICES: ServiceCase[] = [
       refresh_token: 'antigravity-refresh',
       expires_at: NOW + 3_600_000,
     },
+    refresh: {
+      accessToken: 'antigravity-access-refreshed',
+      response: {
+        access_token: 'antigravity-access-refreshed',
+        expires_in: 3600,
+      },
+    },
     create: (input) =>
       new AntigravitySubscriptionService({
         ...input,
@@ -217,49 +224,48 @@ describe('OAuth subscription token authority (shared CredentialStore)', () => {
       assert.equal(fetchCalls, 1, 'a fresh shared token must not trigger a second refresh');
     });
 
-    it(`${serviceCase.name} does not overwrite a credential changed while refresh is in flight`, async () => {
-      const userDataDir = await makeUserDataDir();
-      const credentials = createMemoryCredentialStore();
-      credentials.set(
-        serviceCase.slug,
-        'oauth_token',
-        JSON.stringify({ ...serviceCase.initialTokens, expires_at: NOW - 1 }),
-      );
-      let markRefreshStarted!: () => void;
-      const refreshStarted = new Promise<void>((resolve) => {
-        markRefreshStarted = resolve;
-      });
-      let releaseRefresh!: () => void;
-      const refreshReleased = new Promise<void>((resolve) => {
-        releaseRefresh = resolve;
-      });
-      const service = serviceCase.create({
-        userDataDir,
-        credentialStore: credentials.store,
-        fetchFn: async () => {
-          markRefreshStarted();
-          await refreshReleased;
-          return Response.json(refresh.response);
-        },
-      });
+    for (const entryPoint of ['explicit', 'automatic'] as const) {
+      it(`${serviceCase.name} keeps a credential replaced during ${entryPoint} refresh`, async () => {
+        const userDataDir = await makeUserDataDir();
+        const credentials = createMemoryCredentialStore();
+        credentials.set(
+          serviceCase.slug,
+          'oauth_token',
+          JSON.stringify({ ...serviceCase.initialTokens, expires_at: NOW - 1 }),
+        );
+        const winner = {
+          ...serviceCase.initialTokens,
+          access_token: `${serviceCase.name.toLowerCase()}-winner-access`,
+          expires_at: NOW + 3_600_000,
+        };
+        credentials.replaceAfterNextRead(
+          serviceCase.slug,
+          'oauth_token',
+          JSON.stringify(winner),
+        );
+        let fetchCalls = 0;
+        const service = serviceCase.create({
+          userDataDir,
+          credentialStore: credentials.store,
+          fetchFn: async () => {
+            fetchCalls += 1;
+            return Response.json(refresh.response);
+          },
+        });
 
-      const refreshing = service.refreshTokens();
-      await refreshStarted;
-      const winner = {
-        ...serviceCase.initialTokens,
-        access_token: `${serviceCase.name.toLowerCase()}-winner-access`,
-        expires_at: NOW + 3_600_000,
-      };
-      credentials.set(serviceCase.slug, 'oauth_token', JSON.stringify(winner));
-      releaseRefresh();
+        const result = entryPoint === 'explicit'
+          ? await service.refreshTokens()
+          : await service.getAccessTokenInternal();
 
-      assert.deepEqual(await refreshing, { ok: true });
-      assert.deepEqual(
-        JSON.parse(credentials.get(serviceCase.slug, 'oauth_token') ?? 'null'),
-        winner,
-      );
-      assert.equal(await service.getAccessTokenInternal(), winner.access_token);
-    });
+        if (entryPoint === 'explicit') assert.deepEqual(result, { ok: true });
+        else assert.equal(result, winner.access_token);
+        assert.equal(fetchCalls, 1);
+        assert.deepEqual(
+          JSON.parse(credentials.get(serviceCase.slug, 'oauth_token') ?? 'null'),
+          winner,
+        );
+      });
+    }
   }
 
   for (const serviceCase of STORE_AUTHORITY_SERVICES.slice(0, 2)) {
@@ -521,12 +527,26 @@ function createMemoryCredentialStore(): {
   store: SharedOAuthCredentialStore;
   get(slug: string, kind: 'api_key' | 'oauth_token'): string | null;
   set(slug: string, kind: 'api_key' | 'oauth_token', value: string): void;
+  replaceAfterNextRead(
+    slug: string,
+    kind: 'api_key' | 'oauth_token',
+    value: string,
+  ): void;
 } {
   const secrets = new Map<string, string>();
   const key = (slug: string, kind: string): string => `${slug}\0${kind}`;
+  let replacementAfterNextRead: { key: string; value: string } | undefined;
   return {
     store: {
-      getSecret: async (slug, kind) => secrets.get(key(slug, kind)) ?? null,
+      getSecret: async (slug, kind) => {
+        const storedKey = key(slug, kind);
+        const current = secrets.get(storedKey) ?? null;
+        if (replacementAfterNextRead?.key === storedKey) {
+          secrets.set(storedKey, replacementAfterNextRead.value);
+          replacementAfterNextRead = undefined;
+        }
+        return current;
+      },
       setSecret: async (slug, kind, value) => {
         secrets.set(key(slug, kind), value);
       },
@@ -549,6 +569,9 @@ function createMemoryCredentialStore(): {
     get: (slug, kind) => secrets.get(key(slug, kind)) ?? null,
     set: (slug, kind, value) => {
       secrets.set(key(slug, kind), value);
+    },
+    replaceAfterNextRead: (slug, kind, value) => {
+      replacementAfterNextRead = { key: key(slug, kind), value };
     },
   };
 }

--- a/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
+++ b/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
@@ -1,114 +1,444 @@
 /**
- * Source-grounded contract: the shared CredentialStore (workspace
- * credentials.json) is the single OAuth token authority for the
- * desktop subscription services (#1125). Desktop persists through the
- * shared-credential-bridge helpers and never through Electron
- * safeStorage; the runtime-usable token a pure-Node surface reads is
- * the same one the desktop wrote. Unit coverage of the bridge itself
- * lives in shared-oauth-token-persistence.test.ts.
+ * Contract for the shared CredentialStore (workspace credentials.json)
+ * as the single OAuth token authority for desktop subscription services
+ * (#1125). Service behavior is exercised through public APIs; the
+ * remaining source checks cover architecture and startup ordering.
  */
 
 import { strict as assert } from 'node:assert';
-import { readdir, readFile } from 'node:fs/promises';
-import { dirname, resolve } from 'node:path';
-import { describe, it } from 'node:test';
+import { mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { after, describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
+import type { SubscriptionActionResult } from '@maka/core';
+import { AntigravitySubscriptionService } from '../oauth/antigravity-subscription-service.js';
+import { ClaudeSubscriptionService } from '../oauth/claude-subscription-service.js';
+import { CursorSubscriptionService } from '../oauth/cursor-subscription-service.js';
+import { OpenAiCodexService } from '../oauth/openai-codex-service.js';
+import type { SharedOAuthCredentialStore } from '../oauth/shared-credential-bridge.js';
 import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const DESKTOP_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
 const OAUTH_DIR = resolve(DESKTOP_ROOT, 'src', 'main', 'oauth');
 
-const STORE_AUTHORITY_SERVICES = [
-  ['Claude', 'claude-subscription-service.ts', 'claude-subscription'],
-  ['Codex', 'openai-codex-service.ts', 'codex-subscription'],
-  ['Cursor', 'cursor-subscription-service.ts', 'cursor-subscription'],
-  ['Antigravity', 'antigravity-subscription-service.ts', 'antigravity-subscription'],
-] as const;
+interface OAuthServiceContract {
+  getAccountState(): Promise<object>;
+  getAccessTokenInternal(): Promise<string | null>;
+  refreshTokens(): Promise<SubscriptionActionResult>;
+  logout(): Promise<SubscriptionActionResult>;
+}
+
+interface ServiceCase {
+  name: string;
+  slug: string;
+  legacyFile: string;
+  initialTokens: Record<string, unknown>;
+  refresh?: {
+    accessToken: string;
+    response: Record<string, unknown>;
+  };
+  create(input: {
+    userDataDir: string;
+    credentialStore: SharedOAuthCredentialStore;
+    fetchFn: typeof fetch;
+  }): OAuthServiceContract;
+}
+
+const NOW = 1_700_000_000_000;
+const codexAccessToken = jwt({
+  sub: 'codex-subject',
+  'https://api.openai.com/auth': { chatgpt_account_id: 'codex-account' },
+});
+const refreshedCodexAccessToken = jwt({
+  sub: 'refreshed-codex-subject',
+  'https://api.openai.com/auth': { chatgpt_account_id: 'codex-account' },
+});
+
+const STORE_AUTHORITY_SERVICES: ServiceCase[] = [
+  {
+    name: 'Claude',
+    slug: 'claude-subscription',
+    legacyFile: '.claude_subscription_token',
+    initialTokens: {
+      access_token: 'claude-access',
+      refresh_token: 'claude-refresh',
+      expires_at: NOW + 3_600_000,
+      token_type: 'Bearer',
+      scope: 'user:sessions:claude_code',
+      account_uuid: 'claude-account',
+    },
+    refresh: {
+      accessToken: 'claude-access-refreshed',
+      response: {
+        access_token: 'claude-access-refreshed',
+        refresh_token: 'claude-refresh-refreshed',
+        expires_in: 3600,
+        token_type: 'Bearer',
+        scope: 'user:sessions:claude_code',
+        account: { uuid: 'claude-account' },
+      },
+    },
+    create: (input) =>
+      new ClaudeSubscriptionService({
+        ...input,
+        now: () => NOW,
+        openExternal: async () => undefined,
+      }),
+  },
+  {
+    name: 'Codex',
+    slug: 'codex-subscription',
+    legacyFile: '.codex_subscription_token',
+    initialTokens: {
+      access_token: codexAccessToken,
+      refresh_token: 'codex-refresh',
+      expires_at: NOW + 3_600_000,
+      account_id: 'codex-account',
+    },
+    refresh: {
+      accessToken: refreshedCodexAccessToken,
+      response: {
+        access_token: refreshedCodexAccessToken,
+        refresh_token: 'codex-refresh-refreshed',
+        expires_in: 3600,
+      },
+    },
+    create: (input) =>
+      new OpenAiCodexService({
+        ...input,
+        now: () => NOW,
+        openExternal: async () => undefined,
+      }),
+  },
+  {
+    name: 'Cursor',
+    slug: 'cursor-subscription',
+    legacyFile: '.cursor_subscription_token',
+    initialTokens: {
+      access_token: 'cursor-access',
+      refresh_token: 'cursor-refresh',
+      expires_at: NOW + 3_600_000,
+    },
+    refresh: {
+      accessToken: 'cursor-access-refreshed',
+      response: {
+        accessToken: 'cursor-access-refreshed',
+        refreshToken: 'cursor-refresh-refreshed',
+      },
+    },
+    create: (input) =>
+      new CursorSubscriptionService({
+        ...input,
+        now: () => NOW,
+        openExternal: async () => undefined,
+        sleepFn: async () => undefined,
+      }),
+  },
+  {
+    name: 'Antigravity',
+    slug: 'antigravity-subscription',
+    legacyFile: '.antigravity_subscription_token',
+    initialTokens: {
+      access_token: 'antigravity-access',
+      refresh_token: 'antigravity-refresh',
+      expires_at: NOW + 3_600_000,
+    },
+    create: (input) =>
+      new AntigravitySubscriptionService({
+        ...input,
+        now: () => NOW,
+        openExternal: async () => undefined,
+      }),
+  },
+];
+
+const tempRoots: string[] = [];
+
+after(async () => {
+  await Promise.all(tempRoots.map((root) => rm(root, { recursive: true, force: true })));
+});
 
 describe('OAuth subscription token authority (shared CredentialStore)', () => {
-  for (const [name, file, slug] of STORE_AUTHORITY_SERVICES) {
-    it(`${name} service persists tokens only through the shared credential store`, async () => {
-      const src = await readFile(resolve(OAUTH_DIR, file), 'utf8');
-      assert.match(
-        src,
-        new RegExp(`saveSharedOAuthTokens\\(this\\.credentialStore, '${slug}'`),
-        `${name} service must write tokens to the shared store (the authority)`,
-      );
-      assert.match(
-        src,
-        new RegExp(`loadSharedOAuthTokens\\(this\\.credentialStore, '${slug}'`),
-        `${name} service must read tokens back from the shared store`,
-      );
-      assert.match(
-        src,
-        new RegExp(`deleteSharedOAuthTokens\\(this\\.credentialStore, '${slug}'`),
-        `${name} logout must delete the authoritative shared token`,
-      );
+  for (const serviceCase of STORE_AUTHORITY_SERVICES) {
+    it(`${serviceCase.name} reads account state and logs out through its shared credential`, async () => {
+      const userDataDir = await makeUserDataDir();
+      const credentials = createMemoryCredentialStore();
+      credentials.set(serviceCase.slug, 'oauth_token', JSON.stringify(serviceCase.initialTokens));
+      credentials.set(serviceCase.slug, 'api_key', 'api-key-must-survive');
+      const legacyFile = join(userDataDir, serviceCase.legacyFile);
+      await writeFile(legacyFile, 'legacy-encrypted-token');
+      const service = serviceCase.create({
+        userDataDir,
+        credentialStore: credentials.store,
+        fetchFn: async () => assert.fail('account-state and logout must not use the network'),
+      });
+
+      const state = await service.getAccountState();
+      assert.equal('runtimeState' in state && state.runtimeState, 'authenticated');
+      const serializedState = JSON.stringify(state);
+      assert.doesNotMatch(serializedState, /access_token|refresh_token|id_token/);
+      assert.equal(serializedState.includes(String(serviceCase.initialTokens.access_token)), false);
+
+      assert.deepEqual(await service.logout(), { ok: true });
+      assert.equal(credentials.get(serviceCase.slug, 'oauth_token'), null);
+      assert.equal(credentials.get(serviceCase.slug, 'api_key'), 'api-key-must-survive');
+      await assert.rejects(stat(legacyFile), { code: 'ENOENT' });
     });
 
-    it(`${name} service has no safeStorage / encrypted-file token path left`, async () => {
-      const src = await readFile(resolve(OAUTH_DIR, file), 'utf8');
-      assert.doesNotMatch(
-        src,
-        /from 'electron'.*safeStorage|safeStorage.*from 'electron'/,
-        `${name} service must not import safeStorage — the store is the only authority (#1125)`,
+    const refresh = serviceCase.refresh;
+    if (!refresh) continue;
+
+    it(`${serviceCase.name} refreshes and exposes the new access token from the shared credential`, async () => {
+      const userDataDir = await makeUserDataDir();
+      const credentials = createMemoryCredentialStore();
+      credentials.set(
+        serviceCase.slug,
+        'oauth_token',
+        JSON.stringify({ ...serviceCase.initialTokens, expires_at: NOW - 1 }),
       );
-      assert.doesNotMatch(
-        src,
-        /encryptString|decryptString|isEncryptionAvailable/,
-        `${name} service must not encrypt/decrypt token files`,
-      );
-      assert.doesNotMatch(
-        src,
-        /fs\.writeFile\(this\.legacyTokenFilePath/,
-        `${name} service must never write the legacy token file`,
-      );
-      assert.match(
-        src,
-        /fs\.unlink\(this\.legacyTokenFilePath\)/,
-        `${name} logout must still clear a legacy token file the startup import could not process`,
-      );
+      let fetchCalls = 0;
+      const service = serviceCase.create({
+        userDataDir,
+        credentialStore: credentials.store,
+        fetchFn: async () => {
+          fetchCalls += 1;
+          return Response.json(refresh.response);
+        },
+      });
+
+      assert.deepEqual(await service.refreshTokens(), { ok: true });
+      assert.equal(fetchCalls, 1);
+      const persisted = JSON.parse(
+        credentials.get(serviceCase.slug, 'oauth_token') ?? 'null',
+      ) as { access_token?: string };
+      assert.equal(persisted.access_token, refresh.accessToken);
+      assert.equal(await service.getAccessTokenInternal(), refresh.accessToken);
+      assert.equal(fetchCalls, 1, 'a fresh shared token must not trigger a second refresh');
     });
 
-    it(`${name} delegates refresh persistence and races to the runtime transaction`, async () => {
-      const src = await readFile(resolve(OAUTH_DIR, file), 'utf8');
-      const refreshStart = src.indexOf('async refreshTokens()');
-      const refreshEnd = src.indexOf('\n  async logout()', refreshStart);
-      assert.ok(refreshStart > 0 && refreshEnd > refreshStart, `${name} refreshTokens body must exist`);
-      const refreshBody = src.slice(refreshStart, refreshEnd);
-      assert.match(
-        refreshBody,
-        /refreshAndPersistOAuthSubscriptionTokens\(\{/,
-        `${name} refresh must delegate read/network/CAS persistence to the runtime transaction`,
+    it(`${serviceCase.name} does not overwrite a credential changed while refresh is in flight`, async () => {
+      const userDataDir = await makeUserDataDir();
+      const credentials = createMemoryCredentialStore();
+      credentials.set(
+        serviceCase.slug,
+        'oauth_token',
+        JSON.stringify({ ...serviceCase.initialTokens, expires_at: NOW - 1 }),
       );
-      assert.doesNotMatch(
-        refreshBody,
-        /this\.saveTokens\(/,
-        `${name} refresh must not persist outside the runtime transaction`,
-      );
-      assert.doesNotMatch(
-        src,
-        /credentialEpoch/,
-        `${name} must not keep the in-process epoch guard superseded by cross-process CAS`,
-      );
-    });
+      let markRefreshStarted!: () => void;
+      const refreshStarted = new Promise<void>((resolve) => {
+        markRefreshStarted = resolve;
+      });
+      let releaseRefresh!: () => void;
+      const refreshReleased = new Promise<void>((resolve) => {
+        releaseRefresh = resolve;
+      });
+      const service = serviceCase.create({
+        userDataDir,
+        credentialStore: credentials.store,
+        fetchFn: async () => {
+          markRefreshStarted();
+          await refreshReleased;
+          return Response.json(refresh.response);
+        },
+      });
 
-    it(`${name} delegates automatic refresh decisions to the same runtime transaction`, async () => {
-      const src = await readFile(resolve(OAUTH_DIR, file), 'utf8');
-      const accessTokenMethod = src.match(/async getAccessTokenInternal\([^]*?\n  \}/u)?.[0];
-      assert.ok(accessTokenMethod, `${name} getAccessTokenInternal body must exist`);
-      assert.match(
-        accessTokenMethod,
-        /resolveAndPersistOAuthSubscriptionTokens\(\{/,
-        `${name} automatic refresh must preserve the runtime transaction's first-read CAS basis`,
+      const refreshing = service.refreshTokens();
+      await refreshStarted;
+      const winner = {
+        ...serviceCase.initialTokens,
+        access_token: `${serviceCase.name.toLowerCase()}-winner-access`,
+        expires_at: NOW + 3_600_000,
+      };
+      credentials.set(serviceCase.slug, 'oauth_token', JSON.stringify(winner));
+      releaseRefresh();
+
+      assert.deepEqual(await refreshing, { ok: true });
+      assert.deepEqual(
+        JSON.parse(credentials.get(serviceCase.slug, 'oauth_token') ?? 'null'),
+        winner,
       );
-      assert.doesNotMatch(
-        accessTokenMethod,
-        /tokens\.expires_at/,
-        `${name} must not make an expiry decision before entering the runtime transaction`,
-      );
+      assert.equal(await service.getAccessTokenInternal(), winner.access_token);
     });
   }
+
+  for (const serviceCase of STORE_AUTHORITY_SERVICES.slice(0, 2)) {
+    it(`${serviceCase.name} reports shared credential read failures as storage_failed`, async () => {
+      const userDataDir = await makeUserDataDir();
+      const service = serviceCase.create({
+        userDataDir,
+        credentialStore: {
+          getSecret: async () => {
+            throw new Error('credential store unavailable');
+          },
+          setSecret: async () => undefined,
+          deleteSecret: async () => undefined,
+        },
+        fetchFn: async () => assert.fail('a failed credential read must not use the network'),
+      });
+
+      const state = await service.getAccountState();
+      assert.equal('runtimeState' in state && state.runtimeState, 'storage_failed');
+      assert.match('errorMessage' in state ? String(state.errorMessage) : '', /凭据|credentials\.json/);
+    });
+
+    it(`${serviceCase.name} reports a corrupt shared credential as storage_failed without deleting it`, async () => {
+      const userDataDir = await makeUserDataDir();
+      const credentials = createMemoryCredentialStore();
+      credentials.set(serviceCase.slug, 'oauth_token', 'not-json');
+      const service = serviceCase.create({
+        userDataDir,
+        credentialStore: credentials.store,
+        fetchFn: async () => assert.fail('a corrupt credential read must not use the network'),
+      });
+
+      const state = await service.getAccountState();
+      assert.equal('runtimeState' in state && state.runtimeState, 'storage_failed');
+      assert.equal(credentials.get(serviceCase.slug, 'oauth_token'), 'not-json');
+    });
+  }
+
+  it('Claude does not report login success when the shared credential write fails', async () => {
+    const service = new ClaudeSubscriptionService({
+      userDataDir: await makeUserDataDir(),
+      openExternal: async () => undefined,
+      now: () => NOW,
+      fetchFn: async () =>
+        Response.json({
+          access_token: 'claude-access',
+          refresh_token: 'claude-refresh',
+          expires_in: 3600,
+          token_type: 'Bearer',
+          scope: 'user:sessions:claude_code',
+          account: { uuid: 'claude-account' },
+        }),
+      credentialStore: {
+        getSecret: async () => null,
+        setSecret: async () => {
+          throw new Error('credential store unavailable');
+        },
+        deleteSecret: async () => undefined,
+      },
+    });
+
+    const verifier = 'a'.repeat(43);
+    const result = await service.completeAuthorization('recovered-from-paste', `code#${verifier}`);
+
+    assert.equal(result.ok, false);
+    assert.equal(result.ok ? undefined : result.reason, 'storage_failed');
+  });
+
+  it('Claude login writes the exchanged token to its shared credential', async () => {
+    const credentials = createMemoryCredentialStore();
+    const userDataDir = await makeUserDataDir();
+    const service = new ClaudeSubscriptionService({
+      userDataDir,
+      openExternal: async () => undefined,
+      now: () => NOW,
+      fetchFn: async (input) => {
+        if (String(input).includes('/v1/oauth/token')) {
+          return Response.json({
+            access_token: 'claude-login-access',
+            refresh_token: 'claude-login-refresh',
+            expires_in: 3600,
+            token_type: 'Bearer',
+            scope: 'user:sessions:claude_code',
+            account: { uuid: 'claude-login-account' },
+          });
+        }
+        return Response.json({ account: { uuid: 'claude-login-account' } });
+      },
+      credentialStore: credentials.store,
+    });
+
+    const verifier = 'b'.repeat(43);
+    assert.deepEqual(
+      await service.completeAuthorization('recovered-from-paste', `code#${verifier}`),
+      { ok: true },
+    );
+    const stored = JSON.parse(
+      credentials.get('claude-subscription', 'oauth_token') ?? 'null',
+    ) as { access_token?: string };
+    assert.equal(stored.access_token, 'claude-login-access');
+    assert.equal(credentials.get('codex-subscription', 'oauth_token'), null);
+    await assert.rejects(stat(join(userDataDir, '.claude_subscription_token')), { code: 'ENOENT' });
+  });
+
+  it('Codex login writes the loopback exchange result to its shared credential', async () => {
+    const credentials = createMemoryCredentialStore();
+    const userDataDir = await makeUserDataDir();
+    let openedUrl: string | undefined;
+    const service = new OpenAiCodexService({
+      userDataDir,
+      openExternal: async (url) => {
+        openedUrl = url;
+      },
+      now: () => NOW,
+      fetchFn: async () =>
+        Response.json({
+          access_token: jwt({
+            sub: 'codex-login-subject',
+            'https://api.openai.com/auth': { chatgpt_account_id: 'codex-login-account' },
+          }),
+          refresh_token: 'codex-login-refresh',
+          expires_in: 3600,
+        }),
+      credentialStore: credentials.store,
+    });
+
+    const authorization = await service.getAuthorizationUrl();
+    assert.ok('authRequestId' in authorization);
+    const authRequestId = authorization.authRequestId;
+    try {
+      assert.deepEqual(await service.openAuthorizationUrl(authRequestId), { ok: true });
+      assert.ok(openedUrl);
+      const state = new URL(openedUrl).searchParams.get('state');
+      assert.ok(state);
+      const callback = new URL('http://127.0.0.1:1455/auth/callback');
+      callback.searchParams.set('code', 'codex-login-code');
+      callback.searchParams.set('state', state);
+      const callbackResponse = await fetch(callback);
+      assert.equal(callbackResponse.status, 200);
+      await callbackResponse.text();
+
+      assert.deepEqual(await service.completeAuthorization(authRequestId), { ok: true });
+      const stored = JSON.parse(
+        credentials.get('codex-subscription', 'oauth_token') ?? 'null',
+      ) as { account_id?: string };
+      assert.equal(stored.account_id, 'codex-login-account');
+      assert.equal(credentials.get('claude-subscription', 'oauth_token'), null);
+      await assert.rejects(stat(join(userDataDir, '.codex_subscription_token')), { code: 'ENOENT' });
+    } finally {
+      service.cancelAuthorization(authRequestId);
+    }
+  });
+
+  it('Cursor login writes the successful poll result to its shared credential', async () => {
+    const credentials = createMemoryCredentialStore();
+    const userDataDir = await makeUserDataDir();
+    const service = new CursorSubscriptionService({
+      userDataDir,
+      openExternal: async () => undefined,
+      now: () => NOW,
+      sleepFn: async () => undefined,
+      fetchFn: async () =>
+        Response.json({
+          accessToken: 'cursor-login-access',
+          refreshToken: 'cursor-login-refresh',
+        }),
+      credentialStore: credentials.store,
+    });
+
+    const authorization = await service.getAuthorizationUrl();
+    assert.ok('authRequestId' in authorization);
+    assert.deepEqual(await service.completeAuthorization(authorization.authRequestId), { ok: true });
+    const stored = JSON.parse(
+      credentials.get('cursor-subscription', 'oauth_token') ?? 'null',
+    ) as { access_token?: string };
+    assert.equal(stored.access_token, 'cursor-login-access');
+    assert.equal(credentials.get('codex-subscription', 'oauth_token'), null);
+    await assert.rejects(stat(join(userDataDir, '.cursor_subscription_token')), { code: 'ENOENT' });
+  });
 
   it('no production OAuth path invokes safeStorage (#1125 acceptance)', async () => {
     // The acceptance bar for #1125: saving or loading a runtime-usable
@@ -176,3 +506,49 @@ describe('OAuth subscription token authority (shared CredentialStore)', () => {
     );
   });
 });
+
+function jwt(payload: Record<string, unknown>): string {
+  return `header.${Buffer.from(JSON.stringify(payload), 'utf8').toString('base64url')}.signature`;
+}
+
+async function makeUserDataDir(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-oauth-service-contract-'));
+  tempRoots.push(root);
+  return root;
+}
+
+function createMemoryCredentialStore(): {
+  store: SharedOAuthCredentialStore;
+  get(slug: string, kind: 'api_key' | 'oauth_token'): string | null;
+  set(slug: string, kind: 'api_key' | 'oauth_token', value: string): void;
+} {
+  const secrets = new Map<string, string>();
+  const key = (slug: string, kind: string): string => `${slug}\0${kind}`;
+  return {
+    store: {
+      getSecret: async (slug, kind) => secrets.get(key(slug, kind)) ?? null,
+      setSecret: async (slug, kind, value) => {
+        secrets.set(key(slug, kind), value);
+      },
+      deleteSecret: async (slug, kind) => {
+        if (kind !== undefined) {
+          secrets.delete(key(slug, kind));
+          return;
+        }
+        for (const storedKey of secrets.keys()) {
+          if (storedKey.startsWith(`${slug}\0`)) secrets.delete(storedKey);
+        }
+      },
+      compareAndSetSecret: async (slug, kind, expected, value) => {
+        const current = secrets.get(key(slug, kind)) ?? null;
+        if (current !== expected) return { committed: false, current };
+        secrets.set(key(slug, kind), value);
+        return { committed: true };
+      },
+    },
+    get: (slug, kind) => secrets.get(key(slug, kind)) ?? null,
+    set: (slug, kind, value) => {
+      secrets.set(key(slug, kind), value);
+    },
+  };
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -234,6 +234,7 @@ const credentialStore = createFileCredentialStore(workspaceRoot);
 // and lives in a separate module not statically imported here.
 const claudeSubscription = new ClaudeSubscriptionService({
   userDataDir: app.getPath('userData'),
+  openExternal: (url) => shell.openExternal(url),
   credentialStore,
 });
 // PR-MODEL-OAUTH-ALL-0: Codex / Cursor / Antigravity subscription
@@ -243,6 +244,7 @@ const claudeSubscription = new ClaudeSubscriptionService({
 // until the Google client_id question is resolved.
 const openAiCodex = new OpenAiCodexService({
   userDataDir: app.getPath('userData'),
+  openExternal: (url) => shell.openExternal(url),
   credentialStore,
 });
 const githubCopilotSubscription = new GitHubCopilotSubscriptionService({ credentialStore });
@@ -297,10 +299,12 @@ function hasConnectionSecret(connection: LlmConnection): Promise<boolean> {
 }
 const cursorSubscription = new CursorSubscriptionService({
   userDataDir: app.getPath('userData'),
+  openExternal: (url) => shell.openExternal(url),
   credentialStore,
 });
 const antigravitySubscription = new AntigravitySubscriptionService({
   userDataDir: app.getPath('userData'),
+  openExternal: (url) => shell.openExternal(url),
   credentialStore,
 });
 

--- a/apps/desktop/src/main/oauth/antigravity-subscription-service.ts
+++ b/apps/desktop/src/main/oauth/antigravity-subscription-service.ts
@@ -22,7 +22,6 @@
  *     advances to a real implementation.
  */
 
-import { shell } from 'electron';
 import { randomBytes, randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
@@ -97,6 +96,8 @@ interface PendingAuthorization {
 export interface AntigravitySubscriptionServiceDeps {
   /** Absolute path to userData dir; e.g. app.getPath('userData'). */
   userDataDir: string;
+  /** Opens the provider authorization URL in the system browser. */
+  openExternal: (url: string) => Promise<void>;
   /** Function returning current epoch ms. Injectable for tests. */
   now?: () => number;
   /** fetch implementation. Defaults to global fetch (Node 18+). */
@@ -110,6 +111,7 @@ export class AntigravitySubscriptionService {
    *  anymore; unlinked on logout in case the startup import could not
    *  run, so logout still means "no credential survives anywhere". */
   private readonly legacyTokenFilePath: string;
+  private readonly openExternal: (url: string) => Promise<void>;
   private readonly now: () => number;
   private readonly fetchFn: typeof fetch;
   private readonly credentialStore: SharedOAuthCredentialStore;
@@ -122,6 +124,7 @@ export class AntigravitySubscriptionService {
 
   constructor(deps: AntigravitySubscriptionServiceDeps) {
     this.legacyTokenFilePath = join(deps.userDataDir, '.antigravity_subscription_token');
+    this.openExternal = deps.openExternal;
     this.now = deps.now ?? (() => Date.now());
     this.fetchFn = deps.fetchFn ?? (globalThis.fetch as typeof fetch);
     this.credentialStore = deps.credentialStore;
@@ -203,7 +206,7 @@ export class AntigravitySubscriptionService {
       return { ok: false, reason: 'authorization_expired', message: '授权请求已过期，请重新点击“登录 Antigravity”。' };
     }
     try {
-      await shell.openExternal(pending.url);
+      await this.openExternal(pending.url);
       this.authorizing = true;
       return { ok: true };
     } catch (err) {
@@ -510,8 +513,8 @@ export class AntigravitySubscriptionService {
 
   /**
    * Always reads the shared store — no in-memory copy; the store is
-   * the cross-surface authority (#1125). A corrupt entry is deleted by
-   * the bridge so the next login isn't stuck.
+   * the cross-surface authority (#1125). A corrupt entry is preserved
+   * for recovery; a fresh login can overwrite it.
    */
   private async loadTokens(): Promise<PersistedTokens | null> {
     let result: Awaited<ReturnType<typeof loadSharedOAuthTokens>>;
@@ -555,9 +558,8 @@ export interface AntigravityAccountStateSnapshot {
   errorMessage?: string;
 }
 
-// Re-exports for the IPC handler + tests. Pure helpers live in
-// `antigravity-subscription-helpers.ts` so they can be unit-tested
-// without dragging in the electron ESM module.
+// Re-exports for the IPC handler + focused protocol tests. The pure
+// helpers keep preview configuration and PKCE logic independent of service state.
 export {
   ANTIGRAVITY_MISSING_CLIENT_ID_ENVELOPE,
   ANTIGRAVITY_OAUTH_CONFIG,

--- a/apps/desktop/src/main/oauth/claude-subscription-service.ts
+++ b/apps/desktop/src/main/oauth/claude-subscription-service.ts
@@ -23,7 +23,6 @@
  *   - PKCE state matched with constant-time equality (G-X1).
  */
 
-import { shell } from 'electron';
 import { createHash, randomBytes, randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { dirname, join } from 'node:path';
@@ -163,6 +162,8 @@ const nodeSha256: Sha256Digest = {
 export interface ClaudeSubscriptionServiceDeps {
   /** Absolute path to userData dir; e.g. app.getPath('userData'). */
   userDataDir: string;
+  /** Opens the provider authorization URL in the system browser. */
+  openExternal: (url: string) => Promise<void>;
   /** Function returning current epoch ms. Injectable for tests. */
   now?: () => number;
   /** fetch implementation. Defaults to global fetch (Node 18+). */
@@ -178,6 +179,7 @@ export class ClaudeSubscriptionService {
    *  credential survives anywhere". */
   private readonly legacyTokenFilePath: string;
   private readonly deviceIdFilePath: string;
+  private readonly openExternal: (url: string) => Promise<void>;
   private readonly now: () => number;
   private readonly fetchFn: typeof fetch;
   private readonly credentialStore: SharedOAuthCredentialStore;
@@ -197,6 +199,7 @@ export class ClaudeSubscriptionService {
   constructor(deps: ClaudeSubscriptionServiceDeps) {
     this.legacyTokenFilePath = join(deps.userDataDir, '.claude_subscription_token');
     this.deviceIdFilePath = join(deps.userDataDir, '.claude_subscription_device_id');
+    this.openExternal = deps.openExternal;
     this.now = deps.now ?? (() => Date.now());
     this.fetchFn = deps.fetchFn ?? (globalThis.fetch as typeof fetch);
     this.credentialStore = deps.credentialStore;
@@ -281,7 +284,7 @@ export class ClaudeSubscriptionService {
       return { ok: false, reason: 'authorization_expired', message: '授权请求已过期，请重新点击“登录订阅”。' };
     }
     try {
-      await shell.openExternal(pending.url);
+      await this.openExternal(pending.url);
       this.authorizing = true;
       return { ok: true };
     } catch (err) {

--- a/apps/desktop/src/main/oauth/cursor-subscription-service.ts
+++ b/apps/desktop/src/main/oauth/cursor-subscription-service.ts
@@ -20,7 +20,6 @@
  * Reference: cursor-auth plugin pattern (external reference).
  */
 
-import { shell } from 'electron';
 import { randomBytes, randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { join } from 'node:path';
@@ -95,6 +94,8 @@ interface PendingAuthorization {
 export interface CursorSubscriptionServiceDeps {
   /** Absolute path to userData dir; e.g. app.getPath('userData'). */
   userDataDir: string;
+  /** Opens the provider authorization URL in the system browser. */
+  openExternal: (url: string) => Promise<void>;
   /** Function returning current epoch ms. Injectable for tests. */
   now?: () => number;
   /** fetch implementation. Defaults to global fetch (Node 18+). */
@@ -111,6 +112,7 @@ export class CursorSubscriptionService {
    *  anymore; unlinked on logout in case the startup import could not
    *  run, so logout still means "no credential survives anywhere". */
   private readonly legacyTokenFilePath: string;
+  private readonly openExternal: (url: string) => Promise<void>;
   private readonly now: () => number;
   private readonly fetchFn: typeof fetch;
   private readonly sleepFn: (ms: number) => Promise<void>;
@@ -124,6 +126,7 @@ export class CursorSubscriptionService {
 
   constructor(deps: CursorSubscriptionServiceDeps) {
     this.legacyTokenFilePath = join(deps.userDataDir, '.cursor_subscription_token');
+    this.openExternal = deps.openExternal;
     this.now = deps.now ?? (() => Date.now());
     this.fetchFn = deps.fetchFn ?? (globalThis.fetch as typeof fetch);
     this.sleepFn =
@@ -194,7 +197,7 @@ export class CursorSubscriptionService {
       return { ok: false, reason: 'authorization_expired', message: '授权请求已过期，请重新点击“登录 Cursor”。' };
     }
     try {
-      await shell.openExternal(pending.url);
+      await this.openExternal(pending.url);
       this.authorizing = true;
       return { ok: true };
     } catch (err) {
@@ -462,8 +465,8 @@ export class CursorSubscriptionService {
 
   /**
    * Always reads the shared store — no in-memory copy; the store is
-   * the cross-surface authority (#1125). A corrupt entry is deleted by
-   * the bridge so the next login isn't stuck.
+   * the cross-surface authority (#1125). A corrupt entry is preserved
+   * for recovery; a fresh login can overwrite it.
    */
   private async loadTokens(): Promise<PersistedTokens | null> {
     let result: Awaited<ReturnType<typeof loadSharedOAuthTokens>>;
@@ -505,9 +508,8 @@ export interface CursorAccountStateSnapshot {
   errorMessage?: string;
 }
 
-// Re-exports for the IPC handler + tests. The pure helpers live
-// in `cursor-subscription-helpers.ts` so they can be unit-tested
-// without dragging in the electron ESM module.
+// Re-exports for the IPC handler + focused protocol tests. The pure
+// helpers keep URL, PKCE, and expiry logic independent of service state.
 export {
   CURSOR_OAUTH_CONFIG,
   buildCursorLoginUrl,

--- a/apps/desktop/src/main/oauth/openai-codex-service.ts
+++ b/apps/desktop/src/main/oauth/openai-codex-service.ts
@@ -22,7 +22,6 @@
  * endpoint constants pinned to that file's values.
  */
 
-import { shell } from 'electron';
 import { randomBytes, randomUUID } from 'node:crypto';
 import { promises as fs } from 'node:fs';
 import { createServer, type IncomingMessage, type Server, type ServerResponse } from 'node:http';
@@ -114,6 +113,8 @@ interface PendingAuthorization {
 export interface OpenAiCodexServiceDeps {
   /** Absolute path to userData dir; e.g. app.getPath('userData'). */
   userDataDir: string;
+  /** Opens the provider authorization URL in the system browser. */
+  openExternal: (url: string) => Promise<void>;
   /** Function returning current epoch ms. Injectable for tests. */
   now?: () => number;
   /** Fetch implementation. Defaults to Maka's active-proxy-aware fetch. */
@@ -127,6 +128,7 @@ export class OpenAiCodexService {
    *  anymore; unlinked on logout in case the startup import could not
    *  run, so logout still means "no credential survives anywhere". */
   private readonly legacyTokenFilePath: string;
+  private readonly openExternal: (url: string) => Promise<void>;
   private readonly now: () => number;
   private readonly fetchFn: typeof fetch;
   private readonly credentialStore: SharedOAuthCredentialStore;
@@ -140,6 +142,7 @@ export class OpenAiCodexService {
 
   constructor(deps: OpenAiCodexServiceDeps) {
     this.legacyTokenFilePath = join(deps.userDataDir, '.codex_subscription_token');
+    this.openExternal = deps.openExternal;
     this.now = deps.now ?? (() => Date.now());
     this.fetchFn = deps.fetchFn ?? (proxiedFetch as unknown as typeof fetch);
     this.credentialStore = deps.credentialStore;
@@ -222,7 +225,7 @@ export class OpenAiCodexService {
       return { ok: false, reason: 'authorization_expired', message: '授权请求已过期，请重新点击“登录 Codex”。' };
     }
     try {
-      await shell.openExternal(pending.url);
+      await this.openExternal(pending.url);
       this.authorizing = true;
       return { ok: true };
     } catch (err) {
@@ -671,9 +674,8 @@ export interface CodexAccountStateSnapshot {
 }
 
 // =============================================================
-// Re-exports for the IPC handler + tests. The pure helpers live
-// in `openai-codex-helpers.ts` so they can be unit-tested
-// without dragging in the electron ESM module.
+// Re-exports for the IPC handler + focused protocol tests. The pure
+// helpers keep URL, PKCE, and claim logic independent of service state.
 // =============================================================
 export { buildCodexAuthorizationUrl, extractAccountClaims, pkceChallengeFromVerifier };
 


### PR DESCRIPTION
## Summary

Refs #1125.

Replace OAuth credential source-grep tests that pinned private helper names and method bodies with public behavior contracts.

- Exercise Claude, Codex, Cursor, and Antigravity credential reads, account snapshots, logout, and legacy-file cleanup through their service APIs.
- Verify active-provider login writes the correct shared `oauth_token`, creates no parallel legacy token file, and fails closed when persistence fails.
- Verify refresh persistence and CAS behavior, including an in-flight refresh losing to a newer credential from another surface.
- Prove a desktop-written token is immediately readable by the pure-Node runtime from another store instance.
- Keep only the source-level checks that express architectural boundaries: no production OAuth `safeStorage` hot path and credential migration before interactive OAuth mutations.
- Inject `openExternal` from the Electron composition root so the services can run in plain Node tests while preserving the opaque `authRequestId` URL-opening boundary.
- Keep Antigravity limited to its current preview fail-closed behavior rather than asserting an unreachable successful login.

## Verification

- `npm ci`
- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run pretest`
- `npm --workspace @maka/desktop run clean:main`
- `npm --workspace @maka/desktop run build:main`
- `(cd apps/desktop && node --test --test-reporter=dot "dist/main/**/*.test.js")`

Full workspace `npm run typecheck` is not clean because the current lockfile does not install the already-declared `simple-icons` dependency, so the desktop renderer cannot resolve that unrelated module. The affected main-process TypeScript build passes.

## Review focus

The only production seam change is moving `shell.openExternal` behind a required service dependency supplied by `main.ts`; provider protocol and persistence behavior are unchanged.
