### PR TITLE
fix(headless): include failed Bash completions in RSI analysis

### DIFF
--- a/packages/headless/src/__tests__/rsi-round-analysis.test.ts
+++ b/packages/headless/src/__tests__/rsi-round-analysis.test.ts
@@ -180,6 +180,41 @@ describe('RSI round analysis', () => {
     });
   });
 
+  test('aggregates error and aborted tool completions but ignores successful completions', async () => {
+    await withDir(async (dir) => {
+      const runtimeEventsPath = join(dir, 'runtime.jsonl');
+      const traceEventsPath = join(dir, 'trace.jsonl');
+
+      await writeJsonl(runtimeEventsPath, [
+        functionCall('call-error', 'Bash', { command: 'exit 1' }),
+        functionCall('call-aborted', 'Bash', { command: 'sleep 10' }),
+        functionCall('call-success', 'Bash', { command: 'true' }),
+      ]);
+      await writeJsonl(traceEventsPath, [
+        toolCompleted('call-error', 'Bash', 'error'),
+        toolCompleted('call-aborted', 'Bash', 'aborted'),
+        toolCompleted('call-success', 'Bash', 'success'),
+      ]);
+
+      const analysis = await analyzeRsiRound({
+        heldInTaskIds: ['task-a'],
+        lastKeptEvents: [],
+        candidateEvents: [
+          completed({ taskId: 'task-a', passed: false, runtimeEventsPath, traceEventsPath }),
+        ],
+      });
+
+      assert.deepEqual(analysis.toolFailureClusters, [
+        {
+          name: 'Bash',
+          argsPreview: 'command',
+          count: 2,
+          taskIds: ['task-a'],
+        },
+      ]);
+    });
+  });
+
   test('does not expose tool failure clusters as evidence for tasks with pass fail transitions', async () => {
     await withDir(async (dir) => {
       const taskARuntime = join(dir, 'task-a-runtime.jsonl');
@@ -697,6 +732,10 @@ function functionCall(id: string, name: string, args: Record<string, unknown>): 
 
 function toolFailed(toolUseId: string, toolName: string, errorClass: string): unknown {
   return { type: 'tool_failed', data: { toolUseId, toolName, errorClass } };
+}
+
+function toolCompleted(toolUseId: string, toolName: string, status: string): unknown {
+  return { type: 'tool_completed', data: { toolUseId, toolName, status } };
 }
 
 async function writeJsonl(path: string, events: readonly unknown[]): Promise<void> {

--- a/packages/headless/src/rsi-round-analysis.ts
+++ b/packages/headless/src/rsi-round-analysis.ts
@@ -473,8 +473,12 @@ function toolFailureDigest(
   event: unknown,
   callsById: ReadonlyMap<string, { name: string; argsPreview: string }>,
 ): Omit<RsiToolFailureCluster, 'count' | 'taskIds'> | undefined {
-  if (!isRecord(event) || event.type !== 'tool_failed' || !isRecord(event.data)) return undefined;
+  if (!isRecord(event) || !isRecord(event.data)) return undefined;
   const data = event.data;
+  const isFailedEvent = event.type === 'tool_failed';
+  const isFailedCompletion =
+    event.type === 'tool_completed' && (data.status === 'error' || data.status === 'aborted');
+  if (!isFailedEvent && !isFailedCompletion) return undefined;
   if (typeof data.toolName !== 'string') return undefined;
   const call = typeof data.toolUseId === 'string' ? callsById.get(data.toolUseId) : undefined;
   return {


### PR DESCRIPTION
## Summary

- Include `tool_completed` events with `status: "error"` or `status: "aborted"` in RSI tool-failure clustering.
- Preserve existing runtime trace semantics and existing handling of `tool_failed` events.
- Add regression coverage for failed and aborted Bash completions while excluding successful completions.

## Validation

- `npm --workspace @maka/headless test`
- `npm --workspace @maka/headless run typecheck`
- `npm run format:check`

Closes #1284