### PR TITLE
feat: bound AgentSwarm child runtimes

### DIFF
--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'node:test';
 import type { LlmConnection, SessionEvent, SessionHeader, ToolInvocationRecord } from '@maka/core';
 import {
   AGENT_SWARM_DEFAULT_CONCURRENCY,
+  AGENT_SWARM_DEFAULT_ITEM_TIMEOUT_MS,
   AGENT_SWARM_MAX_CONCURRENCY,
   AGENT_SWARM_MAX_ITEMS,
   AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER,
@@ -44,6 +45,7 @@ describe('AgentSwarm adapter', () => {
     assert.equal(tool.name, AGENT_SWARM_TOOL_NAME);
     assert.equal(tool.permissionRequired, true);
     assert.equal(tool.categoryHint, 'subagent');
+    assert.equal(AGENT_SWARM_DEFAULT_ITEM_TIMEOUT_MS, 2 * 60 * 60 * 1_000);
     assert.equal(([...AGENT_TOOL_NAMES] as string[]).includes(AGENT_SWARM_TOOL_NAME), true);
     assert.deepEqual(
       schema.safeParse({
@@ -655,6 +657,57 @@ describe('AgentSwarm adapter', () => {
     assert.equal(batchTrace?.cancelledItemCount, 4);
     assert.equal(batchTrace?.artifactCount, 2);
     assert.equal(typeof batchTrace?.durationMs, 'number');
+  });
+
+  test('fails only the timed-out item and continues queued siblings', async () => {
+    const parent = new AbortController();
+    const starts: string[] = [];
+    const traceEvents: TestTraceEvent[] = [];
+    const runtime = buildRuntime(
+      async (input) => {
+        starts.push(input.prompt);
+        const index = Number(input.prompt.slice('task-'.length));
+        await input.onReady?.({
+          turnId: `turn-${index}`,
+          agentId: input.spec.id,
+          agentName: input.spec.name,
+        });
+        if (index === 0) {
+          await onceAborted(input.abortSignal);
+          return childResult(index, 'cancelled');
+        }
+        return childResult(index);
+      },
+      { traceEvents },
+    );
+
+    const result = (await executeTool(
+      runtime,
+      {
+        ...buildAgentSwarmTool({ itemTimeoutMs: 20 }),
+        permissionRequired: false,
+      },
+      { items: [swarmItem(0), swarmItem(1)], max_concurrency: 1 },
+      parent,
+    )) as AgentSwarmToolResult;
+
+    assert.equal(parent.signal.aborted, false);
+    assert.deepEqual(starts, ['task-0', 'task-1']);
+    assert.equal(result.status, 'partial');
+    assert.deepEqual(
+      result.items.map((item) => ({ status: item.status, failureClass: item.failureClass })),
+      [
+        { status: 'failed', failureClass: 'Timeout' },
+        { status: 'completed', failureClass: undefined },
+      ],
+    );
+    assert.match(result.items[0]?.summary ?? '', /timed out after 20 ms/i);
+    assert.ok(
+      traceEvents.some(
+        (event) =>
+          event.data?.swarmStage === 'item_completed' && event.data?.failureClass === 'Timeout',
+      ),
+    );
   });
 
   test('composes local width with the shared child-run permit pool', async () => {

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -28,6 +28,7 @@ export const AGENT_SWARM_DEFAULT_CONCURRENCY = 3;
 export const AGENT_SWARM_MAX_CONCURRENCY = 5;
 export const AGENT_SWARM_MAX_ITEMS = 32;
 export const AGENT_SWARM_PROMPT_TEMPLATE_PLACEHOLDER = '{{item}}';
+export const AGENT_SWARM_DEFAULT_ITEM_TIMEOUT_MS = 2 * 60 * 60 * 1_000;
 
 const AGENT_SWARM_WRITE_BACK_MODES = [AGENT_WRITE_BACK_SUMMARY, AGENT_WRITE_BACK_PATCH] as const;
 const AGENT_SWARM_ISOLATION_MODES = [
@@ -95,9 +96,16 @@ interface StartedChildRef {
 }
 
 export function buildAgentSwarmTool(
-  deps: { now?: () => number; adaptiveSwarmPolicy?: AdaptiveSwarmPolicy } = {},
+  deps: {
+    now?: () => number;
+    adaptiveSwarmPolicy?: AdaptiveSwarmPolicy;
+    itemTimeoutMs?: number;
+  } = {},
 ): MakaTool<AgentSwarmToolInput, AgentSwarmToolResult> {
   const now = deps.now ?? Date.now;
+  const itemTimeoutMs = normalizeItemTimeoutMs(
+    deps.itemTimeoutMs ?? AGENT_SWARM_DEFAULT_ITEM_TIMEOUT_MS,
+  );
   return {
     name: AGENT_SWARM_TOOL_NAME,
     displayName: 'Agent Swarm',
@@ -158,6 +166,7 @@ export function buildAgentSwarmTool(
       >(
         prepared.items,
         async (item, { index, attempt, retry, markReady }) => {
+          const deadline = createItemDeadline(ctx.abortSignal, itemTimeoutMs);
           traceAgentSwarm(ctx, 'tool_started', 'item_started', {
             itemId: item.itemId,
             index: item.index,
@@ -181,6 +190,7 @@ export function buildAgentSwarmTool(
               ? ctx.retryChildAgent
                 ? ((await ctx.retryChildAgent({
                     sourceRunId: retry.sourceRunId,
+                    abortSignal: deadline.signal,
                     onReady,
                   })) as SpawnChildAgentResult)
                 : (() => {
@@ -190,6 +200,7 @@ export function buildAgentSwarmTool(
                 ? ((await ctx.resumeChildAgent!({
                     sourceRunId: item.resumedFromRunId!,
                     prompt: item.task,
+                    abortSignal: deadline.signal,
                     onReady,
                   })) as SpawnChildAgentResult)
                 : ((await ctx.spawnChildAgent!({
@@ -199,26 +210,34 @@ export function buildAgentSwarmTool(
                       systemPrompt: item.definition.systemPrompt,
                     },
                     prompt: item.task,
+                    abortSignal: deadline.signal,
                     onReady,
                   })) as SpawnChildAgentResult);
-            for (const artifactId of result.artifactIds) artifactIds[index]!.add(artifactId);
-            const observedResult = { ...result, artifactIds: [...artifactIds[index]!] };
+            const effectiveResult = deadline.timedOut()
+              ? timedOutChildResult(result, itemTimeoutMs)
+              : result;
+            for (const artifactId of effectiveResult.artifactIds)
+              artifactIds[index]!.add(artifactId);
+            const observedResult = {
+              ...effectiveResult,
+              artifactIds: [...artifactIds[index]!],
+            };
             childResults[index] = observedResult;
             if (
-              result.status === 'failed' &&
-              result.failureClass === 'RateLimit' &&
-              result.runId &&
+              effectiveResult.status === 'failed' &&
+              effectiveResult.failureClass === 'RateLimit' &&
+              effectiveResult.runId &&
               ctx.retryChildAgent
             ) {
               return {
                 status: 'rate_limited' as const,
-                retry: { sourceRunId: result.runId },
-                reason: new ProviderRateLimitRetry(result),
+                retry: { sourceRunId: effectiveResult.runId },
+                reason: new ProviderRateLimitRetry(effectiveResult),
               };
             }
             traceAgentSwarm(
               ctx,
-              result.status === 'failed' ? 'tool_failed' : 'tool_completed',
+              effectiveResult.status === 'failed' ? 'tool_failed' : 'tool_completed',
               'item_completed',
               {
                 itemId: item.itemId,
@@ -226,19 +245,25 @@ export function buildAgentSwarmTool(
                 profile: item.profile,
                 mode: item.mode,
                 ...(item.resumedFromRunId ? { resumedFromRunId: item.resumedFromRunId } : {}),
-                status: result.status,
-                turnId: result.turnId,
-                ...(result.runId ? { runId: result.runId } : {}),
-                durationMs: result.durationMs,
-                artifactCount: result.artifactIds.length,
+                status: effectiveResult.status,
+                turnId: effectiveResult.turnId,
+                ...(effectiveResult.runId ? { runId: effectiveResult.runId } : {}),
+                durationMs: effectiveResult.durationMs,
+                artifactCount: effectiveResult.artifactIds.length,
+                ...(effectiveResult.failureClass
+                  ? { failureClass: effectiveResult.failureClass }
+                  : {}),
               },
             );
             ctx.emitOutput(
-              result.status === 'failed' ? 'stderr' : 'stdout',
-              `Agent swarm item ${item.itemId}: ${result.status}\n`,
+              effectiveResult.status === 'failed' ? 'stderr' : 'stdout',
+              `Agent swarm item ${item.itemId}: ${effectiveResult.status}\n`,
             );
             return { status: 'fulfilled' as const, value: observedResult };
           } catch (error) {
+            const effectiveError = deadline.timedOut()
+              ? new AgentSwarmItemTimeoutError(itemTimeoutMs)
+              : error;
             traceAgentSwarm(ctx, 'tool_failed', 'item_completed', {
               itemId: item.itemId,
               index: item.index,
@@ -246,13 +271,15 @@ export function buildAgentSwarmTool(
               mode: item.mode,
               ...(item.resumedFromRunId ? { resumedFromRunId: item.resumedFromRunId } : {}),
               status: ctx.abortSignal.aborted ? 'cancelled' : 'failed',
-              failureClass: boundedFailureClass(error, 'ChildAgentError'),
+              failureClass: boundedFailureClass(effectiveError, 'ChildAgentError'),
             });
             ctx.emitOutput(
               'stderr',
-              `Agent swarm item ${item.itemId} failed: ${boundedSwarmError(error)}\n`,
+              `Agent swarm item ${item.itemId} failed: ${boundedSwarmError(effectiveError)}\n`,
             );
-            throw error;
+            throw effectiveError;
+          } finally {
+            deadline.cleanup();
           }
         },
         {
@@ -769,6 +796,81 @@ class ProviderRateLimitRetry extends Error {
     super(result.summary || 'Child agent provider rate limited');
     this.name = 'RateLimit';
   }
+}
+
+class AgentSwarmItemTimeoutError extends Error {
+  readonly failureClass = 'Timeout';
+
+  constructor(readonly timeoutMs: number) {
+    super(`Child agent timed out after ${formatDuration(timeoutMs)}.`);
+    this.name = 'Timeout';
+  }
+}
+
+function normalizeItemTimeoutMs(value: number): number {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error('Agent swarm item timeout must be a non-negative integer in milliseconds.');
+  }
+  return value;
+}
+
+function createItemDeadline(
+  parentSignal: AbortSignal,
+  timeoutMs: number,
+): {
+  readonly signal: AbortSignal;
+  timedOut(): boolean;
+  cleanup(): void;
+} {
+  if (timeoutMs === 0) {
+    return { signal: parentSignal, timedOut: () => false, cleanup: () => {} };
+  }
+  const controller = new AbortController();
+  let expired = false;
+  const abortFromParent = () => controller.abort(parentSignal.reason);
+  if (parentSignal.aborted) abortFromParent();
+  else parentSignal.addEventListener('abort', abortFromParent, { once: true });
+  const timer = setTimeout(() => {
+    if (controller.signal.aborted) return;
+    expired = true;
+    controller.abort(new AgentSwarmItemTimeoutError(timeoutMs));
+  }, timeoutMs);
+  return {
+    signal: controller.signal,
+    timedOut: () => expired,
+    cleanup: () => {
+      clearTimeout(timer);
+      parentSignal.removeEventListener('abort', abortFromParent);
+    },
+  };
+}
+
+function timedOutChildResult(
+  result: SpawnChildAgentResult,
+  timeoutMs: number,
+): SpawnChildAgentResult {
+  return {
+    ...result,
+    status: 'failed',
+    summary: `Child agent timed out after ${formatDuration(timeoutMs)}.`,
+    failureClass: 'Timeout',
+  };
+}
+
+function formatDuration(ms: number): string {
+  if (ms % 3_600_000 === 0) {
+    const hours = ms / 3_600_000;
+    return `${hours} hour${hours === 1 ? '' : 's'}`;
+  }
+  if (ms % 60_000 === 0) {
+    const minutes = ms / 60_000;
+    return `${minutes} minute${minutes === 1 ? '' : 's'}`;
+  }
+  if (ms % 1_000 === 0) {
+    const seconds = ms / 1_000;
+    return `${seconds} second${seconds === 1 ? '' : 's'}`;
+  }
+  return `${ms} ms`;
 }
 
 function mapChildResult(

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -163,6 +163,8 @@ export interface MakaToolContext {
   spawnChildAgent?: (input: {
     spec: AgentSpec;
     prompt: string;
+    /** Optional per-child signal, always composed with the owning tool invocation signal. */
+    abortSignal?: AbortSignal;
     onReady?: (input: {
       turnId: string;
       agentId: string;
@@ -179,6 +181,8 @@ export interface MakaToolContext {
   resumeChildAgent?: (input: {
     sourceRunId: string;
     prompt: string;
+    /** Optional per-child signal, always composed with the owning tool invocation signal. */
+    abortSignal?: AbortSignal;
     onReady?: (input: {
       turnId: string;
       agentId: string;
@@ -188,6 +192,8 @@ export interface MakaToolContext {
   }) => Promise<unknown>;
   retryChildAgent?: (input: {
     sourceRunId: string;
+    /** Optional per-child signal, always composed with the owning tool invocation signal. */
+    abortSignal?: AbortSignal;
     onReady?: (input: {
       turnId: string;
       agentId: string;
@@ -248,6 +254,14 @@ export const LOOP_GATE_IDENTICAL_THRESHOLD = 3;
 
 const SUBAGENT_TOOL_LIMIT_MESSAGE =
   '只读探索并发过多：同一轮最多 5 个子代理。请等待已有探索完成后再继续。';
+
+function composeChildAbortSignal(
+  invocationSignal: AbortSignal,
+  childSignal: AbortSignal | undefined,
+): AbortSignal {
+  if (!childSignal || childSignal === invocationSignal) return invocationSignal;
+  return AbortSignal.any([invocationSignal, childSignal]);
+}
 
 export interface ToolRuntimeInput {
   sessionId: string;
@@ -1757,6 +1771,7 @@ export class ToolRuntime {
     const limiter = this.childAgentRunLimiter;
     const runWithPermit = async <T>(
       mode: 'spawn' | 'resume' | 'retry',
+      abortSignal: AbortSignal,
       execute: () => Promise<T>,
     ): Promise<T> => {
       const waitingForPermit = limiter.activeCount >= limiter.capacity || limiter.waitingCount > 0;
@@ -1774,7 +1789,7 @@ export class ToolRuntime {
       }
       let permit;
       try {
-        permit = await limiter.acquire(input.abortSignal);
+        permit = await limiter.acquire(abortSignal);
       } catch (error) {
         input.trace?.emit(
           'tool',
@@ -1786,7 +1801,7 @@ export class ToolRuntime {
             boundary: 'shared_child_run_permit',
             stage: 'cancelled_while_waiting',
             mode,
-            status: input.abortSignal.aborted ? 'aborted' : 'error',
+            status: abortSignal.aborted ? 'aborted' : 'error',
           },
         );
         throw error;
@@ -1804,9 +1819,9 @@ export class ToolRuntime {
         capacity: limiter.capacity,
       });
       try {
-        if (input.abortSignal.aborted) {
-          throw input.abortSignal.reason instanceof Error
-            ? input.abortSignal.reason
+        if (abortSignal.aborted) {
+          throw abortSignal.reason instanceof Error
+            ? abortSignal.reason
             : new Error('Child agent run cancelled before it started');
         }
         const result = await execute();
@@ -1827,7 +1842,7 @@ export class ToolRuntime {
           boundary: 'child_run_execution',
           stage: 'completed',
           mode,
-          status: input.abortSignal.aborted ? 'aborted' : 'error',
+          status: abortSignal.aborted ? 'aborted' : 'error',
           durationMs: Math.max(0, this.input.now() - childStartedAt),
         });
         throw error;
@@ -1843,19 +1858,25 @@ export class ToolRuntime {
     return {
       ...(spawnChildAgent
         ? {
-            spawnChildAgent: async (spawnInput) =>
-              await runWithPermit(
+            spawnChildAgent: async (spawnInput) => {
+              const abortSignal = composeChildAbortSignal(
+                input.abortSignal,
+                spawnInput.abortSignal,
+              );
+              return await runWithPermit(
                 'spawn',
+                abortSignal,
                 async () =>
                   await spawnChildAgent({
                     parentRunId,
                     spec: spawnInput.spec,
                     prompt: spawnInput.prompt,
-                    abortSignal: input.abortSignal,
+                    abortSignal,
                     ...(spawnInput.onReady ? { onReady: spawnInput.onReady } : {}),
                     ...(spawnInput.onEvent ? { onEvent: spawnInput.onEvent } : {}),
                   }),
-              ),
+              );
+            },
           }
         : {}),
       ...(prepareChildAgentResume
@@ -1863,35 +1884,47 @@ export class ToolRuntime {
         : {}),
       ...(resumeChildAgent
         ? {
-            resumeChildAgent: async (resumeInput) =>
-              await runWithPermit(
+            resumeChildAgent: async (resumeInput) => {
+              const abortSignal = composeChildAbortSignal(
+                input.abortSignal,
+                resumeInput.abortSignal,
+              );
+              return await runWithPermit(
                 'resume',
+                abortSignal,
                 async () =>
                   await resumeChildAgent({
                     parentRunId,
                     sourceRunId: resumeInput.sourceRunId,
                     prompt: resumeInput.prompt,
-                    abortSignal: input.abortSignal,
+                    abortSignal,
                     ...(resumeInput.onReady ? { onReady: resumeInput.onReady } : {}),
                     ...(resumeInput.onEvent ? { onEvent: resumeInput.onEvent } : {}),
                   }),
-              ),
+              );
+            },
           }
         : {}),
       ...(retryChildAgent
         ? {
-            retryChildAgent: async (retryInput) =>
-              await runWithPermit(
+            retryChildAgent: async (retryInput) => {
+              const abortSignal = composeChildAbortSignal(
+                input.abortSignal,
+                retryInput.abortSignal,
+              );
+              return await runWithPermit(
                 'retry',
+                abortSignal,
                 async () =>
                   await retryChildAgent({
                     parentRunId,
                     sourceRunId: retryInput.sourceRunId,
-                    abortSignal: input.abortSignal,
+                    abortSignal,
                     ...(retryInput.onReady ? { onReady: retryInput.onReady } : {}),
                     ...(retryInput.onEvent ? { onEvent: retryInput.onEvent } : {}),
                   }),
-              ),
+              );
+            },
           }
         : {}),
     };


### PR DESCRIPTION
## What changed

- add a Kimi-compatible two-hour deadline to every active AgentSwarm item
- propagate a child-specific abort signal through the shared runtime permit boundary
- keep the parent invocation signal authoritative by composing both signals
- project a timed-out child as `failed` with `failureClass: Timeout`
- continue queued and active siblings after one item times out
- give each provider-rate-limit retry attempt a fresh deadline

## Why

AgentSwarm already has bounded concurrency and provider-aware backpressure, but a stalled child can still occupy a slot forever. Kimi Code bounds each subagent attempt independently and treats timeout as an item-local failure rather than a batch cancellation. This PR ports that behavior without adding generic failure retries.

This is follow-up work for #1324. It intentionally does not close the issue: true worktree isolation and later pipeline enhancements remain separate.

## Validation

- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime run build`
- `node --test packages/runtime/dist/__tests__/agent-swarm-tools.test.js` — 18/18 passed
- full runtime suite: 2358 passed, 3 unrelated local-environment failures (macOS sandbox/Homebrew executable roots, Homebrew ripgrep pcre2 dylib access, and an existing execution-inspect fixture)
