### PR TITLE
fix(ui): contain StatTile long values

### DIFF
--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -79,6 +79,29 @@ test('shared settings input owns its desktop focus chrome', async ({ window: pag
   expect(focusShadow).not.toContain('inset');
 });
 
+test('open gateway metric values stay contained for long addresses', async ({ window: page }) => {
+  await page.setViewportSize({ width: 900, height: 820 });
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  await page.getByRole('button', { name: '设置' }).click();
+
+  const settings = page.getByRole('main', { name: '设置内容' });
+  await settings.getByRole('button', { name: '开放网关' }).click();
+  await expect(settings.getByRole('heading', { name: '开放网关' })).toBeVisible();
+
+  const addressValue = settings
+    .locator('[data-slot="stat-tile-value"]')
+    .filter({ hasText: 'http://127.0.0.1:3939' });
+  await expect(addressValue).toBeVisible();
+  await expect(addressValue).toHaveCSS('overflow-wrap', 'anywhere');
+  await expect.poll(
+    () =>
+      addressValue.evaluate((element) => ({
+        contained: element.scrollWidth <= element.clientWidth,
+        value: element.textContent,
+      })),
+  ).toEqual({ contained: true, value: 'http://127.0.0.1:3939' });
+});
+
 test('remote access opens a channel detail from the overview and returns', async ({ window: page }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();

--- a/packages/ui/src/primitives/stat-tile.tsx
+++ b/packages/ui/src/primitives/stat-tile.tsx
@@ -83,7 +83,7 @@ export function StatTile({
     >
       <span
         className={cn(
-          'font-semibold leading-tight text-foreground [font-variant-numeric:tabular-nums]',
+          'block max-w-full min-w-0 whitespace-normal font-semibold leading-tight text-foreground [font-variant-numeric:tabular-nums] [overflow-wrap:anywhere]',
           emphasis === 'outline' ? 'text-[length:var(--font-size-stat)]' : 'text-[length:var(--font-size-ui)]',
           TONE_VALUE_CLASS[effectiveTone],
         )}

--- a/packages/ui/stories/stat-tile.stories.tsx
+++ b/packages/ui/stories/stat-tile.stories.tsx
@@ -1,0 +1,58 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { StatTile, type StatTileTone } from '../src/primitives/stat-tile.js';
+
+const meta = {
+  title: 'Primitives/StatTile',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const TONES: StatTileTone[] = ['neutral', 'info', 'success', 'warning', 'destructive'];
+
+export const LongUnbrokenValue: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 16, width: 180 }}>
+      <StatTile
+        emphasis="filled"
+        label="Listen address"
+        value="http://127.0.0.1:3939"
+        detail="Local only"
+      />
+      <StatTile
+        emphasis="outline"
+        label="Gateway token"
+        value="maka_live_token_4f61127a1e66b49c97a1d1c45b0df9f6b28df69c"
+        detail="Long unbroken strings wrap inside the tile"
+      />
+    </div>
+  ),
+};
+
+export const ToneAndEmphasisMatrix: Story = {
+  render: () => (
+    <div style={{ display: 'grid', gap: 16 }}>
+      {(['outline', 'filled'] as const).map((emphasis) => (
+        <div key={emphasis} style={{ display: 'grid', gap: 8 }}>
+          <span style={{ color: 'var(--muted-foreground)', fontSize: 12 }}>{emphasis}</span>
+          <div style={{ display: 'grid', gap: 8, gridTemplateColumns: 'repeat(5, minmax(120px, 1fr))' }}>
+            {TONES.map((tone, index) => (
+              <StatTile
+                key={`${emphasis}-${tone}`}
+                emphasis={emphasis}
+                tone={tone}
+                label={tone}
+                value={index === 0 ? 0 : index * 12}
+                detail={index === 0 ? 'zero neutral' : 'sample'}
+              />
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  ),
+};


### PR DESCRIPTION
## Summary

Closes #1304.

- contain `StatTile` value text with `max-w-full`, `min-w-0`, normal white-space, and `overflow-wrap:anywhere` so long unbroken strings such as Open Gateway listen addresses cannot bleed into neighboring metric tiles
- add a `Primitives/StatTile` Storybook story covering long URL/token values plus tone/emphasis/zero variants
- add a rendered settings E2E contract for the Open Gateway address metric value, asserting both the computed wrap style and `scrollWidth <= clientWidth`

## Verification

- `npm run build` — passed
- `npm run typecheck` — passed
- `npm --workspace @maka/desktop run typecheck` — passed
- `npm --workspace @maka/desktop run build-storybook` — passed
- `npm run prepare:officecli -- --platform darwin --arch arm64 && npm run check:release` — passed
- `cd apps/desktop && npx playwright test --config e2e/playwright.config.ts e2e/settings.spec.ts -g "open gateway metric values stay contained" --timeout=120000` — passed
- Live fixture smoke: launched the Open Gateway settings fixture and captured `/tmp/maka-1304-open-gateway.png`; measured the address value as `scrollWidth=119`, `clientWidth=119`, `overflowWrap=anywhere`

## Notes

- I also ran the repo-level `npm test`; the new/focused settings E2E passes, but the full local run is blocked by an unrelated macOS sandbox/Homebrew dependency issue in `@maka/runtime`'s filesystem-worker smoke: sandboxed `rg` cannot open `/opt/homebrew/opt/pcre2/lib/libpcre2-8.0.dylib`. `@maka/runtime-host run test:dist` and `maka-agent run test:dist` both pass when rerun independently.

-previous
<img width="748" height="564" alt="图片" src="https://github.com/user-attachments/assets/05397a70-3146-47a2-83fb-5fa86ac474e3" />


- fixed
<img width="809" height="674" alt="图片" src="https://github.com/user-attachments/assets/b36379e9-6f08-4fb3-b9e8-cf91ecd148db" />
