### PR TITLE
feat(models): surface custom relay setup

### DIFF
--- a/apps/desktop/e2e/first-run.spec.ts
+++ b/apps/desktop/e2e/first-run.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from './fixtures';
-import { PROVIDER_REGISTRY, RECOMMENDED_PROVIDER_TYPES } from '@maka/core';
+import { PROVIDER_REGISTRY, RECOMMENDED_PROVIDER_TYPES, type ProviderType } from '@maka/core';
+import { PROVIDER_DISPLAY_COPY } from '../src/renderer/settings/provider-display-copy';
+
+function providerDisplayName(type: ProviderType): string {
+  return PROVIDER_DISPLAY_COPY[type]?.zh.name ?? PROVIDER_REGISTRY[type].label;
+}
 
 /**
  * First-run flow: a brand-new workspace (empty userData) must boot to the main
@@ -15,7 +20,7 @@ test('boots to registry recommendations and browses the shared provider catalog'
   const providerRows = page.locator('.maka-firstrun-row');
   await expect(providerRows).toHaveCount(RECOMMENDED_PROVIDER_TYPES.length);
   await expect(providerRows).toContainText(
-    RECOMMENDED_PROVIDER_TYPES.map((type) => PROVIDER_REGISTRY[type].label),
+    RECOMMENDED_PROVIDER_TYPES.map((type) => providerDisplayName(type)),
   );
 
   await page.getByRole('button', { name: '浏览全部服务商' }).click();

--- a/apps/desktop/src/main/__tests__/custom-relay-provider-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/custom-relay-provider-contract.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { PROVIDER_DEFAULTS } from '@maka/core';
+import { PROVIDER_DISPLAY_COPY } from '../../renderer/settings/provider-display-copy.js';
+
+const repoRoot = process.cwd().endsWith('apps/desktop')
+  ? join(process.cwd(), '..', '..')
+  : process.cwd();
+
+async function readRepo(path: string): Promise<string> {
+  return readFile(join(repoRoot, path), 'utf8');
+}
+
+describe('Custom relay provider setup contract', () => {
+  it('surfaces custom relay protocols as first-class recommended providers', () => {
+    const chatRelay = PROVIDER_DEFAULTS['openai-compatible'];
+    const responsesRelay = PROVIDER_DEFAULTS['openai-responses-compatible'];
+    const anthropicRelay = PROVIDER_DEFAULTS['anthropic-compatible'];
+
+    assert.equal(chatRelay.status, 'ready');
+    assert.equal(chatRelay.catalogGroup, 'aggregators');
+    assert.equal(chatRelay.category, 'custom');
+    assert.equal(chatRelay.catalogBadge, 'Relay');
+    assert.equal(chatRelay.recommendedOrder, 7.5);
+    assert.deepEqual(chatRelay.runtimeAdapter, {
+      kind: 'openai-compatible',
+      name: 'connection',
+      requireBaseUrl: true,
+    });
+    assert.equal(chatRelay.modelDiscovery.kind, 'protocol');
+
+    assert.deepEqual(responsesRelay.runtimeAdapter, {
+      kind: 'openai',
+      apiProtocol: 'openai-responses',
+    });
+    assert.equal(responsesRelay.catalogBadge, 'Responses');
+    assert.equal(responsesRelay.recommendedOrder, 7.6);
+    assert.equal(responsesRelay.modelDiscovery.kind, 'protocol');
+
+    assert.deepEqual(anthropicRelay.runtimeAdapter, {
+      kind: 'anthropic',
+      auth: 'api-key',
+      normalizeBaseUrl: true,
+    });
+    assert.equal(anthropicRelay.catalogBadge, 'Anthropic');
+    assert.equal(anthropicRelay.recommendedOrder, 7.7);
+    assert.equal(anthropicRelay.modelDiscovery.kind, 'protocol');
+  });
+
+  it('uses relay-first catalog copy so users can find the中转站入口 without mixing protocols', () => {
+    assert.equal(PROVIDER_DISPLAY_COPY['openai-compatible'].zh.name, '自定义中转站（OpenAI Chat）');
+    assert.match(PROVIDER_DISPLAY_COPY['openai-compatible'].zh.description, /OpenAI Chat Completions 兼容中转站/);
+    assert.equal(PROVIDER_DISPLAY_COPY['openai-compatible'].en.name, 'Custom relay (OpenAI Chat)');
+    assert.match(PROVIDER_DISPLAY_COPY['openai-compatible'].en.description, /OpenAI Chat Completions-compatible relay/);
+
+    assert.equal(PROVIDER_DISPLAY_COPY['openai-responses-compatible'].zh.name, '自定义中转站（OpenAI Responses）');
+    assert.match(PROVIDER_DISPLAY_COPY['openai-responses-compatible'].zh.description, /OpenAI Responses API 兼容中转站/);
+    assert.equal(PROVIDER_DISPLAY_COPY['anthropic-compatible'].zh.name, '自定义中转站（Anthropic）');
+    assert.match(PROVIDER_DISPLAY_COPY['anthropic-compatible'].zh.description, /Anthropic Messages 兼容中转站/);
+  });
+
+  it('keeps custom relay creation on the full profile form with endpoint, key, required model, and gated model fetch', async () => {
+    const form = await readRepo('apps/desktop/src/renderer/settings/provider-add-form.tsx');
+    const copy = await readRepo('apps/desktop/src/renderer/locales/settings-provider-copy.ts');
+
+    assert.match(form, /const requiresBaseUrl = !defaults\.baseUrl && !isCloudflareWorkersAi;/);
+    assert.match(form, /const showsDefaultModel = recommendedDefaultModel\.trim\(\) === '';/);
+    assert.match(form, /const isCustomRelay = defaults\.category === 'custom';/);
+    assert.match(form, /if \(requiresBaseUrl && !baseUrl\.trim\(\)\) return setError\(copy\.endpointRequired\);/);
+    assert.match(form, /if \(isCustomRelay && !normalizedDefaultModel\) return setError\(copy\.defaultModelRequired\);/);
+    assert.match(form, /baseUrl: resolvedBaseUrl,/);
+    assert.match(form, /defaultModel: normalizedDefaultModel \|\| recommendedDefaultModel,/);
+    assert.match(form, /if \(isCustomRelay\) await props\.bridge\.fetchModels\(connection\.slug\)\.catch\(\(\) => undefined\);/);
+    assert.match(form, /aria-label=\{copy\.defaultModelAria\}/);
+    assert.match(form, /<small>\{copy\.defaultModelHelp\}<\/small>/);
+
+    assert.match(copy, /defaultModel: '默认模型'/);
+    assert.match(copy, /defaultModelRequired: '请填写默认模型 ID。保存后仍会自动拉取模型目录。'/);
+    assert.match(copy, /defaultModel: 'Default model'/);
+    assert.match(copy, /defaultModelRequired: 'Enter a default model id\. Maka still fetches the model catalog after saving\.'/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -400,14 +400,15 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
       /'openai-codex':\s*\{\s*zh:\s*\{ name: 'OpenAI OAuth', description: 'ChatGPT \/ Codex 账号登录；登录后自动成为可用模型连接。' \}/,
       'OpenAI OAuth account path should not be presented as a Codex subscription in provider settings',
     );
-    // Both locales ship explicit copy for the custom provider, so the Chinese
-    // UI never falls through to the raw English registry fallback
-    // ("Custom OpenAI-compatible endpoint or gateway.").
-    assert.match(src, /zh: \{ name: '自定义 OpenAI 兼容接口'/);
-    assert.match(src, /en: \{ name: 'Custom OpenAI-compatible'/);
+    // Both locales ship explicit copy for the custom relay provider, so the Chinese
+    // UI never falls through to the raw English registry fallback. The copy must
+    // also name the current wire protocol: this provider is OpenAI Chat
+    // Completions-compatible, not OpenAI Responses.
+    assert.match(src, /zh: \{ name: '自定义中转站（OpenAI Chat）'/);
+    assert.match(src, /en: \{ name: 'Custom relay \(OpenAI Chat\)'/);
     assert.doesNotMatch(
       src,
-      /OpenAI-compatible endpoint or gateway/,
+      /Custom OpenAI-compatible endpoint or gateway|OpenAI-compatible \(custom\)/,
       'localized display copy must not leak the raw English registry fallback into UI',
     );
   });

--- a/apps/desktop/src/renderer/locales/settings-provider-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-provider-copy.ts
@@ -85,6 +85,7 @@ const zhCopy = {
     accountId: 'Cloudflare Account ID', accountIdPlaceholder: '填写账户 ID', accountIdAria: 'Cloudflare 账户 ID', endpoint: '服务地址', endpointAria: '模型供应商服务地址',
     saving: '保存中…', save: '保存供应商', keyRequired: (name: string) => `请填写 ${name} API Key`,
     apiKeyLabel: (required: boolean) => `API Key（${required ? '必填' : '可选'}）`, accountIdLabel: 'Cloudflare Account ID（必填）', endpointLabel: (required: boolean) => `服务地址${required ? '（必填）' : ''}`,
+    defaultModel: '默认模型', defaultModelPlaceholder: '填写你的中转站模型 ID，例如 gpt-4o、claude-sonnet-4-5 或自定义模型名', defaultModelAria: '自定义中转站默认模型', defaultModelHelp: '用于首次连接测试和模型选择器兜底；保存后仍会自动拉取模型目录。', defaultModelRequired: '请填写默认模型 ID。保存后仍会自动拉取模型目录。',
   },
   oauthFlow: {
     refreshFailed: '刷新登录状态失败', accountActionFailed: (name: string) => `${name} 账号操作失败`, loginFailedRetry: '登录失败，请稍后重试。',
@@ -211,6 +212,7 @@ const enCopy: ProviderSettingsCopy = {
     accountId: 'Cloudflare Account ID', accountIdPlaceholder: 'Enter account ID', accountIdAria: 'Cloudflare account ID', endpoint: 'Service URL', endpointAria: 'Model provider service URL',
     saving: 'Saving…', save: 'Save provider', keyRequired: (name: string) => `Enter the ${name} API key`,
     apiKeyLabel: (required: boolean) => `API key (${required ? 'required' : 'optional'})`, accountIdLabel: 'Cloudflare Account ID (required)', endpointLabel: (required: boolean) => `Service URL${required ? ' (required)' : ''}`,
+    defaultModel: 'Default model', defaultModelPlaceholder: 'Enter your relay model id, e.g. gpt-4o, claude-sonnet-4-5, or a custom model name', defaultModelAria: 'Custom relay default model', defaultModelHelp: 'Used as the first connection-test and picker fallback; Maka still fetches the model catalog after saving.', defaultModelRequired: 'Enter a default model id. Maka still fetches the model catalog after saving.',
   },
   oauthFlow: {
     refreshFailed: 'Failed to refresh sign-in status', accountActionFailed: (name: string) => `${name} account action failed`, loginFailedRetry: 'Sign-in failed. Try again later.',

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -32,6 +32,7 @@ export function AddProviderForm(props: {
   const [baseUrl, setBaseUrl] = useState(defaults.baseUrl);
   const [cloudflareAccountId, setCloudflareAccountId] = useState('');
   const [apiKey, setApiKey] = useState('');
+  const [defaultModel, setDefaultModel] = useState(recommendedDefaultModel);
   const [error, setError] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const submitGuard = useActionGuard<'submit'>();
@@ -39,6 +40,8 @@ export function AddProviderForm(props: {
 
   const isCloudflareWorkersAi = props.providerType === 'cloudflare-workers-ai';
   const requiresBaseUrl = !defaults.baseUrl && !isCloudflareWorkersAi;
+  const showsDefaultModel = recommendedDefaultModel.trim() === '';
+  const isCustomRelay = defaults.category === 'custom';
   const isExperimental = defaults.status === 'phase3-experimental';
   const isWiredOAuth = isWiredOAuthProvider(props.providerType);
   const supportsApiKey = providerAuthSupportsApiKey(props.providerType);
@@ -58,6 +61,8 @@ export function AddProviderForm(props: {
       return setError(copy.cloudflareAccount);
     }
     if (requiresBaseUrl && !baseUrl.trim()) return setError(copy.endpointRequired);
+    const normalizedDefaultModel = defaultModel.trim();
+    if (isCustomRelay && !normalizedDefaultModel) return setError(copy.defaultModelRequired);
     if (isExperimental) {
       return setError(isWiredOAuth
         ? copy.wiredLogin
@@ -77,9 +82,11 @@ export function AddProviderForm(props: {
         name: name || display.name,
         providerType: props.providerType,
         baseUrl: resolvedBaseUrl,
-        defaultModel: recommendedDefaultModel,
+        defaultModel: normalizedDefaultModel || recommendedDefaultModel,
         ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
       });
+      if (!addProviderMountedRef.current) return;
+      if (isCustomRelay) await props.bridge.fetchModels(connection.slug).catch(() => undefined);
       if (!addProviderMountedRef.current) return;
       await props.onCreated(connection.slug);
     } catch (err) {
@@ -181,6 +188,19 @@ export function AddProviderForm(props: {
             disabled={isExperimental || busy}
             aria-label={copy.endpointAria}
           />
+        </label>
+      )}
+      {showsDefaultModel && (
+        <label>
+          <span>{copy.defaultModel}</span>
+          <Input
+            value={defaultModel}
+            onChange={(event) => setDefaultModel(event.currentTarget.value)}
+            placeholder={copy.defaultModelPlaceholder}
+            disabled={isExperimental || busy}
+            aria-label={copy.defaultModelAria}
+          />
+          <small>{copy.defaultModelHelp}</small>
         </label>
       )}
       {error && <p className="providerError" role="alert">{error}</p>}

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -391,11 +391,13 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
     case 'opencode-go':
       return <ProviderAssetMask src={opencodeBrandMark} />;
     case 'anthropic':
+    case 'anthropic-compatible':
     case 'claude-subscription':
       return <Claude />;
     case 'openai':
     case 'openai-codex':
     case 'openai-compatible':
+    case 'openai-responses-compatible':
       return <OpenAI />;
     case 'github-copilot':
       return <ProviderAssetMask src={githubCopilotBrandMark} />;

--- a/apps/desktop/src/renderer/settings/provider-display-copy.ts
+++ b/apps/desktop/src/renderer/settings/provider-display-copy.ts
@@ -125,8 +125,16 @@ export const PROVIDER_DISPLAY_COPY = {
     en: { name: 'LocalAI', description: 'Local models served by LocalAI, with optional API key.', badge: 'Local' },
   },
   'openai-compatible': {
-    zh: { name: '自定义 OpenAI 兼容接口', description: '中转站、代理服务或自部署网关。', badge: 'Custom' },
-    en: { name: 'Custom OpenAI-compatible', description: 'Relay, proxy, or self-hosted gateway.', badge: 'Custom' },
+    zh: { name: '自定义中转站（OpenAI Chat）', description: 'OpenAI Chat Completions 兼容中转站、代理服务或自部署网关。', badge: '中转' },
+    en: { name: 'Custom relay (OpenAI Chat)', description: 'OpenAI Chat Completions-compatible relay, proxy, or self-hosted gateway.', badge: 'Relay' },
+  },
+  'openai-responses-compatible': {
+    zh: { name: '自定义中转站（OpenAI Responses）', description: 'OpenAI Responses API 兼容中转站、代理服务或自部署网关。', badge: 'Responses' },
+    en: { name: 'Custom relay (OpenAI Responses)', description: 'OpenAI Responses-compatible relay, proxy, or self-hosted gateway.', badge: 'Responses' },
+  },
+  'anthropic-compatible': {
+    zh: { name: '自定义中转站（Anthropic）', description: 'Anthropic Messages 兼容中转站、代理服务或自部署网关。', badge: 'Anthropic' },
+    en: { name: 'Custom relay (Anthropic)', description: 'Anthropic Messages-compatible relay, proxy, or self-hosted gateway.', badge: 'Anthropic' },
   },
   'fireworks-ai': {
     zh: { name: 'Fireworks AI', description: 'Serverless 开源模型托管', badge: 'API' },

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -86,6 +86,8 @@ describe('provider compatibility contract', () => {
       'lm-studio',
       'localai',
       'openai-compatible',
+      'openai-responses-compatible',
+      'anthropic-compatible',
       'github-copilot',
       'claude-subscription',
       'openai-codex',
@@ -114,6 +116,8 @@ describe('provider compatibility contract', () => {
       'localai',
       'kimi-coding-plan',
       'openai-compatible',
+      'openai-responses-compatible',
+      'anthropic-compatible',
       'minimax-coding-plan',
       'togetherai',
       'fireworks-ai',
@@ -169,6 +173,8 @@ describe('provider compatibility contract', () => {
       'lm-studio',
       'localai',
       'openai-compatible',
+      'openai-responses-compatible',
+      'anthropic-compatible',
       'fireworks-ai',
       'nvidia',
       'tencent-tokenhub',
@@ -220,6 +226,9 @@ describe('provider compatibility contract', () => {
       'kimi-coding-plan',
       'deepseek',
       'ollama',
+      'openai-compatible',
+      'openai-responses-compatible',
+      'anthropic-compatible',
     ]);
     assert.equal(PROVIDER_REGISTRY['kimi-coding-plan'].catalogGroup, 'plans');
     assert.equal(PROVIDER_REGISTRY.siliconflow.catalogGroup, 'aggregators');
@@ -1550,16 +1559,18 @@ describe('persistedBaseUrl', () => {
     );
   });
 
-  it('persists a custom override for openai-compatible (whose default is the empty string)', () => {
-    // openai-compatible is the one provider with no canonical default — any
-    // non-empty value the user supplies is a real override and must persist.
+  it('persists a custom override for custom relay providers (empty canonical default)', () => {
+    // Custom relay providers have no canonical default — any non-empty value
+    // the user supplies is a real override and must persist.
     const custom = 'https://my-gateway.example.com/v1';
-    assert.equal(persistedBaseUrl('openai-compatible', custom), custom);
-    assert.equal(
-      persistedBaseUrl('openai-compatible', ''),
-      undefined,
-      'empty still means no override',
-    );
+    for (const providerType of [
+      'openai-compatible',
+      'openai-responses-compatible',
+      'anthropic-compatible',
+    ] as const) {
+      assert.equal(persistedBaseUrl(providerType, custom), custom);
+      assert.equal(persistedBaseUrl(providerType, ''), undefined, 'empty still means no override');
+    }
   });
 });
 

--- a/packages/core/src/__tests__/provider-catalog-contract.test.ts
+++ b/packages/core/src/__tests__/provider-catalog-contract.test.ts
@@ -63,7 +63,7 @@ describe('provider catalog contract — structural invariants over CATALOG_PROVI
     //   - a concrete baseUrl, or
     //   - a baseUrlTemplate whose placeholders resolve to a concrete URL
     //     (account-scoped endpoints), or
-    //   - a custom openai-compatible connection where the user supplies the URL
+    //   - a custom relay connection where the user supplies the URL
     //     at connect time.
     // Concrete URLs are judged by validateConnectionBaseUrl — the same gate the
     // connection IPC applies — so a registry default can never be something
@@ -97,8 +97,7 @@ describe('provider catalog contract — structural invariants over CATALOG_PROVI
         );
         continue;
       }
-      const isCustomConnection =
-        def.runtimeAdapter.kind === 'openai-compatible' && def.runtimeAdapter.name === 'connection';
+      const isCustomConnection = def.category === 'custom';
       assert.ok(
         isCustomConnection,
         `${type} has no baseUrl, no baseUrlTemplate, and is not a custom connection — it cannot source an endpoint`,

--- a/packages/core/src/provider-contract-matrix.ts
+++ b/packages/core/src/provider-contract-matrix.ts
@@ -324,6 +324,18 @@ function wireDimensionCell(
       contract: `${def.runtimeAdapter.kind} subscription wire is provider-specific (per-model protocol, headers, auth)`,
     };
   }
+  if (
+    def.runtimeAdapter.kind === 'openai' &&
+    def.runtimeAdapter.apiProtocol === 'openai-responses'
+  ) {
+    return {
+      state: 'override',
+      dimension,
+      overrideKey: overrideKeyFor(providerType, dimension),
+      contract:
+        'OpenAI Responses relay wire is provider-specific until the matrix has a generated Responses executor',
+    };
+  }
   return { state: 'generated', dimension, wire: wireForProtocol(def.protocol) };
 }
 

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -11,7 +11,7 @@ export type ProviderCatalogGroup = 'recommended' | 'plans' | 'api' | 'aggregator
 export type ProviderRuntimeAdapter =
   | { kind: 'anthropic'; auth: 'api-key' | 'bearer'; normalizeBaseUrl: boolean }
   | { kind: 'claude-subscription' }
-  | { kind: 'openai' }
+  | { kind: 'openai'; apiProtocol?: 'openai-chat' | 'openai-responses' }
   | { kind: 'openai-codex' }
   | { kind: 'google'; normalizeBaseUrl?: boolean }
   | { kind: 'github-copilot' }
@@ -1541,8 +1541,8 @@ const providerRegistry = {
     catalogOrder: 17.5,
   },
   'openai-compatible': {
-    label: 'OpenAI-compatible (custom)',
-    description: 'Custom OpenAI-compatible endpoint or gateway.',
+    label: 'Custom relay (OpenAI Chat-compatible)',
+    description: 'Custom OpenAI Chat Completions-compatible relay, proxy, or self-hosted gateway.',
     baseUrl: '',
     authKind: 'api_key',
     backendKind: 'ai-sdk',
@@ -1553,9 +1553,46 @@ const providerRegistry = {
     modelDiscovery: { kind: 'protocol' },
     category: 'custom',
     catalogGroup: 'aggregators',
-    catalogBadge: 'Custom',
+    catalogBadge: 'Relay',
     readyOrder: 16,
     catalogOrder: 18,
+    recommendedOrder: 7.5,
+  },
+  'openai-responses-compatible': {
+    label: 'Custom relay (OpenAI Responses)',
+    description: 'Custom OpenAI Responses-compatible relay, proxy, or self-hosted gateway.',
+    baseUrl: '',
+    authKind: 'api_key',
+    backendKind: 'ai-sdk',
+    fallbackModels: [],
+    status: 'ready',
+    protocol: 'openai',
+    runtimeAdapter: { kind: 'openai', apiProtocol: 'openai-responses' },
+    modelDiscovery: { kind: 'protocol' },
+    category: 'custom',
+    catalogGroup: 'aggregators',
+    catalogBadge: 'Responses',
+    readyOrder: 16.1,
+    catalogOrder: 18.1,
+    recommendedOrder: 7.6,
+  },
+  'anthropic-compatible': {
+    label: 'Custom relay (Anthropic)',
+    description: 'Custom Anthropic Messages-compatible relay, proxy, or self-hosted gateway.',
+    baseUrl: '',
+    authKind: 'api_key',
+    backendKind: 'ai-sdk',
+    fallbackModels: [],
+    status: 'ready',
+    protocol: 'anthropic',
+    runtimeAdapter: { kind: 'anthropic', auth: 'api-key', normalizeBaseUrl: true },
+    modelDiscovery: { kind: 'protocol' },
+    category: 'custom',
+    catalogGroup: 'aggregators',
+    catalogBadge: 'Anthropic',
+    readyOrder: 16.2,
+    catalogOrder: 18.2,
+    recommendedOrder: 7.7,
   },
   'github-copilot': {
     label: githubCopilot.name,

--- a/packages/runtime/src/__tests__/model-fetcher.test.ts
+++ b/packages/runtime/src/__tests__/model-fetcher.test.ts
@@ -350,30 +350,61 @@ describe('fetchProviderModels', () => {
     );
   });
 
-  test('OpenAI-compatible providers fetch live /models instead of returning fallback defaults', async () => {
-    const server = await startJsonServer((request, response) => {
-      assert.equal(request.url, '/v1/models');
-      assert.equal(request.headers.authorization, 'Bearer relay-secret');
-      respondJson(response, 200, {
-        data: [{ id: 'custom-live-model' }],
+  test('Custom OpenAI relay providers fetch live /models instead of returning fallback defaults', async () => {
+    for (const [providerType, modelId] of [
+      ['openai-compatible', 'custom-chat-model'],
+      ['openai-responses-compatible', 'custom-responses-model'],
+    ] as const) {
+      const server = await startJsonServer((request, response) => {
+        assert.equal(request.url, '/v1/models');
+        assert.equal(request.headers.authorization, 'Bearer relay-secret');
+        respondJson(response, 200, {
+          data: [{ id: modelId }],
+        });
       });
+
+      const models = await fetchProviderModels(
+        {
+          slug: `${providerType}-relay`,
+          name: 'Relay',
+          providerType,
+          baseUrl: `${server.url}/v1`,
+          defaultModel: modelId,
+          enabled: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        'relay-secret',
+      );
+
+      assert.deepEqual(models, [{ id: modelId }]);
+    }
+  });
+
+  test('Custom Anthropic relay providers fetch live /v1/models with x-api-key auth', async () => {
+    let observedApiKey = '';
+    const server = await startJsonServer((request, response) => {
+      observedApiKey = (request.headers['x-api-key'] as string | undefined) ?? '';
+      assert.equal(request.url, '/anthropic/v1/models');
+      respondJson(response, 200, { data: [{ id: 'claude-relay-sonnet' }] });
     });
 
     const models = await fetchProviderModels(
       {
-        slug: 'relay',
-        name: 'Relay',
-        providerType: 'openai-compatible',
-        baseUrl: `${server.url}/v1`,
-        defaultModel: 'custom-live-model',
+        slug: 'anthropic-relay',
+        name: 'Anthropic Relay',
+        providerType: 'anthropic-compatible',
+        baseUrl: `${server.url}/anthropic`,
+        defaultModel: 'claude-relay-sonnet',
         enabled: true,
         createdAt: 1,
         updatedAt: 1,
       },
-      'relay-secret',
+      'anthropic-relay-secret',
     );
 
-    assert.deepEqual(models, [{ id: 'custom-live-model' }]);
+    assert.equal(observedApiKey, 'anthropic-relay-secret');
+    assert.deepEqual(models, [{ id: 'claude-relay-sonnet' }]);
   });
 
   test('Google Gemini appends /models to a /v1beta base URL without doubling the version segment', async () => {

--- a/packages/runtime/src/__tests__/provider-contract-overrides.ts
+++ b/packages/runtime/src/__tests__/provider-contract-overrides.ts
@@ -73,6 +73,11 @@ export const PROVIDER_CONTRACT_OVERRIDE_BINDINGS: readonly ProviderContractOverr
     title: 'ZenMux replays signed reasoning details in the streamed runtime tool loop',
     run: runZenMuxSignedReasoningReplay,
   },
+  {
+    keys: ['openai-responses-compatible:exact-model-id', 'openai-responses-compatible:tool-loop'],
+    title: 'Custom OpenAI Responses relay preserves exact model ids and tool results',
+    run: runCustomOpenAIResponsesRelayWire,
+  },
 ];
 
 async function runGitHubCopilotDiscovery(): Promise<void> {
@@ -777,6 +782,94 @@ async function runCohereDiscovery(): Promise<void> {
   );
   assert.equal(result.steps[0]?.toolCalls[0]?.toolName, 'echo');
   assert.deepEqual(result.steps[0]?.toolResults[0]?.output, { echoed: 'hello' });
+  assert.equal(result.text, 'Echoed hello.');
+}
+
+async function runCustomOpenAIResponsesRelayWire(): Promise<void> {
+  const modelId = 'relay-responses-model';
+  const requestBodies: Array<Record<string, unknown>> = [];
+  const server = await startJsonServer(async (request, response) => {
+    assert.equal(request.method, 'POST');
+    assert.equal(request.url, '/relay/v1/responses');
+    assert.equal(request.headers.authorization, 'Bearer responses-relay-key');
+    requestBodies.push(JSON.parse(await readBody(request)) as Record<string, unknown>);
+    if (requestBodies.length === 1) {
+      respondJson(response, 200, {
+        id: 'resp_relay_tool',
+        object: 'response',
+        created_at: 1,
+        status: 'completed',
+        model: modelId,
+        output: [
+          {
+            type: 'function_call',
+            id: 'fc_relay_echo',
+            call_id: 'call_relay_echo',
+            name: 'echo',
+            arguments: '{"text":"hello"}',
+            status: 'completed',
+          },
+        ],
+        usage: { input_tokens: 8, output_tokens: 4, total_tokens: 12 },
+      });
+      return;
+    }
+    respondJson(response, 200, {
+      id: 'resp_relay_final',
+      object: 'response',
+      created_at: 2,
+      status: 'completed',
+      model: modelId,
+      output: [
+        {
+          type: 'message',
+          id: 'msg_relay_final',
+          status: 'completed',
+          role: 'assistant',
+          content: [{ type: 'output_text', text: 'Echoed hello.', annotations: [], logprobs: [] }],
+        },
+      ],
+      usage: { input_tokens: 14, output_tokens: 3, total_tokens: 17 },
+    });
+  });
+  const connection: LlmConnection = {
+    slug: 'responses-relay',
+    name: 'Responses Relay',
+    providerType: 'openai-responses-compatible',
+    baseUrl: `${server.url}/relay/v1`,
+    defaultModel: modelId,
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+
+  const result = await generateText({
+    model: getAIModel({ connection, apiKey: 'responses-relay-key', modelId }),
+    prompt: 'Call echo with hello.',
+    stopWhen: isStepCount(2),
+    tools: {
+      echo: tool({
+        description: 'Echo text',
+        inputSchema: z.object({ text: z.string() }),
+        execute: async ({ text }) => ({ echoed: text }),
+      }),
+    },
+  });
+
+  assert.deepEqual(
+    requestBodies.map((body) => body.model),
+    [modelId, modelId],
+  );
+  assert.deepEqual(
+    (requestBodies[1].input as Array<Record<string, unknown>>).find(
+      ({ type }) => type === 'function_call_output',
+    ),
+    {
+      type: 'function_call_output',
+      call_id: 'call_relay_echo',
+      output: '{"echoed":"hello"}',
+    },
+  );
   assert.equal(result.text, 'Echoed hello.');
 }
 

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -88,6 +88,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
       // otherwise the model's declared OpenAI-adapter protocol decides. gpt-5*
       // families are Responses-only; everything else uses Chat Completions.
       const apiProtocol =
+        adapter.apiProtocol ??
         connection.models?.find((model) => model.id === modelId)?.apiProtocol ??
         openAiAdapterApiProtocol(modelId);
       return apiProtocol === 'openai-responses' ? openai.responses(modelId) : openai.chat(modelId);

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -63,17 +63,22 @@ export async function testConnection(
   if (!testModel) {
     return { ok: false, errorMessage: 'No model to test' };
   }
-  const { adapter, baseUrl } = resolveModelRuntime(connection, testModel);
+  const { adapter, baseUrl, apiProtocol } = resolveModelRuntime(connection, testModel);
 
   try {
     switch (adapter.kind) {
       case 'anthropic':
       case 'claude-subscription':
         return await probeAnthropic(connection, baseUrl, secret, testModel, t0);
-      case 'openai':
-        return /^gpt-5/i.test(testModel)
+      case 'openai': {
+        const resolvedApiProtocol =
+          adapter.apiProtocol ??
+          apiProtocol ??
+          (/^gpt-5/i.test(testModel) ? 'openai-responses' : 'openai-chat');
+        return resolvedApiProtocol === 'openai-responses'
           ? await probeOpenAIResponses(baseUrl, secret, testModel, t0)
           : await probeOpenAI(connection, baseUrl, secret, testModel, t0);
+      }
       case 'openai-codex':
       case 'openai-compatible':
         return await probeOpenAI(connection, baseUrl, secret, testModel, t0);


### PR DESCRIPTION
## Summary

Refs #1339.

- Surface custom relay setup as first-class provider catalog entries, following the cc-switch profile pattern: endpoint + API key + default model in one setup flow, then automatic model discovery for custom relays.
- Keep the existing OpenAI Chat Completions-compatible relay explicit as `Custom relay (OpenAI Chat)` / `自定义中转站（OpenAI Chat）`.
- Add separate protocol entries for:
  - `openai-responses-compatible` → `Custom relay (OpenAI Responses)` using the OpenAI Responses wire.
  - `anthropic-compatible` → `Custom relay (Anthropic)` using the Anthropic Messages wire.
- Automatically call `fetchModels` after creating a **custom relay** connection so providers exposing `/v1/models` populate the frontend model list. This is gated to custom relays only; named/provider API-key flows keep their previous creation behavior.
- Require a default model id for custom relays until the connection detail screen has a separate manual model-entry recovery path. Maka still fetches the model catalog after saving, but users do not get stranded in `missing_model` if discovery fails.
- Add runtime/test coverage proving:
  - OpenAI Responses relay uses `/responses`, preserves exact model ids, and preserves tool results across steps.
  - Anthropic-compatible relay uses Anthropic `/v1/messages` semantics and `x-api-key` model discovery.
  - The provider catalog, icons, recommended order, endpoint-source contract, first-run recommendations, and copy stay protocol-explicit.

## cc-switch reference notes

I checked `farion1231/cc-switch` and `SaladDay/cc-switch-cli` before scoping this. The relevant patterns are:

- provider profiles are the primary UX object;
- endpoint + key + model/protocol are visible in one setup flow;
- model fetching is a first-class provider action;
- protocol/API format matters (`anthropic`, OpenAI Chat, OpenAI Responses), so Maka now exposes those as separate provider/protocol entries instead of hiding them behind one generic OpenAI-compatible path.

## Verification

- `npm run typecheck`
- `npm --workspace @maka/core run build && npm --workspace @maka/core run test:dist` — 1154/1154 passed
- `npm --workspace @maka/runtime run build && node --test packages/runtime/dist/__tests__/model-fetcher.test.js packages/runtime/dist/__tests__/provider-contract-matrix.test.js packages/runtime/dist/__tests__/provider-conformance.test.js` — 161/161 passed
- `npm --workspace @maka/desktop test` — 2795/2795 passed
- `npm --workspace @maka/desktop run e2e -- e2e/first-run.spec.ts` — 1/1 passed
- `npm --workspace @maka/desktop run e2e` — 32/32 passed locally

Note: full `npm --workspace @maka/runtime run test:dist` still hits the pre-existing local macOS filesystem-worker smoke failure around the operation-scoped Grep sandbox / Homebrew `rg` dynamic library path; the provider conformance matrix and the new relay coverage pass.

## visual

<img width="1024" height="975" alt="图片" src="https://github.com/user-attachments/assets/08d14704-400e-4eeb-8445-441477308e08" />

<img width="616" height="574" alt="图片" src="https://github.com/user-attachments/assets/5f2a4cc3-6304-46ff-a124-cd0415e9f6d2" />

<img width="542" height="559" alt="图片" src="https://github.com/user-attachments/assets/d72b0946-3887-457e-9500-269250fc9e28" />

<img width="625" height="567" alt="图片" src="https://github.com/user-attachments/assets/5d2e7732-d13f-44d9-a3b5-e0394852bdda" />

