### PR TITLE
refactor(headless): dedupe run-script helpers and extract TaskRunner interface

### DIFF
--- a/packages/headless/harbor/run-harness-ab-detached.mjs
+++ b/packages/headless/harbor/run-harness-ab-detached.mjs
@@ -2,21 +2,17 @@
 
 import { closeSync, openSync } from 'node:fs';
 import { mkdir, readFile } from 'node:fs/promises';
-import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { spawn } from 'node:child_process';
 import { resolveFixedPromptRunRoot } from '#fixed-prompt-task-source';
+import { envPath as parseEnvPath } from '#headless-run-env';
 import { resolveHarnessAbRunId, resolveHarnessCompetitorProfile } from './run-harness-ab.mjs';
 
 const JOURNAL_FILENAME = 'background-run.json';
 const LOG_FILENAME = 'background-run.log';
 
-function envPath(name) {
-  const raw = process.env[name];
-  if (!raw) throw new Error(`${name} is required`);
-  return raw.startsWith('~') ? join(homedir(), raw.slice(1)) : resolve(raw);
-}
+const envPath = (name) => parseEnvPath(name, process.env[name]);
 
 function detachedRunPaths() {
   const outDir = envPath('MAKA_HARNESS_AB_OUT_DIR');

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -57,7 +57,8 @@ import {
   renderHarnessAbReportCsv,
   renderHarnessAbReportMarkdown,
 } from '#harness-ab-report';
-import { buildSubjectFingerprint, buildToolchainFingerprint } from './run-prompt-ab.mjs';
+import { envPath as parseEnvPath } from '#headless-run-env';
+import { buildSubjectFingerprint, buildToolchainFingerprint } from '#experiment-fingerprint';
 
 const execFileAsync = promisify(execFile);
 
@@ -275,15 +276,8 @@ export function resolveHarnessCompetitorToolchain(runRoot, competitorProfile, en
   throw new Error(`unsupported harness competitor: ${competitorProfile.id}`);
 }
 
-function envPath(name, fallback) {
-  return envPathFrom(process.env, name, fallback);
-}
-
-function envPathFrom(env, name, fallback) {
-  const raw = env[name] || fallback;
-  if (!raw) throw new Error(`${name} is required`);
-  return raw.startsWith('~') ? join(homedir(), raw.slice(1)) : resolve(raw);
-}
+const envPath = (name, fallback) => parseEnvPath(name, process.env[name], fallback);
+const envPathFrom = (env, name, fallback) => parseEnvPath(name, env[name], fallback);
 
 function defaultMakaWorkspaceRoot() {
   if (process.platform === 'darwin') {

--- a/packages/headless/harbor/run-prompt-ab.mjs
+++ b/packages/headless/harbor/run-prompt-ab.mjs
@@ -9,14 +9,16 @@
 //   node packages/headless/harbor/run-prompt-ab.mjs
 
 import { createHash } from 'node:crypto';
-import { execFile as execFileCallback } from 'node:child_process';
-import { lstat, mkdir, readdir, readFile, readlink, writeFile } from 'node:fs/promises';
+import { mkdir, readFile, writeFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { basename, join, relative, resolve } from 'node:path';
+import { basename, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { promisify } from 'node:util';
 import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '@maka/headless';
-import { discoverCachedHarborTasks, resolveFixedPromptRunRoot } from '#fixed-prompt-task-source';
+import {
+  discoverCachedHarborTasks,
+  resolveFixedPromptRunRoot,
+  selectTasksByIds,
+} from '#fixed-prompt-task-source';
 import {
   buildPromptAbRunManifest,
   ensurePromptAbRunManifest,
@@ -25,28 +27,24 @@ import {
   renderPromptAbComparisonMarkdown,
   runPromptAbComparison,
 } from '#prompt-ab-run';
-import { envRatio, envPositiveInt } from '#headless-run-env';
+import {
+  envIds as parseEnvIds,
+  envPath as parseEnvPath,
+  envPositiveInt,
+  envRatio,
+} from '#headless-run-env';
 import { createHarborTaskRunner } from '#harbor-task-runner';
+import {
+  buildSubjectFingerprint,
+  buildTaskSourceFingerprint,
+  buildToolchainFingerprint,
+} from '#experiment-fingerprint';
+import { DEEPSEEK_V4_FLASH_PRICING } from '#deepseek-pricing';
 
-const DEEPSEEK_V4_FLASH_PRICING = {
-  inputUsdPer1M: 0.145,
-  outputUsdPer1M: 0.29,
-  cacheReadUsdPer1M: 0.0029,
-  cacheWriteUsdPer1M: 0,
-  source: 'deepseek-v4-flash',
-};
-
-const execFile = promisify(execFileCallback);
-
-function envPath(name, fallback) {
-  const raw = process.env[name];
-  const value = raw && raw.length > 0 ? raw : fallback;
-  if (!value) throw new Error(`${name} is required`);
-  return value.startsWith('~') ? join(homedir(), value.slice(1)) : resolve(value);
-}
-
+const envPath = (name, fallback) => parseEnvPath(name, process.env[name], fallback);
 const envPosInt = (name, fallback) => envPositiveInt(name, process.env[name], fallback);
 const envRatioValue = (name, fallback) => envRatio(name, process.env[name], fallback);
+const envIds = (name) => parseEnvIds(process.env[name]);
 
 function rejectUnsupportedProviderEnv(env) {
   const raw = env.MAKA_PROMPT_AB_PROVIDER;
@@ -57,253 +55,12 @@ function rejectUnsupportedProviderEnv(env) {
   }
 }
 
-function envIds(name) {
-  const raw = process.env[name];
-  if (!raw) return undefined;
-  const ids = raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-  return ids.length > 0 ? ids : undefined;
-}
-
 function promptIdFromPath(path) {
   return basename(path).replace(/\.[^.]+$/, '');
 }
 
-function selectTasksByIds(allTasks, ids) {
-  const duplicates = [...new Set(ids.filter((id, index) => ids.indexOf(id) !== index))];
-  if (duplicates.length > 0) throw new Error(`duplicate task id(s): ${duplicates.join(', ')}`);
-  const byId = new Map(allTasks.map((task) => [task.id, task]));
-  const missing = ids.filter((id) => !byId.has(id));
-  if (missing.length > 0) throw new Error(`unknown task id(s): ${missing.join(', ')}`);
-  return ids.map((id) => byId.get(id));
-}
-
 function hashSystemPrompt(systemPrompt) {
   return `sha256:${createHash('sha256').update(systemPrompt).digest('hex')}`;
-}
-
-function hashBytes(bytes) {
-  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
-}
-
-function hashPayload(payload) {
-  return `sha256:${createHash('sha256').update(canonicalJson(payload)).digest('hex')}`;
-}
-
-function canonicalJson(value) {
-  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
-  if (value && typeof value === 'object') {
-    const entries = Object.entries(value)
-      .filter(([, entryValue]) => entryValue !== undefined)
-      .sort(([a], [b]) => a.localeCompare(b));
-    return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${canonicalJson(entryValue)}`).join(',')}}`;
-  }
-  return JSON.stringify(value);
-}
-
-async function gitOutput(repoPath, args) {
-  const { stdout } = await execFile('git', ['-C', repoPath, ...args], {
-    encoding: 'utf8',
-    maxBuffer: 1024 * 1024,
-  });
-  return stdout.trimEnd();
-}
-
-function isSha256Fingerprint(value) {
-  return /^sha256:[a-f0-9]{64}$/.test(value);
-}
-
-async function toolOutput(command, args) {
-  const { stdout, stderr } = await execFile(command, args, {
-    encoding: 'utf8',
-    maxBuffer: 1024 * 1024,
-  });
-  return `${stdout}${stderr}`.trim();
-}
-
-async function buildInstalledDependencyFingerprint(repoPath) {
-  const packageLockPath = join(repoPath, 'package-lock.json');
-  const installedLockPath = join(repoPath, 'node_modules/.package-lock.json');
-  let packageLock;
-  let installedLock;
-  try {
-    [packageLock, installedLock] = await Promise.all([
-      readFile(packageLockPath),
-      readFile(installedLockPath),
-    ]);
-  } catch (error) {
-    throw new Error(
-      `prompt A/B toolchain fingerprint requires ${packageLockPath} and ${installedLockPath}. Run npm install in MAKA_PROMPT_AB_MAKA_REPO, or set MAKA_PROMPT_AB_TOOLCHAIN_FINGERPRINT to an explicit sha256:<64 lowercase hex> dependency snapshot. Cause: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-  return {
-    packageLockPath: resolve(packageLockPath),
-    packageLockHash: hashBytes(packageLock),
-    installedPackageLockPath: resolve(installedLockPath),
-    installedPackageLockHash: hashBytes(installedLock),
-  };
-}
-
-export async function buildToolchainFingerprint(
-  explicitToolchainFingerprint,
-  readToolOutput = toolOutput,
-  repoPath = resolve(fileURLToPath(new URL('../../..', import.meta.url))),
-) {
-  if (explicitToolchainFingerprint && explicitToolchainFingerprint.trim().length > 0) {
-    const value = explicitToolchainFingerprint.trim();
-    if (!isSha256Fingerprint(value)) {
-      throw new Error(
-        'MAKA_PROMPT_AB_TOOLCHAIN_FINGERPRINT must be a sha256:<64 lowercase hex> content fingerprint',
-      );
-    }
-    return value;
-  }
-  let harborVersion;
-  try {
-    harborVersion = await readToolOutput('harbor', ['--version']);
-  } catch (error) {
-    harborVersion = `unavailable:${error instanceof Error ? error.message : String(error)}`;
-  }
-  return hashPayload({
-    kind: 'prompt-ab-toolchain',
-    node: process.version,
-    harborVersion,
-    dependencyInstallFingerprint: await buildInstalledDependencyFingerprint(repoPath),
-  });
-}
-
-export async function buildSubjectFingerprint(
-  repoPath,
-  explicitSubjectFingerprint,
-  readGitOutput = gitOutput,
-) {
-  if (explicitSubjectFingerprint && explicitSubjectFingerprint.trim().length > 0) {
-    const value = explicitSubjectFingerprint.trim();
-    if (!isSha256Fingerprint(value)) {
-      throw new Error(
-        'MAKA_PROMPT_AB_EXPLICIT_SUBJECT_FINGERPRINT must be a sha256:<64 lowercase hex> content fingerprint',
-      );
-    }
-    return hashPayload({
-      kind: 'prompt-ab-subject',
-      explicitSubjectFingerprint: value,
-    });
-  }
-  let gitRoot;
-  let head;
-  let status;
-  try {
-    [gitRoot, head, status] = await Promise.all([
-      readGitOutput(repoPath, ['rev-parse', '--show-toplevel']),
-      readGitOutput(repoPath, ['rev-parse', 'HEAD']),
-      readGitOutput(repoPath, ['status', '--porcelain=v1', '--untracked-files=normal']),
-    ]);
-  } catch (error) {
-    throw new Error(
-      `MAKA_PROMPT_AB_MAKA_REPO must be a git checkout or MAKA_PROMPT_AB_EXPLICIT_SUBJECT_FINGERPRINT must be set: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
-  if (status.length > 0) {
-    throw new Error(
-      `MAKA_PROMPT_AB_MAKA_REPO must be clean for resume-safe prompt A/B runs. Commit/stash the changes, or set MAKA_PROMPT_AB_EXPLICIT_SUBJECT_FINGERPRINT to an explicit content fingerprint. Dirty git status:\n${status}`,
-    );
-  }
-  return hashPayload({
-    kind: 'prompt-ab-subject',
-    path: resolve(repoPath),
-    gitRoot: resolve(gitRoot),
-    head,
-    dirty: false,
-    statusHash: hashPayload({ status }),
-    runtimeArtifactFingerprint: await buildRuntimeArtifactFingerprint(gitRoot),
-  });
-}
-
-async function buildRuntimeArtifactFingerprint(repoRoot) {
-  const artifactRoots = [
-    'packages/headless/dist',
-    'packages/core/dist',
-    'packages/runtime/dist',
-    'packages/storage/dist',
-  ];
-  return hashPayload({
-    kind: 'prompt-ab-runtime-artifacts',
-    artifacts: await Promise.all(
-      artifactRoots.map(async (artifactPath) => ({
-        path: artifactPath,
-        entries: await hashOptionalDirectory(join(repoRoot, artifactPath)),
-      })),
-    ),
-  });
-}
-
-export async function buildTaskSourceFingerprint(tasksRoot, tasks) {
-  const taskEntries = [];
-  for (const task of tasks) {
-    taskEntries.push({
-      id: task.id,
-      path: resolve(task.path),
-      entries: await hashTaskDirectory(task.path),
-    });
-  }
-  return hashPayload({
-    kind: 'prompt-ab-task-source',
-    tasksRoot: resolve(tasksRoot),
-    tasks: taskEntries,
-  });
-}
-
-async function hashTaskDirectory(taskPath) {
-  const root = resolve(taskPath);
-  return await hashDirectory(root);
-}
-
-async function hashOptionalDirectory(path) {
-  try {
-    return await hashDirectory(resolve(path));
-  } catch (error) {
-    if (isNotFound(error)) return [{ path: '.', type: 'missing' }];
-    throw error;
-  }
-}
-
-async function hashDirectory(root) {
-  const entries = [];
-  await walkTaskDirectory(root, root, entries);
-  return entries;
-}
-
-async function walkTaskDirectory(root, dir, entries) {
-  const children = await readdir(dir, { withFileTypes: true });
-  children.sort((a, b) => a.name.localeCompare(b.name));
-  for (const child of children) {
-    const path = join(dir, child.name);
-    const stats = await lstat(path);
-    const entryPath = relative(root, path).split('\\').join('/');
-    if (child.isDirectory()) {
-      entries.push({ path: entryPath, type: 'directory' });
-      await walkTaskDirectory(root, path, entries);
-    } else if (child.isSymbolicLink()) {
-      throw new Error(
-        `task source symlink is not supported in prompt A/B fingerprints: ${entryPath} -> ${await readlink(path)}`,
-      );
-    } else if (child.isFile()) {
-      entries.push({
-        path: entryPath,
-        type: 'file',
-        executable: (stats.mode & 0o111) !== 0,
-        hash: hashBytes(await readFile(path)),
-      });
-    } else {
-      entries.push({ path: entryPath, type: 'other' });
-    }
-  }
-}
-
-function isNotFound(error) {
-  return error && typeof error === 'object' && 'code' in error && error.code === 'ENOENT';
 }
 
 async function main() {
@@ -397,7 +154,7 @@ async function main() {
     taskSourceFingerprint: await buildTaskSourceFingerprint(tasksRoot, evaluationTasks),
     toolchainFingerprint: await buildToolchainFingerprint(
       process.env.MAKA_PROMPT_AB_TOOLCHAIN_FINGERPRINT,
-      toolOutput,
+      undefined,
       makaRepoPath,
     ),
     evaluationTaskIds: evaluationTasks.map((task) => task.id),

--- a/packages/headless/harbor/run-prompt-control.mjs
+++ b/packages/headless/harbor/run-prompt-control.mjs
@@ -3,17 +3,12 @@
 // It does not run Docker/Harbor tasks. Outputs live under repo-local maka-eval.
 
 import { mkdir } from 'node:fs/promises';
-import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { envPath as parseEnvPath } from '#headless-run-env';
 import { runPromptControlExperiment } from '#prompt-control-run';
 
-function envPath(name, fallback) {
-  const raw = process.env[name];
-  const value = raw && raw.length > 0 ? raw : fallback;
-  if (!value) throw new Error(`${name} is required`);
-  return value.startsWith('~') ? join(homedir(), value.slice(1)) : resolve(value);
-}
+const envPath = (name, fallback) => parseEnvPath(name, process.env[name], fallback);
 
 function defaultLocalEvalRoot(repoRoot) {
   const marker = '/.worktree/';

--- a/packages/headless/harbor/run-prompt-optimization.mjs
+++ b/packages/headless/harbor/run-prompt-optimization.mjs
@@ -22,7 +22,12 @@ import { availableParallelism, homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '@maka/headless';
-import { discoverCachedHarborTasks, resolveFixedPromptRunRoot } from '#fixed-prompt-task-source';
+import {
+  discoverCachedHarborTasks,
+  resolveFixedPromptRunRoot,
+  selectTasksByIds,
+} from '#fixed-prompt-task-source';
+import { DEEPSEEK_V4_FLASH_PRICING } from '#deepseek-pricing';
 import {
   buildRewardHackVerifierPatterns,
   runPromptOptimizationRun,
@@ -31,7 +36,9 @@ import {
 import { renderPromptStructuralSmokeMarkdown } from '#prompt-structural-smoke';
 import {
   envFinitePositiveNumber,
+  envIds as parseEnvIds,
   envNonNegativeInt,
+  envPath as parseEnvPath,
   envPositiveInt,
   envRatio,
   resolveMinStable,
@@ -50,38 +57,6 @@ import {
 } from '#prompt-optimization-manifest';
 import { resolvePromptOptimizationProfile } from '#prompt-optimization-profile';
 
-// DeepSeek per-1M USD pricing (0.145 USD/CNY). "input" is the cache-miss rate;
-// cache writes carry no separate charge, so cacheWriteUsdPer1M is 0. Vendor
-// pricing lives here in the runner, not in @maka/headless: it is run config, not
-// part of the package's generic public API.
-const DEEPSEEK_V4_FLASH_PRICING = {
-  inputUsdPer1M: 0.145,
-  outputUsdPer1M: 0.29,
-  cacheReadUsdPer1M: 0.0029,
-  cacheWriteUsdPer1M: 0,
-  source: 'deepseek-v4-flash',
-};
-
-// This object is plain JS (no HarborTaskPricing type-check) and is no longer
-// pinned by a unit test, so a mistyped field name would leave a rate `undefined`
-// and the runner would silently emit wrong/zero costUsd. Fail loud at startup —
-// before any Docker time — if a canonical rate field is missing or not a finite,
-// non-negative number. The field-name -> MAKA_TRIAL_* forwarding contract is
-// covered in harbor-task-runner.test.ts.
-for (const field of [
-  'inputUsdPer1M',
-  'outputUsdPer1M',
-  'cacheReadUsdPer1M',
-  'cacheWriteUsdPer1M',
-]) {
-  const rate = DEEPSEEK_V4_FLASH_PRICING[field];
-  if (typeof rate !== 'number' || !Number.isFinite(rate) || rate < 0) {
-    throw new Error(
-      `DEEPSEEK_V4_FLASH_PRICING.${field} must be a finite, non-negative number (got ${JSON.stringify(rate)})`,
-    );
-  }
-}
-
 const PROGRAM = `You are improving ONE system prompt for autonomous Terminal-Bench coding agents.
 Given the current prompt, the latest held-in results, and recent failure digests,
 propose a single, conservative improvement that should raise the held-in pass rate
@@ -89,12 +64,7 @@ without overfitting. Do not reference specific task ids or expected outputs. Rep
 with exactly one JSON object {"systemPrompt": "...", "summary": "..."}.
 `;
 
-function envPath(name, fallback) {
-  const raw = process.env[name];
-  const value = raw && raw.length > 0 ? raw : fallback;
-  if (!value) throw new Error(`${name} is required`);
-  return value.startsWith('~') ? join(homedir(), value.slice(1)) : resolve(value);
-}
+const envPath = (name, fallback) => parseEnvPath(name, process.env[name], fallback);
 
 function defaultLocalEvalRoot(repoRoot) {
   const marker = '/.worktree/';
@@ -137,26 +107,7 @@ const envBool = (name, fallback) => {
 };
 
 // Comma-separated explicit task ids (controlled smokes). Empty -> undefined.
-function envIds(name) {
-  const raw = process.env[name];
-  if (!raw) return undefined;
-  const ids = raw
-    .split(',')
-    .map((s) => s.trim())
-    .filter((s) => s.length > 0);
-  return ids.length > 0 ? ids : undefined;
-}
-
-// Pick tasks by explicit id, preserving the requested order; throw on a
-// duplicate (would double-weight a task) or any unknown id.
-function selectTasksByIds(allTasks, ids) {
-  const duplicates = [...new Set(ids.filter((id, index) => ids.indexOf(id) !== index))];
-  if (duplicates.length > 0) throw new Error(`duplicate task id(s): ${duplicates.join(', ')}`);
-  const byId = new Map(allTasks.map((t) => [t.id, t]));
-  const missing = ids.filter((id) => !byId.has(id));
-  if (missing.length > 0) throw new Error(`unknown task id(s): ${missing.join(', ')}`);
-  return ids.map((id) => byId.get(id));
-}
+const envIds = (name) => parseEnvIds(process.env[name]);
 
 async function main() {
   const repoRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));

--- a/packages/headless/harbor/run-runtime-policy-ab.mjs
+++ b/packages/headless/harbor/run-runtime-policy-ab.mjs
@@ -7,8 +7,13 @@ import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '@maka/headless';
 import { ensureAbRunManifest } from '#ab-manifest';
-import { discoverCachedHarborTasks, resolveFixedPromptRunRoot } from '#fixed-prompt-task-source';
+import {
+  discoverCachedHarborTasks,
+  resolveFixedPromptRunRoot,
+  selectTasksByIds,
+} from '#fixed-prompt-task-source';
 import { createHarborTaskRunner } from '#harbor-task-runner';
+import { envPath as parseEnvPath } from '#headless-run-env';
 import { providerCredentialEnv } from '#provider-env';
 import { runRuntimePolicyAbLifecycle } from '#runtime-policy-ab-lifecycle';
 import { parseRuntimePolicyAbExecutionProfile } from '#runtime-policy-ab-profile';
@@ -21,21 +26,11 @@ import {
   buildSubjectFingerprint,
   buildTaskSourceFingerprint,
   buildToolchainFingerprint,
-} from './run-prompt-ab.mjs';
+} from '#experiment-fingerprint';
 
-function envPath(name, fallback) {
-  const raw = process.env[name] || fallback;
-  if (!raw) throw new Error(`${name} is required`);
-  return raw.startsWith('~') ? join(homedir(), raw.slice(1)) : resolve(raw);
-}
-
-function selectTasks(allTasks, taskIds, label) {
-  const byId = new Map(allTasks.map((task) => [task.id, task]));
-  const missing = taskIds.filter((id) => !byId.has(id));
-  if (missing.length > 0)
-    throw new Error(`${label} contains unknown task id(s): ${missing.join(', ')}`);
-  return taskIds.map((id) => byId.get(id));
-}
+const envPath = (name, fallback) => parseEnvPath(name, process.env[name], fallback);
+const selectTasks = (allTasks, taskIds, label) =>
+  selectTasksByIds(allTasks, taskIds, { label, rejectDuplicates: false });
 
 async function main() {
   const repoRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)));

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -26,6 +26,8 @@
   "imports": {
     "#fixed-prompt-task-source": "./dist/fixed-prompt-task-source.js",
     "#headless-run-env": "./dist/headless-run-env.js",
+    "#experiment-fingerprint": "./dist/experiment-fingerprint.js",
+    "#deepseek-pricing": "./dist/deepseek-pricing.js",
     "#prompt-optimization-env": "./dist/prompt-optimization-env.js",
     "#prompt-optimization-bootstrap": "./dist/prompt-optimization-bootstrap.js",
     "#prompt-optimization-manifest": "./dist/prompt-optimization-manifest.js",

--- a/packages/headless/src/__tests__/fixed-prompt-task-source.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-task-source.test.ts
@@ -6,6 +6,7 @@ import { test } from 'node:test';
 import {
   fingerprintFixedPromptTask,
   fingerprintFixedPromptTaskTree,
+  selectTasksByIds,
 } from '../fixed-prompt-task-source.js';
 
 test('task tree fingerprint is root-independent and content-sensitive', async () => {
@@ -50,4 +51,58 @@ test('per-task fingerprint is unaffected by another task changing', async () => 
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+test('selectTasksByIds preserves the requested order and returns the matching tasks', () => {
+  const tasks = [
+    { id: 'task-a', path: '/tasks/task-a' },
+    { id: 'task-b', path: '/tasks/task-b' },
+    { id: 'task-c', path: '/tasks/task-c' },
+  ];
+
+  const selected = selectTasksByIds(tasks, ['task-c', 'task-a']);
+
+  assert.deepEqual(
+    selected,
+    [tasks[2], tasks[0]],
+    'selection must follow the requested id order, not discovery order',
+  );
+});
+
+test('selectTasksByIds rejects duplicate ids by default with the exact message', () => {
+  const tasks = [
+    { id: 'task-a', path: '/tasks/task-a' },
+    { id: 'task-b', path: '/tasks/task-b' },
+  ];
+
+  assert.throws(
+    () => selectTasksByIds(tasks, ['task-a', 'task-b', 'task-a']),
+    new Error('duplicate task id(s): task-a'),
+  );
+});
+
+test('selectTasksByIds passes duplicates through when rejectDuplicates is false', () => {
+  const tasks = [{ id: 'task-a', path: '/tasks/task-a' }];
+
+  const selected = selectTasksByIds(tasks, ['task-a', 'task-a'], { rejectDuplicates: false });
+
+  assert.deepEqual(selected, [tasks[0], tasks[0]]);
+});
+
+test('selectTasksByIds reports unknown ids with the exact unlabeled message', () => {
+  const tasks = [{ id: 'task-a', path: '/tasks/task-a' }];
+
+  assert.throws(
+    () => selectTasksByIds(tasks, ['task-a', 'nope', 'missing']),
+    new Error('unknown task id(s): nope, missing'),
+  );
+});
+
+test('selectTasksByIds prefixes the unknown-id message with the caller label', () => {
+  const tasks = [{ id: 'task-a', path: '/tasks/task-a' }];
+
+  assert.throws(
+    () => selectTasksByIds(tasks, ['nope'], { label: 'pilotTaskIds', rejectDuplicates: false }),
+    new Error('pilotTaskIds contains unknown task id(s): nope'),
+  );
 });

--- a/packages/headless/src/__tests__/headless-run-env-paths.test.ts
+++ b/packages/headless/src/__tests__/headless-run-env-paths.test.ts
@@ -1,0 +1,46 @@
+import assert from 'node:assert/strict';
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { describe, test } from 'node:test';
+import { envIds, envPath } from '../headless-run-env.js';
+
+describe('envPath', () => {
+  test('expands a leading tilde against the home directory', () => {
+    assert.equal(envPath('MAKA_TEST_PATH', '~/x/y'), join(homedir(), '/x/y'));
+  });
+
+  test('resolves a relative value against the current working directory', () => {
+    assert.equal(envPath('MAKA_TEST_PATH', 'relative/dir'), resolve('relative/dir'));
+  });
+
+  test('keeps an absolute value as-is (normalized)', () => {
+    assert.equal(envPath('MAKA_TEST_PATH', '/tmp/maka-out'), resolve('/tmp/maka-out'));
+  });
+
+  test('falls back when the raw value is unset or empty', () => {
+    assert.equal(envPath('MAKA_TEST_PATH', undefined, '/tmp/fallback'), resolve('/tmp/fallback'));
+    assert.equal(envPath('MAKA_TEST_PATH', '', '/tmp/fallback'), resolve('/tmp/fallback'));
+    assert.equal(envPath('MAKA_TEST_PATH', '', '~/fallback'), join(homedir(), '/fallback'));
+  });
+
+  test('throws with the env var name when neither value nor fallback is present', () => {
+    assert.throws(() => envPath('MAKA_TEST_PATH', undefined), /MAKA_TEST_PATH is required/);
+    assert.throws(() => envPath('MAKA_TEST_PATH', ''), /MAKA_TEST_PATH is required/);
+  });
+});
+
+describe('envIds', () => {
+  test('splits on commas, trims entries, and drops empty segments', () => {
+    assert.deepEqual(envIds(' task-a , task-b ,, task-c,'), ['task-a', 'task-b', 'task-c']);
+  });
+
+  test('preserves duplicates and order for the caller to police', () => {
+    assert.deepEqual(envIds('b,a,b'), ['b', 'a', 'b']);
+  });
+
+  test('returns undefined for unset, empty, or all-blank input', () => {
+    assert.equal(envIds(undefined), undefined);
+    assert.equal(envIds(''), undefined);
+    assert.equal(envIds(' , , '), undefined);
+  });
+});

--- a/packages/headless/src/__tests__/prompt-ab-fingerprints.test.ts
+++ b/packages/headless/src/__tests__/prompt-ab-fingerprints.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
-import { mkdir, symlink, writeFile } from 'node:fs/promises';
-import { join } from 'node:path';
+import { createHash } from 'node:crypto';
+import { chmod, lstat, mkdir, readFile, readdir, symlink, writeFile } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
 import { describe, test } from 'node:test';
 import {
   buildSubjectFingerprint,
@@ -156,3 +157,200 @@ describe('prompt A/B source fingerprints', () => {
     });
   });
 });
+
+// Byte-contract pin for the resume-critical fingerprint trio. The tests above
+// only assert that input changes change the hash; these bind the exact output
+// bytes. `legacyFingerprintOracle` is a frozen, verbatim port of the hashing
+// algorithm as it lived in run-prompt-ab.mjs before the helpers moved to
+// experiment-fingerprint.ts — do NOT refactor it to share code with the module
+// under test, and do not update it: if these assertions ever fail, the module
+// changed resume identity for every prior A/B run.
+describe('experiment fingerprint byte contract', () => {
+  test('explicit subject fingerprint hashes to the pinned constant', async () => {
+    assert.equal(
+      await buildSubjectFingerprint('/repo', `sha256:${'a'.repeat(64)}`, async () => {
+        throw new Error('git must not be consulted for an explicit subject fingerprint');
+      }),
+      'sha256:bb02d53e06206262747388edea9ae81725b62498f074ef6d2fbce6639b5d36f3',
+    );
+  });
+
+  test('subject, toolchain, and task-source fingerprints match the frozen legacy algorithm', async () => {
+    await withDir(async (dir) => {
+      // Deterministic fixture: a fake repo with one present dist artifact (the
+      // other three dist roots are missing), a dependency lock pair, and a task
+      // directory with a Dockerfile plus an executable nested script.
+      const repo = join(dir, 'repo');
+      await mkdir(join(repo, 'packages/headless/dist'), { recursive: true });
+      await writeFile(
+        join(repo, 'packages/headless/dist/harbor-cell.js'),
+        'export const version = 1;\n',
+        'utf8',
+      );
+      await writeFile(
+        join(repo, 'package-lock.json'),
+        '{"lockfileVersion":3,"packages":{}}\n',
+        'utf8',
+      );
+      await mkdir(join(repo, 'node_modules'), { recursive: true });
+      await writeFile(
+        join(repo, 'node_modules/.package-lock.json'),
+        '{"lockfileVersion":3,"packages":{"node_modules/ai":{"version":"6.0.185"}}}\n',
+        'utf8',
+      );
+      const tasksRoot = join(dir, 'tasks');
+      const taskPath = join(tasksRoot, 'task-a');
+      await mkdir(join(taskPath, 'scripts'), { recursive: true });
+      await writeFile(join(taskPath, 'task.toml'), 'id = "task-a"\n', 'utf8');
+      await writeFile(join(taskPath, 'Dockerfile'), 'FROM ubuntu:24.04\n', 'utf8');
+      await writeFile(join(taskPath, 'scripts/run.sh'), '#!/bin/sh\nexit 0\n', 'utf8');
+      await chmod(join(taskPath, 'scripts/run.sh'), 0o755);
+
+      const git = async (_repoPath: string, args: readonly string[]): Promise<string> => {
+        const command = args.join(' ');
+        if (command === 'rev-parse --show-toplevel') return repo;
+        if (command === 'rev-parse HEAD') return 'abc123';
+        if (command === 'status --porcelain=v1 --untracked-files=normal') return '';
+        throw new Error(`unexpected git command: ${command}`);
+      };
+      const tool = async () => 'harbor 9.9.9';
+      const oracle = legacyFingerprintOracle();
+
+      assert.equal(
+        await buildSubjectFingerprint(repo, undefined, git),
+        await oracle.subject(repo, git),
+      );
+      assert.equal(
+        await buildToolchainFingerprint(undefined, tool, repo),
+        await oracle.toolchain(tool, repo),
+      );
+      assert.equal(
+        await buildTaskSourceFingerprint(tasksRoot, [{ id: 'task-a', path: taskPath }]),
+        await oracle.taskSource(tasksRoot, [{ id: 'task-a', path: taskPath }]),
+      );
+    });
+  });
+});
+
+/** Frozen verbatim port of the pre-refactor run-prompt-ab.mjs hashing helpers. */
+function legacyFingerprintOracle() {
+  type Entry = Record<string, string | boolean>;
+  const hashBytes = (bytes: Buffer) => `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+  const canonicalJson = (value: unknown): string => {
+    if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+    if (value && typeof value === 'object') {
+      const entries = Object.entries(value)
+        .filter(([, entryValue]) => entryValue !== undefined)
+        .sort(([a], [b]) => a.localeCompare(b));
+      return `{${entries.map(([key, entryValue]) => `${JSON.stringify(key)}:${canonicalJson(entryValue)}`).join(',')}}`;
+    }
+    return JSON.stringify(value);
+  };
+  const hashPayload = (payload: unknown) =>
+    `sha256:${createHash('sha256').update(canonicalJson(payload)).digest('hex')}`;
+  const walk = async (root: string, dir: string, entries: Entry[]): Promise<void> => {
+    const children = await readdir(dir, { withFileTypes: true });
+    children.sort((a, b) => a.name.localeCompare(b.name));
+    for (const child of children) {
+      const path = join(dir, child.name);
+      const stats = await lstat(path);
+      const entryPath = relative(root, path).split('\\').join('/');
+      if (child.isDirectory()) {
+        entries.push({ path: entryPath, type: 'directory' });
+        await walk(root, path, entries);
+      } else if (child.isSymbolicLink()) {
+        throw new Error(`unexpected symlink in oracle fixture: ${entryPath}`);
+      } else if (child.isFile()) {
+        entries.push({
+          path: entryPath,
+          type: 'file',
+          executable: (stats.mode & 0o111) !== 0,
+          hash: hashBytes(await readFile(path)),
+        });
+      } else {
+        entries.push({ path: entryPath, type: 'other' });
+      }
+    }
+  };
+  const hashDirectory = async (root: string): Promise<Entry[]> => {
+    const entries: Entry[] = [];
+    await walk(root, root, entries);
+    return entries;
+  };
+  const hashOptionalDirectory = async (path: string): Promise<Entry[]> => {
+    try {
+      return await hashDirectory(resolve(path));
+    } catch (error) {
+      if ((error as { code?: unknown }).code === 'ENOENT') return [{ path: '.', type: 'missing' }];
+      throw error;
+    }
+  };
+  const runtimeArtifacts = async (repoRoot: string) =>
+    hashPayload({
+      kind: 'prompt-ab-runtime-artifacts',
+      artifacts: await Promise.all(
+        [
+          'packages/headless/dist',
+          'packages/core/dist',
+          'packages/runtime/dist',
+          'packages/storage/dist',
+        ].map(async (artifactPath) => ({
+          path: artifactPath,
+          entries: await hashOptionalDirectory(join(repoRoot, artifactPath)),
+        })),
+      ),
+    });
+  return {
+    subject: async (
+      repoPath: string,
+      git: (repoPath: string, args: readonly string[]) => Promise<string>,
+    ) => {
+      const [gitRoot, head, status] = await Promise.all([
+        git(repoPath, ['rev-parse', '--show-toplevel']),
+        git(repoPath, ['rev-parse', 'HEAD']),
+        git(repoPath, ['status', '--porcelain=v1', '--untracked-files=normal']),
+      ]);
+      return hashPayload({
+        kind: 'prompt-ab-subject',
+        path: resolve(repoPath),
+        gitRoot: resolve(gitRoot),
+        head,
+        dirty: false,
+        statusHash: hashPayload({ status }),
+        runtimeArtifactFingerprint: await runtimeArtifacts(gitRoot),
+      });
+    },
+    toolchain: async (tool: () => Promise<string>, repoPath: string) => {
+      const [packageLock, installedLock] = await Promise.all([
+        readFile(join(repoPath, 'package-lock.json')),
+        readFile(join(repoPath, 'node_modules/.package-lock.json')),
+      ]);
+      return hashPayload({
+        kind: 'prompt-ab-toolchain',
+        node: process.version,
+        harborVersion: await tool(),
+        dependencyInstallFingerprint: {
+          packageLockPath: resolve(join(repoPath, 'package-lock.json')),
+          packageLockHash: hashBytes(packageLock),
+          installedPackageLockPath: resolve(join(repoPath, 'node_modules/.package-lock.json')),
+          installedPackageLockHash: hashBytes(installedLock),
+        },
+      });
+    },
+    taskSource: async (tasksRoot: string, tasks: ReadonlyArray<{ id: string; path: string }>) => {
+      const taskEntries = [];
+      for (const task of tasks) {
+        taskEntries.push({
+          id: task.id,
+          path: resolve(task.path),
+          entries: await hashDirectory(resolve(task.path)),
+        });
+      }
+      return hashPayload({
+        kind: 'prompt-ab-task-source',
+        tasksRoot: resolve(tasksRoot),
+        tasks: taskEntries,
+      });
+    },
+  };
+}

--- a/packages/headless/src/__tests__/prompt-ab-fingerprints.test.ts
+++ b/packages/headless/src/__tests__/prompt-ab-fingerprints.test.ts
@@ -2,14 +2,16 @@ import assert from 'node:assert/strict';
 import { mkdir, symlink, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
+import {
+  buildSubjectFingerprint,
+  buildTaskSourceFingerprint,
+  buildToolchainFingerprint,
+} from '../experiment-fingerprint.js';
 import { sha256 } from './helpers/hash-fixture.js';
 import { withDir } from './helpers/temp-dir.js';
 
-const promptAbScriptUrl = new URL('../../harbor/run-prompt-ab.mjs', import.meta.url).href;
-
 describe('prompt A/B source fingerprints', () => {
   test('rejects dirty subject repos unless an explicit subject fingerprint is provided', async () => {
-    const { buildSubjectFingerprint } = await import(promptAbScriptUrl);
     const gitWithStatus =
       (status: string) =>
       async (_repoPath: string, args: readonly string[]): Promise<string> => {
@@ -38,8 +40,6 @@ describe('prompt A/B source fingerprints', () => {
   });
 
   test('builds a toolchain fingerprint from Node and Harbor identity unless explicit', async () => {
-    const { buildToolchainFingerprint } = await import(promptAbScriptUrl);
-
     await withDir(async (dir) => {
       await writeFile(
         join(dir, 'package-lock.json'),
@@ -81,7 +81,6 @@ describe('prompt A/B source fingerprints', () => {
   });
 
   test('requires an installed dependency lock unless the toolchain fingerprint is explicit', async () => {
-    const { buildToolchainFingerprint } = await import(promptAbScriptUrl);
     await withDir(async (dir) => {
       await writeFile(
         join(dir, 'package-lock.json'),
@@ -101,7 +100,6 @@ describe('prompt A/B source fingerprints', () => {
   });
 
   test('includes runtime dist artifacts in the subject fingerprint', async () => {
-    const { buildSubjectFingerprint } = await import(promptAbScriptUrl);
     await withDir(async (dir) => {
       const repo = join(dir, 'repo');
       const distFile = join(repo, 'packages/headless/dist/harbor-cell.js');
@@ -124,7 +122,6 @@ describe('prompt A/B source fingerprints', () => {
   });
 
   test('hashes non-task.toml files inside selected task directories', async () => {
-    const { buildTaskSourceFingerprint } = await import(promptAbScriptUrl);
     await withDir(async (dir) => {
       const tasksRoot = join(dir, 'tasks');
       const taskPath = join(tasksRoot, 'task-a');
@@ -143,7 +140,6 @@ describe('prompt A/B source fingerprints', () => {
   });
 
   test('rejects symlinks inside selected task directories', async () => {
-    const { buildTaskSourceFingerprint } = await import(promptAbScriptUrl);
     await withDir(async (dir) => {
       const tasksRoot = join(dir, 'tasks');
       const taskPath = join(tasksRoot, 'task-a');

--- a/packages/headless/src/deepseek-pricing.ts
+++ b/packages/headless/src/deepseek-pricing.ts
@@ -1,0 +1,39 @@
+/**
+ * DeepSeek per-1M USD pricing (0.145 USD/CNY) shared by the DeepSeek A/B and
+ * RSI prompt-optimization run scripts. "input" is the cache-miss rate; cache
+ * writes carry no separate charge, so `cacheWriteUsdPer1M` is 0. This is vendor
+ * run config, not part of the generic `@maka/headless` public API, so it is
+ * imported via a package-local `#deepseek-pricing` subpath and is not
+ * re-exported from `index.ts`.
+ *
+ * The object is a plain constant with no per-run unit test pinning it, so a
+ * mistyped field name would leave a rate `undefined` and the runner would
+ * silently emit wrong/zero `costUsd`. Fail loud at import — before any Docker
+ * time — if a canonical rate field is missing or is not a finite, non-negative
+ * number. The field-name -> MAKA_TRIAL_* forwarding contract is covered in
+ * harbor-task-runner.test.ts.
+ */
+
+import type { HarborTaskPricing } from './harbor-task-runner.js';
+
+export const DEEPSEEK_V4_FLASH_PRICING: HarborTaskPricing = {
+  inputUsdPer1M: 0.145,
+  outputUsdPer1M: 0.29,
+  cacheReadUsdPer1M: 0.0029,
+  cacheWriteUsdPer1M: 0,
+  source: 'deepseek-v4-flash',
+};
+
+for (const field of [
+  'inputUsdPer1M',
+  'outputUsdPer1M',
+  'cacheReadUsdPer1M',
+  'cacheWriteUsdPer1M',
+] as const) {
+  const rate = DEEPSEEK_V4_FLASH_PRICING[field];
+  if (typeof rate !== 'number' || !Number.isFinite(rate) || rate < 0) {
+    throw new Error(
+      `DEEPSEEK_V4_FLASH_PRICING.${field} must be a finite, non-negative number (got ${JSON.stringify(rate)})`,
+    );
+  }
+}

--- a/packages/headless/src/experiment-fingerprint.ts
+++ b/packages/headless/src/experiment-fingerprint.ts
@@ -1,0 +1,267 @@
+/**
+ * Resume-safe experiment fingerprints shared by the Harbor A/B run scripts
+ * (`run-prompt-ab`, `run-harness-ab`, `run-runtime-policy-ab`). The three
+ * fingerprints — subject (the maka checkout under test), toolchain (Node +
+ * Harbor + installed dependency lock), and task source (the selected task
+ * directories) — feed the A/B run manifest, whose fingerprint gates resume in
+ * `ensureAbRunManifest`. The bytes hashed here are therefore load-bearing: any
+ * change to the payload shape or `kind` tags would change every prior run's
+ * resume identity. This module is a straight promotion of the helpers that used
+ * to live in `run-prompt-ab.mjs`; keep it byte-identical.
+ *
+ * The prompt-optimization runner keeps its own, deliberately distinct
+ * fingerprints in `prompt-optimization-manifest.ts` (different `kind` tags,
+ * held-in/held-out task split, git-based toolchain). They are not merged here
+ * because doing so would change prompt-optimization resume identity.
+ */
+
+import { execFile as execFileCallback } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { lstat, readFile, readdir, readlink } from 'node:fs/promises';
+import { join, relative, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import { buildRunManifestFingerprint } from './ab-manifest.js';
+import type { FixedPromptTask } from './fixed-prompt-controller.js';
+
+const execFile = promisify(execFileCallback);
+
+type ReadGitOutput = (repoPath: string, args: readonly string[]) => Promise<string>;
+type ReadToolOutput = (command: string, args: readonly string[]) => Promise<string>;
+
+interface TaskDirectoryEntry {
+  path: string;
+  type: 'directory' | 'file' | 'other' | 'missing';
+  executable?: boolean;
+  hash?: string;
+}
+
+function hashBytes(bytes: Buffer): string {
+  return `sha256:${createHash('sha256').update(bytes).digest('hex')}`;
+}
+
+/** Canonical-JSON sha256 of a payload. Identical to the A/B run manifest
+ * fingerprint, reused so the two never drift. */
+function hashPayload(payload: unknown): string {
+  return buildRunManifestFingerprint(payload);
+}
+
+async function gitOutput(repoPath: string, args: readonly string[]): Promise<string> {
+  const { stdout } = await execFile('git', ['-C', repoPath, ...args], {
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024,
+  });
+  return stdout.trimEnd();
+}
+
+function isSha256Fingerprint(value: string): boolean {
+  return /^sha256:[a-f0-9]{64}$/.test(value);
+}
+
+async function toolOutput(command: string, args: readonly string[]): Promise<string> {
+  const { stdout, stderr } = await execFile(command, [...args], {
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024,
+  });
+  return `${stdout}${stderr}`.trim();
+}
+
+async function buildInstalledDependencyFingerprint(repoPath: string): Promise<{
+  packageLockPath: string;
+  packageLockHash: string;
+  installedPackageLockPath: string;
+  installedPackageLockHash: string;
+}> {
+  const packageLockPath = join(repoPath, 'package-lock.json');
+  const installedLockPath = join(repoPath, 'node_modules/.package-lock.json');
+  let packageLock: Buffer;
+  let installedLock: Buffer;
+  try {
+    [packageLock, installedLock] = await Promise.all([
+      readFile(packageLockPath),
+      readFile(installedLockPath),
+    ]);
+  } catch (error) {
+    throw new Error(
+      `prompt A/B toolchain fingerprint requires ${packageLockPath} and ${installedLockPath}. Run npm install in MAKA_PROMPT_AB_MAKA_REPO, or set MAKA_PROMPT_AB_TOOLCHAIN_FINGERPRINT to an explicit sha256:<64 lowercase hex> dependency snapshot. Cause: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  return {
+    packageLockPath: resolve(packageLockPath),
+    packageLockHash: hashBytes(packageLock),
+    installedPackageLockPath: resolve(installedLockPath),
+    installedPackageLockHash: hashBytes(installedLock),
+  };
+}
+
+export async function buildToolchainFingerprint(
+  explicitToolchainFingerprint: string | undefined,
+  readToolOutput: ReadToolOutput = toolOutput,
+  repoPath: string = resolve(fileURLToPath(new URL('../../..', import.meta.url))),
+): Promise<string> {
+  if (explicitToolchainFingerprint && explicitToolchainFingerprint.trim().length > 0) {
+    const value = explicitToolchainFingerprint.trim();
+    if (!isSha256Fingerprint(value)) {
+      throw new Error(
+        'MAKA_PROMPT_AB_TOOLCHAIN_FINGERPRINT must be a sha256:<64 lowercase hex> content fingerprint',
+      );
+    }
+    return value;
+  }
+  let harborVersion: string;
+  try {
+    harborVersion = await readToolOutput('harbor', ['--version']);
+  } catch (error) {
+    harborVersion = `unavailable:${error instanceof Error ? error.message : String(error)}`;
+  }
+  return hashPayload({
+    kind: 'prompt-ab-toolchain',
+    node: process.version,
+    harborVersion,
+    dependencyInstallFingerprint: await buildInstalledDependencyFingerprint(repoPath),
+  });
+}
+
+export async function buildSubjectFingerprint(
+  repoPath: string,
+  explicitSubjectFingerprint: string | undefined,
+  readGitOutput: ReadGitOutput = gitOutput,
+): Promise<string> {
+  if (explicitSubjectFingerprint && explicitSubjectFingerprint.trim().length > 0) {
+    const value = explicitSubjectFingerprint.trim();
+    if (!isSha256Fingerprint(value)) {
+      throw new Error(
+        'MAKA_PROMPT_AB_EXPLICIT_SUBJECT_FINGERPRINT must be a sha256:<64 lowercase hex> content fingerprint',
+      );
+    }
+    return hashPayload({
+      kind: 'prompt-ab-subject',
+      explicitSubjectFingerprint: value,
+    });
+  }
+  let gitRoot: string;
+  let head: string;
+  let status: string;
+  try {
+    [gitRoot, head, status] = await Promise.all([
+      readGitOutput(repoPath, ['rev-parse', '--show-toplevel']),
+      readGitOutput(repoPath, ['rev-parse', 'HEAD']),
+      readGitOutput(repoPath, ['status', '--porcelain=v1', '--untracked-files=normal']),
+    ]);
+  } catch (error) {
+    throw new Error(
+      `MAKA_PROMPT_AB_MAKA_REPO must be a git checkout or MAKA_PROMPT_AB_EXPLICIT_SUBJECT_FINGERPRINT must be set: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+  if (status.length > 0) {
+    throw new Error(
+      `MAKA_PROMPT_AB_MAKA_REPO must be clean for resume-safe prompt A/B runs. Commit/stash the changes, or set MAKA_PROMPT_AB_EXPLICIT_SUBJECT_FINGERPRINT to an explicit content fingerprint. Dirty git status:\n${status}`,
+    );
+  }
+  return hashPayload({
+    kind: 'prompt-ab-subject',
+    path: resolve(repoPath),
+    gitRoot: resolve(gitRoot),
+    head,
+    dirty: false,
+    statusHash: hashPayload({ status }),
+    runtimeArtifactFingerprint: await buildRuntimeArtifactFingerprint(gitRoot),
+  });
+}
+
+async function buildRuntimeArtifactFingerprint(repoRoot: string): Promise<string> {
+  const artifactRoots = [
+    'packages/headless/dist',
+    'packages/core/dist',
+    'packages/runtime/dist',
+    'packages/storage/dist',
+  ];
+  return hashPayload({
+    kind: 'prompt-ab-runtime-artifacts',
+    artifacts: await Promise.all(
+      artifactRoots.map(async (artifactPath) => ({
+        path: artifactPath,
+        entries: await hashOptionalDirectory(join(repoRoot, artifactPath)),
+      })),
+    ),
+  });
+}
+
+export async function buildTaskSourceFingerprint(
+  tasksRoot: string,
+  tasks: readonly Pick<FixedPromptTask, 'id' | 'path'>[],
+): Promise<string> {
+  const taskEntries = [];
+  for (const task of tasks) {
+    taskEntries.push({
+      id: task.id,
+      path: resolve(task.path),
+      entries: await hashTaskDirectory(task.path),
+    });
+  }
+  return hashPayload({
+    kind: 'prompt-ab-task-source',
+    tasksRoot: resolve(tasksRoot),
+    tasks: taskEntries,
+  });
+}
+
+async function hashTaskDirectory(taskPath: string): Promise<TaskDirectoryEntry[]> {
+  const root = resolve(taskPath);
+  return await hashDirectory(root);
+}
+
+async function hashOptionalDirectory(path: string): Promise<TaskDirectoryEntry[]> {
+  try {
+    return await hashDirectory(resolve(path));
+  } catch (error) {
+    if (isNotFound(error)) return [{ path: '.', type: 'missing' }];
+    throw error;
+  }
+}
+
+async function hashDirectory(root: string): Promise<TaskDirectoryEntry[]> {
+  const entries: TaskDirectoryEntry[] = [];
+  await walkTaskDirectory(root, root, entries);
+  return entries;
+}
+
+async function walkTaskDirectory(
+  root: string,
+  dir: string,
+  entries: TaskDirectoryEntry[],
+): Promise<void> {
+  const children = await readdir(dir, { withFileTypes: true });
+  children.sort((a, b) => a.name.localeCompare(b.name));
+  for (const child of children) {
+    const path = join(dir, child.name);
+    const stats = await lstat(path);
+    const entryPath = relative(root, path).split('\\').join('/');
+    if (child.isDirectory()) {
+      entries.push({ path: entryPath, type: 'directory' });
+      await walkTaskDirectory(root, path, entries);
+    } else if (child.isSymbolicLink()) {
+      throw new Error(
+        `task source symlink is not supported in prompt A/B fingerprints: ${entryPath} -> ${await readlink(path)}`,
+      );
+    } else if (child.isFile()) {
+      entries.push({
+        path: entryPath,
+        type: 'file',
+        executable: (stats.mode & 0o111) !== 0,
+        hash: hashBytes(await readFile(path)),
+      });
+    } else {
+      entries.push({ path: entryPath, type: 'other' });
+    }
+  }
+}
+
+function isNotFound(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    (error as { code?: unknown }).code === 'ENOENT'
+  );
+}

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -56,7 +56,16 @@ export interface HarborVerifierOutcome {
   attempts: HarborVerifierAttempt[];
 }
 
-export interface HarborTaskRunOutput {
+/**
+ * The provider-neutral seam the fixed-prompt controller and A/B schedulers
+ * consume: run one task attempt and return its reward plus cell artifacts. The
+ * Harbor implementation (`createHarborTaskRunner`) is the first and, today, only
+ * implementation; a Pier implementation lands later under its own issue and
+ * satisfies the same interface. The output still carries a Harbor-shaped
+ * `harbor` field; generalizing that payload is deferred until a second
+ * implementation actually needs it.
+ */
+export interface TaskRunOutput {
   harbor: {
     reward: number;
     verifierFailureSummary?: string;
@@ -65,7 +74,7 @@ export interface HarborTaskRunOutput {
   cell: HarborTaskRunCellOutput;
 }
 
-export interface HarborTaskRunInput {
+export interface TaskRunInput {
   runId: string;
   roundId: string;
   task: FixedPromptTask;
@@ -74,9 +83,16 @@ export interface HarborTaskRunInput {
   agentEnv?: Record<string, string>;
 }
 
-export interface HarborTaskRunner {
-  (input: HarborTaskRunInput): Promise<HarborTaskRunOutput>;
+export interface TaskRunner {
+  (input: TaskRunInput): Promise<TaskRunOutput>;
 }
+
+/** @deprecated Harbor-named alias retained for existing call sites; use `TaskRunInput`. */
+export type HarborTaskRunInput = TaskRunInput;
+/** @deprecated Harbor-named alias retained for existing call sites; use `TaskRunOutput`. */
+export type HarborTaskRunOutput = TaskRunOutput;
+/** @deprecated Harbor-named alias retained for existing call sites; use `TaskRunner`. */
+export type HarborTaskRunner = TaskRunner;
 
 export interface FixedPromptBudgetExhaustedArtifactRefs {
   runtimeEventsPath?: string;
@@ -378,7 +394,7 @@ export interface RunFixedPromptControllerInput {
   /** Refuse resume when a model attempt was durably admitted but no terminal
    * event exists, preserving single-sample benchmark semantics. */
   protectPassAtOne?: boolean;
-  harborRunner: HarborTaskRunner;
+  harborRunner: TaskRunner;
   now?: () => number;
   newId?: () => string;
 }

--- a/packages/headless/src/fixed-prompt-task-source.ts
+++ b/packages/headless/src/fixed-prompt-task-source.ts
@@ -54,6 +54,32 @@ export async function discoverCachedHarborTasks(
   return [...byId.values()].sort((a, b) => a.id.localeCompare(b.id));
 }
 
+/**
+ * Pick tasks by explicit id, preserving the requested order. Throws on an
+ * unknown id (and, unless `rejectDuplicates` is false, on a duplicate id that
+ * would double-weight a task). `label` scopes the unknown-id error message for
+ * callers that select from more than one named id list.
+ */
+export function selectTasksByIds<T extends { id: string }>(
+  allTasks: readonly T[],
+  ids: readonly string[],
+  options: { label?: string; rejectDuplicates?: boolean } = {},
+): T[] {
+  const { label, rejectDuplicates = true } = options;
+  if (rejectDuplicates) {
+    const duplicates = [...new Set(ids.filter((id, index) => ids.indexOf(id) !== index))];
+    if (duplicates.length > 0) throw new Error(`duplicate task id(s): ${duplicates.join(', ')}`);
+  }
+  const byId = new Map(allTasks.map((task) => [task.id, task]));
+  const missing = ids.filter((id) => !byId.has(id));
+  if (missing.length > 0) {
+    throw new Error(
+      `${label ? `${label} contains ` : ''}unknown task id(s): ${missing.join(', ')}`,
+    );
+  }
+  return ids.map((id) => byId.get(id)!);
+}
+
 export async function fingerprintFixedPromptTaskTree(
   tasks: readonly FixedPromptTask[],
 ): Promise<string> {

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -21,9 +21,9 @@ import {
 import {
   FixedPromptBudgetExhaustedError,
   type FixedPromptBudgetExhaustedError as FixedPromptBudgetExhaustedErrorType,
-  HarborTaskRunInput,
-  HarborTaskRunOutput,
-  HarborTaskRunner,
+  type TaskRunInput,
+  type TaskRunOutput,
+  type TaskRunner,
   type HarborVerifierAttempt,
   type HarborVerifierOutcome,
 } from './fixed-prompt-controller.js';
@@ -182,7 +182,7 @@ export interface HarborOracleQualifierOptions {
 }
 
 export type HarborOracleQualifier = (
-  task: HarborTaskRunInput['task'],
+  task: TaskRunInput['task'],
 ) => Promise<HarnessOracleTaskResult>;
 
 const EXPERIMENT_IDENTITY_ENV_KEYS = new Set([
@@ -200,7 +200,7 @@ const EXPERIMENT_IDENTITY_ENV_KEYS = new Set([
   'MAKA_TRIAL_PRICING_SOURCE',
 ]);
 
-export function createHarborTaskRunner(options: HarborTaskRunnerOptions): HarborTaskRunner {
+export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRunner {
   const runHarbor = options.runHarbor ?? defaultHarborProcessRunner;
   const harborBin = options.harborBin ?? 'harbor';
   // The bare local adapter import paths resolve only when the adapter
@@ -209,9 +209,7 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): Harbor
   const harborAdapterDir = join(options.makaRepoPath, 'packages', 'headless', 'harbor');
   const pythonPath = [harborAdapterDir, process.env.PYTHONPATH].filter(Boolean).join(delimiter);
 
-  const runner: HarborTaskRunner = async (
-    input: HarborTaskRunInput,
-  ): Promise<HarborTaskRunOutput> => {
+  const runner: TaskRunner = async (input: TaskRunInput): Promise<TaskRunOutput> => {
     const jobsDir = join(
       options.jobsDir,
       sanitize(input.runId),
@@ -548,17 +546,14 @@ function assertVerifierRewardAgreement(
   }
 }
 
-function resolveHarborTimeoutMs(
-  options: HarborTaskRunnerOptions,
-  input: HarborTaskRunInput,
-): number {
+function resolveHarborTimeoutMs(options: HarborTaskRunnerOptions, input: TaskRunInput): number {
   if (options.harborTimeoutMs !== undefined) return options.harborTimeoutMs;
   return resolveNativeHarborTimeoutMs(options, input.task);
 }
 
 function resolveNativeHarborTimeoutMs(
   options: Pick<HarborTaskRunnerOptions, 'timeoutMultiplier'>,
-  task: HarborTaskRunInput['task'],
+  task: TaskRunInput['task'],
 ): number {
   const agentSec = task.metadata?.agentTimeoutSec ?? 0;
   const verifierSec = verifierPolicy(task).outerTimeoutSec;
@@ -814,7 +809,7 @@ function mergeAgentEnv(
 }
 
 export function buildHarborJobConfig(
-  input: HarborTaskRunInput,
+  input: TaskRunInput,
   options: HarborTaskRunnerOptions & { jobsDir: string; jobName: string },
 ): Record<string, unknown> {
   const attemptAgentEnv = mergeAgentEnv(options.agentEnv, input.agentEnv);
@@ -1010,7 +1005,7 @@ function harborVerifierConfig(verifier: ReturnType<typeof verifierPolicy>) {
   };
 }
 
-function verifierPolicy(task: HarborTaskRunInput['task']): {
+function verifierPolicy(task: TaskRunInput['task']): {
   attemptTimeoutSec: number;
   outerTimeoutSec: number;
 } {

--- a/packages/headless/src/headless-run-env.ts
+++ b/packages/headless/src/headless-run-env.ts
@@ -5,6 +5,8 @@
  * disable a guard with `NaN`.
  */
 
+import { homedir } from 'node:os';
+import { join, resolve } from 'node:path';
 import {
   assertFinitePositive,
   assertNonNegativeInt,
@@ -13,6 +15,32 @@ import {
 } from './numeric-guards.js';
 
 export const MAX_NODE_TIMER_MS = 2_147_483_647;
+
+/**
+ * Resolve a required filesystem path from a raw env string. An empty/unset value
+ * falls back to `fallback`; a leading `~` expands to the home directory,
+ * otherwise the value is resolved against the current working directory. Throws
+ * with `name` when neither the value nor the fallback is present.
+ */
+export function envPath(name: string, raw: string | undefined, fallback?: string): string {
+  const value = raw && raw.length > 0 ? raw : fallback;
+  if (!value) throw new Error(`${name} is required`);
+  return value.startsWith('~') ? join(homedir(), value.slice(1)) : resolve(value);
+}
+
+/**
+ * Parse a comma-separated list of explicit ids (trimmed, blanks dropped).
+ * Returns `undefined` when unset or empty so callers can distinguish "not
+ * specified" from an explicit empty selection.
+ */
+export function envIds(raw: string | undefined): string[] | undefined {
+  if (!raw) return undefined;
+  const ids = raw
+    .split(',')
+    .map((value) => value.trim())
+    .filter((value) => value.length > 0);
+  return ids.length > 0 ? ids : undefined;
+}
 
 /** Parse a non-negative integer; throw on a non-integer or negative value. */
 export function envNonNegativeInt(name: string, raw: string | undefined, fallback: number): number {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -212,6 +212,7 @@ export type {
   SelfCheckPolicy,
 } from './autonomous-agent-loop.js';
 export { AutonomousAgentLoop, runAutonomousTask } from './autonomous-agent-loop.js';
+export type { TaskRunner, TaskRunInput, TaskRunOutput } from './fixed-prompt-controller.js';
 export { runExperiment, type RunExperimentDeps } from './runner.js';
 export { runMatrix, type ExperimentSpec } from './matrix.js';
 export {

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -212,7 +212,6 @@ export type {
   SelfCheckPolicy,
 } from './autonomous-agent-loop.js';
 export { AutonomousAgentLoop, runAutonomousTask } from './autonomous-agent-loop.js';
-export type { TaskRunner, TaskRunInput, TaskRunOutput } from './fixed-prompt-controller.js';
 export { runExperiment, type RunExperimentDeps } from './runner.js';
 export { runMatrix, type ExperimentSpec } from './matrix.js';
 export {


### PR DESCRIPTION
## Summary

First of two PRs (#1342) extracting a shared experiment engine from the Harbor A/B run-script family. This PR is a behavior-preserving refactor: it deduplicates copy-adapted helpers into shared TS modules and extracts an explicit `TaskRunner` interface. It does **not** add `runExperiment(config)` or migrate the scripts' `main()` bodies — that is PR A2.

Helpers consolidated:
- `envPath` (×6: the four A/B/RSI runners plus `run-prompt-control.mjs` and `run-harness-ab-detached.mjs`, incl. harness `envPathFrom`; the detached script's no-fallback variant is the same parser with an undefined fallback) and `envIds` (×2) → `headless-run-env.ts` (pure parsers; each script keeps a one-line `process.env` wrapper, matching the existing `envPosInt` pattern).
- `selectTasksByIds` / `selectTasks` (×3) → `fixed-prompt-task-source.ts`, parameterized (`label`, `rejectDuplicates`) so the labeled, duplicate-tolerant runtime-policy variant keeps its exact error messages and behavior.
- The resume-safe fingerprint trio `buildSubjectFingerprint` / `buildToolchainFingerprint` / `buildTaskSourceFingerprint` → new `experiment-fingerprint.ts`, ported byte-identically from `run-prompt-ab.mjs`. `run-harness-ab` and `run-runtime-policy-ab` now import it from `#experiment-fingerprint` instead of reverse-importing the `.mjs`.
- `DEEPSEEK_V4_FLASH_PRICING` (×2) → new `deepseek-pricing.ts`, keeping the stricter fail-loud-at-import field validation. Imported via the package-local `#deepseek-pricing` subpath so vendor pricing stays out of the generic `@maka/headless` public API.

TaskRunner seam:
- Extracted a provider-neutral `TaskRunner` / `TaskRunInput` / `TaskRunOutput` interface from `HarborTaskRunner` in `fixed-prompt-controller.ts`. `createHarborTaskRunner` stays the sole implementation and now returns `TaskRunner`; the controller consumes `TaskRunner`. The Harbor-named identifiers remain as deprecated aliases so existing call sites stay unchanged. Per cross-review, the new types are **not** re-exported from `index.ts`: `createHarborTaskRunner` itself is not public API, so a public type-only surface would be unreachable and would prematurely freeze a contract that the Pier implementation (#1343) may still shape. The types are exported from `fixed-prompt-controller.ts` for intra-package use.

### Fingerprint / resume compatibility

**Not affected.** The trio was moved byte-identically: same `canonicalJson` hashing (the module reuses `buildRunManifestFingerprint`, which is the identical `sha256(canonicalJson(...))` algorithm), same `kind` tags, same payload shapes, same `type: 'missing'` sentinel for absent dist dirs, and the same `MAKA_PROMPT_AB_*` error strings (including the pre-existing quirk that the runtime-policy runner surfaces `MAKA_PROMPT_AB_*` names — preserved deliberately). Resume is gated by the A/B run manifest fingerprint (`ensureAbRunManifest` fingerprint compare) and the controller's `resumeFingerprint`; since the trio's output bytes are unchanged, `run-prompt-ab` / `run-harness-ab` / `run-runtime-policy-ab` resume identity is unchanged.

This claim is now pinned in-repo, not just asserted: `prompt-ab-fingerprints.test.ts` gains a byte-contract suite that (a) binds the explicit-subject path to a fixed constant hash and (b) asserts all three builders equal a frozen, verbatim legacy-algorithm oracle over a deterministic fixture tree (known file bytes, executable bit, one present + three missing dist roots, dependency lock pair, injected fake git/tool outputs). Cross-review (Codex + GLM-5.2) independently confirmed byte identity with an external oracle over all four payload kinds before this suite was added.

The parallel prompt-optimization fingerprints in `prompt-optimization-manifest.ts` are **deliberately left untouched**. They are genuinely distinct (different `kind` tags, held-in/held-out task split with metadata, a git-based toolchain rather than the npm-lock one, and a different missing-dir sentinel), so merging them onto the prompt-ab trio would change prompt-optimization resume identity — out of scope for this behavior-preserving PR. `run-prompt-optimization` shares only the copy-adapted helpers (`envPath`, `envIds`, `selectTasksByIds`, pricing).

## Verification

- `packages/headless`: `npm test` (clean + build + full dist suite) — 1194 pass, 0 fail, 1 pre-existing skip. Covers the safety-net tests: `prompt-ab-fingerprints` (incl. the new byte-contract pins), `harness-ab-cli` and `runtime-policy-ab-cli` (execute the `.mjs` scripts, incl. the detached launcher), `ab-run`, `fixed-prompt-controller`, `harbor-task-runner`, `harbor-adapter` script-integration tests, plus new direct unit tests for `selectTasksByIds` option branching, `envPath`, and `envIds` (`headless-run-env-paths.test.ts`, `fixed-prompt-task-source.test.ts`).
- Workspace typecheck: `@maka/core` / `@maka/storage` / `@maka/runtime` / `@maka/headless` / `@maka/cli` / `@maka/ui` clean. `apps/desktop` fails on `app-shell-revision-actions.ts` (`ComposerHandle.getText`) — pre-existing at the branch base (17cc81d4c), untouched by this PR (diff is confined to `packages/headless`).
- `npm run format` (Biome), `npm run format:check`, and `npm run lint` — clean.

### Review

Cross-review adjudicated (Codex + GLM-5.2); the accepted-actions bundle landed as the second commit: leftover `envPath` copies in `run-prompt-control.mjs` / `run-harness-ab-detached.mjs`, direct helper unit tests, the pinned fingerprint byte-contract suite, and removal of the premature `index.ts` type re-export.

### Deferred to PR A2

- `runExperiment(config)` absorbing the duplicated `main()` bodies; migrating `run-prompt-ab` / `run-runtime-policy-ab` / `run-harness-ab` to thin configs with the harness-specific extras (Oracle evidence, CSV report, detached journal) as opt-in hooks.
- Deleting the three `@deprecated Harbor*` aliases and renaming `RunFixedPromptControllerInput.harborRunner` to `taskRunner` — A2 migrates those call sites anyway.

Refs #1342
