### PR TITLE
feat(runtime-host): add full-duplex connection sessions

### DIFF
--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -20,7 +20,10 @@ import {
 import { RuntimeHostKernel, type RuntimeHostComposition } from '../server/index.js';
 import { RuntimeHostConnectionSession } from '../server/connection-session.js';
 import type { OperationHandlerMap } from '../server/operation-dispatcher.js';
-import { BoundedSerialOutboundWriter } from '../server/serial-outbound-writer.js';
+import {
+  BoundedSerialOutboundWriter,
+  RuntimeHostOutboundQueueError,
+} from '../server/serial-outbound-writer.js';
 import { FramedTransport } from '../transport/framed-transport.js';
 
 const CURRENT_PROTOCOL = {
@@ -120,6 +123,83 @@ test('serial outbound writer fails once when its real transport is closed', asyn
   }
 });
 
+test('serial outbound writer reports its 2 MiB byte bound before its frame bound', async () => {
+  const pair = await openTransportPair();
+  let failureCalls = 0;
+  const writer = new BoundedSerialOutboundWriter(pair.clientTransport, () => {
+    failureCalls += 1;
+  });
+  const settlements: Promise<{ status: 'fulfilled' } | { status: 'rejected'; error: Error }>[] = [];
+  let overload: unknown;
+  let acceptedFrames = 0;
+  try {
+    for (let index = 0; index < 64; index += 1) {
+      try {
+        const receipt = writer.enqueue(largeFailureResponse(`byte-bound-${index}`));
+        acceptedFrames += 1;
+        settlements.push(
+          receipt.flushed.then(
+            () => ({ status: 'fulfilled' as const }),
+            (error: unknown) => ({ status: 'rejected' as const, error: asError(error) }),
+          ),
+        );
+      } catch (error) {
+        overload = error;
+        break;
+      }
+    }
+
+    assert.ok(overload instanceof RuntimeHostOutboundQueueError);
+    assert.equal(overload.code, 'byte_limit');
+    assert.ok(acceptedFrames < 64, 'frame bound fired before the 2 MiB byte bound');
+    assert.equal(failureCalls, 1);
+    const results = await Promise.all(settlements);
+    assert.equal(results.length, acceptedFrames);
+    assert.equal(
+      results.every((result) => result.status === 'rejected' && result.error === overload),
+      true,
+    );
+  } finally {
+    writer.close();
+    await pair.close();
+  }
+});
+
+test('clean read EOF drains an already dispatched response before closing', async () => {
+  const fixture = await openHalfClosedDispatchedSession('half-close');
+  try {
+    fixture.releaseHandler.resolve();
+    const response = decodeHostFrame(await fixture.pair.clientTransport.read(1_000));
+    if ('kind' in response || response.operation !== 'turn.query') {
+      assert.fail('Expected the dispatched turn.query response');
+    }
+    assert.equal(response.ok, true);
+    await withTimeout(fixture.run, 1_000, 'connection did not close after draining its response');
+    assert.equal(fixture.teardownCalls(), 1);
+  } finally {
+    await fixture.close();
+  }
+});
+
+test('a fatal transport close during clean EOF drain tears down exactly once', async () => {
+  const fixture = await openHalfClosedDispatchedSession('fatal-close-after-eof');
+  try {
+    fixture.pair.serverTransport.destroy(new Error('forced transport failure'));
+    await withTimeout(
+      fixture.teardownObserved.promise,
+      1_000,
+      'fatal transport close did not interrupt EOF drain',
+    );
+    assert.equal(fixture.teardownCalls(), 1);
+
+    fixture.releaseHandler.resolve();
+    await withTimeout(fixture.run, 1_000, 'connection did not settle after its handler completed');
+    assert.equal(fixture.teardownCalls(), 1);
+  } finally {
+    await fixture.close();
+  }
+});
+
 test('a connection accepted before composition exists resolves ready handlers without reconnecting', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-pre-ready-'));
   const root = join(base, 'root');
@@ -192,7 +272,7 @@ test('a connection accepted before composition exists resolves ready handlers wi
   }
 });
 
-test('disconnect while operation admission is pending does not execute the handler', async () => {
+test('connection reset while operation admission is pending does not execute the handler', async () => {
   const pair = await openTransportPair();
   const admissionEntered = deferred();
   const releaseAdmission = deferred();
@@ -248,7 +328,7 @@ test('disconnect while operation admission is pending does not execute the handl
       input: { sessionId: 'session', turnId: 'turn' },
     });
     await withTimeout(admissionEntered.promise, 1_000, 'operation did not enter admission');
-    pair.clientTransport.destroy();
+    pair.clientTransport.socket.resetAndDestroy();
     await withTimeout(
       teardownObserved.promise,
       1_000,
@@ -503,8 +583,17 @@ interface TransportPair {
   close(): Promise<void>;
 }
 
+interface HalfClosedDispatchedSession {
+  pair: TransportPair;
+  releaseHandler: Deferred;
+  teardownObserved: Deferred;
+  run: Promise<void>;
+  teardownCalls(): number;
+  close(): Promise<void>;
+}
+
 async function openTransportPair(): Promise<TransportPair> {
-  const listener = createServer();
+  const listener = createServer({ allowHalfOpen: true });
   const accepted = new Promise<Socket>((resolve) => listener.once('connection', resolve));
   await listenServer(listener);
   const address = listener.address();
@@ -527,6 +616,87 @@ async function openTransportPair(): Promise<TransportPair> {
       await closeServer(listener);
     },
   };
+}
+
+async function openHalfClosedDispatchedSession(
+  turnId: string,
+): Promise<HalfClosedDispatchedSession> {
+  const pair = await openTransportPair();
+  const handlerEntered = deferred();
+  const releaseHandler = deferred();
+  const teardownObserved = deferred();
+  let teardownCalls = 0;
+  const session = new RuntimeHostConnectionSession({
+    transport: pair.serverTransport,
+    connection: {
+      hostEpoch: 'host-epoch',
+      connectionId: `${turnId}-client`,
+      surface: 'tui',
+      principal: 'local_os_user',
+    },
+    resolveHandlers: () => ({
+      'host.status': async () => ({
+        ok: true,
+        result: {
+          hostEpoch: 'host-epoch',
+          state: 'ready',
+          connections: 1,
+          activeOperations: 1,
+          activeResidencies: 0,
+        },
+      }),
+      ...createHandlers(async (input) => {
+        handlerEntered.resolve();
+        await releaseHandler.promise;
+        return {
+          ok: true,
+          result: runningSnapshot(input.sessionId, input.turnId),
+        };
+      }),
+    }),
+    beginOperation: async () => ({
+      acquireResidency: () => ({ release() {} }),
+      seal() {},
+      finish() {},
+    }),
+    onTeardown: () => {
+      teardownCalls += 1;
+      teardownObserved.resolve();
+    },
+  });
+  const run = session.run();
+  try {
+    await pair.clientTransport.write({
+      requestId: `${turnId}-request`,
+      operation: 'turn.query',
+      input: { sessionId: 'session', turnId },
+    });
+    await withTimeout(handlerEntered.promise, 1_000, 'handler was not dispatched');
+    const readEnded = onceSocketEnd(pair.serverTransport.socket);
+    pair.clientTransport.socket.end();
+    await withTimeout(readEnded, 1_000, 'Host did not observe Client read EOF');
+    return {
+      pair,
+      releaseHandler,
+      teardownObserved,
+      run,
+      teardownCalls: () => teardownCalls,
+      close: async () => {
+        releaseHandler.resolve();
+        pair.clientTransport.destroy();
+        await Promise.allSettled([run, pair.close()]);
+      },
+    };
+  } catch (error) {
+    releaseHandler.resolve();
+    pair.clientTransport.destroy();
+    await Promise.allSettled([run, pair.close()]);
+    throw error;
+  }
+}
+
+function onceSocketEnd(socket: Socket): Promise<void> {
+  return new Promise((resolve) => socket.once('end', resolve));
 }
 
 function listenServer(server: Server): Promise<void> {
@@ -575,6 +745,18 @@ function statusResponse(requestId: string): ResponseFrame {
   };
 }
 
+function largeFailureResponse(requestId: string): ResponseFrame {
+  return {
+    requestId,
+    operation: 'host.status',
+    ok: false,
+    error: {
+      code: 'internal_failure',
+      message: 'x'.repeat(48 * 1024),
+    },
+  };
+}
+
 function runningSnapshot(sessionId: string, turnId: string): TurnSnapshot {
   return {
     sessionId,
@@ -609,6 +791,10 @@ function deferred(): Deferred {
     resolve = resolvePromise;
   });
   return { promise, resolve };
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
 }
 
 async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -1,0 +1,626 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { connect, createServer, type Server, type Socket } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import {
+  resolveRootControlNamespace,
+  resolveStorageRoot,
+  tryAcquireInteractiveRootOwner,
+} from '@maka/storage/root-authority';
+import { readHostRegistration } from '../control/registration.js';
+import { connectRuntimeHost, type RuntimeHostConnection } from '../client/index.js';
+import {
+  decodeHostFrame,
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  type ResponseFrame,
+  type TurnSnapshot,
+} from '../protocol/index.js';
+import { RuntimeHostKernel, type RuntimeHostComposition } from '../server/index.js';
+import { RuntimeHostConnectionSession } from '../server/connection-session.js';
+import type { OperationHandlerMap } from '../server/operation-dispatcher.js';
+import { BoundedSerialOutboundWriter } from '../server/serial-outbound-writer.js';
+import { FramedTransport } from '../transport/framed-transport.js';
+
+const CURRENT_PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+
+type TurnQueryHandler = RuntimeHostComposition['handlers']['turn.query'];
+
+test('concurrent responses remain framed and correlated in reverse completion order', async () => {
+  const requestCount = 16;
+  const entered = Array.from({ length: requestCount }, () => deferred());
+  const release = Array.from({ length: requestCount }, () => deferred());
+  await withRuntimeHost(
+    async (input) => {
+      const index = Number(input.turnId.slice('turn-'.length));
+      entered[index]?.resolve();
+      await release[index]?.promise;
+      return {
+        ok: true,
+        result: runningSnapshot(input.sessionId, input.turnId),
+      };
+    },
+    async ({ connectClient }) => {
+      const client = await connectClient();
+      const requests = Array.from({ length: requestCount }, (_, index) =>
+        client.queryTurn({ sessionId: 'session', turnId: `turn-${index}` }, 5_000),
+      );
+      try {
+        await withTimeout(
+          Promise.all(entered.map((item) => item.promise)),
+          1_000,
+          'concurrent handlers were not all admitted',
+        );
+
+        for (let index = requestCount - 1; index >= 0; index -= 1) {
+          release[index]?.resolve();
+          const result = await requests[index];
+          assert.equal(result?.turnId, `turn-${index}`);
+          assert.equal(result?.runId, `run-turn-${index}`);
+        }
+        const results = await Promise.all(requests);
+        assert.deepEqual(
+          results.map((result) => result.turnId),
+          Array.from({ length: requestCount }, (_, index) => `turn-${index}`),
+        );
+      } finally {
+        for (const gate of release) gate.resolve();
+        await Promise.allSettled(requests);
+      }
+    },
+  );
+});
+
+test('serial outbound writer flushes accepted frames in FIFO order over a real socket', async () => {
+  const pair = await openTransportPair();
+  let failureCalls = 0;
+  const writer = new BoundedSerialOutboundWriter(pair.clientTransport, () => {
+    failureCalls += 1;
+  });
+  try {
+    const frames = ['first', 'second', 'third'].map(statusResponse);
+    const receipts = frames.map((frame) => writer.enqueue(frame));
+    await Promise.all(receipts.map((receipt) => receipt.flushed));
+    for (const expected of frames) {
+      const received = decodeHostFrame(await pair.serverTransport.read(1_000));
+      assert.equal('kind' in received, false);
+      if (!('kind' in received)) assert.equal(received.requestId, expected.requestId);
+    }
+    assert.equal(failureCalls, 0);
+
+    writer.close();
+    assert.throws(() => writer.enqueue(statusResponse('after-close')), /writer is closed/);
+  } finally {
+    writer.close();
+    await pair.close();
+  }
+});
+
+test('serial outbound writer fails once when its real transport is closed', async () => {
+  const pair = await openTransportPair();
+  let failureCalls = 0;
+  const writer = new BoundedSerialOutboundWriter(pair.clientTransport, () => {
+    failureCalls += 1;
+  });
+  try {
+    pair.clientTransport.destroy();
+    await pair.clientTransport.closed;
+    const receipt = writer.enqueue(statusResponse('closed-transport'));
+    await assert.rejects(receipt.flushed);
+    assert.equal(failureCalls, 1);
+    assert.throws(() => writer.enqueue(statusResponse('after-failure')), /writer is closed/);
+    assert.equal(failureCalls, 1);
+  } finally {
+    writer.close();
+    await pair.close();
+  }
+});
+
+test('a connection accepted before composition exists resolves ready handlers without reconnecting', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-pre-ready-'));
+  const root = join(base, 'root');
+  const capability = await resolveStorageRoot({
+    path: root,
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  const factoryEntered = deferred();
+  const releaseFactory = deferred();
+  const hostTask = RuntimeHostKernel.start({
+    owner,
+    idleGraceMs: 10_000,
+    compositionFactory: async () => {
+      factoryEntered.resolve();
+      await releaseFactory.promise;
+      return {
+        handlers: createHandlers(async (input) => ({
+          ok: true,
+          result: runningSnapshot(input.sessionId, input.turnId),
+        })),
+        async recover() {},
+        async close() {},
+      };
+    },
+  });
+  let transport: FramedTransport | undefined;
+  let host: RuntimeHostKernel | undefined;
+  try {
+    await withTimeout(factoryEntered.promise, 1_000, 'Runtime Host did not enter composition');
+    const registration = await readHostRegistration(owner.controlDirectory);
+    assert.ok(registration);
+    assert.equal(registration.state, 'recovering');
+    transport = await openAcceptedTransport(registration.endpoint, 'pre-ready-client');
+
+    await transport.write({
+      requestId: 'before-ready',
+      operation: 'turn.query',
+      input: { sessionId: 'session', turnId: 'turn' },
+    });
+    const beforeReady = decodeHostFrame(await transport.read(1_000));
+    if ('kind' in beforeReady) assert.fail('Expected an operation response');
+    if (beforeReady.ok) assert.fail('Pre-ready request unexpectedly succeeded');
+    assert.equal(beforeReady.error.code, 'host_not_ready');
+
+    releaseFactory.resolve();
+    host = await withTimeout(hostTask, 1_000, 'Runtime Host did not become ready');
+    await transport.write({
+      requestId: 'after-ready',
+      operation: 'turn.query',
+      input: { sessionId: 'session', turnId: 'turn' },
+    });
+    const afterReady = decodeHostFrame(await transport.read(1_000));
+    if ('kind' in afterReady || afterReady.operation !== 'turn.query') {
+      assert.fail('Expected a turn.query response');
+    }
+    if (!afterReady.ok) assert.fail(afterReady.error.message);
+    assert.equal(afterReady.result.runId, 'run-turn');
+  } finally {
+    releaseFactory.resolve();
+    transport?.destroy();
+    host ??= await hostTask.catch(() => undefined);
+    await host?.close().catch(() => undefined);
+    await rm(join(resolveRootControlNamespace(), capability.rootId), {
+      recursive: true,
+      force: true,
+    });
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('disconnect while operation admission is pending does not execute the handler', async () => {
+  const pair = await openTransportPair();
+  const admissionEntered = deferred();
+  const releaseAdmission = deferred();
+  const teardownObserved = deferred();
+  let handlerCalls = 0;
+  let finishCalls = 0;
+  const handlers: OperationHandlerMap = {
+    'host.status': async () => ({
+      ok: true,
+      result: {
+        hostEpoch: 'host-epoch',
+        state: 'ready',
+        connections: 1,
+        activeOperations: 1,
+        activeResidencies: 0,
+      },
+    }),
+    ...createHandlers(async (input) => {
+      handlerCalls += 1;
+      return {
+        ok: true,
+        result: runningSnapshot(input.sessionId, input.turnId),
+      };
+    }),
+  };
+  const session = new RuntimeHostConnectionSession({
+    transport: pair.serverTransport,
+    connection: {
+      hostEpoch: 'host-epoch',
+      connectionId: 'pending-admission',
+      surface: 'tui',
+      principal: 'local_os_user',
+    },
+    resolveHandlers: () => handlers,
+    beginOperation: async () => {
+      admissionEntered.resolve();
+      await releaseAdmission.promise;
+      return {
+        acquireResidency: () => ({ release() {} }),
+        seal() {},
+        finish() {
+          finishCalls += 1;
+        },
+      };
+    },
+    onTeardown: () => teardownObserved.resolve(),
+  });
+  const run = session.run();
+  try {
+    await pair.clientTransport.write({
+      requestId: 'pending-request',
+      operation: 'turn.query',
+      input: { sessionId: 'session', turnId: 'turn' },
+    });
+    await withTimeout(admissionEntered.promise, 1_000, 'operation did not enter admission');
+    pair.clientTransport.destroy();
+    await withTimeout(
+      teardownObserved.promise,
+      1_000,
+      'connection did not tear down while admission was pending',
+    );
+    releaseAdmission.resolve();
+    await withTimeout(run, 1_000, 'connection did not settle after admission completed');
+    assert.equal(handlerCalls, 0);
+    assert.equal(finishCalls, 1);
+  } finally {
+    releaseAdmission.resolve();
+    pair.clientTransport.destroy();
+    await Promise.allSettled([run, pair.close()]);
+  }
+});
+
+test('an admitted operation settles without connection or residency leakage after disconnect', async () => {
+  const handlerEntered = deferred();
+  const releaseHandler = deferred();
+  const handlerSettled = deferred();
+  await withRuntimeHost(
+    async (input, context) => {
+      const residency = context.acquireResidency();
+      handlerEntered.resolve();
+      try {
+        await releaseHandler.promise;
+        return {
+          ok: true,
+          result: runningSnapshot(input.sessionId, input.turnId),
+        };
+      } finally {
+        residency.release();
+        handlerSettled.resolve();
+      }
+    },
+    async ({ connectClient }) => {
+      const client = await connectClient();
+      const requestFailure = client
+        .queryTurn({ sessionId: 'session', turnId: 'disconnect' }, 5_000)
+        .then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+      try {
+        await withTimeout(handlerEntered.promise, 1_000, 'handler was not admitted');
+        await client.close();
+        releaseHandler.resolve();
+        await withTimeout(handlerSettled.promise, 1_000, 'handler did not settle after disconnect');
+        assert.ok((await requestFailure) instanceof Error);
+
+        const observer = await connectClient();
+        const status = await waitForStatus(
+          observer,
+          (value) =>
+            value.connections === 1 &&
+            value.activeOperations === 1 &&
+            value.activeResidencies === 0,
+        );
+        assert.equal(status.connections, 1);
+        assert.equal(status.activeOperations, 1);
+        assert.equal(status.activeResidencies, 0);
+      } finally {
+        releaseHandler.resolve();
+        await client.close().catch(() => undefined);
+        await Promise.allSettled([requestFailure]);
+      }
+    },
+  );
+});
+
+test('a duplicate active request id tears down only the offending connection', async () => {
+  const handlerEntered = deferred();
+  const releaseHandler = deferred();
+  let handlerCalls = 0;
+  await withRuntimeHost(
+    async (input) => {
+      handlerCalls += 1;
+      handlerEntered.resolve();
+      await releaseHandler.promise;
+      return {
+        ok: true,
+        result: runningSnapshot(input.sessionId, input.turnId),
+      };
+    },
+    async ({ connectClient, endpoint }) => {
+      const transport = await openAcceptedTransport(endpoint, 'duplicate-request-client');
+      try {
+        await transport.write({
+          requestId: 'duplicate-request',
+          operation: 'turn.query',
+          input: { sessionId: 'session', turnId: 'first' },
+        });
+        await withTimeout(handlerEntered.promise, 1_000, 'first request was not admitted');
+        await transport.write({
+          requestId: 'duplicate-request',
+          operation: 'turn.query',
+          input: { sessionId: 'session', turnId: 'second' },
+        });
+        await withTimeout(
+          transport.closed,
+          1_000,
+          'duplicate request id did not close its connection',
+        );
+        assert.equal(handlerCalls, 1);
+      } finally {
+        releaseHandler.resolve();
+        transport.destroy();
+      }
+
+      const observer = await connectClient();
+      const status = await waitForStatus(
+        observer,
+        (value) =>
+          value.connections === 1 && value.activeOperations === 1 && value.activeResidencies === 0,
+      );
+      assert.equal(status.state, 'ready');
+    },
+  );
+});
+
+test('a sixty-fifth in-flight request tears down only the overflowing connection', async () => {
+  const releaseHandlers = deferred();
+  await withRuntimeHost(
+    async (input) => {
+      await releaseHandlers.promise;
+      return {
+        ok: true,
+        result: runningSnapshot(input.sessionId, input.turnId),
+      };
+    },
+    async ({ connectClient, endpoint }) => {
+      const transport = await openAcceptedTransport(endpoint, 'overflowing-client');
+      const observer = await connectClient();
+      try {
+        const requests = Array.from({ length: 64 }, (_, index) =>
+          JSON.stringify({
+            requestId: `overflow-${index}`,
+            operation: 'turn.query',
+            input: { sessionId: 'session', turnId: `turn-${index}` },
+          }),
+        ).join('\n');
+        transport.socket.write(`${requests}\n`);
+        await waitForStatus(
+          observer,
+          (value) =>
+            value.connections === 2 &&
+            value.activeOperations === 65 &&
+            value.activeResidencies === 0,
+        );
+        await transport.write({
+          requestId: 'overflow-64',
+          operation: 'turn.query',
+          input: { sessionId: 'session', turnId: 'turn-64' },
+        });
+        await withTimeout(
+          transport.closed,
+          1_000,
+          'in-flight overflow did not close its connection',
+        );
+      } finally {
+        releaseHandlers.resolve();
+        transport.destroy();
+      }
+      const status = await waitForStatus(
+        observer,
+        (value) =>
+          value.connections === 1 && value.activeOperations === 1 && value.activeResidencies === 0,
+      );
+      assert.equal(status.state, 'ready');
+    },
+  );
+});
+
+interface RuntimeHostTestFixture {
+  connectClient(): Promise<RuntimeHostConnection>;
+  endpoint: string;
+}
+
+async function withRuntimeHost(
+  queryTurn: TurnQueryHandler,
+  run: (fixture: RuntimeHostTestFixture) => Promise<void>,
+): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-runtime-host-continuity-'));
+  const root = join(base, 'root');
+  const capability = await resolveStorageRoot({
+    path: root,
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  const connections = new Set<RuntimeHostConnection>();
+  const host = await RuntimeHostKernel.start({
+    owner,
+    idleGraceMs: 10_000,
+    compositionFactory: async () => ({
+      handlers: createHandlers(queryTurn),
+      async recover() {},
+      async close() {},
+    }),
+  });
+  try {
+    await run({
+      endpoint: host.endpoint,
+      connectClient: async () => {
+        const result = await connectRuntimeHost({
+          rootPath: root,
+          surface: 'tui',
+          protocol: CURRENT_PROTOCOL,
+        });
+        assert.equal(result.kind, 'connected');
+        connections.add(result.connection);
+        return result.connection;
+      },
+    });
+  } finally {
+    await Promise.allSettled([...connections].map((connection) => connection.close()));
+    await host.close();
+    await rm(join(resolveRootControlNamespace(), capability.rootId), {
+      recursive: true,
+      force: true,
+    });
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+async function openAcceptedTransport(
+  endpoint: string,
+  clientInstanceId: string,
+): Promise<FramedTransport> {
+  const socket = connect(endpoint);
+  await new Promise<void>((resolve, reject) => {
+    socket.once('connect', resolve);
+    socket.once('error', reject);
+  });
+  const transport = new FramedTransport(socket);
+  await transport.write({
+    kind: 'hello',
+    clientInstanceId,
+    surface: 'tui',
+    protocolMin: CURRENT_PROTOCOL.min,
+    protocolMax: CURRENT_PROTOCOL.max,
+  });
+  const handshake = decodeHostFrame(await transport.read(1_000));
+  assert.ok('kind' in handshake);
+  assert.equal(handshake.kind, 'accepted');
+  return transport;
+}
+
+interface TransportPair {
+  clientTransport: FramedTransport;
+  serverTransport: FramedTransport;
+  close(): Promise<void>;
+}
+
+async function openTransportPair(): Promise<TransportPair> {
+  const listener = createServer();
+  const accepted = new Promise<Socket>((resolve) => listener.once('connection', resolve));
+  await listenServer(listener);
+  const address = listener.address();
+  assert.ok(address && typeof address !== 'string');
+  const clientSocket = connect(address.port, '127.0.0.1');
+  await new Promise<void>((resolve, reject) => {
+    clientSocket.once('connect', resolve);
+    clientSocket.once('error', reject);
+  });
+  const serverSocket = await accepted;
+  const clientTransport = new FramedTransport(clientSocket);
+  const serverTransport = new FramedTransport(serverSocket);
+  return {
+    clientTransport,
+    serverTransport,
+    close: async () => {
+      clientTransport.destroy();
+      serverTransport.destroy();
+      await Promise.all([clientTransport.closed, serverTransport.closed]);
+      await closeServer(listener);
+    },
+  };
+}
+
+function listenServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function createHandlers(queryTurn: TurnQueryHandler): RuntimeHostComposition['handlers'] {
+  return {
+    'turn.start': async (input) => ({
+      ok: true,
+      result: runningSnapshot(input.sessionId, input.turnId),
+    }),
+    'turn.query': queryTurn,
+    'turn.stop': async (input) => ({
+      ok: true,
+      result: runningSnapshot(input.sessionId, input.turnId),
+    }),
+  };
+}
+
+function statusResponse(requestId: string): ResponseFrame {
+  return {
+    requestId,
+    operation: 'host.status',
+    ok: true,
+    result: {
+      hostEpoch: 'host-epoch',
+      state: 'ready',
+      connections: 1,
+      activeOperations: 0,
+      activeResidencies: 0,
+    },
+  };
+}
+
+function runningSnapshot(sessionId: string, turnId: string): TurnSnapshot {
+  return {
+    sessionId,
+    turnId,
+    runId: `run-${turnId}`,
+    status: 'running',
+  };
+}
+
+async function waitForStatus(
+  connection: RuntimeHostConnection,
+  predicate: (status: Awaited<ReturnType<RuntimeHostConnection['status']>>) => boolean,
+): Promise<Awaited<ReturnType<RuntimeHostConnection['status']>>> {
+  const deadline = Date.now() + 1_000;
+  let status = await connection.status(1_000);
+  while (!predicate(status) && Date.now() < deadline) {
+    await new Promise<void>((resolve) => setTimeout(resolve, 10));
+    status = await connection.status(1_000);
+  }
+  assert.equal(predicate(status), true, 'Host operation counters did not settle');
+  return status;
+}
+
+interface Deferred {
+  promise: Promise<void>;
+  resolve(): void;
+}
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timer: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}

--- a/packages/runtime-host/src/__tests__/framed-transport.test.ts
+++ b/packages/runtime-host/src/__tests__/framed-transport.test.ts
@@ -1,8 +1,30 @@
 import assert from 'node:assert/strict';
-import { connect, createServer, type Server, type Socket } from 'node:net';
+import { createServer, Socket, type Server } from 'node:net';
 import { test } from 'node:test';
 import { RUNTIME_HOST_MAX_FRAME_BYTES, RuntimeHostProtocolError } from '../protocol/index.js';
-import { FramedTransport } from '../transport/framed-transport.js';
+import { FramedTransport, RuntimeHostTransportError } from '../transport/framed-transport.js';
+
+test('drains clean half-open input before reporting typed read EOF', async () => {
+  await withSocketPair(async (transport, peer) => {
+    const ended = endSocket(peer, Buffer.from(`${JSON.stringify({ accepted: true })}\n`));
+    assert.deepEqual(await transport.read(1_000), { accepted: true });
+    await assert.rejects(
+      transport.read(1_000),
+      (error: unknown) => error instanceof RuntimeHostTransportError && error.code === 'read_eof',
+    );
+
+    const reply = Buffer.from(`${JSON.stringify({ reply: true })}\n`);
+    const received = readSocket(peer, reply.byteLength);
+    await transport.writeEncoded(reply);
+    assert.deepEqual(await received, reply);
+    await ended;
+
+    const failure = new Error('forced transport failure');
+    transport.destroy(failure);
+    await transport.closed;
+    await assert.rejects(transport.read(0), (error: unknown) => error === failure);
+  });
+});
 
 test('drains a paused frame burst before reporting a terminal partial frame', async () => {
   await withSocketPair(async (transport, peer) => {
@@ -66,7 +88,8 @@ async function withSocketPair(
   await listen(server);
   const address = server.address();
   assert.ok(address && typeof address !== 'string');
-  const socket = connect(address.port, '127.0.0.1');
+  const socket = new Socket({ allowHalfOpen: true });
+  socket.connect(address.port, '127.0.0.1');
   await onceConnected(socket);
   const peer = await accepted.promise;
   const transport = new FramedTransport(socket);
@@ -78,6 +101,30 @@ async function withSocketPair(
     await transport.closed;
     await closeServer(server);
   }
+}
+
+function readSocket(socket: Socket, expectedBytes: number): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let receivedBytes = 0;
+    const onData = (chunk: Buffer) => {
+      chunks.push(Buffer.from(chunk));
+      receivedBytes += chunk.byteLength;
+      if (receivedBytes < expectedBytes) return;
+      cleanup();
+      resolve(Buffer.concat(chunks, receivedBytes));
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const cleanup = () => {
+      socket.off('data', onData);
+      socket.off('error', onError);
+    };
+    socket.on('data', onData);
+    socket.once('error', onError);
+  });
 }
 
 function writeSocket(socket: Socket, bytes: Uint8Array): Promise<void> {

--- a/packages/runtime-host/src/__tests__/framed-transport.test.ts
+++ b/packages/runtime-host/src/__tests__/framed-transport.test.ts
@@ -1,0 +1,133 @@
+import assert from 'node:assert/strict';
+import { connect, createServer, type Server, type Socket } from 'node:net';
+import { test } from 'node:test';
+import { RUNTIME_HOST_MAX_FRAME_BYTES, RuntimeHostProtocolError } from '../protocol/index.js';
+import { FramedTransport } from '../transport/framed-transport.js';
+
+test('drains a paused frame burst before reporting a terminal partial frame', async () => {
+  await withSocketPair(async (transport, peer) => {
+    const frames = Array.from({ length: 96 }, (_, index) => ({ index }));
+    const ended = endSocket(
+      peer,
+      Buffer.from(`${frames.map((frame) => JSON.stringify(frame)).join('\n')}\n{"partial":`),
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    for (const expected of frames) {
+      assert.deepEqual(await transport.read(2_000), expected);
+    }
+    await assert.rejects(
+      transport.read(2_000),
+      (error: unknown) =>
+        error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame',
+    );
+    await ended;
+    await transport.closed;
+  });
+});
+
+test('applies byte backpressure without dropping large valid frames', async () => {
+  await withSocketPair(async (transport, peer) => {
+    const payload = 'x'.repeat(60 * 1024);
+    const frames = Array.from({ length: 40 }, (_, index) => ({ index, payload }));
+    const sent = writeSocket(
+      peer,
+      Buffer.from(`${frames.map((frame) => JSON.stringify(frame)).join('\n')}\n`),
+    );
+    await new Promise<void>((resolve) => setImmediate(resolve));
+
+    for (const expected of frames) {
+      assert.deepEqual(await transport.read(5_000), expected);
+    }
+    await sent;
+    await writeSocket(peer, Buffer.from(`${JSON.stringify({ resumed: true })}\n`));
+    assert.deepEqual(await transport.read(2_000), { resumed: true });
+  });
+});
+
+test('fails closed on an oversized unterminated frame over a real socket', async () => {
+  await withSocketPair(async (transport, peer) => {
+    const read = transport.read(1_000);
+    peer.write(Buffer.alloc(RUNTIME_HOST_MAX_FRAME_BYTES + 1, 0x61));
+    await assert.rejects(
+      read,
+      (error: unknown) =>
+        error instanceof RuntimeHostProtocolError && error.code === 'frame_too_large',
+    );
+    await transport.closed;
+  });
+});
+
+async function withSocketPair(
+  run: (transport: FramedTransport, peer: Socket) => Promise<void>,
+): Promise<void> {
+  const accepted = deferred<Socket>();
+  const server = createServer(accepted.resolve);
+  await listen(server);
+  const address = server.address();
+  assert.ok(address && typeof address !== 'string');
+  const socket = connect(address.port, '127.0.0.1');
+  await onceConnected(socket);
+  const peer = await accepted.promise;
+  const transport = new FramedTransport(socket);
+  try {
+    await run(transport, peer);
+  } finally {
+    transport.destroy();
+    peer.destroy();
+    await transport.closed;
+    await closeServer(server);
+  }
+}
+
+function writeSocket(socket: Socket, bytes: Uint8Array): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.write(bytes, (error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function endSocket(socket: Socket, bytes: Uint8Array): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const onError = (error: Error) => reject(error);
+    socket.once('error', onError);
+    socket.end(bytes, () => {
+      socket.off('error', onError);
+      resolve();
+    });
+  });
+}
+
+function listen(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+}
+
+function onceConnected(socket: Socket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    socket.once('connect', resolve);
+    socket.once('error', reject);
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -629,7 +629,7 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
-  test('shutdown cuts off a status response blocked by a non-reading Client', {
+  test('a non-reading Client overload is isolated to its connection', {
     skip: process.platform === 'win32',
   }, async () => {
     await withHostPaths(async (paths) => {
@@ -650,34 +650,32 @@ describe('non-serving Runtime Host kernel', () => {
       assert.equal(observer.kind, 'connected');
       if (observer.kind !== 'connected') return;
       try {
-        let blockedResponseObserved = false;
-        for (let index = 0; index < 10_000 && !nonReadingSocket.destroyed; index += 1) {
-          nonReadingSocket.write(
-            `${JSON.stringify({
-              requestId: `non-reading-${index}`,
+        const nonReadingClosed = new Promise<void>((resolve) => {
+          nonReadingSocket.once('close', () => resolve());
+        });
+        for (let index = 0; index < 10_000 && !nonReadingSocket.destroyed; index += 8) {
+          const batch = Array.from({ length: 8 }, (_, offset) =>
+            JSON.stringify({
+              requestId: `non-reading-${index + offset}`,
               operation: 'host.status',
               input: {},
-            })}\n`,
-          );
-          const status = await observer.connection.status(2_000);
-          if (status.activeOperations <= 1) continue;
-          await sleep(10);
-          if ((await observer.connection.status(2_000)).activeOperations > 1) {
-            blockedResponseObserved = true;
-            break;
-          }
+            }),
+          ).join('\n');
+          nonReadingSocket.write(`${batch}\n`);
+          await new Promise<void>((resolve) => setImmediate(resolve));
         }
-        assert.equal(
-          blockedResponseObserved,
-          true,
-          'failed to create real socket write backpressure',
+        await withTimeout(
+          nonReadingClosed,
+          2_000,
+          'Runtime Host did not evict the overloaded non-reading Client',
         );
+        assert.equal((await observer.connection.status(2_000)).state, 'ready');
 
         await observer.connection.close();
         await withTimeout(
           candidate.host.close(),
           2_500,
-          'Host shutdown did not cut off a blocked response',
+          'Host shutdown remained blocked after eviction',
         );
         const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
         const owner = await retryOwner(capability, paths);

--- a/packages/runtime-host/src/server/connection-session.ts
+++ b/packages/runtime-host/src/server/connection-session.ts
@@ -1,0 +1,114 @@
+import {
+  decodeClientFrame,
+  type HostOperationErrorCode,
+  type RequestFrame,
+} from '../protocol/index.js';
+import type { FramedTransport } from '../transport/framed-transport.js';
+import {
+  dispatchOperation,
+  operationFailureResponse,
+  type ConnectionContext,
+  type OperationHandlerMap,
+  type OperationResidency,
+} from './operation-dispatcher.js';
+import { BoundedSerialOutboundWriter } from './serial-outbound-writer.js';
+
+const MAX_IN_FLIGHT_REQUESTS = 64;
+
+type AcceptedConnectionContext = Omit<ConnectionContext, 'acquireResidency'>;
+
+export interface ConnectionOperationLease {
+  acquireResidency(): OperationResidency;
+  seal(): void;
+  finish(): void;
+}
+
+export interface RuntimeHostConnectionSessionOptions {
+  transport: FramedTransport;
+  connection: AcceptedConnectionContext;
+  resolveHandlers(): OperationHandlerMap;
+  beginOperation(frame: RequestFrame): Promise<ConnectionOperationLease | HostOperationErrorCode>;
+  onTeardown(): void;
+}
+
+export class RuntimeHostConnectionSession {
+  readonly #options: RuntimeHostConnectionSessionOptions;
+  readonly #writer: BoundedSerialOutboundWriter;
+  readonly #requests = new Map<string, Promise<void>>();
+  #closed = false;
+
+  constructor(options: RuntimeHostConnectionSessionOptions) {
+    this.#options = options;
+    this.#writer = new BoundedSerialOutboundWriter(options.transport, () => this.#teardown());
+  }
+
+  async run(): Promise<void> {
+    try {
+      await this.#pumpInbound();
+    } catch {
+      this.#teardown();
+    } finally {
+      this.#teardown();
+      await Promise.allSettled(this.#requests.values());
+      await Promise.all([this.#writer.settled(), this.#options.transport.closed]);
+    }
+  }
+
+  async #pumpInbound(): Promise<void> {
+    while (!this.#closed) {
+      const frame = decodeClientFrame(await this.#options.transport.read(0));
+      if ('kind' in frame) throw new Error('Unexpected handshake frame after acceptance');
+      if (this.#requests.has(frame.requestId) || this.#requests.size >= MAX_IN_FLIGHT_REQUESTS) {
+        this.#teardown();
+        return;
+      }
+      this.#dispatch(frame);
+    }
+  }
+
+  #dispatch(frame: RequestFrame): void {
+    const task = this.#handleRequest(frame)
+      .catch(() => this.#teardown())
+      .finally(() => {
+        if (this.#requests.get(frame.requestId) === task) {
+          this.#requests.delete(frame.requestId);
+        }
+      });
+    this.#requests.set(frame.requestId, task);
+  }
+
+  async #handleRequest(frame: RequestFrame): Promise<void> {
+    const admission = await this.#options.beginOperation(frame);
+    if (typeof admission === 'string') {
+      if (this.#closed) return;
+      await this.#writer.enqueue(
+        operationFailureResponse(
+          frame,
+          admission,
+          admission === 'host_draining' ? 'Runtime Host is draining' : 'Runtime Host is not ready',
+        ),
+      ).flushed;
+      return;
+    }
+
+    try {
+      if (this.#closed) return;
+      const response = await dispatchOperation(frame, this.#options.resolveHandlers(), {
+        ...this.#options.connection,
+        acquireResidency: () => admission.acquireResidency(),
+      });
+      admission.seal();
+      await this.#writer.enqueue(response).flushed;
+    } finally {
+      admission.finish();
+    }
+  }
+
+  #teardown(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#writer.close();
+    this.#options.transport.destroy();
+    this.#options.onTeardown();
+  }
+}

--- a/packages/runtime-host/src/server/connection-session.ts
+++ b/packages/runtime-host/src/server/connection-session.ts
@@ -12,6 +12,7 @@ import {
   type OperationResidency,
 } from './operation-dispatcher.js';
 import { BoundedSerialOutboundWriter } from './serial-outbound-writer.js';
+import { RuntimeHostTransportError } from '../transport/framed-transport.js';
 
 const MAX_IN_FLIGHT_REQUESTS = 64;
 
@@ -44,7 +45,12 @@ export class RuntimeHostConnectionSession {
 
   async run(): Promise<void> {
     try {
-      await this.#pumpInbound();
+      try {
+        await this.#pumpInbound();
+      } catch (error) {
+        if (!isReadEof(error)) throw error;
+        await this.#closeAfterDispatchedReplies();
+      }
     } catch {
       this.#teardown();
     } finally {
@@ -52,6 +58,24 @@ export class RuntimeHostConnectionSession {
       await Promise.allSettled(this.#requests.values());
       await Promise.all([this.#writer.settled(), this.#options.transport.closed]);
     }
+  }
+
+  async #closeAfterDispatchedReplies(): Promise<void> {
+    const outcome = await Promise.race([
+      Promise.allSettled([...this.#requests.values()]).then(() => 'drained' as const),
+      this.#options.transport.closed.then(() => 'closed' as const),
+    ]);
+    if (outcome === 'closed') {
+      this.#teardown();
+      return;
+    }
+    if (this.#closed) return;
+    await this.#writer.settled();
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#writer.close();
+    this.#options.transport.destroyAfterFlush();
+    this.#options.onTeardown();
   }
 
   async #pumpInbound(): Promise<void> {
@@ -111,4 +135,8 @@ export class RuntimeHostConnectionSession {
     this.#options.transport.destroy();
     this.#options.onTeardown();
   }
+}
+
+function isReadEof(error: unknown): boolean {
+  return error instanceof RuntimeHostTransportError && error.code === 'read_eof';
 }

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -105,7 +105,7 @@ export class RuntimeHostKernel {
       this.#resolveClosed = resolve;
       this.#rejectClosed = reject;
     });
-    this.#server = createServer((socket) => this.#accept(socket));
+    this.#server = createServer({ allowHalfOpen: true }, (socket) => this.#accept(socket));
   }
 
   static async start(options: RuntimeHostKernelOptions): Promise<RuntimeHostKernel> {

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -22,9 +22,10 @@ import {
 } from '../protocol/index.js';
 import { FramedTransport } from '../transport/framed-transport.js';
 import {
-  dispatchOperation,
-  operationFailureResponse,
-  type ConnectionContext,
+  RuntimeHostConnectionSession,
+  type ConnectionOperationLease,
+} from './connection-session.js';
+import {
   type DomainOperationHandlerMap,
   type OperationResidency,
   type OperationHandlerMap,
@@ -62,14 +63,6 @@ export interface RuntimeHostKernelOptions {
   idleGraceMs?: number;
   handshakeTimeoutMs?: number;
   compositionFactory?: RuntimeHostCompositionFactory;
-}
-
-type AcceptedConnectionContext = Omit<ConnectionContext, 'acquireResidency'>;
-
-interface OperationLease {
-  acquireResidency(): RuntimeHostResidency;
-  seal(): void;
-  finish(): void;
 }
 
 export class RuntimeHostKernel {
@@ -193,61 +186,41 @@ export class RuntimeHostKernel {
 
   async #serveConnection(transport: FramedTransport): Promise<void> {
     let connectionAccepted = false;
+    let connectionReleased = false;
+    const releaseConnection = () => {
+      if (!connectionAccepted || connectionReleased) return;
+      connectionReleased = true;
+      this.#releaseConnection(transport);
+    };
     try {
       const frame = decodeClientFrame(await transport.read(this.#handshakeTimeoutMs));
       if (!('kind' in frame) || frame.kind !== 'hello') {
         throw new Error('First Runtime Host frame must be a hello');
       }
       const result = await this.#admitHandshake(frame, transport);
+      connectionAccepted = result.kind === 'accepted';
       await transport.write(result);
       if (result.kind !== 'accepted') {
         transport.destroyAfterFlush();
         return;
       }
-      connectionAccepted = true;
-      await this.#serveAcceptedConnection(transport, {
-        hostEpoch: this.hostEpoch,
-        connectionId: result.connectionId,
-        surface: frame.surface,
-        principal: 'local_os_user',
+      const session = new RuntimeHostConnectionSession({
+        transport,
+        connection: {
+          hostEpoch: this.hostEpoch,
+          connectionId: result.connectionId,
+          surface: frame.surface,
+          principal: 'local_os_user',
+        },
+        resolveHandlers: () => this.#operationHandlers,
+        beginOperation: (request) => this.#beginOperation(request),
+        onTeardown: releaseConnection,
       });
+      await session.run();
     } catch {
       transport.destroy();
     } finally {
-      if (connectionAccepted) this.#releaseConnection(transport);
-    }
-  }
-
-  async #serveAcceptedConnection(
-    transport: FramedTransport,
-    connection: AcceptedConnectionContext,
-  ): Promise<void> {
-    while (true) {
-      const frame = decodeClientFrame(await transport.read(0));
-      if ('kind' in frame) throw new Error('Unexpected handshake frame after acceptance');
-      const admission = await this.#beginOperation(frame);
-      if (typeof admission === 'string') {
-        await transport.write(
-          operationFailureResponse(
-            frame,
-            admission,
-            admission === 'host_draining'
-              ? 'Runtime Host is draining'
-              : 'Runtime Host is not ready',
-          ),
-        );
-        continue;
-      }
-      try {
-        const response = await dispatchOperation(frame, this.#operationHandlers, {
-          ...connection,
-          acquireResidency: () => admission.acquireResidency(),
-        });
-        admission.seal();
-        await transport.write(response);
-      } finally {
-        admission.finish();
-      }
+      releaseConnection();
     }
   }
 
@@ -292,7 +265,9 @@ export class RuntimeHostKernel {
     this.#settleLifecycleAfterWork();
   }
 
-  async #beginOperation(frame: RequestFrame): Promise<OperationLease | HostOperationErrorCode> {
+  async #beginOperation(
+    frame: RequestFrame,
+  ): Promise<ConnectionOperationLease | HostOperationErrorCode> {
     if (!(await this.#hasLiveOwnerOrDrain()) || this.#state === 'draining') return 'host_draining';
     if (this.#shutdownRequested && HOST_OPERATION_SPECS[frame.operation].mode === 'command') {
       return 'host_draining';

--- a/packages/runtime-host/src/server/serial-outbound-writer.ts
+++ b/packages/runtime-host/src/server/serial-outbound-writer.ts
@@ -14,6 +14,17 @@ export interface OutboundWriteReceipt {
   readonly flushed: Promise<void>;
 }
 
+export class RuntimeHostOutboundQueueError extends Error {
+  constructor(readonly code: 'frame_limit' | 'byte_limit') {
+    super(
+      code === 'frame_limit'
+        ? 'Runtime Host outbound queue exceeded its frame bound'
+        : 'Runtime Host outbound queue exceeded its byte bound',
+    );
+    this.name = 'RuntimeHostOutboundQueueError';
+  }
+}
+
 export class BoundedSerialOutboundWriter {
   readonly #transport: FramedTransport;
   readonly #onFailure: () => void;
@@ -41,11 +52,13 @@ export class BoundedSerialOutboundWriter {
       this.#fail(failure);
       throw failure;
     }
-    if (
-      this.#queue.length >= MAX_QUEUED_FRAMES ||
-      this.#queuedBytes + encoded.byteLength > MAX_QUEUED_BYTES
-    ) {
-      const failure = new Error('Runtime Host outbound queue exceeded its bound');
+    if (this.#queue.length >= MAX_QUEUED_FRAMES) {
+      const failure = new RuntimeHostOutboundQueueError('frame_limit');
+      this.#fail(failure);
+      throw failure;
+    }
+    if (this.#queuedBytes + encoded.byteLength > MAX_QUEUED_BYTES) {
+      const failure = new RuntimeHostOutboundQueueError('byte_limit');
       this.#fail(failure);
       throw failure;
     }

--- a/packages/runtime-host/src/server/serial-outbound-writer.ts
+++ b/packages/runtime-host/src/server/serial-outbound-writer.ts
@@ -1,0 +1,109 @@
+import { encodeProtocolFrame, type HostFrame } from '../protocol/index.js';
+import type { FramedTransport } from '../transport/framed-transport.js';
+
+const MAX_QUEUED_FRAMES = 64;
+const MAX_QUEUED_BYTES = 2 * 1024 * 1024;
+
+interface QueuedFrame {
+  encoded: Buffer;
+  resolve(): void;
+  reject(error: Error): void;
+}
+
+export interface OutboundWriteReceipt {
+  readonly flushed: Promise<void>;
+}
+
+export class BoundedSerialOutboundWriter {
+  readonly #transport: FramedTransport;
+  readonly #onFailure: () => void;
+  readonly #queue: QueuedFrame[] = [];
+  #queuedBytes = 0;
+  #writing = false;
+  #drainTask: Promise<void> | undefined;
+  #closed = false;
+
+  constructor(transport: FramedTransport, onFailure: () => void) {
+    this.#transport = transport;
+    this.#onFailure = onFailure;
+  }
+
+  enqueue(frame: HostFrame): OutboundWriteReceipt {
+    if (this.#closed) {
+      throw new Error('Runtime Host outbound writer is closed');
+    }
+
+    let encoded: Buffer;
+    try {
+      encoded = encodeProtocolFrame(frame);
+    } catch (error) {
+      const failure = asError(error);
+      this.#fail(failure);
+      throw failure;
+    }
+    if (
+      this.#queue.length >= MAX_QUEUED_FRAMES ||
+      this.#queuedBytes + encoded.byteLength > MAX_QUEUED_BYTES
+    ) {
+      const failure = new Error('Runtime Host outbound queue exceeded its bound');
+      this.#fail(failure);
+      throw failure;
+    }
+
+    const flushed = new Promise<void>((resolve, reject) => {
+      this.#queue.push({ encoded, resolve, reject });
+      this.#queuedBytes += encoded.byteLength;
+      if (!this.#writing) {
+        this.#writing = true;
+        this.#drainTask = this.#drain();
+      }
+    });
+    return { flushed };
+  }
+
+  settled(): Promise<void> {
+    return this.#drainTask ?? Promise.resolve();
+  }
+
+  close(
+    error = new Error('Runtime Host outbound writer closed before the frame was flushed'),
+  ): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const queued of this.#queue.splice(0)) queued.reject(error);
+    this.#queuedBytes = 0;
+  }
+
+  async #drain(): Promise<void> {
+    try {
+      while (!this.#closed) {
+        const queued = this.#queue[0];
+        if (!queued) return;
+        try {
+          await this.#transport.writeEncoded(queued.encoded);
+        } catch (error) {
+          this.#fail(asError(error));
+          return;
+        }
+        if (this.#closed) return;
+        this.#queue.shift();
+        this.#queuedBytes -= queued.encoded.byteLength;
+        queued.resolve();
+      }
+    } catch (error) {
+      this.#fail(asError(error));
+    } finally {
+      this.#writing = false;
+    }
+  }
+
+  #fail(error: Error): void {
+    if (this.#closed) return;
+    this.close(error);
+    this.#onFailure();
+  }
+}
+
+function asError(error: unknown): Error {
+  return error instanceof Error ? error : new Error(String(error));
+}

--- a/packages/runtime-host/src/transport/framed-transport.ts
+++ b/packages/runtime-host/src/transport/framed-transport.ts
@@ -2,12 +2,20 @@ import type { Socket } from 'node:net';
 import {
   encodeProtocolFrame,
   ProtocolFrameDecoder,
+  RUNTIME_HOST_MAX_FRAME_BYTES,
   RuntimeHostProtocolError,
   type ClientFrame,
   type HostFrame,
 } from '../protocol/index.js';
 
-const MAX_QUEUED_FRAMES = 32;
+const MAX_QUEUED_FRAMES = 64;
+const MAX_QUEUED_BYTES = 2 * 1024 * 1024;
+const MAX_BUFFERED_BYTES = 2 * 1024 * 1024;
+
+interface QueuedFrame {
+  value: unknown;
+  encodedBytes: number;
+}
 
 interface ReadWaiter {
   resolve(value: unknown): void;
@@ -29,9 +37,14 @@ export class RuntimeHostTransportError extends Error {
 export class FramedTransport {
   readonly closed: Promise<void>;
   readonly #decoder = new ProtocolFrameDecoder();
-  readonly #queue: unknown[] = [];
+  readonly #queue: QueuedFrame[] = [];
+  #queuedBytes = 0;
+  #buffered = Buffer.alloc(0);
   #waiter: ReadWaiter | undefined;
   #failure: Error | undefined;
+  #ended = false;
+  #decoderEnded = false;
+  #paused = false;
   #resolveClosed!: () => void;
 
   constructor(readonly socket: Socket) {
@@ -42,11 +55,8 @@ export class FramedTransport {
       this.#receive(typeof chunk === 'string' ? Buffer.from(chunk) : chunk),
     );
     socket.once('end', () => {
-      try {
-        this.#decoder.end();
-      } catch (error) {
-        this.#fail(asError(error));
-      }
+      this.#ended = true;
+      this.#drainInbound();
     });
     socket.once('error', (error) => this.#fail(error));
     socket.once('close', () => {
@@ -56,7 +66,12 @@ export class FramedTransport {
   }
 
   async read(timeoutMs: number): Promise<unknown> {
-    if (this.#queue.length > 0) return this.#queue.shift();
+    const queued = this.#queue.shift();
+    if (queued) {
+      this.#queuedBytes -= queued.encodedBytes;
+      this.#drainInbound();
+      return queued.value;
+    }
     if (this.#failure) throw this.#failure;
     if (this.#waiter) {
       throw new RuntimeHostTransportError(
@@ -78,12 +93,16 @@ export class FramedTransport {
         }, timeoutMs);
       }
       this.#waiter = waiter;
+      this.#drainInbound();
     });
   }
 
   write(frame: ClientFrame | HostFrame): Promise<void> {
+    return this.writeEncoded(encodeProtocolFrame(frame));
+  }
+
+  writeEncoded(encoded: Uint8Array): Promise<void> {
     if (this.#failure) return Promise.reject(this.#failure);
-    const encoded = encodeProtocolFrame(frame);
     return new Promise((resolve, reject) => {
       this.socket.write(encoded, (error) => {
         if (error) reject(error);
@@ -102,34 +121,98 @@ export class FramedTransport {
 
   #receive(chunk: Buffer): void {
     if (this.#failure) return;
-    let frames: unknown[];
+    if (this.#buffered.byteLength + chunk.byteLength > MAX_BUFFERED_BYTES) {
+      this.#failInboundOverflow();
+      return;
+    }
+    this.#buffered =
+      this.#buffered.byteLength === 0 ? Buffer.from(chunk) : Buffer.concat([this.#buffered, chunk]);
+    this.#drainInbound();
+  }
+
+  #drainInbound(): void {
+    if (this.#failure) return;
     try {
-      frames = this.#decoder.push(chunk);
+      while (true) {
+        const newline = this.#buffered.indexOf(0x0a);
+        if (newline === -1) {
+          if (this.#buffered.byteLength > RUNTIME_HOST_MAX_FRAME_BYTES) {
+            throw new RuntimeHostProtocolError(
+              'frame_too_large',
+              'Runtime Host frame exceeds the byte limit',
+            );
+          }
+          break;
+        }
+        const encodedBytes = newline + 1;
+        if (
+          !this.#waiter &&
+          (this.#queue.length >= MAX_QUEUED_FRAMES ||
+            this.#queuedBytes + encodedBytes > MAX_QUEUED_BYTES)
+        ) {
+          break;
+        }
+        const encoded = this.#buffered.subarray(0, encodedBytes);
+        this.#buffered = this.#buffered.subarray(encodedBytes);
+        const frames = this.#decoder.push(encoded);
+        if (frames.length !== 1) {
+          throw new Error('Runtime Host decoder did not produce one complete frame');
+        }
+        this.#deliver(frames[0], encodedBytes);
+      }
+      if (this.#ended && !this.#decoderEnded && this.#buffered.indexOf(0x0a) === -1) {
+        if (this.#buffered.byteLength !== 0) {
+          this.#decoder.push(this.#buffered);
+          this.#buffered = Buffer.alloc(0);
+        }
+        this.#decoder.end();
+        this.#decoderEnded = true;
+      }
     } catch (error) {
       this.#fail(asError(error));
       this.socket.destroy();
       return;
     }
-    for (const frame of frames) {
-      if (this.#waiter) {
-        const waiter = this.#waiter;
-        this.#waiter = undefined;
-        if (waiter.timer) clearTimeout(waiter.timer);
-        waiter.resolve(frame);
-      } else {
-        this.#queue.push(frame);
-        if (this.#queue.length > MAX_QUEUED_FRAMES) {
-          this.#fail(
-            new RuntimeHostTransportError(
-              'inbound_queue_full',
-              'Runtime Host inbound frame queue is full',
-            ),
-          );
-          this.socket.destroy();
-          return;
-        }
-      }
+    this.#updateReadFlow();
+  }
+
+  #deliver(frame: unknown, encodedBytes: number): void {
+    if (this.#waiter) {
+      const waiter = this.#waiter;
+      this.#waiter = undefined;
+      if (waiter.timer) clearTimeout(waiter.timer);
+      waiter.resolve(frame);
+    } else {
+      this.#queue.push({ value: frame, encodedBytes });
+      this.#queuedBytes += encodedBytes;
     }
+  }
+
+  #updateReadFlow(): void {
+    const nextNewline = this.#buffered.indexOf(0x0a);
+    const nextFrameBytes = nextNewline === -1 ? undefined : nextNewline + 1;
+    const blocked =
+      this.#queue.length >= MAX_QUEUED_FRAMES ||
+      (nextFrameBytes !== undefined && this.#queuedBytes + nextFrameBytes > MAX_QUEUED_BYTES);
+    if (blocked && !this.#paused) {
+      this.#paused = true;
+      this.socket.pause();
+      return;
+    }
+    if (!blocked && this.#paused && !this.#ended) {
+      this.#paused = false;
+      this.socket.resume();
+    }
+  }
+
+  #failInboundOverflow(): void {
+    this.#fail(
+      new RuntimeHostTransportError(
+        'inbound_queue_full',
+        'Runtime Host inbound byte buffer is full',
+      ),
+    );
+    this.socket.destroy();
   }
 
   #fail(error: Error): void {

--- a/packages/runtime-host/src/transport/framed-transport.ts
+++ b/packages/runtime-host/src/transport/framed-transport.ts
@@ -25,7 +25,12 @@ interface ReadWaiter {
 
 export class RuntimeHostTransportError extends Error {
   constructor(
-    readonly code: 'closed' | 'read_timeout' | 'concurrent_read' | 'inbound_queue_full',
+    readonly code:
+      | 'closed'
+      | 'read_eof'
+      | 'read_timeout'
+      | 'concurrent_read'
+      | 'inbound_queue_full',
     message: string,
     options?: ErrorOptions,
   ) {
@@ -42,6 +47,7 @@ export class FramedTransport {
   #buffered = Buffer.alloc(0);
   #waiter: ReadWaiter | undefined;
   #failure: Error | undefined;
+  #readTerminal: RuntimeHostTransportError | undefined;
   #ended = false;
   #decoderEnded = false;
   #paused = false;
@@ -59,8 +65,10 @@ export class FramedTransport {
       this.#drainInbound();
     });
     socket.once('error', (error) => this.#fail(error));
-    socket.once('close', () => {
-      this.#fail(new RuntimeHostTransportError('closed', 'Runtime Host transport closed'));
+    socket.once('close', (hadError) => {
+      if (!this.#readTerminal || hadError) {
+        this.#fail(new RuntimeHostTransportError('closed', 'Runtime Host transport closed'));
+      }
       this.#resolveClosed();
     });
   }
@@ -73,6 +81,7 @@ export class FramedTransport {
       return queued.value;
     }
     if (this.#failure) throw this.#failure;
+    if (this.#readTerminal) throw this.#readTerminal;
     if (this.#waiter) {
       throw new RuntimeHostTransportError(
         'concurrent_read',
@@ -167,6 +176,7 @@ export class FramedTransport {
         }
         this.#decoder.end();
         this.#decoderEnded = true;
+        this.#endRead();
       }
     } catch (error) {
       this.#fail(asError(error));
@@ -213,6 +223,19 @@ export class FramedTransport {
       ),
     );
     this.socket.destroy();
+  }
+
+  #endRead(): void {
+    if (this.#readTerminal || this.#failure) return;
+    this.#readTerminal = new RuntimeHostTransportError(
+      'read_eof',
+      'Runtime Host transport read side ended',
+    );
+    if (!this.#waiter) return;
+    const waiter = this.#waiter;
+    this.#waiter = undefined;
+    if (waiter.timer) clearTimeout(waiter.timer);
+    waiter.reject(this.#readTerminal);
   }
 
   #fail(error: Error): void {


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

This PR establishes the complete full-duplex connection transport/session foundation for the Runtime Host:

- accepted connections keep a continuous inbound pump and dispatch independent requests concurrently;
- responses are correlated by `requestId` and serialized through one bounded FIFO writer, so reverse completion cannot corrupt framing;
- inbound delivery is bounded by both frame count and encoded bytes, using socket pause/resume backpressure instead of disconnecting a healthy burst before the session can consume it;
- clean read-side EOF is a typed terminal state: accepted frames drain first, the Host preserves the writable half, and the session flushes replies for work already dispatched before it closes;
- reset, protocol failure, duplicate active request IDs, the 65th in-flight request, write failure, and overload fail fast and tear down only the offending connection;
- a connection accepted while the Host composition is still being built resolves the current handler map for each operation, so it becomes usable after Ready without reconnecting.

## Boundary and decisions

`RuntimeHostConnectionSession` owns the lifetime of one accepted connection. The Kernel continues to own operation admission and residency; the session pumps frames, dispatches admitted work, serializes replies, and performs idempotent connection cleanup.

Clean EOF and hard failure intentionally follow different paths. `FramedTransport` reports `read_eof` only after its accepted frame queue is exhausted, without disabling writes on the half-open socket. The session then stops accepting input, waits for every already-dispatched admission/handler and writer receipt, and closes after flush. A reset or any other transport/protocol failure retains immediate teardown semantics.

The outbound writer separates synchronous queue admission from asynchronous `receipt.flushed` completion. Its queue is capped independently at 64 frames and 2 MiB; internal typed causes distinguish the frame and byte bounds without adding a wire-level teardown reason.

`FramedTransport` retains complete encoded frames while its decoded queue is full, pauses the socket, and resumes as reads release capacity. An oversized partial frame still fails closed, and EOF with a trailing partial frame remains a protocol error rather than clean EOF.

This is the transport/session foundation consumed by later continuity and native-provider slices. Those slices can attach domain behavior without redefining connection flow control or writer semantics.

## Scope

This PR does not add Session subscriptions, Interactive domain owners, native-provider frames, surface wiring, or a production cutover. It also deliberately leaves Client-visible teardown reasons and the command outcome journal to the continuity/protocol slice. Existing production entrypoints remain unchanged, and no protocol operation shape changes.

## Validation

Real socket and Runtime Host tests cover reverse completion, FIFO flush, the 2 MiB writer cause before the frame limit, clean half-close reply draining, hard reset during pending admission, pre-Ready connections, duplicate/in-flight limits, slow-reader isolation, inbound frame/byte backpressure, and oversized/partial frames. The full Runtime Host suite passes 60 tests; root build, typecheck, lint, and format checks pass.

Tracked by #1167. Architectural context: #853.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

本 PR 完整建立 Runtime Host 的全双工 connection transport/session 基础：

- accepted connection 持续运行 inbound pump，并发 dispatch 相互独立的 request；
- response 通过 `requestId` 关联，并经过唯一、有界的 FIFO writer 串行写出，因此 handler 逆序完成不会破坏 framing；
- inbound delivery 同时受 frame 数与 encoded bytes 约束，通过 socket pause/resume 施加背压，避免 session 尚未来得及消费时就把正常 burst 误判为连接故障；
- clean read-side EOF 是 typed 终态：先排空已经接纳的 frame，Host 保留可写半连接，session 在关闭前 flush EOF 前已 dispatch 工作的回复；
- reset、protocol failure、duplicate active request ID、第 65 个 in-flight request、写失败与过载保持 fail fast，并且只关闭问题连接；
- connection 可以在 Host composition 尚未构建完成时被接受，并在每次 operation dispatch 时解析当前 handler map，因此 Host Ready 后无需重连即可正常使用。

## 边界与决策

`RuntimeHostConnectionSession` 负责一个 accepted connection 的生命周期。Kernel 继续拥有 operation admission 与 residency；session 负责 pump frame、dispatch 已接纳工作、串行回复与幂等 connection cleanup。

clean EOF 与 hard failure 有意采用不同路径。`FramedTransport` 只在已经接纳的 frame queue 排空后报告 `read_eof`，并且不会禁用 half-open socket 的写侧。session 随后停止接收输入，等待 EOF 前已 dispatch 的 admission/handler 与 writer receipt 全部完成，并在 flush 后关闭。reset 或其他 transport/protocol failure 仍立即 teardown。

outbound writer 区分同步 queue admission 与异步 `receipt.flushed` 完成。队列分别受 64 frame 与 2 MiB 上限约束；内部 typed cause 会区分 frame bound 与 byte bound，但不会因此增加 wire-level teardown reason。

`FramedTransport` 会在 decoded queue 满时保留完整 encoded frame、暂停 socket，并在 read 释放容量后恢复。超大的 partial frame 仍然 fail closed；EOF 末尾存在 partial frame 时仍属于 protocol error，而不是 clean EOF。

这是后续 continuity 与 native-provider slice 共用的 transport/session 基础。后续 slice 可以接入各自领域行为，无需重新定义 connection flow control 或 writer 语义。

## 范围

本 PR 不增加 Session subscription、Interactive domain owner、native-provider frame、surface wiring 或 production cutover。Client 可见的 teardown reason 与 command outcome journal 明确保留给 continuity/protocol slice。现有 production entrypoint 保持不变，protocol operation shape 也没有变化。

## 验证

真实 socket 与 Runtime Host 测试覆盖 handler 逆序完成、FIFO flush、在 frame limit 前触发 2 MiB writer cause、clean half-close 后回复排空、pending admission 期间的 hard reset、pre-Ready connection、duplicate/in-flight 上限、慢读者隔离、inbound frame/byte backpressure，以及 oversized/partial frame。Runtime Host 全量 60 项通过；根级 build、typecheck、lint 与 format check 通过。

由 #1167 跟踪；架构背景见 #853。

</details>
