### PR TITLE
refactor(headless): extract a shared experiment engine from the A/B run scripts

### DIFF
--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { readFile, rename, writeFile } from 'node:fs/promises';
 import { createHash } from 'node:crypto';
 import { execFile } from 'node:child_process';
 import { homedir } from 'node:os';
@@ -59,6 +59,7 @@ import {
 } from '#harness-ab-report';
 import { envPath as parseEnvPath } from '#headless-run-env';
 import { buildSubjectFingerprint, buildToolchainFingerprint } from '#experiment-fingerprint';
+import { runExperiment } from '#experiment-engine';
 
 const execFileAsync = promisify(execFile);
 
@@ -619,98 +620,98 @@ async function runLocked({
     (await readFile(credentials.apiKeyFile, 'utf8')).trim().length === 0
   )
     throw new Error('harness credential is empty');
-  const controllerDir = join(runRoot, 'controller');
-  const promptsDir = join(runRoot, 'prompts');
-  const jobsDir = join(runRoot, 'jobs');
-  await mkdir(controllerDir, { recursive: true });
-  await mkdir(promptsDir, { recursive: true });
-  await mkdir(jobsDir, { recursive: true });
-  const systemPromptPath = join(promptsDir, 'default-system-prompt.txt');
-  await writeFile(systemPromptPath, DEFAULT_HEADLESS_SYSTEM_PROMPT, 'utf8');
-  const runnerOptions = {
-    makaRepoPath,
-    jobsDir,
-    model: execution.modelSpec,
-    provider: execution.provider,
-    reasoningEffort: execution.reasoningEffort,
-    ...credentials,
-    pricing: execution.pricing,
-    agentEnv: { MAKA_BASE_URL: execution.baseUrl },
-    timeoutMultiplier: 1,
-    dockerPlatform: 'linux/amd64',
-  };
-  const makaContextBudgetEnv = harnessMakaContextBudgetEnv();
-  const config = (id) => ({
-    id: `harness-ab-${id}`,
-    backend: 'ai-sdk',
-    llmConnectionSlug: execution.provider,
-    model: execution.model,
-    thinkingLevel: execution.reasoningEffort,
-  });
-  const summary = await runHarnessAbComparisonUnlocked({
-    runId,
+  const systemPromptPath = join(runRoot, 'prompts', 'default-system-prompt.txt');
+  const evaluatedTaskIds = new Set(evaluationTasks.map((task) => task.id));
+
+  const report = await runExperiment({
     runRoot,
-    resultsJsonlPath: join(controllerDir, 'results.jsonl'),
-    systemPromptPath,
-    resumeFingerprint: buildHarnessAbResumeFingerprint(manifest),
-    evaluationTasks,
-    arms: [
+    prompts: () => [{ path: systemPromptPath, content: DEFAULT_HEADLESS_SYSTEM_PROMPT }],
+    run: async ({ jobsDir, resultsJsonlPath }) => {
+      const runnerOptions = {
+        makaRepoPath,
+        jobsDir,
+        model: execution.modelSpec,
+        provider: execution.provider,
+        reasoningEffort: execution.reasoningEffort,
+        ...credentials,
+        pricing: execution.pricing,
+        agentEnv: { MAKA_BASE_URL: execution.baseUrl },
+        timeoutMultiplier: 1,
+        dockerPlatform: 'linux/amd64',
+      };
+      const makaContextBudgetEnv = harnessMakaContextBudgetEnv();
+      const config = (id) => ({
+        id: `harness-ab-${id}`,
+        backend: 'ai-sdk',
+        llmConnectionSlug: execution.provider,
+        model: execution.model,
+        thinkingLevel: execution.reasoningEffort,
+      });
+      const summary = await runHarnessAbComparisonUnlocked({
+        runId,
+        runRoot,
+        resultsJsonlPath,
+        systemPromptPath,
+        resumeFingerprint: buildHarnessAbResumeFingerprint(manifest),
+        evaluationTasks,
+        arms: [
+          {
+            id: 'maka',
+            config: config('maka'),
+            expectedPricingProfile: execution.pricing.source,
+            billingMode: execution.billingMode,
+            harborRunner: createHarborTaskRunner({
+              ...runnerOptions,
+              agent: 'maka',
+              agentEnv: { ...runnerOptions.agentEnv, ...makaContextBudgetEnv },
+            }),
+          },
+          {
+            id: competitorProfile.id,
+            config: config(competitorProfile.id),
+            expectedPricingProfile: execution.pricing.source,
+            billingMode: execution.billingMode,
+            harborRunner: createHarborTaskRunner({
+              ...runnerOptions,
+              agent: competitorProfile.id,
+              agentVersion: competitorProfile.version,
+              ...(competitorProfile.id === 'kimi-code'
+                ? { kimiCodeToolchainPath: competitorToolchain.path }
+                : competitorProfile.id === 'opencode'
+                  ? { opencodeToolchainPath: competitorToolchain.path }
+                  : { codexToolchainPath: competitorToolchain.path }),
+            }),
+          },
+        ],
+        pairConcurrency: manifest.maxConcurrency,
+        armExecution: manifest.metadata.execution.armExecution,
+      });
+      return buildHarnessAbReport(
+        summary,
+        {
+          ...(oracleEvidence.resolvedSnapshotFingerprint
+            ? { snapshotFingerprint: oracleEvidence.resolvedSnapshotFingerprint }
+            : {}),
+          annotations: oracleEvidence.annotations.filter((annotation) =>
+            evaluatedTaskIds.has(annotation.taskId),
+          ),
+          warnings: oracleEvidence.warnings,
+        },
+        execution.billingMode,
+      );
+    },
+    artifacts: (report) => [
       {
-        id: 'maka',
-        config: config('maka'),
-        expectedPricingProfile: execution.pricing.source,
-        billingMode: execution.billingMode,
-        harborRunner: createHarborTaskRunner({
-          ...runnerOptions,
-          agent: 'maka',
-          agentEnv: { ...runnerOptions.agentEnv, ...makaContextBudgetEnv },
-        }),
+        path: join(runRoot, 'harness-ab-report.json'),
+        content: `${JSON.stringify(report, null, 2)}\n`,
       },
+      { path: join(runRoot, 'harness-ab-report.csv'), content: renderHarnessAbReportCsv(report) },
       {
-        id: competitorProfile.id,
-        config: config(competitorProfile.id),
-        expectedPricingProfile: execution.pricing.source,
-        billingMode: execution.billingMode,
-        harborRunner: createHarborTaskRunner({
-          ...runnerOptions,
-          agent: competitorProfile.id,
-          agentVersion: competitorProfile.version,
-          ...(competitorProfile.id === 'kimi-code'
-            ? { kimiCodeToolchainPath: competitorToolchain.path }
-            : competitorProfile.id === 'opencode'
-              ? { opencodeToolchainPath: competitorToolchain.path }
-              : { codexToolchainPath: competitorToolchain.path }),
-        }),
+        path: join(runRoot, 'harness-ab-report.md'),
+        content: renderHarnessAbReportMarkdown(report),
       },
     ],
-    pairConcurrency: manifest.maxConcurrency,
-    armExecution: manifest.metadata.execution.armExecution,
   });
-  const evaluatedTaskIds = new Set(evaluationTasks.map((task) => task.id));
-  const report = buildHarnessAbReport(
-    summary,
-    {
-      ...(oracleEvidence.resolvedSnapshotFingerprint
-        ? { snapshotFingerprint: oracleEvidence.resolvedSnapshotFingerprint }
-        : {}),
-      annotations: oracleEvidence.annotations.filter((annotation) =>
-        evaluatedTaskIds.has(annotation.taskId),
-      ),
-      warnings: oracleEvidence.warnings,
-    },
-    execution.billingMode,
-  );
-  await writeFile(
-    join(runRoot, 'harness-ab-report.json'),
-    `${JSON.stringify(report, null, 2)}\n`,
-    'utf8',
-  );
-  await writeFile(join(runRoot, 'harness-ab-report.csv'), renderHarnessAbReportCsv(report), 'utf8');
-  await writeFile(
-    join(runRoot, 'harness-ab-report.md'),
-    renderHarnessAbReportMarkdown(report),
-    'utf8',
-  );
   assertHarnessAbReportCompleted(report);
   console.log(
     `${report.runStatus}: ${report.coverage.attemptedCells}/${report.coverage.scheduledCells} cells attempted; ${report.effectiveness.pairedEvaluated} paired Pass@1 outcomes -> ${runRoot}`,

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -550,11 +550,14 @@ async function runLocked({
   const subjectFingerprint = await buildSubjectFingerprint(
     makaRepoPath,
     process.env.MAKA_HARNESS_AB_EXPLICIT_SUBJECT_FINGERPRINT,
+    undefined,
+    'MAKA_HARNESS_AB',
   );
   const hostToolchainFingerprint = await buildToolchainFingerprint(
     process.env.MAKA_HARNESS_AB_TOOLCHAIN_FINGERPRINT,
     undefined,
     makaRepoPath,
+    'MAKA_HARNESS_AB',
   );
   const [verifierImplementationSource, composeImplementationSource] = await Promise.all([
     readFile(join(makaRepoPath, 'packages/headless/harbor/maka_verifier.py')),

--- a/packages/headless/harbor/run-prompt-ab.mjs
+++ b/packages/headless/harbor/run-prompt-ab.mjs
@@ -9,11 +9,12 @@
 //   node packages/headless/harbor/run-prompt-ab.mjs
 
 import { createHash } from 'node:crypto';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { basename, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '@maka/headless';
+import { runExperiment } from '#experiment-engine';
 import {
   discoverCachedHarborTasks,
   resolveFixedPromptRunRoot,
@@ -81,9 +82,9 @@ async function main() {
   const candidatePromptId =
     process.env.MAKA_PROMPT_AB_CANDIDATE_ID || promptIdFromPath(candidatePromptSourcePath);
   const runRoot = resolveFixedPromptRunRoot(outDir, runId, 'MAKA_PROMPT_AB_RUN_ID');
-  const controllerDir = join(runRoot, 'controller');
-  const jobsDir = join(runRoot, 'jobs');
   const promptsDir = join(runRoot, 'prompts');
+  const baselinePromptPath = join(promptsDir, 'maka-baseline.md');
+  const candidatePromptPath = join(promptsDir, `candidate-${basename(candidatePromptSourcePath)}`);
   const provider = 'deepseek';
   const baseUrl = process.env.MAKA_PROMPT_AB_BASE_URL || 'https://api.deepseek.com';
   const model = 'deepseek/deepseek-v4-flash';
@@ -169,69 +170,75 @@ async function main() {
   });
   await ensurePromptAbRunManifest(join(runRoot, 'prompt-ab-manifest.json'), runManifest);
 
-  await mkdir(controllerDir, { recursive: true });
-  await mkdir(jobsDir, { recursive: true });
-  await mkdir(promptsDir, { recursive: true });
-  const baselinePromptPath = join(promptsDir, 'maka-baseline.md');
-  const candidatePromptPath = join(promptsDir, `candidate-${basename(candidatePromptSourcePath)}`);
-  await writeFile(baselinePromptPath, baselinePrompt, 'utf8');
-  await writeFile(candidatePromptPath, candidatePrompt, 'utf8');
-
   const config = {
     id: 'prompt-ab',
     backend: 'harbor',
     llmConnectionSlug: provider,
     model,
   };
-  const harborRunner = createHarborTaskRunner({
-    makaRepoPath,
-    jobsDir,
-    model,
-    provider,
-    apiKeyFile: keyFile,
-    pricing: DEEPSEEK_V4_FLASH_PRICING,
-    agentEnv: { DEEPSEEK_BASE_URL: baseUrl, MAKA_CELL_TIMEOUT_SEC: String(taskBudgetSec) },
-    ...(harborTimeoutMs !== undefined ? { harborTimeoutMs } : {}),
-  });
-  const resultsJsonlPath = join(controllerDir, 'results.jsonl');
-
-  const summary = await runPromptAbComparison({
-    runId,
-    config,
-    baselinePromptPath,
-    candidatePromptPath,
-    candidatePromptId,
-    resultsJsonlPath,
-    evaluationTasks,
-    reps,
-    maxConcurrency,
-    resumeFingerprint: runManifest.fingerprint,
-    budgetMs: taskBudgetSec * 1000,
-    nonInferiorityMargin,
-    harborRunner,
-  });
-
-  const output = {
-    schemaVersion: 'maka.prompt_ab.v2',
-    runId,
-    candidatePromptSourcePath,
-    maxConcurrency,
-    taskBudgetSec,
-    harborTimeoutMs,
-    targetEvaluationTaskCount: targetEvaluationTaskCount ?? null,
-    runManifest,
-    metadataFilter,
-    candidateTaskLimit,
-    summary,
-  };
   const resultPath = join(runRoot, 'prompt-ab-result.json');
   const reportPath = join(runRoot, 'prompt-ab-report.md');
-  await writeFile(resultPath, `${JSON.stringify(output, null, 2)}\n`, 'utf8');
-  await writeFile(
-    reportPath,
-    `${renderMetadataFilterMarkdown(metadataFilter)}${renderCandidateLimitMarkdown(candidateTaskLimit)}${renderPromptAbRunManifestMarkdown(runManifest)}${renderPromptAbComparisonMarkdown(summary)}`,
-    'utf8',
-  );
+
+  const summary = await runExperiment({
+    runRoot,
+    prompts: () => [
+      { path: baselinePromptPath, content: baselinePrompt },
+      { path: candidatePromptPath, content: candidatePrompt },
+    ],
+    run: ({ jobsDir, resultsJsonlPath }) => {
+      const harborRunner = createHarborTaskRunner({
+        makaRepoPath,
+        jobsDir,
+        model,
+        provider,
+        apiKeyFile: keyFile,
+        pricing: DEEPSEEK_V4_FLASH_PRICING,
+        agentEnv: { DEEPSEEK_BASE_URL: baseUrl, MAKA_CELL_TIMEOUT_SEC: String(taskBudgetSec) },
+        ...(harborTimeoutMs !== undefined ? { harborTimeoutMs } : {}),
+      });
+      return runPromptAbComparison({
+        runId,
+        config,
+        baselinePromptPath,
+        candidatePromptPath,
+        candidatePromptId,
+        resultsJsonlPath,
+        evaluationTasks,
+        reps,
+        maxConcurrency,
+        resumeFingerprint: runManifest.fingerprint,
+        budgetMs: taskBudgetSec * 1000,
+        nonInferiorityMargin,
+        harborRunner,
+      });
+    },
+    artifacts: (summary) => [
+      {
+        path: resultPath,
+        content: `${JSON.stringify(
+          {
+            schemaVersion: 'maka.prompt_ab.v2',
+            runId,
+            candidatePromptSourcePath,
+            maxConcurrency,
+            taskBudgetSec,
+            harborTimeoutMs,
+            targetEvaluationTaskCount: targetEvaluationTaskCount ?? null,
+            runManifest,
+            metadataFilter,
+            candidateTaskLimit,
+            summary,
+          },
+          null,
+          2,
+        )}\n`,
+      },
+      {
+        path: reportPath,
+        content: `${renderMetadataFilterMarkdown(metadataFilter)}${renderCandidateLimitMarkdown(candidateTaskLimit)}${renderPromptAbRunManifestMarkdown(runManifest)}${renderPromptAbComparisonMarkdown(summary)}`,
+      },
+    ],
+  });
 
   console.log('---');
   console.log(`decision: ${summary.decision} (${summary.reason})`);

--- a/packages/headless/harbor/run-runtime-policy-ab.mjs
+++ b/packages/headless/harbor/run-runtime-policy-ab.mjs
@@ -60,6 +60,8 @@ async function main() {
     subjectFingerprint: await buildSubjectFingerprint(
       makaRepoPath,
       process.env.MAKA_RUNTIME_AB_EXPLICIT_SUBJECT_FINGERPRINT,
+      undefined,
+      'MAKA_RUNTIME_AB',
     ),
     taskSourceFingerprint: await buildTaskSourceFingerprint(tasksRoot, [
       ...pilotTasks,
@@ -69,6 +71,7 @@ async function main() {
       process.env.MAKA_RUNTIME_AB_TOOLCHAIN_FINGERPRINT,
       undefined,
       makaRepoPath,
+      'MAKA_RUNTIME_AB',
     ),
     evaluationTaskIds: evaluationTasks.map((task) => task.id),
     pilotTaskIds: pilotTasks.map((task) => task.id),

--- a/packages/headless/harbor/run-runtime-policy-ab.mjs
+++ b/packages/headless/harbor/run-runtime-policy-ab.mjs
@@ -1,12 +1,13 @@
 #!/usr/bin/env node
 
 import { createHash } from 'node:crypto';
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '@maka/headless';
 import { ensureAbRunManifest } from '#ab-manifest';
+import { runExperiment } from '#experiment-engine';
 import {
   discoverCachedHarborTasks,
   resolveFixedPromptRunRoot,
@@ -94,14 +95,7 @@ async function main() {
     join(repoRoot, '.local-secrets/deepseek-key'),
   );
   await readFile(keyFile, 'utf8');
-  const controllerDir = join(runRoot, 'controller');
-  const jobsDir = join(runRoot, 'jobs');
-  const promptsDir = join(runRoot, 'prompts');
-  await mkdir(controllerDir, { recursive: true });
-  await mkdir(jobsDir, { recursive: true });
-  await mkdir(promptsDir, { recursive: true });
-  const systemPromptPath = join(promptsDir, 'shared-system-prompt.md');
-  await writeFile(systemPromptPath, systemPrompt, 'utf8');
+  const systemPromptPath = join(runRoot, 'prompts', 'shared-system-prompt.md');
   const config = {
     id: `runtime-policy-ab-${spec.id}`,
     backend: 'harbor',
@@ -113,47 +107,57 @@ async function main() {
     throw new Error(
       `runtime policy A/B provider ${executionProfile.provider} does not declare a base URL environment variable`,
     );
-  const harborRunner = createHarborTaskRunner({
-    makaRepoPath,
-    jobsDir,
-    model: executionProfile.model,
-    provider: executionProfile.provider,
-    apiKeyFile: keyFile,
-    pricing: executionProfile.pricing,
-    agentEnv: {
-      [baseUrlEnvName]: executionProfile.baseUrl,
-      MAKA_CELL_TIMEOUT_SEC: String(executionProfile.taskBudgetSec),
-    },
-    harborTimeoutMs: executionProfile.harborTimeoutMs,
-  });
-  const state = await runRuntimePolicyAbLifecycle({
-    runId,
+
+  const state = await runExperiment({
     runRoot,
-    manifestFingerprint: runManifest.fingerprint,
-    config,
-    systemPromptPath,
-    resultsJsonlPath: join(controllerDir, 'results.jsonl'),
-    pilotTasks,
-    evaluationTasks,
-    fullReps: spec.fullReps,
-    arms: spec.arms,
-    executionProfile,
-    nonInferiorityMargin: spec.nonInferiorityMargin,
-    sharedAgentEnv: spec.sharedAgentEnv,
-    resumeFingerprint: runManifest.fingerprint,
-    harborRunner,
+    prompts: () => [{ path: systemPromptPath, content: systemPrompt }],
+    run: ({ jobsDir, resultsJsonlPath }) => {
+      const harborRunner = createHarborTaskRunner({
+        makaRepoPath,
+        jobsDir,
+        model: executionProfile.model,
+        provider: executionProfile.provider,
+        apiKeyFile: keyFile,
+        pricing: executionProfile.pricing,
+        agentEnv: {
+          [baseUrlEnvName]: executionProfile.baseUrl,
+          MAKA_CELL_TIMEOUT_SEC: String(executionProfile.taskBudgetSec),
+        },
+        harborTimeoutMs: executionProfile.harborTimeoutMs,
+      });
+      return runRuntimePolicyAbLifecycle({
+        runId,
+        runRoot,
+        manifestFingerprint: runManifest.fingerprint,
+        config,
+        systemPromptPath,
+        resultsJsonlPath,
+        pilotTasks,
+        evaluationTasks,
+        fullReps: spec.fullReps,
+        arms: spec.arms,
+        executionProfile,
+        nonInferiorityMargin: spec.nonInferiorityMargin,
+        sharedAgentEnv: spec.sharedAgentEnv,
+        resumeFingerprint: runManifest.fingerprint,
+        harborRunner,
+      });
+    },
+    artifacts: (state) => [
+      {
+        path: join(runRoot, 'runtime-policy-ab-result.json'),
+        content: `${JSON.stringify({ runManifest, spec, state }, null, 2)}\n`,
+      },
+      ...(state.full
+        ? [
+            {
+              path: join(runRoot, 'runtime-policy-ab-report.md'),
+              content: renderRuntimePolicyAbComparisonMarkdown(state.full),
+            },
+          ]
+        : []),
+    ],
   });
-  await writeFile(
-    join(runRoot, 'runtime-policy-ab-result.json'),
-    `${JSON.stringify({ runManifest, spec, state }, null, 2)}\n`,
-    'utf8',
-  );
-  if (state.full)
-    await writeFile(
-      join(runRoot, 'runtime-policy-ab-report.md'),
-      renderRuntimePolicyAbComparisonMarkdown(state.full),
-      'utf8',
-    );
   console.log(
     `status: ${state.status}${state.reason ? ` (${state.reason})` : ''}${state.full ? `; decision: ${state.full.decision}` : ''}`,
   );

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -26,6 +26,7 @@
   "imports": {
     "#fixed-prompt-task-source": "./dist/fixed-prompt-task-source.js",
     "#headless-run-env": "./dist/headless-run-env.js",
+    "#experiment-engine": "./dist/experiment-engine.js",
     "#experiment-fingerprint": "./dist/experiment-fingerprint.js",
     "#deepseek-pricing": "./dist/deepseek-pricing.js",
     "#prompt-optimization-env": "./dist/prompt-optimization-env.js",

--- a/packages/headless/src/__tests__/experiment-engine.test.ts
+++ b/packages/headless/src/__tests__/experiment-engine.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { readFile, readdir, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import {
+  experimentRunLayout,
+  runExperiment,
+  type ExperimentRunLayout,
+} from '../experiment-engine.js';
+import { withDir } from './helpers/temp-dir.js';
+
+describe('runExperiment', () => {
+  test('resolves the standard controller/jobs/prompts layout', () => {
+    const layout = experimentRunLayout('/runs/abc');
+    assert.deepEqual(layout, {
+      runRoot: '/runs/abc',
+      controllerDir: '/runs/abc/controller',
+      jobsDir: '/runs/abc/jobs',
+      promptsDir: '/runs/abc/prompts',
+      resultsJsonlPath: '/runs/abc/controller/results.jsonl',
+    });
+  });
+
+  test('materializes dirs and prompts, runs, then persists artifacts in order', async () => {
+    await withDir(async (dir) => {
+      const runRoot = join(dir, 'run-1');
+      const events: string[] = [];
+      let runLayout: ExperimentRunLayout | undefined;
+
+      const summary = await runExperiment<{ decision: string }>({
+        runRoot,
+        prompts: (layout) => {
+          events.push('prompts');
+          return [{ path: join(layout.promptsDir, 'system.md'), content: 'hello prompt' }];
+        },
+        run: async (layout) => {
+          runLayout = layout;
+          // Directories and the prompt file must already exist before the run.
+          assert.ok((await stat(layout.controllerDir)).isDirectory());
+          assert.ok((await stat(layout.jobsDir)).isDirectory());
+          assert.equal(
+            await readFile(join(layout.promptsDir, 'system.md'), 'utf8'),
+            'hello prompt',
+          );
+          // Artifacts must not be written yet.
+          assert.deepEqual((await readdir(runRoot)).sort(), ['controller', 'jobs', 'prompts']);
+          events.push('run');
+          return { decision: 'keep' };
+        },
+        artifacts: (result, layout) => {
+          events.push('artifacts');
+          assert.equal(layout, runLayout);
+          return [
+            {
+              path: join(runRoot, 'result.json'),
+              content: `${JSON.stringify(result)}\n`,
+            },
+          ];
+        },
+      });
+
+      assert.deepEqual(summary, { decision: 'keep' });
+      assert.deepEqual(events, ['prompts', 'run', 'artifacts']);
+      assert.equal(await readFile(join(runRoot, 'result.json'), 'utf8'), '{"decision":"keep"}\n');
+    });
+  });
+
+  test('awaits an async artifacts builder', async () => {
+    await withDir(async (dir) => {
+      const runRoot = join(dir, 'run-2');
+      await runExperiment<number>({
+        runRoot,
+        prompts: () => [],
+        run: async () => 7,
+        artifacts: async (value) => [{ path: join(runRoot, 'value.txt'), content: String(value) }],
+      });
+      assert.equal(await readFile(join(runRoot, 'value.txt'), 'utf8'), '7');
+    });
+  });
+});

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -16,9 +16,9 @@ import {
   readHarborTaskRunOutput,
   runFixedPromptController,
   type FixedPromptWalEvent,
-  type HarborTaskRunInput,
-  type HarborTaskRunner,
-  type HarborTaskRunOutput,
+  type TaskRunInput,
+  type TaskRunner,
+  type TaskRunOutput,
 } from '../fixed-prompt-controller.js';
 
 const config: Config = {
@@ -44,7 +44,7 @@ describe('fixed prompt controller', () => {
         systemPromptPath,
         resultsJsonlPath: join(dir, 'results.jsonl'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => harborOutput({ taskId: 'task-a', verifier }),
+        taskRunner: async () => harborOutput({ taskId: 'task-a', verifier }),
       });
 
       assert.equal(result.events[0]?.type, 'task_completed');
@@ -79,7 +79,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         requireExecutionIdentity: true,
         expectedPricingProfile: 'test-profile',
-        harborRunner: async () => output,
+        taskRunner: async () => output,
       });
 
       assert.equal(result.events[0]?.type, 'task_plumbing_failed');
@@ -110,7 +110,7 @@ describe('fixed prompt controller', () => {
           { id: 'task-a', path: '/bench/task-a' },
           { id: 'task-b', path: '/bench/task-b' },
         ],
-        harborRunner: async ({ task }): Promise<HarborTaskRunOutput> => {
+        taskRunner: async ({ task }): Promise<TaskRunOutput> => {
           calls.push(task.id);
           return harborOutput({ taskId: task.id });
         },
@@ -147,7 +147,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           return harborOutput({ taskId: task.id });
         },
@@ -183,7 +183,7 @@ describe('fixed prompt controller', () => {
         resultsTsvPath: join(dir, 'matching.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         resumeFingerprint: 'fingerprint-old',
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           matchingCalls.push(task.id);
           return harborOutput({ taskId: task.id });
         },
@@ -203,7 +203,7 @@ describe('fixed prompt controller', () => {
         resultsTsvPath: join(dir, 'changed.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         resumeFingerprint: 'fingerprint-new',
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           changedCalls.push(task.id);
           return harborOutput({ taskId: task.id });
         },
@@ -233,7 +233,7 @@ describe('fixed prompt controller', () => {
         resultsTsvPath: join(dir, 'results-old.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         resumeFingerprint: 'fingerprint-same',
-        harborRunner: async () => {
+        taskRunner: async () => {
           throw new FixedPromptBudgetExhaustedError('harbor run timed out after 600s');
         },
         now: () => 100,
@@ -250,7 +250,7 @@ describe('fixed prompt controller', () => {
         resultsTsvPath: join(dir, 'results-new.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         resumeFingerprint: 'fingerprint-same',
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           return harborOutput({ taskId: task.id });
         },
@@ -312,7 +312,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         resumeFingerprint: 'fingerprint-same',
         requireExecutionIdentity: true,
-        harborRunner: async () => {
+        taskRunner: async () => {
           calls += 1;
           return harborOutput({ taskId: 'task-a' });
         },
@@ -357,7 +357,7 @@ describe('fixed prompt controller', () => {
           { id: 'task-a', path: '/bench/task-a' },
           { id: 'task-b', path: '/bench/task-b' },
         ],
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           return harborOutput({ taskId: task.id });
         },
@@ -380,7 +380,7 @@ describe('fixed prompt controller', () => {
           { id: 'task-a', path: '/bench/task-a' },
           { id: 'task-b', path: '/bench/task-b' },
         ],
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           secondCalls.push(task.id);
           return harborOutput({ taskId: task.id });
         },
@@ -458,7 +458,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           return harborOutput({ taskId: task.id });
         },
@@ -491,7 +491,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         resultsTsvPath,
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => harborOutput({ taskId: 'unused' }),
+        taskRunner: async () => harborOutput({ taskId: 'unused' }),
         now: () => 100,
         newId: idFactory(),
       });
@@ -521,7 +521,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => {
+        taskRunner: async () => {
           throw Object.assign(new Error('container crashed before result.json'), {
             artifactRefs: { providerTelemetryPath: '/logs/task-a/provider-request-telemetry.json' },
           });
@@ -559,7 +559,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         protectPassAtOne: true,
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           const wal = await readFile(`${resultsJsonlPath}.attempts.jsonl`, 'utf8');
           assert.match(wal, /"type":"task_attempt_started"/);
           assert.doesNotMatch(wal, /"type":"task_completed"/);
@@ -603,7 +603,7 @@ describe('fixed prompt controller', () => {
             tasks: [{ id: 'task-a', path: '/bench/task-a' }],
             infraFailurePolicy: 'terminal',
             protectPassAtOne: true,
-            harborRunner: async ({ task }) => {
+            taskRunner: async ({ task }) => {
               harborCalls += 1;
               return harborOutput({ taskId: task.id });
             },
@@ -637,7 +637,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         protectPassAtOne: true,
-        harborRunner: async () => {
+        taskRunner: async () => {
           harborCalls += 1;
           throw new Error('result collection failed after candidate sampling');
         },
@@ -676,7 +676,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         infraFailurePolicy: 'terminal',
         protectPassAtOne: true,
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           harborCalls += 1;
           return harborOutput({ taskId: task.id });
         },
@@ -706,7 +706,7 @@ describe('fixed prompt controller', () => {
         promptHash: hashSystemPrompt('fixed prompt\n'),
       });
       let harborCalls = 0;
-      const harborRunner: HarborTaskRunner = async ({ task }: HarborTaskRunInput) => {
+      const taskRunner: TaskRunner = async ({ task }: TaskRunInput) => {
         harborCalls += 1;
         return harborOutput({ taskId: task.id });
       };
@@ -720,7 +720,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         infraFailurePolicy: 'terminal',
         protectPassAtOne: true,
-        harborRunner,
+        taskRunner,
         now: () => 100,
         newId: idFactory(),
       });
@@ -752,7 +752,7 @@ describe('fixed prompt controller', () => {
         error: 'Harbor failed before the agent started',
       });
       let harborCalls = 0;
-      const harborRunner: HarborTaskRunner = async ({ task }: HarborTaskRunInput) => {
+      const taskRunner: TaskRunner = async ({ task }: TaskRunInput) => {
         harborCalls += 1;
         return harborOutput({ taskId: task.id });
       };
@@ -766,7 +766,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         infraFailurePolicy: 'terminal',
         protectPassAtOne: true,
-        harborRunner,
+        taskRunner,
         now: () => 100,
         newId: idFactory(),
       });
@@ -791,7 +791,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           attempts += 1;
           if (attempts === 1) throw new Error('transient container build hiccup');
           return harborOutput({ taskId: task.id });
@@ -824,7 +824,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => {
+        taskRunner: async () => {
           attempts += 1;
           throw new Error('container crashed both times');
         },
@@ -853,7 +853,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => {
+        taskRunner: async () => {
           attempts += 1;
           throw new FixedPromptBudgetExhaustedError('harbor run timed out after 600s');
         },
@@ -891,7 +891,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         requireExecutionIdentity: true,
         expectedPricingProfile: 'test-profile',
-        harborRunner: async () => {
+        taskRunner: async () => {
           throw new FixedPromptBudgetExhaustedError('timed out before cell output');
         },
         now: () => 100,
@@ -928,7 +928,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => {
+        taskRunner: async () => {
           throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, {
             tokenSummary: retainedUsage,
           });
@@ -975,7 +975,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         requireExecutionIdentity: true,
         expectedPricingProfile: 'test-profile',
-        harborRunner: async () => {
+        taskRunner: async () => {
           throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, {
             cellOutput: cell,
           });
@@ -1019,7 +1019,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         requireExecutionIdentity: true,
         expectedPricingProfile: 'test-profile',
-        harborRunner: async () => {
+        taskRunner: async () => {
           throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, {
             cellOutput: cell,
           });
@@ -1069,7 +1069,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         requireExecutionIdentity: true,
         expectedPricingProfile: 'test-profile',
-        harborRunner: async () => {
+        taskRunner: async () => {
           throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, {
             executionIdentity,
           });
@@ -1116,7 +1116,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         requireExecutionIdentity: true,
         expectedPricingProfile: 'test-profile',
-        harborRunner: async () => {
+        taskRunner: async () => {
           throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, {
             cellOutput: cell,
           });
@@ -1160,7 +1160,7 @@ describe('fixed prompt controller', () => {
           tasks: [{ id: 'task-a', path: '/bench/task-a' }],
           requireExecutionIdentity: true,
           expectedPricingProfile: 'test-profile',
-          harborRunner: async () => {
+          taskRunner: async () => {
             throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, {
               cellOutput: cell,
             });
@@ -1204,7 +1204,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         requireExecutionIdentity: true,
         expectedPricingProfile: 'test-profile',
-        harborRunner: async () => {
+        taskRunner: async () => {
           throw new FixedPromptBudgetExhaustedError('agent timed out', undefined, {
             cellOutput: cell,
           });
@@ -1235,7 +1235,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         resultsTsvPath: join(dir, 'results-old.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => {
+        taskRunner: async () => {
           throw new FixedPromptBudgetExhaustedError('harbor run timed out after 600s');
         },
         now: () => 100,
@@ -1251,7 +1251,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         resultsTsvPath: join(dir, 'results-new.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           return harborOutput({ taskId: task.id });
         },
@@ -1288,7 +1288,7 @@ describe('fixed prompt controller', () => {
           { id: 'task-e', path: '/bench/task-e' },
         ],
         maxInfraFailureRate: 0.2,
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           throw new Error(`container crashed for ${task.id}`);
         },
@@ -1330,7 +1330,7 @@ describe('fixed prompt controller', () => {
         ],
         maxConcurrency: 3,
         maxInfraFailureRate: 0.2,
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           inFlight += 1;
           maxInFlight = Math.max(maxInFlight, inFlight);
@@ -1361,7 +1361,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => {
+        taskRunner: async () => {
           throw new Error('should not run');
         },
         now: () => 100,
@@ -1413,7 +1413,7 @@ describe('fixed prompt controller', () => {
             { id: 'task-a', path: '/bench/task-a' },
             { id: 'task-a', path: '/bench/task-a-copy' },
           ],
-          harborRunner: async ({ task }) => {
+          taskRunner: async ({ task }) => {
             calls.push(task.id);
             return harborOutput({ taskId: task.id });
           },
@@ -1458,7 +1458,7 @@ describe('fixed prompt controller', () => {
           { id: 'task-e', path: '/bench/task-e' },
         ],
         maxInfraFailureRate: 0.2,
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           return harborOutput({ taskId: task.id });
         },
@@ -1490,7 +1490,7 @@ describe('fixed prompt controller', () => {
           { id: 'task-b', path: '/bench/task-b' },
         ],
         maxConcurrency: 1,
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           return harborOutput({
             taskId: task.id,
@@ -1530,7 +1530,7 @@ describe('fixed prompt controller', () => {
           { id: 'task-c', path: '/bench/task-c' },
         ],
         costCeilingUsd: 0.03,
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           return harborOutput({
             taskId: task.id,
@@ -1577,7 +1577,7 @@ describe('fixed prompt controller', () => {
         ],
         maxConcurrency: 3,
         costCeilingUsd: 0.03,
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           inFlight += 1;
           maxInFlight = Math.max(maxInFlight, inFlight);
@@ -1630,7 +1630,7 @@ describe('fixed prompt controller', () => {
           { id: 'task-b', path: '/bench/task-b' },
         ],
         costCeilingUsd: 0.01,
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           return harborOutput({ taskId: task.id });
         },
@@ -1666,7 +1666,7 @@ describe('fixed prompt controller', () => {
           { id: 'task-c', path: '/bench/task-c' },
         ],
         maxConcurrency: 2,
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           inFlight += 1;
           maxInFlight = Math.max(maxInFlight, inFlight);
           await delay(task.id === 'task-a' ? 20 : 0);
@@ -1713,7 +1713,7 @@ describe('fixed prompt controller', () => {
           { id: 'task-c', path: '/bench/task-c' },
         ],
         maxConcurrency: 2,
-        harborRunner: async ({ task }) => {
+        taskRunner: async ({ task }) => {
           calls.push(task.id);
           if (task.id === 'task-a') {
             await releaseA.promise;
@@ -1819,7 +1819,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({ taskId: 'task-a', contextBudgetPolicy, contextBudgetSummary }),
         now: () => 100,
         newId: idFactory(),
@@ -1864,7 +1864,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => harborOutput({ taskId: 'task-a', continuationSummary }),
+        taskRunner: async () => harborOutput({ taskId: 'task-a', continuationSummary }),
         now: () => 100,
         newId: idFactory(),
       });
@@ -1895,7 +1895,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath,
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => harborOutput({ taskId: 'task-a', taskToolSummary }),
+        taskRunner: async () => harborOutput({ taskId: 'task-a', taskToolSummary }),
         now: () => 100,
         newId: idFactory(),
       });
@@ -1922,7 +1922,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => harborOutput({ taskId: 'task-a', reward: 0 }),
+        taskRunner: async () => harborOutput({ taskId: 'task-a', reward: 0 }),
         now: () => 100,
         newId: idFactory(),
       });
@@ -1948,7 +1948,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             reward: 0,
@@ -1979,7 +1979,7 @@ describe('fixed prompt controller', () => {
         systemPromptPath,
         resultsJsonlPath: join(dir, 'results.jsonl'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             reward: 0,
@@ -2014,7 +2014,7 @@ describe('fixed prompt controller', () => {
         systemPromptPath,
         resultsJsonlPath: join(dir, 'results.jsonl'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             reward: 0,
@@ -2049,7 +2049,7 @@ describe('fixed prompt controller', () => {
         systemPromptPath,
         resultsJsonlPath: join(dir, 'results.jsonl'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             reward: 0,
@@ -2085,7 +2085,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             reward: 0,
@@ -2117,7 +2117,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             reward: 0,
@@ -2153,7 +2153,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             reward: 0,
@@ -2183,7 +2183,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             reward: 0,
@@ -2212,7 +2212,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             reward: 0,
@@ -2243,7 +2243,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             tokenSummary: tokenSummary({ input: 2, output: 1, reasoning: 0, total: 3, costUsd: 0 }),
@@ -2274,7 +2274,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         billingMode: 'account-plan',
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             tokenSummary: tokenSummary({ input: 2, output: 1, reasoning: 0, total: 3, costUsd: 0 }),
@@ -2305,7 +2305,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         requireExecutionIdentity: true,
         expectedPricingProfile: 'test-profile',
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             omitTokenSummary: true,
@@ -2342,7 +2342,7 @@ describe('fixed prompt controller', () => {
         requireExecutionIdentity: true,
         requireFinalUsage: true,
         expectedPricingProfile: 'test-profile',
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             omitTokenSummary: true,
@@ -2380,7 +2380,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         requireExecutionIdentity: true,
         expectedPricingProfile: 'test-profile',
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             status: 'failed',
@@ -2420,7 +2420,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => harborOutput({ taskId: 'task-a', promptHash: 'sha256:wrong' }),
+        taskRunner: async () => harborOutput({ taskId: 'task-a', promptHash: 'sha256:wrong' }),
         now: () => 100,
         newId: idFactory(),
       });
@@ -2445,7 +2445,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             errorClass: 'network',
@@ -2478,7 +2478,7 @@ describe('fixed prompt controller', () => {
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         requireExecutionIdentity: true,
-        harborRunner: async () => harborOutput({ taskId: 'task-a' }),
+        taskRunner: async () => harborOutput({ taskId: 'task-a' }),
         now: () => 100,
         newId: idFactory(),
       });
@@ -2501,7 +2501,7 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             omitPromptHash: true,
@@ -2548,7 +2548,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         resumeFingerprint: 'sha256:manifest',
         protectPassAtOne: true,
-        harborRunner: async () => {
+        taskRunner: async () => {
           harborCalls += 1;
           return harborOutput({ taskId: 'task-a' });
         },
@@ -2598,7 +2598,7 @@ describe('fixed prompt controller', () => {
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         resumeFingerprint: 'sha256:manifest',
         protectPassAtOne: true,
-        harborRunner: async () => harborOutput({ taskId: 'task-a' }),
+        taskRunner: async () => harborOutput({ taskId: 'task-a' }),
       });
 
       assert.equal(result.events[0]?.type, 'task_completed');
@@ -2618,7 +2618,7 @@ describe('fixed prompt controller', () => {
         systemPromptPath,
         resultsJsonlPath: join(dir, 'results.jsonl'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () =>
+        taskRunner: async () =>
           harborOutput({
             taskId: 'task-a',
             reward: 1,
@@ -2670,7 +2670,7 @@ describe('fixed prompt controller', () => {
         systemPromptPath,
         resultsJsonlPath,
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        harborRunner: async () => {
+        taskRunner: async () => {
           harborCalls += 1;
           return harborOutput({ taskId: 'task-a' });
         },
@@ -2735,19 +2735,19 @@ function harborOutput(input: {
   reward?: number;
   promptHash?: string;
   omitPromptHash?: boolean;
-  tokenSummary?: HarborTaskRunOutput['cell']['tokenSummary'];
+  tokenSummary?: TaskRunOutput['cell']['tokenSummary'];
   omitTokenSummary?: boolean;
-  contextBudgetPolicy?: HarborTaskRunOutput['cell']['contextBudgetPolicy'];
-  contextBudgetSummary?: HarborTaskRunOutput['cell']['contextBudgetSummary'];
-  continuationSummary?: HarborTaskRunOutput['cell']['continuationSummary'];
-  taskToolSummary?: HarborTaskRunOutput['cell']['taskToolSummary'];
+  contextBudgetPolicy?: TaskRunOutput['cell']['contextBudgetPolicy'];
+  contextBudgetSummary?: TaskRunOutput['cell']['contextBudgetSummary'];
+  continuationSummary?: TaskRunOutput['cell']['continuationSummary'];
+  taskToolSummary?: TaskRunOutput['cell']['taskToolSummary'];
   errorClass?: string;
-  status?: HarborTaskRunOutput['cell']['status'];
-  executionIdentity?: HarborTaskRunOutput['cell']['executionIdentity'];
-  deadlineSettlement?: HarborTaskRunOutput['cell']['deadlineSettlement'];
-  verifier?: HarborTaskRunOutput['harbor']['verifier'];
+  status?: TaskRunOutput['cell']['status'];
+  executionIdentity?: TaskRunOutput['cell']['executionIdentity'];
+  deadlineSettlement?: TaskRunOutput['cell']['deadlineSettlement'];
+  verifier?: TaskRunOutput['harbor']['verifier'];
   providerTelemetryPath?: string;
-}): HarborTaskRunOutput {
+}): TaskRunOutput {
   return {
     harbor: { reward: input.reward ?? 1, ...(input.verifier ? { verifier: input.verifier } : {}) },
     cell: {

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -6,10 +6,7 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 import type { HarborCellExecutionIdentity, HarborCellOutput } from '../cell-output.js';
-import {
-  FixedPromptBudgetExhaustedError,
-  type HarborTaskRunInput,
-} from '../fixed-prompt-controller.js';
+import { FixedPromptBudgetExhaustedError, type TaskRunInput } from '../fixed-prompt-controller.js';
 import {
   buildHarborJobConfig,
   createHarborOracleQualifier,
@@ -49,7 +46,7 @@ function cellOutput(overrides: Partial<HarborCellOutput> = {}): HarborCellOutput
   };
 }
 
-function runInput(overrides: Partial<HarborTaskRunInput> = {}): HarborTaskRunInput {
+function runInput(overrides: Partial<TaskRunInput> = {}): TaskRunInput {
   return {
     runId: 'run-1',
     roundId: 'round-1',

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { HarborCellOutput } from '../cell-output.js';
-import type { HarborTaskRunner } from '../fixed-prompt-controller.js';
+import type { TaskRunner } from '../fixed-prompt-controller.js';
 import { assertHarnessAbReportCompleted, buildHarnessAbReport } from '../harness-ab-report.js';
 import { runHarnessAbComparison } from '../harness-ab-run.js';
 import { HarborInfraError } from '../harbor-task-runner.js';
@@ -430,7 +430,7 @@ function harnessArm(id: 'maka' | 'opencode', calls: string[], beforeRun?: () => 
     llmConnectionSlug: 'zai-coding-plan',
     model: 'glm-5.2',
   };
-  const harborRunner: HarborTaskRunner = async ({ task, systemPrompt }) => {
+  const harborRunner: TaskRunner = async ({ task, systemPrompt }) => {
     await beforeRun?.();
     calls.push(`${task.id}:${id}`);
     const promptHash = hashHeadlessSystemPrompt(systemPrompt);

--- a/packages/headless/src/__tests__/helpers/ab-run-fixtures.ts
+++ b/packages/headless/src/__tests__/helpers/ab-run-fixtures.ts
@@ -1,7 +1,7 @@
 import {
   FIXED_PROMPT_WAL_SCHEMA_VERSION,
   type FixedPromptTaskCompletedEvent,
-  type HarborTaskRunOutput,
+  type TaskRunOutput,
 } from '../../fixed-prompt-controller.js';
 import { tokenSummary } from './cell-output-fixtures.js';
 
@@ -10,7 +10,7 @@ export function harborOutput(input: {
   durationMs?: number;
   promptHash: string;
   reward?: number;
-}): HarborTaskRunOutput {
+}): TaskRunOutput {
   return {
     harbor: { reward: input.reward ?? 1 },
     cell: {

--- a/packages/headless/src/__tests__/helpers/prompt-optimization-loop-harness.ts
+++ b/packages/headless/src/__tests__/helpers/prompt-optimization-loop-harness.ts
@@ -5,8 +5,8 @@ import { join } from 'node:path';
 import { promisify } from 'node:util';
 import {
   hashSystemPrompt,
-  type HarborTaskRunInput,
-  type HarborTaskRunOutput,
+  type TaskRunInput,
+  type TaskRunOutput,
 } from '../../fixed-prompt-controller.js';
 import {
   createCliPromptCandidateGit,
@@ -161,7 +161,7 @@ function fakeHarborRunner(
   verifierFailureSummaryFor?: (roundId: string, taskId: string) => string | undefined,
   onTaskRun?: (roundId: string, taskId: string) => void,
   runtimeEventCommandFor?: (roundId: string, taskId: string) => string | undefined,
-): (input: HarborTaskRunInput) => Promise<HarborTaskRunOutput> {
+): (input: TaskRunInput) => Promise<TaskRunOutput> {
   return async ({ roundId, task, systemPrompt }) => {
     onTaskRun?.(roundId, task.id);
     if (shouldThrowInfra?.(roundId, task.id)) {

--- a/packages/headless/src/__tests__/prompt-optimization-run.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-run.test.ts
@@ -14,8 +14,8 @@ import {
   hashSystemPrompt,
   readFixedPromptWal,
   type FixedPromptTask,
-  type HarborTaskRunInput,
-  type HarborTaskRunOutput,
+  type TaskRunInput,
+  type TaskRunOutput,
 } from '../fixed-prompt-controller.js';
 import {
   buildPromptOptimizationTaskAgentEnv,
@@ -727,7 +727,7 @@ function makeRunTasks(prefix: string, count: number): FixedPromptTask[] {
 function fakeRunHarborRunner(
   eventsDir: string,
   rewardFor: (roundId: string, taskId: string) => number,
-): (input: HarborTaskRunInput) => Promise<HarborTaskRunOutput> {
+): (input: TaskRunInput) => Promise<TaskRunOutput> {
   return async ({ roundId, task, systemPrompt }) => {
     const runtimeEventsPath = join(eventsDir, `${roundId}__${task.id}.jsonl`);
     await writeFile(

--- a/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
@@ -7,8 +7,8 @@ import type { Config } from '../contracts.js';
 import {
   FixedPromptBudgetExhaustedError,
   hashSystemPrompt,
-  type HarborTaskRunInput,
-  type HarborTaskRunOutput,
+  type TaskRunInput,
+  type TaskRunOutput,
 } from '../fixed-prompt-controller.js';
 import { runRuntimePolicyAbLifecycle } from '../runtime-policy-ab-lifecycle.js';
 import { contextBudgetSummary } from './helpers/ab-summary-fixtures.js';
@@ -62,7 +62,7 @@ test('same-run pilot checkpoint gates full execution and resumes completed state
         { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
       ] as const,
       executionProfile,
-      harborRunner: async (runInput: HarborTaskRunInput) => {
+      harborRunner: async (runInput: TaskRunInput) => {
         calls.push(runInput.roundId);
         return output(runInput, runInput.agentEnv?.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE === 'on');
       },
@@ -104,7 +104,7 @@ test('rebuilds a legacy terminal lifecycle summary from WAL before returning it'
         { id: 'prune-on', contextEnv: { MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE: 'on' } },
       ] as const,
       executionProfile,
-      harborRunner: async (runInput: HarborTaskRunInput) => {
+      harborRunner: async (runInput: TaskRunInput) => {
         calls.push(runInput.roundId);
         return output(runInput, runInput.agentEnv?.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE === 'on');
       },
@@ -396,7 +396,7 @@ test('maps an invalid full summary to invalid lifecycle status', async () => {
   });
 });
 
-function output(input: HarborTaskRunInput, activated: boolean): HarborTaskRunOutput {
+function output(input: TaskRunInput, activated: boolean): TaskRunOutput {
   return {
     harbor: { reward: 1 },
     cell: {

--- a/packages/headless/src/__tests__/runtime-policy-ab-run.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-run.test.ts
@@ -6,8 +6,8 @@ import { describe, test } from 'node:test';
 import type { Config } from '../contracts.js';
 import {
   hashSystemPrompt,
-  type HarborTaskRunInput,
-  type HarborTaskRunOutput,
+  type TaskRunInput,
+  type TaskRunOutput,
 } from '../fixed-prompt-controller.js';
 import {
   buildRuntimePolicyAbRunManifest,
@@ -211,7 +211,7 @@ describe('runRuntimePolicyAbComparison', () => {
     await withDir(async (dir) => {
       const promptPath = join(dir, 'system-prompt.md');
       await writeFile(promptPath, 'shared prompt\n', 'utf8');
-      const calls: HarborTaskRunInput[] = [];
+      const calls: TaskRunInput[] = [];
 
       const result = await runRuntimePolicyAbComparison({
         runId: 'runtime-ab-run',
@@ -403,7 +403,7 @@ describe('runRuntimePolicyAbComparison', () => {
         newId: idFactory(),
       };
       let calls = 0;
-      const harborRunner = async (input: HarborTaskRunInput) => {
+      const harborRunner = async (input: TaskRunInput) => {
         calls += 1;
         return harborOutput(input);
       };
@@ -422,7 +422,7 @@ describe('runRuntimePolicyAbComparison', () => {
   });
 });
 
-function harborOutput(input: HarborTaskRunInput): HarborTaskRunOutput {
+function harborOutput(input: TaskRunInput): TaskRunOutput {
   const pruneOn = input.agentEnv?.MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE === 'on';
   return {
     harbor: { reward: 1 },

--- a/packages/headless/src/experiment-engine.ts
+++ b/packages/headless/src/experiment-engine.ts
@@ -1,0 +1,93 @@
+/**
+ * Shared run-root scaffold for the Harbor A/B experiment scripts
+ * (`run-prompt-ab`, `run-runtime-policy-ab`, `run-harness-ab`). Every one of
+ * those `main()` bodies hand-rolled the same sequence: create the standard
+ * `controller` / `jobs` / `prompts` directories, materialize the prompt files,
+ * run the comparison, then persist the result/report artifacts. `runExperiment`
+ * owns exactly that scaffold and nothing else.
+ *
+ * The engine deliberately does NOT own manifest construction, resume-manifest
+ * ensuring, fingerprinting, task-runner creation, or the console summary: those
+ * differ per experiment (and their placement is contract-pinned in the scripts),
+ * so the caller performs them and passes the experiment-specific pieces in as
+ * the config's `prompts` / `run` / `artifacts` callbacks. Harness-only extras
+ * (its run lock, background journal, Oracle evidence, and CSV report) stay in
+ * the caller too — the CSV is just one more entry in `artifacts`, and the lock
+ * and journal wrap the caller's own manifest build, which happens before the
+ * scaffold runs.
+ *
+ * The real comparison engines already exist and are tested
+ * (`runAbComparison`, `runFixedPromptController`, `buildAbRunManifest`); this
+ * module is only the thin orchestration shell around them.
+ */
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+
+/** The standard directory layout materialized under an experiment's run root. */
+export interface ExperimentRunLayout {
+  runRoot: string;
+  controllerDir: string;
+  jobsDir: string;
+  promptsDir: string;
+  /** Append-only WAL the fixed-prompt controller writes each attempt into. */
+  resultsJsonlPath: string;
+}
+
+/** A file the engine writes verbatim; callers pre-serialize `content`. */
+export interface ExperimentFile {
+  path: string;
+  content: string;
+}
+
+export interface RunExperimentConfig<Summary> {
+  runRoot: string;
+  /**
+   * Prompt (and any other) files materialized into the run before the
+   * comparison starts, written after the standard directories exist.
+   */
+  prompts: (layout: ExperimentRunLayout) => readonly ExperimentFile[];
+  /** Execute the comparison against the prepared layout and return its summary. */
+  run: (layout: ExperimentRunLayout) => Promise<Summary>;
+  /** Result/report files persisted after the comparison completes. */
+  artifacts: (
+    summary: Summary,
+    layout: ExperimentRunLayout,
+  ) => readonly ExperimentFile[] | Promise<readonly ExperimentFile[]>;
+}
+
+/** Resolve the standard `controller` / `jobs` / `prompts` layout for a run root. */
+export function experimentRunLayout(runRoot: string): ExperimentRunLayout {
+  const controllerDir = join(runRoot, 'controller');
+  return {
+    runRoot,
+    controllerDir,
+    jobsDir: join(runRoot, 'jobs'),
+    promptsDir: join(runRoot, 'prompts'),
+    resultsJsonlPath: join(controllerDir, 'results.jsonl'),
+  };
+}
+
+/**
+ * Materialize the run layout, write the prompt files, run the comparison, and
+ * persist its artifacts. Returns the comparison summary so the caller can emit
+ * its own (experiment-specific, contract-pinned) console summary.
+ */
+export async function runExperiment<Summary>(
+  config: RunExperimentConfig<Summary>,
+): Promise<Summary> {
+  const layout = experimentRunLayout(config.runRoot);
+  await Promise.all([
+    mkdir(layout.controllerDir, { recursive: true }),
+    mkdir(layout.jobsDir, { recursive: true }),
+    mkdir(layout.promptsDir, { recursive: true }),
+  ]);
+  for (const file of config.prompts(layout)) {
+    await writeFile(file.path, file.content, 'utf8');
+  }
+  const summary = await config.run(layout);
+  for (const file of await config.artifacts(summary, layout)) {
+    await writeFile(file.path, file.content, 'utf8');
+  }
+  return summary;
+}

--- a/packages/headless/src/experiment-fingerprint.ts
+++ b/packages/headless/src/experiment-fingerprint.ts
@@ -66,7 +66,10 @@ async function toolOutput(command: string, args: readonly string[]): Promise<str
   return `${stdout}${stderr}`.trim();
 }
 
-async function buildInstalledDependencyFingerprint(repoPath: string): Promise<{
+async function buildInstalledDependencyFingerprint(
+  repoPath: string,
+  envPrefix: string,
+): Promise<{
   packageLockPath: string;
   packageLockHash: string;
   installedPackageLockPath: string;
@@ -83,7 +86,7 @@ async function buildInstalledDependencyFingerprint(repoPath: string): Promise<{
     ]);
   } catch (error) {
     throw new Error(
-      `prompt A/B toolchain fingerprint requires ${packageLockPath} and ${installedLockPath}. Run npm install in MAKA_PROMPT_AB_MAKA_REPO, or set MAKA_PROMPT_AB_TOOLCHAIN_FINGERPRINT to an explicit sha256:<64 lowercase hex> dependency snapshot. Cause: ${error instanceof Error ? error.message : String(error)}`,
+      `A/B toolchain fingerprint requires ${packageLockPath} and ${installedLockPath}. Run npm install in ${envPrefix}_MAKA_REPO, or set ${envPrefix}_TOOLCHAIN_FINGERPRINT to an explicit sha256:<64 lowercase hex> dependency snapshot. Cause: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
   return {
@@ -98,12 +101,13 @@ export async function buildToolchainFingerprint(
   explicitToolchainFingerprint: string | undefined,
   readToolOutput: ReadToolOutput = toolOutput,
   repoPath: string = resolve(fileURLToPath(new URL('../../..', import.meta.url))),
+  envPrefix = 'MAKA_PROMPT_AB',
 ): Promise<string> {
   if (explicitToolchainFingerprint && explicitToolchainFingerprint.trim().length > 0) {
     const value = explicitToolchainFingerprint.trim();
     if (!isSha256Fingerprint(value)) {
       throw new Error(
-        'MAKA_PROMPT_AB_TOOLCHAIN_FINGERPRINT must be a sha256:<64 lowercase hex> content fingerprint',
+        `${envPrefix}_TOOLCHAIN_FINGERPRINT must be a sha256:<64 lowercase hex> content fingerprint`,
       );
     }
     return value;
@@ -118,7 +122,7 @@ export async function buildToolchainFingerprint(
     kind: 'prompt-ab-toolchain',
     node: process.version,
     harborVersion,
-    dependencyInstallFingerprint: await buildInstalledDependencyFingerprint(repoPath),
+    dependencyInstallFingerprint: await buildInstalledDependencyFingerprint(repoPath, envPrefix),
   });
 }
 
@@ -126,12 +130,13 @@ export async function buildSubjectFingerprint(
   repoPath: string,
   explicitSubjectFingerprint: string | undefined,
   readGitOutput: ReadGitOutput = gitOutput,
+  envPrefix = 'MAKA_PROMPT_AB',
 ): Promise<string> {
   if (explicitSubjectFingerprint && explicitSubjectFingerprint.trim().length > 0) {
     const value = explicitSubjectFingerprint.trim();
     if (!isSha256Fingerprint(value)) {
       throw new Error(
-        'MAKA_PROMPT_AB_EXPLICIT_SUBJECT_FINGERPRINT must be a sha256:<64 lowercase hex> content fingerprint',
+        `${envPrefix}_EXPLICIT_SUBJECT_FINGERPRINT must be a sha256:<64 lowercase hex> content fingerprint`,
       );
     }
     return hashPayload({
@@ -150,12 +155,12 @@ export async function buildSubjectFingerprint(
     ]);
   } catch (error) {
     throw new Error(
-      `MAKA_PROMPT_AB_MAKA_REPO must be a git checkout or MAKA_PROMPT_AB_EXPLICIT_SUBJECT_FINGERPRINT must be set: ${error instanceof Error ? error.message : String(error)}`,
+      `${envPrefix}_MAKA_REPO must be a git checkout or ${envPrefix}_EXPLICIT_SUBJECT_FINGERPRINT must be set: ${error instanceof Error ? error.message : String(error)}`,
     );
   }
   if (status.length > 0) {
     throw new Error(
-      `MAKA_PROMPT_AB_MAKA_REPO must be clean for resume-safe prompt A/B runs. Commit/stash the changes, or set MAKA_PROMPT_AB_EXPLICIT_SUBJECT_FINGERPRINT to an explicit content fingerprint. Dirty git status:\n${status}`,
+      `${envPrefix}_MAKA_REPO must be clean for resume-safe A/B runs. Commit/stash the changes, or set ${envPrefix}_EXPLICIT_SUBJECT_FINGERPRINT to an explicit content fingerprint. Dirty git status:\n${status}`,
     );
   }
   return hashPayload({

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -87,13 +87,6 @@ export interface TaskRunner {
   (input: TaskRunInput): Promise<TaskRunOutput>;
 }
 
-/** @deprecated Harbor-named alias retained for existing call sites; use `TaskRunInput`. */
-export type HarborTaskRunInput = TaskRunInput;
-/** @deprecated Harbor-named alias retained for existing call sites; use `TaskRunOutput`. */
-export type HarborTaskRunOutput = TaskRunOutput;
-/** @deprecated Harbor-named alias retained for existing call sites; use `TaskRunner`. */
-export type HarborTaskRunner = TaskRunner;
-
 export interface FixedPromptBudgetExhaustedArtifactRefs {
   runtimeEventsPath?: string;
   traceEventsPath?: string;
@@ -394,7 +387,7 @@ export interface RunFixedPromptControllerInput {
   /** Refuse resume when a model attempt was durably admitted but no terminal
    * event exists, preserving single-sample benchmark semantics. */
   protectPassAtOne?: boolean;
-  harborRunner: TaskRunner;
+  taskRunner: TaskRunner;
   now?: () => number;
   newId?: () => string;
 }
@@ -605,7 +598,7 @@ export async function readFixedPromptWal(path: string): Promise<FixedPromptWalEv
 
 export async function readHarborTaskRunOutput(
   input: ReadHarborTaskRunOutputInput,
-): Promise<HarborTaskRunOutput> {
+): Promise<TaskRunOutput> {
   return {
     harbor: {
       reward: harborReward(await readJsonObject(input.harborResultPath)),
@@ -709,7 +702,7 @@ async function runTaskAndBuildEvent(input: {
     });
   }
   const runHarbor = () =>
-    input.input.harborRunner({
+    input.input.taskRunner({
       runId: input.input.runId,
       roundId: input.input.roundId,
       task: input.task,
@@ -805,7 +798,7 @@ async function runTaskAndBuildEvent(input: {
 }
 
 function taskEventFromOutput(input: {
-  output: HarborTaskRunOutput;
+  output: TaskRunOutput;
   expectedConfig: Config;
   expectedPromptHash: string;
   requireExecutionIdentity?: boolean;
@@ -864,7 +857,7 @@ function taskEventFromOutput(input: {
 }
 
 function taskCompletedEvent(input: {
-  output: HarborTaskRunOutput;
+  output: TaskRunOutput;
   taskId: string;
   runId: string;
   roundId: string;
@@ -947,7 +940,7 @@ function isUnscoredCellFailure(
 }
 
 function taskPlumbingFailedEvent(input: {
-  output: HarborTaskRunOutput;
+  output: TaskRunOutput;
   expectedPromptHash: string;
   resumeFingerprint?: string;
   taskId: string;
@@ -1004,7 +997,7 @@ function taskPlumbingFailedEvent(input: {
 }
 
 function classifyPlumbingFailure(
-  output: HarborTaskRunOutput,
+  output: TaskRunOutput,
   expectedPromptHash: string,
   expectedConfig: Config,
   requireExecutionIdentity: boolean,
@@ -1126,7 +1119,7 @@ function classifyExplicitIdentityMismatch(
 
 function taskInfraFailedEvent(input: {
   error: unknown;
-  output?: HarborTaskRunOutput;
+  output?: TaskRunOutput;
   errorClass?: FixedPromptTaskInfraFailedEvent['errorClass'];
   taskId: string;
   runId: string;

--- a/packages/headless/src/harness-ab-run.ts
+++ b/packages/headless/src/harness-ab-run.ts
@@ -8,7 +8,7 @@ import {
   readFixedPromptWal,
   runFixedPromptController,
   type FixedPromptTask,
-  type HarborTaskRunner,
+  type TaskRunner,
 } from './fixed-prompt-controller.js';
 import { HARNESS_AB_PAIR_CONCURRENCY, type HarnessAbArmId } from './harness-ab-manifest.js';
 
@@ -17,7 +17,7 @@ export interface HarnessAbRuntimeArm {
   config: Config;
   expectedPricingProfile: string;
   billingMode?: HarborBillingMode;
-  harborRunner: HarborTaskRunner;
+  harborRunner: TaskRunner;
 }
 
 export interface RunHarnessAbComparisonInput {
@@ -97,7 +97,7 @@ export async function runHarnessAbComparisonUnlocked(
         expectedPricingProfile: runtimeArm.expectedPricingProfile,
         ...(runtimeArm.billingMode ? { billingMode: runtimeArm.billingMode } : {}),
         resumeFingerprint: input.resumeFingerprint,
-        harborRunner: runtimeArm.harborRunner,
+        taskRunner: runtimeArm.harborRunner,
         ...(input.now ? { now: input.now } : {}),
         ...(input.newId ? { newId: input.newId } : {}),
       });

--- a/packages/headless/src/headless-run-env.ts
+++ b/packages/headless/src/headless-run-env.ts
@@ -1,8 +1,12 @@
 /**
- * Pure, testable env-string parsers for headless CLI entrypoints. Each parser
- * only turns the raw env string (or undefined) into a typed value and delegates
- * invariants to shared numeric guards, so script wiring cannot accidentally
- * disable a guard with `NaN`.
+ * Pure, testable parsers that turn raw environment strings (or `undefined`) into
+ * typed values for headless CLI entrypoints and the Harbor cell. Beyond numbers
+ * the module also parses filesystem paths (`envPath`), comma-separated id lists
+ * (`envIds`), and booleans (`booleanEnv`). The numeric parsers delegate their
+ * range invariants to the shared numeric guards, so script wiring cannot
+ * accidentally disable a guard with `NaN`. The tail of the file additionally
+ * hosts the `RunHarborCellEnv` bag type and the lenient Harbor-cell env helpers
+ * that must mirror the Python adapter's forgiving parsing.
  */
 
 import { homedir } from 'node:os';

--- a/packages/headless/src/prompt-ab-run.ts
+++ b/packages/headless/src/prompt-ab-run.ts
@@ -117,7 +117,7 @@ async function runComparisonTaskArm(input: {
     resultsTsvPath: `${input.input.resultsJsonlPath}.${input.roundId}.tsv`,
     tasks: [input.task],
     ...(input.input.resumeFingerprint ? { resumeFingerprint: input.input.resumeFingerprint } : {}),
-    harborRunner: input.input.harborRunner,
+    taskRunner: input.input.harborRunner,
     ...(input.input.now ? { now: input.input.now } : {}),
     ...(input.input.newId ? { newId: input.input.newId } : {}),
   });

--- a/packages/headless/src/prompt-ab-types.ts
+++ b/packages/headless/src/prompt-ab-types.ts
@@ -13,7 +13,7 @@ import type {
 import type {
   FixedPromptTask,
   FixedPromptTaskWalEvent,
-  HarborTaskRunner,
+  TaskRunner,
 } from './fixed-prompt-controller.js';
 
 export interface SummarizePromptAbComparisonInput {
@@ -41,7 +41,7 @@ export interface RunPromptAbComparisonInput {
   resumeFingerprint?: string;
   budgetMs?: number;
   nonInferiorityMargin?: number;
-  harborRunner: HarborTaskRunner;
+  harborRunner: TaskRunner;
   now?: () => number;
   newId?: () => string;
 }

--- a/packages/headless/src/prompt-control-run.ts
+++ b/packages/headless/src/prompt-control-run.ts
@@ -5,8 +5,8 @@ import type { HarborCellTokenSummary } from './cell-output.js';
 import {
   hashSystemPrompt,
   type FixedPromptTask,
-  type HarborTaskRunInput,
-  type HarborTaskRunOutput,
+  type TaskRunInput,
+  type TaskRunOutput,
 } from './fixed-prompt-controller.js';
 import type { HarborTaskPricing } from './harbor-task-runner.js';
 import type { MetaAgent } from './prompt-candidate-loop.js';
@@ -156,11 +156,7 @@ export async function runPromptControlExperiment(
 }
 
 function createControlHarborRunner(eventsDir: string) {
-  return async ({
-    roundId,
-    task,
-    systemPrompt,
-  }: HarborTaskRunInput): Promise<HarborTaskRunOutput> => {
+  return async ({ roundId, task, systemPrompt }: TaskRunInput): Promise<TaskRunOutput> => {
     const hasRule = systemPrompt.includes(CONTROL_RULE_MARKER);
     const errorClass = hasRule ? undefined : `missing_${CONTROL_RULE_MARKER}`;
     const runtimeEventsPath = join(eventsDir, `${roundId}__${task.id}.jsonl`);

--- a/packages/headless/src/prompt-optimization-loop.ts
+++ b/packages/headless/src/prompt-optimization-loop.ts
@@ -13,7 +13,7 @@ import {
   type FixedPromptTask,
   type FixedPromptTaskCompletedEvent,
   type FixedPromptTaskWalEvent,
-  type HarborTaskRunner,
+  type TaskRunner,
   type PromptCandidateRewardHackScan,
   type RsiControllerAttributionEvent,
 } from './fixed-prompt-controller.js';
@@ -112,7 +112,7 @@ export interface PromptOptimizationLoopInput {
   heldOutArtifactPaths?: readonly string[];
 
   config: Config;
-  harborRunner: HarborTaskRunner;
+  harborRunner: TaskRunner;
   metaAgent: MetaAgent;
   git: PromptCandidateGit;
 
@@ -260,7 +260,7 @@ export async function runPromptOptimizationLoop(
       resultsJsonlPath: input.resultsJsonlPath,
       resultsTsvPath,
       tasks,
-      harborRunner: input.harborRunner,
+      taskRunner: input.harborRunner,
       ...(input.resumeFingerprint ? { resumeFingerprint: input.resumeFingerprint } : {}),
       ...(input.maxConcurrency !== undefined ? { maxConcurrency: input.maxConcurrency } : {}),
       ...(options?.protectPassAtOne ? { protectPassAtOne: true } : {}),

--- a/packages/headless/src/prompt-optimization-run.ts
+++ b/packages/headless/src/prompt-optimization-run.ts
@@ -3,7 +3,7 @@ import { readdir, readFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import type { LlmConnection } from '@maka/core';
 import type { Config } from './contracts.js';
-import type { FixedPromptTask, HarborTaskRunner } from './fixed-prompt-controller.js';
+import type { FixedPromptTask, TaskRunner } from './fixed-prompt-controller.js';
 import {
   createHarborTaskRunner,
   modelIdForProvider,
@@ -226,7 +226,7 @@ export interface PromptOptimizationRunInput {
   maxStableTaskDurationMs?: number;
 
   // Test overrides — bypass the real Docker/network components.
-  harborRunner?: HarborTaskRunner;
+  harborRunner?: TaskRunner;
   metaAgent?: MetaAgent;
   now?: () => number;
   newId?: () => string;
@@ -301,7 +301,7 @@ export async function runPromptOptimizationRun(
       ...(input.agentEnv ? { agentEnv: input.agentEnv } : {}),
       ...(input.harborTimeoutMs !== undefined ? { harborTimeoutMs: input.harborTimeoutMs } : {}),
     });
-  const harborRunner: HarborTaskRunner = async (runInput) =>
+  const harborRunner: TaskRunner = async (runInput) =>
     baseHarborRunner({
       ...runInput,
       agentEnv: {

--- a/packages/headless/src/runtime-policy-ab-run.ts
+++ b/packages/headless/src/runtime-policy-ab-run.ts
@@ -2,7 +2,7 @@ import { createHash } from 'node:crypto';
 import {
   runFixedPromptController,
   type FixedPromptTask,
-  type HarborTaskRunner,
+  type TaskRunner,
 } from './fixed-prompt-controller.js';
 import { renderAbComparisonMarkdown } from './ab-render.js';
 import { buildAbRunManifest, buildRunManifestFingerprint } from './ab-manifest.js';
@@ -53,7 +53,7 @@ export interface RunRuntimePolicyAbComparisonInput {
   budgetMs?: number;
   nonInferiorityMargin?: number;
   sharedAgentEnv?: Partial<Record<RuntimePolicySharedAgentEnvKey, string>>;
-  harborRunner: HarborTaskRunner;
+  harborRunner: TaskRunner;
   now?: () => number;
   newId?: () => string;
 }
@@ -155,7 +155,7 @@ export async function runRuntimePolicyAbComparisonUnlocked(
           ? { billingMode: input.executionProfile.billingMode }
           : {}),
         resumeFingerprint,
-        harborRunner: (runnerInput) => input.harborRunner({ ...runnerInput, agentEnv }),
+        taskRunner: (runnerInput) => input.harborRunner({ ...runnerInput, agentEnv }),
         ...(input.now ? { now: input.now } : {}),
         ...(input.newId ? { newId: input.newId } : {}),
       });


### PR DESCRIPTION
## Summary

Completes the remaining scope of #1342 (the helper dedupe landed in #1345). The three Harbor A/B run scripts each hand-rolled the same run-root scaffold in their `main()`; this PR extracts it into a shared engine and finishes the deprecated-alias cleanup.

- **`runExperiment(config)`** (new `packages/headless/src/experiment-engine.ts`, exposed via the `#experiment-engine` subpath): owns the shared sequence only — create the standard `controller`/`jobs`/`prompts` layout, materialize prompt files, run the comparison, persist result/report artifacts. It reuses the existing, tested comparison engines (`runAbComparison`/`runFixedPromptController`/`buildAbRunManifest`) rather than rebuilding them.
- **Three scripts migrated to thin configs** (`run-prompt-ab`, `run-runtime-policy-ab`, `run-harness-ab`). Experiment-specific work (manifest build + resume-ensure, fingerprints, task-runner creation, console summary) and harness-only extras (run lock, background journal, Oracle evidence, CSV report) stay in the scripts. The harness CSV is just one more `artifacts` entry, so no bespoke engine hook was needed; the lock and journal wrap the caller's own manifest build, so they remain in the script rather than the engine core.
- **Deprecated aliases deleted**: `HarborTaskRunInput`/`HarborTaskRunOutput`/`HarborTaskRunner` are gone; every call site now uses `TaskRunInput`/`TaskRunOutput`/`TaskRunner`. `RunFixedPromptControllerInput.harborRunner` was renamed to `taskRunner` with its direct call sites synced.
- **Reviewed P3s**: (a) alias migration above; (b) the `headless-run-env` module header no longer claims to only delegate to numeric guards, since it also parses paths, ids, and booleans; (c) `buildSubjectFingerprint`/`buildToolchainFingerprint` take an optional `envPrefix` (default `MAKA_PROMPT_AB`) so the harness and runtime callers surface `MAKA_HARNESS_AB_*` / `MAKA_RUNTIME_AB_*` in their guidance errors. No hashed fingerprint bytes change.

CLI contracts are unchanged: the env-var surface, exported `.mjs` helpers, error messages, and pinned run ids all hold. The source-regex and spawn contract tests in `harbor-adapter.test.ts`, `harness-ab-cli.test.ts`, and `runtime-policy-ab-cli.test.ts` pass unmodified — the scripts keep their experiment-specific calls inline as config, so nothing they pin moved.

## Verification

- `npm test -w @maka/headless`: all assertions pass (1060 pass, 0 assertion failures). 8 test files (`cli`, `harbor-cell`, `runner`, `task-agent-controller`, `prompt-optimization-loop*`) report a file-level "Promise resolution is still pending" teardown error under the sandboxed runner because it blocks socket listening; re-running those files with the sandbox constraint lifted passes them 246/246 with 0 failures. This is a local-sandbox artifact, unrelated to this change.
- `prompt-ab-fingerprints.test.ts` frozen-oracle byte contract: passes unchanged.
- `npm run lint`, `npm run format:check`, `npm run typecheck -w @maka/headless`: clean.
- New `experiment-engine.test.ts` locks the engine's layout, ordering (prompts → run → artifacts), and async-artifacts behavior.

Closes #1342.
