### PR TITLE
feat(headless): add createPierTaskRunner for DeepSWE via Pier

### DIFF
--- a/packages/headless/harbor/kimi_code_agent.py
+++ b/packages/headless/harbor/kimi_code_agent.py
@@ -188,6 +188,25 @@ class MakaKimiCodeAgent(BaseInstalledAgent):
                     await cleanup_process_scope(self, environment, command_scope)
             finally:
                 self._finished_at_ms = int(time.time() * 1000)
+                await self._download_agent_logs(environment)
+
+    async def _download_agent_logs(self, environment: BaseEnvironment) -> None:
+        # _write_cell_output's only in-container input is the stream-json the
+        # CLI writes to /logs/agent/kimi-code.jsonl (identity and timestamps
+        # are host-side). Under Harbor the agent log dir is bind-mounted, so
+        # the file is already host-side and is skipped; under Pier a
+        # --mounts-json run replaces the default log mounts while
+        # capabilities.mounted stays true (pier docker.py), so pier's own log
+        # download never runs — without this download, _events() sees nothing
+        # and a real token-burning run is misclassified as infra. Runs in
+        # run()'s finally so the AgentTimeoutError path is hydrated too.
+        local = self.logs_dir / _OUTPUT_PATH.name
+        if local.exists():
+            return
+        try:
+            await environment.download_file(_OUTPUT_PATH.as_posix(), local)
+        except Exception as exc:  # noqa: BLE001 - best-effort log hydration.
+            self.logger.debug("Could not download Kimi Code stream %s: %s", _OUTPUT_PATH, exc)
 
     def populate_context_post_run(self, context: AgentContext) -> None:
         self._write_cell_output()

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -126,6 +126,7 @@ class MakaAgent(BaseInstalledAgent):
     _RUN_LOG_FILENAME = "maka-run.log"
     _CELL_OUTPUT_FILENAME = "maka-cell-output.json"
     _CELL_USAGE_CHECKPOINT_FILENAME = "maka-cell-usage-checkpoint.json"
+    _RUNTIME_EVENTS_FILENAME = "runtime-events.jsonl"
 
     CLI_FLAGS = [
         CliFlag(
@@ -557,6 +558,17 @@ class MakaAgent(BaseInstalledAgent):
             await environment.download_file(remote.as_posix(), local)
         except Exception as exc:  # noqa: BLE001 - best-effort metadata hydration.
             self.logger.debug("Could not download Maka cell output %s: %s", remote, exc)
+        # The cell output's runtimeEventsPath contract points at this file. Under
+        # Harbor the agent log dir is bind-mounted, so it is already host-side and
+        # is skipped; under Pier a --mounts-json run replaces the default log
+        # mounts, so without this download the path would dangle.
+        events_remote = EnvironmentPaths.agent_dir / self._RUNTIME_EVENTS_FILENAME
+        events_local = self.logs_dir / self._RUNTIME_EVENTS_FILENAME
+        if not events_local.exists():
+            try:
+                await environment.download_file(events_remote.as_posix(), events_local)
+            except Exception as exc:  # noqa: BLE001 - best-effort metadata hydration.
+                self.logger.debug("Could not download Maka runtime events %s: %s", events_remote, exc)
 
     def _read_cell_output(self, *, required: bool) -> dict[str, Any] | None:
         output_path = self.logs_dir / self._CELL_OUTPUT_FILENAME

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -127,6 +127,7 @@ class MakaAgent(BaseInstalledAgent):
     _CELL_OUTPUT_FILENAME = "maka-cell-output.json"
     _CELL_USAGE_CHECKPOINT_FILENAME = "maka-cell-usage-checkpoint.json"
     _RUNTIME_EVENTS_FILENAME = "runtime-events.jsonl"
+    _TRACE_EVENTS_FILENAME = "trace-events.jsonl"
 
     CLI_FLAGS = [
         CliFlag(
@@ -558,17 +559,20 @@ class MakaAgent(BaseInstalledAgent):
             await environment.download_file(remote.as_posix(), local)
         except Exception as exc:  # noqa: BLE001 - best-effort metadata hydration.
             self.logger.debug("Could not download Maka cell output %s: %s", remote, exc)
-        # The cell output's runtimeEventsPath contract points at this file. Under
-        # Harbor the agent log dir is bind-mounted, so it is already host-side and
-        # is skipped; under Pier a --mounts-json run replaces the default log
-        # mounts, so without this download the path would dangle.
-        events_remote = EnvironmentPaths.agent_dir / self._RUNTIME_EVENTS_FILENAME
-        events_local = self.logs_dir / self._RUNTIME_EVENTS_FILENAME
-        if not events_local.exists():
+        # The cell output's runtimeEventsPath/traceEventsPath contracts point at
+        # these files. Under Harbor the agent log dir is bind-mounted, so they
+        # are already host-side and are skipped; under Pier a --mounts-json run
+        # replaces the default log mounts, so without this download the paths
+        # would dangle on the host.
+        for filename in (self._RUNTIME_EVENTS_FILENAME, self._TRACE_EVENTS_FILENAME):
+            events_remote = EnvironmentPaths.agent_dir / filename
+            events_local = self.logs_dir / filename
+            if events_local.exists():
+                continue
             try:
                 await environment.download_file(events_remote.as_posix(), events_local)
             except Exception as exc:  # noqa: BLE001 - best-effort metadata hydration.
-                self.logger.debug("Could not download Maka runtime events %s: %s", events_remote, exc)
+                self.logger.debug("Could not download Maka agent log %s: %s", events_remote, exc)
 
     def _read_cell_output(self, *, required: bool) -> dict[str, Any] | None:
         output_path = self.logs_dir / self._CELL_OUTPUT_FILENAME

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -2793,6 +2793,7 @@ class BaseInstalledAgent:
         self._extra_env = extra_env or {}
         self._version = version
         self.model_name = model_name
+        self.logger = types.SimpleNamespace(debug=lambda *args, **kwargs: None)
 
     def _get_env(self, key):
         return self._extra_env.get(key) or os.environ.get(key)
@@ -2826,6 +2827,9 @@ with tempfile.TemporaryDirectory() as tmp:
     commands = []
 
     class Environment:
+        def __init__(self):
+            self.downloads = []
+
         async def exec(self, command, env=None, **kwargs):
             commands.append((command, env or {}))
             if "--output-format stream-json" in command:
@@ -2840,6 +2844,9 @@ with tempfile.TemporaryDirectory() as tmp:
                     encoding="utf-8",
                 )
             return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+
+        async def download_file(self, remote, local):
+            self.downloads.append(remote)
 
     agent = MakaKimiCodeAgent(
         logs,
@@ -2865,6 +2872,9 @@ with tempfile.TemporaryDirectory() as tmp:
     assert "/opt/maka-kimi-code-toolchain/bin/node" in install_command, install_command
     assert install_env["MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT"] == "sha256:" + "a" * 64, install_env
     asyncio.run(agent.run("hi", environment, object()))
+    # Harbor mounted path: the stream-json already landed host-side, so the
+    # adapter must not race the mount with a re-download.
+    assert environment.downloads == [], environment.downloads
     run_command, run_env = commands[-1]
     assert "--output-format stream-json --prompt" in run_command, run_command
     assert "config.toml" in run_command, run_command
@@ -2976,7 +2986,51 @@ with tempfile.TemporaryDirectory() as tmp:
         if timeout_environment.process is not None and timeout_environment.process.poll() is None:
             os.killpg(timeout_environment.process.pid, signal.SIGKILL)
             timeout_environment.process.wait()
-    print("kimi-code adapter ok")
+
+# Pier custom-mounts path: --mounts-json replaces the default log mounts while
+# capabilities.mounted stays true, so pier's own log download never runs and
+# the CLI's stream-json exists only in the container. The adapter must download
+# it itself, or _events(require_assistant=True) raises and a real
+# token-burning run is misclassified as infra.
+with tempfile.TemporaryDirectory() as pier_tmp:
+    pier_logs = Path(pier_tmp)
+
+    class PierEnvironment:
+        def __init__(self):
+            self.downloads = []
+
+        async def exec(self, command, env=None, **kwargs):
+            # The CLI writes only the in-container /logs/agent/kimi-code.jsonl;
+            # nothing appears under the host logs_dir.
+            return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+
+        async def download_file(self, remote, local):
+            self.downloads.append(remote)
+            Path(local).write_text(
+                json.dumps({"role": "assistant", "content": "done"}) + "\n",
+                encoding="utf-8",
+            )
+
+    pier_agent = MakaKimiCodeAgent(
+        pier_logs,
+        version="0.26.0",
+        model_name="k3",
+        extra_env={
+            "MAKA_PROVIDER_PROXY_URL": "http://host.docker.internal:43210",
+            "MAKA_PROVIDER_PROXY_TOKEN": "ephemeral-token",
+            "MAKA_MODEL": "k3",
+            "MAKA_SYSTEM_PROMPT": "",
+        },
+    )
+    pier_environment = PierEnvironment()
+    asyncio.run(pier_agent.run("hi", pier_environment, object()))
+    assert "/logs/agent/kimi-code.jsonl" in pier_environment.downloads, pier_environment.downloads
+    pier_agent.populate_context_post_run(object())
+    pier_cell = json.loads((pier_logs / "maka-cell-output.json").read_text(encoding="utf-8"))
+    assert pier_cell["status"] == "completed", pier_cell
+    assert pier_cell["steps"] == 1, pier_cell
+
+print("kimi-code adapter ok")
 `;
 }
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1862,6 +1862,33 @@ with tempfile.TemporaryDirectory() as tmp:
     assert hydrated_deadline_output["tokenSummary"] == deadline_usage, hydrated_deadline_output
     assert json.loads(deadline_output_path.read_text(encoding="utf-8"))["tokenSummary"] == deadline_usage
 
+    class DownloadEnvironment:
+        def __init__(self):
+            self.downloads = []
+
+        async def download_file(self, remote, local):
+            self.downloads.append(remote)
+            Path(local).write_text("{}", encoding="utf-8")
+
+    # Pier (--mounts-json replaces the default log mounts): nothing is host-side
+    # yet, so the adapter must download runtime-events.jsonl alongside the cell
+    # output or the cell output's runtimeEventsPath dangles.
+    with tempfile.TemporaryDirectory() as pier_logs:
+        pier_environment = DownloadEnvironment()
+        asyncio.run(MakaAgent(Path(pier_logs))._download_cell_output(pier_environment))
+        assert "/logs/agent/maka-cell-output.json" in pier_environment.downloads, pier_environment.downloads
+        assert "/logs/agent/runtime-events.jsonl" in pier_environment.downloads, pier_environment.downloads
+
+    # Harbor (agent log dir bind-mounted): runtime-events.jsonl already exists
+    # host-side, so the adapter must not race the mount with a re-download; the
+    # cell output download itself stays unchanged.
+    with tempfile.TemporaryDirectory() as harbor_logs:
+        (Path(harbor_logs) / "runtime-events.jsonl").write_text("", encoding="utf-8")
+        mounted_environment = DownloadEnvironment()
+        asyncio.run(MakaAgent(Path(harbor_logs))._download_cell_output(mounted_environment))
+        assert "/logs/agent/maka-cell-output.json" in mounted_environment.downloads, mounted_environment.downloads
+        assert "/logs/agent/runtime-events.jsonl" not in mounted_environment.downloads, mounted_environment.downloads
+
     context = AgentContext()
     agent._apply_cell_output(context, {
         "status": "completed",

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1871,23 +1871,27 @@ with tempfile.TemporaryDirectory() as tmp:
             Path(local).write_text("{}", encoding="utf-8")
 
     # Pier (--mounts-json replaces the default log mounts): nothing is host-side
-    # yet, so the adapter must download runtime-events.jsonl alongside the cell
-    # output or the cell output's runtimeEventsPath dangles.
+    # yet, so the adapter must download runtime-events.jsonl and trace-events.jsonl
+    # alongside the cell output or the cell output's runtimeEventsPath /
+    # traceEventsPath dangle.
     with tempfile.TemporaryDirectory() as pier_logs:
         pier_environment = DownloadEnvironment()
         asyncio.run(MakaAgent(Path(pier_logs))._download_cell_output(pier_environment))
         assert "/logs/agent/maka-cell-output.json" in pier_environment.downloads, pier_environment.downloads
         assert "/logs/agent/runtime-events.jsonl" in pier_environment.downloads, pier_environment.downloads
+        assert "/logs/agent/trace-events.jsonl" in pier_environment.downloads, pier_environment.downloads
 
-    # Harbor (agent log dir bind-mounted): runtime-events.jsonl already exists
+    # Harbor (agent log dir bind-mounted): the agent logs already exist
     # host-side, so the adapter must not race the mount with a re-download; the
     # cell output download itself stays unchanged.
     with tempfile.TemporaryDirectory() as harbor_logs:
         (Path(harbor_logs) / "runtime-events.jsonl").write_text("", encoding="utf-8")
+        (Path(harbor_logs) / "trace-events.jsonl").write_text("", encoding="utf-8")
         mounted_environment = DownloadEnvironment()
         asyncio.run(MakaAgent(Path(harbor_logs))._download_cell_output(mounted_environment))
         assert "/logs/agent/maka-cell-output.json" in mounted_environment.downloads, mounted_environment.downloads
         assert "/logs/agent/runtime-events.jsonl" not in mounted_environment.downloads, mounted_environment.downloads
+        assert "/logs/agent/trace-events.jsonl" not in mounted_environment.downloads, mounted_environment.downloads
 
     context = AgentContext()
     agent._apply_cell_output(context, {

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -266,6 +266,52 @@ test('createPierTaskRunner passes the provider-local bare model id to pier -m', 
   });
 });
 
+test('createPierTaskRunner derives the wall-clock watchdog from the task-native budget', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({ jobsDir, makaRepoPath: repo, runPier: fakePier({ reward: 0, captured }) }),
+    );
+    // DeepSWE-shaped budget: 5400s agent + 1800s verifier. A fixed 45-minute
+    // watchdog would kill every trial mid-flight; the shared Harbor derivation
+    // yields native phases + 15min setup/teardown grace.
+    await runner(
+      runInput({
+        task: {
+          id: 'dasel',
+          path: '/tasks/dasel-html-document-format',
+          metadata: { agentTimeoutSec: 5400, verifierTimeoutSec: 1800 },
+        },
+      }),
+    );
+    assert.equal(captured.request?.timeoutMs, (5400 + 1800) * 1_000 + 15 * 60_000);
+
+    // Without task metadata the 45-minute floor holds.
+    await runner(runInput());
+    assert.equal(captured.request?.timeoutMs, 45 * 60_000);
+
+    // An explicit pierTimeoutMs still wins.
+    const explicit = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        pierTimeoutMs: 1_234,
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+    await explicit(
+      runInput({
+        task: {
+          id: 'dasel',
+          path: '/tasks/dasel-html-document-format',
+          metadata: { agentTimeoutSec: 5400, verifierTimeoutSec: 1800 },
+        },
+      }),
+    );
+    assert.equal(captured.request?.timeoutMs, 1_234);
+  });
+});
+
 test('createPierTaskRunner falls back to the trial verifier_result reward', async () => {
   await withDirs(async ({ jobsDir, repo }) => {
     const runner = createPierTaskRunner(

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -349,12 +349,15 @@ test('createPierTaskRunner derives the wall-clock watchdog from the task-native 
       baseOptions({ jobsDir, makaRepoPath: repo, runPier: fakePier({ reward: 0, captured }) }),
     );
     // DeepSWE-shaped budget (113/113 tasks): build 1800s + agent 5400s +
-    // verifier 1800s, and pier retries build and verification once each on
-    // their timeout errors (tenacity stop_after_attempt(2) in
-    // pier/trial/execution.py:208 and pier/trial/trial.py:333). The watchdog
-    // must cover the complete legitimate lifecycle 2xbuild + agent +
-    // 2xverifier = 12600s, or cold builds and verifier retries get killed as
-    // infra. Contract: derived value covers that ceiling plus grace.
+    // verifier 1800s, plus pier's fixed agent_setup phase (360s,
+    // pier/trial/trial.py:176, multiplier-scaled per
+    // pier/trial/execution.py:129-143), and pier retries build and
+    // verification once each on their timeout errors (tenacity
+    // stop_after_attempt(2) in pier/trial/execution.py:208 and
+    // pier/trial/trial.py:333). The watchdog must cover the complete
+    // legitimate lifecycle 2xbuild + setup + agent + 2xverifier = 12960s, or
+    // cold builds, slow setups, and verifier retries get killed as infra.
+    // Contract: derived value covers that ceiling plus grace.
     const deepSweMetadata = {
       agentTimeoutSec: 5400,
       verifierTimeoutSec: 1800,
@@ -365,8 +368,11 @@ test('createPierTaskRunner derives the wall-clock watchdog from the task-native 
         task: { id: 'dasel', path: '/tasks/dasel-html-document-format', metadata: deepSweMetadata },
       }),
     );
-    assert.equal(captured.request?.timeoutMs, (2 * 1800 + 5400 + 2 * 1800) * 1_000 + 15 * 60_000);
-    assert.ok((captured.request?.timeoutMs ?? 0) >= 12_600_000);
+    assert.equal(
+      captured.request?.timeoutMs,
+      (2 * 1800 + 360 + 5400 + 2 * 1800) * 1_000 + 15 * 60_000,
+    );
+    assert.ok((captured.request?.timeoutMs ?? 0) >= 12_960_000);
 
     // Without task metadata the 45-minute floor holds.
     await runner(runInput());

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -236,6 +236,28 @@ test('createPierTaskRunner maps a completed fake trial to reward and host cell p
   });
 });
 
+test('createPierTaskRunner passes the provider-local bare model id to pier -m', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        model: 'deepseek/deepseek-v4-flash',
+        provider: 'deepseek',
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+    await runner(runInput());
+    // The adapter's model_name outranks MAKA_MODEL, so a prefixed -m would leak
+    // the provider-prefixed id into the cell. Same contract as modelIdForProvider
+    // in the Harbor runner.
+    const modelFlag = captured.request?.args.indexOf('-m') ?? -1;
+    assert.equal(captured.request?.args[modelFlag + 1], 'deepseek-v4-flash');
+    assert.ok(captured.request?.args.includes('MAKA_MODEL=deepseek-v4-flash'));
+  });
+});
+
 test('createPierTaskRunner falls back to the trial verifier_result reward', async () => {
   await withDirs(async ({ jobsDir, repo }) => {
     const runner = createPierTaskRunner(

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -14,12 +14,47 @@ import {
 import {
   buildPierRunArgs,
   createPierTaskRunner,
+  defaultPierProcessRunner,
   PierInfraError,
   type PierProcessRunner,
   type PierRunRequest,
   type PierRunResult,
   type PierTaskRunnerOptions,
 } from '../pier-task-runner.js';
+
+function terminationRequest(script: string, graceMs: number): PierRunRequest {
+  return {
+    pierBin: 'bash',
+    jobName: 'trial',
+    jobsDir: '/tmp',
+    args: ['-c', script],
+    cwd: '/tmp',
+    timeoutMs: 400,
+    terminationGraceMs: graceMs,
+  };
+}
+
+test('defaultPierProcessRunner terminates with SIGTERM first so pier can tear down', async () => {
+  // Pier converts SIGTERM into KeyboardInterrupt (pier/cli/jobs.py) and runs
+  // its finally-based docker teardown; a straight SIGKILL would leak the trial
+  // containers and orphan a host cell. The trap stands in for that handler.
+  const result = await defaultPierProcessRunner(
+    terminationRequest('trap \'echo got-term; exit 0\' TERM; echo ready; sleep 30 & wait', 5_000),
+  );
+  assert.equal(result.timedOut, true);
+  assert.match(result.stdout, /got-term/);
+  assert.notEqual(result.signal, 'SIGKILL');
+});
+
+test('defaultPierProcessRunner escalates to SIGKILL after the grace', async () => {
+  // The loop respawns children the group SIGTERM kills, while bash itself
+  // ignores TERM — only the SIGKILL escalation can end it.
+  const result = await defaultPierProcessRunner(
+    terminationRequest("trap '' TERM; while true; do sleep 1; done", 300),
+  );
+  assert.equal(result.timedOut, true);
+  assert.equal(result.signal, 'SIGKILL');
+});
 
 function cellOutput(overrides: Partial<HarborCellOutput> = {}): HarborCellOutput {
   return {

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -48,6 +48,7 @@ interface FakeOptions {
   rewardJson?: boolean;
   verifierResultReward?: number;
   cell?: HarborCellOutput | null;
+  executionIdentity?: Record<string, unknown>;
   exceptionInfo?: { exception_type: string; exception_message: string };
   exitCode?: number;
   timedOut?: boolean;
@@ -91,6 +92,13 @@ function fakePier(opts: FakeOptions): PierProcessRunner {
       await writeFile(
         join(trialDir, 'agent', 'maka-cell-output.json'),
         JSON.stringify(opts.cell ?? cellOutput()),
+        'utf8',
+      );
+    }
+    if (opts.executionIdentity) {
+      await writeFile(
+        join(trialDir, 'agent', 'maka-cell-execution-identity.json'),
+        JSON.stringify(opts.executionIdentity),
         'utf8',
       );
     }
@@ -335,6 +343,42 @@ test('createPierTaskRunner reports a budget exhaustion as a benchmark outcome', 
       runner(runInput()),
       (error: Error) => error instanceof FixedPromptBudgetExhaustedError,
     );
+  });
+});
+
+test('createPierTaskRunner recovers execution identity from a budget-exhausted trial', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const identity = {
+      llmConnectionSlug: 'fake',
+      model: 'fake',
+      systemPromptMode: 'default',
+      systemPromptHash: 'sha256:abc',
+      pricingProfile: 'fake-structural',
+    };
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({
+          cell: null,
+          executionIdentity: identity,
+          exceptionInfo: {
+            exception_type: 'AgentTimeoutError',
+            exception_message: 'Agent execution timed out after 600 seconds',
+          },
+        }),
+      }),
+    );
+    // The recovered identity keeps the sample Pass@1-eligible; a null
+    // artifactRefs would demote it to missing_execution_identity and silently
+    // shrink the benchmark denominator. Recovery is the shared Harbor
+    // implementation (readTimedOutTrialArtifacts), so both runners honor the
+    // same cross-runner contract by construction.
+    await assert.rejects(runner(runInput()), (error: Error) => {
+      assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+      assert.deepEqual(error.artifactRefs?.executionIdentity, identity);
+      return true;
+    });
   });
 });
 

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -124,6 +124,7 @@ interface FakeOptions {
   exitCode?: number;
   timedOut?: boolean;
   combinedTrace?: boolean;
+  sessionTrace?: boolean;
   captured?: { request?: PierRunRequest; envFile?: Record<string, string> };
 }
 
@@ -176,6 +177,13 @@ function fakePier(opts: FakeOptions): PierProcessRunner {
     await writeFile(join(trialDir, 'agent', 'runtime-events.jsonl'), '{"type":"x"}\n', 'utf8');
     if (opts.combinedTrace) {
       await writeFile(join(trialDir, 'agent', 'trace-events.jsonl'), '{"type":"first"}\n', 'utf8');
+    }
+    if (opts.sessionTrace) {
+      // The in-cell session trace layout hostTraceEventsPath resolves via
+      // cell.runtimeRefs (sessionId 'sess', runId 'run' in cellOutput()).
+      const sessionDir = join(trialDir, 'agent', 'maka-storage', 'sessions', 'sess', 'runs', 'run');
+      await mkdir(sessionDir, { recursive: true });
+      await writeFile(join(sessionDir, 'events.jsonl'), '{"type":"tool_failed"}\n', 'utf8');
     }
     if (opts.reward !== undefined && opts.rewardJson !== false) {
       await writeFile(
@@ -410,12 +418,13 @@ test('createPierTaskRunner falls back to the trial verifier_result reward', asyn
   });
 });
 
-test('createPierTaskRunner surfaces the combined trace path when present', async () => {
+test('createPierTaskRunner surfaces the combined trace path in task-run mode', async () => {
   await withDirs(async ({ jobsDir, repo }) => {
     const runner = createPierTaskRunner(
       baseOptions({
         jobsDir,
         makaRepoPath: repo,
+        agentEnv: { MAKA_HARBOR_MODE: 'task-run' },
         runPier: fakePier({ reward: 0, combinedTrace: true }),
       }),
     );
@@ -424,7 +433,28 @@ test('createPierTaskRunner surfaces the combined trace path when present', async
   });
 });
 
-test('createPierTaskRunner falls back to runtime events when the combined trace is missing', async () => {
+test('createPierTaskRunner resolves the cell-mode session trace via runtimeRefs', async () => {
+  // Shared hostTraceEventsPath: in cell mode the rich trace lives at
+  // agent/maka-storage/sessions/<sid>/runs/<rid>/events.jsonl. Skipping this
+  // branch silently drops tool_failed / provider_request_captured attribution
+  // from downstream failure analysis.
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({ reward: 0, sessionTrace: true }),
+      }),
+    );
+    const output = await runner(runInput());
+    assert.match(
+      output.cell.traceEventsPath ?? '',
+      /agent\/maka-storage\/sessions\/sess\/runs\/run\/events\.jsonl$/,
+    );
+  });
+});
+
+test('createPierTaskRunner falls back to runtime events when no richer trace exists', async () => {
   // Harbor-parity (hostTraceEventsPath): traceEventsPath is always set, so
   // downstream trace analysis never silently skips the sample.
   await withDirs(async ({ jobsDir, repo }) => {

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -626,6 +626,37 @@ test('createPierTaskRunner treats an ungraded non-budget trial exception as infr
   });
 });
 
+test('createPierTaskRunner classifies the reward.json crash sentinel as infra', async () => {
+  // DeepSWE test.sh traps a verifier crash by writing reward -1 when no reward
+  // file exists; grader.py documents real rewards as binary 0/1. A sentinel
+  // must never be recorded as a scored failed sample.
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({ jobsDir, makaRepoPath: repo, runPier: fakePier({ reward: -1 }) }),
+    );
+    await assert.rejects(runner(runInput()), (error: Error) => {
+      assert.ok(error instanceof PierInfraError);
+      assert.match(error.message, /crash sentinel/);
+      return true;
+    });
+  });
+});
+
+test('createPierTaskRunner classifies the verifier_result crash sentinel as infra', async () => {
+  // The sentinel arrives via reward.txt -> pier's verifier parse ->
+  // verifier_result.rewards.reward; there is no reward.json in that path.
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({ jobsDir, makaRepoPath: repo, runPier: fakePier({ verifierResultReward: -1 }) }),
+    );
+    await assert.rejects(runner(runInput()), (error: Error) => {
+      assert.ok(error instanceof PierInfraError);
+      assert.match(error.message, /crash sentinel/);
+      return true;
+    });
+  });
+});
+
 test('createPierTaskRunner rejects provider secrets in agentEnv', async () => {
   await withDirs(async ({ jobsDir, repo }) => {
     const runner = createPierTaskRunner(

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -39,7 +39,7 @@ test('defaultPierProcessRunner terminates with SIGTERM first so pier can tear do
   // its finally-based docker teardown; a straight SIGKILL would leak the trial
   // containers and orphan a host cell. The trap stands in for that handler.
   const result = await defaultPierProcessRunner(
-    terminationRequest('trap \'echo got-term; exit 0\' TERM; echo ready; sleep 30 & wait', 5_000),
+    terminationRequest("trap 'echo got-term; exit 0' TERM; echo ready; sleep 30 & wait", 5_000),
   );
   assert.equal(result.timedOut, true);
   assert.match(result.stdout, /got-term/);
@@ -334,10 +334,7 @@ test('createPierTaskRunner derives the wall-clock watchdog from the task-native 
         task: { id: 'dasel', path: '/tasks/dasel-html-document-format', metadata: deepSweMetadata },
       }),
     );
-    assert.equal(
-      captured.request?.timeoutMs,
-      (2 * 1800 + 5400 + 2 * 1800) * 1_000 + 15 * 60_000,
-    );
+    assert.equal(captured.request?.timeoutMs, (2 * 1800 + 5400 + 2 * 1800) * 1_000 + 15 * 60_000);
     assert.ok((captured.request?.timeoutMs ?? 0) >= 12_600_000);
 
     // Without task metadata the 45-minute floor holds.
@@ -724,5 +721,49 @@ test('createPierTaskRunner keeps the real key host-side via a file path for the 
     assert.ok(captured.request?.args.includes(`MAKA_HOST_API_KEY_FILE=${keyFile}`));
     assert.ok(!captured.request?.args.some((arg) => arg.includes('sk-real')));
     assert.ok(captured.request?.args.includes('MAKA_HOST_BASE_URL=https://api.kimi.com/coding/v1'));
+  });
+});
+
+test('createPierTaskRunner runs keyless providers as a host cell with MAKA_HOST_NO_AUTH', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'maka',
+        backend: 'ai-sdk',
+        provider: 'ollama',
+        model: 'qwen3:32b',
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+    await runner(runInput());
+    // Mirrors the Harbor runner: authKind 'none' providers need no key file and
+    // run on the host with an explicit no-auth marker instead of silently
+    // falling back to the in-container cell.
+    assert.ok(captured.request?.args.includes('MAKA_HOST_NO_AUTH=true'));
+    assert.ok(captured.request?.args.includes(`MAKA_HOST_REPO_ROOT=${repo}`));
+    assert.ok(!captured.request?.args.some((arg) => arg.startsWith('MAKA_HOST_API_KEY_FILE=')));
+  });
+});
+
+test('createPierTaskRunner keeps the fake backend on the in-container cell with no MAKA_HOST_*', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'maka',
+        provider: 'ollama',
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+    await runner(runInput());
+    // backend 'fake' is the zero-cost structural path (bind-mounted repo,
+    // in-container cell); host-runtime wiring must not leak into it even for
+    // keyless providers.
+    assert.ok(!captured.request?.args.some((arg) => arg.startsWith('MAKA_HOST_')));
   });
 });

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -448,6 +448,34 @@ test('pier-graded failed cells stay scored through the fixed-prompt controller',
   });
 });
 
+test('createPierTaskRunner scores a graded trial despite an AgentTimeoutError', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    // Pier records the agent exception and then unconditionally runs the
+    // verifier, so a timed-out agent can still earn its actual reward — for
+    // both outcomes, and even when pier itself exits non-zero.
+    for (const reward of [1, 0]) {
+      const runner = createPierTaskRunner(
+        baseOptions({
+          jobsDir,
+          makaRepoPath: repo,
+          runPier: fakePier({
+            reward,
+            exitCode: 3,
+            exceptionInfo: {
+              exception_type: 'AgentTimeoutError',
+              exception_message: 'Agent execution timed out after 600 seconds',
+            },
+          }),
+        }),
+      );
+      const output = await runner(runInput());
+      assert.equal(output.harbor.reward, reward);
+      assert.equal(output.harbor.verifier?.outcome, reward > 0 ? 'passed' : 'failed');
+      assert.equal(output.cell.status, 'completed');
+    }
+  });
+});
+
 test('createPierTaskRunner recovers execution identity from a budget-exhausted trial', async () => {
   await withDirs(async ({ jobsDir, repo }) => {
     const identity = {

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -372,6 +372,21 @@ test('createPierTaskRunner rejects provider secrets in agentEnv', async () => {
   });
 });
 
+test('createPierTaskRunner rejects experiment identity and pricing overrides in agentEnv', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const overrides: Array<Record<string, string>> = [
+      { MAKA_MODEL: 'other-model' },
+      { MAKA_TRIAL_INPUT_USD_PER_1M: '9' },
+    ];
+    for (const env of overrides) {
+      const runner = createPierTaskRunner(
+        baseOptions({ jobsDir, makaRepoPath: repo, agentEnv: env, runPier: fakePier({ reward: 0 }) }),
+      );
+      await assert.rejects(runner(runInput()), /must not override experiment identity/);
+    }
+  });
+});
+
 test('createPierTaskRunner requires the Kimi toolchain mount for the Kimi arm', async () => {
   await withDirs(async ({ jobsDir, repo }) => {
     const runner = createPierTaskRunner(

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -580,7 +580,31 @@ test('createPierTaskRunner recovers execution identity from a budget-exhausted t
   });
 });
 
-test('createPierTaskRunner treats a non-budget trial exception as infra', async () => {
+test('createPierTaskRunner scores a graded trial despite a non-budget exception', async () => {
+  // Harbor-authority parity: exception_info records how the agent phase ended,
+  // not whether the trial was graded. A Kimi CLI non-zero exit the verifier
+  // still passed must count as passed, not be discarded as infra.
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({
+          reward: 1,
+          exceptionInfo: {
+            exception_type: 'NonZeroAgentExitCodeError',
+            exception_message: 'agent exited 1',
+          },
+        }),
+      }),
+    );
+    const output = await runner(runInput());
+    assert.equal(output.harbor.reward, 1);
+    assert.equal(output.harbor.verifier?.outcome, 'passed');
+  });
+});
+
+test('createPierTaskRunner treats an ungraded non-budget trial exception as infra', async () => {
   await withDirs(async ({ jobsDir, repo }) => {
     const runner = createPierTaskRunner(
       baseOptions({
@@ -594,7 +618,9 @@ test('createPierTaskRunner treats a non-budget trial exception as infra', async 
     );
     await assert.rejects(runner(runInput()), (error: Error) => {
       assert.ok(error instanceof PierInfraError);
-      assert.match(error.message, /pier trial errored/);
+      // The trial exception is the root cause and must ride the diagnostics.
+      assert.match(error.message, /failed before verifier reward/);
+      assert.match(error.message, /RuntimeError: boom/);
       return true;
     });
   });

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -418,6 +418,19 @@ test('createPierTaskRunner surfaces the combined trace path when present', async
   });
 });
 
+test('createPierTaskRunner falls back to runtime events when the combined trace is missing', async () => {
+  // Harbor-parity (hostTraceEventsPath): traceEventsPath is always set, so
+  // downstream trace analysis never silently skips the sample.
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({ jobsDir, makaRepoPath: repo, runPier: fakePier({ reward: 0 }) }),
+    );
+    const output = await runner(runInput());
+    assert.equal(output.cell.traceEventsPath, output.cell.runtimeEventsPath);
+    assert.match(output.cell.traceEventsPath ?? '', /agent\/runtime-events\.jsonl$/);
+  });
+});
+
 test('createPierTaskRunner classifies a pier launch failure as infra', async () => {
   await withDirs(async ({ jobsDir, repo }) => {
     const runner = createPierTaskRunner(

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -811,63 +811,86 @@ test('createPierTaskRunner wires the Kimi arm through the host proxy on a Squid-
   });
 });
 
-async function runConcurrentKimiAttempts(providerProxyPort: number): Promise<number> {
+/** One SEPARATE runner instance per port entry, one concurrent attempt each —
+ * the lock's owner must be the shared host port, not a runner closure, or an
+ * A/B with two Kimi arms in one process EADDRINUSEs. */
+async function runConcurrentKimiAttempts(ports: readonly number[]): Promise<number> {
   return await withDirs(async ({ jobsDir, repo }) => {
     let inFlight = 0;
     let maxInFlight = 0;
     const inner = fakePier({ reward: 0 });
-    const runner = createPierTaskRunner(
-      baseOptions({
-        jobsDir,
-        makaRepoPath: repo,
-        agent: 'kimi-code',
-        backend: 'ai-sdk',
-        provider: 'kimi-coding-plan',
-        model: 'k3',
-        baseUrl: 'https://api.kimi.com/coding/v1',
-        kimiCodeToolchainPath: repo,
-        resolveProviderCredential: () => Promise.resolve({ value: 'upstream-key' }),
-        providerProxyPort,
-        runPier: async (request) => {
-          inFlight += 1;
-          maxInFlight = Math.max(maxInFlight, inFlight);
-          await new Promise((resolve) => setTimeout(resolve, 25));
-          try {
-            return await inner(request);
-          } finally {
-            inFlight -= 1;
-          }
-        },
-      }),
+    const runners = ports.map((providerProxyPort) =>
+      createPierTaskRunner(
+        baseOptions({
+          jobsDir,
+          makaRepoPath: repo,
+          agent: 'kimi-code',
+          backend: 'ai-sdk',
+          provider: 'kimi-coding-plan',
+          model: 'k3',
+          baseUrl: 'https://api.kimi.com/coding/v1',
+          kimiCodeToolchainPath: repo,
+          resolveProviderCredential: () => Promise.resolve({ value: 'upstream-key' }),
+          providerProxyPort,
+          runPier: async (request) => {
+            inFlight += 1;
+            maxInFlight = Math.max(maxInFlight, inFlight);
+            await new Promise((resolve) => setTimeout(resolve, 25));
+            try {
+              return await inner(request);
+            } finally {
+              inFlight -= 1;
+            }
+          },
+        }),
+      ),
     );
-    const [first, second] = await Promise.all([
-      runner(runInput({ task: { id: 't1', path: '/tasks/dasel-html-document-format' } })),
-      runner(runInput({ task: { id: 't2', path: '/tasks/dasel-html-document-format' } })),
-    ]);
-    assert.equal(first.harbor.reward, 0);
-    assert.equal(second.harbor.reward, 0);
+    const outputs = await Promise.all(
+      runners.map((runner, index) =>
+        runner(runInput({ task: { id: `t${index}`, path: '/tasks/dasel-html-document-format' } })),
+      ),
+    );
+    for (const output of outputs) assert.equal(output.harbor.reward, 0);
     return maxInFlight;
   });
 }
 
-test('createPierTaskRunner serializes concurrent Kimi attempts holding a fixed proxy port', async () => {
+/** Grab currently-free ports from the OS (all probes held open together so the
+ * ports are distinct) so tests bind real listeners without privileges for 443. */
+async function grabFreePorts(count: number): Promise<number[]> {
+  const probes = Array.from({ length: count }, () => createServer());
+  const ports = await Promise.all(
+    probes.map(
+      (probe) =>
+        new Promise<number>((resolve) => {
+          probe.listen(0, () => resolve((probe.address() as AddressInfo).port));
+        }),
+    ),
+  );
+  await Promise.all(probes.map((probe) => new Promise((resolve) => probe.close(resolve))));
+  return ports;
+}
+
+test('createPierTaskRunner serializes concurrent Kimi attempts across runners on one fixed port', async () => {
   // A fixed port (like the default 443) admits exactly one bind: a second
-  // concurrent attempt would be a guaranteed EADDRINUSE, so the runner must
-  // hold the port one attempt at a time while both attempts still complete.
-  // Grab a currently-free port from the OS so the test binds a real listener
-  // without needing privileges for 443.
-  const probe = createServer();
-  const fixedPort = await new Promise<number>((resolve) => {
-    probe.listen(0, () => resolve((probe.address() as AddressInfo).port));
-  });
-  await new Promise((resolve) => probe.close(resolve));
-  assert.equal(await runConcurrentKimiAttempts(fixedPort), 1);
+  // concurrent attempt — even from a DIFFERENT runner instance in the same
+  // process — would be a guaranteed EADDRINUSE, so the port is held one
+  // attempt at a time while both attempts still complete.
+  const [fixedPort] = await grabFreePorts(1);
+  assert.equal(await runConcurrentKimiAttempts([fixedPort!, fixedPort!]), 1);
 });
 
 test('createPierTaskRunner lets ephemeral-port Kimi attempts run concurrently', async () => {
   // Port 0 asks the OS for a fresh port per bind — no collision is possible,
   // so the serialization lock must not throttle throughput.
-  assert.equal(await runConcurrentKimiAttempts(0), 2);
+  assert.equal(await runConcurrentKimiAttempts([0, 0]), 2);
+});
+
+test('createPierTaskRunner lets Kimi attempts on distinct fixed ports run concurrently', async () => {
+  // The lock is per port, not global: distinct fixed ports cannot collide.
+  const [portA, portB] = await grabFreePorts(2);
+  assert.notEqual(portA, portB);
+  assert.equal(await runConcurrentKimiAttempts([portA!, portB!]), 2);
 });
 
 test('createPierTaskRunner keeps the real key host-side via a file path for the Maka arm', async () => {

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -317,19 +317,28 @@ test('createPierTaskRunner derives the wall-clock watchdog from the task-native 
     const runner = createPierTaskRunner(
       baseOptions({ jobsDir, makaRepoPath: repo, runPier: fakePier({ reward: 0, captured }) }),
     );
-    // DeepSWE-shaped budget: 5400s agent + 1800s verifier. A fixed 45-minute
-    // watchdog would kill every trial mid-flight; the shared Harbor derivation
-    // yields native phases + 15min setup/teardown grace.
+    // DeepSWE-shaped budget (113/113 tasks): build 1800s + agent 5400s +
+    // verifier 1800s, and pier retries build and verification once each on
+    // their timeout errors (tenacity stop_after_attempt(2) in
+    // pier/trial/execution.py:208 and pier/trial/trial.py:333). The watchdog
+    // must cover the complete legitimate lifecycle 2xbuild + agent +
+    // 2xverifier = 12600s, or cold builds and verifier retries get killed as
+    // infra. Contract: derived value covers that ceiling plus grace.
+    const deepSweMetadata = {
+      agentTimeoutSec: 5400,
+      verifierTimeoutSec: 1800,
+      buildTimeoutSec: 1800,
+    };
     await runner(
       runInput({
-        task: {
-          id: 'dasel',
-          path: '/tasks/dasel-html-document-format',
-          metadata: { agentTimeoutSec: 5400, verifierTimeoutSec: 1800 },
-        },
+        task: { id: 'dasel', path: '/tasks/dasel-html-document-format', metadata: deepSweMetadata },
       }),
     );
-    assert.equal(captured.request?.timeoutMs, (5400 + 1800) * 1_000 + 15 * 60_000);
+    assert.equal(
+      captured.request?.timeoutMs,
+      (2 * 1800 + 5400 + 2 * 1800) * 1_000 + 15 * 60_000,
+    );
+    assert.ok((captured.request?.timeoutMs ?? 0) >= 12_600_000);
 
     // Without task metadata the 45-minute floor holds.
     await runner(runInput());
@@ -346,11 +355,7 @@ test('createPierTaskRunner derives the wall-clock watchdog from the task-native 
     );
     await explicit(
       runInput({
-        task: {
-          id: 'dasel',
-          path: '/tasks/dasel-html-document-format',
-          metadata: { agentTimeoutSec: 5400, verifierTimeoutSec: 1800 },
-        },
+        task: { id: 'dasel', path: '/tasks/dasel-html-document-format', metadata: deepSweMetadata },
       }),
     );
     assert.equal(captured.request?.timeoutMs, 1_234);

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -1,0 +1,428 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { HarborCellOutput } from '../cell-output.js';
+import { FixedPromptBudgetExhaustedError, type TaskRunInput } from '../fixed-prompt-controller.js';
+import {
+  buildPierRunArgs,
+  createPierTaskRunner,
+  PierInfraError,
+  type PierProcessRunner,
+  type PierRunRequest,
+  type PierRunResult,
+  type PierTaskRunnerOptions,
+} from '../pier-task-runner.js';
+
+function cellOutput(overrides: Partial<HarborCellOutput> = {}): HarborCellOutput {
+  return {
+    schemaVersion: 1,
+    status: 'completed',
+    runtimeEventsPath: '/logs/agent/runtime-events.jsonl',
+    executionIdentity: {
+      llmConnectionSlug: 'fake',
+      model: 'fake',
+      systemPromptMode: 'default',
+      systemPromptHash: 'sha256:abc',
+      pricingProfile: 'fake-structural',
+    },
+    toolSummary: {
+      providerVisibleToolCount: 0,
+      actualToolCalls: 0,
+      actualToolNames: [],
+      actualToolCallCounts: {},
+    },
+    steps: 1,
+    durationMs: 9790,
+    startedAt: 1,
+    finishedAt: 2,
+    runtimeRefs: { invocationId: 'inv', sessionId: 'sess', runId: 'run', turnId: 'turn' },
+    ...overrides,
+  };
+}
+
+interface FakeOptions {
+  reward?: number;
+  rewardJson?: boolean;
+  verifierResultReward?: number;
+  cell?: HarborCellOutput | null;
+  exceptionInfo?: { exception_type: string; exception_message: string };
+  exitCode?: number;
+  timedOut?: boolean;
+  combinedTrace?: boolean;
+  captured?: { request?: PierRunRequest; envFile?: Record<string, string> };
+}
+
+/** A Pier process runner that writes the maka-dasel-fake2 trial layout: a
+ * `<task>__<7ch>` trial dir with agent/maka-cell-output.json, verifier/reward.json,
+ * and result.json (job aggregate + per-trial). Mirrors the captured schema. */
+function fakePier(opts: FakeOptions): PierProcessRunner {
+  return async (request): Promise<PierRunResult> => {
+    if (opts.captured) {
+      opts.captured.request = request;
+      const envFileFlag = request.args.indexOf('--env-file');
+      if (envFileFlag >= 0) {
+        const raw = await readFile(request.args[envFileFlag + 1]!, 'utf8');
+        opts.captured.envFile = Object.fromEntries(
+          raw
+            .split('\n')
+            .filter((line) => line.includes('='))
+            .map((line) => {
+              const index = line.indexOf('=');
+              return [line.slice(0, index), line.slice(index + 1)];
+            }),
+        );
+      }
+    }
+    if (opts.timedOut) {
+      return { exitCode: 137, stdout: '', stderr: 'killed', timedOut: true, signal: 'SIGKILL' };
+    }
+    if (opts.exitCode && opts.exitCode !== 0 && opts.cell === undefined && !opts.exceptionInfo) {
+      return { exitCode: opts.exitCode, stdout: '', stderr: 'container build failed' };
+    }
+    const pathFlag = request.args.indexOf('-p');
+    const taskName = request.args[pathFlag + 1]!.split('/').pop()!;
+    const trialDir = join(request.jobsDir, request.jobName, `${taskName}__fjabYqp`);
+    await mkdir(join(trialDir, 'agent'), { recursive: true });
+    await mkdir(join(trialDir, 'verifier'), { recursive: true });
+    if (opts.cell !== null) {
+      await writeFile(
+        join(trialDir, 'agent', 'maka-cell-output.json'),
+        JSON.stringify(opts.cell ?? cellOutput()),
+        'utf8',
+      );
+    }
+    await writeFile(join(trialDir, 'agent', 'runtime-events.jsonl'), '{"type":"x"}\n', 'utf8');
+    if (opts.combinedTrace) {
+      await writeFile(join(trialDir, 'agent', 'trace-events.jsonl'), '{"type":"first"}\n', 'utf8');
+    }
+    if (opts.reward !== undefined && opts.rewardJson !== false) {
+      await writeFile(
+        join(trialDir, 'verifier', 'reward.json'),
+        JSON.stringify({ reward: opts.reward, f2p: 0, p2p: 1 }),
+        'utf8',
+      );
+    }
+    const trialResult: Record<string, unknown> = {
+      trial_name: `${taskName}__fjabYqp`,
+      exception_info: opts.exceptionInfo ?? null,
+      ...(opts.verifierResultReward !== undefined
+        ? { verifier_result: { rewards: { reward: opts.verifierResultReward } } }
+        : {}),
+    };
+    await writeFile(join(trialDir, 'result.json'), JSON.stringify(trialResult), 'utf8');
+    // Job aggregate result.json points at the trial name via stats.evals[*].reward_stats.
+    await writeFile(
+      join(request.jobsDir, request.jobName, 'result.json'),
+      JSON.stringify({
+        stats: {
+          evals: {
+            maka__fake__adhoc: {
+              reward_stats: { reward: { '0': [`${taskName}__fjabYqp`] } },
+            },
+          },
+        },
+      }),
+      'utf8',
+    );
+    return { exitCode: opts.exitCode ?? 0, stdout: 'ok', stderr: '' };
+  };
+}
+
+function runInput(overrides: Partial<TaskRunInput> = {}): TaskRunInput {
+  return {
+    runId: 'run-1',
+    roundId: 'round-1',
+    task: { id: 'dasel', path: '/tasks/dasel-html-document-format' },
+    config: { id: 'cfg', backend: 'ai-sdk', llmConnectionSlug: 'fake', model: 'fake' },
+    systemPrompt: 'CANDIDATE PROMPT\n',
+    ...overrides,
+  };
+}
+
+async function withDirs<T>(
+  fn: (dirs: { jobsDir: string; repo: string }) => Promise<T>,
+): Promise<T> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-pier-runner-'));
+  try {
+    return await fn({ jobsDir: join(root, 'jobs'), repo: join(root, 'repo') });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function baseOptions(
+  overrides: Partial<PierTaskRunnerOptions> &
+    Pick<PierTaskRunnerOptions, 'jobsDir' | 'makaRepoPath'>,
+): PierTaskRunnerOptions {
+  return { model: 'fake', backend: 'fake', ...overrides };
+}
+
+test('buildPierRunArgs emits the pier CLI contract for the Maka arm', () => {
+  const args = buildPierRunArgs({
+    agent: 'maka',
+    model: 'k3',
+    taskPath: '/tasks/dasel',
+    jobsDir: '/jobs',
+    jobName: 'trial',
+    environment: 'docker',
+    timeoutMultiplier: 1,
+    mounts: [{ type: 'bind', source: '/repo', target: '/opt/maka-agent', read_only: true }],
+    agentEnv: { MAKA_MODEL: 'k3', MAKA_PROVIDER: 'kimi-coding-plan' },
+  });
+  const joined = args.join(' ');
+  assert.match(joined, /--agent-import-path maka_agent:MakaAgent/);
+  assert.match(joined, /-m k3/);
+  assert.match(joined, /-p \/tasks\/dasel/);
+  assert.match(joined, /-o \/jobs/);
+  assert.match(joined, /--job-name trial/);
+  assert.match(joined, /-k 1/);
+  assert.match(joined, /-n 1/);
+  assert.match(joined, /--yes/);
+  assert.ok(args.includes('--mounts-json'));
+  assert.ok(args.includes('--ae'));
+  assert.ok(args.includes('MAKA_MODEL=k3'));
+  // No provider secret and no env-file were requested.
+  assert.ok(!args.includes('--env-file'));
+});
+
+test('buildPierRunArgs targets the Kimi Code adapter and forwards an env-file', () => {
+  const args = buildPierRunArgs({
+    agent: 'kimi-code',
+    model: 'k3',
+    taskPath: '/tasks/dasel',
+    jobsDir: '/jobs',
+    jobName: 'trial',
+    environment: 'docker',
+    timeoutMultiplier: 1,
+    mounts: [],
+    agentEnv: {},
+    envFile: '/jobs/pier-agent.env',
+  });
+  assert.match(args.join(' '), /--agent-import-path kimi_code_agent:MakaKimiCodeAgent/);
+  const envFileFlag = args.indexOf('--env-file');
+  assert.equal(args[envFileFlag + 1], '/jobs/pier-agent.env');
+});
+
+test('createPierTaskRunner maps a completed fake trial to reward and host cell paths', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+    const output = await runner(runInput());
+    assert.equal(output.harbor.reward, 0);
+    assert.equal(output.harbor.verifier, undefined);
+    assert.equal(output.cell.status, 'completed');
+    // The container-local runtime path is overridden with the host trial path.
+    assert.match(output.cell.runtimeEventsPath, /agent\/runtime-events\.jsonl$/);
+    assert.ok(output.cell.runtimeEventsPath.startsWith(jobsDir));
+    // MAKA_BACKEND rides the process env (CliFlag env_fallback reads os.environ),
+    // never `--ae`.
+    assert.equal(captured.request?.env?.MAKA_BACKEND, 'fake');
+    assert.ok(!captured.request?.args.some((arg) => arg.startsWith('MAKA_BACKEND=')));
+    // The system prompt is forwarded verbatim through --ae for the identity round-trip.
+    assert.ok(
+      captured.request?.args.some((arg) => arg === 'MAKA_SYSTEM_PROMPT=CANDIDATE PROMPT\n'),
+    );
+  });
+});
+
+test('createPierTaskRunner falls back to the trial verifier_result reward', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({ reward: 1, rewardJson: false, verifierResultReward: 1 }),
+      }),
+    );
+    const output = await runner(runInput());
+    assert.equal(output.harbor.reward, 1);
+  });
+});
+
+test('createPierTaskRunner surfaces the combined trace path when present', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({ reward: 0, combinedTrace: true }),
+      }),
+    );
+    const output = await runner(runInput());
+    assert.match(output.cell.traceEventsPath ?? '', /agent\/trace-events\.jsonl$/);
+  });
+});
+
+test('createPierTaskRunner classifies a pier launch failure as infra', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: () => Promise.reject(new Error('pier: command not found')),
+      }),
+    );
+    await assert.rejects(runner(runInput()), (error: Error) => {
+      assert.ok(error instanceof PierInfraError);
+      assert.equal(error.kind, 'infra_failed');
+      return true;
+    });
+  });
+});
+
+test('createPierTaskRunner classifies a timed-out pier run', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({ jobsDir, makaRepoPath: repo, runPier: fakePier({ timedOut: true }) }),
+    );
+    await assert.rejects(runner(runInput()), (error: Error) => {
+      assert.ok(error instanceof PierInfraError);
+      assert.equal(error.kind, 'timed_out');
+      return true;
+    });
+  });
+});
+
+test('createPierTaskRunner reports a budget exhaustion as a benchmark outcome', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({
+          cell: null,
+          exceptionInfo: {
+            exception_type: 'AgentTimeoutError',
+            exception_message: 'Agent execution timed out after 600 seconds',
+          },
+        }),
+      }),
+    );
+    await assert.rejects(
+      runner(runInput()),
+      (error: Error) => error instanceof FixedPromptBudgetExhaustedError,
+    );
+  });
+});
+
+test('createPierTaskRunner treats a non-budget trial exception as infra', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({
+          cell: null,
+          exceptionInfo: { exception_type: 'RuntimeError', exception_message: 'boom' },
+        }),
+      }),
+    );
+    await assert.rejects(runner(runInput()), (error: Error) => {
+      assert.ok(error instanceof PierInfraError);
+      assert.match(error.message, /pier trial errored/);
+      return true;
+    });
+  });
+});
+
+test('createPierTaskRunner rejects provider secrets in agentEnv', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agentEnv: { KIMI_MODEL_API_KEY: 'sk-real' },
+        runPier: fakePier({ reward: 0 }),
+      }),
+    );
+    await assert.rejects(runner(runInput()), /must not contain provider secrets/);
+  });
+});
+
+test('createPierTaskRunner requires the Kimi toolchain mount for the Kimi arm', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'kimi-code',
+        provider: 'kimi-coding-plan',
+        resolveProviderCredential: () => Promise.resolve({ value: 'upstream-key' }),
+        runPier: fakePier({ reward: 0 }),
+      }),
+    );
+    await assert.rejects(runner(runInput()), /kimiCodeToolchainPath is required/);
+  });
+});
+
+test('createPierTaskRunner wires the Kimi arm through the host proxy on a Squid-legal port', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'kimi-code',
+        backend: 'ai-sdk',
+        provider: 'kimi-coding-plan',
+        model: 'k3',
+        baseUrl: 'https://api.kimi.com/coding/v1',
+        kimiCodeToolchainPath: repo,
+        resolveProviderCredential: () => Promise.resolve({ value: 'upstream-key' }),
+        // A fixed high port stands in for 80/443 without needing privileges.
+        providerProxyPort: 0,
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+    const output = await runner(runInput());
+    assert.equal(output.harbor.reward, 0);
+    // The proxy URL and a minted (non-real) token reach the container via env-file,
+    // never argv.
+    assert.match(
+      captured.envFile?.MAKA_PROVIDER_PROXY_URL ?? '',
+      /^http:\/\/host\.docker\.internal:\d+$/,
+    );
+    assert.ok((captured.envFile?.MAKA_PROVIDER_PROXY_TOKEN ?? '').length >= 32);
+    assert.notEqual(captured.envFile?.MAKA_PROVIDER_PROXY_TOKEN, 'upstream-key');
+    assert.ok(!captured.request?.args.some((arg) => arg.startsWith('MAKA_PROVIDER_PROXY_TOKEN=')));
+    // The Kimi toolchain is mounted read-only alongside the maka repo.
+    const mountsFlag = captured.request?.args.indexOf('--mounts-json') ?? -1;
+    const mounts = JSON.parse(captured.request!.args[mountsFlag + 1]!) as Array<{ target: string }>;
+    assert.ok(mounts.some((mount) => mount.target === '/opt/maka-kimi-code-toolchain'));
+  });
+});
+
+test('createPierTaskRunner keeps the real key host-side via a file path for the Maka arm', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const keyFile = join(repo, 'key');
+    await mkdir(repo, { recursive: true });
+    await writeFile(keyFile, 'sk-real\n', 'utf8');
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'maka',
+        backend: 'ai-sdk',
+        provider: 'kimi-coding-plan',
+        baseUrl: 'https://api.kimi.com/coding/v1',
+        apiKeyFile: keyFile,
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+    await runner(runInput());
+    // Only the key-file PATH rides --ae; the key itself never leaves the file.
+    assert.ok(captured.request?.args.includes(`MAKA_HOST_API_KEY_FILE=${keyFile}`));
+    assert.ok(!captured.request?.args.some((arg) => arg.includes('sk-real')));
+    assert.ok(captured.request?.args.includes('MAKA_HOST_BASE_URL=https://api.kimi.com/coding/v1'));
+  });
+});

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -424,7 +424,12 @@ test('createPierTaskRunner rejects experiment identity and pricing overrides in 
     ];
     for (const env of overrides) {
       const runner = createPierTaskRunner(
-        baseOptions({ jobsDir, makaRepoPath: repo, agentEnv: env, runPier: fakePier({ reward: 0 }) }),
+        baseOptions({
+          jobsDir,
+          makaRepoPath: repo,
+          agentEnv: env,
+          runPier: fakePier({ reward: 0 }),
+        }),
       );
       await assert.rejects(runner(runInput()), /must not override experiment identity/);
     }
@@ -481,6 +486,48 @@ test('createPierTaskRunner wires the Kimi arm through the host proxy on a Squid-
     const mountsFlag = captured.request?.args.indexOf('--mounts-json') ?? -1;
     const mounts = JSON.parse(captured.request!.args[mountsFlag + 1]!) as Array<{ target: string }>;
     assert.ok(mounts.some((mount) => mount.target === '/opt/maka-kimi-code-toolchain'));
+  });
+});
+
+test('createPierTaskRunner serializes concurrent Kimi attempts holding the fixed proxy port', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const inner = fakePier({ reward: 0 });
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'kimi-code',
+        backend: 'ai-sdk',
+        provider: 'kimi-coding-plan',
+        model: 'k3',
+        baseUrl: 'https://api.kimi.com/coding/v1',
+        kimiCodeToolchainPath: repo,
+        resolveProviderCredential: () => Promise.resolve({ value: 'upstream-key' }),
+        providerProxyPort: 0,
+        runPier: async (request) => {
+          inFlight += 1;
+          maxInFlight = Math.max(maxInFlight, inFlight);
+          await new Promise((resolve) => setTimeout(resolve, 25));
+          try {
+            return await inner(request);
+          } finally {
+            inFlight -= 1;
+          }
+        },
+      }),
+    );
+    // The default Kimi port is fixed (443): a second concurrent bind would be a
+    // guaranteed EADDRINUSE, so the runner must hold the port one attempt at a
+    // time while both attempts still complete.
+    const [first, second] = await Promise.all([
+      runner(runInput({ task: { id: 't1', path: '/tasks/dasel-html-document-format' } })),
+      runner(runInput({ task: { id: 't2', path: '/tasks/dasel-html-document-format' } })),
+    ]);
+    assert.equal(first.harbor.reward, 0);
+    assert.equal(second.harbor.reward, 0);
+    assert.equal(maxInFlight, 1);
   });
 });
 

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -227,10 +227,12 @@ test('createPierTaskRunner maps a completed fake trial to reward and host cell p
     // never `--ae`.
     assert.equal(captured.request?.env?.MAKA_BACKEND, 'fake');
     assert.ok(!captured.request?.args.some((arg) => arg.startsWith('MAKA_BACKEND=')));
-    // The system prompt is forwarded verbatim through --ae for the identity round-trip.
-    assert.ok(
-      captured.request?.args.some((arg) => arg === 'MAKA_SYSTEM_PROMPT=CANDIDATE PROMPT\n'),
-    );
+    // The system prompt rides the process env byte-exact (trailing newline
+    // preserved) and must NOT appear in --ae, whose values pier strips — a
+    // stripped extra_env copy would shadow os.environ and break the
+    // execution-identity hash round-trip.
+    assert.equal(captured.request?.env?.MAKA_SYSTEM_PROMPT, 'CANDIDATE PROMPT\n');
+    assert.ok(!captured.request?.args.some((arg) => arg.startsWith('MAKA_SYSTEM_PROMPT=')));
   });
 });
 

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -1012,6 +1012,33 @@ test('createPierTaskRunner wires the Kimi arm through the host proxy on a Squid-
   });
 });
 
+test('createPierTaskRunner overrides the Kimi proxy advertised host for native Linux Docker', async () => {
+  // host.docker.internal does not resolve on native Linux Docker (pier's compose
+  // wires no extra_hosts), so the Kimi arm must be able to advertise the host's
+  // docker-bridge address instead; the container reads it via MAKA_PROVIDER_PROXY_URL.
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'kimi-code',
+        backend: 'ai-sdk',
+        provider: 'kimi-coding-plan',
+        model: 'k3',
+        baseUrl: 'https://api.kimi.com/coding/v1',
+        kimiCodeToolchainPath: repo,
+        resolveProviderCredential: () => Promise.resolve({ value: 'upstream-key' }),
+        providerProxyPort: 0,
+        providerProxyAdvertisedHost: '172.17.0.1',
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+    await runner(runInput());
+    assert.match(captured.envFile?.MAKA_PROVIDER_PROXY_URL ?? '', /^http:\/\/172\.17\.0\.1:\d+$/);
+  });
+});
+
 /** One SEPARATE runner instance per port entry, one concurrent attempt each —
  * the lock's owner must be the shared host port, not a runner closure, or an
  * A/B with two Kimi arms in one process EADDRINUSEs. */

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { mkdir } from 'node:fs/promises';
+import { createServer, type AddressInfo } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -656,8 +657,8 @@ test('createPierTaskRunner wires the Kimi arm through the host proxy on a Squid-
   });
 });
 
-test('createPierTaskRunner serializes concurrent Kimi attempts holding the fixed proxy port', async () => {
-  await withDirs(async ({ jobsDir, repo }) => {
+async function runConcurrentKimiAttempts(providerProxyPort: number): Promise<number> {
+  return await withDirs(async ({ jobsDir, repo }) => {
     let inFlight = 0;
     let maxInFlight = 0;
     const inner = fakePier({ reward: 0 });
@@ -672,7 +673,7 @@ test('createPierTaskRunner serializes concurrent Kimi attempts holding the fixed
         baseUrl: 'https://api.kimi.com/coding/v1',
         kimiCodeToolchainPath: repo,
         resolveProviderCredential: () => Promise.resolve({ value: 'upstream-key' }),
-        providerProxyPort: 0,
+        providerProxyPort,
         runPier: async (request) => {
           inFlight += 1;
           maxInFlight = Math.max(maxInFlight, inFlight);
@@ -685,17 +686,34 @@ test('createPierTaskRunner serializes concurrent Kimi attempts holding the fixed
         },
       }),
     );
-    // The default Kimi port is fixed (443): a second concurrent bind would be a
-    // guaranteed EADDRINUSE, so the runner must hold the port one attempt at a
-    // time while both attempts still complete.
     const [first, second] = await Promise.all([
       runner(runInput({ task: { id: 't1', path: '/tasks/dasel-html-document-format' } })),
       runner(runInput({ task: { id: 't2', path: '/tasks/dasel-html-document-format' } })),
     ]);
     assert.equal(first.harbor.reward, 0);
     assert.equal(second.harbor.reward, 0);
-    assert.equal(maxInFlight, 1);
+    return maxInFlight;
   });
+}
+
+test('createPierTaskRunner serializes concurrent Kimi attempts holding a fixed proxy port', async () => {
+  // A fixed port (like the default 443) admits exactly one bind: a second
+  // concurrent attempt would be a guaranteed EADDRINUSE, so the runner must
+  // hold the port one attempt at a time while both attempts still complete.
+  // Grab a currently-free port from the OS so the test binds a real listener
+  // without needing privileges for 443.
+  const probe = createServer();
+  const fixedPort = await new Promise<number>((resolve) => {
+    probe.listen(0, () => resolve((probe.address() as AddressInfo).port));
+  });
+  await new Promise((resolve) => probe.close(resolve));
+  assert.equal(await runConcurrentKimiAttempts(fixedPort), 1);
+});
+
+test('createPierTaskRunner lets ephemeral-port Kimi attempts run concurrently', async () => {
+  // Port 0 asks the OS for a fresh port per bind — no collision is possible,
+  // so the serialization lock must not throttle throughput.
+  assert.equal(await runConcurrentKimiAttempts(0), 2);
 });
 
 test('createPierTaskRunner keeps the real key host-side via a file path for the Maka arm', async () => {

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -691,6 +691,24 @@ test('createPierTaskRunner classifies the reward.json crash sentinel as infra', 
   });
 });
 
+test('createPierTaskRunner rejects non-binary rewards as infra', async () => {
+  // grader.py: the main reward is binary 0/1 (113/113 DeepSWE tasks); 0.5 or 2
+  // can only come from corrupt or non-contract verifier output, and 0.5 would
+  // otherwise score as a PASS through `reward > 0`.
+  for (const reward of [0.5, 2]) {
+    await withDirs(async ({ jobsDir, repo }) => {
+      const runner = createPierTaskRunner(
+        baseOptions({ jobsDir, makaRepoPath: repo, runPier: fakePier({ reward }) }),
+      );
+      await assert.rejects(runner(runInput()), (error: Error) => {
+        assert.ok(error instanceof PierInfraError);
+        assert.match(error.message, /binary 0\/1 contract/);
+        return true;
+      });
+    });
+  }
+});
+
 test('createPierTaskRunner classifies the verifier_result crash sentinel as infra', async () => {
   // The sentinel arrives via reward.txt -> pier's verifier parse ->
   // verifier_result.rewards.reward; there is no reward.json in that path.

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -118,6 +118,9 @@ function cellOutput(overrides: Partial<HarborCellOutput> = {}): HarborCellOutput
 interface FakeOptions {
   reward?: number;
   rewardJson?: boolean;
+  /** Write reward.json verbatim (e.g. '{}' or malformed JSON), overriding the
+   * structured numeric-reward body. */
+  rewardJsonRaw?: string;
   verifierResultReward?: number;
   cell?: HarborCellOutput | null;
   executionIdentity?: Record<string, unknown>;
@@ -186,7 +189,9 @@ function fakePier(opts: FakeOptions): PierProcessRunner {
       await mkdir(sessionDir, { recursive: true });
       await writeFile(join(sessionDir, 'events.jsonl'), '{"type":"tool_failed"}\n', 'utf8');
     }
-    if (opts.reward !== undefined && opts.rewardJson !== false) {
+    if (opts.rewardJsonRaw !== undefined) {
+      await writeFile(join(trialDir, 'verifier', 'reward.json'), opts.rewardJsonRaw, 'utf8');
+    } else if (opts.reward !== undefined && opts.rewardJson !== false) {
       await writeFile(
         join(trialDir, 'verifier', 'reward.json'),
         JSON.stringify({ reward: opts.reward, f2p: 0, p2p: 1 }),
@@ -806,6 +811,117 @@ test('createPierTaskRunner classifies the verifier_result crash sentinel as infr
       assert.match(error.message, /crash sentinel/);
       return true;
     });
+  });
+});
+
+test('createPierTaskRunner scores a graded trial when both reward mirrors agree', async () => {
+  // The reward.json authority and its trial-result mirror
+  // (verifier_result.rewards.reward) carry the same value on a completed trial;
+  // an agreeing pair must score normally, not trip the mirror-consistency guard.
+  for (const reward of [0, 1]) {
+    await withDirs(async ({ jobsDir, repo }) => {
+      const runner = createPierTaskRunner(
+        baseOptions({
+          jobsDir,
+          makaRepoPath: repo,
+          runPier: fakePier({ reward, verifierResultReward: reward }),
+        }),
+      );
+      const output = await runner(runInput());
+      assert.equal(output.harbor.reward, reward);
+    });
+  }
+});
+
+test('createPierTaskRunner treats disagreeing reward mirrors as infra', async () => {
+  // The two persisted mirrors of the grading authority must be identical; a
+  // reward.json that disagrees with verifier_result.rewards.reward — in either
+  // direction — is infra, never a silently-preferred score.
+  for (const [rewardJsonValue, resultValue] of [
+    [1, 0],
+    [0, 1],
+  ] as const) {
+    await withDirs(async ({ jobsDir, repo }) => {
+      const runner = createPierTaskRunner(
+        baseOptions({
+          jobsDir,
+          makaRepoPath: repo,
+          runPier: fakePier({ reward: rewardJsonValue, verifierResultReward: resultValue }),
+        }),
+      );
+      await assert.rejects(runner(runInput()), (error: Error) => {
+        assert.ok(error instanceof PierInfraError);
+        assert.match(error.message, /mirrors disagree/);
+        return true;
+      });
+    });
+  }
+});
+
+test('createPierTaskRunner treats a reward.json without a reward field as infra', async () => {
+  // A reward.json that exists as valid JSON but carries no numeric reward field
+  // is corrupt grading authority — infra, not a fall-through to the result
+  // mirror or an ungraded miss.
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({ jobsDir, makaRepoPath: repo, runPier: fakePier({ rewardJsonRaw: '{}' }) }),
+    );
+    await assert.rejects(runner(runInput()), (error: Error) => {
+      assert.ok(error instanceof PierInfraError);
+      assert.match(error.message, /no valid numeric reward field/);
+      return true;
+    });
+  });
+});
+
+test('createPierTaskRunner reports a budget exhaustion despite a crash-sentinel reward', async () => {
+  // Budget-gate context: the agent already exhausted its budget, so a verifier
+  // that crashed (result-mirror sentinel -1) does NOT overturn that fact. The
+  // trial is budget_exhausted (no retry), not infra — a graded read would call
+  // the sentinel infra, but here the spent agent budget takes precedence.
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({
+          verifierResultReward: -1,
+          exceptionInfo: {
+            exception_type: 'AgentTimeoutError',
+            exception_message: 'Agent execution timed out after 600 seconds',
+          },
+        }),
+      }),
+    );
+    await assert.rejects(
+      runner(runInput()),
+      (error: Error) => error instanceof FixedPromptBudgetExhaustedError,
+    );
+  });
+});
+
+test('createPierTaskRunner reports a budget exhaustion despite a corrupt reward.json', async () => {
+  // Same budget-gate precedence for a reward.json that is not valid JSON: a
+  // corrupt verifier artifact after the agent already spent its budget stays a
+  // budget_exhausted outcome, not an infra failure the controller would retry.
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({
+          rewardJsonRaw: 'not-json{',
+          exceptionInfo: {
+            exception_type: 'AgentTimeoutError',
+            exception_message: 'Agent execution timed out after 600 seconds',
+          },
+        }),
+      }),
+    );
+    await assert.rejects(
+      runner(runInput()),
+      (error: Error) => error instanceof FixedPromptBudgetExhaustedError,
+    );
   });
 });
 

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -12,6 +12,7 @@ import {
   runFixedPromptController,
   type TaskRunInput,
 } from '../fixed-prompt-controller.js';
+import { findTrialDir } from '../harbor-task-runner.js';
 import {
   buildPierRunArgs,
   createPierTaskRunner,
@@ -55,6 +56,35 @@ test('defaultPierProcessRunner escalates to SIGKILL after the grace', async () =
   );
   assert.equal(result.timedOut, true);
   assert.equal(result.signal, 'SIGKILL');
+});
+
+test('shared findTrialDir honors the exception_stats trial-name hint with pier diagnostics', async () => {
+  // The pier runner reuses harbor's trial-dir discovery, which must keep the
+  // exception_stats branch: an errored trial appears only there, and the
+  // directory-name fallback cannot disambiguate a stale sibling dir.
+  const jobDir = await mkdtemp(join(tmpdir(), 'pier-findtrial-'));
+  try {
+    await mkdir(join(jobDir, 'stale-dir'));
+    await mkdir(join(jobDir, 'errored-trial'));
+    await writeFile(
+      join(jobDir, 'result.json'),
+      JSON.stringify({
+        stats: {
+          evals: { e1: { exception_stats: { NonZeroAgentExitCodeError: ['errored-trial'] } } },
+        },
+      }),
+      'utf8',
+    );
+    const found = await findTrialDir(jobDir, 'unmatched-task', 'pier', PierInfraError);
+    assert.equal(found, join(jobDir, 'errored-trial'));
+    await assert.rejects(
+      findTrialDir(join(jobDir, 'missing'), 'unmatched-task', 'pier', PierInfraError),
+      (error: unknown) =>
+        error instanceof PierInfraError && /pier produced no job output/.test(error.message),
+    );
+  } finally {
+    await rm(jobDir, { recursive: true, force: true });
+  }
 });
 
 function cellOutput(overrides: Partial<HarborCellOutput> = {}): HarborCellOutput {

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -11,6 +11,7 @@ import {
   hashSystemPrompt,
   runFixedPromptController,
   type TaskRunInput,
+  type TaskRunOutput,
 } from '../fixed-prompt-controller.js';
 import { findTrialDir } from '../harbor-task-runner.js';
 import {
@@ -559,6 +560,90 @@ test('pier-graded failed cells stay scored through the fixed-prompt controller',
       assert.equal(event.scored, true);
       assert.equal(event.eligible, true);
       assert.equal(event.errorClass, 'max_tokens');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+test('pier and harbor outputs drive identical controller events for an infra-failed graded cell', async () => {
+  // Cross-runner parity lock for the scoring semantics INHERITED from the
+  // fixed-prompt controller (predating this PR): a CLI-crash cell
+  // (errorClass=infra_failed) with pier grade reward=0 is excluded via
+  // isProviderInfraFailure (scored=false), while reward=1 scores through
+  // structuredVerifierPassed. Whether that asymmetry is desirable is a
+  // controller question out of this PR's scope; the runner invariant is that
+  // Pier and Harbor produce controller-identical events for the same trial
+  // shape, so neither side can drift unilaterally.
+  await withDirs(async ({ jobsDir, repo }) => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-pier-parity-'));
+    try {
+      const systemPrompt = 'CANDIDATE PROMPT\n';
+      const systemPromptPath = join(dir, 'prompt.txt');
+      await writeFile(systemPromptPath, systemPrompt, 'utf8');
+      const promptHash = hashSystemPrompt(systemPrompt);
+      for (const reward of [0, 1]) {
+        const cell = cellOutput({
+          status: 'failed',
+          errorClass: 'infra_failed',
+          promptHash,
+          executionIdentity: {
+            llmConnectionSlug: 'fake',
+            model: 'fake',
+            systemPromptMode: 'default',
+            systemPromptHash: promptHash,
+            pricingProfile: 'fake-structural',
+          },
+        });
+        const pierRunner = createPierTaskRunner(
+          baseOptions({ jobsDir, makaRepoPath: repo, runPier: fakePier({ reward, cell }) }),
+        );
+        const pierOutput = await pierRunner(
+          runInput({
+            config: { id: 'cfg', backend: 'fake', llmConnectionSlug: 'fake', model: 'fake' },
+          }),
+        );
+        // The canonical Harbor-shaped output for the same trial: same graded
+        // reward, same structured verifier outcome, same cell artifacts.
+        const harborOutput: TaskRunOutput = {
+          harbor: {
+            reward,
+            verifier: {
+              outcome: reward > 0 ? 'passed' : 'failed',
+              attempts: [
+                {
+                  attempt: 1,
+                  classification: reward > 0 ? 'passed' : 'failed',
+                  durationMs: 0,
+                  reward,
+                },
+              ],
+            },
+          },
+          cell: pierOutput.cell,
+        };
+        const normalizedEvents: Array<Record<string, unknown>> = [];
+        for (const [flavor, output] of [
+          ['pier', pierOutput],
+          ['harbor', harborOutput],
+        ] as const) {
+          const result = await runFixedPromptController({
+            runId: 'run-1',
+            roundId: 'round-1',
+            config: { id: 'cfg', backend: 'fake', llmConnectionSlug: 'fake', model: 'fake' },
+            systemPromptPath,
+            resultsJsonlPath: join(dir, `results-${flavor}-${reward}.jsonl`),
+            tasks: [{ id: 'dasel', path: '/tasks/dasel-html-document-format' }],
+            taskRunner: () => Promise.resolve(output),
+          });
+          const event = { ...(result.events[0] as unknown as Record<string, unknown>) };
+          for (const volatile of ['id', 'ts', 'startedAt', 'finishedAt', 'durationMs']) {
+            delete event[volatile];
+          }
+          normalizedEvents.push(event);
+        }
+        assert.deepEqual(normalizedEvents[0], normalizedEvents[1]);
+      }
     } finally {
       await rm(dir, { recursive: true, force: true });
     }

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -5,7 +5,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import type { HarborCellOutput } from '../cell-output.js';
-import { FixedPromptBudgetExhaustedError, type TaskRunInput } from '../fixed-prompt-controller.js';
+import {
+  FixedPromptBudgetExhaustedError,
+  hashSystemPrompt,
+  runFixedPromptController,
+  type TaskRunInput,
+} from '../fixed-prompt-controller.js';
 import {
   buildPierRunArgs,
   createPierTaskRunner,
@@ -226,7 +231,12 @@ test('createPierTaskRunner maps a completed fake trial to reward and host cell p
     );
     const output = await runner(runInput());
     assert.equal(output.harbor.reward, 0);
-    assert.equal(output.harbor.verifier, undefined);
+    // Pier's grading is surfaced as the structured verifier outcome the
+    // controller requires for failed-cell scoring.
+    assert.deepEqual(output.harbor.verifier, {
+      outcome: 'failed',
+      attempts: [{ attempt: 1, classification: 'failed', durationMs: 0, reward: 0 }],
+    });
     assert.equal(output.cell.status, 'completed');
     // The container-local runtime path is overridden with the host trial path.
     assert.match(output.cell.runtimeEventsPath, /agent\/runtime-events\.jsonl$/);
@@ -389,6 +399,52 @@ test('createPierTaskRunner reports a budget exhaustion as a benchmark outcome', 
       runner(runInput()),
       (error: Error) => error instanceof FixedPromptBudgetExhaustedError,
     );
+  });
+});
+
+test('pier-graded failed cells stay scored through the fixed-prompt controller', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-pier-controller-'));
+    try {
+      const systemPrompt = 'CANDIDATE PROMPT\n';
+      const systemPromptPath = join(dir, 'prompt.txt');
+      await writeFile(systemPromptPath, systemPrompt, 'utf8');
+      const promptHash = hashSystemPrompt(systemPrompt);
+      const cell = cellOutput({
+        status: 'failed',
+        errorClass: 'max_tokens',
+        promptHash,
+        executionIdentity: {
+          llmConnectionSlug: 'fake',
+          model: 'fake',
+          systemPromptMode: 'default',
+          systemPromptHash: promptHash,
+          pricingProfile: 'fake-structural',
+        },
+      });
+      const runner = createPierTaskRunner(
+        baseOptions({ jobsDir, makaRepoPath: repo, runPier: fakePier({ reward: 0, cell }) }),
+      );
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config: { id: 'cfg', backend: 'fake', llmConnectionSlug: 'fake', model: 'fake' },
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [{ id: 'dasel', path: '/tasks/dasel-html-document-format' }],
+        taskRunner: runner,
+      });
+      // Without the structured verifier outcome this event is scored=false and
+      // silently leaves the benchmark denominator.
+      const event = result.events[0]!;
+      assert.equal(event.type, 'task_completed');
+      assert.equal(event.passed, false);
+      assert.equal(event.scored, true);
+      assert.equal(event.eligible, true);
+      assert.equal(event.errorClass, 'max_tokens');
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/headless/src/__tests__/prompt-optimization-run.test.ts
+++ b/packages/headless/src/__tests__/prompt-optimization-run.test.ts
@@ -225,6 +225,7 @@ describe('discoverCachedHarborTasks', () => {
         estimatedDurationSec: 540,
         agentTimeoutSec: 900,
         verifierTimeoutSec: 1200,
+        buildTimeoutSec: 1800,
       });
       // A hash dir whose inner dir lacks task.toml is ignored.
       await mkdir(join(dir, 'hashC', 'not-a-task'), { recursive: true });
@@ -242,6 +243,7 @@ describe('discoverCachedHarborTasks', () => {
         estimatedDurationSec: 540,
         agentTimeoutSec: 900,
         verifierTimeoutSec: 1200,
+        buildTimeoutSec: 1800,
       });
     });
   });
@@ -801,6 +803,7 @@ async function makeCachedTask(
     estimatedDurationSec?: number;
     agentTimeoutSec?: number;
     verifierTimeoutSec?: number;
+    buildTimeoutSec?: number;
   } = {},
 ): Promise<void> {
   const taskPath = join(root, hash, name);
@@ -830,6 +833,11 @@ async function makeCachedTask(
       '[agent]',
       ...(metadata.agentTimeoutSec !== undefined
         ? [`timeout_sec = ${metadata.agentTimeoutSec}`]
+        : []),
+      '',
+      '[environment]',
+      ...(metadata.buildTimeoutSec !== undefined
+        ? [`build_timeout_sec = ${metadata.buildTimeoutSec}`]
         : []),
       '',
     ].join('\n'),

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -4,7 +4,11 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
-import { startProviderAuthProxy, summarizeProviderTelemetry } from '../provider-auth-proxy.js';
+import {
+  listenProviderAuthProxyServer,
+  startProviderAuthProxy,
+  summarizeProviderTelemetry,
+} from '../provider-auth-proxy.js';
 
 test('provider auth proxy keeps the provider key host-side', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-'));
@@ -654,5 +658,19 @@ test('provider auth proxy reports a clear error when a fixed port is unavailable
   } finally {
     await new Promise<void>((resolve) => occupied.close(() => resolve()));
     await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('proxy listen removes its bind-error listener so later socket errors stay loud', async () => {
+  const server = createServer();
+  await listenProviderAuthProxyServer(server, 0);
+  try {
+    // once()/off() must reference the same named handler. With the anonymous
+    // wrapper regression, a listener remains registered after listen and a
+    // post-listen server error would reject the already-settled bind promise —
+    // silently swallowed instead of crashing loudly like on main.
+    assert.equal(server.listenerCount('error'), 0);
+  } finally {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
   }
 });

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -599,3 +599,60 @@ test('provider auth proxy aborts the upstream stream when its client disconnects
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('provider auth proxy binds a caller-specified port', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-'));
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, 'k\n', 'utf8');
+  // Grab a free port from the OS, then demand the proxy bind exactly it. An
+  // unprivileged high port avoids the CAP_NET_BIND_SERVICE requirement that 80/443
+  // (the only Squid-legal ports) would impose on Linux, while still exercising the
+  // fixed-port path the Kimi arm relies on.
+  const probe = createServer();
+  await new Promise<void>((resolve) => probe.listen(0, '127.0.0.1', resolve));
+  const probeAddress = probe.address();
+  assert.ok(probeAddress && typeof probeAddress !== 'string');
+  const port = probeAddress.port;
+  await new Promise<void>((resolve) => probe.close(() => resolve()));
+
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: 'http://127.0.0.1:1/api',
+    apiKeyFile: keyFile,
+    advertisedHost: 'host.docker.internal',
+    port,
+  });
+  try {
+    assert.equal(proxy.baseUrl, `http://host.docker.internal:${port}`);
+  } finally {
+    await proxy.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('provider auth proxy reports a clear error when a fixed port is unavailable', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-'));
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, 'k\n', 'utf8');
+  const occupied = createServer();
+  // Occupy the wildcard address the proxy also binds, so the collision is a real
+  // EADDRINUSE on every platform (a loopback-only bind does not conflict with
+  // 0.0.0.0 on macOS).
+  await new Promise<void>((resolve) => occupied.listen(0, '0.0.0.0', resolve));
+  const occupiedAddress = occupied.address();
+  assert.ok(occupiedAddress && typeof occupiedAddress !== 'string');
+  try {
+    await assert.rejects(
+      startProviderAuthProxy({
+        upstreamBaseUrl: 'http://127.0.0.1:1/api',
+        apiKeyFile: keyFile,
+        port: occupiedAddress.port,
+      }),
+      (error: Error) =>
+        error.message.includes(`failed to bind port ${occupiedAddress.port}`) &&
+        /Squid egress|already in use/.test(error.message),
+    );
+  } finally {
+    await new Promise<void>((resolve) => occupied.close(() => resolve()));
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -36,6 +36,9 @@ export interface FixedPromptTask {
     juniorTimeEstimateMin?: number;
     agentTimeoutSec?: number;
     verifierTimeoutSec?: number;
+    /** Task-native environment build budget (task.toml [environment]
+     * build_timeout_sec); feeds runner wall-clock watchdog derivation. */
+    buildTimeoutSec?: number;
   };
 }
 

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -61,12 +61,11 @@ export interface HarborVerifierOutcome {
 
 /**
  * The provider-neutral seam the fixed-prompt controller and A/B schedulers
- * consume: run one task attempt and return its reward plus cell artifacts. The
- * Harbor implementation (`createHarborTaskRunner`) is the first and, today, only
- * implementation; a Pier implementation lands later under its own issue and
- * satisfies the same interface. The output still carries a Harbor-shaped
- * `harbor` field; generalizing that payload is deferred until a second
- * implementation actually needs it.
+ * consume: run one task attempt and return its reward plus cell artifacts. Two
+ * implementations exist: `createHarborTaskRunner` (Harbor) and
+ * `createPierTaskRunner` (Pier, for DeepSWE). The output still carries a
+ * Harbor-shaped `harbor` field; both harnesses map into it, and generalizing
+ * that payload is deferred until an implementation cannot.
  */
 export interface TaskRunOutput {
   harbor: {

--- a/packages/headless/src/fixed-prompt-task-source.ts
+++ b/packages/headless/src/fixed-prompt-task-source.ts
@@ -189,6 +189,7 @@ function parseTaskTomlMetadata(text: string): FixedPromptTask['metadata'] {
     ),
     ...numberField('agentTimeoutSec', sectionField(text, 'agent', 'timeout_sec')),
     ...numberField('verifierTimeoutSec', sectionField(text, 'verifier', 'timeout_sec')),
+    ...numberField('buildTimeoutSec', sectionField(text, 'environment', 'build_timeout_sec')),
   };
 }
 

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -825,7 +825,8 @@ function structuredOutputValuesMismatch(normalizedText: string): boolean {
   return normalizedText.includes('only found') && normalizedText.includes('expected values');
 }
 
-function mergeAgentEnv(
+/** Shared across runners: overlay attempt-level env onto runner-level env. */
+export function mergeAgentEnv(
   base: Record<string, string> | undefined,
   attempt: Record<string, string> | undefined,
 ): Record<string, string> | undefined {
@@ -1140,7 +1141,8 @@ function usesHostProviderProxy(agent: HarborTaskRunnerOptions['agent']): boolean
   return agent === 'opencode' || agent === 'kimi-code' || agent === 'codex';
 }
 
-function providerTokenSummary(
+/** Shared cost math across runners: build the cell token summary from proxy-observed usage and per-1M pricing. */
+export function providerTokenSummary(
   usage: ProviderTokenUsage,
   pricing: HarborTaskPricing,
 ): NonNullable<HarborCellOutput['tokenSummary']> {
@@ -1166,7 +1168,8 @@ function providerTokenSummary(
   };
 }
 
-function providerProxyAuthMode(provider: string): 'bearer' | 'x-api-key' {
+/** Shared across runners: provider registry drives the proxy's client-facing auth header. */
+export function providerProxyAuthMode(provider: string): 'bearer' | 'x-api-key' {
   const definition = (
     PROVIDER_DEFAULTS as Partial<Record<string, (typeof PROVIDER_DEFAULTS)[ProviderType]>>
   )[provider];
@@ -1176,7 +1179,8 @@ function providerProxyAuthMode(provider: string): 'bearer' | 'x-api-key' {
     : 'bearer';
 }
 
-function providerProxyUsageProtocol(
+/** Shared across runners: adapter/provider registry drives the proxy's SSE usage parser. */
+export function providerProxyUsageProtocol(
   agent: HarborTaskRunnerOptions['agent'],
   provider: string,
 ): ProviderUsageProtocol | undefined {
@@ -1242,7 +1246,8 @@ function taskAgentEnvWithoutProviderSecrets(
   return result;
 }
 
-function assertNoProviderSecretsInAgentEnv(
+/** Shared benchmark invariant: agentEnv must never carry provider secrets. */
+export function assertNoProviderSecretsInAgentEnv(
   agentEnv: Record<string, string> | undefined,
   allowedHostCredentialEnvNames: ReadonlySet<string> = new Set(),
 ): void {
@@ -1398,7 +1403,8 @@ async function readTrialException(resultPath: string): Promise<string | null> {
   return message ? `${type}: ${message}` : type;
 }
 
-function isBudgetExhaustedTrialException(message: string): boolean {
+/** Shared across runners: the trial exceptions that mean the agent budget ran out (host cell deadline or harness AgentTimeoutError). */
+export function isBudgetExhaustedTrialException(message: string): boolean {
   return (
     /^RuntimeError: Maka host cell exceeded \d+(?:\.\d+)?s$/.test(message) ||
     /^AgentTimeoutError: Agent execution timed out after \d+(?:\.\d+)? seconds$/.test(message)
@@ -1466,7 +1472,10 @@ function isExecFileTimeout(error: unknown): boolean {
   return record.killed === true && record.signal === 'SIGKILL';
 }
 
-function isBudgetExhaustedError(error: unknown): error is FixedPromptBudgetExhaustedErrorType {
+/** Shared across runners: identify FixedPromptBudgetExhaustedError across module instances. */
+export function isBudgetExhaustedError(
+  error: unknown,
+): error is FixedPromptBudgetExhaustedErrorType {
   return (
     error instanceof FixedPromptBudgetExhaustedError ||
     (typeof error === 'object' &&

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -591,7 +591,9 @@ function hostTraceEventsPath(
   return existsSync(cellTracePath) ? cellTracePath : hostEventsPath;
 }
 
-function harborTraceMode(agentEnv: Record<string, string> | undefined): 'cell' | 'task-run' {
+/** Exported alongside readTimedOutTrialArtifacts: the Pier runner resolves the
+ * same MAKA_HARBOR_MODE contract when recovering timed-out trial artifacts. */
+export function harborTraceMode(agentEnv: Record<string, string> | undefined): 'cell' | 'task-run' {
   return agentEnv?.MAKA_HARBOR_MODE === 'task-run' ? 'task-run' : 'cell';
 }
 
@@ -611,7 +613,13 @@ function cellArtifactRefs(
   };
 }
 
-async function readTimedOutTrialArtifacts(
+/** Recover whatever attested evidence a timed-out/budget-exhausted trial left
+ * behind (cell output, execution identity, usage checkpoint) so the sample keeps
+ * its Pass@1 eligibility instead of being excluded as missing_execution_identity.
+ * Cross-runner benchmark invariant: the Pier runner reuses this exact
+ * implementation — both runners' trials are written by the same adapters into
+ * the same agent/ layout, so the recovery contract must not fork. */
+export async function readTimedOutTrialArtifacts(
   trialDir: string,
   taskId: string,
   agent: HarborTaskRunnerOptions['agent'],

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -1229,7 +1229,12 @@ function assertNoProviderSecretsInAgentEnv(
   }
 }
 
-function assertNoExperimentIdentityOverrides(agentEnv: Record<string, string> | undefined): void {
+/** Shared benchmark invariant: attempt-level agentEnv must never override the
+ * experiment's identity or pricing. Exported so the Pier runner enforces the
+ * exact same key set instead of drifting on a copied list. */
+export function assertNoExperimentIdentityOverrides(
+  agentEnv: Record<string, string> | undefined,
+): void {
   const forbidden = Object.keys(agentEnv ?? {}).filter((key) =>
     EXPERIMENT_IDENTITY_ENV_KEYS.has(key),
   );

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -556,25 +556,23 @@ function resolveNativeHarborTimeoutMs(
   task: TaskRunInput['task'],
 ): number {
   return resolveNativeTrialTimeoutMs({
-    agentTimeoutSec: task.metadata?.agentTimeoutSec ?? 0,
-    verifierTimeoutSec: verifierPolicy(task).outerTimeoutSec,
+    nativePhasesSec: (task.metadata?.agentTimeoutSec ?? 0) + verifierPolicy(task).outerTimeoutSec,
     timeoutMultiplier: options.timeoutMultiplier ?? 1,
   });
 }
 
-/** Shared wall-clock watchdog contract for one trial: the task-native phase
- * budget (agent + verifier seconds) times the multiplier, plus container
- * build/teardown grace, floored at 45 minutes so short tasks keep a sane
- * ceiling. Cross-runner benchmark invariant — the Pier runner reuses this
- * derivation with the task's native verifier seconds, while Harbor supplies
- * the oracle verifier policy's outer budget. */
+/** Shared wall-clock watchdog contract for one trial: the harness's maximum
+ * legitimate lifecycle in native seconds, times the multiplier, plus
+ * setup/teardown grace, floored at 45 minutes so short tasks keep a sane
+ * ceiling. Cross-runner benchmark invariant: each runner owns its own
+ * lifecycle shape (which phases run, and how often its harness retries them)
+ * and supplies the summed seconds — Harbor passes agent + the oracle verifier
+ * policy's outer budget; Pier passes its full phase-and-retry model. */
 export function resolveNativeTrialTimeoutMs(input: {
-  agentTimeoutSec: number;
-  verifierTimeoutSec: number;
+  nativePhasesSec: number;
   timeoutMultiplier: number;
 }): number {
-  const nativePhasesMs =
-    (input.agentTimeoutSec + input.verifierTimeoutSec) * input.timeoutMultiplier * 1_000;
+  const nativePhasesMs = input.nativePhasesSec * input.timeoutMultiplier * 1_000;
   return Math.max(DEFAULT_HARBOR_TIMEOUT_MS, nativePhasesMs + HARBOR_SETUP_TEARDOWN_GRACE_MS);
 }
 

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -603,7 +603,13 @@ async function readOptionalCellOutput(
   }
 }
 
-function hostTraceEventsPath(
+/** Shared across runners: resolve the richest host-side trace for a trial.
+ * Task-run mode prefers the combined agent/trace-events.jsonl, then the
+ * task-run session layout; cell mode resolves the maka-storage session events
+ * via cell.runtimeRefs — the raw runtime-events fallback is a last resort, and
+ * skipping the session branch silently drops tool_failed /
+ * provider_request_captured failure attribution downstream. */
+export function hostTraceEventsPath(
   agent: HarborTaskRunnerOptions['agent'],
   mode: 'cell' | 'task-run',
   trialDir: string,

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -1273,7 +1273,9 @@ export function assertNoExperimentIdentityOverrides(
   }
 }
 
-function providerRequiresSecret(provider: string | undefined): boolean {
+/** Shared across runners: registry-driven check whether a provider needs a
+ * real credential (keyless providers like ollama/lm-studio run MAKA_HOST_NO_AUTH). */
+export function providerRequiresSecret(provider: string | undefined): boolean {
   const providerType = (provider ?? 'deepseek') as ProviderType;
   const definition = PROVIDER_DEFAULTS[providerType];
   if (!definition) throw new Error(`unsupported MAKA_PROVIDER: ${provider ?? ''}`);

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -555,9 +555,26 @@ function resolveNativeHarborTimeoutMs(
   options: Pick<HarborTaskRunnerOptions, 'timeoutMultiplier'>,
   task: TaskRunInput['task'],
 ): number {
-  const agentSec = task.metadata?.agentTimeoutSec ?? 0;
-  const verifierSec = verifierPolicy(task).outerTimeoutSec;
-  const nativePhasesMs = (agentSec + verifierSec) * (options.timeoutMultiplier ?? 1) * 1_000;
+  return resolveNativeTrialTimeoutMs({
+    agentTimeoutSec: task.metadata?.agentTimeoutSec ?? 0,
+    verifierTimeoutSec: verifierPolicy(task).outerTimeoutSec,
+    timeoutMultiplier: options.timeoutMultiplier ?? 1,
+  });
+}
+
+/** Shared wall-clock watchdog contract for one trial: the task-native phase
+ * budget (agent + verifier seconds) times the multiplier, plus container
+ * build/teardown grace, floored at 45 minutes so short tasks keep a sane
+ * ceiling. Cross-runner benchmark invariant — the Pier runner reuses this
+ * derivation with the task's native verifier seconds, while Harbor supplies
+ * the oracle verifier policy's outer budget. */
+export function resolveNativeTrialTimeoutMs(input: {
+  agentTimeoutSec: number;
+  verifierTimeoutSec: number;
+  timeoutMultiplier: number;
+}): number {
+  const nativePhasesMs =
+    (input.agentTimeoutSec + input.verifierTimeoutSec) * input.timeoutMultiplier * 1_000;
   return Math.max(DEFAULT_HARBOR_TIMEOUT_MS, nativePhasesMs + HARBOR_SETUP_TEARDOWN_GRACE_MS);
 }
 

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -94,16 +94,24 @@ export class HarborInfraError extends Error {
   }
 }
 
+/** Structural shape shared by HarborInfraError and PierInfraError — PierInfraError
+ * is deliberately NOT a subclass (the controller classifies by behavior, never
+ * identity), so the shared helpers are typed against the structure, not the class. */
+export interface InfraErrorLike extends Error {
+  readonly detail?: string;
+  readonly kind: 'infra_failed' | 'timed_out';
+  readonly artifactRefs?: { providerTelemetryPath?: string };
+}
+
 /** Constructor shape shared by HarborInfraError and PierInfraError. The shared
  * trial-mapping helpers below take this so they throw the calling runner's own
- * error type — the controller classifies by behavior, never identity, but
- * diagnostics must keep naming the failing harness. */
+ * error type — diagnostics must keep naming the failing harness. */
 export type InfraErrorCtor = new (
   message: string,
   detail?: string,
   kind?: 'infra_failed' | 'timed_out',
   artifactRefs?: { providerTelemetryPath?: string },
-) => HarborInfraError;
+) => InfraErrorLike;
 
 export interface HarborTaskPricing {
   inputUsdPer1M: number;

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -94,6 +94,17 @@ export class HarborInfraError extends Error {
   }
 }
 
+/** Constructor shape shared by HarborInfraError and PierInfraError. The shared
+ * trial-mapping helpers below take this so they throw the calling runner's own
+ * error type — the controller classifies by behavior, never identity, but
+ * diagnostics must keep naming the failing harness. */
+export type InfraErrorCtor = new (
+  message: string,
+  detail?: string,
+  kind?: 'infra_failed' | 'timed_out',
+  artifactRefs?: { providerTelemetryPath?: string },
+) => HarborInfraError;
+
 export interface HarborTaskPricing {
   inputUsdPer1M: number;
   outputUsdPer1M: number;
@@ -409,27 +420,32 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
   return runner;
 }
 
-function providerTelemetryArtifactRefs(
+/** Shared across runners: attach the provider-request telemetry artifact to a
+ * thrown outcome so infra failures keep their billing/usage evidence. */
+export function providerTelemetryArtifactRefs(
   telemetry: readonly ProviderRequestTelemetry[],
   providerTelemetryPath: string,
 ): { providerTelemetryPath: string } | undefined {
   return telemetry.length > 0 ? { providerTelemetryPath } : undefined;
 }
 
-function withProviderTelemetryArtifact(
+/** Shared across runners: enriches only the calling runner's own infra error
+ * type, so a foreign error passes through untouched. */
+export function withProviderTelemetryArtifact(
   error: unknown,
   telemetry: readonly ProviderRequestTelemetry[],
   providerTelemetryPath: string,
+  infraError: InfraErrorCtor = HarborInfraError,
 ): unknown {
   const artifactRefs = providerTelemetryArtifactRefs(telemetry, providerTelemetryPath);
   if (
-    !(error instanceof HarborInfraError) ||
+    !(error instanceof infraError) ||
     !artifactRefs ||
     error.artifactRefs?.providerTelemetryPath
   ) {
     return error;
   }
-  const enriched = new HarborInfraError(error.message, error.detail, error.kind, artifactRefs);
+  const enriched = new infraError(error.message, error.detail, error.kind, artifactRefs);
   enriched.stack = error.stack;
   return enriched;
 }
@@ -1282,12 +1298,21 @@ export function providerRequiresSecret(provider: string | undefined): boolean {
   return providerAuthRequiresSecret(providerType);
 }
 
-async function findTrialDir(jobDir: string, taskName: string): Promise<string> {
+/** Shared across runners: Harbor and Pier lay out job output the same way
+ * (result.json reward_stats/exception_stats trial-name hint, then a
+ * task-name-prefixed directory fallback), so trial-dir discovery must not fork.
+ * `harness`/`infraError` keep the thrown diagnostics naming the calling runner. */
+export async function findTrialDir(
+  jobDir: string,
+  taskName: string,
+  harness = 'harbor',
+  infraError: InfraErrorCtor = HarborInfraError,
+): Promise<string> {
   let entries;
   try {
     entries = await readdir(jobDir, { withFileTypes: true });
   } catch (error) {
-    throw new HarborInfraError(`harbor produced no job output at ${jobDir}`, errorText(error));
+    throw new infraError(`${harness} produced no job output at ${jobDir}`, errorText(error));
   }
   const dirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
   const resultTrialName = await readResultTrialName(join(jobDir, 'result.json'));
@@ -1297,8 +1322,8 @@ async function findTrialDir(jobDir: string, taskName: string): Promise<string> {
   const match =
     dirs.find((name) => name === taskName || name.startsWith(`${taskName}__`)) ?? dirs[0];
   if (!match) {
-    throw new HarborInfraError(
-      `harbor produced no trial directory under ${jobDir} for task ${taskName}`,
+    throw new infraError(
+      `${harness} produced no trial directory under ${jobDir} for task ${taskName}`,
     );
   }
   return join(jobDir, match);
@@ -1378,7 +1403,12 @@ async function readReward(rewardPath: string, resultPath: string, taskId: string
   return reward;
 }
 
-async function readTrialException(resultPath: string): Promise<string | null> {
+/** Shared across runners: both harnesses record how the agent phase ended in
+ * the trial result's `exception_info`, in the same shape. */
+export async function readTrialException(
+  resultPath: string,
+  fallbackType = 'HarborTrialError',
+): Promise<string | null> {
   let raw: string;
   try {
     raw = await readFile(resultPath, 'utf8');
@@ -1395,9 +1425,7 @@ async function readTrialException(resultPath: string): Promise<string | null> {
   const exceptionInfo = isRecord(parsed.exception_info) ? parsed.exception_info : null;
   if (!exceptionInfo) return null;
   const type =
-    typeof exceptionInfo.exception_type === 'string'
-      ? exceptionInfo.exception_type
-      : 'HarborTrialError';
+    typeof exceptionInfo.exception_type === 'string' ? exceptionInfo.exception_type : fallbackType;
   const message =
     typeof exceptionInfo.exception_message === 'string' ? exceptionInfo.exception_message : '';
   return message ? `${type}: ${message}` : type;
@@ -1411,32 +1439,29 @@ export function isBudgetExhaustedTrialException(message: string): boolean {
   );
 }
 
-async function readCellOutput(cellOutputPath: string, taskId: string): Promise<HarborCellOutput> {
+/** Shared across runners: the same adapters write the same maka-cell-output.json
+ * contract into both harnesses' trial layouts. */
+export async function readCellOutput(
+  cellOutputPath: string,
+  taskId: string,
+  infraError: InfraErrorCtor = HarborInfraError,
+): Promise<HarborCellOutput> {
   let raw: string;
   try {
     raw = await readFile(cellOutputPath, 'utf8');
   } catch (error) {
-    throw new HarborInfraError(
-      `maka cell did not write output for task ${taskId}`,
-      errorText(error),
-    );
+    throw new infraError(`maka cell did not write output for task ${taskId}`, errorText(error));
   }
   let parsed: unknown;
   try {
     parsed = JSON.parse(raw);
   } catch (error) {
-    throw new HarborInfraError(
-      `maka cell output is not valid JSON for task ${taskId}`,
-      errorText(error),
-    );
+    throw new infraError(`maka cell output is not valid JSON for task ${taskId}`, errorText(error));
   }
   try {
     return validateHarborCellOutput(parsed);
   } catch (error) {
-    throw new HarborInfraError(
-      `maka cell output is malformed for task ${taskId}`,
-      errorText(error),
-    );
+    throw new infraError(`maka cell output is malformed for task ${taskId}`, errorText(error));
   }
 }
 

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -238,6 +238,18 @@ export {
   type ExternalHarborBenchmarkFailureInput,
   type ExternalHarborBenchmarkFailureKind,
 } from './harbor-failure-policy.js';
+export {
+  buildPierRunArgs,
+  createPierTaskRunner,
+  PierInfraError,
+  PIER_PROVIDER_PROXY_DEFAULT_PORT,
+  type BuildPierRunArgsInput,
+  type PierProcessRunner,
+  type PierRunRequest,
+  type PierRunResult,
+  type PierTaskPricing,
+  type PierTaskRunnerOptions,
+} from './pier-task-runner.js';
 export type {
   BuildMakaAheTargetSnapshotOptions,
   MakaAheRunEvidence,

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -14,7 +14,12 @@ import {
   type TaskRunner,
 } from './fixed-prompt-controller.js';
 import { lenientPositiveIntEnv } from './headless-run-env.js';
-import { assertNoExperimentIdentityOverrides, modelIdForProvider } from './harbor-task-runner.js';
+import {
+  assertNoExperimentIdentityOverrides,
+  harborTraceMode,
+  modelIdForProvider,
+  readTimedOutTrialArtifacts,
+} from './harbor-task-runner.js';
 import {
   KIMI_CODE_TOOLCHAIN_CONTAINER_PATH,
   KIMI_CODE_TOOLCHAIN_FINGERPRINT,
@@ -298,10 +303,24 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       const trialException = await readTrialException(join(trialDir, TRIAL_RESULT));
       if (trialException) {
         if (isBudgetExhaustedTrialException(trialException)) {
+          // Recover attested evidence (identity/usage/cell output) via the shared
+          // Harbor implementation so a budget-exhausted sample keeps its Pass@1
+          // eligibility instead of being excluded as missing_execution_identity.
+          const artifactRefs = await readTimedOutTrialArtifacts(
+            trialDir,
+            input.task.id,
+            agent,
+            harborTraceMode(attemptAgentEnv),
+          );
           throw new FixedPromptBudgetExhaustedError(
             `agent budget exhausted for task ${input.task.id}`,
             trialException,
-            providerTelemetry.length > 0 ? { providerTelemetryPath } : undefined,
+            artifactRefs || providerTelemetry.length > 0
+              ? {
+                  ...(artifactRefs ?? {}),
+                  ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
+                }
+              : undefined,
           );
         }
         throw new PierInfraError(

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -1,5 +1,4 @@
 import { spawn, type ChildProcess } from 'node:child_process';
-import { existsSync } from 'node:fs';
 import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { basename, delimiter, join } from 'node:path';
 import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core/llm-connections';
@@ -16,6 +15,7 @@ import {
   assertNoProviderSecretsInAgentEnv,
   findTrialDir,
   harborTraceMode,
+  hostTraceEventsPath,
   isBudgetExhaustedError,
   isBudgetExhaustedTrialException,
   mergeAgentEnv,
@@ -48,7 +48,6 @@ import {
 const CONTAINER_MAKA_REPO = '/opt/maka-agent';
 const TRIAL_CELL_OUTPUT = 'agent/maka-cell-output.json';
 const TRIAL_RUNTIME_EVENTS = 'agent/runtime-events.jsonl';
-const TRIAL_COMBINED_TRACE_EVENTS = 'agent/trace-events.jsonl';
 const TRIAL_REWARD_JSON = 'verifier/reward.json';
 const TRIAL_RESULT = 'result.json';
 const PROVIDER_REQUEST_TELEMETRY = 'provider-request-telemetry.json';
@@ -403,7 +402,6 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
           ? rawCell
           : { ...rawCell, tokenSummary: providerTokenSummary(providerUsage, options.pricing) };
       const hostEventsPath = join(trialDir, TRIAL_RUNTIME_EVENTS);
-      const combinedTracePath = join(trialDir, TRIAL_COMBINED_TRACE_EVENTS);
       // Pier's verifier grading is the scoring authority. Surface it as the
       // structured verifier outcome the controller requires: without it a
       // graded failed cell (max_tokens / tool_step_cap_reached / policy_denied)
@@ -420,10 +418,17 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
           ...cell,
           ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
           runtimeEventsPath: hostEventsPath,
-          // Harbor-parity fallback (hostTraceEventsPath): downstream trace
-          // analysis skips a sample whose traceEventsPath is absent, so when
-          // the combined trace is missing the runtime events stand in.
-          traceEventsPath: existsSync(combinedTracePath) ? combinedTracePath : hostEventsPath,
+          // Shared Harbor resolution: cell mode prefers the maka-storage
+          // session events (the rich trace with tool_failed /
+          // provider_request_captured), task-run mode the combined trace, and
+          // only then the raw runtime events — same layouts, same adapters.
+          traceEventsPath: hostTraceEventsPath(
+            agent,
+            harborTraceMode(attemptAgentEnv),
+            trialDir,
+            cell,
+            hostEventsPath,
+          ),
         },
       };
     } catch (error) {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -754,19 +754,25 @@ async function readOptionalPierReward(trialDir: string, taskId: string): Promise
   return null;
 }
 
-/** A negative reward is DeepSWE's verifier CRASH sentinel, never a grade: every
- * task's tests/test.sh traps EXIT with `echo -1 > reward.txt` when the verifier
- * died before writing any reward file, grader.py documents that path as "an
- * infrastructure error" and real rewards as binary 0/1, and pier's verifier
- * parses reward.txt verbatim into verifier_result.rewards.reward. Recording it
- * as a scored failure would poison the benchmark denominator. */
+/** DeepSWE's grading contract is BINARY: grader.py documents the main reward
+ * as exactly 0 or 1 ("reward binary 0/1"). -1 is the verifier CRASH sentinel —
+ * every task's tests/test.sh traps EXIT with `echo -1 > reward.txt` when the
+ * verifier died before writing any reward file, grader.py documents that path
+ * as "an infrastructure error", and pier's verifier parses reward.txt verbatim
+ * into verifier_result.rewards.reward. Any other value (0.5, 2, ...) can only
+ * come from corrupt or non-contract verifier output. Recording either as a
+ * grade would poison the benchmark: a sentinel as a scored failure, a
+ * fractional value as a pass (`reward > 0`). */
 function assertGradedPierReward(reward: number, taskId: string): number {
+  if (reward === 0 || reward === 1) return reward;
   if (reward < 0) {
     throw new PierInfraError(
       `verifier crashed for task ${taskId}: reward ${reward} is the DeepSWE test.sh crash sentinel, not a grade`,
     );
   }
-  return reward;
+  throw new PierInfraError(
+    `verifier reward ${reward} for task ${taskId} violates the DeepSWE binary 0/1 contract (grader.py); treating as infra, not a grade`,
+  );
 }
 
 async function readPierReward(

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -170,6 +170,19 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
   const harborAdapterDir = join(options.makaRepoPath, 'packages', 'headless', 'harbor');
   const pythonPath = [harborAdapterDir, process.env.PYTHONPATH].filter(Boolean).join(delimiter);
 
+  // The Kimi arm binds ONE fixed proxy port per runner, and Pier's Squid egress
+  // leaves only two usable destination ports (80/443), so concurrent attempts on
+  // the same runner must hold the port one at a time — a second concurrent bind
+  // is a guaranteed EADDRINUSE. Serializing the proxy-holding section (instead of
+  // sharing one proxy) keeps usage/telemetry attribution per attempt. A pool over
+  // both Squid-legal ports is deferred until concurrency actually needs it.
+  let proxyPortQueue: Promise<unknown> = Promise.resolve();
+  const withProxyPortLock = <T>(fn: () => Promise<T>): Promise<T> => {
+    const run = proxyPortQueue.then(fn);
+    proxyPortQueue = run.catch(() => {});
+    return run;
+  };
+
   const runner: TaskRunner = async (input: TaskRunInput): Promise<TaskRunOutput> => {
     const agent = options.agent ?? 'maka';
     const jobsDir = join(
@@ -194,93 +207,97 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
     const providerTelemetryPath = join(jobsDir, PROVIDER_REQUEST_TELEMETRY);
     let providerUsage: ProviderTokenUsage | null = null;
     let providerTelemetry: ProviderRequestTelemetry[] = [];
-    let result: PierRunResult;
     const envFilePath = join(jobsDir, 'pier-agent.env');
-    // Setup errors here are configuration faults, not infra flakes: validate the
-    // mount set and start the proxy BEFORE the launch try so they surface with
-    // their own message (and never leak a listening socket behind a wrapped error).
+    // Config errors fail fast before the proxy exists (and outside the port lock).
     const mounts = buildPierMounts(options, agent);
-    const providerRuntime = await pierProviderRuntime(options, agent);
-    const envFileEntries = providerRuntime?.envFile ?? {};
-    const usesEnvFile = Object.keys(envFileEntries).length > 0;
-    try {
-      // Everything from here until runPier returns lives under one finally that
-      // closes the proxy: a failure in this window (env-file write, arg
-      // assembly) must not leak the listening socket. Bind errors themselves
-      // happen above, before the proxy exists, and still surface raw.
+    const launchAttempt = async (): Promise<PierRunResult> => {
+      // Proxy bind errors surface raw, before the launch try, with their own
+      // message — they are configuration faults, not infra flakes.
+      const providerRuntime = await pierProviderRuntime(options, agent);
+      const envFileEntries = providerRuntime?.envFile ?? {};
+      const usesEnvFile = Object.keys(envFileEntries).length > 0;
       try {
-        const aeEnv = buildPierAgentEnv(input, options, agent, providerRuntime?.agentEnv ?? {});
-        const processEnv: Record<string, string> = {
-          PYTHONPATH: pythonPath,
-          // MAKA_BACKEND is a CliFlag whose env_fallback reads os.environ only, so
-          // `--ae MAKA_BACKEND=` is silently ignored — it must ride the pier process
-          // env. The Kimi adapter ignores it.
-          MAKA_BACKEND: options.backend ?? 'ai-sdk',
-          // Byte-safe channel for the prompt: pier's --ae parser strips leading and
-          // trailing whitespace from values (pier/cli/utils.py key.strip() /
-          // value.strip()), which would drop the prompt's trailing newline and break
-          // the execution-identity hash round-trip on every task. Both adapters fall
-          // back to os.environ (CliFlag env_fallback for Maka, _get_env for Kimi) and
-          // forward the exact bytes into the cell, so the value rides the pier
-          // process env verbatim — and must never also appear in --ae, where the
-          // stripped extra_env copy would take precedence in _get_env.
-          MAKA_SYSTEM_PROMPT: input.systemPrompt,
-        };
-        if (usesEnvFile) await writeEnvFile(envFilePath, envFileEntries);
-        const args = buildPierRunArgs({
-          agent,
-          // Provider-local bare id (same normalization contract as the Harbor
-          // runner): the adapter's model_name takes precedence over MAKA_MODEL, so
-          // a provider-prefixed `-m` would leak the prefixed id into the cell.
-          model: modelIdForProvider(options.model, options.provider ?? 'deepseek'),
-          taskPath: input.task.path,
-          jobsDir,
-          jobName,
-          environment: options.environment ?? 'docker',
-          timeoutMultiplier: options.timeoutMultiplier ?? 1,
-          mounts,
-          agentEnv: aeEnv,
-          ...(usesEnvFile ? { envFile: envFilePath } : {}),
-        });
-        result = await runPier({
-          pierBin,
-          jobName,
-          jobsDir,
-          args,
-          cwd: harborAdapterDir,
-          timeoutMs: options.pierTimeoutMs ?? DEFAULT_PIER_TIMEOUT_MS,
-          env: processEnv,
-        });
-      } finally {
-        await providerRuntime?.close?.();
-        if (usesEnvFile) await rm(envFilePath, { force: true });
-        providerUsage = providerRuntime?.usage?.() ?? null;
-        providerTelemetry = providerRuntime?.telemetry?.() ?? [];
-        if (providerTelemetry.length > 0) {
-          await writeFile(
-            providerTelemetryPath,
-            `${JSON.stringify(
-              {
-                schemaVersion: 1,
-                summary: summarizeProviderTelemetry(providerTelemetry),
-                requests: providerTelemetry,
-              },
-              null,
-              2,
-            )}\n`,
-            'utf8',
-          );
+        // Everything from here until runPier returns lives under one finally that
+        // closes the proxy: a failure in this window (env-file write, arg
+        // assembly) must not leak the listening socket.
+        try {
+          const aeEnv = buildPierAgentEnv(input, options, agent, providerRuntime?.agentEnv ?? {});
+          const processEnv: Record<string, string> = {
+            PYTHONPATH: pythonPath,
+            // MAKA_BACKEND is a CliFlag whose env_fallback reads os.environ only, so
+            // `--ae MAKA_BACKEND=` is silently ignored — it must ride the pier process
+            // env. The Kimi adapter ignores it.
+            MAKA_BACKEND: options.backend ?? 'ai-sdk',
+            // Byte-safe channel for the prompt: pier's --ae parser strips leading and
+            // trailing whitespace from values (pier/cli/utils.py key.strip() /
+            // value.strip()), which would drop the prompt's trailing newline and break
+            // the execution-identity hash round-trip on every task. Both adapters fall
+            // back to os.environ (CliFlag env_fallback for Maka, _get_env for Kimi) and
+            // forward the exact bytes into the cell, so the value rides the pier
+            // process env verbatim — and must never also appear in --ae, where the
+            // stripped extra_env copy would take precedence in _get_env.
+            MAKA_SYSTEM_PROMPT: input.systemPrompt,
+          };
+          if (usesEnvFile) await writeEnvFile(envFilePath, envFileEntries);
+          const args = buildPierRunArgs({
+            agent,
+            // Provider-local bare id (same normalization contract as the Harbor
+            // runner): the adapter's model_name takes precedence over MAKA_MODEL, so
+            // a provider-prefixed `-m` would leak the prefixed id into the cell.
+            model: modelIdForProvider(options.model, options.provider ?? 'deepseek'),
+            taskPath: input.task.path,
+            jobsDir,
+            jobName,
+            environment: options.environment ?? 'docker',
+            timeoutMultiplier: options.timeoutMultiplier ?? 1,
+            mounts,
+            agentEnv: aeEnv,
+            ...(usesEnvFile ? { envFile: envFilePath } : {}),
+          });
+          return await runPier({
+            pierBin,
+            jobName,
+            jobsDir,
+            args,
+            cwd: harborAdapterDir,
+            timeoutMs: options.pierTimeoutMs ?? DEFAULT_PIER_TIMEOUT_MS,
+            env: processEnv,
+          });
+        } finally {
+          await providerRuntime?.close?.();
+          if (usesEnvFile) await rm(envFilePath, { force: true });
+          providerUsage = providerRuntime?.usage?.() ?? null;
+          providerTelemetry = providerRuntime?.telemetry?.() ?? [];
+          if (providerTelemetry.length > 0) {
+            await writeFile(
+              providerTelemetryPath,
+              `${JSON.stringify(
+                {
+                  schemaVersion: 1,
+                  summary: summarizeProviderTelemetry(providerTelemetry),
+                  requests: providerTelemetry,
+                },
+                null,
+                2,
+              )}\n`,
+              'utf8',
+            );
+          }
         }
+      } catch (error) {
+        if (isBudgetExhaustedError(error)) throw error;
+        throw new PierInfraError(
+          `pier run failed to launch for task ${input.task.id}`,
+          errorText(error),
+          'infra_failed',
+          providerTelemetryArtifactRefs(providerTelemetry, providerTelemetryPath),
+        );
       }
-    } catch (error) {
-      if (isBudgetExhaustedError(error)) throw error;
-      throw new PierInfraError(
-        `pier run failed to launch for task ${input.task.id}`,
-        errorText(error),
-        'infra_failed',
-        providerTelemetryArtifactRefs(providerTelemetry, providerTelemetryPath),
-      );
-    }
+    };
+    // Only the Kimi arm competes for a fixed port; the Maka arm binds ephemeral
+    // (or no proxy at all) and needs no serialization.
+    const result =
+      agent === 'kimi-code' ? await withProxyPortLock(launchAttempt) : await launchAttempt();
 
     try {
       if (result.timedOut) {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -711,9 +711,9 @@ async function readVerifierDurationMs(resultPath: string): Promise<number> {
 /** The trial's graded reward, or null when the trial was never graded. Prefers
  * the DeepSWE task verifier's reward.json, falling back to the trial result's
  * verifier_result.rewards.reward (same value, present on a completed trial).
- * Unlike the Maka oracle verifier, Pier tasks write no reward.txt and no
- * structured maka-verifier-outcome.json. A corrupt reward.json is infra, not
- * "ungraded" — the grading authority existed and cannot be read. */
+ * Unlike the Maka oracle verifier, Pier tasks write no structured
+ * maka-verifier-outcome.json. A corrupt reward.json is infra, not "ungraded" —
+ * the grading authority existed and cannot be read. */
 async function readOptionalPierReward(trialDir: string, taskId: string): Promise<number | null> {
   const rewardJson = await readOptionalText(join(trialDir, TRIAL_REWARD_JSON));
   if (rewardJson) {
@@ -727,7 +727,7 @@ async function readOptionalPierReward(trialDir: string, taskId: string): Promise
       );
     }
     if (isRecord(parsed) && typeof parsed.reward === 'number' && Number.isFinite(parsed.reward)) {
-      return parsed.reward;
+      return assertGradedPierReward(parsed.reward, taskId);
     }
   }
   const result = await readOptionalJson(join(trialDir, TRIAL_RESULT));
@@ -735,9 +735,24 @@ async function readOptionalPierReward(trialDir: string, taskId: string): Promise
   const rewards =
     verifierResult && isRecord(verifierResult.rewards) ? verifierResult.rewards : undefined;
   if (rewards && typeof rewards.reward === 'number' && Number.isFinite(rewards.reward)) {
-    return rewards.reward;
+    return assertGradedPierReward(rewards.reward, taskId);
   }
   return null;
+}
+
+/** A negative reward is DeepSWE's verifier CRASH sentinel, never a grade: every
+ * task's tests/test.sh traps EXIT with `echo -1 > reward.txt` when the verifier
+ * died before writing any reward file, grader.py documents that path as "an
+ * infrastructure error" and real rewards as binary 0/1, and pier's verifier
+ * parses reward.txt verbatim into verifier_result.rewards.reward. Recording it
+ * as a scored failure would poison the benchmark denominator. */
+function assertGradedPierReward(reward: number, taskId: string): number {
+  if (reward < 0) {
+    throw new PierInfraError(
+      `verifier crashed for task ${taskId}: reward ${reward} is the DeepSWE test.sh crash sentinel, not a grade`,
+    );
+  }
+  return reward;
 }
 
 async function readPierReward(

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -345,24 +345,19 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
 
       // A populated `exception_info` records how the agent phase ended, NOT
       // whether the trial was graded: pier's trial.py records the exception and
-      // then unconditionally runs verification, so an AgentTimeoutError trial
-      // can still carry an authoritative reward. Mirror Harbor's
-      // completeTimedOutTrial semantics: when the grading authority and the
-      // cell output are both present, score the trial on its actual reward;
-      // only an ungraded budget exhaustion is a budget_exhausted outcome, and
-      // any other exception is infra.
+      // then unconditionally runs verification, so an exceptional trial can
+      // still carry an authoritative reward. Mirror Harbor's authority order
+      // exactly: an ungraded budget exhaustion is a budget_exhausted outcome;
+      // every other exception falls through to the normal reward/cell reads —
+      // a graded trial scores on its actual reward (e.g. a non-zero Kimi CLI
+      // exit the verifier still passed), and missing artifacts become infra
+      // there, with the trial exception attached for diagnosis.
       const trialException = await readTrialException(
         join(trialDir, TRIAL_RESULT),
         'PierTrialError',
       );
       let completeTimedOutTrial = false;
-      if (trialException) {
-        if (!isBudgetExhaustedTrialException(trialException)) {
-          throw new PierInfraError(
-            `pier trial errored for task ${input.task.id}: ${trialException}`,
-            tail(result.stderr || result.stdout),
-          );
-        }
+      if (trialException && isBudgetExhaustedTrialException(trialException)) {
         const [gradedReward, cellArtifact] = await Promise.all([
           readOptionalPierReward(trialDir, input.task.id),
           readOptionalText(join(trialDir, TRIAL_CELL_OUTPUT)),
@@ -397,7 +392,7 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
         );
       }
 
-      const reward = await readPierReward(trialDir, input.task.id);
+      const reward = await readPierReward(trialDir, input.task.id, trialException);
       const rawCell = await readCellOutput(
         join(trialDir, TRIAL_CELL_OUTPUT),
         input.task.id,
@@ -745,9 +740,23 @@ async function readOptionalPierReward(trialDir: string, taskId: string): Promise
   return null;
 }
 
-async function readPierReward(trialDir: string, taskId: string): Promise<number> {
+async function readPierReward(
+  trialDir: string,
+  taskId: string,
+  trialException: string | null,
+): Promise<number> {
   const reward = await readOptionalPierReward(trialDir, taskId);
-  if (reward === null) throw new PierInfraError(`missing verifier reward for task ${taskId}`);
+  if (reward === null) {
+    // Mirror Harbor's readReward diagnostics: when the trial recorded an
+    // exception and grading never produced a reward, name the exception —
+    // that is the root cause, not the missing file.
+    if (trialException) {
+      throw new PierInfraError(
+        `pier trial failed before verifier reward for task ${taskId}: ${trialException}`,
+      );
+    }
+    throw new PierInfraError(`missing verifier reward for task ${taskId}`);
+  }
   return reward;
 }
 

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -1,0 +1,814 @@
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { chmod, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { basename, delimiter, join } from 'node:path';
+import { promisify } from 'node:util';
+import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core/llm-connections';
+import type { ThinkingLevel } from '@maka/core/model-thinking';
+import { validateHarborCellOutput, type HarborCellOutput } from './cell-output.js';
+import {
+  FixedPromptBudgetExhaustedError,
+  type FixedPromptBudgetExhaustedError as FixedPromptBudgetExhaustedErrorType,
+  type TaskRunInput,
+  type TaskRunOutput,
+  type TaskRunner,
+} from './fixed-prompt-controller.js';
+import { lenientPositiveIntEnv } from './headless-run-env.js';
+import { modelIdForProvider } from './harbor-task-runner.js';
+import {
+  KIMI_CODE_TOOLCHAIN_CONTAINER_PATH,
+  KIMI_CODE_TOOLCHAIN_FINGERPRINT,
+} from './kimi-code-toolchain.js';
+import {
+  summarizeProviderTelemetry,
+  startProviderAuthProxy,
+  type ProviderRequestTelemetry,
+  type ProviderTokenUsage,
+  type ProviderUpstreamCredentialResolver,
+  type ProviderUsageProtocol,
+} from './provider-auth-proxy.js';
+import { isSensitiveEnvName } from './provider-env.js';
+
+const execFileAsync = promisify(execFile);
+
+const CONTAINER_MAKA_REPO = '/opt/maka-agent';
+const TRIAL_CELL_OUTPUT = 'agent/maka-cell-output.json';
+const TRIAL_RUNTIME_EVENTS = 'agent/runtime-events.jsonl';
+const TRIAL_COMBINED_TRACE_EVENTS = 'agent/trace-events.jsonl';
+const TRIAL_REWARD_JSON = 'verifier/reward.json';
+const TRIAL_RESULT = 'result.json';
+const PROVIDER_REQUEST_TELEMETRY = 'provider-request-telemetry.json';
+
+/** The default port the Kimi arm binds the host provider proxy to. Pier's Squid
+ * egress for offline (`allow_internet=false`) tasks only permits destination
+ * ports 80/443 (`acl Safe_ports port 80 443`), so a container reaching the host
+ * proxy through Squid must present one of those. 443 keeps the model endpoint on
+ * the conventional TLS port. */
+export const PIER_PROVIDER_PROXY_DEFAULT_PORT = 443;
+
+/** A Pier-side failure (build/docker/timeout/missing artifact) — NOT a benchmark
+ * result. The fixed-prompt controller turns a thrown error into an infra_failed
+ * event, excluding it from scoring instead of recording reward 0. Mirrors
+ * `HarborInfraError`; kept Pier-local so this runner does not depend on the
+ * Harbor runner's error identity. */
+export class PierInfraError extends Error {
+  constructor(
+    message: string,
+    readonly detail?: string,
+    readonly kind: 'infra_failed' | 'timed_out' = 'infra_failed',
+    readonly artifactRefs?: { providerTelemetryPath?: string },
+  ) {
+    super(message);
+    this.name = 'PierInfraError';
+  }
+}
+
+export interface PierTaskPricing {
+  inputUsdPer1M: number;
+  outputUsdPer1M: number;
+  cacheReadUsdPer1M?: number;
+  cacheWriteUsdPer1M?: number;
+  source?: string;
+}
+
+export interface PierTaskRunnerOptions {
+  /** Host path to the maka repo, bind-mounted read-only at /opt/maka-agent. */
+  makaRepoPath: string;
+  /** Pier adapter under test (default: Maka, host-side LLM + offline container). */
+  agent?: 'maka' | 'kimi-code';
+  /** In-container/host cell backend. Only the Maka arm reads it. `fake` runs the
+   * inert cell for zero-cost structural checks; `ai-sdk` is the real run. */
+  backend?: 'ai-sdk' | 'fake';
+  /** Prepared Kimi Code toolchain bind-mounted read-only into task containers. */
+  kimiCodeToolchainPath?: string;
+  /** Base directory under which each task gets an isolated per-task job dir. */
+  jobsDir: string;
+  /** MAKA_MODEL / pier `-m`, e.g. "k3" or "deepseek/deepseek-v4-flash". */
+  model: string;
+  /** MAKA_PROVIDER, e.g. "kimi-coding-plan". */
+  provider?: string;
+  reasoningEffort?: ThinkingLevel;
+  /** Upstream model base URL. Falls back to the provider's registry default. */
+  baseUrl?: string;
+  /** Host path to an API key file. The key stays in the host control process
+   * (read by the host cell, or minted into a scoped token by the proxy); the task
+   * container never receives a provider key env, key-file path, or secret mount. */
+  apiKeyFile?: string;
+  /** Resolves the upstream authority inside the host proxy for every request. */
+  resolveProviderCredential?: ProviderUpstreamCredentialResolver;
+  /** Route the Maka arm's host cell through the auth proxy instead of reading the
+   * key file directly. The Kimi arm always uses the proxy. */
+  useProviderProxy?: boolean;
+  /** Explicit host proxy listen port for the Kimi arm (default 443). */
+  providerProxyPort?: number;
+  /** Per-1M USD pricing forwarded as MAKA_TRIAL_* so the cell emits real costUsd. */
+  pricing?: PierTaskPricing;
+  /** Extra agent env merged last (e.g. MAKA_HARBOR_MODE). Never provider secrets. */
+  agentEnv?: Record<string, string>;
+  /** Pier launcher (default "pier"). */
+  pierBin?: string;
+  /** Pier environment type (default "docker"). */
+  environment?: string;
+  /** Explicit Docker target platform shared by comparison arms. */
+  dockerPlatform?: 'linux/amd64';
+  timeoutMultiplier?: number;
+  /** Wall-clock ceiling for a single `pier run`; a hung Docker/Pier would
+   * otherwise stall the unattended loop forever. Defaults to 45 minutes. */
+  pierTimeoutMs?: number;
+  /** Injectable Pier process runner (default: execFile the pier binary). */
+  runPier?: PierProcessRunner;
+  now?: () => number;
+}
+
+export interface PierRunRequest {
+  pierBin: string;
+  jobName: string;
+  jobsDir: string;
+  args: readonly string[];
+  cwd: string;
+  /** Wall-clock ceiling in ms; the default runner kills pier past this. */
+  timeoutMs?: number;
+  /** Env overlaid onto the pier process (PYTHONPATH + MAKA_BACKEND, which the
+   * adapter's CliFlag env_fallback reads only from os.environ). */
+  env?: Record<string, string>;
+}
+
+export interface PierRunResult {
+  exitCode: number;
+  stdout: string;
+  stderr: string;
+  timedOut?: boolean;
+  signal?: string;
+}
+
+export type PierProcessRunner = (request: PierRunRequest) => Promise<PierRunResult>;
+
+const DEFAULT_PIER_TIMEOUT_MS = 45 * 60_000;
+
+interface PierProviderRuntime {
+  /** Proxy-minted secret env delivered via `--env-file` (kept off argv). */
+  envFile: Record<string, string>;
+  /** Non-secret host env delivered via `--ae` (paths, base URLs). */
+  agentEnv: Record<string, string>;
+  usage?: () => ProviderTokenUsage | null;
+  telemetry?: () => ProviderRequestTelemetry[];
+  close?: () => Promise<void>;
+}
+
+export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner {
+  const runPier = options.runPier ?? defaultPierProcessRunner;
+  const pierBin = options.pierBin ?? 'pier';
+  // The bare adapter import path (`maka_agent:MakaAgent`) resolves only when the
+  // adapter directory is on pier's PYTHONPATH; pier is a uv-installed tool, so its
+  // cwd is not enough. Prepend it, keeping any inherited PYTHONPATH.
+  const harborAdapterDir = join(options.makaRepoPath, 'packages', 'headless', 'harbor');
+  const pythonPath = [harborAdapterDir, process.env.PYTHONPATH].filter(Boolean).join(delimiter);
+
+  const runner: TaskRunner = async (input: TaskRunInput): Promise<TaskRunOutput> => {
+    const agent = options.agent ?? 'maka';
+    const jobsDir = join(
+      options.jobsDir,
+      sanitize(input.runId),
+      sanitize(input.roundId),
+      sanitize(input.task.id),
+    );
+    const jobName = 'trial';
+    const jobDir = join(jobsDir, jobName);
+    // Start each attempt from a clean dir so a crashed prior attempt cannot be
+    // mistaken for this attempt's trial output.
+    await rm(jobsDir, { recursive: true, force: true });
+    await mkdir(jobsDir, { recursive: true });
+
+    const attemptAgentEnv = mergeAgentEnv(options.agentEnv, input.agentEnv);
+    assertNoProviderSecretsInAgentEnv(attemptAgentEnv);
+
+    const providerTelemetryPath = join(jobsDir, PROVIDER_REQUEST_TELEMETRY);
+    let providerUsage: ProviderTokenUsage | null = null;
+    let providerTelemetry: ProviderRequestTelemetry[] = [];
+    let result: PierRunResult;
+    const envFilePath = join(jobsDir, 'pier-agent.env');
+    // Setup errors here are configuration faults, not infra flakes: validate the
+    // mount set and start the proxy BEFORE the launch try so they surface with
+    // their own message (and never leak a listening socket behind a wrapped error).
+    const mounts = buildPierMounts(options, agent);
+    const providerRuntime = await pierProviderRuntime(options, agent);
+    const envFileEntries = providerRuntime?.envFile ?? {};
+    const usesEnvFile = Object.keys(envFileEntries).length > 0;
+    try {
+      const aeEnv = buildPierAgentEnv(input, options, agent, providerRuntime?.agentEnv ?? {});
+      const processEnv: Record<string, string> = {
+        PYTHONPATH: pythonPath,
+        // MAKA_BACKEND is a CliFlag whose env_fallback reads os.environ only, so
+        // `--ae MAKA_BACKEND=` is silently ignored — it must ride the pier process
+        // env. The Kimi adapter ignores it.
+        MAKA_BACKEND: options.backend ?? 'ai-sdk',
+      };
+      if (usesEnvFile) await writeEnvFile(envFilePath, envFileEntries);
+      const args = buildPierRunArgs({
+        agent,
+        model: options.model,
+        taskPath: input.task.path,
+        jobsDir,
+        jobName,
+        environment: options.environment ?? 'docker',
+        timeoutMultiplier: options.timeoutMultiplier ?? 1,
+        mounts,
+        agentEnv: aeEnv,
+        ...(usesEnvFile ? { envFile: envFilePath } : {}),
+      });
+      try {
+        result = await runPier({
+          pierBin,
+          jobName,
+          jobsDir,
+          args,
+          cwd: harborAdapterDir,
+          timeoutMs: options.pierTimeoutMs ?? DEFAULT_PIER_TIMEOUT_MS,
+          env: processEnv,
+        });
+      } finally {
+        await providerRuntime?.close?.();
+        if (usesEnvFile) await rm(envFilePath, { force: true });
+        providerUsage = providerRuntime?.usage?.() ?? null;
+        providerTelemetry = providerRuntime?.telemetry?.() ?? [];
+        if (providerTelemetry.length > 0) {
+          await writeFile(
+            providerTelemetryPath,
+            `${JSON.stringify(
+              {
+                schemaVersion: 1,
+                summary: summarizeProviderTelemetry(providerTelemetry),
+                requests: providerTelemetry,
+              },
+              null,
+              2,
+            )}\n`,
+            'utf8',
+          );
+        }
+      }
+    } catch (error) {
+      if (isBudgetExhaustedError(error)) throw error;
+      throw new PierInfraError(
+        `pier run failed to launch for task ${input.task.id}`,
+        errorText(error),
+        'infra_failed',
+        providerTelemetryArtifactRefs(providerTelemetry, providerTelemetryPath),
+      );
+    }
+
+    try {
+      if (result.timedOut) {
+        throw new PierInfraError(
+          `pier run timed out for task ${input.task.id}`,
+          tail(result.stderr || result.stdout),
+          'timed_out',
+        );
+      }
+      let trialDir: string;
+      try {
+        trialDir = await findTrialDir(jobDir, basename(input.task.path));
+      } catch (error) {
+        if (result.exitCode === 0) throw error;
+        throw new PierInfraError(
+          `pier run exited ${result.exitCode} for task ${input.task.id}`,
+          tail(result.stderr || result.stdout),
+        );
+      }
+
+      // A populated `exception_info` means the trial errored before/while the
+      // verifier graded it. A model budget exhaustion is a benchmark outcome the
+      // controller records separately; anything else is infra.
+      const trialException = await readTrialException(join(trialDir, TRIAL_RESULT));
+      if (trialException) {
+        if (isBudgetExhaustedTrialException(trialException)) {
+          throw new FixedPromptBudgetExhaustedError(
+            `agent budget exhausted for task ${input.task.id}`,
+            trialException,
+            providerTelemetry.length > 0 ? { providerTelemetryPath } : undefined,
+          );
+        }
+        throw new PierInfraError(
+          `pier trial errored for task ${input.task.id}: ${trialException}`,
+          tail(result.stderr || result.stdout),
+        );
+      }
+      if (result.exitCode !== 0) {
+        throw new PierInfraError(
+          `pier run exited ${result.exitCode} for task ${input.task.id}`,
+          tail(result.stderr || result.stdout),
+        );
+      }
+
+      const reward = await readPierReward(trialDir, input.task.id);
+      const rawCell = await readCellOutput(join(trialDir, TRIAL_CELL_OUTPUT), input.task.id);
+      const cell =
+        rawCell.tokenSummary || !providerUsage || !options.pricing
+          ? rawCell
+          : { ...rawCell, tokenSummary: providerTokenSummary(providerUsage, options.pricing) };
+      const hostEventsPath = join(trialDir, TRIAL_RUNTIME_EVENTS);
+      const combinedTracePath = join(trialDir, TRIAL_COMBINED_TRACE_EVENTS);
+      return {
+        harbor: { reward },
+        cell: {
+          ...cell,
+          ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
+          runtimeEventsPath: hostEventsPath,
+          ...(existsSync(combinedTracePath) ? { traceEventsPath: combinedTracePath } : {}),
+        },
+      };
+    } catch (error) {
+      throw withProviderTelemetryArtifact(error, providerTelemetry, providerTelemetryPath);
+    }
+  };
+  return runner;
+}
+
+export interface BuildPierRunArgsInput {
+  agent: 'maka' | 'kimi-code';
+  model: string;
+  taskPath: string;
+  jobsDir: string;
+  jobName: string;
+  environment: string;
+  timeoutMultiplier: number;
+  mounts: ReadonlyArray<Record<string, unknown>>;
+  agentEnv: Record<string, string>;
+  envFile?: string;
+}
+
+/** Assemble the `pier run` argv. Exported for deterministic unit tests. */
+export function buildPierRunArgs(input: BuildPierRunArgsInput): string[] {
+  const importPath =
+    input.agent === 'kimi-code' ? 'kimi_code_agent:MakaKimiCodeAgent' : 'maka_agent:MakaAgent';
+  const args = [
+    'run',
+    '--agent-import-path',
+    importPath,
+    '-m',
+    input.model,
+    '-p',
+    input.taskPath,
+    '-o',
+    input.jobsDir,
+    '--job-name',
+    input.jobName,
+    // -k attempts / -n concurrent: one attempt, one trial — Pass@1 semantics.
+    '-k',
+    '1',
+    '-n',
+    '1',
+    '--timeout-multiplier',
+    String(input.timeoutMultiplier),
+    '-e',
+    input.environment,
+    '--mounts-json',
+    JSON.stringify(input.mounts),
+    '--yes',
+    '--quiet',
+  ];
+  if (input.envFile) args.push('--env-file', input.envFile);
+  for (const [key, value] of Object.entries(input.agentEnv)) {
+    args.push('--ae', `${key}=${value}`);
+  }
+  return args;
+}
+
+function buildPierMounts(
+  options: PierTaskRunnerOptions,
+  agent: 'maka' | 'kimi-code',
+): Array<Record<string, unknown>> {
+  const mounts: Array<Record<string, unknown>> = [
+    { type: 'bind', source: options.makaRepoPath, target: CONTAINER_MAKA_REPO, read_only: true },
+  ];
+  if (agent === 'kimi-code') {
+    if (!options.kimiCodeToolchainPath) {
+      throw new Error('kimiCodeToolchainPath is required for the Kimi Code adapter');
+    }
+    mounts.push({
+      type: 'bind',
+      source: options.kimiCodeToolchainPath,
+      target: KIMI_CODE_TOOLCHAIN_CONTAINER_PATH,
+      read_only: true,
+    });
+  }
+  return mounts;
+}
+
+function buildPierAgentEnv(
+  input: TaskRunInput,
+  options: PierTaskRunnerOptions,
+  agent: 'maka' | 'kimi-code',
+  providerAgentEnv: Record<string, string>,
+): Record<string, string> {
+  const provider = options.provider ?? 'deepseek';
+  const makaModel = modelIdForProvider(options.model, provider);
+  const env: Record<string, string> = {
+    MAKA_MODEL: makaModel,
+    MAKA_PROVIDER: provider,
+    MAKA_LLM_CONNECTION_SLUG: provider,
+    MAKA_REPO_ROOT: CONTAINER_MAKA_REPO,
+    // Verbatim — the controller hashes exactly these bytes and verifies the
+    // round-trip against the cell's execution-identity attestation.
+    MAKA_SYSTEM_PROMPT: input.systemPrompt,
+  };
+  if (options.reasoningEffort) env.MAKA_REASONING_EFFORT = options.reasoningEffort;
+  if (agent === 'kimi-code') {
+    env.MAKA_KIMI_CODE_TOOLCHAIN_FINGERPRINT = KIMI_CODE_TOOLCHAIN_FINGERPRINT;
+  }
+  if (options.pricing) {
+    env.MAKA_TRIAL_INPUT_USD_PER_1M = String(options.pricing.inputUsdPer1M);
+    env.MAKA_TRIAL_OUTPUT_USD_PER_1M = String(options.pricing.outputUsdPer1M);
+    if (options.pricing.cacheReadUsdPer1M !== undefined) {
+      env.MAKA_TRIAL_CACHE_READ_USD_PER_1M = String(options.pricing.cacheReadUsdPer1M);
+    }
+    if (options.pricing.cacheWriteUsdPer1M !== undefined) {
+      env.MAKA_TRIAL_CACHE_WRITE_USD_PER_1M = String(options.pricing.cacheWriteUsdPer1M);
+    }
+    if (options.pricing.source) env.MAKA_TRIAL_PRICING_SOURCE = options.pricing.source;
+  }
+  Object.assign(env, providerAgentEnv);
+  Object.assign(env, mergeAgentEnv(options.agentEnv, input.agentEnv) ?? {});
+  // Lenient by shared contract with the Python adapter: a malformed value must
+  // fall back to the task metadata rather than fail the run.
+  const cellTimeoutSec =
+    lenientPositiveIntEnv(env.MAKA_CELL_TIMEOUT_SEC) ?? input.task.metadata?.agentTimeoutSec;
+  if (cellTimeoutSec !== undefined) {
+    env.MAKA_CELL_TIMEOUT_SEC = String(cellTimeoutSec);
+    const streamTimeoutMs = cellTimeoutSec * 1_000;
+    if (agent === 'maka' && Number.isSafeInteger(streamTimeoutMs)) {
+      // Pier already owns the task-native hard deadline. Keep the runtime's
+      // first-event and between-event watchdogs from imposing a shorter cutoff.
+      env.MAKA_STREAM_CONNECT_TIMEOUT_MS = String(streamTimeoutMs);
+      env.MAKA_STREAM_IDLE_TIMEOUT_MS = String(streamTimeoutMs);
+    }
+  }
+  return env;
+}
+
+async function pierProviderRuntime(
+  options: PierTaskRunnerOptions,
+  agent: 'maka' | 'kimi-code',
+): Promise<PierProviderRuntime | null> {
+  const provider = options.provider ?? 'deepseek';
+  const baseUrl = options.baseUrl ?? providerDefaultBaseUrl(provider);
+  const usesProxy = agent === 'kimi-code' || options.useProviderProxy === true;
+
+  if (!usesProxy) {
+    // Maka arm, direct host-side key file: the host cell reads the real key from
+    // the file path. The path (not the key) rides `--ae`; the container stays
+    // offline and never sees a key. No proxy, so no token metering.
+    if (agent !== 'maka') return null;
+    if (!options.apiKeyFile) return null;
+    return {
+      envFile: {},
+      agentEnv: {
+        MAKA_HOST_REPO_ROOT: options.makaRepoPath,
+        MAKA_HOST_API_KEY_FILE: options.apiKeyFile,
+        ...(baseUrl ? { MAKA_HOST_BASE_URL: baseUrl } : {}),
+      },
+    };
+  }
+
+  if (!options.apiKeyFile && !options.resolveProviderCredential) {
+    throw new Error(
+      `${agent} Pier runs require apiKeyFile or resolveProviderCredential to mint the proxy credential`,
+    );
+  }
+  if (!baseUrl) throw new Error(`Pier ${agent} provider ${provider} requires a base URL`);
+
+  const proxyPort =
+    agent === 'kimi-code'
+      ? (options.providerProxyPort ?? PIER_PROVIDER_PROXY_DEFAULT_PORT)
+      : undefined;
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: baseUrl,
+    // The Maka host cell runs on the host and reaches the proxy on loopback; the
+    // Kimi container reaches it through Docker's host gateway on a Squid-legal port.
+    ...(agent === 'maka' ? { advertisedHost: '127.0.0.1' } : {}),
+    ...(proxyPort !== undefined ? { port: proxyPort } : {}),
+    ...(options.resolveProviderCredential
+      ? { resolveUpstreamCredential: options.resolveProviderCredential }
+      : { apiKeyFile: options.apiKeyFile! }),
+    authMode: agent === 'kimi-code' ? 'bearer' : providerProxyAuthMode(provider),
+    usageProtocol: providerProxyUsageProtocol(agent, provider),
+  });
+
+  return {
+    // Proxy-minted, scoped, ephemeral token — never the real provider key. Routed
+    // through `--env-file` (0600, removed after the run) so it stays off argv.
+    envFile:
+      agent === 'maka'
+        ? {
+            MAKA_HOST_REPO_ROOT: options.makaRepoPath,
+            MAKA_HOST_BASE_URL: proxy.baseUrl,
+            MAKA_HOST_API_KEY: proxy.token,
+          }
+        : { MAKA_PROVIDER_PROXY_URL: proxy.baseUrl, MAKA_PROVIDER_PROXY_TOKEN: proxy.token },
+    agentEnv: {},
+    usage: proxy.usage,
+    telemetry: proxy.telemetry,
+    close: proxy.close,
+  };
+}
+
+function providerDefaultBaseUrl(provider: string): string | undefined {
+  const definition = (
+    PROVIDER_DEFAULTS as Partial<Record<string, (typeof PROVIDER_DEFAULTS)[ProviderType]>>
+  )[provider];
+  return definition?.baseUrl;
+}
+
+function providerProxyAuthMode(provider: string): 'bearer' | 'x-api-key' {
+  const definition = (
+    PROVIDER_DEFAULTS as Partial<Record<string, (typeof PROVIDER_DEFAULTS)[ProviderType]>>
+  )[provider];
+  return definition?.runtimeAdapter.kind === 'anthropic' &&
+    definition.runtimeAdapter.auth === 'api-key'
+    ? 'x-api-key'
+    : 'bearer';
+}
+
+function providerProxyUsageProtocol(
+  agent: 'maka' | 'kimi-code',
+  provider: string,
+): ProviderUsageProtocol | undefined {
+  if (agent === 'kimi-code') return 'openai-chat-sse';
+  const definition = (
+    PROVIDER_DEFAULTS as Partial<Record<string, (typeof PROVIDER_DEFAULTS)[ProviderType]>>
+  )[provider];
+  if (definition?.runtimeAdapter.kind === 'anthropic') return 'anthropic-sse';
+  if (definition?.runtimeAdapter.kind === 'openai-compatible') return 'openai-chat-sse';
+  return undefined;
+}
+
+function providerTokenSummary(
+  usage: ProviderTokenUsage,
+  pricing: PierTaskPricing,
+): NonNullable<HarborCellOutput['tokenSummary']> {
+  const cacheMissInput = Math.max(0, usage.input - usage.cacheRead - usage.cacheWrite);
+  const costUsd =
+    (cacheMissInput * pricing.inputUsdPer1M +
+      usage.cacheRead * (pricing.cacheReadUsdPer1M ?? pricing.inputUsdPer1M) +
+      usage.cacheWrite * (pricing.cacheWriteUsdPer1M ?? pricing.inputUsdPer1M) +
+      usage.output * pricing.outputUsdPer1M) /
+    1_000_000;
+  return {
+    input: usage.input,
+    output: usage.output,
+    cachedInput: usage.cacheRead,
+    cacheHitInput: usage.cacheRead,
+    cacheMissInput,
+    cacheWriteInput: usage.cacheWrite,
+    cacheMissInputSource: 'explicit',
+    reasoning: usage.reasoning ?? 0,
+    total: usage.input + usage.output,
+    costUsd,
+    pricingSource: 'runtime',
+  };
+}
+
+async function writeEnvFile(path: string, env: Record<string, string>): Promise<void> {
+  // dotenv KEY=VALUE lines. Values here are minted/scoped proxy tokens and URLs,
+  // never the real provider key; the file is created 0600 and removed after run.
+  const body = Object.entries(env)
+    .map(([key, value]) => `${key}=${value}`)
+    .join('\n');
+  await writeFile(path, `${body}\n`, { encoding: 'utf8', mode: 0o600 });
+  await chmod(path, 0o600);
+}
+
+async function readPierReward(trialDir: string, taskId: string): Promise<number> {
+  // Prefer the DeepSWE task verifier's reward.json; fall back to the trial
+  // result's verifier_result.rewards.reward (same value, always present on a
+  // completed trial). Unlike the Maka oracle verifier, Pier tasks write no
+  // reward.txt and no structured maka-verifier-outcome.json.
+  const rewardJson = await readOptionalText(join(trialDir, TRIAL_REWARD_JSON));
+  if (rewardJson) {
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rewardJson);
+    } catch (error) {
+      throw new PierInfraError(
+        `verifier reward.json is not valid JSON for task ${taskId}`,
+        errorText(error),
+      );
+    }
+    if (isRecord(parsed) && typeof parsed.reward === 'number' && Number.isFinite(parsed.reward)) {
+      return parsed.reward;
+    }
+  }
+  const result = await readOptionalJson(join(trialDir, TRIAL_RESULT));
+  const verifierResult = isRecord(result?.verifier_result) ? result.verifier_result : undefined;
+  const rewards =
+    verifierResult && isRecord(verifierResult.rewards) ? verifierResult.rewards : undefined;
+  if (rewards && typeof rewards.reward === 'number' && Number.isFinite(rewards.reward)) {
+    return rewards.reward;
+  }
+  throw new PierInfraError(`missing verifier reward for task ${taskId}`);
+}
+
+async function readCellOutput(cellOutputPath: string, taskId: string): Promise<HarborCellOutput> {
+  let raw: string;
+  try {
+    raw = await readFile(cellOutputPath, 'utf8');
+  } catch (error) {
+    throw new PierInfraError(`maka cell did not write output for task ${taskId}`, errorText(error));
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new PierInfraError(
+      `maka cell output is not valid JSON for task ${taskId}`,
+      errorText(error),
+    );
+  }
+  try {
+    return validateHarborCellOutput(parsed);
+  } catch (error) {
+    throw new PierInfraError(`maka cell output is malformed for task ${taskId}`, errorText(error));
+  }
+}
+
+async function findTrialDir(jobDir: string, taskName: string): Promise<string> {
+  let entries;
+  try {
+    entries = await readdir(jobDir, { withFileTypes: true });
+  } catch (error) {
+    throw new PierInfraError(`pier produced no job output at ${jobDir}`, errorText(error));
+  }
+  const dirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
+  const resultTrialName = await readResultTrialName(join(jobDir, TRIAL_RESULT));
+  if (resultTrialName && dirs.includes(resultTrialName)) return join(jobDir, resultTrialName);
+  const match =
+    dirs.find((name) => name === taskName || name.startsWith(`${taskName}__`)) ?? dirs[0];
+  if (!match) {
+    throw new PierInfraError(
+      `pier produced no trial directory under ${jobDir} for task ${taskName}`,
+    );
+  }
+  return join(jobDir, match);
+}
+
+async function readResultTrialName(resultPath: string): Promise<string | null> {
+  const parsed = await readOptionalJson(resultPath);
+  if (!parsed || !isRecord(parsed.stats) || !isRecord(parsed.stats.evals)) return null;
+  for (const evalResult of Object.values(parsed.stats.evals)) {
+    if (!isRecord(evalResult)) continue;
+    const rewardStats = isRecord(evalResult.reward_stats) ? evalResult.reward_stats : null;
+    const rewards =
+      rewardStats && isRecord(rewardStats.reward) ? Object.values(rewardStats.reward) : [];
+    for (const trialNames of rewards) {
+      const trialName = firstString(trialNames);
+      if (trialName) return trialName;
+    }
+  }
+  return null;
+}
+
+async function readTrialException(resultPath: string): Promise<string | null> {
+  const parsed = await readOptionalJson(resultPath);
+  if (!parsed) return null;
+  const exceptionInfo = isRecord(parsed.exception_info) ? parsed.exception_info : null;
+  if (!exceptionInfo) return null;
+  const type =
+    typeof exceptionInfo.exception_type === 'string'
+      ? exceptionInfo.exception_type
+      : 'PierTrialError';
+  const message =
+    typeof exceptionInfo.exception_message === 'string' ? exceptionInfo.exception_message : '';
+  return message ? `${type}: ${message}` : type;
+}
+
+function isBudgetExhaustedTrialException(message: string): boolean {
+  return (
+    /^RuntimeError: Maka host cell exceeded \d+(?:\.\d+)?s$/.test(message) ||
+    /^AgentTimeoutError: Agent execution timed out after \d+(?:\.\d+)? seconds$/.test(message)
+  );
+}
+
+function providerTelemetryArtifactRefs(
+  telemetry: readonly ProviderRequestTelemetry[],
+  providerTelemetryPath: string,
+): { providerTelemetryPath: string } | undefined {
+  return telemetry.length > 0 ? { providerTelemetryPath } : undefined;
+}
+
+function withProviderTelemetryArtifact(
+  error: unknown,
+  telemetry: readonly ProviderRequestTelemetry[],
+  providerTelemetryPath: string,
+): unknown {
+  const artifactRefs = providerTelemetryArtifactRefs(telemetry, providerTelemetryPath);
+  if (
+    !(error instanceof PierInfraError) ||
+    !artifactRefs ||
+    error.artifactRefs?.providerTelemetryPath
+  ) {
+    return error;
+  }
+  const enriched = new PierInfraError(error.message, error.detail, error.kind, artifactRefs);
+  enriched.stack = error.stack;
+  return enriched;
+}
+
+function mergeAgentEnv(
+  base: Record<string, string> | undefined,
+  attempt: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!base && !attempt) return undefined;
+  return { ...(base ?? {}), ...(attempt ?? {}) };
+}
+
+function assertNoProviderSecretsInAgentEnv(agentEnv: Record<string, string> | undefined): void {
+  const forbidden = Object.keys(agentEnv ?? {}).filter((key) => isSensitiveEnvName(key));
+  if (forbidden.length > 0) {
+    throw new Error(`agentEnv must not contain provider secrets: ${forbidden.sort().join(', ')}`);
+  }
+}
+
+const defaultPierProcessRunner: PierProcessRunner = async (request) => {
+  try {
+    const { stdout, stderr } = await execFileAsync(request.pierBin, [...request.args], {
+      cwd: request.cwd,
+      maxBuffer: 64 * 1024 * 1024,
+      ...(request.timeoutMs !== undefined
+        ? { timeout: request.timeoutMs, killSignal: 'SIGKILL' as const }
+        : {}),
+      ...(request.env ? { env: { ...process.env, ...request.env } } : {}),
+    });
+    return { exitCode: 0, stdout, stderr };
+  } catch (error) {
+    const exitCode =
+      typeof (error as { code?: unknown }).code === 'number' ? (error as { code: number }).code : 1;
+    return {
+      exitCode,
+      stdout: String((error as { stdout?: unknown }).stdout ?? ''),
+      stderr: String((error as { stderr?: unknown }).stderr ?? '') || errorText(error),
+      timedOut: isExecFileTimeout(error),
+      ...(typeof (error as { signal?: unknown }).signal === 'string'
+        ? { signal: (error as { signal: string }).signal }
+        : {}),
+    };
+  }
+};
+
+function isExecFileTimeout(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const record = error as { killed?: unknown; signal?: unknown };
+  return record.killed === true && record.signal === 'SIGKILL';
+}
+
+function isBudgetExhaustedError(error: unknown): error is FixedPromptBudgetExhaustedErrorType {
+  return (
+    error instanceof FixedPromptBudgetExhaustedError ||
+    (typeof error === 'object' &&
+      error !== null &&
+      (error as { name?: unknown }).name === 'FixedPromptBudgetExhaustedError')
+  );
+}
+
+async function readOptionalText(path: string): Promise<string | null> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch {
+    return null;
+  }
+}
+
+async function readOptionalJson(path: string): Promise<Record<string, unknown> | null> {
+  const raw = await readOptionalText(path);
+  if (raw === null) return null;
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isRecord(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+function firstString(value: unknown): string | null {
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) {
+    const first = value.find((item): item is string => typeof item === 'string');
+    return first ?? null;
+  }
+  return null;
+}
+
+function sanitize(value: string): string {
+  return value.replace(/[^A-Za-z0-9._-]/g, '_');
+}
+
+function tail(text: string, lines = 20): string {
+  return text.split('\n').slice(-lines).join('\n');
+}
+
+function errorText(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -662,20 +662,26 @@ async function writeEnvFile(path: string, env: Record<string, string>): Promise<
   await chmod(path, 0o600);
 }
 
+/** Pier's agent_setup phase budget (pier/trial/trial.py:176
+ * `_AGENT_SETUP_TIMEOUT_SEC = 360.0`); like the other phases it is scaled by
+ * the timeout multiplier (pier/trial/execution.py:129-143). */
+const PIER_AGENT_SETUP_TIMEOUT_SEC = 360;
+
 /** Pier's maximum legitimate trial lifecycle in task-native seconds. Owns the
  * COMPLETE pier phase-and-retry model in one place — never patch phases in
- * piecemeal. Pier runs environment build, then the agent once, then the
- * verifier, and retries two of those phases once on their timeout errors
- * (tenacity `stop_after_attempt(2)`: `start_environment` in
+ * piecemeal. Pier runs environment build, then agent setup, then the agent
+ * once, then the verifier, and retries two of those phases once on their
+ * timeout errors (tenacity `stop_after_attempt(2)`: `start_environment` in
  * pier/trial/execution.py:208 on EnvironmentStartTimeoutError, and
  * `_verify_with_retry` in pier/trial/trial.py:333 on VerifierTimeoutError), so
- * the legitimate ceiling is 2 x build + agent + 2 x verifier. For DeepSWE
- * (build 1800s, agent 5400s, verifier 1800s) that is 12600s — a derivation
- * missing any phase or retry would let the watchdog kill legitimate trials as
- * infra. */
+ * the legitimate ceiling is 2 x build + setup + agent + 2 x verifier. For
+ * DeepSWE (build 1800s, setup 360s, agent 5400s, verifier 1800s) that is
+ * 12960s — a derivation missing any phase or retry would let the watchdog
+ * kill legitimate trials as infra. */
 function pierMaxTrialPhasesSec(metadata: TaskRunInput['task']['metadata']): number {
   return (
     2 * (metadata?.buildTimeoutSec ?? 0) +
+    PIER_AGENT_SETUP_TIMEOUT_SEC +
     (metadata?.agentTimeoutSec ?? 0) +
     2 * (metadata?.verifierTimeoutSec ?? 0)
   );

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -311,10 +311,14 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
         );
       }
     };
-    // Only the Kimi arm competes for a fixed port; the Maka arm binds ephemeral
-    // (or no proxy at all) and needs no serialization.
+    // Only the Kimi arm on a FIXED port competes for the bind; the Maka arm
+    // (ephemeral or no proxy) and an explicit port 0 (OS-assigned, used by
+    // tests) cannot collide and need no serialization.
+    const kimiProxyPort = options.providerProxyPort ?? PIER_PROVIDER_PROXY_DEFAULT_PORT;
     const result =
-      agent === 'kimi-code' ? await withProxyPortLock(launchAttempt) : await launchAttempt();
+      agent === 'kimi-code' && kimiProxyPort !== 0
+        ? await withProxyPortLock(launchAttempt)
+        : await launchAttempt();
 
     try {
       if (result.timedOut) {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -1,10 +1,9 @@
 import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { chmod, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { basename, delimiter, join } from 'node:path';
 import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core/llm-connections';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
-import { validateHarborCellOutput, type HarborCellOutput } from './cell-output.js';
 import {
   FixedPromptBudgetExhaustedError,
   type HarborVerifierOutcome,
@@ -15,6 +14,7 @@ import {
 import {
   assertNoExperimentIdentityOverrides,
   assertNoProviderSecretsInAgentEnv,
+  findTrialDir,
   harborTraceMode,
   isBudgetExhaustedError,
   isBudgetExhaustedTrialException,
@@ -23,9 +23,13 @@ import {
   providerProxyAuthMode,
   providerProxyUsageProtocol,
   providerRequiresSecret,
+  providerTelemetryArtifactRefs,
   providerTokenSummary,
+  readCellOutput,
   readTimedOutTrialArtifacts,
+  readTrialException,
   resolveNativeTrialTimeoutMs,
+  withProviderTelemetryArtifact,
   type HarborTaskPricing,
 } from './harbor-task-runner.js';
 import { lenientPositiveIntEnv } from './headless-run-env.js';
@@ -330,7 +334,7 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       }
       let trialDir: string;
       try {
-        trialDir = await findTrialDir(jobDir, basename(input.task.path));
+        trialDir = await findTrialDir(jobDir, basename(input.task.path), 'pier', PierInfraError);
       } catch (error) {
         if (result.exitCode === 0) throw error;
         throw new PierInfraError(
@@ -347,7 +351,10 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       // cell output are both present, score the trial on its actual reward;
       // only an ungraded budget exhaustion is a budget_exhausted outcome, and
       // any other exception is infra.
-      const trialException = await readTrialException(join(trialDir, TRIAL_RESULT));
+      const trialException = await readTrialException(
+        join(trialDir, TRIAL_RESULT),
+        'PierTrialError',
+      );
       let completeTimedOutTrial = false;
       if (trialException) {
         if (!isBudgetExhaustedTrialException(trialException)) {
@@ -391,7 +398,11 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       }
 
       const reward = await readPierReward(trialDir, input.task.id);
-      const rawCell = await readCellOutput(join(trialDir, TRIAL_CELL_OUTPUT), input.task.id);
+      const rawCell = await readCellOutput(
+        join(trialDir, TRIAL_CELL_OUTPUT),
+        input.task.id,
+        PierInfraError,
+      );
       const cell =
         rawCell.tokenSummary || !providerUsage || !options.pricing
           ? rawCell
@@ -418,7 +429,12 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
         },
       };
     } catch (error) {
-      throw withProviderTelemetryArtifact(error, providerTelemetry, providerTelemetryPath);
+      throw withProviderTelemetryArtifact(
+        error,
+        providerTelemetry,
+        providerTelemetryPath,
+        PierInfraError,
+      );
     }
   };
   return runner;
@@ -735,104 +751,6 @@ async function readPierReward(trialDir: string, taskId: string): Promise<number>
   return reward;
 }
 
-async function readCellOutput(cellOutputPath: string, taskId: string): Promise<HarborCellOutput> {
-  let raw: string;
-  try {
-    raw = await readFile(cellOutputPath, 'utf8');
-  } catch (error) {
-    throw new PierInfraError(`maka cell did not write output for task ${taskId}`, errorText(error));
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (error) {
-    throw new PierInfraError(
-      `maka cell output is not valid JSON for task ${taskId}`,
-      errorText(error),
-    );
-  }
-  try {
-    return validateHarborCellOutput(parsed);
-  } catch (error) {
-    throw new PierInfraError(`maka cell output is malformed for task ${taskId}`, errorText(error));
-  }
-}
-
-async function findTrialDir(jobDir: string, taskName: string): Promise<string> {
-  let entries;
-  try {
-    entries = await readdir(jobDir, { withFileTypes: true });
-  } catch (error) {
-    throw new PierInfraError(`pier produced no job output at ${jobDir}`, errorText(error));
-  }
-  const dirs = entries.filter((entry) => entry.isDirectory()).map((entry) => entry.name);
-  const resultTrialName = await readResultTrialName(join(jobDir, TRIAL_RESULT));
-  if (resultTrialName && dirs.includes(resultTrialName)) return join(jobDir, resultTrialName);
-  const match =
-    dirs.find((name) => name === taskName || name.startsWith(`${taskName}__`)) ?? dirs[0];
-  if (!match) {
-    throw new PierInfraError(
-      `pier produced no trial directory under ${jobDir} for task ${taskName}`,
-    );
-  }
-  return join(jobDir, match);
-}
-
-async function readResultTrialName(resultPath: string): Promise<string | null> {
-  const parsed = await readOptionalJson(resultPath);
-  if (!parsed || !isRecord(parsed.stats) || !isRecord(parsed.stats.evals)) return null;
-  for (const evalResult of Object.values(parsed.stats.evals)) {
-    if (!isRecord(evalResult)) continue;
-    const rewardStats = isRecord(evalResult.reward_stats) ? evalResult.reward_stats : null;
-    const rewards =
-      rewardStats && isRecord(rewardStats.reward) ? Object.values(rewardStats.reward) : [];
-    for (const trialNames of rewards) {
-      const trialName = firstString(trialNames);
-      if (trialName) return trialName;
-    }
-  }
-  return null;
-}
-
-async function readTrialException(resultPath: string): Promise<string | null> {
-  const parsed = await readOptionalJson(resultPath);
-  if (!parsed) return null;
-  const exceptionInfo = isRecord(parsed.exception_info) ? parsed.exception_info : null;
-  if (!exceptionInfo) return null;
-  const type =
-    typeof exceptionInfo.exception_type === 'string'
-      ? exceptionInfo.exception_type
-      : 'PierTrialError';
-  const message =
-    typeof exceptionInfo.exception_message === 'string' ? exceptionInfo.exception_message : '';
-  return message ? `${type}: ${message}` : type;
-}
-
-function providerTelemetryArtifactRefs(
-  telemetry: readonly ProviderRequestTelemetry[],
-  providerTelemetryPath: string,
-): { providerTelemetryPath: string } | undefined {
-  return telemetry.length > 0 ? { providerTelemetryPath } : undefined;
-}
-
-function withProviderTelemetryArtifact(
-  error: unknown,
-  telemetry: readonly ProviderRequestTelemetry[],
-  providerTelemetryPath: string,
-): unknown {
-  const artifactRefs = providerTelemetryArtifactRefs(telemetry, providerTelemetryPath);
-  if (
-    !(error instanceof PierInfraError) ||
-    !artifactRefs ||
-    error.artifactRefs?.providerTelemetryPath
-  ) {
-    return error;
-  }
-  const enriched = new PierInfraError(error.message, error.detail, error.kind, artifactRefs);
-  enriched.stack = error.stack;
-  return enriched;
-}
-
 /** Grace between SIGTERM and SIGKILL when the watchdog fires. Pier's SIGTERM
  * handler (pier/cli/jobs.py:771 -> :148 raises KeyboardInterrupt) unwinds its
  * Python finally chain, which owns docker compose teardown — containers need
@@ -935,15 +853,6 @@ async function readOptionalJson(path: string): Promise<Record<string, unknown> |
   } catch {
     return null;
   }
-}
-
-function firstString(value: unknown): string | null {
-  if (typeof value === 'string') return value;
-  if (Array.isArray(value)) {
-    const first = value.find((item): item is string => typeof item === 'string');
-    return first ?? null;
-  }
-  return null;
 }
 
 function sanitize(value: string): string {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -216,7 +216,10 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       if (usesEnvFile) await writeEnvFile(envFilePath, envFileEntries);
       const args = buildPierRunArgs({
         agent,
-        model: options.model,
+        // Provider-local bare id (same normalization contract as the Harbor
+        // runner): the adapter's model_name takes precedence over MAKA_MODEL, so
+        // a provider-prefixed `-m` would leak the prefixed id into the cell.
+        model: modelIdForProvider(options.model, options.provider ?? 'deepseek'),
         taskPath: input.task.path,
         jobsDir,
         jobName,

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -59,6 +59,28 @@ const PROVIDER_REQUEST_TELEMETRY = 'provider-request-telemetry.json';
  * the conventional TLS port. */
 export const PIER_PROVIDER_PROXY_DEFAULT_PORT = 443;
 
+/** The Kimi arm binds ONE fixed proxy port per attempt, and Pier's Squid egress
+ * leaves only two usable destination ports (80/443), so concurrent attempts on
+ * the same port must hold it one at a time — a second concurrent bind is a
+ * guaranteed EADDRINUSE. The lock's owner is the shared host PORT, not a runner
+ * instance: two runners in one process (e.g. an A/B with two Kimi arms) compete
+ * for the same bind. Hence a module-level per-port queue; cross-PROCESS
+ * collisions remain the operator's scheduling concern. Serializing the
+ * proxy-holding section (instead of sharing one proxy) keeps usage/telemetry
+ * attribution per attempt. A pool over both Squid-legal ports is deferred until
+ * concurrency actually needs it. */
+const proxyPortQueues = new Map<number, Promise<unknown>>();
+
+function withProxyPortLock<T>(port: number, fn: () => Promise<T>): Promise<T> {
+  const queue = proxyPortQueues.get(port) ?? Promise.resolve();
+  const run = queue.then(fn);
+  proxyPortQueues.set(
+    port,
+    run.catch(() => {}),
+  );
+  return run;
+}
+
 /** A Pier-side failure (build/docker/timeout/missing artifact) — NOT a benchmark
  * result. The fixed-prompt controller turns a thrown error into an infra_failed
  * event, excluding it from scoring instead of recording reward 0.
@@ -181,19 +203,6 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
   // cwd is not enough. Prepend it, keeping any inherited PYTHONPATH.
   const harborAdapterDir = join(options.makaRepoPath, 'packages', 'headless', 'harbor');
   const pythonPath = [harborAdapterDir, process.env.PYTHONPATH].filter(Boolean).join(delimiter);
-
-  // The Kimi arm binds ONE fixed proxy port per runner, and Pier's Squid egress
-  // leaves only two usable destination ports (80/443), so concurrent attempts on
-  // the same runner must hold the port one at a time — a second concurrent bind
-  // is a guaranteed EADDRINUSE. Serializing the proxy-holding section (instead of
-  // sharing one proxy) keeps usage/telemetry attribution per attempt. A pool over
-  // both Squid-legal ports is deferred until concurrency actually needs it.
-  let proxyPortQueue: Promise<unknown> = Promise.resolve();
-  const withProxyPortLock = <T>(fn: () => Promise<T>): Promise<T> => {
-    const run = proxyPortQueue.then(fn);
-    proxyPortQueue = run.catch(() => {});
-    return run;
-  };
 
   const runner: TaskRunner = async (input: TaskRunInput): Promise<TaskRunOutput> => {
     const agent = options.agent ?? 'maka';
@@ -320,7 +329,7 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
     const kimiProxyPort = options.providerProxyPort ?? PIER_PROVIDER_PROXY_DEFAULT_PORT;
     const result =
       agent === 'kimi-code' && kimiProxyPort !== 0
-        ? await withProxyPortLock(launchAttempt)
+        ? await withProxyPortLock(kimiProxyPort, launchAttempt)
         : await launchAttempt();
 
     try {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -19,6 +19,7 @@ import {
   harborTraceMode,
   modelIdForProvider,
   readTimedOutTrialArtifacts,
+  resolveNativeTrialTimeoutMs,
 } from './harbor-task-runner.js';
 import {
   KIMI_CODE_TOOLCHAIN_CONTAINER_PATH,
@@ -118,7 +119,10 @@ export interface PierTaskRunnerOptions {
   environment?: string;
   timeoutMultiplier?: number;
   /** Wall-clock ceiling for a single `pier run`; a hung Docker/Pier would
-   * otherwise stall the unattended loop forever. Defaults to 45 minutes. */
+   * otherwise stall the unattended loop forever. Defaults to the task-native
+   * budget: (agentTimeoutSec + verifierTimeoutSec) x timeoutMultiplier plus
+   * setup/teardown grace, floored at 45 minutes (shared derivation with the
+   * Harbor runner — DeepSWE tasks alone run 5400s agent + 1800s verifier). */
   pierTimeoutMs?: number;
   /** Injectable Pier process runner (default: execFile the pier binary). */
   runPier?: PierProcessRunner;
@@ -148,8 +152,6 @@ export interface PierRunResult {
 }
 
 export type PierProcessRunner = (request: PierRunRequest) => Promise<PierRunResult>;
-
-const DEFAULT_PIER_TIMEOUT_MS = 45 * 60_000;
 
 interface PierProviderRuntime {
   /** Proxy-minted secret env delivered via `--env-file` (kept off argv). */
@@ -260,7 +262,16 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
             jobsDir,
             args,
             cwd: harborAdapterDir,
-            timeoutMs: options.pierTimeoutMs ?? DEFAULT_PIER_TIMEOUT_MS,
+            // Task-aware watchdog (shared Harbor derivation): a fixed 45-minute
+            // default would systematically undercut DeepSWE's native budget of
+            // 5400s agent + 1800s verifier per trial.
+            timeoutMs:
+              options.pierTimeoutMs ??
+              resolveNativeTrialTimeoutMs({
+                agentTimeoutSec: input.task.metadata?.agentTimeoutSec ?? 0,
+                verifierTimeoutSec: input.task.metadata?.verifierTimeoutSec ?? 0,
+                timeoutMultiplier: options.timeoutMultiplier ?? 1,
+              }),
             env: processEnv,
           });
         } finally {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -366,11 +366,19 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       );
       let completeTimedOutTrial = false;
       if (trialException && isBudgetExhaustedTrialException(trialException)) {
-        const [gradedReward, cellArtifact] = await Promise.all([
-          readOptionalPierReward(trialDir, input.task.id),
+        const [grade, cellArtifact] = await Promise.all([
+          readPierGrade(trialDir, input.task.id),
           readOptionalText(join(trialDir, TRIAL_CELL_OUTPUT)),
         ]);
-        if (gradedReward === null || cellArtifact === null) {
+        // Budget-gate context, distinct from the graded read path: the agent has
+        // already exhausted its budget, which is the authoritative fact. A
+        // verifier that crashed or wrote a corrupt reward here does NOT overturn
+        // it — an `invalid` grade is treated exactly like `ungraded` / a missing
+        // reward file, yielding budget_exhausted (no retry, Pass@1 evidence
+        // preserved) rather than an infra failure the controller would retry. In
+        // the graded read path a corrupt scoring authority IS infra; only when
+        // the budget is already spent does the agent fact take precedence.
+        if (grade.state !== 'graded' || cellArtifact === null) {
           // Recover attested evidence (identity/usage/cell output) via the shared
           // Harbor implementation so a budget-exhausted sample keeps its Pass@1
           // eligibility instead of being excluded as missing_execution_identity.
@@ -382,7 +390,10 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
           );
           throw new FixedPromptBudgetExhaustedError(
             `agent budget exhausted for task ${input.task.id}`,
-            trialException,
+            // Carry the invalid-grade detail alongside the exhaustion cause so a
+            // corrupt/crashed verifier is still diagnosable, without letting it
+            // count toward the score.
+            grade.state === 'invalid' ? `${trialException}; ${grade.detail}` : trialException,
             artifactRefs || providerTelemetry.length > 0
               ? {
                   ...(artifactRefs ?? {}),
@@ -731,36 +742,77 @@ async function readVerifierDurationMs(resultPath: string): Promise<number> {
     : 0;
 }
 
-/** The trial's graded reward, or null when the trial was never graded. Prefers
- * the DeepSWE task verifier's reward.json, falling back to the trial result's
- * verifier_result.rewards.reward (same value, present on a completed trial).
- * Unlike the Maka oracle verifier, Pier tasks write no structured
- * maka-verifier-outcome.json. A corrupt reward.json is infra, not "ungraded" —
- * the grading authority existed and cannot be read. */
-async function readOptionalPierReward(trialDir: string, taskId: string): Promise<number | null> {
-  const rewardJson = await readOptionalText(join(trialDir, TRIAL_REWARD_JSON));
-  if (rewardJson) {
+/** The trial's grading state, read as ONE discriminated value from both
+ * persisted mirrors of Pier's scoring authority. Callers interpret it per
+ * context (a corrupt authority is infra when reading a grade, but does not
+ * overturn an already-exhausted agent budget at the budget gate), so the read
+ * itself never throws — there is exactly one place that decides what each
+ * state means for each context.
+ *
+ *  - `graded`: an authoritative binary 0/1 reward. Either reward.json carried
+ *    it and the trial result mirror (verifier_result.rewards.reward), if
+ *    present, agreed; or reward.json was absent/empty and the result mirror
+ *    carried it.
+ *  - `ungraded`: neither mirror carried a numeric reward (the trial was never
+ *    graded).
+ *  - `invalid`: the grading authority existed but cannot be trusted as a grade
+ *    — reward.json is not valid JSON, or is valid JSON with no finite numeric
+ *    reward field, or a value is the crash sentinel / violates the binary 0/1
+ *    contract, or the two mirrors both carried a value and disagree. */
+type PierGrade =
+  | { readonly state: 'graded'; readonly reward: number }
+  | { readonly state: 'ungraded' }
+  | { readonly state: 'invalid'; readonly detail: string };
+
+/** Read both persisted mirrors of Pier's scoring authority and reduce them to a
+ * single discriminated grade. Prefers the DeepSWE task verifier's reward.json,
+ * cross-checking it against the trial result's verifier_result.rewards.reward
+ * (same value on a completed trial); when reward.json is absent or empty the
+ * result mirror stands alone. Unlike the Maka oracle verifier, Pier tasks write
+ * no structured maka-verifier-outcome.json. */
+async function readPierGrade(trialDir: string, taskId: string): Promise<PierGrade> {
+  const rewardJsonText = await readOptionalText(join(trialDir, TRIAL_REWARD_JSON));
+  let rewardJsonValue: number | null = null;
+  // An empty file is treated as absent (never written); a non-empty reward.json
+  // is the grading authority and, if it cannot be read as a numeric reward, is
+  // infra — the authority existed and cannot be trusted.
+  if (rewardJsonText && rewardJsonText.trim().length > 0) {
     let parsed: unknown;
     try {
-      parsed = JSON.parse(rewardJson);
+      parsed = JSON.parse(rewardJsonText);
     } catch (error) {
-      throw new PierInfraError(
-        `verifier reward.json is not valid JSON for task ${taskId}`,
-        errorText(error),
-      );
+      return {
+        state: 'invalid',
+        detail: `verifier reward.json is not valid JSON for task ${taskId}: ${errorText(error)}`,
+      };
     }
     if (isRecord(parsed) && typeof parsed.reward === 'number' && Number.isFinite(parsed.reward)) {
-      return assertGradedPierReward(parsed.reward, taskId);
+      rewardJsonValue = parsed.reward;
+    } else {
+      return {
+        state: 'invalid',
+        detail: `verifier reward.json for task ${taskId} has no valid numeric reward field; a corrupt reward.json is infra — the grading authority existed and cannot be read`,
+      };
     }
   }
   const result = await readOptionalJson(join(trialDir, TRIAL_RESULT));
   const verifierResult = isRecord(result?.verifier_result) ? result.verifier_result : undefined;
   const rewards =
     verifierResult && isRecord(verifierResult.rewards) ? verifierResult.rewards : undefined;
-  if (rewards && typeof rewards.reward === 'number' && Number.isFinite(rewards.reward)) {
-    return assertGradedPierReward(rewards.reward, taskId);
+  const resultValue =
+    rewards && typeof rewards.reward === 'number' && Number.isFinite(rewards.reward)
+      ? rewards.reward
+      : null;
+
+  if (rewardJsonValue !== null && resultValue !== null && rewardJsonValue !== resultValue) {
+    return {
+      state: 'invalid',
+      detail: `verifier reward mirrors disagree for task ${taskId}: ${TRIAL_REWARD_JSON} reward ${rewardJsonValue} != ${TRIAL_RESULT} verifier_result.rewards.reward ${resultValue}; the two persisted mirrors of the grading authority must be identical`,
+    };
   }
-  return null;
+  const value = rewardJsonValue ?? resultValue;
+  if (value === null) return { state: 'ungraded' };
+  return classifyPierReward(value, taskId);
 }
 
 /** DeepSWE's grading contract is BINARY: grader.py documents the main reward
@@ -772,36 +824,39 @@ async function readOptionalPierReward(trialDir: string, taskId: string): Promise
  * come from corrupt or non-contract verifier output. Recording either as a
  * grade would poison the benchmark: a sentinel as a scored failure, a
  * fractional value as a pass (`reward > 0`). */
-function assertGradedPierReward(reward: number, taskId: string): number {
-  if (reward === 0 || reward === 1) return reward;
+function classifyPierReward(reward: number, taskId: string): PierGrade {
+  if (reward === 0 || reward === 1) return { state: 'graded', reward };
   if (reward < 0) {
-    throw new PierInfraError(
-      `verifier crashed for task ${taskId}: reward ${reward} is the DeepSWE test.sh crash sentinel, not a grade`,
-    );
+    return {
+      state: 'invalid',
+      detail: `verifier crashed for task ${taskId}: reward ${reward} is the DeepSWE test.sh crash sentinel, not a grade`,
+    };
   }
-  throw new PierInfraError(
-    `verifier reward ${reward} for task ${taskId} violates the DeepSWE binary 0/1 contract (grader.py); treating as infra, not a grade`,
-  );
+  return {
+    state: 'invalid',
+    detail: `verifier reward ${reward} for task ${taskId} violates the DeepSWE binary 0/1 contract (grader.py); treating as infra, not a grade`,
+  };
 }
 
+/** Graded read path (normal completion and non-budget exception fall-through):
+ * the scoring authority is authoritative here, so an invalid grade IS infra. */
 async function readPierReward(
   trialDir: string,
   taskId: string,
   trialException: string | null,
 ): Promise<number> {
-  const reward = await readOptionalPierReward(trialDir, taskId);
-  if (reward === null) {
-    // Mirror Harbor's readReward diagnostics: when the trial recorded an
-    // exception and grading never produced a reward, name the exception —
-    // that is the root cause, not the missing file.
-    if (trialException) {
-      throw new PierInfraError(
-        `pier trial failed before verifier reward for task ${taskId}: ${trialException}`,
-      );
-    }
-    throw new PierInfraError(`missing verifier reward for task ${taskId}`);
+  const grade = await readPierGrade(trialDir, taskId);
+  if (grade.state === 'graded') return grade.reward;
+  if (grade.state === 'invalid') throw new PierInfraError(grade.detail);
+  // ungraded — mirror Harbor's readReward diagnostics: when the trial recorded
+  // an exception and grading never produced a reward, name the exception, which
+  // is the root cause, not the missing file.
+  if (trialException) {
+    throw new PierInfraError(
+      `pier trial failed before verifier reward for task ${taskId}: ${trialException}`,
+    );
   }
-  return reward;
+  throw new PierInfraError(`missing verifier reward for task ${taskId}`);
 }
 
 /** Grace between SIGTERM and SIGKILL when the watchdog fires. Pier's SIGTERM

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -330,12 +330,28 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
         );
       }
 
-      // A populated `exception_info` means the trial errored before/while the
-      // verifier graded it. A model budget exhaustion is a benchmark outcome the
-      // controller records separately; anything else is infra.
+      // A populated `exception_info` records how the agent phase ended, NOT
+      // whether the trial was graded: pier's trial.py records the exception and
+      // then unconditionally runs verification, so an AgentTimeoutError trial
+      // can still carry an authoritative reward. Mirror Harbor's
+      // completeTimedOutTrial semantics: when the grading authority and the
+      // cell output are both present, score the trial on its actual reward;
+      // only an ungraded budget exhaustion is a budget_exhausted outcome, and
+      // any other exception is infra.
       const trialException = await readTrialException(join(trialDir, TRIAL_RESULT));
+      let completeTimedOutTrial = false;
       if (trialException) {
-        if (isBudgetExhaustedTrialException(trialException)) {
+        if (!isBudgetExhaustedTrialException(trialException)) {
+          throw new PierInfraError(
+            `pier trial errored for task ${input.task.id}: ${trialException}`,
+            tail(result.stderr || result.stdout),
+          );
+        }
+        const [gradedReward, cellArtifact] = await Promise.all([
+          readOptionalPierReward(trialDir, input.task.id),
+          readOptionalText(join(trialDir, TRIAL_CELL_OUTPUT)),
+        ]);
+        if (gradedReward === null || cellArtifact === null) {
           // Recover attested evidence (identity/usage/cell output) via the shared
           // Harbor implementation so a budget-exhausted sample keeps its Pass@1
           // eligibility instead of being excluded as missing_execution_identity.
@@ -356,12 +372,9 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
               : undefined,
           );
         }
-        throw new PierInfraError(
-          `pier trial errored for task ${input.task.id}: ${trialException}`,
-          tail(result.stderr || result.stdout),
-        );
+        completeTimedOutTrial = true;
       }
-      if (result.exitCode !== 0) {
+      if (result.exitCode !== 0 && !completeTimedOutTrial) {
         throw new PierInfraError(
           `pier run exited ${result.exitCode} for task ${input.task.id}`,
           tail(result.stderr || result.stdout),
@@ -686,11 +699,13 @@ async function readVerifierDurationMs(resultPath: string): Promise<number> {
     : 0;
 }
 
-async function readPierReward(trialDir: string, taskId: string): Promise<number> {
-  // Prefer the DeepSWE task verifier's reward.json; fall back to the trial
-  // result's verifier_result.rewards.reward (same value, always present on a
-  // completed trial). Unlike the Maka oracle verifier, Pier tasks write no
-  // reward.txt and no structured maka-verifier-outcome.json.
+/** The trial's graded reward, or null when the trial was never graded. Prefers
+ * the DeepSWE task verifier's reward.json, falling back to the trial result's
+ * verifier_result.rewards.reward (same value, present on a completed trial).
+ * Unlike the Maka oracle verifier, Pier tasks write no reward.txt and no
+ * structured maka-verifier-outcome.json. A corrupt reward.json is infra, not
+ * "ungraded" — the grading authority existed and cannot be read. */
+async function readOptionalPierReward(trialDir: string, taskId: string): Promise<number | null> {
   const rewardJson = await readOptionalText(join(trialDir, TRIAL_REWARD_JSON));
   if (rewardJson) {
     let parsed: unknown;
@@ -713,7 +728,13 @@ async function readPierReward(trialDir: string, taskId: string): Promise<number>
   if (rewards && typeof rewards.reward === 'number' && Number.isFinite(rewards.reward)) {
     return rewards.reward;
   }
-  throw new PierInfraError(`missing verifier reward for task ${taskId}`);
+  return null;
+}
+
+async function readPierReward(trialDir: string, taskId: string): Promise<number> {
+  const reward = await readOptionalPierReward(trialDir, taskId);
+  if (reward === null) throw new PierInfraError(`missing verifier reward for task ${taskId}`);
+  return reward;
 }
 
 async function readCellOutput(cellOutputPath: string, taskId: string): Promise<HarborCellOutput> {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -9,6 +9,7 @@ import { validateHarborCellOutput, type HarborCellOutput } from './cell-output.j
 import {
   FixedPromptBudgetExhaustedError,
   type FixedPromptBudgetExhaustedError as FixedPromptBudgetExhaustedErrorType,
+  type HarborVerifierOutcome,
   type TaskRunInput,
   type TaskRunOutput,
   type TaskRunner,
@@ -375,8 +376,18 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
           : { ...rawCell, tokenSummary: providerTokenSummary(providerUsage, options.pricing) };
       const hostEventsPath = join(trialDir, TRIAL_RUNTIME_EVENTS);
       const combinedTracePath = join(trialDir, TRIAL_COMBINED_TRACE_EVENTS);
+      // Pier's verifier grading is the scoring authority. Surface it as the
+      // structured verifier outcome the controller requires: without it a
+      // graded failed cell (max_tokens / tool_step_cap_reached / policy_denied)
+      // is never verifierGraded and drops out of the benchmark denominator as
+      // scored=false. The outcome is derived from the reward itself, so unlike
+      // Harbor's independently-written oracle artifact it cannot disagree.
+      const verifier = pierVerifierOutcome(
+        reward,
+        await readVerifierDurationMs(join(trialDir, TRIAL_RESULT)),
+      );
       return {
-        harbor: { reward },
+        harbor: { reward, verifier },
         cell: {
           ...cell,
           ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
@@ -643,6 +654,36 @@ async function writeEnvFile(path: string, env: Record<string, string>): Promise<
     .join('\n');
   await writeFile(path, `${body}\n`, { encoding: 'utf8', mode: 0o600 });
   await chmod(path, 0o600);
+}
+
+/** Single-attempt structured outcome from Pier's scoring authority, aligned
+ * with the HarborVerifierOutcome contract the fixed-prompt controller consumes.
+ * Harbor reads this from the Maka oracle verifier's own JSON artifact; Pier has
+ * no such artifact, so the outcome is constructed from the graded reward. */
+function pierVerifierOutcome(reward: number, durationMs: number): HarborVerifierOutcome {
+  const passed = reward > 0;
+  return {
+    outcome: passed ? 'passed' : 'failed',
+    attempts: [
+      {
+        attempt: 1,
+        classification: passed ? 'passed' : 'failed',
+        durationMs,
+        reward,
+      },
+    ],
+  };
+}
+
+async function readVerifierDurationMs(resultPath: string): Promise<number> {
+  const result = await readOptionalJson(resultPath);
+  const phase = result && isRecord(result.verifier) ? result.verifier : null;
+  const started = typeof phase?.started_at === 'string' ? Date.parse(phase.started_at) : Number.NaN;
+  const finished =
+    typeof phase?.finished_at === 'string' ? Date.parse(phase.finished_at) : Number.NaN;
+  return Number.isFinite(started) && Number.isFinite(finished) && finished >= started
+    ? finished - started
+    : 0;
 }
 
 async function readPierReward(trialDir: string, taskId: string): Promise<number> {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -128,8 +128,9 @@ export interface PierRunRequest {
   cwd: string;
   /** Wall-clock ceiling in ms; the default runner kills pier past this. */
   timeoutMs?: number;
-  /** Env overlaid onto the pier process (PYTHONPATH + MAKA_BACKEND, which the
-   * adapter's CliFlag env_fallback reads only from os.environ). */
+  /** Env overlaid onto the pier process: PYTHONPATH, MAKA_BACKEND (the adapter's
+   * CliFlag env_fallback reads only os.environ), and MAKA_SYSTEM_PROMPT (byte-
+   * exact; pier's --ae parser would strip its whitespace). */
   env?: Record<string, string>;
 }
 
@@ -202,6 +203,15 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
         // `--ae MAKA_BACKEND=` is silently ignored — it must ride the pier process
         // env. The Kimi adapter ignores it.
         MAKA_BACKEND: options.backend ?? 'ai-sdk',
+        // Byte-safe channel for the prompt: pier's --ae parser strips leading and
+        // trailing whitespace from values (pier/cli/utils.py key.strip() /
+        // value.strip()), which would drop the prompt's trailing newline and break
+        // the execution-identity hash round-trip on every task. Both adapters fall
+        // back to os.environ (CliFlag env_fallback for Maka, _get_env for Kimi) and
+        // forward the exact bytes into the cell, so the value rides the pier
+        // process env verbatim — and must never also appear in --ae, where the
+        // stripped extra_env copy would take precedence in _get_env.
+        MAKA_SYSTEM_PROMPT: input.systemPrompt,
       };
       if (usesEnvFile) await writeEnvFile(envFilePath, envFileEntries);
       const args = buildPierRunArgs({
@@ -408,9 +418,9 @@ function buildPierAgentEnv(
     MAKA_PROVIDER: provider,
     MAKA_LLM_CONNECTION_SLUG: provider,
     MAKA_REPO_ROOT: CONTAINER_MAKA_REPO,
-    // Verbatim — the controller hashes exactly these bytes and verifies the
-    // round-trip against the cell's execution-identity attestation.
-    MAKA_SYSTEM_PROMPT: input.systemPrompt,
+    // MAKA_SYSTEM_PROMPT deliberately does NOT ride --ae: pier's CLI strips
+    // whitespace from --ae values, and a stripped copy in the adapter's
+    // extra_env would shadow the byte-exact os.environ value. See processEnv.
   };
   if (options.reasoningEffort) env.MAKA_REASONING_EFFORT = options.reasoningEffort;
   if (agent === 'kimi-code') {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -204,40 +204,44 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
     const envFileEntries = providerRuntime?.envFile ?? {};
     const usesEnvFile = Object.keys(envFileEntries).length > 0;
     try {
-      const aeEnv = buildPierAgentEnv(input, options, agent, providerRuntime?.agentEnv ?? {});
-      const processEnv: Record<string, string> = {
-        PYTHONPATH: pythonPath,
-        // MAKA_BACKEND is a CliFlag whose env_fallback reads os.environ only, so
-        // `--ae MAKA_BACKEND=` is silently ignored — it must ride the pier process
-        // env. The Kimi adapter ignores it.
-        MAKA_BACKEND: options.backend ?? 'ai-sdk',
-        // Byte-safe channel for the prompt: pier's --ae parser strips leading and
-        // trailing whitespace from values (pier/cli/utils.py key.strip() /
-        // value.strip()), which would drop the prompt's trailing newline and break
-        // the execution-identity hash round-trip on every task. Both adapters fall
-        // back to os.environ (CliFlag env_fallback for Maka, _get_env for Kimi) and
-        // forward the exact bytes into the cell, so the value rides the pier
-        // process env verbatim — and must never also appear in --ae, where the
-        // stripped extra_env copy would take precedence in _get_env.
-        MAKA_SYSTEM_PROMPT: input.systemPrompt,
-      };
-      if (usesEnvFile) await writeEnvFile(envFilePath, envFileEntries);
-      const args = buildPierRunArgs({
-        agent,
-        // Provider-local bare id (same normalization contract as the Harbor
-        // runner): the adapter's model_name takes precedence over MAKA_MODEL, so
-        // a provider-prefixed `-m` would leak the prefixed id into the cell.
-        model: modelIdForProvider(options.model, options.provider ?? 'deepseek'),
-        taskPath: input.task.path,
-        jobsDir,
-        jobName,
-        environment: options.environment ?? 'docker',
-        timeoutMultiplier: options.timeoutMultiplier ?? 1,
-        mounts,
-        agentEnv: aeEnv,
-        ...(usesEnvFile ? { envFile: envFilePath } : {}),
-      });
+      // Everything from here until runPier returns lives under one finally that
+      // closes the proxy: a failure in this window (env-file write, arg
+      // assembly) must not leak the listening socket. Bind errors themselves
+      // happen above, before the proxy exists, and still surface raw.
       try {
+        const aeEnv = buildPierAgentEnv(input, options, agent, providerRuntime?.agentEnv ?? {});
+        const processEnv: Record<string, string> = {
+          PYTHONPATH: pythonPath,
+          // MAKA_BACKEND is a CliFlag whose env_fallback reads os.environ only, so
+          // `--ae MAKA_BACKEND=` is silently ignored — it must ride the pier process
+          // env. The Kimi adapter ignores it.
+          MAKA_BACKEND: options.backend ?? 'ai-sdk',
+          // Byte-safe channel for the prompt: pier's --ae parser strips leading and
+          // trailing whitespace from values (pier/cli/utils.py key.strip() /
+          // value.strip()), which would drop the prompt's trailing newline and break
+          // the execution-identity hash round-trip on every task. Both adapters fall
+          // back to os.environ (CliFlag env_fallback for Maka, _get_env for Kimi) and
+          // forward the exact bytes into the cell, so the value rides the pier
+          // process env verbatim — and must never also appear in --ae, where the
+          // stripped extra_env copy would take precedence in _get_env.
+          MAKA_SYSTEM_PROMPT: input.systemPrompt,
+        };
+        if (usesEnvFile) await writeEnvFile(envFilePath, envFileEntries);
+        const args = buildPierRunArgs({
+          agent,
+          // Provider-local bare id (same normalization contract as the Harbor
+          // runner): the adapter's model_name takes precedence over MAKA_MODEL, so
+          // a provider-prefixed `-m` would leak the prefixed id into the cell.
+          model: modelIdForProvider(options.model, options.provider ?? 'deepseek'),
+          taskPath: input.task.path,
+          jobsDir,
+          jobName,
+          environment: options.environment ?? 'docker',
+          timeoutMultiplier: options.timeoutMultiplier ?? 1,
+          mounts,
+          agentEnv: aeEnv,
+          ...(usesEnvFile ? { envFile: envFilePath } : {}),
+        });
         result = await runPier({
           pierBin,
           jobName,

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -14,7 +14,7 @@ import {
   type TaskRunner,
 } from './fixed-prompt-controller.js';
 import { lenientPositiveIntEnv } from './headless-run-env.js';
-import { modelIdForProvider } from './harbor-task-runner.js';
+import { assertNoExperimentIdentityOverrides, modelIdForProvider } from './harbor-task-runner.js';
 import {
   KIMI_CODE_TOOLCHAIN_CONTAINER_PATH,
   KIMI_CODE_TOOLCHAIN_FINGERPRINT,
@@ -182,6 +182,9 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
 
     const attemptAgentEnv = mergeAgentEnv(options.agentEnv, input.agentEnv);
     assertNoProviderSecretsInAgentEnv(attemptAgentEnv);
+    // Same benchmark invariant as the Harbor runner (shared implementation):
+    // agentEnv must not override experiment identity or MAKA_TRIAL_* pricing.
+    assertNoExperimentIdentityOverrides(attemptAgentEnv);
 
     const providerTelemetryPath = join(jobsDir, PROVIDER_REQUEST_TELEMETRY);
     let providerUsage: ProviderTokenUsage | null = null;

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -22,6 +22,7 @@ import {
   modelIdForProvider,
   providerProxyAuthMode,
   providerProxyUsageProtocol,
+  providerRequiresSecret,
   providerTokenSummary,
   readTimedOutTrialArtifacts,
   resolveNativeTrialTimeoutMs,
@@ -550,11 +551,30 @@ async function pierProviderRuntime(
   const usesProxy = agent === 'kimi-code' || options.useProviderProxy === true;
 
   if (!usesProxy) {
-    // Maka arm, direct host-side key file: the host cell reads the real key from
-    // the file path. The path (not the key) rides `--ae`; the container stays
-    // offline and never sees a key. No proxy, so no token metering.
     if (agent !== 'maka') return null;
-    if (!options.apiKeyFile) return null;
+    // The fake backend runs the inert in-container cell with no host-side
+    // provider runtime at all — the zero-cost structural path the live e2e
+    // evidence depends on. Never wire MAKA_HOST_* for it.
+    if (options.backend === 'fake') return null;
+    if (!options.apiKeyFile) {
+      // Mirror the Harbor runner's predicate: a keyless-ready provider
+      // (registry authKind 'none' — ollama, lm-studio, localai) runs the host
+      // cell with MAKA_HOST_NO_AUTH; a secret-requiring provider without a key
+      // stays unconfigured so the adapter fails loud at environment creation
+      // instead of the cell dialing the API with an empty credential.
+      if (providerRequiresSecret(provider)) return null;
+      return {
+        envFile: {},
+        agentEnv: {
+          MAKA_HOST_REPO_ROOT: options.makaRepoPath,
+          MAKA_HOST_NO_AUTH: 'true',
+          ...(baseUrl ? { MAKA_HOST_BASE_URL: baseUrl } : {}),
+        },
+      };
+    }
+    // Direct host-side key file: the host cell reads the real key from the
+    // file path. The path (not the key) rides `--ae`; the container stays
+    // offline and never sees a key. No proxy, so no token metering.
     return {
       envFile: {},
       agentEnv: {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -420,7 +420,10 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
           ...cell,
           ...(providerTelemetry.length > 0 ? { providerTelemetryPath } : {}),
           runtimeEventsPath: hostEventsPath,
-          ...(existsSync(combinedTracePath) ? { traceEventsPath: combinedTracePath } : {}),
+          // Harbor-parity fallback (hostTraceEventsPath): downstream trace
+          // analysis skips a sample whose traceEventsPath is absent, so when
+          // the combined trace is missing the runtime events stand in.
+          traceEventsPath: existsSync(combinedTracePath) ? combinedTracePath : hostEventsPath,
         },
       };
     } catch (error) {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -122,10 +122,11 @@ export interface PierTaskRunnerOptions {
   environment?: string;
   timeoutMultiplier?: number;
   /** Wall-clock ceiling for a single `pier run`; a hung Docker/Pier would
-   * otherwise stall the unattended loop forever. Defaults to the task-native
-   * budget: (agentTimeoutSec + verifierTimeoutSec) x timeoutMultiplier plus
-   * setup/teardown grace, floored at 45 minutes (shared derivation with the
-   * Harbor runner — DeepSWE tasks alone run 5400s agent + 1800s verifier). */
+   * otherwise stall the unattended loop forever. Defaults to pier's maximum
+   * legitimate trial lifecycle (2 x build + agent + 2 x verifier task-native
+   * seconds, covering pier's one-retry policy on build and verification) x
+   * timeoutMultiplier plus setup/teardown grace, floored at 45 minutes —
+   * shared floor+grace contract with the Harbor runner. */
   pierTimeoutMs?: number;
   /** Injectable Pier process runner (default: execFile the pier binary). */
   runPier?: PierProcessRunner;
@@ -267,14 +268,13 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
             jobsDir,
             args,
             cwd: harborAdapterDir,
-            // Task-aware watchdog (shared Harbor derivation): a fixed 45-minute
-            // default would systematically undercut DeepSWE's native budget of
-            // 5400s agent + 1800s verifier per trial.
+            // Task-aware watchdog (shared Harbor floor+grace contract, fed with
+            // pier's complete lifecycle model): a fixed 45-minute default would
+            // systematically undercut DeepSWE's native budgets.
             timeoutMs:
               options.pierTimeoutMs ??
               resolveNativeTrialTimeoutMs({
-                agentTimeoutSec: input.task.metadata?.agentTimeoutSec ?? 0,
-                verifierTimeoutSec: input.task.metadata?.verifierTimeoutSec ?? 0,
+                nativePhasesSec: pierMaxTrialPhasesSec(input.task.metadata),
                 timeoutMultiplier: options.timeoutMultiplier ?? 1,
               }),
             env: processEnv,
@@ -622,6 +622,25 @@ async function writeEnvFile(path: string, env: Record<string, string>): Promise<
     .join('\n');
   await writeFile(path, `${body}\n`, { encoding: 'utf8', mode: 0o600 });
   await chmod(path, 0o600);
+}
+
+/** Pier's maximum legitimate trial lifecycle in task-native seconds. Owns the
+ * COMPLETE pier phase-and-retry model in one place — never patch phases in
+ * piecemeal. Pier runs environment build, then the agent once, then the
+ * verifier, and retries two of those phases once on their timeout errors
+ * (tenacity `stop_after_attempt(2)`: `start_environment` in
+ * pier/trial/execution.py:208 on EnvironmentStartTimeoutError, and
+ * `_verify_with_retry` in pier/trial/trial.py:333 on VerifierTimeoutError), so
+ * the legitimate ceiling is 2 x build + agent + 2 x verifier. For DeepSWE
+ * (build 1800s, agent 5400s, verifier 1800s) that is 12600s — a derivation
+ * missing any phase or retry would let the watchdog kill legitimate trials as
+ * infra. */
+function pierMaxTrialPhasesSec(metadata: TaskRunInput['task']['metadata']): number {
+  return (
+    2 * (metadata?.buildTimeoutSec ?? 0) +
+    (metadata?.agentTimeoutSec ?? 0) +
+    2 * (metadata?.verifierTimeoutSec ?? 0)
+  );
 }
 
 /** Single-attempt structured outcome from Pier's scoring authority, aligned

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -136,6 +136,14 @@ export interface PierTaskRunnerOptions {
   useProviderProxy?: boolean;
   /** Explicit host proxy listen port for the Kimi arm (default 443). */
   providerProxyPort?: number;
+  /** Host the Kimi container should dial to reach the host provider proxy. Only
+   * the Kimi arm honors it; the Maka arm's host cell always uses loopback
+   * (127.0.0.1) since it runs on the host itself. Unset keeps the default
+   * host.docker.internal, which Docker Desktop injects but native Linux Docker
+   * does NOT provide (pier 0.3.0's compose wires no extra_hosts/host-gateway),
+   * so on native Linux pass the host's docker-bridge-reachable address (e.g.
+   * 172.17.0.1) or the Kimi container's Squid cannot resolve the proxy. */
+  providerProxyAdvertisedHost?: string;
   /** Per-1M USD pricing forwarded as MAKA_TRIAL_* so the cell emits real costUsd. */
   pricing?: PierTaskPricing;
   /** Extra agent env merged last (e.g. MAKA_HARBOR_MODE). Never provider secrets. */
@@ -639,11 +647,14 @@ async function pierProviderRuntime(
     agent === 'kimi-code'
       ? (options.providerProxyPort ?? PIER_PROVIDER_PROXY_DEFAULT_PORT)
       : undefined;
+  // The Maka host cell runs on the host and reaches the proxy on loopback; the
+  // Kimi container reaches it through Docker's host gateway on a Squid-legal
+  // port, defaulting to host.docker.internal unless an explicit advertised host
+  // is supplied (the native-Linux escape hatch, e.g. 172.17.0.1).
+  const advertisedHost = agent === 'maka' ? '127.0.0.1' : options.providerProxyAdvertisedHost;
   const proxy = await startProviderAuthProxy({
     upstreamBaseUrl: baseUrl,
-    // The Maka host cell runs on the host and reaches the proxy on loopback; the
-    // Kimi container reaches it through Docker's host gateway on a Squid-legal port.
-    ...(agent === 'maka' ? { advertisedHost: '127.0.0.1' } : {}),
+    ...(advertisedHost !== undefined ? { advertisedHost } : {}),
     ...(proxyPort !== undefined ? { port: proxyPort } : {}),
     ...(options.resolveProviderCredential
       ? { resolveUpstreamCredential: options.resolveProviderCredential }

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -8,20 +8,27 @@ import type { ThinkingLevel } from '@maka/core/model-thinking';
 import { validateHarborCellOutput, type HarborCellOutput } from './cell-output.js';
 import {
   FixedPromptBudgetExhaustedError,
-  type FixedPromptBudgetExhaustedError as FixedPromptBudgetExhaustedErrorType,
   type HarborVerifierOutcome,
   type TaskRunInput,
   type TaskRunOutput,
   type TaskRunner,
 } from './fixed-prompt-controller.js';
-import { lenientPositiveIntEnv } from './headless-run-env.js';
 import {
   assertNoExperimentIdentityOverrides,
+  assertNoProviderSecretsInAgentEnv,
   harborTraceMode,
+  isBudgetExhaustedError,
+  isBudgetExhaustedTrialException,
+  mergeAgentEnv,
   modelIdForProvider,
+  providerProxyAuthMode,
+  providerProxyUsageProtocol,
+  providerTokenSummary,
   readTimedOutTrialArtifacts,
   resolveNativeTrialTimeoutMs,
+  type HarborTaskPricing,
 } from './harbor-task-runner.js';
+import { lenientPositiveIntEnv } from './headless-run-env.js';
 import {
   KIMI_CODE_TOOLCHAIN_CONTAINER_PATH,
   KIMI_CODE_TOOLCHAIN_FINGERPRINT,
@@ -32,9 +39,7 @@ import {
   type ProviderRequestTelemetry,
   type ProviderTokenUsage,
   type ProviderUpstreamCredentialResolver,
-  type ProviderUsageProtocol,
 } from './provider-auth-proxy.js';
-import { isSensitiveEnvName } from './provider-env.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -55,9 +60,14 @@ export const PIER_PROVIDER_PROXY_DEFAULT_PORT = 443;
 
 /** A Pier-side failure (build/docker/timeout/missing artifact) — NOT a benchmark
  * result. The fixed-prompt controller turns a thrown error into an infra_failed
- * event, excluding it from scoring instead of recording reward 0. Mirrors
- * `HarborInfraError`; kept Pier-local so this runner does not depend on the
- * Harbor runner's error identity. */
+ * event, excluding it from scoring instead of recording reward 0.
+ *
+ * Deliberately separate from HarborInfraError: the controller classifies infra
+ * by behavior (any thrown non-budget error), never by error identity, so
+ * sharing a class buys no invariant — while a Pier failure surfacing as
+ * "HarborInfraError" in diagnostics would misattribute the failing harness.
+ * The telemetry-attachment helpers below stay local for the same reason: they
+ * construct this runner-local error type. */
 export class PierInfraError extends Error {
   constructor(
     message: string,
@@ -70,13 +80,8 @@ export class PierInfraError extends Error {
   }
 }
 
-export interface PierTaskPricing {
-  inputUsdPer1M: number;
-  outputUsdPer1M: number;
-  cacheReadUsdPer1M?: number;
-  cacheWriteUsdPer1M?: number;
-  source?: string;
-}
+/** Same per-1M pricing contract as the Harbor runner (shared cost math). */
+export type PierTaskPricing = HarborTaskPricing;
 
 export interface PierTaskRunnerOptions {
   /** Host path to the maka repo, bind-mounted read-only at /opt/maka-agent. */
@@ -127,7 +132,6 @@ export interface PierTaskRunnerOptions {
   pierTimeoutMs?: number;
   /** Injectable Pier process runner (default: execFile the pier binary). */
   runPier?: PierProcessRunner;
-  now?: () => number;
 }
 
 export interface PierRunRequest {
@@ -610,55 +614,6 @@ function providerDefaultBaseUrl(provider: string): string | undefined {
   return definition?.baseUrl;
 }
 
-function providerProxyAuthMode(provider: string): 'bearer' | 'x-api-key' {
-  const definition = (
-    PROVIDER_DEFAULTS as Partial<Record<string, (typeof PROVIDER_DEFAULTS)[ProviderType]>>
-  )[provider];
-  return definition?.runtimeAdapter.kind === 'anthropic' &&
-    definition.runtimeAdapter.auth === 'api-key'
-    ? 'x-api-key'
-    : 'bearer';
-}
-
-function providerProxyUsageProtocol(
-  agent: 'maka' | 'kimi-code',
-  provider: string,
-): ProviderUsageProtocol | undefined {
-  if (agent === 'kimi-code') return 'openai-chat-sse';
-  const definition = (
-    PROVIDER_DEFAULTS as Partial<Record<string, (typeof PROVIDER_DEFAULTS)[ProviderType]>>
-  )[provider];
-  if (definition?.runtimeAdapter.kind === 'anthropic') return 'anthropic-sse';
-  if (definition?.runtimeAdapter.kind === 'openai-compatible') return 'openai-chat-sse';
-  return undefined;
-}
-
-function providerTokenSummary(
-  usage: ProviderTokenUsage,
-  pricing: PierTaskPricing,
-): NonNullable<HarborCellOutput['tokenSummary']> {
-  const cacheMissInput = Math.max(0, usage.input - usage.cacheRead - usage.cacheWrite);
-  const costUsd =
-    (cacheMissInput * pricing.inputUsdPer1M +
-      usage.cacheRead * (pricing.cacheReadUsdPer1M ?? pricing.inputUsdPer1M) +
-      usage.cacheWrite * (pricing.cacheWriteUsdPer1M ?? pricing.inputUsdPer1M) +
-      usage.output * pricing.outputUsdPer1M) /
-    1_000_000;
-  return {
-    input: usage.input,
-    output: usage.output,
-    cachedInput: usage.cacheRead,
-    cacheHitInput: usage.cacheRead,
-    cacheMissInput,
-    cacheWriteInput: usage.cacheWrite,
-    cacheMissInputSource: 'explicit',
-    reasoning: usage.reasoning ?? 0,
-    total: usage.input + usage.output,
-    costUsd,
-    pricingSource: 'runtime',
-  };
-}
-
 async function writeEnvFile(path: string, env: Record<string, string>): Promise<void> {
   // dotenv KEY=VALUE lines. Values here are minted/scoped proxy tokens and URLs,
   // never the real provider key; the file is created 0600 and removed after run.
@@ -810,13 +765,6 @@ async function readTrialException(resultPath: string): Promise<string | null> {
   return message ? `${type}: ${message}` : type;
 }
 
-function isBudgetExhaustedTrialException(message: string): boolean {
-  return (
-    /^RuntimeError: Maka host cell exceeded \d+(?:\.\d+)?s$/.test(message) ||
-    /^AgentTimeoutError: Agent execution timed out after \d+(?:\.\d+)? seconds$/.test(message)
-  );
-}
-
 function providerTelemetryArtifactRefs(
   telemetry: readonly ProviderRequestTelemetry[],
   providerTelemetryPath: string,
@@ -840,21 +788,6 @@ function withProviderTelemetryArtifact(
   const enriched = new PierInfraError(error.message, error.detail, error.kind, artifactRefs);
   enriched.stack = error.stack;
   return enriched;
-}
-
-function mergeAgentEnv(
-  base: Record<string, string> | undefined,
-  attempt: Record<string, string> | undefined,
-): Record<string, string> | undefined {
-  if (!base && !attempt) return undefined;
-  return { ...(base ?? {}), ...(attempt ?? {}) };
-}
-
-function assertNoProviderSecretsInAgentEnv(agentEnv: Record<string, string> | undefined): void {
-  const forbidden = Object.keys(agentEnv ?? {}).filter((key) => isSensitiveEnvName(key));
-  if (forbidden.length > 0) {
-    throw new Error(`agentEnv must not contain provider secrets: ${forbidden.sort().join(', ')}`);
-  }
 }
 
 const defaultPierProcessRunner: PierProcessRunner = async (request) => {
@@ -883,19 +816,15 @@ const defaultPierProcessRunner: PierProcessRunner = async (request) => {
   }
 };
 
+// The generic helpers below (isExecFileTimeout .. isRecord) intentionally stay
+// local copies of their harbor-task-runner counterparts: they carry no
+// benchmark semantics, and exporting 3-line utilities would widen the Harbor
+// module's surface for no invariant. Everything with benchmark meaning is
+// imported from harbor-task-runner above.
 function isExecFileTimeout(error: unknown): boolean {
   if (typeof error !== 'object' || error === null) return false;
   const record = error as { killed?: unknown; signal?: unknown };
   return record.killed === true && record.signal === 'SIGKILL';
-}
-
-function isBudgetExhaustedError(error: unknown): error is FixedPromptBudgetExhaustedErrorType {
-  return (
-    error instanceof FixedPromptBudgetExhaustedError ||
-    (typeof error === 'object' &&
-      error !== null &&
-      (error as { name?: unknown }).name === 'FixedPromptBudgetExhaustedError')
-  );
 }
 
 async function readOptionalText(path: string): Promise<string | null> {

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -112,10 +112,10 @@ export interface PierTaskRunnerOptions {
   agentEnv?: Record<string, string>;
   /** Pier launcher (default "pier"). */
   pierBin?: string;
-  /** Pier environment type (default "docker"). */
+  /** Pier environment type (default "docker"). Unlike Harbor, Pier's
+   * EnvironmentConfig has no extra_docker_compose or platform field, so an
+   * explicit Docker target platform cannot be wired through `pier run`. */
   environment?: string;
-  /** Explicit Docker target platform shared by comparison arms. */
-  dockerPlatform?: 'linux/amd64';
   timeoutMultiplier?: number;
   /** Wall-clock ceiling for a single `pier run`; a hung Docker/Pier would
    * otherwise stall the unattended loop forever. Defaults to 45 minutes. */

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -1,8 +1,7 @@
-import { execFile } from 'node:child_process';
+import { spawn, type ChildProcess } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { chmod, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { basename, delimiter, join } from 'node:path';
-import { promisify } from 'node:util';
 import { PROVIDER_DEFAULTS, type ProviderType } from '@maka/core/llm-connections';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import { validateHarborCellOutput, type HarborCellOutput } from './cell-output.js';
@@ -40,8 +39,6 @@ import {
   type ProviderTokenUsage,
   type ProviderUpstreamCredentialResolver,
 } from './provider-auth-proxy.js';
-
-const execFileAsync = promisify(execFile);
 
 const CONTAINER_MAKA_REPO = '/opt/maka-agent';
 const TRIAL_CELL_OUTPUT = 'agent/maka-cell-output.json';
@@ -146,6 +143,9 @@ export interface PierRunRequest {
    * CliFlag env_fallback reads only os.environ), and MAKA_SYSTEM_PROMPT (byte-
    * exact; pier's --ae parser would strip its whitespace). */
   env?: Record<string, string>;
+  /** SIGTERM-to-SIGKILL grace once the watchdog fires (default 120s: pier's
+   * SIGTERM-triggered finally chain must finish docker compose teardown). */
+  terminationGraceMs?: number;
 }
 
 export interface PierRunResult {
@@ -790,42 +790,90 @@ function withProviderTelemetryArtifact(
   return enriched;
 }
 
-const defaultPierProcessRunner: PierProcessRunner = async (request) => {
-  try {
-    const { stdout, stderr } = await execFileAsync(request.pierBin, [...request.args], {
+/** Grace between SIGTERM and SIGKILL when the watchdog fires. Pier's SIGTERM
+ * handler (pier/cli/jobs.py:771 -> :148 raises KeyboardInterrupt) unwinds its
+ * Python finally chain, which owns docker compose teardown — containers need
+ * real time to stop and delete, so the grace must cover a compose down. */
+const DEFAULT_TERMINATION_GRACE_MS = 120_000;
+const MAX_CAPTURED_OUTPUT_BYTES = 64 * 1024 * 1024;
+
+/** Two-phase trial termination. A direct SIGKILL (execFile's timeout path)
+ * would skip every Python finally in pier — leaking docker compose containers
+ * — and, on the Maka host-cell arm, orphan the run-host-cell.mjs child, which
+ * would keep burning real tokens until its own cell deadline. Instead the
+ * child runs detached in its own process group; on timeout the whole group
+ * gets SIGTERM (triggering pier's own teardown — the teardown authority is
+ * pier's finally chain, never docker scanning here), then SIGKILL after the
+ * grace. Exported for the termination-contract tests. The Harbor runner shares
+ * this SIGKILL gap on main; its CLI's signal semantics are unverified, so that
+ * fix is deliberately out of this module's scope. */
+export const defaultPierProcessRunner: PierProcessRunner = async (request) => {
+  return await new Promise<PierRunResult>((resolvePromise) => {
+    const child = spawn(request.pierBin, [...request.args], {
       cwd: request.cwd,
-      maxBuffer: 64 * 1024 * 1024,
-      ...(request.timeoutMs !== undefined
-        ? { timeout: request.timeoutMs, killSignal: 'SIGKILL' as const }
-        : {}),
+      detached: true,
+      stdio: ['ignore', 'pipe', 'pipe'],
       ...(request.env ? { env: { ...process.env, ...request.env } } : {}),
     });
-    return { exitCode: 0, stdout, stderr };
-  } catch (error) {
-    const exitCode =
-      typeof (error as { code?: unknown }).code === 'number' ? (error as { code: number }).code : 1;
-    return {
-      exitCode,
-      stdout: String((error as { stdout?: unknown }).stdout ?? ''),
-      stderr: String((error as { stderr?: unknown }).stderr ?? '') || errorText(error),
-      timedOut: isExecFileTimeout(error),
-      ...(typeof (error as { signal?: unknown }).signal === 'string'
-        ? { signal: (error as { signal: string }).signal }
-        : {}),
-    };
-  }
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    let spawnError: Error | null = null;
+    let graceTimer: NodeJS.Timeout | undefined;
+    const watchdog =
+      request.timeoutMs !== undefined
+        ? setTimeout(() => {
+            timedOut = true;
+            killProcessGroup(child, 'SIGTERM');
+            graceTimer = setTimeout(
+              () => killProcessGroup(child, 'SIGKILL'),
+              request.terminationGraceMs ?? DEFAULT_TERMINATION_GRACE_MS,
+            );
+          }, request.timeoutMs)
+        : undefined;
+    child.stdout?.on('data', (chunk: Buffer) => {
+      if (stdout.length < MAX_CAPTURED_OUTPUT_BYTES) stdout += chunk.toString('utf8');
+    });
+    child.stderr?.on('data', (chunk: Buffer) => {
+      if (stderr.length < MAX_CAPTURED_OUTPUT_BYTES) stderr += chunk.toString('utf8');
+    });
+    child.once('error', (error) => {
+      spawnError = error;
+    });
+    child.once('close', (code, signal) => {
+      clearTimeout(watchdog);
+      clearTimeout(graceTimer);
+      resolvePromise({
+        exitCode: code ?? 1,
+        stdout,
+        stderr: stderr || (spawnError ? errorText(spawnError) : ''),
+        ...(timedOut ? { timedOut } : {}),
+        ...(signal ? { signal } : {}),
+      });
+    });
+  });
 };
 
-// The generic helpers below (isExecFileTimeout .. isRecord) intentionally stay
+function killProcessGroup(child: ChildProcess, signal: NodeJS.Signals): void {
+  if (child.pid === undefined) return;
+  try {
+    // Negative pid: signal the whole detached process group, so pier's own
+    // children (docker compose, the host cell) are reached too.
+    process.kill(-child.pid, signal);
+  } catch {
+    try {
+      child.kill(signal);
+    } catch {
+      // Already gone.
+    }
+  }
+}
+
+// The generic helpers below (readOptionalText .. isRecord) intentionally stay
 // local copies of their harbor-task-runner counterparts: they carry no
 // benchmark semantics, and exporting 3-line utilities would widen the Harbor
 // module's surface for no invariant. Everything with benchmark meaning is
 // imported from harbor-task-runner above.
-function isExecFileTimeout(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null) return false;
-  const record = error as { killed?: unknown; signal?: unknown };
-  return record.killed === true && record.signal === 'SIGKILL';
-}
 
 async function readOptionalText(path: string): Promise<string | null> {
   try {

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -1,6 +1,11 @@
 import { randomBytes, timingSafeEqual } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
-import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
+import {
+  createServer,
+  type IncomingMessage,
+  type Server as HttpServer,
+  type ServerResponse,
+} from 'node:http';
 import type { Socket } from 'node:net';
 
 export interface ProviderAuthProxy {
@@ -208,16 +213,7 @@ export async function startProviderAuthProxy(
     sockets.add(socket);
     socket.once('close', () => sockets.delete(socket));
   });
-  const listenPort = input.port ?? 0;
-  await new Promise<void>((resolve, reject) => {
-    server.once('error', (error) => {
-      reject(listenPort === 0 ? error : bindError(error, listenPort));
-    });
-    server.listen(listenPort, '0.0.0.0', () => {
-      server.off('error', reject);
-      resolve();
-    });
-  });
+  await listenProviderAuthProxyServer(server, input.port ?? 0);
   const address = server.address();
   if (!address || typeof address === 'string') {
     server.close();
@@ -626,6 +622,27 @@ function authorized(
   const presented = Buffer.from(value);
   const expected = Buffer.from(token);
   return presented.length === expected.length && timingSafeEqual(presented, expected);
+}
+
+/** Bind the proxy server, translating fixed-port failures via `bindError`.
+ * Exported only for the listener-pairing regression test: `once`/`off` must
+ * reference the SAME named handler so a successful listen removes it — a
+ * post-listen server socket error must then stay loud (uncaughtException),
+ * not be swallowed as a rejection of the already-settled bind promise. */
+export async function listenProviderAuthProxyServer(
+  server: HttpServer,
+  listenPort: number,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const onBindError = (error: unknown) => {
+      reject(listenPort === 0 ? error : bindError(error, listenPort));
+    };
+    server.once('error', onBindError);
+    server.listen(listenPort, '0.0.0.0', () => {
+      server.off('error', onBindError);
+      resolve();
+    });
+  });
 }
 
 function bindError(error: unknown, port: number): Error {

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -139,6 +139,11 @@ type ProviderAuthProxyInput = {
   advertisedHost?: string;
   authMode?: ProviderAuthProxyMode;
   usageProtocol?: ProviderUsageProtocol;
+  /** Fixed listen port. Defaults to an ephemeral port (0). Pier's Squid egress
+   * for offline tasks only permits destination ports 80/443, so a container
+   * reaching this proxy through Squid needs it bound to 80 or 443. Binding a
+   * privileged port can fail on Linux; callers get a clear error. */
+  port?: number;
   /** Injectable monotonic clock for deterministic tests. */
   now?: () => number;
 } & (
@@ -203,9 +208,12 @@ export async function startProviderAuthProxy(
     sockets.add(socket);
     socket.once('close', () => sockets.delete(socket));
   });
+  const listenPort = input.port ?? 0;
   await new Promise<void>((resolve, reject) => {
-    server.once('error', reject);
-    server.listen(0, '0.0.0.0', () => {
+    server.once('error', (error) => {
+      reject(listenPort === 0 ? error : bindError(error, listenPort));
+    });
+    server.listen(listenPort, '0.0.0.0', () => {
       server.off('error', reject);
       resolve();
     });
@@ -618,6 +626,21 @@ function authorized(
   const presented = Buffer.from(value);
   const expected = Buffer.from(token);
   return presented.length === expected.length && timingSafeEqual(presented, expected);
+}
+
+function bindError(error: unknown, port: number): Error {
+  const code = (error as { code?: unknown }).code;
+  const hint =
+    code === 'EACCES'
+      ? ` Binding privileged port ${port} was denied — run with the CAP_NET_BIND_SERVICE capability (or as root), lower net.ipv4.ip_unprivileged_port_start, or forward 80/443 to an unprivileged port. Pier's Squid egress for offline tasks only allows destination ports 80/443, so the container-facing proxy must present one of those.`
+      : code === 'EADDRINUSE'
+        ? ` Port ${port} is already in use; free it or choose the other of 80/443.`
+        : '';
+  const bound = new Error(
+    `provider auth proxy failed to bind port ${port}: ${error instanceof Error ? error.message : String(error)}.${hint}`,
+  );
+  if (typeof code === 'string') (bound as Error & { code?: string }).code = code;
+  return bound;
 }
 
 async function readRequestBody(request: IncomingMessage): Promise<Buffer> {


### PR DESCRIPTION
## Summary

Adds `createPierTaskRunner`, a `TaskRunner` implementation over Datacurve's Pier (the DeepSWE Harbor fork), plus the provider-proxy port control the offline Kimi arm needs. This is the runner half of the DeepSWE A/B in #1343; the adapters were made Pier-loadable in #1344.

`createPierTaskRunner` mirrors `createHarborTaskRunner` but drives Pier's CLI instead of a JobConfig file. Per task it spawns `pier run` with the maka repo bind-mounted read-only at `/opt/maka-agent`, then maps the trial dir back to `TaskRunOutput`. Three env facts drove the design, each verified against the pilot run under `~/.maka/eval/runs/deepswe-pilot-v1` and pier 0.3.0 source:

- **`--ae KEY=VALUE`** carries the non-secret agent identity/config (model, provider, pricing, cell timeout). Pier strips whitespace from `--ae` values, so nothing whitespace-sensitive may ride here.
- **The pier process env** carries `MAKA_BACKEND` (the adapter `CliFlag`'s `env_fallback` reads only `os.environ`, so `--ae MAKA_BACKEND=` is silently ignored) and `MAKA_SYSTEM_PROMPT` byte-exact — a trailing-newline prompt through `--ae` would be truncated by `value.strip()` and break the execution-identity hash round-trip on every task.
- **A `0600` `--env-file`** (removed after the run) carries proxy-minted secrets so they stay off argv.

Reward is read as one discriminated grading state (`readPierGrade`) from both persisted mirrors of Pier's scoring authority — the DeepSWE verifier's `verifier/reward.json` cross-checked against the trial's `verifier_result.rewards.reward`; mirrors that disagree, a reward file without a numeric reward field, the crash sentinel, and non-binary values are all `invalid` (infra on the graded read path). There is no Maka oracle verifier artifact, so the structured `harbor.verifier` outcome is constructed from the graded reward. Timeouts, trial `exception_info`, and budget exhaustion are classified so the fixed-prompt controller excludes infra from scoring and records budget exhaustion as a benchmark outcome. Cross-runner benchmark invariants are shared with the Harbor runner rather than copied: model-id normalization (`modelIdForProvider`), experiment-identity/pricing override rejection (`assertNoExperimentIdentityOverrides`), and timed-out trial artifact recovery (`readTimedOutTrialArtifacts`, so budget-exhausted samples keep their Pass@1 eligibility instead of shrinking the denominator as `missing_execution_identity`).

The Kimi arm runs the host provider auth proxy on a Squid-legal port and hands the container `MAKA_PROVIDER_PROXY_URL`/`TOKEN`. To support that, the proxy now accepts an explicit fixed listen port (default stays ephemeral); Pier's egress Squid for offline tasks only permits destination ports 80/443 (`acl Safe_ports port 80 443`), and a privileged/busy bind fails with a clear message. Because the default port is fixed, concurrent Kimi attempts on one runner are serialized with a per-runner queue — only for fixed-port binds; an explicit ephemeral port (0) cannot collide and runs concurrently (per-attempt telemetry attribution preserved; a pool over 80+443 is deferred). In every arm the real provider key stays host-side — passed only as a file path (`MAKA_HOST_API_KEY_FILE`) or held by the proxy, which mints a scoped token; the container never receives it.

On a watchdog timeout the runner terminates the detached pier process group with SIGTERM first — pier converts it to KeyboardInterrupt (`pier/cli/jobs.py`) and runs its finally-based docker teardown — escalating to SIGKILL only after a 120s grace, so a timeout does not leak trial containers or an orphaned host cell. The watchdog budget models pier's complete trial lifecycle: 2×build + agent setup (a fixed multiplier-scaled 360s, `pier/trial/trial.py:176`) + agent + 2×verifier, because pier retries environment start and verification once each (`pier/trial/execution.py:208`, `pier/trial/trial.py:333`); `environment.build_timeout_sec` now rides task metadata. The Maka arm also covers keyless providers (registry authKind `none`: ollama/lm-studio/localai) by running the host cell with `MAKA_HOST_NO_AUTH`, mirroring the Harbor runner's predicate, while backend `fake` keeps the inert in-container cell. And because a Pier `--mounts-json` run replaces the default log mounts while `capabilities.mounted` stays true (so pier's own log download never runs), both shared adapters compensate for host-side reachability of every in-container artifact they consume or promise: the maka adapter downloads `agent/runtime-events.jsonl` and `agent/trace-events.jsonl` alongside the cell output, and the Kimi adapter downloads its `kimi-code.jsonl` stream — the cell output's only in-container input — in `run()`'s finally so the AgentTimeoutError path hydrates too; each skips files already host-side under Harbor's bind mount.

Trial classification follows Harbor's authority order exactly: only a budget exhaustion without an authoritative grade becomes a budget_exhausted outcome, every other trial exception falls through to the normal reward/cell reads — a graded trial scores on its actual reward (e.g. a non-zero Kimi CLI exit the verifier still passed), and missing artifacts become infra with the trial exception attached as the root cause. A negative reward is never a grade: DeepSWE's `tests/test.sh` traps a verifier crash by writing `reward.txt=-1` (grader.py documents real rewards as binary 0/1), so on the graded read path the sentinel is infra instead of a scored failed sample. At the budget gate the precedence flips: the agent has already spent its budget, which is the authoritative fact, so an `invalid` grading authority (crashed/corrupt verifier, mismatched mirrors) is treated like ungraded — the sample stays budget_exhausted (no controller retry burning a second agent budget) with the grade detail carried in the diagnostics. `traceEventsPath` is always set, falling back to the runtime events like Harbor's `hostTraceEventsPath`, so downstream trace analysis never silently skips a Pier sample.

Scope is the two arms the issue exercises (Maka host-side + offline container, and Kimi Code) plus the inert `fake` backend; the wide Harbor surface (GitHub Copilot, OpenCode, Codex) is not reimplemented. A `dockerPlatform` option is deliberately absent: pier 0.3.0's `EnvironmentConfig` has no `extra_docker_compose`/platform field, so it cannot be wired. `fixed-prompt-controller.ts` is untouched, using the canonical `TaskRunner`/`TaskRunInput`/`TaskRunOutput` names so a concurrent rename lands without conflict.

## Verification

- `npm test -w @maka/headless` — 1265 tests, 1265 pass, 0 fail, 0 skipped (the pier venv is present locally, so even the pier harness-compat contract tests ran). New since the third round: a Kimi-adapter smoke lock for the Pier stream-json download (downloads under custom mounts, skips under Harbor's mount), graded-despite-exception and ungraded-exception-diagnostics tests for the fall-through classification, crash-sentinel tests for both reward sources, a trace-fallback test, a shared `findTrialDir` exception_stats parity test with pier-named diagnostics, and the watchdog contract updated to the full lifecycle including agent setup (2×1800 + 360 + 5400 + 2×1800 seconds + grace, ≥ 12,960,000 ms). New since the sixth round: mirror-agreement scoring, bidirectional mirror-mismatch → infra, reward.json-without-reward-field → infra, budget-gate precedence over the crash sentinel and over corrupt reward.json (→ budget_exhausted, not infra), and the Kimi advertised-host override.
- `npm run lint`, `npm run format:check` — clean.
- Live Pier + Docker fake trial (zero token, no API key), reusing the pilot's `maka-dasel-fake2` recipe through the real runner and CLI, with a prompt whose bytes end in a newline to lock the `--ae` stripping fix:

  ```
  E2E_OK reward=0 status=completed steps=1
  expectedHash=sha256:8fda3bb6d0fdae201777756ca3921089ec7c7762268fb79cff31916de22acc90
  identityHash=sha256:8fda3bb6d0fdae201777756ca3921089ec7c7762268fb79cff31916de22acc90
  IDENTITY_MATCH — prompt bytes (incl. trailing newline) round-tripped
  RUNTIME_EVENTS_PRESENT — host-side runtime-events.jsonl exists
  TRACE_EVENTS_PRESENT — traceEventsPath set and exists (combined trace or runtime-events fallback)
  ```

  Full chain passed (environment build, offline agent_setup, in-container fake cell, DeepSWE verifier), the cell's execution-identity hash matches the controller-side hash of the exact prompt bytes (confirming the fake backend still takes the in-container path with no `MAKA_HOST_*` wiring), the returned `runtimeEventsPath` exists host-side with the trial's real runtime events downloaded by the adapter, and `traceEventsPath` resolves through the runtime-events fallback to an existing file.

## Benchmark-semantics inventory (Harbor mapping layer -> Pier disposition)

Two independent review arms converged on the same root cause class: the Pier mapping layer re-deriving benchmark semantics that `harbor-task-runner` already owns authoritatively. This inventory enumerates every benchmark semantic carried by the Harbor mapping layer and pins the Pier runner's disposition, as the convergence evidence against a third round of the same defect class.

| Benchmark semantic | Pier disposition |
| --- | --- |
| Task-native wall-clock watchdog derivation | Reuse exported `resolveNativeTrialTimeoutMs` over a runner-supplied phase budget: Harbor supplies agent + oracle verifier outer seconds (byte-identical behavior); Pier supplies its complete lifecycle — 2×build + agent setup (fixed multiplier-scaled 360s, `pier/trial/trial.py:176`, `pier/trial/execution.py:129-143`) + agent + 2×verifier, because pier retries environment start and verification once each (`pier/trial/execution.py:208`, `pier/trial/trial.py:333`) — locked by a contract test against the DeepSWE task profile |
| Model id normalization | Reuse exported `modelIdForProvider` |
| Experiment identity/pricing override rejection | Reuse exported `assertNoExperimentIdentityOverrides` (identical key set) |
| Provider-secret rejection in agentEnv | Reuse exported `assertNoProviderSecretsInAgentEnv` |
| Timed-out trial artifact recovery (Pass@1 eligibility) | Reuse exported `readTimedOutTrialArtifacts` + `harborTraceMode` (same adapters write the same `agent/` layout) |
| Trial-exception classification and graded-trial reconciliation | Mirror Harbor's authority order + unit tests: only a budget exhaustion without an authoritative grade is budget_exhausted (gate: `graded` state + cell output present, since Pier has no oracle verifier artifact; an `invalid` grading authority does not overturn the spent budget and is treated like ungraded at this gate); every other exception falls through to the normal reads — graded trials score, missing artifacts become infra with the trial exception attached (Harbor's `readReward` diagnostics parity) |
| Structured verifier outcome authority | Reuse the `HarborVerifierOutcome` type; Pier constructs a single-attempt outcome from its grading authority (`verifier_result`/`reward.json`) since no oracle JSON exists |
| Verifier/reward agreement assertion | Mirror + unit tests — same invariant as Harbor's `assertVerifierRewardAgreement`, different artifact pair: Pier's two independently persisted mirrors of the grading authority (`verifier/reward.json` vs `result.json` `verifier_result.rewards.reward`) must be identical; `readPierGrade` classifies a disagreement (either direction) as `invalid` → infra on the graded read path, never a silently preferred score |
| `verifierFailureSummary` stdout heuristics | N/A for now — DeepSWE's verifier emits structured f2p/p2p rewards (and ctrf.json) rather than oracle-style assertion text; deferred until real-run failure triage needs it |
| Token/cost summary from proxy usage | Reuse exported `providerTokenSummary`; `PierTaskPricing` is an alias of `HarborTaskPricing` |
| Proxy auth mode / SSE usage protocol selection | Reuse exported `providerProxyAuthMode` / `providerProxyUsageProtocol` |
| Budget-exhaustion classification (trial exception patterns, error identity) | Reuse exported `isBudgetExhaustedTrialException` / `isBudgetExhaustedError` |
| Attempt-env overlay | Reuse exported `mergeAgentEnv` |
| Trace-events path resolution | Reuse exported `hostTraceEventsPath` + unit tests: `traceEventsPath` is always set — cell mode resolves the `agent/maka-storage/sessions/<sid>/runs/<rid>/events.jsonl` session trace via `cell.runtimeRefs` (the rich trace with `tool_failed`/`provider_request_captured`; the earlier pier simplification skipped this branch and silently emptied downstream failure attribution on the maka host-cell arm), task-run mode the combined `agent/trace-events.jsonl`, then the raw runtime events as last resort |
| Reward reading authority | Mirror + unit tests: one discriminated read (`readPierGrade`: graded / ungraded / invalid) over `verifier/reward.json` cross-checked with the trial `verifier_result.rewards.reward` mirror (Harbor reads `reward.txt` + oracle outcome JSON; layouts differ); the DeepSWE contract is enforced as exactly binary 0/1 (grader.py) — -1 is the `test.sh` EXIT-trap crash sentinel, any other value (e.g. 0.5, which `reward > 0` would otherwise score as a pass) can only be corrupt or non-contract verifier output, and a reward.json that exists without a numeric reward field is corrupt authority, all `invalid`: infra on the graded read path, treated like ungraded at the budget gate |
| Trial directory discovery | Reuse exported `findTrialDir`/`readResultTrialName` (parameterized by harness label + `InfraErrorCtor`): the `reward_stats` AND `exception_stats` trial-name hints plus the directory-name fallback are one implementation — the earlier pier fork had silently dropped the exception_stats branch, the exact drift class this inventory exists to prevent; parity locked by unit test |
| Identity/plumbing defenses (prompt hash, execution identity, zero-cost, missing usage) | N/A at runner level — owned by `fixed-prompt-controller`, shared by both runners; the runner's obligation is byte-exact pass-through of cell output and identity (locked by the live-trial IDENTITY_MATCH evidence and the controller-level test) |
| Infra error classification (thrown -> infra_failed / timed_out) | Kept separate as `PierInfraError` with the rationale in code: the controller classifies by behavior, never identity, and diagnostics must name the failing harness; the shared trial-mapping and telemetry-attachment helpers take an `InfraErrorCtor` so each runner throws its own type through one implementation |
| Timed-out process teardown | Pier-specific two-phase group termination (detached process group, SIGTERM → 120s grace → SIGKILL): teardown authority is pier's own finally-based docker cleanup, and SIGTERM is the channel that triggers it (SIGTERM → KeyboardInterrupt in `pier/cli/jobs.py`); the runner invents no docker-scanning logic |
| Keyless (authKind `none`) provider predicate | Reuse exported `providerRequiresSecret`; a backend `fake` gate keeps the inert in-container path unchanged (locked by unit tests plus the live fake-trial evidence) |
| Host-side reachability of in-container artifacts under custom mounts (the defect class: `--mounts-json` replaces pier's default log mounts while `capabilities.mounted` stays true, so pier's own log download never runs) | Both adapters compensate with guarded best-effort downloads that skip files already host-side under Harbor's bind mount: maka `_download_cell_output` fetches `runtime-events.jsonl` and `trace-events.jsonl` alongside the cell output; kimi `_download_agent_logs` fetches `kimi-code.jsonl` (the cell output's only in-container input) in `run()`'s finally so the AgentTimeoutError path hydrates too (adapter smoke tests for both adapters and both mount modes + live-trial file evidence) |
| Secrets channel (key never in container/argv) | Pier-specific by necessity (`--env-file` + process env vs Harbor's job-config `env`); locked by unit tests and the masked-config pilot evidence |
| Generic 3-line utilities (`tail`, `errorText`, `isRecord`, `sanitize`, optional readers) | Local copies under an explicit note — no benchmark semantics, exporting them widens Harbor's surface for no invariant |

## Scoring semantics inherited from the controller

One asymmetry surfaced in review is real but predates this PR and applies to both runners byte-identically: for a cell that crashed (`errorClass: 'infra_failed'`) the fixed-prompt controller excludes the sample via `isProviderInfraFailure` (`fixed-prompt-controller.ts:835,1196`, scored=false, out of the denominator) when the graded reward is 0, but scores it as passed via the `structuredVerifierPassed` override (`fixed-prompt-controller.ts:820,873-878`) when the graded reward is 1. This semantic was introduced on `main` in the #1211/#1313 era and is consumed identically by the Harbor and Pier runners — this PR's invariant is cross-runner parity, not the controller's scoring philosophy, so it is deliberately left unchanged here; revisiting the asymmetry itself is a separate controller issue. A cross-runner parity test now drives the controller with the Pier runner's real output and the canonical Harbor-shaped output for the same trial shape (graded reward 0 and 1, cell failed, `errorClass=infra_failed`) and asserts field-identical controller events, so neither runner can drift from the other on this shape.

## Known risk

The pinned Kimi CLI is Node/undici and does not honor a Pier-injected `HTTP_PROXY` by default, so whether the in-container model request actually reaches the host proxy through Squid can only be confirmed by the first real Kimi trial. If it does not, the Kimi arm's egress wiring needs a redesign. This is a recorded risk (also noted in code), not resolved here; the follow-up 30-task measurement in #1343 will surface it.

Two further deployment notes for the first real trial's gate checklist:

- Linux hosts: pier's Squid egress compose (`pier/environments/agent_setup.py:144-214`) adds no `extra_hosts` to its services, so inside the Squid container `host.docker.internal` only resolves under Docker Desktop's magic DNS (macOS/Windows). On a plain Linux docker host the Kimi arm's first proxied request would fail (Squid 503 on name resolution). The current benchmark host is macOS; a Linux deployment must pass `providerProxyAdvertisedHost` (the escape hatch added for exactly this — e.g. the docker bridge address `172.17.0.1`) and verify reachability on the first trial.
- Watchdog teardown leaves Exited(137) containers behind: SIGTERM triggers pier's shielded stop, which stops but does not always finish deleting the trial containers. Unattended long runs should include periodic docker hygiene (`docker container prune`) so stopped containers do not accumulate disk.





