### PR TITLE
feat(storage): establish kind-bound Headless execution authority

### DIFF
--- a/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import { tmpdir } from 'node:os';
+import { discoverMarkedStorageRoot } from '@maka/storage/root-authority';
 import {
   getE2eFixtureState,
   resolveE2eFixture,
@@ -318,6 +319,7 @@ describe('e2e-fixture mode', () => {
         credentialStore: fakeCredentialStore(),
         now: 1_700_000_000_000,
       });
+      assert.equal((await discoverMarkedStorageRoot({ path: workspaceRoot })).kind, 'interactive');
       assert.equal(getE2eFixtureState(fixture)?.activeSessionId, 'e2e-fixture-turn');
       const tasks = JSON.parse(await readFile(
         join(workspaceRoot, 'sessions', 'e2e-fixture-turn', 'tasks.json'),

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -1,5 +1,6 @@
 import { mkdir, rm } from 'node:fs/promises';
 import type { UiLocale, E2eFixtureScenario, E2eFixtureState } from '@maka/core';
+import { resolveStorageRoot } from '@maka/storage/root-authority';
 import type { CredentialStore } from './credential-store.js';
 import {
   ARTIFACT_SESSION_ID,
@@ -625,6 +626,7 @@ export async function seedE2eFixture(input: {
   const now = input.now ?? E2E_FIXTURE_NOW;
   await rm(input.workspaceRoot, { recursive: true, force: true });
   await mkdir(input.workspaceRoot, { recursive: true });
+  await resolveStorageRoot({ path: input.workspaceRoot, kind: 'interactive' });
   await writeSettings(input.workspaceRoot, input.fixture.scenario);
   if (input.fixture.scenario === 'first-run') return;
   await writeConnections(input.workspaceRoot, now, input.fixture.scenario);

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -70,6 +70,7 @@ import {
   createShellRunStore,
   createTelemetryRepo,
 } from '@maka/storage';
+import { resolveStorageRoot } from '@maka/storage/root-authority';
 import { McpClientManager } from '@maka/mcp';
 import { registerMcpIpcMain } from './mcp-ipc-main.js';
 import {
@@ -195,6 +196,7 @@ try {
   throw error;
 }
 const workspaceRoot = join(app.getPath('userData'), 'workspaces', e2eFixture?.workspaceName ?? 'default');
+await resolveStorageRoot({ path: workspaceRoot, kind: 'interactive' });
 // 保持系统唤醒 (settings.system.keepSystemAwake): holds an Electron
 // `powerSaveBlocker` so in-process scheduled tasks keep firing while the
 // machine would otherwise sleep. Injected with electron's blocker; the

--- a/package-lock.json
+++ b/package-lock.json
@@ -11038,7 +11038,8 @@
         "@maka/core": "0.1.0",
         "@maka/runtime": "0.1.0",
         "@maka/storage": "0.1.0",
-        "ai": "^7.0.31"
+        "ai": "^7.0.31",
+        "fs-native-extensions": "^1.5.0"
       },
       "bin": {
         "maka-headless": "dist/cli.js"

--- a/packages/cli/src/__tests__/cli.test.ts
+++ b/packages/cli/src/__tests__/cli.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { promisify } from 'node:util';
 import { describe, test } from 'node:test';
-import { createSessionStore } from '@maka/storage';
+import { createConnectionStore, createSessionStore } from '@maka/storage';
 import {
   parseMakaCliArgs,
   formatResumeHint,
@@ -15,6 +15,7 @@ import {
   resolveMakaCliExitCode,
   resolveTuiResumeTarget,
 } from '../cli.js';
+import { createMakaCliRuntimeContext } from '../runtime-bootstrap.js';
 
 const execFileAsync = promisify(execFile);
 const cliPath = new URL('../cli.js', import.meta.url).pathname;
@@ -196,17 +197,36 @@ describe('Maka CLI args', () => {
   test('inspects a Session through the executable entrypoint', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-cli-inspect-'));
     try {
-      const session = await createSessionStore(root).create({
-        cwd: '/tmp/workspace',
-        name: 'CLI inspect',
-        backend: 'fake',
-        llmConnectionSlug: 'fake',
-        model: 'fake-model',
-        permissionMode: 'ask',
+      const connections = createConnectionStore(root);
+      await connections.create({
+        slug: 'local',
+        name: 'Local',
+        providerType: 'ollama',
+        defaultModel: 'local-model',
       });
+      const context = await createMakaCliRuntimeContext({
+        surface: 'run',
+        workspaceRoot: root,
+        cwd: '/tmp/workspace',
+      });
+      let sessionId: string;
+      try {
+        sessionId = (
+          await context.runtime.createSession({
+            cwd: context.cwd,
+            name: 'CLI inspect',
+            backend: 'ai-sdk',
+            llmConnectionSlug: context.target.connection.slug,
+            model: context.target.model,
+            permissionMode: 'ask',
+          })
+        ).id;
+      } finally {
+        await context.close();
+      }
       const result = await runCliProcess(cliPath, [
         'inspect',
-        session.id,
+        sessionId,
         '--store',
         root,
         '--kind',

--- a/packages/cli/src/__tests__/inspect-command.test.ts
+++ b/packages/cli/src/__tests__/inspect-command.test.ts
@@ -1,15 +1,26 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, rm } from 'node:fs/promises';
+import { mkdir, mkdtemp, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { AgentRunHeader } from '@maka/core';
-import { createTaskRunStore } from '@maka/headless';
+import { createInMemoryTaskRunStore, runTaskOnce } from '@maka/headless';
 import { createAgentRunStore, createRuntimeEventStore, createSessionStore } from '@maka/storage';
+import {
+  openHeadlessExecutionStoresForWrite,
+  openInteractiveExecutionStoresForWrite,
+} from '@maka/storage/execution-stores';
+import {
+  createHeadlessRootLease,
+  resolveStorageRoot,
+  StorageRootAuthorityError,
+  tryAcquireInteractiveRootOwner,
+} from '@maka/storage/root-authority';
 import {
   inspectResolvedTarget,
   resolveInspectTarget,
-  type InspectCommandStores,
+  runMakaInspectCli,
+  withInspectCommandStores,
 } from '../inspect-command.js';
 
 describe('unified inspect target resolution', () => {
@@ -84,15 +95,165 @@ describe('unified inspect target resolution', () => {
   });
 });
 
-async function createSession(stores: InspectCommandStores, name: string) {
-  return stores.sessionStore.create({
+describe('inspect CLI storage authority boundary', () => {
+  test('inspects a marked headless root through authenticated readers', async () => {
+    await withDiskRoot('maka-inspect-headless-', async (root) => {
+      const capability = await resolveStorageRoot({ path: root, kind: 'headless' });
+      const stores = await openHeadlessExecutionStoresForWrite(
+        createHeadlessRootLease(capability, 'write'),
+      );
+      const session = await stores.sessionStore.create(sessionInput('Headless session'));
+      const sessionOutput = captureIo();
+
+      assert.equal(
+        await runMakaInspectCli([session.id, '--store', root, '--json'], sessionOutput.io),
+        0,
+      );
+      assert.equal(sessionOutput.stderr(), '');
+      assert.equal((JSON.parse(sessionOutput.stdout()) as { kind: string }).kind, 'session');
+
+      const taskRunId = 'headless-task-run';
+      const run = await runTaskOnce(
+        {
+          id: 'inspect-config',
+          backend: 'fake',
+          llmConnectionSlug: 'fake',
+          model: 'fake-model',
+        },
+        {
+          id: 'inspect-task',
+          instruction: 'Create an inspectable TaskRun.',
+          workspaceDir: root,
+          verification: { command: 'true', protectedPaths: [] },
+        },
+        { storageRoot: root, taskRunId },
+      );
+      assert.equal(run.projection.status, 'completed');
+
+      const taskOutput = captureIo();
+      assert.equal(
+        await runMakaInspectCli(
+          [taskRunId, '--store', root, '--kind', 'task-run', '--json'],
+          taskOutput.io,
+        ),
+        0,
+      );
+      assert.equal(taskOutput.stderr(), '');
+      assert.equal((JSON.parse(taskOutput.stdout()) as { kind: string }).kind, 'task_run');
+    });
+  });
+
+  test('inspects a marked interactive root without exposing TaskRun resolution', async () => {
+    await withDiskRoot('maka-inspect-interactive-', async (root) => {
+      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      const writer = await openInteractiveExecutionStoresForWrite(owner.lease);
+      const session = await writer.sessionStore.create(sessionInput('Interactive session'));
+      await owner.close();
+
+      await withInspectCommandStores(root, async (stores) => {
+        assert.equal(stores.taskRunStore, undefined);
+        const taskResolution = await resolveInspectTarget(stores, {
+          id: session.id,
+          requestedKind: 'task-run',
+        });
+        assert.equal(taskResolution.status, 'not_found');
+      });
+      const successor = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(successor);
+      await successor.close();
+
+      const output = captureIo();
+      assert.equal(await runMakaInspectCli([session.id, '--store', root, '--json'], output.io), 0);
+      assert.equal((JSON.parse(output.stdout()) as { kind: string }).kind, 'session');
+    });
+  });
+
+  test('rejects unmarked and invalid roots with typed authority errors', async () => {
+    await withDiskRoot('maka-inspect-unmarked-', async (root) => {
+      await assert.rejects(
+        () => withInspectCommandStores(root, async () => undefined),
+        authorityError('root_unmarked'),
+      );
+
+      const invalidRoot = join(root, 'not-a-directory');
+      await writeFile(invalidRoot, 'invalid\n');
+      await assert.rejects(
+        () => withInspectCommandStores(invalidRoot, async () => undefined),
+        authorityError('invalid_root'),
+      );
+    });
+  });
+
+  test('fails AgentRun inspection closed when root identity changes after resolution', async () => {
+    await withDiskRoot('maka-inspect-identity-', async (base) => {
+      const root = join(base, 'root');
+      const displaced = join(base, 'displaced-root');
+      await mkdir(root);
+      const capability = await resolveStorageRoot({ path: root, kind: 'headless' });
+      const writer = await openHeadlessExecutionStoresForWrite(
+        createHeadlessRootLease(capability, 'write'),
+      );
+      const session = await writer.sessionStore.create(sessionInput('Identity change'));
+      await writer.agentRunStore.createRun(runHeader(session.id, 'run-identity-change'));
+
+      await withInspectCommandStores(root, async (stores) => {
+        const resolution = await resolveInspectTarget(stores, {
+          id: 'run-identity-change',
+          requestedKind: 'agent-run',
+          sessionId: session.id,
+        });
+        assert.equal(resolution.status, 'resolved');
+        if (resolution.status !== 'resolved') return;
+
+        await rename(root, displaced);
+        await mkdir(root);
+        await assert.rejects(
+          () => inspectResolvedTarget(stores, resolution.candidate),
+          authorityError('root_identity_changed'),
+        );
+      });
+    });
+  });
+
+  test('fails closed with a typed error when the interactive reader lock is unavailable', async () => {
+    await withDiskRoot('maka-inspect-locked-', async (root) => {
+      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      try {
+        await assert.rejects(
+          () => withInspectCommandStores(root, async () => undefined),
+          authorityError('lock_failed'),
+        );
+      } finally {
+        await owner.close();
+      }
+    });
+  });
+});
+
+type InspectCommandTestStores = {
+  sessionStore: ReturnType<typeof createSessionStore>;
+  agentRunStore: ReturnType<typeof createAgentRunStore>;
+  runtimeEventStore: ReturnType<typeof createRuntimeEventStore>;
+  taskRunStore: ReturnType<typeof createInMemoryTaskRunStore>;
+};
+
+async function createSession(stores: InspectCommandTestStores, name: string) {
+  return stores.sessionStore.create(sessionInput(name));
+}
+
+function sessionInput(name: string) {
+  return {
     cwd: '/tmp/workspace',
     name,
     backend: 'fake',
     llmConnectionSlug: 'fake',
     model: 'fake-model',
     permissionMode: 'ask',
-  });
+  } as const;
 }
 
 function runHeader(sessionId: string, runId: string): AgentRunHeader {
@@ -112,16 +273,42 @@ function runHeader(sessionId: string, runId: string): AgentRunHeader {
   };
 }
 
-async function withStores(run: (stores: InspectCommandStores) => Promise<void>): Promise<void> {
+async function withStores(run: (stores: InspectCommandTestStores) => Promise<void>): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), 'maka-unified-inspect-'));
   try {
     await run({
       sessionStore: createSessionStore(root),
       agentRunStore: createAgentRunStore(root),
       runtimeEventStore: createRuntimeEventStore(root),
-      taskRunStore: createTaskRunStore(root),
+      taskRunStore: createInMemoryTaskRunStore(),
     });
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+}
+
+async function withDiskRoot(prefix: string, run: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function authorityError(code: StorageRootAuthorityError['code']) {
+  return (error: unknown) => error instanceof StorageRootAuthorityError && error.code === code;
+}
+
+function captureIo() {
+  const stdout: string[] = [];
+  const stderr: string[] = [];
+  return {
+    io: {
+      stdout: { write: (value: string) => stdout.push(value) },
+      stderr: { write: (value: string) => stderr.push(value) },
+    },
+    stdout: () => stdout.join(''),
+    stderr: () => stderr.join(''),
+  };
 }

--- a/packages/cli/src/__tests__/inspect-command.test.ts
+++ b/packages/cli/src/__tests__/inspect-command.test.ts
@@ -177,6 +177,11 @@ describe('inspect CLI storage authority boundary', () => {
         authorityError('root_unmarked'),
       );
 
+      const output = captureIo();
+      assert.equal(await runMakaInspectCli(['missing', '--store', root], output.io), 1);
+      assert.match(output.stderr(), /Initialize it through its owning Maka write command/);
+      assert.doesNotMatch(output.stderr(), /StorageRootAuthorityError|\n\s+at /);
+
       const invalidRoot = join(root, 'not-a-directory');
       await writeFile(invalidRoot, 'invalid\n');
       await assert.rejects(

--- a/packages/cli/src/inspect-command.ts
+++ b/packages/cli/src/inspect-command.ts
@@ -1,30 +1,37 @@
 import { resolve } from 'node:path';
 import type { AgentRunHeader, SessionHeader } from '@maka/core';
 import {
-  createTaskRunStore,
   inspectTaskRun,
+  openHeadlessStorageForRead,
   renderTaskRunInspectTree,
   type TaskRunInspectDocument,
-  type TaskRunStore,
+  type TaskRunReader,
 } from '@maka/headless';
 import {
   inspectAgentRunDocument,
   inspectSessionDocument,
   renderAgentRunInspectTree,
   renderSessionInspectTree,
+  type RuntimeEventInspectReader,
+  type SessionAgentRunInspectReader,
   type AgentRunInspectDocument,
   type SessionInspectDocument,
 } from '@maka/runtime';
 import {
-  createAgentRunStore,
-  createRuntimeEventStore,
-  createSessionStore,
-  type SessionStore,
-} from '@maka/storage';
-import type { AgentRunStore, RuntimeEventStore } from '@maka/core';
+  openInteractiveExecutionStoresForRead,
+  type ExecutionStoresReader,
+} from '@maka/storage/execution-stores';
+import {
+  discoverMarkedStorageRoot,
+  StorageRootAuthorityError,
+  tryAcquireInteractiveRootReader,
+} from '@maka/storage/root-authority';
 import { resolveMakaWorkspaceRoot } from './workspace-root.js';
 
 export const INSPECT_RESOLUTION_SCHEMA_VERSION = 'maka.inspect_resolution.v1' as const;
+
+const isStorageRootAuthorityError = (error: unknown): error is StorageRootAuthorityError =>
+  error instanceof StorageRootAuthorityError;
 
 export type InspectEntityKind = 'session' | 'agent-run' | 'task-run';
 
@@ -51,11 +58,16 @@ export type InspectDocument =
   | AgentRunInspectDocument
   | TaskRunInspectDocument;
 
+interface InspectSessionReader {
+  list(): Promise<readonly { id: string }[]>;
+  readHeader(id: string): Promise<SessionHeader>;
+}
+
 export interface InspectCommandStores {
-  sessionStore: SessionStore;
-  agentRunStore: AgentRunStore;
-  runtimeEventStore: RuntimeEventStore;
-  taskRunStore: TaskRunStore;
+  sessionStore: InspectSessionReader;
+  agentRunStore: SessionAgentRunInspectReader;
+  runtimeEventStore: RuntimeEventInspectReader;
+  taskRunStore?: TaskRunReader;
 }
 
 interface SessionCandidate extends InspectCandidateDescriptor {
@@ -127,6 +139,12 @@ export async function inspectResolvedTarget(
   candidate: InspectCandidate,
 ): Promise<InspectDocument> {
   if (candidate.kind === 'task-run') {
+    if (!stores.taskRunStore) {
+      throw new StorageRootAuthorityError(
+        'root_kind_mismatch',
+        'TaskRun inspection requires a headless storage root',
+      );
+    }
     return inspectTaskRun(
       {
         taskRunStore: stores.taskRunStore,
@@ -141,66 +159,118 @@ export async function inspectResolvedTarget(
       sessionId: candidate.sessionId,
       agentRunId: candidate.id,
       header: candidate.header,
+      isFatalReadError: isStorageRootAuthorityError,
     });
   }
   return inspectSessionDocument(
-    { readHeader: (id) => stores.sessionStore.readHeaderSnapshot(id) },
+    { readHeader: (id) => stores.sessionStore.readHeader(id) },
     stores.agentRunStore,
     stores.runtimeEventStore,
     candidate.id,
-    candidate.header,
+    {
+      header: candidate.header,
+      isFatalReadError: isStorageRootAuthorityError,
+    },
   );
 }
 
-export async function runMakaInspectCli(args: string[]): Promise<number> {
+export interface InspectCommandIo {
+  stdout: { write(value: string): unknown };
+  stderr: { write(value: string): unknown };
+}
+
+export async function runMakaInspectCli(
+  args: string[],
+  io: InspectCommandIo = process,
+): Promise<number> {
   let parsed: ParsedInspectArgs;
   try {
     parsed = parseInspectArgs(args);
   } catch (error) {
-    process.stderr.write(`${errorMessage(error)}\n\n${inspectUsage()}\n`);
+    io.stderr.write(`${errorMessage(error)}\n\n${inspectUsage()}\n`);
     return 2;
   }
   if (parsed.help) {
-    process.stdout.write(`${inspectUsage()}\n`);
+    io.stdout.write(`${inspectUsage()}\n`);
     return 0;
   }
   if (!parsed.id) {
-    process.stderr.write(`${inspectUsage()}\n`);
+    io.stderr.write(`${inspectUsage()}\n`);
     return 2;
   }
 
   const storageRoot = parsed.store ? resolve(parsed.store) : resolveMakaWorkspaceRoot();
-  const stores: InspectCommandStores = {
-    sessionStore: createSessionStore(storageRoot),
-    agentRunStore: createAgentRunStore(storageRoot),
-    runtimeEventStore: createRuntimeEventStore(storageRoot),
-    taskRunStore: createTaskRunStore(storageRoot),
-  };
-  const resolution = await resolveInspectTarget(stores, {
-    id: parsed.id,
-    ...(parsed.kind ? { requestedKind: parsed.kind } : {}),
-    ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
+  const result = await withInspectCommandStores(storageRoot, async (stores) => {
+    const resolution = await resolveInspectTarget(stores, {
+      id: parsed.id!,
+      ...(parsed.kind ? { requestedKind: parsed.kind } : {}),
+      ...(parsed.sessionId ? { sessionId: parsed.sessionId } : {}),
+    });
+    if (resolution.status !== 'resolved') return resolution;
+    return {
+      status: 'inspected' as const,
+      document: await inspectResolvedTarget(stores, resolution.candidate),
+    };
   });
-  if (resolution.status !== 'resolved') {
+  if (result.status !== 'inspected') {
     if (parsed.json) {
-      process.stdout.write(`${JSON.stringify(resolution.document, null, 2)}\n`);
+      io.stdout.write(`${JSON.stringify(result.document, null, 2)}\n`);
     } else {
-      process.stderr.write(`${renderResolutionFailure(resolution.document)}\n`);
+      io.stderr.write(`${renderResolutionFailure(result.document)}\n`);
     }
-    return resolution.status === 'ambiguous' ? 2 : 1;
+    return result.status === 'ambiguous' ? 2 : 1;
   }
 
-  const document = await inspectResolvedTarget(stores, resolution.candidate);
+  const document = result.document;
   if (parsed.json) {
-    process.stdout.write(`${JSON.stringify(document, null, 2)}\n`);
+    io.stdout.write(`${JSON.stringify(document, null, 2)}\n`);
   } else if (document.kind === 'task_run') {
-    process.stdout.write(renderTaskRunInspectTree(document));
+    io.stdout.write(renderTaskRunInspectTree(document));
   } else if (document.kind === 'agent_run') {
-    process.stdout.write(renderAgentRunInspectTree(document));
+    io.stdout.write(renderAgentRunInspectTree(document));
   } else {
-    process.stdout.write(renderSessionInspectTree(document));
+    io.stdout.write(renderSessionInspectTree(document));
   }
   return 0;
+}
+
+export async function withInspectCommandStores<T>(
+  storageRoot: string,
+  operation: (stores: InspectCommandStores) => Promise<T>,
+): Promise<T> {
+  const capability = await discoverMarkedStorageRoot({ path: storageRoot });
+  if (capability.kind === 'headless') {
+    const storage = await openHeadlessStorageForRead(capability);
+    return operation(
+      inspectStoresFromExecutionReader(storage.executionStores, storage.taskRunStore),
+    );
+  }
+
+  const reader = await tryAcquireInteractiveRootReader(capability);
+  if (!reader) {
+    throw new StorageRootAuthorityError(
+      'lock_failed',
+      `Interactive storage root is exclusively locked: ${capability.canonicalPath}`,
+    );
+  }
+  try {
+    const executionStores = await openInteractiveExecutionStoresForRead(reader.lease);
+    return await operation(inspectStoresFromExecutionReader(executionStores));
+  } finally {
+    await reader.close();
+  }
+}
+
+function inspectStoresFromExecutionReader(
+  stores: ExecutionStoresReader<'headless' | 'interactive'>,
+  taskRunStore?: TaskRunReader,
+): InspectCommandStores {
+  return {
+    sessionStore: stores.sessionStore,
+    agentRunStore: stores.agentRunStore,
+    runtimeEventStore: stores.runtimeEventStore,
+    ...(taskRunStore ? { taskRunStore } : {}),
+  };
 }
 
 interface ParsedInspectArgs {
@@ -257,13 +327,20 @@ function isInspectEntityKind(value: string): value is InspectEntityKind {
   return value === 'session' || value === 'agent-run' || value === 'task-run';
 }
 
-async function findSessionCandidates(store: SessionStore, id: string): Promise<SessionCandidate[]> {
+async function findSessionCandidates(
+  store: InspectSessionReader,
+  id: string,
+): Promise<SessionCandidate[]> {
   const summaries = await store.list();
   if (!summaries.some((session) => session.id === id)) return [];
-  return [{ kind: 'session', id, header: await store.readHeaderSnapshot(id) }];
+  return [{ kind: 'session', id, header: await store.readHeader(id) }];
 }
 
-async function findTaskRunCandidates(store: TaskRunStore, id: string): Promise<TaskRunCandidate[]> {
+async function findTaskRunCandidates(
+  store: TaskRunReader | undefined,
+  id: string,
+): Promise<TaskRunCandidate[]> {
+  if (!store) return [];
   const records = await store.readEventRecords(id);
   return records.length > 0 ? [{ kind: 'task-run', id }] : [];
 }

--- a/packages/cli/src/inspect-command.ts
+++ b/packages/cli/src/inspect-command.ts
@@ -211,7 +211,14 @@ export async function runMakaInspectCli(
       status: 'inspected' as const,
       document: await inspectResolvedTarget(stores, resolution.candidate),
     };
+  }).catch((error: unknown) => {
+    if (!isStorageRootAuthorityError(error)) throw error;
+    io.stderr.write(
+      `maka inspect: ${formatInspectAuthorityError(error, parsed.store === undefined)}\n`,
+    );
+    return undefined;
   });
+  if (result === undefined) return 1;
   if (result.status !== 'inspected') {
     if (parsed.json) {
       io.stdout.write(`${JSON.stringify(result.document, null, 2)}\n`);
@@ -409,4 +416,14 @@ function isNotFound(error: unknown): boolean {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+function formatInspectAuthorityError(
+  error: StorageRootAuthorityError,
+  usesDefaultWorkspace: boolean,
+): string {
+  if (error.code !== 'root_unmarked') return error.message;
+  return usesDefaultWorkspace
+    ? `${error.message}. Open Maka Desktop or the TUI once to initialize this workspace, then retry`
+    : `${error.message}. Initialize it through its owning Maka write command, or pass the correct --store root`;
 }

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -67,6 +67,7 @@ import {
   type ForeignSessionStore,
   persistProviderRequestCaptureArtifact,
 } from '@maka/storage';
+import { resolveStorageRoot } from '@maka/storage/root-authority';
 import type { ToolPermissionRule } from '@maka/core/permission';
 import { fetchProviderModels } from '@maka/runtime';
 import { createApiKeyOnboardingSurface, type MakaOnboardingSurface } from './onboarding.js';
@@ -169,6 +170,7 @@ export function isMakaClaudeSubscriptionCloakEnabled(
 export async function createMakaCliRuntimeContext(
   input: CreateMakaCliRuntimeContextInput,
 ): Promise<MakaCliRuntimeContext> {
+  await resolveStorageRoot({ path: input.workspaceRoot, kind: 'interactive' });
   const store = createSessionStore(input.workspaceRoot);
   const runStore = createAgentRunStore(input.workspaceRoot);
   const runtimePersistence = await openRuntimeEventPersistence({

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -70,6 +70,7 @@
     "@maka/core": "0.1.0",
     "@maka/runtime": "0.1.0",
     "@maka/storage": "0.1.0",
-    "ai": "^7.0.31"
+    "ai": "^7.0.31",
+    "fs-native-extensions": "^1.5.0"
   }
 }

--- a/packages/headless/src/__tests__/ahe-evidence-export.test.ts
+++ b/packages/headless/src/__tests__/ahe-evidence-export.test.ts
@@ -16,7 +16,8 @@ import {
 import type { MakaAheTargetComponent } from '../ahe-target-protocol.js';
 import type { ScoreResult, TaskEvent } from '../task-contracts.js';
 import { taskAttemptExecutionEvidence } from '../task-execution-lineage.js';
-import { projectTaskRun } from '../task-run-store.js';
+import { taskRunLocator } from '../task-run-identity.js';
+import { projectTaskRun } from '../task-run-projection.js';
 
 describe('AHE evidence export', () => {
   test('builds a deterministic target snapshot after validating repo source refs', async () => {
@@ -202,21 +203,16 @@ describe('AHE evidence export', () => {
     assert.equal(evidence.harnessResults.results[1]?.scoreAuthority, 'official_scorer');
     assert.equal(evidence.harnessResults.results[0]?.schemaVersion, 'maka.ahe.run_result.v1');
     assert.equal(evidence.harnessResults.results[0]?.taskRunId, 'run-self-check');
+    const traceRoot = `traces/${taskRunLocator('run-self-check')}`;
     assert.equal(
       evidence.harnessResults.results[0]?.executionLineageRef.ref,
-      'traces/run-self-check/execution-lineage.json',
+      `${traceRoot}/execution-lineage.json`,
     );
-    assert.equal(
-      evidence.traceIndex.entries[0]?.transcript?.ref,
-      'traces/run-self-check/result.md',
-    );
-    assert.equal(
-      evidence.traceIndex.entries[0]?.messages?.ref,
-      'traces/run-self-check/messages.json',
-    );
+    assert.equal(evidence.traceIndex.entries[0]?.transcript?.ref, `${traceRoot}/result.md`);
+    assert.equal(evidence.traceIndex.entries[0]?.messages?.ref, `${traceRoot}/messages.json`);
     assert.equal(
       evidence.traceIndex.entries[0]?.taskEventsJsonl?.ref,
-      'traces/run-self-check/task-events.jsonl',
+      `${traceRoot}/task-events.jsonl`,
     );
     assert.equal(evidence.traceIndex.entries[0]?.runtimeEventsJsonl, undefined);
   });
@@ -271,9 +267,10 @@ describe('AHE evidence export', () => {
 
       assert.equal(evidence.harnessResults.results[0]?.status, 'official_pass');
       assert.equal(evidence.harnessResults.results[0]?.scoreAuthority, 'official_scorer');
+      const traceRoot = `traces/${taskRunLocator('run-harbor')}`;
       assert.equal(
         evidence.harnessResults.results[0]?.verifierRef?.ref,
-        'traces/run-harbor/official-harbor-result.json',
+        `${traceRoot}/official-harbor-result.json`,
       );
       assert.match(
         evidence.traceIndex.entries[0]?.artifacts?.[0]?.ref ?? '',
@@ -402,29 +399,21 @@ describe('AHE evidence export', () => {
         },
       });
 
-      const lineageText = await readFile(
-        join(out, 'traces', 'run-safe', 'execution-lineage.json'),
-        'utf8',
-      );
+      const traceRoot = join(out, 'traces', taskRunLocator('run-safe'));
+      const lineageText = await readFile(join(traceRoot, 'execution-lineage.json'), 'utf8');
       assert.match(lineageText, /"rawRuntimeEvents": "omitted_by_policy"/);
       assert.doesNotMatch(lineageText, /PRIVATE_RUNTIME_PAYLOAD/);
       assert.match(
-        await readFile(
-          join(out, 'traces', 'run-safe', 'agent-runs', 'agent-run-1', 'inspect.json'),
-          'utf8',
-        ),
+        await readFile(join(traceRoot, 'agent-runs', 'agent-run-1', 'inspect.json'), 'utf8'),
         /maka.agent_run_inspect.v1/,
       );
       await assert.rejects(
         () =>
-          readFile(
-            join(out, 'traces', 'run-safe', 'agent-runs', 'agent-run-1', 'runtime-events.jsonl'),
-            'utf8',
-          ),
+          readFile(join(traceRoot, 'agent-runs', 'agent-run-1', 'runtime-events.jsonl'), 'utf8'),
         /ENOENT/,
       );
       assert.match(
-        await readFile(join(out, 'traces', 'run-safe', 'task-events.jsonl'), 'utf8'),
+        await readFile(join(traceRoot, 'task-events.jsonl'), 'utf8'),
         /task_attempt_execution_linked/,
       );
     } finally {
@@ -476,18 +465,14 @@ describe('AHE evidence export', () => {
         },
       });
 
-      const lineage = JSON.parse(
-        await readFile(join(out, 'traces', 'run-gap', 'execution-lineage.json'), 'utf8'),
-      );
+      const traceRoot = join(out, 'traces', taskRunLocator('run-gap'));
+      const lineage = JSON.parse(await readFile(join(traceRoot, 'execution-lineage.json'), 'utf8'));
       assert.equal(lineage.attempts.length, 0);
       assert.equal(lineage.gaps[0].code, 'attempt_execution_missing');
       assert.equal(lineage.rawRuntimeEvents, 'requested_with_gaps');
       await assert.rejects(
         () =>
-          readFile(
-            join(out, 'traces', 'run-gap', 'agent-runs', 'agent-run-1', 'runtime-events.jsonl'),
-            'utf8',
-          ),
+          readFile(join(traceRoot, 'agent-runs', 'agent-run-1', 'runtime-events.jsonl'), 'utf8'),
         /ENOENT/,
       );
     } finally {
@@ -683,35 +668,39 @@ describe('AHE evidence export', () => {
 
       assert.equal(firstHarness, await readFile(second.files.harnessResultsJson, 'utf8'));
       const parsedHarness = JSON.parse(firstHarness);
+      const traceLocator = taskRunLocator('run-official');
+      const traceRefRoot = `traces/${traceLocator}`;
+      const traceRoot = join(out, 'traces', traceLocator);
       assert.equal(parsedHarness.results[0].status, 'official_fail');
       assert.equal(parsedHarness.results[0].taskRunId, 'run-official');
-      assert.equal(parsedHarness.results[0].traceRef.ref, 'traces/run-official/task-run.json');
+      assert.equal(parsedHarness.results[0].traceRef.ref, `${traceRefRoot}/task-run.json`);
       assert.match(parsedHarness.results[0].traceRef.digest, /^sha256:/);
       assert.match(parsedHarness.results[0].executionLineageRef.digest, /^sha256:/);
       assert.match(parsedHarness.traceIndexRef.digest, /^sha256:/);
       const traceIndexJson = await readFile(join(out, 'trace-index.json'), 'utf8');
-      assert.match(traceIndexJson, /traces\/run-official\/result.md/);
-      assert.match(traceIndexJson, /traces\/run-official\/task-events.jsonl/);
-      assert.match(traceIndexJson, /traces\/run-official\/execution-lineage.json/);
-      assert.match(traceIndexJson, /traces\/run-official\/agent-runs\/agent-run-1\/inspect.json/);
+      assert.match(traceIndexJson, new RegExp(`${traceRefRoot}/result\\.md`));
+      assert.match(traceIndexJson, new RegExp(`${traceRefRoot}/task-events\\.jsonl`));
+      assert.match(traceIndexJson, new RegExp(`${traceRefRoot}/execution-lineage\\.json`));
       assert.match(
         traceIndexJson,
-        /traces\/run-official\/agent-runs\/agent-run-1\/runtime-events.jsonl/,
+        new RegExp(`${traceRefRoot}/agent-runs/agent-run-1/inspect\\.json`),
+      );
+      assert.match(
+        traceIndexJson,
+        new RegExp(`${traceRefRoot}/agent-runs/agent-run-1/runtime-events\\.jsonl`),
       );
       assert.doesNotMatch(traceIndexJson, /"runtimeEventsJsonl"/);
-      assert.match(traceIndexJson, /traces\/run-official\/messages.json/);
-      assert.match(traceIndexJson, /traces\/run-official\/failure-digest.json/);
+      assert.match(traceIndexJson, new RegExp(`${traceRefRoot}/messages\\.json`));
+      assert.match(traceIndexJson, new RegExp(`${traceRefRoot}/failure-digest\\.json`));
       assert.match(
-        await readFile(join(out, 'traces', 'run-official', 'task-run.json'), 'utf8'),
+        await readFile(join(traceRoot, 'task-run.json'), 'utf8'),
         /maka.task_run_export.v1/,
       );
       assert.match(
-        await readFile(join(out, 'traces', 'run-official', 'task-events.jsonl'), 'utf8'),
+        await readFile(join(traceRoot, 'task-events.jsonl'), 'utf8'),
         /task_run_created/,
       );
-      const lineage = JSON.parse(
-        await readFile(join(out, 'traces', 'run-official', 'execution-lineage.json'), 'utf8'),
-      );
+      const lineage = JSON.parse(await readFile(join(traceRoot, 'execution-lineage.json'), 'utf8'));
       assert.equal(lineage.schemaVersion, 'maka.ahe.execution_lineage.v1');
       assert.equal(lineage.target.snapshotId, snapshot.snapshotId);
       assert.equal(lineage.task.taskRunId, 'run-official');
@@ -726,13 +715,13 @@ describe('AHE evidence export', () => {
       assert.deepEqual(lineage.gaps, []);
       assert.match(
         await readFile(
-          join(out, 'traces', 'run-official', 'agent-runs', 'agent-run-1', 'runtime-events.jsonl'),
+          join(traceRoot, 'agent-runs', 'agent-run-1', 'runtime-events.jsonl'),
           'utf8',
         ),
         /RAW_RUNTIME_PAYLOAD/,
       );
       const failureDigest = JSON.parse(
-        await readFile(join(out, 'traces', 'run-official', 'failure-digest.json'), 'utf8'),
+        await readFile(join(traceRoot, 'failure-digest.json'), 'utf8'),
       );
       assert.equal(failureDigest.schemaVersion, 'maka.ahe.failure_digest.v1');
       assert.equal(failureDigest.status, 'official_fail');
@@ -770,9 +759,7 @@ describe('AHE evidence export', () => {
       assert.ok(
         failureDigest.selfCheck.selfCheckPlan.audit.riskFlags.includes('unplanned_added_path'),
       );
-      const taskRunExport = JSON.parse(
-        await readFile(join(out, 'traces', 'run-official', 'task-run.json'), 'utf8'),
-      );
+      const taskRunExport = JSON.parse(await readFile(join(traceRoot, 'task-run.json'), 'utf8'));
       assert.equal(taskRunExport.progress.selfCheckPlans.latest.planId, 'plan-1');
       assert.equal(taskRunExport.progress.selfCheckPlans.audit.status, 'fail');
       assert.equal(taskRunExport.heavyTask.selfCheckPlan.audit.status, 'fail');
@@ -782,15 +769,13 @@ describe('AHE evidence export', () => {
         /uncleaned workspace side effects/,
       );
       assert.match(failureDigest.officialHarbor.verifier.stdoutExcerpt, /expected move e2e4/);
-      assert.equal(failureDigest.debugRefs.messages.ref, 'traces/run-official/messages.json');
+      assert.equal(failureDigest.debugRefs.messages.ref, `${traceRefRoot}/messages.json`);
       assert.equal(
         failureDigest.debugRefs.taskEventsJsonl.ref,
-        'traces/run-official/task-events.jsonl',
+        `${traceRefRoot}/task-events.jsonl`,
       );
       assert.equal(failureDigest.debugRefs.runtimeEventSources.length, 1);
-      const messages = JSON.parse(
-        await readFile(join(out, 'traces', 'run-official', 'messages.json'), 'utf8'),
-      );
+      const messages = JSON.parse(await readFile(join(traceRoot, 'messages.json'), 'utf8'));
       assert.equal(messages.trace_id, 'run-official');
       assert.equal(messages.messages[0].role, 'system');
       assert.equal(messages.messages[1].role, 'user');

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -8,7 +8,10 @@ import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
 import { validateHarborCellOutput } from '../cell-output.js';
 import { mapLegacyMakaHeadlessArgs } from '../cli.js';
+import { openHeadlessStorageForWrite } from '../headless-storage.js';
 import { readResults } from '../results.js';
+import type { TaskEvent } from '../task-contracts.js';
+import { taskRunLocator } from '../task-run-identity.js';
 
 const cliPath = fileURLToPath(new URL('../cli.js', import.meta.url));
 const repoRoot = fileURLToPath(new URL('../../../../', import.meta.url));
@@ -270,6 +273,15 @@ describe('maka-headless CLI', () => {
         source: 'benchmark.deadline',
         mode: 'immediate',
       });
+      assert.ok(cell.runtimeRefs);
+
+      const storage = await openHeadlessStorageForWrite(storageRoot);
+      const runs = await storage.executionStores.agentRunStore.listSessionRuns(
+        cell.runtimeRefs.sessionId,
+      );
+      assert.equal(runs.length, 1);
+      assert.equal(cell.runtimeRefs.runId, runs[0]?.runId);
+      assert.equal(cell.runtimeRefs.invocationId, runs[0]?.invocationId);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -339,9 +351,8 @@ describe('maka-headless CLI', () => {
       );
       assert.deepEqual(durableIdentity, cell.executionIdentity);
 
-      const taskRunJson = JSON.parse(
-        await readFile(join(outDir, 'exports', 'harbor-run-1', 'task-run.json'), 'utf8'),
-      );
+      const harborExport = join(outDir, 'exports', taskRunLocator('harbor-run-1'));
+      const taskRunJson = JSON.parse(await readFile(join(harborExport, 'task-run.json'), 'utf8'));
       assert.equal(taskRunJson.policy.economyTask.enabled, true);
       assert.equal(taskRunJson.policy.economyTask.triggerSource, 'config');
       assert.equal(taskRunJson.verifier.kind, 'terminal_bench');
@@ -350,18 +361,12 @@ describe('maka-headless CLI', () => {
       assert.equal(taskRunJson.verifier.benchmark.pendingExternalHarborVerifier, true);
       assert.equal(taskRunJson.verifier.authority.authoritative, false);
       assert.equal(taskRunJson.verifier.authority.label, 'external Harbor verifier pending');
-      const events = await readFile(
-        join(outDir, 'exports', 'harbor-run-1', 'events.jsonl'),
-        'utf8',
-      );
+      const events = await readFile(join(harborExport, 'events.jsonl'), 'utf8');
       assert.doesNotMatch(events, /"testCommand":"false"/);
       assert.doesNotMatch(events, /"placeholder":true/);
       assert.doesNotMatch(events, /verificationPlaceholder/);
       assert.doesNotMatch(events, /unsupported local benchmark placeholder/);
-      const resultJson = await readFile(
-        join(outDir, 'exports', 'harbor-run-1', 'result.json'),
-        'utf8',
-      );
+      const resultJson = await readFile(join(harborExport, 'result.json'), 'utf8');
       assert.doesNotMatch(resultJson, /verificationPlaceholder/);
       assert.doesNotMatch(resultJson, /unsupported local benchmark placeholder/);
     } finally {
@@ -461,7 +466,7 @@ describe('maka-headless CLI', () => {
 
       const taskRunJson = JSON.parse(
         await readFile(
-          join(outDir, 'exports', 'harbor-run-custom-dataset', 'task-run.json'),
+          join(outDir, 'exports', taskRunLocator('harbor-run-custom-dataset'), 'task-run.json'),
           'utf8',
         ),
       );
@@ -505,7 +510,10 @@ describe('maka-headless CLI', () => {
       assert.equal(result.code, 0, result.stderr);
 
       const taskRunJson = JSON.parse(
-        await readFile(join(outDir, 'exports', 'harbor-remote-run-1', 'task-run.json'), 'utf8'),
+        await readFile(
+          join(outDir, 'exports', taskRunLocator('harbor-remote-run-1'), 'task-run.json'),
+          'utf8',
+        ),
       );
       assert.match(taskRunJson.workspace.lease.sourceWorkspaceDir, /host-workspace-source$/);
       assert.notEqual(taskRunJson.workspace.lease.sourceWorkspaceDir, '/app');
@@ -569,7 +577,7 @@ describe('maka-headless CLI', () => {
     }
   });
 
-  test('task run, inspect, and export operate on task-run store projections', async () => {
+  test('task run, inspect, and exports tolerate unavailable optional Session evidence', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'maka-headless-task-cli-'));
     try {
       await mkdir(join(dir, 'fixture'), { recursive: true });
@@ -662,6 +670,10 @@ describe('maka-headless CLI', () => {
         /verifier_result_recorded/,
       );
 
+      const sessionId = inspectDocument.attempts[0]?.agentRuns[0]?.identity?.sessionId;
+      assert.equal(typeof sessionId, 'string');
+      await rm(join(outDir, 'runs', 'sessions', sessionId, 'session.jsonl'), { force: true });
+
       const aheExportDir = join(dir, 'ahe-export');
       const aheExported = await runCli([
         'ahe',
@@ -685,12 +697,13 @@ describe('maka-headless CLI', () => {
       assert.equal(aheResults.results[0].taskRunId, 'task-run-1');
       assert.match(aheResults.results[0].executionLineageRef.digest, /^sha256:/);
       const aheTraceIndex = await readFile(join(aheExportDir, 'trace-index.json'), 'utf8');
-      assert.match(aheTraceIndex, /traces\/task-run-1\/result.md/);
+      const traceLocator = taskRunLocator('task-run-1');
+      assert.match(aheTraceIndex, new RegExp(`traces/${traceLocator}/result\\.md`));
       assert.match(aheTraceIndex, /task-events.jsonl/);
       assert.doesNotMatch(aheTraceIndex, /"runtimeEventsJsonl"/);
       const aheLineage = JSON.parse(
         await readFile(
-          join(aheExportDir, 'traces', 'task-run-1', 'execution-lineage.json'),
+          join(aheExportDir, 'traces', traceLocator, 'execution-lineage.json'),
           'utf8',
         ),
       );
@@ -718,6 +731,79 @@ describe('maka-headless CLI', () => {
         ),
         /"runId"/,
       );
+      const aheMessages = JSON.parse(
+        await readFile(join(aheExportDir, 'traces', traceLocator, 'messages.json'), 'utf8'),
+      );
+      assert.deepEqual(
+        aheMessages.messages.map((message: { role: string }) => message.role),
+        ['system', 'user', 'assistant'],
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('preserves a long TaskRun identity across run, inspect, result, and export', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-headless-long-task-run-'));
+    try {
+      await mkdir(join(dir, 'fixture'), { recursive: true });
+      await writeFile(join(dir, 'fixture', 'marker.txt'), 'ok', 'utf8');
+      const spec = {
+        configs: [
+          { id: 'fake-cfg', backend: 'fake', llmConnectionSlug: 'fake', model: 'fake-model' },
+        ],
+        tasks: [
+          {
+            id: 'long-id-task',
+            instruction: 'complete the task',
+            workspaceDir: 'fixture',
+            verification: { command: 'test -f marker.txt', protectedPaths: [] },
+          },
+        ],
+      };
+      const specPath = join(dir, 'spec.json');
+      const outDir = join(dir, 'out');
+      const taskRunId = `long-task-run-${'x'.repeat(320)}`;
+      await writeFile(specPath, JSON.stringify(spec), 'utf8');
+
+      const run = await runCli([
+        'task',
+        'run',
+        specPath,
+        '--task',
+        'long-id-task',
+        '--config',
+        'fake-cfg',
+        '--task-run-id',
+        taskRunId,
+        '--out',
+        outDir,
+        '--include-events',
+      ]);
+      assert.equal(run.code, 0, run.stderr);
+
+      const inspect = await runCli([
+        'task',
+        'inspect',
+        taskRunId,
+        '--store',
+        join(outDir, 'runs'),
+        '--json',
+      ]);
+      assert.equal(inspect.code, 0, inspect.stderr);
+      const inspectDocument = JSON.parse(inspect.stdout);
+      assert.equal(inspectDocument.taskRun.taskRunId, taskRunId);
+      assert.equal(inspectDocument.taskRun.result.taxonomy, 'passed');
+
+      const records = await readResults(join(outDir, 'results.jsonl'));
+      assert.equal(records.length, 1);
+      assert.equal(records[0]?.passed, true);
+
+      const exportRoot = join(outDir, 'exports', taskRunLocator(taskRunId));
+      const exported = JSON.parse(await readFile(join(exportRoot, 'task-run.json'), 'utf8'));
+      assert.equal(exported.taskRun.taskRunId, taskRunId);
+      assert.equal(exported.taskRun.result.taxonomy, 'passed');
+      assert.match(await readFile(join(exportRoot, 'events.jsonl'), 'utf8'), /task_run_completed/);
     } finally {
       await rm(dir, { recursive: true, force: true });
     }
@@ -746,68 +832,64 @@ describe('maka-headless CLI', () => {
       const taskRunId = 'parked-run';
       const firstAttemptId = `${taskRunId}-attempt-1`;
       await writeFile(specPath, JSON.stringify(spec), 'utf8');
-      await mkdir(join(outDir, 'runs', 'task-runs'), { recursive: true });
-      await writeFile(
-        join(outDir, 'runs', 'task-runs', `${taskRunId}.jsonl`),
-        [
-          JSON.stringify({
-            type: 'task_run_created',
-            id: 'e1',
-            taskRunId,
-            ts: 1,
-            taskId: 'approval-task',
-            configId: 'fake-cfg',
-          }),
-          JSON.stringify({
-            type: 'task_run_started',
-            id: 'e2',
-            taskRunId,
-            ts: 2,
-            startedAt: 2,
-            sessionId: 'session-1',
-            agentRunId: 'agent-1',
-          }),
-          JSON.stringify({
-            type: 'task_attempt_started',
-            id: 'e3',
-            taskRunId,
-            ts: 2,
-            attemptId: firstAttemptId,
-            startedAt: 2,
-            sessionId: 'session-1',
-            agentRunId: 'agent-1',
-          }),
-          JSON.stringify({
-            type: 'task_inbox_item_recorded',
-            id: 'e4',
-            taskRunId,
-            ts: 3,
-            item: {
-              schemaVersion: 1,
-              inboxItemId: 'inbox-1',
-              taskRunId,
-              attemptId: firstAttemptId,
-              kind: 'approval_request',
-              status: 'open',
-              title: 'Approval required',
-              reason: 'Bash requires approval',
-              createdAt: 3,
-              relatedRequestId: 'request-1',
-            },
-          }),
-          JSON.stringify({
-            type: 'task_run_needs_approval',
-            id: 'e5',
-            taskRunId,
-            ts: 3,
-            attemptId: firstAttemptId,
-            reason: 'approval',
+      const initialEvents = [
+        JSON.stringify({
+          type: 'task_run_created',
+          id: 'e1',
+          taskRunId,
+          ts: 1,
+          taskId: 'approval-task',
+          configId: 'fake-cfg',
+        }),
+        JSON.stringify({
+          type: 'task_run_started',
+          id: 'e2',
+          taskRunId,
+          ts: 2,
+          startedAt: 2,
+          sessionId: 'session-1',
+          agentRunId: 'agent-1',
+        }),
+        JSON.stringify({
+          type: 'task_attempt_started',
+          id: 'e3',
+          taskRunId,
+          ts: 2,
+          attemptId: firstAttemptId,
+          startedAt: 2,
+          sessionId: 'session-1',
+          agentRunId: 'agent-1',
+        }),
+        JSON.stringify({
+          type: 'task_inbox_item_recorded',
+          id: 'e4',
+          taskRunId,
+          ts: 3,
+          item: {
+            schemaVersion: 1,
             inboxItemId: 'inbox-1',
-          }),
-          '',
-        ].join('\n'),
-        'utf8',
-      );
+            taskRunId,
+            attemptId: firstAttemptId,
+            kind: 'approval_request',
+            status: 'open',
+            title: 'Approval required',
+            reason: 'Bash requires approval',
+            createdAt: 3,
+            relatedRequestId: 'request-1',
+          },
+        }),
+        JSON.stringify({
+          type: 'task_run_needs_approval',
+          id: 'e5',
+          taskRunId,
+          ts: 3,
+          attemptId: firstAttemptId,
+          reason: 'approval',
+          inboxItemId: 'inbox-1',
+        }),
+      ].map((line) => JSON.parse(line) as TaskEvent);
+      const { taskRunStore } = await openHeadlessStorageForWrite(join(outDir, 'runs'));
+      for (const event of initialEvents) await taskRunStore.appendEvent(taskRunId, event);
 
       const resumed = await runCli([
         'task',
@@ -839,7 +921,7 @@ describe('maka-headless CLI', () => {
       assert.equal(projected.taskRun.parked, undefined);
 
       const exported = JSON.parse(
-        await readFile(join(outDir, 'exports', taskRunId, 'task-run.json'), 'utf8'),
+        await readFile(join(outDir, 'exports', taskRunLocator(taskRunId), 'task-run.json'), 'utf8'),
       );
       assert.equal(exported.taskRun.status, 'completed');
       assert.equal(exported.inbox.items[0].status, 'resolved');

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -106,6 +106,24 @@ describe('maka-headless CLI', () => {
     assert.equal(result.code, 1);
   });
 
+  test('task-run readers report an actionable error for a non-Headless root', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-headless-unmarked-'));
+    const exportRoot = join(root, 'export');
+    try {
+      for (const args of [
+        ['task', 'inspect', 'missing', '--store', root],
+        ['task', 'export', 'missing', '--store', root, '--out', exportRoot],
+      ]) {
+        const result = await runCli(args);
+        assert.equal(result.code, 1);
+        assert.match(result.stderr, /Pass the <out>\/runs directory created by a task run/);
+        assert.doesNotMatch(result.stderr, /StorageRootAuthorityError|\n\s+at /);
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('rejects an unknown flag', async () => {
     const result = await runCli(['eval', 'spec.json', '--bogus', 'x']);
     assert.equal(result.code, 1);

--- a/packages/headless/src/__tests__/fixtures/task-run-writer-process.ts
+++ b/packages/headless/src/__tests__/fixtures/task-run-writer-process.ts
@@ -1,0 +1,37 @@
+import { readFile } from 'node:fs/promises';
+import { createHeadlessRootLease, resolveStorageRoot } from '@maka/storage/root-authority';
+import type { TaskEvent } from '../../task-contracts.js';
+import { openHeadlessTaskRunWriter } from '../../task-run-store.js';
+
+const [storageRoot, eventPath] = process.argv.slice(2);
+if (!storageRoot || !eventPath) {
+  throw new Error('storage root and event path are required');
+}
+
+const capability = await resolveStorageRoot({ path: storageRoot, kind: 'headless' });
+const writer = await openHeadlessTaskRunWriter(createHeadlessRootLease(capability, 'write'));
+process.send?.({ type: 'ready' });
+
+process.once('message', async (message) => {
+  if (!isAppendRequest(message)) {
+    process.exitCode = 1;
+    process.disconnect?.();
+    return;
+  }
+
+  try {
+    const event = JSON.parse(await readFile(eventPath, 'utf8')) as TaskEvent;
+    await writer.appendEvent(event.taskRunId, event);
+  } catch (error) {
+    console.error(error);
+    process.exitCode = 1;
+  } finally {
+    process.disconnect?.();
+  }
+});
+
+function isAppendRequest(value: unknown): value is { type: 'append' } {
+  return (
+    typeof value === 'object' && value !== null && (value as { type?: unknown }).type === 'append'
+  );
+}

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -24,8 +24,8 @@ import {
   type ToolResultArchiveReader,
   type ToolResultArchiveRecorder,
 } from '@maka/runtime';
-import { createArtifactStore } from '@maka/storage';
 import type { Config } from '../contracts.js';
+import { openHeadlessStorageForWrite } from '../headless-storage.js';
 import type {
   HeadlessBackendContext,
   IsolatedCommandResult,
@@ -1953,7 +1953,7 @@ describe('runHarborCell', () => {
   });
 
   test('Harbor ai-sdk backend registration exposes native file tools to the provider schema', async () => {
-    await withDirs(async ({ workspaceDir }) => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
       const registry = new BackendRegistry();
       const toolExecutor = fakeToolExecutor();
       const register = buildAiSdkCellBackendRegistration({
@@ -1978,6 +1978,7 @@ describe('runHarborCell', () => {
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
         storageRoot: workspaceDir,
         workspaceDir,
+        artifactStore,
         realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
         toolExecutor,
       });
@@ -2017,7 +2018,7 @@ describe('runHarborCell', () => {
   });
 
   test('Harbor Read persists an isolated screenshot for the provider image input', async () => {
-    await withDirs(async ({ workspaceDir, storageRoot }) => {
+    await withDirs(async ({ workspaceDir, storageRoot, artifactStore }) => {
       const pngBytes = Buffer.from(
         'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFBQIAX8jx0gAAAABJRU5ErkJggg==',
         'base64',
@@ -2042,6 +2043,7 @@ describe('runHarborCell', () => {
         task: { id: 'harbor-cell', instruction: 'inspect screen', workspaceDir },
         storageRoot,
         workspaceDir,
+        artifactStore,
         realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
         toolExecutor,
       });
@@ -2080,7 +2082,7 @@ describe('runHarborCell', () => {
   });
 
   test('Harbor persists provider captures and synthesis blocks under the run storage root', async () => {
-    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot, artifactStore }) => {
       const registry = new BackendRegistry();
       const toolExecutor = fakeToolExecutor();
       const register = buildAiSdkCellBackendRegistration({
@@ -2105,6 +2107,7 @@ describe('runHarborCell', () => {
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
         workspaceDir,
         storageRoot,
+        artifactStore,
         realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
         toolExecutor,
       };
@@ -2125,7 +2128,6 @@ describe('runHarborCell', () => {
       assert.ok(backendInput.loadSynthesisCache);
       assert.ok(backendInput.writeSynthesisCache);
       assert.ok(backendInput.recordProviderRequestCapture);
-
       await backendInput.loadSynthesisCache({ sessionId: 'session-1' });
       const capture: ProviderRequestCaptureRecord = {
         schemaVersion: 1,
@@ -2197,17 +2199,18 @@ describe('runHarborCell', () => {
       const synthesisResult = await backendInput.writeSynthesisCache(synthesisWrite);
       assert.equal(synthesisResult?.blocks.length, 1);
 
-      const records = await createArtifactStore(storageRoot).list('session-1');
+      const records = await artifactStore.list('session-1');
       assert.deepEqual(records.map((record) => record.source).sort(), [
         'provider_request_capture',
         'synthesis_cache_block',
       ]);
-      assert.deepEqual(await createArtifactStore(outputDir).list('session-1'), []);
+      const outputStorage = await openHeadlessStorageForWrite(outputDir);
+      assert.deepEqual(await outputStorage.artifactStore.list('session-1'), []);
     });
   });
 
   test('Harbor ai-sdk backend uses the discovered GitHub Copilot wire', async () => {
-    await withDirs(async ({ workspaceDir }) => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
       const registry = new BackendRegistry();
       const toolExecutor = fakeToolExecutor();
       const register = buildAiSdkCellBackendRegistration({
@@ -2230,6 +2233,7 @@ describe('runHarborCell', () => {
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
         storageRoot: workspaceDir,
         workspaceDir,
+        artifactStore,
         realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
         toolExecutor,
       });
@@ -2284,7 +2288,7 @@ describe('runHarborCell', () => {
       /unsupported Harbor context env key: MAKA_CONTEXT_TASK_TOOL_SHAPE/,
     );
 
-    await withDirs(async ({ workspaceDir }) => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
       const offRegistry = new BackendRegistry();
       const offRegister = buildAiSdkCellBackendRegistration({
         provider: 'openai',
@@ -2304,6 +2308,7 @@ describe('runHarborCell', () => {
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
         storageRoot: workspaceDir,
         workspaceDir,
+        artifactStore,
         realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
         toolExecutor,
       });
@@ -2337,6 +2342,7 @@ describe('runHarborCell', () => {
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
         storageRoot: workspaceDir,
         workspaceDir,
+        artifactStore,
         realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
         toolExecutor,
       });
@@ -2394,7 +2400,7 @@ describe('runHarborCell', () => {
   });
 
   test('Harbor ai-sdk backend passes an explicit system prompt through unchanged', async () => {
-    await withDirs(async ({ workspaceDir }) => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
       const registry = new BackendRegistry();
       const toolExecutor = fakeToolExecutor();
       const register = buildAiSdkCellBackendRegistration({
@@ -2417,6 +2423,7 @@ describe('runHarborCell', () => {
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
         storageRoot: workspaceDir,
         workspaceDir,
+        artifactStore,
         realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
         toolExecutor,
       });
@@ -2432,7 +2439,7 @@ describe('runHarborCell', () => {
   });
 
   test('Harbor ai-sdk backend honors MAKA_TRIAL_* pricing override', async () => {
-    await withDirs(async ({ workspaceDir }) => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
       const registry = new BackendRegistry();
       const toolExecutor = fakeToolExecutor();
       const register = buildAiSdkCellBackendRegistration({
@@ -2457,6 +2464,7 @@ describe('runHarborCell', () => {
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
         storageRoot: workspaceDir,
         workspaceDir,
+        artifactStore,
         realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
         toolExecutor,
       });
@@ -2478,7 +2486,7 @@ describe('runHarborCell', () => {
   });
 
   test('Harbor ai-sdk backend wires env-driven tool-result archive pruning', async () => {
-    await withDirs(async ({ workspaceDir, outputDir }) => {
+    await withDirs(async ({ workspaceDir, outputDir, artifactStore }) => {
       const registry = new BackendRegistry();
       const toolExecutor = fakeToolExecutor();
       const register = buildAiSdkCellBackendRegistration({
@@ -2516,6 +2524,7 @@ describe('runHarborCell', () => {
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
         storageRoot: workspaceDir,
         workspaceDir,
+        artifactStore,
         realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
         toolExecutor,
       });
@@ -2592,7 +2601,7 @@ describe('runHarborCell', () => {
   // archive reader are wired alongside it. The #340-era arms enabled retrieval
   // without stale prune and it never fired; this contract pins the live shape.
   test('Harbor eager archive-retrieval arm gets a placeholder producer and archive reader by default', async () => {
-    await withDirs(async ({ workspaceDir, outputDir }) => {
+    await withDirs(async ({ workspaceDir, outputDir, artifactStore }) => {
       const registry = new BackendRegistry();
       const toolExecutor = fakeToolExecutor();
       const register = buildAiSdkCellBackendRegistration({
@@ -2616,6 +2625,7 @@ describe('runHarborCell', () => {
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
         storageRoot: workspaceDir,
         workspaceDir,
+        artifactStore,
         realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
         toolExecutor,
       });
@@ -2639,7 +2649,7 @@ describe('runHarborCell', () => {
   });
 
   test('Harbor ai-sdk backend leaves context budget policy off when explicitly disabled', async () => {
-    await withDirs(async ({ workspaceDir }) => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
       const registry = new BackendRegistry();
       const toolExecutor = fakeToolExecutor();
       const register = buildAiSdkCellBackendRegistration({
@@ -2664,6 +2674,7 @@ describe('runHarborCell', () => {
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
         storageRoot: workspaceDir,
         workspaceDir,
+        artifactStore,
         realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
         toolExecutor,
       });
@@ -2682,7 +2693,7 @@ describe('runHarborCell', () => {
 
   test('Harbor context budget env rejects explicit malformed positive integers', async () => {
     for (const raw of ['abc', '0', '-1', '1x']) {
-      await withDirs(async ({ workspaceDir }) => {
+      await withDirs(async ({ workspaceDir, artifactStore }) => {
         const registry = new BackendRegistry();
         const toolExecutor = fakeToolExecutor();
 
@@ -2709,6 +2720,7 @@ describe('runHarborCell', () => {
               task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
               storageRoot: workspaceDir,
               workspaceDir,
+              artifactStore,
               realBackendIsolation: {
                 kind: 'external',
                 label: 'Harbor task container',
@@ -2761,7 +2773,7 @@ describe('runHarborCell', () => {
   });
 
   test('Harbor context budget env rejects explicit malformed archive retrieval mode', async () => {
-    await withDirs(async ({ workspaceDir }) => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
       const registry = new BackendRegistry();
       const toolExecutor = fakeToolExecutor();
 
@@ -2787,7 +2799,12 @@ describe('runHarborCell', () => {
           task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
           storageRoot: workspaceDir,
           workspaceDir,
-          realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+          artifactStore,
+          realBackendIsolation: {
+            kind: 'external',
+            label: 'Harbor task container',
+            toolExecutor,
+          },
           toolExecutor,
         });
       }, /MAKA_CONTEXT_ARCHIVE_RETRIEVAL_MODE must be one of eager, history_search_gated, got "histroy_search_gated"/);
@@ -2795,7 +2812,7 @@ describe('runHarborCell', () => {
   });
 
   test('Harbor context budget env keeps unset or blank archive retrieval knobs unspecified', async () => {
-    await withDirs(async ({ workspaceDir }) => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
       const registry = new BackendRegistry();
       const toolExecutor = fakeToolExecutor();
       const register = buildAiSdkCellBackendRegistration({
@@ -2822,6 +2839,7 @@ describe('runHarborCell', () => {
         task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
         storageRoot: workspaceDir,
         workspaceDir,
+        artifactStore,
         realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
         toolExecutor,
       });
@@ -4824,13 +4842,24 @@ function backendContext(workspaceDir: string): BackendFactoryContext {
 }
 
 async function withDirs<T>(
-  fn: (dirs: { workspaceDir: string; outputDir: string; storageRoot: string }) => Promise<T>,
+  fn: (dirs: {
+    workspaceDir: string;
+    outputDir: string;
+    storageRoot: string;
+    artifactStore: HeadlessBackendContext['artifactStore'];
+  }) => Promise<T>,
 ): Promise<T> {
   const workspaceDir = await mkdtemp(join(tmpdir(), 'maka-cell-ws-'));
   const outputDir = await mkdtemp(join(tmpdir(), 'maka-cell-out-'));
   const storageRoot = await mkdtemp(join(tmpdir(), 'maka-cell-store-'));
   try {
-    return await fn({ workspaceDir, outputDir, storageRoot });
+    const storage = await openHeadlessStorageForWrite(storageRoot);
+    return await fn({
+      workspaceDir,
+      outputDir,
+      storageRoot,
+      artifactStore: storage.artifactStore,
+    });
   } finally {
     await rm(workspaceDir, { recursive: true, force: true });
     await rm(outputDir, { recursive: true, force: true });

--- a/packages/headless/src/__tests__/headless-storage-boundary.test.ts
+++ b/packages/headless/src/__tests__/headless-storage-boundary.test.ts
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import {
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  readlink,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import {
+  discoverMarkedStorageRoot,
+  resolveRootControlNamespace,
+  resolveStorageRoot,
+  STORAGE_ROOT_MARKER_FILE,
+  StorageRootAuthorityError,
+} from '@maka/storage/root-authority';
+import { registerFakeBackend } from '../backends.js';
+import { runHarborCell } from '../harbor-cell.js';
+import { openHeadlessStorageForRead } from '../headless-storage.js';
+import { runTaskOnce } from '../task-agent-controller.js';
+import { inspectTaskRun } from '../task-run-inspect.js';
+import type { Config, Task } from '../contracts.js';
+
+const fakeConfig: Config = {
+  id: 'fake-config',
+  backend: 'fake',
+  llmConnectionSlug: 'fake',
+  model: 'fake-model',
+};
+
+describe('Headless storage root boundary', () => {
+  test('rejects an Interactive root before Harbor mutates storage, workspace, output, or control state', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-headless-root-kind-'));
+    const storageRoot = join(base, 'storage');
+    const workspaceDir = join(base, 'workspace');
+    const outputDir = join(base, 'output');
+    let backendRegistrationCalled = false;
+    try {
+      await mkdir(workspaceDir);
+      await mkdir(outputDir);
+      await writeFile(join(workspaceDir, 'workspace-sentinel.txt'), 'workspace\n');
+      await writeFile(join(outputDir, 'output-sentinel.txt'), 'output\n');
+      const interactive = await resolveStorageRoot({ path: storageRoot, kind: 'interactive' });
+      await writeFile(join(storageRoot, 'storage-sentinel.txt'), 'storage\n');
+      const controlDirectory = join(resolveRootControlNamespace(), interactive.rootId);
+      const before = await snapshotManifest({
+        storageRoot,
+        workspaceDir,
+        outputDir,
+        controlDirectory,
+      });
+
+      await assert.rejects(
+        () =>
+          runHarborCell({
+            config: fakeConfig,
+            instruction: 'Do not mutate anything.',
+            cwd: workspaceDir,
+            outputDir,
+            storageRoot,
+            registerBackends: (registry) => {
+              backendRegistrationCalled = true;
+              registerFakeBackend(registry);
+            },
+          }),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'root_kind_mismatch',
+      );
+
+      assert.equal(backendRegistrationCalled, false);
+      assert.deepEqual(
+        await snapshotManifest({ storageRoot, workspaceDir, outputDir, controlDirectory }),
+        before,
+      );
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  test('executes on a Headless root and reads TaskRun and execution state without writes', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-headless-storage-read-'));
+    const storageRoot = join(base, 'storage');
+    const workspaceDir = join(base, 'workspace');
+    try {
+      await mkdir(workspaceDir);
+      await writeFile(join(workspaceDir, 'proof.txt'), 'present\n');
+      const task: Task = {
+        id: 'headless-storage-task',
+        instruction: 'Complete the task.',
+        workspaceDir,
+        verification: { command: 'test -f proof.txt', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        taskRunId: 'task-run-1',
+      });
+      assert.equal(result.resultRecord.status, 'completed');
+
+      const discovered = await discoverMarkedStorageRoot({ path: storageRoot });
+      assert.equal(discovered.kind, 'headless');
+      const beforeRead = await snapshotTree(storageRoot, 'storage');
+      const storage = await openHeadlessStorageForRead(storageRoot);
+      assert.equal('appendEvent' in storage.taskRunStore, false);
+      assert.deepEqual(await storage.taskRunStore.listTaskRunIds(), ['task-run-1']);
+      assert.equal((await storage.taskRunStore.project('task-run-1')).status, 'completed');
+      assert.equal((await storage.executionStores.sessionStore.list()).length, 1);
+      assert.deepEqual(await snapshotTree(storageRoot, 'storage'), beforeRead);
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  test('opens a discovered Headless capability without adopting a replacement root', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-headless-discovered-root-'));
+    const storageRoot = join(base, 'storage');
+    const displacedRoot = join(base, 'displaced');
+    try {
+      const capability = await resolveStorageRoot({ path: storageRoot, kind: 'headless' });
+      await rename(storageRoot, displacedRoot);
+      await resolveStorageRoot({ path: storageRoot, kind: 'headless' });
+
+      await assert.rejects(
+        () => openHeadlessStorageForRead(capability),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'root_identity_changed',
+      );
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
+  test('fails TaskRun inspection closed when root authority changes after AgentRun header read', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-headless-inspect-authority-'));
+    const storageRoot = join(base, 'storage');
+    const workspaceDir = join(base, 'workspace');
+    try {
+      await mkdir(workspaceDir);
+      await writeFile(join(workspaceDir, 'proof.txt'), 'present\n');
+      const task: Task = {
+        id: 'headless-inspect-authority',
+        instruction: 'Complete the task.',
+        workspaceDir,
+        verification: { command: 'test -f proof.txt', protectedPaths: [] },
+      };
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        taskRunId: 'authority-change-run',
+      });
+      assert.equal(result.projection.status, 'completed');
+
+      const storage = await openHeadlessStorageForRead(storageRoot);
+      const markerPath = join(storageRoot, STORAGE_ROOT_MARKER_FILE);
+      const agentRunStore = {
+        ...storage.executionStores.agentRunStore,
+        readRun: async (sessionId: string, runId: string) => {
+          const header = await storage.executionStores.agentRunStore.readRun(sessionId, runId);
+          const marker = JSON.parse(await readFile(markerPath, 'utf8')) as Record<string, unknown>;
+          await writeFile(markerPath, `${JSON.stringify({ ...marker, rootId: 'f'.repeat(64) })}\n`);
+          return header;
+        },
+      };
+
+      await assert.rejects(
+        () =>
+          inspectTaskRun(
+            {
+              taskRunStore: storage.taskRunStore,
+              agentRunStore,
+              runtimeEventStore: storage.executionStores.runtimeEventStore,
+            },
+            'authority-change-run',
+          ),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'root_identity_changed',
+      );
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+});
+
+interface ManifestEntry {
+  path: string;
+  type: 'directory' | 'file' | 'symlink' | 'other' | 'missing';
+  mode?: number;
+  size?: string;
+  mtimeNs?: string;
+  contentSha256?: string;
+}
+
+async function snapshotManifest(paths: {
+  storageRoot: string;
+  workspaceDir: string;
+  outputDir: string;
+  controlDirectory: string;
+}): Promise<ManifestEntry[]> {
+  const groups = await Promise.all([
+    snapshotTree(paths.storageRoot, 'storage'),
+    snapshotTree(paths.workspaceDir, 'workspace'),
+    snapshotTree(paths.outputDir, 'output'),
+    snapshotTree(paths.controlDirectory, 'control'),
+  ]);
+  return groups.flat();
+}
+
+async function snapshotTree(path: string, label: string): Promise<ManifestEntry[]> {
+  let stats;
+  try {
+    stats = await lstat(path, { bigint: true });
+  } catch (error) {
+    if (isNotFound(error)) return [{ path: label, type: 'missing' }];
+    throw error;
+  }
+
+  const type = stats.isDirectory()
+    ? 'directory'
+    : stats.isFile()
+      ? 'file'
+      : stats.isSymbolicLink()
+        ? 'symlink'
+        : 'other';
+  const entry: ManifestEntry = {
+    path: label,
+    type,
+    mode: Number(stats.mode & 0o7777n),
+    size: stats.size.toString(),
+    mtimeNs: stats.mtimeNs.toString(),
+  };
+  if (type === 'file') {
+    entry.contentSha256 = createHash('sha256')
+      .update(await readFile(path))
+      .digest('hex');
+  } else if (type === 'symlink') {
+    entry.contentSha256 = createHash('sha256')
+      .update(await readlink(path))
+      .digest('hex');
+  }
+  if (type !== 'directory') return [entry];
+
+  const children = await readdir(path);
+  const descendants = await Promise.all(
+    children.sort().map((child) => snapshotTree(join(path, child), `${label}/${child}`)),
+  );
+  return [entry, ...descendants.flat()];
+}
+
+function isNotFound(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
+}

--- a/packages/headless/src/__tests__/headless-storage-dependency.test.ts
+++ b/packages/headless/src/__tests__/headless-storage-dependency.test.ts
@@ -1,0 +1,174 @@
+import assert from 'node:assert/strict';
+import { readdirSync } from 'node:fs';
+import { readdir } from 'node:fs/promises';
+import { dirname, join, relative, resolve, sep } from 'node:path';
+import { after, test } from 'node:test';
+import * as ts from 'typescript/unstable/ast';
+import { API } from 'typescript/unstable/sync';
+
+const sourceRoot = join(process.cwd(), 'src');
+const packageRoot = resolve(sourceRoot, '..');
+const distRoot = join(packageRoot, 'dist');
+const harborRoot = join(packageRoot, 'harbor');
+const storageCompositionModule = join(sourceRoot, 'headless-storage.ts');
+const taskRunStoreModule = join(sourceRoot, 'task-run-store.ts');
+const productionJavaScriptModules = listProductionJavaScriptModules(harborRoot);
+const rawStorageWriterFactories = [
+  'createAgentRunStore',
+  'createArtifactStore',
+  'createRuntimeEventStore',
+  'createSessionStore',
+] as const;
+const compilerApi = new API({ cwd: process.cwd() });
+const projectConfig = join(process.cwd(), 'tsconfig.json');
+const compilerSnapshot = compilerApi.updateSnapshot({
+  openProjects: [projectConfig],
+  openFiles: productionJavaScriptModules,
+});
+const compilerProject = loadCompilerProject();
+
+after(() => {
+  compilerSnapshot.dispose();
+  compilerApi.close();
+});
+
+function loadCompilerProject() {
+  const project = compilerSnapshot.getProject(projectConfig);
+  if (!project) throw new Error(`TypeScript did not load ${projectConfig}`);
+  return project;
+}
+
+test('only the Headless storage composition imports production writer factories', async () => {
+  const violations: string[] = [];
+  const productionModules = [
+    ...(await listProductionTypeScriptFiles(sourceRoot)),
+    ...productionJavaScriptModules,
+  ];
+  for (const path of productionModules) {
+    if (path === storageCompositionModule) continue;
+    for (const reference of moduleReferences(path)) {
+      for (const symbol of forbiddenWriterSymbols(path, reference)) {
+        violations.push(`${relative(sourceRoot, path)}: ${reference.specifier} -> ${symbol}`);
+      }
+    }
+  }
+  assert.deepEqual(violations, []);
+});
+
+test('the boundary recognizes every writer imported by the storage composition', () => {
+  const symbols = moduleReferences(storageCompositionModule)
+    .flatMap((reference) => forbiddenWriterSymbols(storageCompositionModule, reference))
+    .sort();
+  assert.deepEqual(symbols, [
+    'createArtifactStore',
+    'openHeadlessExecutionStoresForWrite',
+    'openHeadlessTaskRunWriter',
+  ]);
+});
+
+interface ModuleReference {
+  specifier: string;
+  importedNames: string[] | null;
+}
+
+function forbiddenWriterSymbols(importer: string, reference: ModuleReference): string[] {
+  if (reference.specifier === '@maka/storage') {
+    if (reference.importedNames === null) return [...rawStorageWriterFactories];
+    return reference.importedNames.filter((name) =>
+      rawStorageWriterFactories.includes(name as (typeof rawStorageWriterFactories)[number]),
+    );
+  }
+  if (reference.specifier === '@maka/storage/execution-stores') {
+    if (reference.importedNames === null) return ['writer opener'];
+    return reference.importedNames.filter((name) => /^open[A-Za-z0-9]*ForWrite$/.test(name));
+  }
+  if (
+    reference.specifier.startsWith('.') &&
+    sourcePathForSpecifier(importer, reference.specifier) === taskRunStoreModule &&
+    (reference.importedNames === null ||
+      reference.importedNames.includes('openHeadlessTaskRunWriter'))
+  ) {
+    return ['openHeadlessTaskRunWriter'];
+  }
+  return [];
+}
+
+async function listProductionTypeScriptFiles(root: string): Promise<string[]> {
+  const files: string[] = [];
+  for (const entry of await readdir(root, { withFileTypes: true })) {
+    if (entry.isDirectory() && entry.name === '__tests__') continue;
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) files.push(...(await listProductionTypeScriptFiles(path)));
+    else if (entry.name.endsWith('.ts')) files.push(path);
+  }
+  return files;
+}
+
+function listProductionJavaScriptModules(root: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(root, { withFileTypes: true })) {
+    const path = join(root, entry.name);
+    if (entry.isDirectory()) files.push(...listProductionJavaScriptModules(path));
+    else if (entry.name.endsWith('.mjs') || entry.name.endsWith('.js')) files.push(path);
+  }
+  return files.sort();
+}
+
+function moduleReferences(path: string): ModuleReference[] {
+  const source =
+    compilerProject.program.getSourceFile(path) ??
+    compilerSnapshot.getDefaultProjectForFile(path)?.program.getSourceFile(path);
+  if (!source) throw new Error(`TypeScript did not load ${path}`);
+  const references: ModuleReference[] = [];
+  const visit = (node: ts.Node) => {
+    if (ts.isImportDeclaration(node) && ts.isStringLiteral(node.moduleSpecifier)) {
+      references.push({
+        specifier: node.moduleSpecifier.text,
+        importedNames: importDeclarationNames(node),
+      });
+    }
+    if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      references.push({
+        specifier: node.moduleSpecifier.text,
+        importedNames: exportDeclarationNames(node),
+      });
+    }
+    node.forEachChild(visit);
+  };
+  visit(source);
+  return references;
+}
+
+function importDeclarationNames(node: ts.ImportDeclaration): string[] | null {
+  const clause = node.importClause;
+  if (!clause || clause.phaseModifier === ts.SyntaxKind.TypeKeyword) return [];
+  const names: string[] = [];
+  if (clause.name) names.push('default');
+  if (!clause.namedBindings) return names;
+  if (ts.isNamespaceImport(clause.namedBindings)) return null;
+  for (const element of clause.namedBindings.elements) {
+    if (!element.isTypeOnly) names.push((element.propertyName ?? element.name).text);
+  }
+  return names;
+}
+
+function exportDeclarationNames(node: ts.ExportDeclaration): string[] | null {
+  if (node.isTypeOnly) return [];
+  if (!node.exportClause || ts.isNamespaceExport(node.exportClause)) return null;
+  return node.exportClause.elements
+    .filter((element) => !element.isTypeOnly)
+    .map((element) => (element.propertyName ?? element.name).text);
+}
+
+function sourcePathForSpecifier(importer: string, specifier: string): string {
+  const resolvedTarget = resolve(dirname(importer), specifier);
+  const target = resolvedTarget.startsWith(`${distRoot}${sep}`)
+    ? join(sourceRoot, relative(distRoot, resolvedTarget))
+    : resolvedTarget;
+  if (target.endsWith('.js')) return `${target.slice(0, -3)}.ts`;
+  return target.endsWith('.ts') ? target : `${target}.ts`;
+}

--- a/packages/headless/src/__tests__/heavy-task-self-check-gate.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-self-check-gate.test.ts
@@ -10,7 +10,7 @@ import type {
   HeavyTaskWorkspaceObservationState,
   TaskEvent,
 } from '../task-contracts.js';
-import { projectTaskRun } from '../task-run-store.js';
+import { projectTaskRun } from '../task-run-projection.js';
 
 const heavyTaskMode: HeavyTaskModeFacts = {
   schemaVersion: 1,

--- a/packages/headless/src/__tests__/heavy-task-self-check.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-self-check.test.ts
@@ -16,7 +16,8 @@ import type {
   HeavyTaskSemanticSelfCheckState,
   HeavyTaskSourceGuardResult,
 } from '../task-contracts.js';
-import { createInMemoryTaskRunStore, projectTaskRun } from '../task-run-store.js';
+import { projectTaskRun } from '../task-run-projection.js';
+import { createInMemoryTaskRunStore } from '../task-run-store.js';
 
 const toolContext = {
   sessionId: 'session-1',

--- a/packages/headless/src/__tests__/heavy-task-workspace-observation.test.ts
+++ b/packages/headless/src/__tests__/heavy-task-workspace-observation.test.ts
@@ -8,7 +8,7 @@ import {
 } from '../heavy-task-workspace-observation.js';
 import type { IsolatedCommandInput, IsolatedToolExecutor } from '../isolation.js';
 import type { HeavyTaskSelfCheckPlanState, TaskEvent } from '../task-contracts.js';
-import { projectTaskRun } from '../task-run-store.js';
+import { projectTaskRun } from '../task-run-projection.js';
 
 describe('heavy-task workspace observation', () => {
   test('records machine-observed one-level entries for task artifact directories', async () => {

--- a/packages/headless/src/__tests__/matrix-resume.test.ts
+++ b/packages/headless/src/__tests__/matrix-resume.test.ts
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { resolveStorageRoot, StorageRootAuthorityError } from '@maka/storage/root-authority';
+import { readMatrixPriorRecords } from '../matrix-resume.js';
+
+describe('readMatrixPriorRecords', () => {
+  test('returns no prior results when the runs root does not exist', async () => {
+    const outputRoot = await mkdtemp(join(tmpdir(), 'maka-matrix-resume-'));
+    try {
+      assert.deepEqual(await readMatrixPriorRecords(outputRoot), []);
+      assert.deepEqual(await readdir(outputRoot), []);
+    } finally {
+      await rm(outputRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('does not treat unmarked or Interactive roots as empty Headless stores', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-matrix-resume-'));
+    try {
+      const unmarkedOutput = join(base, 'unmarked-output');
+      await mkdir(join(unmarkedOutput, 'runs'), { recursive: true });
+      await assert.rejects(
+        () => readMatrixPriorRecords(unmarkedOutput),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'root_unmarked',
+      );
+
+      const interactiveOutput = join(base, 'interactive-output');
+      await mkdir(interactiveOutput);
+      await resolveStorageRoot({ path: join(interactiveOutput, 'runs'), kind: 'interactive' });
+      await assert.rejects(
+        () => readMatrixPriorRecords(interactiveOutput),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'root_kind_mismatch',
+      );
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/headless/src/__tests__/result-export.test.ts
+++ b/packages/headless/src/__tests__/result-export.test.ts
@@ -9,7 +9,7 @@ import {
   writeTaskRunExport,
 } from '../result-export.js';
 import type { HeavyTaskTodoItem, TaskEvent } from '../task-contracts.js';
-import { projectTaskRun } from '../task-run-store.js';
+import { projectTaskRun } from '../task-run-projection.js';
 
 describe('task run export', () => {
   test('projects runtime, verifier, score, budget, isolation, inbox, and taxonomy', async () => {

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -16,16 +16,20 @@ import {
   type AgentRunHeader,
   type BackendKind,
   type RuntimeEvent,
-  type RuntimeEventStore,
   type SessionEvent,
   type SessionHeader,
 } from '@maka/core';
 import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
-import { createRuntimeEventStore } from '@maka/storage';
+import { StorageRootAuthorityError } from '@maka/storage/root-authority';
 import type { Config, Task } from '../contracts.js';
+import { openHeadlessStorageForWrite } from '../headless-storage.js';
 import type { HeadlessBackendContext } from '../isolation.js';
 import { commandResourceScope, hashNormalizedArgs } from '../permission-grants.js';
-import { runTaskOnce, type RunTaskOnceResult } from '../task-agent-controller.js';
+import {
+  runTaskOnce,
+  runTaskOnceWithStorage,
+  type RunTaskOnceResult,
+} from '../task-agent-controller.js';
 import type { TaskPermissionGrant } from '../task-contracts.js';
 import { buildIsolatedHeadlessTools } from '../tools.js';
 
@@ -1762,53 +1766,36 @@ describe('runTaskOnce', () => {
     });
   });
 
-  test('does not persist terminal headless run headers when terminal runtime event append fails', async () => {
+  test('rejects a copied Headless storage aggregate before execution', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');
       const task: Task = {
-        id: 'terminal-append-fails',
+        id: 'forged-storage',
         instruction: 'do the thing',
         workspaceDir: fixtureDir,
         verification: { command: 'test -f marker.txt', protectedPaths: [] },
       };
-      const backingRuntimeEventStore = createRuntimeEventStore(storageRoot);
-      const runtimeEventStore: RuntimeEventStore = {
-        appendRuntimeEvent(sessionId, runId, event) {
-          if (isTerminalRuntimeEvent(event)) {
-            throw new Error('terminal append failed');
-          }
-          return backingRuntimeEventStore.appendRuntimeEvent(sessionId, runId, event);
-        },
-        ensureTerminalRuntimeEventDurable() {
-          throw new Error('terminal append failed');
-        },
-        readRuntimeEvents: (sessionId, runId) =>
-          backingRuntimeEventStore.readRuntimeEvents(sessionId, runId),
-        readSessionRuntimeEvents: (sessionId) =>
-          backingRuntimeEventStore.readSessionRuntimeEvents(sessionId),
-      };
+      const storage = await openHeadlessStorageForWrite(storageRoot);
+      let backendRegistrationCalled = false;
 
-      const result = await runTaskOnce(fakeConfig, task, {
-        storageRoot,
-        registerBackends: registerFakeBackend,
-        runtimeEventStore,
-      });
-
-      assert.equal(latestInvocation(result).status, 'failed');
-      assert.equal(latestInvocation(result).failure?.message, 'terminal append failed');
-      const runtimeEvents = await runtimeEventStore.readRuntimeEvents(
-        latestInvocation(result).sessionId,
-        latestInvocation(result).runId,
+      await assert.rejects(
+        () =>
+          runTaskOnceWithStorage(
+            fakeConfig,
+            task,
+            {
+              storageRoot,
+              registerBackends: (registry) => {
+                backendRegistrationCalled = true;
+                registerFakeBackend(registry);
+              },
+            },
+            { ...storage },
+          ),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'invalid_lease',
       );
-      assert.equal(runtimeEvents.some(isTerminalRuntimeEvent), false);
-      const runHeader = await readAgentRunHeader(
-        storageRoot,
-        latestInvocation(result).sessionId,
-        latestInvocation(result).runId,
-      );
-      assert.notEqual(runHeader.status, 'completed');
-      assert.notEqual(runHeader.status, 'failed');
-      assert.notEqual(runHeader.status, 'cancelled');
+      assert.equal(backendRegistrationCalled, false);
     });
   });
 

--- a/packages/headless/src/__tests__/task-run-adapter.test.ts
+++ b/packages/headless/src/__tests__/task-run-adapter.test.ts
@@ -7,7 +7,7 @@ import {
   taskDefinitionFromTask,
   taskEventsFromResultRecord,
 } from '../task-run-adapter.js';
-import { projectTaskRun } from '../task-run-store.js';
+import { projectTaskRun } from '../task-run-projection.js';
 
 const task: Task = {
   id: 'task-1',

--- a/packages/headless/src/__tests__/task-run-projection.test.ts
+++ b/packages/headless/src/__tests__/task-run-projection.test.ts
@@ -1,0 +1,1544 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type {
+  HeavyTaskSelfCheckPlanState,
+  HeavyTaskSemanticSelfCheckState,
+  TaskEvent,
+} from '../task-contracts.js';
+import { taskAttemptExecutionEvidence } from '../task-execution-lineage.js';
+import { projectTaskRun } from '../task-run-projection.js';
+
+function eventIdFactory(): () => string {
+  let i = 0;
+  return () => `e-${++i}`;
+}
+
+function completedEvents(taskRunId = 'tr-1', taskId = 'task-1', configId = 'cfg-1'): TaskEvent[] {
+  const id = eventIdFactory();
+  return [
+    { type: 'task_run_created', id: id(), taskRunId, ts: 10, taskId, configId },
+    {
+      type: 'task_run_started',
+      id: id(),
+      taskRunId,
+      ts: 11,
+      startedAt: 11,
+      sessionId: 's-1',
+      agentRunId: 'r-1',
+    },
+    {
+      type: 'task_attempt_started',
+      id: id(),
+      taskRunId,
+      ts: 12,
+      attemptId: 'a-1',
+      sessionId: 's-1',
+      agentRunId: 'r-1',
+    },
+    {
+      type: 'self_check_observed',
+      id: id(),
+      taskRunId,
+      ts: 13,
+      observation: { id: 'self-1', taskRunId, attemptId: 'a-1', ts: 13, summary: 'looks solved' },
+    },
+    {
+      type: 'feedback_observed',
+      id: id(),
+      taskRunId,
+      ts: 14,
+      observation: {
+        id: 'fb-1',
+        taskRunId,
+        attemptId: 'a-1',
+        ts: 14,
+        source: 'verifier',
+        summary: 'tests passed',
+      },
+    },
+    {
+      type: 'autonomous_decision_recorded',
+      id: id(),
+      taskRunId,
+      ts: 15,
+      decision: {
+        id: 'd-1',
+        taskRunId,
+        attemptId: 'a-1',
+        ts: 15,
+        decision: 'stop',
+        reason: 'verification passed',
+      },
+    },
+    {
+      type: 'verifier_result_recorded',
+      id: id(),
+      taskRunId,
+      ts: 20,
+      result: {
+        id: 'v-1',
+        taskRunId,
+        attemptId: 'a-1',
+        ts: 20,
+        kind: 'command',
+        passed: true,
+        exitCode: 0,
+      },
+    },
+    {
+      type: 'score_result_recorded',
+      id: id(),
+      taskRunId,
+      ts: 21,
+      result: {
+        id: 'score-1',
+        taskRunId,
+        attemptId: 'a-1',
+        ts: 21,
+        passed: true,
+        taxonomy: 'passed',
+      },
+    },
+    {
+      type: 'task_attempt_completed',
+      id: id(),
+      taskRunId,
+      ts: 22,
+      attemptId: 'a-1',
+      finishedAt: 22,
+      status: 'completed',
+    },
+    { type: 'task_run_completed', id: id(), taskRunId, ts: 23, finishedAt: 23 },
+  ];
+}
+
+function heavyTaskEvidenceEvent(
+  taskRunId: string,
+  id: string,
+  evidenceId: string,
+  name: 'Bash' | 'Read',
+  ts: number,
+): TaskEvent {
+  return {
+    type: 'heavy_task_evidence_recorded',
+    id,
+    taskRunId,
+    ts,
+    evidence: {
+      schemaVersion: 1,
+      evidenceId,
+      taskRunId,
+      ts,
+      kind: 'tool',
+      public: true,
+      source: { kind: 'model_tool', toolCallId: `tool-${ts}`, toolName: name },
+      tool: {
+        name,
+        inputSummary: name === 'Bash' ? { command: 'npm test' } : { path: 'README.md' },
+        ...(name === 'Bash' ? { exitCode: 0 } : {}),
+        ok: true,
+        outputs: [
+          {
+            stream: name === 'Bash' ? 'stdout' : 'content',
+            excerpt: 'bounded public summary',
+            byteCount: 22,
+            lineCount: 1,
+            truncated: false,
+            truncationRef: {
+              truncated: false,
+              originalBytes: 22,
+              visibleBytes: 22,
+              omittedBytes: 0,
+            },
+          },
+        ],
+        diff: { status: 'not_applicable' },
+      },
+    },
+  };
+}
+
+describe('TaskRun projection', () => {
+  test('projects status, attempts, observations, verifier, and score from replay', () => {
+    const projection = projectTaskRun(completedEvents(), 'tr-1');
+    assert.equal(projection.status, 'completed');
+    assert.equal(projection.taskId, 'task-1');
+    assert.equal(projection.configId, 'cfg-1');
+    assert.equal(projection.sessionId, 's-1');
+    assert.equal(projection.agentRunId, 'r-1');
+    assert.equal(projection.attempts[0]?.status, 'completed');
+    assert.deepEqual(projection.attempts[0]?.executionLineage, []);
+    assert.equal(projection.selfChecks[0]?.summary, 'looks solved');
+    assert.equal(projection.feedback[0]?.summary, 'tests passed');
+    assert.equal(projection.decisions[0]?.decision, 'stop');
+    assert.equal(projection.latestVerifierResult?.exitCode, 0);
+    assert.equal(projection.latestScoreResult?.taxonomy, 'passed');
+    assert.deepEqual(projection.result, {
+      passed: true,
+      taxonomy: 'passed',
+      verifierResultId: 'v-1',
+      scoreResultId: 'score-1',
+    });
+  });
+
+  test('projects every AgentRun linked to one attempt without copying Runtime facts', () => {
+    const taskRunId = 'tr-lineage';
+    const attemptId = 'attempt-1';
+    const events: TaskEvent[] = [
+      {
+        type: 'task_run_created',
+        id: 'e-1',
+        taskRunId,
+        ts: 1,
+        taskId: 'task-1',
+        configId: 'cfg-1',
+      },
+      {
+        type: 'task_run_started',
+        id: 'e-2',
+        taskRunId,
+        ts: 2,
+        sessionId: 'session-1',
+        agentRunId: 'run-1',
+      },
+      {
+        type: 'task_attempt_started',
+        id: 'e-3',
+        taskRunId,
+        ts: 3,
+        attemptId,
+        sessionId: 'session-1',
+        agentRunId: 'run-1',
+      },
+      {
+        type: 'task_attempt_execution_linked',
+        id: 'e-4',
+        taskRunId,
+        attemptId,
+        ts: 4,
+        evidence: taskAttemptExecutionEvidence({
+          taskRunId,
+          attemptId,
+          sessionId: 'session-1',
+          invocationId: 'invocation-1',
+          agentRunId: 'run-1',
+          turnId: 'turn-1',
+          runtimeEvents: [],
+        }),
+      },
+      {
+        type: 'task_attempt_execution_linked',
+        id: 'e-5',
+        taskRunId,
+        attemptId,
+        ts: 5,
+        evidence: taskAttemptExecutionEvidence({
+          taskRunId,
+          attemptId,
+          sessionId: 'session-1',
+          invocationId: 'invocation-2',
+          agentRunId: 'run-2',
+          turnId: 'turn-2',
+          runtimeEvents: [],
+        }),
+      },
+      {
+        type: 'task_attempt_completed',
+        id: 'e-6',
+        taskRunId,
+        ts: 6,
+        attemptId,
+        status: 'completed',
+      },
+    ];
+
+    const projection = projectTaskRun(events, taskRunId);
+
+    assert.equal(projection.agentRunId, 'run-1');
+    assert.deepEqual(
+      projection.executionLineage.map((ref) => ref.execution?.agentRunId),
+      ['run-1', 'run-2'],
+    );
+    assert.deepEqual(
+      projection.attempts[0]?.executionLineage.map((ref) => ref.execution?.agentRunId),
+      ['run-1', 'run-2'],
+    );
+  });
+
+  test('rejects lineage whose task identity does not match the owning event', () => {
+    const taskRunId = 'tr-lineage-invalid';
+    const projection = projectTaskRun(
+      [
+        { type: 'task_attempt_started', id: 'e-1', taskRunId, ts: 1, attemptId: 'attempt-1' },
+        {
+          type: 'task_attempt_execution_linked',
+          id: 'e-2',
+          taskRunId,
+          attemptId: 'attempt-1',
+          ts: 2,
+          evidence: taskAttemptExecutionEvidence({
+            taskRunId: 'another-task-run',
+            attemptId: 'attempt-1',
+            sessionId: 'session-1',
+            agentRunId: 'run-1',
+            runtimeEvents: [],
+          }),
+        },
+      ],
+      taskRunId,
+    );
+
+    assert.equal(projection.executionLineage.length, 0);
+    assert.match(projection.warnings[0] ?? '', /task identity does not match/);
+  });
+
+  test('projects Runtime provenance onto compact evidence without copying Runtime facts', () => {
+    const taskRunId = 'tr-evidence-provenance';
+    const recorded = heavyTaskEvidenceEvent(taskRunId, 'e-1', 'evidence-1', 'Bash', 1);
+    if (recorded.type !== 'heavy_task_evidence_recorded')
+      throw new Error('expected evidence event');
+    recorded.evidence.attemptId = 'attempt-1';
+    recorded.evidence.source = {
+      ...recorded.evidence.source,
+      sessionId: 'session-1',
+      agentRunId: 'run-1',
+      turnId: 'turn-1',
+    };
+    const events: TaskEvent[] = [
+      recorded,
+      {
+        type: 'heavy_task_evidence_provenance_linked',
+        id: 'e-2',
+        taskRunId,
+        attemptId: 'attempt-1',
+        ts: 2,
+        evidenceId: 'evidence-1',
+        provenance: {
+          schemaVersion: 'maka.execution_evidence_ref.v1',
+          execution: {
+            sessionId: 'session-1',
+            invocationId: 'invocation-1',
+            agentRunId: 'run-1',
+            turnId: 'turn-1',
+          },
+          task: { taskRunId, attemptId: 'attempt-1' },
+          runtimeCoverage: {
+            lowWater: {
+              ledger: 'runtime_event',
+              streamId: 'run-1',
+              sequence: 4,
+              eventId: 'call-1',
+            },
+            highWater: {
+              ledger: 'runtime_event',
+              streamId: 'run-1',
+              sequence: 6,
+              eventId: 'result-1',
+            },
+            eventCount: 3,
+          },
+        },
+      },
+    ];
+
+    const projection = projectTaskRun(events, taskRunId);
+
+    assert.equal(projection.heavyTaskEvidence[0]?.provenance?.execution?.agentRunId, 'run-1');
+    assert.equal(
+      projection.heavyTaskEvidence[0]?.provenance?.runtimeCoverage?.highWater.eventId,
+      'result-1',
+    );
+    assert.equal(projection.events[1]?.type, 'heavy_task_evidence_provenance_linked');
+  });
+
+  test('rejects evidence provenance from a different Runtime source', () => {
+    const taskRunId = 'tr-evidence-provenance-invalid';
+    const recorded = heavyTaskEvidenceEvent(taskRunId, 'e-1', 'evidence-1', 'Bash', 1);
+    if (recorded.type !== 'heavy_task_evidence_recorded')
+      throw new Error('expected evidence event');
+    recorded.evidence.source.agentRunId = 'run-1';
+    const projection = projectTaskRun(
+      [
+        recorded,
+        {
+          type: 'heavy_task_evidence_provenance_linked',
+          id: 'e-2',
+          taskRunId,
+          attemptId: 'attempt-1',
+          ts: 2,
+          evidenceId: 'evidence-1',
+          provenance: {
+            schemaVersion: 'maka.execution_evidence_ref.v1',
+            execution: { sessionId: 'session-1', agentRunId: 'run-2' },
+            task: { taskRunId, attemptId: 'attempt-1' },
+            runtimeCoverage: {
+              highWater: {
+                ledger: 'runtime_event',
+                streamId: 'run-2',
+                sequence: 1,
+                eventId: 'result-1',
+              },
+            },
+          },
+        },
+      ],
+      taskRunId,
+    );
+
+    assert.equal(projection.heavyTaskEvidence[0]?.provenance, undefined);
+    assert.match(projection.warnings[0] ?? '', /Runtime identity does not match/);
+  });
+
+  test('does not trust provenance embedded in the compact evidence fact', () => {
+    const taskRunId = 'tr-embedded-provenance';
+    const recorded = heavyTaskEvidenceEvent(taskRunId, 'e-1', 'evidence-1', 'Bash', 1);
+    if (recorded.type !== 'heavy_task_evidence_recorded')
+      throw new Error('expected evidence event');
+    recorded.evidence.provenance = {
+      schemaVersion: 'maka.execution_evidence_ref.v1',
+      execution: { sessionId: 'session-1', agentRunId: 'run-1' },
+      task: { taskRunId, attemptId: 'attempt-1' },
+      runtimeCoverage: {
+        highWater: {
+          ledger: 'runtime_event',
+          streamId: 'run-1',
+          sequence: 1,
+          eventId: 'forged-result',
+        },
+      },
+    };
+
+    const projection = projectTaskRun([recorded], taskRunId);
+
+    assert.equal(projection.heavyTaskEvidence[0]?.provenance, undefined);
+    assert.match(projection.warnings[0] ?? '', /provenance link event is required/);
+  });
+
+  test('projects first-class task-run artifacts', () => {
+    const projection = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId: 'tr-artifact',
+          ts: 1,
+          taskId: 'task-1',
+          configId: 'cfg-1',
+        },
+        {
+          type: 'task_run_artifact_recorded',
+          id: 'e-2',
+          taskRunId: 'tr-artifact',
+          ts: 2,
+          artifact: {
+            schemaVersion: 1,
+            artifactId: 'artifact-workspace',
+            taskRunId: 'tr-artifact',
+            ts: 2,
+            kind: 'container_workspace',
+            workspacePath: '/app',
+            authority: { source: 'container_capture', authoritative: true },
+          },
+        },
+      ],
+      'tr-artifact',
+    );
+
+    assert.equal(projection.artifacts.length, 1);
+    assert.equal(projection.artifacts[0]?.workspacePath, '/app');
+    assert.equal(projection.artifacts[0]?.authority.source, 'container_capture');
+    assert.equal(projection.heavyTaskEvidence.length, 0);
+  });
+
+  test('projects compact evidence for heavy-task runtime artifacts and skips official artifacts', () => {
+    const taskRunId = 'tr-artifact-evidence';
+    const projection = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId,
+          ts: 1,
+          taskId: 'task-1',
+          configId: 'cfg-1',
+        },
+        {
+          type: 'heavy_task_mode_recorded',
+          id: 'e-2',
+          taskRunId,
+          ts: 2,
+          facts: {
+            schemaVersion: 1,
+            enabled: true,
+            triggerSource: 'config',
+            triggerReason: 'long public task',
+            policyVersion: 'maka-heavy-task-policy.v1',
+          },
+        },
+        {
+          type: 'task_run_artifact_recorded',
+          id: 'e-3',
+          taskRunId,
+          ts: 3,
+          artifact: {
+            schemaVersion: 1,
+            artifactId: 'artifact-runtime',
+            taskRunId,
+            ts: 3,
+            kind: 'generated_output',
+            path: 'build-output.log',
+            authority: {
+              source: 'runtime',
+              authoritative: false,
+              label: 'public runtime artifact',
+            },
+            metadata: { label: 'public label', body: 'raw artifact body' },
+          },
+        },
+        {
+          type: 'task_run_artifact_recorded',
+          id: 'e-4',
+          taskRunId,
+          ts: 4,
+          artifact: {
+            schemaVersion: 1,
+            artifactId: 'artifact-official',
+            taskRunId,
+            ts: 4,
+            kind: 'benchmark_manifest',
+            path: 'official-verifier-output.json',
+            authority: { source: 'official_harbor_verifier', authoritative: true },
+          },
+        },
+      ],
+      taskRunId,
+    );
+
+    assert.equal(projection.artifacts.length, 2);
+    assert.equal(projection.heavyTaskEvidence.length, 1);
+    assert.equal(projection.latestHeavyTaskEvidence?.artifact?.artifactId, 'artifact-runtime');
+    assert.equal(projection.latestHeavyTaskEvidence?.artifact?.authority?.source, 'runtime');
+    assert.equal(projection.latestHeavyTaskEvidence?.artifact?.metadata?.label, 'public label');
+    assert.doesNotMatch(
+      JSON.stringify(projection.heavyTaskEvidence),
+      /raw artifact body|official-verifier-output/,
+    );
+  });
+
+  test('projects heavy-task mode facts', () => {
+    const projection = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId: 'tr-heavy',
+          ts: 1,
+          taskId: 'task-1',
+          configId: 'cfg-1',
+        },
+        {
+          type: 'heavy_task_mode_recorded',
+          id: 'e-2',
+          taskRunId: 'tr-heavy',
+          ts: 2,
+          facts: {
+            schemaVersion: 1,
+            enabled: true,
+            triggerSource: 'task_metadata',
+            triggerReason: 'task declared heavy',
+            policyVersion: 'maka-heavy-task-policy.v1',
+          },
+        },
+      ],
+      'tr-heavy',
+    );
+
+    assert.deepEqual(projection.heavyTaskMode, {
+      schemaVersion: 1,
+      enabled: true,
+      triggerSource: 'task_metadata',
+      triggerReason: 'task declared heavy',
+      policyVersion: 'maka-heavy-task-policy.v1',
+    });
+  });
+
+  test('projects heavy-task inventory and todo snapshots from replay order', () => {
+    const taskRunId = 'tr-progress';
+    const projection = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId,
+          ts: 1,
+          taskId: 'task-1',
+          configId: 'cfg-1',
+        },
+        {
+          type: 'heavy_task_inventory_recorded',
+          id: 'e-2',
+          taskRunId,
+          ts: 2,
+          inventory: {
+            schemaVersion: 1,
+            inventoryId: 'inventory-1',
+            taskRunId,
+            ts: 2,
+            summary: 'Initial inventory',
+            items: [{ path: 'README.md', kind: 'file', status: 'observed' }],
+            source: { kind: 'model_tool', toolCallId: 'tool-1' },
+          },
+        },
+        {
+          type: 'heavy_task_todos_recorded',
+          id: 'e-3',
+          taskRunId,
+          ts: 3,
+          todos: {
+            schemaVersion: 1,
+            todoSetId: 'todos-1',
+            taskRunId,
+            ts: 3,
+            items: [
+              { id: 'inspect', content: 'Inspect files', status: 'in_progress', priority: 'high' },
+            ],
+            source: { kind: 'model_tool', toolCallId: 'tool-2' },
+          },
+        },
+        {
+          type: 'heavy_task_inventory_recorded',
+          id: 'e-4',
+          taskRunId,
+          ts: 4,
+          inventory: {
+            schemaVersion: 1,
+            inventoryId: 'inventory-2',
+            taskRunId,
+            ts: 4,
+            summary: 'Updated inventory',
+            items: [{ path: 'src/app.js', kind: 'file', status: 'planned' }],
+            source: { kind: 'model_tool', toolCallId: 'tool-3' },
+          },
+        },
+        {
+          type: 'heavy_task_todos_recorded',
+          id: 'e-5',
+          taskRunId,
+          ts: 5,
+          todos: {
+            schemaVersion: 1,
+            todoSetId: 'todos-2',
+            taskRunId,
+            ts: 5,
+            items: [
+              {
+                id: 'edit',
+                content: 'Patch implementation',
+                status: 'pending',
+                priority: 'medium',
+              },
+            ],
+            source: { kind: 'model_tool', toolCallId: 'tool-4' },
+          },
+        },
+      ],
+      taskRunId,
+    );
+
+    assert.equal(projection.heavyTaskInventory.length, 2);
+    assert.equal(projection.latestHeavyTaskInventory?.inventoryId, 'inventory-2');
+    assert.equal(projection.latestHeavyTaskInventory?.items[0]?.path, 'src/app.js');
+    assert.equal(projection.heavyTaskTodoStates.length, 2);
+    assert.equal(projection.latestHeavyTaskTodos?.todoSetId, 'todos-2');
+    assert.equal(projection.latestHeavyTaskTodos?.items[0]?.id, 'edit');
+  });
+
+  test('projects heavy-task compact evidence from replay order', () => {
+    const taskRunId = 'tr-evidence';
+    const projection = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId,
+          ts: 1,
+          taskId: 'task-1',
+          configId: 'cfg-1',
+        },
+        heavyTaskEvidenceEvent(taskRunId, 'e-2', 'evidence-1', 'Bash', 2),
+        heavyTaskEvidenceEvent(taskRunId, 'e-3', 'evidence-2', 'Read', 3),
+      ],
+      taskRunId,
+    );
+
+    assert.equal(projection.heavyTaskEvidence.length, 2);
+    assert.equal(projection.heavyTaskEvidence[0]?.evidenceId, 'evidence-1');
+    assert.equal(projection.latestHeavyTaskEvidence?.evidenceId, 'evidence-2');
+    assert.equal(projection.latestHeavyTaskEvidence?.tool?.name, 'Read');
+  });
+
+  test('projects only accepted public heavy-task self-checks from replay', () => {
+    const taskRunId = 'tr-self-check';
+    const accepted = acceptedSelfCheck(
+      taskRunId,
+      'self-check-1',
+      'pass',
+      'npm test passed on public files.',
+    );
+    const rejectedGuard = {
+      ...acceptedSelfCheck(
+        taskRunId,
+        'self-check-2',
+        'fail',
+        'official-verifier-output.json says failed',
+      ),
+      guard: {
+        status: 'rejected' as const,
+        checkedAt: 11,
+        categories: ['official_verifier_artifacts'],
+        publicReason:
+          'Rejected because submitted evidence referenced private, hidden, or evaluator-only material.',
+      },
+    };
+    const privatePayload = acceptedSelfCheck(
+      taskRunId,
+      'self-check-3',
+      'inconclusive',
+      'hidden/tests/private_case.py revealed a failure.',
+    );
+    const projection = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId,
+          ts: 1,
+          taskId: 'task-1',
+          configId: 'cfg-1',
+        },
+        {
+          type: 'heavy_task_self_check_recorded',
+          id: 'e-2',
+          taskRunId,
+          ts: 10,
+          selfCheck: accepted,
+        },
+        {
+          type: 'heavy_task_self_check_recorded',
+          id: 'e-3',
+          taskRunId,
+          ts: 11,
+          selfCheck: rejectedGuard as unknown as HeavyTaskSemanticSelfCheckState,
+        },
+        {
+          type: 'heavy_task_self_check_recorded',
+          id: 'e-4',
+          taskRunId,
+          ts: 12,
+          selfCheck: privatePayload,
+        },
+      ],
+      taskRunId,
+    );
+
+    assert.equal(projection.heavyTaskSelfChecks.length, 1);
+    assert.equal(projection.latestHeavyTaskSelfCheck?.selfCheckId, 'self-check-1');
+    assert.deepEqual(
+      projection.heavyTaskEvidence.map((item) => item.kind),
+      ['check', 'tool', 'artifact'],
+    );
+    assert.equal(projection.heavyTaskEvidence[2]?.artifact?.path, 'build-output.log');
+    assert.equal(projection.heavyTaskEvidence[2]?.artifact?.authority?.source, 'self_check');
+    assert.equal(projection.warnings.length, 2);
+    assert.match(projection.warnings.join('\n'), /source guard did not accept/);
+  });
+
+  test('replays Self-check source binding and invalidates freshness after later workspace mutations', () => {
+    const taskRunId = 'tr-self-check-freshness';
+    const attemptId = 'attempt-1';
+    const selfCheck = {
+      ...acceptedSelfCheck(taskRunId, 'self-check-1', 'pass', 'npm test passed.'),
+      attemptId,
+      source: {
+        kind: 'model_tool' as const,
+        toolCallId: 'self-check-call',
+        sessionId: 'session-1',
+        agentRunId: 'run-1',
+        turnId: 'turn-1',
+      },
+    };
+    const revision = { kind: 'manifest' as const, ref: 'sha256:workspace-1', dirty: false };
+    const workspaceObservation: Extract<
+      TaskEvent,
+      { type: 'heavy_task_workspace_observation_recorded' }
+    >['observation'] = {
+      schemaVersion: 1,
+      observationId: 'workspace-1',
+      taskRunId,
+      ts: 3,
+      roots: ['/app/project'],
+      entries: [{ path: '/app/project/result.txt', kind: 'file', sizeBytes: 2, sha256: 'aa' }],
+      status: 'ok',
+      command: 'observe',
+      revision,
+      source: { kind: 'system', label: 'isolated workspace observation' },
+    };
+    const prefix: TaskEvent[] = [
+      {
+        type: 'task_run_created',
+        id: 'created',
+        taskRunId,
+        ts: 1,
+        taskId: 'task-1',
+        configId: 'cfg-1',
+      },
+      {
+        type: 'heavy_task_self_check_recorded',
+        id: 'self-check-event',
+        taskRunId,
+        ts: 2,
+        selfCheck,
+      },
+      {
+        type: 'heavy_task_workspace_observation_recorded',
+        id: 'workspace-event-1',
+        taskRunId,
+        ts: 3,
+        observation: workspaceObservation,
+      },
+      {
+        type: 'heavy_task_self_check_evidence_linked',
+        id: 'self-check-link',
+        taskRunId,
+        ts: 4,
+        selfCheckId: selfCheck.selfCheckId,
+        attemptId,
+        workspaceObservationId: 'workspace-1',
+        provenance: {
+          schemaVersion: 'maka.execution_evidence_ref.v1',
+          execution: {
+            sessionId: 'session-1',
+            invocationId: 'invocation-1',
+            agentRunId: 'run-1',
+            turnId: 'turn-1',
+          },
+          task: { taskRunId, attemptId },
+          runtimeCoverage: {
+            lowWater: {
+              ledger: 'runtime_event',
+              streamId: 'run-1',
+              sequence: 2,
+              eventId: 'runtime-call',
+            },
+            highWater: {
+              ledger: 'runtime_event',
+              streamId: 'run-1',
+              sequence: 3,
+              eventId: 'runtime-result',
+            },
+            eventCount: 2,
+          },
+          taskCoverage: {
+            highWater: {
+              ledger: 'task_event',
+              streamId: taskRunId,
+              sequence: 1,
+              eventId: 'self-check-event',
+            },
+            eventCount: 2,
+          },
+          workspace: revision,
+        },
+      },
+    ];
+
+    const current = projectTaskRun(prefix, taskRunId);
+    assert.equal(current.latestHeavyTaskSelfCheck?.freshness, 'current');
+    assert.equal(
+      current.latestHeavyTaskSelfCheck?.provenance?.taskCoverage?.highWater.eventId,
+      'self-check-event',
+    );
+
+    const mutationBase = heavyTaskEvidenceEvent(
+      taskRunId,
+      'mutation',
+      'write-evidence',
+      'Bash',
+      5,
+    ) as Extract<TaskEvent, { type: 'heavy_task_evidence_recorded' }>;
+    const mutation: Extract<TaskEvent, { type: 'heavy_task_evidence_recorded' }> = {
+      ...mutationBase,
+      evidence: { ...mutationBase.evidence, attemptId },
+    };
+    const mutated = projectTaskRun([...prefix, mutation], taskRunId);
+    assert.equal(mutated.latestHeavyTaskSelfCheck?.freshness, 'stale');
+    assert.deepEqual(mutated.latestHeavyTaskSelfCheck?.freshnessReasons, [
+      'later_workspace_mutation',
+    ]);
+
+    const reobserved = projectTaskRun(
+      [
+        ...mutated.events,
+        {
+          type: 'heavy_task_workspace_observation_recorded',
+          id: 'workspace-event-2',
+          taskRunId,
+          ts: 6,
+          observation: {
+            ...workspaceObservation,
+            observationId: 'workspace-2',
+            ts: 6,
+          },
+        } as TaskEvent,
+      ],
+      taskRunId,
+    );
+    assert.equal(reobserved.latestHeavyTaskSelfCheck?.freshness, 'current');
+
+    const changed = projectTaskRun(
+      [
+        ...reobserved.events,
+        {
+          type: 'heavy_task_workspace_observation_recorded',
+          id: 'workspace-event-3',
+          taskRunId,
+          ts: 7,
+          observation: {
+            ...workspaceObservation,
+            observationId: 'workspace-3',
+            ts: 7,
+            revision: { kind: 'manifest', ref: 'sha256:workspace-2', dirty: false },
+          },
+        } as TaskEvent,
+      ],
+      taskRunId,
+    );
+    assert.equal(changed.latestHeavyTaskSelfCheck?.freshness, 'stale');
+    assert.deepEqual(changed.latestHeavyTaskSelfCheck?.freshnessReasons, [
+      'workspace_revision_changed',
+    ]);
+  });
+
+  test('derives heavy-task completion from accepted self-checks and latest todos', () => {
+    const taskRunId = 'tr-heavy-completion';
+    const projection = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId,
+          ts: 1,
+          taskId: 'task-1',
+          configId: 'cfg-1',
+        },
+        {
+          type: 'heavy_task_mode_recorded',
+          id: 'e-2',
+          taskRunId,
+          ts: 2,
+          facts: {
+            schemaVersion: 1,
+            enabled: true,
+            triggerSource: 'config',
+            triggerReason: 'long public task',
+            policyVersion: 'maka-heavy-task-policy.v1',
+          },
+        },
+        {
+          type: 'heavy_task_todos_recorded',
+          id: 'e-3',
+          taskRunId,
+          ts: 3,
+          todos: {
+            schemaVersion: 1,
+            todoSetId: 'todos-1',
+            taskRunId,
+            ts: 3,
+            items: [
+              {
+                id: 'edit',
+                content: 'Patch implementation',
+                status: 'completed',
+                priority: 'high',
+              },
+              {
+                id: 'artifact',
+                kind: 'runnable_artifact',
+                content: 'Create first runnable artifact',
+                status: 'completed',
+                priority: 'high',
+                evidence: 'Runnable artifact exists.',
+              },
+              {
+                id: 'check',
+                kind: 'public_check',
+                content: 'Run public check',
+                status: 'completed',
+                priority: 'high',
+                evidence: 'Public check passed.',
+              },
+              {
+                id: 'optional',
+                content: 'Optional polish',
+                status: 'cancelled',
+                priority: 'low',
+                evidence: 'Not required by public task.',
+              },
+            ],
+            source: { kind: 'model_tool', toolCallId: 'tool-2' },
+          },
+        },
+        {
+          type: 'heavy_task_self_check_plan_recorded',
+          id: 'e-3-plan',
+          taskRunId,
+          ts: 3.5,
+          plan: acceptedSelfCheckPlan(taskRunId),
+        },
+        {
+          type: 'heavy_task_self_check_recorded',
+          id: 'e-4',
+          taskRunId,
+          ts: 4,
+          selfCheck: acceptedSelfCheck(
+            taskRunId,
+            'self-check-1',
+            'pass',
+            'npm test passed against public files.',
+          ),
+        },
+        {
+          type: 'score_result_recorded',
+          id: 'e-5',
+          taskRunId,
+          ts: 5,
+          result: {
+            id: 'score-1',
+            taskRunId,
+            ts: 5,
+            passed: false,
+            scored: true,
+            eligible: true,
+            taxonomy: 'verification_failed',
+            authority: { source: 'official_harbor_verifier', authoritative: true },
+          },
+        },
+        {
+          type: 'task_run_budget_exhausted',
+          id: 'e-6',
+          taskRunId,
+          ts: 6,
+          error: { message: 'runtime step cap reached', class: 'max_steps' },
+        },
+      ],
+      taskRunId,
+    );
+
+    assert.equal(projection.heavyTaskCompletion?.runtime.taskRunStatus, 'budget_exhausted');
+    assert.equal(projection.heavyTaskSelfCheckPlans.length, 1);
+    assert.equal(projection.latestHeavyTaskSelfCheckPlan?.planId, 'plan-1');
+    assert.equal(projection.heavyTaskCompletion?.runtime.taxonomy, 'verification_failed');
+    assert.equal(projection.heavyTaskCompletion?.runtime.capKind, 'runtime_step_cap');
+    assert.equal(projection.heavyTaskCompletion?.semantic.status, 'complete');
+    assert.deepEqual(projection.heavyTaskCompletion?.semantic.nonblockingTodoIds, ['optional']);
+    assert.equal(projection.heavyTaskCompletion?.finalization.eligible, true);
+    assert.equal(projection.result?.taxonomy, 'verification_failed');
+    assert.equal(projection.result?.passed, false);
+  });
+
+  test('projects heavy-task self-check gate events while old traces remain ungated', () => {
+    const taskRunId = 'tr-heavy-gate';
+    const projection = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId,
+          ts: 1,
+          taskId: 'task-1',
+          configId: 'cfg-1',
+        },
+        {
+          type: 'heavy_task_self_check_gate_recorded',
+          id: 'e-2',
+          taskRunId,
+          ts: 2,
+          gate: {
+            schemaVersion: 1,
+            action: 'repair_prompt',
+            reason: 'missing accepted public self-check evidence',
+            attempt: 1,
+            maxAttempts: 1,
+            checklist: [
+              {
+                id: 'check-1',
+                kind: 'workspace_hygiene',
+                source: 'generic_heavy_task',
+                description:
+                  'Pass self-check must include sandbox execution evidence and a public workspace hygiene guard',
+                evidenceRequired: 'command_or_artifact',
+              },
+            ],
+            prompt: 'run public checks and self_check_submit',
+          },
+        },
+      ],
+      taskRunId,
+    );
+
+    assert.equal(projection.heavyTaskSelfCheckGates.length, 1);
+    assert.equal(projection.latestHeavyTaskSelfCheckGate?.action, 'repair_prompt');
+    assert.equal(
+      projection.latestHeavyTaskSelfCheckGate?.reason,
+      'missing accepted public self-check evidence',
+    );
+
+    const oldTrace = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId: 'tr-old',
+          ts: 1,
+          taskId: 'task-old',
+          configId: 'cfg-1',
+        },
+      ],
+      'tr-old',
+    );
+    assert.deepEqual(oldTrace.heavyTaskSelfCheckPlans, []);
+    assert.equal(oldTrace.latestHeavyTaskSelfCheckPlan, undefined);
+    assert.deepEqual(oldTrace.heavyTaskSelfCheckGates, []);
+    assert.equal(oldTrace.latestHeavyTaskSelfCheckGate, undefined);
+  });
+
+  test('projects isolation, permission, inbox, and needs_approval facts', () => {
+    const taskRunId = 'tr-approval';
+    const request = {
+      schemaVersion: 1 as const,
+      requestId: 'req-1',
+      taskRunId,
+      attemptId: 'a-1',
+      toolCallId: 'tool-1',
+      toolName: 'Bash',
+      normalizedArgsHash: 'abc123',
+      resourceScope: { kind: 'command' as const, value: 'rm file', mode: 'execute' as const },
+      reason: 'dangerous command',
+      preview: { argKeys: ['command'] },
+      requestedAt: 3,
+      expiresAt: 100,
+    };
+    const grant = {
+      schemaVersion: 1 as const,
+      grantId: 'grant-1',
+      requestId: 'req-1',
+      taskRunId,
+      attemptId: 'a-1',
+      toolCallId: 'tool-1',
+      toolName: 'Bash',
+      normalizedArgsHash: 'abc123',
+      resourceScope: request.resourceScope,
+      decision: 'allow' as const,
+      actor: { kind: 'test' as const },
+      source: 'test_fixture' as const,
+      decidedAt: 4,
+      expiresAt: 100,
+    };
+    const projection = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId,
+          ts: 1,
+          taskId: 'task-1',
+          configId: 'cfg-1',
+        },
+        {
+          type: 'isolation_policy_recorded',
+          id: 'e-2',
+          taskRunId,
+          ts: 2,
+          facts: {
+            schemaVersion: 1,
+            backendKind: 'ai-sdk',
+            required: true,
+            mode: 'external',
+            label: 'unit isolation',
+            assertionSource: 'headless_deps',
+            validatedAt: 2,
+          },
+        },
+        {
+          type: 'workspace_lease_recorded',
+          id: 'e-3',
+          taskRunId,
+          ts: 2,
+          lease: {
+            schemaVersion: 1,
+            leaseId: 'lease-1',
+            taskRunId,
+            attemptId: 'a-1',
+            sourceWorkspaceDir: '/src',
+            workspaceDir: '/tmp/work',
+            leaseKind: 'throwaway_copy',
+            writable: true,
+            cleanupPolicy: 'cleanup_on_finally',
+            createdAt: 2,
+          },
+        },
+        {
+          type: 'tool_executor_identity_recorded',
+          id: 'e-4',
+          taskRunId,
+          ts: 2,
+          identity: {
+            schemaVersion: 1,
+            executorId: 'exec-1',
+            taskRunId,
+            attemptId: 'a-1',
+            toolNames: ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'],
+            isolationMode: 'external',
+            label: 'unit isolation',
+          },
+        },
+        { type: 'task_attempt_started', id: 'e-5', taskRunId, ts: 2, attemptId: 'a-1' },
+        { type: 'permission_request_recorded', id: 'e-6', taskRunId, ts: 3, request },
+        { type: 'permission_grant_recorded', id: 'e-7', taskRunId, ts: 4, grant },
+        {
+          type: 'task_inbox_item_recorded',
+          id: 'e-8',
+          taskRunId,
+          ts: 5,
+          item: {
+            schemaVersion: 1,
+            inboxItemId: 'inbox-1',
+            taskRunId,
+            attemptId: 'a-1',
+            kind: 'approval_request',
+            status: 'open',
+            title: 'Approval required',
+            reason: 'dangerous command',
+            createdAt: 5,
+            relatedRequestId: 'req-1',
+          },
+        },
+        {
+          type: 'task_run_needs_approval',
+          id: 'e-9',
+          taskRunId,
+          ts: 6,
+          attemptId: 'a-1',
+          reason: 'approval',
+          inboxItemId: 'inbox-1',
+        },
+      ],
+      taskRunId,
+    );
+
+    assert.equal(projection.status, 'needs_approval');
+    assert.equal(projection.attempts[0]?.status, 'needs_approval');
+    assert.equal(projection.isolation?.label, 'unit isolation');
+    assert.equal(projection.workspaceLease?.workspaceDir, '/tmp/work');
+    assert.equal(projection.toolExecutors[0]?.executorId, 'exec-1');
+    assert.equal(projection.permissionRequests[0]?.normalizedArgsHash, 'abc123');
+    assert.equal(projection.permissionGrants[0]?.grantId, 'grant-1');
+    assert.equal(projection.inboxItems[0]?.status, 'open');
+    assert.deepEqual(projection.parked, { reason: 'approval', inboxItemId: 'inbox-1', since: 6 });
+  });
+
+  test('terminal events override open inbox parked state', () => {
+    const projection = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId: 'tr-terminal',
+          ts: 1,
+          taskId: 'task-1',
+          configId: 'cfg-1',
+        },
+        {
+          type: 'task_inbox_item_recorded',
+          id: 'e-2',
+          taskRunId: 'tr-terminal',
+          ts: 2,
+          item: {
+            schemaVersion: 1,
+            inboxItemId: 'inbox-1',
+            taskRunId: 'tr-terminal',
+            kind: 'approval_request',
+            status: 'open',
+            title: 'Approval required',
+            reason: 'permission',
+            createdAt: 2,
+          },
+        },
+        {
+          type: 'task_run_needs_approval',
+          id: 'e-3',
+          taskRunId: 'tr-terminal',
+          ts: 3,
+          reason: 'approval',
+          inboxItemId: 'inbox-1',
+        },
+        { type: 'task_run_policy_denied', id: 'e-4', taskRunId: 'tr-terminal', ts: 4 },
+      ],
+      'tr-terminal',
+    );
+
+    assert.equal(projection.status, 'policy_denied');
+    assert.equal(projection.parked, undefined);
+  });
+
+  test('projects failed and cancelled terminal events', () => {
+    const failed = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId: 'tr-f',
+          ts: 1,
+          taskId: 'task-f',
+          configId: 'cfg',
+        },
+        {
+          type: 'task_run_failed',
+          id: 'e-2',
+          taskRunId: 'tr-f',
+          ts: 2,
+          error: { message: 'backend blew up', class: 'backend_failed' },
+        },
+      ],
+      'tr-f',
+    );
+    assert.equal(failed.status, 'failed');
+    assert.equal(failed.error?.message, 'backend blew up');
+
+    const cancelled = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId: 'tr-c',
+          ts: 1,
+          taskId: 'task-c',
+          configId: 'cfg',
+        },
+        { type: 'task_run_cancelled', id: 'e-2', taskRunId: 'tr-c', ts: 2 },
+      ],
+      'tr-c',
+    );
+    assert.equal(cancelled.status, 'cancelled');
+    assert.equal(cancelled.error?.class, 'cancelled');
+  });
+
+  test('projects queued, verifying, incomplete, blocked, policy, budget, and aborted states', () => {
+    const queued = projectTaskRun(
+      [
+        {
+          type: 'task_run_queued',
+          id: 'e-1',
+          taskRunId: 'tr-q',
+          ts: 1,
+          taskId: 'task-q',
+          configId: 'cfg',
+        },
+      ],
+      'tr-q',
+    );
+    assert.equal(queued.status, 'queued');
+    assert.equal(queued.taskId, 'task-q');
+
+    const verifying = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId: 'tr-v',
+          ts: 1,
+          taskId: 'task-v',
+          configId: 'cfg',
+        },
+        { type: 'task_run_started', id: 'e-2', taskRunId: 'tr-v', ts: 2 },
+        { type: 'task_run_verifying', id: 'e-3', taskRunId: 'tr-v', ts: 3 },
+      ],
+      'tr-v',
+    );
+    assert.equal(verifying.status, 'verifying');
+
+    const terminalCases: Array<[TaskEvent, string, string]> = [
+      [
+        { type: 'task_run_incomplete', id: 'e-2', taskRunId: 'tr-x', ts: 2 },
+        'incomplete',
+        'agent_incomplete',
+      ],
+      [{ type: 'task_run_blocked', id: 'e-2', taskRunId: 'tr-x', ts: 2 }, 'blocked', 'blocked'],
+      [
+        { type: 'task_run_policy_denied', id: 'e-2', taskRunId: 'tr-x', ts: 2 },
+        'policy_denied',
+        'policy_denied',
+      ],
+      [
+        { type: 'task_run_budget_exhausted', id: 'e-2', taskRunId: 'tr-x', ts: 2 },
+        'budget_exhausted',
+        'budget_exhausted',
+      ],
+      [{ type: 'task_run_aborted', id: 'e-2', taskRunId: 'tr-x', ts: 2 }, 'aborted', 'aborted'],
+    ];
+
+    for (const [terminalEvent, status, errorClass] of terminalCases) {
+      const projection = projectTaskRun(
+        [
+          {
+            type: 'task_run_created',
+            id: 'e-1',
+            taskRunId: 'tr-x',
+            ts: 1,
+            taskId: 'task-x',
+            configId: 'cfg',
+          },
+          terminalEvent,
+        ],
+        'tr-x',
+      );
+      assert.equal(projection.status, status);
+      assert.equal(projection.error?.class, errorClass);
+    }
+  });
+
+  test('uses the last terminal event and records a warning', () => {
+    const projection = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId: 'tr-1',
+          ts: 1,
+          taskId: 'task-1',
+          configId: 'cfg-1',
+        },
+        {
+          type: 'task_run_failed',
+          id: 'e-2',
+          taskRunId: 'tr-1',
+          ts: 2,
+          error: { message: 'first terminal' },
+        },
+        { type: 'task_run_completed', id: 'e-3', taskRunId: 'tr-1', ts: 3 },
+      ],
+      'tr-1',
+    );
+
+    assert.equal(projection.status, 'completed');
+    assert.match(projection.warnings[0] ?? '', /multiple terminal/);
+  });
+
+  test('event_corrupt stays in replay and surfaces as a projection warning', () => {
+    const projection = projectTaskRun(
+      [
+        {
+          type: 'task_run_created',
+          id: 'e-1',
+          taskRunId: 'tr-1',
+          ts: 1,
+          taskId: 'task-1',
+          configId: 'cfg-1',
+        },
+        {
+          type: 'event_corrupt',
+          id: 'e-corrupt',
+          taskRunId: 'tr-1',
+          ts: 2,
+          raw: '{',
+          error: 'invalid json',
+        },
+        { type: 'task_run_completed', id: 'e-3', taskRunId: 'tr-1', ts: 3 },
+      ],
+      'tr-1',
+    );
+
+    assert.equal(projection.events.length, 3);
+    assert.match(projection.warnings[0] ?? '', /corrupt event/);
+    assert.equal(projection.status, 'completed');
+  });
+});
+
+function acceptedSelfCheck(
+  taskRunId: string,
+  selfCheckId: string,
+  status: HeavyTaskSemanticSelfCheckState['status'],
+  publicReason: string,
+): HeavyTaskSemanticSelfCheckState {
+  return {
+    schemaVersion: 1,
+    selfCheckId,
+    taskRunId,
+    ts: 10,
+    status,
+    publicReason,
+    commandEvidence: [{ command: 'npm test', exitCode: 0, outputExcerpt: 'public tests passed' }],
+    artifactEvidence: [{ path: 'build-output.log', kind: 'log', exists: true }],
+    executionHygiene: {
+      sandbox: {
+        root: '/tmp/maka-self-check/run-1',
+        strategy: 'scratch_dir',
+        commandCwd: '/tmp/maka-self-check/run-1',
+        outputPolicy: 'scratch_only',
+      },
+      scratchUsed: true,
+      scratchPath: '/tmp/maka-self-check/run-1',
+      cleanupPerformed: true,
+      workspaceSideEffects: 'none',
+      workspaceGuard: {
+        checked: true,
+        checkedPaths: ['/app'],
+        addedPaths: [],
+        modifiedPaths: [],
+        removedPaths: [],
+      },
+    },
+    guard: {
+      status: 'accepted',
+      checkedAt: 10,
+      categories: [],
+      publicReason: 'Accepted as public, task-derived advisory self-check evidence.',
+    },
+    source: { kind: 'model_tool', toolCallId: 'tool-1' },
+  };
+}
+
+function acceptedSelfCheckPlan(taskRunId: string): HeavyTaskSelfCheckPlanState {
+  return {
+    schemaVersion: 1,
+    planId: 'plan-1',
+    taskRunId,
+    ts: 3.5,
+    finalArtifacts: [
+      {
+        path: 'build-output.log',
+        purpose: 'public self-check artifact',
+        publicReason: 'visible public check creates this artifact',
+      },
+    ],
+    selfCheckScratch: {
+      root: '/tmp/maka-self-check/run-1',
+      expectedGeneratedPaths: ['/tmp/maka-self-check/run-1/check.log'],
+      publicReason: 'public checks write temporary output under scratch',
+    },
+    workspaceGuardPlan: {
+      checkedPaths: ['/app'],
+      expectedAddedPaths: ['build-output.log'],
+      expectedGeneratedPathsOutsideScratch: [],
+      publicReason: 'public guard checks the deliverable workspace',
+    },
+    publicReason: 'plan is derived from visible public task evidence',
+    guard: {
+      status: 'accepted',
+      checkedAt: 3.5,
+      categories: [],
+      publicReason: 'Accepted as public, task-derived advisory self-check plan.',
+    },
+    source: { kind: 'model_tool', toolCallId: 'tool-plan' },
+  };
+}

--- a/packages/headless/src/__tests__/task-run-store.test.ts
+++ b/packages/headless/src/__tests__/task-run-store.test.ts
@@ -1,29 +1,37 @@
 import assert from 'node:assert/strict';
-import { appendFile, mkdtemp, rm } from 'node:fs/promises';
+import { fork, type ChildProcess } from 'node:child_process';
+import { appendFile, lstat, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
-import type {
-  HeavyTaskSelfCheckPlanState,
-  HeavyTaskSemanticSelfCheckState,
-  TaskEvent,
-} from '../task-contracts.js';
-import { taskAttemptExecutionEvidence } from '../task-execution-lineage.js';
+import {
+  createHeadlessRootLease,
+  resolveStorageRoot,
+  StorageRootAuthorityError,
+  tryAcquireInteractiveRootOwner,
+  type StorageRootLease,
+} from '@maka/storage/root-authority';
+import type { TaskEvent } from '../task-contracts.js';
 import {
   createInMemoryTaskRunStore,
-  createTaskRunStore,
-  projectTaskRun,
+  openHeadlessTaskRunReader,
+  openHeadlessTaskRunWriter,
 } from '../task-run-store.js';
+
+const taskRunWriterProcessPath = fileURLToPath(
+  new URL('./fixtures/task-run-writer-process.js', import.meta.url),
+);
 
 function eventIdFactory(): () => string {
   let i = 0;
   return () => `e-${++i}`;
 }
 
-function completedEvents(taskRunId = 'tr-1'): TaskEvent[] {
+function completedEvents(taskRunId = 'tr-1', taskId = 'task-1', configId = 'cfg-1'): TaskEvent[] {
   const id = eventIdFactory();
   return [
-    { type: 'task_run_created', id: id(), taskRunId, ts: 10, taskId: 'task-1', configId: 'cfg-1' },
+    { type: 'task_run_created', id: id(), taskRunId, ts: 10, taskId, configId },
     {
       type: 'task_run_started',
       id: id(),
@@ -119,53 +127,43 @@ function completedEvents(taskRunId = 'tr-1'): TaskEvent[] {
   ];
 }
 
-function heavyTaskEvidenceEvent(
-  taskRunId: string,
-  id: string,
-  evidenceId: string,
-  name: 'Bash' | 'Read',
-  ts: number,
-): TaskEvent {
-  return {
-    type: 'heavy_task_evidence_recorded',
-    id,
-    taskRunId,
-    ts,
-    evidence: {
-      schemaVersion: 1,
-      evidenceId,
-      taskRunId,
-      ts,
-      kind: 'tool',
-      public: true,
-      source: { kind: 'model_tool', toolCallId: `tool-${ts}`, toolName: name },
-      tool: {
-        name,
-        inputSummary: name === 'Bash' ? { command: 'npm test' } : { path: 'README.md' },
-        ...(name === 'Bash' ? { exitCode: 0 } : {}),
-        ok: true,
-        outputs: [
-          {
-            stream: name === 'Bash' ? 'stdout' : 'content',
-            excerpt: 'bounded public summary',
-            byteCount: 22,
-            lineCount: 1,
-            truncated: false,
-            truncationRef: {
-              truncated: false,
-              originalBytes: 22,
-              visibleBytes: 22,
-              omittedBytes: 0,
-            },
-          },
-        ],
-        diff: { status: 'not_applicable' },
-      },
-    },
-  };
-}
-
 describe('TaskRunStore', () => {
+  test('binds file readers and writers to Headless leases', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-task-run-lease-'));
+    const headlessRoot = join(base, 'headless');
+    const interactiveRoot = join(base, 'interactive');
+    try {
+      const capability = await resolveStorageRoot({ path: headlessRoot, kind: 'headless' });
+      const writer = await openHeadlessTaskRunWriter(createHeadlessRootLease(capability, 'write'));
+      const event = completedEvents('leased-run')[0]!;
+      await writer.appendEvent('leased-run', event);
+
+      const reader = await openHeadlessTaskRunReader(createHeadlessRootLease(capability, 'read'));
+      assert.equal('appendEvent' in reader, false);
+      assert.deepEqual(await reader.readEvents('leased-run'), [event]);
+      assert.deepEqual(await reader.listTaskRunIds(), ['leased-run']);
+
+      const interactive = await resolveStorageRoot({ path: interactiveRoot, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(interactive);
+      assert.ok(owner);
+      try {
+        await assert.rejects(
+          () =>
+            openHeadlessTaskRunWriter(
+              owner.lease as unknown as StorageRootLease<'headless', 'write'>,
+            ),
+          (error: unknown) =>
+            error instanceof StorageRootAuthorityError && error.code === 'invalid_lease',
+        );
+        await assert.rejects(() => lstat(join(interactiveRoot, 'task-runs')), { code: 'ENOENT' });
+      } finally {
+        await owner.close();
+      }
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  });
+
   test('appends and replays events in order', async () => {
     const store = createInMemoryTaskRunStore();
     const events = completedEvents();
@@ -181,1284 +179,6 @@ describe('TaskRunStore', () => {
     );
   });
 
-  test('projects status, attempts, observations, verifier, and score from replay', async () => {
-    const store = createInMemoryTaskRunStore();
-    for (const event of completedEvents()) await store.appendEvent(event.taskRunId, event);
-
-    const projection = await store.project('tr-1');
-    assert.equal(projection.status, 'completed');
-    assert.equal(projection.taskId, 'task-1');
-    assert.equal(projection.configId, 'cfg-1');
-    assert.equal(projection.sessionId, 's-1');
-    assert.equal(projection.agentRunId, 'r-1');
-    assert.equal(projection.attempts[0]?.status, 'completed');
-    assert.deepEqual(projection.attempts[0]?.executionLineage, []);
-    assert.equal(projection.selfChecks[0]?.summary, 'looks solved');
-    assert.equal(projection.feedback[0]?.summary, 'tests passed');
-    assert.equal(projection.decisions[0]?.decision, 'stop');
-    assert.equal(projection.latestVerifierResult?.exitCode, 0);
-    assert.equal(projection.latestScoreResult?.taxonomy, 'passed');
-    assert.deepEqual(projection.result, {
-      passed: true,
-      taxonomy: 'passed',
-      verifierResultId: 'v-1',
-      scoreResultId: 'score-1',
-    });
-  });
-
-  test('projects every AgentRun linked to one attempt without copying Runtime facts', () => {
-    const taskRunId = 'tr-lineage';
-    const attemptId = 'attempt-1';
-    const events: TaskEvent[] = [
-      {
-        type: 'task_run_created',
-        id: 'e-1',
-        taskRunId,
-        ts: 1,
-        taskId: 'task-1',
-        configId: 'cfg-1',
-      },
-      {
-        type: 'task_run_started',
-        id: 'e-2',
-        taskRunId,
-        ts: 2,
-        sessionId: 'session-1',
-        agentRunId: 'run-1',
-      },
-      {
-        type: 'task_attempt_started',
-        id: 'e-3',
-        taskRunId,
-        ts: 3,
-        attemptId,
-        sessionId: 'session-1',
-        agentRunId: 'run-1',
-      },
-      {
-        type: 'task_attempt_execution_linked',
-        id: 'e-4',
-        taskRunId,
-        attemptId,
-        ts: 4,
-        evidence: taskAttemptExecutionEvidence({
-          taskRunId,
-          attemptId,
-          sessionId: 'session-1',
-          invocationId: 'invocation-1',
-          agentRunId: 'run-1',
-          turnId: 'turn-1',
-          runtimeEvents: [],
-        }),
-      },
-      {
-        type: 'task_attempt_execution_linked',
-        id: 'e-5',
-        taskRunId,
-        attemptId,
-        ts: 5,
-        evidence: taskAttemptExecutionEvidence({
-          taskRunId,
-          attemptId,
-          sessionId: 'session-1',
-          invocationId: 'invocation-2',
-          agentRunId: 'run-2',
-          turnId: 'turn-2',
-          runtimeEvents: [],
-        }),
-      },
-      {
-        type: 'task_attempt_completed',
-        id: 'e-6',
-        taskRunId,
-        ts: 6,
-        attemptId,
-        status: 'completed',
-      },
-    ];
-
-    const projection = projectTaskRun(events, taskRunId);
-
-    assert.equal(projection.agentRunId, 'run-1');
-    assert.deepEqual(
-      projection.executionLineage.map((ref) => ref.execution?.agentRunId),
-      ['run-1', 'run-2'],
-    );
-    assert.deepEqual(
-      projection.attempts[0]?.executionLineage.map((ref) => ref.execution?.agentRunId),
-      ['run-1', 'run-2'],
-    );
-  });
-
-  test('rejects lineage whose task identity does not match the owning event', () => {
-    const taskRunId = 'tr-lineage-invalid';
-    const projection = projectTaskRun(
-      [
-        { type: 'task_attempt_started', id: 'e-1', taskRunId, ts: 1, attemptId: 'attempt-1' },
-        {
-          type: 'task_attempt_execution_linked',
-          id: 'e-2',
-          taskRunId,
-          attemptId: 'attempt-1',
-          ts: 2,
-          evidence: taskAttemptExecutionEvidence({
-            taskRunId: 'another-task-run',
-            attemptId: 'attempt-1',
-            sessionId: 'session-1',
-            agentRunId: 'run-1',
-            runtimeEvents: [],
-          }),
-        },
-      ],
-      taskRunId,
-    );
-
-    assert.equal(projection.executionLineage.length, 0);
-    assert.match(projection.warnings[0] ?? '', /task identity does not match/);
-  });
-
-  test('projects Runtime provenance onto compact evidence without copying Runtime facts', () => {
-    const taskRunId = 'tr-evidence-provenance';
-    const recorded = heavyTaskEvidenceEvent(taskRunId, 'e-1', 'evidence-1', 'Bash', 1);
-    if (recorded.type !== 'heavy_task_evidence_recorded')
-      throw new Error('expected evidence event');
-    recorded.evidence.attemptId = 'attempt-1';
-    recorded.evidence.source = {
-      ...recorded.evidence.source,
-      sessionId: 'session-1',
-      agentRunId: 'run-1',
-      turnId: 'turn-1',
-    };
-    const events: TaskEvent[] = [
-      recorded,
-      {
-        type: 'heavy_task_evidence_provenance_linked',
-        id: 'e-2',
-        taskRunId,
-        attemptId: 'attempt-1',
-        ts: 2,
-        evidenceId: 'evidence-1',
-        provenance: {
-          schemaVersion: 'maka.execution_evidence_ref.v1',
-          execution: {
-            sessionId: 'session-1',
-            invocationId: 'invocation-1',
-            agentRunId: 'run-1',
-            turnId: 'turn-1',
-          },
-          task: { taskRunId, attemptId: 'attempt-1' },
-          runtimeCoverage: {
-            lowWater: {
-              ledger: 'runtime_event',
-              streamId: 'run-1',
-              sequence: 4,
-              eventId: 'call-1',
-            },
-            highWater: {
-              ledger: 'runtime_event',
-              streamId: 'run-1',
-              sequence: 6,
-              eventId: 'result-1',
-            },
-            eventCount: 3,
-          },
-        },
-      },
-    ];
-
-    const projection = projectTaskRun(events, taskRunId);
-
-    assert.equal(projection.heavyTaskEvidence[0]?.provenance?.execution?.agentRunId, 'run-1');
-    assert.equal(
-      projection.heavyTaskEvidence[0]?.provenance?.runtimeCoverage?.highWater.eventId,
-      'result-1',
-    );
-    assert.equal(projection.events[1]?.type, 'heavy_task_evidence_provenance_linked');
-  });
-
-  test('rejects evidence provenance from a different Runtime source', () => {
-    const taskRunId = 'tr-evidence-provenance-invalid';
-    const recorded = heavyTaskEvidenceEvent(taskRunId, 'e-1', 'evidence-1', 'Bash', 1);
-    if (recorded.type !== 'heavy_task_evidence_recorded')
-      throw new Error('expected evidence event');
-    recorded.evidence.source.agentRunId = 'run-1';
-    const projection = projectTaskRun(
-      [
-        recorded,
-        {
-          type: 'heavy_task_evidence_provenance_linked',
-          id: 'e-2',
-          taskRunId,
-          attemptId: 'attempt-1',
-          ts: 2,
-          evidenceId: 'evidence-1',
-          provenance: {
-            schemaVersion: 'maka.execution_evidence_ref.v1',
-            execution: { sessionId: 'session-1', agentRunId: 'run-2' },
-            task: { taskRunId, attemptId: 'attempt-1' },
-            runtimeCoverage: {
-              highWater: {
-                ledger: 'runtime_event',
-                streamId: 'run-2',
-                sequence: 1,
-                eventId: 'result-1',
-              },
-            },
-          },
-        },
-      ],
-      taskRunId,
-    );
-
-    assert.equal(projection.heavyTaskEvidence[0]?.provenance, undefined);
-    assert.match(projection.warnings[0] ?? '', /Runtime identity does not match/);
-  });
-
-  test('does not trust provenance embedded in the compact evidence fact', () => {
-    const taskRunId = 'tr-embedded-provenance';
-    const recorded = heavyTaskEvidenceEvent(taskRunId, 'e-1', 'evidence-1', 'Bash', 1);
-    if (recorded.type !== 'heavy_task_evidence_recorded')
-      throw new Error('expected evidence event');
-    recorded.evidence.provenance = {
-      schemaVersion: 'maka.execution_evidence_ref.v1',
-      execution: { sessionId: 'session-1', agentRunId: 'run-1' },
-      task: { taskRunId, attemptId: 'attempt-1' },
-      runtimeCoverage: {
-        highWater: {
-          ledger: 'runtime_event',
-          streamId: 'run-1',
-          sequence: 1,
-          eventId: 'forged-result',
-        },
-      },
-    };
-
-    const projection = projectTaskRun([recorded], taskRunId);
-
-    assert.equal(projection.heavyTaskEvidence[0]?.provenance, undefined);
-    assert.match(projection.warnings[0] ?? '', /provenance link event is required/);
-  });
-
-  test('projects first-class task-run artifacts', () => {
-    const projection = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId: 'tr-artifact',
-          ts: 1,
-          taskId: 'task-1',
-          configId: 'cfg-1',
-        },
-        {
-          type: 'task_run_artifact_recorded',
-          id: 'e-2',
-          taskRunId: 'tr-artifact',
-          ts: 2,
-          artifact: {
-            schemaVersion: 1,
-            artifactId: 'artifact-workspace',
-            taskRunId: 'tr-artifact',
-            ts: 2,
-            kind: 'container_workspace',
-            workspacePath: '/app',
-            authority: { source: 'container_capture', authoritative: true },
-          },
-        },
-      ],
-      'tr-artifact',
-    );
-
-    assert.equal(projection.artifacts.length, 1);
-    assert.equal(projection.artifacts[0]?.workspacePath, '/app');
-    assert.equal(projection.artifacts[0]?.authority.source, 'container_capture');
-    assert.equal(projection.heavyTaskEvidence.length, 0);
-  });
-
-  test('projects compact evidence for heavy-task runtime artifacts and skips official artifacts', () => {
-    const taskRunId = 'tr-artifact-evidence';
-    const projection = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId,
-          ts: 1,
-          taskId: 'task-1',
-          configId: 'cfg-1',
-        },
-        {
-          type: 'heavy_task_mode_recorded',
-          id: 'e-2',
-          taskRunId,
-          ts: 2,
-          facts: {
-            schemaVersion: 1,
-            enabled: true,
-            triggerSource: 'config',
-            triggerReason: 'long public task',
-            policyVersion: 'maka-heavy-task-policy.v1',
-          },
-        },
-        {
-          type: 'task_run_artifact_recorded',
-          id: 'e-3',
-          taskRunId,
-          ts: 3,
-          artifact: {
-            schemaVersion: 1,
-            artifactId: 'artifact-runtime',
-            taskRunId,
-            ts: 3,
-            kind: 'generated_output',
-            path: 'build-output.log',
-            authority: {
-              source: 'runtime',
-              authoritative: false,
-              label: 'public runtime artifact',
-            },
-            metadata: { label: 'public label', body: 'raw artifact body' },
-          },
-        },
-        {
-          type: 'task_run_artifact_recorded',
-          id: 'e-4',
-          taskRunId,
-          ts: 4,
-          artifact: {
-            schemaVersion: 1,
-            artifactId: 'artifact-official',
-            taskRunId,
-            ts: 4,
-            kind: 'benchmark_manifest',
-            path: 'official-verifier-output.json',
-            authority: { source: 'official_harbor_verifier', authoritative: true },
-          },
-        },
-      ],
-      taskRunId,
-    );
-
-    assert.equal(projection.artifacts.length, 2);
-    assert.equal(projection.heavyTaskEvidence.length, 1);
-    assert.equal(projection.latestHeavyTaskEvidence?.artifact?.artifactId, 'artifact-runtime');
-    assert.equal(projection.latestHeavyTaskEvidence?.artifact?.authority?.source, 'runtime');
-    assert.equal(projection.latestHeavyTaskEvidence?.artifact?.metadata?.label, 'public label');
-    assert.doesNotMatch(
-      JSON.stringify(projection.heavyTaskEvidence),
-      /raw artifact body|official-verifier-output/,
-    );
-  });
-
-  test('projects heavy-task mode facts', () => {
-    const projection = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId: 'tr-heavy',
-          ts: 1,
-          taskId: 'task-1',
-          configId: 'cfg-1',
-        },
-        {
-          type: 'heavy_task_mode_recorded',
-          id: 'e-2',
-          taskRunId: 'tr-heavy',
-          ts: 2,
-          facts: {
-            schemaVersion: 1,
-            enabled: true,
-            triggerSource: 'task_metadata',
-            triggerReason: 'task declared heavy',
-            policyVersion: 'maka-heavy-task-policy.v1',
-          },
-        },
-      ],
-      'tr-heavy',
-    );
-
-    assert.deepEqual(projection.heavyTaskMode, {
-      schemaVersion: 1,
-      enabled: true,
-      triggerSource: 'task_metadata',
-      triggerReason: 'task declared heavy',
-      policyVersion: 'maka-heavy-task-policy.v1',
-    });
-  });
-
-  test('projects heavy-task inventory and todo snapshots from replay order', () => {
-    const taskRunId = 'tr-progress';
-    const projection = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId,
-          ts: 1,
-          taskId: 'task-1',
-          configId: 'cfg-1',
-        },
-        {
-          type: 'heavy_task_inventory_recorded',
-          id: 'e-2',
-          taskRunId,
-          ts: 2,
-          inventory: {
-            schemaVersion: 1,
-            inventoryId: 'inventory-1',
-            taskRunId,
-            ts: 2,
-            summary: 'Initial inventory',
-            items: [{ path: 'README.md', kind: 'file', status: 'observed' }],
-            source: { kind: 'model_tool', toolCallId: 'tool-1' },
-          },
-        },
-        {
-          type: 'heavy_task_todos_recorded',
-          id: 'e-3',
-          taskRunId,
-          ts: 3,
-          todos: {
-            schemaVersion: 1,
-            todoSetId: 'todos-1',
-            taskRunId,
-            ts: 3,
-            items: [
-              { id: 'inspect', content: 'Inspect files', status: 'in_progress', priority: 'high' },
-            ],
-            source: { kind: 'model_tool', toolCallId: 'tool-2' },
-          },
-        },
-        {
-          type: 'heavy_task_inventory_recorded',
-          id: 'e-4',
-          taskRunId,
-          ts: 4,
-          inventory: {
-            schemaVersion: 1,
-            inventoryId: 'inventory-2',
-            taskRunId,
-            ts: 4,
-            summary: 'Updated inventory',
-            items: [{ path: 'src/app.js', kind: 'file', status: 'planned' }],
-            source: { kind: 'model_tool', toolCallId: 'tool-3' },
-          },
-        },
-        {
-          type: 'heavy_task_todos_recorded',
-          id: 'e-5',
-          taskRunId,
-          ts: 5,
-          todos: {
-            schemaVersion: 1,
-            todoSetId: 'todos-2',
-            taskRunId,
-            ts: 5,
-            items: [
-              {
-                id: 'edit',
-                content: 'Patch implementation',
-                status: 'pending',
-                priority: 'medium',
-              },
-            ],
-            source: { kind: 'model_tool', toolCallId: 'tool-4' },
-          },
-        },
-      ],
-      taskRunId,
-    );
-
-    assert.equal(projection.heavyTaskInventory.length, 2);
-    assert.equal(projection.latestHeavyTaskInventory?.inventoryId, 'inventory-2');
-    assert.equal(projection.latestHeavyTaskInventory?.items[0]?.path, 'src/app.js');
-    assert.equal(projection.heavyTaskTodoStates.length, 2);
-    assert.equal(projection.latestHeavyTaskTodos?.todoSetId, 'todos-2');
-    assert.equal(projection.latestHeavyTaskTodos?.items[0]?.id, 'edit');
-  });
-
-  test('projects heavy-task compact evidence from replay order', () => {
-    const taskRunId = 'tr-evidence';
-    const projection = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId,
-          ts: 1,
-          taskId: 'task-1',
-          configId: 'cfg-1',
-        },
-        heavyTaskEvidenceEvent(taskRunId, 'e-2', 'evidence-1', 'Bash', 2),
-        heavyTaskEvidenceEvent(taskRunId, 'e-3', 'evidence-2', 'Read', 3),
-      ],
-      taskRunId,
-    );
-
-    assert.equal(projection.heavyTaskEvidence.length, 2);
-    assert.equal(projection.heavyTaskEvidence[0]?.evidenceId, 'evidence-1');
-    assert.equal(projection.latestHeavyTaskEvidence?.evidenceId, 'evidence-2');
-    assert.equal(projection.latestHeavyTaskEvidence?.tool?.name, 'Read');
-  });
-
-  test('projects only accepted public heavy-task self-checks from replay', () => {
-    const taskRunId = 'tr-self-check';
-    const accepted = acceptedSelfCheck(
-      taskRunId,
-      'self-check-1',
-      'pass',
-      'npm test passed on public files.',
-    );
-    const rejectedGuard = {
-      ...acceptedSelfCheck(
-        taskRunId,
-        'self-check-2',
-        'fail',
-        'official-verifier-output.json says failed',
-      ),
-      guard: {
-        status: 'rejected' as const,
-        checkedAt: 11,
-        categories: ['official_verifier_artifacts'],
-        publicReason:
-          'Rejected because submitted evidence referenced private, hidden, or evaluator-only material.',
-      },
-    };
-    const privatePayload = acceptedSelfCheck(
-      taskRunId,
-      'self-check-3',
-      'inconclusive',
-      'hidden/tests/private_case.py revealed a failure.',
-    );
-    const projection = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId,
-          ts: 1,
-          taskId: 'task-1',
-          configId: 'cfg-1',
-        },
-        {
-          type: 'heavy_task_self_check_recorded',
-          id: 'e-2',
-          taskRunId,
-          ts: 10,
-          selfCheck: accepted,
-        },
-        {
-          type: 'heavy_task_self_check_recorded',
-          id: 'e-3',
-          taskRunId,
-          ts: 11,
-          selfCheck: rejectedGuard as unknown as HeavyTaskSemanticSelfCheckState,
-        },
-        {
-          type: 'heavy_task_self_check_recorded',
-          id: 'e-4',
-          taskRunId,
-          ts: 12,
-          selfCheck: privatePayload,
-        },
-      ],
-      taskRunId,
-    );
-
-    assert.equal(projection.heavyTaskSelfChecks.length, 1);
-    assert.equal(projection.latestHeavyTaskSelfCheck?.selfCheckId, 'self-check-1');
-    assert.deepEqual(
-      projection.heavyTaskEvidence.map((item) => item.kind),
-      ['check', 'tool', 'artifact'],
-    );
-    assert.equal(projection.heavyTaskEvidence[2]?.artifact?.path, 'build-output.log');
-    assert.equal(projection.heavyTaskEvidence[2]?.artifact?.authority?.source, 'self_check');
-    assert.equal(projection.warnings.length, 2);
-    assert.match(projection.warnings.join('\n'), /source guard did not accept/);
-  });
-
-  test('replays Self-check source binding and invalidates freshness after later workspace mutations', () => {
-    const taskRunId = 'tr-self-check-freshness';
-    const attemptId = 'attempt-1';
-    const selfCheck = {
-      ...acceptedSelfCheck(taskRunId, 'self-check-1', 'pass', 'npm test passed.'),
-      attemptId,
-      source: {
-        kind: 'model_tool' as const,
-        toolCallId: 'self-check-call',
-        sessionId: 'session-1',
-        agentRunId: 'run-1',
-        turnId: 'turn-1',
-      },
-    };
-    const revision = { kind: 'manifest' as const, ref: 'sha256:workspace-1', dirty: false };
-    const workspaceObservation: Extract<
-      TaskEvent,
-      { type: 'heavy_task_workspace_observation_recorded' }
-    >['observation'] = {
-      schemaVersion: 1,
-      observationId: 'workspace-1',
-      taskRunId,
-      ts: 3,
-      roots: ['/app/project'],
-      entries: [{ path: '/app/project/result.txt', kind: 'file', sizeBytes: 2, sha256: 'aa' }],
-      status: 'ok',
-      command: 'observe',
-      revision,
-      source: { kind: 'system', label: 'isolated workspace observation' },
-    };
-    const prefix: TaskEvent[] = [
-      {
-        type: 'task_run_created',
-        id: 'created',
-        taskRunId,
-        ts: 1,
-        taskId: 'task-1',
-        configId: 'cfg-1',
-      },
-      {
-        type: 'heavy_task_self_check_recorded',
-        id: 'self-check-event',
-        taskRunId,
-        ts: 2,
-        selfCheck,
-      },
-      {
-        type: 'heavy_task_workspace_observation_recorded',
-        id: 'workspace-event-1',
-        taskRunId,
-        ts: 3,
-        observation: workspaceObservation,
-      },
-      {
-        type: 'heavy_task_self_check_evidence_linked',
-        id: 'self-check-link',
-        taskRunId,
-        ts: 4,
-        selfCheckId: selfCheck.selfCheckId,
-        attemptId,
-        workspaceObservationId: 'workspace-1',
-        provenance: {
-          schemaVersion: 'maka.execution_evidence_ref.v1',
-          execution: {
-            sessionId: 'session-1',
-            invocationId: 'invocation-1',
-            agentRunId: 'run-1',
-            turnId: 'turn-1',
-          },
-          task: { taskRunId, attemptId },
-          runtimeCoverage: {
-            lowWater: {
-              ledger: 'runtime_event',
-              streamId: 'run-1',
-              sequence: 2,
-              eventId: 'runtime-call',
-            },
-            highWater: {
-              ledger: 'runtime_event',
-              streamId: 'run-1',
-              sequence: 3,
-              eventId: 'runtime-result',
-            },
-            eventCount: 2,
-          },
-          taskCoverage: {
-            highWater: {
-              ledger: 'task_event',
-              streamId: taskRunId,
-              sequence: 1,
-              eventId: 'self-check-event',
-            },
-            eventCount: 2,
-          },
-          workspace: revision,
-        },
-      },
-    ];
-
-    const current = projectTaskRun(prefix, taskRunId);
-    assert.equal(current.latestHeavyTaskSelfCheck?.freshness, 'current');
-    assert.equal(
-      current.latestHeavyTaskSelfCheck?.provenance?.taskCoverage?.highWater.eventId,
-      'self-check-event',
-    );
-
-    const mutationBase = heavyTaskEvidenceEvent(
-      taskRunId,
-      'mutation',
-      'write-evidence',
-      'Bash',
-      5,
-    ) as Extract<TaskEvent, { type: 'heavy_task_evidence_recorded' }>;
-    const mutation: Extract<TaskEvent, { type: 'heavy_task_evidence_recorded' }> = {
-      ...mutationBase,
-      evidence: { ...mutationBase.evidence, attemptId },
-    };
-    const mutated = projectTaskRun([...prefix, mutation], taskRunId);
-    assert.equal(mutated.latestHeavyTaskSelfCheck?.freshness, 'stale');
-    assert.deepEqual(mutated.latestHeavyTaskSelfCheck?.freshnessReasons, [
-      'later_workspace_mutation',
-    ]);
-
-    const reobserved = projectTaskRun(
-      [
-        ...mutated.events,
-        {
-          type: 'heavy_task_workspace_observation_recorded',
-          id: 'workspace-event-2',
-          taskRunId,
-          ts: 6,
-          observation: {
-            ...workspaceObservation,
-            observationId: 'workspace-2',
-            ts: 6,
-          },
-        } as TaskEvent,
-      ],
-      taskRunId,
-    );
-    assert.equal(reobserved.latestHeavyTaskSelfCheck?.freshness, 'current');
-
-    const changed = projectTaskRun(
-      [
-        ...reobserved.events,
-        {
-          type: 'heavy_task_workspace_observation_recorded',
-          id: 'workspace-event-3',
-          taskRunId,
-          ts: 7,
-          observation: {
-            ...workspaceObservation,
-            observationId: 'workspace-3',
-            ts: 7,
-            revision: { kind: 'manifest', ref: 'sha256:workspace-2', dirty: false },
-          },
-        } as TaskEvent,
-      ],
-      taskRunId,
-    );
-    assert.equal(changed.latestHeavyTaskSelfCheck?.freshness, 'stale');
-    assert.deepEqual(changed.latestHeavyTaskSelfCheck?.freshnessReasons, [
-      'workspace_revision_changed',
-    ]);
-  });
-
-  test('derives heavy-task completion from accepted self-checks and latest todos', () => {
-    const taskRunId = 'tr-heavy-completion';
-    const projection = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId,
-          ts: 1,
-          taskId: 'task-1',
-          configId: 'cfg-1',
-        },
-        {
-          type: 'heavy_task_mode_recorded',
-          id: 'e-2',
-          taskRunId,
-          ts: 2,
-          facts: {
-            schemaVersion: 1,
-            enabled: true,
-            triggerSource: 'config',
-            triggerReason: 'long public task',
-            policyVersion: 'maka-heavy-task-policy.v1',
-          },
-        },
-        {
-          type: 'heavy_task_todos_recorded',
-          id: 'e-3',
-          taskRunId,
-          ts: 3,
-          todos: {
-            schemaVersion: 1,
-            todoSetId: 'todos-1',
-            taskRunId,
-            ts: 3,
-            items: [
-              {
-                id: 'edit',
-                content: 'Patch implementation',
-                status: 'completed',
-                priority: 'high',
-              },
-              {
-                id: 'artifact',
-                kind: 'runnable_artifact',
-                content: 'Create first runnable artifact',
-                status: 'completed',
-                priority: 'high',
-                evidence: 'Runnable artifact exists.',
-              },
-              {
-                id: 'check',
-                kind: 'public_check',
-                content: 'Run public check',
-                status: 'completed',
-                priority: 'high',
-                evidence: 'Public check passed.',
-              },
-              {
-                id: 'optional',
-                content: 'Optional polish',
-                status: 'cancelled',
-                priority: 'low',
-                evidence: 'Not required by public task.',
-              },
-            ],
-            source: { kind: 'model_tool', toolCallId: 'tool-2' },
-          },
-        },
-        {
-          type: 'heavy_task_self_check_plan_recorded',
-          id: 'e-3-plan',
-          taskRunId,
-          ts: 3.5,
-          plan: acceptedSelfCheckPlan(taskRunId),
-        },
-        {
-          type: 'heavy_task_self_check_recorded',
-          id: 'e-4',
-          taskRunId,
-          ts: 4,
-          selfCheck: acceptedSelfCheck(
-            taskRunId,
-            'self-check-1',
-            'pass',
-            'npm test passed against public files.',
-          ),
-        },
-        {
-          type: 'score_result_recorded',
-          id: 'e-5',
-          taskRunId,
-          ts: 5,
-          result: {
-            id: 'score-1',
-            taskRunId,
-            ts: 5,
-            passed: false,
-            scored: true,
-            eligible: true,
-            taxonomy: 'verification_failed',
-            authority: { source: 'official_harbor_verifier', authoritative: true },
-          },
-        },
-        {
-          type: 'task_run_budget_exhausted',
-          id: 'e-6',
-          taskRunId,
-          ts: 6,
-          error: { message: 'runtime step cap reached', class: 'max_steps' },
-        },
-      ],
-      taskRunId,
-    );
-
-    assert.equal(projection.heavyTaskCompletion?.runtime.taskRunStatus, 'budget_exhausted');
-    assert.equal(projection.heavyTaskSelfCheckPlans.length, 1);
-    assert.equal(projection.latestHeavyTaskSelfCheckPlan?.planId, 'plan-1');
-    assert.equal(projection.heavyTaskCompletion?.runtime.taxonomy, 'verification_failed');
-    assert.equal(projection.heavyTaskCompletion?.runtime.capKind, 'runtime_step_cap');
-    assert.equal(projection.heavyTaskCompletion?.semantic.status, 'complete');
-    assert.deepEqual(projection.heavyTaskCompletion?.semantic.nonblockingTodoIds, ['optional']);
-    assert.equal(projection.heavyTaskCompletion?.finalization.eligible, true);
-    assert.equal(projection.result?.taxonomy, 'verification_failed');
-    assert.equal(projection.result?.passed, false);
-  });
-
-  test('projects heavy-task self-check gate events while old traces remain ungated', () => {
-    const taskRunId = 'tr-heavy-gate';
-    const projection = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId,
-          ts: 1,
-          taskId: 'task-1',
-          configId: 'cfg-1',
-        },
-        {
-          type: 'heavy_task_self_check_gate_recorded',
-          id: 'e-2',
-          taskRunId,
-          ts: 2,
-          gate: {
-            schemaVersion: 1,
-            action: 'repair_prompt',
-            reason: 'missing accepted public self-check evidence',
-            attempt: 1,
-            maxAttempts: 1,
-            checklist: [
-              {
-                id: 'check-1',
-                kind: 'workspace_hygiene',
-                source: 'generic_heavy_task',
-                description:
-                  'Pass self-check must include sandbox execution evidence and a public workspace hygiene guard',
-                evidenceRequired: 'command_or_artifact',
-              },
-            ],
-            prompt: 'run public checks and self_check_submit',
-          },
-        },
-      ],
-      taskRunId,
-    );
-
-    assert.equal(projection.heavyTaskSelfCheckGates.length, 1);
-    assert.equal(projection.latestHeavyTaskSelfCheckGate?.action, 'repair_prompt');
-    assert.equal(
-      projection.latestHeavyTaskSelfCheckGate?.reason,
-      'missing accepted public self-check evidence',
-    );
-
-    const oldTrace = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId: 'tr-old',
-          ts: 1,
-          taskId: 'task-old',
-          configId: 'cfg-1',
-        },
-      ],
-      'tr-old',
-    );
-    assert.deepEqual(oldTrace.heavyTaskSelfCheckPlans, []);
-    assert.equal(oldTrace.latestHeavyTaskSelfCheckPlan, undefined);
-    assert.deepEqual(oldTrace.heavyTaskSelfCheckGates, []);
-    assert.equal(oldTrace.latestHeavyTaskSelfCheckGate, undefined);
-  });
-
-  test('projects isolation, permission, inbox, and needs_approval facts', () => {
-    const taskRunId = 'tr-approval';
-    const request = {
-      schemaVersion: 1 as const,
-      requestId: 'req-1',
-      taskRunId,
-      attemptId: 'a-1',
-      toolCallId: 'tool-1',
-      toolName: 'Bash',
-      normalizedArgsHash: 'abc123',
-      resourceScope: { kind: 'command' as const, value: 'rm file', mode: 'execute' as const },
-      reason: 'dangerous command',
-      preview: { argKeys: ['command'] },
-      requestedAt: 3,
-      expiresAt: 100,
-    };
-    const grant = {
-      schemaVersion: 1 as const,
-      grantId: 'grant-1',
-      requestId: 'req-1',
-      taskRunId,
-      attemptId: 'a-1',
-      toolCallId: 'tool-1',
-      toolName: 'Bash',
-      normalizedArgsHash: 'abc123',
-      resourceScope: request.resourceScope,
-      decision: 'allow' as const,
-      actor: { kind: 'test' as const },
-      source: 'test_fixture' as const,
-      decidedAt: 4,
-      expiresAt: 100,
-    };
-    const projection = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId,
-          ts: 1,
-          taskId: 'task-1',
-          configId: 'cfg-1',
-        },
-        {
-          type: 'isolation_policy_recorded',
-          id: 'e-2',
-          taskRunId,
-          ts: 2,
-          facts: {
-            schemaVersion: 1,
-            backendKind: 'ai-sdk',
-            required: true,
-            mode: 'external',
-            label: 'unit isolation',
-            assertionSource: 'headless_deps',
-            validatedAt: 2,
-          },
-        },
-        {
-          type: 'workspace_lease_recorded',
-          id: 'e-3',
-          taskRunId,
-          ts: 2,
-          lease: {
-            schemaVersion: 1,
-            leaseId: 'lease-1',
-            taskRunId,
-            attemptId: 'a-1',
-            sourceWorkspaceDir: '/src',
-            workspaceDir: '/tmp/work',
-            leaseKind: 'throwaway_copy',
-            writable: true,
-            cleanupPolicy: 'cleanup_on_finally',
-            createdAt: 2,
-          },
-        },
-        {
-          type: 'tool_executor_identity_recorded',
-          id: 'e-4',
-          taskRunId,
-          ts: 2,
-          identity: {
-            schemaVersion: 1,
-            executorId: 'exec-1',
-            taskRunId,
-            attemptId: 'a-1',
-            toolNames: ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'],
-            isolationMode: 'external',
-            label: 'unit isolation',
-          },
-        },
-        { type: 'task_attempt_started', id: 'e-5', taskRunId, ts: 2, attemptId: 'a-1' },
-        { type: 'permission_request_recorded', id: 'e-6', taskRunId, ts: 3, request },
-        { type: 'permission_grant_recorded', id: 'e-7', taskRunId, ts: 4, grant },
-        {
-          type: 'task_inbox_item_recorded',
-          id: 'e-8',
-          taskRunId,
-          ts: 5,
-          item: {
-            schemaVersion: 1,
-            inboxItemId: 'inbox-1',
-            taskRunId,
-            attemptId: 'a-1',
-            kind: 'approval_request',
-            status: 'open',
-            title: 'Approval required',
-            reason: 'dangerous command',
-            createdAt: 5,
-            relatedRequestId: 'req-1',
-          },
-        },
-        {
-          type: 'task_run_needs_approval',
-          id: 'e-9',
-          taskRunId,
-          ts: 6,
-          attemptId: 'a-1',
-          reason: 'approval',
-          inboxItemId: 'inbox-1',
-        },
-      ],
-      taskRunId,
-    );
-
-    assert.equal(projection.status, 'needs_approval');
-    assert.equal(projection.attempts[0]?.status, 'needs_approval');
-    assert.equal(projection.isolation?.label, 'unit isolation');
-    assert.equal(projection.workspaceLease?.workspaceDir, '/tmp/work');
-    assert.equal(projection.toolExecutors[0]?.executorId, 'exec-1');
-    assert.equal(projection.permissionRequests[0]?.normalizedArgsHash, 'abc123');
-    assert.equal(projection.permissionGrants[0]?.grantId, 'grant-1');
-    assert.equal(projection.inboxItems[0]?.status, 'open');
-    assert.deepEqual(projection.parked, { reason: 'approval', inboxItemId: 'inbox-1', since: 6 });
-  });
-
-  test('terminal events override open inbox parked state', () => {
-    const projection = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId: 'tr-terminal',
-          ts: 1,
-          taskId: 'task-1',
-          configId: 'cfg-1',
-        },
-        {
-          type: 'task_inbox_item_recorded',
-          id: 'e-2',
-          taskRunId: 'tr-terminal',
-          ts: 2,
-          item: {
-            schemaVersion: 1,
-            inboxItemId: 'inbox-1',
-            taskRunId: 'tr-terminal',
-            kind: 'approval_request',
-            status: 'open',
-            title: 'Approval required',
-            reason: 'permission',
-            createdAt: 2,
-          },
-        },
-        {
-          type: 'task_run_needs_approval',
-          id: 'e-3',
-          taskRunId: 'tr-terminal',
-          ts: 3,
-          reason: 'approval',
-          inboxItemId: 'inbox-1',
-        },
-        { type: 'task_run_policy_denied', id: 'e-4', taskRunId: 'tr-terminal', ts: 4 },
-      ],
-      'tr-terminal',
-    );
-
-    assert.equal(projection.status, 'policy_denied');
-    assert.equal(projection.parked, undefined);
-  });
-
-  test('projects failed and cancelled terminal events', () => {
-    const failed = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId: 'tr-f',
-          ts: 1,
-          taskId: 'task-f',
-          configId: 'cfg',
-        },
-        {
-          type: 'task_run_failed',
-          id: 'e-2',
-          taskRunId: 'tr-f',
-          ts: 2,
-          error: { message: 'backend blew up', class: 'backend_failed' },
-        },
-      ],
-      'tr-f',
-    );
-    assert.equal(failed.status, 'failed');
-    assert.equal(failed.error?.message, 'backend blew up');
-
-    const cancelled = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId: 'tr-c',
-          ts: 1,
-          taskId: 'task-c',
-          configId: 'cfg',
-        },
-        { type: 'task_run_cancelled', id: 'e-2', taskRunId: 'tr-c', ts: 2 },
-      ],
-      'tr-c',
-    );
-    assert.equal(cancelled.status, 'cancelled');
-    assert.equal(cancelled.error?.class, 'cancelled');
-  });
-
-  test('projects queued, verifying, incomplete, blocked, policy, budget, and aborted states', () => {
-    const queued = projectTaskRun(
-      [
-        {
-          type: 'task_run_queued',
-          id: 'e-1',
-          taskRunId: 'tr-q',
-          ts: 1,
-          taskId: 'task-q',
-          configId: 'cfg',
-        },
-      ],
-      'tr-q',
-    );
-    assert.equal(queued.status, 'queued');
-    assert.equal(queued.taskId, 'task-q');
-
-    const verifying = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId: 'tr-v',
-          ts: 1,
-          taskId: 'task-v',
-          configId: 'cfg',
-        },
-        { type: 'task_run_started', id: 'e-2', taskRunId: 'tr-v', ts: 2 },
-        { type: 'task_run_verifying', id: 'e-3', taskRunId: 'tr-v', ts: 3 },
-      ],
-      'tr-v',
-    );
-    assert.equal(verifying.status, 'verifying');
-
-    const terminalCases: Array<[TaskEvent, string, string]> = [
-      [
-        { type: 'task_run_incomplete', id: 'e-2', taskRunId: 'tr-x', ts: 2 },
-        'incomplete',
-        'agent_incomplete',
-      ],
-      [{ type: 'task_run_blocked', id: 'e-2', taskRunId: 'tr-x', ts: 2 }, 'blocked', 'blocked'],
-      [
-        { type: 'task_run_policy_denied', id: 'e-2', taskRunId: 'tr-x', ts: 2 },
-        'policy_denied',
-        'policy_denied',
-      ],
-      [
-        { type: 'task_run_budget_exhausted', id: 'e-2', taskRunId: 'tr-x', ts: 2 },
-        'budget_exhausted',
-        'budget_exhausted',
-      ],
-      [{ type: 'task_run_aborted', id: 'e-2', taskRunId: 'tr-x', ts: 2 }, 'aborted', 'aborted'],
-    ];
-
-    for (const [terminalEvent, status, errorClass] of terminalCases) {
-      const projection = projectTaskRun(
-        [
-          {
-            type: 'task_run_created',
-            id: 'e-1',
-            taskRunId: 'tr-x',
-            ts: 1,
-            taskId: 'task-x',
-            configId: 'cfg',
-          },
-          terminalEvent,
-        ],
-        'tr-x',
-      );
-      assert.equal(projection.status, status);
-      assert.equal(projection.error?.class, errorClass);
-    }
-  });
-
-  test('uses the last terminal event and records a warning', () => {
-    const projection = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId: 'tr-1',
-          ts: 1,
-          taskId: 'task-1',
-          configId: 'cfg-1',
-        },
-        {
-          type: 'task_run_failed',
-          id: 'e-2',
-          taskRunId: 'tr-1',
-          ts: 2,
-          error: { message: 'first terminal' },
-        },
-        { type: 'task_run_completed', id: 'e-3', taskRunId: 'tr-1', ts: 3 },
-      ],
-      'tr-1',
-    );
-
-    assert.equal(projection.status, 'completed');
-    assert.match(projection.warnings[0] ?? '', /multiple terminal/);
-  });
-
   test('serializes concurrent appends for one task run', async () => {
     const store = createInMemoryTaskRunStore();
     const events = completedEvents('tr-concurrent');
@@ -1468,43 +188,14 @@ describe('TaskRunStore', () => {
     assert.deepEqual(await store.readEvents('tr-concurrent'), events);
   });
 
-  test('event_corrupt stays in replay and surfaces as a projection warning', () => {
-    const projection = projectTaskRun(
-      [
-        {
-          type: 'task_run_created',
-          id: 'e-1',
-          taskRunId: 'tr-1',
-          ts: 1,
-          taskId: 'task-1',
-          configId: 'cfg-1',
-        },
-        {
-          type: 'event_corrupt',
-          id: 'e-corrupt',
-          taskRunId: 'tr-1',
-          ts: 2,
-          raw: '{',
-          error: 'invalid json',
-        },
-        { type: 'task_run_completed', id: 'e-3', taskRunId: 'tr-1', ts: 3 },
-      ],
-      'tr-1',
-    );
-
-    assert.equal(projection.events.length, 3);
-    assert.match(projection.warnings[0] ?? '', /corrupt event/);
-    assert.equal(projection.status, 'completed');
-  });
-
   test('file-backed store appends and replays events after restart', async () => {
     const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-run-store-'));
     try {
-      const store = createTaskRunStore(storageRoot);
+      const store = await openFileTaskRunWriter(storageRoot);
       const events = completedEvents('tr-file');
       for (const event of events) await store.appendEvent(event.taskRunId, event);
 
-      const restarted = createTaskRunStore(storageRoot);
+      const restarted = await openFileTaskRunReader(storageRoot);
       assert.deepEqual(await restarted.readEvents('tr-file'), events);
       assert.equal((await restarted.project('tr-file')).status, 'completed');
     } finally {
@@ -1512,19 +203,194 @@ describe('TaskRunStore', () => {
     }
   });
 
-  test('file-backed store surfaces corrupt durable lines and ignores partial tail', async () => {
+  test('atomically publishes the first ledger across independent writers', async () => {
     const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-run-store-'));
     try {
-      const store = createTaskRunStore(storageRoot);
+      const first = await openFileTaskRunWriter(storageRoot);
+      const second = await openFileTaskRunWriter(storageRoot);
+      const taskRunId = 'concurrent-first-write';
+      const firstEvent = completedEvents(taskRunId)[0]!;
+      const secondEvent: TaskEvent = {
+        type: 'task_run_queued',
+        id: 'queued-concurrently',
+        taskRunId,
+        taskId: 'task-1',
+        configId: 'cfg-1',
+        ts: 11,
+      };
+
+      await Promise.all([
+        first.appendEvent(taskRunId, firstEvent),
+        second.appendEvent(taskRunId, secondEvent),
+      ]);
+
+      const reader = await openFileTaskRunReader(storageRoot);
+      assert.deepEqual(
+        (await reader.readEvents(taskRunId)).map((event) => event.id).sort(),
+        [firstEvent.id, secondEvent.id].sort(),
+      );
+      assert.deepEqual(await reader.listTaskRunIds(), [taskRunId]);
+    } finally {
+      await rm(storageRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('serializes large ledger appends across independent processes', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-run-store-'));
+    const children: ChildProcess[] = [];
+    try {
+      const taskRunId = 'concurrent-large-write';
+      const writer = await openFileTaskRunWriter(storageRoot);
+      await writer.appendEvent(taskRunId, completedEvents(taskRunId)[0]!);
+
+      const instructions = [
+        `first:${'a'.repeat(768 * 1024)}:first`,
+        `second:${'b'.repeat(768 * 1024)}:second`,
+      ];
+      const events: TaskEvent[] = instructions.map((instruction, index) => ({
+        type: 'task_run_queued',
+        id: `large-${index + 1}`,
+        taskRunId,
+        taskId: `task-${index + 1}`,
+        configId: 'cfg-1',
+        ts: index + 2,
+        taskDefinition: {
+          id: `task-${index + 1}`,
+          instruction,
+          workspaceDir: '.',
+          verification: { command: 'true', protectedPaths: [] },
+        },
+      }));
+      const eventPaths = events.map((_, index) => join(storageRoot, `event-${index + 1}.json`));
+      await Promise.all(
+        events.map((event, index) => writeFile(eventPaths[index]!, JSON.stringify(event), 'utf8')),
+      );
+
+      const writers = eventPaths.map((eventPath) =>
+        prepareTaskRunWriterProcess(storageRoot, eventPath),
+      );
+      children.push(...writers.map((prepared) => prepared.child));
+      await Promise.all(writers.map((prepared) => prepared.ready));
+      await Promise.all(writers.map((prepared) => prepared.append()));
+
+      const reader = await openFileTaskRunReader(storageRoot);
+      const replayed = await reader.readEvents(taskRunId);
+      assert.deepEqual(
+        replayed
+          .slice(1)
+          .map((event) => ({
+            id: event.id,
+            instruction:
+              event.type === 'task_run_queued' ? event.taskDefinition?.instruction : undefined,
+          }))
+          .sort((left, right) => left.id.localeCompare(right.id)),
+        events.map((event) => ({
+          id: event.id,
+          instruction:
+            event.type === 'task_run_queued' ? event.taskDefinition?.instruction : undefined,
+        })),
+      );
+      assert.deepEqual(await reader.listTaskRunIds(), [taskRunId]);
+    } finally {
+      await Promise.all(children.map(terminateChildProcess));
+      await rm(storageRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('keeps distinct task run identities in separate ledgers', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-run-store-'));
+    try {
+      const store = await openFileTaskRunWriter(storageRoot);
+      const first = completedEvents('run/a', 'slash-task', 'slash-config');
+      const second = completedEvents('run?a', 'question-task', 'question-config');
+      for (let index = 0; index < first.length; index += 1) {
+        await store.appendEvent('run/a', first[index]!);
+        await store.appendEvent('run?a', second[index]!);
+      }
+
+      assert.deepEqual(await store.listTaskRunIds(), ['run/a', 'run?a']);
+      assert.deepEqual(await store.readEvents('run/a'), first);
+      assert.deepEqual(await store.readEvents('run?a'), second);
+
+      const firstProjection = await store.project('run/a');
+      assert.equal(firstProjection.taskId, 'slash-task');
+      assert.deepEqual(firstProjection.events, first);
+      const secondProjection = await store.project('run?a');
+      assert.equal(secondProjection.taskId, 'question-task');
+      assert.deepEqual(secondProjection.events, second);
+
+      const taskRunDir = join(storageRoot, 'task-runs');
+      const ledgerNames = (await readdir(taskRunDir))
+        .filter((name) => name.endsWith('.jsonl'))
+        .sort();
+      assert.equal(ledgerNames.length, 2);
+      assert.notEqual(ledgerNames[0], ledgerNames[1]);
+      for (const ledgerName of ledgerNames) {
+        const identities = new Set(
+          (await readFile(join(taskRunDir, ledgerName), 'utf8'))
+            .trim()
+            .split('\n')
+            .map((line) => (JSON.parse(line) as TaskEvent).taskRunId),
+        );
+        assert.equal(identities.size, 1);
+      }
+    } finally {
+      await rm(storageRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects empty and malformed task run identities before writing a ledger', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-run-store-'));
+    try {
+      const store = await openFileTaskRunWriter(storageRoot);
+      await assert.rejects(
+        () => store.appendEvent('', completedEvents('')[0]!),
+        /taskRunId must not be empty/,
+      );
+      const malformedId = '\uD800';
+      await assert.rejects(
+        () => store.appendEvent(malformedId, completedEvents(malformedId)[0]!),
+        /taskRunId must be well-formed Unicode/,
+      );
+      await assert.rejects(() => lstat(join(storageRoot, 'task-runs')), { code: 'ENOENT' });
+    } finally {
+      await rm(storageRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('keeps long domain identities independent from filesystem component limits', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-run-store-'));
+    try {
+      const store = await openFileTaskRunWriter(storageRoot);
+      const taskRunId = 'long-task-run/'.repeat(64);
+      const event = completedEvents(taskRunId)[0]!;
+      await store.appendEvent(taskRunId, event);
+
+      assert.deepEqual(await store.listTaskRunIds(), [taskRunId]);
+      assert.deepEqual(await store.readEvents(taskRunId), [event]);
+    } finally {
+      await rm(storageRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('discovers identity without scanning corrupt history and repairs a partial tail', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-run-store-'));
+    try {
+      const store = await openFileTaskRunWriter(storageRoot);
       const events = completedEvents('tr-corrupt');
       await store.appendEvent('tr-corrupt', events[0] as TaskEvent);
+      const [ledgerName] = (await readdir(join(storageRoot, 'task-runs'))).filter((name) =>
+        name.endsWith('.jsonl'),
+      );
+      assert.ok(ledgerName);
 
       await appendFile(
-        join(storageRoot, 'task-runs', 'tr-corrupt.jsonl'),
+        join(storageRoot, 'task-runs', ledgerName),
         'not-json\n{"type":"task_run_completed","id":"partial"',
         'utf8',
       );
 
+      assert.deepEqual(await store.listTaskRunIds(), ['tr-corrupt']);
       const replayed = await store.readEvents('tr-corrupt');
       assert.equal(replayed.length, 2);
       assert.equal(replayed[1]?.type, 'event_corrupt');
@@ -1535,87 +401,150 @@ describe('TaskRunStore', () => {
         [0, 1],
       );
       assert.equal(records[1]?.cursor.eventId, 'corrupt-2');
+
+      const completed = completedEvents('tr-corrupt').at(-1)!;
+      await store.appendEvent('tr-corrupt', completed);
+      assert.deepEqual(
+        (await store.readEvents('tr-corrupt')).map((event) => event.id),
+        [events[0]!.id, 'corrupt-2', completed.id],
+      );
+    } finally {
+      await rm(storageRoot, { recursive: true, force: true });
+    }
+  });
+
+  test('rejects a durable event whose identity differs from its ledger', async () => {
+    const storageRoot = await mkdtemp(join(tmpdir(), 'maka-task-run-store-'));
+    try {
+      const store = await openFileTaskRunWriter(storageRoot);
+      await store.appendEvent('owned-run', completedEvents('owned-run')[0]!);
+      const [ledgerName] = (await readdir(join(storageRoot, 'task-runs'))).filter((name) =>
+        name.endsWith('.jsonl'),
+      );
+      assert.ok(ledgerName);
+      await appendFile(
+        join(storageRoot, 'task-runs', ledgerName),
+        `${JSON.stringify(completedEvents('other-run')[0])}\n`,
+        'utf8',
+      );
+
+      await assert.rejects(() => store.readEvents('owned-run'), /contains event for other-run/);
     } finally {
       await rm(storageRoot, { recursive: true, force: true });
     }
   });
 });
 
-function acceptedSelfCheck(
-  taskRunId: string,
-  selfCheckId: string,
-  status: HeavyTaskSemanticSelfCheckState['status'],
-  publicReason: string,
-): HeavyTaskSemanticSelfCheckState {
+async function openFileTaskRunWriter(storageRoot: string) {
+  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'headless' });
+  return openHeadlessTaskRunWriter(createHeadlessRootLease(capability, 'write'));
+}
+
+async function openFileTaskRunReader(storageRoot: string) {
+  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'headless' });
+  return openHeadlessTaskRunReader(createHeadlessRootLease(capability, 'read'));
+}
+
+function prepareTaskRunWriterProcess(
+  storageRoot: string,
+  eventPath: string,
+): { child: ChildProcess; ready: Promise<void>; append: () => Promise<void> } {
+  const child = fork(taskRunWriterProcessPath, [storageRoot, eventPath], {
+    stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+  });
+  let stderr = '';
+  child.stderr?.on('data', (chunk: Buffer) => {
+    stderr += chunk.toString('utf8');
+  });
+
+  const ready = new Promise<void>((resolve, reject) => {
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null) => {
+      cleanup();
+      reject(new Error(`TaskRun writer exited before ready (${String(code)}): ${stderr}`));
+    };
+    const onMessage = (message: unknown) => {
+      if (!isChildMessage(message, 'ready')) return;
+      cleanup();
+      resolve();
+    };
+    const cleanup = () => {
+      child.off('error', onError);
+      child.off('exit', onExit);
+      child.off('message', onMessage);
+    };
+    child.on('error', onError);
+    child.on('exit', onExit);
+    child.on('message', onMessage);
+  });
+
   return {
-    schemaVersion: 1,
-    selfCheckId,
-    taskRunId,
-    ts: 10,
-    status,
-    publicReason,
-    commandEvidence: [{ command: 'npm test', exitCode: 0, outputExcerpt: 'public tests passed' }],
-    artifactEvidence: [{ path: 'build-output.log', kind: 'log', exists: true }],
-    executionHygiene: {
-      sandbox: {
-        root: '/tmp/maka-self-check/run-1',
-        strategy: 'scratch_dir',
-        commandCwd: '/tmp/maka-self-check/run-1',
-        outputPolicy: 'scratch_only',
-      },
-      scratchUsed: true,
-      scratchPath: '/tmp/maka-self-check/run-1',
-      cleanupPerformed: true,
-      workspaceSideEffects: 'none',
-      workspaceGuard: {
-        checked: true,
-        checkedPaths: ['/app'],
-        addedPaths: [],
-        modifiedPaths: [],
-        removedPaths: [],
-      },
-    },
-    guard: {
-      status: 'accepted',
-      checkedAt: 10,
-      categories: [],
-      publicReason: 'Accepted as public, task-derived advisory self-check evidence.',
-    },
-    source: { kind: 'model_tool', toolCallId: 'tool-1' },
+    child,
+    ready: withTestDeadline(ready, 'TaskRun writer readiness'),
+    append: () =>
+      withTestDeadline(
+        new Promise<void>((resolve, reject) => {
+          child.once('error', reject);
+          child.once('exit', (code) => {
+            if (code === 0) resolve();
+            else reject(new Error(`TaskRun writer exited with ${String(code)}: ${stderr}`));
+          });
+          child.send({ type: 'append' }, (error) => {
+            if (error) reject(error);
+          });
+        }),
+        'TaskRun writer append',
+      ),
   };
 }
 
-function acceptedSelfCheckPlan(taskRunId: string): HeavyTaskSelfCheckPlanState {
-  return {
-    schemaVersion: 1,
-    planId: 'plan-1',
-    taskRunId,
-    ts: 3.5,
-    finalArtifacts: [
-      {
-        path: 'build-output.log',
-        purpose: 'public self-check artifact',
-        publicReason: 'visible public check creates this artifact',
+function withTestDeadline<T>(
+  operation: Promise<T>,
+  description: string,
+  timeoutMs = 30_000,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      reject(new Error(`${description} exceeded ${timeoutMs}ms`));
+    }, timeoutMs);
+    operation.then(
+      (value) => {
+        clearTimeout(timeout);
+        resolve(value);
       },
-    ],
-    selfCheckScratch: {
-      root: '/tmp/maka-self-check/run-1',
-      expectedGeneratedPaths: ['/tmp/maka-self-check/run-1/check.log'],
-      publicReason: 'public checks write temporary output under scratch',
-    },
-    workspaceGuardPlan: {
-      checkedPaths: ['/app'],
-      expectedAddedPaths: ['build-output.log'],
-      expectedGeneratedPathsOutsideScratch: [],
-      publicReason: 'public guard checks the deliverable workspace',
-    },
-    publicReason: 'plan is derived from visible public task evidence',
-    guard: {
-      status: 'accepted',
-      checkedAt: 3.5,
-      categories: [],
-      publicReason: 'Accepted as public, task-derived advisory self-check plan.',
-    },
-    source: { kind: 'model_tool', toolCallId: 'tool-plan' },
-  };
+      (error: unknown) => {
+        clearTimeout(timeout);
+        reject(error);
+      },
+    );
+  });
+}
+
+async function terminateChildProcess(child: ChildProcess): Promise<void> {
+  if (child.exitCode !== null || child.signalCode !== null) return;
+  const exited = waitForChildExit(child);
+  child.kill();
+  await withTestDeadline(exited, 'TaskRun writer termination', 5_000);
+}
+
+function waitForChildExit(child: ChildProcess): Promise<void> {
+  return new Promise((resolve) => {
+    if (child.exitCode !== null || child.signalCode !== null) {
+      resolve();
+      return;
+    }
+    const onExit = () => resolve();
+    child.once('exit', onExit);
+    if (child.exitCode !== null || child.signalCode !== null) {
+      child.off('exit', onExit);
+      resolve();
+    }
+  });
+}
+
+function isChildMessage(value: unknown, type: string): boolean {
+  return typeof value === 'object' && value !== null && (value as { type?: unknown }).type === type;
 }

--- a/packages/headless/src/ab-manifest.ts
+++ b/packages/headless/src/ab-manifest.ts
@@ -1,7 +1,7 @@
 import { createHash } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import type { AbRunManifest, AbRunManifestInput } from './ab-types.js';
-import { publishImmutableFile } from './immutable-file.js';
+import { publishFileExclusively } from './immutable-file.js';
 
 export function buildAbRunManifest(input: AbRunManifestInput): AbRunManifest {
   const manifestWithoutFingerprint = withoutUndefined({
@@ -58,7 +58,7 @@ export async function ensureAbRunManifest<T extends { fingerprint: string }>(
 ): Promise<T> {
   let existing = await readAbRunManifest<T>(path);
   if (existing === null) {
-    if (await publishImmutableFile(path, `${JSON.stringify(manifest, null, 2)}\n`)) {
+    if (await publishFileExclusively(path, `${JSON.stringify(manifest, null, 2)}\n`)) {
       return manifest;
     }
     existing = await readAbRunManifest<T>(path);

--- a/packages/headless/src/ahe-evidence-export.ts
+++ b/packages/headless/src/ahe-evidence-export.ts
@@ -61,7 +61,8 @@ import type {
   TaskRunArtifact,
   VerifierResult,
 } from './task-contracts.js';
-import type { TaskRunProjection } from './task-run-store.js';
+import { taskRunLocator } from './task-run-identity.js';
+import type { TaskRunProjection } from './task-run-projection.js';
 
 export const MAKA_AHE_EVIDENCE_EXPORT_SOURCE_LABEL = 'ahe-evidence-export-20260714' as const;
 
@@ -366,7 +367,7 @@ export function makaAheEvidenceFromTaskRunProjections(
     const effectiveExport = official
       ? taskRunExportWithOfficialOverlay(exported, official)
       : exported;
-    const taskRunRef = `${traceBaseRef}/${safePathSegment(projection.taskRunId)}`;
+    const taskRunRef = `${traceBaseRef}/${taskRunLocator(projection.taskRunId)}`;
     const generatedRefs = generatedRefsFor(options.generatedRefs, projection.taskRunId);
     const result = runResultFromProjection(projection, effectiveExport, {
       snapshotId: options.snapshotId,
@@ -435,8 +436,9 @@ export async function writeMakaAheEvidenceExport(
   await writeStableJson(files.targetSnapshotJson, options.snapshot);
 
   for (const projection of sortProjections(options.projections)) {
-    const traceDir = join(outDir, 'traces', safePathSegment(projection.taskRunId));
-    const taskRunRef = `traces/${safePathSegment(projection.taskRunId)}`;
+    const locator = taskRunLocator(projection.taskRunId);
+    const traceDir = join(outDir, 'traces', locator);
+    const taskRunRef = `traces/${locator}`;
     files.traceDirs[projection.taskRunId] = traceDir;
     files.agentRunDirs[projection.taskRunId] = {};
     const taskRunWrite = await writeTaskRunExport(traceDir, projection, {
@@ -705,7 +707,7 @@ function failureDigestFromProjection(
   const authority = scoreAuthority(exported.score, exported.verifier, projection);
   const status = resultStatus(exported, projection, authority);
   if (status === 'official_pass') return undefined;
-  const taskRunRef = `traces/${safePathSegment(projection.taskRunId)}`;
+  const taskRunRef = `traces/${taskRunLocator(projection.taskRunId)}`;
   return {
     schemaVersion: 'maka.ahe.failure_digest.v1',
     taskRunId: projection.taskRunId,

--- a/packages/headless/src/autonomous-agent-loop.ts
+++ b/packages/headless/src/autonomous-agent-loop.ts
@@ -3,10 +3,15 @@ import type { Config, ResultRecord, Task } from './contracts.js';
 import { validateRealBackendIsolation } from './isolation.js';
 import { resolveHeavyTaskMode } from './heavy-task-policy.js';
 import { renderHeavyTaskProgressForPrompt } from './heavy-task-progress.js';
+import {
+  authenticateHeadlessStorageWriter,
+  openHeadlessStorageForWrite,
+  type HeadlessStorageWriter,
+} from './headless-storage.js';
 import { backendNeedsIsolation, validateTaskVerification } from './runner.js';
 import { budgetExtensionInboxItem } from './task-inbox.js';
 import {
-  runTaskOnce,
+  runTaskOnceWithStorage,
   type RunTaskOnceDeps,
   type RunTaskOnceResult,
 } from './task-agent-controller.js';
@@ -21,7 +26,8 @@ import {
   type TaskRunError,
   type TaskRunResult,
 } from './task-contracts.js';
-import { createTaskRunStore, type TaskRunProjection, type TaskRunStore } from './task-run-store.js';
+import type { TaskRunProjection } from './task-run-projection.js';
+import type { TaskRunWriter } from './task-run-store.js';
 import { taskDefinitionFromTask } from './task-run-adapter.js';
 
 export interface AutonomousLoopBudget {
@@ -112,10 +118,21 @@ export async function runAutonomousTask(
   task: Task,
   options: RunAutonomousTaskOptions,
 ): Promise<RunAutonomousTaskResult> {
+  const storage = await openHeadlessStorageForWrite(options.storageRoot);
+  return runAutonomousTaskWithStorage(config, task, options, storage);
+}
+
+export async function runAutonomousTaskWithStorage(
+  config: Config,
+  task: Task,
+  options: RunAutonomousTaskOptions,
+  storage: HeadlessStorageWriter,
+): Promise<RunAutonomousTaskResult> {
+  storage = authenticateHeadlessStorageWriter(storage);
   const now = options.now ?? Date.now;
   const newId = options.newId ?? randomUUID;
   const taskRunId = options.taskRunId ?? newId();
-  const taskRunStore = options.taskRunStore ?? createTaskRunStore(options.storageRoot);
+  const taskRunStore = storage.taskRunStore;
   const startedAt = now();
   const attempts: RunTaskOnceResult[] = [];
 
@@ -242,16 +259,20 @@ export async function runAutonomousTask(
 
     const attemptNumber = attempts.length + 1;
     const attemptId = `${taskRunId}-attempt-${attemptNumber}`;
-    const attempt = await runTaskOnce(config, task, {
-      ...options,
-      taskRunStore,
-      taskRunId,
-      attemptId,
-      createTaskRun: false,
-      closeTaskRun: false,
-      ...(instructionOverride ? { instructionOverride } : {}),
-      ...(priorRuntimeContext.length > 0 ? { priorRuntimeContext } : {}),
-    });
+    const attempt = await runTaskOnceWithStorage(
+      config,
+      task,
+      {
+        ...options,
+        taskRunId,
+        attemptId,
+        createTaskRun: false,
+        closeTaskRun: false,
+        ...(instructionOverride ? { instructionOverride } : {}),
+        ...(priorRuntimeContext.length > 0 ? { priorRuntimeContext } : {}),
+      },
+      storage,
+    );
     attempts.push(attempt);
     latestResultRecord = attempt.resultRecord;
     runtimeStepsUsed += attempt.resultRecord.steps;
@@ -543,7 +564,7 @@ function isNonRetryable(taxonomy: AutonomousResultTaxonomy): boolean {
 async function maybeRecordSelfCheck(
   policy: false | SelfCheckPolicy | undefined,
   input: SelfCheckInput,
-  store: TaskRunStore,
+  store: TaskRunWriter,
   taskRunId: string,
   attemptId: string,
   now: () => number,
@@ -571,7 +592,7 @@ async function maybeRecordSelfCheck(
 }
 
 async function appendVerifierFeedback(
-  store: TaskRunStore,
+  store: TaskRunWriter,
   taskRunId: string,
   attemptId: string,
   now: () => number,
@@ -612,7 +633,7 @@ async function appendVerifierFeedback(
 }
 
 async function appendSystemFeedback(
-  store: TaskRunStore,
+  store: TaskRunWriter,
   taskRunId: string,
   attemptId: string | undefined,
   now: () => number,
@@ -640,7 +661,7 @@ async function appendSystemFeedback(
 }
 
 async function appendDecision(
-  store: TaskRunStore,
+  store: TaskRunWriter,
   taskRunId: string,
   attemptId: string,
   now: () => number,
@@ -679,7 +700,7 @@ async function appendDecision(
 }
 
 async function appendBudgetTerminal(
-  store: TaskRunStore,
+  store: TaskRunWriter,
   taskRunId: string,
   now: () => number,
   newId: () => string,
@@ -863,6 +884,6 @@ Verification exit code: ${attempt.resultRecord.exitCode ?? 'none'}.
 Continue from that feedback and produce a corrected solution.${selfCheckLine}${progressLine}`;
 }
 
-function appendTaskEvent(store: TaskRunStore, taskRunId: string, event: TaskEvent): Promise<void> {
+function appendTaskEvent(store: TaskRunWriter, taskRunId: string, event: TaskEvent): Promise<void> {
   return store.appendEvent(taskRunId, event);
 }

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -4,10 +4,16 @@ import { realpathSync } from 'node:fs';
 import { readFile, stat, writeFile } from 'node:fs/promises';
 import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { createAgentRunStore, createRuntimeEventStore } from '@maka/storage';
 import { inspectAgentRunDocument } from '@maka/runtime';
 import type { Config, ResultRecord, Task } from './contracts.js';
-import { runAutonomousTask } from './autonomous-agent-loop.js';
+import { runAutonomousTask, runAutonomousTaskWithStorage } from './autonomous-agent-loop.js';
+import {
+  authenticateHeadlessStorageReader,
+  isStorageRootAuthorityError,
+  openHeadlessStorageForRead,
+  openHeadlessStorageForWrite,
+  type HeadlessStorageReader,
+} from './headless-storage.js';
 import { harborCommand } from './harbor-cli.js';
 import { runMatrix, type ExperimentSpec } from './matrix.js';
 import { planMatrixRetry, readMatrixPriorRecords } from './matrix-resume.js';
@@ -22,9 +28,10 @@ import {
 } from './ahe-evidence-export.js';
 import { writeTaskRunExport } from './result-export.js';
 import { backendNeedsIsolation, validateTaskVerification } from './runner.js';
-import { runTaskOnce } from './task-agent-controller.js';
+import { runTaskOnce, runTaskOnceWithStorage } from './task-agent-controller.js';
 import { isTerminalTaskRunStatus, type TaskPermissionGrant } from './task-contracts.js';
-import { createTaskRunStore, type TaskRunProjection } from './task-run-store.js';
+import { taskRunLocator } from './task-run-identity.js';
+import type { TaskRunProjection } from './task-run-projection.js';
 import { inspectTaskRun, renderTaskRunInspectTree } from './task-run-inspect.js';
 import { readResults, toComparisonTable, writeResults } from './results.js';
 
@@ -163,10 +170,8 @@ async function taskRunCommand(args: string[]): Promise<number> {
     const config = requireConfig(spec.configs, parsed.flags.config);
     validateRunnableCell(config, task);
     const outDir = resolve(parsed.flags.out ?? 'maka-headless-out');
-    const store = createTaskRunStore(join(outDir, 'runs'));
     const common = {
       storageRoot: join(outDir, 'runs'),
-      taskRunStore: store,
       ...(parsed.flags['task-run-id'] ? { taskRunId: parsed.flags['task-run-id'] } : {}),
     };
     const run = parsed.bools.autonomous
@@ -178,7 +183,7 @@ async function taskRunCommand(args: string[]): Promise<number> {
         })
       : await runTaskOnce(config, task, common);
     await appendResultRecord(outDir, run.resultRecord);
-    const exportDir = join(outDir, 'exports', run.taskRunId);
+    const exportDir = join(outDir, 'exports', taskRunLocator(run.taskRunId));
     await writeTaskRunExport(exportDir, run.projection, {
       includeEvents: parsed.bools['include-events'],
     });
@@ -208,11 +213,12 @@ async function taskInspectCommand(args: string[]): Promise<number> {
     return 1;
   }
   const storageRoot = resolve(parsed.flags.store);
+  const storage = await openHeadlessStorageForRead(storageRoot);
   const document = await inspectTaskRun(
     {
-      taskRunStore: createTaskRunStore(storageRoot),
-      agentRunStore: createAgentRunStore(storageRoot),
-      runtimeEventStore: createRuntimeEventStore(storageRoot),
+      taskRunStore: storage.taskRunStore,
+      agentRunStore: storage.executionStores.agentRunStore,
+      runtimeEventStore: storage.executionStores.runtimeEventStore,
     },
     taskRunId,
   );
@@ -241,7 +247,8 @@ async function taskExportCommand(args: string[]): Promise<number> {
     );
     return 1;
   }
-  const projection = await createTaskRunStore(resolve(parsed.flags.store)).project(taskRunId);
+  const storage = await openHeadlessStorageForRead(resolve(parsed.flags.store));
+  const projection = await storage.taskRunStore.project(taskRunId);
   const result = await writeTaskRunExport(resolve(parsed.flags.out), projection, {
     includeEvents: parsed.bools['include-events'],
   });
@@ -286,9 +293,9 @@ async function aheExportCommand(args: string[]): Promise<number> {
   }
   try {
     const storeRoot = resolve(parsed.flags.store);
-    const store = createTaskRunStore(storeRoot);
+    const storage = await openHeadlessStorageForRead(storeRoot);
     const projections = await Promise.all(
-      parsed.positional.map((taskRunId) => store.project(taskRunId)),
+      parsed.positional.map((taskRunId) => storage.taskRunStore.project(taskRunId)),
     );
     const officialResults = await aheOfficialResultsForCli(projections, {
       storeRoot,
@@ -296,10 +303,10 @@ async function aheExportCommand(args: string[]): Promise<number> {
         ? resolve(parsed.flags['harbor-trial-dir'])
         : undefined,
     });
-    const sessionMessages = await aheSessionMessagesForCli(projections, storeRoot);
+    const sessionMessages = await aheSessionMessagesForCli(projections, storage);
     const agentRunEvidence = await aheAgentRunEvidenceForCli(
       projections,
-      storeRoot,
+      storage,
       parsed.bools['include-events'] === true,
     );
     const snapshot = await buildMakaAheTargetSnapshot({
@@ -365,16 +372,21 @@ async function looksLikeHarborTrialDir(dir: string): Promise<boolean> {
 
 async function aheSessionMessagesForCli(
   projections: readonly TaskRunProjection[],
-  storeRoot: string,
+  storage: HeadlessStorageReader,
 ): Promise<MakaAheSessionMessagesByTaskRun | undefined> {
+  storage = authenticateHeadlessStorageReader(storage);
   const messagesByTaskRun: Record<string, readonly unknown[]> = {};
   for (const projection of projections) {
     if (!projection.sessionId) continue;
-    const messages = await readSessionMessages(
-      join(storeRoot, 'sessions', projection.sessionId, 'session.jsonl'),
-    );
-    if (messages.length > 0) {
-      messagesByTaskRun[projection.taskRunId] = messages;
+    try {
+      const messages = await storage.executionStores.sessionStore.readMessages(
+        projection.sessionId,
+      );
+      if (messages.length > 0) {
+        messagesByTaskRun[projection.taskRunId] = messages;
+      }
+    } catch (error) {
+      rethrowStorageAuthorityError(error);
     }
   }
   return Object.keys(messagesByTaskRun).length > 0 ? messagesByTaskRun : undefined;
@@ -382,11 +394,12 @@ async function aheSessionMessagesForCli(
 
 async function aheAgentRunEvidenceForCli(
   projections: readonly TaskRunProjection[],
-  storeRoot: string,
+  storage: HeadlessStorageReader,
   includeRuntimeEvents: boolean,
 ): Promise<MakaAheAgentRunEvidenceByTaskRun | undefined> {
-  const runStore = createAgentRunStore(storeRoot);
-  const runtimeEventStore = createRuntimeEventStore(storeRoot);
+  storage = authenticateHeadlessStorageReader(storage);
+  const runStore = storage.executionStores.agentRunStore;
+  const runtimeEventStore = storage.executionStores.runtimeEventStore;
   const byTaskRun: Record<string, MakaAheAgentRunEvidenceSource[]> = {};
   for (const projection of projections) {
     const sources: MakaAheAgentRunEvidenceSource[] = [];
@@ -405,8 +418,10 @@ async function aheAgentRunEvidenceForCli(
         source.inspect = await inspectAgentRunDocument(runStore, runtimeEventStore, {
           sessionId: identity.sessionId,
           agentRunId: identity.agentRunId,
+          isFatalReadError: isStorageRootAuthorityError,
         });
       } catch (error) {
+        rethrowStorageAuthorityError(error);
         source.inspectError = errorMessage(error);
       }
       if (includeRuntimeEvents) {
@@ -421,6 +436,7 @@ async function aheAgentRunEvidenceForCli(
             );
           }
         } catch (error) {
+          rethrowStorageAuthorityError(error);
           source.runtimeEventsError = errorMessage(error);
         }
       }
@@ -431,18 +447,8 @@ async function aheAgentRunEvidenceForCli(
   return Object.keys(byTaskRun).length > 0 ? byTaskRun : undefined;
 }
 
-async function readSessionMessages(path: string): Promise<unknown[]> {
-  try {
-    const text = await readFile(path, 'utf8');
-    return text
-      .split('\n')
-      .map((line) => line.trim())
-      .filter(Boolean)
-      .map((line) => JSON.parse(line) as unknown)
-      .filter((record) => Boolean((record as { type?: unknown }).type));
-  } catch {
-    return [];
-  }
+function rethrowStorageAuthorityError(error: unknown): void {
+  if (isStorageRootAuthorityError(error)) throw error;
 }
 
 async function taskResumeCommand(args: string[]): Promise<number> {
@@ -464,7 +470,8 @@ async function taskResumeCommand(args: string[]): Promise<number> {
   }
   try {
     const outDir = resolve(parsed.flags.out);
-    const store = createTaskRunStore(join(outDir, 'runs'));
+    const storage = await openHeadlessStorageForWrite(join(outDir, 'runs'));
+    const store = storage.taskRunStore;
     const projection = await store.project(taskRunId);
     if (isTerminalTaskRunStatus(projection.status)) {
       console.error(
@@ -505,16 +512,20 @@ async function taskResumeCommand(args: string[]): Promise<number> {
       });
     }
     const attemptId = `${taskRunId}-attempt-${projection.attempts.length + 1}`;
-    const run = await runTaskOnce(config, task, {
-      storageRoot: join(outDir, 'runs'),
-      taskRunStore: store,
-      taskRunId,
-      attemptId,
-      createTaskRun: false,
-      permissionGrants: grants,
-    });
+    const run = await runTaskOnceWithStorage(
+      config,
+      task,
+      {
+        storageRoot: join(outDir, 'runs'),
+        taskRunId,
+        attemptId,
+        createTaskRun: false,
+        permissionGrants: grants,
+      },
+      storage,
+    );
     await appendResultRecord(outDir, run.resultRecord);
-    await writeTaskRunExport(join(outDir, 'exports', taskRunId), run.projection);
+    await writeTaskRunExport(join(outDir, 'exports', taskRunLocator(taskRunId)), run.projection);
     console.log(`resumed: ${taskRunId}\nstatus: ${run.projection.status}`);
     return run.resultRecord.error ? 1 : 0;
   } catch (error) {
@@ -545,6 +556,7 @@ async function taskRetryFailedCommand(args: string[]): Promise<number> {
     const spec = await loadSpec(parsed.flags.spec);
     const prior = await readMatrixPriorRecords(resolve(priorPath));
     const outDir = resolve(parsed.flags.out);
+    const storage = await openHeadlessStorageForWrite(join(outDir, 'runs'));
     const onlyTaxonomy = parsed.flags['only-taxonomy']
       ?.split(',')
       .map((value) => value.trim())
@@ -561,12 +573,19 @@ async function taskRetryFailedCommand(args: string[]): Promise<number> {
       }
       validateRunnableCell(decision.config, decision.task);
       console.log(`retry ${decision.task.id} × ${decision.config.id}: ${decision.reason}`);
-      const run = await runTaskOnce(decision.config, decision.task, {
-        storageRoot: join(outDir, 'runs'),
-        taskRunStore: createTaskRunStore(join(outDir, 'runs')),
-      });
+      const run = await runTaskOnceWithStorage(
+        decision.config,
+        decision.task,
+        {
+          storageRoot: join(outDir, 'runs'),
+        },
+        storage,
+      );
       records.push(run.resultRecord);
-      await writeTaskRunExport(join(outDir, 'exports', run.taskRunId), run.projection);
+      await writeTaskRunExport(
+        join(outDir, 'exports', taskRunLocator(run.taskRunId)),
+        run.projection,
+      );
     }
     await writeResults(join(outDir, 'results.jsonl'), records);
     await writeFile(join(outDir, 'comparison.md'), toComparisonTable(records), 'utf8');

--- a/packages/headless/src/cli.ts
+++ b/packages/headless/src/cli.ts
@@ -213,21 +213,23 @@ async function taskInspectCommand(args: string[]): Promise<number> {
     return 1;
   }
   const storageRoot = resolve(parsed.flags.store);
-  const storage = await openHeadlessStorageForRead(storageRoot);
-  const document = await inspectTaskRun(
-    {
-      taskRunStore: storage.taskRunStore,
-      agentRunStore: storage.executionStores.agentRunStore,
-      runtimeEventStore: storage.executionStores.runtimeEventStore,
-    },
-    taskRunId,
-  );
-  if (parsed.bools.json) {
-    process.stdout.write(`${JSON.stringify(document, null, 2)}\n`);
-  } else {
-    process.stdout.write(renderTaskRunInspectTree(document));
-  }
-  return 0;
+  return runTaskRunStorageCommand('inspect', storageRoot, async () => {
+    const storage = await openHeadlessStorageForRead(storageRoot);
+    const document = await inspectTaskRun(
+      {
+        taskRunStore: storage.taskRunStore,
+        agentRunStore: storage.executionStores.agentRunStore,
+        runtimeEventStore: storage.executionStores.runtimeEventStore,
+      },
+      taskRunId,
+    );
+    if (parsed.bools.json) {
+      process.stdout.write(`${JSON.stringify(document, null, 2)}\n`);
+    } else {
+      process.stdout.write(renderTaskRunInspectTree(document));
+    }
+    return 0;
+  });
 }
 
 async function taskExportCommand(args: string[]): Promise<number> {
@@ -247,13 +249,16 @@ async function taskExportCommand(args: string[]): Promise<number> {
     );
     return 1;
   }
-  const storage = await openHeadlessStorageForRead(resolve(parsed.flags.store));
-  const projection = await storage.taskRunStore.project(taskRunId);
-  const result = await writeTaskRunExport(resolve(parsed.flags.out), projection, {
-    includeEvents: parsed.bools['include-events'],
+  const storageRoot = resolve(parsed.flags.store);
+  return runTaskRunStorageCommand('export', storageRoot, async () => {
+    const storage = await openHeadlessStorageForRead(storageRoot);
+    const projection = await storage.taskRunStore.project(taskRunId);
+    const result = await writeTaskRunExport(resolve(parsed.flags.out), projection, {
+      includeEvents: parsed.bools['include-events'],
+    });
+    console.log(`export: ${result.files.taskRunJson}`);
+    return 0;
   });
-  console.log(`export: ${result.files.taskRunJson}`);
-  return 0;
 }
 
 async function aheCommand(args: string[]): Promise<number> {
@@ -603,6 +608,26 @@ function mark(passed: boolean, error?: string): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
+}
+
+async function runTaskRunStorageCommand(
+  command: 'inspect' | 'export',
+  storageRoot: string,
+  operation: () => Promise<number>,
+): Promise<number> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (!isStorageRootAuthorityError(error)) throw error;
+    const message =
+      error.code === 'root_not_found' ||
+      error.code === 'root_unmarked' ||
+      error.code === 'root_kind_mismatch'
+        ? `The selected path is not a Headless task-run root: ${storageRoot}. Pass the <out>/runs directory created by a task run`
+        : error.message;
+    console.error(`maka eval task-run ${command}: ${message}`);
+    return 1;
+  }
 }
 
 interface ParsedArgs {

--- a/packages/headless/src/fs-native-extensions.d.ts
+++ b/packages/headless/src/fs-native-extensions.d.ts
@@ -1,0 +1,8 @@
+declare module 'fs-native-extensions' {
+  export interface LockOptions {
+    shared?: boolean;
+  }
+
+  export function waitForLock(fd: number, options?: LockOptions): Promise<void>;
+  export function unlock(fd: number): void;
+}

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -1,8 +1,14 @@
 import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
-import type { BackendKind, PricingConfig, ProviderType } from '@maka/core';
-import { isThinkingLevel, resolveModelVisionSupport } from '@maka/core';
+import type {
+  AgentRunHeader,
+  BackendKind,
+  PricingConfig,
+  ProviderType,
+  RuntimeEvent,
+} from '@maka/core';
+import { isTerminalRuntimeEvent, isThinkingLevel, resolveModelVisionSupport } from '@maka/core';
 import {
   AiSdkBackend,
   BackendRegistry,
@@ -18,16 +24,13 @@ import {
   loadSynthesisCacheBlocksFromArtifacts,
   persistSynthesisCacheBlocksToArtifacts,
   type InvocationResult,
+  type SynthesisCacheArtifactStore,
   type SynthesisCacheLoader,
   type SynthesisCacheWriter,
 } from '@maka/runtime';
 import {
-  createAgentRunStore,
   createAttachmentByteReader,
-  createArtifactStore,
   createReadImageSnapshotter,
-  createRuntimeEventStore,
-  createSessionStore,
   persistProviderRequestCaptureArtifact,
 } from '@maka/storage';
 import { registerFakeBackend } from './backends.js';
@@ -44,6 +47,12 @@ import {
 import type { Config, Task } from './contracts.js';
 import { resolveHeavyTaskMode } from './heavy-task-policy.js';
 import { resolveEconomyTaskMode } from './economy-task-policy.js';
+import {
+  authenticateHeadlessStorageWriter,
+  isStorageRootAuthorityError,
+  openHeadlessStorageForWrite,
+  type HeadlessStorageWriter,
+} from './headless-storage.js';
 import type { HeadlessBackendContext, RealBackendIsolation } from './isolation.js';
 import { validateRealBackendIsolation } from './isolation.js';
 import { PiCliJsonTransport } from './pi-cli-json-transport.js';
@@ -251,6 +260,15 @@ const PI_PROVIDER_ENV_RULES = [
 ] satisfies Array<{ includes: string[]; keys?: string[]; prefixes?: string[] }>;
 
 export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarborCellResult> {
+  const storage = await openHeadlessStorageForWrite(input.storageRoot);
+  return runHarborCellWithStorage(input, storage);
+}
+
+export async function runHarborCellWithStorage(
+  input: RunHarborCellInput,
+  storage: HeadlessStorageWriter,
+): Promise<RunHarborCellResult> {
+  storage = authenticateHeadlessStorageWriter(storage);
   if (
     input.settleAfterMs !== undefined &&
     (!Number.isFinite(input.settleAfterMs) || input.settleAfterMs <= 0)
@@ -268,9 +286,9 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
 
   const now = input.now ?? Date.now;
   const newId = input.newId ?? randomId;
-  const sessionStore = createSessionStore(input.storageRoot);
-  const agentRunStore = createAgentRunStore(input.storageRoot);
-  const runtimeEventStore = createRuntimeEventStore(input.storageRoot);
+  const sessionStore = storage.executionStores.sessionStore;
+  const agentRunStore = storage.executionStores.agentRunStore;
+  const runtimeEventStore = storage.executionStores.runtimeEventStore;
   const backends = new BackendRegistry();
   const sessionCapabilities = createHeadlessSessionCapabilityBridge();
   const task: Task = {
@@ -290,6 +308,7 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
     storageRoot: input.storageRoot,
     workspaceDir: input.cwd,
     ...sessionCapabilities.capabilities,
+    artifactStore: storage.artifactStore,
     ...(backendNeedsIsolation(input.config.backend)
       ? {
           realBackendIsolation: input.realBackendIsolation,
@@ -370,13 +389,20 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
   let nextText = input.instruction;
   let stepCapHits = 0;
   let attemptedTurnId: string | undefined;
+  let attemptedRunId: string | undefined;
   try {
     for (let turnIndex = 0; turnIndex < continuationPolicy.maxTurns; turnIndex += 1) {
       if (deadlineReached) break;
       const turnId = newId();
+      const runId = newId();
       attemptedTurnId = turnId;
+      attemptedRunId = runId;
       invocation = undefined;
-      for await (const event of manager.sendMessage(session.id, { turnId, text: nextText })) {
+      for await (const event of manager.sendMessage(
+        session.id,
+        { turnId, text: nextText },
+        { runId },
+      )) {
         if ((event as { type?: string }).type === 'permission_request') {
           const { requestId } = event as { requestId: string };
           await manager.respondToPermission(session.id, {
@@ -397,30 +423,40 @@ export async function runHarborCell(input: RunHarborCellInput): Promise<RunHarbo
       nextText = continuationPolicy.prompt;
     }
   } catch (error) {
+    if (isStorageRootAuthorityError(error)) throw error;
     sendMessageError = error;
   } finally {
     if (settlementTimer) clearTimeout(settlementTimer);
   }
   await settlementAttempt;
   if (settlementError) throw settlementError;
+  const deadlineRun =
+    deadlineReached && attemptedRunId
+      ? await agentRunStore.readRun(session.id, attemptedRunId).catch((error) => {
+          if (isStorageRootAuthorityError(error)) throw error;
+          return undefined;
+        })
+      : undefined;
+  const settledByDeadline =
+    deadlineRun?.status === 'cancelled' && deadlineRun.abortSource === 'benchmark.deadline';
   if (sendMessageError) {
     invocations.push(
-      failedInvocationFromError(sendMessageError, {
-        newId,
-        now,
-        sessionId: session.id,
-        turnId: attemptedTurnId ?? newId(),
-      }),
+      settledByDeadline
+        ? failedDeadlineInvocationFromRun(
+            deadlineRun,
+            await runtimeEventStore.readRuntimeEvents(session.id, deadlineRun.runId),
+          )
+        : failedInvocationFromError(sendMessageError, {
+            newId,
+            now,
+            sessionId: session.id,
+            turnId: attemptedTurnId ?? newId(),
+          }),
     );
   } else if (invocations.length === 0) {
     throw new Error('Harbor cell finished without a runtime invocation result');
   }
   const combinedInvocation = combineInvocations(invocations);
-  const terminalRun = deadlineReached
-    ? await agentRunStore.readRun(session.id, combinedInvocation.runId).catch(() => undefined)
-    : undefined;
-  const settledByDeadline =
-    terminalRun?.status === 'cancelled' && terminalRun.abortSource === 'benchmark.deadline';
   const continuationSummary = continuationPolicy.enabled
     ? buildContinuationSummary(continuationPolicy, invocations, stepCapHits)
     : undefined;
@@ -489,23 +525,17 @@ export async function writeHarborCellArtifacts(
 
 export async function writeHarborTaskRunTrace(input: {
   outputDir: string;
-  storageRoot: string;
+  storage: HeadlessStorageWriter;
   invocations: readonly InvocationResult[];
 }): Promise<string> {
-  const chunks = await Promise.all(
+  const storage = authenticateHeadlessStorageWriter(input.storage);
+  const eventGroups = await Promise.all(
     input.invocations.map((invocation) =>
-      readFile(
-        join(
-          input.storageRoot,
-          'sessions',
-          invocation.sessionId,
-          'runs',
-          invocation.runId,
-          'events.jsonl',
-        ),
-        'utf8',
-      ),
+      storage.executionStores.agentRunStore.readEvents(invocation.sessionId, invocation.runId),
     ),
+  );
+  const chunks = eventGroups.map((events) =>
+    events.map((event) => JSON.stringify(event)).join('\n'),
   );
   const nonEmptyChunks = chunks.map((chunk) => chunk.trimEnd()).filter(Boolean);
   const traceEventsPath = join(input.outputDir, HARBOR_CELL_TRACE_EVENTS_FILENAME);
@@ -765,6 +795,37 @@ function failedInvocationFromError(
   };
 }
 
+function failedDeadlineInvocationFromRun(
+  run: AgentRunHeader,
+  events: RuntimeEvent[],
+): InvocationResult {
+  let terminal: RuntimeEvent | undefined;
+  for (let index = events.length - 1; index >= 0; index -= 1) {
+    const candidate = events[index]!;
+    if (!isTerminalRuntimeEvent(candidate)) continue;
+    terminal = candidate;
+    break;
+  }
+  const terminalStatus =
+    terminal?.status === 'completed' ? 'cancelled' : (terminal?.status ?? 'cancelled');
+  const message = terminal?.content?.kind === 'error' ? terminal.content.message : undefined;
+  return {
+    invocationId: run.invocationId ?? events[0]?.invocationId ?? run.runId,
+    runId: run.runId,
+    sessionId: run.sessionId,
+    turnId: run.turnId,
+    status: 'failed',
+    failure: {
+      class: terminalStatus,
+      ...(message ? { message } : {}),
+      terminalStatus,
+    },
+    events,
+    startedAt: run.createdAt,
+    finishedAt: run.completedAt ?? run.updatedAt,
+  };
+}
+
 export function buildAiSdkCellBackendRegistration(input: {
   provider: ProviderType;
   model: string;
@@ -796,6 +857,8 @@ export function buildAiSdkCellBackendRegistration(input: {
     input.env.MAKA_STREAM_IDLE_TIMEOUT_MS,
     'MAKA_STREAM_IDLE_TIMEOUT_MS',
   );
+  const synthesisCacheEnabled =
+    contextBudgetBackendOptions.contextBudget?.synthesisCache?.enabled === true;
   const taskLedgerExperimentPolicy = buildHarborCellTaskLedgerExperimentPolicy(input.env);
   const taskLedgerExperimentStore = taskLedgerExperimentPolicy
     ? createInMemoryTaskLedgerExperimentStore({ now: input.now, newId: input.newId })
@@ -804,12 +867,11 @@ export function buildAiSdkCellBackendRegistration(input: {
     if (!context.toolExecutor) {
       throw new Error('Harbor ai-sdk backend requires an isolated tool executor');
     }
-    // FileArtifactStore owns an in-memory metadata index, so every artifact
-    // consumer under the run's authoritative storage root shares this instance.
-    const artifactStore = createArtifactStore(context.storageRoot);
+    // Artifact consumers share the same lease-bound store and metadata index.
+    const artifactStore = context.artifactStore;
     const synthesisCacheCallbacks = buildHarborCellSynthesisCacheCallbacks(
       artifactStore,
-      contextBudgetBackendOptions.contextBudget?.synthesisCache?.enabled === true,
+      synthesisCacheEnabled,
     );
     registry.register('ai-sdk', (ctx) => {
       const subscriptionFetch = buildSubscriptionModelFetch({
@@ -953,7 +1015,7 @@ async function writeHarborCellArtifact(path: string, contents: string): Promise<
 }
 
 function buildHarborCellSynthesisCacheCallbacks(
-  artifactStore: ReturnType<typeof createArtifactStore>,
+  artifactStore: SynthesisCacheArtifactStore,
   enabled: boolean,
 ): { loadSynthesisCache?: SynthesisCacheLoader; writeSynthesisCache?: SynthesisCacheWriter } {
   if (!enabled) return {};

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -11,7 +11,7 @@ import {
   combineInvocations,
   validateHarborCellExecutionIdentity,
 } from './cell-output.js';
-import { runAutonomousTask } from './autonomous-agent-loop.js';
+import { runAutonomousTaskWithStorage } from './autonomous-agent-loop.js';
 import type { BenchmarkAdapterRegistry } from './benchmark-adapters.js';
 import { resolveEconomyTaskMode } from './economy-task-policy.js';
 import {
@@ -21,7 +21,7 @@ import {
   createHarborHttpToolExecutor,
   harborCellSoftTimeoutMsFromEnv,
   reasoningEffortFromEnv,
-  runHarborCell,
+  runHarborCellWithStorage,
   writeHarborCellArtifacts,
   writeHarborCellExecutionIdentity,
   writeHarborTaskRunTrace,
@@ -30,12 +30,13 @@ import {
 } from './harbor-cell.js';
 import { classifyExternalHarborBenchmarkFailure } from './harbor-failure-policy.js';
 import { resolveHeavyTaskMode } from './heavy-task-policy.js';
+import { openHeadlessStorageForWrite, type HeadlessStorageWriter } from './headless-storage.js';
 import type { RealBackendIsolation } from './isolation.js';
 import { writeTaskRunExport } from './result-export.js';
 import { backendNeedsIsolation } from './runner.js';
-import { runTaskOnce } from './task-agent-controller.js';
+import { runTaskOnceWithStorage } from './task-agent-controller.js';
 import { taxonomyFromResultRecord } from './task-contracts.js';
-import { createTaskRunStore } from './task-run-store.js';
+import { taskRunLocator } from './task-run-identity.js';
 import { requireProviderCredentialEnv } from './provider-env.js';
 import { resolveHeadlessSystemPrompt } from './system-prompts.js';
 
@@ -130,28 +131,37 @@ async function harborRunCommand(args: string[]): Promise<number> {
   }
 
   try {
-    if (options.mode === 'cell') return await runHarborCellMode(options);
-    return await runHarborTaskRunMode(options);
+    const storage = await openHeadlessStorageForWrite(options.storageRoot);
+    if (options.mode === 'cell') return await runHarborCellMode(options, storage);
+    return await runHarborTaskRunMode(options, storage);
   } catch (error) {
     console.error(`maka eval harbor run: ${(error as Error).message}`);
     return 1;
   }
 }
 
-async function runHarborCellMode(options: HarborRunOptions): Promise<number> {
-  const result = await runHarborCell({
-    config: options.config,
-    instruction: options.instruction,
-    cwd: options.workdir,
-    outputDir: options.outDir,
-    storageRoot: options.storageRoot,
-    ...(options.contextBudgetPolicy ? { contextBudgetPolicy: options.contextBudgetPolicy } : {}),
-    ...(options.softTimeoutMs !== undefined ? { settleAfterMs: options.softTimeoutMs } : {}),
-    ...(options.registerBackends ? { registerBackends: options.registerBackends } : {}),
-    ...(options.realBackendIsolation ? { realBackendIsolation: options.realBackendIsolation } : {}),
-    now: options.now,
-    newId: options.newId,
-  });
+async function runHarborCellMode(
+  options: HarborRunOptions,
+  storage: HeadlessStorageWriter,
+): Promise<number> {
+  const result = await runHarborCellWithStorage(
+    {
+      config: options.config,
+      instruction: options.instruction,
+      cwd: options.workdir,
+      outputDir: options.outDir,
+      storageRoot: options.storageRoot,
+      ...(options.contextBudgetPolicy ? { contextBudgetPolicy: options.contextBudgetPolicy } : {}),
+      ...(options.softTimeoutMs !== undefined ? { settleAfterMs: options.softTimeoutMs } : {}),
+      ...(options.registerBackends ? { registerBackends: options.registerBackends } : {}),
+      ...(options.realBackendIsolation
+        ? { realBackendIsolation: options.realBackendIsolation }
+        : {}),
+      now: options.now,
+      newId: options.newId,
+    },
+    storage,
+  );
   process.stdout.write(
     `${JSON.stringify({
       mode: 'cell',
@@ -164,7 +174,10 @@ async function runHarborCellMode(options: HarborRunOptions): Promise<number> {
   return result.output.status === 'completed' ? 0 : 1;
 }
 
-async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> {
+async function runHarborTaskRunMode(
+  options: HarborRunOptions,
+  storage: HeadlessStorageWriter,
+): Promise<number> {
   await Promise.all([
     mkdir(options.outDir, { recursive: true }),
     mkdir(options.cellArtifactDir, { recursive: true }),
@@ -172,12 +185,10 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
   if (options.sourceWorkspaceDir !== options.workdir) {
     await mkdir(options.sourceWorkspaceDir, { recursive: true });
   }
-  const store = createTaskRunStore(options.storageRoot);
   const task = buildHarborTask(options);
   const executionIdentity = await writeTaskRunExecutionIdentity(options, task);
   const common = {
     storageRoot: options.storageRoot,
-    taskRunStore: store,
     taskRunId: options.taskRunId,
     benchmarkAdapters: externalHarborBenchmarkAdapters(),
     ...(options.registerBackends ? { registerBackends: options.registerBackends } : {}),
@@ -189,51 +200,61 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
       : {}),
   };
   const run = options.autonomous
-    ? await runAutonomousTask(options.config, task, {
-        ...common,
-        budget: {
-          maxAttempts: options.maxAttempts,
-          ...(options.maxRuntimeSteps !== undefined
-            ? { maxRuntimeSteps: options.maxRuntimeSteps }
+    ? await runAutonomousTaskWithStorage(
+        options.config,
+        task,
+        {
+          ...common,
+          budget: {
+            maxAttempts: options.maxAttempts,
+            ...(options.maxRuntimeSteps !== undefined
+              ? { maxRuntimeSteps: options.maxRuntimeSteps }
+              : {}),
+            ...(options.maxWallTimeMs !== undefined
+              ? { maxWallTimeMs: options.maxWallTimeMs }
+              : {}),
+          },
+          ...(options.replayPriorAttemptRuntimeContext
+            ? { replayPriorAttemptRuntimeContext: true }
             : {}),
-          ...(options.maxWallTimeMs !== undefined ? { maxWallTimeMs: options.maxWallTimeMs } : {}),
+          decision: ({ attempt, budget }) => {
+            const taxonomy =
+              attempt.projection.latestScoreResult?.taxonomy ??
+              attempt.projection.result?.taxonomy ??
+              taxonomyFromResultRecord(attempt.resultRecord);
+            if (taxonomy === 'unsupported_adapter') {
+              return {
+                decision: 'stop',
+                reason: 'official Harbor verifier is external and pending',
+              };
+            }
+            if (['policy_denied', 'blocked', 'setup_failed', 'infra_failed'].includes(taxonomy)) {
+              return { decision: 'stop', reason: `${taxonomy} is not retryable` };
+            }
+            if (attempt.resultRecord.passed)
+              return { decision: 'stop', reason: 'authoritative verification passed' };
+            if (budget.attemptsUsed >= budget.maxAttempts)
+              return { decision: 'stop', reason: 'max attempts exhausted' };
+            if (
+              budget.maxRuntimeSteps !== undefined &&
+              budget.runtimeStepsUsed >= budget.maxRuntimeSteps
+            ) {
+              return { decision: 'stop', reason: 'runtime step cap reached' };
+            }
+            if (budget.maxWallTimeMs !== undefined && budget.elapsedMs >= budget.maxWallTimeMs) {
+              return { decision: 'stop', reason: 'wall time cap reached' };
+            }
+            return {
+              decision: 'continue',
+              reason: `${taxonomy} can be retried while budget remains`,
+            };
+          },
         },
-        ...(options.replayPriorAttemptRuntimeContext
-          ? { replayPriorAttemptRuntimeContext: true }
-          : {}),
-        decision: ({ attempt, budget }) => {
-          const taxonomy =
-            attempt.projection.latestScoreResult?.taxonomy ??
-            attempt.projection.result?.taxonomy ??
-            taxonomyFromResultRecord(attempt.resultRecord);
-          if (taxonomy === 'unsupported_adapter') {
-            return { decision: 'stop', reason: 'official Harbor verifier is external and pending' };
-          }
-          if (['policy_denied', 'blocked', 'setup_failed', 'infra_failed'].includes(taxonomy)) {
-            return { decision: 'stop', reason: `${taxonomy} is not retryable` };
-          }
-          if (attempt.resultRecord.passed)
-            return { decision: 'stop', reason: 'authoritative verification passed' };
-          if (budget.attemptsUsed >= budget.maxAttempts)
-            return { decision: 'stop', reason: 'max attempts exhausted' };
-          if (
-            budget.maxRuntimeSteps !== undefined &&
-            budget.runtimeStepsUsed >= budget.maxRuntimeSteps
-          ) {
-            return { decision: 'stop', reason: 'runtime step cap reached' };
-          }
-          if (budget.maxWallTimeMs !== undefined && budget.elapsedMs >= budget.maxWallTimeMs) {
-            return { decision: 'stop', reason: 'wall time cap reached' };
-          }
-          return {
-            decision: 'continue',
-            reason: `${taxonomy} can be retried while budget remains`,
-          };
-        },
-      })
-    : await runTaskOnce(options.config, task, common);
+        storage,
+      )
+    : await runTaskOnceWithStorage(options.config, task, common, storage);
 
-  const exportDir = join(options.outDir, 'exports', run.taskRunId);
+  const exportDir = join(options.outDir, 'exports', taskRunLocator(run.taskRunId));
   const exported = await writeTaskRunExport(exportDir, run.projection, {
     includeEvents: options.includeEvents,
   });
@@ -268,7 +289,7 @@ async function runHarborTaskRunMode(options: HarborRunOptions): Promise<number> 
     invocations.length > 0
       ? await writeHarborTaskRunTrace({
           outputDir: options.cellArtifactDir,
-          storageRoot: options.storageRoot,
+          storage,
           invocations,
         })
       : undefined;

--- a/packages/headless/src/headless-storage.ts
+++ b/packages/headless/src/headless-storage.ts
@@ -1,0 +1,149 @@
+import { createArtifactStore, type ArtifactStore } from '@maka/storage';
+import {
+  authenticateExecutionStoresReader,
+  authenticateExecutionStoresWriter,
+  openHeadlessExecutionStoresForRead,
+  openHeadlessExecutionStoresForWrite,
+  type ExecutionStoresReader,
+  type ExecutionStoresWriter,
+} from '@maka/storage/execution-stores';
+import {
+  createHeadlessRootLease,
+  discoverMarkedStorageRoot,
+  resolveStorageRoot,
+  runWithStorageRootLease,
+  StorageRootAuthorityError,
+  type DiscoveredStorageRootCapability,
+  type StorageRootCapability,
+  type StorageRootLease,
+} from '@maka/storage/root-authority';
+import {
+  openHeadlessTaskRunReader,
+  openHeadlessTaskRunWriter,
+  type TaskRunReader,
+  type TaskRunWriter,
+} from './task-run-store.js';
+
+const headlessStorageWriterBrand: unique symbol = Symbol('HeadlessStorageWriter');
+const headlessStorageReaderBrand: unique symbol = Symbol('HeadlessStorageReader');
+const headlessStorageWriters = new WeakSet<object>();
+const headlessStorageReaders = new WeakSet<object>();
+
+export type HeadlessArtifactStore = Readonly<
+  Pick<ArtifactStore, 'create' | 'list' | 'readText' | 'get' | 'readBinary'>
+>;
+
+export interface HeadlessStorageWriter {
+  readonly [headlessStorageWriterBrand]: true;
+  readonly taskRunStore: Readonly<TaskRunWriter>;
+  readonly executionStores: ExecutionStoresWriter<'headless'>;
+  readonly artifactStore: HeadlessArtifactStore;
+}
+
+export interface HeadlessStorageReader {
+  readonly [headlessStorageReaderBrand]: true;
+  readonly taskRunStore: Readonly<TaskRunReader>;
+  readonly executionStores: ExecutionStoresReader<'headless'>;
+}
+
+export async function openHeadlessStorageForWrite(
+  storageRoot: string,
+): Promise<HeadlessStorageWriter> {
+  const capability = await resolveStorageRoot({ path: storageRoot, kind: 'headless' });
+  const lease = createHeadlessRootLease(capability, 'write');
+  const [taskRunStore, executionStores] = await Promise.all([
+    openHeadlessTaskRunWriter(lease),
+    openHeadlessExecutionStoresForWrite(lease),
+  ]);
+
+  const storage: HeadlessStorageWriter = {
+    [headlessStorageWriterBrand]: true,
+    taskRunStore,
+    executionStores,
+    artifactStore: leaseBoundArtifactStore(lease),
+  };
+  Object.freeze(storage);
+  headlessStorageWriters.add(storage);
+  return storage;
+}
+
+export async function openHeadlessStorageForRead(
+  source: string | StorageRootCapability<'headless'>,
+): Promise<HeadlessStorageReader> {
+  const capability =
+    typeof source === 'string'
+      ? requireHeadlessCapability(await discoverMarkedStorageRoot({ path: source }))
+      : source;
+  const lease = createHeadlessRootLease(capability, 'read');
+  const [taskRunStore, executionStores] = await Promise.all([
+    openHeadlessTaskRunReader(lease),
+    openHeadlessExecutionStoresForRead(lease),
+  ]);
+
+  const storage: HeadlessStorageReader = {
+    [headlessStorageReaderBrand]: true,
+    taskRunStore,
+    executionStores,
+  };
+  Object.freeze(storage);
+  headlessStorageReaders.add(storage);
+  return storage;
+}
+
+export function authenticateHeadlessStorageWriter(
+  storage: HeadlessStorageWriter,
+): HeadlessStorageWriter {
+  if (!headlessStorageWriters.has(storage)) {
+    throw new StorageRootAuthorityError(
+      'invalid_lease',
+      'Expected an authentic Headless storage writer',
+    );
+  }
+  authenticateExecutionStoresWriter(storage.executionStores, 'headless');
+  return storage;
+}
+
+export function authenticateHeadlessStorageReader(
+  storage: HeadlessStorageReader,
+): HeadlessStorageReader {
+  if (!headlessStorageReaders.has(storage)) {
+    throw new StorageRootAuthorityError(
+      'invalid_lease',
+      'Expected an authentic Headless storage reader',
+    );
+  }
+  authenticateExecutionStoresReader(storage.executionStores, 'headless');
+  return storage;
+}
+
+export function isStorageRootAuthorityError(error: unknown): error is StorageRootAuthorityError {
+  return error instanceof StorageRootAuthorityError;
+}
+
+function requireHeadlessCapability(
+  capability: DiscoveredStorageRootCapability,
+): StorageRootCapability<'headless'> {
+  if (capability.kind !== 'headless') {
+    throw new StorageRootAuthorityError(
+      'root_kind_mismatch',
+      `Storage root ${capability.canonicalPath} is ${capability.kind}, not headless`,
+    );
+  }
+  return capability;
+}
+
+function leaseBoundArtifactStore(
+  lease: StorageRootLease<'headless', 'write'>,
+): HeadlessArtifactStore {
+  const store = createArtifactStore(lease.canonicalPath);
+  const run = <T>(operation: () => Promise<T>) =>
+    runWithStorageRootLease(lease, 'headless', 'write', operation);
+  const facade: HeadlessArtifactStore = {
+    create: (input) => run(() => store.create(input)),
+    list: (sessionId, options) => run(() => store.list(sessionId, options)),
+    get: (artifactId) => run(() => store.get(artifactId)),
+    readText: (artifactId, options) => run(() => store.readText(artifactId, options)),
+    readBinary: (artifactId, options) => run(() => store.readBinary(artifactId, options)),
+  };
+  return Object.freeze(facade);
+}

--- a/packages/headless/src/heavy-task-evidence.ts
+++ b/packages/headless/src/heavy-task-evidence.ts
@@ -15,7 +15,7 @@ import type {
   HeavyTaskTruncationRef,
   TaskRunArtifact,
 } from './task-contracts.js';
-import type { TaskRunStore } from './task-run-store.js';
+import type { TaskRunWriter } from './task-run-store.js';
 import type {
   IsolatedCommandInput,
   IsolatedCommandResult,
@@ -358,7 +358,7 @@ export function compactSelfCheckEvidence(input: {
 export function createHeavyTaskEvidenceRecorder(input: {
   taskRunId: string;
   attemptId?: string;
-  store: TaskRunStore;
+  store: TaskRunWriter;
   now: () => number;
   newId: () => string;
 }): HeavyTaskEvidenceRecorder {

--- a/packages/headless/src/heavy-task-progress.ts
+++ b/packages/headless/src/heavy-task-progress.ts
@@ -1,7 +1,7 @@
 import type { MakaTool, MakaToolContext } from '@maka/runtime';
 import { z } from 'zod';
 import type { HeavyTaskInventoryState, HeavyTaskTodoState, TaskEvent } from './task-contracts.js';
-import type { TaskRunStore } from './task-run-store.js';
+import type { TaskRunWriter } from './task-run-store.js';
 
 export const HEAVY_TASK_PROGRESS_TOOL_NAMES = ['inventory_submit', 'todo_update'] as const;
 
@@ -103,7 +103,7 @@ export interface HeavyTaskProgressRecorder {
 export function createHeavyTaskProgressRecorder(input: {
   taskRunId: string;
   attemptId?: string;
-  store: TaskRunStore;
+  store: TaskRunWriter;
   now: () => number;
   newId: () => string;
 }): HeavyTaskProgressRecorder {

--- a/packages/headless/src/heavy-task-self-check-gate.ts
+++ b/packages/headless/src/heavy-task-self-check-gate.ts
@@ -12,7 +12,7 @@ import type {
   HeavyTaskWorkspaceObservationState,
   HeavyTaskTodoItem,
 } from './task-contracts.js';
-import type { TaskRunProjection } from './task-run-store.js';
+import type { TaskRunProjection } from './task-run-projection.js';
 
 export type HeavyTaskSelfCheckGateDecision =
   | {

--- a/packages/headless/src/heavy-task-self-check.ts
+++ b/packages/headless/src/heavy-task-self-check.ts
@@ -11,7 +11,7 @@ import type {
   HeavyTaskSourceGuardResult,
   TaskEvent,
 } from './task-contracts.js';
-import type { TaskRunStore } from './task-run-store.js';
+import type { TaskRunWriter } from './task-run-store.js';
 
 export const HEAVY_TASK_SELF_CHECK_TOOL_NAMES = [
   'self_check_plan_submit',
@@ -219,7 +219,7 @@ export interface HeavyTaskSelfCheckRecorder {
 export function createHeavyTaskSelfCheckRecorder(input: {
   taskRunId: string;
   attemptId?: string;
-  store: TaskRunStore;
+  store: TaskRunWriter;
   now: () => number;
   newId: () => string;
 }): HeavyTaskSelfCheckRecorder {

--- a/packages/headless/src/heavy-task-workspace-observation.ts
+++ b/packages/headless/src/heavy-task-workspace-observation.ts
@@ -6,7 +6,7 @@ import type {
   HeavyTaskWorkspaceObservationEntry,
   HeavyTaskWorkspaceObservationRecordedEvent,
 } from './task-contracts.js';
-import type { TaskRunProjection } from './task-run-store.js';
+import type { TaskRunProjection } from './task-run-projection.js';
 
 export async function observeHeavyTaskWorkspace(input: {
   taskRunId: string;

--- a/packages/headless/src/immutable-file.ts
+++ b/packages/headless/src/immutable-file.ts
@@ -2,7 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { link, mkdir, open, rm } from 'node:fs/promises';
 import { dirname } from 'node:path';
 
-export async function publishImmutableFile(path: string, contents: string): Promise<boolean> {
+export async function publishFileExclusively(path: string, contents: string): Promise<boolean> {
   const directory = dirname(path);
   await mkdir(directory, { recursive: true });
   const temporaryPath = `${path}.tmp-${process.pid}-${randomUUID()}`;

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -148,12 +148,18 @@ export {
   resourceScopeEquals,
   type NormalizedPermissionArgs,
 } from './permission-grants.js';
-export type { TaskEventLedgerEntry, TaskRunProjection, TaskRunStore } from './task-run-store.js';
-export {
-  createInMemoryTaskRunStore,
-  createTaskRunStore,
-  projectTaskRun,
+export type { TaskRunProjection } from './task-run-projection.js';
+export { projectTaskRun } from './task-run-projection.js';
+export type {
+  TaskEventLedgerEntry,
+  TaskRunReader,
+  TaskRunWriter,
 } from './task-run-store.js';
+export { createInMemoryTaskRunStore } from './task-run-store.js';
+export {
+  openHeadlessStorageForRead,
+  type HeadlessStorageReader,
+} from './headless-storage.js';
 export {
   TASK_RUN_INSPECT_SCHEMA_VERSION,
   inspectTaskRun,

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -1,5 +1,5 @@
-import type { ShellPlan } from '@maka/runtime';
 import type { StorageRef } from '@maka/core';
+import type { ShellPlan } from '@maka/runtime';
 import type { Config, Task } from './contracts.js';
 import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
 import type { HeavyTaskModeSelection } from './heavy-task-policy.js';
@@ -11,6 +11,7 @@ import type {
   ToolExecutorIdentity,
 } from './task-contracts.js';
 import type { HeadlessSessionCapabilities } from './session-capabilities.js';
+import type { HeadlessArtifactStore } from './headless-storage.js';
 
 export interface IsolatedCommandInput {
   command: string;
@@ -195,6 +196,8 @@ export interface HeadlessBackendContext extends Partial<HeadlessSessionCapabilit
   storageRoot: string;
   /** Absolute throwaway workspace path for this run. */
   workspaceDir: string;
+  /** Lease-bound storage for Headless-owned artifacts. */
+  artifactStore: HeadlessArtifactStore;
   /**
    * Present only for model-backed backends and only after the caller has
    * explicitly asserted an isolation boundary.

--- a/packages/headless/src/matrix-resume.ts
+++ b/packages/headless/src/matrix-resume.ts
@@ -1,6 +1,8 @@
-import { readdir, stat } from 'node:fs/promises';
+import { stat } from 'node:fs/promises';
 import { join } from 'node:path';
+import { StorageRootAuthorityError } from '@maka/storage/root-authority';
 import type { Config, ResultRecord, Task } from './contracts.js';
+import { openHeadlessStorageForRead, type HeadlessStorageReader } from './headless-storage.js';
 import { readResults } from './results.js';
 import {
   isTerminalTaskRunStatus,
@@ -8,7 +10,6 @@ import {
   type AutonomousResultTaxonomy,
 } from './task-contracts.js';
 import { resultRecordFromTaskRunProjection } from './task-run-adapter.js';
-import { createTaskRunStore } from './task-run-store.js';
 
 export const MATRIX_CELL_SEPARATOR = '\u0000';
 
@@ -141,21 +142,17 @@ export async function readMatrixPriorRecords(inputPath: string): Promise<ResultR
 }
 
 export async function readTaskRunStoreRecords(storageRoot: string): Promise<ResultRecord[]> {
-  const taskRunDir = join(storageRoot, 'task-runs');
-  let entries: string[];
+  let storage: HeadlessStorageReader;
   try {
-    entries = await readdir(taskRunDir);
+    storage = await openHeadlessStorageForRead(storageRoot);
   } catch (error) {
-    if (isNotFound(error)) return [];
+    if (error instanceof StorageRootAuthorityError && error.code === 'root_not_found') return [];
     throw error;
   }
-
-  const store = createTaskRunStore(storageRoot);
+  const { taskRunStore } = storage;
   const records: ResultRecord[] = [];
-  for (const entry of entries.sort()) {
-    if (!entry.endsWith('.jsonl')) continue;
-    const taskRunId = entry.slice(0, -'.jsonl'.length);
-    const projection = await store.project(taskRunId);
+  for (const taskRunId of await taskRunStore.listTaskRunIds()) {
+    const projection = await taskRunStore.project(taskRunId);
     if (!isTerminalTaskRunStatus(projection.status) && projection.status !== 'needs_approval')
       continue;
     records.push(resultRecordFromTaskRunProjection(projection));

--- a/packages/headless/src/matrix.ts
+++ b/packages/headless/src/matrix.ts
@@ -1,5 +1,6 @@
 import type { Config, ResultRecord, Task } from './contracts.js';
-import { runExperiment, type RunExperimentDeps } from './runner.js';
+import { openHeadlessStorageForWrite } from './headless-storage.js';
+import { runExperimentWithStorage, type RunExperimentDeps } from './runner.js';
 
 /** An experiment is the cross product of Configs and Tasks. */
 export interface ExperimentSpec {
@@ -21,10 +22,11 @@ export async function runMatrix(
   deps: RunExperimentDeps,
   onResult?: (record: ResultRecord) => void,
 ): Promise<ResultRecord[]> {
+  const storage = await openHeadlessStorageForWrite(deps.storageRoot);
   const records: ResultRecord[] = [];
   for (const task of spec.tasks) {
     for (const config of spec.configs) {
-      const record = await runExperiment(config, task, deps).catch(
+      const record = await runExperimentWithStorage(config, task, deps, storage).catch(
         (error): ResultRecord => failedRecord(config, task, error),
       );
       records.push(record);

--- a/packages/headless/src/result-export.ts
+++ b/packages/headless/src/result-export.ts
@@ -15,7 +15,7 @@ import {
   type VerifierResult,
 } from './task-contracts.js';
 import { resultRecordFromTaskRunProjection } from './task-run-adapter.js';
-import type { TaskRunProjection } from './task-run-store.js';
+import type { TaskRunProjection } from './task-run-projection.js';
 
 export interface TaskRunExport {
   schemaVersion: 'maka.task_run_export.v1';

--- a/packages/headless/src/runner.ts
+++ b/packages/headless/src/runner.ts
@@ -6,9 +6,13 @@ import {
   buildChildAgentTools,
   type InvocationResult,
 } from '@maka/runtime';
-import { createAgentRunStore, createRuntimeEventStore, createSessionStore } from '@maka/storage';
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
+import {
+  authenticateHeadlessStorageWriter,
+  openHeadlessStorageForWrite,
+  type HeadlessStorageWriter,
+} from './headless-storage.js';
 import type { HeadlessBackendContext, RealBackendIsolation } from './isolation.js';
 import { validateRealBackendIsolation } from './isolation.js';
 import {
@@ -91,6 +95,17 @@ export async function runExperiment(
   task: Task,
   deps: RunExperimentDeps,
 ): Promise<ResultRecord> {
+  const storage = await openHeadlessStorageForWrite(deps.storageRoot);
+  return runExperimentWithStorage(config, task, deps, storage);
+}
+
+export async function runExperimentWithStorage(
+  config: Config,
+  task: Task,
+  deps: RunExperimentDeps,
+  storage: HeadlessStorageWriter,
+): Promise<ResultRecord> {
+  storage = authenticateHeadlessStorageWriter(storage);
   if (backendNeedsIsolation(config.backend)) {
     validateRealBackendIsolation(deps.realBackendIsolation);
     if (!deps.registerBackends) {
@@ -120,6 +135,7 @@ export async function runExperiment(
       storageRoot: deps.storageRoot,
       workspaceDir: agentWorkspaceDir,
       ...sessionCapabilities.capabilities,
+      artifactStore: storage.artifactStore,
       ...(backendNeedsIsolation(config.backend)
         ? {
             realBackendIsolation: deps.realBackendIsolation,
@@ -129,11 +145,11 @@ export async function runExperiment(
     });
 
     let invocation: InvocationResult | undefined;
-    const runStore = createAgentRunStore(deps.storageRoot);
+    const runStore = storage.executionStores.agentRunStore;
     const manager = new SessionManager({
-      store: createSessionStore(deps.storageRoot),
+      store: storage.executionStores.sessionStore,
       runStore,
-      runtimeEventStore: createRuntimeEventStore(deps.storageRoot),
+      runtimeEventStore: storage.executionStores.runtimeEventStore,
       backends,
       ...(deps.realBackendIsolation?.toolExecutor
         ? {
@@ -214,7 +230,7 @@ export async function runExperiment(
       });
       const finishedAt = now();
       const runEvidence = invocation
-        ? await runStore.readRun(session.id, invocation.runId).catch(() => undefined)
+        ? await runStore.readRun(session.id, invocation.runId)
         : undefined;
 
       return {

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -634,6 +634,7 @@ export async function runTaskOnceWithStorage(
     });
     const finishedAt = now();
     const scoreResultId = newId();
+    // The TaskRun ledger is canonical here; AgentRun metadata is optional unless authority fails.
     const runEvidence = await agentRunStore.readRun(header.id, invocation.runId).catch((error) => {
       if (isStorageRootAuthorityError(error)) throw error;
       return undefined;

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -1,7 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import {
   isTerminalRuntimeEvent,
-  type AgentRunStore,
   type RuntimeEvent,
   type RuntimeEventStore,
   type SessionBlockedReason,
@@ -18,7 +17,6 @@ import {
   type InvocationResult,
   type SessionStore,
 } from '@maka/runtime';
-import { createAgentRunStore, createRuntimeEventStore, createSessionStore } from '@maka/storage';
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
 import {
@@ -33,6 +31,12 @@ import {
 import { resolveHeavyTaskMode } from './heavy-task-policy.js';
 import { resolveEconomyTaskMode } from './economy-task-policy.js';
 import { MAX_NODE_TIMER_MS } from './headless-run-env.js';
+import {
+  authenticateHeadlessStorageWriter,
+  isStorageRootAuthorityError,
+  openHeadlessStorageForWrite,
+  type HeadlessStorageWriter,
+} from './headless-storage.js';
 import {
   createHeavyTaskProgressRecorder,
   HEAVY_TASK_PROGRESS_TOOL_NAMES,
@@ -94,17 +98,14 @@ import {
   type TaskRunResult,
   type VerifierResult,
 } from './task-contracts.js';
-import { createTaskRunStore, type TaskRunProjection, type TaskRunStore } from './task-run-store.js';
+import type { TaskRunProjection } from './task-run-projection.js';
+import type { TaskRunWriter } from './task-run-store.js';
 import { taskDefinitionFromTask } from './task-run-adapter.js';
 import { taskEvidenceRuntimeProvenanceLinks } from './task-evidence-provenance.js';
 import { taskAttemptExecutionEvidence } from './task-execution-lineage.js';
 import { bindSelfCheckEvidence } from './task-self-check-evidence.js';
 
 export interface RunTaskOnceDeps extends RunExperimentDeps {
-  taskRunStore?: TaskRunStore;
-  runtimeEventStore?: RuntimeEventStore;
-  sessionStore?: SessionStore;
-  agentRunStore?: AgentRunStore;
   taskRunId?: string;
   attemptId?: string;
   createTaskRun?: boolean;
@@ -140,6 +141,17 @@ export async function runTaskOnce(
   task: Task,
   deps: RunTaskOnceDeps,
 ): Promise<RunTaskOnceResult> {
+  const storage = await openHeadlessStorageForWrite(deps.storageRoot);
+  return runTaskOnceWithStorage(config, task, deps, storage);
+}
+
+export async function runTaskOnceWithStorage(
+  config: Config,
+  task: Task,
+  deps: RunTaskOnceDeps,
+  storage: HeadlessStorageWriter,
+): Promise<RunTaskOnceResult> {
+  storage = authenticateHeadlessStorageWriter(storage);
   const isolationRequired = backendNeedsIsolation(config.backend);
   if (isolationRequired) {
     validateRealBackendIsolation(deps.realBackendIsolation);
@@ -158,10 +170,10 @@ export async function runTaskOnce(
   const createTaskRun = deps.createTaskRun ?? true;
   const closeTaskRun = deps.closeTaskRun ?? true;
   const interventionPolicy = deps.interventionPolicy ?? DEFAULT_INTERVENTION_POLICY;
-  const taskRunStore = deps.taskRunStore ?? createTaskRunStore(deps.storageRoot);
-  const sessionStore = deps.sessionStore ?? createSessionStore(deps.storageRoot);
-  const agentRunStore = deps.agentRunStore ?? createAgentRunStore(deps.storageRoot);
-  const runtimeEventStore = deps.runtimeEventStore ?? createRuntimeEventStore(deps.storageRoot);
+  const taskRunStore = storage.taskRunStore;
+  const sessionStore = storage.executionStores.sessionStore;
+  const agentRunStore = storage.executionStores.agentRunStore;
+  const runtimeEventStore = storage.executionStores.runtimeEventStore;
   const startedAt = now();
   const verifier = normalizeVerifier(task);
   const heavyTaskMode = resolveHeavyTaskMode(config, task);
@@ -295,6 +307,7 @@ export async function runTaskOnce(
       task,
       storageRoot: deps.storageRoot,
       workspaceDir: agentWorkspaceDir,
+      artifactStore: storage.artifactStore,
       heavyTaskMode,
       ...(heavyTaskProgress ? { heavyTaskProgress } : {}),
       ...(heavyTaskSelfCheck ? { heavyTaskSelfCheck } : {}),
@@ -621,9 +634,10 @@ export async function runTaskOnce(
     });
     const finishedAt = now();
     const scoreResultId = newId();
-    const runEvidence = await agentRunStore
-      .readRun(header.id, invocation.runId)
-      .catch(() => undefined);
+    const runEvidence = await agentRunStore.readRun(header.id, invocation.runId).catch((error) => {
+      if (isStorageRootAuthorityError(error)) throw error;
+      return undefined;
+    });
     const invocationResultRecord = resultRecordFromInvocation({
       config,
       task,
@@ -749,7 +763,7 @@ export async function runTaskOnce(
 }
 
 async function appendHeavyTaskWorkspaceObservation(input: {
-  taskRunStore: TaskRunStore;
+  taskRunStore: TaskRunWriter;
   taskRunId: string;
   projection: TaskRunProjection;
   executor?: NonNullable<RunTaskOnceDeps['realBackendIsolation']>['toolExecutor'];
@@ -770,7 +784,7 @@ async function appendHeavyTaskWorkspaceObservation(input: {
 }
 
 async function appendHeavyTaskSelfCheckEvidenceLinks(input: {
-  store: TaskRunStore;
+  store: TaskRunWriter;
   runtimeEventStore: RuntimeEventStore;
   taskRunId: string;
   attemptId: string;
@@ -854,7 +868,7 @@ function toolNamesForIdentity(hasIsolatedExecutor: boolean, heavyTaskEnabled: bo
 }
 
 async function appendTaskAttemptExecutionLink(input: {
-  store: TaskRunStore;
+  store: TaskRunWriter;
   runtimeEventStore: RuntimeEventStore;
   taskRunId: string;
   attemptId: string;
@@ -920,7 +934,7 @@ async function appendTaskAttemptExecutionLink(input: {
 
 interface PermissionInterventionInput {
   invocation: InvocationResult;
-  store: TaskRunStore;
+  store: TaskRunWriter;
   taskRunId: string;
   attemptId: string;
   now: () => number;
@@ -1365,7 +1379,10 @@ async function turnHasRetainedOutput(
   sessionId: string,
   turnId: string,
 ): Promise<boolean> {
-  const messages = await store.readMessages(sessionId).catch((): StoredMessage[] => []);
+  const messages = await store.readMessages(sessionId).catch((error): StoredMessage[] => {
+    if (isStorageRootAuthorityError(error)) throw error;
+    return [];
+  });
   return messages.some(
     (message) =>
       (message.type === 'assistant' &&
@@ -1515,7 +1532,7 @@ function summarizeRuntime(
 }
 
 async function appendRuntimeFeedback(
-  store: TaskRunStore,
+  store: TaskRunWriter,
   taskRunId: string,
   attemptId: string,
   now: () => number,
@@ -1707,7 +1724,7 @@ function errorMessageFromTaxonomy(taxonomy: AutonomousResultTaxonomy): string {
   }
 }
 
-function appendTaskEvent(store: TaskRunStore, taskRunId: string, event: TaskEvent): Promise<void> {
+function appendTaskEvent(store: TaskRunWriter, taskRunId: string, event: TaskEvent): Promise<void> {
   return store.appendEvent(taskRunId, event);
 }
 

--- a/packages/headless/src/task-run-adapter.ts
+++ b/packages/headless/src/task-run-adapter.ts
@@ -12,7 +12,7 @@ import {
   type TaskRunResult,
   type VerifierResult,
 } from './task-contracts.js';
-import type { TaskRunProjection } from './task-run-store.js';
+import type { TaskRunProjection } from './task-run-projection.js';
 import { taskAttemptExecutionEvidence } from './task-execution-lineage.js';
 
 export interface TaskEventsFromResultRecordOptions {

--- a/packages/headless/src/task-run-identity.ts
+++ b/packages/headless/src/task-run-identity.ts
@@ -1,0 +1,19 @@
+import { createHash } from 'node:crypto';
+
+const TASK_RUN_LOCATOR_PATTERN = /^[0-9a-f]{64}$/;
+
+export function taskRunLocator(taskRunId: string): string {
+  if (taskRunId.length === 0) {
+    throw new Error('taskRunId must not be empty');
+  }
+  try {
+    encodeURIComponent(taskRunId);
+  } catch {
+    throw new Error('taskRunId must be well-formed Unicode');
+  }
+  return createHash('sha256').update(taskRunId, 'utf8').digest('hex');
+}
+
+export function isTaskRunLocator(value: string): boolean {
+  return TASK_RUN_LOCATOR_PATTERN.test(value);
+}

--- a/packages/headless/src/task-run-inspect.ts
+++ b/packages/headless/src/task-run-inspect.ts
@@ -1,4 +1,4 @@
-import type { AgentRunHeader, AgentRunStore, RuntimeEvent, RuntimeEventStore } from '@maka/core';
+import type { AgentRunHeader, RuntimeEvent } from '@maka/core';
 import type {
   ExecutionEvidenceRef,
   ExecutionIdentityRef,
@@ -7,19 +7,23 @@ import type {
 } from '@maka/core/execution-evidence';
 import {
   inspectAgentRunReadModel,
+  type AgentRunInspectReader,
   type AgentRunInspectDiagnostic,
   type AgentRunInspectSourceHealth,
+  type RuntimeEventInspectReader,
 } from '@maka/runtime/agent-run-inspect';
 import {
   validateHistoryCompactCheckpointShape,
   type HistoryCompactCheckpoint,
 } from '@maka/runtime';
+import { isStorageRootAuthorityError } from './headless-storage.js';
 import {
   isTerminalTaskRunStatus,
   type HeavyTaskSelfCheckProjection,
   type TaskAttempt,
 } from './task-contracts.js';
-import { projectTaskRun, type TaskRunProjection, type TaskRunStore } from './task-run-store.js';
+import { projectTaskRun, type TaskRunProjection } from './task-run-projection.js';
+import type { TaskRunReader } from './task-run-store.js';
 
 export const TASK_RUN_INSPECT_SCHEMA_VERSION = 'maka.task_run_inspect.v1' as const;
 
@@ -141,9 +145,9 @@ export interface TaskRunInspectDocument {
 }
 
 export interface InspectTaskRunDependencies {
-  taskRunStore: TaskRunStore;
-  agentRunStore: AgentRunStore;
-  runtimeEventStore: RuntimeEventStore;
+  taskRunStore: TaskRunReader;
+  agentRunStore: AgentRunInspectReader;
+  runtimeEventStore: RuntimeEventInspectReader;
 }
 
 export async function inspectTaskRun(
@@ -243,7 +247,11 @@ async function inspectLinkedAgentRun(
     const inspected = await inspectAgentRunReadModel(
       dependencies.agentRunStore,
       dependencies.runtimeEventStore,
-      { sessionId: identity.sessionId, runId: identity.agentRunId },
+      {
+        sessionId: identity.sessionId,
+        runId: identity.agentRunId,
+        isFatalReadError: isStorageRootAuthorityError,
+      },
     );
     for (const sourceDiagnostic of inspected.diagnostics) {
       diagnostics.push(agentRunDiagnostic(taskRunId, refs, sourceDiagnostic));
@@ -275,6 +283,7 @@ async function inspectLinkedAgentRun(
       compactionCheckpoints,
     };
   } catch (error) {
+    if (isStorageRootAuthorityError(error)) throw error;
     diagnostics.push(
       diagnostic(
         taskRunId,
@@ -620,7 +629,7 @@ function taskRunSummary(projection: TaskRunProjection): TaskRunInspectSummary {
 }
 
 function taskEventSource(
-  records: Awaited<ReturnType<TaskRunStore['readEventRecords']>>,
+  records: Awaited<ReturnType<TaskRunReader['readEventRecords']>>,
 ): TaskRunInspectTaskEventSource {
   const first = records[0]?.cursor;
   const last = records.at(-1)?.cursor;

--- a/packages/headless/src/task-run-projection.ts
+++ b/packages/headless/src/task-run-projection.ts
@@ -1,0 +1,875 @@
+import {
+  validateExecutionEvidenceRef,
+  type ExecutionEvidenceRef,
+} from '@maka/core/execution-evidence';
+import type { ResultRecord } from './contracts.js';
+import { compactArtifactEvidence, compactSelfCheckEvidence } from './heavy-task-evidence.js';
+import {
+  evaluateHeavyTaskCompletionStatus,
+  type HeavyTaskCompletionStatus,
+} from './heavy-task-finalization.js';
+import { isAcceptedHeavyTaskSelfCheck } from './heavy-task-self-check.js';
+import type {
+  AutonomousDecision,
+  FeedbackObservation,
+  HeavyTaskCompactEvidenceEnvelope,
+  HeavyTaskSelfCheckPlanState,
+  HeavyTaskSelfCheckGateState,
+  HeavyTaskSelfCheckFreshnessReason,
+  HeavyTaskSelfCheckProjection,
+  HeavyTaskWorkspaceObservationState,
+  EconomyTaskModeFacts,
+  HeavyTaskInventoryState,
+  TaskInboxItem,
+  HeavyTaskModeFacts,
+  HeavyTaskSemanticSelfCheckState,
+  HeavyTaskTodoState,
+  TaskIsolationFacts,
+  TaskPermissionGrant,
+  TaskPermissionRequest,
+  TaskRunParkedState,
+  ScoreResult,
+  SelfCheckObservation,
+  TaskAttempt,
+  TaskRunArtifact,
+  TaskEvent,
+  TaskRun,
+  TaskRunError,
+  TaskRunResult,
+  ToolExecutorIdentity,
+  VerifierResult,
+  WorkspaceLeaseFacts,
+} from './task-contracts.js';
+
+export interface TaskRunProjection extends TaskRun {
+  events: TaskEvent[];
+  attempts: TaskAttempt[];
+  executionLineage: ExecutionEvidenceRef[];
+  selfChecks: SelfCheckObservation[];
+  feedback: FeedbackObservation[];
+  decisions: AutonomousDecision[];
+  artifacts: TaskRunArtifact[];
+  verifierResults: VerifierResult[];
+  scoreResults: ScoreResult[];
+  toolExecutors: ToolExecutorIdentity[];
+  permissionGrants: TaskPermissionGrant[];
+  permissionRequests: TaskPermissionRequest[];
+  inboxItems: TaskInboxItem[];
+  warnings: string[];
+  latestVerifierResult?: VerifierResult;
+  latestScoreResult?: ScoreResult;
+  heavyTaskMode?: HeavyTaskModeFacts;
+  economyTaskMode?: EconomyTaskModeFacts;
+  heavyTaskInventory: HeavyTaskInventoryState[];
+  latestHeavyTaskInventory?: HeavyTaskInventoryState;
+  heavyTaskTodoStates: HeavyTaskTodoState[];
+  latestHeavyTaskTodos?: HeavyTaskTodoState;
+  heavyTaskSelfChecks: HeavyTaskSelfCheckProjection[];
+  latestHeavyTaskSelfCheck?: HeavyTaskSelfCheckProjection;
+  heavyTaskSelfCheckPlans: HeavyTaskSelfCheckPlanState[];
+  latestHeavyTaskSelfCheckPlan?: HeavyTaskSelfCheckPlanState;
+  heavyTaskSelfCheckGates: HeavyTaskSelfCheckGateState[];
+  latestHeavyTaskSelfCheckGate?: HeavyTaskSelfCheckGateState;
+  heavyTaskWorkspaceObservations: HeavyTaskWorkspaceObservationState[];
+  latestHeavyTaskWorkspaceObservation?: HeavyTaskWorkspaceObservationState;
+  heavyTaskEvidence: HeavyTaskCompactEvidenceEnvelope[];
+  latestHeavyTaskEvidence?: HeavyTaskCompactEvidenceEnvelope;
+  heavyTaskCompletion?: HeavyTaskCompletionStatus;
+  isolation?: TaskIsolationFacts;
+  workspaceLease?: WorkspaceLeaseFacts;
+  parked?: TaskRunParkedState;
+  sourceResultRecord?: ResultRecord;
+}
+
+export function projectTaskRun(
+  events: readonly TaskEvent[],
+  taskRunId?: string,
+): TaskRunProjection {
+  const projectedTaskRunId = taskRunId ?? events[0]?.taskRunId ?? '';
+  const projection: TaskRunProjection = {
+    taskRunId: projectedTaskRunId,
+    taskId: '',
+    configId: '',
+    status: 'queued',
+    events: [],
+    attempts: [],
+    executionLineage: [],
+    selfChecks: [],
+    feedback: [],
+    decisions: [],
+    artifacts: [],
+    verifierResults: [],
+    scoreResults: [],
+    toolExecutors: [],
+    permissionGrants: [],
+    permissionRequests: [],
+    inboxItems: [],
+    warnings: [],
+    heavyTaskInventory: [],
+    heavyTaskTodoStates: [],
+    heavyTaskSelfCheckPlans: [],
+    heavyTaskSelfChecks: [],
+    heavyTaskSelfCheckGates: [],
+    heavyTaskWorkspaceObservations: [],
+    heavyTaskEvidence: [],
+  };
+  const attempts = new Map<string, TaskAttempt>();
+  const inboxItems = new Map<string, TaskInboxItem>();
+  const selfCheckRows = new Map<
+    string,
+    Array<{ sequence: number; projectionIndex: number; eventId: string }>
+  >();
+  const workspaceObservationRows = new Map<
+    string,
+    { sequence: number; observation: HeavyTaskWorkspaceObservationState }
+  >();
+  let terminalEvents = 0;
+
+  for (let sequence = 0; sequence < events.length; sequence += 1) {
+    const event = events[sequence]!;
+    if (projectedTaskRunId && event.taskRunId !== projectedTaskRunId) {
+      projection.warnings.push(
+        `ignored event ${event.id}: taskRunId ${event.taskRunId} does not match ${projectedTaskRunId}`,
+      );
+      continue;
+    }
+    projection.events.push(event);
+
+    switch (event.type) {
+      case 'task_run_created':
+        projection.taskId = event.taskId;
+        projection.configId = event.configId;
+        projection.status = 'created';
+        projection.sourceResultRecord = event.sourceResultRecord;
+        break;
+      case 'task_run_queued':
+        projection.taskId = event.taskId;
+        projection.configId = event.configId;
+        projection.status = 'queued';
+        break;
+      case 'task_run_started':
+        projection.status = 'running';
+        projection.startedAt = event.startedAt ?? event.ts;
+        setOptionalRefs(projection, event.sessionId, event.agentRunId);
+        break;
+      case 'task_run_verifying':
+        projection.status = 'verifying';
+        break;
+      case 'task_attempt_started': {
+        const previous = attempts.get(event.attemptId);
+        const attempt: TaskAttempt = {
+          attemptId: event.attemptId,
+          taskRunId: event.taskRunId,
+          startedAt: event.startedAt ?? event.ts,
+          status: 'running',
+          ...(event.sessionId ? { sessionId: event.sessionId } : {}),
+          ...(event.agentRunId ? { agentRunId: event.agentRunId } : {}),
+          executionLineage: previous?.executionLineage ?? [],
+        };
+        attempts.set(event.attemptId, attempt);
+        setOptionalRefs(projection, event.sessionId, event.agentRunId);
+        break;
+      }
+      case 'task_attempt_execution_linked': {
+        const evidence = validTaskAttemptExecutionEvidence(event, projection.warnings);
+        if (!evidence) break;
+        projection.executionLineage.push(evidence);
+        const previous = attempts.get(event.attemptId);
+        attempts.set(event.attemptId, {
+          ...(previous ?? {
+            attemptId: event.attemptId,
+            taskRunId: event.taskRunId,
+            startedAt: event.ts,
+            status: 'running',
+            executionLineage: [],
+          }),
+          ...(evidence.execution?.sessionId ? { sessionId: evidence.execution.sessionId } : {}),
+          ...(!previous?.agentRunId && evidence.execution?.agentRunId
+            ? { agentRunId: evidence.execution.agentRunId }
+            : {}),
+          executionLineage: [...(previous?.executionLineage ?? []), evidence],
+        });
+        if (!projection.sessionId && evidence.execution?.sessionId) {
+          projection.sessionId = evidence.execution.sessionId;
+        }
+        if (!projection.agentRunId && evidence.execution?.agentRunId) {
+          projection.agentRunId = evidence.execution.agentRunId;
+        }
+        break;
+      }
+      case 'self_check_observed':
+        projection.selfChecks.push(event.observation);
+        break;
+      case 'feedback_observed':
+        projection.feedback.push(event.observation);
+        break;
+      case 'autonomous_decision_recorded':
+        projection.decisions.push(event.decision);
+        break;
+      case 'verifier_result_recorded':
+        projection.verifierResults.push(event.result);
+        projection.latestVerifierResult = event.result;
+        break;
+      case 'task_run_artifact_recorded':
+        projection.artifacts.push(event.artifact);
+        if (
+          projection.heavyTaskMode?.enabled === true &&
+          isCompactEvidenceEligibleArtifact(event.artifact)
+        ) {
+          appendCompactEvidence(
+            projection,
+            compactArtifactEvidence({
+              evidenceId: `${event.id}:compact-artifact`,
+              taskRunId: projection.taskRunId,
+              ...(event.artifact.attemptId ? { attemptId: event.artifact.attemptId } : {}),
+              ts: event.ts,
+              source: {
+                kind: 'model_tool',
+                toolCallId: `task-run-artifact:${event.id}`,
+                toolName: 'artifact',
+              },
+              artifact: event.artifact,
+            }),
+          );
+        }
+        break;
+      case 'score_result_recorded':
+        projection.scoreResults.push(event.result);
+        projection.latestScoreResult = event.result;
+        projection.result = resultFromScore(event.result, projection.latestVerifierResult);
+        break;
+      case 'heavy_task_mode_recorded':
+        projection.heavyTaskMode = event.facts;
+        break;
+      case 'economy_task_mode_recorded':
+        projection.economyTaskMode = event.facts;
+        break;
+      case 'heavy_task_inventory_recorded':
+        projection.heavyTaskInventory.push(event.inventory);
+        projection.latestHeavyTaskInventory = event.inventory;
+        break;
+      case 'heavy_task_todos_recorded':
+        projection.heavyTaskTodoStates.push(event.todos);
+        projection.latestHeavyTaskTodos = event.todos;
+        break;
+      case 'heavy_task_self_check_plan_recorded':
+        projection.heavyTaskSelfCheckPlans.push(event.plan);
+        projection.latestHeavyTaskSelfCheckPlan = event.plan;
+        break;
+      case 'heavy_task_self_check_recorded':
+        if (isAcceptedHeavyTaskSelfCheck(event.selfCheck)) {
+          const projectedSelfCheck: HeavyTaskSelfCheckProjection = {
+            ...event.selfCheck,
+            freshness: 'unknown',
+            freshnessReasons: ['source_binding_missing'],
+          };
+          const projectionIndex = projection.heavyTaskSelfChecks.push(projectedSelfCheck) - 1;
+          selfCheckRows.set(event.selfCheck.selfCheckId, [
+            ...(selfCheckRows.get(event.selfCheck.selfCheckId) ?? []),
+            { sequence, projectionIndex, eventId: event.id },
+          ]);
+          projection.latestHeavyTaskSelfCheck = projectedSelfCheck;
+          appendCompactEvidence(
+            projection,
+            ...compactSelfCheckEvidence({
+              selfCheck: event.selfCheck,
+              newId: selfCheckEvidenceIdFactory(event.selfCheck.selfCheckId),
+            }),
+          );
+        } else {
+          projection.warnings.push(
+            `ignored heavy-task self-check ${event.selfCheck.selfCheckId}: source guard did not accept public evidence`,
+          );
+        }
+        break;
+      case 'heavy_task_self_check_evidence_linked': {
+        const rows = selfCheckRows.get(event.selfCheckId) ?? [];
+        if (rows.length !== 1) {
+          const reason = rows.length === 0 ? 'was not recorded first' : 'is ambiguous';
+          projection.warnings.push(
+            `ignored self-check evidence link ${event.id}: Self-check ${event.selfCheckId} ${reason}`,
+          );
+          break;
+        }
+        const row = rows[0]!;
+        const selfCheck = projection.heavyTaskSelfChecks[row.projectionIndex]!;
+        if (selfCheck.provenance) {
+          projection.warnings.push(
+            `ignored self-check evidence link ${event.id}: Self-check ${event.selfCheckId} is already linked`,
+          );
+          break;
+        }
+        const observationRow = workspaceObservationRows.get(event.workspaceObservationId);
+        const provenance = validHeavyTaskSelfCheckProvenance(
+          event,
+          selfCheck,
+          row.sequence,
+          row.eventId,
+          observationRow,
+          projection.warnings,
+        );
+        if (!provenance) break;
+        projection.heavyTaskSelfChecks[row.projectionIndex] = {
+          ...selfCheck,
+          provenance,
+          workspaceObservationId: event.workspaceObservationId,
+        };
+        break;
+      }
+      case 'heavy_task_self_check_gate_recorded':
+        projection.heavyTaskSelfCheckGates.push(event.gate);
+        projection.latestHeavyTaskSelfCheckGate = event.gate;
+        break;
+      case 'heavy_task_workspace_observation_recorded':
+        projection.heavyTaskWorkspaceObservations.push(event.observation);
+        projection.latestHeavyTaskWorkspaceObservation = event.observation;
+        workspaceObservationRows.set(event.observation.observationId, {
+          sequence,
+          observation: event.observation,
+        });
+        break;
+      case 'heavy_task_evidence_recorded':
+        if (!appendCompactEvidence(projection, event.evidence)) {
+          projection.warnings.push(
+            `ignored heavy-task evidence ${event.evidence.evidenceId}: evidence must be public and match taskRunId`,
+          );
+        }
+        break;
+      case 'heavy_task_evidence_provenance_linked': {
+        const matchingIndexes = projection.heavyTaskEvidence.flatMap((item, index) =>
+          item.evidenceId === event.evidenceId ? [index] : [],
+        );
+        if (matchingIndexes.length !== 1) {
+          const reason = matchingIndexes.length === 0 ? 'was not recorded first' : 'is ambiguous';
+          projection.warnings.push(
+            `ignored evidence provenance ${event.id}: evidence ${event.evidenceId} ${reason}`,
+          );
+          break;
+        }
+        const index = matchingIndexes[0]!;
+        const evidence = projection.heavyTaskEvidence[index]!;
+        const provenance = validHeavyTaskEvidenceProvenance(event, evidence, projection.warnings);
+        if (!provenance) break;
+        if (evidence.provenance) {
+          projection.warnings.push(
+            `ignored evidence provenance ${event.id}: evidence ${event.evidenceId} is already linked`,
+          );
+          break;
+        }
+        const linked = { ...evidence, provenance };
+        projection.heavyTaskEvidence[index] = linked;
+        if (projection.latestHeavyTaskEvidence?.evidenceId === event.evidenceId) {
+          projection.latestHeavyTaskEvidence = linked;
+        }
+        break;
+      }
+      case 'isolation_policy_recorded':
+        projection.isolation = event.facts;
+        break;
+      case 'workspace_lease_recorded':
+        projection.workspaceLease = event.lease;
+        break;
+      case 'tool_executor_identity_recorded':
+        projection.toolExecutors.push(event.identity);
+        break;
+      case 'permission_request_recorded':
+        projection.permissionRequests.push(event.request);
+        break;
+      case 'permission_grant_recorded':
+        projection.permissionGrants.push(event.grant);
+        break;
+      case 'permission_decision_recorded':
+        break;
+      case 'task_inbox_item_recorded':
+        inboxItems.set(event.item.inboxItemId, event.item);
+        break;
+      case 'task_inbox_item_resolved': {
+        const previous = inboxItems.get(event.inboxItemId);
+        if (previous) {
+          inboxItems.set(event.inboxItemId, {
+            ...previous,
+            status: event.status,
+            ...(event.resolution ? { resolution: event.resolution } : {}),
+          });
+        }
+        if (projection.parked?.inboxItemId === event.inboxItemId && terminalEvents === 0) {
+          delete projection.parked;
+        }
+        break;
+      }
+      case 'task_run_needs_approval':
+        if (terminalEvents === 0) {
+          projection.status = 'needs_approval';
+          projection.parked = {
+            reason: event.reason,
+            inboxItemId: event.inboxItemId,
+            since: event.ts,
+          };
+          if (event.attemptId) {
+            const previous = attempts.get(event.attemptId);
+            attempts.set(event.attemptId, {
+              ...(previous ?? {
+                attemptId: event.attemptId,
+                taskRunId: event.taskRunId,
+                startedAt: event.ts,
+                executionLineage: [],
+              }),
+              status: 'needs_approval',
+              finishedAt: event.ts,
+            });
+          }
+        }
+        break;
+      case 'task_attempt_completed':
+        attempts.set(event.attemptId, {
+          ...(attempts.get(event.attemptId) ?? {
+            attemptId: event.attemptId,
+            taskRunId: event.taskRunId,
+            startedAt: event.ts,
+            executionLineage: [],
+          }),
+          status: event.status,
+          finishedAt: event.finishedAt ?? event.ts,
+          ...(event.error ? { error: event.error } : {}),
+        });
+        break;
+      case 'task_run_completed':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'completed';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.result =
+          event.result ??
+          projection.result ??
+          resultFromScore(projection.latestScoreResult, projection.latestVerifierResult);
+        break;
+      case 'task_run_failed':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'failed';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error;
+        break;
+      case 'task_run_incomplete':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'incomplete';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error ?? {
+          message: 'task run incomplete',
+          class: 'agent_incomplete',
+        };
+        break;
+      case 'task_run_blocked':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'blocked';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error ?? { message: 'task run blocked', class: 'blocked' };
+        break;
+      case 'task_run_policy_denied':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'policy_denied';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error ?? {
+          message: 'task run denied by policy',
+          class: 'policy_denied',
+        };
+        break;
+      case 'task_run_budget_exhausted':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'budget_exhausted';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error ?? {
+          message: 'task run budget exhausted',
+          class: 'budget_exhausted',
+        };
+        break;
+      case 'task_run_aborted':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'aborted';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error ?? { message: 'task run aborted', class: 'aborted' };
+        break;
+      case 'task_run_cancelled':
+        terminalEvents = applyTerminalEvent(projection, terminalEvents);
+        projection.status = 'cancelled';
+        projection.finishedAt = event.finishedAt ?? event.ts;
+        projection.error = event.error ?? { message: 'task run cancelled', class: 'cancelled' };
+        break;
+      case 'event_corrupt':
+        projection.warnings.push(`corrupt event ${event.id}: ${event.error}`);
+        break;
+    }
+  }
+
+  projection.attempts = [...attempts.values()];
+  projection.inboxItems = [...inboxItems.values()];
+  refreshHeavyTaskSelfCheckFreshness(projection, events, workspaceObservationRows);
+  projection.latestVerifierResult = preferredVerifierResult(projection.verifierResults);
+  projection.latestScoreResult = preferredScoreResult(
+    projection.scoreResults,
+    projection.latestVerifierResult,
+  );
+  if (projection.latestScoreResult) {
+    projection.result = resultFromScore(
+      projection.latestScoreResult,
+      projection.latestVerifierResult,
+    );
+  } else if (projection.latestVerifierResult) {
+    projection.result = resultFromVerifier(projection.latestVerifierResult);
+  }
+  if (hasHeavyTaskCompletionState(projection)) {
+    projection.heavyTaskCompletion = evaluateHeavyTaskCompletionStatus({
+      status: projection.status,
+      taxonomy: projection.latestScoreResult?.taxonomy ?? projection.result?.taxonomy,
+      error: projection.error,
+      heavyTaskMode: projection.heavyTaskMode,
+      latestHeavyTaskTodos: projection.latestHeavyTaskTodos,
+      latestHeavyTaskSelfCheckPlan: projection.latestHeavyTaskSelfCheckPlan,
+      latestHeavyTaskSelfCheck: projection.latestHeavyTaskSelfCheck,
+      decisions: projection.decisions,
+    });
+  }
+  return projection;
+}
+
+function setOptionalRefs(
+  projection: TaskRunProjection,
+  sessionId: string | undefined,
+  agentRunId: string | undefined,
+): void {
+  if (sessionId) projection.sessionId = sessionId;
+  if (agentRunId) projection.agentRunId = agentRunId;
+}
+
+function validTaskAttemptExecutionEvidence(
+  event: Extract<TaskEvent, { type: 'task_attempt_execution_linked' }>,
+  warnings: string[],
+): ExecutionEvidenceRef | undefined {
+  const validation = validateExecutionEvidenceRef(event.evidence);
+  if (!validation.ok) {
+    warnings.push(
+      `ignored execution lineage ${event.id}: ${validation.errors.map((issue) => `${issue.path}: ${issue.message}`).join('; ')}`,
+    );
+    return undefined;
+  }
+  const evidence = validation.value;
+  if (evidence.task?.taskRunId !== event.taskRunId || evidence.task.attemptId !== event.attemptId) {
+    warnings.push(
+      `ignored execution lineage ${event.id}: task identity does not match the owning attempt`,
+    );
+    return undefined;
+  }
+  if (!evidence.execution?.agentRunId) {
+    warnings.push(`ignored execution lineage ${event.id}: execution.agentRunId is required`);
+    return undefined;
+  }
+  return evidence;
+}
+
+function validHeavyTaskEvidenceProvenance(
+  event: Extract<TaskEvent, { type: 'heavy_task_evidence_provenance_linked' }>,
+  subject: HeavyTaskCompactEvidenceEnvelope,
+  warnings: string[],
+): ExecutionEvidenceRef | undefined {
+  const validation = validateExecutionEvidenceRef(event.provenance);
+  if (!validation.ok) {
+    warnings.push(
+      `ignored evidence provenance ${event.id}: ${validation.errors
+        .map((issue) => `${issue.path}: ${issue.message}`)
+        .join('; ')}`,
+    );
+    return undefined;
+  }
+  const provenance = validation.value;
+  if (provenance.task?.taskRunId !== event.taskRunId) {
+    warnings.push(
+      `ignored evidence provenance ${event.id}: task identity does not match the owning TaskRun`,
+    );
+    return undefined;
+  }
+  const attemptId = event.attemptId;
+  if (
+    (subject.attemptId && event.attemptId !== subject.attemptId) ||
+    provenance.task?.attemptId !== attemptId
+  ) {
+    warnings.push(
+      `ignored evidence provenance ${event.id}: attempt identity does not match the evidence`,
+    );
+    return undefined;
+  }
+  if (!provenance.execution?.agentRunId || !provenance.runtimeCoverage) {
+    warnings.push(
+      `ignored evidence provenance ${event.id}: AgentRun identity and Runtime coverage are required`,
+    );
+    return undefined;
+  }
+  if (
+    (subject.source.sessionId && subject.source.sessionId !== provenance.execution.sessionId) ||
+    (subject.source.agentRunId && subject.source.agentRunId !== provenance.execution.agentRunId) ||
+    (subject.source.turnId && subject.source.turnId !== provenance.execution.turnId)
+  ) {
+    warnings.push(
+      `ignored evidence provenance ${event.id}: Runtime identity does not match the evidence source`,
+    );
+    return undefined;
+  }
+  return provenance;
+}
+
+function validHeavyTaskSelfCheckProvenance(
+  event: Extract<TaskEvent, { type: 'heavy_task_self_check_evidence_linked' }>,
+  selfCheck: HeavyTaskSelfCheckProjection,
+  selfCheckSequence: number,
+  selfCheckEventId: string,
+  observationRow: { sequence: number; observation: HeavyTaskWorkspaceObservationState } | undefined,
+  warnings: string[],
+): ExecutionEvidenceRef | undefined {
+  const validation = validateExecutionEvidenceRef(event.provenance);
+  if (!validation.ok) {
+    warnings.push(
+      `ignored self-check evidence link ${event.id}: ${validation.errors
+        .map((issue) => `${issue.path}: ${issue.message}`)
+        .join('; ')}`,
+    );
+    return undefined;
+  }
+  const provenance = validation.value;
+  if (
+    provenance.task?.taskRunId !== event.taskRunId ||
+    provenance.task.attemptId !== event.attemptId ||
+    selfCheck.taskRunId !== event.taskRunId ||
+    selfCheck.attemptId !== event.attemptId
+  ) {
+    warnings.push(
+      `ignored self-check evidence link ${event.id}: TaskRun or attempt identity does not match`,
+    );
+    return undefined;
+  }
+  if (
+    !provenance.execution?.agentRunId ||
+    !provenance.runtimeCoverage ||
+    !provenance.taskCoverage ||
+    !provenance.workspace
+  ) {
+    warnings.push(
+      `ignored self-check evidence link ${event.id}: Runtime coverage, Task coverage, and workspace revision are required`,
+    );
+    return undefined;
+  }
+  if (
+    (selfCheck.source.sessionId && selfCheck.source.sessionId !== provenance.execution.sessionId) ||
+    (selfCheck.source.agentRunId &&
+      selfCheck.source.agentRunId !== provenance.execution.agentRunId) ||
+    (selfCheck.source.turnId && selfCheck.source.turnId !== provenance.execution.turnId)
+  ) {
+    warnings.push(
+      `ignored self-check evidence link ${event.id}: Runtime identity does not match the Self-check source`,
+    );
+    return undefined;
+  }
+  const taskHighWater = provenance.taskCoverage.highWater;
+  if (
+    taskHighWater.ledger !== 'task_event' ||
+    taskHighWater.streamId !== event.taskRunId ||
+    taskHighWater.sequence !== selfCheckSequence ||
+    taskHighWater.eventId !== selfCheckEventId
+  ) {
+    warnings.push(
+      `ignored self-check evidence link ${event.id}: Task high water does not identify the Self-check record`,
+    );
+    return undefined;
+  }
+  if (
+    !observationRow ||
+    observationRow.sequence <= selfCheckSequence ||
+    observationRow.observation.status !== 'ok' ||
+    !observationRow.observation.revision
+  ) {
+    warnings.push(
+      `ignored self-check evidence link ${event.id}: referenced post-check workspace observation is missing`,
+    );
+    return undefined;
+  }
+  if (!sameWorkspaceRevision(provenance.workspace, observationRow.observation.revision)) {
+    warnings.push(
+      `ignored self-check evidence link ${event.id}: workspace revision does not match the referenced observation`,
+    );
+    return undefined;
+  }
+  return provenance;
+}
+
+function refreshHeavyTaskSelfCheckFreshness(
+  projection: TaskRunProjection,
+  events: readonly TaskEvent[],
+  observationRows: ReadonlyMap<
+    string,
+    { sequence: number; observation: HeavyTaskWorkspaceObservationState }
+  >,
+): void {
+  projection.heavyTaskSelfChecks = projection.heavyTaskSelfChecks.map((selfCheck) => {
+    if (!selfCheck.provenance || !selfCheck.workspaceObservationId) {
+      return withSelfCheckFreshness(selfCheck, 'unknown', ['source_binding_missing']);
+    }
+    const baseline = observationRows.get(selfCheck.workspaceObservationId);
+    if (!baseline?.observation.revision) {
+      return withSelfCheckFreshness(selfCheck, 'unknown', ['workspace_observation_missing']);
+    }
+    const laterObservations = [...observationRows.values()]
+      .filter(
+        (row) =>
+          row.sequence >= baseline.sequence &&
+          row.observation.status === 'ok' &&
+          row.observation.revision,
+      )
+      .sort((left, right) => left.sequence - right.sequence);
+    const latestObservation = laterObservations.at(-1) ?? baseline;
+    if (
+      !sameWorkspaceRevision(selfCheck.provenance.workspace, latestObservation.observation.revision)
+    ) {
+      return withSelfCheckFreshness(selfCheck, 'stale', ['workspace_revision_changed']);
+    }
+    const hasLaterMutation = events.some(
+      (event, sequence) =>
+        sequence > latestObservation.sequence &&
+        invalidatesSelfCheckWorkspace(event, selfCheck.attemptId),
+    );
+    if (hasLaterMutation) {
+      return withSelfCheckFreshness(selfCheck, 'stale', ['later_workspace_mutation']);
+    }
+    return withSelfCheckFreshness(selfCheck, 'current', []);
+  });
+  projection.latestHeavyTaskSelfCheck = projection.heavyTaskSelfChecks.at(-1);
+}
+
+function withSelfCheckFreshness(
+  selfCheck: HeavyTaskSelfCheckProjection,
+  freshness: HeavyTaskSelfCheckProjection['freshness'],
+  freshnessReasons: HeavyTaskSelfCheckFreshnessReason[],
+): HeavyTaskSelfCheckProjection {
+  return { ...selfCheck, freshness, freshnessReasons };
+}
+
+function invalidatesSelfCheckWorkspace(event: TaskEvent, attemptId: string | undefined): boolean {
+  if (event.type !== 'heavy_task_evidence_recorded') return false;
+  if (!attemptId || event.evidence.attemptId !== attemptId) return false;
+  if (event.evidence.kind === 'artifact') return true;
+  if (event.evidence.kind !== 'tool') return false;
+  return ['Bash', 'Write', 'Edit'].includes(
+    event.evidence.tool?.name ?? event.evidence.source.toolName ?? '',
+  );
+}
+
+function sameWorkspaceRevision(
+  left: ExecutionEvidenceRef['workspace'],
+  right: ExecutionEvidenceRef['workspace'],
+): boolean {
+  return Boolean(
+    left &&
+      right &&
+      left.kind === right.kind &&
+      left.ref === right.ref &&
+      left.dirty === right.dirty,
+  );
+}
+
+function resultFromScore(
+  score: ScoreResult | undefined,
+  verifier: VerifierResult | undefined,
+): TaskRunResult | undefined {
+  if (!score) return undefined;
+  return {
+    passed: score.passed,
+    taxonomy: score.taxonomy,
+    ...(verifier ? { verifierResultId: verifier.id } : {}),
+    scoreResultId: score.id,
+  };
+}
+
+function resultFromVerifier(verifier: VerifierResult): TaskRunResult {
+  return {
+    passed: verifier.passed,
+    taxonomy: verifier.passed ? 'passed' : 'verification_failed',
+    verifierResultId: verifier.id,
+  };
+}
+
+function preferredVerifierResult(results: readonly VerifierResult[]): VerifierResult | undefined {
+  return preferredByAuthority(results);
+}
+
+function preferredScoreResult(
+  results: readonly ScoreResult[],
+  verifier: VerifierResult | undefined,
+): ScoreResult | undefined {
+  if (
+    verifier?.authority?.authoritative === true &&
+    !results.some((result) => result.authority?.authoritative === true)
+  ) {
+    return undefined;
+  }
+  return preferredByAuthority(results);
+}
+
+function preferredByAuthority<T extends { authority?: { authoritative: boolean }; ts: number }>(
+  results: readonly T[],
+): T | undefined {
+  const authoritative = results.filter((result) => result.authority?.authoritative === true);
+  if (authoritative.length > 0) return authoritative[authoritative.length - 1];
+  const nonPlaceholder = results.filter((result) => result.authority?.authoritative !== false);
+  if (nonPlaceholder.length > 0) return nonPlaceholder[nonPlaceholder.length - 1];
+  return results[results.length - 1];
+}
+
+function applyTerminalEvent(projection: TaskRunProjection, terminalEvents: number): number {
+  if (terminalEvents > 0) {
+    projection.warnings.push(
+      'multiple terminal task run events observed; last terminal event wins',
+    );
+  }
+  delete projection.parked;
+  return terminalEvents + 1;
+}
+
+function appendCompactEvidence(
+  projection: TaskRunProjection,
+  ...evidence: HeavyTaskCompactEvidenceEnvelope[]
+): boolean {
+  let ok = true;
+  for (const item of evidence) {
+    if (item.public !== true || item.taskRunId !== projection.taskRunId) {
+      ok = false;
+      continue;
+    }
+    if (item.provenance) {
+      projection.warnings.push(
+        `ignored embedded provenance on heavy-task evidence ${item.evidenceId}: a provenance link event is required`,
+      );
+    }
+    const { provenance: _embeddedProvenance, ...unlinked } = item;
+    projection.heavyTaskEvidence.push(unlinked);
+    projection.latestHeavyTaskEvidence = unlinked;
+  }
+  return ok;
+}
+
+function selfCheckEvidenceIdFactory(selfCheckId: string): () => string {
+  let index = 0;
+  return () => `${selfCheckId}:compact-${++index}`;
+}
+
+function isCompactEvidenceEligibleArtifact(artifact: TaskRunArtifact): boolean {
+  return (
+    (artifact.authority.source === 'runtime' || artifact.authority.source === 'self_check') &&
+    artifact.authority.authoritative !== true
+  );
+}
+
+function hasHeavyTaskCompletionState(projection: TaskRunProjection): boolean {
+  return (
+    projection.heavyTaskMode?.enabled === true ||
+    projection.heavyTaskInventory.length > 0 ||
+    projection.heavyTaskTodoStates.length > 0 ||
+    projection.heavyTaskSelfCheckPlans.length > 0 ||
+    projection.heavyTaskSelfChecks.length > 0 ||
+    projection.heavyTaskEvidence.length > 0
+  );
+}

--- a/packages/headless/src/task-run-store.ts
+++ b/packages/headless/src/task-run-store.ts
@@ -1,94 +1,36 @@
-import { appendFile, mkdir, readFile } from 'node:fs/promises';
+import { Buffer } from 'node:buffer';
+import {
+  appendFile,
+  lstat,
+  mkdir,
+  open,
+  readFile,
+  readdir,
+  type FileHandle,
+} from 'node:fs/promises';
 import { join } from 'node:path';
+import type { ExecutionLogCursor } from '@maka/core/execution-evidence';
 import {
-  validateExecutionEvidenceRef,
-  type ExecutionEvidenceRef,
-  type ExecutionLogCursor,
-} from '@maka/core/execution-evidence';
-import type { ResultRecord } from './contracts.js';
-import { compactArtifactEvidence, compactSelfCheckEvidence } from './heavy-task-evidence.js';
-import {
-  evaluateHeavyTaskCompletionStatus,
-  type HeavyTaskCompletionStatus,
-} from './heavy-task-finalization.js';
-import { isAcceptedHeavyTaskSelfCheck } from './heavy-task-self-check.js';
-import type {
-  AutonomousDecision,
-  FeedbackObservation,
-  HeavyTaskCompactEvidenceEnvelope,
-  HeavyTaskSelfCheckPlanState,
-  HeavyTaskSelfCheckGateState,
-  HeavyTaskSelfCheckFreshnessReason,
-  HeavyTaskSelfCheckProjection,
-  HeavyTaskWorkspaceObservationState,
-  EconomyTaskModeFacts,
-  HeavyTaskInventoryState,
-  TaskInboxItem,
-  HeavyTaskModeFacts,
-  HeavyTaskSemanticSelfCheckState,
-  HeavyTaskTodoState,
-  TaskIsolationFacts,
-  TaskPermissionGrant,
-  TaskPermissionRequest,
-  TaskRunParkedState,
-  ScoreResult,
-  SelfCheckObservation,
-  TaskAttempt,
-  TaskRunArtifact,
-  TaskEvent,
-  TaskRun,
-  TaskRunError,
-  TaskRunResult,
-  ToolExecutorIdentity,
-  VerifierResult,
-  WorkspaceLeaseFacts,
-} from './task-contracts.js';
+  assertStorageRootLease,
+  runWithStorageRootLease,
+  type StorageRootLease,
+} from '@maka/storage/root-authority';
+import { chainWrite } from '@maka/storage/write-queue';
+import { unlock, waitForLock } from 'fs-native-extensions';
+import { publishFileExclusively } from './immutable-file.js';
+import type { TaskEvent } from './task-contracts.js';
+import { isTaskRunLocator, taskRunLocator } from './task-run-identity.js';
+import { projectTaskRun, type TaskRunProjection } from './task-run-projection.js';
 
-export interface TaskRunProjection extends TaskRun {
-  events: TaskEvent[];
-  attempts: TaskAttempt[];
-  executionLineage: ExecutionEvidenceRef[];
-  selfChecks: SelfCheckObservation[];
-  feedback: FeedbackObservation[];
-  decisions: AutonomousDecision[];
-  artifacts: TaskRunArtifact[];
-  verifierResults: VerifierResult[];
-  scoreResults: ScoreResult[];
-  toolExecutors: ToolExecutorIdentity[];
-  permissionGrants: TaskPermissionGrant[];
-  permissionRequests: TaskPermissionRequest[];
-  inboxItems: TaskInboxItem[];
-  warnings: string[];
-  latestVerifierResult?: VerifierResult;
-  latestScoreResult?: ScoreResult;
-  heavyTaskMode?: HeavyTaskModeFacts;
-  economyTaskMode?: EconomyTaskModeFacts;
-  heavyTaskInventory: HeavyTaskInventoryState[];
-  latestHeavyTaskInventory?: HeavyTaskInventoryState;
-  heavyTaskTodoStates: HeavyTaskTodoState[];
-  latestHeavyTaskTodos?: HeavyTaskTodoState;
-  heavyTaskSelfChecks: HeavyTaskSelfCheckProjection[];
-  latestHeavyTaskSelfCheck?: HeavyTaskSelfCheckProjection;
-  heavyTaskSelfCheckPlans: HeavyTaskSelfCheckPlanState[];
-  latestHeavyTaskSelfCheckPlan?: HeavyTaskSelfCheckPlanState;
-  heavyTaskSelfCheckGates: HeavyTaskSelfCheckGateState[];
-  latestHeavyTaskSelfCheckGate?: HeavyTaskSelfCheckGateState;
-  heavyTaskWorkspaceObservations: HeavyTaskWorkspaceObservationState[];
-  latestHeavyTaskWorkspaceObservation?: HeavyTaskWorkspaceObservationState;
-  heavyTaskEvidence: HeavyTaskCompactEvidenceEnvelope[];
-  latestHeavyTaskEvidence?: HeavyTaskCompactEvidenceEnvelope;
-  heavyTaskCompletion?: HeavyTaskCompletionStatus;
-  isolation?: TaskIsolationFacts;
-  workspaceLease?: WorkspaceLeaseFacts;
-  parked?: TaskRunParkedState;
-  sourceResultRecord?: ResultRecord;
-}
-
-export interface TaskRunStore {
-  appendEvent(taskRunId: string, event: TaskEvent): Promise<void>;
+export interface TaskRunReader {
+  listTaskRunIds(): Promise<string[]>;
   readEventRecords(taskRunId: string): Promise<TaskEventLedgerEntry[]>;
   readEvents(taskRunId: string): Promise<TaskEvent[]>;
   project(taskRunId: string): Promise<TaskRunProjection>;
+}
+
+export interface TaskRunWriter extends TaskRunReader {
+  appendEvent(taskRunId: string, event: TaskEvent): Promise<void>;
 }
 
 export interface TaskEventLedgerEntry {
@@ -96,464 +38,56 @@ export interface TaskEventLedgerEntry {
   cursor: ExecutionLogCursor;
 }
 
-export function createInMemoryTaskRunStore(initialEvents: readonly TaskEvent[] = []): TaskRunStore {
+export function createInMemoryTaskRunStore(
+  initialEvents: readonly TaskEvent[] = [],
+): TaskRunWriter {
   return new InMemoryTaskRunStore(initialEvents);
 }
 
-export function createTaskRunStore(storageRoot: string): TaskRunStore {
-  return new FileTaskRunStore(storageRoot);
-}
-
-export function projectTaskRun(
-  events: readonly TaskEvent[],
-  taskRunId?: string,
-): TaskRunProjection {
-  const projectedTaskRunId = taskRunId ?? events[0]?.taskRunId ?? '';
-  const projection: TaskRunProjection = {
-    taskRunId: projectedTaskRunId,
-    taskId: '',
-    configId: '',
-    status: 'queued',
-    events: [],
-    attempts: [],
-    executionLineage: [],
-    selfChecks: [],
-    feedback: [],
-    decisions: [],
-    artifacts: [],
-    verifierResults: [],
-    scoreResults: [],
-    toolExecutors: [],
-    permissionGrants: [],
-    permissionRequests: [],
-    inboxItems: [],
-    warnings: [],
-    heavyTaskInventory: [],
-    heavyTaskTodoStates: [],
-    heavyTaskSelfCheckPlans: [],
-    heavyTaskSelfChecks: [],
-    heavyTaskSelfCheckGates: [],
-    heavyTaskWorkspaceObservations: [],
-    heavyTaskEvidence: [],
-  };
-  const attempts = new Map<string, TaskAttempt>();
-  const inboxItems = new Map<string, TaskInboxItem>();
-  const selfCheckRows = new Map<
-    string,
-    Array<{ sequence: number; projectionIndex: number; eventId: string }>
-  >();
-  const workspaceObservationRows = new Map<
-    string,
-    { sequence: number; observation: HeavyTaskWorkspaceObservationState }
-  >();
-  let terminalEvents = 0;
-
-  for (let sequence = 0; sequence < events.length; sequence += 1) {
-    const event = events[sequence]!;
-    if (projectedTaskRunId && event.taskRunId !== projectedTaskRunId) {
-      projection.warnings.push(
-        `ignored event ${event.id}: taskRunId ${event.taskRunId} does not match ${projectedTaskRunId}`,
-      );
-      continue;
-    }
-    projection.events.push(event);
-
-    switch (event.type) {
-      case 'task_run_created':
-        projection.taskId = event.taskId;
-        projection.configId = event.configId;
-        projection.status = 'created';
-        projection.sourceResultRecord = event.sourceResultRecord;
-        break;
-      case 'task_run_queued':
-        projection.taskId = event.taskId;
-        projection.configId = event.configId;
-        projection.status = 'queued';
-        break;
-      case 'task_run_started':
-        projection.status = 'running';
-        projection.startedAt = event.startedAt ?? event.ts;
-        setOptionalRefs(projection, event.sessionId, event.agentRunId);
-        break;
-      case 'task_run_verifying':
-        projection.status = 'verifying';
-        break;
-      case 'task_attempt_started': {
-        const previous = attempts.get(event.attemptId);
-        const attempt: TaskAttempt = {
-          attemptId: event.attemptId,
-          taskRunId: event.taskRunId,
-          startedAt: event.startedAt ?? event.ts,
-          status: 'running',
-          ...(event.sessionId ? { sessionId: event.sessionId } : {}),
-          ...(event.agentRunId ? { agentRunId: event.agentRunId } : {}),
-          executionLineage: previous?.executionLineage ?? [],
-        };
-        attempts.set(event.attemptId, attempt);
-        setOptionalRefs(projection, event.sessionId, event.agentRunId);
-        break;
-      }
-      case 'task_attempt_execution_linked': {
-        const evidence = validTaskAttemptExecutionEvidence(event, projection.warnings);
-        if (!evidence) break;
-        projection.executionLineage.push(evidence);
-        const previous = attempts.get(event.attemptId);
-        attempts.set(event.attemptId, {
-          ...(previous ?? {
-            attemptId: event.attemptId,
-            taskRunId: event.taskRunId,
-            startedAt: event.ts,
-            status: 'running',
-            executionLineage: [],
-          }),
-          ...(evidence.execution?.sessionId ? { sessionId: evidence.execution.sessionId } : {}),
-          ...(!previous?.agentRunId && evidence.execution?.agentRunId
-            ? { agentRunId: evidence.execution.agentRunId }
-            : {}),
-          executionLineage: [...(previous?.executionLineage ?? []), evidence],
-        });
-        if (!projection.sessionId && evidence.execution?.sessionId) {
-          projection.sessionId = evidence.execution.sessionId;
-        }
-        if (!projection.agentRunId && evidence.execution?.agentRunId) {
-          projection.agentRunId = evidence.execution.agentRunId;
-        }
-        break;
-      }
-      case 'self_check_observed':
-        projection.selfChecks.push(event.observation);
-        break;
-      case 'feedback_observed':
-        projection.feedback.push(event.observation);
-        break;
-      case 'autonomous_decision_recorded':
-        projection.decisions.push(event.decision);
-        break;
-      case 'verifier_result_recorded':
-        projection.verifierResults.push(event.result);
-        projection.latestVerifierResult = event.result;
-        break;
-      case 'task_run_artifact_recorded':
-        projection.artifacts.push(event.artifact);
-        if (
-          projection.heavyTaskMode?.enabled === true &&
-          isCompactEvidenceEligibleArtifact(event.artifact)
-        ) {
-          appendCompactEvidence(
-            projection,
-            compactArtifactEvidence({
-              evidenceId: `${event.id}:compact-artifact`,
-              taskRunId: projection.taskRunId,
-              ...(event.artifact.attemptId ? { attemptId: event.artifact.attemptId } : {}),
-              ts: event.ts,
-              source: {
-                kind: 'model_tool',
-                toolCallId: `task-run-artifact:${event.id}`,
-                toolName: 'artifact',
-              },
-              artifact: event.artifact,
-            }),
-          );
-        }
-        break;
-      case 'score_result_recorded':
-        projection.scoreResults.push(event.result);
-        projection.latestScoreResult = event.result;
-        projection.result = resultFromScore(event.result, projection.latestVerifierResult);
-        break;
-      case 'heavy_task_mode_recorded':
-        projection.heavyTaskMode = event.facts;
-        break;
-      case 'economy_task_mode_recorded':
-        projection.economyTaskMode = event.facts;
-        break;
-      case 'heavy_task_inventory_recorded':
-        projection.heavyTaskInventory.push(event.inventory);
-        projection.latestHeavyTaskInventory = event.inventory;
-        break;
-      case 'heavy_task_todos_recorded':
-        projection.heavyTaskTodoStates.push(event.todos);
-        projection.latestHeavyTaskTodos = event.todos;
-        break;
-      case 'heavy_task_self_check_plan_recorded':
-        projection.heavyTaskSelfCheckPlans.push(event.plan);
-        projection.latestHeavyTaskSelfCheckPlan = event.plan;
-        break;
-      case 'heavy_task_self_check_recorded':
-        if (isAcceptedHeavyTaskSelfCheck(event.selfCheck)) {
-          const projectedSelfCheck: HeavyTaskSelfCheckProjection = {
-            ...event.selfCheck,
-            freshness: 'unknown',
-            freshnessReasons: ['source_binding_missing'],
-          };
-          const projectionIndex = projection.heavyTaskSelfChecks.push(projectedSelfCheck) - 1;
-          selfCheckRows.set(event.selfCheck.selfCheckId, [
-            ...(selfCheckRows.get(event.selfCheck.selfCheckId) ?? []),
-            { sequence, projectionIndex, eventId: event.id },
-          ]);
-          projection.latestHeavyTaskSelfCheck = projectedSelfCheck;
-          appendCompactEvidence(
-            projection,
-            ...compactSelfCheckEvidence({
-              selfCheck: event.selfCheck,
-              newId: selfCheckEvidenceIdFactory(event.selfCheck.selfCheckId),
-            }),
-          );
-        } else {
-          projection.warnings.push(
-            `ignored heavy-task self-check ${event.selfCheck.selfCheckId}: source guard did not accept public evidence`,
-          );
-        }
-        break;
-      case 'heavy_task_self_check_evidence_linked': {
-        const rows = selfCheckRows.get(event.selfCheckId) ?? [];
-        if (rows.length !== 1) {
-          const reason = rows.length === 0 ? 'was not recorded first' : 'is ambiguous';
-          projection.warnings.push(
-            `ignored self-check evidence link ${event.id}: Self-check ${event.selfCheckId} ${reason}`,
-          );
-          break;
-        }
-        const row = rows[0]!;
-        const selfCheck = projection.heavyTaskSelfChecks[row.projectionIndex]!;
-        if (selfCheck.provenance) {
-          projection.warnings.push(
-            `ignored self-check evidence link ${event.id}: Self-check ${event.selfCheckId} is already linked`,
-          );
-          break;
-        }
-        const observationRow = workspaceObservationRows.get(event.workspaceObservationId);
-        const provenance = validHeavyTaskSelfCheckProvenance(
-          event,
-          selfCheck,
-          row.sequence,
-          row.eventId,
-          observationRow,
-          projection.warnings,
-        );
-        if (!provenance) break;
-        projection.heavyTaskSelfChecks[row.projectionIndex] = {
-          ...selfCheck,
-          provenance,
-          workspaceObservationId: event.workspaceObservationId,
-        };
-        break;
-      }
-      case 'heavy_task_self_check_gate_recorded':
-        projection.heavyTaskSelfCheckGates.push(event.gate);
-        projection.latestHeavyTaskSelfCheckGate = event.gate;
-        break;
-      case 'heavy_task_workspace_observation_recorded':
-        projection.heavyTaskWorkspaceObservations.push(event.observation);
-        projection.latestHeavyTaskWorkspaceObservation = event.observation;
-        workspaceObservationRows.set(event.observation.observationId, {
-          sequence,
-          observation: event.observation,
-        });
-        break;
-      case 'heavy_task_evidence_recorded':
-        if (!appendCompactEvidence(projection, event.evidence)) {
-          projection.warnings.push(
-            `ignored heavy-task evidence ${event.evidence.evidenceId}: evidence must be public and match taskRunId`,
-          );
-        }
-        break;
-      case 'heavy_task_evidence_provenance_linked': {
-        const matchingIndexes = projection.heavyTaskEvidence.flatMap((item, index) =>
-          item.evidenceId === event.evidenceId ? [index] : [],
-        );
-        if (matchingIndexes.length !== 1) {
-          const reason = matchingIndexes.length === 0 ? 'was not recorded first' : 'is ambiguous';
-          projection.warnings.push(
-            `ignored evidence provenance ${event.id}: evidence ${event.evidenceId} ${reason}`,
-          );
-          break;
-        }
-        const index = matchingIndexes[0]!;
-        const evidence = projection.heavyTaskEvidence[index]!;
-        const provenance = validHeavyTaskEvidenceProvenance(event, evidence, projection.warnings);
-        if (!provenance) break;
-        if (evidence.provenance) {
-          projection.warnings.push(
-            `ignored evidence provenance ${event.id}: evidence ${event.evidenceId} is already linked`,
-          );
-          break;
-        }
-        const linked = { ...evidence, provenance };
-        projection.heavyTaskEvidence[index] = linked;
-        if (projection.latestHeavyTaskEvidence?.evidenceId === event.evidenceId) {
-          projection.latestHeavyTaskEvidence = linked;
-        }
-        break;
-      }
-      case 'isolation_policy_recorded':
-        projection.isolation = event.facts;
-        break;
-      case 'workspace_lease_recorded':
-        projection.workspaceLease = event.lease;
-        break;
-      case 'tool_executor_identity_recorded':
-        projection.toolExecutors.push(event.identity);
-        break;
-      case 'permission_request_recorded':
-        projection.permissionRequests.push(event.request);
-        break;
-      case 'permission_grant_recorded':
-        projection.permissionGrants.push(event.grant);
-        break;
-      case 'permission_decision_recorded':
-        break;
-      case 'task_inbox_item_recorded':
-        inboxItems.set(event.item.inboxItemId, event.item);
-        break;
-      case 'task_inbox_item_resolved': {
-        const previous = inboxItems.get(event.inboxItemId);
-        if (previous) {
-          inboxItems.set(event.inboxItemId, {
-            ...previous,
-            status: event.status,
-            ...(event.resolution ? { resolution: event.resolution } : {}),
-          });
-        }
-        if (projection.parked?.inboxItemId === event.inboxItemId && terminalEvents === 0) {
-          delete projection.parked;
-        }
-        break;
-      }
-      case 'task_run_needs_approval':
-        if (terminalEvents === 0) {
-          projection.status = 'needs_approval';
-          projection.parked = {
-            reason: event.reason,
-            inboxItemId: event.inboxItemId,
-            since: event.ts,
-          };
-          if (event.attemptId) {
-            const previous = attempts.get(event.attemptId);
-            attempts.set(event.attemptId, {
-              ...(previous ?? {
-                attemptId: event.attemptId,
-                taskRunId: event.taskRunId,
-                startedAt: event.ts,
-                executionLineage: [],
-              }),
-              status: 'needs_approval',
-              finishedAt: event.ts,
-            });
-          }
-        }
-        break;
-      case 'task_attempt_completed':
-        attempts.set(event.attemptId, {
-          ...(attempts.get(event.attemptId) ?? {
-            attemptId: event.attemptId,
-            taskRunId: event.taskRunId,
-            startedAt: event.ts,
-            executionLineage: [],
-          }),
-          status: event.status,
-          finishedAt: event.finishedAt ?? event.ts,
-          ...(event.error ? { error: event.error } : {}),
-        });
-        break;
-      case 'task_run_completed':
-        terminalEvents = applyTerminalEvent(projection, terminalEvents);
-        projection.status = 'completed';
-        projection.finishedAt = event.finishedAt ?? event.ts;
-        projection.result =
-          event.result ??
-          projection.result ??
-          resultFromScore(projection.latestScoreResult, projection.latestVerifierResult);
-        break;
-      case 'task_run_failed':
-        terminalEvents = applyTerminalEvent(projection, terminalEvents);
-        projection.status = 'failed';
-        projection.finishedAt = event.finishedAt ?? event.ts;
-        projection.error = event.error;
-        break;
-      case 'task_run_incomplete':
-        terminalEvents = applyTerminalEvent(projection, terminalEvents);
-        projection.status = 'incomplete';
-        projection.finishedAt = event.finishedAt ?? event.ts;
-        projection.error = event.error ?? {
-          message: 'task run incomplete',
-          class: 'agent_incomplete',
-        };
-        break;
-      case 'task_run_blocked':
-        terminalEvents = applyTerminalEvent(projection, terminalEvents);
-        projection.status = 'blocked';
-        projection.finishedAt = event.finishedAt ?? event.ts;
-        projection.error = event.error ?? { message: 'task run blocked', class: 'blocked' };
-        break;
-      case 'task_run_policy_denied':
-        terminalEvents = applyTerminalEvent(projection, terminalEvents);
-        projection.status = 'policy_denied';
-        projection.finishedAt = event.finishedAt ?? event.ts;
-        projection.error = event.error ?? {
-          message: 'task run denied by policy',
-          class: 'policy_denied',
-        };
-        break;
-      case 'task_run_budget_exhausted':
-        terminalEvents = applyTerminalEvent(projection, terminalEvents);
-        projection.status = 'budget_exhausted';
-        projection.finishedAt = event.finishedAt ?? event.ts;
-        projection.error = event.error ?? {
-          message: 'task run budget exhausted',
-          class: 'budget_exhausted',
-        };
-        break;
-      case 'task_run_aborted':
-        terminalEvents = applyTerminalEvent(projection, terminalEvents);
-        projection.status = 'aborted';
-        projection.finishedAt = event.finishedAt ?? event.ts;
-        projection.error = event.error ?? { message: 'task run aborted', class: 'aborted' };
-        break;
-      case 'task_run_cancelled':
-        terminalEvents = applyTerminalEvent(projection, terminalEvents);
-        projection.status = 'cancelled';
-        projection.finishedAt = event.finishedAt ?? event.ts;
-        projection.error = event.error ?? { message: 'task run cancelled', class: 'cancelled' };
-        break;
-      case 'event_corrupt':
-        projection.warnings.push(`corrupt event ${event.id}: ${event.error}`);
-        break;
-    }
-  }
-
-  projection.attempts = [...attempts.values()];
-  projection.inboxItems = [...inboxItems.values()];
-  refreshHeavyTaskSelfCheckFreshness(projection, events, workspaceObservationRows);
-  projection.latestVerifierResult = preferredVerifierResult(projection.verifierResults);
-  projection.latestScoreResult = preferredScoreResult(
-    projection.scoreResults,
-    projection.latestVerifierResult,
+export async function openHeadlessTaskRunReader(
+  lease: StorageRootLease<'headless', 'read'>,
+): Promise<TaskRunReader> {
+  await assertStorageRootLease(lease, 'headless', 'read');
+  const store = new FileTaskRunStore(lease.canonicalPath);
+  return taskRunReaderFacade(store, (operation) =>
+    runWithStorageRootLease(lease, 'headless', 'read', operation),
   );
-  if (projection.latestScoreResult) {
-    projection.result = resultFromScore(
-      projection.latestScoreResult,
-      projection.latestVerifierResult,
-    );
-  } else if (projection.latestVerifierResult) {
-    projection.result = resultFromVerifier(projection.latestVerifierResult);
-  }
-  if (hasHeavyTaskCompletionState(projection)) {
-    projection.heavyTaskCompletion = evaluateHeavyTaskCompletionStatus({
-      status: projection.status,
-      taxonomy: projection.latestScoreResult?.taxonomy ?? projection.result?.taxonomy,
-      error: projection.error,
-      heavyTaskMode: projection.heavyTaskMode,
-      latestHeavyTaskTodos: projection.latestHeavyTaskTodos,
-      latestHeavyTaskSelfCheckPlan: projection.latestHeavyTaskSelfCheckPlan,
-      latestHeavyTaskSelfCheck: projection.latestHeavyTaskSelfCheck,
-      decisions: projection.decisions,
-    });
-  }
-  return projection;
 }
 
-class InMemoryTaskRunStore implements TaskRunStore {
+export async function openHeadlessTaskRunWriter(
+  lease: StorageRootLease<'headless', 'write'>,
+): Promise<TaskRunWriter> {
+  await assertStorageRootLease(lease, 'headless', 'write');
+  const store = new FileTaskRunStore(lease.canonicalPath);
+  return taskRunWriterFacade(store, (operation) =>
+    runWithStorageRootLease(lease, 'headless', 'write', operation),
+  );
+}
+
+type RunTaskRunOperation = <T>(operation: () => Promise<T>) => Promise<T>;
+
+function taskRunReaderFacade(store: FileTaskRunStore, run: RunTaskRunOperation): TaskRunReader {
+  return Object.freeze(taskRunReaderMethods(store, run));
+}
+
+function taskRunReaderMethods(store: FileTaskRunStore, run: RunTaskRunOperation): TaskRunReader {
+  return {
+    listTaskRunIds: () => run(() => store.listTaskRunIds()),
+    readEventRecords: (taskRunId) => run(() => store.readEventRecords(taskRunId)),
+    readEvents: (taskRunId) => run(() => store.readEvents(taskRunId)),
+    project: (taskRunId) => run(() => store.project(taskRunId)),
+  };
+}
+
+function taskRunWriterFacade(store: FileTaskRunStore, run: RunTaskRunOperation): TaskRunWriter {
+  const writer: TaskRunWriter = {
+    ...taskRunReaderMethods(store, run),
+    appendEvent: (taskRunId, event) => run(() => store.appendEvent(taskRunId, event)),
+  };
+  return Object.freeze(writer);
+}
+
+class InMemoryTaskRunStore implements TaskRunWriter {
   private readonly events = new Map<string, TaskEvent[]>();
   private readonly queues = new Map<string, Promise<void>>();
 
@@ -570,17 +104,15 @@ class InMemoryTaskRunStore implements TaskRunStore {
       throw new Error(`taskRunId mismatch: append target ${taskRunId}, event ${event.taskRunId}`);
     }
 
-    const previous = this.queues.get(taskRunId) ?? Promise.resolve();
-    const next = previous.then(() => {
+    await chainWrite(this.queues, taskRunId, async () => {
       const events = this.events.get(taskRunId) ?? [];
       events.push(event);
       this.events.set(taskRunId, events);
     });
-    this.queues.set(
-      taskRunId,
-      next.catch(() => undefined),
-    );
-    await next;
+  }
+
+  async listTaskRunIds(): Promise<string[]> {
+    return [...this.events.keys()].sort();
   }
 
   async readEvents(taskRunId: string): Promise<TaskEvent[]> {
@@ -599,7 +131,7 @@ class InMemoryTaskRunStore implements TaskRunStore {
   }
 }
 
-class FileTaskRunStore implements TaskRunStore {
+class FileTaskRunStore implements TaskRunWriter {
   private readonly queues = new Map<string, Promise<void>>();
 
   constructor(private readonly storageRoot: string) {}
@@ -609,16 +141,28 @@ class FileTaskRunStore implements TaskRunStore {
       throw new Error(`taskRunId mismatch: append target ${taskRunId}, event ${event.taskRunId}`);
     }
 
-    const previous = this.queues.get(taskRunId) ?? Promise.resolve();
-    const next = previous.then(async () => {
-      await mkdir(this.taskRunDir(), { recursive: true });
-      await appendFile(this.taskRunPath(taskRunId), `${JSON.stringify(event)}\n`, 'utf8');
-    });
-    this.queues.set(
-      taskRunId,
-      next.catch(() => undefined),
+    const locator = taskRunLocator(taskRunId);
+    await chainWrite(this.queues, locator, () =>
+      this.appendTaskRunEvent(locator, taskRunId, event),
     );
-    await next;
+  }
+
+  async listTaskRunIds(): Promise<string[]> {
+    let entries: string[];
+    try {
+      entries = (await readdir(this.taskRunDir())).filter((name) => name.endsWith('.jsonl')).sort();
+    } catch (error) {
+      if (isNotFound(error)) return [];
+      throw error;
+    }
+    const identities: string[] = [];
+    for (const entry of entries) {
+      const locator = taskRunLocatorFromFilename(entry);
+      const header = await readTaskRunLedgerHeader(join(this.taskRunDir(), entry));
+      assertTaskRunLedgerIdentity(header, locator, entry);
+      identities.push(header.taskRunId);
+    }
+    return identities.sort();
   }
 
   async readEvents(taskRunId: string): Promise<TaskEvent[]> {
@@ -626,22 +170,36 @@ class FileTaskRunStore implements TaskRunStore {
   }
 
   async readEventRecords(taskRunId: string): Promise<TaskEventLedgerEntry[]> {
+    const path = this.taskRunPath(taskRunId);
     let content: string;
     try {
-      content = await readFile(this.taskRunPath(taskRunId), 'utf8');
+      content = await readFile(path, 'utf8');
     } catch (error) {
       if (isNotFound(error)) return [];
       throw error;
     }
 
-    const lines = content.endsWith('\n') ? content.split('\n') : content.split('\n').slice(0, -1);
+    const lines = durableJsonlLines(content);
+    const header = parseTaskRunLedgerHeader(lines.shift(), path);
+    assertTaskRunLedgerIdentity(header, taskRunLocator(taskRunId), path);
+    if (header.taskRunId !== taskRunId) {
+      throw new Error(`TaskRun ledger identity does not match requested taskRunId ${taskRunId}`);
+    }
     const records: TaskEventLedgerEntry[] = [];
     for (let i = 0; i < lines.length; i += 1) {
       const line = lines[i];
       if (!line) continue;
       let event: TaskEvent;
       try {
-        event = JSON.parse(line) as TaskEvent;
+        const parsed = JSON.parse(line) as unknown;
+        if (
+          typeof parsed !== 'object' ||
+          parsed === null ||
+          typeof (parsed as { taskRunId?: unknown }).taskRunId !== 'string'
+        ) {
+          throw new Error('record is not a TaskEvent');
+        }
+        event = parsed as TaskEvent;
       } catch (error) {
         event = {
           type: 'event_corrupt',
@@ -651,6 +209,9 @@ class FileTaskRunStore implements TaskRunStore {
           raw: line,
           error: errorMessage(error),
         };
+      }
+      if (event.taskRunId !== taskRunId) {
+        throw new Error(`TaskRun ledger ${path} contains event for ${String(event.taskRunId)}`);
       }
       records.push({
         event,
@@ -669,360 +230,198 @@ class FileTaskRunStore implements TaskRunStore {
   }
 
   private taskRunPath(taskRunId: string): string {
-    return join(this.taskRunDir(), `${safeFileId(taskRunId)}.jsonl`);
+    return join(this.taskRunDir(), `${taskRunLocator(taskRunId)}.jsonl`);
+  }
+
+  private async appendTaskRunEvent(
+    locator: string,
+    taskRunId: string,
+    event: TaskEvent,
+  ): Promise<void> {
+    const eventLine = `${JSON.stringify(event)}\n`;
+    await mkdir(this.taskRunDir(), { recursive: true });
+    const path = join(this.taskRunDir(), `${locator}.jsonl`);
+    await withTaskRunLedgerLock(`${path}.lock`, async () => {
+      let header: TaskRunLedgerHeader;
+      try {
+        header = await readTaskRunLedgerHeader(path);
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+        const initialContent = `${JSON.stringify(taskRunLedgerHeader(taskRunId))}\n${eventLine}`;
+        if (await publishFileExclusively(path, initialContent)) return;
+        header = await readTaskRunLedgerHeader(path);
+      }
+
+      assertTaskRunLedgerIdentity(header, locator, path);
+      if (header.taskRunId !== taskRunId) {
+        throw new Error(`TaskRun identity collision between ${header.taskRunId} and ${taskRunId}`);
+      }
+      await truncatePartialTaskRunTail(path);
+      await appendFile(path, eventLine, 'utf8');
+    });
   }
 }
 
-function setOptionalRefs(
-  projection: TaskRunProjection,
-  sessionId: string | undefined,
-  agentRunId: string | undefined,
+const TASK_RUN_LEDGER_SCHEMA_VERSION = 1 as const;
+const TASK_RUN_LEDGER_TYPE = 'task_run_ledger' as const;
+
+interface TaskRunLedgerHeader {
+  schemaVersion: typeof TASK_RUN_LEDGER_SCHEMA_VERSION;
+  type: typeof TASK_RUN_LEDGER_TYPE;
+  taskRunId: string;
+}
+
+function taskRunLocatorFromFilename(filename: string): string {
+  const locator = filename.slice(0, -'.jsonl'.length);
+  if (!isTaskRunLocator(locator)) {
+    throw new Error(`Invalid TaskRun ledger filename ${filename}`);
+  }
+  return locator;
+}
+
+function taskRunLedgerHeader(taskRunId: string): TaskRunLedgerHeader {
+  taskRunLocator(taskRunId);
+  return {
+    schemaVersion: TASK_RUN_LEDGER_SCHEMA_VERSION,
+    type: TASK_RUN_LEDGER_TYPE,
+    taskRunId,
+  };
+}
+
+function parseTaskRunLedgerHeader(line: string | undefined, source: string): TaskRunLedgerHeader {
+  if (!line) throw new Error(`TaskRun ledger ${source} has no durable header`);
+  let record: unknown;
+  try {
+    record = JSON.parse(line);
+  } catch (error) {
+    throw new Error(`TaskRun ledger ${source} has an invalid header: ${errorMessage(error)}`);
+  }
+  if (
+    typeof record !== 'object' ||
+    record === null ||
+    (record as { schemaVersion?: unknown }).schemaVersion !== TASK_RUN_LEDGER_SCHEMA_VERSION ||
+    (record as { type?: unknown }).type !== TASK_RUN_LEDGER_TYPE ||
+    typeof (record as { taskRunId?: unknown }).taskRunId !== 'string'
+  ) {
+    throw new Error(`TaskRun ledger ${source} has an invalid header`);
+  }
+  const header = record as TaskRunLedgerHeader;
+  taskRunLocator(header.taskRunId);
+  return header;
+}
+
+function assertTaskRunLedgerIdentity(
+  header: TaskRunLedgerHeader,
+  expectedLocator: string,
+  source: string,
 ): void {
-  if (sessionId) projection.sessionId = sessionId;
-  if (agentRunId) projection.agentRunId = agentRunId;
+  if (taskRunLocator(header.taskRunId) !== expectedLocator) {
+    throw new Error(`TaskRun ledger ${source} does not match its identity locator`);
+  }
+}
+
+async function withTaskRunLedgerLock<T>(lockPath: string, operation: () => Promise<T>): Promise<T> {
+  const handle = await open(lockPath, 'a+', 0o600);
+  try {
+    await assertStableLockArtifact(handle, lockPath);
+    await handle.chmod(0o600);
+    await waitForLock(handle.fd);
+    try {
+      await assertStableLockArtifact(handle, lockPath);
+      return await operation();
+    } finally {
+      releaseLock(handle);
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+async function assertStableLockArtifact(handle: FileHandle, path: string): Promise<void> {
+  const [handleStats, pathStats] = await Promise.all([
+    handle.stat({ bigint: true }),
+    lstat(path, { bigint: true }),
+  ]);
+  if (
+    !handleStats.isFile() ||
+    !pathStats.isFile() ||
+    handleStats.dev !== pathStats.dev ||
+    handleStats.ino !== pathStats.ino
+  ) {
+    throw new Error(`TaskRun lock path is not one stable regular file: ${path}`);
+  }
+}
+
+function releaseLock(handle: FileHandle): void {
+  try {
+    unlock(handle.fd);
+  } catch {
+    // Closing the file handle is the authoritative release path.
+  }
+}
+
+async function readTaskRunLedgerHeader(path: string): Promise<TaskRunLedgerHeader> {
+  return parseTaskRunLedgerHeader(await readFirstDurableLine(path), path);
+}
+
+async function truncatePartialTaskRunTail(path: string): Promise<void> {
+  const handle = await open(path, 'r+');
+  try {
+    const { size } = await handle.stat();
+    let position = size;
+    while (position > 0) {
+      const length = Math.min(position, 4096);
+      position -= length;
+      const buffer = Buffer.allocUnsafe(length);
+      let bytesRead = 0;
+      while (bytesRead < length) {
+        const read = await handle.read(buffer, bytesRead, length - bytesRead, position + bytesRead);
+        if (read.bytesRead === 0) {
+          throw new Error(`TaskRun ledger ${path} changed while repairing its tail`);
+        }
+        bytesRead += read.bytesRead;
+      }
+      const newline = buffer.lastIndexOf(0x0a);
+      if (newline === -1) continue;
+      const durableSize = position + newline + 1;
+      if (durableSize < size) {
+        await handle.truncate(durableSize);
+        await handle.sync();
+      }
+      return;
+    }
+    throw new Error(`TaskRun ledger ${path} has no durable record`);
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readFirstDurableLine(path: string): Promise<string | undefined> {
+  const handle = await open(path, 'r');
+  const chunks: Buffer[] = [];
+  let position = 0;
+  try {
+    while (true) {
+      const buffer = Buffer.allocUnsafe(4096);
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, position);
+      if (bytesRead === 0) return undefined;
+      const bytes = buffer.subarray(0, bytesRead);
+      const newline = bytes.indexOf(0x0a);
+      chunks.push(newline === -1 ? bytes : bytes.subarray(0, newline));
+      if (newline !== -1) return Buffer.concat(chunks).toString('utf8');
+      position += bytesRead;
+    }
+  } finally {
+    await handle.close();
+  }
+}
+
+function durableJsonlLines(content: string): string[] {
+  return content.endsWith('\n') ? content.split('\n') : content.split('\n').slice(0, -1);
 }
 
 function taskEventCursor(taskRunId: string, sequence: number, eventId: string): ExecutionLogCursor {
   return { ledger: 'task_event', streamId: taskRunId, sequence, eventId };
-}
-
-function validTaskAttemptExecutionEvidence(
-  event: Extract<TaskEvent, { type: 'task_attempt_execution_linked' }>,
-  warnings: string[],
-): ExecutionEvidenceRef | undefined {
-  const validation = validateExecutionEvidenceRef(event.evidence);
-  if (!validation.ok) {
-    warnings.push(
-      `ignored execution lineage ${event.id}: ${validation.errors.map((issue) => `${issue.path}: ${issue.message}`).join('; ')}`,
-    );
-    return undefined;
-  }
-  const evidence = validation.value;
-  if (evidence.task?.taskRunId !== event.taskRunId || evidence.task.attemptId !== event.attemptId) {
-    warnings.push(
-      `ignored execution lineage ${event.id}: task identity does not match the owning attempt`,
-    );
-    return undefined;
-  }
-  if (!evidence.execution?.agentRunId) {
-    warnings.push(`ignored execution lineage ${event.id}: execution.agentRunId is required`);
-    return undefined;
-  }
-  return evidence;
-}
-
-function validHeavyTaskEvidenceProvenance(
-  event: Extract<TaskEvent, { type: 'heavy_task_evidence_provenance_linked' }>,
-  subject: HeavyTaskCompactEvidenceEnvelope,
-  warnings: string[],
-): ExecutionEvidenceRef | undefined {
-  const validation = validateExecutionEvidenceRef(event.provenance);
-  if (!validation.ok) {
-    warnings.push(
-      `ignored evidence provenance ${event.id}: ${validation.errors
-        .map((issue) => `${issue.path}: ${issue.message}`)
-        .join('; ')}`,
-    );
-    return undefined;
-  }
-  const provenance = validation.value;
-  if (provenance.task?.taskRunId !== event.taskRunId) {
-    warnings.push(
-      `ignored evidence provenance ${event.id}: task identity does not match the owning TaskRun`,
-    );
-    return undefined;
-  }
-  const attemptId = event.attemptId;
-  if (
-    (subject.attemptId && event.attemptId !== subject.attemptId) ||
-    provenance.task?.attemptId !== attemptId
-  ) {
-    warnings.push(
-      `ignored evidence provenance ${event.id}: attempt identity does not match the evidence`,
-    );
-    return undefined;
-  }
-  if (!provenance.execution?.agentRunId || !provenance.runtimeCoverage) {
-    warnings.push(
-      `ignored evidence provenance ${event.id}: AgentRun identity and Runtime coverage are required`,
-    );
-    return undefined;
-  }
-  if (
-    (subject.source.sessionId && subject.source.sessionId !== provenance.execution.sessionId) ||
-    (subject.source.agentRunId && subject.source.agentRunId !== provenance.execution.agentRunId) ||
-    (subject.source.turnId && subject.source.turnId !== provenance.execution.turnId)
-  ) {
-    warnings.push(
-      `ignored evidence provenance ${event.id}: Runtime identity does not match the evidence source`,
-    );
-    return undefined;
-  }
-  return provenance;
-}
-
-function validHeavyTaskSelfCheckProvenance(
-  event: Extract<TaskEvent, { type: 'heavy_task_self_check_evidence_linked' }>,
-  selfCheck: HeavyTaskSelfCheckProjection,
-  selfCheckSequence: number,
-  selfCheckEventId: string,
-  observationRow: { sequence: number; observation: HeavyTaskWorkspaceObservationState } | undefined,
-  warnings: string[],
-): ExecutionEvidenceRef | undefined {
-  const validation = validateExecutionEvidenceRef(event.provenance);
-  if (!validation.ok) {
-    warnings.push(
-      `ignored self-check evidence link ${event.id}: ${validation.errors
-        .map((issue) => `${issue.path}: ${issue.message}`)
-        .join('; ')}`,
-    );
-    return undefined;
-  }
-  const provenance = validation.value;
-  if (
-    provenance.task?.taskRunId !== event.taskRunId ||
-    provenance.task.attemptId !== event.attemptId ||
-    selfCheck.taskRunId !== event.taskRunId ||
-    selfCheck.attemptId !== event.attemptId
-  ) {
-    warnings.push(
-      `ignored self-check evidence link ${event.id}: TaskRun or attempt identity does not match`,
-    );
-    return undefined;
-  }
-  if (
-    !provenance.execution?.agentRunId ||
-    !provenance.runtimeCoverage ||
-    !provenance.taskCoverage ||
-    !provenance.workspace
-  ) {
-    warnings.push(
-      `ignored self-check evidence link ${event.id}: Runtime coverage, Task coverage, and workspace revision are required`,
-    );
-    return undefined;
-  }
-  if (
-    (selfCheck.source.sessionId && selfCheck.source.sessionId !== provenance.execution.sessionId) ||
-    (selfCheck.source.agentRunId &&
-      selfCheck.source.agentRunId !== provenance.execution.agentRunId) ||
-    (selfCheck.source.turnId && selfCheck.source.turnId !== provenance.execution.turnId)
-  ) {
-    warnings.push(
-      `ignored self-check evidence link ${event.id}: Runtime identity does not match the Self-check source`,
-    );
-    return undefined;
-  }
-  const taskHighWater = provenance.taskCoverage.highWater;
-  if (
-    taskHighWater.ledger !== 'task_event' ||
-    taskHighWater.streamId !== event.taskRunId ||
-    taskHighWater.sequence !== selfCheckSequence ||
-    taskHighWater.eventId !== selfCheckEventId
-  ) {
-    warnings.push(
-      `ignored self-check evidence link ${event.id}: Task high water does not identify the Self-check record`,
-    );
-    return undefined;
-  }
-  if (
-    !observationRow ||
-    observationRow.sequence <= selfCheckSequence ||
-    observationRow.observation.status !== 'ok' ||
-    !observationRow.observation.revision
-  ) {
-    warnings.push(
-      `ignored self-check evidence link ${event.id}: referenced post-check workspace observation is missing`,
-    );
-    return undefined;
-  }
-  if (!sameWorkspaceRevision(provenance.workspace, observationRow.observation.revision)) {
-    warnings.push(
-      `ignored self-check evidence link ${event.id}: workspace revision does not match the referenced observation`,
-    );
-    return undefined;
-  }
-  return provenance;
-}
-
-function refreshHeavyTaskSelfCheckFreshness(
-  projection: TaskRunProjection,
-  events: readonly TaskEvent[],
-  observationRows: ReadonlyMap<
-    string,
-    { sequence: number; observation: HeavyTaskWorkspaceObservationState }
-  >,
-): void {
-  projection.heavyTaskSelfChecks = projection.heavyTaskSelfChecks.map((selfCheck) => {
-    if (!selfCheck.provenance || !selfCheck.workspaceObservationId) {
-      return withSelfCheckFreshness(selfCheck, 'unknown', ['source_binding_missing']);
-    }
-    const baseline = observationRows.get(selfCheck.workspaceObservationId);
-    if (!baseline?.observation.revision) {
-      return withSelfCheckFreshness(selfCheck, 'unknown', ['workspace_observation_missing']);
-    }
-    const laterObservations = [...observationRows.values()]
-      .filter(
-        (row) =>
-          row.sequence >= baseline.sequence &&
-          row.observation.status === 'ok' &&
-          row.observation.revision,
-      )
-      .sort((left, right) => left.sequence - right.sequence);
-    const latestObservation = laterObservations.at(-1) ?? baseline;
-    if (
-      !sameWorkspaceRevision(selfCheck.provenance.workspace, latestObservation.observation.revision)
-    ) {
-      return withSelfCheckFreshness(selfCheck, 'stale', ['workspace_revision_changed']);
-    }
-    const hasLaterMutation = events.some(
-      (event, sequence) =>
-        sequence > latestObservation.sequence &&
-        invalidatesSelfCheckWorkspace(event, selfCheck.attemptId),
-    );
-    if (hasLaterMutation) {
-      return withSelfCheckFreshness(selfCheck, 'stale', ['later_workspace_mutation']);
-    }
-    return withSelfCheckFreshness(selfCheck, 'current', []);
-  });
-  projection.latestHeavyTaskSelfCheck = projection.heavyTaskSelfChecks.at(-1);
-}
-
-function withSelfCheckFreshness(
-  selfCheck: HeavyTaskSelfCheckProjection,
-  freshness: HeavyTaskSelfCheckProjection['freshness'],
-  freshnessReasons: HeavyTaskSelfCheckFreshnessReason[],
-): HeavyTaskSelfCheckProjection {
-  return { ...selfCheck, freshness, freshnessReasons };
-}
-
-function invalidatesSelfCheckWorkspace(event: TaskEvent, attemptId: string | undefined): boolean {
-  if (event.type !== 'heavy_task_evidence_recorded') return false;
-  if (!attemptId || event.evidence.attemptId !== attemptId) return false;
-  if (event.evidence.kind === 'artifact') return true;
-  if (event.evidence.kind !== 'tool') return false;
-  return ['Bash', 'Write', 'Edit'].includes(
-    event.evidence.tool?.name ?? event.evidence.source.toolName ?? '',
-  );
-}
-
-function sameWorkspaceRevision(
-  left: ExecutionEvidenceRef['workspace'],
-  right: ExecutionEvidenceRef['workspace'],
-): boolean {
-  return Boolean(
-    left &&
-      right &&
-      left.kind === right.kind &&
-      left.ref === right.ref &&
-      left.dirty === right.dirty,
-  );
-}
-
-function resultFromScore(
-  score: ScoreResult | undefined,
-  verifier: VerifierResult | undefined,
-): TaskRunResult | undefined {
-  if (!score) return undefined;
-  return {
-    passed: score.passed,
-    taxonomy: score.taxonomy,
-    ...(verifier ? { verifierResultId: verifier.id } : {}),
-    scoreResultId: score.id,
-  };
-}
-
-function resultFromVerifier(verifier: VerifierResult): TaskRunResult {
-  return {
-    passed: verifier.passed,
-    taxonomy: verifier.passed ? 'passed' : 'verification_failed',
-    verifierResultId: verifier.id,
-  };
-}
-
-function preferredVerifierResult(results: readonly VerifierResult[]): VerifierResult | undefined {
-  return preferredByAuthority(results);
-}
-
-function preferredScoreResult(
-  results: readonly ScoreResult[],
-  verifier: VerifierResult | undefined,
-): ScoreResult | undefined {
-  if (
-    verifier?.authority?.authoritative === true &&
-    !results.some((result) => result.authority?.authoritative === true)
-  ) {
-    return undefined;
-  }
-  return preferredByAuthority(results);
-}
-
-function preferredByAuthority<T extends { authority?: { authoritative: boolean }; ts: number }>(
-  results: readonly T[],
-): T | undefined {
-  const authoritative = results.filter((result) => result.authority?.authoritative === true);
-  if (authoritative.length > 0) return authoritative[authoritative.length - 1];
-  const nonPlaceholder = results.filter((result) => result.authority?.authoritative !== false);
-  if (nonPlaceholder.length > 0) return nonPlaceholder[nonPlaceholder.length - 1];
-  return results[results.length - 1];
-}
-
-function applyTerminalEvent(projection: TaskRunProjection, terminalEvents: number): number {
-  if (terminalEvents > 0) {
-    projection.warnings.push(
-      'multiple terminal task run events observed; last terminal event wins',
-    );
-  }
-  delete projection.parked;
-  return terminalEvents + 1;
-}
-
-function appendCompactEvidence(
-  projection: TaskRunProjection,
-  ...evidence: HeavyTaskCompactEvidenceEnvelope[]
-): boolean {
-  let ok = true;
-  for (const item of evidence) {
-    if (item.public !== true || item.taskRunId !== projection.taskRunId) {
-      ok = false;
-      continue;
-    }
-    if (item.provenance) {
-      projection.warnings.push(
-        `ignored embedded provenance on heavy-task evidence ${item.evidenceId}: a provenance link event is required`,
-      );
-    }
-    const { provenance: _embeddedProvenance, ...unlinked } = item;
-    projection.heavyTaskEvidence.push(unlinked);
-    projection.latestHeavyTaskEvidence = unlinked;
-  }
-  return ok;
-}
-
-function selfCheckEvidenceIdFactory(selfCheckId: string): () => string {
-  let index = 0;
-  return () => `${selfCheckId}:compact-${++index}`;
-}
-
-function isCompactEvidenceEligibleArtifact(artifact: TaskRunArtifact): boolean {
-  return (
-    (artifact.authority.source === 'runtime' || artifact.authority.source === 'self_check') &&
-    artifact.authority.authoritative !== true
-  );
-}
-
-function hasHeavyTaskCompletionState(projection: TaskRunProjection): boolean {
-  return (
-    projection.heavyTaskMode?.enabled === true ||
-    projection.heavyTaskInventory.length > 0 ||
-    projection.heavyTaskTodoStates.length > 0 ||
-    projection.heavyTaskSelfCheckPlans.length > 0 ||
-    projection.heavyTaskSelfChecks.length > 0 ||
-    projection.heavyTaskEvidence.length > 0
-  );
-}
-
-function safeFileId(id: string): string {
-  return id.replace(/[^A-Za-z0-9._-]/g, '_') || '_';
 }
 
 function isNotFound(error: unknown): boolean {

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -2,9 +2,10 @@ import { randomUUID } from 'node:crypto';
 import type { AgentRunHeader } from '@maka/core/agent-run';
 import type { SessionHeader, StoredMessage } from '@maka/core/session';
 import { classifyTerminalRuntimeLedger, type SessionManager } from '@maka/runtime';
-import type {
-  InteractiveExecutionStoresWriter,
-  RootTurnAdmission,
+import {
+  authenticateExecutionStoresWriter,
+  type ExecutionStoresWriter,
+  type RootTurnAdmission,
 } from '@maka/storage/execution-stores';
 import type {
   OperationOutcome,
@@ -54,13 +55,16 @@ export class RootTurnCoordinator {
   readonly #activeBySession = new Map<string, ActiveRootTurn>();
   readonly #sessionGateTails = new Map<string, Promise<void>>();
   readonly #recoveryAdmissionsBySession = new Map<string, readonly RootTurnAdmission[]>();
+  private readonly stores: ExecutionStoresWriter<'interactive'>;
 
   constructor(
     private readonly manager: SessionManager,
-    private readonly stores: InteractiveExecutionStoresWriter,
+    stores: ExecutionStoresWriter<'interactive'>,
     private readonly acquireRecoveryResidency: () => RuntimeHostResidency,
     private readonly requestHostDrain: () => void,
-  ) {}
+  ) {
+    this.stores = authenticateExecutionStoresWriter(stores, 'interactive');
+  }
 
   async prepareRecovery(): Promise<void> {
     const sessions = await this.stores.sessionStore.listForRecovery();

--- a/packages/runtime/src/agent-run-inspect.ts
+++ b/packages/runtime/src/agent-run-inspect.ts
@@ -64,17 +64,35 @@ export interface InspectAgentRunOptions {
   sessionId: string;
   runId: string;
   header?: AgentRunHeader;
+  isFatalReadError?: (error: unknown) => boolean;
 }
 
+export type AgentRunInspectReader = Pick<AgentRunStore, 'readRun' | 'readEvents'>;
+
+export type SessionAgentRunInspectReader = AgentRunInspectReader &
+  Pick<AgentRunStore, 'listSessionRuns'>;
+
+export type RuntimeEventInspectReader = Pick<RuntimeEventStore, 'readRuntimeEvents'>;
+
 export async function inspectAgentRunReadModel(
-  runStore: AgentRunStore,
-  runtimeEventStore: RuntimeEventStore,
+  runStore: AgentRunInspectReader,
+  runtimeEventStore: RuntimeEventInspectReader,
   options: InspectAgentRunOptions,
 ): Promise<AgentRunInspectModel> {
   const header = options.header ?? (await runStore.readRun(options.sessionId, options.runId));
   const diagnostics: AgentRunInspectDiagnostic[] = [];
-  const events = await readOperationalEvents(runStore, header, diagnostics);
-  const runtimeRead = await readRuntimeEvents(runtimeEventStore, header, diagnostics);
+  const events = await readOperationalEvents(
+    runStore,
+    header,
+    diagnostics,
+    options.isFatalReadError,
+  );
+  const runtimeRead = await readRuntimeEvents(
+    runtimeEventStore,
+    header,
+    diagnostics,
+    options.isFatalReadError,
+  );
   const runtimeEvents = runtimeRead.events;
 
   const operationalTerminalEvent = latestOperationalTerminalEvent(events);
@@ -164,9 +182,10 @@ export async function inspectAgentRunReadModel(
 }
 
 export async function inspectSessionRunReadModels(
-  runStore: AgentRunStore,
-  runtimeEventStore: RuntimeEventStore,
+  runStore: SessionAgentRunInspectReader,
+  runtimeEventStore: RuntimeEventInspectReader,
   sessionId: string,
+  options: Pick<InspectAgentRunOptions, 'isFatalReadError'> = {},
 ): Promise<AgentRunInspectModel[]> {
   const headers = await runStore.listSessionRuns(sessionId);
   const models: AgentRunInspectModel[] = [];
@@ -176,6 +195,7 @@ export async function inspectSessionRunReadModels(
         sessionId,
         runId: header.runId,
         header,
+        ...(options.isFatalReadError ? { isFatalReadError: options.isFatalReadError } : {}),
       }),
     );
   }
@@ -183,9 +203,10 @@ export async function inspectSessionRunReadModels(
 }
 
 async function readOperationalEvents(
-  runStore: AgentRunStore,
+  runStore: AgentRunInspectReader,
   header: AgentRunHeader,
   diagnostics: AgentRunInspectDiagnostic[],
+  isFatalReadError: InspectAgentRunOptions['isFatalReadError'],
 ): Promise<AgentRunEvent[]> {
   try {
     const events = await runStore.readEvents(header.sessionId, header.runId);
@@ -203,6 +224,7 @@ async function readOperationalEvents(
     }
     return events;
   } catch (error) {
+    if (isFatalReadError?.(error)) throw error;
     diagnostics.push(
       inspectDiagnostic(
         header,
@@ -216,9 +238,10 @@ async function readOperationalEvents(
 }
 
 async function readRuntimeEvents(
-  runtimeEventStore: RuntimeEventStore,
+  runtimeEventStore: RuntimeEventInspectReader,
   header: AgentRunHeader,
   diagnostics: AgentRunInspectDiagnostic[],
+  isFatalReadError: InspectAgentRunOptions['isFatalReadError'],
 ): Promise<{ state: AgentRunInspectSourceHealth['runtimeLedger']; events: RuntimeEvent[] }> {
   try {
     const events = await runtimeEventStore.readRuntimeEvents(header.sessionId, header.runId);
@@ -234,6 +257,7 @@ async function readRuntimeEvents(
     }
     return { state: 'present', events };
   } catch (error) {
+    if (isFatalReadError?.(error)) throw error;
     diagnostics.push(
       inspectDiagnostic(
         header,

--- a/packages/runtime/src/execution-inspect.ts
+++ b/packages/runtime/src/execution-inspect.ts
@@ -1,15 +1,13 @@
-import type {
-  AgentRunHeader,
-  AgentRunStore,
-  RuntimeEvent,
-  RuntimeEventStore,
-  SessionHeader,
-} from '@maka/core';
+import type { AgentRunHeader, RuntimeEvent, SessionHeader } from '@maka/core';
 import type { ExecutionLogCoverage } from '@maka/core/execution-evidence';
 import {
   inspectAgentRunReadModel,
+  type AgentRunInspectReader,
   type AgentRunInspectDiagnostic as SourceDiagnostic,
   type AgentRunInspectSourceHealth,
+  type InspectAgentRunOptions,
+  type RuntimeEventInspectReader,
+  type SessionAgentRunInspectReader,
 } from './agent-run-inspect.js';
 import {
   validateHistoryCompactCheckpointShape,
@@ -115,15 +113,26 @@ export interface SessionHeaderReader {
   readHeader(sessionId: string): Promise<SessionHeader>;
 }
 
+export interface InspectSessionDocumentOptions {
+  header?: SessionHeader;
+  isFatalReadError?: InspectAgentRunOptions['isFatalReadError'];
+}
+
 export async function inspectAgentRunDocument(
-  runStore: AgentRunStore,
-  runtimeEventStore: RuntimeEventStore,
-  input: { sessionId: string; agentRunId: string; header?: AgentRunHeader },
+  runStore: AgentRunInspectReader,
+  runtimeEventStore: RuntimeEventInspectReader,
+  input: {
+    sessionId: string;
+    agentRunId: string;
+    header?: AgentRunHeader;
+    isFatalReadError?: InspectAgentRunOptions['isFatalReadError'];
+  },
 ): Promise<AgentRunInspectDocument> {
   const model = await inspectAgentRunReadModel(runStore, runtimeEventStore, {
     sessionId: input.sessionId,
     runId: input.agentRunId,
     ...(input.header ? { header: input.header } : {}),
+    ...(input.isFatalReadError ? { isFatalReadError: input.isFatalReadError } : {}),
   });
   const diagnostics = model.diagnostics.map((item) => sourceDiagnostic(model.header, item));
   const tools = inspectTools(model.header, model.runtimeEvents, diagnostics);
@@ -152,12 +161,12 @@ export async function inspectAgentRunDocument(
 
 export async function inspectSessionDocument(
   sessionStore: SessionHeaderReader,
-  runStore: AgentRunStore,
-  runtimeEventStore: RuntimeEventStore,
+  runStore: SessionAgentRunInspectReader,
+  runtimeEventStore: RuntimeEventInspectReader,
   sessionId: string,
-  header?: SessionHeader,
+  options: InspectSessionDocumentOptions = {},
 ): Promise<SessionInspectDocument> {
-  const resolvedHeader = header ?? (await sessionStore.readHeader(sessionId));
+  const resolvedHeader = options.header ?? (await sessionStore.readHeader(sessionId));
   const runHeaders = await runStore.listSessionRuns(sessionId);
   const agentRuns: AgentRunInspectDocument[] = [];
   for (const runHeader of runHeaders) {
@@ -166,6 +175,7 @@ export async function inspectSessionDocument(
         sessionId,
         agentRunId: runHeader.runId,
         header: runHeader,
+        ...(options.isFatalReadError ? { isFatalReadError: options.isFatalReadError } : {}),
       }),
     );
   }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1001,10 +1001,13 @@ export {
 export type {
   AgentRunInspectDiagnostic,
   AgentRunInspectDiagnosticCode,
+  AgentRunInspectReader,
   AgentRunInspectModel,
   AgentRunInspectProjectionSummary,
   AgentRunInspectSourceHealth,
   InspectAgentRunOptions,
+  RuntimeEventInspectReader,
+  SessionAgentRunInspectReader,
 } from './agent-run-inspect.js';
 
 // execution-inspect.ts — payload-safe, versioned CLI inspection documents.
@@ -1024,6 +1027,7 @@ export type {
   AgentRunInspectToolSummary,
   ExecutionInspectDiagnostic,
   ExecutionInspectSeverity,
+  InspectSessionDocumentOptions,
   SessionHeaderReader,
   SessionInspectDocument,
   SessionInspectSummary,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -8,7 +8,8 @@
   "exports": {
     ".": "./dist/index.js",
     "./execution-stores": "./dist/execution-stores.js",
-    "./root-authority": "./dist/root-authority.js"
+    "./root-authority": "./dist/root-authority.js",
+    "./write-queue": "./dist/write-queue.js"
   },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",

--- a/packages/storage/src/__tests__/execution-stores.test.ts
+++ b/packages/storage/src/__tests__/execution-stores.test.ts
@@ -15,18 +15,123 @@ import { describe, test } from 'node:test';
 import type { AgentRunEvent, AgentRunHeader, RuntimeEvent } from '@maka/core';
 import { createAgentRunStore } from '../agent-run-store.js';
 import {
+  authenticateExecutionStoresReader,
+  authenticateExecutionStoresWriter,
+  openHeadlessExecutionStoresForRead,
+  openHeadlessExecutionStoresForWrite,
   openInteractiveExecutionStoresForRead,
   openInteractiveExecutionStoresForWrite,
 } from '../execution-stores.js';
 import {
+  createHeadlessRootLease,
   resolveStorageRoot,
   StorageRootAuthorityError,
   tryAcquireInteractiveRootOwner,
   tryAcquireInteractiveRootReader,
+  type StorageRootLease,
 } from '../root-authority.js';
 import { createSessionStore } from '../session-store.js';
 
-describe('interactive execution stores', () => {
+describe('execution stores', () => {
+  test('binds Headless execution readers and writers to Headless leases', async () => {
+    await withRoot(async ({ base, root }) => {
+      const capability = await resolveStorageRoot({
+        path: root,
+        kind: 'headless',
+      });
+      const writer = await openHeadlessExecutionStoresForWrite(
+        createHeadlessRootLease(capability, 'write'),
+      );
+      assert.equal(writer.kind, 'headless');
+      const session = await writer.sessionStore.create(sessionInput(root));
+      await writer.sessionStore.appendMessage(session.id, {
+        type: 'user',
+        id: 'message-1',
+        turnId: 'turn-1',
+        ts: 10,
+        text: 'hello',
+      });
+
+      const reader = await openHeadlessExecutionStoresForRead(
+        createHeadlessRootLease(capability, 'read'),
+      );
+      assert.equal(reader.kind, 'headless');
+      assert.equal((await reader.sessionStore.list()).length, 1);
+      assert.equal((await reader.sessionStore.readMessages(session.id))[0]?.id, 'message-1');
+
+      const interactive = await resolveStorageRoot({
+        path: join(base, 'interactive'),
+        kind: 'interactive',
+      });
+      const owner = await tryAcquireInteractiveRootOwner(interactive);
+      assert.ok(owner);
+      if (!owner) return;
+      try {
+        await assert.rejects(
+          () =>
+            openHeadlessExecutionStoresForWrite(
+              owner.lease as unknown as StorageRootLease<'headless', 'write'>,
+            ),
+          (error: unknown) =>
+            error instanceof StorageRootAuthorityError && error.code === 'invalid_lease',
+        );
+      } finally {
+        await owner.close();
+      }
+    });
+  });
+
+  test('freezes and authenticates execution store facades', async () => {
+    await withRoot(async ({ base, root }) => {
+      const capability = await resolveStorageRoot({
+        path: root,
+        kind: 'headless',
+      });
+      const writer = await openHeadlessExecutionStoresForWrite(
+        createHeadlessRootLease(capability, 'write'),
+      );
+      const session = await writer.sessionStore.create(sessionInput(root));
+      const reader = await openHeadlessExecutionStoresForRead(
+        createHeadlessRootLease(capability, 'read'),
+      );
+      const rawLocalStore = createSessionStore(root);
+
+      assert.equal(Reflect.set(reader, 'sessionStore', rawLocalStore), false);
+      assert.equal(
+        Reflect.set(
+          reader.sessionStore,
+          'readHeader',
+          rawLocalStore.readHeader.bind(rawLocalStore),
+        ),
+        false,
+      );
+      await reader.sessionStore.readHeader(session.id);
+      assert.equal((await rawLocalStore.readHeaderSnapshot(session.id)).connectionLocked, false);
+
+      const otherRoot = join(base, 'other-headless');
+      await resolveStorageRoot({ path: otherRoot, kind: 'headless' });
+      const rawOtherStore = createSessionStore(otherRoot);
+      assert.equal(Reflect.set(writer, 'sessionStore', rawOtherStore), false);
+      assert.equal(
+        Reflect.set(writer.sessionStore, 'create', rawOtherStore.create.bind(rawOtherStore)),
+        false,
+      );
+
+      const copiedReader = { ...reader, sessionStore: rawLocalStore };
+      assert.throws(
+        () => authenticateExecutionStoresReader(copiedReader, 'headless'),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'invalid_lease',
+      );
+      const copiedWriter = { ...writer, sessionStore: rawOtherStore };
+      assert.throws(
+        () => authenticateExecutionStoresWriter(copiedWriter, 'headless'),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'invalid_lease',
+      );
+    });
+  });
+
   test('commits root-turn admission before Run creation and retains its original identity', async () => {
     await withRoot(async ({ root }) => {
       const capability = await resolveStorageRoot({
@@ -38,6 +143,7 @@ describe('interactive execution stores', () => {
       if (!owner) return;
       try {
         const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+        assert.equal(stores.kind, 'interactive');
         const session = await stores.sessionStore.create(sessionInput(root));
         const first = await stores.agentRunStore.admitRootTurn({
           sessionId: session.id,

--- a/packages/storage/src/__tests__/root-authority.test.ts
+++ b/packages/storage/src/__tests__/root-authority.test.ts
@@ -11,6 +11,7 @@ import {
   rename,
   rm,
   symlink,
+  utimes,
   writeFile,
 } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -20,6 +21,7 @@ import {
   assertStorageRootCapability,
   assertStorageRootLease,
   createHeadlessRootLease,
+  discoverMarkedStorageRoot,
   prepareStorageRootControlDirectory,
   resolveExistingStorageRoot,
   resolveRootControlNamespace,
@@ -34,6 +36,66 @@ import {
 } from '../root-authority.js';
 
 describe('storage root authority', () => {
+  test('discovers only marked roots without creating or changing filesystem state', async () => {
+    await withRoots(async ({ base, root }) => {
+      for (const [kind, markedRoot] of [
+        ['interactive', root],
+        ['headless', join(base, 'headless')],
+      ] as const) {
+        await mkdir(markedRoot, { recursive: true });
+        const initialized = await resolveStorageRoot({ path: markedRoot, kind });
+        const payloadPath = join(markedRoot, 'payload.txt');
+        await writeFile(payloadPath, 'preserve me');
+        const fixedTime = new Date('2020-01-02T03:04:05.000Z');
+        await utimes(join(markedRoot, STORAGE_ROOT_MARKER_FILE), fixedTime, fixedTime);
+        await utimes(payloadPath, fixedTime, fixedTime);
+        await utimes(markedRoot, fixedTime, fixedTime);
+        const before = await snapshotFlatRoot(markedRoot);
+
+        const discovered = await discoverMarkedStorageRoot({ path: markedRoot });
+        assert.equal(discovered.kind, kind);
+        assert.equal(discovered.rootId, initialized.rootId);
+        assert.equal(discovered.canonicalPath, initialized.canonicalPath);
+        assert.deepEqual(await snapshotFlatRoot(markedRoot), before);
+      }
+
+      const unmarked = join(base, 'unmarked');
+      await mkdir(unmarked);
+      const unmarkedBefore = await snapshotFlatRoot(unmarked);
+      await assert.rejects(
+        () => discoverMarkedStorageRoot({ path: unmarked }),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'root_unmarked',
+      );
+      assert.deepEqual(await snapshotFlatRoot(unmarked), unmarkedBefore);
+
+      const missing = join(base, 'missing');
+      await assert.rejects(
+        () => discoverMarkedStorageRoot({ path: missing }),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'root_not_found',
+      );
+      await assert.rejects(lstat(missing), { code: 'ENOENT' });
+    });
+  });
+
+  test('rejects an existing wrong-kind root without transient marker writes', async () => {
+    await withRoots(async ({ root }) => {
+      await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const fixedTime = new Date('2020-01-02T03:04:05.000Z');
+      await utimes(join(root, STORAGE_ROOT_MARKER_FILE), fixedTime, fixedTime);
+      await utimes(root, fixedTime, fixedTime);
+      const before = await snapshotFlatRoot(root);
+
+      await assert.rejects(
+        () => resolveStorageRoot({ path: root, kind: 'headless' }),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'root_kind_mismatch',
+      );
+      assert.deepEqual(await snapshotFlatRoot(root), before);
+    });
+  });
+
   test('canonicalizes aliases and gives them one ownership identity', async () => {
     await withRoots(async ({ base, root }) => {
       const alias = join(base, 'alias');
@@ -81,7 +143,7 @@ describe('storage root authority', () => {
             expectedRootId: initialized.rootId,
           }),
         (error: unknown) =>
-          error instanceof StorageRootAuthorityError && error.code === 'invalid_marker',
+          error instanceof StorageRootAuthorityError && error.code === 'root_unmarked',
       );
       await assert.rejects(readFile(join(root, STORAGE_ROOT_MARKER_FILE)), { code: 'ENOENT' });
     });
@@ -490,6 +552,26 @@ describe('storage root authority', () => {
     });
   });
 });
+
+async function snapshotFlatRoot(root: string): Promise<{
+  entries: Array<{ name: string; content: string; mtimeNs: bigint }>;
+  mtimeNs: bigint;
+}> {
+  const names = (await readdir(root)).sort();
+  const entries = await Promise.all(
+    names.map(async (name) => {
+      const path = join(root, name);
+      const stats = await lstat(path, { bigint: true });
+      return {
+        name,
+        content: stats.isFile() ? await readFile(path, 'utf8') : '',
+        mtimeNs: stats.mtimeNs,
+      };
+    }),
+  );
+  const rootStats = await lstat(root, { bigint: true });
+  return { entries, mtimeNs: rootStats.mtimeNs };
+}
 
 async function withRoots(
   run: (input: { base: string; root: string }) => Promise<void>,

--- a/packages/storage/src/artifact-attachments.ts
+++ b/packages/storage/src/artifact-attachments.ts
@@ -8,7 +8,7 @@ import {
 import type { ArtifactStore } from './artifact-store.js';
 
 export function createAttachmentByteReader(input: {
-  artifactStore: ArtifactStore;
+  artifactStore: Pick<ArtifactStore, 'get' | 'readBinary'>;
   sessionId: string;
   maxBytes?: number;
 }): AttachmentByteReader {
@@ -26,7 +26,7 @@ export function createAttachmentByteReader(input: {
   };
 }
 
-export function createReadImageSnapshotter(artifactStore: ArtifactStore) {
+export function createReadImageSnapshotter(artifactStore: Pick<ArtifactStore, 'create'>) {
   return async (input: {
     sessionId: string;
     turnId: string;

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -22,32 +22,41 @@ import { createSessionStore, type SessionStore } from './session-store.js';
 import {
   assertStorageRootLease,
   runWithStorageRootLease,
+  StorageRootAuthorityError,
+  type StorageRootKind,
   type StorageRootLease,
 } from './root-authority.js';
+
+const executionStoresWriterBrand: unique symbol = Symbol('ExecutionStoresWriter');
+const executionStoresReaderBrand: unique symbol = Symbol('ExecutionStoresReader');
+const executionStoresWriterKinds = new WeakMap<object, StorageRootKind>();
+const executionStoresReaderKinds = new WeakMap<object, StorageRootKind>();
 
 export type {
   RootTurnAdmission,
   RootTurnAdmissionInput,
 } from './agent-run-store.js';
 
-export type InteractiveExecutionSessionWriter = SessionStore;
-export type InteractiveExecutionAgentRunWriter = DurableAgentRunStore;
-export type InteractiveExecutionRuntimeEventWriter = DurableRuntimeEventStore;
+export type ExecutionSessionWriter = SessionStore;
+export type ExecutionAgentRunWriter = DurableAgentRunStore;
+export type ExecutionRuntimeEventWriter = DurableRuntimeEventStore;
 
-export interface InteractiveExecutionStoresWriter {
-  sessionStore: InteractiveExecutionSessionWriter;
-  agentRunStore: InteractiveExecutionAgentRunWriter;
-  runtimeEventStore: InteractiveExecutionRuntimeEventWriter;
+export interface ExecutionStoresWriter<K extends StorageRootKind> {
+  readonly kind: K;
+  readonly [executionStoresWriterBrand]: K;
+  readonly sessionStore: Readonly<ExecutionSessionWriter>;
+  readonly agentRunStore: Readonly<ExecutionAgentRunWriter>;
+  readonly runtimeEventStore: Readonly<ExecutionRuntimeEventWriter>;
 }
 
-export interface InteractiveExecutionSessionReader {
+export interface ExecutionSessionReader {
   list(filter?: SessionListFilter): Promise<SessionSummary[]>;
   readHeader(sessionId: string): Promise<SessionHeader>;
   readMessages(sessionId: string): Promise<StoredMessage[]>;
   listTurns(sessionId: string): Promise<TurnRecord[]>;
 }
 
-export interface InteractiveExecutionAgentRunReader {
+export interface ExecutionAgentRunReader {
   readRun(sessionId: string, runId: string): Promise<AgentRunHeader>;
   listSessionRuns(sessionId: string): Promise<AgentRunHeader[]>;
   readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]>;
@@ -58,29 +67,66 @@ export interface InteractiveExecutionAgentRunReader {
   readRootTurnAdmission(sessionId: string, turnId: string): Promise<RootTurnAdmission | undefined>;
 }
 
-export interface InteractiveExecutionRuntimeEventReader {
+export interface ExecutionRuntimeEventReader {
   readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
   readImmutableRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
   readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]>;
 }
 
-export interface InteractiveExecutionStoresReader {
-  sessionStore: InteractiveExecutionSessionReader;
-  agentRunStore: InteractiveExecutionAgentRunReader;
-  runtimeEventStore: InteractiveExecutionRuntimeEventReader;
+export interface ExecutionStoresReader<K extends StorageRootKind> {
+  readonly kind: K;
+  readonly [executionStoresReaderBrand]: K;
+  readonly sessionStore: Readonly<ExecutionSessionReader>;
+  readonly agentRunStore: Readonly<ExecutionAgentRunReader>;
+  readonly runtimeEventStore: Readonly<ExecutionRuntimeEventReader>;
+}
+
+export function authenticateExecutionStoresWriter<K extends StorageRootKind>(
+  stores: ExecutionStoresWriter<K>,
+  expectedKind: K,
+): ExecutionStoresWriter<K> {
+  if (executionStoresWriterKinds.get(stores) !== expectedKind) {
+    throw invalidExecutionStores(expectedKind, 'write');
+  }
+  return stores;
+}
+
+export function authenticateExecutionStoresReader<K extends StorageRootKind>(
+  stores: ExecutionStoresReader<K>,
+  expectedKind: K,
+): ExecutionStoresReader<K> {
+  if (executionStoresReaderKinds.get(stores) !== expectedKind) {
+    throw invalidExecutionStores(expectedKind, 'read');
+  }
+  return stores;
 }
 
 export async function openInteractiveExecutionStoresForWrite(
   lease: StorageRootLease<'interactive', 'write'>,
-): Promise<InteractiveExecutionStoresWriter> {
-  await assertStorageRootLease(lease, 'interactive', 'write');
+): Promise<ExecutionStoresWriter<'interactive'>> {
+  return openExecutionStoresForWrite(lease, 'interactive');
+}
+
+export async function openHeadlessExecutionStoresForWrite(
+  lease: StorageRootLease<'headless', 'write'>,
+): Promise<ExecutionStoresWriter<'headless'>> {
+  return openExecutionStoresForWrite(lease, 'headless');
+}
+
+async function openExecutionStoresForWrite<K extends StorageRootKind>(
+  lease: StorageRootLease<K, 'write'>,
+  kind: K,
+): Promise<ExecutionStoresWriter<K>> {
+  await assertStorageRootLease(lease, kind, 'write');
   const sessionStore = createSessionStore(lease.canonicalPath);
   const agentRunStore = createAgentRunStore(lease.canonicalPath);
   const runtimeEventStore = createRuntimeEventStore(lease.canonicalPath);
   const run = <T>(operation: () => Promise<T>) =>
-    runWithStorageRootLease(lease, 'interactive', 'write', operation);
+    runWithStorageRootLease(lease, kind, 'write', operation);
 
-  return {
+  const stores: ExecutionStoresWriter<K> = {
+    kind,
+    [executionStoresWriterBrand]: kind,
     sessionStore: {
       create: (input) => run(() => sessionStore.create(input)),
       list: (filter) => run(() => sessionStore.list(filter)),
@@ -146,19 +192,37 @@ export async function openInteractiveExecutionStoresForWrite(
         run(() => runtimeEventStore.readSessionRuntimeEvents(sessionId)),
     },
   };
+  freezeExecutionStoresFacade(stores);
+  executionStoresWriterKinds.set(stores, kind);
+  return stores;
 }
 
 export async function openInteractiveExecutionStoresForRead(
   lease: StorageRootLease<'interactive', 'read'>,
-): Promise<InteractiveExecutionStoresReader> {
-  await assertStorageRootLease(lease, 'interactive', 'read');
+): Promise<ExecutionStoresReader<'interactive'>> {
+  return openExecutionStoresForRead(lease, 'interactive');
+}
+
+export async function openHeadlessExecutionStoresForRead(
+  lease: StorageRootLease<'headless', 'read'>,
+): Promise<ExecutionStoresReader<'headless'>> {
+  return openExecutionStoresForRead(lease, 'headless');
+}
+
+async function openExecutionStoresForRead<K extends StorageRootKind>(
+  lease: StorageRootLease<K, 'read'>,
+  kind: K,
+): Promise<ExecutionStoresReader<K>> {
+  await assertStorageRootLease(lease, kind, 'read');
   const sessionStore = createSessionStore(lease.canonicalPath);
   const agentRunStore = createAgentRunStore(lease.canonicalPath);
   const runtimeEventStore = createRuntimeEventStore(lease.canonicalPath);
   const run = <T>(operation: () => Promise<T>) =>
-    runWithStorageRootLease(lease, 'interactive', 'read', operation);
+    runWithStorageRootLease(lease, kind, 'read', operation);
 
-  return {
+  const stores: ExecutionStoresReader<K> = {
+    kind,
+    [executionStoresReaderBrand]: kind,
     sessionStore: {
       list: (filter) => run(() => sessionStore.list(filter)),
       readHeader: (sessionId) => run(() => sessionStore.readHeaderSnapshot(sessionId)),
@@ -183,4 +247,28 @@ export async function openInteractiveExecutionStoresForRead(
         run(() => runtimeEventStore.readSessionRuntimeEvents(sessionId)),
     },
   };
+  freezeExecutionStoresFacade(stores);
+  executionStoresReaderKinds.set(stores, kind);
+  return stores;
+}
+
+function freezeExecutionStoresFacade(stores: {
+  readonly sessionStore: object;
+  readonly agentRunStore: object;
+  readonly runtimeEventStore: object;
+}): void {
+  Object.freeze(stores.sessionStore);
+  Object.freeze(stores.agentRunStore);
+  Object.freeze(stores.runtimeEventStore);
+  Object.freeze(stores);
+}
+
+function invalidExecutionStores(
+  kind: StorageRootKind,
+  access: 'read' | 'write',
+): StorageRootAuthorityError {
+  return new StorageRootAuthorityError(
+    'invalid_lease',
+    `Expected authentic ${kind} ${access} execution stores`,
+  );
 }

--- a/packages/storage/src/provider-request-capture-artifact.ts
+++ b/packages/storage/src/provider-request-capture-artifact.ts
@@ -12,7 +12,7 @@ export interface PersistProviderRequestCaptureArtifactInput {
 }
 
 export function persistProviderRequestCaptureArtifact(
-  store: ArtifactStore,
+  store: Pick<ArtifactStore, 'create'>,
   input: PersistProviderRequestCaptureArtifactInput,
 ): Promise<ArtifactRecord> {
   return store.create({

--- a/packages/storage/src/root-authority.ts
+++ b/packages/storage/src/root-authority.ts
@@ -31,6 +31,10 @@ export interface StorageRootCapability<K extends StorageRootKind = StorageRootKi
   readonly [capabilityBrand]: true;
 }
 
+export type DiscoveredStorageRootCapability =
+  | StorageRootCapability<'interactive'>
+  | StorageRootCapability<'headless'>;
+
 export interface StorageRootLease<
   K extends StorageRootKind = StorageRootKind,
   A extends StorageRootAccess = StorageRootAccess,
@@ -45,6 +49,10 @@ export interface StorageRootLease<
 export interface ResolveStorageRootInput<K extends StorageRootKind> {
   path: string;
   kind: K;
+}
+
+export interface DiscoverStorageRootInput {
+  path: string;
 }
 
 export interface ResolveExistingStorageRootInput<K extends StorageRootKind>
@@ -108,6 +116,8 @@ const interactiveRootLocks = new WeakMap<object, { access: StorageRootAccess }>(
 export type StorageRootAuthorityErrorCode =
   | 'invalid_root'
   | 'invalid_root_kind'
+  | 'root_not_found'
+  | 'root_unmarked'
   | 'invalid_marker'
   | 'root_kind_mismatch'
   | 'root_identity_collision'
@@ -150,6 +160,26 @@ export async function resolveStorageRoot<K extends StorageRootKind>(
   );
 }
 
+export async function discoverMarkedStorageRoot(
+  input: DiscoverStorageRootInput,
+): Promise<DiscoveredStorageRootCapability> {
+  return withAuthorityFailure('root_io_failed', 'Unable to discover the storage root', async () => {
+    const { canonicalPath, rootStat } = await resolveExistingRootPath(input.path);
+
+    const identity = { dev: rootStat.dev, ino: rootStat.ino };
+    const marker = await confirmRootSnapshot({
+      root: canonicalPath,
+      identity,
+      readMarker: () => readRootMarker(canonicalPath),
+      markerMismatchCode: 'root_identity_collision',
+      markerMismatchMessage: `Storage root marker belongs to a different directory: ${canonicalPath}`,
+    });
+    return marker.kind === 'interactive'
+      ? createCapability('interactive', canonicalPath, marker.rootId, identity)
+      : createCapability('headless', canonicalPath, marker.rootId, identity);
+  });
+}
+
 async function resolveStorageRootUnchecked<K extends StorageRootKind>(
   input: ResolveStorageRootInput<K>,
 ): Promise<StorageRootCapability<K>> {
@@ -183,14 +213,7 @@ export async function resolveExistingStorageRoot<K extends StorageRootKind>(
     'root_io_failed',
     'Unable to resolve the existing storage root',
     async () => {
-      const canonicalPath = canonicalizePath(await realpath(resolve(input.path)));
-      const rootStat = await stat(canonicalPath, { bigint: true });
-      if (!rootStat.isDirectory()) {
-        throw new StorageRootAuthorityError(
-          'invalid_root',
-          `Storage root is not a directory: ${canonicalPath}`,
-        );
-      }
+      const { canonicalPath, rootStat } = await resolveExistingRootPath(input.path);
       const identity = { dev: rootStat.dev, ino: rootStat.ino };
       const marker = await confirmRootSnapshot({
         root: canonicalPath,
@@ -203,6 +226,43 @@ export async function resolveExistingStorageRoot<K extends StorageRootKind>(
       return createCapability(input.kind, canonicalPath, marker.rootId, identity);
     },
   );
+}
+
+async function resolveExistingRootPath(path: string): Promise<{
+  canonicalPath: string;
+  rootStat: BigIntStats;
+}> {
+  let canonicalPath: string;
+  try {
+    canonicalPath = canonicalizePath(await realpath(resolve(path)));
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      throw new StorageRootAuthorityError(
+        'root_not_found',
+        `Storage root does not exist: ${resolve(path)}`,
+      );
+    }
+    throw error;
+  }
+  let rootStat: BigIntStats;
+  try {
+    rootStat = await stat(canonicalPath, { bigint: true });
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      throw new StorageRootAuthorityError(
+        'root_not_found',
+        `Storage root does not exist: ${resolve(path)}`,
+      );
+    }
+    throw error;
+  }
+  if (!rootStat.isDirectory()) {
+    throw new StorageRootAuthorityError(
+      'invalid_root',
+      `Storage root is not a directory: ${canonicalPath}`,
+    );
+  }
+  return { canonicalPath, rootStat };
 }
 
 function createCapability<K extends StorageRootKind>(
@@ -543,11 +603,6 @@ async function assertRootIdentity(record: CapabilityRecord): Promise<void> {
     'root_io_failed',
     `Unable to validate storage root identity: ${record.canonicalPath}`,
     async () => {
-      await assertRootPathIdentity(
-        record.canonicalPath,
-        record.identity,
-        `Storage root identity changed: ${record.canonicalPath}`,
-      );
       await confirmRootSnapshot({
         root: record.canonicalPath,
         identity: record.identity,
@@ -570,18 +625,22 @@ interface ConfirmRootSnapshotInput {
 }
 
 async function confirmRootSnapshot(input: ConfirmRootSnapshotInput): Promise<RootMarker> {
-  const marker = await input.readMarker();
+  const identityChangedMessage = `Storage root identity changed while validating its marker: ${input.root}`;
+  await assertRootPathIdentity(input.root, input.identity, identityChangedMessage);
+  let marker: RootMarker;
+  try {
+    marker = await input.readMarker();
+  } catch (error) {
+    await assertRootPathIdentity(input.root, input.identity, identityChangedMessage);
+    throw error;
+  }
+  await assertRootPathIdentity(input.root, input.identity, identityChangedMessage);
   if (
     (input.expectedRootId !== undefined && marker.rootId !== input.expectedRootId) ||
     !markerMatchesIdentity(marker, input.identity)
   ) {
     throw new StorageRootAuthorityError(input.markerMismatchCode, input.markerMismatchMessage);
   }
-  await assertRootPathIdentity(
-    input.root,
-    input.identity,
-    `Storage root identity changed while validating its marker: ${input.root}`,
-  );
   return marker;
 }
 
@@ -591,6 +650,13 @@ async function ensureRootMarker(
   identity: RootIdentity,
 ): Promise<RootMarker> {
   const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
+  try {
+    await lstat(markerPath);
+    return await readAndValidateRootMarker(root, kind);
+  } catch (error) {
+    if (!isNodeError(error, 'ENOENT')) throw error;
+  }
+
   const marker: RootMarker = {
     schemaVersion: STORAGE_ROOT_MARKER_SCHEMA_VERSION,
     kind,
@@ -649,6 +715,17 @@ async function readAndValidateRootMarker(
   root: string,
   expectedKind: StorageRootKind,
 ): Promise<RootMarker> {
+  const marker = await readRootMarker(root);
+  if (marker.kind !== expectedKind) {
+    throw new StorageRootAuthorityError(
+      'root_kind_mismatch',
+      `Storage root ${root} is ${marker.kind}, not ${expectedKind}`,
+    );
+  }
+  return marker;
+}
+
+async function readRootMarker(root: string): Promise<RootMarker> {
   const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
   let marker: unknown;
   try {
@@ -676,6 +753,9 @@ async function readAndValidateRootMarker(
     }
   } catch (error) {
     if (error instanceof StorageRootAuthorityError) throw error;
+    if (isNodeError(error, 'ENOENT')) {
+      throw new StorageRootAuthorityError('root_unmarked', `Storage root is not marked: ${root}`);
+    }
     if (error instanceof SyntaxError || isInvalidMarkerPathError(error)) {
       throw new StorageRootAuthorityError(
         'invalid_marker',
@@ -689,12 +769,6 @@ async function readAndValidateRootMarker(
     throw new StorageRootAuthorityError(
       'invalid_marker',
       `Invalid storage root marker at ${markerPath}`,
-    );
-  }
-  if (marker.kind !== expectedKind) {
-    throw new StorageRootAuthorityError(
-      'root_kind_mismatch',
-      `Storage root ${root} is ${marker.kind}, not ${expectedKind}`,
     );
   }
   return marker;


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

This PR establishes the complete kind-bound Storage authority and Headless execution boundary tracked by #1167:

- execution Store readers and writers are opened only from an authentic `interactive` or `headless` root lease, and every operation revalidates that lease before reaching the filesystem;
- read and write facades expose only the methods required by their access mode, are frozen, and retain unforgeable kind identity;
- the Headless runtime receives one authenticated aggregate for TaskRun, Session/AgentRun/RuntimeEvent, and artifact access instead of constructing raw Stores independently;
- TaskRun persistence uses a content-addressed locator, a durable identity header, a real cross-process file lock, and bounded torn-tail repair;
- Headless, Harbor, export, resume, and inspection paths consume the same authority boundary;
- `maka inspect` discovers the persisted root kind without mutating the root, acquires the appropriate read authority, and renders expected authority failures as actionable CLI errors rather than fatal stacks.

## Boundary and decisions

Root kind is a storage fact, not a caller hint. `discoverMarkedStorageRoot()` reads and authenticates an existing marker without initializing or repairing the target. A caller cannot inspect an unmarked directory as Headless or temporarily rewrite a marker to select a different owner.

Initialization belongs to the writer: the first writer establishes an unmarked root's declared kind, while read paths never initialize or relabel it. Desktop now initializes its shared workspace as `interactive` before opening its current raw Stores, and E2E reseeding restores the same marker after replacing the workspace. This establishes root identity without changing Desktop's pre-M5 writer ownership. Kind is not inferred from directory-shape heuristics because Interactive and Headless roots share execution Store layout.

Execution Store facades are capability-derived rather than structurally trusted. The Storage package creates and authenticates them, binds their methods to the root lease, and keeps the Interactive and Headless types distinct. This closes the path where a correctly shaped object or a raw Store could bypass kind and lease checks.

`HeadlessStorageWriter` is the production composition boundary for Headless execution. It groups the TaskRun ledger, execution Stores, and the bounded artifact surface under one Headless write lease. Consumers receive the aggregate or a narrowed reader/writer interface; they do not reopen ownership through a path string.

TaskRun durability is part of this slice because Headless cannot have a complete writer boundary while its canonical ledger remains process-local. Raw task IDs no longer become path segments. The durable header binds the requested identity to the hashed locator, the native lock serializes independent processes, and repair is limited to an unterminated tail before the next append. Complete malformed event records are retained as `event_corrupt` entries and surfaced as projection warnings; malformed headers, locator mismatches, and cross-run event identities fail closed.

This is an intentional hard cut for an unreleased format. Pre-locator TaskRun ledgers and legacy export paths have no migration, dual-read path, or compatibility alias; development artifacts using those layouts must be regenerated.

Inspection remains observational. Headless inspection opens the authenticated read aggregate; Interactive inspection acquires the existing shared reader lease. Runtime inspection helpers accept narrowed reader contracts and preserve authority failures instead of downgrading them to missing optional evidence. `maka inspect` and `maka eval task-run inspect/export` report an incorrect or uninitialized root with command-specific recovery guidance.

## Scope

This PR does not move Interactive domains into the Runtime Host, add protocol operations, change Desktop production ownership, or implement the bounded-shutdown foundation. Existing production Interactive entrypoints remain the sole Interactive writers. The shutdown foundation remains the next prerequisite before extracting any Host-owned domain slice.

## Validation

Real filesystem and process tests cover kind separation, forged/stale capabilities, observational discovery, independent TaskRun writers, durable identity, torn-tail repair, Headless producer/consumer wiring, production producer-to-CLI-inspect flow, and actionable authority diagnostics. Desktop fixture coverage verifies that workspace replacement preserves the Interactive root marker. Storage, Runtime, Headless, CLI, and Desktop checks pass together with root build, typecheck, lint, and format checks.

Tracked by #1167. Architectural context: #853.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

本 PR 完整建立 #1167 所追踪的 kind-bound Storage authority 与 Headless execution boundary：

- execution Store 的 reader/writer 只能由真实的 `interactive` 或 `headless` root lease 打开，并且每次操作在访问文件系统前都会重新验证 lease；
- read/write facade 只暴露各自访问模式所需的方法，保持冻结，并携带不可伪造的 kind identity；
- Headless runtime 通过一个经过认证的 aggregate 访问 TaskRun、Session/AgentRun/RuntimeEvent 与 artifact，不再各自从路径构造 raw Store；
- TaskRun 持久化使用内容寻址 locator、durable identity header、真实跨进程文件锁与有界的 torn-tail repair；
- Headless、Harbor、export、resume 与 inspect 路径共用同一 authority boundary；
- `maka inspect` 在不修改 root 的前提下发现已持久化的 root kind，取得相应 read authority，并将预期内的 authority failure 呈现为可行动的 CLI 错误，而不是 fatal stack。

## 边界与决策

root kind 是 storage fact，而不是 caller hint。`discoverMarkedStorageRoot()` 只读取并认证已有 marker，不会初始化或修复目标目录。调用方不能把未标记目录当作 Headless inspect，也不能通过临时改写 marker 选择另一个 owner。

初始化属于 writer：第一个 writer 为未标记 root 建立其声明的 kind，而 read path 永远不会初始化或改标。Desktop 现在会在打开现有 raw Store 之前将共享 workspace 初始化为 `interactive`；E2E fixture 替换 workspace 后也会恢复同一 marker。这只建立 root identity，不改变 M5 前 Desktop 的 writer ownership。Interactive 与 Headless root 共用 execution Store 目录布局，因此 kind 不通过目录形状启发式推断。

Execution Store facade 来自 capability，而不是依赖结构类型判断。Storage package 负责创建和认证 facade，将每个方法绑定到 root lease，并在类型上区分 Interactive 与 Headless。这关闭了“形状正确的对象”或 raw Store 绕过 kind/lease 检查的路径。

`HeadlessStorageWriter` 是 production Headless execution 的组合边界。它在同一个 Headless write lease 下组合 TaskRun ledger、execution Stores 与有界 artifact surface。消费者接收 aggregate 或收窄后的 reader/writer interface，不会再通过 path string 重新打开 ownership。

TaskRun durability 属于本 slice，因为 canonical ledger 如果仍只有进程内互斥，Headless writer boundary 就不完整。raw task ID 不再直接成为路径片段；durable header 会把请求 identity 绑定到 hash locator，native lock 会串行化独立进程，repair 只允许在下一次 append 前修复未终止的 tail。完整但 malformed 的 event record 会保留为 `event_corrupt` 并以 projection warning 呈现；malformed header、locator mismatch 与跨 TaskRun event identity 则保持 fail closed。

这是针对未发布格式的有意 hard cut。pre-locator TaskRun ledger 与旧 export path 不提供 migration、dual-read path 或兼容 alias；采用旧布局的开发期产物需要重新生成。

inspect 保持 observational。Headless inspect 打开经过认证的 read aggregate；Interactive inspect 取得已有的 shared reader lease。Runtime inspect helper 接收收窄后的 reader contract，并保留 authority failure，不再把它降级为 optional evidence 缺失。`maka inspect` 与 `maka eval task-run inspect/export` 会针对错误或未初始化的 root 给出与命令对应的恢复提示。

## 范围

本 PR 不把 Interactive 领域迁入 Runtime Host，不增加 protocol operation，不改变 Desktop production ownership，也不实现 bounded-shutdown foundation。现有 production Interactive entrypoint 仍是唯一 Interactive writer。shutdown foundation 继续作为任何 Host-owned domain slice 开始前的下一项前置条件。

## 验证

真实文件系统与进程测试覆盖 kind 隔离、伪造或 stale capability、observational discovery、独立 TaskRun writer、durable identity、torn-tail repair、Headless producer/consumer 接线、production producer 到 CLI inspect 的完整路径，以及可行动的 authority 诊断。Desktop fixture 覆盖会验证 workspace 被替换后仍保留 Interactive root marker。Storage、Runtime、Headless、CLI 与 Desktop 检查通过，同时根级 build、typecheck、lint 与 format check 通过。

由 #1167 跟踪；架构背景见 #853。

</details>
