### PR TITLE
feat(runtime-host): bound shutdown with process fail-stop

### DIFF
--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -216,7 +216,8 @@ test('graceful Host shutdown stops and drains an active Turn before releasing ow
       text: FAKE_ASK_USER_QUESTION_PROMPT,
     });
 
-    await fixture.stopHost(host);
+    const exit = await fixture.stopHost(host);
+    assert.deepEqual(exit, { code: 0, signal: null });
     await client.closed;
 
     const successor = await fixture.startHost();
@@ -602,12 +603,19 @@ class ExecutionFixture {
     await owner?.close();
   }
 
-  async stopHost(host: ExecutionHostHandle): Promise<void> {
+  async stopHost(
+    host: ExecutionHostHandle,
+  ): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
     if (host.child.exitCode === null && host.child.signalCode === null) {
       host.child.kill('SIGTERM');
     }
-    await withTimeout(waitForExit(host.child), PROCESS_TIMEOUT_MS, 'execution Host did not stop');
+    const exit = await withTimeout(
+      waitForExitResult(host.child),
+      PROCESS_TIMEOUT_MS,
+      'execution Host did not stop',
+    );
     this.#children.delete(host.child);
+    return exit;
   }
 
   async killHost(host: ExecutionHostHandle): Promise<void> {
@@ -886,6 +894,30 @@ function waitForExit(child: ChildProcess): Promise<void> {
   return new Promise((resolve, reject) => {
     child.once('error', reject);
     child.once('exit', () => resolve());
+  });
+}
+
+function waitForExitResult(
+  child: ChildProcess,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  }
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      child.off('error', onError);
+      child.off('exit', onExit);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      resolve({ code, signal });
+    };
+    child.once('error', onError);
+    child.once('exit', onExit);
   });
 }
 

--- a/packages/runtime-host/src/__tests__/fixtures/execution-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host.ts
@@ -1,4 +1,5 @@
 import { startExecutionRuntimeHostCandidate } from '../../server/execution-candidate.js';
+import { runRuntimeHostProcessLifecycle } from '../../server/process-lifecycle.js';
 
 const [rootPath, expectedRootId, idleGraceRaw] = process.argv.slice(2);
 if (!rootPath || !expectedRootId || !/^[a-f0-9]{64}$/.test(expectedRootId)) {
@@ -22,17 +23,8 @@ process.send?.({
   endpoint: result.host.endpoint,
 });
 
-let closing = false;
-const close = () => {
-  if (closing) return;
-  closing = true;
-  void result.host.close();
-};
-process.once('SIGINT', close);
-process.once('SIGTERM', close);
-process.once('disconnect', close);
 try {
-  await result.host.closed;
+  await runRuntimeHostProcessLifecycle(result.host, { closeOnDisconnect: true });
 } catch {
   process.exitCode = 1;
 } finally {

--- a/packages/runtime-host/src/__tests__/fixtures/uncooperative-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/uncooperative-host.ts
@@ -1,0 +1,66 @@
+import {
+  resolveExistingStorageRoot,
+  tryAcquireInteractiveRootOwner,
+} from '@maka/storage/root-authority';
+import { RuntimeHostKernel, type RuntimeHostComposition } from '../../server/host-kernel.js';
+import { runRuntimeHostProcessLifecycle } from '../../server/process-lifecycle.js';
+
+const [rootPath, expectedRootId, shutdownGraceRaw] = process.argv.slice(2);
+if (!rootPath || !expectedRootId || !/^[a-f0-9]{64}$/.test(expectedRootId)) {
+  throw new Error('usage: uncooperative-host <root> <expected-root-id> <shutdown-grace-ms>');
+}
+const shutdownGraceMs = Number(shutdownGraceRaw);
+if (!Number.isSafeInteger(shutdownGraceMs) || shutdownGraceMs <= 0) {
+  throw new Error('uncooperative-host requires a positive shutdown grace');
+}
+
+const capability = await resolveExistingStorageRoot({
+  path: rootPath,
+  kind: 'interactive',
+  expectedRootId,
+});
+const owner = await tryAcquireInteractiveRootOwner(capability);
+if (!owner) throw new Error('uncooperative-host could not acquire the Interactive root');
+
+const host = await RuntimeHostKernel.start({
+  owner,
+  idleGraceMs: 60_000,
+  shutdownGraceMs,
+  compositionFactory: async (context): Promise<RuntimeHostComposition> => ({
+    handlers: {
+      'turn.start': async () => {
+        context.acquireResidency();
+        process.send?.({ type: 'operation-blocked' });
+        return new Promise<never>(() => undefined);
+      },
+      'turn.query': async () => ({
+        ok: false,
+        error: { code: 'operation_unavailable', message: 'Operation unavailable in test Host' },
+      }),
+      'turn.stop': async () => ({
+        ok: false,
+        error: { code: 'operation_unavailable', message: 'Operation unavailable in test Host' },
+      }),
+    },
+    async recover() {},
+    async close() {},
+  }),
+});
+
+process.on('message', (message: unknown) => {
+  if (
+    message &&
+    typeof message === 'object' &&
+    (message as { type?: unknown }).type === 'shutdown'
+  ) {
+    void host.close();
+    process.send?.({ type: 'shutdown-requested' });
+  }
+});
+process.send?.({ type: 'ready', hostEpoch: host.hostEpoch, endpoint: host.endpoint });
+
+try {
+  await runRuntimeHostProcessLifecycle(host, { closeOnDisconnect: true });
+} catch {
+  process.exitCode = 1;
+}

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -713,6 +713,112 @@ describe('non-serving Runtime Host kernel', () => {
     });
   });
 
+  test('forces an uncooperative command Host to exit before a successor acquires ownership', {
+    timeout: 10_000,
+  }, async () => {
+    await withHostPaths(async (paths) => {
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      const child = paths.resources.trackChild(
+        fork(
+          new URL('./fixtures/uncooperative-host.js', import.meta.url),
+          [paths.root, capability.rootId, '2000'],
+          { stdio: ['ignore', 'ignore', 'inherit', 'ipc'] },
+        ),
+      );
+      let transport: FramedTransport | undefined;
+      try {
+        const ready = await waitForUncooperativeHostMessage(child, 'ready');
+        transport = new FramedTransport(await openSocket(ready.endpoint));
+        await transport.write({
+          kind: 'hello',
+          clientInstanceId: 'bounded-shutdown-test',
+          surface: 'tui',
+          protocolMin: CURRENT_PROTOCOL.min,
+          protocolMax: CURRENT_PROTOCOL.max,
+        });
+        const handshake = decodeHostFrame(await transport.read(2_000));
+        assert.ok('kind' in handshake);
+        assert.equal(handshake.kind, 'accepted');
+
+        const blocked = waitForUncooperativeHostMessage(child, 'operation-blocked');
+        await transport.write({
+          requestId: 'blocked-turn-start',
+          operation: 'turn.start',
+          input: { sessionId: 'session', turnId: 'turn', text: 'block forever' },
+        });
+        await blocked;
+        const shutdownRequested = waitForUncooperativeHostMessage(child, 'shutdown-requested');
+        child.send({ type: 'shutdown' });
+        await shutdownRequested;
+
+        await transport.write({
+          requestId: 'post-drain-status',
+          operation: 'host.status',
+          input: {},
+        });
+        const rejectedOperation = decodeHostFrame(await transport.read(1_000));
+        assert.ok(!('kind' in rejectedOperation));
+        if (!('kind' in rejectedOperation)) {
+          assert.equal(rejectedOperation.requestId, 'post-drain-status');
+          assert.equal(rejectedOperation.operation, 'host.status');
+          assert.equal(rejectedOperation.ok, false);
+          if (!rejectedOperation.ok) assert.equal(rejectedOperation.error.code, 'host_draining');
+        }
+
+        const rejectedHandshakeTransport = new FramedTransport(await openSocket(ready.endpoint));
+        try {
+          await rejectedHandshakeTransport.write({
+            kind: 'hello',
+            clientInstanceId: 'post-drain-client',
+            surface: 'inspect',
+            protocolMin: CURRENT_PROTOCOL.min,
+            protocolMax: CURRENT_PROTOCOL.max,
+          });
+          assert.deepEqual(decodeHostFrame(await rejectedHandshakeTransport.read(1_000)), {
+            kind: 'draining',
+            hostEpoch: ready.hostEpoch,
+          });
+        } finally {
+          rejectedHandshakeTransport.destroy();
+        }
+
+        assert.equal(child.exitCode, null);
+        assert.equal(child.signalCode, null);
+        const contender = await tryAcquireInteractiveRootOwner(capability);
+        try {
+          assert.equal(contender, undefined);
+        } finally {
+          await contender?.close();
+        }
+        const exit = await withTimeout(
+          waitForChildExitResult(child),
+          5_000,
+          'uncooperative Runtime Host did not exit within its shutdown bound',
+        );
+        assert.deepEqual(exit, { code: 1, signal: null });
+
+        const successor = await startTestRuntimeHostCandidate(paths, {
+          rootPath: paths.root,
+          idleGraceMs: 10_000,
+        });
+        assert.equal(successor.kind, 'winner');
+        if (successor.kind !== 'winner') return;
+        assert.notEqual(successor.host.hostEpoch, ready.hostEpoch);
+        const connected = await retryConnect(paths, CURRENT_PROTOCOL);
+        assert.equal(connected.kind, 'connected');
+        if (connected.kind !== 'connected') return;
+        const status = await connected.connection.status();
+        assert.equal(status.hostEpoch, successor.host.hostEpoch);
+        await connected.connection.close();
+        await successor.host.close();
+      } finally {
+        transport?.destroy();
+        if (child.exitCode === null && child.signalCode === null) child.kill('SIGKILL');
+        await withTimeout(waitForExit(child), 1_000, 'uncooperative Host cleanup did not exit');
+      }
+    });
+  });
+
   test('startup rejects invalid lifecycle durations and releases the owner lock', async () => {
     await withHostPaths(async (paths) => {
       await assert.rejects(
@@ -729,6 +835,16 @@ describe('non-serving Runtime Host kernel', () => {
             rootPath: paths.root,
             handshakeTimeoutMs: 0,
           }),
+        RangeError,
+      );
+      const capability = await resolveStorageRoot({ path: paths.root, kind: 'interactive' });
+      const owner = paths.resources.trackCloseable(
+        await tryAcquireInteractiveRootOwner(capability),
+      );
+      assert.ok(owner);
+      if (!owner) return;
+      await assert.rejects(
+        () => RuntimeHostKernel.start({ owner, shutdownGraceMs: 0 }),
         RangeError,
       );
       const retry = await startTestRuntimeHostCandidate(paths, {
@@ -1197,6 +1313,80 @@ function isElectronParentLaunch(
     Number.isSafeInteger(message.pid) &&
     (message.pid as number) > 0
   );
+}
+
+type UncooperativeHostMessage =
+  | { type: 'ready'; hostEpoch: string; endpoint: string }
+  | { type: 'operation-blocked' }
+  | { type: 'shutdown-requested' };
+
+function waitForUncooperativeHostMessage<T extends UncooperativeHostMessage['type']>(
+  child: ChildProcess,
+  type: T,
+): Promise<Extract<UncooperativeHostMessage, { type: T }>> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      cleanup();
+      reject(new Error(`uncooperative Host did not report ${type}`));
+    }, 5_000);
+    const cleanup = () => {
+      clearTimeout(timer);
+      child.off('error', onError);
+      child.off('exit', onExit);
+      child.off('message', onMessage);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      reject(new Error(`uncooperative Host exited before ${type}: ${code ?? signal}`));
+    };
+    const onMessage = (message: unknown) => {
+      if (!isUncooperativeHostMessage(message) || message.type !== type) return;
+      cleanup();
+      resolve(message as Extract<UncooperativeHostMessage, { type: T }>);
+    };
+    child.once('error', onError);
+    child.once('exit', onExit);
+    child.on('message', onMessage);
+  });
+}
+
+function isUncooperativeHostMessage(value: unknown): value is UncooperativeHostMessage {
+  if (!value || typeof value !== 'object') return false;
+  const message = value as Record<string, unknown>;
+  if (message.type === 'operation-blocked' || message.type === 'shutdown-requested') return true;
+  return (
+    message.type === 'ready' &&
+    typeof message.hostEpoch === 'string' &&
+    typeof message.endpoint === 'string'
+  );
+}
+
+function waitForChildExitResult(
+  child: ChildProcess,
+): Promise<{ code: number | null; signal: NodeJS.Signals | null }> {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve({ code: child.exitCode, signal: child.signalCode });
+  }
+  return new Promise((resolve, reject) => {
+    const cleanup = () => {
+      child.off('error', onError);
+      child.off('exit', onExit);
+    };
+    const onError = (error: Error) => {
+      cleanup();
+      reject(error);
+    };
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      cleanup();
+      resolve({ code, signal });
+    };
+    child.once('error', onError);
+    child.once('exit', onExit);
+  });
 }
 
 function waitForExit(child: ChildProcess): Promise<void> {

--- a/packages/runtime-host/src/candidate-main.ts
+++ b/packages/runtime-host/src/candidate-main.ts
@@ -1,20 +1,13 @@
 #!/usr/bin/env node
 import { startRuntimeHostCandidate, type RuntimeHostCandidateOptions } from './server/candidate.js';
+import { runRuntimeHostProcessLifecycle } from './server/process-lifecycle.js';
 
 const options = parseArguments(process.argv.slice(2));
 const result = await startRuntimeHostCandidate(options);
 if (result.kind === 'loser') process.exit(2);
 
-let closing = false;
-const close = () => {
-  if (closing) return;
-  closing = true;
-  void result.host.close();
-};
-process.once('SIGINT', close);
-process.once('SIGTERM', close);
 try {
-  await result.host.closed;
+  await runRuntimeHostProcessLifecycle(result.host);
 } catch {
   process.exitCode = 1;
 }

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -33,6 +33,7 @@ import {
 
 const DEFAULT_IDLE_GRACE_MS = 30_000;
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 5_000;
+const DEFAULT_SHUTDOWN_GRACE_MS = 10_000;
 const SHUTDOWN_HANDSHAKE_GRACE_MS = 1_000;
 const SHUTDOWN_OPERATION_GRACE_MS = 1_000;
 const HOST_PROTOCOL = {
@@ -41,6 +42,15 @@ const HOST_PROTOCOL = {
 } as const;
 
 export type RuntimeHostResidency = OperationResidency;
+
+export class RuntimeHostProcessTerminationRequiredError extends Error {
+  readonly code = 'process_termination_required';
+
+  constructor(readonly shutdownGraceMs: number) {
+    super(`Runtime Host did not shut down within ${shutdownGraceMs} ms`);
+    this.name = 'RuntimeHostProcessTerminationRequiredError';
+  }
+}
 
 export interface RuntimeHostCompositionContext {
   owner: InteractiveRootOwner;
@@ -62,6 +72,7 @@ export interface RuntimeHostKernelOptions {
   owner: InteractiveRootOwner;
   idleGraceMs?: number;
   handshakeTimeoutMs?: number;
+  shutdownGraceMs?: number;
   compositionFactory?: RuntimeHostCompositionFactory;
 }
 
@@ -77,6 +88,7 @@ export class RuntimeHostKernel {
   readonly #residencyDrainWaiters = new Set<() => void>();
   readonly #idleGraceMs: number;
   readonly #handshakeTimeoutMs: number;
+  readonly #shutdownGraceMs: number;
   #endpoint: RuntimeHostEndpoint | undefined;
   #state: HostLifecycleState = 'starting';
   #activeOperations = 0;
@@ -87,6 +99,8 @@ export class RuntimeHostKernel {
   #idleTimer: NodeJS.Timeout | undefined;
   #shutdownRequested = false;
   #shutdownTask: Promise<void> | undefined;
+  #shutdownDeadlineTimer: NodeJS.Timeout | undefined;
+  #terminationRequired: RuntimeHostProcessTerminationRequiredError | undefined;
   #resolveClosed!: () => void;
   #rejectClosed!: (error: unknown) => void;
 
@@ -97,8 +111,10 @@ export class RuntimeHostKernel {
       'handshakeTimeoutMs',
       1,
     );
+    assertDuration(options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS, 'shutdownGraceMs', 1);
     this.#idleGraceMs = options.idleGraceMs ?? DEFAULT_IDLE_GRACE_MS;
     this.#handshakeTimeoutMs = options.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS;
+    this.#shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
     this.#options = options;
     this.#operationHandlers = this.#createOperationHandlers(unavailableDomainHandlers());
     this.closed = new Promise((resolve, reject) => {
@@ -116,6 +132,7 @@ export class RuntimeHostKernel {
         owner,
         idleGraceMs: options.idleGraceMs,
         handshakeTimeoutMs: options.handshakeTimeoutMs,
+        shutdownGraceMs: options.shutdownGraceMs,
         compositionFactory: options.compositionFactory,
       });
       await host.#start();
@@ -146,8 +163,11 @@ export class RuntimeHostKernel {
   }
 
   #requestDrain(): void {
-    this.#shutdownRequested = true;
-    this.#cancelIdle();
+    if (!this.#shutdownRequested) {
+      this.#shutdownRequested = true;
+      this.#cancelIdle();
+      this.#armShutdownDeadline();
+    }
     this.#commitRequestedShutdownIfQuiescent();
   }
 
@@ -228,10 +248,10 @@ export class RuntimeHostKernel {
     hello: ClientHello,
     transport: FramedTransport,
   ): Promise<HostHandshakeResult> {
-    if (!(await this.#hasLiveOwnerOrDrain()) || this.#state === 'draining') {
+    const admittedState = await this.#readAdmissionState();
+    if (!admittedState) {
       return { kind: 'draining', hostEpoch: this.hostEpoch };
     }
-    const admittedState = this.#state;
     const selectedProtocol = negotiateProtocol(
       { min: hello.protocolMin, max: hello.protocolMax },
       HOST_PROTOCOL,
@@ -268,10 +288,7 @@ export class RuntimeHostKernel {
   async #beginOperation(
     frame: RequestFrame,
   ): Promise<ConnectionOperationLease | HostOperationErrorCode> {
-    if (!(await this.#hasLiveOwnerOrDrain()) || this.#state === 'draining') return 'host_draining';
-    if (this.#shutdownRequested && HOST_OPERATION_SPECS[frame.operation].mode === 'command') {
-      return 'host_draining';
-    }
+    if (!(await this.#readAdmissionState())) return 'host_draining';
     if (
       HOST_OPERATION_SPECS[frame.operation].admission !== 'bootstrap' &&
       this.#state !== 'ready'
@@ -319,6 +336,13 @@ export class RuntimeHostKernel {
       return false;
     }
     return !this.#isDraining();
+  }
+
+  async #readAdmissionState(): Promise<Exclude<HostLifecycleState, 'draining'> | undefined> {
+    if (this.#shutdownRequested || this.#isDraining()) return undefined;
+    if (!(await this.#hasLiveOwnerOrDrain())) return undefined;
+    const state = this.#state;
+    return this.#shutdownRequested || state === 'draining' ? undefined : state;
   }
 
   #isDraining(): boolean {
@@ -419,19 +443,53 @@ export class RuntimeHostKernel {
   }
 
   #commitShutdown(): Promise<void> {
+    if (this.#terminationRequired) return this.closed;
     if (!this.#shutdownTask) {
-      this.#shutdownRequested = true;
+      if (!this.#shutdownRequested) {
+        this.#shutdownRequested = true;
+        this.#armShutdownDeadline();
+      }
       this.#state = 'draining';
       this.#cancelIdle();
       this.#shutdownTask = this.#closeResources();
-      void this.#shutdownTask.then(this.#resolveClosed, this.#rejectClosed);
+      void this.#shutdownTask.then(
+        () => {
+          this.#clearShutdownDeadline();
+          if (!this.#terminationRequired) this.#resolveClosed();
+        },
+        (error: unknown) => {
+          this.#clearShutdownDeadline();
+          if (!this.#terminationRequired) this.#rejectClosed(error);
+        },
+      );
     }
     return this.closed;
+  }
+
+  #armShutdownDeadline(): void {
+    if (this.#shutdownDeadlineTimer || this.#terminationRequired) return;
+    this.#shutdownDeadlineTimer = setTimeout(() => {
+      this.#shutdownDeadlineTimer = undefined;
+      const error = new RuntimeHostProcessTerminationRequiredError(this.#shutdownGraceMs);
+      this.#terminationRequired = error;
+      this.#rejectClosed(error);
+    }, this.#shutdownGraceMs);
+  }
+
+  #clearShutdownDeadline(): void {
+    if (!this.#shutdownDeadlineTimer) return;
+    clearTimeout(this.#shutdownDeadlineTimer);
+    this.#shutdownDeadlineTimer = undefined;
+  }
+
+  #assertShutdownCanContinue(): void {
+    if (this.#terminationRequired) throw this.#terminationRequired;
   }
 
   async #closeResources(): Promise<void> {
     const errors: unknown[] = [];
     await this.#publishRegistration().catch((error: unknown) => errors.push(error));
+    this.#assertShutdownCanContinue();
     const serverClosed = closeServer(this.#server).catch((error: unknown) => errors.push(error));
     const accepted = [...this.#acceptedTransports];
     const handshaking = [...this.#handshakingTransports];
@@ -440,20 +498,28 @@ export class RuntimeHostKernel {
       waitForBoundedCompletion(operationDrain, SHUTDOWN_OPERATION_GRACE_MS),
       waitForTransportClose(handshaking, SHUTDOWN_HANDSHAKE_GRACE_MS),
     ]);
+    this.#assertShutdownCanContinue();
     if (!operationsDrained) {
       for (const transport of accepted) transport.destroy();
     }
     for (const transport of handshaking) transport.destroy();
     await operationDrain;
+    this.#assertShutdownCanContinue();
     await this.#composition?.close().catch((error: unknown) => errors.push(error));
+    this.#assertShutdownCanContinue();
     await this.#waitForResidencies();
+    this.#assertShutdownCanContinue();
     for (const transport of accepted) transport.destroy();
     await serverClosed;
+    this.#assertShutdownCanContinue();
     await this.#endpoint?.cleanup().catch((error: unknown) => errors.push(error));
+    this.#assertShutdownCanContinue();
     await removeHostRegistration(this.#options.owner.controlDirectory, this.hostEpoch).catch(
       (error: unknown) => errors.push(error),
     );
+    this.#assertShutdownCanContinue();
     await this.#options.owner.close().catch((error: unknown) => errors.push(error));
+    this.#assertShutdownCanContinue();
     if (errors.length > 0)
       throw new AggregateError(
         errors,

--- a/packages/runtime-host/src/server/index.ts
+++ b/packages/runtime-host/src/server/index.ts
@@ -1,5 +1,6 @@
 export {
   RuntimeHostKernel,
+  RuntimeHostProcessTerminationRequiredError,
   type RuntimeHostComposition,
   type RuntimeHostCompositionContext,
   type RuntimeHostCompositionFactory,

--- a/packages/runtime-host/src/server/process-lifecycle.ts
+++ b/packages/runtime-host/src/server/process-lifecycle.ts
@@ -1,0 +1,34 @@
+import {
+  RuntimeHostProcessTerminationRequiredError,
+  type RuntimeHostKernel,
+} from './host-kernel.js';
+
+export interface RuntimeHostProcessLifecycleOptions {
+  closeOnDisconnect?: boolean;
+}
+
+export async function runRuntimeHostProcessLifecycle(
+  host: RuntimeHostKernel,
+  options: RuntimeHostProcessLifecycleOptions = {},
+): Promise<void> {
+  let closing = false;
+  const close = () => {
+    if (closing) return;
+    closing = true;
+    void host.close();
+  };
+
+  process.once('SIGINT', close);
+  process.once('SIGTERM', close);
+  if (options.closeOnDisconnect) process.once('disconnect', close);
+  try {
+    await host.closed;
+  } catch (error) {
+    if (error instanceof RuntimeHostProcessTerminationRequiredError) process.exit(1);
+    throw error;
+  } finally {
+    process.off('SIGINT', close);
+    process.off('SIGTERM', close);
+    if (options.closeOnDisconnect) process.off('disconnect', close);
+  }
+}


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

This PR establishes the bounded shutdown foundation required before a Runtime Host owns additional Interactive domains:

- the first drain request closes new connection and operation admission and starts one absolute clean-shutdown deadline, even while an already admitted command is still reaching its seal point;
- admitted work keeps the existing normal response window, while operation, composition, residency, control-plane, and owner cleanup share one finite budget rather than restarting a timeout at each phase;
- expiry rejects `closed` with a typed `process_termination_required` result, and the dedicated Host process immediately fail-stops instead of continuing ordinary cleanup or force-releasing ownership;
- the OS-held owner lock remains the only writer authority and is reclaimed by process death; a successor still has to acquire that lock before it can recover or serve;
- the production Candidate and the real execution child use the same signal, close, and fail-stop process lifecycle.

## Boundary and decisions

The default clean-shutdown grace is 10 seconds. The existing one-second operation and handshake windows remain early transport-drain bounds; they are not separate ownership deadlines. A command that was admitted before shutdown may finish its handler and enqueue its protocol response, but a command that never reaches that boundary can no longer keep the process and owner lock alive forever.

`RuntimeHostKernel` reports deadline expiry as a typed process-termination requirement instead of calling `process.exit()` from a reusable in-process class. The dedicated process entrypoint owns the hard exit. This keeps the Kernel testable without weakening the production rule: once fail-stop is required, ordinary endpoint cleanup, registration removal, or `owner.close()` cannot be used as proof that the old writer is isolated.

This slice does not add a lock-stealing path, a protocol-visible fail-stop state, a supervisor, or arbitrary-descendant containment. Registration and endpoint files remain discovery evidence only. The successor journey is gated by actual OS lock acquisition.

## Scope

This PR changes Runtime Host lifecycle and its dedicated process entrypoints only. It does not migrate an Interactive domain, change protocol operation shapes, alter Storage's drain-before-unlock contract, or activate the production Host cutover.

## Validation

A real child-process test uses the real local transport and Interactive owner lock, blocks an admitted `turn.start` before seal, verifies that a contender cannot acquire ownership during the grace period, observes bounded non-clean process exit, and then proves that a different-epoch successor acquires the lock and serves `host.status`. The existing active-Turn shutdown journey now also proves a normal code-zero exit and preserves its single durable `cancelled` outcome.

The Runtime Host suite passes 61 tests. Root build, typecheck, lint, and format checks pass.

Tracked by #1167. Architectural context: #853.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

本 PR 建立 Runtime Host 在继续持有其他 Interactive 领域前所需的 bounded shutdown foundation：

- 第一次 drain request 会关闭新的 connection 与 operation admission，并启动唯一的 absolute clean-shutdown deadline；即使一个已经接纳的 command 仍在走向 seal point，也不会延后计时；
- 已接纳工作继续保留现有的正常回复窗口；operation、composition、residency、control-plane 与 owner cleanup 共用一个有限预算，不会在每个阶段重新获得一份 timeout；
- deadline 到期后，`closed` 以 typed `process_termination_required` 结束，专用 Host process 立即 fail-stop，不再继续普通 cleanup 或强制释放 ownership；
- OS-held owner lock 继续作为唯一 writer authority，并只由进程死亡触发回收；successor 仍须真实取得该 lock，之后才能 recovery 或提供服务；
- production Candidate 与真实 execution child 共用同一套 signal、close 与 fail-stop process lifecycle。

## 边界与决策

默认 clean-shutdown grace 为 10 秒。既有的 1 秒 operation/handshake window 继续作为提前处理 transport drain 的边界，而不是另一份 ownership deadline。shutdown 前已经接纳的 command 可以完成 handler 并把协议回复接纳进写队列；永远到不了该边界的 command 则不能再永久占住进程与 owner lock。

`RuntimeHostKernel` 以 typed process-termination requirement 报告 deadline 到期，而不是从可复用的进程内 class 直接调用 `process.exit()`；hard exit 由专用进程入口负责。这样既保持 Kernel 可测试，也不削弱 production 规则：进入 fail-stop 后，普通 endpoint cleanup、registration 删除或 `owner.close()` 都不能被当作旧 writer 已隔离的证明。

本 slice 不增加偷锁路径、protocol-visible fail-stop 状态、supervisor 或 arbitrary-descendant containment。registration 与 endpoint 文件仍然只提供 discovery evidence；successor journey 由真实 OS lock acquisition 约束。

## 范围

本 PR 只改变 Runtime Host lifecycle 与专用进程入口。它不迁移 Interactive 领域，不改变 protocol operation shape，不修改 Storage 的 drain-before-unlock 契约，也不启用 production Host cutover。

## 验证

一个真实 child-process 测试使用真实 local transport 与 Interactive owner lock，让已接纳的 `turn.start` 在 seal 前永久阻塞，验证 grace 期间 contender 无法取得 ownership，观察有界的 non-clean process exit，并证明不同 Epoch 的 successor 随后取得 lock 且能够提供 `host.status`。既有 active-Turn shutdown journey 也新增了 code-zero 正常退出断言，并继续保留唯一 durable `cancelled` outcome。

Runtime Host 全包 61 项通过；根级 build、typecheck、lint 与 format check 通过。

由 #1167 跟踪；架构背景见 #853。

</details>
