### PR TITLE
feat(runtime-host): establish message authority foundation

### DIFF
--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -159,6 +159,39 @@ describe('Maka Pi TUI transcript', () => {
     );
   });
 
+  test('renders steering messages with human-facing text and falls back to model-facing text', () => {
+    const state = createMakaPiTranscriptState();
+
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'steering_message',
+        messageId: 'steering-display',
+        content: {
+          text: '<system-reminder>internal context</system-reminder>\nShow the result',
+          displayText: 'Show the result',
+        },
+      }),
+    );
+    applyMakaSessionEventToTranscript(
+      state,
+      event({
+        type: 'steering_message',
+        messageId: 'steering-plain',
+        content: { text: 'Also include the tests' },
+      }),
+    );
+
+    assert.deepEqual(state.entries, [
+      { kind: 'user', text: 'Show the result' },
+      { kind: 'user', text: 'Also include the tests' },
+    ]);
+    const rendered = renderMakaPiTranscript(state, meta(), 100).map(stripAnsi).join('\n');
+    assert.match(rendered, /Show the result/);
+    assert.match(rendered, /Also include the tests/);
+    assert.doesNotMatch(rendered, /internal context/);
+  });
+
   test('shows a fixed system notice when the configured step limit is reached', () => {
     const state = createMakaPiTranscriptState();
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -693,7 +693,7 @@ export function applyMakaSessionEventToTranscript(
 
     case 'steering_message':
       // A user interjection injected mid-turn; render it in place as a user turn.
-      appendUserPrompt(state, event.text);
+      appendUserPrompt(state, event.content.displayText ?? event.content.text);
       break;
 
     case 'queue_update':

--- a/packages/core/src/__tests__/runtime-event.test.ts
+++ b/packages/core/src/__tests__/runtime-event.test.ts
@@ -1,6 +1,7 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
 import { expect } from '../test-helpers.js';
+import { decodeMessageContent, messageContentsEqual, normalizeMessageContent } from '../events.js';
 import {
   RUNTIME_EVENT_AUTHORS,
   RUNTIME_EVENT_CONTENT_KINDS,
@@ -20,6 +21,7 @@ import {
   type RuntimeEventActions,
   type RuntimeEventContent,
 } from '../runtime-event.js';
+import { decodeStoredMessageForRecovery } from '../session.js';
 
 /** Minimal valid RuntimeEvent; callers spread overrides on top. */
 function baseEvent(overrides: Partial<RuntimeEvent> = {}): RuntimeEvent {
@@ -85,6 +87,153 @@ describe('RuntimeEvent role / author / status enums', () => {
 });
 
 describe('RuntimeEvent content variants', () => {
+  test('owns canonical MessageContent decoding, copying, and equality', () => {
+    const attachments = [
+      {
+        kind: 'code' as const,
+        name: 'b.ts',
+        mimeType: 'text/typescript',
+        bytes: 2,
+        ref: { kind: 'workspace_file' as const, relativePath: 'b.ts' },
+      },
+      {
+        kind: 'code' as const,
+        name: 'a.ts',
+        mimeType: 'text/typescript',
+        bytes: 1,
+        ref: { kind: 'workspace_file' as const, relativePath: 'a.ts' },
+      },
+    ];
+    const quotes = [
+      { text: 'first', label: 'Assistant', sourceTurnId: 'turn-1' },
+      { text: 'second', sourceTurnId: 'turn-2' },
+    ];
+    assert.deepEqual(normalizeMessageContent({ text: 'model', displayText: 'model' }), {
+      text: 'model',
+    });
+    assert.deepEqual(normalizeMessageContent({ text: 'model', attachments: [] }), {
+      text: 'model',
+    });
+    assert.deepEqual(normalizeMessageContent({ text: 'model', quotes: [] }), {
+      text: 'model',
+    });
+    const decoded = decodeMessageContent({ text: 'model', attachments, quotes });
+    assert.deepEqual(decoded.attachments, attachments);
+    assert.deepEqual(decoded.quotes, quotes);
+    assert.notEqual(decoded.attachments, attachments);
+    assert.notEqual(decoded.attachments?.[0], attachments[0]);
+    assert.notEqual(decoded.attachments?.[0]?.ref, attachments[0]?.ref);
+    assert.notEqual(decoded.quotes, quotes);
+    assert.notEqual(decoded.quotes?.[0], quotes[0]);
+    assert.equal(messageContentsEqual(decoded, { text: 'model', attachments, quotes }), true);
+    assert.equal(
+      messageContentsEqual(decoded, {
+        text: 'model',
+        attachments: [...attachments].reverse(),
+        quotes,
+      }),
+      false,
+    );
+    assert.equal(
+      messageContentsEqual(decoded, { text: 'model', attachments, quotes: [...quotes].reverse() }),
+      false,
+    );
+    assert.equal(
+      messageContentsEqual(decoded, {
+        text: 'model',
+        attachments,
+        quotes: [{ ...quotes[0]!, sourceTurnId: 'turn-other' }, quotes[1]!],
+      }),
+      false,
+    );
+    assert.throws(() => decodeMessageContent({ text: 'model', extra: true }), TypeError);
+    assert.throws(
+      () =>
+        decodeMessageContent({
+          text: 'model',
+          attachments: [{ ...attachments[0]!, ref: { kind: 'workspace_file', relativePath: 1 } }],
+        }),
+      TypeError,
+    );
+    assert.throws(
+      () =>
+        decodeMessageContent({
+          text: 'model',
+          attachments: [{ ...attachments[0]!, bytes: 1.5 }],
+        }),
+      TypeError,
+    );
+    for (const quote of [
+      { text: 1 },
+      { text: 'excerpt', label: 1 },
+      { text: 'excerpt', sourceTurnId: 1 },
+      { text: 'excerpt', extra: true },
+    ]) {
+      assert.throws(() => decodeMessageContent({ text: 'model', quotes: [quote] }), TypeError);
+    }
+    assert.deepEqual(
+      decodeRuntimeEvent(
+        baseEvent({
+          role: 'user',
+          author: 'user',
+          content: {
+            kind: 'text',
+            text: 'model',
+            displayText: 'model',
+            attachments: [],
+            quotes,
+          },
+        }),
+      ).content,
+      { kind: 'text', text: 'model', quotes },
+    );
+    const event = decodeRuntimeEvent(
+      baseEvent({ content: { kind: 'text', text: 'model', quotes } }),
+    );
+    assert.notEqual(
+      event.content && 'quotes' in event.content ? event.content.quotes : undefined,
+      quotes,
+    );
+    assert.notEqual(
+      event.content && 'quotes' in event.content ? event.content.quotes?.[0] : undefined,
+      quotes[0],
+    );
+    const stored = decodeStoredMessageForRecovery({
+      type: 'user',
+      id: 'message-1',
+      turnId: 'turn-1',
+      ts: 1,
+      text: 'model',
+      displayText: 'model',
+      attachments: [],
+      quotes,
+    });
+    assert.deepEqual(stored, {
+      type: 'user',
+      id: 'message-1',
+      turnId: 'turn-1',
+      ts: 1,
+      text: 'model',
+      quotes,
+    });
+    assert.equal(stored.type, 'user');
+    if (stored.type !== 'user') throw new Error('unreachable');
+    assert.notEqual(stored.quotes, quotes);
+    assert.notEqual(stored.quotes?.[0], quotes[0]);
+    assert.throws(
+      () =>
+        decodeStoredMessageForRecovery({
+          type: 'user',
+          id: 'message-1',
+          turnId: 'turn-1',
+          ts: 1,
+          text: 'model',
+          quotes: [{ text: 'excerpt', sourceTurnId: 1 }],
+        }),
+      /Invalid stored message schema/,
+    );
+  });
+
   test('text content carries a string body', () => {
     const content: RuntimeEventContent = { kind: 'text', text: 'hello' };
     if (content.kind !== 'text') throw new Error('unreachable');

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -35,6 +35,26 @@ export interface AgentRunContinuationSource {
   sourceRuntimeEventHighWater: number;
 }
 
+export type RootExecutionDescriptor =
+  | { kind: 'external_message' }
+  | {
+      kind: 'linked_child_initial';
+      agentId: string;
+      agentName: string;
+    }
+  | {
+      kind: 'linked_child_resume';
+      agentId: string;
+      agentName: string;
+      sourceRunId: string;
+    }
+  | {
+      kind: 'linked_child_provider_retry';
+      agentId: string;
+      agentName: string;
+      sourceRunId: string;
+    };
+
 const AGENT_RUN_CONTINUATION_SOURCE_SHAPE = defineObjectShape<AgentRunContinuationSource>()(
   ['sourceInvocationId', 'sourceRunId', 'sourceTurnId', 'sourceRuntimeEventHighWater'],
   [],

--- a/packages/core/src/backend-types.ts
+++ b/packages/core/src/backend-types.ts
@@ -8,7 +8,7 @@
  * implementation file.
  */
 
-import type { AttachmentRef, QuoteRef, SessionEvent } from './events.js';
+import type { AttachmentRef, MessageContent, QuoteRef, SessionEvent } from './events.js';
 import type { RuntimeEvent } from './runtime-event.js';
 import type { StoredMessage, BackendKind } from './session.js';
 import type { PermissionResponse } from './permission.js';
@@ -77,10 +77,13 @@ export interface BackendSendInput {
   nackSteering?: (leaseIds: readonly string[]) => void;
 }
 
-/** One leased steering message: queue identity + user text. */
+/** One leased steering message: queue identity + canonical user content. */
 export interface SteeringLease {
+  /** Stable user-message identity shared with the durable steering event. */
+  messageId: string;
+  /** Ephemeral delivery lease identity used only for ack/nack settlement. */
   id: string;
-  text: string;
+  content: MessageContent;
 }
 
 /** Alias for clarity at the backend boundary. */

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -29,6 +29,7 @@ import type {
   PrefixChangeReason,
   PromptSegmentEstimate,
 } from './usage-stats/types.js';
+import { defineObjectShape, hasExactShape, isRecord } from './record-schema.js';
 
 export const TOOL_OUTPUT_STREAMS = ['stdout', 'stderr'] as const;
 export const TOOL_OUTPUT_DELTA_MAX_CHARS = 8192;
@@ -75,6 +76,229 @@ export interface QuoteRef {
   label?: string;
   /** Provenance: the transcript turn the excerpt was selected from. */
   sourceTurnId?: string;
+}
+
+/** Canonical user-authored content shared by storage, runtime, and Host wire. */
+export interface MessageContent {
+  /**
+   * Authoritative model-facing input. This may be a composed envelope when a
+   * client injects context such as explicit skill instructions.
+   */
+  text: string;
+  /** Human-facing text when it differs from `text`; omit when equal. */
+  displayText?: string;
+  /** Ordered attachment references; omit when empty. Attachment bytes never travel here. */
+  attachments?: AttachmentRef[];
+  /** Ordered inline excerpts; omit when empty. Provenance remains part of content identity. */
+  quotes?: QuoteRef[];
+}
+
+const MESSAGE_CONTENT_SHAPE = defineObjectShape<MessageContent>()(
+  ['text'],
+  ['displayText', 'attachments', 'quotes'],
+);
+const ATTACHMENT_REF_SHAPE = defineObjectShape<AttachmentRef>()(
+  ['kind', 'name', 'mimeType', 'bytes', 'ref'],
+  [],
+);
+const QUOTE_REF_SHAPE = defineObjectShape<QuoteRef>()(['text'], ['label', 'sourceTurnId']);
+const SESSION_FILE_REF_SHAPE = defineObjectShape<Extract<StorageRef, { kind: 'session_file' }>>()(
+  ['kind', 'sessionId', 'relativePath'],
+  [],
+);
+const WORKSPACE_FILE_REF_SHAPE = defineObjectShape<
+  Extract<StorageRef, { kind: 'workspace_file' }>
+>()(['kind', 'relativePath'], []);
+const EXTERNAL_FILE_REF_SHAPE = defineObjectShape<Extract<StorageRef, { kind: 'external_file' }>>()(
+  ['kind', 'absolutePath'],
+  [],
+);
+
+export function normalizeMessageContent(content: MessageContent): MessageContent {
+  return {
+    text: content.text,
+    ...(content.displayText !== undefined && content.displayText !== content.text
+      ? { displayText: content.displayText }
+      : {}),
+    ...(content.attachments !== undefined && content.attachments.length > 0
+      ? {
+          attachments: content.attachments.map((attachment) => ({
+            ...attachment,
+            bytes: Object.is(attachment.bytes, -0) ? 0 : attachment.bytes,
+            ref: { ...attachment.ref },
+          })),
+        }
+      : {}),
+    ...(content.quotes !== undefined && content.quotes.length > 0
+      ? {
+          quotes: content.quotes.map((quote) => ({
+            text: quote.text,
+            ...(quote.label !== undefined ? { label: quote.label } : {}),
+            ...(quote.sourceTurnId !== undefined ? { sourceTurnId: quote.sourceTurnId } : {}),
+          })),
+        }
+      : {}),
+  };
+}
+
+export function decodeMessageContent(value: unknown): MessageContent {
+  if (!isMessageContent(value)) throw new TypeError('Invalid MessageContent');
+  return normalizeMessageContent(value);
+}
+
+export function isMessageContent(value: unknown): value is MessageContent {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, MESSAGE_CONTENT_SHAPE) &&
+    typeof value.text === 'string' &&
+    (value.displayText === undefined || typeof value.displayText === 'string') &&
+    (value.attachments === undefined ||
+      (Array.isArray(value.attachments) && value.attachments.every(isAttachmentRef))) &&
+    (value.quotes === undefined || (Array.isArray(value.quotes) && value.quotes.every(isQuoteRef)))
+  );
+}
+
+export function isQuoteRef(value: unknown): value is QuoteRef {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, QUOTE_REF_SHAPE) &&
+    typeof value.text === 'string' &&
+    (value.label === undefined || typeof value.label === 'string') &&
+    (value.sourceTurnId === undefined || typeof value.sourceTurnId === 'string')
+  );
+}
+
+export function isAttachmentRef(value: unknown): value is AttachmentRef {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, ATTACHMENT_REF_SHAPE) &&
+    (value.kind === 'image' ||
+      value.kind === 'pdf' ||
+      value.kind === 'doc' ||
+      value.kind === 'code' ||
+      value.kind === 'other') &&
+    typeof value.name === 'string' &&
+    typeof value.mimeType === 'string' &&
+    typeof value.bytes === 'number' &&
+    Number.isSafeInteger(value.bytes) &&
+    value.bytes >= 0 &&
+    isStorageRef(value.ref)
+  );
+}
+
+/** A structurally valid attachment whose metadata and locator are canonical at durable boundaries. */
+export function isCanonicalAttachmentRef(value: unknown): value is AttachmentRef {
+  return (
+    isAttachmentRef(value) &&
+    value.name.length > 0 &&
+    value.mimeType.length > 0 &&
+    isCanonicalStorageRef(value.ref)
+  );
+}
+
+export function isStorageRef(value: unknown): value is StorageRef {
+  if (!isRecord(value)) return false;
+  if (value.kind === 'session_file') {
+    return (
+      hasExactShape(value, SESSION_FILE_REF_SHAPE) &&
+      typeof value.sessionId === 'string' &&
+      typeof value.relativePath === 'string'
+    );
+  }
+  if (value.kind === 'workspace_file') {
+    return hasExactShape(value, WORKSPACE_FILE_REF_SHAPE) && typeof value.relativePath === 'string';
+  }
+  return (
+    value.kind === 'external_file' &&
+    hasExactShape(value, EXTERNAL_FILE_REF_SHAPE) &&
+    typeof value.absolutePath === 'string'
+  );
+}
+
+export function isCanonicalStorageRef(value: unknown): value is StorageRef {
+  if (!isStorageRef(value)) return false;
+  if (value.kind === 'external_file') return isCanonicalAbsolutePath(value.absolutePath);
+  if (value.kind === 'session_file' && !/^[A-Za-z0-9_-]{1,128}$/.test(value.sessionId)) {
+    return false;
+  }
+  return isCanonicalRelativePath(value.relativePath);
+}
+
+function isCanonicalRelativePath(path: string): boolean {
+  return (
+    path.length > 0 &&
+    !path.includes('\0') &&
+    !path.includes('\\') &&
+    !path.startsWith('/') &&
+    !/^[A-Za-z]:/.test(path) &&
+    path.split('/').every((segment) => segment.length > 0 && segment !== '.' && segment !== '..')
+  );
+}
+
+function isCanonicalAbsolutePath(path: string): boolean {
+  if (path.length === 0 || path.includes('\0')) return false;
+  if (path.startsWith('/')) return true;
+  if (/^[A-Za-z]:[\\/]/.test(path)) return true;
+  return /^\\\\[^\\/]+[\\/][^\\/]+/.test(path);
+}
+
+export function messageContentsEqual(left: MessageContent, right: MessageContent): boolean {
+  const leftDisplayText = left.displayText === left.text ? undefined : left.displayText;
+  const rightDisplayText = right.displayText === right.text ? undefined : right.displayText;
+  const leftAttachments = left.attachments?.length ? left.attachments : undefined;
+  const rightAttachments = right.attachments?.length ? right.attachments : undefined;
+  const leftQuotes = left.quotes?.length ? left.quotes : undefined;
+  const rightQuotes = right.quotes?.length ? right.quotes : undefined;
+  return (
+    left.text === right.text &&
+    leftDisplayText === rightDisplayText &&
+    ((leftAttachments === undefined && rightAttachments === undefined) ||
+      (leftAttachments !== undefined &&
+        rightAttachments !== undefined &&
+        leftAttachments.length === rightAttachments.length &&
+        leftAttachments.every((attachment, index) =>
+          attachmentRefsEqual(attachment, rightAttachments[index]!),
+        ))) &&
+    ((leftQuotes === undefined && rightQuotes === undefined) ||
+      (leftQuotes !== undefined &&
+        rightQuotes !== undefined &&
+        leftQuotes.length === rightQuotes.length &&
+        leftQuotes.every((quote, index) => quoteRefsEqual(quote, rightQuotes[index]!))))
+  );
+}
+
+function quoteRefsEqual(left: QuoteRef, right: QuoteRef): boolean {
+  return (
+    left.text === right.text &&
+    left.label === right.label &&
+    left.sourceTurnId === right.sourceTurnId
+  );
+}
+
+function attachmentRefsEqual(left: AttachmentRef, right: AttachmentRef): boolean {
+  if (
+    left.kind !== right.kind ||
+    left.name !== right.name ||
+    left.mimeType !== right.mimeType ||
+    left.bytes !== right.bytes ||
+    left.ref.kind !== right.ref.kind
+  ) {
+    return false;
+  }
+  switch (left.ref.kind) {
+    case 'session_file':
+      return (
+        right.ref.kind === 'session_file' &&
+        left.ref.sessionId === right.ref.sessionId &&
+        left.ref.relativePath === right.ref.relativePath
+      );
+    case 'workspace_file':
+      return (
+        right.ref.kind === 'workspace_file' && left.ref.relativePath === right.ref.relativePath
+      );
+    case 'external_file':
+      return right.ref.kind === 'external_file' && left.ref.absolutePath === right.ref.absolutePath;
+  }
 }
 
 // ============================================================================
@@ -557,7 +781,7 @@ export interface TokenUsageEvent extends BaseEvent {
 export interface SteeringMessageEvent extends BaseEvent {
   type: 'steering_message';
   messageId: string;
-  text: string;
+  content: MessageContent;
 }
 
 /**

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -59,6 +59,7 @@ export type {
   StorageRef,
   AttachmentRef,
   QuoteRef,
+  MessageContent,
   AttachmentIngestItem,
   CompleteStopReason,
   ContextBudgetExhaustedDetail,
@@ -71,7 +72,15 @@ export type {
   UserQuestionResult,
 } from './user-question.js';
 export {
+  decodeMessageContent,
   failureClassFromCompleteStopReason,
+  isAttachmentRef,
+  isCanonicalAttachmentRef,
+  isCanonicalStorageRef,
+  isMessageContent,
+  isStorageRef,
+  messageContentsEqual,
+  normalizeMessageContent,
   TOOL_ACTIVITY_KINDS,
   TOOL_OUTPUT_DELTA_MAX_CHARS,
   TOOL_OUTPUT_STREAMS,
@@ -234,6 +243,7 @@ export type {
   AgentRunInputSummary,
   AgentRunStatus,
   AgentRunStore,
+  RootExecutionDescriptor,
 } from './agent-run.js';
 export {
   AGENT_RUN_STATUSES,

--- a/packages/core/src/interaction-record-schema.ts
+++ b/packages/core/src/interaction-record-schema.ts
@@ -13,7 +13,6 @@ import {
   validateAdditionalPermissionProfile,
   type AdditionalPermissionRiskSummary,
 } from './additional-permissions.js';
-import type { AttachmentRef, StorageRef } from './events.js';
 import type { UserQuestion, UserQuestionOption, UserQuestionRequest } from './user-question.js';
 import {
   defineObjectShape,
@@ -103,23 +102,6 @@ const QUESTION_REQUEST_SHAPE = defineObjectShape<UserQuestionRequest>()(
 );
 const QUESTION_SHAPE = defineObjectShape<UserQuestion>()(['question', 'options'], []);
 const QUESTION_OPTION_SHAPE = defineObjectShape<UserQuestionOption>()(['label'], ['description']);
-
-const ATTACHMENT_SHAPE = defineObjectShape<AttachmentRef>()(
-  ['kind', 'name', 'mimeType', 'bytes', 'ref'],
-  [],
-);
-type SessionFileRef = Extract<StorageRef, { kind: 'session_file' }>;
-type WorkspaceFileRef = Extract<StorageRef, { kind: 'workspace_file' }>;
-type ExternalFileRef = Extract<StorageRef, { kind: 'external_file' }>;
-const SESSION_FILE_REF_SHAPE = defineObjectShape<SessionFileRef>()(
-  ['kind', 'sessionId', 'relativePath'],
-  [],
-);
-const WORKSPACE_FILE_REF_SHAPE = defineObjectShape<WorkspaceFileRef>()(
-  ['kind', 'relativePath'],
-  [],
-);
-const EXTERNAL_FILE_REF_SHAPE = defineObjectShape<ExternalFileRef>()(['kind', 'absolutePath'], []);
 
 const TOOL_PERMISSION_REASONS = new Set([
   'shell_dangerous',
@@ -217,38 +199,6 @@ export function isUserQuestionRequest(value: unknown): value is UserQuestionRequ
     typeof value.toolUseId === 'string' &&
     Array.isArray(value.questions) &&
     value.questions.every(isUserQuestion)
-  );
-}
-
-export function isAttachmentRef(value: unknown): value is AttachmentRef {
-  return (
-    isRecord(value) &&
-    hasExactShape(value, ATTACHMENT_SHAPE) &&
-    ['image', 'pdf', 'doc', 'code', 'other'].includes(value.kind as string) &&
-    typeof value.name === 'string' &&
-    typeof value.mimeType === 'string' &&
-    isFiniteNumber(value.bytes) &&
-    value.bytes >= 0 &&
-    isStorageRef(value.ref)
-  );
-}
-
-export function isStorageRef(value: unknown): value is StorageRef {
-  if (!isRecord(value)) return false;
-  if (value.kind === 'session_file') {
-    return (
-      hasExactShape(value, SESSION_FILE_REF_SHAPE) &&
-      typeof value.sessionId === 'string' &&
-      typeof value.relativePath === 'string'
-    );
-  }
-  if (value.kind === 'workspace_file') {
-    return hasExactShape(value, WORKSPACE_FILE_REF_SHAPE) && typeof value.relativePath === 'string';
-  }
-  return (
-    value.kind === 'external_file' &&
-    hasExactShape(value, EXTERNAL_FILE_REF_SHAPE) &&
-    typeof value.absolutePath === 'string'
   );
 }
 

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -14,7 +14,7 @@
  * projection, or ledger logic lives here. Those arrive in later nodes.
  */
 
-import type { AttachmentRef, QuoteRef } from './events.js';
+import { isMessageContent, normalizeMessageContent, type MessageContent } from './events.js';
 import type { PermissionRequestPayload, PermissionResponse } from './permission.js';
 import type { UserQuestionRequest } from './user-question.js';
 import type {
@@ -32,7 +32,6 @@ import {
   isStringArray,
 } from './record-schema.js';
 import {
-  isAttachmentRef,
   isPermissionRequestPayload,
   isPermissionResponse,
   isUserQuestionRequest,
@@ -109,25 +108,8 @@ export function isTerminalRuntimeEventStatus(value: unknown): boolean {
 // Content (model-facing payload)
 // ============================================================================
 
-export interface RuntimeEventTextContent {
+export interface RuntimeEventTextContent extends MessageContent {
   kind: 'text';
-  text: string;
-  /**
-   * Human-facing text when it differs from `text` (e.g. the typed
-   * `/skill:…` prompt while `text` is the composed skill-injection
-   * envelope). Model-history projections MUST ignore this and use `text`
-   * only; UI/transcript/rewind projections should prefer it when present.
-   */
-  displayText?: string;
-  /**
-   * Optional user-bound attachments carried with the text turn. Adapters
-   * MUST preserve these when converting legacy UserMessage rows so
-   * RuntimeEvent history does not silently degrade multimodal/file turns
-   * into plain text.
-   */
-  attachments?: AttachmentRef[];
-  /** Inline quoted excerpts carried with the text turn (see QuoteRef). */
-  quotes?: QuoteRef[];
   /**
    * Marks a user message steered into a running turn at a step boundary.
    * `text` stays raw for UI/transcript projections; model-replay projections
@@ -491,6 +473,16 @@ export function decodeRuntimeEvent(value: unknown): RuntimeEvent {
   ) {
     throw new Error('Invalid RuntimeEvent schema');
   }
+  if (isRecord(value.content) && value.content.kind === 'text') {
+    return {
+      ...value,
+      content: {
+        kind: 'text',
+        ...normalizeMessageContent(value.content as unknown as MessageContent),
+        ...(value.content.steering === true ? { steering: true as const } : {}),
+      },
+    } as unknown as RuntimeEvent;
+  }
   return value as unknown as RuntimeEvent;
 }
 
@@ -498,14 +490,18 @@ function isRuntimeEventContent(value: unknown): value is RuntimeEventContent {
   if (!isRecord(value)) return false;
   switch (value.kind) {
     case 'text':
-      return (
-        hasExactShape(value, TEXT_CONTENT_SHAPE) &&
-        typeof value.text === 'string' &&
-        isOptionalString(value.displayText) &&
-        (value.attachments === undefined ||
-          (Array.isArray(value.attachments) && value.attachments.every(isAttachmentRef))) &&
-        (value.steering === undefined || value.steering === true)
-      );
+      if (
+        !hasExactShape(value, TEXT_CONTENT_SHAPE) ||
+        (value.steering !== undefined && value.steering !== true)
+      ) {
+        return false;
+      }
+      return isMessageContent({
+        text: value.text,
+        ...(value.displayText !== undefined ? { displayText: value.displayText } : {}),
+        ...(value.attachments !== undefined ? { attachments: value.attachments } : {}),
+        ...(value.quotes !== undefined ? { quotes: value.quotes } : {}),
+      });
     case 'thinking':
       return (
         hasExactShape(value, THINKING_CONTENT_SHAPE) &&

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -2,7 +2,7 @@
  * Inputs to runtime APIs (create session, send message, list/filter).
  */
 
-import type { AttachmentRef, QuoteRef } from './events.js';
+import type { MessageContent } from './events.js';
 import type {
   BackendKind,
   SessionBlockedReason,
@@ -66,28 +66,12 @@ export type CreateSessionRequestInput = Partial<CreateSessionInput> & {
   mode?: SessionStartMode;
 };
 
-export interface UserMessageInput {
+export interface UserMessageInput extends MessageContent {
   /** Caller-generated uuid. Same id used in the UserMessage.turnId and in
    *  every event emitted by this turn. */
   turnId: string;
-  /**
-   * Model-facing turn text (and the default human-facing text). When the
-   * client wraps the user's typed input — e.g. explicit skill invocation
-   * injects `<invoked-skill>` blocks — put the composed envelope here and
-   * the original typed text in `displayText`.
-   */
-  text: string;
-  /**
-   * Human-facing text when it differs from `text`. Session title derivation,
-   * transcript restore, rewind refill, and sidebar previews should prefer
-   * this over `text`. Omit when the two are identical.
-   */
-  displayText?: string;
   /** Trusted host-supplied orchestration override for this turn only. */
   turnOrchestration?: TurnOrchestration;
-  attachments?: AttachmentRef[];
-  /** Inline quoted excerpts; folded into model content, rendered as chips. */
-  quotes?: QuoteRef[];
   parentRunId?: string;
   /** Child AgentRun whose durable conversation this child continues. */
   resumedFromRunId?: string;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -7,9 +7,9 @@
  */
 
 import {
+  decodeMessageContent,
   TOOL_ACTIVITY_KINDS,
-  type AttachmentRef,
-  type QuoteRef,
+  type MessageContent,
   type ToolActivityKind,
   type ToolResultContent,
 } from './events.js';
@@ -35,12 +35,15 @@ import {
   isOptionalString,
   isRecord,
 } from './record-schema.js';
-import { isAttachmentRef, isPermissionDecisionFields } from './interaction-record-schema.js';
+import { isPermissionDecisionFields } from './interaction-record-schema.js';
 import { isTokenUsageFields } from './usage-record-schema.js';
 import {
   decodeCanonicalToolResultContent,
   normalizeToolResultContentForRead,
 } from './tool-result-record-schema.js';
+
+export { isDeepResearchSession } from './explore-agent.js';
+export { isExpertTeamSession } from './expert-team.js';
 
 export const SESSION_STATUSES = [
   'active',
@@ -561,26 +564,11 @@ export type StoredMessage =
   | TurnStateMessage
   | SystemNoteMessage;
 
-export interface UserMessage {
+export interface UserMessage extends MessageContent {
   type: 'user';
   id: string;
   turnId: string;
   ts: number;
-  /**
-   * Model-facing turn text (and the default human-facing text). May be a
-   * composed envelope when the client injected content such as explicit
-   * skill instructions; see `displayText`.
-   */
-  text: string;
-  /**
-   * Human-facing text when it differs from `text`. Presentation layers
-   * (transcript, rewind, previews, search) should prefer this. Absent on
-   * legacy rows and on turns where the model text is what the user typed.
-   */
-  displayText?: string;
-  attachments?: AttachmentRef[];
-  /** Inline quoted excerpts carried into this message; rendered as chips. */
-  quotes?: QuoteRef[];
   /** Non-user trigger source (automation fire). Lets the chat mark turns the
    *  user did not hand-type. Mirrors TurnOrigin in runtime-inputs. */
   origin?: { kind: 'automation'; automationId: string };
@@ -852,13 +840,19 @@ function decodeStoredMessage(
       if (
         hasExactShape(message, USER_MESSAGE_SHAPE) &&
         hasMessageEnvelope(message, true) &&
-        typeof message.text === 'string' &&
-        isOptionalString(message.displayText) &&
-        (message.attachments === undefined ||
-          (Array.isArray(message.attachments) && message.attachments.every(isAttachmentRef))) &&
         (message.origin === undefined || isAutomationOrigin(message.origin))
-      )
-        return message as unknown as UserMessage;
+      ) {
+        const { displayText, attachments, quotes, origin, ...envelope } = message;
+        try {
+          return {
+            ...envelope,
+            ...decodeMessageContent({ text: message.text, displayText, attachments, quotes }),
+            ...(origin !== undefined ? { origin } : {}),
+          } as unknown as UserMessage;
+        } catch {
+          break;
+        }
+      }
       break;
     case 'assistant':
       if (

--- a/packages/core/src/tool-result-record-schema.ts
+++ b/packages/core/src/tool-result-record-schema.ts
@@ -3,7 +3,7 @@ import {
   normalizeShellToolResultContent,
 } from './shell-run-result.js';
 import { isPermissionMode } from './permission.js';
-import type { ToolResultContent } from './events.js';
+import { isStorageRef, type ToolResultContent } from './events.js';
 import {
   defineObjectShape,
   hasExactShape,
@@ -13,7 +13,6 @@ import {
   isRecord,
   isStringArray,
 } from './record-schema.js';
-import { isStorageRef } from './interaction-record-schema.js';
 
 type Result<K extends ToolResultContent['kind']> = Extract<ToolResultContent, { kind: K }>;
 type ExploreResult = Result<'explore_agent'>;

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -720,6 +720,13 @@ function closeServer(server: Server): Promise<void> {
 }
 
 function createHandlers(queryTurn: TurnQueryHandler): RuntimeHostComposition['handlers'] {
+  const unavailable: Awaited<ReturnType<OperationHandlerMap['turn.message.submit']>> = {
+    ok: false,
+    error: {
+      code: 'operation_unavailable',
+      message: 'not available in this test composition',
+    },
+  };
   return {
     ...createUnavailableDomainOperationHandlers(),
     'turn.start': async (input) => ({
@@ -731,6 +738,9 @@ function createHandlers(queryTurn: TurnQueryHandler): RuntimeHostComposition['ha
       ok: true,
       result: runningSnapshot(input.sessionId, input.turnId),
     }),
+    'turn.message.submit': async () => unavailable,
+    'queue.retract': async () => unavailable,
+    'turn.interrupt': async () => unavailable,
   };
 }
 

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -25,6 +25,8 @@ const allowedHostExternalImports = new Set([
 const allowedServerExternalImports = new Set([
   ...allowedHostExternalImports,
   '@maka/core/agent-run',
+  '@maka/core/backend-types',
+  '@maka/core/events',
   '@maka/core/runtime-policy',
   '@maka/core/runtime-event',
   '@maka/core/session',
@@ -34,7 +36,12 @@ const allowedServerExternalImports = new Set([
 ]);
 const allowedExternalImports = {
   client: allowedHostExternalImports,
-  protocol: new Set(['@maka/core/runtime-policy', 'node:util']),
+  protocol: new Set([
+    '@maka/core/attachments',
+    '@maka/core/events',
+    '@maka/core/runtime-policy',
+    'node:util',
+  ]),
 } as const;
 
 async function dependencyScannerFixture(target: string): Promise<void> {

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -7,10 +7,16 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import type { AgentRunHeader } from '@maka/core/agent-run';
+import type { MessageContent } from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
 import { isTerminalRuntimeEvent } from '@maka/core/runtime-event';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
-import { classifyTerminalRuntimeLedger, FAKE_ASK_USER_QUESTION_PROMPT } from '@maka/runtime';
+import {
+  buildRecoveredTerminalRuntimeEvent,
+  classifyTerminalRuntimeLedger,
+  commitTerminalRunWithRuntimeFact,
+  FAKE_ASK_USER_QUESTION_PROMPT,
+} from '@maka/runtime';
 import {
   openInteractiveExecutionStoresForRead,
   openInteractiveExecutionStoresForWrite,
@@ -30,6 +36,7 @@ import {
 import {
   decodeHostFrame,
   RUNTIME_HOST_PROTOCOL_VERSION,
+  type TurnMessageSubmitInput,
   type TurnSnapshot,
 } from '../protocol/index.js';
 import { FramedTransport } from '../transport/framed-transport.js';
@@ -89,7 +96,7 @@ test('two Clients share one execution after the starting Client disconnects', as
     const started = await first.startTurn({
       sessionId: fixture.sessionId,
       turnId,
-      text: FAKE_ASK_USER_QUESTION_PROMPT,
+      content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
     });
     assert.equal(started.turnId, turnId);
     await assert.rejects(
@@ -97,7 +104,7 @@ test('two Clients share one execution after the starting Client disconnects', as
         second.startTurn({
           sessionId: fixture.sessionId,
           turnId: randomUUID(),
-          text: 'must stay busy',
+          content: { text: 'must stay busy' },
         }),
       operationError('session_busy'),
     );
@@ -123,13 +130,13 @@ test('two Clients share one execution after the starting Client disconnects', as
     const next = await second.startTurn({
       sessionId: fixture.sessionId,
       turnId: nextTurnId,
-      text: FAKE_ASK_USER_QUESTION_PROMPT,
+      content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
     });
     assert.deepEqual(
       await second.startTurn({
         sessionId: fixture.sessionId,
         turnId,
-        text: FAKE_ASK_USER_QUESTION_PROMPT,
+        content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
       }),
       stopped,
     );
@@ -181,12 +188,12 @@ test('concurrent root admission for one Session has a single winner', async () =
       first.startTurn({
         sessionId: fixture.sessionId,
         turnId: turnIds[0],
-        text: FAKE_ASK_USER_QUESTION_PROMPT,
+        content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
       }),
       second.startTurn({
         sessionId: fixture.sessionId,
         turnId: turnIds[1],
-        text: FAKE_ASK_USER_QUESTION_PROMPT,
+        content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
       }),
     ]);
     const winners = outcomes.filter(
@@ -230,7 +237,7 @@ test('an archived Session rejects a new Turn before durable admission', async ()
         client.startTurn({
           sessionId: fixture.sessionId,
           turnId,
-          text: 'must not execute',
+          content: { text: 'must not execute' },
         }),
       operationError('session_archived'),
     );
@@ -256,7 +263,7 @@ test('a killed Host is recovered exactly once before its successor becomes ready
     const started = await first.startTurn({
       sessionId: fixture.sessionId,
       turnId,
-      text: FAKE_ASK_USER_QUESTION_PROMPT,
+      content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
     });
 
     await fixture.killHost(firstHost);
@@ -300,7 +307,7 @@ test('graceful Host shutdown stops and drains an active Turn before releasing ow
     const started = await client.startTurn({
       sessionId: fixture.sessionId,
       turnId,
-      text: FAKE_ASK_USER_QUESTION_PROMPT,
+      content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
     });
 
     const exit = await fixture.stopHost(host);
@@ -331,7 +338,8 @@ test('graceful Host shutdown stops and drains an active Turn before releasing ow
 test('a durable admission without a Run resumes before the Host becomes ready', async () => {
   await withExecutionRoot(async (fixture) => {
     const turnId = randomUUID();
-    const { runId } = await fixture.seedAdmission(turnId, FAKE_ASK_USER_QUESTION_PROMPT);
+    const quotes = quotedContent('recover pending admission');
+    const { runId } = await fixture.seedAdmission(turnId, quotes);
     const host = await fixture.startHost();
     const client = await connectClient(fixture.root, 'tui');
 
@@ -346,7 +354,7 @@ test('a durable admission without a Run resumes before the Host becomes ready', 
         client.startTurn({
           sessionId: fixture.sessionId,
           turnId: randomUUID(),
-          text: 'must remain behind the recovered admission',
+          content: { text: 'must remain behind the recovered admission' },
         }),
       operationError('session_busy'),
     );
@@ -365,11 +373,38 @@ test('a durable admission without a Run resumes before the Host becomes ready', 
     const ledger = await fixture.readTurn(turnId);
     assert.equal(ledger.runs.length, 1);
     assert.equal(ledger.userMessages.length, 1);
+    assert.deepEqual(ledger.userMessages[0]?.quotes, quotes.quotes);
+    assert.deepEqual(userRuntimeContent(ledger.runtimeEvents)?.quotes, quotes.quotes);
     assert.equal(ledger.terminalEvents.length, 1);
     assert.equal(ledger.classification.kind, 'fact');
     if (ledger.classification.kind === 'fact') {
       assert.notEqual(ledger.classification.fact.failureClass, 'app_restarted');
     }
+  });
+});
+
+test('startup recovery compares an existing quoted UserMessage canonically', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const turnId = randomUUID();
+    const content = quotedContent('recover existing message');
+    const { runId, userMessageId } = await fixture.seedRunWithUserMessage(turnId, content);
+    const host = await fixture.startHost();
+    const client = await connectClient(fixture.root, 'tui');
+
+    const recovered = await client.queryTurn({
+      sessionId: fixture.sessionId,
+      turnId,
+    });
+    assert.equal(recovered.runId, runId);
+    assert.equal(recovered.status, 'failed');
+    await client.close();
+    await fixture.stopHost(host);
+
+    const ledger = await fixture.readTurn(turnId);
+    assert.equal(ledger.userMessages.length, 1);
+    assert.equal(ledger.userMessages[0]?.id, userMessageId);
+    assert.deepEqual(ledger.userMessages[0]?.quotes, content.quotes);
+    assert.equal(ledger.terminalEvents.length, 1);
   });
 });
 
@@ -400,6 +435,63 @@ test('startup recovery restores the admitted UserMessage before terminalizing it
     assert.equal(ledger.userMessages.length, 1);
     assert.equal(ledger.userMessages[0]?.id, userMessageId);
     assert.equal(ledger.terminalEvents.length, 1);
+  });
+});
+
+test('startup recovery canonically closes pending linked child admissions without inventing identity', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const initial = await fixture.seedPendingChildAdmission('linked_child_initial');
+    const resume = await fixture.seedPendingChildAdmission('linked_child_resume');
+    const retry = await fixture.seedPendingChildAdmission('linked_child_provider_retry');
+
+    const firstHost = await fixture.startHost();
+    await fixture.stopHost(firstHost);
+    const secondHost = await fixture.startHost();
+    await fixture.stopHost(secondHost);
+
+    const reader = await tryAcquireInteractiveRootReader(fixture.capability);
+    assert.ok(reader);
+    if (!reader) throw new Error('Unable to acquire recovery result reader');
+    try {
+      const stores = await openInteractiveExecutionStoresForRead(reader.lease);
+      for (const recovered of [initial, resume, retry]) {
+        const run = await stores.agentRunStore.readRun(recovered.sessionId, recovered.runId);
+        assert.equal(run.status, 'failed');
+        assert.equal(run.failureClass, 'app_restarted');
+        assert.equal(run.agentId, recovered.agentId);
+        assert.equal(run.agentName, recovered.agentName);
+        assert.equal(run.workspaceIdentity, undefined);
+        if (recovered.kind === 'linked_child_resume') {
+          assert.equal(run.resumedFromRunId, recovered.sourceRunId);
+          assert.equal(run.retriedFromRunId, undefined);
+        } else if (recovered.kind === 'linked_child_provider_retry') {
+          assert.equal(run.retriedFromRunId, recovered.sourceRunId);
+          assert.equal(run.resumedFromRunId, undefined);
+        } else {
+          assert.equal(run.resumedFromRunId, undefined);
+          assert.equal(run.retriedFromRunId, undefined);
+        }
+        const runtimeEvents = await stores.runtimeEventStore.readImmutableRuntimeEvents(
+          recovered.sessionId,
+          recovered.runId,
+        );
+        const terminal = classifyTerminalRuntimeLedger(run, runtimeEvents);
+        assert.equal(terminal.kind, 'fact');
+        if (terminal.kind === 'fact') {
+          assert.equal(terminal.fact.runStatus, 'failed');
+          assert.equal(terminal.fact.failureClass, 'app_restarted');
+        }
+        const userMessages = (await stores.sessionStore.readMessages(recovered.sessionId)).filter(
+          (message) => message.type === 'user' && message.turnId === recovered.turnId,
+        );
+        assert.equal(userMessages.length, recovered.kind === 'linked_child_provider_retry' ? 0 : 1);
+        if (recovered.kind !== 'linked_child_provider_retry') {
+          assert.equal(userMessages[0]?.id, recovered.userMessageId);
+        }
+      }
+    } finally {
+      await reader.close();
+    }
   });
 });
 
@@ -500,7 +592,7 @@ test('a pre-start durability failure rejects turn.start and drains the Host', {
           client.startTurn({
             sessionId: fixture.sessionId,
             turnId,
-            text: 'fail before the durable start barrier',
+            content: { text: 'fail before the durable start barrier' },
           }),
         operationError('internal_failure'),
       );
@@ -544,7 +636,7 @@ test('retry after a discarded turn.start response reuses the durable semantic ad
     const retried = await observer.startTurn({
       sessionId: fixture.sessionId,
       turnId,
-      text,
+      content: { text },
     });
     assert.equal(retried.runId, committed.runId);
     await assert.rejects(
@@ -552,7 +644,7 @@ test('retry after a discarded turn.start response reuses the durable semantic ad
         observer.startTurn({
           sessionId: fixture.sessionId,
           turnId,
-          text: `${text} changed`,
+          content: { text: `${text} changed` },
         }),
       operationError('operation_conflict'),
     );
@@ -564,14 +656,18 @@ test('retry after a discarded turn.start response reuses the durable semantic ad
     const successorHost = await fixture.startHost();
     const successorClient = await connectClient(fixture.root, 'run');
     assert.deepEqual(
-      await successorClient.startTurn({ sessionId: fixture.sessionId, turnId, text }),
+      await successorClient.startTurn({
+        sessionId: fixture.sessionId,
+        turnId,
+        content: { text },
+      }),
       terminal,
     );
     const successorTurnId = randomUUID();
     await successorClient.startTurn({
       sessionId: fixture.sessionId,
       turnId: successorTurnId,
-      text: 'successor must extend the recovered durable tip',
+      content: { text: 'successor must extend the recovered durable tip' },
     });
     await waitForTerminalTurn(successorClient, fixture.sessionId, successorTurnId);
     await successorClient.close();
@@ -590,6 +686,429 @@ test('retry after a discarded turn.start response reuses the durable semantic ad
   });
 });
 
+test('a fresh quoted Turn preserves durable and Runtime handoff content', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const host = await fixture.startHost();
+    const client = await connectClient(fixture.root, 'desktop');
+    const turnId = randomUUID();
+    const content = quotedContent('fresh quoted turn');
+
+    await client.startTurn({ sessionId: fixture.sessionId, turnId, content });
+    await waitForTerminalTurn(client, fixture.sessionId, turnId);
+    await client.close();
+    await fixture.stopHost(host);
+
+    const chain = await fixture.readAdmissionChain();
+    assert.equal(chain.length, 1);
+    assert.deepEqual(chain[0]?.normalizedInput, content);
+    const ledger = await fixture.readTurn(turnId);
+    assert.equal(ledger.userMessages.length, 1);
+    assert.deepEqual(ledger.userMessages[0]?.quotes, content.quotes);
+    assert.deepEqual(userRuntimeContent(ledger.runtimeEvents)?.quotes, content.quotes);
+  });
+});
+
+test('same idle Message submit is connection-independent and starts one canonical root', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const host = await fixture.startHost();
+    const first = await connectClient(fixture.root, 'desktop');
+    const second = await connectClient(fixture.root, 'tui');
+    const messageId = randomUUID();
+    const content = {
+      text: '<context>canonical model input</context>',
+      displayText: 'canonical display input',
+      attachments: [attachment('idle-message', 'context.png')],
+    };
+    const input = {
+      originHostEpoch: host.hostEpoch,
+      sessionId: fixture.sessionId,
+      messageId,
+      content,
+      placement: 'next_turn' as const,
+    };
+
+    const [firstResult, secondResult] = await Promise.all([
+      first.request('turn.message.submit', input),
+      second.request('turn.message.submit', input),
+    ]);
+    assert.deepEqual(secondResult, firstResult);
+    assert.equal(firstResult.disposition, 'turn_started');
+    if (firstResult.disposition !== 'turn_started') return;
+    await waitForTerminalTurn(first, fixture.sessionId, firstResult.turnId);
+    await first.close();
+    await second.close();
+    await fixture.stopHost(host);
+
+    const chain = await fixture.readAdmissionChain();
+    assert.equal(chain.length, 1);
+    assert.deepEqual(chain[0]?.normalizedInput, content);
+    assert.deepEqual(chain[0]?.sourceMessages, [
+      { messageId, content, placement: 'next_turn', disposition: 'turn_started' },
+    ]);
+    const ledger = await fixture.readTurn(firstResult.turnId);
+    assert.equal(ledger.runs.length, 1);
+    assert.equal(ledger.userMessages.length, 1);
+    assert.equal(ledger.userMessages[0]?.id, messageId);
+    assert.equal(ledger.userMessages[0]?.text, content.text);
+    assert.equal(ledger.userMessages[0]?.displayText, content.displayText);
+    assert.deepEqual(ledger.userMessages[0]?.attachments, content.attachments);
+  });
+});
+
+test('stale Session operations return not_found across the SQLite-backed UDS Host boundary', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const host = await fixture.startHost();
+    const client = await connectClient(fixture.root, 'desktop');
+    const staleSessionId = randomUUID();
+    try {
+      await assert.rejects(
+        () =>
+          client.request('turn.message.submit', {
+            originHostEpoch: host.hostEpoch,
+            sessionId: staleSessionId,
+            messageId: randomUUID(),
+            content: { text: 'stale submit' },
+            placement: 'next_turn',
+          }),
+        operationError('not_found'),
+      );
+      await assert.rejects(
+        () =>
+          client.request('turn.interrupt', {
+            originHostEpoch: host.hostEpoch,
+            sessionId: staleSessionId,
+            interruptId: randomUUID(),
+            turnId: randomUUID(),
+            runId: randomUUID(),
+          }),
+        operationError('not_found'),
+      );
+      await assert.rejects(
+        () =>
+          client.startTurn({
+            sessionId: staleSessionId,
+            turnId: randomUUID(),
+            content: { text: 'stale start' },
+          }),
+        operationError('not_found'),
+      );
+    } finally {
+      await client.close();
+      await fixture.stopHost(host);
+    }
+  });
+});
+
+test('steering becomes durable and ordered followups automatically start the next root', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const host = await fixture.startHost();
+    const first = await connectClient(fixture.root, 'desktop');
+    const second = await connectClient(fixture.root, 'tui');
+    const firstTurnId = randomUUID();
+    await first.startTurn({
+      sessionId: fixture.sessionId,
+      turnId: firstTurnId,
+      content: { text: `long-running root ${'x'.repeat(540)}` },
+    });
+    const steeringId = randomUUID();
+    const steeringContent = {
+      text: '<steer>use the correction</steer>',
+      displayText: 'use the correction',
+      attachments: [attachment('steering', 'correction.png')],
+    };
+    const followupSources: Array<{ messageId: string; content: MessageContent }> = [
+      {
+        messageId: randomUUID(),
+        content: {
+          text: '<followup>first queued task</followup>',
+          displayText: 'first queued task',
+          attachments: [attachment('followup-first', 'first.png')],
+          quotes: quoteRefs('followup-first'),
+        },
+      },
+      {
+        messageId: randomUUID(),
+        content: {
+          text: 'second queued task',
+          quotes: [
+            {
+              text: 'second followup excerpt',
+              sourceTurnId: 'turn-followup-second',
+            },
+          ],
+        },
+      },
+    ];
+
+    assert.equal(
+      (
+        await second.request('turn.message.submit', {
+          originHostEpoch: host.hostEpoch,
+          sessionId: fixture.sessionId,
+          messageId: steeringId,
+          content: steeringContent,
+          placement: 'current_turn',
+        })
+      ).disposition,
+      'steering',
+    );
+    for (const source of followupSources) {
+      assert.equal(
+        (
+          await second.request('turn.message.submit', {
+            originHostEpoch: host.hostEpoch,
+            sessionId: fixture.sessionId,
+            ...source,
+            placement: 'next_turn',
+          })
+        ).disposition,
+        'followup',
+      );
+    }
+
+    assert.equal(
+      (await waitForTerminalTurn(first, fixture.sessionId, firstTurnId)).status,
+      'completed',
+    );
+    await waitForDurableMessageConflict(second, {
+      originHostEpoch: 'previous-host-epoch',
+      sessionId: fixture.sessionId,
+      messageId: followupSources[0]!.messageId,
+      content: { text: 'deliberately different durable identity probe' },
+      placement: 'next_turn',
+    });
+    await first.close();
+    await second.close();
+    await fixture.stopHost(host);
+
+    const firstLedger = await fixture.readTurn(firstTurnId);
+    const steeringEvents = firstLedger.runtimeEvents.filter(
+      (event) =>
+        event.refs?.providerEventId === steeringId &&
+        event.content?.kind === 'text' &&
+        event.content.steering === true,
+    );
+    assert.equal(steeringEvents.length, 1);
+    assert.equal(steeringEvents[0]?.content?.kind, 'text');
+    if (steeringEvents[0]?.content?.kind === 'text') {
+      const { kind: _kind, steering: _steering, ...durableContent } = steeringEvents[0].content;
+      assert.deepEqual(durableContent, steeringContent);
+    }
+
+    const chain = await fixture.readAdmissionChain();
+    assert.equal(chain.length, 2);
+    assert.equal(chain[1]?.previousRootTurnId, firstTurnId);
+    assert.deepEqual(
+      chain[1]?.sourceMessages,
+      followupSources.map((source) => ({
+        ...source,
+        placement: 'next_turn',
+        disposition: 'followup',
+      })),
+    );
+    assert.deepEqual(chain[1]?.normalizedInput, {
+      text: `${followupSources[0].content.text}\n\n${followupSources[1].content.text}`,
+      displayText: `${followupSources[0].content.displayText}\n\n${followupSources[1].content.text}`,
+      attachments: followupSources[0].content.attachments,
+      quotes: followupSources.flatMap((source) => source.content.quotes ?? []),
+    });
+    const followupTurnId = chain[1]?.turnId;
+    assert.ok(followupTurnId);
+    const followupLedger = await fixture.readTurn(followupTurnId);
+    const expectedQuotes = followupSources.flatMap((source) => source.content.quotes ?? []);
+    assert.equal(followupLedger.userMessages.length, 1);
+    assert.deepEqual(followupLedger.userMessages[0]?.quotes, expectedQuotes);
+    assert.deepEqual(userRuntimeContent(followupLedger.runtimeEvents)?.quotes, expectedQuotes);
+  });
+});
+
+test('explicit retract is durable across connections and prevents successor admission', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const host = await fixture.startHost();
+    const first = await connectClient(fixture.root, 'desktop');
+    const second = await connectClient(fixture.root, 'tui');
+    const turnId = randomUUID();
+    const started = await first.startTurn({
+      sessionId: fixture.sessionId,
+      turnId,
+      content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
+    });
+    const messageId = randomUUID();
+    const submitted = await first.request('turn.message.submit', {
+      originHostEpoch: host.hostEpoch,
+      sessionId: fixture.sessionId,
+      messageId,
+      content: { text: 'withdraw before successor admission' },
+      placement: 'next_turn',
+    });
+    assert.equal(submitted.disposition, 'followup');
+
+    const retractInput = {
+      originHostEpoch: host.hostEpoch,
+      sessionId: fixture.sessionId,
+      retractId: randomUUID(),
+    };
+    const retracted = await second.request('queue.retract', retractInput);
+    assert.deepEqual(
+      retracted.retracted.map((entry) => ({ messageId: entry.messageId, state: entry.state })),
+      [{ messageId, state: 'retracted' }],
+    );
+
+    await second.close();
+    const retrying = await connectClient(fixture.root, 'run');
+    assert.deepEqual(await retrying.request('queue.retract', retractInput), retracted);
+
+    const terminal = await first.stopTurn({
+      sessionId: fixture.sessionId,
+      turnId,
+      runId: started.runId,
+    });
+    assert.equal(terminal.status, 'cancelled');
+    await first.close();
+    await retrying.close();
+    await fixture.stopHost(host);
+
+    const chain = await fixture.readAdmissionChain();
+    assert.deepEqual(
+      chain.map((admission) => admission.turnId),
+      [turnId],
+    );
+  });
+});
+
+test('interrupt atomically retracts queued followup, stops the exact run, and is idempotent', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const host = await fixture.startHost();
+    const first = await connectClient(fixture.root, 'desktop');
+    const second = await connectClient(fixture.root, 'tui');
+    const turnId = randomUUID();
+    const started = await first.startTurn({
+      sessionId: fixture.sessionId,
+      turnId,
+      content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
+    });
+    const followupId = randomUUID();
+    const followupContent = {
+      text: '<followup>must be withdrawn</followup>',
+      displayText: 'must be withdrawn',
+      attachments: [attachment('interrupt-followup', 'withdraw.png')],
+    };
+    await second.request('turn.message.submit', {
+      originHostEpoch: host.hostEpoch,
+      sessionId: fixture.sessionId,
+      messageId: followupId,
+      content: followupContent,
+      placement: 'next_turn',
+    });
+    const interruptInput = {
+      originHostEpoch: host.hostEpoch,
+      sessionId: fixture.sessionId,
+      interruptId: randomUUID(),
+      turnId,
+      runId: started.runId,
+    };
+
+    const [interrupted, concurrentRetry] = await Promise.all([
+      first.request('turn.interrupt', interruptInput, PROCESS_TIMEOUT_MS),
+      second.request('turn.interrupt', interruptInput, PROCESS_TIMEOUT_MS),
+    ]);
+    assert.deepEqual(concurrentRetry, interrupted);
+    assert.deepEqual(
+      await second.request('turn.interrupt', interruptInput, PROCESS_TIMEOUT_MS),
+      interrupted,
+    );
+    assert.equal(interrupted.turn.turnId, turnId);
+    assert.equal(interrupted.turn.runId, started.runId);
+    assert.equal(interrupted.turn.status, 'cancelled');
+    assert.equal(interrupted.retracted.length, 1);
+    assert.ok(interrupted.retracted[0]?.entryId);
+    assert.deepEqual(interrupted.retracted, [
+      {
+        entryId: interrupted.retracted[0]?.entryId,
+        messageId: followupId,
+        content: followupContent,
+        placement: 'next_turn',
+        state: 'retracted',
+      },
+    ]);
+    await first.close();
+    await second.close();
+    await fixture.stopHost(host);
+
+    const chain = await fixture.readAdmissionChain();
+    assert.equal(chain.length, 1);
+    assert.equal(chain[0]?.turnId, turnId);
+  });
+});
+
+test('old-Epoch Message submit returns only exact durable outcomes', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const firstHost = await fixture.startHost();
+    const first = await connectClient(fixture.root, 'desktop');
+    const rootMessageId = randomUUID();
+    const rootContent = { text: `durable root ${'x'.repeat(360)}` };
+    const rootResult = await first.request('turn.message.submit', {
+      originHostEpoch: firstHost.hostEpoch,
+      sessionId: fixture.sessionId,
+      messageId: rootMessageId,
+      content: rootContent,
+      placement: 'next_turn',
+    });
+    assert.equal(rootResult.disposition, 'turn_started');
+    if (rootResult.disposition !== 'turn_started') return;
+    await waitForRunningTurn(first, fixture.sessionId, rootResult.turnId);
+    const steeringId = randomUUID();
+    const steeringContent = { text: 'durable steering proof' };
+    await first.request('turn.message.submit', {
+      originHostEpoch: firstHost.hostEpoch,
+      sessionId: fixture.sessionId,
+      messageId: steeringId,
+      content: steeringContent,
+      placement: 'current_turn',
+    });
+    await waitForTerminalTurn(first, fixture.sessionId, rootResult.turnId);
+    await first.close();
+    await fixture.stopHost(firstHost);
+
+    const successorHost = await fixture.startHost();
+    const successor = await connectClient(fixture.root, 'run');
+    assert.deepEqual(
+      await successor.request('turn.message.submit', {
+        originHostEpoch: firstHost.hostEpoch,
+        sessionId: fixture.sessionId,
+        messageId: rootMessageId,
+        content: rootContent,
+        placement: 'next_turn',
+      }),
+      rootResult,
+    );
+    await assert.rejects(
+      () =>
+        successor.request('turn.message.submit', {
+          originHostEpoch: firstHost.hostEpoch,
+          sessionId: fixture.sessionId,
+          messageId: steeringId,
+          content: steeringContent,
+          placement: 'current_turn',
+        }),
+      operationError('outcome_unknown'),
+    );
+    await assert.rejects(
+      () =>
+        successor.request('turn.message.submit', {
+          originHostEpoch: firstHost.hostEpoch,
+          sessionId: fixture.sessionId,
+          messageId: randomUUID(),
+          content: { text: 'no durable proof exists' },
+          placement: 'next_turn',
+        }),
+      operationError('outcome_unknown'),
+    );
+    await successor.close();
+    await fixture.stopHost(successorHost);
+  });
+});
+
 interface ExecutionHostHandle {
   child: ChildProcess;
   hostEpoch: string;
@@ -598,7 +1117,8 @@ interface ExecutionHostHandle {
 
 interface TurnLedger {
   runs: AgentRunHeader[];
-  userMessages: StoredMessage[];
+  userMessages: Array<Extract<StoredMessage, { type: 'user' }>>;
+  runtimeEvents: RuntimeEvent[];
   terminalEvents: RuntimeEvent[];
   classification: ReturnType<typeof classifyTerminalRuntimeLedger>;
 }
@@ -625,8 +1145,148 @@ class ExecutionFixture {
     return join(this.root, 'sessions', this.sessionId, 'runs', runId, 'events.jsonl');
   }
 
-  seedAdmission(turnId: string, text: string): Promise<{ runId: string; userMessageId: string }> {
-    return this.seedTurnState(turnId, text, false);
+  async seedPendingChildAdmission(
+    kind: 'linked_child_initial' | 'linked_child_resume' | 'linked_child_provider_retry',
+  ): Promise<{
+    kind: 'linked_child_initial' | 'linked_child_resume' | 'linked_child_provider_retry';
+    sessionId: string;
+    turnId: string;
+    runId: string;
+    sourceRunId: string | undefined;
+    userMessageId: string | null;
+    agentId: string;
+    agentName: string;
+  }> {
+    const owner = await tryAcquireInteractiveRootOwner(this.capability);
+    assert.ok(owner);
+    if (!owner) throw new Error('Unable to acquire execution root for child admission setup');
+    try {
+      const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+      const turnId = randomUUID();
+      const runId = randomUUID();
+      const sourceRunId = kind === 'linked_child_initial' ? undefined : randomUUID();
+      const agentId = 'local-read';
+      const agentName = 'Local Read';
+      const child = await stores.sessionStore.createSubagent({
+        cwd: this.root,
+        name: `${agentName} ${kind}`,
+        backend: 'fake',
+        llmConnectionSlug: 'fake',
+        model: 'fake-model',
+        permissionMode: 'explore',
+        collaborationMode: 'agent',
+        orchestrationMode: 'default',
+        subagentParent: {
+          kind: 'subagent',
+          parentSessionId: this.sessionId,
+          spawnedBy: {
+            parentRunId: `parent-${kind}`,
+            parentTurnId: `parent-turn-${kind}`,
+            toolCallId: `tool-${kind}`,
+          },
+          lifecycle: 'foreground',
+        },
+        subagentRuntime: {
+          schemaVersion: 1,
+          definitionVersion: 1,
+          agentId,
+          agentName,
+          profile: 'local_read',
+          systemPrompt: 'Read the assigned workspace task.',
+          toolNames: ['Read', 'Glob', 'Grep'],
+          categoryPolicy: { read: 'allow' },
+          permissionCeiling: 'ask',
+        },
+        subagentSpawn: {
+          schemaVersion: 1,
+          requestFingerprint: (kind === 'linked_child_initial'
+            ? 'a'
+            : kind === 'linked_child_resume'
+              ? 'b'
+              : 'c'
+          ).repeat(64),
+          initialTurnId: kind === 'linked_child_initial' ? turnId : `initial-${kind}`,
+          initialRunId: kind === 'linked_child_initial' ? runId : sourceRunId!,
+        },
+      });
+      assert.equal(child.created, true);
+      if (sourceRunId) {
+        const sourceTs = Date.now();
+        const sourceRun: AgentRunHeader = {
+          runId: sourceRunId,
+          invocationId: sourceRunId,
+          sessionId: child.header.id,
+          turnId: `source-turn-${kind}`,
+          status: 'created',
+          backendKind: 'fake',
+          llmConnectionSlug: 'fake',
+          modelId: 'fake-model',
+          cwd: this.root,
+          permissionMode: 'explore',
+          collaborationMode: 'agent',
+          createdAt: sourceTs,
+          updatedAt: sourceTs,
+          agentId,
+          agentName,
+        };
+        await stores.agentRunStore.createRun(sourceRun, { durable: true });
+        const sourceTerminal = buildRecoveredTerminalRuntimeEvent({
+          id: randomUUID(),
+          run: sourceRun,
+          status: 'failed',
+          ts: sourceTs,
+          failureClass: kind === 'linked_child_provider_retry' ? 'RateLimit' : 'source_failed',
+          recoveryReason: 'test_source_terminal',
+        });
+        await commitTerminalRunWithRuntimeFact({
+          runStore: stores.agentRunStore,
+          runtimeEventStore: stores.runtimeEventStore,
+          newId: randomUUID,
+          sessionId: child.header.id,
+          runId: sourceRunId,
+          turnId: sourceRun.turnId,
+          status: 'failed',
+          ts: sourceTs,
+          terminalEvent: sourceTerminal,
+          failureClass: kind === 'linked_child_provider_retry' ? 'RateLimit' : 'source_failed',
+        });
+      }
+      const userMessageId = kind === 'linked_child_provider_retry' ? null : randomUUID();
+      const admitted = await stores.agentRunStore.admitRootTurn({
+        sessionId: child.header.id,
+        turnId,
+        proposedRunId: runId,
+        proposedUserMessageId: userMessageId,
+        execution:
+          kind === 'linked_child_initial'
+            ? { kind, agentId, agentName }
+            : { kind, agentId, agentName, sourceRunId: sourceRunId! },
+        previousRootTurnId: null,
+        normalizedInput: { text: `pending ${kind}` },
+        sourceMessages: [],
+        admittedAt: Date.now(),
+      });
+      assert.equal(admitted.kind, 'admitted');
+      return {
+        kind,
+        sessionId: child.header.id,
+        turnId,
+        runId,
+        sourceRunId,
+        userMessageId,
+        agentId,
+        agentName,
+      };
+    } finally {
+      await owner.close();
+    }
+  }
+
+  seedAdmission(
+    turnId: string,
+    content: string | MessageContent,
+  ): Promise<{ runId: string; userMessageId: string }> {
+    return this.seedTurnState(turnId, content, false, false);
   }
 
   async archiveSession(): Promise<void> {
@@ -643,15 +1303,23 @@ class ExecutionFixture {
 
   seedRunWithoutUserMessage(
     turnId: string,
-    text: string,
+    content: string | MessageContent,
   ): Promise<{ runId: string; userMessageId: string }> {
-    return this.seedTurnState(turnId, text, true);
+    return this.seedTurnState(turnId, content, true, false);
+  }
+
+  seedRunWithUserMessage(
+    turnId: string,
+    content: MessageContent,
+  ): Promise<{ runId: string; userMessageId: string }> {
+    return this.seedTurnState(turnId, content, true, true);
   }
 
   private async seedTurnState(
     turnId: string,
-    text: string,
+    input: string | MessageContent,
     createRun: boolean,
+    createUserMessage: boolean,
   ): Promise<{ runId: string; userMessageId: string }> {
     const owner = await tryAcquireInteractiveRootOwner(this.capability);
     assert.ok(owner);
@@ -659,13 +1327,16 @@ class ExecutionFixture {
     try {
       const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
       const admittedAt = Date.now();
+      const content = typeof input === 'string' ? { text: input } : input;
       const result = await stores.agentRunStore.admitRootTurn({
         sessionId: this.sessionId,
         turnId,
         proposedRunId: randomUUID(),
         proposedUserMessageId: randomUUID(),
+        execution: { kind: 'external_message' },
         previousRootTurnId: null,
-        normalizedInput: { text },
+        normalizedInput: content,
+        sourceMessages: [],
         admittedAt,
       });
       assert.equal(result.kind, 'admitted');
@@ -683,6 +1354,16 @@ class ExecutionFixture {
           permissionMode: 'ask',
           createdAt: admittedAt,
           updatedAt: admittedAt,
+        });
+      }
+      assert.ok(result.admission.userMessageId);
+      if (createUserMessage) {
+        await stores.sessionStore.appendMessage(this.sessionId, {
+          type: 'user',
+          id: result.admission.userMessageId,
+          turnId,
+          ts: admittedAt,
+          ...content,
         });
       }
       return {
@@ -765,8 +1446,10 @@ class ExecutionFixture {
       return {
         runs,
         userMessages: messages.filter(
-          (message) => message.type === 'user' && message.turnId === turnId,
+          (message): message is Extract<StoredMessage, { type: 'user' }> =>
+            message.type === 'user' && message.turnId === turnId,
         ),
+        runtimeEvents,
         terminalEvents: runtimeEvents.filter(isTerminalRuntimeEvent),
         classification: classifyTerminalRuntimeLedger(run, runtimeEvents),
       };
@@ -900,7 +1583,11 @@ async function sendStartWithoutReadingResponse(
   await transport.write({
     requestId: randomUUID(),
     operation: 'turn.start',
-    input,
+    input: {
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      content: { text: input.text },
+    },
   });
   return transport;
 }
@@ -958,6 +1645,40 @@ async function waitForTerminalTurn(
   }
 }
 
+async function waitForRunningTurn(
+  connection: RuntimeHostConnection,
+  sessionId: string,
+  turnId: string,
+): Promise<TurnSnapshot> {
+  const deadline = Date.now() + PROCESS_TIMEOUT_MS;
+  while (true) {
+    const snapshot = await connection.queryTurn({ sessionId, turnId });
+    if (snapshot.status === 'running' || snapshot.status === 'waiting_permission') return snapshot;
+    if (Date.now() >= deadline) throw new Error('Turn did not become active');
+    await sleep(20);
+  }
+}
+
+async function waitForDurableMessageConflict(
+  connection: RuntimeHostConnection,
+  input: TurnMessageSubmitInput,
+): Promise<void> {
+  const deadline = Date.now() + PROCESS_TIMEOUT_MS;
+  while (true) {
+    try {
+      await connection.request('turn.message.submit', input);
+      throw new Error('Conflicting durable Message identity was accepted');
+    } catch (error) {
+      if (error instanceof RuntimeHostOperationError && error.code === 'operation_conflict') return;
+      if (!(error instanceof RuntimeHostOperationError) || error.code !== 'outcome_unknown') {
+        throw error;
+      }
+    }
+    if (Date.now() >= deadline) throw new Error('Durable Message source was not observed');
+    await sleep(20);
+  }
+}
+
 function operationError(code: RuntimeHostOperationError['code']) {
   return (error: unknown): boolean =>
     error instanceof RuntimeHostOperationError && error.code === code;
@@ -967,6 +1688,43 @@ function assertJsonLines(bytes: string): void {
   for (const line of bytes.split('\n').filter(Boolean)) {
     assert.doesNotThrow(() => JSON.parse(line));
   }
+}
+
+function attachment(id: string, name: string) {
+  return {
+    kind: 'image' as const,
+    name,
+    mimeType: 'image/png',
+    bytes: 10,
+    ref: { kind: 'workspace_file' as const, relativePath: `attachments/${id}.png` },
+  };
+}
+
+function quoteRefs(prefix: string) {
+  return [
+    {
+      text: `${prefix} first excerpt`,
+      label: 'Assistant',
+      sourceTurnId: `turn-${prefix}-1`,
+    },
+    {
+      text: `${prefix} second excerpt`,
+      sourceTurnId: `turn-${prefix}-2`,
+    },
+  ];
+}
+
+function quotedContent(text: string): MessageContent {
+  return { text, quotes: quoteRefs(text.replaceAll(' ', '-')) };
+}
+
+function userRuntimeContent(
+  events: readonly RuntimeEvent[],
+): Extract<NonNullable<RuntimeEvent['content']>, { kind: 'text' }> | undefined {
+  for (const event of events) {
+    if (event.role === 'user' && event.content?.kind === 'text') return event.content;
+  }
+  return undefined;
 }
 
 function waitForHostReady(child: ChildProcess): Promise<{ hostEpoch: string; endpoint: string }> {

--- a/packages/runtime-host/src/__tests__/fixtures/uncooperative-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/uncooperative-host.ts
@@ -43,6 +43,18 @@ const host = await RuntimeHostKernel.start({
         ok: false,
         error: { code: 'operation_unavailable', message: 'Operation unavailable in test Host' },
       }),
+      'turn.message.submit': async () => ({
+        ok: false,
+        error: { code: 'operation_unavailable', message: 'Operation unavailable in test Host' },
+      }),
+      'queue.retract': async () => ({
+        ok: false,
+        error: { code: 'operation_unavailable', message: 'Operation unavailable in test Host' },
+      }),
+      'turn.interrupt': async () => ({
+        ok: false,
+        error: { code: 'operation_unavailable', message: 'Operation unavailable in test Host' },
+      }),
     },
     async recover() {},
     async close() {},

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -136,6 +136,9 @@ describe('non-serving Runtime Host kernel', () => {
               'turn.start': unavailable,
               'turn.query': unavailable,
               'turn.stop': unavailable,
+              'turn.message.submit': unavailable,
+              'queue.retract': unavailable,
+              'turn.interrupt': unavailable,
             },
             async recover() {},
             async close() {},
@@ -828,7 +831,11 @@ describe('non-serving Runtime Host kernel', () => {
         await transport.write({
           requestId: 'blocked-turn-start',
           operation: 'turn.start',
-          input: { sessionId: 'session', turnId: 'turn', text: 'block forever' },
+          input: {
+            sessionId: 'session',
+            turnId: 'turn',
+            content: { text: 'block forever' },
+          },
         });
         await blocked;
         const shutdownRequested = waitForUncooperativeHostMessage(child, 'shutdown-requested');

--- a/packages/runtime-host/src/__tests__/message-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/message-coordinator.test.ts
@@ -1,0 +1,1378 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { MessageContent } from '@maka/core/events';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import type {
+  MessageOperationReceipt,
+  MessageReceiptStore,
+  RootTurnSourceMessageReceipt,
+} from '@maka/storage/execution-stores';
+import {
+  MESSAGE_OPERATION_RESULT_MAX_BYTES,
+  MESSAGE_QUEUE_PROJECTION_MAX_BYTES,
+  type TurnSnapshot,
+} from '../protocol/index.js';
+import {
+  HostMessageCoordinator,
+  type HostMessageCoordinatorOptions,
+  type HostMessageRootPort,
+  type HostMessageRootState,
+} from '../server/message-coordinator.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+
+const ROOT = { sessionId: 'session-1', turnId: 'turn-1', runId: 'run-1' } as const;
+
+test('idle submit starts exactly one root Turn and retry identity is connection-independent', async () => {
+  const fixture = createFixture();
+  fixture.setRootState({ kind: 'idle' });
+  const input = {
+    originHostEpoch: 'epoch-1',
+    sessionId: ROOT.sessionId,
+    messageId: 'idle-message',
+    content: { text: 'start from idle' },
+    placement: 'next_turn',
+  } as const;
+
+  const first = await fixture.coordinator.handlers['turn.message.submit'](
+    input,
+    operationContext('connection-before-disconnect'),
+  );
+  const retry = await fixture.coordinator.handlers['turn.message.submit'](
+    input,
+    operationContext('connection-after-disconnect'),
+  );
+
+  assert.deepEqual(first, {
+    ok: true,
+    result: { disposition: 'turn_started', turnId: 'idle-turn' },
+  });
+  assert.deepEqual(retry, first);
+  assert.equal(fixture.startCalls(), 1);
+  assert.equal(fixture.liveResidencies(), 0);
+});
+
+test('queue projection capacity is rejected before mutation or residency acquisition', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+
+  const outcome = await submit(fixture, 'oversized', 'x'.repeat(52 * 1024), 'current_turn');
+
+  assert.equal(outcome.ok, false);
+  if (!outcome.ok) assert.equal(outcome.error.code, 'session_busy');
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId).steering, []);
+  assert.equal(fixture.liveResidencies(), 0);
+  fixture.coordinator.abandonRootReservation(ROOT);
+  await fixture.coordinator.close();
+});
+
+test('queue admission rejects content that cannot form a durable follow-up Turn', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+
+  const first = await submit(fixture, 'large-followup', 'x'.repeat(40 * 1024), 'next_turn');
+  assert.equal(first.ok && first.result.disposition, 'followup');
+  const projectionBefore = structuredClone(fixture.coordinator.projection(ROOT.sessionId));
+
+  const rejected = await submitContent(
+    fixture,
+    'display-followup',
+    { text: 'model', displayText: 'human' },
+    'next_turn',
+  );
+  assert.equal(rejected.ok, false);
+  if (!rejected.ok) assert.equal(rejected.error.code, 'session_busy');
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId), projectionBefore);
+  assert.equal(fixture.liveResidencies(), 1);
+
+  const retracted = await fixture.coordinator.handlers['queue.retract'](
+    { originHostEpoch: 'epoch-1', sessionId: ROOT.sessionId, retractId: 'cleanup-large' },
+    operationContext(),
+  );
+  assert.equal(retracted.ok, true);
+  fixture.coordinator.abandonRootReservation(ROOT);
+  await fixture.coordinator.close();
+});
+
+test('pull crosses the retract commit cut and only queued entries are retracted', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+
+  await submit(fixture, 'steer-1', 'steer me', 'current_turn');
+  await submit(fixture, 'follow-1', 'later', 'next_turn');
+  const [lease] = owner.pull();
+  assert.ok(lease);
+
+  const outcome = await fixture.coordinator.handlers['queue.retract'](
+    {
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      retractId: 'retract-1',
+    },
+    operationContext(),
+  );
+  assert.equal(outcome.ok, true);
+  if (!outcome.ok) return;
+  assert.deepEqual(
+    outcome.result.retracted.map((entry) => entry.messageId),
+    ['follow-1'],
+  );
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId), {
+    hostEpoch: 'epoch-1',
+    queueRevision: 4,
+    steering: [
+      {
+        entryId: 'id-1',
+        messageId: 'steer-1',
+        content: { text: 'steer me' },
+        placement: 'current_turn',
+        state: 'in_flight',
+      },
+    ],
+    followup: [],
+  });
+
+  owner.ack([lease.id]);
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  fixture.coordinator.completeIdle(batch);
+  assert.equal(fixture.liveResidencies(), 0);
+});
+
+test('submit mutation is visible before its receipt and concurrent retries share the cut', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  const receipt = fixture.delayReceipt('submit', 'delayed-submit');
+
+  const submitted = submit(fixture, 'delayed-submit', 'steer now', 'current_turn');
+  const retry = submit(fixture, 'delayed-submit', 'steer now', 'current_turn');
+  assert.equal(retry, submitted);
+  const conflict = await submit(fixture, 'delayed-submit', 'different', 'current_turn');
+  assert.equal(conflict.ok, false);
+  if (!conflict.ok) assert.equal(conflict.error.code, 'operation_conflict');
+
+  await receipt.started.promise;
+  assert.deepEqual(
+    fixture.coordinator.projection(ROOT.sessionId).steering.map((entry) => entry.messageId),
+    ['delayed-submit'],
+  );
+  const [lease] = owner.pull();
+  assert.ok(lease);
+  owner.nack([lease.id]);
+
+  receipt.release.resolve(undefined);
+  const outcome = await submitted;
+  assert.deepEqual(outcome, {
+    ok: true,
+    result: { disposition: 'steering', queueRevision: 1 },
+  });
+  assert.deepEqual(await submit(fixture, 'delayed-submit', 'steer now', 'current_turn'), outcome);
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId), {
+    hostEpoch: 'epoch-1',
+    queueRevision: 3,
+    steering: [
+      {
+        entryId: 'id-1',
+        messageId: 'delayed-submit',
+        content: { text: 'steer now' },
+        placement: 'current_turn',
+        state: 'queued',
+      },
+    ],
+    followup: [],
+  });
+
+  await fixture.coordinator.handlers['queue.retract'](
+    { originHostEpoch: 'epoch-1', sessionId: ROOT.sessionId, retractId: 'cleanup-submit-cut' },
+    operationContext(),
+  );
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  fixture.coordinator.completeIdle(batch);
+});
+
+test('retract mutation is visible while its receipt waits and preserves its exact cut', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  await submit(fixture, 'steer-1', 'first', 'current_turn');
+  await submit(fixture, 'steer-2', 'second', 'current_turn');
+  await submit(fixture, 'follow-1', 'later', 'next_turn');
+  const leases = owner.pull();
+  assert.equal(leases.length, 2);
+  const receipt = fixture.delayReceipt('retract', 'delayed-retract');
+
+  const retracted = fixture.coordinator.handlers['queue.retract'](
+    {
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      retractId: 'delayed-retract',
+    },
+    operationContext(),
+  );
+  const retry = fixture.coordinator.handlers['queue.retract'](
+    {
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      retractId: 'delayed-retract',
+    },
+    operationContext(),
+  );
+  assert.equal(retry, retracted);
+
+  await receipt.started.promise;
+  assert.deepEqual(owner.pull(), []);
+  owner.ack([leases[0]!.id]);
+  owner.nack([leases[1]!.id]);
+  assert.deepEqual(
+    fixture.coordinator.projection(ROOT.sessionId).steering.map((entry) => entry.messageId),
+    ['steer-2'],
+  );
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId).followup, []);
+
+  receipt.release.resolve(undefined);
+  const outcome = await retracted;
+  assert.deepEqual(outcome, {
+    ok: true,
+    result: {
+      queueRevision: 5,
+      retracted: [
+        {
+          entryId: 'id-3',
+          messageId: 'follow-1',
+          content: { text: 'later' },
+          placement: 'next_turn',
+          state: 'retracted',
+        },
+      ],
+    },
+  });
+  assert.deepEqual(await retry, outcome);
+
+  await fixture.coordinator.handlers['queue.retract'](
+    { originHostEpoch: 'epoch-1', sessionId: ROOT.sessionId, retractId: 'cleanup-retract-cut' },
+    operationContext(),
+  );
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  fixture.coordinator.completeIdle(batch);
+});
+
+test('post-effect receipt failure fail-stops the Host Epoch and drains retained residency', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  const receipt = fixture.delayReceipt('submit', 'receipt-failure', new Error('disk failed'));
+
+  const submitted = submit(fixture, 'receipt-failure', 'accepted effect', 'current_turn');
+  await receipt.started.promise;
+  assert.equal(fixture.liveResidencies(), 1);
+  receipt.release.resolve(undefined);
+  await assert.rejects(submitted, /disk failed/);
+
+  assert.equal(fixture.drainRequests(), 1);
+  const rejected = await submit(fixture, 'after-failure', 'must not serve', 'current_turn');
+  assert.equal(rejected.ok, false);
+  if (!rejected.ok) assert.equal(rejected.error.code, 'host_draining');
+  const rejectedRetract = await fixture.coordinator.handlers['queue.retract'](
+    { originHostEpoch: 'epoch-1', sessionId: ROOT.sessionId, retractId: 'after-failure' },
+    operationContext(),
+  );
+  assert.equal(rejectedRetract.ok, false);
+  if (!rejectedRetract.ok) assert.equal(rejectedRetract.error.code, 'host_draining');
+  const rejectedInterrupt = await fixture.coordinator.handlers['turn.interrupt'](
+    {
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      interruptId: 'after-failure',
+      turnId: ROOT.turnId,
+      runId: ROOT.runId,
+    },
+    operationContext(),
+  );
+  assert.equal(rejectedInterrupt.ok, false);
+  if (!rejectedInterrupt.ok) assert.equal(rejectedInterrupt.error.code, 'host_draining');
+
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  assert.deepEqual(batch.sources, []);
+  assert.equal(fixture.liveResidencies(), 0);
+  fixture.coordinator.completeIdle(batch);
+  await fixture.coordinator.close();
+});
+
+test('operations queued behind a receipt failure recheck fail-stop before reads or mutation', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  const receipt = fixture.delayReceipt('submit', 'poison-authority', new Error('disk failed'));
+
+  const poisoning = submit(fixture, 'poison-authority', 'accepted effect', 'current_turn');
+  await receipt.started.promise;
+  const queuedSubmit = submit(fixture, 'queued-submit', 'must not land', 'current_turn');
+  const queuedRetract = fixture.coordinator.handlers['queue.retract'](
+    { originHostEpoch: 'epoch-1', sessionId: ROOT.sessionId, retractId: 'queued-retract' },
+    operationContext(),
+  );
+  const queuedInterrupt = fixture.coordinator.handlers['turn.interrupt'](
+    {
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      interruptId: 'queued-interrupt',
+      turnId: ROOT.turnId,
+      runId: ROOT.runId,
+    },
+    operationContext(),
+  );
+  await Promise.resolve();
+  const readsBeforeFailure = fixture.receiptReads();
+  const rootReadsBeforeFailure = fixture.rootReads();
+  const projectionBeforeFailure = structuredClone(fixture.coordinator.projection(ROOT.sessionId));
+
+  receipt.release.resolve(undefined);
+  await assert.rejects(poisoning, /disk failed/);
+  const outcomes = await Promise.all([queuedSubmit, queuedRetract, queuedInterrupt]);
+
+  for (const outcome of outcomes) {
+    assert.equal(outcome.ok, false);
+    if (!outcome.ok) assert.equal(outcome.error.code, 'host_draining');
+  }
+  assert.equal(fixture.receiptReads(), readsBeforeFailure);
+  assert.equal(fixture.rootReads(), rootReadsBeforeFailure);
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId), projectionBeforeFailure);
+  assert.equal(fixture.drainRequests(), 1);
+
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  fixture.coordinator.completeIdle(batch);
+  await fixture.coordinator.close();
+});
+
+test('stop delivery failure after the queue fence fail-stops and retry is prompt', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  await submit(fixture, 'queued-before-stop-failure', 'retract at fence', 'next_turn');
+  fixture.failStopDelivery(new Error('stop delivery failed'));
+  const input = {
+    originHostEpoch: 'epoch-1',
+    sessionId: ROOT.sessionId,
+    interruptId: 'interrupt-delivery-failure',
+    turnId: ROOT.turnId,
+    runId: ROOT.runId,
+  } as const;
+
+  await assert.rejects(
+    fixture.coordinator.handlers['turn.interrupt'](input, operationContext()),
+    /stop delivery failed/,
+  );
+  assert.equal(fixture.drainRequests(), 1);
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId).followup, []);
+
+  const retry = await fixture.coordinator.handlers['turn.interrupt'](
+    input,
+    operationContext('retry-after-delivery-failure'),
+  );
+  assert.equal(retry.ok, false);
+  if (!retry.ok) assert.equal(retry.error.code, 'host_draining');
+
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  fixture.coordinator.completeIdle(batch);
+  await fixture.coordinator.close();
+});
+
+test('an interrupt generation fence makes a late nack discard its in-flight entry', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  await submit(fixture, 'steer-1', 'leased', 'current_turn');
+  const interruptedContent = {
+    text: '<model>queued</model>',
+    displayText: 'queued',
+    attachments: [attachment('interrupt', 'queued.png')],
+  };
+  await submitContent(fixture, 'follow-1', interruptedContent, 'next_turn');
+  const [lease] = owner.pull();
+  assert.ok(lease);
+
+  const interrupted = fixture.coordinator.handlers['turn.interrupt'](
+    {
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      interruptId: 'interrupt-1',
+      turnId: ROOT.turnId,
+      runId: ROOT.runId,
+    },
+    operationContext(),
+  );
+  const retry = fixture.coordinator.handlers['turn.interrupt'](
+    {
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      interruptId: 'interrupt-1',
+      turnId: ROOT.turnId,
+      runId: ROOT.runId,
+    },
+    operationContext(),
+  );
+  await fixture.stopClaimed.promise;
+
+  owner.nack([lease.id]);
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId).steering, []);
+  assert.equal(fixture.liveResidencies(), 0);
+  fixture.resolveTerminal({
+    ...ROOT,
+    status: 'cancelled',
+    terminalEventId: 'terminal-1',
+    abortSource: 'user_interrupt',
+  });
+  const [outcome, retryOutcome] = await Promise.all([interrupted, retry]);
+  assert.equal(outcome.ok, true);
+  assert.deepEqual(retryOutcome, outcome);
+  if (outcome.ok) {
+    assert.deepEqual(outcome.result.retracted, [
+      {
+        entryId: 'id-2',
+        messageId: 'follow-1',
+        content: interruptedContent,
+        placement: 'next_turn',
+        state: 'retracted',
+      },
+    ]);
+  }
+  assert.deepEqual(
+    await fixture.coordinator.handlers['turn.interrupt'](
+      {
+        originHostEpoch: 'epoch-1',
+        sessionId: ROOT.sessionId,
+        interruptId: 'interrupt-1',
+        turnId: ROOT.turnId,
+        runId: ROOT.runId,
+      },
+      operationContext('connection-after-terminal'),
+    ),
+    outcome,
+  );
+  const identityConflict = await fixture.coordinator.handlers['turn.interrupt'](
+    {
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      interruptId: 'interrupt-1',
+      turnId: ROOT.turnId,
+      runId: 'different-run',
+    },
+    operationContext(),
+  );
+  assert.equal(identityConflict.ok, false);
+  if (!identityConflict.ok) assert.equal(identityConflict.error.code, 'operation_conflict');
+
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  fixture.coordinator.completeIdle(batch);
+});
+
+test('interrupt receipt deletion reclaims state after terminal completion wins the race', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  await submit(fixture, 'queued-before-interrupt', 'later', 'next_turn');
+  const receipt = fixture.delayReceipt('interrupt', 'interrupt-terminal-first');
+
+  const interrupted = fixture.coordinator.handlers['turn.interrupt'](
+    {
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      interruptId: 'interrupt-terminal-first',
+      turnId: ROOT.turnId,
+      runId: ROOT.runId,
+    },
+    operationContext(),
+  );
+  await fixture.stopClaimed.promise;
+  fixture.resolveTerminal({
+    ...ROOT,
+    status: 'cancelled',
+    terminalEventId: 'terminal-first',
+    abortSource: 'user_interrupt',
+  });
+  await receipt.started.promise;
+
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  fixture.coordinator.completeIdle(batch);
+  assert.notEqual(fixture.coordinator.projection(ROOT.sessionId).queueRevision, 0);
+
+  receipt.release.resolve(undefined);
+  assert.equal((await interrupted).ok, true);
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId), {
+    hostEpoch: 'epoch-1',
+    queueRevision: 0,
+    steering: [],
+    followup: [],
+  });
+});
+
+test('stale interrupt deletion reclaims state after terminal transition completes first', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  await submit(fixture, 'consumed-before-stale', 'consume', 'current_turn');
+  const [lease] = owner.pull();
+  assert.ok(lease);
+  owner.ack([lease.id]);
+  const rootRead = fixture.delayRootState();
+
+  const interrupted = fixture.coordinator.handlers['turn.interrupt'](
+    {
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      interruptId: 'interrupt-stale',
+      turnId: ROOT.turnId,
+      runId: ROOT.runId,
+    },
+    operationContext(),
+  );
+  await rootRead.started.promise;
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  fixture.coordinator.completeIdle(batch);
+  fixture.setRootState({ kind: 'idle' });
+  rootRead.release.resolve(undefined);
+
+  const outcome = await interrupted;
+  assert.equal(outcome.ok, false);
+  if (!outcome.ok) assert.equal(outcome.error.code, 'operation_conflict');
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId), {
+    hostEpoch: 'epoch-1',
+    queueRevision: 0,
+    steering: [],
+    followup: [],
+  });
+});
+
+test('every admitted queue state retains an encodable interrupt result', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+
+  for (let index = 0; index < 64; index += 1) {
+    const admitted = await submit(fixture, `message-${index}`, 'x'.repeat(723), 'next_turn');
+    assert.equal(admitted.ok && admitted.result.disposition, 'followup');
+  }
+  const projectionBytes = Buffer.byteLength(
+    JSON.stringify(fixture.coordinator.projection(ROOT.sessionId)),
+    'utf8',
+  );
+  assert.ok(projectionBytes > MESSAGE_QUEUE_PROJECTION_MAX_BYTES - 32);
+  assert.ok(projectionBytes <= MESSAGE_QUEUE_PROJECTION_MAX_BYTES);
+
+  const interrupted = fixture.coordinator.handlers['turn.interrupt'](
+    {
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      interruptId: 'interrupt-capacity',
+      turnId: ROOT.turnId,
+      runId: ROOT.runId,
+    },
+    operationContext(),
+  );
+  await fixture.stopClaimed.promise;
+  fixture.resolveTerminal({
+    ...ROOT,
+    status: 'failed',
+    terminalEventId: 'x'.repeat(128),
+    failureClass: '\0'.repeat(128),
+  });
+  const outcome = await interrupted;
+  assert.equal(outcome.ok, true);
+  if (outcome.ok) {
+    assert.equal(outcome.result.retracted.length, 64);
+    assert.ok(
+      Buffer.byteLength(JSON.stringify(outcome.result), 'utf8') <=
+        MESSAGE_OPERATION_RESULT_MAX_BYTES,
+    );
+  }
+
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  fixture.coordinator.completeIdle(batch);
+});
+
+test('release folds unpulled steering ahead of follow-up without changing source semantics', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  const firstAttachment = attachment('first-source', 'same-name.png');
+  const secondAttachment = attachment('second-source', 'same-name.png');
+  const thirdAttachment = attachment('third-source', 'same-name.png');
+  const firstQuotes = [
+    { text: 'first excerpt', label: 'assistant', sourceTurnId: 'turn-source-1' },
+    { text: 'second excerpt', sourceTurnId: 'turn-source-2' },
+  ];
+  const secondQuotes = [{ text: 'third excerpt', label: 'tool output' }];
+  const thirdQuotes = [{ text: 'fourth excerpt', sourceTurnId: 'turn-source-3' }];
+  const first = await submitContent(
+    fixture,
+    'steer-1',
+    {
+      text: '<model>first</model>',
+      displayText: 'first',
+      attachments: [firstAttachment],
+      quotes: firstQuotes,
+    },
+    'current_turn',
+  );
+  assert.equal(first.ok, true, JSON.stringify(first));
+  const third = await submitContent(
+    fixture,
+    'follow-1',
+    {
+      text: '<model>third</model>',
+      displayText: 'third',
+      attachments: [thirdAttachment],
+      quotes: thirdQuotes,
+    },
+    'next_turn',
+  );
+  assert.equal(third.ok, true, JSON.stringify(third));
+  const second = await submitContent(
+    fixture,
+    'steer-2',
+    { text: 'second', attachments: [secondAttachment], quotes: secondQuotes },
+    'current_turn',
+  );
+  assert.equal(second.ok, true, JSON.stringify(second));
+
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  assert.deepEqual(batch.content, {
+    text: '<model>first</model>\n\nsecond\n\n<model>third</model>',
+    displayText: 'first\n\nsecond\n\nthird',
+    attachments: [firstAttachment, secondAttachment, thirdAttachment],
+    quotes: [...firstQuotes, ...secondQuotes, ...thirdQuotes],
+  });
+  assert.deepEqual(batch.sources, [
+    {
+      messageId: 'steer-1',
+      content: {
+        text: '<model>first</model>',
+        displayText: 'first',
+        attachments: [firstAttachment],
+        quotes: firstQuotes,
+      },
+      placement: 'current_turn',
+      disposition: 'steering',
+    },
+    {
+      messageId: 'steer-2',
+      content: { text: 'second', attachments: [secondAttachment], quotes: secondQuotes },
+      placement: 'current_turn',
+      disposition: 'steering',
+    },
+    {
+      messageId: 'follow-1',
+      content: {
+        text: '<model>third</model>',
+        displayText: 'third',
+        attachments: [thirdAttachment],
+        quotes: thirdQuotes,
+      },
+      placement: 'next_turn',
+      disposition: 'followup',
+    },
+  ]);
+  assert.equal(fixture.liveResidencies(), 3);
+
+  fixture.coordinator.commitNextRoot(batch, {
+    sessionId: ROOT.sessionId,
+    turnId: 'turn-2',
+    runId: 'run-2',
+  });
+  assert.equal(fixture.liveResidencies(), 0);
+  const next = fixture.coordinator.bindRun({
+    sessionId: ROOT.sessionId,
+    turnId: 'turn-2',
+    runId: 'run-2',
+  });
+  next.release();
+  const empty = fixture.coordinator.beginTerminalTransition({
+    sessionId: ROOT.sessionId,
+    turnId: 'turn-2',
+    runId: 'run-2',
+  });
+  fixture.coordinator.completeIdle(empty);
+});
+
+test('terminal transition atomically folds messages submitted after run release', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+
+  owner.release();
+  const submitted = await submit(fixture, 'late-steer', 'next intent', 'current_turn');
+  assert.equal(submitted.ok && submitted.result.disposition, 'steering');
+
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  assert.deepEqual(batch.sources, [
+    {
+      messageId: 'late-steer',
+      content: { text: 'next intent' },
+      placement: 'current_turn',
+      disposition: 'steering',
+    },
+  ]);
+  fixture.coordinator.commitNextRoot(batch, {
+    sessionId: ROOT.sessionId,
+    turnId: 'turn-2',
+    runId: 'run-2',
+  });
+  const next = fixture.coordinator.bindRun({
+    sessionId: ROOT.sessionId,
+    turnId: 'turn-2',
+    runId: 'run-2',
+  });
+  next.release();
+  const empty = fixture.coordinator.beginTerminalTransition({
+    sessionId: ROOT.sessionId,
+    turnId: 'turn-2',
+    runId: 'run-2',
+  });
+  fixture.coordinator.completeIdle(empty);
+});
+
+test('administrative drain preserves accepted entries until the terminal stop fence', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  await submit(fixture, 'steer-drain', 'current intent', 'current_turn');
+  await submit(fixture, 'follow-drain', 'next intent', 'next_turn');
+
+  fixture.coordinator.beginDrain();
+  const rejected = await submit(fixture, 'late-drain', 'too late', 'current_turn');
+  assert.equal(rejected.ok, false);
+  if (!rejected.ok) assert.equal(rejected.error.code, 'host_draining');
+  assert.deepEqual(
+    fixture.coordinator.projection(ROOT.sessionId).steering.map((entry) => entry.messageId),
+    ['steer-drain'],
+  );
+  assert.deepEqual(
+    fixture.coordinator.projection(ROOT.sessionId).followup.map((entry) => entry.messageId),
+    ['follow-drain'],
+  );
+
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  assert.deepEqual(batch.sources, []);
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId).steering, []);
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId).followup, []);
+  fixture.coordinator.completeIdle(batch);
+  assert.equal(fixture.liveResidencies(), 0);
+  await fixture.coordinator.close();
+});
+
+test('semantic retry history does not become a permanent Session admission cap', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+
+  for (let index = 0; index < 65; index += 1) {
+    const outcome = await fixture.coordinator.handlers['queue.retract'](
+      {
+        originHostEpoch: 'epoch-1',
+        sessionId: ROOT.sessionId,
+        retractId: `retract-${index}`,
+      },
+      operationContext(),
+    );
+    assert.equal(outcome.ok, true);
+  }
+});
+
+test('submit retries use keyed receipts and durable proof while old-Epoch rich conflicts fail', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+
+  const first = await submit(fixture, 'same-1', 'same text', 'current_turn');
+  const retry = await submit(fixture, 'same-1', 'same text', 'current_turn');
+  assert.deepEqual(retry, first);
+  const conflict = await submit(fixture, 'same-1', 'changed', 'current_turn');
+  assert.equal(conflict.ok, false);
+  if (!conflict.ok) assert.equal(conflict.error.code, 'operation_conflict');
+  assert.equal(fixture.coordinator.projection(ROOT.sessionId).steering.length, 1);
+
+  fixture.receipts.set(
+    'current-follow',
+    sourceReceipt('current-follow', 'durable current follow-up', 'next_turn', 'followup'),
+  );
+  fixture.receipts.set(
+    'old-follow',
+    sourceReceipt(
+      'old-follow',
+      {
+        text: '<model>durable follow-up</model>',
+        displayText: 'durable follow-up',
+        attachments: [attachment('proof-follow', 'proof.png')],
+      },
+      'next_turn',
+      'followup',
+    ),
+  );
+  const oldFollow = await submitContent(
+    fixture,
+    'old-follow',
+    {
+      text: '<model>durable follow-up</model>',
+      displayText: 'durable follow-up',
+      attachments: [attachment('proof-follow', 'proof.png')],
+    },
+    'next_turn',
+    'old-epoch',
+  );
+  assert.equal(oldFollow.ok, false);
+  if (!oldFollow.ok) assert.equal(oldFollow.error.code, 'outcome_unknown');
+
+  fixture.events.push(
+    steeringEvent('old-steer', {
+      text: '<model>durable steering</model>',
+      displayText: 'durable steering',
+      attachments: [attachment('proof-steer', 'proof.png')],
+    }),
+  );
+  const oldSteer = await submitContent(
+    fixture,
+    'old-steer',
+    {
+      text: '<model>durable steering</model>',
+      displayText: 'durable steering',
+      attachments: [attachment('proof-steer', 'proof.png')],
+    },
+    'current_turn',
+    'old-epoch',
+  );
+  assert.equal(oldSteer.ok, false);
+  if (!oldSteer.ok) assert.equal(oldSteer.error.code, 'outcome_unknown');
+
+  const durableBeforeRetries = {
+    receipts: structuredClone([...fixture.receipts]),
+    events: structuredClone(fixture.events),
+  };
+  const queueBeforeRetries = structuredClone(fixture.coordinator.projection(ROOT.sessionId));
+  const currentFollow = await submit(
+    fixture,
+    'current-follow',
+    'durable current follow-up',
+    'next_turn',
+  );
+  assert.equal(currentFollow.ok, false);
+  if (!currentFollow.ok) assert.equal(currentFollow.error.code, 'outcome_unknown');
+  const displayConflict = await submitContent(
+    fixture,
+    'old-follow',
+    {
+      text: '<model>durable follow-up</model>',
+      displayText: 'changed display',
+      attachments: [attachment('proof-follow', 'proof.png')],
+    },
+    'next_turn',
+    'old-epoch',
+  );
+  assert.equal(displayConflict.ok, false);
+  if (!displayConflict.ok) assert.equal(displayConflict.error.code, 'operation_conflict');
+  const attachmentRefConflict = await submitContent(
+    fixture,
+    'old-steer',
+    {
+      text: '<model>durable steering</model>',
+      displayText: 'durable steering',
+      attachments: [attachment('changed-proof-steer', 'proof.png')],
+    },
+    'current_turn',
+    'old-epoch',
+  );
+  assert.equal(attachmentRefConflict.ok, false);
+  if (!attachmentRefConflict.ok) {
+    assert.equal(attachmentRefConflict.error.code, 'operation_conflict');
+  }
+  assert.deepEqual(
+    {
+      receipts: [...fixture.receipts],
+      events: fixture.events,
+    },
+    durableBeforeRetries,
+  );
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId), queueBeforeRetries);
+
+  const unknown = await submit(fixture, 'old-unknown', 'not durable', 'current_turn', 'old-epoch');
+  assert.equal(unknown.ok, false);
+  if (!unknown.ok) assert.equal(unknown.error.code, 'outcome_unknown');
+
+  const retracted = await fixture.coordinator.handlers['queue.retract'](
+    {
+      originHostEpoch: 'epoch-1',
+      sessionId: ROOT.sessionId,
+      retractId: 'cleanup',
+    },
+    operationContext(),
+  );
+  assert.equal(retracted.ok, true);
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  fixture.coordinator.completeIdle(batch);
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId), {
+    hostEpoch: 'epoch-1',
+    queueRevision: 0,
+    steering: [],
+    followup: [],
+  });
+  assert.deepEqual(await submit(fixture, 'same-1', 'same text', 'current_turn'), first);
+  const reclaimedConflict = await submit(fixture, 'same-1', 'changed after idle', 'current_turn');
+  assert.equal(reclaimedConflict.ok, false);
+  if (!reclaimedConflict.ok) assert.equal(reclaimedConflict.error.code, 'operation_conflict');
+});
+
+test('old-Epoch steering proof compares ordered quote provenance before reporting ambiguity', async () => {
+  const fixture = createFixture();
+  const messageId = 'old-steer';
+  const content = {
+    text: 'durable steering',
+    quotes: [
+      { text: 'first durable excerpt', label: 'assistant', sourceTurnId: 'turn-source-1' },
+      { text: 'second durable excerpt', sourceTurnId: 'turn-source-2' },
+    ],
+  };
+  fixture.events.push({ ...steeringEvent(messageId, content), partial: true });
+
+  const unknown = await submitContent(fixture, messageId, content, 'current_turn', 'old-epoch');
+  assert.equal(unknown.ok, false);
+  if (!unknown.ok) assert.equal(unknown.error.code, 'outcome_unknown');
+
+  fixture.events.push(steeringEvent(messageId, content));
+  const proven = await submitContent(fixture, messageId, content, 'current_turn', 'old-epoch');
+  assert.equal(proven.ok, false);
+  if (!proven.ok) assert.equal(proven.error.code, 'outcome_unknown');
+
+  const provenanceConflict = await submitContent(
+    fixture,
+    messageId,
+    {
+      ...content,
+      quotes: [content.quotes[0]!, { ...content.quotes[1]!, sourceTurnId: 'turn-source-changed' }],
+    },
+    'current_turn',
+    'old-epoch',
+  );
+  assert.equal(provenanceConflict.ok, false);
+  if (!provenanceConflict.ok) {
+    assert.equal(provenanceConflict.error.code, 'operation_conflict');
+  }
+});
+
+test('canonical content preserves ordered attachment and quote identity across queue projections', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+  const firstAttachment = attachment('first', 'same-name.png');
+  const secondAttachment = attachment('second', 'same-name.png');
+  const steeringQuotes = [
+    { text: 'first quote', label: 'assistant', sourceTurnId: 'turn-source-1' },
+    { text: 'second quote', sourceTurnId: 'turn-source-2' },
+  ];
+  const followupQuotes = [{ text: 'follow-up quote', label: 'user selection' }];
+
+  const submitted = await submitContent(
+    fixture,
+    'rich-steer',
+    {
+      text: '<model>first</model>',
+      displayText: 'first',
+      attachments: [firstAttachment, secondAttachment],
+      quotes: steeringQuotes,
+    },
+    'current_turn',
+  );
+  assert.equal(submitted.ok, true, JSON.stringify(submitted));
+  const reordered = await submitContent(
+    fixture,
+    'rich-steer',
+    {
+      text: '<model>first</model>',
+      displayText: 'first',
+      attachments: [secondAttachment, firstAttachment],
+      quotes: steeringQuotes,
+    },
+    'current_turn',
+  );
+  assert.equal(reordered.ok, false);
+  if (!reordered.ok) assert.equal(reordered.error.code, 'operation_conflict');
+  const quoteOrderConflict = await submitContent(
+    fixture,
+    'rich-steer',
+    {
+      text: '<model>first</model>',
+      displayText: 'first',
+      attachments: [firstAttachment, secondAttachment],
+      quotes: [...steeringQuotes].reverse(),
+    },
+    'current_turn',
+  );
+  assert.equal(quoteOrderConflict.ok, false);
+  if (!quoteOrderConflict.ok) assert.equal(quoteOrderConflict.error.code, 'operation_conflict');
+  const followup = await submitContent(
+    fixture,
+    'rich-followup',
+    {
+      text: '<model>later</model>',
+      displayText: 'later',
+      quotes: followupQuotes,
+    },
+    'next_turn',
+  );
+  assert.equal(followup.ok, true);
+
+  const projection = fixture.coordinator.projection(ROOT.sessionId);
+  assert.deepEqual(projection.steering[0]?.content, {
+    text: '<model>first</model>',
+    displayText: 'first',
+    attachments: [firstAttachment, secondAttachment],
+    quotes: steeringQuotes,
+  });
+  assert.deepEqual(projection.followup[0]?.content, {
+    text: '<model>later</model>',
+    displayText: 'later',
+    quotes: followupQuotes,
+  });
+
+  const [lease] = owner.pull();
+  assert.ok(lease);
+  assert.deepEqual(lease.content, {
+    text: '<model>first</model>',
+    displayText: 'first',
+    attachments: [firstAttachment, secondAttachment],
+    quotes: steeringQuotes,
+  });
+  const retracted = await fixture.coordinator.handlers['queue.retract'](
+    { originHostEpoch: 'epoch-1', sessionId: ROOT.sessionId, retractId: 'cleanup-rich-followup' },
+    operationContext(),
+  );
+  assert.equal(retracted.ok, true);
+  if (retracted.ok) {
+    assert.deepEqual(retracted.result.retracted[0]?.content, projection.followup[0]?.content);
+  }
+  owner.ack([lease.id]);
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  fixture.coordinator.completeIdle(batch);
+});
+
+test('canonical retry omits redundant display text and empty ordered refs', async () => {
+  const fixture = createFixture();
+  fixture.coordinator.reserveRootTurn(ROOT);
+  const owner = fixture.coordinator.bindRun(ROOT);
+
+  const first = await submitContent(
+    fixture,
+    'canonical',
+    { text: 'same', displayText: 'same', attachments: [], quotes: [] },
+    'current_turn',
+  );
+  assert.deepEqual(
+    await submitContent(fixture, 'canonical', { text: 'same' }, 'current_turn'),
+    first,
+  );
+  assert.deepEqual(fixture.coordinator.projection(ROOT.sessionId).steering[0]?.content, {
+    text: 'same',
+  });
+
+  const retracted = await fixture.coordinator.handlers['queue.retract'](
+    { originHostEpoch: 'epoch-1', sessionId: ROOT.sessionId, retractId: 'cleanup' },
+    operationContext(),
+  );
+  assert.equal(retracted.ok, true);
+  if (retracted.ok) {
+    assert.deepEqual(retracted.result.retracted[0]?.content, { text: 'same' });
+  }
+  owner.release();
+  const batch = fixture.coordinator.beginTerminalTransition(ROOT);
+  fixture.coordinator.completeIdle(batch);
+});
+
+function createFixture() {
+  let nextId = 1;
+  let liveResidencies = 0;
+  let startCalls = 0;
+  let drainRequests = 0;
+  let receiptReads = 0;
+  let rootReads = 0;
+  let stopDeliveryError: Error | undefined;
+  let rootState: HostMessageRootState = { kind: 'active', ...ROOT };
+  let rootStateDelay:
+    | {
+        readonly started: ReturnType<typeof deferred<void>>;
+        readonly release: ReturnType<typeof deferred<void>>;
+      }
+    | undefined;
+  const receipts = new Map<string, RootTurnSourceMessageReceipt>();
+  const events: RuntimeEvent[] = [];
+  const operationReceipts = new Map<string, MessageOperationReceipt>();
+  const receiptDelays = new Map<
+    string,
+    {
+      readonly started: ReturnType<typeof deferred<void>>;
+      readonly release: ReturnType<typeof deferred<void>>;
+      readonly error?: Error;
+    }
+  >();
+  const stopClaimed = deferred<void>();
+  const terminal = deferred<TurnSnapshot>();
+  let coordinator: HostMessageCoordinator;
+  const root: HostMessageRootPort = {
+    readSessionHeader: async () => {
+      rootReads += 1;
+      return { isArchived: false };
+    },
+    readRootState: async () => {
+      rootReads += 1;
+      const delay = rootStateDelay;
+      if (delay) {
+        rootStateDelay = undefined;
+        delay.started.resolve(undefined);
+        await delay.release.promise;
+      }
+      return rootState;
+    },
+    startFromMessage: async (input) => {
+      startCalls += 1;
+      const turnId = 'idle-turn';
+      receipts.set(
+        input.sourceMessage.messageId,
+        sourceReceipt(
+          input.sourceMessage.messageId,
+          input.sourceMessage.content,
+          input.sourceMessage.placement,
+          'turn_started',
+          turnId,
+        ),
+      );
+      rootState = { kind: 'active', sessionId: input.sessionId, turnId, runId: 'idle-run' };
+      coordinator.reserveRootTurn(rootState);
+      return { turnId };
+    },
+    claimStop: async (_input, commitQueueFence) => {
+      commitQueueFence();
+      return {
+        deliverStop: async () => {
+          stopClaimed.resolve(undefined);
+          if (stopDeliveryError) throw stopDeliveryError;
+        },
+        terminal: terminal.promise,
+      };
+    },
+  };
+  const options: HostMessageCoordinatorOptions = {
+    hostEpoch: 'epoch-1',
+    root,
+    durableProof: {
+      readRootTurnSourceMessageReceipt: async (_sessionId, messageId) => receipts.get(messageId),
+      readImmutableSteeringMessageProof: async (_sessionId, messageId) => {
+        const event = events.find(
+          (candidate) =>
+            candidate.partial === false &&
+            candidate.refs?.providerEventId === messageId &&
+            candidate.content?.kind === 'text' &&
+            candidate.content.steering === true,
+        );
+        return event ? { event } : undefined;
+      },
+    },
+    receipts: memoryReceiptStore(
+      operationReceipts,
+      async (operation, operationId) => {
+        const delay = receiptDelays.get(`${operation}:${operationId}`);
+        if (!delay) return;
+        receiptDelays.delete(`${operation}:${operationId}`);
+        delay.started.resolve(undefined);
+        await delay.release.promise;
+        if (delay.error) throw delay.error;
+      },
+      () => {
+        receiptReads += 1;
+      },
+    ),
+    sessionAdmission: new SessionAdmissionGate(),
+    acquireResidency: () => {
+      liveResidencies += 1;
+      let released = false;
+      return {
+        release: () => {
+          assert.equal(released, false);
+          released = true;
+          liveResidencies -= 1;
+        },
+      };
+    },
+    requestDrain: () => {
+      drainRequests += 1;
+    },
+    createId: () => `id-${nextId++}`,
+  };
+  coordinator = new HostMessageCoordinator(options);
+  return {
+    coordinator,
+    setRootState: (state: HostMessageRootState) => {
+      rootState = state;
+    },
+    startCalls: () => startCalls,
+    events,
+    receipts,
+    stopClaimed,
+    resolveTerminal: terminal.resolve,
+    liveResidencies: () => liveResidencies,
+    drainRequests: () => drainRequests,
+    receiptReads: () => receiptReads,
+    rootReads: () => rootReads,
+    failStopDelivery: (error: Error) => {
+      stopDeliveryError = error;
+    },
+    delayReceipt: (
+      operation: 'submit' | 'retract' | 'interrupt',
+      operationId: string,
+      error?: Error,
+    ) => {
+      const delay = { started: deferred<void>(), release: deferred<void>(), error };
+      receiptDelays.set(`${operation}:${operationId}`, delay);
+      return delay;
+    },
+    delayRootState: () => {
+      const delay = { started: deferred<void>(), release: deferred<void>() };
+      rootStateDelay = delay;
+      return delay;
+    },
+  };
+}
+
+function memoryReceiptStore(
+  receipts: Map<string, MessageOperationReceipt>,
+  beforeCommit?: (operation: string, operationId: string) => Promise<void>,
+  onRead?: () => void,
+): MessageReceiptStore {
+  const key = (hostEpoch: string, operation: string, sessionId: string, operationId: string) =>
+    `${hostEpoch}:${operation}:${sessionId}:${operationId}`;
+  return {
+    beginHostEpoch: async () => undefined,
+    read: async (hostEpoch, operation, sessionId, operationId) => {
+      onRead?.();
+      return receipts.get(key(hostEpoch, operation, sessionId, operationId));
+    },
+    commit: async (hostEpoch, operation, sessionId, operationId, receipt) => {
+      await beforeCommit?.(operation, operationId);
+      const receiptKey = key(hostEpoch, operation, sessionId, operationId);
+      const existing = receipts.get(receiptKey);
+      if (existing) return existing;
+      const snapshot = structuredClone(receipt);
+      receipts.set(receiptKey, snapshot);
+      return snapshot;
+    },
+  };
+}
+
+function submit(
+  fixture: ReturnType<typeof createFixture>,
+  messageId: string,
+  text: string,
+  placement: 'current_turn' | 'next_turn',
+  originHostEpoch = 'epoch-1',
+) {
+  return submitContent(fixture, messageId, { text }, placement, originHostEpoch);
+}
+
+function submitContent(
+  fixture: ReturnType<typeof createFixture>,
+  messageId: string,
+  content: MessageContent,
+  placement: 'current_turn' | 'next_turn',
+  originHostEpoch = 'epoch-1',
+) {
+  return fixture.coordinator.handlers['turn.message.submit'](
+    {
+      originHostEpoch,
+      sessionId: ROOT.sessionId,
+      messageId,
+      content,
+      placement,
+    },
+    operationContext(),
+  );
+}
+
+function sourceReceipt(
+  messageId: string,
+  content: MessageContent | string,
+  placement: 'current_turn' | 'next_turn',
+  disposition: 'steering' | 'followup' | 'turn_started',
+  turnId = 'durable-turn',
+): RootTurnSourceMessageReceipt {
+  const normalizedContent = typeof content === 'string' ? { text: content } : content;
+  const sourceMessage = { messageId, content: normalizedContent, placement, disposition };
+  return {
+    admission: {
+      schemaVersion: 1,
+      sessionId: ROOT.sessionId,
+      turnId,
+      runId: 'durable-run',
+      userMessageId: 'durable-user-message',
+      execution: { kind: 'external_message' },
+      previousRootTurnId: ROOT.turnId,
+      normalizedInput: normalizedContent,
+      sourceMessages: [sourceMessage],
+      admittedAt: 1,
+    },
+    sourceMessage,
+  };
+}
+
+function steeringEvent(messageId: string, content: MessageContent | string): RuntimeEvent {
+  const normalizedContent = typeof content === 'string' ? { text: content } : content;
+  return {
+    id: `event-${messageId}`,
+    invocationId: 'invocation-1',
+    runId: ROOT.runId,
+    sessionId: ROOT.sessionId,
+    turnId: ROOT.turnId,
+    ts: 1,
+    partial: false,
+    role: 'user',
+    author: 'user',
+    content: { kind: 'text', ...normalizedContent, steering: true },
+    refs: { providerEventId: messageId },
+  };
+}
+
+function attachment(id: string, name: string) {
+  return {
+    kind: 'image' as const,
+    name,
+    mimeType: 'image/png',
+    bytes: 10,
+    ref: { kind: 'workspace_file' as const, relativePath: `attachments/${id}.png` },
+  };
+}
+
+function operationContext(connectionId = 'connection-1') {
+  return {
+    hostEpoch: 'epoch-1',
+    connectionId,
+    surface: 'tui' as const,
+    principal: 'local_os_user' as const,
+    acquireResidency: () => ({ release: () => undefined }),
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise;
+  });
+  return { promise, resolve };
+}

--- a/packages/runtime-host/src/__tests__/operation-dispatcher.test.ts
+++ b/packages/runtime-host/src/__tests__/operation-dispatcher.test.ts
@@ -106,6 +106,49 @@ describe('Runtime Host operation dispatcher', () => {
       error: { code: 'not_found', message: 'Turn does not exist' },
     });
   });
+
+  test('revalidates Message operation outcomes through the shared decoder', async () => {
+    const messageRequest = {
+      requestId: 'submit-request-1',
+      operation: 'turn.message.submit',
+      input: {
+        originHostEpoch: 'epoch-1',
+        sessionId: 'session-1',
+        messageId: 'message-1',
+        content: { text: 'steer' },
+        placement: 'current_turn',
+      },
+    } satisfies RequestFrame;
+    const handlers = validHandlers();
+    handlers['turn.message.submit'] = async () =>
+      ({
+        ok: true,
+        result: { disposition: 'steering', queueRevision: 1, privateState: true },
+      }) as unknown as OperationOutcome<'turn.message.submit'>;
+    assert.deepEqual(await dispatchOperation(messageRequest, handlers, context), {
+      requestId: messageRequest.requestId,
+      operation: messageRequest.operation,
+      ok: false,
+      error: { code: 'internal_failure', message: 'Runtime Host operation failed' },
+    });
+
+    handlers['turn.message.submit'] = async () => ({
+      ok: false,
+      error: {
+        code: 'outcome_unknown',
+        message: 'Message disposition cannot be proven in this Host Epoch',
+      },
+    });
+    assert.deepEqual(await dispatchOperation(messageRequest, handlers, context), {
+      requestId: messageRequest.requestId,
+      operation: messageRequest.operation,
+      ok: false,
+      error: {
+        code: 'outcome_unknown',
+        message: 'Message disposition cannot be proven in this Host Epoch',
+      },
+    });
+  });
 });
 
 function validHandlers(): OperationHandlerMap {

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -1,23 +1,89 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
+import { MAX_ATTACHMENT_BYTES, MAX_ATTACHMENT_COUNT } from '@maka/core/attachments';
 import {
   decodeClientFrame,
   decodeHostFrame,
+  decodeHostRegistration,
+  decodeSessionMessageQueueProjection,
+  encodeProtocolFrame,
   HOST_OPERATION_SPECS,
+  MESSAGE_OPERATION_RESULT_MAX_BYTES,
+  MESSAGE_QUEUE_MAX_ENTRIES,
   negotiateProtocol,
   ProtocolFrameDecoder,
   RUNTIME_HOST_MAX_FRAME_BYTES,
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  TURN_MESSAGE_CONTENT_MAX_BYTES,
+  TURN_MESSAGE_TEXT_MAX_BYTES,
   RUNTIME_POLICY_OPERATION_SPECS,
   RuntimeHostProtocolError,
 } from '../protocol/index.js';
 import { HOST_STATUS_OPERATION_SPECS } from '../protocol/host-status.js';
 import { composeOperationSpecMaps } from '../protocol/operation-spec.js';
+import {
+  TURN_MESSAGE_QUOTE_LABEL_MAX_LENGTH,
+  TURN_MESSAGE_QUOTE_MAX_COUNT,
+  TURN_MESSAGE_QUOTE_TEXT_MAX_LENGTH,
+} from '../protocol/turn.js';
 
 describe('Runtime Host bootstrap protocol', () => {
   test('selects the highest mutually supported protocol and rejects a gap', () => {
     assert.equal(negotiateProtocol({ min: 0, max: 0 }, { min: 0, max: 0 }), 0);
     assert.equal(negotiateProtocol({ min: 1, max: 3 }, { min: 2, max: 4 }), 3);
     assert.equal(negotiateProtocol({ min: 0, max: 0 }, { min: 1, max: 1 }), undefined);
+    assert.throws(() => negotiateProtocol({ min: -1, max: 0 }, { min: 0, max: 0 }), isInvalidFrame);
+  });
+
+  test('keeps the experimental protocol at v0 with ready Message authority operations', () => {
+    assert.equal(RUNTIME_HOST_PROTOCOL_VERSION, 0);
+    assert.deepEqual(Object.keys(HOST_OPERATION_SPECS).sort(), [
+      'connection.catalog.create',
+      'connection.catalog.query',
+      'connection.catalog.remove',
+      'connection.catalog.set-default-target',
+      'connection.catalog.update',
+      'credential.vault.delete',
+      'credential.vault.query',
+      'credential.vault.set',
+      'host.status',
+      'queue.retract',
+      'runtime.policy.mutate',
+      'runtime.policy.query',
+      'turn.interrupt',
+      'turn.message.submit',
+      'turn.query',
+      'turn.start',
+      'turn.stop',
+    ]);
+    const errors = [
+      'host_not_ready',
+      'host_draining',
+      'operation_unavailable',
+      'not_found',
+      'session_archived',
+      'session_busy',
+      'operation_conflict',
+      'outcome_unknown',
+      'internal_failure',
+    ];
+    assert.deepEqual(
+      Object.fromEntries(
+        (['turn.message.submit', 'queue.retract', 'turn.interrupt'] as const).map((operation) => [
+          operation,
+          {
+            mode: HOST_OPERATION_SPECS[operation].mode,
+            availability: HOST_OPERATION_SPECS[operation].availability,
+            errors: HOST_OPERATION_SPECS[operation].errors,
+          },
+        ]),
+      ),
+      {
+        'turn.message.submit': { mode: 'command', availability: 'ready', errors },
+        'queue.retract': { mode: 'command', availability: 'ready', errors },
+        'turn.interrupt': { mode: 'control', availability: 'ready', errors },
+      },
+    );
   });
 
   test('declares exactly the ten Runtime Policy operations in the current framework', () => {
@@ -114,7 +180,7 @@ describe('Runtime Host bootstrap protocol', () => {
   test('decodes split UTF-8 and multiple newline-delimited frames without an unbounded tail', () => {
     const decoder = new ProtocolFrameDecoder();
     const wire = Buffer.from(
-      `${JSON.stringify({ kind: 'hello', clientInstanceId: '客户端', surface: 'tui', protocolMin: 0, protocolMax: 0 })}\n` +
+      `${JSON.stringify({ kind: 'hello', clientInstanceId: '客户端', surface: 'tui', protocolMin: RUNTIME_HOST_PROTOCOL_VERSION, protocolMax: RUNTIME_HOST_PROTOCOL_VERSION })}\n` +
         `${JSON.stringify({ requestId: 'status-1', operation: 'host.status', input: {} })}\n`,
     );
     const split = wire.indexOf(Buffer.from('端')) + 1;
@@ -125,8 +191,8 @@ describe('Runtime Host bootstrap protocol', () => {
       kind: 'hello',
       clientInstanceId: '客户端',
       surface: 'tui',
-      protocolMin: 0,
-      protocolMax: 0,
+      protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
+      protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
     });
     assert.deepEqual(decodeClientFrame(frames[1]), {
       requestId: 'status-1',
@@ -134,6 +200,51 @@ describe('Runtime Host bootstrap protocol', () => {
       input: {},
     });
     decoder.end();
+  });
+
+  test('accepts protocol v0 in handshakes and Host registration while rejecting negatives', () => {
+    const accepted = {
+      kind: 'accepted' as const,
+      hostEpoch: 'epoch-1',
+      connectionId: 'connection-1',
+      selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,
+      state: 'ready' as const,
+    };
+    assert.deepEqual(decodeHostFrame(accepted), accepted);
+
+    const registration = {
+      kind: 'maka-runtime-host' as const,
+      schemaVersion: 1 as const,
+      rootId: 'a'.repeat(64),
+      hostEpoch: 'epoch-1',
+      endpoint: '/tmp/maka-runtime-host.sock',
+      protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
+      protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
+      state: 'ready' as const,
+      pid: 42,
+      createdAt: '2026-07-23T00:00:00.000Z',
+    };
+    assert.deepEqual(decodeHostRegistration(registration), registration);
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          kind: 'hello',
+          clientInstanceId: 'client-1',
+          surface: 'tui',
+          protocolMin: -1,
+          protocolMax: 0,
+        }),
+      isInvalidFrame,
+    );
+    assert.throws(() => decodeHostFrame({ ...accepted, selectedProtocol: -1 }), isInvalidFrame);
+    assert.throws(
+      () => decodeHostRegistration({ ...registration, protocolMin: -1 }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () => decodeHostRegistration({ ...registration, protocolMax: Number.MAX_SAFE_INTEGER + 1 }),
+      isInvalidFrame,
+    );
   });
 
   test('keeps the operation registry closed at request and response boundaries', () => {
@@ -171,6 +282,365 @@ describe('Runtime Host bootstrap protocol', () => {
         }),
       isInvalidFrame,
     );
+  });
+
+  test('requires stable Message command identities, origin Host Epoch, and exact inputs', () => {
+    const submit = {
+      requestId: 'submit-request-1',
+      operation: 'turn.message.submit' as const,
+      input: {
+        originHostEpoch: 'epoch-1',
+        sessionId: 'session-1',
+        messageId: 'message-1',
+        content: { text: 'adjust the active turn' },
+        placement: 'current_turn' as const,
+      },
+    };
+    const retract = {
+      requestId: 'retract-request-1',
+      operation: 'queue.retract' as const,
+      input: { originHostEpoch: 'epoch-1', sessionId: 'session-1', retractId: 'retract-1' },
+    };
+    const interrupt = {
+      requestId: 'interrupt-request-1',
+      operation: 'turn.interrupt' as const,
+      input: {
+        originHostEpoch: 'epoch-1',
+        sessionId: 'session-1',
+        interruptId: 'interrupt-1',
+        turnId: 'turn-1',
+        runId: 'run-1',
+      },
+    };
+    assert.deepEqual(decodeClientFrame(submit), submit);
+    assert.deepEqual(decodeClientFrame(retract), retract);
+    assert.deepEqual(decodeClientFrame(interrupt), interrupt);
+    assert.throws(
+      () =>
+        decodeClientFrame({ ...submit, input: { ...submit.input, originHostEpoch: undefined } }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () => decodeClientFrame({ ...retract, input: { ...retract.input, generation: 1 } }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          ...interrupt,
+          input: { ...interrupt.input, interruptId: 'not/a/semantic/id' },
+        }),
+      isInvalidFrame,
+    );
+  });
+
+  test('decodes old-Epoch ambiguity only for operations that declare outcome_unknown', () => {
+    const response = {
+      requestId: 'submit-old-epoch',
+      operation: 'turn.message.submit' as const,
+      ok: false as const,
+      error: {
+        code: 'outcome_unknown' as const,
+        message: 'Message disposition cannot be proven in this Host Epoch',
+      },
+    };
+    assert.deepEqual(decodeHostFrame(response), response);
+    assert.throws(() => decodeHostFrame({ ...response, operation: 'turn.query' }), isInvalidFrame);
+  });
+
+  test('uses canonical MessageContent for turn start and submit', () => {
+    const attachment = attachmentRef({ kind: 'workspace_file', relativePath: 'src/a.ts' });
+    const quotes = [
+      { text: 'first excerpt', label: 'Assistant', sourceTurnId: 'turn-source-1' },
+      { text: 'second excerpt', sourceTurnId: 'turn-source-2' },
+    ];
+    const startWire = {
+      requestId: 'start-request-1',
+      operation: 'turn.start' as const,
+      input: {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        content: {
+          text: 'model text',
+          displayText: 'model text',
+          attachments: [attachment],
+          quotes,
+        },
+      },
+    };
+    const start = decodeClientFrame(JSON.parse(encodeProtocolFrame(startWire).toString('utf8')));
+    assert.deepEqual(start, {
+      requestId: 'start-request-1',
+      operation: 'turn.start',
+      input: {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        content: { text: 'model text', attachments: [attachment], quotes },
+      },
+    });
+    assert.notEqual(start.input.content.quotes, quotes);
+    assert.notEqual(start.input.content.quotes?.[0], quotes[0]);
+    const submitWire = {
+      requestId: 'submit-request-1',
+      operation: 'turn.message.submit' as const,
+      input: {
+        originHostEpoch: 'epoch-1',
+        sessionId: 'session-1',
+        messageId: 'message-1',
+        content: { text: 'follow up', quotes: [...quotes].reverse() },
+        placement: 'next_turn' as const,
+      },
+    };
+    assert.deepEqual(
+      decodeClientFrame(JSON.parse(encodeProtocolFrame(submitWire).toString('utf8'))),
+      submitWire,
+    );
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          requestId: 'legacy-start',
+          operation: 'turn.start',
+          input: { sessionId: 'session-1', turnId: 'turn-1', text: 'legacy' },
+        }),
+      isInvalidFrame,
+    );
+    assert.deepEqual(
+      decodeClientFrame({
+        ...submitWire,
+        input: { ...submitWire.input, content: { text: 'valid', quotes: [] } },
+      }),
+      {
+        ...submitWire,
+        input: { ...submitWire.input, content: { text: 'valid' } },
+      },
+    );
+  });
+
+  test('bounds canonical MessageContent attachments and quotes', () => {
+    const submit = (content: unknown) =>
+      decodeClientFrame({
+        requestId: 'submit-bounds',
+        operation: 'turn.message.submit',
+        input: {
+          originHostEpoch: 'epoch-1',
+          sessionId: 'session-1',
+          messageId: 'message-1',
+          content,
+          placement: 'next_turn',
+        },
+      });
+    assert.doesNotThrow(() =>
+      submit({
+        text: 'valid',
+        attachments: Array.from({ length: MAX_ATTACHMENT_COUNT }, (_, index) =>
+          attachmentRef({ kind: 'workspace_file', relativePath: `${index}.ts` }),
+        ),
+      }),
+    );
+    assert.throws(
+      () =>
+        submit({
+          text: 'valid',
+          attachments: Array.from({ length: MAX_ATTACHMENT_COUNT + 1 }, (_, index) =>
+            attachmentRef({ kind: 'workspace_file', relativePath: `${index}.ts` }),
+          ),
+        }),
+      isInvalidFrame,
+    );
+    for (const attachment of [
+      { ...attachmentRef({ kind: 'workspace_file', relativePath: 'a.ts' }), bytes: -1 },
+      {
+        ...attachmentRef({ kind: 'workspace_file', relativePath: 'a.ts' }),
+        bytes: MAX_ATTACHMENT_BYTES + 1,
+      },
+      { ...attachmentRef({ kind: 'workspace_file', relativePath: 'a.ts' }), name: '' },
+      { ...attachmentRef({ kind: 'workspace_file', relativePath: 'a.ts' }), mimeType: '' },
+      attachmentRef({ kind: 'workspace_file', relativePath: 'a'.repeat(4097) }),
+      attachmentRef({ kind: 'session_file', sessionId: 'bad/id', relativePath: 'a.ts' }),
+      attachmentRef({ kind: 'workspace_file', relativePath: '../secret' }),
+      attachmentRef({ kind: 'workspace_file', relativePath: 'src//a.ts' }),
+      attachmentRef({ kind: 'external_file', absolutePath: 'relative/a.ts' }),
+    ]) {
+      assert.throws(() => submit({ text: 'valid', attachments: [attachment] }), isInvalidFrame);
+    }
+    assert.doesNotThrow(() =>
+      submit({
+        text: 'valid',
+        quotes: Array.from({ length: TURN_MESSAGE_QUOTE_MAX_COUNT }, (_, index) => ({
+          text: `excerpt-${index}`,
+          label: 'Assistant',
+          sourceTurnId: `turn-${index}`,
+        })),
+      }),
+    );
+    for (const quotes of [
+      Array.from({ length: TURN_MESSAGE_QUOTE_MAX_COUNT + 1 }, () => ({ text: 'excerpt' })),
+      [{ text: '' }],
+      [{ text: 'x'.repeat(TURN_MESSAGE_QUOTE_TEXT_MAX_LENGTH + 1) }],
+      [{ text: 'excerpt', label: '' }],
+      [{ text: 'excerpt', label: 'x'.repeat(TURN_MESSAGE_QUOTE_LABEL_MAX_LENGTH + 1) }],
+      [{ text: 'excerpt', sourceTurnId: 'bad/id' }],
+      [{ text: 'excerpt', sourceTurnId: 'x'.repeat(129) }],
+      [{ text: 'excerpt', extra: true }],
+    ]) {
+      assert.throws(() => submit({ text: 'valid', quotes }), isInvalidFrame);
+    }
+    assert.throws(
+      () => submit({ text: 'a'.repeat(TURN_MESSAGE_CONTENT_MAX_BYTES), displayText: 'also large' }),
+      isInvalidFrame,
+    );
+  });
+
+  test('bounds Message text in UTF-8 bytes while preserving frame headroom', () => {
+    const input = {
+      originHostEpoch: 'epoch-1',
+      sessionId: 'session-1',
+      messageId: 'message-1',
+      content: { text: 'a'.repeat(TURN_MESSAGE_TEXT_MAX_BYTES) },
+      placement: 'next_turn' as const,
+    };
+    const frame = decodeClientFrame({
+      requestId: 'submit-request-1',
+      operation: 'turn.message.submit',
+      input,
+    });
+    assert.ok(encodeProtocolFrame(frame).byteLength < RUNTIME_HOST_MAX_FRAME_BYTES);
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          requestId: 'submit-request-2',
+          operation: 'turn.message.submit',
+          input: {
+            ...input,
+            content: { text: '界'.repeat(Math.floor(TURN_MESSAGE_TEXT_MAX_BYTES / 3) + 1) },
+          },
+        }),
+      isInvalidFrame,
+    );
+  });
+
+  test('decodes exact submit dispositions and bounded retract and interrupt results', () => {
+    for (const result of [
+      { disposition: 'steering', queueRevision: 2 },
+      { disposition: 'followup', queueRevision: 3 },
+      { disposition: 'turn_started', turnId: 'turn-2' },
+    ]) {
+      assert.doesNotThrow(() =>
+        decodeHostFrame({
+          requestId: 'submit-response',
+          operation: 'turn.message.submit',
+          ok: true,
+          result,
+        }),
+      );
+    }
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          requestId: 'submit-response',
+          operation: 'turn.message.submit',
+          ok: true,
+          result: { disposition: 'turn_started', turnId: 'turn-2', queueRevision: 4 },
+        }),
+      isInvalidFrame,
+    );
+    const retracted = [retractedMessage()];
+    assert.doesNotThrow(() =>
+      decodeHostFrame({
+        requestId: 'interrupt-response',
+        operation: 'turn.interrupt',
+        ok: true,
+        result: {
+          queueRevision: 5,
+          retracted,
+          turn: {
+            sessionId: 'session-1',
+            turnId: 'turn-1',
+            runId: 'run-1',
+            status: 'cancelled',
+            terminalEventId: 'event-1',
+            abortSource: 'user_interrupt',
+          },
+        },
+      }),
+    );
+    const oversized = Array.from({ length: MESSAGE_QUEUE_MAX_ENTRIES }, (_, index) => ({
+      ...retractedMessage('a'.repeat(900)),
+      entryId: `entry-${index}`,
+      messageId: `message-${index}`,
+    }));
+    assert.ok(Buffer.byteLength(JSON.stringify(oversized)) > MESSAGE_OPERATION_RESULT_MAX_BYTES);
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          requestId: 'retract-response',
+          operation: 'queue.retract',
+          ok: true,
+          result: { queueRevision: 6, retracted: oversized },
+        }),
+      isInvalidFrame,
+    );
+  });
+
+  test('validates queued, in-flight, and retracted snapshots as closed bounded unions', () => {
+    const projectedQuotes = [
+      { text: 'one', sourceTurnId: 'turn-1' },
+      { text: 'two', label: 'User', sourceTurnId: 'turn-2' },
+    ];
+    const followup = {
+      ...queuedMessage('later', 'next_turn'),
+      entryId: 'entry-3',
+      messageId: 'm-3',
+      content: { text: 'later', quotes: projectedQuotes },
+    };
+    const projectionWire = {
+      hostEpoch: 'epoch-1',
+      queueRevision: 7,
+      steering: [queuedMessage(), inFlightMessage()],
+      followup: [followup],
+    };
+    assert.deepEqual(
+      decodeSessionMessageQueueProjection(JSON.parse(JSON.stringify(projectionWire))),
+      projectionWire,
+    );
+    for (const projection of [
+      {
+        hostEpoch: 'epoch-1',
+        queueRevision: 1,
+        steering: [queuedMessage('wrong lane', 'next_turn')],
+        followup: [],
+      },
+      {
+        hostEpoch: 'epoch-1',
+        queueRevision: 1,
+        steering: [],
+        followup: [{ ...inFlightMessage(), placement: 'next_turn' }],
+      },
+      {
+        hostEpoch: 'epoch-1',
+        queueRevision: 1,
+        steering: [],
+        followup: [queuedMessage('wrong followup lane', 'current_turn')],
+      },
+      {
+        hostEpoch: 'epoch-1',
+        queueRevision: 1,
+        steering: [queuedMessage(), { ...queuedMessage(), entryId: 'other-entry' }],
+        followup: [],
+      },
+      {
+        hostEpoch: 'epoch-1',
+        queueRevision: 1,
+        steering: Array.from({ length: MESSAGE_QUEUE_MAX_ENTRIES + 1 }, (_, index) => ({
+          ...queuedMessage(),
+          entryId: `entry-${index}`,
+          messageId: `message-${index}`,
+        })),
+        followup: [],
+      },
+    ]) {
+      assert.throws(() => decodeSessionMessageQueueProjection(projection), isInvalidFrame);
+    }
   });
 
   test('rejects duplicate operation keys while composing domain registries', () => {
@@ -216,4 +686,45 @@ describe('Runtime Host bootstrap protocol', () => {
 
 function isInvalidFrame(error: unknown): boolean {
   return error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame';
+}
+
+function queuedMessage(
+  text = 'adjust this turn',
+  placement: 'current_turn' | 'next_turn' = 'current_turn',
+) {
+  return {
+    entryId: 'entry-1',
+    messageId: 'message-1',
+    content: { text },
+    placement,
+    state: 'queued' as const,
+  };
+}
+
+function inFlightMessage() {
+  return {
+    ...queuedMessage('already pulled'),
+    entryId: 'entry-2',
+    messageId: 'message-2',
+    state: 'in_flight' as const,
+  };
+}
+
+function retractedMessage(text = 'do this next') {
+  return {
+    entryId: 'entry-retracted',
+    messageId: 'message-retracted',
+    content: { text },
+    placement: 'next_turn' as const,
+    state: 'retracted' as const,
+  };
+}
+
+function attachmentRef(
+  ref:
+    | { kind: 'session_file'; sessionId: string; relativePath: string }
+    | { kind: 'workspace_file'; relativePath: string }
+    | { kind: 'external_file'; absolutePath: string },
+) {
+  return { kind: 'code' as const, name: 'a.ts', mimeType: 'text/typescript', bytes: 10, ref };
 }

--- a/packages/runtime-host/src/__tests__/root-admission-owner.test.ts
+++ b/packages/runtime-host/src/__tests__/root-admission-owner.test.ts
@@ -3,7 +3,12 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
-import { createAgentRunStore, type RootTurnAdmissionStore } from '@maka/storage';
+import {
+  createAgentRunStore,
+  type RootTurnAdmission,
+  type RootTurnAdmissionStore,
+  type RootTurnSourceMessage,
+} from '@maka/storage';
 import { RootAdmissionOwner } from '../server/root-admission-owner.js';
 import { SessionAdmissionGate } from '../server/session-admission-gate.js';
 
@@ -21,6 +26,8 @@ test('poisons a Session after an ambiguous durable admission failure', async () 
       },
       readRootTurnAdmission: (sessionId, turnId) =>
         durableStore.readRootTurnAdmission(sessionId, turnId),
+      readRootTurnSourceMessageReceipt: (sessionId, sourceMessageId) =>
+        durableStore.readRootTurnSourceMessageReceipt(sessionId, sourceMessageId),
       listRootTurnAdmissionsForRecovery: (sessionId) =>
         durableStore.listRootTurnAdmissionsForRecovery(sessionId),
     };
@@ -75,7 +82,7 @@ test('recovery installs the validated tip and the successor extends it', async (
 test('fails closed when a known durable admission identity drifts', async () => {
   await withStore(async (store) => {
     const first = await store.admitRootTurn({
-      ...admitInput('session', 'turn-1', 10),
+      ...multiSourceAdmitInput('session', 'turn-1', 10),
       previousRootTurnId: null,
     });
     const owner = new RootAdmissionOwner(store);
@@ -85,8 +92,202 @@ test('fails closed when a known durable admission identity drifts', async () => 
       () => owner.assertKnownAdmission({ ...first.admission, runId: 'run-drifted' }),
       /identity changed/,
     );
+    assert.throws(
+      () =>
+        owner.assertKnownAdmission({
+          ...first.admission,
+          normalizedInput: { ...first.admission.normalizedInput, displayText: 'drifted' },
+        }),
+      /identity changed/,
+    );
+    assert.throws(
+      () =>
+        owner.assertKnownAdmission({
+          ...first.admission,
+          execution: {
+            kind: 'linked_child_resume',
+            agentId: 'local-read',
+            agentName: 'Local Read',
+            sourceRunId: 'source-run',
+          },
+        }),
+      /identity changed/,
+    );
+    assert.throws(
+      () =>
+        owner.assertKnownAdmission({
+          ...first.admission,
+          normalizedInput: {
+            ...first.admission.normalizedInput,
+            attachments: first.admission.normalizedInput.attachments?.map((attachment, index) =>
+              index === 0 ? { ...attachment, name: 'drifted.png' } : attachment,
+            ),
+          },
+        }),
+      /identity changed/,
+    );
+    const [firstSource] = first.admission.sourceMessages;
+    assert.ok(firstSource);
+    const sourceDrifts: RootTurnAdmission[] = [
+      {
+        ...first.admission,
+        sourceMessages: [...first.admission.sourceMessages].reverse(),
+      },
+      {
+        ...first.admission,
+        sourceMessages: [
+          { ...firstSource, messageId: 'source-drifted' },
+          ...first.admission.sourceMessages.slice(1),
+        ],
+      },
+      {
+        ...first.admission,
+        sourceMessages: [
+          { ...firstSource, content: { ...firstSource.content, displayText: 'drifted source' } },
+          ...first.admission.sourceMessages.slice(1),
+        ],
+      },
+      {
+        ...first.admission,
+        sourceMessages: [
+          { ...firstSource, placement: 'next_turn' },
+          ...first.admission.sourceMessages.slice(1),
+        ],
+      },
+      {
+        ...first.admission,
+        sourceMessages: [
+          { ...firstSource, disposition: 'followup' },
+          ...first.admission.sourceMessages.slice(1),
+        ],
+      },
+    ];
+    for (const drifted of sourceDrifts) {
+      assert.throws(() => owner.assertKnownAdmission(drifted), /identity changed/);
+    }
     await assert.rejects(() => owner.recoverSession('session'), /already installed/);
   });
+});
+
+test('snapshots recovered admissions without retaining mutable caller references', async () => {
+  const admission = mutableAdmission();
+  const store: RootTurnAdmissionStore = {
+    admitRootTurn: async () => ({ kind: 'admitted', admission }),
+    readRootTurnAdmission: async () => admission,
+    readRootTurnSourceMessageReceipt: async () => undefined,
+    listRootTurnAdmissionsForRecovery: async () => [admission],
+  };
+  const owner = new RootAdmissionOwner(store);
+  const [snapshot] = await owner.recoverSession('session');
+  assert.ok(snapshot);
+  const mutableSources = admission.sourceMessages as RootTurnSourceMessage[];
+  assert.throws(
+    () =>
+      owner.assertKnownAdmission({
+        ...snapshot,
+        normalizedInput: {
+          ...snapshot.normalizedInput,
+          quotes: [...(snapshot.normalizedInput.quotes ?? [])].reverse(),
+        },
+      }),
+    /identity changed/,
+  );
+  assert.throws(
+    () =>
+      owner.assertKnownAdmission({
+        ...snapshot,
+        normalizedInput: {
+          ...snapshot.normalizedInput,
+          quotes: snapshot.normalizedInput.quotes?.map((quote, index) =>
+            index === 0 ? { ...quote, sourceTurnId: 'turn-drifted' } : quote,
+          ),
+        },
+      }),
+    /identity changed/,
+  );
+
+  admission.normalizedInput.displayText = 'mutated display';
+  admission.normalizedInput.attachments![0]!.name = 'mutated.png';
+  admission.normalizedInput.attachments![0]!.ref = {
+    kind: 'external_file',
+    absolutePath: '/mutated.png',
+  };
+  admission.normalizedInput.quotes![0]!.text = 'mutated quote';
+  admission.normalizedInput.quotes!.reverse();
+  mutableSources[0]!.content.text = 'mutated source';
+  mutableSources[0]!.content.attachments![0]!.ref = {
+    kind: 'external_file',
+    absolutePath: '/mutated-source.png',
+  };
+  mutableSources[0]!.content.quotes![0]!.sourceTurnId = 'turn-mutated';
+  mutableSources[0]!.placement = 'next_turn';
+  mutableSources.reverse();
+
+  assert.equal(snapshot.normalizedInput.displayText, 'display text\n\nfollowup text');
+  assert.equal(snapshot.normalizedInput.attachments?.[0]?.name, 'image.png');
+  assert.deepEqual(snapshot.normalizedInput.attachments?.[0]?.ref, {
+    kind: 'workspace_file',
+    relativePath: 'image.png',
+  });
+  assert.deepEqual(snapshot.normalizedInput.quotes, [
+    { text: 'first excerpt', label: 'Assistant', sourceTurnId: 'turn-source-1' },
+    { text: 'second excerpt', sourceTurnId: 'turn-source-2' },
+  ]);
+  assert.deepEqual(
+    snapshot.sourceMessages.map((source) => [source.messageId, source.content.text]),
+    [
+      ['source-1', 'model text'],
+      ['source-2', 'followup text'],
+    ],
+  );
+  assert.ok(Object.isFrozen(snapshot));
+  assert.ok(Object.isFrozen(snapshot.normalizedInput));
+  assert.ok(Object.isFrozen(snapshot.normalizedInput.attachments));
+  assert.ok(Object.isFrozen(snapshot.normalizedInput.attachments?.[0]));
+  assert.ok(Object.isFrozen(snapshot.normalizedInput.attachments?.[0]?.ref));
+  assert.ok(Object.isFrozen(snapshot.normalizedInput.quotes));
+  assert.ok(Object.isFrozen(snapshot.normalizedInput.quotes?.[0]));
+  assert.ok(Object.isFrozen(snapshot.sourceMessages));
+  assert.ok(Object.isFrozen(snapshot.sourceMessages[0]));
+  assert.ok(Object.isFrozen(snapshot.sourceMessages[0]?.content));
+  assert.ok(Object.isFrozen(snapshot.sourceMessages[0]?.content.attachments));
+  assert.ok(Object.isFrozen(snapshot.sourceMessages[0]?.content.attachments?.[0]));
+  assert.ok(Object.isFrozen(snapshot.sourceMessages[0]?.content.attachments?.[0]?.ref));
+  assert.ok(Object.isFrozen(snapshot.sourceMessages[0]?.content.quotes));
+  assert.ok(Object.isFrozen(snapshot.sourceMessages[0]?.content.quotes?.[0]));
+  assert.throws(() => {
+    snapshot.normalizedInput.quotes![0]!.text = 'returned mutation';
+  }, TypeError);
+  assert.doesNotThrow(() => owner.assertKnownAdmission(snapshot));
+  assert.throws(() => owner.assertKnownAdmission(admission), /identity changed/);
+});
+
+test('returns an owned frozen admission instead of the mutable store result', async () => {
+  const durableAdmission = mutableAdmission();
+  const store: RootTurnAdmissionStore = {
+    admitRootTurn: async () => ({ kind: 'admitted', admission: durableAdmission }),
+    readRootTurnAdmission: async () => durableAdmission,
+    readRootTurnSourceMessageReceipt: async () => undefined,
+    listRootTurnAdmissionsForRecovery: async () => [],
+  };
+  const owner = new RootAdmissionOwner(store);
+  await owner.recoverSession('session');
+
+  const result = await owner.admitRootTurn(quotedMultiSourceAdmitInput('session', 'turn-1', 10));
+  assert.notEqual(result.admission, durableAdmission);
+  assert.ok(Object.isFrozen(result));
+  assert.ok(Object.isFrozen(result.admission));
+  assert.ok(Object.isFrozen(result.admission.normalizedInput.quotes));
+  assert.ok(Object.isFrozen(result.admission.normalizedInput.quotes?.[0]));
+
+  durableAdmission.normalizedInput.quotes![0]!.text = 'store mutation';
+  durableAdmission.sourceMessages[0]!.content.quotes![0]!.label = 'Store mutation';
+  assert.deepEqual(result.admission.normalizedInput.quotes, [
+    { text: 'first excerpt', label: 'Assistant', sourceTurnId: 'turn-source-1' },
+    { text: 'second excerpt', sourceTurnId: 'turn-source-2' },
+  ]);
+  assert.doesNotThrow(() => owner.assertKnownAdmission(result.admission));
+  assert.throws(() => owner.assertKnownAdmission(durableAdmission), /identity changed/);
 });
 
 function admitInput(sessionId: string, turnId: string, admittedAt: number) {
@@ -95,8 +296,85 @@ function admitInput(sessionId: string, turnId: string, admittedAt: number) {
     turnId,
     proposedRunId: `run-${turnId}`,
     proposedUserMessageId: `message-${turnId}`,
+    execution: { kind: 'external_message' as const },
     normalizedInput: { text: `text-${turnId}` },
+    sourceMessages: [],
     admittedAt,
+  };
+}
+
+function multiSourceAdmitInput(sessionId: string, turnId: string, admittedAt: number) {
+  const attachment = {
+    kind: 'image' as const,
+    name: 'image.png',
+    mimeType: 'image/png',
+    bytes: 42,
+    ref: { kind: 'workspace_file' as const, relativePath: 'image.png' },
+  };
+  return {
+    sessionId,
+    turnId,
+    proposedRunId: `run-${turnId}`,
+    proposedUserMessageId: `message-${turnId}`,
+    execution: { kind: 'external_message' as const },
+    normalizedInput: {
+      text: 'model text\n\nfollowup text',
+      displayText: 'display text\n\nfollowup text',
+      attachments: [attachment],
+    },
+    sourceMessages: [
+      {
+        messageId: 'source-1',
+        content: { text: 'model text', displayText: 'display text', attachments: [attachment] },
+        placement: 'current_turn' as const,
+        disposition: 'steering' as const,
+      },
+      {
+        messageId: 'source-2',
+        content: { text: 'followup text' },
+        placement: 'next_turn' as const,
+        disposition: 'followup' as const,
+      },
+    ],
+    admittedAt,
+  };
+}
+
+function quotedMultiSourceAdmitInput(sessionId: string, turnId: string, admittedAt: number) {
+  const input = multiSourceAdmitInput(sessionId, turnId, admittedAt);
+  const quotes = [
+    { text: 'first excerpt', label: 'Assistant', sourceTurnId: 'turn-source-1' },
+    { text: 'second excerpt', sourceTurnId: 'turn-source-2' },
+  ];
+  return {
+    ...input,
+    normalizedInput: { ...input.normalizedInput, quotes },
+    sourceMessages: [
+      {
+        ...input.sourceMessages[0]!,
+        content: { ...input.sourceMessages[0]!.content, quotes: [quotes[0]!] },
+      },
+      {
+        ...input.sourceMessages[1]!,
+        content: { ...input.sourceMessages[1]!.content, quotes: [quotes[1]!] },
+      },
+    ],
+  };
+}
+
+function mutableAdmission(): RootTurnAdmission {
+  const input = quotedMultiSourceAdmitInput('session', 'turn-1', 10);
+  return {
+    schemaVersion: 1,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    runId: input.proposedRunId,
+    userMessageId: input.proposedUserMessageId,
+    execution: input.execution,
+    previousRootTurnId: null,
+    normalizedInput: input.normalizedInput,
+    sourceMessages: input.sourceMessages,
+    admittedAt: input.admittedAt,
   };
 }
 

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -1,0 +1,1013 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import {
+  BackendRegistry,
+  classifyTerminalRuntimeLedger,
+  FakeBackend,
+  FAKE_ASK_USER_QUESTION_PROMPT,
+  LOCAL_READ_AGENT_PROFILE,
+  RuntimeHostedRootConflictError,
+  SessionManager,
+  type RuntimeHostedRootAuthority,
+} from '@maka/runtime';
+import type { AgentBackend, BackendSendInput } from '@maka/core/backend-types';
+import type { SessionEvent } from '@maka/core/events';
+import type { MakaTool } from '@maka/runtime';
+import {
+  openInteractiveExecutionStoresForWrite,
+  type RootTurnAdmissionStore,
+} from '@maka/storage/execution-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import type { RuntimeHostResidency } from '../server/host-kernel.js';
+import { type HostMessageRootPort, HostMessageCoordinator } from '../server/message-coordinator.js';
+import { RootAdmissionOwner } from '../server/root-admission-owner.js';
+import { RootTurnCoordinator } from '../server/root-turn-coordinator.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+
+const HOLD_EXTERNAL_PROMPT = 'hold external root before follow-up';
+
+test('hosted linked child roots share admission, message, terminal, and stop authority', {
+  timeout: 20_000,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-linked-root-authority-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'root'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) throw new Error('Unable to acquire test root');
+
+  try {
+    const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const parent = await stores.sessionStore.create({
+      cwd: capability.canonicalPath,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    const sessionAdmission = new SessionAdmissionGate();
+    const rootAdmissionOwner = new RootAdmissionOwner(stores.agentRunStore);
+    await rootAdmissionOwner.recoverSession(parent.id);
+    const acquireResidency = (): RuntimeHostResidency => ({ release() {} });
+    let coordinator: RootTurnCoordinator | undefined;
+    const rootPort: HostMessageRootPort = {
+      readSessionHeader: (sessionId) =>
+        requireCoordinator(coordinator).readSessionHeader(sessionId),
+      readRootState: (sessionId) => requireCoordinator(coordinator).readRootState(sessionId),
+      startFromMessage: (input) => requireCoordinator(coordinator).startFromMessage(input),
+      claimStop: (input, commitQueueFence) =>
+        requireCoordinator(coordinator).claimStop(input, commitQueueFence),
+    };
+    const hostEpoch = 'epoch-linked-root';
+    await stores.messageReceiptStore.beginHostEpoch(hostEpoch);
+    const messages = new HostMessageCoordinator({
+      hostEpoch,
+      root: rootPort,
+      durableProof: {
+        readRootTurnSourceMessageReceipt: (sessionId, messageId) =>
+          stores.agentRunStore.readRootTurnSourceMessageReceipt(sessionId, messageId),
+        readImmutableSteeringMessageProof: (sessionId, messageId) =>
+          stores.runtimeEventStore.readImmutableSteeringMessageProof(sessionId, messageId),
+      },
+      receipts: stores.messageReceiptStore,
+      sessionAdmission,
+      acquireResidency,
+    });
+    const authority: RuntimeHostedRootAuthority = {
+      bindRun: (identity) => messages.bindRun(identity),
+      executeRoot: (input) => requireCoordinator(coordinator).executeRoot(input),
+      stopRoot: (identity, input) => requireCoordinator(coordinator).stopRoot(identity, input),
+      stopSession: (sessionId, input) =>
+        requireCoordinator(coordinator).stopSession(sessionId, input),
+    };
+    const backends = new BackendRegistry();
+    const linkedBackends = new Map<string, LinkedChildAuthorityBackend>();
+    backends.register('fake', (context) => {
+      if (!context.header.subagentRuntime) return new FakeBackend(context);
+      const backend = new LinkedChildAuthorityBackend(context.sessionId);
+      linkedBackends.set(context.sessionId, backend);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store: stores.sessionStore,
+      runStore: stores.agentRunStore,
+      runtimeEventStore: stores.runtimeEventStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: randomUUID,
+      now: Date.now,
+      messageAuthority: authority,
+    });
+    let drainRequested = false;
+    coordinator = new RootTurnCoordinator(
+      manager,
+      stores,
+      sessionAdmission,
+      rootAdmissionOwner,
+      messages,
+      acquireResidency,
+      () => {
+        drainRequested = true;
+      },
+    );
+
+    const parentTurnId = randomUUID();
+    const parentStarted = await coordinator.handlers['turn.start'](
+      {
+        sessionId: parent.id,
+        turnId: parentTurnId,
+        content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
+      },
+      operationContext('epoch-linked-root', acquireResidency),
+    );
+    assert.equal(parentStarted.ok, true);
+    if (!parentStarted.ok) return;
+
+    let initialReady:
+      | {
+          childSessionId: string;
+          turnId: string;
+          runId: string;
+          agentId: string;
+          agentName: string;
+        }
+      | undefined;
+    let initialEventCount = 0;
+    const child = await manager.spawnChildSession(parent.id, {
+      spawnedBy: {
+        parentRunId: parentStarted.result.runId,
+        parentTurnId,
+        toolCallId: 'linked-initial',
+      },
+      agentProfile: LOCAL_READ_AGENT_PROFILE,
+      prompt: 'initial linked child',
+      onReady: (ready) => {
+        initialReady = ready;
+      },
+      onEvent: () => {
+        initialEventCount += 1;
+      },
+    });
+    assert.equal(child.status, 'completed');
+    assert.deepEqual(initialReady, {
+      childSessionId: child.childSessionId,
+      turnId: child.turnId,
+      runId: child.runId,
+      agentId: child.agentId,
+      agentName: child.agentName,
+    });
+    assert.equal(initialEventCount, child.eventCount);
+    const initialAdmissions = await stores.agentRunStore.listRootTurnAdmissionsForRecovery(
+      child.childSessionId,
+    );
+    assert.equal(initialAdmissions.length, 1);
+    assert.equal(initialAdmissions[0]?.runId, child.runId);
+    assert.ok(initialAdmissions[0]?.userMessageId);
+    assert.deepEqual(initialAdmissions[0]?.execution, {
+      kind: 'linked_child_initial',
+      agentId: child.agentId,
+      agentName: child.agentName,
+    });
+    const externalJoin = await coordinator.handlers['turn.start'](
+      {
+        sessionId: child.childSessionId,
+        turnId: child.turnId,
+        content: { text: 'initial linked child' },
+      },
+      operationContext(hostEpoch, acquireResidency),
+    );
+    assert.deepEqual(externalJoin, {
+      ok: false,
+      error: {
+        code: 'operation_conflict',
+        message: 'Turn identity belongs to a different execution kind',
+      },
+    });
+
+    const resumeAbort = new AbortController();
+    resumeAbort.abort();
+    const runsBeforeAbortedResume = await stores.agentRunStore.listSessionRuns(
+      child.childSessionId,
+    );
+    const sendsBeforeAbortedResume = linkedBackends.get(child.childSessionId)?.sendCount;
+    let abortedResumeReady = 0;
+    await assert.rejects(
+      manager.resumeChildAgent(parent.id, {
+        parentRunId: parentStarted.result.runId,
+        sourceRunId: child.runId,
+        prompt: 'must not start',
+        abortSignal: resumeAbort.signal,
+        onReady: () => {
+          abortedResumeReady += 1;
+        },
+      }),
+      { name: 'AbortError' },
+    );
+    assert.equal(
+      (await stores.agentRunStore.listSessionRuns(child.childSessionId)).length,
+      runsBeforeAbortedResume.length,
+    );
+    assert.equal(linkedBackends.get(child.childSessionId)?.sendCount, sendsBeforeAbortedResume);
+    assert.equal(abortedResumeReady, 0);
+
+    let resumeReadyRunId: string | undefined;
+    let resumeEventCount = 0;
+    const resumed = await manager.resumeChildAgent(parent.id, {
+      parentRunId: parentStarted.result.runId,
+      sourceRunId: child.runId,
+      prompt: 'rate limit this resumed child',
+      onReady: (ready) => {
+        resumeReadyRunId = ready.runId;
+      },
+      onEvent: () => {
+        resumeEventCount += 1;
+      },
+    });
+    assert.equal(resumed.status, 'failed');
+    assert.equal(resumed.failureClass, 'RateLimit');
+    assert.equal(resumed.resumedFromRunId, child.runId);
+    assert.equal(resumeReadyRunId, resumed.runId);
+    assert.equal(resumeEventCount, resumed.eventCount);
+
+    let retryReadyRunId: string | undefined;
+    let retryEventCount = 0;
+    const retried = await manager.retryChildAgent(parent.id, {
+      parentRunId: parentStarted.result.runId,
+      sourceRunId: resumed.runId!,
+      execution: {
+        kind: 'child_session',
+        sessionId: child.childSessionId,
+        currentRunId: resumed.runId,
+      },
+      onReady: (ready) => {
+        retryReadyRunId = ready.runId;
+      },
+      onEvent: () => {
+        retryEventCount += 1;
+      },
+    });
+    assert.equal(retried.status, 'completed');
+    assert.equal(retried.retriedFromRunId, resumed.runId);
+    assert.equal(retryReadyRunId, retried.runId);
+    assert.equal(retryEventCount, retried.eventCount);
+    const admissions = await stores.agentRunStore.listRootTurnAdmissionsForRecovery(
+      child.childSessionId,
+    );
+    assert.equal(admissions.length, 3);
+    assert.equal(admissions[1]?.runId, resumed.runId);
+    assert.ok(admissions[1]?.userMessageId);
+    assert.deepEqual(admissions[1]?.execution, {
+      kind: 'linked_child_resume',
+      agentId: resumed.agentId,
+      agentName: resumed.agentName,
+      sourceRunId: child.runId,
+    });
+    assert.equal(admissions[2]?.runId, retried.runId);
+    assert.equal(admissions[2]?.userMessageId, null);
+    assert.deepEqual(admissions[2]?.execution, {
+      kind: 'linked_child_provider_retry',
+      agentId: retried.agentId,
+      agentName: retried.agentName,
+      sourceRunId: resumed.runId,
+    });
+    const retryMessages = (await stores.sessionStore.readMessages(child.childSessionId)).filter(
+      (message) => 'turnId' in message && message.turnId === retried.turnId,
+    );
+    assert.deepEqual(retryMessages, []);
+    assert.deepEqual(coordinator.readRootState(child.childSessionId), { kind: 'idle' });
+
+    const externalTurnId = randomUUID();
+    const external = await coordinator.handlers['turn.start'](
+      {
+        sessionId: child.childSessionId,
+        turnId: externalTurnId,
+        content: { text: HOLD_EXTERNAL_PROMPT },
+      },
+      operationContext(hostEpoch, acquireResidency),
+    );
+    assert.equal(external.ok, true);
+    if (!external.ok) return;
+    const queuedFollowup = await messages.handlers['turn.message.submit'](
+      {
+        originHostEpoch: hostEpoch,
+        sessionId: child.childSessionId,
+        messageId: randomUUID(),
+        content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
+        placement: 'next_turn',
+      },
+      operationContext(hostEpoch, acquireResidency),
+    );
+    assert.equal(queuedFollowup.ok && queuedFollowup.result.disposition, 'followup');
+    linkedBackends.get(child.childSessionId)?.release();
+    await waitUntil(() => {
+      const state = requireCoordinator(coordinator).readRootState(child.childSessionId);
+      return state.kind === 'active' && state.turnId !== externalTurnId;
+    });
+    const followupState = coordinator.readRootState(child.childSessionId);
+    assert.equal(followupState.kind, 'active');
+    if (followupState.kind !== 'active') return;
+
+    await assert.rejects(
+      manager.resumeChildAgent(parent.id, {
+        parentRunId: parentStarted.result.runId,
+        sourceRunId: retried.runId!,
+        prompt: 'internal resume racing the external follow-up',
+      }),
+      (error) => {
+        assert.ok(error instanceof RuntimeHostedRootConflictError);
+        assert.equal(error.code, 'session_busy');
+        assert.deepEqual(error.scope, {
+          kind: 'session',
+          sessionId: child.childSessionId,
+        });
+        return true;
+      },
+    );
+    assert.equal(drainRequested, false);
+    await coordinator.stopRoot(followupState);
+    assert.deepEqual(coordinator.readRootState(child.childSessionId), { kind: 'idle' });
+
+    const failedResume = await manager.resumeChildAgent(parent.id, {
+      parentRunId: parentStarted.result.runId,
+      sourceRunId: retried.runId!,
+      prompt: 'rate limit one more linked child',
+    });
+    assert.equal(failedResume.status, 'failed');
+    const linkedBackend = linkedBackends.get(child.childSessionId);
+    assert.ok(linkedBackend);
+    const runsBeforeAbortedRetry = await stores.agentRunStore.listSessionRuns(child.childSessionId);
+    const sendsBeforeAbortedRetry = linkedBackend?.sendCount;
+    const retryAbort = new AbortController();
+    retryAbort.abort();
+    let abortedRetryReady = 0;
+    await assert.rejects(
+      manager.retryChildAgent(parent.id, {
+        parentRunId: parentStarted.result.runId,
+        sourceRunId: failedResume.runId!,
+        abortSignal: retryAbort.signal,
+        onReady: () => {
+          abortedRetryReady += 1;
+        },
+      }),
+      { name: 'AbortError' },
+    );
+    assert.equal(
+      (await stores.agentRunStore.listSessionRuns(child.childSessionId)).length,
+      runsBeforeAbortedRetry.length,
+    );
+    assert.equal(linkedBackend?.sendCount, sendsBeforeAbortedRetry);
+    assert.equal(abortedRetryReady, 0);
+    assert.equal(drainRequested, false);
+
+    const abortController = new AbortController();
+    let joinedInitial: Promise<typeof child> | undefined;
+    const interrupted = await manager.spawnChildSession(parent.id, {
+      spawnedBy: {
+        parentRunId: parentStarted.result.runId,
+        parentTurnId,
+        toolCallId: 'linked-interrupt',
+      },
+      agentProfile: LOCAL_READ_AGENT_PROFILE,
+      prompt: FAKE_ASK_USER_QUESTION_PROMPT,
+      abortSignal: abortController.signal,
+      onReady: () => {
+        joinedInitial = manager.spawnChildSession(parent.id, {
+          spawnedBy: {
+            parentRunId: parentStarted.result.runId,
+            parentTurnId,
+            toolCallId: 'linked-interrupt',
+          },
+          agentProfile: LOCAL_READ_AGENT_PROFILE,
+          prompt: FAKE_ASK_USER_QUESTION_PROMPT,
+        });
+        abortController.abort();
+      },
+    });
+    assert.ok(joinedInitial);
+    const joinedInterrupted = await joinedInitial;
+    assert.equal(interrupted.status, 'cancelled');
+    assert.deepEqual(joinedInterrupted, interrupted);
+    const interruptedRun = await stores.agentRunStore.readRun(
+      interrupted.childSessionId,
+      interrupted.runId,
+    );
+    const interruptedEvents = await stores.runtimeEventStore.readImmutableRuntimeEvents(
+      interrupted.childSessionId,
+      interrupted.runId,
+    );
+    const interruptedTerminal = classifyTerminalRuntimeLedger(interruptedRun, interruptedEvents);
+    assert.equal(interruptedTerminal.kind, 'fact');
+    if (interruptedTerminal.kind === 'fact') {
+      assert.equal(interruptedTerminal.fact.runStatus, 'cancelled');
+    }
+    assert.deepEqual(coordinator.readRootState(interrupted.childSessionId), { kind: 'idle' });
+    assert.equal(drainRequested, false);
+
+    await coordinator.stopRoot({
+      sessionId: parent.id,
+      turnId: parentTurnId,
+      runId: parentStarted.result.runId,
+    });
+    await coordinator.close();
+    await messages.close();
+  } finally {
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('pre-bind startup failure fail-stops without orphaning an admitted queued Message', {
+  timeout: 20_000,
+}, async () => {
+  const backendFactoryEntered = deferred<void>();
+  const releaseBackendFactory = deferred<void>();
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) => {
+      backends.register('fake', async () => {
+        backendFactoryEntered.resolve();
+        await releaseBackendFactory.promise;
+        throw new Error('injected backend startup failure');
+      });
+    },
+  });
+
+  try {
+    const turnId = 'turn-pre-bind-failure';
+    const starting = fixture.coordinator.handlers['turn.start'](
+      {
+        sessionId: fixture.sessionId,
+        turnId,
+        content: { text: 'start then fail before binding the Run' },
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    await backendFactoryEntered.promise;
+    const admission = await fixture.stores.agentRunStore.readRootTurnAdmission(
+      fixture.sessionId,
+      turnId,
+    );
+    assert.ok(admission);
+    if (!admission) return;
+
+    const submitted = await fixture.messages.handlers['turn.message.submit'](
+      {
+        originHostEpoch: fixture.hostEpoch,
+        sessionId: fixture.sessionId,
+        messageId: 'message-held-across-startup-failure',
+        content: { text: 'retain this accepted follow-up' },
+        placement: 'next_turn',
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(submitted.ok && submitted.result.disposition, 'followup');
+
+    releaseBackendFactory.resolve();
+    await assert.rejects(starting, /injected backend startup failure/);
+
+    const expectedOwner = {
+      kind: 'active' as const,
+      sessionId: fixture.sessionId,
+      turnId,
+      runId: admission.runId,
+    };
+    assert.deepEqual(fixture.coordinator.readRootState(fixture.sessionId), expectedOwner);
+    assert.deepEqual(
+      fixture.messages.projection(fixture.sessionId).followup.map((entry) => entry.messageId),
+      ['message-held-across-startup-failure'],
+    );
+    assert.equal(fixture.liveResidencies(), 2);
+    assert.equal(fixture.drainRequested(), true);
+
+    const rejected = await fixture.messages.handlers['turn.message.submit'](
+      {
+        originHostEpoch: fixture.hostEpoch,
+        sessionId: fixture.sessionId,
+        messageId: 'message-after-startup-failure',
+        content: { text: 'must not enter a failed Host Epoch' },
+        placement: 'next_turn',
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(rejected.ok, false);
+    if (!rejected.ok) assert.equal(rejected.error.code, 'host_draining');
+
+    await assert.rejects(fixture.coordinator.close());
+    await assert.rejects(fixture.messages.close(), /live owner, entry, or transition/);
+    assert.deepEqual(fixture.coordinator.readRootState(fixture.sessionId), expectedOwner);
+    assert.equal(fixture.liveResidencies(), 2);
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('successor admission failure retains the terminal transition and its confirmed Message', {
+  timeout: 20_000,
+}, async () => {
+  let backend: LinkedChildAuthorityBackend | undefined;
+  const fixture = await createFailureFixture({
+    registerBackend: (backends) => {
+      backends.register('fake', () => {
+        backend = new LinkedChildAuthorityBackend('terminal-admission-failure');
+        return backend;
+      });
+    },
+    wrapAdmissionStore: (store) => ({
+      admitRootTurn: async (input) => {
+        if (input.previousRootTurnId !== null) {
+          throw new Error('injected successor admission write failure');
+        }
+        return store.admitRootTurn(input);
+      },
+      readRootTurnAdmission: (sessionId, turnId) => store.readRootTurnAdmission(sessionId, turnId),
+      readRootTurnSourceMessageReceipt: (sessionId, messageId) =>
+        store.readRootTurnSourceMessageReceipt(sessionId, messageId),
+      listRootTurnAdmissionsForRecovery: (sessionId) =>
+        store.listRootTurnAdmissionsForRecovery(sessionId),
+    }),
+  });
+
+  try {
+    const turnId = 'turn-successor-admission-failure';
+    const started = await fixture.coordinator.handlers['turn.start'](
+      {
+        sessionId: fixture.sessionId,
+        turnId,
+        content: { text: HOLD_EXTERNAL_PROMPT },
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(started.ok, true);
+    if (!started.ok) return;
+
+    const submitted = await fixture.messages.handlers['turn.message.submit'](
+      {
+        originHostEpoch: fixture.hostEpoch,
+        sessionId: fixture.sessionId,
+        messageId: 'message-held-in-terminal-transition',
+        content: { text: 'retain this confirmed successor input' },
+        placement: 'next_turn',
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(submitted.ok && submitted.result.disposition, 'followup');
+
+    backend?.release();
+    await waitUntil(() => fixture.drainRequested());
+
+    const expectedOwner = {
+      kind: 'active' as const,
+      sessionId: fixture.sessionId,
+      turnId,
+      runId: started.result.runId,
+    };
+    assert.deepEqual(fixture.coordinator.readRootState(fixture.sessionId), expectedOwner);
+    assert.deepEqual(
+      fixture.messages.projection(fixture.sessionId).followup.map((entry) => entry.messageId),
+      ['message-held-in-terminal-transition'],
+    );
+    assert.equal(fixture.liveResidencies(), 2);
+    assert.equal(
+      (await fixture.stores.agentRunStore.listRootTurnAdmissionsForRecovery(fixture.sessionId))
+        .length,
+      1,
+    );
+
+    const rejected = await fixture.messages.handlers['turn.message.submit'](
+      {
+        originHostEpoch: fixture.hostEpoch,
+        sessionId: fixture.sessionId,
+        messageId: 'message-after-successor-admission-failure',
+        content: { text: 'must not enter a failed Host Epoch' },
+        placement: 'next_turn',
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(rejected.ok, false);
+    if (!rejected.ok) assert.equal(rejected.error.code, 'host_draining');
+
+    await assert.rejects(fixture.coordinator.close(), (error) => {
+      assert.ok(error instanceof AggregateError);
+      assert.equal(
+        error.errors.some(
+          (cause) =>
+            cause instanceof Error &&
+            cause.message === 'Stop fence cannot replace a terminal transition',
+        ),
+        true,
+      );
+      return true;
+    });
+    await assert.rejects(fixture.messages.close(), /live owner, entry, or transition/);
+    assert.deepEqual(fixture.coordinator.readRootState(fixture.sessionId), expectedOwner);
+    assert.deepEqual(
+      fixture.messages.projection(fixture.sessionId).followup.map((entry) => entry.messageId),
+      ['message-held-in-terminal-transition'],
+    );
+    assert.equal(fixture.liveResidencies(), 2);
+  } finally {
+    await fixture.dispose();
+  }
+});
+
+test('shutdown re-scans a successor created by an in-flight terminal handoff', {
+  timeout: 20_000,
+}, async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-root-turn-close-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'root'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) throw new Error('Unable to acquire test root');
+
+  try {
+    const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const session = await stores.sessionStore.create({
+      cwd: capability.canonicalPath,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    const followupAdmissionStarted = deferred<void>();
+    const releaseFollowupAdmission = deferred<void>();
+    const admissionStore: RootTurnAdmissionStore = {
+      admitRootTurn: async (input) => {
+        if (input.previousRootTurnId !== null) {
+          followupAdmissionStarted.resolve();
+          await releaseFollowupAdmission.promise;
+        }
+        return stores.agentRunStore.admitRootTurn(input);
+      },
+      readRootTurnAdmission: (sessionId, turnId) =>
+        stores.agentRunStore.readRootTurnAdmission(sessionId, turnId),
+      readRootTurnSourceMessageReceipt: (sessionId, messageId) =>
+        stores.agentRunStore.readRootTurnSourceMessageReceipt(sessionId, messageId),
+      listRootTurnAdmissionsForRecovery: (sessionId) =>
+        stores.agentRunStore.listRootTurnAdmissionsForRecovery(sessionId),
+    };
+    const rootAdmissionOwner = new RootAdmissionOwner(admissionStore);
+    await rootAdmissionOwner.recoverSession(session.id);
+
+    let liveResidencies = 0;
+    const acquireResidency = (): RuntimeHostResidency => {
+      liveResidencies += 1;
+      let released = false;
+      return {
+        release: () => {
+          assert.equal(released, false);
+          released = true;
+          liveResidencies -= 1;
+        },
+      };
+    };
+    const sessionAdmission = new SessionAdmissionGate();
+    let coordinator: RootTurnCoordinator | undefined;
+    const rootPort: HostMessageRootPort = {
+      readSessionHeader: (sessionId) =>
+        requireCoordinator(coordinator).readSessionHeader(sessionId),
+      readRootState: (sessionId) => requireCoordinator(coordinator).readRootState(sessionId),
+      startFromMessage: (input) => requireCoordinator(coordinator).startFromMessage(input),
+      claimStop: (input, commitQueueFence) =>
+        requireCoordinator(coordinator).claimStop(input, commitQueueFence),
+    };
+    const hostEpoch = 'epoch-close-handoff';
+    await stores.messageReceiptStore.beginHostEpoch(hostEpoch);
+    const messages = new HostMessageCoordinator({
+      hostEpoch,
+      root: rootPort,
+      durableProof: {
+        readRootTurnSourceMessageReceipt: (sessionId, messageId) =>
+          stores.agentRunStore.readRootTurnSourceMessageReceipt(sessionId, messageId),
+        readImmutableSteeringMessageProof: (sessionId, messageId) =>
+          stores.runtimeEventStore.readImmutableSteeringMessageProof(sessionId, messageId),
+      },
+      receipts: stores.messageReceiptStore,
+      sessionAdmission,
+      acquireResidency,
+    });
+    const backends = new BackendRegistry();
+    backends.register('fake', (context) => new FakeBackend(context));
+    const manager = new SessionManager({
+      store: stores.sessionStore,
+      runStore: stores.agentRunStore,
+      runtimeEventStore: stores.runtimeEventStore,
+      backends,
+      newId: randomUUID,
+      now: Date.now,
+      messageAuthority: messages,
+    });
+    let drainRequested = false;
+    coordinator = new RootTurnCoordinator(
+      manager,
+      stores,
+      sessionAdmission,
+      rootAdmissionOwner,
+      messages,
+      acquireResidency,
+      () => {
+        drainRequested = true;
+      },
+    );
+
+    const firstTurnId = 'turn-close-first';
+    const started = await coordinator.handlers['turn.start'](
+      {
+        sessionId: session.id,
+        turnId: firstTurnId,
+        content: { text: `long-running root ${'x'.repeat(540)}` },
+      },
+      operationContext(hostEpoch, acquireResidency),
+    );
+    assert.equal(started.ok, true);
+    const followup = await messages.handlers['turn.message.submit'](
+      {
+        originHostEpoch: hostEpoch,
+        sessionId: session.id,
+        messageId: 'message-close-followup',
+        content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
+        placement: 'next_turn',
+      },
+      operationContext(hostEpoch, acquireResidency),
+    );
+    assert.equal(followup.ok && followup.result.disposition, 'followup');
+
+    await followupAdmissionStarted.promise;
+    messages.beginDrain();
+    const closing = coordinator.close();
+    assert.equal(await settlesWithin(closing, 25), false);
+    releaseFollowupAdmission.resolve();
+    await closing;
+    await messages.close();
+
+    assert.deepEqual(coordinator.readRootState(session.id), { kind: 'idle' });
+    assert.equal(liveResidencies, 0);
+    assert.equal(drainRequested, false);
+    const admissions = await stores.agentRunStore.listRootTurnAdmissionsForRecovery(session.id);
+    assert.equal(admissions.length, 2);
+    const successor = admissions[1];
+    assert.ok(successor);
+    const run = await stores.agentRunStore.readRun(session.id, successor.runId);
+    const runtimeEvents = await stores.runtimeEventStore.readImmutableRuntimeEvents(
+      session.id,
+      successor.runId,
+    );
+    const terminal = classifyTerminalRuntimeLedger(run, runtimeEvents);
+    assert.equal(terminal.kind, 'fact');
+    if (terminal.kind === 'fact') assert.equal(terminal.fact.runStatus, 'cancelled');
+  } finally {
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+async function createFailureFixture(options: {
+  registerBackend(backends: BackendRegistry): void;
+  wrapAdmissionStore?(store: RootTurnAdmissionStore): RootTurnAdmissionStore;
+}) {
+  const base = await mkdtemp(join(tmpdir(), 'maka-root-turn-message-failure-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'root'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) throw new Error('Unable to acquire test root');
+
+  const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+  const session = await stores.sessionStore.create({
+    cwd: capability.canonicalPath,
+    backend: 'fake',
+    llmConnectionSlug: 'fake',
+    model: 'fake-model',
+    permissionMode: 'ask',
+  });
+  const admissionStore = options.wrapAdmissionStore?.(stores.agentRunStore) ?? stores.agentRunStore;
+  const rootAdmissionOwner = new RootAdmissionOwner(admissionStore);
+  await rootAdmissionOwner.recoverSession(session.id);
+  const sessionAdmission = new SessionAdmissionGate();
+  let liveResidencies = 0;
+  const acquireResidency = (): RuntimeHostResidency => {
+    liveResidencies += 1;
+    let released = false;
+    return {
+      release: () => {
+        assert.equal(released, false);
+        released = true;
+        liveResidencies -= 1;
+      },
+    };
+  };
+  let drainRequested = false;
+  let coordinator: RootTurnCoordinator | undefined;
+  const rootPort: HostMessageRootPort = {
+    readSessionHeader: (sessionId) => requireCoordinator(coordinator).readSessionHeader(sessionId),
+    readRootState: (sessionId) => requireCoordinator(coordinator).readRootState(sessionId),
+    startFromMessage: (input) => requireCoordinator(coordinator).startFromMessage(input),
+    claimStop: (input, commitQueueFence) =>
+      requireCoordinator(coordinator).claimStop(input, commitQueueFence),
+  };
+  const hostEpoch = 'epoch-message-failure';
+  await stores.messageReceiptStore.beginHostEpoch(hostEpoch);
+  const requestDrain = () => {
+    drainRequested = true;
+  };
+  const messages = new HostMessageCoordinator({
+    hostEpoch,
+    root: rootPort,
+    durableProof: {
+      readRootTurnSourceMessageReceipt: (sessionId, messageId) =>
+        stores.agentRunStore.readRootTurnSourceMessageReceipt(sessionId, messageId),
+      readImmutableSteeringMessageProof: (sessionId, messageId) =>
+        stores.runtimeEventStore.readImmutableSteeringMessageProof(sessionId, messageId),
+    },
+    receipts: stores.messageReceiptStore,
+    sessionAdmission,
+    acquireResidency,
+    requestDrain,
+  });
+  const backends = new BackendRegistry();
+  options.registerBackend(backends);
+  const manager = new SessionManager({
+    store: stores.sessionStore,
+    runStore: stores.agentRunStore,
+    runtimeEventStore: stores.runtimeEventStore,
+    backends,
+    newId: randomUUID,
+    now: Date.now,
+    messageAuthority: messages,
+  });
+  coordinator = new RootTurnCoordinator(
+    manager,
+    stores,
+    sessionAdmission,
+    rootAdmissionOwner,
+    messages,
+    acquireResidency,
+    requestDrain,
+  );
+
+  return {
+    stores,
+    sessionId: session.id,
+    hostEpoch,
+    messages,
+    coordinator,
+    acquireResidency,
+    liveResidencies: () => liveResidencies,
+    drainRequested: () => drainRequested,
+    dispose: async () => {
+      await owner.close();
+      await rm(base, { recursive: true, force: true });
+    },
+  };
+}
+
+function requireCoordinator(coordinator: RootTurnCoordinator | undefined): RootTurnCoordinator {
+  if (!coordinator) throw new Error('RootTurnCoordinator is not composed');
+  return coordinator;
+}
+
+function operationContext(hostEpoch: string, acquireResidency: () => RuntimeHostResidency) {
+  return {
+    hostEpoch,
+    connectionId: 'connection-close-handoff',
+    surface: 'tui' as const,
+    principal: 'local_os_user' as const,
+    acquireResidency,
+  };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
+
+async function settlesWithin(promise: Promise<unknown>, timeoutMs: number): Promise<boolean> {
+  return Promise.race([
+    promise.then(
+      () => true,
+      () => true,
+    ),
+    new Promise<false>((resolve) => setTimeout(resolve, timeoutMs, false)),
+  ]);
+}
+
+async function waitUntil(predicate: () => boolean, timeoutMs = 2_000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('Timed out waiting for test condition');
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+}
+
+class LinkedChildAuthorityBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  sendCount = 0;
+  private stopped = false;
+  private releaseWait: (() => void) | undefined;
+
+  constructor(readonly sessionId: string) {}
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    this.sendCount += 1;
+    this.stopped = false;
+    if (input.text === HOLD_EXTERNAL_PROMPT) {
+      await new Promise<void>((resolve) => {
+        this.releaseWait = resolve;
+      });
+    }
+    if (input.text === FAKE_ASK_USER_QUESTION_PROMPT) {
+      await new Promise<void>((resolve) => {
+        this.releaseWait = resolve;
+        if (this.stopped) resolve();
+      });
+      yield {
+        type: 'abort',
+        id: randomUUID(),
+        turnId: input.turnId,
+        ts: Date.now(),
+        reason: 'user_stop',
+      };
+      yield {
+        type: 'complete',
+        id: randomUUID(),
+        turnId: input.turnId,
+        ts: Date.now(),
+        stopReason: 'user_stop',
+      };
+      return;
+    }
+    if (input.text.includes('rate limit')) {
+      yield {
+        type: 'error',
+        id: randomUUID(),
+        turnId: input.turnId,
+        ts: Date.now(),
+        recoverable: true,
+        reason: 'RateLimit',
+        message: 'provider 429',
+      };
+      yield {
+        type: 'complete',
+        id: randomUUID(),
+        turnId: input.turnId,
+        ts: Date.now(),
+        stopReason: 'error',
+      };
+      return;
+    }
+    yield {
+      type: 'text_delta',
+      id: randomUUID(),
+      turnId: input.turnId,
+      ts: Date.now(),
+      messageId: randomUUID(),
+      text: 'linked child complete',
+    };
+    yield {
+      type: 'complete',
+      id: randomUUID(),
+      turnId: input.turnId,
+      ts: Date.now(),
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {
+    this.stopped = true;
+    this.releaseWait?.();
+  }
+
+  release(): void {
+    this.releaseWait?.();
+  }
+
+  async respondToPermission(): Promise<void> {}
+
+  async dispose(): Promise<void> {
+    this.releaseWait?.();
+  }
+}
+
+function testTool(name: string): MakaTool {
+  return {
+    name,
+    description: `${name} test tool`,
+    parameters: {},
+    permissionRequired: false,
+    impl: async () => ({ ok: true }),
+  };
+}

--- a/packages/runtime-host/src/__tests__/runtime-policy-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-policy-coordinator.test.ts
@@ -67,10 +67,10 @@ test('production composition shares one gate across mutation and backend activat
       model: 'fake-model',
       permissionMode: 'ask',
     });
-    await setupStores.sessionStore.close?.();
 
     composition = await createExecutionRuntimeHostComposition({
       owner,
+      hostEpoch: context.hostEpoch,
       acquireResidency: context.acquireResidency,
       requestDrain: () => undefined,
     });
@@ -95,7 +95,7 @@ test('production composition shares one gate across mutation and backend activat
         {
           sessionId: session.id,
           turnId,
-          text: FAKE_ASK_USER_QUESTION_PROMPT,
+          content: { text: FAKE_ASK_USER_QUESTION_PROMPT },
         },
         context,
       ),
@@ -157,10 +157,10 @@ test('production policy mutation drains and poisons activation when cached backe
       model: 'fake-model',
       permissionMode: 'ask',
     });
-    await setupStores.sessionStore.close?.();
 
     composition = await createExecutionRuntimeHostComposition({
       owner,
+      hostEpoch: context.hostEpoch,
       acquireResidency: context.acquireResidency,
       requestDrain: () => {
         drainRequests += 1;
@@ -170,7 +170,11 @@ test('production policy mutation drains and poisons activation when cached backe
 
     const firstTurnId = randomUUID();
     const started = await composition.handlers['turn.start'](
-      { sessionId: session.id, turnId: firstTurnId, text: 'cache this backend' },
+      {
+        sessionId: session.id,
+        turnId: firstTurnId,
+        content: { text: 'cache this backend' },
+      },
       context,
     );
     assert.equal(started.ok, true);

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -11,6 +11,7 @@ import {
 } from './operations.js';
 
 export { RuntimeHostProtocolError } from './errors.js';
+export * from './message.js';
 export * from './operations.js';
 
 export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;

--- a/packages/runtime-host/src/protocol/message.ts
+++ b/packages/runtime-host/src/protocol/message.ts
@@ -1,0 +1,343 @@
+import { invalidProtocolFrame } from './errors.js';
+import {
+  assertExactKeys,
+  requireCount,
+  requireEntityId,
+  requireExactRecord,
+  requireId,
+  requireRecord,
+} from './codec.js';
+import { defineOperation } from './operation-spec.js';
+import {
+  decodeMessageContent,
+  decodeTurnSnapshot,
+  type MessageContent,
+  type TurnSnapshot,
+} from './turn.js';
+
+export const MESSAGE_QUEUE_MAX_ENTRIES = 64;
+export const MESSAGE_QUEUE_PROJECTION_MAX_BYTES = 52 * 1024;
+export const MESSAGE_OPERATION_RESULT_MAX_BYTES = 56 * 1024;
+
+export type MessagePlacement = 'current_turn' | 'next_turn';
+
+interface MessageQueueEntrySnapshotBase {
+  readonly entryId: string;
+  readonly messageId: string;
+  readonly content: MessageContent;
+  readonly placement: MessagePlacement;
+}
+
+export interface QueuedMessageSnapshot extends MessageQueueEntrySnapshotBase {
+  readonly state: 'queued';
+}
+
+export interface InFlightMessageSnapshot extends MessageQueueEntrySnapshotBase {
+  readonly placement: 'current_turn';
+  readonly state: 'in_flight';
+}
+
+export interface RetractedMessageSnapshot extends MessageQueueEntrySnapshotBase {
+  readonly state: 'retracted';
+}
+
+export type MessageQueueEntrySnapshot =
+  | QueuedMessageSnapshot
+  | InFlightMessageSnapshot
+  | RetractedMessageSnapshot;
+
+export type SteeringMessageSnapshot =
+  | (QueuedMessageSnapshot & { readonly placement: 'current_turn' })
+  | InFlightMessageSnapshot;
+
+export interface SessionMessageQueueProjection {
+  readonly hostEpoch: string;
+  readonly queueRevision: number;
+  readonly steering: readonly SteeringMessageSnapshot[];
+  readonly followup: readonly QueuedMessageSnapshot[];
+}
+
+export interface TurnMessageSubmitInput {
+  readonly originHostEpoch: string;
+  readonly sessionId: string;
+  readonly messageId: string;
+  readonly content: MessageContent;
+  readonly placement: MessagePlacement;
+}
+
+export type TurnMessageSubmitResult =
+  | { readonly disposition: 'steering'; readonly queueRevision: number }
+  | { readonly disposition: 'followup'; readonly queueRevision: number }
+  | { readonly disposition: 'turn_started'; readonly turnId: string };
+
+export interface QueueRetractInput {
+  readonly originHostEpoch: string;
+  readonly sessionId: string;
+  readonly retractId: string;
+}
+
+export interface QueueRetractResult {
+  readonly queueRevision: number;
+  readonly retracted: readonly RetractedMessageSnapshot[];
+}
+
+export interface TurnInterruptInput {
+  readonly originHostEpoch: string;
+  readonly sessionId: string;
+  readonly interruptId: string;
+  readonly turnId: string;
+  readonly runId: string;
+}
+
+export interface TurnInterruptResult {
+  readonly queueRevision: number;
+  readonly retracted: readonly RetractedMessageSnapshot[];
+  readonly turn: TurnSnapshot;
+}
+
+const MESSAGE_OPERATION_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'not_found',
+  'session_archived',
+  'session_busy',
+  'operation_conflict',
+  'outcome_unknown',
+  'internal_failure',
+] as const;
+
+export const MESSAGE_OPERATION_SPECS = {
+  'turn.message.submit': defineOperation({
+    mode: 'command',
+    availability: 'ready',
+    errors: MESSAGE_OPERATION_ERRORS,
+    decodeInput: decodeTurnMessageSubmitInput,
+    decodeOutput: decodeTurnMessageSubmitResult,
+  }),
+  'queue.retract': defineOperation({
+    mode: 'command',
+    availability: 'ready',
+    errors: MESSAGE_OPERATION_ERRORS,
+    decodeInput: decodeQueueRetractInput,
+    decodeOutput: decodeQueueRetractResult,
+  }),
+  'turn.interrupt': defineOperation({
+    mode: 'control',
+    availability: 'ready',
+    errors: MESSAGE_OPERATION_ERRORS,
+    decodeInput: decodeTurnInterruptInput,
+    decodeOutput: decodeTurnInterruptResult,
+  }),
+} as const;
+
+export function decodeSessionMessageQueueProjection(value: unknown): SessionMessageQueueProjection {
+  const record = requireExactRecord(value, 'Session message queue projection', [
+    'hostEpoch',
+    'queueRevision',
+    'steering',
+    'followup',
+  ]);
+  const steering = decodeSteeringMessages(record.steering);
+  const followup = decodeFollowupMessages(record.followup);
+  if (steering.length + followup.length > MESSAGE_QUEUE_MAX_ENTRIES) {
+    throw invalidProtocolFrame('Invalid Session message queue projection');
+  }
+  assertUniqueQueueEntries([...steering, ...followup], 'Session message queue projection');
+  const projection = {
+    hostEpoch: requireId(record.hostEpoch, 'queue hostEpoch'),
+    queueRevision: requireCount(record.queueRevision, 'queueRevision'),
+    steering,
+    followup,
+  };
+  requireEncodedByteLimit(
+    projection,
+    'Session message queue projection',
+    MESSAGE_QUEUE_PROJECTION_MAX_BYTES,
+  );
+  return projection;
+}
+
+function decodeTurnMessageSubmitInput(value: unknown): TurnMessageSubmitInput {
+  const record = requireExactRecord(value, 'turn.message.submit input', [
+    'originHostEpoch',
+    'sessionId',
+    'messageId',
+    'content',
+    'placement',
+  ]);
+  return {
+    originHostEpoch: requireId(record.originHostEpoch, 'originHostEpoch'),
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    messageId: requireEntityId(record.messageId, 'messageId'),
+    content: decodeMessageContent(record.content),
+    placement: requireMessagePlacement(record.placement),
+  };
+}
+
+function decodeTurnMessageSubmitResult(value: unknown): TurnMessageSubmitResult {
+  const record = requireRecord(value, 'turn.message.submit result');
+  if (record.disposition === 'turn_started') {
+    assertExactKeys(record, 'turn.message.submit turn_started result', ['disposition', 'turnId']);
+    return { disposition: record.disposition, turnId: requireEntityId(record.turnId, 'turnId') };
+  }
+  if (record.disposition === 'steering' || record.disposition === 'followup') {
+    assertExactKeys(record, 'turn.message.submit queued result', ['disposition', 'queueRevision']);
+    return {
+      disposition: record.disposition,
+      queueRevision: requireCount(record.queueRevision, 'queueRevision'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid turn.message.submit disposition');
+}
+
+function decodeQueueRetractInput(value: unknown): QueueRetractInput {
+  const record = requireExactRecord(value, 'queue.retract input', [
+    'originHostEpoch',
+    'sessionId',
+    'retractId',
+  ]);
+  return {
+    originHostEpoch: requireId(record.originHostEpoch, 'originHostEpoch'),
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    retractId: requireEntityId(record.retractId, 'retractId'),
+  };
+}
+
+function decodeQueueRetractResult(value: unknown): QueueRetractResult {
+  const record = requireExactRecord(value, 'queue.retract result', ['queueRevision', 'retracted']);
+  const result = {
+    queueRevision: requireCount(record.queueRevision, 'queueRevision'),
+    retracted: decodeRetractedMessages(record.retracted),
+  };
+  requireEncodedByteLimit(result, 'queue.retract result', MESSAGE_OPERATION_RESULT_MAX_BYTES);
+  return result;
+}
+
+function decodeTurnInterruptInput(value: unknown): TurnInterruptInput {
+  const record = requireExactRecord(value, 'turn.interrupt input', [
+    'originHostEpoch',
+    'sessionId',
+    'interruptId',
+    'turnId',
+    'runId',
+  ]);
+  return {
+    originHostEpoch: requireId(record.originHostEpoch, 'originHostEpoch'),
+    sessionId: requireEntityId(record.sessionId, 'sessionId'),
+    interruptId: requireEntityId(record.interruptId, 'interruptId'),
+    turnId: requireEntityId(record.turnId, 'turnId'),
+    runId: requireEntityId(record.runId, 'runId'),
+  };
+}
+
+function decodeTurnInterruptResult(value: unknown): TurnInterruptResult {
+  const record = requireExactRecord(value, 'turn.interrupt result', [
+    'queueRevision',
+    'retracted',
+    'turn',
+  ]);
+  const result = {
+    queueRevision: requireCount(record.queueRevision, 'queueRevision'),
+    retracted: decodeRetractedMessages(record.retracted),
+    turn: decodeTurnSnapshot(record.turn),
+  };
+  requireEncodedByteLimit(result, 'turn.interrupt result', MESSAGE_OPERATION_RESULT_MAX_BYTES);
+  return result;
+}
+
+function decodeSteeringMessages(value: unknown): SteeringMessageSnapshot[] {
+  return requireBoundedArray(value, 'steering queue').map((entry) => {
+    const decoded = decodeMessageQueueEntrySnapshot(entry);
+    if (decoded.placement !== 'current_turn') {
+      throw invalidProtocolFrame('Invalid steering queue entry');
+    }
+    if (decoded.state === 'queued') return { ...decoded, placement: 'current_turn' };
+    if (decoded.state === 'in_flight') return decoded;
+    throw invalidProtocolFrame('Invalid steering queue entry');
+  });
+}
+
+function decodeFollowupMessages(value: unknown): QueuedMessageSnapshot[] {
+  return requireBoundedArray(value, 'followup queue').map((entry) => {
+    const decoded = decodeMessageQueueEntrySnapshot(entry);
+    if (decoded.state !== 'queued' || decoded.placement !== 'next_turn') {
+      throw invalidProtocolFrame('Invalid followup queue entry');
+    }
+    return { ...decoded, placement: 'next_turn' };
+  });
+}
+
+function decodeRetractedMessages(value: unknown): RetractedMessageSnapshot[] {
+  const entries = requireBoundedArray(value, 'retracted messages').map((entry) => {
+    const decoded = decodeMessageQueueEntrySnapshot(entry);
+    if (decoded.state !== 'retracted') {
+      throw invalidProtocolFrame('Invalid retracted message state');
+    }
+    return decoded;
+  });
+  assertUniqueQueueEntries(entries, 'retracted messages');
+  return entries;
+}
+
+function decodeMessageQueueEntrySnapshot(value: unknown): MessageQueueEntrySnapshot {
+  const record = requireExactRecord(value, 'message queue entry snapshot', [
+    'entryId',
+    'messageId',
+    'content',
+    'placement',
+    'state',
+  ]);
+  const base = {
+    entryId: requireEntityId(record.entryId, 'entryId'),
+    messageId: requireEntityId(record.messageId, 'messageId'),
+    content: decodeMessageContent(record.content),
+    placement: requireMessagePlacement(record.placement),
+  };
+  if (record.state === 'queued' || record.state === 'retracted') {
+    return { ...base, state: record.state };
+  }
+  if (record.state === 'in_flight' && base.placement === 'current_turn') {
+    return { ...base, placement: 'current_turn', state: record.state };
+  }
+  throw invalidProtocolFrame('Invalid message queue entry state');
+}
+
+function requireMessagePlacement(value: unknown): MessagePlacement {
+  if (value === 'current_turn' || value === 'next_turn') return value;
+  throw invalidProtocolFrame('Invalid message placement');
+}
+
+function requireBoundedArray(value: unknown, label: string): unknown[] {
+  if (!Array.isArray(value) || value.length > MESSAGE_QUEUE_MAX_ENTRIES) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value;
+}
+
+function assertUniqueQueueEntries(
+  entries: readonly MessageQueueEntrySnapshot[],
+  label: string,
+): void {
+  const entryIds = new Set<string>();
+  const messageIds = new Set<string>();
+  for (const entry of entries) {
+    if (entryIds.has(entry.entryId) || messageIds.has(entry.messageId)) {
+      throw invalidProtocolFrame(`${label} repeats a message identity`);
+    }
+    entryIds.add(entry.entryId);
+    messageIds.add(entry.messageId);
+  }
+}
+
+function requireEncodedByteLimit(value: unknown, label: string, maxBytes: number): void {
+  let encoded: string | undefined;
+  try {
+    encoded = JSON.stringify(value);
+  } catch {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  if (encoded === undefined || Buffer.byteLength(encoded, 'utf8') > maxBytes) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+}

--- a/packages/runtime-host/src/protocol/operation-spec.ts
+++ b/packages/runtime-host/src/protocol/operation-spec.ts
@@ -12,6 +12,7 @@ export type HostOperationErrorCode =
   | 'invalid_request'
   | 'persistence_failed'
   | 'commit_outcome_unknown'
+  | 'outcome_unknown'
   | 'internal_failure';
 
 export interface HostOperationError<C extends HostOperationErrorCode = HostOperationErrorCode> {

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -1,6 +1,7 @@
 import { requireExactRecord, requireId, requireRecord, requireString } from './codec.js';
 import { invalidProtocolFrame } from './errors.js';
 import { HOST_STATUS_OPERATION_SPECS } from './host-status.js';
+import { MESSAGE_OPERATION_SPECS } from './message.js';
 import {
   composeOperationSpecMaps,
   type HostOperationError,
@@ -12,6 +13,25 @@ import { TURN_OPERATION_SPECS } from './turn.js';
 
 export type { HostLifecycleState, HostStatusInput, HostStatusResult } from './host-status.js';
 export type { HostOperationError, HostOperationErrorCode } from './operation-spec.js';
+export {
+  TURN_MESSAGE_CONTENT_MAX_BYTES,
+  TURN_MESSAGE_TEXT_MAX_BYTES,
+} from './turn.js';
+export type {
+  InFlightMessageSnapshot,
+  MessagePlacement,
+  MessageQueueEntrySnapshot,
+  QueueRetractInput,
+  QueueRetractResult,
+  QueuedMessageSnapshot,
+  RetractedMessageSnapshot,
+  SessionMessageQueueProjection,
+  SteeringMessageSnapshot,
+  TurnInterruptInput,
+  TurnInterruptResult,
+  TurnMessageSubmitInput,
+  TurnMessageSubmitResult,
+} from './message.js';
 export type {
   TurnQueryInput,
   TurnRunStatus,
@@ -21,9 +41,19 @@ export type {
 } from './turn.js';
 export * from './runtime-policy.js';
 
-export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
-  composeOperationSpecMaps(HOST_STATUS_OPERATION_SPECS, TURN_OPERATION_SPECS),
+const HOST_AND_TURN_OPERATION_SPECS = composeOperationSpecMaps(
+  HOST_STATUS_OPERATION_SPECS,
+  TURN_OPERATION_SPECS,
+);
+
+const CORE_OPERATION_SPECS = composeOperationSpecMaps(
+  HOST_AND_TURN_OPERATION_SPECS,
   RUNTIME_POLICY_OPERATION_SPECS,
+);
+
+export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
+  CORE_OPERATION_SPECS,
+  MESSAGE_OPERATION_SPECS,
 );
 
 export type OperationSpecMap = typeof HOST_OPERATION_SPECS;

--- a/packages/runtime-host/src/protocol/turn.ts
+++ b/packages/runtime-host/src/protocol/turn.ts
@@ -1,3 +1,9 @@
+import { MAX_ATTACHMENT_BYTES, MAX_ATTACHMENT_COUNT } from '@maka/core/attachments';
+import {
+  decodeMessageContent as decodeCanonicalMessageContent,
+  isCanonicalAttachmentRef,
+  type MessageContent,
+} from '@maka/core/events';
 import { invalidProtocolFrame } from './errors.js';
 import {
   assertExactKeys,
@@ -12,8 +18,19 @@ import { defineOperation } from './operation-spec.js';
 export interface TurnStartInput {
   sessionId: string;
   turnId: string;
-  text: string;
+  content: MessageContent;
 }
+
+export type { MessageContent };
+
+export const TURN_MESSAGE_TEXT_MAX_BYTES = 48 * 1024;
+export const TURN_MESSAGE_CONTENT_MAX_BYTES = 52 * 1024;
+export const TURN_MESSAGE_QUOTE_MAX_COUNT = 16;
+export const TURN_MESSAGE_QUOTE_TEXT_MAX_LENGTH = 32_000;
+export const TURN_MESSAGE_QUOTE_LABEL_MAX_LENGTH = 200;
+const ATTACHMENT_NAME_MAX_BYTES = 512;
+const ATTACHMENT_MIME_TYPE_MAX_BYTES = 256;
+const ATTACHMENT_PATH_MAX_BYTES = 4096;
 
 export interface TurnQueryInput {
   sessionId: string;
@@ -104,12 +121,98 @@ export const TURN_OPERATION_SPECS = {
 } as const;
 
 function decodeTurnStartInput(value: unknown): TurnStartInput {
-  const record = requireExactRecord(value, 'turn.start input', ['sessionId', 'turnId', 'text']);
+  const record = requireExactRecord(value, 'turn.start input', ['sessionId', 'turnId', 'content']);
   return {
     sessionId: requireEntityId(record.sessionId, 'sessionId'),
     turnId: requireEntityId(record.turnId, 'turnId'),
-    text: requireString(record.text, 'text', 48 * 1024),
+    content: decodeMessageContent(record.content),
   };
+}
+
+export function decodeMessageContent(value: unknown): MessageContent {
+  let content: MessageContent;
+  try {
+    content = decodeCanonicalMessageContent(value);
+  } catch {
+    throw invalidProtocolFrame('Invalid Message content');
+  }
+  requireUtf8String(content.text, 'Message text', TURN_MESSAGE_TEXT_MAX_BYTES, false);
+  if (content.displayText !== undefined) {
+    requireUtf8String(
+      content.displayText,
+      'Message displayText',
+      TURN_MESSAGE_TEXT_MAX_BYTES,
+      true,
+    );
+  }
+  if ((content.attachments?.length ?? 0) > MAX_ATTACHMENT_COUNT) {
+    throw invalidProtocolFrame('Invalid Message attachments');
+  }
+  for (const attachment of content.attachments ?? []) {
+    if (!isCanonicalAttachmentRef(attachment)) {
+      throw invalidProtocolFrame('Invalid AttachmentRef');
+    }
+    requireUtf8String(attachment.name, 'AttachmentRef name', ATTACHMENT_NAME_MAX_BYTES, false);
+    requireUtf8String(
+      attachment.mimeType,
+      'AttachmentRef mimeType',
+      ATTACHMENT_MIME_TYPE_MAX_BYTES,
+      false,
+    );
+    if (attachment.bytes > MAX_ATTACHMENT_BYTES) {
+      throw invalidProtocolFrame('Invalid AttachmentRef bytes');
+    }
+    if (attachment.ref.kind === 'session_file') {
+      requireEntityId(attachment.ref.sessionId, 'AttachmentRef sessionId');
+    }
+    const path =
+      attachment.ref.kind === 'external_file'
+        ? attachment.ref.absolutePath
+        : attachment.ref.relativePath;
+    requireUtf8String(path, 'AttachmentRef path', ATTACHMENT_PATH_MAX_BYTES, false);
+  }
+  if ((content.quotes?.length ?? 0) > TURN_MESSAGE_QUOTE_MAX_COUNT) {
+    throw invalidProtocolFrame('Invalid Message quotes');
+  }
+  for (const quote of content.quotes ?? []) {
+    requireString(quote.text, 'QuoteRef text', TURN_MESSAGE_QUOTE_TEXT_MAX_LENGTH);
+    if (quote.label !== undefined) {
+      requireString(quote.label, 'QuoteRef label', TURN_MESSAGE_QUOTE_LABEL_MAX_LENGTH);
+    }
+    if (quote.sourceTurnId !== undefined) {
+      requireEntityId(quote.sourceTurnId, 'QuoteRef sourceTurnId');
+    }
+  }
+  requireEncodedByteLimit(content, 'Message content', TURN_MESSAGE_CONTENT_MAX_BYTES);
+  return content;
+}
+
+function requireUtf8String(
+  value: unknown,
+  label: string,
+  maxBytes: number,
+  allowEmpty: boolean,
+): string {
+  if (
+    typeof value !== 'string' ||
+    (!allowEmpty && value.length === 0) ||
+    Buffer.byteLength(value, 'utf8') > maxBytes
+  ) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value;
+}
+
+function requireEncodedByteLimit(value: unknown, label: string, maxBytes: number): void {
+  let encoded: string | undefined;
+  try {
+    encoded = JSON.stringify(value);
+  } catch {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  if (encoded === undefined || Buffer.byteLength(encoded, 'utf8') > maxBytes) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
 }
 
 function decodeTurnQueryInput(value: unknown): TurnQueryInput {
@@ -129,7 +232,7 @@ function decodeTurnStopInput(value: unknown): TurnStopInput {
   };
 }
 
-function decodeTurnSnapshot(value: unknown): TurnSnapshot {
+export function decodeTurnSnapshot(value: unknown): TurnSnapshot {
   const record = requireRecord(value, 'Turn snapshot');
   const base = {
     sessionId: requireEntityId(record.sessionId, 'sessionId'),

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1,8 +1,15 @@
 import { randomUUID } from 'node:crypto';
-import { BackendRegistry, FakeBackend, SessionManager } from '@maka/runtime';
+import {
+  BackendRegistry,
+  FakeBackend,
+  SessionManager,
+  type RuntimeHostedRootAuthority,
+} from '@maka/runtime';
 import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
 import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
 import type { RuntimeHostComposition, RuntimeHostCompositionContext } from './host-kernel.js';
+import { type HostMessageRootPort, HostMessageCoordinator } from './message-coordinator.js';
+import type { DomainOperationHandlerMap } from './operation-dispatcher.js';
 import { RootAdmissionOwner } from './root-admission-owner.js';
 import { RootTurnCoordinator } from './root-turn-coordinator.js';
 import { RuntimePolicyActivationGate } from './runtime-policy-activation-gate.js';
@@ -17,9 +24,43 @@ export async function createExecutionRuntimeHostComposition(
     const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
       context.owner.lease,
     );
+    await stores.messageReceiptStore.beginHostEpoch(context.hostEpoch);
     const backends = new BackendRegistry();
     backends.register('fake', (backendContext) => new FakeBackend(backendContext));
     const runtimePolicyActivation = new RuntimePolicyActivationGate();
+    const sessionAdmission = new SessionAdmissionGate();
+    let rootCoordinator: RootTurnCoordinator | undefined;
+    const rootPort: HostMessageRootPort = {
+      readSessionHeader: (sessionId) =>
+        requireRootCoordinator(rootCoordinator).readSessionHeader(sessionId),
+      readRootState: (sessionId) =>
+        requireRootCoordinator(rootCoordinator).readRootState(sessionId),
+      startFromMessage: (input) => requireRootCoordinator(rootCoordinator).startFromMessage(input),
+      claimStop: (input, commitQueueFence) =>
+        requireRootCoordinator(rootCoordinator).claimStop(input, commitQueueFence),
+    };
+    const messages = new HostMessageCoordinator({
+      hostEpoch: context.hostEpoch,
+      root: rootPort,
+      durableProof: {
+        readRootTurnSourceMessageReceipt: (sessionId, messageId) =>
+          stores.agentRunStore.readRootTurnSourceMessageReceipt(sessionId, messageId),
+        readImmutableSteeringMessageProof: (sessionId, messageId) =>
+          stores.runtimeEventStore.readImmutableSteeringMessageProof(sessionId, messageId),
+      },
+      receipts: stores.messageReceiptStore,
+      sessionAdmission,
+      acquireResidency: context.acquireResidency,
+      requestDrain: context.requestDrain,
+    });
+    const runtimeAuthority: RuntimeHostedRootAuthority = {
+      bindRun: (identity) => messages.bindRun(identity),
+      executeRoot: (input) => requireRootCoordinator(rootCoordinator).executeRoot(input),
+      stopRoot: (identity, input) =>
+        requireRootCoordinator(rootCoordinator).stopRoot(identity, input),
+      stopSession: (sessionId, input) =>
+        requireRootCoordinator(rootCoordinator).stopSession(sessionId, input),
+    };
     const manager = new SessionManager({
       store: stores.sessionStore,
       runStore: stores.agentRunStore,
@@ -28,17 +69,19 @@ export async function createExecutionRuntimeHostComposition(
       newId: randomUUID,
       now: Date.now,
       runBackendActivation: (operation) => runtimePolicyActivation.runBackendActivation(operation),
+      messageAuthority: runtimeAuthority,
     });
-    const sessionAdmission = new SessionAdmissionGate();
     const rootAdmissionOwner = new RootAdmissionOwner(stores.agentRunStore);
-    const coordinator = new RootTurnCoordinator(
+    rootCoordinator = new RootTurnCoordinator(
       manager,
       stores,
       sessionAdmission,
       rootAdmissionOwner,
+      messages,
       context.acquireResidency,
       context.requestDrain,
     );
+    const coordinator = rootCoordinator;
     const runtimePolicy = new HostRuntimePolicyCoordinator(
       runtimePolicyStores,
       runtimePolicyActivation,
@@ -51,18 +94,44 @@ export async function createExecutionRuntimeHostComposition(
         }
       },
     );
+    const handlers = {
+      ...coordinator.handlers,
+      ...messages.handlers,
+      ...runtimePolicy.handlers,
+    } satisfies DomainOperationHandlerMap;
     return {
-      handlers: { ...coordinator.handlers, ...runtimePolicy.handlers },
+      handlers,
       recover: async () => {
+        const sessions = await stores.sessionStore.listForRecovery();
+        for (const session of sessions) {
+          await stores.runtimeEventStore.repairImmutableSteeringMessageProofsForRecovery(
+            session.id,
+          );
+        }
         await coordinator.prepareRecovery();
         await manager.recoverInterruptedSessionsStrict(stores);
         await coordinator.recover();
       },
       close: async () => {
+        messages.beginDrain();
+        const errors: unknown[] = [];
         try {
           await coordinator.close();
-        } finally {
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
+          await messages.close();
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
           await stores.sessionStore.close?.();
+        } catch (error) {
+          errors.push(error);
+        }
+        if (errors.length > 0) {
+          throw new AggregateError(errors, 'Unable to close Runtime Host execution composition');
         }
       },
     };
@@ -70,4 +139,9 @@ export async function createExecutionRuntimeHostComposition(
     await stores.sessionStore.close?.();
     throw error;
   }
+}
+
+function requireRootCoordinator(coordinator: RootTurnCoordinator | undefined): RootTurnCoordinator {
+  if (!coordinator) throw new Error('Runtime Host root coordinator is not composed');
+  return coordinator;
 }

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -56,6 +56,7 @@ export class RuntimeHostProcessTerminationRequiredError extends Error {
 
 export interface RuntimeHostCompositionContext {
   owner: InteractiveRootOwner;
+  hostEpoch: string;
   acquireResidency(): RuntimeHostResidency;
   requestDrain(): void;
 }
@@ -189,6 +190,7 @@ export class RuntimeHostKernel {
       await this.#publishRegistration();
       this.#composition = await this.#options.compositionFactory({
         owner: this.#options.owner,
+        hostEpoch: this.hostEpoch,
         acquireResidency: () => this.#acquireResidency(),
         requestDrain: () => this.#requestDrain(),
       });

--- a/packages/runtime-host/src/server/message-coordinator.ts
+++ b/packages/runtime-host/src/server/message-coordinator.ts
@@ -1,0 +1,1421 @@
+import { randomUUID } from 'node:crypto';
+import { isDeepStrictEqual } from 'node:util';
+import type { SteeringLease } from '@maka/core/backend-types';
+import {
+  messageContentsEqual,
+  normalizeMessageContent,
+  type MessageContent,
+} from '@maka/core/events';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import {
+  RuntimeMessageAuthorityInvariantError,
+  type RuntimeMessageAuthority,
+  type RuntimeMessageRunIdentity,
+  type RuntimeMessageRunOwner,
+} from '@maka/runtime';
+import {
+  normalizeRootTurnAdmissionPayload,
+  type ImmutableSteeringMessageProof,
+  type MessageReceiptStore,
+  type RootTurnSourceMessage,
+  type RootTurnSourceMessageReceipt,
+} from '@maka/storage/execution-stores';
+import {
+  MESSAGE_QUEUE_MAX_ENTRIES,
+  MESSAGE_QUEUE_PROJECTION_MAX_BYTES,
+  MESSAGE_OPERATION_RESULT_MAX_BYTES,
+  MESSAGE_OPERATION_SPECS,
+  type MessagePlacement,
+  type QueueRetractInput,
+  type QueueRetractResult,
+  type QueuedMessageSnapshot,
+  type RetractedMessageSnapshot,
+  type SessionMessageQueueProjection,
+  type SteeringMessageSnapshot,
+  type TurnInterruptInput,
+  type TurnInterruptResult,
+  type TurnMessageSubmitInput,
+  type TurnMessageSubmitResult,
+  type TurnSnapshot,
+} from '../protocol/index.js';
+import type { RuntimeHostResidency } from './host-kernel.js';
+import type { MessageOperationHandlerMap } from './operation-dispatcher.js';
+import { SessionAdmissionGate } from './session-admission-gate.js';
+
+type MessageOperationErrorCode =
+  | 'host_draining'
+  | 'operation_unavailable'
+  | 'not_found'
+  | 'session_archived'
+  | 'session_busy'
+  | 'operation_conflict'
+  | 'outcome_unknown';
+
+type MessageOutcome<T> =
+  | { readonly ok: true; readonly result: T }
+  | {
+      readonly ok: false;
+      readonly error: { readonly code: MessageOperationErrorCode; readonly message: string };
+    };
+
+export interface HostMessageSessionHeader {
+  readonly isArchived: boolean;
+  readonly unavailableReason?: string;
+}
+
+export type HostMessageRootState =
+  | { readonly kind: 'idle' }
+  | ({ readonly kind: 'active' } & RuntimeMessageRunIdentity);
+
+export interface HostMessageStartInput {
+  readonly sessionId: string;
+  readonly content: MessageContent;
+  readonly sourceMessage: RootTurnSourceMessage;
+}
+
+export interface HostMessageStopClaim {
+  readonly deliverStop: () => Promise<void>;
+  readonly terminal: Promise<TurnSnapshot>;
+}
+
+/** Root execution operations that must share the message coordinator's Session gate. */
+export interface HostMessageRootPort {
+  readSessionHeader(sessionId: string): Promise<HostMessageSessionHeader | null>;
+  readRootState(sessionId: string): Promise<HostMessageRootState> | HostMessageRootState;
+  startFromMessage(input: HostMessageStartInput): Promise<{ readonly turnId: string }>;
+  claimStop(
+    input: Omit<TurnInterruptInput, 'originHostEpoch' | 'interruptId'>,
+    commitQueueFence: () => QueueFenceResult,
+  ): Promise<HostMessageStopClaim>;
+}
+
+/** Existing durable facts used only to prove an earlier Host Epoch's submit disposition. */
+export interface HostMessageDurableProofReader {
+  readRootTurnSourceMessageReceipt(
+    sessionId: string,
+    messageId: string,
+  ): Promise<RootTurnSourceMessageReceipt | undefined>;
+  readImmutableSteeringMessageProof(
+    sessionId: string,
+    messageId: string,
+  ): Promise<ImmutableSteeringMessageProof | undefined>;
+}
+
+export interface HostMessageCoordinatorOptions {
+  readonly hostEpoch: string;
+  readonly root: HostMessageRootPort;
+  readonly durableProof: HostMessageDurableProofReader;
+  readonly receipts: MessageReceiptStore;
+  readonly sessionAdmission: SessionAdmissionGate;
+  readonly acquireResidency: () => RuntimeHostResidency;
+  readonly requestDrain?: () => void;
+  readonly createId?: () => string;
+}
+
+interface LiveEntry {
+  readonly entryId: string;
+  readonly messageId: string;
+  readonly content: MessageContent;
+  readonly placement: MessagePlacement;
+  readonly disposition: 'steering' | 'followup';
+  readonly generation: number;
+  readonly residency: RuntimeHostResidency;
+  state: 'queued' | 'in_flight' | 'released';
+  leaseId?: string;
+}
+
+interface BoundRun extends RuntimeMessageRunIdentity {
+  readonly generation: number;
+  released: boolean;
+}
+
+interface InterruptReceipt {
+  readonly payload: TurnInterruptInput;
+  readonly result: Promise<MessageOutcome<TurnInterruptResult>>;
+}
+
+interface PendingSubmit {
+  readonly payload: CanonicalSubmitPayload;
+  readonly result: Promise<MessageOutcome<TurnMessageSubmitResult>>;
+}
+
+interface PendingRetract {
+  readonly payload: QueueRetractInput;
+  readonly result: Promise<MessageOutcome<QueueRetractResult>>;
+}
+
+interface InterruptDeferred {
+  readonly promise: Promise<MessageOutcome<TurnInterruptResult>>;
+  resolve(result: MessageOutcome<TurnInterruptResult>): void;
+  reject(error: unknown): void;
+}
+
+interface TerminalTransition {
+  readonly transitionId: string;
+  readonly identity: RuntimeMessageRunIdentity;
+  readonly entries: readonly LiveEntry[];
+}
+
+interface SessionState {
+  revision: number;
+  generation: number;
+  phase: 'open' | 'closed';
+  steering: LiveEntry[];
+  inFlight: Map<string, LiveEntry>;
+  followup: LiveEntry[];
+  reservedRoot?: RuntimeMessageRunIdentity;
+  run?: BoundRun;
+  transition?: TerminalTransition;
+  stopFence?: {
+    readonly identity: RuntimeMessageRunIdentity;
+    readonly result: QueueFenceResult;
+  };
+  interruptReceipts: Map<string, InterruptReceipt>;
+}
+
+export interface RootFollowupSource {
+  readonly messageId: string;
+  readonly content: MessageContent;
+  readonly placement: MessagePlacement;
+  readonly disposition: 'steering' | 'followup';
+}
+
+export interface RootFollowupBatch {
+  readonly transitionId: string;
+  readonly sessionId: string;
+  readonly previousTurnId: string;
+  readonly content: MessageContent;
+  readonly sources: readonly RootFollowupSource[];
+}
+
+export interface QueueFenceResult {
+  readonly queueRevision: number;
+  readonly retracted: readonly RetractedMessageSnapshot[];
+}
+
+/** The sole in-memory message authority for one Runtime Host Epoch. */
+export class HostMessageCoordinator implements RuntimeMessageAuthority {
+  readonly handlers: MessageOperationHandlerMap = {
+    'turn.message.submit': (input) => this.submit(input),
+    'queue.retract': (input) => this.retract(input),
+    'turn.interrupt': (input) => this.interrupt(input),
+  };
+
+  readonly #hostEpoch: string;
+  readonly #root: HostMessageRootPort;
+  readonly #durableProof: HostMessageDurableProofReader;
+  readonly #receipts: MessageReceiptStore;
+  readonly #sessionAdmission: SessionAdmissionGate;
+  readonly #acquireResidency: () => RuntimeHostResidency;
+  readonly #requestDrain: () => void;
+  readonly #createId: () => string;
+  readonly #sessions = new Map<string, SessionState>();
+  readonly #pendingSubmits = new Map<string, PendingSubmit>();
+  readonly #pendingRetracts = new Map<string, PendingRetract>();
+  #draining = false;
+  #failStopped = false;
+
+  constructor(options: HostMessageCoordinatorOptions) {
+    if (options.hostEpoch.length === 0 || options.hostEpoch.length > 128) {
+      throw new RuntimeMessageAuthorityInvariantError('Invalid Host Epoch identity');
+    }
+    this.#hostEpoch = options.hostEpoch;
+    this.#root = options.root;
+    this.#durableProof = options.durableProof;
+    this.#receipts = options.receipts;
+    this.#sessionAdmission = options.sessionAdmission;
+    this.#acquireResidency = options.acquireResidency;
+    this.#requestDrain = options.requestDrain ?? (() => undefined);
+    this.#createId = options.createId ?? randomUUID;
+  }
+
+  projection(sessionId: string): SessionMessageQueueProjection {
+    const state = this.#sessions.get(sessionId);
+    if (!state) {
+      return { hostEpoch: this.#hostEpoch, queueRevision: 0, steering: [], followup: [] };
+    }
+    return this.#project(state);
+  }
+
+  bindRun(identity: RuntimeMessageRunIdentity): RuntimeMessageRunOwner {
+    const state = this.#state(identity.sessionId);
+    const exactPreStartStop =
+      state.stopFence !== undefined && sameRun(state.stopFence.identity, identity);
+    if (state.phase !== 'open' && !exactPreStartStop) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Message Run bound while admission was closed',
+      );
+    }
+    if (!state.reservedRoot || !sameRun(state.reservedRoot, identity) || state.run) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        `Message Run ${identity.runId} was not the exact reserved root identity`,
+      );
+    }
+    const run: BoundRun = { ...identity, generation: state.generation, released: false };
+    state.run = run;
+    return Object.freeze({
+      ...identity,
+      pull: () => this.#pull(run),
+      ack: (leaseIds: readonly string[]) => this.#ack(run, leaseIds),
+      nack: (leaseIds: readonly string[]) => this.#nack(run, leaseIds),
+      release: () => this.#releaseRun(run),
+    });
+  }
+
+  reserveRootTurn(identity: RuntimeMessageRunIdentity): void {
+    const state = this.#state(identity.sessionId);
+    if (state.reservedRoot) {
+      if (sameRun(state.reservedRoot, identity)) return;
+      throw new RuntimeMessageAuthorityInvariantError('Session already reserved another root Turn');
+    }
+    if (state.run || state.transition) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Cannot reserve a root Turn during live ownership',
+      );
+    }
+    state.reservedRoot = { ...identity };
+    state.phase = 'open';
+  }
+
+  abandonRootReservation(identity: RuntimeMessageRunIdentity): void {
+    const state = this.#requireState(identity.sessionId);
+    if (!state.reservedRoot || !sameRun(state.reservedRoot, identity) || state.run) {
+      throw new RuntimeMessageAuthorityInvariantError('Root reservation cannot be abandoned');
+    }
+    if (state.transition || allLiveEntries(state).length !== 0) {
+      this.#failStop();
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Root reservation with confirmed Message effects cannot be abandoned',
+      );
+    }
+    state.reservedRoot = undefined;
+    state.stopFence = undefined;
+    state.phase = 'closed';
+    this.#maybeReclaim(identity.sessionId, state);
+  }
+
+  beginTerminalTransition(identity: RuntimeMessageRunIdentity): RootFollowupBatch {
+    const state = this.#requireState(identity.sessionId);
+    const run = state.run;
+    if (
+      !state.reservedRoot ||
+      !sameRun(state.reservedRoot, identity) ||
+      !run ||
+      !sameRun(run, identity) ||
+      !run.released
+    ) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Terminal transition requires a released exact root owner',
+      );
+    }
+    if (state.inFlight.size !== 0 || state.transition) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Terminal transition began before in-flight steering settled',
+      );
+    }
+    if (state.phase !== 'open' && !state.stopFence) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Terminal transition found closed admission without a stop fence',
+      );
+    }
+    if (this.#draining && !state.stopFence) {
+      this.#commitQueueFence(identity);
+    }
+    state.phase = 'closed';
+    const folded = state.steering.splice(0);
+    for (const entry of folded) entry.state = 'queued';
+    if (folded.length > 0) {
+      state.followup.unshift(...folded);
+      this.#mutated(state);
+    }
+    state.run = undefined;
+    const entries = [...state.followup];
+    const followup = canonicalFollowupBatch(entries);
+    const transition: TerminalTransition = {
+      transitionId: this.#createId(),
+      identity: { ...identity },
+      entries,
+    };
+    state.transition = transition;
+    return {
+      transitionId: transition.transitionId,
+      sessionId: identity.sessionId,
+      previousTurnId: identity.turnId,
+      content: followup.content,
+      sources: followup.sources,
+    };
+  }
+
+  commitNextRoot(batch: RootFollowupBatch, identity: RuntimeMessageRunIdentity): void {
+    const state = this.#requireTransition(batch);
+    if (identity.sessionId !== batch.sessionId) {
+      throw new RuntimeMessageAuthorityInvariantError('Next root identity changed Session');
+    }
+    this.#commitTransition(state);
+    state.generation += 1;
+    state.reservedRoot = { ...identity };
+    state.phase = 'open';
+    this.#mutated(state);
+  }
+
+  completeIdle(batch: RootFollowupBatch): void {
+    const state = this.#requireTransition(batch);
+    if (batch.sources.length !== 0) {
+      throw new RuntimeMessageAuthorityInvariantError('Cannot become idle with a follow-up batch');
+    }
+    this.#commitTransition(state);
+    state.generation += 1;
+    state.reservedRoot = undefined;
+    state.phase = 'open';
+    this.#mutated(state);
+    this.#maybeReclaim(batch.sessionId, state);
+  }
+
+  beginDrain(): void {
+    this.#draining = true;
+  }
+
+  commitStopFence(identity: RuntimeMessageRunIdentity): QueueFenceResult {
+    return this.#commitQueueFence(identity);
+  }
+
+  async close(): Promise<void> {
+    this.beginDrain();
+    for (const state of this.#sessions.values()) {
+      if (
+        state.run ||
+        state.reservedRoot ||
+        state.transition ||
+        allLiveEntries(state).length !== 0
+      ) {
+        throw new RuntimeMessageAuthorityInvariantError(
+          'Message coordinator closed with a live owner, entry, or transition',
+        );
+      }
+    }
+    this.#sessions.clear();
+  }
+
+  private submit(input: TurnMessageSubmitInput): Promise<MessageOutcome<TurnMessageSubmitResult>> {
+    const payload = canonicalSubmitPayload(input);
+    const isCurrentEpoch = input.originHostEpoch === this.#hostEpoch;
+    if (isCurrentEpoch) {
+      const pending = this.#pendingSubmits.get(operationKey(input.sessionId, input.messageId));
+      if (pending) {
+        return samePayload(pending.payload, payload)
+          ? pending.result
+          : Promise.resolve(
+              failure('operation_conflict', 'Message identity has a different payload'),
+            );
+      }
+    }
+    if (this.#failStopped) {
+      return Promise.resolve(failure('host_draining', 'Runtime Host message authority has failed'));
+    }
+    if (!isCurrentEpoch) return this.#submitAdmitted(input, payload);
+    const key = operationKey(input.sessionId, input.messageId);
+    const result = this.#submitAdmitted(input, payload);
+    this.#pendingSubmits.set(key, { payload, result });
+    void result.then(
+      () => this.#deletePendingSubmit(key, result),
+      () => this.#deletePendingSubmit(key, result),
+    );
+    return result;
+  }
+
+  #submitAdmitted(
+    input: TurnMessageSubmitInput,
+    payload: CanonicalSubmitPayload,
+  ): Promise<MessageOutcome<TurnMessageSubmitResult>> {
+    return this.#sessionAdmission.run(input.sessionId, async () => {
+      if (this.#failStopped) {
+        return failure('host_draining', 'Runtime Host message authority has failed');
+      }
+      const isCurrentEpoch = input.originHostEpoch === this.#hostEpoch;
+      if (isCurrentEpoch) {
+        const receipt = await this.#readSubmitReceipt(input.sessionId, input.messageId);
+        if (this.#failStopped) {
+          return failure('host_draining', 'Runtime Host message authority has failed');
+        }
+        if (receipt) {
+          return samePayload(receipt.payload, payload)
+            ? success(receipt.result)
+            : failure('operation_conflict', 'Message identity has a different payload');
+        }
+      }
+      const durableProof = await this.#queryDurableSubmitProof(input, payload);
+      if (this.#failStopped) {
+        return failure('host_draining', 'Runtime Host message authority has failed');
+      }
+      if (durableProof) return durableProof;
+      if (!isCurrentEpoch) {
+        return failure(
+          'outcome_unknown',
+          'Message disposition cannot be proven in this Host Epoch',
+        );
+      }
+      if (this.#draining) {
+        return failure('host_draining', 'Runtime Host is draining');
+      }
+      const header = await this.#root.readSessionHeader(input.sessionId);
+      if (this.#failStopped) {
+        return failure('host_draining', 'Runtime Host message authority has failed');
+      }
+      if (!header) return failure('not_found', 'Session does not exist');
+      if (header.isArchived) return failure('session_archived', 'Session is archived');
+      const rootState = await this.#root.readRootState(input.sessionId);
+      if (this.#failStopped) {
+        return failure('host_draining', 'Runtime Host message authority has failed');
+      }
+      if (rootState.kind === 'idle') {
+        if (header.unavailableReason) {
+          return failure('operation_unavailable', header.unavailableReason);
+        }
+        const existingState = this.#sessions.get(input.sessionId);
+        if (existingState && hasLiveMessageState(existingState)) {
+          throw new RuntimeMessageAuthorityInvariantError(
+            'Root reported idle while the message authority retained live state',
+          );
+        }
+        const sourceMessage: RootTurnSourceMessage = {
+          messageId: input.messageId,
+          content: payload.content,
+          placement: input.placement,
+          disposition: 'turn_started',
+        };
+        const started = await this.#root.startFromMessage({
+          sessionId: input.sessionId,
+          content: payload.content,
+          sourceMessage,
+        });
+        if (!isEntityId(started.turnId)) {
+          throw new RuntimeMessageAuthorityInvariantError('Started Turn identity is not encodable');
+        }
+        const result = { disposition: 'turn_started', turnId: started.turnId } as const;
+        return success(result);
+      }
+      const state = this.#requireState(input.sessionId);
+      if (state.phase !== 'open') {
+        return failure('session_busy', 'Message admission is closed for the active generation');
+      }
+      if (!state.reservedRoot || !sameRun(state.reservedRoot, rootState)) {
+        throw new RuntimeMessageAuthorityInvariantError(
+          'Root state does not match message reservation',
+        );
+      }
+      if (allLiveEntries(state).length >= MESSAGE_QUEUE_MAX_ENTRIES) {
+        return failure('session_busy', 'Message queue capacity is full');
+      }
+      const disposition = input.placement === 'current_turn' ? 'steering' : 'followup';
+      const candidateRevision = state.revision;
+      const candidateGeneration = state.generation;
+      const entryId = this.#createId();
+      if (!isEntityId(entryId)) {
+        throw new RuntimeMessageAuthorityInvariantError('Message entry identity is not encodable');
+      }
+      const candidateEntry: QueuedMessageSnapshot = {
+        entryId,
+        messageId: input.messageId,
+        content: payload.content,
+        placement: input.placement,
+        state: 'queued',
+      };
+      const current = this.#project(state);
+      const candidate: SessionMessageQueueProjection = {
+        ...current,
+        queueRevision: state.revision + 1,
+        steering:
+          disposition === 'steering'
+            ? [
+                ...[...state.inFlight.values()].map(inFlightSnapshot),
+                ...state.steering.map(queuedSteeringSnapshot),
+                { ...candidateEntry, placement: 'current_turn' },
+              ]
+            : current.steering,
+        followup:
+          disposition === 'followup' ? [...current.followup, candidateEntry] : current.followup,
+      };
+      if (!projectionFitsEveryEntryState(candidate)) {
+        return failure('session_busy', 'Message queue projection capacity is full');
+      }
+      if (!interruptResultFits(candidate, rootState)) {
+        return failure('session_busy', 'Message queue interrupt result capacity is full');
+      }
+      const prospectiveSources = [
+        ...[...state.inFlight.values(), ...state.steering, ...state.followup].map(sourceFromEntry),
+        {
+          messageId: input.messageId,
+          content: payload.content,
+          placement: input.placement,
+          disposition,
+        },
+      ] satisfies RootTurnSourceMessage[];
+      if (!rootAdmissionPayloadFits(prospectiveSources)) {
+        return failure('session_busy', 'Message queue cannot form a durable follow-up Turn');
+      }
+      if (
+        state.phase !== 'open' ||
+        state.revision !== candidateRevision ||
+        state.generation !== candidateGeneration ||
+        !state.reservedRoot ||
+        !sameRun(state.reservedRoot, rootState)
+      ) {
+        return failure('session_busy', 'Message queue changed during admission');
+      }
+      const result = { disposition, queueRevision: candidateRevision + 1 } as const;
+      const residency = this.#acquireResidency();
+      const entry: LiveEntry = {
+        entryId,
+        messageId: input.messageId,
+        content: payload.content,
+        placement: input.placement,
+        disposition,
+        generation: state.generation,
+        residency,
+        state: 'queued',
+      };
+      if (disposition === 'steering') state.steering.push(entry);
+      else state.followup.push(entry);
+      state.revision = result.queueRevision;
+      try {
+        await this.#commitReceipt('submit', input.sessionId, input.messageId, payload, result);
+      } catch (error) {
+        this.#failStop();
+        throw error;
+      }
+      return success(result);
+    });
+  }
+
+  private retract(input: QueueRetractInput): Promise<MessageOutcome<QueueRetractResult>> {
+    const isCurrentEpoch = input.originHostEpoch === this.#hostEpoch;
+    if (isCurrentEpoch) {
+      const pending = this.#pendingRetracts.get(operationKey(input.sessionId, input.retractId));
+      if (pending) {
+        return samePayload(pending.payload, input)
+          ? pending.result
+          : Promise.resolve(
+              failure('operation_conflict', 'Retract identity has a different payload'),
+            );
+      }
+    }
+    if (this.#failStopped) {
+      return Promise.resolve(failure('host_draining', 'Runtime Host message authority has failed'));
+    }
+    if (!isCurrentEpoch) {
+      return Promise.resolve(
+        failure('outcome_unknown', 'Retract outcome is not durable across Host Epochs'),
+      );
+    }
+    const key = operationKey(input.sessionId, input.retractId);
+    const result = this.#retractAdmitted(input);
+    this.#pendingRetracts.set(key, { payload: input, result });
+    void result.then(
+      () => this.#deletePendingRetract(key, result),
+      () => this.#deletePendingRetract(key, result),
+    );
+    return result;
+  }
+
+  #retractAdmitted(input: QueueRetractInput): Promise<MessageOutcome<QueueRetractResult>> {
+    return this.#sessionAdmission.run(input.sessionId, async () => {
+      if (this.#failStopped) {
+        return failure('host_draining', 'Runtime Host message authority has failed');
+      }
+      const receipt = await this.#readRetractReceipt(input.sessionId, input.retractId);
+      if (this.#failStopped) {
+        return failure('host_draining', 'Runtime Host message authority has failed');
+      }
+      if (receipt) {
+        return samePayload(receipt.payload, input)
+          ? success(receipt.result)
+          : failure('operation_conflict', 'Retract identity has a different payload');
+      }
+      const header = await this.#root.readSessionHeader(input.sessionId);
+      if (this.#failStopped) {
+        return failure('host_draining', 'Runtime Host message authority has failed');
+      }
+      if (!header) return failure('not_found', 'Session does not exist');
+      if (header.isArchived) return failure('session_archived', 'Session is archived');
+      const state = this.#state(input.sessionId);
+      if (
+        !retractionResultFits(
+          state,
+          state.revision + (queuedEntryCount(state) > 0 ? 1 : 0),
+          MESSAGE_OPERATION_RESULT_MAX_BYTES,
+        )
+      ) {
+        return failure('session_busy', 'Retract result exceeds protocol capacity');
+      }
+      const queued = [...state.steering, ...state.followup];
+      const result = {
+        queueRevision: state.revision + (queued.length > 0 ? 1 : 0),
+        retracted: queued.map(retractedSnapshot),
+      };
+      const retracted = this.#retractQueued(state);
+      if (retracted.length > 0) this.#mutated(state);
+      if (!isDeepStrictEqual(result, { queueRevision: state.revision, retracted })) {
+        throw new RuntimeMessageAuthorityInvariantError(
+          'Retract mutation did not match its prepared result',
+        );
+      }
+      this.#maybeReclaim(input.sessionId, state);
+      try {
+        await this.#commitReceipt('retract', input.sessionId, input.retractId, input, result);
+      } catch (error) {
+        this.#failStop();
+        throw error;
+      }
+      return success(result);
+    });
+  }
+
+  private async interrupt(input: TurnInterruptInput): Promise<MessageOutcome<TurnInterruptResult>> {
+    if (input.originHostEpoch !== this.#hostEpoch) {
+      return failure('outcome_unknown', 'Interrupt outcome is not durable across Host Epochs');
+    }
+    if (this.#failStopped) {
+      return failure('host_draining', 'Runtime Host message authority has failed');
+    }
+    const durableReceipt = await this.#readInterruptReceipt(input.sessionId, input.interruptId);
+    if (this.#failStopped) {
+      return failure('host_draining', 'Runtime Host message authority has failed');
+    }
+    if (durableReceipt) {
+      return samePayload(durableReceipt.payload, input)
+        ? durableReceipt.result
+        : failure('operation_conflict', 'Interrupt identity has a different payload');
+    }
+    const admitted = await this.#sessionAdmission.run(input.sessionId, async () => {
+      if (this.#failStopped) {
+        return {
+          kind: 'conflict' as const,
+          result: failure('host_draining', 'Runtime Host message authority has failed'),
+        };
+      }
+      const prior = this.#sessions.get(input.sessionId)?.interruptReceipts.get(input.interruptId);
+      if (prior) {
+        return samePayload(prior.payload, input)
+          ? { kind: 'receipt' as const, result: prior.result }
+          : {
+              kind: 'conflict' as const,
+              result: failure('operation_conflict', 'Interrupt identity has a different payload'),
+            };
+      }
+
+      const header = await this.#root.readSessionHeader(input.sessionId);
+      if (this.#failStopped) {
+        return {
+          kind: 'conflict' as const,
+          result: failure('host_draining', 'Runtime Host message authority has failed'),
+        };
+      }
+      if (!header) {
+        return {
+          kind: 'conflict' as const,
+          result: failure('not_found', 'Session does not exist'),
+        };
+      }
+      if (header.isArchived) {
+        return {
+          kind: 'conflict' as const,
+          result: failure('session_archived', 'Session is archived'),
+        };
+      }
+      const state = this.#state(input.sessionId);
+      const deferred = interruptDeferred();
+      state.interruptReceipts.set(input.interruptId, {
+        payload: input,
+        result: deferred.promise,
+      });
+      try {
+        const rootState = await this.#root.readRootState(input.sessionId);
+        if (this.#failStopped) {
+          const result = failure('host_draining', 'Runtime Host message authority has failed');
+          this.#deleteInterruptReceipt(input.sessionId, state, input.interruptId);
+          deferred.resolve(result);
+          return { kind: 'receipt' as const, result: deferred.promise };
+        }
+        if (
+          rootState.kind !== 'active' ||
+          rootState.sessionId !== input.sessionId ||
+          rootState.turnId !== input.turnId ||
+          rootState.runId !== input.runId
+        ) {
+          const result = failure(
+            'operation_conflict',
+            'Interrupt does not match the active root Turn',
+          );
+          await this.#commitReceipt('interrupt', input.sessionId, input.interruptId, input, result);
+          this.#deleteInterruptReceipt(input.sessionId, state, input.interruptId);
+          deferred.resolve(result);
+          return { kind: 'receipt' as const, result: deferred.promise };
+        }
+        let fence: QueueFenceResult | undefined;
+        const claim = await this.#root.claimStop(
+          { sessionId: input.sessionId, turnId: input.turnId, runId: input.runId },
+          () => {
+            if (this.#failStopped) {
+              throw new RuntimeMessageAuthorityInvariantError(
+                'Message authority failed before the stop fence commit',
+              );
+            }
+            fence ??= this.#commitQueueFence(rootState);
+            return fence;
+          },
+        );
+        if (!fence) {
+          throw new RuntimeMessageAuthorityInvariantError(
+            'Root stop claim omitted queue fence commit',
+          );
+        }
+        return { kind: 'owner' as const, claim, fence, deferred };
+      } catch (error) {
+        this.#deleteInterruptReceipt(input.sessionId, state, input.interruptId);
+        deferred.reject(error);
+        throw error;
+      }
+    });
+
+    if (admitted.kind === 'conflict') return admitted.result;
+    if (admitted.kind === 'receipt') return admitted.result;
+    try {
+      try {
+        await admitted.claim.deliverStop();
+      } catch (error) {
+        this.#failStop();
+        throw error;
+      }
+      const turn = await admitted.claim.terminal;
+      const result = success({ ...admitted.fence, turn });
+      try {
+        await this.#commitReceipt('interrupt', input.sessionId, input.interruptId, input, result);
+      } catch (error) {
+        this.#failStop();
+        throw error;
+      }
+      const state = this.#sessions.get(input.sessionId);
+      if (state) this.#deleteInterruptReceipt(input.sessionId, state, input.interruptId);
+      admitted.deferred.resolve(result);
+      return result;
+    } catch (error) {
+      const state = this.#sessions.get(input.sessionId);
+      if (state) this.#deleteInterruptReceipt(input.sessionId, state, input.interruptId);
+      admitted.deferred.reject(error);
+      throw error;
+    }
+  }
+
+  async #queryDurableSubmitProof(
+    input: TurnMessageSubmitInput,
+    payload: CanonicalSubmitPayload,
+  ): Promise<MessageOutcome<TurnMessageSubmitResult> | undefined> {
+    const receipt = await this.#durableProof.readRootTurnSourceMessageReceipt(
+      input.sessionId,
+      input.messageId,
+    );
+    if (this.#failStopped) {
+      return failure('host_draining', 'Runtime Host message authority has failed');
+    }
+    if (receipt) {
+      const source = receipt.sourceMessage;
+      if (!sameSourcePayload(source, payload)) {
+        return failure('operation_conflict', 'Durable message receipt has a different payload');
+      }
+      if (source.disposition === 'turn_started') {
+        return success({ disposition: 'turn_started', turnId: receipt.admission.turnId });
+      }
+      return failure(
+        'outcome_unknown',
+        'Durable message proof does not include the original queue revision',
+      );
+    }
+    const steeringProof = await this.#durableProof.readImmutableSteeringMessageProof(
+      input.sessionId,
+      input.messageId,
+    );
+    const event = steeringProof?.event;
+    if (event) {
+      if (
+        input.placement !== 'current_turn' ||
+        event.content?.kind !== 'text' ||
+        !messageContentsEqual(runtimeEventContent(event.content), payload.content)
+      ) {
+        return failure('operation_conflict', 'Durable steering fact has a different payload');
+      }
+      return failure(
+        'outcome_unknown',
+        'Durable steering proof does not include the original queue revision',
+      );
+    }
+    return undefined;
+  }
+
+  async #readSubmitReceipt(
+    sessionId: string,
+    messageId: string,
+  ): Promise<{ payload: CanonicalSubmitPayload; result: TurnMessageSubmitResult } | undefined> {
+    const receipt = await this.#receipts.read(this.#hostEpoch, 'submit', sessionId, messageId);
+    if (!receipt) return undefined;
+    try {
+      return {
+        payload: canonicalSubmitPayload(
+          MESSAGE_OPERATION_SPECS['turn.message.submit'].decodeInput(receipt.payload),
+        ),
+        result: MESSAGE_OPERATION_SPECS['turn.message.submit'].decodeOutput(receipt.result),
+      };
+    } catch (error) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        `Invalid durable submit receipt: ${error instanceof Error ? error.message : 'malformed'}`,
+      );
+    }
+  }
+
+  async #readRetractReceipt(
+    sessionId: string,
+    retractId: string,
+  ): Promise<{ payload: QueueRetractInput; result: QueueRetractResult } | undefined> {
+    const receipt = await this.#receipts.read(this.#hostEpoch, 'retract', sessionId, retractId);
+    if (!receipt) return undefined;
+    try {
+      return {
+        payload: MESSAGE_OPERATION_SPECS['queue.retract'].decodeInput(receipt.payload),
+        result: MESSAGE_OPERATION_SPECS['queue.retract'].decodeOutput(receipt.result),
+      };
+    } catch (error) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        `Invalid durable retract receipt: ${error instanceof Error ? error.message : 'malformed'}`,
+      );
+    }
+  }
+
+  async #readInterruptReceipt(
+    sessionId: string,
+    interruptId: string,
+  ): Promise<
+    { payload: TurnInterruptInput; result: MessageOutcome<TurnInterruptResult> } | undefined
+  > {
+    const receipt = await this.#receipts.read(this.#hostEpoch, 'interrupt', sessionId, interruptId);
+    if (!receipt) return undefined;
+    try {
+      return {
+        payload: MESSAGE_OPERATION_SPECS['turn.interrupt'].decodeInput(receipt.payload),
+        result: decodeInterruptReceiptOutcome(receipt.result),
+      };
+    } catch (error) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        `Invalid durable interrupt receipt: ${error instanceof Error ? error.message : 'malformed'}`,
+      );
+    }
+  }
+
+  async #commitReceipt(
+    operation: 'submit' | 'retract' | 'interrupt',
+    sessionId: string,
+    operationId: string,
+    payload: object,
+    result: object,
+  ): Promise<void> {
+    const receipt = { payload, result };
+    const committed = await this.#receipts.commit(
+      this.#hostEpoch,
+      operation,
+      sessionId,
+      operationId,
+      receipt,
+    );
+    if (!isDeepStrictEqual(committed, receipt)) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Durable message receipt publication returned an ambiguous outcome',
+      );
+    }
+  }
+
+  #deletePendingSubmit(
+    key: string,
+    result: Promise<MessageOutcome<TurnMessageSubmitResult>>,
+  ): void {
+    if (this.#pendingSubmits.get(key)?.result === result) this.#pendingSubmits.delete(key);
+  }
+
+  #deletePendingRetract(key: string, result: Promise<MessageOutcome<QueueRetractResult>>): void {
+    if (this.#pendingRetracts.get(key)?.result === result) this.#pendingRetracts.delete(key);
+  }
+
+  #deleteInterruptReceipt(sessionId: string, state: SessionState, interruptId: string): void {
+    state.interruptReceipts.delete(interruptId);
+    this.#maybeReclaim(sessionId, state);
+  }
+
+  #failStop(): void {
+    if (this.#failStopped) return;
+    this.#failStopped = true;
+    this.beginDrain();
+    try {
+      this.#requestDrain();
+    } catch {
+      // The coordinator remains fail-stopped even if the Host drain signal itself fails.
+    }
+  }
+
+  #pull(run: BoundRun): readonly SteeringLease[] {
+    this.#assertRun(run);
+    const state = this.#requireState(run.sessionId);
+    if (state.phase !== 'open' || run.generation !== state.generation) return [];
+    const entries = state.steering.splice(0);
+    if (entries.length === 0) return [];
+    const leases = entries.map((entry): SteeringLease => {
+      const leaseId = this.#createId();
+      entry.state = 'in_flight';
+      entry.leaseId = leaseId;
+      state.inFlight.set(leaseId, entry);
+      return {
+        id: leaseId,
+        messageId: entry.messageId,
+        content: normalizeMessageContent(entry.content),
+      };
+    });
+    this.#mutated(state);
+    return leases;
+  }
+
+  #ack(run: BoundRun, leaseIds: readonly string[]): void {
+    this.#assertRun(run);
+    const state = this.#requireState(run.sessionId);
+    let changed = false;
+    for (const leaseId of uniqueLeaseIds(leaseIds)) {
+      const entry = state.inFlight.get(leaseId);
+      if (!entry) continue;
+      state.inFlight.delete(leaseId);
+      this.#releaseEntry(entry);
+      changed = true;
+    }
+    if (changed) this.#mutated(state);
+  }
+
+  #nack(run: BoundRun, leaseIds: readonly string[]): void {
+    this.#assertRun(run);
+    const state = this.#requireState(run.sessionId);
+    const returned: LiveEntry[] = [];
+    let changed = false;
+    for (const leaseId of uniqueLeaseIds(leaseIds)) {
+      const entry = state.inFlight.get(leaseId);
+      if (!entry) continue;
+      state.inFlight.delete(leaseId);
+      entry.leaseId = undefined;
+      if (
+        state.phase === 'open' &&
+        run.generation === state.generation &&
+        entry.generation === state.generation
+      ) {
+        entry.state = 'queued';
+        returned.push(entry);
+      } else {
+        this.#releaseEntry(entry);
+      }
+      changed = true;
+    }
+    if (returned.length > 0) state.steering.unshift(...returned);
+    if (changed) this.#mutated(state);
+  }
+
+  #releaseRun(run: BoundRun): void {
+    this.#assertRun(run);
+    const state = this.#requireState(run.sessionId);
+    if (state.inFlight.size !== 0) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Message Run released with in-flight steering',
+      );
+    }
+    run.released = true;
+  }
+
+  #commitQueueFence(identity: RuntimeMessageRunIdentity): QueueFenceResult {
+    const state = this.#requireState(identity.sessionId);
+    if (state.transition) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Stop fence cannot replace a terminal transition',
+      );
+    }
+    const existing = state.stopFence;
+    if (existing) {
+      if (!sameRun(existing.identity, identity)) {
+        throw new RuntimeMessageAuthorityInvariantError('Stop fence belongs to another root Turn');
+      }
+      return existing.result;
+    }
+    if (!state.reservedRoot || !sameRun(state.reservedRoot, identity)) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Stop fence does not match the reserved root Turn',
+      );
+    }
+    if (!interruptResultFits(this.#project(state), identity)) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Stop fence interrupt result exceeds protocol capacity',
+      );
+    }
+    state.phase = 'closed';
+    const retracted = this.#retractQueued(state);
+    state.generation += 1;
+    this.#mutated(state);
+    const result = { queueRevision: state.revision, retracted };
+    state.stopFence = { identity: { ...identity }, result };
+    return result;
+  }
+
+  #retractQueued(state: SessionState): RetractedMessageSnapshot[] {
+    const entries = [...state.steering, ...state.followup];
+    state.steering = [];
+    state.followup = [];
+    for (const entry of entries) this.#releaseEntry(entry);
+    return entries.map(retractedSnapshot);
+  }
+
+  #commitTransition(state: SessionState): void {
+    const transition = state.transition;
+    if (!transition) throw new RuntimeMessageAuthorityInvariantError('Missing terminal transition');
+    for (const entry of transition.entries) this.#releaseEntry(entry);
+    state.followup = [];
+    state.transition = undefined;
+    state.reservedRoot = undefined;
+    state.stopFence = undefined;
+  }
+
+  #requireTransition(batch: RootFollowupBatch): SessionState {
+    const state = this.#requireState(batch.sessionId);
+    const transition = state.transition;
+    if (
+      !transition ||
+      transition.transitionId !== batch.transitionId ||
+      transition.identity.turnId !== batch.previousTurnId ||
+      !isDeepStrictEqual(transition.entries.map(sourceFromEntry), batch.sources) ||
+      !messageContentsEqual(
+        aggregateMessageContent(transition.entries.map((entry) => entry.content)),
+        batch.content,
+      )
+    ) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Follow-up batch does not own the transition',
+      );
+    }
+    return state;
+  }
+
+  #assertRun(run: BoundRun): void {
+    const state = this.#requireState(run.sessionId);
+    if (run.released || state.run !== run) {
+      throw new RuntimeMessageAuthorityInvariantError(`Message Run ${run.runId} is not live`);
+    }
+  }
+
+  #state(sessionId: string): SessionState {
+    let state = this.#sessions.get(sessionId);
+    if (!state) {
+      state = {
+        revision: 0,
+        generation: 0,
+        phase: 'open',
+        steering: [],
+        inFlight: new Map(),
+        followup: [],
+        interruptReceipts: new Map(),
+      };
+      this.#sessions.set(sessionId, state);
+    }
+    return state;
+  }
+
+  #requireState(sessionId: string): SessionState {
+    const state = this.#sessions.get(sessionId);
+    if (!state)
+      throw new RuntimeMessageAuthorityInvariantError(`Unknown message Session ${sessionId}`);
+    return state;
+  }
+
+  #mutated(state: SessionState): void {
+    state.revision += 1;
+  }
+
+  #maybeReclaim(sessionId: string, state: SessionState): void {
+    if (
+      this.#sessions.get(sessionId) === state &&
+      !hasLiveMessageState(state) &&
+      !state.stopFence &&
+      state.interruptReceipts.size === 0
+    ) {
+      this.#sessions.delete(sessionId);
+    }
+  }
+
+  #project(
+    state: SessionState,
+    steering: readonly LiveEntry[] = state.steering,
+    followup: readonly LiveEntry[] = state.followup,
+  ): SessionMessageQueueProjection {
+    return {
+      hostEpoch: this.#hostEpoch,
+      queueRevision: state.revision,
+      steering: [
+        ...[...state.inFlight.values()].map(inFlightSnapshot),
+        ...steering.map(queuedSteeringSnapshot),
+      ],
+      followup: followup.map(queuedSnapshot),
+    };
+  }
+
+  #releaseEntry(entry: LiveEntry): void {
+    if (entry.state === 'released') return;
+    entry.state = 'released';
+    entry.leaseId = undefined;
+    entry.residency.release();
+  }
+}
+
+function success<T>(result: T): MessageOutcome<T> {
+  return { ok: true, result };
+}
+
+function failure(
+  code: MessageOperationErrorCode,
+  message: string,
+): {
+  readonly ok: false;
+  readonly error: { readonly code: MessageOperationErrorCode; readonly message: string };
+} {
+  return { ok: false, error: { code, message } };
+}
+
+function operationKey(sessionId: string, operationId: string): string {
+  return `${sessionId}\0${operationId}`;
+}
+
+function decodeInterruptReceiptOutcome(value: unknown): MessageOutcome<TurnInterruptResult> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Interrupt receipt outcome is not an object');
+  }
+  const record = value as Record<string, unknown>;
+  if (record.ok === true && Object.keys(record).length === 2 && Object.hasOwn(record, 'result')) {
+    return success(MESSAGE_OPERATION_SPECS['turn.interrupt'].decodeOutput(record.result));
+  }
+  if (
+    record.ok !== false ||
+    Object.keys(record).length !== 2 ||
+    !record.error ||
+    typeof record.error !== 'object' ||
+    Array.isArray(record.error)
+  ) {
+    throw new Error('Invalid interrupt receipt outcome');
+  }
+  const error = record.error as Record<string, unknown>;
+  if (
+    Object.keys(error).length !== 2 ||
+    error.code !== 'operation_conflict' ||
+    typeof error.message !== 'string'
+  ) {
+    throw new Error('Invalid interrupt receipt error');
+  }
+  return failure(error.code, error.message);
+}
+
+function interruptDeferred(): InterruptDeferred {
+  let resolve!: (result: MessageOutcome<TurnInterruptResult>) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<MessageOutcome<TurnInterruptResult>>(
+    (resolvePromise, rejectPromise) => {
+      resolve = resolvePromise;
+      reject = rejectPromise;
+    },
+  );
+  void promise.catch(() => undefined);
+  return { promise, resolve, reject };
+}
+
+function samePayload(left: object, right: object): boolean {
+  return isDeepStrictEqual(left, right);
+}
+
+function sameRun(left: RuntimeMessageRunIdentity, right: RuntimeMessageRunIdentity): boolean {
+  return (
+    left.sessionId === right.sessionId && left.turnId === right.turnId && left.runId === right.runId
+  );
+}
+
+function sameSourcePayload(source: RootTurnSourceMessage, input: CanonicalSubmitPayload): boolean {
+  return (
+    source.messageId === input.messageId &&
+    messageContentsEqual(source.content, input.content) &&
+    source.placement === input.placement
+  );
+}
+
+function sourceFromEntry(entry: LiveEntry): RootFollowupSource {
+  return {
+    messageId: entry.messageId,
+    content: normalizeMessageContent(entry.content),
+    placement: entry.placement,
+    disposition: entry.disposition,
+  };
+}
+
+function queuedSnapshot(entry: LiveEntry): QueuedMessageSnapshot {
+  return {
+    entryId: entry.entryId,
+    messageId: entry.messageId,
+    content: normalizeMessageContent(entry.content),
+    placement: entry.placement,
+    state: 'queued',
+  };
+}
+
+function queuedSteeringSnapshot(entry: LiveEntry): SteeringMessageSnapshot {
+  if (entry.placement !== 'current_turn') {
+    throw new RuntimeMessageAuthorityInvariantError('Steering entry lost current-turn placement');
+  }
+  return { ...queuedSnapshot(entry), placement: 'current_turn' };
+}
+
+function inFlightSnapshot(entry: LiveEntry): SteeringMessageSnapshot {
+  if (entry.placement !== 'current_turn') {
+    throw new RuntimeMessageAuthorityInvariantError('In-flight entry lost current-turn placement');
+  }
+  return {
+    entryId: entry.entryId,
+    messageId: entry.messageId,
+    content: normalizeMessageContent(entry.content),
+    placement: 'current_turn',
+    state: 'in_flight',
+  };
+}
+
+function retractedSnapshot(entry: LiveEntry): RetractedMessageSnapshot {
+  return { ...queuedSnapshot(entry), state: 'retracted' };
+}
+
+function uniqueLeaseIds(leaseIds: readonly string[]): readonly string[] {
+  return [...new Set(leaseIds)];
+}
+
+function allLiveEntries(state: SessionState): LiveEntry[] {
+  return [...new Set([...state.steering, ...state.inFlight.values(), ...state.followup])].filter(
+    (entry) => entry.state !== 'released',
+  );
+}
+
+function hasLiveMessageState(state: SessionState): boolean {
+  return Boolean(
+    state.reservedRoot || state.run || state.transition || allLiveEntries(state).length !== 0,
+  );
+}
+
+function queuedEntryCount(state: SessionState): number {
+  return state.steering.length + state.followup.length;
+}
+
+function projectionFitsEveryEntryState(projection: SessionMessageQueueProjection): boolean {
+  const worstCase: SessionMessageQueueProjection = {
+    ...projection,
+    queueRevision: Number.MAX_SAFE_INTEGER,
+    steering: projection.steering.map((entry) => ({ ...entry, state: 'in_flight' as const })),
+  };
+  return fitsEncodedByteLimit(worstCase, MESSAGE_QUEUE_PROJECTION_MAX_BYTES);
+}
+
+function retractionResultFits(
+  state: SessionState,
+  queueRevision: number,
+  maxBytes: number,
+): boolean {
+  const retracted = [...state.steering, ...state.followup].map(retractedSnapshot);
+  return fitsEncodedByteLimit({ queueRevision, retracted }, maxBytes);
+}
+
+function fitsEncodedByteLimit(value: unknown, maxBytes: number): boolean {
+  try {
+    return Buffer.byteLength(JSON.stringify(value), 'utf8') <= maxBytes;
+  } catch {
+    return false;
+  }
+}
+
+function isEntityId(value: string): boolean {
+  return /^[A-Za-z0-9_-]{1,128}$/.test(value);
+}
+
+interface CanonicalSubmitPayload {
+  readonly originHostEpoch: string;
+  readonly sessionId: string;
+  readonly messageId: string;
+  readonly content: MessageContent;
+  readonly placement: MessagePlacement;
+}
+
+function canonicalSubmitPayload(input: TurnMessageSubmitInput): CanonicalSubmitPayload {
+  return {
+    originHostEpoch: input.originHostEpoch,
+    sessionId: input.sessionId,
+    messageId: input.messageId,
+    content: normalizeMessageContent(input.content),
+    placement: input.placement,
+  };
+}
+
+function aggregateMessageContent(contents: readonly MessageContent[]): MessageContent {
+  const text = contents.map((content) => content.text).join('\n\n');
+  const displayText = contents.map((content) => content.displayText ?? content.text).join('\n\n');
+  const attachments = contents.flatMap((content) => content.attachments ?? []);
+  const quotes = contents.flatMap((content) => content.quotes ?? []);
+  return normalizeMessageContent({ text, displayText, attachments, quotes });
+}
+
+function canonicalFollowupBatch(entries: readonly LiveEntry[]): {
+  readonly content: MessageContent;
+  readonly sources: readonly RootFollowupSource[];
+} {
+  if (entries.length === 0) return { content: { text: '' }, sources: [] };
+  const sources = entries.map(sourceFromEntry);
+  const content = aggregateMessageContent(entries.map((entry) => entry.content));
+  try {
+    const { normalizedInput } = normalizeRootTurnAdmissionPayload(content, sources);
+    return { content: normalizedInput, sources };
+  } catch {
+    throw new RuntimeMessageAuthorityInvariantError(
+      'Accepted follow-up batch violates the durable root admission contract',
+    );
+  }
+}
+
+function rootAdmissionPayloadFits(sources: readonly RootTurnSourceMessage[]): boolean {
+  try {
+    const content = aggregateMessageContent(sources.map((source) => source.content));
+    normalizeRootTurnAdmissionPayload(content, sources);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function interruptResultFits(
+  projection: SessionMessageQueueProjection,
+  identity: RuntimeMessageRunIdentity,
+): boolean {
+  const retracted = [...projection.steering, ...projection.followup]
+    .filter((entry) => entry.state === 'queued')
+    .map((entry): RetractedMessageSnapshot => ({ ...entry, state: 'retracted' }));
+  // Control characters maximize JSON expansion for the protocol-bounded string field.
+  const worstCaseTurn: TurnSnapshot = {
+    ...identity,
+    status: 'failed',
+    terminalEventId: 'x'.repeat(128),
+    failureClass: '\0'.repeat(128),
+  };
+  return fitsEncodedByteLimit(
+    { queueRevision: Number.MAX_SAFE_INTEGER, retracted, turn: worstCaseTurn },
+    MESSAGE_OPERATION_RESULT_MAX_BYTES,
+  );
+}
+
+function runtimeEventContent(
+  content: Extract<RuntimeEvent['content'], { kind: 'text' }>,
+): MessageContent {
+  return normalizeMessageContent(content);
+}

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -34,14 +34,19 @@ export type OperationHandlerMap = {
 };
 
 export type DomainOperationKey = Exclude<OperationKey, 'host.status'>;
-export type TurnOperationKey = Extract<OperationKey, `turn.${string}`>;
+export type TurnOperationKey = Extract<OperationKey, 'turn.start' | 'turn.query' | 'turn.stop'>;
 export type RuntimePolicyOperationKey = Extract<
   OperationKey,
   `runtime.policy.${string}` | `connection.catalog.${string}` | `credential.vault.${string}`
 >;
+export type MessageOperationKey = Extract<
+  OperationKey,
+  'turn.message.submit' | 'queue.retract' | 'turn.interrupt'
+>;
 export type DomainOperationHandlerMap = Pick<OperationHandlerMap, DomainOperationKey>;
 export type TurnOperationHandlerMap = Pick<OperationHandlerMap, TurnOperationKey>;
 export type RuntimePolicyOperationHandlerMap = Pick<OperationHandlerMap, RuntimePolicyOperationKey>;
+export type MessageOperationHandlerMap = Pick<OperationHandlerMap, MessageOperationKey>;
 
 export function composeOperationHandlers(
   ...handlerMaps: readonly Partial<OperationHandlerMap>[]

--- a/packages/runtime-host/src/server/root-admission-owner.ts
+++ b/packages/runtime-host/src/server/root-admission-owner.ts
@@ -1,8 +1,15 @@
+import { isDeepStrictEqual } from 'node:util';
+import {
+  messageContentsEqual,
+  normalizeMessageContent,
+  type MessageContent,
+} from '@maka/core/events';
 import type {
   AdmitRootTurnInput,
   AdmitRootTurnResult,
   RootTurnAdmission,
   RootTurnAdmissionStore,
+  RootTurnSourceMessage,
 } from '@maka/storage/execution-stores';
 
 type OwnedAdmitRootTurnInput = Omit<AdmitRootTurnInput, 'previousRootTurnId'>;
@@ -26,7 +33,7 @@ export class RootAdmissionOwner {
       throw new Error(`Root Turn recovery chain was already installed for Session ${sessionId}`);
     }
     const admissions = await this.store.listRootTurnAdmissionsForRecovery(sessionId);
-    const snapshots = admissions.map(snapshotAdmission);
+    const snapshots = Object.freeze(admissions.map(snapshotAdmission));
     const byTurnId = new Map<string, RootTurnAdmission>();
     for (const admission of snapshots) byTurnId.set(admission.turnId, admission);
     this.#admissionsBySession.set(sessionId, byTurnId);
@@ -63,7 +70,7 @@ export class RootAdmissionOwner {
       byTurnId.set(admission.turnId, snapshot);
       this.#admissionsBySession.set(input.sessionId, byTurnId);
       this.#tips.set(input.sessionId, snapshot);
-      return result;
+      return Object.freeze({ ...result, admission: snapshot });
     } catch (error) {
       this.#poisonedSessions.add(input.sessionId);
       throw error;
@@ -78,15 +85,48 @@ function sameRootAdmission(left: RootTurnAdmission, right: RootTurnAdmission): b
     left.turnId === right.turnId &&
     left.runId === right.runId &&
     left.userMessageId === right.userMessageId &&
+    isDeepStrictEqual(left.execution, right.execution) &&
     left.previousRootTurnId === right.previousRootTurnId &&
-    left.normalizedInput.text === right.normalizedInput.text &&
+    messageContentsEqual(left.normalizedInput, right.normalizedInput) &&
+    left.sourceMessages.length === right.sourceMessages.length &&
+    left.sourceMessages.every((source, index) => {
+      const other = right.sourceMessages[index];
+      return (
+        other !== undefined &&
+        source.messageId === other.messageId &&
+        source.placement === other.placement &&
+        source.disposition === other.disposition &&
+        messageContentsEqual(source.content, other.content)
+      );
+    }) &&
     left.admittedAt === right.admittedAt
   );
 }
 
 function snapshotAdmission(admission: RootTurnAdmission): RootTurnAdmission {
+  const sourceMessages = admission.sourceMessages.map(
+    (source): RootTurnSourceMessage =>
+      Object.freeze({
+        ...source,
+        content: snapshotMessageContent(source.content),
+      }),
+  );
   return Object.freeze({
     ...admission,
-    normalizedInput: Object.freeze({ ...admission.normalizedInput }),
+    execution: Object.freeze({ ...admission.execution }),
+    normalizedInput: snapshotMessageContent(admission.normalizedInput),
+    sourceMessages: Object.freeze(sourceMessages),
   });
+}
+
+function snapshotMessageContent(content: MessageContent): MessageContent {
+  const snapshot = normalizeMessageContent(content);
+  for (const attachment of snapshot.attachments ?? []) {
+    Object.freeze(attachment.ref);
+    Object.freeze(attachment);
+  }
+  if (snapshot.attachments) Object.freeze(snapshot.attachments);
+  for (const quote of snapshot.quotes ?? []) Object.freeze(quote);
+  if (snapshot.quotes) Object.freeze(snapshot.quotes);
+  return Object.freeze(snapshot);
 }

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -1,9 +1,29 @@
 import { randomUUID } from 'node:crypto';
+import { isDeepStrictEqual } from 'node:util';
+import type { BackendStopMode } from '@maka/core/backend-types';
 import type { AgentRunHeader } from '@maka/core/agent-run';
-import type { SessionHeader, StoredMessage } from '@maka/core/session';
-import { classifyTerminalRuntimeLedger, type SessionManager } from '@maka/runtime';
+import {
+  messageContentsEqual,
+  normalizeMessageContent,
+  type MessageContent,
+} from '@maka/core/events';
+import {
+  isDeepResearchSession,
+  isExpertTeamSession,
+  type SessionHeader,
+  type StoredMessage,
+} from '@maka/core/session';
+import {
+  classifyTerminalRuntimeLedger,
+  RuntimeHostedRootConflictError,
+  RuntimeMessageAuthorityInvariantError,
+  type RuntimeHostedRootExecutionInput,
+  type RuntimeMessageRunIdentity,
+  type SessionManager,
+} from '@maka/runtime';
 import {
   authenticateExecutionStoresWriter,
+  isSessionNotFoundError,
   type ExecutionStoresWriter,
   type RootTurnAdmission,
 } from '@maka/storage/execution-stores';
@@ -15,6 +35,15 @@ import type {
   TurnStopInput,
 } from '../protocol/index.js';
 import type { RuntimeHostResidency } from './host-kernel.js';
+import {
+  type HostMessageRootState,
+  type HostMessageSessionHeader,
+  type HostMessageStartInput,
+  type HostMessageStopClaim,
+  HostMessageCoordinator,
+  type QueueFenceResult,
+  type RootFollowupBatch,
+} from './message-coordinator.js';
 import type { ConnectionContext, TurnOperationHandlerMap } from './operation-dispatcher.js';
 import { RootAdmissionOwner } from './root-admission-owner.js';
 import { SessionAdmissionGate } from './session-admission-gate.js';
@@ -22,10 +51,13 @@ import { SessionAdmissionGate } from './session-admission-gate.js';
 interface ActiveRootTurn {
   turnId: string;
   runId: string;
-  userMessageId: string;
+  userMessageId: string | null;
+  execution?: RuntimeHostedRootExecutionInput;
   started: Promise<void>;
   done: Promise<void>;
   residency: RuntimeHostResidency;
+  stopRequested: boolean;
+  messageTransitionCommitted: boolean;
 }
 
 type TurnStartOutcome = OperationOutcome<'turn.start'>;
@@ -33,6 +65,13 @@ type TurnStartOutcome = OperationOutcome<'turn.start'>;
 type TurnStartDisposition =
   | { kind: 'complete'; outcome: TurnStartOutcome }
   | { kind: 'await_start'; active: ActiveRootTurn };
+
+type TurnStopOutcome = OperationOutcome<'turn.stop'>;
+
+type TurnStopDisposition =
+  | { kind: 'complete'; outcome: TurnStopOutcome }
+  | { kind: 'request_stop'; active: ActiveRootTurn }
+  | { kind: 'await_terminal'; active: ActiveRootTurn };
 
 interface Deferred {
   readonly promise: Promise<void>;
@@ -45,6 +84,7 @@ interface RecoverySessionPlan {
   sessionId: string;
   admissions: readonly RootTurnAdmission[];
   missingMessages: readonly RecoveryUserMessage[];
+  pendingChildAdmissions: readonly RootTurnAdmission[];
 }
 
 export class RootTurnCoordinator {
@@ -63,6 +103,7 @@ export class RootTurnCoordinator {
     stores: ExecutionStoresWriter<'interactive'>,
     private readonly sessionAdmission: SessionAdmissionGate,
     private readonly rootAdmissionOwner: RootAdmissionOwner,
+    private readonly messages: HostMessageCoordinator,
     private readonly acquireRecoveryResidency: () => RuntimeHostResidency,
     private readonly requestHostDrain: () => void,
   ) {
@@ -84,16 +125,69 @@ export class RootTurnCoordinator {
       const messageIndex = indexRecoveryMessages(messages);
       const pending: RootTurnAdmission[] = [];
       const missingMessages: RecoveryUserMessage[] = [];
+      const pendingChildAdmissions: RootTurnAdmission[] = [];
       for (const admission of admissions) {
         const run = runsById.get(admission.runId);
         const userMessages = messageIndex.userMessagesByTurnId.get(admission.turnId) ?? [];
-        const messageIdOwners = messageIndex.messagesById.get(admission.userMessageId) ?? [];
+        const messageIdOwners = admission.userMessageId
+          ? (messageIndex.messagesById.get(admission.userMessageId) ?? [])
+          : [];
+        const childExecution = admission.execution.kind !== 'external_message';
+        const retryExecution = admission.execution.kind === 'linked_child_provider_retry';
+        if (childExecution && admission.sourceMessages.length !== 0) {
+          throw new Error(
+            `Admitted Turn ${admission.turnId} has child execution with Message queue sources`,
+          );
+        }
+        if (retryExecution !== (admission.userMessageId === null)) {
+          throw new Error(
+            `Admitted Turn ${admission.turnId} has an invalid UserMessage execution contract`,
+          );
+        }
+        if (admission.userMessageId === null) {
+          if (userMessages.length > 0) {
+            throw new Error(`Admitted Turn ${admission.turnId} must not record a UserMessage`);
+          }
+          if (!run) {
+            pendingChildAdmissions.push(admission);
+            continue;
+          }
+          assertRunMatchesAdmission(run, admission);
+          continue;
+        }
         if (messageIdOwners.length > 1) {
           throw new Error(
             `Admitted Turn ${admission.turnId} has a duplicated UserMessage identity`,
           );
         }
         const messageIdOwner = messageIdOwners[0];
+        if (!run && childExecution) {
+          if (userMessages.length > 1) {
+            throw new Error(`Admitted Turn ${admission.turnId} has multiple UserMessages`);
+          }
+          const userMessage = userMessages[0];
+          if (userMessage) {
+            if (
+              messageIdOwner !== userMessage ||
+              userMessage.id !== admission.userMessageId ||
+              !messageContentsEqual(
+                storedUserMessageContent(userMessage),
+                admission.normalizedInput,
+              )
+            ) {
+              throw new Error(`Admitted Turn ${admission.turnId} does not match its UserMessage`);
+            }
+          } else {
+            if (messageIdOwner) {
+              throw new Error(`Admitted Turn ${admission.turnId} reuses another message identity`);
+            }
+            const recoveredMessage = recoveryUserMessage(admission);
+            missingMessages.push(recoveredMessage);
+            indexRecoveryMessage(messageIndex, recoveredMessage);
+          }
+          pendingChildAdmissions.push(admission);
+          continue;
+        }
         if (!run) {
           if (userMessages.length > 0 || messageIdOwner) {
             throw new Error(`Admitted Turn ${admission.turnId} has a UserMessage but no Run`);
@@ -101,11 +195,7 @@ export class RootTurnCoordinator {
           pending.push(admission);
           continue;
         }
-        if (run.turnId !== admission.turnId) {
-          throw new Error(
-            `Admitted Turn ${admission.turnId} does not match Run ${admission.runId}`,
-          );
-        }
+        assertRunMatchesAdmission(run, admission);
         if (userMessages.length > 1) {
           throw new Error(`Admitted Turn ${admission.turnId} has multiple UserMessages`);
         }
@@ -114,7 +204,7 @@ export class RootTurnCoordinator {
           if (
             messageIdOwner !== userMessage ||
             userMessage.id !== admission.userMessageId ||
-            userMessage.text !== admission.normalizedInput.text
+            !messageContentsEqual(storedUserMessageContent(userMessage), admission.normalizedInput)
           ) {
             throw new Error(`Admitted Turn ${admission.turnId} does not match its UserMessage`);
           }
@@ -123,13 +213,7 @@ export class RootTurnCoordinator {
         if (messageIdOwner) {
           throw new Error(`Admitted Turn ${admission.turnId} reuses another message identity`);
         }
-        const recoveredMessage = {
-          type: 'user',
-          id: admission.userMessageId,
-          turnId: admission.turnId,
-          ts: admission.admittedAt,
-          text: admission.normalizedInput.text,
-        } satisfies RecoveryUserMessage;
+        const recoveredMessage = recoveryUserMessage(admission);
         missingMessages.push(recoveredMessage);
         indexRecoveryMessage(messageIndex, recoveredMessage);
       }
@@ -137,19 +221,32 @@ export class RootTurnCoordinator {
         throw new Error(`Session ${session.id} has multiple admitted Turns without Runs`);
       }
       const admission = pending[0];
-      if (admission && session.status === 'archived') {
+      if (admission && (session.status === 'archived' || session.isArchived)) {
         throw new Error(`Archived Session ${session.id} has an admitted Turn without a Run`);
       }
       plans.push({
         sessionId: session.id,
         admissions,
         missingMessages,
+        pendingChildAdmissions,
       });
     }
 
     for (const plan of plans) {
       for (const message of plan.missingMessages) {
         await this.stores.sessionStore.appendMessage(plan.sessionId, message);
+      }
+      for (const admission of plan.pendingChildAdmissions) {
+        if (admission.execution.kind === 'external_message') {
+          throw new Error('External Message admission cannot use child recovery closure');
+        }
+        await this.manager.closePendingHostedLinkedChildAdmission({
+          sessionId: admission.sessionId,
+          turnId: admission.turnId,
+          runId: admission.runId,
+          admittedAt: admission.admittedAt,
+          execution: admission.execution,
+        });
       }
       this.#recoveryAdmissionsBySession.set(plan.sessionId, plan.admissions);
     }
@@ -179,7 +276,7 @@ export class RootTurnCoordinator {
       const input = {
         sessionId,
         turnId: admission.turnId,
-        text: admission.normalizedInput.text,
+        content: normalizeMessageContent(admission.normalizedInput),
       };
       const disposition = await this.sessionAdmission.run(sessionId, () =>
         this.prepareAdmittedTurn(input, admission, this.acquireRecoveryResidency),
@@ -195,14 +292,19 @@ export class RootTurnCoordinator {
   }
 
   async close(): Promise<void> {
-    const active = [...this.#activeBySession.entries()];
-    const stopResults = await Promise.allSettled(
-      active.map(([sessionId]) => this.manager.stopSession(sessionId, { source: 'stop_button' })),
-    );
-    const drainResults = await Promise.allSettled(active.map(([, turn]) => turn.done));
-    const errors = [...stopResults, ...drainResults]
-      .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
-      .map((result) => result.reason);
+    const errors: unknown[] = [];
+    while (errors.length === 0) {
+      const active = [...this.#activeBySession.entries()];
+      if (active.length === 0) break;
+      const results = await Promise.allSettled(
+        active.map(([sessionId, turn]) => this.stopActiveTurn(sessionId, turn)),
+      );
+      errors.push(
+        ...results
+          .filter((result): result is PromiseRejectedResult => result.status === 'rejected')
+          .map((result) => result.reason),
+      );
+    }
     if (this.#activeBySession.size !== 0) {
       errors.push(new Error('Runtime Host execution composition closed with active Turns'));
     }
@@ -210,8 +312,32 @@ export class RootTurnCoordinator {
       throw new AggregateError(errors, 'Unable to close Runtime Host execution composition');
   }
 
-  private startTurn(input: TurnStartInput, context: ConnectionContext): Promise<TurnStartOutcome> {
+  async readSessionHeader(sessionId: string): Promise<HostMessageSessionHeader | null> {
+    try {
+      const header = await this.stores.sessionStore.readHeaderSnapshot(sessionId);
+      return {
+        isArchived: header.isArchived || header.status === 'archived',
+        unavailableReason: unsupportedSessionModeReason(header),
+      };
+    } catch (error) {
+      if (isSessionNotFoundError(error)) return null;
+      throw error;
+    }
+  }
+
+  readRootState(sessionId: string): HostMessageRootState {
+    const active = this.#activeBySession.get(sessionId);
+    return active
+      ? { kind: 'active', sessionId, turnId: active.turnId, runId: active.runId }
+      : { kind: 'idle' };
+  }
+
+  executeRoot(input: RuntimeHostedRootExecutionInput): Promise<void> {
     return this.runCommand(async () => {
+      const canonicalInput = {
+        ...input,
+        content: normalizeMessageContent(input.content),
+      };
       const disposition = await this.sessionAdmission.run(input.sessionId, async () => {
         const existing = await this.stores.agentRunStore.readRootTurnAdmission(
           input.sessionId,
@@ -219,23 +345,255 @@ export class RootTurnCoordinator {
         );
         if (existing) {
           this.rootAdmissionOwner.assertKnownAdmission(existing);
-          if (existing.normalizedInput.text !== input.text) {
+          if (
+            existing.runId !== input.runId ||
+            existing.userMessageId !== input.userMessageId ||
+            !isDeepStrictEqual(existing.execution, input.execution) ||
+            !messageContentsEqual(existing.normalizedInput, canonicalInput.content) ||
+            existing.sourceMessages.length !== 0
+          ) {
+            throw new RuntimeMessageAuthorityInvariantError(
+              'Hosted root execution identity conflicts with its durable admission',
+            );
+          }
+          return this.prepareAdmittedTurn(
+            canonicalInput,
+            existing,
+            this.acquireRecoveryResidency,
+            undefined,
+            canonicalInput,
+          );
+        }
+
+        const header = await this.stores.sessionStore.readHeaderSnapshot(input.sessionId);
+        if (header.status === 'archived' || header.isArchived) {
+          throw new Error('Cannot start a hosted root execution in an archived Session');
+        }
+        const unavailableReason = unsupportedSessionModeReason(header);
+        if (unavailableReason) throw new Error(unavailableReason);
+        if (this.#activeBySession.has(input.sessionId)) {
+          throw new RuntimeHostedRootConflictError(
+            input.sessionId,
+            'Session already has an active root Turn',
+          );
+        }
+        const admitted = await this.rootAdmissionOwner.admitRootTurn({
+          sessionId: input.sessionId,
+          turnId: input.turnId,
+          proposedRunId: input.runId,
+          proposedUserMessageId: input.userMessageId,
+          execution: input.execution,
+          normalizedInput: canonicalInput.content,
+          sourceMessages: [],
+          admittedAt: Date.now(),
+        });
+        if (
+          admitted.admission.runId !== input.runId ||
+          admitted.admission.userMessageId !== input.userMessageId ||
+          !isDeepStrictEqual(admitted.admission.execution, input.execution) ||
+          !messageContentsEqual(admitted.admission.normalizedInput, canonicalInput.content) ||
+          admitted.admission.sourceMessages.length !== 0
+        ) {
+          throw new RuntimeMessageAuthorityInvariantError(
+            'Hosted root execution admission changed identity',
+          );
+        }
+        return this.prepareAdmittedTurn(
+          canonicalInput,
+          admitted.admission,
+          this.acquireRecoveryResidency,
+          undefined,
+          canonicalInput,
+        );
+      });
+      if (disposition.kind === 'complete') {
+        if (!disposition.outcome.ok) {
+          if (disposition.outcome.error.code === 'session_busy') {
+            throw new RuntimeHostedRootConflictError(
+              input.sessionId,
+              disposition.outcome.error.message,
+            );
+          }
+          throw new RuntimeMessageAuthorityInvariantError(disposition.outcome.error.message);
+        }
+        return;
+      }
+      await disposition.active.started;
+      await disposition.active.done;
+    });
+  }
+
+  stopRoot(
+    identity: RuntimeMessageRunIdentity,
+    input: {
+      source?: 'stop_button' | 'benchmark_deadline';
+      mode?: BackendStopMode;
+    } = {},
+  ): Promise<void> {
+    return this.runCommand(async () => {
+      await this.awaitExactActiveStart(identity);
+      const disposition = await this.sessionAdmission.run(identity.sessionId, () =>
+        this.prepareStopDisposition(identity, () => this.messages.commitStopFence(identity)),
+      );
+      if (disposition.kind === 'complete') {
+        if (!disposition.outcome.ok) throw new Error(disposition.outcome.error.message);
+        return;
+      }
+      if (disposition.kind === 'request_stop') {
+        await this.deliverRuntimeStop(identity.sessionId, disposition.active, input);
+      }
+      await disposition.active.done;
+    });
+  }
+
+  stopSession(
+    sessionId: string,
+    input: {
+      source?: 'stop_button' | 'benchmark_deadline';
+      mode?: BackendStopMode;
+    } = {},
+  ): Promise<void> {
+    return this.runCommand(async () => {
+      const disposition = await this.sessionAdmission.run(sessionId, async () => {
+        const active = this.#activeBySession.get(sessionId);
+        if (!active) return undefined;
+        const identity = { sessionId, turnId: active.turnId, runId: active.runId };
+        return this.prepareStopDisposition(identity, () => this.messages.commitStopFence(identity));
+      });
+      if (!disposition || disposition.kind === 'complete') {
+        if (disposition && !disposition.outcome.ok) {
+          throw new Error(disposition.outcome.error.message);
+        }
+        return;
+      }
+      if (disposition.kind === 'request_stop') {
+        await this.deliverRuntimeStop(sessionId, disposition.active, input);
+      }
+      await disposition.active.done;
+    });
+  }
+
+  startFromMessage(input: HostMessageStartInput): Promise<{ readonly turnId: string }> {
+    return this.runCommand(async () => {
+      const content = normalizeMessageContent(input.content);
+      if (
+        input.sourceMessage.disposition !== 'turn_started' ||
+        !messageContentsEqual(input.sourceMessage.content, content)
+      ) {
+        throw new RuntimeMessageAuthorityInvariantError(
+          'Idle Message start lost its canonical turn_started source',
+        );
+      }
+      if (this.#activeBySession.has(input.sessionId)) {
+        throw new RuntimeMessageAuthorityInvariantError(
+          'Message authority attempted an idle start while a root Turn was active',
+        );
+      }
+
+      const turnId = randomUUID();
+      const admitted = await this.rootAdmissionOwner.admitRootTurn({
+        sessionId: input.sessionId,
+        turnId,
+        proposedRunId: randomUUID(),
+        proposedUserMessageId: input.sourceMessage.messageId,
+        execution: { kind: 'external_message' },
+        normalizedInput: content,
+        sourceMessages: [input.sourceMessage],
+        admittedAt: Date.now(),
+      });
+      if (admitted.kind !== 'admitted') {
+        throw new RuntimeMessageAuthorityInvariantError(
+          'Fresh Message root Turn identity already existed',
+        );
+      }
+      const disposition = await this.prepareAdmittedTurn(
+        { sessionId: input.sessionId, turnId, content },
+        admitted.admission,
+        this.acquireRecoveryResidency,
+      );
+      if (disposition.kind !== 'await_start') {
+        throw new RuntimeMessageAuthorityInvariantError(
+          'Fresh Message root Turn did not reserve execution',
+        );
+      }
+      return { turnId };
+    });
+  }
+
+  claimStop(
+    input: Pick<TurnStopInput, 'sessionId' | 'turnId' | 'runId'>,
+    commitQueueFence: () => QueueFenceResult,
+  ): Promise<HostMessageStopClaim> {
+    return this.runCommand(async () => {
+      await this.awaitExactActiveStart(input);
+      const disposition = await this.prepareStopDisposition(input, commitQueueFence);
+      if (disposition.kind === 'complete') {
+        if (!disposition.outcome.ok) {
+          throw new RuntimeMessageAuthorityInvariantError(
+            'Message interrupt no longer matched its admitted root Turn',
+          );
+        }
+        return {
+          deliverStop: () => Promise.resolve(),
+          terminal: Promise.resolve(disposition.outcome.result),
+        };
+      }
+      return {
+        deliverStop: () =>
+          disposition.kind === 'request_stop'
+            ? this.deliverRuntimeStop(input.sessionId, disposition.active)
+            : Promise.resolve(),
+        terminal: disposition.active.done.then(() =>
+          this.readCanonicalSnapshot(input.sessionId, input.turnId, input.runId),
+        ),
+      };
+    });
+  }
+
+  private startTurn(input: TurnStartInput, context: ConnectionContext): Promise<TurnStartOutcome> {
+    return this.runCommand(async () => {
+      const canonicalInput: TurnStartInput = {
+        ...input,
+        content: normalizeMessageContent(input.content),
+      };
+      const disposition = await this.sessionAdmission.run(input.sessionId, async () => {
+        const existing = await this.stores.agentRunStore.readRootTurnAdmission(
+          input.sessionId,
+          input.turnId,
+        );
+        if (existing) {
+          this.rootAdmissionOwner.assertKnownAdmission(existing);
+          if (existing.execution.kind !== 'external_message') {
+            return completedStart(
+              operationConflict('Turn identity belongs to a different execution kind'),
+            );
+          }
+          if (
+            !messageContentsEqual(existing.normalizedInput, canonicalInput.content) ||
+            existing.sourceMessages.length !== 0
+          ) {
             return completedStart(
               operationConflict('Turn identity was already admitted with a different payload'),
             );
           }
-          return this.prepareAdmittedTurn(input, existing, context.acquireResidency);
+          return this.prepareAdmittedTurn(canonicalInput, existing, context.acquireResidency);
         }
 
         let header: SessionHeader;
         try {
           header = await this.stores.sessionStore.readHeaderSnapshot(input.sessionId);
         } catch (error) {
-          if (isMissingFile(error)) return completedStart(notFound('Session does not exist'));
+          if (isSessionNotFoundError(error)) {
+            return completedStart(notFound('Session does not exist'));
+          }
           throw error;
         }
-        if (header.status === 'archived') {
+        if (header.status === 'archived' || header.isArchived) {
           return completedStart(sessionArchived('Cannot start a new Turn in an archived Session'));
+        }
+        const unavailableReason = unsupportedSessionModeReason(header);
+        if (unavailableReason) {
+          return completedStart(operationUnavailable(unavailableReason));
         }
 
         if (this.#activeBySession.has(input.sessionId)) {
@@ -247,17 +605,31 @@ export class RootTurnCoordinator {
           turnId: input.turnId,
           proposedRunId: randomUUID(),
           proposedUserMessageId: randomUUID(),
-          normalizedInput: { text: input.text },
+          execution: { kind: 'external_message' },
+          normalizedInput: canonicalInput.content,
+          sourceMessages: [],
           admittedAt: Date.now(),
         });
-        if (admission.admission.normalizedInput.text !== input.text) {
+        if (admission.admission.execution.kind !== 'external_message') {
+          return completedStart(
+            operationConflict('Turn identity belongs to a different execution kind'),
+          );
+        }
+        if (
+          !messageContentsEqual(admission.admission.normalizedInput, canonicalInput.content) ||
+          admission.admission.sourceMessages.length !== 0
+        ) {
           return completedStart(
             operationConflict('Turn identity was already admitted with a different payload'),
           );
         }
-        return this.prepareAdmittedTurn(input, admission.admission, context.acquireResidency);
+        return this.prepareAdmittedTurn(
+          canonicalInput,
+          admission.admission,
+          context.acquireResidency,
+        );
       });
-      return this.resolveStartDisposition(input, disposition);
+      return this.resolveStartDisposition(canonicalInput, disposition);
     });
   }
 
@@ -277,54 +649,85 @@ export class RootTurnCoordinator {
   }
 
   private stopTurn(input: TurnStopInput): Promise<OperationOutcome<'turn.stop'>> {
-    return this.runCommand(() =>
-      this.sessionAdmission.run(input.sessionId, async () => {
-        const admission = await this.stores.agentRunStore.readRootTurnAdmission(
-          input.sessionId,
-          input.turnId,
-        );
-        if (!admission) return notFound('Turn was not admitted');
-        this.rootAdmissionOwner.assertKnownAdmission(admission);
-        if (admission.runId !== input.runId) {
-          return operationConflict('Run identity does not match the admitted Turn');
-        }
+    return this.runCommand(async () => {
+      await this.awaitExactActiveStart(input);
+      const disposition = await this.sessionAdmission.run(input.sessionId, () =>
+        this.prepareStopDisposition(input, () => this.messages.commitStopFence(input)),
+      );
+      if (disposition.kind === 'complete') return disposition.outcome;
+      if (disposition.kind === 'request_stop') {
+        await this.deliverRuntimeStop(input.sessionId, disposition.active);
+      }
+      await disposition.active.done;
+      return {
+        ok: true,
+        result: await this.readCanonicalSnapshot(input.sessionId, input.turnId, input.runId),
+      };
+    });
+  }
 
-        const snapshot = await this.readCanonicalSnapshot(
-          input.sessionId,
-          input.turnId,
-          input.runId,
-        );
-        if (isTerminalSnapshot(snapshot)) return { ok: true, result: snapshot };
-        const active = this.#activeBySession.get(input.sessionId);
-        if (!active) {
-          throw new Error('Admitted non-terminal Turn has no active Runtime Host execution');
-        }
-        if (active.turnId !== input.turnId || active.runId !== input.runId) {
-          return operationConflict('A different root Turn owns the active Session execution');
-        }
-
-        await this.manager.stopSession(input.sessionId, {
-          source: 'stop_button',
-        });
-        await active.done;
-        return {
-          ok: true,
-          result: await this.readCanonicalSnapshot(input.sessionId, input.turnId, input.runId),
-        };
-      }),
+  private async prepareStopDisposition(
+    input: Pick<TurnStopInput, 'sessionId' | 'turnId' | 'runId'>,
+    commitQueueFence: () => QueueFenceResult,
+  ): Promise<TurnStopDisposition> {
+    const admission = await this.stores.agentRunStore.readRootTurnAdmission(
+      input.sessionId,
+      input.turnId,
     );
+    if (!admission) return { kind: 'complete', outcome: notFound('Turn was not admitted') };
+    this.rootAdmissionOwner.assertKnownAdmission(admission);
+    if (admission.runId !== input.runId) {
+      return {
+        kind: 'complete',
+        outcome: operationConflict('Run identity does not match the admitted Turn'),
+      };
+    }
+
+    const snapshot = await this.readCanonicalSnapshot(input.sessionId, input.turnId, input.runId);
+    const active = this.#activeBySession.get(input.sessionId);
+    if (isTerminalSnapshot(snapshot)) {
+      if (active?.turnId === input.turnId && active.runId === input.runId) {
+        commitQueueFence();
+        active.stopRequested = true;
+        return { kind: 'await_terminal', active };
+      }
+      return { kind: 'complete', outcome: { ok: true, result: snapshot } };
+    }
+    if (!active) {
+      throw new Error('Admitted non-terminal Turn has no active Runtime Host execution');
+    }
+    if (active.turnId !== input.turnId || active.runId !== input.runId) {
+      return {
+        kind: 'complete',
+        outcome: operationConflict('A different root Turn owns the active Session execution'),
+      };
+    }
+
+    commitQueueFence();
+    const shouldRequestStop = !active.stopRequested;
+    active.stopRequested = true;
+    return shouldRequestStop
+      ? { kind: 'request_stop', active }
+      : { kind: 'await_terminal', active };
   }
 
   private async prepareAdmittedTurn(
     input: TurnStartInput,
     admission: RootTurnAdmission,
     acquireResidency: () => RuntimeHostResidency,
+    replacing?: ActiveRootTurn,
+    execution?: RuntimeHostedRootExecutionInput,
   ): Promise<TurnStartDisposition> {
     if (admission.sessionId !== input.sessionId || admission.turnId !== input.turnId) {
       throw new Error('Root Turn admission identity does not match its input');
     }
     const { runId } = admission;
     const existingRun = await this.readRunIfPresent(input.sessionId, runId);
+    if (replacing && existingRun) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Fresh follow-up root Turn unexpectedly had an existing Run',
+      );
+    }
     if (existingRun) {
       const snapshot = await this.readCanonicalSnapshot(
         input.sessionId,
@@ -342,7 +745,12 @@ export class RootTurnCoordinator {
     }
 
     const active = this.#activeBySession.get(input.sessionId);
-    if (active) {
+    if (replacing && active !== replacing) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Follow-up root replacement lost the previous active Turn',
+      );
+    }
+    if (active && active !== replacing) {
       if (active.turnId !== input.turnId || active.runId !== runId) {
         return completedStart(sessionBusy('Session already has an active root Turn'));
       }
@@ -350,17 +758,34 @@ export class RootTurnCoordinator {
     }
 
     const residency = acquireResidency();
+    const messageIdentity = { sessionId: input.sessionId, turnId: input.turnId, runId };
+    try {
+      this.messages.reserveRootTurn(messageIdentity);
+    } catch (error) {
+      residency.release();
+      throw error;
+    }
     const started = deferred();
     const entry: ActiveRootTurn = {
       turnId: input.turnId,
       runId,
       userMessageId: admission.userMessageId,
+      ...(execution ? { execution } : {}),
       started: started.promise,
       done: Promise.resolve(),
       residency,
+      stopRequested: false,
+      messageTransitionCommitted: false,
     };
+    if (replacing && this.#activeBySession.get(input.sessionId) !== replacing) {
+      residency.release();
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Follow-up root replacement changed during execution reservation',
+      );
+    }
     this.#activeBySession.set(input.sessionId, entry);
     entry.done = this.drainTurn(input, entry, started);
+    void entry.done.catch(() => undefined);
     return { kind: 'await_start', active: entry };
   }
 
@@ -370,13 +795,22 @@ export class RootTurnCoordinator {
   ): Promise<TurnStartOutcome> {
     if (disposition.kind === 'complete') return disposition.outcome;
     await disposition.active.started;
-    return {
-      ok: true,
-      result: await this.readCanonicalSnapshot(
+    let result = await this.readCanonicalSnapshot(
+      input.sessionId,
+      input.turnId,
+      disposition.active.runId,
+    );
+    if (isTerminalSnapshot(result)) {
+      await disposition.active.done;
+      result = await this.readCanonicalSnapshot(
         input.sessionId,
         input.turnId,
         disposition.active.runId,
-      ),
+      );
+    }
+    return {
+      ok: true,
+      result,
     };
   }
 
@@ -385,22 +819,40 @@ export class RootTurnCoordinator {
     active: ActiveRootTurn,
     started: Deferred,
   ): Promise<void> {
+    let terminalTransitionStarted = false;
     try {
-      for await (const _event of this.manager.sendMessage(
-        input.sessionId,
-        { turnId: input.turnId, text: input.text },
-        {
-          runId: active.runId,
-          userMessageId: active.userMessageId,
-          durability: 'required',
-          onRunStarted: (startedRunId) => {
-            if (startedRunId !== active.runId) {
-              throw new Error('Runtime started a different Run than the admitted identity');
-            }
-            started.resolve();
-          },
-        },
-      )) {
+      const stream = active.execution
+        ? active.execution.start({
+            runId: active.runId,
+            userMessageId: active.userMessageId,
+            onRunStarted: async () => {
+              started.resolve();
+              await active.execution?.onReady?.();
+            },
+          })
+        : this.manager.sendMessage(
+            input.sessionId,
+            { turnId: input.turnId, ...normalizeMessageContent(input.content) },
+            {
+              runId: active.runId,
+              userMessageId: active.userMessageId ?? undefined,
+              durability: 'required',
+              onRunStarted: (startedRunId) => {
+                if (startedRunId !== active.runId) {
+                  throw new Error('Runtime started a different Run than the admitted identity');
+                }
+                started.resolve();
+              },
+            },
+          );
+      for await (const event of stream) {
+        if (active.execution?.onEvent) {
+          try {
+            active.execution.onEvent(event);
+          } catch {
+            // Presentation observers do not participate in execution authority.
+          }
+        }
         // The Host must consume the complete stream so Runtime finalization can commit.
       }
       const snapshot = await this.readCanonicalSnapshot(
@@ -408,29 +860,163 @@ export class RootTurnCoordinator {
         input.turnId,
         active.runId,
       );
+      if (active.execution) {
+        const completedRun = await this.readRunIfPresent(input.sessionId, active.runId);
+        if (!completedRun) {
+          throw new RuntimeMessageAuthorityInvariantError(
+            'Hosted root execution completed without its admitted Run',
+          );
+        }
+        assertRunMatchesExecution(completedRun, input.turnId, active.execution.execution);
+      }
       if (!isTerminalSnapshot(snapshot)) {
         throw new Error('Runtime Turn drained without a canonical terminal fact');
       }
+      terminalTransitionStarted = true;
+      await this.completeTerminalTransition(input.sessionId, active);
     } catch (error) {
-      if (started.settled) {
+      if (started.settled && !terminalTransitionStarted) {
         try {
           const snapshot = await this.readCanonicalSnapshot(
             input.sessionId,
             input.turnId,
             active.runId,
           );
-          if (isTerminalSnapshot(snapshot)) return;
+          if (isTerminalSnapshot(snapshot)) {
+            terminalTransitionStarted = true;
+            await this.completeTerminalTransition(input.sessionId, active);
+            return;
+          }
         } catch {
           // The original execution error remains the command failure.
         }
       }
       started.reject(error);
       this.requestHostDrain();
+      throw error;
     } finally {
-      if (this.#activeBySession.get(input.sessionId) === active) {
-        this.#activeBySession.delete(input.sessionId);
+      let releaseRootOwnership = active.messageTransitionCommitted;
+      if (!active.messageTransitionCommitted) {
+        try {
+          this.messages.abandonRootReservation({
+            sessionId: input.sessionId,
+            turnId: active.turnId,
+            runId: active.runId,
+          });
+          releaseRootOwnership = true;
+        } catch {
+          this.requestHostDrain();
+        }
       }
-      active.residency.release();
+      if (releaseRootOwnership) {
+        if (this.#activeBySession.get(input.sessionId) === active) {
+          this.#activeBySession.delete(input.sessionId);
+        }
+        active.residency.release();
+      }
+    }
+  }
+
+  private completeTerminalTransition(sessionId: string, active: ActiveRootTurn): Promise<void> {
+    return this.sessionAdmission.run(sessionId, async () => {
+      if (this.#activeBySession.get(sessionId) !== active) {
+        throw new RuntimeMessageAuthorityInvariantError(
+          'Terminal root Turn no longer owns the Session',
+        );
+      }
+      const identity = { sessionId, turnId: active.turnId, runId: active.runId };
+      const batch = this.messages.beginTerminalTransition(identity);
+      if (batch.sources.length === 0) {
+        this.messages.completeIdle(batch);
+        active.messageTransitionCommitted = true;
+        this.#activeBySession.delete(sessionId);
+        return;
+      }
+      await this.startFollowupBatch(batch, active);
+    });
+  }
+
+  private async startFollowupBatch(
+    batch: RootFollowupBatch,
+    previous: ActiveRootTurn,
+  ): Promise<void> {
+    const turnId = randomUUID();
+    const admitted = await this.rootAdmissionOwner.admitRootTurn({
+      sessionId: batch.sessionId,
+      turnId,
+      proposedRunId: randomUUID(),
+      proposedUserMessageId: randomUUID(),
+      execution: { kind: 'external_message' },
+      normalizedInput: batch.content,
+      sourceMessages: batch.sources,
+      admittedAt: Date.now(),
+    });
+    if (admitted.kind !== 'admitted') {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Fresh follow-up root Turn identity already existed',
+      );
+    }
+
+    const nextIdentity = {
+      sessionId: batch.sessionId,
+      turnId,
+      runId: admitted.admission.runId,
+    };
+    this.messages.commitNextRoot(batch, nextIdentity);
+    previous.messageTransitionCommitted = true;
+    if (this.#activeBySession.get(batch.sessionId) !== previous) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Follow-up transition lost the previous root Turn',
+      );
+    }
+    const disposition = await this.prepareAdmittedTurn(
+      {
+        sessionId: batch.sessionId,
+        turnId,
+        content: admitted.admission.normalizedInput,
+      },
+      admitted.admission,
+      this.acquireRecoveryResidency,
+      previous,
+    );
+    if (disposition.kind !== 'await_start') {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Fresh follow-up root Turn did not reserve execution',
+      );
+    }
+  }
+
+  private async deliverRuntimeStop(
+    sessionId: string,
+    active: ActiveRootTurn,
+    input: {
+      source?: 'stop_button' | 'benchmark_deadline';
+      mode?: BackendStopMode;
+    } = { source: 'stop_button' },
+  ): Promise<void> {
+    await active.started;
+    await this.manager.deliverHostedRootStop(sessionId, input);
+  }
+
+  private async awaitExactActiveStart(
+    input: Pick<TurnStopInput, 'sessionId' | 'turnId' | 'runId'>,
+  ): Promise<void> {
+    const active = this.#activeBySession.get(input.sessionId);
+    if (active && active.turnId === input.turnId && active.runId === input.runId) {
+      await active.started;
+    }
+  }
+
+  private async stopActiveTurn(sessionId: string, active: ActiveRootTurn): Promise<void> {
+    const outcome = await this.stopTurn({
+      sessionId,
+      turnId: active.turnId,
+      runId: active.runId,
+    });
+    if (!outcome.ok) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        `Unable to stop active root Turn during shutdown: ${outcome.error.code}`,
+      );
     }
   }
 
@@ -511,7 +1097,9 @@ export class RootTurnCoordinator {
     try {
       return await operation();
     } catch (error) {
-      this.requestHostDrain();
+      if (!(error instanceof RuntimeHostedRootConflictError)) {
+        this.requestHostDrain();
+      }
       throw error;
     }
   }
@@ -524,6 +1112,47 @@ interface RecoveryMessageIndex {
   messagesById: Map<string, StoredMessage[]>;
 }
 
+function recoveryUserMessage(admission: RootTurnAdmission): RecoveryUserMessage {
+  if (!admission.userMessageId) {
+    throw new Error(`Admitted Turn ${admission.turnId} does not own a UserMessage`);
+  }
+  return {
+    type: 'user',
+    id: admission.userMessageId,
+    turnId: admission.turnId,
+    ts: admission.admittedAt,
+    ...normalizeMessageContent(admission.normalizedInput),
+  };
+}
+
+function assertRunMatchesAdmission(run: AgentRunHeader, admission: RootTurnAdmission): void {
+  assertRunMatchesExecution(run, admission.turnId, admission.execution);
+}
+
+function assertRunMatchesExecution(
+  run: AgentRunHeader,
+  turnId: string,
+  execution: RootTurnAdmission['execution'],
+): void {
+  if (run.turnId !== turnId) {
+    throw new Error(`Admitted Turn ${turnId} does not match Run ${run.runId}`);
+  }
+  if (execution.kind === 'external_message') return;
+  if (run.agentId !== execution.agentId || run.agentName !== execution.agentName) {
+    throw new Error(`Admitted Turn ${turnId} changed its trusted agent identity`);
+  }
+  if (
+    (execution.kind === 'linked_child_initial' &&
+      (run.resumedFromRunId !== undefined || run.retriedFromRunId !== undefined)) ||
+    (execution.kind === 'linked_child_resume' &&
+      (run.resumedFromRunId !== execution.sourceRunId || run.retriedFromRunId !== undefined)) ||
+    (execution.kind === 'linked_child_provider_retry' &&
+      (run.retriedFromRunId !== execution.sourceRunId || run.resumedFromRunId !== undefined))
+  ) {
+    throw new Error(`Admitted Turn ${turnId} changed its child execution lineage`);
+  }
+}
+
 function indexRecoveryMessages(messages: readonly StoredMessage[]): RecoveryMessageIndex {
   const index: RecoveryMessageIndex = {
     userMessagesByTurnId: new Map(),
@@ -531,6 +1160,10 @@ function indexRecoveryMessages(messages: readonly StoredMessage[]): RecoveryMess
   };
   for (const message of messages) indexRecoveryMessage(index, message);
   return index;
+}
+
+function storedUserMessageContent(message: RecoveryUserMessage): MessageContent {
+  return normalizeMessageContent(message);
 }
 
 function indexRecoveryMessage(index: RecoveryMessageIndex, message: StoredMessage): void {
@@ -554,6 +1187,7 @@ function deferred(): Deferred {
     resolvePromise = resolve;
     rejectPromise = reject;
   });
+  void promise.catch(() => undefined);
   return {
     promise,
     get settled() {
@@ -574,6 +1208,21 @@ function deferred(): Deferred {
 
 function isMissingFile(error: unknown): boolean {
   return (error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT';
+}
+
+function unsupportedSessionModeReason(
+  header: Pick<SessionHeader, 'collaborationMode' | 'labels'>,
+): string | undefined {
+  if (header.collaborationMode === 'plan') {
+    return 'Plan sessions are not yet supported by Runtime Host.';
+  }
+  if (isDeepResearchSession(header.labels)) {
+    return 'Deep Research sessions are not yet supported by Runtime Host.';
+  }
+  if (isExpertTeamSession(header.labels)) {
+    return 'Expert Team sessions are not yet supported by Runtime Host.';
+  }
+  return undefined;
 }
 
 function isTerminalSnapshot(snapshot: TurnSnapshot): boolean {
@@ -598,6 +1247,10 @@ function sessionBusy(message: string) {
 
 function sessionArchived(message: string) {
   return { ok: false, error: { code: 'session_archived', message } } as const;
+}
+
+function operationUnavailable(message: string) {
+  return { ok: false, error: { code: 'operation_unavailable', message } } as const;
 }
 
 function operationConflict(message: string) {

--- a/packages/runtime/src/__tests__/agent-run-steering-recovery.test.ts
+++ b/packages/runtime/src/__tests__/agent-run-steering-recovery.test.ts
@@ -1,0 +1,108 @@
+import { chmod, mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { AgentRunHeader, RuntimeEvent } from '@maka/core';
+import type { SessionEvent } from '@maka/core/events';
+import {
+  createAgentRunStore,
+  createLegacyFileSessionStore,
+  createRuntimeEventStore,
+} from '@maka/storage';
+import { AgentRun } from '../agent-run.js';
+
+test('acks a steering event whose canonical append preceded proof publication failure', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-agent-run-steering-recovery-'));
+  try {
+    const store = createLegacyFileSessionStore(root);
+    const session = await store.create({
+      cwd: '/tmp/cwd',
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    const runStore = createAgentRunStore(root);
+    const runtimeEventStore = createRuntimeEventStore(root);
+    const runId = 'run-1';
+    const turnId = 'turn-1';
+    await runStore.createRun(makeRunHeader(session.id, runId, turnId));
+    const run = new AgentRun({
+      sessionId: session.id,
+      header: session,
+      userInput: { turnId, text: 'start' },
+      runId,
+      store,
+      runStore,
+      runtimeEventStore,
+      newId: () => 'unused-id',
+      now: () => 10,
+      recordSessionMessages: false,
+      hooks: {
+        ensureActive: async () => {
+          throw new Error('ensureActive should not be called');
+        },
+        registerRun: () => {},
+        unregisterRun: () => {},
+        updateHeader: (sessionId, patch) => store.updateHeader(sessionId, patch),
+        updateStatus: async () => {},
+        appendTurnState: async () => {},
+      },
+    });
+    const sessionEvent: SessionEvent = {
+      type: 'steering_message',
+      id: 'runtime-steering',
+      turnId,
+      ts: 2,
+      messageId: 'message-steering',
+      content: { text: 'persist me once' },
+    };
+    const runtimeEvent: RuntimeEvent = {
+      id: sessionEvent.id,
+      invocationId: run.invocationId,
+      runId,
+      sessionId: session.id,
+      turnId,
+      ts: sessionEvent.ts,
+      partial: false,
+      role: 'user',
+      author: 'user',
+      content: { kind: 'text', text: 'persist me once', steering: true },
+      refs: { providerEventId: sessionEvent.messageId },
+    };
+    const proofDirectory = join(root, 'sessions', session.id, 'message-proofs', 'steering');
+    await mkdir(proofDirectory, { recursive: true });
+    await chmod(proofDirectory, 0o500);
+
+    await run.acceptMappedEvent(sessionEvent, runtimeEvent);
+
+    await chmod(proofDirectory, 0o700);
+    await rm(proofDirectory, { recursive: true });
+    const recovered = createRuntimeEventStore(root);
+    await recovered.repairImmutableSteeringMessageProofsForRecovery(session.id);
+    assert.deepEqual(await recovered.readImmutableRuntimeEvents(session.id, runId), [runtimeEvent]);
+    assert.deepEqual(
+      await recovered.readImmutableSteeringMessageProof(session.id, sessionEvent.messageId),
+      { event: runtimeEvent },
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function makeRunHeader(sessionId: string, runId: string, turnId: string): AgentRunHeader {
+  return {
+    runId,
+    sessionId,
+    turnId,
+    status: 'running',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/tmp/cwd',
+    permissionMode: 'ask',
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -331,6 +331,39 @@ describe('AgentSwarm adapter', () => {
     assert.equal(starts, 0);
   });
 
+  test('rejects resume inputs that resolve to the same linked child Session before starting work', async () => {
+    let starts = 0;
+    const tool = buildAgentSwarmTool();
+    await assert.rejects(
+      Promise.resolve(
+        tool.impl(
+          {
+            resume_run_ids: {
+              'run-a': 'Continue A.',
+              'run-b': 'Continue B.',
+            },
+          },
+          context({
+            prepareChildAgentResume: async (sourceRunId) => ({
+              ...preparedResume(sourceRunId),
+              execution: {
+                kind: 'child_session',
+                sessionId: 'shared-child-session',
+                currentRunId: sourceRunId,
+              },
+            }),
+            resumeChildAgent: async () => {
+              starts += 1;
+              return childResult(0);
+            },
+          }),
+        ),
+      ),
+      /cannot resume child Session shared-child-session more than once/,
+    );
+    assert.equal(starts, 0);
+  });
+
   test('orders resumed children before new items and preserves resume evidence', async () => {
     const calls: string[] = [];
     const tool = buildAgentSwarmTool();

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -30,6 +30,7 @@ import {
   formatSyntheticToolErrorText,
   normalizeAiSdkUsage,
   repairMakaToolCall,
+  type AiSdkBackendInput,
   type RunTraceEvent,
 } from '../ai-sdk-backend.js';
 import type { MakaTool, ToolRuntime } from '../tool-runtime.js';
@@ -11539,7 +11540,10 @@ function archiveGatedTurnEvents(suffix: 'a' | 'b', path: string, result: unknown
 }
 
 describe('AiSdkBackend steering durability and identity', () => {
-  const steeringBackend = (model: MockLanguageModelV4): AiSdkBackend =>
+  const steeringBackend = (
+    model: MockLanguageModelV4,
+    options: Partial<Pick<AiSdkBackendInput, 'supportsVision' | 'readAttachmentBytes'>> = {},
+  ): AiSdkBackend =>
     new AiSdkBackend({
       sessionId: 'session-1',
       header: header(),
@@ -11552,14 +11556,17 @@ describe('AiSdkBackend steering durability and identity', () => {
       tools: [],
       newId: idGenerator(),
       now: monotonicClock(),
+      ...options,
     });
 
-  const pullOnce = (text: string): (() => Array<{ id: string; text: string }>) => {
+  const pullOnce = (
+    text: string,
+  ): (() => Array<{ id: string; messageId: string; content: { text: string } }>) => {
     let pulled = false;
     return () => {
       if (pulled) return [];
       pulled = true;
-      return [{ id: `lease-${text}`, text }];
+      return [{ id: `lease-${text}`, messageId: `message-${text}`, content: { text } }];
     };
   };
 
@@ -11608,6 +11615,82 @@ describe('AiSdkBackend steering durability and identity', () => {
       events.some((event) => event.type === 'complete' && event.stopReason === 'end_turn'),
       true,
     );
+  });
+
+  test('persists canonical steering content and materializes attachments for the model', async () => {
+    const model = textCompletionModel('done');
+    const pngBytes = new Uint8Array([137, 80, 78, 71]);
+    const image = {
+      kind: 'image' as const,
+      name: 'first.png',
+      mimeType: 'image/png',
+      bytes: pngBytes.length,
+      ref: { kind: 'session_file' as const, sessionId: 'session-1', relativePath: 'first.png' },
+    };
+    const document = {
+      kind: 'pdf' as const,
+      name: 'second.pdf',
+      mimeType: 'application/pdf',
+      bytes: 12,
+      ref: { kind: 'session_file' as const, sessionId: 'session-1', relativePath: 'second.pdf' },
+    };
+    const backend = steeringBackend(model, {
+      supportsVision: true,
+      readAttachmentBytes: async (ref) => {
+        assert.deepEqual(ref, image.ref);
+        return { ok: true, bytes: pngBytes };
+      },
+    });
+    const content = {
+      text: 'inspect the authoritative inputs',
+      displayText: 'human-only command',
+      attachments: [image, document],
+    };
+    let pulled = false;
+    const acked: string[] = [];
+    const iterator = backend
+      .send({
+        turnId: 'turn-1',
+        text: 'start',
+        context: [],
+        pullSteering: () => {
+          if (pulled) return [];
+          pulled = true;
+          return [{ id: 'lease-content', messageId: 'message-content', content }];
+        },
+        ackSteering: (leaseIds) => acked.push(...leaseIds),
+      })
+      [Symbol.asyncIterator]();
+
+    const steeringEvent = await nextSteeringEvent(iterator);
+    assert.equal(steeringEvent.type, 'steering_message');
+    if (steeringEvent.type !== 'steering_message') assert.fail('expected steering event');
+    assert.deepEqual(steeringEvent.content, content);
+    assert.equal(model.doStreamCalls.length, 0);
+    assert.deepEqual(acked, []);
+    for (let next = await iterator.next(); next.done !== true; next = await iterator.next()) {}
+    assert.deepEqual(acked, ['lease-content']);
+
+    const prompt = compactPrompt(model) as Array<{ role: string; content: unknown }>;
+    const parts = prompt.at(-1)?.content as Array<{
+      type: string;
+      text?: string;
+      mediaType?: string;
+      data?: unknown;
+    }>;
+    assert.deepEqual(
+      parts.map((part) => part.type),
+      ['text', 'file'],
+    );
+    assert.equal(
+      parts[0]?.text,
+      buildSteeringEnvelope(
+        'inspect the authoritative inputs\n\n[attachment: first.png (image/png)] [attachment: second.pdf (application/pdf)]',
+      ),
+    );
+    assert.equal(parts[1]?.mediaType, 'image/png');
+    assert.notEqual(parts[1]?.data, undefined);
+    assert.equal(JSON.stringify(prompt).includes('human-only command'), false);
   });
 
   test('a steering message never reaches the provider when the consumer detaches before the ack', async () => {
@@ -11895,8 +11978,8 @@ describe('AiSdkBackend steering durability and identity', () => {
           if (pulled) return [];
           pulled = true;
           return [
-            { id: 'lease-1', text: 'do it' },
-            { id: 'lease-2', text: 'do it' },
+            { id: 'lease-1', messageId: 'message-1', content: { text: 'do it' } },
+            { id: 'lease-2', messageId: 'message-2', content: { text: 'do it' } },
           ];
         },
       }),

--- a/packages/runtime/src/__tests__/fake-backend.test.ts
+++ b/packages/runtime/src/__tests__/fake-backend.test.ts
@@ -77,8 +77,8 @@ test('pullSteering drains queued messages at step boundaries as steering events'
   });
   // Queue two steering messages, delivered one per step boundary, then dry up.
   const pending = [
-    { id: 'lease-1', text: 'do X' },
-    { id: 'lease-2', text: 'and Y' },
+    { id: 'lease-1', messageId: 'message-1', content: { text: 'do X' } },
+    { id: 'lease-2', messageId: 'message-2', content: { text: 'and Y' } },
   ];
   const acked: string[] = [];
   const steered: string[] = [];
@@ -90,7 +90,7 @@ test('pullSteering drains queued messages at step boundaries as steering events'
     pullSteering: () => (pending.length > 0 ? [pending.shift()!] : []),
     ackSteering: (leaseIds) => acked.push(...leaseIds),
   })) {
-    if (event.type === 'steering_message') steered.push(event.text);
+    if (event.type === 'steering_message') steered.push(event.content.text);
     if (event.type === 'text_complete') completedText = event.text;
   }
   assert.deepEqual(steered, ['do X', 'and Y']);
@@ -124,8 +124,8 @@ test('a batch of leases settles per lease: delivered ones ack, undelivered ones 
         if (pulled) return [];
         pulled = true;
         return [
-          { id: 'lease-a', text: 'A' },
-          { id: 'lease-b', text: 'B' },
+          { id: 'lease-a', messageId: 'message-a', content: { text: 'A' } },
+          { id: 'lease-b', messageId: 'message-b', content: { text: 'B' } },
         ];
       },
       ackSteering: (leaseIds) => acked.push(...leaseIds),
@@ -137,7 +137,7 @@ test('a batch of leases settles per lease: delivered ones ack, undelivered ones 
   for (let i = 0; i < 20 && steered.length < 2; i += 1) {
     const result = await iterator.next();
     if (result.done) break;
-    if (result.value.type === 'steering_message') steered.push(result.value.text);
+    if (result.value.type === 'steering_message') steered.push(result.value.content.text);
   }
   assert.deepEqual(steered, ['A', 'B']);
 
@@ -157,7 +157,7 @@ test('a lease is acked only after its event is consumed, and nacked when the con
     store: {} as SessionStore,
     appendMessage: async () => {},
   });
-  const pending = [{ id: 'lease-1', text: 'do X' }];
+  const pending = [{ id: 'lease-1', messageId: 'message-1', content: { text: 'do X' } }];
   const acked: string[] = [];
   const nacked: string[] = [];
   const iterator = backend

--- a/packages/runtime/src/__tests__/overflow-reactive-recovery.test.ts
+++ b/packages/runtime/src/__tests__/overflow-reactive-recovery.test.ts
@@ -484,7 +484,7 @@ function buildReactiveFixture(options: ReactiveFixtureOptions): ReactiveFixture 
 async function runTurn(
   fixture: ReactiveFixture,
   consumer: 'immediate' | 'slow' = 'immediate',
-  pullSteering?: () => Array<{ id: string; text: string }>,
+  pullSteering?: () => Array<{ id: string; messageId: string; content: { text: string } }>,
 ): Promise<void> {
   for await (const event of fixture.backend.send({
     runId: 'run-1',
@@ -1166,7 +1166,7 @@ describe('reactive overflow recovery in the streaming backend', () => {
     await runTurn(fixture, 'immediate', () => {
       if (pulled) return [];
       pulled = true;
-      return [{ id: 'lease-1', text: STEER_SENTINEL }];
+      return [{ id: 'lease-1', messageId: 'message-1', content: { text: STEER_SENTINEL } }];
     });
 
     assert.equal(fixture.model.doStreamCalls.length, 2);
@@ -1194,7 +1194,7 @@ describe('reactive overflow recovery in the streaming backend', () => {
     await runTurn(fixture, 'immediate', () => {
       if (pulled) return [];
       pulled = true;
-      return [{ id: 'lease-1', text: STEER_SENTINEL }];
+      return [{ id: 'lease-1', messageId: 'message-1', content: { text: STEER_SENTINEL } }];
     });
 
     assert.equal(fixture.model.doStreamCalls.length, 2);
@@ -1221,7 +1221,7 @@ describe('reactive overflow recovery in the streaming backend', () => {
     await runTurn(fixture, 'immediate', () => {
       if (pulled) return [];
       pulled = true;
-      return [{ id: 'lease-1', text: STEER_SENTINEL }];
+      return [{ id: 'lease-1', messageId: 'message-1', content: { text: STEER_SENTINEL } }];
     });
 
     assert.equal(fixture.model.doStreamCalls.length, 3);
@@ -1258,9 +1258,21 @@ describe('reactive overflow recovery in the streaming backend', () => {
     await runTurn(fixture, 'immediate', () => {
       pullCount += 1;
       if (pullCount === 2)
-        return [{ id: 'lease-pin-1', text: `PIN_STEER_ONE ${'A'.repeat(6_000)}` }];
+        return [
+          {
+            id: 'lease-pin-1',
+            messageId: 'message-pin-1',
+            content: { text: `PIN_STEER_ONE ${'A'.repeat(6_000)}` },
+          },
+        ];
       if (pullCount === 3)
-        return [{ id: 'lease-pin-2', text: `PIN_STEER_TWO ${'B'.repeat(12_000)}` }];
+        return [
+          {
+            id: 'lease-pin-2',
+            messageId: 'message-pin-2',
+            content: { text: `PIN_STEER_TWO ${'B'.repeat(12_000)}` },
+          },
+        ];
       return [];
     });
 
@@ -1296,7 +1308,9 @@ describe('reactive overflow recovery in the streaming backend', () => {
       pullCount += 1;
       // Steer at the SECOND step boundary, after the tool step: the verdict
       // owner (step >= 1) must see the grown payload, not the step-0 baseline.
-      return pullCount === 2 ? [{ id: 'lease-bulk', text: bulkSteer }] : [];
+      return pullCount === 2
+        ? [{ id: 'lease-bulk', messageId: 'message-bulk', content: { text: bulkSteer } }]
+        : [];
     });
 
     const outcome = complete(fixture);

--- a/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
@@ -877,7 +877,7 @@ describe('buildModelHistoryFromRuntimeEvents', () => {
     });
 
     // Id-based dedupe holds when this projection is the request base.
-    const injected = steeringModelMessage(steered.id, 'steer it');
+    const injected = steeringModelMessage(steered.id, buildSteeringEnvelope('steer it'));
     expect(steeringMessagesMissingFromBase([injected], textMessages)).toEqual([]);
     expect(steeringMessagesMissingFromBase([injected], plan.textMessages)).toEqual([]);
   });

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -72,6 +72,11 @@ import {
   materializeExpertAgentDefinition,
 } from '../expert-catalog.js';
 import { AGENT_TEAM_CHILD_TOOL_NAMES } from '../agent-team-tool-names.js';
+import {
+  RuntimeMessageAuthorityInvariantError,
+  type RuntimeHostedRootAuthority,
+  type RuntimeMessageRunIdentity,
+} from '../message-authority.js';
 
 describe('SessionManager child-session read model', () => {
   test('lists typed child sessions without treating branches as children', async () => {
@@ -113,6 +118,39 @@ describe('SessionManager child-session read model', () => {
 });
 
 describe('SessionManager claimed graph intent execution', () => {
+  test('rejects hosted graph execution before durable state or backend activation', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    let backendBuilds = 0;
+    backends.register('fake', (ctx) => {
+      backendBuilds += 1;
+      return new TestBackend(ctx);
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      messageAuthority: hostedRootAuthority(),
+      newId: nextId(),
+      now: nextNow(20),
+    });
+    const parent = await manager.createSession(makeInput({ name: 'Supervisor' }));
+    const child = await createGraphOperatorSession(store, parent.id);
+    const claim = graphIntentClaim({ targetSessionId: child.id });
+
+    await expectRejects(
+      manager.runClaimedAgentGraphIntent(graphExecutionInput(claim, 'must not start')),
+      /requires a Runtime Host graph composition/,
+    );
+
+    expect(await runStore.listSessionRuns(child.id)).toEqual([]);
+    expect(await store.readMessages(child.id)).toEqual([]);
+    expect(backendBuilds).toBe(0);
+  });
+
   test('runs the exact claimed session-inline activation and durably deduplicates retries', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -739,7 +777,7 @@ describe('SessionManager child-session runtime primitive', () => {
         async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
           childAttempts += 1;
           childInputs.push(input);
-          if (childAttempts === 1) {
+          if (childAttempts <= 2) {
             yield {
               type: 'error',
               id: `${input.turnId}-error`,
@@ -809,26 +847,46 @@ describe('SessionManager child-session runtime primitive', () => {
     expect(child.status).toBe('failed');
     expect(child.failureClass).toBe('RateLimit');
 
-    const retried = await manager.retryChildAgent(parent.id, {
+    const resumed = await manager.resumeChildAgent(parent.id, {
       parentRunId: parentRun.runId,
       sourceRunId: child.runId,
+      prompt: 'retry with additional guidance',
+    });
+    expect(resumed.status).toBe('failed');
+    expect(resumed.failureClass).toBe('RateLimit');
+    await expectRejects(
+      manager.retryChildAgent(parent.id, {
+        parentRunId: parentRun.runId,
+        sourceRunId: child.runId,
+      }),
+      /already has a successor/,
+    );
+
+    const retried = await manager.retryChildAgent(parent.id, {
+      parentRunId: parentRun.runId,
+      sourceRunId: resumed.runId!,
       execution: {
         kind: 'child_session',
         sessionId: child.childSessionId,
-        currentRunId: child.runId,
+        currentRunId: resumed.runId!,
       },
     });
     expect(retried.status).toBe('completed');
     expect(retried.childSessionId).toBe(child.childSessionId);
-    expect(retried.retriedFromRunId).toBe(child.runId);
+    expect(retried.retriedFromRunId).toBe(resumed.runId);
     expect(childInputs.map((input) => input.text)).toEqual([
       'inspect with a transient provider failure',
+      'retry with additional guidance',
       '',
     ]);
     const retryRun = await runStore.readRun(child.childSessionId, retried.runId!);
     expect(isSessionInlineRun(retryRun)).toBe(true);
     expect(retryRun.parentRunId).toBe(undefined);
-    expect(retryRun.retriedFromRunId).toBe(child.runId);
+    expect(retryRun.retriedFromRunId).toBe(resumed.runId);
+    await expectRejects(
+      manager.prepareChildAgentResume(parent.id, child.runId),
+      /already has a successor/,
+    );
     expect((await manager.prepareChildAgentResume(parent.id, retried.runId!)).execution).toEqual({
       kind: 'child_session',
       sessionId: child.childSessionId,
@@ -849,7 +907,7 @@ describe('SessionManager child-session runtime primitive', () => {
     while (!(await parentTurn.next()).done) {}
   });
 
-  test('deduplicates concurrent and durable retries while rejecting request drift', async () => {
+  test('hosted child spawn joins the exact in-flight identity and rejects request drift', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
@@ -869,6 +927,7 @@ describe('SessionManager child-session runtime primitive', () => {
       childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
       newId: nextId(),
       now: nextNow(150),
+      messageAuthority: hostedRootAuthority(),
     });
     const parent = await manager.createSession(makeInput());
     const parentTurn = manager
@@ -911,6 +970,87 @@ describe('SessionManager child-session runtime primitive', () => {
     expect(durableRetry.summary).toBe('ok');
     expect((await manager.listChildSessions(parent.id)).length).toBe(1);
     expect(backendsBySession.get(firstResult.childSessionId)?.sendInputs.length).toBe(1);
+
+    parentGate.release();
+    while (!(await parentTurn.next()).done) {}
+  });
+
+  test('hosted linked-child gate precedes resume preparation and remains held through terminal', async () => {
+    const store = new MemorySessionStore();
+    const preparationEntered = makeGate();
+    const allowPreparation = makeGate();
+    let watchedRunId: string | undefined;
+    let preparationReads = 0;
+    const runStore = new MemoryAgentRunStore({
+      beforeRuntimeEventRead: async (_sessionId, runId) => {
+        if (runId !== watchedRunId) return;
+        preparationReads += 1;
+        preparationEntered.release();
+        await allowPreparation.promise;
+      },
+    });
+    const backends = new BackendRegistry();
+    const parentGate = makeGate();
+    backends.register(
+      'fake',
+      (ctx) => new TestBackend(ctx, ctx.header.subagentRuntime ? undefined : parentGate),
+    );
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(165),
+      messageAuthority: hostedRootAuthority(),
+    });
+    const parent = await manager.createSession(makeInput());
+    const parentTurn = manager
+      .sendMessage(parent.id, { turnId: 'parent-turn', text: 'keep parent active' })
+      [Symbol.asyncIterator]();
+    await parentTurn.next();
+    const [parentRun] = await runStore.listSessionRuns(parent.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+    const child = await manager.spawnChildSession(parent.id, {
+      spawnedBy: {
+        parentRunId: parentRun.runId,
+        parentTurnId: parentRun.turnId,
+        toolCallId: 'hosted-gate-cut',
+      },
+      agentProfile: LOCAL_READ_AGENT_PROFILE,
+      prompt: 'inspect the gate cut',
+    });
+
+    watchedRunId = child.runId;
+    const first = manager.resumeChildAgent(parent.id, {
+      parentRunId: parentRun.runId,
+      sourceRunId: child.runId,
+      prompt: 'first successor',
+    });
+    await preparationEntered.promise;
+    const second = manager.resumeChildAgent(parent.id, {
+      parentRunId: parentRun.runId,
+      sourceRunId: child.runId,
+      prompt: 'stale second successor',
+    });
+    const outcomes = Promise.allSettled([first, second]);
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    const readsBeforeRelease = preparationReads;
+    allowPreparation.release();
+
+    const [firstOutcome, secondOutcome] = await outcomes;
+    expect(readsBeforeRelease).toBe(1);
+    expect(firstOutcome.status).toBe('fulfilled');
+    expect(secondOutcome.status).toBe('rejected');
+    expect(secondOutcome.status === 'rejected' ? String(secondOutcome.reason) : '').toContain(
+      'already has an active execution',
+    );
+    expect(
+      (await runStore.listSessionRuns(child.childSessionId)).filter(
+        (run) => run.resumedFromRunId === child.runId,
+      ).length,
+    ).toBe(1);
 
     parentGate.release();
     while (!(await parentTurn.next()).done) {}
@@ -8080,7 +8220,7 @@ describe('SessionManager permission mode updates', () => {
     ).toBe(true);
     await expectRejects(
       manager.prepareChildAgentResume(session.id, source.runId),
-      /already has a resume successor/,
+      /already has a successor/,
     );
     expect(await manager.prepareChildAgentResume(session.id, resumed.runId!)).toMatchObject({
       sourceRunId: resumed.runId,
@@ -8248,13 +8388,40 @@ describe('SessionManager permission mode updates', () => {
     expect(first.failureClass).toBe('RateLimit');
     if (!first.runId) throw new Error('rate-limited child run id was not recorded');
 
-    const second = await manager.retryChildAgent(session.id, {
+    const second = await manager.resumeChildAgent(session.id, {
       parentRunId: parentRun.runId,
       sourceRunId: first.runId,
+      prompt: 'retry with additional guidance',
     });
     expect(second.status).toBe('failed');
     expect(second.failureClass).toBe('RateLimit');
     if (!second.runId) throw new Error('second rate-limited child run id was not recorded');
+    await expectRejects(
+      manager.retryChildAgent(session.id, {
+        parentRunId: parentRun.runId,
+        sourceRunId: first.runId,
+      }),
+      /already has a successor/,
+    );
+
+    const retryAbort = new AbortController();
+    retryAbort.abort();
+    const runsBeforeAbortedRetry = await runStore.listSessionRuns(session.id);
+    let abortedRetryReady = 0;
+    await expectRejects(
+      manager.retryChildAgent(session.id, {
+        parentRunId: parentRun.runId,
+        sourceRunId: second.runId,
+        abortSignal: retryAbort.signal,
+        onReady: () => {
+          abortedRetryReady += 1;
+        },
+      }),
+      /cancelled before start/,
+    );
+    expect((await runStore.listSessionRuns(session.id)).length).toBe(runsBeforeAbortedRetry.length);
+    expect(sendInputs).toHaveLength(2);
+    expect(abortedRetryReady).toBe(0);
 
     const retried = await manager.retryChildAgent(session.id, {
       parentRunId: parentRun.runId,
@@ -8263,7 +8430,11 @@ describe('SessionManager permission mode updates', () => {
 
     expect(retried.status).toBe('completed');
     expect(retried.retriedFromRunId).toBe(second.runId);
-    expect(sendInputs.map((input) => input.text)).toEqual(['inspect auth', '', '']);
+    expect(sendInputs.map((input) => input.text)).toEqual([
+      'inspect auth',
+      'retry with additional guidance',
+      '',
+    ]);
     expect(
       sendInputs[2]?.runtimeContext?.some(
         (event) =>
@@ -12727,6 +12898,165 @@ describe('SessionManager steering and followup queues', () => {
     return events;
   }
 
+  test('hosted root runs consume the Host owner and release it exactly once', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new FakeBackend(ctx));
+    const identities: RuntimeMessageRunIdentity[] = [];
+    const acked: string[] = [];
+    const nacked: string[] = [];
+    let pulled = false;
+    let releases = 0;
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(1_000),
+      messageAuthority: {
+        bindRun: (identity) => {
+          identities.push(identity);
+          return {
+            ...identity,
+            pull: () => {
+              if (pulled) return [];
+              pulled = true;
+              return [
+                {
+                  id: 'host-lease-1',
+                  messageId: 'host-message-1',
+                  content: { text: 'host steer', displayText: 'visible host steer' },
+                },
+              ];
+            },
+            ack: (leaseIds) => acked.push(...leaseIds),
+            nack: (leaseIds) => nacked.push(...leaseIds),
+            release: () => {
+              releases += 1;
+            },
+          };
+        },
+      },
+    });
+    const session = await manager.createSession(
+      makeInput({ backend: 'fake', permissionMode: 'bypass' }),
+    );
+
+    const events = await drainAll(
+      manager.sendMessage(session.id, { turnId: 'turn-host-message', text: 'start' }),
+    );
+    const [run] = await runStore.listSessionRuns(session.id);
+    expect(identities).toEqual([
+      { sessionId: session.id, turnId: 'turn-host-message', runId: run?.runId },
+    ]);
+    expect(acked).toEqual(['host-lease-1']);
+    expect(nacked).toEqual([]);
+    expect(releases).toBe(1);
+    expect(
+      events.some(
+        (event) =>
+          event.type === 'steering_message' &&
+          event.messageId === 'host-message-1' &&
+          event.content.displayText === 'visible host steer',
+      ),
+    ).toBe(true);
+    expect(events.some((event) => event.type === 'queue_update')).toBe(false);
+    for (const operation of [
+      () => manager.steer(session.id, 'runtime mirror'),
+      () => manager.queueMessage(session.id, 'runtime mirror'),
+      () => manager.drainFollowup(session.id),
+      () => manager.retractQueue(session.id),
+    ]) {
+      let error: unknown;
+      try {
+        operation();
+      } catch (caught) {
+        error = caught;
+      }
+      expect(error instanceof RuntimeMessageAuthorityInvariantError).toBe(true);
+    }
+  });
+
+  test('hosted owner is released when the event consumer abandons the run', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new FakeBackend(ctx));
+    let releases = 0;
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(1_000),
+      messageAuthority: {
+        bindRun: (identity) => ({
+          ...identity,
+          pull: () => [],
+          ack: () => {},
+          nack: () => {},
+          release: () => {
+            releases += 1;
+          },
+        }),
+      },
+    });
+    const session = await manager.createSession(
+      makeInput({ backend: 'fake', permissionMode: 'bypass' }),
+    );
+    const iterator = manager
+      .sendMessage(session.id, { turnId: 'turn-host-abandoned', text: 'start' })
+      [Symbol.asyncIterator]();
+
+    await iterator.next();
+    await iterator.return?.(undefined);
+    expect(releases).toBe(1);
+  });
+
+  test('hosted owner is released when backend execution fails', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new ThrowBeforeTerminalBackend(ctx));
+    let releases = 0;
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(1_000),
+      messageAuthority: {
+        bindRun: (identity) => ({
+          ...identity,
+          pull: () => [],
+          ack: () => {},
+          nack: () => {},
+          release: () => {
+            releases += 1;
+          },
+        }),
+      },
+    });
+    const session = await manager.createSession(
+      makeInput({ backend: 'fake', permissionMode: 'bypass' }),
+    );
+
+    let failure: unknown;
+    try {
+      await drainAll(
+        manager.sendMessage(session.id, { turnId: 'turn-host-failed', text: 'start' }),
+      );
+    } catch (error) {
+      failure = error;
+    }
+    expect((failure as Error).message).toBe('backend failed before terminal');
+    expect(releases).toBe(1);
+  });
+
   test('steer injects a user message mid-turn and emits queue snapshots', async () => {
     const { manager } = steeringManager();
     const session = await manager.createSession(
@@ -12741,7 +13071,9 @@ describe('SessionManager steering and followup queues', () => {
     expect(steerOutcome).toEqual({ kind: 'queued' });
     // The interjection is echoed as a first-class user event…
     expect(
-      events.some((event) => event.type === 'steering_message' && event.text === 'also do X'),
+      events.some(
+        (event) => event.type === 'steering_message' && event.content.text === 'also do X',
+      ),
     ).toBe(true);
     // …the enqueue and the step-boundary consumption both push a queue snapshot…
     const queueUpdates = events.filter(
@@ -12869,7 +13201,9 @@ describe('SessionManager steering and followup queues', () => {
     });
     expect(outcome?.kind).toBe('queued');
     expect(
-      events.some((event) => event.type === 'steering_message' && event.text === 'now consumed'),
+      events.some(
+        (event) => event.type === 'steering_message' && event.content.text === 'now consumed',
+      ),
     ).toBe(true);
   });
 
@@ -12914,7 +13248,7 @@ describe('SessionManager steering and followup queues', () => {
     expect(backend?.pulls.get('turn-b')).toEqual([['for the owner']]);
     expect(
       secondEvents.some(
-        (event) => event.type === 'steering_message' && event.text === 'for the owner',
+        (event) => event.type === 'steering_message' && event.content.text === 'for the owner',
       ),
     ).toBe(true);
   });
@@ -13603,7 +13937,7 @@ class GatedSteeringBackend implements AgentBackend {
     await gate.promise;
     const leases = input.pullSteering?.() ?? [];
     const record = this.pulls.get(input.turnId) ?? [];
-    record.push(leases.map((lease) => lease.text));
+    record.push(leases.map((lease) => lease.content.text));
     this.pulls.set(input.turnId, record);
     let seq = 0;
     for (const lease of leases) {
@@ -13613,8 +13947,8 @@ class GatedSteeringBackend implements AgentBackend {
         id: `${input.turnId}-steer-${seq}`,
         turnId: input.turnId,
         ts: seq,
-        messageId: `${input.turnId}-steer-m-${seq}`,
-        text: lease.text,
+        messageId: lease.messageId,
+        content: lease.content,
       };
     }
     // Delivery for this fake is the echo itself; ack the leases.
@@ -15758,6 +16092,29 @@ function makeTestRuntimePolicyGate(): {
       await Promise.all([...activeActivations]);
       return operation();
     },
+  };
+}
+
+function hostedRootAuthority(): RuntimeHostedRootAuthority {
+  return {
+    bindRun: (identity) => ({
+      ...identity,
+      pull: () => [],
+      ack: () => {},
+      nack: () => {},
+      release: () => {},
+    }),
+    executeRoot: async (input) => {
+      for await (const event of input.start({
+        runId: input.runId,
+        userMessageId: input.userMessageId,
+        onRunStarted: () => input.onReady?.(),
+      })) {
+        input.onEvent?.(event);
+      }
+    },
+    stopRoot: async () => {},
+    stopSession: async () => {},
   };
 }
 

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -621,6 +621,16 @@ async function prepareAgentSwarmInput(
       };
     }),
   );
+  const linkedChildSessions = new Set<string>();
+  for (const resume of resumes) {
+    if (resume.execution?.kind !== 'child_session') continue;
+    if (linkedChildSessions.has(resume.execution.sessionId)) {
+      throw new Error(
+        `Agent swarm cannot resume child Session ${resume.execution.sessionId} more than once`,
+      );
+    }
+    linkedChildSessions.add(resume.execution.sessionId);
+  }
   return {
     items: [...resumes, ...preflight.items],
     maxConcurrency: preflight.maxConcurrency,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -82,6 +82,7 @@ import type {
   ModelFailureKind,
   ToolCallPart,
   ToolResultOutput,
+  UserContent,
 } from './model-protocol.js';
 import { z } from 'zod';
 
@@ -2571,7 +2572,16 @@ export class AiSdkBackend implements AgentBackend {
         // still presents steering exactly once, in its one provider form.
         const sidecar = steeringSidecar?.get(m.id);
         if (sidecar) {
-          out.push(steeringModelMessage(sidecar.eventId, formatTextWithInlineRefs(m.text, m)));
+          out.push(
+            steeringModelMessage(
+              sidecar.eventId,
+              await this.appendImageParts(
+                buildSteeringEnvelope(formatTextWithInlineRefs(m.text, m)),
+                m.attachments,
+                `steering:${sidecar.eventId}`,
+              ),
+            ),
+          );
           continue;
         }
         out.push({
@@ -2629,7 +2639,7 @@ export class AiSdkBackend implements AgentBackend {
     textContent: string,
     attachments?: AttachmentRef[],
     decisionKeyPrefix?: string,
-  ): Promise<ModelMessage['content']> {
+  ): Promise<UserContent> {
     const images = attachments?.filter((a) => a.kind === 'image') ?? [];
     if (images.length === 0) {
       return textContent;
@@ -2672,7 +2682,7 @@ export class AiSdkBackend implements AgentBackend {
         text: `[${omittedByBudget} image attachment(s) omitted: the per-request image budget was exceeded. Earlier images were sent; ask the user to send fewer or smaller images.]`,
       });
     }
-    return parts as ModelMessage['content'];
+    return parts;
   }
 
   private async materializeToolResultOutput(
@@ -2721,7 +2731,7 @@ export class AiSdkBackend implements AgentBackend {
     attachments?: AttachmentRef[],
     quotes?: QuoteRef[],
     runtimeEventId?: string,
-  ): Promise<ModelMessage['content']> {
+  ): Promise<UserContent> {
     return this.appendImageParts(
       formatTextWithInlineRefs(text, {
         ...(attachments !== undefined ? { attachments } : {}),
@@ -2845,14 +2855,29 @@ export class AiSdkBackend implements AgentBackend {
         if (queue.consumerDetached) {
           throw new Error('steering message was not durably consumed: event consumer detached');
         }
+        // Materialize provider content before publishing the durable event.
+        // After consumption there must be no fallible gap before ack/injection.
         const eventId = this.newId();
+        const providerContent = await this.appendImageParts(
+          buildSteeringEnvelope(formatTextWithInlineRefs(lease.content.text, lease.content)),
+          lease.content.attachments,
+          `steering:${eventId}`,
+        );
+        if (this.aborted || abortSignal?.aborted) {
+          throw Object.assign(new Error('aborted before steering was pushed'), {
+            name: 'AbortError',
+          });
+        }
+        if (queue.consumerDetached) {
+          throw new Error('steering message was not durably consumed: event consumer detached');
+        }
         queue.push({
           type: 'steering_message',
           id: eventId,
           turnId,
           ts: this.now(),
-          messageId: this.newId(),
-          text: lease.text,
+          messageId: lease.messageId,
+          content: lease.content,
         } satisfies SessionEvent);
         const pushedThrough = queue.pushedCount;
         for (;;) {
@@ -2864,7 +2889,7 @@ export class AiSdkBackend implements AgentBackend {
         }
         // The mapped RuntimeEvent inherits this session event's id, so the
         // injected message and its future ledger replay share one identity.
-        this.injectedSteeringMessages.push(steeringModelMessage(eventId, lease.text));
+        this.injectedSteeringMessages.push(steeringModelMessage(eventId, providerContent));
         input.ackSteering?.([lease.id]);
         undelivered.shift();
         if (this.aborted || abortSignal?.aborted) {

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -32,6 +32,7 @@
 
 import {
   failureClassFromCompleteStopReason,
+  normalizeMessageContent,
   type AnyPermissionRequestEvent,
   type CompleteEvent,
   type SessionEvent,
@@ -459,9 +460,9 @@ function mapBackendSessionEvent(
         ...base,
         role: 'user',
         author: 'user',
-        // Raw text + steering marker: read models render the text as-is,
-        // model replay wraps it in the canonical steering envelope.
-        content: { kind: 'text', text: event.text, steering: true },
+        // Canonical content + steering marker: read models may prefer
+        // displayText, while model replay uses text and materializes attachments.
+        content: { kind: 'text', ...normalizeMessageContent(event.content), steering: true },
         refs: { providerEventId: event.messageId },
       };
 

--- a/packages/runtime/src/fake-backend.ts
+++ b/packages/runtime/src/fake-backend.ts
@@ -69,7 +69,7 @@ export class FakeBackend implements AgentBackend {
       if (leases.length === 0) return [];
       outstanding.push(...leases.map((lease) => lease.id));
       return leases.map((lease) => {
-        steered.push(lease.text);
+        steered.push(lease.content.text);
         return {
           leaseId: lease.id,
           event: {
@@ -77,8 +77,8 @@ export class FakeBackend implements AgentBackend {
             id: randomUUID(),
             turnId,
             ts: Date.now(),
-            messageId: randomUUID(),
-            text: lease.text,
+            messageId: lease.messageId,
+            content: lease.content,
           } satisfies SessionEvent,
         };
       });

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -138,6 +138,18 @@ export type {
 export { PermissionEngine, createDefaultPermissionEngineDeps } from './permission-engine.js';
 export type { EvaluateResult, EvaluateInput, PermissionEngineDeps } from './permission-engine.js';
 export { renderSwarmModePrompt } from './swarm-mode.js';
+export {
+  RuntimeHostedRootConflictError,
+  RuntimeMessageAuthorityInvariantError,
+} from './message-authority.js';
+export type {
+  RuntimeHostedRootAuthority,
+  RuntimeHostedRootExecutionInput,
+  RuntimeMessageAuthority,
+  RuntimeMessageRunIdentity,
+  RuntimeMessageRunOwner,
+} from './message-authority.js';
+export { isRuntimeHostedRootAuthority } from './message-authority.js';
 
 export {
   MAX_ADDITIONAL_PERMISSION_JUSTIFICATION_CHARS,
@@ -1089,7 +1101,11 @@ export type {
   RuntimeEventTerminalFact,
   RuntimeEventTerminalFactResult,
 } from './runtime-event-read-model.js';
-export { classifyTerminalRuntimeLedger } from './terminal-run-commit.js';
+export {
+  buildRecoveredTerminalRuntimeEvent,
+  classifyTerminalRuntimeLedger,
+  commitTerminalRunWithRuntimeFact,
+} from './terminal-run-commit.js';
 export type { TerminalRuntimeLedgerClassification } from './terminal-run-commit.js';
 export {
   RuntimeReadModel,

--- a/packages/runtime/src/message-authority.ts
+++ b/packages/runtime/src/message-authority.ts
@@ -1,0 +1,78 @@
+import type { BackendStopMode, SteeringLease } from '@maka/core/backend-types';
+import type { RootExecutionDescriptor } from '@maka/core/agent-run';
+import type { MessageContent, SessionEvent } from '@maka/core/events';
+
+export interface RuntimeMessageRunIdentity {
+  readonly sessionId: string;
+  readonly turnId: string;
+  readonly runId: string;
+}
+
+/** Synchronous lease bridge owned by the Runtime Host for one live root run. */
+export interface RuntimeMessageRunOwner extends RuntimeMessageRunIdentity {
+  pull(): readonly SteeringLease[];
+  ack(leaseIds: readonly string[]): void;
+  nack(leaseIds: readonly string[]): void;
+  /** Ends Runtime access; the Host closes admission at its terminal transition cut. */
+  release(): void;
+}
+
+/** Process-wide factory. Queue admission and projection remain Host responsibilities. */
+export interface RuntimeMessageAuthority {
+  bindRun(identity: RuntimeMessageRunIdentity): RuntimeMessageRunOwner;
+}
+
+export interface RuntimeHostedRootExecutionInput extends RuntimeMessageRunIdentity {
+  readonly userMessageId: string | null;
+  readonly execution: RootExecutionDescriptor;
+  readonly content: MessageContent;
+  readonly start: (input: {
+    readonly runId: string;
+    readonly userMessageId: string | null;
+    readonly onRunStarted: () => void | Promise<void>;
+  }) => AsyncIterable<SessionEvent>;
+  readonly onEvent?: (event: SessionEvent) => void;
+  readonly onReady?: () => void | Promise<void>;
+}
+
+/** Host-only root lifecycle capability. Embedded compositions must omit it. */
+export interface RuntimeHostedRootAuthority extends RuntimeMessageAuthority {
+  executeRoot(input: RuntimeHostedRootExecutionInput): Promise<void>;
+  stopRoot(
+    identity: RuntimeMessageRunIdentity,
+    input?: { source?: 'stop_button' | 'benchmark_deadline'; mode?: BackendStopMode },
+  ): Promise<void>;
+  stopSession(
+    sessionId: string,
+    input?: { source?: 'stop_button' | 'benchmark_deadline'; mode?: BackendStopMode },
+  ): Promise<void>;
+}
+
+export function isRuntimeHostedRootAuthority(
+  authority: RuntimeMessageAuthority | undefined,
+): authority is RuntimeHostedRootAuthority {
+  return (
+    authority !== undefined &&
+    'executeRoot' in authority &&
+    typeof authority.executeRoot === 'function' &&
+    'stopRoot' in authority &&
+    typeof authority.stopRoot === 'function' &&
+    'stopSession' in authority &&
+    typeof authority.stopSession === 'function'
+  );
+}
+
+export class RuntimeMessageAuthorityInvariantError extends Error {
+  readonly name = 'RuntimeMessageAuthorityInvariantError';
+}
+
+export class RuntimeHostedRootConflictError extends Error {
+  readonly name = 'RuntimeHostedRootConflictError';
+  readonly code = 'session_busy';
+  readonly scope: { readonly kind: 'session'; readonly sessionId: string };
+
+  constructor(sessionId: string, message: string) {
+    super(message);
+    this.scope = { kind: 'session', sessionId };
+  }
+}

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -44,7 +44,7 @@ import {
 } from '@maka/core/runtime-event';
 import { normalizeShellToolResultContent } from '@maka/core';
 import type { AttachmentRef, QuoteRef } from '@maka/core/events';
-import type { ModelMessage } from './model-protocol.js';
+import type { ModelMessage, UserContent, UserModelMessage } from './model-protocol.js';
 
 // ============================================================================
 // Output type
@@ -770,11 +770,14 @@ export function steeringProviderOptions(
   return { [STEERING_PROVIDER_OPTIONS_NAMESPACE]: { steeringEventId: eventId } };
 }
 
-/** The canonical injected/replayed form of one steered user message. */
-export function steeringModelMessage(eventId: string, text: string): ModelMessage {
+/** Add structured steering identity to already-canonical provider content. */
+export function steeringModelMessage(
+  eventId: string,
+  providerContent: UserContent,
+): UserModelMessage {
   return {
     role: 'user',
-    content: buildSteeringEnvelope(text),
+    content: providerContent,
     providerOptions: steeringProviderOptions(eventId),
   };
 }

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -78,6 +78,11 @@ import {
   matchingTerminalRuntimeEvents,
   terminalRunStatusFromRuntimeEvent,
 } from './terminal-run-commit.js';
+import {
+  RuntimeMessageAuthorityInvariantError,
+  type RuntimeMessageAuthority,
+  type RuntimeMessageRunOwner,
+} from './message-authority.js';
 
 export interface RuntimeKernelLike {
   startTurn(
@@ -121,19 +126,15 @@ export interface ChildAgentRetryInput {
   continuation: RuntimeContinuation;
   /** Retry an ordinary session-inline AgentRun inside a linked child Session. */
   linkedSession?: boolean;
+  onRunStarted?: () => void | Promise<void>;
 }
 
 /**
- * A session's two authoritative pending-message queues plus the sink that
- * pushes queue snapshots into the active turn's event stream. The runtime is
- * the single source of truth; UIs mirror it from `queue_update` events and the
- * enqueue results.
+ * An embedded session's authoritative pending-message queues plus its event
+ * sink. Hosted composition never creates this state; its Host owns admission,
+ * snapshots, leases, and follow-up drain.
  */
-interface PendingSteeringMessage {
-  /** Queue/lease identity — NOT the ledger event id. */
-  id: string;
-  text: string;
-}
+interface PendingSteeringMessage extends SteeringLease {}
 
 /**
  * A pulled lease is bound to the turn that pulled it: only the issuing turn's
@@ -187,6 +188,8 @@ export interface RuntimeKernelDeps {
   safeBoundaryResumeEnabled?: boolean;
   continuationFailpoint?: (point: RuntimeContinuationFailpoint) => Promise<void>;
   runBackendActivation?: BackendActivationBoundary;
+  /** Hosted composition capability. When present, the Host owns all message queues. */
+  messageAuthority?: RuntimeMessageAuthority;
 }
 
 export interface HistoryCompactCleanupRequest {
@@ -746,7 +749,13 @@ export class RuntimeKernel implements RuntimeKernelLike {
 
     // A provider retry replays the source ledger without recording a second
     // user prompt and without turning the child into a session continuation.
-    yield* this.runAgentContinuation(continuation, run, false);
+    yield* this.runAgentContinuation(
+      continuation,
+      run,
+      false,
+      input.linkedSession === true,
+      input.onRunStarted,
+    );
   }
 
   private async *runAgentTurn(
@@ -760,14 +769,34 @@ export class RuntimeKernel implements RuntimeKernelLike {
     const sessionEvents = new AsyncEventQueue<SessionEvent>();
     const abortController = new AbortController();
     let flowDone = false;
+    let messageOwner: RuntimeMessageRunOwner | undefined;
+    let messageOwnerReleased = false;
+    const releaseMessageOwner = (): void => {
+      if (!messageOwner || messageOwnerReleased) return;
+      messageOwnerReleased = true;
+      messageOwner.release();
+    };
     let begin: AgentRunBeginResult;
     try {
       begin = await this.runBackendActivation(() => run.begin());
+      if (steering && this.deps.messageAuthority) {
+        messageOwner = this.deps.messageAuthority.bindRun({
+          sessionId,
+          turnId: run.turnId,
+          runId: run.runId,
+        });
+      }
       if (onRunStarted && initialHeader) await onRunStarted(run.runId, initialHeader);
     } catch (error) {
-      await run.recordFailure(error);
+      let failure = error;
+      try {
+        releaseMessageOwner();
+      } catch (releaseError) {
+        failure = new AggregateError([error, releaseError], 'Message owner bind cleanup failed');
+      }
+      await run.recordFailure(failure);
       await run.finalize();
-      throw error;
+      throw failure;
     }
 
     // Steering is a top-level-turn affordance only; child agent turns run
@@ -780,7 +809,11 @@ export class RuntimeKernel implements RuntimeKernelLike {
     let pullSteering: (() => readonly SteeringLease[]) | undefined;
     let ackSteering: ((leaseIds: readonly string[]) => void) | undefined;
     let nackSteering: ((leaseIds: readonly string[]) => void) | undefined;
-    if (steering) {
+    if (messageOwner) {
+      pullSteering = () => messageOwner?.pull() ?? [];
+      ackSteering = (leaseIds) => messageOwner?.ack(leaseIds);
+      nackSteering = (leaseIds) => messageOwner?.nack(leaseIds);
+    } else if (steering) {
       const state = this.ensureSteering(sessionId);
       state.sink = (event) => {
         void sessionEvents.push(event).catch(() => {});
@@ -829,7 +862,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           // Back to the FRONT of the queue: a re-pull at the next step
           // boundary preserves the user's original ordering.
           current.steering = [
-            ...returned.map(({ id, text }) => ({ id, text })),
+            ...returned.map(({ id, messageId, content }) => ({ id, messageId, content })),
             ...current.steering,
           ];
         } else {
@@ -838,7 +871,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
           // steering queue would strand the text ownerless. The followup
           // queue is its only safe home — the same direction a release-time
           // fold takes.
-          current.followup = [...returned.map((message) => message.text), ...current.followup];
+          current.followup = [
+            ...returned.map((message) => message.content.text),
+            ...current.followup,
+          ];
         }
         this.emitQueueUpdate(sessionId, current);
       };
@@ -863,12 +899,13 @@ export class RuntimeKernel implements RuntimeKernelLike {
         flowDone = true;
         try {
           await run.finalize();
-          // Release ownership BEFORE the event stream closes: the stranded
-          // steering → followup migration emits a final queue snapshot through
-          // the sink, and a push after close() is a silent no-op. The release
-          // in the outer finally stays as an idempotent backstop for paths
-          // that never reach this hook (identity-checked, so it no-ops here).
-          if (steering) this.releaseSteeringTurn(sessionId, run.turnId);
+          // Release Runtime access BEFORE the event stream closes. Embedded
+          // queues still emit their final steering → followup projection here;
+          // a hosted owner is only sealed, then the Host performs that handoff
+          // under its Session admission gate. The outer finally remains an
+          // idempotent backstop for paths that never reach this hook.
+          if (messageOwner) releaseMessageOwner();
+          else if (steering) this.releaseSteeringTurn(sessionId, run.turnId);
           sessionEvents.close();
         } catch (error) {
           sessionEvents.fail(error);
@@ -912,6 +949,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           if (!flowDone) {
             flowDone = true;
             await run.finalize();
+            releaseMessageOwner();
             sessionEvents.close();
           }
           await this.deps.runtimeInvocationObserver?.(result);
@@ -934,7 +972,8 @@ export class RuntimeKernel implements RuntimeKernelLike {
         sessionEvents.close();
       }
       await runnerResult.catch(() => undefined);
-      if (steering) this.releaseSteeringTurn(sessionId, run.turnId);
+      if (messageOwner) releaseMessageOwner();
+      else if (steering) this.releaseSteeringTurn(sessionId, run.turnId);
     }
   }
 
@@ -942,19 +981,42 @@ export class RuntimeKernel implements RuntimeKernelLike {
     continuation: RuntimeContinuation,
     run: AgentRun,
     persistContinuationSource = true,
+    bindHostedRoot = false,
+    onRunStarted?: () => void | Promise<void>,
   ): AsyncIterable<SessionEvent> {
     const sessionEvents = new AsyncEventQueue<SessionEvent>();
     const abortController = new AbortController();
     let flowDone = false;
+    let messageOwner: RuntimeMessageRunOwner | undefined;
+    let messageOwnerReleased = false;
+    const releaseMessageOwner = (): void => {
+      if (!messageOwner || messageOwnerReleased) return;
+      messageOwnerReleased = true;
+      messageOwner.release();
+    };
     let begin: Awaited<ReturnType<AgentRun['beginContinuation']>>;
     try {
       begin = await this.runBackendActivation(() =>
         persistContinuationSource ? run.beginContinuation(continuation) : run.beginOperation(),
       );
+      if (bindHostedRoot && this.deps.messageAuthority) {
+        messageOwner = this.deps.messageAuthority.bindRun({
+          sessionId: continuation.sessionId,
+          turnId: continuation.turnId,
+          runId: continuation.runId,
+        });
+      }
+      await onRunStarted?.();
     } catch (error) {
-      await run.recordFailure(error);
+      let failure = error;
+      try {
+        releaseMessageOwner();
+      } catch (releaseError) {
+        failure = new AggregateError([error, releaseError], 'Message owner bind cleanup failed');
+      }
+      await run.recordFailure(failure);
       await run.finalize();
-      throw error;
+      throw failure;
     }
 
     const aiSdkFlow = new AiSdkFlow({
@@ -976,6 +1038,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
         flowDone = true;
         try {
           await run.finalize();
+          releaseMessageOwner();
           sessionEvents.close();
         } catch (error) {
           sessionEvents.fail(error);
@@ -1027,6 +1090,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
         await run.finalize();
       }
       await runnerResult.catch(() => undefined);
+      releaseMessageOwner();
     }
   }
 
@@ -1221,6 +1285,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   // --------------------------------------------------------------------------
 
   steer(sessionId: string, text: string): QueueEnqueueOutcome {
+    this.assertEmbeddedMessageQueue('steer');
     // Steering's delivery contract is anchored to the runtime event ledger
     // (fail-closed persist + durable-consume ack). Without a RuntimeEventStore
     // that anchor does not exist — same condition as requireTerminalWrite —
@@ -1233,12 +1298,14 @@ export class RuntimeKernel implements RuntimeKernelLike {
     // fresh turn instead so the message is never dropped.
     const state = this.liveSteeringState(sessionId);
     if (!state) return { kind: 'fallback' };
-    state.steering.push({ id: this.deps.newId(), text });
+    const messageId = this.deps.newId();
+    state.steering.push({ id: messageId, messageId, content: { text } });
     this.emitQueueUpdate(sessionId, state);
     return { kind: 'queued' };
   }
 
   queueMessage(sessionId: string, text: string): QueueEnqueueOutcome {
+    this.assertEmbeddedMessageQueue('queueMessage');
     const state = this.liveSteeringState(sessionId);
     if (!state) return { kind: 'fallback' };
     state.followup.push(text);
@@ -1247,6 +1314,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   }
 
   drainFollowup(sessionId: string): string | null {
+    this.assertEmbeddedMessageQueue('drainFollowup');
     const state = this.steeringBySession.get(sessionId);
     if (!state || state.followup.length === 0) return null;
     const drained = state.followup.splice(0);
@@ -1255,6 +1323,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   }
 
   retractQueue(sessionId: string): string {
+    this.assertEmbeddedMessageQueue('retractQueue');
     const state = this.steeringBySession.get(sessionId);
     if (!state) return '';
     // Retract reclaims QUEUED messages only. pull() is the single atomic
@@ -1263,7 +1332,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     // handing its text back to the user here would refill AND execute the
     // same directive. An in-flight lease settles only by the persistence
     // fact (ack when the ledger owns it, nack back to a queue otherwise).
-    const all = [...state.steering.map((message) => message.text), ...state.followup];
+    const all = [...state.steering.map((message) => message.content.text), ...state.followup];
     state.steering = [];
     state.followup = [];
     this.emitQueueUpdate(sessionId, state);
@@ -1276,6 +1345,14 @@ export class RuntimeKernel implements RuntimeKernelLike {
     const created: SessionSteeringState = { steering: [], inFlight: [], followup: [] };
     this.steeringBySession.set(sessionId, created);
     return created;
+  }
+
+  private assertEmbeddedMessageQueue(operation: string): void {
+    if (this.deps.messageAuthority) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        `Hosted Runtime cannot ${operation}; the Runtime Host owns message admission and queues`,
+      );
+    }
   }
 
   /**
@@ -1296,8 +1373,8 @@ export class RuntimeKernel implements RuntimeKernelLike {
       turnId: state.activeTurnId ?? '',
       ts: this.deps.now(),
       steering: [
-        ...state.inFlight.map((message) => message.text),
-        ...state.steering.map((message) => message.text),
+        ...state.inFlight.map((message) => message.content.text),
+        ...state.steering.map((message) => message.content.text),
       ],
       followup: [...state.followup],
     });
@@ -1328,7 +1405,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       // backstop that keeps a never-settled lease from stranding invisibly.
       if (own.length === 0) return;
       state.inFlight = state.inFlight.filter((message) => message.issuingTurnId !== turnId);
-      state.followup = [...own.map((message) => message.text), ...state.followup];
+      state.followup = [...own.map((message) => message.content.text), ...state.followup];
       this.emitQueueUpdate(sessionId, state);
       return;
     }
@@ -1339,8 +1416,8 @@ export class RuntimeKernel implements RuntimeKernelLike {
     // is cleared; otherwise observers stay on the stale pre-fold snapshot.
     if (state.steering.length > 0 || own.length > 0) {
       state.followup = [
-        ...own.map((message) => message.text),
-        ...state.steering.map((message) => message.text),
+        ...own.map((message) => message.content.text),
+        ...state.steering.map((message) => message.content.text),
         ...state.followup,
       ];
       state.inFlight = state.inFlight.filter((message) => message.issuingTurnId !== turnId);

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -77,6 +77,7 @@ import type {
   AgentRunHeader,
   AgentRunStore,
   ArtifactRecord,
+  RootExecutionDescriptor,
   RuntimeEvent,
   RuntimeEventStore,
   ToolBoundaryProtocol,
@@ -111,6 +112,13 @@ import type { HistoryCompactCheckpoint } from './history-compact-checkpoint.js';
 import type { AgentRunLineage, RuntimeContinuationFailpoint } from './agent-run.js';
 import { classifyAgentRunRecovery, type AgentRunRecoveryDecision } from './agent-run-recovery.js';
 import type { InvocationResult, InvocationSource } from './invocation-context.js';
+import {
+  isRuntimeHostedRootAuthority,
+  RuntimeMessageAuthorityInvariantError,
+  type RuntimeHostedRootExecutionInput,
+  type RuntimeMessageAuthority,
+  type RuntimeMessageRunIdentity,
+} from './message-authority.js';
 import {
   RuntimeKernel,
   type BackendActivationBoundary,
@@ -497,6 +505,8 @@ export interface SessionManagerDeps {
   continuationFailpoint?: (point: RuntimeContinuationFailpoint) => Promise<void>;
   runBackendActivation?: BackendActivationBoundary;
   safeBoundaryResumeEnabled?: boolean;
+  /** Hosted composition capability. Omit for the production embedded queue. */
+  messageAuthority?: RuntimeMessageAuthority;
   onContinuationLifecycleEvent?: (event: RuntimeContinuationLifecycleEvent) => void | Promise<void>;
   generateSessionTitle?: (input: {
     sessionId: string;
@@ -536,6 +546,7 @@ export type RuntimeContinuationLifecycleEvent =
 export class SessionManager {
   private readonly runtimeKernel: RuntimeKernelLike;
   private readonly runtimeLedgerRepair?: RuntimeLedgerRepair;
+  private readonly activeHostedLinkedChildSessions = new Set<string>();
   private readonly childSessionSpawns = new Map<
     string,
     { requestFingerprint: string; promise: Promise<SpawnChildSessionResult> }
@@ -1407,6 +1418,11 @@ export class SessionManager {
   async runClaimedAgentGraphIntent(
     input: RunClaimedAgentGraphIntentInput,
   ): Promise<ClaimedAgentGraphIntentResult> {
+    if (isRuntimeHostedRootAuthority(this.deps.messageAuthority)) {
+      throw new RuntimeMessageAuthorityInvariantError(
+        'Claimed graph execution requires a Runtime Host graph composition',
+      );
+    }
     const claim = await input.claimStore.readAgentGraphIntentClaim(input.graphId, input.intentId);
     if (!claim) {
       throw new Error(`Graph intent ${input.graphId}/${input.intentId} has not been claimed`);
@@ -1729,125 +1745,142 @@ export class SessionManager {
     if (!snapshot || !spawn || !child.subagentParent) {
       throw new Error('Stored child session is missing its durable runtime or spawn identity');
     }
-    const turnId = spawn.initialTurnId;
-    const runId = spawn.initialRunId;
-    const readyInfo = {
-      childSessionId: child.id,
-      turnId,
-      runId,
-      agentId: snapshot.agentId,
-      agentName: snapshot.agentName,
-    };
-    let readyNotification: Promise<void> | undefined;
-    const notifyReady = (): Promise<void> => {
-      readyNotification ??= Promise.resolve().then(() => input.onReady?.(readyInfo));
-      return readyNotification;
-    };
-
-    // Close the create/start race: if the parent settled (or cancellation
-    // arrived) while metadata was being written, retain an inspectable aborted
-    // child but do not admit new foreground work.
+    const releaseHostedExecution = this.acquireHostedLinkedChildExecution(child.id);
     try {
-      this.assertActiveParentRun(parentSessionId, parentRun, input.spawnedBy.parentTurnId);
-      if (input.abortSignal?.aborted) {
-        throw new Error('Child session spawn was cancelled before its first run');
-      }
-    } catch (error) {
-      if (creation.created) await this.updateStatus(child.id, 'aborted').catch(() => {});
-      throw error;
-    }
-
-    if (!creation.created) {
-      const existing = await this.resolveExistingChildSpawn(child, input, notifyReady);
-      if (existing) return existing;
-    }
-
-    // A committed metadata row without its initial AgentRun is a recoverable
-    // crash boundary. Revalidate admission after the lookup: the parent or
-    // caller may have settled while durable state was being inspected.
-    try {
-      const latestParentRun = await this.deps.runStore.readRun(
-        parentSessionId,
-        input.spawnedBy.parentRunId,
-      );
-      this.assertActiveParentRun(parentSessionId, latestParentRun, input.spawnedBy.parentTurnId);
-      if (input.abortSignal?.aborted) {
-        throw new Error('Child session spawn was cancelled before its first run');
-      }
-    } catch (error) {
-      await this.updateStatus(child.id, 'aborted').catch(() => {});
-      throw error;
-    }
-
-    const startedAt = this.deps.now();
-    const summary = new ChildAgentSummaryAccumulator();
-    let aborted = false;
-    let stopPromise: Promise<void> | undefined;
-    const iterator = this.sendMessage(
-      child.id,
-      {
+      const turnId = spawn.initialTurnId;
+      const runId = spawn.initialRunId;
+      const readyInfo = {
+        childSessionId: child.id,
         turnId,
-        text: input.prompt,
+        runId,
         agentId: snapshot.agentId,
         agentName: snapshot.agentName,
-      },
-      {
-        runId,
-        durability: 'required',
-        onRunStarted: notifyReady,
-      },
-    )[Symbol.asyncIterator]();
-    const onAbort = () => {
-      aborted = true;
-      stopPromise ??= this.stopSession(child.id, { source: 'stop_button' });
-    };
-    if (input.abortSignal) {
-      input.abortSignal.addEventListener('abort', onAbort, { once: true });
-      if (input.abortSignal.aborted) onAbort();
-    }
-    try {
-      while (!aborted) {
-        const next = await iterator.next();
-        if (next.done) break;
-        summary.add(next.value);
-        try {
-          input.onEvent?.(next.value);
-        } catch {
-          // A presentation observer must not change the child run outcome.
-        }
-        if (aborted) break;
-      }
-    } finally {
-      input.abortSignal?.removeEventListener('abort', onAbort);
-      if (aborted) {
-        await stopPromise;
-        await iterator.return?.();
-      }
-    }
+      };
+      let readyNotification: Promise<void> | undefined;
+      const notifyReady = (): Promise<void> => {
+        readyNotification ??= Promise.resolve().then(() => input.onReady?.(readyInfo));
+        return readyNotification;
+      };
 
-    const completedAt = this.deps.now();
-    const run = await this.findRunByTurnId(child.id, turnId);
-    const failureClass = run?.failureClass ?? summary.failureClass;
-    const artifacts = this.deps.listArtifactsForTurn
-      ? await this.deps.listArtifactsForTurn(child.id, turnId)
-      : [];
-    return {
-      childSessionId: child.id,
-      agentId: snapshot.agentId,
-      agentName: snapshot.agentName,
-      profile: snapshot.profile,
-      turnId,
-      runId,
-      status: run ? agentRunStatusForSpawnResult(run.status) : summary.status(aborted),
-      permissionMode: child.permissionMode,
-      summary: summary.text(),
-      artifactIds: artifacts.map((artifact) => artifact.id),
-      startedAt,
-      completedAt,
-      durationMs: Math.max(0, completedAt - startedAt),
-      eventCount: summary.eventCount,
-      ...(failureClass ? { failureClass } : {}),
-    };
+      // Close the create/start race: if the parent settled (or cancellation
+      // arrived) while metadata was being written, retain an inspectable aborted
+      // child but do not admit new foreground work.
+      try {
+        this.assertActiveParentRun(parentSessionId, parentRun, input.spawnedBy.parentTurnId);
+        if (input.abortSignal?.aborted) {
+          throw new Error('Child session spawn was cancelled before its first run');
+        }
+      } catch (error) {
+        if (creation.created) await this.updateStatus(child.id, 'aborted').catch(() => {});
+        throw error;
+      }
+
+      if (!creation.created) {
+        const existing = await this.resolveExistingChildSpawn(child, input, notifyReady);
+        if (existing) return existing;
+      }
+
+      // A committed metadata row without its initial AgentRun is a recoverable
+      // crash boundary. Revalidate admission after the lookup: the parent or
+      // caller may have settled while durable state was being inspected.
+      try {
+        const latestParentRun = await this.deps.runStore.readRun(
+          parentSessionId,
+          input.spawnedBy.parentRunId,
+        );
+        this.assertActiveParentRun(parentSessionId, latestParentRun, input.spawnedBy.parentTurnId);
+        if (input.abortSignal?.aborted) {
+          throw new Error('Child session spawn was cancelled before its first run');
+        }
+      } catch (error) {
+        await this.updateStatus(child.id, 'aborted').catch(() => {});
+        throw error;
+      }
+
+      const startedAt = this.deps.now();
+      const summary = new ChildAgentSummaryAccumulator();
+      let aborted = false;
+      let stopPromise: Promise<void> | undefined;
+      const identity = { sessionId: child.id, turnId, runId };
+      const execution = this.consumeLinkedRootExecution(
+        {
+          ...identity,
+          userMessageId: this.deps.newId(),
+          execution: {
+            kind: 'linked_child_initial',
+            agentId: snapshot.agentId,
+            agentName: snapshot.agentName,
+          },
+          content: { text: input.prompt },
+          start: ({ runId: admittedRunId, userMessageId, onRunStarted }) =>
+            this.sendMessage(
+              child.id,
+              {
+                turnId,
+                text: input.prompt,
+                agentId: snapshot.agentId,
+                agentName: snapshot.agentName,
+              },
+              {
+                runId: admittedRunId,
+                ...(userMessageId ? { userMessageId } : {}),
+                durability: 'required',
+                onRunStarted,
+              },
+            ),
+          onReady: notifyReady,
+          onEvent: (event) => {
+            summary.add(event);
+            try {
+              input.onEvent?.(event);
+            } catch {
+              // A presentation observer must not change the child run outcome.
+            }
+          },
+        },
+        true,
+      );
+      const onAbort = () => {
+        aborted = true;
+        stopPromise ??= this.stopLinkedRoot(identity, { source: 'stop_button' });
+      };
+      if (input.abortSignal) {
+        input.abortSignal.addEventListener('abort', onAbort, { once: true });
+        if (input.abortSignal.aborted) onAbort();
+      }
+      try {
+        await execution;
+      } finally {
+        input.abortSignal?.removeEventListener('abort', onAbort);
+        if (aborted) await stopPromise;
+      }
+
+      const completedAt = this.deps.now();
+      const run = await this.findRunByTurnId(child.id, turnId);
+      const failureClass = run?.failureClass ?? summary.failureClass;
+      const artifacts = this.deps.listArtifactsForTurn
+        ? await this.deps.listArtifactsForTurn(child.id, turnId)
+        : [];
+      return {
+        childSessionId: child.id,
+        agentId: snapshot.agentId,
+        agentName: snapshot.agentName,
+        profile: snapshot.profile,
+        turnId,
+        runId,
+        status: run ? agentRunStatusForSpawnResult(run.status) : summary.status(aborted),
+        permissionMode: child.permissionMode,
+        summary: summary.text(),
+        artifactIds: artifacts.map((artifact) => artifact.id),
+        startedAt,
+        completedAt,
+        durationMs: Math.max(0, completedAt - startedAt),
+        eventCount: summary.eventCount,
+        ...(failureClass ? { failureClass } : {}),
+      };
+    } finally {
+      releaseHostedExecution();
+    }
   }
 
   private async resolveExistingChildSpawn(
@@ -1946,6 +1979,17 @@ export class SessionManager {
       throw new Error('Child AgentRun resume requires AgentRunStore and RuntimeEventStore');
     }
     const execution = await this.resolveChildAgentExecution(sessionId, sourceRunId);
+    return await this.prepareChildAgentResumeForExecution(sessionId, execution, sourceRunId);
+  }
+
+  private async prepareChildAgentResumeForExecution(
+    sessionId: string,
+    execution: SubagentExecutionRef,
+    sourceRunId: string,
+  ): Promise<PrepareChildAgentResumeResult> {
+    if (!this.deps.runStore || !this.deps.runtimeEventStore) {
+      throw new Error('Child AgentRun resume requires AgentRunStore and RuntimeEventStore');
+    }
     if (execution.kind === 'child_session') {
       return await this.prepareLinkedChildSessionResume(sessionId, execution, sourceRunId);
     }
@@ -2011,7 +2055,7 @@ export class SessionManager {
         throw new Error(`Child AgentRun resume source ${cursor.runId} is not in a resumable state`);
       }
 
-      const previousRunId = cursor.resumedFromRunId;
+      const previousRunId = cursor.resumedFromRunId ?? cursor.retriedFromRunId;
       if (!previousRunId) break;
       cursor = runsById.get(previousRunId);
       if (!cursor) {
@@ -2019,9 +2063,7 @@ export class SessionManager {
       }
     }
 
-    if (runs.some((run) => run.resumedFromRunId === sourceRunId)) {
-      throw new Error(`Child AgentRun ${sourceRunId} already has a resume successor`);
-    }
+    this.assertChildRunHasNoSuccessor(runs, sourceRunId);
     return {
       sourceRunId,
       execution,
@@ -2162,9 +2204,7 @@ export class SessionManager {
     if (!first || first.kind !== 'text' || first.role !== 'user') {
       throw new Error(`Child AgentRun resume source ${sourceRunId} has no user-anchored history`);
     }
-    if (runs.some((run) => run.resumedFromRunId === sourceRunId)) {
-      throw new Error(`Child AgentRun ${sourceRunId} already has a resume successor`);
-    }
+    this.assertChildRunHasNoSuccessor(runs, sourceRunId);
     return {
       sourceRunId,
       execution,
@@ -2178,10 +2218,29 @@ export class SessionManager {
     sessionId: string,
     input: ResumeChildAgentInput,
   ): Promise<SpawnChildAgentResult> {
-    const prepared = await this.prepareChildAgentResume(sessionId, input.sourceRunId);
-    if (prepared.execution.kind === 'child_session') {
-      return await this.resumeLinkedChildSession(sessionId, prepared.execution, prepared, input);
+    throwIfChildExecutionAborted(
+      input.abortSignal,
+      'Child agent resume was cancelled before start',
+    );
+    const execution = await this.resolveChildAgentExecution(sessionId, input.sourceRunId);
+    if (execution.kind === 'child_session') {
+      const releaseHostedExecution = this.acquireHostedLinkedChildExecution(execution.sessionId);
+      try {
+        const prepared = await this.prepareChildAgentResumeForExecution(
+          sessionId,
+          execution,
+          input.sourceRunId,
+        );
+        return await this.resumeLinkedChildSession(sessionId, execution, prepared, input, true);
+      } finally {
+        releaseHostedExecution();
+      }
     }
+    const prepared = await this.prepareChildAgentResumeForExecution(
+      sessionId,
+      execution,
+      input.sourceRunId,
+    );
     const definition = getBuiltinAgentDefinition(prepared.agentId)!;
     return await this.runChildAgent(sessionId, definition, input, input.sourceRunId);
   }
@@ -2191,7 +2250,12 @@ export class SessionManager {
     execution: Extract<SubagentExecutionRef, { kind: 'child_session' }>,
     prepared: PrepareChildAgentResumeResult,
     input: ResumeChildAgentInput,
+    hostedGateAlreadyHeld: boolean,
   ): Promise<SpawnChildAgentResult> {
+    throwIfChildExecutionAborted(
+      input.abortSignal,
+      'Child agent resume was cancelled before start',
+    );
     if (!this.deps.runStore) {
       throw new Error('Child Session resume requires AgentRunStore');
     }
@@ -2214,19 +2278,40 @@ export class SessionManager {
     const summary = new ChildAgentSummaryAccumulator();
     let aborted = input.abortSignal?.aborted === true;
     let stopPromise: Promise<void> | undefined;
-    const iterator = this.sendMessage(
-      child.id,
+    const identity = { sessionId: child.id, turnId, runId };
+    throwIfChildExecutionAborted(
+      input.abortSignal,
+      'Child agent resume was cancelled before start',
+    );
+    const executionPromise = this.consumeLinkedRootExecution(
       {
-        turnId,
-        text: input.prompt,
-        resumedFromRunId: input.sourceRunId,
-        agentId: prepared.agentId,
-        agentName: prepared.agentName,
-      },
-      {
-        runId,
-        durability: 'required',
-        onRunStarted: () =>
+        ...identity,
+        userMessageId: this.deps.newId(),
+        execution: {
+          kind: 'linked_child_resume',
+          agentId: prepared.agentId,
+          agentName: prepared.agentName,
+          sourceRunId: input.sourceRunId,
+        },
+        content: { text: input.prompt },
+        start: ({ runId: admittedRunId, userMessageId, onRunStarted }) =>
+          this.sendMessage(
+            child.id,
+            {
+              turnId,
+              text: input.prompt,
+              resumedFromRunId: input.sourceRunId,
+              agentId: prepared.agentId,
+              agentName: prepared.agentName,
+            },
+            {
+              runId: admittedRunId,
+              ...(userMessageId ? { userMessageId } : {}),
+              durability: 'required',
+              onRunStarted,
+            },
+          ),
+        onReady: () =>
           input.onReady?.({
             childSessionId: child.id,
             turnId,
@@ -2234,34 +2319,30 @@ export class SessionManager {
             agentId: prepared.agentId,
             agentName: prepared.agentName,
           }),
+        onEvent: (event) => {
+          summary.add(event);
+          try {
+            input.onEvent?.(event);
+          } catch {
+            // A presentation observer must not change the child run outcome.
+          }
+        },
       },
-    )[Symbol.asyncIterator]();
+      hostedGateAlreadyHeld,
+    );
     const onAbort = () => {
       aborted = true;
-      stopPromise ??= this.stopSession(child.id, { source: 'stop_button' });
+      stopPromise ??= this.stopLinkedRoot(identity, { source: 'stop_button' });
     };
     if (input.abortSignal) {
       input.abortSignal.addEventListener('abort', onAbort, { once: true });
       if (input.abortSignal.aborted) onAbort();
     }
     try {
-      while (!aborted) {
-        const next = await iterator.next();
-        if (next.done) break;
-        summary.add(next.value);
-        try {
-          input.onEvent?.(next.value);
-        } catch {
-          // A presentation observer must not change the child run outcome.
-        }
-        if (aborted) break;
-      }
+      await executionPromise;
     } finally {
       input.abortSignal?.removeEventListener('abort', onAbort);
-      if (aborted) {
-        await stopPromise;
-        await iterator.return?.();
-      }
+      if (aborted) await stopPromise;
     }
 
     const completedAt = this.deps.now();
@@ -2295,6 +2376,10 @@ export class SessionManager {
     input: SpawnChildAgentInput | ResumeChildAgentInput,
     resumedFromRunId?: string,
   ): Promise<SpawnChildAgentResult> {
+    throwIfChildExecutionAborted(
+      input.abortSignal,
+      'Child agent execution was cancelled before start',
+    );
     const turnId = input.turnId ?? this.deps.newId();
     const startedAt = this.deps.now();
     const summary = new ChildAgentSummaryAccumulator();
@@ -2362,10 +2447,31 @@ export class SessionManager {
     sessionId: string,
     input: RetryChildAgentInput,
   ): Promise<SpawnChildAgentResult> {
+    throwIfChildExecutionAborted(input.abortSignal, 'Child agent retry was cancelled before start');
     if (!this.deps.runStore || !this.deps.runtimeEventStore) {
       throw new Error('Child agent retry requires AgentRunStore and RuntimeEventStore');
     }
     const execution = await this.resolveChildAgentExecution(sessionId, input.sourceRunId);
+    const releaseHostedExecution =
+      execution.kind === 'child_session'
+        ? this.acquireHostedLinkedChildExecution(execution.sessionId)
+        : () => {};
+    try {
+      return await this.retryChildAgentWithExecution(sessionId, input, execution);
+    } finally {
+      releaseHostedExecution();
+    }
+  }
+
+  private async retryChildAgentWithExecution(
+    sessionId: string,
+    input: RetryChildAgentInput,
+    execution: SubagentExecutionRef,
+  ): Promise<SpawnChildAgentResult> {
+    throwIfChildExecutionAborted(input.abortSignal, 'Child agent retry was cancelled before start');
+    if (!this.deps.runStore || !this.deps.runtimeEventStore) {
+      throw new Error('Child agent retry requires AgentRunStore and RuntimeEventStore');
+    }
     if (
       input.execution &&
       (input.execution.kind !== execution.kind ||
@@ -2421,10 +2527,7 @@ export class SessionManager {
     if (sourceRun.status !== 'failed' || sourceRun.failureClass !== 'RateLimit') {
       throw new Error('Child agent retry source must be a provider rate-limit failure');
     }
-    const existingRetry = runs.find((run) => run.retriedFromRunId === sourceRun.runId);
-    if (existingRetry) {
-      throw new Error(`Child agent retry source already has a successor: ${existingRetry.runId}`);
-    }
+    this.assertChildRunHasNoSuccessor(runs, sourceRun.runId);
 
     const replaySegments: RuntimeEvent[][] = [];
     let chainRun: AgentRunHeader | undefined = rawSourceRun;
@@ -2459,6 +2562,11 @@ export class SessionManager {
     }
     const sourceInvocationId = sourceRun.invocationId ?? sourceEvents[0]?.invocationId;
     if (!sourceInvocationId) throw new Error('Child agent retry source has no invocation id');
+    const retryReplay = buildRuntimeEventModelReplayPlan(replaySegments.flat());
+    const retryAnchor = retryReplay.items[0];
+    if (!retryAnchor || retryAnchor.kind !== 'text' || retryAnchor.role !== 'user') {
+      throw new Error('Child agent retry source has no user-anchored history');
+    }
     const turnId = this.deps.newId();
     const runId = this.deps.newId();
     const invocationId = this.deps.newId();
@@ -2483,33 +2591,82 @@ export class SessionManager {
     const startedAt = this.deps.now();
     const summary = new ChildAgentSummaryAccumulator();
     let aborted = input.abortSignal?.aborted === true;
-    await input.onReady?.({
-      ...(execution.kind === 'child_session' ? { childSessionId: execution.sessionId, runId } : {}),
-      turnId,
-      agentId: definition.id,
-      agentName: definition.name,
-    });
     const startChildRetry = this.runtimeKernel.startChildRetry;
     if (!startChildRetry) throw new Error('RuntimeKernel does not support child agent retry');
-    const iterator = startChildRetry
-      .call(this.runtimeKernel, targetSessionId, {
-        parentRunId: input.parentRunId,
-        spec: {
-          id: definition.id,
-          name: definition.name,
-          systemPrompt: definition.systemPrompt,
-        },
-        continuation,
-        ...(execution.kind === 'child_session' ? { linkedSession: true } : {}),
-      })
-      [Symbol.asyncIterator]();
+    const linkedIdentity = { sessionId: targetSessionId, turnId, runId };
+    const emitReady = () =>
+      input.onReady?.({
+        ...(execution.kind === 'child_session'
+          ? { childSessionId: execution.sessionId, runId }
+          : {}),
+        turnId,
+        agentId: definition.id,
+        agentName: definition.name,
+      });
+    const consumeEvent = (event: SessionEvent) => {
+      summary.add(event);
+      try {
+        input.onEvent?.(event);
+      } catch {
+        // A presentation observer must not change the child run outcome.
+      }
+    };
+    throwIfChildExecutionAborted(input.abortSignal, 'Child agent retry was cancelled before start');
+    const executionPromise =
+      execution.kind === 'child_session'
+        ? this.consumeLinkedRootExecution(
+            {
+              ...linkedIdentity,
+              userMessageId: null,
+              execution: {
+                kind: 'linked_child_provider_retry',
+                agentId: definition.id,
+                agentName: definition.name,
+                sourceRunId: sourceRun.runId,
+              },
+              content: {
+                text: retryAnchor.content,
+                ...(retryAnchor.attachments ? { attachments: retryAnchor.attachments } : {}),
+              },
+              start: ({ onRunStarted }) =>
+                startChildRetry.call(this.runtimeKernel, targetSessionId, {
+                  parentRunId: input.parentRunId,
+                  spec: {
+                    id: definition.id,
+                    name: definition.name,
+                    systemPrompt: definition.systemPrompt,
+                  },
+                  continuation,
+                  linkedSession: true,
+                  onRunStarted,
+                }),
+              onReady: emitReady,
+              onEvent: consumeEvent,
+            },
+            true,
+          )
+        : this.consumeRuntimeEvents(
+            startChildRetry.call(this.runtimeKernel, targetSessionId, {
+              parentRunId: input.parentRunId,
+              spec: {
+                id: definition.id,
+                name: definition.name,
+                systemPrompt: definition.systemPrompt,
+              },
+              continuation,
+            }),
+            emitReady,
+            consumeEvent,
+          );
     let stopPromise: Promise<void> | undefined;
     const onAbort = () => {
       aborted = true;
       if (execution.kind === 'child_session') {
-        stopPromise ??= this.stopSession(targetSessionId, { source: 'stop_button' });
+        stopPromise ??= this.stopLinkedRoot(linkedIdentity, { source: 'stop_button' });
       } else {
-        void iterator.return?.();
+        stopPromise ??= this.runtimeKernel.stopSession(targetSessionId, {
+          source: 'stop_button',
+        });
       }
     };
     if (input.abortSignal) {
@@ -2517,22 +2674,10 @@ export class SessionManager {
       if (input.abortSignal.aborted) onAbort();
     }
     try {
-      while (!aborted) {
-        const next = await iterator.next();
-        if (next.done) break;
-        summary.add(next.value);
-        try {
-          input.onEvent?.(next.value);
-        } catch {
-          // A presentation observer must not change the child run outcome.
-        }
-      }
+      await executionPromise;
     } finally {
       input.abortSignal?.removeEventListener('abort', onAbort);
-      if (aborted) {
-        await stopPromise;
-        await iterator.return?.();
-      }
+      if (aborted) await stopPromise;
     }
 
     const completedAt = this.deps.now();
@@ -2558,6 +2703,16 @@ export class SessionManager {
       eventCount: summary.eventCount,
       ...(failureClass ? { failureClass } : {}),
     };
+  }
+
+  private assertChildRunHasNoSuccessor(runs: readonly AgentRunHeader[], sourceRunId: string): void {
+    if (
+      runs.some(
+        (run) => run.resumedFromRunId === sourceRunId || run.retriedFromRunId === sourceRunId,
+      )
+    ) {
+      throw new Error(`Child AgentRun ${sourceRunId} already has a successor`);
+    }
   }
 
   async listChildAgents(sessionId: string): Promise<AgentListResult> {
@@ -2708,7 +2863,12 @@ export class SessionManager {
   }
 
   async stopSession(sessionId: string, input: StopSessionInput = {}): Promise<void> {
-    const ownStop = this.runtimeKernel.stopSession(sessionId, input);
+    const hostedAuthority = isRuntimeHostedRootAuthority(this.deps.messageAuthority)
+      ? this.deps.messageAuthority
+      : undefined;
+    const ownStop = hostedAuthority
+      ? hostedAuthority.stopSession(sessionId, input)
+      : this.runtimeKernel.stopSession(sessionId, input);
     let childStops: PromiseSettledResult<void>[] = [];
     let childLookupError: unknown;
     try {
@@ -2716,7 +2876,11 @@ export class SessionManager {
       childStops = await Promise.allSettled(
         children
           .filter((child) => child.subagentParent?.lifecycle === 'foreground')
-          .map((child) => this.runtimeKernel.stopSession(child.id, input)),
+          .map((child) =>
+            hostedAuthority
+              ? hostedAuthority.stopSession(child.id, input)
+              : this.runtimeKernel.stopSession(child.id, input),
+          ),
       );
     } catch (error) {
       childLookupError = error;
@@ -2727,6 +2891,195 @@ export class SessionManager {
     )?.reason;
     if (childLookupError !== undefined) throw childLookupError;
     if (childStopError !== undefined) throw childStopError;
+  }
+
+  async deliverHostedRootStop(sessionId: string, input: StopSessionInput = {}): Promise<void> {
+    const ownStop = this.runtimeKernel.stopSession(sessionId, input);
+    const authority = isRuntimeHostedRootAuthority(this.deps.messageAuthority)
+      ? this.deps.messageAuthority
+      : undefined;
+    let childStops: PromiseSettledResult<void>[] = [];
+    let childLookupError: unknown;
+    try {
+      const children = await this.listChildSessions(sessionId);
+      childStops = await Promise.allSettled(
+        children
+          .filter((child) => child.subagentParent?.lifecycle === 'foreground')
+          .map((child) =>
+            authority
+              ? authority.stopSession(child.id, input)
+              : this.runtimeKernel.stopSession(child.id, input),
+          ),
+      );
+    } catch (error) {
+      childLookupError = error;
+    }
+    await ownStop;
+    const childStopError = childStops.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    )?.reason;
+    if (childLookupError !== undefined) throw childLookupError;
+    if (childStopError !== undefined) throw childStopError;
+  }
+
+  async closePendingHostedLinkedChildAdmission(input: {
+    sessionId: string;
+    turnId: string;
+    runId: string;
+    admittedAt: number;
+    execution: Exclude<RootExecutionDescriptor, { kind: 'external_message' }>;
+  }): Promise<void> {
+    if (!this.deps.runStore || !this.deps.runtimeEventStore) {
+      throw new Error('Linked child admission recovery requires execution stores');
+    }
+    const session = await this.deps.store.readHeader(input.sessionId);
+    if (
+      session.subagentParent?.kind !== 'subagent' ||
+      session.subagentRuntime?.agentId !== input.execution.agentId ||
+      session.subagentRuntime.agentName !== input.execution.agentName
+    ) {
+      throw new Error(
+        `Admitted Turn ${input.turnId} does not match its linked child Session identity`,
+      );
+    }
+
+    let workspaceIdentity: string | undefined;
+    if (input.execution.kind !== 'linked_child_initial') {
+      const sourceRun = await this.deps.runStore.readRun(
+        input.sessionId,
+        input.execution.sourceRunId,
+      );
+      if (
+        sourceRun.agentId !== input.execution.agentId ||
+        sourceRun.agentName !== input.execution.agentName
+      ) {
+        throw new Error(`Admitted Turn ${input.turnId} source changed its trusted agent identity`);
+      }
+      workspaceIdentity = sourceRun.workspaceIdentity;
+    }
+
+    const run: AgentRunHeader = {
+      runId: input.runId,
+      invocationId: input.runId,
+      sessionId: input.sessionId,
+      turnId: input.turnId,
+      status: 'created',
+      backendKind: session.backend,
+      llmConnectionSlug: session.llmConnectionSlug,
+      modelId: session.model,
+      cwd: session.cwd,
+      ...(workspaceIdentity !== undefined ? { workspaceIdentity } : {}),
+      permissionMode: session.permissionMode,
+      collaborationMode: session.collaborationMode ?? 'agent',
+      createdAt: input.admittedAt,
+      updatedAt: input.admittedAt,
+      ...(input.execution.kind === 'linked_child_resume'
+        ? { resumedFromRunId: input.execution.sourceRunId }
+        : {}),
+      ...(input.execution.kind === 'linked_child_provider_retry'
+        ? { retriedFromRunId: input.execution.sourceRunId }
+        : {}),
+      agentId: input.execution.agentId,
+      agentName: input.execution.agentName,
+    };
+    await this.deps.runStore.createRun(run, { durable: true });
+
+    const ts = this.deps.now();
+    const recoveryReason = 'child_internal_admission_without_run';
+    const terminalEvent = buildRecoveredTerminalRuntimeEvent({
+      id: this.deps.newId(),
+      run,
+      status: 'failed',
+      ts,
+      failureClass: 'app_restarted',
+      recoveryReason,
+      diagnostic: {
+        executionKind: input.execution.kind,
+        ...(input.execution.kind === 'linked_child_initial'
+          ? {}
+          : { sourceRunId: input.execution.sourceRunId }),
+      },
+      message: 'app_restarted',
+    });
+    await commitTerminalRunWithRuntimeFact({
+      runStore: this.deps.runStore,
+      runtimeEventStore: this.deps.runtimeEventStore,
+      newId: this.deps.newId,
+      sessionId: input.sessionId,
+      runId: input.runId,
+      turnId: input.turnId,
+      status: 'failed',
+      ts,
+      terminalEvent,
+      failureClass: 'app_restarted',
+      runEventData: {
+        recovered: true,
+        recoveryReason,
+        executionKind: input.execution.kind,
+      },
+      existingEvents: [],
+    });
+  }
+
+  private async consumeLinkedRootExecution(
+    input: RuntimeHostedRootExecutionInput,
+    hostedGateAlreadyHeld = false,
+  ): Promise<void> {
+    const authority = isRuntimeHostedRootAuthority(this.deps.messageAuthority)
+      ? this.deps.messageAuthority
+      : undefined;
+    if (authority) {
+      const release = hostedGateAlreadyHeld
+        ? undefined
+        : this.acquireHostedLinkedChildExecution(input.sessionId);
+      try {
+        await authority.executeRoot(input);
+        return;
+      } finally {
+        release?.();
+      }
+    }
+    await this.consumeRuntimeEvents(
+      input.start({
+        runId: input.runId,
+        userMessageId: input.userMessageId,
+        onRunStarted: () => input.onReady?.(),
+      }),
+      undefined,
+      input.onEvent,
+    );
+  }
+
+  private acquireHostedLinkedChildExecution(sessionId: string): () => void {
+    if (!isRuntimeHostedRootAuthority(this.deps.messageAuthority)) return () => {};
+    if (this.activeHostedLinkedChildSessions.has(sessionId)) {
+      throw new Error(`Child Session ${sessionId} already has an active execution`);
+    }
+    this.activeHostedLinkedChildSessions.add(sessionId);
+    return () => {
+      this.activeHostedLinkedChildSessions.delete(sessionId);
+    };
+  }
+
+  private async consumeRuntimeEvents(
+    events: AsyncIterable<SessionEvent>,
+    onReady?: () => void | Promise<void>,
+    onEvent?: (event: SessionEvent) => void,
+  ): Promise<void> {
+    await onReady?.();
+    for await (const event of events) onEvent?.(event);
+  }
+
+  private stopLinkedRoot(
+    identity: RuntimeMessageRunIdentity,
+    input: StopSessionInput,
+  ): Promise<void> {
+    const authority = isRuntimeHostedRootAuthority(this.deps.messageAuthority)
+      ? this.deps.messageAuthority
+      : undefined;
+    return authority
+      ? authority.stopRoot(identity, input)
+      : this.runtimeKernel.stopSession(identity.sessionId, input);
   }
 
   /** Queue a user message for mid-turn injection at the next step boundary. */
@@ -3894,6 +4247,11 @@ function normalizeAgentOutputMaxEvents(value: number | undefined): number {
 function tail<T>(items: readonly T[], max: number): T[] {
   if (items.length <= max) return [...items];
   return items.slice(items.length - max);
+}
+
+function throwIfChildExecutionAborted(signal: AbortSignal | undefined, message: string): void {
+  if (!signal?.aborted) return;
+  throw Object.assign(new Error(message), { name: 'AbortError' });
 }
 
 // Re-export the suppressed-unused types so this file is the canonical home

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -1,10 +1,16 @@
-import { mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, it } from 'node:test';
+import { isDeepStrictEqual } from 'node:util';
 import assert from 'node:assert/strict';
 import { createAgentRunStore, createRuntimeEventStore } from '../agent-run-store.js';
-import type { AgentRunEvent, AgentRunHeader, RuntimeEvent } from '@maka/core';
+import {
+  DurableStoreWriteError,
+  type AgentRunEvent,
+  type AgentRunHeader,
+  type RuntimeEvent,
+} from '@maka/core';
 
 describe('AgentRunStore', () => {
   it('creates, reads, updates, and lists runs under a session', async () => {
@@ -1192,6 +1198,139 @@ describe('AgentRunStore', () => {
         events.map((event) => event.id),
         ['runtime-1', 'runtime-2'],
       );
+    });
+  });
+
+  it('preflights durable steering identity before append and repairs a missing proof', async () => {
+    await withStores(async (runStore, runtimeEventStore, root) => {
+      await runStore.createRun(makeHeader());
+      await runStore.createRun(makeHeader({ runId: 'run-2', turnId: 'turn-2' }));
+      const steering = makeRuntimeEvent({
+        id: 'runtime-steering',
+        content: { kind: 'text', text: 'original steering', steering: true },
+        refs: { providerEventId: 'message-steering' },
+      });
+
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', steering);
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', steering);
+      assert.deepEqual(await runtimeEventStore.readImmutableRuntimeEvents('session-1', 'run-1'), [
+        steering,
+      ]);
+
+      await rm(
+        join(root, 'sessions', 'session-1', 'message-proofs', 'steering', 'message-steering.json'),
+      );
+      const reopened = createRuntimeEventStore(root);
+      await reopened.repairImmutableSteeringMessageProofsForRecovery('session-1');
+      await reopened.appendRuntimeEvent('session-1', 'run-1', steering);
+
+      const conflicting = makeRuntimeEvent({
+        ...steering,
+        id: 'runtime-conflicting-steering',
+        runId: 'run-2',
+        turnId: 'turn-2',
+        content: { kind: 'text', text: 'conflicting steering', steering: true },
+      });
+      await assert.rejects(
+        () => reopened.appendRuntimeEvent('session-1', 'run-2', conflicting),
+        /Immutable steering message identity conflict: message-steering/,
+      );
+
+      const recovered = createRuntimeEventStore(root);
+      await recovered.repairImmutableSteeringMessageProofsForRecovery('session-1');
+      assert.deepEqual(
+        await recovered.readImmutableSteeringMessageProof('session-1', 'message-steering'),
+        { event: steering },
+      );
+      assert.deepEqual(await recovered.readImmutableRuntimeEvents('session-1', 'run-1'), [
+        steering,
+      ]);
+      assert.deepEqual(await recovered.readImmutableRuntimeEvents('session-1', 'run-2'), []);
+    });
+  });
+
+  it('reports a durable canonical steering event when proof publication fails', async () => {
+    await withStores(async (runStore, runtimeEventStore, root) => {
+      await runStore.createRun(makeHeader());
+      const steering = makeRuntimeEvent({
+        id: 'runtime-steering',
+        content: { kind: 'text', text: 'persisted before proof', steering: true },
+        refs: { providerEventId: 'message-steering' },
+      });
+      const proofDirectory = join(root, 'sessions', 'session-1', 'message-proofs', 'steering');
+      await mkdir(proofDirectory, { recursive: true });
+      await chmod(proofDirectory, 0o500);
+
+      await assert.rejects(
+        () => runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', steering),
+        (error: unknown) => {
+          assert.ok(error instanceof Error);
+          assert.equal(error.name, 'RuntimeEventPostEffectError');
+          assert.match(error.message, /RuntimeEvent runtime-steering is durable/);
+          assert.ok(!(error instanceof DurableStoreWriteError));
+          assert.ok(error.cause instanceof DurableStoreWriteError);
+          return true;
+        },
+      );
+      assert.deepEqual(await runtimeEventStore.readImmutableRuntimeEvents('session-1', 'run-1'), [
+        steering,
+      ]);
+
+      await chmod(proofDirectory, 0o700);
+      await rm(proofDirectory, { recursive: true });
+      const recovered = createRuntimeEventStore(root);
+      await recovered.repairImmutableSteeringMessageProofsForRecovery('session-1');
+
+      assert.deepEqual(
+        await recovered.readImmutableSteeringMessageProof('session-1', 'message-steering'),
+        { event: steering },
+      );
+      assert.deepEqual(await recovered.readImmutableRuntimeEvents('session-1', 'run-1'), [
+        steering,
+      ]);
+    });
+  });
+
+  it('linearizes competing steering identities across runs in one session', async () => {
+    await withStores(async (runStore, runtimeEventStore, root) => {
+      await runStore.createRun(makeHeader());
+      await runStore.createRun(makeHeader({ runId: 'run-2', turnId: 'turn-2' }));
+      const candidates = [
+        makeRuntimeEvent({
+          id: 'runtime-steering-1',
+          content: { kind: 'text', text: 'first candidate', steering: true },
+          refs: { providerEventId: 'message-shared' },
+        }),
+        makeRuntimeEvent({
+          id: 'runtime-steering-2',
+          runId: 'run-2',
+          turnId: 'turn-2',
+          content: { kind: 'text', text: 'second candidate', steering: true },
+          refs: { providerEventId: 'message-shared' },
+        }),
+      ] as const;
+
+      const results = await Promise.allSettled(
+        candidates.map((event) =>
+          runtimeEventStore.appendRuntimeEvent('session-1', event.runId, event),
+        ),
+      );
+      assert.equal(results.filter((result) => result.status === 'fulfilled').length, 1);
+      assert.equal(results.filter((result) => result.status === 'rejected').length, 1);
+
+      const reopened = createRuntimeEventStore(root);
+      await reopened.repairImmutableSteeringMessageProofsForRecovery('session-1');
+      const ledger = (
+        await Promise.all(
+          ['run-1', 'run-2'].map((runId) =>
+            reopened.readImmutableRuntimeEvents('session-1', runId),
+          ),
+        )
+      ).flat();
+      const proof = await reopened.readImmutableSteeringMessageProof('session-1', 'message-shared');
+      assert.equal(ledger.length, 1);
+      assert.deepEqual(proof, { event: ledger[0] });
+      assert.ok(candidates.some((candidate) => isDeepStrictEqual(candidate, ledger[0])));
     });
   });
 });

--- a/packages/storage/src/__tests__/execution-stores.test.ts
+++ b/packages/storage/src/__tests__/execution-stores.test.ts
@@ -12,8 +12,21 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import type { AgentRunEvent, AgentRunHeader, RuntimeEvent } from '@maka/core';
-import { createAgentRunStore, ROOT_TURN_ADMISSION_SCHEMA_VERSION } from '../agent-run-store.js';
+import {
+  MAX_ATTACHMENT_BYTES,
+  MAX_ATTACHMENT_COUNT,
+  type AgentRunEvent,
+  type AgentRunHeader,
+  type AttachmentRef,
+  type QuoteRef,
+  type RuntimeEvent,
+} from '@maka/core';
+import {
+  createAgentRunStore,
+  ROOT_TURN_ADMISSION_MAX_CONTENT_BYTES,
+  ROOT_TURN_ADMISSION_MAX_RECORD_BYTES,
+  ROOT_TURN_ADMISSION_SCHEMA_VERSION,
+} from '../agent-run-store.js';
 import {
   authenticateExecutionStoresReader,
   authenticateExecutionStoresWriter,
@@ -31,6 +44,25 @@ import {
   type StorageRootLease,
 } from '../root-authority.js';
 import { createSessionStore } from '../session-store.js';
+
+const chartAttachment: AttachmentRef = {
+  kind: 'image',
+  name: 'chart.png',
+  mimeType: 'image/png',
+  bytes: 128,
+  ref: {
+    kind: 'session_file',
+    sessionId: 'session-files',
+    relativePath: 'attachments/chart.png',
+  },
+};
+const notesAttachment: AttachmentRef = {
+  kind: 'doc',
+  name: 'notes.txt',
+  mimeType: 'text/plain',
+  bytes: 64,
+  ref: { kind: 'workspace_file', relativePath: 'notes/notes.txt' },
+};
 
 describe('execution stores', () => {
   test('binds Headless execution readers and writers to Headless leases', async () => {
@@ -132,7 +164,7 @@ describe('execution stores', () => {
     });
   });
 
-  test('commits root-turn admission before Run creation and retains its original identity', async () => {
+  test('round-trips canonical root admission content and retains immutable identity', async () => {
     await withRoot(async ({ root }) => {
       const capability = await resolveStorageRoot({
         path: root,
@@ -145,16 +177,41 @@ describe('execution stores', () => {
         const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
         assert.equal(stores.kind, 'interactive');
         const session = await stores.sessionStore.create(sessionInput(root));
+        const mutableAttachment = {
+          ...chartAttachment,
+          ref: { ...chartAttachment.ref },
+        };
         const first = await stores.agentRunStore.admitRootTurn({
           sessionId: session.id,
           turnId: 'turn-1',
           proposedRunId: 'run-1',
           proposedUserMessageId: 'message-1',
+          execution: { kind: 'external_message' },
           previousRootTurnId: null,
-          normalizedInput: { text: 'hello' },
+          normalizedInput: {
+            text: '<model>hello</model>',
+            displayText: 'hello',
+            attachments: [mutableAttachment, notesAttachment],
+          },
+          sourceMessages: [
+            {
+              messageId: 'source-1',
+              content: {
+                text: '<model>hello</model>',
+                displayText: 'hello',
+                attachments: [mutableAttachment, notesAttachment],
+              },
+              placement: 'current_turn',
+              disposition: 'steering',
+            },
+          ],
           admittedAt: 10,
         });
         assert.equal(first.kind, 'admitted');
+        mutableAttachment.name = 'mutated.png';
+        assert.equal(first.admission.normalizedInput.attachments?.[0]?.name, 'chart.png');
+        assert.equal(Object.isFrozen(first.admission), true);
+        assert.equal(Object.isFrozen(first.admission.normalizedInput.attachments?.[0]?.ref), true);
         assert.deepEqual(await stores.agentRunStore.listSessionRuns(session.id), []);
 
         const retry = await stores.agentRunStore.admitRootTurn({
@@ -162,35 +219,151 @@ describe('execution stores', () => {
           turnId: 'turn-1',
           proposedRunId: 'run-never-used',
           proposedUserMessageId: 'message-never-used',
+          execution: { kind: 'external_message' },
           previousRootTurnId: null,
-          normalizedInput: { text: 'hello' },
+          normalizedInput: {
+            text: '<model>hello</model>',
+            displayText: 'hello',
+            attachments: [chartAttachment, notesAttachment],
+          },
+          sourceMessages: [
+            {
+              messageId: 'source-1',
+              content: {
+                text: '<model>hello</model>',
+                displayText: 'hello',
+                attachments: [chartAttachment, notesAttachment],
+              },
+              placement: 'current_turn',
+              disposition: 'steering',
+            },
+          ],
           admittedAt: 20,
         });
         assert.equal(retry.kind, 'existing');
         assert.equal(retry.admission.runId, 'run-1');
         assert.equal(retry.admission.userMessageId, 'message-1');
         assert.equal(retry.admission.admittedAt, 10);
-        assert.deepEqual(retry.admission.normalizedInput, { text: 'hello' });
+        assert.deepEqual(retry.admission.normalizedInput.attachments, [
+          chartAttachment,
+          notesAttachment,
+        ]);
+
+        const stored = await stores.agentRunStore.readRootTurnAdmission(session.id, 'turn-1');
+        assert.deepEqual(stored, first.admission);
+        assert.equal(Object.isFrozen(stored?.sourceMessages[0]?.content), true);
+
+        const receipt = await stores.agentRunStore.readRootTurnSourceMessageReceipt(
+          session.id,
+          'source-1',
+        );
+        assert.equal(receipt?.admission.turnId, 'turn-1');
+        assert.deepEqual(receipt?.sourceMessage, first.admission.sourceMessages[0]);
+        assert.equal(Object.isFrozen(receipt), true);
+        const rootProofPath = join(
+          root,
+          'sessions',
+          session.id,
+          'message-proofs',
+          'root',
+          'source-1.json',
+        );
+        await rm(rootProofPath);
+        assert.equal(
+          await stores.agentRunStore.readRootTurnSourceMessageReceipt(session.id, 'source-1'),
+          undefined,
+        );
+        await stores.agentRunStore.listRootTurnAdmissionsForRecovery(session.id);
+        assert.equal(
+          (await stores.agentRunStore.readRootTurnSourceMessageReceipt(session.id, 'source-1'))
+            ?.admission.turnId,
+          'turn-1',
+        );
+        const unrelatedAdmissionEntry = join(
+          root,
+          'sessions',
+          session.id,
+          'turn-admissions',
+          'not-an-admission',
+        );
+        await writeFile(unrelatedAdmissionEntry, 'unrelated');
+        assert.equal(
+          (await stores.agentRunStore.readRootTurnSourceMessageReceipt(session.id, 'source-1'))
+            ?.admission.turnId,
+          'turn-1',
+        );
+        await rm(unrelatedAdmissionEntry);
 
         const conflict = await stores.agentRunStore.admitRootTurn({
           sessionId: session.id,
           turnId: 'turn-1',
           proposedRunId: 'run-never-used',
           proposedUserMessageId: 'message-never-used',
+          execution: { kind: 'external_message' },
           previousRootTurnId: null,
-          normalizedInput: { text: 'changed' },
+          normalizedInput: {
+            text: '<model>hello</model>',
+            displayText: 'hello',
+            attachments: [notesAttachment, chartAttachment],
+          },
+          sourceMessages: [
+            {
+              messageId: 'source-1',
+              content: {
+                text: '<model>hello</model>',
+                displayText: 'hello',
+                attachments: [notesAttachment, chartAttachment],
+              },
+              placement: 'current_turn',
+              disposition: 'steering',
+            },
+          ],
           admittedAt: 30,
         });
         assert.equal(conflict.kind, 'conflict');
         assert.equal(conflict.admission.runId, 'run-1');
+
+        const dispositionConflict = await stores.agentRunStore.admitRootTurn({
+          sessionId: session.id,
+          turnId: 'turn-1',
+          proposedRunId: 'run-never-used',
+          proposedUserMessageId: 'message-never-used',
+          execution: { kind: 'linked_child_initial', agentId: 'agent', agentName: 'Agent' },
+          previousRootTurnId: null,
+          normalizedInput: {
+            text: '<model>hello</model>',
+            displayText: 'hello',
+            attachments: [chartAttachment, notesAttachment],
+          },
+          sourceMessages: [],
+          admittedAt: 35,
+        });
+        assert.equal(dispositionConflict.kind, 'conflict');
 
         const lineageConflict = await stores.agentRunStore.admitRootTurn({
           sessionId: session.id,
           turnId: 'turn-1',
           proposedRunId: 'run-never-used',
           proposedUserMessageId: 'message-never-used',
+          execution: { kind: 'external_message' },
           previousRootTurnId: 'different-predecessor',
-          normalizedInput: { text: 'hello' },
+          normalizedInput: {
+            text: '<model>hello</model>',
+            displayText: 'hello',
+            attachments: [chartAttachment, notesAttachment],
+          },
+          sourceMessages: [
+            {
+              messageId: 'source-1',
+              content: {
+                text: '<model>hello</model>',
+                displayText: 'hello',
+                attachments: [chartAttachment, notesAttachment],
+              },
+              placement: 'current_turn',
+              disposition: 'steering',
+            },
+          ],
           admittedAt: 40,
         });
         assert.equal(lineageConflict.kind, 'conflict');
@@ -219,6 +392,837 @@ describe('execution stores', () => {
     });
   });
 
+  test('durably preserves ordered quote provenance across admission and recovery', async () => {
+    await withRoot(async ({ root }) => {
+      const store = createAgentRunStore(root);
+      const expectedFirstQuote = {
+        text: 'first excerpt',
+        label: 'Assistant answer',
+        sourceTurnId: 'origin-turn-1',
+      };
+      const expectedSecondQuote = {
+        text: 'second excerpt',
+        label: 'Tool result',
+        sourceTurnId: 'origin-turn-2',
+      };
+      const mutableFirstQuote = { ...expectedFirstQuote };
+      const mutableSecondQuote = { ...expectedSecondQuote };
+      const mutableNormalizedQuotes = [mutableFirstQuote, mutableSecondQuote];
+      const mutableFirstSourceQuotes = [mutableFirstQuote];
+      const mutableSecondSourceQuotes = [mutableSecondQuote];
+      const sourceMessages = (firstQuotes: QuoteRef[], secondQuotes: QuoteRef[]) => [
+        {
+          messageId: 'source-first',
+          content: {
+            text: 'first',
+            displayText: 'First visible',
+            quotes: firstQuotes,
+          },
+          placement: 'current_turn' as const,
+          disposition: 'steering' as const,
+        },
+        {
+          messageId: 'source-second',
+          content: {
+            text: 'second',
+            quotes: secondQuotes,
+          },
+          placement: 'next_turn' as const,
+          disposition: 'followup' as const,
+        },
+      ];
+
+      const admitted = await store.admitRootTurn({
+        sessionId: 'session-quotes',
+        turnId: 'turn-1',
+        proposedRunId: 'run-1',
+        proposedUserMessageId: 'message-1',
+        execution: { kind: 'external_message' },
+        previousRootTurnId: null,
+        normalizedInput: {
+          text: 'first\n\nsecond',
+          displayText: 'First visible\n\nsecond',
+          quotes: mutableNormalizedQuotes,
+        },
+        sourceMessages: sourceMessages(mutableFirstSourceQuotes, mutableSecondSourceQuotes),
+        admittedAt: 10,
+      });
+      assert.equal(admitted.kind, 'admitted');
+
+      mutableFirstQuote.text = 'caller-mutated';
+      mutableSecondQuote.sourceTurnId = 'caller-mutated';
+      mutableNormalizedQuotes.reverse();
+      mutableFirstSourceQuotes.push({
+        text: 'late excerpt',
+        label: 'Late',
+        sourceTurnId: 'origin-turn-late',
+      });
+      mutableSecondSourceQuotes.length = 0;
+
+      assert.deepEqual(admitted.admission.normalizedInput.quotes, [
+        expectedFirstQuote,
+        expectedSecondQuote,
+      ]);
+      assert.deepEqual(admitted.admission.sourceMessages[0]?.content.quotes, [expectedFirstQuote]);
+      assert.deepEqual(admitted.admission.sourceMessages[1]?.content.quotes, [expectedSecondQuote]);
+      assert.equal(Object.isFrozen(admitted.admission.normalizedInput.quotes), true);
+      assert.equal(Object.isFrozen(admitted.admission.normalizedInput.quotes?.[0]), true);
+      assert.equal(
+        Object.isFrozen(admitted.admission.sourceMessages[0]?.content.quotes?.[0]),
+        true,
+      );
+
+      const stored = await createAgentRunStore(root).readRootTurnAdmission(
+        'session-quotes',
+        'turn-1',
+      );
+      assert.deepEqual(stored, admitted.admission);
+      assert.notEqual(stored?.normalizedInput.quotes, admitted.admission.normalizedInput.quotes);
+      assert.notEqual(
+        stored?.normalizedInput.quotes?.[0],
+        admitted.admission.normalizedInput.quotes?.[0],
+      );
+
+      await assert.rejects(
+        () =>
+          store.admitRootTurn({
+            sessionId: 'session-reversed-quotes',
+            turnId: 'turn-1',
+            proposedRunId: 'run-1',
+            proposedUserMessageId: 'message-1',
+            execution: { kind: 'external_message' },
+            previousRootTurnId: null,
+            normalizedInput: {
+              text: 'first\n\nsecond',
+              displayText: 'First visible\n\nsecond',
+              quotes: [expectedSecondQuote, expectedFirstQuote],
+            },
+            sourceMessages: sourceMessages([expectedFirstQuote], [expectedSecondQuote]),
+            admittedAt: 10,
+          }),
+        /input content does not match source messages/,
+      );
+
+      const changedFirstQuote = {
+        ...expectedFirstQuote,
+        sourceTurnId: 'origin-turn-changed',
+      };
+      const provenanceConflict = await store.admitRootTurn({
+        sessionId: 'session-quotes',
+        turnId: 'turn-1',
+        proposedRunId: 'run-never-used',
+        proposedUserMessageId: 'message-never-used',
+        execution: { kind: 'external_message' },
+        previousRootTurnId: null,
+        normalizedInput: {
+          text: 'first\n\nsecond',
+          displayText: 'First visible\n\nsecond',
+          quotes: [changedFirstQuote, expectedSecondQuote],
+        },
+        sourceMessages: sourceMessages([changedFirstQuote], [expectedSecondQuote]),
+        admittedAt: 20,
+      });
+      assert.equal(provenanceConflict.kind, 'conflict');
+
+      const proofPath = join(
+        root,
+        'sessions',
+        'session-quotes',
+        'message-proofs',
+        'root',
+        'source-first.json',
+      );
+      await rm(proofPath);
+      const restarted = createAgentRunStore(root);
+      const recovered = await restarted.listRootTurnAdmissionsForRecovery('session-quotes');
+      assert.deepEqual(recovered, [admitted.admission]);
+      const receipt = await restarted.readRootTurnSourceMessageReceipt(
+        'session-quotes',
+        'source-first',
+      );
+      assert.deepEqual(receipt?.sourceMessage.content.quotes, [expectedFirstQuote]);
+      assert.deepEqual(receipt?.admission.normalizedInput.quotes, [
+        expectedFirstQuote,
+        expectedSecondQuote,
+      ]);
+      assert.equal(Object.isFrozen(receipt?.sourceMessage.content.quotes?.[0]), true);
+    });
+  });
+
+  test('rejects invalid root admission contracts before write and when reading disk', async () => {
+    await withRoot(async ({ root }) => {
+      const store = createAgentRunStore(root);
+      const turnStartedSource = {
+        messageId: 'source-message',
+        content: { text: 'source' },
+        placement: 'current_turn' as const,
+        disposition: 'turn_started' as const,
+      };
+      const invalidContracts = [
+        {
+          name: 'external-null-message',
+          userMessageId: null,
+          execution: { kind: 'external_message' as const },
+          sourceMessages: [],
+        },
+        {
+          name: 'retry-with-message',
+          userMessageId: 'message-1',
+          execution: {
+            kind: 'linked_child_provider_retry' as const,
+            agentId: 'agent',
+            agentName: 'Agent',
+            sourceRunId: 'source-run',
+          },
+          sourceMessages: [],
+        },
+        {
+          name: 'child-with-source',
+          userMessageId: 'message-1',
+          execution: {
+            kind: 'linked_child_initial' as const,
+            agentId: 'agent',
+            agentName: 'Agent',
+          },
+          sourceMessages: [turnStartedSource],
+        },
+        {
+          name: 'resume-self-source',
+          userMessageId: 'message-1',
+          execution: {
+            kind: 'linked_child_resume' as const,
+            agentId: 'agent',
+            agentName: 'Agent',
+            sourceRunId: 'run-1',
+          },
+          sourceMessages: [],
+        },
+        {
+          name: 'retry-self-source',
+          userMessageId: null,
+          execution: {
+            kind: 'linked_child_provider_retry' as const,
+            agentId: 'agent',
+            agentName: 'Agent',
+            sourceRunId: 'run-1',
+          },
+          sourceMessages: [],
+        },
+        {
+          name: 'turn-started-owner-mismatch',
+          userMessageId: 'message-1',
+          execution: { kind: 'external_message' as const },
+          sourceMessages: [turnStartedSource],
+        },
+      ];
+
+      for (const invalid of invalidContracts) {
+        const sessionId = `session-${invalid.name}`;
+        const turnId = 'turn-1';
+        const normalizedInput =
+          invalid.sourceMessages.length > 0 ? { text: 'source' } : { text: 'input' };
+        await assert.rejects(
+          () =>
+            store.admitRootTurn({
+              sessionId,
+              turnId,
+              proposedRunId: 'run-1',
+              proposedUserMessageId: invalid.userMessageId,
+              execution: invalid.execution,
+              previousRootTurnId: null,
+              normalizedInput,
+              sourceMessages: invalid.sourceMessages,
+              admittedAt: 10,
+            }),
+          /Invalid root turn admission contract/,
+        );
+        assert.equal(await store.readRootTurnAdmission(sessionId, turnId), undefined);
+
+        const admissionRoot = join(root, 'sessions', sessionId, 'turn-admissions');
+        await mkdir(admissionRoot, { recursive: true });
+        await writeFile(
+          join(admissionRoot, `${turnId}.json`),
+          `${JSON.stringify({
+            schemaVersion: ROOT_TURN_ADMISSION_SCHEMA_VERSION,
+            sessionId,
+            turnId,
+            runId: 'run-1',
+            userMessageId: invalid.userMessageId,
+            execution: invalid.execution,
+            previousRootTurnId: null,
+            normalizedInput,
+            sourceMessages: invalid.sourceMessages,
+            admittedAt: 10,
+          })}\n`,
+        );
+        await assert.rejects(
+          () => store.readRootTurnAdmission(sessionId, turnId),
+          /Invalid root turn admission contract/,
+        );
+      }
+    });
+  });
+
+  test('treats ordered source messages as identity and fails closed on ambiguous receipts', async () => {
+    await withRoot(async ({ root }) => {
+      const store = createAgentRunStore(root);
+      const sources = [
+        {
+          messageId: 'source-steering',
+          content: { text: 'steering' },
+          placement: 'current_turn' as const,
+          disposition: 'steering' as const,
+        },
+        {
+          messageId: 'source-followup',
+          content: { text: 'followup' },
+          placement: 'next_turn' as const,
+          disposition: 'followup' as const,
+        },
+      ];
+      const base = {
+        sessionId: 'session-source-order',
+        turnId: 'turn-1',
+        proposedRunId: 'run-1',
+        proposedUserMessageId: 'message-1',
+        execution: { kind: 'external_message' },
+        previousRootTurnId: null,
+        admittedAt: 10,
+      } as const;
+      assert.equal(
+        (
+          await store.admitRootTurn({
+            ...base,
+            normalizedInput: { text: 'steering\n\nfollowup' },
+            sourceMessages: sources,
+          })
+        ).kind,
+        'admitted',
+      );
+
+      const reordered = await store.admitRootTurn({
+        ...base,
+        proposedRunId: 'unused-run',
+        proposedUserMessageId: 'unused-message',
+        normalizedInput: { text: 'followup\n\nsteering' },
+        sourceMessages: [...sources].reverse(),
+      });
+      assert.equal(reordered.kind, 'conflict');
+
+      await assert.rejects(
+        () =>
+          store.admitRootTurn({
+            ...base,
+            proposedRunId: 'unused-run',
+            proposedUserMessageId: 'unused-message',
+            normalizedInput: { text: 'steering\n\nfollowup' },
+            sourceMessages: [{ ...sources[0]! }, { ...sources[1]!, placement: 'current_turn' }],
+          }),
+        /Invalid root turn source message/,
+      );
+
+      const invalidAdmissionRoot = join(
+        root,
+        'sessions',
+        'session-invalid-followup',
+        'turn-admissions',
+      );
+      await mkdir(invalidAdmissionRoot, { recursive: true });
+      await writeFile(
+        join(invalidAdmissionRoot, 'turn-1.json'),
+        `${JSON.stringify({
+          schemaVersion: ROOT_TURN_ADMISSION_SCHEMA_VERSION,
+          sessionId: 'session-invalid-followup',
+          turnId: 'turn-1',
+          runId: 'run-1',
+          userMessageId: 'message-1',
+          execution: { kind: 'external_message' },
+          previousRootTurnId: null,
+          normalizedInput: { text: 'followup' },
+          sourceMessages: [
+            {
+              messageId: 'source-followup',
+              content: { text: 'followup' },
+              placement: 'current_turn',
+              disposition: 'followup',
+            },
+          ],
+          admittedAt: 10,
+        })}\n`,
+      );
+      await assert.rejects(
+        () => store.readRootTurnAdmission('session-invalid-followup', 'turn-1'),
+        /Invalid root turn source message/,
+      );
+
+      const startedFromNextPlacement = await store.admitRootTurn({
+        sessionId: 'session-turn-started-next',
+        turnId: 'turn-1',
+        proposedRunId: 'run-1',
+        proposedUserMessageId: 'message-1',
+        execution: { kind: 'external_message' },
+        previousRootTurnId: null,
+        normalizedInput: { text: 'started' },
+        sourceMessages: [
+          {
+            messageId: 'message-1',
+            content: { text: 'started' },
+            placement: 'next_turn',
+            disposition: 'turn_started',
+          },
+        ],
+        admittedAt: 10,
+      });
+      assert.equal(startedFromNextPlacement.kind, 'admitted');
+
+      await assert.rejects(
+        () =>
+          store.admitRootTurn({
+            ...base,
+            turnId: 'turn-2',
+            proposedRunId: 'run-2',
+            proposedUserMessageId: 'message-2',
+            execution: { kind: 'external_message' },
+            previousRootTurnId: 'turn-1',
+            normalizedInput: { text: 'followup' },
+            sourceMessages: [{ ...sources[1]! }],
+          }),
+        /Root source message identity belongs to both turn-1 and turn-2/,
+      );
+    });
+  });
+
+  test('rejects a competing source owner without publishing its Turn or partial proofs', async () => {
+    await withRoot(async ({ root }) => {
+      const store = createAgentRunStore(root);
+      const admit = (suffix: 'a' | 'b') =>
+        store.admitRootTurn({
+          sessionId: 'session-proof-conflict',
+          turnId: `turn-${suffix}`,
+          proposedRunId: `run-${suffix}`,
+          proposedUserMessageId: `message-${suffix}`,
+          execution: { kind: 'external_message' },
+          previousRootTurnId: null,
+          normalizedInput: { text: `unique-${suffix}\n\nshared` },
+          sourceMessages: [
+            {
+              messageId: `source-${suffix}`,
+              content: { text: `unique-${suffix}` },
+              placement: 'current_turn',
+              disposition: 'steering',
+            },
+            {
+              messageId: 'source-shared',
+              content: { text: 'shared' },
+              placement: 'next_turn',
+              disposition: 'followup',
+            },
+          ],
+          admittedAt: suffix === 'a' ? 10 : 20,
+        });
+
+      const settled = await Promise.allSettled([admit('a'), admit('b')]);
+      const admittedIndex = settled.findIndex(
+        (result) => result.status === 'fulfilled' && result.value.kind === 'admitted',
+      );
+      const rejectedIndex = settled.findIndex((result) => result.status === 'rejected');
+      assert.notEqual(admittedIndex, -1);
+      assert.notEqual(rejectedIndex, -1);
+      assert.match(
+        String(
+          rejectedIndex === -1
+            ? undefined
+            : (settled[rejectedIndex] as PromiseRejectedResult).reason,
+        ),
+        /Root source message identity belongs to both/,
+      );
+
+      const winner = admittedIndex === 0 ? 'a' : 'b';
+      const loser = winner === 'a' ? 'b' : 'a';
+      assert.equal(
+        await store.readRootTurnAdmission('session-proof-conflict', `turn-${loser}`),
+        undefined,
+      );
+      assert.equal(
+        await store.readRootTurnSourceMessageReceipt('session-proof-conflict', `source-${loser}`),
+        undefined,
+      );
+      assert.equal(
+        (await store.readRootTurnSourceMessageReceipt('session-proof-conflict', 'source-shared'))
+          ?.admission.turnId,
+        `turn-${winner}`,
+      );
+
+      await rm(
+        join(
+          root,
+          'sessions',
+          'session-proof-conflict',
+          'message-proofs',
+          'root',
+          `source-${winner}.json`,
+        ),
+      );
+      const restartedStore = createAgentRunStore(root);
+      const recovered =
+        await restartedStore.listRootTurnAdmissionsForRecovery('session-proof-conflict');
+      assert.deepEqual(
+        recovered.map((admission) => admission.turnId),
+        [`turn-${winner}`],
+      );
+      assert.equal(
+        (
+          await restartedStore.readRootTurnSourceMessageReceipt(
+            'session-proof-conflict',
+            `source-${winner}`,
+          )
+        )?.admission.turnId,
+        `turn-${winner}`,
+      );
+      assert.equal(
+        await restartedStore.readRootTurnSourceMessageReceipt(
+          'session-proof-conflict',
+          `source-${loser}`,
+        ),
+        undefined,
+      );
+    });
+  });
+
+  test('shares root admission serialization across writer facades from one live lease', async () => {
+    await withRoot(async ({ root }) => {
+      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+
+      let winner: 'a' | 'b' | undefined;
+      let loser: 'a' | 'b' | undefined;
+      try {
+        const [first, second] = await Promise.all([
+          openInteractiveExecutionStoresForWrite(owner.lease),
+          openInteractiveExecutionStoresForWrite(owner.lease),
+        ]);
+        const session = await first.sessionStore.create(sessionInput(root));
+        const input = (suffix: 'a' | 'b') => ({
+          sessionId: session.id,
+          turnId: `turn-${suffix}`,
+          proposedRunId: `run-${suffix}`,
+          proposedUserMessageId: `message-${suffix}`,
+          execution: { kind: 'external_message' as const },
+          previousRootTurnId: null,
+          normalizedInput: { text: `unique-${suffix}\n\nshared` },
+          sourceMessages: [
+            {
+              messageId: `source-${suffix}`,
+              content: { text: `unique-${suffix}` },
+              placement: 'current_turn' as const,
+              disposition: 'steering' as const,
+            },
+            {
+              messageId: 'source-shared',
+              content: { text: 'shared' },
+              placement: 'next_turn' as const,
+              disposition: 'followup' as const,
+            },
+          ],
+          admittedAt: suffix === 'a' ? 10 : 20,
+        });
+
+        const settled = await Promise.allSettled([
+          first.agentRunStore.admitRootTurn(input('a')),
+          second.agentRunStore.admitRootTurn(input('b')),
+        ]);
+        const admittedIndex = settled.findIndex(
+          (result) => result.status === 'fulfilled' && result.value.kind === 'admitted',
+        );
+        const rejectedIndex = settled.findIndex((result) => result.status === 'rejected');
+        assert.notEqual(admittedIndex, -1);
+        assert.notEqual(rejectedIndex, -1);
+        assert.match(
+          String(
+            rejectedIndex === -1
+              ? undefined
+              : (settled[rejectedIndex] as PromiseRejectedResult).reason,
+          ),
+          /Root source message identity belongs to both/,
+        );
+
+        winner = admittedIndex === 0 ? 'a' : 'b';
+        loser = winner === 'a' ? 'b' : 'a';
+        assert.equal(
+          await first.agentRunStore.readRootTurnAdmission(session.id, `turn-${loser}`),
+          undefined,
+        );
+        assert.equal(
+          await first.agentRunStore.readRootTurnSourceMessageReceipt(session.id, `source-${loser}`),
+          undefined,
+        );
+        assert.equal(first, second);
+
+        await rm(
+          join(root, 'sessions', session.id, 'message-proofs', 'root', `source-${winner}.json`),
+        );
+      } finally {
+        await owner.close();
+      }
+
+      assert.ok(winner);
+      assert.ok(loser);
+      const successor = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(successor);
+      if (!successor) return;
+      try {
+        const reopened = await openInteractiveExecutionStoresForWrite(successor.lease);
+        const sessions = await reopened.sessionStore.list();
+        assert.equal(sessions.length, 1);
+        const sessionId = sessions[0]!.id;
+        const recovered = await reopened.agentRunStore.listRootTurnAdmissionsForRecovery(sessionId);
+        assert.deepEqual(
+          recovered.map((admission) => admission.turnId),
+          [`turn-${winner}`],
+        );
+        assert.equal(
+          (
+            await reopened.agentRunStore.readRootTurnSourceMessageReceipt(
+              sessionId,
+              `source-${winner}`,
+            )
+          )?.admission.turnId,
+          `turn-${winner}`,
+        );
+        assert.equal(
+          await reopened.agentRunStore.readRootTurnSourceMessageReceipt(
+            sessionId,
+            `source-${loser}`,
+          ),
+          undefined,
+        );
+      } finally {
+        await successor.close();
+      }
+    });
+  });
+
+  test('round-trips only the final root admission schema v1', async () => {
+    await withRoot(async ({ root }) => {
+      const store = createAgentRunStore(root);
+      const admitted = await store.admitRootTurn({
+        sessionId: 'session-schema',
+        turnId: 'turn-1',
+        proposedRunId: 'run-1',
+        proposedUserMessageId: 'message-1',
+        execution: { kind: 'external_message' },
+        previousRootTurnId: null,
+        normalizedInput: { text: 'hello' },
+        sourceMessages: [],
+        admittedAt: 10,
+      });
+      assert.equal(admitted.kind, 'admitted');
+
+      const path = join(root, 'sessions', 'session-schema', 'turn-admissions', 'turn-1.json');
+      const v1 = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>;
+      assert.equal(v1.schemaVersion, 1);
+      assert.deepEqual(
+        await createAgentRunStore(root).readRootTurnAdmission('session-schema', 'turn-1'),
+        admitted.admission,
+      );
+
+      await writeFile(path, `${JSON.stringify({ ...v1, schemaVersion: 2 })}\n`, 'utf8');
+      const reopened = createAgentRunStore(root);
+      await assert.rejects(
+        () => reopened.readRootTurnAdmission('session-schema', 'turn-1'),
+        /Invalid root turn admission/,
+      );
+      await assert.rejects(
+        () => reopened.listRootTurnAdmissionsForRecovery('session-schema'),
+        /Invalid root turn admission/,
+      );
+    });
+  });
+
+  test('keys operation receipts by Host Epoch and discards completed Epochs', async () => {
+    await withRoot(async ({ root }) => {
+      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      try {
+        const stores = await openInteractiveExecutionStoresForWrite(owner.lease);
+        const receipt = {
+          payload: {
+            originHostEpoch: 'epoch-1',
+            sessionId: 'session-1',
+            retractId: 'retract-1',
+          },
+          result: { queueRevision: 3, retracted: [] },
+        };
+        await stores.messageReceiptStore.beginHostEpoch('epoch-1');
+        await stores.messageReceiptStore.commit(
+          'epoch-1',
+          'retract',
+          'session-1',
+          'retract-1',
+          receipt,
+        );
+        assert.deepEqual(
+          await stores.messageReceiptStore.read('epoch-1', 'retract', 'session-1', 'retract-1'),
+          receipt,
+        );
+        await assert.rejects(
+          () =>
+            stores.messageReceiptStore.commit('epoch-1', 'retract', 'session-1', 'retract-1', {
+              ...receipt,
+              result: { queueRevision: 4, retracted: [] },
+            }),
+          /identity conflict/,
+        );
+
+        await stores.messageReceiptStore.beginHostEpoch('epoch-2');
+        assert.equal(
+          await stores.messageReceiptStore.read('epoch-1', 'retract', 'session-1', 'retract-1'),
+          undefined,
+        );
+      } finally {
+        await owner.close();
+      }
+    });
+  });
+
+  test('rejects malformed and oversized admission content at the Store boundary', async () => {
+    await withRoot(async ({ root }) => {
+      const store = createAgentRunStore(root);
+      const admit = (label: string, attachment: AttachmentRef) =>
+        store.admitRootTurn({
+          sessionId: `session-${label}`,
+          turnId: 'turn-1',
+          proposedRunId: `run-${label}`,
+          proposedUserMessageId: `message-${label}`,
+          execution: { kind: 'external_message' },
+          previousRootTurnId: null,
+          normalizedInput: { text: 'content', attachments: [attachment] },
+          sourceMessages: [],
+          admittedAt: 10,
+        });
+
+      await assert.rejects(
+        () =>
+          admit('unsafe-path', {
+            ...notesAttachment,
+            ref: { kind: 'workspace_file', relativePath: '../secret' },
+          }),
+        /Invalid root turn normalized input attachment/,
+      );
+      await assert.rejects(
+        () =>
+          admit('unsafe-session', {
+            ...chartAttachment,
+            ref: {
+              kind: 'session_file',
+              sessionId: 'not/safe',
+              relativePath: 'attachments/chart.png',
+            },
+          }),
+        /Invalid root turn normalized input attachment/,
+      );
+      await assert.rejects(
+        () =>
+          admit('oversized-attachment', { ...chartAttachment, bytes: MAX_ATTACHMENT_BYTES + 1 }),
+        /Invalid root turn normalized input attachment/,
+      );
+      await assert.rejects(
+        () =>
+          store.admitRootTurn({
+            sessionId: 'session-too-many',
+            turnId: 'turn-1',
+            proposedRunId: 'run-too-many',
+            proposedUserMessageId: 'message-too-many',
+            execution: { kind: 'external_message' },
+            previousRootTurnId: null,
+            normalizedInput: {
+              text: 'content',
+              attachments: Array.from({ length: MAX_ATTACHMENT_COUNT + 1 }, () => notesAttachment),
+            },
+            sourceMessages: [],
+            admittedAt: 10,
+          }),
+        /Invalid root turn normalized input/,
+      );
+      await assert.rejects(
+        () =>
+          store.admitRootTurn({
+            sessionId: 'session-large-content',
+            turnId: 'turn-1',
+            proposedRunId: 'run-large-content',
+            proposedUserMessageId: 'message-large-content',
+            execution: { kind: 'external_message' },
+            previousRootTurnId: null,
+            normalizedInput: { text: 'x'.repeat(ROOT_TURN_ADMISSION_MAX_CONTENT_BYTES + 1) },
+            sourceMessages: [],
+            admittedAt: 10,
+          }),
+        /content exceeds size limit/,
+      );
+      await assert.rejects(
+        () =>
+          store.admitRootTurn({
+            sessionId: 'session-large-quote',
+            turnId: 'turn-1',
+            proposedRunId: 'run-large-quote',
+            proposedUserMessageId: 'message-large-quote',
+            execution: { kind: 'external_message' },
+            previousRootTurnId: null,
+            normalizedInput: {
+              text: 'content',
+              quotes: [{ text: 'q'.repeat(ROOT_TURN_ADMISSION_MAX_CONTENT_BYTES) }],
+            },
+            sourceMessages: [],
+            admittedAt: 10,
+          }),
+        /content exceeds size limit/,
+      );
+
+      const oversizedAdmissionRoot = join(
+        root,
+        'sessions',
+        'session-large-record',
+        'turn-admissions',
+      );
+      await mkdir(oversizedAdmissionRoot, { recursive: true });
+      await writeFile(
+        join(oversizedAdmissionRoot, 'turn-1.json'),
+        JSON.stringify({ padding: 'x'.repeat(ROOT_TURN_ADMISSION_MAX_RECORD_BYTES) }),
+      );
+      await assert.rejects(
+        () => store.readRootTurnAdmission('session-large-record', 'turn-1'),
+        /record exceeds size limit/,
+      );
+
+      await assert.rejects(
+        () =>
+          store.admitRootTurn({
+            sessionId: 'session-invalid-source',
+            turnId: 'turn-1',
+            proposedRunId: 'run-invalid-source',
+            proposedUserMessageId: 'message-invalid-source',
+            execution: { kind: 'external_message' },
+            previousRootTurnId: null,
+            normalizedInput: { text: 'content' },
+            sourceMessages: [
+              {
+                messageId: 'invalid/source',
+                content: { text: 'content' },
+                placement: 'current_turn',
+                disposition: 'turn_started',
+              },
+            ],
+            admittedAt: 10,
+          }),
+        /Invalid root turn source message/,
+      );
+    });
+  });
+
   test('keeps shared execution reads observational', async () => {
     await withRoot(async ({ root }) => {
       const capability = await resolveStorageRoot({
@@ -240,8 +1244,10 @@ describe('execution stores', () => {
         turnId: 'turn-1',
         proposedRunId: 'run-1',
         proposedUserMessageId: 'message-1',
+        execution: { kind: 'external_message' },
         previousRootTurnId: null,
         normalizedInput: { text: 'hello' },
+        sourceMessages: [],
         admittedAt: 9,
       });
       await rawAgentRunStore.createRun(runHeader(session.id, 'run-1'));
@@ -358,6 +1364,50 @@ describe('execution stores', () => {
           ),
           ['runtime-1'],
         );
+        const steering = {
+          ...runtimeEvent(session.id, header.runId, 'runtime-steering', 16),
+          content: { kind: 'text' as const, text: 'steer', steering: true as const },
+          refs: { providerEventId: 'message-steering' },
+        };
+        await stores.runtimeEventStore.appendRuntimeEvent(session.id, header.runId, steering);
+        assert.deepEqual(
+          await stores.runtimeEventStore.readImmutableSteeringMessageProof(
+            session.id,
+            'message-steering',
+          ),
+          { event: steering },
+        );
+        const steeringProofPath = join(
+          root,
+          'sessions',
+          session.id,
+          'message-proofs',
+          'steering',
+          'message-steering.json',
+        );
+        await rm(steeringProofPath);
+        assert.equal(
+          await stores.runtimeEventStore.readImmutableSteeringMessageProof(
+            session.id,
+            'message-steering',
+          ),
+          undefined,
+        );
+        await stores.runtimeEventStore.repairImmutableSteeringMessageProofsForRecovery(session.id);
+        assert.deepEqual(
+          await stores.runtimeEventStore.readImmutableSteeringMessageProof(
+            session.id,
+            'message-steering',
+          ),
+          { event: steering },
+        );
+        assert.equal(
+          await stores.runtimeEventStore.readImmutableSteeringMessageProof(
+            session.id,
+            'message-unknown',
+          ),
+          undefined,
+        );
 
         for (const path of [sessionPath, eventsPath, runtimeEventsPath]) {
           const lines = (await readFile(path, 'utf8')).split('\n').filter(Boolean);
@@ -448,8 +1498,10 @@ describe('execution stores', () => {
           turnId: 'turn-1',
           proposedRunId: 'run-1',
           proposedUserMessageId: 'message-1',
+          execution: { kind: 'external_message' },
           previousRootTurnId: null,
           normalizedInput: { text: 'hello' },
+          sourceMessages: [],
           admittedAt: 10,
         });
 
@@ -483,8 +1535,10 @@ describe('execution stores', () => {
         turnId: 'z-root',
         proposedRunId: 'run-root',
         proposedUserMessageId: 'message-root',
+        execution: { kind: 'external_message' },
         previousRootTurnId: null,
         normalizedInput: { text: 'root' },
+        sourceMessages: [],
         admittedAt: 100,
       });
       await store.admitRootTurn({
@@ -492,8 +1546,10 @@ describe('execution stores', () => {
         turnId: 'a-successor',
         proposedRunId: 'run-successor',
         proposedUserMessageId: 'message-successor',
+        execution: { kind: 'external_message' },
         previousRootTurnId: 'z-root',
         normalizedInput: { text: 'successor' },
+        sourceMessages: [],
         admittedAt: 100,
       });
 
@@ -572,8 +1628,10 @@ describe('execution stores', () => {
           turnId: 'turn-1',
           proposedRunId: 'run-1',
           proposedUserMessageId: 'message-1',
+          execution: { kind: 'external_message' },
           previousRootTurnId: null,
           normalizedInput: { text: 'hello' },
+          sourceMessages: [],
           admittedAt: 10,
         });
         await writeFile(
@@ -613,8 +1671,10 @@ function rootAdmissionRecord(turnId: string, previousRootTurnId: string | null) 
     turnId,
     runId: `run-${turnId}`,
     userMessageId: `message-${turnId}`,
+    execution: { kind: 'external_message' as const },
     previousRootTurnId,
     normalizedInput: { text: turnId },
+    sourceMessages: [],
     admittedAt: 100,
   };
 }

--- a/packages/storage/src/__tests__/message-receipt-store.test.ts
+++ b/packages/storage/src/__tests__/message-receipt-store.test.ts
@@ -1,0 +1,59 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { createMessageReceiptStore } from '../message-receipt-store.js';
+
+test('commit returns the detached canonical JSON snapshot written to disk', async () => {
+  await withStore(async (store) => {
+    const receipt = {
+      payload: { nested: { value: 'before' } },
+      result: { queueRevision: 1, retracted: [] },
+    };
+
+    const committing = store.commit('epoch-1', 'retract', 'session-1', 'retract-1', receipt);
+    receipt.payload.nested.value = 'after';
+    receipt.result.queueRevision = 2;
+
+    const committed = await committing;
+    assert.deepEqual(committed, {
+      payload: { nested: { value: 'before' } },
+      result: { queueRevision: 1, retracted: [] },
+    });
+    assert.deepEqual(await store.read('epoch-1', 'retract', 'session-1', 'retract-1'), committed);
+  });
+});
+
+test('commit rejects receipts that are not exactly JSON representable', async () => {
+  await withStore(async (store) => {
+    const cycle: Record<string, unknown> = {};
+    cycle.self = cycle;
+    const invalid = [
+      { label: 'undefined', payload: undefined },
+      { label: 'non-finite', payload: { value: Number.NaN } },
+      { label: 'bigint', payload: { value: 1n } },
+      { label: 'cycle', payload: cycle },
+    ];
+
+    for (const candidate of invalid) {
+      await assert.rejects(() =>
+        store.commit('epoch-1', 'submit', 'session-1', candidate.label, {
+          payload: candidate.payload,
+          result: { disposition: 'turn_started', turnId: 'turn-1' },
+        }),
+      );
+    }
+  });
+});
+
+async function withStore(
+  run: (store: ReturnType<typeof createMessageReceiptStore>) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-message-receipts-'));
+  try {
+    await run(createMessageReceiptStore(root));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/packages/storage/src/__tests__/sqlite-session-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-store.test.ts
@@ -7,11 +7,35 @@ import type { CreateSessionInput, SessionHeader } from '@maka/core';
 import {
   createLegacyFileSessionStore,
   createSessionStore,
+  isSessionNotFoundError,
+  SessionNotFoundError,
   SQLITE_SESSION_METADATA_DATABASE_NAME,
 } from '../session-store.js';
 import { createSqliteSessionMetadataStore } from '../sqlite-session-metadata-store.js';
 
 describe('default SQLite session metadata store', () => {
+  test('SQLite and legacy File stores expose one typed missing-Session boundary', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-store-not-found-'));
+    const stores = [
+      createSessionStore(join(root, 'sqlite')),
+      createLegacyFileSessionStore(join(root, 'legacy')),
+    ];
+    try {
+      for (const store of stores) {
+        await assert.rejects(store.readHeaderSnapshot('deleted-session'), (error) => {
+          assert.ok(error instanceof SessionNotFoundError);
+          assert.equal(isSessionNotFoundError(error), true);
+          assert.equal(error.code, 'session_not_found');
+          assert.equal(error.sessionId, 'deleted-session');
+          return true;
+        });
+      }
+    } finally {
+      await Promise.all(stores.map((store) => store.close?.()));
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('waits for in-flight legacy metadata import before closing SQLite', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-store-close-ready-'));
     const legacy = createLegacyFileSessionStore(root);

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -24,11 +24,19 @@ import { syncDirectory, syncDirectoryChain, syncFile } from './stable-storage.js
 import { chainWrite } from './write-queue.js';
 import {
   DurableStoreWriteError,
+  decodeMessageContent,
+  isCanonicalAttachmentRef,
   isTerminalRuntimeEvent,
+  MAX_ATTACHMENT_BYTES,
+  MAX_ATTACHMENT_COUNT,
+  messageContentsEqual,
   type AgentRunEvent,
   type AgentRunEventType,
   type AgentRunHeader,
   type AgentRunStore,
+  type AttachmentRef,
+  type MessageContent,
+  type RootExecutionDescriptor,
   type RuntimeEvent,
   type RuntimeEventStore,
 } from '@maka/core';
@@ -37,10 +45,18 @@ const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 const EXCLUSIVE_TEMP_SUFFIX_PATTERN =
   /^\d+\.[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}\.tmp$/;
 
-export const ROOT_TURN_ADMISSION_SCHEMA_VERSION = 2 as const;
+export const ROOT_TURN_ADMISSION_SCHEMA_VERSION = 1 as const;
+export const ROOT_TURN_ADMISSION_MAX_SOURCE_MESSAGES = 64;
+export const ROOT_TURN_ADMISSION_MAX_CONTENT_BYTES = 64 * 1024;
+export const ROOT_TURN_ADMISSION_MAX_RECORD_BYTES = 1024 * 1024;
+const ROOT_TURN_ADMISSION_MAX_AGGREGATED_ATTACHMENTS =
+  ROOT_TURN_ADMISSION_MAX_SOURCE_MESSAGES * MAX_ATTACHMENT_COUNT;
 
-export interface RootTurnAdmissionInput {
-  text: string;
+export interface RootTurnSourceMessage {
+  messageId: string;
+  content: MessageContent;
+  placement: 'current_turn' | 'next_turn';
+  disposition: 'steering' | 'followup' | 'turn_started';
 }
 
 export interface RootTurnAdmission {
@@ -48,9 +64,11 @@ export interface RootTurnAdmission {
   sessionId: string;
   turnId: string;
   runId: string;
-  userMessageId: string;
+  userMessageId: string | null;
+  execution: RootExecutionDescriptor;
   previousRootTurnId: string | null;
-  normalizedInput: RootTurnAdmissionInput;
+  normalizedInput: MessageContent;
+  sourceMessages: readonly RootTurnSourceMessage[];
   admittedAt: number;
 }
 
@@ -58,10 +76,21 @@ export interface AdmitRootTurnInput {
   sessionId: string;
   turnId: string;
   proposedRunId: string;
-  proposedUserMessageId: string;
+  proposedUserMessageId: string | null;
+  execution: RootExecutionDescriptor;
   previousRootTurnId: string | null;
-  normalizedInput: RootTurnAdmissionInput;
+  normalizedInput: MessageContent;
+  sourceMessages: readonly RootTurnSourceMessage[];
   admittedAt: number;
+}
+
+export interface RootTurnSourceMessageReceipt {
+  admission: RootTurnAdmission;
+  sourceMessage: RootTurnSourceMessage;
+}
+
+export interface ImmutableSteeringMessageProof {
+  event: RuntimeEvent;
 }
 
 export type AdmitRootTurnResult =
@@ -72,6 +101,10 @@ export type AdmitRootTurnResult =
 export interface RootTurnAdmissionStore {
   admitRootTurn(input: AdmitRootTurnInput): Promise<AdmitRootTurnResult>;
   readRootTurnAdmission(sessionId: string, turnId: string): Promise<RootTurnAdmission | undefined>;
+  readRootTurnSourceMessageReceipt(
+    sessionId: string,
+    sourceMessageId: string,
+  ): Promise<RootTurnSourceMessageReceipt | undefined>;
   listRootTurnAdmissionsForRecovery(sessionId: string): Promise<RootTurnAdmission[]>;
 }
 
@@ -92,12 +125,28 @@ export interface DurableAgentRunStore extends AgentRunStore, RootTurnAdmissionSt
 
 export interface DurableRuntimeEventStore extends RuntimeEventStore {
   readImmutableRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
+  readImmutableSteeringMessageProof(
+    sessionId: string,
+    messageId: string,
+  ): Promise<ImmutableSteeringMessageProof | undefined>;
+  repairImmutableSteeringMessageProofsForRecovery(sessionId: string): Promise<void>;
 }
 
 interface RuntimePartialSnapshot {
   version: 1;
   event: RuntimeEvent;
   afterEventId?: string;
+}
+
+class RuntimeEventPostEffectError extends Error {
+  readonly name = 'RuntimeEventPostEffectError';
+
+  constructor(
+    message: string,
+    readonly cause: DurableStoreWriteError,
+  ) {
+    super(message);
+  }
 }
 
 export function createAgentRunStore(workspaceRoot: string): DurableAgentRunStore {
@@ -112,6 +161,7 @@ class FileAgentRunStore implements DurableAgentRunStore {
   private readonly durabilityRoot: string;
   private readonly sessionsRoot: string;
   private readonly writeQueues = new Map<string, Promise<void>>();
+  private readonly rootTurnAdmissionWriteQueues = new Map<string, Promise<void>>();
   private readonly projectionWriteQueues = new Map<string, Promise<void>>();
 
   constructor(workspaceRoot: string) {
@@ -154,14 +204,19 @@ class FileAgentRunStore implements DurableAgentRunStore {
     assertSafeId(input.sessionId, 'Invalid session id');
     assertSafeId(input.turnId, 'Invalid turn id');
     assertSafeId(input.proposedRunId, 'Invalid run id');
-    assertSafeId(input.proposedUserMessageId, 'Invalid user message id');
+    if (input.proposedUserMessageId !== null) {
+      assertSafeId(input.proposedUserMessageId, 'Invalid user message id');
+    }
     if (input.previousRootTurnId !== null) {
       assertSafeId(input.previousRootTurnId, 'Invalid previous root turn id');
       if (input.previousRootTurnId === input.turnId) {
         throw new Error('Root turn admission cannot reference itself');
       }
     }
-    const normalizedInput = normalizeRootTurnAdmissionInput(input.normalizedInput);
+    const { normalizedInput, sourceMessages } = normalizeRootTurnAdmissionPayload(
+      input.normalizedInput,
+      input.sourceMessages,
+    );
     if (!Number.isSafeInteger(input.admittedAt) || input.admittedAt < 0) {
       throw new Error('Invalid root turn admission timestamp');
     }
@@ -171,24 +226,44 @@ class FileAgentRunStore implements DurableAgentRunStore {
       turnId: input.turnId,
       runId: input.proposedRunId,
       userMessageId: input.proposedUserMessageId,
+      execution: normalizeRootExecutionDescriptor(input.execution),
       previousRootTurnId: input.previousRootTurnId,
       normalizedInput,
+      sourceMessages,
       admittedAt: input.admittedAt,
     };
-    const path = this.rootTurnAdmissionPath(input.sessionId, input.turnId);
-    const created = await writeExclusiveAtomic(
-      path,
-      JSON.stringify(admission) + '\n',
-      { durable: true },
-      this.durabilityRoot,
-    );
-    if (created) return { kind: 'admitted', admission };
-    const existing = await this.readRootTurnAdmission(input.sessionId, input.turnId);
-    if (!existing) throw new Error(`Root turn admission disappeared: ${input.turnId}`);
-    return existing.previousRootTurnId === input.previousRootTurnId &&
-      existing.normalizedInput.text === normalizedInput.text
-      ? { kind: 'existing', admission: existing }
-      : { kind: 'conflict', admission: existing };
+    assertRootTurnAdmissionContract(admission);
+    assertRootTurnAdmissionRecordSize(admission);
+    deepFreezeRootTurnAdmission(admission);
+    let result: AdmitRootTurnResult | undefined;
+    await chainWrite(this.rootTurnAdmissionWriteQueues, input.sessionId, async () => {
+      const path = this.rootTurnAdmissionPath(input.sessionId, input.turnId);
+      let existing = await this.readRootTurnAdmission(input.sessionId, input.turnId);
+      if (!existing) {
+        await this.assertRootSourceMessageProofOwners(admission);
+        const created = await writeExclusiveAtomic(
+          path,
+          JSON.stringify(admission) + '\n',
+          { durable: true },
+          this.durabilityRoot,
+        );
+        if (created) {
+          await this.ensureRootSourceMessageProofs(admission);
+          result = { kind: 'admitted', admission };
+          return;
+        }
+        existing = await this.readRootTurnAdmission(input.sessionId, input.turnId);
+        if (!existing) throw new Error(`Root turn admission disappeared: ${input.turnId}`);
+      }
+      await this.ensureRootSourceMessageProofs(existing);
+      result =
+        existing.previousRootTurnId === input.previousRootTurnId &&
+        rootTurnAdmissionPayloadsEqual(existing, admission)
+          ? { kind: 'existing', admission: existing }
+          : { kind: 'conflict', admission: existing };
+    });
+    if (!result) throw new Error(`Root turn admission did not complete: ${input.turnId}`);
+    return result;
   }
 
   async readRootTurnAdmission(
@@ -204,7 +279,41 @@ class FileAgentRunStore implements DurableAgentRunStore {
       if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
       throw error;
     }
+    assertRootTurnAdmissionSerializedSize(raw);
     return normalizeRootTurnAdmission(JSON.parse(raw), sessionId, turnId);
+  }
+
+  async readRootTurnSourceMessageReceipt(
+    sessionId: string,
+    sourceMessageId: string,
+  ): Promise<RootTurnSourceMessageReceipt | undefined> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(sourceMessageId, 'Invalid source message id');
+    let raw: string;
+    try {
+      raw = await readFile(this.rootSourceMessageProofPath(sessionId, sourceMessageId), 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw error;
+    }
+    const pointer = decodeRootSourceMessageProofPointer(
+      JSON.parse(raw),
+      sessionId,
+      sourceMessageId,
+    );
+    const admission = await this.readRootTurnAdmission(sessionId, pointer.turnId);
+    if (!admission) {
+      throw new Error(`Root source message proof references missing Turn ${pointer.turnId}`);
+    }
+    const matching = admission.sourceMessages.filter(
+      (source) => source.messageId === sourceMessageId,
+    );
+    if (matching.length !== 1) {
+      throw new Error(
+        `Root source message proof does not identify exactly one source: ${sourceMessageId}`,
+      );
+    }
+    return Object.freeze({ admission, sourceMessage: matching[0]! });
   }
 
   async listRootTurnAdmissionsForRecovery(sessionId: string): Promise<RootTurnAdmission[]> {
@@ -236,7 +345,9 @@ class FileAgentRunStore implements DurableAgentRunStore {
       throw new Error(`Invalid root turn admission entry: ${entry.name}`);
     }
     if (removedStagingFile) await syncDirectory(admissionsRoot);
-    return orderRootTurnAdmissionChain(sessionId, admissions);
+    const ordered = orderRootTurnAdmissionChain(sessionId, admissions);
+    for (const admission of ordered) await this.ensureRootSourceMessageProofs(admission);
+    return ordered;
   }
 
   async updateRun(
@@ -524,6 +635,62 @@ class FileAgentRunStore implements DurableAgentRunStore {
     return join(this.sessionsRoot, sessionId, 'turn-admissions');
   }
 
+  private rootSourceMessageProofPath(sessionId: string, messageId: string): string {
+    return join(this.sessionsRoot, sessionId, 'message-proofs', 'root', `${messageId}.json`);
+  }
+
+  private async assertRootSourceMessageProofOwners(admission: RootTurnAdmission): Promise<void> {
+    for (const source of admission.sourceMessages) {
+      const path = this.rootSourceMessageProofPath(admission.sessionId, source.messageId);
+      let raw: string;
+      try {
+        raw = await readFile(path, 'utf8');
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw error;
+      }
+      const existing = decodeRootSourceMessageProofPointer(
+        JSON.parse(raw),
+        admission.sessionId,
+        source.messageId,
+      );
+      if (existing.turnId !== admission.turnId) {
+        throw new Error(
+          `Root source message identity belongs to both ${existing.turnId} and ${admission.turnId}`,
+        );
+      }
+    }
+  }
+
+  private async ensureRootSourceMessageProofs(admission: RootTurnAdmission): Promise<void> {
+    for (const source of admission.sourceMessages) {
+      const pointer = {
+        schemaVersion: 1,
+        sessionId: admission.sessionId,
+        messageId: source.messageId,
+        turnId: admission.turnId,
+      };
+      const path = this.rootSourceMessageProofPath(admission.sessionId, source.messageId);
+      const created = await writeExclusiveAtomic(
+        path,
+        `${JSON.stringify(pointer)}\n`,
+        { durable: true },
+        this.durabilityRoot,
+      );
+      if (created) continue;
+      const existing = decodeRootSourceMessageProofPointer(
+        JSON.parse(await readFile(path, 'utf8')),
+        admission.sessionId,
+        source.messageId,
+      );
+      if (existing.turnId !== admission.turnId) {
+        throw new Error(
+          `Root source message identity belongs to both ${existing.turnId} and ${admission.turnId}`,
+        );
+      }
+    }
+  }
+
   private async removeUncommittedRunDirectory(sessionId: string, runId: string): Promise<boolean> {
     const directory = this.runDir(sessionId, runId);
     const entries = await readdir(directory, { withFileTypes: true });
@@ -669,6 +836,7 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
   private readonly durabilityRoot: string;
   private readonly sessionsRoot: string;
   private readonly writeQueues = new Map<string, Promise<void>>();
+  private readonly immutableSteeringWriteQueues = new Map<string, Promise<void>>();
 
   constructor(workspaceRoot: string) {
     this.durabilityRoot = resolve(workspaceRoot);
@@ -683,6 +851,23 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
   ): Promise<void> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
+    const steeringMessageId = immutableSteeringMessageId(event);
+    if (steeringMessageId) {
+      await this.withImmutableSteeringQueue(sessionId, async () => {
+        if (await this.preflightImmutableSteeringMessage(event, steeringMessageId)) return;
+        await this.appendRuntimeEventForRun(sessionId, runId, event, options);
+      });
+      return;
+    }
+    await this.appendRuntimeEventForRun(sessionId, runId, event, options);
+  }
+
+  private async appendRuntimeEventForRun(
+    sessionId: string,
+    runId: string,
+    event: RuntimeEvent,
+    options: { durable?: boolean },
+  ): Promise<void> {
     await this.withQueue(sessionId, runId, async () => {
       await mkdir(this.runDir(sessionId, runId), { recursive: true });
       const partial = partialRuntimeStream(event);
@@ -720,11 +905,27 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
         }
         return;
       }
+      const steeringMessageId = immutableSteeringMessageId(event);
       await appendJsonl(
         this.runtimeEventsPath(sessionId, runId),
         JSON.stringify(event, sanitizeJson) + '\n',
-        { ...options, durabilityRoot: this.durabilityRoot },
+        {
+          ...options,
+          ...(steeringMessageId ? { durable: true } : {}),
+          durabilityRoot: this.durabilityRoot,
+        },
       );
+      if (steeringMessageId) {
+        try {
+          await this.ensureImmutableSteeringMessageProof(event, steeringMessageId);
+        } catch (error) {
+          if (!(error instanceof DurableStoreWriteError)) throw error;
+          throw new RuntimeEventPostEffectError(
+            `RuntimeEvent ${event.id} is durable but its steering proof was not published`,
+            error,
+          );
+        }
+      }
       const completedPartialKey = completedPartialRuntimeStreamKey(event);
       if (completedPartialKey) {
         await rm(this.runtimePartialPath(sessionId, runId, completedPartialKey), {
@@ -812,6 +1013,52 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
     );
   }
 
+  async readImmutableSteeringMessageProof(
+    sessionId: string,
+    messageId: string,
+  ): Promise<ImmutableSteeringMessageProof | undefined> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(messageId, 'Invalid message id');
+    let raw: string;
+    try {
+      raw = await readFile(this.immutableSteeringMessageProofPath(sessionId, messageId), 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw error;
+    }
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      !isPlainRecord(parsed) ||
+      !hasExactKeys(parsed, ['schemaVersion', 'messageId', 'event']) ||
+      parsed.schemaVersion !== 1 ||
+      parsed.messageId !== messageId ||
+      !isPlainRecord(parsed.event) ||
+      typeof parsed.event.runId !== 'string' ||
+      !isSafeId(parsed.event.runId)
+    ) {
+      throw new Error(`Invalid immutable steering message proof: ${messageId}`);
+    }
+    const event = decodeRuntimeEvent(
+      parsed.event,
+      await this.readRunHeader(sessionId, parsed.event.runId),
+    );
+    if (immutableSteeringMessageId(event) !== messageId) {
+      throw new Error(`Invalid immutable steering message proof: ${messageId}`);
+    }
+    return Object.freeze({ event });
+  }
+
+  async repairImmutableSteeringMessageProofsForRecovery(sessionId: string): Promise<void> {
+    assertSafeId(sessionId, 'Invalid session id');
+    await this.withImmutableSteeringQueue(sessionId, async () => {
+      const events = await this.readSessionRuntimeEvents(sessionId);
+      for (const event of events) {
+        const messageId = immutableSteeringMessageId(event);
+        if (messageId) await this.ensureImmutableSteeringMessageProof(event, messageId);
+      }
+    });
+  }
+
   async readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]> {
     assertSafeId(sessionId, 'Invalid session id');
     const runsRoot = this.runsRoot(sessionId);
@@ -880,6 +1127,45 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
     return join(this.runtimePartialsDir(sessionId, runId), `${key}.partial`);
   }
 
+  private immutableSteeringMessageProofPath(sessionId: string, messageId: string): string {
+    return join(this.sessionsRoot, sessionId, 'message-proofs', 'steering', `${messageId}.json`);
+  }
+
+  private async ensureImmutableSteeringMessageProof(
+    event: RuntimeEvent,
+    messageId: string,
+  ): Promise<void> {
+    const path = this.immutableSteeringMessageProofPath(event.sessionId, messageId);
+    const stored = { schemaVersion: 1, messageId, event };
+    const created = await writeExclusiveAtomic(
+      path,
+      `${JSON.stringify(stored, sanitizeJson)}\n`,
+      { durable: true },
+      this.durabilityRoot,
+    );
+    if (created) return;
+    const existing = await this.readImmutableSteeringMessageProof(event.sessionId, messageId);
+    if (
+      !existing ||
+      !isDeepStrictEqual(existing.event, JSON.parse(JSON.stringify(event, sanitizeJson)))
+    ) {
+      throw new Error(`Immutable steering message identity conflict: ${messageId}`);
+    }
+  }
+
+  private async preflightImmutableSteeringMessage(
+    event: RuntimeEvent,
+    messageId: string,
+  ): Promise<boolean> {
+    const canonicalEvent = JSON.parse(JSON.stringify(event, sanitizeJson)) as RuntimeEvent;
+    const proof = await this.readImmutableSteeringMessageProof(event.sessionId, messageId);
+    if (!proof) return false;
+    if (!isDeepStrictEqual(proof.event, canonicalEvent)) {
+      throw new Error(`Immutable steering message identity conflict: ${messageId}`);
+    }
+    return true;
+  }
+
   private async readRuntimePartials(
     sessionId: string,
     runId: string,
@@ -926,6 +1212,14 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
     return chainWrite(this.writeQueues, `${sessionId}:${runId}`, operation);
+  }
+
+  private withImmutableSteeringQueue(
+    sessionId: string,
+    operation: () => Promise<void>,
+  ): Promise<void> {
+    assertSafeId(sessionId, 'Invalid session id');
+    return chainWrite(this.immutableSteeringWriteQueues, sessionId, operation);
   }
 }
 
@@ -1009,6 +1303,17 @@ function completedPartialRuntimeStreamKey(event: RuntimeEvent): string | undefin
     identity = `tool:call:${event.refs.toolCallId}`;
   }
   return identity ? runtimePartialStreamKey(identity, event) : undefined;
+}
+
+function immutableSteeringMessageId(event: RuntimeEvent): string | undefined {
+  const messageId = event.refs?.providerEventId;
+  return event.partial === false &&
+    typeof messageId === 'string' &&
+    isSafeId(messageId) &&
+    event.content?.kind === 'text' &&
+    event.content.steering === true
+    ? messageId
+    : undefined;
 }
 
 function runtimePartialStreamKey(identity: string, event: RuntimeEvent): string {
@@ -1227,18 +1532,18 @@ function normalizeRootTurnAdmission(
   sessionId: string,
   turnId: string,
 ): RootTurnAdmission {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+  if (!isPlainRecord(value)) {
     throw new Error(`Invalid root turn admission for turn ${turnId}: expected an object`);
   }
-  const record = value as Record<string, unknown>;
+  const record = value;
   const valid =
     record.schemaVersion === ROOT_TURN_ADMISSION_SCHEMA_VERSION &&
     record.sessionId === sessionId &&
     record.turnId === turnId &&
     typeof record.runId === 'string' &&
     isSafeId(record.runId) &&
-    typeof record.userMessageId === 'string' &&
-    isSafeId(record.userMessageId) &&
+    (record.userMessageId === null ||
+      (typeof record.userMessageId === 'string' && isSafeId(record.userMessageId))) &&
     (record.previousRootTurnId === null ||
       (typeof record.previousRootTurnId === 'string' &&
         isSafeId(record.previousRootTurnId) &&
@@ -1251,23 +1556,53 @@ function normalizeRootTurnAdmission(
       'turnId',
       'runId',
       'userMessageId',
+      'execution',
       'previousRootTurnId',
       'normalizedInput',
+      'sourceMessages',
       'admittedAt',
     ]);
   if (!valid) {
     throw new Error(`Invalid root turn admission for turn ${turnId}: malformed fields`);
   }
-  return {
+  const { normalizedInput, sourceMessages } = normalizeRootTurnAdmissionPayload(
+    record.normalizedInput,
+    record.sourceMessages,
+  );
+  const admission: RootTurnAdmission = {
     schemaVersion: ROOT_TURN_ADMISSION_SCHEMA_VERSION,
     sessionId,
     turnId,
     runId: record.runId as string,
-    userMessageId: record.userMessageId as string,
+    userMessageId: record.userMessageId as string | null,
+    execution: normalizeRootExecutionDescriptor(record.execution),
     previousRootTurnId: record.previousRootTurnId as string | null,
-    normalizedInput: normalizeRootTurnAdmissionInput(record.normalizedInput),
+    normalizedInput,
+    sourceMessages,
     admittedAt: record.admittedAt as number,
   };
+  assertRootTurnAdmissionContract(admission);
+  assertRootTurnAdmissionRecordSize(admission);
+  return deepFreezeRootTurnAdmission(admission);
+}
+
+function decodeRootSourceMessageProofPointer(
+  value: unknown,
+  sessionId: string,
+  messageId: string,
+): { readonly turnId: string } {
+  if (
+    !isPlainRecord(value) ||
+    !hasExactKeys(value, ['schemaVersion', 'sessionId', 'messageId', 'turnId']) ||
+    value.schemaVersion !== 1 ||
+    value.sessionId !== sessionId ||
+    value.messageId !== messageId ||
+    typeof value.turnId !== 'string' ||
+    !isSafeId(value.turnId)
+  ) {
+    throw new Error(`Invalid root source message proof: ${messageId}`);
+  }
+  return Object.freeze({ turnId: value.turnId });
 }
 
 function orderRootTurnAdmissionChain(
@@ -1316,19 +1651,275 @@ function orderRootTurnAdmissionChain(
   return ordered;
 }
 
-function normalizeRootTurnAdmissionInput(value: unknown): RootTurnAdmissionInput {
-  if (!value || typeof value !== 'object' || Array.isArray(value)) {
-    throw new Error('Invalid root turn normalized input: expected an object');
+function normalizeRootTurnMessageContent(
+  value: unknown,
+  description: string,
+  maxAttachments: number,
+): MessageContent {
+  let normalized: MessageContent;
+  try {
+    normalized = decodeMessageContent(value);
+  } catch {
+    if (isPlainRecord(value) && Array.isArray(value.attachments)) {
+      const invalidAttachmentIndex = value.attachments.findIndex(
+        (attachment) => !isCanonicalAttachmentRef(attachment),
+      );
+      if (invalidAttachmentIndex >= 0) {
+        throw new Error(`Invalid ${description} attachment at index ${invalidAttachmentIndex}`);
+      }
+    }
+    throw new Error(`Invalid ${description}`);
   }
-  const record = value as Record<string, unknown>;
+  if (normalized.text.length === 0 || (normalized.attachments?.length ?? 0) > maxAttachments) {
+    throw new Error(`Invalid ${description}`);
+  }
+  for (const [index, attachment] of (normalized.attachments ?? []).entries()) {
+    if (!isValidRootTurnAttachment(attachment)) {
+      throw new Error(`Invalid ${description} attachment at index ${index}`);
+    }
+  }
   if (
-    !hasExactKeys(record, ['text']) ||
-    typeof record.text !== 'string' ||
-    record.text.length === 0
+    Buffer.byteLength(JSON.stringify(normalized), 'utf8') > ROOT_TURN_ADMISSION_MAX_CONTENT_BYTES
   ) {
-    throw new Error('Invalid root turn normalized input');
+    throw new Error(`Invalid ${description}: content exceeds size limit`);
   }
-  return { text: record.text };
+  deepFreezeRootTurnMessageContent(normalized);
+  return normalized;
+}
+
+function isValidRootTurnAttachment(attachment: AttachmentRef): boolean {
+  return isCanonicalAttachmentRef(attachment) && attachment.bytes <= MAX_ATTACHMENT_BYTES;
+}
+
+export function normalizeRootTurnAdmissionPayload(
+  normalizedInputValue: unknown,
+  sourceMessagesValue: unknown,
+): {
+  normalizedInput: MessageContent;
+  sourceMessages: readonly RootTurnSourceMessage[];
+} {
+  const sourceMessages = normalizeRootTurnSourceMessages(sourceMessagesValue);
+  const normalizedInputMaxAttachments =
+    sourceMessages.length > 1
+      ? ROOT_TURN_ADMISSION_MAX_AGGREGATED_ATTACHMENTS
+      : MAX_ATTACHMENT_COUNT;
+  const normalizedInput = normalizeRootTurnMessageContent(
+    normalizedInputValue,
+    'root turn normalized input',
+    normalizedInputMaxAttachments,
+  );
+  if (sourceMessages.length > 0) {
+    const sourceText = sourceMessages.map((source) => source.content.text).join('\n\n');
+    const sourceDisplayText = sourceMessages
+      .map((source) => source.content.displayText ?? source.content.text)
+      .join('\n\n');
+    const sourceAttachments = sourceMessages.flatMap((source) => source.content.attachments ?? []);
+    const sourceQuotes = sourceMessages.flatMap((source) => source.content.quotes ?? []);
+    const expectedInput = normalizeRootTurnMessageContent(
+      {
+        text: sourceText,
+        ...(sourceDisplayText !== sourceText ? { displayText: sourceDisplayText } : {}),
+        ...(sourceAttachments.length > 0 ? { attachments: sourceAttachments } : {}),
+        ...(sourceQuotes.length > 0 ? { quotes: sourceQuotes } : {}),
+      },
+      'root turn aggregated source content',
+      normalizedInputMaxAttachments,
+    );
+    if (!messageContentsEqual(normalizedInput, expectedInput)) {
+      throw new Error('Root turn admission input content does not match source messages');
+    }
+  }
+  const turnStartedCount = sourceMessages.filter(
+    (source) => source.disposition === 'turn_started',
+  ).length;
+  if (turnStartedCount > 0 && (turnStartedCount !== 1 || sourceMessages.length !== 1)) {
+    throw new Error('Root turn admission turn_started source must be the only source message');
+  }
+  return { normalizedInput, sourceMessages };
+}
+
+function normalizeRootTurnSourceMessages(value: unknown): readonly RootTurnSourceMessage[] {
+  if (!Array.isArray(value) || value.length > ROOT_TURN_ADMISSION_MAX_SOURCE_MESSAGES) {
+    throw new Error('Invalid root turn source messages: expected a bounded array');
+  }
+  const messageIds = new Set<string>();
+  const normalized = value.map((item, index): RootTurnSourceMessage => {
+    if (
+      !isPlainRecord(item) ||
+      !hasExactKeys(item, ['messageId', 'content', 'placement', 'disposition'])
+    ) {
+      throw new Error(`Invalid root turn source message at index ${index}`);
+    }
+    const { messageId, content, placement, disposition } = item;
+    if (
+      typeof messageId !== 'string' ||
+      !isSafeId(messageId) ||
+      (placement !== 'current_turn' && placement !== 'next_turn') ||
+      (disposition !== 'steering' &&
+        disposition !== 'followup' &&
+        disposition !== 'turn_started') ||
+      (disposition === 'steering' && placement !== 'current_turn') ||
+      (disposition === 'followup' && placement !== 'next_turn')
+    ) {
+      throw new Error(`Invalid root turn source message at index ${index}`);
+    }
+    if (messageIds.has(messageId)) {
+      throw new Error(`Duplicate root turn source message id: ${messageId}`);
+    }
+    messageIds.add(messageId);
+    return Object.freeze({
+      messageId,
+      content: normalizeRootTurnMessageContent(
+        content,
+        `root turn source message content at index ${index}`,
+        MAX_ATTACHMENT_COUNT,
+      ),
+      placement,
+      disposition,
+    });
+  });
+  return Object.freeze(normalized);
+}
+
+function rootTurnAdmissionPayloadsEqual(
+  left: RootTurnAdmission,
+  right: RootTurnAdmission,
+): boolean {
+  return (
+    isDeepStrictEqual(left.execution, right.execution) &&
+    messageContentsEqual(left.normalizedInput, right.normalizedInput) &&
+    left.sourceMessages.length === right.sourceMessages.length &&
+    left.sourceMessages.every((source, index) => {
+      const other = right.sourceMessages[index];
+      return (
+        other !== undefined &&
+        source.messageId === other.messageId &&
+        source.placement === other.placement &&
+        source.disposition === other.disposition &&
+        messageContentsEqual(source.content, other.content)
+      );
+    })
+  );
+}
+
+function assertRootTurnAdmissionRecordSize(admission: RootTurnAdmission): void {
+  assertRootTurnAdmissionSerializedSize(`${JSON.stringify(admission)}\n`);
+}
+
+function assertRootTurnAdmissionSerializedSize(serialized: string): void {
+  if (Buffer.byteLength(serialized, 'utf8') > ROOT_TURN_ADMISSION_MAX_RECORD_BYTES) {
+    throw new Error('Invalid root turn admission: record exceeds size limit');
+  }
+}
+
+function assertRootTurnAdmissionContract(admission: RootTurnAdmission): void {
+  const execution = admission.execution;
+  const providerRetry = execution.kind === 'linked_child_provider_retry';
+  if ((admission.userMessageId === null) !== providerRetry) {
+    throw new Error(
+      'Invalid root turn admission contract: only linked child provider retry omits UserMessage',
+    );
+  }
+  if (execution.kind !== 'external_message' && admission.sourceMessages.length !== 0) {
+    throw new Error(
+      'Invalid root turn admission contract: linked child execution cannot have source messages',
+    );
+  }
+  if (
+    (execution.kind === 'linked_child_resume' ||
+      execution.kind === 'linked_child_provider_retry') &&
+    execution.sourceRunId === admission.runId
+  ) {
+    throw new Error(
+      'Invalid root turn admission contract: linked child source Run cannot be the admitted Run',
+    );
+  }
+  if (
+    execution.kind === 'external_message' &&
+    admission.sourceMessages.some(
+      (source) =>
+        source.disposition === 'turn_started' && source.messageId !== admission.userMessageId,
+    )
+  ) {
+    throw new Error(
+      'Invalid root turn admission contract: turn-started source must own the UserMessage',
+    );
+  }
+}
+
+function deepFreezeRootTurnAdmission(admission: RootTurnAdmission): RootTurnAdmission {
+  Object.freeze(admission.execution);
+  deepFreezeRootTurnMessageContent(admission.normalizedInput);
+  for (const sourceMessage of admission.sourceMessages) {
+    deepFreezeRootTurnMessageContent(sourceMessage.content);
+    Object.freeze(sourceMessage);
+  }
+  Object.freeze(admission.sourceMessages);
+  return Object.freeze(admission);
+}
+
+function normalizeRootExecutionDescriptor(value: unknown): RootExecutionDescriptor {
+  if (!isPlainRecord(value) || typeof value.kind !== 'string') {
+    throw new Error('Invalid root execution descriptor');
+  }
+  if (value.kind === 'external_message') {
+    if (!hasExactKeys(value, ['kind'])) throw new Error('Invalid root execution descriptor');
+    return Object.freeze({ kind: 'external_message' });
+  }
+  if (
+    value.kind !== 'linked_child_initial' &&
+    value.kind !== 'linked_child_resume' &&
+    value.kind !== 'linked_child_provider_retry'
+  ) {
+    throw new Error('Invalid root execution descriptor');
+  }
+  const hasSource = value.kind !== 'linked_child_initial';
+  if (
+    !hasExactKeys(
+      value,
+      hasSource
+        ? ['kind', 'agentId', 'agentName', 'sourceRunId']
+        : ['kind', 'agentId', 'agentName'],
+    ) ||
+    typeof value.agentId !== 'string' ||
+    !isSafeId(value.agentId) ||
+    typeof value.agentName !== 'string' ||
+    value.agentName.length === 0 ||
+    Buffer.byteLength(value.agentName, 'utf8') > 256 ||
+    (hasSource && (typeof value.sourceRunId !== 'string' || !isSafeId(value.sourceRunId)))
+  ) {
+    throw new Error('Invalid root execution descriptor');
+  }
+  if (value.kind === 'linked_child_initial') {
+    return Object.freeze({
+      kind: value.kind,
+      agentId: value.agentId,
+      agentName: value.agentName,
+    });
+  }
+  return Object.freeze({
+    kind: value.kind,
+    agentId: value.agentId,
+    agentName: value.agentName,
+    sourceRunId: value.sourceRunId as string,
+  });
+}
+
+function deepFreezeRootTurnMessageContent(content: MessageContent): void {
+  for (const attachment of content.attachments ?? []) {
+    Object.freeze(attachment.ref);
+    Object.freeze(attachment);
+  }
+  if (content.attachments) Object.freeze(content.attachments);
+  for (const quote of content.quotes ?? []) Object.freeze(quote);
+  if (content.quotes) Object.freeze(content.quotes);
+  Object.freeze(content);
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
 }
 
 function turnIdFromAdmissionFile(name: string): string | undefined {

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -17,7 +17,9 @@ import {
   type DurableAgentRunStore,
   type DurableRuntimeEventStore,
   type RootTurnAdmission,
+  type RootTurnSourceMessageReceipt,
 } from './agent-run-store.js';
+import { createMessageReceiptStore, type MessageReceiptStore } from './message-receipt-store.js';
 import { createSessionStore, type SessionStore } from './session-store.js';
 import {
   assertStorageRootLease,
@@ -31,18 +33,30 @@ const executionStoresWriterBrand: unique symbol = Symbol('ExecutionStoresWriter'
 const executionStoresReaderBrand: unique symbol = Symbol('ExecutionStoresReader');
 const executionStoresWriterKinds = new WeakMap<object, StorageRootKind>();
 const executionStoresReaderKinds = new WeakMap<object, StorageRootKind>();
+const executionStoresWritersByLease = new WeakMap<object, ExecutionStoresWriter<StorageRootKind>>();
+
+export { normalizeRootTurnAdmissionPayload } from './agent-run-store.js';
+export { isSessionNotFoundError } from './session-store.js';
 
 export type {
   AdmitRootTurnInput,
   AdmitRootTurnResult,
+  ImmutableSteeringMessageProof,
   RootTurnAdmission,
-  RootTurnAdmissionInput,
   RootTurnAdmissionStore,
+  RootTurnSourceMessage,
+  RootTurnSourceMessageReceipt,
 } from './agent-run-store.js';
+export type {
+  MessageOperationReceipt,
+  MessageReceiptOperation,
+  MessageReceiptStore,
+} from './message-receipt-store.js';
 
 export type ExecutionSessionWriter = SessionStore;
 export type ExecutionAgentRunWriter = DurableAgentRunStore;
 export type ExecutionRuntimeEventWriter = DurableRuntimeEventStore;
+export type ExecutionMessageReceiptWriter = MessageReceiptStore;
 
 export interface ExecutionStoresWriter<K extends StorageRootKind> {
   readonly kind: K;
@@ -50,6 +64,7 @@ export interface ExecutionStoresWriter<K extends StorageRootKind> {
   readonly sessionStore: Readonly<ExecutionSessionWriter>;
   readonly agentRunStore: Readonly<ExecutionAgentRunWriter>;
   readonly runtimeEventStore: Readonly<ExecutionRuntimeEventWriter>;
+  readonly messageReceiptStore: Readonly<ExecutionMessageReceiptWriter>;
 }
 
 export interface ExecutionSessionReader {
@@ -68,6 +83,10 @@ export interface ExecutionAgentRunReader {
     type: AgentRunEventType,
   ): Promise<AgentRunEvent | null | undefined>;
   readRootTurnAdmission(sessionId: string, turnId: string): Promise<RootTurnAdmission | undefined>;
+  readRootTurnSourceMessageReceipt(
+    sessionId: string,
+    sourceMessageId: string,
+  ): Promise<RootTurnSourceMessageReceipt | undefined>;
 }
 
 export interface ExecutionRuntimeEventReader {
@@ -121,9 +140,13 @@ async function openExecutionStoresForWrite<K extends StorageRootKind>(
   kind: K,
 ): Promise<ExecutionStoresWriter<K>> {
   await assertStorageRootLease(lease, kind, 'write');
+  const existing = executionStoresWritersByLease.get(lease);
+  if (existing) return existing as ExecutionStoresWriter<K>;
+
   const sessionStore = createSessionStore(lease.canonicalPath);
   const agentRunStore = createAgentRunStore(lease.canonicalPath);
   const runtimeEventStore = createRuntimeEventStore(lease.canonicalPath);
+  const messageReceiptStore = createMessageReceiptStore(lease.canonicalPath);
   const run = <T>(operation: () => Promise<T>) =>
     runWithStorageRootLease(lease, kind, 'write', operation);
 
@@ -183,6 +206,8 @@ async function openExecutionStoresForWrite<K extends StorageRootKind>(
         run(() => agentRunStore.admitRootTurn(input)),
       readRootTurnAdmission: (sessionId, turnId) =>
         run(() => agentRunStore.readRootTurnAdmission(sessionId, turnId)),
+      readRootTurnSourceMessageReceipt: (sessionId, sourceMessageId) =>
+        run(() => agentRunStore.readRootTurnSourceMessageReceipt(sessionId, sourceMessageId)),
       listRootTurnAdmissionsForRecovery: (sessionId) =>
         run(() => agentRunStore.listRootTurnAdmissionsForRecovery(sessionId)),
     },
@@ -197,10 +222,24 @@ async function openExecutionStoresForWrite<K extends StorageRootKind>(
         run(() => runtimeEventStore.readImmutableRuntimeEvents(sessionId, runId)),
       readSessionRuntimeEvents: (sessionId) =>
         run(() => runtimeEventStore.readSessionRuntimeEvents(sessionId)),
+      readImmutableSteeringMessageProof: (sessionId, messageId) =>
+        run(() => runtimeEventStore.readImmutableSteeringMessageProof(sessionId, messageId)),
+      repairImmutableSteeringMessageProofsForRecovery: (sessionId) =>
+        run(() => runtimeEventStore.repairImmutableSteeringMessageProofsForRecovery(sessionId)),
+    },
+    messageReceiptStore: {
+      beginHostEpoch: (hostEpoch) => run(() => messageReceiptStore.beginHostEpoch(hostEpoch)),
+      read: (hostEpoch, operation, sessionId, operationId) =>
+        run(() => messageReceiptStore.read(hostEpoch, operation, sessionId, operationId)),
+      commit: (hostEpoch, operation, sessionId, operationId, receipt) =>
+        run(() =>
+          messageReceiptStore.commit(hostEpoch, operation, sessionId, operationId, receipt),
+        ),
     },
   };
   freezeExecutionStoresFacade(stores);
   executionStoresWriterKinds.set(stores, kind);
+  executionStoresWritersByLease.set(lease, stores);
   return stores;
 }
 
@@ -244,6 +283,8 @@ async function openExecutionStoresForRead<K extends StorageRootKind>(
         run(() => agentRunStore.readEventProjection(sessionId, type)),
       readRootTurnAdmission: (sessionId, turnId) =>
         run(() => agentRunStore.readRootTurnAdmission(sessionId, turnId)),
+      readRootTurnSourceMessageReceipt: (sessionId, sourceMessageId) =>
+        run(() => agentRunStore.readRootTurnSourceMessageReceipt(sessionId, sourceMessageId)),
     },
     runtimeEventStore: {
       readRuntimeEvents: (sessionId, runId) =>
@@ -263,10 +304,12 @@ function freezeExecutionStoresFacade(stores: {
   readonly sessionStore: object;
   readonly agentRunStore: object;
   readonly runtimeEventStore: object;
+  readonly messageReceiptStore?: object;
 }): void {
   Object.freeze(stores.sessionStore);
   Object.freeze(stores.agentRunStore);
   Object.freeze(stores.runtimeEventStore);
+  if (stores.messageReceiptStore) Object.freeze(stores.messageReceiptStore);
   Object.freeze(stores);
 }
 

--- a/packages/storage/src/message-receipt-store.ts
+++ b/packages/storage/src/message-receipt-store.ts
@@ -1,0 +1,242 @@
+import { randomUUID } from 'node:crypto';
+import { link, mkdir, open, readFile, readdir, rm, unlink } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
+import { syncDirectory, syncDirectoryChain } from './stable-storage.js';
+import { chainWrite } from './write-queue.js';
+
+const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+const RECEIPT_SCHEMA_VERSION = 1 as const;
+const RECEIPT_MAX_BYTES = 64 * 1024;
+
+export type MessageReceiptOperation = 'submit' | 'retract' | 'interrupt';
+
+export interface MessageOperationReceipt {
+  readonly payload: unknown;
+  readonly result: unknown;
+}
+
+export interface MessageReceiptStore {
+  beginHostEpoch(hostEpoch: string): Promise<void>;
+  read(
+    hostEpoch: string,
+    operation: MessageReceiptOperation,
+    sessionId: string,
+    operationId: string,
+  ): Promise<MessageOperationReceipt | undefined>;
+  commit(
+    hostEpoch: string,
+    operation: MessageReceiptOperation,
+    sessionId: string,
+    operationId: string,
+    receipt: MessageOperationReceipt,
+  ): Promise<MessageOperationReceipt>;
+}
+
+interface StoredMessageOperationReceipt {
+  readonly schemaVersion: typeof RECEIPT_SCHEMA_VERSION;
+  readonly hostEpoch: string;
+  readonly operation: MessageReceiptOperation;
+  readonly sessionId: string;
+  readonly operationId: string;
+  readonly payload: unknown;
+  readonly result: unknown;
+}
+
+export function createMessageReceiptStore(workspaceRoot: string): MessageReceiptStore {
+  return new FileMessageReceiptStore(workspaceRoot);
+}
+
+class FileMessageReceiptStore implements MessageReceiptStore {
+  readonly #durabilityRoot: string;
+  readonly #epochsRoot: string;
+  readonly #writeQueues = new Map<string, Promise<void>>();
+
+  constructor(workspaceRoot: string) {
+    this.#durabilityRoot = resolve(workspaceRoot);
+    this.#epochsRoot = join(this.#durabilityRoot, 'message-receipts');
+  }
+
+  async beginHostEpoch(hostEpoch: string): Promise<void> {
+    assertSafeId(hostEpoch, 'Invalid Host Epoch');
+    await mkdir(join(this.#epochsRoot, hostEpoch), { recursive: true });
+    const entries = await readdir(this.#epochsRoot, { withFileTypes: true });
+    let removed = false;
+    for (const entry of entries) {
+      if (!entry.isDirectory() || !SAFE_ID_PATTERN.test(entry.name)) {
+        throw new Error(`Invalid message receipt Epoch entry: ${entry.name}`);
+      }
+      if (entry.name === hostEpoch) continue;
+      await rm(join(this.#epochsRoot, entry.name), { recursive: true });
+      removed = true;
+    }
+    if (removed) await syncDirectory(this.#epochsRoot);
+  }
+
+  async read(
+    hostEpoch: string,
+    operation: MessageReceiptOperation,
+    sessionId: string,
+    operationId: string,
+  ): Promise<MessageOperationReceipt | undefined> {
+    validateIdentity(hostEpoch, operation, sessionId, operationId);
+    let raw: string;
+    try {
+      raw = await readFile(this.#receiptPath(hostEpoch, operation, sessionId, operationId), 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+      throw error;
+    }
+    if (Buffer.byteLength(raw, 'utf8') > RECEIPT_MAX_BYTES) {
+      throw new Error('Message operation receipt exceeds size limit');
+    }
+    const stored = decodeStoredReceipt(JSON.parse(raw), {
+      hostEpoch,
+      operation,
+      sessionId,
+      operationId,
+    });
+    return Object.freeze({ payload: stored.payload, result: stored.result });
+  }
+
+  async commit(
+    hostEpoch: string,
+    operation: MessageReceiptOperation,
+    sessionId: string,
+    operationId: string,
+    receipt: MessageOperationReceipt,
+  ): Promise<MessageOperationReceipt> {
+    validateIdentity(hostEpoch, operation, sessionId, operationId);
+    const stored: StoredMessageOperationReceipt = {
+      schemaVersion: RECEIPT_SCHEMA_VERSION,
+      hostEpoch,
+      operation,
+      sessionId,
+      operationId,
+      payload: receipt.payload,
+      result: receipt.result,
+    };
+    const encoded = JSON.stringify(stored);
+    const snapshot = decodeStoredReceipt(JSON.parse(encoded), {
+      hostEpoch,
+      operation,
+      sessionId,
+      operationId,
+    });
+    if (!isDeepStrictEqual(snapshot, stored)) {
+      throw new Error('Message operation receipt is not exactly JSON representable');
+    }
+    const serialized = `${encoded}\n`;
+    if (Buffer.byteLength(serialized, 'utf8') > RECEIPT_MAX_BYTES) {
+      throw new Error('Message operation receipt exceeds size limit');
+    }
+    const key = `${hostEpoch}:${operation}:${sessionId}:${operationId}`;
+    let committed: MessageOperationReceipt | undefined;
+    await chainWrite(this.#writeQueues, key, async () => {
+      const path = this.#receiptPath(hostEpoch, operation, sessionId, operationId);
+      const created = await writeExclusiveDurable(path, serialized, this.#durabilityRoot);
+      if (!created) {
+        const existing = await this.read(hostEpoch, operation, sessionId, operationId);
+        if (!existing) throw new Error('Message operation receipt disappeared');
+        if (
+          !isDeepStrictEqual(existing, {
+            payload: snapshot.payload,
+            result: snapshot.result,
+          })
+        ) {
+          throw new Error('Message operation receipt identity conflict');
+        }
+        committed = existing;
+        return;
+      }
+      committed = Object.freeze({ payload: snapshot.payload, result: snapshot.result });
+    });
+    if (!committed) throw new Error('Message operation receipt commit produced no result');
+    return committed;
+  }
+
+  #receiptPath(
+    hostEpoch: string,
+    operation: MessageReceiptOperation,
+    sessionId: string,
+    operationId: string,
+  ): string {
+    return join(this.#epochsRoot, hostEpoch, operation, sessionId, `${operationId}.json`);
+  }
+}
+
+function validateIdentity(
+  hostEpoch: string,
+  operation: MessageReceiptOperation,
+  sessionId: string,
+  operationId: string,
+): void {
+  assertSafeId(hostEpoch, 'Invalid Host Epoch');
+  if (operation !== 'submit' && operation !== 'retract' && operation !== 'interrupt') {
+    throw new Error('Invalid message receipt operation');
+  }
+  assertSafeId(sessionId, 'Invalid Session identity');
+  assertSafeId(operationId, 'Invalid message operation identity');
+}
+
+function decodeStoredReceipt(
+  value: unknown,
+  expected: {
+    hostEpoch: string;
+    operation: MessageReceiptOperation;
+    sessionId: string;
+    operationId: string;
+  },
+): StoredMessageOperationReceipt {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    Object.keys(value).length !== 7
+  ) {
+    throw new Error('Invalid message operation receipt');
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    record.schemaVersion !== RECEIPT_SCHEMA_VERSION ||
+    record.hostEpoch !== expected.hostEpoch ||
+    record.operation !== expected.operation ||
+    record.sessionId !== expected.sessionId ||
+    record.operationId !== expected.operationId ||
+    !Object.hasOwn(record, 'payload') ||
+    !Object.hasOwn(record, 'result')
+  ) {
+    throw new Error('Invalid message operation receipt');
+  }
+  return record as unknown as StoredMessageOperationReceipt;
+}
+
+async function writeExclusiveDurable(
+  path: string,
+  content: string,
+  durabilityRoot: string,
+): Promise<boolean> {
+  await mkdir(dirname(path), { recursive: true });
+  const tempPath = `${path}.${process.pid}.${randomUUID()}.tmp`;
+  const handle = await open(tempPath, 'wx', 0o600);
+  try {
+    await handle.writeFile(content, 'utf8');
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+  try {
+    await link(tempPath, path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false;
+    throw error;
+  } finally {
+    await unlink(tempPath).catch(() => undefined);
+  }
+  await syncDirectoryChain(dirname(path), durabilityRoot);
+  return true;
+}
+
+function assertSafeId(value: string, message: string): void {
+  if (!SAFE_ID_PATTERN.test(value)) throw new Error(message);
+}

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -47,6 +47,19 @@ import type {
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 export const SQLITE_SESSION_METADATA_DATABASE_NAME = 'sessions.sqlite';
 
+export class SessionNotFoundError extends Error {
+  readonly name = 'SessionNotFoundError';
+  readonly code = 'session_not_found';
+
+  constructor(readonly sessionId: string) {
+    super(`Session metadata not found: ${sessionId}`);
+  }
+}
+
+export function isSessionNotFoundError(error: unknown): error is SessionNotFoundError {
+  return error instanceof SessionNotFoundError;
+}
+
 export interface SessionStore {
   create(input: CreateSessionInput): Promise<SessionHeader>;
   createSubagent(input: CreateSessionInput): Promise<{ header: SessionHeader; created: boolean }>;
@@ -538,7 +551,14 @@ class FileSessionStore implements SessionStore {
   }
 
   async readHeaderSnapshot(sessionId: string): Promise<SessionHeader> {
-    return this.readHeaderOnly(sessionId);
+    try {
+      return await this.readHeaderOnly(sessionId);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException | undefined)?.code === 'ENOENT') {
+        throw new SessionNotFoundError(sessionId);
+      }
+      throw error;
+    }
   }
 
   async readMessages(sessionId: string): Promise<StoredMessage[]> {

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -21,7 +21,11 @@ import {
   type SessionListFilter,
   type SubagentSessionParent,
 } from '@maka/core';
-import { assertSafeSessionId, normalizeSessionHeader } from './session-store.js';
+import {
+  assertSafeSessionId,
+  normalizeSessionHeader,
+  SessionNotFoundError,
+} from './session-store.js';
 import {
   configureSqliteSessionMetadataDatabase,
   migrateSqliteSessionMetadataDatabase,
@@ -220,7 +224,7 @@ export class SqliteSessionMetadataStore {
     this.assertOpen();
     assertSafeSessionId(sessionId);
     const record = this.readRecordSync(sessionId);
-    if (!record) throw new Error(`Session metadata not found: ${sessionId}`);
+    if (!record) throw new SessionNotFoundError(sessionId);
     return record;
   }
 
@@ -474,7 +478,7 @@ export class SqliteSessionMetadataStore {
     }
     return this.transaction(() => {
       const current = this.readRecordSync(sessionId);
-      if (!current) throw new Error(`Session metadata not found: ${sessionId}`);
+      if (!current) throw new SessionNotFoundError(sessionId);
       if (
         options.expectedVersion !== undefined &&
         options.expectedVersion !== current.metadataVersion


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Context

This PR establishes the Host-owned Message authority slice for the Runtime Host Session-core migration tracked in #1167.

The Runtime Host remains non-serving in production. This PR does not switch any Desktop, TUI, CLI, or Headless entrypoint.

## What changes

### Canonical content and durable admission

- Define one canonical `MessageContent` across Core, Runtime, Storage, and the Host wire: model-facing `text`, optional human-facing `displayText`, ordered attachment references, and ordered structured quotes. Attachment bytes remain outside this contract.
- Apply exact decoding, normalization, copying, and equality at protocol and durable boundaries, preserving model input, UI provenance, and retry identity.
- Persist each root-Turn admission with its ordered source messages, placement, disposition, normalized aggregate, and execution identity.
- Preflight every source-message proof before publishing the admission, so a conflicting identity cannot leave a poisoned admission behind.
- Keep the admission record at the sole current schema version (`v1`). No migration path is added because no production Runtime Host state exists.

### Host-owned queue and control authority

- Add the closed operations `turn.message.submit`, `queue.retract`, and `turn.interrupt`, with exact inputs, outputs, typed failures, and bounded projections.
- Make one `HostMessageCoordinator` own Host-Epoch queue revision, steering/follow-up entries, Runtime leases, retry state, and residency.
- Same-Epoch retries are idempotent only for the same canonical payload. Reusing an identity with different content fails with `operation_conflict`.
- Old-Epoch retries resolve only from immutable keyed durable proofs. If the exact result, including its revision, cannot be proven, they return `outcome_unknown`.
- An idle submission starts exactly one root Turn. Active submissions become steering or follow-up entries; retract removes only entries that have not crossed the pull cut; interrupt commits one stop fence and returns the canonical terminal Turn result.
- Preflight immutable steering identity before appending the Runtime ledger. Recovery alone repairs the narrow crash window between durable append and proof publication; the normal path does not scan Session history.

### Root and linked-child lifecycle

- Route hosted linked-child initial runs, resumes, provider retries, and stops through the same root admission and Message authority used by external roots.
- Hold a per-child execution gate from preparation through terminal projection. Resume and retry share one successor rule, while an exact duplicate initial spawn joins the existing in-flight operation.
- Recover a pending foreground child admission after restart by closing it canonically as `app_restarted`; embedded execution remains unchanged.
- Keep external `turn.start` idempotency within `external_message`; a matching linked-child admission remains owned by hosted execution and returns `operation_conflict`.
- Allow an exact stop to establish its queue fence before Run binding, so later Message effects cannot cross that cut. Active cancellation of a backend factory, `run.begin()`, or the first iterator step remains an immediate root-execution follow-up and is not claimed by this PR.
- Reject claimed graph execution before claim lookup or durable side effects when a Hosted graph composition is absent. A dedicated pre-M4 slice will route graph activations through exact root admission and stop authority.

### Receipts, failure boundaries, and terminal handoff

- Store keyed root and steering proofs under the owning Session, and scope retry receipts to the Host Epoch.
- Publish a queue mutation before its receipt so the observable cut matches the admitted effect. Concurrent equivalent retries share one in-flight operation.
- If an accepted effect cannot be given its required proof or receipt, fail-stop the Host Epoch and retain owner residency until bounded Host termination rather than continuing with an ambiguous writer.
- Preserve a confirmed queue entry or terminal transition when startup or successor admission fails; do not reclaim its root owner as though the operation were cleanly abandoned.
- At terminal handoff, fold unpulled steering ahead of follow-up input, preflight the exact durable successor admission, and replace the previous root owner without an observable idle window.
- Map missing Sessions from both File and SQLite stores to the same typed `not_found` result at the real Host boundary.

The in-memory queue is deliberately a current-Epoch authority structure, not a crash-durable replay journal. After process termination, immutable proofs resolve outcomes that can be proven; unproven work returns `outcome_unknown` rather than being replayed speculatively.

## Evidence

The tests exercise real Storage and Host boundaries for conflicting source proofs, steering identity linearization, old-Epoch proof exactness, cross-connection retry and retract, SQLite missing-Session projection, linked-child ownership, queue/interrupt cuts, receipt publication failure, startup and successor-admission fail-stop, restart closure, and terminal late-input handoff.

## Scope

This slice intentionally does not add complete pending-start cancellation, Hosted graph composition, continuity/query/subscription, Interaction ownership, automation/goal ownership, production surface wiring, or the M4/M5 production cutover. Those remain in their owning follow-up slices.

Part of #1167. Related to #853.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 背景

本 PR 建立 Runtime Host Session core 迁移所需的 Host-owned Message authority slice，整体由 #1167 跟踪。

Runtime Host 仍未进入 production serving；本 PR 不切换 Desktop、TUI、CLI 或 Headless 的任何入口。

## 改动内容

### Canonical content 与 durable admission

- 在 Core、Runtime、Storage 与 Host wire 之间定义唯一的 canonical `MessageContent`：面向模型的 `text`、可选的面向用户的 `displayText`、有序 attachment reference，以及有序的结构化 quote。附件字节本身不经过该契约。
- 在协议与持久化边界使用严格解码、规范化、复制和相等性判断，保留模型输入、UI provenance 与 retry identity。
- 每条 root-Turn admission 持久化其有序 source message、placement、disposition、规范化后的聚合输入与 execution identity。
- 在发布 admission 前 preflight 全部 source-message proof，使冲突 identity 无法留下污染后续 recovery 的坏 admission。
- Admission record 只保留当前唯一的 schema version（`v1`）。Runtime Host 尚无 production state，因此不增加没有实际对象的 migration。

### Host-owned queue 与控制 authority

- 增加封闭 operation：`turn.message.submit`、`queue.retract` 与 `turn.interrupt`，具有精确 input/output、typed failure 与有界 projection。
- 由一个 `HostMessageCoordinator` 统一持有 Host Epoch 内的 queue revision、steering/follow-up entry、Runtime lease、retry state 与 residency。
- 同一 Epoch 的 retry 只有在 canonical payload 相同时才幂等；相同 identity 配合不同内容会返回 `operation_conflict`。
- 旧 Epoch retry 只能由不可变的 keyed durable proof 解析；无法证明包括 revision 在内的精确结果时返回 `outcome_unknown`。
- Idle submission 只启动一个 root Turn。Active submission 成为 steering 或 follow-up；retract 只移除尚未越过 pull cut 的 entry；interrupt 提交唯一 stop fence，并返回 canonical terminal Turn 结果。
- 在追加 Runtime ledger 前 preflight immutable steering identity。只有 recovery 才修复 durable append 与 proof publication 之间的窄 crash window；正常路径不会扫描 Session 历史。

### Root 与 linked-child lifecycle

- 让 hosted linked child 的 initial run、resume、provider retry 与 stop 经由外部 root 使用的同一套 root admission 与 Message authority。
- 从 preparation 到 terminal projection 持有 per-child execution gate。Resume 与 retry 共用一个 successor rule；完全相同的 initial spawn retry 会加入既有 in-flight operation。
- Host 重启后，将 pending foreground child admission 规范地关闭为 `app_restarted`；embedded execution 保持不变。
- 将外部 `turn.start` 的幂等范围限制在 `external_message`；命中 linked-child admission 时，其 ownership 仍归 hosted execution，并返回 `operation_conflict`。
- Exact stop 可以在 Run bind 前建立 queue fence，使之后的 Message effect 无法越过该 cut。主动取消 backend factory、`run.begin()` 或首个 iterator step 属于紧随其后的 root-execution follow-up，本 PR 不宣称已经交付。
- Hosted graph composition 尚未建立时，在读取 claim 或产生持久化副作用前拒绝 claimed graph execution。M4 前的独立 slice 会让 graph activation 经由精确的 root admission 与 stop authority。

### Receipt、失败边界与 terminal handoff

- 在所属 Session 下保存 keyed root/steering proof，并让 retry receipt 受 Host Epoch 约束。
- 先发布 queue mutation，再发布对应 receipt，使可观测 cut 与已接纳 effect 一致；并发且等价的 retry 共用一个 in-flight operation。
- 如果已接纳 effect 无法取得所需 proof 或 receipt，则 fail-stop 当前 Host Epoch，并保留 owner residency 直到有界 Host termination；不让存在歧义的 writer 继续运行。
- Startup 或 successor admission 失败时，保留已经确认的 queue entry 或 terminal transition，不把对应 root owner 当作正常 abandon 回收。
- Terminal handoff 时，将尚未 pull 的 steering 折入 follow-up 前部，preflight 精确的 durable successor admission，并在不存在可观测 idle window 的情况下替换 previous root owner。
- File 与 SQLite Store 的 Session 缺失都会在真实 Host 边界映射为同一个 typed `not_found`。

内存 queue 有意只作为当前 Epoch 的 authority structure，而不是 crash-durable replay journal。进程终止后，可由 immutable proof 证明的结果会被解析；无法证明的工作返回 `outcome_unknown`，不会被推测性重放。

## 验证证据

测试通过真实 Storage 与 Host 边界覆盖 source-proof conflict、steering identity 线性化、old-Epoch proof exactness、跨 connection retry/retract、SQLite missing-Session projection、linked-child ownership、queue/interrupt cut、receipt publication failure、startup 与 successor-admission fail-stop、restart closure，以及 terminal late-input handoff。

## 范围

本 slice 明确不加入完整 pending-start cancellation、Hosted graph composition、continuity/query/subscription、Interaction ownership、automation/goal ownership、production surface wiring，或 M4/M5 production cutover。这些内容保留给各自所属的 follow-up slice。

属于 #1167；关联 #853。

</details>
