### PR TITLE
fix(runtime): identify workspaces by UUID marker

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -71,6 +71,7 @@ import {
   createTelemetryRepo,
 } from '@maka/storage';
 import { resolveStorageRoot } from '@maka/storage/root-authority';
+import { resolveWorkspaceIdentity } from '@maka/storage/workspace-identity';
 import { McpClientManager } from '@maka/mcp';
 import { registerMcpIpcMain } from './mcp-ipc-main.js';
 import {
@@ -749,6 +750,7 @@ const runtime = new SessionManager({
   },
   inspectContinuationSafety: createLocalContinuationSafetyInspector({
     readSessionCwd: async (sessionId) => (await store.readHeader(sessionId)).cwd,
+    resolveWorkspaceIdentity: async (cwd) => resolveWorkspaceIdentity({ path: cwd }),
     listAvailableToolNames: async () => [
       ...builtinTools.map((tool) => tool.name),
       'expert_dispatch',

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -333,7 +333,7 @@ describe('Maka session driver', () => {
     assert.deepEqual(runtime.sessionUpdates, []);
   });
 
-  test('moves an active session, warns about dirty old cwd, and injects one replayable reminder', async () => {
+  test('moves an active session, warns about dirty old cwd, and leaves prompts unchanged', async () => {
     const oldCwd = await mkdtemp(join(tmpdir(), 'maka-move-old-'));
     const nextCwd = join(oldCwd, 'worktree-next');
     await mkdir(nextCwd);
@@ -364,21 +364,12 @@ describe('Maka session driver', () => {
       assert.deepEqual(inspected, [oldCwd]);
       assert.deepEqual(runtime.sessionUpdates.at(-1), {
         sessionId: 'session-1',
-        patch: {
-          cwd: canonicalNextCwd,
-          pendingCwdReminder: { from: oldCwd, to: canonicalNextCwd },
-        },
+        patch: { cwd: canonicalNextCwd },
       });
 
       await collectPrompt(driver, 'after move');
-      assert.match(
-        runtime.sent.at(-1)?.input.text ?? '',
-        new RegExp(`<system-reminder>.*${escapeRegExp(oldCwd)}.*${escapeRegExp(canonicalNextCwd)}`),
-      );
-      assert.equal(runtime.sent.at(-1)?.input.displayText, 'after move');
-
-      await collectPrompt(driver, 'later turn');
-      assert.equal(runtime.sent.at(-1)?.input.text, 'later turn');
+      assert.equal(runtime.sent.at(-1)?.input.text, 'after move');
+      assert.equal(runtime.sent.at(-1)?.input.displayText, undefined);
     } finally {
       await rm(oldCwd, { recursive: true, force: true });
     }
@@ -407,7 +398,7 @@ describe('Maka session driver', () => {
     }
   });
 
-  test('does not carry a pending cwd reminder into a new session', async () => {
+  test('uses the moved cwd for a new session without changing its prompt', async () => {
     const oldCwd = await mkdtemp(join(tmpdir(), 'maka-move-new-session-'));
     const nextCwd = join(oldCwd, 'next');
     await mkdir(nextCwd);
@@ -483,19 +474,14 @@ describe('Maka session driver', () => {
     }
   });
 
-  test('restores a persisted cwd reminder when resuming a moved session', async () => {
+  test('uses a resumed session cwd without injecting a synthetic reminder', async () => {
     const oldCwd = await mkdtemp(join(tmpdir(), 'maka-move-persisted-old-'));
     const nextCwd = join(oldCwd, 'worktree-next');
     await mkdir(nextCwd);
     try {
       const runtime = new RecordingRuntime();
       const canonicalNextCwd = await realpath(nextCwd);
-      runtime.sessionSummaries = [
-        {
-          ...sessionSummary({ id: 'session-2', cwd: canonicalNextCwd }),
-          pendingCwdReminder: { from: oldCwd, to: canonicalNextCwd },
-        },
-      ];
+      runtime.sessionSummaries = [sessionSummary({ id: 'session-2', cwd: canonicalNextCwd })];
       const driver = createMakaSessionDriver({
         runtime,
         cwd: oldCwd,
@@ -506,14 +492,9 @@ describe('Maka session driver', () => {
       await driver.switchSession('session-2');
       await collectPrompt(driver, 'after restart');
 
-      assert.match(
-        runtime.sent.at(-1)?.input.text ?? '',
-        new RegExp(`<system-reminder>.*${escapeRegExp(oldCwd)}.*${escapeRegExp(canonicalNextCwd)}`),
-      );
-      assert.deepEqual(runtime.sessionUpdates.at(-1), {
-        sessionId: 'session-2',
-        patch: { pendingCwdReminder: undefined },
-      });
+      assert.equal(runtime.sent.at(-1)?.input.text, 'after restart');
+      assert.equal(runtime.sent.at(-1)?.input.displayText, undefined);
+      assert.deepEqual(runtime.sessionUpdates, []);
     } finally {
       await rm(oldCwd, { recursive: true, force: true });
     }
@@ -1026,7 +1007,6 @@ class RecordingRuntime {
     sessionId: string;
     patch: {
       cwd?: string;
-      pendingCwdReminder?: SessionSummary['pendingCwdReminder'];
       model?: string;
       llmConnectionSlug?: string;
       thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined;
@@ -1199,7 +1179,6 @@ class RecordingRuntime {
     sessionId: string,
     patch: {
       cwd?: string;
-      pendingCwdReminder?: SessionSummary['pendingCwdReminder'];
       model?: string;
       llmConnectionSlug?: string;
       thinkingLevel?: import('@maka/core/model-thinking').ThinkingLevel | undefined;
@@ -1210,9 +1189,6 @@ class RecordingRuntime {
     return {
       id: sessionId,
       cwd: patch.cwd ?? '/repo',
-      ...(Object.hasOwn(patch, 'pendingCwdReminder')
-        ? { pendingCwdReminder: patch.pendingCwdReminder }
-        : {}),
       name: this.updatedSessionName,
       isFlagged: false,
       isArchived: false,

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -71,6 +71,7 @@ import {
   persistProviderRequestCaptureArtifact,
 } from '@maka/storage';
 import { resolveStorageRoot } from '@maka/storage/root-authority';
+import { resolveWorkspaceIdentity } from '@maka/storage/workspace-identity';
 import type { ToolPermissionRule } from '@maka/core/permission';
 import { fetchProviderModels } from '@maka/runtime';
 import { createApiKeyOnboardingSurface, type MakaOnboardingSurface } from './onboarding.js';
@@ -725,6 +726,7 @@ export async function createMakaCliRuntimeContext(
     },
     inspectContinuationSafety: createLocalContinuationSafetyInspector({
       readSessionCwd: async (sessionId) => (await store.readHeader(sessionId)).cwd,
+      resolveWorkspaceIdentity: async (cwd) => resolveWorkspaceIdentity({ path: cwd }),
       listAvailableToolNames: async () => allTools.map((tool) => tool.name),
       hasPendingBackgroundOperations: async (sessionId) => {
         const [shellUpdates, runs] = await Promise.all([

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -54,7 +54,6 @@ export interface MakaSessionRuntime {
     sessionId: string,
     patch: {
       cwd?: string;
-      pendingCwdReminder?: SessionSummary['pendingCwdReminder'];
       model?: string;
       llmConnectionSlug?: string;
       thinkingLevel?: ThinkingLevel | undefined;
@@ -206,7 +205,6 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   private thinkingLevel: ThinkingLevel | undefined;
   private permissionMode: PermissionMode;
   private orchestrationMode: OrchestrationMode;
-  private pendingCwdReminder: { from: string; to: string } | undefined;
   private readonly newId: () => string;
 
   constructor(private readonly input: MakaSessionDriverInput) {
@@ -224,11 +222,7 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   ): Promise<MakaPreparedSessionTurn> {
     const sessionId = await this.ensureSession();
     const turnId = options.turnId ?? this.newId();
-    const pendingReminder = this.pendingCwdReminder;
-    const baseModelText = options.modelText ?? prompt;
-    const modelText = pendingReminder
-      ? `${cwdChangeReminder(pendingReminder.from, pendingReminder.to)}\n\n${baseModelText}`
-      : baseModelText;
+    const modelText = options.modelText ?? prompt;
     const events = this.input.runtime.sendMessage(sessionId, {
       turnId,
       text: modelText,
@@ -238,38 +232,8 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     return {
       sessionId,
       turnId,
-      events: pendingReminder
-        ? this.clearCwdReminderAfterStart(sessionId, events, pendingReminder)
-        : events,
+      events,
     };
-  }
-
-  private async *clearCwdReminderAfterStart(
-    sessionId: string,
-    events: AsyncIterable<SessionEvent>,
-    reminder: { from: string; to: string },
-  ): AsyncIterable<SessionEvent> {
-    const iterator = events[Symbol.asyncIterator]();
-    const first = await iterator.next();
-    if (first.done) return;
-    if (
-      this.pendingCwdReminder?.from === reminder.from &&
-      this.pendingCwdReminder.to === reminder.to
-    ) {
-      try {
-        await this.input.runtime.updateSession(sessionId, { pendingCwdReminder: undefined });
-        this.pendingCwdReminder = undefined;
-      } catch {
-        // Keep the durable reminder when header cleanup fails. The next turn
-        // may repeat it, but the session cannot lose the cwd context.
-      }
-    }
-    yield first.value;
-    while (true) {
-      const next = await iterator.next();
-      if (next.done) return;
-      yield next.value;
-    }
   }
 
   async *compactSession(): AsyncIterable<SessionEvent> {
@@ -411,15 +375,10 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     }
     const inspectCwdChanges = this.input.inspectCwdChanges ?? inspectGitCwdChanges;
     const oldCwdDirty = await inspectCwdChanges(previousCwd).catch(() => undefined);
-    const reminderFrom = this.pendingCwdReminder?.from ?? previousCwd;
-    const pendingCwdReminder =
-      reminderFrom === nextCwd ? undefined : { from: reminderFrom, to: nextCwd };
     const summary = await this.input.runtime.updateSession(this.sessionId, {
       cwd: nextCwd,
-      pendingCwdReminder,
     });
     this.cwd = summary.cwd ?? nextCwd;
-    this.pendingCwdReminder = summary.pendingCwdReminder ?? pendingCwdReminder;
     return { previousCwd, cwd: this.cwd, changed: true, oldCwdDirty };
   }
 
@@ -434,7 +393,6 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     const sessionCwd = summary.cwd!;
     const messages = await this.input.runtime.getMessages(summary.id);
     this.sessionId = summary.id;
-    this.pendingCwdReminder = summary.pendingCwdReminder;
     this.cwd = sessionCwd;
     this.model = summary.model;
     this.llmConnectionSlug = summary.llmConnectionSlug;
@@ -493,7 +451,6 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     // stay put, so the next prompt lazily creates a fresh session that inherits
     // them (via ensureSession). The old session is left intact on disk.
     this.sessionId = null;
-    this.pendingCwdReminder = undefined;
   }
 
   getSessionId(): string | null {
@@ -573,19 +530,6 @@ async function inspectGitCwdChanges(cwd: string): Promise<boolean | undefined> {
     // never prevent a successful move. The warning is best-effort by design.
     return undefined;
   }
-}
-
-function cwdChangeReminder(from: string, to: string): string {
-  return `<system-reminder>The session working directory changed from ${escapeReminderPath(from)} to ${escapeReminderPath(to)}. This is the same project, possibly at a new location. Use the new working directory for all subsequent file and shell operations.</system-reminder>`;
-}
-
-function escapeReminderPath(value: string): string {
-  return value
-    .replaceAll('&', '&amp;')
-    .replaceAll('<', '&lt;')
-    .replaceAll('>', '&gt;')
-    .replaceAll('"', '&quot;')
-    .replaceAll("'", '&apos;');
 }
 
 function cwdRank(session: SessionSummary, cwd: string): number {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -86,8 +86,6 @@ export interface SessionHeader {
   id: string;
   workspaceRoot: string;
   cwd: string;
-  /** One-shot model context to inject after a CLI session cwd move. */
-  pendingCwdReminder?: { from: string; to: string };
 
   // Lifecycle timestamps
   createdAt: number;
@@ -146,8 +144,6 @@ export type BackendKind = 'ai-sdk' | 'fake' | 'pi-agent';
 export interface SessionSummary {
   id: string;
   cwd?: string;
-  /** One-shot model context to inject after a CLI session cwd move. */
-  pendingCwdReminder?: { from: string; to: string };
   name: string;
   isFlagged: boolean;
   isArchived: boolean;

--- a/packages/runtime/src/__tests__/runtime-continuation.test.ts
+++ b/packages/runtime/src/__tests__/runtime-continuation.test.ts
@@ -15,14 +15,19 @@ import { RuntimeRunner } from '../runtime-runner.js';
 test('local continuation safety inspector derives portable authoritative host facts', async () => {
   const inspect = createLocalContinuationSafetyInspector({
     readSessionCwd: async () => '/workspace/repo-link',
-    resolveWorkspacePath: async () => '/workspace/repo',
-    readWorkspaceStat: async () => ({ dev: 7, ino: 42 }),
+    resolveWorkspaceIdentity: async () => ({
+      workspaceIdentity: 'workspace:v1:123e4567-e89b-42d3-a456-426614174000',
+      canonicalPath: '/workspace/repo',
+      legacyWorkspaceIdentities: ['fs:7:42:/workspace/repo'],
+    }),
     listAvailableToolNames: async () => ['Write', 'Read', 'Read'],
     hasPendingBackgroundOperations: async () => false,
   });
 
   assert.deepEqual(await inspect('session-1'), {
-    workspaceIdentity: 'fs:7:42:/workspace/repo',
+    workspaceIdentity: 'workspace:v1:123e4567-e89b-42d3-a456-426614174000',
+    workspacePath: '/workspace/repo',
+    legacyWorkspaceIdentities: ['fs:7:42:/workspace/repo'],
     backgroundOperationsSettled: true,
     availableToolNames: ['Read', 'Write'],
   });

--- a/packages/runtime/src/__tests__/runtime-resume.test.ts
+++ b/packages/runtime/src/__tests__/runtime-resume.test.ts
@@ -310,6 +310,46 @@ describe('runtime resume phase 1 safe-boundary continuation', () => {
     assert.deepEqual(plan.rejectionReasons, ['workspace_identity_mismatch']);
   });
 
+  test('continues after a workspace path change when the UUID marker is unchanged', () => {
+    const plan = buildSafeBoundaryContinuationPlan(
+      [textEvent('user-1', 'user', 'inspect the repository')],
+      {
+        ...safeBoundaryFacts(),
+        currentCwd: '/fresh-sandbox/repo',
+      },
+    );
+
+    assert.equal(plan.disposition, 'continue');
+    assert.deepEqual(plan.rejectionReasons, []);
+    assert.deepEqual(plan.diagnostics, [
+      {
+        code: 'workspace_location_changed',
+        message: 'workspace location differs from the source resume boundary',
+        detail: {
+          sourceCwd: '/workspace/repo',
+          currentCwd: '/fresh-sandbox/repo',
+        },
+      },
+    ]);
+  });
+
+  test('migrates a legacy filesystem anchor through a marker alias', () => {
+    const workspaceIdentity = 'workspace:v1:123e4567-e89b-42d3-a456-426614174000';
+    const legacyIdentity = 'fs:7:42:/workspace/repo';
+    const plan = buildSafeBoundaryContinuationPlan(
+      [textEvent('user-1', 'user', 'inspect the repository')],
+      {
+        ...safeBoundaryFacts(),
+        sourceWorkspaceIdentity: legacyIdentity,
+        currentWorkspaceIdentity: workspaceIdentity,
+        currentWorkspaceIdentityAliases: [legacyIdentity],
+      },
+    );
+
+    assert.equal(plan.disposition, 'continue');
+    assert.equal(plan.continuation?.safetySnapshot.workspaceIdentity, workspaceIdentity);
+  });
+
   test('parks while a background operation is still unsettled', () => {
     const plan = buildSafeBoundaryContinuationPlan(
       [
@@ -362,10 +402,6 @@ describe('runtime resume phase 1 safe-boundary continuation', () => {
       {
         facts: { ...safeBoundaryFacts(), terminalRepairSucceeded: false },
         reason: 'terminal_repair_failed',
-      },
-      {
-        facts: { ...safeBoundaryFacts(), currentCwd: '/workspace/other' },
-        reason: 'workspace_cwd_mismatch',
       },
     ] as const;
 

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -1151,7 +1151,7 @@ describe('SessionManager permission mode updates', () => {
     expect(runtimeEvents[2]?.status).toBe('completed');
   });
 
-  test('executes an approved safe-boundary continuation as a new lineage run without another user message', async () => {
+  test('executes an approved continuation after a path move without another user message', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
@@ -1240,6 +1240,8 @@ describe('SessionManager permission mode updates', () => {
     expect(plan.disposition).toBe('continue');
     if (!plan.continuation) throw new Error('expected continuation');
 
+    const movedCwd = '/fresh-sandbox/repo';
+    await store.updateHeader(session.id, { cwd: movedCwd });
     const sessionEvents = await collectSessionEvents(
       manager.resumeSafeBoundaryContinuation(plan.continuation),
     );
@@ -1250,6 +1252,7 @@ describe('SessionManager permission mode updates', () => {
     expect(continuationRun.turnId).toBe(plan.continuation.turnId);
     expect(continuationRun.parentRunId).toBe(sourceRunId);
     expect(continuationRun.parentTurnId).toBe(sourceTurnId);
+    expect(continuationRun.cwd).toBe(movedCwd);
     expect(continuationRun.status).toBe('completed');
     expect(continuationRun).toMatchObject({
       orchestrationMode: 'swarm',

--- a/packages/runtime/src/continuation-safety.ts
+++ b/packages/runtime/src/continuation-safety.ts
@@ -1,48 +1,42 @@
-import { realpath, stat } from 'node:fs/promises';
-
 import type { RuntimeContinuationSafetyObservation } from './runtime-resume.js';
+
+export interface ResolvedWorkspaceIdentity {
+  workspaceIdentity: string;
+  canonicalPath: string;
+  legacyWorkspaceIdentities?: readonly string[];
+}
 
 export interface LocalContinuationSafetyInspectorDeps {
   readSessionCwd(sessionId: string): Promise<string>;
+  resolveWorkspaceIdentity(cwd: string): Promise<ResolvedWorkspaceIdentity>;
   listAvailableToolNames(sessionId: string): Promise<readonly string[]>;
   hasPendingBackgroundOperations(sessionId: string): Promise<boolean>;
   readWorkspaceCheckpoint?: (
     sessionId: string,
   ) => Promise<RuntimeContinuationSafetyObservation['workspaceCheckpoint']>;
-  resolveWorkspacePath?: (cwd: string) => Promise<string>;
-  readWorkspaceStat?: (path: string) => Promise<{ dev: number | bigint; ino: number | bigint }>;
 }
 
 export function createLocalContinuationSafetyInspector(
   deps: LocalContinuationSafetyInspectorDeps,
 ): (sessionId: string) => Promise<RuntimeContinuationSafetyObservation> {
-  const resolveWorkspacePath = deps.resolveWorkspacePath ?? realpath;
-  const readWorkspaceStat =
-    deps.readWorkspaceStat ??
-    (async (path: string) => {
-      const value = await stat(path);
-      return { dev: value.dev, ino: value.ino };
-    });
   return async (sessionId) => {
     const cwd = await deps.readSessionCwd(sessionId);
-    const resolvedPath = normalizeWorkspacePath(await resolveWorkspacePath(cwd));
-    const workspaceStat = await readWorkspaceStat(resolvedPath);
-    const [availableToolNames, hasPendingBackgroundOperations, workspaceCheckpoint] =
+    const [workspace, availableToolNames, hasPendingBackgroundOperations, workspaceCheckpoint] =
       await Promise.all([
+        deps.resolveWorkspaceIdentity(cwd),
         deps.listAvailableToolNames(sessionId),
         deps.hasPendingBackgroundOperations(sessionId),
         deps.readWorkspaceCheckpoint?.(sessionId),
       ]);
     return {
-      workspaceIdentity: `fs:${String(workspaceStat.dev)}:${String(workspaceStat.ino)}:${resolvedPath}`,
+      workspaceIdentity: workspace.workspaceIdentity,
+      workspacePath: workspace.canonicalPath,
+      ...(workspace.legacyWorkspaceIdentities?.length
+        ? { legacyWorkspaceIdentities: [...workspace.legacyWorkspaceIdentities] }
+        : {}),
       backgroundOperationsSettled: !hasPendingBackgroundOperations,
       availableToolNames: [...new Set(availableToolNames)].sort(),
       ...(workspaceCheckpoint ? { workspaceCheckpoint } : {}),
     };
   };
-}
-
-function normalizeWorkspacePath(value: string): string {
-  const normalized = value.replaceAll('\\', '/').replace(/\/+$/, '');
-  return /^[A-Za-z]:\//.test(normalized) ? normalized.toLowerCase() : normalized;
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1088,7 +1088,10 @@ export type {
 } from './recovery-resolver.js';
 
 export { createLocalContinuationSafetyInspector } from './continuation-safety.js';
-export type { LocalContinuationSafetyInspectorDeps } from './continuation-safety.js';
+export type {
+  LocalContinuationSafetyInspectorDeps,
+  ResolvedWorkspaceIdentity,
+} from './continuation-safety.js';
 // history-compact-summarizer.ts — replay-plan → ModelMessage[] projection
 // (issue #1055's session-recap generator reuses this authoritative slice
 // instead of re-deriving a lossy projection of its own).

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -349,7 +349,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       continuation.sessionId,
       continuation.sourceRunId,
     );
-    assertContinuationSourceUnchanged(continuation, sourceRun, sourceEvents, header.cwd);
+    assertContinuationSourceUnchanged(continuation, sourceRun, sourceEvents);
     if (!this.deps.inspectContinuationSafety) {
       throw new Error('Runtime continuation requires an authoritative safety inspector');
     }
@@ -1687,7 +1687,6 @@ function assertContinuationSourceUnchanged(
   continuation: RuntimeContinuation,
   sourceRun: AgentRunHeader,
   sourceEvents: readonly RuntimeEvent[],
-  currentCwd: string,
 ): void {
   if (
     sourceRun.runId !== continuation.sourceRunId ||
@@ -1706,12 +1705,6 @@ function assertContinuationSourceUnchanged(
     throw new RuntimeContinuationRevalidationError(
       'source_terminal_changed',
       'Runtime continuation source is no longer terminal',
-    );
-  }
-  if (normalizeResumeCwd(sourceRun.cwd) !== normalizeResumeCwd(currentCwd)) {
-    throw new RuntimeContinuationRevalidationError(
-      'source_cwd_changed',
-      'Runtime continuation workspace cwd changed after planning',
     );
   }
   if (sourceEvents.length !== continuation.sourceRuntimeEventHighWater) {
@@ -1746,11 +1739,6 @@ function assertContinuationSourceUnchanged(
       'Runtime continuation replay context changed after planning',
     );
   }
-}
-
-function normalizeResumeCwd(value: string): string {
-  const normalized = value.replaceAll('\\', '/').replace(/\/+$/, '');
-  return /^[A-Za-z]:\//.test(normalized) ? normalized.toLowerCase() : normalized;
 }
 
 function assertContinuationSafetyUnchanged(

--- a/packages/runtime/src/runtime-resume.ts
+++ b/packages/runtime/src/runtime-resume.ts
@@ -63,6 +63,7 @@ export type ResumePlanDiagnosticCode =
   | 'runtime_ledger_unreadable'
   | 'terminal_repair_failed'
   | 'workspace_cwd_mismatch'
+  | 'workspace_location_changed'
   | 'runtime_ledger_empty'
   | 'runtime_identity_mismatch'
   | 'continuation_identity_reused'
@@ -217,6 +218,7 @@ export interface SafeBoundaryContinuationFacts {
   currentCwd: string;
   sourceWorkspaceIdentity: string;
   currentWorkspaceIdentity: string;
+  currentWorkspaceIdentityAliases?: readonly string[];
   backgroundOperationsSettled: boolean;
   availableToolNames: readonly string[];
   continuationIdentity: ContinuationIdentity;
@@ -258,6 +260,10 @@ export interface RuntimeContinuationSafetySnapshot {
 
 export interface RuntimeContinuationSafetyObservation {
   workspaceIdentity: string;
+  /** Current location is diagnostic only and never participates in identity. */
+  workspacePath?: string;
+  /** One-way compatibility aliases for legacy fs:{dev}:{ino}:{path} AgentRuns. */
+  legacyWorkspaceIdentities?: readonly string[];
   backgroundOperationsSettled: boolean;
   availableToolNames: readonly string[];
   workspaceCheckpoint?: {
@@ -280,6 +286,7 @@ export interface RuntimeContinuationPlannerInput {
   currentCwd: string;
   sourceWorkspaceIdentity: string;
   currentWorkspaceIdentity: string;
+  currentWorkspaceIdentityAliases?: readonly string[];
   backgroundOperationsSettled: boolean;
   availableToolNames: readonly string[];
   expectedRuntimeEventHighWater?: number;
@@ -371,6 +378,9 @@ export class RuntimeContinuationPlanner {
       currentCwd: input.currentCwd,
       sourceWorkspaceIdentity: input.sourceWorkspaceIdentity,
       currentWorkspaceIdentity: input.currentWorkspaceIdentity,
+      ...(input.currentWorkspaceIdentityAliases?.length
+        ? { currentWorkspaceIdentityAliases: input.currentWorkspaceIdentityAliases }
+        : {}),
       backgroundOperationsSettled: input.backgroundOperationsSettled,
       availableToolNames: input.availableToolNames,
       continuationIdentity: {
@@ -613,13 +623,15 @@ export function buildSafeBoundaryContinuationPlan(
   }
   if (normalizeCwd(facts.sourceCwd) !== normalizeCwd(facts.currentCwd)) {
     phaseOneDiagnostics.push({
-      code: 'workspace_cwd_mismatch',
-      message: 'current cwd differs from the source resume boundary',
+      code: 'workspace_location_changed',
+      message: 'workspace location differs from the source resume boundary',
       detail: { sourceCwd: facts.sourceCwd, currentCwd: facts.currentCwd },
     });
-    phaseOneRejectionReasons.push('workspace_cwd_mismatch');
   }
-  if (facts.sourceWorkspaceIdentity !== facts.currentWorkspaceIdentity) {
+  if (
+    facts.sourceWorkspaceIdentity !== facts.currentWorkspaceIdentity &&
+    !facts.currentWorkspaceIdentityAliases?.includes(facts.sourceWorkspaceIdentity)
+  ) {
     phaseOneDiagnostics.push({
       code: 'workspace_identity_mismatch',
       message: 'current workspace identity differs from the source resume boundary',
@@ -713,7 +725,7 @@ export function buildSafeBoundaryContinuationPlan(
   return {
     disposition: 'continue',
     rejectionReasons: [],
-    diagnostics: [],
+    diagnostics: phaseOneDiagnostics,
     continuation: {
       sessionId: source.sessionId,
       ...facts.continuationIdentity,

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1072,6 +1072,9 @@ export class SessionManager {
       currentCwd: header.cwd,
       sourceWorkspaceIdentity: sourceRun.workspaceIdentity,
       currentWorkspaceIdentity: observation.workspaceIdentity,
+      ...(observation.legacyWorkspaceIdentities?.length
+        ? { currentWorkspaceIdentityAliases: observation.legacyWorkspaceIdentities }
+        : {}),
       backgroundOperationsSettled: observation.backgroundOperationsSettled,
       availableToolNames: observation.availableToolNames,
       ...(input.expectedRuntimeEventHighWater !== undefined
@@ -2258,7 +2261,6 @@ export function headerToSummary(h: SessionHeader): SessionSummary {
   const summary: SessionSummary = {
     id: h.id,
     cwd: h.cwd,
-    ...(h.pendingCwdReminder ? { pendingCwdReminder: h.pendingCwdReminder } : {}),
     name: h.name === 'New Session' ? DEFAULT_SESSION_NAME : h.name,
     isFlagged: h.isFlagged,
     isArchived: h.isArchived,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -9,6 +9,7 @@
     ".": "./dist/index.js",
     "./execution-stores": "./dist/execution-stores.js",
     "./root-authority": "./dist/root-authority.js",
+    "./workspace-identity": "./dist/workspace-identity.js",
     "./write-queue": "./dist/write-queue.js"
   },
   "scripts": {

--- a/packages/storage/src/__tests__/root-authority.test.ts
+++ b/packages/storage/src/__tests__/root-authority.test.ts
@@ -18,6 +18,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import {
+  adoptStorageRootOnImport,
   assertStorageRootCapability,
   assertStorageRootLease,
   createHeadlessRootLease,
@@ -119,6 +120,60 @@ describe('storage root authority', () => {
         () => resolveStorageRoot({ path: copiedRoot, kind: 'interactive' }),
         (error: unknown) =>
           error instanceof StorageRootAuthorityError && error.code === 'root_identity_collision',
+      );
+    });
+  });
+
+  test('adopts the host-local identity of an explicitly imported storage root', async () => {
+    await withRoots(async ({ base, root }) => {
+      const initialized = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const copiedRoot = join(base, 'copied-root');
+      await cp(root, copiedRoot, { recursive: true });
+
+      await assert.rejects(
+        () => resolveStorageRoot({ path: copiedRoot, kind: 'interactive' }),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'root_identity_collision',
+      );
+      const markerBeforeConflict = await readFile(
+        join(copiedRoot, STORAGE_ROOT_MARKER_FILE),
+        'utf8',
+      );
+      await assert.rejects(
+        () =>
+          adoptStorageRootOnImport({
+            path: copiedRoot,
+            kind: 'interactive',
+            expectedRootId: '0'.repeat(64),
+          }),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'root_identity_collision',
+      );
+      assert.equal(
+        await readFile(join(copiedRoot, STORAGE_ROOT_MARKER_FILE), 'utf8'),
+        markerBeforeConflict,
+      );
+      await rm(root, { recursive: true, force: true });
+
+      const adopted = await adoptStorageRootOnImport({
+        path: copiedRoot,
+        kind: 'interactive',
+        expectedRootId: initialized.rootId,
+      });
+      assert.equal(adopted.rootId, initialized.rootId);
+      assert.equal(
+        (
+          await adoptStorageRootOnImport({
+            path: copiedRoot,
+            kind: 'interactive',
+            expectedRootId: initialized.rootId,
+          })
+        ).rootId,
+        initialized.rootId,
+      );
+      assert.equal(
+        (await resolveStorageRoot({ path: copiedRoot, kind: 'interactive' })).rootId,
+        initialized.rootId,
       );
     });
   });

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -97,18 +97,26 @@ describe('FileSessionStore CRUD', () => {
     });
   });
 
-  test('persists and clears the pending cwd reminder in the session header', async () => {
-    await withStore(async (store) => {
+  test('reads legacy pending cwd reminders but drops them during normalization', async () => {
+    await withStore(async (store, workspaceRoot) => {
       const header = await store.create(makeInput({ name: 'Moved session' }));
-      const reminder = { from: '/tmp/old-worktree', to: '/tmp/new-worktree' };
+      const path = join(workspaceRoot, 'sessions', header.id, 'session.jsonl');
+      const legacyHeader = {
+        ...JSON.parse(await readFile(path, 'utf8')),
+        pendingCwdReminder: {
+          from: '/tmp/old-worktree',
+          to: '/tmp/new-worktree',
+        },
+      };
+      await writeFile(path, `${JSON.stringify(legacyHeader)}\n`, 'utf8');
 
-      await store.updateHeader(header.id, { pendingCwdReminder: reminder });
-      assert.deepEqual((await store.readHeader(header.id)).pendingCwdReminder, reminder);
-      assert.deepEqual((await store.list())[0]?.pendingCwdReminder, reminder);
+      const normalized = await store.readHeader(header.id);
+      assert.equal(Object.hasOwn(normalized, 'pendingCwdReminder'), false);
+      assert.equal(Object.hasOwn((await store.list())[0]!, 'pendingCwdReminder'), false);
 
-      await store.updateHeader(header.id, { pendingCwdReminder: undefined });
-      assert.equal((await store.readHeader(header.id)).pendingCwdReminder, undefined);
-      assert.equal((await store.list())[0]?.pendingCwdReminder, undefined);
+      await store.updateHeader(header.id, { name: 'Normalized after move' });
+      const persisted = JSON.parse(await readFile(path, 'utf8')) as Record<string, unknown>;
+      assert.equal(Object.hasOwn(persisted, 'pendingCwdReminder'), false);
     });
   });
 

--- a/packages/storage/src/__tests__/workspace-identity.test.ts
+++ b/packages/storage/src/__tests__/workspace-identity.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { cp, mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -71,6 +71,86 @@ test('import adoption rejects a conflicting workspace UUID', async () => {
         }),
       (error: unknown) =>
         error instanceof WorkspaceIdentityError && error.code === 'workspace_identity_conflict',
+    );
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('import adoption rejects an alias overflow without changing the durable marker', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-alias-overflow-'));
+  try {
+    const original = await resolveWorkspaceIdentity({ path: workspace });
+    const markerPath = join(workspace, WORKSPACE_MARKER_FILE);
+    const marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+      schemaVersion: number;
+      workspaceId: string;
+      legacyAnchors: string[];
+    };
+    marker.legacyAnchors = Array.from(
+      { length: 32 },
+      (_, index) => `fs:1:${index + 1}:/legacy/workspace-${index}`,
+    );
+    await writeFile(markerPath, `${JSON.stringify(marker)}\n`, 'utf8');
+    const markerBefore = await readFile(markerPath);
+
+    await assert.rejects(
+      () =>
+        adoptWorkspaceIdentityOnImport({
+          path: workspace,
+          legacyWorkspaceIdentity: 'fs:9:9:/legacy/overflow',
+        }),
+      (error: unknown) =>
+        error instanceof WorkspaceIdentityError && error.code === 'invalid_workspace_marker',
+    );
+
+    assert.deepEqual(await readFile(markerPath), markerBefore);
+    assert.equal(
+      (await resolveWorkspaceIdentity({ path: workspace })).workspaceIdentity,
+      original.workspaceIdentity,
+    );
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('import adoption rejects a marker size overflow without changing the durable marker', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-size-overflow-'));
+  try {
+    const original = await resolveWorkspaceIdentity({ path: workspace });
+    const markerPath = join(workspace, WORKSPACE_MARKER_FILE);
+    const marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+      schemaVersion: number;
+      workspaceId: string;
+      legacyAnchors: string[];
+    };
+    marker.legacyAnchors = [`fs:1:1:/${'a'.repeat(1_900)}`, `fs:1:2:/${'b'.repeat(1_900)}`];
+    const markerBeforeText = `${JSON.stringify(marker)}\n`;
+    const overflowAlias = `fs:1:3:/${'c'.repeat(300)}`;
+    assert.ok(Buffer.byteLength(markerBeforeText, 'utf8') <= 4_096);
+    assert.ok(
+      Buffer.byteLength(
+        `${JSON.stringify({ ...marker, legacyAnchors: [...marker.legacyAnchors, overflowAlias] })}\n`,
+        'utf8',
+      ) > 4_096,
+    );
+    await writeFile(markerPath, markerBeforeText, 'utf8');
+    const markerBefore = await readFile(markerPath);
+
+    await assert.rejects(
+      () =>
+        adoptWorkspaceIdentityOnImport({
+          path: workspace,
+          legacyWorkspaceIdentity: overflowAlias,
+        }),
+      (error: unknown) =>
+        error instanceof WorkspaceIdentityError && error.code === 'invalid_workspace_marker',
+    );
+
+    assert.deepEqual(await readFile(markerPath), markerBefore);
+    assert.equal(
+      (await resolveWorkspaceIdentity({ path: workspace })).workspaceIdentity,
+      original.workspaceIdentity,
     );
   } finally {
     await rm(workspace, { recursive: true, force: true });

--- a/packages/storage/src/__tests__/workspace-identity.test.ts
+++ b/packages/storage/src/__tests__/workspace-identity.test.ts
@@ -1,0 +1,78 @@
+import assert from 'node:assert/strict';
+import { cp, mkdir, mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import {
+  adoptWorkspaceIdentityOnImport,
+  resolveWorkspaceIdentity,
+  WORKSPACE_IDENTITY_PREFIX,
+  WORKSPACE_MARKER_FILE,
+  WorkspaceIdentityError,
+} from '../workspace-identity.js';
+
+test('a copied marker preserves workspace identity across archive extraction', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-workspace-identity-'));
+  try {
+    const source = join(base, 'source');
+    const imported = join(base, 'imported');
+    await mkdir(source);
+    const original = await resolveWorkspaceIdentity({ path: source });
+    const markerBefore = await readFile(join(source, WORKSPACE_MARKER_FILE), 'utf8');
+
+    await cp(source, imported, { recursive: true });
+    assert.equal(await readFile(join(imported, WORKSPACE_MARKER_FILE), 'utf8'), markerBefore);
+    const adopted = await adoptWorkspaceIdentityOnImport({
+      path: imported,
+      expectedWorkspaceIdentity: original.workspaceIdentity,
+    });
+
+    assert.equal(adopted.workspaceIdentity, original.workspaceIdentity);
+    assert.match(adopted.workspaceIdentity, new RegExp(`^${WORKSPACE_IDENTITY_PREFIX}`));
+    assert.equal(await readFile(join(imported, WORKSPACE_MARKER_FILE), 'utf8'), markerBefore);
+    assert.equal(
+      JSON.parse(await readFile(join(imported, WORKSPACE_MARKER_FILE), 'utf8')).workspaceId,
+      JSON.parse(markerBefore).workspaceId,
+    );
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('explicit import adoption records a pre-marker legacy filesystem anchor', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-legacy-'));
+  try {
+    const legacyWorkspaceIdentity = 'fs:7:42:/old-sandbox/repo';
+    const adopted = await adoptWorkspaceIdentityOnImport({
+      path: workspace,
+      legacyWorkspaceIdentity,
+    });
+
+    assert.ok(adopted.legacyWorkspaceIdentities.includes(legacyWorkspaceIdentity));
+    assert.equal(
+      (await resolveWorkspaceIdentity({ path: workspace })).workspaceIdentity,
+      adopted.workspaceIdentity,
+    );
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('import adoption rejects a conflicting workspace UUID', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-conflict-'));
+  try {
+    await resolveWorkspaceIdentity({ path: workspace });
+    await assert.rejects(
+      () =>
+        adoptWorkspaceIdentityOnImport({
+          path: workspace,
+          expectedWorkspaceIdentity: 'workspace:v1:123e4567-e89b-42d3-a456-426614174000',
+        }),
+      (error: unknown) =>
+        error instanceof WorkspaceIdentityError && error.code === 'workspace_identity_conflict',
+    );
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -32,3 +32,4 @@ export * from './automation-store.js';
 export * from './sqlite-runtime-store.js';
 export * from './runtime-event-transfer.js';
 export * from './mcp-config-store.js';
+export * from './workspace-identity.js';

--- a/packages/storage/src/root-authority.ts
+++ b/packages/storage/src/root-authority.ts
@@ -7,6 +7,7 @@ import {
   mkdir,
   open,
   realpath,
+  rename,
   stat,
   unlink,
   type FileHandle,
@@ -59,6 +60,9 @@ export interface ResolveExistingStorageRootInput<K extends StorageRootKind>
   extends ResolveStorageRootInput<K> {
   expectedRootId: string;
 }
+
+export type AdoptStorageRootOnImportInput<K extends StorageRootKind> =
+  ResolveExistingStorageRootInput<K>;
 
 export interface InteractiveRootOwner {
   readonly capability: StorageRootCapability<'interactive'>;
@@ -222,6 +226,49 @@ export async function resolveExistingStorageRoot<K extends StorageRootKind>(
         expectedRootId: input.expectedRootId,
         markerMismatchCode: 'root_identity_changed',
         markerMismatchMessage: `Storage root identity does not match the expected root: ${canonicalPath}`,
+      });
+      return createCapability(input.kind, canonicalPath, marker.rootId, identity);
+    },
+  );
+}
+
+/**
+ * Explicit import boundary for a storage root copied through an archive.
+ * The durable rootId stays authoritative while the host-local dev/ino binding
+ * is atomically adopted for the extracted directory.
+ */
+export async function adoptStorageRootOnImport<K extends StorageRootKind>(
+  input: AdoptStorageRootOnImportInput<K>,
+): Promise<StorageRootCapability<K>> {
+  assertStorageRootKind(input.kind);
+  return withAuthorityFailure(
+    'root_io_failed',
+    'Unable to adopt the imported storage root',
+    async () => {
+      const { canonicalPath, rootStat } = await resolveExistingRootPath(input.path);
+      const identity = { dev: rootStat.dev, ino: rootStat.ino };
+      let marker = await readAndValidateRootMarker(canonicalPath, input.kind);
+      if (marker.rootId !== input.expectedRootId) {
+        throw new StorageRootAuthorityError(
+          'root_identity_collision',
+          `Imported storage root does not match the expected root: ${canonicalPath}`,
+        );
+      }
+      await assertRootPathIdentity(
+        canonicalPath,
+        identity,
+        `Storage root identity changed while adopting an import: ${canonicalPath}`,
+      );
+      if (!markerMatchesIdentity(marker, identity)) {
+        marker = await replaceRootMarkerIdentity(canonicalPath, identity, marker);
+      }
+      await confirmRootSnapshot({
+        root: canonicalPath,
+        identity,
+        readMarker: () => readAndValidateRootMarker(canonicalPath, input.kind),
+        expectedRootId: input.expectedRootId,
+        markerMismatchCode: 'root_identity_changed',
+        markerMismatchMessage: `Imported storage root identity changed: ${canonicalPath}`,
       });
       return createCapability(input.kind, canonicalPath, marker.rootId, identity);
     },
@@ -698,6 +745,69 @@ async function ensureRootMarker(
     }
   }
   return readAndValidateRootMarker(root, kind);
+}
+
+async function replaceRootMarkerIdentity(
+  root: string,
+  identity: RootIdentity,
+  sourceMarker: RootMarker,
+): Promise<RootMarker> {
+  const current = await readAndValidateRootMarker(root, sourceMarker.kind);
+  if (current.rootId !== sourceMarker.rootId) {
+    throw new StorageRootAuthorityError(
+      'root_identity_collision',
+      `Storage root marker changed while adopting an import: ${root}`,
+    );
+  }
+  const marker: RootMarker = {
+    ...current,
+    rootIdentity: {
+      dev: identity.dev.toString(),
+      ino: identity.ino.toString(),
+    },
+  };
+  const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
+  const tempPath = join(root, `${STORAGE_ROOT_MARKER_FILE}.${process.pid}.${randomUUID()}.tmp`);
+  let tempCreated = false;
+  try {
+    const handle = await open(tempPath, 'wx', 0o600);
+    tempCreated = true;
+    try {
+      await handle.writeFile(`${JSON.stringify(marker)}\n`, 'utf8');
+      await handle.sync();
+    } finally {
+      await handle.close();
+    }
+    await assertRootPathIdentity(
+      root,
+      identity,
+      `Storage root identity changed before adopting its marker: ${root}`,
+    );
+    await rename(tempPath, markerPath);
+    tempCreated = false;
+    await syncDirectory(root);
+  } finally {
+    if (tempCreated) {
+      try {
+        await unlink(tempPath);
+      } catch (error) {
+        if (!isNodeError(error, 'ENOENT')) throw error;
+      }
+    }
+  }
+  await assertRootPathIdentity(
+    root,
+    identity,
+    `Storage root identity changed after adopting its marker: ${root}`,
+  );
+  const adopted = await readAndValidateRootMarker(root, sourceMarker.kind);
+  if (adopted.rootId !== sourceMarker.rootId || !markerMatchesIdentity(adopted, identity)) {
+    throw new StorageRootAuthorityError(
+      'root_identity_changed',
+      `Storage root marker changed while adopting an import: ${root}`,
+    );
+  }
+  return adopted;
 }
 
 async function assertRootPathIdentity(

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -581,6 +581,8 @@ type StoredSessionHeader = Omit<
   status?: unknown;
   blockedReason?: unknown;
   titleIsManual?: unknown;
+  /** Accepted only while decoding old session headers and dropped on normalization. */
+  pendingCwdReminder?: unknown;
 };
 
 function createJsonlCorruptionNote(
@@ -696,42 +698,54 @@ function resolveMigratedStatus(header: StoredSessionHeader): SessionHeader['stat
   return 'active';
 }
 
-function normalizeMigratedHeader(header: SessionHeader, sessionId: string): SessionHeader {
+function normalizeMigratedHeader(
+  header: SessionHeader & { pendingCwdReminder?: unknown },
+  sessionId: string,
+): SessionHeader {
+  const { pendingCwdReminder: _legacyPendingCwdReminder, ...normalizedHeader } = header;
   const valid =
-    header.id === sessionId &&
-    typeof header.workspaceRoot === 'string' &&
-    typeof header.cwd === 'string' &&
-    (header.pendingCwdReminder === undefined || isCwdReminder(header.pendingCwdReminder)) &&
-    isFiniteNumber(header.createdAt) &&
-    isFiniteNumber(header.lastUsedAt) &&
-    (header.lastMessageAt === undefined || isFiniteNumber(header.lastMessageAt)) &&
-    typeof header.name === 'string' &&
-    typeof header.titleIsManual === 'boolean' &&
-    typeof header.isFlagged === 'boolean' &&
-    Array.isArray(header.labels) &&
-    header.labels.every((label) => typeof label === 'string') &&
-    typeof header.isArchived === 'boolean' &&
-    (header.archivedAt === undefined || isFiniteNumber(header.archivedAt)) &&
-    isSessionStatus(header.status) &&
-    (header.blockedReason === undefined || isSessionBlockedReason(header.blockedReason)) &&
-    (header.statusUpdatedAt === undefined || isFiniteNumber(header.statusUpdatedAt)) &&
-    (header.parentSessionId === undefined || typeof header.parentSessionId === 'string') &&
-    (header.branchOfTurnId === undefined || typeof header.branchOfTurnId === 'string') &&
-    isValidRevisionLineage(header) &&
-    (header.lastReadMessageId === undefined || typeof header.lastReadMessageId === 'string') &&
-    typeof header.hasUnread === 'boolean' &&
-    isBackendKind(header.backend) &&
-    typeof header.llmConnectionSlug === 'string' &&
-    typeof header.connectionLocked === 'boolean' &&
-    typeof header.model === 'string' &&
-    isPermissionMode(header.permissionMode) &&
-    isCollaborationMode(header.collaborationMode) &&
-    isOrchestrationMode(header.orchestrationMode) &&
-    header.schemaVersion === 1;
+    normalizedHeader.id === sessionId &&
+    typeof normalizedHeader.workspaceRoot === 'string' &&
+    typeof normalizedHeader.cwd === 'string' &&
+    isFiniteNumber(normalizedHeader.createdAt) &&
+    isFiniteNumber(normalizedHeader.lastUsedAt) &&
+    (normalizedHeader.lastMessageAt === undefined ||
+      isFiniteNumber(normalizedHeader.lastMessageAt)) &&
+    typeof normalizedHeader.name === 'string' &&
+    typeof normalizedHeader.titleIsManual === 'boolean' &&
+    typeof normalizedHeader.isFlagged === 'boolean' &&
+    Array.isArray(normalizedHeader.labels) &&
+    normalizedHeader.labels.every((label) => typeof label === 'string') &&
+    typeof normalizedHeader.isArchived === 'boolean' &&
+    (normalizedHeader.archivedAt === undefined || isFiniteNumber(normalizedHeader.archivedAt)) &&
+    isSessionStatus(normalizedHeader.status) &&
+    (normalizedHeader.blockedReason === undefined ||
+      isSessionBlockedReason(normalizedHeader.blockedReason)) &&
+    (normalizedHeader.statusUpdatedAt === undefined ||
+      isFiniteNumber(normalizedHeader.statusUpdatedAt)) &&
+    (normalizedHeader.parentSessionId === undefined ||
+      typeof normalizedHeader.parentSessionId === 'string') &&
+    (normalizedHeader.branchOfTurnId === undefined ||
+      typeof normalizedHeader.branchOfTurnId === 'string') &&
+    isValidRevisionLineage(normalizedHeader) &&
+    (normalizedHeader.lastReadMessageId === undefined ||
+      typeof normalizedHeader.lastReadMessageId === 'string') &&
+    typeof normalizedHeader.hasUnread === 'boolean' &&
+    isBackendKind(normalizedHeader.backend) &&
+    typeof normalizedHeader.llmConnectionSlug === 'string' &&
+    typeof normalizedHeader.connectionLocked === 'boolean' &&
+    typeof normalizedHeader.model === 'string' &&
+    isPermissionMode(normalizedHeader.permissionMode) &&
+    isCollaborationMode(normalizedHeader.collaborationMode) &&
+    isOrchestrationMode(normalizedHeader.orchestrationMode) &&
+    normalizedHeader.schemaVersion === 1;
   if (!valid) {
     throw new Error(`Invalid session header for session ${sessionId}: malformed fields`);
   }
-  return { ...header, name: normalizeSessionName(header.name) };
+  return {
+    ...normalizedHeader,
+    name: normalizeSessionName(normalizedHeader.name),
+  };
 }
 
 function isValidRevisionLineage(header: SessionHeader): boolean {
@@ -765,15 +779,6 @@ function isFiniteNumber(value: unknown): value is number {
   return typeof value === 'number' && Number.isFinite(value);
 }
 
-function isCwdReminder(value: unknown): value is NonNullable<SessionHeader['pendingCwdReminder']> {
-  return (
-    typeof value === 'object' &&
-    value !== null &&
-    typeof (value as { from?: unknown }).from === 'string' &&
-    typeof (value as { to?: unknown }).to === 'string'
-  );
-}
-
 function toSummary(header: SessionHeader, messages: StoredMessage[] = []): SessionSummary {
   const preview = lastMessagePreview(messages);
   const derivedLastMessageAt = latestVisibleMessageAt(messages);
@@ -781,7 +786,6 @@ function toSummary(header: SessionHeader, messages: StoredMessage[] = []): Sessi
   return {
     id: header.id,
     cwd: header.cwd,
-    ...(header.pendingCwdReminder ? { pendingCwdReminder: header.pendingCwdReminder } : {}),
     name: normalizeSessionName(header.name),
     isFlagged: header.isFlagged,
     isArchived: header.isArchived,

--- a/packages/storage/src/workspace-identity.ts
+++ b/packages/storage/src/workspace-identity.ts
@@ -6,6 +6,8 @@ import { join, normalize, parse, resolve } from 'node:path';
 export const WORKSPACE_MARKER_FILE = '.maka-workspace.json';
 export const WORKSPACE_MARKER_SCHEMA_VERSION = 1 as const;
 export const WORKSPACE_IDENTITY_PREFIX = 'workspace:v1:' as const;
+const MAX_WORKSPACE_MARKER_BYTES = 4_096;
+const MAX_LEGACY_ANCHORS = 32;
 
 interface WorkspaceMarker {
   schemaVersion: typeof WORKSPACE_MARKER_SCHEMA_VERSION;
@@ -234,13 +236,31 @@ async function replaceWorkspaceMarker(
 }
 
 async function writeMarkerFile(path: string, marker: WorkspaceMarker): Promise<void> {
+  const serializedMarker = serializeWorkspaceMarker(marker);
   const handle = await open(path, 'wx', 0o600);
   try {
-    await handle.writeFile(`${JSON.stringify(marker)}\n`, 'utf8');
+    await handle.writeFile(serializedMarker, 'utf8');
     await handle.sync();
   } finally {
     await handle.close();
   }
+}
+
+function serializeWorkspaceMarker(marker: WorkspaceMarker): string {
+  if (!isWorkspaceMarker(marker)) {
+    throw new WorkspaceIdentityError(
+      'invalid_workspace_marker',
+      'Workspace marker candidate has invalid fields',
+    );
+  }
+  const serializedMarker = `${JSON.stringify(marker)}\n`;
+  if (Buffer.byteLength(serializedMarker, 'utf8') > MAX_WORKSPACE_MARKER_BYTES) {
+    throw new WorkspaceIdentityError(
+      'invalid_workspace_marker',
+      'Workspace marker candidate exceeds the size limit',
+    );
+  }
+  return serializedMarker;
 }
 
 async function readWorkspaceMarker(root: string): Promise<WorkspaceMarker> {
@@ -256,7 +276,7 @@ async function readWorkspaceMarker(root: string): Promise<WorkspaceMarker> {
       if (
         !handleStat.isFile() ||
         !pathStat.isFile() ||
-        handleStat.size > 4_096n ||
+        handleStat.size > BigInt(MAX_WORKSPACE_MARKER_BYTES) ||
         handleStat.dev !== pathStat.dev ||
         handleStat.ino !== pathStat.ino
       ) {
@@ -305,7 +325,7 @@ function isWorkspaceMarker(value: unknown): value is WorkspaceMarker {
     typeof marker.workspaceId === 'string' &&
     isUuid(marker.workspaceId) &&
     Array.isArray(marker.legacyAnchors) &&
-    marker.legacyAnchors.length <= 32 &&
+    marker.legacyAnchors.length <= MAX_LEGACY_ANCHORS &&
     marker.legacyAnchors.every(isLegacyWorkspaceIdentity) &&
     new Set(marker.legacyAnchors).size === marker.legacyAnchors.length
   );

--- a/packages/storage/src/workspace-identity.ts
+++ b/packages/storage/src/workspace-identity.ts
@@ -1,0 +1,455 @@
+import { randomUUID } from 'node:crypto';
+import { constants as fsConstants, type BigIntStats } from 'node:fs';
+import { link, lstat, open, realpath, rename, stat, unlink } from 'node:fs/promises';
+import { join, normalize, parse, resolve } from 'node:path';
+
+export const WORKSPACE_MARKER_FILE = '.maka-workspace.json';
+export const WORKSPACE_MARKER_SCHEMA_VERSION = 1 as const;
+export const WORKSPACE_IDENTITY_PREFIX = 'workspace:v1:' as const;
+
+interface WorkspaceMarker {
+  schemaVersion: typeof WORKSPACE_MARKER_SCHEMA_VERSION;
+  workspaceId: string;
+  legacyAnchors: string[];
+}
+
+export interface WorkspaceIdentityResolution {
+  workspaceIdentity: string;
+  canonicalPath: string;
+  /** Legacy filesystem identities accepted only while migrating old AgentRun headers. */
+  legacyWorkspaceIdentities: readonly string[];
+}
+
+export interface ResolveWorkspaceIdentityInput {
+  path: string;
+}
+
+export interface AdoptWorkspaceIdentityOnImportInput extends ResolveWorkspaceIdentityInput {
+  /** When supplied, importing a marker with any other UUID fails closed. */
+  expectedWorkspaceIdentity?: string;
+  /** Explicit provenance supplied by an importer for a pre-marker bundle. */
+  legacyWorkspaceIdentity?: string;
+}
+
+export type WorkspaceIdentityErrorCode =
+  | 'workspace_not_found'
+  | 'invalid_workspace'
+  | 'workspace_unmarked'
+  | 'invalid_workspace_marker'
+  | 'workspace_identity_conflict'
+  | 'workspace_identity_changed'
+  | 'workspace_io_failed';
+
+export class WorkspaceIdentityError extends Error {
+  constructor(
+    readonly code: WorkspaceIdentityErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'WorkspaceIdentityError';
+  }
+}
+
+/**
+ * Resolves the intrinsic workspace identity, creating a marker only when the
+ * workspace has never been marked. Existing markers are authoritative and are
+ * never rebound based on path or inode.
+ */
+export async function resolveWorkspaceIdentity(
+  input: ResolveWorkspaceIdentityInput,
+): Promise<WorkspaceIdentityResolution> {
+  return withWorkspaceFailure(async () => {
+    const snapshot = await resolveWorkspaceSnapshot(input.path);
+    const currentLegacyAnchor = legacyAnchor(snapshot.canonicalPath, snapshot.workspaceStat);
+    const marker = await ensureWorkspaceMarker(snapshot, currentLegacyAnchor);
+    return toResolution(snapshot.canonicalPath, marker, currentLegacyAnchor);
+  });
+}
+
+/**
+ * Explicit import boundary. It preserves a copied marker UUID, or creates a
+ * marker for a legacy bundle while recording the importer's trusted old anchor.
+ */
+export async function adoptWorkspaceIdentityOnImport(
+  input: AdoptWorkspaceIdentityOnImportInput,
+): Promise<WorkspaceIdentityResolution> {
+  return withWorkspaceFailure(async () => {
+    const expectedWorkspaceId =
+      input.expectedWorkspaceIdentity === undefined
+        ? undefined
+        : parseWorkspaceIdentity(input.expectedWorkspaceIdentity);
+    if (
+      input.legacyWorkspaceIdentity !== undefined &&
+      !isLegacyWorkspaceIdentity(input.legacyWorkspaceIdentity)
+    ) {
+      throw new WorkspaceIdentityError(
+        'invalid_workspace_marker',
+        `Invalid legacy workspace identity: ${input.legacyWorkspaceIdentity}`,
+      );
+    }
+
+    const snapshot = await resolveWorkspaceSnapshot(input.path);
+    const currentLegacyAnchor = legacyAnchor(snapshot.canonicalPath, snapshot.workspaceStat);
+    let marker: WorkspaceMarker;
+    try {
+      marker = await readWorkspaceMarker(snapshot.canonicalPath);
+    } catch (error) {
+      if (!(error instanceof WorkspaceIdentityError) || error.code !== 'workspace_unmarked') {
+        throw error;
+      }
+      marker = await createWorkspaceMarker(
+        snapshot,
+        expectedWorkspaceId ?? randomUUID(),
+        uniqueStrings([input.legacyWorkspaceIdentity, currentLegacyAnchor]),
+      );
+    }
+
+    if (expectedWorkspaceId !== undefined && marker.workspaceId !== expectedWorkspaceId) {
+      throw new WorkspaceIdentityError(
+        'workspace_identity_conflict',
+        `Imported workspace marker does not match the expected identity: ${snapshot.canonicalPath}`,
+      );
+    }
+
+    const nextLegacyAnchors = uniqueStrings([
+      ...marker.legacyAnchors,
+      input.legacyWorkspaceIdentity,
+    ]);
+    if (!sameStrings(marker.legacyAnchors, nextLegacyAnchors)) {
+      marker = await replaceWorkspaceMarker(snapshot, {
+        ...marker,
+        legacyAnchors: nextLegacyAnchors,
+      });
+    }
+    return toResolution(snapshot.canonicalPath, marker, currentLegacyAnchor);
+  });
+}
+
+interface WorkspaceSnapshot {
+  canonicalPath: string;
+  workspaceStat: BigIntStats;
+}
+
+async function resolveWorkspaceSnapshot(path: string): Promise<WorkspaceSnapshot> {
+  let canonicalPath: string;
+  try {
+    canonicalPath = canonicalizePath(await realpath(resolve(path)));
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      throw new WorkspaceIdentityError(
+        'workspace_not_found',
+        `Workspace does not exist: ${resolve(path)}`,
+      );
+    }
+    throw error;
+  }
+  const workspaceStat = await stat(canonicalPath, { bigint: true });
+  if (!workspaceStat.isDirectory()) {
+    throw new WorkspaceIdentityError(
+      'invalid_workspace',
+      `Workspace is not a directory: ${canonicalPath}`,
+    );
+  }
+  return { canonicalPath, workspaceStat };
+}
+
+async function ensureWorkspaceMarker(
+  snapshot: WorkspaceSnapshot,
+  currentLegacyAnchor: string,
+): Promise<WorkspaceMarker> {
+  try {
+    return await readWorkspaceMarker(snapshot.canonicalPath);
+  } catch (error) {
+    if (!(error instanceof WorkspaceIdentityError) || error.code !== 'workspace_unmarked') {
+      throw error;
+    }
+  }
+  return createWorkspaceMarker(snapshot, randomUUID(), [currentLegacyAnchor]);
+}
+
+async function createWorkspaceMarker(
+  snapshot: WorkspaceSnapshot,
+  workspaceId: string,
+  legacyAnchors: string[],
+): Promise<WorkspaceMarker> {
+  const marker: WorkspaceMarker = {
+    schemaVersion: WORKSPACE_MARKER_SCHEMA_VERSION,
+    workspaceId,
+    legacyAnchors,
+  };
+  const markerPath = join(snapshot.canonicalPath, WORKSPACE_MARKER_FILE);
+  const tempPath = temporaryMarkerPath(snapshot.canonicalPath);
+  let tempCreated = false;
+  try {
+    await writeMarkerFile(tempPath, marker);
+    tempCreated = true;
+    await assertWorkspaceSnapshot(snapshot);
+    try {
+      await link(tempPath, markerPath);
+      await syncDirectory(snapshot.canonicalPath);
+    } catch (error) {
+      if (!isNodeError(error, 'EEXIST')) throw error;
+    }
+  } finally {
+    if (tempCreated) await unlinkIfPresent(tempPath);
+  }
+  await assertWorkspaceSnapshot(snapshot);
+  return readWorkspaceMarker(snapshot.canonicalPath);
+}
+
+async function replaceWorkspaceMarker(
+  snapshot: WorkspaceSnapshot,
+  marker: WorkspaceMarker,
+): Promise<WorkspaceMarker> {
+  const markerPath = join(snapshot.canonicalPath, WORKSPACE_MARKER_FILE);
+  const existing = await readWorkspaceMarker(snapshot.canonicalPath);
+  if (existing.workspaceId !== marker.workspaceId) {
+    throw new WorkspaceIdentityError(
+      'workspace_identity_conflict',
+      `Workspace identity changed while adopting an import: ${snapshot.canonicalPath}`,
+    );
+  }
+  const tempPath = temporaryMarkerPath(snapshot.canonicalPath);
+  let tempCreated = false;
+  try {
+    await writeMarkerFile(tempPath, marker);
+    tempCreated = true;
+    await assertWorkspaceSnapshot(snapshot);
+    await rename(tempPath, markerPath);
+    tempCreated = false;
+    await syncDirectory(snapshot.canonicalPath);
+  } finally {
+    if (tempCreated) await unlinkIfPresent(tempPath);
+  }
+  await assertWorkspaceSnapshot(snapshot);
+  const adopted = await readWorkspaceMarker(snapshot.canonicalPath);
+  if (adopted.workspaceId !== marker.workspaceId) {
+    throw new WorkspaceIdentityError(
+      'workspace_identity_conflict',
+      `Workspace identity changed while adopting an import: ${snapshot.canonicalPath}`,
+    );
+  }
+  return adopted;
+}
+
+async function writeMarkerFile(path: string, marker: WorkspaceMarker): Promise<void> {
+  const handle = await open(path, 'wx', 0o600);
+  try {
+    await handle.writeFile(`${JSON.stringify(marker)}\n`, 'utf8');
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function readWorkspaceMarker(root: string): Promise<WorkspaceMarker> {
+  const markerPath = join(root, WORKSPACE_MARKER_FILE);
+  let marker: unknown;
+  try {
+    const handle = await open(markerPath, markerReadFlags());
+    try {
+      const [handleStat, pathStat] = await Promise.all([
+        handle.stat({ bigint: true }),
+        lstat(markerPath, { bigint: true }),
+      ]);
+      if (
+        !handleStat.isFile() ||
+        !pathStat.isFile() ||
+        handleStat.size > 4_096n ||
+        handleStat.dev !== pathStat.dev ||
+        handleStat.ino !== pathStat.ino
+      ) {
+        throw new WorkspaceIdentityError(
+          'invalid_workspace_marker',
+          `Workspace marker must be one bounded regular file: ${markerPath}`,
+        );
+      }
+      marker = JSON.parse(await handle.readFile('utf8'));
+    } finally {
+      await handle.close();
+    }
+  } catch (error) {
+    if (error instanceof WorkspaceIdentityError) throw error;
+    if (isMissingPathError(error)) {
+      throw new WorkspaceIdentityError('workspace_unmarked', `Workspace is not marked: ${root}`);
+    }
+    if (error instanceof SyntaxError || isInvalidMarkerPathError(error)) {
+      throw new WorkspaceIdentityError(
+        'invalid_workspace_marker',
+        `Invalid workspace marker at ${markerPath}`,
+        { cause: error },
+      );
+    }
+    throw error;
+  }
+  if (!isWorkspaceMarker(marker)) {
+    throw new WorkspaceIdentityError(
+      'invalid_workspace_marker',
+      `Invalid workspace marker at ${markerPath}`,
+    );
+  }
+  return marker;
+}
+
+function isWorkspaceMarker(value: unknown): value is WorkspaceMarker {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const marker = value as Record<string, unknown>;
+  const keys = Object.keys(marker).sort();
+  return (
+    keys.length === 3 &&
+    keys[0] === 'legacyAnchors' &&
+    keys[1] === 'schemaVersion' &&
+    keys[2] === 'workspaceId' &&
+    marker.schemaVersion === WORKSPACE_MARKER_SCHEMA_VERSION &&
+    typeof marker.workspaceId === 'string' &&
+    isUuid(marker.workspaceId) &&
+    Array.isArray(marker.legacyAnchors) &&
+    marker.legacyAnchors.length <= 32 &&
+    marker.legacyAnchors.every(isLegacyWorkspaceIdentity) &&
+    new Set(marker.legacyAnchors).size === marker.legacyAnchors.length
+  );
+}
+
+function parseWorkspaceIdentity(value: string): string {
+  if (!value.startsWith(WORKSPACE_IDENTITY_PREFIX)) {
+    throw new WorkspaceIdentityError(
+      'invalid_workspace_marker',
+      `Invalid workspace identity: ${value}`,
+    );
+  }
+  const workspaceId = value.slice(WORKSPACE_IDENTITY_PREFIX.length);
+  if (!isUuid(workspaceId)) {
+    throw new WorkspaceIdentityError(
+      'invalid_workspace_marker',
+      `Invalid workspace identity: ${value}`,
+    );
+  }
+  return workspaceId;
+}
+
+function isUuid(value: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
+}
+
+function isLegacyWorkspaceIdentity(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    /^fs:\d+:\d+:.+/.test(value) &&
+    Buffer.byteLength(value, 'utf8') <= 2_048
+  );
+}
+
+function legacyAnchor(path: string, workspaceStat: BigIntStats): string {
+  return `fs:${workspaceStat.dev.toString()}:${workspaceStat.ino.toString()}:${normalizeWorkspacePath(path)}`;
+}
+
+function toResolution(
+  canonicalPath: string,
+  marker: WorkspaceMarker,
+  currentLegacyAnchor: string,
+): WorkspaceIdentityResolution {
+  return {
+    workspaceIdentity: `${WORKSPACE_IDENTITY_PREFIX}${marker.workspaceId}`,
+    canonicalPath,
+    legacyWorkspaceIdentities: uniqueStrings([...marker.legacyAnchors, currentLegacyAnchor]),
+  };
+}
+
+function uniqueStrings(values: readonly (string | undefined)[]): string[] {
+  return [...new Set(values.filter((value): value is string => value !== undefined))];
+}
+
+function sameStrings(left: readonly string[], right: readonly string[]): boolean {
+  return left.length === right.length && left.every((value, index) => value === right[index]);
+}
+
+async function assertWorkspaceSnapshot(snapshot: WorkspaceSnapshot): Promise<void> {
+  const current = await statWorkspaceIfPresent(snapshot.canonicalPath);
+  if (
+    !current?.isDirectory() ||
+    current.dev !== snapshot.workspaceStat.dev ||
+    current.ino !== snapshot.workspaceStat.ino
+  ) {
+    throw new WorkspaceIdentityError(
+      'workspace_identity_changed',
+      `Workspace changed while validating its marker: ${snapshot.canonicalPath}`,
+    );
+  }
+}
+
+function temporaryMarkerPath(root: string): string {
+  return join(root, `${WORKSPACE_MARKER_FILE}.${process.pid}.${randomUUID()}.tmp`);
+}
+
+async function unlinkIfPresent(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (error) {
+    if (!isNodeError(error, 'ENOENT')) throw error;
+  }
+}
+
+async function syncDirectory(path: string): Promise<void> {
+  if (process.platform === 'win32') return;
+  const handle = await open(path, 'r');
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+function canonicalizePath(path: string): string {
+  const normalized = normalize(path);
+  const root = parse(normalized).root;
+  return normalized === root ? normalized : normalized.replace(/[\\/]+$/, '');
+}
+
+function normalizeWorkspacePath(value: string): string {
+  const normalized = value.replaceAll('\\', '/').replace(/\/+$/, '');
+  return /^[A-Za-z]:\//.test(normalized) ? normalized.toLowerCase() : normalized;
+}
+
+function markerReadFlags(): string | number {
+  if (process.platform === 'win32') return 'r';
+  return fsConstants.O_RDONLY | fsConstants.O_NONBLOCK | fsConstants.O_NOFOLLOW;
+}
+
+async function statWorkspaceIfPresent(path: string): Promise<BigIntStats | undefined> {
+  try {
+    return await stat(path, { bigint: true });
+  } catch (error) {
+    if (isMissingPathError(error)) return undefined;
+    throw error;
+  }
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+  return (
+    error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code
+  );
+}
+
+function isMissingPathError(error: unknown): boolean {
+  return isNodeError(error, 'ENOENT') || isNodeError(error, 'ENOTDIR');
+}
+
+function isInvalidMarkerPathError(error: unknown): boolean {
+  return isMissingPathError(error) || isNodeError(error, 'ELOOP') || isNodeError(error, 'ENXIO');
+}
+
+async function withWorkspaceFailure<T>(operation: () => Promise<T>): Promise<T> {
+  try {
+    return await operation();
+  } catch (error) {
+    if (error instanceof WorkspaceIdentityError) throw error;
+    throw new WorkspaceIdentityError(
+      'workspace_io_failed',
+      'Unable to resolve workspace identity',
+      {
+        cause: error,
+      },
+    );
+  }
+}


### PR DESCRIPTION
<details>
<summary>展开中文说明</summary>

## 概要

- 使用带版本的 UUID marker 替代基于 `dev`、`ino` 和路径的 workspace identity
- workspace 路径变化后仍允许 safe-boundary resume，同时保留执行前的 UUID 重校验
- 为 workspace marker 和 storage-root marker 增加显式的导入收养机制
- 通过 marker alias 迁移旧的 `fs:{dev}:{ino}:{path}` AgentRun identity
- 删除 `pendingCwdReminder` 提示词注入 workaround，同时保证旧 session 仍可读取

## 实现细节

Workspace identity 现在保存在 `.maka-workspace.json` 中，格式为 `workspace:v1:<uuid>`。Marker 使用原子方式创建，并对文件大小、格式和 identity 冲突进行严格校验。

Workspace 路径仍会保留在诊断信息中，但不再决定 continuation 能否恢复。Runtime 在 backend 执行前仍会重新校验 UUID，因此如果 marker 在规划完成后被替换，恢复会安全失败。

导入收养机制会保留复制过来的 workspace UUID。对于尚未包含 marker 的旧 bundle，importer 可以显式登记原来的 filesystem anchor。Storage root 也增加了独立的显式收养入口：保留原有 `rootId`，同时将解压目录的新 `dev` 和 `ino` 写回 marker。普通 storage-root resolution 的行为不变，在未经过显式收养前仍会拒绝复制出来的 root。

CLI/Desktop 的 `/move` 现在只持久化新的 `cwd`。修改 `cwd` 本来就会使当前 backend 失效，因此下一轮会按照更新后的 session header 重建 backend。旧 session 文件中的 `pendingCwdReminder` 仍可读取，但 normalize 时会丢弃该字段。

## 兼容性与安全性

- 继续使用 AgentRun header 现有的 `workspaceIdentity` 字段
- 匹配的旧 filesystem anchor 会迁移到 UUID identity
- 冲突或格式错误的 marker 会安全失败
- storage-root adoption 必须提供预期的持久化 `rootId`
- workspace marker 经复制或归档后仍保留原 UUID 和文件内容
- 旧 `pendingCwdReminder` 字段可读取，并在下次规范化写入时移除

## 测试

- Runtime continuation 与 SessionManager：231 项通过
- CLI session driver：41 项通过
- Workspace marker 创建、归档保留、导入收养、旧 identity 迁移和冲突测试
- Storage-root 导入收养和冲突测试
- 旧 session normalize 兼容测试
- Core、Storage、Runtime、CLI 和 Desktop 主进程类型检查
- Biome lint 与 `git diff --check`

尚未运行完整的 Desktop Playwright E2E。现有 E2E 中也还没有 tar/untar 跨 sandbox resume 场景。

</details>

## Summary

- replace filesystem-based workspace identity (`dev` / `ino` / path) with a versioned UUID marker
- allow safe-boundary resume after workspace path changes while retaining UUID revalidation before execution
- add explicit import adoption for workspace and storage-root markers
- migrate legacy `fs:{dev}:{ino}:{path}` AgentRun identities through marker aliases
- remove the `pendingCwdReminder` prompt-injection workaround while preserving legacy session readability

## Details

Workspace identity is now stored in `.maka-workspace.json` as `workspace:v1:<uuid>`. Marker creation is atomic, bounded, and rejects malformed or conflicting markers.

Workspace paths remain available for diagnostics but no longer determine whether a continuation can resume. Runtime still revalidates the UUID immediately before backend execution, so replacing the marker after planning fails closed.

Import adoption preserves copied workspace UUIDs. Pre-marker imports may explicitly register their legacy filesystem anchor. Storage roots receive a separate explicit adoption path that preserves `rootId` while rebinding the extracted directory’s host-local `dev` and `ino`. Normal storage-root resolution continues to reject copied roots until that import boundary is invoked.

The CLI/Desktop `/move` path now persists only the new `cwd`. Updating `cwd` already invalidates the active backend, so the next turn rebuilds it from the updated session header. Existing session files containing `pendingCwdReminder` remain readable, but normalization drops the legacy field.

## Compatibility and safety

- existing AgentRun headers keep using the `workspaceIdentity` field
- matching legacy filesystem anchors migrate to the UUID identity
- conflicting or malformed markers fail closed
- storage-root adoption requires the expected durable `rootId`
- copied workspace markers retain their UUID and archive bytes
- old `pendingCwdReminder` fields are accepted on read and removed on the next normalized write

## Tests

- Runtime continuation and SessionManager suite: 231 passed
- CLI session driver suite: 41 passed
- workspace marker creation, archive preservation, import adoption, legacy migration, and conflict tests
- storage-root import adoption and conflict tests
- legacy session normalization test
- Core, Storage, Runtime, CLI, and Desktop main-process type checks
- Biome lint and `git diff --check`

Full Desktop Playwright E2E was not run. The existing E2E suite does not currently contain a tar/untar cross-sandbox resume scenario.

Closes #1337