### PR TITLE
feat(storage): make SQLite the default session metadata store

### DIFF
--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -6,6 +6,7 @@ import type { BotRegistry, SessionManager, ShellRunProcessManager } from '@maka/
 import type { McpClientManager } from '@maka/mcp';
 import type {
   createConnectionStore,
+  createSessionStore,
   createSettingsStore,
   createTelemetryRepo,
   openRuntimeEventPersistence,
@@ -35,6 +36,7 @@ export interface AppLifecycleDeps {
   isIsolatedE2e: boolean;
   e2eFixture: ReturnType<typeof resolveE2eFixture>;
   workspaceRoot: string;
+  sessionStore: ReturnType<typeof createSessionStore>;
   credentialStore: ReturnType<typeof createFileCredentialStore>;
   connectionStore: ReturnType<typeof createConnectionStore>;
   settingsStore: ReturnType<typeof createSettingsStore>;
@@ -84,6 +86,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     isIsolatedE2e,
     e2eFixture,
     workspaceRoot,
+    sessionStore,
     credentialStore,
     connectionStore,
     settingsStore,
@@ -331,5 +334,6 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
       if (result.status === 'rejected') console.error('[shutdown] cleanup failed:', result.reason);
     }
     runtimePersistence.close();
+    sessionStore.close?.();
   }
 }

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -16,7 +16,6 @@ import type { createFileCredentialStore } from './credential-store.js';
 import { startConfigFileWatcher, type ConfigFileWatcher } from './config-file-watcher.js';
 import { toContractNetworkSettings } from './network-settings-main.js';
 import { importLegacyOAuthTokenFiles } from './oauth/shared-credential-bridge.js';
-import { seedE2eFixture } from './e2e-fixture.js';
 import type { resolveE2eFixture } from './e2e-fixture.js';
 import type { OpenGatewayService } from './open-gateway.js';
 import type { KeepSystemAwakeController } from './keep-system-awake.js';
@@ -204,17 +203,9 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     // settled. Any state that background startup mutates is pushed to the
     // renderer via the existing `sessions:changed` / `connections:event`
     // / `settings:bots:statusChanged` channels, so the UI converges lazily.
-    // E2e-fixture mode wipes and reseeds the whole workspace
-    // (`rm -rf` first). That wipe must finish BEFORE the window opens and
-    // before background startup touches the workspace: createWindow reads
-    // the settings store, and a concurrent wipe lands inside the store's
-    // read-or-create write (mkdir → tmp → rename), rejecting createWindow
-    // so the window never appears. Fixture runs trade first-paint latency
-    // for determinism by definition; production launches skip this await.
-    if (e2eFixture) {
-      console.log(`[e2e-fixture] scenario=${e2eFixture.scenario} workspace=${workspaceRoot}`);
-      await seedE2eFixture({ workspaceRoot, fixture: e2eFixture, credentialStore });
-    }
+    // E2E fixture workspaces are wiped and seeded before stores open in
+    // main.ts. SQLite keeps live file handles, so resetting the workspace
+    // here after store construction would detach the canonical database.
     await runCredentialStartup();
     app.on('second-instance', focusOrCreateMainWindow);
     app.on('activate', focusOrCreateMainWindow);

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -83,7 +83,7 @@ import { bindOnboardingDeps, createOnboardingService } from './onboarding-servic
 import { handleQuickChatStart as runQuickChatStart, type QuickChatResult } from './quick-chat.js';
 import { createDailyReviewArchiveStore } from './daily-review-archive-store.js';
 import { resolveDefaultPermissionMode } from './permission-mode-default.js';
-import { resolveE2eFixture } from './e2e-fixture.js';
+import { resolveE2eFixture, seedE2eFixture } from './e2e-fixture.js';
 import { resolveBuildInfo } from './build-info.js';
 import { OpenGatewayService } from './open-gateway.js';
 import { LocalMemoryService } from './local-memory-service.js';
@@ -196,7 +196,13 @@ try {
   throw error;
 }
 const workspaceRoot = join(app.getPath('userData'), 'workspaces', e2eFixture?.workspaceName ?? 'default');
-await resolveStorageRoot({ path: workspaceRoot, kind: 'interactive' });
+const credentialStore = createFileCredentialStore(workspaceRoot);
+if (e2eFixture) {
+  console.log(`[e2e-fixture] scenario=${e2eFixture.scenario} workspace=${workspaceRoot}`);
+  await seedE2eFixture({ workspaceRoot, fixture: e2eFixture, credentialStore });
+} else {
+  await resolveStorageRoot({ path: workspaceRoot, kind: 'interactive' });
+}
 // 保持系统唤醒 (settings.system.keepSystemAwake): holds an Electron
 // `powerSaveBlocker` so in-process scheduled tasks keep firing while the
 // machine would otherwise sleep. Injected with electron's blocker; the
@@ -233,7 +239,6 @@ const artifactStore = createArtifactStore(workspaceRoot);
 const deepResearchStore = createDeepResearchStore(workspaceRoot);
 const storeReadImage = createReadImageSnapshotter(artifactStore);
 const attachmentApprovals = createAttachmentApprovalRegistry();
-const credentialStore = createFileCredentialStore(workspaceRoot);
 // PR-OAUTH-SUBSCRIPTION-0: Claude subscription OAuth service.
 // Lives in main process only; renderer accesses via IPC. Tokens
 // never cross the IPC boundary (xuan G-X3). Cloak path is dynamic-

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1214,6 +1214,7 @@ wireAppLifecycle({
   isIsolatedE2e,
   e2eFixture,
   workspaceRoot,
+  sessionStore: store,
   credentialStore,
   connectionStore,
   settingsStore,

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -889,6 +889,7 @@ export async function createMakaCliRuntimeContext(
       goalManager.dispose();
       await shellRuns.terminateAll();
       shellRunListeners.clear();
+      store.close?.();
       runtimePersistence.close();
     },
   };

--- a/packages/headless/src/__tests__/headless-storage-boundary.test.ts
+++ b/packages/headless/src/__tests__/headless-storage-boundary.test.ts
@@ -227,14 +227,18 @@ async function snapshotTree(path: string, label: string): Promise<ManifestEntry[
       : stats.isSymbolicLink()
         ? 'symlink'
         : 'other';
+  const isSqliteSharedMemory = type === 'file' && label.endsWith('.sqlite-shm');
   const entry: ManifestEntry = {
     path: label,
     type,
     mode: Number(stats.mode & 0o7777n),
     size: stats.size.toString(),
-    mtimeNs: stats.mtimeNs.toString(),
+    // WAL readers update lock slots in the SQLite shared-memory sidecar.
+    // Those bytes and their timestamp are connection coordination, not
+    // durable storage mutation; the database and WAL remain fully compared.
+    ...(isSqliteSharedMemory ? {} : { mtimeNs: stats.mtimeNs.toString() }),
   };
-  if (type === 'file') {
+  if (type === 'file' && !isSqliteSharedMemory) {
     entry.contentSha256 = createHash('sha256')
       .update(await readFile(path))
       .digest('hex');

--- a/packages/storage/src/__tests__/session-metadata-transfer.test.ts
+++ b/packages/storage/src/__tests__/session-metadata-transfer.test.ts
@@ -146,6 +146,35 @@ describe('legacy session metadata transfer', () => {
       await rm(root, { recursive: true, force: true });
     }
   });
+
+  test('keeps canonical metadata readable when its optional transcript is missing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-missing-transcript-'));
+    const legacy = createSessionStore(root);
+    const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
+    try {
+      const created = await legacy.create(makeInput({ name: 'Canonical metadata' }));
+      await importLegacySessionMetadataTree({ workspaceRoot: root, destination: sqlite });
+      await rm(join(root, 'sessions', created.id, 'session.jsonl'));
+
+      const report = await importLegacySessionMetadataTree({
+        workspaceRoot: root,
+        destination: sqlite,
+      });
+
+      assert.deepEqual(report, {
+        filesScanned: 1,
+        headersRead: 0,
+        headersImported: 0,
+        headersExisting: 0,
+        sourcesAlreadyImported: 0,
+        sourcesTombstoned: 0,
+      });
+      assert.equal((await sqlite.read(created.id)).header.name, 'Canonical metadata');
+    } finally {
+      sqlite.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 function makeInput(overrides: Partial<CreateSessionInput> = {}): CreateSessionInput {

--- a/packages/storage/src/__tests__/session-metadata-transfer.test.ts
+++ b/packages/storage/src/__tests__/session-metadata-transfer.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { CreateSessionInput } from '@maka/core';
 import { importLegacySessionMetadataTree } from '../session-metadata-transfer.js';
-import { createSessionStore } from '../session-store.js';
+import { createLegacyFileSessionStore as createSessionStore } from '../session-store.js';
 import { createSqliteSessionMetadataStore } from '../sqlite-session-metadata-store.js';
 
 describe('legacy session metadata transfer', () => {
@@ -39,6 +39,7 @@ describe('legacy session metadata transfer', () => {
         headersImported: 2,
         headersExisting: 0,
         sourcesAlreadyImported: 0,
+        sourcesTombstoned: 0,
       });
       assert.deepEqual((await sqlite.list()).map((record) => record.header.name).sort(), [
         'First',
@@ -72,6 +73,7 @@ describe('legacy session metadata transfer', () => {
         headersImported: 0,
         headersExisting: 0,
         sourcesAlreadyImported: 2,
+        sourcesTombstoned: 0,
       });
       assert.equal((await sqlite.read(first.id)).header.name, 'SQLite is canonical now');
     } finally {
@@ -135,7 +137,7 @@ describe('legacy session metadata transfer', () => {
 
       await assert.rejects(
         () => importLegacySessionMetadataTree({ workspaceRoot: root, destination: sqlite }),
-        /Invalid session header/,
+        /Invalid legacy session header/,
       );
       await assert.rejects(() => sqlite.read(valid.id), /not found/);
       assert.deepEqual(await sqlite.list(), []);

--- a/packages/storage/src/__tests__/session-store.test.ts
+++ b/packages/storage/src/__tests__/session-store.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import { describe, test } from 'node:test';
 import type { CreateSessionInput, SessionHeader, StoredMessage } from '@maka/core';
-import { createSessionStore } from '../session-store.js';
+import { createLegacyFileSessionStore as createSessionStore } from '../session-store.js';
 
 describe('FileSessionStore CRUD', () => {
   test('list on a missing workspace is observational and does not create session storage', async () => {

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -18,7 +18,7 @@ describe('SqliteSessionMetadataStore', () => {
     try {
       const store = createSqliteSessionMetadataStore(path, { now: () => 100 });
       const header = fullHeader();
-      assert.equal(store.schemaVersion(), 1);
+      assert.equal(store.schemaVersion(), 2);
       assert.equal(store.journalMode(), 'wal');
       assert.deepEqual(await store.create(header), {
         header,
@@ -29,7 +29,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const reopened = createSqliteSessionMetadataStore(path, { now: () => 200 });
       try {
-        assert.equal(reopened.schemaVersion(), 1);
+        assert.equal(reopened.schemaVersion(), 2);
         assert.deepEqual(await reopened.read(header.id), {
           header,
           metadataVersion: 1,
@@ -50,7 +50,7 @@ describe('SqliteSessionMetadataStore', () => {
     const metadata = createSqliteSessionMetadataStore(path);
     try {
       assert.equal(runtime.schemaVersion(), 4);
-      assert.equal(metadata.schemaVersion(), 1);
+      assert.equal(metadata.schemaVersion(), 2);
       await metadata.create(fullHeader());
       await runtime.appendRuntimeEvent('session-1', 'run-1', {
         id: 'event-1',
@@ -205,10 +205,12 @@ describe('SqliteSessionMetadataStore', () => {
       assert.deepEqual(await store.importEntries([entry]), {
         created: [true],
         sourcesAlreadyImported: 0,
+        sourcesTombstoned: 0,
       });
       assert.deepEqual(await store.importEntries([entry]), {
         created: [],
         sourcesAlreadyImported: 1,
+        sourcesTombstoned: 0,
       });
       await assert.rejects(
         () =>
@@ -264,6 +266,16 @@ describe('SqliteSessionMetadataStore', () => {
       assert.equal(await store.remove('session-1'), true);
       assert.equal(await store.remove('session-1'), false);
       assert.deepEqual(await store.list({ labelSlug: 'alpha' }), []);
+      assert.deepEqual(
+        await store.importEntries([
+          {
+            header: fullHeader(),
+            source: { path: '/session-1.jsonl', fingerprint: '1:1' },
+          },
+        ]),
+        { created: [], sourcesAlreadyImported: 0, sourcesTombstoned: 1 },
+      );
+      await assert.rejects(() => store.create(fullHeader()), /tombstoned/);
     } finally {
       store.close();
     }

--- a/packages/storage/src/__tests__/sqlite-session-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-store.test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type { CreateSessionInput, SessionHeader } from '@maka/core';
+import {
+  createLegacyFileSessionStore,
+  createSessionStore,
+  SQLITE_SESSION_METADATA_DATABASE_NAME,
+} from '../session-store.js';
+import { createSqliteSessionMetadataStore } from '../sqlite-session-metadata-store.js';
+
+describe('default SQLite session metadata store', () => {
+  test('uses SQLite as canonical metadata while keeping transcript bodies in JSONL', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-default-session-store-'));
+    const store = createSessionStore(root);
+    try {
+      const created = await store.create(makeInput({ name: 'Initial title' }));
+      await store.appendMessage(created.id, {
+        type: 'user',
+        id: 'user-1',
+        turnId: 'turn-1',
+        ts: 10,
+        text: 'hello',
+      });
+      await store.rename(created.id, 'SQLite title');
+      await store.updateHeader(created.id, {
+        hasUnread: true,
+        lastMessageAt: 10,
+      });
+
+      assert.equal((await store.readHeader(created.id)).name, 'SQLite title');
+      assert.equal((await store.list())[0]?.name, 'SQLite title');
+      assert.equal((await store.readMessages(created.id))[0]?.type, 'user');
+
+      const transcriptPath = join(root, 'sessions', created.id, 'session.jsonl');
+      const [legacyHeader, message] = (await readFile(transcriptPath, 'utf8'))
+        .trim()
+        .split('\n')
+        .map((line) => JSON.parse(line) as Record<string, unknown>);
+      assert.equal(legacyHeader?.name, 'Initial title');
+      assert.equal(message?.type, 'user');
+      await stat(join(root, SQLITE_SESSION_METADATA_DATABASE_NAME));
+      await assert.rejects(() => stat(join(root, 'runtime.sqlite')), { code: 'ENOENT' });
+    } finally {
+      store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('imports an existing JSONL catalog once and preserves later SQLite-only updates', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-default-session-migration-'));
+    const legacy = createLegacyFileSessionStore(root);
+    const created = await legacy.create(makeInput({ name: 'Legacy title', labels: ['legacy'] }));
+    await legacy.updateHeader(created.id, {
+      status: 'blocked',
+      blockedReason: 'permission_required',
+      hasUnread: true,
+    });
+    await legacy.appendMessage(created.id, {
+      type: 'user',
+      id: 'user-1',
+      turnId: 'turn-1',
+      ts: 10,
+      text: 'legacy message',
+    });
+
+    const first = createSessionStore(root);
+    try {
+      assert.equal((await first.readHeader(created.id)).name, 'Legacy title');
+      await first.rename(created.id, 'SQLite title');
+      await first.appendMessage(created.id, {
+        type: 'assistant',
+        id: 'assistant-1',
+        turnId: 'turn-1',
+        ts: 11,
+        text: 'new message',
+        modelId: 'fake-model',
+      });
+    } finally {
+      first.close?.();
+    }
+
+    const reopened = createSessionStore(root);
+    try {
+      assert.equal((await reopened.readHeader(created.id)).name, 'SQLite title');
+      assert.equal((await reopened.readMessages(created.id)).length, 2);
+      assert.deepEqual(
+        (await reopened.list({ labelSlug: 'legacy' })).map((item) => item.id),
+        [created.id],
+      );
+    } finally {
+      reopened.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('uses tombstones to prevent a deleted legacy transcript from resurrecting', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-default-session-delete-'));
+    const store = createSessionStore(root);
+    let header!: SessionHeader;
+    try {
+      header = await store.create(makeInput({ name: 'Delete me' }));
+      await store.remove(header.id);
+    } finally {
+      store.close?.();
+    }
+
+    const sessionDir = join(root, 'sessions', header.id);
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(join(sessionDir, 'session.jsonl'), `${JSON.stringify(header)}\n`, 'utf8');
+
+    const reopened = createSessionStore(root);
+    try {
+      assert.deepEqual(await reopened.list(), []);
+      await assert.rejects(() => reopened.readHeader(header.id), /not found/);
+    } finally {
+      reopened.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('fails the whole startup migration before exposing a partial catalog', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-default-session-invalid-'));
+    const legacy = createLegacyFileSessionStore(root);
+    const valid = await legacy.create(makeInput({ name: 'Valid' }));
+    const invalid = await legacy.create(makeInput({ name: 'Invalid' }));
+    const invalidPath = join(root, 'sessions', invalid.id, 'session.jsonl');
+    const lines = (await readFile(invalidPath, 'utf8')).split('\n');
+    lines[0] = JSON.stringify({ ...JSON.parse(lines[0]!), labels: 'invalid' });
+    await writeFile(invalidPath, lines.join('\n'), 'utf8');
+
+    const store = createSessionStore(root);
+    try {
+      await assert.rejects(() => store.list(), /Invalid legacy session header/);
+    } finally {
+      store.close?.();
+    }
+
+    const metadata = createSqliteSessionMetadataStore(
+      join(root, SQLITE_SESSION_METADATA_DATABASE_NAME),
+    );
+    try {
+      await assert.rejects(() => metadata.read(valid.id), /not found/);
+      assert.deepEqual(await metadata.list(), []);
+    } finally {
+      metadata.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function makeInput(overrides: Partial<CreateSessionInput> = {}): CreateSessionInput {
+  return {
+    cwd: '/tmp/cwd',
+    backend: 'fake',
+    llmConnectionSlug: 'fake',
+    model: 'fake-model',
+    permissionMode: 'ask',
+    name: 'Session',
+    labels: [],
+    ...overrides,
+  };
+}

--- a/packages/storage/src/session-metadata-transfer.ts
+++ b/packages/storage/src/session-metadata-transfer.ts
@@ -16,6 +16,7 @@ export interface LegacySessionMetadataImportReport {
   headersImported: number;
   headersExisting: number;
   sourcesAlreadyImported: number;
+  sourcesTombstoned: number;
 }
 
 /**
@@ -32,19 +33,7 @@ export async function importLegacySessionMetadataTree(input: {
   const entries: SessionMetadataImportEntry[] = [];
   for (const directory of await sessionDirectoryNames(sessionsRoot)) {
     const sourcePath = join(sessionsRoot, directory, 'session.jsonl');
-    let value: unknown;
-    let headerLine: string;
-    try {
-      headerLine = await readFirstJsonlRecord(sourcePath);
-      value = JSON.parse(headerLine) as unknown;
-    } catch (error) {
-      throw new Error(`Invalid legacy session header at ${sourcePath}`, { cause: error });
-    }
-    const fingerprint = createHash('sha256').update(headerLine).digest('hex');
-    entries.push({
-      header: decodeSessionHeader(value, directory),
-      source: { path: sourcePath, fingerprint },
-    });
+    entries.push(await readLegacySessionMetadataEntry(sourcePath, directory));
   }
   const result = await input.destination.importEntries(entries);
   const headersImported = result.created.filter(Boolean).length;
@@ -54,7 +43,29 @@ export async function importLegacySessionMetadataTree(input: {
     headersImported,
     headersExisting: result.created.length - headersImported,
     sourcesAlreadyImported: result.sourcesAlreadyImported,
+    sourcesTombstoned: result.sourcesTombstoned,
   };
+}
+
+export async function readLegacySessionMetadataEntry(
+  sourcePath: string,
+  sessionId: string,
+): Promise<SessionMetadataImportEntry> {
+  let value: unknown;
+  let headerLine: string;
+  try {
+    headerLine = await readFirstJsonlRecord(sourcePath);
+    value = JSON.parse(headerLine) as unknown;
+    return {
+      header: decodeSessionHeader(value, sessionId),
+      source: {
+        path: sourcePath,
+        fingerprint: createHash('sha256').update(headerLine).digest('hex'),
+      },
+    };
+  } catch (error) {
+    throw new Error(`Invalid legacy session header at ${sourcePath}`, { cause: error });
+  }
 }
 
 async function sessionDirectoryNames(root: string): Promise<string[]> {

--- a/packages/storage/src/session-metadata-transfer.ts
+++ b/packages/storage/src/session-metadata-transfer.ts
@@ -31,14 +31,24 @@ export async function importLegacySessionMetadataTree(input: {
 }): Promise<LegacySessionMetadataImportReport> {
   const sessionsRoot = join(input.workspaceRoot, 'sessions');
   const entries: SessionMetadataImportEntry[] = [];
-  for (const directory of await sessionDirectoryNames(sessionsRoot)) {
+  const directories = await sessionDirectoryNames(sessionsRoot);
+  for (const directory of directories) {
     const sourcePath = join(sessionsRoot, directory, 'session.jsonl');
-    entries.push(await readLegacySessionMetadataEntry(sourcePath, directory));
+    try {
+      entries.push(await readLegacySessionMetadataEntry(sourcePath, directory));
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      const canonicalStateExists =
+        (await input.destination.has(directory)) ||
+        (await input.destination.isTombstoned(directory));
+      if (canonicalStateExists) continue;
+      throw error;
+    }
   }
   const result = await input.destination.importEntries(entries);
   const headersImported = result.created.filter(Boolean).length;
   return {
-    filesScanned: entries.length,
+    filesScanned: directories.length,
     headersRead: entries.length,
     headersImported,
     headersExisting: result.created.length - headersImported,
@@ -66,6 +76,15 @@ export async function readLegacySessionMetadataEntry(
   } catch (error) {
     throw new Error(`Invalid legacy session header at ${sourcePath}`, { cause: error });
   }
+}
+
+function isNotFound(error: unknown): boolean {
+  let current = error;
+  while (current && typeof current === 'object') {
+    if ('code' in current && current.code === 'ENOENT') return true;
+    current = 'cause' in current ? current.cause : undefined;
+  }
+  return false;
 }
 
 async function sessionDirectoryNames(root: string): Promise<string[]> {

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -8,6 +8,14 @@ import {
 } from './execution-record-codec.js';
 import { appendJsonl } from './jsonl-append.js';
 import { classifyJsonRecord } from './json-prefix.js';
+import {
+  importLegacySessionMetadataTree,
+  readLegacySessionMetadataEntry,
+} from './session-metadata-transfer.js';
+import {
+  createSqliteSessionMetadataStore,
+  type SqliteSessionMetadataStore,
+} from './sqlite-session-metadata-store.js';
 import { chainWrite } from './write-queue.js';
 import {
   DEFAULT_SESSION_NAME,
@@ -30,6 +38,7 @@ import type {
 } from '@maka/core';
 
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+export const SQLITE_SESSION_METADATA_DATABASE_NAME = 'sessions.sqlite';
 
 export interface SessionStore {
   create(input: CreateSessionInput): Promise<SessionHeader>;
@@ -56,10 +65,240 @@ export interface SessionStore {
   rename(sessionId: string, name: string): Promise<void>;
   setGeneratedTitleIfAbsent(sessionId: string, title: string): Promise<SessionHeader | null>;
   remove(sessionId: string): Promise<void>;
+  close?(): void;
 }
 
 export function createSessionStore(workspaceRoot: string): SessionStore {
+  return new SqliteSessionStore(workspaceRoot);
+}
+
+/** Legacy JSONL-header store retained only for migration and compatibility tests. */
+export function createLegacyFileSessionStore(workspaceRoot: string): SessionStore {
   return new FileSessionStore(workspaceRoot);
+}
+
+class SqliteSessionStore implements SessionStore {
+  private readonly files: FileSessionStore;
+  private readonly metadata: SqliteSessionMetadataStore;
+  private readonly ready: Promise<void>;
+
+  constructor(private readonly workspaceRoot: string) {
+    this.files = new FileSessionStore(workspaceRoot);
+    this.metadata = createSqliteSessionMetadataStore(
+      join(workspaceRoot, SQLITE_SESSION_METADATA_DATABASE_NAME),
+    );
+    this.ready = importLegacySessionMetadataTree({
+      workspaceRoot,
+      destination: this.metadata,
+    }).then(() => {});
+  }
+
+  async create(input: CreateSessionInput): Promise<SessionHeader> {
+    await this.ensureReady();
+    const staged = await this.files.create(input);
+    try {
+      const sourcePath = this.sessionPath(staged.id);
+      const entry = await readLegacySessionMetadataEntry(sourcePath, staged.id);
+      await this.metadata.importEntries([entry]);
+      return (await this.metadata.read(staged.id)).header;
+    } catch (error) {
+      await this.files.remove(staged.id).catch(() => {});
+      throw error;
+    }
+  }
+
+  async list(filter?: SessionListFilter): Promise<SessionSummary[]> {
+    await this.ensureReady();
+    const records = await this.metadata.list(filter);
+    const withPreviews: Array<{
+      header: SessionHeader;
+      previewMessages: StoredMessage[];
+    }> = [];
+    for (const record of records) {
+      const previewMessages = await this.files
+        .readPreviewMessages(record.header.id)
+        .catch(() => []);
+      withPreviews.push({ header: record.header, previewMessages });
+    }
+    withPreviews.sort((a, b) => {
+      const aLastMessageAt = maxTimestamp(
+        a.header.lastMessageAt,
+        latestVisibleMessageAt(a.previewMessages),
+      );
+      const bLastMessageAt = maxTimestamp(
+        b.header.lastMessageAt,
+        latestVisibleMessageAt(b.previewMessages),
+      );
+      const tsDelta = (bLastMessageAt ?? 0) - (aLastMessageAt ?? 0);
+      return tsDelta !== 0 ? tsDelta : a.header.id.localeCompare(b.header.id);
+    });
+
+    const summaries: SessionSummary[] = [];
+    for (let index = 0; index < withPreviews.length; index += 1) {
+      const { header, previewMessages } = withPreviews[index]!;
+      let messages = previewMessages.slice(-10);
+      if (index < 3) {
+        messages = (await this.files.readMessagesSnapshot(header.id).catch(() => messages)).slice(
+          -10,
+        );
+      }
+      summaries.push(toSummary(header, messages));
+    }
+    return summaries;
+  }
+
+  async listForRecovery(): Promise<SessionHeader[]> {
+    await this.ensureReady();
+    const headers = (await this.metadata.list())
+      .map((record) => record.header)
+      .sort((a, b) => a.id.localeCompare(b.id));
+    for (const header of headers) {
+      await this.files.readMessagesForRecovery(header.id);
+    }
+    return headers;
+  }
+
+  async readHeaderSnapshot(sessionId: string): Promise<SessionHeader> {
+    await this.ensureReady();
+    return (await this.metadata.read(sessionId)).header;
+  }
+
+  async readMessagesSnapshot(sessionId: string): Promise<StoredMessage[]> {
+    await this.ensureReady();
+    return this.files.readMessagesSnapshot(sessionId);
+  }
+
+  async readMessagesForRecovery(sessionId: string): Promise<StoredMessage[]> {
+    await this.ensureReady();
+    return this.files.readMessagesForRecovery(sessionId);
+  }
+
+  async listTurnsSnapshot(sessionId: string): Promise<TurnRecord[]> {
+    return deriveTurnRecords(await this.readMessagesSnapshot(sessionId));
+  }
+
+  async readHeader(sessionId: string): Promise<SessionHeader> {
+    const header = await this.readHeaderSnapshot(sessionId);
+    return this.lockConnectionAfterFirstUserMessage(header);
+  }
+
+  async readMessages(sessionId: string): Promise<StoredMessage[]> {
+    const messages = await this.readMessagesSnapshot(sessionId);
+    const header = (await this.metadata.read(sessionId)).header;
+    await this.lockConnectionAfterFirstUserMessage(header, messages);
+    return messages;
+  }
+
+  async listTurns(sessionId: string): Promise<TurnRecord[]> {
+    return deriveTurnRecords(await this.readMessages(sessionId));
+  }
+
+  async appendMessage(sessionId: string, message: StoredMessage): Promise<void> {
+    await this.appendMessages(sessionId, [message]);
+  }
+
+  async appendMessages(sessionId: string, messages: StoredMessage[]): Promise<void> {
+    await this.ensureReady();
+    await this.files.appendMessages(sessionId, messages);
+  }
+
+  async updateHeader(sessionId: string, patch: Partial<SessionHeader>): Promise<SessionHeader> {
+    await this.ensureReady();
+    return (await this.metadata.update(sessionId, patch)).header;
+  }
+
+  async markSessionReadThrough(sessionId: string, readThroughTs: number): Promise<SessionHeader> {
+    const header = await this.readHeaderSnapshot(sessionId);
+    const messages = await this.readMessagesSnapshot(sessionId);
+    const effectiveLastMessageAt = maxTimestamp(
+      header.lastMessageAt,
+      latestVisibleMessageAt(messages),
+    );
+    if (
+      !Number.isFinite(readThroughTs) ||
+      !header.hasUnread ||
+      (effectiveLastMessageAt !== undefined && effectiveLastMessageAt > readThroughTs)
+    ) {
+      return header;
+    }
+    return this.updateHeader(sessionId, { hasUnread: false });
+  }
+
+  async archive(sessionId: string): Promise<void> {
+    const now = Date.now();
+    await this.updateHeader(sessionId, {
+      isArchived: true,
+      archivedAt: now,
+      status: 'archived',
+      statusUpdatedAt: now,
+    });
+  }
+
+  async unarchive(sessionId: string): Promise<void> {
+    await this.updateHeader(sessionId, {
+      isArchived: false,
+      archivedAt: undefined,
+      status: 'active',
+      blockedReason: undefined,
+      statusUpdatedAt: Date.now(),
+    });
+  }
+
+  async setFlagged(sessionId: string, isFlagged: boolean): Promise<void> {
+    await this.updateHeader(sessionId, { isFlagged });
+  }
+
+  async rename(sessionId: string, name: string): Promise<void> {
+    const normalized = normalizeUserSessionName(name);
+    if (!normalized.ok) throw new Error(normalized.error);
+    await this.updateHeader(sessionId, {
+      name: normalized.value,
+      titleIsManual: true,
+    });
+  }
+
+  async setGeneratedTitleIfAbsent(sessionId: string, title: string): Promise<SessionHeader | null> {
+    const normalized = normalizeUserSessionName(title);
+    if (!normalized.ok) return null;
+    const current = await this.readHeaderSnapshot(sessionId);
+    if (
+      current.titleIsManual ||
+      current.name !== DEFAULT_SESSION_NAME ||
+      normalized.value === current.name
+    ) {
+      return null;
+    }
+    return this.updateHeader(sessionId, { name: normalized.value });
+  }
+
+  async remove(sessionId: string): Promise<void> {
+    await this.ensureReady();
+    await this.metadata.remove(sessionId);
+    await this.files.remove(sessionId);
+  }
+
+  close(): void {
+    this.metadata.close();
+  }
+
+  private async lockConnectionAfterFirstUserMessage(
+    header: SessionHeader,
+    knownMessages?: StoredMessage[],
+  ): Promise<SessionHeader> {
+    if (header.connectionLocked) return header;
+    const messages = knownMessages ?? (await this.files.readMessagesSnapshot(header.id));
+    if (!messages.some((message) => message.type === 'user')) return header;
+    return this.updateHeader(header.id, { connectionLocked: true });
+  }
+
+  private async ensureReady(): Promise<void> {
+    await this.ready;
+  }
+
+  private sessionPath(sessionId: string): string {
+    assertSafeSessionId(sessionId);
+    return join(this.workspaceRoot, 'sessions', sessionId, 'session.jsonl');
+  }
 }
 
 class FileSessionStore implements SessionStore {
@@ -257,6 +496,10 @@ class FileSessionStore implements SessionStore {
 
   async readMessagesSnapshot(sessionId: string): Promise<StoredMessage[]> {
     return (await this.readFileParts(sessionId)).messages;
+  }
+
+  async readPreviewMessages(sessionId: string): Promise<StoredMessage[]> {
+    return this.readTailPreviewMessages(sessionId);
   }
 
   async readMessagesForRecovery(sessionId: string): Promise<StoredMessage[]> {

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 1;
+export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 2;
 
 const MIGRATIONS: ReadonlyMap<number, string> = new Map([
   [
@@ -60,6 +60,15 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
       session_id TEXT NOT NULL,
       imported_at INTEGER NOT NULL,
       FOREIGN KEY(session_id) REFERENCES session_metadata(session_id) ON DELETE CASCADE
+    );
+  `,
+  ],
+  [
+    2,
+    `
+    CREATE TABLE session_metadata_tombstones (
+      session_id TEXT PRIMARY KEY,
+      deleted_at INTEGER NOT NULL
     );
   `,
   ],

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -46,6 +46,7 @@ export interface SessionMetadataImportEntry {
 export interface SessionMetadataImportResult {
   created: boolean[];
   sourcesAlreadyImported: number;
+  sourcesTombstoned: number;
 }
 
 export class SessionMetadataConflictError extends Error {
@@ -100,6 +101,11 @@ export class SqliteSessionMetadataStore {
     const normalized = normalizeSessionHeader(header);
     assertSafeSessionId(normalized.id);
     return this.transaction(() => {
+      if (this.hasTombstone(normalized.id)) {
+        throw new SessionMetadataConflictError(
+          `Session metadata id is tombstoned: ${normalized.id}`,
+        );
+      }
       if (this.readRecordSync(normalized.id)) {
         throw new SessionMetadataConflictError(`Session metadata already exists: ${normalized.id}`);
       }
@@ -236,11 +242,19 @@ export class SqliteSessionMetadataStore {
   async remove(sessionId: string): Promise<boolean> {
     this.assertOpen();
     assertSafeSessionId(sessionId);
-    return this.transaction(
-      () =>
+    return this.transaction(() => {
+      const deleted =
         this.db.prepare('DELETE FROM session_metadata WHERE session_id = ?').run(sessionId)
-          .changes === 1,
-    );
+          .changes === 1;
+      this.db
+        .prepare(`
+          INSERT INTO session_metadata_tombstones(session_id, deleted_at)
+          VALUES (?, ?)
+          ON CONFLICT(session_id) DO NOTHING
+        `)
+        .run(sessionId, this.now());
+      return deleted;
+    });
   }
 
   async importEntries(
@@ -263,7 +277,12 @@ export class SqliteSessionMetadataStore {
     return this.transaction(() => {
       const created: boolean[] = [];
       let sourcesAlreadyImported = 0;
+      let sourcesTombstoned = 0;
       for (const entry of normalized) {
+        if (this.hasTombstone(entry.header.id)) {
+          sourcesTombstoned += 1;
+          continue;
+        }
         const source = this.db
           .prepare(`
             SELECT fingerprint
@@ -306,7 +325,7 @@ export class SqliteSessionMetadataStore {
           .run(entry.source.path, entry.source.fingerprint, entry.header.id, this.now());
         this.options.failpoint?.('after_session_import_marker_write');
       }
-      return { created, sourcesAlreadyImported };
+      return { created, sourcesAlreadyImported, sourcesTombstoned };
     });
   }
 
@@ -386,6 +405,14 @@ export class SqliteSessionMetadataStore {
       `)
       .get(sessionId) as SessionMetadataRow | undefined;
     return row ? decodeRecord(row) : undefined;
+  }
+
+  private hasTombstone(sessionId: string): boolean {
+    return (
+      this.db
+        .prepare('SELECT 1 AS found FROM session_metadata_tombstones WHERE session_id = ?')
+        .get(sessionId) !== undefined
+    );
   }
 
   private transaction<T>(operation: () => T): T {

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -121,6 +121,18 @@ export class SqliteSessionMetadataStore {
     return record;
   }
 
+  async has(sessionId: string): Promise<boolean> {
+    this.assertOpen();
+    assertSafeSessionId(sessionId);
+    return this.readRecordSync(sessionId) !== undefined;
+  }
+
+  async isTombstoned(sessionId: string): Promise<boolean> {
+    this.assertOpen();
+    assertSafeSessionId(sessionId);
+    return this.hasTombstone(sessionId);
+  }
+
   async list(filter: SessionListFilter = {}): Promise<SessionMetadataRecord[]> {
     this.assertOpen();
     const where: string[] = [];


### PR DESCRIPTION
Part 2 of #1370.

Depends on #1371. Please review/merge that foundation PR first; this is a stacked draft PR and will temporarily show the Part 1 commits until its dependency lands.

## What changes

- Makes `createSessionStore()` use SQLite as the canonical store for all `SessionHeader` metadata.
- Atomically imports existing JSONL line-1 headers into a dedicated `sessions.sqlite` database on startup.
- Keeps JSONL as the transcript body store during the compatibility window; metadata updates no longer rewrite the legacy header.
- Adds deletion tombstones so a leftover legacy transcript cannot resurrect a removed session after a crash.
- Preserves session listing, recovery validation, connection-lock self-healing, archive/flag/read/title operations, and transcript previews.
- Closes the SQLite handle during desktop and CLI shutdown.
- Keeps session metadata in `sessions.sqlite` rather than `runtime.sqlite`, so this cutover does not implicitly change the existing opt-in RuntimeEvent rollout.

## Compatibility boundary

Fresh sessions still receive a frozen legacy header as the JSONL first record. SQLite is authoritative immediately; Part 3 will replace that record with an explicit transcript marker and add export/downgrade/backup coverage.

## Validation

- `npm test --workspace @maka/storage`: 435 passed, 1 skipped
- `npm run build:test`: passed across all workspaces and desktop bundles
- `npx biome lint` on all 11 changed files: passed
- `git diff --check`: passed
- `npm run test:dist`: storage and other workspaces passed; `@maka/runtime` has 2 unrelated macOS sandbox/toolchain failures (hard-coded `/usr/local` executable-root expectation and Homebrew `rg` blocked from loading PCRE2). Runtime result: 2377 passed, 7 skipped, 2 failed.

Closes the default-cutover portion of #1370.