### PR TITLE
fix(ui): preserve Skill draft ownership

### DIFF
--- a/apps/desktop/e2e/skill-draft-lifecycle.spec.ts
+++ b/apps/desktop/e2e/skill-draft-lifecycle.spec.ts
@@ -1,0 +1,94 @@
+import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+
+async function createStarterSkill(page: Page): Promise<void> {
+  const result = await page.evaluate(() => window.maka.skills.createStarter());
+  expect(result.ok).toBe(true);
+  await page.reload();
+  await expect(page.locator('.maka-onboarding-quickchat-input')).toBeVisible();
+}
+
+async function seedEditableTurn(page: Page): Promise<void> {
+  const quickChat = page.locator('.maka-onboarding-quickchat-input');
+  await quickChat.fill('original message');
+  await quickChat.press('Enter');
+  await expect(page.getByText(/Fake backend received: original message/)).toBeVisible();
+}
+
+async function selectSkill(page: Page, name: RegExp): Promise<void> {
+  const composer = page.locator('.maka-composer-textarea');
+  await composer.fill('/');
+  const option = page.getByRole('listbox', { name: '技能' }).getByRole('option', { name });
+  await expect(option).toBeVisible();
+  await option.click();
+}
+
+async function beginRevision(page: Page): Promise<void> {
+  const userMessage = page.getByLabel('你发送的消息').first();
+  await userMessage.hover();
+  await userMessage.getByRole('button', { name: '编辑并重发' }).click();
+  await expect(page.locator('[data-revision-notice="true"]')).toBeVisible();
+}
+
+async function failStarterSkillRevision(page: Page): Promise<void> {
+  const disabled = await page.evaluate(() =>
+    window.maka.skills.setEnabled('starter-skill', false),
+  );
+  expect(disabled.ok).toBe(true);
+
+  const composer = page.locator('.maka-composer-textarea');
+  await composer.press('Enter');
+  await expect(page.getByText('Skill 调用失败，消息未发送')).toBeVisible();
+  await expect(composer).toHaveValue('edited with skill');
+  await expect(page.locator('.maka-composer-skill-chip')).toContainText('示例技能');
+}
+
+test('a successful revision retry clears both child and source drafts', async ({
+  window: page,
+}) => {
+  await createStarterSkill(page);
+  await seedEditableTurn(page);
+  await beginRevision(page);
+  await selectSkill(page, /示例技能/);
+  await page.locator('.maka-composer-textarea').fill('edited with skill');
+  await failStarterSkillRevision(page);
+
+  const enabled = await page.evaluate(() =>
+    window.maka.skills.setEnabled('starter-skill', true),
+  );
+  expect(enabled.ok).toBe(true);
+  await page.locator('.maka-composer-textarea').press('Enter');
+
+  await expect(page.locator('[data-revision-notice="true"]')).toHaveCount(0);
+  await expect(page.locator('.maka-composer-skill-chip')).toHaveCount(0);
+  await expect(page.locator('.maka-composer-textarea')).toHaveValue('');
+  await page.getByRole('button', { name: '查看上一版本' }).click();
+  await expect(
+    page.getByLabel('你发送的消息').getByText('original message', { exact: true }),
+  ).toBeVisible();
+  await expect(page.locator('.maka-composer-skill-chip')).toHaveCount(0);
+  await expect(page.locator('.maka-composer-textarea')).toHaveValue('');
+});
+
+test('cancelling a failed revision restores the complete pre-edit draft', async ({
+  invocableSkillsWindow: page,
+}) => {
+  await createStarterSkill(page);
+  await seedEditableTurn(page);
+
+  const composer = page.locator('.maka-composer-textarea');
+  await selectSkill(page, /Workspace Only/);
+  await composer.fill('previous unsent draft');
+  await beginRevision(page);
+  await page.locator('.maka-composer-skill-chip').getByRole('button').click();
+  await selectSkill(page, /示例技能/);
+  await composer.fill('edited with skill');
+  await failStarterSkillRevision(page);
+
+  await page.getByRole('button', { name: '取消' }).click();
+
+  await expect(page.locator('[data-revision-notice="true"]')).toHaveCount(0);
+  await expect(composer).toHaveValue('previous unsent draft');
+  await expect(page.locator('.maka-composer-skill-chip')).toHaveCount(1);
+  await expect(page.locator('.maka-composer-skill-chip')).toContainText('Workspace Only');
+});

--- a/apps/desktop/src/main/__tests__/app-shell-revision-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-revision-actions.test.ts
@@ -99,6 +99,9 @@ function createHarness(options: {
         appendText: () => undefined,
         getText: () => options.previousComposerText ?? 'Previous draft',
         setSkills: () => undefined,
+        copySkillDraft: (sourceKey: string, targetKey: string) => {
+          composerCalls.push(`<skills:${sourceKey}->${targetKey}>`);
+        },
         clearDraft: (key: string) => { composerCalls.push(`<clear:${key}>`); },
         setDraft: (key: string, text: string) => { composerCalls.push(`<draft:${key}:${text}>`); },
         focus: () => { composerCalls.push('<focus>'); },
@@ -149,7 +152,13 @@ describe('app shell revision actions', () => {
       assert.equal(harness.revisionDraftRef.current?.draftSessionId, 'revision');
       assert.deepEqual(
         harness.composerCalls,
-        ['Human-facing prompt', '<focus>', '<draft:revision:Edited prompt>', '<focus>'],
+        [
+          'Human-facing prompt',
+          '<focus>',
+          '<skills:source->revision>',
+          '<draft:revision:Edited prompt>',
+          '<focus>',
+        ],
       );
     } finally {
       harness.restoreWindow();

--- a/apps/desktop/src/main/__tests__/app-shell-revision-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-revision-actions.test.ts
@@ -5,6 +5,7 @@ import {
   createAppShellRevisionActions,
   type TurnRevisionDraft,
 } from '../../renderer/app-shell-revision-actions.js';
+import type { ComposerSkillSelection } from '@maka/ui';
 
 function session(id: string): SessionSummary {
   return {
@@ -74,7 +75,8 @@ function createHarness(options: {
   messages?: StoredMessage[];
   pendingAttachments?: boolean;
   previousComposerText?: string;
-  previousComposerSkills?: Array<{ id: string; name: string }>;
+  previousComposerSkills?: ComposerSkillSelection[];
+  getComposerSkills?: () => ComposerSkillSelection[];
   refreshMessagesResult?: boolean;
 }) {
   const activeIdRef: { current: string | undefined } = { current: 'source' };
@@ -84,6 +86,7 @@ function createHarness(options: {
   const revisionCalls: Array<[string, { sourceTurnId: string }]> = [];
   const removed: string[] = [];
   const infoToasts: Array<[string, string | undefined]> = [];
+  const writtenSkillDrafts: Array<[string, ComposerSkillSelection[]]> = [];
   const restoreWindow = installWindow(
     async (sessionId, input) => {
       revisionCalls.push([sessionId, input]);
@@ -99,13 +102,11 @@ function createHarness(options: {
         setText: (text: string) => { composerCalls.push(text); },
         appendText: () => undefined,
         getText: () => options.previousComposerText ?? 'Previous draft',
-        getSkills: () => options.previousComposerSkills ?? [],
+        getSkills: () => options.getComposerSkills?.() ?? options.previousComposerSkills ?? [],
         setSkills: () => undefined,
         setSkillDraft: (key, skills) => {
+          writtenSkillDrafts.push([key, skills.map((skill) => ({ ...skill }))]);
           composerCalls.push(`<skill-draft:${key}:${skills.map((skill) => skill.id).join(',')}>`);
-        },
-        copySkillDraft: (sourceKey: string, targetKey: string) => {
-          composerCalls.push(`<skills:${sourceKey}->${targetKey}>`);
         },
         clearDraft: (key: string) => { composerCalls.push(`<clear:${key}>`); },
         setDraft: (key: string, text: string) => { composerCalls.push(`<draft:${key}:${text}>`); },
@@ -137,6 +138,7 @@ function createHarness(options: {
     infoToasts,
     opened,
     removed,
+    writtenSkillDrafts,
     restoreWindow,
     revisionDraftRef,
   };
@@ -161,11 +163,37 @@ describe('app shell revision actions', () => {
         [
           'Human-facing prompt',
           '<focus>',
-          '<skills:source->revision>',
+          '<skill-draft:revision:>',
           '<draft:revision:Edited prompt>',
           '<focus>',
         ],
       );
+    } finally {
+      harness.restoreWindow();
+    }
+  });
+
+  it('migrates the submitted Skill snapshot when the live draft changes during revision creation', async () => {
+    let resolveRevision: ((value: SessionSummary) => void) | undefined;
+    const revisionPromise = new Promise<SessionSummary>((resolve) => { resolveRevision = resolve; });
+    let liveSkills: ComposerSkillSelection[] = [
+      { id: 'alpha', name: 'Alpha' },
+    ];
+    const harness = createHarness({
+      getComposerSkills: () => liveSkills,
+      reviseBeforeTurn: async () => revisionPromise,
+    });
+    try {
+      harness.actions.beginEditUserMessage('turn-1');
+      const pending = harness.actions.prepareRevisionSend('Edited prompt');
+      await Promise.resolve();
+      liveSkills = [{ id: 'beta', name: 'Beta' }];
+      resolveRevision?.(session('revision'));
+
+      assert.equal(await pending, true);
+      assert.deepEqual(harness.writtenSkillDrafts, [
+        ['revision', [{ id: 'alpha', name: 'Alpha' }]],
+      ]);
     } finally {
       harness.restoreWindow();
     }

--- a/apps/desktop/src/main/__tests__/app-shell-revision-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-revision-actions.test.ts
@@ -74,6 +74,7 @@ function createHarness(options: {
   messages?: StoredMessage[];
   pendingAttachments?: boolean;
   previousComposerText?: string;
+  previousComposerSkills?: Array<{ id: string; name: string }>;
   refreshMessagesResult?: boolean;
 }) {
   const activeIdRef: { current: string | undefined } = { current: 'source' };
@@ -98,7 +99,11 @@ function createHarness(options: {
         setText: (text: string) => { composerCalls.push(text); },
         appendText: () => undefined,
         getText: () => options.previousComposerText ?? 'Previous draft',
+        getSkills: () => options.previousComposerSkills ?? [],
         setSkills: () => undefined,
+        setSkillDraft: (key, skills) => {
+          composerCalls.push(`<skill-draft:${key}:${skills.map((skill) => skill.id).join(',')}>`);
+        },
         copySkillDraft: (sourceKey: string, targetKey: string) => {
           composerCalls.push(`<skills:${sourceKey}->${targetKey}>`);
         },
@@ -144,6 +149,7 @@ describe('app shell revision actions', () => {
       harness.actions.beginEditUserMessage('turn-1');
       assert.deepEqual(harness.revisionCalls, []);
       assert.equal(harness.revisionDraftRef.current?.draftSessionId, 'source');
+      assert.deepEqual(harness.revisionDraftRef.current?.previousComposerSkills, []);
       assert.deepEqual(harness.composerCalls, ['Human-facing prompt', '<focus>']);
 
       assert.equal(await harness.actions.prepareRevisionSend('Edited prompt'), true);
@@ -251,7 +257,10 @@ describe('app shell revision actions', () => {
   });
 
   it('cancels back to the source and restores its previous draft', async () => {
-    const harness = createHarness({ reviseBeforeTurn: async () => session('revision') });
+    const harness = createHarness({
+      reviseBeforeTurn: async () => session('revision'),
+      previousComposerSkills: [{ id: 'workspace-only', name: 'Workspace Only' }],
+    });
     try {
       harness.actions.beginEditUserMessage('turn-1');
       await harness.actions.prepareRevisionSend('Edited prompt');
@@ -260,6 +269,7 @@ describe('app shell revision actions', () => {
       assert.deepEqual(harness.opened, ['revision', 'source']);
       assert.deepEqual(harness.removed, ['revision']);
       assert.ok(harness.composerCalls.includes('<clear:revision>'));
+      assert.ok(harness.composerCalls.includes('<skill-draft:source:workspace-only>'));
       assert.deepEqual(harness.composerCalls.slice(-2), ['Previous draft', '<focus>']);
     } finally {
       harness.restoreWindow();

--- a/apps/desktop/src/main/__tests__/desktop-skill-invocation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-skill-invocation-contract.test.ts
@@ -21,11 +21,22 @@ describe('Desktop explicit Skill invocation contract', () => {
     assert.doesNotMatch(popup, /skillMentionInsertion\(item\.id\)/);
     assert.match(composer, /className="maka-composer-skill-chip"/);
     assert.match(composer, /props\.onSend\(text, skillIds\)/);
+    assert.match(composer, /clearDraft\(draftKey\);\s*skillDraft\.clear\(draftKey\)/);
     assert.match(composer, /<UiButton[\s\S]*?size="icon"[\s\S]*?shape="pill"[\s\S]*?className="maka-composer-skill-chip-remove"/);
     assert.match(composer, /skillDraft\.remove\(skill\.id\);[\s\S]*?requestAnimationFrame\(\(\) => textareaRef\.current\?\.focus\(\)\)/);
     assert.match(draft, /storeRef = useRef<Map<string, ComposerSkillSelection\[\]>>/);
     assert.match(styles, /\.maka-composer-skill-chip \{[\s\S]*?min-height: 32px;/);
     assert.doesNotMatch(styles, /\.maka-composer-skill-chip-remove \{/);
+  });
+
+  it('clears the submitted Skill owner before guarding the visible draft', async () => {
+    const composer = await read('packages/ui/src/composer.tsx');
+    const clearSubmittedAt = composer.indexOf('skillDraft.clear(submittedSkillDraftKey)');
+    const ownerGuardAt = composer.indexOf(
+      'if (activeDraftKey() !== submittedDraftKey) return',
+      clearSubmittedAt,
+    );
+    assert.ok(clearSubmittedAt >= 0 && ownerGuardAt > clearSubmittedAt);
   });
 
   it('re-resolves structured ids and direct tokens before consuming attachments', async () => {

--- a/apps/desktop/src/main/__tests__/session-revision-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-revision-contract.test.ts
@@ -34,6 +34,11 @@ describe('session revision (edit-and-resend) contract', () => {
     );
     assert.match(shell, /prepareRevisionSend/);
     assert.match(
+      source,
+      /copySkillDraft\(sourceSessionId, newSession\.id\)[\s\S]*setDraft\(newSession\.id, text\)/,
+      'revision preparation must migrate structured Skills with the text draft',
+    );
+    assert.match(
       shell,
       /revisionNotice=\{[\s\S]*revisionDraft && activeId === revisionDraft\.draftSessionId/,
     );

--- a/apps/desktop/src/main/__tests__/session-revision-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-revision-contract.test.ts
@@ -35,8 +35,8 @@ describe('session revision (edit-and-resend) contract', () => {
     assert.match(shell, /prepareRevisionSend/);
     assert.match(
       source,
-      /copySkillDraft\(sourceSessionId, newSession\.id\)[\s\S]*setDraft\(newSession\.id, text\)/,
-      'revision preparation must migrate structured Skills with the text draft',
+      /const submittedSkills =[\s\S]*getSkills\(\)[\s\S]*await window\.maka\.sessions\.reviseBeforeTurn[\s\S]*setSkillDraft\(newSession\.id, submittedSkills\)[\s\S]*setDraft\(newSession\.id, text\)/,
+      'revision preparation must snapshot submitted Skills before creating the child session',
     );
     assert.match(
       source,

--- a/apps/desktop/src/main/__tests__/session-revision-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-revision-contract.test.ts
@@ -39,10 +39,24 @@ describe('session revision (edit-and-resend) contract', () => {
       'revision preparation must migrate structured Skills with the text draft',
     );
     assert.match(
+      source,
+      /previousComposerSkills: composerRef\.current\?\.getSkills\(\) \?\? \[\]/,
+      'revision cancellation must be able to restore the complete pre-edit draft',
+    );
+    assert.match(
+      source,
+      /setSkillDraft\(\s*draft\.sourceSessionId,\s*draft\.previousComposerSkills/,
+      'revision cancellation must restore the source Skill snapshot',
+    );
+    assert.match(
       shell,
       /revisionNotice=\{[\s\S]*revisionDraft && activeId === revisionDraft\.draftSessionId/,
     );
-    assert.match(shell, /composerRef\.current\?\.clearDraft\(expectedRevisionSessionId\)/);
+    assert.match(
+      shell,
+      /clearDraft\(expectedRevisionDraft\.draftSessionId\)[\s\S]*clearDraft\(expectedRevisionDraft\.sourceSessionId\)/,
+      'a successful child retry must clear both copies of the migrated draft',
+    );
     assert.match(
       shell,
       /if \(\(skillIds\.length === 0 && text\.trim\(\) === '\/compact'\) \|\| swarmCommand\) \{[\s\S]*revisionCommandUnsupported/,

--- a/apps/desktop/src/renderer/app-shell-revision-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-revision-actions.ts
@@ -1,6 +1,6 @@
 import type { SessionSummary, StoredMessage, UiLocale } from '@maka/core';
 import { userFacingText } from '@maka/core';
-import type { ComposerHandle } from '@maka/ui';
+import type { ComposerHandle, ComposerSkillSelection } from '@maka/ui';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
 import { localizedShellErrorMessage } from './locales/shell-copy.js';
 import {
@@ -27,6 +27,8 @@ export type TurnRevisionDraft = {
   originalText: string;
   /** Composer text that was present before edit began; restored on cancel. */
   previousComposerText: string;
+  /** Structured Skills that were present before edit began; restored on cancel. */
+  previousComposerSkills: ComposerSkillSelection[];
 };
 
 export interface AppShellRevisionActions {
@@ -141,6 +143,7 @@ export function createAppShellRevisionActions(deps: {
       draftSessionId: sessionId,
       originalText: prompt,
       previousComposerText: composerRef.current?.getText() ?? '',
+      previousComposerSkills: composerRef.current?.getSkills() ?? [],
     });
     composerRef.current?.setText(prompt);
     composerRef.current?.focus();
@@ -235,6 +238,10 @@ export function createAppShellRevisionActions(deps: {
       draft.draftSessionId !== draft.sourceSessionId ? draft.draftSessionId : undefined;
     commitRevisionDraft(null);
     composerRef.current?.setDraft(draft.sourceSessionId, draft.previousComposerText);
+    composerRef.current?.setSkillDraft(
+      draft.sourceSessionId,
+      draft.previousComposerSkills,
+    );
     if (preparedSessionId) composerRef.current?.clearDraft(preparedSessionId);
     if (activeIdRef.current !== draft.sourceSessionId) {
       openSessionInChat(draft.sourceSessionId);

--- a/apps/desktop/src/renderer/app-shell-revision-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-revision-actions.ts
@@ -183,6 +183,12 @@ export function createAppShellRevisionActions(deps: {
     if (draft.draftSessionId !== draft.sourceSessionId) return true;
 
     const sourceSessionId = draft.sourceSessionId;
+    // Snapshot the submitted structured draft before the first async boundary.
+    // The composer remains editable while the revision session is created, so
+    // reading it after reviseBeforeTurn() could migrate a newer, unsent Skill
+    // selection instead of the one that belongs to this send attempt.
+    const submittedSkills =
+      composerRef.current?.getSkills().map((skill) => ({ ...skill })) ?? [];
     let preparedSessionId: string | undefined;
     try {
       const newSession = await window.maka.sessions.reviseBeforeTurn(sourceSessionId, {
@@ -195,7 +201,7 @@ export function createAppShellRevisionActions(deps: {
       }
 
       const prepared = { ...draft, draftSessionId: newSession.id };
-      composerRef.current?.copySkillDraft(sourceSessionId, newSession.id);
+      composerRef.current?.setSkillDraft(newSession.id, submittedSkills);
       composerRef.current?.setDraft(newSession.id, text);
       commitRevisionDraft(prepared);
       upsertSessionSummary(newSession);

--- a/apps/desktop/src/renderer/app-shell-revision-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-revision-actions.ts
@@ -192,6 +192,7 @@ export function createAppShellRevisionActions(deps: {
       }
 
       const prepared = { ...draft, draftSessionId: newSession.id };
+      composerRef.current?.copySkillDraft(sourceSessionId, newSession.id);
       composerRef.current?.setDraft(newSession.id, text);
       commitRevisionDraft(prepared);
       upsertSessionSummary(newSession);

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1175,8 +1175,8 @@ function AppShellContent({
       return ok;
     }
     const pending = pendingAttachments.length > 0 ? pendingAttachments : undefined;
-    const expectedRevisionSessionId = revisionSend
-      ? revisionDraftRef.current?.draftSessionId
+    const expectedRevisionDraft = revisionSend
+      ? revisionDraftRef.current
       : undefined;
     const quotes = pendingQuotes.length > 0 ? pendingQuotes : undefined;
     const ok = await send(text, pending, {
@@ -1186,8 +1186,11 @@ function AppShellContent({
     if (ok !== false && pending) clearSubmittedAttachments(pending);
     if (ok !== false && quotes) clearQuotes();
     if (ok !== false && revisionSend) {
-      if (expectedRevisionSessionId) {
-        composerRef.current?.clearDraft(expectedRevisionSessionId);
+      if (expectedRevisionDraft) {
+        composerRef.current?.clearDraft(expectedRevisionDraft.draftSessionId);
+        if (expectedRevisionDraft.sourceSessionId !== expectedRevisionDraft.draftSessionId) {
+          composerRef.current?.clearDraft(expectedRevisionDraft.sourceSessionId);
+        }
       }
       commitRevisionDraft(null);
     }

--- a/packages/ui/src/__tests__/chat-input-behavior.test.ts
+++ b/packages/ui/src/__tests__/chat-input-behavior.test.ts
@@ -11,7 +11,6 @@ import {
 } from '../chat-input-behavior.js';
 import {
   addUniqueComposerSkillSelection,
-  copyComposerSkillDraftSelections,
 } from '../use-composer-skill-draft.js';
 
 describe('shared chat input behavior', () => {
@@ -162,22 +161,5 @@ describe('structured Skill selections', () => {
       { id: 'alpha', name: 'Alpha' },
       { id: 'beta', name: 'Beta' },
     ]);
-  });
-
-  it('copies the live Skill draft into a revision key without consuming the source', () => {
-    const active = [{ id: 'alpha', name: 'Alpha' }];
-    const store = new Map<string, Array<{ id: string; name: string }>>();
-    const copied = copyComposerSkillDraftSelections(
-      store,
-      'source',
-      'revision',
-      'source',
-      active,
-    );
-
-    assert.deepEqual(copied, active);
-    assert.notEqual(copied, active);
-    assert.deepEqual(store.get('revision'), active);
-    assert.deepEqual(active, [{ id: 'alpha', name: 'Alpha' }]);
   });
 });

--- a/packages/ui/src/__tests__/chat-input-behavior.test.ts
+++ b/packages/ui/src/__tests__/chat-input-behavior.test.ts
@@ -9,7 +9,10 @@ import {
   mentionQueryMatches,
   skillMentionQuery,
 } from '../chat-input-behavior.js';
-import { addUniqueComposerSkillSelection } from '../use-composer-skill-draft.js';
+import {
+  addUniqueComposerSkillSelection,
+  copyComposerSkillDraftSelections,
+} from '../use-composer-skill-draft.js';
 
 describe('shared chat input behavior', () => {
   it('recognizes IME composition from either the native flag or Process key', () => {
@@ -159,5 +162,22 @@ describe('structured Skill selections', () => {
       { id: 'alpha', name: 'Alpha' },
       { id: 'beta', name: 'Beta' },
     ]);
+  });
+
+  it('copies the live Skill draft into a revision key without consuming the source', () => {
+    const active = [{ id: 'alpha', name: 'Alpha' }];
+    const store = new Map<string, Array<{ id: string; name: string }>>();
+    const copied = copyComposerSkillDraftSelections(
+      store,
+      'source',
+      'revision',
+      'source',
+      active,
+    );
+
+    assert.deepEqual(copied, active);
+    assert.notEqual(copied, active);
+    assert.deepEqual(store.get('revision'), active);
+    assert.deepEqual(active, [{ id: 'alpha', name: 'Alpha' }]);
   });
 });

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -19,7 +19,10 @@ import { type ChatModelChoice, modelChoiceValue } from './chat-model-helpers.js'
 import { appendPromptContextDraft, isReferenceSizedPaste } from './composer-helpers.js';
 import { useComposerDraft } from './use-composer-draft.js';
 import { useComposerHistory } from './use-composer-history.js';
-import { useComposerSkillDraft } from './use-composer-skill-draft.js';
+import {
+  useComposerSkillDraft,
+  type ComposerSkillSelection,
+} from './use-composer-skill-draft.js';
 import {
   createChatInputActionOwner,
   fileTransferContainsFiles,
@@ -58,10 +61,17 @@ export interface ComposerHandle {
   appendText(text: string): void;
   /** Read the current uncontrolled textarea value. */
   getText(): string;
+  /** Snapshot the structured Skills owned by the active draft. */
+  getSkills(): ComposerSkillSelection[];
   /** Clear one persisted text and Skill draft without affecting another session. */
   clearDraft(draftKey: string): void;
   /** Write a specific session draft before navigation changes the active key. */
   setDraft(draftKey: string, text: string): void;
+  /** Replace structured Skills under an explicit session draft key. */
+  setSkillDraft(
+    draftKey: string,
+    skills: readonly ComposerSkillSelection[],
+  ): void;
   /** Copy structured Skill selections when a revision changes draft ownership. */
   copySkillDraft(sourceDraftKey: string, targetDraftKey: string): void;
   /** Move focus to the textarea without changing its content. */
@@ -332,6 +342,9 @@ export const Composer = forwardRef<
       getText() {
         return textareaRef.current?.value ?? '';
       },
+      getSkills() {
+        return skillDraft.get(skillDraft.activeDraftKey());
+      },
       clearDraft(draftKey: string) {
         clearDraft(draftKey);
         skillDraft.clear(draftKey);
@@ -351,6 +364,12 @@ export const Composer = forwardRef<
         autoResize();
         focusTextInputAtEnd(el);
       },
+      setSkillDraft(
+        draftKey: string,
+        skills: readonly ComposerSkillSelection[],
+      ) {
+        skillDraft.replace(draftKey, skills);
+      },
       copySkillDraft(sourceDraftKey: string, targetDraftKey: string) {
         skillDraft.copy(sourceDraftKey, targetDraftKey);
       },
@@ -358,8 +377,7 @@ export const Composer = forwardRef<
         textareaRef.current?.focus();
       },
       setSkills(skills) {
-        skillDraft.clear(skillDraft.activeDraftKey());
-        for (const skill of skills) skillDraft.add(skill);
+        skillDraft.replace(skillDraft.activeDraftKey(), skills);
       },
     }),
     [],

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -72,8 +72,6 @@ export interface ComposerHandle {
     draftKey: string,
     skills: readonly ComposerSkillSelection[],
   ): void;
-  /** Copy structured Skill selections when a revision changes draft ownership. */
-  copySkillDraft(sourceDraftKey: string, targetDraftKey: string): void;
   /** Move focus to the textarea without changing its content. */
   focus(): void;
   /** Fixture/integration seam for the same structured selection state used by `/`. */
@@ -369,9 +367,6 @@ export const Composer = forwardRef<
         skills: readonly ComposerSkillSelection[],
       ) {
         skillDraft.replace(draftKey, skills);
-      },
-      copySkillDraft(sourceDraftKey: string, targetDraftKey: string) {
-        skillDraft.copy(sourceDraftKey, targetDraftKey);
       },
       focus() {
         textareaRef.current?.focus();

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -58,10 +58,12 @@ export interface ComposerHandle {
   appendText(text: string): void;
   /** Read the current uncontrolled textarea value. */
   getText(): string;
-  /** Clear one persisted draft without affecting a different active session. */
+  /** Clear one persisted text and Skill draft without affecting another session. */
   clearDraft(draftKey: string): void;
   /** Write a specific session draft before navigation changes the active key. */
   setDraft(draftKey: string, text: string): void;
+  /** Copy structured Skill selections when a revision changes draft ownership. */
+  copySkillDraft(sourceDraftKey: string, targetDraftKey: string): void;
   /** Move focus to the textarea without changing its content. */
   focus(): void;
   /** Fixture/integration seam for the same structured selection state used by `/`. */
@@ -332,6 +334,7 @@ export const Composer = forwardRef<
       },
       clearDraft(draftKey: string) {
         clearDraft(draftKey);
+        skillDraft.clear(draftKey);
         if (activeDraftKey() !== draftKey) return;
         const el = textareaRef.current;
         if (el) el.value = '';
@@ -347,6 +350,9 @@ export const Composer = forwardRef<
         el.value = text;
         autoResize();
         focusTextInputAtEnd(el);
+      },
+      copySkillDraft(sourceDraftKey: string, targetDraftKey: string) {
+        skillDraft.copy(sourceDraftKey, targetDraftKey);
       },
       focus() {
         textareaRef.current?.focus();
@@ -383,11 +389,11 @@ export const Composer = forwardRef<
     // survives page reloads and is shared across all input surfaces.
     if (text) rememberSentEntry(text);
     clearDraft(submittedDraftKey);
+    skillDraft.clear(submittedSkillDraftKey);
     // The owner may have changed while onSend awaited (new-session creation,
     // revision branch, or user navigation). Never erase a foreign draft.
     if (activeDraftKey() !== submittedDraftKey) return;
     saveCurrentDraft('');
-    skillDraft.clear(submittedSkillDraftKey);
     skillDraft.clear(skillDraft.activeDraftKey());
     form?.reset();
     // form.reset() empties the textarea but doesn't fire input — collapse

--- a/packages/ui/src/use-composer-skill-draft.ts
+++ b/packages/ui/src/use-composer-skill-draft.ts
@@ -65,6 +65,8 @@ export function useComposerSkillDraft(draftKey: string | undefined) {
   function clear(key: string | undefined) {
     if (key) storeRef.current.delete(key);
     if (key === activeKeyRef.current) {
+      // Keep clear terminal: commit([]) would immediately recreate
+      // the active store entry.
       currentRef.current = [];
       setSkillsState([]);
     }

--- a/packages/ui/src/use-composer-skill-draft.ts
+++ b/packages/ui/src/use-composer-skill-draft.ts
@@ -14,6 +14,24 @@ export function addUniqueComposerSkillSelection(
     : [...skills, skill];
 }
 
+export function copyComposerSkillDraftSelections(
+  store: Map<string, ComposerSkillSelection[]>,
+  sourceKey: string | undefined,
+  targetKey: string | undefined,
+  activeKey: string | undefined,
+  activeSkills: readonly ComposerSkillSelection[],
+): ComposerSkillSelection[] {
+  const source =
+    sourceKey === activeKey
+      ? activeSkills
+      : sourceKey
+        ? (store.get(sourceKey) ?? [])
+        : [];
+  const next = [...source];
+  if (targetKey) store.set(targetKey, next);
+  return next;
+}
+
 /** Per-session structured Skill selections, parallel to the textarea draft. */
 export function useComposerSkillDraft(draftKey: string | undefined) {
   const storeRef = useRef<Map<string, ComposerSkillSelection[]>>(new Map());
@@ -49,6 +67,20 @@ export function useComposerSkillDraft(draftKey: string | undefined) {
     if (key === activeKeyRef.current) commit([]);
   }
 
+  function copy(sourceKey: string | undefined, targetKey: string | undefined) {
+    const next = copyComposerSkillDraftSelections(
+      storeRef.current,
+      sourceKey,
+      targetKey,
+      activeKeyRef.current,
+      currentRef.current,
+    );
+    if (targetKey === activeKeyRef.current) {
+      currentRef.current = next;
+      setSkillsState(next);
+    }
+  }
+
   useEffect(() => {
     const previousKey = activeKeyRef.current;
     if (previousKey === draftKey) return;
@@ -65,6 +97,7 @@ export function useComposerSkillDraft(draftKey: string | undefined) {
     remove,
     removeLast,
     clear,
+    copy,
     activeDraftKey: () => activeKeyRef.current,
   };
 }

--- a/packages/ui/src/use-composer-skill-draft.ts
+++ b/packages/ui/src/use-composer-skill-draft.ts
@@ -14,24 +14,6 @@ export function addUniqueComposerSkillSelection(
     : [...skills, skill];
 }
 
-export function copyComposerSkillDraftSelections(
-  store: Map<string, ComposerSkillSelection[]>,
-  sourceKey: string | undefined,
-  targetKey: string | undefined,
-  activeKey: string | undefined,
-  activeSkills: readonly ComposerSkillSelection[],
-): ComposerSkillSelection[] {
-  const source =
-    sourceKey === activeKey
-      ? activeSkills
-      : sourceKey
-        ? (store.get(sourceKey) ?? [])
-        : [];
-  const next = [...source];
-  if (targetKey) store.set(targetKey, next);
-  return next;
-}
-
 /** Per-session structured Skill selections, parallel to the textarea draft. */
 export function useComposerSkillDraft(draftKey: string | undefined) {
   const storeRef = useRef<Map<string, ComposerSkillSelection[]>>(new Map());
@@ -95,20 +77,6 @@ export function useComposerSkillDraft(draftKey: string | undefined) {
     }
   }
 
-  function copy(sourceKey: string | undefined, targetKey: string | undefined) {
-    const next = copyComposerSkillDraftSelections(
-      storeRef.current,
-      sourceKey,
-      targetKey,
-      activeKeyRef.current,
-      currentRef.current,
-    );
-    if (targetKey === activeKeyRef.current) {
-      currentRef.current = next;
-      setSkillsState(next);
-    }
-  }
-
   useEffect(() => {
     const previousKey = activeKeyRef.current;
     if (previousKey === draftKey) return;
@@ -127,7 +95,6 @@ export function useComposerSkillDraft(draftKey: string | undefined) {
     clear,
     get,
     replace,
-    copy,
     activeDraftKey: () => activeKeyRef.current,
   };
 }

--- a/packages/ui/src/use-composer-skill-draft.ts
+++ b/packages/ui/src/use-composer-skill-draft.ts
@@ -64,7 +64,33 @@ export function useComposerSkillDraft(draftKey: string | undefined) {
 
   function clear(key: string | undefined) {
     if (key) storeRef.current.delete(key);
-    if (key === activeKeyRef.current) commit([]);
+    if (key === activeKeyRef.current) {
+      currentRef.current = [];
+      setSkillsState([]);
+    }
+  }
+
+  function get(key: string | undefined) {
+    return key === activeKeyRef.current
+      ? [...currentRef.current]
+      : key
+        ? [...(storeRef.current.get(key) ?? [])]
+        : [];
+  }
+
+  function replace(
+    key: string | undefined,
+    skills: readonly ComposerSkillSelection[],
+  ) {
+    const next = [...skills];
+    if (key) {
+      if (next.length > 0) storeRef.current.set(key, next);
+      else storeRef.current.delete(key);
+    }
+    if (key === activeKeyRef.current) {
+      currentRef.current = next;
+      setSkillsState(next);
+    }
   }
 
   function copy(sourceKey: string | undefined, targetKey: string | undefined) {
@@ -97,6 +123,8 @@ export function useComposerSkillDraft(draftKey: string | undefined) {
     remove,
     removeLast,
     clear,
+    get,
+    replace,
     copy,
     activeDraftKey: () => activeKeyRef.current,
   };


### PR DESCRIPTION
## Summary

- clear the submitted Skill draft before the visible-composer ownership guard, preventing stale chips when `onSend` changes sessions
- snapshot the complete submitted Skill selection before revision creation awaits, so later composer edits cannot change the child draft
- restore the complete pre-edit draft, including Skill selections, when a revision is cancelled
- clear both the child and source draft copies after a successful revision retry
- add real Electron coverage for successful retry and failed-revision cancellation

## Context

This is a focused follow-up to #1282 and addresses non-blocking review items 2 and 3 from the approval review. It excludes the separate host-capability alignment follow-up (item 1). #1279 remains open.

There is no visual styling change. The observable behavior changes are:

1. a successful send clears the Skill chips owned by the submitted session even if navigation changes while the send is pending
2. revision creation preserves the exact Skill selection submitted before its asynchronous session handoff
3. a revision whose Skill resolution fails keeps its text and chips in the child session, so retrying does not silently fall back to plain text
4. a successful retry clears the copied draft from both the child and original session
5. cancelling a failed revision restores the original session's complete pre-edit text and Skill selection
6. discarded revision sessions do not retain text or Skill draft state

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- targeted UI and Desktop revision suites — 34/34
- `npm --workspace @maka/ui run test:dist` — 230/230
- `npm --workspace @maka/desktop run test:dist` — 2821/2821
- `npm --workspace @maka/desktop run e2e` — 40/40
- after rebasing onto current `main`: `npm --workspace @maka/desktop run e2e -- skill-draft-lifecycle.spec.ts` — 2/2
- `npm --workspace maka-agent run test:dist` — 643/643 on serial rerun
- `npm test` is not locally green because the unchanged Runtime macOS filesystem-worker smoke cannot load Homebrew `pcre2` inside its sandbox; serial Runtime rerun passed 2381 tests, skipped 7, and failed only that environment-specific smoke assertion
