### PR TITLE
fix: make workspace identity best-effort for new turns

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -5455,7 +5455,7 @@ describe('Maka Pi TUI runner', () => {
     await run;
   });
 
-  test('handles /move without sending a prompt and warns about dirty old cwd', async () => {
+  test('handles /move without sending it as a prompt and accepts the next prompt', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
     const run = runMakaPiTui({
@@ -5475,6 +5475,11 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => plainTerminalOutput(terminal.output()).includes('uncommitted changes'));
     assert.deepEqual(driver.moves, ['/repo/.worktree/feature']);
     assert.deepEqual(driver.prompts, []);
+
+    terminal.input('continue in the moved workspace');
+    terminal.input('\r');
+    await waitFor(() => driver.prompts.length === 1);
+    assert.deepEqual(driver.prompts, ['continue in the moved workspace']);
 
     exitMaka(terminal);
     await Promise.race([

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -855,6 +855,38 @@ describe('SessionManager permission mode updates', () => {
     );
   });
 
+  test('starts a new turn without workspace identity when safety inspection fails', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new FinalTextTestBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      safeBoundaryResumeEnabled: true,
+      inspectContinuationSafety: async () => {
+        throw new Error('workspace marker is unavailable');
+      },
+      newId: nextId(),
+      now: nextNow(6_526),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+
+    const events = await collectSessionEvents(
+      manager.sendMessage(session.id, {
+        turnId: 'turn-workspace-identity-unavailable',
+        text: 'continue without resumability',
+      }),
+    );
+
+    expect(events.map((event) => event.type)).toEqual(['text_complete', 'complete']);
+    const [run] = await runStore.listSessionRuns(session.id);
+    expect(run?.workspaceIdentity).toBeUndefined();
+  });
+
   test('does not inspect continuation safety on normal turns while resume is disabled', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -260,10 +260,16 @@ export class RuntimeKernel implements RuntimeKernelLike {
     let pending = true;
     try {
       const header = await this.deps.store.readHeader(sessionId);
-      const workspaceIdentity =
-        this.deps.safeBoundaryResumeEnabled === true && this.deps.inspectContinuationSafety
-          ? (await this.deps.inspectContinuationSafety(sessionId)).workspaceIdentity
-          : undefined;
+      let workspaceIdentity: string | undefined;
+      if (this.deps.safeBoundaryResumeEnabled === true && this.deps.inspectContinuationSafety) {
+        try {
+          workspaceIdentity = (await this.deps.inspectContinuationSafety(sessionId))
+            .workspaceIdentity;
+        } catch {
+          // A new turn remains usable without continuation metadata. Actual
+          // continuation claims inspect the same facts strictly below.
+        }
+      }
       const run = new AgentRun({
         sessionId,
         header,

--- a/packages/storage/src/__tests__/workspace-identity.test.ts
+++ b/packages/storage/src/__tests__/workspace-identity.test.ts
@@ -143,6 +143,31 @@ test('concurrent Git workspace resolution returns one clean identity', async () 
   }
 });
 
+test('a full Git exclude does not grow when resolving workspace identity', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-git-exclude-full-'));
+  try {
+    await execFileAsync('git', ['init', '--quiet'], { cwd: workspace });
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-parse', '--path-format=absolute', '--git-path', 'info/exclude'],
+      { cwd: workspace, encoding: 'utf8' },
+    );
+    const excludePath = stdout.trim();
+    const originalContents = '#'.repeat(1024 * 1024);
+    await writeFile(excludePath, originalContents, 'utf8');
+
+    await assert.rejects(
+      () => resolveWorkspaceIdentity({ path: workspace }),
+      (error: unknown) =>
+        error instanceof WorkspaceIdentityError && error.code === 'workspace_io_failed',
+    );
+    assert.equal(await readFile(excludePath, 'utf8'), originalContents);
+    await assert.rejects(access(join(workspace, WORKSPACE_MARKER_FILE)), { code: 'ENOENT' });
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
 test('a malformed enclosing Git repository prevents publishing a new marker', async () => {
   const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-git-malformed-'));
   try {

--- a/packages/storage/src/__tests__/workspace-identity.test.ts
+++ b/packages/storage/src/__tests__/workspace-identity.test.ts
@@ -1,8 +1,10 @@
 import assert from 'node:assert/strict';
-import { cp, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { access, chmod, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
+import { promisify } from 'node:util';
 
 import {
   adoptWorkspaceIdentityOnImport,
@@ -12,16 +14,210 @@ import {
   WorkspaceIdentityError,
 } from '../workspace-identity.js';
 
-test('a copied marker preserves workspace identity across archive extraction', async () => {
+const execFileAsync = promisify(execFile);
+
+test('creating a workspace identity keeps a Git worktree clean', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-git-clean-'));
+  try {
+    await execFileAsync('git', ['init', '--quiet'], { cwd: workspace });
+
+    await resolveWorkspaceIdentity({ path: workspace });
+
+    const { stdout } = await execFileAsync(
+      'git',
+      ['status', '--porcelain=v1', '--untracked-files=normal'],
+      { cwd: workspace, encoding: 'utf8' },
+    );
+    assert.equal(stdout, '');
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('an existing workspace marker becomes locally ignored after Git initialization', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-git-existing-'));
+  try {
+    const original = await resolveWorkspaceIdentity({ path: workspace });
+    await execFileAsync('git', ['init', '--quiet'], { cwd: workspace });
+
+    const resolved = await resolveWorkspaceIdentity({ path: workspace });
+
+    assert.equal(resolved.workspaceIdentity, original.workspaceIdentity);
+    const { stdout } = await execFileAsync(
+      'git',
+      ['status', '--porcelain=v1', '--untracked-files=normal'],
+      { cwd: workspace, encoding: 'utf8' },
+    );
+    assert.equal(stdout, '');
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('a subdirectory workspace stays clean inside a linked Git worktree', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-workspace-git-linked-'));
+  try {
+    const repository = join(base, 'repository');
+    const linkedWorktree = join(base, 'linked');
+    const workspace = join(linkedWorktree, 'nested', 'workspace');
+    await mkdir(repository);
+    await execFileAsync('git', ['init', '--quiet'], { cwd: repository });
+    await writeFile(join(repository, 'tracked.txt'), 'tracked\n', 'utf8');
+    await execFileAsync('git', ['add', 'tracked.txt'], { cwd: repository });
+    await execFileAsync(
+      'git',
+      [
+        '-c',
+        'user.name=Maka Test',
+        '-c',
+        'user.email=test@maka.invalid',
+        'commit',
+        '--quiet',
+        '-m',
+        'init',
+      ],
+      { cwd: repository },
+    );
+    await execFileAsync(
+      'git',
+      ['worktree', 'add', '--quiet', '-b', 'linked-test', linkedWorktree],
+      {
+        cwd: repository,
+      },
+    );
+    await mkdir(workspace, { recursive: true });
+
+    await resolveWorkspaceIdentity({ path: workspace });
+
+    const { stdout } = await execFileAsync(
+      'git',
+      ['status', '--porcelain=v1', '--untracked-files=normal'],
+      { cwd: linkedWorktree, encoding: 'utf8' },
+    );
+    assert.equal(stdout, '');
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('repeated Git workspace resolution adds one local exclude rule', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-git-idempotent-'));
+  try {
+    await execFileAsync('git', ['init', '--quiet'], { cwd: workspace });
+
+    await resolveWorkspaceIdentity({ path: workspace });
+    await resolveWorkspaceIdentity({ path: workspace });
+
+    const { stdout } = await execFileAsync(
+      'git',
+      ['rev-parse', '--path-format=absolute', '--git-path', 'info/exclude'],
+      { cwd: workspace, encoding: 'utf8' },
+    );
+    const rules = (await readFile(stdout.trim(), 'utf8'))
+      .split(/\r?\n/)
+      .filter((line) => line === WORKSPACE_MARKER_FILE);
+    assert.equal(rules.length, 1);
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('concurrent Git workspace resolution returns one clean identity', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-git-concurrent-'));
+  try {
+    await execFileAsync('git', ['init', '--quiet'], { cwd: workspace });
+
+    const resolutions = await Promise.all(
+      Array.from({ length: 8 }, () => resolveWorkspaceIdentity({ path: workspace })),
+    );
+
+    assert.equal(new Set(resolutions.map((resolution) => resolution.workspaceIdentity)).size, 1);
+    const { stdout } = await execFileAsync(
+      'git',
+      ['status', '--porcelain=v1', '--untracked-files=normal'],
+      { cwd: workspace, encoding: 'utf8' },
+    );
+    assert.equal(stdout, '');
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('a malformed enclosing Git repository prevents publishing a new marker', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-git-malformed-'));
+  try {
+    await writeFile(join(workspace, '.git'), 'gitdir: /missing/maka-git-dir\n', 'utf8');
+
+    await assert.rejects(
+      () => resolveWorkspaceIdentity({ path: workspace }),
+      (error: unknown) =>
+        error instanceof WorkspaceIdentityError && error.code === 'workspace_io_failed',
+    );
+    await assert.rejects(access(join(workspace, WORKSPACE_MARKER_FILE)), { code: 'ENOENT' });
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('a non-Git workspace resolves when the Git executable is unavailable', {
+  skip: process.platform === 'win32',
+}, async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-no-git-required-'));
+  try {
+    await resolveWorkspaceIdentityWithoutGit(workspace);
+
+    await access(join(workspace, WORKSPACE_MARKER_FILE));
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('a Git workspace does not publish a marker when the Git executable is unavailable', {
+  skip: process.platform === 'win32',
+}, async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-git-unavailable-'));
+  try {
+    await execFileAsync('git', ['init', '--quiet'], { cwd: workspace });
+
+    await assert.rejects(resolveWorkspaceIdentityWithoutGit(workspace));
+    await assert.rejects(access(join(workspace, WORKSPACE_MARKER_FILE)), { code: 'ENOENT' });
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('an unmarked read-only workspace fails without leaving marker state', {
+  skip: process.platform === 'win32',
+}, async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-read-only-'));
+  try {
+    await chmod(workspace, 0o555);
+
+    await assert.rejects(
+      () => resolveWorkspaceIdentity({ path: workspace }),
+      (error: unknown) =>
+        error instanceof WorkspaceIdentityError && error.code === 'workspace_io_failed',
+    );
+    await assert.rejects(access(join(workspace, WORKSPACE_MARKER_FILE)), { code: 'ENOENT' });
+  } finally {
+    await chmod(workspace, 0o755);
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
+
+test('a tar archive round-trip preserves workspace identity', async () => {
   const base = await mkdtemp(join(tmpdir(), 'maka-workspace-identity-'));
   try {
     const source = join(base, 'source');
     const imported = join(base, 'imported');
+    const archive = join(base, 'workspace.tar');
     await mkdir(source);
     const original = await resolveWorkspaceIdentity({ path: source });
     const markerBefore = await readFile(join(source, WORKSPACE_MARKER_FILE), 'utf8');
 
-    await cp(source, imported, { recursive: true });
+    await mkdir(imported);
+    await execFileAsync('tar', ['-cf', archive, '-C', source, '.']);
+    await execFileAsync('tar', ['-xf', archive, '-C', imported]);
     assert.equal(await readFile(join(imported, WORKSPACE_MARKER_FILE), 'utf8'), markerBefore);
     const adopted = await adoptWorkspaceIdentityOnImport({
       path: imported,
@@ -35,6 +231,37 @@ test('a copied marker preserves workspace identity across archive extraction', a
       JSON.parse(await readFile(join(imported, WORKSPACE_MARKER_FILE), 'utf8')).workspaceId,
       JSON.parse(markerBefore).workspaceId,
     );
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('importing an existing marker into a Git worktree keeps it clean', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-workspace-import-git-'));
+  try {
+    const source = join(base, 'source');
+    const imported = join(base, 'imported');
+    await mkdir(source);
+    await mkdir(imported);
+    const original = await resolveWorkspaceIdentity({ path: source });
+    await writeFile(
+      join(imported, WORKSPACE_MARKER_FILE),
+      await readFile(join(source, WORKSPACE_MARKER_FILE)),
+    );
+    await execFileAsync('git', ['init', '--quiet'], { cwd: imported });
+
+    const adopted = await adoptWorkspaceIdentityOnImport({
+      path: imported,
+      expectedWorkspaceIdentity: original.workspaceIdentity,
+    });
+
+    assert.equal(adopted.workspaceIdentity, original.workspaceIdentity);
+    const { stdout } = await execFileAsync(
+      'git',
+      ['status', '--porcelain=v1', '--untracked-files=normal'],
+      { cwd: imported, encoding: 'utf8' },
+    );
+    assert.equal(stdout, '');
   } finally {
     await rm(base, { recursive: true, force: true });
   }
@@ -156,3 +383,20 @@ test('import adoption rejects a marker size overflow without changing the durabl
     await rm(workspace, { recursive: true, force: true });
   }
 });
+
+async function resolveWorkspaceIdentityWithoutGit(workspace: string): Promise<void> {
+  const env: NodeJS.ProcessEnv = { ...process.env, PATH: '' };
+  delete env.Path;
+  const moduleUrl = new URL('../workspace-identity.js', import.meta.url).href;
+  await execFileAsync(
+    process.execPath,
+    [
+      '--input-type=module',
+      '-e',
+      'const [moduleUrl, workspace] = process.argv.slice(1); const { resolveWorkspaceIdentity } = await import(moduleUrl); await resolveWorkspaceIdentity({ path: workspace });',
+      moduleUrl,
+      workspace,
+    ],
+    { env },
+  );
+}

--- a/packages/storage/src/workspace-identity.ts
+++ b/packages/storage/src/workspace-identity.ts
@@ -1,13 +1,17 @@
+import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { constants as fsConstants, type BigIntStats } from 'node:fs';
 import { link, lstat, open, realpath, rename, stat, unlink } from 'node:fs/promises';
-import { join, normalize, parse, resolve } from 'node:path';
+import { isAbsolute, join, normalize, parse, resolve } from 'node:path';
+import { promisify } from 'node:util';
 
 export const WORKSPACE_MARKER_FILE = '.maka-workspace.json';
 export const WORKSPACE_MARKER_SCHEMA_VERSION = 1 as const;
 export const WORKSPACE_IDENTITY_PREFIX = 'workspace:v1:' as const;
 const MAX_WORKSPACE_MARKER_BYTES = 4_096;
 const MAX_LEGACY_ANCHORS = 32;
+const MAX_GIT_EXCLUDE_BYTES = 1024 * 1024;
+const execFileAsync = promisify(execFile);
 
 interface WorkspaceMarker {
   schemaVersion: typeof WORKSPACE_MARKER_SCHEMA_VERSION;
@@ -113,6 +117,7 @@ export async function adoptWorkspaceIdentityOnImport(
         `Imported workspace marker does not match the expected identity: ${snapshot.canonicalPath}`,
       );
     }
+    await ensureWorkspaceMarkerIgnored(snapshot.canonicalPath);
 
     const nextLegacyAnchors = uniqueStrings([
       ...marker.legacyAnchors,
@@ -161,7 +166,9 @@ async function ensureWorkspaceMarker(
   currentLegacyAnchor: string,
 ): Promise<WorkspaceMarker> {
   try {
-    return await readWorkspaceMarker(snapshot.canonicalPath);
+    const marker = await readWorkspaceMarker(snapshot.canonicalPath);
+    await ensureWorkspaceMarkerIgnored(snapshot.canonicalPath);
+    return marker;
   } catch (error) {
     if (!(error instanceof WorkspaceIdentityError) || error.code !== 'workspace_unmarked') {
       throw error;
@@ -175,6 +182,7 @@ async function createWorkspaceMarker(
   workspaceId: string,
   legacyAnchors: string[],
 ): Promise<WorkspaceMarker> {
+  await ensureWorkspaceMarkerIgnored(snapshot.canonicalPath);
   const marker: WorkspaceMarker = {
     schemaVersion: WORKSPACE_MARKER_SCHEMA_VERSION,
     workspaceId,
@@ -198,6 +206,74 @@ async function createWorkspaceMarker(
   }
   await assertWorkspaceSnapshot(snapshot);
   return readWorkspaceMarker(snapshot.canonicalPath);
+}
+
+async function ensureWorkspaceMarkerIgnored(workspacePath: string): Promise<void> {
+  if (!(await hasEnclosingGitEntry(workspacePath))) return;
+
+  const env: NodeJS.ProcessEnv = { ...process.env, GIT_OPTIONAL_LOCKS: '0' };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_COMMON_DIR;
+  const { stdout } = await execFileAsync(
+    'git',
+    ['-C', workspacePath, 'rev-parse', '--path-format=absolute', '--git-path', 'info/exclude'],
+    {
+      env,
+      encoding: 'utf8',
+      maxBuffer: 64 * 1024,
+      timeout: 3_000,
+      windowsHide: true,
+    },
+  );
+  const excludePath = stdout.trim();
+  if (!isAbsolute(excludePath)) {
+    throw new Error(`Git returned a non-absolute exclude path: ${excludePath}`);
+  }
+
+  const handle = await open(
+    excludePath,
+    fsConstants.O_CREAT | fsConstants.O_RDWR | fsConstants.O_APPEND | fsConstants.O_NOFOLLOW,
+    0o600,
+  );
+  try {
+    const [handleStat, pathStat] = await Promise.all([
+      handle.stat({ bigint: true }),
+      lstat(excludePath, { bigint: true }),
+    ]);
+    if (
+      !handleStat.isFile() ||
+      !pathStat.isFile() ||
+      handleStat.size > BigInt(MAX_GIT_EXCLUDE_BYTES) ||
+      handleStat.dev !== pathStat.dev ||
+      handleStat.ino !== pathStat.ino
+    ) {
+      throw new Error(`Git exclude must be one bounded regular file: ${excludePath}`);
+    }
+    const contents = await handle.readFile('utf8');
+    if (contents.split(/\r?\n/).includes(WORKSPACE_MARKER_FILE)) return;
+    const separator = contents.length === 0 || contents.endsWith('\n') ? '' : '\n';
+    await handle.writeFile(`${separator}${WORKSPACE_MARKER_FILE}\n`, 'utf8');
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+async function hasEnclosingGitEntry(workspacePath: string): Promise<boolean> {
+  let currentPath = workspacePath;
+  while (true) {
+    try {
+      await lstat(join(currentPath, '.git'));
+      return true;
+    } catch (error) {
+      if (!isMissingPathError(error)) throw error;
+    }
+    const parentPath = parse(currentPath).dir;
+    if (parentPath === currentPath) return false;
+    currentPath = parentPath;
+  }
 }
 
 async function replaceWorkspaceMarker(
@@ -241,8 +317,11 @@ async function writeMarkerFile(path: string, marker: WorkspaceMarker): Promise<v
   try {
     await handle.writeFile(serializedMarker, 'utf8');
     await handle.sync();
-  } finally {
     await handle.close();
+  } catch (error) {
+    await handle.close().catch(() => {});
+    await unlinkIfPresent(path);
+    throw error;
   }
 }
 

--- a/packages/storage/src/workspace-identity.ts
+++ b/packages/storage/src/workspace-identity.ts
@@ -254,7 +254,14 @@ async function ensureWorkspaceMarkerIgnored(workspacePath: string): Promise<void
     const contents = await handle.readFile('utf8');
     if (contents.split(/\r?\n/).includes(WORKSPACE_MARKER_FILE)) return;
     const separator = contents.length === 0 || contents.endsWith('\n') ? '' : '\n';
-    await handle.writeFile(`${separator}${WORKSPACE_MARKER_FILE}\n`, 'utf8');
+    const addition = `${separator}${WORKSPACE_MARKER_FILE}\n`;
+    if (
+      handleStat.size + BigInt(Buffer.byteLength(addition, 'utf8')) >
+      BigInt(MAX_GIT_EXCLUDE_BYTES)
+    ) {
+      throw new Error(`Git exclude must be one bounded regular file: ${excludePath}`);
+    }
+    await handle.writeFile(addition, 'utf8');
     await handle.sync();
   } finally {
     await handle.close();


### PR DESCRIPTION
## Summary

- Keep new turns usable when workspace identity inspection fails by omitting continuation metadata; actual continuation planning and claims remain strict.
- Ensure `.maka-workspace.json` is covered by the repository-local Git exclude before a new or existing marker is treated as usable, using Git itself to resolve linked-worktree and subdirectory layouts.
- Clean up partially written marker temp files and cover real archive round-trips, read-only workspaces, malformed or unavailable Git, concurrency, and the TUI `/move` happy path.

Refs #1378

## Verification

- `npm test -w @maka/storage` — 463 tests passed, 1 skipped.
- `npm test -w @maka/runtime` — 2,383 tests passed, 7 skipped.
- `npm test -w maka-agent` — 643 tests passed.
- `npm run lint` — passed.
- `npm run format:check` — passed.
- `npm run typecheck` — all workspaces through CLI/UI passed; the command stops in the untouched desktop renderer on the existing `onSetSkillPinned` prop mismatch at `apps/desktop/src/renderer/app-shell.tsx:1630`, reproduced on `main` after rebuilding the same dependencies.
- Real PTY smoke with the built TUI and a fake driver: `/move /tmp` rendered `Session moved to "/tmp"`; the following prompt completed with `smoke-ok`.

## Review focus

- Git repository discovery only checks for an enclosing `.git` entry; Git remains authoritative for the actual `info/exclude` path. A suspected Git workspace fails closed if that exclusion cannot be ensured, while non-Git directories do not require the Git executable.
- This PR intentionally does not remove legacy aliases or workspace-adoption paths. That cleanup remains PR 2 of #1378.
