### PR TITLE
feat(runtime): migrate agent tools to child sessions

### DIFF
--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -222,9 +222,9 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
     });
     const backendToolNames = new Set(selectedTools.map((tool) => tool.name));
     const backendSkillHost = buildHostCapabilitiesFromBinding(backendToolNames);
-    // Child backends share the parent sessionId but intentionally have a
-    // narrower tool surface. They do not receive the Desktop Skill tool, so
-    // they must not overwrite the parent session's resolver entry.
+    // Legacy child-run backends share the parent sessionId; linked child
+    // sessions have their own id. Both receive a narrower tool surface without
+    // the Desktop Skill tool, so only a session's full backend owns this entry.
     if (!ctx.tools) desktopSessionSkillHosts.set(ctx.sessionId, backendSkillHost);
     const effectivePermissionMode = collaborationMode === 'plan' ? 'explore' : ctx.header.permissionMode;
     const sandboxDiagnosticsSnapshot = await sandboxDiagnosticsProvider.resolve({
@@ -257,6 +257,20 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
       agentTeam,
       toolAvailability: backendToolAvailability,
       spawnChildAgent: (input) => getRuntime().spawnChildAgent(ctx.sessionId, input),
+      spawnChildSession: (input) =>
+        getRuntime().spawnChildSession(ctx.sessionId, {
+          spawnedBy: {
+            parentRunId: input.parentRunId,
+            parentTurnId: input.parentTurnId,
+            toolCallId: input.toolCallId,
+          },
+          agentProfile: input.agentProfile,
+          prompt: input.prompt,
+          ...(input.swarm ? { swarm: input.swarm } : {}),
+          abortSignal: input.abortSignal,
+          ...(input.onReady ? { onReady: input.onReady } : {}),
+          ...(input.onEvent ? { onEvent: input.onEvent } : {}),
+        }),
       prepareChildAgentResume: (sourceRunId) =>
         getRuntime().prepareChildAgentResume(ctx.sessionId, sourceRunId),
       resumeChildAgent: (input) => getRuntime().resumeChildAgent(ctx.sessionId, input),

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -378,6 +378,7 @@ describe('Maka CLI runtime bootstrap', () => {
         const backendInput = (backend as unknown as { input: AiSdkBackendInput }).input;
 
         assert.equal(typeof backendInput.spawnChildAgent, 'function');
+        assert.equal(typeof backendInput.spawnChildSession, 'function');
         assert.equal(typeof backendInput.retryChildAgent, 'function');
         assert.equal(typeof backendInput.listChildAgents, 'function');
         assert.equal(typeof backendInput.readChildAgentOutput, 'function');

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -623,6 +623,20 @@ export async function createMakaCliRuntimeContext(
       ...(input.surface === 'tui'
         ? {
             spawnChildAgent: (childInput) => runtime.spawnChildAgent(ctx.sessionId, childInput),
+            spawnChildSession: (childInput) =>
+              runtime.spawnChildSession(ctx.sessionId, {
+                spawnedBy: {
+                  parentRunId: childInput.parentRunId,
+                  parentTurnId: childInput.parentTurnId,
+                  toolCallId: childInput.toolCallId,
+                },
+                agentProfile: childInput.agentProfile,
+                prompt: childInput.prompt,
+                ...(childInput.swarm ? { swarm: childInput.swarm } : {}),
+                abortSignal: childInput.abortSignal,
+                ...(childInput.onReady ? { onReady: childInput.onReady } : {}),
+                ...(childInput.onEvent ? { onEvent: childInput.onEvent } : {}),
+              }),
             prepareChildAgentResume: (sourceRunId) =>
               runtime.prepareChildAgentResume(ctx.sessionId, sourceRunId),
             resumeChildAgent: (childInput) => runtime.resumeChildAgent(ctx.sessionId, childInput),

--- a/packages/core/src/__tests__/agent-swarm-result.test.ts
+++ b/packages/core/src/__tests__/agent-swarm-result.test.ts
@@ -98,6 +98,7 @@ function agentSwarmResult(): Extract<ToolResultContent, { kind: 'agent_swarm' }>
         index: 0,
         profile: 'local_read',
         started: true,
+        childSessionId: 'child-session-auth',
         agentId: 'local-read',
         agentName: 'Local Read',
         turnId: 'turn-auth',

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -351,6 +351,7 @@ export type ToolResultContent =
     }
   | {
       kind: 'subagent';
+      childSessionId?: string;
       agentId?: string;
       agentName: string;
       turnId: string;
@@ -373,6 +374,7 @@ export type ToolResultContent =
         index: number;
         profile: string;
         started: boolean;
+        childSessionId?: string;
         agentId?: string;
         agentName?: string;
         turnId?: string;

--- a/packages/core/src/task-ledger.ts
+++ b/packages/core/src/task-ledger.ts
@@ -55,6 +55,8 @@ export type ResumeTrust = (typeof TASK_RESUME_TRUST_LEVELS)[number];
 
 export interface TaskOwner {
   actor: 'main_agent' | 'child_agent';
+  /** Owning child Session for durable subagent work; absent on legacy child AgentRuns. */
+  sessionId?: string;
   agentId?: string;
   runId?: string;
   turnId?: string;
@@ -940,6 +942,7 @@ export function isTaskOwner(value: unknown): value is TaskOwner {
   const owner = value as Partial<TaskOwner>;
   return (
     (owner.actor === 'main_agent' || owner.actor === 'child_agent') &&
+    (owner.sessionId === undefined || isSafeTaskId(owner.sessionId)) &&
     (owner.agentId === undefined || isSafeTaskId(owner.agentId)) &&
     (owner.runId === undefined || isSafeTaskId(owner.runId)) &&
     (owner.turnId === undefined || isSafeTaskId(owner.turnId))

--- a/packages/core/src/tool-result-record-schema.ts
+++ b/packages/core/src/tool-result-record-schema.ts
@@ -117,7 +117,16 @@ const EXPLORE_MATCH_SHAPE = defineObjectShape<ExploreMatch>()(
 );
 const SUBAGENT_SHAPE = defineObjectShape<Result<'subagent'>>()(
   ['kind', 'agentName', 'turnId', 'status', 'permissionMode', 'summary', 'artifactIds'],
-  ['agentId', 'runId', 'startedAt', 'completedAt', 'durationMs', 'eventCount', 'failureClass'],
+  [
+    'childSessionId',
+    'agentId',
+    'runId',
+    'startedAt',
+    'completedAt',
+    'durationMs',
+    'eventCount',
+    'failureClass',
+  ],
 );
 const AGENT_SWARM_SHAPE = defineObjectShape<AgentSwarmResult>()(
   ['kind', 'status', 'items', 'startedAt', 'completedAt', 'durationMs'],
@@ -127,6 +136,7 @@ type AgentSwarmItem = AgentSwarmResult['items'][number];
 const AGENT_SWARM_ITEM_SHAPE = defineObjectShape<AgentSwarmItem>()(
   ['itemId', 'index', 'profile', 'started', 'status', 'summary', 'artifactIds'],
   [
+    'childSessionId',
     'agentId',
     'agentName',
     'turnId',
@@ -272,6 +282,7 @@ function isNonShellToolResultContent(value: unknown): value is ToolResultContent
     case 'subagent':
       return (
         hasExactShape(value, SUBAGENT_SHAPE) &&
+        isOptionalString(value.childSessionId) &&
         isOptionalString(value.agentId) &&
         typeof value.agentName === 'string' &&
         typeof value.turnId === 'string' &&
@@ -318,6 +329,7 @@ function isAgentSwarmItem(value: unknown): value is AgentSwarmItem {
     Number(value.index) >= 0 &&
     typeof value.profile === 'string' &&
     typeof value.started === 'boolean' &&
+    isOptionalString(value.childSessionId) &&
     isOptionalString(value.agentId) &&
     isOptionalString(value.agentName) &&
     isOptionalString(value.turnId) &&

--- a/packages/headless/src/__tests__/runner.test.ts
+++ b/packages/headless/src/__tests__/runner.test.ts
@@ -418,6 +418,7 @@ describe('fail-closed (a model-backed backend does not run without isolation)', 
       assert.equal(contexts[0]?.config.id, 'real-cfg');
       assert.equal(contexts[0]?.task.id, 'real-task');
       assert.equal(typeof contexts[0]?.spawnChildAgent, 'function');
+      assert.equal(typeof contexts[0]?.spawnChildSession, 'function');
       assert.equal(typeof contexts[0]?.retryChildAgent, 'function');
       assert.equal(typeof contexts[0]?.listChildAgents, 'function');
       assert.equal(typeof contexts[0]?.readChildAgentOutput, 'function');

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -910,6 +910,22 @@ export function buildAiSdkCellBackendRegistration(input: {
         spawnChildAgent: context.spawnChildAgent
           ? (childInput) => context.spawnChildAgent!(ctx.sessionId, childInput)
           : undefined,
+        spawnChildSession: context.spawnChildSession
+          ? (childInput) =>
+              context.spawnChildSession!(ctx.sessionId, {
+                spawnedBy: {
+                  parentRunId: childInput.parentRunId,
+                  parentTurnId: childInput.parentTurnId,
+                  toolCallId: childInput.toolCallId,
+                },
+                agentProfile: childInput.agentProfile,
+                prompt: childInput.prompt,
+                ...(childInput.swarm ? { swarm: childInput.swarm } : {}),
+                abortSignal: childInput.abortSignal,
+                ...(childInput.onReady ? { onReady: childInput.onReady } : {}),
+                ...(childInput.onEvent ? { onEvent: childInput.onEvent } : {}),
+              })
+          : undefined,
         prepareChildAgentResume: context.prepareChildAgentResume
           ? (sourceRunId) => context.prepareChildAgentResume!(ctx.sessionId, sourceRunId)
           : undefined,

--- a/packages/headless/src/session-capabilities.ts
+++ b/packages/headless/src/session-capabilities.ts
@@ -8,10 +8,16 @@ import type {
   SessionManager,
   SpawnChildAgentInput,
   SpawnChildAgentResult,
+  SpawnChildSessionInput,
+  SpawnChildSessionResult,
 } from '@maka/runtime';
 
 export interface HeadlessSessionCapabilities {
   spawnChildAgent(sessionId: string, input: SpawnChildAgentInput): Promise<SpawnChildAgentResult>;
+  spawnChildSession(
+    parentSessionId: string,
+    input: SpawnChildSessionInput,
+  ): Promise<SpawnChildSessionResult>;
   prepareChildAgentResume(
     sessionId: string,
     sourceRunId: string,
@@ -37,6 +43,8 @@ export function createHeadlessSessionCapabilityBridge(): {
     capabilities: {
       spawnChildAgent: async (sessionId, input) =>
         await requireManager().spawnChildAgent(sessionId, input),
+      spawnChildSession: async (parentSessionId, input) =>
+        await requireManager().spawnChildSession(parentSessionId, input),
       prepareChildAgentResume: async (sessionId, sourceRunId) =>
         await requireManager().prepareChildAgentResume(sessionId, sourceRunId),
       resumeChildAgent: async (sessionId, input) =>

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -20,6 +20,7 @@ import {
   AGENT_WRITE_BACK_SUMMARY,
   IMPLEMENTATION_AGENT_PROFILE,
   LOCAL_READ_AGENT_PROFILE,
+  requireBuiltinAgentDefinitionByProfile,
 } from '../agent-catalog.js';
 import { buildChildAgentTools, AGENT_TOOL_NAMES } from '../subagent-tools.js';
 import type { SpawnChildAgentResult } from '../session-manager.js';
@@ -131,7 +132,7 @@ describe('AgentSwarm adapter', () => {
             ],
           },
           context({
-            spawnChildAgent: async () => {
+            spawnChildSession: async () => {
               starts += 1;
               return childResult(0);
             },
@@ -207,6 +208,7 @@ describe('AgentSwarm adapter', () => {
 
   test('normalizes prompt_template items through the existing ordered execution path', async () => {
     const prompts: string[] = [];
+    const spawnRefs: Array<{ swarmId: string; itemId: string } | undefined> = [];
     const tool = buildAgentSwarmTool();
     const result = await tool.impl(
       {
@@ -216,25 +218,53 @@ describe('AgentSwarm adapter', () => {
         max_concurrency: 2,
       },
       context({
-        spawnChildAgent: async (input) => {
+        spawnChildSession: async (input) => {
           prompts.push(input.prompt);
           const index = prompts.length - 1;
+          spawnRefs.push(input.swarm);
           await input.onReady?.({
+            childSessionId: `child-session-${index}`,
+            runId: `run-${index}`,
             turnId: `turn-${index}`,
-            agentId: input.spec.id,
-            agentName: input.spec.name,
+            agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+            agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
           });
-          return childResult(index);
+          return {
+            ...childResult(index),
+            childSessionId: `child-session-${index}`,
+          };
         },
       }),
     );
 
     assert.deepEqual(prompts, ['Compare runtime with runtime.', 'Compare desktop with desktop.']);
+    assert.deepEqual(spawnRefs, [
+      { swarmId: 'tool-swarm', itemId: 'item-1' },
+      { swarmId: 'tool-swarm', itemId: 'item-2' },
+    ]);
     assert.deepEqual(
-      result.items.map((item) => ({ itemId: item.itemId, index: item.index, status: item.status })),
+      result.items.map((item) => ({
+        itemId: item.itemId,
+        index: item.index,
+        childSessionId: item.childSessionId,
+        runId: item.runId,
+        status: item.status,
+      })),
       [
-        { itemId: 'item-1', index: 0, status: 'completed' },
-        { itemId: 'item-2', index: 1, status: 'completed' },
+        {
+          itemId: 'item-1',
+          index: 0,
+          childSessionId: 'child-session-0',
+          runId: 'run-0',
+          status: 'completed',
+        },
+        {
+          itemId: 'item-2',
+          index: 1,
+          childSessionId: 'child-session-1',
+          runId: 'run-1',
+          status: 'completed',
+        },
       ],
     );
   });
@@ -289,7 +319,7 @@ describe('AgentSwarm adapter', () => {
               starts += 1;
               return childResult(10);
             },
-            spawnChildAgent: async () => {
+            spawnChildSession: async () => {
               starts += 1;
               return childResult(0);
             },
@@ -326,12 +356,14 @@ describe('AgentSwarm adapter', () => {
             resumedFromRunId: input.sourceRunId,
           };
         },
-        spawnChildAgent: async (input) => {
+        spawnChildSession: async (input) => {
           calls.push(`spawn:${input.prompt}`);
           await input.onReady?.({
+            childSessionId: 'child-session',
+            runId: 'child-run',
             turnId: 'turn-0',
-            agentId: input.spec.id,
-            agentName: input.spec.name,
+            agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+            agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
           });
           return childResult(0);
         },
@@ -363,7 +395,7 @@ describe('AgentSwarm adapter', () => {
 
     await assert.rejects(
       Promise.resolve(tool.impl({ items: [swarmItem(0)] }, context())),
-      /spawnChildAgent capability is unavailable/,
+      /spawnChildSession capability is unavailable/,
     );
   });
 
@@ -384,13 +416,15 @@ describe('AgentSwarm adapter', () => {
           emitRunTrace: (type, message, data) => {
             traceEvents.push({ type, message, data });
           },
-          spawnChildAgent: async (input) => {
+          spawnChildSession: async (input) => {
             const index = Number(input.prompt.slice('task-'.length));
             started.push(index);
             await input.onReady?.({
+              childSessionId: 'child-session',
+              runId: 'child-run',
               turnId: `turn-${index}`,
-              agentId: input.spec.id,
-              agentName: input.spec.name,
+              agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+              agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
             });
             const result = await gates[index]!.promise;
             completionOrder.push(index);
@@ -489,13 +523,15 @@ describe('AgentSwarm adapter', () => {
         max_concurrency: 2,
       },
       context({
-        spawnChildAgent: async (input) => {
+        spawnChildSession: async (input) => {
           const index = Number(input.prompt.slice('task-'.length));
           if (index === 1) throw new Error('provider startup failed');
           await input.onReady?.({
+            childSessionId: 'child-session',
+            runId: 'child-run',
             turnId: `turn-${index}`,
-            agentId: input.spec.id,
-            agentName: input.spec.name,
+            agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+            agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
           });
           return childResult(index);
         },
@@ -512,7 +548,7 @@ describe('AgentSwarm adapter', () => {
     assert.equal(result.items[1]?.failureClass, 'Error');
   });
 
-  test('retries provider rate limits without spawning the child prompt twice', async () => {
+  test('keeps adaptive rate-limit retry for legacy resumed child runs', async () => {
     const traceEvents: TestTraceEvent[] = [];
     const prompts: string[] = [];
     const retrySources: string[] = [];
@@ -528,16 +564,23 @@ describe('AgentSwarm adapter', () => {
       },
     });
     const pending = tool.impl(
-      { items: [swarmItem(0), swarmItem(1)], max_concurrency: 2 },
+      {
+        resume_run_ids: {
+          'source-run-0': 'task-0',
+          'source-run-1': 'task-1',
+        },
+        max_concurrency: 2,
+      },
       context({
         emitRunTrace: (type, message, data) => traceEvents.push({ type, message, data }),
-        spawnChildAgent: async (input) => {
+        prepareChildAgentResume: async (sourceRunId) => preparedResume(sourceRunId),
+        resumeChildAgent: async (input) => {
           prompts.push(input.prompt);
           const index = Number(input.prompt.slice('task-'.length));
           await input.onReady?.({
             turnId: `turn-${index}`,
-            agentId: input.spec.id,
-            agentName: input.spec.name,
+            agentId: 'local-read',
+            agentName: 'Local Read',
           });
           if (index === 1) return await siblingGate.promise;
           return {
@@ -575,6 +618,31 @@ describe('AgentSwarm adapter', () => {
     assert.ok(traceEvents.some((event) => event.data?.swarmStage === 'capacity_changed'));
   });
 
+  test('settles a rate-limited child-session run without invoking the legacy retry path', async () => {
+    let retries = 0;
+    const result = await buildAgentSwarmTool().impl(
+      { items: [swarmItem(0)] },
+      context({
+        spawnChildSession: async () => ({
+          ...childResult(0, 'failed'),
+          childSessionId: 'child-session-0',
+          failureClass: 'RateLimit',
+          summary: 'provider 429',
+        }),
+        retryChildAgent: async () => {
+          retries += 1;
+          return childResult(0);
+        },
+      }),
+    );
+
+    assert.equal(retries, 0);
+    assert.equal(result.status, 'partial');
+    assert.equal(result.items[0]?.childSessionId, 'child-session-0');
+    assert.equal(result.items[0]?.runId, 'run-0');
+    assert.equal(result.items[0]?.failureClass, 'RateLimit');
+  });
+
   test('distinguishes active cancellation from items that never started', async () => {
     const controller = new AbortController();
     const tool = buildAgentSwarmTool();
@@ -591,13 +659,15 @@ describe('AgentSwarm adapter', () => {
         emitRunTrace: (type, message, data) => {
           traceEvents.push({ type, message, data });
         },
-        spawnChildAgent: async (input) => {
+        spawnChildSession: async (input) => {
           const index = Number(input.prompt.slice('task-'.length));
           started.push(index);
           await input.onReady?.({
+            childSessionId: 'child-session',
+            runId: 'child-run',
             turnId: `turn-${index}`,
-            agentId: input.spec.id,
-            agentName: input.spec.name,
+            agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+            agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
           });
           await onceAborted(controller.signal);
           return childResult(index, 'cancelled');
@@ -668,9 +738,11 @@ describe('AgentSwarm adapter', () => {
         starts.push(input.prompt);
         const index = Number(input.prompt.slice('task-'.length));
         await input.onReady?.({
+          childSessionId: 'child-session',
+          runId: 'child-run',
           turnId: `turn-${index}`,
-          agentId: input.spec.id,
-          agentName: input.spec.name,
+          agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+          agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
         });
         if (index === 0) {
           await onceAborted(input.abortSignal);
@@ -722,9 +794,11 @@ describe('AgentSwarm adapter', () => {
         active.add(input.prompt);
         maxActive = Math.max(maxActive, active.size);
         await input.onReady?.({
+          childSessionId: 'child-session',
+          runId: 'child-run',
           turnId: `turn-${input.prompt}`,
-          agentId: input.spec.id,
-          agentName: input.spec.name,
+          agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+          agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
         });
         return await new Promise((resolve) => {
           releases.set(input.prompt, () => {
@@ -942,6 +1016,52 @@ describe('AgentSwarm adapter', () => {
       false,
     );
   });
+
+  test('binds child-session creation to the owning parent run, turn, tool call, and swarm item', async () => {
+    const calls: Array<
+      Parameters<NonNullable<ConstructorParameters<typeof ToolRuntime>[0]['spawnChildSession']>>[0]
+    > = [];
+    const runtime = buildRuntime(async (input) => {
+      calls.push(input);
+      const definition = requireBuiltinAgentDefinitionByProfile(input.agentProfile);
+      await input.onReady?.({
+        childSessionId: 'child-session-1',
+        turnId: 'child-turn-1',
+        runId: 'child-run-1',
+        agentId: definition.id,
+        agentName: definition.name,
+      });
+      return {
+        ...childResult(1),
+        childSessionId: 'child-session-1',
+        turnId: 'child-turn-1',
+        runId: 'child-run-1',
+      };
+    });
+
+    const result = (await executeTool(
+      runtime,
+      {
+        ...buildAgentSwarmTool(),
+        permissionRequired: false,
+      },
+      { items: [swarmItem(1)] },
+      new AbortController(),
+      [],
+      'swarm-tool-call',
+    )) as AgentSwarmToolResult;
+
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.parentRunId, 'parent-run');
+    assert.equal(calls[0]?.parentTurnId, 'turn-1');
+    assert.equal(calls[0]?.toolCallId, 'swarm-tool-call');
+    assert.deepEqual(calls[0]?.swarm, {
+      swarmId: 'swarm-tool-call',
+      itemId: 'item-1',
+    });
+    assert.equal(result.items[0]?.childSessionId, 'child-session-1');
+    assert.equal(result.items[0]?.runId, 'child-run-1');
+  });
 });
 
 function swarmItem(index: number): AgentSwarmExplicitItemInput {
@@ -1025,13 +1145,9 @@ function singleChildProbeTool(): MakaTool {
     permissionRequired: false,
     categoryHint: 'subagent',
     impl: async (_input, ctx) => {
-      if (!ctx.spawnChildAgent) throw new Error('missing spawn capability');
-      return await ctx.spawnChildAgent({
-        spec: {
-          id: 'local-read',
-          name: 'Local Read',
-          systemPrompt: 'Test.',
-        },
+      if (!ctx.spawnChildSession) throw new Error('missing spawn capability');
+      return await ctx.spawnChildSession({
+        agentProfile: LOCAL_READ_AGENT_PROFILE,
         prompt: 'single',
       });
     },
@@ -1039,7 +1155,7 @@ function singleChildProbeTool(): MakaTool {
 }
 
 function buildRuntime(
-  spawnChildAgent: NonNullable<ConstructorParameters<typeof ToolRuntime>[0]['spawnChildAgent']>,
+  spawnChildSession: NonNullable<ConstructorParameters<typeof ToolRuntime>[0]['spawnChildSession']>,
   options: {
     permissionEngine?: PermissionEngine;
     permissionMode?: SessionHeader['permissionMode'];
@@ -1065,7 +1181,7 @@ function buildRuntime(
     now: () => 1,
     getPermissionPauseTarget: () => null,
     getCurrentRunId: () => 'parent-run',
-    spawnChildAgent,
+    spawnChildSession,
     ...(options.traceEvents ? { getRunTrace: () => testTrace(options.traceEvents!) } : {}),
     ...(options.recordToolInvocation ? { recordToolInvocation: options.recordToolInvocation } : {}),
   });

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -390,6 +390,51 @@ describe('AgentSwarm adapter', () => {
     );
   });
 
+  test('continues a fresh swarm child by its returned runId and keeps the child Session ref', async () => {
+    const tool = buildAgentSwarmTool();
+    const result = await tool.impl(
+      {
+        resume_run_ids: {
+          'fresh-child-run': 'Continue the fresh child.',
+        },
+      },
+      context({
+        prepareChildAgentResume: async (sourceRunId) => ({
+          sourceRunId,
+          execution: {
+            kind: 'child_session',
+            sessionId: 'fresh-child-session',
+            currentRunId: sourceRunId,
+          },
+          agentId: 'local-read',
+          agentName: 'Local Read',
+          profile: LOCAL_READ_AGENT_PROFILE,
+        }),
+        resumeChildAgent: async (input) => {
+          await input.onReady?.({
+            childSessionId: 'fresh-child-session',
+            turnId: 'fresh-resumed-turn',
+            runId: 'fresh-resumed-run',
+            agentId: 'local-read',
+            agentName: 'Local Read',
+          });
+          return {
+            ...childResult(0),
+            childSessionId: 'fresh-child-session',
+            turnId: 'fresh-resumed-turn',
+            runId: 'fresh-resumed-run',
+            resumedFromRunId: input.sourceRunId,
+          };
+        },
+      }),
+    );
+
+    assert.equal(result.status, 'completed');
+    assert.equal(result.items[0]?.childSessionId, 'fresh-child-session');
+    assert.equal(result.items[0]?.runId, 'fresh-resumed-run');
+    assert.equal(result.items[0]?.resumedFromRunId, 'fresh-child-run');
+  });
+
   test('fails at the tool boundary when child spawning is unavailable', async () => {
     const tool = buildAgentSwarmTool();
 
@@ -618,29 +663,65 @@ describe('AgentSwarm adapter', () => {
     assert.ok(traceEvents.some((event) => event.data?.swarmStage === 'capacity_changed'));
   });
 
-  test('settles a rate-limited child-session run without invoking the legacy retry path', async () => {
+  test('adaptively retries a rate-limited run inside the same child Session', async () => {
     let retries = 0;
-    const result = await buildAgentSwarmTool().impl(
-      { items: [swarmItem(0)] },
+    const retryExecutions: unknown[] = [];
+    const traceEvents: TestTraceEvent[] = [];
+    const siblingGate = deferred<SpawnChildAgentResult>();
+    const pending = buildAgentSwarmTool({
+      adaptiveSwarmPolicy: {
+        initialLaunchLimit: 2,
+        initialLaunchIntervalMs: 1,
+        rateLimitRetryBaseMs: 1,
+        rateLimitRetryFactor: 2,
+        capacityShrinkIntervalMs: 1,
+        capacityRecoveryIntervalMs: 100,
+      },
+    }).impl(
+      { items: [swarmItem(0), swarmItem(1)], max_concurrency: 2 },
       context({
-        spawnChildSession: async () => ({
-          ...childResult(0, 'failed'),
-          childSessionId: 'child-session-0',
-          failureClass: 'RateLimit',
-          summary: 'provider 429',
-        }),
-        retryChildAgent: async () => {
+        emitRunTrace: (type, message, data) => traceEvents.push({ type, message, data }),
+        spawnChildSession: async (input) =>
+          input.prompt === 'task-1'
+            ? await siblingGate.promise
+            : {
+                ...childResult(0, 'failed'),
+                childSessionId: 'child-session-0',
+                failureClass: 'RateLimit',
+                summary: 'provider 429',
+              },
+        retryChildAgent: async (input) => {
           retries += 1;
-          return childResult(0);
+          retryExecutions.push(input.execution);
+          return {
+            ...childResult(0),
+            childSessionId: 'child-session-0',
+            turnId: 'turn-0-retry',
+            runId: 'run-0-retry',
+          };
         },
       }),
     );
 
-    assert.equal(retries, 0);
-    assert.equal(result.status, 'partial');
+    await waitFor(() => traceEvents.some((event) => event.data?.swarmStage === 'item_suspended'));
+    siblingGate.resolve({
+      ...childResult(1),
+      childSessionId: 'child-session-1',
+    });
+    const result = await pending;
+
+    assert.equal(retries, 1);
+    assert.deepEqual(retryExecutions, [
+      {
+        kind: 'child_session',
+        sessionId: 'child-session-0',
+        currentRunId: 'run-0',
+      },
+    ]);
+    assert.equal(result.status, 'completed');
     assert.equal(result.items[0]?.childSessionId, 'child-session-0');
-    assert.equal(result.items[0]?.runId, 'run-0');
-    assert.equal(result.items[0]?.failureClass, 'RateLimit');
+    assert.equal(result.items[0]?.runId, 'run-0-retry');
+    assert.equal(result.items[0]?.failureClass, undefined);
   });
 
   test('distinguishes active cancellation from items that never started', async () => {
@@ -1103,6 +1184,11 @@ function childResultForPrompt(prompt: string): SpawnChildAgentResult {
 function preparedResume(sourceRunId: string) {
   return {
     sourceRunId,
+    execution: {
+      kind: 'legacy_child_run' as const,
+      sessionId: 'session-1',
+      runId: sourceRunId,
+    },
     agentId: 'local-read',
     agentName: 'Local Read',
     profile: LOCAL_READ_AGENT_PROFILE,

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -16,7 +16,11 @@ import {
   type ToolAvailabilityConfig,
 } from '../tool-availability.js';
 import { toolSchemaCharsForDiagnostics } from '../request-shape.js';
-import { LOCAL_READ_AGENT_ID, LOCAL_READ_AGENT_PROFILE } from '../agent-catalog.js';
+import {
+  LOCAL_READ_AGENT_ID,
+  LOCAL_READ_AGENT_PROFILE,
+  requireBuiltinAgentDefinitionByProfile,
+} from '../agent-catalog.js';
 import { AGENT_SWARM_TOOL_NAME } from '../agent-swarm-tools.js';
 import {
   AGENT_LIST_TOOL_NAME,
@@ -117,12 +121,14 @@ function agentBackend(
     modelFactory: () => model,
     tools: buildParentAgentTools(),
     ...(resolved ? { toolAvailability: resolved } : {}),
-    spawnChildAgent: async (input) => {
+    spawnChildSession: async (input) => {
       const childIndex = spawnCalls.length;
       spawnCalls.push(input);
+      const definition = requireBuiltinAgentDefinitionByProfile(input.agentProfile);
       return {
-        agentId: input.spec.id,
-        agentName: input.spec.name,
+        childSessionId: `child-session-${childIndex}`,
+        agentId: definition.id,
+        agentName: definition.name,
         runId: `child-run-${childIndex}`,
         turnId: `child-turn-${childIndex}`,
         status: 'completed',
@@ -459,16 +465,9 @@ describe('AiSdkBackend deferred agent tools', () => {
     );
     assert.deepEqual(spawnCalls[0], {
       parentRunId: 'parent-run',
-      spec: {
-        id: LOCAL_READ_AGENT_ID,
-        name: 'Local Read',
-        systemPrompt: [
-          'You are a foreground local-read child agent.',
-          'Use only the provided Read, Glob, and Grep tools.',
-          'Do not use shell, web, browser, write, or nested agent tools.',
-          'Return a concise answer with concrete file or symbol evidence.',
-        ].join('\n'),
-      },
+      parentTurnId: 'turn-1',
+      toolCallId: 'tc-spawn',
+      agentProfile: LOCAL_READ_AGENT_PROFILE,
       prompt: 'Inspect the runtime tests.',
       abortSignal: assertAbortSignal(spawnCalls[0]),
       onEvent: assertOnEvent(spawnCalls[0]),

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -274,6 +274,202 @@ describe('SessionManager child-session runtime primitive', () => {
     while (!(await parentTurn.next()).done) {}
   });
 
+  test('resumes a fresh child by returned runId inside the same linked Session', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const parentGate = makeGate();
+    const backendsBySession = new Map<string, TestBackend>();
+    backends.register('fake', (ctx) => {
+      const backend = new TestBackend(ctx, ctx.header.subagentRuntime ? undefined : parentGate);
+      backendsBySession.set(ctx.sessionId, backend);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(130),
+      runtimeSource: 'test',
+    });
+    const parent = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    const parentTurn = manager
+      .sendMessage(parent.id, { turnId: 'parent-turn', text: 'keep parent active' })
+      [Symbol.asyncIterator]();
+    await parentTurn.next();
+    const [parentRun] = await runStore.listSessionRuns(parent.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+
+    const child = await manager.spawnChildSession(parent.id, {
+      spawnedBy: {
+        parentRunId: parentRun.runId,
+        parentTurnId: parentRun.turnId,
+        toolCallId: 'fresh-swarm-item',
+      },
+      agentProfile: LOCAL_READ_AGENT_PROFILE,
+      prompt: 'inspect the initial boundary',
+    });
+    const prepared = await manager.prepareChildAgentResume(parent.id, child.runId);
+    expect(prepared.execution).toEqual({
+      kind: 'child_session',
+      sessionId: child.childSessionId,
+      currentRunId: child.runId,
+    });
+
+    const resumed = await manager.resumeChildAgent(parent.id, {
+      parentRunId: parentRun.runId,
+      sourceRunId: child.runId,
+      prompt: 'continue from the returned swarm run id',
+    });
+    expect(resumed.childSessionId).toBe(child.childSessionId);
+    expect(resumed.resumedFromRunId).toBe(child.runId);
+    const resumedRun = await runStore.readRun(child.childSessionId, resumed.runId!);
+    expect(isSessionInlineRun(resumedRun)).toBe(true);
+    expect(resumedRun.parentRunId).toBe(undefined);
+    expect(resumedRun.resumedFromRunId).toBe(child.runId);
+    expect(
+      backendsBySession
+        .get(child.childSessionId)
+        ?.sendInputs[1]?.runtimeContext?.some((event) => event.runId === child.runId),
+    ).toBe(true);
+    expect((await manager.listChildAgents(parent.id)).executions[0]?.execution).toEqual({
+      kind: 'child_session',
+      sessionId: child.childSessionId,
+      currentRunId: resumed.runId,
+    });
+
+    parentGate.release();
+    while (!(await parentTurn.next()).done) {}
+  });
+
+  test('retries a rate-limited fresh child inside the same linked Session', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const parentGate = makeGate();
+    const childInputs: BackendSendInput[] = [];
+    let childAttempts = 0;
+    backends.register('fake', (ctx) => {
+      if (!ctx.header.subagentRuntime) return new TestBackend(ctx, parentGate);
+      return {
+        kind: 'fake' as const,
+        sessionId: ctx.sessionId,
+        async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+          childAttempts += 1;
+          childInputs.push(input);
+          if (childAttempts === 1) {
+            yield {
+              type: 'error',
+              id: `${input.turnId}-error`,
+              turnId: input.turnId,
+              ts: 1,
+              recoverable: true,
+              reason: 'RateLimit',
+              message: 'provider 429',
+            };
+            yield {
+              type: 'complete',
+              id: `${input.turnId}-complete`,
+              turnId: input.turnId,
+              ts: 2,
+              stopReason: 'error',
+            };
+            return;
+          }
+          yield {
+            type: 'text_delta',
+            id: `${input.turnId}-delta`,
+            turnId: input.turnId,
+            ts: 3,
+            messageId: `${input.turnId}-message`,
+            text: 'recovered',
+          };
+          yield {
+            type: 'complete',
+            id: `${input.turnId}-complete`,
+            turnId: input.turnId,
+            ts: 4,
+            stopReason: 'end_turn',
+          };
+        },
+        async stop(): Promise<void> {},
+        async respondToPermission(): Promise<void> {},
+        async dispose(): Promise<void> {},
+      };
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(145),
+      runtimeSource: 'test',
+    });
+    const parent = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    const parentTurn = manager
+      .sendMessage(parent.id, { turnId: 'parent-turn', text: 'keep parent active' })
+      [Symbol.asyncIterator]();
+    await parentTurn.next();
+    const [parentRun] = await runStore.listSessionRuns(parent.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+
+    const child = await manager.spawnChildSession(parent.id, {
+      spawnedBy: {
+        parentRunId: parentRun.runId,
+        parentTurnId: parentRun.turnId,
+        toolCallId: 'rate-limited-swarm-item',
+      },
+      agentProfile: LOCAL_READ_AGENT_PROFILE,
+      prompt: 'inspect with a transient provider failure',
+    });
+    expect(child.status).toBe('failed');
+    expect(child.failureClass).toBe('RateLimit');
+
+    const retried = await manager.retryChildAgent(parent.id, {
+      parentRunId: parentRun.runId,
+      sourceRunId: child.runId,
+      execution: {
+        kind: 'child_session',
+        sessionId: child.childSessionId,
+        currentRunId: child.runId,
+      },
+    });
+    expect(retried.status).toBe('completed');
+    expect(retried.childSessionId).toBe(child.childSessionId);
+    expect(retried.retriedFromRunId).toBe(child.runId);
+    expect(childInputs.map((input) => input.text)).toEqual([
+      'inspect with a transient provider failure',
+      '',
+    ]);
+    const retryRun = await runStore.readRun(child.childSessionId, retried.runId!);
+    expect(isSessionInlineRun(retryRun)).toBe(true);
+    expect(retryRun.parentRunId).toBe(undefined);
+    expect(retryRun.retriedFromRunId).toBe(child.runId);
+    expect((await manager.prepareChildAgentResume(parent.id, retried.runId!)).execution).toEqual({
+      kind: 'child_session',
+      sessionId: child.childSessionId,
+      currentRunId: retried.runId,
+    });
+    expect(
+      (await store.readMessages(child.childSessionId)).filter(
+        (message) => 'turnId' in message && message.turnId === retried.turnId,
+      ),
+    ).toEqual([]);
+    expect((await manager.listChildAgents(parent.id)).executions[0]?.execution).toEqual({
+      kind: 'child_session',
+      sessionId: child.childSessionId,
+      currentRunId: retried.runId,
+    });
+
+    parentGate.release();
+    while (!(await parentTurn.next()).done) {}
+  });
+
   test('deduplicates concurrent and durable retries while rejecting request drift', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
@@ -6948,6 +7144,11 @@ describe('SessionManager permission mode updates', () => {
 
     expect(await manager.prepareChildAgentResume(session.id, source.runId)).toEqual({
       sourceRunId: source.runId,
+      execution: {
+        kind: 'legacy_child_run',
+        sessionId: session.id,
+        runId: source.runId,
+      },
       agentId: LOCAL_READ_AGENT_ID,
       agentName: LOCAL_READ_AGENT_DEFINITION.name,
       profile: LOCAL_READ_AGENT_DEFINITION.profile,

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -237,6 +237,38 @@ describe('SessionManager child-session runtime primitive', () => {
       manager.setPermissionMode(result.childSessionId, 'execute'),
       /exceeds its "ask" ceiling/,
     );
+    const projection = await manager.listChildAgents(parent.id);
+    expect(projection.runs).toEqual([]);
+    expect(projection.executions).toHaveLength(1);
+    expect(projection.executions[0]?.execution).toEqual({
+      kind: 'child_session',
+      sessionId: result.childSessionId,
+      currentRunId: result.runId,
+    });
+    expect(projection.executions[0]?.status).toBe('completed');
+    const output = await manager.readChildAgentOutput(parent.id, {
+      execution: {
+        kind: 'child_session',
+        sessionId: result.childSessionId,
+      },
+    });
+    expect(output.execution).toEqual({
+      kind: 'child_session',
+      sessionId: result.childSessionId,
+      currentRunId: result.runId,
+    });
+    expect(output.header.sessionId).toBe(result.childSessionId);
+    expect(output.header.runId).toBe(result.runId);
+    const unrelatedParent = await manager.createSession(makeInput({ name: 'Unrelated parent' }));
+    await expectRejects(
+      manager.readChildAgentOutput(unrelatedParent.id, {
+        execution: {
+          kind: 'child_session',
+          sessionId: result.childSessionId,
+        },
+      }),
+      /could not find the requested child session/,
+    );
 
     parentGate.release();
     while (!(await parentTurn.next()).done) {}
@@ -7897,6 +7929,13 @@ describe('SessionManager permission mode updates', () => {
       requiredRuntime: 'worktree_child_executor',
     });
     expect(list.runs.map((agent) => agent.runId)).toEqual(['child-run']);
+    expect(list.executions.map((agent) => agent.execution)).toEqual([
+      {
+        kind: 'legacy_child_run',
+        sessionId: session.id,
+        runId: 'child-run',
+      },
+    ]);
     expect(list.runs[0]?.agentId).toBe(LOCAL_READ_AGENT_ID);
     expect(list.runs[0]?.agentName).toBe('Researcher');
     expect(list.runs[0]?.durationMs).toBe(10);
@@ -8116,7 +8155,7 @@ describe('SessionManager permission mode updates', () => {
 
     await expectRejects(
       manager.readChildAgentOutput(session.id, { runId: 'child-run', turnId: 'child-turn' }),
-      /exactly one of runId or turnId/,
+      /exactly one execution, runId, or turnId/,
     );
   });
 

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -33,6 +33,7 @@ import {
   evaluateAgentDefinitionAvailability,
   evaluateAgentDefinitionToolAccess,
   listBuiltinAgentDefinitions,
+  requireBuiltinAgentDefinitionByProfile,
 } from '../agent-catalog.js';
 import { AGENT_SWARM_TOOL_NAME } from '../agent-swarm-tools.js';
 import {
@@ -401,7 +402,7 @@ describe('subagent tools', () => {
         toolCallId: 'tool-1',
         abortSignal: abortController.signal,
         emitOutput: (stream, chunk) => output.push({ stream, chunk }),
-        spawnChildAgent: async (input) => {
+        spawnChildSession: async (input) => {
           calls.push(input);
           input.onEvent?.({
             type: 'tool_start',
@@ -423,9 +424,11 @@ describe('subagent tools', () => {
             content: { kind: 'text', text: 'secret body' },
           });
           return {
-            agentId: input.spec.id,
-            agentName: input.spec.name,
+            childSessionId: 'child-session',
+            agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+            agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
             turnId: 'child-turn',
+            runId: 'child-run',
             status: 'completed',
             permissionMode: 'explore',
             summary: 'done',
@@ -440,15 +443,11 @@ describe('subagent tools', () => {
     expect(tool.permissionRequired).toBe(true);
     expect(calls).toHaveLength(1);
     const call = calls[0] as {
-      spec: unknown;
+      agentProfile: string;
       prompt: string;
       onEvent?: (event: SessionEvent) => void;
     };
-    expect(call.spec).toEqual({
-      id: LOCAL_READ_AGENT_ID,
-      name: 'Local Read',
-      systemPrompt: LOCAL_READ_AGENT_DEFINITION.systemPrompt,
-    });
+    expect(call.agentProfile).toBe(LOCAL_READ_AGENT_PROFILE);
     expect(call.prompt).toBe('Inspect the runtime tests.');
     expect(typeof call.onEvent).toBe('function');
     expect(output).toEqual([
@@ -461,9 +460,11 @@ describe('subagent tools', () => {
     expect(JSON.stringify(output)).not.toContain('secret body');
     expect(result).toEqual({
       kind: 'subagent',
+      childSessionId: 'child-session',
       agentId: LOCAL_READ_AGENT_ID,
       agentName: 'Local Read',
       turnId: 'child-turn',
+      runId: 'child-run',
       status: 'completed',
       permissionMode: 'explore',
       summary: 'done',
@@ -487,7 +488,7 @@ describe('subagent tools', () => {
         toolCallId: 'tool-1',
         abortSignal: new AbortController().signal,
         emitOutput: (_stream, chunk) => output.push(chunk),
-        spawnChildAgent: async (input) => {
+        spawnChildSession: async (input) => {
           for (let index = 0; index < 100; index += 1) {
             input.onEvent?.({
               type: 'tool_start',
@@ -500,8 +501,8 @@ describe('subagent tools', () => {
             });
           }
           return {
-            agentId: input.spec.id,
-            agentName: input.spec.name,
+            agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+            agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
             turnId: 'child-turn',
             status: 'completed',
             permissionMode: 'explore',
@@ -535,7 +536,7 @@ describe('subagent tools', () => {
             toolCallId: 'tool-1',
             abortSignal: new AbortController().signal,
             emitOutput: (_stream, chunk) => output.push(chunk),
-            spawnChildAgent: async () => {
+            spawnChildSession: async () => {
               throw new Error('x'.repeat(10_000));
             },
           },
@@ -566,11 +567,11 @@ describe('subagent tools', () => {
         toolCallId: 'tool-1',
         abortSignal: new AbortController().signal,
         emitOutput: () => {},
-        spawnChildAgent: async (input) => {
+        spawnChildSession: async (input) => {
           calls.push(input);
           return {
-            agentId: input.spec.id,
-            agentName: input.spec.name,
+            agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+            agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
             turnId: 'child-turn',
             status: 'completed',
             permissionMode: 'execute',
@@ -583,15 +584,11 @@ describe('subagent tools', () => {
 
     expect(calls).toHaveLength(1);
     const call = calls[0] as {
-      spec: unknown;
+      agentProfile: string;
       prompt: string;
       onEvent?: (event: SessionEvent) => void;
     };
-    expect(call.spec).toEqual({
-      id: WEB_RESEARCH_AGENT_ID,
-      name: 'Web Research',
-      systemPrompt: WEB_RESEARCH_AGENT_DEFINITION.systemPrompt,
-    });
+    expect(call.agentProfile).toBe(WEB_RESEARCH_AGENT_PROFILE);
     expect(call.prompt).toBe('Find current sources.');
     expect(typeof call.onEvent).toBe('function');
     expect(result).toMatchObject({
@@ -627,15 +624,17 @@ describe('subagent tools', () => {
         toolCallId: 'tool-1',
         abortSignal: new AbortController().signal,
         emitOutput: () => {},
-        spawnChildAgent: async (input) => {
+        spawnChildSession: async (input) => {
           await input.onReady?.({
+            childSessionId: 'child-session',
+            runId: 'child-run',
             turnId: 'child-turn',
-            agentId: input.spec.id,
-            agentName: input.spec.name,
+            agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+            agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
           });
           return {
-            agentId: input.spec.id,
-            agentName: input.spec.name,
+            agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+            agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
             runId: 'child-run',
             turnId: 'child-turn',
             status: 'completed',
@@ -650,6 +649,7 @@ describe('subagent tools', () => {
     expect(task.status).toBe('in_progress');
     expect(task.owner).toEqual({
       actor: 'child_agent',
+      sessionId: 'child-session',
       agentId: LOCAL_READ_AGENT_ID,
       runId: 'child-run',
       turnId: 'child-turn',
@@ -684,7 +684,7 @@ describe('subagent tools', () => {
       now: () => 1,
       getPermissionPauseTarget: () => null,
       getCurrentRunId: () => 'parent-run',
-      spawnChildAgent: async () => {
+      spawnChildSession: async () => {
         spawned = true;
         return {};
       },
@@ -746,7 +746,7 @@ describe('subagent tools', () => {
             toolCallId: 'tool-1',
             abortSignal: new AbortController().signal,
             emitOutput: () => {},
-            spawnChildAgent: async () => {
+            spawnChildSession: async () => {
               spawned = true;
               return {};
             },
@@ -783,15 +783,17 @@ describe('subagent tools', () => {
           toolCallId: 'tool-1',
           abortSignal: new AbortController().signal,
           emitOutput: () => {},
-          spawnChildAgent: async (input) => {
+          spawnChildSession: async (input) => {
             await input.onReady?.({
+              childSessionId: 'child-session',
+              runId: 'child-run',
               turnId: `child-${status}`,
-              agentId: input.spec.id,
-              agentName: input.spec.name,
+              agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+              agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
             });
             return {
-              agentId: input.spec.id,
-              agentName: input.spec.name,
+              agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+              agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
               runId: `run-${status}`,
               turnId: `child-${status}`,
               status,
@@ -810,6 +812,7 @@ describe('subagent tools', () => {
       expect(task.status).toBe(status);
       expect(task.owner).toEqual({
         actor: 'child_agent',
+        sessionId: 'child-session',
         agentId: LOCAL_READ_AGENT_ID,
         runId: `run-${status}`,
         turnId: `child-${status}`,
@@ -844,11 +847,13 @@ describe('subagent tools', () => {
             toolCallId: 'tool-1',
             abortSignal: new AbortController().signal,
             emitOutput: () => {},
-            spawnChildAgent: async (input) => {
+            spawnChildSession: async (input) => {
               await input.onReady?.({
+                childSessionId: 'child-session',
+                runId: 'child-run',
                 turnId: 'child-turn',
-                agentId: input.spec.id,
-                agentName: input.spec.name,
+                agentId: requireBuiltinAgentDefinitionByProfile(input.agentProfile).id,
+                agentName: requireBuiltinAgentDefinitionByProfile(input.agentProfile).name,
               });
               throw new Error('child startup failed');
             },
@@ -889,7 +894,7 @@ describe('subagent tools', () => {
             toolCallId: 'tool-1',
             abortSignal: new AbortController().signal,
             emitOutput: () => {},
-            spawnChildAgent: async () => {
+            spawnChildSession: async () => {
               spawned = true;
               return {};
             },
@@ -1006,7 +1011,7 @@ describe('subagent tools', () => {
             toolCallId: 'tool-1',
             abortSignal: new AbortController().signal,
             emitOutput: () => {},
-            spawnChildAgent: async () => {
+            spawnChildSession: async () => {
               throw new Error('spawn should not be called');
             },
           },
@@ -1047,6 +1052,18 @@ describe('subagent tools', () => {
         readChildAgentOutput: async (input) => ({ requested: input }),
       },
     );
+    const childSessionOutput = await outputTool.impl(
+      { child_session_id: 'child-session', run_id: 'child-session-run' },
+      {
+        sessionId: 'session-1',
+        turnId: 'parent-turn',
+        cwd: '/tmp/cwd',
+        toolCallId: 'tool-output-child-session',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+        readChildAgentOutput: async (input) => ({ requested: input }),
+      },
+    );
 
     expect(listTool.name).toBe(AGENT_LIST_TOOL_NAME);
     expect(outputTool.name).toBe(AGENT_OUTPUT_TOOL_NAME);
@@ -1056,17 +1073,49 @@ describe('subagent tools', () => {
       definitions: [{ id: LOCAL_READ_AGENT_ID }],
       runs: [{ runId: 'child-run', turnId: 'child-turn' }],
     });
-    expect(output).toEqual({ requested: { runId: 'child-run' } });
+    expect(output).toEqual({
+      requested: {
+        execution: {
+          kind: 'legacy_child_run',
+          sessionId: 'session-1',
+          runId: 'child-run',
+        },
+      },
+    });
+    expect(childSessionOutput).toEqual({
+      requested: {
+        execution: {
+          kind: 'child_session',
+          sessionId: 'child-session',
+          currentRunId: 'child-session-run',
+        },
+      },
+    });
   });
 
-  test('agent_output requires exactly one run locator', () => {
+  test('agent_output accepts linked child-session and legacy run locators', () => {
     const outputTool = buildSubagentOutputTool();
     const schema = outputTool.parameters as { safeParse(input: unknown): { success: boolean } };
 
     expect(schema.safeParse({ run_id: 'child-run' }).success).toBe(true);
     expect(schema.safeParse({ turn_id: 'child-turn' }).success).toBe(true);
+    expect(schema.safeParse({ child_session_id: 'child-session' }).success).toBe(true);
+    expect(
+      schema.safeParse({
+        child_session_id: 'child-session',
+        run_id: 'child-run',
+      }).success,
+    ).toBe(true);
     expect(schema.safeParse({}).success).toBe(false);
     expect(schema.safeParse({ run_id: 'child-run', turn_id: 'child-turn' }).success).toBe(false);
+    expect(
+      schema.safeParse({
+        child_session_id: 'child-session',
+        turn_id: 'child-turn',
+      }).success,
+    ).toBe(false);
+    expect(schema.safeParse({ child_session_id: '' }).success).toBe(false);
+    expect(schema.safeParse({ run_id: '' }).success).toBe(false);
   });
 });
 

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -1072,6 +1072,7 @@ export class AgentRun {
     const runsById = new Map(sessionRuns.map((run) => [run.runId, run]));
     const reverseChain: AgentRunHeader[] = [];
     const visited = new Set<string>();
+    const linkedChildSession = this.input.header.subagentParent?.kind === 'subagent';
     let cursor: string | undefined = sourceRunId;
     while (cursor) {
       if (visited.has(cursor)) {
@@ -1080,14 +1081,16 @@ export class AgentRun {
       visited.add(cursor);
       const run = runsById.get(cursor);
       if (!run) throw new Error(`Child AgentRun resume source ${cursor} was not found`);
-      if (!run.parentRunId || isSessionInlineRun(run)) {
+      if (
+        linkedChildSession ? !isSessionInlineRun(run) : !run.parentRunId || isSessionInlineRun(run)
+      ) {
         throw new Error(`AgentRun ${cursor} is not a resumable child run`);
       }
       if (!run.agentId || run.agentId !== this.input.userInput.agentId) {
         throw new Error(`Child AgentRun resume profile changed at ${cursor}`);
       }
       reverseChain.push(run);
-      cursor = run.resumedFromRunId;
+      cursor = run.resumedFromRunId ?? (linkedChildSession ? run.retriedFromRunId : undefined);
     }
 
     const chain = reverseChain.reverse();

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -90,10 +90,15 @@ interface PendingAgentSwarmResume {
 }
 
 interface StartedChildRef {
+  readonly childSessionId?: string;
   readonly turnId: string;
   readonly agentId: string;
   readonly agentName: string;
 }
+
+type ChildExecutionResult = SpawnChildAgentResult & {
+  readonly childSessionId?: string;
+};
 
 export function buildAgentSwarmTool(
   deps: {
@@ -121,8 +126,8 @@ export function buildAgentSwarmTool(
     categoryHint: 'subagent',
     impl: async (input, ctx) => {
       const prepared = await prepareAgentSwarmInput(input, ctx);
-      if (prepared.items.some((item) => item.mode === 'spawn') && !ctx.spawnChildAgent) {
-        throw new Error('spawnChildAgent capability is unavailable in this runtime context');
+      if (prepared.items.some((item) => item.mode === 'spawn') && !ctx.spawnChildSession) {
+        throw new Error('spawnChildSession capability is unavailable in this runtime context');
       }
       if (
         prepared.items.some((item) => item.mode === 'resume') &&
@@ -155,13 +160,13 @@ export function buildAgentSwarmTool(
       const readyRefs: Array<StartedChildRef | undefined> = Array.from({
         length: prepared.items.length,
       });
-      const childResults: Array<SpawnChildAgentResult | undefined> = Array.from({
+      const childResults: Array<ChildExecutionResult | undefined> = Array.from({
         length: prepared.items.length,
       });
       const artifactIds = prepared.items.map(() => new Set<string>());
       const rows = await runAdaptiveSwarm<
         PreparedAgentSwarmItem,
-        SpawnChildAgentResult,
+        ChildExecutionResult,
         { sourceRunId: string }
       >(
         prepared.items,
@@ -182,11 +187,16 @@ export function buildAgentSwarmTool(
             `Agent swarm item ${item.itemId} ${retry ? 'retry' : 'started'}: ${item.definition.name}\n`,
           );
           try {
-            const onReady = ({ turnId, agentId, agentName }: StartedChildRef) => {
-              readyRefs[index] = { turnId, agentId, agentName };
+            const onReady = ({ childSessionId, turnId, agentId, agentName }: StartedChildRef) => {
+              readyRefs[index] = {
+                ...(childSessionId ? { childSessionId } : {}),
+                turnId,
+                agentId,
+                agentName,
+              };
               markReady();
             };
-            const result = retry
+            const result: ChildExecutionResult = retry
               ? ctx.retryChildAgent
                 ? ((await ctx.retryChildAgent({
                     sourceRunId: retry.sourceRunId,
@@ -203,17 +213,17 @@ export function buildAgentSwarmTool(
                     abortSignal: deadline.signal,
                     onReady,
                   })) as SpawnChildAgentResult)
-                : ((await ctx.spawnChildAgent!({
-                    spec: {
-                      id: item.definition.id,
-                      name: item.definition.name,
-                      systemPrompt: item.definition.systemPrompt,
-                    },
+                : ((await ctx.spawnChildSession!({
+                    agentProfile: item.definition.profile,
                     prompt: item.task,
+                    swarm: {
+                      swarmId: ctx.toolCallId,
+                      itemId: item.itemId,
+                    },
                     abortSignal: deadline.signal,
                     onReady,
-                  })) as SpawnChildAgentResult);
-            const effectiveResult = deadline.timedOut()
+                  })) as ChildExecutionResult);
+            const effectiveResult: ChildExecutionResult = deadline.timedOut()
               ? timedOutChildResult(result, itemTimeoutMs)
               : result;
             for (const artifactId of effectiveResult.artifactIds)
@@ -227,6 +237,7 @@ export function buildAgentSwarmTool(
               effectiveResult.status === 'failed' &&
               effectiveResult.failureClass === 'RateLimit' &&
               effectiveResult.runId &&
+              !effectiveResult.childSessionId &&
               ctx.retryChildAgent
             ) {
               return {
@@ -246,6 +257,9 @@ export function buildAgentSwarmTool(
                 mode: item.mode,
                 ...(item.resumedFromRunId ? { resumedFromRunId: item.resumedFromRunId } : {}),
                 status: effectiveResult.status,
+                ...(effectiveResult.childSessionId
+                  ? { childSessionId: effectiveResult.childSessionId }
+                  : {}),
                 turnId: effectiveResult.turnId,
                 ...(effectiveResult.runId ? { runId: effectiveResult.runId } : {}),
                 durationMs: effectiveResult.durationMs,
@@ -558,8 +572,8 @@ async function prepareAgentSwarmInput(
   readonly maxConcurrency: number;
 }> {
   const preflight = preflightAgentSwarmInput(input);
-  if (preflight.items.length > 0 && !ctx.spawnChildAgent) {
-    throw new Error('spawnChildAgent capability is unavailable in this runtime context');
+  if (preflight.items.length > 0 && !ctx.spawnChildSession) {
+    throw new Error('spawnChildSession capability is unavailable in this runtime context');
   }
   if (preflight.resumes.length > 0 && (!ctx.prepareChildAgentResume || !ctx.resumeChildAgent)) {
     throw new Error('Child AgentRun resume capability is unavailable in this runtime context');
@@ -740,9 +754,9 @@ function expandAgentSwarmPromptTemplate(promptTemplate: string, item: string): s
 
 function mapAgentSwarmItem(
   item: PreparedAgentSwarmItem,
-  row: AdaptiveSwarmItemResult<SpawnChildAgentResult>,
+  row: AdaptiveSwarmItemResult<ChildExecutionResult>,
   ready: StartedChildRef | undefined,
-  observed: SpawnChildAgentResult | undefined,
+  observed: ChildExecutionResult | undefined,
 ): AgentSwarmToolResult['items'][number] {
   if (row.status === 'fulfilled') {
     return mapChildResult(
@@ -846,9 +860,9 @@ function createItemDeadline(
 }
 
 function timedOutChildResult(
-  result: SpawnChildAgentResult,
+  result: ChildExecutionResult,
   timeoutMs: number,
-): SpawnChildAgentResult {
+): ChildExecutionResult {
   return {
     ...result,
     status: 'failed',
@@ -875,7 +889,7 @@ function formatDuration(ms: number): string {
 
 function mapChildResult(
   item: PreparedAgentSwarmItem,
-  result: SpawnChildAgentResult,
+  result: ChildExecutionResult,
   status: AgentSwarmToolResult['items'][number]['status'],
 ): AgentSwarmToolResult['items'][number] {
   return {
@@ -885,6 +899,7 @@ function mapChildResult(
     started: true,
     agentId: result.agentId,
     agentName: result.agentName,
+    ...(result.childSessionId ? { childSessionId: result.childSessionId } : {}),
     turnId: result.turnId,
     ...(result.runId ? { runId: result.runId } : {}),
     ...(item.resumedFromRunId ? { resumedFromRunId: item.resumedFromRunId } : {}),

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -21,6 +21,7 @@ import {
   type AdaptiveSwarmItemResult,
 } from './adaptive-swarm.js';
 import type { SpawnChildAgentResult } from './session-manager.js';
+import type { SubagentExecutionRef } from './subagent-execution.js';
 import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 
 export const AGENT_SWARM_TOOL_NAME = 'agent_swarm';
@@ -80,6 +81,7 @@ interface PreparedAgentSwarmItem {
   readonly definition: AgentDefinition;
   readonly mode: 'spawn' | 'resume';
   readonly resumedFromRunId?: string;
+  readonly execution?: SubagentExecutionRef;
 }
 
 interface PendingAgentSwarmResume {
@@ -92,6 +94,7 @@ interface PendingAgentSwarmResume {
 interface StartedChildRef {
   readonly childSessionId?: string;
   readonly turnId: string;
+  readonly runId?: string;
   readonly agentId: string;
   readonly agentName: string;
 }
@@ -167,7 +170,7 @@ export function buildAgentSwarmTool(
       const rows = await runAdaptiveSwarm<
         PreparedAgentSwarmItem,
         ChildExecutionResult,
-        { sourceRunId: string }
+        { sourceRunId: string; execution?: SubagentExecutionRef }
       >(
         prepared.items,
         async (item, { index, attempt, retry, markReady }) => {
@@ -187,10 +190,17 @@ export function buildAgentSwarmTool(
             `Agent swarm item ${item.itemId} ${retry ? 'retry' : 'started'}: ${item.definition.name}\n`,
           );
           try {
-            const onReady = ({ childSessionId, turnId, agentId, agentName }: StartedChildRef) => {
+            const onReady = ({
+              childSessionId,
+              turnId,
+              runId,
+              agentId,
+              agentName,
+            }: StartedChildRef) => {
               readyRefs[index] = {
                 ...(childSessionId ? { childSessionId } : {}),
                 turnId,
+                ...(runId ? { runId } : {}),
                 agentId,
                 agentName,
               };
@@ -200,6 +210,7 @@ export function buildAgentSwarmTool(
               ? ctx.retryChildAgent
                 ? ((await ctx.retryChildAgent({
                     sourceRunId: retry.sourceRunId,
+                    ...(retry.execution ? { execution: retry.execution } : {}),
                     abortSignal: deadline.signal,
                     onReady,
                   })) as SpawnChildAgentResult)
@@ -237,12 +248,22 @@ export function buildAgentSwarmTool(
               effectiveResult.status === 'failed' &&
               effectiveResult.failureClass === 'RateLimit' &&
               effectiveResult.runId &&
-              !effectiveResult.childSessionId &&
               ctx.retryChildAgent
             ) {
               return {
                 status: 'rate_limited' as const,
-                retry: { sourceRunId: effectiveResult.runId },
+                retry: {
+                  sourceRunId: effectiveResult.runId,
+                  ...(effectiveResult.childSessionId
+                    ? {
+                        execution: {
+                          kind: 'child_session' as const,
+                          sessionId: effectiveResult.childSessionId,
+                          currentRunId: effectiveResult.runId,
+                        },
+                      }
+                    : {}),
+                },
                 reason: new ProviderRateLimitRetry(effectiveResult),
               };
             }
@@ -596,6 +617,7 @@ async function prepareAgentSwarmInput(
         definition,
         mode: 'resume',
         resumedFromRunId: item.sourceRunId,
+        execution: prepared.execution,
       };
     }),
   );

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -108,6 +108,7 @@ import {
   type ToolModelOutput,
 } from './tool-runtime.js';
 import type { RuntimeCommitSink } from './runtime-commit-sink.js';
+import type { SubagentExecutionRef } from './subagent-execution.js';
 import {
   ModelAdapter,
   normalizeAiSdkUsage,
@@ -549,9 +550,12 @@ export interface AiSdkBackendInput {
   retryChildAgent?: (input: {
     parentRunId: string;
     sourceRunId: string;
+    execution?: SubagentExecutionRef;
     abortSignal: AbortSignal;
     onReady?: (input: {
+      childSessionId?: string;
       turnId: string;
+      runId?: string;
       agentId: string;
       agentName: string;
     }) => void | Promise<void>;

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -543,6 +543,7 @@ export interface AiSdkBackendInput {
     }) => void | Promise<void>;
     onEvent?: (event: SessionEvent) => void;
   }) => Promise<unknown>;
+  spawnChildSession?: ToolRuntimeInput['spawnChildSession'];
   prepareChildAgentResume?: ToolRuntimeInput['prepareChildAgentResume'];
   resumeChildAgent?: ToolRuntimeInput['resumeChildAgent'];
   retryChildAgent?: (input: {
@@ -557,11 +558,7 @@ export interface AiSdkBackendInput {
     onEvent?: (event: SessionEvent) => void;
   }) => Promise<unknown>;
   listChildAgents?: () => Promise<unknown>;
-  readChildAgentOutput?: (input: {
-    runId?: string;
-    turnId?: string;
-    maxEvents?: number;
-  }) => Promise<unknown>;
+  readChildAgentOutput?: ToolRuntimeInput['readChildAgentOutput'];
   /** Optional diagnostic trace hook for explaining a runtime turn without changing renderer events. */
   recordRunTrace?: RunTraceRecorder;
   /**
@@ -774,6 +771,7 @@ export class AiSdkBackend implements AgentBackend {
       getCurrentOrchestration: () => this.currentOrchestration,
       permissionRules: input.permissionRules,
       spawnChildAgent: input.spawnChildAgent,
+      spawnChildSession: input.spawnChildSession,
       prepareChildAgentResume: input.prepareChildAgentResume,
       resumeChildAgent: input.resumeChildAgent,
       retryChildAgent: input.retryChildAgent,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -31,10 +31,12 @@ export type {
   RetryChildAgentInput,
   AgentListItem,
   AgentListResult,
+  SubagentExecutionListItem,
   AgentOutputInput,
   AgentOutputResult,
   StopSessionInput,
 } from './session-manager.js';
+export type { SubagentExecutionRef } from './subagent-execution.js';
 
 export { PermissionEngine, createDefaultPermissionEngineDeps } from './permission-engine.js';
 export type { EvaluateResult, EvaluateInput, PermissionEngineDeps } from './permission-engine.js';

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -118,6 +118,8 @@ export interface ChildAgentRetryInput {
   parentRunId: string;
   spec: ChildAgentTurnInput['spec'];
   continuation: RuntimeContinuation;
+  /** Retry an ordinary session-inline AgentRun inside a linked child Session. */
+  linkedSession?: boolean;
 }
 
 /**
@@ -620,15 +622,38 @@ export class RuntimeKernel implements RuntimeKernelLike {
       throw new Error('Child retry continuation belongs to a different session');
     }
     const parentHeader = await this.deps.store.readHeader(sessionId);
-    const definition = requireResolvedAgentDefinition(input.spec.id);
+    const linkedSnapshot = input.linkedSession ? parentHeader.subagentRuntime : undefined;
+    if (
+      input.linkedSession &&
+      (parentHeader.subagentParent?.kind !== 'subagent' ||
+        !linkedSnapshot ||
+        linkedSnapshot.agentId !== input.spec.id)
+    ) {
+      throw new Error('Linked child retry is missing its durable runtime snapshot');
+    }
+    const definition = linkedSnapshot
+      ? {
+          id: linkedSnapshot.agentId,
+          name: linkedSnapshot.agentName,
+          systemPrompt: linkedSnapshot.systemPrompt,
+          permissionMode: parentHeader.permissionMode,
+          tools: linkedSnapshot.toolNames,
+          categoryPolicy: linkedSnapshot.categoryPolicy,
+        }
+      : requireResolvedAgentDefinition(input.spec.id);
     const availableChildTools = this.deps.childTools ?? [];
-    assertAgentDefinitionRunnable({
-      parentPermissionMode: parentHeader.permissionMode,
-      definition,
-      tools: availableChildTools,
-    });
+    if (!linkedSnapshot) {
+      assertAgentDefinitionRunnable({
+        parentPermissionMode: parentHeader.permissionMode,
+        definition: requireResolvedAgentDefinition(input.spec.id),
+        tools: availableChildTools,
+      });
+    }
     const childTools = buildToolsForAgentDefinition(availableChildTools, definition);
-    const expertIdentity = parseExpertAgentId(definition.id);
+    if (linkedSnapshot && childTools.length !== linkedSnapshot.toolNames.length) {
+      throw new Error('Linked child retry durable runtime tool snapshot is unavailable');
+    }
+    const expertIdentity = linkedSnapshot ? undefined : parseExpertAgentId(definition.id);
     const agentTeam: AgentTeamExecutionContext | undefined = expertIdentity
       ? {
           role: 'member',
@@ -637,15 +662,17 @@ export class RuntimeKernel implements RuntimeKernelLike {
           parentRunId: input.parentRunId,
         }
       : undefined;
-    const childHeader: SessionHeader = {
-      ...parentHeader,
-      permissionMode: definition.permissionMode,
-      connectionLocked: true,
-    };
+    const childHeader: SessionHeader = linkedSnapshot
+      ? parentHeader
+      : {
+          ...parentHeader,
+          permissionMode: definition.permissionMode,
+          connectionLocked: true,
+        };
     const userInput: UserMessageInput = {
       turnId: continuation.turnId,
       text: '',
-      parentRunId: input.parentRunId,
+      ...(!linkedSnapshot ? { parentRunId: input.parentRunId } : {}),
       retriedFromRunId: continuation.sourceRunId,
       agentId: definition.id,
       agentName: definition.name,
@@ -671,19 +698,33 @@ export class RuntimeKernel implements RuntimeKernelLike {
       recordSessionMessages: false,
       hooks: {
         ensureActive: (targetSessionId, nextHeader) =>
-          this.ensureChildActive(
-            activeKey,
-            targetSessionId,
-            nextHeader,
-            definition.systemPrompt,
-            childTools,
-            agentTeam,
-          ),
+          linkedSnapshot
+            ? this.ensureActive(targetSessionId, nextHeader)
+            : this.ensureChildActive(
+                activeKey,
+                targetSessionId,
+                nextHeader,
+                definition.systemPrompt,
+                childTools,
+                agentTeam,
+              ),
         registerRun: (active, activeRun) => this.registerRun(active, activeRun),
-        unregisterRun: (active, activeRun) => this.unregisterChildRun(activeKey, active, activeRun),
-        updateHeader: async (_targetSessionId, patch) => ({ ...childHeader, ...patch }),
-        updateStatus: async () => {},
-        appendTurnState: async () => {},
+        unregisterRun: (active, activeRun) =>
+          linkedSnapshot
+            ? this.unregisterParentRun(active, activeRun)
+            : this.unregisterChildRun(activeKey, active, activeRun),
+        updateHeader: (targetSessionId, patch) =>
+          linkedSnapshot
+            ? this.updateHeader(targetSessionId, patch)
+            : Promise.resolve({ ...childHeader, ...patch }),
+        updateStatus: (targetSessionId, status, blockedReason, ts) =>
+          linkedSnapshot
+            ? this.updateStatus(targetSessionId, status, blockedReason, ts)
+            : Promise.resolve(),
+        appendTurnState: (targetSessionId, turnId, status, lineage, options) =>
+          linkedSnapshot
+            ? this.appendTurnState(targetSessionId, turnId, status, lineage, options)
+            : Promise.resolve(),
       },
     });
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -118,6 +118,7 @@ import {
 } from './session-projection-helpers.js';
 import {
   assertAgentDefinitionRunnable,
+  buildToolsForAgentDefinition,
   getBuiltinAgentDefinition,
   listBuiltinAgentDefinitions,
   requireBuiltinAgentDefinitionByProfile,
@@ -192,6 +193,7 @@ export interface SpawnChildSessionResult extends SpawnChildAgentResult {
 
 export interface PrepareChildAgentResumeResult {
   sourceRunId: string;
+  execution: SubagentExecutionRef;
   agentId: string;
   agentName: string;
   profile: string;
@@ -203,12 +205,19 @@ export interface ResumeChildAgentInput {
   turnId?: string;
   prompt: string;
   abortSignal?: AbortSignal;
-  onReady?: (input: { turnId: string; agentId: string; agentName: string }) => void | Promise<void>;
+  onReady?: (input: {
+    childSessionId?: string;
+    turnId: string;
+    runId?: string;
+    agentId: string;
+    agentName: string;
+  }) => void | Promise<void>;
   /** Presentation-only observer for projecting child activity into a parent surface. */
   onEvent?: (event: SessionEvent) => void;
 }
 
 export interface SpawnChildAgentResult {
+  childSessionId?: string;
   agentId: string;
   agentName: string;
   turnId: string;
@@ -229,8 +238,15 @@ export interface SpawnChildAgentResult {
 export interface RetryChildAgentInput {
   parentRunId: string;
   sourceRunId: string;
+  execution?: SubagentExecutionRef;
   abortSignal?: AbortSignal;
-  onReady?: (input: { turnId: string; agentId: string; agentName: string }) => void | Promise<void>;
+  onReady?: (input: {
+    childSessionId?: string;
+    turnId: string;
+    runId?: string;
+    agentId: string;
+    agentName: string;
+  }) => void | Promise<void>;
   /** Presentation-only observer for projecting child activity into a parent surface. */
   onEvent?: (event: SessionEvent) => void;
 }
@@ -1614,6 +1630,10 @@ export class SessionManager {
     if (!this.deps.runStore || !this.deps.runtimeEventStore) {
       throw new Error('Child AgentRun resume requires AgentRunStore and RuntimeEventStore');
     }
+    const execution = await this.resolveChildAgentExecution(sessionId, sourceRunId);
+    if (execution.kind === 'child_session') {
+      return await this.prepareLinkedChildSessionResume(sessionId, execution, sourceRunId);
+    }
     const runs = await this.deps.runStore.listSessionRuns(sessionId);
     const runsById = new Map(runs.map((run) => [run.runId, run]));
     const source = runsById.get(sourceRunId);
@@ -1689,9 +1709,153 @@ export class SessionManager {
     }
     return {
       sourceRunId,
+      execution,
       agentId: definition.id,
       agentName: definition.name,
       profile: definition.profile,
+    };
+  }
+
+  private async resolveChildAgentExecution(
+    parentSessionId: string,
+    sourceRunId: string,
+  ): Promise<SubagentExecutionRef> {
+    if (!this.deps.runStore) {
+      throw new Error('Child AgentRun lookup requires AgentRunStore');
+    }
+    const legacy = await this.deps.runStore.readRun(parentSessionId, sourceRunId).catch((error) => {
+      if (isNotFoundError(error)) return undefined;
+      throw error;
+    });
+    if (legacy?.parentRunId && !isSessionInlineRun(legacy)) {
+      return {
+        kind: 'legacy_child_run',
+        sessionId: parentSessionId,
+        runId: sourceRunId,
+      };
+    }
+
+    const children = await this.listChildSessions(parentSessionId);
+    const matches = (
+      await Promise.all(
+        children.map(async (child) => {
+          const run = await this.deps.runStore!.readRun(child.id, sourceRunId).catch((error) => {
+            if (isNotFoundError(error)) return undefined;
+            throw error;
+          });
+          return run && isSessionInlineRun(run) ? child.id : undefined;
+        }),
+      )
+    ).filter((childSessionId): childSessionId is string => childSessionId !== undefined);
+    if (matches.length !== 1) {
+      throw new Error(`Child AgentRun resume source ${sourceRunId} was not found`);
+    }
+    return {
+      kind: 'child_session',
+      sessionId: matches[0]!,
+      currentRunId: sourceRunId,
+    };
+  }
+
+  private async prepareLinkedChildSessionResume(
+    parentSessionId: string,
+    execution: Extract<SubagentExecutionRef, { kind: 'child_session' }>,
+    sourceRunId: string,
+  ): Promise<PrepareChildAgentResumeResult> {
+    if (!this.deps.runStore || !this.deps.runtimeEventStore) {
+      throw new Error('Child Session resume requires AgentRunStore and RuntimeEventStore');
+    }
+    const child = await this.deps.store.readHeader(execution.sessionId);
+    const snapshot = child.subagentRuntime;
+    if (
+      child.subagentParent?.kind !== 'subagent' ||
+      child.subagentParent.parentSessionId !== parentSessionId ||
+      !snapshot
+    ) {
+      throw new Error(`Child AgentRun resume source ${sourceRunId} was not found`);
+    }
+    if (!isPermissionModeWithinCeiling(child.permissionMode, snapshot.permissionCeiling)) {
+      throw new Error('Child Session permission mode exceeds its durable runtime ceiling');
+    }
+    const runnableTools = buildToolsForAgentDefinition(this.deps.childTools ?? [], {
+      id: snapshot.agentId,
+      permissionMode: child.permissionMode,
+      tools: snapshot.toolNames,
+      categoryPolicy: snapshot.categoryPolicy,
+    });
+    if (runnableTools.length !== snapshot.toolNames.length) {
+      throw new Error('Child Session durable runtime tool snapshot is unavailable');
+    }
+
+    const runs = await this.deps.runStore.listSessionRuns(child.id);
+    const runsById = new Map(runs.map((run) => [run.runId, run]));
+    const source = runsById.get(sourceRunId);
+    if (!source || !isSessionInlineRun(source)) {
+      throw new Error(`Child AgentRun resume source ${sourceRunId} was not found`);
+    }
+    const visited = new Set<string>();
+    const replaySegments: RuntimeEvent[][] = [];
+    let cursor: AgentRunHeader | undefined = source;
+    while (cursor) {
+      if (visited.has(cursor.runId)) {
+        throw new Error(`Child AgentRun resume lineage contains a cycle at ${cursor.runId}`);
+      }
+      visited.add(cursor.runId);
+      if (!isSessionInlineRun(cursor) || cursor.agentId !== snapshot.agentId) {
+        throw new Error(`Child AgentRun resume profile changed at ${cursor.runId}`);
+      }
+      if (
+        cursor.backendKind !== child.backend ||
+        cursor.llmConnectionSlug !== child.llmConnectionSlug ||
+        cursor.modelId !== child.model ||
+        cursor.cwd !== child.cwd ||
+        cursor.permissionMode !== child.permissionMode
+      ) {
+        throw new Error(`Child AgentRun resume environment changed for ${cursor.runId}`);
+      }
+
+      const events = await this.deps.runtimeEventStore
+        .readRuntimeEvents(child.id, cursor.runId)
+        .catch(() => []);
+      const replay = buildRuntimeEventModelReplayPlan(events);
+      const unsafe = replay.diagnostics.find((diagnostic) =>
+        isUnsafeChildResumeDiagnostic(diagnostic.code),
+      );
+      if (unsafe) {
+        throw new Error(`Child AgentRun resume history is unsafe: ${unsafe.code}`);
+      }
+      replaySegments.unshift(events);
+      const terminal = classifyTerminalRuntimeLedger(cursor, events);
+      if (terminal.kind !== 'fact') {
+        throw new Error(`Child AgentRun resume source ${cursor.runId} is not durably terminal`);
+      }
+      const effective = effectiveRunHeaderFromTerminalFact(cursor, terminal.fact);
+      if (!['completed', 'failed', 'cancelled'].includes(effective.status)) {
+        throw new Error(`Child AgentRun resume source ${cursor.runId} is not in a resumable state`);
+      }
+
+      const previousRunId = cursor.resumedFromRunId ?? cursor.retriedFromRunId;
+      if (!previousRunId) break;
+      cursor = runsById.get(previousRunId);
+      if (!cursor) {
+        throw new Error(`Child AgentRun resume source ${previousRunId} was not found`);
+      }
+    }
+
+    const replay = buildRuntimeEventModelReplayPlan(replaySegments.flat());
+    const first = replay.items[0];
+    if (!first || first.kind !== 'text' || first.role !== 'user') {
+      throw new Error(`Child AgentRun resume source ${sourceRunId} has no user-anchored history`);
+    }
+    if (runs.some((run) => run.resumedFromRunId === sourceRunId)) {
+      throw new Error(`Child AgentRun ${sourceRunId} already has a resume successor`);
+    }
+    return {
+      sourceRunId,
+      execution,
+      agentId: snapshot.agentId,
+      agentName: snapshot.agentName,
+      profile: snapshot.profile,
     };
   }
 
@@ -1700,8 +1864,114 @@ export class SessionManager {
     input: ResumeChildAgentInput,
   ): Promise<SpawnChildAgentResult> {
     const prepared = await this.prepareChildAgentResume(sessionId, input.sourceRunId);
+    if (prepared.execution.kind === 'child_session') {
+      return await this.resumeLinkedChildSession(sessionId, prepared.execution, prepared, input);
+    }
     const definition = getBuiltinAgentDefinition(prepared.agentId)!;
     return await this.runChildAgent(sessionId, definition, input, input.sourceRunId);
+  }
+
+  private async resumeLinkedChildSession(
+    parentSessionId: string,
+    execution: Extract<SubagentExecutionRef, { kind: 'child_session' }>,
+    prepared: PrepareChildAgentResumeResult,
+    input: ResumeChildAgentInput,
+  ): Promise<SpawnChildAgentResult> {
+    if (!this.deps.runStore) {
+      throw new Error('Child Session resume requires AgentRunStore');
+    }
+    const [parentRun, child] = await Promise.all([
+      this.deps.runStore.readRun(parentSessionId, input.parentRunId),
+      this.deps.store.readHeader(execution.sessionId),
+    ]);
+    this.assertActiveParentRun(parentSessionId, parentRun, parentRun.turnId);
+    if (
+      child.subagentParent?.kind !== 'subagent' ||
+      child.subagentParent.parentSessionId !== parentSessionId ||
+      child.subagentRuntime?.agentId !== prepared.agentId
+    ) {
+      throw new Error(`Child AgentRun resume source ${input.sourceRunId} was not found`);
+    }
+
+    const turnId = input.turnId ?? this.deps.newId();
+    const runId = this.deps.newId();
+    const startedAt = this.deps.now();
+    const summary = new ChildAgentSummaryAccumulator();
+    let aborted = input.abortSignal?.aborted === true;
+    let stopPromise: Promise<void> | undefined;
+    const iterator = this.sendMessage(
+      child.id,
+      {
+        turnId,
+        text: input.prompt,
+        resumedFromRunId: input.sourceRunId,
+        agentId: prepared.agentId,
+        agentName: prepared.agentName,
+      },
+      {
+        runId,
+        durability: 'required',
+        onRunStarted: () =>
+          input.onReady?.({
+            childSessionId: child.id,
+            turnId,
+            runId,
+            agentId: prepared.agentId,
+            agentName: prepared.agentName,
+          }),
+      },
+    )[Symbol.asyncIterator]();
+    const onAbort = () => {
+      aborted = true;
+      stopPromise ??= this.stopSession(child.id, { source: 'stop_button' });
+    };
+    if (input.abortSignal) {
+      input.abortSignal.addEventListener('abort', onAbort, { once: true });
+      if (input.abortSignal.aborted) onAbort();
+    }
+    try {
+      while (!aborted) {
+        const next = await iterator.next();
+        if (next.done) break;
+        summary.add(next.value);
+        try {
+          input.onEvent?.(next.value);
+        } catch {
+          // A presentation observer must not change the child run outcome.
+        }
+        if (aborted) break;
+      }
+    } finally {
+      input.abortSignal?.removeEventListener('abort', onAbort);
+      if (aborted) {
+        await stopPromise;
+        await iterator.return?.();
+      }
+    }
+
+    const completedAt = this.deps.now();
+    const run = await this.findRunByTurnId(child.id, turnId);
+    const failureClass = run?.failureClass ?? summary.failureClass;
+    const artifacts = this.deps.listArtifactsForTurn
+      ? await this.deps.listArtifactsForTurn(child.id, turnId)
+      : [];
+    return {
+      childSessionId: child.id,
+      agentId: prepared.agentId,
+      agentName: prepared.agentName,
+      turnId,
+      runId,
+      resumedFromRunId: input.sourceRunId,
+      status: run ? agentRunStatusForSpawnResult(run.status) : summary.status(aborted),
+      permissionMode: child.permissionMode,
+      summary: summary.text(),
+      artifactIds: artifacts.map((artifact) => artifact.id),
+      startedAt,
+      completedAt,
+      durationMs: Math.max(0, completedAt - startedAt),
+      eventCount: summary.eventCount,
+      ...(failureClass ? { failureClass } : {}),
+    };
   }
 
   private async runChildAgent(
@@ -1780,23 +2050,67 @@ export class SessionManager {
     if (!this.deps.runStore || !this.deps.runtimeEventStore) {
       throw new Error('Child agent retry requires AgentRunStore and RuntimeEventStore');
     }
-    const runs = await this.deps.runStore.listSessionRuns(sessionId);
+    const execution = await this.resolveChildAgentExecution(sessionId, input.sourceRunId);
+    if (
+      input.execution &&
+      (input.execution.kind !== execution.kind ||
+        input.execution.sessionId !== execution.sessionId ||
+        (input.execution.kind === 'legacy_child_run' &&
+          (execution.kind !== 'legacy_child_run' || input.execution.runId !== execution.runId)) ||
+        (input.execution.kind === 'child_session' &&
+          input.execution.currentRunId !== undefined &&
+          input.execution.currentRunId !== input.sourceRunId))
+    ) {
+      throw new Error('Child agent retry execution identity changed');
+    }
+    const targetSessionId = execution.sessionId;
+    const runs = await this.deps.runStore.listSessionRuns(targetSessionId);
     const rawSourceRun = runs.find((run) => run.runId === input.sourceRunId);
     if (!rawSourceRun) throw new Error('Child agent retry source run was not found');
     const sourceRun = await this.effectiveRunHeaderFromRuntimeLedger(rawSourceRun);
-    if (!sourceRun.parentRunId || sourceRun.parentRunId !== input.parentRunId) {
-      throw new Error('Child agent retry source does not belong to the active parent run');
+    let definition: {
+      id: string;
+      name: string;
+      systemPrompt: string;
+      permissionMode: PermissionMode;
+    };
+    if (execution.kind === 'child_session') {
+      const [parentRun, child] = await Promise.all([
+        this.deps.runStore.readRun(sessionId, input.parentRunId),
+        this.deps.store.readHeader(targetSessionId),
+      ]);
+      this.assertActiveParentRun(sessionId, parentRun, parentRun.turnId);
+      const snapshot = child.subagentRuntime;
+      if (
+        child.subagentParent?.kind !== 'subagent' ||
+        child.subagentParent.parentSessionId !== sessionId ||
+        !snapshot ||
+        !isSessionInlineRun(sourceRun) ||
+        sourceRun.agentId !== snapshot.agentId
+      ) {
+        throw new Error('Child agent retry source does not belong to the parent Session');
+      }
+      definition = {
+        id: snapshot.agentId,
+        name: snapshot.agentName,
+        systemPrompt: snapshot.systemPrompt,
+        permissionMode: child.permissionMode,
+      };
+    } else {
+      if (!sourceRun.parentRunId || sourceRun.parentRunId !== input.parentRunId) {
+        throw new Error('Child agent retry source does not belong to the active parent run');
+      }
+      if (!sourceRun.agentId) throw new Error('Child agent retry source is missing its agent id');
+      definition = requireResolvedAgentDefinition(sourceRun.agentId);
     }
     if (sourceRun.status !== 'failed' || sourceRun.failureClass !== 'RateLimit') {
       throw new Error('Child agent retry source must be a provider rate-limit failure');
     }
-    if (!sourceRun.agentId) throw new Error('Child agent retry source is missing its agent id');
     const existingRetry = runs.find((run) => run.retriedFromRunId === sourceRun.runId);
     if (existingRetry) {
       throw new Error(`Child agent retry source already has a successor: ${existingRetry.runId}`);
     }
 
-    const definition = requireResolvedAgentDefinition(sourceRun.agentId);
     const replaySegments: RuntimeEvent[][] = [];
     let chainRun: AgentRunHeader | undefined = rawSourceRun;
     const visited = new Set<string>();
@@ -1804,7 +2118,10 @@ export class SessionManager {
       if (visited.has(chainRun.runId))
         throw new Error('Child agent retry lineage contains a cycle');
       visited.add(chainRun.runId);
-      const events = await this.deps.runtimeEventStore.readRuntimeEvents(sessionId, chainRun.runId);
+      const events = await this.deps.runtimeEventStore.readRuntimeEvents(
+        targetSessionId,
+        chainRun.runId,
+      );
       const plan = buildResumePlanFromRuntimeEvents(events);
       if (plan.disposition !== 'safe_replay') {
         throw new Error(`Child agent retry source is not safely replayable: ${chainRun.runId}`);
@@ -1818,7 +2135,7 @@ export class SessionManager {
     }
 
     const sourceEvents = await this.deps.runtimeEventStore.readRuntimeEvents(
-      sessionId,
+      targetSessionId,
       sourceRun.runId,
     );
     const sourcePlan = buildResumePlanFromRuntimeEvents(sourceEvents);
@@ -1831,7 +2148,7 @@ export class SessionManager {
     const runId = this.deps.newId();
     const invocationId = this.deps.newId();
     const continuation: RuntimeContinuation = {
-      sessionId,
+      sessionId: targetSessionId,
       invocationId,
       runId,
       turnId,
@@ -1851,11 +2168,16 @@ export class SessionManager {
     const startedAt = this.deps.now();
     const summary = new ChildAgentSummaryAccumulator();
     let aborted = input.abortSignal?.aborted === true;
-    await input.onReady?.({ turnId, agentId: definition.id, agentName: definition.name });
+    await input.onReady?.({
+      ...(execution.kind === 'child_session' ? { childSessionId: execution.sessionId, runId } : {}),
+      turnId,
+      agentId: definition.id,
+      agentName: definition.name,
+    });
     const startChildRetry = this.runtimeKernel.startChildRetry;
     if (!startChildRetry) throw new Error('RuntimeKernel does not support child agent retry');
     const iterator = startChildRetry
-      .call(this.runtimeKernel, sessionId, {
+      .call(this.runtimeKernel, targetSessionId, {
         parentRunId: input.parentRunId,
         spec: {
           id: definition.id,
@@ -1863,14 +2185,21 @@ export class SessionManager {
           systemPrompt: definition.systemPrompt,
         },
         continuation,
+        ...(execution.kind === 'child_session' ? { linkedSession: true } : {}),
       })
       [Symbol.asyncIterator]();
+    let stopPromise: Promise<void> | undefined;
     const onAbort = () => {
       aborted = true;
-      void iterator.return?.();
+      if (execution.kind === 'child_session') {
+        stopPromise ??= this.stopSession(targetSessionId, { source: 'stop_button' });
+      } else {
+        void iterator.return?.();
+      }
     };
-    if (input.abortSignal && !input.abortSignal.aborted) {
+    if (input.abortSignal) {
       input.abortSignal.addEventListener('abort', onAbort, { once: true });
+      if (input.abortSignal.aborted) onAbort();
     }
     try {
       while (!aborted) {
@@ -1885,16 +2214,20 @@ export class SessionManager {
       }
     } finally {
       input.abortSignal?.removeEventListener('abort', onAbort);
-      if (aborted) await iterator.return?.();
+      if (aborted) {
+        await stopPromise;
+        await iterator.return?.();
+      }
     }
 
     const completedAt = this.deps.now();
-    const run = await this.findRunByTurnId(sessionId, turnId);
+    const run = await this.findRunByTurnId(targetSessionId, turnId);
     const failureClass = run?.failureClass ?? summary.failureClass;
     const artifacts = this.deps.listArtifactsForTurn
-      ? await this.deps.listArtifactsForTurn(sessionId, turnId)
+      ? await this.deps.listArtifactsForTurn(targetSessionId, turnId)
       : [];
     return {
+      ...(execution.kind === 'child_session' ? { childSessionId: execution.sessionId } : {}),
       agentId: definition.id,
       agentName: definition.name,
       turnId,

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -127,6 +127,7 @@ import {
 } from './agent-catalog.js';
 import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import { requireResolvedAgentDefinition } from './expert-catalog.js';
+import type { SubagentExecutionRef } from './subagent-execution.js';
 import {
   buildResumePlanFromRuntimeEvents,
   RuntimeContinuationPlanner,
@@ -252,18 +253,38 @@ export interface AgentListItem {
   failureClass?: string;
 }
 
+export interface SubagentExecutionListItem {
+  execution: SubagentExecutionRef;
+  agentId?: string;
+  agentName?: string;
+  profile?: string;
+  turnId?: string;
+  status: AgentRunHeader['status'];
+  permissionMode: PermissionMode;
+  createdAt: number;
+  updatedAt: number;
+  completedAt?: number;
+  durationMs?: number;
+  failureClass?: string;
+}
+
 export interface AgentListResult {
   definitions: AgentDefinitionListItem[];
+  /** Canonical mixed projection for new child Sessions and legacy same-session child AgentRuns. */
+  executions: SubagentExecutionListItem[];
+  /** Legacy projection retained while callers migrate to executions. */
   runs: AgentListItem[];
 }
 
 export interface AgentOutputInput {
+  execution?: SubagentExecutionRef;
   runId?: string;
   turnId?: string;
   maxEvents?: number;
 }
 
 export interface AgentOutputResult {
+  execution: SubagentExecutionRef;
   header: AgentRunHeader;
   events: AgentRunEvent[];
   runtimeEvents: RuntimeEvent[];
@@ -1897,7 +1918,7 @@ export class SessionManager {
       parentPermissionMode: header.permissionMode,
       tools: this.deps.childTools ?? [],
     });
-    if (!this.deps.runStore) return { definitions, runs: [] };
+    if (!this.deps.runStore) return { definitions, executions: [], runs: [] };
     const runs = await this.deps.runStore.listSessionRuns(sessionId);
     const childRuns = await Promise.all(
       runs
@@ -1912,24 +1933,91 @@ export class SessionManager {
           }),
         ),
     );
+    const legacyRuns = childRuns.map((run) => ({
+      runId: run.runId,
+      turnId: run.turnId,
+      parentRunId: run.parentRunId,
+      ...(run.agentId ? { agentId: run.agentId } : {}),
+      ...(run.agentName ? { agentName: run.agentName } : {}),
+      status: run.status,
+      permissionMode: run.permissionMode,
+      createdAt: run.createdAt,
+      updatedAt: run.updatedAt,
+      ...(run.completedAt !== undefined ? { completedAt: run.completedAt } : {}),
+      ...(run.completedAt !== undefined
+        ? { durationMs: Math.max(0, run.completedAt - run.createdAt) }
+        : {}),
+      ...(run.failureClass ? { failureClass: run.failureClass } : {}),
+    }));
+    const childSessionHeaders = await Promise.all(
+      (await this.listChildSessions(sessionId)).map((child) =>
+        this.deps.store.readHeader(child.id),
+      ),
+    );
+    const childSessionExecutions = await Promise.all(
+      childSessionHeaders.map(async (child): Promise<SubagentExecutionListItem> => {
+        const childRuns = await this.deps.runStore!.listSessionRuns(child.id);
+        const latest = childRuns
+          .slice()
+          .sort(
+            (left, right) =>
+              right.createdAt - left.createdAt ||
+              right.updatedAt - left.updatedAt ||
+              right.runId.localeCompare(left.runId),
+          )[0];
+        const run = latest ? await this.effectiveRunHeaderFromRuntimeLedger(latest) : undefined;
+        const currentRunId = run?.runId ?? child.subagentSpawn?.initialRunId;
+        return {
+          execution: {
+            kind: 'child_session',
+            sessionId: child.id,
+            ...(currentRunId ? { currentRunId } : {}),
+          },
+          ...(child.subagentRuntime?.agentId ? { agentId: child.subagentRuntime.agentId } : {}),
+          ...(child.subagentRuntime?.agentName
+            ? { agentName: child.subagentRuntime.agentName }
+            : {}),
+          ...(child.subagentRuntime?.profile ? { profile: child.subagentRuntime.profile } : {}),
+          ...(run?.turnId ? { turnId: run.turnId } : {}),
+          status: run?.status ?? (child.status === 'aborted' ? 'cancelled' : 'created'),
+          permissionMode: run?.permissionMode ?? child.permissionMode,
+          createdAt: run?.createdAt ?? child.createdAt,
+          updatedAt: run?.updatedAt ?? child.lastUsedAt,
+          ...(run?.completedAt !== undefined ? { completedAt: run.completedAt } : {}),
+          ...(run?.completedAt !== undefined
+            ? { durationMs: Math.max(0, run.completedAt - run.createdAt) }
+            : {}),
+          ...(run?.failureClass ? { failureClass: run.failureClass } : {}),
+        };
+      }),
+    );
     return {
       definitions,
-      runs: childRuns.map((run) => ({
-        runId: run.runId,
-        turnId: run.turnId,
-        parentRunId: run.parentRunId,
-        ...(run.agentId ? { agentId: run.agentId } : {}),
-        ...(run.agentName ? { agentName: run.agentName } : {}),
-        status: run.status,
-        permissionMode: run.permissionMode,
-        createdAt: run.createdAt,
-        updatedAt: run.updatedAt,
-        ...(run.completedAt !== undefined ? { completedAt: run.completedAt } : {}),
-        ...(run.completedAt !== undefined
-          ? { durationMs: Math.max(0, run.completedAt - run.createdAt) }
-          : {}),
-        ...(run.failureClass ? { failureClass: run.failureClass } : {}),
-      })),
+      executions: [
+        ...childSessionExecutions,
+        ...childRuns.map(
+          (run): SubagentExecutionListItem => ({
+            execution: {
+              kind: 'legacy_child_run',
+              sessionId,
+              runId: run.runId,
+            },
+            ...(run.agentId ? { agentId: run.agentId } : {}),
+            ...(run.agentName ? { agentName: run.agentName } : {}),
+            turnId: run.turnId,
+            status: run.status,
+            permissionMode: run.permissionMode,
+            createdAt: run.createdAt,
+            updatedAt: run.updatedAt,
+            ...(run.completedAt !== undefined ? { completedAt: run.completedAt } : {}),
+            ...(run.completedAt !== undefined
+              ? { durationMs: Math.max(0, run.completedAt - run.createdAt) }
+              : {}),
+            ...(run.failureClass ? { failureClass: run.failureClass } : {}),
+          }),
+        ),
+      ],
+      runs: legacyRuns,
     };
   }
 
@@ -1940,21 +2028,23 @@ export class SessionManager {
     if (!this.deps.runStore || !this.deps.runtimeEventStore) {
       throw new Error('agent_output requires AgentRunStore and RuntimeEventStore');
     }
-    const header = await this.findChildRunForOutput(sessionId, input);
+    const located = await this.findChildRunForOutput(sessionId, input);
+    const { header } = located;
     const inspected = await inspectAgentRunReadModel(
       this.deps.runStore,
       this.deps.runtimeEventStore,
       {
-        sessionId,
+        sessionId: header.sessionId,
         runId: header.runId,
         header,
       },
     );
     const artifacts = this.deps.listArtifactsForTurn
-      ? await this.deps.listArtifactsForTurn(sessionId, header.turnId)
+      ? await this.deps.listArtifactsForTurn(header.sessionId, header.turnId)
       : [];
     const maxEvents = normalizeAgentOutputMaxEvents(input.maxEvents);
     return {
+      execution: located.execution,
       header: inspected.header,
       events: tail(inspected.events, maxEvents),
       runtimeEvents: tail(inspected.runtimeEvents, maxEvents),
@@ -2230,17 +2320,75 @@ export class SessionManager {
   private async findChildRunForOutput(
     sessionId: string,
     input: AgentOutputInput,
-  ): Promise<AgentRunHeader> {
-    if (Number(!!input.runId) + Number(!!input.turnId) !== 1) {
-      throw new Error('agent_output requires exactly one of runId or turnId');
+  ): Promise<{ header: AgentRunHeader; execution: SubagentExecutionRef }> {
+    if (Number(!!input.execution) + Number(!!input.runId) + Number(!!input.turnId) !== 1) {
+      throw new Error('agent_output requires exactly one execution, runId, or turnId locator');
+    }
+    if (input.execution?.kind === 'child_session') {
+      const execution = input.execution;
+      const child = await this.deps.store.readHeader(execution.sessionId).catch((error) => {
+        if (isNotFoundError(error)) return undefined;
+        throw error;
+      });
+      if (
+        !child ||
+        child.subagentParent?.kind !== 'subagent' ||
+        child.subagentParent.parentSessionId !== sessionId
+      ) {
+        throw new Error('agent_output could not find the requested child session');
+      }
+      const runs = await this.deps.runStore?.listSessionRuns(child.id);
+      const selected = execution.currentRunId
+        ? runs?.find((run) => run.runId === execution.currentRunId)
+        : runs
+            ?.slice()
+            .sort(
+              (left, right) =>
+                right.createdAt - left.createdAt ||
+                right.updatedAt - left.updatedAt ||
+                right.runId.localeCompare(left.runId),
+            )[0];
+      if (!selected || !isSessionInlineRun(selected)) {
+        throw new Error('agent_output could not find the requested child session run');
+      }
+      const header = await this.effectiveRunHeaderFromRuntimeLedger(selected);
+      return {
+        header,
+        execution: {
+          kind: 'child_session',
+          sessionId: child.id,
+          currentRunId: header.runId,
+        },
+      };
+    }
+
+    const legacyExecution =
+      input.execution?.kind === 'legacy_child_run' ? input.execution : undefined;
+    if (legacyExecution && legacyExecution.sessionId !== sessionId) {
+      throw new Error('agent_output could not find the requested legacy child run');
     }
     const runs = await this.deps.runStore?.listSessionRuns(sessionId);
     const header = runs?.find((run) =>
-      input.runId ? run.runId === input.runId : input.turnId ? run.turnId === input.turnId : false,
+      legacyExecution
+        ? run.runId === legacyExecution.runId
+        : input.runId
+          ? run.runId === input.runId
+          : input.turnId
+            ? run.turnId === input.turnId
+            : false,
     );
     if (!header) throw new Error('agent_output could not find the requested child agent run');
-    if (!header.parentRunId) throw new Error('agent_output only reads child agent runs');
-    return this.effectiveRunHeaderFromRuntimeLedger(header);
+    if (!header.parentRunId || isSessionInlineRun(header)) {
+      throw new Error('agent_output only reads child agent runs');
+    }
+    return {
+      header: await this.effectiveRunHeaderFromRuntimeLedger(header),
+      execution: {
+        kind: 'legacy_child_run',
+        sessionId,
+        runId: header.runId,
+      },
+    };
   }
 
   private async effectiveRunHeaderFromRuntimeLedger(run: AgentRunHeader): Promise<AgentRunHeader> {

--- a/packages/runtime/src/subagent-execution.ts
+++ b/packages/runtime/src/subagent-execution.ts
@@ -1,0 +1,17 @@
+/**
+ * Stable compatibility handle for subagent work during the child-session migration.
+ *
+ * New work is addressed by its durable child Session. Historical child AgentRuns
+ * remain readable in the parent Session without rewriting their ledgers.
+ */
+export type SubagentExecutionRef =
+  | {
+      kind: 'child_session';
+      sessionId: string;
+      currentRunId?: string;
+    }
+  | {
+      kind: 'legacy_child_run';
+      sessionId: string;
+      runId: string;
+    };

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -147,8 +147,8 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
           `Agent profile "${definition.profile}" requires "${requestedIsolation}" workspace isolation, but this runtime does not provide a worktree child executor yet.`,
         );
       }
-      if (!ctx.spawnChildAgent) {
-        throw new Error('spawnChildAgent capability is unavailable in this runtime context');
+      if (!ctx.spawnChildSession) {
+        throw new Error('spawnChildSession capability is unavailable in this runtime context');
       }
       const boundTask = input.task_id
         ? await deps.taskLedger?.get(ctx.sessionId, input.task_id)
@@ -157,22 +157,30 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
         throw new Error('Task binding is unavailable in this runtime');
       if (input.task_id && !boundTask)
         throw new Error(`No such task in this session: ${input.task_id}`);
-      let claimedOwner: { actor: 'child_agent'; agentId: string; turnId: string } | undefined;
+      let claimedOwner:
+        | {
+            actor: 'child_agent';
+            sessionId: string;
+            agentId: string;
+            turnId: string;
+          }
+        | undefined;
       let result: Omit<SubagentToolResult, 'kind'>;
       const progress = new ChildAgentProgressProjector(ctx);
       ctx.emitOutput('stdout', `Starting child agent: ${definition.name}\n`);
       try {
-        result = (await ctx.spawnChildAgent({
-          spec: {
-            id: definition.id,
-            name: definition.name,
-            systemPrompt: definition.systemPrompt,
-          },
+        result = (await ctx.spawnChildSession({
+          agentProfile: definition.profile,
           prompt: input.task,
           ...(boundTask
             ? {
-                onReady: async ({ turnId, agentId }) => {
-                  const owner = { actor: 'child_agent' as const, agentId, turnId };
+                onReady: async ({ childSessionId, turnId, agentId }) => {
+                  const owner = {
+                    actor: 'child_agent' as const,
+                    sessionId: childSessionId,
+                    agentId,
+                    turnId,
+                  };
                   await deps.taskLedger!.claim(ctx.sessionId, boundTask.id, owner, {
                     runId: ctx.runId,
                     turnId: ctx.turnId,
@@ -308,6 +316,7 @@ export function buildSubagentListTool(): MakaTool<Record<string, never>, unknown
 
 export function buildSubagentOutputTool(): MakaTool<
   {
+    child_session_id?: string;
     run_id?: string;
     turn_id?: string;
     max_events?: number;
@@ -318,15 +327,35 @@ export function buildSubagentOutputTool(): MakaTool<
     name: AGENT_OUTPUT_TOOL_NAME,
     displayName: 'Agent Output',
     description:
-      'Inspect a child agent run by run_id or turn_id, including runtime events and artifacts.',
+      'Inspect a linked child session (optionally at run_id) or a legacy child run by run_id/turn_id, including runtime events and artifacts.',
     parameters: z
       .object({
-        run_id: z.string().optional(),
-        turn_id: z.string().optional(),
+        child_session_id: z
+          .string()
+          .min(1)
+          .optional()
+          .describe('Linked child Session id. Without run_id, inspects its latest AgentRun.'),
+        run_id: z.string().min(1).optional(),
+        turn_id: z.string().min(1).optional(),
         max_events: z.number().int().min(1).max(100).optional(),
       })
-      .refine((input) => Number(!!input.run_id) + Number(!!input.turn_id) === 1, {
-        message: 'Provide exactly one of run_id or turn_id',
+      .superRefine((input, ctx) => {
+        if (input.child_session_id) {
+          if (input.turn_id) {
+            ctx.addIssue({
+              code: z.ZodIssueCode.custom,
+              path: ['turn_id'],
+              message: 'turn_id cannot be combined with child_session_id',
+            });
+          }
+          return;
+        }
+        if (Number(!!input.run_id) + Number(!!input.turn_id) !== 1) {
+          ctx.addIssue({
+            code: z.ZodIssueCode.custom,
+            message: 'Provide child_session_id, or exactly one legacy run_id/turn_id',
+          });
+        }
       }),
     permissionRequired: false,
     categoryHint: 'read',
@@ -335,7 +364,23 @@ export function buildSubagentOutputTool(): MakaTool<
         throw new Error('readChildAgentOutput capability is unavailable in this runtime context');
       }
       return await ctx.readChildAgentOutput({
-        ...(input.run_id ? { runId: input.run_id } : {}),
+        ...(input.child_session_id
+          ? {
+              execution: {
+                kind: 'child_session' as const,
+                sessionId: input.child_session_id,
+                ...(input.run_id ? { currentRunId: input.run_id } : {}),
+              },
+            }
+          : input.run_id
+            ? {
+                execution: {
+                  kind: 'legacy_child_run' as const,
+                  sessionId: ctx.sessionId,
+                  runId: input.run_id,
+                },
+              }
+            : {}),
         ...(input.turn_id ? { turnId: input.turn_id } : {}),
         ...(input.max_events !== undefined ? { maxEvents: input.max_events } : {}),
       });

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -67,6 +67,8 @@ import {
   type ToolRecoveryMode,
 } from './runtime-commit-sink.js';
 import { ChildAgentRunLimiter } from './child-agent-run-limiter.js';
+import type { AgentProfile } from './agent-catalog.js';
+import type { SubagentExecutionRef } from './subagent-execution.js';
 import { serializeSandboxError } from './sandbox/errors.js';
 
 export type ToolModelOutputPart =
@@ -178,6 +180,25 @@ export interface MakaToolContext {
     }) => void | Promise<void>;
     onEvent?: (event: SessionEvent) => void;
   }) => Promise<unknown>;
+  spawnChildSession?: (input: {
+    agentProfile: AgentProfile;
+    prompt: string;
+    /** Optional swarm identity, scoped to the owning tool call. */
+    swarm?: {
+      swarmId: string;
+      itemId: string;
+    };
+    /** Optional per-child signal, always composed with the owning tool invocation signal. */
+    abortSignal?: AbortSignal;
+    onReady?: (input: {
+      childSessionId: string;
+      turnId: string;
+      runId: string;
+      agentId: string;
+      agentName: string;
+    }) => void | Promise<void>;
+    onEvent?: (event: SessionEvent) => void;
+  }) => Promise<unknown>;
   prepareChildAgentResume?: (sourceRunId: string) => Promise<{
     sourceRunId: string;
     agentId: string;
@@ -209,6 +230,7 @@ export interface MakaToolContext {
   }) => Promise<unknown>;
   listChildAgents?: () => Promise<unknown>;
   readChildAgentOutput?: (input: {
+    execution?: SubagentExecutionRef;
     runId?: string;
     turnId?: string;
     maxEvents?: number;
@@ -303,6 +325,26 @@ export interface ToolRuntimeInput {
     }) => void | Promise<void>;
     onEvent?: (event: SessionEvent) => void;
   }) => Promise<unknown>;
+  spawnChildSession?: (input: {
+    parentRunId: string;
+    parentTurnId: string;
+    toolCallId: string;
+    agentProfile: AgentProfile;
+    prompt: string;
+    swarm?: {
+      swarmId: string;
+      itemId: string;
+    };
+    abortSignal: AbortSignal;
+    onReady?: (input: {
+      childSessionId: string;
+      turnId: string;
+      runId: string;
+      agentId: string;
+      agentName: string;
+    }) => void | Promise<void>;
+    onEvent?: (event: SessionEvent) => void;
+  }) => Promise<unknown>;
   prepareChildAgentResume?: (sourceRunId: string) => Promise<{
     sourceRunId: string;
     agentId: string;
@@ -334,6 +376,7 @@ export interface ToolRuntimeInput {
   }) => Promise<unknown>;
   listChildAgents?: () => Promise<unknown>;
   readChildAgentOutput?: (input: {
+    execution?: SubagentExecutionRef;
     runId?: string;
     turnId?: string;
     maxEvents?: number;
@@ -1317,6 +1360,7 @@ export class ToolRuntime {
             ? { readChildAgentOutput: this.input.readChildAgentOutput }
             : {}),
           ...this.buildChildAgentContext({
+            turnId,
             abortSignal: ctx.abortSignal,
             trace,
             toolUseId,
@@ -1770,19 +1814,24 @@ export class ToolRuntime {
   }
 
   private buildChildAgentContext(input: {
+    turnId: string;
     abortSignal: AbortSignal;
     trace: RunTraceLike | null;
     toolUseId: string;
     toolName: string;
   }): Pick<
     MakaToolContext,
-    'spawnChildAgent' | 'prepareChildAgentResume' | 'resumeChildAgent' | 'retryChildAgent'
+    | 'spawnChildAgent'
+    | 'spawnChildSession'
+    | 'prepareChildAgentResume'
+    | 'resumeChildAgent'
+    | 'retryChildAgent'
   > {
     const parentRunId = this.input.getCurrentRunId?.();
     if (!parentRunId) return {};
     const limiter = this.childAgentRunLimiter;
     const runWithPermit = async <T>(
-      mode: 'spawn' | 'resume' | 'retry',
+      mode: 'spawn' | 'spawn_session' | 'resume' | 'retry',
       abortSignal: AbortSignal,
       execute: () => Promise<T>,
     ): Promise<T> => {
@@ -1864,6 +1913,7 @@ export class ToolRuntime {
     };
 
     const spawnChildAgent = this.input.spawnChildAgent;
+    const spawnChildSession = this.input.spawnChildSession;
     const prepareChildAgentResume = this.input.prepareChildAgentResume;
     const resumeChildAgent = this.input.resumeChildAgent;
     const retryChildAgent = this.input.retryChildAgent;
@@ -1883,6 +1933,32 @@ export class ToolRuntime {
                     parentRunId,
                     spec: spawnInput.spec,
                     prompt: spawnInput.prompt,
+                    abortSignal,
+                    ...(spawnInput.onReady ? { onReady: spawnInput.onReady } : {}),
+                    ...(spawnInput.onEvent ? { onEvent: spawnInput.onEvent } : {}),
+                  }),
+              );
+            },
+          }
+        : {}),
+      ...(spawnChildSession
+        ? {
+            spawnChildSession: async (spawnInput) => {
+              const abortSignal = composeChildAbortSignal(
+                input.abortSignal,
+                spawnInput.abortSignal,
+              );
+              return await runWithPermit(
+                'spawn_session',
+                abortSignal,
+                async () =>
+                  await spawnChildSession({
+                    parentRunId,
+                    parentTurnId: input.turnId,
+                    toolCallId: input.toolUseId,
+                    agentProfile: spawnInput.agentProfile,
+                    prompt: spawnInput.prompt,
+                    ...(spawnInput.swarm ? { swarm: spawnInput.swarm } : {}),
                     abortSignal,
                     ...(spawnInput.onReady ? { onReady: spawnInput.onReady } : {}),
                     ...(spawnInput.onEvent ? { onEvent: spawnInput.onEvent } : {}),

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -201,6 +201,7 @@ export interface MakaToolContext {
   }) => Promise<unknown>;
   prepareChildAgentResume?: (sourceRunId: string) => Promise<{
     sourceRunId: string;
+    execution: SubagentExecutionRef;
     agentId: string;
     agentName: string;
     profile: string;
@@ -211,7 +212,9 @@ export interface MakaToolContext {
     /** Optional per-child signal, always composed with the owning tool invocation signal. */
     abortSignal?: AbortSignal;
     onReady?: (input: {
+      childSessionId?: string;
       turnId: string;
+      runId?: string;
       agentId: string;
       agentName: string;
     }) => void | Promise<void>;
@@ -219,10 +222,13 @@ export interface MakaToolContext {
   }) => Promise<unknown>;
   retryChildAgent?: (input: {
     sourceRunId: string;
+    execution?: SubagentExecutionRef;
     /** Optional per-child signal, always composed with the owning tool invocation signal. */
     abortSignal?: AbortSignal;
     onReady?: (input: {
+      childSessionId?: string;
       turnId: string;
+      runId?: string;
       agentId: string;
       agentName: string;
     }) => void | Promise<void>;
@@ -347,6 +353,7 @@ export interface ToolRuntimeInput {
   }) => Promise<unknown>;
   prepareChildAgentResume?: (sourceRunId: string) => Promise<{
     sourceRunId: string;
+    execution: SubagentExecutionRef;
     agentId: string;
     agentName: string;
     profile: string;
@@ -357,7 +364,9 @@ export interface ToolRuntimeInput {
     prompt: string;
     abortSignal: AbortSignal;
     onReady?: (input: {
+      childSessionId?: string;
       turnId: string;
+      runId?: string;
       agentId: string;
       agentName: string;
     }) => void | Promise<void>;
@@ -366,9 +375,12 @@ export interface ToolRuntimeInput {
   retryChildAgent?: (input: {
     parentRunId: string;
     sourceRunId: string;
+    execution?: SubagentExecutionRef;
     abortSignal: AbortSignal;
     onReady?: (input: {
+      childSessionId?: string;
       turnId: string;
+      runId?: string;
       agentId: string;
       agentName: string;
     }) => void | Promise<void>;
@@ -2007,6 +2019,7 @@ export class ToolRuntime {
                   await retryChildAgent({
                     parentRunId,
                     sourceRunId: retryInput.sourceRunId,
+                    ...(retryInput.execution ? { execution: retryInput.execution } : {}),
                     abortSignal,
                     ...(retryInput.onReady ? { onReady: retryInput.onReady } : {}),
                     ...(retryInput.onEvent ? { onEvent: retryInput.onEvent } : {}),

--- a/packages/storage/src/__tests__/task-ledger-store.test.ts
+++ b/packages/storage/src/__tests__/task-ledger-store.test.ts
@@ -723,7 +723,20 @@ describe('TaskLedgerStore', () => {
     await writeFile(
       tasksFilePath(root),
       JSON.stringify([
-        { id: 'legacy-task', subject: 'old task', status: 'pending', createdAt: 1, updatedAt: 1 },
+        {
+          id: 'legacy-task',
+          subject: 'old task',
+          status: 'pending',
+          createdAt: 1,
+          updatedAt: 1,
+          owner: {
+            actor: 'child_agent',
+            sessionId: 'child-session',
+            agentId: 'local-read',
+            runId: 'child-run',
+            turnId: 'child-turn',
+          },
+        },
       ]),
       'utf8',
     );
@@ -732,6 +745,13 @@ describe('TaskLedgerStore', () => {
       tasks.map((t) => t.id),
       ['legacy-task'],
     );
+    assert.deepEqual(tasks[0]?.owner, {
+      actor: 'child_agent',
+      sessionId: 'child-session',
+      agentId: 'local-read',
+      runId: 'child-run',
+      turnId: 'child-turn',
+    });
   });
 
   it('imports legacy tasks into the event log before appending the first create', async () => {

--- a/packages/storage/src/task-ledger-store.ts
+++ b/packages/storage/src/task-ledger-store.ts
@@ -759,6 +759,7 @@ function normalizeOptionalOwner(value: unknown): Pick<Task, 'owner'> | Record<st
   return {
     owner: {
       actor: owner.actor,
+      ...(owner.sessionId ? { sessionId: owner.sessionId } : {}),
       ...(owner.agentId ? { agentId: owner.agentId } : {}),
       ...(owner.runId ? { runId: owner.runId } : {}),
       ...(owner.turnId ? { turnId: owner.turnId } : {}),


### PR DESCRIPTION
## Summary

- Route fresh `agent_spawn` calls and new `agent_swarm` items through the linked child-session primitive introduced in PR #1376.
- Preserve the existing foreground/synchronous parent tool boundary, cancellation propagation, bounded concurrency, input ordering, and swarm all-settled behavior.
- Add a canonical `SubagentExecutionRef` and mixed `agent_list` / `agent_output` read model so child sessions are addressed by `childSessionId`, while legacy same-session child runs remain inspectable by `runId`.
- Return both `childSessionId` and `runId` for newly spawned children, persist child-session task ownership plus swarm/item lineage, and wire the dedicated capability through Desktop, CLI/TUI, and headless hosts.

## Continuation and compatibility

- `resume_run_ids` now resolves a returned `runId` to either a legacy same-session child run or a linked child Session. A fresh swarm child is continued by creating a new session-inline AgentRun in that same child Session, with durable `resumedFromRunId` lineage.
- Adaptive provider-rate-limit recovery is preserved for fresh child sessions. Each retry creates another AgentRun in the same child Session, records `retriedFromRunId`, reuses the durable child runtime snapshot, and keeps the resulting `childSessionId + runId` consumable by later `resume_run_ids` calls.
- `agent_list.runs` remains the legacy projection; `agent_list.executions` is the canonical mixed child-session / legacy-run view and projects the latest child-session run as `currentRunId`.
- Legacy `tasks.json` import and recovery now preserve `TaskOwner.sessionId` alongside the JSONL event-ledger copy.
- New child creation keeps the current **fresh** context semantics. The proposed `contextMode: "fork"` is intentionally not exposed yet: it needs explicit model-input snapshot semantics, artifact/checkpoint handling, and distinct fork provenance rather than pretending that fresh child creation already provides those guarantees.
- This is PR 3 in the implementation sequence for #1366. Broader host-level multi-turn UX remains follow-up work.

## Validation

- `npm run lint`
- `npm run format:check`
- `npm run build`
- `npm --workspace @maka/storage test`
- Focused runtime suites — 270 passed
- Focused storage fallback regression — passed

Refs #1366

<details>
<summary>中文说明</summary>

## 概要

- 将新的 `agent_spawn` 和 `agent_swarm` fresh item 切换到 PR #1376 引入的关联 child session runtime primitive。
- 保持父 tool call 前台同步等待、取消传播、有界并发、输入顺序和 swarm all-settled 语义不变。
- 引入统一的 `SubagentExecutionRef` 与混合 `agent_list` / `agent_output` 读模型：新的 child session 使用 `childSessionId` 定位，旧的同 session child run 继续使用 `runId` 查询。
- 新建子 agent 返回 `childSessionId + runId`，持久化 task owner 的 child session 引用与 swarm/item lineage，并完成 Desktop、CLI/TUI、headless host 的能力接线。

## Continuation 与兼容性

- `resume_run_ids` 现在会把返回的 `runId` 解析为 legacy same-session child run 或 linked child Session。fresh swarm child 会在同一个 child Session 内创建新的 session-inline AgentRun，并持久化 `resumedFromRunId` lineage。
- fresh child session 保留自适应 RateLimit 恢复：每次 retry 都在同一个 child Session 内创建新 AgentRun，记录 `retriedFromRunId`，复用 durable child runtime snapshot，并让最终的 `childSessionId + runId` 仍可继续交给后续 `resume_run_ids`。
- `agent_list.runs` 保留为 legacy projection；`agent_list.executions` 是 child session 与 legacy run 的规范混合视图，并把 child session 最新的 run 投影为 `currentRunId`。
- legacy `tasks.json` 导入和恢复现在会保留 `TaskOwner.sessionId`，与 JSONL event ledger 中的元数据副本一致。
- 新 child 只实现当前的 **fresh** 上下文语义。讨论中的 `contextMode: "fork"` 暂不暴露，因为它需要明确的模型输入快照、artifact/checkpoint 处理和独立的 fork provenance。
- 这是 #1366 实现序列中的 PR 3；更完整的 host 多轮交互 UX 留给后续 PR。

## 验证

- `npm run lint`
- `npm run format:check`
- `npm run build`
- Storage 全量测试
- Runtime 相关测试：270 passed
- Storage fallback 回归测试通过

</details>
