### PR TITLE
fix(desktop): align Skill host capabilities

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -43,6 +43,8 @@ async function seedE2eInvocableSkills(userDataDir: string): Promise<void> {
   await Promise.all([
     mkdir(path.join(projectSkillRoot, 'project-only'), { recursive: true }),
     mkdir(path.join(projectSkillRoot, 'host-incompatible'), { recursive: true }),
+    mkdir(path.join(projectSkillRoot, 'agent-write'), { recursive: true }),
+    mkdir(path.join(projectSkillRoot, 'deep-research-only'), { recursive: true }),
     mkdir(path.join(workspaceSkillRoot, 'workspace-only'), { recursive: true }),
   ]);
   await Promise.all([
@@ -54,6 +56,16 @@ async function seedE2eInvocableSkills(userDataDir: string): Promise<void> {
     writeFile(
       path.join(projectSkillRoot, 'host-incompatible', 'SKILL.md'),
       `---\nname: Host Incompatible\ndescription: Must be hidden from this host.\nrequired-tools: [DefinitelyMissingTool]\n---\n# Host Incompatible`,
+      'utf8',
+    ),
+    writeFile(
+      path.join(projectSkillRoot, 'agent-write', 'SKILL.md'),
+      `---\nname: Agent Write\ndescription: Requires a mutating tool excluded from Plan mode.\nrequired-tools: [Write]\n---\n# Agent Write`,
+      'utf8',
+    ),
+    writeFile(
+      path.join(projectSkillRoot, 'deep-research-only', 'SKILL.md'),
+      `---\nname: Deep Research Only\ndescription: Requires a tool available only in Deep Research mode.\nrequired-tools: [deep_research_status]\n---\n# Deep Research Only`,
       'utf8',
     ),
     writeFile(

--- a/apps/desktop/e2e/onboarding-skill-invocation.spec.ts
+++ b/apps/desktop/e2e/onboarding-skill-invocation.spec.ts
@@ -49,7 +49,65 @@ test('slash suggestions follow Runtime project discovery and host gating', async
   await expect(listbox).toBeVisible();
   await expect(listbox).toContainText('Project Only');
   await expect(listbox).toContainText('Workspace Only');
+  await expect(listbox).toContainText('Agent Write');
   await expect(listbox).not.toContainText('Host Incompatible');
+
+  const planNames = await page.evaluate(async () =>
+    (await window.maka.skills.listInvocable(undefined, {
+      collaborationMode: 'plan',
+    })).map((skill) => skill.name),
+  );
+  expect(planNames).not.toContain('Agent Write');
+});
+
+test('ready-empty slash suggestions follow the selected Deep Research mode', async ({
+  invocableSkillsWindow: page,
+}) => {
+  const quickChat = page.locator('.maka-onboarding-quickchat-input');
+  const listbox = page.getByRole('listbox', { name: '技能' });
+
+  await quickChat.fill('/');
+  await expect(listbox).toBeVisible();
+  await expect(listbox).not.toContainText('Deep Research Only');
+  await quickChat.fill('');
+
+  await page.getByRole('button', { name: '深度研究一个项目' }).click();
+  await expect(page.getByText('深度研究 · 只读分析')).toBeVisible();
+  await quickChat.fill('/');
+  await expect(listbox).toContainText('Deep Research Only');
+});
+
+test('open Skill suggestions follow current collaboration capabilities', async ({
+  invocableSkillsWindow: page,
+}) => {
+  const quickChat = page.locator('.maka-onboarding-quickchat-input');
+  await quickChat.fill('Open a session');
+  await quickChat.press('Enter');
+  const composer = page.getByRole('textbox', { name: '消息输入框' });
+  await expect(composer).toBeVisible();
+  const [session] = await page.evaluate(() => window.maka.sessions.list());
+  if (!session) throw new Error('Quick Chat did not create a session');
+
+  const listNames = (sessionId: string) =>
+    page.evaluate(
+      async (id) => (await window.maka.skills.listInvocable(id)).map((skill) => skill.name),
+      sessionId,
+    );
+
+  await expect.poll(() => listNames(session.id)).toContain('Agent Write');
+  await composer.fill('/');
+  const listbox = page.getByRole('listbox', { name: '技能' });
+  await expect(listbox).toContainText('Agent Write');
+
+  await expect
+    .poll(async () => (await page.evaluate(() => window.maka.sessions.list()))[0]?.status)
+    .not.toBe('running');
+  await page.evaluate(
+    ({ sessionId }) => window.maka.sessions.setCollaborationMode(sessionId, 'plan'),
+    { sessionId: session.id },
+  );
+  await expect.poll(() => listNames(session.id)).not.toContain('Agent Write');
+  await expect(listbox).not.toContainText('Agent Write');
 });
 
 test('chip-only send renders a readable user message', async ({ window: page }) => {

--- a/apps/desktop/src/main/__tests__/agent-team-collaboration-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-team-collaboration-contract.test.ts
@@ -4,7 +4,8 @@ import { readMainProcessCombinedSource } from './main-process-contract-source-he
 
 // The lead/child team tool builders and the childAgentTools surface moved into
 // tool-assembly.ts (arch R4); the expert-dispatch + agentTeam backend wiring
-// stays in main.ts. Reading the combined main-process source keeps every
+// now lives in the shared backend tool-surface resolver. Reading the combined
+// main-process source keeps every
 // assertion intact across both files.
 describe('desktop agent-team collaboration wiring', () => {
   it('shares one durable mailbox/task ledger across lead and child tools', async () => {
@@ -22,9 +23,9 @@ describe('desktop agent-team collaboration wiring', () => {
     assert.match(main, /const childAgentTools = buildChildAgentTools\([\s\S]*?\.\.\.agentTeamChildTools/);
     assert.match(
       main,
-      /buildExpertDispatchToolForTeamId\(expertTeamId, \{ taskLedger: taskLedgerStore \}\)/,
+      /buildExpertDispatchToolForTeamId\(expertTeamId, \{[\s\S]*?taskLedger: deps\.taskLedgerStore/,
     );
-    assert.match(main, /tools: expertDispatchTool[\s\S]*?\.\.\.agentTeamLeadTools/);
+    assert.match(main, /tools: expertDispatchTool[\s\S]*?\.\.\.deps\.agentTeamLeadTools/);
     assert.match(main, /agentTeam,/);
   });
 });

--- a/apps/desktop/src/main/__tests__/deep-research-workspace-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/deep-research-workspace-contract.test.ts
@@ -13,15 +13,15 @@ describe('Deep Research durable workspace wiring', () => {
       fileURLToPath(new URL('../../../src/main/tool-assembly.ts', import.meta.url)),
       'utf8',
     );
-    const sessionStream = await readFile(
-      fileURLToPath(new URL('../../../src/main/session-stream.ts', import.meta.url)),
+    const backendToolSurface = await readFile(
+      fileURLToPath(new URL('../../../src/main/desktop-backend-tool-surface.ts', import.meta.url)),
       'utf8',
     );
     const builtinTools = toolAssembly.match(
       /const builtinTools: MakaTool\[\] = \[[\s\S]*?\n\];/,
     )?.[0] ?? '';
-    const candidateTools = sessionStream.match(
-      /const candidateTools = ctx\.tools[\s\S]*?const candidateToolAvailability/,
+    const candidateTools = backendToolSurface.match(
+      /const candidateTools = input\.tools[\s\S]*?const candidateToolAvailability/,
     )?.[0] ?? '';
     const preload = await readFile(
       fileURLToPath(new URL('../../../src/preload/preload.ts', import.meta.url)),
@@ -45,7 +45,7 @@ describe('Deep Research durable workspace wiring', () => {
     );
     assert.match(
       candidateTools,
-      /ctx\.tools\s*\?\s*\[\.\.\.ctx\.tools\]\s*:\s*isComputerUseRealModelE2e[\s\S]*isDeepResearchSession\(ctx\.header\.labels\) \? deepResearchTools : \[\]/,
+      /input\.tools\s*\?\s*\[\.\.\.input\.tools\]\s*:\s*deps\.isComputerUseRealModelE2e[\s\S]*isDeepResearchSession\(input\.header\.labels\) \? deps\.deepResearchTools : \[\]/,
       'child tool scopes must win before computer-use and root-only Deep Research expansion',
     );
   });

--- a/apps/desktop/src/main/__tests__/desktop-backend-tool-surface.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-backend-tool-surface.test.ts
@@ -1,0 +1,279 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { LlmConnection, SessionHeader, TaskLedgerStore } from '@maka/core';
+import { emptyPlanSessionState, type PlanStore } from '@maka/core/plan';
+import type { McpClientManager } from '@maka/mcp';
+import type { MakaTool, ToolAvailabilityConfig } from '@maka/runtime';
+import {
+  resolveDesktopBackendToolSurface,
+  resolveDesktopNewSessionSkillHost,
+  resolveDesktopSessionSkillHost,
+  type DesktopBackendToolSurfaceDeps,
+} from '../desktop-backend-tool-surface.js';
+
+const readTool = tool('Read', 'read');
+const writeTool = tool('Write', 'file_write');
+const computerTool = tool('maka_computer', 'computer_use');
+const availability: ToolAvailabilityConfig = {
+  economy: true,
+  groups: [
+    { id: 'files', toolNames: ['Read', 'Write'] },
+    { id: 'computer_use', toolNames: ['maka_computer'] },
+  ],
+};
+
+describe('Desktop backend tool surface', () => {
+  it('derives model-gated Skill capabilities from the current session header', async () => {
+    const deps = makeDeps();
+
+    const visual = await resolveDesktopBackendToolSurface(
+      deps,
+      inputFor('claude-sonnet-4-5-20250929'),
+    );
+    assert.equal(visual.supportsVision, true);
+    assert.equal(visual.skillHost.toolNames.has('maka_computer'), true);
+    assert.equal(
+      visual.toolAvailability.groups?.some((group) => group.id === 'computer_use'),
+      true,
+    );
+
+    const textOnly = await resolveDesktopBackendToolSurface(
+      deps,
+      inputFor('text-only-e2e'),
+    );
+    assert.equal(textOnly.supportsVision, false);
+    assert.equal(textOnly.skillHost.toolNames.has('maka_computer'), false);
+    assert.equal(
+      textOnly.toolAvailability.groups?.some((group) => group.id === 'computer_use'),
+      false,
+    );
+  });
+
+  it('derives collaboration-gated Skill capabilities from the current session header', async () => {
+    const deps = makeDeps();
+    const agent = await resolveDesktopBackendToolSurface(
+      deps,
+      inputFor('claude-sonnet-4-5-20250929', 'agent'),
+    );
+    assert.equal(agent.skillHost.toolNames.has('Read'), true);
+    assert.equal(agent.skillHost.toolNames.has('Write'), true);
+    assert.equal(agent.skillHost.toolNames.has('SubmitPlan'), false);
+
+    const plan = await resolveDesktopBackendToolSurface(
+      deps,
+      inputFor('claude-sonnet-4-5-20250929', 'plan'),
+    );
+    assert.equal(plan.skillHost.toolNames.has('Read'), true);
+    assert.equal(plan.skillHost.toolNames.has('Write'), false);
+    assert.equal(plan.skillHost.toolNames.has('SubmitPlan'), true);
+  });
+
+  it('keeps MCP readiness fail-open while deriving builtin capabilities', async () => {
+    let readinessCalls = 0;
+    const deps = makeDeps({
+      ensureMcpReady: async () => {
+        readinessCalls += 1;
+        throw new Error('invalid mcp config');
+      },
+    });
+
+    const surface = await resolveDesktopBackendToolSurface(
+      deps,
+      inputFor('claude-sonnet-4-5-20250929'),
+    );
+    assert.equal(readinessCalls, 1);
+    assert.equal(surface.skillHost.toolNames.has('Read'), true);
+    assert.equal(surface.skillHost.toolNames.has('Write'), true);
+  });
+
+  it('keeps expert-team tools on the parent surface and scoped child tools isolated', async () => {
+    const deps = makeDeps({
+      agentTeamLeadTools: [tool('team_message', 'custom_tool')],
+    });
+    const parentInput = inputFor('claude-sonnet-4-5-20250929');
+    parentInput.header.labels = ['mode:expert-team:code-review'];
+    const parent = await resolveDesktopBackendToolSurface(deps, parentInput);
+    assert.equal(parent.skillHost.toolNames.has('expert_dispatch'), true);
+    assert.equal(parent.skillHost.toolNames.has('team_message'), true);
+
+    const child = await resolveDesktopBackendToolSurface(deps, {
+      ...parentInput,
+      tools: [readTool],
+      agentTeam: {
+        role: 'member',
+        teamId: 'code-review',
+        agentId: 'correctness-reviewer',
+        parentRunId: 'run-1',
+      },
+    });
+    assert.deepEqual([...child.skillHost.toolNames], ['Read']);
+  });
+
+  it('keeps scoped child tools ahead of root-only computer-use and Plan controls', async () => {
+    const deps = makeDeps({ isComputerUseRealModelE2e: true });
+    const input = inputFor('claude-sonnet-4-5-20250929', 'plan');
+
+    const child = await resolveDesktopBackendToolSurface(deps, {
+      ...input,
+      tools: [readTool],
+      agentTeam: {
+        role: 'member',
+        teamId: 'plan-team',
+        agentId: 'researcher',
+        parentRunId: 'run-1',
+      },
+    });
+
+    assert.deepEqual([...child.skillHost.toolNames], ['Read']);
+    assert.equal(child.skillHost.toolNames.has('maka_computer'), false);
+    assert.equal(child.skillHost.toolNames.has('SubmitPlan'), false);
+  });
+
+  it('uses the durable child snapshot for the persisted-session Skill host', async () => {
+    const header = inputFor('claude-sonnet-4-5-20250929').header;
+    header.subagentParent = {} as SessionHeader['subagentParent'];
+    header.subagentRuntime = {
+      schemaVersion: 1,
+      definitionVersion: 1,
+      agentId: 'read-only-child',
+      agentName: 'Read-only child',
+      profile: 'local_read',
+      systemPrompt: 'Read only.',
+      toolNames: ['Read'],
+      categoryPolicy: { read: 'allow' },
+      permissionCeiling: 'ask',
+    };
+
+    const host = await resolveDesktopSessionSkillHost(makeDeps(), {
+      sessionId: header.id,
+      header,
+      childTools: [readTool, writeTool],
+    });
+
+    assert.deepEqual([...host.toolNames], ['Read']);
+    assert.equal(host.toolNames.has('Write'), false);
+  });
+
+  it('includes Deep Research tools in the ready-empty Skill preview only for that mode', async () => {
+    const deepResearchTool = tool('deep_research_status', 'read');
+    const deps = makeDeps({ deepResearchTools: [deepResearchTool] });
+    const readyConnection = {
+      connection: connectionFor('claude-sonnet-4-5-20250929'),
+      apiKey: 'preview-key',
+      model: 'claude-sonnet-4-5-20250929',
+    };
+
+    const regular = await resolveDesktopNewSessionSkillHost(deps, {
+      projectRoot: '/tmp/project',
+      workspaceRoot: '/tmp/workspace',
+      readyConnection,
+      context: { mode: 'chat' },
+    });
+    const deepResearch = await resolveDesktopNewSessionSkillHost(deps, {
+      projectRoot: '/tmp/project',
+      workspaceRoot: '/tmp/workspace',
+      readyConnection,
+      context: { mode: 'deep_research' },
+    });
+
+    assert.equal(regular.toolNames.has('deep_research_status'), false);
+    assert.equal(deepResearch.toolNames.has('deep_research_status'), true);
+  });
+
+  it('uses explicit preview inputs without reading a nonexistent session plan', async () => {
+    let connectionReads = 0;
+    let planReads = 0;
+    const deps = makeDeps({
+      getReadyConnection: async () => {
+        connectionReads += 1;
+        throw new Error('preview must reuse its resolved connection');
+      },
+      planStore: {
+        readState: async () => {
+          planReads += 1;
+          throw new Error('preview must reuse its empty plan state');
+        },
+      } as unknown as PlanStore,
+    });
+    const input = inputFor('claude-sonnet-4-5-20250929', 'plan');
+    const surface = await resolveDesktopBackendToolSurface(deps, {
+      ...input,
+      readyConnection: {
+        connection: connectionFor('claude-sonnet-4-5-20250929'),
+        apiKey: 'preview-key',
+        model: 'claude-sonnet-4-5-20250929',
+      },
+      planState: emptyPlanSessionState(input.sessionId),
+    });
+
+    assert.equal(connectionReads, 0);
+    assert.equal(planReads, 0);
+    assert.equal(surface.skillHost.toolNames.has('Write'), false);
+    assert.equal(surface.skillHost.toolNames.has('SubmitPlan'), true);
+  });
+});
+
+function makeDeps(
+  overrides: Partial<DesktopBackendToolSurfaceDeps> = {},
+): DesktopBackendToolSurfaceDeps {
+  const planStore = {
+    readState: async (sessionId: string) => emptyPlanSessionState(sessionId),
+  } as PlanStore;
+  return {
+    isComputerUseRealModelE2e: false,
+    ensureMcpReady: async () => {},
+    getReadyConnection: async (_slug, model) => ({
+      connection: connectionFor(model ?? 'claude-sonnet-4-5-20250929'),
+      apiKey: 'test-key',
+      model: model ?? 'claude-sonnet-4-5-20250929',
+    }),
+    mcpManager: { tools: () => [] } as unknown as McpClientManager,
+    taskLedgerStore: {} as TaskLedgerStore,
+    deepResearchTools: [],
+    computerUseTools: [computerTool],
+    agentTeamLeadTools: [],
+    builtinTools: [readTool, writeTool, computerTool],
+    toolAvailability: availability,
+    planStore,
+    ...overrides,
+  };
+}
+
+function inputFor(
+  model: string,
+  collaborationMode: 'agent' | 'plan' = 'agent',
+) {
+  return {
+    sessionId: 'session-1',
+    header: {
+      id: 'session-1',
+      cwd: '/tmp/project',
+      workspaceRoot: '/tmp/workspace',
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'connection-1',
+      model,
+      collaborationMode,
+      permissionMode: 'ask',
+      labels: [],
+    } as unknown as SessionHeader,
+  };
+}
+
+function connectionFor(model: string): LlmConnection {
+  return {
+    slug: 'connection-1',
+    name: 'Connection',
+    providerType: 'anthropic',
+    defaultModel: model,
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function tool(
+  name: string,
+  categoryHint: MakaTool['categoryHint'],
+): MakaTool {
+  return { name, categoryHint } as MakaTool;
+}

--- a/apps/desktop/src/main/__tests__/desktop-skill-invocation-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-skill-invocation-contract.test.ts
@@ -69,11 +69,37 @@ describe('Desktop explicit Skill invocation contract', () => {
 
   it('uses the same session project root and host for resolution and slash suggestions', async () => {
     const main = await read('apps/desktop/src/main/main.ts');
+    const desktopToolSurface = await read(
+      'apps/desktop/src/main/desktop-backend-tool-surface.ts',
+    );
+    const sessionStream = await read('apps/desktop/src/main/session-stream.ts');
     const workspaceIpc = await read('apps/desktop/src/main/workspace-resources-ipc-main.ts');
     const preload = await read('apps/desktop/src/preload/preload.ts');
     const mentions = await read('apps/desktop/src/renderer/use-composer-mentions.ts');
     assert.match(main, /resolveSkillDiscoveryPaths\([\s\S]*resolveProjectRootForContext\(sessionId\)[\s\S]*workspaceRoot/);
-    assert.match(main, /desktopSessionSkillHosts\.get\(sessionId\) \?\? desktopHostCapabilities/);
+    assert.match(main, /resolveDesktopSkillHostForSession\(sessionId\)/);
+    assert.match(main, /resolveDesktopSkillHostForNewSession\(projectRoot, newSessionContext\)/);
+    assert.match(
+      main,
+      /resolveDesktopSessionSkillHost\(desktopBackendToolSurfaceDeps, \{[\s\S]*header,[\s\S]*childTools: childAgentTools/,
+    );
+    assert.match(
+      main,
+      /resolveDesktopNewSessionSkillHost\(desktopBackendToolSurfaceDeps, \{[\s\S]*context,/,
+    );
+    assert.match(
+      desktopToolSurface,
+      /resolveDesktopBackendToolSurface\(deps, \{[\s\S]*header: input\.header,[\s\S]*\{ tools \}/,
+    );
+    assert.match(
+      desktopToolSurface,
+      /input\.context\?\.mode === 'deep_research'[\s\S]*labels: deepResearch \? \[DEEP_RESEARCH_SESSION_LABEL\]/,
+    );
+    assert.doesNotMatch(
+      main,
+      /host: desktopSessionSkillHosts\.get\(sessionId\) \?\? desktopHostCapabilities/,
+    );
+    assert.match(sessionStream, /resolveDesktopBackendToolSurface\(deps, ctx\)/);
     assert.doesNotMatch(main, /resolveDesktopSkillDiscoverySource/);
     assert.match(main, /listInvocableSkills: listDesktopInvocableSkills/);
     assert.match(
@@ -81,9 +107,14 @@ describe('Desktop explicit Skill invocation contract', () => {
       /if \(sessionId && isSessionWorkspaceUnavailableError\(error\)\) return \[\]/,
       'stale sessions must fail soft without rejected Skill-list IPC noise',
     );
-    assert.match(workspaceIpc, /ipcMain\.handle\('skills:listInvocable'[\s\S]*deps\.listInvocableSkills/);
-    assert.match(preload, /listInvocable\(sessionId\?: string\)[\s\S]*skills:listInvocable/);
-    assert.match(mentions, /window\.maka\.skills\.listInvocable\(sessionId\)/);
+    assert.match(workspaceIpc, /'skills:listInvocable'[\s\S]*deps\.listInvocableSkills/);
+    assert.match(preload, /listInvocable\([\s\S]*newSessionContext[\s\S]*skills:listInvocable/);
+    assert.match(
+      mentions,
+      /window\.maka\.skills\.listInvocable\(\s*sessionId,\s*sessionId/,
+    );
+    assert.match(mentions, /window\.maka\.sessions\.subscribeChanges\(\(event\) =>/);
+    assert.match(mentions, /window\.maka\.mcp\.subscribeChanges\(\(\) => refresh\(\)\)/);
     assert.doesNotMatch(mentions, /filter\(\(skill\) => skill\.enabled/);
   });
 

--- a/apps/desktop/src/main/__tests__/ipc-surface-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-surface-contract.test.ts
@@ -69,8 +69,8 @@ describe('IPC surface contract', () => {
     assert.match(main, /new LocalMemoryService\([\s\S]*getPrivacyContext: getWorkspacePrivacyContext/);
     assert.doesNotMatch(main, /defaultWorkspacePrivacyContext/);
 
-    // The ai-sdk backend wiring moved into session-stream.ts (arch R5); these two
-    // pins now target the combined main-process source instead of main.ts itself.
+    // The ai-sdk backend wiring lives in session-stream.ts and its shared tool
+    // surface resolver; these pins target the combined main-process source.
     assert.match(combinedMainProcess, /const memoryPromptSnapshot = await systemPromptService\.buildLocalMemoryPromptFragment\(\)/);
     assert.match(
       combinedMainProcess,
@@ -85,11 +85,11 @@ describe('IPC surface contract', () => {
     assert.match(combinedMainProcess, /<memory-update>/);
     assert.match(
       combinedMainProcess,
-      /const candidateTools = ctx\.tools\s+\? \[\.\.\.ctx\.tools\]\s+: isComputerUseRealModelE2e/,
+      /const candidateTools = input\.tools\s+\? \[\.\.\.input\.tools\]\s+: deps\.isComputerUseRealModelE2e/,
     );
     assert.match(
       combinedMainProcess,
-      /const planControlTools = ctx\.tools\s+\? \[\]\s+: collaborationMode === 'plan'/,
+      /const planControlTools = input\.tools\s+\? \[\]\s+: collaborationMode === 'plan'/,
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -15,6 +15,7 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/connections-ipc-main.ts',
   'apps/desktop/src/main/daily-review-ipc-main.ts',
   'apps/desktop/src/main/daily-review-main.ts',
+  'apps/desktop/src/main/desktop-backend-tool-surface.ts',
   'apps/desktop/src/main/gateway-ipc-main.ts',
   'apps/desktop/src/main/git-ipc-main.ts',
   'apps/desktop/src/main/main-window.ts',

--- a/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-sticky-model-contract.test.ts
@@ -44,7 +44,11 @@ describe('PR-SESSION-STICKY-MODEL-0 contract', () => {
     // and the session send projection share one normalization.
     assert.match(coreReadiness, /normalizeRequestedModelForReadiness\(\s*connection: LlmConnection,\s*requestedModel: string \| undefined,\s*\)/);
     assert.match(coreReadiness, /CODEX_SUBSCRIPTION_UNSUPPORTED_CHATGPT_MODELS\.has\(requestedModel\)/);
-    assert.match(main, /const \{ connection, apiKey, model \} = await getReadyConnection\(ctx\.header\.llmConnectionSlug, ctx\.header\.model\)/);
+    assert.match(
+      main,
+      /deps\.getReadyConnection\(\s*input\.header\.llmConnectionSlug,\s*input\.header\.model,\s*\)/,
+    );
+    assert.match(main, /resolveDesktopBackendToolSurface\(deps, ctx\)/);
     assert.match(main, /header: \{ \.\.\.ctx\.header, model, permissionMode: effectivePermissionMode \}/);
     assert.match(main, /modelId: model/);
     // #1038: the locked/sticky guarantee lives in the core projection —

--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -114,7 +114,7 @@ Use the Office tools.`);
     assert.match(mainProcess, /buildSkillSearchAgentTool\([\s\S]*resolveDesktopSkillHost,[\s\S]*shadowTracker/);
     assert.match(mainProcess, /const backendSkillHost = buildHostCapabilitiesFromBinding\(backendToolNames\)/);
     assert.doesNotMatch(mainProcess, /const backendCapabilities = new Set<string>\(\)/);
-    assert.match(mainProcess, /\[\.\.\.builtinTools, \.\.\.buildMcpTools\(mcpManager\)\]/);
+    assert.match(mainProcess, /\.\.\.deps\.builtinTools,[\s\S]*\.\.\.buildMcpTools\(deps\.mcpManager\)/);
     assert.match(mainProcess, /const backendTools = computerUseToolsForModel\(/);
     assert.match(mainProcess, /const backendToolNames = new Set\(/);
     assert.match(mainProcess, /selectedTools\.map\(\(tool\) => tool\.name\)/);

--- a/apps/desktop/src/main/desktop-backend-tool-surface.ts
+++ b/apps/desktop/src/main/desktop-backend-tool-surface.ts
@@ -1,0 +1,300 @@
+import {
+  activePlanExecution,
+  DEFAULT_SESSION_NAME,
+  DEEP_RESEARCH_SESSION_LABEL,
+  expertTeamIdFromLabels,
+  isDeepResearchSession,
+  isPermissionModeWithinCeiling,
+  resolveModelVisionSupport,
+} from '@maka/core';
+import type {
+  CollaborationMode,
+  LlmConnection,
+  QuickChatMode,
+  SessionHeader,
+  TaskLedgerStore,
+} from '@maka/core';
+import {
+  emptyPlanSessionState,
+  type PlanExecution,
+  type PlanSessionState,
+  type PlanStore,
+} from '@maka/core/plan';
+import {
+  buildCancelPlanTool,
+  buildExpertDispatchToolForTeamId,
+  buildHostCapabilitiesFromBinding,
+  buildMcpTools,
+  buildSubmitPlanTool,
+  buildToolsForAgentDefinition,
+  buildUpdatePlanTool,
+  selectCollaborationTools,
+} from '@maka/runtime';
+import type {
+  BackendFactoryContext,
+  HostCapabilities,
+  MakaTool,
+  ToolAvailabilityConfig,
+} from '@maka/runtime';
+import type { McpClientManager } from '@maka/mcp';
+import {
+  computerUseAvailabilityForModel,
+  computerUseToolsForModel,
+} from './computer-use-model-tools.js';
+import type { ReadyConnection } from './chat-readiness.js';
+
+export interface DesktopBackendToolSurfaceDeps {
+  isComputerUseRealModelE2e: boolean;
+  ensureMcpReady: () => Promise<void>;
+  getReadyConnection: (
+    slug: string | null | undefined,
+    model?: string,
+  ) => Promise<ReadyConnection>;
+  mcpManager: McpClientManager;
+  taskLedgerStore: TaskLedgerStore;
+  deepResearchTools: readonly MakaTool[];
+  computerUseTools: readonly MakaTool[];
+  agentTeamLeadTools: readonly MakaTool[];
+  builtinTools: readonly MakaTool[];
+  toolAvailability: ToolAvailabilityConfig;
+  planStore: PlanStore;
+}
+
+export interface DesktopBackendToolSurfaceInput {
+  sessionId: string;
+  header: SessionHeader;
+  /** Scoped child tools. Main sessions leave this undefined. */
+  tools?: readonly MakaTool[];
+  agentTeam?: BackendFactoryContext['agentTeam'];
+  /** Reuse a connection already resolved for a not-yet-persisted session preview. */
+  readyConnection?: ReadyConnection;
+  /** Avoid reading a durable plan ledger for a not-yet-persisted session preview. */
+  planState?: PlanSessionState;
+}
+
+export interface DesktopBackendToolSurface {
+  connection: LlmConnection;
+  apiKey: string;
+  model: string;
+  supportsVision: boolean;
+  collaborationMode: CollaborationMode;
+  planState: PlanSessionState;
+  activeExecution?: PlanExecution;
+  interruptedExecution?: PlanExecution;
+  agentTeam?: BackendFactoryContext['agentTeam'];
+  selectedTools: MakaTool[];
+  toolAvailability: ToolAvailabilityConfig;
+  skillHost: HostCapabilities;
+}
+
+export interface DesktopNewSessionSkillContext {
+  collaborationMode?: CollaborationMode;
+  mode?: QuickChatMode;
+}
+
+/**
+ * Resolve Skill capabilities for an existing Desktop session from the same
+ * durable child-tool snapshot that Runtime uses when it builds that session's
+ * backend. Root sessions keep using the normal Desktop catalog.
+ */
+export async function resolveDesktopSessionSkillHost(
+  deps: DesktopBackendToolSurfaceDeps,
+  input: {
+    sessionId: string;
+    header: SessionHeader;
+    childTools: readonly MakaTool[];
+  },
+): Promise<HostCapabilities> {
+  if (input.header.backend !== 'ai-sdk') return { toolNames: new Set() };
+  const tools = resolveDurableChildTools(input.header, input.childTools);
+  return (
+    await resolveDesktopBackendToolSurface(deps, {
+      sessionId: input.sessionId,
+      header: input.header,
+      ...(tools !== undefined ? { tools } : {}),
+    })
+  ).skillHost;
+}
+
+/**
+ * Resolve Skill capabilities for the ready-empty composer before a session is
+ * persisted. The preview header mirrors the mode labels and permission mode
+ * that quickChat:start will use for the real session.
+ */
+export async function resolveDesktopNewSessionSkillHost(
+  deps: DesktopBackendToolSurfaceDeps,
+  input: {
+    projectRoot: string;
+    workspaceRoot: string;
+    readyConnection: ReadyConnection;
+    context?: DesktopNewSessionSkillContext;
+  },
+): Promise<HostCapabilities> {
+  const sessionId = 'new-session-skill-preview';
+  const now = Date.now();
+  const deepResearch = input.context?.mode === 'deep_research';
+  const header: SessionHeader = {
+    id: sessionId,
+    workspaceRoot: input.workspaceRoot,
+    cwd: input.projectRoot,
+    createdAt: now,
+    lastUsedAt: now,
+    name: deepResearch ? 'Deep Research' : DEFAULT_SESSION_NAME,
+    titleIsManual: false,
+    isFlagged: false,
+    labels: deepResearch ? [DEEP_RESEARCH_SESSION_LABEL] : [],
+    isArchived: false,
+    status: 'active',
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: input.readyConnection.connection.slug,
+    connectionLocked: false,
+    model: input.readyConnection.model,
+    permissionMode: deepResearch ? 'explore' : 'ask',
+    collaborationMode: input.context?.collaborationMode ?? 'agent',
+    orchestrationMode: 'default',
+    schemaVersion: 1,
+  };
+  return (
+    await resolveDesktopBackendToolSurface(deps, {
+      sessionId,
+      header,
+      readyConnection: input.readyConnection,
+      planState: emptyPlanSessionState(sessionId),
+    })
+  ).skillHost;
+}
+
+/**
+ * Derive the exact tool surface an upcoming Desktop ai-sdk backend will bind.
+ *
+ * Pre-send Skill resolution and slash discovery call this with the persisted
+ * session header; backend construction calls it with the same header/context.
+ * Keeping the model, collaboration, plan, expert-team, MCP and child-tool
+ * filters here prevents either path from advertising capabilities the other
+ * path cannot execute.
+ */
+export async function resolveDesktopBackendToolSurface(
+  deps: DesktopBackendToolSurfaceDeps,
+  input: DesktopBackendToolSurfaceInput,
+): Promise<DesktopBackendToolSurface> {
+  // MCP is optional. A corrupt mcp.json remains visible in the MCP module,
+  // but must not prevent builtin-only conversations or Skill discovery.
+  await deps.ensureMcpReady().catch(() => {});
+  const { connection, apiKey, model } =
+    input.readyConnection ??
+    (await deps.getReadyConnection(
+      input.header.llmConnectionSlug,
+      input.header.model,
+    ));
+  const supportsVision = modelSupportsVision(connection, model);
+  const collaborationMode = input.header.collaborationMode ?? 'agent';
+  const planState = input.planState ?? (await deps.planStore.readState(input.sessionId));
+  const activeExecution = activePlanExecution(planState);
+  const interruptedExecution = [...planState.executions]
+    .reverse()
+    .find((execution) => execution.status === 'interrupted');
+  const candidateTools = input.tools
+    ? [...input.tools]
+    : deps.isComputerUseRealModelE2e
+      ? [...deps.computerUseTools]
+      : [
+          ...deps.builtinTools,
+          ...buildMcpTools(deps.mcpManager),
+          ...(isDeepResearchSession(input.header.labels) ? deps.deepResearchTools : []),
+        ];
+  const candidateToolAvailability = deps.isComputerUseRealModelE2e
+    ? { economy: false, groups: [] }
+    : deps.toolAvailability;
+
+  // Expert-team lead: a main session labeled `mode:expert-team:<teamId>`
+  // gets expert_dispatch. Child turns inherit the label but receive scoped
+  // tools and must not be able to spawn nested teams.
+  const expertTeamId = input.tools ? undefined : expertTeamIdFromLabels(input.header.labels);
+  const expertDispatchTool = expertTeamId
+    ? buildExpertDispatchToolForTeamId(expertTeamId, {
+        taskLedger: deps.taskLedgerStore,
+      })
+    : undefined;
+  const agentTeam =
+    input.agentTeam ??
+    (expertTeamId
+      ? { role: 'lead' as const, teamId: expertTeamId, agentId: 'lead' }
+      : undefined);
+  const planControlTools = input.tools
+    ? []
+    : collaborationMode === 'plan'
+      ? [buildSubmitPlanTool(deps.planStore, interruptedExecution?.executionId)]
+      : activeExecution
+        ? [
+            buildUpdatePlanTool(deps.planStore, activeExecution.executionId),
+            buildCancelPlanTool(deps.planStore, activeExecution.executionId),
+          ]
+        : [];
+  const backendTools = computerUseToolsForModel(
+    [...candidateTools, ...planControlTools],
+    deps.computerUseTools,
+    supportsVision,
+  );
+  const toolAvailability = computerUseAvailabilityForModel(
+    candidateToolAvailability,
+    supportsVision,
+  );
+  const selectedTools = selectCollaborationTools({
+    mode: collaborationMode,
+    tools: expertDispatchTool
+      ? [...backendTools, expertDispatchTool, ...deps.agentTeamLeadTools]
+      : backendTools,
+    hasActiveExecution: activeExecution !== undefined,
+  });
+  const backendToolNames = new Set(selectedTools.map((tool) => tool.name));
+  const backendSkillHost = buildHostCapabilitiesFromBinding(backendToolNames);
+
+  return {
+    connection,
+    apiKey,
+    model,
+    supportsVision,
+    collaborationMode,
+    planState,
+    activeExecution,
+    interruptedExecution,
+    agentTeam,
+    selectedTools,
+    toolAvailability,
+    skillHost: backendSkillHost,
+  };
+}
+
+function modelSupportsVision(connection: LlmConnection, model: string): boolean {
+  return resolveModelVisionSupport(connection.providerType, connection.models, model);
+}
+
+function resolveDurableChildTools(
+  header: SessionHeader,
+  availableChildTools: readonly MakaTool[],
+): MakaTool[] | undefined {
+  const snapshot = header.subagentRuntime;
+  if (!snapshot) {
+    if (header.subagentParent) {
+      throw new Error('Linked child session is missing its durable runtime snapshot');
+    }
+    return undefined;
+  }
+  if (!header.subagentParent) {
+    throw new Error('Subagent runtime snapshot requires a linked child session');
+  }
+  if (!isPermissionModeWithinCeiling(header.permissionMode, snapshot.permissionCeiling)) {
+    throw new Error('Subagent runtime permission mode exceeds its durable ceiling');
+  }
+  const tools = buildToolsForAgentDefinition(availableChildTools, {
+    id: snapshot.agentId,
+    permissionMode: header.permissionMode,
+    tools: snapshot.toolNames,
+    categoryPolicy: snapshot.categoryPolicy,
+  });
+  if (tools.length !== snapshot.toolNames.length) {
+    throw new Error('Subagent runtime tool snapshot is unavailable');
+  }
+  return tools;
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -16,6 +16,7 @@ import type {
   SessionChangedEvent,
   SessionChangedReason,
   SessionEvent,
+  SessionHeader,
 } from '@maka/core';
 import { deriveBotStatusPersistenceUpdate } from './bot-status-persistence.js';
 import { runThreadSearch } from './search/thread-search.js';
@@ -108,6 +109,7 @@ import { registerConnectionsIpc } from './connections-ipc-main.js';
 import { registerConfigIpc } from './config-ipc-main.js';
 import { registerPlanReminderIpc } from './plan-reminders-ipc-main.js';
 import { registerWorkspaceResourcesIpc } from './workspace-resources-ipc-main.js';
+import type { NewSessionSkillContext } from './workspace-resources-ipc-main.js';
 import { registerDailyReviewIpc } from './daily-review-ipc-main.js';
 import { registerUsageIpc } from './usage-ipc-main.js';
 import { registerWebSearchIpc } from './web-search-ipc-main.js';
@@ -125,6 +127,11 @@ import { createE2eFixtureBotOnboardingAdapters } from './bot-onboarding-e2e-fixt
 import { createKeepSystemAwakeController } from './keep-system-awake.js';
 import { createSettingsRuntimeEffects } from './settings-runtime-effects.js';
 import { createAiSdkBackendFactory, createSessionStreamer } from './session-stream.js';
+import {
+  resolveDesktopBackendToolSurface,
+  resolveDesktopNewSessionSkillHost,
+  resolveDesktopSessionSkillHost,
+} from './desktop-backend-tool-surface.js';
 import { registerGatewayIpc } from './gateway-ipc-main.js';
 import { registerSessionsIpc } from './sessions-ipc-main.js';
 import {
@@ -495,9 +502,10 @@ const localMemory = new LocalMemoryService({
   updateSettings: (patch) => settingsStore.update(patch),
   getPrivacyContext: getWorkspacePrivacyContext,
 });
-// Resolve a session's backend host at Skill invocation time. The fallback is
-// the binding-derived Desktop surface created after the product tool catalog
-// is assembled below.
+// The synchronous Runtime Skill tools execute inside an already-built backend.
+// Their resolver uses the exact host cached by that backend. Pre-send
+// invocation and slash discovery derive a fresh surface from the persisted
+// session header instead; see resolveDesktopSkillHostForSession below.
 const desktopSessionSkillHosts = new Map<string, HostCapabilities>();
 const resolveDesktopSkillHost: HostCapabilitiesResolver = ({ sessionId }) =>
   desktopSessionSkillHosts.get(sessionId) ?? desktopHostCapabilities;
@@ -610,6 +618,19 @@ const {
   getWorkspacePrivacyContext,
   resolveDesktopSkillHost,
 });
+const desktopBackendToolSurfaceDeps = {
+  isComputerUseRealModelE2e,
+  ensureMcpReady,
+  getReadyConnection,
+  mcpManager,
+  taskLedgerStore,
+  deepResearchTools,
+  computerUseTools,
+  agentTeamLeadTools,
+  builtinTools,
+  toolAvailability,
+  planStore,
+};
 // Cursor-overlay teardown assigns a module-scoped `let`, so it stays in main.ts.
 onMainWindowClose = () => computerUseOverlay.destroyAll();
 const systemPromptService = createSystemPromptMainService({
@@ -698,28 +719,18 @@ const planReminders = createPlanReminderMainService({
 app.setName('Maka');
 
 backends.register('ai-sdk', createAiSdkBackendFactory({
-  isComputerUseRealModelE2e,
-  ensureMcpReady,
-  getReadyConnection,
+  ...desktopBackendToolSurfaceDeps,
   buildSubscriptionModelFetch,
   systemPromptService,
-  mcpManager,
   permissionEngine,
-  taskLedgerStore,
   telemetryRepo,
   artifactStore,
-  deepResearchTools,
   desktopSessionSkillHosts,
-  computerUseTools,
-  agentTeamLeadTools,
-  builtinTools,
-  toolAvailability,
   sandboxDiagnosticsProvider,
   persistToolArtifacts,
   persistArchivedToolResult,
   readArchivedToolResult,
   runtimeCommitStore: runtimePersistence.runtimeCommitStore,
-  planStore,
   safeSendToRenderer,
   openGateway,
   emitSessionsChanged,
@@ -1097,32 +1108,62 @@ function getReadyConnection(slug: string | null | undefined, model?: string) {
   return requireReadyConnection(slug, readyConnectionDeps, model);
 }
 
+async function resolveDesktopSkillHostForSession(
+  sessionId: string,
+): Promise<HostCapabilities> {
+  const header = await store.readHeader(sessionId);
+  return resolveDesktopSessionSkillHost(desktopBackendToolSurfaceDeps, {
+    sessionId,
+    header,
+    childTools: childAgentTools,
+  });
+}
+
+async function resolveDesktopSkillHostForNewSession(
+  projectRoot: string,
+  context?: NewSessionSkillContext,
+): Promise<HostCapabilities> {
+  const ready = await getReadyConnection(
+    context?.llmConnectionSlug ?? (await connectionStore.getDefault()),
+    context?.model,
+  );
+  return resolveDesktopNewSessionSkillHost(desktopBackendToolSurfaceDeps, {
+    projectRoot,
+    workspaceRoot,
+    readyConnection: ready,
+    context,
+  });
+}
+
 async function prepareDesktopSkillInvocation(
   sessionId: string,
   text: string,
   skillIds?: readonly string[],
 ) {
+  const [projectRoot, host] = await Promise.all([
+    resolveProjectRootForContext(sessionId),
+    resolveDesktopSkillHostForSession(sessionId),
+  ]);
   return prepareSkillInvocationMessage({
     text,
     ...(skillIds ? { skillIds } : {}),
-    source: resolveSkillDiscoveryPaths(
-      await resolveProjectRootForContext(sessionId),
-      workspaceRoot,
-    ),
-    host: desktopSessionSkillHosts.get(sessionId) ?? desktopHostCapabilities,
+    source: resolveSkillDiscoveryPaths(projectRoot, workspaceRoot),
+    host,
   });
 }
 
-async function listDesktopInvocableSkills(sessionId?: string) {
+async function listDesktopInvocableSkills(
+  sessionId?: string,
+  newSessionContext?: NewSessionSkillContext,
+) {
   try {
+    const projectRoot = await resolveProjectRootForContext(sessionId);
+    const host = sessionId
+      ? await resolveDesktopSkillHostForSession(sessionId)
+      : await resolveDesktopSkillHostForNewSession(projectRoot, newSessionContext);
     return await listInvocableSkills(
-      resolveSkillDiscoveryPaths(
-        await resolveProjectRootForContext(sessionId),
-        workspaceRoot,
-      ),
-      sessionId
-        ? (desktopSessionSkillHosts.get(sessionId) ?? desktopHostCapabilities)
-        : desktopHostCapabilities,
+      resolveSkillDiscoveryPaths(projectRoot, workspaceRoot),
+      host,
     );
   } catch (error) {
     // Stale sessions with a removed working directory remain browseable, but

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -1,25 +1,11 @@
 import { randomUUID } from 'node:crypto';
-import {
-  activePlanExecution,
-  expertTeamIdFromLabels,
-  isDeepResearchSession,
-  resolveModelVisionSupport,
-} from '@maka/core';
 import type { SessionChangedReason, SessionEvent } from '@maka/core';
-import type { PlanStore } from '@maka/core/plan';
-import type { LlmConnection } from '@maka/core/llm-connections';
 import type { LlmCallRecord, ToolInvocationRecord } from '@maka/core/usage-stats/types';
 import {
   AiSdkBackend,
   buildDefaultContextBudgetPolicy,
-  buildExpertDispatchToolForTeamId,
-  buildHostCapabilitiesFromBinding,
   buildLlmHistorySummarizer,
-  buildMcpTools,
   buildProviderOptions,
-  buildCancelPlanTool,
-  buildSubmitPlanTool,
-  buildUpdatePlanTool,
   createProviderRequestCaptureRecorder,
   getAIModel,
   loadHistoryCompactBlocksFromArtifacts,
@@ -31,13 +17,11 @@ import {
   renderInterruptedPlanContext,
   renderPlanModePrompt,
   resolveSelectedModelContextWindow,
-  selectCollaborationTools,
 } from '@maka/runtime';
 import type {
   BackendFactory,
   GoalTurnOutcome,
   HostCapabilities,
-  MakaTool,
   PermissionEngine,
   SessionActivityLease,
   SessionActivityRegistry,
@@ -47,7 +31,6 @@ import type {
   ToolResultArchiveRecorderInput,
   buildPricingLookup,
 } from '@maka/runtime';
-import type { McpClientManager } from '@maka/mcp';
 import {
   createArtifactStore,
   createAttachmentByteReader,
@@ -56,25 +39,22 @@ import {
   persistProviderRequestCaptureArtifact,
 } from '@maka/storage';
 import { WEB_SEARCH_TOOL_NAME } from './web-search/agent-tool.js';
-import {
-  computerUseAvailabilityForModel,
-  computerUseToolsForModel,
-} from './computer-use-model-tools.js';
 import { errorCode, errorMessage, errorReason } from './chat-readiness.js';
-import type { ReadyConnection } from './chat-readiness.js';
 import type { assembleDesktopTools } from './tool-assembly.js';
 import type { ToolArtifactPersistence } from './tool-artifact-persistence.js';
-import type { createMainTaskLedgerWiring } from './task-ledger-wiring.js';
 import type { createMainGoalWiring } from './goal-wiring.js';
 import type { createSubscriptionModelFetch } from './subscription-model-fetch.js';
 import type { createSystemPromptMainService } from './system-prompt-main.js';
 import type { OpenGatewayService } from './open-gateway.js';
 import { startDesktopSessionTurn, type SessionGoalBoundary } from './session-turn-stream.js';
+import {
+  resolveDesktopBackendToolSurface,
+  type DesktopBackendToolSurfaceDeps,
+} from './desktop-backend-tool-surface.js';
 
 type AssembledTools = ReturnType<typeof assembleDesktopTools>;
 type SystemPromptMainService = ReturnType<typeof createSystemPromptMainService>;
 type SubscriptionModelFetchBuilder = ReturnType<typeof createSubscriptionModelFetch>;
-type TaskLedgerStore = ReturnType<typeof createMainTaskLedgerWiring>['store'];
 type GoalWiring = ReturnType<typeof createMainGoalWiring>;
 type ArtifactStore = ReturnType<typeof createArtifactStore>;
 type TelemetryRepo = ReturnType<typeof createTelemetryRepo>;
@@ -82,38 +62,18 @@ type PricingLookup = ReturnType<typeof buildPricingLookup>;
 type RuntimeCommitStore = Awaited<ReturnType<typeof openRuntimeEventPersistence>>['runtimeCommitStore'];
 const SKILL_CATALOG_TRACE_DECISION_LIMIT = 100;
 
-/**
- * Selected-model image-input capability, consulted before wiring AiSdkBackend.
- * Stored provider capabilities win; a bare model id falls back to in-repo
- * metadata (provider `/models` responses do not report image support).
- */
-function modelSupportsVision(connection: LlmConnection, model: string): boolean {
-  return resolveModelVisionSupport(connection.providerType, connection.models, model);
-}
-
-export interface AiSdkBackendFactoryDeps {
-  isComputerUseRealModelE2e: boolean;
-  ensureMcpReady: () => Promise<void>;
-  getReadyConnection: (slug: string | null | undefined, model?: string) => Promise<ReadyConnection>;
+export interface AiSdkBackendFactoryDeps extends DesktopBackendToolSurfaceDeps {
   buildSubscriptionModelFetch: SubscriptionModelFetchBuilder;
   systemPromptService: SystemPromptMainService;
-  mcpManager: McpClientManager;
   permissionEngine: PermissionEngine;
-  taskLedgerStore: TaskLedgerStore;
   telemetryRepo: TelemetryRepo;
   artifactStore: ArtifactStore;
-  deepResearchTools: MakaTool[];
   desktopSessionSkillHosts: Map<string, HostCapabilities>;
-  computerUseTools: AssembledTools['computerUseTools'];
-  agentTeamLeadTools: AssembledTools['agentTeamLeadTools'];
-  builtinTools: AssembledTools['builtinTools'];
-  toolAvailability: AssembledTools['toolAvailability'];
   sandboxDiagnosticsProvider: AssembledTools['sandboxDiagnosticsProvider'];
   persistToolArtifacts: ToolArtifactPersistence['persistToolArtifacts'];
   persistArchivedToolResult: ToolArtifactPersistence['persistArchivedToolResult'];
   readArchivedToolResult: ToolArtifactPersistence['readArchivedToolResult'];
   runtimeCommitStore: RuntimeCommitStore;
-  planStore: PlanStore;
   safeSendToRenderer: (channel: string, ...args: unknown[]) => void;
   openGateway: OpenGatewayService;
   emitSessionsChanged: (reason: SessionChangedReason, sessionId?: string) => void;
@@ -132,28 +92,17 @@ export interface AiSdkBackendFactoryDeps {
  */
 export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): BackendFactory {
   const {
-    isComputerUseRealModelE2e,
-    ensureMcpReady,
-    getReadyConnection,
     buildSubscriptionModelFetch,
     systemPromptService,
-    mcpManager,
     permissionEngine,
-    taskLedgerStore,
     telemetryRepo,
     artifactStore,
-    deepResearchTools,
     desktopSessionSkillHosts,
-    computerUseTools,
-    agentTeamLeadTools,
-    builtinTools,
-    toolAvailability,
     sandboxDiagnosticsProvider,
     persistToolArtifacts,
     persistArchivedToolResult,
     readArchivedToolResult,
     runtimeCommitStore,
-    planStore,
     safeSendToRenderer,
     openGateway,
     emitSessionsChanged,
@@ -162,70 +111,23 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
   } = deps;
 
   return async (ctx) => {
-    // MCP is optional. A corrupt mcp.json remains visible in the MCP module,
-    // but must not prevent builtin-only conversations from creating a backend.
-    await ensureMcpReady().catch(() => {});
-    const { connection, apiKey, model } = await getReadyConnection(ctx.header.llmConnectionSlug, ctx.header.model);
+    const toolSurface = await resolveDesktopBackendToolSurface(deps, ctx);
+    const {
+      connection,
+      apiKey,
+      model,
+      supportsVision,
+      collaborationMode,
+      planState,
+      activeExecution,
+      interruptedExecution,
+      agentTeam,
+      selectedTools,
+      toolAvailability: backendToolAvailability,
+      skillHost: backendSkillHost,
+    } = toolSurface;
     const modelFetch = buildSubscriptionModelFetch(connection, ctx.sessionId, model);
     const memoryPromptSnapshot = await systemPromptService.buildLocalMemoryPromptFragment();
-    const supportsVision = modelSupportsVision(connection, model);
-    const collaborationMode = ctx.header.collaborationMode ?? 'agent';
-    const planState = await planStore.readState(ctx.sessionId);
-    const activeExecution = activePlanExecution(planState);
-    const interruptedExecution = [...planState.executions]
-      .reverse()
-      .find((execution) => execution.status === 'interrupted');
-    const buildDesktopBaseTools = () => [...builtinTools, ...buildMcpTools(mcpManager)];
-    const candidateTools = ctx.tools
-      ? [...ctx.tools]
-      : isComputerUseRealModelE2e
-        ? computerUseTools
-        : [
-            ...buildDesktopBaseTools(),
-            ...(isDeepResearchSession(ctx.header.labels) ? deepResearchTools : []),
-          ];
-    const candidateToolAvailability = isComputerUseRealModelE2e
-      ? { economy: false, groups: [] }
-      : toolAvailability;
-    // Expert-team lead: a main session (ctx.tools undefined) labeled
-    // `mode:expert-team:<teamId>` gets the team-bound expert_dispatch tool.
-    // Child turns receive scoped `ctx.tools` and inherit the label, but must NOT
-    // get expert_dispatch — members cannot spawn nested teams.
-    const expertTeamId = ctx.tools ? undefined : expertTeamIdFromLabels(ctx.header.labels);
-    const expertDispatchTool = expertTeamId
-      ? buildExpertDispatchToolForTeamId(expertTeamId, { taskLedger: taskLedgerStore })
-      : undefined;
-    const agentTeam = ctx.agentTeam ?? (expertTeamId
-      ? { role: 'lead' as const, teamId: expertTeamId, agentId: 'lead' }
-      : undefined);
-    const planControlTools = ctx.tools
-      ? []
-      : collaborationMode === 'plan'
-        ? [buildSubmitPlanTool(planStore, interruptedExecution?.executionId)]
-        : activeExecution
-          ? [
-              buildUpdatePlanTool(planStore, activeExecution.executionId),
-              buildCancelPlanTool(planStore, activeExecution.executionId),
-            ]
-          : [];
-    const backendTools = computerUseToolsForModel(
-      [...candidateTools, ...planControlTools],
-      computerUseTools,
-      supportsVision,
-    );
-    const backendToolAvailability = computerUseAvailabilityForModel(
-      candidateToolAvailability,
-      supportsVision,
-    );
-    const selectedTools = selectCollaborationTools({
-      mode: collaborationMode,
-      tools: expertDispatchTool
-        ? [...backendTools, expertDispatchTool, ...agentTeamLeadTools]
-        : backendTools,
-      hasActiveExecution: activeExecution !== undefined,
-    });
-    const backendToolNames = new Set(selectedTools.map((tool) => tool.name));
-    const backendSkillHost = buildHostCapabilitiesFromBinding(backendToolNames);
     // Legacy child-run backends share the parent sessionId; linked child
     // sessions have their own id. Both receive a narrower tool surface without
     // the Desktop Skill tool, so only a session's full backend owns this entry.

--- a/apps/desktop/src/main/workspace-resources-ipc-main.ts
+++ b/apps/desktop/src/main/workspace-resources-ipc-main.ts
@@ -1,7 +1,13 @@
 import { ipcMain, shell } from 'electron';
 import { copyFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { ArtifactSaveResult } from '@maka/core';
+import {
+  isCollaborationMode,
+  isQuickChatMode,
+  type ArtifactSaveResult,
+  type CollaborationMode,
+  type QuickChatMode,
+} from '@maka/core';
 import type {
   HostCapabilities,
   InvocableSkillEntry,
@@ -33,12 +39,22 @@ import {
 type ArtifactStore = ReturnType<typeof createArtifactStore>;
 type MainWindowController = ReturnType<typeof createMainWindowController>;
 
+export interface NewSessionSkillContext {
+  llmConnectionSlug?: string;
+  model?: string;
+  collaborationMode?: CollaborationMode;
+  mode?: QuickChatMode;
+}
+
 interface WorkspaceResourcesIpcDeps {
   workspaceRoot: string;
   artifactStore: ArtifactStore;
   mainWindowController: MainWindowController;
   sendToRenderer: MainWindowController['send'];
-  listInvocableSkills(sessionId?: string): Promise<InvocableSkillEntry[]>;
+  listInvocableSkills(
+    sessionId?: string,
+    newSessionContext?: NewSessionSkillContext,
+  ): Promise<InvocableSkillEntry[]>;
   skillHost?: HostCapabilities;
   getCurrentProjectRoot?: () => Promise<string>;
   getSkillSelectionReport?: (cwd: string) => SkillSelectionReport | undefined;
@@ -138,9 +154,15 @@ export function registerWorkspaceResourcesIpc(deps: WorkspaceResourcesIpcDeps): 
       },
     );
   });
-  ipcMain.handle('skills:listInvocable', async (_event, sessionId?: unknown) => {
-    return deps.listInvocableSkills(typeof sessionId === 'string' ? sessionId : undefined);
-  });
+  ipcMain.handle(
+    'skills:listInvocable',
+    async (_event, sessionId?: unknown, newSessionContext?: unknown) => {
+      return deps.listInvocableSkills(
+        typeof sessionId === 'string' ? sessionId : undefined,
+        normalizeNewSessionSkillContext(newSessionContext),
+      );
+    },
+  );
   ipcMain.handle('skills:catalog:list', async () => {
     return listBundledSkillCatalog(deps.workspaceRoot);
   });
@@ -230,4 +252,28 @@ export function registerWorkspaceResourcesIpc(deps: WorkspaceResourcesIpcDeps): 
     if (error) return { ok: false, reason: 'open_failed' as const };
     return { ok: true as const, target: resolved.target };
   });
+}
+
+function normalizeNewSessionSkillContext(input: unknown): NewSessionSkillContext | undefined {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return undefined;
+  const record = input as Record<string, unknown>;
+  const llmConnectionSlug = boundedText(record.llmConnectionSlug, 128);
+  const model = boundedText(record.model, 512);
+  const collaborationMode = isCollaborationMode(record.collaborationMode)
+    ? record.collaborationMode
+    : undefined;
+  const mode = isQuickChatMode(record.mode) ? record.mode : undefined;
+  if (!llmConnectionSlug && !model && !collaborationMode && !mode) return undefined;
+  return {
+    ...(llmConnectionSlug ? { llmConnectionSlug } : {}),
+    ...(model ? { model } : {}),
+    ...(collaborationMode ? { collaborationMode } : {}),
+    ...(mode ? { mode } : {}),
+  };
+}
+
+function boundedText(input: unknown, maxLength: number): string | undefined {
+  if (typeof input !== 'string') return undefined;
+  const value = input.trim();
+  return value.length > 0 && value.length <= maxLength ? value : undefined;
 }

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -673,7 +673,15 @@ export interface MakaBridge {
   };
   skills: {
     list(): Promise<SkillEntry[]>;
-    listInvocable(sessionId?: string): Promise<import('@maka/runtime').InvocableSkillEntry[]>;
+    listInvocable(
+      sessionId?: string,
+      newSessionContext?: {
+        llmConnectionSlug?: string;
+        model?: string;
+        collaborationMode?: 'agent' | 'plan';
+        mode?: QuickChatMode;
+      },
+    ): Promise<import('@maka/runtime').InvocableSkillEntry[]>;
     catalog: {
       list(): Promise<BundledSkillCatalogEntry[]>;
       install(id: string): Promise<

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1058,8 +1058,16 @@ const makaBridge = {
     list(): Promise<SkillEntry[]> {
       return ipcRenderer.invoke('skills:list');
     },
-    listInvocable(sessionId?: string): Promise<import('@maka/runtime').InvocableSkillEntry[]> {
-      return ipcRenderer.invoke('skills:listInvocable', sessionId);
+    listInvocable(
+      sessionId?: string,
+      newSessionContext?: {
+        llmConnectionSlug?: string;
+        model?: string;
+        collaborationMode?: 'agent' | 'plan';
+        mode?: QuickChatMode;
+      },
+    ): Promise<import('@maka/runtime').InvocableSkillEntry[]> {
+      return ipcRenderer.invoke('skills:listInvocable', sessionId, newSessionContext);
     },
     catalog: {
       list(): Promise<BundledSkillCatalogEntry[]> {

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -81,6 +81,8 @@ export interface OnboardingHeroProps {
   ) => boolean | Promise<boolean>;
   /** Enabled, host-compatible Skills offered by the `/` popup. */
   mentionSkills?: ReadonlyArray<{ ref?: string; id: string; name: string; description?: string }>;
+  /** Keep the parent Skill projection aligned with the ready-empty draft mode. */
+  onQuickChatModeChange?: (mode?: QuickChatMode) => void;
   /**
    * Flag set when a `quickChat:start` call is in flight, so the
    * composer can disable its submit button without owning the
@@ -180,6 +182,7 @@ export function OnboardingHero(props: OnboardingHeroProps) {
         <ReadyEmptyHero
           onQuickChatSubmit={props.onQuickChatSubmit}
           mentionSkills={props.mentionSkills}
+          onQuickChatModeChange={props.onQuickChatModeChange}
           quickChatPending={props.quickChatPending === true}
           onImportDroppedTextFiles={props.onImportDroppedTextFiles}
         />
@@ -502,6 +505,7 @@ function ReadyEmptyHero(props: {
     skillIds?: readonly string[],
   ) => boolean | Promise<boolean>;
   mentionSkills?: ReadonlyArray<{ ref?: string; id: string; name: string; description?: string }>;
+  onQuickChatModeChange?: (mode?: QuickChatMode) => void;
   quickChatPending: boolean;
   onImportDroppedTextFiles?: (files: File[]) => Promise<string | undefined>;
 }) {
@@ -526,8 +530,9 @@ function ReadyEmptyHero(props: {
     return () => {
       submitPendingRef.current = false;
       importActionOwnerRef.current?.reset();
+      props.onQuickChatModeChange?.(undefined);
     };
-  }, []);
+  }, [props.onQuickChatModeChange]);
 
   const locale = useUiLocale();
   const onboardingCopy = getOnboardingCopy(locale);
@@ -578,6 +583,7 @@ function ReadyEmptyHero(props: {
       if (!submitted) return;
       setDraft('');
       setDraftMode(undefined);
+      props.onQuickChatModeChange?.(undefined);
       skillDraft.clear(skillDraft.activeDraftKey());
     } finally {
       submitPendingRef.current = false;
@@ -662,6 +668,7 @@ function ReadyEmptyHero(props: {
     const nextDraft = prompt;
     setDraft(nextDraft);
     setDraftMode(mode);
+    props.onQuickChatModeChange?.(mode);
     window.requestAnimationFrame(() => {
       const input = inputRef.current;
       if (!input) return;
@@ -677,6 +684,7 @@ function ReadyEmptyHero(props: {
       return nextDraft;
     });
     setDraftMode(undefined);
+    props.onQuickChatModeChange?.(undefined);
     window.requestAnimationFrame(() => {
       const input = inputRef.current;
       if (!input) return;

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -10,7 +10,14 @@ import {
   type Dispatch,
   type SetStateAction,
 } from 'react';
-import type { PermissionMode, PlanReminder, SessionSummary, UiLocale, UiLocalePreference } from '@maka/core';
+import type {
+  PermissionMode,
+  PlanReminder,
+  QuickChatMode,
+  SessionSummary,
+  UiLocale,
+  UiLocalePreference,
+} from '@maka/core';
 import {
   buildDeepResearchImplementationPrompt,
   collapseSessionRevisions,
@@ -228,6 +235,7 @@ function AppShellContent({
     draftKey: attachmentDraftKey,
   });
   const [newChatPlanModeActive, setNewChatPlanModeActive] = useState(false);
+  const [newChatQuickChatMode, setNewChatQuickChatMode] = useState<QuickChatMode | undefined>();
   const [pendingCollaborationModeBySession, setPendingCollaborationModeBySession] = useState<Record<string, boolean>>({});
   const [newChatSwarmModeActive, setNewChatSwarmModeActive] = useState(false);
   const [pendingOrchestrationModeBySession, setPendingOrchestrationModeBySession] = useState<Record<string, boolean>>({});
@@ -1010,6 +1018,9 @@ function AppShellContent({
     skills,
     sessionId: activeId,
     projectPath: projectInfo?.projectPath,
+    newSessionModel: newChatModel,
+    newSessionCollaborationMode: newChatPlanModeActive ? 'plan' : 'agent',
+    newSessionMode: newChatQuickChatMode,
   });
 
   const { applyE2eFixture } = useStableActions(createAppShellE2eFixtureActions, {
@@ -1390,6 +1401,7 @@ function AppShellContent({
   async function createSession() {
     startNewSession();
     setNewChatPlanModeActive(false);
+    setNewChatQuickChatMode(undefined);
     setNavSelection({ section: 'sessions', filter: 'chats' });
     setSearchScrollTarget(null);
     // New-task affordances reset to the empty-state composer; move focus
@@ -1772,6 +1784,7 @@ function AppShellContent({
                 onBrowseProviders={openProviderCatalog}
                 onQuickChatSubmit={handleQuickChatSubmit}
                 mentionSkills={mentionSkills}
+                onQuickChatModeChange={setNewChatQuickChatMode}
                 quickChatPending={quickChatPending}
                 connections={connections}
                 onRefreshConnections={refreshConnections}

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -40,6 +40,7 @@ interface ChatMessageSurfaceProps extends Omit<
     skillIds?: readonly string[],
   ) => boolean | Promise<boolean>;
   mentionSkills?: ReadonlyArray<{ ref?: string; id: string; name: string; description?: string }>;
+  onQuickChatModeChange?: (mode?: QuickChatMode) => void;
   quickChatPending?: boolean;
   connections: LlmConnection[];
   onRefreshConnections: () => Promise<void> | void;
@@ -59,6 +60,7 @@ export function ChatMessageSurface({
   onBrowseProviders,
   onQuickChatSubmit,
   mentionSkills,
+  onQuickChatModeChange,
   quickChatPending,
   connections,
   onRefreshConnections,
@@ -86,6 +88,7 @@ export function ChatMessageSurface({
         onBrowseProviders={onBrowseProviders}
         onQuickChatSubmit={onQuickChatSubmit}
         mentionSkills={mentionSkills}
+        onQuickChatModeChange={onQuickChatModeChange}
         quickChatPending={quickChatPending}
         connections={connections}
         onRefreshConnections={onRefreshConnections}

--- a/apps/desktop/src/renderer/onboarding-empty-state.tsx
+++ b/apps/desktop/src/renderer/onboarding-empty-state.tsx
@@ -13,6 +13,7 @@ interface OnboardingEmptyStateProps {
     skillIds?: readonly string[],
   ) => boolean | Promise<boolean>;
   mentionSkills?: ReadonlyArray<{ ref?: string; id: string; name: string; description?: string }>;
+  onQuickChatModeChange?: (mode?: QuickChatMode) => void;
   quickChatPending?: boolean;
   connections: LlmConnection[];
   onRefreshConnections?: () => Promise<void> | void;
@@ -35,6 +36,7 @@ export function OnboardingEmptyState({
   onBrowseProviders,
   onQuickChatSubmit,
   mentionSkills,
+  onQuickChatModeChange,
   quickChatPending,
   connections,
   onRefreshConnections,
@@ -52,6 +54,7 @@ export function OnboardingEmptyState({
         onBrowseProviders={onBrowseProviders}
         onQuickChatSubmit={onQuickChatSubmit}
         mentionSkills={mentionSkills}
+        onQuickChatModeChange={onQuickChatModeChange}
         quickChatPending={quickChatPending}
         connections={connections}
         onRefreshConnections={onRefreshConnections}

--- a/apps/desktop/src/renderer/use-composer-mentions.ts
+++ b/apps/desktop/src/renderer/use-composer-mentions.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import type { QuickChatMode } from '@maka/core';
 import type { SkillEntry } from '@maka/ui';
 import type { InvocableSkillEntry } from '@maka/runtime';
 
@@ -14,31 +15,81 @@ export function useComposerMentions(options: {
   skills: readonly SkillEntry[];
   sessionId?: string;
   projectPath?: string;
+  newSessionModel?: { llmConnectionSlug: string; model: string };
+  newSessionCollaborationMode?: 'agent' | 'plan';
+  newSessionMode?: QuickChatMode;
 }): {
   mentionSkills: ReadonlyArray<{ ref?: string; id: string; name: string; description?: string }>;
   searchMentionFiles(query: string): Promise<ReadonlyArray<{ relativePath: string }>>;
 } {
-  const { projectPath, sessionId, skills } = options;
+  const {
+    projectPath,
+    sessionId,
+    skills,
+    newSessionModel,
+    newSessionCollaborationMode,
+    newSessionMode,
+  } = options;
   const [mentionSkills, setMentionSkills] = useState<InvocableSkillEntry[]>([]);
 
   useEffect(() => {
     let cancelled = false;
+    let requestVersion = 0;
     // Do not briefly advertise the previous session/project's Skills while the
-    // authoritative projection is being refreshed.
-    setMentionSkills([]);
-    void window.maka.skills.listInvocable(sessionId).then(
-      (next) => {
-        if (!cancelled) setMentionSkills(next);
-      },
-      () => {
-        // Fail soft: an unavailable projection leaves `/` with no suggestions.
-        // Direct `/skill:<id>` input still reaches the same Runtime resolver.
-      },
-    );
+    // authoritative projection is being refreshed. The same fail-closed reset
+    // applies when a model/mode/plan or MCP event changes the backend surface:
+    // a visible popup must never retain a now-unavailable Skill.
+    const refresh = () => {
+      const version = ++requestVersion;
+      setMentionSkills([]);
+      void window.maka.skills.listInvocable(
+        sessionId,
+        sessionId
+          ? undefined
+          : {
+              ...(newSessionModel ?? {}),
+              collaborationMode: newSessionCollaborationMode ?? 'agent',
+              ...(newSessionMode ? { mode: newSessionMode } : {}),
+            },
+      ).then(
+        (next) => {
+          if (!cancelled && version === requestVersion) setMentionSkills(next);
+        },
+        () => {
+          // Fail soft: an unavailable projection leaves `/` with no suggestions.
+          // Direct `/skill:<id>` input still reaches the same Runtime resolver.
+        },
+      );
+    };
+    refresh();
+    const unsubscribeSessions = window.maka.sessions.subscribeChanges((event) => {
+      if (
+        sessionId &&
+        event.sessionId === sessionId &&
+        (event.reason === 'updated' ||
+          event.reason === 'mode-change' ||
+          event.reason === 'turn-status-change' ||
+          event.reason === 'rebound')
+      ) {
+        refresh();
+      }
+    });
+    const unsubscribeMcp = window.maka.mcp.subscribeChanges(() => refresh());
     return () => {
       cancelled = true;
+      requestVersion += 1;
+      unsubscribeSessions();
+      unsubscribeMcp();
     };
-  }, [projectPath, sessionId, skills]);
+  }, [
+    projectPath,
+    sessionId,
+    skills,
+    newSessionModel?.llmConnectionSlug,
+    newSessionModel?.model,
+    newSessionCollaborationMode,
+    newSessionMode,
+  ]);
 
   const searchMentionFiles = useCallback(
     async (query: string): Promise<ReadonlyArray<{ relativePath: string }>> => {

--- a/scripts/cu-real-model-launcher.test.mjs
+++ b/scripts/cu-real-model-launcher.test.mjs
@@ -14,12 +14,16 @@ import {
 
 const launcher = await readFile(new URL('./cu-real-model-launcher.mjs', import.meta.url), 'utf8');
 // The ai-sdk backend wiring (the isComputerUseRealModelE2e tool / economy
-// branches) moved into session-stream.ts (arch R5); scan main.ts + the
-// extracted module together so the isolation-gate pins follow the split.
+// branches) moved into the shared backend tool-surface resolver; scan main.ts
+// plus both extracted modules so the isolation-gate pins follow the split.
 const main = (
   await Promise.all([
     readFile(new URL('../apps/desktop/src/main/main.ts', import.meta.url), 'utf8'),
     readFile(new URL('../apps/desktop/src/main/session-stream.ts', import.meta.url), 'utf8'),
+    readFile(
+      new URL('../apps/desktop/src/main/desktop-backend-tool-surface.ts', import.meta.url),
+      'utf8',
+    ),
   ])
 ).join('\n');
 
@@ -93,8 +97,8 @@ test('Desktop isolation gate does not enable FakeBackend', () => {
   assert.match(main, /const isComputerUseRealModelE2e =[\s\S]*MAKA_CU_REAL_MODEL_E2E/);
   assert.match(main, /const isE2e = hasIsolatedE2eProfile && process\.env\.MAKA_E2E === '1'/);
   assert.match(main, /const isIsolatedE2e = isE2e \|\| isComputerUseRealModelE2e/);
-  assert.match(main, /isComputerUseRealModelE2e[\s\S]*\? computerUseTools/);
-  assert.match(main, /isComputerUseRealModelE2e[\s\S]*\? \{ economy: false, groups: \[\] \}/);
+  assert.match(main, /deps\.isComputerUseRealModelE2e[\s\S]*\? \[\.\.\.deps\.computerUseTools\]/);
+  assert.match(main, /deps\.isComputerUseRealModelE2e[\s\S]*\? \{ economy: false, groups: \[\] \}/);
   assert.doesNotMatch(main, /if \(isComputerUseRealModelE2e\) \{[\s\S]*backends\.register\('fake'/);
 });
 


### PR DESCRIPTION
## Context

Follow-up to the host-capability consistency work discussed in #1279.

Skill discovery and invocation should use the same host capability surface as the actual Desktop backend turn. Without that shared resolution, the UI can advertise a Skill that the selected backend cannot execute, or hide a Skill that becomes available through mode-specific or MCP tools.

## What changed

- Added one shared Desktop backend tool-surface resolver for built-in tools, MCP tools, model support, and collaboration-mode gating.
- Reused that resolver for Skill discovery, Skill invocation, session streaming, revision sends, and active-turn previews.
- Derived linked child-session Skill capabilities from the durable `subagentRuntime.toolNames` snapshot, including the same permission ceiling, category policy, and unavailable-tool checks used by Runtime.
- Propagated ready-empty Quick Chat mode through renderer, preload, and IPC so the preview header mirrors the real Deep Research session label and permission mode.
- Kept expert and child sessions isolated from root-only Computer Use and Plan tools.
- Added unit, source-contract, and Electron E2E regression coverage for both review findings.

## Tests

Validated after rebasing onto `main` at `8f8d87fe`:

- `npm run format:check` — 1028 files checked
- `npm run lint` — 2055 files checked
- `npm run typecheck` — all workspaces passed
- focused Desktop capability and invocation contracts — 15/15 passed
- `PATH="/Applications/ChatGPT.app/Contents/Resources:$PATH" npm run test:dist` — all workspace tests passed; Desktop 2839/2839
- `npm --workspace @maka/desktop run e2e` — 45/45 passed
- visible-window programmatic smoke — window visible and focused, renderer mounted, modal focused, no ErrorBoundary
- GitHub Actions — typecheck, test, and e2e passed for `9183a161`

The static app `rg` is used for the local full-suite run because the Homebrew binary links a PCRE2 dylib that the Runtime operation-scoped Seatbelt sandbox correctly blocks. The exact Runtime smoke passes with the static binary; no product code was changed for this local dependency.

## Review notes

- No visual styling or layout changes are included.
- This PR changes the capability input used by existing Skill discovery and invocation flows; it does not add Skill management UI.

Refs #1279