### PR TITLE
refactor: simplify workspace identity persistence

### DIFF
--- a/packages/runtime/src/__tests__/runtime-continuation.test.ts
+++ b/packages/runtime/src/__tests__/runtime-continuation.test.ts
@@ -12,13 +12,12 @@ import {
 } from '../runtime-resume.js';
 import { RuntimeRunner } from '../runtime-runner.js';
 
-test('local continuation safety inspector derives portable authoritative host facts', async () => {
+test('local continuation safety inspector returns current authoritative workspace facts', async () => {
   const inspect = createLocalContinuationSafetyInspector({
     readSessionCwd: async () => '/workspace/repo-link',
     resolveWorkspaceIdentity: async () => ({
       workspaceIdentity: 'workspace:v1:123e4567-e89b-42d3-a456-426614174000',
       canonicalPath: '/workspace/repo',
-      legacyWorkspaceIdentities: ['fs:7:42:/workspace/repo'],
     }),
     listAvailableToolNames: async () => ['Write', 'Read', 'Read'],
     hasPendingBackgroundOperations: async () => false,
@@ -27,7 +26,6 @@ test('local continuation safety inspector derives portable authoritative host fa
   assert.deepEqual(await inspect('session-1'), {
     workspaceIdentity: 'workspace:v1:123e4567-e89b-42d3-a456-426614174000',
     workspacePath: '/workspace/repo',
-    legacyWorkspaceIdentities: ['fs:7:42:/workspace/repo'],
     backgroundOperationsSettled: true,
     availableToolNames: ['Read', 'Write'],
   });

--- a/packages/runtime/src/__tests__/runtime-resume.test.ts
+++ b/packages/runtime/src/__tests__/runtime-resume.test.ts
@@ -333,23 +333,6 @@ describe('runtime resume phase 1 safe-boundary continuation', () => {
     ]);
   });
 
-  test('migrates a legacy filesystem anchor through a marker alias', () => {
-    const workspaceIdentity = 'workspace:v1:123e4567-e89b-42d3-a456-426614174000';
-    const legacyIdentity = 'fs:7:42:/workspace/repo';
-    const plan = buildSafeBoundaryContinuationPlan(
-      [textEvent('user-1', 'user', 'inspect the repository')],
-      {
-        ...safeBoundaryFacts(),
-        sourceWorkspaceIdentity: legacyIdentity,
-        currentWorkspaceIdentity: workspaceIdentity,
-        currentWorkspaceIdentityAliases: [legacyIdentity],
-      },
-    );
-
-    assert.equal(plan.disposition, 'continue');
-    assert.equal(plan.continuation?.safetySnapshot.workspaceIdentity, workspaceIdentity);
-  });
-
   test('parks while a background operation is still unsettled', () => {
     const plan = buildSafeBoundaryContinuationPlan(
       [

--- a/packages/runtime/src/continuation-safety.ts
+++ b/packages/runtime/src/continuation-safety.ts
@@ -3,7 +3,6 @@ import type { RuntimeContinuationSafetyObservation } from './runtime-resume.js';
 export interface ResolvedWorkspaceIdentity {
   workspaceIdentity: string;
   canonicalPath: string;
-  legacyWorkspaceIdentities?: readonly string[];
 }
 
 export interface LocalContinuationSafetyInspectorDeps {
@@ -31,9 +30,6 @@ export function createLocalContinuationSafetyInspector(
     return {
       workspaceIdentity: workspace.workspaceIdentity,
       workspacePath: workspace.canonicalPath,
-      ...(workspace.legacyWorkspaceIdentities?.length
-        ? { legacyWorkspaceIdentities: [...workspace.legacyWorkspaceIdentities] }
-        : {}),
       backgroundOperationsSettled: !hasPendingBackgroundOperations,
       availableToolNames: [...new Set(availableToolNames)].sort(),
       ...(workspaceCheckpoint ? { workspaceCheckpoint } : {}),

--- a/packages/runtime/src/runtime-resume.ts
+++ b/packages/runtime/src/runtime-resume.ts
@@ -218,7 +218,6 @@ export interface SafeBoundaryContinuationFacts {
   currentCwd: string;
   sourceWorkspaceIdentity: string;
   currentWorkspaceIdentity: string;
-  currentWorkspaceIdentityAliases?: readonly string[];
   backgroundOperationsSettled: boolean;
   availableToolNames: readonly string[];
   continuationIdentity: ContinuationIdentity;
@@ -262,8 +261,6 @@ export interface RuntimeContinuationSafetyObservation {
   workspaceIdentity: string;
   /** Current location is diagnostic only and never participates in identity. */
   workspacePath?: string;
-  /** One-way compatibility aliases for legacy fs:{dev}:{ino}:{path} AgentRuns. */
-  legacyWorkspaceIdentities?: readonly string[];
   backgroundOperationsSettled: boolean;
   availableToolNames: readonly string[];
   workspaceCheckpoint?: {
@@ -286,7 +283,6 @@ export interface RuntimeContinuationPlannerInput {
   currentCwd: string;
   sourceWorkspaceIdentity: string;
   currentWorkspaceIdentity: string;
-  currentWorkspaceIdentityAliases?: readonly string[];
   backgroundOperationsSettled: boolean;
   availableToolNames: readonly string[];
   expectedRuntimeEventHighWater?: number;
@@ -378,9 +374,6 @@ export class RuntimeContinuationPlanner {
       currentCwd: input.currentCwd,
       sourceWorkspaceIdentity: input.sourceWorkspaceIdentity,
       currentWorkspaceIdentity: input.currentWorkspaceIdentity,
-      ...(input.currentWorkspaceIdentityAliases?.length
-        ? { currentWorkspaceIdentityAliases: input.currentWorkspaceIdentityAliases }
-        : {}),
       backgroundOperationsSettled: input.backgroundOperationsSettled,
       availableToolNames: input.availableToolNames,
       continuationIdentity: {
@@ -628,10 +621,7 @@ export function buildSafeBoundaryContinuationPlan(
       detail: { sourceCwd: facts.sourceCwd, currentCwd: facts.currentCwd },
     });
   }
-  if (
-    facts.sourceWorkspaceIdentity !== facts.currentWorkspaceIdentity &&
-    !facts.currentWorkspaceIdentityAliases?.includes(facts.sourceWorkspaceIdentity)
-  ) {
+  if (facts.sourceWorkspaceIdentity !== facts.currentWorkspaceIdentity) {
     phaseOneDiagnostics.push({
       code: 'workspace_identity_mismatch',
       message: 'current workspace identity differs from the source resume boundary',

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -1132,9 +1132,6 @@ export class SessionManager {
       currentCwd: header.cwd,
       sourceWorkspaceIdentity: sourceRun.workspaceIdentity,
       currentWorkspaceIdentity: observation.workspaceIdentity,
-      ...(observation.legacyWorkspaceIdentities?.length
-        ? { currentWorkspaceIdentityAliases: observation.legacyWorkspaceIdentities }
-        : {}),
       backgroundOperationsSettled: observation.backgroundOperationsSettled,
       availableToolNames: observation.availableToolNames,
       ...(input.expectedRuntimeEventHighWater !== undefined

--- a/packages/storage/src/__tests__/marker-file.test.ts
+++ b/packages/storage/src/__tests__/marker-file.test.ts
@@ -1,0 +1,82 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, open, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import {
+  publishMarkerFile,
+  type MarkerFileDependencies,
+  type MarkerFileHandle,
+} from '../marker-file.js';
+
+for (const publication of ['create', 'replace'] as const) {
+  for (const failurePhase of ['write', 'sync', 'close'] as const) {
+    test(`${publication} removes its temporary marker after a ${failurePhase} failure`, async () => {
+      const root = await mkdtemp(join(tmpdir(), 'maka-marker-file-fault-'));
+      const markerFile = '.marker.json';
+      const temporaryPath = join(root, `${markerFile}.${process.pid}.fault.tmp`);
+      const fault = new Error(`${failurePhase} failed`);
+      try {
+        await assert.rejects(
+          () =>
+            publishMarkerFile(
+              {
+                root,
+                markerFile,
+                contents: '{"schemaVersion":1}\n',
+                maxBytes: 1_024,
+                publication,
+                invalidFile: () => new Error('invalid marker'),
+              },
+              {
+                randomUUID: () => 'fault',
+                open: faultingOpen(temporaryPath, failurePhase, fault),
+              },
+            ),
+          fault,
+        );
+        assert.deepEqual(await readdir(root), []);
+      } finally {
+        await rm(root, { recursive: true, force: true });
+      }
+    });
+  }
+}
+
+function faultingOpen(
+  temporaryPath: string,
+  failurePhase: 'write' | 'sync' | 'close',
+  fault: Error,
+): MarkerFileDependencies['open'] {
+  return async (path, flags, mode) => {
+    const handle = await open(path, flags, mode);
+    if (path !== temporaryPath) return handle;
+
+    let closeFailed = false;
+    const wrapped: MarkerFileHandle = {
+      stat: (options) => handle.stat(options),
+      readFile: (encoding) => handle.readFile(encoding),
+      writeFile: async (data, encoding) => {
+        if (failurePhase === 'write') {
+          await handle.writeFile(data.slice(0, 1), encoding);
+          throw fault;
+        }
+        await handle.writeFile(data, encoding);
+      },
+      sync: async () => {
+        if (failurePhase === 'sync') throw fault;
+        await handle.sync();
+      },
+      close: async () => {
+        if (failurePhase === 'close' && !closeFailed) {
+          closeFailed = true;
+          await handle.close();
+          throw fault;
+        }
+        await handle.close();
+      },
+    };
+    return wrapped;
+  };
+}

--- a/packages/storage/src/__tests__/root-authority-dependency.test.ts
+++ b/packages/storage/src/__tests__/root-authority-dependency.test.ts
@@ -10,6 +10,7 @@ const compilerApi = new API({ cwd: process.cwd() });
 const projectConfig = join(process.cwd(), 'tsconfig.json');
 const compilerSnapshot = compilerApi.updateSnapshot({ openProjects: [projectConfig] });
 const compilerProject = loadCompilerProject();
+const allowedAuthorityLocalModules = new Set(['marker-file.ts', 'root-authority.ts']);
 const allowedAuthorityExternalImports = new Set([
   'fs-native-extensions',
   'node:crypto',
@@ -46,7 +47,10 @@ test('root authority cannot transitively reach domain Stores or Runtime composit
   const violations: string[] = [];
   for (const path of reachableModules(authorityEntrypoint)) {
     const localPath = relative(sourceRoot, path);
-    if (localPath !== 'root-authority.ts' && !localPath.startsWith(`root-authority${sep}`)) {
+    if (
+      !allowedAuthorityLocalModules.has(localPath) &&
+      !localPath.startsWith(`root-authority${sep}`)
+    ) {
       violations.push(`root authority reaches ${localPath}`);
     }
     for (const specifier of moduleSpecifiers(path)) {

--- a/packages/storage/src/__tests__/workspace-identity.test.ts
+++ b/packages/storage/src/__tests__/workspace-identity.test.ts
@@ -7,7 +7,6 @@ import { test } from 'node:test';
 import { promisify } from 'node:util';
 
 import {
-  adoptWorkspaceIdentityOnImport,
   resolveWorkspaceIdentity,
   WORKSPACE_IDENTITY_PREFIX,
   WORKSPACE_MARKER_FILE,
@@ -15,6 +14,20 @@ import {
 } from '../workspace-identity.js';
 
 const execFileAsync = promisify(execFile);
+
+test('a new workspace marker contains only its schema version and UUID', async () => {
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-marker-shape-'));
+  try {
+    const resolution = await resolveWorkspaceIdentity({ path: workspace });
+
+    assert.deepEqual(JSON.parse(await readFile(join(workspace, WORKSPACE_MARKER_FILE), 'utf8')), {
+      schemaVersion: 1,
+      workspaceId: resolution.workspaceIdentity.slice(WORKSPACE_IDENTITY_PREFIX.length),
+    });
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
+});
 
 test('creating a workspace identity keeps a Git worktree clean', async () => {
   const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-git-clean-'));
@@ -244,10 +257,7 @@ test('a tar archive round-trip preserves workspace identity', async () => {
     await execFileAsync('tar', ['-cf', archive, '-C', source, '.']);
     await execFileAsync('tar', ['-xf', archive, '-C', imported]);
     assert.equal(await readFile(join(imported, WORKSPACE_MARKER_FILE), 'utf8'), markerBefore);
-    const adopted = await adoptWorkspaceIdentityOnImport({
-      path: imported,
-      expectedWorkspaceIdentity: original.workspaceIdentity,
-    });
+    const adopted = await resolveWorkspaceIdentity({ path: imported });
 
     assert.equal(adopted.workspaceIdentity, original.workspaceIdentity);
     assert.match(adopted.workspaceIdentity, new RegExp(`^${WORKSPACE_IDENTITY_PREFIX}`));
@@ -275,10 +285,7 @@ test('importing an existing marker into a Git worktree keeps it clean', async ()
     );
     await execFileAsync('git', ['init', '--quiet'], { cwd: imported });
 
-    const adopted = await adoptWorkspaceIdentityOnImport({
-      path: imported,
-      expectedWorkspaceIdentity: original.workspaceIdentity,
-    });
+    const adopted = await resolveWorkspaceIdentity({ path: imported });
 
     assert.equal(adopted.workspaceIdentity, original.workspaceIdentity);
     const { stdout } = await execFileAsync(
@@ -289,123 +296,6 @@ test('importing an existing marker into a Git worktree keeps it clean', async ()
     assert.equal(stdout, '');
   } finally {
     await rm(base, { recursive: true, force: true });
-  }
-});
-
-test('explicit import adoption records a pre-marker legacy filesystem anchor', async () => {
-  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-legacy-'));
-  try {
-    const legacyWorkspaceIdentity = 'fs:7:42:/old-sandbox/repo';
-    const adopted = await adoptWorkspaceIdentityOnImport({
-      path: workspace,
-      legacyWorkspaceIdentity,
-    });
-
-    assert.ok(adopted.legacyWorkspaceIdentities.includes(legacyWorkspaceIdentity));
-    assert.equal(
-      (await resolveWorkspaceIdentity({ path: workspace })).workspaceIdentity,
-      adopted.workspaceIdentity,
-    );
-  } finally {
-    await rm(workspace, { recursive: true, force: true });
-  }
-});
-
-test('import adoption rejects a conflicting workspace UUID', async () => {
-  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-conflict-'));
-  try {
-    await resolveWorkspaceIdentity({ path: workspace });
-    await assert.rejects(
-      () =>
-        adoptWorkspaceIdentityOnImport({
-          path: workspace,
-          expectedWorkspaceIdentity: 'workspace:v1:123e4567-e89b-42d3-a456-426614174000',
-        }),
-      (error: unknown) =>
-        error instanceof WorkspaceIdentityError && error.code === 'workspace_identity_conflict',
-    );
-  } finally {
-    await rm(workspace, { recursive: true, force: true });
-  }
-});
-
-test('import adoption rejects an alias overflow without changing the durable marker', async () => {
-  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-alias-overflow-'));
-  try {
-    const original = await resolveWorkspaceIdentity({ path: workspace });
-    const markerPath = join(workspace, WORKSPACE_MARKER_FILE);
-    const marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
-      schemaVersion: number;
-      workspaceId: string;
-      legacyAnchors: string[];
-    };
-    marker.legacyAnchors = Array.from(
-      { length: 32 },
-      (_, index) => `fs:1:${index + 1}:/legacy/workspace-${index}`,
-    );
-    await writeFile(markerPath, `${JSON.stringify(marker)}\n`, 'utf8');
-    const markerBefore = await readFile(markerPath);
-
-    await assert.rejects(
-      () =>
-        adoptWorkspaceIdentityOnImport({
-          path: workspace,
-          legacyWorkspaceIdentity: 'fs:9:9:/legacy/overflow',
-        }),
-      (error: unknown) =>
-        error instanceof WorkspaceIdentityError && error.code === 'invalid_workspace_marker',
-    );
-
-    assert.deepEqual(await readFile(markerPath), markerBefore);
-    assert.equal(
-      (await resolveWorkspaceIdentity({ path: workspace })).workspaceIdentity,
-      original.workspaceIdentity,
-    );
-  } finally {
-    await rm(workspace, { recursive: true, force: true });
-  }
-});
-
-test('import adoption rejects a marker size overflow without changing the durable marker', async () => {
-  const workspace = await mkdtemp(join(tmpdir(), 'maka-workspace-size-overflow-'));
-  try {
-    const original = await resolveWorkspaceIdentity({ path: workspace });
-    const markerPath = join(workspace, WORKSPACE_MARKER_FILE);
-    const marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
-      schemaVersion: number;
-      workspaceId: string;
-      legacyAnchors: string[];
-    };
-    marker.legacyAnchors = [`fs:1:1:/${'a'.repeat(1_900)}`, `fs:1:2:/${'b'.repeat(1_900)}`];
-    const markerBeforeText = `${JSON.stringify(marker)}\n`;
-    const overflowAlias = `fs:1:3:/${'c'.repeat(300)}`;
-    assert.ok(Buffer.byteLength(markerBeforeText, 'utf8') <= 4_096);
-    assert.ok(
-      Buffer.byteLength(
-        `${JSON.stringify({ ...marker, legacyAnchors: [...marker.legacyAnchors, overflowAlias] })}\n`,
-        'utf8',
-      ) > 4_096,
-    );
-    await writeFile(markerPath, markerBeforeText, 'utf8');
-    const markerBefore = await readFile(markerPath);
-
-    await assert.rejects(
-      () =>
-        adoptWorkspaceIdentityOnImport({
-          path: workspace,
-          legacyWorkspaceIdentity: overflowAlias,
-        }),
-      (error: unknown) =>
-        error instanceof WorkspaceIdentityError && error.code === 'invalid_workspace_marker',
-    );
-
-    assert.deepEqual(await readFile(markerPath), markerBefore);
-    assert.equal(
-      (await resolveWorkspaceIdentity({ path: workspace })).workspaceIdentity,
-      original.workspaceIdentity,
-    );
-  } finally {
-    await rm(workspace, { recursive: true, force: true });
   }
 });
 

--- a/packages/storage/src/marker-file.ts
+++ b/packages/storage/src/marker-file.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from 'node:crypto';
+import { constants as fsConstants, type BigIntStats } from 'node:fs';
+import { link, lstat, open, rename, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+
+export interface MarkerFileHandle {
+  stat(options: { bigint: true }): Promise<BigIntStats>;
+  readFile(encoding: 'utf8'): Promise<string>;
+  writeFile(data: string, encoding: 'utf8'): Promise<void>;
+  sync(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface MarkerFileDependencies {
+  open(path: string, flags: string | number, mode?: number): Promise<MarkerFileHandle>;
+  randomUUID(): string;
+}
+
+const defaultDependencies: MarkerFileDependencies = {
+  open: async (path, flags, mode) => open(path, flags, mode),
+  randomUUID,
+};
+
+export interface ReadBoundedMarkerFileInput {
+  path: string;
+  maxBytes: number;
+  invalidFile(): Error;
+}
+
+export async function readBoundedMarkerFile(
+  input: ReadBoundedMarkerFileInput,
+  dependencies: Partial<MarkerFileDependencies> = {},
+): Promise<string> {
+  const deps = { ...defaultDependencies, ...dependencies };
+  const handle = await deps.open(input.path, markerReadFlags());
+  try {
+    const [handleStat, pathStat] = await Promise.all([
+      handle.stat({ bigint: true }),
+      lstat(input.path, { bigint: true }),
+    ]);
+    if (
+      !handleStat.isFile() ||
+      !pathStat.isFile() ||
+      handleStat.size > BigInt(input.maxBytes) ||
+      handleStat.dev !== pathStat.dev ||
+      handleStat.ino !== pathStat.ino
+    ) {
+      throw input.invalidFile();
+    }
+    return await handle.readFile('utf8');
+  } finally {
+    await handle.close();
+  }
+}
+
+export interface PublishMarkerFileInput {
+  root: string;
+  markerFile: string;
+  contents: string;
+  maxBytes: number;
+  publication: 'create' | 'replace';
+  beforePublish?(): Promise<void>;
+  invalidFile(): Error;
+}
+
+export async function publishMarkerFile(
+  input: PublishMarkerFileInput,
+  dependencies: Partial<MarkerFileDependencies> = {},
+): Promise<'published' | 'already_exists'> {
+  const deps = { ...defaultDependencies, ...dependencies };
+  if (Buffer.byteLength(input.contents, 'utf8') > input.maxBytes) {
+    throw input.invalidFile();
+  }
+
+  const markerPath = join(input.root, input.markerFile);
+  const tempPath = join(input.root, `${input.markerFile}.${process.pid}.${deps.randomUUID()}.tmp`);
+  let tempCreated = false;
+  try {
+    const handle = await deps.open(tempPath, 'wx', 0o600);
+    tempCreated = true;
+    try {
+      await handle.writeFile(input.contents, 'utf8');
+      await handle.sync();
+      await handle.close();
+    } catch (error) {
+      await handle.close().catch(() => {});
+      throw error;
+    }
+
+    await input.beforePublish?.();
+    if (input.publication === 'create') {
+      try {
+        await link(tempPath, markerPath);
+      } catch (error) {
+        if (!isNodeError(error, 'EEXIST')) throw error;
+        return 'already_exists';
+      }
+    } else {
+      await rename(tempPath, markerPath);
+      tempCreated = false;
+    }
+    await syncDirectory(input.root, deps);
+    return 'published';
+  } finally {
+    if (tempCreated) await unlinkIfPresent(tempPath);
+  }
+}
+
+async function unlinkIfPresent(path: string): Promise<void> {
+  try {
+    await unlink(path);
+  } catch (error) {
+    if (!isNodeError(error, 'ENOENT')) throw error;
+  }
+}
+
+async function syncDirectory(path: string, deps: MarkerFileDependencies): Promise<void> {
+  if (process.platform === 'win32') return;
+  const handle = await deps.open(path, 'r');
+  try {
+    await handle.sync();
+  } finally {
+    await handle.close();
+  }
+}
+
+function markerReadFlags(): string | number {
+  if (process.platform === 'win32') return 'r';
+  return fsConstants.O_RDONLY | fsConstants.O_NONBLOCK | fsConstants.O_NOFOLLOW;
+}
+
+function isNodeError(error: unknown, code: string): boolean {
+  return (
+    error instanceof Error && 'code' in error && (error as NodeJS.ErrnoException).code === code
+  );
+}

--- a/packages/storage/src/root-authority.ts
+++ b/packages/storage/src/root-authority.ts
@@ -1,23 +1,15 @@
-import { randomBytes, randomUUID } from 'node:crypto';
-import { constants as fsConstants, type BigIntStats } from 'node:fs';
-import {
-  chmod,
-  link,
-  lstat,
-  mkdir,
-  open,
-  realpath,
-  rename,
-  stat,
-  unlink,
-  type FileHandle,
-} from 'node:fs/promises';
+import { randomBytes } from 'node:crypto';
+import { type BigIntStats } from 'node:fs';
+import { chmod, lstat, mkdir, open, realpath, stat, type FileHandle } from 'node:fs/promises';
 import { userInfo } from 'node:os';
 import { isAbsolute, join, normalize, parse, resolve } from 'node:path';
 import { tryLock, unlock } from 'fs-native-extensions';
 
+import { publishMarkerFile, readBoundedMarkerFile } from './marker-file.js';
+
 export const STORAGE_ROOT_MARKER_FILE = '.maka-storage-root.json';
 export const STORAGE_ROOT_MARKER_SCHEMA_VERSION = 1 as const;
+const MAX_STORAGE_ROOT_MARKER_BYTES = 1_024;
 
 export type StorageRootKind = 'interactive' | 'headless';
 export type StorageRootAccess = 'read' | 'write';
@@ -713,37 +705,24 @@ async function ensureRootMarker(
       ino: identity.ino.toString(),
     },
   };
-  const tempPath = join(root, `${STORAGE_ROOT_MARKER_FILE}.${process.pid}.${randomUUID()}.tmp`);
-  let tempCreated = false;
-  try {
-    const handle = await open(tempPath, 'wx', 0o600);
-    tempCreated = true;
-    try {
-      await handle.writeFile(`${JSON.stringify(marker)}\n`, 'utf8');
-      await handle.sync();
-    } finally {
-      await handle.close();
-    }
-    await assertRootPathIdentity(
-      root,
-      identity,
-      `Storage root identity changed before publishing its marker: ${root}`,
-    );
-    try {
-      await link(tempPath, markerPath);
-      await syncDirectory(root);
-    } catch (error) {
-      if (!isNodeError(error, 'EEXIST')) throw error;
-    }
-  } finally {
-    if (tempCreated) {
-      try {
-        await unlink(tempPath);
-      } catch (error) {
-        if (!isNodeError(error, 'ENOENT')) throw error;
-      }
-    }
-  }
+  await publishMarkerFile({
+    root,
+    markerFile: STORAGE_ROOT_MARKER_FILE,
+    contents: `${JSON.stringify(marker)}\n`,
+    maxBytes: MAX_STORAGE_ROOT_MARKER_BYTES,
+    publication: 'create',
+    beforePublish: () =>
+      assertRootPathIdentity(
+        root,
+        identity,
+        `Storage root identity changed before publishing its marker: ${root}`,
+      ),
+    invalidFile: () =>
+      new StorageRootAuthorityError(
+        'invalid_marker',
+        `Storage root marker candidate exceeds the size limit: ${markerPath}`,
+      ),
+  });
   return readAndValidateRootMarker(root, kind);
 }
 
@@ -767,34 +746,24 @@ async function replaceRootMarkerIdentity(
     },
   };
   const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
-  const tempPath = join(root, `${STORAGE_ROOT_MARKER_FILE}.${process.pid}.${randomUUID()}.tmp`);
-  let tempCreated = false;
-  try {
-    const handle = await open(tempPath, 'wx', 0o600);
-    tempCreated = true;
-    try {
-      await handle.writeFile(`${JSON.stringify(marker)}\n`, 'utf8');
-      await handle.sync();
-    } finally {
-      await handle.close();
-    }
-    await assertRootPathIdentity(
-      root,
-      identity,
-      `Storage root identity changed before adopting its marker: ${root}`,
-    );
-    await rename(tempPath, markerPath);
-    tempCreated = false;
-    await syncDirectory(root);
-  } finally {
-    if (tempCreated) {
-      try {
-        await unlink(tempPath);
-      } catch (error) {
-        if (!isNodeError(error, 'ENOENT')) throw error;
-      }
-    }
-  }
+  await publishMarkerFile({
+    root,
+    markerFile: STORAGE_ROOT_MARKER_FILE,
+    contents: `${JSON.stringify(marker)}\n`,
+    maxBytes: MAX_STORAGE_ROOT_MARKER_BYTES,
+    publication: 'replace',
+    beforePublish: () =>
+      assertRootPathIdentity(
+        root,
+        identity,
+        `Storage root identity changed before adopting its marker: ${root}`,
+      ),
+    invalidFile: () =>
+      new StorageRootAuthorityError(
+        'invalid_marker',
+        `Storage root marker candidate exceeds the size limit: ${markerPath}`,
+      ),
+  });
   await assertRootPathIdentity(
     root,
     identity,
@@ -839,28 +808,17 @@ async function readRootMarker(root: string): Promise<RootMarker> {
   const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
   let marker: unknown;
   try {
-    const handle = await open(markerPath, markerReadFlags());
-    try {
-      const [markerStat, pathStat] = await Promise.all([
-        handle.stat({ bigint: true }),
-        lstat(markerPath, { bigint: true }),
-      ]);
-      if (
-        !markerStat.isFile() ||
-        !pathStat.isFile() ||
-        markerStat.size > 1_024n ||
-        markerStat.dev !== pathStat.dev ||
-        markerStat.ino !== pathStat.ino
-      ) {
-        throw new StorageRootAuthorityError(
-          'invalid_marker',
-          `Storage root marker must be one bounded regular file: ${markerPath}`,
-        );
-      }
-      marker = JSON.parse(await handle.readFile('utf8'));
-    } finally {
-      await handle.close();
-    }
+    marker = JSON.parse(
+      await readBoundedMarkerFile({
+        path: markerPath,
+        maxBytes: MAX_STORAGE_ROOT_MARKER_BYTES,
+        invalidFile: () =>
+          new StorageRootAuthorityError(
+            'invalid_marker',
+            `Storage root marker must be one bounded regular file: ${markerPath}`,
+          ),
+      }),
+    );
   } catch (error) {
     if (error instanceof StorageRootAuthorityError) throw error;
     if (isNodeError(error, 'ENOENT')) {
@@ -940,16 +898,6 @@ async function ensurePrivateDirectory(path: string): Promise<void> {
   }
 }
 
-async function syncDirectory(path: string): Promise<void> {
-  if (process.platform === 'win32') return;
-  const handle = await open(path, 'r');
-  try {
-    await handle.sync();
-  } finally {
-    await handle.close();
-  }
-}
-
 async function assertStableLockArtifact(handle: FileHandle, path: string): Promise<void> {
   let stable = false;
   try {
@@ -999,11 +947,6 @@ function isMissingPathError(error: unknown): boolean {
 
 function isInvalidMarkerPathError(error: unknown): boolean {
   return isMissingPathError(error) || isNodeError(error, 'ELOOP') || isNodeError(error, 'ENXIO');
-}
-
-function markerReadFlags(): string | number {
-  if (process.platform === 'win32') return 'r';
-  return fsConstants.O_RDONLY | fsConstants.O_NONBLOCK | fsConstants.O_NOFOLLOW;
 }
 
 async function statRootIfPresent(path: string): Promise<BigIntStats | undefined> {

--- a/packages/storage/src/workspace-identity.ts
+++ b/packages/storage/src/workspace-identity.ts
@@ -1,9 +1,11 @@
 import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { constants as fsConstants, type BigIntStats } from 'node:fs';
-import { link, lstat, open, realpath, stat, unlink } from 'node:fs/promises';
+import { lstat, open, realpath, stat } from 'node:fs/promises';
 import { isAbsolute, join, normalize, parse, resolve } from 'node:path';
 import { promisify } from 'node:util';
+
+import { publishMarkerFile, readBoundedMarkerFile } from './marker-file.js';
 
 export const WORKSPACE_MARKER_FILE = '.maka-workspace.json';
 export const WORKSPACE_MARKER_SCHEMA_VERSION = 1 as const;
@@ -110,22 +112,19 @@ async function createWorkspaceMarker(
     schemaVersion: WORKSPACE_MARKER_SCHEMA_VERSION,
     workspaceId,
   };
-  const markerPath = join(snapshot.canonicalPath, WORKSPACE_MARKER_FILE);
-  const tempPath = temporaryMarkerPath(snapshot.canonicalPath);
-  let tempCreated = false;
-  try {
-    await writeMarkerFile(tempPath, marker);
-    tempCreated = true;
-    await assertWorkspaceSnapshot(snapshot);
-    try {
-      await link(tempPath, markerPath);
-      await syncDirectory(snapshot.canonicalPath);
-    } catch (error) {
-      if (!isNodeError(error, 'EEXIST')) throw error;
-    }
-  } finally {
-    if (tempCreated) await unlinkIfPresent(tempPath);
-  }
+  await publishMarkerFile({
+    root: snapshot.canonicalPath,
+    markerFile: WORKSPACE_MARKER_FILE,
+    contents: serializeWorkspaceMarker(marker),
+    maxBytes: MAX_WORKSPACE_MARKER_BYTES,
+    publication: 'create',
+    beforePublish: () => assertWorkspaceSnapshot(snapshot),
+    invalidFile: () =>
+      new WorkspaceIdentityError(
+        'invalid_workspace_marker',
+        'Workspace marker candidate exceeds the size limit',
+      ),
+  });
   await assertWorkspaceSnapshot(snapshot);
   return readWorkspaceMarker(snapshot.canonicalPath);
 }
@@ -205,20 +204,6 @@ async function hasEnclosingGitEntry(workspacePath: string): Promise<boolean> {
   }
 }
 
-async function writeMarkerFile(path: string, marker: WorkspaceMarker): Promise<void> {
-  const serializedMarker = serializeWorkspaceMarker(marker);
-  const handle = await open(path, 'wx', 0o600);
-  try {
-    await handle.writeFile(serializedMarker, 'utf8');
-    await handle.sync();
-    await handle.close();
-  } catch (error) {
-    await handle.close().catch(() => {});
-    await unlinkIfPresent(path);
-    throw error;
-  }
-}
-
 function serializeWorkspaceMarker(marker: WorkspaceMarker): string {
   if (!isWorkspaceMarker(marker)) {
     throw new WorkspaceIdentityError(
@@ -226,42 +211,24 @@ function serializeWorkspaceMarker(marker: WorkspaceMarker): string {
       'Workspace marker candidate has invalid fields',
     );
   }
-  const serializedMarker = `${JSON.stringify(marker)}\n`;
-  if (Buffer.byteLength(serializedMarker, 'utf8') > MAX_WORKSPACE_MARKER_BYTES) {
-    throw new WorkspaceIdentityError(
-      'invalid_workspace_marker',
-      'Workspace marker candidate exceeds the size limit',
-    );
-  }
-  return serializedMarker;
+  return `${JSON.stringify(marker)}\n`;
 }
 
 async function readWorkspaceMarker(root: string): Promise<WorkspaceMarker> {
   const markerPath = join(root, WORKSPACE_MARKER_FILE);
   let marker: unknown;
   try {
-    const handle = await open(markerPath, markerReadFlags());
-    try {
-      const [handleStat, pathStat] = await Promise.all([
-        handle.stat({ bigint: true }),
-        lstat(markerPath, { bigint: true }),
-      ]);
-      if (
-        !handleStat.isFile() ||
-        !pathStat.isFile() ||
-        handleStat.size > BigInt(MAX_WORKSPACE_MARKER_BYTES) ||
-        handleStat.dev !== pathStat.dev ||
-        handleStat.ino !== pathStat.ino
-      ) {
-        throw new WorkspaceIdentityError(
-          'invalid_workspace_marker',
-          `Workspace marker must be one bounded regular file: ${markerPath}`,
-        );
-      }
-      marker = JSON.parse(await handle.readFile('utf8'));
-    } finally {
-      await handle.close();
-    }
+    marker = JSON.parse(
+      await readBoundedMarkerFile({
+        path: markerPath,
+        maxBytes: MAX_WORKSPACE_MARKER_BYTES,
+        invalidFile: () =>
+          new WorkspaceIdentityError(
+            'invalid_workspace_marker',
+            `Workspace marker must be one bounded regular file: ${markerPath}`,
+          ),
+      }),
+    );
   } catch (error) {
     if (error instanceof WorkspaceIdentityError) throw error;
     if (isMissingPathError(error)) {
@@ -324,37 +291,10 @@ async function assertWorkspaceSnapshot(snapshot: WorkspaceSnapshot): Promise<voi
   }
 }
 
-function temporaryMarkerPath(root: string): string {
-  return join(root, `${WORKSPACE_MARKER_FILE}.${process.pid}.${randomUUID()}.tmp`);
-}
-
-async function unlinkIfPresent(path: string): Promise<void> {
-  try {
-    await unlink(path);
-  } catch (error) {
-    if (!isNodeError(error, 'ENOENT')) throw error;
-  }
-}
-
-async function syncDirectory(path: string): Promise<void> {
-  if (process.platform === 'win32') return;
-  const handle = await open(path, 'r');
-  try {
-    await handle.sync();
-  } finally {
-    await handle.close();
-  }
-}
-
 function canonicalizePath(path: string): string {
   const normalized = normalize(path);
   const root = parse(normalized).root;
   return normalized === root ? normalized : normalized.replace(/[\\/]+$/, '');
-}
-
-function markerReadFlags(): string | number {
-  if (process.platform === 'win32') return 'r';
-  return fsConstants.O_RDONLY | fsConstants.O_NONBLOCK | fsConstants.O_NOFOLLOW;
 }
 
 async function statWorkspaceIfPresent(path: string): Promise<BigIntStats | undefined> {

--- a/packages/storage/src/workspace-identity.ts
+++ b/packages/storage/src/workspace-identity.ts
@@ -1,7 +1,7 @@
 import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { constants as fsConstants, type BigIntStats } from 'node:fs';
-import { link, lstat, open, realpath, rename, stat, unlink } from 'node:fs/promises';
+import { link, lstat, open, realpath, stat, unlink } from 'node:fs/promises';
 import { isAbsolute, join, normalize, parse, resolve } from 'node:path';
 import { promisify } from 'node:util';
 
@@ -9,32 +9,21 @@ export const WORKSPACE_MARKER_FILE = '.maka-workspace.json';
 export const WORKSPACE_MARKER_SCHEMA_VERSION = 1 as const;
 export const WORKSPACE_IDENTITY_PREFIX = 'workspace:v1:' as const;
 const MAX_WORKSPACE_MARKER_BYTES = 4_096;
-const MAX_LEGACY_ANCHORS = 32;
 const MAX_GIT_EXCLUDE_BYTES = 1024 * 1024;
 const execFileAsync = promisify(execFile);
 
 interface WorkspaceMarker {
   schemaVersion: typeof WORKSPACE_MARKER_SCHEMA_VERSION;
   workspaceId: string;
-  legacyAnchors: string[];
 }
 
 export interface WorkspaceIdentityResolution {
   workspaceIdentity: string;
   canonicalPath: string;
-  /** Legacy filesystem identities accepted only while migrating old AgentRun headers. */
-  legacyWorkspaceIdentities: readonly string[];
 }
 
 export interface ResolveWorkspaceIdentityInput {
   path: string;
-}
-
-export interface AdoptWorkspaceIdentityOnImportInput extends ResolveWorkspaceIdentityInput {
-  /** When supplied, importing a marker with any other UUID fails closed. */
-  expectedWorkspaceIdentity?: string;
-  /** Explicit provenance supplied by an importer for a pre-marker bundle. */
-  legacyWorkspaceIdentity?: string;
 }
 
 export type WorkspaceIdentityErrorCode =
@@ -42,7 +31,6 @@ export type WorkspaceIdentityErrorCode =
   | 'invalid_workspace'
   | 'workspace_unmarked'
   | 'invalid_workspace_marker'
-  | 'workspace_identity_conflict'
   | 'workspace_identity_changed'
   | 'workspace_io_failed';
 
@@ -67,69 +55,8 @@ export async function resolveWorkspaceIdentity(
 ): Promise<WorkspaceIdentityResolution> {
   return withWorkspaceFailure(async () => {
     const snapshot = await resolveWorkspaceSnapshot(input.path);
-    const currentLegacyAnchor = legacyAnchor(snapshot.canonicalPath, snapshot.workspaceStat);
-    const marker = await ensureWorkspaceMarker(snapshot, currentLegacyAnchor);
-    return toResolution(snapshot.canonicalPath, marker, currentLegacyAnchor);
-  });
-}
-
-/**
- * Explicit import boundary. It preserves a copied marker UUID, or creates a
- * marker for a legacy bundle while recording the importer's trusted old anchor.
- */
-export async function adoptWorkspaceIdentityOnImport(
-  input: AdoptWorkspaceIdentityOnImportInput,
-): Promise<WorkspaceIdentityResolution> {
-  return withWorkspaceFailure(async () => {
-    const expectedWorkspaceId =
-      input.expectedWorkspaceIdentity === undefined
-        ? undefined
-        : parseWorkspaceIdentity(input.expectedWorkspaceIdentity);
-    if (
-      input.legacyWorkspaceIdentity !== undefined &&
-      !isLegacyWorkspaceIdentity(input.legacyWorkspaceIdentity)
-    ) {
-      throw new WorkspaceIdentityError(
-        'invalid_workspace_marker',
-        `Invalid legacy workspace identity: ${input.legacyWorkspaceIdentity}`,
-      );
-    }
-
-    const snapshot = await resolveWorkspaceSnapshot(input.path);
-    const currentLegacyAnchor = legacyAnchor(snapshot.canonicalPath, snapshot.workspaceStat);
-    let marker: WorkspaceMarker;
-    try {
-      marker = await readWorkspaceMarker(snapshot.canonicalPath);
-    } catch (error) {
-      if (!(error instanceof WorkspaceIdentityError) || error.code !== 'workspace_unmarked') {
-        throw error;
-      }
-      marker = await createWorkspaceMarker(
-        snapshot,
-        expectedWorkspaceId ?? randomUUID(),
-        uniqueStrings([input.legacyWorkspaceIdentity, currentLegacyAnchor]),
-      );
-    }
-
-    if (expectedWorkspaceId !== undefined && marker.workspaceId !== expectedWorkspaceId) {
-      throw new WorkspaceIdentityError(
-        'workspace_identity_conflict',
-        `Imported workspace marker does not match the expected identity: ${snapshot.canonicalPath}`,
-      );
-    }
-    await ensureWorkspaceMarkerIgnored(snapshot.canonicalPath);
-
-    const nextLegacyAnchors = uniqueStrings([
-      ...marker.legacyAnchors,
-      input.legacyWorkspaceIdentity,
-    ]);
-    if (!sameStrings(marker.legacyAnchors, nextLegacyAnchors)) {
-      marker = await replaceWorkspaceMarker(snapshot, {
-        ...marker,
-        legacyAnchors: nextLegacyAnchors,
-      });
-    }
-    return toResolution(snapshot.canonicalPath, marker, currentLegacyAnchor);
+    const marker = await ensureWorkspaceMarker(snapshot);
+    return toResolution(snapshot.canonicalPath, marker);
   });
 }
 
@@ -161,10 +88,7 @@ async function resolveWorkspaceSnapshot(path: string): Promise<WorkspaceSnapshot
   return { canonicalPath, workspaceStat };
 }
 
-async function ensureWorkspaceMarker(
-  snapshot: WorkspaceSnapshot,
-  currentLegacyAnchor: string,
-): Promise<WorkspaceMarker> {
+async function ensureWorkspaceMarker(snapshot: WorkspaceSnapshot): Promise<WorkspaceMarker> {
   try {
     const marker = await readWorkspaceMarker(snapshot.canonicalPath);
     await ensureWorkspaceMarkerIgnored(snapshot.canonicalPath);
@@ -174,19 +98,17 @@ async function ensureWorkspaceMarker(
       throw error;
     }
   }
-  return createWorkspaceMarker(snapshot, randomUUID(), [currentLegacyAnchor]);
+  return createWorkspaceMarker(snapshot, randomUUID());
 }
 
 async function createWorkspaceMarker(
   snapshot: WorkspaceSnapshot,
   workspaceId: string,
-  legacyAnchors: string[],
 ): Promise<WorkspaceMarker> {
   await ensureWorkspaceMarkerIgnored(snapshot.canonicalPath);
   const marker: WorkspaceMarker = {
     schemaVersion: WORKSPACE_MARKER_SCHEMA_VERSION,
     workspaceId,
-    legacyAnchors,
   };
   const markerPath = join(snapshot.canonicalPath, WORKSPACE_MARKER_FILE);
   const tempPath = temporaryMarkerPath(snapshot.canonicalPath);
@@ -283,41 +205,6 @@ async function hasEnclosingGitEntry(workspacePath: string): Promise<boolean> {
   }
 }
 
-async function replaceWorkspaceMarker(
-  snapshot: WorkspaceSnapshot,
-  marker: WorkspaceMarker,
-): Promise<WorkspaceMarker> {
-  const markerPath = join(snapshot.canonicalPath, WORKSPACE_MARKER_FILE);
-  const existing = await readWorkspaceMarker(snapshot.canonicalPath);
-  if (existing.workspaceId !== marker.workspaceId) {
-    throw new WorkspaceIdentityError(
-      'workspace_identity_conflict',
-      `Workspace identity changed while adopting an import: ${snapshot.canonicalPath}`,
-    );
-  }
-  const tempPath = temporaryMarkerPath(snapshot.canonicalPath);
-  let tempCreated = false;
-  try {
-    await writeMarkerFile(tempPath, marker);
-    tempCreated = true;
-    await assertWorkspaceSnapshot(snapshot);
-    await rename(tempPath, markerPath);
-    tempCreated = false;
-    await syncDirectory(snapshot.canonicalPath);
-  } finally {
-    if (tempCreated) await unlinkIfPresent(tempPath);
-  }
-  await assertWorkspaceSnapshot(snapshot);
-  const adopted = await readWorkspaceMarker(snapshot.canonicalPath);
-  if (adopted.workspaceId !== marker.workspaceId) {
-    throw new WorkspaceIdentityError(
-      'workspace_identity_conflict',
-      `Workspace identity changed while adopting an import: ${snapshot.canonicalPath}`,
-    );
-  }
-  return adopted;
-}
-
 async function writeMarkerFile(path: string, marker: WorkspaceMarker): Promise<void> {
   const serializedMarker = serializeWorkspaceMarker(marker);
   const handle = await open(path, 'wx', 0o600);
@@ -403,71 +290,24 @@ function isWorkspaceMarker(value: unknown): value is WorkspaceMarker {
   const marker = value as Record<string, unknown>;
   const keys = Object.keys(marker).sort();
   return (
-    keys.length === 3 &&
-    keys[0] === 'legacyAnchors' &&
-    keys[1] === 'schemaVersion' &&
-    keys[2] === 'workspaceId' &&
+    keys.length === 2 &&
+    keys[0] === 'schemaVersion' &&
+    keys[1] === 'workspaceId' &&
     marker.schemaVersion === WORKSPACE_MARKER_SCHEMA_VERSION &&
     typeof marker.workspaceId === 'string' &&
-    isUuid(marker.workspaceId) &&
-    Array.isArray(marker.legacyAnchors) &&
-    marker.legacyAnchors.length <= MAX_LEGACY_ANCHORS &&
-    marker.legacyAnchors.every(isLegacyWorkspaceIdentity) &&
-    new Set(marker.legacyAnchors).size === marker.legacyAnchors.length
+    isUuid(marker.workspaceId)
   );
-}
-
-function parseWorkspaceIdentity(value: string): string {
-  if (!value.startsWith(WORKSPACE_IDENTITY_PREFIX)) {
-    throw new WorkspaceIdentityError(
-      'invalid_workspace_marker',
-      `Invalid workspace identity: ${value}`,
-    );
-  }
-  const workspaceId = value.slice(WORKSPACE_IDENTITY_PREFIX.length);
-  if (!isUuid(workspaceId)) {
-    throw new WorkspaceIdentityError(
-      'invalid_workspace_marker',
-      `Invalid workspace identity: ${value}`,
-    );
-  }
-  return workspaceId;
 }
 
 function isUuid(value: string): boolean {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(value);
 }
 
-function isLegacyWorkspaceIdentity(value: unknown): value is string {
-  return (
-    typeof value === 'string' &&
-    /^fs:\d+:\d+:.+/.test(value) &&
-    Buffer.byteLength(value, 'utf8') <= 2_048
-  );
-}
-
-function legacyAnchor(path: string, workspaceStat: BigIntStats): string {
-  return `fs:${workspaceStat.dev.toString()}:${workspaceStat.ino.toString()}:${normalizeWorkspacePath(path)}`;
-}
-
-function toResolution(
-  canonicalPath: string,
-  marker: WorkspaceMarker,
-  currentLegacyAnchor: string,
-): WorkspaceIdentityResolution {
+function toResolution(canonicalPath: string, marker: WorkspaceMarker): WorkspaceIdentityResolution {
   return {
     workspaceIdentity: `${WORKSPACE_IDENTITY_PREFIX}${marker.workspaceId}`,
     canonicalPath,
-    legacyWorkspaceIdentities: uniqueStrings([...marker.legacyAnchors, currentLegacyAnchor]),
   };
-}
-
-function uniqueStrings(values: readonly (string | undefined)[]): string[] {
-  return [...new Set(values.filter((value): value is string => value !== undefined))];
-}
-
-function sameStrings(left: readonly string[], right: readonly string[]): boolean {
-  return left.length === right.length && left.every((value, index) => value === right[index]);
 }
 
 async function assertWorkspaceSnapshot(snapshot: WorkspaceSnapshot): Promise<void> {
@@ -510,11 +350,6 @@ function canonicalizePath(path: string): string {
   const normalized = normalize(path);
   const root = parse(normalized).root;
   return normalized === root ? normalized : normalized.replace(/[\\/]+$/, '');
-}
-
-function normalizeWorkspacePath(value: string): string {
-  const normalized = value.replaceAll('\\', '/').replace(/\/+$/, '');
-  return /^[A-Za-z]:\//.test(normalized) ? normalized.toLowerCase() : normalized;
 }
 
 function markerReadFlags(): string | number {


### PR DESCRIPTION
## Summary

- Remove the pre-release workspace legacy alias pipeline and unused workspace-adoption API, leaving exact portable UUID identity as the single continuation authority.
- Consolidate bounded no-follow reads, synced temporary writes, atomic create/replace publication, directory sync, and failure cleanup in one internal storage marker-file primitive.
- Keep workspace and storage-root schemas and policy in their existing owners; storage-root adoption and host-local authority validation remain unchanged.

Closes #1378

## Verification

- `npm test -w @maka/storage` — 471 passed, 1 skipped.
- `npm test -w @maka/runtime` — 2,391 passed, 7 skipped.
- `npm test -w maka-agent` — 644 passed, including the TUI `/move` command, directory picker, quoted-path, and moved-cwd session-driver paths.
- `npm run typecheck` — passed for all workspaces after rebuilding the locally stale `@maka/ui` output.
- `npm run lint` — passed.
- `npm run format:check` — passed.
- `git diff --check main...HEAD` — passed.

## Review focus

- New workspace markers accept exactly schema version plus UUID. Pre-release markers carrying `legacyAnchors` are intentionally rejected instead of preserving another compatibility path.
- Old `fs:` pending runs now park with `workspace_identity_mismatch`; historical session data remains readable.
- `marker-file.ts` is internal and owns only filesystem mechanics. Workspace identity and storage-root authority retain their separate validation and policy.