### PR TITLE
refactor(runtime): contain the AI SDK protocol in ModelAdapter (#1381 slice 1)

### DIFF
--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -1,7 +1,6 @@
 import { randomBytes, randomUUID } from 'node:crypto';
 import { chmod, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
-import type { ModelMessage } from 'ai';
 import {
   AiSdkBackend,
   AutomationManager,
@@ -53,6 +52,7 @@ import {
   type ShellRunUpdate,
   type SkillSource,
   type ToolAvailabilityConfig,
+  type ModelMessage,
 } from '@maka/runtime';
 import {
   createAgentRunStore,

--- a/packages/runtime/src/__tests__/active-full-compact.test.ts
+++ b/packages/runtime/src/__tests__/active-full-compact.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from '../model-protocol.js';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 
 import {

--- a/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
+++ b/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { z } from 'zod';
 import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
 import type { LanguageModelV4StreamPart, LanguageModelV4Usage } from '@ai-sdk/provider';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from '../model-protocol.js';
 
 import {
   activeToolResultLineageIdentity,

--- a/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
+++ b/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
@@ -3,7 +3,7 @@ import { describe, test } from 'node:test';
 import { z } from 'zod';
 import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
 import type { LanguageModelV4StreamPart, LanguageModelV4Usage } from '@ai-sdk/provider';
-import type { ModelMessage } from '../model-protocol.js';
+import type { ModelMessage, ModelToolSet } from '../model-protocol.js';
 
 import {
   activeToolResultLineageIdentity,
@@ -434,9 +434,9 @@ describe('active current-turn tool-result pruning', () => {
       },
     });
 
-    const aiSdkTools: Record<string, unknown> = {};
+    const modelTools: ModelToolSet = {};
     for (const tool of plan.providerTools) {
-      aiSdkTools[tool.name] = {
+      modelTools[tool.name] = {
         description: tool.description,
         inputSchema: tool.parameters,
         execute:
@@ -465,7 +465,7 @@ describe('active current-turn tool-result pruning', () => {
     const result = await newAdapter().startStream({
       model,
       messages: [{ role: 'user', content: 'load rive' }],
-      tools: aiSdkTools,
+      tools: modelTools,
       activeTools: plan.activeTools,
       prepareStep: composePrepareStep(plan.prepareStep, undefined, activePrune),
       abortSignal: new AbortController().signal,

--- a/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
+++ b/packages/runtime/src/__tests__/active-tool-result-prune.test.ts
@@ -149,7 +149,7 @@ describe('active current-turn tool-result pruning', () => {
       abortSignal: new AbortController().signal,
       repairToolCall: async () => null,
     });
-    await drain(result.stream);
+    await drain(result.events);
 
     assert.equal(prompts.length, 2, 'expected a tool step and a follow-up step');
     assert.equal(archiveRequests.length, 1);
@@ -471,7 +471,7 @@ describe('active current-turn tool-result pruning', () => {
       abortSignal: new AbortController().signal,
       repairToolCall: async () => null,
     });
-    await drain(result.stream);
+    await drain(result.events);
 
     assert.ok(!toolsPerStep[0]?.includes('RiveWorkflow'), 'step 0 hides the group tool');
     assert.ok(toolsPerStep[1]?.includes('RiveWorkflow'), 'step 1 advertises the loaded group tool');

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -2,7 +2,7 @@ import assert from 'node:assert/strict';
 import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import { describe, test } from 'node:test';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from '../model-protocol.js';
 import { MockLanguageModelV4, simulateReadableStream } from 'ai/test';
 import { APICallError, type LanguageModelV4StreamPart } from '@ai-sdk/provider';
 import type {

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -10808,24 +10808,25 @@ describe('AiSdkBackend thinking persistence', () => {
         modelAdapter: { startStream: (input: FakeStreamInput) => Promise<unknown> };
       }
     ).modelAdapter.startStream = async (input: FakeStreamInput) => ({
-      stream: (async function* () {
+      // The adapter boundary now exposes Maka-owned `ModelStreamEvent`s, not
+      // raw SDK chunks. This fake adapter yields events directly so the test
+      // drives the backend through the new contract: `step-finish` for the
+      // step boundary, `thinking` / `thinking-signature` for step 2's signed
+      // reasoning, and NO trailing `step-finish` / `finish` (the stream ends
+      // abruptly).
+      events: (async function* () {
         // Step 1 (pure tool): execute mid-step, then close the step.
         await input.tools['Read']!.execute(
           { path: 'a.md' },
           { toolCallId: 'tool-1', abortSignal: input.abortSignal },
         );
-        yield { type: 'finish-step', finishReason: { unified: 'tool-calls', raw: 'tool_calls' } };
+        yield { kind: 'step-finish', finishReason: 'tool_calls' };
         // Step 2 (thinking-only): signed reasoning, then the stream ends with
-        // NO trailing finish-step and NO finish chunk.
-        yield { type: 'reasoning-delta', delta: 'final thoughts' };
-        yield {
-          type: 'reasoning-delta',
-          delta: '',
-          providerMetadata: { anthropic: { signature: 'sig-last' } },
-        };
+        // NO trailing step-finish and NO finish event.
+        yield { kind: 'thinking', text: 'final thoughts' };
+        yield { kind: 'thinking-signature', signature: 'sig-last' };
       })(),
       usage: Promise.resolve(undefined),
-      finalStep: Promise.resolve(undefined),
       finishReason: Promise.resolve('tool-calls'),
     });
 

--- a/packages/runtime/src/__tests__/deferred-tools-prepare-step.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-prepare-step.test.ts
@@ -5,6 +5,7 @@ import { MockLanguageModelV4, convertArrayToReadableStream } from 'ai/test';
 import type { LanguageModelV4StreamPart, LanguageModelV4Usage } from '@ai-sdk/provider';
 
 import { ModelAdapter } from '../model-adapter.js';
+import type { ModelToolSet } from '../model-protocol.js';
 import { ToolAvailabilityRuntime, LOAD_TOOLS_NAME } from '../tool-availability.js';
 import type { MakaTool } from '../tool-runtime.js';
 
@@ -80,9 +81,9 @@ describe('prepareStep activates a group within the same turn (Codex Δ1)', () =>
 
     // Build the ai-sdk tools dict the backend would build, with a working
     // load_tools execute that returns the thin activation result.
-    const aiSdkTools: Record<string, unknown> = {};
+    const modelTools: ModelToolSet = {};
     for (const t of plan.providerTools) {
-      aiSdkTools[t.name] = {
+      modelTools[t.name] = {
         description: t.description,
         inputSchema: t.parameters,
         execute:
@@ -93,7 +94,7 @@ describe('prepareStep activates a group within the same turn (Codex Δ1)', () =>
     const result = await newAdapter().startStream({
       model,
       messages: [{ role: 'user', content: 'animate it' }],
-      tools: aiSdkTools,
+      tools: modelTools,
       activeTools: plan.activeTools,
       prepareStep: plan.prepareStep,
       system: 'sys',

--- a/packages/runtime/src/__tests__/deferred-tools-prepare-step.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-prepare-step.test.ts
@@ -100,7 +100,7 @@ describe('prepareStep activates a group within the same turn (Codex Δ1)', () =>
       abortSignal: new AbortController().signal,
       repairToolCall: async () => null,
     });
-    for await (const _chunk of result.stream) {
+    for await (const _chunk of result.events) {
       void _chunk;
     }
 

--- a/packages/runtime/src/__tests__/deferred-tools-wire.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-wire.test.ts
@@ -17,6 +17,7 @@ const STREAM_PARTS: LanguageModelV4StreamPart[] = [
 ];
 
 import { ModelAdapter } from '../model-adapter.js';
+import type { ModelToolSet } from '../model-protocol.js';
 import { canonicalizeToolSet } from '../request-shape.js';
 import type { MakaTool } from '../tool-runtime.js';
 
@@ -53,9 +54,9 @@ async function toolNamesSeenByProvider(activeNames: ReadonlySet<string>): Promis
   const invalid = tool('invalid');
   const canonical = canonicalizeToolSet(tools, invalid, activeNames);
 
-  const aiSdkTools: Record<string, unknown> = {};
+  const modelTools: ModelToolSet = {};
   for (const t of canonical.providerTools) {
-    aiSdkTools[t.name] = { description: t.description, inputSchema: t.parameters };
+    modelTools[t.name] = { description: t.description, inputSchema: t.parameters };
   }
 
   let seen: string[] = [];
@@ -69,7 +70,7 @@ async function toolNamesSeenByProvider(activeNames: ReadonlySet<string>): Promis
   const result = await newAdapter().startStream({
     model,
     messages: [{ role: 'user', content: 'hi' }],
-    tools: aiSdkTools,
+    tools: modelTools,
     activeTools: canonical.activeTools,
     system: 'sys',
     abortSignal: new AbortController().signal,

--- a/packages/runtime/src/__tests__/deferred-tools-wire.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-wire.test.ts
@@ -76,7 +76,7 @@ async function toolNamesSeenByProvider(activeNames: ReadonlySet<string>): Promis
     repairToolCall: async () => null,
   });
   // Drain the stream so streamText materializes the provider call.
-  for await (const _chunk of result.stream) {
+  for await (const _chunk of result.events) {
     void _chunk;
   }
   return seen;

--- a/packages/runtime/src/__tests__/model-adapter-onerror.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter-onerror.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import { MockLanguageModelV4 } from 'ai/test';
+import { convertArrayToReadableStream, MockLanguageModelV4 } from 'ai/test';
 
 import { ModelAdapter } from '../model-adapter.js';
 
@@ -16,6 +16,41 @@ function newAdapter(): ModelAdapter {
 }
 
 describe('ModelAdapter.startStream onError', () => {
+  test('returns normalized Maka-owned request metadata', async () => {
+    const model = new MockLanguageModelV4({
+      doStream: {
+        request: { body: { model: 'mock', temperature: 0 } },
+        stream: convertArrayToReadableStream([
+          { type: 'stream-start', warnings: [] },
+          {
+            type: 'finish',
+            finishReason: { unified: 'stop', raw: 'stop' },
+            usage: {
+              inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+              outputTokens: { total: 1, text: 1, reasoning: 0 },
+            },
+          },
+        ]),
+      },
+    });
+    const result = await newAdapter().startStream({
+      model,
+      messages: [{ role: 'user', content: 'hi' }],
+      tools: {},
+      activeTools: [],
+      system: 'sys',
+      abortSignal: new AbortController().signal,
+      repairToolCall: async () => null,
+    });
+    for await (const _event of result.events) {
+      void _event;
+    }
+
+    assert.deepEqual(await result.request, {
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+  });
+
   // streamText's default onError is `console.error(error)`, which dumps the
   // raw error object (stack + request bodies) straight onto the terminal,
   // bypassing the TUI transcript. Stream failures already reach the user via
@@ -44,11 +79,19 @@ describe('ModelAdapter.startStream onError', () => {
         abortSignal: new AbortController().signal,
         repairToolCall: async () => null,
       });
-      for await (const chunk of result.events) {
-        if ((chunk as { type?: unknown }).type === 'error') break;
+      const failures = [];
+      for await (const event of result.events) {
+        if (event.kind === 'error') failures.push(event.failure);
       }
       // Let any post-chunk callback settle before asserting.
       await new Promise((resolve) => setImmediate(resolve));
+      assert.deepEqual(failures, [
+        {
+          type: 'model_failure',
+          kind: 'network',
+          message: 'Network error',
+        },
+      ]);
     } finally {
       console.error = original;
     }

--- a/packages/runtime/src/__tests__/model-adapter-onerror.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter-onerror.test.ts
@@ -44,7 +44,7 @@ describe('ModelAdapter.startStream onError', () => {
         abortSignal: new AbortController().signal,
         repairToolCall: async () => null,
       });
-      for await (const chunk of result.stream) {
+      for await (const chunk of result.events) {
         if ((chunk as { type?: unknown }).type === 'error') break;
       }
       // Let any post-chunk callback settle before asserting.

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -68,13 +68,19 @@ describe('ModelAdapter stream and error normalization', () => {
         .map((event) => (event as { text: string }).text),
       ['think ', 'more'],
     );
-    const errorEvent = events.find((event) => event.kind === 'error') as
-      | Extract<ModelStreamEvent, { kind: 'error' }>
-      | undefined;
+    const errorEvent = events.find(
+      (event): event is Extract<ModelStreamEvent, { kind: 'error' }> => event.kind === 'error',
+    );
     assert.ok(errorEvent);
-    assert.equal((errorEvent.error as { code?: number }).code, 429);
-    // The adapter surfaces the raw error; the backend owns ErrorEvent shaping.
-    const shaped = adapter.makeErrorEvent('turn-1', errorEvent.error);
+    assert.deepEqual(errorEvent.failure, {
+      type: 'model_failure',
+      kind: 'rate_limit',
+      code: '429',
+      message: 'Rate limit exceeded',
+    });
+    // The backend consumes the typed failure without recovering the raw
+    // provider error shape.
+    const shaped = adapter.makeErrorEvent('turn-1', errorEvent.failure);
     assert.equal(shaped.reason, 'rate_limit');
     assert.equal(shaped.code, '429');
     assert.equal(shaped.message, 'Rate limit exceeded');

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -1,10 +1,9 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import type { SessionEvent } from '@maka/core/events';
 import { RetryError } from 'ai';
 
-import { AsyncEventQueue } from '../async-queue.js';
-import { ModelAdapter, normalizeAiSdkUsage, type AiSdkStreamChunk } from '../model-adapter.js';
+import { ModelAdapter, normalizeAiSdkUsage } from '../model-adapter.js';
+import type { ModelStreamEvent } from '../model-protocol.js';
 
 describe('ModelAdapter stream and error normalization', () => {
   test('resolves optional-key LocalAI without fabricating a credential', () => {
@@ -35,34 +34,10 @@ describe('ModelAdapter stream and error normalization', () => {
     assert.equal(observedApiKey, '');
   });
 
-  test('normalizes provider text, reasoning, ignored tool chunks, and errors into SessionEvents', () => {
-    const events: SessionEvent[] = [];
-    const queue = new AsyncEventQueue<SessionEvent>();
+  test('translates provider text, reasoning, ignored tool chunks, and errors into ModelStreamEvents', () => {
     const adapter = newAdapter();
-    const callbacks = {
-      text: '',
-      thinking: '',
-      signature: undefined as string | undefined,
-      onText(text: string) {
-        this.text += text;
-      },
-      onTextComplete(text: string) {
-        this.text = text;
-      },
-      onThinking(text: string) {
-        this.thinking += text;
-      },
-      onThinkingSignature(signature: string) {
-        this.signature = signature;
-      },
-    };
-    const push = queue.push.bind(queue);
-    queue.push = (event: SessionEvent) => {
-      events.push(event);
-      push(event);
-    };
-
-    const chunks: AiSdkStreamChunk[] = [
+    type Chunk = Parameters<typeof adapter.translateChunk>[0];
+    const chunks: Chunk[] = [
       { type: 'text-delta', text: 'hello ' },
       { type: 'text-delta', textDelta: 'world' },
       { type: 'reasoning', delta: 'think ' },
@@ -73,111 +48,84 @@ describe('ModelAdapter stream and error normalization', () => {
       { type: 'unknown-provider-chunk' },
     ];
 
-    for (const chunk of chunks) {
-      adapter.handleStreamChunk(chunk, 'turn-1', 'assistant-1', queue, callbacks);
-    }
+    const events: ModelStreamEvent[] = chunks.flatMap((chunk) => adapter.translateChunk(chunk));
 
-    assert.equal(callbacks.text, 'hello world');
-    assert.equal(callbacks.thinking, 'think more');
+    // Tool chunks and unknown chunks are inert; the error is carried as a
+    // Maka-owned `error` event for the backend to classify via makeErrorEvent.
     assert.deepEqual(
-      events.map((event) => event.type),
-      ['text_delta', 'text_delta', 'thinking_delta', 'thinking_delta', 'error'],
+      events.map((event) => event.kind),
+      ['text', 'text', 'thinking', 'thinking', 'error'],
     );
     assert.deepEqual(
-      events.filter((event) => event.type === 'text_delta').map((event) => event.text),
+      events
+        .filter((event) => event.kind === 'text')
+        .map((event) => (event as { text: string }).text),
       ['hello ', 'world'],
     );
     assert.deepEqual(
-      events.filter((event) => event.type === 'thinking_delta').map((event) => event.text),
+      events
+        .filter((event) => event.kind === 'thinking')
+        .map((event) => (event as { text: string }).text),
       ['think ', 'more'],
     );
-    const error = events.find((event) => event.type === 'error') as
-      | Extract<SessionEvent, { type: 'error' }>
+    const errorEvent = events.find((event) => event.kind === 'error') as
+      | Extract<ModelStreamEvent, { kind: 'error' }>
       | undefined;
-    assert.equal(error?.reason, 'rate_limit');
-    assert.equal(error?.code, '429');
-    assert.equal(error?.message, 'Rate limit exceeded');
+    assert.ok(errorEvent);
+    assert.equal((errorEvent.error as { code?: number }).code, 429);
+    // The adapter surfaces the raw error; the backend owns ErrorEvent shaping.
+    const shaped = adapter.makeErrorEvent('turn-1', errorEvent.error);
+    assert.equal(shaped.reason, 'rate_limit');
+    assert.equal(shaped.code, '429');
+    assert.equal(shaped.message, 'Rate limit exceeded');
   });
 
-  test('treats AI SDK 7 step boundaries (start-step / finish-step) as no-ops', () => {
-    const events: SessionEvent[] = [];
-    const queue = new AsyncEventQueue<SessionEvent>();
+  test('reduces AI SDK 7 step boundaries to Maka-owned step-finish events', () => {
     const adapter = newAdapter();
-    const callbacks = {
-      textCalls: 0,
-      thinkingCalls: 0,
-      signatureCalls: 0,
-      onText() {
-        this.textCalls += 1;
-      },
-      onTextComplete() {},
-      onThinking() {
-        this.thinkingCalls += 1;
-      },
-      onThinkingSignature() {
-        this.signatureCalls += 1;
-      },
-    };
-    const push = queue.push.bind(queue);
-    queue.push = (event: SessionEvent) => {
-      events.push(event);
-      push(event);
-    };
-
-    // The backend owns step accounting (count + per-step AssistantMessage flush
-    // + messageId rotation), so the adapter must not emit events or touch the
-    // text/thinking callbacks for step-boundary chunks.
-    const chunks: AiSdkStreamChunk[] = [
-      { type: 'start-step' } as AiSdkStreamChunk,
+    type Chunk = Parameters<typeof adapter.translateChunk>[0];
+    // The backend owns step counting + per-step AssistantMessage flush +
+    // messageId rotation, but the adapter owns reducing the SDK step-boundary
+    // chunk to a `step-finish` event carrying the normalized finish reason.
+    // `start-step` carries nothing and is inert.
+    const chunks: Chunk[] = [
+      { type: 'start-step' },
       { type: 'text-delta', text: 'one' },
-      {
-        type: 'finish-step',
-        finishReason: { unified: 'tool-calls', raw: 'tool_calls' },
-      } as AiSdkStreamChunk,
-      { type: 'start-step' } as AiSdkStreamChunk,
+      { type: 'finish-step', finishReason: { unified: 'tool-calls', raw: 'tool_calls' } },
+      { type: 'start-step' },
       { type: 'text-delta', text: 'two' },
-      { type: 'finish-step', finishReason: { unified: 'stop', raw: 'stop' } } as AiSdkStreamChunk,
+      { type: 'finish-step', finishReason: { unified: 'stop', raw: 'stop' } },
     ];
-    for (const chunk of chunks) {
-      adapter.handleStreamChunk(chunk, 'turn-1', 'assistant-1', queue, callbacks);
-    }
+    const events: ModelStreamEvent[] = chunks.flatMap((chunk) => adapter.translateChunk(chunk));
 
-    // Only the two text deltas produce events / callbacks; boundaries are inert.
     assert.deepEqual(
-      events.map((event) => event.type),
-      ['text_delta', 'text_delta'],
+      events.map((event) => event.kind),
+      ['text', 'step-finish', 'text', 'step-finish'],
     );
-    assert.equal(callbacks.textCalls, 2);
-    assert.equal(callbacks.thinkingCalls, 0);
-    assert.equal(callbacks.signatureCalls, 0);
+    assert.deepEqual(
+      events
+        .filter((event) => event.kind === 'text')
+        .map((event) => (event as { text: string }).text),
+      ['one', 'two'],
+    );
+    const stepFinishes = events.filter((event) => event.kind === 'step-finish') as Array<
+      Extract<ModelStreamEvent, { kind: 'step-finish' }>
+    >;
+    assert.deepEqual(
+      stepFinishes.map((event) => event.finishReason),
+      ['tool_calls', 'stop'],
+    );
+    // No usage on these chunks -> no usage field on the events.
+    assert.equal(stepFinishes[0].usage, undefined);
+    assert.equal(stepFinishes[1].usage, undefined);
   });
 
-  test('captures the Anthropic reasoning signature without emitting an empty thinking delta', () => {
-    const events: SessionEvent[] = [];
-    const queue = new AsyncEventQueue<SessionEvent>();
+  test('captures the Anthropic reasoning signature without emitting an empty thinking event', () => {
     const adapter = newAdapter();
-    const callbacks = {
-      thinking: '',
-      signature: undefined as string | undefined,
-      onText() {},
-      onTextComplete() {},
-      onThinking(text: string) {
-        this.thinking += text;
-      },
-      onThinkingSignature(signature: string) {
-        this.signature = signature;
-      },
-    };
-    const push = queue.push.bind(queue);
-    queue.push = (event: SessionEvent) => {
-      events.push(event);
-      push(event);
-    };
-
+    type Chunk = Parameters<typeof adapter.translateChunk>[0];
     // Mirrors the @ai-sdk/anthropic stream shape: reasoning text deltas, then a
     // standalone signature-only delta with empty text, then reasoning-end.
-    const chunks: AiSdkStreamChunk[] = [
-      { type: 'reasoning-start' } as AiSdkStreamChunk,
+    const chunks: Chunk[] = [
+      { type: 'reasoning-start' },
       { type: 'reasoning-delta', delta: 'weigh ' },
       { type: 'reasoning-delta', delta: 'options' },
       {
@@ -185,23 +133,24 @@ describe('ModelAdapter stream and error normalization', () => {
         delta: '',
         providerMetadata: { anthropic: { signature: 'sig-xyz' } },
       },
-      { type: 'reasoning-end' } as AiSdkStreamChunk,
+      { type: 'reasoning-end' },
     ];
-    for (const chunk of chunks) {
-      adapter.handleStreamChunk(chunk, 'turn-1', 'assistant-1', queue, callbacks);
-    }
+    const events: ModelStreamEvent[] = chunks.flatMap((chunk) => adapter.translateChunk(chunk));
 
-    assert.equal(callbacks.thinking, 'weigh options');
-    assert.equal(callbacks.signature, 'sig-xyz');
-    // The empty signature-carrier delta must not become a thinking_delta event.
     assert.deepEqual(
-      events.map((event) => event.type),
-      ['thinking_delta', 'thinking_delta'],
+      events.map((event) => event.kind),
+      ['thinking', 'thinking', 'thinking-signature'],
     );
     assert.deepEqual(
-      events.filter((event) => event.type === 'thinking_delta').map((event) => event.text),
+      events
+        .filter((event) => event.kind === 'thinking')
+        .map((event) => (event as { text: string }).text),
       ['weigh ', 'options'],
     );
+    const signatureEvent = events.find((event) => event.kind === 'thinking-signature') as
+      | Extract<ModelStreamEvent, { kind: 'thinking-signature' }>
+      | undefined;
+    assert.equal(signatureEvent?.signature, 'sig-xyz');
   });
 
   test('classifies provider errors and maps finish reasons through adapter-owned helpers', () => {

--- a/packages/runtime/src/__tests__/model-protocol-boundary-contract.test.ts
+++ b/packages/runtime/src/__tests__/model-protocol-boundary-contract.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Source-contract guard for the ModelAdapter provider boundary (#1381 slice 1).
+ *
+ * Mirrors the `containment-guard-contract` pattern: scan the monorepo source
+ * trees and fail if a file outside the adapter boundary re-introduces a direct
+ * AI SDK *protocol* import. The seam established by #1390 means runtime/CLI
+ * consumers import `ModelMessage` / `JSONValue` from `@maka/runtime`
+ * (re-exported from `./model-protocol.js`) instead of from `ai`; this test
+ * keeps that property cheap and enforceable as the codebase evolves.
+ *
+ * The two allowed homes are:
+ *   - `packages/runtime/src/model-protocol.ts` — the type seam (the only place
+ *     that may import the SDK message/value types).
+ *   - `packages/runtime/src/model-adapter.ts` — the value/implementation
+ *     boundary (dynamic `import('ai')` for `streamText` / `generateText` lives
+ *     here; protocol lowering/normalization is owned here).
+ *
+ * Schema helpers (`jsonSchema` / `zodSchema`), `RetryError`, and
+ * `generateText` / `LanguageModel` value imports are deliberately out of scope
+ * for slice 1 (RFC #1381 follow-up Q2/Q4) and are NOT policed by this guard —
+ * only the message/value protocol symbols are.
+ */
+import { strict as assert } from 'node:assert';
+import { readdir, readFile } from 'node:fs/promises';
+import { relative, resolve } from 'node:path';
+import { describe, it } from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../..');
+const PROTOCOL_HOME = resolve(REPO_ROOT, 'packages/runtime/src/model-protocol.ts');
+const ADAPTER_HOME = resolve(REPO_ROOT, 'packages/runtime/src/model-adapter.ts');
+const ALLOWED_HOMES = new Set([PROTOCOL_HOME, ADAPTER_HOME]);
+
+// Scan every TypeScript source tree under the monorepo; `walk` prunes tests,
+// build output, deps, worktrees, and Playwright e2e (mirrors the containment
+// guard's traversal so the two contracts stay consistent).
+const SCAN_ROOTS = ['packages', 'apps'];
+
+// SDK protocol symbols that must not cross the ModelAdapter boundary into
+// runtime/CLI consumers. Re-importing either from `ai` / `@ai-sdk/*` outside
+// the two homes re-opens the leak #1390 closed.
+const PROTOCOL_SYMBOLS = new Set(['ModelMessage', 'JSONValue']);
+const IMPORT_RE = /import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"](?:ai|@ai-sdk\/[^'"]+)['"]/g;
+
+async function* walk(dir: string): AsyncGenerator<string> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    if (['node_modules', '__tests__', 'dist', '.worktree', '.pi', 'e2e'].includes(entry.name))
+      continue;
+    const full = resolve(dir, entry.name);
+    if (entry.isDirectory()) yield* walk(full);
+    else if (entry.name.endsWith('.ts') || entry.name.endsWith('.tsx')) yield full;
+  }
+}
+
+function importedProtocolSymbols(fileText: string): string[] {
+  const found: string[] = [];
+  for (const match of fileText.matchAll(IMPORT_RE)) {
+    for (const spec of match[1].split(',')) {
+      // `ModelMessage` or `ModelMessage as Foo` — flag the source binding.
+      const name = spec.split(' as ')[0].trim();
+      if (PROTOCOL_SYMBOLS.has(name)) found.push(name);
+    }
+  }
+  return found;
+}
+
+describe('model-protocol boundary contract', () => {
+  it('the protocol seam home exists and exports ModelMessage and JSONValue', async () => {
+    const home = await readFile(PROTOCOL_HOME, 'utf8');
+    assert.match(home, /export type ModelMessage\b/, 'model-protocol.ts must export ModelMessage');
+    assert.match(home, /export type JSONValue\b/, 'model-protocol.ts must export JSONValue');
+  });
+
+  it('no source outside the adapter boundary imports ModelMessage/JSONValue from ai or @ai-sdk/*', async () => {
+    const offenders: string[] = [];
+    for (const root of SCAN_ROOTS) {
+      for await (const file of walk(resolve(REPO_ROOT, root))) {
+        if (ALLOWED_HOMES.has(file)) continue;
+        const text = await readFile(file, 'utf8');
+        const symbols = importedProtocolSymbols(text);
+        if (symbols.length > 0) {
+          offenders.push(
+            `${relative(REPO_ROOT, file)} imports ${symbols.join(', ')} from ai/ai-sdk`,
+          );
+        }
+      }
+    }
+    assert.deepEqual(
+      offenders,
+      [],
+      'ModelMessage/JSONValue must be imported from @maka/runtime (or ./model-protocol.js), not from ai. ' +
+        'Re-introducing a direct SDK protocol import outside model-protocol.ts/model-adapter.ts re-opens the #1381 slice-1 leak.',
+    );
+  });
+});

--- a/packages/runtime/src/__tests__/model-protocol-boundary-contract.test.ts
+++ b/packages/runtime/src/__tests__/model-protocol-boundary-contract.test.ts
@@ -51,6 +51,15 @@ const PROTOCOL_SYMBOLS = new Set([
   'ModelStreamEvent',
   'ModelStreamResult',
   'ModelFinishReason',
+  'ModelToolDefinition',
+  'ModelToolSet',
+  'ModelFailure',
+  'ModelRequestMetadata',
+  // Corresponding AI SDK source contracts. Aliasing one of these under a
+  // Maka name outside the adapter still crosses the boundary.
+  'Tool',
+  'ToolSet',
+  'LanguageModelRequestMetadata',
   // Retired SDK-shaped boundary types (now adapter-internal). Flagging a
   // re-import keeps the backend from re-learning raw SDK chunk names.
   'StreamTextResult',
@@ -102,6 +111,10 @@ describe('model-protocol boundary contract', () => {
     const home = await readFile(PROTOCOL_HOME, 'utf8');
     assert.match(home, /export type ModelMessage\b/, 'model-protocol.ts must export ModelMessage');
     assert.match(home, /export type JSONValue\b/, 'model-protocol.ts must export JSONValue');
+    assert.match(home, /export interface ModelToolDefinition\b/);
+    assert.match(home, /export interface ModelFailure\b/);
+    assert.match(home, /export interface ModelRequestMetadata\b/);
+    assert.doesNotMatch(home, /kind: 'error'; error: unknown/);
     assert.doesNotMatch(
       home,
       SDK_DEPENDENCY_RE,

--- a/packages/runtime/src/__tests__/model-protocol-boundary-contract.test.ts
+++ b/packages/runtime/src/__tests__/model-protocol-boundary-contract.test.ts
@@ -36,9 +36,29 @@ const ALLOWED_HOMES = new Set([PROTOCOL_HOME, ADAPTER_HOME]);
 const SCAN_ROOTS = ['packages', 'apps'];
 
 // SDK protocol symbols that must not cross the ModelAdapter boundary into
-// runtime/CLI consumers. Re-importing either from `ai` / `@ai-sdk/*` outside
-// the two homes re-opens the leak #1390 closed.
-const PROTOCOL_SYMBOLS = new Set(['ModelMessage', 'JSONValue']);
+// runtime/CLI consumers. Re-importing any of these from `ai` / `@ai-sdk/*`
+// outside the two homes re-opens the leak #1390 / #1381 slice 1 closed.
+// `NormalizedUsage` / `ModelStreamEvent` / `ModelStreamResult` /
+// `ModelFinishReason` / `RawUsageFields` are Maka-owned contracts exported from
+// `model-protocol.ts`; the adapter lowers/normalizes to them. `StreamTextResult`
+// / `AiSdkStreamChunk` are the retired SDK-shaped boundary types the relocation
+// removed — re-introducing them would re-expose raw SDK chunk names to the
+// backend.
+const PROTOCOL_SYMBOLS = new Set([
+  'ModelMessage',
+  'JSONValue',
+  'NormalizedUsage',
+  'RawUsageFields',
+  'ModelStreamEvent',
+  'ModelStreamResult',
+  'ModelFinishReason',
+  // Retired SDK-shaped boundary types (now adapter-internal). Flagging a
+  // re-import keeps the backend from re-learning raw SDK chunk names.
+  'StreamTextResult',
+  'AiSdkStreamChunk',
+  'handleStreamChunk',
+  'ModelAdapterStreamCallbacks',
+]);
 const IMPORT_RE = /import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"](?:ai|@ai-sdk\/[^'"]+)['"]/g;
 
 async function* walk(dir: string): AsyncGenerator<string> {

--- a/packages/runtime/src/__tests__/model-protocol-boundary-contract.test.ts
+++ b/packages/runtime/src/__tests__/model-protocol-boundary-contract.test.ts
@@ -8,12 +8,10 @@
  * (re-exported from `./model-protocol.js`) instead of from `ai`; this test
  * keeps that property cheap and enforceable as the codebase evolves.
  *
- * The two allowed homes are:
- *   - `packages/runtime/src/model-protocol.ts` — the type seam (the only place
- *     that may import the SDK message/value types).
- *   - `packages/runtime/src/model-adapter.ts` — the value/implementation
- *     boundary (dynamic `import('ai')` for `streamText` / `generateText` lives
- *     here; protocol lowering/normalization is owned here).
+ * The only allowed home is `packages/runtime/src/model-adapter.ts`, the
+ * value/implementation boundary where request lowering and response
+ * normalization live. `model-protocol.ts` owns independent Maka contracts and
+ * must not import the SDK at all.
  *
  * Schema helpers (`jsonSchema` / `zodSchema`), `RetryError`, and
  * `generateText` / `LanguageModel` value imports are deliberately out of scope
@@ -27,8 +25,9 @@ import { describe, it } from 'node:test';
 
 const REPO_ROOT = resolve(import.meta.dirname, '../../../..');
 const PROTOCOL_HOME = resolve(REPO_ROOT, 'packages/runtime/src/model-protocol.ts');
+const PROTOCOL_DECLARATION = resolve(REPO_ROOT, 'packages/runtime/dist/model-protocol.d.ts');
 const ADAPTER_HOME = resolve(REPO_ROOT, 'packages/runtime/src/model-adapter.ts');
-const ALLOWED_HOMES = new Set([PROTOCOL_HOME, ADAPTER_HOME]);
+const ALLOWED_HOMES = new Set([ADAPTER_HOME]);
 
 // Scan every TypeScript source tree under the monorepo; `walk` prunes tests,
 // build output, deps, worktrees, and Playwright e2e (mirrors the containment
@@ -37,7 +36,7 @@ const SCAN_ROOTS = ['packages', 'apps'];
 
 // SDK protocol symbols that must not cross the ModelAdapter boundary into
 // runtime/CLI consumers. Re-importing any of these from `ai` / `@ai-sdk/*`
-// outside the two homes re-opens the leak #1390 / #1381 slice 1 closed.
+// outside the adapter re-opens the leak #1390 / #1381 slice 1 closed.
 // `NormalizedUsage` / `ModelStreamEvent` / `ModelStreamResult` /
 // `ModelFinishReason` / `RawUsageFields` are Maka-owned contracts exported from
 // `model-protocol.ts`; the adapter lowers/normalizes to them. `StreamTextResult`
@@ -60,6 +59,7 @@ const PROTOCOL_SYMBOLS = new Set([
   'ModelAdapterStreamCallbacks',
 ]);
 const IMPORT_RE = /import\s+(?:type\s+)?\{([^}]*)\}\s*from\s*['"](?:ai|@ai-sdk\/[^'"]+)['"]/g;
+const SDK_DEPENDENCY_RE = /(?:from\s*|import\s*\(\s*)['"](?:ai|@ai-sdk\/[^'"]+)['"]/;
 
 async function* walk(dir: string): AsyncGenerator<string> {
   let entries;
@@ -90,10 +90,32 @@ function importedProtocolSymbols(fileText: string): string[] {
 }
 
 describe('model-protocol boundary contract', () => {
+  it('does not exempt the Maka-owned protocol seam from SDK import checks', () => {
+    assert.equal(
+      ALLOWED_HOMES.has(PROTOCOL_HOME),
+      false,
+      'model-protocol.ts must remain independent from ai and @ai-sdk/*',
+    );
+  });
+
   it('the protocol seam home exists and exports ModelMessage and JSONValue', async () => {
     const home = await readFile(PROTOCOL_HOME, 'utf8');
     assert.match(home, /export type ModelMessage\b/, 'model-protocol.ts must export ModelMessage');
     assert.match(home, /export type JSONValue\b/, 'model-protocol.ts must export JSONValue');
+    assert.doesNotMatch(
+      home,
+      SDK_DEPENDENCY_RE,
+      'model-protocol.ts must not import ai or @ai-sdk/*',
+    );
+  });
+
+  it('emits a declaration with no AI SDK dependency', async () => {
+    const declaration = await readFile(PROTOCOL_DECLARATION, 'utf8');
+    assert.doesNotMatch(
+      declaration,
+      SDK_DEPENDENCY_RE,
+      'model-protocol.d.ts must not import ai or @ai-sdk/*',
+    );
   });
 
   it('no source outside the adapter boundary imports ModelMessage/JSONValue from ai or @ai-sdk/*', async () => {
@@ -114,7 +136,7 @@ describe('model-protocol boundary contract', () => {
       offenders,
       [],
       'ModelMessage/JSONValue must be imported from @maka/runtime (or ./model-protocol.js), not from ai. ' +
-        'Re-introducing a direct SDK protocol import outside model-protocol.ts/model-adapter.ts re-opens the #1381 slice-1 leak.',
+        'Re-introducing a direct SDK protocol import outside model-adapter.ts re-opens the #1381 slice-1 leak.',
     );
   });
 });

--- a/packages/runtime/src/__tests__/semantic-compact.test.ts
+++ b/packages/runtime/src/__tests__/semantic-compact.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from '../model-protocol.js';
 import { buildActiveCompactionHeadAnchor } from '../active-full-compact.js';
 
 import {

--- a/packages/runtime/src/__tests__/tool-runtime-extraction-contract.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-extraction-contract.test.ts
@@ -130,6 +130,8 @@ describe('ModelAdapter extraction contract', () => {
     assert.match(adapter, /translateChunk\(/);
     assert.match(adapter, /switch \(chunk\.type\)/);
     assert.match(adapter, /case 'reasoning-delta'/);
+    assert.match(adapter, /normalizeModelFailure\(/);
+    assert.match(adapter, /include: \{ requestMessages: true \}/);
     assert.match(adapter, /makeErrorEvent\(/);
     assert.match(adapter, /mapFinishReason\(/);
     assert.match(adapter, /export function normalizeAiSdkUsage/);

--- a/packages/runtime/src/__tests__/tool-runtime-extraction-contract.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-extraction-contract.test.ts
@@ -85,11 +85,11 @@ describe('ModelAdapter extraction contract', () => {
     assert.match(backend, /private readonly modelAdapter: ModelAdapter;/);
     assert.match(backend, /this\.modelAdapter\.resolveModel\(\)/);
     assert.match(backend, /this\.modelAdapter\.startStream\(/);
-    assert.match(backend, /this\.modelAdapter\.handleStreamChunk\(/);
-    assert.match(
-      backend,
-      /normalizeAiSdkUsage\(await result\.usage,[\s\S]*?rawFinishReason[\s\S]*?\)/,
-    );
+    // #1381 slice 1: the backend consumes the Maka-owned event stream and
+    // never parses raw SDK chunk names, calls normalizeAiSdkUsage, or reads
+    // result.stream. It iterates result.events and switches on event.kind.
+    assert.match(backend, /for await \(const event of result\.events\)/);
+    assert.match(backend, /event\.kind/);
     assert.match(backend, /this\.modelAdapter\.classifyError\(/);
     assert.match(
       backend,
@@ -104,8 +104,11 @@ describe('ModelAdapter extraction contract', () => {
 
     assert.doesNotMatch(backend, /await import\('ai'\)/);
     assert.doesNotMatch(backend, /const \{ streamText, isStepCount \}/);
+    assert.doesNotMatch(backend, /this\.modelAdapter\.handleStreamChunk\(/);
     assert.doesNotMatch(backend, /switch \(chunk\.type\)/);
     assert.doesNotMatch(backend, /case 'reasoning-delta'/);
+    assert.doesNotMatch(backend, /normalizeAiSdkUsage\(await result\.usage/);
+    assert.doesNotMatch(backend, /result\.stream/);
     assert.doesNotMatch(backend, /function finiteToken/);
   });
 
@@ -121,7 +124,10 @@ describe('ModelAdapter extraction contract', () => {
     // backend's reactive overflow retry passes only the remaining budget.
     assert.match(adapter, /input\.maxSteps \?\? this\.input\.maxSteps/);
     assert.match(adapter, /isStepCount\(maxSteps\)/);
-    assert.match(adapter, /handleStreamChunk\(/);
+    // #1381 slice 1: raw SDK chunk interpretation is adapter-internal via
+    // translateChunk, which emits the Maka-owned ModelStreamEvent. The retired
+    // handleStreamChunk/callbacks boundary is gone.
+    assert.match(adapter, /translateChunk\(/);
     assert.match(adapter, /switch \(chunk\.type\)/);
     assert.match(adapter, /case 'reasoning-delta'/);
     assert.match(adapter, /makeErrorEvent\(/);

--- a/packages/runtime/src/active-full-compact-facts.ts
+++ b/packages/runtime/src/active-full-compact-facts.ts
@@ -1,4 +1,4 @@
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from './model-protocol.js';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import { estimateTokens } from './context-budget-helpers.js';
 import { serializeToolResultForArchive } from './tool-result-archive.js';

--- a/packages/runtime/src/active-full-compact.ts
+++ b/packages/runtime/src/active-full-compact.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from './model-protocol.js';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
 import {

--- a/packages/runtime/src/active-tool-result-prune.ts
+++ b/packages/runtime/src/active-tool-result-prune.ts
@@ -1,4 +1,4 @@
-import type { JSONValue, ModelMessage } from 'ai';
+import type { JSONValue, ModelMessage } from './model-protocol.js';
 
 import {
   ARCHIVED_TOOL_RESULT_REWRITE_VERSION,

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -85,7 +85,7 @@ import type {
   ToolInvocationRecord,
 } from '@maka/core/usage-stats/types';
 import type { ContextBudgetDiagnostic, PromptSegmentEstimate } from '@maka/core/usage-stats/types';
-import type { JSONValue, ModelMessage } from './model-protocol.js';
+import type { JSONValue, ModelMessage, ModelToolSet } from './model-protocol.js';
 import { z } from 'zod';
 
 import { PermissionEngine } from './permission-engine.js';
@@ -1038,11 +1038,11 @@ export class AiSdkBackend implements AgentBackend {
       this.toolRuntime.setGating(plan.gating);
     }
 
-    const aiSdkTools: Record<string, unknown> = {};
+    const modelTools: ModelToolSet = {};
     let currentStepToolExecutions = 0;
     for (const t of providerTools) {
       const execute = this.wrapToolExecute(t, turnId, queue);
-      aiSdkTools[t.name] = {
+      modelTools[t.name] = {
         description: t.description,
         inputSchema: t.parameters,
         execute: async (
@@ -1467,7 +1467,7 @@ export class AiSdkBackend implements AgentBackend {
           result = await this.modelAdapter.startStream({
             model,
             messages: attemptMessages,
-            tools: aiSdkTools,
+            tools: modelTools,
             activeTools,
             repairToolCall: async ({
               toolCall,
@@ -1490,7 +1490,7 @@ export class AiSdkBackend implements AgentBackend {
             ...(remainingStepBudget !== undefined ? { maxSteps: remainingStepBudget } : {}),
           });
 
-          let streamErrorChunk: unknown;
+          let streamFailure: unknown;
           let sawStreamError = false;
           try {
             for await (const event of result.events) {
@@ -1500,7 +1500,7 @@ export class AiSdkBackend implements AgentBackend {
                 // A request-level error ends this stream; capture it and stop
                 // consuming (the synthesized trailer carries no real step) so
                 // the recovery decision runs on the outcome, not the trailer.
-                streamErrorChunk = event.error;
+                streamFailure = event.failure;
                 sawStreamError = true;
                 break;
               }
@@ -1575,19 +1575,19 @@ export class AiSdkBackend implements AgentBackend {
               }
             }
           } catch (error) {
-            streamErrorChunk = error;
+            streamFailure = error;
             sawStreamError = true;
           }
 
           if (sawStreamError && !this.aborted) {
-            if (this.stopAfterStepRequested) throw streamErrorChunk;
+            if (this.stopAfterStepRequested) throw streamFailure;
             // A retry is a fresh provider request that would run at least one
             // more step; with the send-level budget already spent there is
             // nothing left to grant it, so the error is terminal.
             const stepBudgetRemains = this.maxSteps === undefined || runtimeSteps < this.maxSteps;
             const recovered = stepBudgetRemains
               ? await this.compaction.recoverFromOverflowError({
-                  error: streamErrorChunk,
+                  error: streamFailure,
                   retryAlreadyUsed: overflowRetryUsed,
                   midTurnState,
                   turnId,
@@ -1610,7 +1610,7 @@ export class AiSdkBackend implements AgentBackend {
               attemptObservedSteps = [];
               continue;
             }
-            const errorClass = this.modelAdapter.classifyError(streamErrorChunk);
+            const errorClass = this.modelAdapter.classifyError(streamFailure);
             if (
               errorClass === 'Network' &&
               !transportRetryUsed &&
@@ -1636,7 +1636,7 @@ export class AiSdkBackend implements AgentBackend {
             // Unrecoverable (not context-length, latch spent, no seam, or no
             // safe fold): surface the real provider error via the terminal
             // handler — never a fabricated success.
-            throw streamErrorChunk;
+            throw streamFailure;
           }
           break;
         }

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -83,7 +83,7 @@ import type {
   ToolInvocationRecord,
 } from '@maka/core/usage-stats/types';
 import type { ContextBudgetDiagnostic, PromptSegmentEstimate } from '@maka/core/usage-stats/types';
-import type { JSONValue, ModelMessage } from 'ai';
+import type { JSONValue, ModelMessage } from './model-protocol.js';
 import { z } from 'zod';
 
 import { PermissionEngine } from './permission-engine.js';

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -40,6 +40,8 @@ import type {
   TextCompleteEvent,
   ThinkingCompleteEvent,
   TokenUsageEvent,
+  TextDeltaEvent,
+  ThinkingDeltaEvent,
   StorageRef,
   AttachmentRef,
   QuoteRef,
@@ -110,16 +112,14 @@ import {
 import type { RuntimeCommitSink } from './runtime-commit-sink.js';
 import {
   ModelAdapter,
-  normalizeAiSdkUsage,
-  rawFinishReasonString,
   type ModelFactory,
   type ModelFactoryInput,
   type NormalizedAiSdkUsage,
+  type ModelStreamResult,
   type PrepareStepFunctionLike,
   type PrepareStepLike,
   type PrepareStepResultLike,
   type RepairableAiSdkToolCall,
-  type StreamTextResult,
 } from './model-adapter.js';
 import type {
   ActiveToolResultArchiveCandidate,
@@ -1453,7 +1453,7 @@ export class AiSdkBackend implements AgentBackend {
         let attemptMessages: ModelMessage[] = messages;
         let overflowRetryUsed = false;
         let transportRetryUsed = false;
-        let result!: StreamTextResult;
+        let result: ModelStreamResult;
         for (;;) {
           // The step limit is a SEND-level cap: `runtimeSteps` (this send's
           // completed steps across attempts) is its single counter, so a retry
@@ -1493,31 +1493,25 @@ export class AiSdkBackend implements AgentBackend {
           let streamErrorChunk: unknown;
           let sawStreamError = false;
           try {
-            for await (const chunk of result.stream) {
+            for await (const event of result.events) {
               if (this.aborted) break;
               watchdog.markActivity();
-              // A request-level error ends this stream; capture it and stop
-              // consuming (the synthesized trailer carries no real step) so the
-              // recovery decision runs on the outcome, not the trailer.
-              if (chunk.type === 'error') {
-                streamErrorChunk = chunk.error;
+              if (event.kind === 'error') {
+                // A request-level error ends this stream; capture it and stop
+                // consuming (the synthesized trailer carries no real step) so
+                // the recovery decision runs on the outcome, not the trailer.
+                streamErrorChunk = event.error;
                 sawStreamError = true;
                 break;
               }
-              // Step boundary: AI SDK 7 delimits steps with `start-step` /
-              // `finish-step`; `step-finish` remains accepted for replaying an
-              // older adapter fixture during the migration window.
-              // Missing the boundary would silently degrade back to one message per
-              // turn, so match both names. A duplicate boundary is harmless: the
-              // second flush no-ops (accumulators already cleared) and one extra id
-              // rotation just discards an unused id.
-              const isStepFinishChunk =
-                chunk.type === 'finish-step' || chunk.type === 'step-finish';
-              if (isStepFinishChunk) {
+              if (event.kind === 'step-finish') {
+                // Step boundary: AI SDK 7 delimits steps with `finish-step`
+                // (and `step-finish` for legacy replay fixtures); the adapter
+                // reduces both to this event. A duplicate boundary is harmless:
+                // the second flush no-ops (accumulators already cleared) and one
+                // extra id rotation just discards an unused id.
                 runtimeSteps += 1;
-                const stepUsage = normalizeAiSdkUsage(chunk.usage, {
-                  rawFinishReason: chunk.finishReason,
-                });
+                const stepUsage = event.usage;
                 if (!stepUsage) sawUnusableStepUsage = true;
                 // Fail closed: reset on every step boundary so a missing final
                 // step's usage does not leave a stale value from an earlier step.
@@ -1534,44 +1528,47 @@ export class AiSdkBackend implements AgentBackend {
                   });
                 }
               }
-              if (chunk.type === 'finish' || isStepFinishChunk) {
-                rawFinishReason = rawFinishReasonString(chunk.finishReason) ?? rawFinishReason;
+              if (event.kind === 'finish' || event.kind === 'step-finish') {
+                rawFinishReason = event.finishReason ?? rawFinishReason;
               }
-              this.modelAdapter.handleStreamChunk(
-                chunk,
-                turnId,
-                this.currentStepMessageId!,
-                queue,
-                {
-                  onText: (t) => {
-                    stepText += t;
-                  },
-                  onTextComplete: (t) => {
-                    stepText = t;
-                  },
-                  onThinking: (t) => {
-                    stepThinking += t;
-                  },
-                  onThinkingSignature: (sig) => {
-                    stepSignature = sig;
-                  },
-                },
-              );
-              // The step's text/thinking deltas are all in (the stream is
-              // drained in order), so flush this step's AssistantMessage and rotate
-              // to a fresh id for the next step. The step's tool calls (appended
-              // mid-step via execute()) already carry the pre-rotation id via
-              // `getCurrentStepId`, so replay can regroup them with this step's
-              // reasoning even though they land before this row in the ledger.
-              if (isStepFinishChunk) {
+              if (event.kind === 'text') {
+                stepText += event.text;
+                queue.push({
+                  type: 'text_delta',
+                  id: this.newId(),
+                  turnId,
+                  ts: this.now(),
+                  messageId: this.currentStepMessageId!,
+                  text: event.text,
+                } satisfies TextDeltaEvent);
+              } else if (event.kind === 'thinking') {
+                stepThinking += event.text;
+                queue.push({
+                  type: 'thinking_delta',
+                  id: this.newId(),
+                  turnId,
+                  ts: this.now(),
+                  messageId: this.currentStepMessageId!,
+                  text: event.text,
+                } satisfies ThinkingDeltaEvent);
+              } else if (event.kind === 'thinking-signature') {
+                stepSignature = event.signature;
+              } else if (event.kind === 'step-finish') {
+                // The step's text/thinking deltas are all in (the stream is
+                // drained in order), so flush this step's AssistantMessage and
+                // rotate to a fresh id for the next step. The step's tool calls
+                // (appended mid-step via execute()) already carry the pre-rotation
+                // id via `getCurrentStepId`, so replay can regroup them with this
+                // step's reasoning even though they land before this row.
                 await flushStep();
                 currentStepToolExecutions = 0;
                 this.currentStepMessageId = this.newId();
                 if (midTurnState) {
-                  // Durability clock: step N's thinking/text completion events are
-                  // enqueued by flushStep just above, so only after this boundary
-                  // can a seq-ack wait for step N mean anything. Wake waiters AFTER
-                  // the increment or they would re-check a stale count and sleep.
+                  // Durability clock: step N's thinking/text completion events
+                  // are enqueued by flushStep just above, so only after this
+                  // boundary can a seq-ack wait for step N mean anything. Wake
+                  // waiters AFTER the increment or they would re-check a stale
+                  // count and sleep.
                   midTurnState.flushedSteps += 1;
                   queue.wake();
                 }
@@ -1679,10 +1676,10 @@ export class AiSdkBackend implements AgentBackend {
 
         // With an explicit maxSteps, `finishReason === 'tool-calls'` means the
         // model wanted another tool step but the configured budget stopped it.
-        const finishReason = await result.finishReason.catch(() => 'stop');
+        const finishReason = (await result.finishReason.catch(() => 'stop')) ?? 'stop';
         const stepLimit = this.maxSteps;
         const stepLimitReached = stepLimit !== undefined && finishReason === 'tool-calls';
-        rawFinishReason = rawFinishReason ?? rawFinishReasonString(finishReason);
+        rawFinishReason = rawFinishReason ?? finishReason;
         if (stepLimitReached && runtimeSteps < stepLimit) {
           runtimeSteps = stepLimit;
         }
@@ -1698,7 +1695,7 @@ export class AiSdkBackend implements AgentBackend {
         // fails the whole record closed (#972) — a later attempt's valid
         // cumulative usage must not wash it back to "complete".
         try {
-          const attemptTotalUsage = normalizeAiSdkUsage(await result.usage, { rawFinishReason });
+          const attemptTotalUsage = await result.usage;
           tokenUsage =
             overflowRetryUsed || transportRetryUsed
               ? sawUnusableStepUsage

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -48,7 +48,7 @@ import {
 } from './history-compact-checkpoint.js';
 
 import { createHash } from 'node:crypto';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from './model-protocol.js';
 import {
   normalizeAiSdkUsage,
   type ModelAdapter,

--- a/packages/runtime/src/ai-sdk-tool-output.ts
+++ b/packages/runtime/src/ai-sdk-tool-output.ts
@@ -1,4 +1,4 @@
-import type { JSONValue } from 'ai';
+import type { JSONValue } from './model-protocol.js';
 import type { ToolModelOutput } from './tool-runtime.js';
 
 /**

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -98,7 +98,7 @@ import {
   type HistoryRewriteGatePolicy,
 } from './history-compact.js';
 
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from './model-protocol.js';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type {
   CompactionDecisionDiagnostic,

--- a/packages/runtime/src/history-compact-summarizer.ts
+++ b/packages/runtime/src/history-compact-summarizer.ts
@@ -1,4 +1,4 @@
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from './model-protocol.js';
 import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import { toolResultOutput } from './ai-sdk-tool-output.js';
 import type { HistoryCompactSummaryInput } from './ai-sdk-backend.js';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -11,6 +11,7 @@ export {
   headerToSummary,
   changesBackendConfig,
 } from './session-manager.js';
+export type { ModelMessage, JSONValue } from './model-protocol.js';
 export type {
   CompactSessionInput,
   PlanSafeBoundaryContinuationInput,

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -9,7 +9,7 @@ import { providerAuthRequiresSecret, type LlmConnection } from '@maka/core/llm-c
 import { lookupModelMetadata } from '@maka/core/model-metadata';
 import { generalizedErrorMessage } from '@maka/core/redaction';
 import type { CacheMissInputSource } from '@maka/core/usage-stats/types';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from './model-protocol.js';
 
 import type { AsyncEventQueue } from './async-queue.js';
 import { resolveModelRuntime } from './model-runtime.js';

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -10,6 +10,10 @@ import type {
   ModelStreamEvent,
   ModelStreamResult,
   ModelFinishReason,
+  ModelFailure,
+  ModelFailureKind,
+  ModelRequestMetadata,
+  ModelToolSet,
 } from './model-protocol.js';
 export type {
   NormalizedUsage,
@@ -17,6 +21,10 @@ export type {
   ModelStreamEvent,
   ModelStreamResult,
   ModelFinishReason,
+  ModelFailure,
+  ModelFailureKind,
+  ModelRequestMetadata,
+  ModelToolSet,
 } from './model-protocol.js';
 
 import { resolveModelRuntime } from './model-runtime.js';
@@ -114,7 +122,7 @@ export interface CompactSummaryResult {
 export interface ModelAdapterStreamInput {
   model: unknown;
   messages: ModelMessage[];
-  tools: Record<string, unknown>;
+  tools: ModelToolSet;
   activeTools: string[];
   system?: string;
   abortSignal: AbortSignal;
@@ -221,6 +229,10 @@ export class ModelAdapter {
       ...(input.system ? { instructions: input.system } : {}),
       ...(maxOutputTokens !== undefined ? { maxOutputTokens } : {}),
       providerOptions: this.input.providerOptions,
+      // Preserve the final request's Maka-owned message projection without
+      // retaining the provider request body. ProviderRequestTracker owns body
+      // capture; duplicating it here can retain large base64 image payloads.
+      include: { requestMessages: true },
       // streamText defaults to one step when stopWhen is omitted. Its exported
       // non-stopping condition is required for an unbounded tool loop.
       stopWhen: stopAfterStep ? [configuredStop, () => stopAfterStep()] : configuredStop,
@@ -237,14 +249,18 @@ export class ModelAdapter {
   /**
    * Lower an AI SDK `streamText` result into the Maka-owned `ModelStreamResult`.
    * The raw SDK chunk stream is translated lazily to `ModelStreamEvent`s so
-   * streaming stays live; `usage` / `finishReason` are normalized to Maka-owned
-   * contracts. No AI SDK type escapes this method.
+   * streaming stays live; failures, usage, finish reason, and request messages
+   * are normalized to Maka-owned contracts. No AI SDK type escapes this method.
    */
   private toModelStreamResult(sdk: SdkStreamResult): ModelStreamResult {
     const events: AsyncIterable<ModelStreamEvent> = {
       async *[Symbol.asyncIterator]() {
-        for await (const chunk of sdk.stream as AsyncIterable<AiSdkStreamChunk>) {
-          for (const event of translateChunk(chunk)) yield event;
+        try {
+          for await (const chunk of sdk.stream as AsyncIterable<AiSdkStreamChunk>) {
+            for (const event of translateChunk(chunk)) yield event;
+          }
+        } catch (error) {
+          yield { kind: 'error', failure: normalizeModelFailure(error) };
         }
       },
     };
@@ -257,7 +273,10 @@ export class ModelAdapter {
     })();
     const finishReason = (async () =>
       rawFinishReasonString(await sdk.finishReason.catch(() => undefined)))();
-    return { events, usage, finishReason };
+    const request = Promise.resolve(sdk.request)
+      .then(normalizeRequestMetadata)
+      .catch(() => undefined);
+    return { events, usage, finishReason, request };
   }
 
   async generateCompactSummary(input: CompactSummaryRequest): Promise<CompactSummaryResult> {
@@ -310,24 +329,21 @@ export class ModelAdapter {
   }
 
   makeErrorEvent(turnId: string, err: unknown): ErrorEvent {
-    const errorClass = classifyError(err);
-    const presentation = errorPresentationFromClass(errorClass);
-    const message = presentation.message ?? generalizedErrorMessage(err);
-    const code =
-      err instanceof Error && 'code' in err ? String((err as { code?: unknown }).code) : undefined;
+    const failure = normalizeModelFailure(err);
     return {
       type: 'error',
       id: this.input.newId(),
       turnId,
       ts: this.input.now(),
       recoverable: false,
-      ...(code !== undefined ? { code } : {}),
-      ...(presentation.reason !== undefined ? { reason: presentation.reason } : {}),
-      message,
+      ...(failure.code !== undefined ? { code: failure.code } : {}),
+      ...(failure.kind !== 'abort' && failure.kind !== 'unknown' ? { reason: failure.kind } : {}),
+      message: failure.message,
     };
   }
 
   classifyError(error: unknown): string {
+    if (isModelFailure(error)) return errorClassFromFailureKind(error.kind);
     return classifyError(error);
   }
 
@@ -415,6 +431,9 @@ interface SdkStreamResult {
   stream: AsyncIterable<AiSdkStreamChunk>;
   usage: Promise<AiSdkUsageLike | undefined>;
   finishReason: Promise<unknown>;
+  request: PromiseLike<{
+    messages?: ModelMessage[];
+  }>;
 }
 
 /**
@@ -485,10 +504,92 @@ function translateChunk(chunk: AiSdkStreamChunk): ModelStreamEvent[] {
     case 'tool-result':
       return [];
     case 'error':
-      return [{ kind: 'error', error: chunk.error }];
+      return [{ kind: 'error', failure: normalizeModelFailure(chunk.error) }];
     default:
       return [];
   }
+}
+
+function normalizeModelFailure(error: unknown): ModelFailure {
+  if (isModelFailure(error)) return error;
+  const errorClass = classifyError(error);
+  const presentation = errorPresentationFromClass(errorClass);
+  const code =
+    error instanceof Error && 'code' in error
+      ? String((error as { code?: unknown }).code)
+      : undefined;
+  return {
+    type: 'model_failure',
+    kind: modelFailureKind(errorClass),
+    ...(code !== undefined ? { code } : {}),
+    message: presentation.message ?? generalizedErrorMessage(error),
+  };
+}
+
+function isModelFailure(value: unknown): value is ModelFailure {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    (value as { type?: unknown }).type === 'model_failure' &&
+    typeof (value as { kind?: unknown }).kind === 'string' &&
+    typeof (value as { message?: unknown }).message === 'string'
+  );
+}
+
+function modelFailureKind(errorClass: string): ModelFailureKind {
+  switch (errorClass) {
+    case 'Abort':
+      return 'abort';
+    case 'Auth':
+      return 'auth';
+    case 'ContextLength':
+      return 'context_overflow';
+    case 'Network':
+      return 'network';
+    case 'ProviderBilling':
+      return 'provider_billing';
+    case 'ProviderUnavailable':
+      return 'provider_unavailable';
+    case 'RateLimit':
+      return 'rate_limit';
+    case 'Timeout':
+      return 'timeout';
+    default:
+      return 'unknown';
+  }
+}
+
+function errorClassFromFailureKind(kind: ModelFailureKind): string {
+  switch (kind) {
+    case 'abort':
+      return 'Abort';
+    case 'auth':
+      return 'Auth';
+    case 'context_overflow':
+      return 'ContextLength';
+    case 'network':
+      return 'Network';
+    case 'provider_billing':
+      return 'ProviderBilling';
+    case 'provider_unavailable':
+      return 'ProviderUnavailable';
+    case 'rate_limit':
+      return 'RateLimit';
+    case 'timeout':
+      return 'Timeout';
+    case 'unknown':
+      return 'Other';
+  }
+}
+
+function normalizeRequestMetadata(
+  metadata:
+    | {
+        messages?: ModelMessage[];
+      }
+    | undefined,
+): ModelRequestMetadata | undefined {
+  return metadata?.messages === undefined ? undefined : { messages: metadata.messages };
 }
 
 type TokenCountBreakdown = {

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -1,17 +1,24 @@
-import type {
-  ErrorEvent,
-  SessionEvent,
-  TextDeltaEvent,
-  ThinkingDeltaEvent,
-  CompleteEvent,
-} from '@maka/core/events';
+import type { ErrorEvent, CompleteEvent } from '@maka/core/events';
 import { providerAuthRequiresSecret, type LlmConnection } from '@maka/core/llm-connections';
 import { lookupModelMetadata } from '@maka/core/model-metadata';
 import { generalizedErrorMessage } from '@maka/core/redaction';
 import type { CacheMissInputSource } from '@maka/core/usage-stats/types';
-import type { ModelMessage } from './model-protocol.js';
+import type {
+  ModelMessage,
+  NormalizedUsage,
+  RawUsageFields,
+  ModelStreamEvent,
+  ModelStreamResult,
+  ModelFinishReason,
+} from './model-protocol.js';
+export type {
+  NormalizedUsage,
+  RawUsageFields,
+  ModelStreamEvent,
+  ModelStreamResult,
+  ModelFinishReason,
+} from './model-protocol.js';
 
-import type { AsyncEventQueue } from './async-queue.js';
 import { resolveModelRuntime } from './model-runtime.js';
 import { classifyError, errorPresentationFromClass } from './provider-error-classification.js';
 import type { ProviderRequestTracker } from './provider-request-telemetry.js';
@@ -135,21 +142,6 @@ export interface ModelAdapterStreamInput {
   providerRequestTracker?: ProviderRequestTracker;
 }
 
-export interface ModelAdapterStreamCallbacks {
-  onText: (text: string) => void;
-  onTextComplete: (text: string) => void;
-  onThinking: (text: string) => void;
-  /**
-   * Provider-signed reasoning signature (Anthropic). Delivered out-of-band from
-   * the thinking text: the provider emits it on a separate reasoning chunk
-   * (empty delta) or on `reasoning-end`, so the caller records it without
-   * disturbing the accumulated thinking text. The final `thinking_complete`
-   * SessionEvent is emitted by the backend's turn-finalization seam (mirroring
-   * `text_complete`), carrying the accumulated text plus this signature.
-   */
-  onThinkingSignature: (signature: string) => void;
-}
-
 interface ProviderMiddlewareStreamInput {
   doStream: () => PromiseLike<{
     stream: ReadableStream<unknown>;
@@ -183,14 +175,14 @@ export class ModelAdapter {
     });
   }
 
-  async startStream(input: ModelAdapterStreamInput): Promise<StreamTextResult> {
+  async startStream(input: ModelAdapterStreamInput): Promise<ModelStreamResult> {
     const ai = await import('ai').catch((err) => {
       throw new Error(
         `Failed to load 'ai' package. Run \`npm install ai\`. Inner: ${(err as Error).message}`,
       );
     });
     const { streamText, isStepCount, isLoopFinished, wrapLanguageModel } = ai as unknown as {
-      streamText: (opts: Record<string, unknown>) => StreamTextResult;
+      streamText: (opts: Record<string, unknown>) => SdkStreamResult;
       isStepCount: (n: number) => unknown;
       isLoopFinished: () => unknown;
       wrapLanguageModel: (input: Record<string, unknown>) => unknown;
@@ -219,7 +211,7 @@ export class ModelAdapter {
           },
         })
       : input.model;
-    return streamText({
+    const sdkResult = streamText({
       model: trackedModel,
       messages: input.messages,
       tools: input.tools,
@@ -236,9 +228,36 @@ export class ModelAdapter {
       // The SDK default onError console.errors the raw error object (stack,
       // request bodies), which lands on the terminal outside the TUI
       // transcript. Stream failures already surface through the stream
-      // `error` chunk → ErrorEvent path, so silence the default.
+      // `error` event → ErrorEvent path, so silence the default.
       onError: () => {},
-    });
+    }) as unknown as SdkStreamResult;
+    return this.toModelStreamResult(sdkResult);
+  }
+
+  /**
+   * Lower an AI SDK `streamText` result into the Maka-owned `ModelStreamResult`.
+   * The raw SDK chunk stream is translated lazily to `ModelStreamEvent`s so
+   * streaming stays live; `usage` / `finishReason` are normalized to Maka-owned
+   * contracts. No AI SDK type escapes this method.
+   */
+  private toModelStreamResult(sdk: SdkStreamResult): ModelStreamResult {
+    const events: AsyncIterable<ModelStreamEvent> = {
+      async *[Symbol.asyncIterator]() {
+        for await (const chunk of sdk.stream as AsyncIterable<AiSdkStreamChunk>) {
+          for (const event of translateChunk(chunk)) yield event;
+        }
+      },
+    };
+    const usage = (async () => {
+      const [sdkUsage, sdkFinishReason] = await Promise.all([
+        sdk.usage.catch(() => undefined),
+        sdk.finishReason.catch(() => undefined),
+      ]);
+      return normalizeAiSdkUsage(sdkUsage, { rawFinishReason: sdkFinishReason });
+    })();
+    const finishReason = (async () =>
+      rawFinishReasonString(await sdk.finishReason.catch(() => undefined)))();
+    return { events, usage, finishReason };
   }
 
   async generateCompactSummary(input: CompactSummaryRequest): Promise<CompactSummaryResult> {
@@ -279,75 +298,15 @@ export class ModelAdapter {
     };
   }
 
-  handleStreamChunk(
-    chunk: AiSdkStreamChunk,
-    turnId: string,
-    assistantMessageId: string,
-    queue: AsyncEventQueue<SessionEvent>,
-    callbacks: ModelAdapterStreamCallbacks,
-  ): void {
-    const ts = this.input.now();
-    switch (chunk.type) {
-      case 'text-delta': {
-        const text = chunk.text ?? chunk.textDelta ?? chunk.delta ?? '';
-        callbacks.onText(text);
-        queue.push({
-          type: 'text_delta',
-          id: this.input.newId(),
-          turnId,
-          ts,
-          messageId: assistantMessageId,
-          text,
-        } satisfies TextDeltaEvent);
-        break;
-      }
-      case 'reasoning':
-      case 'reasoning-delta': {
-        const text = chunk.text ?? chunk.textDelta ?? chunk.delta ?? '';
-        const signature = reasoningSignatureFromChunk(chunk);
-        if (signature) callbacks.onThinkingSignature(signature);
-        // The signed reasoning chunk arrives as a standalone delta with empty
-        // text; only stream a thinking_delta when there is actual text so the
-        // signature carrier does not surface as an empty reasoning fragment.
-        if (text) {
-          callbacks.onThinking(text);
-          queue.push({
-            type: 'thinking_delta',
-            id: this.input.newId(),
-            turnId,
-            ts,
-            messageId: assistantMessageId,
-            text,
-          } satisfies ThinkingDeltaEvent);
-        }
-        break;
-      }
-      case 'reasoning-end': {
-        const signature = reasoningSignatureFromChunk(chunk);
-        if (signature) callbacks.onThinkingSignature(signature);
-        break;
-      }
-      case 'reasoning-start':
-        break;
-      // Step boundaries (`start-step` / `finish-step`) and the terminal
-      // `finish` carry no
-      // text/thinking to stream. The backend owns step accounting: it counts and
-      // flushes one AssistantMessage per step and rotates the messageId at each
-      // `finish-step`. Handling them here would double-count, so they are no-ops.
-      case 'start-step':
-      case 'finish-step':
-      case 'step-finish': // legacy replay fixture compatibility
-      case 'finish':
-        break;
-      case 'tool-call':
-      case 'tool-result':
-        break;
-      case 'error':
-        queue.push(this.makeErrorEvent(turnId, chunk.error));
-        break;
-      default:
-        break;
-    }
+  /**
+   * Translate one raw AI SDK stream chunk into zero or more Maka-owned
+   * `ModelStreamEvent`s. This is the sole place that parses SDK chunk names
+   * (`text-delta` / `reasoning-delta` / `finish-step` / `finish` / `error` / …);
+   * the backend never sees them. Pure and side-effect-free so it is directly
+   * testable through the Maka-owned event contract.
+   */
+  translateChunk(chunk: AiSdkStreamChunk): ModelStreamEvent[] {
+    return translateChunk(chunk);
   }
 
   makeErrorEvent(turnId: string, err: unknown): ErrorEvent {
@@ -425,7 +384,13 @@ export interface ModelAdapterRuntimeEventReplaySupport {
   signedThinking: boolean;
 }
 
-export interface AiSdkStreamChunk {
+/**
+ * Internal, adapter-only shape of an AI SDK `streamText` stream chunk. This
+ * type never crosses the `ModelAdapter` boundary — `ModelAdapter.translateChunk`
+ * consumes it and emits the Maka-owned `ModelStreamEvent`. It mirrors the AI
+ * SDK chunk union just enough to read the fields Maka cares about.
+ */
+interface AiSdkStreamChunk {
   type: string;
   text?: string;
   delta?: string;
@@ -442,6 +407,17 @@ export interface AiSdkStreamChunk {
 }
 
 /**
+ * Internal, adapter-only shape of an AI SDK `streamText` result. The public
+ * boundary contract is `ModelStreamResult`; this exists only to type the
+ * lowering cast inside `ModelAdapter`.
+ */
+interface SdkStreamResult {
+  stream: AsyncIterable<AiSdkStreamChunk>;
+  usage: Promise<AiSdkUsageLike | undefined>;
+  finishReason: Promise<unknown>;
+}
+
+/**
  * Extract the provider-signed reasoning signature from a stream chunk.
  * Anthropic delivers it via `providerMetadata.anthropic.signature`; other
  * providers omit it and this returns undefined.
@@ -455,11 +431,64 @@ function reasoningSignatureFromChunk(chunk: AiSdkStreamChunk): string | undefine
   return typeof signature === 'string' && signature.length > 0 ? signature : undefined;
 }
 
-export interface StreamTextResult {
-  stream: AsyncIterable<AiSdkStreamChunk>;
-  usage: Promise<AiSdkUsageLike | undefined>;
-  finalStep: Promise<{ usage?: AiSdkUsageLike } | undefined>;
-  finishReason: Promise<unknown>;
+/**
+ * Translate one raw AI SDK stream chunk into zero or more Maka-owned
+ * `ModelStreamEvent`s. The sole site that parses SDK chunk names; the backend
+ * never sees raw chunks. Pure and side-effect-free.
+ */
+function translateChunk(chunk: AiSdkStreamChunk): ModelStreamEvent[] {
+  switch (chunk.type) {
+    case 'text-delta': {
+      const text = chunk.text ?? chunk.textDelta ?? chunk.delta ?? '';
+      return text ? [{ kind: 'text', text }] : [];
+    }
+    case 'reasoning':
+    case 'reasoning-delta': {
+      const text = chunk.text ?? chunk.textDelta ?? chunk.delta ?? '';
+      const signature = reasoningSignatureFromChunk(chunk);
+      const events: ModelStreamEvent[] = [];
+      if (signature) events.push({ kind: 'thinking-signature', signature });
+      // The signed reasoning chunk arrives as a standalone delta with empty
+      // text; only emit a `thinking` event when there is actual text so the
+      // signature carrier does not surface as an empty reasoning fragment.
+      if (text) events.push({ kind: 'thinking', text });
+      return events;
+    }
+    case 'reasoning-end': {
+      const signature = reasoningSignatureFromChunk(chunk);
+      return signature ? [{ kind: 'thinking-signature', signature }] : [];
+    }
+    // Step boundaries (`start-step` / `finish-step`) and the terminal `finish`
+    // carry no text/thinking to stream. The backend owns step accounting: it
+    // counts and flushes one AssistantMessage per step and rotates the
+    // messageId at each `finish-step`. `step-finish` is legacy replay fixture
+    // compatibility — handled as a step boundary, not a text carrier.
+    case 'finish-step':
+    case 'step-finish': {
+      const finishReason = rawFinishReasonString(chunk.finishReason);
+      const usage = normalizeAiSdkUsage(chunk.usage, { rawFinishReason: chunk.finishReason });
+      return [
+        {
+          kind: 'step-finish',
+          ...(usage ? { usage } : {}),
+          ...(finishReason ? { finishReason } : {}),
+        },
+      ];
+    }
+    case 'finish': {
+      const finishReason = rawFinishReasonString(chunk.finishReason);
+      return [{ kind: 'finish', ...(finishReason ? { finishReason } : {}) }];
+    }
+    case 'reasoning-start':
+    case 'start-step':
+    case 'tool-call':
+    case 'tool-result':
+      return [];
+    case 'error':
+      return [{ kind: 'error', error: chunk.error }];
+    default:
+      return [];
+  }
 }
 
 type TokenCountBreakdown = {
@@ -471,19 +500,12 @@ type TokenCountBreakdown = {
   reasoning?: number;
 };
 
-export interface AiSdkRawUsageFields {
-  prompt_tokens?: number;
-  completion_tokens?: number;
-  total_tokens?: number;
-  prompt_cache_hit_tokens?: number;
-  prompt_cache_miss_tokens?: number;
-  prompt_tokens_details?: {
-    cached_tokens?: number;
-  };
-  completion_tokens_details?: {
-    reasoning_tokens?: number;
-  };
-}
+/**
+ * Internal, adapter-only mirror of the AI SDK raw usage fields. The public
+ * `RawUsageFields` contract lives in `model-protocol.ts`; this stays here as
+ * the lowering input shape and is assigned to `NormalizedUsage.raw`.
+ */
+export type AiSdkRawUsageFields = RawUsageFields;
 
 export interface AiSdkUsageLike {
   promptTokens?: number;
@@ -524,25 +546,17 @@ export interface AiSdkUsageLike {
   raw?: AiSdkRawUsageFields;
 }
 
-export interface NormalizedAiSdkUsage {
-  inputTokens: number;
-  outputTokens: number;
-  cacheHitInputTokens: number;
-  cacheMissInputTokens: number;
-  cacheMissInputSource: CacheMissInputSource;
-  cacheWriteInputTokens: number;
-  reasoningTokens: number;
-  totalTokens: number;
-  rawFinishReason?: string;
-  raw?: AiSdkRawUsageFields;
-  /** Backward-compatible alias for cacheHitInputTokens. */
-  cachedInputTokens: number;
-}
+/**
+ * @deprecated alias for the Maka-owned `NormalizedUsage` contract exported
+ * from `model-protocol.ts`. Kept for backward compatibility with existing
+ * internal import sites during the slice-1 transition.
+ */
+export type NormalizedAiSdkUsage = NormalizedUsage;
 
 export function normalizeAiSdkUsage(
   usage: AiSdkUsageLike | undefined,
   options: { rawFinishReason?: unknown } = {},
-): NormalizedAiSdkUsage | undefined {
+): NormalizedUsage | undefined {
   if (!usage) return undefined;
   const reportedInputTokens =
     finiteTokenFromValueOrBreakdown(usage.inputTokens, 'total') ??

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -44,7 +44,7 @@ import {
 } from '@maka/core/runtime-event';
 import { normalizeShellToolResultContent } from '@maka/core';
 import type { AttachmentRef, QuoteRef } from '@maka/core/events';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from './model-protocol.js';
 
 // ============================================================================
 // Output type

--- a/packages/runtime/src/model-protocol.ts
+++ b/packages/runtime/src/model-protocol.ts
@@ -227,6 +227,32 @@ export type ToolResultOutput =
   | { type: 'error-json'; value: JSONValue; providerOptions?: ProviderOptions }
   | { type: 'content'; value: ToolResultContentPart[] };
 
+/**
+ * Maka-owned provider-facing tool contract. The schema stays opaque because
+ * schema construction is a local implementation detail; executable behavior
+ * remains present until #1381 moves loop ownership out of the AI SDK.
+ */
+export interface ModelToolExecutionContext {
+  toolCallId: string;
+  abortSignal: AbortSignal;
+}
+
+export interface ModelToolDefinition {
+  description?: string;
+  inputSchema: unknown;
+  execute?: (
+    input: unknown,
+    context: ModelToolExecutionContext,
+  ) => unknown | PromiseLike<unknown> | AsyncIterable<unknown>;
+  toModelOutput?: (options: {
+    toolCallId: string;
+    input: unknown;
+    output: unknown;
+  }) => ToolResultOutput | PromiseLike<ToolResultOutput>;
+}
+
+export type ModelToolSet = Record<string, ModelToolDefinition>;
+
 export interface ToolResultPart {
   type: 'tool-result';
   toolCallId: string;
@@ -336,6 +362,42 @@ export interface NormalizedUsage {
 export type ModelFinishReason = string;
 
 // ---------------------------------------------------------------------------
+// Failure contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable failure categories consumed by Runtime policy. Provider-specific
+ * error objects and AI SDK wrappers are classified inside `ModelAdapter` and
+ * never cross the boundary.
+ */
+export type ModelFailureKind =
+  | 'abort'
+  | 'auth'
+  | 'context_overflow'
+  | 'network'
+  | 'provider_billing'
+  | 'provider_unavailable'
+  | 'rate_limit'
+  | 'timeout'
+  | 'unknown';
+
+export interface ModelFailure {
+  type: 'model_failure';
+  kind: ModelFailureKind;
+  message: string;
+  code?: string;
+}
+
+/**
+ * Provider request metadata reduced to the Maka-owned message projection.
+ * Headers and provider request bodies stay with ProviderRequestTracker, their
+ * existing capture owner, instead of being retained again by the stream result.
+ */
+export interface ModelRequestMetadata {
+  messages?: readonly ModelMessage[];
+}
+
+// ---------------------------------------------------------------------------
 // Stream-event / stream-result contract
 // ---------------------------------------------------------------------------
 
@@ -356,8 +418,9 @@ export type ModelFinishReason = string;
  *   flush, and the messageId rotation.
  * - `finish`: the terminal stream boundary, carrying the normalized finish
  *   reason.
- * - `error`: a request-level provider failure. The backend captures it for
- *   overflow/transport recovery and terminal error emission.
+ * - `error`: a request-level provider failure, already classified and scrubbed
+ *   by the adapter. The backend uses its stable kind for overflow/transport
+ *   recovery and terminal error emission.
  */
 export type ModelStreamEvent =
   | { kind: 'text'; text: string }
@@ -365,17 +428,18 @@ export type ModelStreamEvent =
   | { kind: 'thinking-signature'; signature: string }
   | { kind: 'step-finish'; usage?: NormalizedUsage; finishReason?: ModelFinishReason }
   | { kind: 'finish'; finishReason?: ModelFinishReason }
-  | { kind: 'error'; error: unknown };
+  | { kind: 'error'; failure: ModelFailure };
 
 /**
  * Maka-owned result of a single `ModelAdapter.startStream` provider call. The
  * backend consumes `events` for streaming + step accounting, awaits `usage`
- * for the final billing-relevant token totals, and `finishReason` for the
- * terminal stop reason. All three are already normalized to Maka-owned types;
- * no AI SDK type crosses this surface.
+ * for the final billing-relevant token totals, `finishReason` for the terminal
+ * stop reason, and `request` for the final Maka-owned message projection. All
+ * four are normalized to Maka-owned types; no AI SDK type crosses this surface.
  */
 export interface ModelStreamResult {
   events: AsyncIterable<ModelStreamEvent>;
   usage: Promise<NormalizedUsage | undefined>;
   finishReason: Promise<ModelFinishReason | undefined>;
+  request: Promise<ModelRequestMetadata | undefined>;
 }

--- a/packages/runtime/src/model-protocol.ts
+++ b/packages/runtime/src/model-protocol.ts
@@ -1,0 +1,34 @@
+/**
+ * Maka-owned provider-boundary model protocol types.
+ *
+ * This module is the single seam where AI SDK message/value types cross into
+ * Maka-owned territory. Runtime consumers (history projection, compaction,
+ * context budget, request shape, the adapter itself) import these names from
+ * here instead of importing `ai` directly, so that `ai`'s `ModelMessage` /
+ * `JSONValue` shapes never leak past the `ModelAdapter` boundary.
+ *
+ * Per maka-agent/maka-agent#1381 (slice 1): define Maka-owned model message and
+ * tool-value contracts; keep raw AI SDK types behind `ModelAdapter`. These are
+ * type aliases to the AI SDK shapes today — the boundary is established by
+ * ownership of the import site, not by re-deriving the union. A later slice may
+ * replace the alias with a Maka-defined union once the lowering path is fully
+ * owned, but that is out of scope for the seam.
+ *
+ * Schema helpers (`jsonSchema` / `zodSchema`) and SDK value imports
+ * (`generateText`, `RetryError`, ...) remain local implementation details or
+ * follow-up work (RFC #1381 follow-up Q2/Q4); they do not belong on this
+ * boundary.
+ */
+import type { ModelMessage as AiModelMessage, JSONValue as AiJsonValue } from 'ai';
+
+/**
+ * The canonical provider-boundary message shape. One arm per role, matching
+ * the AI SDK `ModelMessage` union used by `streamText` / `generateText`.
+ */
+export type ModelMessage = AiModelMessage;
+
+/**
+ * JSON value used in tool input/output and tool-result content. Owned here so
+ * tool-output and pruning consumers do not import `ai` for it.
+ */
+export type JSONValue = AiJsonValue;

--- a/packages/runtime/src/model-protocol.ts
+++ b/packages/runtime/src/model-protocol.ts
@@ -1,34 +1,381 @@
 /**
- * Maka-owned provider-boundary model protocol types.
+ * Maka-owned provider-boundary model protocol types (#1381 slice 1).
  *
- * This module is the single seam where AI SDK message/value types cross into
- * Maka-owned territory. Runtime consumers (history projection, compaction,
- * context budget, request shape, the adapter itself) import these names from
- * here instead of importing `ai` directly, so that `ai`'s `ModelMessage` /
- * `JSONValue` shapes never leak past the `ModelAdapter` boundary.
+ * This module is the single seam where the provider-boundary message/value
+ * contract is *owned* by Maka. Runtime consumers (history projection,
+ * compaction, context budget, request shape, tool output, the adapter
+ * itself) import these names from here — never from `ai` — so AI SDK type
+ * changes no longer propagate past the `ModelAdapter` boundary.
  *
- * Per maka-agent/maka-agent#1381 (slice 1): define Maka-owned model message and
- * tool-value contracts; keep raw AI SDK types behind `ModelAdapter`. These are
- * type aliases to the AI SDK shapes today — the boundary is established by
- * ownership of the import site, not by re-deriving the union. A later slice may
- * replace the alias with a Maka-defined union once the lowering path is fully
- * owned, but that is out of scope for the seam.
+ * The shapes defined here are structurally equivalent to the AI SDK 7
+ * `@ai-sdk/provider-utils` message/value unions, but they are **Maka-owned**:
+ * the generated declaration of this module imports nothing from `ai` or
+ * `@ai-sdk/*`. Lowering Maka messages to AI SDK types, and normalizing AI SDK
+ * responses back to Maka types, happens only inside `ModelAdapter`
+ * (`model-adapter.ts`); that module is the lone runtime file permitted to
+ * import the SDK protocol types for the lowering/normalization cast.
  *
  * Schema helpers (`jsonSchema` / `zodSchema`) and SDK value imports
  * (`generateText`, `RetryError`, ...) remain local implementation details or
- * follow-up work (RFC #1381 follow-up Q2/Q4); they do not belong on this
- * boundary.
+ * follow-up work (RFC #1381 follow-up Q2/Q4) and are deliberately out of scope
+ * for this seam.
  */
-import type { ModelMessage as AiModelMessage, JSONValue as AiJsonValue } from 'ai';
+
+import type { CacheMissInputSource } from '@maka/core/usage-stats/types';
+
+// ---------------------------------------------------------------------------
+// JSON value contract
+// ---------------------------------------------------------------------------
+
+export type JSONValue = null | string | number | boolean | JSONObject | JSONArray;
+export type JSONObject = { [key: string]: JSONValue | undefined };
+export type JSONArray = JSONValue[];
+
+// ---------------------------------------------------------------------------
+// Provider metadata / options contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Provider-specific metadata/option bag, keyed by provider name. Mirrors the
+ * AI SDK `SharedV4ProviderOptions` / `SharedV4ProviderMetadata` shape so
+ * pass-through values stay structurally compatible across the lowering cast.
+ */
+export type ProviderOptions = Record<string, JSONObject>;
+export type ProviderMetadata = Record<string, JSONObject>;
+
+/**
+ * A mapping of provider names to provider-specific file identifiers. A
+ * provider reference identifies a file across providers without re-uploading.
+ * The `type?: never` constraint excludes any object that has a `type` property,
+ * so a provider reference cannot be confused with a tagged file-data shape
+ * (`{ type: 'data', data }` / `{ type: 'reference', reference }`) when both
+ * appear in the same union.
+ */
+export type ProviderReference = Record<string, string> & { type?: never };
+
+// ---------------------------------------------------------------------------
+// File / data content contract
+// ---------------------------------------------------------------------------
+
+export type DataContent = string | Uint8Array | ArrayBuffer | Buffer;
+
+export interface FileDataData {
+  type: 'data';
+  data: DataContent;
+}
+export interface FileDataUrl {
+  type: 'url';
+  url: URL;
+}
+export interface FileDataReference {
+  type: 'reference';
+  reference: ProviderReference;
+}
+export interface FileDataText {
+  type: 'text';
+  text: string;
+}
+export type FileData = FileDataData | FileDataUrl | FileDataReference | FileDataText;
+
+// ---------------------------------------------------------------------------
+// Content part contract
+// ---------------------------------------------------------------------------
+
+export interface TextPart {
+  type: 'text';
+  text: string;
+  providerOptions?: ProviderOptions;
+}
+
+export interface ImagePart {
+  type: 'image';
+  image: DataContent | URL | ProviderReference;
+  mediaType?: string;
+  providerOptions?: ProviderOptions;
+}
+
+export interface FilePart {
+  type: 'file';
+  data: FileData | DataContent | URL | ProviderReference;
+  filename?: string;
+  mediaType: string;
+  providerOptions?: ProviderOptions;
+}
+
+export interface ReasoningPart {
+  type: 'reasoning';
+  text: string;
+  providerOptions?: ProviderOptions;
+}
+
+export interface CustomPart {
+  type: 'custom';
+  kind: `${string}.${string}`;
+  providerOptions?: ProviderOptions;
+}
+
+export interface ReasoningFilePart {
+  type: 'reasoning-file';
+  data: FileDataData | FileDataUrl | DataContent | URL;
+  mediaType: string;
+  providerOptions?: ProviderOptions;
+}
+
+export interface ToolCallPart {
+  type: 'tool-call';
+  toolCallId: string;
+  toolName: string;
+  input: unknown;
+  providerOptions?: ProviderOptions;
+  providerExecuted?: boolean;
+}
+
+export type ToolApprovalRequest = {
+  type: 'tool-approval-request';
+  approvalId: string;
+  toolCallId: string;
+  isAutomatic?: boolean;
+  signature?: string;
+};
+
+export type ToolApprovalResponse = {
+  type: 'tool-approval-response';
+  approvalId: string;
+  approved: boolean;
+  reason?: string;
+  providerExecuted?: boolean;
+};
+
+// ---------------------------------------------------------------------------
+// Tool result output contract
+// ---------------------------------------------------------------------------
+
+/**
+ * One part of a `content`-shaped tool result output. Includes the legacy
+ * `file-data` / `file-url` / `file-id` / `file-reference` / `image-*` arms so
+ * any provider-emitted tool result stays structurally compatible with the
+ * Maka-owned union.
+ */
+export type ToolResultContentPart =
+  | { type: 'text'; text: string; providerOptions?: ProviderOptions }
+  | {
+      type: 'file';
+      data: FileData;
+      mediaType: string;
+      filename?: string;
+      providerOptions?: ProviderOptions;
+    }
+  | {
+      /** @deprecated use `{ type: 'file', data: { type: 'data', data } }` */
+      type: 'file-data';
+      data: string;
+      mediaType: string;
+      filename?: string;
+      providerOptions?: ProviderOptions;
+    }
+  | {
+      /** @deprecated use `{ type: 'file', data: { type: 'url', url } }` */
+      type: 'file-url';
+      url: string;
+      mediaType?: string;
+      providerOptions?: ProviderOptions;
+    }
+  | {
+      /** @deprecated use `{ type: 'file', data: { type: 'reference', reference } }` */
+      type: 'file-id';
+      fileId: string | Record<string, string>;
+      providerOptions?: ProviderOptions;
+    }
+  | {
+      /** @deprecated use `{ type: 'file', data: { type: 'reference', reference } }` */
+      type: 'file-reference';
+      providerReference: ProviderReference;
+      providerOptions?: ProviderOptions;
+    }
+  | {
+      /** @deprecated use `{ type: 'file', mediaType: 'image', data }` */
+      type: 'image-data';
+      data: string;
+      mediaType: string;
+      providerOptions?: ProviderOptions;
+    }
+  | {
+      /** @deprecated use `{ type: 'file', mediaType: 'image', data: { type: 'url', url } }` */
+      type: 'image-url';
+      url: string;
+      providerOptions?: ProviderOptions;
+    }
+  | {
+      /** @deprecated use `{ type: 'file', data: { type: 'reference', reference } }` */
+      type: 'image-file-id';
+      fileId: string | Record<string, string>;
+      providerOptions?: ProviderOptions;
+    }
+  | {
+      /** @deprecated use `{ type: 'file', data: { type: 'reference', reference } }` */
+      type: 'image-file-reference';
+      providerReference: ProviderReference;
+      providerOptions?: ProviderOptions;
+    }
+  | { type: 'custom'; providerOptions?: ProviderOptions };
+
+export type ToolResultOutput =
+  | { type: 'text'; value: string; providerOptions?: ProviderOptions }
+  | { type: 'json'; value: JSONValue; providerOptions?: ProviderOptions }
+  | { type: 'execution-denied'; reason?: string; providerOptions?: ProviderOptions }
+  | { type: 'error-text'; value: string; providerOptions?: ProviderOptions }
+  | { type: 'error-json'; value: JSONValue; providerOptions?: ProviderOptions }
+  | { type: 'content'; value: ToolResultContentPart[] };
+
+export interface ToolResultPart {
+  type: 'tool-result';
+  toolCallId: string;
+  toolName: string;
+  output: ToolResultOutput;
+  providerOptions?: ProviderOptions;
+}
+
+// ---------------------------------------------------------------------------
+// Message contract
+// ---------------------------------------------------------------------------
+
+export type AssistantContent =
+  | string
+  | Array<
+      | TextPart
+      | CustomPart
+      | FilePart
+      | ReasoningPart
+      | ReasoningFilePart
+      | ToolCallPart
+      | ToolResultPart
+      | ToolApprovalRequest
+    >;
+export type UserContent = string | Array<TextPart | ImagePart | FilePart>;
+export type ToolContent = Array<ToolResultPart | ToolApprovalResponse>;
+
+export interface SystemModelMessage {
+  role: 'system';
+  content: string;
+  providerOptions?: ProviderOptions;
+}
+export interface UserModelMessage {
+  role: 'user';
+  content: UserContent;
+  providerOptions?: ProviderOptions;
+}
+export interface AssistantModelMessage {
+  role: 'assistant';
+  content: AssistantContent;
+  providerOptions?: ProviderOptions;
+}
+export interface ToolModelMessage {
+  role: 'tool';
+  content: ToolContent;
+  providerOptions?: ProviderOptions;
+}
 
 /**
  * The canonical provider-boundary message shape. One arm per role, matching
  * the AI SDK `ModelMessage` union used by `streamText` / `generateText`.
+ * Consumers build and read this Maka-owned union; `ModelAdapter` lowers it to
+ * the AI SDK message type at the request boundary.
  */
-export type ModelMessage = AiModelMessage;
+export type ModelMessage =
+  | SystemModelMessage
+  | UserModelMessage
+  | AssistantModelMessage
+  | ToolModelMessage;
+
+// ---------------------------------------------------------------------------
+// Completion / usage / finish-reason contract
+// ---------------------------------------------------------------------------
 
 /**
- * JSON value used in tool input/output and tool-result content. Owned here so
- * tool-output and pruning consumers do not import `ai` for it.
+ * Raw provider usage fields the AI SDK surfaces, mirrored here so the
+ * normalized usage can carry a verbatim provider view without importing `ai`.
+ * Owned by Maka; only the `ModelAdapter` normalization helper reads it.
  */
-export type JSONValue = AiJsonValue;
+export interface RawUsageFields {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  prompt_cache_hit_tokens?: number;
+  prompt_cache_miss_tokens?: number;
+  prompt_tokens_details?: { cached_tokens?: number };
+  completion_tokens_details?: { reasoning_tokens?: number };
+}
+
+/**
+ * Maka-owned, provider-agnostic token-usage contract. `ModelAdapter`
+ * normalizes the AI SDK usage shape into this stable contract; runtime
+ * consumers (compaction cost, telemetry, token-usage events) read only this
+ * shape and never the SDK usage union.
+ */
+export interface NormalizedUsage {
+  inputTokens: number;
+  outputTokens: number;
+  cacheHitInputTokens: number;
+  cacheMissInputTokens: number;
+  cacheMissInputSource: CacheMissInputSource;
+  cacheWriteInputTokens: number;
+  reasoningTokens: number;
+  totalTokens: number;
+  rawFinishReason?: string;
+  raw?: RawUsageFields;
+  /** Backward-compatible alias for `cacheHitInputTokens`. */
+  cachedInputTokens: number;
+}
+
+/**
+ * Normalized provider finish reason as a Maka-owned string. The raw AI SDK
+ * finish-reason value (string or `{ raw, unified }` object) is reduced to this
+ * string only inside `ModelAdapter`; downstream code compares against the
+ * string literal (e.g. `'tool-calls'`) or maps it via `ModelAdapter.mapFinishReason`.
+ */
+export type ModelFinishReason = string;
+
+// ---------------------------------------------------------------------------
+// Stream-event / stream-result contract
+// ---------------------------------------------------------------------------
+
+/**
+ * Maka-owned discriminated stream event. `ModelAdapter` translates each raw
+ * AI SDK stream chunk into zero or more of these events; runtime consumers
+ * iterate `ModelStreamResult.events` and never see raw SDK chunk names.
+ *
+ * - `text` / `thinking`: incremental assistant content deltas for the current
+ *   step. The backend accumulates them per step and flushes one
+ *   `AssistantMessage` (+ terminal text/thinking `SessionEvent`s) at the
+ *   next `step-finish`.
+ * - `thinking-signature`: a provider-signed reasoning signature (Anthropic)
+ *   delivered out-of-band from the thinking text.
+ * - `step-finish`: a provider step boundary. Carries the step's normalized
+ *   usage (already reduced to `NormalizedUsage`) and normalized finish
+ *   reason. The backend owns step counting, the per-step `AssistantMessage`
+ *   flush, and the messageId rotation.
+ * - `finish`: the terminal stream boundary, carrying the normalized finish
+ *   reason.
+ * - `error`: a request-level provider failure. The backend captures it for
+ *   overflow/transport recovery and terminal error emission.
+ */
+export type ModelStreamEvent =
+  | { kind: 'text'; text: string }
+  | { kind: 'thinking'; text: string }
+  | { kind: 'thinking-signature'; signature: string }
+  | { kind: 'step-finish'; usage?: NormalizedUsage; finishReason?: ModelFinishReason }
+  | { kind: 'finish'; finishReason?: ModelFinishReason }
+  | { kind: 'error'; error: unknown };
+
+/**
+ * Maka-owned result of a single `ModelAdapter.startStream` provider call. The
+ * backend consumes `events` for streaming + step accounting, awaits `usage`
+ * for the final billing-relevant token totals, and `finishReason` for the
+ * terminal stop reason. All three are already normalized to Maka-owned types;
+ * no AI SDK type crosses this surface.
+ */
+export interface ModelStreamResult {
+  events: AsyncIterable<ModelStreamEvent>;
+  usage: Promise<NormalizedUsage | undefined>;
+  finishReason: Promise<ModelFinishReason | undefined>;
+}

--- a/packages/runtime/src/request-shape.ts
+++ b/packages/runtime/src/request-shape.ts
@@ -6,7 +6,7 @@ import type {
   ToolSchemaChangeReason,
   ToolAvailabilityDiagnostic,
 } from '@maka/core/usage-stats/types';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from './model-protocol.js';
 import { toJSONSchema } from 'zod';
 
 import type { MakaTool } from './tool-runtime.js';

--- a/packages/runtime/src/semantic-compact.ts
+++ b/packages/runtime/src/semantic-compact.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'node:crypto';
-import type { ModelMessage } from 'ai';
+import type { ModelMessage } from './model-protocol.js';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
 import {


### PR DESCRIPTION
## Summary

Complete #1381 Slice 1 by making the main-agent `ModelAdapter` boundary Maka-owned end to end.

- Define independent Maka contracts for JSON/model messages, provider-facing tool definitions, stream events, typed failures, usage, finish reasons, and final request-message metadata.
- Keep raw AI SDK chunks, failure classification, request lowering, and response normalization inside `ModelAdapter`; `AiSdkBackend` consumes only the Maka event/result surface.
- Preserve the existing SDK-owned multi-step loop and executable-tool behavior for this slice. Tool settlement and loop ownership remain the later #1381 slices.
- Keep provider request-body capture with the existing `ProviderRequestTracker` owner instead of retaining large request bodies a second time in the stream result.
- Guard both source and emitted declarations against reintroducing `ai` / `@ai-sdk/*` protocol dependencies outside the adapter.

Refs #1381.

## Verification

- `npm --workspace @maka/runtime test` — 2,396 passed, 7 skipped, 0 failed.
- `npm --workspace @maka/runtime run typecheck` — passed.
- `npm run lint` — passed.
- `npm run format:check` — passed.
- Repository-wide `npm run typecheck` reaches the unrelated desktop baseline failure at `apps/desktop/src/renderer/app-shell.tsx:1630` (`onSetSkillPinned`); the same failure reproduces on current `main`.

## Review focus

This is a boundary relocation, not a provider rewrite. The production path remains singular: the AI SDK still owns the current multi-step loop, while all protocol types crossing into Runtime are now Maka-owned.