### PR TITLE
fix(headless): preserve verifier services at deadline

### DIFF
--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -464,11 +464,10 @@ class MakaAgent(BaseInstalledAgent):
             run_log_path.write_bytes(stdout + stderr)
             if process.returncode == 124:
                 # run-host-cell uses 124 only after it has settled the runtime at
-                # the soft deadline and persisted maka-cell-output.json. Freeze the
-                # task before grading by reclaiming every process started through
-                # this cell, including background commands that already returned
-                # to the model but can still mutate packages or workspace files.
-                executor.mark_reclaim_scoped_processes()
+                # the soft deadline and persisted maka-cell-output.json. Stop only
+                # commands that are still active: completed commands may have
+                # intentionally left verifier-visible services running.
+                executor.mark_reclaim_active_commands()
                 return
             if process.returncode != 0:
                 message = (stderr or stdout).decode("utf-8", errors="replace").strip()
@@ -827,11 +826,14 @@ class MakaAgent(BaseInstalledAgent):
                 )
                 raise
 
-            # A non-zero runner exit is an infrastructure failure. Flag it inside
-            # the executor scope so __aexit__ reclaims scoped background processes
-            # instead of preserving them as if the run had completed. A clean exit
-            # (return code 0) still preserves verifier-visible services.
-            if proc is not None and proc.returncode != 0:
+            if proc is not None and proc.returncode == 124:
+                # The benchmark deadline is an expected scored terminal state.
+                # Reclaim only in-flight commands while preserving services from
+                # completed commands for the post-exit verifier.
+                executor.mark_reclaim_active_commands()
+            elif proc is not None and proc.returncode != 0:
+                # Other non-zero exits are infrastructure failures, so no scoped
+                # background work should survive into grading or later attempts.
                 executor.mark_reclaim_scoped_processes()
 
         parsed = self._parse_node_result(stdout)
@@ -1053,6 +1055,7 @@ class _ToolExecutorServer:
         self._futures_lock = threading.Lock()
         self._accepting_requests = False
         self._reclaim_scoped_processes = False
+        self._reclaim_active_commands = False
         self._command_cleanup_error: BaseException | None = None
         self.token = secrets.token_urlsafe(32)
         self.command_scope = secrets.token_urlsafe(24)
@@ -1081,18 +1084,25 @@ class _ToolExecutorServer:
     def mark_reclaim_scoped_processes(self) -> None:
         """Make teardown stop active scoped commands before returning.
 
-        Callers use this after a settled deadline or a non-zero runner exit,
-        where waiting for a bridged command to finish would either overrun the
-        outer benchmark timeout or leave an orphan that can affect grading.
+        Callers use this after an exception or a non-zero infrastructure exit,
+        where scoped background processes must not survive into grading.
         """
         self._reclaim_scoped_processes = True
+
+    def mark_reclaim_active_commands(self) -> None:
+        """Stop in-flight commands while preserving completed service processes."""
+        self._reclaim_active_commands = True
 
     async def __aexit__(self, exc_type: Any, exc: Any, tb: Any) -> None:
         stop_error: BaseException | None = None
         cleanup_error: BaseException | None = None
         reclaim_scope = exc_type is not None or self._reclaim_scoped_processes
+        reclaim_active = self._reclaim_active_commands and not reclaim_scope
         try:
-            cleanup_error = await self._stop_server(reclaim_scoped_processes=reclaim_scope)
+            cleanup_error = await self._stop_server(
+                reclaim_scoped_processes=reclaim_scope,
+                reclaim_active_commands=reclaim_active,
+            )
         except BaseException as error:
             stop_error = error
         if stop_error is not None and not reclaim_scope:
@@ -1106,12 +1116,26 @@ class _ToolExecutorServer:
         if command_cleanup_error is not None:
             raise command_cleanup_error
 
-    async def _stop_server(self, *, reclaim_scoped_processes: bool) -> BaseException | None:
+    async def _stop_server(
+        self,
+        *,
+        reclaim_scoped_processes: bool,
+        reclaim_active_commands: bool,
+    ) -> BaseException | None:
         with self._futures_lock:
             self._accepting_requests = False
             futures = list(self._futures)
+            active_command_ids = [
+                self._future_command_ids[future]
+                for future in futures
+                if not future.done() and future in self._future_command_ids
+            ]
         if reclaim_scoped_processes:
-            cleanup_error = await self._drain_futures_with_cleanup(futures)
+            cleanup_error = await self._drain_futures_with_cleanup(futures, None)
+        elif reclaim_active_commands:
+            cleanup_error = await self._drain_futures_with_cleanup(
+                futures, active_command_ids
+            )
         else:
             cleanup_error = await self._drain_futures(futures)
         if self._server is not None:
@@ -1133,9 +1157,10 @@ class _ToolExecutorServer:
     async def _drain_futures_with_cleanup(
         self,
         futures: list[concurrent.futures.Future[Any]],
+        command_ids: list[str] | None,
     ) -> BaseException | None:
         while any(not future.done() for future in futures):
-            cleanup_error = await self._cleanup_processes(None)
+            cleanup_error = await self._cleanup_processes(command_ids)
             if cleanup_error is not None:
                 for future in futures:
                     future.cancel()
@@ -1143,7 +1168,7 @@ class _ToolExecutorServer:
                 return cleanup_error
             await asyncio.sleep(0.2)
         await self._drain_futures(futures)
-        return await self._cleanup_processes(None)
+        return await self._cleanup_processes(command_ids)
 
     async def _cleanup_processes(
         self, command_ids: list[str] | None

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -419,6 +419,9 @@ describe('Harbor adapter contract', () => {
     // A non-zero runner subprocess is flagged as an infra failure inside the
     // executor scope so teardown reclaims orphaned scoped background processes.
     assert.match(source, /executor\.mark_reclaim_scoped_processes\(\)/);
+    // A scored deadline preserves services from completed commands for the
+    // post-exit verifier while still reclaiming commands that remain active.
+    assert.match(source, /executor\.mark_reclaim_active_commands\(\)/);
     // The bridged tool exec is a bare container exec (real exit code returned as
     // a 200), not exec_as_agent (which raises on non-zero and injects agent env).
     assert.match(source, /self\._environment\.exec\(\s*\n\s*command=_scoped_command\(/);
@@ -1116,6 +1119,7 @@ function pierPython(): string | null {
 function pythonBridgeContractScript(root: string): string {
   return String.raw`
 import asyncio
+import concurrent.futures
 import contextlib
 import json
 import os
@@ -1273,7 +1277,7 @@ async def fix3_infra_failure_reclaims_scoped_processes():
     assert preserved is None, "clean exit killed a verifier-visible scoped process"
 
 
-async def fix4_deadline_reclaims_all_scoped_commands():
+async def fix4_deadline_reclaims_only_active_commands():
     with tempfile.TemporaryDirectory() as tmp:
         agent = MakaAgent(Path(tmp))
         env = BlockingLocalShellEnv()
@@ -1299,15 +1303,14 @@ async def fix4_deadline_reclaims_all_scoped_commands():
                     {"command": "sleep 30"},
                 ))
                 await asyncio.wait_for(env.active_started.wait(), timeout=2)
-                server.mark_reclaim_scoped_processes()
+                server.mark_reclaim_active_commands()
             await request
             assert env.active_process is not None and env.active_process.returncode is not None, (
                 "deadline teardown left an active bridged command running"
             )
-            deadline = time.time() + 2
-            while service.poll() is None and time.time() < deadline:
-                time.sleep(0.02)
-            assert service.poll() is not None, "deadline teardown left a completed background command running"
+            assert service.poll() is None, (
+                "deadline teardown killed a completed verifier-visible service"
+            )
         finally:
             if request is not None and not request.done():
                 request.cancel()
@@ -1321,6 +1324,25 @@ async def fix4_deadline_reclaims_all_scoped_commands():
                 for path in scope_dir.glob("*"):
                     path.unlink()
                 scope_dir.rmdir()
+
+
+async def fix4b_deadline_ignores_done_but_still_mapped_commands():
+    with tempfile.TemporaryDirectory() as tmp:
+        server = m._ToolExecutorServer(MakaAgent(Path(tmp)), LocalShellEnv())
+        completed = concurrent.futures.Future()
+        completed.set_result(None)
+        server._futures.add(completed)
+        server._future_command_ids[completed] = "completed-command"
+        cleanup_calls = []
+
+        async def capture_cleanup(command_ids):
+            cleanup_calls.append(command_ids)
+            return None
+
+        server._cleanup_processes = capture_cleanup
+        server.mark_reclaim_active_commands()
+        await server.__aexit__(None, None, None)
+        assert cleanup_calls == [[]], cleanup_calls
 
 
 class TimedOutLocalShellEnv:
@@ -1460,7 +1482,8 @@ async def fix6_cleanup_failure_is_not_reported_as_a_typed_timeout():
 asyncio.run(fix1_bridge_exec_contract())
 asyncio.run(fix2_workdir_probe_falls_back())
 asyncio.run(fix3_infra_failure_reclaims_scoped_processes())
-asyncio.run(fix4_deadline_reclaims_all_scoped_commands())
+asyncio.run(fix4_deadline_reclaims_only_active_commands())
+asyncio.run(fix4b_deadline_ignores_done_but_still_mapped_commands())
 asyncio.run(fix5_timed_out_command_is_reclaimed_immediately())
 asyncio.run(fix6_cleanup_failure_is_not_reported_as_a_typed_timeout())
 print("bridge-contract ok")
@@ -2155,6 +2178,7 @@ with tempfile.TemporaryDirectory() as tmp:
             self.url = "http://127.0.0.1:4321"
             self.token = "tool-token"
             self.reclaim_scoped_processes = False
+            self.reclaim_active_commands = False
             self.instances.append(self)
 
         async def __aenter__(self):
@@ -2165,6 +2189,9 @@ with tempfile.TemporaryDirectory() as tmp:
 
         def mark_reclaim_scoped_processes(self):
             self.reclaim_scoped_processes = True
+
+        def mark_reclaim_active_commands(self):
+            self.reclaim_active_commands = True
 
     class FakeHostProcess:
         pid = 123
@@ -2316,7 +2343,8 @@ with tempfile.TemporaryDirectory() as tmp:
             )
         )
         assert captured_host_process["kwargs"]["env"]["MAKA_CELL_SOFT_TIMEOUT_MS"] == "50000"
-        assert FakeToolExecutor.instances[-1].reclaim_scoped_processes
+        assert FakeToolExecutor.instances[-1].reclaim_active_commands
+        assert not FakeToolExecutor.instances[-1].reclaim_scoped_processes
 
         captured_host_process.clear()
         captured_host_process.update(host_cell_process)
@@ -2332,9 +2360,10 @@ with tempfile.TemporaryDirectory() as tmp:
 
         asyncio.create_subprocess_exec = fake_deadline_subprocess_exec
         asyncio.run(host_process_agent._run_host_cell(host_process_environment, Path(tmp) / "instruction.txt"))
-        assert FakeToolExecutor.instances[-1].reclaim_scoped_processes, (
-            "a settled deadline must freeze the workspace by reclaiming every scoped process"
+        assert FakeToolExecutor.instances[-1].reclaim_active_commands, (
+            "a settled deadline must reclaim commands still active at the cutoff"
         )
+        assert not FakeToolExecutor.instances[-1].reclaim_scoped_processes
 
         class CancelledHostProcess:
             def __init__(self):


### PR DESCRIPTION
## Summary

Preserve verifier-visible services after a scored Harbor deadline. Executor teardown now snapshots only command IDs whose futures are not done and reclaims those commands on return code 124, while services launched by commands that already completed remain available to the post-agent verifier.

Other nonzero infrastructure exits and exceptions still reclaim the whole command scope. Clean completion continues to preserve scoped services.

## Verification

- RED: real local-process Harbor bridge contract failed because deadline teardown had no active-command-only lifecycle (`AttributeError: _ToolExecutorServer.mark_reclaim_active_commands`)
- RED: deterministic done-but-still-mapped future passed `completed-command` to deadline cleanup instead of an empty command-ID list
- `npm --workspace @maka/headless test` (1282 tests: 1281 passed, 1 conditionally skipped)
- `npm run lint`
- `npm run format:check`
- `python3 -m py_compile packages/headless/harbor/maka_agent.py`
- `git diff --check`