### PR TITLE
fix(headless): retry verifier after apt repository 502

### DIFF
--- a/packages/headless/harbor/maka_verifier.py
+++ b/packages/headless/harbor/maka_verifier.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import math
+import re
 import shlex
 import time
 from pathlib import Path
@@ -25,6 +26,10 @@ _INFRA_LINE_PREFIXES = (
     "e: failed to fetch http://",
     "e: failed to fetch https://",
     "curl: (35) openssl ssl_connect: ssl_error_syscall in connection to astral.sh:443",
+)
+_APT_REPOSITORY_502_RE = re.compile(
+    r"\berr:\d+\s+https?://[^\s'\"\\]+(?:(?!\\n)[^\r\n])*(?:\\n|\r?\n)[ \t]*502[ \t]+bad gateway\b",
+    re.IGNORECASE,
 )
 
 
@@ -205,7 +210,7 @@ def _read_optional_text(path: Path) -> str:
 
 
 def _is_infra_failure(text: str) -> bool:
-    return any(
+    return _APT_REPOSITORY_502_RE.search(text) is not None or any(
         line.strip().lower().startswith(prefix)
         for line in text.splitlines()
         for prefix in _INFRA_LINE_PREFIXES

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -3612,6 +3612,24 @@ class FakeEnvironment:
             self.trial_paths.test_stdout_path.write_text("E: Failed to fetch https://deb.example.invalid/pkg.deb 502 Bad Gateway", encoding="utf-8")
             self.trial_paths.reward_text_path.write_text("0\n", encoding="utf-8")
             return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+        if outcome == "infra_pytest_escaped_newline_with_fail_reward":
+            self.trial_paths.test_stdout_path.write_text(
+                "E       assert 'TEST PASSED' in 'Err:1 http://archive.ubuntu.com/ubuntu noble InRelease\\n"
+                "  502  Bad Gateway [IP: 198.18.0.119 80]\\nErr:2 http://security.ubuntu.com/ubuntu noble-security InRelease\\n'\n"
+                "E        +  where ... = CompletedProcess(args=['bash', '/tests/verify.sh'], returncode=0).stdout",
+                encoding="utf-8",
+            )
+            self.trial_paths.reward_text_path.write_text("0\n", encoding="utf-8")
+            return types.SimpleNamespace(return_code=0, stdout="", stderr="")
+        if outcome == "infra_pytest_real_newline_with_fail_reward":
+            self.trial_paths.test_stdout_path.write_text(
+                "E       assert 'TEST PASSED' in 'Err:1 http://archive.ubuntu.com/ubuntu noble InRelease\n"
+                "  502  Bad Gateway [IP: 198.18.0.119 80]\nErr:2 http://security.ubuntu.com/ubuntu noble-security InRelease\n'\n"
+                "E        +  where ... = CompletedProcess(args=['bash', '/tests/verify.sh'], returncode=0).stdout",
+                encoding="utf-8",
+            )
+            self.trial_paths.reward_text_path.write_text("0\n", encoding="utf-8")
+            return types.SimpleNamespace(return_code=0, stdout="", stderr="")
         if outcome == "infra_curl_ssl_with_fail_reward":
             self.trial_paths.test_stdout_path.write_text(
                 "curl: (35) OpenSSL SSL_connect: SSL_ERROR_SYSCALL in connection to astral.sh:443\n"
@@ -3625,8 +3643,11 @@ class FakeEnvironment:
             self.trial_paths.test_stdout_path.write_text("APT warning: Failed to fetch optional archive", encoding="utf-8")
             self.trial_paths.reward_text_path.write_text("1\n", encoding="utf-8")
             return types.SimpleNamespace(return_code=0, stdout="", stderr="")
-        if outcome == "warning_with_fail_reward":
-            self.trial_paths.test_stdout_path.write_text("assertion expected: 502 Bad Gateway", encoding="utf-8")
+        if outcome == "candidate_assertion_mentions_apt_502":
+            self.trial_paths.test_stdout_path.write_text(
+                "E       assert 'Err:1 http://archive.ubuntu.com/ubuntu noble InRelease expected status: 502 Bad Gateway' == 'success'",
+                encoding="utf-8",
+            )
             self.trial_paths.reward_text_path.write_text("0\n", encoding="utf-8")
             return types.SimpleNamespace(return_code=0, stdout="", stderr="")
         if outcome == "timeout":
@@ -3676,6 +3697,18 @@ assert outcome["outcome"] == "passed", outcome
 assert [item["classification"] for item in outcome["attempts"]] == ["infra_setup_failed", "passed"], outcome
 assert len([command for command in commands if "timeout --signal=KILL" in command]) == 2, commands
 
+result, outcome, commands = asyncio.run(run_case(["infra_pytest_escaped_newline_with_fail_reward", "pass"]))
+assert result.rewards == {"reward": 1.0}, result.rewards
+assert outcome["outcome"] == "passed", outcome
+assert [item["classification"] for item in outcome["attempts"]] == ["infra_setup_failed", "passed"], outcome
+assert len([command for command in commands if "timeout --signal=KILL" in command]) == 2, commands
+
+result, outcome, commands = asyncio.run(run_case(["infra_pytest_real_newline_with_fail_reward", "pass"]))
+assert result.rewards == {"reward": 1.0}, result.rewards
+assert outcome["outcome"] == "passed", outcome
+assert [item["classification"] for item in outcome["attempts"]] == ["infra_setup_failed", "passed"], outcome
+assert len([command for command in commands if "timeout --signal=KILL" in command]) == 2, commands
+
 result, outcome, commands = asyncio.run(run_case(["infra_curl_ssl_with_fail_reward", "pass"]))
 assert result.rewards == {"reward": 1.0}, result.rewards
 assert outcome["outcome"] == "passed", outcome
@@ -3700,7 +3733,7 @@ assert outcome["outcome"] == "passed", outcome
 assert [item["classification"] for item in outcome["attempts"]] == ["passed"], outcome
 assert len([command for command in commands if "timeout --signal=KILL" in command]) == 1, commands
 
-result, outcome, commands = asyncio.run(run_case(["warning_with_fail_reward"]))
+result, outcome, commands = asyncio.run(run_case(["candidate_assertion_mentions_apt_502"]))
 assert result.rewards == {"reward": 0.0}, result.rewards
 assert outcome["outcome"] == "failed", outcome
 assert [item["classification"] for item in outcome["attempts"]] == ["failed"], outcome


### PR DESCRIPTION
## Summary

Classify apt repository 502 Bad Gateway output as verifier infrastructure failure when pytest embeds it with either escaped or real newlines, allowing the existing in-place verifier retry to run.

Keep the match scoped to adjacent apt Err repository and 502 Bad Gateway lines so candidate assertions that merely mention an apt URL and 502 remain candidate failures.

## Verification

- RED: the focused Harbor verifier smoke test returned reward 0.0 instead of the expected retried reward 1.0 for escaped-newline output; the same focused test failed independently when the real-newline branch was absent.
- npm --workspace @maka/headless test (1281 passed, 1 skipped, 0 failed)
- npm --workspace @maka/headless run typecheck
- npm run format:check
- npm run lint
- python3 -m py_compile packages/headless/harbor/maka_verifier.py