### PR TITLE
fix(headless): allow long Harbor bridge commands

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11039,10 +11039,20 @@
         "@maka/runtime": "0.1.0",
         "@maka/storage": "0.1.0",
         "ai": "^7.0.31",
-        "fs-native-extensions": "^1.5.0"
+        "fs-native-extensions": "^1.5.0",
+        "undici": "^8.7.0"
       },
       "bin": {
         "maka-headless": "dist/cli.js"
+      }
+    },
+    "packages/headless/node_modules/undici": {
+      "version": "8.8.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.8.0.tgz",
+      "integrity": "sha512-ubshXMXwF3MQIMF1y/WxZdNBnjEKeSg2wF5mcGUtU55YTw34tnVVpKRlLf7ruDXZ5344KokPVX4RBx1wJm64Bw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=22.19.0"
       }
     },
     "packages/mcp": {

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -71,6 +71,7 @@
     "@maka/runtime": "0.1.0",
     "@maka/storage": "0.1.0",
     "ai": "^7.0.31",
-    "fs-native-extensions": "^1.5.0"
+    "fs-native-extensions": "^1.5.0",
+    "undici": "^8.7.0"
   }
 }

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -5558,7 +5558,7 @@ describe('createHarborHttpToolExecutor', () => {
       assert.ok(optionsSymbol);
       const dispatcherOptions = Reflect.get(observedDispatcher, optionsSymbol);
       assert.equal(Reflect.get(dispatcherOptions, 'headersTimeout'), 0);
-      assert.equal(Reflect.get(dispatcherOptions, 'bodyTimeout'), 0);
+      assert.equal(Reflect.has(dispatcherOptions, 'bodyTimeout'), false);
       assert.equal(observedSignal, controller.signal);
       assert.deepEqual(observedBody, {
         command: 'sleep until cancelled',

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1,6 +1,7 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
 import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
@@ -31,6 +32,7 @@ import {
   type ToolResultArchiveReader,
   type ToolResultArchiveRecorder,
 } from '@maka/runtime';
+import { Agent } from 'undici';
 import type { Config } from '../contracts.js';
 import { openHeadlessStorageForWrite } from '../headless-storage.js';
 import type {
@@ -5372,12 +5374,45 @@ setTimeout(() => {
 });
 
 describe('createHarborHttpToolExecutor', () => {
+  const createMockedHarborHttpToolExecutor = (
+    env: Parameters<typeof createHarborHttpToolExecutor>[0],
+  ) => createHarborHttpToolExecutor(env, globalThis.fetch as never);
+
+  test('uses its explicit HTTP client for real bridge requests', async () => {
+    const server = createServer((_request, response) => {
+      response.end(JSON.stringify({ exitCode: 0, stdout: 'ok', stderr: '' }));
+    });
+    await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const previousFetch = globalThis.fetch;
+    try {
+      globalThis.fetch = async () => {
+        throw new Error('global fetch must not own Harbor bridge transport');
+      };
+      const address = server.address();
+      assert.ok(address && typeof address !== 'string');
+      const executor = createHarborHttpToolExecutor({
+        MAKA_HARBOR_TOOL_EXECUTOR_URL: `http://127.0.0.1:${address.port}`,
+        MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
+      });
+
+      assert.deepEqual(
+        await executor.exec({ command: 'echo hello', cwd: '/workspace', timeoutMs: 10_000 }),
+        { exitCode: 0, stdout: 'ok', stderr: '' },
+      );
+    } finally {
+      globalThis.fetch = previousFetch;
+      await new Promise<void>((resolve, reject) =>
+        server.close((error) => (error ? reject(error) : resolve())),
+      );
+    }
+  });
+
   test('keeps bridge failures out of command stderr', async () => {
     const previousFetch = globalThis.fetch;
     try {
       globalThis.fetch = async () =>
         new Response(JSON.stringify({ error: 'executor bridge failed' }), { status: 500 });
-      const executor = createHarborHttpToolExecutor({
+      const executor = createMockedHarborHttpToolExecutor({
         MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
         MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
       });
@@ -5395,7 +5430,7 @@ describe('createHarborHttpToolExecutor', () => {
     const previousFetch = globalThis.fetch;
     try {
       globalThis.fetch = async () => new Response(JSON.stringify(['not', 'an', 'envelope']));
-      const executor = createHarborHttpToolExecutor({
+      const executor = createMockedHarborHttpToolExecutor({
         MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
         MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
       });
@@ -5414,7 +5449,7 @@ describe('createHarborHttpToolExecutor', () => {
     try {
       globalThis.fetch = async () =>
         new Response(JSON.stringify({ exitCode: 0, returnCode: 9, stdout: '', stderr: '' }));
-      const executor = createHarborHttpToolExecutor({
+      const executor = createMockedHarborHttpToolExecutor({
         MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
         MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
       });
@@ -5433,7 +5468,7 @@ describe('createHarborHttpToolExecutor', () => {
     try {
       globalThis.fetch = async () =>
         new Response(JSON.stringify({ exitCode: 0, stdout: '', stderr: '', timedOut: true }));
-      const executor = createHarborHttpToolExecutor({
+      const executor = createMockedHarborHttpToolExecutor({
         MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
         MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
       });
@@ -5454,7 +5489,7 @@ describe('createHarborHttpToolExecutor', () => {
         new Response(
           JSON.stringify({ exitCode: Number.MAX_SAFE_INTEGER + 1, stdout: '', stderr: '' }),
         );
-      const executor = createHarborHttpToolExecutor({
+      const executor = createMockedHarborHttpToolExecutor({
         MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
         MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
       });
@@ -5473,7 +5508,7 @@ describe('createHarborHttpToolExecutor', () => {
     try {
       globalThis.fetch = async () =>
         new Response(JSON.stringify({ exitCode: 124, stdout: '', stderr: '', timedOut: true }));
-      const executor = createHarborHttpToolExecutor({
+      const executor = createMockedHarborHttpToolExecutor({
         MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
         MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
       });
@@ -5489,33 +5524,47 @@ describe('createHarborHttpToolExecutor', () => {
     }
   });
 
-  test('forwards active-tool cancellation to fetch without serializing execution control', async () => {
+  test('uses a long-running dispatcher without replacing active-tool cancellation', async () => {
     const previousFetch = globalThis.fetch;
     const controller = new AbortController();
+    let observedDispatcher: unknown;
     let observedSignal: AbortSignal | null | undefined;
     let observedBody: unknown;
     try {
       globalThis.fetch = async (_input, init) => {
+        observedDispatcher = Reflect.get(init ?? {}, 'dispatcher');
         observedSignal = init?.signal;
         observedBody = JSON.parse(String(init?.body));
         return new Response(JSON.stringify({ exitCode: 0, stdout: 'ok', stderr: '' }), {
           status: 200,
         });
       };
-      const executor = createHarborHttpToolExecutor({
+      const executor = createMockedHarborHttpToolExecutor({
         MAKA_HARBOR_TOOL_EXECUTOR_URL: 'http://127.0.0.1:1',
         MAKA_HARBOR_TOOL_EXECUTOR_TOKEN: 'test-token',
       });
 
       await executor.exec(
-        { command: 'sleep until cancelled', cwd: '/workspace' },
+        { command: 'sleep until cancelled', cwd: '/workspace', timeoutMs: 600_000 },
         { abortSignal: controller.signal },
       );
 
+      assert.ok(observedDispatcher instanceof Agent);
+      // Undici has no public getter for Agent defaults. Its own options symbol is
+      // the cheapest observable distinction from the default 300-second Agent.
+      const optionsSymbol = Object.getOwnPropertySymbols(observedDispatcher).find(
+        (symbol) => symbol.description === 'options',
+      );
+      assert.ok(optionsSymbol);
+      const dispatcherOptions = Reflect.get(observedDispatcher, optionsSymbol);
+      assert.equal(Reflect.get(dispatcherOptions, 'headersTimeout'), 0);
+      assert.equal(Reflect.get(dispatcherOptions, 'bodyTimeout'), 0);
       assert.equal(observedSignal, controller.signal);
       assert.deepEqual(observedBody, {
         command: 'sleep until cancelled',
         cwd: '/workspace',
+        timeoutMs: 600_000,
+        timeoutSec: 600,
       });
     } finally {
       globalThis.fetch = previousFetch;

--- a/packages/headless/src/harbor-cell-tool-executor.ts
+++ b/packages/headless/src/harbor-cell-tool-executor.ts
@@ -23,7 +23,7 @@ export const HARBOR_CELL_DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 
 // The bridge returns response headers only after the isolated command exits.
 // Leave command duration to its timeout and the active tool's abort signal.
-const harborHttpDispatcher = new Agent({ headersTimeout: 0, bodyTimeout: 0 });
+const harborHttpDispatcher = new Agent({ headersTimeout: 0 });
 
 export function buildHarborCellAiSdkTools(
   executor: IsolatedToolExecutor,

--- a/packages/headless/src/harbor-cell-tool-executor.ts
+++ b/packages/headless/src/harbor-cell-tool-executor.ts
@@ -6,6 +6,7 @@
 import { exec as nodeExec } from 'node:child_process';
 import { promisify } from 'node:util';
 import { defaultShellPlan, runShellWithBoundedTail, type MakaTool } from '@maka/runtime';
+import { Agent, fetch as undiciFetch } from 'undici';
 import { numericEnv, type RunHarborCellEnv } from './headless-run-env.js';
 import type { IsolatedCommandResult, IsolatedToolExecutor } from './isolation.js';
 import { ISOLATED_HEADLESS_TOOL_NAMES } from './isolation.js';
@@ -20,6 +21,10 @@ const execAsync = promisify(nodeExec);
 
 export const HARBOR_CELL_DEFAULT_COMMAND_TIMEOUT_MS = 120_000;
 
+// The bridge returns response headers only after the isolated command exits.
+// Leave command duration to its timeout and the active tool's abort signal.
+const harborHttpDispatcher = new Agent({ headersTimeout: 0, bodyTimeout: 0 });
+
 export function buildHarborCellAiSdkTools(
   executor: IsolatedToolExecutor,
   options: BuildIsolatedHeadlessToolsOptions = {},
@@ -32,6 +37,7 @@ export function buildHarborCellAiSdkTools(
 
 export function createHarborHttpToolExecutor(
   env: RunHarborCellEnv = process.env,
+  fetchImpl: typeof undiciFetch = undiciFetch,
 ): IsolatedToolExecutor {
   const baseUrl = requiredHarborEnv(env, 'MAKA_HARBOR_TOOL_EXECUTOR_URL');
   const token = requiredHarborEnv(env, 'MAKA_HARBOR_TOOL_EXECUTOR_TOKEN');
@@ -39,7 +45,7 @@ export function createHarborHttpToolExecutor(
     exec: async (input, control) => {
       const timeoutSec =
         input.timeoutMs === undefined ? undefined : Math.max(1, Math.ceil(input.timeoutMs / 1000));
-      const response = await fetch(new URL('/exec', baseUrl), {
+      const response = await fetchImpl(new URL('/exec', baseUrl), {
         method: 'POST',
         headers: {
           authorization: `Bearer ${token}`,
@@ -50,6 +56,7 @@ export function createHarborHttpToolExecutor(
           ...(timeoutSec !== undefined ? { timeoutSec } : {}),
         }),
         signal: control?.abortSignal,
+        dispatcher: harborHttpDispatcher,
       });
       const body = await response.text();
       if (!response.ok) {


### PR DESCRIPTION
## Summary

- use a direct `undici` dependency for a compatible Harbor bridge HTTP client and dispatcher
- disable Undici response-header and body transport timeouts so the command `timeoutMs` and active-tool abort signal remain authoritative
- preserve the existing Harbor request protocol, response-envelope validation, and bridge error handling

## Verification

- `npm --workspace @maka/headless run test:dist` (1282 passed, 1 skipped)
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run typecheck`
- mutation check: replacing the configured dispatcher with default `new Agent()` fails the transport-timeout contract (`headersTimeout` is not `0`)
