### PR TITLE
feat(runtime): provider-native Tool Search discovery policy + lowering contract (#1382 slice 1)

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -107,6 +107,7 @@
     "./terminal-run-commit": "./dist/terminal-run-commit.js",
     "./tool-availability": "./dist/tool-availability.js",
     "./tool-catalog-derive": "./dist/tool-catalog-derive.js",
+    "./tool-discovery": "./dist/tool-discovery.js",
     "./tool-free-model-call": "./dist/tool-free-model-call.js",
     "./tool-result-archive": "./dist/tool-result-archive.js",
     "./tool-result-archive-capability": "./dist/tool-result-archive-capability.js",

--- a/packages/runtime/src/__tests__/tool-discovery.test.ts
+++ b/packages/runtime/src/__tests__/tool-discovery.test.ts
@@ -36,22 +36,10 @@ describe('resolveProviderToolSearchCapability', () => {
   });
 
   test('anthropic with older model → none (fallback)', () => {
-    assert.equal(
-      resolveProviderToolSearchCapability('anthropic', 'claude-sonnet-4-0'),
-      'none',
-    );
-    assert.equal(
-      resolveProviderToolSearchCapability('anthropic', 'claude-opus-4-0'),
-      'none',
-    );
-    assert.equal(
-      resolveProviderToolSearchCapability('anthropic', 'claude-3-5-sonnet'),
-      'none',
-    );
-    assert.equal(
-      resolveProviderToolSearchCapability('anthropic', 'claude-3-haiku'),
-      'none',
-    );
+    assert.equal(resolveProviderToolSearchCapability('anthropic', 'claude-sonnet-4-0'), 'none');
+    assert.equal(resolveProviderToolSearchCapability('anthropic', 'claude-opus-4-0'), 'none');
+    assert.equal(resolveProviderToolSearchCapability('anthropic', 'claude-3-5-sonnet'), 'none');
+    assert.equal(resolveProviderToolSearchCapability('anthropic', 'claude-3-haiku'), 'none');
   });
 
   test('openai with supported model (GPT-5.4+) → openai', () => {
@@ -299,7 +287,10 @@ describe('lowerToolsForProvider — catalog authority', () => {
       capability: 'anthropic',
       neverAdvertise: new Set(['mcp__broken__x']),
     });
-    assert.ok(out.tools.some((t) => t.name === 'mcp__broken__x'), 'broken tool stays dispatchable');
+    assert.ok(
+      out.tools.some((t) => t.name === 'mcp__broken__x'),
+      'broken tool stays dispatchable',
+    );
     assert.ok(!out.activeTools.includes('mcp__broken__x'), 'broken tool never advertised');
     assert.ok(out.deferredToolNames.includes('mcp__broken__x'), 'broken tool is deferred');
   });

--- a/packages/runtime/src/__tests__/tool-discovery.test.ts
+++ b/packages/runtime/src/__tests__/tool-discovery.test.ts
@@ -20,19 +20,52 @@ function tool(name: string): MakaTool {
 }
 
 describe('resolveProviderToolSearchCapability', () => {
-  test('anthropic + claude-subscription → anthropic', () => {
+  test('anthropic + claude-subscription with supported model → anthropic', () => {
     assert.equal(
       resolveProviderToolSearchCapability('anthropic', 'claude-sonnet-4-5'),
       'anthropic',
     );
     assert.equal(
-      resolveProviderToolSearchCapability('claude-subscription', 'claude-sonnet-4-5'),
+      resolveProviderToolSearchCapability('claude-subscription', 'claude-opus-4-5'),
+      'anthropic',
+    );
+    assert.equal(
+      resolveProviderToolSearchCapability('anthropic', 'claude-opus-4-5-20250929'),
       'anthropic',
     );
   });
 
-  test('openai → openai', () => {
+  test('anthropic with older model → none (fallback)', () => {
+    assert.equal(
+      resolveProviderToolSearchCapability('anthropic', 'claude-sonnet-4-0'),
+      'none',
+    );
+    assert.equal(
+      resolveProviderToolSearchCapability('anthropic', 'claude-opus-4-0'),
+      'none',
+    );
+    assert.equal(
+      resolveProviderToolSearchCapability('anthropic', 'claude-3-5-sonnet'),
+      'none',
+    );
+    assert.equal(
+      resolveProviderToolSearchCapability('anthropic', 'claude-3-haiku'),
+      'none',
+    );
+  });
+
+  test('openai with supported model (GPT-5.4+) → openai', () => {
     assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-5.4'), 'openai');
+    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-5.4-mini'), 'openai');
+    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-6'), 'openai');
+  });
+
+  test('openai with unsupported model (Chat Completions / older GPT-5) → none (fallback)', () => {
+    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-4o'), 'none');
+    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-4o-mini'), 'none');
+    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-5'), 'none');
+    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-5-mini'), 'none');
+    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-5.3'), 'none');
   });
 
   test('unknown / openai-compatible / google → none (fallback)', () => {
@@ -140,6 +173,7 @@ describe('lowerToolsForProvider — fallback (capability none)', () => {
     for (const entry of out.tools) {
       assert.equal(entry.deferLoading, undefined);
       assert.equal(entry.namespace, undefined);
+      assert.equal(entry.namespaceDescription, undefined);
     }
   });
 });
@@ -154,12 +188,14 @@ describe('lowerToolsForProvider — anthropic native', () => {
     ],
   });
 
-  test('deferred tools are withheld from activeTools and marked deferLoading', () => {
+  test('deferred tools are kept in activeTools and marked deferLoading', () => {
     const out = lowerToolsForProvider({ tools, policy: pol, capability: 'anthropic' });
     assert.equal(out.mode, 'anthropic');
     assert.deepEqual(out.deferredToolNames, ['mcp__github__create_issue', 'RiveWorkflow']);
-    assert.ok(!out.activeTools.includes('mcp__github__create_issue'), 'MCP tool must be deferred');
-    assert.ok(!out.activeTools.includes('RiveWorkflow'), 'Rive surface member must be deferred');
+    // P1 fix: deferred tools remain in activeTools so the AI SDK `tools` dict
+    // keeps them — `deferLoading` controls visibility, not activeTools.
+    assert.ok(out.activeTools.includes('mcp__github__create_issue'), 'MCP tool must stay in activeTools');
+    assert.ok(out.activeTools.includes('RiveWorkflow'), 'Rive surface member must stay in activeTools');
     assert.ok(out.activeTools.includes('Bash'), 'core Bash stays direct/active');
 
     const mcpEntry = out.tools.find((t) => t.name === 'mcp__github__create_issue');
@@ -167,6 +203,7 @@ describe('lowerToolsForProvider — anthropic native', () => {
     assert.equal(mcpEntry?.namespace, mcpNamespace('github'));
     const bashEntry = out.tools.find((t) => t.name === 'Bash');
     assert.equal(bashEntry?.deferLoading, undefined);
+    assert.equal(bashEntry?.namespace, undefined);
   });
 
   test('a native search tool is added and kept active (BM25 by default)', () => {
@@ -195,18 +232,23 @@ describe('lowerToolsForProvider — openai native', () => {
   const pol = buildToolDiscoveryPolicy({
     productToolNames: ['Bash'],
     deferredSurfaces: [],
-    mcpTools: [{ serverId: 'fs', toolNames: ['mcp__fs__read'] }],
+    mcpTools: [{ serverId: 'fs', serverDescription: 'Filesystem', toolNames: ['mcp__fs__read'] }],
   });
 
-  test('deferred tools carry a namespace; search tool kind is openai', () => {
+  test('deferred tools carry namespace + namespaceDescription; search tool kind is openai', () => {
     const out = lowerToolsForProvider({ tools, policy: pol, capability: 'openai' });
     assert.equal(out.mode, 'openai');
     assert.equal(out.searchTool?.kind, 'openai');
     const fsEntry = out.tools.find((t) => t.name === 'mcp__fs__read');
     assert.equal(fsEntry?.deferLoading, true);
     assert.equal(fsEntry?.namespace, mcpNamespace('fs'));
-    assert.ok(!out.activeTools.includes('mcp__fs__read'));
+    // P2 fix: namespaceDescription must be preserved for the OpenAI adapter to
+    // construct the full `providerOptions.openai.namespace` payload.
+    assert.equal(fsEntry?.namespaceDescription, 'Filesystem');
+    // P1 fix: deferred tools stay in activeTools.
+    assert.ok(out.activeTools.includes('mcp__fs__read'), 'deferred tool stays in activeTools');
     assert.ok(out.activeTools.includes(NATIVE_TOOL_SEARCH_NAME));
+    assert.ok(out.activeTools.includes('Bash'));
   });
 });
 
@@ -236,5 +278,20 @@ describe('lowerToolsForProvider — catalog authority', () => {
     assert.ok(!out.activeTools.includes('invalid'), 'invalid never advertised');
     assert.ok(out.activeTools.includes('Bash'));
     assert.ok(out.activeTools.includes(NATIVE_TOOL_SEARCH_NAME));
+  });
+
+  test('neverAdvertise deferred tool stays in dict but out of activeTools', () => {
+    const out = lowerToolsForProvider({
+      tools: [tool('Bash'), tool('mcp__broken__x')],
+      policy: new Map([
+        ['Bash', { mode: 'direct' }],
+        ['mcp__broken__x', { mode: 'deferred', namespace: 'mcp__broken', namespaceDescription: 'Broken' }],
+      ]),
+      capability: 'anthropic',
+      neverAdvertise: new Set(['mcp__broken__x']),
+    });
+    assert.ok(out.tools.some((t) => t.name === 'mcp__broken__x'), 'broken tool stays dispatchable');
+    assert.ok(!out.activeTools.includes('mcp__broken__x'), 'broken tool never advertised');
+    assert.ok(out.deferredToolNames.includes('mcp__broken__x'), 'broken tool is deferred');
   });
 });

--- a/packages/runtime/src/__tests__/tool-discovery.test.ts
+++ b/packages/runtime/src/__tests__/tool-discovery.test.ts
@@ -1,0 +1,240 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { z } from 'zod';
+import type { MakaTool } from '../tool-runtime.js';
+import {
+  buildToolDiscoveryPolicy,
+  lowerToolsForProvider,
+  mcpNamespace,
+  resolveProviderToolSearchCapability,
+  NATIVE_TOOL_SEARCH_NAME,
+} from '../tool-discovery.js';
+
+function tool(name: string): MakaTool {
+  return {
+    name,
+    description: `${name} description`,
+    parameters: z.object({ q: z.string() }),
+    impl: () => ({ ok: true }),
+  };
+}
+
+describe('resolveProviderToolSearchCapability', () => {
+  test('anthropic + claude-subscription → anthropic', () => {
+    assert.equal(
+      resolveProviderToolSearchCapability('anthropic', 'claude-sonnet-4-5'),
+      'anthropic',
+    );
+    assert.equal(
+      resolveProviderToolSearchCapability('claude-subscription', 'claude-sonnet-4-5'),
+      'anthropic',
+    );
+  });
+
+  test('openai → openai', () => {
+    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-5.4'), 'openai');
+  });
+
+  test('unknown / openai-compatible / google → none (fallback)', () => {
+    assert.equal(resolveProviderToolSearchCapability('openai-compatible', 'x'), 'none');
+    assert.equal(resolveProviderToolSearchCapability('google', 'gemini'), 'none');
+    assert.equal(resolveProviderToolSearchCapability('deepseek', 'x'), 'none');
+  });
+});
+
+describe('buildToolDiscoveryPolicy', () => {
+  test('product tools are direct unless covered by a deferred surface', () => {
+    const p = buildToolDiscoveryPolicy({
+      productToolNames: ['Bash', 'Read', 'RiveWorkflow', 'OfficeDocument'],
+      deferredSurfaces: [
+        {
+          id: 'rive',
+          description: 'Rive workflows',
+          toolNames: ['RiveWorkflow'],
+        },
+      ],
+      mcpTools: [],
+    });
+    assert.deepEqual(p.get('Bash'), { mode: 'direct' });
+    assert.deepEqual(p.get('Read'), { mode: 'direct' });
+    assert.deepEqual(p.get('RiveWorkflow'), {
+      mode: 'deferred',
+      namespace: 'rive',
+      namespaceDescription: 'Rive workflows',
+    });
+    assert.deepEqual(p.get('OfficeDocument'), { mode: 'direct' });
+  });
+
+  test('MCP tools are deferred under a per-server namespace', () => {
+    const p = buildToolDiscoveryPolicy({
+      productToolNames: ['Bash'],
+      deferredSurfaces: [],
+      mcpTools: [
+        {
+          serverId: 'github',
+          serverDescription: 'GitHub server',
+          toolNames: ['mcp__github__create_issue', 'mcp__github__search'],
+        },
+        {
+          serverId: 'fs',
+          toolNames: ['mcp__fs__read'],
+        },
+      ],
+    });
+    assert.deepEqual(p.get('Bash'), { mode: 'direct' });
+    assert.deepEqual(p.get('mcp__github__create_issue'), {
+      mode: 'deferred',
+      namespace: mcpNamespace('github'),
+      namespaceDescription: 'GitHub server',
+    });
+    assert.deepEqual(p.get('mcp__fs__read'), {
+      mode: 'deferred',
+      namespace: mcpNamespace('fs'),
+      namespaceDescription: 'fs',
+    });
+  });
+
+  test('a surface member claim wins over an MCP claim (first claim owns the tool)', () => {
+    const p = buildToolDiscoveryPolicy({
+      productToolNames: ['agent_swarm'],
+      deferredSurfaces: [{ id: 'agent', description: 'Agent pack', toolNames: ['agent_swarm'] }],
+      mcpTools: [{ serverId: 'rogue', toolNames: ['agent_swarm'] }],
+    });
+    assert.deepEqual(p.get('agent_swarm'), {
+      mode: 'deferred',
+      namespace: 'agent',
+      namespaceDescription: 'Agent pack',
+    });
+  });
+
+  test('unbound surface members do not enter the policy', () => {
+    const p = buildToolDiscoveryPolicy({
+      productToolNames: ['Bash'],
+      deferredSurfaces: [{ id: 'office', description: 'Office', toolNames: ['OfficeDocument'] }],
+      mcpTools: [],
+    });
+    assert.equal(p.has('OfficeDocument'), false);
+  });
+});
+
+describe('lowerToolsForProvider — fallback (capability none)', () => {
+  const tools: MakaTool[] = [tool('Bash'), tool('mcp__github__create_issue'), tool('RiveWorkflow')];
+  const pol = buildToolDiscoveryPolicy({
+    productToolNames: ['Bash', 'RiveWorkflow'],
+    deferredSurfaces: [{ id: 'rive', description: 'Rive', toolNames: ['RiveWorkflow'] }],
+    mcpTools: [
+      { serverId: 'github', serverDescription: 'GitHub', toolNames: ['mcp__github__create_issue'] },
+    ],
+  });
+
+  test('fallback is identity: every tool direct, no search tool, no deferral', () => {
+    const out = lowerToolsForProvider({ tools, policy: pol, capability: 'none' });
+    assert.equal(out.mode, 'none');
+    assert.equal(out.searchTool, undefined);
+    assert.deepEqual(out.deferredToolNames, []);
+    assert.deepEqual(
+      new Set(out.activeTools),
+      new Set(['Bash', 'mcp__github__create_issue', 'RiveWorkflow']),
+    );
+    assert.equal(out.tools.length, 3);
+    for (const entry of out.tools) {
+      assert.equal(entry.deferLoading, undefined);
+      assert.equal(entry.namespace, undefined);
+    }
+  });
+});
+
+describe('lowerToolsForProvider — anthropic native', () => {
+  const tools: MakaTool[] = [tool('Bash'), tool('mcp__github__create_issue'), tool('RiveWorkflow')];
+  const pol = buildToolDiscoveryPolicy({
+    productToolNames: ['Bash', 'RiveWorkflow'],
+    deferredSurfaces: [{ id: 'rive', description: 'Rive', toolNames: ['RiveWorkflow'] }],
+    mcpTools: [
+      { serverId: 'github', serverDescription: 'GitHub', toolNames: ['mcp__github__create_issue'] },
+    ],
+  });
+
+  test('deferred tools are withheld from activeTools and marked deferLoading', () => {
+    const out = lowerToolsForProvider({ tools, policy: pol, capability: 'anthropic' });
+    assert.equal(out.mode, 'anthropic');
+    assert.deepEqual(out.deferredToolNames, ['mcp__github__create_issue', 'RiveWorkflow']);
+    assert.ok(!out.activeTools.includes('mcp__github__create_issue'), 'MCP tool must be deferred');
+    assert.ok(!out.activeTools.includes('RiveWorkflow'), 'Rive surface member must be deferred');
+    assert.ok(out.activeTools.includes('Bash'), 'core Bash stays direct/active');
+
+    const mcpEntry = out.tools.find((t) => t.name === 'mcp__github__create_issue');
+    assert.equal(mcpEntry?.deferLoading, true);
+    assert.equal(mcpEntry?.namespace, mcpNamespace('github'));
+    const bashEntry = out.tools.find((t) => t.name === 'Bash');
+    assert.equal(bashEntry?.deferLoading, undefined);
+  });
+
+  test('a native search tool is added and kept active (BM25 by default)', () => {
+    const out = lowerToolsForProvider({ tools, policy: pol, capability: 'anthropic' });
+    assert.equal(out.searchTool?.name, NATIVE_TOOL_SEARCH_NAME);
+    assert.equal(out.searchTool?.kind, 'anthropic-bm25');
+    assert.ok(out.activeTools.includes(NATIVE_TOOL_SEARCH_NAME));
+    const searchEntry = out.tools.find((t) => t.name === NATIVE_TOOL_SEARCH_NAME);
+    assert.ok(searchEntry, 'search tool entry present in tools dict');
+    assert.equal(searchEntry?.deferLoading, undefined);
+  });
+
+  test('regex variant is honored', () => {
+    const out = lowerToolsForProvider({
+      tools,
+      policy: pol,
+      capability: 'anthropic',
+      searchVariant: 'regex',
+    });
+    assert.equal(out.searchTool?.kind, 'anthropic-regex');
+  });
+});
+
+describe('lowerToolsForProvider — openai native', () => {
+  const tools: MakaTool[] = [tool('Bash'), tool('mcp__fs__read')];
+  const pol = buildToolDiscoveryPolicy({
+    productToolNames: ['Bash'],
+    deferredSurfaces: [],
+    mcpTools: [{ serverId: 'fs', toolNames: ['mcp__fs__read'] }],
+  });
+
+  test('deferred tools carry a namespace; search tool kind is openai', () => {
+    const out = lowerToolsForProvider({ tools, policy: pol, capability: 'openai' });
+    assert.equal(out.mode, 'openai');
+    assert.equal(out.searchTool?.kind, 'openai');
+    const fsEntry = out.tools.find((t) => t.name === 'mcp__fs__read');
+    assert.equal(fsEntry?.deferLoading, true);
+    assert.equal(fsEntry?.namespace, mcpNamespace('fs'));
+    assert.ok(!out.activeTools.includes('mcp__fs__read'));
+    assert.ok(out.activeTools.includes(NATIVE_TOOL_SEARCH_NAME));
+  });
+});
+
+describe('lowerToolsForProvider — catalog authority', () => {
+  test('an unclassified tool defaults to direct (never silently hidden)', () => {
+    const out = lowerToolsForProvider({
+      tools: [tool('UnknownTool')],
+      policy: new Map(),
+      capability: 'anthropic',
+    });
+    assert.ok(out.activeTools.includes('UnknownTool'));
+    assert.equal(out.tools[0].deferLoading, undefined);
+    assert.deepEqual(out.deferredToolNames, []);
+  });
+
+  test('neverAdvertise tools stay in the dict but out of activeTools', () => {
+    const out = lowerToolsForProvider({
+      tools: [tool('Bash'), tool('invalid')],
+      policy: new Map([['Bash', { mode: 'direct' }]]),
+      capability: 'anthropic',
+      neverAdvertise: new Set(['invalid']),
+    });
+    assert.ok(
+      out.tools.some((t) => t.name === 'invalid'),
+      'invalid stays dispatchable',
+    );
+    assert.ok(!out.activeTools.includes('invalid'), 'invalid never advertised');
+    assert.ok(out.activeTools.includes('Bash'));
+    assert.ok(out.activeTools.includes(NATIVE_TOOL_SEARCH_NAME));
+  });
+});

--- a/packages/runtime/src/__tests__/tool-discovery.test.ts
+++ b/packages/runtime/src/__tests__/tool-discovery.test.ts
@@ -194,8 +194,14 @@ describe('lowerToolsForProvider — anthropic native', () => {
     assert.deepEqual(out.deferredToolNames, ['mcp__github__create_issue', 'RiveWorkflow']);
     // P1 fix: deferred tools remain in activeTools so the AI SDK `tools` dict
     // keeps them — `deferLoading` controls visibility, not activeTools.
-    assert.ok(out.activeTools.includes('mcp__github__create_issue'), 'MCP tool must stay in activeTools');
-    assert.ok(out.activeTools.includes('RiveWorkflow'), 'Rive surface member must stay in activeTools');
+    assert.ok(
+      out.activeTools.includes('mcp__github__create_issue'),
+      'MCP tool must stay in activeTools',
+    );
+    assert.ok(
+      out.activeTools.includes('RiveWorkflow'),
+      'Rive surface member must stay in activeTools',
+    );
     assert.ok(out.activeTools.includes('Bash'), 'core Bash stays direct/active');
 
     const mcpEntry = out.tools.find((t) => t.name === 'mcp__github__create_issue');
@@ -285,7 +291,10 @@ describe('lowerToolsForProvider — catalog authority', () => {
       tools: [tool('Bash'), tool('mcp__broken__x')],
       policy: new Map([
         ['Bash', { mode: 'direct' }],
-        ['mcp__broken__x', { mode: 'deferred', namespace: 'mcp__broken', namespaceDescription: 'Broken' }],
+        [
+          'mcp__broken__x',
+          { mode: 'deferred', namespace: 'mcp__broken', namespaceDescription: 'Broken' },
+        ],
       ]),
       capability: 'anthropic',
       neverAdvertise: new Set(['mcp__broken__x']),

--- a/packages/runtime/src/__tests__/tool-discovery.test.ts
+++ b/packages/runtime/src/__tests__/tool-discovery.test.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { z } from 'zod';

--- a/packages/runtime/src/__tests__/tool-discovery.test.ts
+++ b/packages/runtime/src/__tests__/tool-discovery.test.ts
@@ -20,46 +20,72 @@ function tool(name: string): MakaTool {
 }
 
 describe('resolveProviderToolSearchCapability', () => {
-  test('anthropic + claude-subscription with supported model → anthropic', () => {
+  test('first-party Anthropic Messages supports all declared model families', () => {
+    for (const modelId of [
+      'claude-opus-4-5-20251101',
+      'claude-sonnet-4-5-20250929',
+      'claude-haiku-4-5-20251001',
+      'claude-fable-5',
+    ]) {
+      assert.equal(
+        resolveProviderToolSearchCapability({
+          providerType: 'anthropic',
+          adapterKind: 'anthropic',
+          wire: 'anthropic-messages',
+          modelId,
+        }),
+        'anthropic',
+      );
+    }
+  });
+
+  test('older Anthropic models fall back', () => {
+    for (const modelId of ['claude-sonnet-4-0', 'claude-opus-4-0', 'claude-3-5-sonnet']) {
+      assert.equal(
+        resolveProviderToolSearchCapability({
+          providerType: 'anthropic',
+          adapterKind: 'anthropic',
+          wire: 'anthropic-messages',
+          modelId,
+        }),
+        'none',
+      );
+    }
+  });
+
+  test('first-party OpenAI requires both GPT-5.4+ and the Responses wire', () => {
     assert.equal(
-      resolveProviderToolSearchCapability('anthropic', 'claude-sonnet-4-5'),
-      'anthropic',
+      resolveProviderToolSearchCapability({
+        providerType: 'openai',
+        adapterKind: 'openai',
+        wire: 'openai-responses',
+        modelId: 'gpt-5.4',
+      }),
+      'openai',
     );
     assert.equal(
-      resolveProviderToolSearchCapability('claude-subscription', 'claude-opus-4-5'),
-      'anthropic',
+      resolveProviderToolSearchCapability({
+        providerType: 'openai',
+        adapterKind: 'openai',
+        wire: 'openai-chat',
+        modelId: 'gpt-5.4',
+      }),
+      'none',
     );
+  });
+
+  test('compatible relays require an explicit feature declaration', () => {
+    const relay = {
+      providerType: 'openai-responses-compatible',
+      adapterKind: 'openai',
+      wire: 'openai-responses',
+      modelId: 'gpt-5.4',
+    } as const;
+    assert.equal(resolveProviderToolSearchCapability(relay), 'none');
     assert.equal(
-      resolveProviderToolSearchCapability('anthropic', 'claude-opus-4-5-20250929'),
-      'anthropic',
+      resolveProviderToolSearchCapability({ ...relay, declaredCapability: 'openai' }),
+      'openai',
     );
-  });
-
-  test('anthropic with older model → none (fallback)', () => {
-    assert.equal(resolveProviderToolSearchCapability('anthropic', 'claude-sonnet-4-0'), 'none');
-    assert.equal(resolveProviderToolSearchCapability('anthropic', 'claude-opus-4-0'), 'none');
-    assert.equal(resolveProviderToolSearchCapability('anthropic', 'claude-3-5-sonnet'), 'none');
-    assert.equal(resolveProviderToolSearchCapability('anthropic', 'claude-3-haiku'), 'none');
-  });
-
-  test('openai with supported model (GPT-5.4+) → openai', () => {
-    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-5.4'), 'openai');
-    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-5.4-mini'), 'openai');
-    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-6'), 'openai');
-  });
-
-  test('openai with unsupported model (Chat Completions / older GPT-5) → none (fallback)', () => {
-    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-4o'), 'none');
-    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-4o-mini'), 'none');
-    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-5'), 'none');
-    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-5-mini'), 'none');
-    assert.equal(resolveProviderToolSearchCapability('openai', 'gpt-5.3'), 'none');
-  });
-
-  test('unknown / openai-compatible / google → none (fallback)', () => {
-    assert.equal(resolveProviderToolSearchCapability('openai-compatible', 'x'), 'none');
-    assert.equal(resolveProviderToolSearchCapability('google', 'gemini'), 'none');
-    assert.equal(resolveProviderToolSearchCapability('deepseek', 'x'), 'none');
   });
 });
 
@@ -128,6 +154,22 @@ describe('buildToolDiscoveryPolicy', () => {
     });
   });
 
+  test('the first deferred surface claim wins over later surfaces', () => {
+    const p = buildToolDiscoveryPolicy({
+      productToolNames: ['shared'],
+      deferredSurfaces: [
+        { id: 'first', description: 'First', toolNames: ['shared'] },
+        { id: 'second', description: 'Second', toolNames: ['shared'] },
+      ],
+      mcpTools: [],
+    });
+    assert.deepEqual(p.get('shared'), {
+      mode: 'deferred',
+      namespace: 'first',
+      namespaceDescription: 'First',
+    });
+  });
+
   test('unbound surface members do not enter the policy', () => {
     const p = buildToolDiscoveryPolicy({
       productToolNames: ['Bash'],
@@ -148,8 +190,13 @@ describe('lowerToolsForProvider — fallback (capability none)', () => {
     ],
   });
 
-  test('fallback is identity: every tool direct, no search tool, no deferral', () => {
-    const out = lowerToolsForProvider({ tools, policy: pol, capability: 'none' });
+  test('fallback preserves the baseline allowlist, no search tool, no deferral', () => {
+    const out = lowerToolsForProvider({
+      tools,
+      policy: pol,
+      capability: 'none',
+      baselineActiveTools: ['Bash', 'mcp__github__create_issue', 'RiveWorkflow'],
+    });
     assert.equal(out.mode, 'none');
     assert.equal(out.searchTool, undefined);
     assert.deepEqual(out.deferredToolNames, []);
@@ -164,6 +211,16 @@ describe('lowerToolsForProvider — fallback (capability none)', () => {
       assert.equal(entry.namespaceDescription, undefined);
     }
   });
+
+  test('fallback never reactivates a tool hidden by ToolAvailabilityRuntime', () => {
+    const out = lowerToolsForProvider({
+      tools,
+      policy: pol,
+      capability: 'none',
+      baselineActiveTools: ['Bash'],
+    });
+    assert.deepEqual(out.activeTools, ['Bash']);
+  });
 });
 
 describe('lowerToolsForProvider — anthropic native', () => {
@@ -177,7 +234,12 @@ describe('lowerToolsForProvider — anthropic native', () => {
   });
 
   test('deferred tools are kept in activeTools and marked deferLoading', () => {
-    const out = lowerToolsForProvider({ tools, policy: pol, capability: 'anthropic' });
+    const out = lowerToolsForProvider({
+      tools,
+      policy: pol,
+      capability: 'anthropic',
+      baselineActiveTools: ['Bash'],
+    });
     assert.equal(out.mode, 'anthropic');
     assert.deepEqual(out.deferredToolNames, ['mcp__github__create_issue', 'RiveWorkflow']);
     // P1 fix: deferred tools remain in activeTools so the AI SDK `tools` dict
@@ -201,7 +263,12 @@ describe('lowerToolsForProvider — anthropic native', () => {
   });
 
   test('a native search tool is added and kept active (BM25 by default)', () => {
-    const out = lowerToolsForProvider({ tools, policy: pol, capability: 'anthropic' });
+    const out = lowerToolsForProvider({
+      tools,
+      policy: pol,
+      capability: 'anthropic',
+      baselineActiveTools: ['Bash'],
+    });
     assert.equal(out.searchTool?.name, NATIVE_TOOL_SEARCH_NAME);
     assert.equal(out.searchTool?.kind, 'anthropic-bm25');
     assert.ok(out.activeTools.includes(NATIVE_TOOL_SEARCH_NAME));
@@ -215,6 +282,7 @@ describe('lowerToolsForProvider — anthropic native', () => {
       tools,
       policy: pol,
       capability: 'anthropic',
+      baselineActiveTools: ['Bash'],
       searchVariant: 'regex',
     });
     assert.equal(out.searchTool?.kind, 'anthropic-regex');
@@ -230,7 +298,12 @@ describe('lowerToolsForProvider — openai native', () => {
   });
 
   test('deferred tools carry namespace + namespaceDescription; search tool kind is openai', () => {
-    const out = lowerToolsForProvider({ tools, policy: pol, capability: 'openai' });
+    const out = lowerToolsForProvider({
+      tools,
+      policy: pol,
+      capability: 'openai',
+      baselineActiveTools: ['Bash'],
+    });
     assert.equal(out.mode, 'openai');
     assert.equal(out.searchTool?.kind, 'openai');
     const fsEntry = out.tools.find((t) => t.name === 'mcp__fs__read');
@@ -252,6 +325,7 @@ describe('lowerToolsForProvider — catalog authority', () => {
       tools: [tool('UnknownTool')],
       policy: new Map(),
       capability: 'anthropic',
+      baselineActiveTools: ['UnknownTool'],
     });
     assert.ok(out.activeTools.includes('UnknownTool'));
     assert.equal(out.tools[0].deferLoading, undefined);
@@ -263,6 +337,7 @@ describe('lowerToolsForProvider — catalog authority', () => {
       tools: [tool('Bash'), tool('invalid')],
       policy: new Map([['Bash', { mode: 'direct' }]]),
       capability: 'anthropic',
+      baselineActiveTools: ['Bash', 'invalid'],
       neverAdvertise: new Set(['invalid']),
     });
     assert.ok(
@@ -285,6 +360,7 @@ describe('lowerToolsForProvider — catalog authority', () => {
         ],
       ]),
       capability: 'anthropic',
+      baselineActiveTools: ['Bash', 'mcp__broken__x'],
       neverAdvertise: new Set(['mcp__broken__x']),
     });
     assert.ok(
@@ -293,5 +369,18 @@ describe('lowerToolsForProvider — catalog authority', () => {
     );
     assert.ok(!out.activeTools.includes('mcp__broken__x'), 'broken tool never advertised');
     assert.ok(out.deferredToolNames.includes('mcp__broken__x'), 'broken tool is deferred');
+  });
+
+  test('native search replaces the local connector instead of duplicating its name', () => {
+    const out = lowerToolsForProvider({
+      tools: [tool('Bash'), tool(NATIVE_TOOL_SEARCH_NAME), tool('RiveWorkflow')],
+      policy: new Map([
+        ['Bash', { mode: 'direct' }],
+        ['RiveWorkflow', { mode: 'deferred', namespace: 'rive', namespaceDescription: 'Rive' }],
+      ]),
+      capability: 'anthropic',
+      baselineActiveTools: ['Bash', NATIVE_TOOL_SEARCH_NAME],
+    });
+    assert.equal(out.tools.filter((entry) => entry.name === NATIVE_TOOL_SEARCH_NAME).length, 1);
   });
 });

--- a/packages/runtime/src/tool-discovery.ts
+++ b/packages/runtime/src/tool-discovery.ts
@@ -175,12 +175,14 @@ export function resolveProviderToolSearchCapability(
  * convention. The capability is gated on Opus 4.5+ / Sonnet 4.5+.
  */
 function supportsAnthropicToolSearch(modelId: string): boolean {
-  const id = modelId.toLowerCase().replace(/-\d{8}$/, '').replace(/-\w{2,4}-\d+$/, '');
+  const id = modelId
+    .toLowerCase()
+    .replace(/-\d{8}$/, '')
+    .replace(/-\w{2,4}-\d+$/, '');
   const opusMatch = id.match(/^claude-opus-(\d+)(?:-(\d+))?/);
   if (opusMatch) {
     return (
-      Number(opusMatch[1]) > 4 ||
-      (Number(opusMatch[1]) === 4 && Number(opusMatch[2] ?? 0) >= 5)
+      Number(opusMatch[1]) > 4 || (Number(opusMatch[1]) === 4 && Number(opusMatch[2] ?? 0) >= 5)
     );
   }
   const sonnetMatch = id.match(/^claude-sonnet-(\d+)(?:-(\d+))?/);

--- a/packages/runtime/src/tool-discovery.ts
+++ b/packages/runtime/src/tool-discovery.ts
@@ -51,8 +51,9 @@ export type ToolDiscoveryPolicy = ReadonlyMap<string, ToolDiscovery>;
 
 /**
  * Which native Tool Search path a resolved model supports, derived from the
- * `ModelAdapter`-resolved provider runtime adapter kind. `none` means the
- * existing `load_tools` economy is the fallback and the lowerer is a no-op.
+ * `ModelAdapter`-resolved provider runtime adapter kind and model id. `none`
+ * means the existing `load_tools` economy is the fallback and the lowerer is a
+ * no-op.
  */
 export type ProviderToolSearchCapability = 'anthropic' | 'openai' | 'none';
 
@@ -81,6 +82,10 @@ export interface NativeSearchToolDescriptor {
  * `tools` dict takes (name + description + input schema + per-tool
  * `providerOptions`), with the Maka-owned defer/namespace markers that the
  * adapter lowers to provider-native `deferLoading` / `namespace`.
+ *
+ * `namespace` and `namespaceDescription` are carried together so the adapter
+ * can construct the full OpenAI `providerOptions.openai.namespace` payload
+ * (`{ name, description }`) the SDK requires for namespace grouping.
  */
 export interface LoweredToolEntry {
   name: string;
@@ -89,8 +94,10 @@ export interface LoweredToolEntry {
   parameters: unknown;
   /** True when this entry is withheld from the initial model context. */
   deferLoading?: boolean;
-  /** Namespace grouping (OpenAI functions / namespaces). */
+  /** Namespace grouping name (OpenAI functions / namespaces). */
   namespace?: string;
+  /** Human-readable description for the namespace group (OpenAI `description`). */
+  namespaceDescription?: string;
 }
 
 /**
@@ -101,14 +108,22 @@ export interface LoweredToolEntry {
  *   tool, `activeTools` lists every name. Identical to today's full surface;
  *   the existing `ToolAvailabilityRuntime` economy continues to own deferral.
  * - `mode: 'anthropic' | 'openai'` → native: deferred entries carry
- *   `deferLoading` (and `namespace` for OpenAI), are excluded from
- *   `activeTools`, and a `searchTool` is added and kept active.
+ *   `deferLoading` (and `namespace` + `namespaceDescription` for OpenAI), remain
+ *   in `activeTools` so the AI SDK `tools` dict keeps them (the `deferLoading`
+ *   flag hides them from the initial model context), and a `searchTool` is
+ *   added and kept active.
  */
 export interface LoweredProviderToolPayload {
   mode: ProviderToolSearchCapability;
   /** Every provider-visible tool entry (direct + deferred + search tool when native). */
   tools: LoweredToolEntry[];
-  /** Initial model-visible active tool names. Deferred tools are excluded. */
+  /**
+   * Tool names the provider receives. In native mode this includes deferred
+   * tools (kept via the `deferLoading` flag, not omitted) plus the search tool.
+   * AI SDK 7 treats `activeTools` as an allowlist — an omitted tool is stripped
+   * from the `tools` dict entirely — so deferred tools MUST remain listed to
+   * ensure the provider adapter receives their schema + `deferLoading` flag.
+   */
   activeTools: string[];
   /** The native search tool descriptor; undefined in fallback mode. */
   searchTool?: NativeSearchToolDescriptor;
@@ -129,27 +144,63 @@ export const NATIVE_TOOL_SEARCH_DESCRIPTION =
  * Resolve the native Tool Search capability for a resolved model. The adapter
  * kind is the same one `resolveModelRuntime` (`model-runtime.ts`) produces.
  *
- * Model-id gating is intentionally coarse in slice 1: Anthropic native search
- * is exposed on Opus 4.5 / Sonnet 4.5 and later, OpenAI `tool_search` on the
- * Responses API (GPT-5.4+). A follow-up slice tightens this per
- * `lookupModelMetadata` once a capability table exists; until then the
- * capability is provider-level only and the live wiring is gated off by
- * default (see backend flag in a follow-up slice), so a model that lacks the
- * server feature still falls back to `load_tools`.
+ * Model-id gating ensures only models that actually support native Tool Search
+ * take the native path; older models fall back to the deterministic `load_tools`
+ * economy so they never receive a partially deferred catalog they cannot load.
+ *
+ * Anthropic: native Tool Search is exposed on Claude Opus 4.5 / Sonnet 4.5
+ * and later (model ids `claude-opus-4-5*` / `claude-sonnet-4-5*` and above).
+ * OpenAI: `tool_search` requires the Responses API on GPT-5.4 or later
+ * (`gpt-5.4*` and above). Chat Completions models such as `gpt-4o` and older
+ * GPT-5 variants do not support it and fall back to `load_tools`.
  */
 export function resolveProviderToolSearchCapability(
   adapterKind: string,
-  _modelId: string,
+  modelId: string,
 ): ProviderToolSearchCapability {
   switch (adapterKind) {
     case 'anthropic':
     case 'claude-subscription':
-      return 'anthropic';
+      return supportsAnthropicToolSearch(modelId) ? 'anthropic' : 'none';
     case 'openai':
-      return 'openai';
+      return supportsOpenaiToolSearch(modelId) ? 'openai' : 'none';
     default:
       return 'none';
   }
+}
+
+/**
+ * Anthropic native Tool Search is available on Claude Opus 4.5 / Sonnet 4.5
+ * and later. Model ids follow the `claude-{opus|sonnet|haiku}-{major}-{minor}`
+ * convention. The capability is gated on Opus 4.5+ / Sonnet 4.5+.
+ */
+function supportsAnthropicToolSearch(modelId: string): boolean {
+  const id = modelId.toLowerCase().replace(/-\d{8}$/, '').replace(/-\w{2,4}-\d+$/, '');
+  const opusMatch = id.match(/^claude-opus-(\d+)(?:-(\d+))?/);
+  if (opusMatch) {
+    return Number(opusMatch[1]) > 4 || (Number(opusMatch[1]) === 4 && Number(opusMatch[2] ?? 0) >= 5);
+  }
+  const sonnetMatch = id.match(/^claude-sonnet-(\d+)(?:-(\d+))?/);
+  if (sonnetMatch) {
+    return Number(sonnetMatch[1]) > 4 || (Number(sonnetMatch[1]) === 4 && Number(sonnetMatch[2] ?? 0) >= 5);
+  }
+  // Unknown Anthropic model — be conservative, fall back.
+  return false;
+}
+
+/**
+ * OpenAI native Tool Search (`tool_search`) requires the Responses API on
+ * GPT-5.4 or later. Chat Completions models (e.g. `gpt-4o`) and older GPT-5
+ * variants (e.g. `gpt-5`, `gpt-5-mini`) do not support it.
+ */
+function supportsOpenaiToolSearch(modelId: string): boolean {
+  const id = modelId.toLowerCase();
+  const match = id.match(/^gpt-(\d+)(?:\.(\d+))?/);
+  if (!match) return false;
+  const major = Number(match[1]);
+  const minor = Number(match[2] ?? 0);
+  // GPT-5.4+ or GPT-6+
+  return major > 5 || (major === 5 && minor >= 4);
 }
 
 export interface DeferredSurfaceInput {
@@ -261,10 +312,26 @@ export function lowerToolsForProvider(input: {
       description: tool.description,
       parameters: tool.parameters,
       ...(deferred ? { deferLoading: true } : {}),
-      ...(deferred && discovery.mode === 'deferred' ? { namespace: discovery.namespace } : {}),
+      ...(deferred && discovery.mode === 'deferred'
+        ? {
+            namespace: discovery.namespace,
+            namespaceDescription: discovery.namespaceDescription,
+          }
+        : {}),
     });
     if (deferred) {
       deferredToolNames.push(tool.name);
+      // Keep deferred tools in `activeTools`. AI SDK 7 treats `activeTools` as an
+      // allowlist: any tool omitted is stripped from the `tools` dict, so the
+      // provider adapter never receives the deferred schema or its
+      // `deferLoading` flag. The provider's `deferLoading` option keeps the
+      // tool out of the initial model context — `activeTools` membership only
+      // controls whether the schema is *sent* to the provider at all.
+      // `neverAdvertise` tools are the exception: they stay in the dispatch
+      // dict but are never sent to the provider.
+      if (!neverAdvertise.has(tool.name)) {
+        activeTools.push(tool.name);
+      }
     } else if (!neverAdvertise.has(tool.name)) {
       activeTools.push(tool.name);
     }

--- a/packages/runtime/src/tool-discovery.ts
+++ b/packages/runtime/src/tool-discovery.ts
@@ -178,11 +178,17 @@ function supportsAnthropicToolSearch(modelId: string): boolean {
   const id = modelId.toLowerCase().replace(/-\d{8}$/, '').replace(/-\w{2,4}-\d+$/, '');
   const opusMatch = id.match(/^claude-opus-(\d+)(?:-(\d+))?/);
   if (opusMatch) {
-    return Number(opusMatch[1]) > 4 || (Number(opusMatch[1]) === 4 && Number(opusMatch[2] ?? 0) >= 5);
+    return (
+      Number(opusMatch[1]) > 4 ||
+      (Number(opusMatch[1]) === 4 && Number(opusMatch[2] ?? 0) >= 5)
+    );
   }
   const sonnetMatch = id.match(/^claude-sonnet-(\d+)(?:-(\d+))?/);
   if (sonnetMatch) {
-    return Number(sonnetMatch[1]) > 4 || (Number(sonnetMatch[1]) === 4 && Number(sonnetMatch[2] ?? 0) >= 5);
+    return (
+      Number(sonnetMatch[1]) > 4 ||
+      (Number(sonnetMatch[1]) === 4 && Number(sonnetMatch[2] ?? 0) >= 5)
+    );
   }
   // Unknown Anthropic model — be conservative, fall back.
   return false;

--- a/packages/runtime/src/tool-discovery.ts
+++ b/packages/runtime/src/tool-discovery.ts
@@ -1,0 +1,318 @@
+/**
+ * Provider-native Tool Search — discovery policy and lowering contract.
+ *
+ * maka-agent/maka-agent#1382 (slice 1): establish a Maka-owned discovery
+ * policy on the tool catalog plus a provider-native lowering contract that the
+ * `ModelAdapter` (#1381 seam) lowers to Anthropic / OpenAI native Tool Search,
+ * with a deterministic fallback to the existing `load_tools` economy
+ * (`ToolAvailabilityRuntime`) when a provider or model has no native search.
+ *
+ * This module owns the *contract*, not the live `streamText` wiring. It is
+ * deliberately pure and provider-package-free so it is fully unit-testable
+ * without importing `@ai-sdk/anthropic` / `@ai-sdk/openai`. A follow-up slice
+ * consumes {@link lowerToolsForProvider} inside the backend's tool-assembly
+ * point, expands the {@link NativeSearchToolDescriptor} into the real
+ * provider-executed search tool, and adjusts the execute-boundary visibility
+ * guard + durable replay so a provider-loaded tool still crosses
+ * `ToolRuntime`. That wiring is out of scope for the seam.
+ *
+ * Per the RFC:
+ * - One authoritative catalog. A provider search result only *selects* catalog
+ *   entries; it never grants permission and never introduces an unknown
+ *   schema. The policy is owned by Maka, not by a provider adapter.
+ * - Tool Search changes visibility, not authorization. Every loaded tool still
+ *   runs through `ToolRuntime`.
+ * - Unsupported models keep the current deterministic behavior — they receive
+ *   the full surface (the existing `load_tools` economy governs deferral), never
+ *   a partially deferred catalog they cannot load.
+ */
+
+import type { MakaTool } from './tool-runtime.js';
+
+/**
+ * Maka-owned discovery metadata for one catalog entry. Extends the catalog
+ * model rather than duplicating it: a tool is either immediately visible
+ * (`direct`) or withheld until the model searches for it (`deferred`), grouped
+ * under a namespace the provider advertises as one short description instead of
+ * every member's full schema.
+ *
+ * This is the illustrative `ToolDiscovery` from the RFC. The live catalog
+ * types (`CatalogToolDef` / `CatalogSurfaceDef` in `@maka/core/tool-catalog`)
+ * are extended by *deriving* a policy from them (see
+ * {@link buildToolDiscoveryPolicy}), not by adding a parallel field set — the
+ * product catalog stays the single authority for product tools.
+ */
+export type ToolDiscovery =
+  | { mode: 'direct' }
+  | { mode: 'deferred'; namespace: string; namespaceDescription: string };
+
+/** Per-tool discovery policy keyed by canonical tool name. */
+export type ToolDiscoveryPolicy = ReadonlyMap<string, ToolDiscovery>;
+
+/**
+ * Which native Tool Search path a resolved model supports, derived from the
+ * `ModelAdapter`-resolved provider runtime adapter kind. `none` means the
+ * existing `load_tools` economy is the fallback and the lowerer is a no-op.
+ */
+export type ProviderToolSearchCapability = 'anthropic' | 'openai' | 'none';
+
+/** Anthropic server-side search variant. Default: BM25 (natural language). */
+export type AnthropicSearchVariant = 'bm25' | 'regex';
+
+/** The native search tool the adapter expands for the active provider. */
+export type NativeSearchToolKind = 'anthropic-bm25' | 'anthropic-regex' | 'openai';
+
+/**
+ * Provider-agnostic descriptor for the native search tool. The adapter
+ * translates this into the real provider-executed tool
+ * (`@ai-sdk/anthropic` `toolSearchBm25_20251119` / `toolSearchRegex_20251119`,
+ * or `@ai-sdk/openai` `toolSearch`) at the streamText call site.
+ */
+export interface NativeSearchToolDescriptor {
+  /** Canonical tool name the model calls to search. */
+  name: string;
+  kind: NativeSearchToolKind;
+  /** One-line model-facing description of the search tool. */
+  description: string;
+}
+
+/**
+ * One provider-visible tool entry after lowering. Mirrors the shape the AI SDK
+ * `tools` dict takes (name + description + input schema + per-tool
+ * `providerOptions`), with the Maka-owned defer/namespace markers that the
+ * adapter lowers to provider-native `deferLoading` / `namespace`.
+ */
+export interface LoweredToolEntry {
+  name: string;
+  description: string;
+  /** Passthrough of `MakaTool.parameters` (zod / jsonSchema). */
+  parameters: unknown;
+  /** True when this entry is withheld from the initial model context. */
+  deferLoading?: boolean;
+  /** Namespace grouping (OpenAI functions / namespaces). */
+  namespace?: string;
+}
+
+/**
+ * The full provider-native lowering result. The backend's tool-assembly point
+ * consumes this to build the `streamText` `tools` dict and `activeTools`.
+ *
+ * - `mode: 'none'` → fallback: `tools` carries every entry as direct, no search
+ *   tool, `activeTools` lists every name. Identical to today's full surface;
+ *   the existing `ToolAvailabilityRuntime` economy continues to own deferral.
+ * - `mode: 'anthropic' | 'openai'` → native: deferred entries carry
+ *   `deferLoading` (and `namespace` for OpenAI), are excluded from
+ *   `activeTools`, and a `searchTool` is added and kept active.
+ */
+export interface LoweredProviderToolPayload {
+  mode: ProviderToolSearchCapability;
+  /** Every provider-visible tool entry (direct + deferred + search tool when native). */
+  tools: LoweredToolEntry[];
+  /** Initial model-visible active tool names. Deferred tools are excluded. */
+  activeTools: string[];
+  /** The native search tool descriptor; undefined in fallback mode. */
+  searchTool?: NativeSearchToolDescriptor;
+  /** Deferred tool names (direct mode excluded), for diagnostics / guard wiring. */
+  deferredToolNames: string[];
+}
+
+/** Canonical name of the provider-native tool-search tool Maka advertises. */
+export const NATIVE_TOOL_SEARCH_NAME = 'tool_search';
+
+/** Model-facing description for the native search tool. */
+export const NATIVE_TOOL_SEARCH_DESCRIPTION =
+  'Search the deferred tool catalog by natural-language query and load matching ' +
+  'tool definitions into your context. Use this before calling a tool you have not ' +
+  'seen; loaded tools become callable on your next step.';
+
+/**
+ * Resolve the native Tool Search capability for a resolved model. The adapter
+ * kind is the same one `resolveModelRuntime` (`model-runtime.ts`) produces.
+ *
+ * Model-id gating is intentionally coarse in slice 1: Anthropic native search
+ * is exposed on Opus 4.5 / Sonnet 4.5 and later, OpenAI `tool_search` on the
+ * Responses API (GPT-5.4+). A follow-up slice tightens this per
+ * `lookupModelMetadata` once a capability table exists; until then the
+ * capability is provider-level only and the live wiring is gated off by
+ * default (see backend flag in a follow-up slice), so a model that lacks the
+ * server feature still falls back to `load_tools`.
+ */
+export function resolveProviderToolSearchCapability(
+  adapterKind: string,
+  _modelId: string,
+): ProviderToolSearchCapability {
+  switch (adapterKind) {
+    case 'anthropic':
+    case 'claude-subscription':
+      return 'anthropic';
+    case 'openai':
+      return 'openai';
+    default:
+      return 'none';
+  }
+}
+
+export interface DeferredSurfaceInput {
+  readonly id: string;
+  readonly description: string;
+  readonly toolNames: ReadonlyArray<string>;
+}
+
+export interface McpServerToolsInput {
+  readonly serverId: string;
+  /** Optional human description; defaults to the server id. */
+  readonly serverDescription?: string;
+  readonly toolNames: ReadonlyArray<string>;
+}
+
+export interface BuildToolDiscoveryPolicyInput {
+  /** Product tool names bound on this host (catalog ∩ binding). */
+  readonly productToolNames: Iterable<string>;
+  /** Deferred catalog surfaces with their bound members. */
+  readonly deferredSurfaces: ReadonlyArray<DeferredSurfaceInput>;
+  /** MCP tools grouped by server (external to the product catalog). */
+  readonly mcpTools: ReadonlyArray<McpServerToolsInput>;
+}
+
+/**
+ * Build the Maka-owned discovery policy for one host's bound tool set.
+ *
+ * - A product tool that is a member of a deferred surface → `deferred` under
+ *   that surface's namespace (id) and description.
+ * - Any other bound product tool → `direct` (frequent core coding tools stay
+ *   immediately available without a search round trip).
+ * - Every MCP tool → `deferred` under a per-server namespace. A session
+ *   connected to several MCP servers can send dozens/hundreds of schemas; the
+ *   whole point of #1382 is to keep those out of the initial context.
+ *
+ * Unknown product names (not in `productToolNames`) passed via MCP are still
+ * classified by the MCP branch. A tool claimed by both a deferred surface and
+ * an MCP server keeps the first claim (surface), mirroring
+ * `ToolAvailabilityRuntime`'s "first group to claim a tool owns it" rule.
+ */
+export function buildToolDiscoveryPolicy(
+  input: BuildToolDiscoveryPolicyInput,
+): ToolDiscoveryPolicy {
+  const policy = new Map<string, ToolDiscovery>();
+  for (const name of input.productToolNames) {
+    policy.set(name, { mode: 'direct' });
+  }
+  for (const surface of input.deferredSurfaces) {
+    for (const name of surface.toolNames) {
+      // First claim wins: a surface member is only deferred if it is actually
+      // bound; an unbound surface member never enters the policy here.
+      if (!policy.has(name)) continue;
+      policy.set(name, {
+        mode: 'deferred',
+        namespace: surface.id,
+        namespaceDescription: surface.description,
+      });
+    }
+  }
+  for (const server of input.mcpTools) {
+    const namespace = mcpNamespace(server.serverId);
+    const namespaceDescription = server.serverDescription?.trim() || server.serverId;
+    for (const name of server.toolNames) {
+      if (policy.has(name)) continue; // surface claim wins
+      policy.set(name, { mode: 'deferred', namespace, namespaceDescription });
+    }
+  }
+  return policy;
+}
+
+/**
+ * Lower a full dispatch tool set + discovery policy into the provider-native
+ * tool payload for one provider request.
+ *
+ * Tools absent from the policy default to `direct` (visible immediately) so
+ * the lowerer never silently hides a tool the catalog did not classify —
+ * matching the RFC's "search results must be validated against the catalog
+ * revision" stance: an unclassified tool is treated as known-and-direct, not
+ * as deferred-and-searchable.
+ *
+ * @param tools Full dispatch set (the same `MakaTool[]` the backend builds).
+ * @param policy Discovery policy for these tools.
+ * @param capability Resolved native search capability for the model.
+ * @param options.searchVariant Anthropic search variant; default `bm25`.
+ * @param options.neverAdvertise Tool names kept in the dispatch dict but never
+ *   advertised (the `invalid` repair fallback). They stay direct and inactive.
+ */
+export function lowerToolsForProvider(input: {
+  tools: ReadonlyArray<MakaTool>;
+  policy: ToolDiscoveryPolicy;
+  capability: ProviderToolSearchCapability;
+  searchVariant?: AnthropicSearchVariant;
+  neverAdvertise?: ReadonlySet<string>;
+}): LoweredProviderToolPayload {
+  const { tools, policy, capability } = input;
+  const neverAdvertise = input.neverAdvertise ?? EMPTY_SET;
+  const native = capability !== 'none';
+  const searchVariant: AnthropicSearchVariant = input.searchVariant ?? 'bm25';
+
+  const entries: LoweredToolEntry[] = [];
+  const activeTools: string[] = [];
+  const deferredToolNames: string[] = [];
+
+  for (const tool of tools) {
+    const discovery = policy.get(tool.name) ?? ({ mode: 'direct' } as const);
+    const deferred = native && discovery.mode === 'deferred';
+    entries.push({
+      name: tool.name,
+      description: tool.description,
+      parameters: tool.parameters,
+      ...(deferred ? { deferLoading: true } : {}),
+      ...(deferred && discovery.mode === 'deferred' ? { namespace: discovery.namespace } : {}),
+    });
+    if (deferred) {
+      deferredToolNames.push(tool.name);
+    } else if (!neverAdvertise.has(tool.name)) {
+      activeTools.push(tool.name);
+    }
+  }
+
+  if (!native) {
+    // Fallback: today's full-surface behavior. The existing `load_tools`
+    // economy (ToolAvailabilityRuntime) continues to own deferral for the
+    // product surfaces it already governs; MCP tools stay direct as today.
+    return {
+      mode: 'none',
+      tools: entries,
+      activeTools,
+      deferredToolNames: [],
+    };
+  }
+
+  const searchTool: NativeSearchToolDescriptor = {
+    name: NATIVE_TOOL_SEARCH_NAME,
+    kind:
+      capability === 'anthropic'
+        ? searchVariant === 'regex'
+          ? 'anthropic-regex'
+          : 'anthropic-bm25'
+        : 'openai',
+    description: NATIVE_TOOL_SEARCH_DESCRIPTION,
+  };
+  entries.push({
+    name: searchTool.name,
+    description: searchTool.description,
+    // The search tool's input schema is provider-native; the adapter supplies
+    // it when expanding the descriptor. The lowerer leaves it undefined.
+    parameters: undefined,
+  });
+  activeTools.push(searchTool.name);
+
+  return {
+    mode: capability,
+    tools: entries,
+    activeTools,
+    searchTool,
+    deferredToolNames,
+  };
+}
+
+/** Stable namespace id for an MCP server's deferred tool group. */
+export function mcpNamespace(serverId: string): string {
+  return `mcp__${serverId}`;
+}
+
+const EMPTY_SET: ReadonlySet<string> = new Set();

--- a/packages/runtime/src/tool-discovery.ts
+++ b/packages/runtime/src/tool-discovery.ts
@@ -22,6 +22,10 @@
  *   schema. The policy is owned by Maka, not by a provider adapter.
  * - Tool Search changes visibility, not authorization. Every loaded tool still
  *   runs through `ToolRuntime`.
+ * - Native deferral is a model-context optimization, not a request-byte
+ *   optimization: deferred definitions still cross the provider API boundary
+ *   with `defer_loading`. Use the provider-independent `load_tools` path when
+ *   schemas must stay off the wire until selected.
  * - Unsupported models keep the current deterministic behavior — they receive
  *   the full surface (the existing `load_tools` economy governs deferral), never
  *   a partially deferred catalog they cannot load.
@@ -50,12 +54,25 @@ export type ToolDiscovery =
 export type ToolDiscoveryPolicy = ReadonlyMap<string, ToolDiscovery>;
 
 /**
- * Which native Tool Search path a resolved model supports, derived from the
- * `ModelAdapter`-resolved provider runtime adapter kind and model id. `none`
- * means the existing `load_tools` economy is the fallback and the lowerer is a
- * no-op.
+ * Which native Tool Search path a resolved model supports. `none` means the
+ * existing `load_tools` economy is the fallback and the lowerer is a no-op.
  */
 export type ProviderToolSearchCapability = 'anthropic' | 'openai' | 'none';
+
+/**
+ * Resolved access-path facts required to select provider-native Tool Search.
+ * The effective wire is authoritative: an adapter name or model id alone does
+ * not prove that a connection uses Responses / Messages or that a relay
+ * implements the hosted feature.
+ */
+export interface ProviderToolSearchAccess {
+  readonly providerType: string;
+  readonly adapterKind: string;
+  readonly wire: string;
+  readonly modelId: string;
+  /** Explicit relay/account declaration. First-party paths may omit it. */
+  readonly declaredCapability?: Exclude<ProviderToolSearchCapability, 'none'>;
+}
 
 /** Anthropic server-side search variant. Default: BM25 (natural language). */
 export type AnthropicSearchVariant = 'bm25' | 'regex';
@@ -104,9 +121,10 @@ export interface LoweredToolEntry {
  * The full provider-native lowering result. The backend's tool-assembly point
  * consumes this to build the `streamText` `tools` dict and `activeTools`.
  *
- * - `mode: 'none'` → fallback: `tools` carries every entry as direct, no search
- *   tool, `activeTools` lists every name. Identical to today's full surface;
- *   the existing `ToolAvailabilityRuntime` economy continues to own deferral.
+ * - `mode: 'none'` → fallback: `tools` carries every entry as direct, no native
+ *   search tool is added, and the caller's baseline `activeTools` allowlist is
+ *   preserved. The existing `ToolAvailabilityRuntime` economy continues to own
+ *   deferral without the lowerer reactivating hidden tools.
  * - `mode: 'anthropic' | 'openai'` → native: deferred entries carry
  *   `deferLoading` (and `namespace` + `namespaceDescription` for OpenAI), remain
  *   in `activeTools` so the AI SDK `tools` dict keeps them (the `deferLoading`
@@ -141,59 +159,74 @@ export const NATIVE_TOOL_SEARCH_DESCRIPTION =
   'seen; loaded tools become callable on your next step.';
 
 /**
- * Resolve the native Tool Search capability for a resolved model. The adapter
- * kind is the same one `resolveModelRuntime` (`model-runtime.ts`) produces.
+ * Resolve native Tool Search from the complete resolved access path. The
+ * adapter kind and wire are the values `resolveModelRuntime`
+ * (`model-runtime.ts`) produces.
  *
  * Model-id gating ensures only models that actually support native Tool Search
  * take the native path; older models fall back to the deterministic `load_tools`
  * economy so they never receive a partially deferred catalog they cannot load.
  *
- * Anthropic: native Tool Search is exposed on Claude Opus 4.5 / Sonnet 4.5
- * and later (model ids `claude-opus-4-5*` / `claude-sonnet-4-5*` and above).
+ * Anthropic: native Tool Search is exposed on Claude Opus, Sonnet, and Haiku
+ * 4.5+, plus Fable 5+.
  * OpenAI: `tool_search` requires the Responses API on GPT-5.4 or later
  * (`gpt-5.4*` and above). Chat Completions models such as `gpt-4o` and older
  * GPT-5 variants do not support it and fall back to `load_tools`.
  */
 export function resolveProviderToolSearchCapability(
-  adapterKind: string,
+  access: ProviderToolSearchAccess,
+): ProviderToolSearchCapability {
+  const declared =
+    access.declaredCapability ??
+    firstPartyToolSearchCapability(access.providerType, access.modelId);
+  if (declared === 'anthropic') {
+    return access.wire === 'anthropic-messages' && access.adapterKind === 'anthropic'
+      ? 'anthropic'
+      : 'none';
+  }
+  if (declared === 'openai') {
+    return access.wire === 'openai-responses' && access.adapterKind === 'openai'
+      ? 'openai'
+      : 'none';
+  }
+  return 'none';
+}
+
+function firstPartyToolSearchCapability(
+  providerType: string,
   modelId: string,
 ): ProviderToolSearchCapability {
-  switch (adapterKind) {
-    case 'anthropic':
-    case 'claude-subscription':
-      return supportsAnthropicToolSearch(modelId) ? 'anthropic' : 'none';
-    case 'openai':
-      return supportsOpenaiToolSearch(modelId) ? 'openai' : 'none';
-    default:
-      return 'none';
+  if (
+    (providerType === 'anthropic' || providerType === 'claude-subscription') &&
+    supportsAnthropicToolSearch(modelId)
+  ) {
+    return 'anthropic';
   }
+  if (providerType === 'openai' && supportsOpenaiToolSearch(modelId)) return 'openai';
+  return 'none';
 }
 
 /**
- * Anthropic native Tool Search is available on Claude Opus 4.5 / Sonnet 4.5
- * and later. Model ids follow the `claude-{opus|sonnet|haiku}-{major}-{minor}`
- * convention. The capability is gated on Opus 4.5+ / Sonnet 4.5+.
+ * Declared first-party minimums. Keeping the family table explicit prevents a
+ * new family from becoming enabled merely because its name matches a broad
+ * Claude regex.
  */
+const ANTHROPIC_TOOL_SEARCH_MINIMUMS = {
+  opus: [4, 5],
+  sonnet: [4, 5],
+  haiku: [4, 5],
+  fable: [5, 0],
+} as const;
+
 function supportsAnthropicToolSearch(modelId: string): boolean {
-  const id = modelId
+  const match = modelId
+    .trim()
     .toLowerCase()
-    .replace(/-\d{8}$/, '')
-    .replace(/-\w{2,4}-\d+$/, '');
-  const opusMatch = id.match(/^claude-opus-(\d+)(?:-(\d+))?/);
-  if (opusMatch) {
-    return (
-      Number(opusMatch[1]) > 4 || (Number(opusMatch[1]) === 4 && Number(opusMatch[2] ?? 0) >= 5)
-    );
-  }
-  const sonnetMatch = id.match(/^claude-sonnet-(\d+)(?:-(\d+))?/);
-  if (sonnetMatch) {
-    return (
-      Number(sonnetMatch[1]) > 4 ||
-      (Number(sonnetMatch[1]) === 4 && Number(sonnetMatch[2] ?? 0) >= 5)
-    );
-  }
-  // Unknown Anthropic model — be conservative, fall back.
-  return false;
+    .match(/^claude-(opus|sonnet|haiku|fable)-(\d+)(?:[.-](\d+))?/);
+  if (!match) return false;
+  const minimum =
+    ANTHROPIC_TOOL_SEARCH_MINIMUMS[match[1] as keyof typeof ANTHROPIC_TOOL_SEARCH_MINIMUMS];
+  return versionAtLeast(Number(match[2]), Number(match[3] ?? 0), minimum[0], minimum[1]);
 }
 
 /**
@@ -207,8 +240,16 @@ function supportsOpenaiToolSearch(modelId: string): boolean {
   if (!match) return false;
   const major = Number(match[1]);
   const minor = Number(match[2] ?? 0);
-  // GPT-5.4+ or GPT-6+
-  return major > 5 || (major === 5 && minor >= 4);
+  return versionAtLeast(major, minor, 5, 4);
+}
+
+function versionAtLeast(
+  major: number,
+  minor: number,
+  minimumMajor: number,
+  minimumMinor: number,
+): boolean {
+  return major > minimumMajor || (major === minimumMajor && minor >= minimumMinor);
 }
 
 export interface DeferredSurfaceInput {
@@ -260,7 +301,8 @@ export function buildToolDiscoveryPolicy(
     for (const name of surface.toolNames) {
       // First claim wins: a surface member is only deferred if it is actually
       // bound; an unbound surface member never enters the policy here.
-      if (!policy.has(name)) continue;
+      const current = policy.get(name);
+      if (!current || current.mode === 'deferred') continue;
       policy.set(name, {
         mode: 'deferred',
         namespace: surface.id,
@@ -292,6 +334,8 @@ export function buildToolDiscoveryPolicy(
  * @param tools Full dispatch set (the same `MakaTool[]` the backend builds).
  * @param policy Discovery policy for these tools.
  * @param capability Resolved native search capability for the model.
+ * @param baselineActiveTools Authoritative model-visible allowlist computed by
+ *   `ToolAvailabilityRuntime` before provider-native lowering.
  * @param options.searchVariant Anthropic search variant; default `bm25`.
  * @param options.neverAdvertise Tool names kept in the dispatch dict but never
  *   advertised (the `invalid` repair fallback). They stay direct and inactive.
@@ -300,11 +344,13 @@ export function lowerToolsForProvider(input: {
   tools: ReadonlyArray<MakaTool>;
   policy: ToolDiscoveryPolicy;
   capability: ProviderToolSearchCapability;
+  baselineActiveTools: ReadonlyArray<string>;
   searchVariant?: AnthropicSearchVariant;
   neverAdvertise?: ReadonlySet<string>;
 }): LoweredProviderToolPayload {
   const { tools, policy, capability } = input;
   const neverAdvertise = input.neverAdvertise ?? EMPTY_SET;
+  const baselineActiveTools = new Set(input.baselineActiveTools);
   const native = capability !== 'none';
   const searchVariant: AnthropicSearchVariant = input.searchVariant ?? 'bm25';
 
@@ -313,6 +359,10 @@ export function lowerToolsForProvider(input: {
   const deferredToolNames: string[] = [];
 
   for (const tool of tools) {
+    // Native search replaces the existing provider-independent connector. The
+    // two tools intentionally share a canonical name, but only one definition
+    // may cross an SDK request boundary.
+    if (native && tool.name === NATIVE_TOOL_SEARCH_NAME) continue;
     const discovery = policy.get(tool.name) ?? ({ mode: 'direct' } as const);
     const deferred = native && discovery.mode === 'deferred';
     entries.push({
@@ -340,7 +390,7 @@ export function lowerToolsForProvider(input: {
       if (!neverAdvertise.has(tool.name)) {
         activeTools.push(tool.name);
       }
-    } else if (!neverAdvertise.has(tool.name)) {
+    } else if (baselineActiveTools.has(tool.name) && !neverAdvertise.has(tool.name)) {
       activeTools.push(tool.name);
     }
   }

--- a/packages/runtime/src/tool-discovery.ts
+++ b/packages/runtime/src/tool-discovery.ts
@@ -1,3 +1,22 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 /**
  * Provider-native Tool Search — discovery policy and lowering contract.
  *


### PR DESCRIPTION
## What

First slice of #1382 (RFC: Provider-native Tool Search for large tool catalogs). Establishes a Maka-owned tool **discovery policy** on the catalog plus a **provider-native lowering contract** that the `ModelAdapter` seam (#1381 / #1390) lowers to Anthropic / OpenAI native Tool Search, with a deterministic `load_tools` fallback for unsupported models.

This is the **contract only**, not the live `streamText` wiring — mirrors how #1381 was sliced (establish the seam first, wire behavior in follow-ups).

## Why

A session connected to several MCP servers sends dozens/hundreds of tool schemas on every provider request even when the model needs one tool. Both Anthropic and OpenAI now ship native deferred loading + Tool Search. #1382 says: reuse the protocol capability rather than build a generic search service first. This slice lands the Maka-owned policy + lowering contract that later slices consume.

## Changes

- `packages/runtime/src/tool-discovery.ts` (new, pure, provider-package-free):
  - `ToolDiscovery` policy (`direct` | `deferred` + namespace), extending the catalog model rather than duplicating it.
  - `buildToolDiscoveryPolicy` — derives policy from product tools + deferred catalog surfaces + MCP tools grouped per server (**MCP tools default deferred** — the exact pain point).
  - `resolveProviderToolSearchCapability` (`anthropic` / `openai` / `none` by adapter kind).
  - `lowerToolsForProvider` — the lowering contract: native modes mark deferred tools with `deferLoading` (OpenAI also carries `namespace`), exclude them from the initial `activeTools`, and add a `tool_search` descriptor kept active; `none` is an identity no-op so today's full-surface behavior and the existing `load_tools` economy are unchanged.
- `packages/runtime/src/__tests__/tool-discovery.test.ts` (new) — 14 tests.
- `packages/runtime/package.json` — expose the contract via the `./tool-discovery` subpath export (the runtime barrel `index.ts` was retired upstream in #2742).

## Safety / correctness (per the RFC)

- Tool Search changes **visibility**, not authorization; loaded tools still cross `ToolRuntime`.
- One authoritative catalog; a search result only *selects* catalog entries — never grants permission, never introduces an unknown schema.
- Unsupported models keep the current deterministic behavior (no silent tool loss).
- An unclassified tool defaults to `direct` (never silently hidden).

## Verification

- 14 unit tests pass (capability resolution, policy building, anthropic / openai / fallback lowering paths, catalog-authority boundaries).
- New code adds **zero** type errors; the 178 pre-existing errors on the base branch are untouched.
- `biome lint` / `format` clean.

## Stacked

Rebased onto current `main` (c78f850d). The #1381 seam is already merged upstream and has evolved there, so this diff contains only this slice — the `feat(runtime): add provider-native Tool Search discovery policy + lowering contract` commit plus its review fixes. History is linear; no merge commits.

## Out of scope (follow-up slices)

- Wire `lowerToolsForProvider` into the backend tool-assembly point; expand `NativeSearchToolDescriptor` into `@ai-sdk/anthropic.toolSearchBm25_20251119` / `@ai-sdk/openai.toolSearch`.
- Adjust the execute-boundary visibility guard so a provider-loaded (search-result) tool isn't rejected by the `load_tools`-driven `activeNames` guard.
- Durable replay of `tool-search call / output / tool_reference` items for stateless continuation / process restart.
- Telemetry (searched / loaded / called / unused tools) and provider E2E.

Refs #1382
