### PR TITLE
fix: wire task-run child sessions

### DIFF
--- a/packages/headless/src/__tests__/session-capabilities.test.ts
+++ b/packages/headless/src/__tests__/session-capabilities.test.ts
@@ -1,0 +1,121 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import type { SessionManager, SpawnChildSessionResult, StopSessionInput } from '@maka/runtime';
+import { createHeadlessSessionCapabilityBridge } from '../session-capabilities.js';
+
+const childResult: SpawnChildSessionResult = {
+  childSessionId: 'child-session',
+  agentId: 'local-read',
+  agentName: 'Local Read',
+  profile: 'local_read',
+  turnId: 'child-turn',
+  runId: 'child-run',
+  status: 'cancelled',
+  permissionMode: 'explore',
+  summary: '',
+  artifactIds: [],
+  startedAt: 1,
+  completedAt: 2,
+  durationMs: 1,
+  eventCount: 1,
+};
+
+for (const scenario of [
+  { name: 'normal cleanup', input: undefined },
+  {
+    name: 'deadline cleanup',
+    input: { source: 'benchmark_deadline' } satisfies StopSessionInput,
+  },
+]) {
+  test(`${scenario.name} retries a transient stop before draining child work`, async () => {
+    let releaseChild!: () => void;
+    const child = new Promise<SpawnChildSessionResult>((resolve) => {
+      releaseChild = () => resolve(childResult);
+    });
+    let stopCalls = 0;
+    const transientStopError = new Error('transient child stop failure');
+    const manager = {
+      spawnChildSession: () => child,
+      stopSession: async () => {
+        stopCalls += 1;
+        if (stopCalls === 1) throw transientStopError;
+        releaseChild();
+      },
+    } as unknown as SessionManager;
+    const bridge = createHeadlessSessionCapabilityBridge();
+    bridge.bind(manager);
+    const spawn = bridge.capabilities.spawnChildSession('parent-session', {
+      spawnedBy: {
+        parentRunId: 'parent-run',
+        parentTurnId: 'parent-turn',
+        toolCallId: 'tool-call',
+      },
+      agentProfile: 'local_read',
+      prompt: 'wait for cleanup',
+    });
+    const settle = bridge.settle('parent-session', scenario.input).then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+
+    let watchdog: ReturnType<typeof setTimeout> | undefined;
+    const completedBeforeWatchdog = await Promise.race([
+      settle.then(() => true),
+      new Promise<false>((resolve) => {
+        watchdog = setTimeout(() => resolve(false), 750);
+      }),
+    ]);
+    if (watchdog) clearTimeout(watchdog);
+    if (!completedBeforeWatchdog) releaseChild();
+    const settleError = await settle;
+    await spawn;
+
+    assert.equal(completedBeforeWatchdog, true);
+    assert.equal(stopCalls, 2);
+    assert.equal(settleError, undefined);
+  });
+}
+
+test('settle preserves the first unrecoverable stop error after one bounded retry', async () => {
+  let releaseChild!: () => void;
+  const child = new Promise<SpawnChildSessionResult>((resolve) => {
+    releaseChild = () => resolve(childResult);
+  });
+  const firstStopError = new Error('first stop failure');
+  const secondStopError = new Error('second stop failure');
+  let stopCalls = 0;
+  const manager = {
+    spawnChildSession: () => child,
+    stopSession: async () => {
+      stopCalls += 1;
+      throw stopCalls === 1 ? firstStopError : secondStopError;
+    },
+  } as unknown as SessionManager;
+  const bridge = createHeadlessSessionCapabilityBridge();
+  bridge.bind(manager);
+  const spawn = bridge.capabilities.spawnChildSession('parent-session', {
+    spawnedBy: {
+      parentRunId: 'parent-run',
+      parentTurnId: 'parent-turn',
+      toolCallId: 'tool-call',
+    },
+    agentProfile: 'local_read',
+    prompt: 'wait for cleanup',
+  });
+  let watchdog: ReturnType<typeof setTimeout> | undefined;
+  const settleResult = await Promise.race([
+    bridge.settle('parent-session').then(
+      () => undefined,
+      (error: unknown) => error,
+    ),
+    new Promise<Error>((resolve) => {
+      watchdog = setTimeout(() => resolve(new Error('settle watchdog expired')), 750);
+    }),
+  ]);
+  if (watchdog) clearTimeout(watchdog);
+  releaseChild();
+  await spawn;
+
+  assert.equal(settleResult, firstStopError);
+  assert.equal(stopCalls, 2);
+});

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -275,6 +275,7 @@ class ParentWithBackgroundChildBackend implements AgentBackend {
     private readonly childStarted: Promise<void>,
     private readonly observeChild: (promise: Promise<unknown>) => void,
     private readonly waitForStop: boolean,
+    private readonly stopError?: Error,
   ) {
     this.sessionId = sessionId;
   }
@@ -314,6 +315,49 @@ class ParentWithBackgroundChildBackend implements AgentBackend {
 
   async stop(): Promise<void> {
     this.release();
+    if (this.stopError) throw this.stopError;
+  }
+
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+class FailingStopBackgroundChildBackend implements AgentBackend {
+  readonly kind: BackendKind = 'ai-sdk';
+  readonly sessionId: string;
+  stopCalls = 0;
+  private finish!: () => void;
+  private readonly finished = new Promise<void>((resolve) => {
+    this.finish = resolve;
+  });
+
+  constructor(
+    sessionId: string,
+    private readonly onStarted: () => void,
+    private readonly stopError: Error,
+  ) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    this.onStarted();
+    await this.finished;
+    yield {
+      type: 'complete',
+      id: 'failing-stop-child-complete',
+      turnId: input.turnId,
+      ts: Date.now(),
+      stopReason: 'user_stop',
+    };
+  }
+
+  async stop(): Promise<void> {
+    this.stopCalls += 1;
+    throw this.stopError;
+  }
+
+  finishForTest(): void {
+    this.finish();
   }
 
   async respondToPermission(_decision: PermissionDecision): Promise<void> {}
@@ -1228,6 +1272,70 @@ describe('runTaskOnce', () => {
     });
   });
 
+  test('surfaces a cleanup error when the task runtime succeeds', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const cleanupError = new Error('child cleanup stop failed');
+      let resolveChildStarted!: () => void;
+      const childStarted = new Promise<void>((resolve) => {
+        resolveChildStarted = resolve;
+      });
+      let childBackend: FailingStopBackgroundChildBackend | undefined;
+      let childPromise: Promise<unknown> | undefined;
+      let buildCount = 0;
+      const task: Task = {
+        id: 'successful-runtime-cleanup-failure',
+        instruction: 'surface cleanup failure',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const run = runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+        storageRoot,
+        registerBackends: (registry, context) => {
+          registry.register('ai-sdk', (ctx) => {
+            buildCount += 1;
+            if (buildCount === 1) {
+              return new ParentWithBackgroundChildBackend(
+                ctx.sessionId,
+                context,
+                childStarted,
+                (promise) => {
+                  childPromise = promise;
+                },
+                false,
+              );
+            }
+            childBackend = new FailingStopBackgroundChildBackend(
+              ctx.sessionId,
+              resolveChildStarted,
+              cleanupError,
+            );
+            return childBackend;
+          });
+        },
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'unit isolated executor',
+          toolExecutor: {
+            async exec() {
+              return { exitCode: 0, stdout: '', stderr: '' };
+            },
+          },
+        },
+      });
+      try {
+        await assert.rejects(run, (error: unknown) => {
+          assert.equal(error, cleanupError);
+          return true;
+        });
+        assert.equal(childBackend?.stopCalls, 2);
+      } finally {
+        childBackend?.finishForTest();
+        await childPromise;
+      }
+    });
+  });
+
   test('settles background child sessions at the task-run deadline', async (t) => {
     await withDirs(async (fixtureDir, storageRoot) => {
       const realSetTimeout = setTimeout;
@@ -1303,6 +1411,93 @@ describe('runTaskOnce', () => {
         await childPromise;
       } finally {
         if (watchdog) realClearTimeout(watchdog);
+        t.mock.timers.reset();
+      }
+    });
+  });
+
+  test('preserves the runtime error when deadline cleanup also fails', async (t) => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const realSetTimeout = setTimeout;
+      const realClearTimeout = clearTimeout;
+      t.mock.timers.enable({ apis: ['setTimeout'] });
+      const runtimeError = new Error('parent deadline stop failed');
+      const cleanupError = new Error('child cleanup stop failed');
+      let resolveChildStarted!: () => void;
+      const childStarted = new Promise<void>((resolve) => {
+        resolveChildStarted = resolve;
+      });
+      let childBackend: FailingStopBackgroundChildBackend | undefined;
+      let childPromise: Promise<unknown> | undefined;
+      let buildCount = 0;
+      const task: Task = {
+        id: 'deadline-runtime-and-cleanup-failure',
+        instruction: 'preserve the primary runtime failure',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const run = runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+        storageRoot,
+        registerBackends: (registry, context) => {
+          registry.register('ai-sdk', (ctx) => {
+            buildCount += 1;
+            if (buildCount === 1) {
+              return new ParentWithBackgroundChildBackend(
+                ctx.sessionId,
+                context,
+                childStarted,
+                (promise) => {
+                  childPromise = promise;
+                },
+                true,
+                runtimeError,
+              );
+            }
+            childBackend = new FailingStopBackgroundChildBackend(
+              ctx.sessionId,
+              resolveChildStarted,
+              cleanupError,
+            );
+            return childBackend;
+          });
+        },
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'unit isolated executor',
+          toolExecutor: {
+            async exec() {
+              return { exitCode: 0, stdout: '', stderr: '' };
+            },
+          },
+        },
+        now: () => 0,
+        deadlineAtMs: 100,
+      });
+      let watchdog: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await childStarted;
+        t.mock.timers.tick(100);
+        await assert.rejects(
+          Promise.race([
+            run,
+            new Promise<never>((_resolve, reject) => {
+              watchdog = realSetTimeout(
+                () => reject(new Error('dual failure watchdog expired')),
+                1_000,
+              );
+            }),
+          ]),
+          (error: unknown) => {
+            assert.equal(error, runtimeError);
+            return true;
+          },
+        );
+        assert.equal(childBackend?.stopCalls, 2);
+      } finally {
+        if (watchdog) realClearTimeout(watchdog);
+        childBackend?.finishForTest();
+        await childPromise;
         t.mock.timers.reset();
       }
     });

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -156,6 +156,170 @@ class DeadlineBackend implements AgentBackend {
   async dispose(): Promise<void> {}
 }
 
+class ChildCapabilityBackend implements AgentBackend {
+  readonly kind: BackendKind = 'ai-sdk';
+  readonly sessionId: string;
+
+  constructor(
+    sessionId: string,
+    private readonly context: HeadlessBackendContext,
+    private readonly observed: {
+      childSessionId?: string;
+      childStatus?: string;
+      listedSessionIds?: string[];
+      outputSessionId?: string;
+    },
+  ) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    assert.ok(this.context.spawnChildSession);
+    assert.ok(this.context.listChildAgents);
+    assert.ok(this.context.readChildAgentOutput);
+    assert.ok(input.runId);
+    const child = await this.context.spawnChildSession(this.sessionId, {
+      spawnedBy: {
+        parentRunId: input.runId,
+        parentTurnId: input.turnId,
+        toolCallId: 'child-capability-call',
+      },
+      agentProfile: 'local_read',
+      prompt: 'inspect the task workspace',
+    });
+    const listed = await this.context.listChildAgents(this.sessionId);
+    const output = await this.context.readChildAgentOutput(this.sessionId, {
+      execution: {
+        kind: 'child_session',
+        sessionId: child.childSessionId,
+        currentRunId: child.runId,
+      },
+    });
+    this.observed.childSessionId = child.childSessionId;
+    this.observed.childStatus = child.status;
+    this.observed.listedSessionIds = listed.executions.flatMap((execution) =>
+      execution.execution.kind === 'child_session' ? [execution.execution.sessionId] : [],
+    );
+    this.observed.outputSessionId =
+      output.execution.kind === 'child_session' ? output.execution.sessionId : undefined;
+    yield {
+      type: 'text_complete',
+      id: 'capability-parent-text',
+      turnId: input.turnId,
+      ts: Date.now(),
+      messageId: 'capability-parent-message',
+      text: 'done',
+    };
+    yield {
+      type: 'complete',
+      id: 'capability-parent-complete',
+      turnId: input.turnId,
+      ts: Date.now(),
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+class BackgroundChildBackend implements AgentBackend {
+  readonly kind: BackendKind = 'ai-sdk';
+  readonly sessionId: string;
+  stopCalls = 0;
+  private release!: () => void;
+  private readonly stopped = new Promise<void>((resolve) => {
+    this.release = resolve;
+  });
+
+  constructor(
+    sessionId: string,
+    private readonly onStarted: () => void,
+  ) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    this.onStarted();
+    await this.stopped;
+    yield {
+      type: 'complete',
+      id: 'background-child-complete',
+      turnId: input.turnId,
+      ts: Date.now(),
+      stopReason: 'user_stop',
+    };
+  }
+
+  async stop(): Promise<void> {
+    this.stopCalls += 1;
+    this.release();
+  }
+
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+class ParentWithBackgroundChildBackend implements AgentBackend {
+  readonly kind: BackendKind = 'ai-sdk';
+  readonly sessionId: string;
+  private release!: () => void;
+  private readonly stopped = new Promise<void>((resolve) => {
+    this.release = resolve;
+  });
+
+  constructor(
+    sessionId: string,
+    private readonly context: HeadlessBackendContext,
+    private readonly childStarted: Promise<void>,
+    private readonly observeChild: (promise: Promise<unknown>) => void,
+    private readonly waitForStop: boolean,
+  ) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    assert.ok(input.runId);
+    assert.ok(this.context.spawnChildSession);
+    this.observeChild(
+      this.context.spawnChildSession(this.sessionId, {
+        spawnedBy: {
+          parentRunId: input.runId,
+          parentTurnId: input.turnId,
+          toolCallId: 'background-child-call',
+        },
+        agentProfile: 'local_read',
+        prompt: 'wait for parent cleanup',
+      }),
+    );
+    await this.childStarted;
+    if (this.waitForStop) await this.stopped;
+    yield {
+      type: 'text_complete',
+      id: 'background-parent-text',
+      turnId: input.turnId,
+      ts: Date.now(),
+      messageId: 'background-parent-message',
+      text: 'done',
+    };
+    yield {
+      type: 'complete',
+      id: 'background-parent-complete',
+      turnId: input.turnId,
+      ts: Date.now(),
+      stopReason: this.waitForStop ? 'user_stop' : 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {
+    this.release();
+  }
+
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
 class ResettingDeadlineBackend implements AgentBackend {
   readonly kind: BackendKind = 'fake';
 
@@ -945,6 +1109,205 @@ async function readAgentRunHeader(
 }
 
 describe('runTaskOnce', () => {
+  test('lets a task-run backend spawn, list, and read a linked child session', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const observed: {
+        childSessionId?: string;
+        childStatus?: string;
+        childToolNames?: string[];
+        listedSessionIds?: string[];
+        outputSessionId?: string;
+      } = {};
+      let buildCount = 0;
+      const task: Task = {
+        id: 'child-capability-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+        storageRoot,
+        registerBackends: (registry, context) => {
+          registry.register('ai-sdk', (ctx) => {
+            buildCount += 1;
+            if (buildCount === 1) {
+              return new ChildCapabilityBackend(ctx.sessionId, context, observed);
+            }
+            observed.childToolNames = ctx.tools?.map((tool) => tool.name);
+            return new FakeBackend({
+              sessionId: ctx.sessionId,
+              header: ctx.header,
+              store: ctx.store,
+            });
+          });
+        },
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'unit isolated executor',
+          toolExecutor: {
+            async exec() {
+              return { exitCode: 0, stdout: '', stderr: '' };
+            },
+          },
+        },
+      });
+
+      assert.equal(
+        result.resultRecord.status,
+        'completed',
+        JSON.stringify(result.resultRecord, null, 2),
+      );
+      assert.equal(observed.childStatus, 'completed');
+      assert.deepEqual(observed.childToolNames, ['Read', 'Glob', 'Grep']);
+      assert.ok(observed.childSessionId);
+      assert.deepEqual(observed.listedSessionIds, [observed.childSessionId]);
+      assert.equal(observed.outputSessionId, observed.childSessionId);
+    });
+  });
+
+  test('settles background child sessions after a normal task-run completion', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      let resolveChildStarted!: () => void;
+      const childStarted = new Promise<void>((resolve) => {
+        resolveChildStarted = resolve;
+      });
+      let childBackend: BackgroundChildBackend | undefined;
+      let childPromise: Promise<unknown> | undefined;
+      let childSettled = false;
+      let buildCount = 0;
+      const task: Task = {
+        id: 'normal-background-child',
+        instruction: 'coordinate child work',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+        storageRoot,
+        registerBackends: (registry, context) => {
+          registry.register('ai-sdk', (ctx) => {
+            buildCount += 1;
+            if (buildCount === 1) {
+              return new ParentWithBackgroundChildBackend(
+                ctx.sessionId,
+                context,
+                childStarted,
+                (promise) => {
+                  childPromise = promise.finally(() => {
+                    childSettled = true;
+                  });
+                },
+                false,
+              );
+            }
+            childBackend = new BackgroundChildBackend(ctx.sessionId, resolveChildStarted);
+            return childBackend;
+          });
+        },
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'unit isolated executor',
+          toolExecutor: {
+            async exec() {
+              return { exitCode: 0, stdout: '', stderr: '' };
+            },
+          },
+        },
+      });
+
+      assert.equal(
+        result.resultRecord.status,
+        'completed',
+        JSON.stringify(result.resultRecord, null, 2),
+      );
+      assert.equal(result.settledByDeadline, false);
+      assert.equal(childBackend?.stopCalls, 1);
+      assert.equal(childSettled, true);
+      await childPromise;
+    });
+  });
+
+  test('settles background child sessions at the task-run deadline', async (t) => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const realSetTimeout = setTimeout;
+      const realClearTimeout = clearTimeout;
+      t.mock.timers.enable({ apis: ['setTimeout'] });
+      let resolveChildStarted!: () => void;
+      const childStarted = new Promise<void>((resolve) => {
+        resolveChildStarted = resolve;
+      });
+      let childBackend: BackgroundChildBackend | undefined;
+      let childPromise: Promise<unknown> | undefined;
+      let childSettled = false;
+      let buildCount = 0;
+      const task: Task = {
+        id: 'deadline-background-child',
+        instruction: 'coordinate child work',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const run = runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+        storageRoot,
+        registerBackends: (registry, context) => {
+          registry.register('ai-sdk', (ctx) => {
+            buildCount += 1;
+            if (buildCount === 1) {
+              return new ParentWithBackgroundChildBackend(
+                ctx.sessionId,
+                context,
+                childStarted,
+                (promise) => {
+                  childPromise = promise.finally(() => {
+                    childSettled = true;
+                  });
+                },
+                true,
+              );
+            }
+            childBackend = new BackgroundChildBackend(ctx.sessionId, resolveChildStarted);
+            return childBackend;
+          });
+        },
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'unit isolated executor',
+          toolExecutor: {
+            async exec() {
+              return { exitCode: 0, stdout: '', stderr: '' };
+            },
+          },
+        },
+        now: () => 0,
+        deadlineAtMs: 100,
+      });
+      let watchdog: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await childStarted;
+        t.mock.timers.tick(100);
+        const result = await Promise.race([
+          run,
+          new Promise<never>((_resolve, reject) => {
+            watchdog = realSetTimeout(
+              () => reject(new Error('deadline child lifecycle watchdog expired')),
+              1_000,
+            );
+          }),
+        ]);
+
+        assert.ok(childBackend);
+        assert.equal(result.settledByDeadline, true);
+        assert.equal(childBackend.stopCalls, 1);
+        assert.equal(childSettled, true);
+        await childPromise;
+      } finally {
+        if (watchdog) realClearTimeout(watchdog);
+        t.mock.timers.reset();
+      }
+    });
+  });
+
   test('does not dispatch a runtime attempt after the benchmark deadline', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       const counters = { sendCalls: 0 };

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -28,6 +28,7 @@ import { commandResourceScope, hashNormalizedArgs } from '../permission-grants.j
 import {
   runTaskOnce,
   runTaskOnceWithStorage,
+  TaskAgentController,
   type RunTaskOnceResult,
 } from '../task-agent-controller.js';
 import type { TaskPermissionGrant } from '../task-contracts.js';
@@ -228,6 +229,7 @@ class BackgroundChildBackend implements AgentBackend {
   readonly kind: BackendKind = 'ai-sdk';
   readonly sessionId: string;
   stopCalls = 0;
+  runId?: string;
   private release!: () => void;
   private readonly stopped = new Promise<void>((resolve) => {
     this.release = resolve;
@@ -241,6 +243,7 @@ class BackgroundChildBackend implements AgentBackend {
   }
 
   async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    this.runId = input.runId;
     this.onStarted();
     await this.stopped;
     yield {
@@ -1269,6 +1272,13 @@ describe('runTaskOnce', () => {
       assert.equal(childBackend?.stopCalls, 1);
       assert.equal(childSettled, true);
       await childPromise;
+      assert.ok(childBackend?.runId);
+      const childRunHeader = await readAgentRunHeader(
+        storageRoot,
+        childBackend.sessionId,
+        childBackend.runId,
+      );
+      assert.equal(childRunHeader.abortSource, 'user_stop');
     });
   });
 
@@ -1416,12 +1426,105 @@ describe('runTaskOnce', () => {
     });
   });
 
-  test('preserves the runtime error when deadline cleanup also fails', async (t) => {
+  test('settles child sessions with deadline provenance when parent settlement fails', async (t) => {
     await withDirs(async (fixtureDir, storageRoot) => {
       const realSetTimeout = setTimeout;
       const realClearTimeout = clearTimeout;
       t.mock.timers.enable({ apis: ['setTimeout'] });
       const runtimeError = new Error('parent deadline stop failed');
+      let resolveChildStarted!: () => void;
+      const childStarted = new Promise<void>((resolve) => {
+        resolveChildStarted = resolve;
+      });
+      let childBackend: BackgroundChildBackend | undefined;
+      let childPromise: Promise<unknown> | undefined;
+      let childSettled = false;
+      let buildCount = 0;
+      const task: Task = {
+        id: 'deadline-parent-settlement-failure',
+        instruction: 'preserve deadline provenance',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const run = runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+        storageRoot,
+        registerBackends: (registry, context) => {
+          registry.register('ai-sdk', (ctx) => {
+            buildCount += 1;
+            if (buildCount === 1) {
+              return new ParentWithBackgroundChildBackend(
+                ctx.sessionId,
+                context,
+                childStarted,
+                (promise) => {
+                  childPromise = promise.finally(() => {
+                    childSettled = true;
+                  });
+                },
+                true,
+                runtimeError,
+              );
+            }
+            childBackend = new BackgroundChildBackend(ctx.sessionId, resolveChildStarted);
+            return childBackend;
+          });
+        },
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'unit isolated executor',
+          toolExecutor: {
+            async exec() {
+              return { exitCode: 0, stdout: '', stderr: '' };
+            },
+          },
+        },
+        now: () => 0,
+        deadlineAtMs: 100,
+      });
+      let watchdog: ReturnType<typeof setTimeout> | undefined;
+      try {
+        await childStarted;
+        t.mock.timers.tick(100);
+        await assert.rejects(
+          Promise.race([
+            run,
+            new Promise<never>((_resolve, reject) => {
+              watchdog = realSetTimeout(
+                () => reject(new Error('deadline settlement failure watchdog expired')),
+                1_000,
+              );
+            }),
+          ]),
+          (error: unknown) => {
+            assert.equal(error, runtimeError);
+            return true;
+          },
+        );
+        assert.ok(childBackend?.runId);
+        assert.equal(childBackend.stopCalls, 1);
+        assert.equal(childSettled, true);
+        await childPromise;
+        const childRunHeader = await readAgentRunHeader(
+          storageRoot,
+          childBackend.sessionId,
+          childBackend.runId,
+        );
+        assert.equal(childRunHeader.abortSource, 'benchmark.deadline');
+      } finally {
+        if (watchdog) realClearTimeout(watchdog);
+        t.mock.timers.reset();
+      }
+    });
+  });
+
+  test('preserves the runtime error when deadline cleanup also fails', async (t) => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const realSetTimeout = setTimeout;
+      const realClearTimeout = clearTimeout;
+      t.mock.timers.enable({ apis: ['setTimeout'] });
+      class ParentSettlementError extends Error {}
+      const runtimeError = new ParentSettlementError('parent deadline stop failed');
       const cleanupError = new Error('child cleanup stop failed');
       let resolveChildStarted!: () => void;
       const childStarted = new Promise<void>((resolve) => {
@@ -1437,7 +1540,7 @@ describe('runTaskOnce', () => {
         verification: { command: 'true', protectedPaths: [] },
       };
 
-      const run = runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+      const run = new TaskAgentController({
         storageRoot,
         registerBackends: (registry, context) => {
           registry.register('ai-sdk', (ctx) => {
@@ -1473,7 +1576,7 @@ describe('runTaskOnce', () => {
         },
         now: () => 0,
         deadlineAtMs: 100,
-      });
+      }).runOnce({ ...fakeConfig, backend: 'ai-sdk' }, task);
       let watchdog: ReturnType<typeof setTimeout> | undefined;
       try {
         await childStarted;
@@ -1490,6 +1593,8 @@ describe('runTaskOnce', () => {
           ]),
           (error: unknown) => {
             assert.equal(error, runtimeError);
+            assert.ok(error instanceof ParentSettlementError);
+            assert.equal(error.cause, cleanupError);
             return true;
           },
         );

--- a/packages/headless/src/session-capabilities.ts
+++ b/packages/headless/src/session-capabilities.ts
@@ -10,6 +10,7 @@ import type {
   SpawnChildAgentResult,
   SpawnChildSessionInput,
   SpawnChildSessionResult,
+  StopSessionInput,
 } from '@maka/runtime';
 
 export interface HeadlessSessionCapabilities {
@@ -31,26 +32,36 @@ export interface HeadlessSessionCapabilities {
 export function createHeadlessSessionCapabilityBridge(): {
   capabilities: HeadlessSessionCapabilities;
   bind(manager: SessionManager): void;
+  settle(sessionId: string, input?: StopSessionInput): Promise<void>;
 } {
   let manager: SessionManager | undefined;
+  const activeOperations = new Set<Promise<unknown>>();
   const requireManager = (): SessionManager => {
     if (!manager) {
       throw new Error('Headless session capabilities are unavailable during backend registration');
     }
     return manager;
   };
+  const track = <T>(operation: Promise<T>): Promise<T> => {
+    activeOperations.add(operation);
+    void operation.then(
+      () => activeOperations.delete(operation),
+      () => activeOperations.delete(operation),
+    );
+    return operation;
+  };
   return {
     capabilities: {
       spawnChildAgent: async (sessionId, input) =>
-        await requireManager().spawnChildAgent(sessionId, input),
+        await track(requireManager().spawnChildAgent(sessionId, input)),
       spawnChildSession: async (parentSessionId, input) =>
-        await requireManager().spawnChildSession(parentSessionId, input),
+        await track(requireManager().spawnChildSession(parentSessionId, input)),
       prepareChildAgentResume: async (sessionId, sourceRunId) =>
         await requireManager().prepareChildAgentResume(sessionId, sourceRunId),
       resumeChildAgent: async (sessionId, input) =>
-        await requireManager().resumeChildAgent(sessionId, input),
+        await track(requireManager().resumeChildAgent(sessionId, input)),
       retryChildAgent: async (sessionId, input) =>
-        await requireManager().retryChildAgent(sessionId, input),
+        await track(requireManager().retryChildAgent(sessionId, input)),
       listChildAgents: async (sessionId) => await requireManager().listChildAgents(sessionId),
       readChildAgentOutput: async (sessionId, input) =>
         await requireManager().readChildAgentOutput(sessionId, input),
@@ -60,6 +71,27 @@ export function createHeadlessSessionCapabilityBridge(): {
         throw new Error('Headless session capabilities are already bound');
       }
       manager = nextManager;
+    },
+    async settle(sessionId, input) {
+      const operations = [...activeOperations];
+      let firstStopError: unknown;
+      try {
+        await requireManager().stopSession(sessionId, input);
+      } catch (error) {
+        firstStopError = error;
+      }
+      if (firstStopError !== undefined) {
+        try {
+          await requireManager().stopSession(sessionId, input);
+        } catch {
+          throw firstStopError;
+        }
+      }
+      const results = await Promise.allSettled(operations);
+      const error = results.find(
+        (result): result is PromiseRejectedResult => result.status === 'rejected',
+      )?.reason;
+      if (error !== undefined) throw error;
     },
   };
 }

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -13,6 +13,8 @@ import {
   AiSdkFlow,
   BackendRegistry,
   RuntimeRunner,
+  SessionManager,
+  buildChildAgentTools,
   type AgentRunActiveSession,
   type InvocationResult,
   type SessionStore,
@@ -76,6 +78,7 @@ import {
   restoreProtectedPaths,
 } from './sandbox.js';
 import { defaultFinalScorer } from './scorer.js';
+import { createHeadlessSessionCapabilityBridge } from './session-capabilities.js';
 import { approvalRequestInboxItem } from './task-inbox.js';
 import { normalizeVerifier, runVerifier, verifierProtectedPaths } from './verifier.js';
 import {
@@ -104,6 +107,7 @@ import { taskDefinitionFromTask } from './task-run-adapter.js';
 import { taskEvidenceRuntimeProvenanceLinks } from './task-evidence-provenance.js';
 import { taskAttemptExecutionEvidence } from './task-execution-lineage.js';
 import { bindSelfCheckEvidence } from './task-self-check-evidence.js';
+import { buildIsolatedHeadlessTools } from './tools.js';
 
 export interface RunTaskOnceDeps extends RunExperimentDeps {
   taskRunId?: string;
@@ -300,6 +304,7 @@ export async function runTaskOnceWithStorage(
       }),
     });
     const backends = new BackendRegistry();
+    const sessionCapabilities = createHeadlessSessionCapabilityBridge();
     const registerBackends: NonNullable<RunExperimentDeps['registerBackends']> =
       deps.registerBackends ?? ((registry) => registerFakeBackend(registry));
     await registerBackends(backends, {
@@ -307,6 +312,7 @@ export async function runTaskOnceWithStorage(
       task,
       storageRoot: deps.storageRoot,
       workspaceDir: agentWorkspaceDir,
+      ...sessionCapabilities.capabilities,
       artifactStore: storage.artifactStore,
       heavyTaskMode,
       ...(heavyTaskProgress ? { heavyTaskProgress } : {}),
@@ -319,6 +325,27 @@ export async function runTaskOnceWithStorage(
           }
         : {}),
     });
+
+    let parentActive: ReturnType<typeof createSingleRunActiveSession> | undefined;
+    const sessionCapabilityManager = new SessionManager({
+      store: sessionStore,
+      runStore: agentRunStore,
+      runtimeEventStore,
+      backends,
+      ...(deps.realBackendIsolation?.toolExecutor
+        ? {
+            childTools: buildChildAgentTools(
+              buildIsolatedHeadlessTools(deps.realBackendIsolation.toolExecutor),
+            ),
+          }
+        : {}),
+      isParentRunActive: (sessionId, runId, turnId) =>
+        parentActive?.hasActiveRun(sessionId, runId, turnId) ?? false,
+      newId,
+      now,
+      runtimeSource: 'test',
+    });
+    sessionCapabilities.bind(sessionCapabilityManager);
 
     const header = await sessionStore.create({
       cwd: agentWorkspaceDir,
@@ -334,6 +361,7 @@ export async function runTaskOnceWithStorage(
     });
     const turnId = newId();
     const active = createSingleRunActiveSession(backends, sessionStore, now, newId);
+    parentActive = active;
     const run = new AgentRun({
       sessionId: header.id,
       header,
@@ -388,7 +416,12 @@ export async function runTaskOnceWithStorage(
       runtimeInvocation = runtimeAttempt.invocation;
       settledByDeadline = runtimeAttempt.settledByDeadline;
     } finally {
-      await active.dispose();
+      await disposeTaskRunSession(
+        active,
+        sessionCapabilities,
+        header.id,
+        settledByDeadline ? 'benchmark_deadline' : 'stop_button',
+      );
     }
     await appendTaskAttemptExecutionLink({
       store: taskRunStore,
@@ -472,6 +505,7 @@ export async function runTaskOnceWithStorage(
 
       if (gateDecision.action === 'repair_prompt') {
         const repairActive = createSingleRunActiveSession(backends, sessionStore, now, newId);
+        parentActive = repairActive;
         const repairRun = new AgentRun({
           sessionId: header.id,
           header,
@@ -500,7 +534,12 @@ export async function runTaskOnceWithStorage(
           repairInvocation = repairRuntimeAttempt.invocation;
           settledByDeadline ||= repairRuntimeAttempt.settledByDeadline;
         } finally {
-          await repairActive.dispose();
+          await disposeTaskRunSession(
+            repairActive,
+            sessionCapabilities,
+            header.id,
+            settledByDeadline ? 'benchmark_deadline' : 'stop_button',
+          );
         }
         await appendTaskAttemptExecutionLink({
           store: taskRunStore,
@@ -1259,6 +1298,7 @@ function createSingleRunActiveSession(
 ): {
   hooks: AgentRunHooks;
   bindRun(run: AgentRun): void;
+  hasActiveRun(sessionId: string, runId: string, turnId: string): boolean;
   settleByDeadline(): Promise<boolean>;
   dispose(): Promise<void>;
 } {
@@ -1269,6 +1309,10 @@ function createSingleRunActiveSession(
   };
   return {
     bindRun,
+    hasActiveRun: (sessionId, runId, turnId) =>
+      active?.sessionId === sessionId &&
+      active.activeRuns.get(runId)?.turnId === turnId &&
+      active.turnToRunId.get(turnId) === runId,
     settleByDeadline: async () => {
       if (!active) return false;
       const stoppedRuns = [...active.activeRuns.values()].filter((run) =>
@@ -1361,6 +1405,24 @@ function createSingleRunActiveSession(
       if (backend) await backend.dispose().catch(() => {});
     },
   };
+}
+
+async function disposeTaskRunSession(
+  active: { dispose(): Promise<void> },
+  sessionCapabilities: {
+    settle(
+      sessionId: string,
+      input: { source: 'benchmark_deadline' | 'stop_button' },
+    ): Promise<void>;
+  },
+  sessionId: string,
+  source: 'benchmark_deadline' | 'stop_button',
+): Promise<void> {
+  try {
+    await sessionCapabilities.settle(sessionId, { source });
+  } finally {
+    await active.dispose();
+  }
 }
 
 function statusPatch(

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -401,28 +401,31 @@ export async function runTaskOnceWithStorage(
 
     let runtimeInvocation: InvocationResult;
     let settledByDeadline = false;
-    try {
-      const runtimeAttempt = await runRuntimeAttempt({
-        run,
-        header,
-        instruction,
-        ...(deps.priorRuntimeContext ? { priorRuntimeContext: deps.priorRuntimeContext } : {}),
-        requireTerminalRuntimeEventWrite: Boolean(runtimeEventStore),
-        now,
-        newId,
-        settleByDeadline: active.settleByDeadline,
-        ...(deps.deadlineAtMs !== undefined ? { deadlineAtMs: deps.deadlineAtMs } : {}),
-      });
-      runtimeInvocation = runtimeAttempt.invocation;
-      settledByDeadline = runtimeAttempt.settledByDeadline;
-    } finally {
-      await disposeTaskRunSession(
-        active,
-        sessionCapabilities,
-        header.id,
-        settledByDeadline ? 'benchmark_deadline' : 'stop_button',
-      );
-    }
+    const runtimeAttempt = await runWithTaskSessionCleanup(
+      async () => {
+        const attempt = await runRuntimeAttempt({
+          run,
+          header,
+          instruction,
+          ...(deps.priorRuntimeContext ? { priorRuntimeContext: deps.priorRuntimeContext } : {}),
+          requireTerminalRuntimeEventWrite: Boolean(runtimeEventStore),
+          now,
+          newId,
+          settleByDeadline: active.settleByDeadline,
+          ...(deps.deadlineAtMs !== undefined ? { deadlineAtMs: deps.deadlineAtMs } : {}),
+        });
+        settledByDeadline = attempt.settledByDeadline;
+        return attempt;
+      },
+      () =>
+        disposeTaskRunSession(
+          active,
+          sessionCapabilities,
+          header.id,
+          settledByDeadline ? 'benchmark_deadline' : 'stop_button',
+        ),
+    );
+    runtimeInvocation = runtimeAttempt.invocation;
     await appendTaskAttemptExecutionLink({
       store: taskRunStore,
       runtimeEventStore,
@@ -519,28 +522,33 @@ export async function runTaskOnceWithStorage(
         });
         repairActive.bindRun(repairRun);
         let repairInvocation: InvocationResult;
-        try {
-          const repairRuntimeAttempt = await runRuntimeAttempt({
-            run: repairRun,
-            header,
-            instruction: gateDecision.prompt,
-            ...(deps.priorRuntimeContext ? { priorRuntimeContext: deps.priorRuntimeContext } : {}),
-            requireTerminalRuntimeEventWrite: Boolean(runtimeEventStore),
-            now,
-            newId,
-            settleByDeadline: repairActive.settleByDeadline,
-            ...(deps.deadlineAtMs !== undefined ? { deadlineAtMs: deps.deadlineAtMs } : {}),
-          });
-          repairInvocation = repairRuntimeAttempt.invocation;
-          settledByDeadline ||= repairRuntimeAttempt.settledByDeadline;
-        } finally {
-          await disposeTaskRunSession(
-            repairActive,
-            sessionCapabilities,
-            header.id,
-            settledByDeadline ? 'benchmark_deadline' : 'stop_button',
-          );
-        }
+        const repairRuntimeAttempt = await runWithTaskSessionCleanup(
+          async () => {
+            const attempt = await runRuntimeAttempt({
+              run: repairRun,
+              header,
+              instruction: gateDecision.prompt,
+              ...(deps.priorRuntimeContext
+                ? { priorRuntimeContext: deps.priorRuntimeContext }
+                : {}),
+              requireTerminalRuntimeEventWrite: Boolean(runtimeEventStore),
+              now,
+              newId,
+              settleByDeadline: repairActive.settleByDeadline,
+              ...(deps.deadlineAtMs !== undefined ? { deadlineAtMs: deps.deadlineAtMs } : {}),
+            });
+            settledByDeadline ||= attempt.settledByDeadline;
+            return attempt;
+          },
+          () =>
+            disposeTaskRunSession(
+              repairActive,
+              sessionCapabilities,
+              header.id,
+              settledByDeadline ? 'benchmark_deadline' : 'stop_button',
+            ),
+        );
+        repairInvocation = repairRuntimeAttempt.invocation;
         await appendTaskAttemptExecutionLink({
           store: taskRunStore,
           runtimeEventStore,
@@ -1405,6 +1413,21 @@ function createSingleRunActiveSession(
       if (backend) await backend.dispose().catch(() => {});
     },
   };
+}
+
+async function runWithTaskSessionCleanup<T>(
+  run: () => Promise<T>,
+  cleanup: () => Promise<void>,
+): Promise<T> {
+  let result: T;
+  try {
+    result = await run();
+  } catch (primaryError) {
+    await cleanup().catch(() => {});
+    throw primaryError;
+  }
+  await cleanup();
+  return result;
 }
 
 async function disposeTaskRunSession(

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -401,6 +401,7 @@ export async function runTaskOnceWithStorage(
 
     let runtimeInvocation: InvocationResult;
     let settledByDeadline = false;
+    let deadlineTriggered = false;
     const runtimeAttempt = await runWithTaskSessionCleanup(
       async () => {
         const attempt = await runRuntimeAttempt({
@@ -412,6 +413,9 @@ export async function runTaskOnceWithStorage(
           now,
           newId,
           settleByDeadline: active.settleByDeadline,
+          onDeadlineTriggered: () => {
+            deadlineTriggered = true;
+          },
           ...(deps.deadlineAtMs !== undefined ? { deadlineAtMs: deps.deadlineAtMs } : {}),
         });
         settledByDeadline = attempt.settledByDeadline;
@@ -422,7 +426,7 @@ export async function runTaskOnceWithStorage(
           active,
           sessionCapabilities,
           header.id,
-          settledByDeadline ? 'benchmark_deadline' : 'stop_button',
+          deadlineTriggered ? 'benchmark_deadline' : undefined,
         ),
     );
     runtimeInvocation = runtimeAttempt.invocation;
@@ -522,6 +526,7 @@ export async function runTaskOnceWithStorage(
         });
         repairActive.bindRun(repairRun);
         let repairInvocation: InvocationResult;
+        let repairDeadlineTriggered = false;
         const repairRuntimeAttempt = await runWithTaskSessionCleanup(
           async () => {
             const attempt = await runRuntimeAttempt({
@@ -535,6 +540,9 @@ export async function runTaskOnceWithStorage(
               now,
               newId,
               settleByDeadline: repairActive.settleByDeadline,
+              onDeadlineTriggered: () => {
+                repairDeadlineTriggered = true;
+              },
               ...(deps.deadlineAtMs !== undefined ? { deadlineAtMs: deps.deadlineAtMs } : {}),
             });
             settledByDeadline ||= attempt.settledByDeadline;
@@ -545,7 +553,7 @@ export async function runTaskOnceWithStorage(
               repairActive,
               sessionCapabilities,
               header.id,
-              settledByDeadline ? 'benchmark_deadline' : 'stop_button',
+              repairDeadlineTriggered ? 'benchmark_deadline' : undefined,
             ),
         );
         repairInvocation = repairRuntimeAttempt.invocation;
@@ -1204,6 +1212,7 @@ interface RunRuntimeAttemptInput {
   newId: () => string;
   deadlineAtMs?: number;
   settleByDeadline(): Promise<boolean>;
+  onDeadlineTriggered(): void;
 }
 
 async function runRuntimeAttempt(input: RunRuntimeAttemptInput): Promise<{
@@ -1248,6 +1257,7 @@ async function runRuntimeAttempt(input: RunRuntimeAttemptInput): Promise<{
   let settlementError: unknown;
   let settlementAttempt: Promise<void> | undefined;
   const settle = () => {
+    input.onDeadlineTriggered();
     settlementAttempt = input
       .settleByDeadline()
       .then((settled) => {
@@ -1423,11 +1433,37 @@ async function runWithTaskSessionCleanup<T>(
   try {
     result = await run();
   } catch (primaryError) {
-    await cleanup().catch(() => {});
+    try {
+      await cleanup();
+    } catch (cleanupError) {
+      attachTaskCleanupCause(primaryError, cleanupError);
+    }
     throw primaryError;
   }
   await cleanup();
   return result;
+}
+
+function attachTaskCleanupCause(primaryError: unknown, cleanupError: unknown): void {
+  if (!(primaryError instanceof Error)) return;
+  const existingCause = primaryError.cause;
+  const cause =
+    existingCause === undefined
+      ? cleanupError
+      : new AggregateError(
+          [existingCause, cleanupError],
+          'task session cleanup failed after the primary error',
+        );
+  try {
+    Object.defineProperty(primaryError, 'cause', {
+      value: cause,
+      configurable: true,
+      enumerable: false,
+      writable: true,
+    });
+  } catch {
+    // A frozen caller-owned error must remain the primary thrown value.
+  }
 }
 
 async function disposeTaskRunSession(
@@ -1435,14 +1471,14 @@ async function disposeTaskRunSession(
   sessionCapabilities: {
     settle(
       sessionId: string,
-      input: { source: 'benchmark_deadline' | 'stop_button' },
+      input?: { source: 'benchmark_deadline' | 'stop_button' },
     ): Promise<void>;
   },
   sessionId: string,
-  source: 'benchmark_deadline' | 'stop_button',
+  source: 'benchmark_deadline' | undefined,
 ): Promise<void> {
   try {
-    await sessionCapabilities.settle(sessionId, { source });
+    await sessionCapabilities.settle(sessionId, source ? { source } : undefined);
   } finally {
     await active.dispose();
   }

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -1055,6 +1055,56 @@ describe('SessionManager child-session runtime primitive', () => {
     expect(await manager.listChildSessions(parent.id)).toEqual([]);
   });
 
+  test('admits child work through an external parent-run authority', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    let externalParent:
+      | {
+          sessionId: string;
+          runId: string;
+          turnId: string;
+        }
+      | undefined;
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      isParentRunActive: (sessionId, runId, turnId) =>
+        externalParent !== undefined &&
+        externalParent.sessionId === sessionId &&
+        externalParent.runId === runId &&
+        externalParent.turnId === turnId,
+      newId: nextId(),
+      now: nextNow(250),
+    });
+    const parent = await manager.createSession(makeInput());
+    await drain(manager.sendMessage(parent.id, { turnId: 'parent-turn', text: 'parent' }));
+    const [parentRun] = await runStore.listSessionRuns(parent.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+    externalParent = {
+      sessionId: parent.id,
+      runId: parentRun.runId,
+      turnId: parentRun.turnId,
+    };
+
+    const child = await manager.spawnChildSession(parent.id, {
+      spawnedBy: {
+        parentRunId: parentRun.runId,
+        parentTurnId: parentRun.turnId,
+        toolCallId: 'tool-call-1',
+      },
+      agentProfile: LOCAL_READ_AGENT_PROFILE,
+      prompt: 'inspect',
+    });
+
+    expect(child.status).toBe('completed');
+    expect(child.childSessionId === parent.id).toBe(false);
+  });
+
   test('child stop is isolated while parent stop reaches every foreground child session', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -11,6 +11,7 @@ import type {
   TaskOwner,
 } from '@maka/core';
 import type { SessionEvent } from '@maka/core/events';
+import { zodSchema } from 'ai';
 import { buildBuiltinTools } from '../builtin-tools.js';
 import { PermissionEngine } from '../permission-engine.js';
 import {
@@ -63,6 +64,29 @@ describe('subagent tools', () => {
       AGENT_LIST_TOOL_NAME,
       AGENT_OUTPUT_TOOL_NAME,
     ]);
+  });
+
+  test('agent_spawn advertises task_id only when task binding is available', async () => {
+    const advertisedProperties = async (tool: MakaTool) => {
+      const schema = (await zodSchema(tool.parameters as never).jsonSchema) as {
+        properties?: Record<string, unknown>;
+      };
+      return schema.properties ?? {};
+    };
+
+    expect(Object.keys(await advertisedProperties(buildSubagentSpawnTool()))).toEqual([
+      'profile',
+      'task',
+      'write_back',
+      'isolation',
+    ]);
+    expect(
+      Object.keys(
+        await advertisedProperties(
+          buildSubagentSpawnTool({ taskLedger: taskLedgerStub(undefined, []) }),
+        ),
+      ),
+    ).toEqual(['profile', 'task', 'write_back', 'isolation', 'task_id']);
   });
 
   test('built-in catalog exposes local-read without shell, web, nested, or write tools', () => {

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -89,6 +89,20 @@ describe('subagent tools', () => {
     ).toEqual(['profile', 'task', 'write_back', 'isolation', 'task_id']);
   });
 
+  test('agent_spawn rejects task_id when task binding is unavailable', () => {
+    const schema = buildSubagentSpawnTool().parameters as {
+      safeParse(input: unknown): { success: boolean };
+    };
+
+    expect(
+      schema.safeParse({
+        profile: LOCAL_READ_AGENT_PROFILE,
+        task: 'Inspect the repo.',
+        task_id: 'T1',
+      }).success,
+    ).toBe(false);
+  });
+
   test('built-in catalog exposes local-read without shell, web, nested, or write tools', () => {
     expect(LOCAL_READ_AGENT_DEFINITION.id).toBe(LOCAL_READ_AGENT_ID);
     expect(LOCAL_READ_AGENT_DEFINITION.profile).toBe(LOCAL_READ_AGENT_PROFILE);

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -444,6 +444,8 @@ export interface SessionManagerDeps {
   runtimeSource?: InvocationSource;
   runtimeInvocationObserver?: (result: InvocationResult) => void | Promise<void>;
   runtimeKernel?: RuntimeKernelLike;
+  /** Optional host-owned parent run authority for runtimes that execute the parent externally. */
+  isParentRunActive?: (sessionId: string, runId: string, turnId: string) => boolean;
   shellRuns?: ShellRunProcessManager;
   cleanupHistoryCompactArtifacts?: (input: HistoryCompactCleanupRequest) => Promise<void>;
   inspectContinuationSafety?: (sessionId: string) => Promise<RuntimeContinuationSafetyObservation>;
@@ -2615,7 +2617,10 @@ export class SessionManager {
     if (
       parentRun.sessionId !== parentSessionId ||
       parentRun.turnId !== parentTurnId ||
-      !this.runtimeKernel.hasActiveRun?.(parentSessionId, parentRun.runId, parentTurnId)
+      !(
+        this.runtimeKernel.hasActiveRun?.(parentSessionId, parentRun.runId, parentTurnId) ||
+        this.deps.isParentRunActive?.(parentSessionId, parentRun.runId, parentTurnId)
+      )
     ) {
       throw new Error('Child session parent run is not active');
     }

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -111,6 +111,7 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
             }
           : {}),
       })
+      .strict()
       .superRefine((input, ctx) => {
         const definition = requireBuiltinAgentDefinitionByProfile(input.profile);
         const requestedWriteBack = input.write_back ?? definition.contract.defaultWriteBack;

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -99,13 +99,17 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
           .describe(
             'Requested child workspace isolation. Worktree profiles fail closed until a worktree child executor is available.',
           ),
-        task_id: z
-          .string()
-          .min(1)
-          .max(TASK_ID_MAX_CHARS)
-          .refine(isSafeTaskId)
-          .optional()
-          .describe('Existing task UUID or short key to bind to this child run.'),
+        ...(deps.taskLedger
+          ? {
+              task_id: z
+                .string()
+                .min(1)
+                .max(TASK_ID_MAX_CHARS)
+                .refine(isSafeTaskId)
+                .optional()
+                .describe('Existing task UUID or short key to bind to this child run.'),
+            }
+          : {}),
       })
       .superRefine((input, ctx) => {
         const definition = requireBuiltinAgentDefinitionByProfile(input.profile);


### PR DESCRIPTION
## Summary

- give `runTaskOnce` backends the existing linked child-session capability surface, backed by the task run's durable stores and isolated read-only child tools
- keep the existing task-run active map as the single parent-run authority and expose only an admission predicate to `SessionManager`, so linked children and their parent share authoritative liveness without duplicating run state
- stop and drain background linked child sessions after both normal completion and benchmark-deadline settlement; a transient stop failure gets one bounded retry through SessionManager's existing stop authority before child operations are drained
- advertise `agent_spawn.task_id` only when a `TaskLedgerStore` can honor task binding

## Verification

- `node --test packages/runtime/dist/__tests__/session-manager.test.js packages/runtime/dist/__tests__/subagent-tools.test.js` (238 passed)
- `node --test packages/headless/dist/__tests__/session-capabilities.test.js packages/headless/dist/__tests__/task-agent-controller.test.js packages/headless/dist/__tests__/runner.test.js` (48 passed)
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run typecheck`

## Review focus

- The task-run integration test performs a real `spawnChildSession`, then lists and reads the linked child through child-session execution refs; it does not merely assert that capability functions exist.
- Normal and deadline cleanup tests launch an unawaited linked child, verify its backend receives one stop, and require the child promise to settle before `runTaskOnce` returns.
- Cleanup retries stop exactly once before draining tracked children. Deterministic normal/deadline tests cover a child that only releases on the second stop; a separate test proves two stop failures return the first error without a third attempt or an unbounded child wait.
- `isParentRunActive` is a narrow read-only admission seam: default SessionManager behavior still uses RuntimeKernel ownership, while task runs query their existing `createSingleRunActiveSession` map.
