### PR TITLE
fix(headless): aggregate Harbor usage checkpoints

### DIFF
--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -2364,6 +2364,39 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('rejects a deadline-settled result when required final usage is missing', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireFinalUsage: true,
+        taskRunner: async () =>
+          harborOutput({
+            taskId: 'task-a',
+            reward: 0,
+            status: 'failed',
+            errorClass: 'aborted',
+            deadlineSettlement: { source: 'benchmark.deadline', mode: 'immediate' },
+            omitTokenSummary: true,
+          }),
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'missing_token_usage');
+      assert.equal(result.events[0]?.eligible, false);
+      assert.equal(result.events[0]?.scored, false);
+    });
+  });
+
   test('keeps an attested tool-step-cap result eligible when usage is unavailable', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -4,7 +4,13 @@ import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import type { BackendKind, LlmConnection, SessionEvent, SessionHeader } from '@maka/core';
+import type {
+  BackendKind,
+  LlmConnection,
+  RuntimeEvent,
+  SessionEvent,
+  SessionHeader,
+} from '@maka/core';
 import type {
   BackendSendInput,
   BackendStopMode,
@@ -17,6 +23,7 @@ import {
   type AgentBackend,
   type AiSdkBackendInput,
   type BackendFactoryContext,
+  type InvocationResult,
   type PiAgentTransport,
   type ProviderRequestCaptureRecord,
   type SessionStore,
@@ -48,8 +55,10 @@ import {
   resolveHarborCellAiSdkEnv,
   runHarborCellFromEnv,
   runHarborCell,
+  writeHarborCellArtifacts,
   writeHarborCellUsageCheckpoint,
 } from '../harbor-cell.js';
+import { resolveHarborRunOptions } from '../harbor-cli.js';
 import { DEFAULT_HEADLESS_SYSTEM_PROMPT } from '../system-prompts.js';
 import { buildIsolatedBashTool } from '../tools.js';
 
@@ -773,6 +782,106 @@ describe('runHarborCell', () => {
         readFile(join(outputDir, HARBOR_CELL_USAGE_CHECKPOINT_FILENAME), 'utf8'),
         (error: NodeJS.ErrnoException) => error.code === 'ENOENT',
       );
+    });
+  });
+
+  test('writes child-inclusive checkpoint usage into the canonical cell output', async () => {
+    await withDirs(async ({ outputDir }) => {
+      await writeHarborCellUsageCheckpoint(outputDir, {
+        inputTokens: 140,
+        outputTokens: 20,
+        cacheHitInputTokens: 40,
+        cacheMissInputTokens: 100,
+        cacheMissInputSource: 'explicit',
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 5,
+        totalTokens: 160,
+        costUsd: 0.012,
+      });
+      const usageEvent: RuntimeEvent = {
+        id: 'parent-usage',
+        sessionId: 'session-1',
+        invocationId: 'invocation-1',
+        runId: 'run-1',
+        turnId: 'turn-1',
+        ts: 100,
+        partial: false,
+        role: 'model',
+        author: 'agent',
+        actions: {
+          tokenUsage: {
+            input: 100,
+            output: 10,
+            cacheHitInput: 30,
+            cacheMissInput: 70,
+            cacheMissInputSource: 'explicit',
+            cacheWriteInput: 0,
+            reasoning: 2,
+            total: 110,
+            runtimeSteps: 1,
+            costUsd: 0.006,
+          },
+        },
+      };
+      const invocation: InvocationResult = {
+        invocationId: 'invocation-1',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        turnId: 'turn-1',
+        status: 'completed',
+        events: [usageEvent],
+        startedAt: 100,
+        finishedAt: 200,
+      };
+
+      const result = await writeHarborCellArtifacts({ invocation, outputDir });
+
+      assert.deepEqual(result.output.tokenSummary, {
+        input: 140,
+        output: 20,
+        cachedInput: 40,
+        cacheHitInput: 40,
+        cacheMissInput: 100,
+        cacheWriteInput: 0,
+        cacheMissInputSource: 'explicit',
+        reasoning: 5,
+        total: 160,
+        costUsd: 0.012,
+        pricingSource: 'runtime',
+      });
+      assert.deepEqual(
+        JSON.parse(await readFile(result.outputPath, 'utf8')).tokenSummary,
+        result.output.tokenSummary,
+      );
+    });
+  });
+
+  test('a new cell run does not inherit a stale checkpoint from the same output directory', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      await writeHarborCellUsageCheckpoint(outputDir, {
+        inputTokens: 500,
+        outputTokens: 50,
+        cacheHitInputTokens: 200,
+        cacheMissInputTokens: 300,
+        cacheMissInputSource: 'explicit',
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 10,
+        totalTokens: 550,
+        costUsd: 1,
+      });
+
+      const result = await runHarborCell({
+        config,
+        instruction: 'fail before model usage',
+        cwd: workspaceDir,
+        outputDir,
+        storageRoot,
+        registerBackends: registerThrowingBackend,
+      });
+
+      assert.equal(result.output.status, 'failed');
+      assert.equal(result.output.tokenSummary, undefined);
+      assert.equal(JSON.parse(await readFile(result.outputPath, 'utf8')).tokenSummary, undefined);
     });
   });
 
@@ -2034,6 +2143,566 @@ describe('runHarborCell', () => {
       );
       assert.equal(scopedInput.systemPrompt, 'Durable child prompt.');
       assert.equal(scopedInput.toolAvailability, undefined);
+    });
+  });
+
+  test('Harbor replaces each backend cumulative usage snapshot', async () => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
+      const registry = new BackendRegistry();
+      const checkpoints: Array<{ inputTokens: number; outputTokens: number; totalTokens: number }> =
+        [];
+      const register = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-5.6-sol',
+        env: { OPENAI_API_KEY: 'test-key' },
+        now: () => 123,
+        newId: testIdFactory(),
+        recordUsageCheckpoint: (usage) => {
+          checkpoints.push(usage);
+        },
+      });
+      const toolExecutor = fakeToolExecutor();
+      await register(registry, {
+        config: {
+          id: 'harbor-ai-sdk',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'openai',
+          model: 'gpt-5.6-sol',
+        },
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        storageRoot: workspaceDir,
+        workspaceDir,
+        artifactStore,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+
+      const parent = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const childContext = backendContext(workspaceDir);
+      const child = await registry.build('ai-sdk', {
+        ...childContext,
+        sessionId: 'child-session',
+        header: { ...childContext.header, id: 'child-session' },
+      });
+      const recordParentUsage = (
+        parent as unknown as {
+          input: Pick<AiSdkBackendInput, 'recordUsageCheckpoint'>;
+        }
+      ).input.recordUsageCheckpoint;
+      const recordChildUsage = (
+        child as unknown as {
+          input: Pick<AiSdkBackendInput, 'recordUsageCheckpoint'>;
+        }
+      ).input.recordUsageCheckpoint;
+      assert.ok(recordParentUsage);
+      assert.ok(recordChildUsage);
+
+      await recordParentUsage({
+        inputTokens: 11,
+        outputTokens: 2,
+        cacheHitInputTokens: 3,
+        cachedInputTokens: 3,
+        cacheMissInputTokens: 7,
+        cacheMissInputSource: 'explicit',
+        cacheWriteInputTokens: 1,
+        reasoningTokens: 1,
+        totalTokens: 13,
+        costUsd: 0.004,
+      });
+      await recordChildUsage({
+        inputTokens: 5,
+        outputTokens: 2,
+        cacheHitInputTokens: 1,
+        cachedInputTokens: 1,
+        cacheMissInputTokens: 4,
+        cacheMissInputSource: 'derived',
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 0,
+        totalTokens: 7,
+        costUsd: 0.002,
+      });
+      await recordParentUsage({
+        inputTokens: 19,
+        outputTokens: 5,
+        cacheHitInputTokens: 6,
+        cachedInputTokens: 6,
+        cacheMissInputTokens: 11,
+        cacheMissInputSource: 'explicit',
+        cacheWriteInputTokens: 2,
+        reasoningTokens: 4,
+        totalTokens: 24,
+        costUsd: 0.009,
+      });
+
+      assert.deepEqual(
+        checkpoints.map(({ inputTokens, outputTokens, totalTokens }) => ({
+          inputTokens,
+          outputTokens,
+          totalTokens,
+        })),
+        [
+          { inputTokens: 11, outputTokens: 2, totalTokens: 13 },
+          { inputTokens: 16, outputTokens: 4, totalTokens: 20 },
+          { inputTokens: 24, outputTokens: 7, totalTokens: 31 },
+        ],
+      );
+    });
+  });
+
+  test('Harbor retains usage across repeated backend registrations for one run', async () => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
+      const checkpoints: Array<{ inputTokens: number; outputTokens: number }> = [];
+      const register = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-5.6-sol',
+        env: { OPENAI_API_KEY: 'test-key' },
+        now: () => 123,
+        newId: testIdFactory(),
+        recordUsageCheckpoint: (usage) => {
+          checkpoints.push(usage);
+        },
+      });
+      const context = {
+        config: {
+          id: 'harbor-ai-sdk',
+          backend: 'ai-sdk' as const,
+          llmConnectionSlug: 'openai',
+          model: 'gpt-5.6-sol',
+        },
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        storageRoot: workspaceDir,
+        workspaceDir,
+        artifactStore,
+        realBackendIsolation: {
+          kind: 'external' as const,
+          label: 'Harbor task container',
+          toolExecutor: fakeToolExecutor(),
+        },
+        toolExecutor: fakeToolExecutor(),
+      };
+      const recorders: Array<NonNullable<AiSdkBackendInput['recordUsageCheckpoint']>> = [];
+      for (const sessionId of ['attempt-1', 'attempt-2']) {
+        const registry = new BackendRegistry();
+        await register(registry, context);
+        const backendContextInput = backendContext(workspaceDir);
+        const backend = await registry.build('ai-sdk', {
+          ...backendContextInput,
+          sessionId,
+          header: { ...backendContextInput.header, id: sessionId },
+        });
+        const recorder = (
+          backend as unknown as {
+            input: Pick<AiSdkBackendInput, 'recordUsageCheckpoint'>;
+          }
+        ).input.recordUsageCheckpoint;
+        assert.ok(recorder);
+        recorders.push(recorder);
+      }
+
+      await recorders[0]!({
+        inputTokens: 90,
+        outputTokens: 10,
+        cacheHitInputTokens: 20,
+        cachedInputTokens: 20,
+        cacheMissInputTokens: 70,
+        cacheMissInputSource: 'explicit',
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 2,
+        totalTokens: 100,
+        costUsd: 0.01,
+      });
+      await recorders[1]!({
+        inputTokens: 8,
+        outputTokens: 2,
+        cacheHitInputTokens: 3,
+        cachedInputTokens: 3,
+        cacheMissInputTokens: 5,
+        cacheMissInputSource: 'derived',
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 1,
+        totalTokens: 10,
+        costUsd: 0.002,
+      });
+
+      assert.deepEqual(
+        checkpoints.map(({ inputTokens, outputTokens }) => ({ inputTokens, outputTokens })),
+        [
+          { inputTokens: 90, outputTokens: 10 },
+          { inputTokens: 98, outputTokens: 12 },
+        ],
+      );
+    });
+  });
+
+  test('Harbor preserves pricing and cache fields in parent-child usage aggregates', async () => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
+      const registry = new BackendRegistry();
+      const checkpoints: Array<{
+        cacheHitInputTokens: number;
+        cacheMissInputTokens: number;
+        cacheMissInputSource: 'explicit' | 'derived';
+        cacheWriteInputTokens: number;
+        reasoningTokens: number;
+        costUsd?: number;
+      }> = [];
+      const register = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-5.6-sol',
+        env: { OPENAI_API_KEY: 'test-key' },
+        now: () => 123,
+        newId: testIdFactory(),
+        recordUsageCheckpoint: (usage) => {
+          checkpoints.push(usage);
+        },
+      });
+      const toolExecutor = fakeToolExecutor();
+      await register(registry, {
+        config: {
+          id: 'harbor-ai-sdk',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'openai',
+          model: 'gpt-5.6-sol',
+        },
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        storageRoot: workspaceDir,
+        workspaceDir,
+        artifactStore,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+
+      const parent = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const child = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const recordParentUsage = (
+        parent as unknown as {
+          input: Pick<AiSdkBackendInput, 'recordUsageCheckpoint'>;
+        }
+      ).input.recordUsageCheckpoint;
+      const recordChildUsage = (
+        child as unknown as {
+          input: Pick<AiSdkBackendInput, 'recordUsageCheckpoint'>;
+        }
+      ).input.recordUsageCheckpoint;
+      assert.ok(recordParentUsage);
+      assert.ok(recordChildUsage);
+
+      await recordParentUsage({
+        inputTokens: 14,
+        outputTokens: 3,
+        cacheHitInputTokens: 4,
+        cachedInputTokens: 4,
+        cacheMissInputTokens: 8,
+        cacheMissInputSource: 'derived',
+        cacheWriteInputTokens: 2,
+        reasoningTokens: 1,
+        totalTokens: 17,
+        costUsd: 0.006,
+      });
+      await recordChildUsage({
+        inputTokens: 9,
+        outputTokens: 5,
+        cacheHitInputTokens: 5,
+        cachedInputTokens: 5,
+        cacheMissInputTokens: 4,
+        cacheMissInputSource: 'explicit',
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 2,
+        totalTokens: 14,
+        costUsd: 0.008,
+      });
+
+      const aggregate = checkpoints.at(-1);
+      assert.ok(aggregate);
+      assert.deepEqual(
+        {
+          cacheHitInputTokens: aggregate.cacheHitInputTokens,
+          cacheMissInputTokens: aggregate.cacheMissInputTokens,
+          cacheMissInputSource: aggregate.cacheMissInputSource,
+          cacheWriteInputTokens: aggregate.cacheWriteInputTokens,
+          reasoningTokens: aggregate.reasoningTokens,
+          costUsd: aggregate.costUsd,
+        },
+        {
+          cacheHitInputTokens: 9,
+          cacheMissInputTokens: 12,
+          cacheMissInputSource: 'explicit',
+          cacheWriteInputTokens: 2,
+          reasoningTokens: 3,
+          costUsd: 0.014,
+        },
+      );
+    });
+  });
+
+  test('Harbor serializes concurrent aggregate checkpoint persistence', async () => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
+      const registry = new BackendRegistry();
+      const persisted: Array<{ inputTokens: number; outputTokens: number; totalTokens: number }> =
+        [];
+      let persistenceCalls = 0;
+      let releaseFirstPersistence = () => {};
+      const firstPersistenceBlocked = new Promise<void>((resolve) => {
+        releaseFirstPersistence = resolve;
+      });
+      let observeFirstPersistence = () => {};
+      const firstPersistenceStarted = new Promise<void>((resolve) => {
+        observeFirstPersistence = resolve;
+      });
+      const register = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-5.6-sol',
+        env: { OPENAI_API_KEY: 'test-key' },
+        now: () => 123,
+        newId: testIdFactory(),
+        recordUsageCheckpoint: async (usage) => {
+          persistenceCalls += 1;
+          if (persistenceCalls === 1) {
+            observeFirstPersistence();
+            await firstPersistenceBlocked;
+          }
+          persisted.push(usage);
+        },
+      });
+      const toolExecutor = fakeToolExecutor();
+      await register(registry, {
+        config: {
+          id: 'harbor-ai-sdk',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'openai',
+          model: 'gpt-5.6-sol',
+        },
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        storageRoot: workspaceDir,
+        workspaceDir,
+        artifactStore,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+
+      const parent = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const child = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const recordParentUsage = (
+        parent as unknown as {
+          input: Pick<AiSdkBackendInput, 'recordUsageCheckpoint'>;
+        }
+      ).input.recordUsageCheckpoint;
+      const recordChildUsage = (
+        child as unknown as {
+          input: Pick<AiSdkBackendInput, 'recordUsageCheckpoint'>;
+        }
+      ).input.recordUsageCheckpoint;
+      assert.ok(recordParentUsage);
+      assert.ok(recordChildUsage);
+
+      const parentWrite = recordParentUsage({
+        inputTokens: 8,
+        outputTokens: 2,
+        cacheHitInputTokens: 1,
+        cachedInputTokens: 1,
+        cacheMissInputTokens: 7,
+        cacheMissInputSource: 'derived',
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 0,
+        totalTokens: 10,
+        costUsd: 0.003,
+      });
+      await firstPersistenceStarted;
+      const childWrite = recordChildUsage({
+        inputTokens: 15,
+        outputTokens: 4,
+        cacheHitInputTokens: 5,
+        cachedInputTokens: 5,
+        cacheMissInputTokens: 10,
+        cacheMissInputSource: 'explicit',
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 2,
+        totalTokens: 19,
+        costUsd: 0.007,
+      });
+      await Promise.resolve();
+      const callsBeforeRelease = persistenceCalls;
+      releaseFirstPersistence();
+      await Promise.all([parentWrite, childWrite]);
+
+      assert.equal(callsBeforeRelease, 1);
+      assert.deepEqual(
+        persisted.map(({ inputTokens, outputTokens, totalTokens }) => ({
+          inputTokens,
+          outputTokens,
+          totalTokens,
+        })),
+        [
+          { inputTokens: 8, outputTokens: 2, totalTokens: 10 },
+          { inputTokens: 23, outputTokens: 6, totalTokens: 29 },
+        ],
+      );
+    });
+  });
+
+  test('Harbor continues checkpoint aggregation after a persistence failure', async () => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
+      const registry = new BackendRegistry();
+      const persisted: Array<{ inputTokens: number; outputTokens: number }> = [];
+      let persistenceCalls = 0;
+      const register = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-5.6-sol',
+        env: { OPENAI_API_KEY: 'test-key' },
+        now: () => 123,
+        newId: testIdFactory(),
+        recordUsageCheckpoint: (usage) => {
+          persistenceCalls += 1;
+          if (persistenceCalls === 1) throw new Error('checkpoint disk unavailable');
+          persisted.push(usage);
+        },
+      });
+      const toolExecutor = fakeToolExecutor();
+      await register(registry, {
+        config: {
+          id: 'harbor-ai-sdk',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'openai',
+          model: 'gpt-5.6-sol',
+        },
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        storageRoot: workspaceDir,
+        workspaceDir,
+        artifactStore,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+      const parent = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const child = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const recordParentUsage = (
+        parent as unknown as {
+          input: Pick<AiSdkBackendInput, 'recordUsageCheckpoint'>;
+        }
+      ).input.recordUsageCheckpoint;
+      const recordChildUsage = (
+        child as unknown as {
+          input: Pick<AiSdkBackendInput, 'recordUsageCheckpoint'>;
+        }
+      ).input.recordUsageCheckpoint;
+      assert.ok(recordParentUsage);
+      assert.ok(recordChildUsage);
+
+      await assert.rejects(
+        async () =>
+          await recordParentUsage({
+            inputTokens: 80,
+            outputTokens: 20,
+            cacheHitInputTokens: 30,
+            cachedInputTokens: 30,
+            cacheMissInputTokens: 50,
+            cacheMissInputSource: 'explicit',
+            cacheWriteInputTokens: 0,
+            reasoningTokens: 5,
+            totalTokens: 100,
+            costUsd: 0.01,
+          }),
+        /checkpoint disk unavailable/,
+      );
+      await recordChildUsage({
+        inputTokens: 8,
+        outputTokens: 2,
+        cacheHitInputTokens: 3,
+        cachedInputTokens: 3,
+        cacheMissInputTokens: 5,
+        cacheMissInputSource: 'derived',
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 1,
+        totalTokens: 10,
+        costUsd: 0.002,
+      });
+
+      assert.equal(persistenceCalls, 2);
+      assert.deepEqual(
+        persisted.map(({ inputTokens, outputTokens }) => ({ inputTokens, outputTokens })),
+        [{ inputTokens: 88, outputTokens: 22 }],
+      );
+    });
+  });
+
+  test('task-run CLI persists runtime usage checkpoints to the cell artifact directory', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot, artifactStore }) => {
+      const cellArtifactDir = join(outputDir, 'cell-artifacts');
+      const options = await resolveHarborRunOptions(
+        [
+          '--mode',
+          'task-run',
+          '--backend',
+          'ai-sdk',
+          '--isolation',
+          'harbor-local',
+          '--instruction',
+          'solve',
+          '--workdir',
+          workspaceDir,
+          '--out',
+          outputDir,
+          '--storage-root',
+          storageRoot,
+          '--provider',
+          'openai',
+          '--model',
+          'gpt-5.6-sol',
+        ],
+        {
+          OPENAI_API_KEY: 'test-key',
+          MAKA_CELL_ARTIFACT_DIR: cellArtifactDir,
+        },
+      );
+      assert.ok(options.registerBackends);
+      const registry = new BackendRegistry();
+      const toolExecutor = fakeToolExecutor();
+      await options.registerBackends(registry, {
+        config: options.config,
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        storageRoot,
+        workspaceDir,
+        artifactStore,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+      const backend = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const recordUsageCheckpoint = (
+        backend as unknown as {
+          input: Pick<AiSdkBackendInput, 'recordUsageCheckpoint'>;
+        }
+      ).input.recordUsageCheckpoint;
+      assert.ok(recordUsageCheckpoint);
+
+      await recordUsageCheckpoint({
+        inputTokens: 21,
+        outputTokens: 4,
+        cacheHitInputTokens: 7,
+        cachedInputTokens: 7,
+        cacheMissInputTokens: 12,
+        cacheMissInputSource: 'explicit',
+        cacheWriteInputTokens: 2,
+        reasoningTokens: 3,
+        totalTokens: 25,
+        costUsd: 0.012,
+      });
+
+      assert.deepEqual(
+        JSON.parse(
+          await readFile(join(cellArtifactDir, HARBOR_CELL_USAGE_CHECKPOINT_FILENAME), 'utf8'),
+        ),
+        {
+          input: 21,
+          output: 4,
+          cachedInput: 7,
+          cacheHitInput: 7,
+          cacheMissInput: 12,
+          cacheWriteInput: 2,
+          cacheMissInputSource: 'explicit',
+          reasoning: 3,
+          total: 25,
+          costUsd: 0.012,
+          pricingSource: 'runtime',
+        },
+      );
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -56,6 +56,7 @@ import {
   runHarborCellFromEnv,
   runHarborCell,
   writeHarborCellArtifacts,
+  writeHarborCellExecutionIdentity,
   writeHarborCellUsageCheckpoint,
 } from '../harbor-cell.js';
 import { resolveHarborRunOptions } from '../harbor-cli.js';
@@ -2702,6 +2703,149 @@ describe('runHarborCell', () => {
           costUsd: 0.012,
           pricingSource: 'runtime',
         },
+      );
+    });
+  });
+
+  test('cell-mode CLI keeps usage checkpoints with its canonical cell artifacts', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot, artifactStore }) => {
+      const detachedCellArtifactDir = join(outputDir, 'detached-cell-artifacts');
+      const options = await resolveHarborRunOptions(
+        [
+          '--mode',
+          'cell',
+          '--backend',
+          'ai-sdk',
+          '--isolation',
+          'harbor-local',
+          '--instruction',
+          'solve',
+          '--workdir',
+          workspaceDir,
+          '--out',
+          outputDir,
+          '--storage-root',
+          storageRoot,
+          '--provider',
+          'openai',
+          '--model',
+          'gpt-5.6-sol',
+        ],
+        {
+          OPENAI_API_KEY: 'test-key',
+          MAKA_CELL_ARTIFACT_DIR: detachedCellArtifactDir,
+        },
+      );
+      const staleUsage = {
+        inputTokens: 500,
+        outputTokens: 50,
+        cacheHitInputTokens: 200,
+        cacheMissInputTokens: 300,
+        cacheMissInputSource: 'explicit' as const,
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 10,
+        totalTokens: 550,
+        costUsd: 1,
+      };
+      await writeHarborCellUsageCheckpoint(outputDir, staleUsage);
+      const executionIdentity = {
+        llmConnectionSlug: 'openai',
+        model: 'gpt-5.6-sol',
+        systemPromptHash: 'sha256:cell-mode-checkpoint',
+        pricingProfile: 'test-profile',
+      };
+      await writeHarborCellExecutionIdentity(outputDir, executionIdentity);
+
+      assert.ok(options.registerBackends);
+      const registry = new BackendRegistry();
+      const toolExecutor = fakeToolExecutor();
+      await options.registerBackends(registry, {
+        config: options.config,
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        storageRoot,
+        workspaceDir,
+        artifactStore,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+      const backend = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const recordUsageCheckpoint = (
+        backend as unknown as {
+          input: Pick<AiSdkBackendInput, 'recordUsageCheckpoint'>;
+        }
+      ).input.recordUsageCheckpoint;
+      assert.ok(recordUsageCheckpoint);
+      await recordUsageCheckpoint({
+        inputTokens: 140,
+        outputTokens: 20,
+        cacheHitInputTokens: 40,
+        cachedInputTokens: 40,
+        cacheMissInputTokens: 100,
+        cacheMissInputSource: 'explicit',
+        cacheWriteInputTokens: 0,
+        reasoningTokens: 5,
+        totalTokens: 160,
+        costUsd: 0.012,
+      });
+
+      const invocation: InvocationResult = {
+        invocationId: 'invocation-1',
+        sessionId: 'session-1',
+        runId: 'run-1',
+        turnId: 'turn-1',
+        status: 'completed',
+        events: [
+          {
+            id: 'parent-usage',
+            sessionId: 'session-1',
+            invocationId: 'invocation-1',
+            runId: 'run-1',
+            turnId: 'turn-1',
+            ts: 100,
+            partial: false,
+            role: 'model',
+            author: 'agent',
+            actions: {
+              tokenUsage: {
+                input: 100,
+                output: 10,
+                cacheHitInput: 30,
+                cacheMissInput: 70,
+                cacheMissInputSource: 'explicit',
+                cacheWriteInput: 0,
+                reasoning: 2,
+                total: 110,
+                runtimeSteps: 1,
+                costUsd: 0.006,
+              },
+            },
+          },
+        ],
+        startedAt: 100,
+        finishedAt: 200,
+      };
+      const artifacts = await writeHarborCellArtifacts({
+        invocation,
+        outputDir,
+        executionIdentity,
+      });
+
+      assert.deepEqual(artifacts.output.tokenSummary, {
+        input: 140,
+        output: 20,
+        cachedInput: 40,
+        cacheHitInput: 40,
+        cacheMissInput: 100,
+        cacheWriteInput: 0,
+        cacheMissInputSource: 'explicit',
+        reasoning: 5,
+        total: 160,
+        costUsd: 0.012,
+        pricingSource: 'runtime',
+      });
+      await assert.rejects(
+        readFile(join(detachedCellArtifactDir, HARBOR_CELL_USAGE_CHECKPOINT_FILENAME), 'utf8'),
+        (error: NodeJS.ErrnoException) => error.code === 'ENOENT',
       );
     });
   });

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1326,6 +1326,100 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
+  test('hydrates missing deadline usage from the trial checkpoint', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const usageCheckpoint = tokenSummary({
+        input: 12_000,
+        output: 800,
+        reasoning: 400,
+        total: 12_800,
+        costUsd: 0.01,
+      });
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          reward: '0\n',
+          cell: cellOutput({
+            status: 'failed',
+            errorClass: 'aborted',
+            deadlineSettlement: { source: 'benchmark.deadline', mode: 'immediate' },
+            tokenSummary: undefined,
+          }),
+          usageCheckpoint,
+        }),
+      });
+
+      const output = await runner(runInput());
+      assert.deepEqual(output.cell.tokenSummary, usageCheckpoint);
+    });
+  });
+
+  test('replaces a parent-only summary with a child-inclusive checkpoint', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const parentOnly = tokenSummary({
+        input: 100,
+        output: 10,
+        reasoning: 2,
+        total: 110,
+        costUsd: 0.004,
+      });
+      const childInclusive = tokenSummary({
+        input: 160,
+        output: 25,
+        reasoning: 7,
+        total: 185,
+        costUsd: 0.011,
+      });
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          reward: '1\n',
+          cell: cellOutput({ tokenSummary: parentOnly }),
+          usageCheckpoint: childInclusive,
+        }),
+      });
+
+      const output = await runner(runInput());
+      assert.deepEqual(output.cell.tokenSummary, childInclusive);
+    });
+  });
+
+  test('retains the final summary when a higher-total checkpoint is not cumulative', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const finalSummary = tokenSummary({
+        input: 100,
+        output: 20,
+        reasoning: 4,
+        total: 120,
+        costUsd: 0.008,
+      });
+      const conflictingCheckpoint = tokenSummary({
+        input: 90,
+        output: 40,
+        reasoning: 8,
+        total: 130,
+        costUsd: 0.01,
+      });
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          reward: '1\n',
+          cell: cellOutput({ tokenSummary: finalSummary }),
+          usageCheckpoint: conflictingCheckpoint,
+        }),
+      });
+
+      const output = await runner(runInput());
+      assert.deepEqual(output.cell.tokenSummary, finalSummary);
+    });
+  });
+
   test('treats a non-zero Harbor exit with an incomplete agent-timeout trial as budget exhausted', async () => {
     await withRun(async ({ jobsDir, repo }) => {
       const executionIdentity = {
@@ -1439,6 +1533,86 @@ describe('createHarborTaskRunner', () => {
           executionIdentity,
         );
         assert.deepEqual(error.artifactRefs?.tokenSummary, usageCheckpoint);
+        return true;
+      });
+    });
+  });
+
+  test('recovers checkpoint usage when a timed-out deadline cell has no summary', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const usageCheckpoint = tokenSummary({
+        input: 120,
+        output: 15,
+        reasoning: 3,
+        total: 135,
+        costUsd: 0.009,
+      });
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          cell: cellOutput({
+            status: 'failed',
+            errorClass: 'aborted',
+            deadlineSettlement: { source: 'benchmark.deadline', mode: 'immediate' },
+            tokenSummary: undefined,
+          }),
+          usageCheckpoint,
+          trialResult: {
+            exception_info: {
+              exception_type: 'AgentTimeoutError',
+              exception_message: 'Agent execution timed out after 60.0 seconds',
+            },
+          },
+        }),
+      });
+
+      await assert.rejects(runner(runInput()), (error: unknown) => {
+        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+        assert.deepEqual(error.artifactRefs?.tokenSummary, usageCheckpoint);
+        assert.deepEqual(error.artifactRefs?.cellOutput?.tokenSummary, usageCheckpoint);
+        return true;
+      });
+    });
+  });
+
+  test('recovers child-inclusive usage when a timed-out cell has a parent summary', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const parentOnly = tokenSummary({
+        input: 100,
+        output: 10,
+        reasoning: 2,
+        total: 110,
+        costUsd: 0.006,
+      });
+      const childInclusive = tokenSummary({
+        input: 140,
+        output: 20,
+        reasoning: 5,
+        total: 160,
+        costUsd: 0.012,
+      });
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          cell: cellOutput({ tokenSummary: parentOnly }),
+          usageCheckpoint: childInclusive,
+          trialResult: {
+            exception_info: {
+              exception_type: 'AgentTimeoutError',
+              exception_message: 'Agent execution timed out after 60.0 seconds',
+            },
+          },
+        }),
+      });
+
+      await assert.rejects(runner(runInput()), (error: unknown) => {
+        assert.ok(error instanceof FixedPromptBudgetExhaustedError);
+        assert.deepEqual(error.artifactRefs?.tokenSummary, childInclusive);
+        assert.deepEqual(error.artifactRefs?.cellOutput?.tokenSummary, childInclusive);
         return true;
       });
     });

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -19,6 +19,75 @@ export interface HarborCellTokenSummary {
   pricingSource: 'runtime';
 }
 
+/** Prefer a child-inclusive cumulative checkpoint only when it safely extends
+ * every counter in an existing final summary; a larger total alone is insufficient. */
+export function selectHarborCellTokenSummary(
+  current: HarborCellTokenSummary | undefined,
+  checkpoint: HarborCellTokenSummary | null,
+): HarborCellTokenSummary | undefined {
+  if (!checkpoint) return current;
+  if (!current) return checkpoint;
+  if (
+    !isConsistentCumulativeTokenSummary(current) ||
+    !isConsistentCumulativeTokenSummary(checkpoint)
+  ) {
+    return current;
+  }
+  if (
+    current.cacheMissInputSource === 'explicit' &&
+    checkpoint.cacheMissInputSource !== 'explicit'
+  ) {
+    return current;
+  }
+  const currentCounts = [
+    current.input,
+    current.output,
+    current.cachedInput,
+    current.cacheHitInput,
+    current.cacheMissInput,
+    current.cacheWriteInput,
+    current.reasoning,
+    current.total,
+    current.costUsd,
+  ];
+  const checkpointCounts = [
+    checkpoint.input,
+    checkpoint.output,
+    checkpoint.cachedInput,
+    checkpoint.cacheHitInput,
+    checkpoint.cacheMissInput,
+    checkpoint.cacheWriteInput,
+    checkpoint.reasoning,
+    checkpoint.total,
+    checkpoint.costUsd,
+  ];
+  return checkpointCounts.every((value, index) => value >= currentCounts[index]!) &&
+    checkpointCounts.some((value, index) => value > currentCounts[index]!)
+    ? checkpoint
+    : current;
+}
+
+function isConsistentCumulativeTokenSummary(summary: HarborCellTokenSummary): boolean {
+  const counts = [
+    summary.input,
+    summary.output,
+    summary.cachedInput,
+    summary.cacheHitInput,
+    summary.cacheMissInput,
+    summary.cacheWriteInput,
+    summary.reasoning,
+    summary.total,
+    summary.costUsd,
+  ];
+  return (
+    counts.every((value) => Number.isFinite(value) && value >= 0) &&
+    summary.cachedInput === summary.cacheHitInput &&
+    summary.input === summary.cacheHitInput + summary.cacheMissInput + summary.cacheWriteInput &&
+    summary.total === summary.input + summary.output &&
+    summary.reasoning <= summary.output
+  );
+}
+
 export interface HarborCellContextBudgetSummary {
   diagnosticEvents: number;
   enabledEvents: number;

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1034,7 +1034,8 @@ function classifyPlumbingFailure(
   }
   if (
     requireFinalUsage &&
-    output.cell.status === 'completed' &&
+    (output.cell.status === 'completed' ||
+      output.cell.deadlineSettlement?.source === 'benchmark.deadline') &&
     output.cell.tokenSummary === undefined
   ) {
     return {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -38,7 +38,9 @@ import {
   buildHarborCellOutput,
   combineInvocations,
   countRuntimeSteps,
+  selectHarborCellTokenSummary,
   validateHarborCellOutput,
+  validateHarborCellTokenSummary,
   type HarborCellContextBudgetPolicySnapshot,
   type HarborCellDeadlineSettlement,
   type HarborCellExecutionIdentity,
@@ -492,6 +494,7 @@ export async function writeHarborCellExecutionIdentity(
   executionIdentity: HarborCellExecutionIdentity,
 ): Promise<void> {
   await mkdir(outputDir, { recursive: true });
+  await rm(join(outputDir, HARBOR_CELL_USAGE_CHECKPOINT_FILENAME), { force: true });
   await writeHarborCellArtifact(
     join(outputDir, HARBOR_CELL_EXECUTION_IDENTITY_FILENAME),
     `${JSON.stringify(executionIdentity, null, 2)}\n`,
@@ -505,7 +508,7 @@ export async function writeHarborCellArtifacts(
   const runtimeEventsPath = join(input.outputDir, HARBOR_CELL_RUNTIME_EVENTS_FILENAME);
   const outputPath = join(input.outputDir, HARBOR_CELL_OUTPUT_FILENAME);
   await writeHarborCellArtifact(runtimeEventsPath, runtimeEventsJsonl(input.invocation));
-  const output = validateHarborCellOutput(
+  const rawOutput = validateHarborCellOutput(
     buildHarborCellOutput({
       invocation: input.invocation,
       runtimeEventsPath,
@@ -519,8 +522,26 @@ export async function writeHarborCellArtifacts(
         : {}),
     }),
   );
+  const usageCheckpoint = await readHarborCellUsageCheckpoint(input.outputDir);
+  const tokenSummary = selectHarborCellTokenSummary(rawOutput.tokenSummary, usageCheckpoint);
+  const output =
+    tokenSummary && tokenSummary !== rawOutput.tokenSummary
+      ? { ...rawOutput, tokenSummary }
+      : rawOutput;
   await writeHarborCellArtifact(outputPath, `${JSON.stringify(output, null, 2)}\n`);
   return { output, outputPath, runtimeEventsPath };
+}
+
+async function readHarborCellUsageCheckpoint(
+  outputDir: string,
+): Promise<NonNullable<HarborCellOutput['tokenSummary']> | null> {
+  try {
+    return validateHarborCellTokenSummary(
+      JSON.parse(await readFile(join(outputDir, HARBOR_CELL_USAGE_CHECKPOINT_FILENAME), 'utf8')),
+    );
+  } catch {
+    return null;
+  }
 }
 
 export async function writeHarborTaskRunTrace(input: {
@@ -863,6 +884,8 @@ export function buildAiSdkCellBackendRegistration(input: {
   const taskLedgerExperimentStore = taskLedgerExperimentPolicy
     ? createInMemoryTaskLedgerExperimentStore({ now: input.now, newId: input.newId })
     : undefined;
+  const backendUsageCheckpoints = new Map<symbol, HarborCellUsageCheckpoint>();
+  let usageCheckpointQueue = Promise.resolve();
   return (registry, context) => {
     if (!context.toolExecutor) {
       throw new Error('Harbor ai-sdk backend requires an isolated tool executor');
@@ -874,6 +897,7 @@ export function buildAiSdkCellBackendRegistration(input: {
       synthesisCacheEnabled,
     );
     registry.register('ai-sdk', (ctx) => {
+      const backendUsageKey = Symbol('harbor-cell-backend-usage');
       const subscriptionFetch = buildSubscriptionModelFetch({
         connection,
         sessionId: ctx.sessionId,
@@ -991,7 +1015,18 @@ export function buildAiSdkCellBackendRegistration(input: {
         recordActiveFullCompactBlock: ctx.recordActiveFullCompactBlock,
         recordSemanticCompactBlock: ctx.recordSemanticCompactBlock,
         ...(input.recordUsageCheckpoint
-          ? { recordUsageCheckpoint: input.recordUsageCheckpoint }
+          ? {
+              recordUsageCheckpoint: (usage: HarborCellUsageCheckpoint) => {
+                const update = usageCheckpointQueue.then(async () => {
+                  backendUsageCheckpoints.set(backendUsageKey, usage);
+                  await input.recordUsageCheckpoint!(
+                    aggregateHarborCellUsageCheckpoints(backendUsageCheckpoints.values()),
+                  );
+                });
+                usageCheckpointQueue = update.catch(() => {});
+                return update;
+              },
+            }
           : {}),
       });
     });
@@ -999,6 +1034,37 @@ export function buildAiSdkCellBackendRegistration(input: {
 }
 
 export const buildHarborAiSdkBackendRegistration = buildAiSdkCellBackendRegistration;
+
+function aggregateHarborCellUsageCheckpoints(
+  checkpoints: Iterable<HarborCellUsageCheckpoint>,
+): HarborCellUsageCheckpoint {
+  let aggregate: HarborCellUsageCheckpoint | undefined;
+  for (const checkpoint of checkpoints) {
+    if (!aggregate) {
+      aggregate = { ...checkpoint };
+      continue;
+    }
+    aggregate = {
+      inputTokens: aggregate.inputTokens + checkpoint.inputTokens,
+      outputTokens: aggregate.outputTokens + checkpoint.outputTokens,
+      cacheHitInputTokens: aggregate.cacheHitInputTokens + checkpoint.cacheHitInputTokens,
+      cacheMissInputTokens: aggregate.cacheMissInputTokens + checkpoint.cacheMissInputTokens,
+      cacheMissInputSource:
+        aggregate.cacheMissInputSource === 'explicit' ||
+        checkpoint.cacheMissInputSource === 'explicit'
+          ? 'explicit'
+          : 'derived',
+      cacheWriteInputTokens: aggregate.cacheWriteInputTokens + checkpoint.cacheWriteInputTokens,
+      reasoningTokens: aggregate.reasoningTokens + checkpoint.reasoningTokens,
+      totalTokens: aggregate.totalTokens + checkpoint.totalTokens,
+      ...(aggregate.costUsd !== undefined && checkpoint.costUsd !== undefined
+        ? { costUsd: aggregate.costUsd + checkpoint.costUsd }
+        : {}),
+    };
+  }
+  if (!aggregate) throw new Error('cannot aggregate an empty Harbor usage checkpoint set');
+  return aggregate;
+}
 
 export async function writeHarborCellUsageCheckpoint(
   outputDir: string,

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -24,6 +24,7 @@ import {
   runHarborCellWithStorage,
   writeHarborCellArtifacts,
   writeHarborCellExecutionIdentity,
+  writeHarborCellUsageCheckpoint,
   writeHarborTaskRunTrace,
   type RunHarborCellEnv,
   type RunHarborCellInput,
@@ -422,7 +423,14 @@ export async function resolveHarborRunOptions(
     heavyTask: parsed.bools['heavy-task'] || truthyEnv(env.MAKA_HEAVY_TASK_MODE),
     economyTask: parsed.bools['economy-task'] || truthyEnv(env.MAKA_ECONOMY_TASK_MODE),
   });
-  const registerBackends = buildBackendRegistration({ backend, env, now, newId, maxSteps });
+  const registerBackends = buildBackendRegistration({
+    backend,
+    env,
+    now,
+    newId,
+    cellArtifactDir,
+    maxSteps,
+  });
   const realBackendIsolation = buildIsolation(isolation, env, workdir);
   return {
     mode,
@@ -581,6 +589,7 @@ function buildBackendRegistration(input: {
   env: RunHarborCellEnv;
   now: () => number;
   newId: () => string;
+  cellArtifactDir: string;
   maxSteps?: number;
 }): RunHarborCellInput['registerBackends'] | undefined {
   if (input.backend === 'fake') return undefined;
@@ -595,6 +604,7 @@ function buildBackendRegistration(input: {
     env: input.env,
     now: input.now,
     newId: input.newId,
+    recordUsageCheckpoint: (usage) => writeHarborCellUsageCheckpoint(input.cellArtifactDir, usage),
     ...(input.maxSteps !== undefined ? { maxSteps: input.maxSteps } : {}),
   });
 }

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -382,7 +382,7 @@ export async function resolveHarborRunOptions(
   preflightIsolation(backend, isolation, env);
 
   const outDir = resolve(valueOf(parsed, env, 'out', 'MAKA_OUTPUT_DIR') ?? '/logs/agent');
-  const cellArtifactDir = resolve(env.MAKA_CELL_ARTIFACT_DIR ?? outDir);
+  const cellArtifactDir = mode === 'cell' ? outDir : resolve(env.MAKA_CELL_ARTIFACT_DIR ?? outDir);
   const storageRoot = resolve(
     valueOf(parsed, env, 'storage-root', 'MAKA_STORAGE_ROOT') ??
       (mode === 'task-run' ? join(outDir, 'runs') : join(outDir, 'maka-storage')),

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -12,6 +12,7 @@ import {
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import { fetchGitHubCopilotModels, isSupportedGitHubCopilotAccountToken } from '@maka/runtime';
 import {
+  selectHarborCellTokenSummary,
   validateHarborCellExecutionIdentity,
   validateHarborCellOutput,
   validateHarborCellTokenSummary,
@@ -375,11 +376,19 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
       }
       const reward = await readReward(rewardPath, resultPath, input.task.id);
       const rawCell = await readCellOutput(cellOutputPath, input.task.id);
+      const usageCheckpoint = await readOptionalTokenSummary(
+        join(trialDir, TRIAL_USAGE_CHECKPOINT),
+      );
+      const selectedUsage = selectHarborCellTokenSummary(rawCell.tokenSummary, usageCheckpoint);
+      const checkpointedCell =
+        selectedUsage && selectedUsage !== rawCell.tokenSummary
+          ? { ...rawCell, tokenSummary: selectedUsage }
+          : rawCell;
       const cell =
-        rawCell.tokenSummary || !providerUsage || !runnerOptions.pricing
-          ? rawCell
+        checkpointedCell.tokenSummary || !providerUsage || !runnerOptions.pricing
+          ? checkpointedCell
           : {
-              ...rawCell,
+              ...checkpointedCell,
               tokenSummary: providerTokenSummary(providerUsage, runnerOptions.pricing),
             };
       const verifierStdout = await readOptionalText(join(trialDir, TRIAL_VERIFIER_STDOUT));
@@ -671,8 +680,21 @@ export async function readTimedOutTrialArtifacts(
   mode: 'cell' | 'task-run',
 ) {
   const cell = await readOptionalCellOutput(join(trialDir, TRIAL_CELL_OUTPUT), taskId);
-  if (cell)
-    return cellArtifactRefs(cell, join(trialDir, TRIAL_RUNTIME_EVENTS), trialDir, agent, mode);
+  if (cell) {
+    const usageCheckpoint = await readOptionalTokenSummary(join(trialDir, TRIAL_USAGE_CHECKPOINT));
+    const selectedUsage = selectHarborCellTokenSummary(cell.tokenSummary, usageCheckpoint);
+    const recoveredCell =
+      selectedUsage && selectedUsage !== cell.tokenSummary
+        ? { ...cell, tokenSummary: selectedUsage }
+        : cell;
+    return cellArtifactRefs(
+      recoveredCell,
+      join(trialDir, TRIAL_RUNTIME_EVENTS),
+      trialDir,
+      agent,
+      mode,
+    );
+  }
   const [executionIdentity, tokenSummary] = await Promise.all([
     readOptionalExecutionIdentity(join(trialDir, TRIAL_EXECUTION_IDENTITY)),
     readOptionalTokenSummary(join(trialDir, TRIAL_USAGE_CHECKPOINT)),


### PR DESCRIPTION
## Summary

- make each resolved Harbor backend registration the single run-lifetime usage authority by replacing per-backend cumulative snapshots, aggregating parent/child and repeated-attempt backends, and serializing persistence without poisoning the queue after a failed write
- reset the exact usage checkpoint when a new execution identity claims an output directory, preventing a reused Harbor `--out` directory from leaking stale usage into a new run while preserving checkpoints across autonomous attempts
- wire task-run CLI checkpoints through the existing atomic writer and apply the child-inclusive checkpoint to canonical `maka-cell-output.json` before Python, Pier, or collectors consume it
- centralize safe checkpoint preference in the cell-output contract, while retaining Harbor/Pier recovery fallbacks for old or incomplete artifacts and requiring usage for deadline-settled fixed-prompt results

## Verification

- rebased onto `d6ced3be9` (`feat(runtime): migrate agent tools to child sessions`) and audited the durable child-session backend path against the run-lifetime usage authority
- affected cell-output, Harbor cell, Harbor runner, Pier runner, and fixed-prompt suites (334 passed)
- `npm --workspace @maka/headless test` (1296 passed)
- `npm run format:check`
- `npm run lint`
- `npm run build`
- `npm run typecheck`