### PR TITLE
fix(runtime): retry transient Codex edge rejections

### DIFF
--- a/packages/runtime/src/__tests__/subscription-model-fetch.test.ts
+++ b/packages/runtime/src/__tests__/subscription-model-fetch.test.ts
@@ -124,6 +124,342 @@ describe('subscription model fetch', () => {
     assert.equal(body.text.verbosity, 'medium');
   });
 
+  test('retries a transient HTML 403 from the Codex edge', async () => {
+    let attempts = 0;
+    const modelFetch = buildSubscriptionModelFetch({
+      connection: openAiCodexConnection(),
+      sessionId: 'session-123',
+      modelId: 'gpt-5.6-sol',
+      fetchFn: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          return new Response('<!doctype html><title>Request rejected</title>', {
+            status: 403,
+            headers: { 'retry-after': '0' },
+          });
+        }
+        return Response.json({ ok: true });
+      },
+    });
+
+    assert.ok(modelFetch);
+    const response = await modelFetch('https://chatgpt.com/backend-api/codex/responses', {
+      method: 'POST',
+      body: JSON.stringify({ input: [{ role: 'user', content: 'hello' }] }),
+    });
+
+    assert.equal(response.ok, true);
+    assert.equal(attempts, 2);
+  });
+
+  test('does not retry a JSON 403 from the Codex API', async () => {
+    let attempts = 0;
+    const modelFetch = buildSubscriptionModelFetch({
+      connection: openAiCodexConnection(),
+      sessionId: 'session-123',
+      modelId: 'gpt-5.6-sol',
+      fetchFn: async () => {
+        attempts += 1;
+        return Response.json({ error: { message: 'account is not authorized' } }, { status: 403 });
+      },
+    });
+
+    assert.ok(modelFetch);
+    await assert.rejects(
+      modelFetch('https://chatgpt.com/backend-api/codex/responses', {
+        method: 'POST',
+        body: JSON.stringify({ input: [{ role: 'user', content: 'hello' }] }),
+      }),
+      /Codex OAuth request failed: HTTP 403/,
+    );
+    assert.equal(attempts, 1);
+  });
+
+  test('does not retry an HTML 403 when the body belongs to a Request object', async () => {
+    let attempts = 0;
+    const modelFetch = buildSubscriptionModelFetch({
+      connection: openAiCodexConnection(),
+      sessionId: 'session-123',
+      modelId: 'gpt-5.6-sol',
+      fetchFn: async (request) => {
+        attempts += 1;
+        if (request instanceof Request) await request.text();
+        return new Response('<html><title>Request rejected</title>', {
+          status: 403,
+          headers: { 'content-type': 'text/html', 'retry-after': '0' },
+        });
+      },
+    });
+
+    assert.ok(modelFetch);
+    const request = new Request('https://chatgpt.com/backend-api/codex/responses', {
+      method: 'POST',
+      body: JSON.stringify({ input: [{ role: 'user', content: 'hello' }] }),
+    });
+    await assert.rejects(modelFetch(request), /Codex OAuth request failed: HTTP 403/);
+    assert.equal(request.bodyUsed, true);
+    assert.equal(attempts, 1);
+  });
+
+  test('does not treat a null body override as clearing a Request body', async () => {
+    let attempts = 0;
+    const modelFetch = buildSubscriptionModelFetch({
+      connection: openAiCodexConnection(),
+      sessionId: 'session-123',
+      modelId: 'gpt-5.6-sol',
+      fetchFn: async (request) => {
+        attempts += 1;
+        if (request instanceof Request) await request.text();
+        return new Response('<html><title>Request rejected</title>', {
+          status: 403,
+          headers: { 'content-type': 'text/html', 'retry-after': '0' },
+        });
+      },
+    });
+
+    assert.ok(modelFetch);
+    const request = new Request('https://chatgpt.com/backend-api/codex/responses', {
+      method: 'POST',
+      body: JSON.stringify({ input: [{ role: 'user', content: 'hello' }] }),
+    });
+    await assert.rejects(
+      modelFetch(request, { body: null }),
+      /Codex OAuth request failed: HTTP 403/,
+    );
+    assert.equal(attempts, 1);
+  });
+
+  test('does not retry an HTML 403 with a non-string request body', async () => {
+    let attempts = 0;
+    const modelFetch = buildSubscriptionModelFetch({
+      connection: openAiCodexConnection(),
+      sessionId: 'session-123',
+      modelId: 'gpt-5.6-sol',
+      fetchFn: async () => {
+        attempts += 1;
+        return new Response('<html><title>Request rejected</title>', {
+          status: 403,
+          headers: { 'content-type': 'text/html', 'retry-after': '0' },
+        });
+      },
+    });
+
+    assert.ok(modelFetch);
+    await assert.rejects(
+      modelFetch('https://chatgpt.com/backend-api/codex/responses', {
+        method: 'POST',
+        body: new Uint8Array([123, 125]),
+      }),
+      /Codex OAuth request failed: HTTP 403/,
+    );
+    assert.equal(attempts, 1);
+  });
+
+  test('aborts while waiting to retry an HTML 403', async () => {
+    let attempts = 0;
+    const controller = new AbortController();
+    const modelFetch = buildSubscriptionModelFetch({
+      connection: openAiCodexConnection(),
+      sessionId: 'session-123',
+      modelId: 'gpt-5.6-sol',
+      fetchFn: async () => {
+        attempts += 1;
+        controller.abort();
+        return new Response('<html><title>Request rejected</title>', {
+          status: 403,
+          headers: { 'content-type': 'text/html' },
+        });
+      },
+    });
+
+    assert.ok(modelFetch);
+    await assert.rejects(
+      modelFetch('https://chatgpt.com/backend-api/codex/responses', {
+        method: 'POST',
+        body: JSON.stringify({ input: [{ role: 'user', content: 'hello' }] }),
+        signal: controller.signal,
+      }),
+      /abort/i,
+    );
+    assert.equal(attempts, 1);
+  });
+
+  test('aborts a retry delay through a Request signal', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    let attempts = 0;
+    const controller = new AbortController();
+    const modelFetch = buildSubscriptionModelFetch({
+      connection: openAiCodexConnection(),
+      sessionId: 'session-123',
+      modelId: 'gpt-5.6-sol',
+      fetchFn: async () => {
+        attempts += 1;
+        return new Response('<html><title>Request rejected</title>', {
+          status: 403,
+          headers: { 'content-type': 'text/html' },
+        });
+      },
+    });
+
+    assert.ok(modelFetch);
+    const request = new Request('https://chatgpt.com/backend-api/codex/responses', {
+      signal: controller.signal,
+    });
+    const outcome = modelFetch(request).then(
+      () => 'resolved',
+      (error: unknown) => String(error),
+    );
+    await eventLoopTurn();
+    controller.abort();
+
+    const result = await Promise.race([outcome, eventLoopTurn().then(() => 'pending')]);
+    assert.match(result, /abort/i);
+    assert.equal(attempts, 1);
+  });
+
+  test('prefers an init signal over a Request signal', async () => {
+    let attempts = 0;
+    const requestController = new AbortController();
+    const initController = new AbortController();
+    const modelFetch = buildSubscriptionModelFetch({
+      connection: openAiCodexConnection(),
+      sessionId: 'session-123',
+      modelId: 'gpt-5.6-sol',
+      fetchFn: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          requestController.abort();
+          return new Response('<html><title>Request rejected</title>', {
+            status: 403,
+            headers: { 'content-type': 'text/html', 'retry-after': '0' },
+          });
+        }
+        return Response.json({ ok: true });
+      },
+    });
+
+    assert.ok(modelFetch);
+    const request = new Request('https://chatgpt.com/backend-api/codex/responses', {
+      signal: requestController.signal,
+    });
+    const response = await modelFetch(request, { signal: initController.signal });
+
+    assert.equal(response.ok, true);
+    assert.equal(attempts, 2);
+  });
+
+  test('does not inherit a Request signal when init explicitly sets signal to null', async () => {
+    let attempts = 0;
+    const controller = new AbortController();
+    controller.abort();
+    const modelFetch = buildSubscriptionModelFetch({
+      connection: openAiCodexConnection(),
+      sessionId: 'session-123',
+      modelId: 'gpt-5.6-sol',
+      fetchFn: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          return new Response('<html><title>Request rejected</title>', {
+            status: 403,
+            headers: { 'content-type': 'text/html', 'retry-after': '0' },
+          });
+        }
+        return Response.json({ ok: true });
+      },
+    });
+
+    assert.ok(modelFetch);
+    const request = new Request('https://chatgpt.com/backend-api/codex/responses', {
+      signal: controller.signal,
+    });
+    const response = await modelFetch(request, { signal: null });
+
+    assert.equal(response.ok, true);
+    assert.equal(attempts, 2);
+  });
+
+  test('caps HTML 403 retries after fallback delays of 2, 10, and 30 seconds', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    let attempts = 0;
+    const modelFetch = buildSubscriptionModelFetch({
+      connection: openAiCodexConnection(),
+      sessionId: 'session-123',
+      modelId: 'gpt-5.6-sol',
+      fetchFn: async () => {
+        attempts += 1;
+        return new Response('<html><title>Request rejected</title>', {
+          status: 403,
+          headers: { 'content-type': 'text/html' },
+        });
+      },
+    });
+
+    assert.ok(modelFetch);
+    const rejection = assert.rejects(
+      modelFetch('https://chatgpt.com/backend-api/codex/responses', {
+        method: 'POST',
+        body: JSON.stringify({ input: [{ role: 'user', content: 'hello' }] }),
+      }),
+      /Codex OAuth request failed: HTTP 403/,
+    );
+
+    await eventLoopTurn();
+    assert.equal(attempts, 1);
+    t.mock.timers.tick(1_999);
+    await eventLoopTurn();
+    assert.equal(attempts, 1);
+    t.mock.timers.tick(1);
+    await eventLoopTurn();
+    assert.equal(attempts, 2);
+    t.mock.timers.tick(9_999);
+    await eventLoopTurn();
+    assert.equal(attempts, 2);
+    t.mock.timers.tick(1);
+    await eventLoopTurn();
+    assert.equal(attempts, 3);
+    t.mock.timers.tick(29_999);
+    await eventLoopTurn();
+    assert.equal(attempts, 3);
+    t.mock.timers.tick(1);
+    await rejection;
+    assert.equal(attempts, 4);
+  });
+
+  test('caps a numeric Retry-After delay at 30 seconds', async (t) => {
+    t.mock.timers.enable({ apis: ['setTimeout'] });
+    let attempts = 0;
+    const modelFetch = buildSubscriptionModelFetch({
+      connection: openAiCodexConnection(),
+      sessionId: 'session-123',
+      modelId: 'gpt-5.6-sol',
+      fetchFn: async () => {
+        attempts += 1;
+        if (attempts === 1) {
+          return new Response('<html><title>Request rejected</title>', {
+            status: 403,
+            headers: { 'content-type': 'text/html', 'retry-after': '60' },
+          });
+        }
+        return Response.json({ ok: true });
+      },
+    });
+
+    assert.ok(modelFetch);
+    const response = modelFetch('https://chatgpt.com/backend-api/codex/responses', {
+      method: 'POST',
+      body: JSON.stringify({ input: [{ role: 'user', content: 'hello' }] }),
+    });
+
+    await eventLoopTurn();
+    t.mock.timers.tick(29_999);
+    await eventLoopTurn();
+    assert.equal(attempts, 1);
+    t.mock.timers.tick(1);
+    await eventLoopTurn();
+    assert.equal(attempts, 2);
+    assert.equal((await response).ok, true);
+  });
+
   test('adds the Copilot compatibility headers and derives the turn initiator without rewriting the body', async () => {
     const observed: Array<{ headers: Headers; body: string }> = [];
     const modelFetch = buildSubscriptionModelFetch({
@@ -177,6 +513,10 @@ describe('subscription model fetch', () => {
     assert.equal(observed[2]?.body, responsesBody);
   });
 });
+
+function eventLoopTurn(): Promise<void> {
+  return new Promise((resolve) => setImmediate(resolve));
+}
 
 function claudeSubscriptionConnection(): LlmConnection {
   return {

--- a/packages/runtime/src/subscription-model-fetch.ts
+++ b/packages/runtime/src/subscription-model-fetch.ts
@@ -161,15 +161,73 @@ async function checkedOpenAiCodexFetch(
   url: Parameters<typeof fetch>[0],
   init?: Parameters<typeof fetch>[1],
 ): Promise<Response> {
-  const response = await fetchFn(url, init);
-  if (!response.ok) {
+  const edgeRetryDelaysMs = [2_000, 10_000, 30_000] as const;
+  for (let retry = 0; ; retry += 1) {
+    const response = await fetchFn(url, init);
+    if (response.ok) return response;
     const detail = await response
       .clone()
       .text()
       .catch(() => '');
+    if (
+      edgeRetryDelaysMs[retry] !== undefined &&
+      isReplayableOpenAiCodexRequest(url, init) &&
+      isTransientOpenAiCodexEdgeRejection(response, detail)
+    ) {
+      await abortableDelay(
+        openAiCodexRetryAfterMs(response, edgeRetryDelaysMs[retry] ?? 30_000),
+        effectiveOpenAiCodexRequestSignal(url, init),
+      );
+      continue;
+    }
     throw new Error(formatOpenAiCodexHttpError(response.status, detail));
   }
-  return response;
+}
+
+function isReplayableOpenAiCodexRequest(
+  url: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+): boolean {
+  if (typeof init?.body === 'string') return true;
+  if (init?.body != null) return false;
+  return !(url instanceof Request) || url.body === null;
+}
+
+function effectiveOpenAiCodexRequestSignal(
+  url: Parameters<typeof fetch>[0],
+  init?: Parameters<typeof fetch>[1],
+): AbortSignal | null | undefined {
+  if (init?.signal !== undefined) return init.signal;
+  return url instanceof Request ? url.signal : undefined;
+}
+
+function isTransientOpenAiCodexEdgeRejection(response: Response, detail: string): boolean {
+  if (response.status !== 403) return false;
+  const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+  return contentType.includes('text/html') || /^\s*(?:<!doctype html|<html\b)/i.test(detail);
+}
+
+function openAiCodexRetryAfterMs(response: Response, fallbackMs: number): number {
+  const rawRetryAfter = response.headers.get('retry-after');
+  if (rawRetryAfter === null || rawRetryAfter.trim() === '') return fallbackMs;
+  const retryAfterSeconds = Number(rawRetryAfter);
+  if (!Number.isFinite(retryAfterSeconds) || retryAfterSeconds < 0) return fallbackMs;
+  return Math.min(retryAfterSeconds * 1_000, 30_000);
+}
+
+function abortableDelay(ms: number, signal?: AbortSignal | null): Promise<void> {
+  signal?.throwIfAborted();
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(signal?.reason);
+    };
+    signal?.addEventListener('abort', onAbort, { once: true });
+  });
 }
 
 function codexInstructionsFromBody(body: Record<string, unknown>): string {


### PR DESCRIPTION
## Summary

- Retry transient Codex HTTP 403 responses only when the response is HTML and the effective request body is replayable.
- Follow Fetch request composition semantics: non-null init bodies override Request bodies, null leaves a Request body inherited, non-null init signals override Request signals, and an explicit null signal detaches from the Request signal.
- Use bounded 2s, 10s, and 30s fallback delays, respect numeric Retry-After values up to 30 seconds, and abort waits through the effective request signal.
- Keep JSON 403 responses, non-string bodies, consumed Request bodies, other statuses, and fetch failures on the existing immediate-error path.

## Verification

- npm --workspace @maka/runtime test (2402 tests passed, 7 skipped)
- npm run lint
- npm run format:check
- npm run typecheck

## Root cause

The Codex edge can return a transient HTML 403 before a request reaches the JSON API. The runtime previously classified every non-success response immediately as an OAuth failure, so these transient edge rejections ended otherwise valid runs. Retry safety also needs the effective Fetch request semantics so inherited Request bodies are never replayed and the effective signal, including an explicit null detachment, controls the backoff.