### PR TITLE
feat(host): expose linked child session lifecycle

### DIFF
--- a/apps/desktop/src/main/__tests__/linked-child-session-observation.test.ts
+++ b/apps/desktop/src/main/__tests__/linked-child-session-observation.test.ts
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { SessionChangedReason, SessionEvent } from '@maka/core';
+import { createLinkedChildEventProjection } from '../session-stream.js';
+
+describe('linked child session observation', () => {
+  test('projects nested child events onto normal renderer and gateway channels', async () => {
+    const rendererEvents: Array<{ channel: string; event: SessionEvent }> = [];
+    const gatewayEvents: Array<{ sessionId: string; event: SessionEvent }> = [];
+    const changes: Array<{ reason: SessionChangedReason; sessionId?: string }> = [];
+    const presentationEvents: SessionEvent[] = [];
+    const projection = createLinkedChildEventProjection({
+      lifecycle: 'created',
+      safeSendToRenderer: (channel, event) => {
+        rendererEvents.push({ channel, event: event as SessionEvent });
+      },
+      openGateway: {
+        publishSessionEvent: (sessionId, event) => gatewayEvents.push({ sessionId, event }),
+      },
+      emitSessionsChanged: (reason, sessionId) => changes.push({ reason, sessionId }),
+      onEvent: (event) => presentationEvents.push(event),
+    });
+    await projection.onReady({
+      childSessionId: 'child-session',
+      turnId: 'child-turn',
+      runId: 'child-run',
+      agentId: 'local-read',
+      agentName: 'Local Read',
+    });
+    const delta: SessionEvent = {
+      type: 'text_delta',
+      id: 'delta',
+      turnId: 'child-turn',
+      ts: 1,
+      messageId: 'message',
+      text: 'observed',
+    };
+    const complete: SessionEvent = {
+      type: 'complete',
+      id: 'complete',
+      turnId: 'child-turn',
+      ts: 2,
+      stopReason: 'end_turn',
+    };
+
+    projection.onEvent(delta);
+    projection.onEvent(complete);
+
+    assert.deepEqual(
+      rendererEvents.map(({ channel, event }) => [channel, event.id]),
+      [
+        ['sessions:event:child-session', 'delta'],
+        ['sessions:event:child-session', 'complete'],
+      ],
+    );
+    assert.deepEqual(
+      gatewayEvents.map(({ sessionId, event }) => [sessionId, event.id]),
+      [
+        ['child-session', 'delta'],
+        ['child-session', 'complete'],
+      ],
+    );
+    assert.deepEqual(presentationEvents.map((event) => event.id), ['delta', 'complete']);
+    assert.deepEqual(changes, [
+      { reason: 'created', sessionId: 'child-session' },
+      { reason: 'turn-status-change', sessionId: 'child-session' },
+      { reason: 'message-appended', sessionId: 'child-session' },
+      { reason: 'status-change', sessionId: 'child-session' },
+      { reason: 'turn-status-change', sessionId: 'child-session' },
+    ]);
+  });
+
+  test('does not project a legacy child run that has no child Session identity', async () => {
+    const rendererEvents: unknown[] = [];
+    const projection = createLinkedChildEventProjection({
+      lifecycle: 'continued',
+      safeSendToRenderer: (...args) => rendererEvents.push(args),
+      openGateway: { publishSessionEvent: () => assert.fail('must not publish') },
+      emitSessionsChanged: () => assert.fail('must not announce a child Session'),
+    });
+
+    await projection.onReady({
+      turnId: 'legacy-turn',
+      agentId: 'local-read',
+      agentName: 'Local Read',
+    });
+    projection.onEvent({
+      type: 'complete',
+      id: 'complete',
+      turnId: 'legacy-turn',
+      ts: 1,
+      stopReason: 'end_turn',
+    });
+
+    assert.deepEqual(rendererEvents, []);
+  });
+});

--- a/apps/desktop/src/main/__tests__/open-gateway.test.ts
+++ b/apps/desktop/src/main/__tests__/open-gateway.test.ts
@@ -581,6 +581,40 @@ describe('OpenGatewayService', () => {
     assert.ok(statusChanges.includes(0), 'closing an SSE stream should publish activeEventStreams=0');
   });
 
+  test('delivers one child-session event sequence to two observing clients', async () => {
+    const service = makeService();
+    activeServices.push(service);
+    const status = await service.sync(
+      createGatewaySettings({ enabled: true, port: 0, token: 'dev-token' }).openGateway,
+    );
+    assert.ok(status.baseUrl);
+
+    const first = await openEventStream(status.baseUrl, 'child-session');
+    const second = await openEventStream(status.baseUrl, 'child-session');
+    const firstReader = first.response.body!.getReader();
+    const secondReader = second.response.body!.getReader();
+    service.publishSessionEvent(
+      'child-session',
+      textDeltaEvent({ id: 'child-event-1', turnId: 'child-turn', text: 'first' }),
+    );
+    service.publishSessionEvent(
+      'child-session',
+      textDeltaEvent({ id: 'child-event-2', turnId: 'child-turn', text: 'second' }),
+    );
+
+    const [firstStream, secondStream] = await Promise.all([
+      readUntil(firstReader, 'id: child-event-2'),
+      readUntil(secondReader, 'id: child-event-2'),
+    ]);
+    for (const stream of [firstStream, secondStream]) {
+      assert.ok(stream.indexOf('id: child-event-1') < stream.indexOf('id: child-event-2'));
+    }
+
+    first.controller.abort();
+    second.controller.abort();
+    await waitFor(() => service.getStatus().activeEventStreams === 0);
+  });
+
   test('rejects excess SSE streams before establishing event-stream headers', async () => {
     const service = makeService();
     activeServices.push(service);

--- a/apps/desktop/src/main/__tests__/session-list-render-helpers.ts
+++ b/apps/desktop/src/main/__tests__/session-list-render-helpers.ts
@@ -26,6 +26,9 @@ export function renderSessionListPanel(options: {
   sessions?: SessionSummary[];
   rowActions?: Parameters<typeof SessionListPanel>[0]['rowActions'];
   statusGroups?: Parameters<typeof SessionListPanel>[0]['statusGroups'];
+  childSessionsByParentId?: Parameters<
+    typeof SessionListPanel
+  >[0]['childSessionsByParentId'];
   viewMode?: Parameters<typeof SessionListPanel>[0]['viewMode'];
 } = {}): string {
   const rowActions = options.rowActions ?? {
@@ -42,6 +45,7 @@ export function renderSessionListPanel(options: {
       selection: { section: 'sessions', filter: 'chats' },
       sessions: options.sessions ?? [makeSessionSummary(options.session)],
       statusGroups: options.statusGroups,
+      childSessionsByParentId: options.childSessionsByParentId,
       viewMode: options.viewMode,
       onViewModeChange: options.viewMode ? () => {} : undefined,
       onSelectSession() {},

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -2,6 +2,8 @@ import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
 import { join, resolve } from 'node:path';
 import { describe, it } from 'node:test';
+import { filterLinkedSessionTree, projectLinkedSessionTree } from '@maka/core';
+import { sessionMatchesNavSelection } from '../../renderer/session-nav-filter.js';
 import { deriveProjectGroups } from '../../renderer/session-project-grouping.js';
 import { makeSessionSummary, renderSessionListPanel } from './session-list-render-helpers.js';
 
@@ -99,17 +101,84 @@ describe('sidebar project view mode', () => {
     assert.match(markup, /lucide-bot/);
   });
 
+  it('applies Chats, Flagged, and Archived filters independently to parents and children', () => {
+    const parent = makeSessionSummary({
+      id: 'parent',
+      name: 'Parent task',
+      lastMessageAt: 10,
+    });
+    const archivedChild = makeSessionSummary({
+      id: 'archived-child',
+      name: 'Archived child',
+      isArchived: true,
+      lastMessageAt: 20,
+      subagentParent: childRelation(parent.id),
+    });
+    const flaggedChild = makeSessionSummary({
+      id: 'flagged-child',
+      name: 'Flagged child',
+      isFlagged: true,
+      lastMessageAt: 30,
+      subagentParent: childRelation(parent.id),
+    });
+    const archivedParent = makeSessionSummary({
+      id: 'archived-parent',
+      name: 'Archived parent',
+      isArchived: true,
+      lastMessageAt: 40,
+    });
+    const activeChild = makeSessionSummary({
+      id: 'active-child',
+      name: 'Active child',
+      lastMessageAt: 50,
+      subagentParent: childRelation(archivedParent.id),
+    });
+    const tree = projectLinkedSessionTree([
+      parent,
+      archivedChild,
+      flaggedChild,
+      archivedParent,
+      activeChild,
+    ]);
+    const filter = (selection: 'chats' | 'flagged' | 'archived') =>
+      filterLinkedSessionTree(tree, (session) =>
+        sessionMatchesNavSelection(session, { section: 'sessions', filter: selection }),
+      );
+
+    const chats = filter('chats');
+    assert.deepEqual(
+      chats.roots.map((session) => session.id),
+      [parent.id, activeChild.id],
+    );
+    assert.deepEqual(
+      chats.childrenByParentId.get(parent.id)?.map((session) => session.id),
+      [flaggedChild.id],
+    );
+
+    const flagged = filter('flagged');
+    assert.deepEqual(
+      flagged.roots.map((session) => session.id),
+      [flaggedChild.id],
+    );
+
+    const archived = filter('archived');
+    assert.deepEqual(
+      archived.roots.map((session) => session.id),
+      [archivedChild.id, archivedParent.id],
+    );
+  });
+
   it('AppShell derives status and project groups from the same visible session set', async () => {
     const appShell = await readRepo('apps/desktop/src/renderer/app-shell.tsx');
     const panel = await readRepo('packages/ui/src/session-list-panel.tsx');
 
     assert.match(
       appShell,
-      /const sidebarSessionTree = useMemo\([\s\S]*projectLinkedSessionTree\(collapseSessionRevisions\(sessions, activeId\)\)[\s\S]*\[sessions, activeId\]/,
+      /const sidebarSessionTree = useMemo\([\s\S]*projectRevisionLinkedSessionTree\(sessions, activeId\)[\s\S]*\[sessions, activeId\]/,
     );
     assert.match(
       appShell,
-      /const visibleSessions = useMemo\([\s\S]*filterSessions\(sidebarSessionTree\.roots, navSelection\)[\s\S]*\[sidebarSessionTree, navSelection\]/,
+      /const visibleSessionTree = useMemo\([\s\S]*filterLinkedSessionTree\(sidebarSessionTree,[\s\S]*sessionMatchesNavSelection\(session, navSelection\)[\s\S]*\[sidebarSessionTree, navSelection\]/,
     );
     assert.match(appShell, /deriveSessionStatusGroups\(visibleSessions, \{ pinFirst: true, locale: uiLocale \}\)/);
     assert.match(appShell, /deriveProjectGroups\(visibleSessions, uiLocale\)/);
@@ -117,7 +186,7 @@ describe('sidebar project view mode', () => {
     assert.match(appShell, /statusGroups=\{sessionListGroups\}/);
     assert.match(
       appShell,
-      /childSessionsByParentId=\{sidebarSessionTree\.childrenByParentId\}/,
+      /childSessionsByParentId=\{visibleSessionTree\.childrenByParentId\}/,
     );
     assert.doesNotMatch(appShell, /projectGroups=\{/);
 
@@ -161,3 +230,16 @@ describe('sidebar project view mode', () => {
     }
   });
 });
+
+function childRelation(parentSessionId: string) {
+  return {
+    kind: 'subagent' as const,
+    parentSessionId,
+    spawnedBy: {
+      parentRunId: 'parent-run',
+      parentTurnId: 'parent-turn',
+      toolCallId: `spawn-${parentSessionId}`,
+    },
+    lifecycle: 'foreground' as const,
+  };
+}

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -85,16 +85,40 @@ describe('sidebar project view mode', () => {
     assert.match(markup, /显示更多/);
   });
 
+  it('renders linked child sessions directly beneath their parent as normal selectable rows', () => {
+    const parent = makeSessionSummary({ id: 'parent', name: 'Parent task' });
+    const child = makeSessionSummary({ id: 'child', name: 'Child agent' });
+    const markup = renderSessionListPanel({
+      sessions: [parent],
+      childSessionsByParentId: new Map([[parent.id, [child]]]),
+    });
+
+    assert.ok(markup.indexOf('Parent task') < markup.indexOf('Child agent'));
+    assert.match(markup, /data-subagent="true"/);
+    assert.match(markup, /data-session-id="child"/);
+    assert.match(markup, /lucide-bot/);
+  });
+
   it('AppShell derives status and project groups from the same visible session set', async () => {
     const appShell = await readRepo('apps/desktop/src/renderer/app-shell.tsx');
     const panel = await readRepo('packages/ui/src/session-list-panel.tsx');
 
-    assert.match(appShell, /const sidebarSessions = useMemo\([\s\S]*collapseSessionRevisions\(sessions, activeId\)[\s\S]*\[sessions, activeId\]/);
-    assert.match(appShell, /const visibleSessions = useMemo\([\s\S]*filterSessions\(sidebarSessions, navSelection\)[\s\S]*\[sidebarSessions, navSelection\]/);
+    assert.match(
+      appShell,
+      /const sidebarSessionTree = useMemo\([\s\S]*projectLinkedSessionTree\(collapseSessionRevisions\(sessions, activeId\)\)[\s\S]*\[sessions, activeId\]/,
+    );
+    assert.match(
+      appShell,
+      /const visibleSessions = useMemo\([\s\S]*filterSessions\(sidebarSessionTree\.roots, navSelection\)[\s\S]*\[sidebarSessionTree, navSelection\]/,
+    );
     assert.match(appShell, /deriveSessionStatusGroups\(visibleSessions, \{ pinFirst: true, locale: uiLocale \}\)/);
     assert.match(appShell, /deriveProjectGroups\(visibleSessions, uiLocale\)/);
     assert.match(appShell, /const sessionListGroups = viewMode === 'project' \? sessionProjectGroups : sessionStatusGroups/);
     assert.match(appShell, /statusGroups=\{sessionListGroups\}/);
+    assert.match(
+      appShell,
+      /childSessionsByParentId=\{sidebarSessionTree\.childrenByParentId\}/,
+    );
     assert.doesNotMatch(appShell, /projectGroups=\{/);
 
     assert.doesNotMatch(panel, /projectGroups\?:/);

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -719,6 +719,8 @@ backends.register('ai-sdk', createAiSdkBackendFactory({
   runtimeCommitStore: runtimePersistence.runtimeCommitStore,
   planStore,
   safeSendToRenderer,
+  openGateway,
+  emitSessionsChanged,
   getRuntime: () => runtime,
   getLookupPricing: () => lookupPricing,
 }));

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -115,6 +115,8 @@ export interface AiSdkBackendFactoryDeps {
   runtimeCommitStore: RuntimeCommitStore;
   planStore: PlanStore;
   safeSendToRenderer: (channel: string, ...args: unknown[]) => void;
+  openGateway: OpenGatewayService;
+  emitSessionsChanged: (reason: SessionChangedReason, sessionId?: string) => void;
   getRuntime: () => SessionManager;
   getLookupPricing: () => PricingLookup;
 }
@@ -153,6 +155,8 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
     runtimeCommitStore,
     planStore,
     safeSendToRenderer,
+    openGateway,
+    emitSessionsChanged,
     getRuntime,
     getLookupPricing,
   } = deps;
@@ -257,8 +261,16 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
       agentTeam,
       toolAvailability: backendToolAvailability,
       spawnChildAgent: (input) => getRuntime().spawnChildAgent(ctx.sessionId, input),
-      spawnChildSession: (input) =>
-        getRuntime().spawnChildSession(ctx.sessionId, {
+      spawnChildSession: (input) => {
+        const observation = createLinkedChildEventProjection({
+          lifecycle: 'created',
+          safeSendToRenderer,
+          openGateway,
+          emitSessionsChanged,
+          onReady: input.onReady,
+          onEvent: input.onEvent,
+        });
+        return getRuntime().spawnChildSession(ctx.sessionId, {
           spawnedBy: {
             parentRunId: input.parentRunId,
             parentTurnId: input.parentTurnId,
@@ -268,13 +280,42 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
           prompt: input.prompt,
           ...(input.swarm ? { swarm: input.swarm } : {}),
           abortSignal: input.abortSignal,
-          ...(input.onReady ? { onReady: input.onReady } : {}),
-          ...(input.onEvent ? { onEvent: input.onEvent } : {}),
-        }),
+          onReady: observation.onReady,
+          onEvent: observation.onEvent,
+        });
+      },
       prepareChildAgentResume: (sourceRunId) =>
         getRuntime().prepareChildAgentResume(ctx.sessionId, sourceRunId),
-      resumeChildAgent: (input) => getRuntime().resumeChildAgent(ctx.sessionId, input),
-      retryChildAgent: (input) => getRuntime().retryChildAgent(ctx.sessionId, input),
+      resumeChildAgent: (input) => {
+        const observation = createLinkedChildEventProjection({
+          lifecycle: 'continued',
+          safeSendToRenderer,
+          openGateway,
+          emitSessionsChanged,
+          onReady: input.onReady,
+          onEvent: input.onEvent,
+        });
+        return getRuntime().resumeChildAgent(ctx.sessionId, {
+          ...input,
+          onReady: observation.onReady,
+          onEvent: observation.onEvent,
+        });
+      },
+      retryChildAgent: (input) => {
+        const observation = createLinkedChildEventProjection({
+          lifecycle: 'continued',
+          safeSendToRenderer,
+          openGateway,
+          emitSessionsChanged,
+          onReady: input.onReady,
+          onEvent: input.onEvent,
+        });
+        return getRuntime().retryChildAgent(ctx.sessionId, {
+          ...input,
+          onReady: observation.onReady,
+          onEvent: observation.onEvent,
+        });
+      },
       listChildAgents: () => getRuntime().listChildAgents(ctx.sessionId),
       readChildAgentOutput: (input) => getRuntime().readChildAgentOutput(ctx.sessionId, input),
       providerOptions: buildProviderOptions(connection, model, ctx.header.thinkingLevel),
@@ -401,6 +442,68 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
       newId: randomUUID,
       now: Date.now,
     });
+  };
+}
+
+interface LinkedChildReady {
+  childSessionId?: string;
+  turnId: string;
+  runId?: string;
+  agentId: string;
+  agentName: string;
+}
+
+/**
+ * Bridge linked-child events onto the child Session's normal Desktop and Open
+ * Gateway channels while the parent tool call remains the stream consumer.
+ * Direct user follow-ups already use createSessionStreamer; this closes the
+ * nested spawn/resume/retry observation gap without inventing a subagent-only
+ * event protocol.
+ */
+export function createLinkedChildEventProjection<
+  Ready extends LinkedChildReady = LinkedChildReady,
+>(input: {
+  lifecycle: 'created' | 'continued';
+  safeSendToRenderer: (channel: string, ...args: unknown[]) => void;
+  openGateway: Pick<OpenGatewayService, 'publishSessionEvent'>;
+  emitSessionsChanged: (reason: SessionChangedReason, sessionId?: string) => void;
+  onReady?: (ready: Ready) => void | Promise<void>;
+  onEvent?: (event: SessionEvent) => void;
+}): {
+  onReady(ready: Ready): Promise<void>;
+  onEvent(event: SessionEvent): void;
+} {
+  let childSessionId: string | undefined;
+  let messageAppendBroadcasted = false;
+  return {
+    async onReady(ready) {
+      childSessionId = ready.childSessionId;
+      if (childSessionId) {
+        input.emitSessionsChanged(
+          input.lifecycle === 'created' ? 'created' : 'status-change',
+          childSessionId,
+        );
+        input.emitSessionsChanged('turn-status-change', childSessionId);
+      }
+      await input.onReady?.(ready);
+    },
+    onEvent(event) {
+      if (childSessionId) {
+        input.safeSendToRenderer(`sessions:event:${childSessionId}`, event);
+        input.openGateway.publishSessionEvent(childSessionId, event);
+        if (!messageAppendBroadcasted) {
+          input.emitSessionsChanged('message-appended', childSessionId);
+          messageAppendBroadcasted = true;
+        }
+        if (isStatusChangingSessionEvent(event)) {
+          input.emitSessionsChanged('status-change', childSessionId);
+        }
+        if (isTurnStatusChangingSessionEvent(event)) {
+          input.emitSessionsChanged('turn-status-change', childSessionId);
+        }
+      }
+      input.onEvent?.(event);
+    },
   };
 }
 

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -14,9 +14,10 @@ import type { PermissionMode, PlanReminder, SessionSummary, UiLocale, UiLocalePr
 import {
   buildDeepResearchImplementationPrompt,
   collapseSessionRevisions,
+  filterLinkedSessionTree,
   hasSettledInitialOnboarding,
   parseSwarmCommand,
-  projectLinkedSessionTree,
+  projectRevisionLinkedSessionTree,
   resolveUiLocale,
 } from '@maka/core';
 import {
@@ -62,7 +63,8 @@ import { deriveSessionStatusGroups } from './session-status-grouping';
 import { deriveAppShellTurnViewModel } from './app-shell-turn-view-model';
 import { readScrollMotionBehavior } from './scroll-motion-policy';
 import { deriveBranchBanner } from './branch-banner';
-import { filterSessions, readNavSelection } from './nav-selection';
+import { readNavSelection } from './nav-selection';
+import { sessionMatchesNavSelection } from './session-nav-filter';
 import { deriveSessionRevisionNavigation } from './session-revisions';
 import {
   SESSION_LIST_COLLAPSED_WIDTH,
@@ -343,13 +345,17 @@ function AppShellContent({
   // `aborted` is dropped. Pinned (flagged) sessions float to the top
   // in their own group, preserving the PR48 pin-floats behavior.
   const sidebarSessionTree = useMemo(
-    () => projectLinkedSessionTree(collapseSessionRevisions(sessions, activeId)),
+    () => projectRevisionLinkedSessionTree(sessions, activeId),
     [sessions, activeId],
   );
-  const visibleSessions = useMemo(
-    () => filterSessions(sidebarSessionTree.roots, navSelection),
+  const visibleSessionTree = useMemo(
+    () =>
+      filterLinkedSessionTree(sidebarSessionTree, (session) =>
+        sessionMatchesNavSelection(session, navSelection),
+      ),
     [sidebarSessionTree, navSelection],
   );
+  const visibleSessions = visibleSessionTree.roots;
   const sessionStatusGroups = useMemo(
     () => deriveSessionStatusGroups(visibleSessions, { pinFirst: true, locale: uiLocale }),
     [visibleSessions, uiLocale],
@@ -1553,7 +1559,7 @@ function AppShellContent({
             viewMode={viewMode}
             onViewModeChange={setViewMode}
             statusGroups={sessionListGroups}
-            childSessionsByParentId={sidebarSessionTree.childrenByParentId}
+            childSessionsByParentId={visibleSessionTree.childrenByParentId}
             onSelect={setNavSelection}
             onSelectSession={sessionListSelectSession}
             onOpenSettings={openSettings}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -16,6 +16,7 @@ import {
   collapseSessionRevisions,
   hasSettledInitialOnboarding,
   parseSwarmCommand,
+  projectLinkedSessionTree,
   resolveUiLocale,
 } from '@maka/core';
 import {
@@ -341,13 +342,13 @@ function AppShellContent({
   // Running → Waiting → Blocked → Active → Review → Done → Archived);
   // `aborted` is dropped. Pinned (flagged) sessions float to the top
   // in their own group, preserving the PR48 pin-floats behavior.
-  const sidebarSessions = useMemo(
-    () => collapseSessionRevisions(sessions, activeId),
+  const sidebarSessionTree = useMemo(
+    () => projectLinkedSessionTree(collapseSessionRevisions(sessions, activeId)),
     [sessions, activeId],
   );
   const visibleSessions = useMemo(
-    () => filterSessions(sidebarSessions, navSelection),
-    [sidebarSessions, navSelection],
+    () => filterSessions(sidebarSessionTree.roots, navSelection),
+    [sidebarSessionTree, navSelection],
   );
   const sessionStatusGroups = useMemo(
     () => deriveSessionStatusGroups(visibleSessions, { pinFirst: true, locale: uiLocale }),
@@ -1552,6 +1553,7 @@ function AppShellContent({
             viewMode={viewMode}
             onViewModeChange={setViewMode}
             statusGroups={sessionListGroups}
+            childSessionsByParentId={sidebarSessionTree.childrenByParentId}
             onSelect={setNavSelection}
             onSelectSession={sessionListSelectSession}
             onOpenSettings={openSettings}

--- a/apps/desktop/src/renderer/nav-selection.ts
+++ b/apps/desktop/src/renderer/nav-selection.ts
@@ -1,6 +1,5 @@
 import type { NavSelection } from '@maka/ui';
 import { safeLocalStorageGet } from './browser-storage';
-export { filterSessions, sessionMatchesNavSelection } from './session-nav-filter';
 
 export function readNavSelection(): NavSelection {
   try {

--- a/apps/desktop/src/renderer/nav-selection.ts
+++ b/apps/desktop/src/renderer/nav-selection.ts
@@ -1,6 +1,6 @@
-import type { SessionSummary } from '@maka/core';
 import type { NavSelection } from '@maka/ui';
 import { safeLocalStorageGet } from './browser-storage';
+export { filterSessions, sessionMatchesNavSelection } from './session-nav-filter';
 
 export function readNavSelection(): NavSelection {
   try {
@@ -28,16 +28,4 @@ export function readNavSelection(): NavSelection {
     /* fall through */
   }
   return { section: 'sessions', filter: 'chats' };
-}
-
-export function filterSessions(sessions: SessionSummary[], selection: NavSelection): SessionSummary[] {
-  const filter = selection.section === 'sessions' ? selection.filter : 'chats';
-  switch (filter) {
-    case 'flagged':
-      return sessions.filter((session) => session.isFlagged && !session.isArchived && session.lastMessageAt);
-    case 'archived':
-      return sessions.filter((session) => session.isArchived);
-    case 'chats':
-      return sessions.filter((session) => !session.isArchived && session.lastMessageAt);
-  }
 }

--- a/apps/desktop/src/renderer/session-nav-filter.ts
+++ b/apps/desktop/src/renderer/session-nav-filter.ts
@@ -1,13 +1,6 @@
 import type { SessionSummary } from '@maka/core';
 import type { NavSelection } from '@maka/ui';
 
-export function filterSessions(
-  sessions: SessionSummary[],
-  selection: NavSelection,
-): SessionSummary[] {
-  return sessions.filter((session) => sessionMatchesNavSelection(session, selection));
-}
-
 export function sessionMatchesNavSelection(
   session: SessionSummary,
   selection: NavSelection,

--- a/apps/desktop/src/renderer/session-nav-filter.ts
+++ b/apps/desktop/src/renderer/session-nav-filter.ts
@@ -1,0 +1,24 @@
+import type { SessionSummary } from '@maka/core';
+import type { NavSelection } from '@maka/ui';
+
+export function filterSessions(
+  sessions: SessionSummary[],
+  selection: NavSelection,
+): SessionSummary[] {
+  return sessions.filter((session) => sessionMatchesNavSelection(session, selection));
+}
+
+export function sessionMatchesNavSelection(
+  session: SessionSummary,
+  selection: NavSelection,
+): boolean {
+  const filter = selection.section === 'sessions' ? selection.filter : 'chats';
+  switch (filter) {
+    case 'flagged':
+      return Boolean(session.isFlagged && !session.isArchived && session.lastMessageAt);
+    case 'archived':
+      return session.isArchived;
+    case 'chats':
+      return Boolean(!session.isArchived && session.lastMessageAt);
+  }
+}

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -364,6 +364,21 @@
   transition: background-color var(--duration-base) var(--ease-out-strong);
 }
 
+.maka-list-session-children {
+  margin-inline-start: var(--space-2);
+  padding-inline-start: var(--space-1);
+  border-inline-start: var(--border-width-hairline) solid var(--border);
+}
+
+.maka-list-row[data-subagent="true"] {
+  background: var(--selection);
+}
+
+.maka-list-row-subagent-icon {
+  flex: 0 0 auto;
+  color: var(--muted-foreground);
+}
+
 .maka-list-row:hover {
   background: var(--state-hover-bg);
 }

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -5755,6 +5755,58 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('nests linked child sessions in the picker and allows opening one directly', async () => {
+    const terminal = new FakeTerminal();
+    const parent = fakeSessionSummary('parent-session', '/repo', 'Parent chat');
+    const child = {
+      ...fakeSessionSummary('child-session', '/repo', 'Local Read'),
+      subagentParent: {
+        kind: 'subagent' as const,
+        parentSessionId: parent.id,
+        spawnedBy: {
+          parentRunId: 'parent-run',
+          parentTurnId: 'parent-turn',
+          toolCallId: 'tool-call',
+        },
+        lifecycle: 'foreground' as const,
+      },
+      subagentRuntime: {
+        schemaVersion: 1 as const,
+        definitionVersion: 1,
+        agentId: 'local-read',
+        agentName: 'Local Read',
+        profile: 'local_read',
+        toolNames: ['Read', 'Glob', 'Grep'],
+        permissionCeiling: 'ask' as const,
+      },
+    };
+    const driver = new SlashCommandDriver([parent, child]);
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/session');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('↳ Local Read'));
+    assert.match(
+      plainTerminalOutput(terminal.screenOutput()),
+      /Local Read.*subagent:local_read active/,
+    );
+
+    terminal.input('\x1b[B');
+    terminal.input('\r');
+    await waitFor(() => driver.sessionIds.includes(child.id));
+
+    exitMaka(terminal);
+    await run;
+  });
+
   test('imports a foreign session from /session into a fresh handoff turn', async () => {
     const terminal = new FakeTerminal();
     // No Maka sessions, so the only picker row is the foreign one.

--- a/packages/cli/src/__tests__/run-session-selection.test.ts
+++ b/packages/cli/src/__tests__/run-session-selection.test.ts
@@ -186,6 +186,48 @@ describe('maka run session selection', () => {
     assert.equal(selected.cwd, '/repo');
   });
 
+  test('continue skips linked child sessions while explicit resume still accepts them', async () => {
+    const child = session({
+      id: 'child',
+      lastMessageAt: 500,
+      subagentParent: {
+        kind: 'subagent',
+        parentSessionId: 'parent',
+        spawnedBy: {
+          parentRunId: 'parent-run',
+          parentTurnId: 'parent-turn',
+          toolCallId: 'tool-call',
+        },
+        lifecycle: 'foreground',
+      },
+    });
+    const parent = session({ id: 'parent', lastMessageAt: 100 });
+    const deps = canonicalizer({ '/repo': '/repo' });
+
+    const continued = await selectMakaRunSession(
+      {
+        sessions: [child, parent],
+        continueLatest: true,
+        processCwd: '/repo',
+        thinkingSpecified: false,
+      },
+      deps,
+    );
+    assert.equal(continued.kind === 'existing' ? continued.session.id : undefined, parent.id);
+
+    const resumed = await selectMakaRunSession(
+      {
+        sessions: [child, parent],
+        resumeId: child.id,
+        continueLatest: false,
+        processCwd: '/repo',
+        thinkingSpecified: false,
+      },
+      deps,
+    );
+    assert.equal(resumed.kind === 'existing' ? resumed.session.id : undefined, child.id);
+  });
+
   test('continue returns a preflight failure when no cwd-compatible session exists', async () => {
     await assert.rejects(
       selectMakaRunSession(

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -24,7 +24,7 @@ import type { OrchestrationMode } from '@maka/core/orchestration';
 import {
   ShellRunUpdateBuffer,
   mergeShellRunUpdate,
-  projectLinkedSessionTree,
+  projectRevisionLinkedSessionTree,
   projectShellRunUpdateForSession,
   type SessionSummary,
   type ShellRunUpdate,
@@ -1705,7 +1705,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const showSessionList = async () => {
     const sessions = await input.driver.listSessions();
-    const sessionTree = projectLinkedSessionTree(sessions);
+    const sessionTree = projectRevisionLinkedSessionTree(
+      sessions,
+      input.driver.getSessionId() ?? undefined,
+    );
     const projectedSessions = flattenLinkedSessionTree(
       sessionTree.roots,
       sessionTree.childrenByParentId,

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -24,7 +24,9 @@ import type { OrchestrationMode } from '@maka/core/orchestration';
 import {
   ShellRunUpdateBuffer,
   mergeShellRunUpdate,
+  projectLinkedSessionTree,
   projectShellRunUpdateForSession,
+  type SessionSummary,
   type ShellRunUpdate,
 } from '@maka/core';
 import {
@@ -1703,6 +1705,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const showSessionList = async () => {
     const sessions = await input.driver.listSessions();
+    const sessionTree = projectLinkedSessionTree(sessions);
+    const projectedSessions = flattenLinkedSessionTree(
+      sessionTree.roots,
+      sessionTree.childrenByParentId,
+    );
     // Maka-session availability and the foreign scan are independent I/O; run
     // them concurrently so the picker's open latency is the slower of the two,
     // not their sum.
@@ -1745,19 +1752,22 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     const renderScope = (): void => {
       const visibleSessions =
         sessionListScope === 'current'
-          ? sessions.filter((session) => session.cwd === cwd)
-          : sessions;
-      const items: SelectItem[] = visibleSessions.map((session) => {
+          ? projectedSessions.filter(({ session }) => session.cwd === cwd)
+          : projectedSessions;
+      const items: SelectItem[] = visibleSessions.map(({ session, depth }) => {
         const state = availability.get(session.id);
         const location =
           sessionListScope === 'all' && session.cwd ? ` ${basename(session.cwd)}` : '';
+        const childDetail = session.subagentRuntime
+          ? ` subagent:${session.subagentRuntime.profile} ${session.status}`
+          : '';
         return {
           value: session.id,
-          label: session.name || session.id,
+          label: `${depth > 0 ? `${'  '.repeat(depth - 1)}↳ ` : ''}${session.name || session.id}`,
           description:
             state?.available === false
               ? `${shortSessionId(session.id)} ${state.reason}`
-              : `${shortSessionId(session.id)}${location} ${session.llmConnectionSlug} ${session.model}`,
+              : `${shortSessionId(session.id)}${location}${childDetail} ${session.llmConnectionSlug} ${session.model}`,
         };
       });
       // Foreign sessions are cwd-scoped; show them in both scope views (they
@@ -2621,6 +2631,21 @@ const BOTTOM_PICKER_MARGIN_ROWS = 4;
 // full slash-command menu, so a bare `/` shows every command rather than
 // silently clipping the last command.
 const EDITOR_AUTOCOMPLETE_MAX_VISIBLE = 16;
+
+function flattenLinkedSessionTree(
+  roots: readonly SessionSummary[],
+  childrenByParentId: ReadonlyMap<string, readonly SessionSummary[]>,
+): Array<{ session: SessionSummary; depth: number }> {
+  const flattened: Array<{ session: SessionSummary; depth: number }> = [];
+  const visit = (session: SessionSummary, depth: number): void => {
+    flattened.push({ session, depth });
+    for (const child of childrenByParentId.get(session.id) ?? []) {
+      visit(child, depth + 1);
+    }
+  };
+  for (const root of roots) visit(root, 0);
+  return flattened;
+}
 
 // A short, stable slice of a session id — enough to tell two same-named
 // sessions apart in the picker without showing the full unreadable uuid.

--- a/packages/cli/src/run-session-selection.ts
+++ b/packages/cli/src/run-session-selection.ts
@@ -76,6 +76,7 @@ async function selectLatestSession(
 
 function isContinueCandidate(session: SessionSummary): boolean {
   return (
+    session.subagentParent === undefined &&
     !session.isArchived &&
     (session.status === 'active' || session.status === 'aborted') &&
     typeof session.lastMessageAt === 'number' &&

--- a/packages/core/src/__tests__/session-revisions.test.ts
+++ b/packages/core/src/__tests__/session-revisions.test.ts
@@ -1,6 +1,10 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { collapseSessionRevisions, revisionFamilySessionIds } from '../session-revisions.js';
+import {
+  collapseSessionRevisions,
+  projectRevisionLinkedSessionTree,
+  revisionFamilySessionIds,
+} from '../session-revisions.js';
 import type { SessionSummary } from '../session.js';
 
 function summary(id: string, overrides: Partial<SessionSummary> = {}): SessionSummary {
@@ -57,6 +61,40 @@ describe('logical session revision projection', () => {
     assert.deepEqual(
       collapseSessionRevisions([preparing, root], 'preparing').map((session) => session.id),
       ['preparing'],
+    );
+  });
+
+  it('keeps a child nested under the selected representative of its physical parent revision', () => {
+    const root = summary('parent-v1', { lastMessageAt: 10 });
+    const revision = summary('parent-v2', {
+      revisionRootSessionId: root.id,
+      revisionParentSessionId: root.id,
+      revisionIndex: 2,
+      revisionState: 'committed',
+      lastMessageAt: 20,
+    });
+    const child = summary('child', {
+      subagentParent: {
+        kind: 'subagent',
+        parentSessionId: root.id,
+        spawnedBy: {
+          parentRunId: 'parent-run',
+          parentTurnId: 'parent-turn',
+          toolCallId: 'tool-call',
+        },
+        lifecycle: 'foreground',
+      },
+    });
+
+    const tree = projectRevisionLinkedSessionTree([root, child, revision]);
+
+    assert.deepEqual(
+      tree.roots.map((session) => session.id),
+      [revision.id],
+    );
+    assert.deepEqual(
+      tree.childrenByParentId.get(revision.id)?.map((session) => session.id),
+      [child.id],
     );
   });
 });

--- a/packages/core/src/__tests__/subagent-session-parent.test.ts
+++ b/packages/core/src/__tests__/subagent-session-parent.test.ts
@@ -8,6 +8,7 @@ import type {
 } from '../session.js';
 import {
   childSessionsForParent,
+  filterLinkedSessionTree,
   isSubagentSessionParent,
   isSubagentSessionRuntime,
   isSubagentSessionSpawn,
@@ -172,6 +173,43 @@ describe('subagent session parent relation', () => {
       ['child-a', 'child-b'],
     );
     assert.equal(tree.childrenByParentId.size, 0);
+  });
+
+  test('filters every tree level and promotes matching descendants past hidden ancestors', () => {
+    const parent = summary('parent', { isFlagged: false, isArchived: false });
+    const archivedChild = summary('archived-child', {
+      isArchived: true,
+      subagentParent: { ...relation, parentSessionId: parent.id },
+    });
+    const flaggedGrandchild = summary('flagged-grandchild', {
+      isFlagged: true,
+      subagentParent: { ...relation, parentSessionId: archivedChild.id },
+    });
+    const tree = projectLinkedSessionTree([parent, archivedChild, flaggedGrandchild]);
+
+    const chats = filterLinkedSessionTree(tree, (session) => !session.isArchived);
+    assert.deepEqual(
+      chats.roots.map((session) => session.id),
+      ['parent'],
+    );
+    assert.deepEqual(
+      chats.childrenByParentId.get(parent.id)?.map((session) => session.id),
+      ['flagged-grandchild'],
+    );
+
+    const archived = filterLinkedSessionTree(tree, (session) => session.isArchived);
+    assert.deepEqual(
+      archived.roots.map((session) => session.id),
+      ['archived-child'],
+    );
+    assert.equal(archived.childrenByParentId.size, 0);
+
+    const flagged = filterLinkedSessionTree(tree, (session) => session.isFlagged);
+    assert.deepEqual(
+      flagged.roots.map((session) => session.id),
+      ['flagged-grandchild'],
+    );
+    assert.equal(flagged.childrenByParentId.size, 0);
   });
 });
 

--- a/packages/core/src/__tests__/subagent-session-parent.test.ts
+++ b/packages/core/src/__tests__/subagent-session-parent.test.ts
@@ -11,6 +11,7 @@ import {
   isSubagentSessionParent,
   isSubagentSessionRuntime,
   isSubagentSessionSpawn,
+  projectLinkedSessionTree,
   subagentSessionRuntimeSummary,
 } from '../session.js';
 import { isPermissionModeWithinCeiling } from '../permission.js';
@@ -122,6 +123,55 @@ describe('subagent session parent relation', () => {
       ),
       ['child-a', 'child-b'],
     );
+  });
+
+  test('projects linked children beneath parents while preserving branches and orphans', () => {
+    const parent = summary('parent');
+    const child = summary('child', {
+      subagentParent: { ...relation, parentSessionId: parent.id },
+    });
+    const grandchild = summary('grandchild', {
+      subagentParent: { ...relation, parentSessionId: child.id },
+    });
+    const branch = summary('branch', {
+      parentSessionId: parent.id,
+      branchOfTurnId: 'parent-turn',
+    });
+    const orphan = summary('orphan', {
+      subagentParent: { ...relation, parentSessionId: 'deleted-parent' },
+    });
+
+    const tree = projectLinkedSessionTree([parent, child, grandchild, branch, orphan]);
+
+    assert.deepEqual(
+      tree.roots.map((session) => session.id),
+      ['parent', 'branch', 'orphan'],
+    );
+    assert.deepEqual(
+      tree.childrenByParentId.get(parent.id)?.map((session) => session.id),
+      ['child'],
+    );
+    assert.deepEqual(
+      tree.childrenByParentId.get(child.id)?.map((session) => session.id),
+      ['grandchild'],
+    );
+  });
+
+  test('keeps cyclic linked relations visible as roots', () => {
+    const childA = summary('child-a', {
+      subagentParent: { ...relation, parentSessionId: 'child-b' },
+    });
+    const childB = summary('child-b', {
+      subagentParent: { ...relation, parentSessionId: 'child-a' },
+    });
+
+    const tree = projectLinkedSessionTree([childA, childB]);
+
+    assert.deepEqual(
+      tree.roots.map((session) => session.id),
+      ['child-a', 'child-b'],
+    );
+    assert.equal(tree.childrenByParentId.size, 0);
   });
 });
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -161,6 +161,7 @@ export { DurableStoreWriteError } from './runtime-event-store.js';
 export type {
   SessionHeader,
   SessionSummary,
+  LinkedSessionTree,
   SessionChangedEvent,
   SessionChangedReason,
   SessionStatus,
@@ -192,6 +193,7 @@ export {
   SUBAGENT_SESSION_SPAWN_SCHEMA_VERSION,
   TURN_STATUSES,
   childSessionsForParent,
+  projectLinkedSessionTree,
   STEP_LIMIT_NOTICE_TEXT,
   deriveTurnRecords,
   isSessionStatus,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -162,6 +162,7 @@ export type {
   SessionHeader,
   SessionSummary,
   LinkedSessionTree,
+  LinkedSessionTreeProjectionOptions,
   SessionChangedEvent,
   SessionChangedReason,
   SessionStatus,
@@ -193,6 +194,7 @@ export {
   SUBAGENT_SESSION_SPAWN_SCHEMA_VERSION,
   TURN_STATUSES,
   childSessionsForParent,
+  filterLinkedSessionTree,
   projectLinkedSessionTree,
   STEP_LIMIT_NOTICE_TEXT,
   deriveTurnRecords,
@@ -537,6 +539,7 @@ export type {
 
 export {
   collapseSessionRevisions,
+  projectRevisionLinkedSessionTree,
   revisionFamilySessionIds,
   sessionRevisionFamilyId,
   visibleSessionRevisionMembers,

--- a/packages/core/src/session-revisions.ts
+++ b/packages/core/src/session-revisions.ts
@@ -1,4 +1,8 @@
-import type { SessionSummary } from './session.js';
+import {
+  projectLinkedSessionTree,
+  type LinkedSessionTree,
+  type SessionSummary,
+} from './session.js';
 
 export function sessionRevisionFamilyId(session: SessionSummary): string {
   return session.revisionRootSessionId ?? session.id;
@@ -60,6 +64,30 @@ export function collapseSessionRevisions(
   return sessions.filter(
     (session) => selected.get(sessionRevisionFamilyId(session)) === session.id,
   );
+}
+
+/**
+ * Build the host-facing child-session tree over logical revision rows.
+ *
+ * Child relations remain durably anchored to the exact physical parent that
+ * spawned them. This read model aliases every physical revision id to the
+ * currently selected representative so edit-and-resend cannot orphan a child
+ * in Desktop/TUI projection.
+ */
+export function projectRevisionLinkedSessionTree(
+  sessions: readonly SessionSummary[],
+  activeId?: string,
+): LinkedSessionTree {
+  const logicalSessions = collapseSessionRevisions(sessions, activeId);
+  const representativeByFamilyId = new Map(
+    logicalSessions.map((session) => [sessionRevisionFamilyId(session), session.id]),
+  );
+  const parentSessionIdAliases = new Map<string, string>();
+  for (const session of sessions) {
+    const representativeId = representativeByFamilyId.get(sessionRevisionFamilyId(session));
+    if (representativeId) parentSessionIdAliases.set(session.id, representativeId);
+  }
+  return projectLinkedSessionTree(logicalSessions, { parentSessionIdAliases });
 }
 
 /** Every durable physical version represented by a logical conversation row. */

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -264,6 +264,20 @@ export interface SessionSummary {
   orchestrationMode?: OrchestrationMode;
 }
 
+/**
+ * Host-facing projection of linked subagent Sessions.
+ *
+ * The flat Session list remains the storage/read authority. Hosts use this
+ * projection to nest a linked child beneath its durable parent without
+ * confusing ordinary branch lineage with subagent ownership. Missing-parent
+ * and cyclic relations fail open into roots so an inspectable child can never
+ * disappear from the product surface.
+ */
+export interface LinkedSessionTree {
+  roots: SessionSummary[];
+  childrenByParentId: ReadonlyMap<string, readonly SessionSummary[]>;
+}
+
 const SUBAGENT_SESSION_PARENT_SHAPE = defineObjectShape<SubagentSessionParent>()(
   ['kind', 'parentSessionId', 'spawnedBy', 'lifecycle'],
   ['swarm'],
@@ -384,6 +398,56 @@ export function childSessionsForParent(
       isSubagentSessionParent(session.subagentParent) &&
       session.subagentParent.parentSessionId === parentSessionId,
   );
+}
+
+/** Read-model projection; input order is preserved at every tree level. */
+export function projectLinkedSessionTree(sessions: readonly SessionSummary[]): LinkedSessionTree {
+  const sessionsById = new Map(sessions.map((session) => [session.id, session]));
+  const nestedParentByChildId = new Map<string, string>();
+
+  for (const session of sessions) {
+    const relation = session.subagentParent;
+    if (!isSubagentSessionParent(relation)) continue;
+    if (!sessionsById.has(relation.parentSessionId)) continue;
+    if (relation.parentSessionId === session.id) continue;
+    if (linkedParentChainContainsCycle(session.id, sessionsById)) continue;
+    nestedParentByChildId.set(session.id, relation.parentSessionId);
+  }
+
+  const roots: SessionSummary[] = [];
+  const mutableChildren = new Map<string, SessionSummary[]>();
+  for (const session of sessions) {
+    const parentSessionId = nestedParentByChildId.get(session.id);
+    if (!parentSessionId) {
+      roots.push(session);
+      continue;
+    }
+    const children = mutableChildren.get(parentSessionId) ?? [];
+    children.push(session);
+    mutableChildren.set(parentSessionId, children);
+  }
+
+  return {
+    roots,
+    childrenByParentId: mutableChildren,
+  };
+}
+
+function linkedParentChainContainsCycle(
+  startSessionId: string,
+  sessionsById: ReadonlyMap<string, SessionSummary>,
+): boolean {
+  const visited = new Set<string>();
+  let sessionId: string | undefined = startSessionId;
+  while (sessionId) {
+    if (visited.has(sessionId)) return true;
+    visited.add(sessionId);
+    const relation: SubagentSessionParent | undefined = sessionsById.get(sessionId)?.subagentParent;
+    if (!isSubagentSessionParent(relation)) return false;
+    if (!sessionsById.has(relation.parentSessionId)) return false;
+    sessionId = relation.parentSessionId;
+  }
+  return false;
 }
 
 function isSessionLineageId(value: unknown): value is string {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -278,6 +278,15 @@ export interface LinkedSessionTree {
   childrenByParentId: ReadonlyMap<string, readonly SessionSummary[]>;
 }
 
+export interface LinkedSessionTreeProjectionOptions {
+  /**
+   * Read-model aliases from durable physical parent ids to visible logical
+   * Session ids. Revision projection uses this to keep a child attached when
+   * its spawning parent revision is no longer the selected representative.
+   */
+  parentSessionIdAliases?: ReadonlyMap<string, string>;
+}
+
 const SUBAGENT_SESSION_PARENT_SHAPE = defineObjectShape<SubagentSessionParent>()(
   ['kind', 'parentSessionId', 'spawnedBy', 'lifecycle'],
   ['swarm'],
@@ -401,17 +410,27 @@ export function childSessionsForParent(
 }
 
 /** Read-model projection; input order is preserved at every tree level. */
-export function projectLinkedSessionTree(sessions: readonly SessionSummary[]): LinkedSessionTree {
+export function projectLinkedSessionTree(
+  sessions: readonly SessionSummary[],
+  options: LinkedSessionTreeProjectionOptions = {},
+): LinkedSessionTree {
   const sessionsById = new Map(sessions.map((session) => [session.id, session]));
   const nestedParentByChildId = new Map<string, string>();
+  const linkedParentId = (session: SessionSummary): string | undefined => {
+    const relation = session.subagentParent;
+    if (!isSubagentSessionParent(relation)) return undefined;
+    return (
+      options.parentSessionIdAliases?.get(relation.parentSessionId) ?? relation.parentSessionId
+    );
+  };
 
   for (const session of sessions) {
-    const relation = session.subagentParent;
-    if (!isSubagentSessionParent(relation)) continue;
-    if (!sessionsById.has(relation.parentSessionId)) continue;
-    if (relation.parentSessionId === session.id) continue;
-    if (linkedParentChainContainsCycle(session.id, sessionsById)) continue;
-    nestedParentByChildId.set(session.id, relation.parentSessionId);
+    const parentSessionId = linkedParentId(session);
+    if (!parentSessionId) continue;
+    if (!sessionsById.has(parentSessionId)) continue;
+    if (parentSessionId === session.id) continue;
+    if (linkedParentChainContainsCycle(session.id, sessionsById, linkedParentId)) continue;
+    nestedParentByChildId.set(session.id, parentSessionId);
   }
 
   const roots: SessionSummary[] = [];
@@ -433,19 +452,54 @@ export function projectLinkedSessionTree(sessions: readonly SessionSummary[]): L
   };
 }
 
+/**
+ * Filter a linked tree without leaking non-matching descendants through a
+ * matching parent. Matching descendants whose ancestors do not match are
+ * promoted to the nearest matching ancestor, or to a root when none exists.
+ */
+export function filterLinkedSessionTree(
+  tree: LinkedSessionTree,
+  include: (session: SessionSummary) => boolean,
+): LinkedSessionTree {
+  const roots: SessionSummary[] = [];
+  const mutableChildren = new Map<string, SessionSummary[]>();
+
+  const visit = (session: SessionSummary, visibleParentId?: string): void => {
+    const included = include(session);
+    const nextVisibleParentId = included ? session.id : visibleParentId;
+    if (included) {
+      if (visibleParentId) {
+        const children = mutableChildren.get(visibleParentId) ?? [];
+        children.push(session);
+        mutableChildren.set(visibleParentId, children);
+      } else {
+        roots.push(session);
+      }
+    }
+    for (const child of tree.childrenByParentId.get(session.id) ?? []) {
+      visit(child, nextVisibleParentId);
+    }
+  };
+
+  for (const root of tree.roots) visit(root);
+  return { roots, childrenByParentId: mutableChildren };
+}
+
 function linkedParentChainContainsCycle(
   startSessionId: string,
   sessionsById: ReadonlyMap<string, SessionSummary>,
+  linkedParentId: (session: SessionSummary) => string | undefined,
 ): boolean {
   const visited = new Set<string>();
   let sessionId: string | undefined = startSessionId;
   while (sessionId) {
     if (visited.has(sessionId)) return true;
     visited.add(sessionId);
-    const relation: SubagentSessionParent | undefined = sessionsById.get(sessionId)?.subagentParent;
-    if (!isSubagentSessionParent(relation)) return false;
-    if (!sessionsById.has(relation.parentSessionId)) return false;
-    sessionId = relation.parentSessionId;
+    const session = sessionsById.get(sessionId);
+    if (!session) return false;
+    const parentSessionId = linkedParentId(session);
+    if (!parentSessionId || !sessionsById.has(parentSessionId)) return false;
+    sessionId = parentSessionId;
   }
   return false;
 }

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -767,6 +767,105 @@ describe('SessionManager child-session runtime primitive', () => {
     while (!(await parentTurn.next()).done) {}
   });
 
+  test('reopens after restart with isolated history, tool activity, usage, and compaction', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    const parentGate = makeGate();
+    const compactCalls: Array<{ turnId: string; runtimeContextCount: number }> = [];
+    const childBackends: LifecycleChildBackend[] = [];
+    backends.register('fake', (ctx) => {
+      if (!ctx.header.subagentRuntime) return new TestBackend(ctx, parentGate);
+      const backend = new LifecycleChildBackend(ctx, compactCalls);
+      childBackends.push(backend);
+      return backend;
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(186),
+      runtimeSource: 'test',
+    });
+    const parent = await manager.createSession(makeInput());
+    const parentTurn = manager
+      .sendMessage(parent.id, { turnId: 'parent-turn', text: 'private parent context' })
+      [Symbol.asyncIterator]();
+    await parentTurn.next();
+    const [parentRun] = await runStore.listSessionRuns(parent.id);
+    if (!parentRun) throw new Error('parent run was not recorded');
+
+    const child = await manager.spawnChildSession(parent.id, {
+      spawnedBy: {
+        parentRunId: parentRun.runId,
+        parentTurnId: parentRun.turnId,
+        toolCallId: 'restart-observation-tool',
+      },
+      agentProfile: LOCAL_READ_AGENT_PROFILE,
+      prompt: 'inspect README before restart',
+    });
+
+    // A new manager represents a restarted Runtime Host. It must activate the
+    // child through the durable Session header and replay only child history.
+    const restarted = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(196),
+      runtimeSource: 'test',
+    });
+    await drain(
+      restarted.sendMessage(child.childSessionId, {
+        turnId: 'child-follow-up',
+        text: 'inspect it again after restart',
+      }),
+    );
+    const restartedBackend = childBackends.at(-1);
+    const followUpContext = restartedBackend?.sendInputs.at(-1)?.runtimeContext ?? [];
+    expect(followUpContext.some((event) => event.runId === child.runId)).toBe(true);
+    expect(
+      followUpContext.some(
+        (event) =>
+          event.content?.kind === 'text' && event.content.text.includes('private parent context'),
+      ),
+    ).toBe(false);
+
+    await drain(restarted.compactSession(child.childSessionId, { turnId: 'child-compact' }));
+    expect(compactCalls).toHaveLength(1);
+    expect(compactCalls[0]?.turnId).toBe('child-compact');
+
+    const childMessages = await restarted.getMessages(child.childSessionId);
+    expect(childMessages.some((message) => message.type === 'tool_call')).toBe(true);
+    expect(childMessages.some((message) => message.type === 'tool_result')).toBe(true);
+    expect(childMessages.some((message) => message.type === 'token_usage')).toBe(true);
+    expect(
+      childMessages.some(
+        (message) =>
+          message.type === 'turn_state' &&
+          message.turnId === 'child-compact' &&
+          message.status === 'completed',
+      ),
+    ).toBe(true);
+    const parentMessages = await restarted.getMessages(parent.id);
+    expect(
+      parentMessages.some(
+        (message) =>
+          message.turnId === child.turnId ||
+          message.turnId === 'child-follow-up' ||
+          message.turnId === 'child-compact',
+      ),
+    ).toBe(false);
+
+    parentGate.release();
+    while (!(await parentTurn.next()).done) {}
+  });
+
   test('refuses to activate a linked legacy child without a runtime snapshot', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -12920,6 +13019,46 @@ class CompactingTestBackend extends TestBackend {
       runtimeContextCount: input.runtimeContext.length,
     });
     return compactHistoryResult();
+  }
+}
+
+class LifecycleChildBackend extends CompactingTestBackend {
+  override async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    this.sendInputs.push(input);
+    yield {
+      type: 'tool_start',
+      id: `${input.turnId}-tool-start`,
+      turnId: input.turnId,
+      ts: 1,
+      toolUseId: `${input.turnId}-read`,
+      toolName: 'Read',
+      args: { path: 'README.md' },
+    };
+    yield {
+      type: 'tool_result',
+      id: `${input.turnId}-tool-result`,
+      turnId: input.turnId,
+      ts: 2,
+      toolUseId: `${input.turnId}-read`,
+      isError: false,
+      content: { kind: 'text', text: 'README body' },
+    };
+    yield {
+      type: 'token_usage',
+      id: `${input.turnId}-usage`,
+      turnId: input.turnId,
+      ts: 3,
+      input: 10,
+      output: 5,
+      total: 15,
+    };
+    yield {
+      type: 'complete',
+      id: `${input.turnId}-complete`,
+      turnId: input.turnId,
+      ts: 4,
+      stopReason: 'end_turn',
+    };
   }
 }
 

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -6,6 +6,7 @@ import {
   Archive,
   ArchiveRestore,
   Ban,
+  Bot,
   ChevronRight,
   CircleCheckBig,
   Eye,
@@ -81,6 +82,8 @@ export function SessionHistoryList(props: {
    * doesn't have to know about Archived being closed by default.
    */
   statusGroups?: ReadonlyArray<SessionHistoryStatusGroup>;
+  /** Linked subagent Sessions keyed by their durable parent Session id. */
+  childSessionsByParentId?: ReadonlyMap<string, readonly SessionSummary[]>;
   groupVariant?: SessionHistoryGroupVariant;
   onSelectSession(sessionId: string): void;
   rowActions?: SessionRowActions;
@@ -194,6 +197,7 @@ export function SessionHistoryList(props: {
             activeId={props.activeId}
             streamingSessionIds={props.streamingSessionIds}
             staleSessionIds={props.staleSessionIds}
+            childSessionsByParentId={props.childSessionsByParentId}
             onSelectSession={props.onSelectSession}
             rowActions={props.rowActions}
           />
@@ -226,6 +230,7 @@ function SessionListGroups(props: {
   activeId?: string;
   streamingSessionIds?: Set<string>;
   staleSessionIds?: Set<string>;
+  childSessionsByParentId?: ReadonlyMap<string, readonly SessionSummary[]>;
   onSelectSession(sessionId: string): void;
   rowActions?: SessionRowActions;
 }) {
@@ -266,6 +271,7 @@ function SessionListGroups(props: {
               activeId={props.activeId}
               streamingSessionIds={props.streamingSessionIds}
               staleSessionIds={props.staleSessionIds}
+              childSessionsByParentId={props.childSessionsByParentId}
               onSelectSession={props.onSelectSession}
               rowActions={props.rowActions}
             />
@@ -306,14 +312,15 @@ function SessionListGroups(props: {
             {expanded && (
               <div id={`maka-list-group-body-${group.key}`}>
                 {group.sessions.map((session) => (
-                  <SessionRow
+                  <SessionTreeRow
                     key={session.id}
                     session={session}
-                    active={session.id === props.activeId}
-                    streaming={props.streamingSessionIds?.has(session.id) ?? false}
-                    stale={props.staleSessionIds?.has(session.id) ?? false}
-                    onSelect={props.onSelectSession}
-                    actions={props.rowActions}
+                    activeId={props.activeId}
+                    streamingSessionIds={props.streamingSessionIds}
+                    staleSessionIds={props.staleSessionIds}
+                    childSessionsByParentId={props.childSessionsByParentId}
+                    onSelectSession={props.onSelectSession}
+                    rowActions={props.rowActions}
                   />
                 ))}
               </div>
@@ -332,6 +339,7 @@ function ProjectSessionGroup(props: {
   activeId?: string;
   streamingSessionIds?: Set<string>;
   staleSessionIds?: Set<string>;
+  childSessionsByParentId?: ReadonlyMap<string, readonly SessionSummary[]>;
   onSelectSession(sessionId: string): void;
   rowActions?: SessionRowActions;
 }) {
@@ -363,14 +371,15 @@ function ProjectSessionGroup(props: {
         <>
           <div id={`maka-list-group-body-${props.groupKey}`}>
             {visibleSessions.map((session) => (
-              <SessionRow
+              <SessionTreeRow
                 key={session.id}
                 session={session}
-                active={session.id === props.activeId}
-                streaming={props.streamingSessionIds?.has(session.id) ?? false}
-                stale={props.staleSessionIds?.has(session.id) ?? false}
-                onSelect={props.onSelectSession}
-                actions={props.rowActions}
+                activeId={props.activeId}
+                streamingSessionIds={props.streamingSessionIds}
+                staleSessionIds={props.staleSessionIds}
+                childSessionsByParentId={props.childSessionsByParentId}
+                onSelectSession={props.onSelectSession}
+                rowActions={props.rowActions}
               />
             ))}
           </div>
@@ -385,6 +394,48 @@ function ProjectSessionGroup(props: {
             </BaseButton>
           )}
         </>
+      )}
+    </div>
+  );
+}
+
+function SessionTreeRow(props: {
+  session: SessionSummary;
+  activeId?: string;
+  streamingSessionIds?: Set<string>;
+  staleSessionIds?: Set<string>;
+  childSessionsByParentId?: ReadonlyMap<string, readonly SessionSummary[]>;
+  onSelectSession(sessionId: string): void;
+  rowActions?: SessionRowActions;
+  depth?: number;
+}) {
+  const depth = props.depth ?? 0;
+  const children = props.childSessionsByParentId?.get(props.session.id) ?? [];
+  return (
+    <div
+      className="maka-list-session-tree"
+      data-depth={depth > 0 ? String(depth) : undefined}
+    >
+      <SessionRow
+        session={props.session}
+        active={props.session.id === props.activeId}
+        streaming={props.streamingSessionIds?.has(props.session.id) ?? false}
+        stale={props.staleSessionIds?.has(props.session.id) ?? false}
+        nested={depth > 0}
+        onSelect={props.onSelectSession}
+        actions={props.rowActions}
+      />
+      {children.length > 0 && (
+        <div className="maka-list-session-children">
+          {children.map((child) => (
+            <SessionTreeRow
+              key={child.id}
+              {...props}
+              session={child}
+              depth={depth + 1}
+            />
+          ))}
+        </div>
       )}
     </div>
   );
@@ -474,10 +525,12 @@ const SessionRow = memo(function SessionRow(props: {
    * user can spot broken sessions in the list before clicking in.
    */
   stale?: boolean;
+  /** Render this linked child as an indented nested Session row. */
+  nested?: boolean;
   onSelect(sessionId: string): void;
   actions?: SessionRowActions;
 }) {
-  const { session, active, streaming, stale, actions, onSelect } = props;
+  const { session, active, streaming, stale, nested, actions, onSelect } = props;
   const locale = useUiLocale();
   const copy = getConversationCopy(locale).sessions;
   const [editing, setEditing] = useState(false);
@@ -561,6 +614,7 @@ const SessionRow = memo(function SessionRow(props: {
       data-menu-open={menuOpen ? 'true' : undefined}
       data-streaming={streaming ? 'true' : undefined}
       data-stale={stale ? 'true' : undefined}
+      data-subagent={nested ? 'true' : undefined}
       onMouseEnter={() => setActionsVisible(true)}
       onMouseLeave={(event) => {
         if (event.currentTarget.contains(document.activeElement)) return;
@@ -655,6 +709,13 @@ const SessionRow = memo(function SessionRow(props: {
           */}
           <div className="maka-list-row-text">
             <div className="maka-list-row-name">
+              {nested && (
+                <Bot
+                  size={12}
+                  aria-hidden="true"
+                  className="maka-list-row-subagent-icon"
+                />
+              )}
               {streaming && (
                 <span
                   className="maka-list-row-streaming-dot"

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -16,6 +16,7 @@ export function SessionListPanel(props: {
   streamingSessionIds?: Set<string>;
   staleSessionIds?: Set<string>;
   statusGroups?: ReadonlyArray<SessionHistoryStatusGroup>;
+  childSessionsByParentId?: ReadonlyMap<string, readonly SessionSummary[]>;
   viewMode?: SessionViewMode;
   onViewModeChange?: (mode: SessionViewMode) => void;
   onSelectSession(sessionId: string): void;
@@ -71,6 +72,7 @@ export function SessionListPanel(props: {
         staleSessionIds={props.staleSessionIds}
         groupVariant={viewMode === 'project' ? 'project' : 'status'}
         statusGroups={statusGroups}
+        childSessionsByParentId={props.childSessionsByParentId}
         onSelectSession={props.onSelectSession}
         rowActions={props.rowActions}
       />


### PR DESCRIPTION
## Summary

This is PR 4, the final slice of #1366.

- Project durable child-session lineage into a parent-first tree in Desktop and the TUI without conflating ordinary branches.
- Keep orphaned or cyclic relations visible as roots so corrupted or partially migrated metadata cannot hide an inspectable session.
- Render child sessions as normal selectable Desktop rows and TUI entries; direct resume/follow-up continues through the existing Session APIs.
- Prevent implicit `--continue` from silently promoting the latest child session, while preserving explicit `--resume <child-session-id>`.
- Fan nested spawn/resume/retry events onto the child Session's existing Desktop renderer and Open Gateway channels, while retaining the parent tool's presentation callbacks.
- Cover Runtime Host restart, isolated child history, child-only compaction, usage/tool activity ownership, and two-client observation of one child event stream.

## Design boundary

This does not add a second agent runtime or a subagent-specific protocol. A child remains a normal Session with durable parent metadata; the host only projects the relation and routes the already-existing Session event stream.

Forked parent context is intentionally not included here. That changes creation semantics and data-copy policy, so it should remain a separate follow-up rather than expanding this lifecycle/observation PR.

## Validation

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- Desktop full suite: 2,825 tests passed
- Focused core, CLI, Runtime, child-observation, and multi-client Open Gateway tests passed
- `npm run test:fast` reaches two unrelated macOS sandbox failures (`/usr/local` executable-root ordering and Homebrew `rg`/PCRE2 dylib access); both reproduce unchanged on `origin/main`

Closes #1366

<details>
<summary>中文</summary>

## 概要

这是 #1366 的 PR 4，也是最后一个实现切片。

- 在 Desktop 和 TUI 中把持久化的 child-session 关系投影为父子树，同时不把普通 branch 混进 subagent 关系。
- 父会话缺失或关系成环时，child 会话仍作为根节点显示，避免异常或迁移不完整的元数据让会话不可观察。
- child session 在 Desktop 和 TUI 中仍是普通、可直接选择的会话；继续追问和恢复沿用现有 Session API。
- `--continue` 不再无意中把最近的 child session 当成主会话，但显式 `--resume <child-session-id>` 仍然支持。
- 嵌套 spawn/resume/retry 的事件会进入 child Session 已有的 Desktop renderer 与 Open Gateway 事件通道，同时保留父工具调用原有的展示回调。
- 增加 Runtime Host 重启、child 上下文隔离、child 独立压缩、usage/tool activity 归属，以及两个 client 同时观察一个 child stream 的覆盖。

## 设计边界

这个 PR 不增加第二套 agent runtime，也不引入 subagent 专用协议。child 仍然是带有持久化父关系元数据的普通 Session；host 只负责关系投影和复用既有 Session event stream 的路由。

父会话上下文 fork 有不同的创建语义和数据复制策略，因此有意留作独立后续，不扩张这个 lifecycle/observation PR。

## 验证

- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- Desktop 全量测试：2,825 个通过
- core、CLI、Runtime、child observation、Open Gateway 多客户端聚焦测试通过
- `npm run test:fast` 仅剩两个与本 PR 无关的 macOS sandbox 失败（`/usr/local` executable-root 顺序，以及 Homebrew `rg`/PCRE2 dylib 访问）；两项都能在未改动的 `origin/main` 上复现

</details>
