### PR TITLE
feat(runtime-host): add runtime policy authority

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./runtime-event": "./dist/runtime-event.js",
+    "./runtime-policy": "./dist/runtime-policy.js",
     "./execution-evidence": "./dist/execution-evidence.js",
     "./events": "./dist/events.js",
     "./session": "./dist/session.js",

--- a/packages/core/src/__tests__/runtime-policy-codec.test.ts
+++ b/packages/core/src/__tests__/runtime-policy-codec.test.ts
@@ -1,0 +1,83 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  createDefaultRuntimePolicy,
+  decodeCanonicalConnectionCatalogEntry,
+  decodeCanonicalRuntimePolicy,
+  normalizeCreateCatalogConnectionInput,
+  normalizeRuntimePolicyMutation,
+  normalizeSetCredentialInput,
+  RuntimePolicyDomainDecodeError,
+} from '../runtime-policy.js';
+
+test('normalizes policy input while canonical policy decode rejects producer drift', () => {
+  const mutation = normalizeRuntimePolicyMutation({
+    expectedRevision: 0,
+    operation: {
+      kind: 'set_network_proxy',
+      value: { ...createDefaultRuntimePolicy().networkProxy, enabled: true, host: ' proxy.local ' },
+    },
+  });
+  assert.equal(mutation.operation.kind, 'set_network_proxy');
+  if (mutation.operation.kind !== 'set_network_proxy') return;
+  assert.equal(mutation.operation.value.host, 'proxy.local');
+
+  assert.throws(
+    () =>
+      decodeCanonicalRuntimePolicy({
+        ...createDefaultRuntimePolicy(),
+        networkProxy: { ...mutation.operation.value, host: ' proxy.local ' },
+      }),
+    RuntimePolicyDomainDecodeError,
+  );
+  assert.doesNotThrow(() =>
+    decodeCanonicalRuntimePolicy({
+      ...createDefaultRuntimePolicy(),
+      networkProxy: { ...mutation.operation.value, host: 'proxy.local' },
+    }),
+  );
+});
+
+test('normalizes catalog inputs while canonical entries reject noncanonical endpoints', () => {
+  const input = normalizeCreateCatalogConnectionInput({
+    expectedCatalogRevision: 0,
+    connection: {
+      slug: 'openai-main',
+      name: 'OpenAI',
+      providerType: 'openai',
+      baseUrl: 'https://proxy.example:443/v1',
+      enabled: true,
+      enabledModelIds: [],
+    },
+  });
+  assert.equal(input.connection.baseUrl, 'https://proxy.example/v1');
+
+  assert.throws(
+    () =>
+      decodeCanonicalConnectionCatalogEntry({
+        ...input.connection,
+        connectionId: '123e4567-e89b-42d3-a456-426614174000',
+        revision: 1,
+        baseUrl: 'https://proxy.example:443/v1',
+        models: [],
+      }),
+    RuntimePolicyDomainDecodeError,
+  );
+});
+
+test('credential domain validation requires material but leaves capacity to callers', () => {
+  const input = normalizeSetCredentialInput({
+    locator: {
+      scope: 'connection',
+      connectionId: '123e4567-e89b-42d3-a456-426614174000',
+      kind: 'api_key',
+    },
+    expected: null,
+    secret: 's'.repeat(20 * 1024),
+  });
+  assert.equal(input.secret.length, 20 * 1024);
+  assert.throws(
+    () => normalizeSetCredentialInput({ ...input, secret: '' }),
+    RuntimePolicyDomainDecodeError,
+  );
+});

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './orchestration.js';
 export * from './swarm-command.js';
 export * from './plan.js';
 export * from './agent-graph-control.js';
+export * from './runtime-policy.js';
 
 // events.ts
 export type {

--- a/packages/core/src/runtime-policy.ts
+++ b/packages/core/src/runtime-policy.ts
@@ -1,0 +1,287 @@
+import type {
+  ConnectionLastTestStatus,
+  ConnectionTestErrorClass,
+  ModelDiscoveryResult,
+  ModelInfo,
+} from './llm-connections.js';
+import type { ProviderType } from './provider-registry.js';
+import type { ChatDefaultPermissionMode, ProxyProtocol } from './settings.js';
+import { WEB_SEARCH_PROVIDERS, type WebSearchProvider } from './web-search.js';
+
+export { WEB_SEARCH_PROVIDERS };
+export { RuntimePolicyDomainDecodeError } from './runtime-policy/domain-codec.js';
+export {
+  decodeCanonicalRuntimePolicy,
+  normalizeRuntimePolicyMutation,
+} from './runtime-policy/policy-codec.js';
+export {
+  CONNECTION_CATALOG_MAX_CONNECTIONS,
+  CONNECTION_CATALOG_MAX_ENABLED_MODEL_IDS,
+  CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION,
+  CONNECTION_MODEL_ID_MAX_LENGTH,
+  CONNECTION_NAME_MAX_LENGTH,
+  decodeCanonicalConnectionBaseUrl,
+  decodeCanonicalConnectionCatalogEntry,
+  decodeConnectionModelId,
+  decodeConnectionModel,
+  decodeConnectionName,
+  decodeConnectionSlug,
+  decodeConnectionTarget,
+  decodeConnectionTestSummary,
+  decodeConnectionVersionBasis,
+  decodeProviderType,
+  normalizeCatalogConnectionBaseUrl,
+  normalizeConnectionCatalogEntryDraft,
+  normalizeConnectionCatalogEntryUpdate,
+  normalizeConnectionCatalogEntryUpdateForProvider,
+  normalizeCreateCatalogConnectionInput,
+  normalizeRemoveCatalogConnectionInput,
+  normalizeSetDefaultConnectionTargetInput,
+  normalizeUpdateCatalogConnectionInput,
+} from './runtime-policy/connection-catalog-codec.js';
+export {
+  decodeCredentialLocator,
+  decodeCredentialStatus,
+  decodeCredentialVersionBasis,
+  normalizeCredentialSecret,
+  normalizeDeleteCredentialInput,
+  normalizeSetCredentialInput,
+} from './runtime-policy/credential-vault-codec.js';
+
+export type Revision = number;
+export type EntityId = string;
+
+export interface RevisionConflict {
+  readonly kind: 'revision_conflict';
+  readonly expectedRevision: Revision;
+  readonly actualRevision: Revision;
+}
+
+export interface RuntimePolicy {
+  readonly networkProxy: {
+    readonly enabled: boolean;
+    readonly protocol: ProxyProtocol;
+    readonly host: string;
+    readonly port: number;
+    readonly authEnabled: boolean;
+    readonly username: string;
+    readonly bypassList: readonly string[];
+    readonly autoBypassDomains: readonly string[];
+  };
+  readonly personalization: {
+    readonly displayName: string;
+    readonly assistantTone: string;
+  };
+  readonly memory: {
+    readonly enabled: boolean;
+    readonly agentReadEnabled: boolean;
+  };
+  readonly workspaceInstructions: {
+    readonly enabled: boolean;
+  };
+  readonly privacy: {
+    readonly incognitoActive: boolean;
+  };
+  readonly chatDefaults: {
+    readonly permissionMode: ChatDefaultPermissionMode;
+  };
+  readonly webSearch: {
+    readonly enabled: boolean;
+    readonly defaultProvider: WebSearchProvider;
+  };
+}
+
+export interface RuntimePolicySnapshot {
+  readonly revision: Revision;
+  readonly policy: RuntimePolicy;
+}
+
+export type RuntimePolicyMutation =
+  | { readonly kind: 'set_network_proxy'; readonly value: RuntimePolicy['networkProxy'] }
+  | { readonly kind: 'set_personalization'; readonly value: RuntimePolicy['personalization'] }
+  | { readonly kind: 'set_memory'; readonly value: RuntimePolicy['memory'] }
+  | {
+      readonly kind: 'set_workspace_instructions';
+      readonly value: RuntimePolicy['workspaceInstructions'];
+    }
+  | { readonly kind: 'set_privacy'; readonly value: RuntimePolicy['privacy'] }
+  | { readonly kind: 'set_chat_defaults'; readonly value: RuntimePolicy['chatDefaults'] }
+  | { readonly kind: 'set_web_search'; readonly value: RuntimePolicy['webSearch'] };
+
+export interface MutateRuntimePolicyInput {
+  readonly expectedRevision: Revision;
+  readonly operation: RuntimePolicyMutation;
+}
+
+export type MutateRuntimePolicyResult =
+  | { readonly kind: 'committed'; readonly snapshot: RuntimePolicySnapshot }
+  | RevisionConflict;
+
+export function createDefaultRuntimePolicy(): RuntimePolicy {
+  return {
+    networkProxy: {
+      enabled: false,
+      protocol: 'http',
+      host: '127.0.0.1',
+      port: 7890,
+      authEnabled: false,
+      username: '',
+      bypassList: ['metaso.cn', 'baidu.com'],
+      autoBypassDomains: ['localhost', '127.0.0.1', '::1', '192.168.*', '10.*', '*.local'],
+    },
+    personalization: { displayName: '', assistantTone: '' },
+    memory: { enabled: true, agentReadEnabled: false },
+    workspaceInstructions: { enabled: true },
+    privacy: { incognitoActive: false },
+    chatDefaults: { permissionMode: 'ask' },
+    webSearch: { enabled: false, defaultProvider: 'tavily' },
+  };
+}
+
+export type ConnectionModel = Readonly<ModelInfo>;
+
+export type ConnectionModelDiscoveryResult = Readonly<
+  Pick<ModelDiscoveryResult, 'source' | 'fetchedAt'>
+> & {
+  readonly models: readonly ConnectionModel[];
+};
+
+export interface ConnectionTestSummary {
+  readonly status: ConnectionLastTestStatus;
+  readonly checkedAt: string;
+  readonly errorClass?: ConnectionTestErrorClass;
+}
+
+export interface ConnectionConfiguration {
+  readonly slug: string;
+  readonly name: string;
+  readonly providerType: ProviderType;
+  readonly baseUrl?: string;
+  readonly enabled: boolean;
+  readonly enabledModelIds: readonly string[];
+}
+
+export interface ConnectionCatalogEntry extends ConnectionConfiguration {
+  readonly connectionId: EntityId;
+  readonly revision: Revision;
+  readonly models: ConnectionModelDiscoveryResult['models'];
+  readonly modelSource?: ConnectionModelDiscoveryResult['source'];
+  readonly modelsFetchedAt?: ConnectionModelDiscoveryResult['fetchedAt'];
+  readonly lastTest?: ConnectionTestSummary;
+}
+
+export type ConnectionCatalogEntryDraft = ConnectionConfiguration;
+
+export interface ConnectionCatalogEntryUpdate {
+  readonly name: string;
+  readonly baseUrl?: string;
+  readonly enabled: boolean;
+  readonly enabledModelIds: readonly string[];
+}
+
+export interface ConnectionVersionBasis {
+  readonly connectionId: EntityId;
+  readonly revision: Revision;
+}
+
+export interface ConnectionTarget {
+  readonly connectionId: EntityId;
+  readonly modelId: string;
+}
+
+export interface ConnectionCatalogSnapshot {
+  readonly revision: Revision;
+  readonly defaultTarget: ConnectionTarget | null;
+  readonly connections: readonly ConnectionCatalogEntry[];
+}
+
+export interface CreateCatalogConnectionInput {
+  readonly expectedCatalogRevision: Revision;
+  readonly connection: ConnectionCatalogEntryDraft;
+}
+
+export interface UpdateCatalogConnectionInput {
+  readonly expected: ConnectionVersionBasis;
+  readonly changes: ConnectionCatalogEntryUpdate;
+}
+
+export interface RemoveCatalogConnectionInput {
+  readonly expected: ConnectionVersionBasis;
+}
+
+export interface SetDefaultConnectionTargetInput {
+  readonly expectedCatalogRevision: Revision;
+  readonly target: ConnectionTarget | null;
+}
+
+export type ConnectionCatalogConflict =
+  | RevisionConflict
+  | { readonly kind: 'connection_exists'; readonly slug: string }
+  | {
+      readonly kind: 'connection_stale';
+      readonly expected: ConnectionVersionBasis;
+      readonly actual: ConnectionVersionBasis | null;
+    }
+  | { readonly kind: 'invalid_default_target'; readonly target: ConnectionTarget };
+
+export type ConnectionCatalogMutationResult =
+  | { readonly kind: 'committed'; readonly snapshot: ConnectionCatalogSnapshot }
+  | ConnectionCatalogConflict;
+
+export type CredentialLocator =
+  | {
+      readonly scope: 'connection';
+      readonly connectionId: EntityId;
+      readonly kind: 'api_key' | 'oauth_token';
+    }
+  | { readonly scope: 'web_search'; readonly provider: WebSearchProvider; readonly kind: 'api_key' }
+  | { readonly scope: 'network_proxy'; readonly kind: 'password' };
+
+export interface CredentialIdentity {
+  readonly credentialId: EntityId;
+}
+
+export interface CredentialVersionBasis extends CredentialIdentity {
+  readonly locator: CredentialLocator;
+  readonly revision: Revision;
+}
+
+export type CredentialStatus =
+  | {
+      readonly locator: CredentialLocator;
+      readonly configured: false;
+      readonly credentialId: null;
+      readonly revision: null;
+      readonly updatedAt: null;
+    }
+  | {
+      readonly locator: CredentialLocator;
+      readonly configured: true;
+      readonly credentialId: EntityId;
+      readonly revision: Revision;
+      readonly updatedAt: number;
+    };
+
+export interface CredentialVaultSnapshot {
+  readonly revision: Revision;
+  readonly entries: readonly CredentialStatus[];
+}
+
+export interface SetCredentialInput {
+  readonly locator: CredentialLocator;
+  readonly expected: (CredentialIdentity & { readonly revision: Revision }) | null;
+  readonly secret: string;
+}
+
+export interface DeleteCredentialInput {
+  readonly expected: CredentialVersionBasis;
+}
+
+export type CredentialMutationResult =
+  | { readonly kind: 'committed'; readonly snapshot: CredentialVaultSnapshot }
+  | { readonly kind: 'connection_not_found' }
+  | {
+      readonly kind: 'credential_stale';
+      readonly expected: CredentialVersionBasis | null;
+      readonly actual: CredentialVersionBasis | null;
+    };

--- a/packages/core/src/runtime-policy/connection-catalog-codec.ts
+++ b/packages/core/src/runtime-policy/connection-catalog-codec.ts
@@ -1,0 +1,411 @@
+import { PROVIDER_DEFAULTS, validateSlug, type ProviderType } from '../llm-connections.js';
+import type {
+  ConnectionCatalogEntry,
+  ConnectionCatalogEntryDraft,
+  ConnectionCatalogEntryUpdate,
+  ConnectionModel,
+  ConnectionTarget,
+  ConnectionTestSummary,
+  ConnectionVersionBasis,
+  CreateCatalogConnectionInput,
+  RemoveCatalogConnectionInput,
+  SetDefaultConnectionTargetInput,
+  UpdateCatalogConnectionInput,
+} from '../runtime-policy.js';
+import {
+  assertCanonicalValue,
+  booleanValue,
+  domainError,
+  entityIdValue,
+  exactRecord,
+  integerValue,
+  nonEmptyStringValue,
+  positiveRevisionValue,
+  revisionValue,
+  stringValue,
+} from './domain-codec.js';
+
+const PROVIDER_TYPES = new Set<string>(Object.keys(PROVIDER_DEFAULTS));
+
+export const CONNECTION_CATALOG_MAX_CONNECTIONS = 1_024;
+export const CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION = 2_048;
+export const CONNECTION_CATALOG_MAX_ENABLED_MODEL_IDS = 512;
+export const CONNECTION_NAME_MAX_LENGTH = 256;
+export const CONNECTION_MODEL_ID_MAX_LENGTH = 512;
+
+export function normalizeCreateCatalogConnectionInput(
+  value: unknown,
+): CreateCatalogConnectionInput {
+  const input = exactRecord(value, 'create connection input', [
+    'expectedCatalogRevision',
+    'connection',
+  ]);
+  return {
+    expectedCatalogRevision: revisionValue(
+      input.expectedCatalogRevision,
+      'create connection expected catalog revision',
+    ),
+    connection: normalizeConnectionCatalogEntryDraft(input.connection),
+  };
+}
+
+export function normalizeUpdateCatalogConnectionInput(
+  value: unknown,
+): UpdateCatalogConnectionInput {
+  const input = exactRecord(value, 'update connection input', ['expected', 'changes']);
+  return {
+    expected: decodeConnectionVersionBasis(input.expected),
+    changes: normalizeConnectionCatalogEntryUpdate(input.changes),
+  };
+}
+
+export function normalizeRemoveCatalogConnectionInput(
+  value: unknown,
+): RemoveCatalogConnectionInput {
+  const input = exactRecord(value, 'remove connection input', ['expected']);
+  return { expected: decodeConnectionVersionBasis(input.expected) };
+}
+
+export function normalizeSetDefaultConnectionTargetInput(
+  value: unknown,
+): SetDefaultConnectionTargetInput {
+  const input = exactRecord(value, 'set default target input', [
+    'expectedCatalogRevision',
+    'target',
+  ]);
+  return {
+    expectedCatalogRevision: revisionValue(
+      input.expectedCatalogRevision,
+      'set default target expected catalog revision',
+    ),
+    target: input.target === null ? null : decodeConnectionTarget(input.target),
+  };
+}
+
+export function normalizeConnectionCatalogEntryDraft(value: unknown): ConnectionCatalogEntryDraft {
+  const item = exactRecord(
+    value,
+    'connection draft',
+    ['slug', 'name', 'providerType', 'baseUrl', 'enabled', 'enabledModelIds'],
+    ['slug', 'name', 'providerType', 'enabled', 'enabledModelIds'],
+  );
+  const providerType = decodeProviderType(item.providerType);
+  const baseUrl = normalizeCatalogConnectionBaseUrl(item.baseUrl, providerType);
+  return {
+    slug: decodeConnectionSlug(item.slug),
+    name: decodeConnectionName(item.name),
+    providerType,
+    ...(baseUrl === undefined ? {} : { baseUrl }),
+    enabled: booleanValue(item.enabled, 'connection enabled'),
+    enabledModelIds: decodeConnectionModelIds(item.enabledModelIds),
+  };
+}
+
+export function normalizeConnectionCatalogEntryUpdate(
+  value: unknown,
+): ConnectionCatalogEntryUpdate {
+  const item = exactRecord(
+    value,
+    'connection update',
+    ['name', 'baseUrl', 'enabled', 'enabledModelIds'],
+    ['name', 'enabled', 'enabledModelIds'],
+  );
+  const baseUrl = normalizeCatalogConnectionBaseUrl(item.baseUrl);
+  return {
+    name: decodeConnectionName(item.name),
+    ...(baseUrl === undefined ? {} : { baseUrl }),
+    enabled: booleanValue(item.enabled, 'connection enabled'),
+    enabledModelIds: decodeConnectionModelIds(item.enabledModelIds),
+  };
+}
+
+export function normalizeConnectionCatalogEntryUpdateForProvider(
+  value: unknown,
+  providerType: ProviderType,
+): ConnectionCatalogEntryUpdate {
+  const update = normalizeConnectionCatalogEntryUpdate(value);
+  const baseUrl = normalizeCatalogConnectionBaseUrl(update.baseUrl, providerType);
+  return {
+    name: update.name,
+    ...(baseUrl === undefined ? {} : { baseUrl }),
+    enabled: update.enabled,
+    enabledModelIds: update.enabledModelIds,
+  };
+}
+
+export function decodeCanonicalConnectionCatalogEntry(value: unknown): ConnectionCatalogEntry {
+  const item = exactRecord(
+    value,
+    'connection catalog entry',
+    [
+      'connectionId',
+      'revision',
+      'slug',
+      'name',
+      'providerType',
+      'baseUrl',
+      'enabled',
+      'enabledModelIds',
+      'models',
+      'modelSource',
+      'modelsFetchedAt',
+      'lastTest',
+    ],
+    [
+      'connectionId',
+      'revision',
+      'slug',
+      'name',
+      'providerType',
+      'enabled',
+      'enabledModelIds',
+      'models',
+    ],
+  );
+  const draft = normalizeConnectionCatalogEntryDraft({
+    slug: item.slug,
+    name: item.name,
+    providerType: item.providerType,
+    ...(item.baseUrl === undefined ? {} : { baseUrl: item.baseUrl }),
+    enabled: item.enabled,
+    enabledModelIds: item.enabledModelIds,
+  });
+  if (
+    !Array.isArray(item.models) ||
+    item.models.length > CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION
+  ) {
+    throw domainError('connection models must be a bounded array');
+  }
+  const models = item.models.map(decodeConnectionModel);
+  if (new Set(models.map((model) => model.id)).size !== models.length) {
+    throw domainError('connection model ids must be unique');
+  }
+  if (
+    item.modelSource !== undefined &&
+    item.modelSource !== 'fetched' &&
+    item.modelSource !== 'fallback'
+  ) {
+    throw domainError('connection model source is invalid');
+  }
+  if ((item.modelSource === undefined) !== (item.modelsFetchedAt === undefined)) {
+    throw domainError('connection model source and fetched time must occur together');
+  }
+  if (item.modelSource === undefined && models.length > 0) {
+    throw domainError('connection models must be empty before model discovery');
+  }
+  const decoded: ConnectionCatalogEntry = {
+    ...draft,
+    connectionId: entityIdValue(item.connectionId, 'connection id'),
+    revision: positiveRevisionValue(item.revision, 'connection revision'),
+    models,
+    ...(item.modelSource === undefined ? {} : { modelSource: item.modelSource }),
+    ...(item.modelsFetchedAt === undefined
+      ? {}
+      : {
+          modelsFetchedAt: integerValue(
+            item.modelsFetchedAt,
+            'models fetched at',
+            0,
+            Number.MAX_SAFE_INTEGER,
+          ),
+        }),
+    ...(item.lastTest === undefined
+      ? {}
+      : { lastTest: decodeConnectionTestSummary(item.lastTest) }),
+  };
+  assertCanonicalValue(value, decoded, 'connection catalog entry');
+  return decoded;
+}
+
+export function decodeConnectionVersionBasis(value: unknown): ConnectionVersionBasis {
+  const item = exactRecord(value, 'connection basis', ['connectionId', 'revision']);
+  return {
+    connectionId: entityIdValue(item.connectionId, 'connection id'),
+    revision: positiveRevisionValue(item.revision, 'connection revision'),
+  };
+}
+
+export function decodeConnectionTarget(value: unknown): ConnectionTarget {
+  const item = exactRecord(value, 'connection target', ['connectionId', 'modelId']);
+  return {
+    connectionId: entityIdValue(item.connectionId, 'connection id'),
+    modelId: decodeConnectionModelId(item.modelId),
+  };
+}
+
+export function decodeConnectionModel(value: unknown): ConnectionModel {
+  const item = exactRecord(
+    value,
+    'connection model',
+    ['id', 'displayName', 'apiProtocol', 'contextWindow', 'maxOutputTokens', 'capabilities'],
+    ['id'],
+  );
+  if (
+    item.apiProtocol !== undefined &&
+    item.apiProtocol !== 'openai-chat' &&
+    item.apiProtocol !== 'openai-responses' &&
+    item.apiProtocol !== 'anthropic-messages'
+  ) {
+    throw domainError('connection model API protocol is invalid');
+  }
+  let capabilities: ConnectionModel['capabilities'];
+  if (item.capabilities !== undefined) {
+    const raw = exactRecord(
+      item.capabilities,
+      'connection model capabilities',
+      ['chat', 'vision', 'reasoning', 'functionCalling', 'imageGeneration'],
+      [],
+    );
+    capabilities = {};
+    for (const key of Object.keys(raw)) {
+      (capabilities as Record<string, boolean>)[key] = booleanValue(
+        raw[key],
+        `connection model capability ${key}`,
+      );
+    }
+  }
+  return {
+    id: decodeConnectionModelId(item.id),
+    ...(item.displayName === undefined
+      ? {}
+      : { displayName: stringValue(item.displayName, 'model display name', 512) }),
+    ...(item.apiProtocol === undefined ? {} : { apiProtocol: item.apiProtocol }),
+    ...(item.contextWindow === undefined
+      ? {}
+      : {
+          contextWindow: integerValue(
+            item.contextWindow,
+            'model context window',
+            1,
+            Number.MAX_SAFE_INTEGER,
+          ),
+        }),
+    ...(item.maxOutputTokens === undefined
+      ? {}
+      : {
+          maxOutputTokens: integerValue(
+            item.maxOutputTokens,
+            'model max output tokens',
+            1,
+            Number.MAX_SAFE_INTEGER,
+          ),
+        }),
+    ...(capabilities === undefined ? {} : { capabilities }),
+  };
+}
+
+export function decodeConnectionTestSummary(value: unknown): ConnectionTestSummary {
+  const item = exactRecord(
+    value,
+    'connection test summary',
+    ['status', 'checkedAt', 'errorClass'],
+    ['status', 'checkedAt'],
+  );
+  if (item.status !== 'verified' && item.status !== 'needs_reauth' && item.status !== 'error') {
+    throw domainError('connection test status is invalid');
+  }
+  if (
+    item.errorClass !== undefined &&
+    item.errorClass !== 'auth' &&
+    item.errorClass !== 'timeout' &&
+    item.errorClass !== 'provider_unavailable' &&
+    item.errorClass !== 'network' &&
+    item.errorClass !== 'unknown'
+  ) {
+    throw domainError('connection test error class is invalid');
+  }
+  return {
+    status: item.status,
+    checkedAt: nonEmptyStringValue(item.checkedAt, 'connection test checkedAt', 128),
+    ...(item.errorClass === undefined ? {} : { errorClass: item.errorClass }),
+  };
+}
+
+export function decodeConnectionSlug(value: unknown): string {
+  if (typeof value !== 'string') throw domainError('connection slug must be a string');
+  const error = validateSlug(value);
+  if (error) throw domainError(`connection slug: ${error}`);
+  return value;
+}
+
+export function decodeConnectionName(value: unknown): string {
+  return stringValue(value, 'connection name', CONNECTION_NAME_MAX_LENGTH);
+}
+
+export function decodeConnectionModelId(value: unknown): string {
+  return nonEmptyStringValue(value, 'model id', CONNECTION_MODEL_ID_MAX_LENGTH);
+}
+
+function decodeConnectionModelIds(value: unknown): string[] {
+  if (!Array.isArray(value) || value.length > CONNECTION_CATALOG_MAX_ENABLED_MODEL_IDS) {
+    throw domainError('enabled model ids must be a bounded array');
+  }
+  const modelIds = value.map(decodeConnectionModelId);
+  if (new Set(modelIds).size !== modelIds.length) {
+    throw domainError('enabled model ids must be unique');
+  }
+  return modelIds;
+}
+
+export function decodeProviderType(value: unknown): ProviderType {
+  if (typeof value !== 'string' || !PROVIDER_TYPES.has(value)) {
+    throw domainError('connection provider type is not registered');
+  }
+  return value as ProviderType;
+}
+
+export function normalizeCatalogConnectionBaseUrl(
+  value: unknown,
+  providerType?: ProviderType,
+): string | undefined {
+  if (value === undefined) return undefined;
+  const raw = stringValue(value, 'connection base URL', 2_048);
+  const trimmed = raw.trim();
+  if (!trimmed) return undefined;
+  let parsed: URL;
+  try {
+    parsed = new URL(trimmed);
+  } catch {
+    throw domainError('connection base URL must be a valid URL');
+  }
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw domainError('connection base URL must use http or https');
+  }
+  if (parsed.username || parsed.password) {
+    throw domainError('connection base URL must not contain credentials');
+  }
+  if (trimmed.includes('?') || trimmed.includes('#')) {
+    throw domainError('connection base URL must not contain a query or fragment');
+  }
+  const canonical = parsed.toString();
+  const providerDefault =
+    providerType === undefined ? undefined : canonicalProviderBaseUrl(providerType);
+  const override = canonical === providerDefault ? undefined : canonical;
+  if (
+    override !== undefined &&
+    providerType &&
+    PROVIDER_DEFAULTS[providerType].authKind === 'oauth_token'
+  ) {
+    throw domainError('OAuth provider endpoint cannot be overridden');
+  }
+  return override;
+}
+
+export function decodeCanonicalConnectionBaseUrl(
+  value: unknown,
+  providerType: ProviderType,
+): string | undefined {
+  const decoded = normalizeCatalogConnectionBaseUrl(value, providerType);
+  if (value !== decoded) throw domainError('connection base URL must be canonical');
+  return decoded;
+}
+
+function canonicalProviderBaseUrl(providerType: ProviderType): string | undefined {
+  const raw = PROVIDER_DEFAULTS[providerType].baseUrl.trim();
+  if (!raw) return undefined;
+  try {
+    return new URL(raw).toString();
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/core/src/runtime-policy/credential-vault-codec.ts
+++ b/packages/core/src/runtime-policy/credential-vault-codec.ts
@@ -1,0 +1,134 @@
+import type {
+  CredentialLocator,
+  CredentialStatus,
+  CredentialVersionBasis,
+  DeleteCredentialInput,
+  SetCredentialInput,
+} from '../runtime-policy.js';
+import { WEB_SEARCH_PROVIDERS } from '../web-search.js';
+import {
+  domainError,
+  entityIdValue,
+  exactRecord,
+  integerValue,
+  positiveRevisionValue,
+} from './domain-codec.js';
+
+export function decodeCredentialLocator(value: unknown): CredentialLocator {
+  const base = exactRecord(
+    value,
+    'credential locator',
+    ['scope', 'connectionId', 'provider', 'kind'],
+    ['scope', 'kind'],
+  );
+  if (base.scope === 'connection') {
+    const item = exactRecord(value, 'connection credential locator', [
+      'scope',
+      'connectionId',
+      'kind',
+    ]);
+    if (item.kind !== 'api_key' && item.kind !== 'oauth_token') {
+      throw domainError('connection credential kind is invalid');
+    }
+    return {
+      scope: 'connection',
+      connectionId: entityIdValue(item.connectionId, 'connection id'),
+      kind: item.kind,
+    };
+  }
+  if (base.scope === 'web_search') {
+    const item = exactRecord(value, 'web search credential locator', ['scope', 'provider', 'kind']);
+    if (
+      item.kind !== 'api_key' ||
+      !(WEB_SEARCH_PROVIDERS as readonly unknown[]).includes(item.provider)
+    ) {
+      throw domainError('web search credential locator is invalid');
+    }
+    return {
+      scope: 'web_search',
+      provider: item.provider as Extract<CredentialLocator, { scope: 'web_search' }>['provider'],
+      kind: 'api_key',
+    };
+  }
+  if (base.scope === 'network_proxy') {
+    const item = exactRecord(value, 'network proxy credential locator', ['scope', 'kind']);
+    if (item.kind !== 'password') throw domainError('network proxy credential kind is invalid');
+    return { scope: 'network_proxy', kind: 'password' };
+  }
+  throw domainError('credential locator scope is invalid');
+}
+
+export function decodeCredentialVersionBasis(value: unknown): CredentialVersionBasis {
+  const item = exactRecord(value, 'credential basis', ['locator', 'credentialId', 'revision']);
+  return {
+    locator: decodeCredentialLocator(item.locator),
+    credentialId: entityIdValue(item.credentialId, 'credential id'),
+    revision: positiveRevisionValue(item.revision, 'credential revision'),
+  };
+}
+
+export function decodeCredentialStatus(value: unknown): CredentialStatus {
+  const item = exactRecord(value, 'credential status', [
+    'locator',
+    'configured',
+    'credentialId',
+    'revision',
+    'updatedAt',
+  ]);
+  if (item.configured === false) {
+    if (item.credentialId !== null || item.revision !== null || item.updatedAt !== null) {
+      throw domainError('unconfigured credential status must not carry version metadata');
+    }
+    return {
+      locator: decodeCredentialLocator(item.locator),
+      configured: false,
+      credentialId: null,
+      revision: null,
+      updatedAt: null,
+    };
+  }
+  if (item.configured === true) {
+    return {
+      locator: decodeCredentialLocator(item.locator),
+      configured: true,
+      credentialId: entityIdValue(item.credentialId, 'credential id'),
+      revision: positiveRevisionValue(item.revision, 'credential revision'),
+      updatedAt: integerValue(item.updatedAt, 'credential updatedAt', 0, Number.MAX_SAFE_INTEGER),
+    };
+  }
+  throw domainError('credential status configured flag is invalid');
+}
+
+export function normalizeSetCredentialInput(value: unknown): SetCredentialInput {
+  const input = exactRecord(value, 'set credential input', ['locator', 'expected', 'secret']);
+  let expected: SetCredentialInput['expected'];
+  if (input.expected === null) {
+    expected = null;
+  } else {
+    const basis = exactRecord(input.expected, 'set credential expected basis', [
+      'credentialId',
+      'revision',
+    ]);
+    expected = {
+      credentialId: entityIdValue(basis.credentialId, 'credential id'),
+      revision: positiveRevisionValue(basis.revision, 'credential revision'),
+    };
+  }
+  return {
+    locator: decodeCredentialLocator(input.locator),
+    expected,
+    secret: normalizeCredentialSecret(input.secret),
+  };
+}
+
+export function normalizeDeleteCredentialInput(value: unknown): DeleteCredentialInput {
+  const input = exactRecord(value, 'delete credential input', ['expected']);
+  return { expected: decodeCredentialVersionBasis(input.expected) };
+}
+
+export function normalizeCredentialSecret(value: unknown): string {
+  if (typeof value !== 'string' || value.length === 0) {
+    throw domainError('credential secret must be a non-empty string');
+  }
+  return value;
+}

--- a/packages/core/src/runtime-policy/domain-codec.ts
+++ b/packages/core/src/runtime-policy/domain-codec.ts
@@ -1,0 +1,117 @@
+import type { EntityId, Revision } from '../runtime-policy.js';
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+export class RuntimePolicyDomainDecodeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'RuntimePolicyDomainDecodeError';
+  }
+}
+
+export function exactRecord(
+  value: unknown,
+  context: string,
+  allowed: readonly string[],
+  required: readonly string[] = allowed,
+): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw domainError(`${context} must be an object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw domainError(`${context} must be a plain object`);
+  }
+  const item = value as Record<string, unknown>;
+  const allowedSet = new Set(allowed);
+  for (const key of Object.keys(item)) {
+    if (!allowedSet.has(key)) throw domainError(`${context} contains unknown field '${key}'`);
+  }
+  for (const key of required) {
+    if (!Object.hasOwn(item, key)) throw domainError(`${context} is missing '${key}'`);
+  }
+  return item;
+}
+
+export function booleanValue(value: unknown, context: string): boolean {
+  if (typeof value !== 'boolean') throw domainError(`${context} must be a boolean`);
+  return value;
+}
+
+export function integerValue(value: unknown, context: string, min: number, max: number): number {
+  if (!Number.isSafeInteger(value) || (value as number) < min || (value as number) > max) {
+    throw domainError(`${context} must be an integer between ${min} and ${max}`);
+  }
+  return value as number;
+}
+
+export function revisionValue(value: unknown, context: string): Revision {
+  return integerValue(value, context, 0, Number.MAX_SAFE_INTEGER);
+}
+
+export function positiveRevisionValue(value: unknown, context: string): Revision {
+  return integerValue(value, context, 1, Number.MAX_SAFE_INTEGER);
+}
+
+export function stringValue(value: unknown, context: string, maxLength: number): string {
+  if (typeof value !== 'string' || value.length > maxLength) {
+    throw domainError(`${context} must be a string no longer than ${maxLength} characters`);
+  }
+  return value;
+}
+
+export function nonEmptyStringValue(value: unknown, context: string, maxLength: number): string {
+  const parsed = stringValue(value, context, maxLength);
+  if (parsed.length === 0) throw domainError(`${context} must not be empty`);
+  return parsed;
+}
+
+export function stringArrayValue(value: unknown, context: string, maxEntries: number): string[] {
+  if (!Array.isArray(value) || value.length > maxEntries) {
+    throw domainError(`${context} must be a bounded string array`);
+  }
+  const parsed = value.map((item, index) => nonEmptyStringValue(item, `${context}[${index}]`, 512));
+  if (new Set(parsed).size !== parsed.length) {
+    throw domainError(`${context} values must be unique`);
+  }
+  return parsed;
+}
+
+export function entityIdValue(value: unknown, context: string): EntityId {
+  const parsed = nonEmptyStringValue(value, context, 64);
+  if (!UUID_PATTERN.test(parsed)) throw domainError(`${context} must be a UUID`);
+  return parsed;
+}
+
+export function assertCanonicalValue(original: unknown, canonical: unknown, context: string): void {
+  if (!sameValue(original, canonical)) throw domainError(`${context} must be canonical`);
+}
+
+export function domainError(message: string): RuntimePolicyDomainDecodeError {
+  return new RuntimePolicyDomainDecodeError(message);
+}
+
+function sameValue(left: unknown, right: unknown): boolean {
+  if (Object.is(left, right)) return true;
+  if (left === null || right === null || typeof left !== 'object' || typeof right !== 'object') {
+    return false;
+  }
+  if (Array.isArray(left) || Array.isArray(right)) {
+    return (
+      Array.isArray(left) &&
+      Array.isArray(right) &&
+      left.length === right.length &&
+      left.every((value, index) => sameValue(value, right[index]))
+    );
+  }
+  const leftRecord = left as Record<string, unknown>;
+  const rightRecord = right as Record<string, unknown>;
+  const leftKeys = Object.keys(leftRecord);
+  const rightKeys = Object.keys(rightRecord);
+  return (
+    leftKeys.length === rightKeys.length &&
+    leftKeys.every(
+      (key) => Object.hasOwn(rightRecord, key) && sameValue(leftRecord[key], rightRecord[key]),
+    )
+  );
+}

--- a/packages/core/src/runtime-policy/policy-codec.ts
+++ b/packages/core/src/runtime-policy/policy-codec.ts
@@ -1,0 +1,158 @@
+import { CHAT_DEFAULT_PERMISSION_MODES } from '../settings.js';
+import type {
+  MutateRuntimePolicyInput,
+  RuntimePolicy,
+  RuntimePolicyMutation,
+} from '../runtime-policy.js';
+import { WEB_SEARCH_PROVIDERS } from '../web-search.js';
+import {
+  assertCanonicalValue,
+  booleanValue,
+  domainError,
+  exactRecord,
+  integerValue,
+  revisionValue,
+  stringArrayValue,
+  stringValue,
+} from './domain-codec.js';
+
+export function decodeCanonicalRuntimePolicy(value: unknown): RuntimePolicy {
+  const decoded = normalizeRuntimePolicy(value);
+  assertCanonicalValue(value, decoded, 'runtime policy');
+  return decoded;
+}
+
+export function normalizeRuntimePolicyMutation(value: unknown): MutateRuntimePolicyInput {
+  const input = exactRecord(value, 'runtime policy mutation', ['expectedRevision', 'operation']);
+  const operation = exactRecord(input.operation, 'runtime policy operation', ['kind', 'value']);
+  return {
+    expectedRevision: revisionValue(input.expectedRevision, 'runtime policy expected revision'),
+    operation: normalizeMutationOperation(operation),
+  };
+}
+
+function normalizeRuntimePolicy(value: unknown): RuntimePolicy {
+  const policy = exactRecord(value, 'runtime policy', [
+    'networkProxy',
+    'personalization',
+    'memory',
+    'workspaceInstructions',
+    'privacy',
+    'chatDefaults',
+    'webSearch',
+  ]);
+  return {
+    networkProxy: normalizeNetworkProxy(policy.networkProxy),
+    personalization: normalizePersonalization(policy.personalization),
+    memory: normalizeMemory(policy.memory),
+    workspaceInstructions: normalizeWorkspaceInstructions(policy.workspaceInstructions),
+    privacy: normalizePrivacy(policy.privacy),
+    chatDefaults: normalizeChatDefaults(policy.chatDefaults),
+    webSearch: normalizeWebSearch(policy.webSearch),
+  };
+}
+
+function normalizeMutationOperation(operation: Record<string, unknown>): RuntimePolicyMutation {
+  switch (operation.kind) {
+    case 'set_network_proxy':
+      return { kind: operation.kind, value: normalizeNetworkProxy(operation.value) };
+    case 'set_personalization':
+      return { kind: operation.kind, value: normalizePersonalization(operation.value) };
+    case 'set_memory':
+      return { kind: operation.kind, value: normalizeMemory(operation.value) };
+    case 'set_workspace_instructions':
+      return { kind: operation.kind, value: normalizeWorkspaceInstructions(operation.value) };
+    case 'set_privacy':
+      return { kind: operation.kind, value: normalizePrivacy(operation.value) };
+    case 'set_chat_defaults':
+      return { kind: operation.kind, value: normalizeChatDefaults(operation.value) };
+    case 'set_web_search':
+      return { kind: operation.kind, value: normalizeWebSearch(operation.value) };
+    default:
+      throw domainError(`runtime policy operation '${String(operation.kind)}' is unknown`);
+  }
+}
+
+function normalizeNetworkProxy(value: unknown): RuntimePolicy['networkProxy'] {
+  const item = exactRecord(value, 'network proxy', [
+    'enabled',
+    'protocol',
+    'host',
+    'port',
+    'authEnabled',
+    'username',
+    'bypassList',
+    'autoBypassDomains',
+  ]);
+  const enabled = booleanValue(item.enabled, 'network proxy enabled');
+  const rawHost = stringValue(item.host, 'network proxy host', 255);
+  if (/[\u0000-\u001f\u007f-\u009f]/.test(rawHost)) {
+    throw domainError('network proxy host must not contain control characters');
+  }
+  const host = rawHost.trim();
+  if (enabled && host.length === 0) {
+    throw domainError('network proxy host must not be empty when enabled');
+  }
+  if (item.protocol !== 'http' && item.protocol !== 'https' && item.protocol !== 'socks5') {
+    throw domainError('network proxy protocol is invalid');
+  }
+  return {
+    enabled,
+    protocol: item.protocol,
+    host,
+    port: integerValue(item.port, 'network proxy port', 1, 65_535),
+    authEnabled: booleanValue(item.authEnabled, 'network proxy authEnabled'),
+    username: stringValue(item.username, 'network proxy username', 256),
+    bypassList: stringArrayValue(item.bypassList, 'network proxy bypassList', 256),
+    autoBypassDomains: stringArrayValue(
+      item.autoBypassDomains,
+      'network proxy autoBypassDomains',
+      256,
+    ),
+  };
+}
+
+function normalizePersonalization(value: unknown): RuntimePolicy['personalization'] {
+  const item = exactRecord(value, 'personalization', ['displayName', 'assistantTone']);
+  return {
+    displayName: stringValue(item.displayName, 'personalization displayName', 256),
+    assistantTone: stringValue(item.assistantTone, 'personalization assistantTone', 4_096),
+  };
+}
+
+function normalizeMemory(value: unknown): RuntimePolicy['memory'] {
+  const item = exactRecord(value, 'memory policy', ['enabled', 'agentReadEnabled']);
+  return {
+    enabled: booleanValue(item.enabled, 'memory enabled'),
+    agentReadEnabled: booleanValue(item.agentReadEnabled, 'memory agentReadEnabled'),
+  };
+}
+
+function normalizeWorkspaceInstructions(value: unknown): RuntimePolicy['workspaceInstructions'] {
+  const item = exactRecord(value, 'workspace instructions policy', ['enabled']);
+  return { enabled: booleanValue(item.enabled, 'workspace instructions enabled') };
+}
+
+function normalizePrivacy(value: unknown): RuntimePolicy['privacy'] {
+  const item = exactRecord(value, 'privacy policy', ['incognitoActive']);
+  return { incognitoActive: booleanValue(item.incognitoActive, 'privacy incognitoActive') };
+}
+
+function normalizeChatDefaults(value: unknown): RuntimePolicy['chatDefaults'] {
+  const item = exactRecord(value, 'chat defaults', ['permissionMode']);
+  if (!(CHAT_DEFAULT_PERMISSION_MODES as readonly unknown[]).includes(item.permissionMode)) {
+    throw domainError('chat default permission mode is invalid');
+  }
+  return { permissionMode: item.permissionMode as RuntimePolicy['chatDefaults']['permissionMode'] };
+}
+
+function normalizeWebSearch(value: unknown): RuntimePolicy['webSearch'] {
+  const item = exactRecord(value, 'web search policy', ['enabled', 'defaultProvider']);
+  if (!(WEB_SEARCH_PROVIDERS as readonly unknown[]).includes(item.defaultProvider)) {
+    throw domainError('web search default provider is invalid');
+  }
+  return {
+    enabled: booleanValue(item.enabled, 'web search enabled'),
+    defaultProvider: item.defaultProvider as RuntimePolicy['webSearch']['defaultProvider'],
+  };
+}

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -19,7 +19,10 @@ import {
 } from '../protocol/index.js';
 import { RuntimeHostKernel, type RuntimeHostComposition } from '../server/index.js';
 import { RuntimeHostConnectionSession } from '../server/connection-session.js';
-import type { OperationHandlerMap } from '../server/operation-dispatcher.js';
+import {
+  createUnavailableDomainOperationHandlers,
+  type OperationHandlerMap,
+} from '../server/operation-dispatcher.js';
 import {
   BoundedSerialOutboundWriter,
   RuntimeHostOutboundQueueError,
@@ -718,6 +721,7 @@ function closeServer(server: Server): Promise<void> {
 
 function createHandlers(queryTurn: TurnQueryHandler): RuntimeHostComposition['handlers'] {
   return {
+    ...createUnavailableDomainOperationHandlers(),
     'turn.start': async (input) => ({
       ok: true,
       result: runningSnapshot(input.sessionId, input.turnId),

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -25,14 +25,16 @@ const allowedHostExternalImports = new Set([
 const allowedServerExternalImports = new Set([
   ...allowedHostExternalImports,
   '@maka/core/agent-run',
+  '@maka/core/runtime-policy',
   '@maka/core/runtime-event',
   '@maka/core/session',
   '@maka/runtime',
   '@maka/storage/execution-stores',
+  '@maka/storage/runtime-policy-stores',
 ]);
 const allowedExternalImports = {
   client: allowedHostExternalImports,
-  protocol: new Set(['node:util']),
+  protocol: new Set(['@maka/core/runtime-policy', 'node:util']),
 } as const;
 
 async function dependencyScannerFixture(target: string): Promise<void> {
@@ -80,7 +82,11 @@ test('protocol and client stay within their subpaths and the root-authority boun
           if (!isInside(sourceRoot, target)) violations.push(`${path}: ${specifier}`);
           continue;
         }
-        if (!allowedExternalImports[area].has(specifier)) violations.push(`${path}: ${specifier}`);
+        const allowedImports =
+          topLevelArea === 'protocol'
+            ? allowedExternalImports.protocol
+            : allowedExternalImports[area];
+        if (!allowedImports.has(specifier)) violations.push(`${path}: ${specifier}`);
       }
     }
   }
@@ -96,7 +102,9 @@ test('only the server subgraph can reach the M2 Runtime composition', async () =
     const allowedImports =
       topLevelArea === 'server' || localPath === 'candidate-main.ts'
         ? allowedServerExternalImports
-        : allowedHostExternalImports;
+        : topLevelArea === 'protocol'
+          ? allowedExternalImports.protocol
+          : allowedHostExternalImports;
     for (const specifier of moduleSpecifiers(path)) {
       if (isRelativeSpecifier(specifier)) {
         const target = sourcePathForSpecifier(path, specifier);
@@ -116,13 +124,18 @@ test('the production Candidate dependency graph remains non-serving', () => {
     'server/execution-candidate.ts',
     'server/execution-composition.ts',
     'server/root-turn-coordinator.ts',
+    'server/runtime-policy-coordinator.ts',
   ]);
   const violations: string[] = [];
   for (const path of reached) {
     const localPath = relative(sourceRoot, path);
     if (forbiddenLocalModules.has(localPath)) violations.push(localPath);
     for (const specifier of moduleSpecifiers(path)) {
-      if (specifier === '@maka/runtime' || specifier === '@maka/storage/execution-stores') {
+      if (
+        specifier === '@maka/runtime' ||
+        specifier === '@maka/storage/execution-stores' ||
+        specifier === '@maka/storage/runtime-policy-stores'
+      ) {
         violations.push(`${localPath}: ${specifier}`);
       }
     }

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -40,6 +40,45 @@ const CURRENT_PROTOCOL = {
 } as const;
 const PROCESS_TIMEOUT_MS = 10_000;
 
+test('two UDS Clients share one Runtime Policy authority and CAS winner', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const host = await fixture.startHost();
+    const first = await connectClient(fixture.root, 'desktop');
+    const second = await connectClient(fixture.root, 'tui');
+    try {
+      const initial = await first.request('runtime.policy.query', {});
+      assert.deepEqual(await second.request('runtime.policy.query', {}), initial);
+      const outcomes = await Promise.all([
+        first.request('runtime.policy.mutate', {
+          expectedRevision: initial.revision,
+          operation: {
+            kind: 'set_personalization',
+            value: { displayName: 'Desktop', assistantTone: 'precise' },
+          },
+        }),
+        second.request('runtime.policy.mutate', {
+          expectedRevision: initial.revision,
+          operation: {
+            kind: 'set_memory',
+            value: { enabled: false, agentReadEnabled: false },
+          },
+        }),
+      ]);
+      assert.deepEqual(outcomes.map((outcome) => outcome.kind).sort(), [
+        'committed',
+        'revision_conflict',
+      ]);
+      assert.deepEqual(
+        await first.request('runtime.policy.query', {}),
+        await second.request('runtime.policy.query', {}),
+      );
+    } finally {
+      await Promise.allSettled([first.close(), second.close()]);
+      await fixture.stopHost(host);
+    }
+  });
+});
+
 test('two Clients share one execution after the starting Client disconnects', async () => {
   await withExecutionRoot(async (fixture) => {
     const host = await fixture.startHost();

--- a/packages/runtime-host/src/__tests__/fixtures/uncooperative-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/uncooperative-host.ts
@@ -3,6 +3,7 @@ import {
   tryAcquireInteractiveRootOwner,
 } from '@maka/storage/root-authority';
 import { RuntimeHostKernel, type RuntimeHostComposition } from '../../server/host-kernel.js';
+import { createUnavailableDomainOperationHandlers } from '../../server/operation-dispatcher.js';
 import { runRuntimeHostProcessLifecycle } from '../../server/process-lifecycle.js';
 
 const [rootPath, expectedRootId, shutdownGraceRaw] = process.argv.slice(2);
@@ -28,6 +29,7 @@ const host = await RuntimeHostKernel.start({
   shutdownGraceMs,
   compositionFactory: async (context): Promise<RuntimeHostComposition> => ({
     handlers: {
+      ...createUnavailableDomainOperationHandlers(),
       'turn.start': async () => {
         context.acquireResidency();
         process.send?.({ type: 'operation-blocked' });

--- a/packages/runtime-host/src/__tests__/host-kernel.test.ts
+++ b/packages/runtime-host/src/__tests__/host-kernel.test.ts
@@ -40,6 +40,7 @@ import {
   type RuntimeHostCandidateOptions,
   type RuntimeHostCandidateResult,
 } from '../server/index.js';
+import { createUnavailableDomainOperationHandlers } from '../server/operation-dispatcher.js';
 import { FramedTransport, RuntimeHostTransportError } from '../transport/framed-transport.js';
 import {
   prepareStorageRootControlDirectory,
@@ -131,6 +132,7 @@ describe('non-serving Runtime Host kernel', () => {
           await factoryReleased;
           return {
             handlers: {
+              ...createUnavailableDomainOperationHandlers(),
               'turn.start': unavailable,
               'turn.query': unavailable,
               'turn.stop': unavailable,

--- a/packages/runtime-host/src/__tests__/operation-dispatcher.test.ts
+++ b/packages/runtime-host/src/__tests__/operation-dispatcher.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'node:test';
 import type { OperationKey, OperationOutcome, RequestFrame } from '../protocol/index.js';
 import {
   composeOperationHandlers,
+  createUnavailableDomainOperationHandlers,
   dispatchOperation,
   type ConnectionContext,
   type OperationHandlerMap,
@@ -118,9 +119,7 @@ function validHandlers(): OperationHandlerMap {
     }) as OperationOutcome<K>;
   return {
     'host.status': unavailable,
-    'turn.start': unavailable,
-    'turn.query': unavailable,
-    'turn.stop': unavailable,
+    ...createUnavailableDomainOperationHandlers(),
   };
 }
 

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -3,9 +3,11 @@ import { describe, test } from 'node:test';
 import {
   decodeClientFrame,
   decodeHostFrame,
+  HOST_OPERATION_SPECS,
   negotiateProtocol,
   ProtocolFrameDecoder,
   RUNTIME_HOST_MAX_FRAME_BYTES,
+  RUNTIME_POLICY_OPERATION_SPECS,
   RuntimeHostProtocolError,
 } from '../protocol/index.js';
 import { HOST_STATUS_OPERATION_SPECS } from '../protocol/host-status.js';
@@ -16,6 +18,97 @@ describe('Runtime Host bootstrap protocol', () => {
     assert.equal(negotiateProtocol({ min: 0, max: 0 }, { min: 0, max: 0 }), 0);
     assert.equal(negotiateProtocol({ min: 1, max: 3 }, { min: 2, max: 4 }), 3);
     assert.equal(negotiateProtocol({ min: 0, max: 0 }, { min: 1, max: 1 }), undefined);
+  });
+
+  test('declares exactly the ten Runtime Policy operations in the current framework', () => {
+    const queries = [
+      'runtime.policy.query',
+      'connection.catalog.query',
+      'credential.vault.query',
+    ] as const;
+    const mutations = [
+      'runtime.policy.mutate',
+      'connection.catalog.create',
+      'connection.catalog.update',
+      'connection.catalog.remove',
+      'connection.catalog.set-default-target',
+      'credential.vault.set',
+      'credential.vault.delete',
+    ] as const;
+    assert.deepEqual(
+      Object.keys(RUNTIME_POLICY_OPERATION_SPECS).sort(),
+      [...queries, ...mutations].sort(),
+    );
+    for (const operation of queries) {
+      assert.equal(RUNTIME_POLICY_OPERATION_SPECS[operation].mode, 'query');
+      assert.equal(RUNTIME_POLICY_OPERATION_SPECS[operation].availability, 'ready');
+      assert.ok(RUNTIME_POLICY_OPERATION_SPECS[operation].errors.includes('persistence_failed'));
+      assert.ok(RUNTIME_POLICY_OPERATION_SPECS[operation].errors.includes('internal_failure'));
+    }
+    for (const operation of mutations) {
+      assert.equal(RUNTIME_POLICY_OPERATION_SPECS[operation].mode, 'command');
+      assert.equal(RUNTIME_POLICY_OPERATION_SPECS[operation].availability, 'ready');
+      assert.ok(RUNTIME_POLICY_OPERATION_SPECS[operation].errors.includes('invalid_request'));
+      assert.ok(RUNTIME_POLICY_OPERATION_SPECS[operation].errors.includes('persistence_failed'));
+      assert.ok(
+        RUNTIME_POLICY_OPERATION_SPECS[operation].errors.includes('commit_outcome_unknown'),
+      );
+      assert.ok(RUNTIME_POLICY_OPERATION_SPECS[operation].errors.includes('internal_failure'));
+    }
+  });
+
+  test('keeps Runtime Policy request and response codecs exact', () => {
+    assert.deepEqual(
+      decodeClientFrame({
+        requestId: 'policy-query',
+        operation: 'runtime.policy.query',
+        input: {},
+      }),
+      {
+        requestId: 'policy-query',
+        operation: 'runtime.policy.query',
+        input: {},
+      },
+    );
+    assert.throws(
+      () =>
+        decodeClientFrame({
+          requestId: 'policy-query-extra',
+          operation: 'runtime.policy.query',
+          input: { secret: 'must-not-cross-wire' },
+        }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          requestId: 'credential-status-secret',
+          operation: 'credential.vault.query',
+          ok: true,
+          result: {
+            kind: 'status',
+            status: {
+              locator: { scope: 'network_proxy', kind: 'password' },
+              configured: false,
+              credentialId: null,
+              revision: null,
+              updatedAt: null,
+              secret: 'must-not-cross-wire',
+            },
+          },
+        }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () =>
+        decodeHostFrame({
+          requestId: 'undeclared-error',
+          operation: 'runtime.policy.query',
+          ok: false,
+          error: { code: 'commit_outcome_unknown', message: 'not declared for query' },
+        }),
+      isInvalidFrame,
+    );
   });
 
   test('decodes split UTF-8 and multiple newline-delimited frames without an unbounded tail', () => {

--- a/packages/runtime-host/src/__tests__/runtime-policy-activation-gate.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-policy-activation-gate.test.ts
@@ -1,0 +1,141 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation-gate.js';
+
+const POISONED_MESSAGE = 'Runtime policy activation is poisoned';
+
+test('backend activations run concurrently while a mutation waits and blocks a later activation', async () => {
+  const gate = new RuntimePolicyActivationGate();
+  const firstEntered = deferred();
+  const secondEntered = deferred();
+  const releaseStarts = deferred();
+  const mutationEntered = deferred();
+  const releaseMutation = deferred();
+  const laterStartEntered = deferred();
+  let mutationHasEntered = false;
+  let laterStartHasEntered = false;
+
+  const firstStart = gate.runBackendActivation(async () => {
+    firstEntered.resolve();
+    await releaseStarts.promise;
+  });
+  const secondStart = gate.runBackendActivation(async () => {
+    secondEntered.resolve();
+    await releaseStarts.promise;
+  });
+
+  await Promise.all([firstEntered.promise, secondEntered.promise]);
+
+  const mutation = gate.runMutation(async () => {
+    mutationHasEntered = true;
+    mutationEntered.resolve();
+    await releaseMutation.promise;
+  });
+  const laterStart = gate.runBackendActivation(() => {
+    laterStartHasEntered = true;
+    laterStartEntered.resolve();
+  });
+
+  assert.equal(mutationHasEntered, false);
+  assert.equal(laterStartHasEntered, false);
+
+  releaseStarts.resolve();
+  await mutationEntered.promise;
+  assert.equal(laterStartHasEntered, false);
+
+  releaseMutation.resolve();
+  await laterStartEntered.promise;
+  await Promise.all([firstStart, secondStart, mutation, laterStart]);
+});
+
+test('a failed mutation releases backend activations and the next mutation', async () => {
+  const gate = new RuntimePolicyActivationGate();
+  const expected = new Error('injected mutation failure');
+  const firstEntered = deferred();
+  const releaseFirst = deferred();
+  const laterStartEntered = deferred();
+  const nextMutationEntered = deferred();
+
+  const firstMutation = gate.runMutation(async () => {
+    firstEntered.resolve();
+    await releaseFirst.promise;
+    throw expected;
+  });
+  await firstEntered.promise;
+
+  const laterStart = gate.runBackendActivation(() => {
+    laterStartEntered.resolve();
+  });
+  const nextMutation = gate.runMutation(() => {
+    nextMutationEntered.resolve();
+  });
+  const failed = assert.rejects(firstMutation, expected);
+
+  releaseFirst.resolve();
+  await failed;
+  await Promise.all([laterStartEntered.promise, nextMutationEntered.promise]);
+  await Promise.all([laterStart, nextMutation]);
+});
+
+test('poison preserves an executing mutation outcome and closes queued and later work', async () => {
+  const gate = new RuntimePolicyActivationGate();
+  const mutationEntered = deferred();
+  const releaseMutation = deferred();
+  let queuedStartEntered = false;
+  let queuedMutationEntered = false;
+  let laterStartEntered = false;
+  let laterMutationEntered = false;
+
+  const activeMutation = gate.runMutation(async () => {
+    mutationEntered.resolve();
+    await releaseMutation.promise;
+    return { kind: 'committed' as const, revision: 7 };
+  });
+  await mutationEntered.promise;
+
+  const queuedStart = gate.runBackendActivation(() => {
+    queuedStartEntered = true;
+  });
+  const queuedMutation = gate.runMutation(() => {
+    queuedMutationEntered = true;
+  });
+  const queuedStartRejected = assert.rejects(queuedStart, { message: POISONED_MESSAGE });
+  const queuedMutationRejected = assert.rejects(queuedMutation, { message: POISONED_MESSAGE });
+
+  gate.poison();
+  gate.poison();
+  releaseMutation.resolve();
+
+  assert.deepEqual(await activeMutation, { kind: 'committed', revision: 7 });
+  await Promise.all([queuedStartRejected, queuedMutationRejected]);
+  assert.equal(queuedStartEntered, false);
+  assert.equal(queuedMutationEntered, false);
+
+  await assert.rejects(
+    gate.runBackendActivation(() => {
+      laterStartEntered = true;
+    }),
+    { message: POISONED_MESSAGE },
+  );
+  await assert.rejects(
+    gate.runMutation(() => {
+      laterMutationEntered = true;
+    }),
+    { message: POISONED_MESSAGE },
+  );
+  assert.equal(laterStartEntered, false);
+  assert.equal(laterMutationEntered, false);
+});
+
+interface Deferred {
+  readonly promise: Promise<void>;
+  resolve(): void;
+}
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}

--- a/packages/runtime-host/src/__tests__/runtime-policy-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-policy-coordinator.test.ts
@@ -1,0 +1,631 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, open, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { mock, test } from 'node:test';
+import type {
+  ConnectionCatalogEntryDraft,
+  ConnectionCatalogSnapshot,
+  CredentialLocator,
+} from '@maka/core/runtime-policy';
+import { FAKE_ASK_USER_QUESTION_PROMPT } from '@maka/runtime';
+import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
+import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import {
+  CONNECTION_CATALOG_PAGE_MAX_BYTES,
+  CONNECTION_CATALOG_PAGE_MAX_ITEMS,
+  type ConnectionCatalogPageItem,
+} from '../protocol/index.js';
+import { createExecutionRuntimeHostComposition } from '../server/execution-composition.js';
+import type { ConnectionContext } from '../server/operation-dispatcher.js';
+import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation-gate.js';
+import { HostRuntimePolicyCoordinator } from '../server/runtime-policy-coordinator.js';
+
+const context: ConnectionContext = {
+  hostEpoch: 'runtime-policy-test-epoch',
+  connectionId: 'runtime-policy-test-connection',
+  surface: 'desktop',
+  principal: 'local_os_user',
+  acquireResidency: () => ({ release: () => undefined }),
+};
+
+test('production composition shares one gate across mutation and backend activation', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-runtime-policy-composition-'));
+  const root = join(base, 'interactive');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+
+  const mutationGates: RuntimePolicyActivationGate[] = [];
+  const backendActivationGates: RuntimePolicyActivationGate[] = [];
+  const originalRunMutation = RuntimePolicyActivationGate.prototype.runMutation;
+  const originalRunBackendActivation = RuntimePolicyActivationGate.prototype.runBackendActivation;
+  const mutationSpy = mock.method(RuntimePolicyActivationGate.prototype, 'runMutation', function <
+    T,
+  >(this: RuntimePolicyActivationGate, operation: () => Promise<T> | T): Promise<T> {
+    mutationGates.push(this);
+    return Reflect.apply(originalRunMutation, this, [operation]) as Promise<T>;
+  });
+  const backendActivationSpy = mock.method(
+    RuntimePolicyActivationGate.prototype,
+    'runBackendActivation',
+    function <T>(this: RuntimePolicyActivationGate, operation: () => Promise<T> | T): Promise<T> {
+      backendActivationGates.push(this);
+      return Reflect.apply(originalRunBackendActivation, this, [operation]) as Promise<T>;
+    },
+  );
+  let composition: Awaited<ReturnType<typeof createExecutionRuntimeHostComposition>> | undefined;
+  try {
+    const setupStores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const session = await setupStores.sessionStore.create({
+      cwd: root,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    await setupStores.sessionStore.close?.();
+
+    composition = await createExecutionRuntimeHostComposition({
+      owner,
+      acquireResidency: context.acquireResidency,
+      requestDrain: () => undefined,
+    });
+    await composition.recover();
+
+    const initial = await composition.handlers['runtime.policy.query']({}, context);
+    assert.equal(initial.ok, true);
+    if (!initial.ok) return;
+    const turnId = randomUUID();
+    const [mutated, started] = await Promise.all([
+      composition.handlers['runtime.policy.mutate'](
+        {
+          expectedRevision: initial.result.revision,
+          operation: {
+            kind: 'set_memory',
+            value: { enabled: false, agentReadEnabled: false },
+          },
+        },
+        context,
+      ),
+      composition.handlers['turn.start'](
+        {
+          sessionId: session.id,
+          turnId,
+          text: FAKE_ASK_USER_QUESTION_PROMPT,
+        },
+        context,
+      ),
+    ]);
+
+    assert.equal(mutated.ok, true);
+    assert.equal(started.ok, true);
+    assert.equal(mutationGates.length, 1);
+    assert.equal(backendActivationGates.length, 1);
+    assert.equal(mutationGates[0], backendActivationGates[0]);
+    if (started.ok) {
+      await composition.handlers['turn.stop'](
+        { sessionId: session.id, turnId, runId: started.result.runId },
+        context,
+      );
+    }
+  } finally {
+    mutationSpy.mock.restore();
+    backendActivationSpy.mock.restore();
+    try {
+      await composition?.close();
+    } finally {
+      try {
+        await owner.close();
+      } finally {
+        await rm(base, { recursive: true, force: true });
+      }
+    }
+  }
+});
+
+test('projects runtime policy CAS results without returning the committed snapshot', async () => {
+  let invalidations = 0;
+  await withCoordinator(async ({ stores }) => {
+    const coordinator = new HostRuntimePolicyCoordinator(
+      stores,
+      new RuntimePolicyActivationGate(),
+      async () => {
+        invalidations += 1;
+      },
+    );
+    const initial = await coordinator.handlers['runtime.policy.query']({}, context);
+    assert.equal(initial.ok, true);
+    if (!initial.ok) return;
+
+    const committed = await coordinator.handlers['runtime.policy.mutate'](
+      {
+        expectedRevision: initial.result.revision,
+        operation: {
+          kind: 'set_personalization',
+          value: { displayName: 'Runtime Host', assistantTone: 'precise' },
+        },
+      },
+      context,
+    );
+    assert.deepEqual(committed, { ok: true, result: { kind: 'committed', revision: 1 } });
+    assert.equal(invalidations, 1);
+
+    const conflict = await coordinator.handlers['runtime.policy.mutate'](
+      {
+        expectedRevision: initial.result.revision,
+        operation: {
+          kind: 'set_memory',
+          value: { enabled: false, agentReadEnabled: false },
+        },
+      },
+      context,
+    );
+    assert.deepEqual(conflict, {
+      ok: true,
+      result: { kind: 'revision_conflict', expectedRevision: 0, actualRevision: 1 },
+    });
+    assert.equal(invalidations, 1);
+  });
+});
+
+test('awaits committed mutation invalidation before returning the outcome', async () => {
+  await withCoordinator(async ({ stores }) => {
+    let releaseInvalidation!: () => void;
+    const invalidation = new Promise<void>((resolve) => {
+      releaseInvalidation = resolve;
+    });
+    const coordinator = new HostRuntimePolicyCoordinator(
+      stores,
+      new RuntimePolicyActivationGate(),
+      () => invalidation,
+    );
+    let settled = false;
+    const mutation = coordinator.handlers['runtime.policy.mutate'](
+      {
+        expectedRevision: 0,
+        operation: {
+          kind: 'set_memory',
+          value: { enabled: false, agentReadEnabled: false },
+        },
+      },
+      context,
+    );
+    void mutation.finally(() => {
+      settled = true;
+    });
+
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(settled, false);
+    releaseInvalidation();
+    assert.deepEqual(await mutation, {
+      ok: true,
+      result: { kind: 'committed', revision: 1 },
+    });
+  });
+});
+
+test('preserves a committed mutation outcome when invalidation fails', async () => {
+  await withCoordinator(async ({ stores }) => {
+    let invalidations = 0;
+    const coordinator = new HostRuntimePolicyCoordinator(
+      stores,
+      new RuntimePolicyActivationGate(),
+      async () => {
+        invalidations += 1;
+        throw new Error('injected invalidation failure after commit');
+      },
+    );
+
+    assert.deepEqual(
+      await coordinator.handlers['runtime.policy.mutate'](
+        {
+          expectedRevision: 0,
+          operation: {
+            kind: 'set_memory',
+            value: { enabled: false, agentReadEnabled: false },
+          },
+        },
+        context,
+      ),
+      { ok: true, result: { kind: 'committed', revision: 1 } },
+    );
+    assert.equal(invalidations, 1);
+    assert.equal((await stores.runtimePolicy.getSnapshot()).revision, 1);
+    await assert.rejects(() =>
+      coordinator.handlers['runtime.policy.mutate'](
+        {
+          expectedRevision: 1,
+          operation: {
+            kind: 'set_memory',
+            value: { enabled: true, agentReadEnabled: true },
+          },
+        },
+        context,
+      ),
+    );
+    assert.equal((await stores.runtimePolicy.getSnapshot()).revision, 1);
+  });
+});
+
+test('invalidates when a real published mutation loses its commit reply', {
+  skip: process.platform === 'win32',
+}, async () => {
+  await withCoordinator(async ({ stores, root }) => {
+    let invalidations = 0;
+    const coordinator = new HostRuntimePolicyCoordinator(
+      stores,
+      new RuntimePolicyActivationGate(),
+      async () => {
+        invalidations += 1;
+        throw new Error('injected invalidation failure after unknown commit');
+      },
+    );
+    const probe = await open(root, 'r');
+    const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+      sync: typeof probe.sync;
+    };
+    const originalSync = fileHandlePrototype.sync;
+    await probe.close();
+    let syncCalls = 0;
+    const syncMock = mock.method(fileHandlePrototype, 'sync', async function (this: typeof probe) {
+      syncCalls += 1;
+      if (syncCalls === 2) throw new Error('injected directory sync reply loss');
+      return originalSync.call(this);
+    });
+
+    const outcome = await (async () => {
+      try {
+        return await coordinator.handlers['runtime.policy.mutate'](
+          {
+            expectedRevision: 0,
+            operation: {
+              kind: 'set_personalization',
+              value: { displayName: 'Published', assistantTone: 'unknown-reply' },
+            },
+          },
+          context,
+        );
+      } finally {
+        syncMock.mock.restore();
+      }
+    })();
+
+    assert.deepEqual(outcome, {
+      ok: false,
+      error: {
+        code: 'commit_outcome_unknown',
+        message: 'Runtime policy commit outcome is unknown',
+      },
+    });
+    assert.equal(syncCalls, 2);
+    assert.equal(invalidations, 1);
+    const published = await stores.runtimePolicy.getSnapshot();
+    assert.equal(published.revision, 1);
+    assert.deepEqual(published.policy.personalization, {
+      displayName: 'Published',
+      assistantTone: 'unknown-reply',
+    });
+  });
+});
+
+test('credential control-plane results never retain or expose secret material', async () => {
+  await withCoordinator(async ({ coordinator }) => {
+    const locator: CredentialLocator = { scope: 'network_proxy', kind: 'password' };
+    const secret = 'runtime-host-secret-that-must-not-escape';
+    const set = await coordinator.handlers['credential.vault.set'](
+      { locator, expected: null, secret },
+      context,
+    );
+    assert.equal(set.ok, true);
+    if (!set.ok || set.result.kind !== 'committed') return;
+    assert.equal(set.result.status.configured, true);
+    assert.equal(JSON.stringify(set).includes(secret), false);
+
+    const queried = await coordinator.handlers['credential.vault.query']({ locator }, context);
+    assert.equal(queried.ok, true);
+    if (!queried.ok || queried.result.kind !== 'status') return;
+    assert.deepEqual(queried.result.status, set.result.status);
+    assert.equal(JSON.stringify(queried).includes(secret), false);
+    if (!queried.result.status.configured) return;
+
+    const deleted = await coordinator.handlers['credential.vault.delete'](
+      {
+        expected: {
+          locator,
+          credentialId: queried.result.status.credentialId,
+          revision: queried.result.status.revision,
+        },
+      },
+      context,
+    );
+    assert.equal(deleted.ok, true);
+    if (!deleted.ok || deleted.result.kind !== 'committed') return;
+    assert.deepEqual(deleted.result.status, {
+      locator,
+      configured: false,
+      credentialId: null,
+      revision: null,
+      updatedAt: null,
+    });
+    assert.equal(JSON.stringify(deleted).includes(secret), false);
+  });
+});
+
+test('projects state-dependent OAuth endpoint overrides as invalid requests', async () => {
+  await withCoordinator(async ({ coordinator, stores }) => {
+    const created = await stores.connectionCatalog.create({
+      expectedCatalogRevision: 0,
+      connection: {
+        slug: 'github-copilot',
+        name: 'GitHub Copilot',
+        providerType: 'github-copilot',
+        enabled: true,
+        enabledModelIds: [],
+      },
+    });
+    assert.equal(created.kind, 'committed');
+    if (created.kind !== 'committed') return;
+    const connection = created.snapshot.connections[0];
+    assert.ok(connection);
+    if (!connection) return;
+
+    const updated = await coordinator.handlers['connection.catalog.update'](
+      {
+        expected: { connectionId: connection.connectionId, revision: connection.revision },
+        changes: {
+          name: connection.name,
+          baseUrl: 'https://copilot.example.test/v1',
+          enabled: connection.enabled,
+          enabledModelIds: connection.enabledModelIds,
+        },
+      },
+      context,
+    );
+
+    assert.deepEqual(updated, {
+      ok: false,
+      error: {
+        code: 'invalid_request',
+        message: 'Runtime policy mutation is invalid for the current state',
+      },
+    });
+  });
+});
+
+test('returns connection_not_found when deleting a credential after its connection is removed', async () => {
+  await withCoordinator(async ({ coordinator, stores }) => {
+    const created = await stores.connectionCatalog.create({
+      expectedCatalogRevision: 0,
+      connection: {
+        slug: 'credential-owner',
+        name: 'Credential owner',
+        providerType: 'openai',
+        enabled: true,
+        enabledModelIds: [],
+      },
+    });
+    assert.equal(created.kind, 'committed');
+    if (created.kind !== 'committed') return;
+    const connection = created.snapshot.connections[0];
+    assert.ok(connection);
+    if (!connection) return;
+    const locator: CredentialLocator = {
+      scope: 'connection',
+      connectionId: connection.connectionId,
+      kind: 'api_key',
+    };
+    const configured = await stores.credentialVault.set({
+      locator,
+      expected: null,
+      secret: 'deleted-connection-secret',
+    });
+    assert.equal(configured.kind, 'committed');
+    if (configured.kind !== 'committed') return;
+    const status = configured.snapshot.entries[0];
+    assert.ok(status?.configured);
+    if (!status?.configured) return;
+
+    const removed = await stores.connectionCatalog.remove({
+      expected: { connectionId: connection.connectionId, revision: connection.revision },
+    });
+    assert.equal(removed.kind, 'committed');
+
+    const deleted = await coordinator.handlers['credential.vault.delete'](
+      {
+        expected: {
+          locator,
+          credentialId: status.credentialId,
+          revision: status.revision,
+        },
+      },
+      context,
+    );
+    assert.deepEqual(deleted, { ok: true, result: { kind: 'connection_not_found' } });
+  });
+});
+
+test('projects a corrupted runtime policy document as persistence_failed on query', async () => {
+  await withCoordinator(async ({ coordinator, root }) => {
+    await writeFile(join(root, 'runtime-policy.json'), '{not-json', 'utf8');
+
+    const queried = await coordinator.handlers['runtime.policy.query']({}, context);
+
+    assert.deepEqual(queried, {
+      ok: false,
+      error: {
+        code: 'persistence_failed',
+        message: 'Runtime policy persistence failed',
+      },
+    });
+  });
+});
+
+test('reconstructs a large catalog with revision-pinned pages and rejects stale cursors', async () => {
+  await withCoordinator(async ({ coordinator, stores }) => {
+    for (let connectionIndex = 0; connectionIndex < 5; connectionIndex += 1) {
+      const current = await stores.connectionCatalog.getSnapshot();
+      const result = await stores.connectionCatalog.create({
+        expectedCatalogRevision: current.revision,
+        connection: largeConnection(connectionIndex),
+      });
+      assert.equal(result.kind, 'committed');
+    }
+
+    const snapshot = await stores.connectionCatalog.getSnapshot();
+    assert.ok(
+      Buffer.byteLength(JSON.stringify(snapshot), 'utf8') > CONNECTION_CATALOG_PAGE_MAX_BYTES,
+    );
+    const first = await coordinator.handlers['connection.catalog.query'](
+      { kind: 'start' },
+      context,
+    );
+    assert.equal(first.ok, true);
+    if (!first.ok || first.result.kind !== 'page') return;
+
+    const pages = [first.result];
+    while (pages.at(-1)?.nextCursor) {
+      const previous = pages.at(-1);
+      assert.ok(previous?.nextCursor);
+      if (!previous?.nextCursor) break;
+      const next = await coordinator.handlers['connection.catalog.query'](
+        {
+          kind: 'continue',
+          revision: first.result.revision,
+          cursor: previous.nextCursor,
+        },
+        context,
+      );
+      assert.equal(next.ok, true);
+      if (!next.ok || next.result.kind !== 'page') return;
+      pages.push(next.result);
+    }
+
+    assert.ok(pages.length > 1);
+    for (const page of pages) {
+      assert.equal(page.revision, snapshot.revision);
+      assert.equal(page.connectionCount, snapshot.connections.length);
+      assert.ok(page.items.length <= CONNECTION_CATALOG_PAGE_MAX_ITEMS);
+      assert.ok(
+        Buffer.byteLength(JSON.stringify(page), 'utf8') <= CONNECTION_CATALOG_PAGE_MAX_BYTES,
+      );
+    }
+    assert.deepEqual(
+      pages.flatMap((page) => page.items),
+      expectedCatalogItems(snapshot),
+    );
+
+    const staleCursor = first.result.nextCursor;
+    assert.ok(staleCursor);
+    if (!staleCursor) return;
+    const appended = await stores.connectionCatalog.create({
+      expectedCatalogRevision: snapshot.revision,
+      connection: {
+        slug: 'after-first-page',
+        name: 'After first page',
+        providerType: 'openai',
+        enabled: true,
+        enabledModelIds: [],
+      },
+    });
+    assert.equal(appended.kind, 'committed');
+
+    const changed = await coordinator.handlers['connection.catalog.query'](
+      {
+        kind: 'continue',
+        revision: snapshot.revision,
+        cursor: staleCursor,
+      },
+      context,
+    );
+    assert.deepEqual(changed, {
+      ok: true,
+      result: {
+        kind: 'revision_changed',
+        expectedRevision: snapshot.revision,
+        actualRevision: snapshot.revision + 1,
+      },
+    });
+
+    const invalid = await coordinator.handlers['connection.catalog.query'](
+      {
+        kind: 'continue',
+        revision: snapshot.revision + 1,
+        cursor: { connectionIndex: 999, part: 'connection' },
+      },
+      context,
+    );
+    assert.deepEqual(invalid, {
+      ok: false,
+      error: { code: 'invalid_request', message: 'Invalid connection catalog cursor' },
+    });
+  });
+});
+
+function largeConnection(connectionIndex: number): ConnectionCatalogEntryDraft {
+  return {
+    slug: `large-${connectionIndex}`,
+    name: `Large connection ${connectionIndex}`,
+    providerType: 'openai',
+    enabled: true,
+    enabledModelIds: Array.from(
+      { length: 128 },
+      (_, itemIndex) => `model-${connectionIndex}-${itemIndex}-${'x'.repeat(300)}`,
+    ),
+  };
+}
+
+function expectedCatalogItems(snapshot: ConnectionCatalogSnapshot): ConnectionCatalogPageItem[] {
+  const items: ConnectionCatalogPageItem[] = [];
+  for (const [connectionIndex, connection] of snapshot.connections.entries()) {
+    const { enabledModelIds, models, ...header } = connection;
+    items.push({
+      kind: 'connection',
+      connectionIndex,
+      ...header,
+      enabledModelIdCount: enabledModelIds.length,
+      modelCount: models.length,
+    });
+    for (const [itemIndex, modelId] of enabledModelIds.entries()) {
+      items.push({ kind: 'enabled_model_id', connectionIndex, itemIndex, modelId });
+    }
+    for (const [itemIndex, model] of models.entries()) {
+      items.push({ kind: 'model', connectionIndex, itemIndex, model });
+    }
+  }
+  return items;
+}
+
+type Stores = Awaited<ReturnType<typeof openInteractiveRuntimePolicyStoresForWrite>>;
+
+async function withCoordinator(
+  run: (input: {
+    coordinator: HostRuntimePolicyCoordinator;
+    stores: Stores;
+    root: string;
+  }) => Promise<void>,
+): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-runtime-policy-host-'));
+  const root = join(base, 'interactive');
+  const capability = await resolveStorageRoot({
+    path: root,
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  try {
+    const stores = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+    await run({
+      coordinator: new HostRuntimePolicyCoordinator(stores, new RuntimePolicyActivationGate()),
+      stores,
+      root,
+    });
+  } finally {
+    await owner.close();
+    await rm(base, { recursive: true, force: true });
+  }
+}

--- a/packages/runtime-host/src/__tests__/runtime-policy-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/runtime-policy-coordinator.test.ts
@@ -9,7 +9,7 @@ import type {
   ConnectionCatalogSnapshot,
   CredentialLocator,
 } from '@maka/core/runtime-policy';
-import { FAKE_ASK_USER_QUESTION_PROMPT } from '@maka/runtime';
+import { FAKE_ASK_USER_QUESTION_PROMPT, FakeBackend } from '@maka/runtime';
 import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
 import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
@@ -115,6 +115,110 @@ test('production composition shares one gate across mutation and backend activat
   } finally {
     mutationSpy.mock.restore();
     backendActivationSpy.mock.restore();
+    try {
+      await composition?.close();
+    } finally {
+      try {
+        await owner.close();
+      } finally {
+        await rm(base, { recursive: true, force: true });
+      }
+    }
+  }
+});
+
+test('production policy mutation drains and poisons activation when cached backend disposal fails', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-runtime-policy-disposal-failure-'));
+  const root = join(base, 'interactive');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+
+  let drainRequests = 0;
+  let composition: Awaited<ReturnType<typeof createExecutionRuntimeHostComposition>> | undefined;
+  let disposalSpy: ReturnType<typeof mock.method> | undefined;
+  const activationGates: RuntimePolicyActivationGate[] = [];
+  const originalRunBackendActivation = RuntimePolicyActivationGate.prototype.runBackendActivation;
+  const activationSpy = mock.method(
+    RuntimePolicyActivationGate.prototype,
+    'runBackendActivation',
+    function <T>(this: RuntimePolicyActivationGate, operation: () => Promise<T> | T): Promise<T> {
+      activationGates.push(this);
+      return Reflect.apply(originalRunBackendActivation, this, [operation]) as Promise<T>;
+    },
+  );
+  try {
+    const setupStores = await openInteractiveExecutionStoresForWrite(owner.lease);
+    const session = await setupStores.sessionStore.create({
+      cwd: root,
+      backend: 'fake',
+      llmConnectionSlug: 'fake',
+      model: 'fake-model',
+      permissionMode: 'ask',
+    });
+    await setupStores.sessionStore.close?.();
+
+    composition = await createExecutionRuntimeHostComposition({
+      owner,
+      acquireResidency: context.acquireResidency,
+      requestDrain: () => {
+        drainRequests += 1;
+      },
+    });
+    await composition.recover();
+
+    const firstTurnId = randomUUID();
+    const started = await composition.handlers['turn.start'](
+      { sessionId: session.id, turnId: firstTurnId, text: 'cache this backend' },
+      context,
+    );
+    assert.equal(started.ok, true);
+    if (!started.ok) return;
+    let snapshot = started.result;
+    for (let attempt = 0; attempt < 100 && !isTerminalTurnStatus(snapshot.status); attempt += 1) {
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+      const queried = await composition.handlers['turn.query'](
+        { sessionId: session.id, turnId: firstTurnId },
+        context,
+      );
+      assert.equal(queried.ok, true);
+      if (!queried.ok) return;
+      snapshot = queried.result;
+    }
+    assert.equal(isTerminalTurnStatus(snapshot.status), true);
+
+    disposalSpy = mock.method(FakeBackend.prototype, 'dispose', async () => {
+      throw new Error('injected cached backend disposal failure');
+    });
+    const initial = await composition.handlers['runtime.policy.query']({}, context);
+    assert.equal(initial.ok, true);
+    if (!initial.ok) return;
+    const mutated = await composition.handlers['runtime.policy.mutate'](
+      {
+        expectedRevision: initial.result.revision,
+        operation: {
+          kind: 'set_memory',
+          value: { enabled: false, agentReadEnabled: false },
+        },
+      },
+      context,
+    );
+
+    assert.deepEqual(mutated, {
+      ok: true,
+      result: { kind: 'committed', revision: initial.result.revision + 1 },
+    });
+    assert.equal(drainRequests, 1);
+    assert.equal(activationGates.length, 1);
+    await assert.rejects(
+      () => activationGates[0]!.runBackendActivation(async () => undefined),
+      /Runtime policy activation is poisoned/,
+    );
+    assert.equal(drainRequests, 1);
+  } finally {
+    activationSpy.mock.restore();
+    disposalSpy?.mock.restore();
     try {
       await composition?.close();
     } finally {
@@ -564,6 +668,10 @@ test('reconstructs a large catalog with revision-pinned pages and rejects stale 
     });
   });
 });
+
+function isTerminalTurnStatus(status: string): boolean {
+  return status === 'completed' || status === 'failed' || status === 'cancelled';
+}
 
 function largeConnection(connectionIndex: number): ConnectionCatalogEntryDraft {
   return {

--- a/packages/runtime-host/src/protocol/operation-spec.ts
+++ b/packages/runtime-host/src/protocol/operation-spec.ts
@@ -9,6 +9,9 @@ export type HostOperationErrorCode =
   | 'session_archived'
   | 'session_busy'
   | 'operation_conflict'
+  | 'invalid_request'
+  | 'persistence_failed'
+  | 'commit_outcome_unknown'
   | 'internal_failure';
 
 export interface HostOperationError<C extends HostOperationErrorCode = HostOperationErrorCode> {

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -7,6 +7,7 @@ import {
   type HostOperationErrorCode,
   type OperationSpec,
 } from './operation-spec.js';
+import { RUNTIME_POLICY_OPERATION_SPECS } from './runtime-policy.js';
 import { TURN_OPERATION_SPECS } from './turn.js';
 
 export type { HostLifecycleState, HostStatusInput, HostStatusResult } from './host-status.js';
@@ -18,10 +19,11 @@ export type {
   TurnStartInput,
   TurnStopInput,
 } from './turn.js';
+export * from './runtime-policy.js';
 
 export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
-  HOST_STATUS_OPERATION_SPECS,
-  TURN_OPERATION_SPECS,
+  composeOperationSpecMaps(HOST_STATUS_OPERATION_SPECS, TURN_OPERATION_SPECS),
+  RUNTIME_POLICY_OPERATION_SPECS,
 );
 
 export type OperationSpecMap = typeof HOST_OPERATION_SPECS;

--- a/packages/runtime-host/src/protocol/runtime-policy.ts
+++ b/packages/runtime-host/src/protocol/runtime-policy.ts
@@ -1,0 +1,918 @@
+import {
+  CONNECTION_CATALOG_MAX_CONNECTIONS,
+  CONNECTION_CATALOG_MAX_ENABLED_MODEL_IDS,
+  CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION,
+  decodeCanonicalConnectionBaseUrl,
+  decodeCanonicalRuntimePolicy,
+  decodeConnectionModel,
+  decodeConnectionModelId,
+  decodeConnectionName,
+  decodeConnectionSlug,
+  decodeConnectionTarget,
+  decodeConnectionTestSummary,
+  decodeConnectionVersionBasis,
+  decodeCredentialLocator,
+  decodeCredentialStatus,
+  decodeCredentialVersionBasis,
+  decodeProviderType,
+  normalizeCreateCatalogConnectionInput,
+  normalizeDeleteCredentialInput,
+  normalizeRemoveCatalogConnectionInput,
+  normalizeRuntimePolicyMutation,
+  normalizeSetCredentialInput,
+  normalizeSetDefaultConnectionTargetInput,
+  normalizeUpdateCatalogConnectionInput,
+  RuntimePolicyDomainDecodeError,
+  type ConnectionCatalogEntry,
+  type ConnectionModel,
+  type ConnectionTarget,
+  type ConnectionVersionBasis,
+  type CreateCatalogConnectionInput,
+  type CredentialLocator,
+  type CredentialStatus,
+  type CredentialVersionBasis,
+  type DeleteCredentialInput,
+  type MutateRuntimePolicyInput,
+  type RemoveCatalogConnectionInput,
+  type RevisionConflict,
+  type RuntimePolicySnapshot,
+  type SetCredentialInput,
+  type SetDefaultConnectionTargetInput,
+  type UpdateCatalogConnectionInput,
+} from '@maka/core/runtime-policy';
+import { requireExactRecord, requireRecord } from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+export const CONNECTION_CATALOG_PAGE_MAX_ITEMS = 128;
+export const CONNECTION_CATALOG_PAGE_MAX_BYTES = 48 * 1024;
+export const RUNTIME_POLICY_SNAPSHOT_MAX_BYTES = 48 * 1024;
+export const CREDENTIAL_SECRET_MAX_BYTES = 10 * 1024;
+
+const CONNECTION_MUTATION_MAX_ENABLED_MODEL_IDS = 64;
+const QUERY_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'internal_failure',
+  'persistence_failed',
+] as const;
+const CATALOG_QUERY_ERRORS = [...QUERY_ERRORS, 'invalid_request'] as const;
+const CREDENTIAL_QUERY_ERRORS = [...QUERY_ERRORS, 'invalid_request'] as const;
+const MUTATION_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'invalid_request',
+  'internal_failure',
+  'persistence_failed',
+  'commit_outcome_unknown',
+] as const;
+
+export type RuntimePolicyQueryInput = Record<string, never>;
+export type RuntimePolicyQueryResult = RuntimePolicySnapshot;
+export type RuntimePolicyMutateInput = MutateRuntimePolicyInput;
+export type RuntimePolicyMutateResult =
+  | { readonly kind: 'committed'; readonly revision: number }
+  | RevisionConflict;
+
+export type ConnectionCatalogCursor =
+  | { readonly connectionIndex: number; readonly part: 'connection' }
+  | {
+      readonly connectionIndex: number;
+      readonly part: 'enabled_model_id' | 'model';
+      readonly itemIndex: number;
+    };
+
+export type ConnectionCatalogQueryInput =
+  | { readonly kind: 'start' }
+  | {
+      readonly kind: 'continue';
+      readonly revision: number;
+      readonly cursor: ConnectionCatalogCursor;
+    };
+
+export type ConnectionCatalogHeaderItem = Omit<
+  ConnectionCatalogEntry,
+  'enabledModelIds' | 'models'
+> & {
+  readonly kind: 'connection';
+  readonly connectionIndex: number;
+  readonly enabledModelIdCount: number;
+  readonly modelCount: number;
+};
+
+export type ConnectionCatalogPageItem =
+  | ConnectionCatalogHeaderItem
+  | {
+      readonly kind: 'enabled_model_id';
+      readonly connectionIndex: number;
+      readonly itemIndex: number;
+      readonly modelId: string;
+    }
+  | {
+      readonly kind: 'model';
+      readonly connectionIndex: number;
+      readonly itemIndex: number;
+      readonly model: ConnectionModel;
+    };
+
+export type ConnectionCatalogQueryResult =
+  | {
+      readonly kind: 'page';
+      readonly revision: number;
+      readonly defaultTarget: ConnectionTarget | null;
+      readonly connectionCount: number;
+      readonly items: readonly ConnectionCatalogPageItem[];
+      readonly nextCursor: ConnectionCatalogCursor | null;
+    }
+  | {
+      readonly kind: 'revision_changed';
+      readonly expectedRevision: number;
+      readonly actualRevision: number;
+    };
+
+export type CreateCatalogConnectionResult =
+  | CatalogConnectionCommitted
+  | RevisionConflict
+  | { readonly kind: 'connection_exists'; readonly slug: string };
+export type UpdateCatalogConnectionResult =
+  | CatalogConnectionCommitted
+  | ConnectionStale
+  | { readonly kind: 'invalid_default_target'; readonly target: ConnectionTarget };
+export type RemoveCatalogConnectionResult = CatalogCommitted | ConnectionStale;
+export type SetDefaultConnectionTargetResult =
+  | CatalogCommitted
+  | RevisionConflict
+  | { readonly kind: 'invalid_default_target'; readonly target: ConnectionTarget };
+export type ConnectionCatalogCreateInput = CreateCatalogConnectionInput;
+export type ConnectionCatalogUpdateInput = UpdateCatalogConnectionInput;
+export type ConnectionCatalogRemoveInput = RemoveCatalogConnectionInput;
+export type ConnectionCatalogSetDefaultTargetInput = SetDefaultConnectionTargetInput;
+
+interface CatalogCommitted {
+  readonly kind: 'committed';
+  readonly catalogRevision: number;
+}
+
+interface CatalogConnectionCommitted extends CatalogCommitted {
+  readonly connection: ConnectionVersionBasis;
+}
+
+interface ConnectionStale {
+  readonly kind: 'connection_stale';
+  readonly expected: ConnectionVersionBasis;
+  readonly actual: ConnectionVersionBasis | null;
+}
+
+export interface CredentialVaultQueryInput {
+  readonly locator: CredentialLocator;
+}
+
+export type CredentialVaultQueryResult =
+  | { readonly kind: 'status'; readonly status: CredentialStatus }
+  | { readonly kind: 'connection_not_found' };
+
+export type SetCredentialResult =
+  | CredentialCommitted
+  | { readonly kind: 'connection_not_found' }
+  | CredentialStale;
+export type DeleteCredentialResult =
+  | CredentialCommitted
+  | { readonly kind: 'connection_not_found' }
+  | CredentialStale;
+export type CredentialVaultSetInput = SetCredentialInput;
+export type CredentialVaultDeleteInput = DeleteCredentialInput;
+
+interface CredentialCommitted {
+  readonly kind: 'committed';
+  readonly vaultRevision: number;
+  readonly status: CredentialStatus;
+}
+
+interface CredentialStale {
+  readonly kind: 'credential_stale';
+  readonly expected: CredentialVersionBasis | null;
+  readonly actual: CredentialVersionBasis | null;
+}
+
+export const RUNTIME_POLICY_OPERATION_SPECS = {
+  'runtime.policy.query': defineOperation<
+    RuntimePolicyQueryInput,
+    RuntimePolicyQueryResult,
+    (typeof QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeEmptyInput,
+    decodeOutput: decodeRuntimePolicySnapshot,
+  }),
+  'runtime.policy.mutate': defineOperation<
+    RuntimePolicyMutateInput,
+    RuntimePolicyMutateResult,
+    (typeof MUTATION_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: MUTATION_ERRORS,
+    decodeInput: decodeRuntimePolicyMutation,
+    decodeOutput: decodeRuntimePolicyMutationResult,
+  }),
+  'connection.catalog.query': defineOperation<
+    ConnectionCatalogQueryInput,
+    ConnectionCatalogQueryResult,
+    (typeof CATALOG_QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: CATALOG_QUERY_ERRORS,
+    decodeInput: decodeCatalogQueryInput,
+    decodeOutput: decodeCatalogQueryResult,
+  }),
+  'connection.catalog.create': defineOperation<
+    ConnectionCatalogCreateInput,
+    CreateCatalogConnectionResult,
+    (typeof MUTATION_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: MUTATION_ERRORS,
+    decodeInput: decodeCreateConnectionInput,
+    decodeOutput: decodeCreateConnectionResult,
+  }),
+  'connection.catalog.update': defineOperation<
+    ConnectionCatalogUpdateInput,
+    UpdateCatalogConnectionResult,
+    (typeof MUTATION_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: MUTATION_ERRORS,
+    decodeInput: decodeUpdateConnectionInput,
+    decodeOutput: decodeUpdateConnectionResult,
+  }),
+  'connection.catalog.remove': defineOperation<
+    ConnectionCatalogRemoveInput,
+    RemoveCatalogConnectionResult,
+    (typeof MUTATION_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: MUTATION_ERRORS,
+    decodeInput: decodeRemoveConnectionInput,
+    decodeOutput: decodeRemoveConnectionResult,
+  }),
+  'connection.catalog.set-default-target': defineOperation<
+    ConnectionCatalogSetDefaultTargetInput,
+    SetDefaultConnectionTargetResult,
+    (typeof MUTATION_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: MUTATION_ERRORS,
+    decodeInput: decodeSetDefaultTargetInput,
+    decodeOutput: decodeSetDefaultTargetResult,
+  }),
+  'credential.vault.query': defineOperation<
+    CredentialVaultQueryInput,
+    CredentialVaultQueryResult,
+    (typeof CREDENTIAL_QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: CREDENTIAL_QUERY_ERRORS,
+    decodeInput: decodeCredentialQueryInput,
+    decodeOutput: decodeCredentialQueryResult,
+  }),
+  'credential.vault.set': defineOperation<
+    CredentialVaultSetInput,
+    SetCredentialResult,
+    (typeof MUTATION_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: MUTATION_ERRORS,
+    decodeInput: decodeSetCredentialInput,
+    decodeOutput: decodeSetCredentialResult,
+  }),
+  'credential.vault.delete': defineOperation<
+    CredentialVaultDeleteInput,
+    DeleteCredentialResult,
+    (typeof MUTATION_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: MUTATION_ERRORS,
+    decodeInput: decodeDeleteCredentialInput,
+    decodeOutput: decodeDeleteCredentialResult,
+  }),
+} as const;
+
+function decodeEmptyInput(value: unknown): RuntimePolicyQueryInput {
+  requireExactRecord(value, 'runtime policy query input', []);
+  return {};
+}
+
+function decodeRuntimePolicySnapshot(value: unknown): RuntimePolicySnapshot {
+  const item = requireExactRecord(value, 'runtime policy snapshot', ['revision', 'policy']);
+  const snapshot = {
+    revision: revision(item.revision, 'runtime policy revision'),
+    policy: decodeDomain(() => decodeCanonicalRuntimePolicy(item.policy)),
+  };
+  if (Buffer.byteLength(JSON.stringify(snapshot), 'utf8') > RUNTIME_POLICY_SNAPSHOT_MAX_BYTES) {
+    throw invalidProtocolFrame('Runtime policy snapshot exceeds byte limit');
+  }
+  return snapshot;
+}
+
+function decodeRuntimePolicyMutation(value: unknown): MutateRuntimePolicyInput {
+  return decodeDomain(() => normalizeRuntimePolicyMutation(value));
+}
+
+function decodeRuntimePolicyMutationResult(value: unknown): RuntimePolicyMutateResult {
+  const item = requireRecord(value, 'runtime policy mutation result');
+  if (item.kind === 'committed') {
+    const committed = requireExactRecord(item, 'runtime policy committed result', [
+      'kind',
+      'revision',
+    ]);
+    return { kind: 'committed', revision: revision(committed.revision, 'runtime policy revision') };
+  }
+  return revisionConflict(item, 'runtime policy mutation result');
+}
+
+function decodeCatalogQueryInput(value: unknown): ConnectionCatalogQueryInput {
+  const item = requireRecord(value, 'connection catalog query input');
+  if (item.kind === 'start') {
+    requireExactRecord(item, 'connection catalog start query', ['kind']);
+    return { kind: 'start' };
+  }
+  if (item.kind === 'continue') {
+    const continuation = requireExactRecord(item, 'connection catalog continuation query', [
+      'kind',
+      'revision',
+      'cursor',
+    ]);
+    return {
+      kind: 'continue',
+      revision: revision(continuation.revision, 'catalog revision'),
+      cursor: catalogCursor(continuation.cursor),
+    };
+  }
+  throw invalidProtocolFrame('Invalid connection catalog query kind');
+}
+
+function decodeCatalogQueryResult(value: unknown): ConnectionCatalogQueryResult {
+  const item = requireRecord(value, 'connection catalog query result');
+  if (item.kind === 'revision_changed') {
+    const changed = requireExactRecord(item, 'catalog revision changed result', [
+      'kind',
+      'expectedRevision',
+      'actualRevision',
+    ]);
+    return {
+      kind: 'revision_changed',
+      expectedRevision: revision(changed.expectedRevision, 'expected catalog revision'),
+      actualRevision: revision(changed.actualRevision, 'actual catalog revision'),
+    };
+  }
+  if (item.kind !== 'page')
+    throw invalidProtocolFrame('Invalid connection catalog query result kind');
+  const page = requireExactRecord(item, 'connection catalog page', [
+    'kind',
+    'revision',
+    'defaultTarget',
+    'connectionCount',
+    'items',
+    'nextCursor',
+  ]);
+  if (!Array.isArray(page.items) || page.items.length > CONNECTION_CATALOG_PAGE_MAX_ITEMS) {
+    throw invalidProtocolFrame('Invalid connection catalog page items');
+  }
+  const decoded: ConnectionCatalogQueryResult = {
+    kind: 'page',
+    revision: revision(page.revision, 'catalog revision'),
+    defaultTarget:
+      page.defaultTarget === null
+        ? null
+        : decodeDomain(() => decodeConnectionTarget(page.defaultTarget)),
+    connectionCount: integer(
+      page.connectionCount,
+      'connection count',
+      0,
+      CONNECTION_CATALOG_MAX_CONNECTIONS,
+    ),
+    items: page.items.map(catalogPageItem),
+    nextCursor: page.nextCursor === null ? null : catalogCursor(page.nextCursor),
+  };
+  if (Buffer.byteLength(JSON.stringify(decoded), 'utf8') > CONNECTION_CATALOG_PAGE_MAX_BYTES) {
+    throw invalidProtocolFrame('Connection catalog page exceeds byte limit');
+  }
+  validateCatalogPageStructure(decoded);
+  return decoded;
+}
+
+function catalogCursor(value: unknown): ConnectionCatalogCursor {
+  const item = requireRecord(value, 'connection catalog cursor');
+  if (item.part === 'connection') {
+    const cursor = requireExactRecord(item, 'connection catalog cursor', [
+      'connectionIndex',
+      'part',
+    ]);
+    return {
+      connectionIndex: integer(
+        cursor.connectionIndex,
+        'connection index',
+        0,
+        CONNECTION_CATALOG_MAX_CONNECTIONS - 1,
+      ),
+      part: 'connection',
+    };
+  }
+  if (item.part === 'enabled_model_id' || item.part === 'model') {
+    const cursor = requireExactRecord(item, 'connection catalog cursor', [
+      'connectionIndex',
+      'part',
+      'itemIndex',
+    ]);
+    const maxItems =
+      item.part === 'enabled_model_id'
+        ? CONNECTION_CATALOG_MAX_ENABLED_MODEL_IDS
+        : CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION;
+    return {
+      connectionIndex: integer(
+        cursor.connectionIndex,
+        'connection index',
+        0,
+        CONNECTION_CATALOG_MAX_CONNECTIONS - 1,
+      ),
+      part: item.part,
+      itemIndex: integer(cursor.itemIndex, 'item index', 0, maxItems - 1),
+    };
+  }
+  throw invalidProtocolFrame('Invalid connection catalog cursor part');
+}
+
+function catalogPageItem(value: unknown): ConnectionCatalogPageItem {
+  const item = requireRecord(value, 'connection catalog page item');
+  if (item.kind === 'enabled_model_id') {
+    const enabled = requireExactRecord(item, 'enabled model id item', [
+      'kind',
+      'connectionIndex',
+      'itemIndex',
+      'modelId',
+    ]);
+    return {
+      kind: 'enabled_model_id',
+      connectionIndex: integer(
+        enabled.connectionIndex,
+        'connection index',
+        0,
+        CONNECTION_CATALOG_MAX_CONNECTIONS - 1,
+      ),
+      itemIndex: integer(
+        enabled.itemIndex,
+        'item index',
+        0,
+        CONNECTION_CATALOG_MAX_ENABLED_MODEL_IDS - 1,
+      ),
+      modelId: decodeDomain(() => decodeConnectionModelId(enabled.modelId)),
+    };
+  }
+  if (item.kind === 'model') {
+    const modelItem = requireExactRecord(item, 'connection model item', [
+      'kind',
+      'connectionIndex',
+      'itemIndex',
+      'model',
+    ]);
+    return {
+      kind: 'model',
+      connectionIndex: integer(
+        modelItem.connectionIndex,
+        'connection index',
+        0,
+        CONNECTION_CATALOG_MAX_CONNECTIONS - 1,
+      ),
+      itemIndex: integer(
+        modelItem.itemIndex,
+        'item index',
+        0,
+        CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION - 1,
+      ),
+      model: decodeDomain(() => decodeConnectionModel(modelItem.model)),
+    };
+  }
+  if (item.kind !== 'connection')
+    throw invalidProtocolFrame('Invalid connection catalog page item kind');
+  const header = optionalRecord(
+    item,
+    'connection header',
+    [
+      'kind',
+      'connectionIndex',
+      'connectionId',
+      'revision',
+      'slug',
+      'name',
+      'providerType',
+      'baseUrl',
+      'enabled',
+      'modelSource',
+      'modelsFetchedAt',
+      'lastTest',
+      'enabledModelIdCount',
+      'modelCount',
+    ],
+    [
+      'kind',
+      'connectionIndex',
+      'connectionId',
+      'revision',
+      'slug',
+      'name',
+      'providerType',
+      'enabled',
+      'enabledModelIdCount',
+      'modelCount',
+    ],
+  );
+  if ((header.modelSource === undefined) !== (header.modelsFetchedAt === undefined)) {
+    throw invalidProtocolFrame('Invalid connection header model discovery fields');
+  }
+  const provider = decodeDomain(() => decodeProviderType(header.providerType));
+  const baseUrl =
+    header.baseUrl === undefined
+      ? undefined
+      : decodeDomain(() => decodeCanonicalConnectionBaseUrl(header.baseUrl, provider));
+  const modelCount = integer(
+    header.modelCount,
+    'model count',
+    0,
+    CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION,
+  );
+  if (header.modelSource === undefined && modelCount !== 0) {
+    throw invalidProtocolFrame('Invalid connection header model count');
+  }
+  const basis = decodeDomain(() =>
+    decodeConnectionVersionBasis({
+      connectionId: header.connectionId,
+      revision: header.revision,
+    }),
+  );
+  return {
+    kind: 'connection',
+    connectionIndex: integer(
+      header.connectionIndex,
+      'connection index',
+      0,
+      CONNECTION_CATALOG_MAX_CONNECTIONS - 1,
+    ),
+    connectionId: basis.connectionId,
+    revision: basis.revision,
+    slug: decodeDomain(() => decodeConnectionSlug(header.slug)),
+    name: decodeDomain(() => decodeConnectionName(header.name)),
+    providerType: provider,
+    ...(baseUrl === undefined ? {} : { baseUrl }),
+    enabled: boolean(header.enabled, 'connection enabled'),
+    ...(header.modelSource === undefined ? {} : { modelSource: modelSource(header.modelSource) }),
+    ...(header.modelsFetchedAt === undefined
+      ? {}
+      : {
+          modelsFetchedAt: integer(
+            header.modelsFetchedAt,
+            'models fetched at',
+            0,
+            Number.MAX_SAFE_INTEGER,
+          ),
+        }),
+    ...(header.lastTest === undefined
+      ? {}
+      : { lastTest: decodeDomain(() => decodeConnectionTestSummary(header.lastTest)) }),
+    enabledModelIdCount: integer(
+      header.enabledModelIdCount,
+      'enabled model id count',
+      0,
+      CONNECTION_CATALOG_MAX_ENABLED_MODEL_IDS,
+    ),
+    modelCount,
+  };
+}
+
+function decodeCreateConnectionInput(value: unknown): CreateCatalogConnectionInput {
+  const input = decodeDomain(() => normalizeCreateCatalogConnectionInput(value));
+  assertMutationEnabledModelIds(input.connection.enabledModelIds);
+  return input;
+}
+
+function decodeUpdateConnectionInput(value: unknown): UpdateCatalogConnectionInput {
+  const input = decodeDomain(() => normalizeUpdateCatalogConnectionInput(value));
+  assertMutationEnabledModelIds(input.changes.enabledModelIds);
+  return input;
+}
+
+function decodeRemoveConnectionInput(value: unknown): RemoveCatalogConnectionInput {
+  return decodeDomain(() => normalizeRemoveCatalogConnectionInput(value));
+}
+
+function decodeSetDefaultTargetInput(value: unknown): SetDefaultConnectionTargetInput {
+  return decodeDomain(() => normalizeSetDefaultConnectionTargetInput(value));
+}
+
+function decodeCreateConnectionResult(value: unknown): CreateCatalogConnectionResult {
+  const item = requireRecord(value, 'create connection result');
+  if (item.kind === 'committed') return catalogConnectionCommitted(item);
+  if (item.kind === 'connection_exists') {
+    const conflict = requireExactRecord(item, 'connection exists conflict', ['kind', 'slug']);
+    return {
+      kind: 'connection_exists',
+      slug: decodeDomain(() => decodeConnectionSlug(conflict.slug)),
+    };
+  }
+  return revisionConflict(item, 'create connection result');
+}
+
+function decodeUpdateConnectionResult(value: unknown): UpdateCatalogConnectionResult {
+  const item = requireRecord(value, 'update connection result');
+  if (item.kind === 'committed') return catalogConnectionCommitted(item);
+  if (item.kind === 'connection_stale') return connectionStale(item);
+  return invalidDefaultTarget(item, 'update connection result');
+}
+
+function decodeRemoveConnectionResult(value: unknown): RemoveCatalogConnectionResult {
+  const item = requireRecord(value, 'remove connection result');
+  return item.kind === 'committed' ? catalogCommitted(item) : connectionStale(item);
+}
+
+function decodeSetDefaultTargetResult(value: unknown): SetDefaultConnectionTargetResult {
+  const item = requireRecord(value, 'set default target result');
+  if (item.kind === 'committed') return catalogCommitted(item);
+  if (item.kind === 'revision_conflict') return revisionConflict(item, 'set default target result');
+  return invalidDefaultTarget(item, 'set default target result');
+}
+
+function catalogCommitted(value: unknown): CatalogCommitted {
+  const item = requireExactRecord(value, 'catalog committed result', ['kind', 'catalogRevision']);
+  if (item.kind !== 'committed') throw invalidProtocolFrame('Invalid catalog committed result');
+  return { kind: 'committed', catalogRevision: revision(item.catalogRevision, 'catalog revision') };
+}
+
+function catalogConnectionCommitted(value: unknown): CatalogConnectionCommitted {
+  const item = requireExactRecord(value, 'catalog connection committed result', [
+    'kind',
+    'catalogRevision',
+    'connection',
+  ]);
+  if (item.kind !== 'committed') throw invalidProtocolFrame('Invalid catalog committed result');
+  return {
+    kind: 'committed',
+    catalogRevision: revision(item.catalogRevision, 'catalog revision'),
+    connection: decodeDomain(() => decodeConnectionVersionBasis(item.connection)),
+  };
+}
+
+function connectionStale(value: unknown): ConnectionStale {
+  const item = requireExactRecord(value, 'connection stale conflict', [
+    'kind',
+    'expected',
+    'actual',
+  ]);
+  if (item.kind !== 'connection_stale') throw invalidProtocolFrame('Invalid connection conflict');
+  return {
+    kind: 'connection_stale',
+    expected: decodeDomain(() => decodeConnectionVersionBasis(item.expected)),
+    actual:
+      item.actual === null ? null : decodeDomain(() => decodeConnectionVersionBasis(item.actual)),
+  };
+}
+
+function invalidDefaultTarget(
+  value: unknown,
+  label: string,
+): { kind: 'invalid_default_target'; target: ConnectionTarget } {
+  const item = requireExactRecord(value, label, ['kind', 'target']);
+  if (item.kind !== 'invalid_default_target') throw invalidProtocolFrame(`Invalid ${label}`);
+  return {
+    kind: 'invalid_default_target',
+    target: decodeDomain(() => decodeConnectionTarget(item.target)),
+  };
+}
+
+function decodeCredentialQueryInput(value: unknown): CredentialVaultQueryInput {
+  const item = requireExactRecord(value, 'credential query input', ['locator']);
+  return { locator: decodeDomain(() => decodeCredentialLocator(item.locator)) };
+}
+
+function decodeCredentialQueryResult(value: unknown): CredentialVaultQueryResult {
+  const item = requireRecord(value, 'credential query result');
+  if (item.kind === 'connection_not_found') {
+    requireExactRecord(item, 'credential connection not found result', ['kind']);
+    return { kind: 'connection_not_found' };
+  }
+  const status = requireExactRecord(item, 'credential status result', ['kind', 'status']);
+  if (status.kind !== 'status') throw invalidProtocolFrame('Invalid credential query result');
+  return { kind: 'status', status: decodeDomain(() => decodeCredentialStatus(status.status)) };
+}
+
+function decodeSetCredentialInput(value: unknown): SetCredentialInput {
+  const input = decodeDomain(() => normalizeSetCredentialInput(value));
+  if (Buffer.byteLength(input.secret, 'utf8') > CREDENTIAL_SECRET_MAX_BYTES) {
+    throw invalidProtocolFrame('Invalid credential secret');
+  }
+  return input;
+}
+
+function decodeDeleteCredentialInput(value: unknown): DeleteCredentialInput {
+  return decodeDomain(() => normalizeDeleteCredentialInput(value));
+}
+
+function decodeSetCredentialResult(value: unknown): SetCredentialResult {
+  const item = requireRecord(value, 'set credential result');
+  if (item.kind === 'committed') return credentialCommitted(item);
+  if (item.kind === 'connection_not_found') {
+    requireExactRecord(item, 'credential connection not found result', ['kind']);
+    return { kind: 'connection_not_found' };
+  }
+  return credentialStale(item);
+}
+
+function decodeDeleteCredentialResult(value: unknown): DeleteCredentialResult {
+  const item = requireRecord(value, 'delete credential result');
+  if (item.kind === 'committed') return credentialCommitted(item);
+  if (item.kind === 'connection_not_found') {
+    requireExactRecord(item, 'credential connection not found result', ['kind']);
+    return { kind: 'connection_not_found' };
+  }
+  return credentialStale(item);
+}
+
+function validateCatalogPageStructure(
+  page: Extract<ConnectionCatalogQueryResult, { readonly kind: 'page' }>,
+): void {
+  if (page.items.length === 0) {
+    if (page.connectionCount !== 0 || page.defaultTarget !== null || page.nextCursor !== null) {
+      throw invalidProtocolFrame('Invalid empty connection catalog page');
+    }
+    return;
+  }
+  let previous: ConnectionCatalogCursor | undefined;
+  for (const item of page.items) {
+    if (item.connectionIndex >= page.connectionCount) {
+      throw invalidProtocolFrame('Connection catalog item exceeds connection count');
+    }
+    const position = cursorForPageItem(item);
+    if (previous && compareCatalogCursor(previous, position) >= 0) {
+      throw invalidProtocolFrame('Connection catalog page does not make forward progress');
+    }
+    previous = position;
+  }
+  if (page.nextCursor) {
+    if (
+      page.nextCursor.connectionIndex >= page.connectionCount ||
+      !previous ||
+      compareCatalogCursor(previous, page.nextCursor) >= 0
+    ) {
+      throw invalidProtocolFrame('Invalid connection catalog next cursor');
+    }
+  }
+}
+
+function cursorForPageItem(item: ConnectionCatalogPageItem): ConnectionCatalogCursor {
+  return item.kind === 'connection'
+    ? { connectionIndex: item.connectionIndex, part: 'connection' }
+    : {
+        connectionIndex: item.connectionIndex,
+        part: item.kind,
+        itemIndex: item.itemIndex,
+      };
+}
+
+function compareCatalogCursor(
+  left: ConnectionCatalogCursor,
+  right: ConnectionCatalogCursor,
+): number {
+  if (left.connectionIndex !== right.connectionIndex) {
+    return left.connectionIndex - right.connectionIndex;
+  }
+  const leftPart = catalogCursorPartOrder(left.part);
+  const rightPart = catalogCursorPartOrder(right.part);
+  if (leftPart !== rightPart) return leftPart - rightPart;
+  return (
+    ('itemIndex' in left ? left.itemIndex : -1) - ('itemIndex' in right ? right.itemIndex : -1)
+  );
+}
+
+function catalogCursorPartOrder(part: ConnectionCatalogCursor['part']): number {
+  switch (part) {
+    case 'connection':
+      return 0;
+    case 'enabled_model_id':
+      return 1;
+    case 'model':
+      return 2;
+  }
+}
+
+function credentialCommitted(value: unknown): CredentialCommitted {
+  const item = requireExactRecord(value, 'credential committed result', [
+    'kind',
+    'vaultRevision',
+    'status',
+  ]);
+  if (item.kind !== 'committed') throw invalidProtocolFrame('Invalid credential committed result');
+  return {
+    kind: 'committed',
+    vaultRevision: revision(item.vaultRevision, 'vault revision'),
+    status: decodeDomain(() => decodeCredentialStatus(item.status)),
+  };
+}
+
+function credentialStale(value: unknown): CredentialStale {
+  const item = requireExactRecord(value, 'credential stale conflict', [
+    'kind',
+    'expected',
+    'actual',
+  ]);
+  if (item.kind !== 'credential_stale') throw invalidProtocolFrame('Invalid credential conflict');
+  return {
+    kind: 'credential_stale',
+    expected:
+      item.expected === null
+        ? null
+        : decodeDomain(() => decodeCredentialVersionBasis(item.expected)),
+    actual:
+      item.actual === null ? null : decodeDomain(() => decodeCredentialVersionBasis(item.actual)),
+  };
+}
+
+function revisionConflict(value: unknown, label: string): RevisionConflict {
+  const item = requireExactRecord(value, label, ['kind', 'expectedRevision', 'actualRevision']);
+  if (item.kind !== 'revision_conflict') throw invalidProtocolFrame(`Invalid ${label}`);
+  return {
+    kind: 'revision_conflict',
+    expectedRevision: revision(item.expectedRevision, 'expected revision'),
+    actualRevision: revision(item.actualRevision, 'actual revision'),
+  };
+}
+
+function optionalRecord(
+  value: unknown,
+  label: string,
+  allowed: readonly string[],
+  required: readonly string[],
+): Record<string, unknown> {
+  const item = requireRecord(value, label);
+  assertAllowedKeys(item, label, allowed);
+  if (required.some((key) => !Object.hasOwn(item, key)))
+    throw invalidProtocolFrame(`Invalid ${label} fields`);
+  return item;
+}
+
+function assertAllowedKeys(
+  record: Record<string, unknown>,
+  label: string,
+  keys: readonly string[],
+): void {
+  const allowed = new Set(keys);
+  if (Object.keys(record).some((key) => !allowed.has(key))) {
+    throw invalidProtocolFrame(`Unknown ${label} field`);
+  }
+}
+
+function boolean(value: unknown, label: string): boolean {
+  if (typeof value !== 'boolean') throw invalidProtocolFrame(`Invalid ${label}`);
+  return value;
+}
+
+function integer(value: unknown, label: string, min: number, max: number): number {
+  if (!Number.isSafeInteger(value) || (value as number) < min || (value as number) > max)
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  return value as number;
+}
+
+function revision(value: unknown, label: string): number {
+  return integer(value, label, 0, Number.MAX_SAFE_INTEGER);
+}
+function modelSource(value: unknown): 'fetched' | 'fallback' {
+  if (value !== 'fetched' && value !== 'fallback')
+    throw invalidProtocolFrame('Invalid model source');
+  return value;
+}
+
+function assertMutationEnabledModelIds(values: readonly string[]): void {
+  if (values.length > CONNECTION_MUTATION_MAX_ENABLED_MODEL_IDS) {
+    throw invalidProtocolFrame('Invalid enabled model ids');
+  }
+}
+
+function decodeDomain<T>(decode: () => T): T {
+  try {
+    return decode();
+  } catch (error) {
+    if (error instanceof RuntimePolicyDomainDecodeError) {
+      throw invalidProtocolFrame(error.message);
+    }
+    throw error;
+  }
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1,48 +1,73 @@
 import { randomUUID } from 'node:crypto';
 import { BackendRegistry, FakeBackend, SessionManager } from '@maka/runtime';
 import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
+import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
 import type { RuntimeHostComposition, RuntimeHostCompositionContext } from './host-kernel.js';
 import { RootAdmissionOwner } from './root-admission-owner.js';
 import { RootTurnCoordinator } from './root-turn-coordinator.js';
+import { RuntimePolicyActivationGate } from './runtime-policy-activation-gate.js';
+import { HostRuntimePolicyCoordinator } from './runtime-policy-coordinator.js';
 import { SessionAdmissionGate } from './session-admission-gate.js';
 
 export async function createExecutionRuntimeHostComposition(
   context: RuntimeHostCompositionContext,
 ): Promise<RuntimeHostComposition> {
   const stores = await openInteractiveExecutionStoresForWrite(context.owner.lease);
-  const backends = new BackendRegistry();
-  backends.register('fake', (backendContext) => new FakeBackend(backendContext));
-  const manager = new SessionManager({
-    store: stores.sessionStore,
-    runStore: stores.agentRunStore,
-    runtimeEventStore: stores.runtimeEventStore,
-    backends,
-    newId: randomUUID,
-    now: Date.now,
-  });
-  const sessionAdmission = new SessionAdmissionGate();
-  const rootAdmissionOwner = new RootAdmissionOwner(stores.agentRunStore);
-  const coordinator = new RootTurnCoordinator(
-    manager,
-    stores,
-    sessionAdmission,
-    rootAdmissionOwner,
-    context.acquireResidency,
-    context.requestDrain,
-  );
-  return {
-    handlers: coordinator.handlers,
-    recover: async () => {
-      await coordinator.prepareRecovery();
-      await manager.recoverInterruptedSessionsStrict(stores);
-      await coordinator.recover();
-    },
-    close: async () => {
-      try {
-        await coordinator.close();
-      } finally {
-        await stores.sessionStore.close?.();
-      }
-    },
-  };
+  try {
+    const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
+      context.owner.lease,
+    );
+    const backends = new BackendRegistry();
+    backends.register('fake', (backendContext) => new FakeBackend(backendContext));
+    const runtimePolicyActivation = new RuntimePolicyActivationGate();
+    const manager = new SessionManager({
+      store: stores.sessionStore,
+      runStore: stores.agentRunStore,
+      runtimeEventStore: stores.runtimeEventStore,
+      backends,
+      newId: randomUUID,
+      now: Date.now,
+      runBackendActivation: (operation) => runtimePolicyActivation.runBackendActivation(operation),
+    });
+    const sessionAdmission = new SessionAdmissionGate();
+    const rootAdmissionOwner = new RootAdmissionOwner(stores.agentRunStore);
+    const coordinator = new RootTurnCoordinator(
+      manager,
+      stores,
+      sessionAdmission,
+      rootAdmissionOwner,
+      context.acquireResidency,
+      context.requestDrain,
+    );
+    const runtimePolicy = new HostRuntimePolicyCoordinator(
+      runtimePolicyStores,
+      runtimePolicyActivation,
+      async () => {
+        try {
+          await manager.refreshIdleBackends();
+        } catch (error) {
+          context.requestDrain();
+          throw error;
+        }
+      },
+    );
+    return {
+      handlers: { ...coordinator.handlers, ...runtimePolicy.handlers },
+      recover: async () => {
+        await coordinator.prepareRecovery();
+        await manager.recoverInterruptedSessionsStrict(stores);
+        await coordinator.recover();
+      },
+      close: async () => {
+        try {
+          await coordinator.close();
+        } finally {
+          await stores.sessionStore.close?.();
+        }
+      },
+    };
+  } catch (error) {
+    await stores.sessionStore.close?.();
+    throw error;
+  }
 }

--- a/packages/runtime-host/src/server/host-kernel.ts
+++ b/packages/runtime-host/src/server/host-kernel.ts
@@ -27,6 +27,7 @@ import {
 } from './connection-session.js';
 import {
   composeOperationHandlers,
+  createUnavailableDomainOperationHandlers,
   type DomainOperationHandlerMap,
   type OperationResidency,
   type OperationHandlerMap,
@@ -117,7 +118,9 @@ export class RuntimeHostKernel {
     this.#handshakeTimeoutMs = options.handshakeTimeoutMs ?? DEFAULT_HANDSHAKE_TIMEOUT_MS;
     this.#shutdownGraceMs = options.shutdownGraceMs ?? DEFAULT_SHUTDOWN_GRACE_MS;
     this.#options = options;
-    this.#operationHandlers = this.#createOperationHandlers(unavailableDomainHandlers());
+    this.#operationHandlers = this.#createOperationHandlers(
+      createUnavailableDomainOperationHandlers(),
+    );
     this.closed = new Promise((resolve, reject) => {
       this.#resolveClosed = resolve;
       this.#rejectClosed = reject;
@@ -619,19 +622,4 @@ function assertDuration(value: number, label: string, minimum: 0 | 1): void {
   if (!Number.isSafeInteger(value) || value < minimum || value > 120_000) {
     throw new RangeError(`${label} must be an integer between ${minimum} and 120000`);
   }
-}
-
-function unavailableDomainHandlers(): DomainOperationHandlerMap {
-  const unavailable = {
-    ok: false,
-    error: {
-      code: 'operation_unavailable',
-      message: 'Runtime Host operation is unavailable in this composition',
-    },
-  } as const;
-  return {
-    'turn.start': async () => unavailable,
-    'turn.query': async () => unavailable,
-    'turn.stop': async () => unavailable,
-  };
 }

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -34,7 +34,14 @@ export type OperationHandlerMap = {
 };
 
 export type DomainOperationKey = Exclude<OperationKey, 'host.status'>;
+export type TurnOperationKey = Extract<OperationKey, `turn.${string}`>;
+export type RuntimePolicyOperationKey = Extract<
+  OperationKey,
+  `runtime.policy.${string}` | `connection.catalog.${string}` | `credential.vault.${string}`
+>;
 export type DomainOperationHandlerMap = Pick<OperationHandlerMap, DomainOperationKey>;
+export type TurnOperationHandlerMap = Pick<OperationHandlerMap, TurnOperationKey>;
+export type RuntimePolicyOperationHandlerMap = Pick<OperationHandlerMap, RuntimePolicyOperationKey>;
 
 export function composeOperationHandlers(
   ...handlerMaps: readonly Partial<OperationHandlerMap>[]
@@ -60,6 +67,27 @@ export function composeOperationHandlers(
     throw new Error(`Missing Runtime Host operation handlers: ${missing.join(', ')}`);
   }
   return combined as OperationHandlerMap;
+}
+
+export function createUnavailableDomainOperationHandlers(): DomainOperationHandlerMap {
+  const handlers: Partial<DomainOperationHandlerMap> = {};
+  for (const operation of Object.keys(HOST_OPERATION_SPECS) as OperationKey[]) {
+    if (operation === 'host.status') continue;
+    const errors = HOST_OPERATION_SPECS[operation].errors as readonly HostOperationErrorCode[];
+    if (!errors.includes('operation_unavailable')) {
+      throw new Error(`${operation} does not declare operation_unavailable`);
+    }
+    Object.assign(handlers, {
+      [operation]: async () => ({
+        ok: false,
+        error: {
+          code: 'operation_unavailable',
+          message: 'Runtime Host operation is unavailable in this composition',
+        },
+      }),
+    });
+  }
+  return handlers as DomainOperationHandlerMap;
 }
 
 export async function dispatchOperation(

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -15,7 +15,7 @@ import type {
   TurnStopInput,
 } from '../protocol/index.js';
 import type { RuntimeHostResidency } from './host-kernel.js';
-import type { ConnectionContext, DomainOperationHandlerMap } from './operation-dispatcher.js';
+import type { ConnectionContext, TurnOperationHandlerMap } from './operation-dispatcher.js';
 import { RootAdmissionOwner } from './root-admission-owner.js';
 import { SessionAdmissionGate } from './session-admission-gate.js';
 
@@ -48,7 +48,7 @@ interface RecoverySessionPlan {
 }
 
 export class RootTurnCoordinator {
-  readonly handlers: DomainOperationHandlerMap = {
+  readonly handlers: TurnOperationHandlerMap = {
     'turn.start': (input, context) => this.startTurn(input, context),
     'turn.query': (input) => this.queryTurn(input),
     'turn.stop': (input) => this.stopTurn(input),

--- a/packages/runtime-host/src/server/runtime-policy-activation-gate.ts
+++ b/packages/runtime-host/src/server/runtime-policy-activation-gate.ts
@@ -1,0 +1,95 @@
+const POISONED_MESSAGE = 'Runtime policy activation is poisoned';
+
+/**
+ * Coordinates runtime-policy mutation/invalidation with the short backend
+ * activation window that selects a backend and starts a run.
+ */
+export class RuntimePolicyActivationGate {
+  readonly #backendActivations = new Set<Promise<void>>();
+  #mutationTail = Promise.resolve();
+  #poisoned = false;
+
+  runBackendActivation<T>(operation: () => Promise<T> | T): Promise<T> {
+    if (this.#poisoned) return Promise.reject(poisonedError());
+
+    const precedingMutations = this.#mutationTail;
+    const completion = deferred();
+    this.#backendActivations.add(completion.promise);
+
+    return this.#executeBackendActivation(precedingMutations, completion, operation);
+  }
+
+  runMutation<T>(operation: () => Promise<T> | T): Promise<T> {
+    if (this.#poisoned) return Promise.reject(poisonedError());
+
+    const precedingMutation = this.#mutationTail;
+    const precedingBackendActivations = [...this.#backendActivations];
+    const completion = deferred();
+
+    // This tail never rejects, so later registrations cannot create an
+    // unhandled rejection from an operation failure.
+    this.#mutationTail = precedingMutation.then(() => completion.promise);
+
+    return this.#executeMutation(
+      precedingMutation,
+      precedingBackendActivations,
+      completion,
+      operation,
+    );
+  }
+
+  poison(): void {
+    this.#poisoned = true;
+  }
+
+  async #executeBackendActivation<T>(
+    precedingMutations: Promise<void>,
+    completion: Deferred,
+    operation: () => Promise<T> | T,
+  ): Promise<T> {
+    try {
+      await precedingMutations;
+      this.#assertOpen();
+      return await operation();
+    } finally {
+      completion.resolve();
+      this.#backendActivations.delete(completion.promise);
+    }
+  }
+
+  async #executeMutation<T>(
+    precedingMutation: Promise<void>,
+    precedingBackendActivations: readonly Promise<void>[],
+    completion: Deferred,
+    operation: () => Promise<T> | T,
+  ): Promise<T> {
+    try {
+      await Promise.all([precedingMutation, ...precedingBackendActivations]);
+      this.#assertOpen();
+      return await operation();
+    } finally {
+      completion.resolve();
+    }
+  }
+
+  #assertOpen(): void {
+    if (this.#poisoned) throw poisonedError();
+  }
+}
+
+interface Deferred {
+  readonly promise: Promise<void>;
+  resolve(): void;
+}
+
+function deferred(): Deferred {
+  let resolve!: () => void;
+  const promise = new Promise<void>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function poisonedError(): Error {
+  return new Error(POISONED_MESSAGE);
+}

--- a/packages/runtime-host/src/server/runtime-policy-coordinator.ts
+++ b/packages/runtime-host/src/server/runtime-policy-coordinator.ts
@@ -1,0 +1,477 @@
+import type {
+  ConnectionCatalogEntry,
+  ConnectionCatalogSnapshot,
+  ConnectionVersionBasis,
+  CredentialLocator,
+  CredentialStatus,
+  MutateRuntimePolicyResult,
+} from '@maka/core/runtime-policy';
+import {
+  authenticateRuntimePolicyStoresWriter,
+  RuntimePolicyStoreError,
+  type RuntimePolicyStoresWriter,
+} from '@maka/storage/runtime-policy-stores';
+import {
+  CONNECTION_CATALOG_PAGE_MAX_BYTES,
+  CONNECTION_CATALOG_PAGE_MAX_ITEMS,
+  type ConnectionCatalogCreateInput,
+  type ConnectionCatalogCursor,
+  type ConnectionCatalogPageItem,
+  type ConnectionCatalogQueryInput,
+  type ConnectionCatalogQueryResult,
+  type ConnectionCatalogRemoveInput,
+  type ConnectionCatalogSetDefaultTargetInput,
+  type ConnectionCatalogUpdateInput,
+  type CredentialVaultDeleteInput,
+  type CredentialVaultQueryInput,
+  type CredentialVaultSetInput,
+  type OperationOutcome,
+  type RuntimePolicyMutateInput,
+} from '../protocol/index.js';
+import type { RuntimePolicyOperationHandlerMap } from './operation-dispatcher.js';
+import { RuntimePolicyActivationGate } from './runtime-policy-activation-gate.js';
+
+type StoreQueryOutcome<T> =
+  | { readonly ok: true; readonly result: T }
+  | {
+      readonly ok: false;
+      readonly error: {
+        readonly code: 'persistence_failed';
+        readonly message: string;
+      };
+    };
+
+type StoreCredentialQueryOutcome<T> =
+  | StoreQueryOutcome<T>
+  | {
+      readonly ok: false;
+      readonly error: {
+        readonly code: 'invalid_request';
+        readonly message: string;
+      };
+    };
+
+type StoreMutationOutcome<T> =
+  | StoreQueryOutcome<T>
+  | {
+      readonly ok: false;
+      readonly error: {
+        readonly code: 'commit_outcome_unknown' | 'invalid_request';
+        readonly message: string;
+      };
+    };
+
+/** Runtime Host control-plane projection over the authentic interactive policy stores. */
+export class HostRuntimePolicyCoordinator {
+  readonly handlers: RuntimePolicyOperationHandlerMap = {
+    'runtime.policy.query': () => this.#queryPolicy(),
+    'runtime.policy.mutate': (input) => this.#mutatePolicy(input),
+    'connection.catalog.query': (input) => this.#queryCatalog(input),
+    'connection.catalog.create': (input) => this.#createConnection(input),
+    'connection.catalog.update': (input) => this.#updateConnection(input),
+    'connection.catalog.remove': (input) => this.#removeConnection(input),
+    'connection.catalog.set-default-target': (input) => this.#setDefaultTarget(input),
+    'credential.vault.query': (input) => this.#queryCredential(input),
+    'credential.vault.set': (input) => this.#setCredential(input),
+    'credential.vault.delete': (input) => this.#deleteCredential(input),
+  };
+
+  readonly #stores: RuntimePolicyStoresWriter;
+
+  constructor(
+    stores: RuntimePolicyStoresWriter,
+    private readonly activation: RuntimePolicyActivationGate,
+    private readonly onCommittedMutation: () => Promise<void> = async () => {},
+  ) {
+    this.#stores = authenticateRuntimePolicyStoresWriter(stores);
+  }
+
+  async #queryPolicy(): Promise<OperationOutcome<'runtime.policy.query'>> {
+    return this.#storeQuery(() => this.#stores.runtimePolicy.getSnapshot());
+  }
+
+  async #mutatePolicy(
+    input: RuntimePolicyMutateInput,
+  ): Promise<OperationOutcome<'runtime.policy.mutate'>> {
+    return this.#storeMutation(async () =>
+      projectPolicyMutation(await this.#stores.runtimePolicy.mutate(input)),
+    );
+  }
+
+  async #queryCatalog(
+    input: ConnectionCatalogQueryInput,
+  ): Promise<OperationOutcome<'connection.catalog.query'>> {
+    const stored = await this.#storeQuery(() => this.#stores.connectionCatalog.getSnapshot());
+    if (!stored.ok) return stored;
+    const snapshot = stored.result;
+    if (input.kind === 'continue' && snapshot.revision !== input.revision) {
+      return {
+        ok: true,
+        result: {
+          kind: 'revision_changed' as const,
+          expectedRevision: input.revision,
+          actualRevision: snapshot.revision,
+        },
+      };
+    }
+
+    const items = projectCatalogItems(snapshot);
+    const offset = input.kind === 'start' ? 0 : cursorOffset(input.cursor, items);
+    if (offset === null) return invalidCatalogRequest();
+    return { ok: true, result: catalogPage(snapshot, items, offset) };
+  }
+
+  async #createConnection(
+    input: ConnectionCatalogCreateInput,
+  ): Promise<OperationOutcome<'connection.catalog.create'>> {
+    return this.#storeMutation(async () => {
+      const result = await this.#stores.connectionCatalog.create(input);
+      if (result.kind === 'revision_conflict' || result.kind === 'connection_exists') return result;
+      if (result.kind !== 'committed') {
+        throw invariantFailure(`Connection create returned ${result.kind}`);
+      }
+      const created = result.snapshot.connections.find(
+        (connection) => connection.slug === input.connection.slug,
+      );
+      if (!created) throw invariantFailure('Committed connection creation omitted its basis');
+      return committedConnection(result.snapshot, created);
+    });
+  }
+
+  async #updateConnection(
+    input: ConnectionCatalogUpdateInput,
+  ): Promise<OperationOutcome<'connection.catalog.update'>> {
+    return this.#storeMutation(async () => {
+      const result = await this.#stores.connectionCatalog.update(input);
+      if (result.kind === 'connection_stale' || result.kind === 'invalid_default_target') {
+        return result;
+      }
+      if (result.kind !== 'committed') {
+        throw invariantFailure(`Connection update returned ${result.kind}`);
+      }
+      const updated = result.snapshot.connections.find(
+        (connection) => connection.connectionId === input.expected.connectionId,
+      );
+      if (!updated) throw invariantFailure('Committed connection update omitted its basis');
+      return committedConnection(result.snapshot, updated);
+    });
+  }
+
+  async #removeConnection(
+    input: ConnectionCatalogRemoveInput,
+  ): Promise<OperationOutcome<'connection.catalog.remove'>> {
+    return this.#storeMutation(async () => {
+      const result = await this.#stores.connectionCatalog.remove(input);
+      if (result.kind === 'connection_stale') return result;
+      if (result.kind !== 'committed') {
+        throw invariantFailure(`Connection remove returned ${result.kind}`);
+      }
+      return committedCatalogRevision(result.snapshot);
+    });
+  }
+
+  async #setDefaultTarget(
+    input: ConnectionCatalogSetDefaultTargetInput,
+  ): Promise<OperationOutcome<'connection.catalog.set-default-target'>> {
+    return this.#storeMutation(async () => {
+      const result = await this.#stores.connectionCatalog.setDefaultTarget(input);
+      if (result.kind === 'revision_conflict' || result.kind === 'invalid_default_target') {
+        return result;
+      }
+      if (result.kind !== 'committed') {
+        throw invariantFailure(`Set default target returned ${result.kind}`);
+      }
+      return committedCatalogRevision(result.snapshot);
+    });
+  }
+
+  async #queryCredential(
+    input: CredentialVaultQueryInput,
+  ): Promise<OperationOutcome<'credential.vault.query'>> {
+    return this.#storeCredentialQuery(() => this.#stores.credentialVault.getStatus(input.locator));
+  }
+
+  async #setCredential(
+    input: CredentialVaultSetInput,
+  ): Promise<OperationOutcome<'credential.vault.set'>> {
+    return this.#storeMutation(async () => {
+      const result = await this.#stores.credentialVault.set(input);
+      if (result.kind === 'connection_not_found' || result.kind === 'credential_stale') {
+        return result;
+      }
+      const status = result.snapshot.entries.find((entry) =>
+        sameLocator(entry.locator, input.locator),
+      );
+      if (!status?.configured) {
+        throw invariantFailure('Committed credential set omitted its configured status');
+      }
+      return { kind: 'committed' as const, vaultRevision: result.snapshot.revision, status };
+    });
+  }
+
+  async #deleteCredential(
+    input: CredentialVaultDeleteInput,
+  ): Promise<OperationOutcome<'credential.vault.delete'>> {
+    return this.#storeMutation(async () => {
+      const result = await this.#stores.credentialVault.delete(input);
+      if (result.kind === 'connection_not_found' || result.kind === 'credential_stale') {
+        return result;
+      }
+      return {
+        kind: 'committed' as const,
+        vaultRevision: result.snapshot.revision,
+        status: unconfiguredStatus(input.expected.locator),
+      };
+    });
+  }
+
+  async #storeQuery<T>(operation: () => Promise<T>): Promise<StoreQueryOutcome<T>> {
+    return this.#runStoreOperation(operation, 'query');
+  }
+
+  async #storeCredentialQuery<T>(
+    operation: () => Promise<T>,
+  ): Promise<StoreCredentialQueryOutcome<T>> {
+    return this.#runStoreOperation(operation, 'credential_query');
+  }
+
+  async #storeMutation<T>(operation: () => Promise<T>): Promise<StoreMutationOutcome<T>> {
+    return this.activation.runMutation(async () => {
+      const outcome = await this.#runStoreOperation(operation, 'mutation');
+      if (
+        (!outcome.ok && outcome.error.code === 'commit_outcome_unknown') ||
+        (outcome.ok && isCommittedMutationResult(outcome.result))
+      ) {
+        try {
+          await this.onCommittedMutation();
+        } catch {
+          // The durable outcome is authoritative, but no later Turn may activate
+          // against a backend whose invalidation did not complete.
+          this.activation.poison();
+        }
+      }
+      return outcome;
+    });
+  }
+
+  async #runStoreOperation<T>(
+    operation: () => Promise<T>,
+    mode: 'query',
+  ): Promise<StoreQueryOutcome<T>>;
+  async #runStoreOperation<T>(
+    operation: () => Promise<T>,
+    mode: 'credential_query',
+  ): Promise<StoreCredentialQueryOutcome<T>>;
+  async #runStoreOperation<T>(
+    operation: () => Promise<T>,
+    mode: 'mutation',
+  ): Promise<StoreMutationOutcome<T>>;
+  async #runStoreOperation<T>(
+    operation: () => Promise<T>,
+    mode: 'query' | 'credential_query' | 'mutation',
+  ): Promise<StoreMutationOutcome<T>> {
+    try {
+      return { ok: true, result: await operation() };
+    } catch (error) {
+      if (!(error instanceof RuntimePolicyStoreError)) throw error;
+      switch (error.code) {
+        case 'commit_outcome_unknown':
+          if (mode !== 'mutation') {
+            throw invariantFailure('A read operation reported an unknown commit outcome');
+          }
+          return {
+            ok: false,
+            error: {
+              code: 'commit_outcome_unknown',
+              message: 'Runtime policy commit outcome is unknown',
+            },
+          };
+        case 'io_failed':
+        case 'invalid_document':
+          return {
+            ok: false,
+            error: {
+              code: 'persistence_failed',
+              message: 'Runtime policy persistence failed',
+            },
+          };
+        case 'invalid_policy_input':
+        case 'invalid_connection_input':
+          if (mode !== 'mutation') {
+            throw invariantFailure('A read operation admitted invalid runtime policy input');
+          }
+          return {
+            ok: false,
+            error: {
+              code: 'invalid_request',
+              message: 'Runtime policy mutation is invalid for the current state',
+            },
+          };
+        case 'invalid_credential_input':
+          if (mode === 'query') {
+            throw invariantFailure('A read operation admitted invalid runtime policy input');
+          }
+          return {
+            ok: false,
+            error: {
+              code: 'invalid_request',
+              message:
+                mode === 'mutation'
+                  ? 'Runtime policy mutation is invalid for the current state'
+                  : 'Credential query is invalid for the current connection',
+            },
+          };
+      }
+    }
+  }
+}
+
+function isCommittedMutationResult(value: unknown): boolean {
+  return (
+    typeof value === 'object' && value !== null && 'kind' in value && value.kind === 'committed'
+  );
+}
+
+function projectPolicyMutation(result: MutateRuntimePolicyResult) {
+  return result.kind === 'committed'
+    ? { kind: 'committed' as const, revision: result.snapshot.revision }
+    : result;
+}
+
+function committedCatalogRevision(snapshot: ConnectionCatalogSnapshot) {
+  return { kind: 'committed' as const, catalogRevision: snapshot.revision };
+}
+
+function committedConnection(
+  snapshot: ConnectionCatalogSnapshot,
+  connection: ConnectionCatalogEntry,
+) {
+  return {
+    kind: 'committed' as const,
+    catalogRevision: snapshot.revision,
+    connection: connectionBasis(connection),
+  };
+}
+
+function connectionBasis(connection: ConnectionCatalogEntry): ConnectionVersionBasis {
+  return { connectionId: connection.connectionId, revision: connection.revision };
+}
+
+function projectCatalogItems(snapshot: ConnectionCatalogSnapshot): ConnectionCatalogPageItem[] {
+  const items: ConnectionCatalogPageItem[] = [];
+  for (const [connectionIndex, connection] of snapshot.connections.entries()) {
+    const { enabledModelIds, models, ...header } = connection;
+    items.push({
+      kind: 'connection',
+      connectionIndex,
+      ...header,
+      enabledModelIdCount: enabledModelIds.length,
+      modelCount: models.length,
+    });
+    for (const [itemIndex, modelId] of enabledModelIds.entries()) {
+      items.push({ kind: 'enabled_model_id', connectionIndex, itemIndex, modelId });
+    }
+    for (const [itemIndex, model] of models.entries()) {
+      items.push({ kind: 'model', connectionIndex, itemIndex, model });
+    }
+  }
+  return items;
+}
+
+function catalogPage(
+  snapshot: ConnectionCatalogSnapshot,
+  allItems: readonly ConnectionCatalogPageItem[],
+  offset: number,
+): ConnectionCatalogQueryResult {
+  const items: ConnectionCatalogPageItem[] = [];
+  const limit = Math.min(allItems.length, offset + CONNECTION_CATALOG_PAGE_MAX_ITEMS);
+  for (let index = offset; index < limit; index += 1) {
+    const item = allItems[index];
+    if (!item) throw invariantFailure('Catalog projection index was out of bounds');
+    const candidate = [...items, item];
+    const nextOffset = offset + candidate.length;
+    const result = {
+      kind: 'page' as const,
+      revision: snapshot.revision,
+      defaultTarget: snapshot.defaultTarget,
+      connectionCount: snapshot.connections.length,
+      items: candidate,
+      nextCursor: nextOffset < allItems.length ? cursorForItem(allItems[nextOffset]) : null,
+    };
+    if (Buffer.byteLength(JSON.stringify(result), 'utf8') > CONNECTION_CATALOG_PAGE_MAX_BYTES) {
+      break;
+    }
+    items.push(item);
+  }
+  if (items.length === 0 && offset < allItems.length) {
+    throw invariantFailure('A legal catalog item exceeded the page result byte limit');
+  }
+  const nextOffset = offset + items.length;
+  return {
+    kind: 'page' as const,
+    revision: snapshot.revision,
+    defaultTarget: snapshot.defaultTarget,
+    connectionCount: snapshot.connections.length,
+    items,
+    nextCursor: nextOffset < allItems.length ? cursorForItem(allItems[nextOffset]) : null,
+  };
+}
+
+function cursorForItem(item: ConnectionCatalogPageItem | undefined): ConnectionCatalogCursor {
+  if (!item) throw invariantFailure('Catalog next cursor had no corresponding item');
+  return item.kind === 'connection'
+    ? { connectionIndex: item.connectionIndex, part: 'connection' }
+    : {
+        connectionIndex: item.connectionIndex,
+        part: item.kind,
+        itemIndex: item.itemIndex,
+      };
+}
+
+function cursorOffset(
+  cursor: ConnectionCatalogCursor,
+  items: readonly ConnectionCatalogPageItem[],
+): number | null {
+  const offset = items.findIndex((item) => sameCursor(item, cursor));
+  return offset >= 0 ? offset : null;
+}
+
+function sameCursor(item: ConnectionCatalogPageItem, cursor: ConnectionCatalogCursor): boolean {
+  if (item.connectionIndex !== cursor.connectionIndex || item.kind !== cursor.part) return false;
+  if (item.kind === 'connection') return cursor.part === 'connection';
+  if (cursor.part === 'connection') return false;
+  return item.itemIndex === cursor.itemIndex;
+}
+
+function invalidCatalogRequest() {
+  return {
+    ok: false as const,
+    error: { code: 'invalid_request' as const, message: 'Invalid connection catalog cursor' },
+  };
+}
+
+function unconfiguredStatus(locator: CredentialLocator): CredentialStatus {
+  return {
+    locator,
+    configured: false,
+    credentialId: null,
+    revision: null,
+    updatedAt: null,
+  };
+}
+
+function sameLocator(left: CredentialLocator, right: CredentialLocator): boolean {
+  if (left.scope !== right.scope || left.kind !== right.kind) return false;
+  switch (left.scope) {
+    case 'connection':
+      return right.scope === 'connection' && left.connectionId === right.connectionId;
+    case 'web_search':
+      return right.scope === 'web_search' && left.provider === right.provider;
+    case 'network_proxy':
+      return right.scope === 'network_proxy';
+  }
+}
+
+function invariantFailure(message: string): Error {
+  return new Error(`Runtime policy coordinator invariant failed: ${message}`);
+}

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -734,10 +734,24 @@ describe('SessionManager child-session runtime primitive', () => {
 
     const originalPrompt = LOCAL_READ_AGENT_DEFINITION.systemPrompt;
     const originalPolicy = LOCAL_READ_AGENT_DEFINITION.categoryPolicy;
+    let parentTurnDrained = false;
+    const drainParentTurn = async (): Promise<void> => {
+      parentGate.release();
+      while (!(await parentTurn.next()).done) {}
+      parentTurnDrained = true;
+    };
     try {
       LOCAL_READ_AGENT_DEFINITION.systemPrompt = 'Changed catalog prompt that must not leak.';
       LOCAL_READ_AGENT_DEFINITION.categoryPolicy = { read: 'block' };
-      await manager.refreshIdleBackends();
+      let refreshSettled = false;
+      const refresh = manager.refreshIdleBackends().finally(() => {
+        refreshSettled = true;
+      });
+      await Promise.resolve();
+      expect(refreshSettled).toBe(false);
+      expect(contexts.filter((ctx) => ctx.sessionId === parent.id).length).toBe(1);
+      await drainParentTurn();
+      await refresh;
       await drain(
         manager.sendMessage(child.childSessionId, {
           turnId: 'child-follow-up',
@@ -745,6 +759,7 @@ describe('SessionManager child-session runtime primitive', () => {
         }),
       );
     } finally {
+      if (!parentTurnDrained) await drainParentTurn();
       LOCAL_READ_AGENT_DEFINITION.systemPrompt = originalPrompt;
       LOCAL_READ_AGENT_DEFINITION.categoryPolicy = originalPolicy;
     }
@@ -772,9 +787,6 @@ describe('SessionManager child-session runtime primitive', () => {
       ),
       /runtime tool snapshot is unavailable/,
     );
-
-    parentGate.release();
-    while (!(await parentTurn.next()).done) {}
   });
 
   test('reopens after restart with isolated history, tool activity, usage, and compaction', async () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -117,6 +117,7 @@ describe('SessionManager child-session runtime primitive', () => {
     const backends = new BackendRegistry();
     const parentGate = makeGate();
     const contexts: BackendFactoryContext[] = [];
+    const backendActivationSessions: string[] = [];
     const backendsBySession = new Map<string, TestBackend>();
     backends.register('fake', (ctx) => {
       contexts.push(ctx);
@@ -133,6 +134,14 @@ describe('SessionManager child-session runtime primitive', () => {
       newId: nextId(),
       now: nextNow(100),
       runtimeSource: 'test',
+      runBackendActivation: async (operation) => {
+        const contextIndex = contexts.length;
+        const result = await operation();
+        const activatedContext = contexts[contextIndex];
+        if (!activatedContext) throw new Error('Backend activation did not build a backend');
+        backendActivationSessions.push(activatedContext.sessionId);
+        return result;
+      },
     });
     const parent = await manager.createSession(
       makeInput({
@@ -202,6 +211,7 @@ describe('SessionManager child-session runtime primitive', () => {
     expect(childRun.agentId).toBe(LOCAL_READ_AGENT_ID);
     expect(isSessionInlineRun(childRun)).toBe(true);
     expect(result.status).toBe('completed');
+    expect(backendActivationSessions).toEqual([parent.id, result.childSessionId]);
     expect(
       (await runStore.readRuntimeEvents(result.childSessionId, childRun.runId)).every(
         (event) => event.sessionId === result.childSessionId,

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -43,7 +43,7 @@ import {
   type BackendFactoryContext,
   type SessionStore,
 } from '../session-manager.js';
-import type { RuntimeKernelLike } from '../runtime-kernel.js';
+import { RuntimeKernel, type RuntimeKernelLike } from '../runtime-kernel.js';
 import { FakeBackend } from '../fake-backend.js';
 import { RuntimeReadModel } from '../runtime-read-model.js';
 import type { AgentBackend } from '@maka/core/backend-types';
@@ -1679,14 +1679,297 @@ describe('SessionManager manual compaction', () => {
 
     const firstTurn = drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hi' }));
     await turnStarted.promise;
-    await manager.refreshIdleBackends();
+    const refresh = manager.refreshIdleBackends();
     expect(store.disposeCount).toBe(0);
 
     sendGate.release();
     await firstTurn;
+    await refresh;
     expect(store.disposeCount).toBe(1);
     await drain(manager.sendMessage(session.id, { turnId: 'turn-2', text: 'again' }));
     expect(builds).toBe(2);
+  });
+
+  test('backend refresh propagates delayed disposal failure after an active turn settles', async () => {
+    const store = new MemorySessionStore();
+    const sendGate = makeGate();
+    const turnStarted = makeGate();
+    const backends = new BackendRegistry();
+    backends.register(
+      'fake',
+      (ctx) =>
+        new (class extends ActiveTurnBackend {
+          override async dispose(): Promise<void> {
+            throw new Error('injected delayed disposal failure');
+          }
+        })(ctx, { turnStarted, sendGate, compactCalls: [] }),
+    );
+    const manager = new SessionManager({
+      store,
+      backends,
+      newId: nextId(),
+      now: nextNow(26_500),
+    });
+    const session = await manager.createSession(makeInput());
+    const firstTurn = drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'hi' }));
+    await turnStarted.promise;
+
+    const refreshResult = manager.refreshIdleBackends().then(
+      () => undefined,
+      (error: unknown) => error,
+    );
+    sendGate.release();
+    await firstTurn;
+
+    const refreshError = await refreshResult;
+    expect(refreshError instanceof Error).toBe(true);
+    expect((refreshError as Error).message).toBe('injected delayed disposal failure');
+  });
+
+  test('backend refresh joins an in-flight best-effort disposal and observes its failure', async () => {
+    const store = new MemorySessionStore();
+    const disposeStarted = makeGate();
+    const releaseDispose = makeGate();
+    let disposeCalls = 0;
+    const backends = new BackendRegistry();
+    backends.register(
+      'fake',
+      (ctx) =>
+        new (class extends TestBackend {
+          override async dispose(): Promise<void> {
+            disposeCalls += 1;
+            disposeStarted.release();
+            await releaseDispose.promise;
+            throw new Error('injected concurrent disposal failure');
+          }
+        })(ctx),
+    );
+    const newId = nextId();
+    const now = nextNow(26_750);
+    const runtimeKernel = new RuntimeKernel({ store, backends, newId, now });
+    const manager = new SessionManager({
+      store,
+      backends,
+      runtimeKernel,
+      newId,
+      now,
+    });
+    const session = await manager.createSession(makeInput());
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-1', text: 'cache me' }));
+
+    const bestEffort = runtimeKernel.invalidateBackend(session.id);
+    await disposeStarted.promise;
+    let strictSettled = false;
+    const strictResult = manager.refreshIdleBackends().then(
+      () => ({ ok: true as const }),
+      (error: unknown) => ({ ok: false as const, error }),
+    );
+    void strictResult.finally(() => {
+      strictSettled = true;
+    });
+    await Promise.resolve();
+    expect(strictSettled).toBe(false);
+
+    releaseDispose.release();
+    await bestEffort;
+    const strict = await strictResult;
+
+    expect(strict.ok).toBe(false);
+    if (strict.ok) throw new Error('Strict refresh unexpectedly succeeded');
+    expect(strict.error instanceof Error).toBe(true);
+    expect((strict.error as Error).message).toBe('injected concurrent disposal failure');
+    expect(disposeCalls).toBe(1);
+  });
+
+  test('backend activation waits for disposal and a later mutation invalidates its replacement', async () => {
+    const store = new MemorySessionStore();
+    const firstDisposeStarted = makeGate();
+    const releaseFirstDispose = makeGate();
+    const replacementPreBuildReached = makeGate();
+    const releaseReplacementPreBuild = makeGate();
+    let replacementCheckpointArmed = true;
+    const runStore = new MemoryAgentRunStore({
+      beforeRuntimeEventAppend: async (_sessionId, _runId, event) => {
+        if (!replacementCheckpointArmed || event.turnId !== 'turn-b') return;
+        replacementCheckpointArmed = false;
+        replacementPreBuildReached.release();
+        await releaseReplacementPreBuild.promise;
+      },
+    });
+    const { runBackendActivation, runMutation } = makeTestRuntimePolicyGate();
+    let builds = 0;
+    const disposed: number[] = [];
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => {
+      const generation = ++builds;
+      return new (class extends TestBackend {
+        override async dispose(): Promise<void> {
+          disposed.push(generation);
+          if (generation === 1) {
+            firstDisposeStarted.release();
+            await releaseFirstDispose.promise;
+          }
+        }
+      })(ctx);
+    });
+    const newId = nextId();
+    const now = nextNow(26_875);
+    const runtimeKernel = new RuntimeKernel({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId,
+      now,
+      runBackendActivation,
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      runtimeKernel,
+      newId,
+      now,
+    });
+    const session = await manager.createSession(makeInput());
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-a', text: 'build A' }));
+
+    const bestEffort = runtimeKernel.invalidateBackend(session.id);
+    await firstDisposeStarted.promise;
+    const replacementTurn = drain(
+      manager.sendMessage(session.id, { turnId: 'turn-b', text: 'build B' }),
+    );
+    await replacementPreBuildReached.promise;
+    releaseReplacementPreBuild.release();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(builds).toBe(1);
+    const mutation = runMutation(() => manager.refreshIdleBackends());
+
+    releaseFirstDispose.release();
+    await bestEffort;
+    await replacementTurn;
+    await mutation;
+
+    expect(builds).toBe(2);
+    expect(disposed).toEqual([1, 2]);
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-c', text: 'build C' }));
+    expect(builds).toBe(3);
+  });
+
+  test('child backend activation waits for disposal and is covered by the later mutation', async () => {
+    const store = new MemorySessionStore();
+    const firstDisposeStarted = makeGate();
+    const releaseFirstDispose = makeGate();
+    const childPreBuildReached = makeGate();
+    const releaseChildPreBuild = makeGate();
+    let childCheckpointArmed = true;
+    const runStore = new MemoryAgentRunStore({
+      beforeRuntimeEventAppend: async (_sessionId, _runId, event) => {
+        if (!childCheckpointArmed || event.turnId !== 'child-turn') return;
+        childCheckpointArmed = false;
+        childPreBuildReached.release();
+        await releaseChildPreBuild.promise;
+      },
+    });
+    const { runBackendActivation, runMutation } = makeTestRuntimePolicyGate();
+    let builds = 0;
+    const disposed: number[] = [];
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => {
+      const generation = ++builds;
+      return new (class extends TestBackend {
+        override async dispose(): Promise<void> {
+          disposed.push(generation);
+          if (generation === 1) {
+            firstDisposeStarted.release();
+            await releaseFirstDispose.promise;
+          }
+        }
+      })(ctx);
+    });
+    const newId = nextId();
+    const now = nextNow(26_900);
+    const runtimeKernel = new RuntimeKernel({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId,
+      now,
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      runBackendActivation,
+    });
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      runtimeKernel,
+      newId,
+      now,
+    });
+    const session = await manager.createSession(makeInput());
+    await drain(manager.sendMessage(session.id, { turnId: 'turn-a', text: 'build A' }));
+
+    const bestEffort = runtimeKernel.invalidateBackend(session.id);
+    await firstDisposeStarted.promise;
+    const childTurn = drain(
+      manager.startChildTurn(session.id, {
+        turnId: 'child-turn',
+        parentRunId: 'parent-run',
+        spec: {
+          id: LOCAL_READ_AGENT_ID,
+          name: 'Researcher',
+          systemPrompt: 'read only',
+        },
+        prompt: 'inspect',
+      }),
+    );
+    await childPreBuildReached.promise;
+    releaseChildPreBuild.release();
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    expect(builds).toBe(1);
+    const mutation = runMutation(() => manager.refreshIdleBackends());
+
+    releaseFirstDispose.release();
+    await bestEffort;
+    await childTurn;
+    await mutation;
+
+    expect(builds).toBe(2);
+    expect(disposed).toEqual([1, 2]);
+  });
+
+  test('backend refresh invalidates only cached sessions without listing persisted history', async () => {
+    const store = new MemorySessionStore();
+    const disposed: string[] = [];
+    const backends = new BackendRegistry();
+    backends.register(
+      'fake',
+      (ctx) =>
+        new (class extends TestBackend {
+          override async dispose(): Promise<void> {
+            disposed.push(this.sessionId);
+          }
+        })(ctx),
+    );
+    const manager = new SessionManager({
+      store,
+      backends,
+      newId: nextId(),
+      now: nextNow(27_000),
+    });
+    const cached = await manager.createSession(makeInput());
+    await manager.createSession(makeInput());
+    await drain(manager.sendMessage(cached.id, { turnId: 'turn-1', text: 'cache me' }));
+    store.list = async () => {
+      throw new Error('refresh must not list persisted sessions');
+    };
+
+    await manager.refreshIdleBackends();
+
+    expect(disposed).toEqual([cached.id]);
   });
 });
 
@@ -2570,7 +2853,7 @@ describe('SessionManager permission mode updates', () => {
     expect(followUpContext.some((event) => event.runId === plan.continuation?.runId)).toBe(true);
   });
 
-  test('stopSession projects an aborted turn state for an active continuation', async () => {
+  test('strict backend refresh settles after an active continuation finalizes', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const turnStarted = makeGate();
@@ -2652,9 +2935,18 @@ describe('SessionManager permission mode updates', () => {
       manager.resumeSafeBoundaryContinuation(plan.continuation),
     );
     await turnStarted.promise;
+    let refreshSettled = false;
+    const refresh = manager.refreshIdleBackends();
+    void refresh.finally(() => {
+      refreshSettled = true;
+    });
+    await Promise.resolve();
+    expect(refreshSettled).toBe(false);
     await manager.stopSession(session.id, { source: 'stop_button' });
     sendGate.release();
     await execution;
+    await refresh;
+    expect(store.disposeCount).toBe(1);
 
     const cachedMessages = await store.readMessages(session.id);
     expect(
@@ -13033,6 +13325,10 @@ class DelegatingRuntimeKernel implements RuntimeKernelLike {
     if (!this.activeRuns) this.disposed.push(sessionId);
   }
 
+  async invalidateCachedBackends(): Promise<void> {
+    // This test double does not retain backend instances between calls.
+  }
+
   async disposeBackend(sessionId: string): Promise<void> {
     this.disposed.push(sessionId);
   }
@@ -14641,6 +14937,11 @@ class MemoryAgentRunStore implements AgentRunStore, RuntimeEventStore {
       failUpdateRunStatusOnce?: AgentRunHeader['status'];
       failContinuationCreate?: boolean;
       beforeRuntimeEventRead?: (sessionId: string, runId: string) => Promise<void> | void;
+      beforeRuntimeEventAppend?: (
+        sessionId: string,
+        runId: string,
+        event: RuntimeEvent,
+      ) => Promise<void> | void;
       beforeRunRead?: (sessionId: string, runId: string) => Promise<void> | void;
       beforeAgentRunEventAppend?: (
         sessionId: string,
@@ -14710,6 +15011,7 @@ class MemoryAgentRunStore implements AgentRunStore, RuntimeEventStore {
   }
 
   async appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void> {
+    await this.options.beforeRuntimeEventAppend?.(sessionId, runId, event);
     if (this.options.failRuntimeEventAppends) throw new Error('runtime event append failed');
     this.runtimeEventAppendCount += 1;
     if (
@@ -15017,6 +15319,29 @@ function makeGate(): Gate {
     release = resolve;
   });
   return { promise, release };
+}
+
+function makeTestRuntimePolicyGate(): {
+  runBackendActivation<T>(operation: () => Promise<T> | T): Promise<T>;
+  runMutation<T>(operation: () => Promise<T>): Promise<T>;
+} {
+  const activeActivations = new Set<Promise<void>>();
+  return {
+    async runBackendActivation<T>(operation: () => Promise<T> | T): Promise<T> {
+      const completion = makeGate();
+      activeActivations.add(completion.promise);
+      try {
+        return await operation();
+      } finally {
+        completion.release();
+        activeActivations.delete(completion.promise);
+      }
+    },
+    async runMutation<T>(operation: () => Promise<T>): Promise<T> {
+      await Promise.all([...activeActivations]);
+      return operation();
+    },
+  };
 }
 
 function makeInput(overrides: Partial<CreateSessionInput> = {}): CreateSessionInput {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -165,6 +165,8 @@ interface SessionSteeringState {
   activeTurnId?: string;
 }
 
+export type BackendActivationBoundary = <T>(operation: () => Promise<T> | T) => Promise<T>;
+
 export interface RuntimeKernelDeps {
   store: SessionStore;
   runStore?: AgentRunStore;
@@ -183,6 +185,7 @@ export interface RuntimeKernelDeps {
   inspectContinuationSafety?: (sessionId: string) => Promise<RuntimeContinuationSafetyObservation>;
   safeBoundaryResumeEnabled?: boolean;
   continuationFailpoint?: (point: RuntimeContinuationFailpoint) => Promise<void>;
+  runBackendActivation?: BackendActivationBoundary;
 }
 
 export interface HistoryCompactCleanupRequest {
@@ -249,6 +252,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
     if (deps.runStore && !deps.runtimeEventStore) {
       throw new Error('RuntimeEventStore is required when AgentRunStore is configured');
     }
+  }
+
+  private async runBackendActivation<T>(operation: () => Promise<T> | T): Promise<T> {
+    return await (this.deps.runBackendActivation?.(operation) ?? operation());
   }
 
   async *startTurn(
@@ -468,7 +475,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
 
     let begin: Awaited<ReturnType<typeof run.beginOperation>>;
     try {
-      begin = await run.beginOperation();
+      begin = await this.runBackendActivation(() => run.beginOperation());
     } catch (error) {
       await run.recordFailure(error);
       await run.finalize();
@@ -746,7 +753,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     let flowDone = false;
     let begin: AgentRunBeginResult;
     try {
-      begin = await run.begin();
+      begin = await this.runBackendActivation(() => run.begin());
       if (onRunStarted && initialHeader) await onRunStarted(run.runId, initialHeader);
     } catch (error) {
       await run.recordFailure(error);
@@ -932,9 +939,9 @@ export class RuntimeKernel implements RuntimeKernelLike {
     let flowDone = false;
     let begin: Awaited<ReturnType<AgentRun['beginContinuation']>>;
     try {
-      begin = persistContinuationSource
-        ? await run.beginContinuation(continuation)
-        : await run.beginOperation();
+      begin = await this.runBackendActivation(() =>
+        persistContinuationSource ? run.beginContinuation(continuation) : run.beginOperation(),
+      );
     } catch (error) {
       await run.recordFailure(error);
       await run.finalize();

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -104,6 +104,7 @@ export interface RuntimeKernelLike {
   hasActiveRun?(sessionId: string, runId: string, turnId?: string): boolean;
   updateCachedHeader(sessionId: string, header: SessionHeader): void;
   invalidateBackend(sessionId: string): Promise<void>;
+  invalidateCachedBackends(): Promise<void>;
   disposeBackend(sessionId: string): Promise<void>;
 }
 
@@ -226,6 +227,14 @@ interface PendingStopAttempt {
   delivery: Promise<void>;
 }
 
+type BackendDisposalOutcome = { ok: true } | { ok: false; error: unknown };
+
+interface BackendInvalidationState {
+  readonly outcome: Promise<BackendDisposalOutcome>;
+  resolve(outcome: BackendDisposalOutcome): void;
+  disposal?: Promise<void>;
+}
+
 export class RuntimeKernel implements RuntimeKernelLike {
   private readonly active = new Map<string, ActiveSession>();
   private readonly childActive = new Map<string, ActiveSession>();
@@ -246,7 +255,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   private readonly pendingContinuationClaims = new Set<string>();
   private readonly pendingContinuationSessions = new Set<string>();
   private readonly steeringBySession = new Map<string, SessionSteeringState>();
-  private readonly backendInvalidations = new Set<string>();
+  private readonly backendInvalidations = new Map<string, BackendInvalidationState>();
 
   constructor(private readonly deps: RuntimeKernelDeps) {
     if (deps.runStore && !deps.runtimeEventStore) {
@@ -421,7 +430,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
         ensureActive: (targetSessionId, nextHeader) =>
           this.ensureActive(targetSessionId, nextHeader),
         registerRun: (active, activeRun) => this.registerRun(active, activeRun),
-        unregisterRun: (active, activeRun) => this.unregisterRun(active, activeRun),
+        unregisterRun: (active, activeRun) => this.unregisterParentRun(active, activeRun),
         updateHeader: (targetSessionId, patch) => this.updateHeader(targetSessionId, patch),
         updateStatus: (targetSessionId, status, blockedReason, ts) =>
           this.updateStatus(targetSessionId, status, blockedReason, ts),
@@ -1359,12 +1368,30 @@ export class RuntimeKernel implements RuntimeKernelLike {
   }
 
   async invalidateBackend(sessionId: string): Promise<void> {
-    this.backendInvalidations.add(sessionId);
+    this.ensureBackendInvalidation(sessionId);
     await this.flushBackendInvalidation(sessionId);
   }
 
+  async invalidateCachedBackends(): Promise<void> {
+    const sessionIds = new Set(this.active.keys());
+    for (const active of this.childActive.values()) sessionIds.add(active.sessionId);
+    for (const sessionId of this.backendInvalidations.keys()) sessionIds.add(sessionId);
+    await Promise.all(
+      [...sessionIds].map(async (sessionId) => {
+        const invalidation = this.ensureBackendInvalidation(sessionId);
+        await this.flushBackendInvalidation(sessionId);
+        const outcome = await invalidation.outcome;
+        if (!outcome.ok) throw outcome.error;
+      }),
+    );
+  }
+
   async disposeBackend(sessionId: string): Promise<void> {
-    this.backendInvalidations.delete(sessionId);
+    const invalidation = this.ensureBackendInvalidation(sessionId);
+    await this.startBackendDisposal(sessionId, invalidation);
+  }
+
+  private async disposeBackendNow(sessionId: string): Promise<BackendDisposalOutcome> {
     const activeSessions = this.activeSessionsFor(sessionId);
     this.active.delete(sessionId);
     this.steeringBySession.delete(sessionId);
@@ -1373,13 +1400,15 @@ export class RuntimeKernel implements RuntimeKernelLike {
     for (const [key, active] of this.childActive.entries()) {
       if (active.sessionId === sessionId) this.childActive.delete(key);
     }
+    let disposalError: unknown;
     for (const active of activeSessions) {
       try {
         await active.backend.dispose();
-      } catch {
-        // best-effort
+      } catch (error) {
+        disposalError ??= error;
       }
     }
+    return disposalError === undefined ? { ok: true } : { ok: false, error: disposalError };
   }
 
   private activeSessionsFor(sessionId: string): ActiveSession[] {
@@ -1495,7 +1524,13 @@ export class RuntimeKernel implements RuntimeKernelLike {
   }
 
   private async ensureActive(sessionId: string, header: SessionHeader): Promise<ActiveSession> {
-    const existing = this.active.get(sessionId);
+    let existing = this.active.get(sessionId);
+    if (existing) {
+      existing.cachedHeader = header;
+      return existing;
+    }
+    await this.waitForBackendDisposal(sessionId);
+    existing = this.active.get(sessionId);
     if (existing) {
       existing.cachedHeader = header;
       return existing;
@@ -1623,7 +1658,13 @@ export class RuntimeKernel implements RuntimeKernelLike {
     tools: readonly MakaTool[],
     agentTeam?: AgentTeamExecutionContext,
   ): Promise<ActiveSession> {
-    const existing = this.childActive.get(activeKey);
+    let existing = this.childActive.get(activeKey);
+    if (existing) {
+      existing.cachedHeader = header;
+      return existing;
+    }
+    await this.waitForBackendDisposal(sessionId);
+    existing = this.childActive.get(activeKey);
     if (existing) {
       existing.cachedHeader = header;
       return existing;
@@ -1733,6 +1774,10 @@ export class RuntimeKernel implements RuntimeKernelLike {
   ): Promise<void> {
     this.unregisterRun(active, run);
     if (active.activeRuns.size > 0) return;
+    if (this.backendInvalidations.has(active.sessionId)) {
+      await this.flushBackendInvalidation(active.sessionId);
+      return;
+    }
     this.childActive.delete(activeKey);
     try {
       await active.backend.dispose();
@@ -1743,8 +1788,47 @@ export class RuntimeKernel implements RuntimeKernelLike {
   }
 
   private async flushBackendInvalidation(sessionId: string): Promise<void> {
-    if (!this.backendInvalidations.has(sessionId) || this.hasActiveRuns(sessionId)) return;
-    await this.disposeBackend(sessionId);
+    const invalidation = this.backendInvalidations.get(sessionId);
+    if (!invalidation || this.hasActiveRuns(sessionId)) return;
+    await this.startBackendDisposal(sessionId, invalidation);
+  }
+
+  private async waitForBackendDisposal(sessionId: string): Promise<void> {
+    const invalidation = this.backendInvalidations.get(sessionId);
+    if (invalidation?.disposal) await invalidation.outcome;
+  }
+
+  private async startBackendDisposal(
+    sessionId: string,
+    invalidation: BackendInvalidationState,
+  ): Promise<void> {
+    if (!invalidation.disposal) {
+      invalidation.disposal = (async () => {
+        let outcome: BackendDisposalOutcome;
+        try {
+          outcome = await this.disposeBackendNow(sessionId);
+        } catch (error) {
+          outcome = { ok: false, error };
+        }
+        invalidation.resolve(outcome);
+        if (this.backendInvalidations.get(sessionId) === invalidation) {
+          this.backendInvalidations.delete(sessionId);
+        }
+      })();
+    }
+    await invalidation.disposal;
+  }
+
+  private ensureBackendInvalidation(sessionId: string): BackendInvalidationState {
+    const existing = this.backendInvalidations.get(sessionId);
+    if (existing) return existing;
+    let resolve!: (outcome: BackendDisposalOutcome) => void;
+    const outcome = new Promise<BackendDisposalOutcome>((resolvePromise) => {
+      resolve = resolvePromise;
+    });
+    const invalidation = { outcome, resolve };
+    this.backendInvalidations.set(sessionId, invalidation);
+    return invalidation;
   }
 
   private async updateStatus(

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -108,7 +108,12 @@ import type { HistoryCompactCheckpoint } from './history-compact-checkpoint.js';
 import type { AgentRunLineage, RuntimeContinuationFailpoint } from './agent-run.js';
 import { classifyAgentRunRecovery, type AgentRunRecoveryDecision } from './agent-run-recovery.js';
 import type { InvocationResult, InvocationSource } from './invocation-context.js';
-import { RuntimeKernel, type RuntimeKernelLike, type TurnStartOptions } from './runtime-kernel.js';
+import {
+  RuntimeKernel,
+  type BackendActivationBoundary,
+  type RuntimeKernelLike,
+  type TurnStartOptions,
+} from './runtime-kernel.js';
 import { fallbackSessionTitle, sessionTitleSource } from './session-title.js';
 import type { HistoryCompactCleanupRequest } from './runtime-kernel.js';
 import {
@@ -452,6 +457,7 @@ export interface SessionManagerDeps {
   cleanupHistoryCompactArtifacts?: (input: HistoryCompactCleanupRequest) => Promise<void>;
   inspectContinuationSafety?: (sessionId: string) => Promise<RuntimeContinuationSafetyObservation>;
   continuationFailpoint?: (point: RuntimeContinuationFailpoint) => Promise<void>;
+  runBackendActivation?: BackendActivationBoundary;
   safeBoundaryResumeEnabled?: boolean;
   onContinuationLifecycleEvent?: (event: RuntimeContinuationLifecycleEvent) => void | Promise<void>;
   generateSessionTitle?: (input: {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -547,8 +547,7 @@ export class SessionManager {
 
   /** Invalidate backend snapshots now, or immediately after active turns settle. */
   async refreshIdleBackends(): Promise<void> {
-    const sessions = await this.deps.store.list();
-    await Promise.all(sessions.map((session) => this.runtimeKernel.invalidateBackend(session.id)));
+    await this.runtimeKernel.invalidateCachedBackends();
   }
 
   async getMessages(sessionId: string): Promise<StoredMessage[]> {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -9,6 +9,7 @@
     ".": "./dist/index.js",
     "./execution-stores": "./dist/execution-stores.js",
     "./root-authority": "./dist/root-authority.js",
+    "./runtime-policy-stores": "./dist/runtime-policy-stores.js",
     "./workspace-identity": "./dist/workspace-identity.js",
     "./write-queue": "./dist/write-queue.js"
   },

--- a/packages/storage/src/__tests__/runtime-policy-stores.test.ts
+++ b/packages/storage/src/__tests__/runtime-policy-stores.test.ts
@@ -1,0 +1,1090 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import {
+  lstat,
+  mkdtemp,
+  open,
+  readFile,
+  readdir,
+  rm,
+  stat,
+  symlink,
+  writeFile,
+} from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { describe, mock, test } from 'node:test';
+import type {
+  ConnectionCatalogEntry,
+  ConnectionCatalogEntryDraft,
+  ConnectionVersionBasis,
+  CredentialLocator,
+  CredentialStatus,
+  CredentialVersionBasis,
+  MutateRuntimePolicyInput,
+  RuntimePolicy,
+} from '@maka/core/runtime-policy';
+import {
+  createHeadlessRootLease,
+  resolveStorageRoot,
+  StorageRootAuthorityError,
+  tryAcquireInteractiveRootOwner,
+  tryAcquireInteractiveRootReader,
+  type StorageRootLease,
+} from '../root-authority.js';
+import {
+  authenticateRuntimePolicyStoresReader,
+  authenticateRuntimePolicyStoresWriter,
+  openInteractiveRuntimePolicyStoresForRead,
+  openInteractiveRuntimePolicyStoresForWrite,
+  RuntimePolicyStoreError,
+} from '../runtime-policy-stores.js';
+
+const execFileAsync = promisify(execFile);
+
+describe('runtime policy stores', () => {
+  test('commits closed policy mutations, canonicalizes proxy hosts, and preserves connection identity', async () => {
+    await withInteractiveOwner(async ({ root, stores }) => {
+      const policy = await stores.runtimePolicy.mutate(personalizationMutation(0));
+      assert.equal(policy.kind, 'committed');
+      assert.deepEqual(
+        await stores.runtimePolicy.mutate({
+          expectedRevision: 0,
+          operation: {
+            kind: 'set_memory',
+            value: { enabled: false, agentReadEnabled: false },
+          },
+        }),
+        {
+          kind: 'revision_conflict',
+          expectedRevision: 0,
+          actualRevision: 1,
+        },
+      );
+      await assert.rejects(
+        () =>
+          stores.runtimePolicy.mutate({
+            expectedRevision: 1,
+            operation: { kind: 'replace_everything', value: {} },
+          } as unknown as MutateRuntimePolicyInput),
+        isStoreError('invalid_policy_input'),
+      );
+      for (const host of ['   ', 'proxy\u0000.internal']) {
+        await assert.rejects(
+          () => stores.runtimePolicy.mutate(networkProxyMutation(1, { host })),
+          isStoreError('invalid_policy_input'),
+        );
+      }
+      const proxy = await stores.runtimePolicy.mutate(
+        networkProxyMutation(1, {
+          host: ' proxy.internal ',
+          authEnabled: false,
+          username: '',
+        }),
+      );
+      assert.equal(proxy.kind, 'committed');
+      if (proxy.kind === 'committed')
+        assert.equal(proxy.snapshot.policy.networkProxy.host, 'proxy.internal');
+
+      const connection = await createConnection(stores, 0, {
+        ...connectionDraft('openai-main', 'openai', 'OpenAI'),
+        baseUrl: 'HTTPS://API.OPENAI.COM:443/v1',
+      });
+      assert.match(connection.connectionId, UUID_PATTERN);
+      assert.equal(connection.baseUrl, undefined);
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.baseUrl,
+        undefined,
+      );
+      assert.deepEqual(connectionBasis(connection), {
+        connectionId: connection.connectionId,
+        revision: 1,
+      });
+
+      const target = { connectionId: connection.connectionId, modelId: 'gpt-5' };
+      assert.equal(
+        (
+          await stores.connectionCatalog.setDefaultTarget({
+            expectedCatalogRevision: 1,
+            target,
+          })
+        ).kind,
+        'committed',
+      );
+
+      const changes = {
+        name: 'Renamed',
+        baseUrl: ' https://Gateway.EXAMPLE:443/v1 ',
+        enabled: true,
+        enabledModelIds: ['gpt-5'],
+      };
+      await assert.rejects(
+        () =>
+          stores.connectionCatalog.update({
+            expected: connectionBasis(connection),
+            changes: { ...changes, slug: 'replacement', providerType: 'anthropic' },
+          } as never),
+        isStoreError('invalid_connection_input'),
+      );
+      const updated = await stores.connectionCatalog.update({
+        expected: connectionBasis(connection),
+        changes,
+      });
+      assert.equal(updated.kind, 'committed');
+      if (updated.kind !== 'committed') return;
+      const current = updated.snapshot.connections[0];
+      assert.ok(current);
+      assert.equal(current.connectionId, connection.connectionId);
+      assert.equal(current.slug, 'openai-main');
+      assert.equal(current.providerType, 'openai');
+      assert.equal(current.name, 'Renamed');
+      assert.equal(current.baseUrl, 'https://gateway.example/v1');
+      assert.deepEqual(updated.snapshot.defaultTarget, target);
+
+      const persisted = JSON.parse(
+        await readFile(join(root, 'connection-catalog.json'), 'utf8'),
+      ) as {
+        connections: Array<Record<string, unknown>>;
+      };
+      assert.equal(persisted.connections[0]?.baseUrl, 'https://gateway.example/v1');
+    });
+  });
+
+  test('rejects a valid mutation whose combined policy document exceeds its byte limit', async () => {
+    await withInteractiveOwner(async ({ root, stores }) => {
+      const committed = await stores.runtimePolicy.mutate(personalizationMutation(0));
+      assert.equal(committed.kind, 'committed');
+      if (committed.kind !== 'committed') return;
+      const path = join(root, 'runtime-policy.json');
+      const persistedBefore = await readFile(path);
+
+      const entries = Array.from(
+        { length: 64 },
+        (_, index) => `domain-${index}-${'x'.repeat(480)}`,
+      );
+      await assert.rejects(
+        () =>
+          stores.runtimePolicy.mutate(
+            networkProxyMutation(1, {
+              bypassList: entries.map((entry) => `bypass-${entry}`),
+              autoBypassDomains: entries.map((entry) => `auto-${entry}`),
+            }),
+          ),
+        isStoreError('invalid_policy_input'),
+      );
+
+      assert.deepEqual(await stores.runtimePolicy.getSnapshot(), committed.snapshot);
+      assert.deepEqual(await readFile(path), persistedBefore);
+    });
+  });
+
+  test('rejects a valid create when the aggregate catalog exceeds its byte limit', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const enabledModelIds = Array.from({ length: 512 }, (_, index) => {
+        const prefix = index.toString(36).padStart(4, '0');
+        return `${prefix}-${'m'.repeat(507)}`;
+      });
+      let revision = 0;
+      let rejected = false;
+
+      for (let index = 0; index < 32; index += 1) {
+        try {
+          const result = await stores.connectionCatalog.create({
+            expectedCatalogRevision: revision,
+            connection: {
+              ...connectionDraft(`catalog-cap-${index}`, 'openai', `Catalog cap ${index}`),
+              enabledModelIds,
+            },
+          });
+          assert.equal(result.kind, 'committed');
+          if (result.kind !== 'committed') {
+            throw new Error('catalog capacity setup did not commit');
+          }
+          revision = result.snapshot.revision;
+        } catch (error) {
+          assert.ok(isStoreError('invalid_connection_input')(error));
+          rejected = true;
+          break;
+        }
+      }
+
+      assert.equal(rejected, true);
+      const snapshot = await stores.connectionCatalog.getSnapshot();
+      assert.equal(snapshot.revision, revision);
+      assert.equal(snapshot.connections.length, revision);
+    });
+  });
+
+  test('rejects a valid secret when the aggregate vault exceeds its byte limit', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const secret = 's'.repeat(64 * 1024);
+      let catalogRevision = 0;
+      let vaultRevision = 0;
+      let rejected = false;
+
+      for (let index = 0; index < 40; index += 1) {
+        const connection = await createConnection(
+          stores,
+          catalogRevision,
+          connectionDraft(`vault-cap-${index}`, 'openai', `Vault cap ${index}`),
+        );
+        catalogRevision += 1;
+        try {
+          const result = await stores.credentialVault.set({
+            locator: connectionCredential(connection, 'api_key'),
+            expected: null,
+            secret,
+          });
+          assert.equal(result.kind, 'committed');
+          if (result.kind !== 'committed') {
+            throw new Error('vault capacity setup did not commit');
+          }
+          vaultRevision = result.snapshot.revision;
+        } catch (error) {
+          assert.ok(isStoreError('invalid_credential_input')(error));
+          rejected = true;
+          break;
+        }
+      }
+
+      assert.equal(rejected, true);
+      const snapshot = await stores.credentialVault.getSnapshot();
+      assert.equal(snapshot.revision, vaultRevision);
+      assert.equal(snapshot.entries.length, vaultRevision);
+    });
+  });
+
+  test('owns endpoints and fails closed on unsafe or unreachable persisted connection state', async () => {
+    await withInteractiveOwner(async ({ root, stores }) => {
+      const rejected: ConnectionCatalogEntryDraft[] = [
+        { ...connectionDraft('ftp', 'openai', 'FTP'), baseUrl: 'ftp://example.com/v1' },
+        {
+          ...connectionDraft('userinfo', 'openai', 'Userinfo'),
+          baseUrl: 'https://user:pass@example.com/v1',
+        },
+        {
+          ...connectionDraft('query', 'openai', 'Query'),
+          baseUrl: 'https://example.com/v1?tenant=a',
+        },
+        {
+          ...connectionDraft('fragment', 'openai', 'Fragment'),
+          baseUrl: 'https://example.com/v1#models',
+        },
+        {
+          ...connectionDraft('oauth', 'github-copilot', 'OAuth'),
+          baseUrl: 'https://example.com/copilot',
+        },
+      ];
+      for (const connection of rejected) {
+        await assert.rejects(
+          () => stores.connectionCatalog.create({ expectedCatalogRevision: 0, connection }),
+          isStoreError('invalid_connection_input'),
+        );
+      }
+
+      const canonical = await createConnection(stores, 0, {
+        ...connectionDraft('canonical', 'openai', 'Canonical'),
+        baseUrl: 'HTTPS://Gateway.EXAMPLE:443/v1',
+      });
+      assert.equal(canonical.baseUrl, 'https://gateway.example/v1');
+
+      const path = join(root, 'connection-catalog.json');
+      const document = JSON.parse(await readFile(path, 'utf8')) as {
+        connections: Array<Record<string, unknown>>;
+      };
+      document.connections[0]!.models = [{ id: 'persisted-but-unreachable' }];
+      const unreachable = `${JSON.stringify(document)}\n`;
+      await writeFile(path, unreachable, 'utf8');
+      await assert.rejects(
+        () => stores.connectionCatalog.getSnapshot(),
+        isStoreError('invalid_document'),
+      );
+      assert.equal(await readFile(path, 'utf8'), unreachable);
+    });
+  });
+
+  test('validates credential locators and redacts credential status', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const required = await createConnection(
+        stores,
+        0,
+        connectionDraft('required', 'openai', 'Required key'),
+      );
+
+      assert.deepEqual(
+        await stores.credentialVault.getStatus({
+          scope: 'connection',
+          connectionId: '00000000-0000-4000-8000-000000000001',
+          kind: 'api_key',
+        }),
+        { kind: 'connection_not_found' },
+      );
+      await assert.rejects(
+        () => stores.credentialVault.getStatus(connectionCredential(required, 'oauth_token')),
+        isStoreError('invalid_credential_input'),
+      );
+
+      const apiSecret = 'api-secret-never-redacted-back';
+      const proxySecret = 'proxy-secret-never-redacted-back';
+      const apiSet = await stores.credentialVault.set({
+        locator: connectionCredential(required, 'api_key'),
+        expected: null,
+        secret: apiSecret,
+      });
+      assert.equal(apiSet.kind, 'committed');
+      const proxySet = await stores.credentialVault.set({
+        locator: proxyCredential(),
+        expected: null,
+        secret: proxySecret,
+      });
+      assert.equal(proxySet.kind, 'committed');
+
+      const requiredStatus = await getCredentialStatus(
+        stores.credentialVault,
+        connectionCredential(required, 'api_key'),
+      );
+      const proxyStatus = await getCredentialStatus(stores.credentialVault, proxyCredential());
+      const publicViews = JSON.stringify([
+        apiSet,
+        proxySet,
+        requiredStatus,
+        proxyStatus,
+        await stores.credentialVault.getSnapshot(),
+      ]);
+      assert.equal(publicViews.includes(apiSecret), false);
+      assert.equal(publicViews.includes(proxySecret), false);
+    });
+  });
+
+  test('resolves execution connection material from one mutation cut', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const disabled = await createConnection(stores, 0, {
+        ...connectionDraft('execution-disabled', 'openai', 'Disabled'),
+        enabled: false,
+      });
+      const required = await createConnection(
+        stores,
+        1,
+        connectionDraft('execution-required', 'openai', 'Required'),
+      );
+      const optional = await createConnection(
+        stores,
+        2,
+        connectionDraft('execution-optional', 'localai', 'Optional'),
+      );
+      const none = await createConnection(
+        stores,
+        3,
+        connectionDraft('execution-none', 'ollama', 'None'),
+      );
+
+      assert.deepEqual(await stores.operations.resolveExecutionConnection('missing'), {
+        kind: 'not_found',
+      });
+      assert.deepEqual(await stores.operations.resolveExecutionConnection(disabled.slug), {
+        kind: 'disabled',
+      });
+
+      const missingRequired = await stores.operations.resolveExecutionConnection(required.slug);
+      assert.equal(missingRequired.kind, 'credential_not_configured');
+      if (missingRequired.kind === 'credential_not_configured') {
+        assert.deepEqual(missingRequired.status.locator, connectionCredential(required, 'api_key'));
+      }
+      for (const connection of [optional, none]) {
+        const resolved = await stores.operations.resolveExecutionConnection(connection.slug);
+        assert.equal(resolved.kind, 'ready');
+        if (resolved.kind === 'ready') assert.deepEqual(resolved.secretMaterial, {});
+      }
+
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: connectionCredential(required, 'api_key'),
+            expected: null,
+            secret: 'execution-connection-secret',
+          })
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (
+          await stores.runtimePolicy.mutate(
+            networkProxyMutation(0, { host: 'execution.proxy.internal' }),
+          )
+        ).kind,
+        'committed',
+      );
+      const missingProxy = await stores.operations.resolveExecutionConnection(required.slug);
+      assert.equal(missingProxy.kind, 'credential_not_configured');
+      if (missingProxy.kind === 'credential_not_configured') {
+        assert.deepEqual(missingProxy.status.locator, proxyCredential());
+      }
+
+      const [proxySet, resolved] = await Promise.all([
+        stores.credentialVault.set({
+          locator: proxyCredential(),
+          expected: null,
+          secret: 'execution-proxy-secret',
+        }),
+        stores.operations.resolveExecutionConnection(required.slug),
+      ]);
+      assert.equal(proxySet.kind, 'committed');
+      assert.equal(resolved.kind, 'ready');
+      if (resolved.kind !== 'ready') return;
+      assert.deepEqual(resolved.connection, required);
+      assert.equal(resolved.networkProxy.host, 'execution.proxy.internal');
+      assert.equal(resolved.secretMaterial.connection?.secret, 'execution-connection-secret');
+      assert.equal(resolved.secretMaterial.networkProxy?.secret, 'execution-proxy-secret');
+    });
+  });
+
+  test('allows only Copilot OAuth tokens through the public credential setter', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const claude = await createConnection(
+        stores,
+        0,
+        connectionDraft('public-claude', 'claude-subscription', 'Public Claude'),
+      );
+      const codex = await createConnection(
+        stores,
+        1,
+        connectionDraft('public-codex', 'openai-codex', 'Public Codex'),
+      );
+      const copilot = await createConnection(
+        stores,
+        2,
+        connectionDraft('public-copilot', 'github-copilot', 'Public Copilot'),
+      );
+      const preview = await createConnection(
+        stores,
+        3,
+        connectionDraft('public-preview', 'gemini-cli', 'Public preview'),
+      );
+      const apiKey = await createConnection(
+        stores,
+        4,
+        connectionDraft('public-api-key', 'openai', 'Public API key'),
+      );
+
+      for (const connection of [claude, codex, preview]) {
+        await assert.rejects(
+          () =>
+            stores.credentialVault.set({
+              locator: connectionCredential(connection, 'oauth_token'),
+              expected: null,
+              secret: 'public-oauth-must-be-rejected',
+            }),
+          isStoreError('invalid_credential_input'),
+        );
+        assert.equal(
+          (
+            await getCredentialStatus(
+              stores.credentialVault,
+              connectionCredential(connection, 'oauth_token'),
+            )
+          ).configured,
+          false,
+        );
+      }
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: connectionCredential(copilot, 'oauth_token'),
+            expected: null,
+            secret: 'copilot-import',
+          })
+        ).kind,
+        'committed',
+      );
+      for (const input of [
+        {
+          locator: connectionCredential(apiKey, 'api_key'),
+          expected: null,
+          secret: 'api-key-input',
+        },
+        {
+          locator: {
+            scope: 'web_search' as const,
+            provider: 'tavily' as const,
+            kind: 'api_key' as const,
+          },
+          expected: null,
+          secret: 'web-search-input',
+        },
+        { locator: proxyCredential(), expected: null, secret: 'proxy-input' },
+      ]) {
+        assert.equal((await stores.credentialVault.set(input)).kind, 'committed');
+      }
+    });
+  });
+
+  test('removes credentials only for a matching connection revision and converges on partial retries', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const original = await createConnection(
+        stores,
+        0,
+        connectionDraft('removable', 'openai', 'Removable'),
+      );
+      const locator = connectionCredential(original, 'api_key');
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator,
+            expected: null,
+            secret: 'must-survive-stale-remove',
+          })
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (
+          await stores.connectionCatalog.setDefaultTarget({
+            expectedCatalogRevision: 1,
+            target: { connectionId: original.connectionId, modelId: 'gpt-5' },
+          })
+        ).kind,
+        'committed',
+      );
+      const updatedResult = await stores.connectionCatalog.update({
+        expected: connectionBasis(original),
+        changes: {
+          name: 'Current revision',
+          enabled: true,
+          enabledModelIds: ['gpt-5'],
+        },
+      });
+      assert.equal(updatedResult.kind, 'committed');
+      if (updatedResult.kind !== 'committed') return;
+      const updated = updatedResult.snapshot.connections[0];
+      assert.ok(updated);
+
+      const stale = await stores.connectionCatalog.remove({ expected: connectionBasis(original) });
+      assert.equal(stale.kind, 'connection_stale');
+      assert.deepEqual((await stores.connectionCatalog.getSnapshot()).defaultTarget, {
+        connectionId: original.connectionId,
+        modelId: 'gpt-5',
+      });
+
+      const removed = await stores.connectionCatalog.remove({ expected: connectionBasis(updated) });
+      assert.equal(removed.kind, 'committed');
+      if (removed.kind !== 'committed') return;
+      assert.deepEqual(removed.snapshot.connections, []);
+      assert.equal(removed.snapshot.defaultTarget, null);
+      assert.deepEqual((await stores.credentialVault.getSnapshot()).entries, []);
+      assert.deepEqual(await stores.credentialVault.getStatus(locator), {
+        kind: 'connection_not_found',
+      });
+      const retry = await stores.connectionCatalog.remove({ expected: connectionBasis(updated) });
+      assert.equal(retry.kind, 'committed');
+      if (retry.kind === 'committed')
+        assert.equal(retry.snapshot.revision, removed.snapshot.revision);
+
+      const recreated = await createConnection(
+        stores,
+        removed.snapshot.revision,
+        connectionDraft('removable', 'openai', 'Recreated'),
+      );
+      assert.notEqual(recreated.connectionId, original.connectionId);
+      const recreatedLocator = connectionCredential(recreated, 'api_key');
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: recreatedLocator,
+            expected: null,
+            secret: 'partial-state-secret',
+          })
+        ).kind,
+        'committed',
+      );
+      const recreatedStatus = await getCredentialStatus(stores.credentialVault, recreatedLocator);
+      assert.equal(
+        (
+          await stores.credentialVault.delete({
+            expected: credentialBasis(recreatedStatus),
+          })
+        ).kind,
+        'committed',
+      );
+      const converged = await stores.connectionCatalog.remove({
+        expected: connectionBasis(recreated),
+      });
+      assert.equal(converged.kind, 'committed');
+      if (converged.kind === 'committed') assert.deepEqual(converged.snapshot.connections, []);
+      assert.deepEqual((await stores.credentialVault.getSnapshot()).entries, []);
+    });
+  });
+
+  test('successor recovery removes credentials orphaned by an interrupted connection removal', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    await withInteractiveRoot(async ({ root, capability }) => {
+      const firstOwner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(firstOwner);
+      if (!firstOwner) return;
+      const interrupted = await (async () => {
+        try {
+          const stores = await openInteractiveRuntimePolicyStoresForWrite(firstOwner.lease);
+          const connection = await createConnection(
+            stores,
+            0,
+            connectionDraft('interrupted-remove', 'openai', 'Interrupted remove'),
+          );
+          const locator = connectionCredential(connection, 'api_key');
+          assert.equal(
+            (
+              await stores.credentialVault.set({
+                locator,
+                expected: null,
+                secret: 'cleanup-after-restart',
+              })
+            ).kind,
+            'committed',
+          );
+
+          const probe = await open(root, 'r');
+          const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+            sync: typeof probe.sync;
+          };
+          const originalSync = fileHandlePrototype.sync;
+          await probe.close();
+          let syncCalls = 0;
+          const syncMock = mock.method(
+            fileHandlePrototype,
+            'sync',
+            async function (this: typeof probe) {
+              syncCalls += 1;
+              if (syncCalls === 3) throw new Error('injected credential cleanup failure');
+              return originalSync.call(this);
+            },
+          );
+          try {
+            await assert.rejects(
+              stores.connectionCatalog.remove({ expected: connectionBasis(connection) }),
+              isStoreError('commit_outcome_unknown'),
+            );
+          } finally {
+            syncMock.mock.restore();
+          }
+
+          assert.equal(syncCalls, 3);
+          const committedCatalog = await stores.connectionCatalog.getSnapshot();
+          assert.deepEqual(committedCatalog.connections, []);
+          assert.equal((await stores.credentialVault.getSnapshot()).entries.length, 1);
+          return {
+            basis: connectionBasis(connection),
+            catalogRevision: committedCatalog.revision,
+          };
+        } finally {
+          if (!firstOwner.closed) await firstOwner.close();
+        }
+      })();
+
+      const successor = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(successor);
+      if (!successor) return;
+      try {
+        const stores = await openInteractiveRuntimePolicyStoresForWrite(successor.lease);
+        assert.deepEqual((await stores.credentialVault.getSnapshot()).entries, []);
+        const retry = await stores.connectionCatalog.remove({
+          expected: interrupted.basis,
+        });
+        assert.equal(retry.kind, 'committed');
+        if (retry.kind === 'committed') {
+          assert.equal(retry.snapshot.revision, interrupted.catalogRevision);
+        }
+      } finally {
+        if (!successor.closed) await successor.close();
+      }
+    });
+  });
+
+  test('drains every synchronously admitted ordered mutation before owner close completes', async () => {
+    await withInteractiveRoot(async ({ capability }) => {
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      const stores = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+
+      const first = stores.runtimePolicy.mutate(personalizationMutation(0));
+      const second = stores.runtimePolicy.mutate({
+        expectedRevision: 1,
+        operation: {
+          kind: 'set_memory',
+          value: { enabled: false, agentReadEnabled: false },
+        },
+      });
+      const third = stores.runtimePolicy.mutate({
+        expectedRevision: 2,
+        operation: {
+          kind: 'set_privacy',
+          value: { incognitoActive: true },
+        },
+      });
+      const closing = owner.close();
+      assert.equal(owner.closed, true);
+
+      const results = await Promise.all([first, second, third, closing]);
+      assert.deepEqual(
+        results.slice(0, 3).map((result) => result?.kind),
+        ['committed', 'committed', 'committed'],
+      );
+
+      const readerHandle = await tryAcquireInteractiveRootReader(capability);
+      assert.ok(readerHandle);
+      if (!readerHandle) return;
+      try {
+        const reader = await openInteractiveRuntimePolicyStoresForRead(readerHandle.lease);
+        const snapshot = await reader.runtimePolicy.getSnapshot();
+        assert.equal(snapshot.revision, 3);
+        assert.deepEqual(snapshot.policy.personalization, {
+          displayName: 'Maka',
+          assistantTone: 'concise',
+        });
+        assert.deepEqual(snapshot.policy.memory, { enabled: false, agentReadEnabled: false });
+        assert.deepEqual(snapshot.policy.privacy, { incognitoActive: true });
+      } finally {
+        await readerHandle.close();
+      }
+    });
+  });
+
+  test('fails closed on final symlinks, FIFOs, and oversized documents without changing bytes', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    await withInteractiveOwner(async ({ root, stores }) => {
+      const external = join(root, '..', 'external-policy.json');
+      const original = Buffer.from('{"external":true}\n');
+      await writeFile(external, original);
+      await symlink(external, join(root, 'runtime-policy.json'));
+      await assert.rejects(
+        () => stores.runtimePolicy.mutate(personalizationMutation(0)),
+        isStoreError('invalid_document'),
+      );
+      assert.deepEqual(await readFile(external), original);
+      assert.equal((await lstat(join(root, 'runtime-policy.json'))).isSymbolicLink(), true);
+    });
+
+    await withInteractiveOwner(async ({ root, stores }) => {
+      const path = join(root, 'runtime-policy.json');
+      await execFileAsync('mkfifo', [path]);
+      await assert.rejects(
+        () => stores.runtimePolicy.getSnapshot(),
+        isStoreError('invalid_document'),
+      );
+      assert.equal((await lstat(path)).isFIFO(), true);
+    });
+
+    await withInteractiveOwner(async ({ root, stores }) => {
+      const path = join(root, 'runtime-policy.json');
+      const original = Buffer.alloc(256 * 1024 + 1, 0x78);
+      await writeFile(path, original);
+      await assert.rejects(
+        () => stores.runtimePolicy.mutate(personalizationMutation(0)),
+        isStoreError('invalid_document'),
+      );
+      assert.deepEqual(await readFile(path), original);
+    });
+  });
+
+  test('single-flights writer recovery and preserves credential material across owner reopen', async () => {
+    await withInteractiveRoot(async ({ root, capability }) => {
+      const firstOwner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(firstOwner);
+      if (!firstOwner) return;
+      let connection!: ConnectionCatalogEntry;
+      let firstStatus!: CredentialStatus;
+      const secret = 'persisted-secret-after-recovery';
+      const temporaryNames = [
+        'runtime-policy.json.11111111-1111-4111-8111-111111111111.tmp',
+        'connection-catalog.json.22222222-2222-4222-8222-222222222222.tmp',
+        'credential-vault.json.33333333-3333-4333-8333-333333333333.tmp',
+      ];
+      try {
+        await Promise.all([
+          writeFile(join(root, temporaryNames[0]!), '{"orphan":true}\n', 'utf8'),
+          writeFile(join(root, temporaryNames[1]!), '{"orphan":true}\n', 'utf8'),
+          writeFile(join(root, temporaryNames[2]!), 'plaintext-credential-orphan\n', 'utf8'),
+        ]);
+        const [first, sameLeaseOpen] = await Promise.all([
+          openInteractiveRuntimePolicyStoresForWrite(firstOwner.lease),
+          openInteractiveRuntimePolicyStoresForWrite(firstOwner.lease),
+        ]);
+        assert.equal(first, sameLeaseOpen);
+        const remaining = new Set(await readdir(root));
+        assert.deepEqual(
+          temporaryNames.filter((name) => remaining.has(name)),
+          [],
+        );
+
+        connection = await createConnection(
+          first,
+          0,
+          connectionDraft('reopen', 'openai', 'Reopen'),
+        );
+        const locator = connectionCredential(connection, 'api_key');
+        assert.equal(
+          (
+            await first.credentialVault.set({
+              locator,
+              expected: null,
+              secret,
+            })
+          ).kind,
+          'committed',
+        );
+        firstStatus = await getCredentialStatus(first.credentialVault, locator);
+        assert.equal(JSON.stringify(firstStatus).includes(secret), false);
+      } finally {
+        if (!firstOwner.closed) await firstOwner.close();
+      }
+
+      const secondOwner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(secondOwner);
+      if (!secondOwner) return;
+      try {
+        const second = await openInteractiveRuntimePolicyStoresForWrite(secondOwner.lease);
+        const resolved = await second.operations.resolveExecutionConnection(connection.slug);
+        assert.equal(resolved.kind, 'ready');
+        if (resolved.kind !== 'ready') return;
+        assert.equal(resolved.secretMaterial.connection?.secret, secret);
+        assert.equal(resolved.secretMaterial.connection?.credentialId, firstStatus.credentialId);
+      } finally {
+        if (!secondOwner.closed) await secondOwner.close();
+      }
+
+      const readerHandle = await tryAcquireInteractiveRootReader(capability);
+      assert.ok(readerHandle);
+      if (!readerHandle) return;
+      try {
+        const reader = await openInteractiveRuntimePolicyStoresForRead(readerHandle.lease);
+        const publicStatus = await getCredentialStatus(
+          reader.credentialVault,
+          connectionCredential(connection, 'api_key'),
+        );
+        assert.equal(publicStatus.credentialId, firstStatus.credentialId);
+        const publicViews = JSON.stringify([
+          publicStatus,
+          await reader.credentialVault.getSnapshot(),
+        ]);
+        assert.equal(publicViews.includes(secret), false);
+      } finally {
+        await readerHandle.close();
+      }
+    });
+  });
+
+  test('rejects headless leases, forged facades, and operations after interactive lease close', async () => {
+    await withTempDir(async (base) => {
+      const headlessRoot = join(base, 'headless');
+      const headless = await resolveStorageRoot({ path: headlessRoot, kind: 'headless' });
+      const before = await snapshotRoot(headlessRoot);
+      await assert.rejects(
+        () =>
+          openInteractiveRuntimePolicyStoresForWrite(
+            createHeadlessRootLease(headless, 'write') as unknown as StorageRootLease<
+              'interactive',
+              'write'
+            >,
+          ),
+        isInvalidLease,
+      );
+      assert.deepEqual(await snapshotRoot(headlessRoot), before);
+    });
+
+    await withInteractiveRoot(async ({ capability }) => {
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      const writer = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+      assert.equal(authenticateRuntimePolicyStoresWriter(writer), writer);
+      assert.throws(() => authenticateRuntimePolicyStoresWriter({ ...writer }), isInvalidLease);
+      await owner.close();
+      await assert.rejects(() => writer.runtimePolicy.getSnapshot(), isInvalidLease);
+
+      const readerHandle = await tryAcquireInteractiveRootReader(capability);
+      assert.ok(readerHandle);
+      if (!readerHandle) return;
+      const reader = await openInteractiveRuntimePolicyStoresForRead(readerHandle.lease);
+      assert.equal(authenticateRuntimePolicyStoresReader(reader), reader);
+      assert.throws(() => authenticateRuntimePolicyStoresReader({ ...reader }), isInvalidLease);
+      await readerHandle.close();
+      await assert.rejects(() => reader.connectionCatalog.getSnapshot(), isInvalidLease);
+    });
+  });
+});
+
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
+
+type Writer = Awaited<ReturnType<typeof openInteractiveRuntimePolicyStoresForWrite>>;
+
+async function createConnection(
+  stores: Writer,
+  expectedCatalogRevision: number,
+  connection: ConnectionCatalogEntryDraft,
+): Promise<ConnectionCatalogEntry> {
+  const result = await stores.connectionCatalog.create({ expectedCatalogRevision, connection });
+  assert.equal(result.kind, 'committed');
+  if (result.kind !== 'committed') throw new Error('connection creation did not commit');
+  const created = result.snapshot.connections.find((item) => item.slug === connection.slug);
+  assert.ok(created);
+  return created;
+}
+
+function connectionDraft(
+  slug: string,
+  providerType: ConnectionCatalogEntryDraft['providerType'],
+  name: string,
+): ConnectionCatalogEntryDraft {
+  return {
+    slug,
+    name,
+    providerType,
+    enabled: true,
+    enabledModelIds: ['gpt-5'],
+  };
+}
+
+function connectionBasis(connection: ConnectionCatalogEntry): ConnectionVersionBasis {
+  return { connectionId: connection.connectionId, revision: connection.revision };
+}
+
+function connectionCredential(
+  connection: ConnectionCatalogEntry,
+  kind: 'api_key' | 'oauth_token',
+): Extract<CredentialLocator, { scope: 'connection' }> {
+  return { scope: 'connection', connectionId: connection.connectionId, kind };
+}
+
+function proxyCredential(): Extract<CredentialLocator, { scope: 'network_proxy' }> {
+  return { scope: 'network_proxy', kind: 'password' };
+}
+
+async function getCredentialStatus(
+  vault: Pick<Writer['credentialVault'], 'getStatus'>,
+  locator: CredentialLocator,
+): Promise<CredentialStatus> {
+  const result = await vault.getStatus(locator);
+  assert.equal(result.kind, 'status');
+  if (result.kind !== 'status') throw new Error('credential status query did not return a status');
+  return result.status;
+}
+
+function credentialBasis(status: CredentialStatus): CredentialVersionBasis {
+  assert.equal(status.configured, true);
+  if (!status.configured) throw new Error('credential is not configured');
+  return {
+    locator: status.locator,
+    credentialId: status.credentialId,
+    revision: status.revision,
+  };
+}
+
+function credentialExpectation(status: CredentialStatus): {
+  credentialId: string;
+  revision: number;
+} {
+  const basis = credentialBasis(status);
+  return { credentialId: basis.credentialId, revision: basis.revision };
+}
+
+function personalizationMutation(expectedRevision: number): MutateRuntimePolicyInput {
+  return {
+    expectedRevision,
+    operation: {
+      kind: 'set_personalization',
+      value: { displayName: 'Maka', assistantTone: 'concise' },
+    },
+  };
+}
+
+function networkProxyMutation(
+  expectedRevision: number,
+  changes: Partial<RuntimePolicy['networkProxy']> = {},
+): MutateRuntimePolicyInput {
+  return {
+    expectedRevision,
+    operation: {
+      kind: 'set_network_proxy',
+      value: {
+        enabled: true,
+        protocol: 'http',
+        host: '127.0.0.1',
+        port: 8080,
+        authEnabled: true,
+        username: 'proxy-user',
+        bypassList: ['localhost'],
+        autoBypassDomains: ['127.0.0.1'],
+        ...changes,
+      },
+    },
+  };
+}
+
+function isStoreError(code: RuntimePolicyStoreError['code']) {
+  return (error: unknown) => error instanceof RuntimePolicyStoreError && error.code === code;
+}
+
+function isInvalidLease(error: unknown): boolean {
+  return error instanceof StorageRootAuthorityError && error.code === 'invalid_lease';
+}
+
+async function withInteractiveOwner(
+  run: (input: { root: string; stores: Writer }) => Promise<void>,
+): Promise<void> {
+  await withInteractiveRoot(async ({ root, capability }) => {
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    if (!owner) return;
+    try {
+      await run({ root, stores: await openInteractiveRuntimePolicyStoresForWrite(owner.lease) });
+    } finally {
+      if (!owner.closed) await owner.close();
+    }
+  });
+}
+
+async function withInteractiveRoot(
+  run: (input: {
+    root: string;
+    capability: Awaited<ReturnType<typeof resolveStorageRoot<'interactive'>>>;
+  }) => Promise<void>,
+): Promise<void> {
+  await withTempDir(async (base) => {
+    const root = join(base, 'interactive');
+    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    await run({ root, capability });
+  });
+}
+
+async function withTempDir(run: (base: string) => Promise<void>): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-runtime-policy-'));
+  try {
+    await run(base);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+async function snapshotRoot(root: string): Promise<readonly RootSnapshotEntry[]> {
+  const names = (await readdir(root)).sort();
+  return Promise.all(
+    names.map(async (name) => {
+      const path = join(root, name);
+      const metadata = await stat(path);
+      return {
+        name,
+        size: metadata.size,
+        mtimeMs: metadata.mtimeMs,
+        contents: metadata.isFile() ? await readFile(path, 'utf8') : null,
+      };
+    }),
+  );
+}
+
+interface RootSnapshotEntry {
+  readonly name: string;
+  readonly size: number;
+  readonly mtimeMs: number;
+  readonly contents: string | null;
+}

--- a/packages/storage/src/runtime-policy-stores.ts
+++ b/packages/storage/src/runtime-policy-stores.ts
@@ -1,0 +1,215 @@
+import type {
+  ConnectionCatalogMutationResult,
+  ConnectionCatalogSnapshot,
+  CreateCatalogConnectionInput,
+  CredentialLocator,
+  CredentialMutationResult,
+  CredentialVaultSnapshot,
+  DeleteCredentialInput,
+  MutateRuntimePolicyInput,
+  MutateRuntimePolicyResult,
+  RemoveCatalogConnectionInput,
+  RuntimePolicySnapshot,
+  SetCredentialInput,
+  SetDefaultConnectionTargetInput,
+  UpdateCatalogConnectionInput,
+} from '@maka/core/runtime-policy';
+import {
+  assertStorageRootLease,
+  runWithStorageRootLease,
+  StorageRootAuthorityError,
+  type StorageRootLease,
+} from './root-authority.js';
+import { RuntimePolicyCoordinator } from './runtime-policy/coordinator.js';
+import type {
+  CredentialStatusQueryResult as CredentialStatusQuery,
+  RuntimePolicyOperationCoordinator as OperationCoordinator,
+} from './runtime-policy/operations.js';
+
+export {
+  RuntimePolicyStoreError,
+  type RuntimePolicyStoreErrorCode,
+} from './runtime-policy/errors.js';
+export type {
+  CredentialStatusQueryResult,
+  ProviderAuthKind,
+  RuntimePolicyCredentialMaterial,
+  RuntimePolicyOperationCoordinator,
+  RuntimePolicyOperationSecretMaterial,
+  ResolveExecutionConnectionResult,
+} from './runtime-policy/operations.js';
+
+const readerBrand: unique symbol = Symbol('RuntimePolicyStoresReader');
+const writerBrand: unique symbol = Symbol('RuntimePolicyStoresWriter');
+const readers = new WeakSet<object>();
+const writers = new WeakSet<object>();
+const writerByLease = new WeakMap<object, RuntimePolicyStoresWriter>();
+const writerOpeningByLease = new WeakMap<object, Promise<RuntimePolicyStoresWriter>>();
+
+export interface RuntimePolicyReader {
+  getSnapshot(): Promise<RuntimePolicySnapshot>;
+}
+
+export interface RuntimePolicyWriter extends RuntimePolicyReader {
+  mutate(input: MutateRuntimePolicyInput): Promise<MutateRuntimePolicyResult>;
+}
+
+export interface ConnectionCatalogReader {
+  getSnapshot(): Promise<ConnectionCatalogSnapshot>;
+}
+
+export interface ConnectionCatalogWriter extends ConnectionCatalogReader {
+  create(input: CreateCatalogConnectionInput): Promise<ConnectionCatalogMutationResult>;
+  update(input: UpdateCatalogConnectionInput): Promise<ConnectionCatalogMutationResult>;
+  remove(input: RemoveCatalogConnectionInput): Promise<ConnectionCatalogMutationResult>;
+  setDefaultTarget(
+    input: SetDefaultConnectionTargetInput,
+  ): Promise<ConnectionCatalogMutationResult>;
+}
+
+export interface CredentialVaultReader {
+  getSnapshot(): Promise<CredentialVaultSnapshot>;
+  getStatus(locator: CredentialLocator): Promise<CredentialStatusQuery>;
+}
+
+export interface CredentialVaultWriter extends CredentialVaultReader {
+  set(input: SetCredentialInput): Promise<CredentialMutationResult>;
+  delete(input: DeleteCredentialInput): Promise<CredentialMutationResult>;
+}
+
+export interface RuntimePolicyStoresReader {
+  readonly kind: 'interactive';
+  readonly access: 'read';
+  readonly [readerBrand]: true;
+  readonly runtimePolicy: Readonly<RuntimePolicyReader>;
+  readonly connectionCatalog: Readonly<ConnectionCatalogReader>;
+  readonly credentialVault: Readonly<CredentialVaultReader>;
+}
+
+export interface RuntimePolicyStoresWriter {
+  readonly kind: 'interactive';
+  readonly access: 'write';
+  readonly [writerBrand]: true;
+  readonly runtimePolicy: Readonly<RuntimePolicyWriter>;
+  readonly connectionCatalog: Readonly<ConnectionCatalogWriter>;
+  readonly credentialVault: Readonly<CredentialVaultWriter>;
+  readonly operations: Readonly<OperationCoordinator>;
+}
+
+export function authenticateRuntimePolicyStoresReader(
+  stores: RuntimePolicyStoresReader,
+): RuntimePolicyStoresReader {
+  if (!readers.has(stores)) throw invalidFacade('read');
+  return stores;
+}
+
+export function authenticateRuntimePolicyStoresWriter(
+  stores: RuntimePolicyStoresWriter,
+): RuntimePolicyStoresWriter {
+  if (!writers.has(stores)) throw invalidFacade('write');
+  return stores;
+}
+
+export async function openInteractiveRuntimePolicyStoresForRead(
+  lease: StorageRootLease<'interactive', 'read'>,
+): Promise<RuntimePolicyStoresReader> {
+  await assertStorageRootLease(lease, 'interactive', 'read');
+  const coordinator = new RuntimePolicyCoordinator(<T>(operation: (root: string) => Promise<T>) =>
+    runWithStorageRootLease(lease, 'interactive', 'read', operation),
+  );
+  const stores: RuntimePolicyStoresReader = {
+    kind: 'interactive',
+    access: 'read',
+    [readerBrand]: true,
+    runtimePolicy: { getSnapshot: () => coordinator.getPolicySnapshot() },
+    connectionCatalog: { getSnapshot: () => coordinator.getCatalogSnapshot() },
+    credentialVault: {
+      getSnapshot: () => coordinator.getVaultSnapshot(),
+      getStatus: (locator) => coordinator.getCredentialStatus(locator),
+    },
+  };
+  freezeFacade(stores);
+  readers.add(stores);
+  return stores;
+}
+
+export async function openInteractiveRuntimePolicyStoresForWrite(
+  lease: StorageRootLease<'interactive', 'write'>,
+): Promise<RuntimePolicyStoresWriter> {
+  await assertStorageRootLease(lease, 'interactive', 'write');
+  const existing = writerByLease.get(lease);
+  if (existing) return existing;
+  const opening = writerOpeningByLease.get(lease);
+  if (opening) return opening;
+
+  const coordinator = new RuntimePolicyCoordinator(<T>(operation: (root: string) => Promise<T>) =>
+    runWithStorageRootLease(lease, 'interactive', 'write', operation),
+  );
+  const pending = Promise.resolve().then(async () => {
+    await coordinator.recoverForWrite();
+    await assertStorageRootLease(lease, 'interactive', 'write');
+    const recoveredExisting = writerByLease.get(lease);
+    if (recoveredExisting) return recoveredExisting;
+    const stores = createWriterFacade(coordinator);
+    writers.add(stores);
+    writerByLease.set(lease, stores);
+    return stores;
+  });
+  writerOpeningByLease.set(lease, pending);
+  try {
+    return await pending;
+  } finally {
+    if (writerOpeningByLease.get(lease) === pending) writerOpeningByLease.delete(lease);
+  }
+}
+
+function createWriterFacade(coordinator: RuntimePolicyCoordinator): RuntimePolicyStoresWriter {
+  const stores: RuntimePolicyStoresWriter = {
+    kind: 'interactive',
+    access: 'write',
+    [writerBrand]: true,
+    runtimePolicy: {
+      getSnapshot: () => coordinator.getPolicySnapshot(),
+      mutate: (input) => coordinator.mutatePolicy(input),
+    },
+    connectionCatalog: {
+      getSnapshot: () => coordinator.getCatalogSnapshot(),
+      create: (input) => coordinator.createConnection(input),
+      update: (input) => coordinator.updateConnection(input),
+      remove: (input) => coordinator.removeConnection(input),
+      setDefaultTarget: (input) => coordinator.setDefaultTarget(input),
+    },
+    credentialVault: {
+      getSnapshot: () => coordinator.getVaultSnapshot(),
+      getStatus: (locator) => coordinator.getCredentialStatus(locator),
+      set: (input) => coordinator.setCredential(input),
+      delete: (input) => coordinator.deleteCredential(input),
+    },
+    operations: {
+      resolveExecutionConnection: (connectionSlug) =>
+        coordinator.resolveExecutionConnection(connectionSlug),
+    },
+  };
+  freezeFacade(stores);
+  return stores;
+}
+
+function invalidFacade(access: 'read' | 'write'): StorageRootAuthorityError {
+  return new StorageRootAuthorityError(
+    'invalid_lease',
+    `Expected authentic interactive ${access} runtime policy stores`,
+  );
+}
+
+function freezeFacade(stores: {
+  readonly runtimePolicy: object;
+  readonly connectionCatalog: object;
+  readonly credentialVault: object;
+  readonly operations?: object;
+}): void {
+  Object.freeze(stores.runtimePolicy);
+  Object.freeze(stores.connectionCatalog);
+  Object.freeze(stores.credentialVault);
+  if (stores.operations) Object.freeze(stores.operations);
+  Object.freeze(stores);
+}

--- a/packages/storage/src/runtime-policy/codec.ts
+++ b/packages/storage/src/runtime-policy/codec.ts
@@ -1,0 +1,65 @@
+import type { Revision } from '@maka/core/runtime-policy';
+import { codecError, type CodecSource } from './errors.js';
+
+export function record(
+  value: unknown,
+  context: string,
+  source: CodecSource,
+  allowed: readonly string[],
+  required: readonly string[] = allowed,
+): Record<string, unknown> {
+  if (value === null || typeof value !== 'object' || Array.isArray(value)) {
+    throw codecError(source, `${context} must be an object`);
+  }
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw codecError(source, `${context} must be a plain object`);
+  }
+  const candidate = value as Record<string, unknown>;
+  const allowedSet = new Set(allowed);
+  for (const key of Object.keys(candidate)) {
+    if (!allowedSet.has(key))
+      throw codecError(source, `${context} contains unknown field '${key}'`);
+  }
+  for (const key of required) {
+    if (!Object.hasOwn(candidate, key)) throw codecError(source, `${context} is missing '${key}'`);
+  }
+  return candidate;
+}
+
+export function revision(value: unknown, context: string, source: CodecSource): Revision {
+  return integer(value, context, 0, Number.MAX_SAFE_INTEGER, source);
+}
+
+export function integer(
+  value: unknown,
+  context: string,
+  min: number,
+  max: number,
+  source: CodecSource,
+): number {
+  if (!Number.isSafeInteger(value) || (value as number) < min || (value as number) > max) {
+    throw codecError(source, `${context} must be an integer between ${min} and ${max}`);
+  }
+  return value as number;
+}
+
+export function unique(values: readonly string[], context: string, source: CodecSource): void {
+  if (new Set(values).size !== values.length) {
+    throw codecError(source, `${context} values must be unique`);
+  }
+}
+
+export function nextRevision(value: Revision): Revision {
+  if (value >= Number.MAX_SAFE_INTEGER) {
+    throw codecError('invalid_document', 'Revision space is exhausted');
+  }
+  return value + 1;
+}
+
+export function deepFreeze<T>(value: T): T {
+  if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
+  Object.freeze(value);
+  for (const item of Object.values(value)) deepFreeze(item);
+  return value;
+}

--- a/packages/storage/src/runtime-policy/connection-catalog-document.ts
+++ b/packages/storage/src/runtime-policy/connection-catalog-document.ts
@@ -1,0 +1,284 @@
+import { randomUUID } from 'node:crypto';
+import {
+  CONNECTION_CATALOG_MAX_CONNECTIONS,
+  decodeCanonicalConnectionCatalogEntry,
+  decodeConnectionTarget,
+  decodeConnectionVersionBasis,
+  normalizeConnectionCatalogEntryUpdateForProvider,
+  normalizeCreateCatalogConnectionInput,
+  normalizeRemoveCatalogConnectionInput,
+  normalizeSetDefaultConnectionTargetInput,
+  normalizeUpdateCatalogConnectionInput,
+  type ConnectionCatalogEntry,
+  type ConnectionCatalogMutationResult,
+  type ConnectionCatalogSnapshot,
+  type ConnectionTarget,
+  type ConnectionVersionBasis,
+  type CreateCatalogConnectionInput,
+  type RemoveCatalogConnectionInput,
+  type SetDefaultConnectionTargetInput,
+  type UpdateCatalogConnectionInput,
+} from '@maka/core/runtime-policy';
+import { deepFreeze, nextRevision, record, revision, unique } from './codec.js';
+import {
+  codecError,
+  decodeConnectionInput,
+  decodePersistedDomain,
+  RuntimePolicyStoreError,
+} from './errors.js';
+import {
+  CATALOG_DOCUMENT_MAX_BYTES,
+  readBoundedJsonDocument,
+  serializeJsonDocument,
+  writeJsonDocument,
+} from './document-io.js';
+
+const FILE = 'connection-catalog.json';
+const SCHEMA_VERSION = 1 as const;
+
+export interface ConnectionCatalogDocument {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly revision: number;
+  readonly defaultTarget: ConnectionTarget | null;
+  readonly connections: readonly ConnectionCatalogEntry[];
+}
+
+export class ConnectionCatalogDocumentOwner {
+  async read(root: string): Promise<ConnectionCatalogDocument> {
+    const value = await readBoundedJsonDocument(root, FILE, CATALOG_DOCUMENT_MAX_BYTES);
+    if (value === undefined) {
+      return { schemaVersion: SCHEMA_VERSION, revision: 0, defaultTarget: null, connections: [] };
+    }
+    const raw = record(value, FILE, 'invalid_document', [
+      'schemaVersion',
+      'revision',
+      'defaultTarget',
+      'connections',
+    ]);
+    if (raw.schemaVersion !== SCHEMA_VERSION) {
+      throw codecError('invalid_document', `${FILE} has an unsupported schema version`);
+    }
+    if (
+      !Array.isArray(raw.connections) ||
+      raw.connections.length > CONNECTION_CATALOG_MAX_CONNECTIONS
+    ) {
+      throw codecError('invalid_document', `${FILE}.connections must be a bounded array`);
+    }
+    const connections = raw.connections.map((item) =>
+      decodePersistedDomain(() => decodeCanonicalConnectionCatalogEntry(item)),
+    );
+    unique(
+      connections.map((item) => item.slug),
+      `${FILE} connection slugs`,
+      'invalid_document',
+    );
+    unique(
+      connections.map((item) => item.connectionId),
+      `${FILE} connection ids`,
+      'invalid_document',
+    );
+    const defaultTarget =
+      raw.defaultTarget === null
+        ? null
+        : decodePersistedDomain(() => decodeConnectionTarget(raw.defaultTarget));
+    if (defaultTarget && !isValidTarget(defaultTarget, connections)) {
+      throw codecError('invalid_document', `${FILE} contains an invalid default target`);
+    }
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      revision: revision(raw.revision, `${FILE}.revision`, 'invalid_document'),
+      defaultTarget,
+      connections,
+    };
+  }
+
+  async create(
+    root: string,
+    rawInput: CreateCatalogConnectionInput,
+  ): Promise<ConnectionCatalogMutationResult> {
+    const input = decodeConnectionInput(() => normalizeCreateCatalogConnectionInput(rawInput));
+    const current = await this.read(root);
+    if (current.revision !== input.expectedCatalogRevision) {
+      return revisionConflict(input.expectedCatalogRevision, current.revision);
+    }
+    if (current.connections.some((item) => item.slug === input.connection.slug)) {
+      return deepFreeze({ kind: 'connection_exists', slug: input.connection.slug });
+    }
+    if (current.connections.length >= CONNECTION_CATALOG_MAX_CONNECTIONS) {
+      throw codecError(
+        'invalid_connection_input',
+        `Connection catalog cannot exceed ${CONNECTION_CATALOG_MAX_CONNECTIONS} entries`,
+      );
+    }
+    const next: ConnectionCatalogDocument = {
+      ...current,
+      revision: nextRevision(current.revision),
+      connections: [
+        ...current.connections,
+        {
+          ...input.connection,
+          connectionId: randomUUID(),
+          revision: 1,
+          models: [],
+        },
+      ],
+    };
+    await this.write(root, next);
+    return committed(next);
+  }
+
+  async update(
+    root: string,
+    rawInput: UpdateCatalogConnectionInput,
+  ): Promise<ConnectionCatalogMutationResult> {
+    const input = decodeConnectionInput(() => normalizeUpdateCatalogConnectionInput(rawInput));
+    const current = await this.read(root);
+    const index = findConnectionIndex(current, input.expected);
+    const previous = index < 0 ? undefined : current.connections[index];
+    if (!previous || previous.revision !== input.expected.revision) {
+      return connectionStale(input.expected, previous ? connectionBasis(previous) : null);
+    }
+    const changes = decodeConnectionInput(() =>
+      normalizeConnectionCatalogEntryUpdateForProvider(input.changes, previous.providerType),
+    );
+    const endpointChanged = previous.baseUrl !== changes.baseUrl;
+    const connections = [...current.connections];
+    connections[index] = {
+      connectionId: previous.connectionId,
+      revision: nextRevision(previous.revision),
+      slug: previous.slug,
+      name: changes.name,
+      providerType: previous.providerType,
+      ...(changes.baseUrl === undefined ? {} : { baseUrl: changes.baseUrl }),
+      enabled: changes.enabled,
+      enabledModelIds: changes.enabledModelIds,
+      models: endpointChanged ? [] : previous.models,
+      ...(endpointChanged || previous.modelSource === undefined
+        ? {}
+        : { modelSource: previous.modelSource }),
+      ...(endpointChanged || previous.modelsFetchedAt === undefined
+        ? {}
+        : { modelsFetchedAt: previous.modelsFetchedAt }),
+      ...(endpointChanged || previous.lastTest === undefined
+        ? {}
+        : { lastTest: previous.lastTest }),
+    };
+    if (current.defaultTarget && !isValidTarget(current.defaultTarget, connections)) {
+      return deepFreeze({ kind: 'invalid_default_target', target: current.defaultTarget });
+    }
+    const next = { ...current, revision: nextRevision(current.revision), connections };
+    await this.write(root, next);
+    return committed(next);
+  }
+
+  async remove(
+    root: string,
+    rawInput: RemoveCatalogConnectionInput,
+  ): Promise<ConnectionCatalogMutationResult> {
+    const input = decodeConnectionInput(() => normalizeRemoveCatalogConnectionInput(rawInput));
+    const current = await this.read(root);
+    const index = findConnectionIndex(current, input.expected);
+    const previous = index < 0 ? undefined : current.connections[index];
+    if (!previous || previous.revision !== input.expected.revision) {
+      return connectionStale(input.expected, previous ? connectionBasis(previous) : null);
+    }
+    const next: ConnectionCatalogDocument = {
+      ...current,
+      revision: nextRevision(current.revision),
+      defaultTarget:
+        current.defaultTarget && sameConnectionIdentity(current.defaultTarget, previous)
+          ? null
+          : current.defaultTarget,
+      connections: current.connections.filter((_item, candidate) => candidate !== index),
+    };
+    await this.write(root, next);
+    return committed(next);
+  }
+
+  async setDefaultTarget(
+    root: string,
+    rawInput: SetDefaultConnectionTargetInput,
+  ): Promise<ConnectionCatalogMutationResult> {
+    const input = decodeConnectionInput(() => normalizeSetDefaultConnectionTargetInput(rawInput));
+    const current = await this.read(root);
+    if (current.revision !== input.expectedCatalogRevision) {
+      return revisionConflict(input.expectedCatalogRevision, current.revision);
+    }
+    if (input.target && !isValidTarget(input.target, current.connections)) {
+      return deepFreeze({ kind: 'invalid_default_target', target: input.target });
+    }
+    const next = {
+      ...current,
+      revision: nextRevision(current.revision),
+      defaultTarget: input.target,
+    };
+    await this.write(root, next);
+    return committed(next);
+  }
+
+  private async write(root: string, document: ConnectionCatalogDocument): Promise<void> {
+    if (serializeJsonDocument(document).length > CATALOG_DOCUMENT_MAX_BYTES) {
+      throw new RuntimePolicyStoreError(
+        'invalid_connection_input',
+        `connection catalog exceeds its ${CATALOG_DOCUMENT_MAX_BYTES} byte limit`,
+      );
+    }
+    await writeJsonDocument(root, FILE, document, CATALOG_DOCUMENT_MAX_BYTES);
+  }
+}
+
+export function catalogSnapshot(document: ConnectionCatalogDocument): ConnectionCatalogSnapshot {
+  return deepFreeze({
+    revision: document.revision,
+    defaultTarget: structuredClone(document.defaultTarget),
+    connections: structuredClone(document.connections),
+  });
+}
+
+export function connectionBasis(connection: ConnectionCatalogEntry): ConnectionVersionBasis {
+  return {
+    connectionId: connection.connectionId,
+    revision: connection.revision,
+  };
+}
+
+export function findConnection(
+  document: ConnectionCatalogDocument,
+  identity: Pick<ConnectionVersionBasis, 'connectionId'>,
+): ConnectionCatalogEntry | undefined {
+  return document.connections.find((item) => sameConnectionIdentity(item, identity));
+}
+
+function findConnectionIndex(
+  document: ConnectionCatalogDocument,
+  identity: Pick<ConnectionVersionBasis, 'connectionId'>,
+): number {
+  return document.connections.findIndex((item) => sameConnectionIdentity(item, identity));
+}
+
+function sameConnectionIdentity(
+  left: Pick<ConnectionVersionBasis, 'connectionId'>,
+  right: Pick<ConnectionVersionBasis, 'connectionId'>,
+): boolean {
+  return left.connectionId === right.connectionId;
+}
+
+function isValidTarget(
+  target: ConnectionTarget,
+  connections: readonly ConnectionCatalogEntry[],
+): boolean {
+  const connection = connections.find((item) => sameConnectionIdentity(item, target));
+  return Boolean(connection?.enabled && connection.enabledModelIds.includes(target.modelId));
+}
+
+function revisionConflict(expectedRevision: number, actualRevision: number) {
+  return deepFreeze({ kind: 'revision_conflict' as const, expectedRevision, actualRevision });
+}
+
+function connectionStale(expected: ConnectionVersionBasis, actual: ConnectionVersionBasis | null) {
+  return deepFreeze({ kind: 'connection_stale' as const, expected, actual });
+}
+
+function committed(document: ConnectionCatalogDocument): ConnectionCatalogMutationResult {
+  return deepFreeze({ kind: 'committed', snapshot: catalogSnapshot(document) });
+}

--- a/packages/storage/src/runtime-policy/coordinator.ts
+++ b/packages/storage/src/runtime-policy/coordinator.ts
@@ -1,0 +1,357 @@
+import {
+  decodeConnectionSlug,
+  decodeCredentialLocator,
+  normalizeDeleteCredentialInput,
+  normalizeRemoveCatalogConnectionInput,
+  normalizeSetCredentialInput,
+  type ConnectionCatalogEntry,
+  type CreateCatalogConnectionInput,
+  type CredentialLocator,
+  type CredentialStatus,
+  type DeleteCredentialInput,
+  type MutateRuntimePolicyInput,
+  type RemoveCatalogConnectionInput,
+  type RuntimePolicy,
+  type SetCredentialInput,
+  type SetDefaultConnectionTargetInput,
+  type UpdateCatalogConnectionInput,
+} from '@maka/core/runtime-policy';
+import { deriveProviderAuthContract } from '@maka/core/provider-auth';
+import { PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
+import { deepFreeze } from './codec.js';
+import {
+  catalogSnapshot,
+  connectionBasis,
+  ConnectionCatalogDocumentOwner,
+  findConnection,
+} from './connection-catalog-document.js';
+import {
+  credentialMaterial,
+  credentialStatus,
+  CredentialVaultDocumentOwner,
+  findCredential,
+  vaultSnapshot,
+} from './credential-vault-document.js';
+import { cleanupRuntimePolicyDocumentTemps } from './document-io.js';
+import {
+  codecError,
+  commitOutcomeUnknown,
+  decodeConnectionInput,
+  decodeCredentialInput,
+} from './errors.js';
+import {
+  connectionCredentialLocator,
+  type CredentialStatusQueryResult,
+  type RuntimePolicyCredentialMaterial,
+  type RuntimePolicyOperationSecretMaterial,
+  type ResolveExecutionConnectionResult,
+} from './operations.js';
+import { policySnapshot, RuntimePolicyDocumentOwner } from './policy-document.js';
+
+type RootExecutor = <T>(operation: (root: string) => Promise<T>) => Promise<T>;
+
+interface PreparedConnectionMaterial {
+  readonly kind: 'ready';
+  readonly secretMaterial: RuntimePolicyOperationSecretMaterial;
+  readonly networkProxy: RuntimePolicy['networkProxy'];
+}
+
+export class RuntimePolicyCoordinator {
+  private readonly lane = new MutationLane();
+  private readonly policy = new RuntimePolicyDocumentOwner();
+  private readonly catalog = new ConnectionCatalogDocumentOwner();
+  private readonly vault = new CredentialVaultDocumentOwner();
+
+  constructor(private readonly execute: RootExecutor) {}
+
+  recoverForWrite(): Promise<void> {
+    return this.inLane(async (root) => {
+      await cleanupRuntimePolicyDocumentTemps(root);
+      const catalog = await this.catalog.read(root);
+      const vault = await this.vault.read(root);
+      await this.vault.deleteOrphanedConnectionCredentials(
+        root,
+        vault,
+        new Set(catalog.connections.map((connection) => connection.connectionId)),
+      );
+    });
+  }
+
+  getPolicySnapshot() {
+    return this.execute(async (root) => policySnapshot(await this.policy.read(root)));
+  }
+
+  getCatalogSnapshot() {
+    return this.execute(async (root) => catalogSnapshot(await this.catalog.read(root)));
+  }
+
+  getVaultSnapshot() {
+    return this.execute(async (root) => vaultSnapshot(await this.vault.read(root)));
+  }
+
+  getCredentialStatus(rawLocator: CredentialLocator): Promise<CredentialStatusQueryResult> {
+    return this.inLane(async (root) => {
+      const locator = decodeCredentialInput(() => decodeCredentialLocator(rawLocator));
+      if (!(await this.validateConnectionCredentialLocator(root, locator))) {
+        return deepFreeze({ kind: 'connection_not_found' as const });
+      }
+      const status = credentialStatus(await this.vault.read(root), locator);
+      return deepFreeze({ kind: 'status' as const, status });
+    });
+  }
+
+  mutatePolicy(input: MutateRuntimePolicyInput) {
+    return this.inLane((root) => this.policy.mutate(root, input));
+  }
+
+  createConnection(input: CreateCatalogConnectionInput) {
+    return this.inLane((root) => this.catalog.create(root, input));
+  }
+
+  updateConnection(input: UpdateCatalogConnectionInput) {
+    return this.inLane((root) => this.catalog.update(root, input));
+  }
+
+  removeConnection(rawInput: RemoveCatalogConnectionInput) {
+    return this.inLane(async (root) => {
+      const { expected } = decodeConnectionInput(() =>
+        normalizeRemoveCatalogConnectionInput(rawInput),
+      );
+      const catalog = await this.catalog.read(root);
+      const connection = findConnection(catalog, expected);
+      if (connection && connection.revision !== expected.revision) {
+        return deepFreeze({
+          kind: 'connection_stale' as const,
+          expected,
+          actual: connectionBasis(connection),
+        });
+      }
+
+      const vault = await this.vault.read(root);
+      if (!connection) {
+        await this.vault.deleteConnectionCredentials(root, vault, expected.connectionId);
+        return deepFreeze({ kind: 'committed' as const, snapshot: catalogSnapshot(catalog) });
+      }
+      const result = await this.catalog.remove(root, { expected });
+      if (result.kind === 'committed') {
+        try {
+          await this.vault.deleteConnectionCredentials(root, vault, expected.connectionId);
+        } catch (error) {
+          throw commitOutcomeUnknown(
+            'Connection removal committed before credential cleanup completed',
+            error,
+          );
+        }
+      }
+      return result;
+    });
+  }
+
+  setDefaultTarget(input: SetDefaultConnectionTargetInput) {
+    return this.inLane((root) => this.catalog.setDefaultTarget(root, input));
+  }
+
+  setCredential(rawInput: SetCredentialInput) {
+    return this.inLane(async (root) => {
+      const input = decodeCredentialInput(() => normalizeSetCredentialInput(rawInput));
+      const { locator } = input;
+      if (locator.scope === 'connection') {
+        const catalog = await this.catalog.read(root);
+        const connection = findConnection(catalog, locator);
+        if (!connection) {
+          return deepFreeze({ kind: 'connection_not_found' as const });
+        }
+        const required = connectionCredentialLocator(
+          connection.connectionId,
+          PROVIDER_DEFAULTS[connection.providerType].authKind,
+        );
+        if (!required || required.kind !== locator.kind) {
+          throw codecError(
+            'invalid_credential_input',
+            'Connection credential kind does not match the provider auth contract',
+          );
+        }
+        if (locator.kind === 'oauth_token' && connection.providerType !== 'github-copilot') {
+          throw codecError(
+            'invalid_credential_input',
+            'Client-supplied OAuth credentials are only accepted for GitHub Copilot',
+          );
+        }
+      }
+      return this.vault.set(root, input);
+    });
+  }
+
+  deleteCredential(rawInput: DeleteCredentialInput) {
+    return this.inLane(async (root) => {
+      const { expected } = decodeCredentialInput(() => normalizeDeleteCredentialInput(rawInput));
+      if (!(await this.validateConnectionCredentialLocator(root, expected.locator))) {
+        return deepFreeze({ kind: 'connection_not_found' as const });
+      }
+      return this.vault.delete(root, { expected });
+    });
+  }
+
+  resolveExecutionConnection(rawConnectionSlug: string): Promise<ResolveExecutionConnectionResult> {
+    return this.inLane(async (root) => {
+      const connectionSlug = decodeConnectionInput(() => decodeConnectionSlug(rawConnectionSlug));
+      const catalog = await this.catalog.read(root);
+      const connection = catalog.connections.find((candidate) => candidate.slug === connectionSlug);
+      if (!connection) return deepFreeze({ kind: 'not_found' as const });
+      if (!connection.enabled) return deepFreeze({ kind: 'disabled' as const });
+
+      const contract = deriveProviderAuthContract({
+        providerType: connection.providerType,
+        enabled: true,
+        hasSecret: true,
+        lastTestStatus: connection.lastTest?.status,
+      });
+      const prepared = await this.prepareConnectionMaterial(
+        root,
+        connection,
+        contract.requiresSecret,
+      );
+      if (prepared.kind !== 'ready') return prepared;
+      return deepFreeze({
+        kind: 'ready' as const,
+        connection: structuredClone(connection),
+        secretMaterial: prepared.secretMaterial,
+        networkProxy: structuredClone(prepared.networkProxy),
+      });
+    });
+  }
+
+  private async prepareConnectionMaterial(
+    root: string,
+    connection: ConnectionCatalogEntry,
+    requiresConnectionSecret: boolean,
+  ): Promise<
+    | PreparedConnectionMaterial
+    | { readonly kind: 'credential_not_configured'; readonly status: CredentialStatus }
+  > {
+    const authKind = PROVIDER_DEFAULTS[connection.providerType].authKind;
+    const locator = connectionCredentialLocator(connection.connectionId, authKind);
+    const policy = await this.policy.read(root);
+    const networkProxy = structuredClone(policy.policy.networkProxy);
+    const proxyLocator = requiresNetworkProxyCredential(networkProxy)
+      ? networkProxyCredentialLocator()
+      : null;
+    const secretMaterial: {
+      connection?: RuntimePolicyCredentialMaterial;
+      networkProxy?: RuntimePolicyCredentialMaterial;
+    } = {};
+
+    if (locator || proxyLocator) {
+      const vault = await this.vault.read(root);
+      if (locator) {
+        const status = credentialStatus(vault, locator);
+        const entry = findCredential(vault, locator);
+        if (!entry) {
+          if (requiresConnectionSecret) {
+            return deepFreeze({
+              kind: 'credential_not_configured' as const,
+              status,
+            });
+          }
+        } else {
+          secretMaterial.connection = credentialMaterial(entry);
+        }
+      }
+      if (proxyLocator) {
+        const status = credentialStatus(vault, proxyLocator);
+        const entry = findCredential(vault, proxyLocator);
+        if (!entry) {
+          return deepFreeze({
+            kind: 'credential_not_configured' as const,
+            status,
+          });
+        }
+        secretMaterial.networkProxy = credentialMaterial(entry);
+      }
+    }
+
+    return {
+      kind: 'ready',
+      secretMaterial,
+      networkProxy,
+    };
+  }
+
+  private async validateConnectionCredentialLocator(
+    root: string,
+    locator: CredentialLocator,
+  ): Promise<boolean> {
+    if (locator.scope !== 'connection') return true;
+    const catalog = await this.catalog.read(root);
+    const connection = findConnection(catalog, locator);
+    if (!connection) return false;
+    const required = connectionCredentialLocator(
+      connection.connectionId,
+      PROVIDER_DEFAULTS[connection.providerType].authKind,
+    );
+    if (!required || required.kind !== locator.kind) {
+      throw codecError(
+        'invalid_credential_input',
+        'Connection credential kind does not match the provider auth contract',
+      );
+    }
+    return true;
+  }
+
+  private inLane<T>(operation: (root: string) => Promise<T>): Promise<T> {
+    const reservation = this.lane.reserve();
+    let entered = false;
+    let execution: Promise<T>;
+    try {
+      execution = this.execute(async (root) => {
+        entered = true;
+        await reservation.ready;
+        try {
+          return await operation(root);
+        } finally {
+          reservation.release();
+        }
+      });
+    } catch (error) {
+      reservation.release();
+      throw error;
+    }
+    return execution.finally(() => {
+      if (!entered) reservation.release();
+    });
+  }
+}
+
+interface MutationReservation {
+  readonly ready: Promise<void>;
+  release(): void;
+}
+
+class MutationLane {
+  private tail: Promise<void> = Promise.resolve();
+
+  reserve(): MutationReservation {
+    const ready = this.tail;
+    let resolve!: () => void;
+    this.tail = new Promise<void>((release) => {
+      resolve = release;
+    });
+    let released = false;
+    return {
+      ready,
+      release: () => {
+        if (released) return;
+        released = true;
+        resolve();
+      },
+    };
+  }
+}
+
+function networkProxyCredentialLocator(): Extract<CredentialLocator, { scope: 'network_proxy' }> {
+  return { scope: 'network_proxy', kind: 'password' };
+}
+
+function requiresNetworkProxyCredential(networkProxy: RuntimePolicy['networkProxy']): boolean {
+  return networkProxy.enabled && networkProxy.authEnabled;
+}

--- a/packages/storage/src/runtime-policy/credential-vault-document.ts
+++ b/packages/storage/src/runtime-policy/credential-vault-document.ts
@@ -1,0 +1,347 @@
+import { randomUUID } from 'node:crypto';
+import {
+  decodeCredentialVersionBasis,
+  normalizeCredentialSecret,
+  normalizeDeleteCredentialInput,
+  normalizeSetCredentialInput,
+  type CredentialLocator,
+  type CredentialMutationResult,
+  type CredentialStatus,
+  type CredentialVaultSnapshot,
+  type CredentialVersionBasis,
+  type DeleteCredentialInput,
+  type SetCredentialInput,
+} from '@maka/core/runtime-policy';
+import { deepFreeze, integer, nextRevision, record, revision, unique } from './codec.js';
+import {
+  codecError,
+  decodeCredentialInput,
+  decodePersistedDomain,
+  RuntimePolicyStoreError,
+} from './errors.js';
+import {
+  readBoundedJsonDocument,
+  serializeJsonDocument,
+  VAULT_DOCUMENT_MAX_BYTES,
+  writeJsonDocument,
+} from './document-io.js';
+import type { RuntimePolicyCredentialMaterial } from './operations.js';
+
+const FILE = 'credential-vault.json';
+const SCHEMA_VERSION = 1 as const;
+const MAX_SECRET_LENGTH = 64 * 1024;
+const MAX_VAULT_ENTRIES = 2_048;
+
+export interface CredentialVaultEntry extends CredentialVersionBasis {
+  readonly secret: string;
+  readonly updatedAt: number;
+}
+
+export interface CredentialVaultDocument {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly revision: number;
+  readonly entries: readonly CredentialVaultEntry[];
+}
+
+export class CredentialVaultDocumentOwner {
+  async read(root: string): Promise<CredentialVaultDocument> {
+    const value = await readBoundedJsonDocument(root, FILE, VAULT_DOCUMENT_MAX_BYTES);
+    if (value === undefined) return { schemaVersion: SCHEMA_VERSION, revision: 0, entries: [] };
+    const raw = record(value, FILE, 'invalid_document', ['schemaVersion', 'revision', 'entries']);
+    if (raw.schemaVersion !== SCHEMA_VERSION) {
+      throw codecError('invalid_document', `${FILE} has an unsupported schema version`);
+    }
+    if (!Array.isArray(raw.entries) || raw.entries.length > MAX_VAULT_ENTRIES) {
+      throw codecError('invalid_document', `${FILE}.entries must be a bounded array`);
+    }
+    const entries = raw.entries.map((item, index) => parseEntry(item, `${FILE}.entries[${index}]`));
+    unique(
+      entries.map((entry) => locatorKey(entry.locator)),
+      `${FILE} locators`,
+      'invalid_document',
+    );
+    unique(
+      entries.map((entry) => entry.credentialId),
+      `${FILE} credential ids`,
+      'invalid_document',
+    );
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      revision: revision(raw.revision, `${FILE}.revision`, 'invalid_document'),
+      entries,
+    };
+  }
+
+  async set(root: string, rawInput: SetCredentialInput): Promise<CredentialMutationResult> {
+    const input = decodeCredentialInput(() => normalizeSetCredentialInput(rawInput));
+    assertCredentialInputSecretLimit(input.secret, 'set credential secret');
+    const current = await this.read(root);
+    const index = findCredentialIndex(current, input.locator);
+    const previous = index < 0 ? undefined : current.entries[index];
+    if (!matchesExpectation(previous, input.expected)) {
+      return credentialStale(
+        input.expected ? { locator: input.locator, ...input.expected } : null,
+        previous ? credentialBasis(previous) : null,
+      );
+    }
+    if (index < 0 && current.entries.length >= MAX_VAULT_ENTRIES) {
+      throw codecError('invalid_credential_input', 'Credential vault entry limit has been reached');
+    }
+    const entry: CredentialVaultEntry = previous
+      ? {
+          ...previous,
+          revision: nextRevision(previous.revision),
+          secret: input.secret,
+          updatedAt: Date.now(),
+        }
+      : {
+          locator: input.locator,
+          credentialId: randomUUID(),
+          revision: 1,
+          secret: input.secret,
+          updatedAt: Date.now(),
+        };
+    const entries = [...current.entries];
+    if (index < 0) entries.push(entry);
+    else entries[index] = entry;
+    const next = {
+      schemaVersion: SCHEMA_VERSION,
+      revision: nextRevision(current.revision),
+      entries,
+    };
+    await this.write(root, next);
+    return committed(next);
+  }
+
+  async delete(root: string, rawInput: DeleteCredentialInput): Promise<CredentialMutationResult> {
+    const input = decodeCredentialInput(() => normalizeDeleteCredentialInput(rawInput));
+    const current = await this.read(root);
+    const index = findCredentialIndex(current, input.expected.locator);
+    const previous = index < 0 ? undefined : current.entries[index];
+    if (!sameCredentialBasis(previous, input.expected)) {
+      return credentialStale(input.expected, previous ? credentialBasis(previous) : null);
+    }
+    const next = {
+      schemaVersion: SCHEMA_VERSION,
+      revision: nextRevision(current.revision),
+      entries: current.entries.filter((_entry, candidate) => candidate !== index),
+    };
+    await this.write(root, next);
+    return committed(next);
+  }
+
+  async deleteConnectionCredentials(
+    root: string,
+    current: CredentialVaultDocument,
+    connectionId: string,
+  ): Promise<CredentialVaultSnapshot> {
+    const entries = current.entries.filter(
+      (entry) =>
+        entry.locator.scope !== 'connection' || entry.locator.connectionId !== connectionId,
+    );
+    return this.replaceEntries(root, current, entries);
+  }
+
+  async deleteOrphanedConnectionCredentials(
+    root: string,
+    current: CredentialVaultDocument,
+    liveConnectionIds: ReadonlySet<string>,
+  ): Promise<CredentialVaultSnapshot> {
+    const entries = current.entries.filter(
+      (entry) =>
+        entry.locator.scope !== 'connection' || liveConnectionIds.has(entry.locator.connectionId),
+    );
+    return this.replaceEntries(root, current, entries);
+  }
+
+  private async replaceEntries(
+    root: string,
+    current: CredentialVaultDocument,
+    entries: CredentialVaultDocument['entries'],
+  ): Promise<CredentialVaultSnapshot> {
+    if (entries.length === current.entries.length) return vaultSnapshot(current);
+    const next = {
+      schemaVersion: SCHEMA_VERSION,
+      revision: nextRevision(current.revision),
+      entries,
+    };
+    await this.write(root, next);
+    return vaultSnapshot(next);
+  }
+
+  private async write(root: string, document: CredentialVaultDocument): Promise<void> {
+    if (serializeJsonDocument(document).length > VAULT_DOCUMENT_MAX_BYTES) {
+      throw new RuntimePolicyStoreError(
+        'invalid_credential_input',
+        `credential vault exceeds its ${VAULT_DOCUMENT_MAX_BYTES} byte limit`,
+      );
+    }
+    await writeJsonDocument(root, FILE, document, VAULT_DOCUMENT_MAX_BYTES);
+  }
+}
+
+export function vaultSnapshot(document: CredentialVaultDocument): CredentialVaultSnapshot {
+  return deepFreeze({
+    revision: document.revision,
+    entries: document.entries.map((entry) => credentialStatusFromEntry(entry)),
+  });
+}
+
+export function credentialStatus(
+  document: CredentialVaultDocument,
+  locator: CredentialLocator,
+): CredentialStatus {
+  const entry = findCredential(document, locator);
+  return deepFreeze(
+    entry
+      ? credentialStatusFromEntry(entry)
+      : {
+          locator: structuredClone(locator),
+          configured: false,
+          credentialId: null,
+          revision: null,
+          updatedAt: null,
+        },
+  );
+}
+
+export function credentialMaterial(entry: CredentialVaultEntry): RuntimePolicyCredentialMaterial {
+  return deepFreeze({ ...credentialBasis(entry), secret: entry.secret });
+}
+
+export function credentialBasis(entry: CredentialVaultEntry): CredentialVersionBasis {
+  return {
+    locator: structuredClone(entry.locator),
+    credentialId: entry.credentialId,
+    revision: entry.revision,
+  };
+}
+
+export function findCredential(
+  document: CredentialVaultDocument,
+  locator: CredentialLocator,
+): CredentialVaultEntry | undefined {
+  return document.entries.find((entry) => sameLocator(entry.locator, locator));
+}
+
+export function sameCredentialBasis(
+  actual: CredentialVaultEntry | undefined,
+  expected: CredentialVersionBasis,
+): boolean {
+  return (
+    actual !== undefined &&
+    sameLocator(actual.locator, expected.locator) &&
+    actual.credentialId === expected.credentialId &&
+    actual.revision === expected.revision
+  );
+}
+
+function parseEntry(value: unknown, context: string): CredentialVaultEntry {
+  const item = record(value, context, 'invalid_document', [
+    'locator',
+    'credentialId',
+    'revision',
+    'secret',
+    'updatedAt',
+  ]);
+  const basis = decodePersistedDomain(() =>
+    decodeCredentialVersionBasis({
+      locator: item.locator,
+      credentialId: item.credentialId,
+      revision: item.revision,
+    }),
+  );
+  const secret = decodePersistedDomain(() => normalizeCredentialSecret(item.secret));
+  assertPersistedSecretLimit(secret, `${context}.secret`);
+  return {
+    ...basis,
+    secret,
+    updatedAt: integer(
+      item.updatedAt,
+      `${context}.updatedAt`,
+      0,
+      Number.MAX_SAFE_INTEGER,
+      'invalid_document',
+    ),
+  };
+}
+
+function assertCredentialInputSecretLimit(value: string, context: string): void {
+  if (value.length > MAX_SECRET_LENGTH) {
+    throw codecError(
+      'invalid_credential_input',
+      `${context} must be no longer than ${MAX_SECRET_LENGTH} characters`,
+    );
+  }
+}
+
+function assertPersistedSecretLimit(value: string, context: string): void {
+  if (value.length > MAX_SECRET_LENGTH) {
+    throw codecError(
+      'invalid_document',
+      `${context} must be no longer than ${MAX_SECRET_LENGTH} characters`,
+    );
+  }
+}
+
+function credentialStatusFromEntry(entry: CredentialVaultEntry): CredentialStatus {
+  return {
+    locator: structuredClone(entry.locator),
+    configured: true,
+    credentialId: entry.credentialId,
+    revision: entry.revision,
+    updatedAt: entry.updatedAt,
+  };
+}
+
+function findCredentialIndex(
+  document: CredentialVaultDocument,
+  locator: CredentialLocator,
+): number {
+  return document.entries.findIndex((entry) => sameLocator(entry.locator, locator));
+}
+
+function sameLocator(left: CredentialLocator, right: CredentialLocator): boolean {
+  if (left.scope !== right.scope || left.kind !== right.kind) return false;
+  if (left.scope === 'connection' && right.scope === 'connection') {
+    return left.connectionId === right.connectionId;
+  }
+  if (left.scope === 'web_search' && right.scope === 'web_search') {
+    return left.provider === right.provider;
+  }
+  return left.scope === 'network_proxy' && right.scope === 'network_proxy';
+}
+
+function locatorKey(locator: CredentialLocator): string {
+  switch (locator.scope) {
+    case 'connection':
+      return `connection:${locator.connectionId}:${locator.kind}`;
+    case 'web_search':
+      return `web_search:${locator.provider}:api_key`;
+    case 'network_proxy':
+      return 'network_proxy:password';
+  }
+}
+
+function matchesExpectation(
+  actual: CredentialVaultEntry | undefined,
+  expected: SetCredentialInput['expected'],
+): boolean {
+  if (expected === null) return actual === undefined;
+  return (
+    actual !== undefined &&
+    actual.credentialId === expected.credentialId &&
+    actual.revision === expected.revision
+  );
+}
+
+function credentialStale(
+  expected: CredentialVersionBasis | null,
+  actual: CredentialVersionBasis | null,
+): CredentialMutationResult {
+  return deepFreeze({ kind: 'credential_stale', expected, actual });
+}
+
+function committed(document: CredentialVaultDocument): CredentialMutationResult {
+  return deepFreeze({ kind: 'committed', snapshot: vaultSnapshot(document) });
+}

--- a/packages/storage/src/runtime-policy/document-io.ts
+++ b/packages/storage/src/runtime-policy/document-io.ts
@@ -1,0 +1,189 @@
+import { constants } from 'node:fs';
+import { lstat, open, readdir, rename, rm, unlink } from 'node:fs/promises';
+import { join } from 'node:path';
+import { randomUUID } from 'node:crypto';
+import { syncDirectory } from '../stable-storage.js';
+import {
+  commitOutcomeUnknown,
+  invalidDocument,
+  ioFailed,
+  RuntimePolicyStoreError,
+} from './errors.js';
+
+export const POLICY_DOCUMENT_MAX_BYTES = 48 * 1024;
+export const CATALOG_DOCUMENT_MAX_BYTES = 4 * 1024 * 1024;
+export const VAULT_DOCUMENT_MAX_BYTES = 2 * 1024 * 1024;
+
+const READ_CHUNK_BYTES = 64 * 1024;
+const RUNTIME_POLICY_TEMP_PATTERN =
+  /^(?:runtime-policy|connection-catalog|credential-vault)\.json\.[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.tmp$/;
+
+export async function cleanupRuntimePolicyDocumentTemps(root: string): Promise<void> {
+  let failure: unknown;
+  try {
+    const entries = await readdir(root);
+    for (const entry of entries) {
+      if (!RUNTIME_POLICY_TEMP_PATTERN.test(entry)) continue;
+      const path = join(root, entry);
+      let metadata;
+      try {
+        metadata = await lstat(path);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw ioFailed('A runtime policy temporary artifact could not be inspected', error);
+      }
+      if (metadata.isDirectory()) {
+        throw invalidDocument('Runtime policy temporary artifacts must not be directories');
+      }
+      try {
+        await unlink(path);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw ioFailed('A runtime policy temporary artifact could not be removed', error);
+      }
+    }
+  } catch (error) {
+    failure =
+      error instanceof RuntimePolicyStoreError
+        ? error
+        : ioFailed('Runtime policy temporary artifacts could not be listed', error);
+  }
+
+  try {
+    await syncDirectory(root);
+  } catch (error) {
+    failure ??= ioFailed(
+      'Runtime policy temporary artifact cleanup could not be synchronized',
+      error,
+    );
+  }
+  if (failure !== undefined) throw failure;
+}
+
+export async function readBoundedJsonDocument(
+  root: string,
+  file: string,
+  maxBytes: number,
+): Promise<unknown | undefined> {
+  const path = join(root, file);
+  const flags =
+    process.platform === 'win32'
+      ? constants.O_RDONLY
+      : constants.O_RDONLY | constants.O_NOFOLLOW | constants.O_NONBLOCK;
+  let handle;
+  try {
+    handle = await open(path, flags);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    if (process.platform !== 'win32' && (error as NodeJS.ErrnoException).code === 'ELOOP') {
+      throw invalidDocument(`${file} must not be a symbolic link`, error);
+    }
+    throw ioFailed(`${file} could not be opened`, error);
+  }
+
+  let result: unknown | undefined;
+  let failure: unknown;
+  try {
+    const metadata = await handle.stat();
+    if (!metadata.isFile()) throw invalidDocument(`${file} must be a regular file`);
+    if (metadata.size > maxBytes)
+      throw invalidDocument(`${file} exceeds its ${maxBytes} byte limit`);
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+    for (;;) {
+      const remaining = maxBytes + 1 - total;
+      if (remaining <= 0) throw invalidDocument(`${file} exceeds its ${maxBytes} byte limit`);
+      const buffer = Buffer.allocUnsafe(Math.min(READ_CHUNK_BYTES, remaining));
+      const { bytesRead } = await handle.read(buffer, 0, buffer.length, total);
+      if (bytesRead === 0) break;
+      total += bytesRead;
+      chunks.push(buffer.subarray(0, bytesRead));
+    }
+    if (total > maxBytes) throw invalidDocument(`${file} exceeds its ${maxBytes} byte limit`);
+
+    let text: string;
+    try {
+      text = new TextDecoder('utf-8', { fatal: true }).decode(Buffer.concat(chunks, total));
+    } catch (error) {
+      throw invalidDocument(`${file} is not valid UTF-8`, error);
+    }
+    try {
+      result = JSON.parse(text) as unknown;
+    } catch (error) {
+      throw invalidDocument(`${file} is not valid JSON`, error);
+    }
+  } catch (error) {
+    failure = error;
+  } finally {
+    try {
+      await handle.close();
+    } catch (error) {
+      failure ??= error;
+    }
+  }
+
+  if (failure !== undefined) {
+    if (failure instanceof RuntimePolicyStoreError) throw failure;
+    throw ioFailed(`${file} could not be read`, failure);
+  }
+  return result;
+}
+
+export async function writeJsonDocument(
+  root: string,
+  file: string,
+  value: unknown,
+  maxBytes: number,
+): Promise<void> {
+  const bytes = serializeJsonDocument(value);
+  if (bytes.length > maxBytes) throw invalidDocument(`${file} exceeds its ${maxBytes} byte limit`);
+
+  const path = join(root, file);
+  const temporaryPath = `${path}.${randomUUID()}.tmp`;
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  let temporaryCreated = false;
+  let published = false;
+  let failure: unknown;
+  try {
+    handle = await open(temporaryPath, 'wx', 0o600);
+    temporaryCreated = true;
+    await handle.writeFile(bytes);
+    await handle.sync();
+    await handle.close();
+    handle = undefined;
+    await rename(temporaryPath, path);
+    published = true;
+    await syncDirectory(root);
+  } catch (error) {
+    failure = error;
+  } finally {
+    if (handle !== undefined) {
+      try {
+        await handle.close();
+      } catch (error) {
+        failure ??= error;
+      }
+    }
+    if (temporaryCreated && !published) {
+      try {
+        await rm(temporaryPath, { force: true });
+      } catch (error) {
+        failure ??= error;
+      }
+    }
+  }
+
+  if (failure === undefined) return;
+  if (published) {
+    throw commitOutcomeUnknown(
+      `${file} commit outcome is unknown; reload before retrying`,
+      failure,
+    );
+  }
+  throw ioFailed(`${file} I/O failed before publication`, failure);
+}
+
+export function serializeJsonDocument(value: unknown): Buffer {
+  return Buffer.from(`${JSON.stringify(value, null, 2)}\n`, 'utf8');
+}

--- a/packages/storage/src/runtime-policy/errors.ts
+++ b/packages/storage/src/runtime-policy/errors.ts
@@ -1,0 +1,73 @@
+import { RuntimePolicyDomainDecodeError } from '@maka/core/runtime-policy';
+
+export type RuntimePolicyStoreErrorCode =
+  | 'invalid_document'
+  | 'invalid_policy_input'
+  | 'invalid_connection_input'
+  | 'invalid_credential_input'
+  | 'io_failed'
+  | 'commit_outcome_unknown';
+
+export class RuntimePolicyStoreError extends Error {
+  constructor(
+    readonly code: RuntimePolicyStoreErrorCode,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'RuntimePolicyStoreError';
+  }
+}
+
+export type CodecSource =
+  | 'invalid_document'
+  | 'invalid_policy_input'
+  | 'invalid_connection_input'
+  | 'invalid_credential_input';
+
+export function codecError(source: CodecSource, message: string): RuntimePolicyStoreError {
+  return new RuntimePolicyStoreError(source, message);
+}
+
+export function decodePolicyInput<T>(decode: () => T): T {
+  return mapDomainError(decode, 'invalid_policy_input');
+}
+
+export function decodeConnectionInput<T>(decode: () => T): T {
+  return mapDomainError(decode, 'invalid_connection_input');
+}
+
+export function decodeCredentialInput<T>(decode: () => T): T {
+  return mapDomainError(decode, 'invalid_credential_input');
+}
+
+export function decodePersistedDomain<T>(decode: () => T): T {
+  return mapDomainError(decode, 'invalid_document');
+}
+
+export function invalidDocument(message: string, cause?: unknown): RuntimePolicyStoreError {
+  return new RuntimePolicyStoreError(
+    'invalid_document',
+    message,
+    cause === undefined ? undefined : { cause },
+  );
+}
+
+export function ioFailed(message: string, cause: unknown): RuntimePolicyStoreError {
+  return new RuntimePolicyStoreError('io_failed', message, { cause });
+}
+
+export function commitOutcomeUnknown(message: string, cause: unknown): RuntimePolicyStoreError {
+  return new RuntimePolicyStoreError('commit_outcome_unknown', message, { cause });
+}
+
+function mapDomainError<T>(decode: () => T, code: CodecSource): T {
+  try {
+    return decode();
+  } catch (error) {
+    if (error instanceof RuntimePolicyDomainDecodeError) {
+      throw new RuntimePolicyStoreError(code, error.message, { cause: error });
+    }
+    throw error;
+  }
+}

--- a/packages/storage/src/runtime-policy/operations.ts
+++ b/packages/storage/src/runtime-policy/operations.ts
@@ -1,0 +1,53 @@
+import type {
+  ConnectionCatalogEntry,
+  CredentialLocator,
+  CredentialStatus,
+  CredentialVersionBasis,
+  RuntimePolicy,
+} from '@maka/core/runtime-policy';
+import type { ProviderDefaults } from '@maka/core/llm-connections';
+
+export type ProviderAuthKind = ProviderDefaults['authKind'];
+
+export interface RuntimePolicyCredentialMaterial extends CredentialVersionBasis {
+  readonly secret: string;
+}
+
+export interface RuntimePolicyOperationSecretMaterial {
+  readonly connection?: RuntimePolicyCredentialMaterial;
+  readonly networkProxy?: RuntimePolicyCredentialMaterial;
+}
+
+export type CredentialStatusQueryResult =
+  | { readonly kind: 'status'; readonly status: CredentialStatus }
+  | { readonly kind: 'connection_not_found' };
+
+export type ResolveExecutionConnectionResult =
+  | { readonly kind: 'not_found' }
+  | { readonly kind: 'disabled' }
+  | { readonly kind: 'credential_not_configured'; readonly status: CredentialStatus }
+  | {
+      readonly kind: 'ready';
+      readonly connection: ConnectionCatalogEntry;
+      readonly secretMaterial: RuntimePolicyOperationSecretMaterial;
+      readonly networkProxy: RuntimePolicy['networkProxy'];
+    };
+
+export interface RuntimePolicyOperationCoordinator {
+  resolveExecutionConnection(connectionSlug: string): Promise<ResolveExecutionConnectionResult>;
+}
+
+export function connectionCredentialLocator(
+  connectionId: string,
+  authKind: ProviderAuthKind,
+): Extract<CredentialLocator, { scope: 'connection' }> | null {
+  switch (authKind) {
+    case 'api_key':
+    case 'optional_api_key':
+      return { scope: 'connection', connectionId, kind: 'api_key' };
+    case 'oauth_token':
+      return { scope: 'connection', connectionId, kind: 'oauth_token' };
+    case 'none':
+      return null;
+  }
+}

--- a/packages/storage/src/runtime-policy/policy-document.ts
+++ b/packages/storage/src/runtime-policy/policy-document.ts
@@ -1,0 +1,105 @@
+import {
+  createDefaultRuntimePolicy,
+  decodeCanonicalRuntimePolicy,
+  normalizeRuntimePolicyMutation,
+  type MutateRuntimePolicyInput,
+  type MutateRuntimePolicyResult,
+  type RuntimePolicy,
+  type RuntimePolicyMutation,
+  type RuntimePolicySnapshot,
+} from '@maka/core/runtime-policy';
+import { deepFreeze, nextRevision, record, revision } from './codec.js';
+import {
+  codecError,
+  decodePersistedDomain,
+  decodePolicyInput,
+  RuntimePolicyStoreError,
+} from './errors.js';
+import {
+  POLICY_DOCUMENT_MAX_BYTES,
+  readBoundedJsonDocument,
+  serializeJsonDocument,
+  writeJsonDocument,
+} from './document-io.js';
+
+const FILE = 'runtime-policy.json';
+const SCHEMA_VERSION = 1 as const;
+
+export interface RuntimePolicyDocument {
+  readonly schemaVersion: typeof SCHEMA_VERSION;
+  readonly revision: number;
+  readonly policy: RuntimePolicy;
+}
+
+export class RuntimePolicyDocumentOwner {
+  async read(root: string): Promise<RuntimePolicyDocument> {
+    const value = await readBoundedJsonDocument(root, FILE, POLICY_DOCUMENT_MAX_BYTES);
+    if (value === undefined) {
+      return { schemaVersion: SCHEMA_VERSION, revision: 0, policy: createDefaultRuntimePolicy() };
+    }
+    const document = record(value, FILE, 'invalid_document', [
+      'schemaVersion',
+      'revision',
+      'policy',
+    ]);
+    if (document.schemaVersion !== SCHEMA_VERSION) {
+      throw codecError('invalid_document', `${FILE} has an unsupported schema version`);
+    }
+    return {
+      schemaVersion: SCHEMA_VERSION,
+      revision: revision(document.revision, `${FILE}.revision`, 'invalid_document'),
+      policy: decodePersistedDomain(() => decodeCanonicalRuntimePolicy(document.policy)),
+    };
+  }
+
+  async mutate(
+    root: string,
+    rawInput: MutateRuntimePolicyInput,
+  ): Promise<MutateRuntimePolicyResult> {
+    const input = decodePolicyInput(() => normalizeRuntimePolicyMutation(rawInput));
+    const current = await this.read(root);
+    if (current.revision !== input.expectedRevision) {
+      return deepFreeze({
+        kind: 'revision_conflict',
+        expectedRevision: input.expectedRevision,
+        actualRevision: current.revision,
+      });
+    }
+    const next: RuntimePolicyDocument = {
+      schemaVersion: SCHEMA_VERSION,
+      revision: nextRevision(current.revision),
+      policy: applyMutation(current.policy, input.operation),
+    };
+    if (serializeJsonDocument(next).length > POLICY_DOCUMENT_MAX_BYTES) {
+      throw new RuntimePolicyStoreError(
+        'invalid_policy_input',
+        `runtime policy exceeds its ${POLICY_DOCUMENT_MAX_BYTES} byte limit`,
+      );
+    }
+    await writeJsonDocument(root, FILE, next, POLICY_DOCUMENT_MAX_BYTES);
+    return deepFreeze({ kind: 'committed', snapshot: policySnapshot(next) });
+  }
+}
+
+export function policySnapshot(document: RuntimePolicyDocument): RuntimePolicySnapshot {
+  return deepFreeze({ revision: document.revision, policy: structuredClone(document.policy) });
+}
+
+function applyMutation(policy: RuntimePolicy, operation: RuntimePolicyMutation): RuntimePolicy {
+  switch (operation.kind) {
+    case 'set_network_proxy':
+      return { ...policy, networkProxy: operation.value };
+    case 'set_personalization':
+      return { ...policy, personalization: operation.value };
+    case 'set_memory':
+      return { ...policy, memory: operation.value };
+    case 'set_workspace_instructions':
+      return { ...policy, workspaceInstructions: operation.value };
+    case 'set_privacy':
+      return { ...policy, privacy: operation.value };
+    case 'set_chat_defaults':
+      return { ...policy, chatDefaults: operation.value };
+    case 'set_web_search':
+      return { ...policy, webSearch: operation.value };
+  }
+}


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Context

This PR establishes the Runtime Host authority for Runtime Policy, the Connection Catalog, and the Credential Vault. It is a complete M3 authority slice tracked by #1167.

The Host remains non-serving in production. This PR does not switch Desktop, TUI, CLI, or Headless entrypoints, and it does not migrate the current mixed surface settings document.

## What changes

### Canonical contracts

- Add closed codecs and canonical snapshots for Runtime Policy, Connection Catalog, and Credential Vault state.
- Give every mutable document a revision and compare-and-set mutation contract. Exact decoders reject unknown fields, malformed identities, unsupported providers, invalid endpoints, and oversized state.
- Keep credential projections redacted. Secret material is available only through the authenticated Host-side execution resolver and never crosses the operation protocol.
- Keep model inventory, discovery provenance, fetch time, and last-test facts in the canonical Connection Catalog schema. The authority owns these facts even though the network effects that produce them remain in a later slice.

### Lease-bound persistence

- Bind readers and the single writer facade to an authentic Interactive root lease; forged facades, wrong root kinds, and operations after lease close fail closed.
- Serialize mutations across the three documents and publish private files through bounded, synchronized temporary writes.
- Report ambiguous durable publication as `commit_outcome_unknown` rather than guessing whether a retry is safe.
- Recover recognizable temporary artifacts before exposing the writer. If connection removal commits before credential cleanup, a successor removes only credentials whose Connection owner no longer exists; unrelated web-search and proxy credentials are preserved.

### Typed Host operations

- Add ten exact query and mutation operations for Runtime Policy, Connection Catalog, and Credential Vault state, including revision-pinned catalog pagination.
- Compose those operations through the existing closed dispatcher. Non-serving compositions receive typed unavailable handlers for every declared domain operation.
- Order mutations against one shared backend-activation boundary. Root turns, linked and legacy child runs, continuations, retries, and compaction cross the same boundary; activations remain concurrent, while a mutation waits for admitted activations and blocks later ones until invalidation settles.
- Invalidate only backend identities currently owned by the RuntimeKernel cache. A policy edit does not enumerate persisted Sessions or read transcript previews merely to find idle work.
- Treat policy invalidation as a strict boundary. It joins an already-running disposal, waits for active work to settle, and observes the disposal outcome. Failure preserves the committed policy result, poisons later activation, and asks the Host to drain. Ordinary non-policy invalidation remains best-effort.
- Backend activation waits for any in-flight disposal and then rechecks the relevant parent or child cache, so a replacement cannot escape a mutation that has already entered the authority boundary.

## Evidence

Coverage includes strict codec boundaries, lease authentication, compare-and-set conflicts, secret redaction, ambiguous durable publication, interrupted connection removal and successor recovery, large revision-pinned catalogs, two real UDS Clients racing one authority, production gate composition, cached-only invalidation, disposal failure propagation, and deterministic parent/child replacement races.

After rebasing onto current `main`, the full Runtime suite passes 2,495 tests with seven existing skips, and Runtime Host passes all 89 tests. The workspace build and typecheck, Biome format/lint checks, and `git diff --check` also pass.

## Scope

This slice intentionally does not perform model discovery, connection testing, OAuth refresh/presentation, or other network/native effects. Those belong to later Connection Effects and OAuth slices, which will commit their results through this authority. Production surface wiring, `AppSettings` removal, deferred-tool economy wiring, and the M4 cutover also remain out of scope.

Part of #1167. Related to #853.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 背景

本 PR 建立 Runtime Host 对 Runtime Policy、Connection Catalog 与 Credential Vault 的权威所有权，是 #1167 跟踪的一份完整 M3 authority slice。

Runtime Host 仍未进入 production serving。本 PR 不切换 Desktop、TUI、CLI 或 Headless 的入口，也不迁移当前混合了多个 owner 的 surface settings 文档。

## 改动内容

### Canonical 契约

- 为 Runtime Policy、Connection Catalog 与 Credential Vault 状态增加封闭 codec 和 canonical snapshot。
- 每个可变文档都有 revision 与 compare-and-set mutation 契约。精确 decoder 会拒绝未知字段、畸形 identity、不支持的 provider、非法 endpoint 与超限状态。
- Credential projection 始终脱敏。秘密材料只能由经过认证的 Host 侧 execution resolver 取得，绝不会穿过 operation protocol。
- Connection Catalog 的 canonical schema 保留 model inventory、discovery provenance、fetch time 与 last-test fact。该 authority 拥有这些事实，但产生它们的网络 effect 留在后续 slice。

### Lease-bound 持久化

- Reader 与唯一 writer facade 都绑定到真实 Interactive root lease；伪造 facade、错误 root kind，以及 lease 关闭后的 operation 都会 fail closed。
- 三份文档的 mutation 统一串行化，并通过有界、同步的临时写入发布私有文件。
- Durable publication 结果不确定时返回 `commit_outcome_unknown`，不猜测重试是否安全。
- Writer 对外可用前先恢复可识别的临时 artifact。如果 connection removal 已提交、但 credential cleanup 尚未完成，successor 只删除已经失去 Connection owner 的 credential；无关的 web-search 与 proxy credential 会被保留。

### Typed Host operation

- 增加十个精确的 Runtime Policy、Connection Catalog 与 Credential Vault query/mutation operation，其中包括绑定 revision 的 Catalog pagination。
- 这些 operation 通过现有封闭 dispatcher 组合；non-serving composition 会为每个已声明 domain operation 提供 typed unavailable handler。
- Mutation 与同一个 backend-activation boundary 排序。Root turn、linked/legacy child run、continuation、retry 与 compaction 都经过该边界；多个 activation 仍可并行，mutation 会等待已经接纳的 activation，并在 invalidation 收束前阻止后来的 activation。
- 只使 RuntimeKernel cache 当前拥有的 backend identity 失效。Policy edit 不会为了寻找 idle work 枚举持久化 Session 或读取 transcript preview。
- Policy invalidation 是 strict boundary：加入正在进行的 disposal，等待 active work 收束，并观察 disposal outcome。失败时保留已提交的 policy result、poison 后续 activation，并请求 Host drain；普通非 policy invalidation 仍保持 best-effort。
- Backend activation 会等待同 Session 正在进行的 disposal，再重新检查对应 parent/child cache，避免 replacement 逃过已经进入 authority boundary 的 mutation。

## 验证证据

覆盖严格 codec 边界、lease 认证、compare-and-set 冲突、秘密脱敏、durable publication 结果不确定、connection removal 中断后的 successor recovery、大型 revision-pinned Catalog、两个真实 UDS Client 竞争同一 authority、production gate composition、cached-only invalidation、disposal failure propagation，以及确定性的 parent/child replacement race。

Rebase 到当前 `main` 后，Runtime 全量 2,495 项通过，另有 7 项既有 skip；Runtime Host 89 项全部通过。全 workspace build 与 typecheck、Biome format/lint 和 `git diff --check` 也均通过。

## 范围

本 slice 刻意不执行 model discovery、connection test、OAuth refresh/presentation 或其他 network/native effect。这些内容属于后续 Connection Effects 与 OAuth slice，并通过本 authority 提交结果。Production surface wiring、`AppSettings` 删除、deferred-tool economy 接线与 M4 cutover 也不在本 PR 范围内。

属于 #1167；关联 #853。

</details>
