### PR TITLE
fix(desktop): deep-link first-run provider rows into the create dialog

### DIFF
--- a/apps/desktop/e2e/first-run.spec.ts
+++ b/apps/desktop/e2e/first-run.spec.ts
@@ -53,3 +53,11 @@ test('provider list bottom fade tracks scroll position', async ({ emptyWindow: p
   });
   await expect.poll(fadeOpacity).toBe('0');
 });
+
+test('clicking a recommended provider row opens that provider connection form', async ({ emptyWindow: page }) => {
+  const name = providerDisplayName('deepseek');
+  await page.locator('.maka-firstrun-row', { hasText: name }).click();
+
+  await expect(page.getByLabel('设置内容')).toBeVisible();
+  await expect(page.getByRole('dialog', { name: `连接 ${name}` })).toBeVisible();
+});

--- a/apps/desktop/e2e/first-run.spec.ts
+++ b/apps/desktop/e2e/first-run.spec.ts
@@ -61,3 +61,20 @@ test('clicking a recommended provider row opens that provider connection form', 
   await expect(page.getByLabel('设置内容')).toBeVisible();
   await expect(page.getByRole('dialog', { name: `连接 ${name}` })).toBeVisible();
 });
+
+test('closing the auto-opened provider form does not resurrect it on section re-entry', async ({ emptyWindow: page }) => {
+  const name = providerDisplayName('deepseek');
+  await page.locator('.maka-firstrun-row', { hasText: name }).click();
+
+  const dialog = page.getByRole('dialog', { name: `连接 ${name}` });
+  await expect(dialog).toBeVisible();
+  await dialog.getByRole('button', { name: '关闭' }).click();
+  await expect(dialog).not.toBeVisible();
+
+  const settingsNav = page.locator('[aria-label="设置分组"]');
+  await settingsNav.getByText('外观', { exact: true }).click();
+  await settingsNav.getByText('模型', { exact: true }).click();
+
+  await expect(page.getByRole('heading', { name: '添加新连接' })).toBeVisible();
+  await expect(dialog).not.toBeVisible();
+});

--- a/apps/desktop/src/renderer/OnboardingHero.tsx
+++ b/apps/desktop/src/renderer/OnboardingHero.tsx
@@ -21,7 +21,7 @@
 
 import { ArrowRight, ArrowUp, ChevronRight, RotateCcw, Sparkles, KeyRound, Settings as SettingsIcon, Cpu, AlertCircle, FolderOpen, Paperclip, X } from '@maka/ui/icons';
 import { Fragment, useCallback, useEffect, useRef, useState, type ClipboardEvent, type DragEvent, type KeyboardEvent } from 'react';
-import { RECOMMENDED_PROVIDER_TYPES, type LlmConnection, type OnboardingState, type QuickChatMode, type SettingsSection } from '@maka/core';
+import { RECOMMENDED_PROVIDER_TYPES, type LlmConnection, type OnboardingState, type ProviderType, type QuickChatMode, type SettingsSection } from '@maka/core';
 import {
   Button,
   ComposerMentionPopup,
@@ -62,6 +62,8 @@ export interface OnboardingHeroProps {
   state: OnboardingState;
   /** Open Settings with a specific section preselected. */
   onOpenSettings: (section?: SettingsSection) => void;
+  /** Open Settings → 模型 with the create-connection dialog for this provider. */
+  onAddProvider: (providerType: ProviderType) => void;
   /** Open the shared Settings provider catalog. */
   onBrowseProviders: () => void;
   /**
@@ -135,7 +137,7 @@ export function OnboardingHero(props: OnboardingHeroProps) {
     case 'needs_connection':
       return (
         <NeedsConnectionHero
-          onOpenSettings={props.onOpenSettings}
+          onAddProvider={props.onAddProvider}
           onBrowseProviders={props.onBrowseProviders}
           onRefreshConnections={props.onRefreshConnections ? runRefreshConnections : undefined}
           refreshConnectionsPending={refreshConnectionsPending}
@@ -223,7 +225,7 @@ function connectionLabel(
 }
 
 function NeedsConnectionHero(props: {
-  onOpenSettings: (section?: SettingsSection) => void;
+  onAddProvider: (providerType: ProviderType) => void;
   onBrowseProviders: () => void;
   onRefreshConnections?: () => void;
   refreshConnectionsPending?: boolean;
@@ -261,7 +263,7 @@ function NeedsConnectionHero(props: {
                   render={
                     <button
                       type="button"
-                      onClick={() => props.onOpenSettings('models')}
+                      onClick={() => props.onAddProvider(type)}
                     />
                   }
                 >

--- a/apps/desktop/src/renderer/app-shell-overlays.tsx
+++ b/apps/desktop/src/renderer/app-shell-overlays.tsx
@@ -1,6 +1,7 @@
 import { lazy, Suspense, useCallback } from 'react';
 import type {
   LlmConnection,
+  ProviderType,
   SettingsSection,
   ThemePalette,
   ThemePreference,
@@ -53,6 +54,7 @@ export function AppShellOverlays(props: {
   settingsRequestedSection: SettingsSection | undefined;
   settingsProviderCatalogOpen: boolean;
   settingsConnectionDetailSlug: string | undefined;
+  settingsCreateProviderType: ProviderType | undefined;
   onOpenDailyReview(): void;
   onOpenSettingsSession(sessionId: string): void;
   helpOpen: boolean;
@@ -89,6 +91,7 @@ export function AppShellOverlays(props: {
     settingsRequestedSection,
     settingsProviderCatalogOpen,
     settingsConnectionDetailSlug,
+    settingsCreateProviderType,
     setThemePalette,
     setThemePref,
     setUiLocalePreference,
@@ -128,6 +131,7 @@ export function AppShellOverlays(props: {
             requestedSection={settingsRequestedSection}
             openProviderCatalog={settingsProviderCatalogOpen}
             initialConnectionSlug={settingsConnectionDetailSlug}
+            initialCreateProviderType={settingsCreateProviderType}
             onOpenDailyReview={props.onOpenDailyReview}
             onOpenSession={props.onOpenSettingsSession}
           />

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -265,12 +265,14 @@ function AppShellContent({
     settingsRequestedSection,
     settingsProviderCatalogOpen,
     settingsConnectionDetailSlug,
+    settingsCreateProviderType,
     setSettingsOpen,
     setSettingsProviderCatalogOpen,
     openSettings,
     openSettingsSection,
     openProviderCatalog,
     openConnectionDetail,
+    openProviderCreate,
   } = useSettingsModal();
   const {
     themePref,
@@ -1763,6 +1765,7 @@ function AppShellContent({
                   if (section) openSettingsSection(section);
                   else openSettings();
                 }}
+                onAddProvider={openProviderCreate}
                 onBrowseProviders={openProviderCatalog}
                 onQuickChatSubmit={handleQuickChatSubmit}
                 mentionSkills={mentionSkills}
@@ -1988,6 +1991,7 @@ function AppShellContent({
         settingsRequestedSection={settingsRequestedSection}
         settingsProviderCatalogOpen={settingsProviderCatalogOpen}
         settingsConnectionDetailSlug={settingsConnectionDetailSlug}
+        settingsCreateProviderType={settingsCreateProviderType}
         onOpenDailyReview={() => {
           closeSettings();
           setNavSelection({ section: 'daily-review' });

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -3,6 +3,7 @@ import {
   isDeepResearchSession,
   type LlmConnection,
   type OnboardingState,
+  type ProviderType,
   type QuickChatMode,
   type SettingsSection,
 } from '@maka/core';
@@ -31,6 +32,7 @@ interface ChatMessageSurfaceProps extends Omit<
   onboardingState: OnboardingState | undefined;
   isOnboardingLoading: boolean;
   onOpenSettings: (section?: SettingsSection) => void;
+  onAddProvider: (providerType: ProviderType) => void;
   onBrowseProviders: () => void;
   onQuickChatSubmit: (
     prompt: string,
@@ -53,6 +55,7 @@ export function ChatMessageSurface({
   onboardingState,
   isOnboardingLoading,
   onOpenSettings,
+  onAddProvider,
   onBrowseProviders,
   onQuickChatSubmit,
   mentionSkills,
@@ -79,6 +82,7 @@ export function ChatMessageSurface({
       <OnboardingEmptyState
         state={onboardingState}
         onOpenSettings={onOpenSettings}
+        onAddProvider={onAddProvider}
         onBrowseProviders={onBrowseProviders}
         onQuickChatSubmit={onQuickChatSubmit}
         mentionSkills={mentionSkills}

--- a/apps/desktop/src/renderer/onboarding-empty-state.tsx
+++ b/apps/desktop/src/renderer/onboarding-empty-state.tsx
@@ -1,10 +1,11 @@
-import type { LlmConnection, OnboardingState, QuickChatMode, SettingsSection } from '@maka/core';
+import type { LlmConnection, OnboardingState, ProviderType, QuickChatMode, SettingsSection } from '@maka/core';
 import { OnboardingHero } from './OnboardingHero';
 import { FirstRunChecklist } from './FirstRunChecklist';
 
 interface OnboardingEmptyStateProps {
   state: OnboardingState;
   onOpenSettings: (section?: SettingsSection) => void;
+  onAddProvider: (providerType: ProviderType) => void;
   onBrowseProviders: () => void;
   onQuickChatSubmit: (
     prompt: string,
@@ -30,6 +31,7 @@ interface OnboardingEmptyStateProps {
 export function OnboardingEmptyState({
   state,
   onOpenSettings,
+  onAddProvider,
   onBrowseProviders,
   onQuickChatSubmit,
   mentionSkills,
@@ -46,6 +48,7 @@ export function OnboardingEmptyState({
       <OnboardingHero
         state={state}
         onOpenSettings={onOpenSettings}
+        onAddProvider={onAddProvider}
         onBrowseProviders={onBrowseProviders}
         onQuickChatSubmit={onQuickChatSubmit}
         mentionSkills={mentionSkills}

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -42,7 +42,7 @@ type CatalogCategory = ProviderCatalogGroup | 'accounts';
 
 const CATALOG_TABS: CatalogCategory[] = ['recommended', 'accounts', 'plans', 'api', 'aggregators', 'local'];
 
-export function ProvidersPanel({ bridge, initialPage = 'connections', initialConnectionSlug, initialCreateProviderType }: {
+export function ProvidersPanel({ bridge, initialPage = 'connections', initialConnectionSlug, initialCreateProviderType, onInitialCreateProviderConsumed }: {
   bridge: ConnectionsBridge;
   initialPage?: 'connections' | 'catalog';
   /**
@@ -56,9 +56,12 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
    * When set, auto-open the create-connection dialog for this provider once
    * the panel has loaded. Used by the first-run hero so clicking a provider
    * row lands directly in that provider's form; a real user reaches the
-   * same dialog by clicking the provider's catalog card.
+   * same dialog by clicking the provider's catalog card. One-shot: the
+   * caller retires the request via onInitialCreateProviderConsumed.
    */
   initialCreateProviderType?: ProviderType;
+  /** Called once the auto-opened create dialog has been raised. */
+  onInitialCreateProviderConsumed?: () => void;
 }) {
   const [connections, setConnections] = useState<LlmConnection[]>([]);
   const [defaultSlug, setDefaultSlug] = useState<string | null>(null);
@@ -134,12 +137,11 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
     setDialogState({ kind: 'manage', slug: initialConnectionSlug });
   }, [loading, initialConnectionSlug, connections]);
 
-  const initialCreateDialogOpenedRef = useRef(false);
   useEffect(() => {
-    if (loading || !initialCreateProviderType || initialCreateDialogOpenedRef.current) return;
-    initialCreateDialogOpenedRef.current = true;
+    if (loading || !initialCreateProviderType) return;
     setDialogState({ kind: 'create', providerType: initialCreateProviderType });
-  }, [loading, initialCreateProviderType]);
+    onInitialCreateProviderConsumed?.();
+  }, [loading, initialCreateProviderType, onInitialCreateProviderConsumed]);
 
   const selected = useMemo(
     () => dialogState?.kind === 'manage'

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -42,7 +42,7 @@ type CatalogCategory = ProviderCatalogGroup | 'accounts';
 
 const CATALOG_TABS: CatalogCategory[] = ['recommended', 'accounts', 'plans', 'api', 'aggregators', 'local'];
 
-export function ProvidersPanel({ bridge, initialPage = 'connections', initialConnectionSlug }: {
+export function ProvidersPanel({ bridge, initialPage = 'connections', initialConnectionSlug, initialCreateProviderType }: {
   bridge: ConnectionsBridge;
   initialPage?: 'connections' | 'catalog';
   /**
@@ -52,6 +52,13 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
    * real user reaches the same sheet by clicking the connection row.
    */
   initialConnectionSlug?: string;
+  /**
+   * When set, auto-open the create-connection dialog for this provider once
+   * the panel has loaded. Used by the first-run hero so clicking a provider
+   * row lands directly in that provider's form; a real user reaches the
+   * same dialog by clicking the provider's catalog card.
+   */
+  initialCreateProviderType?: ProviderType;
 }) {
   const [connections, setConnections] = useState<LlmConnection[]>([]);
   const [defaultSlug, setDefaultSlug] = useState<string | null>(null);
@@ -126,6 +133,13 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
     initialConnectionDetailOpenedRef.current = true;
     setDialogState({ kind: 'manage', slug: initialConnectionSlug });
   }, [loading, initialConnectionSlug, connections]);
+
+  const initialCreateDialogOpenedRef = useRef(false);
+  useEffect(() => {
+    if (loading || !initialCreateProviderType || initialCreateDialogOpenedRef.current) return;
+    initialCreateDialogOpenedRef.current = true;
+    setDialogState({ kind: 'create', providerType: initialCreateProviderType });
+  }, [loading, initialCreateProviderType]);
 
   const selected = useMemo(
     () => dialogState?.kind === 'manage'

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from 'react';
 import type {
   LlmConnection,
+  ProviderType,
   SettingsSection,
   ThemePalette,
   ThemePreference,
@@ -41,6 +42,7 @@ export function SettingsModal(props: {
   requestedSection?: SettingsSection;
   openProviderCatalog?: boolean;
   initialConnectionSlug?: string;
+  initialCreateProviderType?: ProviderType;
   /**
    * PR-DAILY-REVIEW-MVP-0 follow-up: navigate to the sidebar's
    * Daily Review module. Optional so the settings page degrades
@@ -98,6 +100,7 @@ export function SettingsModal(props: {
         requestedSection={props.requestedSection}
         openProviderCatalog={props.openProviderCatalog}
         initialConnectionSlug={props.initialConnectionSlug}
+        initialCreateProviderType={props.initialCreateProviderType}
         initialFocusRef={activeNavRef}
         onOpenDailyReview={props.onOpenDailyReview}
         onOpenSession={props.onOpenSession}

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -63,6 +63,10 @@ export function SettingsSurface(props: {
   const localizedNav = groupedNav(locale);
   const [section, setSection] = useState<SettingsSection>(() => props.requestedSection ?? readLastSettingsSection());
   const [providerCatalogRequested, setProviderCatalogRequested] = useState(props.openProviderCatalog === true);
+  // One-shot landing intent, mirroring providerCatalogRequested above: the
+  // request retires once ProvidersPanel consumes it, so remounting the panel
+  // (switching sections away and back) does not resurrect the create dialog.
+  const [createProviderRequest, setCreateProviderRequest] = useState(props.initialCreateProviderType);
 
   // When the parent updates requestedSection (e.g. the palette opens
   // Settings with a different section while it's already mounted), reflect
@@ -296,7 +300,8 @@ export function SettingsSurface(props: {
               onOpenSession={props.onOpenSession}
               openProviderCatalog={providerCatalogRequested}
               initialConnectionSlug={props.initialConnectionSlug}
-              initialCreateProviderType={props.initialCreateProviderType}
+              initialCreateProviderType={createProviderRequest}
+              onInitialCreateProviderConsumed={() => setCreateProviderRequest(undefined)}
             />
           )}
         </OverlayScrollArea>
@@ -324,6 +329,7 @@ function SettingsPage(props: {
   openProviderCatalog?: boolean;
   initialConnectionSlug?: string;
   initialCreateProviderType?: ProviderType;
+  onInitialCreateProviderConsumed?(): void;
 }) {
   const locale = useUiLocale();
   const copy = getSettingsSharedCopy(locale);
@@ -342,6 +348,7 @@ function SettingsPage(props: {
             initialPage={props.openProviderCatalog ? 'catalog' : 'connections'}
             initialConnectionSlug={props.initialConnectionSlug}
             initialCreateProviderType={props.initialCreateProviderType}
+            onInitialCreateProviderConsumed={props.onInitialCreateProviderConsumed}
           />
         </div>
       );

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -4,6 +4,7 @@ import { Button as BaseButton } from '@base-ui/react/button';
 import type {
   AppSettings,
   LlmConnection,
+  ProviderType,
   SettingsSection,
   ThemePalette,
   ThemePreference,
@@ -52,6 +53,7 @@ export function SettingsSurface(props: {
   requestedSection?: SettingsSection;
   openProviderCatalog?: boolean;
   initialConnectionSlug?: string;
+  initialCreateProviderType?: ProviderType;
   initialFocusRef: RefObject<HTMLButtonElement | null>;
   onOpenDailyReview?(): void;
   onOpenSession?(sessionId: string): void;
@@ -294,6 +296,7 @@ export function SettingsSurface(props: {
               onOpenSession={props.onOpenSession}
               openProviderCatalog={providerCatalogRequested}
               initialConnectionSlug={props.initialConnectionSlug}
+              initialCreateProviderType={props.initialCreateProviderType}
             />
           )}
         </OverlayScrollArea>
@@ -320,6 +323,7 @@ function SettingsPage(props: {
   onOpenSession?(sessionId: string): void;
   openProviderCatalog?: boolean;
   initialConnectionSlug?: string;
+  initialCreateProviderType?: ProviderType;
 }) {
   const locale = useUiLocale();
   const copy = getSettingsSharedCopy(locale);
@@ -337,6 +341,7 @@ function SettingsPage(props: {
             bridge={window.maka.connections}
             initialPage={props.openProviderCatalog ? 'catalog' : 'connections'}
             initialConnectionSlug={props.initialConnectionSlug}
+            initialCreateProviderType={props.initialCreateProviderType}
           />
         </div>
       );

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -68,6 +68,17 @@ export function SettingsSurface(props: {
   // (switching sections away and back) does not resurrect the create dialog.
   const [createProviderRequest, setCreateProviderRequest] = useState(props.initialCreateProviderType);
 
+  // Keep the pending intent in sync with the hook-level request: a newer
+  // opener (e.g. a ⌘K section jump while Settings is still loading) clears
+  // or replaces the prop, and the pending intent must follow — otherwise a
+  // stale copy raises the create dialog after the user already navigated
+  // away (GPT 5.6 Sol review, PR #1402). Keyed on prop CHANGE only, so an
+  // already-consumed request (cleared below) is not resurrected while the
+  // hook value is unchanged.
+  useEffect(() => {
+    setCreateProviderRequest(props.initialCreateProviderType);
+  }, [props.initialCreateProviderType]);
+
   // When the parent updates requestedSection (e.g. the palette opens
   // Settings with a different section while it's already mounted), reflect
   // that into the local state.

--- a/apps/desktop/src/renderer/use-settings-modal.ts
+++ b/apps/desktop/src/renderer/use-settings-modal.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import type { SettingsSection } from '@maka/core';
+import type { ProviderType, SettingsSection } from '@maka/core';
 import { safeLocalStorageSet } from './browser-storage';
 
 /**
@@ -18,10 +18,12 @@ export function useSettingsModal() {
   );
   const [settingsProviderCatalogOpen, setSettingsProviderCatalogOpen] = useState(false);
   const [settingsConnectionDetailSlug, setSettingsConnectionDetailSlug] = useState<string | undefined>(undefined);
+  const [settingsCreateProviderType, setSettingsCreateProviderType] = useState<ProviderType | undefined>(undefined);
 
   function openSettings() {
     setSettingsProviderCatalogOpen(false);
     setSettingsConnectionDetailSlug(undefined);
+    setSettingsCreateProviderType(undefined);
     setSettingsOpen(true);
   }
 
@@ -30,6 +32,7 @@ export function useSettingsModal() {
     setSettingsRequestedSection(section);
     setSettingsProviderCatalogOpen(false);
     setSettingsConnectionDetailSlug(undefined);
+    setSettingsCreateProviderType(undefined);
     setSettingsOpen(true);
   }
 
@@ -38,6 +41,7 @@ export function useSettingsModal() {
     setSettingsRequestedSection('models');
     setSettingsProviderCatalogOpen(true);
     setSettingsConnectionDetailSlug(undefined);
+    setSettingsCreateProviderType(undefined);
     setSettingsOpen(true);
   }
 
@@ -47,6 +51,17 @@ export function useSettingsModal() {
     setSettingsRequestedSection('models');
     setSettingsProviderCatalogOpen(false);
     setSettingsConnectionDetailSlug(slug);
+    setSettingsCreateProviderType(undefined);
+    setSettingsOpen(true);
+  }
+
+  /** Open Settings → 模型 with the create-connection dialog for this provider expanded. */
+  function openProviderCreate(providerType: ProviderType) {
+    safeLocalStorageSet('maka-settings-section-v1', 'models');
+    setSettingsRequestedSection('models');
+    setSettingsProviderCatalogOpen(false);
+    setSettingsConnectionDetailSlug(undefined);
+    setSettingsCreateProviderType(providerType);
     setSettingsOpen(true);
   }
 
@@ -55,11 +70,13 @@ export function useSettingsModal() {
     settingsRequestedSection,
     settingsProviderCatalogOpen,
     settingsConnectionDetailSlug,
+    settingsCreateProviderType,
     setSettingsOpen,
     setSettingsProviderCatalogOpen,
     openSettings,
     openSettingsSection,
     openProviderCatalog,
     openConnectionDetail,
+    openProviderCreate,
   };
 }

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -278,6 +278,7 @@ export const EmptyHome: Story = {
           <OnboardingHero
             state={{ kind: 'ready_empty', defaultConnectionSlug: 'anthropic-main', defaultModel: 'claude-sonnet-4-5' }}
             onOpenSettings={noop}
+            onAddProvider={noop}
             onBrowseProviders={noop}
             onQuickChatSubmit={async () => true}
           />

--- a/apps/desktop/stories/onboarding.stories.tsx
+++ b/apps/desktop/stories/onboarding.stories.tsx
@@ -69,6 +69,7 @@ function heroProps(state: OnboardingState) {
   return {
     state,
     onOpenSettings: (_section?: SettingsSection) => undefined,
+    onAddProvider: () => undefined,
     onBrowseProviders: () => undefined,
     onQuickChatSubmit: async () => true,
     connections,


### PR DESCRIPTION
## Summary

On the first-run hero (选择你的 AI), clicking a provider row discarded the provider type and only opened Settings → 模型, landing on the connection list instead of that provider's form — even though the list header promises 点一个进入设置，填它的 key. Reported by a user clicking DeepSeek and getting the generic models page.

Root cause: `NeedsConnectionHero`'s row handler was `onClick={() => props.onOpenSettings('models')}` — the `type` was dropped at the source, and no channel existed to carry a provider target into Settings. It had been that way since the hero was introduced; the first-run e2e only asserted row count/text and clicked 浏览全部服务商, never a provider row, so the happy path shipped untested.

Fix mirrors the existing `openConnectionDetail` seam end to end rather than adding a parallel path:

- `use-settings-modal`: new `openProviderCreate(type)` opener + `settingsCreateProviderType` state (the other openers clear it, same as the existing targets).
- Threaded as `initialCreateProviderType`: AppShell → AppShellOverlays → SettingsModal → SettingsSurface → ProvidersPanel, one line per layer, exactly like `initialConnectionSlug`.
- `ProvidersPanel`: an auto-open effect (mirroring the slug one) sets the existing `dialogState = { kind: 'create', providerType }` — no new dialog or form code.
- Hero side: `NeedsConnectionHero`'s `onOpenSettings` prop had no remaining use except the rows (the footer dedup removed the other one), so it is replaced by a semantic `onAddProvider(type)` callback, threaded like `onBrowseProviders` and wired to `openProviderCreate` in AppShell.

Considered and rejected: smuggling the type through `onOpenSettings(section, opts)` (fewer lines, but the section param becomes a lie when a provider target is set, and it breaks the one-callback-per-intent convention), and unifying the four settings-target openers into one discriminated union (a rewrite of a working pattern, out of scope for this fix).

## Verification

- New regression e2e in `first-run.spec.ts` clicks the DeepSeek row and asserts the `连接 DeepSeek` dialog opens inside Settings. Confirmed RED first (failed exactly at the dialog assertion, reproducing the reported symptom), then GREEN after the fix:
  ```
  ✓ boots to registry recommendations and browses the shared provider catalog
  ✓ clicking a recommended provider row opens that provider connection form
  2 passed
  ```
- Broadened e2e over the affected surfaces: `providers.spec.ts`, `settings.spec.ts`, `command-palette.spec.ts`, `session-health-notice.spec.ts` — 13 passed.
- `npm run lint` clean; `npm run typecheck` clean across all workspaces (renderer + storybook configs included).
- Did not run: the full e2e suite (only the specs above) and `npm test` for main-process unit tests (no main-process code touched).