### PR TITLE
fix(desktop): retire the first-run list bottom fade at scroll end

### DIFF
--- a/apps/desktop/e2e/first-run.spec.ts
+++ b/apps/desktop/e2e/first-run.spec.ts
@@ -39,3 +39,17 @@ test('boots to registry recommendations and browses the shared provider catalog'
   await expect(page.getByRole('heading', { name: '添加新连接' })).toBeVisible();
   await expect(page.getByPlaceholder('搜索服务商')).toBeVisible();
 });
+
+// The provider list's bottom fade is a "more below" cue: it must be opaque
+// while the list can scroll further down and gone at scroll end (otherwise
+// it veils the last row, reading as broken dimming).
+test('provider list bottom fade tracks scroll position', async ({ emptyWindow: page }) => {
+  const scroller = page.locator('.maka-firstrun-list ul');
+  const fadeOpacity = () => scroller.evaluate((el) => getComputedStyle(el, '::after').opacity);
+
+  await expect.poll(fadeOpacity).toBe('1');
+  await scroller.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+  await expect.poll(fadeOpacity).toBe('0');
+});

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -212,7 +212,6 @@
 
 /* --- provider list panel (scrolls vertically as the list grows) --- */
 .maka-firstrun-list {
-  position: relative;
   border: var(--border-width-hairline) solid var(--border);
   border-radius: var(--radius-surface);
   overflow: hidden;

--- a/apps/desktop/src/renderer/styles/onboarding.css
+++ b/apps/desktop/src/renderer/styles/onboarding.css
@@ -221,21 +221,12 @@
 
 /* Designer audit P2-15: the height clamp cut the last visible provider row
    in half with no cue that the list scrolls — it read as broken clipping.
-   A bottom fade signals "more below" (the provider count always exceeds the
-   clamp, so the cue never lies); pointer-events none keeps rows clickable. */
-.maka-firstrun-list::after {
-  content: "";
-  position: absolute;
-  left: var(--border-width-hairline);
-  right: var(--border-width-hairline);
-  bottom: var(--border-width-hairline);
-  /* 56px: tall enough to fully veil a half-clipped row's text — at 28px the
-     cut row stayed half-legible under the fade and still read as broken. */
-  height: 56px;
-  border-radius: 0 0 var(--radius-surface) var(--radius-surface);
-  background: linear-gradient(to bottom, oklch(from var(--background-elevated) l c h / 0), var(--background-elevated));
-  pointer-events: none;
-}
+   A bottom fade signals "more below". The cue must retire at scroll end:
+   an always-on fade veils the last row and reads as broken dimming. The
+   fade therefore lives on the scroller itself as a sticky ::after, and a
+   scroll-state container query (Chromium 133+, Electron 43) drops it once
+   the list can no longer scroll down — including when the list fits and
+   never overflows. */
 .maka-firstrun-list ul {
   margin: 0;
   padding: 0;
@@ -245,6 +236,32 @@
      windows while still bounding growth as more providers are added. */
   max-height: clamp(240px, 42vh, 420px);
   overflow-y: auto;
+  container-type: scroll-state;
+}
+.maka-firstrun-list ul::after {
+  content: "";
+  display: block;
+  /* Sticky pins the fade to the scrollport's bottom edge while more
+     content follows; margin-top pulls the last row back up under it so the
+     pseudo adds no scrollable height. pointer-events none keeps rows
+     clickable. */
+  position: sticky;
+  bottom: 0;
+  /* 56px: tall enough to fully veil a half-clipped row's text — at 28px the
+     cut row stayed half-legible under the fade and still read as broken.
+     margin-top derives from the same local var so the two never drift. */
+  --firstrun-fade-height: 56px;
+  height: var(--firstrun-fade-height);
+  margin-top: calc(-1 * var(--firstrun-fade-height));
+  border-radius: 0 0 var(--radius-surface) var(--radius-surface);
+  background: linear-gradient(to bottom, oklch(from var(--background-elevated) l c h / 0), var(--background-elevated));
+  pointer-events: none;
+  transition: opacity var(--duration-quick) var(--ease-out-strong);
+}
+@container not scroll-state(scrollable: bottom) {
+  .maka-firstrun-list ul::after {
+    opacity: 0;
+  }
 }
 .maka-firstrun-list li + li {
   border-top: var(--border-width-hairline) solid var(--border);


### PR DESCRIPTION
## Summary

On the first-run hero, scrolling the provider list to the bottom left the last row dimmed under a grey veil. Root cause: `.maka-firstrun-list::after` was an unconditional 56px bottom-fade overlay — a "more below" cue that never retired. The original comment's rationale ("the provider count always exceeds the clamp, so the cue never lies") only held while more content was below; at scroll end the cue lied, covering the last row (found during manual onboarding testing, confirmed against the live app via CDP computed styles: `atBottom: true` while the ::after gradient sat at `opacity: 1`).

Fix is pure CSS, no component or DOM changes: the fade moves onto the scroller (`ul`) as a sticky `::after`, and a scroll-state container query (Chromium 133+, Electron 43) drops it to `opacity: 0` once the list can no longer scroll down — which also correctly handles the list-fits-no-overflow case the static overlay got wrong. The sticky pseudo adds no scrollable height (`margin-top` derives from the height via a local var), and the fade-out transition uses `--duration-quick`/`--ease-out-strong` per the motion-token converge contracts. Approach verified live before implementation by injecting the candidate CSS over CDP and probing computed opacity at both scroll positions.

## Verification

- New e2e contract in `first-run.spec.ts`: computed `::after` opacity is `'1'` while scrollable and `'0'` at scroll end. Confirmed RED before the fix, GREEN after: `first-run.spec.ts` 2/2.
- `npm test` (main-process unit + CSS contract suites): 0 failures — including the motion-token and spacing converge contracts, which caught bare `120ms`/`ease-out`/`-56px` in the first draft; the committed version uses tokens.
- `npm run lint` clean.
- Live-app evidence: CDP probe of the fixed build shows the fade opaque at scroll top and gone at scroll end; the previously reported dimmed last row (自定义中转站 Anthropic) renders at full opacity.
- Did not run: the full e2e suite (only `first-run.spec.ts`) — change is scoped to one CSS rule and its contract test.