### PR TITLE
feat(runtime): enable Anthropic automatic prompt caching

### DIFF
--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -17,32 +17,53 @@ function conn(providerType: LlmConnection['providerType'], slug = 'test'): LlmCo
 }
 
 describe('buildProviderOptions: thinking level', () => {
+  test('only native Anthropic enables automatic prompt caching', () => {
+    assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-opus-4-8'), {
+      anthropic: { cacheControl: { type: 'ephemeral' } },
+    });
+    for (const providerType of [
+      'claude-subscription',
+      'MiniMax',
+      'MiniMax-cn',
+      'kimi-coding-plan',
+    ] as const) {
+      const anthropic = buildProviderOptions(conn(providerType), 'claude-opus-4-8').anthropic;
+      assert.equal(
+        (anthropic as { cacheControl?: unknown } | undefined)?.cacheControl,
+        undefined,
+        `${providerType} must not inherit Anthropic automatic prompt caching`,
+      );
+    }
+  });
+
   test('anthropic effort model (opus-4-8) sends effort field directly; no budgetTokens mapping', () => {
-    assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-opus-4-8'), { anthropic: {} });
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-opus-4-8', 'high'), {
-      anthropic: { effort: 'high' },
+      anthropic: { cacheControl: { type: 'ephemeral' }, effort: 'high' },
     });
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-opus-4-8', 'max'), {
-      anthropic: { effort: 'max' },
+      anthropic: { cacheControl: { type: 'ephemeral' }, effort: 'max' },
     });
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-opus-4-8', 'xhigh'), {
-      anthropic: { effort: 'xhigh' },
+      anthropic: { cacheControl: { type: 'ephemeral' }, effort: 'xhigh' },
     });
   });
 
   test('anthropic budget/toggle model (haiku-4-5) sends thinking.disabled for off; drops unsupported effort', () => {
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-haiku-4-5', 'off'), {
-      anthropic: { thinking: { type: 'disabled' } },
+      anthropic: {
+        cacheControl: { type: 'ephemeral' },
+        thinking: { type: 'disabled' },
+      },
     });
     // haiku-4-5 has no effort variants, only off → high is dropped
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-haiku-4-5', 'high'), {
-      anthropic: {},
+      anthropic: { cacheControl: { type: 'ephemeral' } },
     });
   });
 
   test('anthropic effort model without toggle (opus-4-8) drops off (cannot disable)', () => {
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-opus-4-8', 'off'), {
-      anthropic: {},
+      anthropic: { cacheControl: { type: 'ephemeral' } },
     });
   });
 
@@ -292,7 +313,7 @@ describe('buildProviderOptions: thinking level', () => {
       openai: { store: false },
     });
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-haiku-4-5', 'max'), {
-      anthropic: {},
+      anthropic: { cacheControl: { type: 'ephemeral' } },
     });
   });
 });

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -18,6 +18,53 @@ import {
 after(closeAllJsonServers);
 
 describe('models.dev provider conformance', () => {
+  test('native Anthropic sends automatic prompt caching on the Messages wire', async () => {
+    let requestBody: Record<string, unknown> | undefined;
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/v1/messages');
+      assert.equal(request.headers['x-api-key'], 'anthropic-test-key');
+      requestBody = JSON.parse(await readBody(request)) as Record<string, unknown>;
+      respondJson(response, 200, {
+        id: 'msg_anthropic_cache',
+        type: 'message',
+        role: 'assistant',
+        model: 'claude-opus-4-8',
+        content: [{ type: 'text', text: 'Cached.' }],
+        stop_reason: 'end_turn',
+        stop_sequence: null,
+        usage: {
+          input_tokens: 4,
+          output_tokens: 1,
+          cache_creation_input_tokens: 0,
+          cache_read_input_tokens: 0,
+        },
+      });
+    });
+    const connection: LlmConnection = {
+      slug: 'anthropic',
+      name: 'Anthropic',
+      providerType: 'anthropic',
+      baseUrl: server.url,
+      defaultModel: 'claude-opus-4-8',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    await generateText({
+      model: getAIModel({
+        connection,
+        apiKey: 'anthropic-test-key',
+        modelId: connection.defaultModel,
+      }),
+      prompt: 'Hello.',
+      providerOptions: buildProviderOptions(connection, connection.defaultModel),
+    });
+
+    assert.deepEqual(requestBody?.cache_control, { type: 'ephemeral' });
+  });
+
   test('GitHub Copilot connection probe validates the selected account model without inference', async () => {
     const server = await startJsonServer((request, response) => {
       assert.equal(request.method, 'GET');

--- a/packages/runtime/src/__tests__/subscription-model-fetch.test.ts
+++ b/packages/runtime/src/__tests__/subscription-model-fetch.test.ts
@@ -47,7 +47,9 @@ describe('subscription model fetch', () => {
     );
     assert.equal(body.system[0].text.startsWith('x-anthropic-billing-header:'), true);
     assert.equal(body.system[1].text, "You are Claude Code, Anthropic's official CLI for Claude.");
+    assert.deepEqual(body.system[1].cache_control, { type: 'ephemeral' });
     assert.equal(body.system[2].text, 'Use the Maka system prompt.');
+    assert.equal(body.cache_control, undefined);
   });
 
   test('leaves Claude subscription requests untouched when the cloak opt-out is disabled', async () => {

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -315,16 +315,22 @@ export function buildProviderOptions(
     case 'anthropic':
     case 'MiniMax':
     case 'MiniMax-cn':
-    case 'claude-subscription':
+    case 'claude-subscription': {
+      let reasoning = {};
+      if (level === 'off' && thinkingOptions?.offBehavior === 'anthropic-thinking-disabled') {
+        reasoning = { thinking: { type: 'disabled' as const } };
+      } else if (level && level !== 'off') {
+        reasoning = { effort: level };
+      }
       return {
-        anthropic: level
-          ? level === 'off'
-            ? thinkingOptions?.offBehavior === 'anthropic-thinking-disabled'
-              ? { thinking: { type: 'disabled' as const } }
-              : {}
-            : { effort: level }
-          : {},
+        anthropic: {
+          ...(connection.providerType === 'anthropic'
+            ? { cacheControl: { type: 'ephemeral' as const } }
+            : {}),
+          ...reasoning,
+        },
       };
+    }
     case 'openai-codex':
       return {
         openai: {


### PR DESCRIPTION
## Summary

- Enable top-level automatic prompt caching for native Anthropic API-key requests using the default ephemeral cache.
- Preserve existing thinking and effort options while excluding Claude subscription, MiniMax, Kimi, and other providers.
- Add final Messages wire coverage and regression tests for provider isolation and the subscription prefix marker.

## Verification

- `npm --workspace @maka/runtime run build`
- Focused runtime tests: 91 passed, 0 failed

Closes #1380