### PR TITLE
fix(runtime): preserve token usage fields across replay

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -5916,7 +5916,7 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('renders switched session history instead of a session id note', async () => {
+  test('restores switched session state from stored messages', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver(
       [fakeSessionSummary('session-2', '/repo')],
@@ -5926,6 +5926,28 @@ describe('Maka Pi TUI runner', () => {
           [
             storedUserMessage('user-1', 'turn-1', 'previous question'),
             storedAssistantMessage('assistant-1', 'turn-1', 'previous answer'),
+            {
+              type: 'token_usage',
+              id: 'usage-1',
+              turnId: 'turn-1',
+              ts: 3,
+              input: 100,
+              output: 20,
+              cacheHitInput: 20,
+              cacheMissInput: 80,
+              contextRemaining: 490_000,
+            },
+            {
+              type: 'token_usage',
+              id: 'usage-2',
+              turnId: 'turn-1',
+              ts: 4,
+              input: 100,
+              output: 20,
+              cacheHitInput: 60,
+              cacheMissInput: 40,
+              contextRemaining: 480_000,
+            },
           ],
         ],
       ]),
@@ -5937,6 +5959,7 @@ describe('Maka Pi TUI runner', () => {
       model: 'claude-sonnet-4-5',
       connectionSlug: 'claude-subscription',
       permissionMode: 'ask',
+      modelContextWindow: 500_000,
       terminal,
     });
 
@@ -5945,6 +5968,8 @@ describe('Maka Pi TUI runner', () => {
 
     await waitFor(() => plainTerminalOutput(terminal.output()).includes('previous question'));
     await waitFor(() => plainTerminalOutput(terminal.output()).includes('previous answer'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('ctx 20k/500k 4%'));
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('cache 40%'));
     const output = plainTerminalOutput(terminal.output());
     assert.equal(output.includes('Session: session-2'), false);
 

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -212,6 +212,7 @@ function accumulateUsage(
     cacheWriteInput?: number;
     cacheCreation?: number;
     cacheMissInput?: number;
+    contextRemaining?: number;
   },
 ): void {
   usage.costUsd += msg.costUsd ?? 0;
@@ -219,6 +220,7 @@ function accumulateUsage(
   const write = msg.cacheWriteInput ?? msg.cacheCreation ?? 0;
   usage.cacheHitInput += hit;
   usage.cacheMissInput += msg.cacheMissInput ?? Math.max(0, (msg.input ?? 0) - hit - write);
+  usage.contextRemaining = msg.contextRemaining;
 }
 
 export function appendUserPrompt(state: MakaPiTranscriptState, text: string): void {
@@ -686,7 +688,6 @@ export function applyMakaSessionEventToTranscript(
 
     case 'token_usage': {
       accumulateUsage(state.usage, event);
-      state.usage.contextRemaining = event.contextRemaining;
       const notice = contextBudgetOutcomeNotice(event.contextBudget);
       if (notice) {
         state.entries.push({

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -690,6 +690,7 @@ export interface TokenUsageMessage {
   cacheCreation?: number;
   costUsd?: number;
   systemPromptHash?: string;
+  contextRemaining?: number;
   prefixHash?: string;
   prefixChangeReason?: PrefixChangeReason;
   requestShapeHash?: string;
@@ -786,6 +787,7 @@ const TOKEN_USAGE_MESSAGE_SHAPE = defineObjectShape<TokenUsageMessage>()(
     'cacheCreation',
     'costUsd',
     'systemPromptHash',
+    'contextRemaining',
     'prefixHash',
     'prefixChangeReason',
     'requestShapeHash',

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -1,11 +1,15 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
-import type { BackendKind } from '@maka/core/session';
+import { decodeStoredMessageForRecovery, type BackendKind } from '@maka/core/session';
 import type { SessionEvent } from '@maka/core/events';
 import type { BackendSendInput, PermissionDecision } from '@maka/core/backend-types';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
-import { isTerminalRuntimeEvent, isPartialRuntimeEvent } from '@maka/core/runtime-event';
+import {
+  decodeRuntimeEvent,
+  isTerminalRuntimeEvent,
+  isPartialRuntimeEvent,
+} from '@maka/core/runtime-event';
 
 import {
   AiSdkFlow,
@@ -17,6 +21,8 @@ import { flowSupportsControl } from '../agent-flow.js';
 import type { AgentBackend } from '@maka/core/backend-types';
 import { RuntimeRunner } from '../runtime-runner.js';
 import type { InvocationContext } from '../invocation-context.js';
+import { projectRuntimeEventsToStoredMessages } from '../runtime-event-read-model.js';
+import { backfillRuntimeEventsFromStoredMessages } from '../runtime-event-backfill.js';
 
 // ============================================================================
 // Fake backend — scripted SessionEvent stream + recorded control calls
@@ -728,6 +734,102 @@ describe('AiSdkFlow seam', () => {
     assert.deepEqual(backend.stopCalls, ['user_stop']);
     assert.equal(out.length, 2);
     assert.equal(isTerminalRuntimeEvent(out[out.length - 1]), true);
+  });
+});
+
+describe('token usage durable round trip', () => {
+  test('token usage fields survive SessionEvent projection and legacy backfill', () => {
+    const contextBudget = {
+      enabled: true,
+      estimatedTokensBefore: 100,
+      estimatedTokensAfter: 80,
+      keptTurns: 2,
+      droppedTurns: 1,
+      keptEvents: 4,
+      droppedEvents: 2,
+    };
+    const usage = {
+      input: 100,
+      output: 25,
+      cacheHitInput: 40,
+      cacheMissInput: 60,
+      cacheWriteInput: 10,
+      cacheMissInputSource: 'explicit' as const,
+      reasoning: 5,
+      total: 125,
+      rawFinishReason: 'stop',
+      runtimeSteps: 3,
+      cacheRead: 40,
+      cacheCreation: 10,
+      costUsd: 0.002,
+      systemPromptHash: 'system-hash',
+      contextRemaining: 9000,
+      prefixHash: 'prefix-hash',
+      prefixChangeReason: 'stable' as const,
+      requestShapeHash: 'request-shape-hash',
+      requestShapeChangeReason: 'stable' as const,
+      promptSegments: [{ kind: 'system_prompt' as const, chars: 400, estimatedTokens: 100 }],
+      contextBudget,
+    };
+    const sessionEvent: SessionEvent = {
+      type: 'token_usage',
+      id: 'usage-1',
+      turnId: 'turn-1',
+      ts: 123,
+      ...usage,
+      providerRequestTraceId: 'provider-trace-1',
+    };
+    const runtimeEvent = decodeRuntimeEvent(
+      JSON.parse(
+        JSON.stringify(
+          mapSessionEventToRuntimeEvent(sessionEvent, ctx, createSessionEventMapMemory()),
+        ),
+      ),
+    );
+
+    assert.deepEqual(runtimeEvent.actions?.tokenUsage, usage);
+    assert.equal(runtimeEvent.refs?.providerRequestTraceId, 'provider-trace-1');
+
+    const projected = projectRuntimeEventsToStoredMessages([runtimeEvent], {
+      runHeaders: [],
+    });
+    const projectedMessage = projected.messages[0];
+    assert.ok(projectedMessage);
+    const stored = decodeStoredMessageForRecovery(JSON.parse(JSON.stringify(projectedMessage)));
+    assert.deepEqual(stored, {
+      type: 'token_usage',
+      id: 'usage-1',
+      turnId: 'turn-1',
+      ts: 123,
+      ...usage,
+      providerRequestTraceId: 'provider-trace-1',
+    });
+    assert.deepEqual(projected.diagnostics, []);
+
+    const backfilled = backfillRuntimeEventsFromStoredMessages({
+      run: {
+        runId: 'run-1',
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        status: 'completed',
+        backendKind: 'ai-sdk',
+        llmConnectionSlug: 'anthropic',
+        modelId: 'model-1',
+        cwd: '/tmp',
+        permissionMode: 'ask',
+        createdAt: 100,
+        updatedAt: 200,
+      },
+      messages: [stored],
+      newId: () => 'backfilled-usage-1',
+      now: () => 999,
+    });
+
+    const backfilledEvent = backfilled.events[0];
+    assert.ok(backfilledEvent);
+    const replayed = decodeRuntimeEvent(JSON.parse(JSON.stringify(backfilledEvent)));
+    assert.deepEqual(replayed.actions?.tokenUsage, usage);
+    assert.equal(replayed.refs?.providerRequestTraceId, 'provider-trace-1');
   });
 });
 

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -150,9 +150,11 @@ function baseEvents(): RuntimeEvent[] {
           cacheRead: 10,
           costUsd: 0.002,
           systemPromptHash: 'sys-hash',
+          runtimeSteps: 3,
           contextRemaining: 9000,
         },
       },
+      refs: { providerRequestTraceId: 'provider-trace-1' },
     }),
     ev({
       id: 'evt-complete',
@@ -223,6 +225,9 @@ function equivalentLegacyMessages(): StoredMessage[] {
       cacheRead: 10,
       costUsd: 0.002,
       systemPromptHash: 'sys-hash',
+      runtimeSteps: 3,
+      contextRemaining: 9000,
+      providerRequestTraceId: 'provider-trace-1',
     },
     {
       type: 'turn_state',
@@ -320,7 +325,7 @@ describe('projectRuntimeEventsToStoredMessages', () => {
       parentTurnId: 'parent-turn',
       partialOutputRetained: true,
     });
-    expect(out.diagnostics.map((diag) => diag.code)).toEqual(['context_remaining_unsupported']);
+    expect(out.diagnostics).toEqual([]);
   });
 
   test('projects an AskUserQuestion round trip without a legacy row for the live request', () => {
@@ -668,10 +673,7 @@ describe('projectRuntimeEventsToStoredMessages', () => {
         reason: 'stale_tool_result_pruned_before_compact',
       },
     });
-    expect(out.diagnostics.map((diag) => diag.code)).toEqual([
-      'archived_tool_result_placeholder',
-      'context_remaining_unsupported',
-    ]);
+    expect(out.diagnostics.map((diag) => diag.code)).toEqual(['archived_tool_result_placeholder']);
   });
 
   test('archive status wrapper can project missing and corrupt rows without changing sync defaults', () => {
@@ -1211,6 +1213,33 @@ describe('compareRuntimeReadModelMessages', () => {
     ];
 
     expect(compareRuntimeReadModelMessages(projected, legacy).compatible).toBe(false);
+  });
+
+  test('rejects mismatched replay-critical token usage fields', () => {
+    const usage: Extract<StoredMessage, { type: 'token_usage' }> = {
+      type: 'token_usage',
+      id: 'usage-1',
+      turnId,
+      ts,
+      input: 100,
+      output: 25,
+      runtimeSteps: 3,
+      contextRemaining: 9000,
+      providerRequestTraceId: 'provider-trace-1',
+    };
+
+    expect(
+      compareRuntimeReadModelMessages([usage], [{ ...usage, runtimeSteps: 4 }]).compatible,
+    ).toBe(false);
+    expect(
+      compareRuntimeReadModelMessages([usage], [{ ...usage, contextRemaining: 8000 }]).compatible,
+    ).toBe(false);
+    expect(
+      compareRuntimeReadModelMessages(
+        [usage],
+        [{ ...usage, providerRequestTraceId: 'provider-trace-2' }],
+      ).compatible,
+    ).toBe(false);
   });
 
   test('rejects missing tool result and assistant text cases', () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -3866,7 +3866,7 @@ describe('SessionManager permission mode updates', () => {
     );
   });
 
-  test('sendMessage backfills an empty prior runtime ledger for model context', async () => {
+  test('sendMessage preserves token usage fields while resuming from an empty prior runtime ledger', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();
     const backends = new BackendRegistry();
@@ -3875,13 +3875,15 @@ describe('SessionManager permission mode updates', () => {
       backend = new TestBackend(ctx);
       return backend;
     });
+    const newId = nextId();
+    const now = nextNow(7_000);
     const manager = new SessionManager({
       store,
       runStore,
       runtimeEventStore: runStore,
       backends,
-      newId: nextId(),
-      now: nextNow(7_000),
+      newId,
+      now,
       runtimeSource: 'test',
     });
     const session = await manager.createSession(makeInput());
@@ -3896,10 +3898,21 @@ describe('SessionManager permission mode updates', () => {
         modelId: 'fake-model',
       },
       {
+        type: 'token_usage',
+        id: 'legacy-usage',
+        turnId: 'turn-1',
+        ts: 103,
+        input: 100,
+        output: 25,
+        runtimeSteps: 3,
+        contextRemaining: 9000,
+        providerRequestTraceId: 'provider-trace-1',
+      },
+      {
         type: 'turn_state',
         id: 'legacy-state',
         turnId: 'turn-1',
-        ts: 103,
+        ts: 104,
         status: 'completed',
         partialOutputRetained: true,
       },
@@ -3911,35 +3924,53 @@ describe('SessionManager permission mode updates', () => {
         turnId: 'turn-1',
         status: 'completed',
         createdAt: 100,
-        updatedAt: 103,
-        completedAt: 103,
+        updatedAt: 104,
+        completedAt: 104,
       }),
     );
 
+    const restarted = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId,
+      now,
+      runtimeSource: 'test',
+    });
     const sessionEvents = await collectSessionEvents(
-      manager.sendMessage(session.id, { turnId: 'turn-2', text: 'follow up' }),
+      restarted.sendMessage(session.id, { turnId: 'turn-2', text: 'follow up' }),
     );
 
     expect(sessionEvents.map((event) => event.type)).toEqual(['text_delta', 'complete']);
     expect(backend?.sendInputs[0]?.context.map((message) => message.type)).toEqual([
       'user',
       'assistant',
+      'token_usage',
       'turn_state',
     ]);
     expect(
       backend?.sendInputs[0]?.context.map((message) =>
         'text' in message ? message.text : message.type,
       ),
-    ).toEqual(['prior question', 'prior answer', 'turn_state']);
+    ).toEqual(['prior question', 'prior answer', 'token_usage', 'turn_state']);
     expect(backend?.sendInputs[0]?.runtimeContext?.map((event) => event.runId)).toEqual([
       'run-1',
       'run-1',
       'run-1',
+      'run-1',
     ]);
+    const resumedUsage = backend?.sendInputs[0]?.runtimeContext?.find(
+      (event) => event.actions?.tokenUsage,
+    );
+    expect(resumedUsage?.actions?.tokenUsage?.runtimeSteps).toBe(3);
+    expect(resumedUsage?.actions?.tokenUsage?.contextRemaining).toBe(9000);
+    expect(resumedUsage?.refs?.providerRequestTraceId).toBe('provider-trace-1');
     const repairedRuntimeEvents = await runStore.readRuntimeEvents(session.id, 'run-1');
     expect(repairedRuntimeEvents.map((event) => event.refs?.storedMessageId)).toEqual([
       'legacy-user',
       'legacy-assistant',
+      'legacy-usage',
       'legacy-state',
     ]);
     expect(repairedRuntimeEvents.at(-1)?.status).toBe('completed');

--- a/packages/runtime/src/runtime-event-backfill.ts
+++ b/packages/runtime/src/runtime-event-backfill.ts
@@ -248,7 +248,12 @@ export function backfillRuntimeEventsFromStoredMessages(
             stateDelta: recoveryState(now, message),
             tokenUsage: tokenUsageFromMessage(message),
           },
-          refs: { storedMessageId: message.id },
+          refs: {
+            storedMessageId: message.id,
+            ...(message.providerRequestTraceId !== undefined
+              ? { providerRequestTraceId: message.providerRequestTraceId }
+              : {}),
+          },
         });
         break;
 
@@ -417,9 +422,13 @@ function tokenUsageFromMessage(
     ...(message.reasoning !== undefined ? { reasoning: message.reasoning } : {}),
     ...(message.total !== undefined ? { total: message.total } : {}),
     ...(message.rawFinishReason !== undefined ? { rawFinishReason: message.rawFinishReason } : {}),
+    ...(message.runtimeSteps !== undefined ? { runtimeSteps: message.runtimeSteps } : {}),
     ...(message.cacheRead !== undefined ? { cacheRead: message.cacheRead } : {}),
     ...(message.cacheCreation !== undefined ? { cacheCreation: message.cacheCreation } : {}),
     ...(message.costUsd !== undefined ? { costUsd: message.costUsd } : {}),
+    ...(message.contextRemaining !== undefined
+      ? { contextRemaining: message.contextRemaining }
+      : {}),
     ...(message.systemPromptHash !== undefined
       ? { systemPromptHash: message.systemPromptHash }
       : {}),

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -23,7 +23,6 @@ export type RuntimeEventReadModelDiagnosticCode =
   | 'incomplete_event'
   | 'archived_tool_result_placeholder'
   | 'generated_id'
-  | 'context_remaining_unsupported'
   | 'tool_use_id_mismatch'
   | 'missing_legacy_message'
   | 'unexpected_projected_message';
@@ -198,15 +197,6 @@ export function projectRuntimeEventsToStoredMessages(
 
     if (isTerminalRuntimeEvent(event)) {
       projected = projectTerminalTurnState(event, state, messages) || projected;
-    }
-
-    if (event.actions?.tokenUsage?.contextRemaining !== undefined) {
-      diagnostic(
-        state,
-        event,
-        'context_remaining_unsupported',
-        'token usage contextRemaining is diagnostic-only in StoredMessage',
-      );
     }
 
     if (!projected) {
@@ -795,6 +785,7 @@ function projectTokenUsage(
     ...(usage.cacheCreation !== undefined ? { cacheCreation: usage.cacheCreation } : {}),
     ...(usage.costUsd !== undefined ? { costUsd: usage.costUsd } : {}),
     ...(usage.systemPromptHash !== undefined ? { systemPromptHash: usage.systemPromptHash } : {}),
+    ...(usage.contextRemaining !== undefined ? { contextRemaining: usage.contextRemaining } : {}),
     ...(usage.prefixHash !== undefined ? { prefixHash: usage.prefixHash } : {}),
     ...(usage.prefixChangeReason !== undefined
       ? { prefixChangeReason: usage.prefixChangeReason }
@@ -805,6 +796,9 @@ function projectTokenUsage(
       : {}),
     ...(usage.promptSegments !== undefined ? { promptSegments: usage.promptSegments } : {}),
     ...(usage.contextBudget !== undefined ? { contextBudget: usage.contextBudget } : {}),
+    ...(event.refs?.providerRequestTraceId !== undefined
+      ? { providerRequestTraceId: event.refs.providerRequestTraceId }
+      : {}),
   });
   return true;
 }
@@ -1205,16 +1199,19 @@ function semanticMessage(message: StoredMessage): unknown {
         reasoning: message.reasoning,
         total: message.total,
         rawFinishReason: message.rawFinishReason,
+        runtimeSteps: message.runtimeSteps,
         cacheRead: message.cacheRead,
         cacheCreation: message.cacheCreation,
         costUsd: message.costUsd,
         systemPromptHash: message.systemPromptHash,
+        contextRemaining: message.contextRemaining,
         prefixHash: message.prefixHash,
         prefixChangeReason: message.prefixChangeReason,
         requestShapeHash: message.requestShapeHash,
         requestShapeChangeReason: message.requestShapeChangeReason,
         promptSegments: message.promptSegments,
         contextBudget: message.contextBudget,
+        providerRequestTraceId: message.providerRequestTraceId,
       };
     case 'turn_state':
       return {


### PR DESCRIPTION
## Summary

Live `TokenUsageEvent`s include `contextRemaining`, which the CLI uses to display ctx usage. However, the field was omitted from `TokenUsageMessage` and discarded by the RuntimeEvent read model. As a result, ctx information disappeared after switching sessions, restarting, or resuming.

This PR preserves `contextRemaining` across the full SessionEvent → RuntimeEvent → StoredMessage → replay path. It also fixes two omissions at the same boundary: `runtimeSteps` during backfill and `providerRequestTraceId` during projection and backfill.

Legacy data without these fields remains `undefined`; no migration or inferred values are introduced.

## Verification

- Core and runtime builds and test suites passed.
- CLI build and full test suite passed.
- Added full-field round-trip coverage.
- Added session resume and CLI session-switch regression coverage.
- Biome and `git diff --check` passed.
- Not run: full monorepo test suite.