### PR TITLE
fix(storage): tolerate malformed legacy session headers during import

### DIFF
--- a/packages/storage/src/__tests__/session-metadata-transfer.test.ts
+++ b/packages/storage/src/__tests__/session-metadata-transfer.test.ts
@@ -306,11 +306,11 @@ describe('malformed legacy headers at the public SessionStore boundary', () => {
     await legacy.close?.();
     const corruptPath = join(root, 'sessions', corrupt.id, 'session.jsonl');
     const lines = (await readFile(corruptPath, 'utf8')).split('\n');
-    const validHeaderLine = (await readFile(join(root, 'sessions', valid.id, 'session.jsonl'), 'utf8')).split('\n')[0]!;
+    const validHeaderLine = (
+      await readFile(join(root, 'sessions', valid.id, 'session.jsonl'), 'utf8')
+    ).split('\n')[0]!;
     const newContent =
-      typeof corruptContent === 'function'
-        ? corruptContent(corrupt.id, lines[0]!)
-        : corruptContent;
+      typeof corruptContent === 'function' ? corruptContent(corrupt.id, lines[0]!) : corruptContent;
     await writeFile(corruptPath, newContent, 'utf8');
     return { root, validId: valid.id, corruptId: corrupt.id, corruptPath, validHeaderLine };
   }
@@ -318,7 +318,11 @@ describe('malformed legacy headers at the public SessionStore boundary', () => {
   // Helper: repair a corrupt session file by writing a valid header line
   // derived from the valid session's header, with the id swapped to the
   // corrupt session's id.
-  async function repairSession(path: string, validHeaderLine: string, targetId: string): Promise<void> {
+  async function repairSession(
+    path: string,
+    validHeaderLine: string,
+    targetId: string,
+  ): Promise<void> {
     const header = JSON.parse(validHeaderLine) as Record<string, unknown>;
     header.id = targetId;
     await writeFile(path, `${JSON.stringify(header)}\n`, 'utf8');
@@ -478,10 +482,7 @@ describe('malformed legacy headers at the public SessionStore boundary', () => {
       await mkdir(unreadablePath);
 
       const store = createSessionStore(root);
-      await assert.rejects(
-        store.list(),
-        (error: NodeJS.ErrnoException) => error.code === 'EISDIR',
-      );
+      await assert.rejects(store.list(), (error: NodeJS.ErrnoException) => error.code === 'EISDIR');
       // No metadata or tombstone was written for either session.
       const meta = openMetadata(root);
       assert.equal(await meta.has(valid.id), false);

--- a/packages/storage/src/__tests__/session-metadata-transfer.test.ts
+++ b/packages/storage/src/__tests__/session-metadata-transfer.test.ts
@@ -5,13 +5,17 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { CreateSessionInput } from '@maka/core';
 import { importLegacySessionMetadataTree } from '../session-metadata-transfer.js';
-import { createLegacyFileSessionStore as createSessionStore } from '../session-store.js';
+import {
+  createLegacyFileSessionStore as createLegacyStore,
+  createSessionStore,
+  SQLITE_SESSION_METADATA_DATABASE_NAME,
+} from '../session-store.js';
 import { createSqliteSessionMetadataStore } from '../sqlite-session-metadata-store.js';
 
 describe('legacy session metadata transfer', () => {
   test('imports every legacy line-1 header without reading transcript payloads as metadata', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-'));
-    const legacy = createSessionStore(root);
+    const legacy = createLegacyStore(root);
     const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
     try {
       const first = await legacy.create(makeInput({ name: 'First', labels: ['alpha'] }));
@@ -130,7 +134,7 @@ describe('legacy session metadata transfer', () => {
 
   test('skips a malformed header without tombstoning it while importing valid sessions', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-invalid-'));
-    const legacy = createSessionStore(root);
+    const legacy = createLegacyStore(root);
     const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
     try {
       const valid = await legacy.create(makeInput({ name: 'Valid' }));
@@ -178,7 +182,7 @@ describe('legacy session metadata transfer', () => {
 
   test('does not tombstone a session when a non-ENOENT filesystem error occurs', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-fs-error-'));
-    const legacy = createSessionStore(root);
+    const legacy = createLegacyStore(root);
     const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
     try {
       const valid = await legacy.create(makeInput({ name: 'Valid' }));
@@ -191,9 +195,11 @@ describe('legacy session metadata transfer', () => {
 
       await assert.rejects(
         importLegacySessionMetadataTree({ workspaceRoot: root, destination: sqlite }),
+        (error: NodeJS.ErrnoException) => error.code === 'EISDIR',
       );
       // The session must NOT be tombstoned — a filesystem error is not corrupt data.
       assert.equal(await sqlite.isTombstoned(unreadable.id), false);
+      assert.equal(await sqlite.has(unreadable.id), false);
       // The valid session was not imported because the scan aborted.
       assert.equal(await sqlite.has(valid.id), false);
     } finally {
@@ -204,7 +210,7 @@ describe('legacy session metadata transfer', () => {
 
   test('skips a malformed header without tombstoning when a later scan step fails', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-rollback-'));
-    const legacy = createSessionStore(root);
+    const legacy = createLegacyStore(root);
     const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
     try {
       const valid = await legacy.create(makeInput({ name: 'Valid' }));
@@ -253,7 +259,7 @@ describe('legacy session metadata transfer', () => {
 
   test('keeps canonical metadata readable when its optional transcript is missing', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-missing-transcript-'));
-    const legacy = createSessionStore(root);
+    const legacy = createLegacyStore(root);
     const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
     try {
       const created = await legacy.create(makeInput({ name: 'Canonical metadata' }));
@@ -276,6 +282,214 @@ describe('legacy session metadata transfer', () => {
       assert.equal((await sqlite.read(created.id)).header.name, 'Canonical metadata');
     } finally {
       sqlite.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe('malformed legacy headers at the public SessionStore boundary', () => {
+  // Helper: create a workspace root with one valid legacy session and one
+  // corrupt legacy session whose session.jsonl is replaced by `corruptContent`.
+  async function setupWorkspaceWithCorruptSession(
+    corruptContent: string | ((sessionId: string, headerLine: string) => string),
+  ): Promise<{
+    root: string;
+    validId: string;
+    corruptId: string;
+    corruptPath: string;
+    validHeaderLine: string;
+  }> {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-boundary-'));
+    const legacy = createLegacyStore(root);
+    const valid = await legacy.create(makeInput({ name: 'Valid' }));
+    const corrupt = await legacy.create(makeInput({ name: 'Corrupt' }));
+    await legacy.close?.();
+    const corruptPath = join(root, 'sessions', corrupt.id, 'session.jsonl');
+    const lines = (await readFile(corruptPath, 'utf8')).split('\n');
+    const validHeaderLine = (await readFile(join(root, 'sessions', valid.id, 'session.jsonl'), 'utf8')).split('\n')[0]!;
+    const newContent =
+      typeof corruptContent === 'function'
+        ? corruptContent(corrupt.id, lines[0]!)
+        : corruptContent;
+    await writeFile(corruptPath, newContent, 'utf8');
+    return { root, validId: valid.id, corruptId: corrupt.id, corruptPath, validHeaderLine };
+  }
+
+  // Helper: repair a corrupt session file by writing a valid header line
+  // derived from the valid session's header, with the id swapped to the
+  // corrupt session's id.
+  async function repairSession(path: string, validHeaderLine: string, targetId: string): Promise<void> {
+    const header = JSON.parse(validHeaderLine) as Record<string, unknown>;
+    header.id = targetId;
+    await writeFile(path, `${JSON.stringify(header)}\n`, 'utf8');
+  }
+
+  // Helper: open the metadata store used by createSessionStore to check
+  // tombstone and has state.
+  function openMetadata(root: string) {
+    return createSqliteSessionMetadataStore(join(root, SQLITE_SESSION_METADATA_DATABASE_NAME));
+  }
+
+  test('empty session.jsonl: store.list() resolves, valid session visible, corrupt absent, no tombstone', async () => {
+    const { root, validId, corruptId, corruptPath, validHeaderLine } =
+      await setupWorkspaceWithCorruptSession('');
+    try {
+      const store = createSessionStore(root);
+      const sessions = await store.list();
+      assert.equal(sessions.length, 1, 'only the valid session should be listed');
+      assert.equal(sessions[0]!.id, validId);
+      // The corrupt session is absent.
+      await assert.rejects(store.readHeader(corruptId), /Session metadata not found/);
+      // No tombstone was written.
+      const meta = openMetadata(root);
+      assert.equal(await meta.isTombstoned(corruptId), false);
+      assert.equal(await meta.has(corruptId), false);
+      meta.close();
+      await store.close?.();
+
+      // Repair: write a valid header, reopen, and verify the session is imported.
+      await repairSession(corruptPath, validHeaderLine, corruptId);
+      const store2 = createSessionStore(root);
+      const sessions2 = await store2.list();
+      assert.equal(sessions2.length, 2, 'both sessions should be listed after repair');
+      assert.equal(
+        sessions2.some((s) => s.id === corruptId),
+        true,
+        'repaired session should appear in list',
+      );
+      await store2.close?.();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('truncated JSON without a newline: catalog remains usable, session skipped without tombstone', async () => {
+    const { root, validId, corruptId, corruptPath, validHeaderLine } =
+      await setupWorkspaceWithCorruptSession('{ "id": "truncated"');
+    try {
+      const store = createSessionStore(root);
+      const sessions = await store.list();
+      assert.equal(sessions.length, 1);
+      assert.equal(sessions[0]!.id, validId);
+      await assert.rejects(store.readHeader(corruptId), /Session metadata not found/);
+      const meta = openMetadata(root);
+      assert.equal(await meta.isTombstoned(corruptId), false);
+      assert.equal(await meta.has(corruptId), false);
+      meta.close();
+      await store.close?.();
+
+      // Repair and verify import.
+      await repairSession(corruptPath, validHeaderLine, corruptId);
+      const store2 = createSessionStore(root);
+      const sessions2 = await store2.list();
+      assert.equal(sessions2.length, 2);
+      assert.equal(
+        sessions2.some((s) => s.id === corruptId),
+        true,
+      );
+      await store2.close?.();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('first record over 1 MiB limit: catalog usable, session skipped without tombstone', async () => {
+    // Build a >1 MiB first line that has no newline.
+    const oversized = '{ "' + 'x'.repeat(1024 * 1024 + 100) + '": 1 }';
+    const { root, validId, corruptId, corruptPath, validHeaderLine } =
+      await setupWorkspaceWithCorruptSession(oversized);
+    try {
+      const store = createSessionStore(root);
+      const sessions = await store.list();
+      assert.equal(sessions.length, 1);
+      assert.equal(sessions[0]!.id, validId);
+      await assert.rejects(store.readHeader(corruptId), /Session metadata not found/);
+      const meta = openMetadata(root);
+      assert.equal(await meta.isTombstoned(corruptId), false);
+      assert.equal(await meta.has(corruptId), false);
+      meta.close();
+      await store.close?.();
+
+      // Repair and verify import.
+      await repairSession(corruptPath, validHeaderLine, corruptId);
+      const store2 = createSessionStore(root);
+      const sessions2 = await store2.list();
+      assert.equal(sessions2.length, 2);
+      assert.equal(
+        sessions2.some((s) => s.id === corruptId),
+        true,
+      );
+      await store2.close?.();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('turn_state first record: valid sessions remain available through createSessionStore()', async () => {
+    // Simulate the original bug: a turn_state record where the header should be.
+    const turnStateFirst = (_sessionId: string, _original: string) =>
+      JSON.stringify({
+        type: 'turn_state',
+        id: 'state-1',
+        turnId: 'turn-1',
+        ts: 1,
+        status: 'running',
+        partialOutputRetained: false,
+      }) + '\n';
+    const { root, validId, corruptId, corruptPath, validHeaderLine } =
+      await setupWorkspaceWithCorruptSession(turnStateFirst);
+    try {
+      const store = createSessionStore(root);
+      const sessions = await store.list();
+      assert.equal(sessions.length, 1);
+      assert.equal(sessions[0]!.id, validId);
+      await assert.rejects(store.readHeader(corruptId), /Session metadata not found/);
+      const meta = openMetadata(root);
+      assert.equal(await meta.isTombstoned(corruptId), false);
+      assert.equal(await meta.has(corruptId), false);
+      meta.close();
+      await store.close?.();
+
+      // Repair and verify import.
+      await repairSession(corruptPath, validHeaderLine, corruptId);
+      const store2 = createSessionStore(root);
+      const sessions2 = await store2.list();
+      assert.equal(sessions2.length, 2);
+      assert.equal(
+        sessions2.some((s) => s.id === corruptId),
+        true,
+      );
+      await store2.close?.();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('EISDIR filesystem failure: store.list() rejects with EISDIR, no metadata or tombstone written', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-boundary-eisdir-'));
+    const legacy = createLegacyStore(root);
+    try {
+      const valid = await legacy.create(makeInput({ name: 'Valid' }));
+      const unreadable = await legacy.create(makeInput({ name: 'Unreadable' }));
+      await legacy.close?.();
+      const unreadablePath = join(root, 'sessions', unreadable.id, 'session.jsonl');
+      // Replace the session file with a directory to provoke EISDIR.
+      await rm(unreadablePath);
+      await mkdir(unreadablePath);
+
+      const store = createSessionStore(root);
+      await assert.rejects(
+        store.list(),
+        (error: NodeJS.ErrnoException) => error.code === 'EISDIR',
+      );
+      // No metadata or tombstone was written for either session.
+      const meta = openMetadata(root);
+      assert.equal(await meta.has(valid.id), false);
+      assert.equal(await meta.has(unreadable.id), false);
+      assert.equal(await meta.isTombstoned(unreadable.id), false);
+      meta.close();
+      await store.close?.();
+    } finally {
       await rm(root, { recursive: true, force: true });
     }
   });

--- a/packages/storage/src/__tests__/session-metadata-transfer.test.ts
+++ b/packages/storage/src/__tests__/session-metadata-transfer.test.ts
@@ -128,7 +128,7 @@ describe('legacy session metadata transfer', () => {
     }
   });
 
-  test('rejects one malformed header before importing any session', async () => {
+  test('skips a malformed header and tombstones it while importing valid sessions', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-invalid-'));
     const legacy = createSessionStore(root);
     const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
@@ -140,12 +140,24 @@ describe('legacy session metadata transfer', () => {
       lines[0] = JSON.stringify({ ...JSON.parse(lines[0]!), labels: 'not-an-array' });
       await writeFile(invalidPath, lines.join('\n'), 'utf8');
 
-      await assert.rejects(
-        () => importLegacySessionMetadataTree({ workspaceRoot: root, destination: sqlite }),
-        /Invalid legacy session header/,
-      );
-      await assert.rejects(() => sqlite.read(valid.id), /not found/);
-      assert.deepEqual(await sqlite.list(), []);
+      const report = await importLegacySessionMetadataTree({
+        workspaceRoot: root,
+        destination: sqlite,
+      });
+      assert.equal(report.filesScanned, 2);
+      assert.equal(report.headersImported, 1);
+      // The valid session was imported.
+      assert.equal((await sqlite.read(valid.id)).header.name, 'Valid');
+      // The malformed session was tombstoned, not imported.
+      assert.equal(await sqlite.has(invalid.id), false);
+      assert.equal(await sqlite.isTombstoned(invalid.id), true);
+      // Re-importing should not retry the tombstoned session.
+      const repeated = await importLegacySessionMetadataTree({
+        workspaceRoot: root,
+        destination: sqlite,
+      });
+      assert.equal(repeated.filesScanned, 2);
+      assert.equal(repeated.headersImported, 0);
     } finally {
       sqlite.close();
       await rm(root, { recursive: true, force: true });

--- a/packages/storage/src/__tests__/session-metadata-transfer.test.ts
+++ b/packages/storage/src/__tests__/session-metadata-transfer.test.ts
@@ -180,83 +180,6 @@ describe('legacy session metadata transfer', () => {
     }
   });
 
-  test('does not tombstone a session when a non-ENOENT filesystem error occurs', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-fs-error-'));
-    const legacy = createLegacyStore(root);
-    const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
-    try {
-      const valid = await legacy.create(makeInput({ name: 'Valid' }));
-      const unreadable = await legacy.create(makeInput({ name: 'Unreadable' }));
-      const unreadablePath = join(root, 'sessions', unreadable.id, 'session.jsonl');
-      // Replace the session file with a directory to provoke a non-ENOENT
-      // filesystem error (EISDIR) when readFirstJsonlRecord tries to open it.
-      await rm(unreadablePath);
-      await mkdir(unreadablePath);
-
-      await assert.rejects(
-        importLegacySessionMetadataTree({ workspaceRoot: root, destination: sqlite }),
-        (error: NodeJS.ErrnoException) => error.code === 'EISDIR',
-      );
-      // The session must NOT be tombstoned — a filesystem error is not corrupt data.
-      assert.equal(await sqlite.isTombstoned(unreadable.id), false);
-      assert.equal(await sqlite.has(unreadable.id), false);
-      // The valid session was not imported because the scan aborted.
-      assert.equal(await sqlite.has(valid.id), false);
-    } finally {
-      sqlite.close();
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  test('skips a malformed header without tombstoning when a later scan step fails', async () => {
-    const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-rollback-'));
-    const legacy = createLegacyStore(root);
-    const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
-    try {
-      const valid = await legacy.create(makeInput({ name: 'Valid' }));
-      const invalid = await legacy.create(makeInput({ name: 'Invalid' }));
-      // Corrupt the invalid session's header.
-      const invalidPath = join(root, 'sessions', invalid.id, 'session.jsonl');
-      const lines = (await readFile(invalidPath, 'utf8')).split('\n');
-      lines[0] = JSON.stringify({ ...JSON.parse(lines[0]!), labels: 'not-an-array' });
-      await writeFile(invalidPath, lines.join('\n'), 'utf8');
-      // Create an orphan transcript-marker directory with no SQLite metadata.
-      // The scan will skip the malformed header, but the transcript marker
-      // check fails before the import, so no writes should occur.
-      const orphanId = 'orphan-transcript-session';
-      const orphanDir = join(root, 'sessions', orphanId);
-      await mkdir(orphanDir, { recursive: true });
-      const orphanPath = join(orphanDir, 'session.jsonl');
-      await writeFile(
-        orphanPath,
-        `${JSON.stringify({ type: 'session_transcript', sessionId: orphanId, schemaVersion: 1 })}\n`,
-        'utf8',
-      );
-
-      await assert.rejects(
-        importLegacySessionMetadataTree({ workspaceRoot: root, destination: sqlite }),
-        /transcript marker has no SQLite metadata/,
-      );
-      // The malformed session must NOT be tombstoned (skipped, not quarantined).
-      assert.equal(await sqlite.isTombstoned(invalid.id), false);
-      // The valid session was not imported either (scan aborted).
-      assert.equal(await sqlite.has(valid.id), false);
-      // Re-running with the orphan removed should import the valid session
-      // and skip (not tombstone) the malformed one.
-      await rm(orphanDir, { recursive: true, force: true });
-      const report = await importLegacySessionMetadataTree({
-        workspaceRoot: root,
-        destination: sqlite,
-      });
-      assert.equal(report.headersImported, 1);
-      assert.equal(await sqlite.read(valid.id).then((r) => r.header.name), 'Valid');
-      assert.equal(await sqlite.isTombstoned(invalid.id), false);
-    } finally {
-      sqlite.close();
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
   test('keeps canonical metadata readable when its optional transcript is missing', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-missing-transcript-'));
     const legacy = createLegacyStore(root);
@@ -288,16 +211,14 @@ describe('legacy session metadata transfer', () => {
 });
 
 describe('malformed legacy headers at the public SessionStore boundary', () => {
-  // Helper: create a workspace root with one valid legacy session and one
-  // corrupt legacy session whose session.jsonl is replaced by `corruptContent`.
   async function setupWorkspaceWithCorruptSession(
-    corruptContent: string | ((sessionId: string, headerLine: string) => string),
+    corruptContent: (originalHeaderLine: string) => string,
   ): Promise<{
     root: string;
     validId: string;
     corruptId: string;
     corruptPath: string;
-    validHeaderLine: string;
+    originalHeaderLine: string;
   }> {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-boundary-'));
     const legacy = createLegacyStore(root);
@@ -305,169 +226,153 @@ describe('malformed legacy headers at the public SessionStore boundary', () => {
     const corrupt = await legacy.create(makeInput({ name: 'Corrupt' }));
     await legacy.close?.();
     const corruptPath = join(root, 'sessions', corrupt.id, 'session.jsonl');
-    const lines = (await readFile(corruptPath, 'utf8')).split('\n');
-    const validHeaderLine = (
-      await readFile(join(root, 'sessions', valid.id, 'session.jsonl'), 'utf8')
-    ).split('\n')[0]!;
-    const newContent =
-      typeof corruptContent === 'function' ? corruptContent(corrupt.id, lines[0]!) : corruptContent;
-    await writeFile(corruptPath, newContent, 'utf8');
-    return { root, validId: valid.id, corruptId: corrupt.id, corruptPath, validHeaderLine };
+    const originalHeaderLine = (await readFile(corruptPath, 'utf8')).split('\n')[0]!;
+    await writeFile(corruptPath, corruptContent(originalHeaderLine), 'utf8');
+    return {
+      root,
+      validId: valid.id,
+      corruptId: corrupt.id,
+      corruptPath,
+      originalHeaderLine,
+    };
   }
 
-  // Helper: repair a corrupt session file by writing a valid header line
-  // derived from the valid session's header, with the id swapped to the
-  // corrupt session's id.
-  async function repairSession(
-    path: string,
-    validHeaderLine: string,
-    targetId: string,
-  ): Promise<void> {
-    const header = JSON.parse(validHeaderLine) as Record<string, unknown>;
-    header.id = targetId;
-    await writeFile(path, `${JSON.stringify(header)}\n`, 'utf8');
-  }
-
-  // Helper: open the metadata store used by createSessionStore to check
-  // tombstone and has state.
   function openMetadata(root: string) {
     return createSqliteSessionMetadataStore(join(root, SQLITE_SESSION_METADATA_DATABASE_NAME));
   }
 
-  test('empty session.jsonl: store.list() resolves, valid session visible, corrupt absent, no tombstone', async () => {
-    const { root, validId, corruptId, corruptPath, validHeaderLine } =
-      await setupWorkspaceWithCorruptSession('');
+  async function assertRepairableMalformedHeader(
+    corruptContent: (originalHeaderLine: string) => string,
+  ): Promise<void> {
+    const { root, validId, corruptId, corruptPath, originalHeaderLine } =
+      await setupWorkspaceWithCorruptSession(corruptContent);
     try {
       const store = createSessionStore(root);
-      const sessions = await store.list();
-      assert.equal(sessions.length, 1, 'only the valid session should be listed');
-      assert.equal(sessions[0]!.id, validId);
-      // The corrupt session is absent.
-      await assert.rejects(store.readHeader(corruptId), /Session metadata not found/);
-      // No tombstone was written.
-      const meta = openMetadata(root);
-      assert.equal(await meta.isTombstoned(corruptId), false);
-      assert.equal(await meta.has(corruptId), false);
-      meta.close();
-      await store.close?.();
+      try {
+        assert.deepEqual(
+          (await store.list()).map((session) => session.id),
+          [validId],
+        );
+        await assert.rejects(store.readHeader(corruptId), /Session metadata not found/);
+      } finally {
+        await store.close?.();
+      }
 
-      // Repair: write a valid header, reopen, and verify the session is imported.
-      await repairSession(corruptPath, validHeaderLine, corruptId);
-      const store2 = createSessionStore(root);
-      const sessions2 = await store2.list();
-      assert.equal(sessions2.length, 2, 'both sessions should be listed after repair');
-      assert.equal(
-        sessions2.some((s) => s.id === corruptId),
-        true,
-        'repaired session should appear in list',
-      );
-      await store2.close?.();
+      const meta = openMetadata(root);
+      try {
+        assert.equal(await meta.has(corruptId), false);
+        assert.equal(await meta.isTombstoned(corruptId), false);
+      } finally {
+        meta.close();
+      }
+
+      await writeFile(corruptPath, `${originalHeaderLine}\n`, 'utf8');
+      const reopened = createSessionStore(root);
+      try {
+        const repaired = await reopened.list();
+        assert.equal(repaired.length, 2);
+        assert.equal(
+          repaired.some((session) => session.id === corruptId && session.name === 'Corrupt'),
+          true,
+        );
+      } finally {
+        await reopened.close?.();
+      }
     } finally {
       await rm(root, { recursive: true, force: true });
     }
-  });
+  }
 
-  test('truncated JSON without a newline: catalog remains usable, session skipped without tombstone', async () => {
-    const { root, validId, corruptId, corruptPath, validHeaderLine } =
-      await setupWorkspaceWithCorruptSession('{ "id": "truncated"');
+  const repairableMalformedHeaders = [
+    {
+      name: 'empty session.jsonl',
+      content: () => '',
+    },
+    {
+      name: 'truncated JSON without a newline',
+      content: () => '{ "id": "truncated"',
+    },
+    {
+      name: 'complete valid header over 1 MiB',
+      content: (originalHeaderLine: string) => {
+        const header = JSON.parse(originalHeaderLine) as Record<string, unknown>;
+        header.name = 'x'.repeat(1024 * 1024);
+        return `${JSON.stringify(header)}\n`;
+      },
+    },
+    {
+      name: 'turn_state first record',
+      content: () =>
+        `${JSON.stringify({
+          type: 'turn_state',
+          id: 'state-1',
+          turnId: 'turn-1',
+          ts: 1,
+          status: 'running',
+          partialOutputRetained: false,
+        })}\n`,
+    },
+  ];
+
+  for (const { name, content } of repairableMalformedHeaders) {
+    test(`${name}: skips only the corrupt session and imports it after repair`, () =>
+      assertRepairableMalformedHeader(content));
+  }
+
+  async function assertInvalidCurrentTranscriptMarker(marker: {
+    sessionId: string;
+    schemaVersion: number;
+  }): Promise<void> {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-boundary-invalid-marker-'));
+    const legacy = createLegacyStore(root);
     try {
-      const store = createSessionStore(root);
-      const sessions = await store.list();
-      assert.equal(sessions.length, 1);
-      assert.equal(sessions[0]!.id, validId);
-      await assert.rejects(store.readHeader(corruptId), /Session metadata not found/);
-      const meta = openMetadata(root);
-      assert.equal(await meta.isTombstoned(corruptId), false);
-      assert.equal(await meta.has(corruptId), false);
-      meta.close();
-      await store.close?.();
-
-      // Repair and verify import.
-      await repairSession(corruptPath, validHeaderLine, corruptId);
-      const store2 = createSessionStore(root);
-      const sessions2 = await store2.list();
-      assert.equal(sessions2.length, 2);
-      assert.equal(
-        sessions2.some((s) => s.id === corruptId),
-        true,
+      const valid = await legacy.create(makeInput({ name: 'Valid' }));
+      await legacy.close?.();
+      const markerSessionId = 'invalid-marker-session';
+      const markerDir = join(root, 'sessions', markerSessionId);
+      await mkdir(markerDir, { recursive: true });
+      await writeFile(
+        join(markerDir, 'session.jsonl'),
+        `${JSON.stringify({
+          type: 'session_transcript',
+          ...marker,
+        })}\n`,
+        'utf8',
       );
-      await store2.close?.();
+
+      const store = createSessionStore(root);
+      try {
+        await assert.rejects(store.list(), /invalid transcript marker/);
+      } finally {
+        await store.close?.();
+      }
+
+      const meta = openMetadata(root);
+      try {
+        assert.equal(await meta.has(valid.id), false);
+        assert.equal(await meta.has(markerSessionId), false);
+        assert.equal(await meta.isTombstoned(markerSessionId), false);
+      } finally {
+        meta.close();
+      }
     } finally {
       await rm(root, { recursive: true, force: true });
     }
-  });
+  }
 
-  test('first record over 1 MiB limit: catalog usable, session skipped without tombstone', async () => {
-    // Build a >1 MiB first line that has no newline.
-    const oversized = '{ "' + 'x'.repeat(1024 * 1024 + 100) + '": 1 }';
-    const { root, validId, corruptId, corruptPath, validHeaderLine } =
-      await setupWorkspaceWithCorruptSession(oversized);
-    try {
-      const store = createSessionStore(root);
-      const sessions = await store.list();
-      assert.equal(sessions.length, 1);
-      assert.equal(sessions[0]!.id, validId);
-      await assert.rejects(store.readHeader(corruptId), /Session metadata not found/);
-      const meta = openMetadata(root);
-      assert.equal(await meta.isTombstoned(corruptId), false);
-      assert.equal(await meta.has(corruptId), false);
-      meta.close();
-      await store.close?.();
-
-      // Repair and verify import.
-      await repairSession(corruptPath, validHeaderLine, corruptId);
-      const store2 = createSessionStore(root);
-      const sessions2 = await store2.list();
-      assert.equal(sessions2.length, 2);
-      assert.equal(
-        sessions2.some((s) => s.id === corruptId),
-        true,
-      );
-      await store2.close?.();
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
-
-  test('turn_state first record: valid sessions remain available through createSessionStore()', async () => {
-    // Simulate the original bug: a turn_state record where the header should be.
-    const turnStateFirst = (_sessionId: string, _original: string) =>
-      JSON.stringify({
-        type: 'turn_state',
-        id: 'state-1',
-        turnId: 'turn-1',
-        ts: 1,
-        status: 'running',
-        partialOutputRetained: false,
-      }) + '\n';
-    const { root, validId, corruptId, corruptPath, validHeaderLine } =
-      await setupWorkspaceWithCorruptSession(turnStateFirst);
-    try {
-      const store = createSessionStore(root);
-      const sessions = await store.list();
-      assert.equal(sessions.length, 1);
-      assert.equal(sessions[0]!.id, validId);
-      await assert.rejects(store.readHeader(corruptId), /Session metadata not found/);
-      const meta = openMetadata(root);
-      assert.equal(await meta.isTombstoned(corruptId), false);
-      assert.equal(await meta.has(corruptId), false);
-      meta.close();
-      await store.close?.();
-
-      // Repair and verify import.
-      await repairSession(corruptPath, validHeaderLine, corruptId);
-      const store2 = createSessionStore(root);
-      const sessions2 = await store2.list();
-      assert.equal(sessions2.length, 2);
-      assert.equal(
-        sessions2.some((s) => s.id === corruptId),
-        true,
-      );
-      await store2.close?.();
-    } finally {
-      await rm(root, { recursive: true, force: true });
-    }
-  });
+  for (const { name, marker } of [
+    {
+      name: 'wrong session id',
+      marker: { sessionId: 'wrong-session-id', schemaVersion: 1 },
+    },
+    {
+      name: 'unsupported schema version',
+      marker: { sessionId: 'invalid-marker-session', schemaVersion: 2 },
+    },
+  ]) {
+    test(`current transcript marker with ${name} rejects without partial import`, () =>
+      assertInvalidCurrentTranscriptMarker(marker));
+  }
 
   test('EISDIR filesystem failure: store.list() rejects with EISDIR, no metadata or tombstone written', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-boundary-eisdir-'));
@@ -482,14 +387,23 @@ describe('malformed legacy headers at the public SessionStore boundary', () => {
       await mkdir(unreadablePath);
 
       const store = createSessionStore(root);
-      await assert.rejects(store.list(), (error: NodeJS.ErrnoException) => error.code === 'EISDIR');
-      // No metadata or tombstone was written for either session.
+      try {
+        await assert.rejects(
+          store.list(),
+          (error: NodeJS.ErrnoException) => error.code === 'EISDIR',
+        );
+      } finally {
+        await store.close?.();
+      }
+
       const meta = openMetadata(root);
-      assert.equal(await meta.has(valid.id), false);
-      assert.equal(await meta.has(unreadable.id), false);
-      assert.equal(await meta.isTombstoned(unreadable.id), false);
-      meta.close();
-      await store.close?.();
+      try {
+        assert.equal(await meta.has(valid.id), false);
+        assert.equal(await meta.has(unreadable.id), false);
+        assert.equal(await meta.isTombstoned(unreadable.id), false);
+      } finally {
+        meta.close();
+      }
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/storage/src/__tests__/session-metadata-transfer.test.ts
+++ b/packages/storage/src/__tests__/session-metadata-transfer.test.ts
@@ -164,6 +164,81 @@ describe('legacy session metadata transfer', () => {
     }
   });
 
+  test('does not tombstone a session when a non-ENOENT filesystem error occurs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-fs-error-'));
+    const legacy = createSessionStore(root);
+    const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
+    try {
+      const valid = await legacy.create(makeInput({ name: 'Valid' }));
+      const unreadable = await legacy.create(makeInput({ name: 'Unreadable' }));
+      const unreadablePath = join(root, 'sessions', unreadable.id, 'session.jsonl');
+      // Replace the session file with a directory to provoke a non-ENOENT
+      // filesystem error (EISDIR) when readFirstJsonlRecord tries to open it.
+      await rm(unreadablePath);
+      await mkdir(unreadablePath);
+
+      await assert.rejects(
+        importLegacySessionMetadataTree({ workspaceRoot: root, destination: sqlite }),
+      );
+      // The session must NOT be tombstoned — a filesystem error is not corrupt data.
+      assert.equal(await sqlite.isTombstoned(unreadable.id), false);
+      // The valid session was not imported because the scan aborted.
+      assert.equal(await sqlite.has(valid.id), false);
+    } finally {
+      sqlite.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('does not tombstone a malformed header when a later scan step fails', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-rollback-'));
+    const legacy = createSessionStore(root);
+    const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
+    try {
+      const valid = await legacy.create(makeInput({ name: 'Valid' }));
+      const invalid = await legacy.create(makeInput({ name: 'Invalid' }));
+      // Corrupt the invalid session's header.
+      const invalidPath = join(root, 'sessions', invalid.id, 'session.jsonl');
+      const lines = (await readFile(invalidPath, 'utf8')).split('\n');
+      lines[0] = JSON.stringify({ ...JSON.parse(lines[0]!), labels: 'not-an-array' });
+      await writeFile(invalidPath, lines.join('\n'), 'utf8');
+      // Create an orphan transcript-marker directory with no SQLite metadata.
+      // The scan will collect the malformed tombstone, but the transcript
+      // marker check fails before the import, so the tombstone must not be
+      // committed.
+      const orphanId = 'orphan-transcript-session';
+      const orphanDir = join(root, 'sessions', orphanId);
+      await mkdir(orphanDir, { recursive: true });
+      const orphanPath = join(orphanDir, 'session.jsonl');
+      await writeFile(
+        orphanPath,
+        `${JSON.stringify({ type: 'session_transcript', sessionId: orphanId, schemaVersion: 1 })}\n`,
+        'utf8',
+      );
+
+      await assert.rejects(
+        importLegacySessionMetadataTree({ workspaceRoot: root, destination: sqlite }),
+        /transcript marker has no SQLite metadata/,
+      );
+      // The malformed session must NOT be tombstoned because the scan failed.
+      assert.equal(await sqlite.isTombstoned(invalid.id), false);
+      // The valid session was not imported either.
+      assert.equal(await sqlite.has(valid.id), false);
+      // Re-running with the orphan removed should now succeed and tombstone.
+      await rm(orphanDir, { recursive: true, force: true });
+      const report = await importLegacySessionMetadataTree({
+        workspaceRoot: root,
+        destination: sqlite,
+      });
+      assert.equal(report.headersImported, 1);
+      assert.equal(await sqlite.read(valid.id).then((r) => r.header.name), 'Valid');
+      assert.equal(await sqlite.isTombstoned(invalid.id), true);
+    } finally {
+      sqlite.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('keeps canonical metadata readable when its optional transcript is missing', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-missing-transcript-'));
     const legacy = createSessionStore(root);

--- a/packages/storage/src/__tests__/session-metadata-transfer.test.ts
+++ b/packages/storage/src/__tests__/session-metadata-transfer.test.ts
@@ -128,7 +128,7 @@ describe('legacy session metadata transfer', () => {
     }
   });
 
-  test('skips a malformed header and tombstones it while importing valid sessions', async () => {
+  test('skips a malformed header without tombstoning it while importing valid sessions', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-invalid-'));
     const legacy = createSessionStore(root);
     const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
@@ -148,16 +148,28 @@ describe('legacy session metadata transfer', () => {
       assert.equal(report.headersImported, 1);
       // The valid session was imported.
       assert.equal((await sqlite.read(valid.id)).header.name, 'Valid');
-      // The malformed session was tombstoned, not imported.
+      // The malformed session was skipped, not imported and not tombstoned.
       assert.equal(await sqlite.has(invalid.id), false);
-      assert.equal(await sqlite.isTombstoned(invalid.id), true);
-      // Re-importing should not retry the tombstoned session.
+      assert.equal(await sqlite.isTombstoned(invalid.id), false);
+      // Re-importing should skip the malformed session again (not tombstoned).
       const repeated = await importLegacySessionMetadataTree({
         workspaceRoot: root,
         destination: sqlite,
       });
       assert.equal(repeated.filesScanned, 2);
       assert.equal(repeated.headersImported, 0);
+      // Repairing the header should allow it to be imported on the next run.
+      const repairedLines = (await readFile(invalidPath, 'utf8')).split('\n');
+      const repairedHeader = JSON.parse(repairedLines[0]!);
+      repairedHeader.labels = ['repaired'];
+      repairedLines[0] = JSON.stringify(repairedHeader);
+      await writeFile(invalidPath, repairedLines.join('\n'), 'utf8');
+      const repaired = await importLegacySessionMetadataTree({
+        workspaceRoot: root,
+        destination: sqlite,
+      });
+      assert.equal(repaired.headersImported, 1);
+      assert.equal((await sqlite.read(invalid.id)).header.name, 'Invalid');
     } finally {
       sqlite.close();
       await rm(root, { recursive: true, force: true });
@@ -190,7 +202,7 @@ describe('legacy session metadata transfer', () => {
     }
   });
 
-  test('does not tombstone a malformed header when a later scan step fails', async () => {
+  test('skips a malformed header without tombstoning when a later scan step fails', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-session-transfer-rollback-'));
     const legacy = createSessionStore(root);
     const sqlite = createSqliteSessionMetadataStore(join(root, 'state.sqlite'));
@@ -203,9 +215,8 @@ describe('legacy session metadata transfer', () => {
       lines[0] = JSON.stringify({ ...JSON.parse(lines[0]!), labels: 'not-an-array' });
       await writeFile(invalidPath, lines.join('\n'), 'utf8');
       // Create an orphan transcript-marker directory with no SQLite metadata.
-      // The scan will collect the malformed tombstone, but the transcript
-      // marker check fails before the import, so the tombstone must not be
-      // committed.
+      // The scan will skip the malformed header, but the transcript marker
+      // check fails before the import, so no writes should occur.
       const orphanId = 'orphan-transcript-session';
       const orphanDir = join(root, 'sessions', orphanId);
       await mkdir(orphanDir, { recursive: true });
@@ -220,11 +231,12 @@ describe('legacy session metadata transfer', () => {
         importLegacySessionMetadataTree({ workspaceRoot: root, destination: sqlite }),
         /transcript marker has no SQLite metadata/,
       );
-      // The malformed session must NOT be tombstoned because the scan failed.
+      // The malformed session must NOT be tombstoned (skipped, not quarantined).
       assert.equal(await sqlite.isTombstoned(invalid.id), false);
-      // The valid session was not imported either.
+      // The valid session was not imported either (scan aborted).
       assert.equal(await sqlite.has(valid.id), false);
-      // Re-running with the orphan removed should now succeed and tombstone.
+      // Re-running with the orphan removed should import the valid session
+      // and skip (not tombstone) the malformed one.
       await rm(orphanDir, { recursive: true, force: true });
       const report = await importLegacySessionMetadataTree({
         workspaceRoot: root,
@@ -232,7 +244,7 @@ describe('legacy session metadata transfer', () => {
       });
       assert.equal(report.headersImported, 1);
       assert.equal(await sqlite.read(valid.id).then((r) => r.header.name), 'Valid');
-      assert.equal(await sqlite.isTombstoned(invalid.id), true);
+      assert.equal(await sqlite.isTombstoned(invalid.id), false);
     } finally {
       sqlite.close();
       await rm(root, { recursive: true, force: true });

--- a/packages/storage/src/__tests__/sqlite-session-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-store.test.ts
@@ -257,7 +257,9 @@ describe('default SQLite session metadata store', () => {
     try {
       assert.equal((await metadata.read(valid.id)).header.name, 'Valid');
       assert.equal(await metadata.has(invalid.id), false);
-      assert.equal(await metadata.isTombstoned(invalid.id), true);
+      // Malformed legacy headers are skipped, not tombstoned, so a repaired
+      // header can be imported on the next startup.
+      assert.equal(await metadata.isTombstoned(invalid.id), false);
     } finally {
       metadata.close();
       await rm(root, { recursive: true, force: true });

--- a/packages/storage/src/__tests__/sqlite-session-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-store.test.ts
@@ -228,7 +228,7 @@ describe('default SQLite session metadata store', () => {
     }
   });
 
-  test('fails the whole startup migration before exposing a partial catalog', async () => {
+  test('skips a malformed header during startup migration while importing valid sessions', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-default-session-invalid-'));
     const legacy = createLegacyFileSessionStore(root);
     const valid = await legacy.create(makeInput({ name: 'Valid' }));
@@ -240,7 +240,13 @@ describe('default SQLite session metadata store', () => {
 
     const store = createSessionStore(root);
     try {
-      await assert.rejects(() => store.list(), /Invalid legacy session header/);
+      // Startup import must not fail closed: valid sessions stay available.
+      assert.deepEqual(
+        (await store.list()).map((item) => item.id),
+        [valid.id],
+      );
+      assert.equal((await store.readHeader(valid.id)).name, 'Valid');
+      await assert.rejects(() => store.readHeader(invalid.id), /not found/);
     } finally {
       await store.close?.();
     }
@@ -249,8 +255,9 @@ describe('default SQLite session metadata store', () => {
       join(root, SQLITE_SESSION_METADATA_DATABASE_NAME),
     );
     try {
-      await assert.rejects(() => metadata.read(valid.id), /not found/);
-      assert.deepEqual(await metadata.list(), []);
+      assert.equal((await metadata.read(valid.id)).header.name, 'Valid');
+      assert.equal(await metadata.has(invalid.id), false);
+      assert.equal(await metadata.isTombstoned(invalid.id), true);
     } finally {
       metadata.close();
       await rm(root, { recursive: true, force: true });

--- a/packages/storage/src/session-metadata-transfer.ts
+++ b/packages/storage/src/session-metadata-transfer.ts
@@ -89,12 +89,15 @@ export async function readLegacySessionMetadataEntry(
   sourcePath: string,
   sessionId: string,
 ): Promise<SessionMetadataImportEntry | null> {
-  // File I/O errors (EACCES, EIO, etc.) propagate without wrapping so they
-  // are not mistaken for corrupt data by isMalformedLegacySessionHeader().
-  const headerLine = await readFirstJsonlRecord(sourcePath);
-  let value: unknown;
   try {
-    value = JSON.parse(headerLine) as unknown;
+    // readFirstJsonlRecord may throw:
+    //  - Filesystem I/O errors (EACCES, EIO, EISDIR, etc.) which carry a
+    //    `.code` property and must propagate without wrapping.
+    //  - Content/framing errors (empty file, no newline, oversized header)
+    //    which are plain Error instances without `.code` and should be
+    //    treated as malformed legacy content.
+    const headerLine = await readFirstJsonlRecord(sourcePath);
+    const value = JSON.parse(headerLine) as unknown;
     if (isSessionTranscriptMarker(value)) {
       decodeSessionTranscriptMarker(value, sessionId);
       return null;
@@ -107,6 +110,9 @@ export async function readLegacySessionMetadataEntry(
       },
     };
   } catch (error) {
+    // Filesystem I/O errors propagate without wrapping so they are not
+    // mistaken for corrupt data by isMalformedLegacySessionHeader().
+    if (isFilesystemError(error)) throw error;
     throw new Error(`Invalid legacy session header at ${sourcePath}`, { cause: error });
   }
 }
@@ -121,14 +127,25 @@ function isNotFound(error: unknown): boolean {
 }
 
 /**
+ * Returns `true` for Node.js filesystem errors that carry a `.code`
+ * property (e.g. `EACCES`, `EIO`, `EISDIR`, `EMFILE`).  These are
+ * transient or environmental failures, not corrupt session content.
+ */
+function isFilesystemError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const code = (error as { code?: unknown }).code;
+  return typeof code === 'string' && /^E[A-Z]/.test(code);
+}
+
+/**
  * Detects errors caused by a corrupt or malformed legacy session header.
  *
- * `readLegacySessionMetadataEntry` wraps only parse/decode failures
- * (JSON.parse, decodeSessionHeader, decodeSessionTranscriptMarker) as
- * `"Invalid legacy session header at <path>"` with the original error
- * as `cause`.  Filesystem I/O errors (EACCES, EIO, etc.) propagate without
- * wrapping and are NOT matched here, so transient failures are not treated
- * as corrupt data.
+ * `readLegacySessionMetadataEntry` wraps only parse/decode/framing
+ * failures (JSON.parse, decodeSessionHeader, decodeSessionTranscriptMarker,
+ * empty/truncated/oversized files) as `"Invalid legacy session header at
+ * <path>"` with the original error as `cause`.  Filesystem I/O errors
+ * (EACCES, EIO, etc.) propagate without wrapping and are NOT matched
+ * here, so transient failures are not treated as corrupt data.
  */
 function isMalformedLegacySessionHeader(error: unknown): boolean {
   let current = error;

--- a/packages/storage/src/session-metadata-transfer.ts
+++ b/packages/storage/src/session-metadata-transfer.ts
@@ -44,11 +44,25 @@ export async function importLegacySessionMetadataTree(input: {
         transcriptMarkerSessionIds.push(directory);
       }
     } catch (error) {
-      if (!isNotFound(error)) throw error;
-      const canonicalStateExists =
-        (await input.destination.has(directory)) ||
-        (await input.destination.isTombstoned(directory));
-      if (canonicalStateExists) continue;
+      if (isNotFound(error)) {
+        const canonicalStateExists =
+          (await input.destination.has(directory)) ||
+          (await input.destination.isTombstoned(directory));
+        if (canonicalStateExists) continue;
+        throw error;
+      }
+      // Corrupt or malformed legacy session headers should not crash the
+      // entire import. Skip the session if it already exists in the SQLite
+      // metadata store; otherwise tombstone it so it is not retried on
+      // every subsequent launch.
+      if (isMalformedLegacySessionHeader(error)) {
+        const canonicalStateExists =
+          (await input.destination.has(directory)) ||
+          (await input.destination.isTombstoned(directory));
+        if (canonicalStateExists) continue;
+        await input.destination.remove(directory);
+        continue;
+      }
       throw error;
     }
   }
@@ -101,6 +115,27 @@ function isNotFound(error: unknown): boolean {
   let current = error;
   while (current && typeof current === 'object') {
     if ('code' in current && current.code === 'ENOENT') return true;
+    current = 'cause' in current ? current.cause : undefined;
+  }
+  return false;
+}
+
+/**
+ * Detects errors caused by a corrupt or malformed legacy session header.
+ *
+ * `readLegacySessionMetadataEntry` wraps any decode/parse failure as
+ * `"Invalid legacy session header at <path>"` with the original error as
+ * `cause`.  We walk the cause chain looking for the signature messages
+ * produced by `decodeSessionHeader` / `normalizeSessionHeader`.
+ */
+function isMalformedLegacySessionHeader(error: unknown): boolean {
+  let current = error;
+  while (current && typeof current === 'object') {
+    if (current instanceof Error) {
+      const msg = current.message;
+      if (msg.startsWith('Invalid legacy session header at ')) return true;
+      if (msg.startsWith('Invalid session header for session ')) return true;
+    }
     current = 'cause' in current ? current.cause : undefined;
   }
   return false;

--- a/packages/storage/src/session-metadata-transfer.ts
+++ b/packages/storage/src/session-metadata-transfer.ts
@@ -11,6 +11,13 @@ import type {
 const LEGACY_SESSION_HEADER_MAX_BYTES = 1024 * 1024;
 const LEGACY_SESSION_HEADER_READ_BYTES = 8192;
 
+class MalformedLegacySessionHeaderError extends Error {
+  constructor(sourcePath: string, cause?: unknown) {
+    super(`Invalid legacy session header at ${sourcePath}`, { cause });
+    this.name = 'MalformedLegacySessionHeaderError';
+  }
+}
+
 export interface LegacySessionMetadataImportReport {
   filesScanned: number;
   headersRead: number;
@@ -59,7 +66,7 @@ export async function importLegacySessionMetadataTree(input: {
       // header on subsequent launches. Skipping means the malformed
       // session is retried next launch, which is harmless (it will be
       // skipped again until repaired).
-      if (isMalformedLegacySessionHeader(error)) {
+      if (error instanceof MalformedLegacySessionHeaderError) {
         continue;
       }
       throw error;
@@ -89,75 +96,34 @@ export async function readLegacySessionMetadataEntry(
   sourcePath: string,
   sessionId: string,
 ): Promise<SessionMetadataImportEntry | null> {
+  const headerLine = await readFirstJsonlRecord(sourcePath);
+  let value: unknown;
   try {
-    // readFirstJsonlRecord may throw:
-    //  - Filesystem I/O errors (EACCES, EIO, EISDIR, etc.) which carry a
-    //    `.code` property and must propagate without wrapping.
-    //  - Content/framing errors (empty file, no newline, oversized header)
-    //    which are plain Error instances without `.code` and should be
-    //    treated as malformed legacy content.
-    const headerLine = await readFirstJsonlRecord(sourcePath);
-    const value = JSON.parse(headerLine) as unknown;
-    if (isSessionTranscriptMarker(value)) {
-      decodeSessionTranscriptMarker(value, sessionId);
-      return null;
-    }
-    return {
-      header: decodeSessionHeader(value, sessionId),
-      source: {
-        path: sourcePath,
-        fingerprint: createHash('sha256').update(headerLine).digest('hex'),
-      },
-    };
+    value = JSON.parse(headerLine) as unknown;
   } catch (error) {
-    // Filesystem I/O errors propagate without wrapping so they are not
-    // mistaken for corrupt data by isMalformedLegacySessionHeader().
-    if (isFilesystemError(error)) throw error;
-    throw new Error(`Invalid legacy session header at ${sourcePath}`, { cause: error });
+    throw new MalformedLegacySessionHeaderError(sourcePath, error);
   }
+  if (isSessionTranscriptMarker(value)) {
+    decodeSessionTranscriptMarker(value, sessionId);
+    return null;
+  }
+  let header;
+  try {
+    header = decodeSessionHeader(value, sessionId);
+  } catch (error) {
+    throw new MalformedLegacySessionHeaderError(sourcePath, error);
+  }
+  return {
+    header,
+    source: {
+      path: sourcePath,
+      fingerprint: createHash('sha256').update(headerLine).digest('hex'),
+    },
+  };
 }
 
 function isNotFound(error: unknown): boolean {
-  let current = error;
-  while (current && typeof current === 'object') {
-    if ('code' in current && current.code === 'ENOENT') return true;
-    current = 'cause' in current ? current.cause : undefined;
-  }
-  return false;
-}
-
-/**
- * Returns `true` for Node.js filesystem errors that carry a `.code`
- * property (e.g. `EACCES`, `EIO`, `EISDIR`, `EMFILE`).  These are
- * transient or environmental failures, not corrupt session content.
- */
-function isFilesystemError(error: unknown): boolean {
-  if (typeof error !== 'object' || error === null) return false;
-  const code = (error as { code?: unknown }).code;
-  return typeof code === 'string' && /^E[A-Z]/.test(code);
-}
-
-/**
- * Detects errors caused by a corrupt or malformed legacy session header.
- *
- * `readLegacySessionMetadataEntry` wraps only parse/decode/framing
- * failures (JSON.parse, decodeSessionHeader, decodeSessionTranscriptMarker,
- * empty/truncated/oversized files) as `"Invalid legacy session header at
- * <path>"` with the original error as `cause`.  Filesystem I/O errors
- * (EACCES, EIO, etc.) propagate without wrapping and are NOT matched
- * here, so transient failures are not treated as corrupt data.
- */
-function isMalformedLegacySessionHeader(error: unknown): boolean {
-  let current = error;
-  while (current && typeof current === 'object') {
-    if (current instanceof Error) {
-      const msg = current.message;
-      if (msg.startsWith('Invalid legacy session header at ')) return true;
-      if (msg.startsWith('Invalid session header for session ')) return true;
-    }
-    current = 'cause' in current ? current.cause : undefined;
-  }
-  return false;
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT';
 }
 
 async function sessionDirectoryNames(root: string): Promise<string[]> {
@@ -196,7 +162,10 @@ async function readFirstJsonlRecord(path: string): Promise<string> {
       if (newline >= 0) return text.slice(0, newline);
       offset += bytesRead;
     }
-    throw new Error(`Cannot read legacy session header from ${path}`);
+    throw new MalformedLegacySessionHeaderError(
+      path,
+      new Error(`Cannot read legacy session header from ${path}`),
+    );
   } finally {
     await handle.close();
   }

--- a/packages/storage/src/session-metadata-transfer.ts
+++ b/packages/storage/src/session-metadata-transfer.ts
@@ -24,8 +24,9 @@ export interface LegacySessionMetadataImportReport {
  * Import every legacy line-1 SessionHeader in one SQLite transaction.
  *
  * The scan and decode phase completes before the transaction begins.
- * Malformed headers are skipped (and tombstoned when no canonical metadata
- * exists yet) so one corrupt session cannot block the rest of the catalog.
+ * Malformed headers are skipped (not tombstoned) so one corrupt session
+ * cannot block the rest of the catalog.  Skipping without tombstoning means
+ * a repaired header will be picked up on the next launch.
  */
 export async function importLegacySessionMetadataTree(input: {
   workspaceRoot: string;
@@ -34,7 +35,6 @@ export async function importLegacySessionMetadataTree(input: {
   const sessionsRoot = join(input.workspaceRoot, 'sessions');
   const entries: SessionMetadataImportEntry[] = [];
   const transcriptMarkerSessionIds: string[] = [];
-  const tombstoneSessionIds: string[] = [];
   const directories = await sessionDirectoryNames(sessionsRoot);
   for (const directory of directories) {
     const sourcePath = join(sessionsRoot, directory, 'session.jsonl');
@@ -54,17 +54,12 @@ export async function importLegacySessionMetadataTree(input: {
         throw error;
       }
       // Corrupt or malformed legacy session headers should not crash the
-      // entire import. Skip the session if it already exists in the SQLite
-      // metadata store; otherwise defer a tombstone so it is not retried on
-      // every subsequent launch.  Tombstones are applied only after the
-      // full scan and import succeed, so a later failure rolls them back
-      // implicitly (the malformed session will be retried next launch).
+      // entire import. Skip the session without tombstoning it — the
+      // deletion tombstone is permanent and would suppress a repaired
+      // header on subsequent launches. Skipping means the malformed
+      // session is retried next launch, which is harmless (it will be
+      // skipped again until repaired).
       if (isMalformedLegacySessionHeader(error)) {
-        const canonicalStateExists =
-          (await input.destination.has(directory)) ||
-          (await input.destination.isTombstoned(directory));
-        if (canonicalStateExists) continue;
-        tombstoneSessionIds.push(directory);
         continue;
       }
       throw error;
@@ -79,11 +74,6 @@ export async function importLegacySessionMetadataTree(input: {
     }
   }
   const result = await input.destination.importEntries(entries);
-  // Apply deferred tombstones only after the import succeeds so a scan or
-  // import failure does not permanently suppress repairable sessions.
-  for (const sessionId of tombstoneSessionIds) {
-    await input.destination.remove(sessionId);
-  }
   const headersImported = result.created.filter(Boolean).length;
   return {
     filesScanned: directories.length,

--- a/packages/storage/src/session-metadata-transfer.ts
+++ b/packages/storage/src/session-metadata-transfer.ts
@@ -23,8 +23,9 @@ export interface LegacySessionMetadataImportReport {
 /**
  * Import every legacy line-1 SessionHeader in one SQLite transaction.
  *
- * The scan and decode phase completes before the transaction begins, so a
- * malformed header cannot leave a partially imported session catalog.
+ * The scan and decode phase completes before the transaction begins.
+ * Malformed headers are skipped (and tombstoned when no canonical metadata
+ * exists yet) so one corrupt session cannot block the rest of the catalog.
  */
 export async function importLegacySessionMetadataTree(input: {
   workspaceRoot: string;

--- a/packages/storage/src/session-metadata-transfer.ts
+++ b/packages/storage/src/session-metadata-transfer.ts
@@ -34,6 +34,7 @@ export async function importLegacySessionMetadataTree(input: {
   const sessionsRoot = join(input.workspaceRoot, 'sessions');
   const entries: SessionMetadataImportEntry[] = [];
   const transcriptMarkerSessionIds: string[] = [];
+  const tombstoneSessionIds: string[] = [];
   const directories = await sessionDirectoryNames(sessionsRoot);
   for (const directory of directories) {
     const sourcePath = join(sessionsRoot, directory, 'session.jsonl');
@@ -54,14 +55,16 @@ export async function importLegacySessionMetadataTree(input: {
       }
       // Corrupt or malformed legacy session headers should not crash the
       // entire import. Skip the session if it already exists in the SQLite
-      // metadata store; otherwise tombstone it so it is not retried on
-      // every subsequent launch.
+      // metadata store; otherwise defer a tombstone so it is not retried on
+      // every subsequent launch.  Tombstones are applied only after the
+      // full scan and import succeed, so a later failure rolls them back
+      // implicitly (the malformed session will be retried next launch).
       if (isMalformedLegacySessionHeader(error)) {
         const canonicalStateExists =
           (await input.destination.has(directory)) ||
           (await input.destination.isTombstoned(directory));
         if (canonicalStateExists) continue;
-        await input.destination.remove(directory);
+        tombstoneSessionIds.push(directory);
         continue;
       }
       throw error;
@@ -76,6 +79,11 @@ export async function importLegacySessionMetadataTree(input: {
     }
   }
   const result = await input.destination.importEntries(entries);
+  // Apply deferred tombstones only after the import succeeds so a scan or
+  // import failure does not permanently suppress repairable sessions.
+  for (const sessionId of tombstoneSessionIds) {
+    await input.destination.remove(sessionId);
+  }
   const headersImported = result.created.filter(Boolean).length;
   return {
     filesScanned: directories.length,
@@ -91,10 +99,11 @@ export async function readLegacySessionMetadataEntry(
   sourcePath: string,
   sessionId: string,
 ): Promise<SessionMetadataImportEntry | null> {
+  // File I/O errors (EACCES, EIO, etc.) propagate without wrapping so they
+  // are not mistaken for corrupt data by isMalformedLegacySessionHeader().
+  const headerLine = await readFirstJsonlRecord(sourcePath);
   let value: unknown;
-  let headerLine: string;
   try {
-    headerLine = await readFirstJsonlRecord(sourcePath);
     value = JSON.parse(headerLine) as unknown;
     if (isSessionTranscriptMarker(value)) {
       decodeSessionTranscriptMarker(value, sessionId);
@@ -124,10 +133,12 @@ function isNotFound(error: unknown): boolean {
 /**
  * Detects errors caused by a corrupt or malformed legacy session header.
  *
- * `readLegacySessionMetadataEntry` wraps any decode/parse failure as
- * `"Invalid legacy session header at <path>"` with the original error as
- * `cause`.  We walk the cause chain looking for the signature messages
- * produced by `decodeSessionHeader` / `normalizeSessionHeader`.
+ * `readLegacySessionMetadataEntry` wraps only parse/decode failures
+ * (JSON.parse, decodeSessionHeader, decodeSessionTranscriptMarker) as
+ * `"Invalid legacy session header at <path>"` with the original error
+ * as `cause`.  Filesystem I/O errors (EACCES, EIO, etc.) propagate without
+ * wrapping and are NOT matched here, so transient failures are not treated
+ * as corrupt data.
  */
 function isMalformedLegacySessionHeader(error: unknown): boolean {
   let current = error;


### PR DESCRIPTION
## Summary

A malformed legacy `session.jsonl` header no longer blocks startup migration or hides every valid session. The importer skips only repairable legacy-content failures, writes no deletion tombstone, and retries the session on a later launch so a repaired header can be imported.

The error boundary now preserves the existing fail-closed behavior for filesystem failures and invalid current-format `session_transcript` markers. A private structured error identifies only legacy framing, JSON, and header-decoding failures; message matching, cause-chain inspection, and filesystem error-code heuristics have been removed.

The public `SessionStore` tests cover empty and truncated files, a complete valid header beyond the 1 MiB limit, the reported `turn_state` first-record failure, invalid current marker identities/schema versions, repair and reopen, no tombstones, and no partial import on environmental or marker failures. Repeated recovery cases are table-driven.

## Verification

- `npm --workspace @maka/storage test` — 478 passed, 1 existing Windows-only test skipped
- `npm run format:check` — passed
- `npm run lint` — passed
- `npm --workspace @maka/storage run typecheck` — passed
- Targeted `session-metadata-transfer` and `sqlite-session-store` suites — 18 passed
- Mutation check: temporarily raising the production limit to 2 MiB made the >1 MiB regression test fail by importing the oversized valid header, confirming the test isolates the size cap; the production limit was restored before commit
- GitHub CI on `d1fae87f7` — typecheck, test, and e2e passed

## Root cause

The legacy migration originally treated every non-`ENOENT` read/decode failure as fatal. An intermediate fix then wrapped all non-filesystem failures as malformed legacy headers, which also swallowed validation errors from current-format transcript markers. The final implementation assigns recoverable status at the source: legacy framing/JSON/header errors use one private error type, while current marker validation and real I/O errors propagate unchanged.
