### PR TITLE
fix: make question answers directly editable

### DIFF
--- a/apps/desktop/e2e/ask-user-question.spec.ts
+++ b/apps/desktop/e2e/ask-user-question.spec.ts
@@ -22,6 +22,8 @@ test('answers three questions and continues the same fake-backend turn', async (
         backgroundColor: style.backgroundColor,
         borderColor: style.borderColor,
         boxShadow: style.boxShadow,
+        dotBackgroundColor: getComputedStyle(element.querySelector('.maka-question-radio')!).backgroundColor,
+        dotBoxShadow: getComputedStyle(element.querySelector('.maka-question-radio')!).boxShadow,
       };
     }),
     unselectedOption.evaluate((element) => {
@@ -30,12 +32,16 @@ test('answers three questions and continues the same fake-backend turn', async (
         backgroundColor: style.backgroundColor,
         borderColor: style.borderColor,
         boxShadow: style.boxShadow,
+        dotBackgroundColor: getComputedStyle(element.querySelector('.maka-question-radio')!).backgroundColor,
+        dotBoxShadow: getComputedStyle(element.querySelector('.maka-question-radio')!).boxShadow,
       };
     }),
   ]);
   expect(selectionStyles[0].backgroundColor).not.toBe(selectionStyles[1].backgroundColor);
   expect(selectionStyles[0].borderColor).not.toBe(selectionStyles[1].borderColor);
   expect(selectionStyles[0].boxShadow).not.toBe('none');
+  expect(selectionStyles[0].dotBackgroundColor).not.toBe(selectionStyles[1].dotBackgroundColor);
+  expect(selectionStyles[0].dotBoxShadow).not.toBe('none');
   await prompt.getByRole('button', { name: '下一题' }).click();
 
   await expect(prompt.getByText('2 / 3', { exact: true })).toBeVisible();
@@ -54,15 +60,8 @@ test('answers three questions and continues the same fake-backend turn', async (
   const geometryBeforeInput = await Promise.all([
     prompt.boundingBox(),
     otherField.boundingBox(),
-    other.boundingBox(),
   ]);
   expect(geometryBeforeInput.every(Boolean)).toBe(true);
-  expect(geometryBeforeInput[2]?.y).toBeGreaterThanOrEqual(geometryBeforeInput[1]?.y ?? Number.POSITIVE_INFINITY);
-  expect((geometryBeforeInput[2]?.y ?? 0) + (geometryBeforeInput[2]?.height ?? 0))
-    .toBeLessThanOrEqual((geometryBeforeInput[1]?.y ?? 0) + (geometryBeforeInput[1]?.height ?? 0));
-  expect(
-    await other.evaluate((input) => getComputedStyle(input).borderTopWidth),
-  ).toBe('0px');
   expect(
     await otherField.evaluate((field) => {
       const input = field.querySelector<HTMLElement>('.maka-question-other-input');
@@ -80,8 +79,19 @@ test('answers three questions and continues the same fake-backend turn', async (
       });
     }),
   ).toBe(true);
-  await otherField.click({ position: { x: 8, y: 8 } });
+
+  const preset = prompt.getByRole('radio', { name: '是' });
+  const submit = prompt.getByRole('button', { name: '提交答案' });
+  await preset.click();
+  await expect(preset).toBeChecked();
+  await expect(submit).toBeEnabled();
+  await preset.press('Tab');
   await expect(other).toBeFocused();
+  await expect(preset).toBeChecked();
+  await expect(otherField).not.toHaveAttribute('data-selected');
+  await expect(submit).toBeEnabled();
+  await other.pressSequentially('自');
+  await expect(preset).not.toBeChecked();
   await expect(otherField).toHaveAttribute('data-selected', '');
   expect(
     await otherField.evaluate((field) => getComputedStyle(field).boxShadow),
@@ -89,12 +99,21 @@ test('answers three questions and continues the same fake-backend turn', async (
   expect(
     await other.evaluate((input) => input.closest('[role="radiogroup"]') === null),
   ).toBe(true);
-  await expect(prompt.getByRole('button', { name: '提交答案' })).toBeDisabled();
+  await other.fill('');
+  await expect(submit).toBeDisabled();
+  await preset.click();
+  await expect(otherField).not.toHaveAttribute('data-selected');
+  await otherField.click({ position: { x: 8, y: 8 } });
+  await expect(other).toBeFocused();
+  await expect(preset).toBeChecked();
+  await expect(otherField).not.toHaveAttribute('data-selected');
+  await expect(submit).toBeEnabled();
   await other.fill('自定义节奏');
+  await expect(preset).not.toBeChecked();
+  await expect(otherField).toHaveAttribute('data-selected', '');
   const geometryAfterInput = await Promise.all([
     prompt.boundingBox(),
     otherField.boundingBox(),
-    other.boundingBox(),
   ]);
   expect(geometryAfterInput).toEqual(geometryBeforeInput);
   await other.press('Home');

--- a/apps/desktop/e2e/ask-user-question.spec.ts
+++ b/apps/desktop/e2e/ask-user-question.spec.ts
@@ -44,13 +44,16 @@ test('answers three questions and continues the same fake-backend turn', async (
 
   await expect(prompt.getByText('3 / 3', { exact: true })).toBeVisible();
   await expect(prompt.getByRole('radio', { name: '是' })).toBeFocused();
-  const otherOption = prompt.getByRole('radio', { name: /其他/ });
+  await expect(prompt.getByRole('radio', { name: /其他/ })).toHaveCount(0);
+  const otherField = prompt.locator('.maka-question-other-field');
   const other = prompt.getByRole('textbox', { name: '其他答案' });
+  await expect(otherField).toBeVisible();
+  await expect(otherField.locator('.maka-question-other-icon')).toBeVisible();
   await expect(other).toBeVisible();
   await expect(other).toHaveValue('');
   const geometryBeforeInput = await Promise.all([
     prompt.boundingBox(),
-    otherOption.boundingBox(),
+    otherField.boundingBox(),
     other.boundingBox(),
   ]);
   expect(geometryBeforeInput.every(Boolean)).toBe(true);
@@ -61,26 +64,28 @@ test('answers three questions and continues the same fake-backend turn', async (
     await other.evaluate((input) => getComputedStyle(input).borderTopWidth),
   ).toBe('0px');
   expect(
-    await prompt.locator('.maka-question-options').evaluate((container) => {
-      const radio = container.querySelector<HTMLElement>('.maka-question-other-trigger');
-      const input = container.querySelector<HTMLElement>('.maka-question-other-input');
-      if (!radio || !input) return false;
-      const width = container.getBoundingClientRect();
-      const row = radio.getBoundingClientRect();
+    await otherField.evaluate((field) => {
+      const input = field.querySelector<HTMLElement>('.maka-question-other-input');
+      if (!input) return false;
+      const row = field.getBoundingClientRect();
       const points = [0.1, 0.5, 0.9].flatMap((xRatio) =>
         [0.1, 0.5, 0.9].map((yRatio) => [
-          width.left + width.width * xRatio,
+          row.left + row.width * xRatio,
           row.top + row.height * yRatio,
         ] as const)
       );
       return points.every(([x, y]) => {
         const target = document.elementFromPoint(x, y);
-        return target === input || target === radio || Boolean(target && radio.contains(target));
+        return target === field || Boolean(target && field.contains(target));
       });
     }),
   ).toBe(true);
-  await other.focus();
-  await expect(otherOption).toBeChecked();
+  await otherField.click({ position: { x: 8, y: 8 } });
+  await expect(other).toBeFocused();
+  await expect(otherField).toHaveAttribute('data-selected', '');
+  expect(
+    await otherField.evaluate((field) => getComputedStyle(field).boxShadow),
+  ).not.toBe('none');
   expect(
     await other.evaluate((input) => input.closest('[role="radiogroup"]') === null),
   ).toBe(true);
@@ -88,7 +93,7 @@ test('answers three questions and continues the same fake-backend turn', async (
   await other.fill('自定义节奏');
   const geometryAfterInput = await Promise.all([
     prompt.boundingBox(),
-    otherOption.boundingBox(),
+    otherField.boundingBox(),
     other.boundingBox(),
   ]);
   expect(geometryAfterInput).toEqual(geometryBeforeInput);
@@ -96,7 +101,6 @@ test('answers three questions and continues the same fake-backend turn', async (
   await other.press('ArrowLeft');
   await expect(other).toBeFocused();
   await expect(other).toHaveValue('自定义节奏');
-  await expect(otherOption).toBeChecked();
   await prompt.getByRole('button', { name: '提交答案' }).click();
 
   await expect(prompt).toHaveCount(0);

--- a/apps/desktop/e2e/ask-user-question.spec.ts
+++ b/apps/desktop/e2e/ask-user-question.spec.ts
@@ -44,21 +44,59 @@ test('answers three questions and continues the same fake-backend turn', async (
 
   await expect(prompt.getByText('3 / 3', { exact: true })).toBeVisible();
   await expect(prompt.getByRole('radio', { name: '是' })).toBeFocused();
+  const otherOption = prompt.getByRole('radio', { name: /其他/ });
   const other = prompt.getByRole('textbox', { name: '其他答案' });
   await expect(other).toBeVisible();
   await expect(other).toHaveValue('');
+  const geometryBeforeInput = await Promise.all([
+    prompt.boundingBox(),
+    otherOption.boundingBox(),
+    other.boundingBox(),
+  ]);
+  expect(geometryBeforeInput.every(Boolean)).toBe(true);
+  expect(geometryBeforeInput[2]?.y).toBeGreaterThanOrEqual(geometryBeforeInput[1]?.y ?? Number.POSITIVE_INFINITY);
+  expect((geometryBeforeInput[2]?.y ?? 0) + (geometryBeforeInput[2]?.height ?? 0))
+    .toBeLessThanOrEqual((geometryBeforeInput[1]?.y ?? 0) + (geometryBeforeInput[1]?.height ?? 0));
+  expect(
+    await other.evaluate((input) => getComputedStyle(input).borderTopWidth),
+  ).toBe('0px');
+  expect(
+    await prompt.locator('.maka-question-options').evaluate((container) => {
+      const radio = container.querySelector<HTMLElement>('.maka-question-other-trigger');
+      const input = container.querySelector<HTMLElement>('.maka-question-other-input');
+      if (!radio || !input) return false;
+      const width = container.getBoundingClientRect();
+      const row = radio.getBoundingClientRect();
+      const points = [0.1, 0.5, 0.9].flatMap((xRatio) =>
+        [0.1, 0.5, 0.9].map((yRatio) => [
+          width.left + width.width * xRatio,
+          row.top + row.height * yRatio,
+        ] as const)
+      );
+      return points.every(([x, y]) => {
+        const target = document.elementFromPoint(x, y);
+        return target === input || target === radio || Boolean(target && radio.contains(target));
+      });
+    }),
+  ).toBe(true);
   await other.focus();
-  await expect(prompt.getByRole('radio', { name: /其他/ })).toBeChecked();
+  await expect(otherOption).toBeChecked();
   expect(
     await other.evaluate((input) => input.closest('[role="radiogroup"]') === null),
   ).toBe(true);
   await expect(prompt.getByRole('button', { name: '提交答案' })).toBeDisabled();
   await other.fill('自定义节奏');
+  const geometryAfterInput = await Promise.all([
+    prompt.boundingBox(),
+    otherOption.boundingBox(),
+    other.boundingBox(),
+  ]);
+  expect(geometryAfterInput).toEqual(geometryBeforeInput);
   await other.press('Home');
   await other.press('ArrowLeft');
   await expect(other).toBeFocused();
   await expect(other).toHaveValue('自定义节奏');
-  await expect(prompt.getByRole('radio', { name: /其他/ })).toBeChecked();
+  await expect(otherOption).toBeChecked();
   await prompt.getByRole('button', { name: '提交答案' }).click();
 
   await expect(prompt).toHaveCount(0);

--- a/apps/desktop/e2e/ask-user-question.spec.ts
+++ b/apps/desktop/e2e/ask-user-question.spec.ts
@@ -12,7 +12,30 @@ test('answers three questions and continues the same fake-backend turn', async (
   await expect(prompt.getByText('1 / 3', { exact: true })).toBeVisible();
   await expect(prompt.getByText('先验证核心流程，再逐步扩大范围。')).toBeVisible();
 
-  await prompt.getByRole('radio', { name: /邀请制/ }).click();
+  const selectedOption = prompt.getByRole('radio', { name: /邀请制/ });
+  const unselectedOption = prompt.getByRole('radio', { name: /公开测试/ });
+  await selectedOption.click();
+  const selectionStyles = await Promise.all([
+    selectedOption.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        backgroundColor: style.backgroundColor,
+        borderColor: style.borderColor,
+        boxShadow: style.boxShadow,
+      };
+    }),
+    unselectedOption.evaluate((element) => {
+      const style = getComputedStyle(element);
+      return {
+        backgroundColor: style.backgroundColor,
+        borderColor: style.borderColor,
+        boxShadow: style.boxShadow,
+      };
+    }),
+  ]);
+  expect(selectionStyles[0].backgroundColor).not.toBe(selectionStyles[1].backgroundColor);
+  expect(selectionStyles[0].borderColor).not.toBe(selectionStyles[1].borderColor);
+  expect(selectionStyles[0].boxShadow).not.toBe('none');
   await prompt.getByRole('button', { name: '下一题' }).click();
 
   await expect(prompt.getByText('2 / 3', { exact: true })).toBeVisible();
@@ -21,8 +44,14 @@ test('answers three questions and continues the same fake-backend turn', async (
 
   await expect(prompt.getByText('3 / 3', { exact: true })).toBeVisible();
   await expect(prompt.getByRole('radio', { name: '是' })).toBeFocused();
-  await prompt.getByRole('radio', { name: /其他/ }).click();
   const other = prompt.getByRole('textbox', { name: '其他答案' });
+  await expect(other).toBeVisible();
+  await expect(other).toHaveValue('');
+  await other.focus();
+  await expect(prompt.getByRole('radio', { name: /其他/ })).toBeChecked();
+  expect(
+    await other.evaluate((input) => input.closest('.maka-question-other-option') !== null),
+  ).toBe(true);
   await expect(prompt.getByRole('button', { name: '提交答案' })).toBeDisabled();
   await other.fill('自定义节奏');
   await prompt.getByRole('button', { name: '提交答案' }).click();

--- a/apps/desktop/e2e/ask-user-question.spec.ts
+++ b/apps/desktop/e2e/ask-user-question.spec.ts
@@ -50,10 +50,15 @@ test('answers three questions and continues the same fake-backend turn', async (
   await other.focus();
   await expect(prompt.getByRole('radio', { name: /其他/ })).toBeChecked();
   expect(
-    await other.evaluate((input) => input.closest('.maka-question-other-option') !== null),
+    await other.evaluate((input) => input.closest('[role="radiogroup"]') === null),
   ).toBe(true);
   await expect(prompt.getByRole('button', { name: '提交答案' })).toBeDisabled();
   await other.fill('自定义节奏');
+  await other.press('Home');
+  await other.press('ArrowLeft');
+  await expect(other).toBeFocused();
+  await expect(other).toHaveValue('自定义节奏');
+  await expect(prompt.getByRole('radio', { name: /其他/ })).toBeChecked();
   await prompt.getByRole('button', { name: '提交答案' }).click();
 
   await expect(prompt).toHaveCount(0);

--- a/apps/desktop/src/renderer/styles/permission-dialog.css
+++ b/apps/desktop/src/renderer/styles/permission-dialog.css
@@ -160,7 +160,10 @@
   color: var(--foreground);
   font-size: var(--font-size-ui);
   line-height: var(--leading-snug);
-  caret-color: var(--foreground);
+}
+
+.maka-question-other-input:disabled {
+  opacity: 1;
 }
 
 .maka-question-other-input::placeholder {

--- a/apps/desktop/src/renderer/styles/permission-dialog.css
+++ b/apps/desktop/src/renderer/styles/permission-dialog.css
@@ -34,14 +34,22 @@
 
 .maka-question-options {
   display: grid;
+}
+
+.maka-question-choice-group {
+  display: grid;
   gap: var(--space-1-5);
 }
 
-.maka-question-option,
-.maka-question-other-option {
+.maka-question-option {
   width: 100%;
   min-height: 44px;
   box-sizing: border-box;
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  align-items: start;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-2-5);
   color: var(--foreground);
   text-align: left;
   border: var(--border-width-hairline) solid var(--border);
@@ -53,32 +61,18 @@
     box-shadow var(--duration-quick) var(--ease-out-strong);
 }
 
-.maka-question-option {
-  display: grid;
-  grid-template-columns: 16px minmax(0, 1fr);
-  align-items: start;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-2-5);
-}
-
-.maka-question-other-option {
-  display: grid;
-}
-
-.maka-question-option:hover,
-.maka-question-other-option:hover {
+.maka-question-option:hover {
   background: var(--state-hover-bg);
 }
 
 .maka-question-option[data-checked],
-.maka-question-other-option[data-checked] {
-  border-color: oklch(from var(--accent) l c h / 0.68);
-  background: oklch(from var(--accent) l c h / 0.10);
-  box-shadow: 0 0 0 1px oklch(from var(--accent) l c h / 0.16);
+.maka-question-options:has(.maka-question-other-trigger[data-checked]) .maka-question-other-answer {
+  border-color: var(--ring);
+  background: var(--state-selected-bg);
+  box-shadow: 0 0 0 1px var(--foreground-alpha-10);
 }
 
-.maka-question-option:focus-visible,
-.maka-question-other-option:has(.maka-question-other-trigger:focus-visible) {
+.maka-question-option:focus-visible {
   outline: none;
   box-shadow: 0 0 0 2px var(--focus-ring);
 }
@@ -92,10 +86,9 @@
   background: var(--background);
 }
 
-.maka-question-option[data-checked] .maka-question-radio,
-.maka-question-other-option[data-checked] .maka-question-radio {
-  border-color: var(--accent);
-  background: var(--accent);
+.maka-question-option[data-checked] .maka-question-radio {
+  border-color: var(--foreground);
+  background: var(--foreground);
   box-shadow: inset 0 0 0 3px var(--background);
 }
 
@@ -118,18 +111,21 @@
 }
 
 .maka-question-other-trigger {
-  min-height: 0;
-  border: 0;
+  border-bottom: 0;
   border-radius: var(--radius-control) var(--radius-control) 0 0;
-  background: transparent;
 }
 
-.maka-question-other-trigger:hover {
-  background: transparent;
-}
-
-.maka-question-other-trigger:focus-visible {
-  box-shadow: none;
+.maka-question-other-answer {
+  min-width: 0;
+  display: grid;
+  border: var(--border-width-hairline) solid var(--border);
+  border-top: 0;
+  border-radius: 0 0 var(--radius-control) var(--radius-control);
+  background: var(--background);
+  transition:
+    background var(--duration-quick) var(--ease-out-strong),
+    border-color var(--duration-quick) var(--ease-out-strong),
+    box-shadow var(--duration-quick) var(--ease-out-strong);
 }
 
 .maka-question-other-input {

--- a/apps/desktop/src/renderer/styles/permission-dialog.css
+++ b/apps/desktop/src/renderer/styles/permission-dialog.css
@@ -33,9 +33,8 @@
 }
 
 .maka-question-options {
-  --maka-question-other-label-width: clamp(8rem, 24%, 12rem);
-  position: relative;
   display: grid;
+  gap: var(--space-1-5);
 }
 
 .maka-question-choice-group {
@@ -111,30 +110,53 @@
   line-height: var(--leading-normal);
 }
 
-.maka-question-other-trigger {
+.maka-question-other-field {
+  width: 100%;
   min-height: 44px;
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
   align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-2-5);
+  cursor: text;
+  border: var(--border-width-hairline) solid var(--border);
+  border-radius: var(--radius-control);
+  background: var(--background);
+  transition:
+    background var(--duration-quick) var(--ease-out-strong),
+    border-color var(--duration-quick) var(--ease-out-strong),
+    box-shadow var(--duration-quick) var(--ease-out-strong);
 }
 
-.maka-question-options:not(:has(.maka-question-other-trigger[data-checked])):has(.maka-question-other-input:hover)
-  .maka-question-other-trigger {
+.maka-question-other-field:hover {
   background: var(--state-hover-bg);
 }
 
-.maka-question-options:has(.maka-question-other-input:focus-visible) .maka-question-other-trigger {
+.maka-question-other-field[data-selected] {
+  border-color: var(--ring);
+  background: var(--state-selected-bg);
+  box-shadow: 0 0 0 1px var(--foreground-alpha-10);
+}
+
+.maka-question-other-field:focus-within {
   box-shadow: 0 0 0 2px var(--focus-ring);
 }
 
+.maka-question-other-field:has(.maka-question-other-input:disabled) {
+  cursor: not-allowed;
+  opacity: var(--opacity-disabled);
+}
+
+.maka-question-other-icon {
+  width: 14px;
+  height: 14px;
+  color: var(--foreground-secondary);
+}
+
 .maka-question-other-input {
-  position: absolute;
-  right: 0;
-  bottom: 0;
-  left: var(--maka-question-other-label-width);
-  width: auto;
-  height: 44px;
+  width: 100%;
   min-width: 0;
-  box-sizing: border-box;
-  padding: var(--space-2) var(--space-2-5) var(--space-2) 0;
   color: var(--foreground);
   font-size: var(--font-size-ui);
   line-height: var(--leading-snug);

--- a/apps/desktop/src/renderer/styles/permission-dialog.css
+++ b/apps/desktop/src/renderer/styles/permission-dialog.css
@@ -37,14 +37,11 @@
   gap: var(--space-1-5);
 }
 
-.maka-question-option {
+.maka-question-option,
+.maka-question-other-option {
   width: 100%;
   min-height: 44px;
-  display: grid;
-  grid-template-columns: 16px minmax(0, 1fr);
-  align-items: start;
-  gap: var(--space-2);
-  padding: var(--space-2) var(--space-2-5);
+  box-sizing: border-box;
   color: var(--foreground);
   text-align: left;
   border: var(--border-width-hairline) solid var(--border);
@@ -56,18 +53,34 @@
     box-shadow var(--duration-quick) var(--ease-out-strong);
 }
 
-.maka-question-option:hover {
+.maka-question-option {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  align-items: start;
+  gap: var(--space-2);
+  padding: var(--space-2) var(--space-2-5);
+}
+
+.maka-question-other-option {
+  display: grid;
+}
+
+.maka-question-option:hover,
+.maka-question-other-option:hover {
   background: var(--state-hover-bg);
 }
 
-.maka-question-option:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 2px var(--focus-ring);
+.maka-question-option[data-checked],
+.maka-question-other-option[data-checked] {
+  border-color: oklch(from var(--accent) l c h / 0.68);
+  background: oklch(from var(--accent) l c h / 0.10);
+  box-shadow: 0 0 0 1px oklch(from var(--accent) l c h / 0.16);
 }
 
-.maka-question-option[data-checked] {
-  border-color: var(--border-strong);
-  background: var(--state-selected-bg);
+.maka-question-option:focus-visible,
+.maka-question-other-option:has(.maka-question-other-trigger:focus-visible) {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--focus-ring);
 }
 
 .maka-question-radio {
@@ -79,8 +92,11 @@
   background: var(--background);
 }
 
-.maka-question-option[data-checked] .maka-question-radio {
-  border: var(--border-width-thick) solid var(--foreground);
+.maka-question-option[data-checked] .maka-question-radio,
+.maka-question-other-option[data-checked] .maka-question-radio {
+  border-color: var(--accent);
+  background: var(--accent);
+  box-shadow: inset 0 0 0 3px var(--background);
 }
 
 .maka-question-option-copy {
@@ -101,8 +117,26 @@
   line-height: var(--leading-normal);
 }
 
+.maka-question-other-trigger {
+  min-height: 0;
+  border: 0;
+  border-radius: var(--radius-control) var(--radius-control) 0 0;
+  background: transparent;
+}
+
+.maka-question-other-trigger:hover {
+  background: transparent;
+}
+
+.maka-question-other-trigger:focus-visible {
+  box-shadow: none;
+}
+
 .maka-question-other-input {
-  width: 100%;
+  width: auto;
+  min-width: 0;
+  margin: 0 var(--space-2-5) var(--space-2)
+    calc(var(--space-2-5) + 16px + var(--space-2));
 }
 
 .permissionActions.maka-question-actions {

--- a/apps/desktop/src/renderer/styles/permission-dialog.css
+++ b/apps/desktop/src/renderer/styles/permission-dialog.css
@@ -33,6 +33,8 @@
 }
 
 .maka-question-options {
+  --maka-question-other-label-width: clamp(8rem, 24%, 12rem);
+  position: relative;
   display: grid;
 }
 
@@ -65,8 +67,7 @@
   background: var(--state-hover-bg);
 }
 
-.maka-question-option[data-checked],
-.maka-question-options:has(.maka-question-other-trigger[data-checked]) .maka-question-other-answer {
+.maka-question-option[data-checked] {
   border-color: var(--ring);
   background: var(--state-selected-bg);
   box-shadow: 0 0 0 1px var(--foreground-alpha-10);
@@ -111,28 +112,38 @@
 }
 
 .maka-question-other-trigger {
-  border-bottom: 0;
-  border-radius: var(--radius-control) var(--radius-control) 0 0;
+  min-height: 44px;
+  align-items: center;
 }
 
-.maka-question-other-answer {
-  min-width: 0;
-  display: grid;
-  border: var(--border-width-hairline) solid var(--border);
-  border-top: 0;
-  border-radius: 0 0 var(--radius-control) var(--radius-control);
-  background: var(--background);
-  transition:
-    background var(--duration-quick) var(--ease-out-strong),
-    border-color var(--duration-quick) var(--ease-out-strong),
-    box-shadow var(--duration-quick) var(--ease-out-strong);
+.maka-question-options:not(:has(.maka-question-other-trigger[data-checked])):has(.maka-question-other-input:hover)
+  .maka-question-other-trigger {
+  background: var(--state-hover-bg);
+}
+
+.maka-question-options:has(.maka-question-other-input:focus-visible) .maka-question-other-trigger {
+  box-shadow: 0 0 0 2px var(--focus-ring);
 }
 
 .maka-question-other-input {
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: var(--maka-question-other-label-width);
   width: auto;
+  height: 44px;
   min-width: 0;
-  margin: 0 var(--space-2-5) var(--space-2)
-    calc(var(--space-2-5) + 16px + var(--space-2));
+  box-sizing: border-box;
+  padding: var(--space-2) var(--space-2-5) var(--space-2) 0;
+  color: var(--foreground);
+  font-size: var(--font-size-ui);
+  line-height: var(--leading-snug);
+  caret-color: var(--foreground);
+}
+
+.maka-question-other-input::placeholder {
+  color: var(--foreground-secondary);
+  opacity: var(--opacity-muted);
 }
 
 .permissionActions.maka-question-actions {

--- a/apps/desktop/stories/ask-user-question.stories.tsx
+++ b/apps/desktop/stories/ask-user-question.stories.tsx
@@ -80,6 +80,6 @@ export const OtherAnswerSelected: Story = {
     const input = canvas.getByRole('textbox', { name: '其他答案' });
     await userEvent.click(input);
     await expect(input).toHaveFocus();
-    await expect(canvas.getByRole('radio', { name: /其他/ })).toBeChecked();
+    await expect(input.closest('.maka-question-other-field')).toHaveAttribute('data-selected');
   },
 };

--- a/apps/desktop/stories/ask-user-question.stories.tsx
+++ b/apps/desktop/stories/ask-user-question.stories.tsx
@@ -80,6 +80,8 @@ export const OtherAnswerSelected: Story = {
     const input = canvas.getByRole('textbox', { name: '其他答案' });
     await userEvent.click(input);
     await expect(input).toHaveFocus();
+    await userEvent.type(input, '分阶段发布');
+    await expect(input).toHaveValue('分阶段发布');
     await expect(input.closest('.maka-question-other-field')).toHaveAttribute('data-selected');
   },
 };

--- a/apps/desktop/stories/ask-user-question.stories.tsx
+++ b/apps/desktop/stories/ask-user-question.stories.tsx
@@ -39,6 +39,7 @@ const REQUEST: UserQuestionRequestEvent = {
 function PreviewColumn(props: {
   title: string;
   width: number;
+  request?: UserQuestionRequestEvent;
 }) {
   return (
     <div className="maka-question-review-column" style={{ width: props.width }}>
@@ -48,7 +49,7 @@ function PreviewColumn(props: {
           <div><strong>你</strong><p>请帮我确定官网上线方案。</p></div>
           <div><strong>Maka</strong><p>我需要先确认几个有明确选项的发布决策，然后会继续生成执行计划。</p></div>
         </div>
-        <UserQuestionPrompt request={REQUEST} onRespond={() => {}} onStop={() => {}} />
+        <UserQuestionPrompt request={props.request ?? REQUEST} onRespond={() => {}} onStop={() => {}} />
       </div>
     </div>
   );
@@ -61,4 +62,22 @@ export const StandardAndNarrow: Story = {
       <PreviewColumn title="窄聊天列" width={390} />
     </main>
   ),
+};
+
+export const OtherAnswerSelected: Story = {
+  render: () => (
+    <main className="maka-question-review-board">
+      <PreviewColumn
+        title="“其他”选中并直接输入"
+        width={760}
+        request={{ ...REQUEST, questions: REQUEST.questions.slice(0, 1) }}
+      />
+    </main>
+  ),
+  play: async ({ canvasElement }) => {
+    await new Promise<void>((resolve) => {
+      window.requestAnimationFrame(() => window.requestAnimationFrame(() => resolve()));
+    });
+    canvasElement.querySelector<HTMLInputElement>('.maka-question-other-input')?.focus();
+  },
 };

--- a/apps/desktop/stories/ask-user-question.stories.tsx
+++ b/apps/desktop/stories/ask-user-question.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-vite';
 import type { UserQuestionRequestEvent } from '@maka/core';
 import { UserQuestionPrompt } from '@maka/ui';
+import { expect, userEvent, within } from 'storybook/test';
 
 import './ask-user-question.css';
 
@@ -75,9 +76,10 @@ export const OtherAnswerSelected: Story = {
     </main>
   ),
   play: async ({ canvasElement }) => {
-    await new Promise<void>((resolve) => {
-      window.requestAnimationFrame(() => window.requestAnimationFrame(() => resolve()));
-    });
-    canvasElement.querySelector<HTMLInputElement>('.maka-question-other-input')?.focus();
+    const canvas = within(canvasElement);
+    const input = canvas.getByRole('textbox', { name: '其他答案' });
+    await userEvent.click(input);
+    await expect(input).toHaveFocus();
+    await expect(canvas.getByRole('radio', { name: /其他/ })).toBeChecked();
   },
 };

--- a/packages/ui/src/user-question-prompt.tsx
+++ b/packages/ui/src/user-question-prompt.tsx
@@ -29,6 +29,7 @@ export function UserQuestionPrompt(props: {
   const responsePendingRef = useRef(false);
   const activeRequestIdRef = useRef(props.request.requestId);
   const firstOptionRef = useRef<HTMLButtonElement>(null);
+  const otherInputRef = useRef<HTMLInputElement>(null);
   const mountedRef = useMountedRef();
 
   useEffect(() => {
@@ -61,6 +62,7 @@ export function UserQuestionPrompt(props: {
   function select(value: string) {
     if (value === OTHER_VALUE) {
       updateDraft(draft?.kind === 'other' ? draft : { kind: 'other', value: '' });
+      otherInputRef.current?.focus();
       return;
     }
     const optionIndex = Number(value.slice('option:'.length));
@@ -117,30 +119,35 @@ export function UserQuestionPrompt(props: {
               </span>
             </ChoiceCard>
           ))}
-          <ChoiceCard
-            className="maka-question-option"
-            value={OTHER_VALUE}
-            disabled={interactionDisabled}
+          <div
+            className="maka-question-other-option"
+            data-checked={draft?.kind === 'other' ? '' : undefined}
           >
-            <span className="maka-question-radio" aria-hidden="true" />
-            <span className="maka-question-option-copy">
-              <strong>{copy.other}</strong>
-              <small>{copy.otherDescription}</small>
-            </span>
-          </ChoiceCard>
+            <ChoiceCard
+              className="maka-question-option maka-question-other-trigger"
+              value={OTHER_VALUE}
+              disabled={interactionDisabled}
+            >
+              <span className="maka-question-radio" aria-hidden="true" />
+              <span className="maka-question-option-copy">
+                <strong>{copy.other}</strong>
+                <small>{copy.otherDescription}</small>
+              </span>
+            </ChoiceCard>
+            <Input
+              ref={otherInputRef}
+              aria-label={copy.otherAriaLabel}
+              className="maka-question-other-input"
+              placeholder={copy.otherPlaceholder}
+              value={draft?.kind === 'other' ? draft.value : ''}
+              disabled={interactionDisabled}
+              onFocus={() => {
+                if (draft?.kind !== 'other') updateDraft({ kind: 'other', value: '' });
+              }}
+              onChange={(event) => updateDraft({ kind: 'other', value: event.currentTarget.value })}
+            />
+          </div>
         </ChoiceCardGroup>
-
-        {draft?.kind === 'other' && (
-          <Input
-            autoFocus
-            aria-label={copy.otherAriaLabel}
-            className="maka-question-other-input"
-            placeholder={copy.otherPlaceholder}
-            value={draft.value}
-            disabled={interactionDisabled}
-            onChange={(event) => updateDraft({ kind: 'other', value: event.currentTarget.value })}
-          />
-        )}
 
         <footer className="permissionActions maka-question-actions">
           <Button

--- a/packages/ui/src/user-question-prompt.tsx
+++ b/packages/ui/src/user-question-prompt.tsx
@@ -98,31 +98,28 @@ export function UserQuestionPrompt(props: {
           </div>
         </header>
 
-        <ChoiceCardGroup
-          aria-label={question.question}
-          className="maka-question-options"
-          value={selectedValue}
-          onValueChange={select}
-        >
-          {question.options.map((option, optionIndex) => (
-            <ChoiceCard
-              ref={optionIndex === 0 ? firstOptionRef : undefined}
-              className="maka-question-option"
-              value={`option:${optionIndex}`}
-              key={`${optionIndex}:${option.label}`}
-              disabled={interactionDisabled}
-            >
-              <span className="maka-question-radio" aria-hidden="true" />
-              <span className="maka-question-option-copy">
-                <strong>{option.label}</strong>
-                {option.description && <small>{option.description}</small>}
-              </span>
-            </ChoiceCard>
-          ))}
-          <div
-            className="maka-question-other-option"
-            data-checked={draft?.kind === 'other' ? '' : undefined}
+        <div className="maka-question-options">
+          <ChoiceCardGroup
+            aria-label={question.question}
+            className="maka-question-choice-group"
+            value={selectedValue}
+            onValueChange={select}
           >
+            {question.options.map((option, optionIndex) => (
+              <ChoiceCard
+                ref={optionIndex === 0 ? firstOptionRef : undefined}
+                className="maka-question-option"
+                value={`option:${optionIndex}`}
+                key={`${optionIndex}:${option.label}`}
+                disabled={interactionDisabled}
+              >
+                <span className="maka-question-radio" aria-hidden="true" />
+                <span className="maka-question-option-copy">
+                  <strong>{option.label}</strong>
+                  {option.description && <small>{option.description}</small>}
+                </span>
+              </ChoiceCard>
+            ))}
             <ChoiceCard
               className="maka-question-option maka-question-other-trigger"
               value={OTHER_VALUE}
@@ -134,6 +131,8 @@ export function UserQuestionPrompt(props: {
                 <small>{copy.otherDescription}</small>
               </span>
             </ChoiceCard>
+          </ChoiceCardGroup>
+          <div className="maka-question-other-answer">
             <Input
               ref={otherInputRef}
               aria-label={copy.otherAriaLabel}
@@ -147,7 +146,7 @@ export function UserQuestionPrompt(props: {
               onChange={(event) => updateDraft({ kind: 'other', value: event.currentTarget.value })}
             />
           </div>
-        </ChoiceCardGroup>
+        </div>
 
         <footer className="permissionActions maka-question-actions">
           <Button

--- a/packages/ui/src/user-question-prompt.tsx
+++ b/packages/ui/src/user-question-prompt.tsx
@@ -128,24 +128,22 @@ export function UserQuestionPrompt(props: {
               <span className="maka-question-radio" aria-hidden="true" />
               <span className="maka-question-option-copy">
                 <strong>{copy.other}</strong>
-                <small>{copy.otherDescription}</small>
               </span>
             </ChoiceCard>
           </ChoiceCardGroup>
-          <div className="maka-question-other-answer">
-            <Input
-              ref={otherInputRef}
-              aria-label={copy.otherAriaLabel}
-              className="maka-question-other-input"
-              placeholder={copy.otherPlaceholder}
-              value={draft?.kind === 'other' ? draft.value : ''}
-              disabled={interactionDisabled}
-              onFocus={() => {
-                if (draft?.kind !== 'other') updateDraft({ kind: 'other', value: '' });
-              }}
-              onChange={(event) => updateDraft({ kind: 'other', value: event.currentTarget.value })}
-            />
-          </div>
+          <Input
+            ref={otherInputRef}
+            unstyled
+            aria-label={copy.otherAriaLabel}
+            className="maka-question-other-input"
+            placeholder={copy.otherPlaceholder}
+            value={draft?.kind === 'other' ? draft.value : ''}
+            disabled={interactionDisabled}
+            onFocus={() => {
+              if (draft?.kind !== 'other') updateDraft({ kind: 'other', value: '' });
+            }}
+            onChange={(event) => updateDraft({ kind: 'other', value: event.currentTarget.value })}
+          />
         </div>
 
         <footer className="permissionActions maka-question-actions">

--- a/packages/ui/src/user-question-prompt.tsx
+++ b/packages/ui/src/user-question-prompt.tsx
@@ -124,9 +124,6 @@ export function UserQuestionPrompt(props: {
               placeholder={copy.otherPlaceholder}
               value={draft?.kind === 'other' ? draft.value : ''}
               disabled={interactionDisabled}
-              onFocus={() => {
-                if (draft?.kind !== 'other') updateDraft({ kind: 'other', value: '' });
-              }}
               onChange={(event) => updateDraft({ kind: 'other', value: event.currentTarget.value })}
             />
           </label>

--- a/packages/ui/src/user-question-prompt.tsx
+++ b/packages/ui/src/user-question-prompt.tsx
@@ -2,6 +2,7 @@ import { useEffect, useId, useRef, useState } from 'react';
 import type { UserQuestionRequestEvent, UserQuestionResponse } from '@maka/core';
 import { ChoiceCard, ChoiceCardGroup } from './primitives/choice-card.js';
 import { Input } from './primitives/input.js';
+import { Pencil } from './icons.js';
 import { Button } from './ui.js';
 import { useMountedRef } from './use-mounted-ref.js';
 import {
@@ -12,8 +13,6 @@ import {
 } from './user-question-prompt-state.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
-
-const OTHER_VALUE = '__other__';
 
 export function UserQuestionPrompt(props: {
   request: UserQuestionRequestEvent;
@@ -29,7 +28,6 @@ export function UserQuestionPrompt(props: {
   const responsePendingRef = useRef(false);
   const activeRequestIdRef = useRef(props.request.requestId);
   const firstOptionRef = useRef<HTMLButtonElement>(null);
-  const otherInputRef = useRef<HTMLInputElement>(null);
   const mountedRef = useMountedRef();
 
   useEffect(() => {
@@ -48,9 +46,7 @@ export function UserQuestionPrompt(props: {
   const question = props.request.questions[questionIndex];
   if (!question) return null;
   const draft = drafts[questionIndex] ?? null;
-  const selectedValue = draft?.kind === 'option'
-    ? `option:${draft.optionIndex}`
-    : draft?.kind === 'other' ? OTHER_VALUE : '';
+  const selectedValue = draft?.kind === 'option' ? `option:${draft.optionIndex}` : '';
   const interactionDisabled = Boolean(props.stopPending) || responsePending;
   const canContinue = canLeaveQuestion(draft) && !interactionDisabled;
   const isLast = questionIndex === props.request.questions.length - 1;
@@ -60,11 +56,6 @@ export function UserQuestionPrompt(props: {
   }
 
   function select(value: string) {
-    if (value === OTHER_VALUE) {
-      updateDraft(draft?.kind === 'other' ? draft : { kind: 'other', value: '' });
-      otherInputRef.current?.focus();
-      return;
-    }
     const optionIndex = Number(value.slice('option:'.length));
     updateDraft({ kind: 'option', optionIndex });
   }
@@ -120,30 +111,25 @@ export function UserQuestionPrompt(props: {
                 </span>
               </ChoiceCard>
             ))}
-            <ChoiceCard
-              className="maka-question-option maka-question-other-trigger"
-              value={OTHER_VALUE}
-              disabled={interactionDisabled}
-            >
-              <span className="maka-question-radio" aria-hidden="true" />
-              <span className="maka-question-option-copy">
-                <strong>{copy.other}</strong>
-              </span>
-            </ChoiceCard>
           </ChoiceCardGroup>
-          <Input
-            ref={otherInputRef}
-            unstyled
-            aria-label={copy.otherAriaLabel}
-            className="maka-question-other-input"
-            placeholder={copy.otherPlaceholder}
-            value={draft?.kind === 'other' ? draft.value : ''}
-            disabled={interactionDisabled}
-            onFocus={() => {
-              if (draft?.kind !== 'other') updateDraft({ kind: 'other', value: '' });
-            }}
-            onChange={(event) => updateDraft({ kind: 'other', value: event.currentTarget.value })}
-          />
+          <label
+            className="maka-question-other-field"
+            data-selected={draft?.kind === 'other' ? '' : undefined}
+          >
+            <Pencil className="maka-question-other-icon" aria-hidden="true" />
+            <Input
+              unstyled
+              aria-label={copy.otherAriaLabel}
+              className="maka-question-other-input"
+              placeholder={copy.otherPlaceholder}
+              value={draft?.kind === 'other' ? draft.value : ''}
+              disabled={interactionDisabled}
+              onFocus={() => {
+                if (draft?.kind !== 'other') updateDraft({ kind: 'other', value: '' });
+              }}
+              onChange={(event) => updateDraft({ kind: 'other', value: event.currentTarget.value })}
+            />
+          </label>
         </div>
 
         <footer className="permissionActions maka-question-actions">


### PR DESCRIPTION
## Summary

- strengthen selected question cards with the governed neutral selected surface, stronger boundary, and filled radio indicator
- keep preset answers in the native `radiogroup` and make custom text a separate full-row input surface with a Pencil affordance
- preserve fixed 44px geometry before and during typing, with the entire custom-answer row acting as the input target
- keep focus as navigation: tabbing through the custom field preserves a preset answer, and only actual text input switches the draft to custom
- add Storybook and Electron E2E contracts for styling, ARIA boundaries, keyboard state transitions, zero layout movement, and full-row hit coverage

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- final desktop `test:dist`: 2830/2830
- `npm --workspace @maka/desktop run e2e -- ask-user-question.spec.ts`
- inspected selected and unselected states in Storybook at standard and 390px widths
- captured before/after evidence from the live Electron app and verified full-row hit coverage
- independent final review: no P0–P3 findings, GO

<img width="2464" height="1332" alt="image" src="https://github.com/user-attachments/assets/761e17a9-000c-4a2e-a7af-f22377da726e" />