### PR TITLE
fix(ui): restore processing tool icons

### DIFF
--- a/packages/ui/src/__tests__/processing-block.test.tsx
+++ b/packages/ui/src/__tests__/processing-block.test.tsx
@@ -52,15 +52,25 @@ describe('ProcessingBlock disclosure wiring (#1307)', () => {
     assert.doesNotMatch(markup, /data-trow="group"/);
   });
 
-  it('uses the first summarized tool kind for the collapsed block icon', () => {
-    const markup = renderToStaticMarkup(createElement(TurnView, {
+  it('keeps the collapsed block icon aligned with the first summarized tool kind', () => {
+    const commandFirst = renderToStaticMarkup(createElement(TurnView, {
       turn: turnWithTools([
         { toolUseId: 'b1', toolName: 'Bash', activityKind: 'command', status: 'completed', args: {} },
         { toolUseId: 'r1', toolName: 'Read', activityKind: 'read', status: 'completed', args: {} },
       ]),
     }));
+    assert.match(commandFirst, /lucide-terminal/);
+    assert.match(commandFirst, /运行 1 条命令，读取 1 个文件/);
+    assert.doesNotMatch(commandFirst, /lucide-file-text|lucide-cpu/);
 
-    assert.match(markup, /lucide-terminal/);
-    assert.doesNotMatch(markup, /lucide-cpu/);
+    const readFirst = renderToStaticMarkup(createElement(TurnView, {
+      turn: turnWithTools([
+        { toolUseId: 'r1', toolName: 'Read', activityKind: 'read', status: 'completed', args: {} },
+        { toolUseId: 'b1', toolName: 'Bash', activityKind: 'command', status: 'completed', args: {} },
+      ]),
+    }));
+    assert.match(readFirst, /lucide-file-text/);
+    assert.match(readFirst, /读取 1 个文件，运行 1 条命令/);
+    assert.doesNotMatch(readFirst, /lucide-terminal|lucide-cpu/);
   });
 });

--- a/packages/ui/src/__tests__/processing-block.test.tsx
+++ b/packages/ui/src/__tests__/processing-block.test.tsx
@@ -51,4 +51,16 @@ describe('ProcessingBlock disclosure wiring (#1307)', () => {
     assert.match(markup, /data-processing="block"/);
     assert.doesNotMatch(markup, /data-trow="group"/);
   });
+
+  it('uses the first summarized tool kind for the collapsed block icon', () => {
+    const markup = renderToStaticMarkup(createElement(TurnView, {
+      turn: turnWithTools([
+        { toolUseId: 'b1', toolName: 'Bash', activityKind: 'command', status: 'completed', args: {} },
+        { toolUseId: 'r1', toolName: 'Read', activityKind: 'read', status: 'completed', args: {} },
+      ]),
+    }));
+
+    assert.match(markup, /lucide-terminal/);
+    assert.doesNotMatch(markup, /lucide-cpu/);
+  });
 });

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -1,7 +1,7 @@
 import { Fragment, memo, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import { Button as BaseButton } from '@base-ui/react/button';
 import { useMountedRef } from './use-mounted-ref.js';
-import { AlertOctagon, Ban, Brain, Check, ChevronRight, Copy, Cpu, GitBranch, Info, Loader2, Pencil, RefreshCcw, Timer } from './icons.js';
+import { AlertOctagon, Ban, Brain, Check, ChevronRight, Copy, GitBranch, Info, Loader2, Pencil, RefreshCcw, Timer } from './icons.js';
 import { type ClipboardCopyPhase, useClipboardCopyFeedback } from './clipboard-feedback.js';
 import { Markdown } from './markdown.js';
 import { formatAbsoluteTimestamp, formatClockTime, turnAbortMarkerLabel } from './chat-display-helpers.js';
@@ -16,8 +16,13 @@ import { QuoteRefChip } from './quote-ref-chip.js';
 import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from './primitives/collapsible.js';
 import { Bubble, Marker, markerVariants, Message, TextShimmer } from './primitives/chat.js';
 import { Tooltip, TooltipTrigger, TooltipContent } from './primitives/tooltip.js';
-import { SETTLE_FADE, ToolTrow, useToolDisclosure } from './tool-activity.js';
-import { isProcessingRunning, processingNeedsAttention, summarizeProcessing } from './tool-activity/trow-summary.js';
+import { SETTLE_FADE, ToolKindIcon, ToolTrow, useToolDisclosure } from './tool-activity.js';
+import {
+  isProcessingRunning,
+  processingActivityKind,
+  processingNeedsAttention,
+  summarizeProcessing,
+} from './tool-activity/trow-summary.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
 
@@ -942,6 +947,7 @@ function ProcessingBlock(props: { entries: FoldedTimelineChild[] }) {
   const settled = !running;
   const settling = settled && everRunningRef.current;
   const hasError = entries.some((entry) => entry.kind === 'tools' && entry.items.some((item) => item.status === 'errored'));
+  const activityKind = processingActivityKind(entries);
   const summary = summarizeProcessing(entries, { live: running, locale });
   return (
     <Collapsible
@@ -954,7 +960,8 @@ function ProcessingBlock(props: { entries: FoldedTimelineChild[] }) {
       {/* Same row language as the tool trow / 深度思考: [16px icon] + [label] +
           hover/open chevron, one tier — hierarchy carried by color, not size. */}
       <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">
-        <Cpu
+        <ToolKindIcon
+          kind={activityKind}
           size={16}
           aria-hidden="true"
           className={cn('shrink-0', hasError ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]')}

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -370,6 +370,11 @@ const TROW_KIND_ICON: Record<TrowActivityKind, ComponentType<LucideProps>> = {
   tool: Settings,
 };
 
+export function ToolKindIcon({ kind, ...props }: LucideProps & { kind: TrowActivityKind }) {
+  const Icon = TROW_KIND_ICON[kind];
+  return <Icon {...props} />;
+}
+
 // #646 run→done seam: the one-shot settle "landing" for the group summary line.
 // Reuses the whitelisted `maka-stream-fade-in` keyframe (opacity 0→1, one-shot
 // `both`) — no new keyframe (design-406 governance) — and rides
@@ -419,7 +424,6 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   // #tool-jitter: the group icon stays on the first bucket's kind (the same
   // first-seen order the summary clauses use), not the active tool's kind — so
   // a mixed-kind group's icon doesn't flip as the active tool changes mid-run.
-  const SummaryIcon = TROW_KIND_ICON[firstPresentation.kind];
   // Multi-tool running group shows the whole-group bucket aggregation with a
   // "正在" prefix instead of the active tool's description, so the summary line
   // stops cycling through each tool's intent as tools start/finish in
@@ -432,7 +436,7 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   return (
     <Collapsible className="flex flex-col" data-trow="group" data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">
-        <SummaryIcon size={16} aria-hidden="true" className={cn('shrink-0', hasError ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]')} />
+        <ToolKindIcon kind={firstPresentation.kind} size={16} aria-hidden="true" className={cn('shrink-0', hasError ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]')} />
         {running ? (
           <TextShimmer active delayed className="min-w-0 truncate text-[length:var(--font-size-base)]">{summary}</TextShimmer>
         ) : (
@@ -478,7 +482,6 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
   const running = isToolRowRunning(item.status);
   const settled = isToolRowSettled(item.status);
   const errored = item.status === 'errored';
-  const RowIcon = TROW_KIND_ICON[presentation.kind];
   // One row language with the multi-tool summary row: a kind icon + a
   // user-language phrase, never the old status-dot + mono tool-name + status
   // word. Running shimmers the model's intent (or the friendly tool name);
@@ -490,7 +493,8 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
   return (
     <Collapsible className="flex flex-col" data-trow="row" data-status={item.status} data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">
-        <RowIcon
+        <ToolKindIcon
+          kind={presentation.kind}
           size={16}
           aria-hidden="true"
           className={cn('shrink-0', errored ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]')}

--- a/packages/ui/src/tool-activity/trow-summary.ts
+++ b/packages/ui/src/tool-activity/trow-summary.ts
@@ -159,6 +159,14 @@ function processingTools(children: readonly FoldedTimelineChild[]): ToolActivity
   return children.flatMap((child) => (child.kind === 'tools' ? child.items : []));
 }
 
+/** The first tool bucket represented by a processing block's summary and icon. */
+export function processingActivityKind(
+  children: readonly FoldedTimelineChild[],
+): TrowActivityKind {
+  const firstTool = processingTools(children)[0];
+  return firstTool ? trowActivityKind(firstTool.toolName, firstTool.activityKind) : 'tool';
+}
+
 /** True while any tool is in flight or any reasoning block is still streaming. */
 export function isProcessingRunning(children: readonly FoldedTimelineChild[]): boolean {
   return children.some((child) =>


### PR DESCRIPTION
## Summary

- restore the collapsed Processing block icon to the first tool category represented by its summary instead of a hard-coded CPU icon
- reuse one `ToolKindIcon` mapping across Processing blocks, tool groups, and individual tool rows
- add a regression test proving the icon follows first-seen tool order in both command-first and read-first blocks

## Verification

- `npm run format:check`
- `npm run lint`
- `npm --workspace @maka/ui run typecheck`
- `npm --workspace @maka/ui run test` — 231 tests passed, including the bidirectional collapsed-block icon contract

<img width="902" height="85" alt="image" src="https://github.com/user-attachments/assets/117abf39-8055-4825-887a-e853d2181ffc" />