### PR TITLE
fix(storybook): align shell composition stories with reachable app states

### DIFF
--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -5,7 +5,6 @@ import type { SessionSummary, StoredMessage } from '@maka/core';
 import { ChatView, Composer, SessionListPanel } from '@maka/ui';
 import type { ChatModelChoice } from '@maka/ui';
 import { AppShellTopbarActions, AppShellWorkspaceTopActions } from '../src/renderer/app-shell-chrome-actions';
-import { OnboardingHero } from '../src/renderer/OnboardingHero';
 
 const NOW = Date.UTC(2026, 6, 1, 9, 30, 0);
 
@@ -275,21 +274,12 @@ export const WaitingForPermission: Story = {
   ),
 };
 
+// The DAILY empty home: a returning user (sessions exist, sidebar expanded)
+// with no messages in the active chat. ChatView falls back to its built-in
+// EmptyChatHero (greeting + composer). Do NOT render OnboardingHero here —
+// app-shell only shows it when sessions.length === 0 (first run), and those
+// states are covered by Product/Onboarding. Presenting the first-run hero as
+// the daily home makes every visual comparison against this story wrong.
 export const EmptyHome: Story = {
-  render: () => (
-    <ComposedShell
-      sidebarCollapsed
-      detailChildren={
-        <div style={{ margin: '0 auto', maxWidth: 720, padding: '48px 32px', width: '100%' }}>
-          <OnboardingHero
-            state={{ kind: 'ready_empty', defaultConnectionSlug: 'anthropic-main', defaultModel: 'claude-sonnet-4-5' }}
-            onOpenSettings={noop}
-            onAddProvider={noop}
-            onBrowseProviders={noop}
-            onQuickChatSubmit={async () => true}
-          />
-        </div>
-      }
-    />
-  ),
+  render: () => <ComposedShell chat={{ messages: [] }} />,
 };

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -180,8 +180,13 @@ function ComposedShell(props: {
           onExpandSidebar={() => setCollapsed(false)}
           onCreateSession={noop}
         />
-        {!collapsed && (
-          <div className="maka-panel maka-panel-list maka-floating-panel">
+        {/* Grid is 3 columns (sidebar / handle / detail): the handle must
+            always render or the detail panel falls into the 0px handle
+            column. When collapsed, keep the sidebar mounted (production
+            hides it via the data-sidebar-state CSS) so auto-placement
+            stays aligned. */}
+        <div className="maka-panel maka-panel-list maka-floating-panel">
+          {!collapsed && (
             <SessionListPanel
               selection={{ section: 'sessions', filter: 'chats' }}
               sessions={sidebarSessions}
@@ -194,8 +199,9 @@ function ComposedShell(props: {
               onNew={noop}
               rowActions={sidebarRowActions}
             />
-          </div>
-        )}
+          )}
+        </div>
+        <div className="maka-resize-handle" aria-hidden="true" />
         <div
           className="maka-panel maka-panel-detail maka-floating-panel agents-content-area agents-parchment-paper-surface"
           data-sidebar-state={collapsed ? 'collapsed' : 'expanded'}

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -8,6 +8,14 @@ import { AppShellTopbarActions, AppShellWorkspaceTopActions } from '../src/rende
 
 const NOW = Date.UTC(2026, 6, 1, 9, 30, 0);
 
+// FIDELITY CONVENTION — every story in this file must map to an app state a
+// real user can reach, with the path noted above the story. A story that
+// composes an unreachable state (or a state that requires different app
+// data than shown) lies about the product, and every visual comparison or
+// review built on it is wrong. If the app changes so a story no longer
+// matches a reachable state, fix the story or delete it — do not keep both
+// "the app" and "the story version" of a surface alive.
+
 const meta = {
   title: 'Product/Shell Child Composition',
   parameters: {
@@ -230,14 +238,20 @@ function ComposedShell(props: {
   );
 }
 
+// Real path: returning user with session history → open a session that has
+// messages (sidebar expanded, composer ready).
 export const DefaultLayout: Story = {
   render: () => <ComposedShell />,
 };
 
+// Real path: same as DefaultLayout after the user collapses the sidebar
+// (topbar toggle).
 export const CollapsedSidebar: Story = {
   render: () => <ComposedShell sidebarCollapsed />,
 };
 
+// Real path: send a message → the turn is streaming (composer shows the
+// stop button and the streaming hint).
 export const StreamingTurn: Story = {
   render: () => (
     <ComposedShell
@@ -259,6 +273,9 @@ export const StreamingTurn: Story = {
   ),
 };
 
+// Real path: the agent calls a tool that needs approval → session enters
+// waiting_for_user, composer is disabled, the permission-mode picker is
+// locked with an explanatory reason.
 export const WaitingForPermission: Story = {
   render: () => (
     <ComposedShell
@@ -274,9 +291,9 @@ export const WaitingForPermission: Story = {
   ),
 };
 
-// The DAILY empty home: a returning user (sessions exist, sidebar expanded)
-// with no messages in the active chat. ChatView falls back to its built-in
-// EmptyChatHero (greeting + composer). Do NOT render OnboardingHero here —
+// Real path: returning user with session history → start a new chat (or
+// open a session with no messages yet). This is the DAILY empty home:
+// ChatView falls back to its built-in EmptyChatHero (greeting + composer). Do NOT render OnboardingHero here —
 // app-shell only shows it when sessions.length === 0 (first run), and those
 // states are covered by Product/Onboarding. Presenting the first-run hero as
 // the daily home makes every visual comparison against this story wrong.


### PR DESCRIPTION
## Summary

The shell-composition stories drifted from what the app actually renders, which quietly poisoned every visual comparison built on them (see #1433 for the audit that surfaced this):

1. **The detail panel rendered at zero width.** `.maka-shell-2col` is a 3-column grid (sidebar / resize handle / detail), but the story omitted the resize handle and unmounted the sidebar when collapsed. Grid auto-placement dropped the detail panel into the 0px handle column, so `ChatView` + `Composer` were invisible in every shell story.
2. **`EmptyHome` showed a state daily users never see.** It composed the first-run `OnboardingHero(ready_empty)` inside a collapsed sidebar — but `app-shell` only shows the onboarding hero when `sessions.length === 0` (first run, already covered by `Product/Onboarding`). The daily empty home is `ChatView`'s built-in `EmptyChatHero` (greeting + composer) with the sidebar expanded.
3. **Convention to prevent recurrence.** Every story in this file is now annotated with the real app path that reaches it, under a file-level fidelity convention: a story that composes an unreachable state lies about the product; fix the story or delete it.

Refs #1433 (item 6). No production code changes — Storybook only.

## Verification

- `npm run build-storybook` — passes.
- Rendered `Product/Shell Child Composition` stories locally: the detail panel now lays out in all variants, and `EmptyHome` shows the real daily empty home (`EmptyChatHero` + expanded session sidebar + full composer) in light and dark.

## Review focus

- `apps/desktop/stories/app-shell.stories.tsx` — the sidebar panel and resize handle now stay mounted to mirror the production DOM; collapsed state is expressed via `data-sidebar-state` CSS, as in the app.
