### PR TITLE
fix(storybook): match the shell story composer to production chrome

### DIFF
--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -137,7 +137,18 @@ const baseComposerProps: ComposerProps = {
   modelChoices,
   permissionMode: 'ask',
   onPermissionModeChange: noop,
-	  workspacePicker: {
+  // Fidelity: production app-shell always wires these (app-shell.tsx
+  // ~1851-1960), so the daily composer renders the ＋ menu, the Plan
+  // switch, and the Swarm switch. Omitting them here understated the
+  // persistent element count in every shell story. expertTeams stays
+  // empty — most users have none configured; the ＋ menu shows just the
+  // attachment item then, as it does for them.
+  onPickAttachments: noop,
+  planModeActive: false,
+  onPlanModeChange: noop,
+  swarmModeActive: false,
+  onSwarmModeChange: noop,
+  workspacePicker: {
 	    label: 'maka-agent',
 	    branch: 'opencode/storybook-surface-coverage',
 	    onOpen: noop,


### PR DESCRIPTION
## Summary

The shell-composition story's `baseComposerProps` omitted handlers that production `app-shell` always wires (`onPickAttachments`, `onPlanModeChange`, `onSwarmModeChange`). Because the `＋` menu and the Plan/Swarm switches only render when those props exist, the story composer showed ~4 persistent elements while the real daily composer shows 8 — quietly understating the persistent-chrome count that #1433 uses as its baseline.

The fixture now wires the same handlers (with a comment explaining the choice and why `expertTeams` stays empty), so the story renders the true production composer: ＋ · permission mode ▾ · Plan · Swarm · model picker ▾ · send · workspace row.

Refs #1433. Storybook only, no production code changes.

## Verification

- `npm run build-storybook` — passes.
- Rendered `Product/Shell Child Composition › Default Layout`: composer now shows the ＋ menu, Plan and Swarm switches alongside permission mode and the model picker (screenshot available on request).
