### PR TITLE
Prefer swarm while preserving agent judgment

### DIFF
--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -363,6 +363,8 @@ describe('AiSdkBackend deferred agent tools', () => {
 
     assert.ok(capturedTools[0]?.includes(AGENT_SWARM_TOOL_NAME));
     assert.match(capturedPrompts[0] ?? '', /Orchestration Mode: Swarm/);
+    assert.match(capturedPrompts[0] ?? '', /preferred default execution strategy/);
+    assert.match(capturedPrompts[0] ?? '', /You may continue directly/);
     assert.match(capturedPrompts[0] ?? '', /only tool in its assistant step/);
   });
 

--- a/packages/runtime/src/__tests__/swarm-mode.test.ts
+++ b/packages/runtime/src/__tests__/swarm-mode.test.ts
@@ -4,13 +4,17 @@ import { describe, test } from 'node:test';
 import { renderSwarmModePrompt } from '../swarm-mode.js';
 
 describe('Swarm Mode shared prompt', () => {
-  test('defines bounded dispatch, exclusive use, settlement, and synthesis', () => {
+  test('makes swarm the preferred default while preserving agent judgment', () => {
     const prompt = renderSwarmModePrompt();
     assert.match(prompt, /<orchestration_mode>/);
-    assert.match(prompt, /meaningful independent items/);
+    assert.match(prompt, /preferred default execution strategy/);
+    assert.match(prompt, /decide whether parallel delegation would materially improve/);
+    assert.match(prompt, /at least two meaningful independent items/);
+    assert.match(prompt, /You may continue directly/);
     assert.match(prompt, /only tool in its assistant step/);
     assert.match(prompt, /whole batch to settle/);
     assert.match(prompt, /semantically synthesize/);
-    assert.match(prompt, /Do not manufacture fake parallelism/);
+    assert.match(prompt, /Do not manufacture parallelism/);
+    assert.doesNotMatch(prompt, /routing is mandatory/);
   });
 });

--- a/packages/runtime/src/swarm-mode.ts
+++ b/packages/runtime/src/swarm-mode.ts
@@ -2,12 +2,15 @@ export function renderSwarmModePrompt(): string {
   return [
     '<orchestration_mode>',
     '# Orchestration Mode: Swarm',
-    'Use the agent_swarm tool when the work can be split into at least two meaningful independent items.',
+    'Swarm Mode is active for this session. Treat agent_swarm as the preferred default execution strategy for each new user request.',
+    'Before acting, decide whether parallel delegation would materially improve speed, quality, coverage, or independent verification.',
+    'Prefer agent_swarm when the work can be split into at least two meaningful independent items, including complementary execution and verification roles.',
+    'You may continue directly when the request is small, conversational, latency-sensitive, or cannot be usefully divided.',
     'Perform only the lightweight exploration needed to establish boundaries before dispatch.',
     'Make every item bounded and self-contained with an explicit scope, expected output, and constraints.',
     'Avoid overlapping writes. Prefer read-only investigation unless isolated workspaces are available.',
     'Call agent_swarm as the only tool in its assistant step, wait for the whole batch to settle, then verify, deduplicate, and semantically synthesize the results.',
-    'Do not manufacture fake parallelism. If the task cannot be meaningfully split, explain why and continue normally.',
+    'Do not manufacture parallelism or create duplicate busywork merely because Swarm Mode is enabled.',
     '</orchestration_mode>',
   ].join('\n');
 }


### PR DESCRIPTION
## What changed

- Make agent_swarm the preferred default execution strategy while Desktop Swarm Mode is active.
- Preserve lead-agent judgment for small, conversational, latency-sensitive, or indivisible requests.
- Discourage manufactured parallelism and duplicate busywork.
- Strengthen shared prompt and backend integration tests.

## Why

The previous prompt did not give delegation enough priority. Making Swarm mandatory would create low-value work. This change prefers Swarm while allowing direct execution when the lead agent judges it better.

## User impact

With the Desktop Swarm toggle enabled, Maka actively considers and prefers swarm delegation on every request without forcing artificial fan-out.

## Validation

- Biome check on the three changed files
- @maka/runtime build
- Focused runtime tests: 14 passed
- @maka/desktop build:main
- Desktop Swarm host contract tests: 3 passed