### PR TITLE
refactor(runtime): dedupe isLikelySandboxDenial into sandbox/detect l…

### DIFF
--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -16,6 +16,7 @@ import { assertAdditionalPermissionProposal } from '../additional-permissions.js
 import { SandboxManager } from '../sandbox/sandbox-manager.js';
 import { LinuxBubblewrapBackend } from '../sandbox/linux-sandbox.js';
 import { MacosSeatbeltBackend } from '../sandbox/macos-seatbelt.js';
+import { SandboxCommandError } from '../sandbox/errors.js';
 import { sandboxEscalationCommandHash } from '../sandbox-escalation.js';
 import type { ShellRunLauncher } from '../shell-tools.js';
 import {
@@ -1234,6 +1235,53 @@ describe('builtin Bash streaming output', () => {
     expect(err?.code).toBe(124);
     expect(err?.stdout).toBe('out-before');
     expect(err?.stderr).toBe('err-before');
+  });
+});
+
+describe('builtin Bash sandbox denial classification', () => {
+  test('throws SandboxCommandError when a sandboxed command emits a denial message', async () => {
+    const cwd = await mkdtemp(join(tmpdir(), 'maka-bash-sandbox-denial-'));
+    try {
+      const executor = fakeExecutor({
+        exec: async () => ({
+          exitCode: 1,
+          stdout: '',
+          stderr: 'Operation not permitted',
+          timedOut: false,
+          aborted: false,
+        }),
+      });
+      const bash = buildBuiltinTools({
+        executor,
+        permissionProfile: createWorkspaceWritePermissionProfile(),
+        sandboxManager: new SandboxManager([new MacosSeatbeltBackend()]),
+        sandboxPlatform: 'darwin',
+      }).find((candidate) => candidate.name === 'Bash');
+      if (!bash) throw new Error('Bash tool missing');
+
+      let err: unknown = null;
+      try {
+        await bash.impl(
+          { command: 'rm -rf /', timeout_ms: 5_000 },
+          {
+            sessionId: 'session-1',
+            turnId: 'turn-1',
+            cwd,
+            toolCallId: 'tool-1',
+            abortSignal: new AbortController().signal,
+            emitOutput: () => {},
+          },
+        );
+      } catch (e: unknown) {
+        err = e;
+      }
+
+      assert.ok(err instanceof SandboxCommandError, 'expected a SandboxCommandError');
+      assert.equal((err as SandboxCommandError).reason, 'sandbox_denial');
+      assert.equal((err as SandboxCommandError).recoverable, true);
+    } finally {
+      await rm(cwd, { recursive: true, force: true });
+    }
   });
 });
 

--- a/packages/runtime/src/__tests__/sandbox-detect.test.ts
+++ b/packages/runtime/src/__tests__/sandbox-detect.test.ts
@@ -1,0 +1,148 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+
+import { isLikelySandboxDenial } from '../sandbox/detect.js';
+
+describe('isLikelySandboxDenial regex branches', () => {
+  test('matches "operation not permitted" branch', () => {
+    assert.equal(
+      isLikelySandboxDenial({ stdout: '', stderr: 'Operation not permitted', sandboxed: true }),
+      true,
+    );
+  });
+
+  test('matches "sandbox-exec" branch', () => {
+    assert.equal(
+      isLikelySandboxDenial({
+        stdout: '',
+        stderr: 'launching sandbox-exec profile',
+        sandboxed: true,
+      }),
+      true,
+    );
+  });
+
+  test('matches "sandbox...denied" branch', () => {
+    assert.equal(
+      isLikelySandboxDenial({
+        stdout: '',
+        stderr: 'sandbox-denied: write outside',
+        sandboxed: true,
+      }),
+      true,
+    );
+  });
+
+  test('matches "sandboxed ... denied" variant', () => {
+    assert.equal(
+      isLikelySandboxDenial({
+        stdout: '',
+        stderr: 'The operation was sandboxed and denied by policy',
+        sandboxed: true,
+      }),
+      true,
+    );
+  });
+});
+
+describe('isLikelySandboxDenial stdout vs stderr', () => {
+  test('detects denial message in stdout (not just stderr)', () => {
+    assert.equal(
+      isLikelySandboxDenial({ stdout: 'Operation not permitted', stderr: '', sandboxed: true }),
+      true,
+    );
+  });
+
+  test('scans the combined stderr+stdout text', () => {
+    assert.equal(
+      isLikelySandboxDenial({ stdout: 'sandbox denied', stderr: '', sandboxed: true }),
+      true,
+    );
+  });
+});
+
+describe('isLikelySandboxDenial near-misses', () => {
+  test('returns false when sandboxed is false, even if text matches', () => {
+    assert.equal(
+      isLikelySandboxDenial({ stdout: '', stderr: 'Operation not permitted', sandboxed: false }),
+      false,
+    );
+  });
+
+  test('returns false for "operation permitted" (missing "not")', () => {
+    assert.equal(
+      isLikelySandboxDenial({ stdout: '', stderr: 'operation permitted', sandboxed: true }),
+      false,
+    );
+  });
+
+  test('returns false for "sandbox" alone (no deny/denied)', () => {
+    assert.equal(
+      isLikelySandboxDenial({
+        stdout: '',
+        stderr: 'running in sandbox environment',
+        sandboxed: true,
+      }),
+      false,
+    );
+  });
+
+  test('returns false for "permission denied" (no sandbox prefix)', () => {
+    assert.equal(
+      isLikelySandboxDenial({ stdout: '', stderr: 'permission denied', sandboxed: true }),
+      false,
+    );
+  });
+
+  test('returns false for "sandbox denial" (denial != deny/denied)', () => {
+    assert.equal(
+      isLikelySandboxDenial({
+        stdout: '',
+        stderr: 'sandbox denial detected',
+        sandboxed: true,
+      }),
+      false,
+    );
+  });
+
+  test('returns false for plain text without any sandbox signal', () => {
+    assert.equal(
+      isLikelySandboxDenial({
+        stdout: 'command not found',
+        stderr: 'exit code 127',
+        sandboxed: true,
+      }),
+      false,
+    );
+  });
+
+  test('returns false for denial split across stdout/stderr by a newline', () => {
+    // The predicate scans `${stderr}\n${stdout}`; regex branch 3 uses [^\n]*
+    // which cannot cross a newline, so "sandbox" and "denied" must be in the
+    // same field to match.
+    assert.equal(
+      isLikelySandboxDenial({ stdout: 'then denied', stderr: 'sandbox setup', sandboxed: true }),
+      false,
+    );
+  });
+});
+
+describe('isLikelySandboxDenial case-insensitive', () => {
+  test('matches uppercase "OPERATION NOT PERMITTED"', () => {
+    assert.equal(
+      isLikelySandboxDenial({
+        stdout: '',
+        stderr: 'OPERATION NOT PERMITTED',
+        sandboxed: true,
+      }),
+      true,
+    );
+  });
+
+  test('matches mixed case "Sandbox-Denied"', () => {
+    assert.equal(
+      isLikelySandboxDenial({ stdout: '', stderr: 'Sandbox-Denied', sandboxed: true }),
+      true,
+    );
+  });
+});

--- a/packages/runtime/src/__tests__/shell-run-tool-result.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-tool-result.test.ts
@@ -98,6 +98,65 @@ describe('shell run sandbox denial projection', () => {
   });
 });
 
+describe('PTY flattening for sandbox denial', () => {
+  test('detects denial in PTY scrollback field', () => {
+    const record: ShellRunRecord = {
+      ...failedShellRun(),
+      output: ptyOutput({ scrollback: 'Operation not permitted', screen: '' }),
+      sandboxExecution: { type: 'macos-seatbelt', enforced: true },
+    };
+    assert.equal(terminalContent(record).sandboxDenial?.likely, true);
+  });
+
+  test('detects denial in PTY screen field', () => {
+    const record: ShellRunRecord = {
+      ...failedShellRun(),
+      output: ptyOutput({ scrollback: '', screen: 'sandbox-denied: write' }),
+      sandboxExecution: { type: 'macos-seatbelt', enforced: true },
+    };
+    assert.equal(terminalContent(record).sandboxDenial?.likely, true);
+  });
+
+  test('detects denial in PTY lastAlternateScreen field', () => {
+    const record: ShellRunRecord = {
+      ...failedShellRun(),
+      output: ptyOutput({
+        scrollback: '',
+        screen: '',
+        lastAlternateScreen: 'launching sandbox-exec profile',
+      }),
+      sandboxExecution: { type: 'macos-seatbelt', enforced: true },
+    };
+    assert.equal(terminalContent(record).sandboxDenial?.likely, true);
+  });
+
+  test('does NOT detect denial split across PTY fields (regex cannot cross newline)', () => {
+    // flattenSandboxDenialText joins scrollback + "\n" + screen + "\n" + lastAlt;
+    // the regex branch "sandbox(?:ed)?[^\n]*den(?:y|ied)" uses [^\n]* which cannot
+    // span the newline separator, so "sandbox" in scrollback and "denied" in screen
+    // must NOT be matched together.
+    const record: ShellRunRecord = {
+      ...failedShellRun(),
+      output: ptyOutput({
+        scrollback: 'sandbox setup',
+        screen: 'then denied',
+        lastAlternateScreen: undefined,
+      }),
+      sandboxExecution: { type: 'macos-seatbelt', enforced: true },
+    };
+    assert.equal(terminalContent(record).sandboxDenial, undefined);
+  });
+
+  test('does not flag PTY output when sandbox is not enforced', () => {
+    const record: ShellRunRecord = {
+      ...failedShellRun(),
+      output: ptyOutput({ screen: 'Operation not permitted' }),
+      sandboxExecution: { type: 'macos-seatbelt', enforced: false },
+    };
+    assert.equal(terminalContent(record).sandboxDenial, undefined);
+  });
+});
+
 function failedShellRun(): ShellRunRecord {
   return {
     shellRunId: 'shell-1',

--- a/packages/runtime/src/__tests__/shell-tools.test.ts
+++ b/packages/runtime/src/__tests__/shell-tools.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'node:test';
 import {
   buildLocalForegroundBashTool,
   buildManagedBashTool,
+  shapeTerminalResult,
   type ShellRunLauncher,
 } from '../shell-tools.js';
 import type { ShellPlan } from '../shell-detect.js';
@@ -86,6 +87,58 @@ describe('Bash tool shell is threaded through to execution, not just the descrip
     const tool = buildManagedBashTool(controller, { shell: pwshPlan });
     await tool.impl({ command: 'echo hi', run_in_background: true }, fakeToolContext());
     assert.deepEqual((captured[0] as { shell?: unknown }).shell, pwshPlan);
+  });
+});
+
+describe('shapeTerminalResult sandbox denial projection', () => {
+  test('surfaces sandboxDenial when a sandboxed command fails with a denial message', () => {
+    const result = shapeTerminalResult({
+      cwd: '/ws',
+      command: 'rm -rf /',
+      result: {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'Operation not permitted',
+        sandboxed: true,
+        sandboxType: 'macos-seatbelt',
+      },
+    });
+    assert.deepEqual(result.sandboxDenial, {
+      likely: true,
+      backend: 'macos-seatbelt',
+      recovery: 'require_escalated',
+    });
+  });
+
+  test('omits sandboxDenial when sandboxed is false', () => {
+    const result = shapeTerminalResult({
+      cwd: '/ws',
+      command: 'ls /no-such-dir',
+      result: {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'Operation not permitted',
+        sandboxed: false,
+      },
+    });
+    assert.equal(result.sandboxDenial, undefined);
+  });
+
+  test('omits sandboxDenial when sandboxed field is absent (BoundedShellResult shape)', () => {
+    const result = shapeTerminalResult({
+      cwd: '/ws',
+      command: 'ls',
+      result: {
+        exitCode: 1,
+        stdout: '',
+        stderr: 'Operation not permitted',
+        stdoutTruncated: false,
+        stderrTruncated: false,
+        timedOut: false,
+        aborted: false,
+      },
+    });
+    assert.equal(result.sandboxDenial, undefined);
   });
 });
 

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -46,6 +46,7 @@ export type { MakaTool, MakaToolContext };
 import { withFileWriteLock } from './file-write-lock.js';
 import type { SandboxManager } from './sandbox/sandbox-manager.js';
 import { SandboxCommandError } from './sandbox/errors.js';
+import { isLikelySandboxDenial } from './sandbox/detect.js';
 import { linuxExecutableRoots } from './sandbox/linux-sandbox.js';
 import type { SandboxPlatform, SandboxType } from './sandbox/types.js';
 import type { ChildFdInput } from './child-fd-input.js';
@@ -1057,7 +1058,11 @@ function terminalError(
   },
   code: number,
 ): Error {
-  const sandboxDenied = isLikelySandboxDenial(result);
+  const sandboxDenied = isLikelySandboxDenial({
+    stdout: result.stdout,
+    stderr: result.stderr,
+    sandboxed: result.sandboxed === true,
+  });
   const error = sandboxDenied
     ? new SandboxCommandError({
         domain: 'command',
@@ -1080,15 +1085,6 @@ function terminalError(
     ...(sandboxDenied ? { reason: 'sandbox_denial', recoverable: true } : {}),
   });
   return error;
-}
-
-function isLikelySandboxDenial(
-  result: Pick<WorkspaceExecResult, 'stdout' | 'stderr'> & { sandboxed?: boolean },
-): boolean {
-  if (result.sandboxed !== true) return false;
-  return /operation not permitted|sandbox-exec|sandbox(?:ed)?[^\n]*den(?:y|ied)/i.test(
-    `${result.stderr}\n${result.stdout}`,
-  );
 }
 
 function assertRelativeGlobPattern(pattern: string): void {

--- a/packages/runtime/src/sandbox/detect.ts
+++ b/packages/runtime/src/sandbox/detect.ts
@@ -1,0 +1,11 @@
+const SANDBOX_DENIAL_PATTERN =
+  /operation not permitted|sandbox-exec|sandbox(?:ed)?[^\n]*den(?:y|ied)/i;
+
+export function isLikelySandboxDenial(input: {
+  stdout: string;
+  stderr: string;
+  sandboxed: boolean;
+}): boolean {
+  if (!input.sandboxed) return false;
+  return SANDBOX_DENIAL_PATTERN.test(`${input.stderr}\n${input.stdout}`);
+}

--- a/packages/runtime/src/shell-run-tool-result.ts
+++ b/packages/runtime/src/shell-run-tool-result.ts
@@ -13,6 +13,7 @@ import type {
 
 import { shellRunResourceRef, type ShellRunWriteInput } from './shell-run-contract.js';
 import { truncateToolOutput } from './tool-output.js';
+import { isLikelySandboxDenial } from './sandbox/detect.js';
 
 export const PTY_MODEL_TEXT_BUDGET_BYTES = 50 * 1024;
 
@@ -152,12 +153,9 @@ function sandboxDenialForRecord(record: ShellRunRecord):
       recovery: 'require_escalated';
     }
   | undefined {
-  if (
-    record.status !== 'failed' ||
-    record.sandboxExecution?.enforced !== true ||
-    !isLikelySandboxDenialOutput(record.output)
-  )
-    return undefined;
+  if (record.status !== 'failed' || record.sandboxExecution?.enforced !== true) return undefined;
+  const flat = flattenSandboxDenialText(record.output);
+  if (!isLikelySandboxDenial({ ...flat, sandboxed: true })) return undefined;
   const backend = record.sandboxExecution.type;
   return {
     likely: true,
@@ -166,12 +164,15 @@ function sandboxDenialForRecord(record: ShellRunRecord):
   };
 }
 
-function isLikelySandboxDenialOutput(output: ShellOutput): boolean {
-  const text =
-    output.mode === 'pipes'
-      ? `${output.stderr}\n${output.stdout}`
-      : `${output.scrollback}\n${output.screen}\n${output.lastAlternateScreen ?? ''}`;
-  return /operation not permitted|sandbox-exec|sandbox(?:ed)?[^\n]*den(?:y|ied)/i.test(text);
+function flattenSandboxDenialText(output: ShellOutput): {
+  stdout: string;
+  stderr: string;
+} {
+  if (output.mode === 'pipes') return { stdout: output.stdout, stderr: output.stderr };
+  return {
+    stdout: `${output.scrollback}\n${output.screen}\n${output.lastAlternateScreen ?? ''}`,
+    stderr: '',
+  };
 }
 
 function projectShellOutputForModel(output: ShellOutput): ShellOutput {

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -14,6 +14,7 @@ import type {
   SandboxEscalationPlannerContext,
 } from './sandbox-escalation.js';
 import type { SandboxType } from './sandbox/types.js';
+import { isLikelySandboxDenial } from './sandbox/detect.js';
 import { runShellWithBoundedTail, type BoundedShellResult } from './shell-exec.js';
 import { bashToolShellGuidance, defaultShellPlan, type ShellPlan } from './shell-detect.js';
 import { truncateToolOutput } from './tool-output.js';
@@ -382,7 +383,11 @@ export function shapeTerminalResult(input: {
       stderrTruncated: Boolean(input.result.stderrTruncated) || stderrView.truncated,
       redacted: stdout !== input.result.stdout || stderr !== input.result.stderr,
     },
-    ...(isLikelySandboxDenial(input.result)
+    ...(isLikelySandboxDenial({
+      stdout: input.result.stdout,
+      stderr: input.result.stderr,
+      sandboxed: 'sandboxed' in input.result && input.result.sandboxed === true,
+    })
       ? {
           sandboxDenial: {
             likely: true,
@@ -395,13 +400,6 @@ export function shapeTerminalResult(input: {
         }
       : {}),
   };
-}
-
-function isLikelySandboxDenial(result: ForegroundBashResult | BoundedShellResult): boolean {
-  if (!('sandboxed' in result) || result.sandboxed !== true) return false;
-  return /operation not permitted|sandbox-exec|sandbox(?:ed)?[^\n]*den(?:y|ied)/i.test(
-    `${result.stderr}\n${result.stdout}`,
-  );
 }
 
 function terminalStatus(


### PR DESCRIPTION
## Summary

Dedupe the `isLikelySandboxDenial` predicate — three copies (shell-tools.ts, builtin-tools.ts, and a PTY-aware variant in shell-run-tool-result.ts) shared the same regex but differed in input shape. Extracts one primitive `isLikelySandboxDenial({ stdout, stderr, sandboxed })` into a new `sandbox/detect.ts` leaf, so the regex and the sandboxed-gating live in exactly one place. Addresses the "Sandbox-denial predicate" slice from #1404.

The three call sites keep their own input shaping, since that's where their scenarios genuinely differ:

| File | `sandboxed` source | text source |
|---|---|---|
| `shell-tools.ts` | `'sandboxed' in result && result.sandboxed === true` | `result.stdout` / `result.stderr` (BoundedShellResult lacks the field, so the `in` narrowing stays at the call site) |
| `builtin-tools.ts` | `result.sandboxed === true` | `result.stdout` / `result.stderr` |
| `shell-run-tool-result.ts` | hard-coded `true` (wrapper already gated on `sandboxExecution.enforced`) | new local `flattenSandboxDenialText(output)` — preserves the original pipes-vs-pty flattening (pty: `scrollback` + `screen` + `lastAlternateScreen` → stdout) |

Behavior-neutral: the regex is byte-identical to all three originals, and the PTY-flattened text matches the original variant's output (leading `\n` from the empty stderr doesn't affect regex matching). No public surface change — all three call sites are internal, `isLikelySandboxDenial` is an internal leaf consumed only by these three files (not re-exported from `sandbox/index.ts` barrel, since `runtime/index.ts` doesn't expose it externally).

## Verification

- `npm --workspace @maka/runtime run typecheck` — clean
- `npm --workspace @maka/runtime test` — **2403 pass, 0 fail, 7 skipped** (full suite, including the `shell-run-tool-result` sandbox-denial projection tests that cover the variant call site)
- `npm run lint` — clean (2041 files)
- `npm run format:check` — clean (1019 files)
- `git diff origin/main...HEAD --check` — no whitespace errors

## Review focus

- **The variant (`shell-run-tool-result.ts`)** is the only non-mechanical change. Confirm `flattenSandboxDenialText` preserves the original PTY text shape — the pty branch stuffs `scrollback` + `screen` + `lastAlternateScreen` into the `stdout` slot and leaves `stderr` empty, so the primitive's `${stderr}\n${stdout}` reconstructs the original `${scrollback}\n${screen}\n${lastAlternateScreen}` (with a leading `\n` that doesn't affect the regex).
- **`sandboxed` resolution lives at each call site**, not in the primitive — this is deliberate (each scenario computes "is this a sandboxed run" from different data: a `sandboxed?` field, a `'sandboxed' in result` narrowing, or an upstream `sandboxExecution.enforced` gate). Confirm the three resolutions are equivalent to the originals.
