### PR TITLE
fix(ui): flatten tools inside processing blocks

### DIFF
--- a/packages/ui/src/__tests__/processing-block.test.tsx
+++ b/packages/ui/src/__tests__/processing-block.test.tsx
@@ -29,17 +29,19 @@ function turnWithTools(tools: ToolActivityItem[]): TurnViewModel {
 }
 
 describe('ProcessingBlock disclosure wiring (#1307)', () => {
-  it('a waiting_permission tool inside the block forces the disclosure open', () => {
+  it('opens for waiting permission without nesting a duplicate tool-group disclosure', () => {
     const markup = renderToStaticMarkup(createElement(TurnView, {
       turn: turnWithTools([
+        { toolUseId: 'b1', toolName: 'Bash', activityKind: 'command', status: 'completed', args: {} },
         { toolUseId: 'w1', toolName: 'Write', activityKind: 'edit', status: 'waiting_permission', args: {}, intent: '写入配置' },
       ]),
     }));
-    // The folded run renders as one Processing block whose panel is OPEN —
-    // the nested tool trow (and thereby the actionable permission row) is in
-    // the static markup, not hidden behind the collapsed summary.
+    // Processing owns the group summary. Its expanded panel exposes each tool
+    // row directly, so the hierarchy is Processing → tool rather than the
+    // duplicate Processing → tool group → tool seen in the regression.
     assert.match(markup, /data-processing="block"/);
-    assert.match(markup, /data-trow="group"/);
+    assert.doesNotMatch(markup, /data-trow="group"/);
+    assert.equal((markup.match(/data-trow="row"/g) ?? []).length, 2);
   });
 
   it('ordinary settled work stays collapsed (no panel content in static markup)', () => {

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -929,8 +929,9 @@ function TurnTimelineEntry(props: {
  * destructive; folded reasoning is not counted) once the turn ends. A
  * `waiting_permission` prompt inside forces the block open (trowNeedsAttention);
  * an errored tool stays collapsed with its failure count on the summary line.
- * The expanded panel replays the full timeline — the SAME 深度思考 disclosures
- * and tool trows, just nested one indent in — so nothing is lost, only folded.
+ * The expanded panel preserves the full timeline with the SAME 深度思考
+ * disclosures and direct tool rows. Processing already owns the group summary,
+ * so nesting another tool-group disclosure would duplicate that layer.
  */
 function ProcessingBlock(props: { entries: FoldedTimelineChild[] }) {
   const locale = useUiLocale();
@@ -979,9 +980,13 @@ function ProcessingBlock(props: { entries: FoldedTimelineChild[] }) {
       </CollapsibleTrigger>
       <CollapsiblePanel>
         <div className="mt-0.5 ml-2 flex flex-col gap-0.5 border-l border-[var(--border)] pl-2.5">
-          {entries.map((entry, index) => (
-            <TurnTimelineEntry key={timelineEntryKey(entry, index)} item={entry} />
-          ))}
+          {entries.map((entry, index) =>
+            entry.kind === 'tools' ? (
+              <ToolTrow key={timelineEntryKey(entry, index)} items={entry.items} variant="rows" />
+            ) : (
+              <TurnTimelineEntry key={timelineEntryKey(entry, index)} item={entry} />
+            ),
+          )}
         </div>
       </CollapsiblePanel>
     </Collapsible>

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -392,9 +392,20 @@ export const SETTLE_FADE = '[animation:maka-stream-fade-in_var(--duration-emphas
  * boxed "工具调用 N" card stack inside a turn. The summary disclosure is the
  * stable root for both one and many tools, so a second call appends inside the
  * same component instead of replacing an expanded row with a collapsed group.
+ * A parent Processing disclosure can request direct rows because it already
+ * owns the group summary; this avoids rendering the same summary twice.
  */
-export function ToolTrow({ items }: { items: ToolActivityItem[] }) {
+export function ToolTrow({
+  items,
+  variant = 'group',
+}: {
+  items: ToolActivityItem[];
+  variant?: 'group' | 'rows';
+}) {
   if (items.length === 0) return null;
+  if (variant === 'rows') {
+    return items.map((item) => <ToolTrowRow key={item.toolUseId} item={item} />);
+  }
   return <ToolTrowGroup items={items} />;
 }
 


### PR DESCRIPTION
## Summary

Flatten tool rows inside expanded Processing blocks so the disclosure hierarchy is `Processing → tool` instead of the duplicated `Processing → tool group → tool` structure. Standalone ToolTrow grouping remains unchanged.

## Verification

- `npm --workspace @maka/ui test` — 231 tests passed
- `npm run build` — passed
- `npm run typecheck` — passed after building workspace dependencies
- Added an SSR regression covering an expanded multi-tool Processing block and asserting that it renders direct tool rows without a nested group disclosure

## Root cause

The Processing block reused the complete grouped ToolTrow when expanded, even though Processing already owned the aggregate summary. Existing coverage explicitly expected the nested group and exercised only one tool in the expanded state; the multi-tool Storybook case stayed collapsed, so the third disclosure level was not visible.
