### PR TITLE
feat(ui): move Plan/Swarm switches into the composer ＋ menu

### DIFF
--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -44,24 +44,6 @@
   flex: 0 0 auto;
 }
 
-.maka-composer-plan-mode-control,
-.maka-composer-swarm-mode-control {
-  height: 26px;
-  display: inline-flex;
-  align-items: center;
-  gap: var(--space-1-5);
-  padding: 0 var(--space-0-5) 0 var(--space-1);
-  color: var(--foreground-secondary);
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-medium);
-  white-space: nowrap;
-}
-
-.maka-composer-plan-mode-label,
-.maka-composer-swarm-mode-label {
-  line-height: var(--leading-none);
-}
-
 .maka-composer-right-controls {
   flex: 0 0 auto;
   justify-content: flex-end;

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -44,6 +44,35 @@
   flex: 0 0 auto;
 }
 
+/* #1433: active-mode mark (Plan/Swarm) — the same quiet-text-button
+   language as the permission select beside it, minus the chevron (it
+   cannot drop down; clicking turns the mode off). No chip wash, no dot:
+   weight and color alone carry the "this is on" signal. */
+.maka-composer-mode-indicator {
+  display: inline-flex;
+  align-items: center;
+  min-height: var(--h-control-sm);
+  padding: 0 var(--space-1);
+  border: 0;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--foreground);
+  font-size: var(--font-size-ui);
+  font-weight: var(--font-weight-semibold);
+  line-height: var(--leading-none);
+  white-space: nowrap;
+  transition: background-color var(--duration-base) var(--ease-out-strong);
+}
+
+.maka-composer-mode-indicator:hover:not(:disabled) {
+  background: var(--state-hover-bg);
+}
+
+.maka-composer-mode-indicator:disabled {
+  cursor: not-allowed;
+  color: var(--muted-foreground);
+}
+
 .maka-composer-right-controls {
   flex: 0 0 auto;
   justify-content: flex-end;

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -302,6 +302,12 @@ export const WaitingForPermission: Story = {
   ),
 };
 
+// Real path: enable Plan mode (＋ menu) → while the mode is on, the composer
+// shows a quiet Plan indicator next to the permission select (#1433).
+export const PlanModeActive: Story = {
+  render: () => <ComposedShell composer={{ planModeActive: true }} />,
+};
+
 // Real path: returning user with session history → start a new chat (or
 // open a session with no messages yet). This is the DAILY empty home:
 // ChatView falls back to its built-in EmptyChatHero (greeting + composer). Do NOT render OnboardingHero here —

--- a/packages/ui/src/__tests__/conversation-localization.test.tsx
+++ b/packages/ui/src/__tests__/conversation-localization.test.tsx
@@ -107,49 +107,30 @@ describe('localized conversation journey', () => {
     assert.match(en, /Go to model settings/);
   });
 
-  it('renders the compact Plan Mode switch only when the session action is available', () => {
-    const inactive = render(
+  it('keeps Plan Mode out of the toolbar and reachable from the ＋ menu (#1433)', () => {
+    const markup = render(
       'zh',
-      <Composer onSend={() => {}} onStop={() => {}} onPlanModeChange={() => {}} />,
+      <Composer onSend={() => {}} onStop={() => {}} onPickAttachments={() => {}} onPlanModeChange={() => {}} />,
     );
-    assert.match(inactive, /maka-composer-plan-mode-control/);
-    assert.match(inactive, />Plan</);
-    assert.match(inactive, /role="switch"/);
-    assert.match(inactive, /aria-label="开启 Plan Mode"/);
-    assert.match(inactive, /aria-checked="false"/);
-
-    const active = render(
-      'en',
-      <Composer
-        onSend={() => {}}
-        onStop={() => {}}
-        planModeActive
-        onPlanModeChange={() => {}}
-      />,
-    );
-    assert.match(active, /aria-label="Disable Plan Mode"/);
-    assert.match(active, /aria-checked="true"/);
-
-    const unavailable = render('zh', <Composer onSend={() => {}} onStop={() => {}} />);
-    assert.doesNotMatch(unavailable, /maka-composer-plan-mode-control/);
+    // The toolbar no longer carries a standalone Plan switch…
+    assert.doesNotMatch(markup, /maka-composer-plan-mode-control/);
+    // …but the ＋ trigger is present so the mode stays reachable from the menu.
+    assert.match(markup, /aria-label="添加"/);
   });
 
-  it('renders the compact Swarm Mode switch with localized state labels', () => {
-    const inactive = render(
-      'zh',
-      <Composer onSend={() => {}} onStop={() => {}} onSwarmModeChange={() => {}} />,
-    );
-    assert.match(inactive, /maka-composer-swarm-mode-control/);
-    assert.match(inactive, />Swarm</);
-    assert.match(inactive, /aria-label="开启 Swarm Mode"/);
-    assert.match(inactive, /aria-checked="false"/);
+  it('keeps the ＋ menu available when only mode switches are wired', () => {
+    const markup = render('zh', <Composer onSend={() => {}} onStop={() => {}} onPlanModeChange={() => {}} />);
+    assert.match(markup, /aria-label="添加"/);
+    assert.doesNotMatch(markup, /maka-composer-plan-mode-control/);
+  });
 
-    const active = render(
-      'en',
-      <Composer onSend={() => {}} onStop={() => {}} swarmModeActive onSwarmModeChange={() => {}} />,
+  it('keeps Swarm Mode out of the toolbar (#1433)', () => {
+    const markup = render(
+      'zh',
+      <Composer onSend={() => {}} onStop={() => {}} onPickAttachments={() => {}} onSwarmModeChange={() => {}} />,
     );
-    assert.match(active, /aria-label="Disable Swarm Mode"/);
-    assert.match(active, /aria-checked="true"/);
+    assert.doesNotMatch(markup, /maka-composer-swarm-mode-control/);
+    assert.match(markup, /aria-label="添加"/);
   });
 
   it('localizes permission and question chrome while preserving raw values', () => {

--- a/packages/ui/src/__tests__/conversation-localization.test.tsx
+++ b/packages/ui/src/__tests__/conversation-localization.test.tsx
@@ -124,6 +124,39 @@ describe('localized conversation journey', () => {
     assert.doesNotMatch(markup, /maka-composer-plan-mode-control/);
   });
 
+  it('shows a quiet Plan indicator next to permission mode only while Plan is active', () => {
+    const on = render(
+      'zh',
+      <Composer onSend={() => {}} onStop={() => {}} planModeActive onPlanModeChange={() => {}} />,
+    );
+    assert.match(on, /maka-composer-mode-indicator/);
+    assert.match(on, /Plan 模式已启用/);
+    // Same visual language as the permission select: a quiet text BUTTON
+    // (no chevron — it cannot drop down); clicking turns the mode off.
+    assert.match(on, /<button[^>]*maka-composer-mode-indicator/);
+
+    const off = render('zh', <Composer onSend={() => {}} onStop={() => {}} onPlanModeChange={() => {}} />);
+    assert.doesNotMatch(off, /maka-composer-mode-indicator/);
+  });
+
+  it('keeps the active-mode indicator visible but disabled with reason while streaming', () => {
+    const markup = render(
+      'zh',
+      <Composer
+        onSend={() => {}}
+        onStop={() => {}}
+        streaming
+        swarmModeActive
+        swarmModeDisabledReason="等待流式输出结束"
+        onSwarmModeChange={() => {}}
+      />,
+    );
+    assert.match(markup, /maka-composer-mode-indicator/);
+    assert.match(markup, /Swarm 模式已启用/);
+    assert.match(markup, /disabled=""/);
+    assert.match(markup, /等待流式输出结束/);
+  });
+
   it('keeps Swarm Mode out of the toolbar (#1433)', () => {
     const markup = render(
       'zh',

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -895,6 +895,56 @@ export const Composer = forwardRef<
                 disabledReason={props.permissionModeDisabledReason}
               />
             ) : null}
+            {/* #1433: active-mode indicators. The Plan/Swarm toggles live in
+                the ＋ menu (subtraction), so an ON mode would otherwise be
+                invisible — including while streaming, where the ＋ menu is
+                hidden. The indicator uses the same quiet-text-button language
+                as the permission select next to it, WITHOUT a chevron: it
+                cannot drop down. Clicking turns the mode off directly; while
+                streaming (or otherwise disabled) it stays visible but
+                disabled with the reason as its title. */}
+            {props.planModeActive ? (
+              <button
+                type="button"
+                className="maka-composer-mode-indicator"
+                data-mode="plan"
+                disabled={
+                  props.disabled
+                  || props.planModePending === true
+                  || Boolean(props.planModeDisabledReason)
+                }
+                onClick={() => {
+                  void props.onPlanModeChange?.(false);
+                }}
+                aria-label={copy.planModeOnTitle}
+                title={
+                  props.planModeDisabledReason ?? copy.planModeOnTitle
+                }
+              >
+                {copy.planModeLabel}
+              </button>
+            ) : null}
+            {props.swarmModeActive ? (
+              <button
+                type="button"
+                className="maka-composer-mode-indicator"
+                data-mode="swarm"
+                disabled={
+                  props.disabled
+                  || props.swarmModePending === true
+                  || Boolean(props.swarmModeDisabledReason)
+                }
+                onClick={() => {
+                  void props.onSwarmModeChange?.(false);
+                }}
+                aria-label={copy.swarmModeOnTitle}
+                title={
+                  props.swarmModeDisabledReason ?? copy.swarmModeOnTitle
+                }
+              >
+                {copy.swarmModeLabel}
+              </button>
+            ) : null}
           </div>
           <span className="maka-composer-status-slot">
             {props.disabled ? (

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -34,13 +34,13 @@ import { ComposerMentionPopup, mentionOptionId } from './composer-mention-popup.
 import { useMentionPopup } from './use-mention-popup.js';
 import { ComposerWorkspaceRow, type ComposerBranchPicker, type ComposerWorkspacePicker } from './composer-workspace-row.js';
 import type { AttachmentRef, PermissionMode, ProviderType, QuoteRef, SessionSummary } from '@maka/core';
-import { Button as UiButton, Switch } from './ui.js';
+import { Button as UiButton } from './ui.js';
 import { Textarea as UiTextarea } from './primitives/textarea.js';
 import { AttachmentFileCard } from './attachment-file-card.js';
 import { QuoteRefChip } from './quote-ref-chip.js';
 import { Kbd } from './primitives/kbd.js';
 import { PermissionModeSelect } from './permission-mode-menu.js';
-import { Menu, MenuItem, MenuPopup, MenuSub, MenuSubPopup, MenuSubTrigger, MenuTrigger } from './primitives/menu.js';
+import { Menu, MenuCheckboxItem, MenuItem, MenuPopup, MenuSeparator, MenuSub, MenuSubPopup, MenuSubTrigger, MenuTrigger } from './primitives/menu.js';
 
 const COMPOSER_MAX_HEIGHT = 240;
 
@@ -771,7 +771,7 @@ export const Composer = forwardRef<
         )}
         <div className="maka-composer-toolbar composerActions" data-streaming={props.streaming ? 'true' : undefined}>
           <div className="maka-composer-left-controls">
-            {!props.streaming && (props.onPickAttachments || (props.expertTeams?.length ?? 0) > 0) ? (
+            {!props.streaming && (props.onPickAttachments || (props.expertTeams?.length ?? 0) > 0 || props.onPlanModeChange || props.onSwarmModeChange) ? (
               <Menu>
                 <MenuTrigger
                   render={({ onClick: menuToggleClick, ...triggerRest }) => (
@@ -818,6 +818,59 @@ export const Composer = forwardRef<
                       </MenuSubPopup>
                     </MenuSub>
                   ) : null}
+                  {/* #1433 subtraction: Plan/Swarm live here as switch
+                      items instead of standalone toolbar switches — the
+                      toolbar keeps only add / permission / model / send. */}
+                  {props.onPlanModeChange || props.onSwarmModeChange ? (
+                    <>
+                      {/* Separator only when an attachment/expert-team group
+                          precedes it — a modes-only menu must not lead with
+                          a divider (review P3). */}
+                      {props.onPickAttachments || (props.expertTeams?.length ?? 0) > 0 ? (
+                        <MenuSeparator />
+                      ) : null}
+                      {props.onPlanModeChange ? (
+                        <MenuCheckboxItem
+                          variant="switch"
+                          checked={props.planModeActive === true}
+                          disabled={
+                            props.disabled
+                            || props.planModePending === true
+                            || Boolean(props.planModeDisabledReason)
+                          }
+                          onCheckedChange={(checked) => {
+                            void props.onPlanModeChange?.(checked);
+                          }}
+                          title={
+                            props.planModeDisabledReason
+                            ?? (props.planModeActive ? copy.disablePlanMode : copy.enablePlanMode)
+                          }
+                        >
+                          {copy.planModeLabel}
+                        </MenuCheckboxItem>
+                      ) : null}
+                      {props.onSwarmModeChange ? (
+                        <MenuCheckboxItem
+                          variant="switch"
+                          checked={props.swarmModeActive === true}
+                          disabled={
+                            props.disabled
+                            || props.swarmModePending === true
+                            || Boolean(props.swarmModeDisabledReason)
+                          }
+                          onCheckedChange={(checked) => {
+                            void props.onSwarmModeChange?.(checked);
+                          }}
+                          title={
+                            props.swarmModeDisabledReason
+                            ?? (props.swarmModeActive ? copy.disableSwarmMode : copy.enableSwarmMode)
+                          }
+                        >
+                          {copy.swarmModeLabel}
+                        </MenuCheckboxItem>
+                      ) : null}
+                    </>
+                  ) : null}
                 </MenuPopup>
               </Menu>
             ) : null}
@@ -841,54 +894,6 @@ export const Composer = forwardRef<
                 disabled={props.disabled || props.permissionModePending === true || Boolean(props.permissionModeDisabledReason)}
                 disabledReason={props.permissionModeDisabledReason}
               />
-            ) : null}
-            {props.onPlanModeChange ? (
-              <span
-                className="maka-composer-plan-mode-control"
-                data-active={props.planModeActive ? 'true' : 'false'}
-              >
-                <span className="maka-composer-plan-mode-label">{copy.planModeLabel}</span>
-                <Switch
-                  checked={props.planModeActive === true}
-                  disabled={
-                    props.disabled
-                    || props.planModePending === true
-                    || Boolean(props.planModeDisabledReason)
-                  }
-                  onCheckedChange={(checked) => {
-                    void props.onPlanModeChange?.(checked);
-                  }}
-                  aria-label={props.planModeActive ? copy.disablePlanMode : copy.enablePlanMode}
-                  title={
-                    props.planModeDisabledReason
-                    ?? (props.planModeActive ? copy.disablePlanMode : copy.enablePlanMode)
-                  }
-                />
-              </span>
-            ) : null}
-            {props.onSwarmModeChange ? (
-              <span
-                className="maka-composer-swarm-mode-control"
-                data-active={props.swarmModeActive ? 'true' : 'false'}
-              >
-                <span className="maka-composer-swarm-mode-label">{copy.swarmModeLabel}</span>
-                <Switch
-                  checked={props.swarmModeActive === true}
-                  disabled={
-                    props.disabled
-                    || props.swarmModePending === true
-                    || Boolean(props.swarmModeDisabledReason)
-                  }
-                  onCheckedChange={(checked) => {
-                    void props.onSwarmModeChange?.(checked);
-                  }}
-                  aria-label={props.swarmModeActive ? copy.disableSwarmMode : copy.enableSwarmMode}
-                  title={
-                    props.swarmModeDisabledReason
-                    ?? (props.swarmModeActive ? copy.disableSwarmMode : copy.enableSwarmMode)
-                  }
-                />
-              </span>
             ) : null}
           </div>
           <span className="maka-composer-status-slot">

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -87,9 +87,11 @@ export interface ConversationCopy {
     planModeLabel: string;
     enablePlanMode: string;
     disablePlanMode: string;
+    planModeOnTitle: string;
     swarmModeLabel: string;
     enableSwarmMode: string;
     disableSwarmMode: string;
+    swarmModeOnTitle: string;
     /** Inline hint shown above the composer when no model connection exists yet. */
     noModelHint: string;
     /** Link-button on that hint that opens Settings · 模型. */
@@ -335,7 +337,9 @@ const CONVERSATION_COPY = {
       selectModel: '选择模型', dropToImport: '松开以导入文件内容', addingAttachment: '正在添加附件', add: '添加', addTitle: '添加文件、专家团…', addFileOrDirectory: '添加文件或目录',
       switchDisabledStreaming: '当前对话正在流式输出，等结束后再切换模型。', switchDisabledRunning: '当前对话正在运行，等结束后再切换模型。', switchDisabledPermission: '当前有工具调用正在等待确认，处理后再切换模型。',
       planModeLabel: 'Plan', enablePlanMode: '开启 Plan Mode', disablePlanMode: '退出 Plan Mode',
+      planModeOnTitle: 'Plan 模式已启用，点击关闭',
       swarmModeLabel: 'Swarm', enableSwarmMode: '开启 Swarm Mode', disableSwarmMode: '退出 Swarm Mode',
+      swarmModeOnTitle: 'Swarm 模式已启用，点击关闭',
       noModelHint: '还没有可用的模型连接，无法发送。', noModelAction: '前往模型设置', noModelSendTitle: '先添加一个模型连接才能发送。',
     },
     model: {
@@ -470,7 +474,9 @@ const CONVERSATION_COPY = {
       selectModel: 'Choose model', dropToImport: 'Drop to import file contents', addingAttachment: 'Adding attachment', add: 'Add', addTitle: 'Add files or an expert team…', addFileOrDirectory: 'Add file or directory',
       switchDisabledStreaming: 'Wait for the current response to finish before switching models.', switchDisabledRunning: 'Wait for the current run to finish before switching models.', switchDisabledPermission: 'Resolve the pending tool permission before switching models.',
       planModeLabel: 'Plan', enablePlanMode: 'Enable Plan Mode', disablePlanMode: 'Disable Plan Mode',
+      planModeOnTitle: 'Plan mode is on — click to turn off',
       swarmModeLabel: 'Swarm', enableSwarmMode: 'Enable Swarm Mode', disableSwarmMode: 'Disable Swarm Mode',
+      swarmModeOnTitle: 'Swarm mode is on — click to turn off',
       noModelHint: 'No model connection yet, so sending is unavailable.', noModelAction: 'Go to model settings', noModelSendTitle: 'Add a model connection before sending.',
     },
     model: {


### PR DESCRIPTION
## Summary

First module of the #1433 subtraction series (one PR per module for reviewability).

The composer toolbar carried 8+ persistent elements: ＋, permission mode, **Plan switch**, **Swarm switch**, status hint, model picker, send, plus the workspace row. This PR moves the Plan and Swarm switches into the ＋ menu as switch-style checkbox items, per the direction agreed in #1433 (permission mode, model picker, and the workspace row are unchanged).

- Toolbar after: ＋ · 询问权限 ▾ · 模型 ▾ · ↑ (+ workspace row)
- ＋ menu after: 添加文件或目录 · 专家团 › · Plan ⏻ · Swarm ⏻ (separator only when a preceding group exists)
- The ＋ menu now also opens when only mode handlers are wired (previously it required attachments or expert teams), so the modes stay reachable in every session.
- **Active-mode signal**: while Plan or Swarm is on, a quiet text-button indicator appears next to the permission select — same visual language, no chevron, since it cannot drop down. Clicking it turns the mode off directly; while streaming it stays visible but disabled, with the reason as its title. This keeps an ON mode visible without re-adding persistent chrome when both modes are off.
- Dead CSS for the standalone switches removed with them.

Refs #1433.

## Verification

- `packages/ui` tests: 234 pass, including localization contract tests for the new behavior (no standalone switches; ＋ trigger with modes-only wiring; indicator only while active; indicator visible while streaming).
- `npm run typecheck -w @maka/ui`, `npm run lint`, `npm run build-storybook -w @maka/desktop` — pass.
- Storybook `Product/Shell Child Composition`: before/after toolbar, ＋ menu open, and the new `Plan Mode Active` story — screenshots attached below.
- Not run: desktop e2e (no e2e selectors reference the removed switches; CI runs the suite).

## Evidence

<img width="1880" height="668" alt="image" src="https://github.com/user-attachments/assets/cf685566-cef6-4f69-94da-a9cb12710223" />