### PR TITLE
feat(runtime): project committed agent events as graph records

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -52,7 +52,8 @@
     "./invocation-context": "./dist/invocation-context.js",
     "./runtime-runner": "./dist/runtime-runner.js",
     "./agent-flow": "./dist/agent-flow.js",
-    "./ai-sdk-flow": "./dist/ai-sdk-flow.js"
+    "./ai-sdk-flow": "./dist/ai-sdk-flow.js",
+    "./stream-graph-projection": "./dist/stream-graph-projection.js"
   },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",

--- a/packages/runtime/src/__tests__/stream-graph-projection.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-projection.test.ts
@@ -144,12 +144,39 @@ describe('committed stream graph projection', () => {
       ],
     );
     assert.deepEqual(
-      projection.records.map((record) => record.logicalTime),
-      [1, 2, 3, 4, 5, 6, 7],
+      projection.records.map((record) => record.eventTime),
+      [baseTs + 1, baseTs + 2, baseTs + 4, baseTs + 5, baseTs + 6, baseTs + 7, baseTs + 8],
+    );
+    assert.deepEqual(
+      projection.records
+        .filter((record) => record.operatorId === 'research')
+        .map((record) => record.orderKey.committedEventOrdinal),
+      [0, 1, 2, 3],
+      'partial events do not renumber committed source facts',
     );
     assert.deepEqual(projection.records[0]?.facets, ['message']);
     assert.deepEqual(projection.records[1]?.facets, ['tool_call']);
     assert.deepEqual(projection.records[5]?.facets, ['error', 'failed']);
+    assert.deepEqual(projection.records[2]?.supervisorSignals, [
+      { kind: 'attention', reason: 'permission_request' },
+    ]);
+    assert.deepEqual(projection.records[5]?.supervisorSignals, [
+      { kind: 'terminal', status: 'failed' },
+    ]);
+    assert.deepEqual(
+      projection.supervisorMetaStream.map((record) => record.recordId),
+      projection.records.map((record) => record.recordId),
+      'the supervisor observes every graph record, not only attention records',
+    );
+    assert.deepEqual(projection.supervisorMetaStream[0]?.signals, []);
+    assert.deepEqual(projection.supervisorMetaStream[2]?.signals, [
+      { kind: 'attention', reason: 'permission_request' },
+    ]);
+    assert.equal(
+      replayAgentGraphRecords(projection.records.slice(0, 3)).operators.research?.status,
+      'running',
+      'supervisor attention is orthogonal to graph lifecycle',
+    );
     assert.equal(projection.state.operators.research?.status, 'completed');
     assert.equal(projection.state.operators.verify?.status, 'failed');
     assert.equal(projection.state.operators.research?.activations['run-a']?.recordCount, 4);
@@ -205,6 +232,168 @@ describe('committed stream graph projection', () => {
     assert.deepEqual(reorderedWithDuplicates, canonical);
   });
 
+  test('keeps existing records byte-stable when a late operator contributes earlier event time', () => {
+    const runA = runHeader({
+      sessionId: 'child-a',
+      runId: 'run-a',
+      turnId: 'turn-a',
+      status: 'running',
+      createdAt: baseTs,
+    });
+    const runB = runHeader({
+      sessionId: 'child-b',
+      runId: 'run-b',
+      turnId: 'turn-b',
+      status: 'running',
+      createdAt: baseTs + 1,
+    });
+    const streamA = {
+      operator: { operatorId: 'research', sessionId: runA.sessionId },
+      run: runA,
+      events: [
+        runtimeEvent(runA, {
+          id: 'event-a',
+          ts: baseTs + 100,
+          role: 'model' as const,
+          author: 'agent' as const,
+          content: { kind: 'text' as const, text: 'A' },
+        }),
+      ],
+    };
+    const streamB = {
+      operator: { operatorId: 'verify', sessionId: runB.sessionId },
+      run: runB,
+      events: [
+        runtimeEvent(runB, {
+          id: 'event-b',
+          ts: baseTs + 90,
+          role: 'model' as const,
+          author: 'agent' as const,
+          content: { kind: 'text' as const, text: 'B' },
+        }),
+      ],
+    };
+
+    const initial = projectAgentGraphRecords({
+      graphId: 'graph-incremental',
+      streams: [streamA],
+    });
+    const expanded = projectAgentGraphRecords({
+      graphId: 'graph-incremental',
+      streams: [streamA, streamB],
+    });
+    const initialA = initial.records.find((record) => record.source.runtimeEventId === 'event-a');
+    const expandedA = expanded.records.find((record) => record.source.runtimeEventId === 'event-a');
+
+    assert.deepEqual(expandedA, initialA);
+    assert.deepEqual(
+      expanded.records.map((record) => record.source.runtimeEventId),
+      ['event-b', 'event-a'],
+    );
+    const replayed = replayAgentGraphRecords([...initial.records, ...expanded.records]);
+    assert.equal(replayed.appliedRecordIds.length, 2);
+  });
+
+  test('allows equal event times and resolves them with the stable source order key', () => {
+    const first = runHeader({
+      sessionId: 'child-z',
+      runId: 'run-z',
+      turnId: 'turn-z',
+      status: 'running',
+      createdAt: baseTs,
+    });
+    const second = runHeader({
+      sessionId: 'child-a',
+      runId: 'run-a',
+      turnId: 'turn-a',
+      status: 'running',
+      createdAt: baseTs + 1,
+    });
+    const { records } = projectAgentGraphRecords({
+      graphId: 'graph-equal-time',
+      streams: [
+        {
+          operator: { operatorId: 'z-operator', sessionId: first.sessionId },
+          run: first,
+          events: [runtimeEvent(first, { id: 'event-z', ts: baseTs + 10 })],
+        },
+        {
+          operator: { operatorId: 'a-operator', sessionId: second.sessionId },
+          run: second,
+          events: [runtimeEvent(second, { id: 'event-a', ts: baseTs + 10 })],
+        },
+      ],
+    });
+
+    assert.deepEqual(
+      records.map((record) => record.source.runtimeEventId),
+      ['event-z', 'event-a'],
+      'run creation time wins before lexical operator identity',
+    );
+    assert.deepEqual(
+      records.map((record) => record.eventTime),
+      [baseTs + 10, baseTs + 10],
+    );
+    assert.equal(replayAgentGraphRecords(records).appliedRecordIds.length, 2);
+  });
+
+  test('routes human-interaction facts to the always-on supervisor without blocking lifecycle', () => {
+    const run = runHeader({
+      sessionId: 'child-a',
+      runId: 'run-a',
+      turnId: 'turn-a',
+      status: 'running',
+      createdAt: baseTs,
+    });
+    const { records } = projectAgentGraphRecords({
+      graphId: 'graph-supervisor',
+      streams: [
+        {
+          operator: { operatorId: 'research', sessionId: run.sessionId },
+          run,
+          events: [
+            runtimeEvent(run, {
+              id: 'permission-request',
+              ts: baseTs + 1,
+              actions: {
+                permissionRequest: {
+                  kind: 'tool_permission',
+                  requestId: 'permission-1',
+                  toolUseId: 'tool-1',
+                  toolName: 'Read',
+                  category: 'read',
+                  reason: 'custom',
+                  args: {},
+                  rememberForTurnAllowed: true,
+                },
+              },
+            }),
+            runtimeEvent(run, {
+              id: 'question-request',
+              ts: baseTs + 2,
+              actions: {
+                userQuestionRequest: {
+                  requestId: 'question-1',
+                  toolUseId: 'tool-2',
+                  questions: [{ question: 'Choose', options: [{ label: 'Continue' }] }],
+                },
+              },
+            }),
+          ],
+        },
+      ],
+    });
+
+    assert.deepEqual(
+      records.map((record) => record.supervisorSignals),
+      [
+        [{ kind: 'attention', reason: 'permission_request' }],
+        [{ kind: 'attention', reason: 'user_question_request' }],
+      ],
+    );
+    assert.equal(replayAgentGraphRecords(records).operators.research?.status, 'running');
+  });
+
   test('keeps later session-inline runs as distinct activations of one operator', () => {
     const first = runHeader({
       sessionId: 'child-a',
@@ -251,6 +440,67 @@ describe('committed stream graph projection', () => {
     const state = replayAgentGraphRecords(records);
     assert.deepEqual(Object.keys(state.operators.research?.activations ?? {}), ['run-1', 'run-2']);
     assert.equal(state.operators.research?.currentActivationId, 'run-2');
+  });
+
+  test('reads only session-inline activations while legacy child runs remain compatible', async () => {
+    const inline = runHeader({
+      sessionId: 'child-a',
+      runId: 'inline-run',
+      turnId: 'inline-turn',
+      status: 'completed',
+      createdAt: baseTs,
+    });
+    const legacy = {
+      ...runHeader({
+        sessionId: 'child-a',
+        runId: 'legacy-child-run',
+        turnId: 'legacy-turn',
+        status: 'completed',
+        createdAt: baseTs + 1,
+      }),
+      parentRunId: 'legacy-parent-run',
+    };
+    const reads: string[] = [];
+    const projection = await readCommittedAgentGraphProjection({
+      graphId: 'graph-inline-only',
+      operators: [{ operatorId: 'research', sessionId: inline.sessionId }],
+      runStore: {
+        async listSessionRuns() {
+          return [legacy, inline];
+        },
+      },
+      runtimeEventStore: {
+        async readImmutableRuntimeEvents(_sessionId, runId) {
+          reads.push(runId);
+          return [
+            runtimeEvent(inline, {
+              id: 'inline-complete',
+              ts: baseTs + 2,
+              status: 'completed',
+            }),
+          ];
+        },
+      },
+    });
+
+    assert.deepEqual(reads, ['inline-run']);
+    assert.deepEqual(Object.keys(projection.state.operators.research?.activations ?? {}), [
+      'inline-run',
+    ]);
+    assert.throws(
+      () =>
+        projectAgentGraphRecords({
+          graphId: 'graph-reject-legacy',
+          streams: [
+            {
+              operator: { operatorId: 'research', sessionId: legacy.sessionId },
+              run: legacy,
+              events: [],
+            },
+          ],
+        }),
+      /must be a session-inline AgentRun/,
+    );
   });
 
   test('fails closed on ambiguous authority or impossible replay order', async () => {
@@ -317,7 +567,6 @@ describe('committed stream graph projection', () => {
 
     assert.deepEqual(projection.state, {
       graphId: 'graph-empty',
-      lastLogicalTime: 0,
       appliedRecordIds: [],
       operators: {},
     });

--- a/packages/runtime/src/__tests__/stream-graph-projection.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-projection.test.ts
@@ -232,6 +232,49 @@ describe('committed stream graph projection', () => {
     assert.deepEqual(reorderedWithDuplicates, canonical);
   });
 
+  test('rejects one Session projected under different operators across observations', () => {
+    const run = runHeader({
+      sessionId: 'child-a',
+      runId: 'run-a',
+      turnId: 'turn-a',
+      status: 'running',
+      createdAt: baseTs,
+    });
+    const event = runtimeEvent(run, {
+      id: 'shared-event',
+      ts: baseTs + 1,
+      role: 'model',
+      author: 'agent',
+      content: { kind: 'text', text: 'one durable fact' },
+    });
+    const first = projectAgentGraphRecords({
+      graphId: 'graph-session-owner',
+      streams: [
+        {
+          operator: { operatorId: 'one', sessionId: run.sessionId },
+          run,
+          events: [event],
+        },
+      ],
+    });
+    const second = projectAgentGraphRecords({
+      graphId: 'graph-session-owner',
+      streams: [
+        {
+          operator: { operatorId: 'two', sessionId: run.sessionId },
+          run,
+          events: [event],
+        },
+      ],
+    });
+
+    assert.notEqual(first.records[0]?.recordId, second.records[0]?.recordId);
+    assert.throws(
+      () => replayAgentGraphRecords([...first.records, ...second.records]),
+      /Session child-a is bound to both one and two/,
+    );
+  });
+
   test('keeps existing records byte-stable when a late operator contributes earlier event time', () => {
     const runA = runHeader({
       sessionId: 'child-a',

--- a/packages/runtime/src/__tests__/stream-graph-projection.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-projection.test.ts
@@ -1,0 +1,363 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { AgentRunHeader, RuntimeEvent, RuntimeEventStore } from '@maka/core';
+import {
+  projectAgentGraphRecords,
+  readCommittedAgentGraphProjection,
+  replayAgentGraphRecords,
+} from '../stream-graph-projection.js';
+
+const baseTs = 1_800_000_000_000;
+
+describe('committed stream graph projection', () => {
+  test('projects immutable child-session events into a stable reference-only graph trace', async () => {
+    const runA = runHeader({
+      sessionId: 'child-a',
+      runId: 'run-a',
+      turnId: 'turn-a',
+      status: 'completed',
+      createdAt: baseTs,
+    });
+    const runB = runHeader({
+      sessionId: 'child-b',
+      runId: 'run-b',
+      turnId: 'turn-b',
+      status: 'failed',
+      createdAt: baseTs + 1,
+    });
+    const eventsByRun = new Map<string, RuntimeEvent[]>([
+      [
+        runA.runId,
+        [
+          runtimeEvent(runA, {
+            id: 'a-message',
+            ts: baseTs + 1,
+            role: 'model',
+            author: 'agent',
+            content: { kind: 'text', text: 'payload-must-not-be-copied' },
+          }),
+          runtimeEvent(runA, {
+            id: 'a-partial',
+            ts: baseTs + 2,
+            partial: true,
+            role: 'model',
+            author: 'agent',
+            content: { kind: 'text', text: 'mutable-stream-chunk' },
+          }),
+          runtimeEvent(runA, {
+            id: 'a-permission',
+            ts: baseTs + 4,
+            actions: {
+              permissionRequest: {
+                kind: 'tool_permission',
+                requestId: 'permission-a',
+                toolUseId: 'tool-a',
+                toolName: 'Read',
+                category: 'read',
+                reason: 'custom',
+                args: {},
+                rememberForTurnAllowed: true,
+              },
+            },
+          }),
+          runtimeEvent(runA, {
+            id: 'a-permission-decision',
+            ts: baseTs + 5,
+            author: 'user',
+            actions: {
+              permissionDecision: {
+                requestId: 'permission-a',
+                decision: 'allow',
+                rememberForTurn: false,
+              },
+            },
+          }),
+          runtimeEvent(runA, {
+            id: 'a-complete',
+            ts: baseTs + 8,
+            status: 'completed',
+            actions: { endInvocation: true },
+          }),
+        ],
+      ],
+      [
+        runB.runId,
+        [
+          runtimeEvent(runB, {
+            id: 'b-tool-call',
+            ts: baseTs + 2,
+            role: 'model',
+            author: 'agent',
+            content: { kind: 'function_call', id: 'tool-b', name: 'Grep', args: {} },
+          }),
+          runtimeEvent(runB, {
+            id: 'b-tool-result',
+            ts: baseTs + 6,
+            role: 'tool',
+            author: 'tool',
+            content: {
+              kind: 'function_response',
+              id: 'tool-b',
+              name: 'Grep',
+              result: { matches: 0 },
+            },
+          }),
+          runtimeEvent(runB, {
+            id: 'b-failed',
+            ts: baseTs + 7,
+            status: 'failed',
+            content: { kind: 'error', message: 'provider failed' },
+          }),
+        ],
+      ],
+    ]);
+
+    const projection = await readCommittedAgentGraphProjection({
+      graphId: 'graph-1',
+      operators: [
+        { operatorId: 'research', sessionId: runA.sessionId },
+        { operatorId: 'verify', sessionId: runB.sessionId },
+      ],
+      runStore: {
+        async listSessionRuns(sessionId) {
+          return sessionId === runA.sessionId ? [runA] : [runB];
+        },
+      },
+      runtimeEventStore: {
+        async readImmutableRuntimeEvents(_sessionId, runId) {
+          return eventsByRun.get(runId) ?? [];
+        },
+      },
+    });
+
+    assert.equal(projection.ignoredPartialEvents, 1);
+    assert.deepEqual(
+      projection.records.map((record) => record.source.runtimeEventId),
+      [
+        'a-message',
+        'b-tool-call',
+        'a-permission',
+        'a-permission-decision',
+        'b-tool-result',
+        'b-failed',
+        'a-complete',
+      ],
+    );
+    assert.deepEqual(
+      projection.records.map((record) => record.logicalTime),
+      [1, 2, 3, 4, 5, 6, 7],
+    );
+    assert.deepEqual(projection.records[0]?.facets, ['message']);
+    assert.deepEqual(projection.records[1]?.facets, ['tool_call']);
+    assert.deepEqual(projection.records[5]?.facets, ['error', 'failed']);
+    assert.equal(projection.state.operators.research?.status, 'completed');
+    assert.equal(projection.state.operators.verify?.status, 'failed');
+    assert.equal(projection.state.operators.research?.activations['run-a']?.recordCount, 4);
+    assert.equal(projection.records[0]?.previousRecordId, undefined);
+    assert.equal(
+      projection.records[2]?.previousRecordId,
+      projection.records[0]?.recordId,
+      'predecessors are activation-local rather than global',
+    );
+    assert.doesNotMatch(JSON.stringify(projection.records), /payload-must-not-be-copied/);
+    assert.doesNotMatch(JSON.stringify(projection.records), /mutable-stream-chunk/);
+  });
+
+  test('replay is deterministic for reordered delivery and idempotent duplicates', () => {
+    const run = runHeader({
+      sessionId: 'child-a',
+      runId: 'run-a',
+      turnId: 'turn-a',
+      status: 'completed',
+      createdAt: baseTs,
+    });
+    const { records } = projectAgentGraphRecords({
+      graphId: 'graph-replay',
+      streams: [
+        {
+          operator: { operatorId: 'research', sessionId: run.sessionId },
+          run,
+          events: [
+            runtimeEvent(run, {
+              id: 'message',
+              ts: baseTs + 1,
+              role: 'model',
+              author: 'agent',
+              content: { kind: 'text', text: 'result' },
+            }),
+            runtimeEvent(run, {
+              id: 'complete',
+              ts: baseTs + 2,
+              status: 'completed',
+            }),
+          ],
+        },
+      ],
+    });
+
+    const canonical = replayAgentGraphRecords(records);
+    const reorderedWithDuplicates = replayAgentGraphRecords([
+      records[1]!,
+      records[0]!,
+      records[0]!,
+      records[1]!,
+    ]);
+    assert.deepEqual(reorderedWithDuplicates, canonical);
+  });
+
+  test('keeps later session-inline runs as distinct activations of one operator', () => {
+    const first = runHeader({
+      sessionId: 'child-a',
+      runId: 'run-1',
+      turnId: 'turn-1',
+      status: 'completed',
+      createdAt: baseTs,
+    });
+    const followup = runHeader({
+      sessionId: 'child-a',
+      runId: 'run-2',
+      turnId: 'turn-2',
+      status: 'completed',
+      createdAt: baseTs + 10,
+    });
+    const { records } = projectAgentGraphRecords({
+      graphId: 'graph-followup',
+      streams: [
+        {
+          operator: { operatorId: 'research', sessionId: first.sessionId },
+          run: followup,
+          events: [
+            runtimeEvent(followup, {
+              id: 'followup-complete',
+              ts: baseTs + 11,
+              status: 'completed',
+            }),
+          ],
+        },
+        {
+          operator: { operatorId: 'research', sessionId: first.sessionId },
+          run: first,
+          events: [
+            runtimeEvent(first, {
+              id: 'initial-complete',
+              ts: baseTs + 1,
+              status: 'completed',
+            }),
+          ],
+        },
+      ],
+    });
+
+    const state = replayAgentGraphRecords(records);
+    assert.deepEqual(Object.keys(state.operators.research?.activations ?? {}), ['run-1', 'run-2']);
+    assert.equal(state.operators.research?.currentActivationId, 'run-2');
+  });
+
+  test('fails closed on ambiguous authority or impossible replay order', async () => {
+    const run = runHeader({
+      sessionId: 'child-a',
+      runId: 'run-a',
+      turnId: 'turn-a',
+      status: 'completed',
+      createdAt: baseTs,
+    });
+    const runtimeEventStore: Pick<RuntimeEventStore, 'readImmutableRuntimeEvents'> = {};
+
+    await assert.rejects(
+      readCommittedAgentGraphProjection({
+        graphId: 'graph-no-immutable-reader',
+        operators: [{ operatorId: 'research', sessionId: run.sessionId }],
+        runStore: {
+          async listSessionRuns() {
+            return [run];
+          },
+        },
+        runtimeEventStore,
+      }),
+      /requires immutable RuntimeEvent reads/,
+    );
+
+    const { records } = projectAgentGraphRecords({
+      graphId: 'graph-terminal',
+      streams: [
+        {
+          operator: { operatorId: 'research', sessionId: run.sessionId },
+          run,
+          events: [
+            runtimeEvent(run, { id: 'terminal', ts: baseTs + 1, status: 'completed' }),
+            runtimeEvent(run, {
+              id: 'after-terminal',
+              ts: baseTs + 2,
+              role: 'model',
+              author: 'agent',
+              content: { kind: 'text', text: 'impossible' },
+            }),
+          ],
+        },
+      ],
+    });
+    assert.throws(() => replayAgentGraphRecords(records), /appears after terminal record/);
+  });
+
+  test('preserves graph identity when no committed operator facts exist yet', async () => {
+    const projection = await readCommittedAgentGraphProjection({
+      graphId: 'graph-empty',
+      operators: [],
+      runStore: {
+        async listSessionRuns() {
+          return [];
+        },
+      },
+      runtimeEventStore: {
+        async readImmutableRuntimeEvents() {
+          return [];
+        },
+      },
+    });
+
+    assert.deepEqual(projection.state, {
+      graphId: 'graph-empty',
+      lastLogicalTime: 0,
+      appliedRecordIds: [],
+      operators: {},
+    });
+  });
+});
+
+function runHeader(input: {
+  sessionId: string;
+  runId: string;
+  turnId: string;
+  status: AgentRunHeader['status'];
+  createdAt: number;
+}): AgentRunHeader {
+  return {
+    ...input,
+    invocationId: `invocation-${input.runId}`,
+    backendKind: 'ai-sdk',
+    llmConnectionSlug: 'deepseek',
+    modelId: 'deepseek-chat',
+    cwd: '/workspace',
+    permissionMode: 'explore',
+    updatedAt: input.createdAt + 1,
+    ...(input.status === 'completed' || input.status === 'failed' || input.status === 'cancelled'
+      ? { completedAt: input.createdAt + 1 }
+      : {}),
+  };
+}
+
+function runtimeEvent(
+  run: AgentRunHeader,
+  overrides: Partial<RuntimeEvent> & Pick<RuntimeEvent, 'id' | 'ts'>,
+): RuntimeEvent {
+  return {
+    invocationId: run.invocationId ?? `invocation-${run.runId}`,
+    runId: run.runId,
+    sessionId: run.sessionId,
+    turnId: run.turnId,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -53,9 +53,13 @@ export type {
   AgentGraphProjection,
   AgentGraphRecord,
   AgentGraphRecordFacet,
+  AgentGraphRecordOrderKey,
   AgentGraphReplayState,
   AgentGraphRunStream,
   AgentGraphRuntimeEventSource,
+  AgentGraphSupervisorAttentionReason,
+  AgentGraphSupervisorMetaRecord,
+  AgentGraphSupervisorSignal,
   ProjectAgentGraphRecordsInput,
   ReadCommittedAgentGraphProjectionInput,
 } from './stream-graph-projection.js';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -38,6 +38,27 @@ export type {
   StopSessionInput,
 } from './session-manager.js';
 export type { SubagentExecutionRef } from './subagent-execution.js';
+export {
+  AGENT_GRAPH_RECORD_FACETS,
+  AGENT_GRAPH_RECORD_SCHEMA_VERSION,
+  projectAgentGraphRecords,
+  readCommittedAgentGraphProjection,
+  replayAgentGraphRecords,
+} from './stream-graph-projection.js';
+export type {
+  AgentGraphActivationState,
+  AgentGraphActivationStatus,
+  AgentGraphOperatorBinding,
+  AgentGraphOperatorState,
+  AgentGraphProjection,
+  AgentGraphRecord,
+  AgentGraphRecordFacet,
+  AgentGraphReplayState,
+  AgentGraphRunStream,
+  AgentGraphRuntimeEventSource,
+  ProjectAgentGraphRecordsInput,
+  ReadCommittedAgentGraphProjectionInput,
+} from './stream-graph-projection.js';
 
 export { PermissionEngine, createDefaultPermissionEngineDeps } from './permission-engine.js';
 export type { EvaluateResult, EvaluateInput, PermissionEngineDeps } from './permission-engine.js';

--- a/packages/runtime/src/stream-graph-projection.ts
+++ b/packages/runtime/src/stream-graph-projection.ts
@@ -1,0 +1,562 @@
+import type { AgentRunHeader, AgentRunStore, RuntimeEvent, RuntimeEventStore } from '@maka/core';
+import { stableHash, stableStringify } from './request-shape.js';
+
+export const AGENT_GRAPH_RECORD_SCHEMA_VERSION = 1 as const;
+
+export const AGENT_GRAPH_RECORD_FACETS = [
+  'message',
+  'thinking',
+  'error',
+  'tool_call',
+  'tool_dispatch',
+  'tool_result',
+  'artifact_update',
+  'permission_request',
+  'permission_decision',
+  'user_question_request',
+  'transfer',
+  'usage',
+  'completed',
+  'failed',
+  'aborted',
+  'cancelled',
+  'runtime_fact',
+] as const;
+
+export type AgentGraphRecordFacet = (typeof AGENT_GRAPH_RECORD_FACETS)[number];
+
+export type AgentGraphActivationStatus =
+  | 'running'
+  | 'blocked'
+  | 'completed'
+  | 'failed'
+  | 'aborted'
+  | 'cancelled';
+
+/**
+ * Read-only binding between a graph operator and an existing durable Session.
+ *
+ * The graph does not own the Session or its RuntimeEvents. Each session-inline
+ * AgentRun is projected as one activation while the Session remains the stable
+ * operator execution identity across follow-ups and recovery.
+ */
+export interface AgentGraphOperatorBinding {
+  operatorId: string;
+  sessionId: string;
+}
+
+export interface AgentGraphRuntimeEventSource {
+  kind: 'runtime_event';
+  runtimeEventId: string;
+  sessionId: string;
+  runId: string;
+  turnId: string;
+  ts: number;
+}
+
+/**
+ * A bounded reference-only record projected from one committed RuntimeEvent.
+ *
+ * The source RuntimeEvent remains authoritative. The graph record deliberately
+ * does not copy message/tool payloads, and `partial: true` events never enter
+ * this stream.
+ */
+export interface AgentGraphRecord {
+  schemaVersion: typeof AGENT_GRAPH_RECORD_SCHEMA_VERSION;
+  recordId: string;
+  graphId: string;
+  operatorId: string;
+  activationId: string;
+  sessionId: string;
+  agentRunId: string;
+  logicalTime: number;
+  previousRecordId?: string;
+  type: 'agent_runtime_event';
+  facets: AgentGraphRecordFacet[];
+  source: AgentGraphRuntimeEventSource;
+}
+
+export interface AgentGraphActivationState {
+  activationId: string;
+  agentRunId: string;
+  status: AgentGraphActivationStatus;
+  recordCount: number;
+  firstLogicalTime: number;
+  lastLogicalTime: number;
+  lastRecordId: string;
+  terminalRecordId?: string;
+}
+
+export interface AgentGraphOperatorState {
+  operatorId: string;
+  sessionId: string;
+  status: AgentGraphActivationStatus;
+  currentActivationId: string;
+  activations: Record<string, AgentGraphActivationState>;
+}
+
+/**
+ * Deterministic trace state only. It intentionally has no graph-wide
+ * completion flag: topology closure and admission closure require a later
+ * control protocol and cannot be inferred from observed Agent runs alone.
+ */
+export interface AgentGraphReplayState {
+  graphId: string;
+  lastLogicalTime: number;
+  appliedRecordIds: string[];
+  operators: Record<string, AgentGraphOperatorState>;
+}
+
+export interface AgentGraphRunStream {
+  operator: AgentGraphOperatorBinding;
+  run: AgentRunHeader;
+  events: readonly RuntimeEvent[];
+}
+
+export interface ProjectAgentGraphRecordsInput {
+  graphId: string;
+  streams: readonly AgentGraphRunStream[];
+}
+
+export interface AgentGraphProjection {
+  graphId: string;
+  operators: AgentGraphOperatorBinding[];
+  ignoredPartialEvents: number;
+  records: AgentGraphRecord[];
+  state: AgentGraphReplayState;
+}
+
+export interface ReadCommittedAgentGraphProjectionInput {
+  graphId: string;
+  operators: readonly AgentGraphOperatorBinding[];
+  runStore: Pick<AgentRunStore, 'listSessionRuns'>;
+  runtimeEventStore: Pick<RuntimeEventStore, 'readImmutableRuntimeEvents'>;
+}
+
+interface OrderedRuntimeEvent {
+  operator: AgentGraphOperatorBinding;
+  run: AgentRunHeader;
+  event: RuntimeEvent;
+  eventIndex: number;
+}
+
+export async function readCommittedAgentGraphProjection(
+  input: ReadCommittedAgentGraphProjectionInput,
+): Promise<AgentGraphProjection> {
+  assertGraphIdentity(input.graphId, input.operators);
+  const readImmutableRuntimeEvents = input.runtimeEventStore.readImmutableRuntimeEvents;
+  if (!readImmutableRuntimeEvents) {
+    throw new Error('Committed graph projection requires immutable RuntimeEvent reads');
+  }
+
+  const streams = (
+    await Promise.all(
+      input.operators.map(async (operator) => {
+        const runs = await input.runStore.listSessionRuns(operator.sessionId);
+        const orderedRuns = [...runs].sort(
+          (a, b) => a.createdAt - b.createdAt || a.runId.localeCompare(b.runId),
+        );
+        return await Promise.all(
+          orderedRuns.map(async (run): Promise<AgentGraphRunStream> => {
+            if (run.sessionId !== operator.sessionId) {
+              throw new Error(
+                `Run ${run.runId} belongs to ${run.sessionId}, expected ${operator.sessionId}`,
+              );
+            }
+            return {
+              operator,
+              run,
+              events: await readImmutableRuntimeEvents.call(
+                input.runtimeEventStore,
+                operator.sessionId,
+                run.runId,
+              ),
+            };
+          }),
+        );
+      }),
+    )
+  ).flat();
+
+  const projected = projectAgentGraphRecords({ graphId: input.graphId, streams });
+  const state =
+    projected.records.length > 0
+      ? replayAgentGraphRecords(projected.records)
+      : { graphId: input.graphId, lastLogicalTime: 0, appliedRecordIds: [], operators: {} };
+  return {
+    graphId: input.graphId,
+    operators: input.operators.map((operator) => ({ ...operator })),
+    ignoredPartialEvents: projected.ignoredPartialEvents,
+    records: projected.records,
+    state,
+  };
+}
+
+export function projectAgentGraphRecords(input: ProjectAgentGraphRecordsInput): {
+  ignoredPartialEvents: number;
+  records: AgentGraphRecord[];
+} {
+  const operators = uniqueBindings(input.streams.map((stream) => stream.operator));
+  assertGraphIdentity(input.graphId, operators);
+
+  const ordered: OrderedRuntimeEvent[] = [];
+  let ignoredPartialEvents = 0;
+  const sourceEventIds = new Set<string>();
+
+  for (const stream of input.streams) {
+    assertRunStream(stream);
+    let lastCommittedTs: number | undefined;
+    for (let eventIndex = 0; eventIndex < stream.events.length; eventIndex += 1) {
+      const event = stream.events[eventIndex]!;
+      assertRuntimeEventIdentity(stream, event);
+      if (event.partial) {
+        ignoredPartialEvents += 1;
+        continue;
+      }
+      if (lastCommittedTs !== undefined && event.ts < lastCommittedTs) {
+        throw new Error(
+          `Committed RuntimeEvents for ${stream.run.runId} are not timestamp-monotonic`,
+        );
+      }
+      lastCommittedTs = event.ts;
+      if (sourceEventIds.has(event.id)) {
+        throw new Error(
+          `RuntimeEvent ${event.id} is bound more than once in graph ${input.graphId}`,
+        );
+      }
+      sourceEventIds.add(event.id);
+      ordered.push({ operator: stream.operator, run: stream.run, event, eventIndex });
+    }
+  }
+
+  ordered.sort(compareOrderedRuntimeEvents);
+
+  const previousByActivation = new Map<string, string>();
+  const records = ordered.map((item, index): AgentGraphRecord => {
+    const activationId = item.run.runId;
+    const activationKey = `${item.operator.operatorId}\0${activationId}`;
+    const previousRecordId = previousByActivation.get(activationKey);
+    const recordId = graphRecordId({
+      graphId: input.graphId,
+      operatorId: item.operator.operatorId,
+      sessionId: item.operator.sessionId,
+      runId: item.run.runId,
+      runtimeEventId: item.event.id,
+    });
+    previousByActivation.set(activationKey, recordId);
+    return {
+      schemaVersion: AGENT_GRAPH_RECORD_SCHEMA_VERSION,
+      recordId,
+      graphId: input.graphId,
+      operatorId: item.operator.operatorId,
+      activationId,
+      sessionId: item.operator.sessionId,
+      agentRunId: item.run.runId,
+      logicalTime: index + 1,
+      ...(previousRecordId ? { previousRecordId } : {}),
+      type: 'agent_runtime_event',
+      facets: runtimeEventFacets(item.event, item.run),
+      source: {
+        kind: 'runtime_event',
+        runtimeEventId: item.event.id,
+        sessionId: item.event.sessionId,
+        runId: item.event.runId,
+        turnId: item.event.turnId,
+        ts: item.event.ts,
+      },
+    };
+  });
+
+  return { ignoredPartialEvents, records };
+}
+
+export function replayAgentGraphRecords(
+  records: readonly AgentGraphRecord[],
+): AgentGraphReplayState {
+  if (records.length === 0) {
+    return { graphId: '', lastLogicalTime: 0, appliedRecordIds: [], operators: {} };
+  }
+
+  const uniqueRecords = new Map<string, AgentGraphRecord>();
+  for (const record of records) {
+    const existing = uniqueRecords.get(record.recordId);
+    if (existing) {
+      if (stableStringify(existing) !== stableStringify(record)) {
+        throw new Error(`Conflicting graph record ${record.recordId}`);
+      }
+      continue;
+    }
+    uniqueRecords.set(record.recordId, record);
+  }
+
+  const ordered = [...uniqueRecords.values()].sort(
+    (a, b) => a.logicalTime - b.logicalTime || a.recordId.localeCompare(b.recordId),
+  );
+  const graphId = ordered[0]!.graphId;
+  const logicalTimes = new Map<number, string>();
+  const operators: Record<string, AgentGraphOperatorState> = {};
+
+  for (const record of ordered) {
+    assertReplayRecord(record, graphId);
+    const logicalTimeOwner = logicalTimes.get(record.logicalTime);
+    if (logicalTimeOwner && logicalTimeOwner !== record.recordId) {
+      throw new Error(
+        `Logical time ${record.logicalTime} is shared by ${logicalTimeOwner} and ${record.recordId}`,
+      );
+    }
+    logicalTimes.set(record.logicalTime, record.recordId);
+
+    let operator = operators[record.operatorId];
+    if (!operator) {
+      operator = {
+        operatorId: record.operatorId,
+        sessionId: record.sessionId,
+        status: 'running',
+        currentActivationId: record.activationId,
+        activations: {},
+      };
+      operators[record.operatorId] = operator;
+    } else if (operator.sessionId !== record.sessionId) {
+      throw new Error(
+        `Operator ${record.operatorId} is bound to both ${operator.sessionId} and ${record.sessionId}`,
+      );
+    }
+
+    let activation = operator.activations[record.activationId];
+    if (!activation) {
+      activation = {
+        activationId: record.activationId,
+        agentRunId: record.agentRunId,
+        status: 'running',
+        recordCount: 0,
+        firstLogicalTime: record.logicalTime,
+        lastLogicalTime: record.logicalTime,
+        lastRecordId: record.recordId,
+      };
+      operator.activations[record.activationId] = activation;
+    } else {
+      if (activation.agentRunId !== record.agentRunId) {
+        throw new Error(`Activation ${record.activationId} references multiple AgentRuns`);
+      }
+      if (activation.terminalRecordId) {
+        throw new Error(
+          `Graph record ${record.recordId} appears after terminal record ${activation.terminalRecordId}`,
+        );
+      }
+    }
+
+    const status = activationStatusAfterRecord(activation.status, record.facets);
+    activation.status = status;
+    activation.recordCount += 1;
+    activation.lastLogicalTime = record.logicalTime;
+    activation.lastRecordId = record.recordId;
+    if (isTerminalActivationStatus(status)) {
+      activation.terminalRecordId = record.recordId;
+    }
+
+    const current = operator.activations[operator.currentActivationId];
+    if (!current || activation.lastLogicalTime >= current.lastLogicalTime) {
+      operator.currentActivationId = activation.activationId;
+      operator.status = activation.status;
+    }
+  }
+
+  return {
+    graphId,
+    lastLogicalTime: ordered.at(-1)!.logicalTime,
+    appliedRecordIds: ordered.map((record) => record.recordId),
+    operators,
+  };
+}
+
+function runtimeEventFacets(event: RuntimeEvent, run: AgentRunHeader): AgentGraphRecordFacet[] {
+  const facets: AgentGraphRecordFacet[] = [];
+  switch (event.content?.kind) {
+    case 'text':
+      facets.push('message');
+      break;
+    case 'thinking':
+      facets.push('thinking');
+      break;
+    case 'error':
+      facets.push('error');
+      break;
+    case 'function_call':
+      facets.push('tool_call');
+      break;
+    case 'function_response':
+      facets.push('tool_result');
+      break;
+  }
+
+  const actions = event.actions;
+  if (actions?.toolDispatch) facets.push('tool_dispatch');
+  if (actions?.artifactDelta) facets.push('artifact_update');
+  if (actions?.permissionRequest) facets.push('permission_request');
+  if (actions?.permissionDecision) facets.push('permission_decision');
+  if (actions?.userQuestionRequest) facets.push('user_question_request');
+  if (actions?.transferToAgent) facets.push('transfer');
+  if (actions?.tokenUsage) facets.push('usage');
+
+  const terminalStatus =
+    event.status === 'completed' ||
+    event.status === 'failed' ||
+    event.status === 'aborted' ||
+    event.status === 'cancelled'
+      ? event.status
+      : actions?.endInvocation
+        ? terminalStatusFromRun(run)
+        : undefined;
+  if (terminalStatus) facets.push(terminalStatus);
+  if (facets.length === 0) facets.push('runtime_fact');
+  return facets;
+}
+
+function terminalStatusFromRun(
+  run: AgentRunHeader,
+): Extract<AgentGraphRecordFacet, 'completed' | 'failed' | 'cancelled'> {
+  switch (run.status) {
+    case 'completed':
+    case 'failed':
+    case 'cancelled':
+      return run.status;
+    default:
+      throw new Error(
+        `RuntimeEvent ended invocation ${run.runId} while its AgentRun is ${run.status}`,
+      );
+  }
+}
+
+function activationStatusAfterRecord(
+  current: AgentGraphActivationStatus,
+  facets: readonly AgentGraphRecordFacet[],
+): AgentGraphActivationStatus {
+  const terminal = terminalStatusFromFacets(facets);
+  if (terminal) return terminal;
+  if (facets.includes('permission_request') || facets.includes('user_question_request')) {
+    return 'blocked';
+  }
+  if (facets.includes('permission_decision') && current === 'blocked') return 'running';
+  return current;
+}
+
+function terminalStatusFromFacets(
+  facets: readonly AgentGraphRecordFacet[],
+):
+  | Extract<AgentGraphActivationStatus, 'completed' | 'failed' | 'aborted' | 'cancelled'>
+  | undefined {
+  const terminal = facets.filter(
+    (
+      facet,
+    ): facet is Extract<AgentGraphRecordFacet, 'completed' | 'failed' | 'aborted' | 'cancelled'> =>
+      facet === 'completed' || facet === 'failed' || facet === 'aborted' || facet === 'cancelled',
+  );
+  if (terminal.length > 1) {
+    throw new Error(`Graph record carries conflicting terminal facets: ${terminal.join(', ')}`);
+  }
+  return terminal[0];
+}
+
+function isTerminalActivationStatus(status: AgentGraphActivationStatus): boolean {
+  return (
+    status === 'completed' || status === 'failed' || status === 'aborted' || status === 'cancelled'
+  );
+}
+
+function uniqueBindings(
+  operators: readonly AgentGraphOperatorBinding[],
+): AgentGraphOperatorBinding[] {
+  const byOperator = new Map<string, AgentGraphOperatorBinding>();
+  for (const operator of operators) {
+    const existing = byOperator.get(operator.operatorId);
+    if (existing && existing.sessionId !== operator.sessionId) {
+      throw new Error(
+        `Operator ${operator.operatorId} is bound to both ${existing.sessionId} and ${operator.sessionId}`,
+      );
+    }
+    byOperator.set(operator.operatorId, operator);
+  }
+  return [...byOperator.values()];
+}
+
+function assertGraphIdentity(
+  graphId: string,
+  operators: readonly AgentGraphOperatorBinding[],
+): void {
+  if (!graphId.trim()) throw new Error('Graph id must not be empty');
+  const operatorIds = new Set<string>();
+  const sessionIds = new Set<string>();
+  for (const operator of operators) {
+    if (!operator.operatorId.trim()) throw new Error('Operator id must not be empty');
+    if (!operator.sessionId.trim()) throw new Error('Operator session id must not be empty');
+    if (operatorIds.has(operator.operatorId)) {
+      throw new Error(`Duplicate graph operator ${operator.operatorId}`);
+    }
+    if (sessionIds.has(operator.sessionId)) {
+      throw new Error(`Session ${operator.sessionId} is bound to multiple graph operators`);
+    }
+    operatorIds.add(operator.operatorId);
+    sessionIds.add(operator.sessionId);
+  }
+}
+
+function assertRunStream(stream: AgentGraphRunStream): void {
+  if (stream.run.sessionId !== stream.operator.sessionId) {
+    throw new Error(
+      `Run ${stream.run.runId} belongs to ${stream.run.sessionId}, expected ${stream.operator.sessionId}`,
+    );
+  }
+}
+
+function assertRuntimeEventIdentity(stream: AgentGraphRunStream, event: RuntimeEvent): void {
+  if (
+    event.sessionId !== stream.operator.sessionId ||
+    event.runId !== stream.run.runId ||
+    event.turnId !== stream.run.turnId
+  ) {
+    throw new Error(
+      `RuntimeEvent ${event.id} does not belong to ${stream.operator.sessionId}/${stream.run.runId}/${stream.run.turnId}`,
+    );
+  }
+}
+
+function compareOrderedRuntimeEvents(a: OrderedRuntimeEvent, b: OrderedRuntimeEvent): number {
+  return (
+    a.event.ts - b.event.ts ||
+    a.run.createdAt - b.run.createdAt ||
+    a.operator.operatorId.localeCompare(b.operator.operatorId) ||
+    a.run.runId.localeCompare(b.run.runId) ||
+    a.eventIndex - b.eventIndex ||
+    a.event.id.localeCompare(b.event.id)
+  );
+}
+
+function graphRecordId(input: {
+  graphId: string;
+  operatorId: string;
+  sessionId: string;
+  runId: string;
+  runtimeEventId: string;
+}): string {
+  return `graph_record_${stableHash(input).slice('sha256:'.length, 'sha256:'.length + 32)}`;
+}
+
+function assertReplayRecord(record: AgentGraphRecord, graphId: string): void {
+  if (record.schemaVersion !== AGENT_GRAPH_RECORD_SCHEMA_VERSION) {
+    throw new Error(`Unsupported graph record schema ${record.schemaVersion}`);
+  }
+  if (record.graphId !== graphId) {
+    throw new Error(`Cannot replay records from graphs ${graphId} and ${record.graphId} together`);
+  }
+  if (!Number.isSafeInteger(record.logicalTime) || record.logicalTime <= 0) {
+    throw new Error(`Invalid logical time on graph record ${record.recordId}`);
+  }
+  if (
+    record.source.sessionId !== record.sessionId ||
+    record.source.runId !== record.agentRunId ||
+    record.activationId !== record.agentRunId
+  ) {
+    throw new Error(`Invalid source identity on graph record ${record.recordId}`);
+  }
+  terminalStatusFromFacets(record.facets);
+}

--- a/packages/runtime/src/stream-graph-projection.ts
+++ b/packages/runtime/src/stream-graph-projection.ts
@@ -1,4 +1,5 @@
 import type { AgentRunHeader, AgentRunStore, RuntimeEvent, RuntimeEventStore } from '@maka/core';
+import { isSessionInlineRun } from '@maka/core';
 import { stableHash, stableStringify } from './request-shape.js';
 
 export const AGENT_GRAPH_RECORD_SCHEMA_VERSION = 1 as const;
@@ -27,11 +28,22 @@ export type AgentGraphRecordFacet = (typeof AGENT_GRAPH_RECORD_FACETS)[number];
 
 export type AgentGraphActivationStatus =
   | 'running'
-  | 'blocked'
   | 'completed'
   | 'failed'
   | 'aborted'
   | 'cancelled';
+
+export type AgentGraphSupervisorAttentionReason = 'permission_request' | 'user_question_request';
+
+export type AgentGraphSupervisorSignal =
+  | {
+      kind: 'attention';
+      reason: AgentGraphSupervisorAttentionReason;
+    }
+  | {
+      kind: 'terminal';
+      status: Extract<AgentGraphActivationStatus, 'completed' | 'failed' | 'aborted' | 'cancelled'>;
+    };
 
 /**
  * Read-only binding between a graph operator and an existing durable Session.
@@ -55,11 +67,27 @@ export interface AgentGraphRuntimeEventSource {
 }
 
 /**
+ * Stable tie-break metadata for records with the same immutable event time.
+ *
+ * `committedEventOrdinal` is counted after partial rows are excluded, so
+ * legacy partial-row retention or migration cannot renumber committed facts.
+ */
+export interface AgentGraphRecordOrderKey {
+  runCreatedAt: number;
+  operatorId: string;
+  runId: string;
+  committedEventOrdinal: number;
+  runtimeEventId: string;
+}
+
+/**
  * A bounded reference-only record projected from one committed RuntimeEvent.
  *
  * The source RuntimeEvent remains authoritative. The graph record deliberately
  * does not copy message/tool payloads, and `partial: true` events never enter
- * this stream.
+ * this stream. Every record is also part of the always-on main-agent supervisor
+ * meta-stream; `supervisorSignals` marks facts that require semantic attention
+ * without putting the supervisor on the downstream data path.
  */
 export interface AgentGraphRecord {
   schemaVersion: typeof AGENT_GRAPH_RECORD_SCHEMA_VERSION;
@@ -69,10 +97,32 @@ export interface AgentGraphRecord {
   activationId: string;
   sessionId: string;
   agentRunId: string;
-  logicalTime: number;
+  eventTime: number;
+  orderKey: AgentGraphRecordOrderKey;
   previousRecordId?: string;
   type: 'agent_runtime_event';
   facets: AgentGraphRecordFacet[];
+  supervisorSignals: AgentGraphSupervisorSignal[];
+  source: AgentGraphRuntimeEventSource;
+}
+
+/**
+ * Bounded always-on view consumed by the main-agent supervisor.
+ *
+ * It reuses the graph record identity and source reference, so it is a routing
+ * projection rather than a second fact. Empty `signals` still carries normal
+ * activity to the supervisor; non-empty signals mark semantic attention or a
+ * terminal milestone.
+ */
+export interface AgentGraphSupervisorMetaRecord {
+  recordId: string;
+  graphId: string;
+  operatorId: string;
+  activationId: string;
+  eventTime: number;
+  orderKey: AgentGraphRecordOrderKey;
+  facets: AgentGraphRecordFacet[];
+  signals: AgentGraphSupervisorSignal[];
   source: AgentGraphRuntimeEventSource;
 }
 
@@ -81,8 +131,8 @@ export interface AgentGraphActivationState {
   agentRunId: string;
   status: AgentGraphActivationStatus;
   recordCount: number;
-  firstLogicalTime: number;
-  lastLogicalTime: number;
+  firstEventTime: number;
+  lastEventTime: number;
   lastRecordId: string;
   terminalRecordId?: string;
 }
@@ -102,7 +152,7 @@ export interface AgentGraphOperatorState {
  */
 export interface AgentGraphReplayState {
   graphId: string;
-  lastLogicalTime: number;
+  latestEventTime?: number;
   appliedRecordIds: string[];
   operators: Record<string, AgentGraphOperatorState>;
 }
@@ -123,6 +173,7 @@ export interface AgentGraphProjection {
   operators: AgentGraphOperatorBinding[];
   ignoredPartialEvents: number;
   records: AgentGraphRecord[];
+  supervisorMetaStream: AgentGraphSupervisorMetaRecord[];
   state: AgentGraphReplayState;
 }
 
@@ -137,7 +188,7 @@ interface OrderedRuntimeEvent {
   operator: AgentGraphOperatorBinding;
   run: AgentRunHeader;
   event: RuntimeEvent;
-  eventIndex: number;
+  committedEventOrdinal: number;
 }
 
 export async function readCommittedAgentGraphProjection(
@@ -153,9 +204,9 @@ export async function readCommittedAgentGraphProjection(
     await Promise.all(
       input.operators.map(async (operator) => {
         const runs = await input.runStore.listSessionRuns(operator.sessionId);
-        const orderedRuns = [...runs].sort(
-          (a, b) => a.createdAt - b.createdAt || a.runId.localeCompare(b.runId),
-        );
+        const orderedRuns = runs
+          .filter(isSessionInlineRun)
+          .sort((a, b) => a.createdAt - b.createdAt || a.runId.localeCompare(b.runId));
         return await Promise.all(
           orderedRuns.map(async (run): Promise<AgentGraphRunStream> => {
             if (run.sessionId !== operator.sessionId) {
@@ -182,12 +233,13 @@ export async function readCommittedAgentGraphProjection(
   const state =
     projected.records.length > 0
       ? replayAgentGraphRecords(projected.records)
-      : { graphId: input.graphId, lastLogicalTime: 0, appliedRecordIds: [], operators: {} };
+      : { graphId: input.graphId, appliedRecordIds: [], operators: {} };
   return {
     graphId: input.graphId,
     operators: input.operators.map((operator) => ({ ...operator })),
     ignoredPartialEvents: projected.ignoredPartialEvents,
     records: projected.records,
+    supervisorMetaStream: projected.supervisorMetaStream,
     state,
   };
 }
@@ -195,6 +247,7 @@ export async function readCommittedAgentGraphProjection(
 export function projectAgentGraphRecords(input: ProjectAgentGraphRecordsInput): {
   ignoredPartialEvents: number;
   records: AgentGraphRecord[];
+  supervisorMetaStream: AgentGraphSupervisorMetaRecord[];
 } {
   const operators = uniqueBindings(input.streams.map((stream) => stream.operator));
   assertGraphIdentity(input.graphId, operators);
@@ -206,8 +259,8 @@ export function projectAgentGraphRecords(input: ProjectAgentGraphRecordsInput): 
   for (const stream of input.streams) {
     assertRunStream(stream);
     let lastCommittedTs: number | undefined;
-    for (let eventIndex = 0; eventIndex < stream.events.length; eventIndex += 1) {
-      const event = stream.events[eventIndex]!;
+    let committedEventOrdinal = 0;
+    for (const event of stream.events) {
       assertRuntimeEventIdentity(stream, event);
       if (event.partial) {
         ignoredPartialEvents += 1;
@@ -225,14 +278,20 @@ export function projectAgentGraphRecords(input: ProjectAgentGraphRecordsInput): 
         );
       }
       sourceEventIds.add(event.id);
-      ordered.push({ operator: stream.operator, run: stream.run, event, eventIndex });
+      ordered.push({
+        operator: stream.operator,
+        run: stream.run,
+        event,
+        committedEventOrdinal,
+      });
+      committedEventOrdinal += 1;
     }
   }
 
   ordered.sort(compareOrderedRuntimeEvents);
 
   const previousByActivation = new Map<string, string>();
-  const records = ordered.map((item, index): AgentGraphRecord => {
+  const records = ordered.map((item): AgentGraphRecord => {
     const activationId = item.run.runId;
     const activationKey = `${item.operator.operatorId}\0${activationId}`;
     const previousRecordId = previousByActivation.get(activationKey);
@@ -252,10 +311,18 @@ export function projectAgentGraphRecords(input: ProjectAgentGraphRecordsInput): 
       activationId,
       sessionId: item.operator.sessionId,
       agentRunId: item.run.runId,
-      logicalTime: index + 1,
+      eventTime: item.event.ts,
+      orderKey: {
+        runCreatedAt: item.run.createdAt,
+        operatorId: item.operator.operatorId,
+        runId: item.run.runId,
+        committedEventOrdinal: item.committedEventOrdinal,
+        runtimeEventId: item.event.id,
+      },
       ...(previousRecordId ? { previousRecordId } : {}),
       type: 'agent_runtime_event',
       facets: runtimeEventFacets(item.event, item.run),
+      supervisorSignals: runtimeEventSupervisorSignals(item.event, item.run),
       source: {
         kind: 'runtime_event',
         runtimeEventId: item.event.id,
@@ -267,14 +334,32 @@ export function projectAgentGraphRecords(input: ProjectAgentGraphRecordsInput): 
     };
   });
 
-  return { ignoredPartialEvents, records };
+  return {
+    ignoredPartialEvents,
+    records,
+    supervisorMetaStream: records.map(projectSupervisorMetaRecord),
+  };
+}
+
+function projectSupervisorMetaRecord(record: AgentGraphRecord): AgentGraphSupervisorMetaRecord {
+  return {
+    recordId: record.recordId,
+    graphId: record.graphId,
+    operatorId: record.operatorId,
+    activationId: record.activationId,
+    eventTime: record.eventTime,
+    orderKey: { ...record.orderKey },
+    facets: [...record.facets],
+    signals: record.supervisorSignals.map((signal) => ({ ...signal })),
+    source: { ...record.source },
+  };
 }
 
 export function replayAgentGraphRecords(
   records: readonly AgentGraphRecord[],
 ): AgentGraphReplayState {
   if (records.length === 0) {
-    return { graphId: '', lastLogicalTime: 0, appliedRecordIds: [], operators: {} };
+    return { graphId: '', appliedRecordIds: [], operators: {} };
   }
 
   const uniqueRecords = new Map<string, AgentGraphRecord>();
@@ -289,22 +374,12 @@ export function replayAgentGraphRecords(
     uniqueRecords.set(record.recordId, record);
   }
 
-  const ordered = [...uniqueRecords.values()].sort(
-    (a, b) => a.logicalTime - b.logicalTime || a.recordId.localeCompare(b.recordId),
-  );
+  const ordered = [...uniqueRecords.values()].sort(compareAgentGraphRecords);
   const graphId = ordered[0]!.graphId;
-  const logicalTimes = new Map<number, string>();
   const operators: Record<string, AgentGraphOperatorState> = {};
 
   for (const record of ordered) {
     assertReplayRecord(record, graphId);
-    const logicalTimeOwner = logicalTimes.get(record.logicalTime);
-    if (logicalTimeOwner && logicalTimeOwner !== record.recordId) {
-      throw new Error(
-        `Logical time ${record.logicalTime} is shared by ${logicalTimeOwner} and ${record.recordId}`,
-      );
-    }
-    logicalTimes.set(record.logicalTime, record.recordId);
 
     let operator = operators[record.operatorId];
     if (!operator) {
@@ -329,8 +404,8 @@ export function replayAgentGraphRecords(
         agentRunId: record.agentRunId,
         status: 'running',
         recordCount: 0,
-        firstLogicalTime: record.logicalTime,
-        lastLogicalTime: record.logicalTime,
+        firstEventTime: record.eventTime,
+        lastEventTime: record.eventTime,
         lastRecordId: record.recordId,
       };
       operator.activations[record.activationId] = activation;
@@ -345,25 +420,22 @@ export function replayAgentGraphRecords(
       }
     }
 
-    const status = activationStatusAfterRecord(activation.status, record.facets);
+    const status = activationStatusAfterRecord(record.facets);
     activation.status = status;
     activation.recordCount += 1;
-    activation.lastLogicalTime = record.logicalTime;
+    activation.lastEventTime = record.eventTime;
     activation.lastRecordId = record.recordId;
     if (isTerminalActivationStatus(status)) {
       activation.terminalRecordId = record.recordId;
     }
 
-    const current = operator.activations[operator.currentActivationId];
-    if (!current || activation.lastLogicalTime >= current.lastLogicalTime) {
-      operator.currentActivationId = activation.activationId;
-      operator.status = activation.status;
-    }
+    operator.currentActivationId = activation.activationId;
+    operator.status = activation.status;
   }
 
   return {
     graphId,
-    lastLogicalTime: ordered.at(-1)!.logicalTime,
+    latestEventTime: ordered.at(-1)!.eventTime,
     appliedRecordIds: ordered.map((record) => record.recordId),
     operators,
   };
@@ -398,18 +470,45 @@ function runtimeEventFacets(event: RuntimeEvent, run: AgentRunHeader): AgentGrap
   if (actions?.transferToAgent) facets.push('transfer');
   if (actions?.tokenUsage) facets.push('usage');
 
-  const terminalStatus =
+  const terminalStatus = runtimeEventTerminalStatus(event, run);
+  if (terminalStatus) facets.push(terminalStatus);
+  if (facets.length === 0) facets.push('runtime_fact');
+  return facets;
+}
+
+function runtimeEventSupervisorSignals(
+  event: RuntimeEvent,
+  run: AgentRunHeader,
+): AgentGraphSupervisorSignal[] {
+  const signals: AgentGraphSupervisorSignal[] = [];
+  if (event.actions?.permissionRequest) {
+    signals.push({ kind: 'attention', reason: 'permission_request' });
+  }
+  if (event.actions?.userQuestionRequest) {
+    signals.push({ kind: 'attention', reason: 'user_question_request' });
+  }
+  const terminalStatus = runtimeEventTerminalStatus(event, run);
+  if (terminalStatus) {
+    signals.push({ kind: 'terminal', status: terminalStatus });
+  }
+  return signals;
+}
+
+function runtimeEventTerminalStatus(
+  event: RuntimeEvent,
+  run: AgentRunHeader,
+):
+  | Extract<AgentGraphActivationStatus, 'completed' | 'failed' | 'aborted' | 'cancelled'>
+  | undefined {
+  if (
     event.status === 'completed' ||
     event.status === 'failed' ||
     event.status === 'aborted' ||
     event.status === 'cancelled'
-      ? event.status
-      : actions?.endInvocation
-        ? terminalStatusFromRun(run)
-        : undefined;
-  if (terminalStatus) facets.push(terminalStatus);
-  if (facets.length === 0) facets.push('runtime_fact');
-  return facets;
+  ) {
+    return event.status;
+  }
+  return event.actions?.endInvocation ? terminalStatusFromRun(run) : undefined;
 }
 
 function terminalStatusFromRun(
@@ -428,16 +527,10 @@ function terminalStatusFromRun(
 }
 
 function activationStatusAfterRecord(
-  current: AgentGraphActivationStatus,
   facets: readonly AgentGraphRecordFacet[],
 ): AgentGraphActivationStatus {
   const terminal = terminalStatusFromFacets(facets);
-  if (terminal) return terminal;
-  if (facets.includes('permission_request') || facets.includes('user_question_request')) {
-    return 'blocked';
-  }
-  if (facets.includes('permission_decision') && current === 'blocked') return 'running';
-  return current;
+  return terminal ?? 'running';
 }
 
 function terminalStatusFromFacets(
@@ -506,6 +599,9 @@ function assertRunStream(stream: AgentGraphRunStream): void {
       `Run ${stream.run.runId} belongs to ${stream.run.sessionId}, expected ${stream.operator.sessionId}`,
     );
   }
+  if (!isSessionInlineRun(stream.run)) {
+    throw new Error(`Graph activation ${stream.run.runId} must be a session-inline AgentRun`);
+  }
 }
 
 function assertRuntimeEventIdentity(stream: AgentGraphRunStream, event: RuntimeEvent): void {
@@ -526,8 +622,20 @@ function compareOrderedRuntimeEvents(a: OrderedRuntimeEvent, b: OrderedRuntimeEv
     a.run.createdAt - b.run.createdAt ||
     a.operator.operatorId.localeCompare(b.operator.operatorId) ||
     a.run.runId.localeCompare(b.run.runId) ||
-    a.eventIndex - b.eventIndex ||
+    a.committedEventOrdinal - b.committedEventOrdinal ||
     a.event.id.localeCompare(b.event.id)
+  );
+}
+
+function compareAgentGraphRecords(a: AgentGraphRecord, b: AgentGraphRecord): number {
+  return (
+    a.eventTime - b.eventTime ||
+    a.orderKey.runCreatedAt - b.orderKey.runCreatedAt ||
+    a.orderKey.operatorId.localeCompare(b.orderKey.operatorId) ||
+    a.orderKey.runId.localeCompare(b.orderKey.runId) ||
+    a.orderKey.committedEventOrdinal - b.orderKey.committedEventOrdinal ||
+    a.orderKey.runtimeEventId.localeCompare(b.orderKey.runtimeEventId) ||
+    a.recordId.localeCompare(b.recordId)
   );
 }
 
@@ -548,15 +656,30 @@ function assertReplayRecord(record: AgentGraphRecord, graphId: string): void {
   if (record.graphId !== graphId) {
     throw new Error(`Cannot replay records from graphs ${graphId} and ${record.graphId} together`);
   }
-  if (!Number.isSafeInteger(record.logicalTime) || record.logicalTime <= 0) {
-    throw new Error(`Invalid logical time on graph record ${record.recordId}`);
+  if (!Number.isFinite(record.eventTime)) {
+    throw new Error(`Invalid event time on graph record ${record.recordId}`);
   }
   if (
     record.source.sessionId !== record.sessionId ||
     record.source.runId !== record.agentRunId ||
-    record.activationId !== record.agentRunId
+    record.activationId !== record.agentRunId ||
+    record.source.ts !== record.eventTime ||
+    record.orderKey.operatorId !== record.operatorId ||
+    record.orderKey.runId !== record.agentRunId ||
+    record.orderKey.runtimeEventId !== record.source.runtimeEventId ||
+    !Number.isFinite(record.orderKey.runCreatedAt) ||
+    !Number.isSafeInteger(record.orderKey.committedEventOrdinal) ||
+    record.orderKey.committedEventOrdinal < 0
   ) {
     throw new Error(`Invalid source identity on graph record ${record.recordId}`);
   }
   terminalStatusFromFacets(record.facets);
+  for (const signal of record.supervisorSignals) {
+    if (signal.kind === 'attention' && !record.facets.includes(signal.reason)) {
+      throw new Error(`Supervisor signal does not match graph record ${record.recordId}`);
+    }
+    if (signal.kind === 'terminal' && !record.facets.includes(signal.status)) {
+      throw new Error(`Supervisor terminal does not match graph record ${record.recordId}`);
+    }
+  }
 }

--- a/packages/runtime/src/stream-graph-projection.ts
+++ b/packages/runtime/src/stream-graph-projection.ts
@@ -377,9 +377,17 @@ export function replayAgentGraphRecords(
   const ordered = [...uniqueRecords.values()].sort(compareAgentGraphRecords);
   const graphId = ordered[0]!.graphId;
   const operators: Record<string, AgentGraphOperatorState> = {};
+  const operatorBySession = new Map<string, string>();
 
   for (const record of ordered) {
     assertReplayRecord(record, graphId);
+    const sessionOwner = operatorBySession.get(record.sessionId);
+    if (sessionOwner && sessionOwner !== record.operatorId) {
+      throw new Error(
+        `Session ${record.sessionId} is bound to both ${sessionOwner} and ${record.operatorId}`,
+      );
+    }
+    operatorBySession.set(record.sessionId, record.operatorId);
 
     let operator = operators[record.operatorId];
     if (!operator) {


### PR DESCRIPTION
## Summary

This is the first implementation slice of #1341.

- Add a read-only stream-graph projection over existing durable Agent runtime facts.
- Bind one durable Session to an operator identity and project each session-inline `AgentRun` as an activation.
- Convert each committed `RuntimeEvent` into one reference-only graph record with a stable record ID, immutable `eventTime`, a deterministic source `orderKey`, activation-local predecessor lineage, and bounded semantic facets.
- Keep records byte-stable across incremental observations: a late record may sort before an earlier observation, but it never renumbers or mutates an existing record.
- Exclude every `partial: true` event from graph input. The source ordinal counts committed events only, so legacy partial-row retention cannot renumber committed facts.
- Reconstruct operator/activation trace state through a pure, deterministic, idempotent replay reducer.
- Project every graph record into an always-on main-agent supervisor meta-stream. Permission and user-question facts become attention signals; terminal facts become milestone signals.
- Keep supervisor attention orthogonal to graph lifecycle. Nonterminal activations remain `running`; only terminal RuntimeEvents derive `completed` / `failed` / `aborted` / `cancelled`.
- Filter legacy same-session child AgentRuns from Session reads and fail closed if the pure projection is explicitly given a non-session-inline run.

## Authority and supervision boundary

This PR deliberately keeps the graph read-only.

The original `RuntimeEvent` remains authoritative. Graph records and supervisor meta-records contain source identity and lifecycle metadata but do not copy message text, tool arguments/results, or other large payloads. The supervisor projection reuses the same graph `recordId` and RuntimeEvent source reference, so it is a routing/read projection rather than a second fact.

The main-agent supervisor is structurally present beside the graph and observes every record without becoming a serial data-path gate. Attention signals identify facts that require semantic supervision; later auditable scheduler control records will carry the resulting intervention.

The adapter fails closed when immutable event reads are unavailable, identities are ambiguous, records conflict, source ordering is invalid, or an activation contains committed facts after its terminal record.

## Deliberate non-goals

- No graph execution, topology mutation, operator admission, cancellation, or retry.
- No resource scheduler or permits.
- No supervisor control-record authority yet.
- No graph-wide `completed` predicate. Observed child terminals cannot prove that topology and admission are closed; that requires a later explicit closing protocol.
- No Agent runtime rewrite and no changes to `agent_spawn` / `agent_swarm` behavior.

This addresses the first architectural tensions raised on #1341: projection remains honest while it is read-only, downstream graph inputs are committed facts only, records remain stable as concurrent observations arrive, and the always-on supervisor is visible without importing human-interaction wait states into graph lifecycle.

## Validation

- `npm run typecheck`
- focused stream-graph projection suite: 10 passed
- Runtime full suite: 2,445 passed, 7 skipped, 2 known unrelated macOS sandbox failures:
  - `/usr/local` executable-root ordering assertion
  - Homebrew `rg` unable to load PCRE2 inside the operation-scoped Seatbelt sandbox
- Biome check on all changed files
- `git diff --check`

Refs #1341

<details>
<summary>中文说明</summary>

这是 #1341 的第一个实现切片。

- 在现有持久化 Agent runtime facts 之上增加只读 stream-graph projection。
- 一个持久 Session 绑定一个 operator identity；其中每个 session-inline `AgentRun` 投影为一次 activation。
- 每个 committed `RuntimeEvent` 转换为一条只保存引用的 graph record，包含稳定 record ID、不可变 `eventTime`、确定性 source `orderKey`、activation 内 predecessor lineage，以及有界语义 facets。
- 增量观察不会改变旧 record：晚到 record 可以排到之前观察到的 record 前面，但不能重新编号或修改已有 record。
- 所有 `partial: true` 事件都不会进入 graph input；source ordinal 只计算 committed events，历史 partial row 是否保留不会导致 committed facts 重编号。
- 通过纯函数、确定性、幂等的 replay reducer 重建 operator/activation trace state。
- 每条 graph record 都同时进入主 Agent 的 always-on supervisor meta-stream。Permission 与 user-question facts 产生 attention signal；terminal facts 产生 milestone signal。
- Supervisor attention 与 graph lifecycle 正交。非终止 activation 始终保持 `running`；只有 terminal RuntimeEvent 才产生 `completed` / `failed` / `aborted` / `cancelled`。
- 从 Session 读取时过滤历史 same-session child AgentRuns；纯 projection 若显式收到 non-session-inline run 则 fail closed。

本 PR 刻意保持 graph 只读。原始 `RuntimeEvent` 仍是权威事实；graph record 与 supervisor meta-record 不复制消息正文、工具参数/结果或大块 payload。Supervisor projection 复用同一个 graph `recordId` 与 RuntimeEvent source reference，因此它是 routing/read projection，而不是第二套事实。

主 Agent supervisor 在结构上始终位于 graph 旁边，观察每条 record，但不会成为串行数据路径门禁。Attention signal 标记需要语义监督的事实；后续可审计 scheduler control record 再承载 supervisor 的干预结果。

本切片仍不执行 graph，不修改 topology，不做 admission/cancel/retry，不引入 resource scheduler，也暂不建立 supervisor control-record authority 或 graph-wide `completed` 协议。

</details>