### PR TITLE
feat(runtime): materialize trace graph topology

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -53,7 +53,8 @@
     "./runtime-runner": "./dist/runtime-runner.js",
     "./agent-flow": "./dist/agent-flow.js",
     "./ai-sdk-flow": "./dist/ai-sdk-flow.js",
-    "./stream-graph-projection": "./dist/stream-graph-projection.js"
+    "./stream-graph-projection": "./dist/stream-graph-projection.js",
+    "./stream-graph-trace": "./dist/stream-graph-trace.js"
   },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",

--- a/packages/runtime/src/__tests__/stream-graph-projection.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-projection.test.ts
@@ -232,6 +232,38 @@ describe('committed stream graph projection', () => {
     assert.deepEqual(reorderedWithDuplicates, canonical);
   });
 
+  test('replays reserved JavaScript property names as ordinary graph identities', () => {
+    const run = runHeader({
+      sessionId: 'reserved-session',
+      runId: 'constructor',
+      turnId: 'reserved-turn',
+      status: 'running',
+      createdAt: baseTs,
+    });
+    const { records } = projectAgentGraphRecords({
+      graphId: 'graph-reserved-identities',
+      streams: [
+        {
+          operator: { operatorId: '__proto__', sessionId: run.sessionId },
+          run,
+          events: [runtimeEvent(run, { id: 'toString', ts: baseTs + 1 })],
+        },
+      ],
+    });
+
+    const state = replayAgentGraphRecords(records);
+    assert.equal(Object.hasOwn(state.operators, '__proto__'), true);
+    assert.equal(state.operators['__proto__']?.operatorId, '__proto__');
+    assert.equal(
+      Object.hasOwn(state.operators['__proto__']?.activations ?? {}, 'constructor'),
+      true,
+    );
+    const reservedActivation = Object.entries(state.operators['__proto__']?.activations ?? {}).find(
+      ([activationId]) => activationId === 'constructor',
+    )?.[1];
+    assert.equal(reservedActivation?.agentRunId, 'constructor');
+  });
+
   test('rejects one Session projected under different operators across observations', () => {
     const run = runHeader({
       sessionId: 'child-a',

--- a/packages/runtime/src/__tests__/stream-graph-trace.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-trace.test.ts
@@ -1,0 +1,312 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { AgentRunHeader, RuntimeEvent } from '@maka/core';
+import { projectAgentGraphRecords } from '../stream-graph-projection.js';
+import {
+  AGENT_GRAPH_TRACE_SCHEMA_VERSION,
+  buildAgentGraphTraceSnapshot,
+  type AgentGraphTraceTopology,
+} from '../stream-graph-trace.js';
+
+const baseTs = 1_800_000_000_000;
+
+describe('stream graph trace topology', () => {
+  test('materializes deterministic direct-edge routes without putting the supervisor in the path', () => {
+    const research = runHeader('research', baseTs);
+    const verify = runHeader('verify', baseTs + 1);
+    const synthesize = runHeader('synthesize', baseTs + 2);
+    const audit = runHeader('audit', baseTs + 3);
+    const projection = projectAgentGraphRecords({
+      graphId: 'graph-trace',
+      streams: [
+        stream(research, 'research', [
+          runtimeEvent(research, 'research-message', baseTs + 10, 'private-research-payload'),
+        ]),
+        stream(verify, 'verify', [
+          runtimeEvent(verify, 'verify-message', baseTs + 5, 'private-verification-payload'),
+        ]),
+        stream(synthesize, 'synthesize', [
+          runtimeEvent(synthesize, 'synthesis-message', baseTs + 20, 'private-synthesis-payload'),
+        ]),
+      ],
+    });
+    const topology: AgentGraphTraceTopology = {
+      graphId: 'graph-trace',
+      operators: [
+        binding(audit, 'audit'),
+        binding(synthesize, 'synthesize'),
+        binding(verify, 'verify'),
+        binding(research, 'research'),
+      ],
+      edges: [
+        { edgeId: 'synthesis-to-audit', fromOperatorId: 'synthesize', toOperatorId: 'audit' },
+        { edgeId: 'verify-to-synthesis', fromOperatorId: 'verify', toOperatorId: 'synthesize' },
+        {
+          edgeId: 'research-to-synthesis',
+          fromOperatorId: 'research',
+          toOperatorId: 'synthesize',
+        },
+      ],
+    };
+
+    const snapshot = buildAgentGraphTraceSnapshot({
+      topology,
+      records: projection.records,
+    });
+
+    assert.equal(snapshot.schemaVersion, AGENT_GRAPH_TRACE_SCHEMA_VERSION);
+    assert.deepEqual(snapshot.topologicalOrder, ['research', 'verify', 'synthesize', 'audit']);
+    assert.deepEqual(snapshot.rootOperatorIds, ['research', 'verify']);
+    assert.deepEqual(snapshot.sinkOperatorIds, ['audit']);
+    assert.deepEqual(
+      snapshot.recordIds,
+      projection.records.map((record) => record.recordId),
+    );
+    assert.deepEqual(
+      snapshot.routes.map((route) => [
+        route.sourceOperatorId,
+        route.targetOperatorId,
+        route.sourceRecordId,
+      ]),
+      [
+        ['verify', 'synthesize', projection.records[0]!.recordId],
+        ['research', 'synthesize', projection.records[1]!.recordId],
+        ['synthesize', 'audit', projection.records[2]!.recordId],
+      ],
+      'records travel across direct edges only; trace routing does not recursively invent work',
+    );
+    assert.deepEqual(snapshot.operators.synthesize?.upstreamOperatorIds, ['research', 'verify']);
+    assert.equal(snapshot.operators.synthesize?.receivedRouteIds.length, 2);
+    assert.equal(snapshot.operators.audit?.receivedRouteIds.length, 1);
+    assert.equal(snapshot.operators.audit?.runtimeState, undefined);
+    assert.equal(
+      snapshot.operators.verify?.runtimeState?.activations[verify.runId]?.recordCount,
+      1,
+    );
+    assert.deepEqual(
+      projection.supervisorMetaStream.map((record) => record.recordId),
+      projection.records.map((record) => record.recordId),
+      'the always-on supervisor continues to observe source records independently',
+    );
+    assert.doesNotMatch(
+      JSON.stringify(snapshot),
+      /private-(research|verification|synthesis)-payload/,
+    );
+  });
+
+  test('is deterministic and idempotent for reordered duplicate observations', () => {
+    const source = runHeader('source', baseTs);
+    const target = runHeader('target', baseTs + 1);
+    const projection = projectAgentGraphRecords({
+      graphId: 'graph-replay',
+      streams: [
+        stream(source, 'source', [
+          runtimeEvent(source, 'first', baseTs + 1, 'first'),
+          runtimeEvent(source, 'second', baseTs + 2, 'second'),
+        ]),
+      ],
+    });
+    const topology: AgentGraphTraceTopology = {
+      graphId: 'graph-replay',
+      operators: [binding(target, 'target'), binding(source, 'source')],
+      edges: [{ edgeId: 'source-to-target', fromOperatorId: 'source', toOperatorId: 'target' }],
+    };
+
+    const canonical = buildAgentGraphTraceSnapshot({
+      topology,
+      records: projection.records,
+    });
+    const replayed = buildAgentGraphTraceSnapshot({
+      topology: {
+        ...topology,
+        operators: [...topology.operators].reverse(),
+        edges: [...topology.edges].reverse(),
+      },
+      records: [
+        projection.records[1]!,
+        projection.records[0]!,
+        projection.records[1]!,
+        projection.records[0]!,
+      ],
+    });
+
+    assert.deepEqual(replayed, canonical);
+    assert.equal(new Set(canonical.routes.map((route) => route.routeId)).size, 2);
+  });
+
+  test('keeps existing route identities stable as later observations arrive', () => {
+    const source = runHeader('source', baseTs);
+    const target = runHeader('target', baseTs + 1);
+    const initialProjection = projectAgentGraphRecords({
+      graphId: 'graph-incremental',
+      streams: [stream(source, 'source', [runtimeEvent(source, 'first', baseTs + 10, 'first')])],
+    });
+    const expandedProjection = projectAgentGraphRecords({
+      graphId: 'graph-incremental',
+      streams: [
+        stream(source, 'source', [
+          runtimeEvent(source, 'first', baseTs + 10, 'first'),
+          runtimeEvent(source, 'second', baseTs + 20, 'second'),
+        ]),
+      ],
+    });
+    const topology: AgentGraphTraceTopology = {
+      graphId: 'graph-incremental',
+      operators: [binding(source, 'source'), binding(target, 'target')],
+      edges: [{ edgeId: 'source-to-target', fromOperatorId: 'source', toOperatorId: 'target' }],
+    };
+
+    const initial = buildAgentGraphTraceSnapshot({
+      topology,
+      records: initialProjection.records,
+    });
+    const expanded = buildAgentGraphTraceSnapshot({
+      topology,
+      records: expandedProjection.records,
+    });
+
+    assert.deepEqual(expanded.routes[0], initial.routes[0]);
+    assert.equal(expanded.routes.length, 2);
+  });
+
+  test('retains an observable topology before any runtime facts arrive', () => {
+    const source = runHeader('source', baseTs);
+    const target = runHeader('target', baseTs + 1);
+
+    const snapshot = buildAgentGraphTraceSnapshot({
+      topology: {
+        graphId: 'graph-empty-trace',
+        operators: [binding(target, 'target'), binding(source, 'source')],
+        edges: [{ edgeId: 'source-to-target', fromOperatorId: 'source', toOperatorId: 'target' }],
+      },
+      records: [],
+    });
+
+    assert.deepEqual(snapshot.topologicalOrder, ['source', 'target']);
+    assert.deepEqual(snapshot.rootOperatorIds, ['source']);
+    assert.deepEqual(snapshot.sinkOperatorIds, ['target']);
+    assert.deepEqual(snapshot.recordIds, []);
+    assert.deepEqual(snapshot.routes, []);
+    assert.equal(snapshot.operators.source?.runtimeState, undefined);
+    assert.equal(snapshot.operators.target?.runtimeState, undefined);
+  });
+
+  test('fails closed on invalid topology and record ownership', () => {
+    const one = runHeader('one', baseTs);
+    const two = runHeader('two', baseTs + 1);
+    const three = runHeader('three', baseTs + 2);
+    const projection = projectAgentGraphRecords({
+      graphId: 'graph-invalid',
+      streams: [stream(one, 'one', [runtimeEvent(one, 'one-message', baseTs + 1, 'one')])],
+    });
+
+    assert.throws(
+      () =>
+        buildAgentGraphTraceSnapshot({
+          topology: {
+            graphId: 'graph-invalid',
+            operators: [binding(one, 'one'), binding(two, 'two'), binding(three, 'three')],
+            edges: [
+              { edgeId: 'one-two', fromOperatorId: 'one', toOperatorId: 'two' },
+              { edgeId: 'two-three', fromOperatorId: 'two', toOperatorId: 'three' },
+              { edgeId: 'three-one', fromOperatorId: 'three', toOperatorId: 'one' },
+            ],
+          },
+          records: projection.records,
+        }),
+      /contains a cycle involving: one, three, two/,
+    );
+    assert.throws(
+      () =>
+        buildAgentGraphTraceSnapshot({
+          topology: {
+            graphId: 'graph-invalid',
+            operators: [binding(one, 'one'), binding(two, 'two')],
+            edges: [{ edgeId: 'one-missing', fromOperatorId: 'one', toOperatorId: 'missing' }],
+          },
+          records: projection.records,
+        }),
+      /unknown target missing/,
+    );
+    assert.throws(
+      () =>
+        buildAgentGraphTraceSnapshot({
+          topology: {
+            graphId: 'graph-invalid',
+            operators: [{ operatorId: 'one', sessionId: 'different-session' }, binding(two, 'two')],
+            edges: [{ edgeId: 'one-two', fromOperatorId: 'one', toOperatorId: 'two' }],
+          },
+          records: projection.records,
+        }),
+      /Topology operator one is bound to different-session/,
+    );
+    assert.throws(
+      () =>
+        buildAgentGraphTraceSnapshot({
+          topology: {
+            graphId: 'different-graph',
+            operators: [binding(one, 'one'), binding(two, 'two')],
+            edges: [{ edgeId: 'one-two', fromOperatorId: 'one', toOperatorId: 'two' }],
+          },
+          records: projection.records,
+        }),
+      /cannot observe records from graph graph-invalid/,
+    );
+    assert.throws(
+      () =>
+        buildAgentGraphTraceSnapshot({
+          topology: {
+            graphId: 'graph-invalid',
+            operators: [binding(two, 'two')],
+            edges: [],
+          },
+          records: projection.records,
+        }),
+      /unknown topology operator one/,
+    );
+  });
+});
+
+function runHeader(name: string, createdAt: number): AgentRunHeader {
+  return {
+    sessionId: `session-${name}`,
+    runId: `run-${name}`,
+    turnId: `turn-${name}`,
+    invocationId: `invocation-${name}`,
+    backendKind: 'ai-sdk',
+    llmConnectionSlug: 'deepseek',
+    modelId: 'deepseek-chat',
+    cwd: '/workspace',
+    permissionMode: 'explore',
+    status: 'running',
+    createdAt,
+    updatedAt: createdAt + 1,
+  };
+}
+
+function binding(run: AgentRunHeader, operatorId: string) {
+  return { operatorId, sessionId: run.sessionId };
+}
+
+function stream(run: AgentRunHeader, operatorId: string, events: readonly RuntimeEvent[]) {
+  return {
+    operator: binding(run, operatorId),
+    run,
+    events,
+  };
+}
+
+function runtimeEvent(run: AgentRunHeader, id: string, ts: number, text: string): RuntimeEvent {
+  return {
+    id,
+    invocationId: run.invocationId ?? `invocation-${run.runId}`,
+    runId: run.runId,
+    sessionId: run.sessionId,
+    turnId: run.turnId,
+    ts,
+    partial: false,
+    role: 'model',
+    author: 'agent',
+    content: { kind: 'text', text },
+  };
+}

--- a/packages/runtime/src/__tests__/stream-graph-trace.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-trace.test.ts
@@ -191,6 +191,88 @@ describe('stream graph trace topology', () => {
     assert.equal(snapshot.operators.target?.runtimeState, undefined);
   });
 
+  test('materializes reserved JavaScript property names as own snapshot keys', () => {
+    const source = {
+      ...runHeader('reserved-source', baseTs),
+      runId: 'constructor',
+      invocationId: 'reserved-invocation',
+    };
+    const target = runHeader('reserved-target', baseTs + 1);
+    const projection = projectAgentGraphRecords({
+      graphId: 'graph-reserved-keys',
+      streams: [
+        stream(source, '__proto__', [
+          runtimeEvent(source, 'reserved-record', baseTs + 1, 'reserved'),
+        ]),
+      ],
+    });
+
+    const snapshot = buildAgentGraphTraceSnapshot({
+      topology: {
+        graphId: 'graph-reserved-keys',
+        operators: [binding(source, '__proto__'), binding(target, 'toString')],
+        edges: [
+          {
+            edgeId: '__proto__',
+            fromOperatorId: '__proto__',
+            toOperatorId: 'toString',
+          },
+        ],
+      },
+      records: projection.records,
+    });
+
+    assert.equal(Object.hasOwn(snapshot.operators, '__proto__'), true);
+    assert.equal(Object.hasOwn(snapshot.operators, 'toString'), true);
+    assert.equal(Object.hasOwn(snapshot.edges, '__proto__'), true);
+    assert.equal(snapshot.edges['__proto__']?.routeIds.length, 1);
+    assert.equal(
+      Object.hasOwn(
+        snapshot.operators['__proto__']?.runtimeState?.activations ?? {},
+        'constructor',
+      ),
+      true,
+    );
+  });
+
+  test('binds route identity to immutable edge endpoints', () => {
+    const source = runHeader('route-source', baseTs);
+    const targetA = runHeader('route-target-a', baseTs + 1);
+    const targetB = runHeader('route-target-b', baseTs + 2);
+    const projection = projectAgentGraphRecords({
+      graphId: 'graph-edge-rebinding',
+      streams: [
+        stream(source, 'source', [runtimeEvent(source, 'source-record', baseTs + 1, 'source')]),
+      ],
+    });
+    const operators = [
+      binding(source, 'source'),
+      binding(targetA, 'target-a'),
+      binding(targetB, 'target-b'),
+    ];
+
+    const first = buildAgentGraphTraceSnapshot({
+      topology: {
+        graphId: 'graph-edge-rebinding',
+        operators,
+        edges: [{ edgeId: 'edge', fromOperatorId: 'source', toOperatorId: 'target-a' }],
+      },
+      records: projection.records,
+    });
+    const rebound = buildAgentGraphTraceSnapshot({
+      topology: {
+        graphId: 'graph-edge-rebinding',
+        operators,
+        edges: [{ edgeId: 'edge', fromOperatorId: 'source', toOperatorId: 'target-b' }],
+      },
+      records: projection.records,
+    });
+
+    assert.notEqual(first.routes[0]?.routeId, rebound.routes[0]?.routeId);
+    assert.equal(first.routes[0]?.targetOperatorId, 'target-a');
+    assert.equal(rebound.routes[0]?.targetOperatorId, 'target-b');
+  });
+
   test('fails closed on invalid topology and record ownership', () => {
     const one = runHeader('one', baseTs);
     const two = runHeader('two', baseTs + 1);

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -63,6 +63,19 @@ export type {
   ProjectAgentGraphRecordsInput,
   ReadCommittedAgentGraphProjectionInput,
 } from './stream-graph-projection.js';
+export {
+  AGENT_GRAPH_TRACE_SCHEMA_VERSION,
+  buildAgentGraphTraceSnapshot,
+} from './stream-graph-trace.js';
+export type {
+  AgentGraphTraceEdge,
+  AgentGraphTraceEdgeState,
+  AgentGraphTraceOperatorState,
+  AgentGraphTraceRoute,
+  AgentGraphTraceSnapshot,
+  AgentGraphTraceTopology,
+  BuildAgentGraphTraceSnapshotInput,
+} from './stream-graph-trace.js';
 
 export { PermissionEngine, createDefaultPermissionEngineDeps } from './permission-engine.js';
 export type { EvaluateResult, EvaluateInput, PermissionEngineDeps } from './permission-engine.js';

--- a/packages/runtime/src/stream-graph-projection.ts
+++ b/packages/runtime/src/stream-graph-projection.ts
@@ -191,6 +191,10 @@ interface OrderedRuntimeEvent {
   committedEventOrdinal: number;
 }
 
+interface MutableAgentGraphOperatorState extends Omit<AgentGraphOperatorState, 'activations'> {
+  activations: Map<string, AgentGraphActivationState>;
+}
+
 export async function readCommittedAgentGraphProjection(
   input: ReadCommittedAgentGraphProjectionInput,
 ): Promise<AgentGraphProjection> {
@@ -376,7 +380,7 @@ export function replayAgentGraphRecords(
 
   const ordered = [...uniqueRecords.values()].sort(compareAgentGraphRecords);
   const graphId = ordered[0]!.graphId;
-  const operators: Record<string, AgentGraphOperatorState> = {};
+  const operatorsById = new Map<string, MutableAgentGraphOperatorState>();
   const operatorBySession = new Map<string, string>();
 
   for (const record of ordered) {
@@ -389,23 +393,23 @@ export function replayAgentGraphRecords(
     }
     operatorBySession.set(record.sessionId, record.operatorId);
 
-    let operator = operators[record.operatorId];
+    let operator = operatorsById.get(record.operatorId);
     if (!operator) {
       operator = {
         operatorId: record.operatorId,
         sessionId: record.sessionId,
         status: 'running',
         currentActivationId: record.activationId,
-        activations: {},
+        activations: new Map(),
       };
-      operators[record.operatorId] = operator;
+      operatorsById.set(record.operatorId, operator);
     } else if (operator.sessionId !== record.sessionId) {
       throw new Error(
         `Operator ${record.operatorId} is bound to both ${operator.sessionId} and ${record.sessionId}`,
       );
     }
 
-    let activation = operator.activations[record.activationId];
+    let activation = operator.activations.get(record.activationId);
     if (!activation) {
       activation = {
         activationId: record.activationId,
@@ -416,7 +420,7 @@ export function replayAgentGraphRecords(
         lastEventTime: record.eventTime,
         lastRecordId: record.recordId,
       };
-      operator.activations[record.activationId] = activation;
+      operator.activations.set(record.activationId, activation);
     } else {
       if (activation.agentRunId !== record.agentRunId) {
         throw new Error(`Activation ${record.activationId} references multiple AgentRuns`);
@@ -440,6 +444,19 @@ export function replayAgentGraphRecords(
     operator.currentActivationId = activation.activationId;
     operator.status = activation.status;
   }
+
+  const operators: Record<string, AgentGraphOperatorState> = Object.fromEntries(
+    [...operatorsById].map(([operatorId, operator]) => {
+      const { activations, ...operatorState } = operator;
+      return [
+        operatorId,
+        {
+          ...operatorState,
+          activations: Object.fromEntries(activations),
+        },
+      ];
+    }),
+  );
 
   return {
     graphId,

--- a/packages/runtime/src/stream-graph-trace.ts
+++ b/packages/runtime/src/stream-graph-trace.ts
@@ -1,0 +1,355 @@
+import { stableHash } from './request-shape.js';
+import {
+  replayAgentGraphRecords,
+  type AgentGraphOperatorBinding,
+  type AgentGraphOperatorState,
+  type AgentGraphRecord,
+} from './stream-graph-projection.js';
+
+export const AGENT_GRAPH_TRACE_SCHEMA_VERSION = 1 as const;
+
+/**
+ * One directed record path between two existing operator bindings.
+ *
+ * Edges deliberately do not own readiness policy. Every committed source
+ * record is visible on every direct outgoing edge; a later operator adapter
+ * can decide locally which inputs make one activation runnable.
+ */
+export interface AgentGraphTraceEdge {
+  edgeId: string;
+  fromOperatorId: string;
+  toOperatorId: string;
+}
+
+/**
+ * Read-only DAG topology for a trace snapshot.
+ *
+ * The topology identifies existing Session-backed operators. It does not
+ * create, start, stop, or otherwise own those Sessions.
+ */
+export interface AgentGraphTraceTopology {
+  graphId: string;
+  operators: readonly AgentGraphOperatorBinding[];
+  edges: readonly AgentGraphTraceEdge[];
+}
+
+/**
+ * Reference-only observation that one committed graph record is visible to a
+ * direct downstream operator.
+ */
+export interface AgentGraphTraceRoute {
+  schemaVersion: typeof AGENT_GRAPH_TRACE_SCHEMA_VERSION;
+  routeId: string;
+  graphId: string;
+  edgeId: string;
+  sourceOperatorId: string;
+  targetOperatorId: string;
+  sourceActivationId: string;
+  sourceRecordId: string;
+  eventTime: number;
+}
+
+export interface AgentGraphTraceEdgeState extends AgentGraphTraceEdge {
+  routeIds: string[];
+  sourceRecordIds: string[];
+}
+
+export interface AgentGraphTraceOperatorState {
+  operatorId: string;
+  sessionId: string;
+  topologicalIndex: number;
+  upstreamOperatorIds: string[];
+  downstreamOperatorIds: string[];
+  emittedRecordIds: string[];
+  receivedRouteIds: string[];
+  runtimeState?: AgentGraphOperatorState;
+}
+
+/**
+ * Deterministic, trace-only materialization of topology plus committed facts.
+ *
+ * This snapshot has no graph-wide completion or runnable state. Those require
+ * explicit admission/closure and operator-readiness protocols in later slices.
+ */
+export interface AgentGraphTraceSnapshot {
+  schemaVersion: typeof AGENT_GRAPH_TRACE_SCHEMA_VERSION;
+  graphId: string;
+  topologicalOrder: string[];
+  rootOperatorIds: string[];
+  sinkOperatorIds: string[];
+  recordIds: string[];
+  operators: Record<string, AgentGraphTraceOperatorState>;
+  edges: Record<string, AgentGraphTraceEdgeState>;
+  routes: AgentGraphTraceRoute[];
+}
+
+export interface BuildAgentGraphTraceSnapshotInput {
+  topology: AgentGraphTraceTopology;
+  records: readonly AgentGraphRecord[];
+}
+
+interface ValidatedTopology {
+  operatorsById: Map<string, AgentGraphOperatorBinding>;
+  edges: AgentGraphTraceEdge[];
+  incoming: Map<string, AgentGraphTraceEdge[]>;
+  outgoing: Map<string, AgentGraphTraceEdge[]>;
+  topologicalOrder: string[];
+}
+
+export function buildAgentGraphTraceSnapshot(
+  input: BuildAgentGraphTraceSnapshotInput,
+): AgentGraphTraceSnapshot {
+  const validated = validateTopology(input.topology);
+  const replay =
+    input.records.length > 0
+      ? replayAgentGraphRecords(input.records)
+      : {
+          graphId: input.topology.graphId,
+          appliedRecordIds: [],
+          operators: {},
+        };
+
+  if (replay.graphId !== input.topology.graphId) {
+    throw new Error(
+      `Trace topology ${input.topology.graphId} cannot observe records from graph ${replay.graphId}`,
+    );
+  }
+
+  const recordsById = new Map(input.records.map((record) => [record.recordId, record]));
+  const orderedRecords = replay.appliedRecordIds.map((recordId) => recordsById.get(recordId)!);
+  for (const record of orderedRecords) {
+    const binding = validated.operatorsById.get(record.operatorId);
+    if (!binding) {
+      throw new Error(
+        `Graph record ${record.recordId} references unknown topology operator ${record.operatorId}`,
+      );
+    }
+    if (binding.sessionId !== record.sessionId) {
+      throw new Error(
+        `Topology operator ${record.operatorId} is bound to ${binding.sessionId}, record uses ${record.sessionId}`,
+      );
+    }
+  }
+
+  const topologicalIndex = new Map(
+    validated.topologicalOrder.map((operatorId, index) => [operatorId, index]),
+  );
+  const compareOperators = (a: string, b: string): number =>
+    topologicalIndex.get(a)! - topologicalIndex.get(b)! || a.localeCompare(b);
+
+  const operators: Record<string, AgentGraphTraceOperatorState> = {};
+  for (const operatorId of validated.topologicalOrder) {
+    const binding = validated.operatorsById.get(operatorId)!;
+    operators[operatorId] = {
+      operatorId,
+      sessionId: binding.sessionId,
+      topologicalIndex: topologicalIndex.get(operatorId)!,
+      upstreamOperatorIds: uniqueOperatorIds(
+        (validated.incoming.get(operatorId) ?? []).map((edge) => edge.fromOperatorId),
+        compareOperators,
+      ),
+      downstreamOperatorIds: uniqueOperatorIds(
+        (validated.outgoing.get(operatorId) ?? []).map((edge) => edge.toOperatorId),
+        compareOperators,
+      ),
+      emittedRecordIds: [],
+      receivedRouteIds: [],
+      ...(replay.operators[operatorId]
+        ? { runtimeState: cloneOperatorState(replay.operators[operatorId]) }
+        : {}),
+    };
+  }
+
+  const edges: Record<string, AgentGraphTraceEdgeState> = {};
+  for (const edge of validated.edges) {
+    edges[edge.edgeId] = {
+      ...edge,
+      routeIds: [],
+      sourceRecordIds: [],
+    };
+  }
+
+  const routes: AgentGraphTraceRoute[] = [];
+  for (const record of orderedRecords) {
+    operators[record.operatorId]!.emittedRecordIds.push(record.recordId);
+    const outgoing = [...(validated.outgoing.get(record.operatorId) ?? [])].sort(
+      (a, b) =>
+        compareOperators(a.toOperatorId, b.toOperatorId) || a.edgeId.localeCompare(b.edgeId),
+    );
+    for (const edge of outgoing) {
+      const route: AgentGraphTraceRoute = {
+        schemaVersion: AGENT_GRAPH_TRACE_SCHEMA_VERSION,
+        routeId: traceRouteId(input.topology.graphId, edge.edgeId, record.recordId),
+        graphId: input.topology.graphId,
+        edgeId: edge.edgeId,
+        sourceOperatorId: edge.fromOperatorId,
+        targetOperatorId: edge.toOperatorId,
+        sourceActivationId: record.activationId,
+        sourceRecordId: record.recordId,
+        eventTime: record.eventTime,
+      };
+      routes.push(route);
+      edges[edge.edgeId]!.routeIds.push(route.routeId);
+      edges[edge.edgeId]!.sourceRecordIds.push(record.recordId);
+      operators[edge.toOperatorId]!.receivedRouteIds.push(route.routeId);
+    }
+  }
+
+  return {
+    schemaVersion: AGENT_GRAPH_TRACE_SCHEMA_VERSION,
+    graphId: input.topology.graphId,
+    topologicalOrder: [...validated.topologicalOrder],
+    rootOperatorIds: validated.topologicalOrder.filter(
+      (operatorId) => (validated.incoming.get(operatorId) ?? []).length === 0,
+    ),
+    sinkOperatorIds: validated.topologicalOrder.filter(
+      (operatorId) => (validated.outgoing.get(operatorId) ?? []).length === 0,
+    ),
+    recordIds: replay.appliedRecordIds,
+    operators,
+    edges,
+    routes,
+  };
+}
+
+function validateTopology(topology: AgentGraphTraceTopology): ValidatedTopology {
+  if (!topology.graphId.trim()) throw new Error('Trace graph id must not be empty');
+  if (topology.operators.length === 0) {
+    throw new Error(`Trace graph ${topology.graphId} must contain at least one operator`);
+  }
+
+  const operatorsById = new Map<string, AgentGraphOperatorBinding>();
+  const operatorBySession = new Map<string, string>();
+  for (const operator of topology.operators) {
+    if (!operator.operatorId.trim()) throw new Error('Trace operator id must not be empty');
+    if (!operator.sessionId.trim()) throw new Error('Trace operator session id must not be empty');
+    if (operatorsById.has(operator.operatorId)) {
+      throw new Error(`Duplicate trace operator ${operator.operatorId}`);
+    }
+    const sessionOwner = operatorBySession.get(operator.sessionId);
+    if (sessionOwner) {
+      throw new Error(
+        `Session ${operator.sessionId} is bound to trace operators ${sessionOwner} and ${operator.operatorId}`,
+      );
+    }
+    operatorsById.set(operator.operatorId, { ...operator });
+    operatorBySession.set(operator.sessionId, operator.operatorId);
+  }
+
+  const edgeIds = new Set<string>();
+  const endpointPairs = new Set<string>();
+  const incoming = new Map<string, AgentGraphTraceEdge[]>();
+  const outgoing = new Map<string, AgentGraphTraceEdge[]>();
+  const edges = topology.edges.map((edge) => ({ ...edge })).sort(compareEdges);
+  for (const edge of edges) {
+    if (!edge.edgeId.trim()) throw new Error('Trace edge id must not be empty');
+    if (edgeIds.has(edge.edgeId)) throw new Error(`Duplicate trace edge ${edge.edgeId}`);
+    edgeIds.add(edge.edgeId);
+    if (!operatorsById.has(edge.fromOperatorId)) {
+      throw new Error(`Trace edge ${edge.edgeId} has unknown source ${edge.fromOperatorId}`);
+    }
+    if (!operatorsById.has(edge.toOperatorId)) {
+      throw new Error(`Trace edge ${edge.edgeId} has unknown target ${edge.toOperatorId}`);
+    }
+    if (edge.fromOperatorId === edge.toOperatorId) {
+      throw new Error(`Trace edge ${edge.edgeId} cannot be a self-loop`);
+    }
+    const endpointPair = `${edge.fromOperatorId}\0${edge.toOperatorId}`;
+    if (endpointPairs.has(endpointPair)) {
+      throw new Error(
+        `Trace graph has multiple edges from ${edge.fromOperatorId} to ${edge.toOperatorId}`,
+      );
+    }
+    endpointPairs.add(endpointPair);
+    addEdge(outgoing, edge.fromOperatorId, edge);
+    addEdge(incoming, edge.toOperatorId, edge);
+  }
+
+  const topologicalOrder = topologicalSort(operatorsById, outgoing, incoming);
+  return { operatorsById, edges, incoming, outgoing, topologicalOrder };
+}
+
+function topologicalSort(
+  operatorsById: ReadonlyMap<string, AgentGraphOperatorBinding>,
+  outgoing: ReadonlyMap<string, readonly AgentGraphTraceEdge[]>,
+  incoming: ReadonlyMap<string, readonly AgentGraphTraceEdge[]>,
+): string[] {
+  const remainingIncoming = new Map(
+    [...operatorsById.keys()].map((operatorId) => [
+      operatorId,
+      (incoming.get(operatorId) ?? []).length,
+    ]),
+  );
+  const ready = [...operatorsById.keys()]
+    .filter((operatorId) => remainingIncoming.get(operatorId) === 0)
+    .sort();
+  const ordered: string[] = [];
+
+  while (ready.length > 0) {
+    const operatorId = ready.shift()!;
+    ordered.push(operatorId);
+    for (const edge of [...(outgoing.get(operatorId) ?? [])].sort(compareEdges)) {
+      const remaining = remainingIncoming.get(edge.toOperatorId)! - 1;
+      remainingIncoming.set(edge.toOperatorId, remaining);
+      if (remaining === 0) {
+        insertSorted(ready, edge.toOperatorId);
+      }
+    }
+  }
+
+  if (ordered.length !== operatorsById.size) {
+    const cyclic = [...operatorsById.keys()]
+      .filter((operatorId) => !ordered.includes(operatorId))
+      .sort();
+    throw new Error(`Trace graph contains a cycle involving: ${cyclic.join(', ')}`);
+  }
+  return ordered;
+}
+
+function addEdge(
+  index: Map<string, AgentGraphTraceEdge[]>,
+  operatorId: string,
+  edge: AgentGraphTraceEdge,
+): void {
+  const edges = index.get(operatorId) ?? [];
+  edges.push(edge);
+  index.set(operatorId, edges);
+}
+
+function uniqueOperatorIds(
+  operatorIds: readonly string[],
+  compare: (a: string, b: string) => number,
+): string[] {
+  return [...new Set(operatorIds)].sort(compare);
+}
+
+function compareEdges(a: AgentGraphTraceEdge, b: AgentGraphTraceEdge): number {
+  return (
+    a.fromOperatorId.localeCompare(b.fromOperatorId) ||
+    a.toOperatorId.localeCompare(b.toOperatorId) ||
+    a.edgeId.localeCompare(b.edgeId)
+  );
+}
+
+function insertSorted(values: string[], value: string): void {
+  const index = values.findIndex((candidate) => value.localeCompare(candidate) < 0);
+  if (index === -1) values.push(value);
+  else values.splice(index, 0, value);
+}
+
+function traceRouteId(graphId: string, edgeId: string, sourceRecordId: string): string {
+  const hash = stableHash({ graphId, edgeId, sourceRecordId });
+  return `graph_route_${hash.slice('sha256:'.length, 'sha256:'.length + 32)}`;
+}
+
+function cloneOperatorState(state: AgentGraphOperatorState): AgentGraphOperatorState {
+  return {
+    ...state,
+    activations: Object.fromEntries(
+      Object.entries(state.activations).map(([activationId, activation]) => [
+        activationId,
+        { ...activation },
+      ]),
+    ),
+  };
+}

--- a/packages/runtime/src/stream-graph-trace.ts
+++ b/packages/runtime/src/stream-graph-trace.ts
@@ -137,10 +137,12 @@ export function buildAgentGraphTraceSnapshot(
   const compareOperators = (a: string, b: string): number =>
     topologicalIndex.get(a)! - topologicalIndex.get(b)! || a.localeCompare(b);
 
-  const operators: Record<string, AgentGraphTraceOperatorState> = {};
+  const replayOperators = new Map(Object.entries(replay.operators));
+  const operators = new Map<string, AgentGraphTraceOperatorState>();
   for (const operatorId of validated.topologicalOrder) {
     const binding = validated.operatorsById.get(operatorId)!;
-    operators[operatorId] = {
+    const runtimeState = replayOperators.get(operatorId);
+    operators.set(operatorId, {
       operatorId,
       sessionId: binding.sessionId,
       topologicalIndex: topologicalIndex.get(operatorId)!,
@@ -154,24 +156,22 @@ export function buildAgentGraphTraceSnapshot(
       ),
       emittedRecordIds: [],
       receivedRouteIds: [],
-      ...(replay.operators[operatorId]
-        ? { runtimeState: cloneOperatorState(replay.operators[operatorId]) }
-        : {}),
-    };
+      ...(runtimeState ? { runtimeState: cloneOperatorState(runtimeState) } : {}),
+    });
   }
 
-  const edges: Record<string, AgentGraphTraceEdgeState> = {};
+  const edges = new Map<string, AgentGraphTraceEdgeState>();
   for (const edge of validated.edges) {
-    edges[edge.edgeId] = {
+    edges.set(edge.edgeId, {
       ...edge,
       routeIds: [],
       sourceRecordIds: [],
-    };
+    });
   }
 
   const routes: AgentGraphTraceRoute[] = [];
   for (const record of orderedRecords) {
-    operators[record.operatorId]!.emittedRecordIds.push(record.recordId);
+    operators.get(record.operatorId)!.emittedRecordIds.push(record.recordId);
     const outgoing = [...(validated.outgoing.get(record.operatorId) ?? [])].sort(
       (a, b) =>
         compareOperators(a.toOperatorId, b.toOperatorId) || a.edgeId.localeCompare(b.edgeId),
@@ -179,7 +179,7 @@ export function buildAgentGraphTraceSnapshot(
     for (const edge of outgoing) {
       const route: AgentGraphTraceRoute = {
         schemaVersion: AGENT_GRAPH_TRACE_SCHEMA_VERSION,
-        routeId: traceRouteId(input.topology.graphId, edge.edgeId, record.recordId),
+        routeId: traceRouteId(input.topology.graphId, edge, record.recordId),
         graphId: input.topology.graphId,
         edgeId: edge.edgeId,
         sourceOperatorId: edge.fromOperatorId,
@@ -189,9 +189,9 @@ export function buildAgentGraphTraceSnapshot(
         eventTime: record.eventTime,
       };
       routes.push(route);
-      edges[edge.edgeId]!.routeIds.push(route.routeId);
-      edges[edge.edgeId]!.sourceRecordIds.push(record.recordId);
-      operators[edge.toOperatorId]!.receivedRouteIds.push(route.routeId);
+      edges.get(edge.edgeId)!.routeIds.push(route.routeId);
+      edges.get(edge.edgeId)!.sourceRecordIds.push(record.recordId);
+      operators.get(edge.toOperatorId)!.receivedRouteIds.push(route.routeId);
     }
   }
 
@@ -206,8 +206,8 @@ export function buildAgentGraphTraceSnapshot(
       (operatorId) => (validated.outgoing.get(operatorId) ?? []).length === 0,
     ),
     recordIds: replay.appliedRecordIds,
-    operators,
-    edges,
+    operators: Object.fromEntries(operators),
+    edges: Object.fromEntries(edges),
     routes,
   };
 }
@@ -337,8 +337,15 @@ function insertSorted(values: string[], value: string): void {
   else values.splice(index, 0, value);
 }
 
-function traceRouteId(graphId: string, edgeId: string, sourceRecordId: string): string {
-  const hash = stableHash({ graphId, edgeId, sourceRecordId });
+function traceRouteId(graphId: string, edge: AgentGraphTraceEdge, sourceRecordId: string): string {
+  const hash = stableHash({
+    schemaVersion: AGENT_GRAPH_TRACE_SCHEMA_VERSION,
+    graphId,
+    edgeId: edge.edgeId,
+    fromOperatorId: edge.fromOperatorId,
+    toOperatorId: edge.toOperatorId,
+    sourceRecordId,
+  });
   return `graph_route_${hash.slice('sha256:'.length, 'sha256:'.length + 32)}`;
 }
 


### PR DESCRIPTION
## Summary

This is the second implementation slice of #1341, building on the committed-event projection merged in #1442.

- Add an explicit read-only DAG topology over existing Session-backed operator bindings.
- Validate graph identity, one-to-one operator/Session ownership, unique directed edges, known endpoints, and acyclicity.
- Derive an input-order-independent topological order with deterministic root and sink sets.
- Project each committed graph record as a stable, reference-only route across every direct outgoing edge; route identity binds the trace schema, edge ID, immutable endpoints, and source record.
- Materialize an observable snapshot for operators, edges, source records, and routed inputs, including topology that has not produced RuntimeEvents yet.
- Reuse committed-record replay as the validation and ordering authority, preserving deterministic/idempotent reconstruction under reordered and duplicate observations.
- Keep route identity stable as later observations arrive.

## Architectural boundary

This PR is still trace-only. It makes topology and record flow explicit without creating another execution authority.

A route says that an existing committed record is visible on one direct downstream edge. It references the source graph record and never copies message or tool payloads. It also does not recursively invent downstream work: only a RuntimeEvent emitted by that downstream operator can produce records on its own outgoing edges.

The main-agent supervisor remains structurally beside the graph. The existing always-on supervisor meta-stream continues to observe every source record independently; it is not consulted before a route appears and therefore cannot become a serial data-path gate.

Edges remain mechanically simple and route every committed source record. Operator-local readiness, buffering, joins, and semantic input selection belong to a later slice rather than a growing central scheduler DSL.

## Validation and failure semantics

Topology materialization fails closed for:

- empty graph/operator/Session/edge identities;
- duplicate operator or Session ownership;
- duplicate edge identities or parallel endpoint pairs;
- unknown endpoints, self-loops, and cycles;
- graph, operator, or Session ownership mismatches between topology and committed records;
- any conflicting or invalid committed-record replay rejected by the #1442 projection primitive.

## Deliberate non-goals

- No Agent runtime actions: no child creation, start, send, resume, cancel, or pause.
- No operator readiness/admission protocol or resource permits.
- No scheduler control-record authority.
- No graph-wide completion or topology-closing protocol.
- No Desktop/TUI renderer yet; this PR provides the deterministic snapshot such a renderer can consume.
- No cyclic or distributed graph execution.

## Validation

- `npm run typecheck`
- focused projection + trace suites: 18 passed
- Runtime full suite: 2,454 passed, 7 skipped, 2 known unrelated macOS sandbox failures:
  - `/usr/local` executable-root ordering assertion
  - Homebrew `rg` cannot load PCRE2 inside the operation-scoped Seatbelt sandbox
- Biome check on all changed files
- `git diff --check`

Refs #1341

<details>
<summary>中文说明</summary>

这是 #1341 的第二个实现切片，建立在 #1442 已合并的 committed-event projection 之上。

- 在现有 Session-backed operator binding 之上增加显式、只读的 DAG topology。
- 校验 graph identity、operator/Session 一对一归属、edge 唯一性、endpoint 存在性与无环性。
- 生成不受输入顺序影响的确定性拓扑序，以及稳定的 root/sink 集合。
- 每条 committed graph record 都会在直接下游 edge 上生成稳定、只保存引用的 route；route identity 同时绑定 trace schema、edge ID、不可变 endpoints 与 source record。
- 物化 operator、edge、source record 与 routed input 的可观测 snapshot；即使 RuntimeEvent 尚未产生，topology 仍然可见。
- 复用 #1442 的 committed-record replay 作为校验与排序权威，因此乱序或重复观察仍能确定、幂等地重建。
- 后续观察加入时，已有 route identity 保持稳定。

本 PR 仍然是 trace-only。Route 只表示一条现有 committed record 在某条直接下游 edge 上可见，不复制 message/tool payload，也不会递归伪造下游执行。只有下游 operator 自己真实产生 RuntimeEvent，才会在它的 outgoing edge 上继续形成 record route。

主 Agent supervisor 始终在图旁监督。现有 always-on supervisor meta-stream 独立观察每条 source record；route 的形成无需等待 supervisor 批准，因此 supervisor 不会成为串行 data-path gate。

Edge 保持机械和简单：转发所有 committed source record。Operator-local readiness、buffering、join 和语义输入筛选留给后续切片，避免把中央 scheduler 扩展成领域 DSL。

本切片不会创建、启动、发消息、恢复、取消或暂停 child，不引入 readiness/admission、resource permits、scheduler control authority、graph-wide completion/closing protocol，也暂不实现 Desktop/TUI renderer。

</details>