### PR TITLE
feat(runtime): derive operator-local graph readiness

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -54,7 +54,8 @@
     "./agent-flow": "./dist/agent-flow.js",
     "./ai-sdk-flow": "./dist/ai-sdk-flow.js",
     "./stream-graph-projection": "./dist/stream-graph-projection.js",
-    "./stream-graph-trace": "./dist/stream-graph-trace.js"
+    "./stream-graph-trace": "./dist/stream-graph-trace.js",
+    "./stream-graph-readiness": "./dist/stream-graph-readiness.js"
   },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",

--- a/packages/runtime/src/__tests__/stream-graph-projection.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-projection.test.ts
@@ -412,6 +412,49 @@ describe('committed stream graph projection', () => {
     assert.equal(replayAgentGraphRecords(records).appliedRecordIds.length, 2);
   });
 
+  test('orders locale-equivalent Unicode source identities independently of stream input order', () => {
+    const precomposedId = '\u00e9';
+    const decomposedId = 'e\u0301';
+    assert.equal(precomposedId.localeCompare(decomposedId), 0);
+    const precomposed = runHeader({
+      sessionId: 'child-precomposed',
+      runId: precomposedId,
+      turnId: 'turn-precomposed',
+      status: 'running',
+      createdAt: baseTs,
+    });
+    const decomposed = runHeader({
+      sessionId: 'child-decomposed',
+      runId: decomposedId,
+      turnId: 'turn-decomposed',
+      status: 'running',
+      createdAt: baseTs,
+    });
+    const streams = [
+      {
+        operator: { operatorId: precomposedId, sessionId: precomposed.sessionId },
+        run: precomposed,
+        events: [runtimeEvent(precomposed, { id: precomposedId, ts: baseTs + 1 })],
+      },
+      {
+        operator: { operatorId: decomposedId, sessionId: decomposed.sessionId },
+        run: decomposed,
+        events: [runtimeEvent(decomposed, { id: decomposedId, ts: baseTs + 1 })],
+      },
+    ];
+
+    const canonical = projectAgentGraphRecords({
+      graphId: 'graph-unicode-order',
+      streams,
+    });
+    const reversed = projectAgentGraphRecords({
+      graphId: 'graph-unicode-order',
+      streams: [...streams].reverse(),
+    });
+
+    assert.deepEqual(reversed, canonical);
+  });
+
   test('routes human-interaction facts to the always-on supervisor without blocking lifecycle', () => {
     const run = runHeader({
       sessionId: 'child-a',

--- a/packages/runtime/src/__tests__/stream-graph-readiness.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-readiness.test.ts
@@ -1,0 +1,497 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { AgentRunHeader, RuntimeEvent } from '@maka/core';
+import {
+  AGENT_GRAPH_READINESS_SCHEMA_VERSION,
+  buildAgentGraphReadinessSnapshot,
+  type AgentGraphReadinessPolicy,
+} from '../stream-graph-readiness.js';
+import { projectAgentGraphRecords } from '../stream-graph-projection.js';
+import type { AgentGraphTraceTopology } from '../stream-graph-trace.js';
+
+const baseTs = 1_800_000_000_000;
+
+describe('operator-local stream graph readiness', () => {
+  test('derives one stable map intent per direct input route without supervisor gating', () => {
+    const source = runHeader('source', baseTs);
+    const worker = runHeader('worker', baseTs + 1);
+    const projection = projectAgentGraphRecords({
+      graphId: 'graph-map',
+      streams: [
+        stream(source, 'source', [
+          runtimeEvent(source, 'first', baseTs + 1, 'private-first-payload'),
+          runtimeEvent(source, 'second', baseTs + 2, 'private-second-payload'),
+        ]),
+      ],
+    });
+    const topology: AgentGraphTraceTopology = {
+      graphId: 'graph-map',
+      operators: [binding(worker, 'worker'), binding(source, 'source')],
+      edges: [{ edgeId: 'source-worker', fromOperatorId: 'source', toOperatorId: 'worker' }],
+    };
+    const policies: AgentGraphReadinessPolicy[] = [
+      { readinessId: 'worker-map', operatorId: 'worker', kind: 'map' },
+    ];
+
+    const snapshot = buildAgentGraphReadinessSnapshot({
+      topology,
+      records: projection.records,
+      policies,
+    });
+    const state = snapshot.readiness['worker-map'];
+
+    assert.equal(snapshot.schemaVersion, AGENT_GRAPH_READINESS_SCHEMA_VERSION);
+    assert.equal(state?.status, 'runnable');
+    assert.equal(state?.intents.length, 2);
+    assert.deepEqual(
+      state?.intents.map((intent) => intent.triggerRouteIds),
+      snapshot.trace.routes.map((route) => [route.routeId]),
+    );
+    assert.deepEqual(
+      state?.intents.map((intent) => intent.triggerRecordIds),
+      projection.records.map((record) => [record.recordId]),
+    );
+    assert.equal(new Set(state?.intents.map((intent) => intent.intentId)).size, 2);
+    assert.deepEqual(snapshot.supervisorView, [
+      {
+        graphId: 'graph-map',
+        topologyFingerprint: snapshot.topologyFingerprint,
+        readinessId: 'worker-map',
+        operatorId: 'worker',
+        policyKind: 'map',
+        policyFingerprint: state?.policyFingerprint,
+        status: 'runnable',
+        intentIds: state?.intents.map((intent) => intent.intentId),
+        waitingFor: [],
+      },
+    ]);
+    assert.doesNotMatch(JSON.stringify(snapshot), /private-(first|second)-payload/);
+
+    const replayed = buildAgentGraphReadinessSnapshot({
+      topology: {
+        ...topology,
+        operators: [...topology.operators].reverse(),
+        edges: [...topology.edges].reverse(),
+      },
+      records: [
+        projection.records[1]!,
+        projection.records[0]!,
+        projection.records[1]!,
+        projection.records[0]!,
+      ],
+      policies: [...policies].reverse(),
+    });
+    assert.deepEqual(replayed, snapshot);
+  });
+
+  test('keeps a map operator waiting while exposing that state to the supervisor', () => {
+    const source = runHeader('empty-source', baseTs);
+    const worker = runHeader('empty-worker', baseTs + 1);
+    const snapshot = buildAgentGraphReadinessSnapshot({
+      topology: {
+        graphId: 'graph-map-waiting',
+        operators: [binding(source, 'source'), binding(worker, 'worker')],
+        edges: [{ edgeId: 'source-worker', fromOperatorId: 'source', toOperatorId: 'worker' }],
+      },
+      records: [],
+      policies: [{ readinessId: 'worker-map', operatorId: 'worker', kind: 'map' }],
+    });
+
+    assert.deepEqual(snapshot.readiness['worker-map']?.waitingFor, [
+      { kind: 'input_route', upstreamOperatorIds: ['source'] },
+    ]);
+    assert.equal(snapshot.readiness['worker-map']?.status, 'waiting');
+    assert.deepEqual(snapshot.supervisorView[0]?.waitingFor, [
+      { kind: 'input_route', upstreamOperatorIds: ['source'] },
+    ]);
+  });
+
+  test('waits for an exact all-settled activation frontier and accepts every terminal outcome', () => {
+    const branchA = runHeader('branch-a', baseTs, 'completed');
+    const branchBRunning = runHeader('branch-b', baseTs + 1);
+    const branchBFailed = { ...branchBRunning, status: 'failed' as const, completedAt: baseTs + 4 };
+    const branchC = runHeader('branch-c', baseTs + 2, 'completed');
+    const join = runHeader('join', baseTs + 3);
+    const topology: AgentGraphTraceTopology = {
+      graphId: 'graph-all-settled',
+      operators: [
+        binding(join, 'join'),
+        binding(branchC, 'branch-c'),
+        binding(branchBRunning, 'branch-b'),
+        binding(branchA, 'branch-a'),
+      ],
+      edges: [
+        { edgeId: 'c-join', fromOperatorId: 'branch-c', toOperatorId: 'join' },
+        { edgeId: 'a-join', fromOperatorId: 'branch-a', toOperatorId: 'join' },
+        { edgeId: 'b-join', fromOperatorId: 'branch-b', toOperatorId: 'join' },
+      ],
+    };
+    const policy: AgentGraphReadinessPolicy = {
+      readinessId: 'join-all',
+      operatorId: 'join',
+      kind: 'all_settled',
+      inputs: [
+        { operatorId: 'branch-c', activationId: branchC.runId },
+        { operatorId: 'branch-b', activationId: branchBRunning.runId },
+        { operatorId: 'branch-a', activationId: branchA.runId },
+      ],
+    };
+    const partial = projectAgentGraphRecords({
+      graphId: 'graph-all-settled',
+      streams: [
+        stream(branchA, 'branch-a', [
+          terminalEvent(branchA, 'a-completed', baseTs + 10, 'completed'),
+        ]),
+        stream(branchBRunning, 'branch-b', [
+          runtimeEvent(branchBRunning, 'b-progress', baseTs + 11, 'progress'),
+        ]),
+      ],
+    });
+
+    const waiting = buildAgentGraphReadinessSnapshot({
+      topology,
+      records: partial.records,
+      policies: [policy],
+    });
+    assert.equal(waiting.readiness['join-all']?.status, 'waiting');
+    assert.deepEqual(waiting.readiness['join-all']?.waitingFor, [
+      {
+        kind: 'activation_running',
+        operatorId: 'branch-b',
+        activationId: branchBRunning.runId,
+      },
+      {
+        kind: 'activation_missing',
+        operatorId: 'branch-c',
+        activationId: branchC.runId,
+      },
+    ]);
+
+    const settled = projectAgentGraphRecords({
+      graphId: 'graph-all-settled',
+      streams: [
+        stream(branchA, 'branch-a', [
+          terminalEvent(branchA, 'a-completed', baseTs + 10, 'completed'),
+        ]),
+        stream(branchBFailed, 'branch-b', [
+          terminalEvent(branchBFailed, 'b-failed', baseTs + 12, 'failed'),
+        ]),
+        stream(branchC, 'branch-c', [
+          terminalEvent(branchC, 'c-completed', baseTs + 13, 'completed'),
+        ]),
+      ],
+    });
+    const runnable = buildAgentGraphReadinessSnapshot({
+      topology,
+      records: settled.records,
+      policies: [policy],
+    });
+    const intent = runnable.readiness['join-all']?.intents[0];
+    assert.equal(runnable.readiness['join-all']?.status, 'runnable');
+    assert.deepEqual(runnable.readiness['join-all']?.waitingFor, []);
+    assert.deepEqual(runnable.readiness['join-all']?.sealedInputs, [
+      { operatorId: 'branch-a', activationId: branchA.runId },
+      { operatorId: 'branch-b', activationId: branchBRunning.runId },
+      { operatorId: 'branch-c', activationId: branchC.runId },
+    ]);
+    assert.deepEqual(
+      intent?.triggerRecordIds,
+      ['a-completed', 'b-failed', 'c-completed'].map(
+        (eventId) =>
+          settled.records.find((record) => record.source.runtimeEventId === eventId)!.recordId,
+      ),
+    );
+  });
+
+  test('does not let a later follow-up activation rewrite a sealed all-settled intent', () => {
+    const branchA = runHeader('sealed-a', baseTs, 'completed');
+    const branchAFollowup = runHeader(
+      'sealed-a-followup',
+      baseTs + 20,
+      'running',
+      branchA.sessionId,
+    );
+    const branchB = runHeader('sealed-b', baseTs + 1, 'completed');
+    const join = runHeader('sealed-join', baseTs + 2);
+    const topology: AgentGraphTraceTopology = {
+      graphId: 'graph-sealed-frontier',
+      operators: [binding(branchA, 'a'), binding(branchB, 'b'), binding(join, 'join')],
+      edges: [
+        { edgeId: 'a-join', fromOperatorId: 'a', toOperatorId: 'join' },
+        { edgeId: 'b-join', fromOperatorId: 'b', toOperatorId: 'join' },
+      ],
+    };
+    const policies: AgentGraphReadinessPolicy[] = [
+      {
+        readinessId: 'join-all',
+        operatorId: 'join',
+        kind: 'all_settled',
+        inputs: [
+          { operatorId: 'a', activationId: branchA.runId },
+          { operatorId: 'b', activationId: branchB.runId },
+        ],
+      },
+    ];
+    const settledStreams = [
+      stream(branchA, 'a', [terminalEvent(branchA, 'a-completed', baseTs + 10, 'completed')]),
+      stream(branchB, 'b', [terminalEvent(branchB, 'b-completed', baseTs + 11, 'completed')]),
+    ];
+    const initial = projectAgentGraphRecords({
+      graphId: 'graph-sealed-frontier',
+      streams: settledStreams,
+    });
+    const withFollowup = projectAgentGraphRecords({
+      graphId: 'graph-sealed-frontier',
+      streams: [
+        ...settledStreams,
+        stream(branchAFollowup, 'a', [
+          runtimeEvent(branchAFollowup, 'a-followup-progress', baseTs + 21, 'new work'),
+        ]),
+      ],
+    });
+
+    const before = buildAgentGraphReadinessSnapshot({
+      topology,
+      records: initial.records,
+      policies,
+    });
+    const after = buildAgentGraphReadinessSnapshot({
+      topology,
+      records: withFollowup.records,
+      policies,
+    });
+
+    assert.equal(after.trace.operators.a?.runtimeState?.status, 'running');
+    assert.equal(after.readiness['join-all']?.status, 'runnable');
+    assert.deepEqual(after.readiness['join-all']?.intents, before.readiness['join-all']?.intents);
+  });
+
+  test('invalidates intent identity when the canonical topology changes', () => {
+    const source = runHeader('fingerprint-source', baseTs);
+    const worker = runHeader('fingerprint-worker', baseTs + 1);
+    const observer = runHeader('fingerprint-observer', baseTs + 2);
+    const records = projectAgentGraphRecords({
+      graphId: 'graph-fingerprint',
+      streams: [stream(source, 'source', [runtimeEvent(source, 'record', baseTs + 1, 'record')])],
+    }).records;
+    const policy: AgentGraphReadinessPolicy = {
+      readinessId: 'worker-map',
+      operatorId: 'worker',
+      kind: 'map',
+    };
+    const initial = buildAgentGraphReadinessSnapshot({
+      topology: {
+        graphId: 'graph-fingerprint',
+        operators: [binding(source, 'source'), binding(worker, 'worker')],
+        edges: [{ edgeId: 'source-worker', fromOperatorId: 'source', toOperatorId: 'worker' }],
+      },
+      records,
+      policies: [policy],
+    });
+    const expanded = buildAgentGraphReadinessSnapshot({
+      topology: {
+        graphId: 'graph-fingerprint',
+        operators: [
+          binding(observer, 'observer'),
+          binding(worker, 'worker'),
+          binding(source, 'source'),
+        ],
+        edges: [{ edgeId: 'source-worker', fromOperatorId: 'source', toOperatorId: 'worker' }],
+      },
+      records,
+      policies: [policy],
+    });
+
+    assert.notEqual(initial.topologyFingerprint, expanded.topologyFingerprint);
+    assert.notEqual(
+      initial.readiness['worker-map']?.intents[0]?.intentId,
+      expanded.readiness['worker-map']?.intents[0]?.intentId,
+    );
+  });
+
+  test('keeps reserved JavaScript property names safe in readiness identities', () => {
+    const source = runHeader('reserved-source', baseTs);
+    const worker = runHeader('reserved-worker', baseTs + 1);
+    const records = projectAgentGraphRecords({
+      graphId: 'graph-reserved-readiness',
+      streams: [stream(source, 'source', [runtimeEvent(source, 'record', baseTs + 1, 'record')])],
+    }).records;
+
+    const snapshot = buildAgentGraphReadinessSnapshot({
+      topology: {
+        graphId: 'graph-reserved-readiness',
+        operators: [binding(source, 'source'), binding(worker, '__proto__')],
+        edges: [{ edgeId: 'toString', fromOperatorId: 'source', toOperatorId: '__proto__' }],
+      },
+      records,
+      policies: [{ readinessId: 'constructor', operatorId: '__proto__', kind: 'map' }],
+    });
+
+    assert.equal(Object.hasOwn(snapshot.readiness, 'constructor'), true);
+    const reservedState = Object.entries(snapshot.readiness).find(
+      ([readinessId]) => readinessId === 'constructor',
+    )?.[1];
+    assert.equal(reservedState?.operatorId, '__proto__');
+    assert.equal(reservedState?.status, 'runnable');
+  });
+
+  test('fails closed on ambiguous or incomplete local readiness policies', () => {
+    const sourceA = runHeader('invalid-a', baseTs);
+    const sourceB = runHeader('invalid-b', baseTs + 1);
+    const target = runHeader('invalid-target', baseTs + 2);
+    const topology: AgentGraphTraceTopology = {
+      graphId: 'graph-invalid-readiness',
+      operators: [binding(sourceA, 'a'), binding(sourceB, 'b'), binding(target, 'target')],
+      edges: [
+        { edgeId: 'a-target', fromOperatorId: 'a', toOperatorId: 'target' },
+        { edgeId: 'b-target', fromOperatorId: 'b', toOperatorId: 'target' },
+      ],
+    };
+
+    assert.throws(
+      () =>
+        buildAgentGraphReadinessSnapshot({
+          topology,
+          records: [],
+          policies: [
+            { readinessId: 'duplicate', operatorId: 'target', kind: 'map' },
+            { readinessId: 'duplicate', operatorId: 'target', kind: 'map' },
+          ],
+        }),
+      /Duplicate graph readiness duplicate/,
+    );
+    assert.throws(
+      () =>
+        buildAgentGraphReadinessSnapshot({
+          topology,
+          records: [],
+          policies: [
+            { readinessId: 'first', operatorId: 'target', kind: 'map' },
+            {
+              readinessId: 'second',
+              operatorId: 'target',
+              kind: 'all_settled',
+              inputs: [
+                { operatorId: 'a', activationId: sourceA.runId },
+                { operatorId: 'b', activationId: sourceB.runId },
+              ],
+            },
+          ],
+        }),
+      /Operator target has readiness policies first and second/,
+    );
+    assert.throws(
+      () =>
+        buildAgentGraphReadinessSnapshot({
+          topology,
+          records: [],
+          policies: [
+            {
+              readinessId: 'join',
+              operatorId: 'target',
+              kind: 'all_settled',
+              inputs: [{ operatorId: 'a', activationId: sourceA.runId }],
+            },
+          ],
+        }),
+      /does not seal upstream: b/,
+    );
+    assert.throws(
+      () =>
+        buildAgentGraphReadinessSnapshot({
+          topology,
+          records: [],
+          policies: [{ readinessId: 'root-map', operatorId: 'a', kind: 'map' }],
+        }),
+      /requires direct upstream input for a/,
+    );
+    assert.throws(
+      () =>
+        buildAgentGraphReadinessSnapshot({
+          topology,
+          records: [],
+          policies: [
+            {
+              readinessId: 'unsupported',
+              operatorId: 'target',
+              kind: 'quorum',
+            } as unknown as AgentGraphReadinessPolicy,
+          ],
+        }),
+      /Unsupported graph readiness policy quorum/,
+    );
+  });
+});
+
+function runHeader(
+  name: string,
+  createdAt: number,
+  status: AgentRunHeader['status'] = 'running',
+  sessionId = `session-${name}`,
+): AgentRunHeader {
+  return {
+    sessionId,
+    runId: `run-${name}`,
+    turnId: `turn-${name}`,
+    invocationId: `invocation-${name}`,
+    backendKind: 'ai-sdk',
+    llmConnectionSlug: 'deepseek',
+    modelId: 'deepseek-chat',
+    cwd: '/workspace',
+    permissionMode: 'explore',
+    status,
+    createdAt,
+    updatedAt: createdAt + 1,
+    ...(status === 'completed' || status === 'failed' || status === 'cancelled'
+      ? { completedAt: createdAt + 1 }
+      : {}),
+  };
+}
+
+function binding(run: AgentRunHeader, operatorId: string) {
+  return { operatorId, sessionId: run.sessionId };
+}
+
+function stream(run: AgentRunHeader, operatorId: string, events: readonly RuntimeEvent[]) {
+  return {
+    operator: binding(run, operatorId),
+    run,
+    events,
+  };
+}
+
+function runtimeEvent(run: AgentRunHeader, id: string, ts: number, text: string): RuntimeEvent {
+  return {
+    id,
+    invocationId: run.invocationId ?? `invocation-${run.runId}`,
+    runId: run.runId,
+    sessionId: run.sessionId,
+    turnId: run.turnId,
+    ts,
+    partial: false,
+    role: 'model',
+    author: 'agent',
+    content: { kind: 'text', text },
+  };
+}
+
+function terminalEvent(
+  run: AgentRunHeader,
+  id: string,
+  ts: number,
+  status: Extract<AgentRunHeader['status'], 'completed' | 'failed' | 'cancelled'>,
+): RuntimeEvent {
+  return {
+    id,
+    invocationId: run.invocationId ?? `invocation-${run.runId}`,
+    runId: run.runId,
+    sessionId: run.sessionId,
+    turnId: run.turnId,
+    ts,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    status,
+    actions: { endInvocation: true },
+  };
+}

--- a/packages/runtime/src/__tests__/stream-graph-readiness.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-readiness.test.ts
@@ -27,7 +27,13 @@ describe('operator-local stream graph readiness', () => {
     const topology: AgentGraphTraceTopology = {
       graphId: 'graph-map',
       operators: [binding(worker, 'worker'), binding(source, 'source')],
-      edges: [{ edgeId: 'source-worker', fromOperatorId: 'source', toOperatorId: 'worker' }],
+      edges: [
+        {
+          edgeId: 'source-worker',
+          fromOperatorId: 'source',
+          toOperatorId: 'worker',
+        },
+      ],
     };
     const policies: AgentGraphReadinessPolicy[] = [
       { readinessId: 'worker-map', operatorId: 'worker', kind: 'map' },
@@ -60,6 +66,7 @@ describe('operator-local stream graph readiness', () => {
         operatorId: 'worker',
         policyKind: 'map',
         policyFingerprint: state?.policyFingerprint,
+        readinessContextFingerprint: state?.readinessContextFingerprint,
         status: 'runnable',
         intentIds: state?.intents.map((intent) => intent.intentId),
         waitingFor: [],
@@ -91,7 +98,13 @@ describe('operator-local stream graph readiness', () => {
       topology: {
         graphId: 'graph-map-waiting',
         operators: [binding(source, 'source'), binding(worker, 'worker')],
-        edges: [{ edgeId: 'source-worker', fromOperatorId: 'source', toOperatorId: 'worker' }],
+        edges: [
+          {
+            edgeId: 'source-worker',
+            fromOperatorId: 'source',
+            toOperatorId: 'worker',
+          },
+        ],
       },
       records: [],
       policies: [{ readinessId: 'worker-map', operatorId: 'worker', kind: 'map' }],
@@ -109,7 +122,11 @@ describe('operator-local stream graph readiness', () => {
   test('waits for an exact all-settled activation frontier and accepts every terminal outcome', () => {
     const branchA = runHeader('branch-a', baseTs, 'completed');
     const branchBRunning = runHeader('branch-b', baseTs + 1);
-    const branchBFailed = { ...branchBRunning, status: 'failed' as const, completedAt: baseTs + 4 };
+    const branchBFailed = {
+      ...branchBRunning,
+      status: 'failed' as const,
+      completedAt: baseTs + 4,
+    };
     const branchC = runHeader('branch-c', baseTs + 2, 'completed');
     const join = runHeader('join', baseTs + 3);
     const topology: AgentGraphTraceTopology = {
@@ -266,7 +283,7 @@ describe('operator-local stream graph readiness', () => {
     assert.deepEqual(after.readiness['join-all']?.intents, before.readiness['join-all']?.intents);
   });
 
-  test('invalidates intent identity when the canonical topology changes', () => {
+  test('keeps local intent identity stable across unrelated and downstream-only topology changes', () => {
     const source = runHeader('fingerprint-source', baseTs);
     const worker = runHeader('fingerprint-worker', baseTs + 1);
     const observer = runHeader('fingerprint-observer', baseTs + 2);
@@ -283,12 +300,18 @@ describe('operator-local stream graph readiness', () => {
       topology: {
         graphId: 'graph-fingerprint',
         operators: [binding(source, 'source'), binding(worker, 'worker')],
-        edges: [{ edgeId: 'source-worker', fromOperatorId: 'source', toOperatorId: 'worker' }],
+        edges: [
+          {
+            edgeId: 'source-worker',
+            fromOperatorId: 'source',
+            toOperatorId: 'worker',
+          },
+        ],
       },
       records,
       policies: [policy],
     });
-    const expanded = buildAgentGraphReadinessSnapshot({
+    const disconnected = buildAgentGraphReadinessSnapshot({
       topology: {
         graphId: 'graph-fingerprint',
         operators: [
@@ -296,17 +319,113 @@ describe('operator-local stream graph readiness', () => {
           binding(worker, 'worker'),
           binding(source, 'source'),
         ],
-        edges: [{ edgeId: 'source-worker', fromOperatorId: 'source', toOperatorId: 'worker' }],
+        edges: [
+          {
+            edgeId: 'source-worker',
+            fromOperatorId: 'source',
+            toOperatorId: 'worker',
+          },
+        ],
+      },
+      records,
+      policies: [policy],
+    });
+    const downstreamOnly = buildAgentGraphReadinessSnapshot({
+      topology: {
+        graphId: 'graph-fingerprint',
+        operators: [
+          binding(observer, 'observer'),
+          binding(worker, 'worker'),
+          binding(source, 'source'),
+        ],
+        edges: [
+          {
+            edgeId: 'source-worker',
+            fromOperatorId: 'source',
+            toOperatorId: 'worker',
+          },
+          {
+            edgeId: 'worker-observer',
+            fromOperatorId: 'worker',
+            toOperatorId: 'observer',
+          },
+        ],
       },
       records,
       policies: [policy],
     });
 
-    assert.notEqual(initial.topologyFingerprint, expanded.topologyFingerprint);
-    assert.notEqual(
-      initial.readiness['worker-map']?.intents[0]?.intentId,
-      expanded.readiness['worker-map']?.intents[0]?.intentId,
+    assert.notEqual(initial.topologyFingerprint, disconnected.topologyFingerprint);
+    assert.notEqual(initial.topologyFingerprint, downstreamOnly.topologyFingerprint);
+    assert.deepEqual(
+      disconnected.readiness['worker-map']?.intents,
+      initial.readiness['worker-map']?.intents,
     );
+    assert.deepEqual(
+      downstreamOnly.readiness['worker-map']?.intents,
+      initial.readiness['worker-map']?.intents,
+    );
+  });
+
+  test('orders distinct Unicode identities canonically across topology and sealed inputs', () => {
+    const precomposed = runHeader('unicode-precomposed', baseTs);
+    const decomposed = runHeader('unicode-decomposed', baseTs + 1);
+    const join = runHeader('unicode-join', baseTs + 2);
+    const precomposedId = '\u00e9';
+    const decomposedId = 'e\u0301';
+    assert.equal(precomposedId.localeCompare(decomposedId), 0);
+
+    const operators = [
+      binding(precomposed, precomposedId),
+      binding(decomposed, decomposedId),
+      binding(join, 'join'),
+    ];
+    const edges = [
+      {
+        edgeId: 'precomposed-join',
+        fromOperatorId: precomposedId,
+        toOperatorId: 'join',
+      },
+      {
+        edgeId: 'decomposed-join',
+        fromOperatorId: decomposedId,
+        toOperatorId: 'join',
+      },
+    ];
+    const inputs = [
+      { operatorId: precomposedId, activationId: precomposed.runId },
+      { operatorId: decomposedId, activationId: decomposed.runId },
+    ];
+    const canonical = buildAgentGraphReadinessSnapshot({
+      topology: { graphId: 'graph-unicode-readiness', operators, edges },
+      records: [],
+      policies: [
+        {
+          readinessId: 'join-all',
+          operatorId: 'join',
+          kind: 'all_settled',
+          inputs,
+        },
+      ],
+    });
+    const reversed = buildAgentGraphReadinessSnapshot({
+      topology: {
+        graphId: 'graph-unicode-readiness',
+        operators: [...operators].reverse(),
+        edges: [...edges].reverse(),
+      },
+      records: [],
+      policies: [
+        {
+          readinessId: 'join-all',
+          operatorId: 'join',
+          kind: 'all_settled',
+          inputs: [...inputs].reverse(),
+        },
+      ],
+    });
+
+    assert.deepEqual(reversed, canonical);
   });
 
   test('keeps reserved JavaScript property names safe in readiness identities', () => {
@@ -321,7 +440,13 @@ describe('operator-local stream graph readiness', () => {
       topology: {
         graphId: 'graph-reserved-readiness',
         operators: [binding(source, 'source'), binding(worker, '__proto__')],
-        edges: [{ edgeId: 'toString', fromOperatorId: 'source', toOperatorId: '__proto__' }],
+        edges: [
+          {
+            edgeId: 'toString',
+            fromOperatorId: 'source',
+            toOperatorId: '__proto__',
+          },
+        ],
       },
       records,
       policies: [{ readinessId: 'constructor', operatorId: '__proto__', kind: 'map' }],

--- a/packages/runtime/src/__tests__/stream-graph-trace.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-trace.test.ts
@@ -39,8 +39,16 @@ describe('stream graph trace topology', () => {
         binding(research, 'research'),
       ],
       edges: [
-        { edgeId: 'synthesis-to-audit', fromOperatorId: 'synthesize', toOperatorId: 'audit' },
-        { edgeId: 'verify-to-synthesis', fromOperatorId: 'verify', toOperatorId: 'synthesize' },
+        {
+          edgeId: 'synthesis-to-audit',
+          fromOperatorId: 'synthesize',
+          toOperatorId: 'audit',
+        },
+        {
+          edgeId: 'verify-to-synthesis',
+          fromOperatorId: 'verify',
+          toOperatorId: 'synthesize',
+        },
         {
           edgeId: 'research-to-synthesis',
           fromOperatorId: 'research',
@@ -109,7 +117,13 @@ describe('stream graph trace topology', () => {
     const topology: AgentGraphTraceTopology = {
       graphId: 'graph-replay',
       operators: [binding(target, 'target'), binding(source, 'source')],
-      edges: [{ edgeId: 'source-to-target', fromOperatorId: 'source', toOperatorId: 'target' }],
+      edges: [
+        {
+          edgeId: 'source-to-target',
+          fromOperatorId: 'source',
+          toOperatorId: 'target',
+        },
+      ],
     };
 
     const canonical = buildAgentGraphTraceSnapshot({
@@ -134,6 +148,75 @@ describe('stream graph trace topology', () => {
     assert.equal(new Set(canonical.routes.map((route) => route.routeId)).size, 2);
   });
 
+  test('fingerprints only declared topology fields in raw identity order', () => {
+    const precomposed = runHeader('unicode-precomposed', baseTs);
+    const decomposed = runHeader('unicode-decomposed', baseTs + 1);
+    const target = runHeader('unicode-target', baseTs + 2);
+    const precomposedId = '\u00e9';
+    const decomposedId = 'e\u0301';
+    assert.equal(precomposedId.localeCompare(decomposedId), 0);
+
+    const canonical = buildAgentGraphTraceSnapshot({
+      topology: {
+        graphId: 'graph-canonical-fingerprint',
+        operators: [
+          binding(precomposed, precomposedId),
+          binding(decomposed, decomposedId),
+          binding(target, 'target'),
+        ],
+        edges: [
+          {
+            edgeId: 'precomposed-target',
+            fromOperatorId: precomposedId,
+            toOperatorId: 'target',
+          },
+          {
+            edgeId: 'decomposed-target',
+            fromOperatorId: decomposedId,
+            toOperatorId: 'target',
+          },
+        ],
+      },
+      records: [],
+    });
+    const noisyOperators = [
+      { ...binding(target, 'target'), displayName: 'ignored target' },
+      {
+        ...binding(decomposed, decomposedId),
+        displayName: 'ignored decomposed',
+      },
+      {
+        ...binding(precomposed, precomposedId),
+        displayName: 'ignored precomposed',
+      },
+    ];
+    const noisyEdges = [
+      {
+        edgeId: 'decomposed-target',
+        fromOperatorId: decomposedId,
+        toOperatorId: 'target',
+        debugColor: 'blue',
+      },
+      {
+        edgeId: 'precomposed-target',
+        fromOperatorId: precomposedId,
+        toOperatorId: 'target',
+        debugColor: 'red',
+      },
+    ];
+    const reorderedWithExtras = buildAgentGraphTraceSnapshot({
+      topology: {
+        graphId: 'graph-canonical-fingerprint',
+        operators: noisyOperators,
+        edges: noisyEdges,
+      },
+      records: [],
+    });
+
+    assert.deepEqual(reorderedWithExtras, canonical);
+    assert.equal(reorderedWithExtras.topologyFingerprint, canonical.topologyFingerprint);
+  });
+
   test('keeps existing route identities stable as later observations arrive', () => {
     const source = runHeader('source', baseTs);
     const target = runHeader('target', baseTs + 1);
@@ -153,7 +236,13 @@ describe('stream graph trace topology', () => {
     const topology: AgentGraphTraceTopology = {
       graphId: 'graph-incremental',
       operators: [binding(source, 'source'), binding(target, 'target')],
-      edges: [{ edgeId: 'source-to-target', fromOperatorId: 'source', toOperatorId: 'target' }],
+      edges: [
+        {
+          edgeId: 'source-to-target',
+          fromOperatorId: 'source',
+          toOperatorId: 'target',
+        },
+      ],
     };
 
     const initial = buildAgentGraphTraceSnapshot({
@@ -177,7 +266,13 @@ describe('stream graph trace topology', () => {
       topology: {
         graphId: 'graph-empty-trace',
         operators: [binding(target, 'target'), binding(source, 'source')],
-        edges: [{ edgeId: 'source-to-target', fromOperatorId: 'source', toOperatorId: 'target' }],
+        edges: [
+          {
+            edgeId: 'source-to-target',
+            fromOperatorId: 'source',
+            toOperatorId: 'target',
+          },
+        ],
       },
       records: [],
     });
@@ -255,7 +350,13 @@ describe('stream graph trace topology', () => {
       topology: {
         graphId: 'graph-edge-rebinding',
         operators,
-        edges: [{ edgeId: 'edge', fromOperatorId: 'source', toOperatorId: 'target-a' }],
+        edges: [
+          {
+            edgeId: 'edge',
+            fromOperatorId: 'source',
+            toOperatorId: 'target-a',
+          },
+        ],
       },
       records: projection.records,
     });
@@ -263,7 +364,13 @@ describe('stream graph trace topology', () => {
       topology: {
         graphId: 'graph-edge-rebinding',
         operators,
-        edges: [{ edgeId: 'edge', fromOperatorId: 'source', toOperatorId: 'target-b' }],
+        edges: [
+          {
+            edgeId: 'edge',
+            fromOperatorId: 'source',
+            toOperatorId: 'target-b',
+          },
+        ],
       },
       records: projection.records,
     });
@@ -290,8 +397,16 @@ describe('stream graph trace topology', () => {
             operators: [binding(one, 'one'), binding(two, 'two'), binding(three, 'three')],
             edges: [
               { edgeId: 'one-two', fromOperatorId: 'one', toOperatorId: 'two' },
-              { edgeId: 'two-three', fromOperatorId: 'two', toOperatorId: 'three' },
-              { edgeId: 'three-one', fromOperatorId: 'three', toOperatorId: 'one' },
+              {
+                edgeId: 'two-three',
+                fromOperatorId: 'two',
+                toOperatorId: 'three',
+              },
+              {
+                edgeId: 'three-one',
+                fromOperatorId: 'three',
+                toOperatorId: 'one',
+              },
             ],
           },
           records: projection.records,
@@ -304,7 +419,13 @@ describe('stream graph trace topology', () => {
           topology: {
             graphId: 'graph-invalid',
             operators: [binding(one, 'one'), binding(two, 'two')],
-            edges: [{ edgeId: 'one-missing', fromOperatorId: 'one', toOperatorId: 'missing' }],
+            edges: [
+              {
+                edgeId: 'one-missing',
+                fromOperatorId: 'one',
+                toOperatorId: 'missing',
+              },
+            ],
           },
           records: projection.records,
         }),

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -76,6 +76,22 @@ export type {
   AgentGraphTraceTopology,
   BuildAgentGraphTraceSnapshotInput,
 } from './stream-graph-trace.js';
+export {
+  AGENT_GRAPH_READINESS_SCHEMA_VERSION,
+  buildAgentGraphReadinessSnapshot,
+} from './stream-graph-readiness.js';
+export type {
+  AgentGraphAllSettledReadinessPolicy,
+  AgentGraphMapReadinessPolicy,
+  AgentGraphOperatorReadinessState,
+  AgentGraphReadinessPolicy,
+  AgentGraphReadinessSnapshot,
+  AgentGraphReadinessWait,
+  AgentGraphRunnableIntent,
+  AgentGraphSealedActivationInput,
+  AgentGraphSupervisorReadinessObservation,
+  BuildAgentGraphReadinessSnapshotInput,
+} from './stream-graph-readiness.js';
 
 export { PermissionEngine, createDefaultPermissionEngineDeps } from './permission-engine.js';
 export type { EvaluateResult, EvaluateInput, PermissionEngineDeps } from './permission-engine.js';

--- a/packages/runtime/src/stream-graph-identity.ts
+++ b/packages/runtime/src/stream-graph-identity.ts
@@ -1,0 +1,10 @@
+/**
+ * Locale-independent strict total order for opaque graph identities.
+ *
+ * JavaScript relational comparison uses UTF-16 code-unit order and, unlike
+ * localeCompare(), cannot collapse distinct strings such as precomposed and
+ * decomposed Unicode spellings into an ordering tie.
+ */
+export function compareAgentGraphIdentity(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/packages/runtime/src/stream-graph-projection.ts
+++ b/packages/runtime/src/stream-graph-projection.ts
@@ -1,6 +1,7 @@
 import type { AgentRunHeader, AgentRunStore, RuntimeEvent, RuntimeEventStore } from '@maka/core';
 import { isSessionInlineRun } from '@maka/core';
 import { stableHash, stableStringify } from './request-shape.js';
+import { compareAgentGraphIdentity } from './stream-graph-identity.js';
 
 export const AGENT_GRAPH_RECORD_SCHEMA_VERSION = 1 as const;
 
@@ -210,7 +211,7 @@ export async function readCommittedAgentGraphProjection(
         const runs = await input.runStore.listSessionRuns(operator.sessionId);
         const orderedRuns = runs
           .filter(isSessionInlineRun)
-          .sort((a, b) => a.createdAt - b.createdAt || a.runId.localeCompare(b.runId));
+          .sort((a, b) => a.createdAt - b.createdAt || compareAgentGraphIdentity(a.runId, b.runId));
         return await Promise.all(
           orderedRuns.map(async (run): Promise<AgentGraphRunStream> => {
             if (run.sessionId !== operator.sessionId) {
@@ -645,10 +646,10 @@ function compareOrderedRuntimeEvents(a: OrderedRuntimeEvent, b: OrderedRuntimeEv
   return (
     a.event.ts - b.event.ts ||
     a.run.createdAt - b.run.createdAt ||
-    a.operator.operatorId.localeCompare(b.operator.operatorId) ||
-    a.run.runId.localeCompare(b.run.runId) ||
+    compareAgentGraphIdentity(a.operator.operatorId, b.operator.operatorId) ||
+    compareAgentGraphIdentity(a.run.runId, b.run.runId) ||
     a.committedEventOrdinal - b.committedEventOrdinal ||
-    a.event.id.localeCompare(b.event.id)
+    compareAgentGraphIdentity(a.event.id, b.event.id)
   );
 }
 
@@ -656,11 +657,11 @@ function compareAgentGraphRecords(a: AgentGraphRecord, b: AgentGraphRecord): num
   return (
     a.eventTime - b.eventTime ||
     a.orderKey.runCreatedAt - b.orderKey.runCreatedAt ||
-    a.orderKey.operatorId.localeCompare(b.orderKey.operatorId) ||
-    a.orderKey.runId.localeCompare(b.orderKey.runId) ||
+    compareAgentGraphIdentity(a.orderKey.operatorId, b.orderKey.operatorId) ||
+    compareAgentGraphIdentity(a.orderKey.runId, b.orderKey.runId) ||
     a.orderKey.committedEventOrdinal - b.orderKey.committedEventOrdinal ||
-    a.orderKey.runtimeEventId.localeCompare(b.orderKey.runtimeEventId) ||
-    a.recordId.localeCompare(b.recordId)
+    compareAgentGraphIdentity(a.orderKey.runtimeEventId, b.orderKey.runtimeEventId) ||
+    compareAgentGraphIdentity(a.recordId, b.recordId)
   );
 }
 

--- a/packages/runtime/src/stream-graph-readiness.ts
+++ b/packages/runtime/src/stream-graph-readiness.ts
@@ -1,0 +1,448 @@
+import { stableHash } from './request-shape.js';
+import type {
+  AgentGraphActivationState,
+  AgentGraphActivationStatus,
+  AgentGraphRecord,
+} from './stream-graph-projection.js';
+import {
+  buildAgentGraphTraceSnapshot,
+  type AgentGraphTraceOperatorState,
+  type AgentGraphTraceRoute,
+  type AgentGraphTraceSnapshot,
+  type AgentGraphTraceTopology,
+} from './stream-graph-trace.js';
+
+export const AGENT_GRAPH_READINESS_SCHEMA_VERSION = 1 as const;
+
+export interface AgentGraphMapReadinessPolicy {
+  readinessId: string;
+  operatorId: string;
+  kind: 'map';
+}
+
+/**
+ * One immutable activation selected from a direct upstream operator.
+ *
+ * Requiring an explicit frontier prevents a later follow-up activation in the
+ * same Session from silently changing the meaning of an all-settled join.
+ */
+export interface AgentGraphSealedActivationInput {
+  operatorId: string;
+  activationId: string;
+}
+
+export interface AgentGraphAllSettledReadinessPolicy {
+  readinessId: string;
+  operatorId: string;
+  kind: 'all_settled';
+  inputs: readonly AgentGraphSealedActivationInput[];
+}
+
+export type AgentGraphReadinessPolicy =
+  | AgentGraphMapReadinessPolicy
+  | AgentGraphAllSettledReadinessPolicy;
+
+export type AgentGraphReadinessWait =
+  | {
+      kind: 'input_route';
+      upstreamOperatorIds: string[];
+    }
+  | {
+      kind: 'activation_missing';
+      operatorId: string;
+      activationId: string;
+    }
+  | {
+      kind: 'activation_running';
+      operatorId: string;
+      activationId: string;
+    };
+
+/**
+ * A deterministic candidate for later admission, not execution authority.
+ *
+ * A future control-plane slice must durably claim an intent before invoking
+ * Agent runtime actions. Recomputing this projection alone never starts work.
+ */
+export interface AgentGraphRunnableIntent {
+  schemaVersion: typeof AGENT_GRAPH_READINESS_SCHEMA_VERSION;
+  intentId: string;
+  graphId: string;
+  topologyFingerprint: string;
+  policyFingerprint: string;
+  readinessId: string;
+  operatorId: string;
+  policyKind: AgentGraphReadinessPolicy['kind'];
+  triggerRouteIds: string[];
+  triggerRecordIds: string[];
+}
+
+export interface AgentGraphOperatorReadinessState {
+  readinessId: string;
+  operatorId: string;
+  policyKind: AgentGraphReadinessPolicy['kind'];
+  policyFingerprint: string;
+  status: 'waiting' | 'runnable';
+  waitingFor: AgentGraphReadinessWait[];
+  intents: AgentGraphRunnableIntent[];
+  sealedInputs?: AgentGraphSealedActivationInput[];
+}
+
+/**
+ * Bounded side view for the always-on main-agent supervisor.
+ *
+ * Every local readiness state appears here. The supervisor observes the same
+ * deterministic result but is not consulted while the result is derived.
+ */
+export interface AgentGraphSupervisorReadinessObservation {
+  graphId: string;
+  topologyFingerprint: string;
+  readinessId: string;
+  operatorId: string;
+  policyKind: AgentGraphReadinessPolicy['kind'];
+  policyFingerprint: string;
+  status: AgentGraphOperatorReadinessState['status'];
+  intentIds: string[];
+  waitingFor: AgentGraphReadinessWait[];
+}
+
+export interface AgentGraphReadinessSnapshot {
+  schemaVersion: typeof AGENT_GRAPH_READINESS_SCHEMA_VERSION;
+  graphId: string;
+  topologyFingerprint: string;
+  trace: AgentGraphTraceSnapshot;
+  readiness: Record<string, AgentGraphOperatorReadinessState>;
+  supervisorView: AgentGraphSupervisorReadinessObservation[];
+}
+
+export interface BuildAgentGraphReadinessSnapshotInput {
+  topology: AgentGraphTraceTopology;
+  records: readonly AgentGraphRecord[];
+  policies: readonly AgentGraphReadinessPolicy[];
+}
+
+type NormalizedReadinessPolicy =
+  | AgentGraphMapReadinessPolicy
+  | (Omit<AgentGraphAllSettledReadinessPolicy, 'inputs'> & {
+      inputs: AgentGraphSealedActivationInput[];
+    });
+
+export function buildAgentGraphReadinessSnapshot(
+  input: BuildAgentGraphReadinessSnapshotInput,
+): AgentGraphReadinessSnapshot {
+  const trace = buildAgentGraphTraceSnapshot({
+    topology: input.topology,
+    records: input.records,
+  });
+  const operatorsById = new Map(Object.entries(trace.operators));
+  const policies = normalizeAndValidatePolicies(input.policies, operatorsById);
+  const routesById = new Map(trace.routes.map((route) => [route.routeId, route]));
+  const readiness = new Map<string, AgentGraphOperatorReadinessState>();
+
+  for (const policy of policies) {
+    const policyFingerprint = stableHash({
+      schemaVersion: AGENT_GRAPH_READINESS_SCHEMA_VERSION,
+      policy,
+    });
+    const state =
+      policy.kind === 'map'
+        ? evaluateMapReadiness(
+            trace,
+            operatorsById.get(policy.operatorId)!,
+            policy,
+            policyFingerprint,
+            routesById,
+          )
+        : evaluateAllSettledReadiness(trace, operatorsById, policy, policyFingerprint);
+    readiness.set(policy.readinessId, state);
+  }
+
+  const supervisorView = [...readiness.values()].map(
+    (state): AgentGraphSupervisorReadinessObservation => ({
+      graphId: trace.graphId,
+      topologyFingerprint: trace.topologyFingerprint,
+      readinessId: state.readinessId,
+      operatorId: state.operatorId,
+      policyKind: state.policyKind,
+      policyFingerprint: state.policyFingerprint,
+      status: state.status,
+      intentIds: state.intents.map((intent) => intent.intentId),
+      waitingFor: state.waitingFor.map(cloneWait),
+    }),
+  );
+
+  return {
+    schemaVersion: AGENT_GRAPH_READINESS_SCHEMA_VERSION,
+    graphId: trace.graphId,
+    topologyFingerprint: trace.topologyFingerprint,
+    trace,
+    readiness: Object.fromEntries(readiness),
+    supervisorView,
+  };
+}
+
+function evaluateMapReadiness(
+  trace: AgentGraphTraceSnapshot,
+  operator: AgentGraphTraceOperatorState,
+  policy: AgentGraphMapReadinessPolicy,
+  policyFingerprint: string,
+  routesById: ReadonlyMap<string, AgentGraphTraceRoute>,
+): AgentGraphOperatorReadinessState {
+  const routes = operator.receivedRouteIds.map((routeId) => {
+    const route = routesById.get(routeId);
+    if (!route || route.targetOperatorId !== policy.operatorId) {
+      throw new Error(`Invalid route ${routeId} in operator ${policy.operatorId} inbox`);
+    }
+    return route;
+  });
+  const intents = routes.map((route) => runnableIntent(trace, policy, policyFingerprint, [route]));
+
+  return {
+    readinessId: policy.readinessId,
+    operatorId: policy.operatorId,
+    policyKind: policy.kind,
+    policyFingerprint,
+    status: intents.length > 0 ? 'runnable' : 'waiting',
+    waitingFor:
+      intents.length > 0
+        ? []
+        : [
+            {
+              kind: 'input_route',
+              upstreamOperatorIds: [...operator.upstreamOperatorIds],
+            },
+          ],
+    intents,
+  };
+}
+
+function evaluateAllSettledReadiness(
+  trace: AgentGraphTraceSnapshot,
+  operatorsById: ReadonlyMap<string, AgentGraphTraceOperatorState>,
+  policy: Extract<NormalizedReadinessPolicy, { kind: 'all_settled' }>,
+  policyFingerprint: string,
+): AgentGraphOperatorReadinessState {
+  const waitingFor: AgentGraphReadinessWait[] = [];
+  const terminalRoutes: AgentGraphTraceRoute[] = [];
+
+  for (const input of policy.inputs) {
+    const upstream = operatorsById.get(input.operatorId)!;
+    const activation = findActivation(upstream.runtimeState?.activations, input.activationId);
+    if (!activation) {
+      waitingFor.push({ kind: 'activation_missing', ...input });
+      continue;
+    }
+    if (!isTerminalStatus(activation.status)) {
+      waitingFor.push({ kind: 'activation_running', ...input });
+      continue;
+    }
+    if (!activation.terminalRecordId) {
+      throw new Error(
+        `Settled activation ${input.operatorId}/${input.activationId} has no terminal record`,
+      );
+    }
+    const route = trace.routes.find(
+      (candidate) =>
+        candidate.sourceOperatorId === input.operatorId &&
+        candidate.targetOperatorId === policy.operatorId &&
+        candidate.sourceActivationId === input.activationId &&
+        candidate.sourceRecordId === activation.terminalRecordId,
+    );
+    if (!route) {
+      throw new Error(
+        `Terminal record ${activation.terminalRecordId} is not routed from ${input.operatorId} to ${policy.operatorId}`,
+      );
+    }
+    terminalRoutes.push(route);
+  }
+
+  const intents =
+    waitingFor.length === 0
+      ? [runnableIntent(trace, policy, policyFingerprint, terminalRoutes)]
+      : [];
+  return {
+    readinessId: policy.readinessId,
+    operatorId: policy.operatorId,
+    policyKind: policy.kind,
+    policyFingerprint,
+    status: intents.length > 0 ? 'runnable' : 'waiting',
+    waitingFor,
+    intents,
+    sealedInputs: policy.inputs.map((sealedInput) => ({ ...sealedInput })),
+  };
+}
+
+function normalizeAndValidatePolicies(
+  policies: readonly AgentGraphReadinessPolicy[],
+  operators: ReadonlyMap<string, AgentGraphTraceOperatorState>,
+): NormalizedReadinessPolicy[] {
+  const byReadiness = new Map<string, NormalizedReadinessPolicy>();
+  const readinessByOperator = new Map<string, string>();
+
+  for (const policy of policies) {
+    const policyKind: unknown = (policy as { kind?: unknown }).kind;
+    if (typeof policy.readinessId !== 'string' || !policy.readinessId.trim()) {
+      throw new Error('Readiness id must not be empty');
+    }
+    if (typeof policy.operatorId !== 'string' || !policy.operatorId.trim()) {
+      throw new Error('Readiness operator id must not be empty');
+    }
+    if (policyKind !== 'map' && policyKind !== 'all_settled') {
+      throw new Error(`Unsupported graph readiness policy ${String(policyKind)}`);
+    }
+    if (byReadiness.has(policy.readinessId)) {
+      throw new Error(`Duplicate graph readiness ${policy.readinessId}`);
+    }
+    const existingReadiness = readinessByOperator.get(policy.operatorId);
+    if (existingReadiness) {
+      throw new Error(
+        `Operator ${policy.operatorId} has readiness policies ${existingReadiness} and ${policy.readinessId}`,
+      );
+    }
+    const operator = operators.get(policy.operatorId);
+    if (!operator) {
+      throw new Error(
+        `Readiness ${policy.readinessId} references unknown operator ${policy.operatorId}`,
+      );
+    }
+    if (operator.upstreamOperatorIds.length === 0) {
+      throw new Error(
+        `Readiness ${policy.readinessId} requires direct upstream input for ${policy.operatorId}`,
+      );
+    }
+
+    const normalized: NormalizedReadinessPolicy =
+      policy.kind === 'map'
+        ? {
+            readinessId: policy.readinessId,
+            operatorId: policy.operatorId,
+            kind: 'map',
+          }
+        : {
+            readinessId: policy.readinessId,
+            operatorId: policy.operatorId,
+            kind: 'all_settled',
+            inputs: normalizeSealedInputs(policy),
+          };
+    if (normalized.kind === 'all_settled') {
+      validateAllSettledInputs(normalized, operator.upstreamOperatorIds);
+    }
+    byReadiness.set(policy.readinessId, normalized);
+    readinessByOperator.set(policy.operatorId, policy.readinessId);
+  }
+
+  return [...byReadiness.values()].sort((a, b) => a.readinessId.localeCompare(b.readinessId));
+}
+
+function normalizeSealedInputs(
+  policy: AgentGraphAllSettledReadinessPolicy,
+): AgentGraphSealedActivationInput[] {
+  if (!Array.isArray(policy.inputs)) {
+    throw new Error(`All-settled readiness ${policy.readinessId} requires sealed inputs`);
+  }
+  return policy.inputs
+    .map((input) => {
+      if (
+        !input ||
+        typeof input.operatorId !== 'string' ||
+        typeof input.activationId !== 'string' ||
+        !input.operatorId.trim() ||
+        !input.activationId.trim()
+      ) {
+        throw new Error(`All-settled readiness ${policy.readinessId} has an empty input identity`);
+      }
+      return {
+        operatorId: input.operatorId,
+        activationId: input.activationId,
+      };
+    })
+    .sort(compareSealedInputs);
+}
+
+function validateAllSettledInputs(
+  policy: Extract<NormalizedReadinessPolicy, { kind: 'all_settled' }>,
+  upstreamOperatorIds: readonly string[],
+): void {
+  if (policy.inputs.length === 0) {
+    throw new Error(`All-settled readiness ${policy.readinessId} requires sealed inputs`);
+  }
+  const inputOperators = new Set<string>();
+  for (const input of policy.inputs) {
+    if (inputOperators.has(input.operatorId)) {
+      throw new Error(
+        `All-settled readiness ${policy.readinessId} repeats upstream ${input.operatorId}`,
+      );
+    }
+    if (!upstreamOperatorIds.includes(input.operatorId)) {
+      throw new Error(
+        `All-settled readiness ${policy.readinessId} input ${input.operatorId} is not directly upstream of ${policy.operatorId}`,
+      );
+    }
+    inputOperators.add(input.operatorId);
+  }
+  const missing = upstreamOperatorIds.filter((operatorId) => !inputOperators.has(operatorId));
+  if (missing.length > 0) {
+    throw new Error(
+      `All-settled readiness ${policy.readinessId} does not seal upstream: ${missing.join(', ')}`,
+    );
+  }
+}
+
+function runnableIntent(
+  trace: AgentGraphTraceSnapshot,
+  policy: NormalizedReadinessPolicy,
+  policyFingerprint: string,
+  triggerRoutes: readonly AgentGraphTraceRoute[],
+): AgentGraphRunnableIntent {
+  const triggerRouteIds = triggerRoutes.map((route) => route.routeId);
+  const triggerRecordIds = triggerRoutes.map((route) => route.sourceRecordId);
+  const hash = stableHash({
+    schemaVersion: AGENT_GRAPH_READINESS_SCHEMA_VERSION,
+    graphId: trace.graphId,
+    topologyFingerprint: trace.topologyFingerprint,
+    policyFingerprint,
+    readinessId: policy.readinessId,
+    operatorId: policy.operatorId,
+    policyKind: policy.kind,
+    triggerRouteIds,
+    triggerRecordIds,
+  });
+  return {
+    schemaVersion: AGENT_GRAPH_READINESS_SCHEMA_VERSION,
+    intentId: `graph_intent_${hash.slice('sha256:'.length, 'sha256:'.length + 32)}`,
+    graphId: trace.graphId,
+    topologyFingerprint: trace.topologyFingerprint,
+    policyFingerprint,
+    readinessId: policy.readinessId,
+    operatorId: policy.operatorId,
+    policyKind: policy.kind,
+    triggerRouteIds,
+    triggerRecordIds,
+  };
+}
+
+function findActivation(
+  activations: Record<string, AgentGraphActivationState> | undefined,
+  activationId: string,
+): AgentGraphActivationState | undefined {
+  return Object.entries(activations ?? {}).find(([id]) => id === activationId)?.[1];
+}
+
+function isTerminalStatus(status: AgentGraphActivationStatus): boolean {
+  return (
+    status === 'completed' || status === 'failed' || status === 'aborted' || status === 'cancelled'
+  );
+}
+
+function compareSealedInputs(
+  a: AgentGraphSealedActivationInput,
+  b: AgentGraphSealedActivationInput,
+): number {
+  return a.operatorId.localeCompare(b.operatorId) || a.activationId.localeCompare(b.activationId);
+}
+
+function cloneWait(wait: AgentGraphReadinessWait): AgentGraphReadinessWait {
+  return wait.kind === 'input_route'
+    ? { ...wait, upstreamOperatorIds: [...wait.upstreamOperatorIds] }
+    : { ...wait };
+}

--- a/packages/runtime/src/stream-graph-readiness.ts
+++ b/packages/runtime/src/stream-graph-readiness.ts
@@ -4,6 +4,7 @@ import type {
   AgentGraphActivationStatus,
   AgentGraphRecord,
 } from './stream-graph-projection.js';
+import { compareAgentGraphIdentity } from './stream-graph-identity.js';
 import {
   buildAgentGraphTraceSnapshot,
   type AgentGraphTraceOperatorState,
@@ -68,7 +69,7 @@ export interface AgentGraphRunnableIntent {
   schemaVersion: typeof AGENT_GRAPH_READINESS_SCHEMA_VERSION;
   intentId: string;
   graphId: string;
-  topologyFingerprint: string;
+  readinessContextFingerprint: string;
   policyFingerprint: string;
   readinessId: string;
   operatorId: string;
@@ -82,6 +83,7 @@ export interface AgentGraphOperatorReadinessState {
   operatorId: string;
   policyKind: AgentGraphReadinessPolicy['kind'];
   policyFingerprint: string;
+  readinessContextFingerprint: string;
   status: 'waiting' | 'runnable';
   waitingFor: AgentGraphReadinessWait[];
   intents: AgentGraphRunnableIntent[];
@@ -101,6 +103,7 @@ export interface AgentGraphSupervisorReadinessObservation {
   operatorId: string;
   policyKind: AgentGraphReadinessPolicy['kind'];
   policyFingerprint: string;
+  readinessContextFingerprint: string;
   status: AgentGraphOperatorReadinessState['status'];
   intentIds: string[];
   waitingFor: AgentGraphReadinessWait[];
@@ -144,6 +147,11 @@ export function buildAgentGraphReadinessSnapshot(
       schemaVersion: AGENT_GRAPH_READINESS_SCHEMA_VERSION,
       policy,
     });
+    const readinessContextFingerprint = fingerprintReadinessContext(
+      trace,
+      operatorsById.get(policy.operatorId)!,
+      policyFingerprint,
+    );
     const state =
       policy.kind === 'map'
         ? evaluateMapReadiness(
@@ -151,9 +159,16 @@ export function buildAgentGraphReadinessSnapshot(
             operatorsById.get(policy.operatorId)!,
             policy,
             policyFingerprint,
+            readinessContextFingerprint,
             routesById,
           )
-        : evaluateAllSettledReadiness(trace, operatorsById, policy, policyFingerprint);
+        : evaluateAllSettledReadiness(
+            trace,
+            operatorsById,
+            policy,
+            policyFingerprint,
+            readinessContextFingerprint,
+          );
     readiness.set(policy.readinessId, state);
   }
 
@@ -165,6 +180,7 @@ export function buildAgentGraphReadinessSnapshot(
       operatorId: state.operatorId,
       policyKind: state.policyKind,
       policyFingerprint: state.policyFingerprint,
+      readinessContextFingerprint: state.readinessContextFingerprint,
       status: state.status,
       intentIds: state.intents.map((intent) => intent.intentId),
       waitingFor: state.waitingFor.map(cloneWait),
@@ -186,6 +202,7 @@ function evaluateMapReadiness(
   operator: AgentGraphTraceOperatorState,
   policy: AgentGraphMapReadinessPolicy,
   policyFingerprint: string,
+  readinessContextFingerprint: string,
   routesById: ReadonlyMap<string, AgentGraphTraceRoute>,
 ): AgentGraphOperatorReadinessState {
   const routes = operator.receivedRouteIds.map((routeId) => {
@@ -195,13 +212,16 @@ function evaluateMapReadiness(
     }
     return route;
   });
-  const intents = routes.map((route) => runnableIntent(trace, policy, policyFingerprint, [route]));
+  const intents = routes.map((route) =>
+    runnableIntent(trace, policy, policyFingerprint, readinessContextFingerprint, [route]),
+  );
 
   return {
     readinessId: policy.readinessId,
     operatorId: policy.operatorId,
     policyKind: policy.kind,
     policyFingerprint,
+    readinessContextFingerprint,
     status: intents.length > 0 ? 'runnable' : 'waiting',
     waitingFor:
       intents.length > 0
@@ -221,6 +241,7 @@ function evaluateAllSettledReadiness(
   operatorsById: ReadonlyMap<string, AgentGraphTraceOperatorState>,
   policy: Extract<NormalizedReadinessPolicy, { kind: 'all_settled' }>,
   policyFingerprint: string,
+  readinessContextFingerprint: string,
 ): AgentGraphOperatorReadinessState {
   const waitingFor: AgentGraphReadinessWait[] = [];
   const terminalRoutes: AgentGraphTraceRoute[] = [];
@@ -258,13 +279,22 @@ function evaluateAllSettledReadiness(
 
   const intents =
     waitingFor.length === 0
-      ? [runnableIntent(trace, policy, policyFingerprint, terminalRoutes)]
+      ? [
+          runnableIntent(
+            trace,
+            policy,
+            policyFingerprint,
+            readinessContextFingerprint,
+            terminalRoutes,
+          ),
+        ]
       : [];
   return {
     readinessId: policy.readinessId,
     operatorId: policy.operatorId,
     policyKind: policy.kind,
     policyFingerprint,
+    readinessContextFingerprint,
     status: intents.length > 0 ? 'runnable' : 'waiting',
     waitingFor,
     intents,
@@ -331,7 +361,9 @@ function normalizeAndValidatePolicies(
     readinessByOperator.set(policy.operatorId, policy.readinessId);
   }
 
-  return [...byReadiness.values()].sort((a, b) => a.readinessId.localeCompare(b.readinessId));
+  return [...byReadiness.values()].sort((a, b) =>
+    compareAgentGraphIdentity(a.readinessId, b.readinessId),
+  );
 }
 
 function normalizeSealedInputs(
@@ -392,6 +424,7 @@ function runnableIntent(
   trace: AgentGraphTraceSnapshot,
   policy: NormalizedReadinessPolicy,
   policyFingerprint: string,
+  readinessContextFingerprint: string,
   triggerRoutes: readonly AgentGraphTraceRoute[],
 ): AgentGraphRunnableIntent {
   const triggerRouteIds = triggerRoutes.map((route) => route.routeId);
@@ -399,7 +432,7 @@ function runnableIntent(
   const hash = stableHash({
     schemaVersion: AGENT_GRAPH_READINESS_SCHEMA_VERSION,
     graphId: trace.graphId,
-    topologyFingerprint: trace.topologyFingerprint,
+    readinessContextFingerprint,
     policyFingerprint,
     readinessId: policy.readinessId,
     operatorId: policy.operatorId,
@@ -411,7 +444,7 @@ function runnableIntent(
     schemaVersion: AGENT_GRAPH_READINESS_SCHEMA_VERSION,
     intentId: `graph_intent_${hash.slice('sha256:'.length, 'sha256:'.length + 32)}`,
     graphId: trace.graphId,
-    topologyFingerprint: trace.topologyFingerprint,
+    readinessContextFingerprint,
     policyFingerprint,
     readinessId: policy.readinessId,
     operatorId: policy.operatorId,
@@ -419,6 +452,36 @@ function runnableIntent(
     triggerRouteIds,
     triggerRecordIds,
   };
+}
+
+function fingerprintReadinessContext(
+  trace: AgentGraphTraceSnapshot,
+  operator: AgentGraphTraceOperatorState,
+  policyFingerprint: string,
+): string {
+  const incomingEdges = Object.values(trace.edges)
+    .filter((edge) => edge.toOperatorId === operator.operatorId)
+    .map(({ edgeId, fromOperatorId, toOperatorId }) => ({
+      edgeId,
+      fromOperatorId,
+      toOperatorId,
+    }))
+    .sort(
+      (a, b) =>
+        compareAgentGraphIdentity(a.fromOperatorId, b.fromOperatorId) ||
+        compareAgentGraphIdentity(a.toOperatorId, b.toOperatorId) ||
+        compareAgentGraphIdentity(a.edgeId, b.edgeId),
+    );
+  return stableHash({
+    schemaVersion: AGENT_GRAPH_READINESS_SCHEMA_VERSION,
+    graphId: trace.graphId,
+    targetOperator: {
+      operatorId: operator.operatorId,
+      sessionId: operator.sessionId,
+    },
+    incomingEdges,
+    policyFingerprint,
+  });
 }
 
 function findActivation(
@@ -438,7 +501,10 @@ function compareSealedInputs(
   a: AgentGraphSealedActivationInput,
   b: AgentGraphSealedActivationInput,
 ): number {
-  return a.operatorId.localeCompare(b.operatorId) || a.activationId.localeCompare(b.activationId);
+  return (
+    compareAgentGraphIdentity(a.operatorId, b.operatorId) ||
+    compareAgentGraphIdentity(a.activationId, b.activationId)
+  );
 }
 
 function cloneWait(wait: AgentGraphReadinessWait): AgentGraphReadinessWait {

--- a/packages/runtime/src/stream-graph-trace.ts
+++ b/packages/runtime/src/stream-graph-trace.ts
@@ -1,4 +1,5 @@
 import { stableHash } from './request-shape.js';
+import { compareAgentGraphIdentity } from './stream-graph-identity.js';
 import {
   replayAgentGraphRecords,
   type AgentGraphOperatorBinding,
@@ -137,7 +138,7 @@ export function buildAgentGraphTraceSnapshot(
     validated.topologicalOrder.map((operatorId, index) => [operatorId, index]),
   );
   const compareOperators = (a: string, b: string): number =>
-    topologicalIndex.get(a)! - topologicalIndex.get(b)! || a.localeCompare(b);
+    topologicalIndex.get(a)! - topologicalIndex.get(b)! || compareAgentGraphIdentity(a, b);
 
   const replayOperators = new Map(Object.entries(replay.operators));
   const operators = new Map<string, AgentGraphTraceOperatorState>();
@@ -176,7 +177,8 @@ export function buildAgentGraphTraceSnapshot(
     operators.get(record.operatorId)!.emittedRecordIds.push(record.recordId);
     const outgoing = [...(validated.outgoing.get(record.operatorId) ?? [])].sort(
       (a, b) =>
-        compareOperators(a.toOperatorId, b.toOperatorId) || a.edgeId.localeCompare(b.edgeId),
+        compareOperators(a.toOperatorId, b.toOperatorId) ||
+        compareAgentGraphIdentity(a.edgeId, b.edgeId),
     );
     for (const edge of outgoing) {
       const route: AgentGraphTraceRoute = {
@@ -219,10 +221,16 @@ function fingerprintTopology(graphId: string, topology: ValidatedTopology): stri
   return stableHash({
     schemaVersion: AGENT_GRAPH_TRACE_SCHEMA_VERSION,
     graphId,
-    operators: [...topology.operatorsById.values()].sort((a, b) =>
-      a.operatorId.localeCompare(b.operatorId),
-    ),
-    edges: topology.edges,
+    operators: [...topology.operatorsById.values()]
+      .map(({ operatorId, sessionId }) => ({ operatorId, sessionId }))
+      .sort((a, b) => compareAgentGraphIdentity(a.operatorId, b.operatorId)),
+    edges: topology.edges
+      .map(({ edgeId, fromOperatorId, toOperatorId }) => ({
+        edgeId,
+        fromOperatorId,
+        toOperatorId,
+      }))
+      .sort(compareEdges),
   });
 }
 
@@ -246,7 +254,10 @@ function validateTopology(topology: AgentGraphTraceTopology): ValidatedTopology 
         `Session ${operator.sessionId} is bound to trace operators ${sessionOwner} and ${operator.operatorId}`,
       );
     }
-    operatorsById.set(operator.operatorId, { ...operator });
+    operatorsById.set(operator.operatorId, {
+      operatorId: operator.operatorId,
+      sessionId: operator.sessionId,
+    });
     operatorBySession.set(operator.sessionId, operator.operatorId);
   }
 
@@ -254,7 +265,13 @@ function validateTopology(topology: AgentGraphTraceTopology): ValidatedTopology 
   const endpointPairs = new Set<string>();
   const incoming = new Map<string, AgentGraphTraceEdge[]>();
   const outgoing = new Map<string, AgentGraphTraceEdge[]>();
-  const edges = topology.edges.map((edge) => ({ ...edge })).sort(compareEdges);
+  const edges = topology.edges
+    .map(({ edgeId, fromOperatorId, toOperatorId }) => ({
+      edgeId,
+      fromOperatorId,
+      toOperatorId,
+    }))
+    .sort(compareEdges);
   for (const edge of edges) {
     if (!edge.edgeId.trim()) throw new Error('Trace edge id must not be empty');
     if (edgeIds.has(edge.edgeId)) throw new Error(`Duplicate trace edge ${edge.edgeId}`);
@@ -296,7 +313,7 @@ function topologicalSort(
   );
   const ready = [...operatorsById.keys()]
     .filter((operatorId) => remainingIncoming.get(operatorId) === 0)
-    .sort();
+    .sort(compareAgentGraphIdentity);
   const ordered: string[] = [];
 
   while (ready.length > 0) {
@@ -314,7 +331,7 @@ function topologicalSort(
   if (ordered.length !== operatorsById.size) {
     const cyclic = [...operatorsById.keys()]
       .filter((operatorId) => !ordered.includes(operatorId))
-      .sort();
+      .sort(compareAgentGraphIdentity);
     throw new Error(`Trace graph contains a cycle involving: ${cyclic.join(', ')}`);
   }
   return ordered;
@@ -339,14 +356,14 @@ function uniqueOperatorIds(
 
 function compareEdges(a: AgentGraphTraceEdge, b: AgentGraphTraceEdge): number {
   return (
-    a.fromOperatorId.localeCompare(b.fromOperatorId) ||
-    a.toOperatorId.localeCompare(b.toOperatorId) ||
-    a.edgeId.localeCompare(b.edgeId)
+    compareAgentGraphIdentity(a.fromOperatorId, b.fromOperatorId) ||
+    compareAgentGraphIdentity(a.toOperatorId, b.toOperatorId) ||
+    compareAgentGraphIdentity(a.edgeId, b.edgeId)
   );
 }
 
 function insertSorted(values: string[], value: string): void {
-  const index = values.findIndex((candidate) => value.localeCompare(candidate) < 0);
+  const index = values.findIndex((candidate) => compareAgentGraphIdentity(value, candidate) < 0);
   if (index === -1) values.push(value);
   else values.splice(index, 0, value);
 }

--- a/packages/runtime/src/stream-graph-trace.ts
+++ b/packages/runtime/src/stream-graph-trace.ts
@@ -74,6 +74,7 @@ export interface AgentGraphTraceOperatorState {
 export interface AgentGraphTraceSnapshot {
   schemaVersion: typeof AGENT_GRAPH_TRACE_SCHEMA_VERSION;
   graphId: string;
+  topologyFingerprint: string;
   topologicalOrder: string[];
   rootOperatorIds: string[];
   sinkOperatorIds: string[];
@@ -100,6 +101,7 @@ export function buildAgentGraphTraceSnapshot(
   input: BuildAgentGraphTraceSnapshotInput,
 ): AgentGraphTraceSnapshot {
   const validated = validateTopology(input.topology);
+  const topologyFingerprint = fingerprintTopology(input.topology.graphId, validated);
   const replay =
     input.records.length > 0
       ? replayAgentGraphRecords(input.records)
@@ -198,6 +200,7 @@ export function buildAgentGraphTraceSnapshot(
   return {
     schemaVersion: AGENT_GRAPH_TRACE_SCHEMA_VERSION,
     graphId: input.topology.graphId,
+    topologyFingerprint,
     topologicalOrder: [...validated.topologicalOrder],
     rootOperatorIds: validated.topologicalOrder.filter(
       (operatorId) => (validated.incoming.get(operatorId) ?? []).length === 0,
@@ -210,6 +213,17 @@ export function buildAgentGraphTraceSnapshot(
     edges: Object.fromEntries(edges),
     routes,
   };
+}
+
+function fingerprintTopology(graphId: string, topology: ValidatedTopology): string {
+  return stableHash({
+    schemaVersion: AGENT_GRAPH_TRACE_SCHEMA_VERSION,
+    graphId,
+    operators: [...topology.operatorsById.values()].sort((a, b) =>
+      a.operatorId.localeCompare(b.operatorId),
+    ),
+    edges: topology.edges,
+  });
 }
 
 function validateTopology(topology: AgentGraphTraceTopology): ValidatedTopology {


### PR DESCRIPTION
## Summary

This is the third implementation slice of #1341, building on the committed-event projection in #1442 and trace topology in #1443.

- Add a canonical topology fingerprint over graph identity, Session-backed operator bindings, and directed edges. Only schema-declared fields participate, and opaque graph identities use one locale-independent raw/code-unit total order.
- Derive operator-local readiness from the deterministic trace snapshot rather than scanning or mutating Agent runtime state.
- Add a `map` policy that produces one stable candidate intent per direct incoming route.
- Add a sealed-input `all_settled` policy that waits for one exact activation from every direct upstream operator.
- Bind every candidate intent to an operator-local readiness context: target operator/Session binding, direct incoming edge identities, normalized policy, and trigger route/record identities.
- Keep the global topology fingerprint on the snapshot and supervisor view as provenance without globally invalidating otherwise unchanged local intents.
- Expose explicit waiting reasons for missing/running activations or absent input routes.
- Project every local readiness state into an always-on supervisor side view without consulting the supervisor during readiness derivation.
- Preserve deterministic/idempotent output under reordered topology, policy, record, duplicate, and locale-equivalent Unicode identity observations.

## Why the activation frontier is explicit

A Session-backed operator can have multiple session-inline AgentRun activations over time. An all-settled join over "the latest activation" would be unstable: a later follow-up in the same child Session could silently turn an already-runnable join back into waiting or change its trigger identity.

This slice therefore requires the join policy to seal one exact `operatorId / activationId` input for every direct upstream. A later follow-up activation remains observable in the trace but cannot rewrite the already-derived join intent.

All terminal outcomes settle an all-settled input: completed, failed, aborted, or cancelled. Failure policy remains a later operator/control-plane concern.

## Authority boundary

A runnable intent is a deterministic candidate, not execution authority.

Recomputing this projection never creates, starts, resumes, sends to, pauses, or cancels an AgentRun. A later control-plane slice must durably and idempotently claim an intent before invoking existing child-session runtime APIs. That future claim will also provide consumption/acknowledgement and recovery semantics; this PR deliberately does not infer intent consumption from unrelated target Session activity.

Structural readiness also remains separate from resource admission. A runnable intent may still wait for concurrency, provider, budget, fairness, or workspace permits.

The main-agent supervisor is structurally beside the graph. It observes every waiting/runnable state and candidate intent through `supervisorView`, but is not a serial gate in deriving or routing normal work.

## Identity boundary

The full topology fingerprint is graph-level provenance only. It intentionally does not participate in `intentId`: adding a disconnected observer or a downstream-only operator cannot reissue historical local work under a new identity.

Instead, each intent carries a `readinessContextFingerprint` derived from the graph identity, target operator/Session binding, schema-defined direct incoming edges, and normalized policy fingerprint. Trigger route/record identities complete the candidate identity.

Topology validation projects operators to `{ operatorId, sessionId }` and edges to `{ edgeId, fromOperatorId, toOperatorId }`, so undeclared diagnostic/UI fields cannot affect identity. Projection, trace, topology, policy, and sealed-input ordering share a strict raw string comparator rather than locale-sensitive collation.

## Failure semantics

Readiness derivation fails closed for:

- empty, duplicate, unsupported, or unknown readiness policy identities;
- more than one local readiness policy for the same operator in this initial slice;
- readiness attached to an operator with no direct upstream input;
- empty, duplicate, non-direct, or incomplete all-settled activation frontiers;
- settled activations without a terminal record or without the expected direct terminal route;
- every topology, ownership, replay, and reserved-key invariant already enforced by #1442 and #1443.

## Deliberate non-goals

- No Agent runtime actions or runtime rewrite.
- No durable intent claim, acknowledgement, consumption cursor, or recovery authority yet.
- No resource permits or scheduling fairness.
- No quorum/early-exit policy; that needs durable claims so late observations cannot rewrite an executed choice.
- No graph-wide completion or topology/admission closing protocol.
- No supervisor control records or semantic intervention yet.
- No Desktop/TUI renderer.

## Validation

- `npm run typecheck`
- focused projection + trace + readiness suites: 28 passed
- Runtime full suite: 2 known unrelated macOS sandbox failures:
  - `/usr/local` executable-root ordering assertion
  - Homebrew `rg` cannot load PCRE2 inside the operation-scoped Seatbelt sandbox
- Biome lint/format check on all changed files
- `git diff --check`

Refs #1341

<details>
<summary>中文说明</summary>

这是 #1341 的第三个实现切片，建立在 #1442 的 committed-event projection 与 #1443 的 trace topology 之上。

- 对 graph identity、Session-backed operator binding 与 directed edge 生成 canonical topology fingerprint；只有 schema 声明字段参与 identity，所有 opaque graph identity 使用同一个与 locale 无关的 raw/code-unit 严格全序。
- 从确定性的 trace snapshot 推导 operator-local readiness，不扫描或修改 Agent runtime 状态。
- `map` policy 为每条 direct incoming route 生成一个稳定的 candidate intent。
- sealed-input `all_settled` policy 等待每个 direct upstream 的一个精确 activation。
- 每个 candidate intent 绑定 operator-local readiness context：target operator/Session binding、direct incoming edge identity、normalized policy 与 trigger route/record identity。
- 全局 topology fingerprint 继续保留在 snapshot 与 supervisor view 中作为 provenance，但不会让无关的 topology 变化使局部 intent 全局失效。
- 明确输出 input route 缺失、activation 缺失或仍在运行等 waiting reason。
- 每个 local readiness state 都进入 always-on supervisor side view；推导 readiness 时不需要 supervisor 批准。
- topology、policy、record 输入乱序、重复，或出现 `é` / `e\u0301` 这类 locale-equivalent Unicode identity 时，仍能确定、幂等地重建。

一个 Session-backed operator 可以持续产生多个 session-inline AgentRun activation。如果 all-settled 依赖“最新 activation”，同一 child Session 后续出现 follow-up run 时，已经 runnable 的 join 可能重新变回 waiting，或者触发 identity 被改写。

因此本切片要求 join policy 为每个 direct upstream 显式封口一个精确的 `operatorId / activationId`。后续 follow-up activation 仍会进入 trace，但不能改写已经推导出的 join intent。completed、failed、aborted、cancelled 都属于 settled；如何处理失败留给后续 operator/control-plane policy。

全图 topology fingerprint 只负责 graph-level provenance，不再参与 `intentId`。增加 disconnected observer 或 downstream-only operator，不会把历史局部工作换一个 ID 后重新发放。

每个 intent 改为携带 `readinessContextFingerprint`，其来源是 graph identity、目标 operator/Session binding、schema-defined direct incoming edges 与 normalized policy fingerprint；再结合 trigger route/record identity 构成完整 candidate identity。

Topology validation 只保留 operator 的 `{ operatorId, sessionId }` 与 edge 的 `{ edgeId, fromOperatorId, toOperatorId }`，因此未声明的调试/UI 字段不会污染 identity。Projection、trace、topology、policy 与 sealed input 排序统一使用 raw string comparator，不依赖 locale collation。

Runnable intent 只是确定性的候选，不是执行权威。重新计算 projection 不会创建、启动、恢复、发消息、暂停或取消 AgentRun。后续 control-plane 切片必须先持久、幂等地 claim intent，再调用现有 child-session runtime API；consumption/acknowledgement 与 recovery 语义也由那一层建立。

结构 readiness 与资源 admission 继续分离。Intent 即使 runnable，也可能等待 concurrency、provider、budget、fairness 或 workspace permit。

主 Agent supervisor 始终站在图旁边，通过 `supervisorView` 观察全部 waiting/runnable state 与 candidate intent，但不会成为正常 readiness 或 record routing 的串行门禁。

本 PR 不执行任何 Agent runtime action，不引入 durable intent claim/ack、resource permits、quorum/early-exit、graph-wide completion/closing、supervisor control record 或 Desktop/TUI renderer。

</details>
