### PR TITLE
fix(ui): restore sidebar session heading hierarchy

### DIFF
--- a/apps/desktop/e2e/sidebar-navigation.spec.ts
+++ b/apps/desktop/e2e/sidebar-navigation.spec.ts
@@ -22,6 +22,25 @@ test('session grouping menu applies and retains the selected mode', async ({ win
   await expect(page.getByRole('menuitemradio', { name: '按状态' })).toHaveAttribute('aria-checked', 'false');
 });
 
+test('session heading stays singular and uses the shared sidebar type tier', async ({
+  sidebarLongSessionsWindow: page,
+}) => {
+  const sidebar = await expandedSidebar(page);
+  const panelHeading = sidebar.locator('.maka-session-list-heading');
+  const activeGroupHeading = sidebar.getByText('可继续', { exact: true });
+  const navLabel = sidebar.locator('.maka-nav-row span:nth-child(2)').first();
+
+  await expect(sidebar.getByText('会话', { exact: true })).toHaveCount(1);
+  await expect(activeGroupHeading).toBeVisible();
+
+  const fontSizes = await Promise.all(
+    [navLabel, panelHeading, activeGroupHeading].map((locator) =>
+      locator.evaluate((element) => getComputedStyle(element).fontSize),
+    ),
+  );
+  expect(fontSizes).toEqual(['13px', '13px', '13px']);
+});
+
 test('scheduled-task hub restores the last selected child module', async ({ window: page }) => {
   const sidebar = await expandedSidebar(page);
   const scheduledTasks = sidebar.getByRole('button', { name: '定时任务', exact: true });

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from 'node:test';
 import { filterLinkedSessionTree, projectLinkedSessionTree } from '@maka/core';
 import { sessionMatchesNavSelection } from '../../renderer/session-nav-filter.js';
 import { deriveProjectGroups } from '../../renderer/session-project-grouping.js';
+import { deriveSessionStatusGroups } from '../../renderer/session-status-grouping.js';
 import { makeSessionSummary, renderSessionListPanel } from './session-list-render-helpers.js';
 
 const REPO_ROOT = resolve(process.cwd(), '..', '..');
@@ -56,6 +57,33 @@ describe('sidebar project view mode', () => {
     assert.match(panel, /<MenuRadioGroup value=\{viewMode\}/);
     assert.match(panel, /<MenuRadioItem value="status">\{copy\.groupByStatus\}/);
     assert.match(panel, /<MenuRadioItem value="project">\{copy\.groupByProject\}/);
+  });
+
+  it('renders the panel title once and gives active sessions their lifecycle heading', () => {
+    const sessions = [
+      makeSessionSummary({
+        id: 'active-session',
+        name: 'Active session',
+        status: 'active',
+      }),
+    ];
+    const markup = renderSessionListPanel({
+      sessions,
+      statusGroups: deriveSessionStatusGroups(sessions),
+      viewMode: 'status',
+    });
+
+    assert.equal((markup.match(/>会话</g) ?? []).length, 1);
+    assert.match(markup, />可继续</);
+  });
+
+  it('uses the sidebar UI type tier for the session-list heading', async () => {
+    const css = await readRepo('apps/desktop/src/renderer/styles/sidebar.css');
+
+    assert.match(
+      css,
+      /\.maka-session-list-heading\s*\{[^}]*font-size:\s*var\(--font-size-ui\)/s,
+    );
   });
 
   it('renders project groups as folder headers with an initial four-session preview', () => {

--- a/apps/desktop/src/main/__tests__/session-status-grouping.test.ts
+++ b/apps/desktop/src/main/__tests__/session-status-grouping.test.ts
@@ -152,6 +152,13 @@ describe('deriveSessionStatusGroups', () => {
     }
   });
 
+  it('labels active sessions as a lifecycle state instead of repeating the list title', () => {
+    const activeSession = session({ id: 'active', status: 'active' });
+
+    assert.equal(deriveSessionStatusGroups([activeSession], { locale: 'zh' })[0]?.label, '可继续');
+    assert.equal(deriveSessionStatusGroups([activeSession], { locale: 'en' })[0]?.label, 'Ready');
+  });
+
   describe('pinFirst option', () => {
     it('without pinFirst (default), flagged sessions stay in their status group', () => {
       const groups = deriveSessionStatusGroups([

--- a/apps/desktop/src/renderer/locales/conversation-copy.ts
+++ b/apps/desktop/src/renderer/locales/conversation-copy.ts
@@ -130,7 +130,7 @@ const COPY = {
     },
     footer: { labels: { regenerate: '重新生成', branch: '分支', copy: '复制', info: '详情' }, pending: '正在处理…', regenerateRunning: '当前回答仍在进行中，结束后再重新生成', regenerateAgain: '已重新生成过，再次点击将创建新的并行回答', regenerate: '让模型重新生成本轮回答', branchRunning: '当前回答仍在进行中，结束后再分支', branchAborted: '从中断前的上下文分支出新对话', branch: '基于此回答的上下文分支出新对话', copy: '复制回答到剪贴板', copyEmpty: '此回答尚无可复制的内容' },
     lineage: { regeneratedFrom: '重新生成自旧回答', regeneratedFromTooltip: '这是重新生成的并行回答，点击查看被保留的旧回答', regeneratedTo: '已重新生成 → 新回答', regeneratedToTooltip: '点击跳转到重新生成的新回答' },
-    groups: { pinned: '已置顶', running: '进行中', waiting_for_user: '等待你', blocked: '需要处理', active: '会话', review: '待审核', done: '已完成', archived: '归档', aborted: '已中止' },
+    groups: { pinned: '已置顶', running: '进行中', waiting_for_user: '等待你', blocked: '需要处理', active: '可继续', review: '待审核', done: '已完成', archived: '归档', aborted: '已中止' },
     workbar: { ariaLabel: '会话工作栏', sectionsAriaLabel: '会话工作栏栏目', tasks: '任务', browser: '浏览器', files: '文件', quoteTab: '追问引用' },
     quoteCompanion: {
       hint: '这里的追问会带上主对话的完整上下文：只做解释和只读探索，不会改动文件，也不写回主对话。在主对话里继续选中文本追问，会加进这个侧栏。',
@@ -186,7 +186,7 @@ const COPY = {
     },
     footer: { labels: { regenerate: 'Regenerate', branch: 'Branch', copy: 'Copy', info: 'Details' }, pending: 'Working…', regenerateRunning: 'Wait for the current response to finish before regenerating', regenerateAgain: 'A regenerated response already exists; click again to create another parallel response', regenerate: 'Generate another response to this turn', branchRunning: 'Wait for the current response to finish before branching', branchAborted: 'Branch from the context before the interruption', branch: 'Branch a new conversation from this response', copy: 'Copy response to clipboard', copyEmpty: 'This response has no content to copy' },
     lineage: { regeneratedFrom: 'Regenerated from previous response', regeneratedFromTooltip: 'This is a parallel regenerated response; click to view the retained previous response', regeneratedTo: 'Regenerated → New response', regeneratedToTooltip: 'Jump to the regenerated response' },
-    groups: { pinned: 'Pinned', running: 'Running', waiting_for_user: 'Waiting for you', blocked: 'Needs attention', active: 'Conversations', review: 'Review', done: 'Done', archived: 'Archived', aborted: 'Stopped' },
+    groups: { pinned: 'Pinned', running: 'Running', waiting_for_user: 'Waiting for you', blocked: 'Needs attention', active: 'Ready', review: 'Review', done: 'Done', archived: 'Archived', aborted: 'Stopped' },
     workbar: { ariaLabel: 'Conversation workbar', sectionsAriaLabel: 'Conversation workbar sections', tasks: 'Tasks', browser: 'Browser', files: 'Files', quoteTab: 'Quoted' },
     quoteCompanion: {
       hint: 'Questions here carry the full context of the main conversation: read-only exploration and explanation, no file changes, and nothing is written back to the main conversation. Select more text in the main transcript to add it to this side panel.',

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -457,7 +457,7 @@
 .maka-session-list-heading {
   padding-left: var(--space-1-5);
   color: var(--muted-foreground);
-  font-size: var(--font-size-caption);
+  font-size: var(--font-size-ui);
   font-weight: var(--font-weight-semibold);
 }
 


### PR DESCRIPTION
## Summary

- keep the sidebar panel title as the single generic “会话” / “Conversations” heading
- label active-session groups with the existing lifecycle copy “可继续” / “Ready” instead of repeating the panel title
- move the panel heading from the 11px caption tier to the shared 13px sidebar UI tier
- add layered regression coverage for rendered heading duplication, localized lifecycle copy, the typography token, and live computed styles

## Verification

- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` — 2861 passed
- `npx playwright test --config e2e/playwright.config.ts sidebar-navigation.spec.ts --grep "session heading"` — 1 passed
- live Electron assertion: exact “会话” count = 1; “可继续” visible; computed navigation / panel-heading / group-heading font sizes = 13px / 13px / 13px

<img width="840" height="407" alt="image" src="https://github.com/user-attachments/assets/c33b9189-3bf9-4693-8b84-b2fccf54ed82" />

## Root cause

The sidebar hub redesign added a generic session-list toolbar heading while the active status group still used the same generic copy from the previous layout. The new toolbar heading also selected the caption token independently of the surrounding sidebar hierarchy.