### PR TITLE
fix(ui): render Markdown code without programming ligatures

### DIFF
--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -144,6 +144,39 @@ function cssBlocks(css: string): Array<{ selectors: string; decls: string }> {
     .map(([selectors, decls]) => ({ selectors: selectors.trim(), decls: (decls ?? '').trim() }));
 }
 
+describe('MARKDOWN-CODE-LITERAL-LIGATURES-0 contract (#1431)', () => {
+  // Geist Mono enables programming ligatures by default. On Markdown code
+  // that collapses runs like `###` / `===` / `=>` into combined glyphs whose
+  // ink and advance can extend left of the source column, so fenced lines
+  // appear misaligned. Other literal surfaces already pin
+  // `font-variant-ligatures: none` (`.maka-code`). The prose code boundary
+  // must do the same so both inline and fenced code inherit literal shaping.
+  // Non-code prose typography stays untouched.
+
+  it('.maka-prose code disables font ligatures for literal character shaping', async () => {
+    const css = stripCssComments(await readFile(PROSE_CSS, 'utf8'));
+    const blocks = cssBlocks(css);
+    const code = blocks.find(({ selectors }) => /^\.maka-prose\s+code$/.test(selectors));
+    assert.ok(code, 'expected a bare .maka-prose code rule in prose.css');
+    assert.match(
+      code!.decls,
+      /font-variant-ligatures:\s*none/,
+      '.maka-prose code must set font-variant-ligatures: none so Markdown inline and fenced code render ### / === / => literally (#1431)',
+    );
+  });
+
+  it('non-code prose base does not disable ligatures (prose typography unchanged)', async () => {
+    const css = stripCssComments(await readFile(PROSE_CSS, 'utf8'));
+    const blocks = cssBlocks(css);
+    const prose = blocks.find(({ selectors }) => selectors === '.maka-prose');
+    assert.ok(prose, 'expected a bare .maka-prose base rule');
+    assert.ok(
+      !/font-variant-ligatures/.test(prose!.decls),
+      '.maka-prose must not disable ligatures globally — only the code surface is a literal glyph surface (#1431)',
+    );
+  });
+});
+
 describe('CODE-BLOCK-PRE-FONT-TIER-0 contract (#546 PR5)', () => {
   // The assistant code block <pre> must render at the UI/chrome tier
   // (--font-size-ui), NOT inherit the prose body size. A pre-existing reset

--- a/apps/desktop/src/renderer/styles/prose.css
+++ b/apps/desktop/src/renderer/styles/prose.css
@@ -193,6 +193,14 @@
   /* Digit columns in technical replies align (price tables, version
      numbers, build outputs). */
   font-variant-numeric: tabular-nums;
+  /* Geist Mono ships programming ligatures on by default, which collapse
+     runs like `###`, `===`, and `=>` into combined glyphs whose ink and
+     advance can extend left of the source column — misaligning fenced
+     code lines. Markdown code is a literal surface (same policy as
+     `.maka-code` in maka-tokens.css); disable ligatures at this semantic
+     boundary so both inline and fenced code inherit literal shaping
+     (#1431). */
+  font-variant-ligatures: none;
   /* No vertical padding and no border: the Geist Mono font box is already
      15.5px at this size, and with 1px padding + 1px border the pill's ink
      box hit 19.5px — the full line box — so hard-break lines carrying


### PR DESCRIPTION
## Summary
- Disable Geist Mono programming ligatures on `.maka-prose code` so Markdown inline and fenced code render `###`, `===`, and `=>` literally (and keep consistent left alignment in fenced blocks).
- Align with the existing `.maka-code` policy (`font-variant-ligatures: none`); non-code prose typography is unchanged.
- Add `MARKDOWN-CODE-LITERAL-LIGATURES-0` regression contract in `markdown-prose-contract.test.ts`.

Closes #1431

## Test plan
- [x] `npx tsx --test apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts` (20/20 pass)
- [ ] Desktop: render a fenced `text` block with `## Findings` and `### P1 — ...`; confirm left edges and spacing stay aligned
- [ ] Desktop: confirm non-code prose (headings/paragraphs) still uses normal typography ligatures