### PR TITLE
fix(ui): align composer mode indicators

### DIFF
--- a/apps/desktop/e2e/composer-mode-indicator.spec.ts
+++ b/apps/desktop/e2e/composer-mode-indicator.spec.ts
@@ -1,0 +1,73 @@
+import type { Locator, Page } from '@playwright/test';
+import { expect, test } from './fixtures';
+
+async function hoverBackground(locator: Locator): Promise<string> {
+  await locator.hover();
+  let background = '';
+  await expect
+    .poll(async () => {
+      background = await locator.evaluate(
+        (element) => getComputedStyle(element).backgroundColor,
+      );
+      return background;
+    })
+    .not.toBe('rgba(0, 0, 0, 0)');
+  return background;
+}
+
+async function enableMode(
+  page: Page,
+  mode: 'plan' | 'swarm',
+  label: 'Plan' | 'Swarm',
+): Promise<Locator> {
+  await page.getByRole('button', { name: '添加' }).click();
+  await page.getByRole('menuitemcheckbox', { name: label }).click();
+  await page.keyboard.press('Escape');
+  const indicator = page.locator(
+    `.maka-composer-mode-indicator[data-mode="${mode}"]`,
+  );
+  await expect(indicator).toBeVisible();
+  await expect(indicator.locator('svg.lucide-x')).toBeVisible();
+  return indicator;
+}
+
+test('Plan and Swarm indicators match composer controls and close directly', async ({
+  window: page,
+}) => {
+  const quickChat = page.locator('.maka-onboarding-quickchat-input');
+  await quickChat.fill('open composer');
+  await quickChat.press('Enter');
+  await expect(page.getByText(/Fake backend received: open composer/)).toBeVisible();
+
+  const permissionTrigger = page.locator(
+    '.maka-composer-left-controls [data-slot="select-trigger"]',
+  );
+  await expect(permissionTrigger).toBeVisible();
+
+  for (const [mode, label] of [
+    ['plan', 'Plan'],
+    ['swarm', 'Swarm'],
+  ] as const) {
+    const indicator = await enableMode(page, mode, label);
+    const [indicatorGeometry, permissionGeometry] = await Promise.all(
+      [indicator, permissionTrigger].map((locator) =>
+        locator.evaluate((element) => {
+          const style = getComputedStyle(element);
+          return {
+            height: style.height,
+            padding: style.padding,
+            borderRadius: style.borderRadius,
+            gap: style.gap,
+          };
+        }),
+      ),
+    );
+    expect(indicatorGeometry).toEqual(permissionGeometry);
+    expect(await hoverBackground(indicator)).toBe(
+      await hoverBackground(permissionTrigger),
+    );
+
+    await indicator.click();
+    await expect(indicator).toHaveCount(0);
+  }
+});

--- a/apps/desktop/src/main/__tests__/composer-mode-indicator-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-mode-indicator-contract.test.ts
@@ -33,6 +33,19 @@ function declaration(body: string, property: string): string | undefined {
   return match?.[1].trim().replace(/\s+/g, ' ');
 }
 
+function isModeIndicatorRestSelector(selector: string): boolean {
+  const subject =
+    selector
+      .trim()
+      .split(/\s*[>+~]\s*|\s+/)
+      .filter(Boolean)
+      .at(-1) ?? '';
+  return (
+    subject.includes('.maka-composer-mode-indicator') &&
+    !/[:[]/.test(subject)
+  );
+}
+
 describe('composer active-mode indicator visual contract', () => {
   it('shares the composer picker footprint and hover treatment without a private geometry path', async () => {
     const cssRules = rules(await readFile(COMPOSER_CSS, 'utf8'));
@@ -82,7 +95,7 @@ describe('composer active-mode indicator visual contract', () => {
     const privateBaseRules = cssRules.filter(
       (rule) =>
         rule !== baseRule &&
-        rule.selectors.includes('.maka-composer-mode-indicator'),
+        rule.selectors.some(isModeIndicatorRestSelector),
     );
     for (const property of [
       'height',
@@ -103,5 +116,51 @@ describe('composer active-mode indicator visual contract', () => {
         `${property} must come from the shared composer-control rule, not a private mode-indicator rule`,
       );
     }
+
+    const modeHoverRules = cssRules.filter((rule) =>
+      rule.selectors.some(
+        (selector) =>
+          selector.includes('.maka-composer-mode-indicator') &&
+          selector.includes(':hover'),
+      ),
+    );
+    assert.deepEqual(
+      modeHoverRules,
+      [hoverRule],
+      'the shared hover rule must remain the only hover owner for active-mode indicators',
+    );
+  });
+
+  it('catches descendant, compound, selector-list, and private-hover overrides', () => {
+    const fixtures = [
+      '.composer .maka-composer-mode-indicator { height: 24px; }',
+      '.maka-composer-mode-indicator.active { padding: 0 4px; }',
+      '.other, .maka-composer-mode-indicator { border-radius: 4px; }',
+    ];
+    for (const fixture of fixtures) {
+      const fixtureRules = rules(fixture).filter((rule) =>
+        rule.selectors.some(isModeIndicatorRestSelector),
+      );
+      assert.equal(
+        fixtureRules.length,
+        1,
+        `private rest geometry must be detected: ${fixture}`,
+      );
+    }
+
+    const hoverFixture = rules(
+      '.composer .maka-composer-mode-indicator:hover { background: red; }',
+    );
+    assert.equal(
+      hoverFixture.filter((rule) =>
+        rule.selectors.some(
+          (selector) =>
+            selector.includes('.maka-composer-mode-indicator') &&
+            selector.includes(':hover'),
+        ),
+      ).length,
+      1,
+      'a private hover owner must be detected',
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/composer-mode-indicator-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/composer-mode-indicator-contract.test.ts
@@ -1,0 +1,107 @@
+import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { REPO_ROOT, stripCssComments } from './css-test-helpers.js';
+
+const COMPOSER_CSS = join(
+  REPO_ROOT,
+  'apps/desktop/src/renderer/styles/composer.css',
+);
+
+interface CssRule {
+  selectors: string[];
+  body: string;
+}
+
+function rules(css: string): CssRule[] {
+  return [...stripCssComments(css).matchAll(/([^{}]+)\{([^{}]*)\}/g)].map(
+    (match) => ({
+      selectors: match[1]
+        .replace(/^[\s\S]*;/, '')
+        .split(',')
+        .map((selector) => selector.trim()),
+      body: match[2],
+    }),
+  );
+}
+
+function declaration(body: string, property: string): string | undefined {
+  const match = body.match(
+    new RegExp(`(?:^|;)\\s*${property}\\s*:\\s*([^;}]+)`),
+  );
+  return match?.[1].trim().replace(/\s+/g, ' ');
+}
+
+describe('composer active-mode indicator visual contract', () => {
+  it('shares the composer picker footprint and hover treatment without a private geometry path', async () => {
+    const cssRules = rules(await readFile(COMPOSER_CSS, 'utf8'));
+    const baseSelectors = [
+      '.maka-composer-left-controls [data-slot="select-trigger"]',
+      '.maka-composer-right-controls .maka-model-switcher-trigger',
+      '.maka-composer-model-chip',
+      '.maka-composer-mode-indicator',
+    ];
+    const baseRule = cssRules.find((rule) =>
+      baseSelectors.every((selector) => rule.selectors.includes(selector)),
+    );
+
+    assert.ok(
+      baseRule,
+      'permission, model, and active-mode controls must share one base rule',
+    );
+    assert.equal(declaration(baseRule.body, 'height'), '26px');
+    assert.equal(declaration(baseRule.body, 'gap'), 'var(--space-1)');
+    assert.equal(
+      declaration(baseRule.body, 'padding'),
+      '0 var(--space-2)',
+    );
+    assert.equal(
+      declaration(baseRule.body, 'border-radius'),
+      'var(--radius-pill)',
+    );
+
+    const hoverSelectors = [
+      '.maka-composer-left-controls [data-slot="select-trigger"]:hover',
+      '.maka-composer-right-controls .maka-model-switcher-trigger:hover:not(:disabled):not([data-disabled])',
+      '.maka-composer-model-chip:hover',
+      '.maka-composer-mode-indicator:hover:not(:disabled)',
+    ];
+    const hoverRule = cssRules.find((rule) =>
+      hoverSelectors.every((selector) => rule.selectors.includes(selector)),
+    );
+    assert.ok(
+      hoverRule,
+      'permission, model, and active-mode controls must share one hover rule',
+    );
+    assert.equal(
+      declaration(hoverRule.body, 'background'),
+      'var(--state-hover-bg)',
+    );
+
+    const privateBaseRules = cssRules.filter(
+      (rule) =>
+        rule !== baseRule &&
+        rule.selectors.includes('.maka-composer-mode-indicator'),
+    );
+    for (const property of [
+      'height',
+      'min-height',
+      'padding',
+      'border',
+      'border-radius',
+      'background',
+      'font-size',
+      'line-height',
+      'white-space',
+    ]) {
+      assert.equal(
+        privateBaseRules
+          .map((rule) => declaration(rule.body, property))
+          .filter(Boolean).length,
+        0,
+        `${property} must come from the shared composer-control rule, not a private mode-indicator rule`,
+      );
+    }
+  });
+});

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -44,35 +44,6 @@
   flex: 0 0 auto;
 }
 
-/* #1433: active-mode mark (Plan/Swarm) — the same quiet-text-button
-   language as the permission select beside it, minus the chevron (it
-   cannot drop down; clicking turns the mode off). No chip wash, no dot:
-   weight and color alone carry the "this is on" signal. */
-.maka-composer-mode-indicator {
-  display: inline-flex;
-  align-items: center;
-  min-height: var(--h-control-sm);
-  padding: 0 var(--space-1);
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--foreground);
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-semibold);
-  line-height: var(--leading-none);
-  white-space: nowrap;
-  transition: background-color var(--duration-base) var(--ease-out-strong);
-}
-
-.maka-composer-mode-indicator:hover:not(:disabled) {
-  background: var(--state-hover-bg);
-}
-
-.maka-composer-mode-indicator:disabled {
-  cursor: not-allowed;
-  color: var(--muted-foreground);
-}
-
 .maka-composer-right-controls {
   flex: 0 0 auto;
   justify-content: flex-end;
@@ -92,7 +63,8 @@
    controls read identical at rest and on hover. */
 .maka-composer-left-controls [data-slot="select-trigger"],
 .maka-composer-right-controls .maka-model-switcher-trigger,
-.maka-composer-model-chip {
+.maka-composer-model-chip,
+.maka-composer-mode-indicator {
   height: 26px;
   display: inline-flex;
   align-items: center;
@@ -112,10 +84,25 @@
 }
 .maka-composer-left-controls [data-slot="select-trigger"]:hover,
 .maka-composer-right-controls .maka-model-switcher-trigger:hover:not(:disabled):not([data-disabled]),
-.maka-composer-model-chip:hover {
+.maka-composer-model-chip:hover,
+.maka-composer-mode-indicator:hover:not(:disabled) {
   background: var(--state-hover-bg);
   color: var(--foreground);
   border-color: transparent;
+}
+
+/* #1433: active-mode mark (Plan/Swarm) uses the unified composer-control
+   geometry above. Its stronger text plus the trailing X communicate both
+   “enabled” and the direct click-to-close action without inventing a smaller
+   chip or hover footprint beside the permission picker. */
+.maka-composer-mode-indicator {
+  color: var(--foreground);
+  font-weight: var(--font-weight-semibold);
+}
+
+.maka-composer-mode-indicator:disabled {
+  cursor: not-allowed;
+  color: var(--muted-foreground);
 }
 
 .maka-composer-model-chip {

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -334,6 +334,12 @@ export const PlanModeActive: Story = {
   render: () => <ComposedShell composer={{ planModeActive: true }} />,
 };
 
+// Real path: enable Swarm mode (＋ menu) → while the mode is on, the composer
+// shows the same direct-close indicator as Plan beside the permission select.
+export const SwarmModeActive: Story = {
+  render: () => <ComposedShell composer={{ swarmModeActive: true }} />,
+};
+
 // Real path: returning user with session history → start a new chat (or
 // open a session with no messages yet). This is the DAILY empty home:
 // ChatView falls back to its built-in EmptyChatHero (greeting + composer). Do NOT render OnboardingHero here —

--- a/packages/ui/src/__tests__/conversation-localization.test.tsx
+++ b/packages/ui/src/__tests__/conversation-localization.test.tsx
@@ -150,8 +150,13 @@ describe('localized conversation journey', () => {
     assert.match(on, /maka-composer-mode-indicator/);
     assert.match(on, /Plan 模式已启用/);
     // Same visual language as the permission select: a quiet text BUTTON
-    // (no chevron — it cannot drop down); clicking turns the mode off.
+    // with an explicit close icon (no chevron — it cannot drop down);
+    // clicking turns the mode off.
     assert.match(on, /<button[^>]*maka-composer-mode-indicator/);
+    assert.match(
+      on,
+      /<button[^>]*maka-composer-mode-indicator[^>]*>(?:(?!<\/button>)[\s\S])*?<svg[^>]*aria-hidden="true"/,
+    );
 
     const off = render('zh', <Composer onSend={() => {}} onStop={() => {}} onPlanModeChange={() => {}} />);
     assert.doesNotMatch(off, /maka-composer-mode-indicator/);
@@ -173,6 +178,10 @@ describe('localized conversation journey', () => {
     assert.match(markup, /Swarm 模式已启用/);
     assert.match(markup, /disabled=""/);
     assert.match(markup, /等待流式输出结束/);
+    assert.match(
+      markup,
+      /<button[^>]*maka-composer-mode-indicator[^>]*>(?:(?!<\/button>)[\s\S])*?<svg[^>]*aria-hidden="true"/,
+    );
   });
 
   it('keeps Swarm Mode out of the toolbar (#1433)', () => {

--- a/packages/ui/src/__tests__/conversation-localization.test.tsx
+++ b/packages/ui/src/__tests__/conversation-localization.test.tsx
@@ -155,7 +155,7 @@ describe('localized conversation journey', () => {
     assert.match(on, /<button[^>]*maka-composer-mode-indicator/);
     assert.match(
       on,
-      /<button[^>]*maka-composer-mode-indicator[^>]*>(?:(?!<\/button>)[\s\S])*?<svg[^>]*aria-hidden="true"/,
+      /<button[^>]*maka-composer-mode-indicator[^>]*>(?:(?!<\/button>)[\s\S])*?<svg[^>]*class="lucide lucide-x"[^>]*aria-hidden="true"/,
     );
 
     const off = render('zh', <Composer onSend={() => {}} onStop={() => {}} onPlanModeChange={() => {}} />);
@@ -180,7 +180,7 @@ describe('localized conversation journey', () => {
     assert.match(markup, /等待流式输出结束/);
     assert.match(
       markup,
-      /<button[^>]*maka-composer-mode-indicator[^>]*>(?:(?!<\/button>)[\s\S])*?<svg[^>]*aria-hidden="true"/,
+      /<button[^>]*maka-composer-mode-indicator[^>]*>(?:(?!<\/button>)[\s\S])*?<svg[^>]*class="lucide lucide-x"[^>]*aria-hidden="true"/,
     );
   });
 

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -922,6 +922,7 @@ export const Composer = forwardRef<
                 }
               >
                 {copy.planModeLabel}
+                <X size={12} aria-hidden="true" />
               </button>
             ) : null}
             {props.swarmModeActive ? (
@@ -943,6 +944,7 @@ export const Composer = forwardRef<
                 }
               >
                 {copy.swarmModeLabel}
+                <X size={12} aria-hidden="true" />
               </button>
             ) : null}
           </div>


### PR DESCRIPTION
## Summary

- add an explicit close icon to active Plan and Swarm indicators
- share the same 26px geometry, pill radius, spacing, and hover treatment as neighboring composer controls
- add a Swarm-active Storybook state plus component, CSS ownership, and real Electron regression coverage

## Verification

- `npm --workspace @maka/ui test` — 240 passed
- `npm --workspace @maka/desktop test` — 2859 passed
- `npm run lint`
- `npm run format:check`
- `npm --workspace @maka/desktop run typecheck`
- `npx playwright test --config e2e/playwright.config.ts composer-mode-indicator.spec.ts` — 1 passed
- Storybook computed-style check: Plan/Swarm indicator and permission trigger both resolve to 26px height, 0 8px padding, pill radius, and the same hover background

### Visual evidence

<img width="1108" height="464" alt="image" src="https://github.com/user-attachments/assets/c9d09ea6-aad1-4479-a661-66e5d201fe25" />