### PR TITLE
fix(ui): keep conversation controls visible across modules

### DIFF
--- a/apps/desktop/e2e/mcp.spec.ts
+++ b/apps/desktop/e2e/mcp.spec.ts
@@ -15,7 +15,7 @@ test('MCP module completes stdio add, discovery, disable, JSON import, and delet
   await expect(sidebar.getByRole('button', { name: 'MCP', exact: true })).toHaveCount(0);
   await extensions.click();
   await expect(extensions).toHaveAttribute('aria-current', 'page');
-  await expect(sidebar.getByRole('button', { name: '会话分组方式' })).toHaveCount(0);
+  await expect(sidebar.getByRole('button', { name: '会话分组方式' })).toBeVisible();
   await expect(sidebar.locator('.maka-session-list')).toBeVisible();
 
   const extensionSelector = page.locator('.maka-module-hub-selector-trigger');

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -86,6 +86,16 @@ describe('sidebar project view mode', () => {
     );
   });
 
+  it('keeps module-selected conversation controls out of the flexible list track', async () => {
+    const css = await readRepo('apps/desktop/src/renderer/styles/sidebar.css');
+
+    assert.doesNotMatch(
+      css,
+      /\.maka-session-panel\[data-content="module"\]\s*\{[^}]*grid-template-rows:/s,
+      'module selection must not replace the shared five-row sidebar grid',
+    );
+  });
+
   it('renders project groups as folder headers with an initial four-session preview', () => {
     const sessions = Array.from({ length: 5 }, (_, index) => makeSessionSummary({
       id: `project-session-${index + 1}`,

--- a/apps/desktop/src/main/__tests__/sidebar-module-hubs-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-module-hubs-contract.test.ts
@@ -31,13 +31,11 @@ describe('sidebar module hubs contract', () => {
     assert.doesNotMatch(shell, /navSelection\.section === '(?:skills|mcp|daily-review)'/);
   });
 
-  it('hides only session grouping on module pages and preserves history', async () => {
+  it('keeps conversation grouping and history visible on module pages', async () => {
     const source = await readSource('packages/ui/src/session-list-panel.tsx');
 
-    assert.match(source, /showSessionNavigation\s*=\s*props\.selection\.section\s*===\s*'sessions'/);
-    assert.match(source, /showSessionNavigation\s*&&\s*onViewModeChange/);
+    assert.match(source, /\{onViewModeChange\s*&&\s*\(/);
     assert.match(source, /<SessionHistoryList/);
-    assert.doesNotMatch(source, /showSessionNavigation\s*\?\s*\(\s*<SessionHistoryList/s);
-    assert.match(source, /data-content=\{showSessionNavigation\s*\?\s*'sessions'\s*:\s*'module'\}/);
+    assert.doesNotMatch(source, /showSessionNavigation|data-content=/);
   });
 });

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -20,10 +20,6 @@
   grid-template-rows: auto auto minmax(0, 1fr) auto;
 }
 
-.maka-session-panel[data-content="module"] {
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
-}
-
 .maka-session-panel-header {
   display: grid;
   gap: var(--space-1);

--- a/packages/ui/src/__tests__/sidebar-subtraction.test.tsx
+++ b/packages/ui/src/__tests__/sidebar-subtraction.test.tsx
@@ -121,4 +121,24 @@ describe('sidebar subtraction', () => {
     assert.doesNotMatch(markup, />按状态</);
     assert.doesNotMatch(markup, />按项目</);
   });
+
+  it('keeps conversation view controls visible while an extension module is selected', () => {
+    const markup = renderToStaticMarkup(
+      <LocaleProvider locale="zh">
+        <SessionListPanel
+          selection={{ section: 'extensions', module: 'skills' }}
+          sessions={[]}
+          viewMode="status"
+          onViewModeChange={() => {}}
+          onSelectSession={() => {}}
+          onSelect={() => {}}
+          onOpenSettings={() => {}}
+          onNew={() => {}}
+        />
+      </LocaleProvider>,
+    );
+
+    assert.match(markup, /class="maka-session-list-heading"[^>]*>会话</);
+    assert.match(markup, /aria-label="会话分组方式"/);
+  });
 });

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -35,14 +35,12 @@ export function SessionListPanel(props: {
     onViewModeChange,
     statusGroups,
   } = props;
-  const showSessionNavigation = props.selection.section === 'sessions';
 
   return (
     <aside
       className="maka-session-panel agents-sidebar"
       aria-label={copy.listAriaLabel}
       data-collapsed={props.sidebarCollapsed ? 'true' : undefined}
-      data-content={showSessionNavigation ? 'sessions' : 'module'}
     >
       <header className="maka-session-panel-header">
         <div className="maka-sidebar-drag-strip" />
@@ -54,7 +52,7 @@ export function SessionListPanel(props: {
         onSelect={props.onSelect}
         onNew={props.onNew}
       />
-      {showSessionNavigation && onViewModeChange && (
+      {onViewModeChange && (
         <div className="maka-session-list-toolbar">
           <span className="maka-session-list-heading">{copy.title}</span>
           <Menu>

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -326,6 +326,24 @@ export const StatusGroups: Story = {
   ),
 };
 
+export const ExtensionSelected: Story = {
+  render: () => (
+    <StoryFrame>
+      <SessionListPanel
+        {...panelProps({
+          sessions: coreSessions,
+          activeId: 'session-active',
+          streamingSessionIds: new Set(['session-running']),
+          staleSessionIds: new Set(['session-stale']),
+        })}
+        selection={{ section: 'extensions', module: 'skills' }}
+        viewMode="status"
+        onViewModeChange={noop}
+      />
+    </StoryFrame>
+  ),
+};
+
 export const RowActions: Story = {
   render: () => (
     <StoryFrame focusActiveRow>


### PR DESCRIPTION
## Summary

- Keep the conversation heading and grouping menu visible while Extensions or Scheduled Tasks is selected.
- Remove the obsolete module-specific four-row grid so the shared five-row sidebar layout keeps the conversation toolbar compact instead of stretching it into empty space.
- Add an `ExtensionSelected` Storybook state plus rendering and layout contracts for the cross-module behavior.
- Update the representative MCP E2E journey to assert the new visible grouping control.
- Leave status-group flattening and the `StatusGroups` story unchanged for the follow-up PR.

## Verification

- `npm --workspace @maka/ui test` — 241 passed
- `npm --workspace @maka/desktop test` — 2,866 passed
- `npm --workspace @maka/desktop run e2e -- mcp.spec.ts` — 1 passed
- `npm --workspace @maka/ui run typecheck`
- `npm --workspace @maka/desktop run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`
- Verified the `ExtensionSelected` state in Storybook and accepted the same flow in the live Electron app.

<img width="868" height="1276" alt="image" src="https://github.com/user-attachments/assets/395dda29-0a7a-482f-87e5-7eacd0346202" />

