### PR TITLE
refactor(desktop): fold workspace topbar actions into overflow menu

### DIFF
--- a/apps/desktop/e2e/command-palette.spec.ts
+++ b/apps/desktop/e2e/command-palette.spec.ts
@@ -40,10 +40,16 @@ async function expectCompactShortcutHints(dialog: Locator): Promise<void> {
 }
 
 test('command palette header geometry and dismissal stay intact', async ({ window: page }) => {
-  const openButton = page.getByRole('button', { name: '打开命令面板' });
   const dialog = page.getByRole('dialog', { name: '命令面板' });
 
-  await openButton.click();
+  // The palette entry now lives behind the workspace topbar overflow menu
+  // (see topbar-overflow.spec.ts); open it via trigger → menuitem.
+  const openPalette = async (): Promise<void> => {
+    await page.getByRole('button', { name: '更多操作' }).click();
+    await page.getByRole('menuitem', { name: '打开命令面板' }).click();
+  };
+
+  await openPalette();
   await expect(dialog).toBeVisible();
   await expectPaletteHeaderGeometry(dialog);
   await expectCompactShortcutHints(dialog);
@@ -55,7 +61,7 @@ test('command palette header geometry and dismissal stay intact', async ({ windo
   await dialog.getByRole('button', { name: '关闭命令面板' }).click();
   await expect(dialog).toBeHidden();
 
-  await openButton.click();
+  await openPalette();
   await expect(dialog).toBeVisible();
   await page.keyboard.press('Escape');
   await expect(dialog).toBeHidden();

--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -31,7 +31,11 @@ test('session tools share one user-controlled workbar', async ({ sessionWorkbarW
 });
 
 test('workbar toggle stays unmounted without an active session', async ({ window: page }) => {
-  const toggle = page.locator('.maka-workspace-top-actions button[aria-expanded]');
+  // The overflow trigger also carries aria-expanded (its menu opens/closes),
+  // so pin the workbar toggle by its label instead of the shared attribute.
+  const toggle = page
+    .getByRole('toolbar', { name: '工作区辅助操作' })
+    .getByRole('button', { name: /会话工作栏/ });
 
   await expect(toggle).toHaveCount(0);
 });

--- a/apps/desktop/e2e/topbar-overflow.spec.ts
+++ b/apps/desktop/e2e/topbar-overflow.spec.ts
@@ -1,0 +1,26 @@
+import { test, expect } from './fixtures';
+
+// Locks the structure promised by #1433 (desired outcome 3): the workspace
+// topbar collapses its secondary actions behind a single overflow menu
+// instead of rendering them as persistent icon buttons. The workbar toggle
+// stays direct (it is a layout control, symmetric with the sidebar toggle).
+test('workspace topbar folds secondary actions into an overflow menu', async ({ window: page }) => {
+  const toolbar = page.getByRole('toolbar', { name: '工作区辅助操作' });
+  await expect(toolbar).toBeVisible();
+
+  // Secondary actions no longer render as direct buttons in the toolbar.
+  for (const name of ['问题反馈', '打开命令面板', '打开帮助', '打开健康中心']) {
+    await expect(toolbar.getByRole('button', { name })).toHaveCount(0);
+  }
+
+  // They live behind a single overflow trigger.
+  const overflow = toolbar.getByRole('button', { name: '更多操作' });
+  await expect(overflow).toBeVisible();
+
+  // Opening the menu surfaces all four entries.
+  await overflow.click();
+  await expect(page.getByRole('menuitem', { name: '问题反馈' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: '打开命令面板' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: '打开帮助' })).toBeVisible();
+  await expect(page.getByRole('menuitem', { name: '打开健康中心' })).toBeVisible();
+});

--- a/apps/desktop/e2e/topbar-overflow.spec.ts
+++ b/apps/desktop/e2e/topbar-overflow.spec.ts
@@ -4,23 +4,50 @@ import { test, expect } from './fixtures';
 // topbar collapses its secondary actions behind a single overflow menu
 // instead of rendering them as persistent icon buttons. The workbar toggle
 // stays direct (it is a layout control, symmetric with the sidebar toggle).
-test('workspace topbar folds secondary actions into an overflow menu', async ({ window: page }) => {
+//
+// Uses the sessionWorkbarWindow fixture so the workbar toggle is mounted —
+// the resident-button count is then exactly two (overflow trigger + workbar).
+test('workspace topbar folds secondary actions into an overflow menu', async ({ sessionWorkbarWindow: page }) => {
   const toolbar = page.getByRole('toolbar', { name: '工作区辅助操作' });
   await expect(toolbar).toBeVisible();
 
-  // Secondary actions no longer render as direct buttons in the toolbar.
+  // Structural boundary: exactly two resident buttons (overflow + workbar).
+  // A future direct button added here fails before the inset geometry
+  // contract ever notices — that contract only checks count↔inset math.
+  await expect(toolbar.getByRole('button')).toHaveCount(2);
+
+  // The four secondary actions are not direct toolbar buttons.
   for (const name of ['问题反馈', '打开命令面板', '打开帮助', '打开健康中心']) {
     await expect(toolbar.getByRole('button', { name })).toHaveCount(0);
   }
 
-  // They live behind a single overflow trigger.
   const overflow = toolbar.getByRole('button', { name: '更多操作' });
   await expect(overflow).toBeVisible();
 
-  // Opening the menu surfaces all four entries.
+  // Each secondary action surfaces only behind the overflow menu, and clicking
+  // a menuitem fires its callback (the destination opens) — not just visible.
+  const openSecondary = async (label: string): Promise<void> => {
+    await overflow.click();
+    await page.getByRole('menuitem', { name: label }).click();
+  };
+
+  // feedback → opens Settings (About section).
+  await openSecondary('问题反馈');
+  await expect(page.getByRole('main', { name: '设置内容' })).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  // help → opens the keyboard-shortcut dialog.
+  await openSecondary('打开帮助');
+  await expect(page.locator('.maka-help-modal')).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  // health → opens Settings (Health section).
+  await openSecondary('打开健康中心');
+  await expect(page.getByRole('main', { name: '设置内容' })).toBeVisible();
+  await page.keyboard.press('Escape');
+
+  // The command-palette entry is end-to-end verified by command-palette.spec
+  // (overflow → menuitem → dialog); here we only assert it is present.
   await overflow.click();
-  await expect(page.getByRole('menuitem', { name: '问题反馈' })).toBeVisible();
   await expect(page.getByRole('menuitem', { name: '打开命令面板' })).toBeVisible();
-  await expect(page.getByRole('menuitem', { name: '打开帮助' })).toBeVisible();
-  await expect(page.getByRole('menuitem', { name: '打开健康中心' })).toBeVisible();
 });

--- a/apps/desktop/src/main/__tests__/chat-header-actions-inset-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-header-actions-inset-contract.test.ts
@@ -101,7 +101,10 @@ describe('chat header actions inset contract', () => {
     const gap = pxDeclaration(toolbarBody, 'gap');
     const insetAddend = workspaceTopActionsInsetAddend(css);
 
-    assert.equal(buttonCount, 5, 'current top-actions toolbar renders five icon buttons');
+    // buttonCount is intentionally not pinned: the inset formula below must
+    // track whatever the toolbar actually renders (see topbar-overflow.spec.ts
+    // for the structural contract). Adding/folding buttons without updating
+    // --maka-workspace-top-actions-inset fails the formula assertion below.
     assert.equal(buttonSize, 28, 'top-actions use the governed compact Button tier');
     assert.equal(gap, 6, 'top-actions icon buttons use a 6px gap');
     assert.equal(

--- a/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
+++ b/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
@@ -3,6 +3,7 @@ import {
   Grid3X3,
   HelpCircle,
   MessageCircleQuestion,
+  MoreHorizontal,
   PanelLeftClose,
   PanelLeftOpen,
   PanelRightClose,
@@ -10,7 +11,17 @@ import {
   Search,
   SquarePen,
 } from '@maka/ui/icons';
-import { Button as UiButton, Tooltip, TooltipContent, TooltipTrigger, useUiLocale } from '@maka/ui';
+import {
+  Button as UiButton,
+  Menu,
+  MenuItem,
+  MenuPopup,
+  MenuTrigger,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+  useUiLocale,
+} from '@maka/ui';
 import { getShellCopy } from './locales/shell-copy';
 
 export function AppShellTopbarActions(props: {
@@ -86,54 +97,34 @@ export function AppShellWorkspaceTopActions(props: {
 
   return (
     <div className="maka-workspace-top-actions" role="toolbar" aria-label={copy.workspaceActions}>
-      <Tooltip>
-        <TooltipTrigger
+      <Menu>
+        <MenuTrigger
           render={<UiButton variant="quiet" size="icon-sm" />}
           type="button"
           className="maka-titlebar-action"
-          onClick={props.onOpenFeedback}
-          aria-label={copy.feedback}
+          aria-label={copy.moreActions}
         >
-          <MessageCircleQuestion aria-hidden="true" />
-        </TooltipTrigger>
-        <TooltipContent>{copy.feedbackTooltip}</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger
-          render={<UiButton variant="quiet" size="icon-sm" />}
-          type="button"
-          className="maka-titlebar-action"
-          onClick={props.onOpenPalette}
-          aria-label={copy.openCommandPalette}
-        >
-          <Grid3X3 aria-hidden="true" />
-        </TooltipTrigger>
-        <TooltipContent>{copy.openCommandPalette}</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger
-          render={<UiButton variant="quiet" size="icon-sm" />}
-          type="button"
-          className="maka-titlebar-action"
-          onClick={props.onOpenHelp}
-          aria-label={copy.openHelp}
-        >
-          <HelpCircle aria-hidden="true" />
-        </TooltipTrigger>
-        <TooltipContent>{copy.openHelp}</TooltipContent>
-      </Tooltip>
-      <Tooltip>
-        <TooltipTrigger
-          render={<UiButton variant="quiet" size="icon-sm" />}
-          type="button"
-          className="maka-titlebar-action"
-          onClick={props.onOpenHealth}
-          aria-label={copy.openHealth}
-        >
-          <CircleGauge aria-hidden="true" />
-        </TooltipTrigger>
-        <TooltipContent>{copy.openHealth}</TooltipContent>
-      </Tooltip>
+          <MoreHorizontal aria-hidden="true" />
+        </MenuTrigger>
+        <MenuPopup align="end" sideOffset={4}>
+          <MenuItem onClick={props.onOpenFeedback}>
+            <MessageCircleQuestion aria-hidden="true" />
+            <span>{copy.feedback}</span>
+          </MenuItem>
+          <MenuItem onClick={props.onOpenPalette}>
+            <Grid3X3 aria-hidden="true" />
+            <span>{copy.openCommandPalette}</span>
+          </MenuItem>
+          <MenuItem onClick={props.onOpenHelp}>
+            <HelpCircle aria-hidden="true" />
+            <span>{copy.openHelp}</span>
+          </MenuItem>
+          <MenuItem onClick={props.onOpenHealth}>
+            <CircleGauge aria-hidden="true" />
+            <span>{copy.openHealth}</span>
+          </MenuItem>
+        </MenuPopup>
+      </Menu>
       {props.workbarAvailable && (
         <Tooltip>
           <TooltipTrigger

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -384,6 +384,7 @@ type ShellCopy = {
     openCommandPalette: string;
     openHelp: string;
     openHealth: string;
+    moreActions: string;
   };
   app: {
     loadingWorkbarLabel: string;
@@ -1055,6 +1056,7 @@ const SHELL_COPY_BY_LOCALE = {
       openCommandPalette: '打开命令面板',
       openHelp: '打开帮助',
       openHealth: '打开健康中心',
+      moreActions: '更多操作',
     },
     app: {
       loadingWorkbarLabel: '正在加载会话工作栏',
@@ -1555,6 +1557,7 @@ const SHELL_COPY_BY_LOCALE = {
       openCommandPalette: 'Open command palette',
       openHelp: 'Open help',
       openHealth: 'Open Health Center',
+      moreActions: 'More actions',
     },
     app: {
       loadingWorkbarLabel: 'Loading conversation workbar',

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -380,7 +380,6 @@ type ShellCopy = {
     collapseWorkbar: string;
     workspaceActions: string;
     feedback: string;
-    feedbackTooltip: string;
     openCommandPalette: string;
     openHelp: string;
     openHealth: string;
@@ -1052,7 +1051,6 @@ const SHELL_COPY_BY_LOCALE = {
       collapseWorkbar: '收起会话工作栏',
       workspaceActions: '工作区辅助操作',
       feedback: '问题反馈',
-      feedbackTooltip: '问题反馈 · 打开关于与环境信息',
       openCommandPalette: '打开命令面板',
       openHelp: '打开帮助',
       openHealth: '打开健康中心',
@@ -1553,7 +1551,6 @@ const SHELL_COPY_BY_LOCALE = {
       collapseWorkbar: 'Collapse conversation workbar',
       workspaceActions: 'Workspace actions',
       feedback: 'Send feedback',
-      feedbackTooltip: 'Send feedback · Open About and environment information',
       openCommandPalette: 'Open command palette',
       openHelp: 'Open help',
       openHealth: 'Open Health Center',

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -527,13 +527,14 @@
   --maka-workspace-top-actions-top: calc(var(--maka-titlebar-control-safe-top) - 16px); /* pixel-measured lockstep with sidebar rail — lights' optical center is 20.75 */
   --maka-workspace-top-actions-right: 24px;
   /* Horizontal footprint the absolutely-positioned .maka-workspace-top-actions
-     toolbar occupies in the top-right corner: its right offset + five governed
-     28px compact icon buttons with 6px gaps (164px) + a 12px clearance gap. Right-aligned
-     chat-header content (model switcher, .maka-chat-header-mode-pill, memory
-     pill) and the chat-header drag strip reserve this footprint so neither
-     content nor titlebar hit regions sit underneath the toolbar. Companion to
-     PR-CHAT-HEADER-STATUS-CLUSTER-0, which only relocated the status cluster and
-     left the in-header pills overlapping. */
+     toolbar occupies in the top-right corner: its right offset + two resident
+     28px compact icon buttons (the overflow trigger and the workbar toggle)
+     with a 6px gap (62px) + a 12px clearance gap. The four secondary actions
+     (feedback, command palette, help, health) live behind the overflow menu
+     and add no horizontal footprint here. Right-aligned chat-header content
+     (model switcher, .maka-chat-header-mode-pill, memory pill) and the
+     chat-header drag strip reserve this footprint so neither content nor
+     titlebar hit regions sit underneath the toolbar. */
   --maka-workspace-top-actions-inset: calc(var(--maka-workspace-top-actions-right) + 74px);
 
   /* PR-WINDOW-TITLEBAR-0: Electron exposes the titlebar safe area through

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -534,7 +534,7 @@
      content nor titlebar hit regions sit underneath the toolbar. Companion to
      PR-CHAT-HEADER-STATUS-CLUSTER-0, which only relocated the status cluster and
      left the in-header pills overlapping. */
-  --maka-workspace-top-actions-inset: calc(var(--maka-workspace-top-actions-right) + 176px);
+  --maka-workspace-top-actions-inset: calc(var(--maka-workspace-top-actions-right) + 74px);
 
   /* PR-WINDOW-TITLEBAR-0: Electron exposes the titlebar safe area through
      `titlebar-area-*` CSS env vars. The safe area is the usable titlebar


### PR DESCRIPTION
## Summary

The workspace topbar rendered five persistent icon buttons. The four secondary entries — feedback, command palette, help, health — now fold into a single overflow menu (a `MoreHorizontal` trigger opening a `@maka/ui` `Menu`), leaving only the workbar toggle direct.

The workbar toggle stays persistent: it is a layout control, symmetric with the sidebar toggle (left toggles the left rail, right toggles the right rail), and high-frequency — folding it would add two clicks to every open/close.

Refs #1433 (desired outcome 3: collapse the top bar to search / new task / workbar toggle + one overflow menu). Not `Closes` — #1433 also covers sidebar subtraction and module IA, which remain open for discussion.

## Verification

- `npm --workspace @maka/desktop run typecheck` — pass
- `npm --workspace @maka/desktop run test` (main contract suite) — 2845 passed / 0 failed, including the updated `chat-header-actions-inset-contract`
- Playwright e2e — 5 passed: `topbar-overflow` (new structural contract), `command-palette`, `session-workbar`, `chat-chrome-style`

Carried-through changes so the rest of the code stays consistent with the narrower toolbar:

- `maka-tokens.css`: workspace topbar inset 176px → 74px (2 resident buttons now: 2×28 + 1×6 gap + 12 clearance). Left unchanged, `.maka-chat-header` would reserve ~100px too much.
- `chat-header-actions-inset-contract`: dropped the hardcoded `buttonCount === 5` pin; the dynamic inset formula already enforces inset ↔ button count.
- `session-workbar.spec`: pin the workbar toggle by label — the overflow trigger also carries `aria-expanded`, so the old `button[aria-expanded]` locator would match two buttons.
- `command-palette.spec`: open the palette via overflow → menuitem.
- `topbar-overflow.spec`: new structural contract — the four secondary actions are no longer direct toolbar buttons; they surface only behind the overflow menu.

Before/after, captured from the live app with the `sessionWorkbarWindow` fixture (so the workbar toggle is mounted in both states — the diff is the fold itself, not session state): before 5 persistent icons / 328px → after overflow trigger + workbar toggle / 124px.

<img width="468" height="94" alt="image" src="https://github.com/user-attachments/assets/8c333e6d-ed48-4e06-856f-96ccea34c6b9" />