### PR TITLE
feat(runtime): support Kimi OpenAI protocol

### DIFF
--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -135,6 +135,8 @@ export interface ThinkingCompleteEvent extends BaseEvent {
   text: string;
   /** Anthropic signed thinking — MUST be re-sent on replay. */
   signature?: string;
+  /** Provider-owned replay metadata that must survive backend recreation. */
+  providerOptions?: Record<string, unknown>;
 }
 
 export interface ToolStartEvent extends BaseEvent {

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -593,7 +593,7 @@ const providerRegistry = {
   },
   'kimi-coding-plan': {
     label: 'Kimi Coding Plan',
-    description: 'Kimi for Coding over Anthropic-compatible protocol.',
+    description: 'Kimi for Coding over selectable Anthropic- or OpenAI-compatible protocol.',
     baseUrl: 'https://api.kimi.com/coding/v1',
     authKind: 'api_key',
     backendKind: 'ai-sdk',

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -143,6 +143,8 @@ export interface RuntimeEventThinkingContent {
   text: string;
   /** Anthropic signed thinking — MUST be re-sent on replay when present. */
   signature?: string;
+  /** Provider-owned replay metadata that must survive model replay. */
+  providerOptions?: Record<string, unknown>;
 }
 
 export interface RuntimeEventFunctionCallContent {
@@ -384,7 +386,7 @@ const TEXT_CONTENT_SHAPE = defineObjectShape<RuntimeEventTextContent>()(
 );
 const THINKING_CONTENT_SHAPE = defineObjectShape<RuntimeEventThinkingContent>()(
   ['kind', 'text'],
-  ['signature'],
+  ['signature', 'providerOptions'],
 );
 const FUNCTION_CALL_CONTENT_SHAPE = defineObjectShape<RuntimeEventFunctionCallContent>()(
   ['kind', 'id', 'name', 'args'],
@@ -510,7 +512,8 @@ function isRuntimeEventContent(value: unknown): value is RuntimeEventContent {
       return (
         hasExactShape(value, THINKING_CONTENT_SHAPE) &&
         typeof value.text === 'string' &&
-        isOptionalString(value.signature)
+        isOptionalString(value.signature) &&
+        (value.providerOptions === undefined || isRecord(value.providerOptions))
       );
     case 'function_call':
       return (

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -601,6 +601,8 @@ export interface AssistantMessage {
     text: string;
     /** Anthropic signed thinking for replay. */
     signature?: string;
+    /** Provider-owned replay metadata that must survive missing-ledger recovery. */
+    providerOptions?: Record<string, unknown>;
   };
   /**
    * First-observed order of visible content inside this assistant step.
@@ -817,7 +819,10 @@ const SYSTEM_NOTE_MESSAGE_SHAPE = defineObjectShape<SystemNoteMessage>()(
   ['turnId', 'data'],
 );
 type AssistantThinking = NonNullable<AssistantMessage['thinking']>;
-const ASSISTANT_THINKING_SHAPE = defineObjectShape<AssistantThinking>()(['text'], ['signature']);
+const ASSISTANT_THINKING_SHAPE = defineObjectShape<AssistantThinking>()(
+  ['text'],
+  ['signature', 'providerOptions'],
+);
 type AutomationOrigin = NonNullable<UserMessage['origin']>;
 const AUTOMATION_ORIGIN_SHAPE = defineObjectShape<AutomationOrigin>()(['kind', 'automationId'], []);
 
@@ -973,7 +978,8 @@ function isAssistantThinking(value: unknown): value is AssistantThinking {
     isRecord(value) &&
     hasExactShape(value, ASSISTANT_THINKING_SHAPE) &&
     typeof value.text === 'string' &&
-    isOptionalString(value.signature)
+    isOptionalString(value.signature) &&
+    (value.providerOptions === undefined || isRecord(value.providerOptions))
   );
 }
 

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -6149,6 +6149,221 @@ describe('AiSdkBackend model history', () => {
     ]);
     assert.equal(promptJson.includes('private chain of thought'), false);
   });
+
+  test('skips unsupported unsigned thinking without dropping native tool replay', async () => {
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: { ...connection(), providerType: 'openai' },
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(
+      backend.send({
+        turnId: 'turn-current',
+        text: 'current user',
+        context: [],
+        runtimeContext: [
+          runtimeTextEvent({
+            id: 'rt-u',
+            turnId: 'turn-prev',
+            role: 'user',
+            author: 'user',
+            text: 'read the file',
+          }),
+          runtimeEvent({
+            id: 'rt-thinking',
+            turnId: 'turn-prev',
+            role: 'model',
+            author: 'agent',
+            content: { kind: 'thinking', text: 'private unsigned thought' },
+          }),
+          runtimeEvent({
+            id: 'rt-call',
+            turnId: 'turn-prev',
+            role: 'model',
+            author: 'agent',
+            content: {
+              kind: 'function_call',
+              id: 'tool-1',
+              name: 'Read',
+              args: { path: 'package.json' },
+            },
+          }),
+          runtimeEvent({
+            id: 'rt-result',
+            turnId: 'turn-prev',
+            role: 'tool',
+            author: 'tool',
+            content: {
+              kind: 'function_response',
+              id: 'tool-1',
+              name: 'Read',
+              result: 'file contents',
+              isError: false,
+            },
+          }),
+        ],
+      }),
+    );
+
+    const promptJson = JSON.stringify(compactPrompt(model));
+    assert.match(promptJson, /"toolCallId":"tool-1"/);
+    assert.match(promptJson, /file contents/);
+    assert.equal(promptJson.includes('private unsigned thought'), false);
+  });
+
+  test('skips unmarked unsigned thinking when replaying Kimi OpenAI tool history', async () => {
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: {
+        ...connection(),
+        slug: 'kimi-main',
+        providerType: 'kimi-coding-plan',
+        defaultModel: 'k3',
+        models: [{ id: 'k3', apiProtocol: 'openai-chat' }],
+      },
+      apiKey: 'sk-test',
+      modelId: 'k3',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(
+      backend.send({
+        turnId: 'turn-current',
+        text: 'current user',
+        context: [],
+        runtimeContext: [
+          runtimeTextEvent({
+            id: 'rt-u',
+            turnId: 'turn-prev',
+            role: 'user',
+            author: 'user',
+            text: 'read the file',
+          }),
+          runtimeEvent({
+            id: 'rt-thinking',
+            turnId: 'turn-prev',
+            role: 'model',
+            author: 'agent',
+            content: { kind: 'thinking', text: 'private thinking from another provider' },
+          }),
+          runtimeEvent({
+            id: 'rt-call',
+            turnId: 'turn-prev',
+            role: 'model',
+            author: 'agent',
+            content: {
+              kind: 'function_call',
+              id: 'tool-1',
+              name: 'Read',
+              args: { path: 'package.json' },
+            },
+          }),
+          runtimeEvent({
+            id: 'rt-result',
+            turnId: 'turn-prev',
+            role: 'tool',
+            author: 'tool',
+            content: {
+              kind: 'function_response',
+              id: 'tool-1',
+              name: 'Read',
+              result: 'file contents',
+              isError: false,
+            },
+          }),
+        ],
+      }),
+    );
+
+    const promptJson = JSON.stringify(compactPrompt(model));
+    assert.equal(promptJson.includes('private thinking from another provider'), false);
+    assert.match(promptJson, /"toolCallId":"tool-1"/);
+    assert.match(promptJson, /file contents/);
+  });
+
+  test('rejects signed thinking from provider-native replay when the target cannot replay it', async () => {
+    const trace: RunTraceEvent[] = [];
+    const model = new MockLanguageModelV4({
+      doStream: async () => {
+        throw new Error('provider failed');
+      },
+    });
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: { ...connection(), providerType: 'openai' },
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+      recordRunTrace: (event) => trace.push(event),
+    });
+
+    await drain(
+      backend.send({
+        turnId: 'turn-current',
+        text: 'current user',
+        context: [
+          { type: 'user', id: 'projection-u', turnId: 'turn-prev', ts: 1, text: 'prior user' },
+          {
+            type: 'assistant',
+            id: 'projection-a',
+            turnId: 'turn-prev',
+            ts: 2,
+            text: 'prior answer',
+            modelId: 'm',
+          },
+        ],
+        runtimeContext: [
+          runtimeTextEvent({
+            id: 'rt-u',
+            turnId: 'turn-prev',
+            role: 'user',
+            author: 'user',
+            text: 'prior user',
+          }),
+          runtimeEvent({
+            id: 'rt-thinking',
+            turnId: 'turn-prev',
+            role: 'model',
+            author: 'agent',
+            content: { kind: 'thinking', text: 'signed thought', signature: 'sig-1' },
+          }),
+          runtimeTextEvent({
+            id: 'rt-a',
+            turnId: 'turn-prev',
+            role: 'model',
+            author: 'agent',
+            text: 'prior answer',
+          }),
+        ],
+      }),
+    );
+
+    const failure = trace.find((event) => event.type === 'model_stream_failed');
+    assert.equal(failure?.data?.priorReplayGate, 'runtime_replay_unsupported_semantics');
+  });
 });
 
 describe('AiSdkBackend error surfaces', () => {

--- a/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
@@ -326,6 +326,134 @@ describe('Anthropic-compatible Computer Use product loops', () => {
 });
 
 describe('Kimi OpenAI-compatible product loop', () => {
+  test('reconstructs a recovered reasoning and tool-call step as one assistant message', async () => {
+    const sessionId = 'session-kimi-openai-recovered-tool-step';
+    const previousTurnId = 'turn-kimi-openai-recovered-tool-step-1';
+    const currentTurn = createDurableTurnHarness({
+      sessionId,
+      turnId: 'turn-kimi-openai-recovered-tool-step-2',
+      text: 'Continue after the recovered tool step.',
+    });
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/coding/v1/chat/completions');
+      requestBodies.push(JSON.parse(await readBody(request)) as Record<string, unknown>);
+      respondOpenAiTextStream(response, 'k3', 1, 'reasoning_content', 'next step');
+    });
+    const providerConnection = connection(
+      'kimi-coding-plan',
+      `${server.url}/coding`,
+      'k3',
+      'openai-chat',
+      131_072,
+    );
+    const recovered = backfillRuntimeEventsFromStoredMessages({
+      run: {
+        runId: 'run-kimi-openai-recovered-tool-step',
+        invocationId: 'invocation-kimi-openai-recovered-tool-step',
+        sessionId,
+        turnId: previousTurnId,
+        status: 'completed',
+        backendKind: 'ai-sdk',
+        llmConnectionSlug: providerConnection.slug,
+        modelId: 'k3',
+        cwd: '/tmp/maka',
+        permissionMode: 'ask',
+        createdAt: 1,
+        updatedAt: 5,
+        completedAt: 5,
+      } satisfies AgentRunHeader,
+      messages: [
+        {
+          type: 'user',
+          id: 'stored-user-recovered',
+          turnId: previousTurnId,
+          ts: 1,
+          text: 'Inspect the application.',
+        },
+        {
+          type: 'assistant',
+          id: 'stored-step-recovered',
+          turnId: previousTurnId,
+          ts: 2,
+          text: 'I will inspect it.',
+          modelId: 'k3',
+          thinking: {
+            text: '',
+            providerOptions: { maka: { kimiReasoningField: 'reasoning_content' } },
+          },
+        },
+        {
+          type: 'tool_call',
+          id: 'call-recovered',
+          turnId: previousTurnId,
+          ts: 3,
+          toolName: 'maka_computer',
+          args: { action: 'list_apps' },
+          stepId: 'stored-step-recovered',
+        },
+        {
+          type: 'tool_result',
+          id: 'result-recovered',
+          turnId: previousTurnId,
+          ts: 4,
+          toolUseId: 'call-recovered',
+          isError: false,
+          content: { kind: 'text', text: 'Application list' },
+        },
+      ] satisfies StoredMessage[],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    const runtime = new AiSdkBackend({
+      sessionId,
+      header: header('kimi-coding-plan', 'k3'),
+      appendMessage: async () => {},
+      connection: providerConnection,
+      apiKey: 'test-key',
+      modelId: 'k3',
+      permissionEngine: new PermissionEngine({
+        newId: () => 'permission-id',
+        now: () => 1,
+      }),
+      modelFactory: (input) => getAIModel(input),
+      providerOptions: buildProviderOptions(providerConnection, 'k3'),
+      tools: [],
+      maxSteps: 1,
+      loadTurnRuntimeEvents: currentTurn.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    for await (const event of runtime.send(
+      currentTurn.sendInput({ runtimeContext: recovered.events }),
+    )) {
+      currentTurn.record(event);
+    }
+
+    assert.equal(requestBodies.length, 1);
+    const messages = requestBodies[0]!.messages;
+    assert.ok(Array.isArray(messages));
+    const replayedStep = messages.find(
+      (message) =>
+        isRecord(message) &&
+        message.role === 'assistant' &&
+        Array.isArray(message.tool_calls) &&
+        message.tool_calls.some(
+          (toolCall) => isRecord(toolCall) && toolCall.id === 'call-recovered',
+        ),
+    );
+    assert.ok(replayedStep && isRecord(replayedStep));
+    assert.equal(replayedStep.content, 'I will inspect it.');
+    assert.equal(replayedStep.reasoning_content, '');
+    const replayedResult = messages.find(
+      (message) =>
+        isRecord(message) && message.role === 'tool' && message.tool_call_id === 'call-recovered',
+    );
+    assert.ok(replayedResult, 'the recovered result must follow its reconstructed tool call');
+  });
+
   test('replays explicit empty reasoning after missing-ledger recovery and backend recreation', async () => {
     const sessionId = 'session-kimi-openai-cross-turn';
     const firstTurn = createDurableTurnHarness({

--- a/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
+++ b/packages/runtime/src/__tests__/computer-use-provider-protocol.test.ts
@@ -1,7 +1,13 @@
 import assert from 'node:assert/strict';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { after, describe, test } from 'node:test';
-import type { LlmConnection, SessionEvent, SessionHeader } from '@maka/core';
+import type {
+  AgentRunHeader,
+  LlmConnection,
+  SessionEvent,
+  SessionHeader,
+  StoredMessage,
+} from '@maka/core';
 
 import { AiSdkBackend } from '../ai-sdk-backend.js';
 import {
@@ -11,6 +17,11 @@ import {
 } from '../computer-use-tools.js';
 import { buildProviderOptions, getAIModel } from '../model-factory.js';
 import { PermissionEngine } from '../permission-engine.js';
+import type {
+  ProviderRequestAttemptRecord,
+  ProviderRequestCaptureRecord,
+} from '../provider-request-telemetry.js';
+import { backfillRuntimeEventsFromStoredMessages } from '../runtime-event-backfill.js';
 import { createDurableTurnHarness } from './durable-turn-harness.js';
 
 const servers: Array<{ close(): Promise<void> }> = [];
@@ -74,6 +85,8 @@ describe('Anthropic-compatible Computer Use product loops', () => {
         text: 'Set the fixture field to provider-loop.',
       });
       const requestBodies: Array<Record<string, unknown>> = [];
+      const captures: ProviderRequestCaptureRecord[] = [];
+      const attempts: ProviderRequestAttemptRecord[] = [];
       const server = await startJsonServer(async (request, response) => {
         assert.equal(request.method, 'POST');
         assert.equal(request.url, provider.expectedPath);
@@ -95,7 +108,13 @@ describe('Anthropic-compatible Computer Use product loops', () => {
               : step === 3
                 ? semanticInputFromMessages(body.messages)
                 : undefined;
-        respondAnthropicStream(response, provider.modelId, step, toolInput);
+        respondAnthropicStream(
+          response,
+          provider.modelId,
+          step,
+          toolInput,
+          provider.expectedThinking !== undefined,
+        );
       });
       const value = { current: '' };
       const [computerTool] = buildComputerUseTools({
@@ -128,6 +147,13 @@ describe('Anthropic-compatible Computer Use product loops', () => {
         loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
         newId: idGenerator(),
         now: monotonicClock(),
+        recordProviderRequestCapture: async (capture) => {
+          captures.push(capture);
+          return { artifactId: `capture-artifact-${captures.length}` };
+        },
+        recordProviderRequestAttempt: (attempt) => {
+          attempts.push(attempt);
+        },
       });
 
       for await (const event of runtime.send(durable.sendInput())) {
@@ -149,6 +175,8 @@ describe('Anthropic-compatible Computer Use product loops', () => {
       );
       assert.equal(events.at(-1)?.type, 'complete');
       assert.equal(requestBodies.length, 4);
+      assert.equal(captures.length, 4);
+      assert.equal(attempts.length, 4);
       assert.deepEqual(toolResults, [{ isError: false }, { isError: false }, { isError: false }]);
       assert.deepEqual(
         (requestBodies[0].tools as Array<{ name: string }>).map((tool) => tool.name),
@@ -163,6 +191,20 @@ describe('Anthropic-compatible Computer Use product loops', () => {
           );
           assert.deepEqual(body.output_config, { effort: 'max' });
         }
+        assertAnthropicThinkingReplay(requestBodies[1]?.messages, 1);
+        assertAnthropicThinkingReplay(requestBodies[2]?.messages, 2);
+        assertAnthropicThinkingReplay(requestBodies[3]?.messages, 3);
+      }
+      for (const attempt of attempts) {
+        assert.equal(attempt.status, 'completed');
+        assert.equal(attempt.inputTokens, 15);
+        assert.equal(attempt.cacheReadInputTokens, 4);
+        assert.equal(attempt.cacheReadInputSource, 'provider');
+        assert.equal(attempt.cacheWriteInputTokens, 1);
+        assert.equal(attempt.cacheWriteInputSource, 'provider');
+        assert.equal(attempt.cacheMissInputTokens, 10);
+        assert.equal(attempt.cacheMissInputSource, 'provider');
+        assert.equal(attempt.outputTokens, 5);
       }
       for (const body of requestBodies) {
         assert.equal(
@@ -283,6 +325,290 @@ describe('Anthropic-compatible Computer Use product loops', () => {
   }
 });
 
+describe('Kimi OpenAI-compatible product loop', () => {
+  test('replays explicit empty reasoning after missing-ledger recovery and backend recreation', async () => {
+    const sessionId = 'session-kimi-openai-cross-turn';
+    const firstTurn = createDurableTurnHarness({
+      sessionId,
+      turnId: 'turn-kimi-openai-1',
+      text: 'First turn.',
+    });
+    const secondTurn = createDurableTurnHarness({
+      sessionId,
+      turnId: 'turn-kimi-openai-2',
+      text: 'Second turn.',
+    });
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const storedMessages: StoredMessage[] = [
+      {
+        type: 'user',
+        id: 'stored-user-1',
+        turnId: firstTurn.anchor.turnId,
+        ts: firstTurn.anchor.ts,
+        text: 'First turn.',
+      },
+    ];
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/coding/v1/chat/completions');
+      const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+      requestBodies.push(body);
+      const step = requestBodies.length;
+      respondOpenAiTextStream(response, 'k3', step, 'reasoning', step === 1 ? '' : 'second');
+    });
+    const providerConnection = connection(
+      'kimi-coding-plan',
+      `${server.url}/coding`,
+      'k3',
+      'openai-chat',
+      131_072,
+    );
+    const createRuntime = () =>
+      new AiSdkBackend({
+        sessionId,
+        header: header('kimi-coding-plan', 'k3'),
+        appendMessage: async (message) => {
+          storedMessages.push(structuredClone(message));
+        },
+        connection: providerConnection,
+        apiKey: 'test-key',
+        modelId: 'k3',
+        permissionEngine: new PermissionEngine({
+          newId: () => 'permission-id',
+          now: () => 1,
+        }),
+        modelFactory: (input) => getAIModel(input),
+        providerOptions: buildProviderOptions(providerConnection, 'k3'),
+        tools: [],
+        maxSteps: 1,
+        loadTurnRuntimeEvents: async (turnId) =>
+          [...firstTurn.ledger, ...secondTurn.ledger].filter((event) => event.turnId === turnId),
+        newId: idGenerator(),
+        now: monotonicClock(),
+      });
+
+    for await (const event of createRuntime().send(firstTurn.sendInput())) firstTurn.record(event);
+    assert.ok(
+      firstTurn.ledger.some(
+        (event) => event.content?.kind === 'thinking' && event.content.text === '',
+      ),
+      'the first turn must durably preserve the provider-authored empty reasoning field',
+    );
+
+    const recovered = backfillRuntimeEventsFromStoredMessages({
+      run: {
+        runId: firstTurn.anchor.runId,
+        invocationId: firstTurn.anchor.invocationId,
+        sessionId,
+        turnId: firstTurn.anchor.turnId,
+        status: 'completed',
+        backendKind: 'ai-sdk',
+        llmConnectionSlug: providerConnection.slug,
+        modelId: 'k3',
+        cwd: '/tmp/maka',
+        permissionMode: 'ask',
+        createdAt: firstTurn.anchor.ts,
+        updatedAt: firstTurn.anchor.ts + 1,
+        completedAt: firstTurn.anchor.ts + 1,
+      } satisfies AgentRunHeader,
+      messages: storedMessages,
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    assert.ok(
+      recovered.events.some(
+        (event) =>
+          event.content?.kind === 'thinking' &&
+          event.content.text === '' &&
+          isRecord(event.content.providerOptions),
+      ),
+      'missing-ledger recovery must preserve explicit empty reasoning and its provider dialect',
+    );
+
+    for await (const event of createRuntime().send(
+      secondTurn.sendInput({ runtimeContext: recovered.events }),
+    )) {
+      secondTurn.record(event);
+    }
+
+    assert.equal(requestBodies.length, 2);
+    const replayedAssistant = (requestBodies[1]!.messages as unknown[]).find(
+      (message) =>
+        isRecord(message) &&
+        message.role === 'assistant' &&
+        (typeof message.reasoning === 'string' || typeof message.reasoning_content === 'string'),
+    );
+    assert.ok(replayedAssistant && isRecord(replayedAssistant));
+    assert.equal(replayedAssistant.reasoning, '', JSON.stringify(requestBodies[1]!.messages));
+    assert.equal(replayedAssistant.reasoning_content, undefined);
+  });
+
+  test('preserves reasoning, tool pairing, and normalized request telemetry across steps', async () => {
+    const sessionId = 'session-kimi-openai';
+    const durable = createDurableTurnHarness({
+      sessionId,
+      turnId: 'turn-kimi-openai',
+      text: 'Set the fixture field to provider-loop.',
+    });
+    const requestBodies: Array<Record<string, unknown>> = [];
+    const captures: ProviderRequestCaptureRecord[] = [];
+    const attempts: ProviderRequestAttemptRecord[] = [];
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/coding/v1/chat/completions');
+      assert.equal(request.headers.authorization, 'Bearer test-key');
+      const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+      requestBodies.push(body);
+      const step = requestBodies.length;
+      const toolInput =
+        step === 1
+          ? { action: 'list_apps' }
+          : step === 2
+            ? {
+                action: 'observe',
+                app: 'pid:42',
+                window_id: 7,
+                include_screenshot: false,
+              }
+            : step === 3
+              ? semanticInputFromMessages(body.messages)
+              : undefined;
+      respondOpenAiStream(response, 'k3', step, toolInput);
+    });
+    const value = { current: '' };
+    const [computerTool] = buildComputerUseTools({
+      backend: fakeSemanticBackend(value),
+    });
+    const providerConnection = connection(
+      'kimi-coding-plan',
+      `${server.url}/coding`,
+      'k3',
+      'openai-chat',
+      131_072,
+    );
+    const events: SessionEvent[] = [];
+    const runtime = new AiSdkBackend({
+      sessionId,
+      header: header('kimi-coding-plan', 'k3'),
+      appendMessage: async () => {},
+      connection: providerConnection,
+      apiKey: 'test-key',
+      modelId: 'k3',
+      permissionEngine: new PermissionEngine({
+        newId: () => 'permission-id',
+        now: () => 1,
+      }),
+      modelFactory: (input) => getAIModel(input),
+      providerOptions: buildProviderOptions(providerConnection, 'k3'),
+      tools: [computerTool],
+      maxSteps: 4,
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      newId: idGenerator(),
+      now: monotonicClock(),
+      recordProviderRequestCapture: async (capture) => {
+        captures.push(capture);
+        return { artifactId: `capture-artifact-${captures.length}` };
+      },
+      recordProviderRequestAttempt: (attempt) => {
+        attempts.push(attempt);
+      },
+    });
+
+    for await (const event of runtime.send(durable.sendInput())) {
+      durable.record(event);
+      events.push(event);
+    }
+
+    assert.equal(
+      value.current,
+      'provider-loop',
+      JSON.stringify({
+        requestBodies,
+        eventTypes: events.map((event) => event.type),
+        attempts: attempts.map((attempt) => ({
+          step: attempt.step,
+          status: attempt.status,
+          finishReason: attempt.finishReason,
+        })),
+      }),
+    );
+    assert.equal(events.at(-1)?.type, 'complete');
+    assert.equal(requestBodies.length, 4);
+    assert.equal(captures.length, 4);
+    assert.equal(attempts.length, 4);
+    for (const capture of captures) {
+      assert.doesNotMatch(
+        capture.serializedRequest,
+        /MAKA_KIMI_EMPTY_REASONING/,
+        'provider request evidence must not persist the SDK-only empty-reasoning marker',
+      );
+    }
+    for (const body of requestBodies) {
+      assert.equal(body.reasoning_effort, 'max');
+      assert.equal(body.max_tokens, 131_072);
+      assert.deepEqual(body.stream_options, { include_usage: true });
+    }
+    assert.deepEqual(
+      (requestBodies[0]!.tools as Array<{ function?: { name?: string } }>).map(
+        (tool) => tool.function?.name,
+      ),
+      ['maka_computer'],
+    );
+    assertOpenAiReasoningAndToolPair(requestBodies[1]?.messages, 1);
+    assertOpenAiReasoningAndToolPair(requestBodies[2]?.messages, 2);
+    assertOpenAiReasoningAndToolPair(requestBodies[3]?.messages, 3);
+    assert.deepEqual(
+      attempts.map((attempt) => ({
+        step: attempt.step,
+        status: attempt.status,
+        input: attempt.inputTokens,
+        cacheRead: attempt.cacheReadInputTokens,
+        cacheMiss: attempt.cacheMissInputTokens,
+        output: attempt.outputTokens,
+        reasoning: attempt.reasoningTokens,
+      })),
+      [
+        {
+          step: 0,
+          status: 'completed',
+          input: 20,
+          cacheRead: 4,
+          cacheMiss: 16,
+          output: 7,
+          reasoning: 3,
+        },
+        {
+          step: 1,
+          status: 'completed',
+          input: 21,
+          cacheRead: 5,
+          cacheMiss: 16,
+          output: 8,
+          reasoning: 4,
+        },
+        {
+          step: 2,
+          status: 'completed',
+          input: 22,
+          cacheRead: 6,
+          cacheMiss: 16,
+          output: 9,
+          reasoning: 5,
+        },
+        {
+          step: 3,
+          status: 'completed',
+          input: 23,
+          cacheRead: 7,
+          cacheMiss: 16,
+          output: 10,
+          reasoning: 6,
+        },
+      ],
+    );
+  });
+});
+
 function fakeSemanticBackend(value: { current: string }): CuDispatchBackend {
   const observation = (): CuObservation => ({
     observationId: 'backend-observation',
@@ -390,8 +716,12 @@ function collectJsonObjects(value: unknown): Array<Record<string, unknown>> {
     return candidates.flatMap((candidate) => {
       try {
         const parsed = JSON.parse(candidate);
-        return parsed && typeof parsed === 'object' && !Array.isArray(parsed)
-          ? [parsed as Record<string, unknown>]
+        if (Array.isArray(parsed)) return parsed.flatMap(collectJsonObjects);
+        return parsed && typeof parsed === 'object'
+          ? [
+              parsed as Record<string, unknown>,
+              ...Object.values(parsed as Record<string, unknown>).flatMap(collectJsonObjects),
+            ]
           : [];
       } catch {
         return [];
@@ -430,11 +760,60 @@ function findToolResult(value: unknown, toolUseId: string): Record<string, unkno
   return undefined;
 }
 
+function assertOpenAiReasoningAndToolPair(messages: unknown, step: number): void {
+  assert.ok(Array.isArray(messages));
+  const assistantIndex = messages.findIndex(
+    (message) =>
+      isRecord(message) &&
+      message.role === 'assistant' &&
+      Array.isArray(message.tool_calls) &&
+      message.tool_calls.some((toolCall) => isRecord(toolCall) && toolCall.id === `call-${step}`),
+  );
+  const assistant = messages[assistantIndex];
+  assert.ok(assistant && isRecord(assistant));
+  assert.equal(assistant.reasoning, step === 1 ? '' : `reasoning-step-${step}`);
+  assert.equal(assistant.reasoning_content, undefined);
+  const toolResultIndex = messages.findIndex(
+    (message) =>
+      isRecord(message) && message.role === 'tool' && message.tool_call_id === `call-${step}`,
+  );
+  const toolResult = messages[toolResultIndex];
+  assert.ok(toolResult, `tool result for call-${step} must pair with its assistant tool call`);
+  assert.ok(
+    assistantIndex < toolResultIndex,
+    `assistant call-${step} must precede its paired tool result`,
+  );
+}
+
+function assertAnthropicThinkingReplay(messages: unknown, step: number): void {
+  const blocks = collectRecords(messages);
+  assert.ok(
+    blocks.some(
+      (block) =>
+        block.type === 'thinking' &&
+        block.thinking === `reasoning-step-${step}` &&
+        block.signature === `signature-step-${step}`,
+    ),
+    `Anthropic request must replay signed reasoning from step ${step}`,
+  );
+}
+
+function collectRecords(value: unknown): Array<Record<string, unknown>> {
+  if (Array.isArray(value)) return value.flatMap(collectRecords);
+  if (!isRecord(value)) return [];
+  return [value, ...Object.values(value).flatMap(collectRecords)];
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
 function respondAnthropicStream(
   response: ServerResponse,
   model: string,
   step: number,
   toolInput: Record<string, unknown> | undefined,
+  withThinking = false,
 ) {
   response.writeHead(200, {
     'content-type': 'text/event-stream',
@@ -453,13 +832,38 @@ function respondAnthropicStream(
       content: [],
       stop_reason: null,
       stop_sequence: null,
-      usage: { input_tokens: 10, output_tokens: 0 },
+      usage: {
+        input_tokens: 10,
+        cache_read_input_tokens: 4,
+        cache_creation_input_tokens: 1,
+        output_tokens: 0,
+      },
     },
   });
+  let contentIndex = 0;
+  if (withThinking) {
+    send('content_block_start', {
+      type: 'content_block_start',
+      index: contentIndex,
+      content_block: { type: 'thinking', thinking: '' },
+    });
+    send('content_block_delta', {
+      type: 'content_block_delta',
+      index: contentIndex,
+      delta: { type: 'thinking_delta', thinking: `reasoning-step-${step}` },
+    });
+    send('content_block_delta', {
+      type: 'content_block_delta',
+      index: contentIndex,
+      delta: { type: 'signature_delta', signature: `signature-step-${step}` },
+    });
+    send('content_block_stop', { type: 'content_block_stop', index: contentIndex });
+    contentIndex += 1;
+  }
   if (toolInput) {
     send('content_block_start', {
       type: 'content_block_start',
-      index: 0,
+      index: contentIndex,
       content_block: {
         type: 'tool_use',
         id: `toolu-${step}`,
@@ -467,7 +871,7 @@ function respondAnthropicStream(
         input: toolInput,
       },
     });
-    send('content_block_stop', { type: 'content_block_stop', index: 0 });
+    send('content_block_stop', { type: 'content_block_stop', index: contentIndex });
     send('message_delta', {
       type: 'message_delta',
       delta: { stop_reason: 'tool_use', stop_sequence: null },
@@ -476,10 +880,10 @@ function respondAnthropicStream(
   } else {
     send('content_block_start', {
       type: 'content_block_start',
-      index: 0,
+      index: contentIndex,
       content_block: { type: 'text', text: 'done' },
     });
-    send('content_block_stop', { type: 'content_block_stop', index: 0 });
+    send('content_block_stop', { type: 'content_block_stop', index: contentIndex });
     send('message_delta', {
       type: 'message_delta',
       delta: { stop_reason: 'end_turn', stop_sequence: null },
@@ -487,6 +891,112 @@ function respondAnthropicStream(
     });
   }
   send('message_stop', { type: 'message_stop' });
+  response.end();
+}
+
+function respondOpenAiStream(
+  response: ServerResponse,
+  model: string,
+  step: number,
+  toolInput: Record<string, unknown> | undefined,
+) {
+  response.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+  });
+  const send = (data: unknown) => {
+    response.write(`data: ${JSON.stringify(data)}\n\n`);
+  };
+  const choice = (delta: Record<string, unknown>, finishReason: string | null = null) => ({
+    id: `chatcmpl-${step}`,
+    object: 'chat.completion.chunk',
+    created: step,
+    model,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  });
+  send(choice({ role: 'assistant', reasoning: step === 1 ? '' : `reasoning-step-${step}` }));
+  if (toolInput) {
+    send(
+      choice({
+        tool_calls: [
+          {
+            index: 0,
+            id: `call-${step}`,
+            type: 'function',
+            function: {
+              name: 'maka_computer',
+              arguments: JSON.stringify(toolInput),
+            },
+          },
+        ],
+      }),
+    );
+    send(choice({}, 'tool_calls'));
+  } else {
+    send(choice({ content: 'done' }));
+    send(choice({}, 'stop'));
+  }
+  send({
+    id: `chatcmpl-${step}`,
+    object: 'chat.completion.chunk',
+    created: step,
+    model,
+    choices: [
+      {
+        index: 0,
+        delta: {},
+        finish_reason: null,
+        usage: {
+          prompt_tokens: 19 + step,
+          completion_tokens: 6 + step,
+          total_tokens: 25 + step * 2,
+          cached_tokens: 3 + step,
+          completion_tokens_details: { reasoning_tokens: 2 + step },
+        },
+      },
+    ],
+  });
+  response.write('data: [DONE]\n\n');
+  response.end();
+}
+
+function respondOpenAiTextStream(
+  response: ServerResponse,
+  model: string,
+  step: number,
+  reasoningField: 'reasoning' | 'reasoning_content',
+  reasoning: string,
+) {
+  response.writeHead(200, {
+    'content-type': 'text/event-stream',
+    'cache-control': 'no-cache',
+  });
+  const send = (data: unknown) => {
+    response.write(`data: ${JSON.stringify(data)}\n\n`);
+  };
+  const choice = (delta: Record<string, unknown>, finishReason: string | null = null) => ({
+    id: `chatcmpl-text-${step}`,
+    object: 'chat.completion.chunk',
+    created: step,
+    model,
+    choices: [{ index: 0, delta, finish_reason: finishReason }],
+  });
+  send(choice({ role: 'assistant', [reasoningField]: reasoning }));
+  send(choice({ content: `turn-${step}-done` }));
+  send(choice({}, 'stop'));
+  send({
+    id: `chatcmpl-text-${step}`,
+    object: 'chat.completion.chunk',
+    created: step,
+    model,
+    choices: [],
+    usage: {
+      prompt_tokens: 10 + step,
+      completion_tokens: 2,
+      total_tokens: 12 + step,
+    },
+  });
+  response.write('data: [DONE]\n\n');
   response.end();
 }
 
@@ -518,7 +1028,7 @@ function connection(
   providerType: LlmConnection['providerType'],
   baseUrl: string,
   model: string,
-  apiProtocol?: 'anthropic-messages',
+  apiProtocol?: 'anthropic-messages' | 'openai-chat',
   maxOutputTokens?: number,
 ): LlmConnection {
   return {

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -55,6 +55,33 @@ describe('ModelAdapter stream and error normalization', () => {
     assert.equal(adapter.runtimeEventReplaySupport().signedThinking, true);
   });
 
+  test('supports unsigned-thinking replay on Kimi models using the OpenAI wire', () => {
+    const adapter = new ModelAdapter({
+      connection: {
+        slug: 'kimi-coding-plan',
+        name: 'Kimi Coding Plan',
+        providerType: 'kimi-coding-plan',
+        defaultModel: 'k3',
+        models: [{ id: 'k3', apiProtocol: 'openai-chat' }],
+        enabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      apiKey: 'kimi-token',
+      modelId: 'k3',
+      modelFactory: () => ({}),
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    assert.deepEqual(adapter.runtimeEventReplaySupport(), {
+      toolCalls: true,
+      toolResults: true,
+      signedThinking: false,
+      unsignedThinking: true,
+    });
+  });
+
   test('translates provider text, reasoning, tool calls, and errors into ModelStreamEvents', () => {
     const adapter = newAdapter();
     type Chunk = Parameters<typeof adapter.translateChunk>[0];
@@ -106,6 +133,24 @@ describe('ModelAdapter stream and error normalization', () => {
     assert.equal(shaped.reason, 'rate_limit');
     assert.equal(shaped.code, '429');
     assert.equal(shaped.message, 'Rate limit exceeded');
+  });
+
+  test('preserves an explicit empty reasoning delta without inventing one for absent text', () => {
+    const adapter = newAdapter();
+    type Chunk = Parameters<typeof adapter.translateChunk>[0];
+
+    assert.deepEqual(adapter.translateChunk({ type: 'reasoning-delta', text: '' } as Chunk), [
+      { kind: 'thinking', text: '' },
+    ]);
+    assert.deepEqual(adapter.translateChunk({ type: 'reasoning-delta' } as Chunk), []);
+    assert.deepEqual(
+      adapter.translateChunk({
+        type: 'reasoning-delta',
+        text: '',
+        providerMetadata: { anthropic: { signature: 'sig-empty' } },
+      } as Chunk),
+      [{ kind: 'thinking-signature', signature: 'sig-empty' }],
+    );
   });
 
   test('returns a Maka-owned tool call event from one provider step', () => {

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -74,6 +74,16 @@ describe('buildProviderOptions: thinking level', () => {
     assert.deepEqual(buildProviderOptions(conn('kimi-coding-plan'), 'k3', 'max'), expected);
   });
 
+  test('Kimi K3 sends max reasoning effort through the selected OpenAI-compatible namespace', () => {
+    const connection = {
+      ...conn('kimi-coding-plan'),
+      models: [{ id: 'k3', apiProtocol: 'openai-chat' as const }],
+    };
+    const expected = { kimiCodingPlan: { reasoningEffort: 'max' } };
+    assert.deepEqual(buildProviderOptions(connection, 'k3'), expected);
+    assert.deepEqual(buildProviderOptions(connection, 'k3', 'max'), expected);
+  });
+
   test('openai gpt-5.5 sends reasoningEffort (none for off, max for max); gpt-4o drops level', () => {
     assert.deepEqual(buildProviderOptions(conn('openai'), 'gpt-4o', 'high'), {
       openai: { store: false },
@@ -319,6 +329,37 @@ describe('buildProviderOptions: thinking level', () => {
 });
 
 describe('getAIModel: models.dev registry providers', () => {
+  test('routes the existing Kimi provider through its explicitly selected protocol', () => {
+    const anthropic = getAIModel({
+      connection: conn('kimi-coding-plan'),
+      apiKey: 'test-key',
+      modelId: 'k3',
+    });
+    const openai = getAIModel({
+      connection: {
+        ...conn('kimi-coding-plan'),
+        models: [{ id: 'k3', apiProtocol: 'openai-chat' }],
+      },
+      apiKey: 'test-key',
+      modelId: 'k3',
+    });
+
+    assert.equal(anthropic.provider, 'anthropic.messages');
+    assert.equal(openai.provider, 'kimi-coding-plan.chat');
+    assert.throws(
+      () =>
+        getAIModel({
+          connection: {
+            ...conn('kimi-coding-plan'),
+            models: [{ id: 'k3', apiProtocol: 'openai-responses' }],
+          },
+          apiKey: 'test-key',
+          modelId: 'k3',
+        }),
+      /Kimi Coding Plan.*openai-chat.*anthropic-messages/,
+    );
+  });
+
   test('routes SiliconFlow through the shared OpenAI-compatible adapter without rewriting model ids', () => {
     const model = getAIModel({
       connection: conn('siliconflow'),

--- a/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
@@ -66,7 +66,7 @@ const user = (id: string, text: string): UserMessage => ({
 const assistant = (
   id: string,
   text: string,
-  thinking?: { text: string; signature?: string },
+  thinking?: AssistantMessage['thinking'],
 ): AssistantMessage => ({
   type: 'assistant',
   id,
@@ -322,10 +322,20 @@ describe('storedMessageToRuntimeEvents', () => {
     expect(storedMessageToRuntimeEvents(toolCall('tc', 'Read'), ctx)).toEqual([]);
   });
 
-  test('assistant with empty thinking text → single text event only', () => {
-    const out = storedMessageToRuntimeEvents(assistant('a3', 'hi', { text: '' }), ctx);
-    expect(out).toHaveLength(1);
-    expect(out[0]?.content?.kind).toBe('text');
+  test('assistant with explicit empty thinking preserves provider replay metadata', () => {
+    const out = storedMessageToRuntimeEvents(
+      assistant('a3', 'hi', {
+        text: '',
+        providerOptions: { maka: { kimiReasoningField: 'reasoning' } },
+      }),
+      ctx,
+    );
+    expect(out).toHaveLength(2);
+    expect(out[1]?.content).toEqual({
+      kind: 'thinking',
+      text: '',
+      providerOptions: { maka: { kimiReasoningField: 'reasoning' } },
+    });
   });
 });
 
@@ -1064,7 +1074,7 @@ describe('buildModelHistoryFromRuntimeEvents', () => {
     ]);
   });
 
-  test('runtime replay plan skips unsigned thinking instead of flattening or blocking it', () => {
+  test('runtime replay plan preserves unsigned thinking without flattening it into text', () => {
     const events: RuntimeEvent[] = [
       ev({
         role: 'model',
@@ -1076,13 +1086,13 @@ describe('buildModelHistoryFromRuntimeEvents', () => {
 
     const plan = buildRuntimeEventModelReplayPlan(events);
 
-    // Unsigned thinking is skipped from native items and never claims the
-    // 'thinking' semantic kind, but is recorded non-blockingly for observability.
-    expect(plan.diagnostics.map((diagnostic) => diagnostic.code)).toContain(
-      'unsigned_thinking_skipped',
+    expect(plan.diagnostics).toEqual([]);
+    expect(plan.items.map((item) => item.kind)).toEqual(['thinking', 'text']);
+    const thinking = plan.items.find((item) => item.kind === 'thinking');
+    expect(thinking && thinking.kind === 'thinking' ? thinking.signature : undefined).toBe(
+      undefined,
     );
-    expect(plan.items.map((item) => item.kind)).toEqual(['text']);
-    expect(plan.semanticKinds).not.toContain('thinking');
+    expect(plan.semanticKinds).toContain('thinking');
     expect(plan.textMessages).toEqual([{ role: 'assistant', content: 'answer' }]);
   });
 
@@ -1120,13 +1130,17 @@ describe('buildModelHistoryFromRuntimeEvents', () => {
 
     const plan = buildRuntimeEventModelReplayPlan(events);
 
-    // The tool call/result remain native; the unsigned thinking is simply omitted.
+    // The provider-agnostic plan keeps every native semantic item. The target
+    // model adapter decides whether unsigned thinking can be materialized.
     expect(plan.hasProviderNativeSemantics).toBe(true);
-    expect(plan.items.map((item) => item.kind)).toEqual(['text', 'tool_call', 'tool_result']);
-    expect(plan.semanticKinds).not.toContain('thinking');
-    // No blocking diagnostic classes present (only the non-blocking skip note).
+    expect(plan.items.map((item) => item.kind)).toEqual([
+      'text',
+      'thinking',
+      'tool_call',
+      'tool_result',
+    ]);
+    expect(plan.semanticKinds).toContain('thinking');
     const codes = plan.diagnostics.map((diagnostic) => diagnostic.code);
-    expect(codes).toContain('unsigned_thinking_skipped');
     expect(codes).not.toContain('unsupported_role');
     expect(codes).not.toContain('unsupported_content');
     expect(codes).not.toContain('unmatched_tool_result');
@@ -1150,7 +1164,6 @@ describe('buildModelHistoryFromRuntimeEvents', () => {
     expect(thinking && thinking.kind === 'thinking' ? thinking.signature : undefined).toBe('sig-9');
     expect(plan.semanticKinds).toContain('thinking');
     const pureCodes = plan.diagnostics.map((diagnostic) => diagnostic.code);
-    expect(pureCodes).not.toContain('unsigned_thinking_skipped');
     // Boundary: the tool-turn skip must NOT swallow a pure-reasoning turn.
     expect(pureCodes).not.toContain('signed_thinking_in_tool_turn_skipped');
   });

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -812,7 +812,12 @@ describe('projectRuntimeEventsToStoredMessages', () => {
           ts: ts + 5,
           role: 'model',
           author: 'agent',
-          content: { kind: 'thinking', text: 'private reasoning', signature: 'sig-1' },
+          content: {
+            kind: 'thinking',
+            text: 'private reasoning',
+            signature: 'sig-1',
+            providerOptions: { maka: { kimiReasoningField: 'reasoning' } },
+          },
           refs: { storedMessageId: 'legacy-assistant' },
         }),
         ev({
@@ -834,7 +839,11 @@ describe('projectRuntimeEventsToStoredMessages', () => {
         ts: ts + 6,
         text: 'visible answer',
         modelId: 'claude-sonnet-4-5',
-        thinking: { text: 'private reasoning', signature: 'sig-1' },
+        thinking: {
+          text: 'private reasoning',
+          signature: 'sig-1',
+          providerOptions: { maka: { kimiReasoningField: 'reasoning' } },
+        },
       },
     ];
 

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -132,6 +132,7 @@ import {
 } from './ai-sdk-compaction.js';
 import type { AiSdkCompactionCapabilities } from './ai-sdk-compaction-contract.js';
 import type { ToolArtifactRecorder } from './tool-artifacts.js';
+import { kimiReasoningFieldFromProviderOptions } from './kimi-openai-transport.js';
 import { RunTrace, type RunTraceRecorder } from './run-trace.js';
 import {
   toSandboxRunTraceProjection,
@@ -706,6 +707,8 @@ export class AiSdkBackend implements AgentBackend {
     let currentStepMessageId = this.newId();
     let stepText = '';
     let stepThinking = '';
+    let sawStepThinking = false;
+    let stepThinkingProviderOptions: NonNullable<ModelMessage['providerOptions']> | undefined;
     let stepSignature: string | undefined;
     const startedAt = this.now();
 
@@ -719,7 +722,7 @@ export class AiSdkBackend implements AgentBackend {
     // this step's assistant row. Hoisted to send() scope so both the streaming
     // path and the abort/error handler can flush a partial step.
     const flushStep = async (): Promise<void> => {
-      const hasThinking = stepThinking.length > 0 || stepSignature !== undefined;
+      const hasThinking = sawStepThinking || stepSignature !== undefined;
       if (stepText.length === 0 && !hasThinking) return;
       const stepId = currentStepMessageId;
       const msg: AssistantMessage = {
@@ -734,6 +737,9 @@ export class AiSdkBackend implements AgentBackend {
               thinking: {
                 text: stepThinking,
                 ...(stepSignature !== undefined ? { signature: stepSignature } : {}),
+                ...(stepThinkingProviderOptions !== undefined
+                  ? { providerOptions: stepThinkingProviderOptions }
+                  : {}),
               },
             }
           : {}),
@@ -748,6 +754,9 @@ export class AiSdkBackend implements AgentBackend {
           messageId: stepId,
           text: stepThinking,
           ...(stepSignature !== undefined ? { signature: stepSignature } : {}),
+          ...(stepThinkingProviderOptions !== undefined
+            ? { providerOptions: stepThinkingProviderOptions }
+            : {}),
         } satisfies ThinkingCompleteEvent);
       }
       queue.push({
@@ -760,6 +769,8 @@ export class AiSdkBackend implements AgentBackend {
       } satisfies TextCompleteEvent);
       stepText = '';
       stepThinking = '';
+      sawStepThinking = false;
+      stepThinkingProviderOptions = undefined;
       stepSignature = undefined;
     };
     let tokenUsage: NormalizedAiSdkUsage | undefined;
@@ -1357,7 +1368,11 @@ export class AiSdkBackend implements AgentBackend {
                     text: event.text,
                   } satisfies TextDeltaEvent);
                 } else if (event.kind === 'thinking') {
+                  sawStepThinking = true;
                   stepThinking += event.text;
+                  if (event.providerOptions !== undefined) {
+                    stepThinkingProviderOptions = event.providerOptions;
+                  }
                   queue.push({
                     type: 'thinking_delta',
                     id: this.newId(),
@@ -2337,7 +2352,7 @@ export class AiSdkBackend implements AgentBackend {
     for (const item of plan.items) {
       if (item.kind === 'tool_call' && !support.toolCalls) return false;
       if (item.kind === 'tool_result' && !support.toolResults) return false;
-      if (item.kind === 'thinking' && (!support.signedThinking || !item.signature)) return false;
+      if (item.kind === 'thinking' && item.signature && !support.signedThinking) return false;
     }
     return true;
   }
@@ -2370,11 +2385,28 @@ export class AiSdkBackend implements AgentBackend {
     const reasoningByStep = new Map<string, ThinkingItem>();
     const textByStep = new Map<string, string>();
 
-    const reasoningPart = (item: ThinkingItem) => ({
-      type: 'reasoning' as const,
-      text: item.text,
-      providerOptions: { anthropic: { signature: item.signature } },
-    });
+    const replaySupport = this.modelAdapter.runtimeEventReplaySupport();
+    const reasoningReplay = (item: ThinkingItem) => {
+      if (item.signature) {
+        return replaySupport.signedThinking
+          ? {
+              part: {
+                type: 'reasoning' as const,
+                text: item.text,
+                providerOptions: { anthropic: { signature: item.signature } },
+              },
+            }
+          : undefined;
+      }
+      if (!replaySupport.unsignedThinking) return undefined;
+      const kimiReasoningField = kimiReasoningFieldFromProviderOptions(item.providerOptions);
+      if (!kimiReasoningField) return undefined;
+      return {
+        providerOptions: {
+          openaiCompatible: { [kimiReasoningField]: item.text },
+        } as NonNullable<ModelMessage['providerOptions']>,
+      };
+    };
     // Tool results are emitted only when their tool_call claims them here. A
     // result whose call never appears in the plan (sliced-away call, corrupt
     // ledger) is INTENTIONALLY dropped at the end: a standalone tool message
@@ -2415,7 +2447,8 @@ export class AiSdkBackend implements AgentBackend {
       calls: readonly ToolCallItem[],
     ) => {
       const content: unknown[] = [];
-      if (reasoning) content.push(reasoningPart(reasoning));
+      const replayReasoning = reasoning ? reasoningReplay(reasoning) : undefined;
+      if (replayReasoning?.part) content.push(replayReasoning.part);
       if (text.length > 0) content.push({ type: 'text', text });
       for (const call of calls) {
         content.push({
@@ -2426,7 +2459,15 @@ export class AiSdkBackend implements AgentBackend {
           ...(call.providerOptions !== undefined ? { providerOptions: call.providerOptions } : {}),
         });
       }
-      if (content.length > 0) out.push({ role: 'assistant', content } as ModelMessage);
+      if (content.length > 0 || replayReasoning?.providerOptions) {
+        out.push({
+          role: 'assistant',
+          content,
+          ...(replayReasoning?.providerOptions
+            ? { providerOptions: replayReasoning.providerOptions }
+            : {}),
+        } as ModelMessage);
+      }
       await pushToolResults(calls);
     };
     // Emit tool calls no assistant text closed: a thinking + tool step with no
@@ -2477,7 +2518,16 @@ export class AiSdkBackend implements AgentBackend {
           } else {
             // Legacy standalone reasoning (pure-reasoning turn): emit on its own.
             await flushLooseCalls();
-            out.push({ role: 'assistant', content: [reasoningPart(item)] } as ModelMessage);
+            const replayReasoning = reasoningReplay(item);
+            if (replayReasoning) {
+              out.push({
+                role: 'assistant',
+                content: replayReasoning.part ? [replayReasoning.part] : [],
+                ...(replayReasoning.providerOptions
+                  ? { providerOptions: replayReasoning.providerOptions }
+                  : {}),
+              } as ModelMessage);
+            }
           }
           break;
         case 'text':
@@ -2518,7 +2568,16 @@ export class AiSdkBackend implements AgentBackend {
     }
     // Any reasoning whose closing text never arrived (defensive): emit standalone.
     for (const reasoning of reasoningByStep.values()) {
-      out.push({ role: 'assistant', content: [reasoningPart(reasoning)] } as ModelMessage);
+      const replayReasoning = reasoningReplay(reasoning);
+      if (replayReasoning) {
+        out.push({
+          role: 'assistant',
+          content: replayReasoning.part ? [replayReasoning.part] : [],
+          ...(replayReasoning.providerOptions
+            ? { providerOptions: replayReasoning.providerOptions }
+            : {}),
+        } as ModelMessage);
+      }
     }
     return out;
   }

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -324,6 +324,9 @@ function mapBackendSessionEvent(
           kind: 'thinking',
           text: event.text,
           ...(event.signature !== undefined ? { signature: event.signature } : {}),
+          ...(event.providerOptions !== undefined
+            ? { providerOptions: structuredClone(event.providerOptions) }
+            : {}),
         },
         refs: { providerEventId: event.messageId },
       };

--- a/packages/runtime/src/kimi-openai-transport.ts
+++ b/packages/runtime/src/kimi-openai-transport.ts
@@ -1,0 +1,221 @@
+interface KimiOpenAiTransport {
+  fetch: typeof globalThis.fetch;
+  transformRequestBody: (body: Record<string, unknown>) => Record<string, unknown>;
+}
+
+export type KimiReasoningField = 'reasoning_content' | 'reasoning';
+
+const EMPTY_REASONING_MARKER = '\0MAKA_KIMI_EMPTY_REASONING\0';
+
+export interface KimiOpenAiTransportState {
+  reasoningField: KimiReasoningField;
+}
+
+const MAKA_PROVIDER_OPTIONS_NAMESPACE = 'maka';
+
+export function kimiReasoningFieldProviderOptions(
+  field: KimiReasoningField,
+): Record<string, Record<string, string>> {
+  return { [MAKA_PROVIDER_OPTIONS_NAMESPACE]: { kimiReasoningField: field } };
+}
+
+export function kimiReasoningFieldFromProviderOptions(
+  providerOptions: Record<string, unknown> | undefined,
+): KimiReasoningField | undefined {
+  const maka = providerOptions?.[MAKA_PROVIDER_OPTIONS_NAMESPACE];
+  if (!isRecord(maka)) return undefined;
+  return maka.kimiReasoningField === 'reasoning' || maka.kimiReasoningField === 'reasoning_content'
+    ? maka.kimiReasoningField
+    : undefined;
+}
+
+export function createKimiOpenAiTransportState(): KimiOpenAiTransportState {
+  return { reasoningField: 'reasoning_content' };
+}
+
+export function restoreKimiEmptyReasoning(text: string): string {
+  return text === EMPTY_REASONING_MARKER ? '' : text;
+}
+
+export function createKimiOpenAiTransport(
+  fetchImpl: typeof globalThis.fetch = globalThis.fetch,
+  state: KimiOpenAiTransportState = createKimiOpenAiTransportState(),
+): KimiOpenAiTransport {
+  return {
+    fetch: async (input, init) =>
+      normalizeKimiOpenAiResponse(await fetchImpl(input, init), (observed) => {
+        state.reasoningField = observed;
+      }),
+    transformRequestBody: (body) => replayAssistantReasoning(body, state.reasoningField),
+  };
+}
+
+async function normalizeKimiOpenAiResponse(
+  response: Response,
+  observeReasoning: (field: KimiReasoningField) => void,
+): Promise<Response> {
+  if (!response.ok) return response;
+  const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+  if (contentType.includes('text/event-stream') && response.body) {
+    return responseWithBody(
+      response,
+      response.body.pipeThrough(kimiSseNormalizer(observeReasoning)),
+    );
+  }
+  if (contentType.includes('application/json')) {
+    const raw = await response.text();
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(raw);
+    } catch {
+      return responseWithBody(response, raw);
+    }
+    return responseWithBody(
+      response,
+      JSON.stringify(normalizeKimiPayload(parsed, observeReasoning)),
+    );
+  }
+  return response;
+}
+
+function kimiSseNormalizer(
+  observeReasoning: (field: KimiReasoningField) => void,
+): TransformStream<Uint8Array, Uint8Array> {
+  const decoder = new TextDecoder();
+  const encoder = new TextEncoder();
+  let buffered = '';
+  return new TransformStream({
+    transform(chunk, controller) {
+      buffered += decoder.decode(chunk, { stream: true });
+      let newline = buffered.indexOf('\n');
+      while (newline >= 0) {
+        controller.enqueue(
+          encoder.encode(normalizeSseLine(buffered.slice(0, newline + 1), observeReasoning)),
+        );
+        buffered = buffered.slice(newline + 1);
+        newline = buffered.indexOf('\n');
+      }
+    },
+    flush(controller) {
+      buffered += decoder.decode();
+      if (buffered) {
+        controller.enqueue(encoder.encode(normalizeSseLine(buffered, observeReasoning)));
+      }
+    },
+  });
+}
+
+function normalizeSseLine(
+  line: string,
+  observeReasoning: (field: KimiReasoningField) => void,
+): string {
+  const newline = line.endsWith('\r\n') ? '\r\n' : line.endsWith('\n') ? '\n' : '';
+  const body = newline ? line.slice(0, -newline.length) : line;
+  const match = /^(\s*data:\s*)(.*)$/.exec(body);
+  if (!match || match[2] === '[DONE]') return line;
+  try {
+    return `${match[1]}${JSON.stringify(normalizeKimiPayload(JSON.parse(match[2]!), observeReasoning))}${newline}`;
+  } catch {
+    return line;
+  }
+}
+
+function normalizeKimiPayload(
+  value: unknown,
+  observeReasoning: (field: KimiReasoningField) => void,
+): unknown {
+  if (!isRecord(value)) return value;
+  const normalizedValue = normalizeKimiReasoningFields(value, observeReasoning);
+  const nestedUsage = Array.isArray(normalizedValue.choices)
+    ? normalizedValue.choices.find((choice) => isRecord(choice) && isRecord(choice.usage))
+    : undefined;
+  const usage = isRecord(normalizedValue.usage)
+    ? normalizedValue.usage
+    : isRecord(nestedUsage)
+      ? nestedUsage.usage
+      : undefined;
+  if (!isRecord(usage)) return normalizedValue;
+  const normalizedUsage = normalizeKimiUsage(usage);
+  return normalizedValue.usage === normalizedUsage
+    ? normalizedValue
+    : { ...normalizedValue, usage: normalizedUsage };
+}
+
+function normalizeKimiReasoningFields(
+  payload: Record<string, unknown>,
+  observe: (field: KimiReasoningField) => void,
+): Record<string, unknown> {
+  if (!Array.isArray(payload.choices)) return payload;
+  let changed = false;
+  const choices = payload.choices.map((choice) => {
+    if (!isRecord(choice)) return choice;
+    let normalizedChoice = choice;
+    for (const key of ['message', 'delta'] as const) {
+      const carrier: unknown = choice[key];
+      if (!isRecord(carrier)) continue;
+      const field =
+        typeof carrier.reasoning_content === 'string'
+          ? 'reasoning_content'
+          : typeof carrier.reasoning === 'string'
+            ? 'reasoning'
+            : undefined;
+      if (!field) continue;
+      observe(field);
+      if (carrier[field] !== '') continue;
+      normalizedChoice = {
+        ...normalizedChoice,
+        [key]: { ...carrier, [field]: EMPTY_REASONING_MARKER },
+      };
+      changed = true;
+    }
+    return normalizedChoice;
+  });
+  return changed ? { ...payload, choices } : payload;
+}
+
+function replayAssistantReasoning(
+  body: Record<string, unknown>,
+  field: KimiReasoningField,
+): Record<string, unknown> {
+  if (!Array.isArray(body.messages)) return body;
+  let changed = false;
+  const messages = body.messages.map((value) => {
+    if (!isRecord(value) || value.role !== 'assistant') return value;
+    if (typeof value.reasoning_content !== 'string') return value;
+    const restoredReasoning = restoreKimiEmptyReasoning(value.reasoning_content);
+    if (field === 'reasoning_content') {
+      if (restoredReasoning === value.reasoning_content) return value;
+      changed = true;
+      return { ...value, reasoning_content: restoredReasoning };
+    }
+    const { reasoning_content: _reasoningContent, ...message } = value;
+    changed = true;
+    return { ...message, reasoning: restoredReasoning };
+  });
+  return changed ? { ...body, messages } : body;
+}
+
+function normalizeKimiUsage(usage: Record<string, unknown>): Record<string, unknown> {
+  if (typeof usage.cached_tokens !== 'number') return usage;
+  const details = isRecord(usage.prompt_tokens_details) ? usage.prompt_tokens_details : {};
+  if (typeof details.cached_tokens === 'number') return usage;
+  return {
+    ...usage,
+    prompt_tokens_details: { ...details, cached_tokens: usage.cached_tokens },
+  };
+}
+
+function responseWithBody(response: Response, body: BodyInit): Response {
+  const headers = new Headers(response.headers);
+  headers.delete('content-encoding');
+  headers.delete('content-length');
+  return new Response(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -35,6 +35,12 @@ import {
   providerRetryMetadata,
 } from './provider-error-classification.js';
 import type { ProviderRequestTracker } from './provider-request-telemetry.js';
+import {
+  createKimiOpenAiTransportState,
+  kimiReasoningFieldProviderOptions,
+  restoreKimiEmptyReasoning,
+  type KimiOpenAiTransportState,
+} from './kimi-openai-transport.js';
 
 /**
  * Build an ai-sdk LanguageModel from a single input object.
@@ -48,6 +54,7 @@ export interface ModelFactoryInput {
   connection: LlmConnection;
   apiKey: string;
   modelId: string;
+  kimiOpenAiTransportState?: KimiOpenAiTransportState;
 }
 export type ModelFactory = (input: ModelFactoryInput) => unknown;
 
@@ -110,6 +117,8 @@ interface ProviderMiddlewareStreamInput {
 }
 
 export class ModelAdapter {
+  private readonly kimiOpenAiTransportState = createKimiOpenAiTransportState();
+
   constructor(private readonly input: ModelAdapterInput) {}
 
   runtimeEventReplaySupport(): ModelAdapterRuntimeEventReplaySupport {
@@ -117,6 +126,7 @@ export class ModelAdapter {
       toolCalls: true,
       toolResults: true,
       signedThinking: usesAnthropicMessages(this.input.connection, this.input.modelId),
+      unsignedThinking: usesKimiOpenAiChat(this.input.connection, this.input.modelId),
     };
   }
 
@@ -128,6 +138,9 @@ export class ModelAdapter {
       connection: this.input.connection,
       apiKey: this.input.apiKey,
       modelId: this.input.modelId,
+      ...(usesKimiOpenAiChat(this.input.connection, this.input.modelId)
+        ? { kimiOpenAiTransportState: this.kimiOpenAiTransportState }
+        : {}),
     });
   }
 
@@ -204,11 +217,14 @@ export class ModelAdapter {
    * are normalized to Maka-owned contracts. No AI SDK type escapes this method.
    */
   private toModelStreamResult(sdk: SdkStreamResult): ModelStreamResult {
+    const kimiOpenAiTransportState = usesKimiOpenAiChat(this.input.connection, this.input.modelId)
+      ? this.kimiOpenAiTransportState
+      : undefined;
     const events: AsyncIterable<ModelStreamEvent> = {
       async *[Symbol.asyncIterator]() {
         try {
           for await (const chunk of sdk.stream as AsyncIterable<AiSdkStreamChunk>) {
-            for (const event of translateChunk(chunk)) yield event;
+            for (const event of translateChunk(chunk, kimiOpenAiTransportState)) yield event;
           }
         } catch (error) {
           yield { kind: 'error', failure: normalizeModelFailure(error) };
@@ -276,7 +292,12 @@ export class ModelAdapter {
    * testable through the Maka-owned event contract.
    */
   translateChunk(chunk: AiSdkStreamChunk): ModelStreamEvent[] {
-    return translateChunk(chunk);
+    return translateChunk(
+      chunk,
+      usesKimiOpenAiChat(this.input.connection, this.input.modelId)
+        ? this.kimiOpenAiTransportState
+        : undefined,
+    );
   }
 
   makeErrorEvent(turnId: string, err: unknown): ErrorEvent {
@@ -325,12 +346,16 @@ function selectedModelMaxOutputTokens(
   modelId: string,
   providerOptions: Record<string, unknown> | undefined,
 ): number | undefined {
-  if (!usesAnthropicMessages(connection, modelId)) return undefined;
+  const anthropicMessages = usesAnthropicMessages(connection, modelId);
+  const kimiOpenAiChat = usesKimiOpenAiChat(connection, modelId);
+  if (!anthropicMessages && !kimiOpenAiChat) return undefined;
   const wireOutputLimit =
     connection.models?.find((model) => model.id === modelId)?.maxOutputTokens ??
     lookupModelMetadata(connection.providerType, modelId).maxOutputTokens;
   if (wireOutputLimit === undefined) return undefined;
-  return wireOutputLimit - fixedAnthropicThinkingBudget(providerOptions);
+  return anthropicMessages
+    ? wireOutputLimit - fixedAnthropicThinkingBudget(providerOptions)
+    : wireOutputLimit;
 }
 
 function usesAnthropicMessages(connection: LlmConnection, modelId: string): boolean {
@@ -339,6 +364,13 @@ function usesAnthropicMessages(connection: LlmConnection, modelId: string): bool
     adapter.kind === 'anthropic' ||
     adapter.kind === 'claude-subscription' ||
     (adapter.kind === 'github-copilot' && apiProtocol === 'anthropic-messages')
+  );
+}
+
+function usesKimiOpenAiChat(connection: LlmConnection, modelId: string): boolean {
+  return (
+    connection.providerType === 'kimi-coding-plan' &&
+    resolveModelRuntime(connection, modelId).apiProtocol === 'openai-chat'
   );
 }
 
@@ -357,6 +389,7 @@ export interface ModelAdapterRuntimeEventReplaySupport {
   toolCalls: boolean;
   toolResults: boolean;
   signedThinking: boolean;
+  unsignedThinking: boolean;
 }
 
 /**
@@ -416,7 +449,10 @@ function reasoningSignatureFromChunk(chunk: AiSdkStreamChunk): string | undefine
  * `ModelStreamEvent`s. The sole site that parses SDK chunk names; the backend
  * never sees raw chunks. Pure and side-effect-free.
  */
-function translateChunk(chunk: AiSdkStreamChunk): ModelStreamEvent[] {
+function translateChunk(
+  chunk: AiSdkStreamChunk,
+  kimiOpenAiTransportState?: KimiOpenAiTransportState,
+): ModelStreamEvent[] {
   switch (chunk.type) {
     case 'text-delta': {
       const text = chunk.text ?? chunk.textDelta ?? chunk.delta ?? '';
@@ -424,14 +460,33 @@ function translateChunk(chunk: AiSdkStreamChunk): ModelStreamEvent[] {
     }
     case 'reasoning':
     case 'reasoning-delta': {
-      const text = chunk.text ?? chunk.textDelta ?? chunk.delta ?? '';
+      const text =
+        typeof chunk.text === 'string'
+          ? chunk.text
+          : typeof chunk.textDelta === 'string'
+            ? chunk.textDelta
+            : typeof chunk.delta === 'string'
+              ? chunk.delta
+              : undefined;
       const signature = reasoningSignatureFromChunk(chunk);
       const events: ModelStreamEvent[] = [];
       if (signature) events.push({ kind: 'thinking-signature', signature });
       // The signed reasoning chunk arrives as a standalone delta with empty
-      // text; only emit a `thinking` event when there is actual text so the
-      // signature carrier does not surface as an empty reasoning fragment.
-      if (text) events.push({ kind: 'thinking', text });
+      // text; preserve provider-authored empty reasoning, but do not surface a
+      // signature-only carrier as an additional empty reasoning fragment.
+      if (text !== undefined && (text.length > 0 || signature === undefined)) {
+        events.push({
+          kind: 'thinking',
+          text: restoreKimiEmptyReasoning(text),
+          ...(kimiOpenAiTransportState
+            ? {
+                providerOptions: kimiReasoningFieldProviderOptions(
+                  kimiOpenAiTransportState.reasoningField,
+                ),
+              }
+            : {}),
+        });
+      }
       return events;
     }
     case 'reasoning-end': {

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -15,6 +15,10 @@ import { type LlmConnection, type ProviderType } from '@maka/core/llm-connection
 import { openAiAdapterApiProtocol } from '@maka/core/model-metadata';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import { thinkingOptionsForModel, thinkingVariantsForModel } from '@maka/core/model-thinking';
+import {
+  createKimiOpenAiTransport,
+  type KimiOpenAiTransportState,
+} from './kimi-openai-transport.js';
 import { anthropicV1BaseUrl, googleV1BetaBaseUrl } from './provider-urls.js';
 import { resolveModelRuntime } from './model-runtime.js';
 import { claudeSubscriptionHeaders, openAiCodexHeaders } from './subscription-auth.js';
@@ -24,11 +28,12 @@ export interface ModelFactoryInput {
   apiKey: string;
   modelId: string;
   fetch?: typeof globalThis.fetch;
+  kimiOpenAiTransportState?: KimiOpenAiTransportState;
 }
 
 const ANTHROPIC_BETA = 'interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14';
 export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
-  const { connection, apiKey, modelId, fetch } = input;
+  const { connection, apiKey, modelId, fetch, kimiOpenAiTransportState } = input;
   const { adapter, baseUrl: baseURL, apiProtocol } = resolveModelRuntime(connection, modelId);
 
   if (adapter.kind === 'google' && adapter.normalizeBaseUrl === false) {
@@ -112,22 +117,32 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
         );
       }
       const name = adapter.name === 'connection' ? connection.slug : connection.providerType;
+      const kimiTransport =
+        connection.providerType === 'kimi-coding-plan' && apiProtocol === 'openai-chat'
+          ? createKimiOpenAiTransport(fetch ?? globalThis.fetch, kimiOpenAiTransportState)
+          : undefined;
       const model = createOpenAICompatible({
         name,
         apiKey,
         baseURL,
         includeUsage: adapter.includeUsage,
-        ...(adapter.passFetch || fetch ? { fetch } : {}),
+        ...(kimiTransport
+          ? { fetch: kimiTransport.fetch }
+          : adapter.passFetch || fetch
+            ? { fetch }
+            : {}),
+        ...(kimiTransport
+          ? { transformRequestBody: kimiTransport.transformRequestBody }
+          : adapter.replayAssistantReasoningAs
+            ? {
+                transformRequestBody: replayAssistantReasoning(
+                  adapter.replayAssistantReasoningAs,
+                  adapter.replayAssistantReasoningDetails === true,
+                ),
+              }
+            : {}),
         ...(adapter.replayAssistantReasoningDetails
           ? { metadataExtractor: reasoningDetailsMetadataExtractor() }
-          : {}),
-        ...(adapter.replayAssistantReasoningAs
-          ? {
-              transformRequestBody: replayAssistantReasoning(
-                adapter.replayAssistantReasoningAs,
-                adapter.replayAssistantReasoningDetails === true,
-              ),
-            }
           : {}),
       }).chatModel(modelId);
       return adapter.replayAssistantReasoningDetails ? attachReasoningDetails(model) : model;
@@ -292,6 +307,11 @@ export function buildProviderOptions(
   const level = thinkingLevel && variants.includes(thinkingLevel) ? thinkingLevel : undefined;
   switch (connection.providerType) {
     case 'kimi-coding-plan':
+      if (connection.models?.find((model) => model.id === modelId)?.apiProtocol === 'openai-chat') {
+        return {
+          kimiCodingPlan: { reasoningEffort: 'max' },
+        };
+      }
       return {
         anthropic:
           modelId === 'k3'

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -282,6 +282,10 @@ export function collectToolActivityTurnIds(events: readonly RuntimeEvent[]): Set
   return ids;
 }
 
+function assistantReplayStepId(event: RuntimeEvent): string | undefined {
+  return event.refs?.providerEventId ?? event.refs?.storedMessageId;
+}
+
 export function buildRuntimeEventModelReplayPlan(
   events: readonly RuntimeEvent[],
   options: BuildRuntimeEventModelReplayPlanOptions = {},
@@ -437,6 +441,7 @@ export function buildRuntimeEventModelReplayPlan(
           continue;
         }
         const steeringReplay = event.content.steering === true && role === 'user';
+        const assistantStepId = role === 'assistant' ? assistantReplayStepId(event) : undefined;
         items.push({
           kind: 'text',
           role,
@@ -447,11 +452,9 @@ export function buildRuntimeEventModelReplayPlan(
             : formatTextWithInlineRefs(event.content),
           ...(steeringReplay ? { steering: { eventId: event.id } } : {}),
           ...(event.content.attachments ? { attachments: event.content.attachments } : {}),
-          // Model text carries its step id (the message id) so the materializer
-          // can close a step and group its reasoning + tool calls.
-          ...(role === 'assistant' && event.refs?.providerEventId
-            ? { stepId: event.refs.providerEventId }
-            : {}),
+          // Live events carry providerEventId; missing-ledger recovery carries
+          // the same assistant message identity as storedMessageId.
+          ...(assistantStepId ? { stepId: assistantStepId } : {}),
           eventId: event.id,
           ts: event.ts,
         });
@@ -482,6 +485,7 @@ export function buildRuntimeEventModelReplayPlan(
           );
           continue;
         }
+        const thinkingStepId = assistantReplayStepId(event);
         items.push({
           kind: 'thinking',
           text: event.content.text,
@@ -493,7 +497,7 @@ export function buildRuntimeEventModelReplayPlan(
                 >,
               }
             : {}),
-          ...(event.refs?.providerEventId ? { stepId: event.refs.providerEventId } : {}),
+          ...(thinkingStepId ? { stepId: thinkingStepId } : {}),
           eventId: event.id,
           ts: event.ts,
         });

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -86,7 +86,6 @@ export type RuntimeEventReplayDiagnosticCode =
   | 'terminal_fact_diagnostic_only'
   | 'error_content_diagnostic_only'
   | 'empty_text_skipped'
-  | 'unsigned_thinking_skipped'
   | 'signed_thinking_in_tool_turn_skipped'
   | 'unmatched_tool_result'
   | 'unmatched_tool_call'
@@ -125,6 +124,7 @@ export type RuntimeEventModelReplayItem =
       kind: 'thinking';
       text: string;
       signature?: string;
+      providerOptions?: NonNullable<ModelMessage['providerOptions']>;
       /** Assistant step id; pairs this reasoning with its step's tool calls. */
       stepId?: string;
       eventId: string;
@@ -466,26 +466,9 @@ export function buildRuntimeEventModelReplayPlan(
           );
           continue;
         }
-        if (!event.content.signature) {
-          // Unsigned thinking cannot be replayed provider-native: Anthropic
-          // rejects a thinking block without its signature, and other providers
-          // accept no native thinking at all. Skip it from replay items (and its
-          // semantic kind) rather than block — a non-Anthropic (e.g. GLM) turn
-          // persists thinking for the UI, but must not drag the whole history
-          // down to stored-message projection. The thinking stays in the
-          // read-model; it just never re-enters the model request.
-          diagnostics.push(
-            diagnostic(
-              event,
-              'unsigned_thinking_skipped',
-              'unsigned thinking RuntimeEvent skipped for model replay',
-            ),
-          );
-          continue;
-        }
-        if (event.turnId && unpairedToolTurnIds.has(event.turnId)) {
-          // Signed, but its turn has tool calls with no step id to pair against
-          // (legacy per-turn history) — the end-of-turn reasoning cannot be
+        if (event.content.signature && event.turnId && unpairedToolTurnIds.has(event.turnId)) {
+          // Its turn has tool calls with no step id to pair against (legacy
+          // per-turn history) — the end-of-turn reasoning cannot be
           // reattached to the tool-use assistant message. Keep it in the
           // read-model for the UI; skip it from replay without downgrading the
           // whole history. Per-step history (paired tool calls) is not skipped:
@@ -502,7 +485,14 @@ export function buildRuntimeEventModelReplayPlan(
         items.push({
           kind: 'thinking',
           text: event.content.text,
-          signature: event.content.signature,
+          ...(event.content.signature ? { signature: event.content.signature } : {}),
+          ...(event.content.providerOptions !== undefined
+            ? {
+                providerOptions: event.content.providerOptions as NonNullable<
+                  ModelMessage['providerOptions']
+                >,
+              }
+            : {}),
           ...(event.refs?.providerEventId ? { stepId: event.refs.providerEventId } : {}),
           eventId: event.id,
           ts: event.ts,

--- a/packages/runtime/src/model-protocol.ts
+++ b/packages/runtime/src/model-protocol.ts
@@ -414,7 +414,7 @@ export interface ModelRequestMetadata {
  */
 export type ModelStreamEvent =
   | { kind: 'text'; text: string }
-  | { kind: 'thinking'; text: string }
+  | { kind: 'thinking'; text: string; providerOptions?: ProviderOptions }
   | { kind: 'thinking-signature'; signature: string }
   | { kind: 'tool-call'; toolCall: ToolCallPart }
   | { kind: 'step-finish'; usage?: NormalizedUsage; finishReason?: ModelFinishReason }

--- a/packages/runtime/src/model-runtime.ts
+++ b/packages/runtime/src/model-runtime.ts
@@ -28,16 +28,44 @@ export function resolveModelRuntime(
       `Unknown provider type "${connection.providerType}"; cannot resolve model runtime.`,
     );
   }
-  const adapter = override ? runtimeAdapterOverride(override.npm) : defaults.runtimeAdapter;
-  const configuredBaseUrl = connection.baseUrl?.trim();
   const apiProtocol = connection.models?.find((model) => model.id === modelId)?.apiProtocol;
+  if (
+    connection.providerType === 'kimi-coding-plan' &&
+    apiProtocol !== undefined &&
+    apiProtocol !== 'anthropic-messages' &&
+    apiProtocol !== 'openai-chat'
+  ) {
+    throw new Error(
+      `Kimi Coding Plan protocol must be openai-chat or anthropic-messages, received ${apiProtocol}`,
+    );
+  }
+  const adapter =
+    connection.providerType === 'kimi-coding-plan' && apiProtocol === 'openai-chat'
+      ? ({
+          kind: 'openai-compatible',
+          name: 'provider',
+          includeUsage: true,
+          passFetch: true,
+        } as const)
+      : override
+        ? runtimeAdapterOverride(override.npm)
+        : defaults.runtimeAdapter;
+  const configuredBaseUrl = connection.baseUrl?.trim();
+  const resolvedBaseUrl = configuredBaseUrl
+    ? effectiveBaseUrl(connection)
+    : (override?.api ?? effectiveBaseUrl(connection));
   return {
     adapter,
-    baseUrl: configuredBaseUrl
-      ? effectiveBaseUrl(connection)
-      : (override?.api ?? effectiveBaseUrl(connection)),
+    baseUrl:
+      connection.providerType === 'kimi-coding-plan' && apiProtocol === 'openai-chat'
+        ? kimiOpenAiBaseUrl(resolvedBaseUrl)
+        : resolvedBaseUrl,
     ...(apiProtocol ? { apiProtocol } : {}),
   };
+}
+
+function kimiOpenAiBaseUrl(baseUrl: string): string {
+  return `${baseUrl.replace(/\/+$/, '').replace(/\/v1$/i, '')}/v1`;
 }
 
 function runtimeAdapterOverride(packageName: string): ProviderRuntimeAdapter {

--- a/packages/runtime/src/runtime-event-adapters.ts
+++ b/packages/runtime/src/runtime-event-adapters.ts
@@ -167,7 +167,7 @@ export function storedMessageToRuntimeEvents(
   const out: RuntimeEvent[] = [];
   if (primary) out.push(primary);
 
-  if (message.type === 'assistant' && message.thinking && message.thinking.text.length > 0) {
+  if (message.type === 'assistant' && message.thinking) {
     const d = resolveCtx(ctx, message);
     out.push({
       id: d.newId(),
@@ -184,6 +184,9 @@ export function storedMessageToRuntimeEvents(
         text: message.thinking.text,
         ...(message.thinking.signature !== undefined
           ? { signature: message.thinking.signature }
+          : {}),
+        ...(message.thinking.providerOptions !== undefined
+          ? { providerOptions: structuredClone(message.thinking.providerOptions) }
           : {}),
       },
       refs: { storedMessageId: message.id },

--- a/packages/runtime/src/runtime-event-backfill.ts
+++ b/packages/runtime/src/runtime-event-backfill.ts
@@ -113,7 +113,7 @@ export function backfillRuntimeEventsFromStoredMessages(
           actions: { stateDelta: recoveryState(now, message) },
           refs: { storedMessageId: message.id },
         });
-        if (message.thinking && message.thinking.text.length > 0) {
+        if (message.thinking) {
           events.push({
             ...base,
             id: newId(),
@@ -124,6 +124,9 @@ export function backfillRuntimeEventsFromStoredMessages(
               text: message.thinking.text,
               ...(message.thinking.signature !== undefined
                 ? { signature: message.thinking.signature }
+                : {}),
+              ...(message.thinking.providerOptions !== undefined
+                ? { providerOptions: structuredClone(message.thinking.providerOptions) }
                 : {}),
             },
             actions: { stateDelta: recoveryState(now, message) },

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -99,6 +99,7 @@ interface PendingThinking {
   messageId: string;
   text: string;
   signature?: string;
+  providerOptions?: Record<string, unknown>;
 }
 
 export function projectRuntimeEventsToStoredMessages(
@@ -542,6 +543,9 @@ function projectThinking(
     messageId,
     text: event.content.text,
     ...(event.content.signature !== undefined ? { signature: event.content.signature } : {}),
+    ...(event.content.providerOptions !== undefined
+      ? { providerOptions: structuredClone(event.content.providerOptions) }
+      : {}),
   };
   // The step's assistant text row lands after its thinking in ledger order, so
   // attach eagerly if it already exists (older ordering), else park by message id
@@ -910,6 +914,9 @@ function attachThinkingToAssistant(
     message.thinking = {
       text: pending.text,
       ...(pending.signature !== undefined ? { signature: pending.signature } : {}),
+      ...(pending.providerOptions !== undefined
+        ? { providerOptions: structuredClone(pending.providerOptions) }
+        : {}),
     };
     return true;
   }


### PR DESCRIPTION
## Summary

- let the existing Kimi Coding Plan connection select Anthropic Messages or OpenAI Chat per model
- add Kimi OpenAI transport handling for reasoning dialect lifetime, explicit empty reasoning, tool replay, and usage capture
- preserve provider-owned reasoning metadata across RuntimeEvent and missing-ledger StoredMessage recovery
- keep unsupported or unmarked private thinking out of provider replay without dropping paired tool calls and results
- preserve recovered assistant step identity so reasoning, text, and tool calls reconstruct as one provider message

## Context

This is the flat Runtime protocol PR requested in the maintainer review on #1451. Request-trace evidence and the benchmark harness are intentionally excluded and will be submitted separately.

Refs #1269.

## Verification

- Biome format: 1,084 files passed
- Biome lint: 2,126 files passed
- all workspace typechecks passed
- `git diff --check` passed
- TDD regression reproduced the split recovered step before the fix and passed after it
- Kimi/Anthropic product protocol suite: 11 passed
- focused backend/backfill suites: 170 passed
- full `npm test`: all workspaces passed
- independent headless runner: 1,328 passed, 2 skipped
- local `review-agent` full base-diff review: no actionable correctness findings

No paid Kimi or Harbor benchmark was run; benchmark execution remains in the later benchmark PR.