### PR TITLE
feat(runtime): drive runnable agent graphs to quiescence

### DIFF
--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -56,7 +56,8 @@
     "./stream-graph-projection": "./dist/stream-graph-projection.js",
     "./stream-graph-trace": "./dist/stream-graph-trace.js",
     "./stream-graph-readiness": "./dist/stream-graph-readiness.js",
-    "./stream-graph-admission": "./dist/stream-graph-admission.js"
+    "./stream-graph-admission": "./dist/stream-graph-admission.js",
+    "./stream-graph-dispatch": "./dist/stream-graph-dispatch.js"
   },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",

--- a/packages/runtime/src/__tests__/stream-graph-admission.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-admission.test.ts
@@ -32,6 +32,42 @@ describe('stream graph admission', () => {
     assert.match(first.claim.claimId, /^graph_claim_[a-f0-9]{32}$/);
     assert.match(first.claim.intentFingerprint, /^sha256:[a-f0-9]{64}$/);
   });
+
+  test('binds resolved execution input into the durable intent fingerprint', async () => {
+    const firstStore = new MemoryClaimStore();
+    const secondStore = new MemoryClaimStore();
+    const first = await claimAgentGraphRunnableIntent({
+      intent: runnableIntent(),
+      store: firstStore,
+      newId: nextId(),
+      executionInput: { prompt: 'summarize the committed record' },
+    });
+    const same = await claimAgentGraphRunnableIntent({
+      intent: runnableIntent(),
+      store: secondStore,
+      newId: nextId(),
+      executionInput: { prompt: 'summarize the committed record' },
+    });
+    const drifted = await claimAgentGraphRunnableIntent({
+      intent: runnableIntent(),
+      store: new MemoryClaimStore(),
+      newId: nextId(),
+      executionInput: { prompt: 'perform different work' },
+    });
+
+    assert.equal(first.claim.intentFingerprint, same.claim.intentFingerprint);
+    assert.notEqual(first.claim.intentFingerprint, drifted.claim.intentFingerprint);
+    assert.throws(
+      () =>
+        claimAgentGraphRunnableIntent({
+          intent: runnableIntent(),
+          store: new MemoryClaimStore(),
+          newId: nextId(),
+          executionInput: { prompt: '   ' },
+        }),
+      /prompt must not be empty/,
+    );
+  });
 });
 
 class MemoryClaimStore implements AgentGraphIntentClaimStore {
@@ -66,4 +102,9 @@ function runnableIntent(): AgentGraphRunnableIntent {
     triggerRouteIds: ['route-1'],
     triggerRecordIds: ['record-1'],
   };
+}
+
+function nextId(): () => string {
+  let value = 0;
+  return () => `id-${++value}`;
 }

--- a/packages/runtime/src/__tests__/stream-graph-admission.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-admission.test.ts
@@ -16,11 +16,13 @@ describe('stream graph admission', () => {
       intent: runnableIntent(),
       store,
       newId: () => generated.shift()!,
+      executionInput: { prompt: 'summarize the committed record' },
     });
     const retry = await claimAgentGraphRunnableIntent({
       intent: runnableIntent(),
       store,
       newId: () => generated.shift()!,
+      executionInput: { prompt: 'summarize the committed record' },
     });
 
     assert.equal(first.created, true);

--- a/packages/runtime/src/__tests__/stream-graph-dispatch.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-dispatch.test.ts
@@ -1,0 +1,342 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type {
+  AgentGraphIntentClaimStore,
+  AgentRunHeader,
+  RuntimeEvent,
+  SessionEvent,
+} from '@maka/core';
+import { createSqliteSessionMetadataStore } from '@maka/storage';
+import type {
+  AgentGraphIntentExecutor,
+  AgentGraphSupervisorObservation,
+} from '../stream-graph-dispatch.js';
+import { runAgentGraphToQuiescence } from '../stream-graph-dispatch.js';
+import type { AgentGraphReadinessPolicy } from '../stream-graph-readiness.js';
+import type { AgentGraphTraceTopology } from '../stream-graph-trace.js';
+
+describe('stream graph dispatch', () => {
+  test('recovers a durable fan-out and dynamically sealed join to quiescence', async () => {
+    const facts = new MemoryGraphFacts();
+    facts.seedCompleted('session-source', 'run-source', 'turn-source', 1);
+    const claimStore = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(100) });
+    const executor = new MemoryGraphExecutor(claimStore, facts);
+    const ids = nextId();
+    const observations: AgentGraphSupervisorObservation[] = [];
+    const readyOperators: string[] = [];
+    const runtimeOperators: string[] = [];
+
+    try {
+      const first = await runAgentGraphToQuiescence({
+        topology: topology(),
+        runStore: facts,
+        runtimeEventStore: facts,
+        claimStore,
+        executor,
+        newId: ids,
+        maxNewActivations: 3,
+        resolvePolicies: fanOutJoinPolicies,
+        renderPrompt: ({ intent, triggerRecords }) =>
+          `execute ${intent.operatorId} from ${triggerRecords.map((record) => record.recordId).join(',')}`,
+        supervisor: {
+          onObservation(observation) {
+            observations.push(observation);
+            (observation.readiness as { graphId: string }).graphId = 'observer-corruption';
+            throw new Error('presentation observer must not gate execution');
+          },
+          onActivationReady({ intent }) {
+            readyOperators.push(intent.operatorId);
+            throw new Error('presentation observer must not gate execution');
+          },
+          onRuntimeEvent({ intent }) {
+            runtimeOperators.push(intent.operatorId);
+            throw new Error('presentation observer must not gate execution');
+          },
+        },
+      });
+
+      assert.equal(first.status, 'quiescent');
+      assert.equal(first.newActivationCount, 3);
+      assert.equal(first.observedExistingActivationCount, 0);
+      assert.deepEqual(
+        first.dispatches.map((dispatch) => dispatch.intent.operatorId),
+        ['branch-a', 'branch-b', 'join'],
+      );
+      assert.equal(first.failures.length, 0);
+      assert.equal(executor.backendInvocations, 3);
+      assert.deepEqual(readyOperators, ['branch-a', 'branch-b', 'join']);
+      assert.deepEqual(runtimeOperators, ['branch-a', 'branch-b', 'join']);
+      assert.ok(observations.length >= 3);
+      assert.equal(first.readiness.graphId, 'graph-dispatch');
+      assert.equal(first.projection.records.length, 4);
+      assert.equal(first.readiness.readiness['join-ready']?.status, 'runnable');
+
+      const retry = await runAgentGraphToQuiescence({
+        topology: topology(),
+        runStore: facts,
+        runtimeEventStore: facts,
+        claimStore,
+        executor,
+        newId: ids,
+        maxNewActivations: 0,
+        resolvePolicies: fanOutJoinPolicies,
+        renderPrompt: ({ intent, triggerRecords }) =>
+          `execute ${intent.operatorId} from ${triggerRecords.map((record) => record.recordId).join(',')}`,
+      });
+
+      assert.equal(retry.status, 'quiescent');
+      assert.equal(retry.newActivationCount, 0);
+      assert.equal(retry.observedExistingActivationCount, 3);
+      assert.equal(executor.backendInvocations, 3);
+      assert.equal((await claimStore.listAgentGraphIntentClaims('graph-dispatch')).length, 3);
+
+      const drifted = await runAgentGraphToQuiescence({
+        topology: topology(),
+        runStore: facts,
+        runtimeEventStore: facts,
+        claimStore,
+        executor,
+        newId: ids,
+        maxNewActivations: 0,
+        resolvePolicies: fanOutJoinPolicies,
+        renderPrompt: ({ intent }) => `different work for ${intent.operatorId}`,
+      });
+
+      assert.equal(drifted.status, 'failed');
+      assert.equal(drifted.dispatches.length, 0);
+      assert.equal(drifted.failures.length, 3);
+      assert.equal(executor.backendInvocations, 3);
+    } finally {
+      claimStore.close();
+    }
+  });
+
+  test('bounds only newly admitted activations and advances on the next invocation', async () => {
+    const facts = new MemoryGraphFacts();
+    facts.seedCompleted('session-source', 'run-source', 'turn-source', 1);
+    const claimStore = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(200) });
+    const executor = new MemoryGraphExecutor(claimStore, facts);
+    const ids = nextId();
+
+    const run = (maxNewActivations: number) =>
+      runAgentGraphToQuiescence({
+        topology: topology(),
+        runStore: facts,
+        runtimeEventStore: facts,
+        claimStore,
+        executor,
+        newId: ids,
+        maxNewActivations,
+        resolvePolicies: fanOutJoinPolicies,
+        renderPrompt: ({ intent }) => `execute ${intent.operatorId}`,
+      });
+
+    try {
+      const first = await run(1);
+      assert.equal(first.status, 'limit_reached');
+      assert.equal(first.newActivationCount, 1);
+      assert.deepEqual(
+        first.dispatches.map((dispatch) => dispatch.intent.operatorId),
+        ['branch-a'],
+      );
+
+      const second = await run(1);
+      assert.equal(second.status, 'limit_reached');
+      assert.equal(second.newActivationCount, 1);
+      assert.deepEqual(
+        second.dispatches.map((dispatch) => [dispatch.intent.operatorId, dispatch.claimCreated]),
+        [
+          ['branch-a', false],
+          ['branch-b', true],
+        ],
+      );
+
+      const third = await run(1);
+      assert.equal(third.status, 'quiescent');
+      assert.equal(third.newActivationCount, 1);
+      assert.deepEqual(
+        third.dispatches.map((dispatch) => [dispatch.intent.operatorId, dispatch.claimCreated]),
+        [
+          ['branch-a', false],
+          ['branch-b', false],
+          ['join', true],
+        ],
+      );
+      assert.equal(executor.backendInvocations, 3);
+    } finally {
+      claimStore.close();
+    }
+  });
+});
+
+function topology(): AgentGraphTraceTopology {
+  return {
+    graphId: 'graph-dispatch',
+    operators: [
+      { operatorId: 'source', sessionId: 'session-source' },
+      { operatorId: 'branch-a', sessionId: 'session-branch-a' },
+      { operatorId: 'branch-b', sessionId: 'session-branch-b' },
+      { operatorId: 'join', sessionId: 'session-join' },
+    ],
+    edges: [
+      { edgeId: 'source-a', fromOperatorId: 'source', toOperatorId: 'branch-a' },
+      { edgeId: 'source-b', fromOperatorId: 'source', toOperatorId: 'branch-b' },
+      { edgeId: 'a-join', fromOperatorId: 'branch-a', toOperatorId: 'join' },
+      { edgeId: 'b-join', fromOperatorId: 'branch-b', toOperatorId: 'join' },
+    ],
+  };
+}
+
+function fanOutJoinPolicies({
+  claims,
+}: Parameters<
+  NonNullable<Parameters<typeof runAgentGraphToQuiescence>[0]['resolvePolicies']>
+>[0]): AgentGraphReadinessPolicy[] {
+  const policies: AgentGraphReadinessPolicy[] = [
+    { readinessId: 'branch-a-map', operatorId: 'branch-a', kind: 'map' },
+    { readinessId: 'branch-b-map', operatorId: 'branch-b', kind: 'map' },
+  ];
+  const branchA = claims.find((claim) => claim.targetOperatorId === 'branch-a');
+  const branchB = claims.find((claim) => claim.targetOperatorId === 'branch-b');
+  if (branchA && branchB) {
+    policies.push({
+      readinessId: 'join-ready',
+      operatorId: 'join',
+      kind: 'all_settled',
+      inputs: [
+        { operatorId: 'branch-a', activationId: branchA.targetRunId },
+        { operatorId: 'branch-b', activationId: branchB.targetRunId },
+      ],
+    });
+  }
+  return policies;
+}
+
+class MemoryGraphFacts {
+  private readonly runs = new Map<string, AgentRunHeader[]>();
+  private readonly events = new Map<string, RuntimeEvent[]>();
+  private clock = 10;
+
+  async listSessionRuns(sessionId: string): Promise<AgentRunHeader[]> {
+    return [...(this.runs.get(sessionId) ?? [])];
+  }
+
+  async readImmutableRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
+    return [...(this.events.get(factKey(sessionId, runId)) ?? [])];
+  }
+
+  hasRun(sessionId: string, runId: string): boolean {
+    return (this.runs.get(sessionId) ?? []).some((run) => run.runId === runId);
+  }
+
+  seedCompleted(sessionId: string, runId: string, turnId: string, createdAt = this.clock++): void {
+    const run: AgentRunHeader = {
+      sessionId,
+      runId,
+      turnId,
+      invocationId: `invocation-${runId}`,
+      backendKind: 'ai-sdk',
+      llmConnectionSlug: 'deepseek',
+      modelId: 'deepseek-chat',
+      cwd: '/workspace',
+      permissionMode: 'explore',
+      status: 'completed',
+      createdAt,
+      updatedAt: createdAt + 1,
+      completedAt: createdAt + 1,
+    };
+    this.runs.set(sessionId, [...(this.runs.get(sessionId) ?? []), run]);
+    this.events.set(factKey(sessionId, runId), [
+      {
+        id: `terminal-${runId}`,
+        invocationId: run.invocationId!,
+        runId,
+        sessionId,
+        turnId,
+        ts: createdAt + 1,
+        partial: false,
+        role: 'system',
+        author: 'system',
+        status: 'completed',
+        actions: { endInvocation: true },
+      },
+    ]);
+  }
+}
+
+class MemoryGraphExecutor implements AgentGraphIntentExecutor {
+  backendInvocations = 0;
+
+  constructor(
+    private readonly claims: AgentGraphIntentClaimStore,
+    private readonly facts: MemoryGraphFacts,
+  ) {}
+
+  async runClaimedAgentGraphIntent(
+    input: Parameters<AgentGraphIntentExecutor['runClaimedAgentGraphIntent']>[0],
+  ): ReturnType<AgentGraphIntentExecutor['runClaimedAgentGraphIntent']> {
+    const claim = await this.claims.readAgentGraphIntentClaim(input.graphId, input.intentId);
+    if (!claim) throw new Error('missing claim');
+    const isNew = !this.facts.hasRun(claim.targetSessionId, claim.targetRunId);
+    await input.onReady?.({
+      claimId: claim.claimId,
+      graphId: claim.graphId,
+      intentId: claim.intentId,
+      operatorId: claim.targetOperatorId,
+      childSessionId: claim.targetSessionId,
+      turnId: claim.targetTurnId,
+      runId: claim.targetRunId,
+      agentId: `agent-${claim.targetOperatorId}`,
+      agentName: claim.targetOperatorId,
+    });
+    if (isNew) {
+      this.backendInvocations += 1;
+      this.facts.seedCompleted(claim.targetSessionId, claim.targetRunId, claim.targetTurnId);
+      input.onEvent?.(completeEvent(claim.targetTurnId, claim.targetRunId));
+    }
+    return {
+      claimId: claim.claimId,
+      graphId: claim.graphId,
+      intentId: claim.intentId,
+      operatorId: claim.targetOperatorId,
+      childSessionId: claim.targetSessionId,
+      turnId: claim.targetTurnId,
+      runId: claim.targetRunId,
+      agentId: `agent-${claim.targetOperatorId}`,
+      agentName: claim.targetOperatorId,
+      profile: 'read-only',
+      status: 'completed',
+      permissionMode: 'explore',
+      summary: `completed ${claim.targetOperatorId}`,
+      artifactIds: [],
+      startedAt: 1,
+      completedAt: 2,
+      durationMs: 1,
+      eventCount: 1,
+    };
+  }
+}
+
+function completeEvent(turnId: string, runId: string): SessionEvent {
+  return {
+    type: 'complete',
+    id: `event-${runId}`,
+    turnId,
+    ts: 1,
+    stopReason: 'end_turn',
+  };
+}
+
+function factKey(sessionId: string, runId: string): string {
+  return `${sessionId}\0${runId}`;
+}
+
+function nextId(): () => string {
+  let value = 0;
+  return () => `graph-dispatch-id-${++value}`;
+}
+
+function nextNumber(start: number): () => number {
+  let value = start;
+  return () => value++;
+}

--- a/packages/runtime/src/__tests__/stream-graph-dispatch.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-dispatch.test.ts
@@ -167,6 +167,44 @@ describe('stream graph dispatch', () => {
       claimStore.close();
     }
   });
+
+  test('preserves sibling admissions when one execution fails after its claim', async () => {
+    const facts = new MemoryGraphFacts();
+    facts.seedCompleted('session-source', 'run-source', 'turn-source', 1);
+    const claimStore = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(300) });
+    const executor = new MemoryGraphExecutor(claimStore, facts, new Set(['branch-b']));
+
+    try {
+      const result = await runAgentGraphToQuiescence({
+        topology: topology(),
+        runStore: facts,
+        runtimeEventStore: facts,
+        claimStore,
+        executor,
+        newId: nextId(),
+        maxNewActivations: 2,
+        resolvePolicies: fanOutJoinPolicies,
+        renderPrompt: ({ intent }) => `execute ${intent.operatorId}`,
+      });
+
+      assert.equal(result.status, 'failed');
+      assert.equal(result.newActivationCount, 2);
+      assert.equal(result.observedExistingActivationCount, 0);
+      assert.deepEqual(
+        result.dispatches.map((dispatch) => [dispatch.intent.operatorId, dispatch.claimCreated]),
+        [['branch-a', true]],
+      );
+      assert.equal(result.failures.length, 1);
+      assert.equal(result.failures[0]?.intent.operatorId, 'branch-b');
+      assert.equal(result.failures[0]?.claim?.targetOperatorId, 'branch-b');
+      assert.equal(result.failures[0]?.claimCreated, true);
+      assert.match(String(result.failures[0]?.error), /branch-b execution failed/);
+      assert.equal(executor.backendInvocations, 1);
+      assert.equal((await claimStore.listAgentGraphIntentClaims('graph-dispatch')).length, 2);
+    } finally {
+      claimStore.close();
+    }
+  });
 });
 
 function topology(): AgentGraphTraceTopology {
@@ -270,6 +308,7 @@ class MemoryGraphExecutor implements AgentGraphIntentExecutor {
   constructor(
     private readonly claims: AgentGraphIntentClaimStore,
     private readonly facts: MemoryGraphFacts,
+    private readonly failingOperators = new Set<string>(),
   ) {}
 
   async runClaimedAgentGraphIntent(
@@ -277,6 +316,9 @@ class MemoryGraphExecutor implements AgentGraphIntentExecutor {
   ): ReturnType<AgentGraphIntentExecutor['runClaimedAgentGraphIntent']> {
     const claim = await this.claims.readAgentGraphIntentClaim(input.graphId, input.intentId);
     if (!claim) throw new Error('missing claim');
+    if (this.failingOperators.has(claim.targetOperatorId)) {
+      throw new Error(`${claim.targetOperatorId} execution failed`);
+    }
     const isNew = !this.facts.hasRun(claim.targetSessionId, claim.targetRunId);
     await input.onReady?.({
       claimId: claim.claimId,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -84,6 +84,20 @@ export {
 } from './stream-graph-readiness.js';
 export { claimAgentGraphRunnableIntent } from './stream-graph-admission.js';
 export type { ClaimAgentGraphRunnableIntentInput } from './stream-graph-admission.js';
+export { runAgentGraphToQuiescence } from './stream-graph-dispatch.js';
+export type {
+  AgentGraphDispatchFailure,
+  AgentGraphDispatchedActivation,
+  AgentGraphIntentExecutor,
+  AgentGraphQuiescenceResult,
+  AgentGraphSupervisorActivationReady,
+  AgentGraphSupervisorObservation,
+  AgentGraphSupervisorObserver,
+  AgentGraphSupervisorRuntimeEvent,
+  RenderAgentGraphIntentPromptInput,
+  ResolveAgentGraphPoliciesInput,
+  RunAgentGraphToQuiescenceInput,
+} from './stream-graph-dispatch.js';
 export type {
   AgentGraphAllSettledReadinessPolicy,
   AgentGraphMapReadinessPolicy,

--- a/packages/runtime/src/stream-graph-admission.ts
+++ b/packages/runtime/src/stream-graph-admission.ts
@@ -15,12 +15,11 @@ export interface ClaimAgentGraphRunnableIntentInput {
   /**
    * Stable execution input resolved before admission.
    *
-   * A graph driver should provide this so a crash after the claim but before
-   * the Runtime message is durable cannot retry the same intent with different
-   * work. The optional form preserves the projection-only admission primitive
-   * for callers that have not resolved execution input yet.
+   * This must be bound before the durable claim is written so a crash after
+   * admission but before the Runtime message is durable cannot retry the same
+   * intent with different work.
    */
-  executionInput?: {
+  executionInput: {
     prompt: string;
   };
 }
@@ -34,16 +33,14 @@ export interface ClaimAgentGraphRunnableIntentInput {
 export function claimAgentGraphRunnableIntent(
   input: ClaimAgentGraphRunnableIntentInput,
 ): Promise<AgentGraphIntentClaimResult> {
-  if (input.executionInput && !input.executionInput.prompt.trim()) {
+  if (!input.executionInput.prompt.trim()) {
     throw new Error('Agent graph execution prompt must not be empty');
   }
-  const intentFingerprint = input.executionInput
-    ? stableHash({
-        schemaVersion: AGENT_GRAPH_EXECUTION_INPUT_SCHEMA_VERSION,
-        intent: input.intent,
-        executionInput: input.executionInput,
-      })
-    : stableHash(input.intent);
+  const intentFingerprint = stableHash({
+    schemaVersion: AGENT_GRAPH_EXECUTION_INPUT_SCHEMA_VERSION,
+    intent: input.intent,
+    executionInput: input.executionInput,
+  });
   const claimHash = stableHash({
     schemaVersion: AGENT_GRAPH_INTENT_CLAIM_SCHEMA_VERSION,
     graphId: input.intent.graphId,

--- a/packages/runtime/src/stream-graph-admission.ts
+++ b/packages/runtime/src/stream-graph-admission.ts
@@ -6,10 +6,23 @@ import { AGENT_GRAPH_INTENT_CLAIM_SCHEMA_VERSION } from '@maka/core/agent-graph-
 import { stableHash } from './request-shape.js';
 import type { AgentGraphRunnableIntent } from './stream-graph-readiness.js';
 
+const AGENT_GRAPH_EXECUTION_INPUT_SCHEMA_VERSION = 1 as const;
+
 export interface ClaimAgentGraphRunnableIntentInput {
   intent: AgentGraphRunnableIntent;
   store: AgentGraphIntentClaimStore;
   newId: () => string;
+  /**
+   * Stable execution input resolved before admission.
+   *
+   * A graph driver should provide this so a crash after the claim but before
+   * the Runtime message is durable cannot retry the same intent with different
+   * work. The optional form preserves the projection-only admission primitive
+   * for callers that have not resolved execution input yet.
+   */
+  executionInput?: {
+    prompt: string;
+  };
 }
 
 /**
@@ -21,7 +34,16 @@ export interface ClaimAgentGraphRunnableIntentInput {
 export function claimAgentGraphRunnableIntent(
   input: ClaimAgentGraphRunnableIntentInput,
 ): Promise<AgentGraphIntentClaimResult> {
-  const intentFingerprint = stableHash(input.intent);
+  if (input.executionInput && !input.executionInput.prompt.trim()) {
+    throw new Error('Agent graph execution prompt must not be empty');
+  }
+  const intentFingerprint = input.executionInput
+    ? stableHash({
+        schemaVersion: AGENT_GRAPH_EXECUTION_INPUT_SCHEMA_VERSION,
+        intent: input.intent,
+        executionInput: input.executionInput,
+      })
+    : stableHash(input.intent);
   const claimHash = stableHash({
     schemaVersion: AGENT_GRAPH_INTENT_CLAIM_SCHEMA_VERSION,
     graphId: input.intent.graphId,

--- a/packages/runtime/src/stream-graph-dispatch.ts
+++ b/packages/runtime/src/stream-graph-dispatch.ts
@@ -1,0 +1,454 @@
+import {
+  decodeAgentGraphIntentClaim,
+  type AgentGraphIntentClaim,
+  type AgentGraphIntentClaimStore,
+} from '@maka/core/agent-graph-control';
+import type { AgentRunStore } from '@maka/core/agent-run';
+import type { SessionEvent } from '@maka/core/events';
+import type { RuntimeEventStore } from '@maka/core';
+import type {
+  ClaimedAgentGraphIntentResult,
+  RunClaimedAgentGraphIntentInput,
+} from './session-manager.js';
+import { claimAgentGraphRunnableIntent } from './stream-graph-admission.js';
+import { compareAgentGraphIdentity } from './stream-graph-identity.js';
+import {
+  readCommittedAgentGraphProjection,
+  type AgentGraphProjection,
+  type AgentGraphRecord,
+} from './stream-graph-projection.js';
+import {
+  buildAgentGraphReadinessSnapshot,
+  type AgentGraphReadinessPolicy,
+  type AgentGraphReadinessSnapshot,
+  type AgentGraphRunnableIntent,
+} from './stream-graph-readiness.js';
+import type { AgentGraphTraceTopology } from './stream-graph-trace.js';
+
+export interface AgentGraphIntentExecutor {
+  runClaimedAgentGraphIntent(
+    input: RunClaimedAgentGraphIntentInput,
+  ): Promise<ClaimedAgentGraphIntentResult>;
+}
+
+export interface ResolveAgentGraphPoliciesInput {
+  projection: AgentGraphProjection;
+  claims: readonly AgentGraphIntentClaim[];
+}
+
+export interface RenderAgentGraphIntentPromptInput {
+  intent: AgentGraphRunnableIntent;
+  triggerRecords: readonly AgentGraphRecord[];
+}
+
+export interface AgentGraphSupervisorObservation {
+  projection: AgentGraphProjection;
+  readiness: AgentGraphReadinessSnapshot;
+  claims: readonly AgentGraphIntentClaim[];
+}
+
+export interface AgentGraphSupervisorActivationReady {
+  intent: AgentGraphRunnableIntent;
+  claim: AgentGraphIntentClaim;
+  runtime: Parameters<NonNullable<RunClaimedAgentGraphIntentInput['onReady']>>[0];
+}
+
+export interface AgentGraphSupervisorRuntimeEvent {
+  intent: AgentGraphRunnableIntent;
+  claim: AgentGraphIntentClaim;
+  event: SessionEvent;
+}
+
+/**
+ * Presentation-only observer for the main-agent supervisor.
+ *
+ * The driver never awaits these callbacks and ignores observer failures, so
+ * supervision stays beside the graph instead of becoming a data-path gate.
+ */
+export interface AgentGraphSupervisorObserver {
+  onObservation?(observation: AgentGraphSupervisorObservation): void | Promise<void>;
+  onActivationReady?(activation: AgentGraphSupervisorActivationReady): void | Promise<void>;
+  onRuntimeEvent?(event: AgentGraphSupervisorRuntimeEvent): void | Promise<void>;
+}
+
+export interface RunAgentGraphToQuiescenceInput {
+  topology: AgentGraphTraceTopology;
+  runStore: Pick<AgentRunStore, 'listSessionRuns'>;
+  runtimeEventStore: Pick<RuntimeEventStore, 'readImmutableRuntimeEvents'>;
+  claimStore: AgentGraphIntentClaimStore;
+  executor: AgentGraphIntentExecutor;
+  newId: () => string;
+  /**
+   * Hard bound on claims first created by this invocation.
+   *
+   * Existing durable claims remain recoverable even when the budget is zero.
+   * Resource permits and fairness are deliberately outside this structural
+   * scheduling boundary.
+   */
+  maxNewActivations: number;
+  resolvePolicies(
+    input: ResolveAgentGraphPoliciesInput,
+  ): readonly AgentGraphReadinessPolicy[] | Promise<readonly AgentGraphReadinessPolicy[]>;
+  renderPrompt(input: RenderAgentGraphIntentPromptInput): string | Promise<string>;
+  abortSignal?: AbortSignal;
+  supervisor?: AgentGraphSupervisorObserver;
+}
+
+export interface AgentGraphDispatchedActivation {
+  intent: AgentGraphRunnableIntent;
+  claim: AgentGraphIntentClaim;
+  claimCreated: boolean;
+  result: ClaimedAgentGraphIntentResult;
+}
+
+export interface AgentGraphDispatchFailure {
+  intent: AgentGraphRunnableIntent;
+  error: unknown;
+}
+
+export interface AgentGraphQuiescenceResult {
+  /**
+   * `quiescent` is not graph-wide completion. Topology/admission closure remains
+   * a separate future protocol.
+   */
+  status: 'quiescent' | 'limit_reached' | 'failed' | 'cancelled';
+  newActivationCount: number;
+  observedExistingActivationCount: number;
+  dispatches: AgentGraphDispatchedActivation[];
+  failures: AgentGraphDispatchFailure[];
+  projection: AgentGraphProjection;
+  readiness: AgentGraphReadinessSnapshot;
+}
+
+interface GraphObservation {
+  projection: AgentGraphProjection;
+  readiness: AgentGraphReadinessSnapshot;
+  claims: AgentGraphIntentClaim[];
+}
+
+interface PreparedDispatch {
+  intent: AgentGraphRunnableIntent;
+  prompt: string;
+}
+
+type DispatchOutcome =
+  | {
+      status: 'fulfilled';
+      dispatch: AgentGraphDispatchedActivation;
+    }
+  | {
+      status: 'rejected';
+      failure: AgentGraphDispatchFailure;
+    };
+
+/**
+ * Repeatedly reconstructs graph state from durable Runtime facts and executes
+ * newly runnable work until no unobserved intent remains.
+ *
+ * The driver owns no execution ledger. Intent claims are durable admission
+ * authority; AgentRun/RuntimeEvent stores remain execution authority.
+ */
+export async function runAgentGraphToQuiescence(
+  input: RunAgentGraphToQuiescenceInput,
+): Promise<AgentGraphQuiescenceResult> {
+  if (!Number.isSafeInteger(input.maxNewActivations) || input.maxNewActivations < 0) {
+    throw new Error('Agent graph maxNewActivations must be a non-negative safe integer');
+  }
+
+  const processedIntentIds = new Set<string>();
+  const dispatches: AgentGraphDispatchedActivation[] = [];
+  const failures: AgentGraphDispatchFailure[] = [];
+  let newActivationCount = 0;
+  let observedExistingActivationCount = 0;
+  let observation = await observeGraph(input);
+
+  while (true) {
+    if (input.abortSignal?.aborted) {
+      return graphResult(
+        'cancelled',
+        newActivationCount,
+        observedExistingActivationCount,
+        dispatches,
+        failures,
+        observation,
+      );
+    }
+
+    const existingIntentIds = new Set(observation.claims.map((claim) => claim.intentId));
+    const candidates = orderedRunnableIntents(observation.readiness).filter(
+      (intent) => !processedIntentIds.has(intent.intentId),
+    );
+    const selected: AgentGraphRunnableIntent[] = [];
+    let deferredByLimit = false;
+    for (const intent of candidates) {
+      if (
+        existingIntentIds.has(intent.intentId) ||
+        newActivationCount + selectedNewIntentCount(selected, existingIntentIds) <
+          input.maxNewActivations
+      ) {
+        selected.push(intent);
+      } else {
+        deferredByLimit = true;
+      }
+    }
+
+    if (selected.length === 0) {
+      return graphResult(
+        deferredByLimit ? 'limit_reached' : 'quiescent',
+        newActivationCount,
+        observedExistingActivationCount,
+        dispatches,
+        failures,
+        observation,
+      );
+    }
+
+    const rendered = await Promise.allSettled(
+      selected.map(async (intent): Promise<PreparedDispatch> => {
+        const prompt = await input.renderPrompt(
+          clonePlain({
+            intent,
+            triggerRecords: resolveTriggerRecords(observation.projection, intent),
+          }),
+        );
+        if (!prompt.trim()) {
+          throw new Error(`Agent graph intent ${intent.intentId} rendered an empty prompt`);
+        }
+        return { intent, prompt };
+      }),
+    );
+    const prepared: PreparedDispatch[] = [];
+    rendered.forEach((result, index) => {
+      if (result.status === 'fulfilled') {
+        prepared.push(result.value);
+      } else {
+        failures.push({ intent: selected[index]!, error: result.reason });
+      }
+    });
+    if (failures.length > 0) {
+      observation = await observeGraph(input);
+      return graphResult(
+        input.abortSignal?.aborted ? 'cancelled' : 'failed',
+        newActivationCount,
+        observedExistingActivationCount,
+        dispatches,
+        failures,
+        observation,
+      );
+    }
+
+    const outcomes = await Promise.all(prepared.map((dispatch) => dispatchIntent(input, dispatch)));
+    for (const outcome of outcomes) {
+      if (outcome.status === 'fulfilled') {
+        dispatches.push(outcome.dispatch);
+        processedIntentIds.add(outcome.dispatch.intent.intentId);
+        if (outcome.dispatch.claimCreated) newActivationCount += 1;
+        else observedExistingActivationCount += 1;
+      } else {
+        failures.push(outcome.failure);
+      }
+    }
+
+    observation = await observeGraph(input);
+    if (failures.length > 0) {
+      return graphResult(
+        input.abortSignal?.aborted ? 'cancelled' : 'failed',
+        newActivationCount,
+        observedExistingActivationCount,
+        dispatches,
+        failures,
+        observation,
+      );
+    }
+    if (deferredByLimit && newActivationCount >= input.maxNewActivations) {
+      return graphResult(
+        'limit_reached',
+        newActivationCount,
+        observedExistingActivationCount,
+        dispatches,
+        failures,
+        observation,
+      );
+    }
+  }
+}
+
+async function observeGraph(input: RunAgentGraphToQuiescenceInput): Promise<GraphObservation> {
+  const [projection, listedClaims] = await Promise.all([
+    readCommittedAgentGraphProjection({
+      graphId: input.topology.graphId,
+      operators: input.topology.operators,
+      runStore: input.runStore,
+      runtimeEventStore: input.runtimeEventStore,
+    }),
+    input.claimStore.listAgentGraphIntentClaims(input.topology.graphId),
+  ]);
+  const claims = listedClaims
+    .map((claim) => {
+      const decoded = decodeAgentGraphIntentClaim(claim);
+      if (decoded.graphId !== input.topology.graphId) {
+        throw new Error(
+          `Graph claim ${decoded.claimId} belongs to ${decoded.graphId}, expected ${input.topology.graphId}`,
+        );
+      }
+      return decoded;
+    })
+    .sort(
+      (a, b) =>
+        compareAgentGraphIdentity(a.intentId, b.intentId) ||
+        compareAgentGraphIdentity(a.claimId, b.claimId),
+    );
+  assertUniqueClaimIntents(claims);
+  const policies = await input.resolvePolicies(clonePlain({ projection, claims }));
+  const readiness = buildAgentGraphReadinessSnapshot({
+    topology: input.topology,
+    records: projection.records,
+    policies,
+  });
+  notifySupervisor(input.supervisor?.onObservation, {
+    projection,
+    readiness,
+    claims,
+  });
+  return { projection, readiness, claims };
+}
+
+async function dispatchIntent(
+  input: RunAgentGraphToQuiescenceInput,
+  prepared: PreparedDispatch,
+): Promise<DispatchOutcome> {
+  try {
+    if (input.abortSignal?.aborted) {
+      throw new Error('Agent graph dispatch was cancelled before admission');
+    }
+    const claimed = await claimAgentGraphRunnableIntent({
+      intent: prepared.intent,
+      store: input.claimStore,
+      newId: input.newId,
+      executionInput: { prompt: prepared.prompt },
+    });
+    const result = await input.executor.runClaimedAgentGraphIntent({
+      claimStore: input.claimStore,
+      graphId: prepared.intent.graphId,
+      intentId: prepared.intent.intentId,
+      prompt: prepared.prompt,
+      ...(input.abortSignal ? { abortSignal: input.abortSignal } : {}),
+      onReady(runtime) {
+        notifySupervisor(input.supervisor?.onActivationReady, {
+          intent: prepared.intent,
+          claim: claimed.claim,
+          runtime,
+        });
+      },
+      onEvent(event) {
+        notifySupervisor(input.supervisor?.onRuntimeEvent, {
+          intent: prepared.intent,
+          claim: claimed.claim,
+          event,
+        });
+      },
+    });
+    return {
+      status: 'fulfilled',
+      dispatch: {
+        intent: prepared.intent,
+        claim: claimed.claim,
+        claimCreated: claimed.created,
+        result,
+      },
+    };
+  } catch (error) {
+    return {
+      status: 'rejected',
+      failure: {
+        intent: prepared.intent,
+        error,
+      },
+    };
+  }
+}
+
+function orderedRunnableIntents(
+  readiness: AgentGraphReadinessSnapshot,
+): AgentGraphRunnableIntent[] {
+  const topologicalIndex = new Map(
+    readiness.trace.topologicalOrder.map((operatorId, index) => [operatorId, index]),
+  );
+  const intents = Object.values(readiness.readiness).flatMap((state) => state.intents);
+  return intents.sort(
+    (a, b) =>
+      topologicalIndex.get(a.operatorId)! - topologicalIndex.get(b.operatorId)! ||
+      compareAgentGraphIdentity(a.readinessId, b.readinessId) ||
+      compareAgentGraphIdentity(a.intentId, b.intentId),
+  );
+}
+
+function selectedNewIntentCount(
+  selected: readonly AgentGraphRunnableIntent[],
+  existingIntentIds: ReadonlySet<string>,
+): number {
+  return selected.filter((intent) => !existingIntentIds.has(intent.intentId)).length;
+}
+
+function resolveTriggerRecords(
+  projection: AgentGraphProjection,
+  intent: AgentGraphRunnableIntent,
+): AgentGraphRecord[] {
+  const recordsById = new Map(projection.records.map((record) => [record.recordId, record]));
+  return intent.triggerRecordIds.map((recordId) => {
+    const record = recordsById.get(recordId);
+    if (!record) {
+      throw new Error(
+        `Agent graph intent ${intent.intentId} references missing record ${recordId}`,
+      );
+    }
+    return record;
+  });
+}
+
+function assertUniqueClaimIntents(claims: readonly AgentGraphIntentClaim[]): void {
+  const seen = new Set<string>();
+  for (const claim of claims) {
+    if (seen.has(claim.intentId)) {
+      throw new Error(`Graph intent ${claim.graphId}/${claim.intentId} has multiple claims`);
+    }
+    seen.add(claim.intentId);
+  }
+}
+
+function graphResult(
+  status: AgentGraphQuiescenceResult['status'],
+  newActivationCount: number,
+  observedExistingActivationCount: number,
+  dispatches: readonly AgentGraphDispatchedActivation[],
+  failures: readonly AgentGraphDispatchFailure[],
+  observation: GraphObservation,
+): AgentGraphQuiescenceResult {
+  return {
+    status,
+    newActivationCount,
+    observedExistingActivationCount,
+    dispatches: [...dispatches],
+    failures: [...failures],
+    projection: observation.projection,
+    readiness: observation.readiness,
+  };
+}
+
+function notifySupervisor<T>(
+  observer: ((input: T) => void | Promise<void>) | undefined,
+  value: T,
+): void {
+  if (!observer) return;
+  try {
+    void Promise.resolve(observer(clonePlain(value))).catch(() => {
+      // Presentation-only supervision must not gate graph execution.
+    });
+  } catch {
+    // Presentation-only supervision must not gate graph execution.
+  }
+}
+
+function clonePlain<T>(value: T): T {
+  return structuredClone(value);
+}

--- a/packages/runtime/src/stream-graph-dispatch.ts
+++ b/packages/runtime/src/stream-graph-dispatch.ts
@@ -104,6 +104,11 @@ export interface AgentGraphDispatchedActivation {
 export interface AgentGraphDispatchFailure {
   intent: AgentGraphRunnableIntent;
   error: unknown;
+  /**
+   * Present when durable admission completed before execution failed.
+   */
+  claim?: AgentGraphIntentClaim;
+  claimCreated?: boolean;
 }
 
 export interface AgentGraphQuiescenceResult {
@@ -246,6 +251,11 @@ export async function runAgentGraphToQuiescence(
         else observedExistingActivationCount += 1;
       } else {
         failures.push(outcome.failure);
+        if (outcome.failure.claim) {
+          processedIntentIds.add(outcome.failure.intent.intentId);
+          if (outcome.failure.claimCreated) newActivationCount += 1;
+          else observedExistingActivationCount += 1;
+        }
       }
     }
 
@@ -317,6 +327,12 @@ async function dispatchIntent(
   input: RunAgentGraphToQuiescenceInput,
   prepared: PreparedDispatch,
 ): Promise<DispatchOutcome> {
+  let admission:
+    | {
+        claim: AgentGraphIntentClaim;
+        created: boolean;
+      }
+    | undefined;
   try {
     if (input.abortSignal?.aborted) {
       throw new Error('Agent graph dispatch was cancelled before admission');
@@ -327,6 +343,7 @@ async function dispatchIntent(
       newId: input.newId,
       executionInput: { prompt: prepared.prompt },
     });
+    admission = claimed;
     const result = await input.executor.runClaimedAgentGraphIntent({
       claimStore: input.claimStore,
       graphId: prepared.intent.graphId,
@@ -360,10 +377,17 @@ async function dispatchIntent(
   } catch (error) {
     return {
       status: 'rejected',
-      failure: {
-        intent: prepared.intent,
-        error,
-      },
+      failure: admission
+        ? {
+            intent: prepared.intent,
+            error,
+            claim: admission.claim,
+            claimCreated: admission.created,
+          }
+        : {
+            intent: prepared.intent,
+            error,
+          },
     };
   }
 }


### PR DESCRIPTION
## Summary

This is the next bounded execution slice of #1341 after #1450. It composes the previously merged projection, topology, operator-local readiness, durable admission, and claimed child-Session execution primitives into a recoverable graph driver.

- add `runAgentGraphToQuiescence`, which repeatedly reconstructs committed graph state, derives local readiness, durably claims runnable intents, executes them through the existing `SessionManager.runClaimedAgentGraphIntent` boundary, and observes the new Runtime facts before the next wave;
- support fan-out followed by a dynamically sealed `all_settled` join: the policy resolver receives the current committed projection plus durable claims and owns exact activation-frontier selection;
- dispatch structurally runnable work in deterministic topological/readiness/intent order while allowing independent target child Sessions to execute concurrently;
- require an explicit `maxNewActivations` bound per invocation; existing durable claims remain recoverable even when that budget is zero;
- settle the whole selected wave before returning failures, so one thrown activation does not hide successful sibling facts;
- bind the resolved execution prompt into the durable intent fingerprint before admission, closing the crash gap between claim persistence and the first Runtime message;
- expose cloned projection/readiness observations plus tagged activation-ready and Runtime events to the always-on main-agent supervisor; observer failures and mutations cannot gate or alter the graph data path;
- export the driver through the runtime barrel and the `@maka/runtime/stream-graph-dispatch` subpath.

## Authority and recovery boundary

The driver deliberately owns no execution ledger and keeps no correctness-critical state between observations.

1. `RuntimeEvent` and `AgentRun` stores remain execution authority.
2. SQLite-backed graph intent claims remain admission authority.
3. Every wave is rebuilt from those durable facts.
4. Re-entering the driver re-observes existing claims through the claimed-execution primitive; terminal runs do not invoke the backend again, while missing or stale runs follow the existing recovery path.
5. A prompt change for an already claimed intent conflicts before Runtime execution, including when the original process crashed after writing the claim but before writing the user message.

`quiescent` means that the current durable observation contains no unobserved runnable intent. It is intentionally **not** a graph-wide completion fact: topology closure, admission closure, and final acceptance still require a later explicit protocol.

## Supervisor boundary

The main-agent supervisor is structurally present beside every scheduling wave:

- it receives the committed meta-stream and readiness snapshot before execution;
- it observes activation identity as soon as the existing Runtime admits a run;
- it receives tagged child Runtime events while work executes.

These callbacks are non-authoritative presentation/monitoring hooks in this slice. Their inputs are cloned, they are never awaited, and synchronous or asynchronous observer failures are ignored. Normal record delivery and activation execution therefore never wait for supervisor approval.

## Deliberate non-goals

- no resource permits, provider limits, global fairness, leases, or backpressure policy;
- no mutable/cyclic topology or graph control-record ledger;
- no durable supervisor cancel/advisory vocabulary yet;
- no graph-wide closing/completion protocol;
- no Desktop/TUI graph renderer;
- no second Agent loop or RuntimeKernel rewrite;
- no hidden failure/retry policy beyond returning all outcomes from the selected wave;
- no implicit creation of root/operator Sessions: the driver consumes the existing Session-backed topology.

## Validation

- focused projection/trace/readiness/admission/dispatch suites: **32 passed**;
- full runtime suite: **2495 passed, 7 skipped**, with the same two unrelated macOS environment failures documented on preceding graph PRs:
  - `/usr/local` executable-root assertion;
  - Homebrew `rg` cannot load PCRE2 inside the operation-scoped Seatbelt sandbox;
- all workspace builds passed;
- all workspace typechecks passed after rebuilding current `main` artifacts;
- Biome checks and `git diff --check` passed.

Refs #1341

<details>
<summary>中文说明</summary>

## 概要

这是 #1450 之后继续推进 #1341 的下一个有界执行切片。它把前面已经合并的 committed-event projection、DAG topology、operator-local readiness、durable claim 和 linked child Session 执行原语真正串成一个可恢复的 graph driver。

- 增加 `runAgentGraphToQuiescence`：每一轮重新读取 committed graph facts，计算局部 readiness，持久化 claim，调用现有 `SessionManager.runClaimedAgentGraphIntent`，再观察新产生的 Runtime facts 并推进下一轮；
- 支持 fan-out 后动态封口的 `all_settled` join：policy resolver 同时看到当前 committed projection 与 durable claims，并由 operator-local policy 选择精确 activation frontier；
- 按确定性的 topology/readiness/intent 顺序 dispatch；不同目标 child Session 可以并行执行；
- 每次调用必须显式提供 `maxNewActivations` 上限；即使上限为零，已有 durable claim 仍然可以恢复；
- 当前 wave 会 all-settled 后再返回 failure，不会因为一个 activation 抛错而隐藏 sibling 已经形成的 durable facts；
- 在 admission 前把 resolved prompt 纳入 durable intent fingerprint，补上“claim 已提交、首条 Runtime message 尚未持久化”之间崩溃时的输入漂移漏洞；
- 主 Agent supervisor 每轮都能观察 projection/readiness、activation-ready 与带 graph identity 的 Runtime event。Observer 收到的是克隆快照，异常或篡改都不会阻塞或改变数据路径；
- 通过 runtime barrel 与 `@maka/runtime/stream-graph-dispatch` subpath 导出。

## 权威与恢复边界

Driver 不持有第二份 execution ledger，也不依赖跨轮次的内存状态：

1. `RuntimeEvent` / `AgentRun` store 继续作为执行事实权威；
2. SQLite-backed graph intent claim 继续作为 admission 权威；
3. 每一轮都从这些 durable facts 重建；
4. 重进 driver 时会通过 claimed-execution primitive 重新观察已有 claim：terminal run 不会二次调用 backend，missing/stale run 继续走既有恢复路径；
5. 已 claim intent 的 prompt 若发生变化，会在 Runtime 执行前冲突，包括原进程恰好在写入 claim 后、写入 user message 前崩溃的情况。

这里的 `quiescent` 只表示当前 durable observation 中没有尚未观察的 runnable intent，**不等于 graph completed**。Topology closure、admission closure 与最终接受仍需要后续显式协议。

## Supervisor 边界

主 Agent supervisor 在每个 scheduling wave 旁边持续观察：执行前看到 committed meta-stream 与 readiness snapshot；Runtime admission 时看到 activation identity；执行过程中看到带 intent/claim identity 的 child Runtime event。

本切片中这些仍是非权威的 monitoring hook。它们不会被 await，异常会被忽略，输入也会克隆，因此正常 record 传递和 activation 执行不需要等待 supervisor 审批。

## 明确不做

- 不做 resource permit、provider limit、全局公平性、lease 或 backpressure policy；
- 不做动态/有环 topology 或 graph control-record ledger；
- 暂不增加 durable supervisor cancel/advisory vocabulary；
- 不做 graph-wide closing/completion protocol；
- 不做 Desktop/TUI graph renderer；
- 不增加第二套 Agent loop，也不改写 RuntimeKernel；
- 不偷偷决定 retry/failure policy，只返回当前 wave 的完整 outcome；
- 不隐式创建 root/operator Session，driver 消费已有的 Session-backed topology。

## 验证

- graph projection/trace/readiness/admission/dispatch 聚焦测试：32 passed；
- runtime 全套：2495 passed、7 skipped；仍只有前序 graph PR 已记录的两个无关 macOS 环境失败；
- 全 workspace build 与 typecheck 通过；
- Biome 与 `git diff --check` 通过。

</details>
