### PR TITLE
feat(runtime): add compact graph supervisor tools

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -41,6 +41,7 @@
     "./plan-reminders": "./dist/plan-reminders.js",
     "./agent-mailbox": "./dist/agent-mailbox.js",
     "./agent-graph-control": "./dist/agent-graph-control.js",
+    "./agent-graph-schedule": "./dist/agent-graph-schedule.js",
     "./task-ledger": "./dist/task-ledger.js",
     "./foreign-session": "./dist/foreign-session.js",
     "./deep-research-run": "./dist/deep-research-run.js",

--- a/packages/core/src/__tests__/agent-graph-schedule.test.ts
+++ b/packages/core/src/__tests__/agent-graph-schedule.test.ts
@@ -1,0 +1,90 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
+  decodeAgentGraphScheduleUpdate,
+  isAgentGraphScheduleUpdate,
+  isAgentGraphScheduleUpdateRequest,
+  type AgentGraphScheduleUpdateRequest,
+} from '../agent-graph-schedule.js';
+
+describe('agent graph schedule contract', () => {
+  test('validates and clones one compact durable schedule update', () => {
+    const request = scheduleRequest();
+    assert.equal(isAgentGraphScheduleUpdateRequest(request), true);
+    const decoded = decodeAgentGraphScheduleUpdate({
+      ...request,
+      revision: 1,
+      committedAt: 42,
+    });
+    assert.equal(isAgentGraphScheduleUpdate(decoded), true);
+    assert.deepEqual(decoded, { ...request, revision: 1, committedAt: 42 });
+    assert.notEqual(decoded.addWork, request.addWork);
+    assert.notEqual(decoded.addWork[0]?.inputIds, request.addWork[0]?.inputIds);
+  });
+
+  test('rejects ambiguous, duplicate, empty, and add-plus-finish updates', () => {
+    assert.equal(
+      isAgentGraphScheduleUpdateRequest({
+        ...scheduleRequest(),
+        addWork: [
+          {
+            ...scheduleRequest().addWork[0],
+            target: { kind: 'agent', agentId: '' },
+          },
+        ],
+      }),
+      false,
+    );
+    assert.equal(
+      isAgentGraphScheduleUpdateRequest({
+        ...scheduleRequest(),
+        addWork: [],
+        stop: [],
+      }),
+      false,
+    );
+    assert.equal(
+      isAgentGraphScheduleUpdateRequest({
+        ...scheduleRequest(),
+        addWork: [],
+        stop: [
+          { targetId: 'work-1', reason: 'stop duplicate work' },
+          { targetId: 'work-1', reason: 'stop duplicate work again' },
+        ],
+      }),
+      false,
+    );
+    assert.equal(
+      isAgentGraphScheduleUpdateRequest({
+        ...scheduleRequest(),
+        finish: { resultIds: ['result-1'], reason: 'enough evidence' },
+      }),
+      false,
+    );
+  });
+});
+
+function scheduleRequest(): AgentGraphScheduleUpdateRequest {
+  return {
+    schemaVersion: AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
+    updateId: `graph_update_${'a'.repeat(32)}`,
+    updateFingerprint: `sha256:${'b'.repeat(64)}`,
+    graphId: 'graph-1',
+    source: {
+      sessionId: 'session-main',
+      runId: 'run-main',
+      turnId: 'turn-main',
+      toolCallId: 'tool-main',
+    },
+    addWork: [
+      {
+        workId: `graph_work_${'c'.repeat(32)}`,
+        target: { kind: 'agent', agentId: 'fact-checker' },
+        instruction: 'Verify the selected evidence.',
+        inputIds: ['result-1'],
+      },
+    ],
+    stop: [],
+  };
+}

--- a/packages/core/src/agent-graph-schedule.ts
+++ b/packages/core/src/agent-graph-schedule.ts
@@ -1,0 +1,293 @@
+export const AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION = 1 as const;
+
+export const AGENT_GRAPH_SCHEDULE_MAX_ADD_WORK = 20;
+export const AGENT_GRAPH_SCHEDULE_MAX_STOP = 20;
+export const AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS = 64;
+export const AGENT_GRAPH_SCHEDULE_MAX_RESULT_IDS = 64;
+export const AGENT_GRAPH_SCHEDULE_MAX_INSTRUCTION_CHARS = 60_000;
+export const AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS = 4_000;
+
+export interface AgentGraphScheduleUpdateSource {
+  sessionId: string;
+  runId: string;
+  turnId: string;
+  toolCallId: string;
+}
+
+export type AgentGraphWorkTarget =
+  | {
+      kind: 'agent';
+      agentId: string;
+    }
+  | {
+      kind: 'operator';
+      operatorId: string;
+    };
+
+export interface AgentGraphScheduledWork {
+  workId: string;
+  target: AgentGraphWorkTarget;
+  instruction: string;
+  inputIds: string[];
+  replaces?: string;
+}
+
+export interface AgentGraphStoppedTarget {
+  targetId: string;
+  reason: string;
+}
+
+export interface AgentGraphScheduleFinish {
+  resultIds: string[];
+  reason: string;
+}
+
+/**
+ * One main-agent schedule edit after the compact public tool input has been
+ * normalized and assigned durable identities.
+ */
+export interface AgentGraphScheduleUpdateRequest {
+  schemaVersion: typeof AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION;
+  updateId: string;
+  updateFingerprint: string;
+  graphId: string;
+  source: AgentGraphScheduleUpdateSource;
+  addWork: AgentGraphScheduledWork[];
+  stop: AgentGraphStoppedTarget[];
+  finish?: AgentGraphScheduleFinish;
+}
+
+export interface AgentGraphScheduleUpdate extends AgentGraphScheduleUpdateRequest {
+  revision: number;
+  committedAt: number;
+}
+
+export interface AgentGraphScheduleUpdateResult {
+  update: AgentGraphScheduleUpdate;
+  created: boolean;
+}
+
+export interface AgentGraphScheduleStore {
+  commitAgentGraphScheduleUpdate(
+    request: AgentGraphScheduleUpdateRequest,
+  ): Promise<AgentGraphScheduleUpdateResult>;
+  listAgentGraphScheduleUpdates(graphId: string): Promise<AgentGraphScheduleUpdate[]>;
+}
+
+export function isAgentGraphScheduleUpdateRequest(
+  value: unknown,
+): value is AgentGraphScheduleUpdateRequest {
+  if (
+    !isExactRecord(value, [
+      'schemaVersion',
+      'updateId',
+      'updateFingerprint',
+      'graphId',
+      'source',
+      'addWork',
+      'stop',
+      ...(hasOwn(value, 'finish') ? ['finish'] : []),
+    ])
+  ) {
+    return false;
+  }
+  const request = value as unknown as AgentGraphScheduleUpdateRequest;
+  return (
+    request.schemaVersion === AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION &&
+    /^graph_update_[a-f0-9]{32}$/.test(request.updateId) &&
+    isSha256Fingerprint(request.updateFingerprint) &&
+    isOpaqueIdentity(request.graphId) &&
+    isScheduleSource(request.source) &&
+    Array.isArray(request.addWork) &&
+    request.addWork.length <= AGENT_GRAPH_SCHEDULE_MAX_ADD_WORK &&
+    request.addWork.every(isScheduledWork) &&
+    unique(request.addWork.map((work) => work.workId)) &&
+    Array.isArray(request.stop) &&
+    request.stop.length <= AGENT_GRAPH_SCHEDULE_MAX_STOP &&
+    request.stop.every(isStoppedTarget) &&
+    unique(request.stop.map((stopped) => stopped.targetId)) &&
+    (request.finish === undefined || isScheduleFinish(request.finish)) &&
+    request.addWork.length + request.stop.length + (request.finish ? 1 : 0) > 0 &&
+    !(request.finish && request.addWork.length > 0)
+  );
+}
+
+export function isAgentGraphScheduleUpdate(value: unknown): value is AgentGraphScheduleUpdate {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    !hasOwn(value, 'revision') ||
+    !hasOwn(value, 'committedAt')
+  ) {
+    return false;
+  }
+  const { revision, committedAt, ...request } = value as Record<string, unknown>;
+  return (
+    isAgentGraphScheduleUpdateRequest(request) &&
+    isPositiveSafeInteger(revision) &&
+    isNonNegativeSafeInteger(committedAt)
+  );
+}
+
+export function assertAgentGraphScheduleUpdateRequest(
+  value: unknown,
+): asserts value is AgentGraphScheduleUpdateRequest {
+  if (!isAgentGraphScheduleUpdateRequest(value)) {
+    throw new Error('Invalid agent graph schedule update request');
+  }
+}
+
+export function decodeAgentGraphScheduleUpdate(value: unknown): AgentGraphScheduleUpdate {
+  if (!isAgentGraphScheduleUpdate(value)) {
+    throw new Error('Invalid agent graph schedule update');
+  }
+  return {
+    schemaVersion: value.schemaVersion,
+    updateId: value.updateId,
+    updateFingerprint: value.updateFingerprint,
+    graphId: value.graphId,
+    source: { ...value.source },
+    addWork: value.addWork.map((work) => ({
+      workId: work.workId,
+      target: { ...work.target },
+      instruction: work.instruction,
+      inputIds: [...work.inputIds],
+      ...(work.replaces ? { replaces: work.replaces } : {}),
+    })),
+    stop: value.stop.map((stopped) => ({ ...stopped })),
+    ...(value.finish
+      ? {
+          finish: {
+            resultIds: [...value.finish.resultIds],
+            reason: value.finish.reason,
+          },
+        }
+      : {}),
+    revision: value.revision,
+    committedAt: value.committedAt,
+  };
+}
+
+function isScheduleSource(value: unknown): value is AgentGraphScheduleUpdateSource {
+  return (
+    isExactRecord(value, ['sessionId', 'runId', 'turnId', 'toolCallId']) &&
+    isOpaqueIdentity(value.sessionId) &&
+    isOpaqueIdentity(value.runId) &&
+    isOpaqueIdentity(value.turnId) &&
+    isOpaqueIdentity(value.toolCallId)
+  );
+}
+
+function isScheduledWork(value: unknown): value is AgentGraphScheduledWork {
+  if (
+    !isExactRecord(value, [
+      'workId',
+      'target',
+      'instruction',
+      'inputIds',
+      ...(hasOwn(value, 'replaces') ? ['replaces'] : []),
+    ])
+  ) {
+    return false;
+  }
+  return (
+    typeof value.workId === 'string' &&
+    /^graph_work_[a-f0-9]{32}$/.test(value.workId) &&
+    isWorkTarget(value.target) &&
+    isBoundedText(value.instruction, AGENT_GRAPH_SCHEDULE_MAX_INSTRUCTION_CHARS) &&
+    Array.isArray(value.inputIds) &&
+    value.inputIds.length <= AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS &&
+    value.inputIds.every(isOpaqueIdentity) &&
+    unique(value.inputIds) &&
+    (value.replaces === undefined || isOpaqueIdentity(value.replaces))
+  );
+}
+
+function isWorkTarget(value: unknown): value is AgentGraphWorkTarget {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  if (
+    isExactRecord(value, ['kind', 'agentId']) &&
+    value.kind === 'agent' &&
+    isOpaqueIdentity(value.agentId)
+  ) {
+    return true;
+  }
+  return (
+    isExactRecord(value, ['kind', 'operatorId']) &&
+    value.kind === 'operator' &&
+    isOpaqueIdentity(value.operatorId)
+  );
+}
+
+function isStoppedTarget(value: unknown): value is AgentGraphStoppedTarget {
+  return (
+    isExactRecord(value, ['targetId', 'reason']) &&
+    isOpaqueIdentity(value.targetId) &&
+    isBoundedText(value.reason, AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS)
+  );
+}
+
+function isScheduleFinish(value: unknown): value is AgentGraphScheduleFinish {
+  return (
+    isExactRecord(value, ['resultIds', 'reason']) &&
+    Array.isArray(value.resultIds) &&
+    value.resultIds.length > 0 &&
+    value.resultIds.length <= AGENT_GRAPH_SCHEDULE_MAX_RESULT_IDS &&
+    value.resultIds.every(isOpaqueIdentity) &&
+    unique(value.resultIds) &&
+    isBoundedText(value.reason, AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS)
+  );
+}
+
+function isBoundedText(value: unknown, maxChars: number): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= maxChars &&
+    value.trim() === value &&
+    !/[\u0000\u0008\u000b\u000c\u000e-\u001f\u007f]/.test(value)
+  );
+}
+
+function isOpaqueIdentity(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= 256 &&
+    value.trim() === value &&
+    !/[\u0000-\u001f\u007f]/.test(value)
+  );
+}
+
+function isSha256Fingerprint(value: unknown): value is string {
+  return typeof value === 'string' && /^sha256:[a-f0-9]{64}$/.test(value);
+}
+
+function isPositiveSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value > 0;
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function unique(values: readonly string[]): boolean {
+  return new Set(values).size === values.length;
+}
+
+function hasOwn(value: unknown, key: string): boolean {
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    !Array.isArray(value) &&
+    Object.prototype.hasOwnProperty.call(value, key)
+  );
+}
+
+function isExactRecord(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -13,6 +13,7 @@ export * from './orchestration.js';
 export * from './swarm-command.js';
 export * from './plan.js';
 export * from './agent-graph-control.js';
+export * from './agent-graph-schedule.js';
 export * from './runtime-policy.js';
 
 // events.ts

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -57,7 +57,8 @@
     "./stream-graph-trace": "./dist/stream-graph-trace.js",
     "./stream-graph-readiness": "./dist/stream-graph-readiness.js",
     "./stream-graph-admission": "./dist/stream-graph-admission.js",
-    "./stream-graph-dispatch": "./dist/stream-graph-dispatch.js"
+    "./stream-graph-dispatch": "./dist/stream-graph-dispatch.js",
+    "./stream-graph-supervisor-tools": "./dist/stream-graph-supervisor-tools.js"
   },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",

--- a/packages/runtime/src/__tests__/stream-graph-supervisor-tools.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-supervisor-tools.test.ts
@@ -1,0 +1,434 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { createSqliteSessionMetadataStore } from '@maka/storage';
+import type { AgentGraphSupervisorObservation } from '../stream-graph-dispatch.js';
+import type { MakaToolContext } from '../tool-runtime.js';
+import {
+  UPDATE_AGENT_GRAPH_TOOL_NAME,
+  VIEW_AGENT_GRAPH_TOOL_NAME,
+  buildAgentGraphSupervisorTools,
+  projectAgentGraphSchedule,
+} from '../stream-graph-supervisor-tools.js';
+
+describe('stream graph supervisor tools', () => {
+  test('exposes one compact read tool and one durable schedule update tool', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(100) });
+    const [viewTool, updateTool] = buildAgentGraphSupervisorTools({
+      graphId: 'graph-supervised',
+      scheduleStore: store,
+      observeGraph: async () => observationWithRecords('graph-supervised', ['verified-result']),
+    });
+    try {
+      assert.equal(viewTool.name, VIEW_AGENT_GRAPH_TOOL_NAME);
+      assert.equal(updateTool.name, UPDATE_AGENT_GRAPH_TOOL_NAME);
+      assert.equal(viewTool.permissionRequired, false);
+      assert.equal(updateTool.permissionRequired, false);
+      assert.equal(viewTool.recoveryMode, 'replay_safe');
+      assert.equal(updateTool.recoveryMode, 'idempotent');
+
+      const firstInput = {
+        add_work: [
+          {
+            agent_id: 'fact-checker',
+            instruction: 'Verify the conflicting figures.',
+            input_ids: ['result-b', 'result-a'],
+          },
+          {
+            operator_id: 'writer',
+            instruction: 'Prepare a follow-up explanation.',
+            input_ids: ['result-a'],
+          },
+        ],
+      };
+      const first = await updateTool.impl(firstInput, toolContext('tool-1'));
+      const retry = await updateTool.impl(firstInput, toolContext('tool-1'));
+      assert.deepEqual(retry, first);
+      assert.equal((await store.listAgentGraphScheduleUpdates('graph-supervised')).length, 1);
+      assert.deepEqual(first.schedule.work[0]?.inputIds, ['result-a', 'result-b']);
+      assert.equal(first.runtime.operators[0]?.status, 'running');
+      assert.deepEqual(first.runtime.readiness[0]?.waitingFor, [
+        { kind: 'input_route', upstreamOperatorIds: ['researcher'] },
+      ]);
+      assert.doesNotMatch(JSON.stringify(first), /graph-supervised|updateId|"revision"/);
+
+      const [firstWork, secondWork] = first.schedule.work;
+      assert.ok(firstWork);
+      assert.ok(secondWork);
+      const second = await updateTool.impl(
+        {
+          add_work: [
+            {
+              operator_id: 'fact-checker',
+              instruction: 'Recheck the figures against primary filings.',
+              input_ids: ['result-a', 'result-b'],
+              replaces: firstWork.workId,
+            },
+          ],
+          stop: [{ target_id: secondWork.workId, reason: 'The explanation is premature.' }],
+        },
+        toolContext('tool-2'),
+      );
+      assert.equal(
+        (await store.listAgentGraphScheduleUpdates('graph-supervised')).at(-1)?.revision,
+        2,
+      );
+      assert.deepEqual(
+        second.schedule.work.map((work) => work.status),
+        ['requested', 'superseded', 'stopped'],
+      );
+
+      const thirdWork = second.schedule.work.find((work) => work.status === 'requested');
+      assert.ok(thirdWork);
+      await assert.rejects(
+        async () =>
+          await updateTool.impl(
+            {
+              finish: {
+                result_ids: ['does-not-exist'],
+                reason: 'This typo must not close the graph.',
+              },
+            },
+            toolContext('tool-invalid-finish'),
+          ),
+        /not committed graph records/,
+      );
+      assert.equal((await store.listAgentGraphScheduleUpdates('graph-supervised')).length, 2);
+      assert.equal(
+        (await viewTool.impl({}, toolContext('tool-view-before-finish'))).schedule.closed,
+        false,
+      );
+      const finished = await updateTool.impl(
+        {
+          stop: [{ target_id: thirdWork.workId, reason: 'Verification is complete.' }],
+          finish: {
+            result_ids: ['verified-result'],
+            reason: 'Use the verified result as the final answer.',
+          },
+        },
+        toolContext('tool-3'),
+      );
+      assert.equal(
+        (await store.listAgentGraphScheduleUpdates('graph-supervised')).at(-1)?.revision,
+        3,
+      );
+      assert.equal(finished.schedule.closed, true);
+      assert.deepEqual(finished.schedule.finish?.resultIds, ['verified-result']);
+
+      const viewed = await viewTool.impl({}, toolContext('tool-view'));
+      assert.deepEqual(viewed.schedule, finished.schedule);
+      await assert.rejects(
+        async () =>
+          updateTool.impl(
+            {
+              add_work: [
+                {
+                  agent_id: 'researcher',
+                  instruction: 'Start work after the graph is finished.',
+                  input_ids: [],
+                },
+              ],
+            },
+            toolContext('tool-4'),
+          ),
+        /already finished/,
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  test('keeps graph identity and idempotency fields out of the model-facing update schema', () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    const [, updateTool] = buildAgentGraphSupervisorTools({
+      graphId: 'graph-supervised',
+      scheduleStore: store,
+      observeGraph: async () => observationWithRecords('graph-supervised'),
+    });
+    try {
+      const schema = updateTool.parameters as {
+        safeParse(value: unknown): { success: boolean };
+      };
+      assert.equal(schema.safeParse({}).success, false);
+      assert.equal(
+        schema.safeParse({
+          add_work: [{ agent_id: 'researcher', instruction: 'Defaults to no input ids.' }],
+        }).success,
+        true,
+      );
+      assert.equal(
+        schema.safeParse({
+          add_work: [
+            {
+              agent_id: 'researcher',
+              operator_id: 'existing',
+              instruction: 'Ambiguous target.',
+              input_ids: [],
+            },
+          ],
+        }).success,
+        false,
+      );
+      assert.equal(
+        schema.safeParse({
+          graph_id: 'forged-graph',
+          add_work: [
+            {
+              agent_id: 'researcher',
+              instruction: 'Try to escape the bound graph.',
+              input_ids: [],
+            },
+          ],
+        }).success,
+        false,
+      );
+      assert.equal(
+        schema.safeParse({
+          add_work: [
+            {
+              agent_id: 'researcher',
+              instruction: 'Cannot add work while finishing.',
+              input_ids: [],
+            },
+          ],
+          finish: { result_ids: ['result-1'], reason: 'Done.' },
+        }).success,
+        false,
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  test('fails closed on non-contiguous durable schedule replay', () => {
+    assert.throws(
+      () =>
+        projectAgentGraphSchedule('graph-supervised', [
+          {
+            schemaVersion: 1,
+            updateId: `graph_update_${'a'.repeat(32)}`,
+            updateFingerprint: `sha256:${'b'.repeat(64)}`,
+            graphId: 'graph-supervised',
+            source: {
+              sessionId: 'session-main',
+              runId: 'run-main',
+              turnId: 'turn-main',
+              toolCallId: 'tool-main',
+            },
+            addWork: [],
+            stop: [{ targetId: 'work-1', reason: 'Stop stale work.' }],
+            revision: 2,
+            committedAt: 1,
+          },
+        ]),
+      /non-contiguous revision 2/,
+    );
+  });
+
+  test('fails closed when the runtime observation is for another graph', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    const [viewTool] = buildAgentGraphSupervisorTools({
+      graphId: 'graph-supervised',
+      scheduleStore: store,
+      observeGraph: async () => observationWithRecords('graph-other'),
+    });
+    try {
+      await assert.rejects(
+        async () => await viewTool.impl({}, toolContext('tool-view')),
+        /another graph/,
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  test('paginates all live state instead of hiding older requested work', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    const [viewTool, updateTool] = buildAgentGraphSupervisorTools({
+      graphId: 'graph-supervised',
+      scheduleStore: store,
+      observeGraph: async () => observationWithRecords('graph-supervised'),
+    });
+    try {
+      for (let batch = 0; batch < 4; batch += 1) {
+        await updateTool.impl(
+          {
+            add_work: Array.from({ length: 20 }, (_, index) => ({
+              agent_id: `agent-${batch}-${index}`,
+              instruction: `Run live work ${batch}-${index}.`,
+            })),
+          },
+          toolContext(`tool-batch-${batch}`),
+        );
+      }
+
+      const firstPage = await viewTool.impl({}, toolContext('tool-view-1'));
+      assert.equal(firstPage.schedule.work.length, 64);
+      assert.ok(firstPage.nextCursor);
+      const secondPage = await viewTool.impl(
+        { cursor: firstPage.nextCursor },
+        toolContext('tool-view-2'),
+      );
+      assert.equal(secondPage.schedule.work.length, 16);
+      assert.equal(secondPage.runtime.operators.length, 1);
+      assert.equal(secondPage.runtime.readiness.length, 1);
+      assert.equal(secondPage.nextCursor, undefined);
+      assert.equal(
+        new Set([
+          ...firstPage.schedule.work.map((work) => work.workId),
+          ...secondPage.schedule.work.map((work) => work.workId),
+        ]).size,
+        80,
+      );
+    } finally {
+      store.close();
+    }
+  });
+});
+
+function observationWithRecords(
+  graphId: string,
+  recordIds: readonly string[] = [],
+): AgentGraphSupervisorObservation {
+  const topologyFingerprint = `sha256:${'a'.repeat(64)}`;
+  const policyFingerprint = `sha256:${'b'.repeat(64)}`;
+  const readinessContextFingerprint = `sha256:${'c'.repeat(64)}`;
+  const activationId = 'activation-writer';
+  const records = recordIds.map((recordId, index) => {
+    const runtimeEventId = `runtime-event-${index}`;
+    const eventTime = index + 1;
+    return {
+      schemaVersion: 1 as const,
+      recordId,
+      graphId,
+      operatorId: 'writer',
+      activationId,
+      sessionId: 'session-writer',
+      agentRunId: 'run-writer',
+      eventTime,
+      orderKey: {
+        runCreatedAt: 1,
+        operatorId: 'writer',
+        runId: 'run-writer',
+        committedEventOrdinal: index,
+        runtimeEventId,
+      },
+      ...(index > 0 ? { previousRecordId: recordIds[index - 1] } : {}),
+      type: 'agent_runtime_event' as const,
+      facets: ['message' as const],
+      supervisorSignals: [],
+      source: {
+        kind: 'runtime_event' as const,
+        runtimeEventId,
+        sessionId: 'session-writer',
+        runId: 'run-writer',
+        turnId: 'turn-writer',
+        ts: eventTime,
+      },
+    };
+  });
+  const lastRecord = records.at(-1);
+  return {
+    projection: {
+      graphId,
+      operators: [{ operatorId: 'writer', sessionId: 'session-writer' }],
+      ignoredPartialEvents: 0,
+      records,
+      supervisorMetaStream: records.map((record) => ({
+        recordId: record.recordId,
+        graphId,
+        operatorId: record.operatorId,
+        activationId,
+        eventTime: record.eventTime,
+        orderKey: { ...record.orderKey },
+        facets: [...record.facets],
+        signals: [],
+        source: { ...record.source },
+      })),
+      state: {
+        graphId,
+        appliedRecordIds: records.map((record) => record.recordId),
+        operators: lastRecord
+          ? {
+              writer: {
+                operatorId: 'writer',
+                sessionId: 'session-writer',
+                status: 'running',
+                currentActivationId: activationId,
+                activations: {
+                  [activationId]: {
+                    activationId,
+                    agentRunId: 'run-writer',
+                    status: 'running',
+                    recordCount: records.length,
+                    firstEventTime: records[0]!.eventTime,
+                    lastEventTime: lastRecord.eventTime,
+                    lastRecordId: lastRecord.recordId,
+                  },
+                },
+              },
+            }
+          : {},
+      },
+    },
+    readiness: {
+      schemaVersion: 1,
+      graphId,
+      topologyFingerprint,
+      trace: {
+        schemaVersion: 1,
+        graphId,
+        topologyFingerprint,
+        topologicalOrder: ['writer'],
+        rootOperatorIds: ['writer'],
+        sinkOperatorIds: ['writer'],
+        recordIds: records.map((record) => record.recordId),
+        operators: {
+          writer: {
+            operatorId: 'writer',
+            sessionId: 'session-writer',
+            topologicalIndex: 0,
+            upstreamOperatorIds: [],
+            downstreamOperatorIds: [],
+            emittedRecordIds: records.map((record) => record.recordId),
+            receivedRouteIds: [],
+          },
+        },
+        edges: {},
+        routes: [],
+      },
+      readiness: {},
+      supervisorView: [
+        {
+          graphId,
+          topologyFingerprint,
+          readinessId: 'readiness-writer',
+          operatorId: 'writer',
+          policyKind: 'map',
+          policyFingerprint,
+          readinessContextFingerprint,
+          status: 'waiting',
+          intentIds: [],
+          waitingFor: [{ kind: 'input_route', upstreamOperatorIds: ['researcher'] }],
+        },
+      ],
+    },
+    claims: [],
+  };
+}
+
+function toolContext(toolCallId: string): MakaToolContext {
+  return {
+    sessionId: 'session-main',
+    runId: 'run-main',
+    turnId: 'turn-main',
+    toolCallId,
+    cwd: '/workspace',
+    abortSignal: new AbortController().signal,
+    emitOutput() {},
+  };
+}
+
+function nextNumber(start: number): () => number {
+  let value = start;
+  return () => value++;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -98,6 +98,30 @@ export type {
   ResolveAgentGraphPoliciesInput,
   RunAgentGraphToQuiescenceInput,
 } from './stream-graph-dispatch.js';
+export {
+  AGENT_GRAPH_SUPERVISOR_TOOL_NAMES,
+  UPDATE_AGENT_GRAPH_TOOL_NAME,
+  VIEW_AGENT_GRAPH_TOOL_NAME,
+  buildAgentGraphSupervisorTools,
+  compileAgentGraphScheduleUpdate,
+  projectAgentGraphSchedule,
+} from './stream-graph-supervisor-tools.js';
+export type {
+  AgentGraphScheduleFinishView,
+  AgentGraphScheduleProjection,
+  AgentGraphScheduleWorkView,
+  AgentGraphStoppedTargetView,
+  AgentGraphToolActivityView,
+  AgentGraphToolReadinessView,
+  AgentGraphToolRuntimeOperatorView,
+  AgentGraphToolRuntimeView,
+  AgentGraphToolScheduleView,
+  BuildAgentGraphSupervisorToolsInput,
+  UpdateAgentGraphToolInput,
+  UpdateAgentGraphToolResult,
+  ViewAgentGraphToolInput,
+  ViewAgentGraphToolResult,
+} from './stream-graph-supervisor-tools.js';
 export type {
   AgentGraphAllSettledReadinessPolicy,
   AgentGraphMapReadinessPolicy,

--- a/packages/runtime/src/stream-graph-supervisor-tools.ts
+++ b/packages/runtime/src/stream-graph-supervisor-tools.ts
@@ -1,0 +1,791 @@
+import { z } from 'zod';
+import {
+  AGENT_GRAPH_SCHEDULE_MAX_ADD_WORK,
+  AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS,
+  AGENT_GRAPH_SCHEDULE_MAX_INSTRUCTION_CHARS,
+  AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS,
+  AGENT_GRAPH_SCHEDULE_MAX_RESULT_IDS,
+  AGENT_GRAPH_SCHEDULE_MAX_STOP,
+  AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
+  decodeAgentGraphScheduleUpdate,
+  type AgentGraphScheduleFinish,
+  type AgentGraphScheduleStore,
+  type AgentGraphScheduleUpdate,
+  type AgentGraphScheduleUpdateRequest,
+  type AgentGraphScheduledWork,
+  type AgentGraphStoppedTarget,
+  type AgentGraphWorkTarget,
+} from '@maka/core/agent-graph-schedule';
+import { stableHash } from './request-shape.js';
+import type { AgentGraphSupervisorObservation } from './stream-graph-dispatch.js';
+import type {
+  AgentGraphActivationStatus,
+  AgentGraphRecordFacet,
+  AgentGraphSupervisorSignal,
+} from './stream-graph-projection.js';
+import type { AgentGraphReadinessWait } from './stream-graph-readiness.js';
+import type { MakaTool, MakaToolContext } from './tool-runtime.js';
+
+export const VIEW_AGENT_GRAPH_TOOL_NAME = 'view_agent_graph';
+export const UPDATE_AGENT_GRAPH_TOOL_NAME = 'update_agent_graph';
+export const AGENT_GRAPH_SUPERVISOR_TOOL_NAMES = [
+  VIEW_AGENT_GRAPH_TOOL_NAME,
+  UPDATE_AGENT_GRAPH_TOOL_NAME,
+] as const;
+
+const TOOL_VIEW_MAX_TERMINAL_WORK = 64;
+const TOOL_VIEW_MAX_STOPPED_TARGETS = 64;
+const TOOL_VIEW_MAX_INSTRUCTION_CHARS = 2_000;
+const TOOL_VIEW_MAX_ACTIVITY = 64;
+const TOOL_VIEW_MAX_TERMINAL_OPERATORS = 64;
+const TOOL_VIEW_MAX_LIVE_STATE = 64;
+
+const identitySchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(256)
+  .refine((value) => !/[\u0000-\u001f\u007f]/.test(value), 'Identity contains control characters');
+
+const cursorSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(512)
+  .refine((value) => !/[\u0000-\u001f\u007f]/.test(value), 'Cursor contains control characters');
+
+const addWorkSchema = z
+  .object({
+    agent_id: identitySchema.optional().describe('Catalog agent to add as new graph work.'),
+    operator_id: identitySchema
+      .optional()
+      .describe('Existing graph operator to run again or follow up.'),
+    instruction: z.string().trim().min(1).max(AGENT_GRAPH_SCHEDULE_MAX_INSTRUCTION_CHARS),
+    input_ids: z
+      .array(identitySchema)
+      .max(AGENT_GRAPH_SCHEDULE_MAX_INPUT_IDS)
+      .default([])
+      .describe('Durable record or result ids that form this work item input frontier.'),
+    replaces: identitySchema
+      .optional()
+      .describe('Existing work or activation superseded by this request.'),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    if ((value.agent_id ? 1 : 0) + (value.operator_id ? 1 : 0) !== 1) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Exactly one of agent_id or operator_id is required',
+      });
+    }
+    addDuplicateIssue(ctx, value.input_ids, ['input_ids']);
+  });
+
+const stopSchema = z
+  .object({
+    target_id: identitySchema,
+    reason: z.string().trim().min(1).max(AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS),
+  })
+  .strict();
+
+const finishSchema = z
+  .object({
+    result_ids: z
+      .array(identitySchema)
+      .min(1)
+      .max(AGENT_GRAPH_SCHEDULE_MAX_RESULT_IDS)
+      .describe('Committed graph record ids selected as the final result.'),
+    reason: z.string().trim().min(1).max(AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS),
+  })
+  .strict()
+  .superRefine((value, ctx) => addDuplicateIssue(ctx, value.result_ids, ['result_ids']));
+
+const updateSchema = z
+  .object({
+    add_work: z.array(addWorkSchema).max(AGENT_GRAPH_SCHEDULE_MAX_ADD_WORK).optional(),
+    stop: z.array(stopSchema).max(AGENT_GRAPH_SCHEDULE_MAX_STOP).optional(),
+    finish: finishSchema.optional(),
+  })
+  .strict()
+  .superRefine((value, ctx) => {
+    const addWork = value.add_work ?? [];
+    const stop = value.stop ?? [];
+    if (addWork.length + stop.length + (value.finish ? 1 : 0) === 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'At least one add_work, stop, or finish operation is required',
+      });
+    }
+    if (value.finish && addWork.length > 0) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'finish cannot be combined with add_work',
+      });
+    }
+    addDuplicateIssue(
+      ctx,
+      stop.map((entry) => entry.target_id),
+      ['stop'],
+    );
+  });
+
+const viewSchema = z
+  .object({
+    cursor: cursorSchema
+      .optional()
+      .describe('Opaque cursor returned by an earlier view_agent_graph call.'),
+  })
+  .strict();
+
+export interface ViewAgentGraphToolInput {
+  cursor?: string;
+}
+
+export interface UpdateAgentGraphToolInput {
+  add_work?: Array<{
+    agent_id?: string;
+    operator_id?: string;
+    instruction: string;
+    input_ids?: string[];
+    replaces?: string;
+  }>;
+  stop?: Array<{
+    target_id: string;
+    reason: string;
+  }>;
+  finish?: {
+    result_ids: string[];
+    reason: string;
+  };
+}
+
+export interface AgentGraphScheduleWorkView extends AgentGraphScheduledWork {
+  status: 'requested' | 'stopped' | 'superseded';
+  updateId: string;
+  revision: number;
+  committedAt: number;
+}
+
+export interface AgentGraphStoppedTargetView extends AgentGraphStoppedTarget {
+  updateId: string;
+  revision: number;
+  committedAt: number;
+}
+
+export interface AgentGraphScheduleFinishView extends AgentGraphScheduleFinish {
+  updateId: string;
+  revision: number;
+  committedAt: number;
+}
+
+export interface AgentGraphScheduleProjection {
+  schemaVersion: 1;
+  graphId: string;
+  revision: number;
+  updateCount: number;
+  closed: boolean;
+  work: AgentGraphScheduleWorkView[];
+  stoppedTargets: AgentGraphStoppedTargetView[];
+  finish?: AgentGraphScheduleFinishView;
+}
+
+export interface AgentGraphToolScheduleView {
+  closed: boolean;
+  work: Array<
+    Omit<AgentGraphScheduleWorkView, 'updateId' | 'revision'> & {
+      instructionTruncated: boolean;
+    }
+  >;
+  stoppedTargets: Array<Omit<AgentGraphStoppedTargetView, 'updateId' | 'revision'>>;
+  finish?: Omit<AgentGraphScheduleFinishView, 'updateId' | 'revision'>;
+  omittedTerminalWorkCount: number;
+  omittedStoppedTargetCount: number;
+}
+
+export interface AgentGraphToolRuntimeOperatorView {
+  operatorId: string;
+  status: 'not_started' | AgentGraphActivationStatus;
+  currentActivationId?: string;
+  lastEventTime?: number;
+}
+
+export interface AgentGraphToolReadinessView {
+  operatorId: string;
+  policyKind: 'map' | 'all_settled';
+  status: 'waiting' | 'runnable';
+  waitingFor: AgentGraphReadinessWait[];
+}
+
+export interface AgentGraphToolActivityView {
+  recordId: string;
+  operatorId: string;
+  activationId: string;
+  eventTime: number;
+  facets: AgentGraphRecordFacet[];
+  signals: AgentGraphSupervisorSignal[];
+}
+
+export interface AgentGraphToolRuntimeView {
+  operators: AgentGraphToolRuntimeOperatorView[];
+  readiness: AgentGraphToolReadinessView[];
+  recentActivity: AgentGraphToolActivityView[];
+  omittedTerminalOperatorCount: number;
+  omittedActivityCount: number;
+}
+
+export type ViewAgentGraphToolResult = {
+  kind: 'agent_graph_view';
+  schedule: AgentGraphToolScheduleView;
+  runtime: AgentGraphToolRuntimeView;
+  nextCursor?: string;
+};
+
+export type UpdateAgentGraphToolResult = {
+  kind: 'agent_graph_updated';
+  schedule: AgentGraphToolScheduleView;
+  runtime: AgentGraphToolRuntimeView;
+  nextCursor?: string;
+};
+
+export interface BuildAgentGraphSupervisorToolsInput {
+  graphId: string;
+  scheduleStore: AgentGraphScheduleStore;
+  observeGraph(): Promise<AgentGraphSupervisorObservation>;
+}
+
+/**
+ * Builds the compact main-agent control surface for one host-bound graph.
+ *
+ * The update tool durably records schedule intent. A graph reconciler remains
+ * responsible for turning those records into runtime start/stop actions.
+ */
+export function buildAgentGraphSupervisorTools(
+  input: BuildAgentGraphSupervisorToolsInput,
+): [
+  MakaTool<ViewAgentGraphToolInput, ViewAgentGraphToolResult>,
+  MakaTool<UpdateAgentGraphToolInput, UpdateAgentGraphToolResult>,
+] {
+  const graphId = requireIdentity(input.graphId, 'graph id');
+  const viewTool: MakaTool<ViewAgentGraphToolInput, ViewAgentGraphToolResult> = {
+    name: VIEW_AGENT_GRAPH_TOOL_NAME,
+    displayName: 'View agent graph',
+    description:
+      'Inspect the current durable schedule, runtime status, readiness, and recent activity for the agent graph you supervise.',
+    parameters: viewSchema,
+    permissionRequired: false,
+    categoryHint: 'read',
+    recoveryMode: 'replay_safe',
+    impl: async (toolInput) => {
+      const view = await readToolGraphView(
+        input.scheduleStore,
+        graphId,
+        input.observeGraph,
+        toolInput.cursor,
+      );
+      return {
+        kind: 'agent_graph_view',
+        ...view,
+      };
+    },
+  };
+  const updateTool: MakaTool<UpdateAgentGraphToolInput, UpdateAgentGraphToolResult> = {
+    name: UPDATE_AGENT_GRAPH_TOOL_NAME,
+    displayName: 'Update agent graph',
+    description:
+      'Adjust the agent graph you supervise. Add or replace work, stop work that is no longer useful, or finish with selected results. The update is durable and idempotent.',
+    parameters: updateSchema,
+    permissionRequired: false,
+    categoryHint: 'subagent',
+    recoveryMode: 'idempotent',
+    impl: async (toolInput, context) => {
+      const request = compileAgentGraphScheduleUpdate({
+        graphId,
+        input: toolInput,
+        context,
+      });
+      if (request.finish) {
+        assertFinishResultsCommitted(graphId, request.finish.resultIds, await input.observeGraph());
+      }
+      await input.scheduleStore.commitAgentGraphScheduleUpdate(request);
+      const view = await readToolGraphView(
+        input.scheduleStore,
+        graphId,
+        input.observeGraph,
+        undefined,
+      );
+      return {
+        kind: 'agent_graph_updated',
+        ...view,
+      };
+    },
+  };
+  return [viewTool, updateTool];
+}
+
+export function compileAgentGraphScheduleUpdate(input: {
+  graphId: string;
+  input: UpdateAgentGraphToolInput;
+  context: Pick<MakaToolContext, 'sessionId' | 'runId' | 'turnId' | 'toolCallId'>;
+}): AgentGraphScheduleUpdateRequest {
+  const graphId = requireIdentity(input.graphId, 'graph id');
+  const parsed = updateSchema.parse(input.input);
+  const runId = requireIdentity(input.context.runId, 'source run id');
+  const source = {
+    sessionId: requireIdentity(input.context.sessionId, 'source session id'),
+    runId,
+    turnId: requireIdentity(input.context.turnId, 'source turn id'),
+    toolCallId: requireIdentity(input.context.toolCallId, 'source tool call id'),
+  };
+  const addWorkInput = parsed.add_work ?? [];
+  const stopInput = parsed.stop ?? [];
+  const updateHash = stableHash({
+    schemaVersion: AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
+    graphId,
+    source,
+  });
+  const updateId = `graph_update_${updateHash.slice('sha256:'.length, 'sha256:'.length + 32)}`;
+  const addWork = addWorkInput.map((work, index): AgentGraphScheduledWork => {
+    const target = normalizeWorkTarget(work);
+    const inputIds = normalizeUniqueIdentities(work.input_ids, 'input id');
+    const workHash = stableHash({
+      schemaVersion: AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
+      updateId,
+      index,
+    });
+    return {
+      workId: `graph_work_${workHash.slice('sha256:'.length, 'sha256:'.length + 32)}`,
+      target,
+      instruction: requireText(
+        work.instruction,
+        AGENT_GRAPH_SCHEDULE_MAX_INSTRUCTION_CHARS,
+        'instruction',
+      ),
+      inputIds,
+      ...(work.replaces
+        ? { replaces: requireIdentity(work.replaces, 'replacement target id') }
+        : {}),
+    };
+  });
+  const stop = stopInput
+    .map(
+      (entry): AgentGraphStoppedTarget => ({
+        targetId: requireIdentity(entry.target_id, 'stop target id'),
+        reason: requireText(entry.reason, AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS, 'stop reason'),
+      }),
+    )
+    .sort((a, b) => compareIdentity(a.targetId, b.targetId));
+  ensureUnique(
+    stop.map((entry) => entry.targetId),
+    'stop target id',
+  );
+  const finish = parsed.finish
+    ? {
+        resultIds: normalizeUniqueIdentities(parsed.finish.result_ids, 'finish result id'),
+        reason: requireText(
+          parsed.finish.reason,
+          AGENT_GRAPH_SCHEDULE_MAX_REASON_CHARS,
+          'finish reason',
+        ),
+      }
+    : undefined;
+  const semantic = {
+    schemaVersion: AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
+    updateId,
+    graphId,
+    source,
+    addWork,
+    stop,
+    ...(finish ? { finish } : {}),
+  };
+  return {
+    ...semantic,
+    updateFingerprint: stableHash(semantic),
+  };
+}
+
+export function projectAgentGraphSchedule(
+  graphId: string,
+  values: readonly AgentGraphScheduleUpdate[],
+): AgentGraphScheduleProjection {
+  const expectedGraphId = requireIdentity(graphId, 'graph id');
+  const updates = values
+    .map(decodeAgentGraphScheduleUpdate)
+    .sort((a, b) => a.revision - b.revision || compareIdentity(a.updateId, b.updateId));
+  const work: AgentGraphScheduleWorkView[] = [];
+  const stoppedTargets = new Map<string, AgentGraphStoppedTargetView>();
+  const workIds = new Set<string>();
+  const supersededTargetIds = new Set<string>();
+  let finish: AgentGraphScheduleFinishView | undefined;
+  updates.forEach((update, index) => {
+    if (update.graphId !== expectedGraphId) {
+      throw new Error(
+        `Agent graph schedule update ${update.updateId} belongs to ${update.graphId}, expected ${expectedGraphId}`,
+      );
+    }
+    if (update.revision !== index + 1) {
+      throw new Error(
+        `Agent graph schedule ${expectedGraphId} has non-contiguous revision ${update.revision}`,
+      );
+    }
+    if (finish) {
+      throw new Error(`Agent graph schedule ${expectedGraphId} has updates after finish`);
+    }
+    for (const item of update.addWork) {
+      if (workIds.has(item.workId)) {
+        throw new Error(`Agent graph schedule repeats work ${item.workId}`);
+      }
+      workIds.add(item.workId);
+      if (item.replaces) supersededTargetIds.add(item.replaces);
+      work.push({
+        ...item,
+        target: { ...item.target },
+        inputIds: [...item.inputIds],
+        status: 'requested',
+        updateId: update.updateId,
+        revision: update.revision,
+        committedAt: update.committedAt,
+      });
+    }
+    for (const stopped of update.stop) {
+      stoppedTargets.set(stopped.targetId, {
+        ...stopped,
+        updateId: update.updateId,
+        revision: update.revision,
+        committedAt: update.committedAt,
+      });
+    }
+    if (update.finish) {
+      finish = {
+        resultIds: [...update.finish.resultIds],
+        reason: update.finish.reason,
+        updateId: update.updateId,
+        revision: update.revision,
+        committedAt: update.committedAt,
+      };
+    }
+  });
+  for (const item of work) {
+    if (stoppedTargets.has(item.workId)) item.status = 'stopped';
+    else if (supersededTargetIds.has(item.workId)) item.status = 'superseded';
+  }
+  return {
+    schemaVersion: 1,
+    graphId: expectedGraphId,
+    revision: updates.at(-1)?.revision ?? 0,
+    updateCount: updates.length,
+    closed: finish !== undefined,
+    work,
+    stoppedTargets: [...stoppedTargets.values()].sort(
+      (a, b) => a.revision - b.revision || compareIdentity(a.targetId, b.targetId),
+    ),
+    ...(finish ? { finish } : {}),
+  };
+}
+
+function agentGraphToolScheduleView(
+  projection: AgentGraphScheduleProjection,
+  livePage: AgentGraphLiveStatePage,
+): AgentGraphToolScheduleView {
+  const liveWork = projection.work.filter(
+    (item) => item.status === 'requested' && livePage.workIds.has(item.workId),
+  );
+  const terminalWork = projection.work.filter((item) => item.status !== 'requested');
+  const visibleTerminalWork = terminalWork.slice(-TOOL_VIEW_MAX_TERMINAL_WORK);
+  const work = [...liveWork, ...visibleTerminalWork].map((item) => {
+    const instructionTruncated = item.instruction.length > TOOL_VIEW_MAX_INSTRUCTION_CHARS;
+    return {
+      ...item,
+      target: { ...item.target },
+      inputIds: [...item.inputIds],
+      instruction: instructionTruncated
+        ? `${item.instruction.slice(0, TOOL_VIEW_MAX_INSTRUCTION_CHARS)}…`
+        : item.instruction,
+      instructionTruncated,
+    };
+  });
+  const stoppedTargets = projection.stoppedTargets.slice(-TOOL_VIEW_MAX_STOPPED_TARGETS);
+  return {
+    closed: projection.closed,
+    work: work.map(({ updateId: _updateId, revision: _revision, ...entry }) => entry),
+    stoppedTargets: stoppedTargets.map(
+      ({ updateId: _updateId, revision: _revision, ...entry }) => ({ ...entry }),
+    ),
+    omittedTerminalWorkCount: terminalWork.length - visibleTerminalWork.length,
+    omittedStoppedTargetCount: projection.stoppedTargets.length - stoppedTargets.length,
+    ...(projection.finish
+      ? {
+          finish: (({ updateId: _updateId, revision: _revision, ...entry }) => ({
+            ...entry,
+            resultIds: [...entry.resultIds],
+          }))({
+            ...projection.finish,
+            resultIds: [...projection.finish.resultIds],
+          }),
+        }
+      : {}),
+  };
+}
+
+async function readToolGraphView(
+  store: AgentGraphScheduleStore,
+  graphId: string,
+  observeGraph: () => Promise<AgentGraphSupervisorObservation>,
+  cursor: string | undefined,
+): Promise<{
+  schedule: AgentGraphToolScheduleView;
+  runtime: AgentGraphToolRuntimeView;
+  nextCursor?: string;
+}> {
+  const [updates, observation] = await Promise.all([
+    store.listAgentGraphScheduleUpdates(graphId),
+    observeGraph(),
+  ]);
+  assertGraphObservation(graphId, observation);
+  const projection = projectAgentGraphSchedule(graphId, updates);
+  const livePage = paginateAgentGraphLiveState(projection, observation, cursor);
+  return {
+    schedule: agentGraphToolScheduleView(projection, livePage),
+    runtime: agentGraphToolRuntimeView(observation, livePage),
+    ...(livePage.nextCursor ? { nextCursor: livePage.nextCursor } : {}),
+  };
+}
+
+function agentGraphToolRuntimeView(
+  observation: AgentGraphSupervisorObservation,
+  livePage: AgentGraphLiveStatePage,
+): AgentGraphToolRuntimeView {
+  const operatorViews = observation.projection.operators.map(
+    (binding): AgentGraphToolRuntimeOperatorView => {
+      const state = observation.projection.state.operators[binding.operatorId];
+      return {
+        operatorId: binding.operatorId,
+        status: state?.status ?? 'not_started',
+        ...(state
+          ? {
+              currentActivationId: state.currentActivationId,
+              lastEventTime: state.activations[state.currentActivationId]?.lastEventTime,
+            }
+          : {}),
+      };
+    },
+  );
+  const liveOperators = operatorViews.filter(
+    (entry) =>
+      (entry.status === 'not_started' || entry.status === 'running') &&
+      livePage.operatorIds.has(entry.operatorId),
+  );
+  const terminalOperators = operatorViews.filter(
+    (entry) => entry.status !== 'not_started' && entry.status !== 'running',
+  );
+  const visibleTerminalOperators = terminalOperators.slice(-TOOL_VIEW_MAX_TERMINAL_OPERATORS);
+  const readinessEntries = observation.readiness.supervisorView.filter((entry) =>
+    livePage.readinessIds.has(entry.readinessId),
+  );
+  const readiness = readinessEntries.map((entry) => ({
+    operatorId: entry.operatorId,
+    policyKind: entry.policyKind,
+    status: entry.status,
+    waitingFor: entry.waitingFor.map(cloneReadinessWait),
+  }));
+  const activity = observation.projection.supervisorMetaStream;
+  const recentActivity = activity.slice(-TOOL_VIEW_MAX_ACTIVITY).map((entry) => ({
+    recordId: entry.recordId,
+    operatorId: entry.operatorId,
+    activationId: entry.activationId,
+    eventTime: entry.eventTime,
+    facets: [...entry.facets],
+    signals: entry.signals.map((signal) => ({ ...signal })),
+  }));
+  return {
+    operators: [...liveOperators, ...visibleTerminalOperators],
+    readiness,
+    recentActivity,
+    omittedTerminalOperatorCount: terminalOperators.length - visibleTerminalOperators.length,
+    omittedActivityCount: activity.length - recentActivity.length,
+  };
+}
+
+interface AgentGraphLiveStatePage {
+  workIds: Set<string>;
+  operatorIds: Set<string>;
+  readinessIds: Set<string>;
+  nextCursor?: string;
+}
+
+type AgentGraphLiveStateEntry =
+  | {
+      kind: 'work';
+      id: string;
+      cursor: string;
+    }
+  | {
+      kind: 'operator';
+      id: string;
+      cursor: string;
+    }
+  | {
+      kind: 'readiness';
+      id: string;
+      cursor: string;
+    };
+
+function paginateAgentGraphLiveState(
+  projection: AgentGraphScheduleProjection,
+  observation: AgentGraphSupervisorObservation,
+  cursor: string | undefined,
+): AgentGraphLiveStatePage {
+  const entries: AgentGraphLiveStateEntry[] = [
+    ...projection.work
+      .filter((item) => item.status === 'requested')
+      .map((item) => ({
+        kind: 'work' as const,
+        id: item.workId,
+        cursor: `work:${item.workId}`,
+      })),
+    ...observation.projection.operators
+      .filter((binding) => {
+        const status = observation.projection.state.operators[binding.operatorId]?.status;
+        return status === undefined || status === 'running';
+      })
+      .map((binding) => ({
+        kind: 'operator' as const,
+        id: binding.operatorId,
+        cursor: `operator:${binding.operatorId}`,
+      })),
+    ...observation.readiness.supervisorView.map((entry) => ({
+      kind: 'readiness' as const,
+      id: entry.readinessId,
+      cursor: `readiness:${entry.readinessId}`,
+    })),
+  ];
+  ensureUnique(
+    entries.map((entry) => entry.cursor),
+    'live-state cursor',
+  );
+  const cursorIndex = cursor ? entries.findIndex((entry) => entry.cursor === cursor) : -1;
+  if (cursor && cursorIndex < 0) {
+    throw new Error('Agent graph view cursor is stale or invalid');
+  }
+  const start = cursorIndex + 1;
+  const visible = entries.slice(start, start + TOOL_VIEW_MAX_LIVE_STATE);
+  const workIds = new Set<string>();
+  const operatorIds = new Set<string>();
+  const readinessIds = new Set<string>();
+  for (const entry of visible) {
+    if (entry.kind === 'work') workIds.add(entry.id);
+    else if (entry.kind === 'operator') operatorIds.add(entry.id);
+    else readinessIds.add(entry.id);
+  }
+  const hasMore = start + visible.length < entries.length;
+  return {
+    workIds,
+    operatorIds,
+    readinessIds,
+    ...(hasMore && visible.length > 0 ? { nextCursor: visible[visible.length - 1]!.cursor } : {}),
+  };
+}
+
+function assertFinishResultsCommitted(
+  graphId: string,
+  resultIds: readonly string[],
+  observation: AgentGraphSupervisorObservation,
+): void {
+  assertGraphObservation(graphId, observation);
+  const committedRecordIds = new Set(
+    observation.projection.records
+      .filter((record) => record.graphId === graphId)
+      .map((record) => record.recordId),
+  );
+  const missing = resultIds.filter((resultId) => !committedRecordIds.has(resultId));
+  if (missing.length > 0) {
+    throw new Error(
+      `Agent graph finish result ids are not committed graph records: ${missing.join(', ')}`,
+    );
+  }
+}
+
+function assertGraphObservation(
+  graphId: string,
+  observation: AgentGraphSupervisorObservation,
+): void {
+  if (
+    observation.projection.graphId !== graphId ||
+    observation.readiness.graphId !== graphId ||
+    observation.readiness.trace.graphId !== graphId
+  ) {
+    throw new Error('Agent graph supervisor observation belongs to another graph');
+  }
+}
+
+function normalizeWorkTarget(input: {
+  agent_id?: string;
+  operator_id?: string;
+}): AgentGraphWorkTarget {
+  const count = (input.agent_id ? 1 : 0) + (input.operator_id ? 1 : 0);
+  if (count !== 1) throw new Error('Exactly one of agent_id or operator_id is required');
+  return input.agent_id
+    ? { kind: 'agent', agentId: requireIdentity(input.agent_id, 'agent id') }
+    : { kind: 'operator', operatorId: requireIdentity(input.operator_id, 'operator id') };
+}
+
+function normalizeUniqueIdentities(values: readonly string[] | undefined, name: string): string[] {
+  if (!values) return [];
+  const normalized = values.map((value) => requireIdentity(value, name)).sort(compareIdentity);
+  ensureUnique(normalized, name);
+  return normalized;
+}
+
+function cloneReadinessWait(wait: AgentGraphReadinessWait): AgentGraphReadinessWait {
+  return wait.kind === 'input_route'
+    ? { ...wait, upstreamOperatorIds: [...wait.upstreamOperatorIds] }
+    : { ...wait };
+}
+
+function ensureUnique(values: readonly string[], name: string): void {
+  if (new Set(values).size !== values.length) {
+    throw new Error(`Agent graph schedule repeats ${name}`);
+  }
+}
+
+function requireIdentity(value: string | undefined, name: string): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > 256 ||
+    value.trim() !== value ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new Error(`Invalid agent graph ${name}`);
+  }
+  return value;
+}
+
+function requireText(value: string, maxChars: number, name: string): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > maxChars ||
+    value.trim() !== value ||
+    /[\u0000\u0008\u000b\u000c\u000e-\u001f\u007f]/.test(value)
+  ) {
+    throw new Error(`Invalid agent graph ${name}`);
+  }
+  return value;
+}
+
+function compareIdentity(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function addDuplicateIssue(
+  ctx: z.RefinementCtx,
+  values: readonly string[],
+  path: Array<string | number>,
+): void {
+  if (new Set(values).size === values.length) return;
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    path,
+    message: 'Duplicate identities are not allowed',
+  });
+}

--- a/packages/storage/src/__tests__/agent-graph-schedule-updates.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-schedule-updates.test.ts
@@ -1,0 +1,165 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import {
+  AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
+  type AgentGraphScheduleUpdateRequest,
+} from '@maka/core/agent-graph-schedule';
+import {
+  AgentGraphScheduleUpdateConflictError,
+  createSqliteSessionMetadataStore,
+} from '../sqlite-session-metadata-store.js';
+
+describe('SQLite agent graph schedule updates', () => {
+  test('commits ordered idempotent updates and closes the schedule atomically', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(40) });
+    try {
+      const first = await store.commitAgentGraphScheduleUpdate(request());
+      const retry = await store.commitAgentGraphScheduleUpdate(request());
+      const finish = await store.commitAgentGraphScheduleUpdate(
+        request({
+          updateId: `graph_update_${'d'.repeat(32)}`,
+          updateFingerprint: `sha256:${'e'.repeat(64)}`,
+          source: {
+            sessionId: 'session-main',
+            runId: 'run-main',
+            turnId: 'turn-main',
+            toolCallId: 'tool-finish',
+          },
+          addWork: [],
+          stop: [{ targetId: first.update.addWork[0]!.workId, reason: 'evidence is sufficient' }],
+          finish: { resultIds: ['result-1'], reason: 'accept the verified result' },
+        }),
+      );
+
+      assert.equal(first.created, true);
+      assert.equal(retry.created, false);
+      assert.deepEqual(retry.update, first.update);
+      assert.equal(first.update.revision, 1);
+      assert.equal(finish.update.revision, 2);
+      assert.deepEqual(await store.listAgentGraphScheduleUpdates('graph-1'), [
+        first.update,
+        finish.update,
+      ]);
+      await assert.rejects(
+        store.commitAgentGraphScheduleUpdate(
+          request({
+            updateId: `graph_update_${'f'.repeat(32)}`,
+            updateFingerprint: `sha256:${'1'.repeat(64)}`,
+            source: {
+              sessionId: 'session-main',
+              runId: 'run-main',
+              turnId: 'turn-later',
+              toolCallId: 'tool-later',
+            },
+          }),
+        ),
+        /already finished/,
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  test('rejects tool-call and update identities reused for different work', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    try {
+      await store.commitAgentGraphScheduleUpdate(request());
+      await assert.rejects(
+        store.commitAgentGraphScheduleUpdate(
+          request({
+            updateFingerprint: `sha256:${'9'.repeat(64)}`,
+            addWork: [
+              {
+                ...request().addWork[0]!,
+                instruction: 'Perform different work.',
+              },
+            ],
+          }),
+        ),
+        AgentGraphScheduleUpdateConflictError,
+      );
+      await assert.rejects(
+        store.commitAgentGraphScheduleUpdate(
+          request({
+            updateId: `graph_update_${'7'.repeat(32)}`,
+            updateFingerprint: `sha256:${'8'.repeat(64)}`,
+          }),
+        ),
+        AgentGraphScheduleUpdateConflictError,
+      );
+      assert.equal((await store.listAgentGraphScheduleUpdates('graph-1')).length, 1);
+    } finally {
+      store.close();
+    }
+  });
+
+  test('rolls back an update when the transaction fails before commit', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', {
+      failpoint(point) {
+        if (point === 'after_agent_graph_schedule_update_write') throw new Error('crash');
+      },
+    });
+    try {
+      await assert.rejects(store.commitAgentGraphScheduleUpdate(request()), /crash/);
+      assert.deepEqual(await store.listAgentGraphScheduleUpdates('graph-1'), []);
+    } finally {
+      store.close();
+    }
+  });
+
+  test('replays the same schedule after reopening the workspace database', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-agent-graph-schedule-'));
+    const path = join(root, 'state.sqlite');
+    try {
+      const store = createSqliteSessionMetadataStore(path, { now: () => 77 });
+      const committed = await store.commitAgentGraphScheduleUpdate(request());
+      store.close();
+
+      const reopened = createSqliteSessionMetadataStore(path);
+      try {
+        assert.deepEqual(await reopened.listAgentGraphScheduleUpdates('graph-1'), [
+          committed.update,
+        ]);
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});
+
+function request(
+  overrides: Partial<AgentGraphScheduleUpdateRequest> = {},
+): AgentGraphScheduleUpdateRequest {
+  return {
+    schemaVersion: AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
+    updateId: `graph_update_${'a'.repeat(32)}`,
+    updateFingerprint: `sha256:${'b'.repeat(64)}`,
+    graphId: 'graph-1',
+    source: {
+      sessionId: 'session-main',
+      runId: 'run-main',
+      turnId: 'turn-main',
+      toolCallId: 'tool-main',
+    },
+    addWork: [
+      {
+        workId: `graph_work_${'c'.repeat(32)}`,
+        target: { kind: 'agent', agentId: 'fact-checker' },
+        instruction: 'Verify the selected evidence.',
+        inputIds: ['result-1'],
+      },
+    ],
+    stop: [],
+    ...overrides,
+  };
+}
+
+function nextNumber(start: number): () => number {
+  let value = start;
+  return () => value++;
+}

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -19,7 +19,7 @@ describe('SqliteSessionMetadataStore', () => {
     try {
       const store = createSqliteSessionMetadataStore(path, { now: () => 100 });
       const header = fullHeader();
-      assert.equal(store.schemaVersion(), 6);
+      assert.equal(store.schemaVersion(), 7);
       assert.equal(store.journalMode(), 'wal');
       assert.deepEqual(await store.create(header), {
         header,
@@ -30,7 +30,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const reopened = createSqliteSessionMetadataStore(path, { now: () => 200 });
       try {
-        assert.equal(reopened.schemaVersion(), 6);
+        assert.equal(reopened.schemaVersion(), 7);
         assert.deepEqual(await reopened.read(header.id), {
           header,
           metadataVersion: 1,
@@ -51,7 +51,7 @@ describe('SqliteSessionMetadataStore', () => {
     const metadata = createSqliteSessionMetadataStore(path);
     try {
       assert.equal(runtime.schemaVersion(), 4);
-      assert.equal(metadata.schemaVersion(), 6);
+      assert.equal(metadata.schemaVersion(), 7);
       await metadata.create(fullHeader());
       await runtime.appendRuntimeEvent('session-1', 'run-1', {
         id: 'event-1',
@@ -159,7 +159,7 @@ describe('SqliteSessionMetadataStore', () => {
 
     const store = createSqliteSessionMetadataStore(path);
     try {
-      assert.equal(store.schemaVersion(), 6);
+      assert.equal(store.schemaVersion(), 7);
       assert.deepEqual(
         (
           await store.list({
@@ -492,6 +492,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const v4 = new DatabaseSync(path);
       v4.exec(`
+        DROP TABLE agent_graph_schedule_updates;
         DROP TABLE agent_graph_intent_claims;
         DROP TABLE subagent_spawns;
         CREATE UNIQUE INDEX session_metadata_by_subagent_spawn
@@ -513,7 +514,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const migrated = createSqliteSessionMetadataStore(path);
       try {
-        assert.equal(migrated.schemaVersion(), 6);
+        assert.equal(migrated.schemaVersion(), 7);
         assert.equal(await migrated.remove(child.id), true);
         await assert.rejects(
           () => migrated.createSubagent({ ...child, id: 'retry-after-migration' }),

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 6;
+export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 7;
 
 const MIGRATIONS: ReadonlyMap<number, string> = new Map([
   [
@@ -204,6 +204,30 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
 
     CREATE INDEX agent_graph_intent_claims_by_graph
       ON agent_graph_intent_claims(graph_id, claimed_at, intent_id);
+  `,
+  ],
+  [
+    7,
+    `
+    CREATE TABLE agent_graph_schedule_updates (
+      graph_id TEXT NOT NULL,
+      revision INTEGER NOT NULL CHECK (revision > 0),
+      update_id TEXT NOT NULL UNIQUE,
+      schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+      update_fingerprint TEXT NOT NULL,
+      source_session_id TEXT NOT NULL,
+      source_run_id TEXT NOT NULL,
+      source_turn_id TEXT NOT NULL,
+      source_tool_call_id TEXT NOT NULL,
+      closes_graph INTEGER NOT NULL CHECK (closes_graph IN (0, 1)),
+      payload_json TEXT NOT NULL,
+      committed_at INTEGER NOT NULL CHECK (committed_at >= 0),
+      PRIMARY KEY(graph_id, revision),
+      UNIQUE(source_session_id, source_run_id, source_tool_call_id)
+    );
+
+    CREATE INDEX agent_graph_schedule_updates_by_graph
+      ON agent_graph_schedule_updates(graph_id, committed_at, update_id);
   `,
   ],
 ]);

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -4,11 +4,16 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { isDeepStrictEqual } from 'node:util';
 import type { DatabaseSync } from 'node:sqlite';
 import {
+  assertAgentGraphScheduleUpdateRequest,
   assertAgentGraphIntentClaimRequest,
+  decodeAgentGraphScheduleUpdate,
   decodeAgentGraphIntentClaim,
   isSubagentSessionParent,
   isSubagentSessionRuntime,
   isSubagentSessionSpawn,
+  type AgentGraphScheduleUpdate,
+  type AgentGraphScheduleUpdateRequest,
+  type AgentGraphScheduleUpdateResult,
   type AgentGraphIntentClaim,
   type AgentGraphIntentClaimRequest,
   type AgentGraphIntentClaimResult,
@@ -50,7 +55,8 @@ export type SqliteSessionMetadataStoreFailpoint =
   | 'after_session_row_write'
   | 'after_session_labels_write'
   | 'after_session_import_marker_write'
-  | 'after_agent_graph_intent_claim_write';
+  | 'after_agent_graph_intent_claim_write'
+  | 'after_agent_graph_schedule_update_write';
 
 export interface SqliteSessionMetadataStoreOptions {
   now?: () => number;
@@ -88,6 +94,10 @@ export class SessionMetadataConflictError extends Error {
 
 export class AgentGraphIntentClaimConflictError extends SessionMetadataConflictError {
   readonly name = 'AgentGraphIntentClaimConflictError';
+}
+
+export class AgentGraphScheduleUpdateConflictError extends SessionMetadataConflictError {
+  readonly name = 'AgentGraphScheduleUpdateConflictError';
 }
 
 export function createSqliteSessionMetadataStore(
@@ -360,6 +370,92 @@ export class SqliteSessionMetadataStore {
       `)
       .all(...(graphId === undefined ? [] : [graphId])) as unknown as AgentGraphIntentClaim[];
     return rows.map(decodeAgentGraphIntentClaim);
+  }
+
+  async commitAgentGraphScheduleUpdate(
+    request: AgentGraphScheduleUpdateRequest,
+  ): Promise<AgentGraphScheduleUpdateResult> {
+    this.assertOpen();
+    assertAgentGraphScheduleUpdateRequest(request);
+    return this.transaction(() => {
+      const existingById = this.readAgentGraphScheduleUpdateByIdSync(request.updateId);
+      if (existingById) return this.matchAgentGraphScheduleUpdate(existingById, request);
+      const existingBySource = this.readAgentGraphScheduleUpdateBySourceSync(request.source);
+      if (existingBySource) return this.matchAgentGraphScheduleUpdate(existingBySource, request);
+      if (this.hasClosedAgentGraphSchedule(request.graphId)) {
+        throw new AgentGraphScheduleUpdateConflictError(
+          'Agent graph schedule is already finished',
+        );
+      }
+      const revision = this.nextAgentGraphScheduleRevision(request.graphId);
+      const update: AgentGraphScheduleUpdate = {
+        ...request,
+        source: { ...request.source },
+        addWork: request.addWork.map((work) => ({
+          ...work,
+          target: { ...work.target },
+          inputIds: [...work.inputIds],
+        })),
+        stop: request.stop.map((stopped) => ({ ...stopped })),
+        ...(request.finish
+          ? {
+              finish: {
+                resultIds: [...request.finish.resultIds],
+                reason: request.finish.reason,
+              },
+            }
+          : {}),
+        revision,
+        committedAt: this.now(),
+      };
+      this.db
+        .prepare(`
+          INSERT INTO agent_graph_schedule_updates(
+            graph_id,
+            revision,
+            update_id,
+            schema_version,
+            update_fingerprint,
+            source_session_id,
+            source_run_id,
+            source_turn_id,
+            source_tool_call_id,
+            closes_graph,
+            payload_json,
+            committed_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `)
+        .run(
+          update.graphId,
+          update.revision,
+          update.updateId,
+          update.schemaVersion,
+          update.updateFingerprint,
+          update.source.sessionId,
+          update.source.runId,
+          update.source.turnId,
+          update.source.toolCallId,
+          booleanInteger(update.finish !== undefined),
+          JSON.stringify(update),
+          update.committedAt,
+        );
+      this.options.failpoint?.('after_agent_graph_schedule_update_write');
+      return { update: decodeAgentGraphScheduleUpdate(update), created: true };
+    });
+  }
+
+  async listAgentGraphScheduleUpdates(graphId: string): Promise<AgentGraphScheduleUpdate[]> {
+    this.assertOpen();
+    assertGraphLookupIdentity(graphId, 'id');
+    const rows = this.db
+      .prepare(`
+        SELECT payload_json AS payloadJson
+        FROM agent_graph_schedule_updates
+        WHERE graph_id = ?
+        ORDER BY revision ASC
+      `)
+      .all(graphId) as unknown as AgentGraphScheduleUpdateRow[];
+    return rows.map(decodeAgentGraphScheduleUpdateRow);
   }
 
   async update(
@@ -767,6 +863,76 @@ export class SqliteSessionMetadataStore {
     return row ? decodeAgentGraphIntentClaim(row) : undefined;
   }
 
+  private readAgentGraphScheduleUpdateByIdSync(
+    updateId: string,
+  ): AgentGraphScheduleUpdate | undefined {
+    const row = this.db
+      .prepare(`
+        SELECT payload_json AS payloadJson
+        FROM agent_graph_schedule_updates
+        WHERE update_id = ?
+      `)
+      .get(updateId) as AgentGraphScheduleUpdateRow | undefined;
+    return row ? decodeAgentGraphScheduleUpdateRow(row) : undefined;
+  }
+
+  private readAgentGraphScheduleUpdateBySourceSync(
+    source: AgentGraphScheduleUpdateRequest['source'],
+  ): AgentGraphScheduleUpdate | undefined {
+    const row = this.db
+      .prepare(`
+        SELECT payload_json AS payloadJson
+        FROM agent_graph_schedule_updates
+        WHERE source_session_id = ?
+          AND source_run_id = ?
+          AND source_tool_call_id = ?
+      `)
+      .get(source.sessionId, source.runId, source.toolCallId) as
+      | AgentGraphScheduleUpdateRow
+      | undefined;
+    return row ? decodeAgentGraphScheduleUpdateRow(row) : undefined;
+  }
+
+  private matchAgentGraphScheduleUpdate(
+    existing: AgentGraphScheduleUpdate,
+    request: AgentGraphScheduleUpdateRequest,
+  ): AgentGraphScheduleUpdateResult {
+    if (!isDeepStrictEqual(agentGraphScheduleUpdateRequest(existing), request)) {
+      throw new AgentGraphScheduleUpdateConflictError(
+        'Agent graph schedule update identity was reused for different work',
+      );
+    }
+    return { update: existing, created: false };
+  }
+
+  private hasClosedAgentGraphSchedule(graphId: string): boolean {
+    return (
+      this.db
+        .prepare(`
+          SELECT 1 AS found
+          FROM agent_graph_schedule_updates
+          WHERE graph_id = ? AND closes_graph = 1
+          LIMIT 1
+        `)
+        .get(graphId) !== undefined
+    );
+  }
+
+  private nextAgentGraphScheduleRevision(graphId: string): number {
+    const row = this.db
+      .prepare(`
+        SELECT COALESCE(MAX(revision), 0) AS revision
+        FROM agent_graph_schedule_updates
+        WHERE graph_id = ?
+      `)
+      .get(graphId) as { revision?: unknown } | undefined;
+    const revision = row?.revision;
+    if (typeof revision !== 'number' || !Number.isSafeInteger(revision) || revision < 0) {
+      throw new Error(`Invalid agent graph schedule revision for ${graphId}`);
+    }
+    return revision + 1;
+  }
+
   private hasTombstone(sessionId: string): boolean {
     return (
       this.db
@@ -824,6 +990,23 @@ interface SubagentSpawnClaim {
   childSessionId: string;
   initialTurnId: string;
   initialRunId: string;
+}
+
+interface AgentGraphScheduleUpdateRow {
+  payloadJson: string;
+}
+
+function decodeAgentGraphScheduleUpdateRow(
+  row: AgentGraphScheduleUpdateRow,
+): AgentGraphScheduleUpdate {
+  return decodeAgentGraphScheduleUpdate(JSON.parse(row.payloadJson) as unknown);
+}
+
+function agentGraphScheduleUpdateRequest(
+  update: AgentGraphScheduleUpdate,
+): AgentGraphScheduleUpdateRequest {
+  const { revision: _revision, committedAt: _committedAt, ...request } = update;
+  return request;
 }
 
 function decodeRecord(row: SessionMetadataRow): SessionMetadataRecord {


### PR DESCRIPTION
## What changed

- add exactly two host-bound main-agent tools: `view_agent_graph` and `update_agent_graph`
- keep the model-facing update surface compact: `add_work`, `stop`, and `finish`
- derive graph identity and idempotency from trusted host/tool context instead of accepting them from the model
- validate every `finish.result_id` against trusted committed graph records before writing terminal closure
- persist normalized schedule updates in the workspace SQLite database with atomic revisions, tool-call idempotency, conflict detection, rollback safety, and terminal closure
- return a bounded view combining durable schedule state with committed runtime/readiness observations, without exposing graph IDs, revisions, or update IDs
- paginate live work/operator/readiness state with one opaque cursor while truncating only terminal history

## Why

The recoverable graph driver can advance runnable work, but the main agent still needs a small control surface for common supervision decisions. This adds that durable control boundary without turning graph internals into a large collection of low-level tools.

This PR records schedule intent only. A later reconciler will consume these records to perform the actual start/stop runtime actions.

## Validation

- `npm run typecheck`
- all 38 stream-graph admission/dispatch/projection/readiness/supervisor-tool/trace tests
- focused core/storage schedule and migration tests
- Biome lint on all changed TypeScript files

The full runtime suite previously showed two unrelated local macOS sandbox failures: the Homebrew `rg` executable cannot load its PCRE2 dylib inside the test sandbox, and the executable-root assertion consequently misses `/usr/local`. All graph-related runtime tests pass.
