### PR TITLE
fix(desktop): polish metric pages — Permissions and Health

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -211,6 +211,7 @@ export const test = base.extend<{
   staleSessionsWindow: Page;
   sessionWorkbarWindow: Page;
   botSettingsWindow: Page;
+  permissionSettingsWindow: Page;
   zhLocaleWindow: Page;
   enLocaleWindow: Page;
   localeSwitchWindow: Page;
@@ -303,6 +304,22 @@ export const test = base.extend<{
   botSettingsWindow: async ({}, use) => {
     await withE2eWindow(
       { seed: false, readinessSelector: '[aria-label="设置内容"]', e2eFixtureScenario: 'settings-bots', locale: 'zh' },
+      use,
+    );
+  },
+  // #1361: Permission Center with a typed OS-permission snapshot (see
+  // `main/permission-snapshot-e2e-fixture.ts`). The narrow-layout contract is
+  // about rows that carry grant buttons, which the host's real TCC state cannot
+  // guarantee — a granted dev machine renders none, and Linux CI reports most
+  // permissions as `unsupported`.
+  permissionSettingsWindow: async ({}, use) => {
+    await withE2eWindow(
+      {
+        seed: false,
+        readinessSelector: '.settingsOsPermissionRow',
+        e2eFixtureScenario: 'settings-permissions',
+        locale: 'zh',
+      },
       use,
     );
   },

--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -138,15 +138,45 @@ function summaryGeometry(summary: ReturnType<import('@playwright/test').Page['lo
   });
 }
 
-test('permission and health summary tiles stay readable at the window floor', async ({ window: page }) => {
+test('permission rows keep their text at the window floor', async ({ permissionSettingsWindow: page }) => {
   await page.setViewportSize({ width: 480, height: 900 });
-  const settings = await openSettings(page);
-
-  await settings.getByRole('button', { name: '权限与能力', exact: true }).click();
+  const settings = page.getByRole('main', { name: '设置内容' });
   await expect(settings.getByRole('heading', { name: '系统权限' })).toBeVisible();
 
+  // Prove the fixture renders the shape this contract is about before measuring
+  // it: only a requestable + openable permission draws BOTH grant buttons, and
+  // that is the row whose body the `auto` actions track used to squeeze to 0px.
+  // Reading the host's real TCC state would silently skip this — see
+  // `main/permission-snapshot-e2e-fixture.ts`.
+  const rows = settings.locator('.settingsOsPermissionRow');
+  await expect(rows).toHaveCount(5);
+  const twoButtonRows = await rows.evaluateAll((elements) =>
+    elements
+      .map((element, index) => ({
+        index,
+        buttons: element.querySelectorAll('.settingsOsPermissionActions button').length,
+      }))
+      .filter((row) => row.buttons === 2)
+      .map((row) => row.index),
+  );
+  expect(twoButtonRows.length).toBeGreaterThan(0);
+
+  await expect.poll(
+    () =>
+      rows.evaluateAll((elements) =>
+        elements.every((element) => {
+          const body = element.querySelector('.settingsOsPermissionBody');
+          if (!body) return false;
+          // Wide enough for the widest status Badge (~101px intrinsic and
+          // `whitespace-nowrap` by primitive contract), and not clipping.
+          return (
+            body.getBoundingClientRect().width >= 101 && body.scrollWidth <= body.clientWidth
+          );
+        }),
+      ),
+  ).toBe(true);
+
   const permissionSummary = settings.locator('.settingsPermissionSummary');
-  await expect(permissionSummary).toBeVisible();
   await expect.poll(async () => {
     const { trackCount, narrowestTrack, valuesContained } = await summaryGeometry(permissionSummary);
     return {
@@ -156,23 +186,16 @@ test('permission and health summary tiles stay readable at the window floor', as
     };
   }).toEqual({ foldedToFewTracks: true, tracksStayLegible: true, valuesContained: true });
 
-  // The row's `auto` actions track used to beat the body's `minmax(0, 1fr)` and
-  // squeeze it to literally 0px, so the rows that needed action were the ones
-  // that stopped saying which permission they were about.
-  const permissionBodies = settings.locator('.settingsOsPermissionBody');
-  await expect(permissionBodies.first()).toBeVisible();
-  await expect.poll(
-    () =>
-      permissionBodies.evaluateAll((elements) =>
-        elements.every((element) => element.getBoundingClientRect().width >= 96),
-      ),
-  ).toBe(true);
-
   await expect.poll(
     () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
   ).toBe(true);
+});
 
+test('health summary tiles stay readable at the window floor', async ({ window: page }) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  const settings = await openSettings(page);
   await settings.getByRole('button', { name: '健康', exact: true }).click();
+
   const healthSummary = settings.locator('.settingsHealthSummary');
   await expect(healthSummary).toBeVisible();
   await expect.poll(async () => {
@@ -213,10 +236,9 @@ test('permission and health summaries keep one track per metric when wide', asyn
   }).toEqual({ trackCount: 5, tileCount: 5 });
 });
 
-test('capability diagnostics stay contained when expanded at the window floor', async ({ window: page }) => {
+test('capability diagnostics stay contained when expanded at the window floor', async ({ permissionSettingsWindow: page }) => {
   await page.setViewportSize({ width: 480, height: 900 });
-  const settings = await openSettings(page);
-  await settings.getByRole('button', { name: '权限与能力', exact: true }).click();
+  const settings = page.getByRole('main', { name: '设置内容' });
 
   await settings.getByRole('button', { name: '展开详情' }).click();
   const capabilityList = settings.locator('.settingsCapabilityList');

--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -102,6 +102,148 @@ test('open gateway metric values stay contained for long addresses', async ({ wi
   ).toEqual({ contained: true, value: 'http://127.0.0.1:3939' });
 });
 
+/**
+ * #1361 — the Permissions and Health summary strips were fixed 4- and 5-track
+ * grids. At the sanitized window floor (`SAFE_MIN_WIDTH` = 480) that divided the
+ * narrow content column into ~30-40px slivers: the Health tiles ended up with a
+ * 4px content box, so even a single digit overflowed. Same family as the #1304
+ * Open Gateway overflow — #1335 taught StatTile to wrap, but a tile squeezed
+ * below one character wide has nothing left to wrap into.
+ *
+ * Locks the outcome rather than the pixels: tiles fold to fewer, readable
+ * tracks and nothing overflows horizontally.
+ */
+async function openSettings(page: import('@playwright/test').Page) {
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  await page.getByRole('button', { name: '设置' }).click();
+  return page.getByRole('main', { name: '设置内容' });
+}
+
+/** Real track widths, with `auto-fit`'s collapsed 0px tracks filtered out. */
+function summaryGeometry(summary: ReturnType<import('@playwright/test').Page['locator']>) {
+  return summary.evaluate((element) => {
+    const tracks = getComputedStyle(element)
+      .gridTemplateColumns.trim()
+      .split(/\s+/)
+      .map((track) => Number.parseFloat(track))
+      .filter((track) => track > 0);
+    return {
+      trackCount: tracks.length,
+      narrowestTrack: Math.round(Math.min(...tracks)),
+      tileCount: element.querySelectorAll('[data-slot="stat-tile"]').length,
+      valuesContained: Array.from(
+        element.querySelectorAll('[data-slot="stat-tile-value"]'),
+      ).every((value) => value.scrollWidth <= value.clientWidth),
+    };
+  });
+}
+
+test('permission and health summary tiles stay readable at the window floor', async ({ window: page }) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  const settings = await openSettings(page);
+
+  await settings.getByRole('button', { name: '权限与能力', exact: true }).click();
+  await expect(settings.getByRole('heading', { name: '系统权限' })).toBeVisible();
+
+  const permissionSummary = settings.locator('.settingsPermissionSummary');
+  await expect(permissionSummary).toBeVisible();
+  await expect.poll(async () => {
+    const { trackCount, narrowestTrack, valuesContained } = await summaryGeometry(permissionSummary);
+    return {
+      foldedToFewTracks: trackCount <= 2,
+      tracksStayLegible: narrowestTrack >= 96,
+      valuesContained,
+    };
+  }).toEqual({ foldedToFewTracks: true, tracksStayLegible: true, valuesContained: true });
+
+  // The row's `auto` actions track used to beat the body's `minmax(0, 1fr)` and
+  // squeeze it to literally 0px, so the rows that needed action were the ones
+  // that stopped saying which permission they were about.
+  const permissionBodies = settings.locator('.settingsOsPermissionBody');
+  await expect(permissionBodies.first()).toBeVisible();
+  await expect.poll(
+    () =>
+      permissionBodies.evaluateAll((elements) =>
+        elements.every((element) => element.getBoundingClientRect().width >= 96),
+      ),
+  ).toBe(true);
+
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+
+  await settings.getByRole('button', { name: '健康', exact: true }).click();
+  const healthSummary = settings.locator('.settingsHealthSummary');
+  await expect(healthSummary).toBeVisible();
+  await expect.poll(async () => {
+    const { trackCount, narrowestTrack, valuesContained } = await summaryGeometry(healthSummary);
+    return {
+      foldedToFewTracks: trackCount <= 2,
+      tracksStayLegible: narrowestTrack >= 80,
+      valuesContained,
+    };
+  }).toEqual({ foldedToFewTracks: true, tracksStayLegible: true, valuesContained: true });
+
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+});
+
+test('permission and health summaries keep one track per metric when wide', async ({ window: page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const settings = await openSettings(page);
+
+  // `auto-fit` must not cost the full-width layout: one track per metric.
+  await settings.getByRole('button', { name: '权限与能力', exact: true }).click();
+  await expect(settings.locator('.settingsPermissionSummary')).toBeVisible();
+  await expect.poll(async () => {
+    const { trackCount, tileCount } = await summaryGeometry(
+      settings.locator('.settingsPermissionSummary'),
+    );
+    return { trackCount, tileCount };
+  }).toEqual({ trackCount: 4, tileCount: 4 });
+
+  await settings.getByRole('button', { name: '健康', exact: true }).click();
+  await expect(settings.locator('.settingsHealthSummary')).toBeVisible();
+  await expect.poll(async () => {
+    const { trackCount, tileCount } = await summaryGeometry(
+      settings.locator('.settingsHealthSummary'),
+    );
+    return { trackCount, tileCount };
+  }).toEqual({ trackCount: 5, tileCount: 5 });
+});
+
+test('capability diagnostics stay contained when expanded at the window floor', async ({ window: page }) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  const settings = await openSettings(page);
+  await settings.getByRole('button', { name: '权限与能力', exact: true }).click();
+
+  await settings.getByRole('button', { name: '展开详情' }).click();
+  const capabilityList = settings.locator('.settingsCapabilityList');
+  await expect(capabilityList).toHaveAttribute('data-diagnostics-open', 'true');
+
+  // The layers grid used to hold a hard `minmax(150px, …)` floor, wider than the
+  // whole content column; the OfficeCLI guidance buttons then pushed the
+  // overflow up through the row. The install command keeps its own scroller.
+  await expect(settings.locator('.settingsCapabilityLayers').first()).toBeVisible();
+  await expect.poll(
+    () =>
+      capabilityList.evaluate((element) => ({
+        listContained: element.scrollWidth <= element.clientWidth,
+        rowsContained: Array.from(element.querySelectorAll('.settingsCapabilityRow')).every(
+          (row) => row.scrollWidth <= row.clientWidth,
+        ),
+        layersContained: Array.from(element.querySelectorAll('.settingsCapabilityLayers')).every(
+          (layers) => layers.scrollWidth <= layers.clientWidth,
+        ),
+      })),
+  ).toEqual({ listContained: true, rowsContained: true, layersContained: true });
+
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+});
+
 test('remote access opens a channel detail from the overview and returns', async ({ window: page }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();

--- a/apps/desktop/src/main/permission-snapshot-e2e-fixture.ts
+++ b/apps/desktop/src/main/permission-snapshot-e2e-fixture.ts
@@ -1,0 +1,87 @@
+import type { OsPermissionSnapshot, OsPermissionState, PermissionSnapshot } from '@maka/core';
+
+/**
+ * #1361: a typed OS-permission snapshot for the `settings-permissions` e2e
+ * fixture.
+ *
+ * The Permission Center's narrow-layout contract is about what happens when a
+ * row carries grant buttons: the row grid's `auto` actions track used to beat
+ * the body's `minmax(0, 1fr)` and squeeze it to 0px, hiding which permission
+ * the row was even about. Reading the host's real TCC state cannot exercise
+ * that — a fully-granted dev machine renders no buttons at all, and Linux CI
+ * reports most permissions as `unsupported`, so the assertion would pass
+ * without testing anything.
+ *
+ * This fixture pins the states that matter instead:
+ *   - `screen_recording` — `not_determined` + requestable + openable, the only
+ *     shape that renders BOTH buttons (the original squeeze);
+ *   - `microphone` — `denied`, one button;
+ *   - `accessibility` / `notifications` — `granted`, no buttons;
+ *   - `automation` — `unsupported`, which carries the widest status Badge
+ *     ("当前平台不支持", ~101px intrinsic and `whitespace-nowrap` by primitive
+ *     contract) and so sets the row's minimum readable width.
+ *
+ * Mirrors the Storybook fixture in `stories/settings/settings-pages.stories.tsx`
+ * so the story baseline and the E2E contract describe the same page.
+ *
+ * Production is untouched: this returns null unless the fixture scenario is
+ * active, and `registerPermissionsIpc` falls back to `buildPermissionSnapshot`.
+ */
+const FIXTURE_SCENARIO = 'settings-permissions';
+
+type OsPermissionId = keyof PermissionSnapshot['permissions'];
+
+function fixtureOsPermission(input: {
+  id: OsPermissionId;
+  status: OsPermissionState;
+  now: number;
+  reason?: string;
+  canRequest?: boolean;
+  canOpenSettings?: boolean;
+}): OsPermissionSnapshot {
+  return {
+    id: input.id,
+    status: input.status,
+    source: 'static',
+    checkedAt: input.now,
+    reason: input.reason,
+    canOpenSettings: input.canOpenSettings ?? input.status !== 'unsupported',
+    canRequest: input.canRequest ?? false,
+  };
+}
+
+export function permissionSnapshotE2eFixture(now: number): PermissionSnapshot | null {
+  if (process.env.MAKA_E2E_FIXTURE !== FIXTURE_SCENARIO) return null;
+  return {
+    checkedAt: now,
+    platform: 'darwin',
+    permissions: {
+      accessibility: fixtureOsPermission({ id: 'accessibility', status: 'granted', now }),
+      screen_recording: fixtureOsPermission({
+        id: 'screen_recording',
+        status: 'not_determined',
+        now,
+        canRequest: true,
+      }),
+      microphone: fixtureOsPermission({
+        id: 'microphone',
+        status: 'denied',
+        now,
+        reason: '用户在系统设置里拒绝了麦克风访问，语音输入与录音自检都会直接失败。',
+      }),
+      notifications: fixtureOsPermission({
+        id: 'notifications',
+        status: 'granted',
+        now,
+        canRequest: true,
+      }),
+      automation: fixtureOsPermission({
+        id: 'automation',
+        status: 'unsupported',
+        now,
+        reason: '当前系统版本不暴露自动化授权状态。',
+        canOpenSettings: false,
+      }),
+    },
+  };
+}

--- a/apps/desktop/src/main/permissions-ipc-main.ts
+++ b/apps/desktop/src/main/permissions-ipc-main.ts
@@ -10,7 +10,18 @@ import type { ConnectionStore, SettingsStore } from '@maka/storage';
 import type { createTelemetryRepo } from '@maka/storage';
 import { buildCapabilitySnapshotCollection, buildPermissionSnapshot } from './capability-snapshot.js';
 import { openSystemPermissionPane, requestPermissionAccess } from './permissions-actions.js';
+import { permissionSnapshotE2eFixture } from './permission-snapshot-e2e-fixture.js';
 import { probeOfficeCli } from './officecli-probe.js';
+
+/**
+ * #1361: the `settings-permissions` e2e fixture pins a typed OS-permission
+ * snapshot so the Permission Center's narrow-layout contract exercises rows
+ * that actually carry grant buttons. Returns the real host snapshot otherwise —
+ * see `permission-snapshot-e2e-fixture.ts`.
+ */
+function resolvePermissionSnapshot(now = Date.now()) {
+  return permissionSnapshotE2eFixture(now) ?? buildPermissionSnapshot(now);
+}
 
 type TelemetryRepo = ReturnType<typeof createTelemetryRepo>;
 type ComputerUseCapabilityInput = NonNullable<
@@ -28,7 +39,7 @@ export interface PermissionsIpcDeps {
 export function registerPermissionsIpc(deps: PermissionsIpcDeps): void {
   const { settingsStore, connectionStore, telemetryRepo, botRegistry, getComputerUseCapabilityInput } = deps;
 
-  ipcMain.handle('permissions:getSnapshot', () => buildPermissionSnapshot());
+  ipcMain.handle('permissions:getSnapshot', () => resolvePermissionSnapshot());
   ipcMain.handle('permissions:openSystemSettings', async (_event, permId: unknown) => {
     return openSystemPermissionPane(permId);
   });
@@ -36,7 +47,7 @@ export function registerPermissionsIpc(deps: PermissionsIpcDeps): void {
     return requestPermissionAccess(permId);
   });
   ipcMain.handle('capabilities:getSnapshot', async () => {
-    const permissions = buildPermissionSnapshot();
+    const permissions = resolvePermissionSnapshot();
     const settings = await settingsStore.get();
     const officeCliProbe = await probeOfficeCli({ now: permissions.checkedAt });
     return buildCapabilitySnapshotCollection({
@@ -50,7 +61,7 @@ export function registerPermissionsIpc(deps: PermissionsIpcDeps): void {
   });
   ipcMain.handle('health:getSnapshot', async () => {
     const now = Date.now();
-    const permissions = buildPermissionSnapshot(now);
+    const permissions = resolvePermissionSnapshot(now);
     const settings = await settingsStore.get();
     const officeCliProbe = await probeOfficeCli({ now });
     const capabilitySnapshot = buildCapabilitySnapshotCollection({

--- a/apps/desktop/src/renderer/styles/settings/health.css
+++ b/apps/desktop/src/renderer/styles/settings/health.css
@@ -27,7 +27,15 @@
     margin: 0;
     padding: 0;
     display: grid;
-    grid-template-columns: repeat(5, minmax(0, 1fr));
+    /* #1361: was `repeat(5, minmax(0, 1fr))`. Five hard tracks kept dividing
+       whatever width they were given, so at the 480px window floor each tile
+       collapsed to ~30px — 4px of content box after padding, which even a
+       single digit overflows. That is the sibling of the #1304 Open Gateway
+       overflow: #1335 taught StatTile to wrap its own text, but a tile squeezed
+       below one character wide has nothing left to wrap into. `auto-fit` still
+       yields five even tracks at full width (only five tiles exist, and 1fr
+       stretches them) while folding to two readable columns when narrow. */
+    grid-template-columns: repeat(auto-fit, minmax(80px, 1fr));
     gap: var(--space-2-5);
   }
 
@@ -74,6 +82,51 @@
 .settingsHealthSignalList > li + li {
     border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);
   }
+
+/* #1361: at the restored/sanitized 480px window floor (`SAFE_MIN_WIDTH`) the
+   fixed Settings navigation leaves a ~190px content column. The page header's
+   action cluster (read-only badge + last-read timestamp + refresh) never
+   shrinks, so on one row it starved the title/subtitle column down to a few
+   pixels. Stack it instead — same treatment the Remote Access page already
+   applies to its own section headers at this breakpoint. */
+@media (max-width: 620px) {
+  .settingsHealthPage > [data-slot="section-header"] {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  /* The cluster is `shrink-0` by primitive contract and holds three items
+     (read-only badge + nowrap timestamp + refresh), ~239px intrinsic. Stacking
+     the header is not enough on its own — the cluster itself has to wrap. */
+  .settingsHealthPage > [data-slot="section-header"] [data-slot="section-header-action"] {
+    flex-wrap: wrap;
+  }
+
+  /* Blocker badges carry a full sentence ("2 条健康信号会阻塞能力"), ~150px
+     intrinsic — wider than the whole content column at the 480px floor. The row
+     already wraps *between* badges, but that does not help when one badge alone
+     overflows, and `white-space` alone does nothing either: Badge is a
+     `shrink-0` inline-flex with a 22px min-width, so it always takes its
+     max-content width and never feels pressure to wrap. Let these two shrink,
+     then wrap internally.
+
+     Page-level on purpose — Badge's `whitespace-nowrap` + `shrink-0` default is
+     right for the short status labels it normally holds, so the primitive stays
+     as it is. The real oddity is this page putting a sentence in a pill; if the
+     blockers row is ever reworked, prefer a text row over a Badge and this
+     override can go. */
+  .settingsHealthBlockers [data-slot="badge"] {
+    flex-shrink: 1;
+    min-width: 0;
+    /* Badge pins its height (`h-4.5`/`h-5.5`) for single-line pills, so wrapping
+       without releasing that height clips the second line. */
+    height: auto;
+    min-height: 1.125rem; /* Badge's own `sm:h-4.5`, kept as the floor. */
+    padding-block: var(--space-0-5);
+    white-space: normal;
+  }
+}
 
 .settingsHealthFootnote {
     margin: 0;

--- a/apps/desktop/src/renderer/styles/settings/permission.css
+++ b/apps/desktop/src/renderer/styles/settings/permission.css
@@ -363,9 +363,23 @@
      border now lives as a left-edge accent stripe (see status rules
      below) so denied / granted / not_determined still read at a glance. */
 
+/* #1361: was `display: grid` with `36px minmax(0, 1fr) auto`. A grid's `auto`
+   track is sized to its content first, so the actions column won every width
+   contest against the body's `minmax(0, 1fr)` — at the 480px window floor the
+   two grant buttons took the whole column and squeezed the body to *0px*,
+   leaving the rows that need action ("等待授权" / "已拒绝") showing an icon and
+   two buttons but not which permission they were about.
+
+   Flex with `wrap` makes that structural rather than a guessed breakpoint: the
+   body declares the width it needs to stay readable, and when the actions no
+   longer fit beside it they move to their own line on their own. A breakpoint
+   would only relocate the problem — the first attempt at this used 620px and
+   still left 621-660px squeezed, because the threshold depends on the button
+   labels, not on the window. */
+
 .settingsOsPermissionRow {
-    display: grid;
-    grid-template-columns: 36px minmax(0, 1fr) auto;
+    display: flex;
+    flex-wrap: wrap;
     align-items: flex-start;
     gap: var(--space-3);
     padding: var(--space-4) var(--space-4);
@@ -373,10 +387,26 @@
     transition: background var(--duration-base) var(--ease-out-strong);
   }
 
+/* Grows to fill the row, but never narrower than the widest status Badge
+   ("当前平台不支持", ~101px intrinsic and `whitespace-nowrap` by primitive
+   contract) — that floor is what pushes the actions onto their own line.
+
+   The basis is that same floor rather than `auto`: with `auto` the body is
+   measured at its max-content prose width when deciding where to wrap, so a
+   long purpose sentence bumped the body itself onto a second line and left the
+   icon stranded alone on the first. Growing from the floor keeps the icon and
+   the text together and lets only the actions wrap. */
+
+.settingsOsPermissionRow > .settingsOsPermissionBody {
+    flex: 1 1 101px;
+    min-width: 101px;
+  }
+
 .settingsOsPermissionIcon {
     display: inline-flex;
     align-items: center;
     justify-content: center;
+    flex: 0 0 36px;
     width: 36px;
     height: 36px;
     border-radius: var(--radius-surface);
@@ -525,22 +555,23 @@
     gap: var(--space-1);
   }
 
-  /* The row's `auto` actions track wins the width contest against the body's
-     `minmax(0, 1fr)`: at the 480px floor the two grant buttons claimed the
-     whole 86px and squeezed the body column to literally 0px, so exactly the
-     rows that need action ("等待授权" / "已拒绝") hid *which* permission they
-     were about — only an icon and two buttons remained. Give the actions their
-     own row so the body keeps the full column. That also leaves room for the
-     widest status Badge ("当前平台不支持", ~101px intrinsic and
-     `whitespace-nowrap` by primitive contract), which previously overflowed
-     the 86px body by 15px. */
+  /* The row itself wraps structurally (see `.settingsOsPermissionRow` above),
+     so this breakpoint only handles what wrapping cannot: at ~190px of content
+     column the 36px icon plus the body's 101px floor no longer share a line, and
+     the icon is `aria-hidden` chrome — so it yields, the same trade the Remote
+     Access page makes when it drops its decorative chevron here. The actions
+     then take the full width they wrapped onto, left-aligned under the text. */
   .settingsOsPermissionRow {
-    grid-template-columns: 36px minmax(0, 1fr);
     row-gap: var(--space-2-5);
+    padding-inline: var(--space-2-5);
+  }
+
+  .settingsOsPermissionIcon {
+    display: none;
   }
 
   .settingsOsPermissionActions {
-    grid-column: 2 / -1;
+    flex-basis: 100%;
     justify-content: flex-start;
   }
 
@@ -559,41 +590,19 @@
     flex-direction: column;
     gap: var(--space-1-5);
   }
-}
-
-/* Below ~540px the content column no longer fits the body next to the 36px
-   decorative icon: the widest status Badge alone is ~101px intrinsic. The icon
-   is `aria-hidden` chrome, so it yields first — the same trade the Remote
-   Access page makes when it drops the redundant chevron at its narrow
-   breakpoint. Everything textual keeps the full column. */
-@media (max-width: 540px) {
-  .settingsOsPermissionRow {
-    grid-template-columns: minmax(0, 1fr);
-    padding-inline: var(--space-2-5);
-  }
-
-  .settingsOsPermissionIcon {
-    display: none;
-  }
-
-  .settingsOsPermissionActions {
-    grid-column: 1 / -1;
-  }
 
   .settingsCapabilityRow {
     padding-inline: var(--space-2-5);
   }
-}
 
-/* #1361: the OfficeCLI guidance actions are the widest thing on the page —
-   "复制 macOS/Linux 安装命令" is ~193px intrinsic against a ~96px content
-   column at the 480px floor. Button is a fixed-height (`h-8`) `shrink-0`
-   inline-flex, so on its own it neither shrinks nor wraps and the overflow
-   propagated all the way up through the guidance block to the capability list.
-   Allow these two to shrink and grow taller rather than clipping the label —
-   the install command itself keeps its own horizontal scroll (`code` above is
-   deliberately `white-space: nowrap; overflow: auto`). */
-@media (max-width: 620px) {
+  /* The OfficeCLI guidance actions are the widest thing on the page —
+     "复制 macOS/Linux 安装命令" is ~193px intrinsic against a ~96px content
+     column at the 480px floor. Button is a fixed-height (`h-8`) `shrink-0`
+     inline-flex, so on its own it neither shrinks nor wraps, and the overflow
+     propagated all the way up through the guidance block to the capability
+     list. Allow these two to shrink and grow taller rather than clipping the
+     label — the install command keeps its own horizontal scroll (`code` above
+     is deliberately `white-space: nowrap; overflow: auto`). */
   .settingsCapabilityGuidanceActions > div > * {
     min-width: 0;
     flex-shrink: 1;

--- a/apps/desktop/src/renderer/styles/settings/permission.css
+++ b/apps/desktop/src/renderer/styles/settings/permission.css
@@ -94,10 +94,17 @@
     gap: var(--space-3);
   }
 
+/* #1361: `min-width: 0` + a break opportunity on the id. Without them the
+   heading column could not shrink below its widest unbreakable child — the
+   monospace capability id (`office_documents`) — so the readiness Chip on the
+   other end of the space-between row was pushed past the card edge (33px of
+   overflow at the 480px floor). */
+
 .settingsCapabilityHeading {
     display: flex;
     flex-direction: column;
     gap: var(--space-0-5);
+    min-width: 0;
   }
 
 .settingsCapabilityHeading strong {
@@ -109,6 +116,7 @@
     font-family: var(--font-mono);
     font-size: var(--font-size-caption);
     color: var(--muted-foreground);
+    overflow-wrap: anywhere;
   }
 
 .settingsCapabilityDetail {
@@ -126,7 +134,12 @@
 .settingsCapabilityLayers {
     margin: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+    /* #1361: `minmax(150px, 1fr)` is a hard floor — once the content column is
+       narrower than 150px (the 480px window floor leaves ~118px here) the single
+       track still claims 150px and overflows the row. `min(150px, 100%)` keeps
+       the 150px preference while letting the track fall back to the available
+       width. */
+    grid-template-columns: repeat(auto-fit, minmax(min(150px, 100%), 1fr));
     gap: var(--space-1-5) var(--space-4);
   }
 
@@ -230,12 +243,19 @@
     background: oklch(from var(--info) l c h / 0.10);
   }
 
+/* #1361: `min-width: 0` on the guidance stack and its tracks. A grid item
+   defaults to a `min-content` floor, so the long install command and the
+   action buttons inside propagated their intrinsic width back up and burst the
+   capability row. */
+
 .settingsCapabilityGuidance {
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     gap: var(--space-1-5);
     padding: var(--space-2) var(--space-2-5);
     border: var(--border-width-hairline) solid var(--border);
     background: var(--foreground-3);
+    min-width: 0;
   }
 
 .settingsCapabilityGuidance > span {
@@ -254,8 +274,10 @@
 
 .settingsCapabilityGuidanceActions {
     display: grid;
+    grid-template-columns: minmax(0, 1fr);
     gap: var(--space-2);
     padding-top: var(--space-0-5);
+    min-width: 0;
   }
 
 .settingsCapabilityGuidanceActions code {
@@ -386,10 +408,17 @@
     flex-wrap: wrap;
   }
 
+/* #1361: the heading wraps (`flex-wrap: wrap`), but a long permission name is
+   one unbreakable flex item — "自动化（Apple Events）" overflowed the row by
+   15px at the 480px floor because it could not shrink and had nowhere to break.
+   `min-width: 0` lets it shrink; `overflow-wrap` gives it the break. */
+
 .settingsOsPermissionHeading strong {
     font-size: var(--font-size-heading);
     font-weight: var(--font-weight-semibold);
     color: var(--foreground);
+    min-width: 0;
+    overflow-wrap: anywhere;
   }
 
 .settingsOsPermissionPurpose {
@@ -398,9 +427,13 @@
     line-height: var(--leading-normal);
   }
 
+/* #1361: `flex-wrap` so the "影响功能" pill and the impact sentence can break
+   onto separate lines instead of overflowing the row together. */
+
 .settingsOsPermissionImpact {
     display: inline-flex;
     align-items: center;
+    flex-wrap: wrap;
     gap: var(--space-1-5);
     font-size: var(--font-size-ui);
     color: var(--foreground-secondary);
@@ -458,7 +491,13 @@
 
 .settingsPermissionSummary {
     display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
+    /* #1361: was `repeat(4, minmax(0, 1fr))` — see the matching note on
+       `.settingsHealthSummary`. Four hard tracks squeezed each tile to ~41px at
+       the 480px window floor, folding "未知 / 不支持" into a column of single
+       characters. `auto-fit` keeps the four even tracks at full width and drops
+       to two readable columns when narrow. The 96px floor is the wider one of
+       the two summaries because these labels are longer. */
+    grid-template-columns: repeat(auto-fit, minmax(96px, 1fr));
     gap: var(--space-2);
   }
 
@@ -471,6 +510,98 @@
   .settingsCapabilityList:not([data-diagnostics-open="true"]) .settingsCapabilityOsPermissions {
     display: none;
   }
+
+/* #1361: at the 480px window floor the fixed Settings navigation leaves a
+   ~190px content column, and neither header's action cluster shrinks (the page
+   header carries a last-read timestamp + re-detect button; the capabilities
+   header carries the diagnostics toggle). On one row they starved the
+   title/subtitle column to a few pixels — stack both instead, matching the
+   Remote Access page's treatment at this breakpoint. */
+@media (max-width: 620px) {
+  .settingsPermissionPage > [data-slot="section-header"],
+  .settingsPermissionSectionHeader {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-1);
+  }
+
+  /* The row's `auto` actions track wins the width contest against the body's
+     `minmax(0, 1fr)`: at the 480px floor the two grant buttons claimed the
+     whole 86px and squeezed the body column to literally 0px, so exactly the
+     rows that need action ("等待授权" / "已拒绝") hid *which* permission they
+     were about — only an icon and two buttons remained. Give the actions their
+     own row so the body keeps the full column. That also leaves room for the
+     widest status Badge ("当前平台不支持", ~101px intrinsic and
+     `whitespace-nowrap` by primitive contract), which previously overflowed
+     the 86px body by 15px. */
+  .settingsOsPermissionRow {
+    grid-template-columns: 36px minmax(0, 1fr);
+    row-gap: var(--space-2-5);
+  }
+
+  .settingsOsPermissionActions {
+    grid-column: 2 / -1;
+    justify-content: flex-start;
+  }
+
+  /* The action cluster is `shrink-0` by primitive contract, and the last-read
+     timestamp inside it is `whitespace-nowrap` — together ~174px intrinsic,
+     wider than the whole content column. Let the cluster wrap instead. */
+  .settingsPermissionPage > [data-slot="section-header"] [data-slot="section-header-action"],
+  .settingsPermissionSectionHeader [data-slot="section-header-action"] {
+    flex-wrap: wrap;
+  }
+
+  /* Same space-between squeeze as the OS rows: the readiness Chip does not
+     shrink, so it starved the capability name + id column. Stack them. */
+  .settingsCapabilityHeader {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: var(--space-1-5);
+  }
+}
+
+/* Below ~540px the content column no longer fits the body next to the 36px
+   decorative icon: the widest status Badge alone is ~101px intrinsic. The icon
+   is `aria-hidden` chrome, so it yields first — the same trade the Remote
+   Access page makes when it drops the redundant chevron at its narrow
+   breakpoint. Everything textual keeps the full column. */
+@media (max-width: 540px) {
+  .settingsOsPermissionRow {
+    grid-template-columns: minmax(0, 1fr);
+    padding-inline: var(--space-2-5);
+  }
+
+  .settingsOsPermissionIcon {
+    display: none;
+  }
+
+  .settingsOsPermissionActions {
+    grid-column: 1 / -1;
+  }
+
+  .settingsCapabilityRow {
+    padding-inline: var(--space-2-5);
+  }
+}
+
+/* #1361: the OfficeCLI guidance actions are the widest thing on the page —
+   "复制 macOS/Linux 安装命令" is ~193px intrinsic against a ~96px content
+   column at the 480px floor. Button is a fixed-height (`h-8`) `shrink-0`
+   inline-flex, so on its own it neither shrinks nor wraps and the overflow
+   propagated all the way up through the guidance block to the capability list.
+   Allow these two to shrink and grow taller rather than clipping the label —
+   the install command itself keeps its own horizontal scroll (`code` above is
+   deliberately `white-space: nowrap; overflow: auto`). */
+@media (max-width: 620px) {
+  .settingsCapabilityGuidanceActions > div > * {
+    min-width: 0;
+    flex-shrink: 1;
+    height: auto;
+    min-height: 2rem;
+    white-space: normal;
+  }
+}
 
 .settingsPermissionFootnote {
     margin: 0;

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -3,7 +3,14 @@ import type { Decorator, Meta, StoryObj } from '@storybook/react-vite';
 import { ToastProvider } from '@maka/ui';
 import type {
   AppSettings,
+  CapabilitySnapshot,
+  CapabilitySnapshotCollection,
+  HealthSignal,
+  HealthSnapshot,
   LlmConnection,
+  OsPermissionSnapshot,
+  OsPermissionState,
+  PermissionSnapshot,
   ProviderType,
   SettingsSection,
   ThemePalette,
@@ -11,7 +18,12 @@ import type {
   UpdateAppSettingsResult,
   UsageStats,
 } from '@maka/core';
-import { createDefaultSettings, DEFAULT_DAILY_REVIEW_CONFIG, mergeSettings } from '@maka/core';
+import {
+  buildHealthSnapshot,
+  createDefaultSettings,
+  DEFAULT_DAILY_REVIEW_CONFIG,
+  mergeSettings,
+} from '@maka/core';
 import { SettingsSurface } from '../../src/renderer/settings/settings-surface';
 import { createUiLocaleUpdateGate } from '../../src/renderer/settings/ui-locale-update-gate';
 import type { ConnectionsBridge } from '../../src/renderer/settings/ProvidersPanel';
@@ -117,6 +129,224 @@ const usageStats: UsageStats = {
   pricing: [{ provider: 'zai-coding-plan', model: 'glm-4.7', inputPerMTokUsd: 0, outputPerMTokUsd: 0 }],
 };
 
+/**
+ * Permission Center / Health Center fixtures.
+ *
+ * These three bridge channels used to answer with empty payloads, which left
+ * both pages unusable as the visual baseline #1303 asks for: `permissions: {}`
+ * crashed the Permission Center outright (the page maps `OS_PERMISSION_IDS`
+ * and main's `buildPermissionSnapshot` always ships a complete record), and an
+ * all-zero health summary rendered five dimmed tiles with nothing under them.
+ *
+ * The fixtures mirror the shape main actually builds, with a deliberately
+ * mixed set of states so tone, wrapping, and the summary grids are all
+ * exercised at once.
+ */
+function makeOsPermission(input: {
+  id: keyof PermissionSnapshot['permissions'];
+  status: OsPermissionState;
+  reason?: string;
+  canRequest?: boolean;
+  canOpenSettings?: boolean;
+}): OsPermissionSnapshot {
+  return {
+    id: input.id,
+    status: input.status,
+    source: 'electron',
+    checkedAt: NOW - 30_000,
+    reason: input.reason,
+    canOpenSettings: input.canOpenSettings ?? input.status !== 'unsupported',
+    canRequest: input.canRequest ?? false,
+  };
+}
+
+const permissionSnapshot: PermissionSnapshot = {
+  checkedAt: NOW - 30_000,
+  platform: STORY_PLATFORM,
+  permissions: {
+    accessibility: makeOsPermission({ id: 'accessibility', status: 'granted' }),
+    screen_recording: makeOsPermission({
+      id: 'screen_recording',
+      status: 'not_determined',
+      canRequest: true,
+    }),
+    microphone: makeOsPermission({
+      id: 'microphone',
+      status: 'denied',
+      reason: '用户在系统设置里拒绝了麦克风访问，语音输入与录音自检都会直接失败。',
+    }),
+    notifications: makeOsPermission({
+      id: 'notifications',
+      status: 'granted',
+      canRequest: true,
+    }),
+    automation: makeOsPermission({
+      id: 'automation',
+      status: 'unsupported',
+      reason: '当前系统版本不暴露自动化授权状态。',
+      canOpenSettings: false,
+    }),
+  },
+};
+
+function makeCapability(input: Partial<CapabilitySnapshot> & Pick<CapabilitySnapshot, 'id' | 'label' | 'readiness'>): CapabilitySnapshot {
+  return {
+    feature: { state: 'enabled', source: 'settings' },
+    configuration: { state: 'present', source: 'settings' },
+    osPermissions: [],
+    actionApproval: { state: 'not_required', source: 'not_applicable' },
+    memoryAcceptance: { state: 'not_applicable', source: 'not_applicable' },
+    runtimeProbe: { state: 'healthy', source: 'runtime_probe', lastCheckedAt: NOW - 60_000 },
+    canRevoke: false,
+    canPause: false,
+    guidance: [],
+    auditEvents: [],
+    updatedAt: NOW - 60_000,
+    ...input,
+  };
+}
+
+const capabilitySnapshot: CapabilitySnapshotCollection = {
+  checkedAt: NOW - 30_000,
+  capabilities: [
+    makeCapability({
+      id: 'computer_use',
+      label: '计算机操作（辅助功能 + 屏幕录制）',
+      readiness: 'degraded',
+      runtimeProbe: {
+        state: 'degraded',
+        source: 'runtime_probe',
+        lastCheckedAt: NOW - 5 * 60_000,
+        reason: 'cua-driver 未响应握手，已回落到只读观察模式。',
+      },
+      osPermissions: [
+        { id: 'accessibility', required: true, status: 'granted' },
+        { id: 'screen_recording', required: true, status: 'not_determined' },
+      ],
+      actionApproval: { state: 'required_per_action', source: 'capability_policy' },
+      guidance: ['前往系统设置授予屏幕录制权限后重新探测。'],
+    }),
+    makeCapability({
+      id: 'voice',
+      label: '语音输入',
+      readiness: 'denied',
+      feature: { state: 'enabled', source: 'settings' },
+      osPermissions: [{ id: 'microphone', required: true, status: 'denied' }],
+      runtimeProbe: { state: 'not_run', source: 'runtime_probe' },
+      guidance: ['麦克风权限已被拒绝，需要在系统设置中重新开启。'],
+    }),
+    makeCapability({
+      id: 'memory_write',
+      label: '记忆写入',
+      readiness: 'enabled',
+      memoryAcceptance: { state: 'accepted', source: 'memory_contract' },
+      auditEvents: ['2026-07-24 10:12 接受了 3 条记忆草稿'],
+    }),
+    makeCapability({
+      id: 'office_documents',
+      label: 'Office 文档处理',
+      readiness: 'not_configured',
+      configuration: {
+        state: 'missing',
+        source: 'runtime',
+        reason: '未检测到 OfficeCLI 可执行文件。',
+      },
+      runtimeProbe: {
+        state: 'not_available',
+        source: 'runtime_probe',
+        reason: 'OfficeCLI 未安装。',
+      },
+      guidance: ['安装 OfficeCLI 后重新探测，或从 Releases 页面下载对应平台的构建产物。'],
+    }),
+  ],
+};
+
+const healthSignals: HealthSignal[] = [
+  {
+    id: 'app:config',
+    label: '应用配置',
+    scope: 'app',
+    layer: 'configuration',
+    status: 'ok',
+    source: 'settings',
+    checkedAt: NOW - 60_000,
+    message: '配置文件可读写，schema 版本为最新。',
+  },
+  {
+    id: 'conn:zai-live',
+    label: 'Z.AI Live',
+    scope: 'llm_connection',
+    layer: 'validation',
+    status: 'ok',
+    source: 'connection_test',
+    checkedAt: NOW - 12 * 60_000,
+    message: '连接测试通过，延迟 210ms。',
+    detail: '验证通过只代表凭据可用，实际可用性仍需运行态探测确认。',
+  },
+  {
+    id: 'conn:openai-review',
+    label: 'OpenAI Review',
+    scope: 'llm_connection',
+    layer: 'validation',
+    status: 'error',
+    source: 'connection_test',
+    checkedAt: NOW - 3 * 60_000,
+    message: '连接测试失败：HTTP 401 invalid_api_key。',
+    detail: '凭据已失效或被吊销，请在「模型」页重新填写 API Key 后再次测试。',
+    blocksSend: true,
+  },
+  {
+    id: 'perm:microphone',
+    label: '麦克风权限',
+    scope: 'capability',
+    layer: 'permission',
+    status: 'warning',
+    source: 'permission_snapshot',
+    checkedAt: NOW - 30_000,
+    message: '麦克风权限已被拒绝。',
+    relatedCapabilityId: 'voice',
+    blocksCapability: true,
+  },
+  {
+    id: 'feature:computer-use',
+    label: '计算机操作',
+    scope: 'capability',
+    layer: 'feature',
+    status: 'info',
+    source: 'capability_snapshot',
+    checkedAt: NOW - 60_000,
+    message: '功能已开启，但仍以逐次审批模式运行。',
+    relatedCapabilityId: 'computer_use',
+  },
+  {
+    id: 'probe:cua-driver',
+    label: 'cua-driver 运行态探测',
+    scope: 'capability',
+    layer: 'runtime_probe',
+    status: 'warning',
+    source: 'runtime_probe',
+    checkedAt: NOW - 5 * 60_000,
+    message: '探测超时，已回落到只读观察模式。',
+    detail: 'cua-driver 未在 3000ms 内完成握手；下一次探测会在功能被调用时自动触发。',
+    relatedCapabilityId: 'computer_use',
+    blocksCapability: true,
+  },
+  {
+    id: 'storage:sessions',
+    label: '会话存储',
+    scope: 'storage',
+    layer: 'storage',
+    status: 'ok',
+    source: 'storage',
+    checkedAt: NOW - 60_000,
+    message: 'SQLite 库可写，WAL 检查点正常。',
+  },
+];
+
+const healthSnapshot: HealthSnapshot = buildHealthSnapshot(NOW - 45_000, healthSignals);
+
+const emptyHealthSnapshot: HealthSnapshot = buildHealthSnapshot(NOW - 45_000, []);
+
 const makaBridge = {
   settings: {
     get: async () => createDefaultSettings(),
@@ -144,11 +374,7 @@ const makaBridge = {
     }),
   },
   health: {
-    getSnapshot: async () => ({
-      checkedAt: NOW,
-      signals: [],
-      summary: { ok: 0, info: 0, warning: 0, error: 0, unknown: 0 },
-    }),
+    getSnapshot: async () => healthSnapshot,
   },
   gateway: {
     status: async () => ({
@@ -163,19 +389,12 @@ const makaBridge = {
     subscribeStatusChanges: () => () => undefined,
   },
   permissions: {
-    getSnapshot: async () => ({
-      checkedAt: NOW,
-      platform: STORY_PLATFORM,
-      permissions: {},
-    }),
+    getSnapshot: async () => permissionSnapshot,
     openSystemSettings: async () => ({ ok: true }),
     requestAccess: async () => ({ ok: true }),
   },
   capabilities: {
-    getSnapshot: async () => ({
-      checkedAt: NOW,
-      capabilities: [],
-    }),
+    getSnapshot: async () => capabilitySnapshot,
   },
   dailyReview: {
     getConfig: async () => DEFAULT_DAILY_REVIEW_CONFIG,
@@ -191,6 +410,13 @@ const makaBridge = {
 } satisfies Record<string, unknown>;
 
 const withSettingsBridge = withScopedMakaBridge(makaBridge);
+
+const withEmptyHealthBridge = withScopedMakaBridge({
+  ...makaBridge,
+  health: {
+    getSnapshot: async () => emptyHealthSnapshot,
+  },
+} satisfies Record<string, unknown>);
 
 type StoryBotStatuses = Awaited<ReturnType<typeof window.maka.settings.bots.listStatuses>>;
 
@@ -522,6 +748,10 @@ export const PermissionCenter: Story = {
 };
 export const HealthCenter: Story = {
   decorators: [withSettingsBridge],
+  render: () => <SettingsStory section="health" />,
+};
+export const HealthCenterEmpty: Story = {
+  decorators: [withEmptyHealthBridge],
   render: () => <SettingsStory section="health" />,
 };
 export const About: Story = {

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -746,6 +746,30 @@ export const PermissionCenter: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="permissions" />,
 };
+/**
+ * #1361: the capability layers grid, the guidance block and the OfficeCLI
+ * install command are all hidden until diagnostics are expanded, so the
+ * collapsed story gives those layouts no baseline at all — which is exactly
+ * where the remaining overflow was hiding.
+ */
+export const PermissionCenterDiagnosticsExpanded: Story = {
+  decorators: [withSettingsBridge],
+  render: () => <SettingsStory section="permissions" />,
+  play: async ({ canvasElement }) => {
+    const toggle = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.includes('展开详情') === true,
+    );
+    toggle.click();
+    await waitForStoryCondition(
+      () =>
+        canvasElement
+          .querySelector('.settingsCapabilityList')
+          ?.getAttribute('data-diagnostics-open') === 'true',
+      'Permission Center story did not expand the capability diagnostics',
+    );
+  },
+};
 export const HealthCenter: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="health" />,


### PR DESCRIPTION
Sub-issue of #1303 — the visual/layout audit of the two StatTile-heavy pages, same shape as the Open Gateway pilot (#1304). Closes #1361.

Short version: both pages hit the **same failure family as #1304** — layout that keeps dividing a fixed number of tracks no matter how little width is left. #1335 taught `StatTile` to wrap its own text, but a tile squeezed below one character wide has nothing left to wrap into.

## The stories could not serve as a baseline

Before any layout work, neither page was usable as the baseline #1303 asks for. Both were driven by bridge stubs returning empty payloads:

| channel | stub | effect |
| --- | --- | --- |
| `permissions.getSnapshot` | `permissions: {}` | **story crashed** — `TypeError: Cannot read properties of undefined (reading 'id')` |
| `capabilities.getSnapshot` | `[]` | no capability rows at all |
| `health.getSnapshot` | all-zero summary | five dimmed tiles above nothing |

The crash is a **fixture bug, not a page bug**: `PermissionSnapshot.permissions` is typed `Record<OsPermissionId, …>` and main's `buildPermissionSnapshot` always builds all five entries, so I did **not** add a defensive guard — that would only paper over a fixture that lies about the contract. The fixtures now mirror what main builds, with mixed states so tone, wrapping and the grids are all exercised at once. `HealthCenterEmpty` keeps the zero-signal state as its own variant.

## What the audit found

**1. Summary grids collapse below one character wide.** `.settingsHealthSummary` was `repeat(5, minmax(0, 1fr))` and `.settingsPermissionSummary` `repeat(4, …)`. At the 480px window floor (`SAFE_MIN_WIDTH`) the Health tiles measured ~30px — a **4px content box** after padding, so even a single digit overflowed by 9px. Now `repeat(auto-fit, minmax(…, 1fr))`; full-width layout is byte-for-byte the same (one track per metric).

**2. The worse one: permission rows hid *which* permission they were about.** The row grid was `36px minmax(0, 1fr) auto`. The `auto` actions track wins the width contest against `minmax(0, 1fr)`, so at the floor the two grant buttons claimed the whole 86px and squeezed the body column to **literally 0px** — exactly the rows that need action ("等待授权" / "已拒绝") were reduced to an icon and two buttons, with the name, purpose and impact clipped away. Actions now take their own row at ≤620px; the decorative `aria-hidden` icon yields at ≤540px, which also leaves room for the widest status Badge (~101px intrinsic, `whitespace-nowrap` by primitive contract).

**3. Both page headers starved their own titles.** The action clusters are `shrink-0` and hold a `whitespace-nowrap` timestamp (~174px / ~239px intrinsic), so on one row the title/subtitle column was left a few pixels. They stack and wrap at ≤620px — the same treatment the Remote Access page already applies at this breakpoint.

**4. Capability diagnostics burst the row when expanded** (this state is hidden by default, so it needed a separate pass): the unbreakable monospace `office_documents` pushed the readiness Chip past the card edge; the layers grid's hard `minmax(150px, …)` floor exceeded the whole content column; and the OfficeCLI guidance buttons propagated their intrinsic width up through the row. Fixed with `min-width: 0` where shrinking had to propagate, `minmax(min(150px, 100%), …)`, and a break opportunity on the id. The install command keeps its deliberate horizontal scroller.

## No shared primitive was touched

Nothing routes through #1360. `Badge` and `Button` keep their defaults — their `shrink-0` + `whitespace-nowrap` is right for the short labels they normally hold. Two page-level overrides relax them in the narrow breakpoint only, each annotated with why the primitive is correct as-is. (Worth noting for whoever picks up the blockers row: putting a full sentence in a pill is the actual oddity there; a text row would remove the need for the override.)

## Verification

- **Contract tests** (3, in `e2e/settings.spec.ts`) lock the outcome rather than pixels: tracks fold *and* stay legible, permission bodies keep width, nothing overflows horizontally — plus a full-width regression guard so `auto-fit` cannot silently cost the wide layout. **Confirmed they fail against the pre-fix CSS** (`foldedToFewTracks: false`, `listContained: false`); the wide-layout guard correctly stays green, since it guards the new mechanism rather than the old bug.
- Full `settings.spec.ts` suite: **10/10 passing**.
- Measured 480 / 520 / 620 / 760 / 960 / 1280px in Storybook, collapsed *and* with diagnostics expanded: **zero horizontal overflow**.
- `npm run format`, desktop `typecheck`, `test:checks` (console / a11y / copy) and `check-dead-css` all clean.

### Live-app screenshots

Permissions and Health at the 480px floor — summary tiles fold and stay readable, permission rows keep their text:

<img src="https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1361-screenshots/live-permissions-480.png" width="380"> <img src="https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1361-screenshots/live-health-480.png" width="380">

Capability diagnostics expanded at 480px (the widest state on the page) and the unchanged full-width layout:

<img src="https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1361-screenshots/live-permissions-480-diagnostics.png" width="380"> <img src="https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1361-screenshots/live-health-1280.png" width="620">

---

Two things I found but deliberately left alone, since they are outside this sub-issue's scope:

- **Health has no empty state.** With zero signals the page renders a summary of zeros and a footnote, with no "暂无信号" affordance — every layer section returns `null`. Covered as a story (`HealthCenterEmpty`) so it is visible, but adding the affordance is a content/behaviour change, and empty states are #1364's theme.
- At 480px the Settings navigation keeps its full fixed width and takes over half the window, leaving the ~140–240px content column that made all of the above so tight. That is the settings shell, not these two pages.
