### PR TITLE
feat(ui): rebuild the empty chat hero around the Maka wordmark

### DIFF
--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -97,6 +97,14 @@ const STROKE_EXCEPTION_FILES = new Set([
 //   - apps/desktop/src/renderer/settings/provider-brand-marks.tsx — the LLM
 //     provider brand marks (SiliconCloud, Ollama, xAI, …); every path here is
 //     byte-provenance-pinned above to an upstream brand package.
+//   - packages/ui/src/maka-wordmark.tsx — Maka's own wordmark (#1433). The
+//     one mark here that is first-party rather than vendored: its path was
+//     traced with potrace from the `maka` lockup in
+//     apps/desktop/assets/icon.png, so the geometry has the same "official
+//     logo, reproduced exactly" provenance the vendored marks have. lucide
+//     obviously ships no Maka glyph, and routing a product logo through the
+//     generic icon funnel would subject it to the shared stroke and sizing
+//     seam, which is exactly what a mark must not follow.
 //   - apps/desktop/src/renderer/mcp-brand-marks.tsx — the MCP catalog brand
 //     marks. This is the SANCTIONED pattern for library-sourced marks: the
 //     `<svg>` is an inert MOUNTING SHELL that wraps `<path>` children whose
@@ -113,6 +121,7 @@ const STROKE_EXCEPTION_FILES = new Set([
 // justification (inert shell around library-sourced path geometry).
 const INLINE_SVG_ALLOWLIST = new Set([
   resolve(REPO_ROOT, 'packages/ui/src/bot-brand-logo.tsx'),
+  resolve(REPO_ROOT, 'packages/ui/src/maka-wordmark.tsx'),
   resolve(REPO_ROOT, 'apps/desktop/src/renderer/settings/provider-brand-marks.tsx'),
   resolve(REPO_ROOT, 'apps/desktop/src/renderer/mcp-brand-marks.tsx'),
 ]);

--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -301,6 +301,58 @@ describe('visible-copy hygiene contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup v2)', 
       /<MakaWordmark\b/,
       'The empty-chat hero should anchor on the Maka wordmark.',
     );
+
+    // The bubble assertions above cover the staged conversation; these cover
+    // the "product pitch" half of this test's name, which used to live only
+    // in the comment. Both old taglines are pinned by their literal text
+    // because the two locales had drifted into different jobs — zh pitched
+    // the product, en explained the composer — so neither string predicts
+    // the other, and a field-name check cannot tell them apart from
+    // `deepResearchEmpty.intro`, which is legitimate and must survive.
+    //
+    // Searched across BOTH files: the copy bundle is where the strings lived,
+    // but nothing stops a future edit from hardcoding one into the component,
+    // and a bundle-only check would not see it.
+    const allSource = `${src}\n${copy}`;
+    for (const [tagline, locale] of [
+      ['自主规划，陪你把事做完的智能个人助手。', 'zh'],
+      ['Describe what you want to change, ask, or look up.', 'en'],
+    ] as const) {
+      assert.ok(
+        !allSource.includes(tagline),
+        `The empty-chat hero must not reintroduce the ${locale} tagline: the daily empty chat is where returning users land, and they do not need the product explained every time.`,
+      );
+    }
+
+    // Structural backstop, as an allowlist rather than a ban on <p>. A ban
+    // only knows the tag the tagline happened to use — the same sentence in a
+    // <div> walks straight past it, which is not a hypothetical: it was the
+    // first thing tried against the earlier version of this assertion. It
+    // also fails in the other direction, rejecting a semantically correct <p>
+    // if the surface ever legitimately needs one and pushing the author
+    // toward a worse tag to get green.
+    //
+    // Naming the elements this surface may render inverts both problems: any
+    // added element trips it regardless of tag, and widening the surface
+    // becomes an explicit edit here with a reason, which is what a decision
+    // this small and this easy to erode actually needs.
+    const emptyHeroStart = src.indexOf('export function EmptyChatHero');
+    const nextExport = src.indexOf('\nexport function', emptyHeroStart + 1);
+    const emptyHeroBody = src.slice(emptyHeroStart, nextExport === -1 ? undefined : nextExport);
+    assert.ok(
+      emptyHeroStart !== -1 && emptyHeroBody.length > 0,
+      'Could not slice EmptyChatHero out of chat-empty-hero.tsx — this contract needs updating alongside the rename.',
+    );
+    const rendered = [...new Set(
+      [...emptyHeroBody.matchAll(/<([A-Za-z][\w.]*)/g)].map((m) => m[1]!),
+    )].sort();
+    assert.deepEqual(
+      rendered,
+      ['MakaWordmark', 'div', 'h1', 'header', 'section'],
+      'The empty-chat hero renders the wordmark and the greeting, nothing else. '
+        + 'Adding an element here means re-deciding that the empty state should say more than hello — '
+        + `do it deliberately and update this list. Currently rendered: ${rendered.join(', ')}`,
+    );
   });
 });
 

--- a/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/visible-copy-hygiene-contract.test.ts
@@ -268,36 +268,38 @@ describe('visible-copy hygiene contract (PR-SIDEBAR-IA-0 Phase 3 P0 fixup v2)', 
     });
   }
 
-  it('pins the zh empty-chat hero product tagline', async () => {
+  it('keeps the empty-chat hero free of staged conversation and product pitch', async () => {
+    // #1433: the hero used to stage a conversation the user never had —
+    // two chat bubbles ("好，我来帮你理清楚。" / "为这个任务起草计划") plus a
+    // Maka/user avatar pair — on the one surface that has no content, and
+    // pitched the product ("自主规划，陪你把事做完的智能个人助手。") to
+    // returning users every time they opened a new chat. The wordmark is
+    // the anchor now. This contract keeps that decision from silently
+    // regressing: fake message copy must not come back to the empty state.
     const heroPath = resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'chat-empty-hero.tsx');
     const copyPath = resolve(process.cwd(), '..', '..', 'packages', 'ui', 'src', 'conversation-copy.ts');
     const src = stripComments(await readFile(heroPath, 'utf8'));
     const copy = stripComments(await readFile(copyPath, 'utf8'));
 
-    assert.match(
-      copy,
-      /intro:\s*'自主规划，陪你把事做完的智能个人助手。'/,
-      'The default zh chat empty hero should carry Maka’s exact product tagline.',
-    );
-    assert.match(
-      copy,
-      /primaryBubble:\s*'好，我来帮你理清楚。'/,
-      'The default zh chat empty hero visual should not leak the English fixture bubble.',
-    );
-    assert.match(
-      copy,
-      /secondaryBubble:\s*'为这个任务起草计划'/,
-      'The default zh chat empty hero visual should keep the task prompt bubble Chinese-first.',
+    for (const [field, why] of [
+      ['primaryBubble', 'a staged assistant reply'],
+      ['secondaryBubble', 'a staged user prompt'],
+    ] as const) {
+      assert.doesNotMatch(
+        copy,
+        new RegExp(`${field}\\s*:`),
+        `The empty-chat hero must not reintroduce ${why}: the empty state has no conversation to show.`,
+      );
+    }
+    assert.doesNotMatch(
+      src,
+      /maka-hero-bubble|maka-hero-avatar/,
+      'The empty-chat hero must not render conversation bubbles or avatars.',
     );
     assert.match(
       src,
-      /maka-hero-bubble-primary">\{copy\.primaryBubble\}/,
-      'The empty hero primary bubble should render from the locale copy bundle.',
-    );
-    assert.match(
-      src,
-      /maka-hero-bubble-secondary">\{copy\.secondaryBubble\}/,
-      'The empty hero secondary bubble should render from the locale copy bundle.',
+      /<MakaWordmark\b/,
+      'The empty-chat hero should anchor on the Maka wordmark.',
     );
   });
 });

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -127,6 +127,17 @@
   --brand-deep-hover: oklch(from var(--accent) calc(l - 0.06) c h);
   /* Fixed external channel identity; unlike palette-derived Maka accents. */
   --brand-wechat: #07c160;
+  /* Maka's own identity colour, sampled from the `maka` lockup in the app
+     icon (apps/desktop/assets/icon.png).
+     Deliberately NOT `var(--accent)`: an identity mark that turns mauve
+     when the user picks the mauve palette is a themed decoration, not a
+     mark. Same contract as --brand-wechat above — a fixed brand asset that
+     sits outside the palette system — which is also why it stays one value
+     across light and dark rather than being re-derived per theme.
+     Do not reach for this as a general accent: --accent / --brand-deep own
+     emphasis, and using this for CTAs is exactly the palette-invisibility
+     bug called out in the --brand-deep note above. */
+  --maka-brand: #71a8fd;
   /* Every MCP market tile now renders a real library brand mark on a neutral
      plate (mcp-brand-marks.tsx: simple-icons + @ant-design/icons-svg DingTalk +
      the vendored Feishu mark), so no per-brand plate-tint tokens are needed —

--- a/apps/desktop/src/renderer/styles/hero.css
+++ b/apps/desktop/src/renderer/styles/hero.css
@@ -18,8 +18,17 @@
  * Legacy `.emptyChat` and `.eyebrow` are kept as aliases so any
  * external CSS / smoke fixture references still match.
  */
+/* #1433: the width was a hardcoded `min(750px, 80vw)` — the one content
+   surface that did not use `--maka-chat-measure`. Everything else the user
+   reads or types into (message rows, composer, plan mode, permission
+   dialog, `.maka-onboarding`) is capped by that token.
+   This is a consistency fix, not a bug fix: the hero and the composer are
+   both centred in the same column, so the old 750px did not visibly
+   misalign them. What it did do is size the empty state off a magic number
+   and a viewport unit that ignores the sidebar, so the hero's column drifted
+   from the composer's as the window resized. */
 .maka-hero {
-  width: min(750px, 80vw);
+  width: min(var(--maka-chat-measure), 100%);
   margin: auto;
   padding: 0;
   display: grid;
@@ -35,61 +44,14 @@
     gap: var(--space-2-5);
     justify-items: center;
   }
+/* Holds the wordmark on the empty chat surface. It used to be a 130px
+   absolute-positioning stage for two fake chat bubbles and a Maka/user
+   avatar pair (#1433: a staged conversation on the one surface that has
+   none); with the mark it just needs to centre one inline SVG. */
 .maka-hero-visual {
-    position: relative;
-    width: min(520px, 62vw);
-    height: 130px;
-    margin-bottom: var(--space-1);
-  }
-.maka-hero-bubble {
-    position: absolute;
-    display: inline-flex;
-    align-items: center;
-    min-height: 32px;
-    border-radius: var(--radius-modal);
-    background: var(--foreground-3);
-    color: var(--muted-foreground);
-    font-size: var(--font-size-ui);
-    font-weight: var(--font-weight-semibold);
-    line-height: var(--leading-none);
-    white-space: nowrap;
-    padding: 0 var(--space-3);
-  }
-.maka-hero-bubble-primary {
-    left: 38px;
-    top: 16px;
-    background: oklch(from var(--brand-deep) l c h / 0.10);
-    color: var(--brand-deep);
-  }
-.maka-hero-bubble-secondary {
-    right: 22px;
-    top: 42px;
-  }
-.maka-hero-avatar {
-    position: absolute;
-    display: inline-grid;
-    place-items: center;
-    border-radius: var(--radius-pill);
-    box-shadow: 0 6px 18px -14px oklch(from var(--foreground) l c h / 0.32);
-  }
-.maka-hero-avatar-maka {
-    left: calc(50% - 48px);
-    top: 42px;
-    width: 66px;
-    height: 66px;
-    background: oklch(from var(--brand-deep) l c h / 0.18);
-    color: var(--brand-deep);
-  }
-.maka-hero-avatar-user {
-    left: calc(50% + 4px);
-    top: 52px;
-    width: 62px;
-    height: 62px;
-    border: var(--border-width-accent) solid oklch(from var(--brand-deep) l c h / 0.12);
-    background: var(--chat-user-bg);
-    color: var(--foreground);
-    font-size: 1.4667em;
-    font-weight: var(--font-weight-bold);
+    display: grid;
+    justify-items: center;
+    color: var(--maka-brand);
   }
 .maka-hero-eyebrow {
     display: inline-flex;
@@ -127,22 +89,10 @@
     line-height: var(--leading-normal);
     text-wrap: pretty;
   }
-@media (max-width: 820px) {
-    .maka-hero-visual {
-      width: min(420px, 84vw);
-      height: 112px;
-    }
-
-    .maka-hero-bubble {
-      font-size: var(--font-size-caption);
-      padding-inline: var(--space-2-5);
-    }
-
-    .maka-hero-bubble-primary {
-      left: 0;
-    }
-
-    .maka-hero-bubble-secondary {
-      right: 0;
-    }
+/* #1433: the daily empty chat is a returning user's landing surface, not a
+   launch screen, so its greeting steps down from the 2.1333em first-run
+   hero scale to ~20px. The OnboardingHero variants keep the large scale —
+   they are seen once, and there the headline is the whole message. */
+.maka-hero-empty-chat:not(.maka-hero-deep-research) h1 {
+    font-size: 1.5385em;
   }

--- a/packages/ui/src/chat-empty-hero.tsx
+++ b/packages/ui/src/chat-empty-hero.tsx
@@ -26,6 +26,7 @@
 import { Sparkles } from './icons.js';
 import { Button as BaseButton } from '@base-ui/react/button';
 
+import { MakaWordmark } from './maka-wordmark.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy, type DayPeriod } from './conversation-copy.js';
 export type { DayPeriod } from './conversation-copy.js';
@@ -74,23 +75,25 @@ export function EmptyChatHero(props: { onPromptSuggestion?(prompt: string): void
   const period = detectDayPeriod();
   const greeting = copy.greeting[period];
   const greetingTail = copy.greetingTail[period];
+  // #1433: the visual used to be two chat bubbles plus a Maka/user avatar
+  // pair — a staged conversation the user never had. It read as real
+  // content on the one surface that has none, so it went; the wordmark
+  // takes its place as the surface's anchor. The product-pitch line under
+  // the greeting went with it: the daily empty chat is where returning
+  // users land, and they do not need the product explained every time.
   return (
     <section className="maka-hero maka-hero-empty-chat" aria-label={copy.ariaLabel}>
-      <div className="maka-hero-visual" aria-hidden="true">
-        <span className="maka-hero-bubble maka-hero-bubble-primary">{copy.primaryBubble}</span>
-        <span className="maka-hero-avatar maka-hero-avatar-maka">
-          <Sparkles size={18} />
-        </span>
-        <span className="maka-hero-avatar maka-hero-avatar-user">
-          {label ? label.slice(0, 1).toUpperCase() : 'M'}
-        </span>
-        <span className="maka-hero-bubble maka-hero-bubble-secondary">{copy.secondaryBubble}</span>
+      {/* 160px puts the mark's cap height at ~42px against the 25px
+          greeting — a 1.7:1 ratio that reads as anchor-then-line. At the
+          104px it shipped with, the two were within 8% of each other and
+          neither led. */}
+      <div className="maka-hero-visual">
+        <MakaWordmark width={160} />
       </div>
       <header>
         <h1>
           {label ? copy.headlineWithLabel(greeting, label) : copy.headlineFallback(greeting, greetingTail)}
         </h1>
-        <p>{copy.intro}</p>
       </header>
     </section>
   );

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -29,9 +29,6 @@ export interface ConversationCopy {
     greetingTail: Record<DayPeriod, string>;
     headlineWithLabel: (greeting: string, label: string) => string;
     headlineFallback: (greeting: string, tail: string) => string;
-    primaryBubble: string;
-    secondaryBubble: string;
-    intro: string;
   };
   deepResearchEmpty: {
     ariaLabel: string;
@@ -315,7 +312,6 @@ const CONVERSATION_COPY = {
       greeting: { morning: '早上好', noon: '中午好', afternoon: '下午好', evening: '晚上好' },
       greetingTail: { morning: '清醒的早晨适合理清思路', noon: '专注的午间适合一鼓作气', afternoon: '舒缓的下午适合慢慢推进', evening: '安静的夜晚适合深度思考' },
       headlineWithLabel: (greeting, label) => `${greeting} ${label}，今天想做点什么？`, headlineFallback: (greeting, tail) => `${greeting}，${tail}。`,
-      primaryBubble: '好，我来帮你理清楚。', secondaryBubble: '为这个任务起草计划', intro: '自主规划，陪你把事做完的智能个人助手。',
     },
     deepResearchEmpty: {
       ariaLabel: '深度研究空会话', eyebrow: '深度研究 · 只读探索', title: '先把项目读透，再决定怎么改。', intro: '这个会话固定在只读权限：优先阅读、搜索和分析代码；需要动手实现时，先输出文件、风险和验证命令。',
@@ -423,7 +419,6 @@ const CONVERSATION_COPY = {
       greeting: { morning: 'Good morning', noon: 'Good afternoon', afternoon: 'Good afternoon', evening: 'Good evening' },
       greetingTail: { morning: 'A clear morning is good for untangling ideas', noon: 'A focused midday is good for a single big push', afternoon: 'A calm afternoon is good for steady progress', evening: 'A quiet evening is good for deep thinking' },
       headlineWithLabel: (greeting, label) => `${greeting} ${label} — what shall we tackle today?`, headlineFallback: (greeting, tail) => `${greeting} — ${tail}.`,
-      primaryBubble: 'Sure. I can organize that.', secondaryBubble: 'Draft a plan for this task', intro: 'Describe what you want to change, ask, or look up. Maka will start from the composer below.',
     },
     deepResearchEmpty: {
       ariaLabel: 'Empty Deep Research conversation', eyebrow: 'Deep Research · Read-only exploration', title: 'Understand the project before deciding what to change.', intro: 'This conversation stays read only: inspect, search, and analyze first. When implementation is needed, report the files, risks, and verification commands.',

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -48,6 +48,7 @@ export * from './utils.js';
 // consumers can `import { Alert, Empty, ... } from '@maka/ui'`.
 export * from './bot-brand.js';
 export * from './bot-brand-logo.js';
+export * from './maka-wordmark.js';
 export * from './primitives/alert.js';
 export * from './primitives/card.js';
 // `markerVariants` / `toolVariants` are deliberately NOT re-exported here:

--- a/packages/ui/src/maka-wordmark.tsx
+++ b/packages/ui/src/maka-wordmark.tsx
@@ -1,0 +1,48 @@
+/**
+ * The Maka wordmark — our own brand asset, not a generic UI icon.
+ *
+ * Lives beside `bot-brand-logo.tsx` for the same reason: `icons.tsx` is a
+ * pass-through to lucide-react for generic UI glyphs, while fixed product
+ * assets carry their own module.
+ *
+ * Outlines were traced (potrace, deterministic) from the `maka` lockup in
+ * `apps/desktop/assets/icon.png`, which is the app icon shipped with the
+ * desktop build — so the empty-state mark and the dock icon cannot drift
+ * apart. Paths are filled with `currentColor` so the mark inherits the
+ * surface's text colour and works in both themes; callers set the opacity
+ * they want rather than baking a tint in here.
+ */
+
+import type { CSSProperties } from 'react';
+
+export interface MakaWordmarkProps {
+  /** Rendered width in px; height follows the 460:120 aspect ratio. */
+  width?: number | string;
+  className?: string;
+  style?: CSSProperties;
+  /**
+   * Accessible name. Omit it (the default) for decorative use — the mark
+   * then renders `aria-hidden`, because the surrounding hero already names
+   * the surface and a second "Maka" announcement is just noise.
+   */
+  title?: string;
+}
+
+export function MakaWordmark({ width = 104, className, style, title }: MakaWordmarkProps) {
+  return (
+    <svg
+      viewBox="0 0 460 120"
+      width={width}
+      className={className}
+      style={style}
+      role={title ? 'img' : undefined}
+      aria-hidden={title ? undefined : 'true'}
+      aria-label={title}
+    >
+      {title && <title>{title}</title>}
+      <g transform="translate(0,120) scale(0.1,-0.1)" fill="currentColor" stroke="none">
+        <path d="M2639 1187 c-38 -29 -39 -46 -39 -479 0 -400 1 -425 19 -455 23 -37 68 -50 108 -31 41 20 53 53 53 154 0 83 2 92 25 114 l24 23 143 -138 c79 -75 156 -143 171 -151 57 -30 127 14 127 79 0 32 -39 75 -217 238 l-82 75 130 103 c157 125 173 152 123 210 -21 25 -34 31 -65 31 -35 0 -55 -13 -209 -140 l-170 -139 0 229 0 228 -26 31 c-20 24 -34 31 -62 31 -21 0 -44 -6 -53 -13z M1926 969 c-109 -26 -216 -114 -264 -217 -24 -50 -27 -69 -27 -162 0 -95 3 -111 28 -162 39 -79 104 -143 185 -181 62 -29 75 -32 168 -32 94 0 105 2 164 33 35 18 64 31 64 30 18 -50 63 -74 111 -58 57 19 60 32 57 258 -2 176 -6 211 -23 258 -24 63 -100 151 -163 188 -84 49 -205 67 -300 45z m142 -170 c93 -20 171 -113 172 -205 0 -58 -45 -140 -97 -177 -112 -80 -278 -26 -328 107 -43 112 34 247 158 276 45 11 41 11 95 -1z M547 960 c-105 -18 -200 -90 -248 -187 -23 -45 -24 -60 -27 -268 -2 -120 -1 -229 3 -242 7 -30 58 -56 94 -48 16 3 38 16 49 28 19 20 21 36 24 227 3 226 8 248 69 290 69 50 157 44 215 -14 46 -46 54 -88 54 -297 0 -179 1 -186 23 -207 43 -40 100 -37 134 7 9 11 12 71 13 201 0 102 5 202 10 222 32 114 172 160 264 87 55 -44 60 -66 61 -284 1 -110 5 -208 9 -218 13 -27 63 -49 97 -42 16 4 38 18 49 32 19 24 20 40 20 228 0 224 -8 268 -61 348 -60 90 -158 139 -280 139 -62 1 -88 -4 -135 -26 -33 -15 -71 -38 -85 -52 l-27 -26 -50 36 c-82 60 -179 83 -275 66z M3659 960 c-137 -23 -264 -138 -299 -268 -53 -202 61 -407 260 -466 102 -30 242 -14 304 35 15 12 28 20 29 18 1 -2 7 -13 13 -24 26 -48 94 -55 135 -14 19 19 20 30 17 237 -3 214 -3 218 -31 273 -50 103 -163 186 -282 208 -65 12 -79 12 -146 1z m114 -201 c33 -65 48 -81 107 -112 59 -31 61 -49 10 -72 -52 -24 -93 -70 -115 -131 -10 -27 -24 -56 -32 -64 -11 -12 -15 -12 -26 0 -8 8 -19 35 -26 59 -14 48 -67 110 -121 139 -19 10 -35 25 -35 33 0 7 21 23 46 35 52 25 106 82 115 122 8 34 24 54 38 49 6 -2 23 -28 39 -58z" />
+      </g>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary

The daily empty chat staged a conversation the user never had — two chat bubbles ("好，我来帮你理清楚。" / "为这个任务起草计划") and a Maka/user avatar pair — on the one surface that has no content, with the product tagline pitched underneath it every time a returning user opened a new chat. The Maka wordmark replaces all four pieces with one quiet anchor.

<img width="2940" height="1014" alt="image" src="https://github.com/user-attachments/assets/d5bc8160-eaef-46d8-a6fe-2885537674cd" />

Refs #1433 (item 4). Not `Closes`: items 5 and 6 remain, and item 5's premise changed — see the [progress comment](https://github.com/maka-agent/maka-agent/issues/1433#issuecomment-5076963344).

**The repo owned no Maka mark.** `provider-brands/*.svg` and `bot-brand-logo.tsx` are all third-party logos. The wordmark path is traced with `potrace` from the `maka` lockup in `apps/desktop/assets/icon.png` — deterministic vectorisation of an asset we already ship, not redrawn art — and lives in `packages/ui/src/maka-wordmark.tsx` beside `bot-brand-logo.tsx`, because `icons.tsx` is a pure lucide pass-through and fixed product assets get their own module. The icon-governance contract already encodes that split, so the file is allowlisted there with its provenance rather than sneaking past the inline-`<svg>` ban.

**Why the colour is its own token.** `var(--brand-deep)` was the obvious choice and is wrong: it resolves to `var(--accent)`, so the mark renders mauve on the mauve palette and cyan on the glacier one. A logo that follows the user's theme is a themed decoration, not a mark. `--maka-brand` is sampled from the same icon and held constant across palettes and across light/dark — the contract `--brand-wechat` already has. Its token note says explicitly that it is not a general accent, so it does not become the next source of the palette-invisibility bug `--brand-deep` exists to fix.

**Sizing.** At 160px the mark's cap height is ~42px against the 25px greeting (1.7:1 — reads as anchor-then-line). At the 104px it was first drafted at, the two were 27px and 25px, within 8% of each other, so neither led. 200px overshoots and the mark starts competing with the greeting instead of introducing it.

**The greeting steps down** from the 2.1333em first-run scale to ~20px: the daily empty chat is a landing surface, not a launch screen. `OnboardingHero` keeps the large scale, where the headline *is* the whole message.

**The composer is deliberately untouched.** Moving it between the empty and active states would turn the first message of every session into a layout jump; a stable input bar is worth more than a perfectly balanced empty screen.

`.maka-hero`'s width also moves from a hardcoded `min(750px, 80vw)` to `--maka-chat-measure`. This is a **consistency fix, not a bug fix** — see below.

## Verification

Measured in the live app (`getBoundingClientRect` in the built Electron app, empty chat opened from 新任务 with the sidebar expanded), main vs this branch, at four window widths:

| window | hero − composer centre (main → branch) | hero − band centre (main → branch) | hero width (main → branch) |
| --- | --- | --- | --- |
| 1440 | 6px → 6px | 6px → 6px | 750 → 680 |
| 1180 | 6px → 6px | 6px → 6px | 750 → 680 |
| 1024 | 6px → 6px | 6px → 6px | 750 → 680 |
| 900 | 6px → 6px | 6px → 6px | 720 → 680 |

**The hero was already centred on both axes, and this PR does not change that.** `.maka-chatContent` resolves to `display: grid`, and `margin: auto` on a grid item centres both axes — which is what `.maka-hero` has carried since PR-UI-1. An earlier draft of this branch added a `.maka-chatContent:has(...)` flex-centring rule on the theory that vertical centring was broken; measuring it against the live app showed identical geometry with and without the rule, so it is gone. That theory came from measuring the Storybook `ComposedShell` story, which owns its own scaffold and does not reproduce `.maka-chatContent` — the story is a fine surface for pixel iteration and the wrong one for a cascade claim.

The constant 6px is pre-existing and unrelated: the message column sits 6px right of the composer on `main` too. Filed as #1469.

Wordmark colour verified constant at `rgb(113, 168, 253)` on the default and mauve palettes, and in dark mode.

Ran, on this branch: workspace `typecheck`, `npm run lint`, `npm run format:check`, `check-dead-css`, `apps/desktop` `test:checks` (console / a11y / copy), and the full `apps/desktop` node suite — **2845/2845 pass**. The icon-governance contract caught the new inline `<svg>` and is the reason the allowlist entry above exists.

**Contract hardening (review follow-up).** `visible-copy-hygiene-contract` is named "free of staged conversation and product pitch" but only asserted the first half — its comment named the tagline, no assertion touched it. Confirmed by restoring the tagline in full (both locale fields plus `<p>{copy.intro}</p>`): all 30 tests stayed green. Now pinned two ways:

- **Literal text, per locale, across both the component and the copy bundle.** The two taglines had drifted into different jobs — zh pitched the product, en explained the composer — so neither string predicts the other. A field-name check will not do: `deepResearchEmpty.intro` is legitimate and must survive. Searching only the bundle will not do either — the same sentence hardcoded into the component walks past it.
- **An allowlist of the elements this surface renders**, rather than a ban on `<p>`. A ban only knows the tag the tagline happened to use: the identical sentence in a `<div>` slips straight through it. That is not hypothetical — it was the first thing tried against the ban, and it passed 30/30. A ban also fails in the other direction, rejecting a semantically correct `<p>` if this surface ever legitimately needs one, and pushing the author toward a worse tag to get green.

Verified against four injected regressions, each caught by the assertion that should catch it:

| injected regression | caught by |
| --- | --- |
| old bilingual tagline, via the copy bundle + `<p>` | literal |
| old zh tagline, hardcoded in a `<div>` | literal |
| newly written tagline in a `<p>` | allowlist |
| newly written tagline in a `<span>` | allowlist |

Not run: the Playwright E2E suite. No user journey changes here, and the hero's copy and structure are now pinned by the contract above.

## Review focus

`--maka-brand` is a new fixed token. If the answer to "should the logo follow the user's palette?" is yes, that decision inverts the first commit and leaves the second one standing unchanged.


