### PR TITLE
fix: restore Biome formatting in sqlite-session-metadata-store

### DIFF
--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -383,9 +383,7 @@ export class SqliteSessionMetadataStore {
       const existingBySource = this.readAgentGraphScheduleUpdateBySourceSync(request.source);
       if (existingBySource) return this.matchAgentGraphScheduleUpdate(existingBySource, request);
       if (this.hasClosedAgentGraphSchedule(request.graphId)) {
-        throw new AgentGraphScheduleUpdateConflictError(
-          'Agent graph schedule is already finished',
-        );
+        throw new AgentGraphScheduleUpdateConflictError('Agent graph schedule is already finished');
       }
       const revision = this.nextAgentGraphScheduleRevision(request.graphId);
       const update: AgentGraphScheduleUpdate = {


### PR DESCRIPTION
## Summary

`main` has been red since #1465. A single `throw` call in `SqliteSessionMetadataStore.upsertAgentGraphScheduleUpdate` is wrapped across three lines where Biome prints it on one:

```
-        throw new AgentGraphScheduleUpdateConflictError(
-          'Agent graph schedule is already finished',
-        );
+        throw new AgentGraphScheduleUpdateConflictError('Agent graph schedule is already finished');
```

`format:check` runs before `build`/`tsc` in the `typecheck` job, so this one line fails the whole job — and every PR opened since inherits the failure through its merge commit. Found while diagnosing a `typecheck` failure on #1470, whose own `test` and `e2e` jobs pass.

This is pure formatter output: `biome format --write` on the one file, no manual reflowing.

Refs #1465.

## Verification

`biome format .` — 1076 files, clean.
`biome lint .` — 2115 files, clean.

Not run: the test and e2e suites. This change alters whitespace inside one statement and cannot affect behaviour; the same two suites already pass on `main` at `8cb5a5bd5`, where only `typecheck` is red.
