### PR TITLE
feat(runtime): bootstrap dynamic graph operators

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -42,6 +42,7 @@
     "./agent-mailbox": "./dist/agent-mailbox.js",
     "./agent-graph-control": "./dist/agent-graph-control.js",
     "./agent-graph-schedule": "./dist/agent-graph-schedule.js",
+    "./agent-graph-topology": "./dist/agent-graph-topology.js",
     "./task-ledger": "./dist/task-ledger.js",
     "./foreign-session": "./dist/foreign-session.js",
     "./deep-research-run": "./dist/deep-research-run.js",

--- a/packages/core/src/__tests__/agent-graph-topology.test.ts
+++ b/packages/core/src/__tests__/agent-graph-topology.test.ts
@@ -1,0 +1,62 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  decodeAgentGraphOperatorProvision,
+  isAgentGraphOperatorProvisionRequest,
+  type AgentGraphOperatorProvisionRequest,
+} from '../agent-graph-topology.js';
+
+describe('agent graph topology provisions', () => {
+  test('strictly validates one monotonic operator addition', () => {
+    const request = provisionRequest();
+    assert.equal(isAgentGraphOperatorProvisionRequest(request), true);
+    assert.equal(
+      isAgentGraphOperatorProvisionRequest({
+        ...request,
+        edges: [...request.edges, { ...request.edges[0]!, edgeId: `graph_edge_${'9'.repeat(32)}` }],
+      }),
+      false,
+    );
+    assert.equal(
+      isAgentGraphOperatorProvisionRequest({
+        ...request,
+        edges: [{ ...request.edges[0]!, toOperatorId: 'another-operator' }],
+      }),
+      false,
+    );
+  });
+
+  test('decodes a persisted provision without sharing edge objects', () => {
+    const request = provisionRequest();
+    const persisted = {
+      ...request,
+      targetSessionId: 'child-session',
+      provisionedAt: 12,
+    };
+    const decoded = decodeAgentGraphOperatorProvision(persisted);
+    assert.deepEqual(decoded, persisted);
+    assert.notEqual(decoded.edges, persisted.edges);
+  });
+});
+
+function provisionRequest(): AgentGraphOperatorProvisionRequest {
+  const operatorId = `graph_operator_${'4'.repeat(32)}`;
+  return {
+    schemaVersion: 1,
+    provisionId: `graph_provision_${'1'.repeat(32)}`,
+    provisionFingerprint: `sha256:${'2'.repeat(64)}`,
+    graphId: 'graph-1',
+    workId: `graph_work_${'3'.repeat(32)}`,
+    agentId: 'local-read',
+    operatorId,
+    initialTurnId: 'turn-1',
+    initialRunId: 'run-1',
+    edges: [
+      {
+        edgeId: `graph_edge_${'5'.repeat(32)}`,
+        fromOperatorId: 'writer',
+        toOperatorId: operatorId,
+      },
+    ],
+  };
+}

--- a/packages/core/src/__tests__/subagent-session-parent.test.ts
+++ b/packages/core/src/__tests__/subagent-session-parent.test.ts
@@ -57,6 +57,29 @@ describe('subagent session parent relation', () => {
       }),
       true,
     );
+    assert.equal(
+      isSubagentSessionParent({
+        ...relation,
+        graph: {
+          graphId: 'graph-1',
+          workId: `graph_work_${'a'.repeat(32)}`,
+          operatorId: `graph_operator_${'b'.repeat(32)}`,
+        },
+      }),
+      true,
+    );
+    assert.equal(
+      isSubagentSessionParent({
+        ...relation,
+        swarm: { swarmId: 'swarm-1', itemId: 'item-1' },
+        graph: {
+          graphId: 'graph-1',
+          workId: `graph_work_${'a'.repeat(32)}`,
+          operatorId: `graph_operator_${'b'.repeat(32)}`,
+        },
+      }),
+      false,
+    );
   });
 
   test('rejects malformed, unsupported, or extended persisted relations', () => {

--- a/packages/core/src/agent-graph-schedule.ts
+++ b/packages/core/src/agent-graph-schedule.ts
@@ -3,6 +3,7 @@ import type {
   AgentGraphIntentClaimResult,
   AgentGraphIntentClaimStore,
 } from './agent-graph-control.js';
+import type { AgentGraphTopologyStore } from './agent-graph-topology.js';
 
 export const AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION = 1 as const;
 
@@ -126,7 +127,8 @@ export class AgentGraphScheduleClosedError extends Error {
  */
 export interface AgentGraphScheduleControlStore
   extends AgentGraphScheduleStore,
-    AgentGraphIntentClaimStore {
+    AgentGraphIntentClaimStore,
+    AgentGraphTopologyStore {
   claimAgentGraphIntentAtScheduleRevision(
     request: AgentGraphIntentClaimRequest,
     expectedRevision: number,

--- a/packages/core/src/agent-graph-topology.ts
+++ b/packages/core/src/agent-graph-topology.ts
@@ -1,0 +1,161 @@
+export const AGENT_GRAPH_OPERATOR_PROVISION_SCHEMA_VERSION = 1 as const;
+
+export interface AgentGraphProvisionedEdge {
+  edgeId: string;
+  fromOperatorId: string;
+  toOperatorId: string;
+}
+
+/**
+ * Durable request for one monotonic graph-topology extension.
+ *
+ * The request preallocates the first Runtime turn/run identities. The child
+ * Session and topology rows are committed together by the workspace metadata
+ * control plane, so a retry either observes the whole provision or creates it
+ * once.
+ */
+export interface AgentGraphOperatorProvisionRequest {
+  schemaVersion: typeof AGENT_GRAPH_OPERATOR_PROVISION_SCHEMA_VERSION;
+  provisionId: string;
+  provisionFingerprint: string;
+  graphId: string;
+  workId: string;
+  agentId: string;
+  operatorId: string;
+  initialTurnId: string;
+  initialRunId: string;
+  edges: AgentGraphProvisionedEdge[];
+}
+
+export interface AgentGraphOperatorProvision extends AgentGraphOperatorProvisionRequest {
+  targetSessionId: string;
+  provisionedAt: number;
+}
+
+export interface AgentGraphOperatorProvisionResult {
+  provision: AgentGraphOperatorProvision;
+  created: boolean;
+}
+
+export interface AgentGraphTopologyStore {
+  listAgentGraphOperatorProvisions(graphId: string): Promise<AgentGraphOperatorProvision[]>;
+}
+
+export function isAgentGraphOperatorProvisionRequest(
+  value: unknown,
+): value is AgentGraphOperatorProvisionRequest {
+  if (
+    !isExactRecord(value, [
+      'schemaVersion',
+      'provisionId',
+      'provisionFingerprint',
+      'graphId',
+      'workId',
+      'agentId',
+      'operatorId',
+      'initialTurnId',
+      'initialRunId',
+      'edges',
+    ])
+  ) {
+    return false;
+  }
+  const request = value as unknown as AgentGraphOperatorProvisionRequest;
+  return (
+    request.schemaVersion === AGENT_GRAPH_OPERATOR_PROVISION_SCHEMA_VERSION &&
+    /^graph_provision_[a-f0-9]{32}$/.test(request.provisionId) &&
+    isSha256Fingerprint(request.provisionFingerprint) &&
+    isIdentity(request.graphId) &&
+    /^graph_work_[a-f0-9]{32}$/.test(request.workId) &&
+    isIdentity(request.agentId) &&
+    /^graph_operator_[a-f0-9]{32}$/.test(request.operatorId) &&
+    isIdentity(request.initialTurnId) &&
+    isIdentity(request.initialRunId) &&
+    Array.isArray(request.edges) &&
+    request.edges.length <= 64 &&
+    request.edges.every(
+      (edge) =>
+        isExactRecord(edge, ['edgeId', 'fromOperatorId', 'toOperatorId']) &&
+        /^graph_edge_[a-f0-9]{32}$/.test(edge.edgeId) &&
+        isIdentity(edge.fromOperatorId) &&
+        edge.toOperatorId === request.operatorId,
+    ) &&
+    unique(request.edges.map((edge) => edge.edgeId)) &&
+    unique(request.edges.map((edge) => edge.fromOperatorId))
+  );
+}
+
+export function isAgentGraphOperatorProvision(
+  value: unknown,
+): value is AgentGraphOperatorProvision {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    Array.isArray(value) ||
+    !Object.prototype.hasOwnProperty.call(value, 'targetSessionId') ||
+    !Object.prototype.hasOwnProperty.call(value, 'provisionedAt')
+  ) {
+    return false;
+  }
+  const { targetSessionId, provisionedAt, ...request } = value as Record<string, unknown>;
+  return (
+    isAgentGraphOperatorProvisionRequest(request) &&
+    isIdentity(targetSessionId) &&
+    typeof provisionedAt === 'number' &&
+    Number.isSafeInteger(provisionedAt) &&
+    provisionedAt >= 0
+  );
+}
+
+export function assertAgentGraphOperatorProvisionRequest(
+  value: unknown,
+): asserts value is AgentGraphOperatorProvisionRequest {
+  if (!isAgentGraphOperatorProvisionRequest(value)) {
+    throw new Error('Invalid agent graph operator provision request');
+  }
+}
+
+export function decodeAgentGraphOperatorProvision(value: unknown): AgentGraphOperatorProvision {
+  if (!isAgentGraphOperatorProvision(value)) {
+    throw new Error('Invalid agent graph operator provision');
+  }
+  return {
+    schemaVersion: value.schemaVersion,
+    provisionId: value.provisionId,
+    provisionFingerprint: value.provisionFingerprint,
+    graphId: value.graphId,
+    workId: value.workId,
+    agentId: value.agentId,
+    operatorId: value.operatorId,
+    initialTurnId: value.initialTurnId,
+    initialRunId: value.initialRunId,
+    edges: value.edges.map((edge) => ({ ...edge })),
+    targetSessionId: value.targetSessionId,
+    provisionedAt: value.provisionedAt,
+  };
+}
+
+function isIdentity(value: unknown): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= 512 &&
+    value.trim() === value &&
+    !/[\u0000-\u001f\u007f]/.test(value)
+  );
+}
+
+function isSha256Fingerprint(value: unknown): value is string {
+  return typeof value === 'string' && /^sha256:[a-f0-9]{64}$/.test(value);
+}
+
+function unique(values: readonly string[]): boolean {
+  return new Set(values).size === values.length;
+}
+
+function isExactRecord(value: unknown, keys: readonly string[]): value is Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const actual = Object.keys(value).sort();
+  const expected = [...keys].sort();
+  return actual.length === expected.length && actual.every((key, index) => key === expected[index]);
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,6 +14,7 @@ export * from './swarm-command.js';
 export * from './plan.js';
 export * from './agent-graph-control.js';
 export * from './agent-graph-schedule.js';
+export * from './agent-graph-topology.js';
 export * from './runtime-policy.js';
 
 // events.ts

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -95,6 +95,11 @@ export interface SubagentSessionParent {
     swarmId: string;
     itemId: string;
   };
+  graph?: {
+    graphId: string;
+    workId: string;
+    operatorId: string;
+  };
   lifecycle: SubagentSessionLifecycle;
 }
 
@@ -289,7 +294,7 @@ export interface LinkedSessionTreeProjectionOptions {
 
 const SUBAGENT_SESSION_PARENT_SHAPE = defineObjectShape<SubagentSessionParent>()(
   ['kind', 'parentSessionId', 'spawnedBy', 'lifecycle'],
-  ['swarm'],
+  ['swarm', 'graph'],
 );
 const SUBAGENT_SESSION_SPAWN_SHAPE = defineObjectShape<SubagentSessionParent['spawnedBy']>()(
   ['parentRunId', 'parentTurnId', 'toolCallId'],
@@ -298,6 +303,9 @@ const SUBAGENT_SESSION_SPAWN_SHAPE = defineObjectShape<SubagentSessionParent['sp
 const SUBAGENT_SESSION_SWARM_SHAPE = defineObjectShape<
   NonNullable<SubagentSessionParent['swarm']>
 >()(['swarmId', 'itemId'], []);
+const SUBAGENT_SESSION_GRAPH_SHAPE = defineObjectShape<
+  NonNullable<SubagentSessionParent['graph']>
+>()(['graphId', 'workId', 'operatorId'], []);
 const SUBAGENT_SESSION_RUNTIME_SHAPE = defineObjectShape<SubagentSessionRuntime>()(
   [
     'schemaVersion',
@@ -339,13 +347,20 @@ export function isSubagentSessionParent(value: unknown): value is SubagentSessio
   ) {
     return false;
   }
-  return (
+  const swarmValid =
     value.swarm === undefined ||
     (isRecord(value.swarm) &&
       hasExactShape(value.swarm, SUBAGENT_SESSION_SWARM_SHAPE) &&
       isSessionLineageId(value.swarm.swarmId) &&
-      isSessionLineageId(value.swarm.itemId))
-  );
+      isSessionLineageId(value.swarm.itemId));
+  const graphValid =
+    value.graph === undefined ||
+    (isRecord(value.graph) &&
+      hasExactShape(value.graph, SUBAGENT_SESSION_GRAPH_SHAPE) &&
+      isSessionLineageId(value.graph.graphId) &&
+      isSessionLineageId(value.graph.workId) &&
+      isSessionLineageId(value.graph.operatorId));
+  return swarmValid && graphValid && !(value.swarm && value.graph);
 }
 
 /** Strict decoder guard for the persisted child execution snapshot. */

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -13,6 +13,8 @@ import type {
   QueueEnqueueOutcome,
   AgentGraphIntentClaim,
   AgentGraphIntentClaimStore,
+  AgentGraphOperatorProvisionRequest,
+  AgentGraphOperatorProvisionResult,
   AgentRunEvent,
   AgentRunHeader,
   AgentRunStore,
@@ -109,6 +111,72 @@ describe('SessionManager child-session read model', () => {
     expect((await manager.listChildSessions(parent.id)).map((session) => session.id)).toEqual([
       child.id,
     ]);
+  });
+});
+
+describe('SessionManager graph operator provisioning', () => {
+  test('snapshots a catalog agent into a metadata-only child with reserved activation ids', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends: new BackendRegistry(),
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(30),
+    });
+    const parent = await manager.createSession(
+      makeInput({
+        cwd: '/tmp/graph-project',
+        llmConnectionSlug: 'graph-connection',
+        model: 'graph-model',
+        thinkingLevel: 'medium',
+        permissionMode: 'ask',
+      }),
+    );
+    await runStore.createRun(
+      makeRunHeader({
+        sessionId: parent.id,
+        runId: 'supervisor-run',
+        turnId: 'supervisor-turn',
+        cwd: '/tmp/graph-project',
+      }),
+    );
+
+    const result = await manager.provisionAgentGraphOperator({
+      graphId: 'graph-1',
+      workId: `graph_work_${'1'.repeat(32)}`,
+      agentId: LOCAL_READ_AGENT_ID,
+      operatorId: `graph_operator_${'2'.repeat(32)}`,
+      source: {
+        sessionId: parent.id,
+        runId: 'supervisor-run',
+        turnId: 'supervisor-turn',
+        toolCallId: 'schedule-tool',
+      },
+      edges: [
+        {
+          edgeId: `graph_edge_${'3'.repeat(32)}`,
+          fromOperatorId: 'writer',
+          toOperatorId: `graph_operator_${'2'.repeat(32)}`,
+        },
+      ],
+      expectedScheduleRevision: 1,
+    });
+
+    expect(result.created).toBe(true);
+    expect(result.header.subagentParent?.graph).toEqual({
+      graphId: 'graph-1',
+      workId: `graph_work_${'1'.repeat(32)}`,
+      operatorId: `graph_operator_${'2'.repeat(32)}`,
+    });
+    expect(result.header.subagentRuntime?.agentId).toBe(LOCAL_READ_AGENT_ID);
+    expect(result.header.permissionMode).toBe('explore');
+    expect(result.provision.initialTurnId).toBe(result.header.subagentSpawn?.initialTurnId);
+    expect(result.provision.initialRunId).toBe(result.header.subagentSpawn?.initialRunId);
+    expect(await runStore.listSessionRuns(result.header.id)).toEqual([]);
   });
 });
 
@@ -15282,6 +15350,24 @@ class MemorySessionStore implements SessionStore {
       return { header: existing, created: false };
     }
     return { header: await this.create(input), created: true };
+  }
+
+  async createAgentGraphOperator(
+    input: CreateSessionInput,
+    request: AgentGraphOperatorProvisionRequest,
+    _expectedRevision: number,
+  ): Promise<{ header: SessionHeader } & AgentGraphOperatorProvisionResult> {
+    const header = await this.create(input);
+    return {
+      header,
+      created: true,
+      provision: {
+        ...request,
+        edges: request.edges.map((edge) => ({ ...edge })),
+        targetSessionId: header.id,
+        provisionedAt: 1,
+      },
+    };
   }
 
   async create(input: CreateSessionInput): Promise<SessionHeader> {

--- a/packages/runtime/src/__tests__/stream-graph-schedule-reconcile.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-schedule-reconcile.test.ts
@@ -5,6 +5,8 @@ import type {
   AgentGraphScheduleUpdateRequest,
 } from '@maka/core/agent-graph-schedule';
 import type { AgentGraphIntentClaimStore } from '@maka/core/agent-graph-control';
+import type { AgentGraphOperatorProvision } from '@maka/core/agent-graph-topology';
+import type { SessionHeader } from '@maka/core/session';
 import { createSqliteSessionMetadataStore } from '@maka/storage';
 import type {
   AgentGraphIntentExecutor,
@@ -97,6 +99,83 @@ describe('stream graph schedule reconciliation', () => {
     }
   });
 
+  test('materializes agent work as a child operator and claims its reserved first run', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(150) });
+    const provisions: AgentGraphOperatorProvision[] = [];
+    const controlStore = controlStoreWithProvisions(store, provisions);
+    const observation = new MemoryGraphObservation();
+    const executor = new MemoryScheduleExecutor(controlStore, observation);
+    const stopController = new MemoryStopController(observation);
+    try {
+      const update = await commitSchedule(controlStore, 'tool-agent', {
+        add_work: [
+          {
+            agent_id: 'local-read',
+            instruction: 'Inspect one more source.',
+            input_ids: ['record-input'],
+          },
+        ],
+      });
+      let provisionCalls = 0;
+      const result = await reconcileAgentGraphSchedule({
+        topology: topology(),
+        controlStore,
+        executor,
+        stopController,
+        newId: nextId(),
+        maxNewActivations: 1,
+        observeGraph: (currentTopology) => observation.read(currentTopology),
+        async provisionOperator(input) {
+          provisionCalls += 1;
+          assert.equal(input.workId, update.addWork[0]!.workId);
+          assert.equal(input.source.toolCallId, 'tool-agent');
+          assert.deepEqual(
+            input.edges.map((edge) => edge.fromOperatorId),
+            ['writer'],
+          );
+          const provision: AgentGraphOperatorProvision = {
+            schemaVersion: 1,
+            provisionId: `graph_provision_${'1'.repeat(32)}`,
+            provisionFingerprint: `sha256:${'2'.repeat(64)}`,
+            graphId: input.graphId,
+            workId: input.workId,
+            agentId: input.agentId,
+            operatorId: input.operatorId,
+            initialTurnId: 'reserved-turn',
+            initialRunId: 'reserved-run',
+            edges: input.edges,
+            targetSessionId: 'session-dynamic',
+            provisionedAt: 151,
+          };
+          provisions.push(provision);
+          return {
+            provision,
+            created: true,
+            header: { id: provision.targetSessionId } as SessionHeader,
+          };
+        },
+        renderPrompt: ({ work }) => work.instruction,
+      });
+
+      assert.equal(result.status, 'reconciled');
+      assert.equal(provisionCalls, 1);
+      assert.equal(result.deferredWork.length, 0);
+      assert.equal(result.dispatches.length, 1);
+      assert.match(result.dispatches[0]!.intent.operatorId, /^graph_operator_[a-f0-9]{32}$/);
+      assert.equal(result.dispatches[0]!.claim.targetSessionId, 'session-dynamic');
+      assert.equal(result.dispatches[0]!.claim.targetTurnId, 'reserved-turn');
+      assert.equal(result.dispatches[0]!.claim.targetRunId, 'reserved-run');
+      assert.equal(
+        result.observation.projection.operators.some(
+          (operator) => operator.sessionId === 'session-dynamic',
+        ),
+        true,
+      );
+    } finally {
+      store.close();
+    }
+  });
+
   test('stops an admitted activation before considering later work', async () => {
     const store = createSqliteSessionMetadataStore(':memory:', { now: nextNumber(200) });
     const observation = new MemoryGraphObservation();
@@ -175,6 +254,8 @@ describe('stream graph schedule reconciliation', () => {
       const racingStore: AgentGraphScheduleControlStore = {
         commitAgentGraphScheduleUpdate: (request) => store.commitAgentGraphScheduleUpdate(request),
         listAgentGraphScheduleUpdates: (graphId) => store.listAgentGraphScheduleUpdates(graphId),
+        listAgentGraphOperatorProvisions: (graphId) =>
+          store.listAgentGraphOperatorProvisions(graphId),
         claimAgentGraphIntent: (request) => store.claimAgentGraphIntent(request),
         readAgentGraphIntentClaim: (graphId, intentId) =>
           store.readAgentGraphIntentClaim(graphId, intentId),
@@ -242,6 +323,8 @@ describe('stream graph schedule reconciliation', () => {
       const pausingStore: AgentGraphScheduleControlStore = {
         commitAgentGraphScheduleUpdate: (request) => store.commitAgentGraphScheduleUpdate(request),
         listAgentGraphScheduleUpdates: (graphId) => store.listAgentGraphScheduleUpdates(graphId),
+        listAgentGraphOperatorProvisions: (graphId) =>
+          store.listAgentGraphOperatorProvisions(graphId),
         claimAgentGraphIntent: (request) => store.claimAgentGraphIntent(request),
         readAgentGraphIntentClaim: (graphId, intentId) =>
           store.readAgentGraphIntentClaim(graphId, intentId),
@@ -383,6 +466,30 @@ async function commitSchedule(
   return request;
 }
 
+function controlStoreWithProvisions(
+  store: AgentGraphScheduleControlStore,
+  provisions: AgentGraphOperatorProvision[],
+): AgentGraphScheduleControlStore {
+  return {
+    commitAgentGraphScheduleUpdate: (request) => store.commitAgentGraphScheduleUpdate(request),
+    listAgentGraphScheduleUpdates: (graphId) => store.listAgentGraphScheduleUpdates(graphId),
+    listAgentGraphOperatorProvisions: async (graphId) =>
+      provisions
+        .filter((provision) => provision.graphId === graphId)
+        .map((provision) => structuredClone(provision)),
+    claimAgentGraphIntent: (request) => store.claimAgentGraphIntent(request),
+    readAgentGraphIntentClaim: (graphId, intentId) =>
+      store.readAgentGraphIntentClaim(graphId, intentId),
+    listAgentGraphIntentClaims: (graphId) => store.listAgentGraphIntentClaims(graphId),
+    claimAgentGraphIntentAtScheduleRevision: (request, expectedRevision) =>
+      store.claimAgentGraphIntentAtScheduleRevision(request, expectedRevision),
+    beginAgentGraphIntentExecutionAtScheduleRevision: (graphId, intentId, expectedRevision) =>
+      store.beginAgentGraphIntentExecutionAtScheduleRevision(graphId, intentId, expectedRevision),
+    cancelAgentGraphIntentExecution: (graphId, intentId, reason) =>
+      store.cancelAgentGraphIntentExecution(graphId, intentId, reason),
+  };
+}
+
 class MemoryGraphObservation {
   private readonly activations = new Map<
     string,
@@ -408,29 +515,49 @@ class MemoryGraphObservation {
     }
   }
 
-  async read(): Promise<AgentGraphSupervisorObservation> {
-    const activationEntries = [...this.activations]
-      .filter(([, activation]) => activation.sessionId === 'session-writer')
-      .map(([activationId, activation]) => [
-        activationId,
-        {
-          activationId,
-          agentRunId: activationId,
-          status: activation.status,
-          recordCount: 1,
-          firstEventTime: 1,
-          lastEventTime: 2,
-          lastRecordId: `record-${activationId}`,
-          ...(activation.status === 'running'
-            ? {}
-            : { terminalRecordId: `record-${activationId}` }),
-        },
-      ]);
-    const current = activationEntries.at(-1)?.[0] as string | undefined;
+  async read(
+    currentTopology: AgentGraphTraceTopology = topology(),
+  ): Promise<AgentGraphSupervisorObservation> {
+    const operatorStates = Object.fromEntries(
+      currentTopology.operators.flatMap((binding) => {
+        const activationEntries = [...this.activations]
+          .filter(([, activation]) => activation.sessionId === binding.sessionId)
+          .map(([activationId, activation]) => [
+            activationId,
+            {
+              activationId,
+              agentRunId: activationId,
+              status: activation.status,
+              recordCount: 1,
+              firstEventTime: 1,
+              lastEventTime: 2,
+              lastRecordId: `record-${activationId}`,
+              ...(activation.status === 'running'
+                ? {}
+                : { terminalRecordId: `record-${activationId}` }),
+            },
+          ]);
+        const current = activationEntries.at(-1)?.[0] as string | undefined;
+        return current
+          ? [
+              [
+                binding.operatorId,
+                {
+                  operatorId: binding.operatorId,
+                  sessionId: binding.sessionId,
+                  status: this.activations.get(current)!.status,
+                  currentActivationId: current,
+                  activations: Object.fromEntries(activationEntries),
+                },
+              ],
+            ]
+          : [];
+      }),
+    );
     return structuredClone({
       projection: {
         graphId: GRAPH_ID,
-        operators: [{ operatorId: 'writer', sessionId: 'session-writer' }],
+        operators: currentTopology.operators.map((operator) => ({ ...operator })),
         ignoredPartialEvents: 0,
         records: [
           {
@@ -466,17 +593,7 @@ class MemoryGraphObservation {
         state: {
           graphId: GRAPH_ID,
           appliedRecordIds: ['record-input'],
-          operators: current
-            ? {
-                writer: {
-                  operatorId: 'writer',
-                  sessionId: 'session-writer',
-                  status: this.activations.get(current)!.status,
-                  currentActivationId: current,
-                  activations: Object.fromEntries(activationEntries),
-                },
-              }
-            : {},
+          operators: operatorStates,
         },
       },
       readiness: {
@@ -487,7 +604,7 @@ class MemoryGraphObservation {
           schemaVersion: 1,
           graphId: GRAPH_ID,
           topologyFingerprint: `sha256:${'a'.repeat(64)}`,
-          topologicalOrder: ['writer'],
+          topologicalOrder: currentTopology.operators.map((operator) => operator.operatorId),
           rootOperatorIds: ['writer'],
           sinkOperatorIds: ['writer'],
           recordIds: ['record-input'],

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -73,6 +73,10 @@ import {
 import type {
   AgentGraphIntentClaim,
   AgentGraphIntentClaimStore,
+  AgentGraphOperatorProvisionRequest,
+  AgentGraphOperatorProvisionResult,
+  AgentGraphProvisionedEdge,
+  AgentGraphScheduleUpdateSource,
   AgentRunEvent,
   AgentRunHeader,
   AgentRunStore,
@@ -81,6 +85,7 @@ import type {
   RuntimeEventStore,
   ToolBoundaryProtocol,
 } from '@maka/core';
+import { AGENT_GRAPH_OPERATOR_PROVISION_SCHEMA_VERSION } from '@maka/core';
 import { type RuntimeEventTerminalFact } from './runtime-event-read-model.js';
 import {
   RuntimeReadModel,
@@ -136,6 +141,7 @@ import {
 } from './agent-catalog.js';
 import { buildRuntimeEventModelReplayPlan } from './model-history.js';
 import { requireResolvedAgentDefinition } from './expert-catalog.js';
+import { stableHash } from './request-shape.js';
 import type { SubagentExecutionRef } from './subagent-execution.js';
 import {
   buildResumePlanFromRuntimeEvents,
@@ -197,6 +203,20 @@ export interface SpawnChildSessionResult extends SpawnChildAgentResult {
   childSessionId: string;
   runId: string;
   profile: string;
+}
+
+export interface ProvisionAgentGraphOperatorInput {
+  graphId: string;
+  workId: string;
+  agentId: string;
+  operatorId: string;
+  source: AgentGraphScheduleUpdateSource;
+  edges: AgentGraphProvisionedEdge[];
+  expectedScheduleRevision: number;
+}
+
+export interface ProvisionAgentGraphOperatorResult extends AgentGraphOperatorProvisionResult {
+  header: SessionHeader;
 }
 
 export interface RunClaimedAgentGraphIntentInput {
@@ -372,6 +392,11 @@ export interface AgentOutputResult {
 export interface SessionStore {
   create(input: CreateSessionInput): Promise<SessionHeader>;
   createSubagent(input: CreateSessionInput): Promise<{ header: SessionHeader; created: boolean }>;
+  createAgentGraphOperator?(
+    input: CreateSessionInput,
+    request: AgentGraphOperatorProvisionRequest,
+    expectedRevision: number,
+  ): Promise<ProvisionAgentGraphOperatorResult>;
   list(filter?: SessionListFilter): Promise<SessionSummary[]>;
   readHeader(sessionId: string): Promise<SessionHeader>;
   readMessages(sessionId: string): Promise<StoredMessage[]>;
@@ -1400,6 +1425,144 @@ export class SessionManager {
         this.childSessionSpawns.delete(spawnKey);
       }
     }
+  }
+
+  /**
+   * Atomically materialize one catalog agent as a durable child Session and a
+   * monotonic graph-topology operator.
+   *
+   * This is metadata admission only. The reserved first turn/run is executed
+   * later through the ordinary claimed graph-intent path.
+   */
+  async provisionAgentGraphOperator(
+    input: ProvisionAgentGraphOperatorInput,
+  ): Promise<ProvisionAgentGraphOperatorResult> {
+    const create = this.deps.store.createAgentGraphOperator;
+    if (!create || !this.deps.runStore || !this.deps.runtimeEventStore) {
+      throw new Error(
+        'Graph operator provisioning requires SQLite Session metadata, AgentRunStore, and RuntimeEventStore',
+      );
+    }
+    if (input.source.sessionId.length === 0) {
+      throw new Error('Graph operator provision requires a supervisor Session');
+    }
+    const [parentHeader, sourceRun] = await Promise.all([
+      this.deps.store.readHeader(input.source.sessionId),
+      this.deps.runStore.readRun(input.source.sessionId, input.source.runId),
+    ]);
+    if (
+      sourceRun.sessionId !== input.source.sessionId ||
+      sourceRun.runId !== input.source.runId ||
+      sourceRun.turnId !== input.source.turnId
+    ) {
+      throw new Error('Graph schedule source does not match its durable supervisor run');
+    }
+
+    const definition = requireResolvedAgentDefinition(input.agentId);
+    assertAgentDefinitionRunnable({
+      parentPermissionMode: parentHeader.permissionMode,
+      definition,
+      tools: this.deps.childTools ?? [],
+    });
+
+    const initialTurnId = this.deps.newId();
+    const initialRunId = this.deps.newId();
+    const identityHash = stableHash({
+      schemaVersion: AGENT_GRAPH_OPERATOR_PROVISION_SCHEMA_VERSION,
+      graphId: input.graphId,
+      workId: input.workId,
+    }).slice('sha256:'.length, 'sha256:'.length + 32);
+    const provisionFingerprint = stableHash({
+      schemaVersion: AGENT_GRAPH_OPERATOR_PROVISION_SCHEMA_VERSION,
+      graphId: input.graphId,
+      workId: input.workId,
+      agentId: input.agentId,
+      operatorId: input.operatorId,
+      source: input.source,
+      edges: input.edges,
+      definition: {
+        definitionVersion: definition.definitionVersion,
+        agentId: definition.id,
+        profile: definition.profile,
+        permissionMode: definition.permissionMode,
+        toolNames: [...definition.tools],
+        categoryPolicy: { ...definition.categoryPolicy },
+        systemPrompt: definition.systemPrompt,
+      },
+      parentPermissionCeiling: parentHeader.permissionMode,
+    });
+    const request: AgentGraphOperatorProvisionRequest = {
+      schemaVersion: AGENT_GRAPH_OPERATOR_PROVISION_SCHEMA_VERSION,
+      provisionId: `graph_provision_${identityHash}`,
+      provisionFingerprint,
+      graphId: input.graphId,
+      workId: input.workId,
+      agentId: input.agentId,
+      operatorId: input.operatorId,
+      initialTurnId,
+      initialRunId,
+      edges: input.edges.map((edge) => ({ ...edge })),
+    };
+    const result = await create.call(
+      this.deps.store,
+      {
+        cwd: parentHeader.cwd,
+        name: definition.name,
+        backend: parentHeader.backend,
+        llmConnectionSlug: parentHeader.llmConnectionSlug,
+        model: parentHeader.model,
+        ...(parentHeader.thinkingLevel !== undefined
+          ? { thinkingLevel: parentHeader.thinkingLevel }
+          : {}),
+        permissionMode: definition.permissionMode,
+        collaborationMode: 'agent',
+        orchestrationMode: 'default',
+        subagentParent: {
+          kind: 'subagent',
+          parentSessionId: input.source.sessionId,
+          spawnedBy: {
+            parentRunId: input.source.runId,
+            parentTurnId: input.source.turnId,
+            toolCallId: input.source.toolCallId,
+          },
+          graph: {
+            graphId: input.graphId,
+            workId: input.workId,
+            operatorId: input.operatorId,
+          },
+          lifecycle: 'foreground',
+        },
+        subagentRuntime: {
+          schemaVersion: SUBAGENT_SESSION_RUNTIME_SCHEMA_VERSION,
+          definitionVersion: definition.definitionVersion,
+          agentId: definition.id,
+          agentName: definition.name,
+          profile: definition.profile,
+          systemPrompt: definition.systemPrompt,
+          toolNames: [...definition.tools],
+          categoryPolicy: { ...definition.categoryPolicy },
+          permissionCeiling: parentHeader.permissionMode,
+        },
+        subagentSpawn: {
+          schemaVersion: SUBAGENT_SESSION_SPAWN_SCHEMA_VERSION,
+          requestFingerprint: provisionFingerprint.slice('sha256:'.length),
+          initialTurnId,
+          initialRunId,
+        },
+      },
+      request,
+      input.expectedScheduleRevision,
+    );
+    const relation = result.header.subagentParent?.graph;
+    if (
+      relation?.graphId !== input.graphId ||
+      relation.workId !== input.workId ||
+      relation.operatorId !== result.provision.operatorId ||
+      result.header.id !== result.provision.targetSessionId
+    ) {
+      throw new Error('Stored graph operator provision returned mismatched Session metadata');
+    }
+    return result;
   }
 
   /**

--- a/packages/runtime/src/stream-graph-admission.ts
+++ b/packages/runtime/src/stream-graph-admission.ts
@@ -12,6 +12,9 @@ export interface ClaimAgentGraphRunnableIntentInput {
   intent: AgentGraphRunnableIntent;
   store: Pick<AgentGraphIntentClaimStore, 'claimAgentGraphIntent'>;
   newId: () => string;
+  /** Reuse topology-provisioned identities for a newly materialized operator. */
+  targetTurnId?: string;
+  targetRunId?: string;
   /**
    * Stable execution input resolved before admission.
    *
@@ -55,7 +58,7 @@ export function claimAgentGraphRunnableIntent(
     readinessContextFingerprint: input.intent.readinessContextFingerprint,
     targetOperatorId: input.intent.operatorId,
     targetSessionId: input.intent.targetSessionId,
-    targetTurnId: input.newId(),
-    targetRunId: input.newId(),
+    targetTurnId: input.targetTurnId ?? input.newId(),
+    targetRunId: input.targetRunId ?? input.newId(),
   });
 }

--- a/packages/runtime/src/stream-graph-schedule-reconcile.ts
+++ b/packages/runtime/src/stream-graph-schedule-reconcile.ts
@@ -5,7 +5,13 @@ import type {
 import {
   AgentGraphScheduleRevisionConflictError,
   type AgentGraphScheduleControlStore,
+  type AgentGraphScheduleUpdate,
+  type AgentGraphScheduleUpdateSource,
 } from '@maka/core/agent-graph-schedule';
+import type {
+  AgentGraphOperatorProvision,
+  AgentGraphProvisionedEdge,
+} from '@maka/core/agent-graph-topology';
 import type { SessionEvent } from '@maka/core/events';
 import { claimAgentGraphRunnableIntent } from './stream-graph-admission.js';
 import type {
@@ -14,6 +20,10 @@ import type {
   AgentGraphSupervisorObserver,
   AgentGraphSupervisorObservation,
 } from './stream-graph-dispatch.js';
+import type {
+  ProvisionAgentGraphOperatorInput,
+  ProvisionAgentGraphOperatorResult,
+} from './session-manager.js';
 import type { AgentGraphRecord } from './stream-graph-projection.js';
 import type { AgentGraphRunnableIntent } from './stream-graph-readiness.js';
 import {
@@ -43,7 +53,10 @@ export interface ReconcileAgentGraphScheduleInput {
   stopController: AgentGraphScheduleStopController;
   newId: () => string;
   maxNewActivations: number;
-  observeGraph(): Promise<AgentGraphSupervisorObservation>;
+  observeGraph(topology: AgentGraphTraceTopology): Promise<AgentGraphSupervisorObservation>;
+  provisionOperator?(
+    input: ProvisionAgentGraphOperatorInput,
+  ): Promise<ProvisionAgentGraphOperatorResult>;
   renderPrompt(input: RenderAgentGraphScheduledWorkPromptInput): string | Promise<string>;
   abortSignal?: AbortSignal;
   supervisor?: AgentGraphSupervisorObserver;
@@ -64,7 +77,7 @@ export interface AgentGraphScheduleDeferredWork {
 }
 
 export interface AgentGraphScheduleReconciliationFailure {
-  phase: 'schedule' | 'stop' | 'render' | 'dispatch';
+  phase: 'schedule' | 'topology' | 'stop' | 'render' | 'dispatch';
   error: unknown;
   work?: AgentGraphScheduleWorkView;
   intent?: AgentGraphRunnableIntent;
@@ -87,12 +100,16 @@ interface ScheduleSnapshot {
   schedule: AgentGraphScheduleProjection;
   observation: AgentGraphSupervisorObservation;
   claims: AgentGraphIntentClaim[];
+  topology: AgentGraphTraceTopology;
+  provisions: AgentGraphOperatorProvision[];
+  sourceByWorkId: Map<string, AgentGraphScheduleUpdateSource>;
 }
 
 interface PreparedWork {
   work: AgentGraphScheduleWorkView;
   intent: AgentGraphRunnableIntent;
   prompt: string;
+  provision?: AgentGraphOperatorProvision;
 }
 
 type ScheduleDispatchOutcome =
@@ -110,12 +127,13 @@ type ScheduleDispatchOutcome =
     };
 
 /**
- * Applies durable supervisor schedule intent to existing graph operators.
+ * Applies durable supervisor schedule intent to existing and newly
+ * materialized graph operators.
  *
  * Schedule revision and new intent admission are linearized by the control
  * store. Existing claims remain recoverable after finish; unclaimed work does
- * not cross terminal closure. New catalog-agent nodes deliberately remain a
- * separate dynamic-topology concern.
+ * not cross terminal closure. Catalog-agent work is materialized through an
+ * append-only topology provision before its first intent is claimed.
  */
 export async function reconcileAgentGraphSchedule(
   input: ReconcileAgentGraphScheduleInput,
@@ -167,10 +185,76 @@ export async function reconcileAgentGraphSchedule(
     }
 
     const claimsByIntent = new Map(snapshot.claims.map((claim) => [claim.intentId, claim]));
+    const provisionsByWork = new Map(
+      snapshot.provisions.map((provision) => [provision.workId, provision]),
+    );
     const committedRecords = new Map(
       snapshot.observation.projection.records.map((record) => [record.recordId, record]),
     );
     const deferredWork: AgentGraphScheduleDeferredWork[] = [];
+    let topologyChanged = false;
+    let topologyStale = false;
+
+    for (const work of orderedRequestedWork(snapshot.schedule)) {
+      if (work.target.kind !== 'agent' || provisionsByWork.has(work.workId)) continue;
+      if (snapshot.schedule.closed) {
+        deferredWork.push({ work, reason: 'graph_closed' });
+        continue;
+      }
+      const missingInputIds = work.inputIds.filter((recordId) => !committedRecords.has(recordId));
+      if (missingInputIds.length > 0) {
+        deferredWork.push({ work, reason: 'input_not_committed', missingInputIds });
+        continue;
+      }
+      if (!input.provisionOperator) {
+        deferredWork.push({ work, reason: 'agent_topology_required' });
+        continue;
+      }
+      const source = snapshot.sourceByWorkId.get(work.workId);
+      if (!source) {
+        failures.push({
+          phase: 'topology',
+          work,
+          error: new Error(`Graph work ${work.workId} has no durable schedule source`),
+        });
+        continue;
+      }
+      try {
+        await input.provisionOperator(
+          buildOperatorProvisionInput(
+            snapshot.topology,
+            snapshot.observation,
+            work,
+            source,
+            snapshot.schedule.revision,
+          ),
+        );
+        topologyChanged = true;
+      } catch (error) {
+        if (error instanceof AgentGraphScheduleRevisionConflictError) {
+          topologyStale = true;
+          break;
+        }
+        failures.push({ phase: 'topology', work, error });
+      }
+    }
+    if (topologyChanged || topologyStale) {
+      snapshot = await readScheduleSnapshot(input);
+      if (failures.length === 0) continue;
+    }
+    if (failures.length > 0) {
+      return reconciliationResult(
+        'failed',
+        newActivationCount,
+        observedExistingActivationCount,
+        dispatches,
+        stops,
+        deferredWork,
+        failures,
+        snapshot,
+      );
+    }
+
     const candidates: Array<{
       work: AgentGraphScheduleWorkView;
       intent: AgentGraphRunnableIntent;
@@ -178,16 +262,15 @@ export async function reconcileAgentGraphSchedule(
     }> = [];
 
     for (const work of orderedRequestedWork(snapshot.schedule)) {
-      if (work.target.kind === 'agent') {
-        deferredWork.push({
-          work,
-          reason: snapshot.schedule.closed ? 'graph_closed' : 'agent_topology_required',
-        });
-        continue;
-      }
+      if (work.target.kind === 'agent' && !provisionsByWork.has(work.workId)) continue;
       let intent: AgentGraphRunnableIntent;
       try {
-        intent = scheduledWorkIntent(input.topology, snapshot.observation, work);
+        intent = scheduledWorkIntent(
+          snapshot.topology,
+          snapshot.observation,
+          work,
+          provisionsByWork.get(work.workId),
+        );
       } catch (error) {
         failures.push({ phase: 'schedule', work, error });
         continue;
@@ -248,7 +331,8 @@ export async function reconcileAgentGraphSchedule(
         if (!prompt.trim()) {
           throw new Error(`Agent graph scheduled work ${work.workId} rendered an empty prompt`);
         }
-        return { work, intent, prompt };
+        const provision = provisionsByWork.get(work.workId);
+        return { work, intent, prompt, ...(provision ? { provision } : {}) };
       }),
     );
     const prepared: PreparedWork[] = [];
@@ -358,17 +442,22 @@ export async function reconcileAgentGraphSchedule(
 async function readScheduleSnapshot(
   input: ReconcileAgentGraphScheduleInput,
 ): Promise<ScheduleSnapshot> {
-  const [updates, observation, claims] = await Promise.all([
+  const [updates, provisions, claims] = await Promise.all([
     input.controlStore.listAgentGraphScheduleUpdates(input.topology.graphId),
-    input.observeGraph(),
+    input.controlStore.listAgentGraphOperatorProvisions(input.topology.graphId),
     input.controlStore.listAgentGraphIntentClaims(input.topology.graphId),
   ]);
+  const topology = composeProvisionedTopology(input.topology, provisions);
+  const observation = await input.observeGraph(topology);
   assertGraphObservation(input.topology.graphId, observation);
   notifySupervisor(input.supervisor?.onObservation, observation);
   return {
     schedule: projectAgentGraphSchedule(input.topology.graphId, updates),
     observation,
     claims,
+    topology,
+    provisions,
+    sourceByWorkId: scheduleSourceByWorkId(updates),
   };
 }
 
@@ -511,6 +600,12 @@ async function dispatchScheduledWork(
           input.controlStore.claimAgentGraphIntentAtScheduleRevision(request, expectedRevision),
       },
       newId: input.newId,
+      ...(prepared.provision
+        ? {
+            targetTurnId: prepared.provision.initialTurnId,
+            targetRunId: prepared.provision.initialRunId,
+          }
+        : {}),
       executionInput: { prompt: prepared.prompt },
     });
     const result = await input.executor.runClaimedAgentGraphIntent({
@@ -573,11 +668,21 @@ function scheduledWorkIntent(
   topology: AgentGraphTraceTopology,
   observation: AgentGraphSupervisorObservation,
   work: AgentGraphScheduleWorkView,
+  provision?: AgentGraphOperatorProvision,
 ): AgentGraphRunnableIntent {
-  if (work.target.kind !== 'operator') {
-    throw new Error(`Graph work ${work.workId} requires a new agent topology node`);
+  if (work.target.kind === 'agent') {
+    if (
+      !provision ||
+      provision.workId !== work.workId ||
+      provision.agentId !== work.target.agentId
+    ) {
+      throw new Error(`Graph work ${work.workId} has no matching topology provision`);
+    }
+  } else if (provision) {
+    throw new Error(`Existing-operator graph work ${work.workId} cannot own a provision`);
   }
-  const operatorId = work.target.operatorId;
+  const operatorId =
+    work.target.kind === 'operator' ? work.target.operatorId : provision!.operatorId;
   const topologyBinding = topology.operators.find((operator) => operator.operatorId === operatorId);
   const observedBinding = observation.projection.operators.find(
     (operator) => operator.operatorId === operatorId,
@@ -627,6 +732,133 @@ function scheduledWorkIntentId(graphId: string, workId: string): string {
     workId,
   });
   return `graph_intent_${hash.slice('sha256:'.length, 'sha256:'.length + 32)}`;
+}
+
+function buildOperatorProvisionInput(
+  topology: AgentGraphTraceTopology,
+  observation: AgentGraphSupervisorObservation,
+  work: AgentGraphScheduleWorkView,
+  source: AgentGraphScheduleUpdateSource,
+  expectedScheduleRevision: number,
+): ProvisionAgentGraphOperatorInput {
+  if (work.target.kind !== 'agent') {
+    throw new Error(`Graph work ${work.workId} does not target a catalog agent`);
+  }
+  const operatorHash = stableHash({
+    schemaVersion: SCHEDULE_INTENT_SCHEMA_VERSION,
+    kind: 'dynamic_operator',
+    graphId: topology.graphId,
+    workId: work.workId,
+  });
+  const operatorId = `graph_operator_${operatorHash.slice(
+    'sha256:'.length,
+    'sha256:'.length + 32,
+  )}`;
+  const recordsById = new Map(
+    observation.projection.records.map((record) => [record.recordId, record]),
+  );
+  const sourceOperatorIds = [
+    ...new Set(work.inputIds.map((recordId) => recordsById.get(recordId)!.operatorId)),
+  ].sort(compareIdentity);
+  const edges: AgentGraphProvisionedEdge[] = sourceOperatorIds.map((fromOperatorId) => {
+    const edgeHash = stableHash({
+      schemaVersion: SCHEDULE_INTENT_SCHEMA_VERSION,
+      kind: 'dynamic_edge',
+      graphId: topology.graphId,
+      workId: work.workId,
+      fromOperatorId,
+      toOperatorId: operatorId,
+    });
+    return {
+      edgeId: `graph_edge_${edgeHash.slice('sha256:'.length, 'sha256:'.length + 32)}`,
+      fromOperatorId,
+      toOperatorId: operatorId,
+    };
+  });
+  return {
+    graphId: topology.graphId,
+    workId: work.workId,
+    agentId: work.target.agentId,
+    operatorId,
+    source,
+    edges,
+    expectedScheduleRevision,
+  };
+}
+
+function composeProvisionedTopology(
+  baseline: AgentGraphTraceTopology,
+  provisions: readonly AgentGraphOperatorProvision[],
+): AgentGraphTraceTopology {
+  const operators = baseline.operators.map((operator) => ({ ...operator }));
+  const edges = baseline.edges.map((edge) => ({ ...edge }));
+  const operatorById = new Map(operators.map((operator) => [operator.operatorId, operator]));
+  const edgeById = new Map(edges.map((edge) => [edge.edgeId, edge]));
+
+  for (const provision of [...provisions].sort((a, b) =>
+    compareIdentity(a.provisionId, b.provisionId),
+  )) {
+    if (provision.graphId !== baseline.graphId) {
+      throw new Error(`Topology provision ${provision.provisionId} belongs to another graph`);
+    }
+    const existingOperator = operatorById.get(provision.operatorId);
+    if (existingOperator) {
+      throw new Error(`Topology provision reuses existing operator ${provision.operatorId}`);
+    }
+    const binding = {
+      operatorId: provision.operatorId,
+      sessionId: provision.targetSessionId,
+    };
+    operators.push(binding);
+    operatorById.set(binding.operatorId, binding);
+    for (const edge of provision.edges) {
+      const existingEdge = edgeById.get(edge.edgeId);
+      if (existingEdge) {
+        throw new Error(`Topology provision reuses existing edge ${edge.edgeId}`);
+      }
+      const copy = { ...edge };
+      edges.push(copy);
+      edgeById.set(copy.edgeId, copy);
+    }
+  }
+  for (const edge of edges) {
+    if (!operatorById.has(edge.fromOperatorId) || !operatorById.has(edge.toOperatorId)) {
+      throw new Error(`Graph edge ${edge.edgeId} references an unknown operator`);
+    }
+  }
+  return {
+    graphId: baseline.graphId,
+    operators,
+    edges,
+  };
+}
+
+function scheduleSourceByWorkId(
+  updates: readonly AgentGraphScheduleUpdate[],
+): Map<string, AgentGraphScheduleUpdateSource> {
+  const sources = new Map<string, AgentGraphScheduleUpdateSource>();
+  for (const update of updates) {
+    for (const work of update.addWork) {
+      const existing = sources.get(work.workId);
+      if (existing && !sameScheduleSource(existing, update.source)) {
+        throw new Error(`Graph work ${work.workId} has conflicting schedule sources`);
+      }
+      sources.set(work.workId, { ...update.source });
+    }
+  }
+  return sources;
+}
+
+function sameScheduleSource(
+  left: AgentGraphScheduleUpdateSource,
+  right: AgentGraphScheduleUpdateSource,
+): boolean {
+  return (
+    left.sessionId === right.sessionId &&
+    left.runId === right.runId &&
+    left.turnId === right.turnId &&
+    left.toolCallId === right.toolCallId
+  );
 }
 
 function orderedRequestedWork(

--- a/packages/storage/src/__tests__/agent-graph-intent-claims.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-intent-claims.test.ts
@@ -135,6 +135,7 @@ describe('SQLite agent graph intent claims', () => {
 
       const legacy = new DatabaseSync(path);
       legacy.exec(`
+        DROP TABLE agent_graph_operator_provisions;
         DROP INDEX agent_graph_intent_claims_by_graph;
         ALTER TABLE agent_graph_intent_claims RENAME TO agent_graph_intent_claims_v8;
         CREATE TABLE agent_graph_intent_claims (
@@ -178,7 +179,7 @@ describe('SQLite agent graph intent claims', () => {
 
       const migrated = createSqliteSessionMetadataStore(path);
       try {
-        assert.equal(migrated.schemaVersion(), 8);
+        assert.equal(migrated.schemaVersion(), 9);
         assert.deepEqual(
           await migrated.beginAgentGraphIntentExecutionAtScheduleRevision(
             'graph-1',

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
 import { describe, test } from 'node:test';
 import type { SessionHeader } from '@maka/core';
+import type { AgentGraphOperatorProvisionRequest } from '@maka/core/agent-graph-topology';
 import {
   createSqliteSessionMetadataStore,
   SessionMetadataConflictError,
@@ -19,7 +20,7 @@ describe('SqliteSessionMetadataStore', () => {
     try {
       const store = createSqliteSessionMetadataStore(path, { now: () => 100 });
       const header = fullHeader();
-      assert.equal(store.schemaVersion(), 8);
+      assert.equal(store.schemaVersion(), 9);
       assert.equal(store.journalMode(), 'wal');
       assert.deepEqual(await store.create(header), {
         header,
@@ -30,7 +31,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const reopened = createSqliteSessionMetadataStore(path, { now: () => 200 });
       try {
-        assert.equal(reopened.schemaVersion(), 8);
+        assert.equal(reopened.schemaVersion(), 9);
         assert.deepEqual(await reopened.read(header.id), {
           header,
           metadataVersion: 1,
@@ -51,7 +52,7 @@ describe('SqliteSessionMetadataStore', () => {
     const metadata = createSqliteSessionMetadataStore(path);
     try {
       assert.equal(runtime.schemaVersion(), 4);
-      assert.equal(metadata.schemaVersion(), 8);
+      assert.equal(metadata.schemaVersion(), 9);
       await metadata.create(fullHeader());
       await runtime.appendRuntimeEvent('session-1', 'run-1', {
         id: 'event-1',
@@ -159,7 +160,7 @@ describe('SqliteSessionMetadataStore', () => {
 
     const store = createSqliteSessionMetadataStore(path);
     try {
-      assert.equal(store.schemaVersion(), 8);
+      assert.equal(store.schemaVersion(), 9);
       assert.deepEqual(
         (
           await store.list({
@@ -492,6 +493,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const v4 = new DatabaseSync(path);
       v4.exec(`
+        DROP TABLE agent_graph_operator_provisions;
         DROP TABLE agent_graph_schedule_updates;
         DROP TABLE agent_graph_intent_claims;
         DROP TABLE subagent_spawns;
@@ -514,7 +516,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const migrated = createSqliteSessionMetadataStore(path);
       try {
-        assert.equal(migrated.schemaVersion(), 8);
+        assert.equal(migrated.schemaVersion(), 9);
         assert.equal(await migrated.remove(child.id), true);
         await assert.rejects(
           () => migrated.createSubagent({ ...child, id: 'retry-after-migration' }),
@@ -684,6 +686,112 @@ describe('SqliteSessionMetadataStore', () => {
   });
 });
 
+describe('SQLite agent graph operator provisions', () => {
+  test('atomically commits one child Session and monotonic topology row', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', { now: nextNow(700) });
+    try {
+      await store.commitAgentGraphScheduleUpdate({
+        schemaVersion: 1,
+        updateId: `graph_update_${'1'.repeat(32)}`,
+        updateFingerprint: `sha256:${'2'.repeat(64)}`,
+        graphId: 'graph-1',
+        source: {
+          sessionId: 'supervisor-session',
+          runId: 'supervisor-run',
+          turnId: 'supervisor-turn',
+          toolCallId: 'schedule-tool',
+        },
+        addWork: [
+          {
+            workId: `graph_work_${'3'.repeat(32)}`,
+            target: { kind: 'agent', agentId: 'local-read' },
+            instruction: 'Inspect the input.',
+            inputIds: [],
+          },
+        ],
+        stop: [],
+      });
+      const request = graphProvisionRequest();
+      const first = await store.createAgentGraphOperator(graphChildHeader(), request, 1);
+      assert.equal(first.created, true);
+      assert.equal(first.record.header.id, 'graph-child');
+      assert.equal(first.provision.targetSessionId, 'graph-child');
+      assert.deepEqual(await store.listAgentGraphOperatorProvisions('graph-1'), [first.provision]);
+
+      const retryRequest = {
+        ...request,
+        initialTurnId: 'disposable-turn',
+        initialRunId: 'disposable-run',
+      };
+      const retry = await store.createAgentGraphOperator(
+        graphChildHeader({
+          id: 'disposable-child',
+          subagentSpawn: {
+            ...graphChildHeader().subagentSpawn!,
+            initialTurnId: retryRequest.initialTurnId,
+            initialRunId: retryRequest.initialRunId,
+          },
+        }),
+        retryRequest,
+        1,
+      );
+      assert.equal(retry.created, false);
+      assert.equal(retry.record.header.id, 'graph-child');
+      assert.equal(retry.provision.initialRunId, request.initialRunId);
+
+      await assert.rejects(
+        store.createAgentGraphOperator(
+          graphChildHeader({ id: 'drift-child' }),
+          { ...request, provisionFingerprint: `sha256:${'9'.repeat(64)}` },
+          1,
+        ),
+        /reused for different work/,
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  test('rolls back child and topology together on a provision failure', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', {
+      failpoint(point) {
+        if (point === 'after_agent_graph_operator_provision_write') throw new Error('crash');
+      },
+    });
+    try {
+      await store.commitAgentGraphScheduleUpdate({
+        schemaVersion: 1,
+        updateId: `graph_update_${'1'.repeat(32)}`,
+        updateFingerprint: `sha256:${'2'.repeat(64)}`,
+        graphId: 'graph-1',
+        source: {
+          sessionId: 'supervisor-session',
+          runId: 'supervisor-run',
+          turnId: 'supervisor-turn',
+          toolCallId: 'schedule-tool',
+        },
+        addWork: [
+          {
+            workId: `graph_work_${'3'.repeat(32)}`,
+            target: { kind: 'agent', agentId: 'local-read' },
+            instruction: 'Inspect the input.',
+            inputIds: [],
+          },
+        ],
+        stop: [],
+      });
+      await assert.rejects(
+        store.createAgentGraphOperator(graphChildHeader(), graphProvisionRequest(), 1),
+        /crash/,
+      );
+      assert.deepEqual(await store.listAgentGraphOperatorProvisions('graph-1'), []);
+      await assert.rejects(store.read('graph-child'), /not found/);
+    } finally {
+      store.close();
+    }
+  });
+});
+
 function fullHeader(overrides: Partial<SessionHeader> = {}): SessionHeader {
   return {
     id: 'session-1',
@@ -720,6 +828,71 @@ function fullHeader(overrides: Partial<SessionHeader> = {}): SessionHeader {
     schemaVersion: 1,
     ...overrides,
   };
+}
+
+function graphProvisionRequest(): AgentGraphOperatorProvisionRequest {
+  return {
+    schemaVersion: 1,
+    provisionId: `graph_provision_${'4'.repeat(32)}`,
+    provisionFingerprint: `sha256:${'5'.repeat(64)}`,
+    graphId: 'graph-1',
+    workId: `graph_work_${'3'.repeat(32)}`,
+    agentId: 'local-read',
+    operatorId: `graph_operator_${'6'.repeat(32)}`,
+    initialTurnId: 'graph-turn',
+    initialRunId: 'graph-run',
+    edges: [],
+  };
+}
+
+function graphChildHeader(overrides: Partial<SessionHeader> = {}): SessionHeader {
+  const request = graphProvisionRequest();
+  return fullHeader({
+    id: 'graph-child',
+    parentSessionId: undefined,
+    branchOfTurnId: undefined,
+    revisionRootSessionId: undefined,
+    revisionParentSessionId: undefined,
+    revisionOfTurnId: undefined,
+    revisionIndex: undefined,
+    revisionState: undefined,
+    status: 'active',
+    blockedReason: undefined,
+    orchestrationMode: 'default',
+    subagentParent: {
+      kind: 'subagent',
+      parentSessionId: 'supervisor-session',
+      spawnedBy: {
+        parentRunId: 'supervisor-run',
+        parentTurnId: 'supervisor-turn',
+        toolCallId: 'schedule-tool',
+      },
+      graph: {
+        graphId: request.graphId,
+        workId: request.workId,
+        operatorId: request.operatorId,
+      },
+      lifecycle: 'foreground',
+    },
+    subagentRuntime: {
+      schemaVersion: 1,
+      definitionVersion: 1,
+      agentId: request.agentId,
+      agentName: 'Local Read',
+      profile: 'local_read',
+      systemPrompt: 'Read only.',
+      toolNames: ['Read'],
+      categoryPolicy: { read: 'allow' },
+      permissionCeiling: 'ask',
+    },
+    subagentSpawn: {
+      schemaVersion: 1,
+      requestFingerprint: '5'.repeat(64),
+      initialTurnId: request.initialTurnId,
+      initialRunId: request.initialRunId,
+    },
+    ...overrides,
+  });
 }
 
 function nextNow(start: number): () => number {

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -747,6 +747,13 @@ describe('SQLite agent graph operator provisions', () => {
         ),
         /reused for different work/,
       );
+      await assert.rejects(
+        store.remove('graph-child'),
+        /Cannot remove graph operator Session graph-child/,
+      );
+      assert.equal(await store.has('graph-child'), true);
+      assert.equal(await store.isTombstoned('graph-child'), false);
+      assert.deepEqual(await store.listAgentGraphOperatorProvisions('graph-1'), [first.provision]);
     } finally {
       store.close();
     }

--- a/packages/storage/src/__tests__/sqlite-session-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-store.test.ts
@@ -266,7 +266,7 @@ describe('default SQLite session metadata store', () => {
     }
   });
 
-  test('fails closed when a transcript marker has no canonical SQLite metadata', async () => {
+  test('recovers an exact empty transcript marker left before SQLite admission', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-default-session-orphan-marker-'));
     const sessionId = 'orphan-session';
     const sessionDir = join(root, 'sessions', sessionId);
@@ -283,7 +283,36 @@ describe('default SQLite session metadata store', () => {
 
     const store = createSessionStore(root);
     try {
+      assert.deepEqual(await store.list(), []);
+      await assert.rejects(
+        stat(sessionDir),
+        (error: NodeJS.ErrnoException) => error.code === 'ENOENT',
+      );
+    } finally {
+      await store.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('fails closed when an orphan transcript marker contains any additional state', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-default-session-nonempty-orphan-marker-'));
+    const sessionId = 'nonempty-orphan-session';
+    const sessionDir = join(root, 'sessions', sessionId);
+    await mkdir(sessionDir, { recursive: true });
+    await writeFile(
+      join(sessionDir, 'session.jsonl'),
+      `${JSON.stringify({
+        type: 'session_transcript',
+        sessionId,
+        schemaVersion: 1,
+      })}\n${JSON.stringify({ type: 'user', id: 'message-1', text: 'must survive' })}\n`,
+      'utf8',
+    );
+
+    const store = createSessionStore(root);
+    try {
       await assert.rejects(() => store.list(), /has no SQLite metadata/);
+      assert.equal((await stat(join(sessionDir, 'session.jsonl'))).isFile(), true);
     } finally {
       await store.close?.();
       await rm(root, { recursive: true, force: true });

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -133,6 +133,8 @@ async function openExecutionStoresForWrite<K extends StorageRootKind>(
     sessionStore: {
       create: (input) => run(() => sessionStore.create(input)),
       createSubagent: (input) => run(() => sessionStore.createSubagent(input)),
+      createAgentGraphOperator: (input, request, expectedRevision) =>
+        run(() => sessionStore.createAgentGraphOperator(input, request, expectedRevision)),
       list: (filter) => run(() => sessionStore.list(filter)),
       listForRecovery: () => run(() => sessionStore.listForRecovery()),
       readHeaderSnapshot: (sessionId) => run(() => sessionStore.readHeaderSnapshot(sessionId)),

--- a/packages/storage/src/session-metadata-transfer.ts
+++ b/packages/storage/src/session-metadata-transfer.ts
@@ -1,8 +1,12 @@
 import { createHash } from 'node:crypto';
-import { open, readdir } from 'node:fs/promises';
+import { open, readFile, readdir, rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { decodeSessionHeader, isSafeSessionId } from './session-store.js';
-import { decodeSessionTranscriptMarker, isSessionTranscriptMarker } from './session-transcript.js';
+import {
+  createSessionTranscriptMarker,
+  decodeSessionTranscriptMarker,
+  isSessionTranscriptMarker,
+} from './session-transcript.js';
 import type {
   SessionMetadataImportEntry,
   SqliteSessionMetadataStore,
@@ -77,6 +81,7 @@ export async function importLegacySessionMetadataTree(input: {
       !(await input.destination.has(sessionId)) &&
       !(await input.destination.isTombstoned(sessionId))
     ) {
+      if (await removeRecoverableOrphanTranscriptMarker(sessionsRoot, sessionId)) continue;
       throw new Error(`Session transcript marker has no SQLite metadata: ${sessionId}`);
     }
   }
@@ -90,6 +95,30 @@ export async function importLegacySessionMetadataTree(input: {
     sourcesAlreadyImported: result.sourcesAlreadyImported,
     sourcesTombstoned: result.sourcesTombstoned,
   };
+}
+
+/**
+ * Recover only the exact filesystem state published before SQLite admission:
+ * one canonical marker record in an otherwise empty Session directory.
+ *
+ * Any extra transcript byte or directory entry may contain user/runtime state
+ * and therefore remains a fail-closed corruption boundary.
+ */
+async function removeRecoverableOrphanTranscriptMarker(
+  sessionsRoot: string,
+  sessionId: string,
+): Promise<boolean> {
+  const sessionDir = join(sessionsRoot, sessionId);
+  const entries = await readdir(sessionDir, { withFileTypes: true });
+  if (entries.length !== 1 || entries[0]?.name !== 'session.jsonl' || !entries[0].isFile()) {
+    return false;
+  }
+  const path = join(sessionDir, 'session.jsonl');
+  const actual = await readFile(path, 'utf8');
+  const expected = `${JSON.stringify(createSessionTranscriptMarker(sessionId))}\n`;
+  if (actual !== expected) return false;
+  await rm(sessionDir, { recursive: true });
+  return true;
 }
 
 export async function readLegacySessionMetadataEntry(

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -35,6 +35,8 @@ import {
   subagentSessionRuntimeSummary,
 } from '@maka/core';
 import type {
+  AgentGraphOperatorProvisionRequest,
+  AgentGraphOperatorProvisionResult,
   CreateSessionInput,
   SessionHeader,
   SessionListFilter,
@@ -50,6 +52,11 @@ export const SQLITE_SESSION_METADATA_DATABASE_NAME = 'sessions.sqlite';
 export interface SessionStore {
   create(input: CreateSessionInput): Promise<SessionHeader>;
   createSubagent(input: CreateSessionInput): Promise<{ header: SessionHeader; created: boolean }>;
+  createAgentGraphOperator(
+    input: CreateSessionInput,
+    request: AgentGraphOperatorProvisionRequest,
+    expectedRevision: number,
+  ): Promise<{ header: SessionHeader } & AgentGraphOperatorProvisionResult>;
   list(filter?: SessionListFilter): Promise<SessionSummary[]>;
   listForRecovery(): Promise<SessionHeader[]>;
   /** Read only the durable header without triggering connection-lock self-healing. */
@@ -126,6 +133,31 @@ class SqliteSessionStore implements SessionStore {
       const result = await this.metadata.createSubagent(staged);
       if (!result.created) await this.files.remove(staged.id);
       return { header: result.record.header, created: result.created };
+    } catch (error) {
+      await this.files.remove(staged.id).catch(() => {});
+      throw error;
+    }
+  }
+
+  async createAgentGraphOperator(
+    input: CreateSessionInput,
+    request: AgentGraphOperatorProvisionRequest,
+    expectedRevision: number,
+  ): Promise<{ header: SessionHeader } & AgentGraphOperatorProvisionResult> {
+    await this.ensureReady();
+    const staged = await this.files.createTranscript(input);
+    try {
+      const result = await this.metadata.createAgentGraphOperator(
+        staged,
+        request,
+        expectedRevision,
+      );
+      if (!result.created) await this.files.remove(staged.id);
+      return {
+        header: result.record.header,
+        provision: result.provision,
+        created: result.created,
+      };
     } catch (error) {
       await this.files.remove(staged.id).catch(() => {});
       throw error;
@@ -352,6 +384,14 @@ class FileSessionStore implements SessionStore {
     _input: CreateSessionInput,
   ): Promise<{ header: SessionHeader; created: boolean }> {
     throw new Error('Child-session idempotency requires the SQLite metadata control plane');
+  }
+
+  async createAgentGraphOperator(
+    _input: CreateSessionInput,
+    _request: AgentGraphOperatorProvisionRequest,
+    _expectedRevision: number,
+  ): Promise<{ header: SessionHeader } & AgentGraphOperatorProvisionResult> {
+    throw new Error('Graph operator provisioning requires the SQLite metadata control plane');
   }
 
   async createTranscript(input: CreateSessionInput): Promise<SessionHeader> {

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 8;
+export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 9;
 
 const MIGRATIONS: ReadonlyMap<number, string> = new Map([
   [
@@ -244,6 +244,28 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
 
     UPDATE agent_graph_intent_claims
     SET admission_updated_at = claimed_at;
+  `,
+  ],
+  [
+    9,
+    `
+    CREATE TABLE agent_graph_operator_provisions (
+      graph_id TEXT NOT NULL,
+      work_id TEXT NOT NULL,
+      provision_id TEXT NOT NULL UNIQUE,
+      schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+      provision_fingerprint TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      operator_id TEXT NOT NULL,
+      target_session_id TEXT NOT NULL UNIQUE,
+      payload_json TEXT NOT NULL,
+      provisioned_at INTEGER NOT NULL CHECK (provisioned_at >= 0),
+      PRIMARY KEY(graph_id, work_id),
+      UNIQUE(graph_id, operator_id)
+    );
+
+    CREATE INDEX agent_graph_operator_provisions_by_graph
+      ON agent_graph_operator_provisions(graph_id, provisioned_at, operator_id);
   `,
   ],
 ]);

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -736,6 +736,18 @@ export class SqliteSessionMetadataStore {
     this.assertOpen();
     assertSafeSessionId(sessionId);
     return this.transaction(() => {
+      const graphOwner = this.db
+        .prepare(`
+          SELECT graph_id AS graphId, work_id AS workId
+          FROM agent_graph_operator_provisions
+          WHERE target_session_id = ?
+        `)
+        .get(sessionId) as { graphId: string; workId: string } | undefined;
+      if (graphOwner) {
+        throw new SessionMetadataConflictError(
+          `Cannot remove graph operator Session ${sessionId}; owned by ${graphOwner.graphId}/${graphOwner.workId}`,
+        );
+      }
       const deleted =
         this.db.prepare('DELETE FROM session_metadata WHERE session_id = ?').run(sessionId)
           .changes === 1;

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -7,7 +7,9 @@ import {
   assertAgentGraphScheduleUpdateRequest,
   AgentGraphScheduleClosedError,
   AgentGraphScheduleRevisionConflictError,
+  assertAgentGraphOperatorProvisionRequest,
   assertAgentGraphIntentClaimRequest,
+  decodeAgentGraphOperatorProvision,
   decodeAgentGraphScheduleUpdate,
   decodeAgentGraphIntentClaim,
   isSubagentSessionParent,
@@ -21,6 +23,9 @@ import {
   type AgentGraphIntentClaim,
   type AgentGraphIntentClaimRequest,
   type AgentGraphIntentClaimResult,
+  type AgentGraphOperatorProvision,
+  type AgentGraphOperatorProvisionRequest,
+  type AgentGraphOperatorProvisionResult,
   type SessionHeader,
   type SessionListFilter,
   type SubagentSessionParent,
@@ -60,7 +65,8 @@ export type SqliteSessionMetadataStoreFailpoint =
   | 'after_session_labels_write'
   | 'after_session_import_marker_write'
   | 'after_agent_graph_intent_claim_write'
-  | 'after_agent_graph_schedule_update_write';
+  | 'after_agent_graph_schedule_update_write'
+  | 'after_agent_graph_operator_provision_write';
 
 export interface SqliteSessionMetadataStoreOptions {
   now?: () => number;
@@ -76,6 +82,11 @@ export interface SessionMetadataRecord {
 export interface IdempotentSubagentSessionMetadataResult {
   record: SessionMetadataRecord;
   created: boolean;
+}
+
+export interface IdempotentAgentGraphOperatorMetadataResult
+  extends AgentGraphOperatorProvisionResult {
+  record: SessionMetadataRecord;
 }
 
 export interface SessionMetadataImportEntry {
@@ -184,6 +195,9 @@ export class SqliteSessionMetadataStore {
     this.assertOpen();
     const normalized = normalizeSessionHeader(header);
     assertSafeSessionId(normalized.id);
+    if (normalized.subagentParent?.graph) {
+      throw new Error('Graph operator metadata requires atomic topology provisioning');
+    }
     const identity = requireSubagentSpawnIdentity(normalized);
     return this.transaction(() => {
       if (this.hasTombstone(normalized.id)) {
@@ -217,6 +231,102 @@ export class SqliteSessionMetadataStore {
       }
       this.assertMatchingSubagentSpawnClaim(existing.header);
       return { record: existing, created: false };
+    });
+  }
+
+  async createAgentGraphOperator(
+    header: SessionHeader,
+    request: AgentGraphOperatorProvisionRequest,
+    expectedRevision: number,
+  ): Promise<IdempotentAgentGraphOperatorMetadataResult> {
+    this.assertOpen();
+    const normalized = normalizeSessionHeader(header);
+    assertSafeSessionId(normalized.id);
+    assertAgentGraphOperatorProvisionRequest(request);
+    if (!Number.isSafeInteger(expectedRevision) || expectedRevision < 0) {
+      throw new Error('Agent graph schedule expected revision must be a non-negative safe integer');
+    }
+    const identity = requireSubagentSpawnIdentity(normalized);
+    if (
+      !identity.parent.graph ||
+      identity.parent.graph.graphId !== request.graphId ||
+      identity.parent.graph.workId !== request.workId ||
+      identity.parent.graph.operatorId !== request.operatorId ||
+      normalized.subagentRuntime?.agentId !== request.agentId ||
+      identity.spawn.initialTurnId !== request.initialTurnId ||
+      identity.spawn.initialRunId !== request.initialRunId
+    ) {
+      throw new Error('Graph operator Session metadata does not match its provision request');
+    }
+    return this.transaction(() => {
+      const existing = this.readAgentGraphOperatorProvisionSync(request.graphId, request.workId);
+      if (existing) return this.matchAgentGraphOperatorProvision(existing, request);
+      const currentRevision = this.currentAgentGraphScheduleRevision(request.graphId);
+      if (currentRevision !== expectedRevision) {
+        throw new AgentGraphScheduleRevisionConflictError(
+          request.graphId,
+          expectedRevision,
+          currentRevision,
+        );
+      }
+      if (this.hasClosedAgentGraphSchedule(request.graphId)) {
+        throw new AgentGraphScheduleClosedError(request.graphId);
+      }
+      if (this.hasTombstone(normalized.id)) {
+        throw new SessionMetadataConflictError(
+          `Session metadata id is tombstoned: ${normalized.id}`,
+        );
+      }
+      if (this.readRecordSync(normalized.id)) {
+        throw new SessionMetadataConflictError(`Session metadata already exists: ${normalized.id}`);
+      }
+      const provisionedAt = this.now();
+      const claim = this.tryClaimSubagentSpawn(normalized, provisionedAt);
+      if (!claim.created) {
+        throw new SessionMetadataConflictError(
+          'Graph operator spawn identity exists without its topology provision',
+        );
+      }
+      const record = this.insertHeader(normalized, 1, provisionedAt);
+      const provision: AgentGraphOperatorProvision = {
+        ...request,
+        edges: request.edges.map((edge) => ({ ...edge })),
+        targetSessionId: normalized.id,
+        provisionedAt,
+      };
+      this.db
+        .prepare(`
+          INSERT INTO agent_graph_operator_provisions(
+            graph_id,
+            work_id,
+            provision_id,
+            schema_version,
+            provision_fingerprint,
+            agent_id,
+            operator_id,
+            target_session_id,
+            payload_json,
+            provisioned_at
+          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        `)
+        .run(
+          provision.graphId,
+          provision.workId,
+          provision.provisionId,
+          provision.schemaVersion,
+          provision.provisionFingerprint,
+          provision.agentId,
+          provision.operatorId,
+          provision.targetSessionId,
+          JSON.stringify(provision),
+          provision.provisionedAt,
+        );
+      this.options.failpoint?.('after_agent_graph_operator_provision_write');
+      return {
+        record,
+        provision: decodeAgentGraphOperatorProvision(provision),
+        created: true,
+      };
     });
   }
 
@@ -511,6 +621,22 @@ export class SqliteSessionMetadataStore {
       `)
       .all(graphId) as unknown as AgentGraphScheduleUpdateRow[];
     return rows.map(decodeAgentGraphScheduleUpdateRow);
+  }
+
+  async listAgentGraphOperatorProvisions(graphId: string): Promise<AgentGraphOperatorProvision[]> {
+    this.assertOpen();
+    assertGraphLookupIdentity(graphId, 'graph id');
+    const rows = this.db
+      .prepare(`
+        SELECT payload_json AS payloadJson
+        FROM agent_graph_operator_provisions
+        WHERE graph_id = ?
+        ORDER BY provisioned_at ASC, operator_id ASC
+      `)
+      .all(graphId) as unknown as AgentGraphOperatorProvisionRow[];
+    return rows.map((row) =>
+      decodeAgentGraphOperatorProvision(JSON.parse(row.payloadJson) as unknown),
+    );
   }
 
   async update(
@@ -840,8 +966,8 @@ export class SqliteSessionMetadataStore {
         identity.parent.parentSessionId,
         identity.parent.spawnedBy.parentRunId,
         identity.parent.spawnedBy.toolCallId,
-        identity.parent.swarm?.swarmId ?? '',
-        identity.parent.swarm?.itemId ?? '',
+        subagentSpawnScope(identity.parent).scopeId,
+        subagentSpawnScope(identity.parent).itemId,
         identity.spawn.requestFingerprint,
         header.id,
         identity.spawn.initialTurnId,
@@ -888,9 +1014,57 @@ export class SqliteSessionMetadataStore {
         parent.parentSessionId,
         parent.spawnedBy.parentRunId,
         parent.spawnedBy.toolCallId,
-        parent.swarm?.swarmId ?? '',
-        parent.swarm?.itemId ?? '',
+        subagentSpawnScope(parent).scopeId,
+        subagentSpawnScope(parent).itemId,
       ) as SubagentSpawnClaim | undefined;
+  }
+
+  private readAgentGraphOperatorProvisionSync(
+    graphId: string,
+    workId: string,
+  ): AgentGraphOperatorProvision | undefined {
+    const row = this.db
+      .prepare(`
+        SELECT payload_json AS payloadJson
+        FROM agent_graph_operator_provisions
+        WHERE graph_id = ? AND work_id = ?
+      `)
+      .get(graphId, workId) as AgentGraphOperatorProvisionRow | undefined;
+    return row
+      ? decodeAgentGraphOperatorProvision(JSON.parse(row.payloadJson) as unknown)
+      : undefined;
+  }
+
+  private matchAgentGraphOperatorProvision(
+    existing: AgentGraphOperatorProvision,
+    request: AgentGraphOperatorProvisionRequest,
+  ): IdempotentAgentGraphOperatorMetadataResult {
+    if (existing.provisionFingerprint !== request.provisionFingerprint) {
+      throw new SessionMetadataConflictError(
+        'Graph operator provision identity was reused for different work',
+      );
+    }
+    const record = this.readRecordSync(existing.targetSessionId);
+    if (!record) {
+      throw new SessionMetadataConflictError(
+        `Graph operator provision belongs to deleted session: ${existing.targetSessionId}`,
+      );
+    }
+    if (
+      record.header.subagentParent?.graph?.graphId !== existing.graphId ||
+      record.header.subagentParent.graph.workId !== existing.workId ||
+      record.header.subagentParent.graph.operatorId !== existing.operatorId
+    ) {
+      throw new SessionMetadataConflictError(
+        'Graph operator provision disagrees with live session metadata',
+      );
+    }
+    this.assertMatchingSubagentSpawnClaim(record.header);
+    return {
+      record,
+      provision: decodeAgentGraphOperatorProvision(existing),
+      created: false,
+    };
   }
 
   private readAgentGraphIntentClaimSync(
@@ -1137,10 +1311,30 @@ interface AgentGraphScheduleUpdateRow {
   payloadJson: string;
 }
 
+interface AgentGraphOperatorProvisionRow {
+  payloadJson: string;
+}
+
 function decodeAgentGraphScheduleUpdateRow(
   row: AgentGraphScheduleUpdateRow,
 ): AgentGraphScheduleUpdate {
   return decodeAgentGraphScheduleUpdate(JSON.parse(row.payloadJson) as unknown);
+}
+
+function subagentSpawnScope(parent: SubagentSessionParent): {
+  scopeId: string;
+  itemId: string;
+} {
+  if (parent.graph) {
+    return {
+      scopeId: `graph:${parent.graph.graphId}`,
+      itemId: parent.graph.workId,
+    };
+  }
+  return {
+    scopeId: parent.swarm?.swarmId ?? '',
+    itemId: parent.swarm?.itemId ?? '',
+  };
 }
 
 function agentGraphScheduleUpdateRequest(


### PR DESCRIPTION
## Summary

Stacked on #1468. This is the dynamic-topology bootstrap slice of #1341.

- add a strict, append-only graph operator provision contract and a typed `graph` relation on child Sessions;
- migrate the workspace metadata control plane to SQLite schema v9 and atomically commit the child Session, durable spawn identity, and topology provision;
- add a metadata-only `SessionManager.provisionAgentGraphOperator()` primitive that snapshots the selected catalog agent and the parent's environment/permission ceiling without starting Agent runtime;
- teach schedule reconciliation to compose persisted topology additions, turn `agent_id` work into a child Session/operator, and then claim the provisioned first `turnId`/`runId` through the existing graph executor;
- preserve schedule-revision races, stop/finish closure, idempotent recovery, and supervisor observation semantics.

## Why

Before this slice, `operator_id` work could execute but `agent_id` work remained deferred as `agent_topology_required`. The important crash boundary is not merely “create a child, then update an in-memory graph”: child identity and topology identity must become durable together. Otherwise recovery can observe half a graph or admit a different first activation.

The implementation keeps the Agent runtime unchanged. Dynamic topology is a host/control-plane concern, while execution still flows through the existing claimed session-inline runtime primitive.

## Scope and invariants

- monotonic operator/edge addition only;
- one durable provision per `(graph_id, work_id)`;
- no arbitrary deletion, rewiring, or cyclic topology mutation;
- no implicit permission widening;
- SQLite is authoritative for provision lookup; there is no JSONL-scan fallback;
- the newly created child is metadata-only until its durable graph intent is admitted;
- Host/Desktop product wiring remains the next PR.

## Checks

- `npm run typecheck`
- `npm --workspace @maka/core test`
- `npm --workspace @maka/storage test`
- touched runtime suites: SessionManager, graph admission, and schedule reconciliation (240 tests)
- Biome checks on all changed files

Refs #1341

<details>
<summary>中文说明</summary>

## 概要

这是 #1341 的 Dynamic topology bootstrap，并叠在 #1468 之上。

- 新增严格、append-only 的 graph operator provision 契约，并在 child Session 上增加类型化的 `graph` 关系；
- 将 workspace metadata control plane 升级到 SQLite schema v9，在同一事务里提交 child Session、durable spawn identity 和 topology provision；
- 新增 metadata-only 的 `SessionManager.provisionAgentGraphOperator()`：快照 catalog agent、父 Session 的环境与权限上限，但不启动 Agent runtime；
- schedule reconciler 现在会组合持久化 topology，把 `agent_id` work 变成 child Session/operator，再使用 provision 时预留的首个 `turnId/runId` 走现有 graph executor；
- 保留 schedule revision race、stop/finish closure、幂等恢复和 supervisor observation 语义。

## 为什么这样做

此前 `operator_id` work 已经可以执行，但 `agent_id` work 只能返回 `agent_topology_required`。真正关键的 crash boundary 不是“先创建 child，再改一份内存图”，而是 child identity 和 topology identity 必须一起持久化；否则恢复时可能看到半张图，或者给同一项 work 分配出不同的首个 activation。

本 PR 没有改写 Agent runtime。动态图仍属于 host/control plane，执行继续复用现有的 claimed session-inline runtime primitive。

## 范围与不变量

- 首版只允许单调增加 operator/edge；
- 每个 `(graph_id, work_id)` 只有一个 durable provision；
- 不支持任意删除、改边或有环拓扑；
- 不会隐式扩大 child 权限；
- provision 查询以 SQLite 为权威，不提供 JSONL 扫描 fallback；
- 新 child 在 graph intent 被正式 admit 前只存在 metadata，不会启动 runtime；
- Host/Desktop 的产品接线留给下一 PR。

</details>
