### PR TITLE
fix(headless): run Pier task controller in container

### DIFF
--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -820,13 +820,16 @@ class MakaAgent(BaseInstalledAgent):
         env["MAKA_CELL_ARTIFACT_DIR"] = EnvironmentPaths.agent_dir.as_posix()
         env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms(env))
 
-        proxy_url = env.pop("MAKA_PROVIDER_PROXY_URL", None)
-        proxy_token = env.pop("MAKA_PROVIDER_PROXY_TOKEN", None)
+        proxy_url = self._get_env("MAKA_PROVIDER_PROXY_URL")
+        proxy_token = self._get_env("MAKA_PROVIDER_PROXY_TOKEN")
+        env.pop("MAKA_PROVIDER_PROXY_URL", None)
+        env.pop("MAKA_PROVIDER_PROXY_TOKEN", None)
         if self._harbor_backend() != "fake":
             if not proxy_url or not proxy_token:
                 raise RuntimeError("Maka container task-run requires the host provider proxy")
             env["MAKA_HOST_BASE_URL"] = proxy_url
             env["MAKA_HOST_API_KEY"] = proxy_token
+            env["NODE_USE_ENV_PROXY"] = "1"
         return env
 
     async def _download_task_run_artifacts(self, environment: BaseEnvironment) -> None:

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -40,6 +40,7 @@ from process_scope import (
     scoped_command_cleanup_command as _scoped_command_cleanup_command,
     scoped_process_cleanup_command as _scoped_process_cleanup_command,
 )
+from provider_proxy import provider_proxy_endpoint, warn_if_pier_unreachable_proxy_port
 from trial_pricing import estimate_cost, pricing_from_env
 
 # Default wall-clock budget for a single bridged tool command when the client
@@ -56,6 +57,12 @@ _BRIDGE_DEFAULT_TIMEOUT_SEC = 120
 _HARBOR_DIR = Path(__file__).resolve().parent
 _HEADLESS_DIR = _HARBOR_DIR.parent
 _REPO_ROOT_DEFAULT = _HEADLESS_DIR.parent.parent
+_CONTAINER_MAKA_REPO = Path("/opt/maka-agent")
+_CONTAINER_HEADLESS_CLI = _CONTAINER_MAKA_REPO / "packages" / "headless" / "dist" / "cli.js"
+_MAKA_NODE_TOOLCHAIN_ROOT = Path("/opt/maka-node-toolchain")
+_MAKA_NODE_TOOLCHAIN_NODE = _MAKA_NODE_TOOLCHAIN_ROOT / "bin" / "node"
+_MAKA_NODE_TOOLCHAIN_MANIFEST = _MAKA_NODE_TOOLCHAIN_ROOT / "manifest.json"
+_MAKA_NODE_TOOLCHAIN_CHECKSUMS = _MAKA_NODE_TOOLCHAIN_ROOT / "checksums.sha256"
 _DEFAULT_RUNNER_ENV = Path(
     os.environ.get(
         "MAKA_HARBOR_RUNNER_ENV_FILE",
@@ -126,6 +133,7 @@ class MakaAgent(BaseInstalledAgent):
     _RUN_LOG_FILENAME = "maka-run.log"
     _CELL_OUTPUT_FILENAME = "maka-cell-output.json"
     _CELL_USAGE_CHECKPOINT_FILENAME = "maka-cell-usage-checkpoint.json"
+    _CELL_EXECUTION_IDENTITY_FILENAME = "maka-cell-execution-identity.json"
     _RUNTIME_EVENTS_FILENAME = "runtime-events.jsonl"
     _TRACE_EVENTS_FILENAME = "trace-events.jsonl"
 
@@ -184,6 +192,12 @@ class MakaAgent(BaseInstalledAgent):
         # exports NetworkAllowlist = None there.
         if _NetworkAllowlist is None:
             return None
+        if self._task_run_in_container():
+            if self._harbor_backend() == "fake":
+                return _NetworkAllowlist()
+            hostname, port = provider_proxy_endpoint(self._get_env, "Maka")
+            warn_if_pier_unreachable_proxy_port(port, "Maka")
+            return _NetworkAllowlist(domains=[hostname])
         # The empty allowlist keeps a non-internet Pier task fully offline,
         # which is correct exactly when the container makes no model calls. A
         # configuration whose cell would call the provider from inside the
@@ -201,36 +215,73 @@ class MakaAgent(BaseInstalledAgent):
     def _container_makes_model_calls(self) -> bool:
         """True only when the in-container cell itself calls the model provider.
 
-        task-run mode and host-side LLM mode run the model on the host and only
-        bridge tool commands into the container via environment.exec, and
-        backend=fake makes no model calls at all; only a cell-mode ai-sdk run
-        without host-side configuration needs in-container egress.
+        Pier task-run runs the model in the container through the host proxy.
+        Cell mode does so only without host-side LLM configuration. The fake
+        backend never calls a model provider.
         """
         return (
-            self._harbor_mode() == "cell"
-            and self._harbor_backend() != "fake"
-            and not self._host_side_llm_enabled()
+            self._harbor_backend() != "fake"
+            and (
+                self._task_run_in_container()
+                or (
+                    self._harbor_mode() == "cell"
+                    and not self._host_side_llm_enabled()
+                )
+            )
         )
 
+    def _task_run_in_container(self) -> bool:
+        """Pier task runs execute in the task container; plain Harbor keeps its
+        existing host bridge for Terminal-Bench callers."""
+        return self._harbor_mode() == "task-run" and _NetworkAllowlist is not None
+
     def _harbor_mode(self) -> str:
-        """cell (default) runs a RuntimeRunner cell; task-run runs the full
-        task-run controller on the host and bridges tool execution into the
-        container via the shared _ToolExecutorServer. task-run is the
-        heavy-task / autonomous experiment path."""
+        """cell (default) runs a RuntimeRunner cell. task-run runs the full
+        controller inside Pier's task container, while plain Harbor retains
+        the host controller and shared _ToolExecutorServer bridge."""
         mode = (self._get_env("MAKA_HARBOR_MODE") or "cell").strip()
         if mode not in ("cell", "task-run"):
             raise RuntimeError(f"MAKA_HARBOR_MODE must be cell or task-run, got {mode!r}")
         return mode
 
     def get_version_command(self) -> str | None:
-        # task-run runs Maka on the host, not in the container, so there is no
-        # in-container binary to version-check.
         if self._harbor_mode() == "task-run":
-            return None
+            return (
+                f"{shlex.quote(str(_MAKA_NODE_TOOLCHAIN_NODE))} --version"
+                if self._task_run_in_container()
+                else None
+            )
         return "node --version"
 
     async def install(self, environment: BaseEnvironment) -> None:
         if self._harbor_mode() == "task-run":
+            if self._task_run_in_container():
+                expected_fingerprint = self._get_env("MAKA_NODE_TOOLCHAIN_FINGERPRINT")
+                if not expected_fingerprint:
+                    raise ValueError("MAKA_NODE_TOOLCHAIN_FINGERPRINT is required")
+                manifest_check = (
+                    "const fs = require('node:fs'); "
+                    "const manifest = JSON.parse(fs.readFileSync(process.argv[1], 'utf8')); "
+                    "if (manifest.fingerprint !== process.env.MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT) "
+                    "throw new Error('Maka Node toolchain fingerprint mismatch');"
+                )
+                command = (
+                    "set -euo pipefail; "
+                    'test "$(uname -s)" = Linux; '
+                    'test "$(uname -m)" = x86_64; '
+                    f"cd {shlex.quote(str(_MAKA_NODE_TOOLCHAIN_ROOT))}; "
+                    f"sha256sum --check {shlex.quote(_MAKA_NODE_TOOLCHAIN_CHECKSUMS.name)}; "
+                    f"{shlex.quote(str(_MAKA_NODE_TOOLCHAIN_NODE))} "
+                    f"-e {shlex.quote(manifest_check)} "
+                    f"{shlex.quote(str(_MAKA_NODE_TOOLCHAIN_MANIFEST))}; "
+                    f"test -f {shlex.quote(str(_CONTAINER_HEADLESS_CLI))}"
+                )
+                await self.exec_as_agent(
+                    environment,
+                    command=command,
+                    env={"MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT": expected_fingerprint},
+                )
+                return
             # Host-bridge task-run: node and the headless CLI run on the host and
             # bridge tool execution into the task container, so nothing installs
             # inside the task. Fail fast if the built CLI is missing.
@@ -318,7 +369,10 @@ class MakaAgent(BaseInstalledAgent):
         context: AgentContext,
     ) -> None:
         if self._harbor_mode() == "task-run":
-            await self._run_task_run_host(instruction, environment, context)
+            if self._task_run_in_container():
+                await self._run_task_run_container(instruction, environment, context)
+            else:
+                await self._run_task_run_host(instruction, environment, context)
             return
         agent_dir = EnvironmentPaths.agent_dir
         await self.exec_as_agent(environment, command=f"mkdir -p {agent_dir.as_posix()}")
@@ -501,7 +555,12 @@ class MakaAgent(BaseInstalledAgent):
         economy_task_flag = self._resolved_flags.get("economy_task_mode")
         economy_task_env = self._get_env("MAKA_ECONOMY_TASK_MODE")
         economy_task_mode = True if economy_task_flag is True else economy_task_env == "true"
-        if backend == "ai-sdk" and not self._host_side_llm_enabled():
+        has_container_proxy = bool(
+            self._task_run_in_container()
+            and self._get_env("MAKA_PROVIDER_PROXY_URL")
+            and self._get_env("MAKA_PROVIDER_PROXY_TOKEN")
+        )
+        if backend == "ai-sdk" and not self._host_side_llm_enabled() and not has_container_proxy:
             raise RuntimeError("backend=ai-sdk requires host-side provider configuration")
         env = {
             "MAKA_BACKEND": backend,
@@ -685,6 +744,113 @@ class MakaAgent(BaseInstalledAgent):
         except OSError as exc:
             self.logger.debug("Could not write Maka trajectory %s: %s", trajectory_path, exc)
 
+    async def _run_task_run_container(
+        self,
+        instruction: str,
+        environment: BaseEnvironment,
+        context: AgentContext,
+    ) -> None:
+        """Run the full task-run controller inside Pier's task container."""
+        self.logs_dir.mkdir(parents=True, exist_ok=True)
+        agent_dir = EnvironmentPaths.agent_dir
+        await self.exec_as_agent(environment, command=f"mkdir -p {agent_dir.as_posix()}")
+        instruction_path = agent_dir / "instruction.txt"
+        local_instruction_path = self.logs_dir / "instruction.txt"
+        local_instruction_path.write_text(instruction, encoding="utf-8")
+        await environment.upload_file(local_instruction_path, instruction_path.as_posix())
+
+        task_workdir = (
+            str(getattr(getattr(environment, "task_env_config", None), "workdir", "") or ".")
+        )
+        out_dir = agent_dir / "maka-task-run"
+        env = self._container_task_run_env(instruction_path, out_dir)
+        command = _headless_harbor_command(
+            cli_path=_CONTAINER_HEADLESS_CLI,
+            instruction_path=instruction_path,
+            task_workdir=task_workdir,
+            task_id=str(
+                getattr(environment, "session_id", None)
+                or self._get_env("MAKA_TASK_ID")
+                or "terminal-bench-task"
+            ),
+            out_dir=out_dir,
+            env=env,
+            node_path=_MAKA_NODE_TOOLCHAIN_NODE,
+            isolation="harbor-local",
+        )
+        stdout_path = agent_dir / "maka-harbor.stdout.json"
+        stderr_path = agent_dir / "maka-harbor.stderr.log"
+        shell_script = (
+            f"{shlex.join(str(part) for part in command)} "
+            f"> {shlex.quote(stdout_path.as_posix())} "
+            f"2> {shlex.quote(stderr_path.as_posix())}; "
+            "status=$?; "
+            'if [ "$status" -eq 124 ]; then exit 0; fi; '
+            'exit "$status"'
+        )
+        try:
+            await self.exec_as_agent(
+                environment,
+                command=f"bash -lc {shlex.quote(shell_script)}",
+                env=env,
+                timeout_sec=self._cell_timeout_sec(env),
+            )
+        finally:
+            await self._download_task_run_artifacts(environment)
+
+        output = self._read_cell_output(required=True)
+        self._apply_cell_output(context, output)
+
+    def _container_task_run_env(
+        self,
+        instruction_path: Path,
+        out_dir: Path,
+    ) -> dict[str, str]:
+        env = {
+            key: value
+            for key, value in (getattr(self, "_extra_env", {}) or {}).items()
+            if key.startswith("MAKA_") and value is not None
+        }
+        env.update(self._cell_env(instruction_path))
+        _normalize_cli_env(env)
+        env["MAKA_REPO_DIR"] = str(_CONTAINER_MAKA_REPO)
+        env["MAKA_TASK_RUN_OUT_DIR"] = str(out_dir)
+        env["MAKA_OUTPUT_DIR"] = str(out_dir)
+        env["MAKA_STORAGE_ROOT"] = str(out_dir / "runs")
+        env["MAKA_CELL_ARTIFACT_DIR"] = EnvironmentPaths.agent_dir.as_posix()
+        env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms(env))
+
+        proxy_url = env.pop("MAKA_PROVIDER_PROXY_URL", None)
+        proxy_token = env.pop("MAKA_PROVIDER_PROXY_TOKEN", None)
+        if self._harbor_backend() != "fake":
+            if not proxy_url or not proxy_token:
+                raise RuntimeError("Maka container task-run requires the host provider proxy")
+            env["MAKA_HOST_BASE_URL"] = proxy_url
+            env["MAKA_HOST_API_KEY"] = proxy_token
+        return env
+
+    async def _download_task_run_artifacts(self, environment: BaseEnvironment) -> None:
+        await self._download_cell_output(environment)
+        remote_dir = EnvironmentPaths.agent_dir / "maka-task-run"
+        local_dir = self.logs_dir / "maka-task-run"
+        try:
+            await environment.download_dir(remote_dir.as_posix(), local_dir)
+        except Exception as exc:  # noqa: BLE001 - best-effort artifact hydration.
+            self.logger.debug("Could not download Maka task-run artifacts %s: %s", remote_dir, exc)
+        for filename in (
+            self._CELL_USAGE_CHECKPOINT_FILENAME,
+            self._CELL_EXECUTION_IDENTITY_FILENAME,
+            "maka-harbor.stdout.json",
+            "maka-harbor.stderr.log",
+        ):
+            remote = EnvironmentPaths.agent_dir / filename
+            local = self.logs_dir / filename
+            if local.exists():
+                continue
+            try:
+                await environment.download_file(remote.as_posix(), local)
+            except Exception as exc:  # noqa: BLE001 - best-effort artifact hydration.
+                self.logger.debug("Could not download Maka task-run artifact %s: %s", remote, exc)
 
     async def _run_task_run_host(
         self,
@@ -1462,9 +1628,11 @@ def _headless_harbor_command(
     task_id: str,
     out_dir: Path,
     env: dict[str, str],
+    node_path: str | Path = "node",
+    isolation: str = "harbor-http",
 ) -> list[str]:
     command = [
-        "node",
+        str(node_path),
         str(cli_path),
         "harbor",
         "run",
@@ -1473,7 +1641,7 @@ def _headless_harbor_command(
         "--backend",
         env.get("MAKA_BACKEND", "ai-sdk"),
         "--isolation",
-        "harbor-http",
+        isolation,
         "--instruction-file",
         str(instruction_path),
         "--workdir",

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -40,6 +40,7 @@ import {
   CODEX_TOOLCHAIN_SPEC,
   prepareCodexToolchain,
 } from '#codex-toolchain';
+import { MAKA_NODE_TOOLCHAIN_FINGERPRINT, prepareMakaNodeToolchain } from '#maka-node-toolchain';
 import { createCodexOAuthHarnessCredentialBinding } from '#codex-oauth-harness';
 import {
   assertDeepSweSubset30TaskTreeFingerprint,
@@ -172,6 +173,7 @@ export function buildHarnessAbToolchainFingerprint({
   hostToolchainFingerprint,
   competitorProfile,
   pierVersion = null,
+  makaNodeToolchainFingerprint = null,
 }) {
   return `sha256:${createHash('sha256')
     .update(
@@ -180,6 +182,7 @@ export function buildHarnessAbToolchainFingerprint({
         competitor: competitorProfile.id,
         competitorToolchainFingerprint: competitorProfile.toolchainFingerprint,
         ...(pierVersion === null ? {} : { pierVersion }),
+        ...(makaNodeToolchainFingerprint === null ? {} : { makaNodeToolchainFingerprint }),
       }),
     )
     .digest('hex')}`;
@@ -389,6 +392,19 @@ export function resolveHarnessCompetitorToolchain(runRoot, competitorProfile, en
   throw new Error(`unsupported harness competitor: ${competitorProfile.id}`);
 }
 
+export function resolveHarnessMakaNodeToolchain(runRoot, env = process.env) {
+  const fingerprintPrefix = MAKA_NODE_TOOLCHAIN_FINGERPRINT.slice(
+    'sha256:'.length,
+    'sha256:'.length + 12,
+  );
+  return {
+    path: env.MAKA_HARNESS_AB_MAKA_NODE_TOOLCHAIN
+      ? resolve(env.MAKA_HARNESS_AB_MAKA_NODE_TOOLCHAIN)
+      : join(runRoot, 'toolchains', `maka-node-${fingerprintPrefix}-linux-x64`),
+    prepare: prepareMakaNodeToolchain,
+  };
+}
+
 const envPath = (name, fallback) => parseEnvPath(name, process.env[name], fallback);
 const envPathFrom = (env, name, fallback) => parseEnvPath(name, env[name], fallback);
 
@@ -516,6 +532,13 @@ export function harnessMakaContextBudgetEnv() {
   };
 }
 
+export function harnessMakaAgentEnv(benchmarkProfile) {
+  return {
+    ...(benchmarkProfile.executor === 'pier' ? { MAKA_HARBOR_MODE: 'task-run' } : {}),
+    ...harnessMakaContextBudgetEnv(),
+  };
+}
+
 export function buildHarnessAbManifest({
   subjectFingerprint,
   taskSourceFingerprint,
@@ -566,6 +589,15 @@ export function buildHarnessAbManifest({
           attemptPolicy: 'single',
           billingMode: runtime.billingMode,
           contextBudget: HARNESS_MAKA_CONTEXT_BUDGET,
+          ...(benchmarkProfile.executor === 'pier'
+            ? {
+                execution: {
+                  placement: 'task-container',
+                  isolation: 'harbor-local',
+                  nodeToolchainFingerprint: MAKA_NODE_TOOLCHAIN_FINGERPRINT,
+                },
+              }
+            : {}),
         },
       },
       {
@@ -730,6 +762,8 @@ async function runLocked({
     hostToolchainFingerprint,
     competitorProfile,
     pierVersion,
+    makaNodeToolchainFingerprint:
+      benchmarkProfile.executor === 'pier' ? MAKA_NODE_TOOLCHAIN_FINGERPRINT : null,
   });
   const manifest = buildHarnessAbManifest({
     subjectFingerprint,
@@ -752,7 +786,12 @@ async function runLocked({
     throw new Error('manifest contains a task absent from the frozen task source');
 
   const competitorToolchain = resolveHarnessCompetitorToolchain(runRoot, competitorProfile);
-  await competitorToolchain.prepare(competitorToolchain.path);
+  const makaNodeToolchain =
+    benchmarkProfile.executor === 'pier' ? resolveHarnessMakaNodeToolchain(runRoot) : null;
+  await Promise.all([
+    competitorToolchain.prepare(competitorToolchain.path),
+    makaNodeToolchain?.prepare(makaNodeToolchain.path),
+  ]);
 
   const execution = buildHarnessExecutionProfile(competitorProfile);
   if (
@@ -783,13 +822,15 @@ async function runLocked({
         pricing: execution.pricing,
         timeoutMultiplier: 1,
         ...(benchmarkProfile.executor === 'pier'
-          ? { baseUrl: execution.baseUrl }
+          ? {
+              baseUrl: execution.baseUrl,
+              makaNodeToolchainPath: makaNodeToolchain.path,
+            }
           : {
               agentEnv: { MAKA_BASE_URL: execution.baseUrl },
               dockerPlatform: 'linux/amd64',
             }),
       };
-      const makaContextBudgetEnv = harnessMakaContextBudgetEnv();
       const config = (id) => ({
         id: `harness-ab-${id}`,
         backend: 'ai-sdk',
@@ -813,7 +854,7 @@ async function runLocked({
             harborRunner: createBenchmarkRunner({
               ...runnerOptions,
               agent: 'maka',
-              agentEnv: { ...runnerOptions.agentEnv, ...makaContextBudgetEnv },
+              agentEnv: { ...runnerOptions.agentEnv, ...harnessMakaAgentEnv(benchmarkProfile) },
             }),
           },
           {

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -607,6 +607,9 @@ export function buildHarnessAbManifest({
           ...competitorProfile.config,
           externalSystemPrompt: 'empty',
           profile: competitorProfile.id,
+          ...(benchmarkProfile.executor === 'pier'
+            ? { execution: { placement: 'task-container' } }
+            : {}),
         },
       },
     ],
@@ -891,6 +894,7 @@ async function runLocked({
             }
           : { annotations: [], warnings: [] },
         execution.billingMode,
+        manifest,
       );
     },
     artifacts: (report) => [

--- a/packages/headless/harbor/tests/test_harness_compat.py
+++ b/packages/headless/harbor/tests/test_harness_compat.py
@@ -193,13 +193,33 @@ def test_maka_agent_network_policy_under_pier():
     fake = maka_mod.MakaAgent(logs_dir=Path("/tmp"), backend="fake")
     assert fake.network_allowlist().domains == []
 
-    # task-run mode always runs the model on the host and only bridges tool
-    # commands into the container, so the empty allowlist is correct even
-    # without any MAKA_HOST_* configuration.
+    # Pier task-run mode runs Maka in the task container. It may reach only the
+    # host credential proxy, never the upstream provider directly.
     task_run = maka_mod.MakaAgent(
+        logs_dir=Path("/tmp"),
+        extra_env={
+            "MAKA_HARBOR_MODE": "task-run",
+            "MAKA_PROVIDER_PROXY_URL": "https://host.docker.internal",
+            "MAKA_PROVIDER_PROXY_TOKEN": "ephemeral-token",
+        },
+    )
+    assert task_run.network_allowlist().domains == ["host.docker.internal"]
+
+    fake_task_run = maka_mod.MakaAgent(
+        logs_dir=Path("/tmp"),
+        backend="fake",
+        extra_env={"MAKA_HARBOR_MODE": "task-run"},
+    )
+    assert fake_task_run.network_allowlist().domains == []
+
+    missing_task_run_proxy = maka_mod.MakaAgent(
         logs_dir=Path("/tmp"), extra_env={"MAKA_HARBOR_MODE": "task-run"}
     )
-    assert task_run.network_allowlist().domains == []
+    _raises(
+        missing_task_run_proxy.network_allowlist,
+        ValueError,
+        "host provider proxy",
+    )
 
     # A cell-mode ai-sdk run without host-side provider config would need
     # in-container egress the empty allowlist forbids; fail at environment

--- a/packages/headless/harbor/tests/test_harness_compat.py
+++ b/packages/headless/harbor/tests/test_harness_compat.py
@@ -194,16 +194,17 @@ def test_maka_agent_network_policy_under_pier():
     assert fake.network_allowlist().domains == []
 
     # Pier task-run mode runs Maka in the task container. It may reach only the
-    # host credential proxy, never the upstream provider directly.
+    # host credential proxy, never the upstream provider directly. Pier loads
+    # its secret --env-file into os.environ; only --ae values reach extra_env.
+    os.environ["MAKA_PROVIDER_PROXY_URL"] = "https://host.docker.internal"
+    os.environ["MAKA_PROVIDER_PROXY_TOKEN"] = "ephemeral-token"
     task_run = maka_mod.MakaAgent(
         logs_dir=Path("/tmp"),
-        extra_env={
-            "MAKA_HARBOR_MODE": "task-run",
-            "MAKA_PROVIDER_PROXY_URL": "https://host.docker.internal",
-            "MAKA_PROVIDER_PROXY_TOKEN": "ephemeral-token",
-        },
+        extra_env={"MAKA_HARBOR_MODE": "task-run"},
     )
     assert task_run.network_allowlist().domains == ["host.docker.internal"]
+    del os.environ["MAKA_PROVIDER_PROXY_URL"]
+    del os.environ["MAKA_PROVIDER_PROXY_TOKEN"]
 
     fake_task_run = maka_mod.MakaAgent(
         logs_dir=Path("/tmp"),

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -45,6 +45,7 @@
     "#opencode-toolchain": "./dist/opencode-toolchain.js",
     "#kimi-code-toolchain": "./dist/kimi-code-toolchain.js",
     "#codex-toolchain": "./dist/codex-toolchain.js",
+    "#maka-node-toolchain": "./dist/maka-node-toolchain.js",
     "#codex-oauth-harness": "./dist/codex-oauth-harness.js",
     "#runtime-policy-ab-profile": "./dist/runtime-policy-ab-profile.js",
     "#runtime-policy-ab-spec": "./dist/runtime-policy-ab-spec.js",

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -383,18 +383,22 @@ describe('Harbor adapter contract', () => {
     }
   });
 
-  test('maka_agent.py task-run host mode preserves the heavy-task / autonomous bridge contract', async () => {
+  test('maka_agent.py preserves plain Harbor host task-run and Pier container task-run contracts', async () => {
     const source = await readRepoFile('packages/headless/harbor/maka_agent.py');
 
-    // Mode switch: default cell, opt-in task-run host bridge.
+    // Mode switch: default cell, opt-in task-run.
     assert.match(source, /MAKA_HARBOR_MODE/);
     assert.match(source, /def _harbor_mode\(self\) -> str:/);
     assert.match(source, /if self\._harbor_mode\(\) == "task-run":/);
+    assert.match(source, /async def _run_task_run_container\(/);
     assert.match(source, /async def _run_task_run_host\(/);
-    // Spawns the headless CLI in task-run + harbor-http isolation on the host.
+    // Plain Harbor keeps its host bridge; Pier runs the same task-run in the
+    // task container with the pinned runtime and local isolation.
     assert.match(source, /dist" \/ "cli\.js"/);
     assert.match(source, /"--mode",\s*\n\s*"task-run",/);
-    assert.match(source, /"--isolation",\s*\n\s*"harbor-http",/);
+    assert.match(source, /isolation: str = "harbor-http"/);
+    assert.match(source, /isolation="harbor-local"/);
+    assert.match(source, /_MAKA_NODE_TOOLCHAIN_NODE/);
     assert.match(source, /"--include-events"/);
     // autonomous / heavy-task derivation ported verbatim from the fork.
     assert.match(
@@ -1803,6 +1807,141 @@ finally:
     scope_dir.rmdir()
 
 with tempfile.TemporaryDirectory() as tmp:
+    class ContainerTaskRunEnvironment:
+        session_id = "deep-swe-task"
+
+        def __init__(self):
+            self.agent_dir_ready = False
+            self.uploads = []
+            self.downloads = []
+            self.download_dirs = []
+
+        async def upload_file(self, local, remote):
+            assert self.agent_dir_ready, "instruction uploaded before /logs/agent exists"
+            self.uploads.append((str(local), str(remote)))
+
+        async def download_file(self, remote, local):
+            self.downloads.append(str(remote))
+            path = Path(local)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            if str(remote).endswith("/maka-cell-output.json"):
+                path.write_text(json.dumps({
+                    "schemaVersion": 1,
+                    "status": "completed",
+                    "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+                    "promptHash": "sha256:test",
+                    "toolSummary": {
+                        "providerVisibleToolCount": 6,
+                        "actualToolCalls": 0,
+                        "actualToolNames": [],
+                        "actualToolCallCounts": {},
+                    },
+                    "steps": 1,
+                    "durationMs": 1,
+                    "startedAt": 1,
+                    "finishedAt": 2,
+                    "runtimeRefs": {
+                        "invocationId": "inv",
+                        "sessionId": "session",
+                        "runId": "run",
+                        "turnId": "turn",
+                    },
+                }), encoding="utf-8")
+            else:
+                path.write_text("", encoding="utf-8")
+
+        async def download_dir(self, remote, local):
+            self.download_dirs.append(str(remote))
+            Path(local).mkdir(parents=True, exist_ok=True)
+
+    class ContainerTaskRunAgent(MakaAgent):
+        def __init__(self, logs_dir, **kwargs):
+            super().__init__(logs_dir, **kwargs)
+            self.container_execs = []
+
+        async def exec_as_agent(self, environment, command, **kwargs):
+            self.container_execs.append((command, kwargs))
+            if command == "mkdir -p /logs/agent":
+                environment.agent_dir_ready = True
+            return types.SimpleNamespace(stdout="", stderr="", return_code=0)
+
+    async def forbidden_host_task_run(*args, **kwargs):
+        raise AssertionError("Pier task-run used the host bridge")
+
+    class FakeNetworkAllowlist:
+        def __init__(self, domains=None):
+            self.domains = domains or []
+
+    original_network_allowlist = maka_agent_mod._NetworkAllowlist
+    maka_agent_mod._NetworkAllowlist = FakeNetworkAllowlist
+    try:
+        container_agent = ContainerTaskRunAgent(Path(tmp), extra_env={
+            "MAKA_BACKEND": "ai-sdk",
+            "MAKA_HARBOR_MODE": "task-run",
+            "MAKA_NODE_TOOLCHAIN_FINGERPRINT": "sha256:test-node",
+            "MAKA_PROVIDER_PROXY_URL": "http://host.docker.internal:443",
+            "MAKA_PROVIDER_PROXY_TOKEN": "ephemeral-token",
+            "MAKA_CELL_TIMEOUT_SEC": "7200",
+        })
+        container_agent._resolved_flags = {
+            "maka_repo": "/opt/maka-agent",
+            "backend": "ai-sdk",
+        }
+        container_agent._run_task_run_host = forbidden_host_task_run
+        container_environment = ContainerTaskRunEnvironment()
+        container_context = AgentContext()
+        assert container_agent.network_allowlist().domains == ["host.docker.internal"]
+        assert container_agent.get_version_command() == "/opt/maka-node-toolchain/bin/node --version"
+        asyncio.run(
+            container_agent.run(
+                "finish the task",
+                container_environment,
+                container_context,
+            )
+        )
+    finally:
+        maka_agent_mod._NetworkAllowlist = original_network_allowlist
+
+    assert len(container_agent.container_execs) == 2, container_agent.container_execs
+    assert container_agent.container_execs[0][0] == "mkdir -p /logs/agent"
+    container_command, container_kwargs = container_agent.container_execs[1]
+    assert "/opt/maka-node-toolchain/bin/node" in container_command, container_command
+    assert "/opt/maka-agent/packages/headless/dist/cli.js" in container_command, container_command
+    assert "--mode task-run" in container_command, container_command
+    assert "--isolation harbor-local" in container_command, container_command
+    assert "harbor-http" not in container_command, container_command
+    container_env = container_kwargs["env"]
+    assert container_env["MAKA_HOST_BASE_URL"] == "http://host.docker.internal:443", container_env
+    assert container_env["MAKA_HOST_API_KEY"] == "ephemeral-token", container_env
+    assert "MAKA_HARBOR_TOOL_EXECUTOR_URL" not in container_env, container_env
+    assert "MAKA_HARBOR_TOOL_EXECUTOR_TOKEN" not in container_env, container_env
+    assert container_env["MAKA_OUTPUT_DIR"] == "/logs/agent/maka-task-run", container_env
+    assert container_env["MAKA_CELL_ARTIFACT_DIR"] == "/logs/agent", container_env
+    assert container_env["MAKA_STORAGE_ROOT"] == "/logs/agent/maka-task-run/runs", container_env
+    assert container_kwargs["timeout_sec"] == 7200, container_kwargs
+    assert "/logs/agent/maka-task-run" in container_environment.download_dirs
+    assert "/logs/agent/maka-cell-output.json" in container_environment.downloads
+    assert json.loads(
+        Path(container_context.metadata["maka_cell_output"]).read_text(encoding="utf-8")
+    )["status"] == "completed"
+
+    container_install_agent = ContainerTaskRunAgent(Path(tmp), extra_env={
+        "MAKA_BACKEND": "fake",
+        "MAKA_HARBOR_MODE": "task-run",
+        "MAKA_NODE_TOOLCHAIN_FINGERPRINT": "sha256:test-node",
+    })
+    container_install_agent._resolved_flags = {"backend": "fake"}
+    maka_agent_mod._NetworkAllowlist = FakeNetworkAllowlist
+    try:
+        asyncio.run(container_install_agent.install(ContainerTaskRunEnvironment()))
+    finally:
+        maka_agent_mod._NetworkAllowlist = original_network_allowlist
+    install_command, install_kwargs = container_install_agent.container_execs[0]
+    assert "sha256sum --check checksums.sha256" in install_command, install_command
+    assert "/opt/maka-node-toolchain/manifest.json" in install_command, install_command
+    assert "/opt/maka-agent/packages/headless/dist/cli.js" in install_command, install_command
+    assert install_kwargs["env"]["MAKA_EXPECTED_TOOLCHAIN_FINGERPRINT"] == "sha256:test-node"
+
     install_agent = MakaAgent(Path(tmp))
     install_agent._resolved_flags = {"maka_repo": "/opt/maka-agent"}
     fake_environment = types.SimpleNamespace(root_commands=[], agent_commands=[])

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1571,7 +1571,9 @@ class BaseInstalledAgent:
         self.logger = types.SimpleNamespace(debug=lambda *args, **kwargs: None)
 
     def _get_env(self, key):
-        return self._extra_env.get(key)
+        if key in self._extra_env:
+            return self._extra_env[key]
+        return os.environ.get(key)
 
     def version(self):
         return "test"
@@ -1874,13 +1876,13 @@ with tempfile.TemporaryDirectory() as tmp:
 
     original_network_allowlist = maka_agent_mod._NetworkAllowlist
     maka_agent_mod._NetworkAllowlist = FakeNetworkAllowlist
+    os.environ["MAKA_PROVIDER_PROXY_URL"] = "http://host.docker.internal:443"
+    os.environ["MAKA_PROVIDER_PROXY_TOKEN"] = "ephemeral-token"
     try:
         container_agent = ContainerTaskRunAgent(Path(tmp), extra_env={
             "MAKA_BACKEND": "ai-sdk",
             "MAKA_HARBOR_MODE": "task-run",
             "MAKA_NODE_TOOLCHAIN_FINGERPRINT": "sha256:test-node",
-            "MAKA_PROVIDER_PROXY_URL": "http://host.docker.internal:443",
-            "MAKA_PROVIDER_PROXY_TOKEN": "ephemeral-token",
             "MAKA_CELL_TIMEOUT_SEC": "7200",
         })
         container_agent._resolved_flags = {
@@ -1913,6 +1915,9 @@ with tempfile.TemporaryDirectory() as tmp:
     container_env = container_kwargs["env"]
     assert container_env["MAKA_HOST_BASE_URL"] == "http://host.docker.internal:443", container_env
     assert container_env["MAKA_HOST_API_KEY"] == "ephemeral-token", container_env
+    assert container_env["NODE_USE_ENV_PROXY"] == "1", container_env
+    assert "MAKA_PROVIDER_PROXY_URL" not in container_env, container_env
+    assert "MAKA_PROVIDER_PROXY_TOKEN" not in container_env, container_env
     assert "MAKA_HARBOR_TOOL_EXECUTOR_URL" not in container_env, container_env
     assert "MAKA_HARBOR_TOOL_EXECUTOR_TOKEN" not in container_env, container_env
     assert container_env["MAKA_OUTPUT_DIR"] == "/logs/agent/maka-task-run", container_env

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { describe, test, afterEach } from 'node:test';
+import { resolveEconomyTaskMode } from '../economy-task-policy.js';
 import { resolveHarborCellAiSdkEnv } from '../harbor-cell.js';
 import { applyConnectionDefaults, resolveHarborRunOptions } from '../harbor-cli.js';
 
@@ -433,6 +434,23 @@ describe('applyConnectionDefaults', () => {
 });
 
 describe('resolveHarborRunOptions backend guard', () => {
+  test('preserves an explicit economy-task disable over instruction signals', async () => {
+    const opts = await resolveHarborRunOptions(
+      ['--backend', 'fake', '--instruction', 'summarize the log files'],
+      { MAKA_ECONOMY_TASK_MODE: 'false' },
+    );
+
+    const selection = resolveEconomyTaskMode(opts.config, {
+      id: 'economy-signal-task',
+      instruction: opts.instruction,
+      workspaceDir: '/workspace',
+      verification: { command: 'true', protectedPaths: [] },
+    });
+
+    assert.equal(selection.enabled, false);
+    assert.equal(selection.triggerSource, 'config');
+  });
+
   test('wires an explicit environment-proxy fetch into real container backends', async () => {
     const opts = await resolveHarborRunOptions(
       ['--instruction', 'test', '--isolation', 'harbor-local'],

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -433,6 +433,28 @@ describe('applyConnectionDefaults', () => {
 });
 
 describe('resolveHarborRunOptions backend guard', () => {
+  test('wires an explicit environment-proxy fetch into real container backends', async () => {
+    const opts = await resolveHarborRunOptions(
+      ['--instruction', 'test', '--isolation', 'harbor-local'],
+      {
+        MAKA_MODEL: 'openai-codex/gpt-5.6-sol',
+        MAKA_HOST_API_KEY: 'selected-host-token',
+        MAKA_HOST_BASE_URL: 'http://host.docker.internal:443',
+        NODE_USE_ENV_PROXY: '1',
+        HTTP_PROXY: 'http://agent:test@pier-egress-proxy:8080',
+        HTTPS_PROXY: 'http://agent:test@pier-egress-proxy:8080',
+        NO_PROXY: 'localhost,127.0.0.1',
+      },
+    );
+
+    try {
+      assert.ok(opts.providerEnvFetch);
+      assert.ok(opts.registerBackends);
+    } finally {
+      await opts.providerEnvFetch?.close();
+    }
+  });
+
   test('keeps a local external workspace separate from the headless source fixture', async () => {
     const opts = await resolveHarborRunOptions(
       [

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -452,6 +452,10 @@ describe('resolveHarborRunOptions backend guard', () => {
 
     assert.equal(opts.workdir, '/app');
     assert.equal(opts.sourceWorkspaceDir, '/logs/agent/maka-task-run/host-workspace-source');
+    assert.equal(
+      opts.realBackendIsolation?.submittedSnapshotRoot,
+      '/logs/agent/maka-task-run/submitted-snapshots',
+    );
   });
 
   test('uses the strict cell soft-timeout parser in task-run mode', async () => {

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -6,6 +6,7 @@ import { describe, test, afterEach } from 'node:test';
 import { resolveEconomyTaskMode } from '../economy-task-policy.js';
 import { resolveHarborCellAiSdkEnv } from '../harbor-cell.js';
 import { applyConnectionDefaults, resolveHarborRunOptions } from '../harbor-cli.js';
+import { validateRealBackendIsolation } from '../isolation.js';
 
 /**
  * Tests for applyConnectionDefaults — the function that reads
@@ -495,6 +496,37 @@ describe('resolveHarborRunOptions backend guard', () => {
     assert.equal(
       opts.realBackendIsolation?.submittedSnapshotRoot,
       '/logs/agent/maka-task-run/submitted-snapshots',
+    );
+  });
+
+  test('rejects a persistent snapshot root inside its source workspace', async () => {
+    const opts = await resolveHarborRunOptions(
+      [
+        '--backend',
+        'fake',
+        '--instruction',
+        'test',
+        '--isolation',
+        'harbor-local',
+        '--workdir',
+        '/workspace',
+        '--out',
+        '/workspace/out',
+      ],
+      {},
+    );
+
+    assert.throws(
+      () => validateRealBackendIsolation(opts.realBackendIsolation),
+      /submittedSnapshotRoot must stay outside workspaceDir/,
+    );
+    assert.doesNotThrow(() =>
+      validateRealBackendIsolation({
+        kind: 'external',
+        label: 'Pier task container',
+        workspaceDir: '/app',
+        submittedSnapshotRoot: '/logs/agent/submitted-snapshots',
+      }),
     );
   });
 

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -433,6 +433,27 @@ describe('applyConnectionDefaults', () => {
 });
 
 describe('resolveHarborRunOptions backend guard', () => {
+  test('keeps a local external workspace separate from the headless source fixture', async () => {
+    const opts = await resolveHarborRunOptions(
+      [
+        '--backend',
+        'fake',
+        '--instruction',
+        'test',
+        '--isolation',
+        'harbor-local',
+        '--workdir',
+        '/app',
+        '--out',
+        '/logs/agent/maka-task-run',
+      ],
+      {},
+    );
+
+    assert.equal(opts.workdir, '/app');
+    assert.equal(opts.sourceWorkspaceDir, '/logs/agent/maka-task-run/host-workspace-source');
+  });
+
   test('uses the strict cell soft-timeout parser in task-run mode', async () => {
     await assert.rejects(
       resolveHarborRunOptions(['--backend', 'fake', '--instruction', 'test'], {

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -815,6 +815,9 @@ test('harness A/B resolves the DeepSWE benchmark axis orthogonally to competitor
     isolation: 'harbor-local',
     nodeToolchainFingerprint: MAKA_NODE_TOOLCHAIN_FINGERPRINT,
   });
+  assert.deepEqual(manifest.arms[1].metadata.config.execution, {
+    placement: 'task-container',
+  });
 
   // The Pier executor identity is auditable in the manifest, not only hashed
   // into the toolchain fingerprint.
@@ -836,6 +839,7 @@ test('harness A/B resolves the DeepSWE benchmark axis orthogonally to competitor
   });
   assert.equal(tbenchManifest.metadata.order.seed, 'terminal-bench-2.1:k3:harness-comparison:v1');
   assert.equal('execution' in tbenchManifest.arms[0].metadata.config, false);
+  assert.equal('execution' in tbenchManifest.arms[1].metadata.config, false);
   // No executor key for Harbor benchmarks: the manifest payload (and with it
   // the resume fingerprint) must stay byte-identical to historical runs.
   assert.equal('executor' in tbenchManifest.metadata.benchmark, false);

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -32,9 +32,8 @@ test('harness A/B CLI accepts a 5-task operational canary', async () => {
 });
 
 test('harness A/B runtime keeps pruning enabled and semantic compact disabled', async () => {
-  const { harnessMakaContextBudgetEnv } = await import(
-    new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
-  );
+  const { harnessMakaAgentEnv, harnessMakaContextBudgetEnv, resolveHarnessBenchmarkProfile } =
+    await import(new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href);
 
   assert.deepEqual(harnessMakaContextBudgetEnv(), {
     MAKA_CONTEXT_ACTIVE_TOOL_RESULT_PRUNE: 'on',
@@ -45,6 +44,14 @@ test('harness A/B runtime keeps pruning enabled and semantic compact disabled', 
     MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS_FULL: '0',
     MAKA_CONTEXT_SEMANTIC_COMPACT: 'off',
   });
+  assert.equal(
+    harnessMakaAgentEnv(resolveHarnessBenchmarkProfile('deep-swe-1.1')).MAKA_HARBOR_MODE,
+    'task-run',
+  );
+  assert.equal(
+    'MAKA_HARBOR_MODE' in harnessMakaAgentEnv(resolveHarnessBenchmarkProfile('terminal-bench-2.1')),
+    false,
+  );
 });
 
 test('harness A/B uses one safe execution default and accepts per-run overrides', async () => {
@@ -459,6 +466,25 @@ test('harness execution profile rejects a reasoning effort unsupported by model 
   );
 });
 
+test('DeepSWE resolves a dedicated pinned Maka Node toolchain', async () => {
+  const { resolveHarnessMakaNodeToolchain } = await import(
+    new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
+  );
+  const { MAKA_NODE_TOOLCHAIN_FINGERPRINT } = await import('../maka-node-toolchain.js');
+
+  const defaultToolchain = resolveHarnessMakaNodeToolchain('/run', {});
+  assert.match(
+    defaultToolchain.path,
+    new RegExp(`maka-node-${MAKA_NODE_TOOLCHAIN_FINGERPRINT.slice(7, 19)}-linux-x64$`),
+  );
+  assert.equal(defaultToolchain.prepare.name, 'prepareMakaNodeToolchain');
+
+  const overridden = resolveHarnessMakaNodeToolchain('/run', {
+    MAKA_HARNESS_AB_MAKA_NODE_TOOLCHAIN: '/prepared/maka-node',
+  });
+  assert.equal(overridden.path, '/prepared/maka-node');
+});
+
 test('Codex comparison resolves both arms from one OAuth account workflow', async () => {
   const { resolveHarnessCompetitorProfile, resolveHarnessRuntimeCredentials } = await import(
     new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href
@@ -724,6 +750,7 @@ test('harness A/B resolves the DeepSWE benchmark axis orthogonally to competitor
     resolveHarnessBenchmarkProfile,
     resolveHarnessCompetitorProfile,
   } = await import(new URL('../../harbor/run-harness-ab.mjs', import.meta.url).href);
+  const { MAKA_NODE_TOOLCHAIN_FINGERPRINT } = await import('../maka-node-toolchain.js');
   const benchmarkProfile = resolveHarnessBenchmarkProfile('deep-swe-1.1');
 
   assert.throws(
@@ -783,6 +810,11 @@ test('harness A/B resolves the DeepSWE benchmark axis orthogonally to competitor
   assert.equal(manifest.metadata.benchmark.version, '1.1');
   assert.equal(manifest.metadata.order.seed, 'deep-swe-1.1:gpt-5.6-sol:harness-comparison:v1');
   assert.equal(manifest.evaluationTaskIds.length, 30);
+  assert.deepEqual(manifest.arms[0].metadata.config.execution, {
+    placement: 'task-container',
+    isolation: 'harbor-local',
+    nodeToolchainFingerprint: MAKA_NODE_TOOLCHAIN_FINGERPRINT,
+  });
 
   // The Pier executor identity is auditable in the manifest, not only hashed
   // into the toolchain fingerprint.
@@ -803,6 +835,7 @@ test('harness A/B resolves the DeepSWE benchmark axis orthogonally to competitor
     toolchainFingerprint: 'tools',
   });
   assert.equal(tbenchManifest.metadata.order.seed, 'terminal-bench-2.1:k3:harness-comparison:v1');
+  assert.equal('execution' in tbenchManifest.arms[0].metadata.config, false);
   // No executor key for Harbor benchmarks: the manifest payload (and with it
   // the resume fingerprint) must stay byte-identical to historical runs.
   assert.equal('executor' in tbenchManifest.metadata.benchmark, false);
@@ -861,14 +894,23 @@ test('harness A/B toolchain identity freezes the Pier version only for Pier benc
     hostToolchainFingerprint: 'host',
     competitorProfile,
     pierVersion: 'pier 0.3.0',
+    makaNodeToolchainFingerprint: `sha256:${'a'.repeat(64)}`,
   });
   const pier040 = buildHarnessAbToolchainFingerprint({
     hostToolchainFingerprint: 'host',
     competitorProfile,
     pierVersion: 'pier 0.4.0',
+    makaNodeToolchainFingerprint: `sha256:${'a'.repeat(64)}`,
+  });
+  const otherMakaNode = buildHarnessAbToolchainFingerprint({
+    hostToolchainFingerprint: 'host',
+    competitorProfile,
+    pierVersion: 'pier 0.3.0',
+    makaNodeToolchainFingerprint: `sha256:${'b'.repeat(64)}`,
   });
   assert.notEqual(pier030, legacy);
   assert.notEqual(pier030, pier040);
+  assert.notEqual(pier030, otherMakaNode);
 });
 
 async function waitForJournal(

--- a/packages/headless/src/__tests__/harness-ab-report.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-report.test.ts
@@ -8,9 +8,58 @@ import {
   renderHarnessAbReportCsv,
   renderHarnessAbReportMarkdown,
 } from '../harness-ab-report.js';
+import type { HarnessAbRunManifest } from '../harness-ab-manifest.js';
 import { budgetExhausted, completed, withUsage } from './helpers/ab-summary-fixtures.js';
 
 describe('harness A/B report', () => {
+  test('derives both arm placements from the run manifest', () => {
+    const summary = summarizeAbComparison({
+      runId: 'deep-swe-container-placement',
+      roundId: 'ab-summary',
+      baselineArmId: 'maka',
+      candidateArmId: 'codex',
+      evaluationTaskIds: ['a'],
+      baselineRuns: [[usage('a', true, 100, 20, 25, 0)]],
+      candidateRuns: [[usage('a', true, 120, 30, 30, 0)]],
+    });
+    const manifest = {
+      arms: [
+        {
+          id: 'maka',
+          kind: 'harness',
+          fingerprint: 'maka-fingerprint',
+          metadata: { config: { execution: { placement: 'task-container' } } },
+        },
+        {
+          id: 'codex',
+          kind: 'harness',
+          fingerprint: 'codex-fingerprint',
+          metadata: { config: { execution: { placement: 'task-container' } } },
+        },
+      ],
+    } as Pick<HarnessAbRunManifest, 'arms'>;
+
+    const report = buildHarnessAbReport(summary, undefined, 'metered', manifest);
+
+    assert.deepEqual(report.execution, {
+      arms: [
+        { armId: 'maka', placement: 'task-container' },
+        { armId: 'codex', placement: 'task-container' },
+      ],
+    });
+    assert.match(
+      renderHarnessAbReportMarkdown(report),
+      /Execution placement: maka=task-container; codex=task-container\./,
+    );
+    const partialManifest = {
+      arms: [manifest.arms[0], { ...manifest.arms[1], metadata: { config: {} } }],
+    } as Pick<HarnessAbRunManifest, 'arms'>;
+    assert.throws(
+      () => buildHarnessAbReport(summary, undefined, 'metered', partialManifest),
+      /execution placement must be declared for both arms/,
+    );
+  });
+
   test('keeps effectiveness and economy as separate reproducible axes', () => {
     const summary = summarizeAbComparison({
       runId: 'glm-harness-ab',

--- a/packages/headless/src/__tests__/maka-node-toolchain.test.ts
+++ b/packages/headless/src/__tests__/maka-node-toolchain.test.ts
@@ -1,0 +1,21 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  MAKA_NODE_TOOLCHAIN_FINGERPRINT,
+  MAKA_NODE_TOOLCHAIN_SPEC,
+} from '../maka-node-toolchain.js';
+
+test('Maka container task runs pin a Linux/x64 Node runtime', () => {
+  assert.equal(MAKA_NODE_TOOLCHAIN_SPEC.platform, 'linux');
+  assert.equal(MAKA_NODE_TOOLCHAIN_SPEC.arch, 'x64');
+  assert.equal(MAKA_NODE_TOOLCHAIN_SPEC.node.version, '22.23.1');
+  assert.equal(
+    MAKA_NODE_TOOLCHAIN_SPEC.node.archiveSha256,
+    '7a8cb04b4a1df4eaf432125324b81b29a088e73570a23259a8de1c65d07fc129',
+  );
+  assert.equal(
+    MAKA_NODE_TOOLCHAIN_SPEC.node.binarySha256,
+    '93956de2e59480474a7b46571da1651180b1a050cdf32641ebec4ce6e478e068',
+  );
+  assert.match(MAKA_NODE_TOOLCHAIN_FINGERPRINT, /^sha256:[a-f0-9]{64}$/);
+});

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -15,6 +15,7 @@ import {
 } from '../fixed-prompt-controller.js';
 import { CODEX_TOOLCHAIN_FINGERPRINT, CODEX_TOOLCHAIN_SPEC } from '../codex-toolchain.js';
 import { findTrialDir } from '../harbor-task-runner.js';
+import { MAKA_NODE_TOOLCHAIN_FINGERPRINT } from '../maka-node-toolchain.js';
 import {
   buildPierRunArgs,
   createPierTaskRunner,
@@ -282,6 +283,60 @@ test('buildPierRunArgs emits the pier CLI contract for the Maka arm', () => {
   assert.ok(!args.includes('--env-file'));
 });
 
+test('createPierTaskRunner mounts the pinned Maka Node runtime for container task-run mode', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'maka',
+        agentEnv: { MAKA_HARBOR_MODE: 'task-run' },
+        makaNodeToolchainPath: '/toolchains/maka-node',
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+
+    await runner(runInput());
+
+    const args = captured.request?.args ?? [];
+    const mountsFlag = args.indexOf('--mounts-json');
+    const mounts = JSON.parse(args[mountsFlag + 1]!) as Array<{
+      source: string;
+      target: string;
+      read_only: boolean;
+    }>;
+    assert.ok(
+      mounts.some(
+        (mount) =>
+          mount.source === '/toolchains/maka-node' &&
+          mount.target === '/opt/maka-node-toolchain' &&
+          mount.read_only,
+      ),
+    );
+    assert.ok(args.includes(`MAKA_NODE_TOOLCHAIN_FINGERPRINT=${MAKA_NODE_TOOLCHAIN_FINGERPRINT}`));
+  });
+});
+
+test('createPierTaskRunner rejects an unpinned Maka container task run', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'maka',
+        agentEnv: { MAKA_HARBOR_MODE: 'task-run' },
+        runPier: fakePier({ reward: 0 }),
+      }),
+    );
+
+    await assert.rejects(
+      () => runner(runInput()),
+      /makaNodeToolchainPath is required for Maka container task-run mode/,
+    );
+  });
+});
+
 test('buildPierRunArgs targets the Kimi Code adapter and forwards an env-file', () => {
   const args = buildPierRunArgs({
     agent: 'kimi-code',
@@ -431,6 +486,7 @@ test('createPierTaskRunner surfaces the combined trace path in task-run mode', a
       baseOptions({
         jobsDir,
         makaRepoPath: repo,
+        makaNodeToolchainPath: repo,
         agentEnv: { MAKA_HARBOR_MODE: 'task-run' },
         runPier: fakePier({ reward: 0, combinedTrace: true }),
       }),
@@ -1237,6 +1293,39 @@ test('createPierTaskRunner routes a resolver-backed Maka arm through the host pr
     assert.match(captured.envFile?.MAKA_HOST_BASE_URL ?? '', /^http:\/\/127\.0\.0\.1:\d+$/);
     assert.ok((captured.envFile?.MAKA_HOST_API_KEY ?? '').length >= 32);
     assert.notEqual(captured.envFile?.MAKA_HOST_API_KEY, 'upstream-key');
+  });
+});
+
+test('createPierTaskRunner gives a Maka container task run a container-reachable proxy', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        makaNodeToolchainPath: repo,
+        agent: 'maka',
+        agentEnv: { MAKA_HARBOR_MODE: 'task-run' },
+        backend: 'ai-sdk',
+        provider: 'openai-codex',
+        model: 'gpt-5.6-sol',
+        baseUrl: 'https://chatgpt.com/backend-api/codex',
+        resolveProviderCredential: () => Promise.resolve({ value: 'upstream-key' }),
+        providerProxyPort: 0,
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+
+    await runner(runInput());
+
+    assert.match(
+      captured.envFile?.MAKA_PROVIDER_PROXY_URL ?? '',
+      /^http:\/\/host\.docker\.internal:\d+$/,
+    );
+    assert.ok((captured.envFile?.MAKA_PROVIDER_PROXY_TOKEN ?? '').length >= 32);
+    assert.notEqual(captured.envFile?.MAKA_PROVIDER_PROXY_TOKEN, 'upstream-key');
+    assert.equal(captured.envFile?.MAKA_HOST_BASE_URL, undefined);
+    assert.equal(captured.envFile?.MAKA_HOST_API_KEY, undefined);
   });
 });
 

--- a/packages/headless/src/__tests__/provider-env-fetch.test.ts
+++ b/packages/headless/src/__tests__/provider-env-fetch.test.ts
@@ -1,0 +1,57 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import { test } from 'node:test';
+import { createProviderEnvFetch } from '../provider-env-fetch.js';
+
+test('provider env fetch routes AI SDK requests through the process HTTP proxy', async () => {
+  let proxyRequests = 0;
+  const proxy = createServer((_request, response) => {
+    proxyRequests += 1;
+    response.end('through-proxy');
+  });
+
+  await listen(proxy);
+  const proxyPort = addressPort(proxy);
+  const providerFetch = createProviderEnvFetch({
+    NODE_USE_ENV_PROXY: '1',
+    HTTP_PROXY: `http://127.0.0.1:${proxyPort}`,
+    HTTPS_PROXY: `http://127.0.0.1:${proxyPort}`,
+    NO_PROXY: '',
+  });
+  assert.ok(providerFetch);
+
+  try {
+    const response = await providerFetch.fetch('http://host.docker.internal:443/probe');
+    assert.equal(await response.text(), 'through-proxy');
+    assert.equal(proxyRequests, 1);
+  } finally {
+    await providerFetch.close();
+    await close(proxy);
+  }
+});
+
+test('provider env fetch stays absent unless environment proxying is explicitly enabled', () => {
+  assert.equal(
+    createProviderEnvFetch({
+      HTTP_PROXY: 'http://127.0.0.1:8080',
+      HTTPS_PROXY: 'http://127.0.0.1:8080',
+    }),
+    undefined,
+  );
+});
+
+async function listen(server: ReturnType<typeof createServer>): Promise<void> {
+  await new Promise<void>((resolve) => server.listen(0, '127.0.0.1', resolve));
+}
+
+async function close(server: ReturnType<typeof createServer>): Promise<void> {
+  await new Promise<void>((resolve, reject) =>
+    server.close((error) => (error ? reject(error) : resolve())),
+  );
+}
+
+function addressPort(server: ReturnType<typeof createServer>): number {
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('server did not bind a TCP port');
+  return address.port;
+}

--- a/packages/headless/src/__tests__/sandbox.test.ts
+++ b/packages/headless/src/__tests__/sandbox.test.ts
@@ -1,9 +1,18 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, stat, symlink, writeFile } from 'node:fs/promises';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, readlink, rm, stat, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { prepareWorkspace, restoreProtectedPaths } from '../sandbox.js';
+import { promisify } from 'node:util';
+import {
+  freezeSubmittedWorkspace,
+  prepareScoringWorkspace,
+  prepareWorkspace,
+  restoreProtectedPaths,
+} from '../sandbox.js';
+
+const execFileAsync = promisify(execFile);
 
 async function withFixture<T>(fn: (fixtureDir: string) => Promise<T>): Promise<T> {
   const dir = await mkdtemp(join(tmpdir(), 'maka-headless-fixture-'));
@@ -49,6 +58,45 @@ describe('prepareWorkspace', () => {
       await writeFile(join(fixtureDir, 'real.txt'), 'x', 'utf8');
       await symlink('/etc/hosts', join(fixtureDir, 'escape'));
       await assert.rejects(prepareWorkspace(fixtureDir), /symlink/);
+    });
+  });
+});
+
+describe('freezeSubmittedWorkspace', () => {
+  test('copies portable workspace evidence while skipping process-local special files', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    await withFixture(async (fixtureDir) => {
+      const snapshotRoot = await mkdtemp(join(tmpdir(), 'maka-headless-snapshot-'));
+      try {
+        await writeFile(join(fixtureDir, 'result.txt'), 'submitted', 'utf8');
+        await symlink('result.txt', join(fixtureDir, 'result-link'));
+        await execFileAsync('mkfifo', [join(fixtureDir, 'agent.pipe')]);
+
+        const frozen = await freezeSubmittedWorkspace({
+          workspaceDir: fixtureDir,
+          snapshotRoot,
+        });
+
+        assert.equal(
+          await readFile(join(frozen.submittedSnapshot.snapshotPath, 'result.txt'), 'utf8'),
+          'submitted',
+        );
+        assert.equal(
+          await readlink(join(frozen.submittedSnapshot.snapshotPath, 'result-link')),
+          'result.txt',
+        );
+        await assert.rejects(stat(join(frozen.submittedSnapshot.snapshotPath, 'agent.pipe')));
+
+        const scoring = await prepareScoringWorkspace(frozen.submittedSnapshot);
+        try {
+          assert.equal(await readlink(join(scoring.dir, 'result-link')), 'result.txt');
+        } finally {
+          await scoring.cleanup();
+        }
+      } finally {
+        await rm(snapshotRoot, { recursive: true, force: true });
+      }
     });
   });
 });

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -2384,6 +2384,43 @@ describe('runTaskOnce', () => {
     });
   });
 
+  test('persists the submitted snapshot from an explicitly owned external workspace', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const externalWorkspaceDir = await mkdtemp(join(storageRoot, 'external-workspace-'));
+      const submittedSnapshotRoot = join(storageRoot, 'submitted-snapshots');
+      await writeFile(join(fixtureDir, 'check.mjs'), 'fixture copy\n', 'utf8');
+      await writeFile(join(externalWorkspaceDir, 'check.mjs'), 'external copy\n', 'utf8');
+      const task: Task = {
+        id: 'external-workspace-snapshot',
+        instruction: 'modify the external workspace',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce(fakeConfig, task, {
+        storageRoot,
+        registerBackends: registerProtectedTamperBackend,
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'locally accessible task container',
+          workspaceDir: externalWorkspaceDir,
+          submittedSnapshotRoot,
+        },
+      });
+
+      const snapshot = result.projection.latestScoreResult?.details?.submittedSnapshot as
+        | { snapshotPath?: string; workspaceRoot?: string }
+        | undefined;
+      assert.ok(snapshot?.snapshotPath, 'expected persisted external submitted snapshot');
+      assert.equal(snapshot.workspaceRoot, externalWorkspaceDir);
+      assert.match(snapshot.snapshotPath, new RegExp(`^${submittedSnapshotRoot}`));
+      assert.equal(
+        await readFile(join(snapshot.snapshotPath, 'check.mjs'), 'utf8'),
+        'process.exit(0);\n',
+      );
+    });
+  });
+
   test('maps backend failure and incomplete runtime to terminal failure taxonomy', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       await writeFile(join(fixtureDir, 'marker.txt'), 'present', 'utf8');

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -1156,6 +1156,45 @@ async function readAgentRunHeader(
 }
 
 describe('runTaskOnce', () => {
+  test('gives task-run backends the authoritative current-run event reader', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      let loadTurnRuntimeEvents: ((turnId: string) => Promise<RuntimeEvent[]>) | undefined;
+      const task: Task = {
+        id: 'runtime-event-reader-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+        storageRoot,
+        registerBackends: (registry) => {
+          registry.register('ai-sdk', (ctx) => {
+            loadTurnRuntimeEvents = ctx.loadTurnRuntimeEvents;
+            return new ReportingBackend({
+              sessionId: ctx.sessionId,
+              header: ctx.header,
+              store: ctx.store,
+            });
+          });
+        },
+        realBackendIsolation: { kind: 'external', label: 'unit isolation' },
+      });
+
+      assert.ok(loadTurnRuntimeEvents);
+      const events = await loadTurnRuntimeEvents(latestInvocation(result).turnId);
+      assert.ok(
+        events.some(
+          (event) =>
+            event.role === 'user' &&
+            event.content?.kind === 'text' &&
+            event.content.text === task.instruction,
+        ),
+      );
+      assert.ok(events.some((event) => event.status === 'completed'));
+    });
+  });
+
   test('lets a task-run backend spawn, list, and read a linked child session', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       const observed: {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -83,6 +83,7 @@ import {
   buildHarborCellAiSdkTools,
   createHarborCellLocalToolExecutor,
 } from './harbor-cell-tool-executor.js';
+import { createProviderEnvFetch, type ProviderEnvFetch } from './provider-env-fetch.js';
 
 // The Harbor cell orchestration module keeps `#harbor-cell` (and './harbor-cell.js')
 // as the stable public surface. After the sink-file split the moved symbols live in
@@ -599,6 +600,7 @@ export async function runHarborCellFromEnv(
   };
   let config: Config;
   let registerBackends = options.registerBackends;
+  let providerEnvFetch: ProviderEnvFetch | undefined;
 
   switch (backend) {
     case 'ai-sdk': {
@@ -611,15 +613,19 @@ export async function runHarborCellFromEnv(
         llmConnectionSlug: resolvedEnv.MAKA_LLM_CONNECTION_SLUG ?? modelSpec.provider,
         model: modelSpec.model,
       };
-      registerBackends ??= buildAiSdkCellBackendRegistration({
-        provider: modelSpec.provider,
-        model: modelSpec.model,
-        env: resolvedEnv,
-        now,
-        newId,
-        ...(maxSteps !== undefined ? { maxSteps } : {}),
-        recordUsageCheckpoint: (usage) => writeHarborCellUsageCheckpoint(outputDir, usage),
-      });
+      if (!registerBackends) {
+        providerEnvFetch = createProviderEnvFetch(resolvedEnv);
+        registerBackends = buildAiSdkCellBackendRegistration({
+          provider: modelSpec.provider,
+          model: modelSpec.model,
+          env: resolvedEnv,
+          now,
+          newId,
+          ...(providerEnvFetch ? { fetch: providerEnvFetch.fetch } : {}),
+          ...(maxSteps !== undefined ? { maxSteps } : {}),
+          recordUsageCheckpoint: (usage) => writeHarborCellUsageCheckpoint(outputDir, usage),
+        });
+      }
       break;
     }
     case 'pi-agent': {
@@ -665,30 +671,34 @@ export async function runHarborCellFromEnv(
       break;
   }
 
-  return await runHarborCell({
-    config,
-    instruction: await instructionFromEnv(resolvedEnv),
-    cwd: resolvedEnv.MAKA_WORKDIR ?? process.cwd(),
-    outputDir,
-    storageRoot,
-    pricingProfile: resolvedEnv.MAKA_TRIAL_PRICING_SOURCE ?? 'unconfigured',
-    ...(contextBudgetPolicy ? { contextBudgetPolicy } : {}),
-    ...(continuationPolicy ? { continuationPolicy } : {}),
-    ...(taskLedgerExperimentPolicy ? { taskToolSummaryEnabled: true } : {}),
-    ...(settleAfterMs !== undefined ? { settleAfterMs } : {}),
-    ...(registerBackends ? { registerBackends } : {}),
-    ...(backendNeedsIsolation(backend)
-      ? {
-          realBackendIsolation: {
-            kind: 'external',
-            label: 'Harbor task container',
-            toolExecutor: createHarborCellLocalToolExecutor(resolvedEnv),
-          },
-        }
-      : {}),
-    ...(options.now ? { now: options.now } : {}),
-    ...(options.newId ? { newId: options.newId } : {}),
-  });
+  try {
+    return await runHarborCell({
+      config,
+      instruction: await instructionFromEnv(resolvedEnv),
+      cwd: resolvedEnv.MAKA_WORKDIR ?? process.cwd(),
+      outputDir,
+      storageRoot,
+      pricingProfile: resolvedEnv.MAKA_TRIAL_PRICING_SOURCE ?? 'unconfigured',
+      ...(contextBudgetPolicy ? { contextBudgetPolicy } : {}),
+      ...(continuationPolicy ? { continuationPolicy } : {}),
+      ...(taskLedgerExperimentPolicy ? { taskToolSummaryEnabled: true } : {}),
+      ...(settleAfterMs !== undefined ? { settleAfterMs } : {}),
+      ...(registerBackends ? { registerBackends } : {}),
+      ...(backendNeedsIsolation(backend)
+        ? {
+            realBackendIsolation: {
+              kind: 'external',
+              label: 'Harbor task container',
+              toolExecutor: createHarborCellLocalToolExecutor(resolvedEnv),
+            },
+          }
+        : {}),
+      ...(options.now ? { now: options.now } : {}),
+      ...(options.newId ? { newId: options.newId } : {}),
+    });
+  } finally {
+    await providerEnvFetch?.close();
+  }
 }
 
 export function reasoningEffortFromEnv(
@@ -853,6 +863,7 @@ export function buildAiSdkCellBackendRegistration(input: {
   env: RunHarborCellEnv;
   now: () => number;
   newId: () => string;
+  fetch?: typeof globalThis.fetch;
   maxSteps?: number;
   recordUsageCheckpoint?: (usage: HarborCellUsageCheckpoint) => void | Promise<void>;
 }): NonNullable<RunHarborCellInput['registerBackends']> {
@@ -902,7 +913,9 @@ export function buildAiSdkCellBackendRegistration(input: {
         connection,
         sessionId: ctx.sessionId,
         modelId: input.model,
+        ...(input.fetch ? { fetchFn: input.fetch } : {}),
       });
+      const providerFetch = subscriptionFetch ?? input.fetch;
       const hostTools = buildHarborCellAiSdkTools(context.toolExecutor!, {
         ...(context.heavyTaskEvidence ? { heavyTaskEvidence: context.heavyTaskEvidence } : {}),
         ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
@@ -925,7 +938,7 @@ export function buildAiSdkCellBackendRegistration(input: {
         modelFactory: (modelInput) =>
           getAIModel({
             ...modelInput,
-            ...(subscriptionFetch ? { fetch: subscriptionFetch } : {}),
+            ...(providerFetch ? { fetch: providerFetch } : {}),
           }),
         tools,
         toolAvailability: ctx.tools

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -41,6 +41,7 @@ import { taskRunLocator } from './task-run-identity.js';
 import { requireProviderCredentialEnv } from './provider-env.js';
 import { createProviderEnvFetch, type ProviderEnvFetch } from './provider-env-fetch.js';
 import { resolveHeadlessSystemPrompt } from './system-prompts.js';
+import { booleanEnv } from './headless-run-env.js';
 
 type HarborMode = 'cell' | 'task-run';
 type HarborIsolationMode = 'none' | 'harbor-local' | 'harbor-http';
@@ -425,7 +426,9 @@ export async function resolveHarborRunOptions(
     env,
     backend,
     heavyTask: parsed.bools['heavy-task'] || truthyEnv(env.MAKA_HEAVY_TASK_MODE),
-    economyTask: parsed.bools['economy-task'] || truthyEnv(env.MAKA_ECONOMY_TASK_MODE),
+    economyTask: parsed.bools['economy-task']
+      ? true
+      : booleanEnv(env.MAKA_ECONOMY_TASK_MODE, 'MAKA_ECONOMY_TASK_MODE'),
   });
   const realBackendIsolation = buildIsolation(isolation, env, workdir, outDir);
   const providerEnvFetch = backend === 'ai-sdk' ? createProviderEnvFetch(env) : undefined;
@@ -551,9 +554,20 @@ function buildConfig(input: {
   env: RunHarborCellEnv;
   backend: BackendKind;
   heavyTask: boolean;
-  economyTask: boolean;
+  economyTask: boolean | undefined;
 }): Config {
   const thinkingLevel = reasoningEffortFromEnv(input.env.MAKA_REASONING_EFFORT);
+  const economyTaskMode =
+    input.economyTask === undefined
+      ? {}
+      : {
+          economyTaskMode: {
+            enabled: input.economyTask,
+            reason: input.economyTask
+              ? 'maka eval harbor run --economy-task'
+              : 'maka eval harbor run MAKA_ECONOMY_TASK_MODE=false',
+          },
+        };
   if (input.backend === 'fake') {
     return {
       id: input.parsed.flags['config-id'] ?? input.env.MAKA_CONFIG_ID ?? 'harbor-fake',
@@ -564,9 +578,7 @@ function buildConfig(input: {
       ...(input.heavyTask
         ? { heavyTaskMode: { enabled: true, reason: 'maka eval harbor run --heavy-task' } }
         : {}),
-      ...(input.economyTask
-        ? { economyTaskMode: { enabled: true, reason: 'maka eval harbor run --economy-task' } }
-        : {}),
+      ...economyTaskMode,
     };
   }
   if (input.backend !== 'ai-sdk') {
@@ -591,9 +603,7 @@ function buildConfig(input: {
     ...(input.heavyTask
       ? { heavyTaskMode: { enabled: true, reason: 'maka eval harbor run --heavy-task' } }
       : {}),
-    ...(input.economyTask
-      ? { economyTaskMode: { enabled: true, reason: 'maka eval harbor run --economy-task' } }
-      : {}),
+    ...economyTaskMode,
   };
 }
 

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -395,7 +395,7 @@ export async function resolveHarborRunOptions(
   const requestedWorkdir = valueOf(parsed, env, 'workdir', 'MAKA_WORKDIR') ?? process.cwd();
   const workdir = isolation === 'harbor-http' ? requestedWorkdir : resolve(requestedWorkdir);
   const sourceWorkspaceDir =
-    isolation === 'harbor-http' ? resolve(join(outDir, 'host-workspace-source')) : workdir;
+    isolation && isolation !== 'none' ? resolve(join(outDir, 'host-workspace-source')) : workdir;
   const instruction = await instructionFromOptions(parsed, env);
   const officialVerifier = officialVerifierKind(
     valueOf(parsed, env, 'official-verifier', 'MAKA_OFFICIAL_VERIFIER') ?? 'external-harbor',

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -431,7 +431,7 @@ export async function resolveHarborRunOptions(
     cellArtifactDir,
     maxSteps,
   });
-  const realBackendIsolation = buildIsolation(isolation, env, workdir);
+  const realBackendIsolation = buildIsolation(isolation, env, workdir, outDir);
   return {
     mode,
     backend,
@@ -613,6 +613,7 @@ function buildIsolation(
   mode: HarborIsolationMode | undefined,
   env: RunHarborCellEnv,
   workdir: string,
+  outDir: string,
 ): RealBackendIsolation | undefined {
   if (!mode || mode === 'none') return undefined;
   if (mode === 'harbor-local') {
@@ -620,6 +621,7 @@ function buildIsolation(
       kind: 'external',
       label: 'Harbor task container',
       workspaceDir: workdir,
+      submittedSnapshotRoot: join(outDir, 'submitted-snapshots'),
       toolExecutor: createHarborCellLocalToolExecutor(env),
     };
   }

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -39,6 +39,7 @@ import { runTaskOnceWithStorage } from './task-agent-controller.js';
 import { taxonomyFromResultRecord } from './task-contracts.js';
 import { taskRunLocator } from './task-run-identity.js';
 import { requireProviderCredentialEnv } from './provider-env.js';
+import { createProviderEnvFetch, type ProviderEnvFetch } from './provider-env-fetch.js';
 import { resolveHeadlessSystemPrompt } from './system-prompts.js';
 
 type HarborMode = 'cell' | 'task-run';
@@ -78,6 +79,7 @@ interface HarborRunOptions {
   newId: () => string;
   registerBackends?: RunHarborCellInput['registerBackends'];
   realBackendIsolation?: RealBackendIsolation;
+  providerEnvFetch?: ProviderEnvFetch;
 }
 
 const HARBOR_RUN_FLAGS = [
@@ -138,6 +140,8 @@ async function harborRunCommand(args: string[]): Promise<number> {
   } catch (error) {
     console.error(`maka eval harbor run: ${(error as Error).message}`);
     return 1;
+  } finally {
+    await options.providerEnvFetch?.close();
   }
 }
 
@@ -423,15 +427,23 @@ export async function resolveHarborRunOptions(
     heavyTask: parsed.bools['heavy-task'] || truthyEnv(env.MAKA_HEAVY_TASK_MODE),
     economyTask: parsed.bools['economy-task'] || truthyEnv(env.MAKA_ECONOMY_TASK_MODE),
   });
-  const registerBackends = buildBackendRegistration({
-    backend,
-    env,
-    now,
-    newId,
-    cellArtifactDir,
-    maxSteps,
-  });
   const realBackendIsolation = buildIsolation(isolation, env, workdir, outDir);
+  const providerEnvFetch = backend === 'ai-sdk' ? createProviderEnvFetch(env) : undefined;
+  let registerBackends: RunHarborCellInput['registerBackends'];
+  try {
+    registerBackends = buildBackendRegistration({
+      backend,
+      env,
+      now,
+      newId,
+      cellArtifactDir,
+      ...(providerEnvFetch ? { fetch: providerEnvFetch.fetch } : {}),
+      maxSteps,
+    });
+  } catch (error) {
+    await providerEnvFetch?.close();
+    throw error;
+  }
   return {
     mode,
     backend,
@@ -464,6 +476,7 @@ export async function resolveHarborRunOptions(
     newId,
     ...(registerBackends ? { registerBackends } : {}),
     ...(realBackendIsolation ? { realBackendIsolation } : {}),
+    ...(providerEnvFetch ? { providerEnvFetch } : {}),
   };
 }
 
@@ -590,6 +603,7 @@ function buildBackendRegistration(input: {
   now: () => number;
   newId: () => string;
   cellArtifactDir: string;
+  fetch?: typeof globalThis.fetch;
   maxSteps?: number;
 }): RunHarborCellInput['registerBackends'] | undefined {
   if (input.backend === 'fake') return undefined;
@@ -604,6 +618,7 @@ function buildBackendRegistration(input: {
     env: input.env,
     now: input.now,
     newId: input.newId,
+    ...(input.fetch ? { fetch: input.fetch } : {}),
     recordUsageCheckpoint: (usage) => writeHarborCellUsageCheckpoint(input.cellArtifactDir, usage),
     ...(input.maxSteps !== undefined ? { maxSteps: input.maxSteps } : {}),
   });

--- a/packages/headless/src/harness-ab-report.ts
+++ b/packages/headless/src/harness-ab-report.ts
@@ -3,6 +3,7 @@ import type {
   HarnessOracleAnnotation,
   HarnessOracleAnnotationState,
 } from './harness-oracle-registry.js';
+import type { HarnessAbRunManifest } from './harness-ab-manifest.js';
 
 export interface HarnessAbArmEffectiveness {
   armId: string;
@@ -56,6 +57,9 @@ export interface HarnessAbReport {
     baseline: HarnessAbArmEconomy;
     candidate: HarnessAbArmEconomy;
   };
+  execution?: {
+    arms: [{ armId: string; placement: string }, { armId: string; placement: string }];
+  };
   oracleEvidence?: {
     snapshotFingerprint?: string;
     stateCounts: Partial<Record<HarnessOracleAnnotationState, number>>;
@@ -74,6 +78,7 @@ export function buildHarnessAbReport(
   summary: AbComparisonSummary,
   oracleEvidence?: HarnessAbOracleEvidenceReportInput,
   billingMode: HarnessAbReport['billingMode'] = 'metered',
+  manifest?: Pick<HarnessAbRunManifest, 'arms'>,
 ): HarnessAbReport {
   const coverage = {
     scheduledCells: summary.baseline.attempts + summary.candidate.attempts,
@@ -95,6 +100,7 @@ export function buildHarnessAbReport(
       : coverage.unscoredCells > 0 || coverage.missingFinalUsageCells > 0
         ? 'completed_with_gaps'
         : 'completed';
+  const execution = manifestExecution(manifest);
   return {
     schemaVersion: 'maka.harness_ab.report.v3',
     runId: summary.runId,
@@ -141,6 +147,7 @@ export function buildHarnessAbReport(
         summary.pairedAttempts.candidateMeteredPassed,
       ),
     },
+    ...(execution ? { execution } : {}),
     ...(oracleEvidence
       ? {
           oracleEvidence: {
@@ -300,6 +307,7 @@ export function renderHarnessAbReportMarkdown(report: HarnessAbReport): string {
     `Status: ${report.runStatus}${report.stopReason ? ` (${report.stopReason})` : ''}.`,
     '',
     `Run: ${report.runId}; tasks: ${report.taskCount}; paired evaluated: ${report.effectiveness.pairedEvaluated}.`,
+    ...executionPlacementMarkdown(report),
     `Cell coverage: ${report.coverage.attemptedCells}/${report.coverage.scheduledCells} attempted; ${report.coverage.modelScoredCells} model-scored; ${report.coverage.unscoredCells} unscored (including ${report.coverage.infraFailedCells} infra-failed); ${report.coverage.missingFinalUsageCells} missing final usage.`,
     `Economy coverage: fully metered pairs: ${report.economy.pairedMetered}; missing usage: ${report.economy.missingUsagePairs}.`,
     ...oracleEvidenceMarkdown(report),
@@ -334,6 +342,40 @@ export function renderHarnessAbReportMarkdown(report: HarnessAbReport): string {
       : 'No composite score: effectiveness and economy are reported as separate axes. Recorded cost is a cache-aware API-equivalent estimate from the frozen pricing profile.',
     '',
   ].join('\n');
+}
+
+function manifestExecution(
+  manifest: Pick<HarnessAbRunManifest, 'arms'> | undefined,
+): HarnessAbReport['execution'] {
+  if (!manifest) return undefined;
+  const placements = manifest.arms.map((arm) => {
+    const config = recordValue(arm.metadata?.config);
+    const execution = recordValue(config?.execution);
+    const placement = execution?.placement;
+    return typeof placement === 'string' && placement.trim().length > 0
+      ? { armId: arm.id, placement }
+      : undefined;
+  });
+  if (placements.every((placement) => placement === undefined)) return undefined;
+  if (placements.some((placement) => placement === undefined)) {
+    throw new Error('harness report execution placement must be declared for both arms');
+  }
+  return { arms: placements as NonNullable<HarnessAbReport['execution']>['arms'] };
+}
+
+function executionPlacementMarkdown(report: HarnessAbReport): string[] {
+  if (!report.execution) return [];
+  return [
+    `Execution placement: ${report.execution.arms
+      .map((arm) => `${arm.armId}=${arm.placement}`)
+      .join('; ')}.`,
+  ];
+}
+
+function recordValue(value: unknown): Record<string, unknown> | undefined {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
 }
 
 function countOracleStates(

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -1,5 +1,5 @@
 import type { StorageRef } from '@maka/core';
-import type { ShellPlan } from '@maka/runtime';
+import { isPathInside, type ShellPlan } from '@maka/runtime';
 import { isAbsolute } from 'node:path';
 import type { Config, Task } from './contracts.js';
 import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
@@ -244,6 +244,9 @@ export function validateRealBackendIsolation(isolation: RealBackendIsolation | u
     }
     if (!isAbsolute(isolation.submittedSnapshotRoot)) {
       throw new Error('realBackendIsolation.submittedSnapshotRoot must be absolute');
+    }
+    if (isPathInside(isolation.workspaceDir, isolation.submittedSnapshotRoot)) {
+      throw new Error('realBackendIsolation.submittedSnapshotRoot must stay outside workspaceDir');
     }
   }
 }

--- a/packages/headless/src/isolation.ts
+++ b/packages/headless/src/isolation.ts
@@ -1,5 +1,6 @@
 import type { StorageRef } from '@maka/core';
 import type { ShellPlan } from '@maka/runtime';
+import { isAbsolute } from 'node:path';
 import type { Config, Task } from './contracts.js';
 import type { HeavyTaskEvidenceRecorder } from './heavy-task-evidence.js';
 import type { HeavyTaskModeSelection } from './heavy-task-policy.js';
@@ -180,6 +181,12 @@ export interface ExternalRealBackendIsolation {
    */
   workspaceDir?: string;
   /**
+   * Persistent directory for freezing the agent-visible workspace after the
+   * run. Set only when the controller can read workspaceDir directly; remote
+   * executors such as Harbor HTTP must leave it unset.
+   */
+  submittedSnapshotRoot?: string;
+  /**
    * Optional command executor for callers that want to reuse the built-in
    * headless Bash tool. A caller may omit this when its registered backend is
    * already isolated internally.
@@ -228,6 +235,16 @@ export function validateRealBackendIsolation(isolation: RealBackendIsolation | u
   }
   if (typeof isolation.label !== 'string' || isolation.label.trim().length === 0) {
     throw new Error('realBackendIsolation.label is required');
+  }
+  if (isolation.submittedSnapshotRoot !== undefined) {
+    if (!isolation.workspaceDir || !isAbsolute(isolation.workspaceDir)) {
+      throw new Error(
+        'realBackendIsolation.submittedSnapshotRoot requires an absolute workspaceDir',
+      );
+    }
+    if (!isAbsolute(isolation.submittedSnapshotRoot)) {
+      throw new Error('realBackendIsolation.submittedSnapshotRoot must be absolute');
+    }
   }
 }
 

--- a/packages/headless/src/maka-node-toolchain.ts
+++ b/packages/headless/src/maka-node-toolchain.ts
@@ -1,0 +1,52 @@
+import { createHash } from 'node:crypto';
+import {
+  prepareNodeCliToolchain,
+  validatePreparedNodeCliToolchain,
+  type PinnedNodeCliToolchainDefinition,
+} from './node-cli-toolchain.js';
+
+export const MAKA_NODE_TOOLCHAIN_CONTAINER_PATH = '/opt/maka-node-toolchain';
+
+export const MAKA_NODE_TOOLCHAIN_SPEC = {
+  schemaVersion: 1,
+  platform: 'linux',
+  arch: 'x64',
+  node: {
+    version: '22.23.1',
+    archiveUrl: 'https://nodejs.org/dist/v22.23.1/node-v22.23.1-linux-x64.tar.gz',
+    archiveSha256: '7a8cb04b4a1df4eaf432125324b81b29a088e73570a23259a8de1c65d07fc129',
+    binarySha256: '93956de2e59480474a7b46571da1651180b1a050cdf32641ebec4ce6e478e068',
+  },
+} as const;
+
+export const MAKA_NODE_TOOLCHAIN_FINGERPRINT = `sha256:${createHash('sha256')
+  .update(JSON.stringify(MAKA_NODE_TOOLCHAIN_SPEC))
+  .digest('hex')}`;
+
+export interface PreparedMakaNodeToolchain {
+  path: string;
+  fingerprint: typeof MAKA_NODE_TOOLCHAIN_FINGERPRINT;
+}
+
+const DEFINITION: PinnedNodeCliToolchainDefinition<typeof MAKA_NODE_TOOLCHAIN_SPEC> = {
+  label: 'Maka Node runtime',
+  fingerprint: MAKA_NODE_TOOLCHAIN_FINGERPRINT,
+  spec: MAKA_NODE_TOOLCHAIN_SPEC,
+  node: MAKA_NODE_TOOLCHAIN_SPEC.node,
+  packageFiles: [],
+};
+
+export async function validatePreparedMakaNodeToolchain(
+  path: string,
+): Promise<PreparedMakaNodeToolchain> {
+  await validatePreparedNodeCliToolchain(path, DEFINITION);
+  return { path, fingerprint: MAKA_NODE_TOOLCHAIN_FINGERPRINT };
+}
+
+export async function prepareMakaNodeToolchain(
+  path: string,
+  options: { fetchFn?: typeof fetch } = {},
+): Promise<PreparedMakaNodeToolchain> {
+  await prepareNodeCliToolchain(path, DEFINITION, options);
+  return { path, fingerprint: MAKA_NODE_TOOLCHAIN_FINGERPRINT };
+}

--- a/packages/headless/src/node-cli-toolchain.ts
+++ b/packages/headless/src/node-cli-toolchain.ts
@@ -17,7 +17,7 @@ export interface PinnedNodeCliToolchainDefinition<TSpec> {
     archiveSha256: string;
     binarySha256: string;
   };
-  packageArchive: {
+  packageArchive?: {
     url: string;
     integrity: `sha512-${string}`;
   };
@@ -79,7 +79,9 @@ export async function prepareNodeCliToolchain<TSpec>(
   const temporaryPath = await mkdtemp(join(dirname(path), `.${basename(path)}-`));
   try {
     const nodeArchive = join(temporaryPath, 'node.tar.gz');
-    const packageArchive = join(temporaryPath, 'package.tgz');
+    const packageArchive = definition.packageArchive
+      ? join(temporaryPath, 'package.tgz')
+      : undefined;
     await downloadVerified({
       url: definition.node.archiveUrl,
       path: nodeArchive,
@@ -87,14 +89,18 @@ export async function prepareNodeCliToolchain<TSpec>(
       expected: definition.node.archiveSha256,
       fetchFn: options.fetchFn ?? fetch,
     });
-    await downloadVerified({
-      url: definition.packageArchive.url,
-      path: packageArchive,
-      algorithm: 'sha512',
-      expected: definition.packageArchive.integrity.slice('sha512-'.length),
-      encoding: 'base64',
-      fetchFn: options.fetchFn ?? fetch,
-    });
+    if (definition.packageArchive && packageArchive) {
+      await downloadVerified({
+        url: definition.packageArchive.url,
+        path: packageArchive,
+        algorithm: 'sha512',
+        expected: definition.packageArchive.integrity.slice('sha512-'.length),
+        encoding: 'base64',
+        fetchFn: options.fetchFn ?? fetch,
+      });
+    } else if (definition.packageFiles.length > 0) {
+      throw new Error(`${definition.label} toolchain package files require a package archive`);
+    }
     await mkdir(join(temporaryPath, 'bin'));
     await execFileAsync('tar', [
       '-xzf',
@@ -109,6 +115,9 @@ export async function prepareNodeCliToolchain<TSpec>(
       const installedPath = join(temporaryPath, file.installedPath);
       const targetDir = dirname(installedPath);
       await mkdir(targetDir, { recursive: true });
+      if (!packageArchive) {
+        throw new Error(`${definition.label} toolchain package files require a package archive`);
+      }
       await execFileAsync('tar', [
         '-xzf',
         packageArchive,
@@ -158,7 +167,7 @@ export async function prepareNodeCliToolchain<TSpec>(
       'utf8',
     );
     await rm(nodeArchive);
-    await rm(packageArchive);
+    if (packageArchive) await rm(packageArchive);
     await validatePreparedNodeCliToolchain(temporaryPath, definition);
     try {
       await rename(temporaryPath, path);

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -43,6 +43,10 @@ import {
   KIMI_CODE_TOOLCHAIN_FINGERPRINT,
 } from './kimi-code-toolchain.js';
 import {
+  MAKA_NODE_TOOLCHAIN_CONTAINER_PATH,
+  MAKA_NODE_TOOLCHAIN_FINGERPRINT,
+} from './maka-node-toolchain.js';
+import {
   summarizeProviderTelemetry,
   startProviderAuthProxy,
   type ProviderRequestTelemetry,
@@ -57,14 +61,14 @@ const TRIAL_REWARD_JSON = 'verifier/reward.json';
 const TRIAL_RESULT = 'result.json';
 const PROVIDER_REQUEST_TELEMETRY = 'provider-request-telemetry.json';
 
-/** The default port a container-CLI arm (Kimi/Codex) binds the host provider
+/** The default port an in-container agent binds the host provider
  * proxy to. Pier's Squid egress for offline (`allow_internet=false`) tasks only
  * permits destination ports 80/443 (`acl Safe_ports port 80 443`), so a
  * container reaching the host proxy through Squid must present one of those.
  * 443 keeps the model endpoint on the conventional TLS port. */
 export const PIER_PROVIDER_PROXY_DEFAULT_PORT = 443;
 
-/** A container-CLI arm binds ONE fixed proxy port per attempt, and Pier's Squid
+/** An in-container agent binds ONE fixed proxy port per attempt, and Pier's Squid
  * egress leaves only two usable destination ports (80/443), so concurrent
  * attempts on the same port must hold it one at a time — a second concurrent
  * bind is a guaranteed EADDRINUSE. The lock's owner is the shared host PORT,
@@ -114,7 +118,9 @@ export type PierTaskPricing = HarborTaskPricing;
 export interface PierTaskRunnerOptions {
   /** Host path to the maka repo, bind-mounted read-only at /opt/maka-agent. */
   makaRepoPath: string;
-  /** Pier adapter under test (default: Maka, host-side LLM + offline container). */
+  /** Pinned Linux/x64 Node runtime mounted read-only for in-container Maka task runs. */
+  makaNodeToolchainPath?: string;
+  /** Pier adapter under test (default: Maka). */
   agent?: PierAgent;
   /** In-container/host cell backend. Only the Maka arm reads it. `fake` runs the
    * inert cell for zero-cost structural checks; `ai-sdk` is the real run. */
@@ -142,16 +148,16 @@ export interface PierTaskRunnerOptions {
   apiKeyFile?: string;
   /** Resolves the upstream authority inside the host proxy for every request. */
   resolveProviderCredential?: ProviderUpstreamCredentialResolver;
-  /** Route the Maka arm's host cell through the auth proxy instead of reading the
-   * key file directly. The container-CLI arms (Kimi/Codex) always use the proxy. */
+  /** Route a Maka host cell through the auth proxy instead of reading the key
+   * file directly. In-container agents, including Maka task-run, always use it. */
   useProviderProxy?: boolean;
-  /** Explicit host proxy listen port for a container-CLI arm (default 443). */
+  /** Explicit host proxy listen port for an in-container agent (default 443). */
   providerProxyPort?: number;
-  /** Host a container-CLI arm's container should dial to reach the host
-   * provider proxy. Only those arms honor it; the Maka arm's host cell always
-   * uses loopback (127.0.0.1) since it runs on the host itself. Unset keeps the
-   * default host.docker.internal, which Docker Desktop injects but native Linux
-   * Docker does NOT provide (pier 0.3.0's compose wires no
+  /** Host an in-container agent should dial to reach the host provider proxy.
+   * This covers Kimi, Codex, and Maka task-run mode; a Maka host cell still uses
+   * loopback (127.0.0.1). Unset keeps the default host.docker.internal, which
+   * Docker Desktop injects but native Linux Docker does NOT provide (pier
+   * 0.3.0's compose wires no
    * extra_hosts/host-gateway), so on native Linux pass the host's
    * docker-bridge-reachable address (e.g. 172.17.0.1) or the container's Squid
    * cannot resolve the proxy. */
@@ -252,16 +258,17 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
     // agentEnv must not override experiment identity or MAKA_TRIAL_* pricing.
     assertNoExperimentIdentityOverrides(attemptAgentEnv);
 
+    const traceMode = harborTraceMode(attemptAgentEnv);
     const providerTelemetryPath = join(jobsDir, PROVIDER_REQUEST_TELEMETRY);
     let providerUsage: ProviderTokenUsage | null = null;
     let providerTelemetry: ProviderRequestTelemetry[] = [];
     const envFilePath = join(jobsDir, 'pier-agent.env');
     // Config errors fail fast before the proxy exists (and outside the port lock).
-    const mounts = buildPierMounts(options, agent);
+    const mounts = buildPierMounts(options, agent, traceMode);
     const launchAttempt = async (): Promise<PierRunResult> => {
       // Proxy bind errors surface raw, before the launch try, with their own
       // message — they are configuration faults, not infra flakes.
-      const providerRuntime = await pierProviderRuntime(options, agent);
+      const providerRuntime = await pierProviderRuntime(options, agent, traceMode);
       const envFileEntries = providerRuntime?.envFile ?? {};
       const usesEnvFile = Object.keys(envFileEntries).length > 0;
       try {
@@ -363,12 +370,13 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
         );
       }
     };
-    // Only a container-CLI arm (Kimi/Codex) on a FIXED port competes for the
-    // bind; the Maka arm (ephemeral or no proxy) and an explicit port 0
-    // (OS-assigned, used by tests) cannot collide and need no serialization.
+    // Only an in-container agent on a FIXED port competes for the bind; a Maka
+    // host cell and an explicit port 0 (OS-assigned, used by tests) cannot
+    // collide and need no serialization.
     const containerProxyPort = options.providerProxyPort ?? PIER_PROVIDER_PROXY_DEFAULT_PORT;
+    const usesContainerProxy = agent !== 'maka' || traceMode === 'task-run';
     const result =
-      agent !== 'maka' && containerProxyPort !== 0
+      usesContainerProxy && containerProxyPort !== 0
         ? await withProxyPortLock(containerProxyPort, launchAttempt)
         : await launchAttempt();
 
@@ -565,10 +573,22 @@ export function buildPierRunArgs(input: BuildPierRunArgsInput): string[] {
 function buildPierMounts(
   options: PierTaskRunnerOptions,
   agent: PierAgent,
+  mode: 'cell' | 'task-run',
 ): Array<Record<string, unknown>> {
   const mounts: Array<Record<string, unknown>> = [
     { type: 'bind', source: options.makaRepoPath, target: CONTAINER_MAKA_REPO, read_only: true },
   ];
+  if (agent === 'maka' && mode === 'task-run') {
+    if (!options.makaNodeToolchainPath) {
+      throw new Error('makaNodeToolchainPath is required for Maka container task-run mode');
+    }
+    mounts.push({
+      type: 'bind',
+      source: options.makaNodeToolchainPath,
+      target: MAKA_NODE_TOOLCHAIN_CONTAINER_PATH,
+      read_only: true,
+    });
+  }
   if (agent === 'kimi-code') {
     if (!options.kimiCodeToolchainPath) {
       throw new Error('kimiCodeToolchainPath is required for the Kimi Code adapter');
@@ -612,6 +632,9 @@ function buildPierAgentEnv(
     // extra_env would shadow the byte-exact os.environ value. See processEnv.
   };
   if (options.reasoningEffort) env.MAKA_REASONING_EFFORT = options.reasoningEffort;
+  if (agent === 'maka' && options.makaNodeToolchainPath) {
+    env.MAKA_NODE_TOOLCHAIN_FINGERPRINT = MAKA_NODE_TOOLCHAIN_FINGERPRINT;
+  }
   if (agent === 'kimi-code') {
     env.MAKA_KIMI_CODE_TOOLCHAIN_FINGERPRINT = KIMI_CODE_TOOLCHAIN_FINGERPRINT;
   }
@@ -651,14 +674,17 @@ function buildPierAgentEnv(
 async function pierProviderRuntime(
   options: PierTaskRunnerOptions,
   agent: PierAgent,
+  mode: 'cell' | 'task-run',
 ): Promise<PierProviderRuntime | null> {
   const provider = options.provider ?? 'deepseek';
   const baseUrl = options.baseUrl ?? providerDefaultBaseUrl(provider);
+  const makaContainerTaskRun = agent === 'maka' && mode === 'task-run';
   // A resolver-backed credential (e.g. Codex OAuth) is only usable through the
   // proxy — same contract as the Harbor runner — so it forces the proxy path
   // even when the caller forgot useProviderProxy.
   const usesProxy =
     agent !== 'maka' ||
+    (makaContainerTaskRun && options.backend !== 'fake') ||
     options.useProviderProxy === true ||
     options.resolveProviderCredential !== undefined;
 
@@ -705,12 +731,14 @@ async function pierProviderRuntime(
   if (!baseUrl) throw new Error(`Pier ${agent} provider ${provider} requires a base URL`);
 
   const proxyPort =
-    agent !== 'maka' ? (options.providerProxyPort ?? PIER_PROVIDER_PROXY_DEFAULT_PORT) : undefined;
-  // The Maka host cell runs on the host and reaches the proxy on loopback; a
-  // container-CLI arm (Kimi/Codex) reaches it through Docker's host gateway on
-  // a Squid-legal port, defaulting to host.docker.internal unless an explicit
-  // advertised host is supplied (the native-Linux escape hatch, e.g. 172.17.0.1).
-  const advertisedHost = agent === 'maka' ? '127.0.0.1' : options.providerProxyAdvertisedHost;
+    agent !== 'maka' || makaContainerTaskRun
+      ? (options.providerProxyPort ?? PIER_PROVIDER_PROXY_DEFAULT_PORT)
+      : undefined;
+  // A Maka host cell reaches the proxy on loopback. In-container agents reach
+  // it through Docker's host gateway on a Squid-legal port, defaulting to
+  // host.docker.internal unless native Linux supplies an explicit bridge host.
+  const advertisedHost =
+    agent === 'maka' && !makaContainerTaskRun ? '127.0.0.1' : options.providerProxyAdvertisedHost;
   const proxy = await startProviderAuthProxy({
     upstreamBaseUrl: baseUrl,
     ...(advertisedHost !== undefined ? { advertisedHost } : {}),
@@ -727,11 +755,16 @@ async function pierProviderRuntime(
     // through `--env-file` (0600, removed after the run) so it stays off argv.
     envFile:
       agent === 'maka'
-        ? {
-            MAKA_HOST_REPO_ROOT: options.makaRepoPath,
-            MAKA_HOST_BASE_URL: proxy.baseUrl,
-            MAKA_HOST_API_KEY: proxy.token,
-          }
+        ? makaContainerTaskRun
+          ? {
+              MAKA_PROVIDER_PROXY_URL: proxy.baseUrl,
+              MAKA_PROVIDER_PROXY_TOKEN: proxy.token,
+            }
+          : {
+              MAKA_HOST_REPO_ROOT: options.makaRepoPath,
+              MAKA_HOST_BASE_URL: proxy.baseUrl,
+              MAKA_HOST_API_KEY: proxy.token,
+            }
         : { MAKA_PROVIDER_PROXY_URL: proxy.baseUrl, MAKA_PROVIDER_PROXY_TOKEN: proxy.token },
     agentEnv: {},
     usage: proxy.usage,

--- a/packages/headless/src/provider-env-fetch.ts
+++ b/packages/headless/src/provider-env-fetch.ts
@@ -1,0 +1,31 @@
+import { EnvHttpProxyAgent, fetch as undiciFetch } from 'undici';
+
+export interface ProviderEnvFetch {
+  fetch: typeof globalThis.fetch;
+  close(): Promise<void>;
+}
+
+export function createProviderEnvFetch(
+  env: NodeJS.ProcessEnv = process.env,
+): ProviderEnvFetch | undefined {
+  if (env.NODE_USE_ENV_PROXY !== '1') return undefined;
+  const httpProxy = env.http_proxy ?? env.HTTP_PROXY;
+  const httpsProxy = env.https_proxy ?? env.HTTPS_PROXY;
+  if (!httpProxy && !httpsProxy) return undefined;
+
+  const dispatcher = new EnvHttpProxyAgent({
+    ...(httpProxy ? { httpProxy } : {}),
+    ...(httpsProxy ? { httpsProxy } : {}),
+    ...(env.no_proxy !== undefined || env.NO_PROXY !== undefined
+      ? { noProxy: env.no_proxy ?? env.NO_PROXY }
+      : {}),
+  });
+  return {
+    fetch: async (input, init) =>
+      (await undiciFetch(input as Parameters<typeof undiciFetch>[0], {
+        ...(init as Parameters<typeof undiciFetch>[1]),
+        dispatcher,
+      })) as unknown as Response,
+    close: () => dispatcher.close(),
+  };
+}

--- a/packages/headless/src/sandbox.ts
+++ b/packages/headless/src/sandbox.ts
@@ -58,7 +58,14 @@ export async function freezeSubmittedWorkspace(input: {
   await mkdir(snapshotRoot, { recursive: true });
   const snapshotPath = await mkdtemp(join(snapshotRoot, 'maka-headless-submitted-'));
   try {
-    await cp(await realpath(input.workspaceDir), snapshotPath, { recursive: true });
+    await cp(await realpath(input.workspaceDir), snapshotPath, {
+      recursive: true,
+      verbatimSymlinks: true,
+      filter: async (source) => {
+        const entry = await lstat(source);
+        return entry.isFile() || entry.isDirectory() || entry.isSymbolicLink();
+      },
+    });
   } catch (error) {
     await rm(snapshotPath, { recursive: true, force: true });
     throw error;
@@ -79,7 +86,10 @@ export async function prepareScoringWorkspace(
 ): Promise<PreparedWorkspace> {
   const dir = await mkdtemp(join(tmpdir(), 'maka-headless-score-'));
   try {
-    await cp(await realpath(snapshot.snapshotPath), dir, { recursive: true });
+    await cp(await realpath(snapshot.snapshotPath), dir, {
+      recursive: true,
+      verbatimSymlinks: true,
+    });
   } catch (error) {
     await rm(dir, { recursive: true, force: true });
     throw error;

--- a/packages/headless/src/sandbox.ts
+++ b/packages/headless/src/sandbox.ts
@@ -48,12 +48,15 @@ export async function prepareWorkspace(fixtureDir: string): Promise<PreparedWork
 
 export async function freezeSubmittedWorkspace(input: {
   workspaceDir: string;
+  snapshotRoot?: string;
   artifactRefs?: Array<Record<string, unknown>>;
   now?: () => number;
   newId?: () => string;
 }): Promise<ArtifactFreezeResult> {
   const id = input.newId?.() ?? randomUUID();
-  const snapshotPath = await mkdtemp(join(tmpdir(), 'maka-headless-submitted-'));
+  const snapshotRoot = input.snapshotRoot ?? tmpdir();
+  await mkdir(snapshotRoot, { recursive: true });
+  const snapshotPath = await mkdtemp(join(snapshotRoot, 'maka-headless-submitted-'));
   try {
     await cp(await realpath(input.workspaceDir), snapshotPath, { recursive: true });
   } catch (error) {

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -644,8 +644,10 @@ export async function runTaskOnceWithStorage(
       startedAt: now(),
     });
     const runnerCompleted = invocation.status === 'completed';
+    const submittedSnapshotRoot = deps.realBackendIsolation?.submittedSnapshotRoot;
     const frozen = await freezeSubmittedWorkspace({
-      workspaceDir: workspace.dir,
+      workspaceDir: submittedSnapshotRoot ? agentWorkspaceDir : workspace.dir,
+      ...(submittedSnapshotRoot ? { snapshotRoot: submittedSnapshotRoot } : {}),
       artifactRefs: runtimeSummary.artifactRefs,
       now,
       newId,

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -355,7 +355,13 @@ export async function runTaskOnceWithStorage(
       name: `task:${config.id}:${task.id}`,
     });
     const turnId = newId();
-    const active = createSingleRunActiveSession(backends, sessionStore, now, newId);
+    const active = createSingleRunActiveSession(
+      backends,
+      sessionStore,
+      runtimeEventStore,
+      now,
+      newId,
+    );
     parentActive = active;
     const run = new AgentRun({
       sessionId: header.id,
@@ -506,7 +512,13 @@ export async function runTaskOnceWithStorage(
       });
 
       if (gateDecision.action === 'repair_prompt') {
-        const repairActive = createSingleRunActiveSession(backends, sessionStore, now, newId);
+        const repairActive = createSingleRunActiveSession(
+          backends,
+          sessionStore,
+          runtimeEventStore,
+          now,
+          newId,
+        );
         parentActive = repairActive;
         const repairRun = new AgentRun({
           sessionId: header.id,
@@ -1091,6 +1103,7 @@ type AgentRunHooks = ConstructorParameters<typeof AgentRun>[0]['hooks'];
 function createSingleRunActiveSession(
   backends: BackendRegistry,
   store: SessionStore,
+  runtimeEventStore: RuntimeEventStore | undefined,
   now: () => number,
   newId: () => string,
 ): {
@@ -1144,6 +1157,17 @@ function createSingleRunActiveSession(
           },
           recordProviderRequestAttempt: (attempt) =>
             boundRun?.recordProviderRequestAttempt(attempt),
+          ...(runtimeEventStore
+            ? {
+                loadTurnRuntimeEvents: (turnId: string) => {
+                  if (!boundRun || boundRun.turnId !== turnId) {
+                    return Promise.reject(new Error('No active AgentRun for turn runtime events'));
+                  }
+                  return boundRun.loadTurnRuntimeEvents();
+                },
+              }
+            : {}),
+          allowMidTurnHistoryCompaction: Boolean(runtimeEventStore),
           recordActiveFullCompactBlock: (block) => boundRun?.recordActiveFullCompactBlock(block),
           recordSemanticCompactBlock: (block) => boundRun?.recordSemanticCompactBlock(block),
         });

--- a/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
+++ b/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
@@ -145,6 +145,11 @@ describe('Claude subscription runtime wiring', () => {
       src.indexOf("case 'claude-subscription'"),
     );
     assert.match(region, /adapter\.normalizeBaseUrl\s*\?\s*anthropicV1BaseUrl\(baseURL\)/);
+    assert.match(
+      region,
+      /fetch,/,
+      'Anthropic-compatible providers must accept an explicitly supplied proxy transport',
+    );
   });
 
   test('registry sends both MiniMax variants over Bearer without rewriting their base URL', () => {

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -32,7 +32,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
   const { adapter, baseUrl: baseURL, apiProtocol } = resolveModelRuntime(connection, modelId);
 
   if (adapter.kind === 'google' && adapter.normalizeBaseUrl === false) {
-    return createGoogle({ apiKey, baseURL }).chat(modelId);
+    return createGoogle({ apiKey, baseURL, fetch }).chat(modelId);
   }
 
   switch (adapter.kind) {
@@ -40,6 +40,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
       return createAnthropic({
         ...(adapter.auth === 'bearer' ? { authToken: apiKey } : { apiKey }),
         baseURL: adapter.normalizeBaseUrl ? anthropicV1BaseUrl(baseURL) : baseURL,
+        fetch,
         headers: { 'anthropic-beta': ANTHROPIC_BETA },
       }).chat(modelId);
 
@@ -82,7 +83,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
       throw new Error(`${connection.providerType} is experimental and not wired yet`);
 
     case 'openai': {
-      const openai = createOpenAI({ apiKey, baseURL });
+      const openai = createOpenAI({ apiKey, baseURL, fetch });
       // Routing is declaration-driven via the ModelInfo.apiProtocol seam: an
       // account-declared protocol wins (mirrors the github-copilot case above);
       // otherwise the model's declared OpenAI-adapter protocol decides. gpt-5*
@@ -98,6 +99,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
       return createGoogle({
         apiKey,
         baseURL: googleV1BetaBaseUrl(baseURL),
+        fetch,
       }).chat(modelId);
 
     case 'cohere':
@@ -115,7 +117,7 @@ export function getAIModel(input: ModelFactoryInput): LanguageModelV4 {
         apiKey,
         baseURL,
         includeUsage: adapter.includeUsage,
-        ...(adapter.passFetch ? { fetch } : {}),
+        ...(adapter.passFetch || fetch ? { fetch } : {}),
         ...(adapter.replayAssistantReasoningDetails
           ? { metadataExtractor: reasoningDetailsMetadataExtractor() }
           : {}),


### PR DESCRIPTION
## Summary

- run Maka's complete DeepSWE task controller inside the Pier task container, so tool stdout and stderr no longer cross Pier's merged `exec()` transport boundary
- keep provider authority on the host behind the existing attempt-scoped proxy; forward Pier proxy variables into the container and give AI SDK transports an explicit environment-proxy fetch
- mount a checksum-verified, fingerprinted Linux/x64 Node 22.23.1 runtime read-only and include the Pier/runtime placement in experiment identity
- preserve the actual external task workspace as a portable submitted snapshot, retaining symlinks while skipping sockets, FIFOs, and device nodes; reject recursive snapshot placement before any model run
- preserve an explicit `MAKA_ECONOMY_TASK_MODE=false`, so instruction signals cannot silently change the benchmark system prompt
- hydrate the container's execution evidence after teardown, record both A/B arms' placement in the report, and wire parent and repair runs to `AgentRun`'s durable RuntimeEvent ledger
- preserve the existing plain Harbor host-bridge path for Terminal-Bench; Pier itself is unchanged

Refs #1473

## Verification

- `npm --workspace @maka/headless test`: 1330 passed across 124 suites
- `npm run lint`: passed (2123 files)
- `npm run format:check`: passed (1082 files)
- `npm run typecheck`: passed for every workspace
- focused regressions cover explicit economy disable, FIFO filtering, verbatim relative symlinks, recursive snapshot rejection, provider-proxy wiring, runtime-provider wiring, and the durable task-controller reader
- Pier 0.3.0 compatibility test against the real `_ToolExecutorServer`
- pinned Node archive, binary, manifest, and checksum validation in a Linux/x64 container
- real Pier DeepSWE fake-backend canary: container task-run completed, official verifier ran, stdout/stderr stayed separate, and cell/runtime/trace artifacts hydrated to the host
- real-provider Pier stress canary after the proxy and durable-reader fixes: the task container completed 31 main-run tool call/response pairs plus child-agent runs, including Read/Glob/Grep/Bash/Edit/Write, with execution identity, usage, runtime events, traces, and official verifier output surviving teardown. The top-level experiment was intentionally stopped rather than waiting through the task's 90-minute agent budget, so this is transport/continuation evidence, not a benchmark-pass claim.

## Root cause

Pier's `DockerEnvironment.exec()` merges stderr into stdout. The previous Maka arm crossed that boundary for every tool call, while the other benchmark arms ran their complete agent processes inside the task container. Maka now uses the same placement: Pier supervises one container-local task-run process, and Maka's tools execute locally inside that container.

Two integration consequences also had to be handled at their existing owners:

- AI SDK providers use an explicit custom fetch, so Node's process-level proxy setting alone does not route their requests. The headless entrypoints now create one `EnvHttpProxyAgent`-backed fetch from Pier's proxy environment and close it with the backend lifecycle.
- headless task runs use a single-run activation helper rather than `SessionManager` for the parent run. That helper now exposes the bound `AgentRun`'s authoritative durable event reader so provider continuations replay persisted tool facts instead of an in-memory shadow.

## Security

The upstream provider key or OAuth authority never enters the task container. A per-attempt host proxy mints the only token exposed to the container, Pier network policy allowlists only that proxy hostname, provider environment variables are stripped from tool subprocesses, and the mounted Node toolchain is fingerprinted and read-only.

