### PR TITLE
fix(ui): scroll wide DataTable content inside its own container (#1360)

### DIFF
--- a/packages/ui/src/__tests__/data-table.test.ts
+++ b/packages/ui/src/__tests__/data-table.test.ts
@@ -29,9 +29,31 @@ function render() {
 
 test('DataTable exposes the caller-provided accessible name and pin class', () => {
   const markup = render();
-  assert.match(markup, /^<table\b[^>]*aria-label="Providers table"/);
+  assert.match(markup, /<table\b[^>]*aria-label="Providers table"/);
   assert.match(markup, /data-slot="data-table"/);
   assert.match(markup, /class="[^"]*pinnedTable/, 'pin class must pass through for CSS/CDP selectors');
+});
+
+test('DataTable scrolls wide content inside its own container (#1360)', () => {
+  const markup = render();
+  // The nowrap column recipe gives the table a min-content width as wide as
+  // its widest cells, so the primitive owns the horizontal scroller (#1303
+  // acceptance rule: wide content scrolls in its own overflow-x container).
+  assert.match(
+    markup,
+    /^<div\b[^>]*data-slot="data-table-scroller"[^>]*class="[^"]*overflow-x-auto/,
+    'the scroller wraps the table and owns overflow-x',
+  );
+  // The hairline box + radius live on the scroller — a border on the <table>
+  // itself would scroll along with the content.
+  assert.match(markup, /data-slot="data-table-scroller"[^>]*class="[^"]*border-border/);
+  assert.match(markup, /data-slot="data-table-scroller"[^>]*class="[^"]*pinnedTable/, 'pin class addresses the outermost element');
+  const tableClass = markup.match(/<table[^>]*class="([^"]*)"/)?.[1] ?? '';
+  assert.ok(!tableClass.includes('border-border'), 'the table itself carries no box border');
+  // Without border-collapse merging into the box border, the last row sheds
+  // its hairline so the bottom edge is a single line. (`&`/`>` arrive
+  // HTML-escaped in static markup.)
+  assert.match(markup, /\[&amp;&gt;tbody&gt;tr:last-child&gt;\*\]:border-b-0/);
 });
 
 test('DataTable scopes the header row and the first data cell of every row', () => {

--- a/packages/ui/src/primitives/data-table.tsx
+++ b/packages/ui/src/primitives/data-table.tsx
@@ -61,15 +61,30 @@ export function DataTable({ ariaLabel, columns, rows, className }: DataTableProp
     `${CELL_BASE} text-foreground-secondary ${shape(column)}`;
   const headClass = (column: DataTableColumn) =>
     `${CELL_BASE} font-medium text-muted-foreground ${shape(column)}`;
+  // #1364 → routed through #1360: the recipe deliberately keeps every
+  // non-grow column on one line (`whitespace-nowrap`), so the table's
+  // min-content width is the sum of its widest cells — a dated preview model
+  // id plus a namespaced MCP tool name already exceeded the settings column at
+  // full window width, and a bare <table> propagates that to every ancestor.
+  // Wide content scrolls inside its own container (#1303 acceptance rule), so
+  // the primitive owns that container: the hairline box + radius move onto the
+  // scroller (a border on the <table> itself would scroll along with it), and
+  // the caller's pin class stays on the outermost element it always addressed.
   return (
-    <table
-      aria-label={ariaLabel}
-      data-slot="data-table"
+    <div
+      data-slot="data-table-scroller"
       className={cn(
-        'w-full border-collapse overflow-hidden rounded-[var(--radius-surface)] border border-border text-[length:var(--font-size-caption)]',
+        'overflow-x-auto rounded-[var(--radius-surface)] border border-border',
         className,
       )}
     >
+      <table
+        aria-label={ariaLabel}
+        data-slot="data-table"
+        // Last row drops its hairline: the box border lives on the scroller
+        // now, so border-collapse no longer merges the two into one line.
+        className="w-full border-collapse text-[length:var(--font-size-caption)] [&>tbody>tr:last-child>*]:border-b-0"
+      >
       <thead>
         <tr>
           {columns.map((column, columnIndex) => (
@@ -100,6 +115,7 @@ export function DataTable({ ariaLabel, columns, rows, className }: DataTableProp
           </tr>
         ))}
       </tbody>
-    </table>
+      </table>
+    </div>
   );
 }

--- a/packages/ui/stories/data-table.stories.tsx
+++ b/packages/ui/stories/data-table.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { DataTable } from '../src/primitives/data-table.js';
+
+const meta = {
+  title: 'Primitives/DataTable',
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+const REQUEST_COLUMNS = [
+  { header: '时间' },
+  { header: '类型' },
+  { header: '对象', grow: true },
+  { header: '会话' },
+  { header: 'Token', numeric: true },
+  { header: '费用', numeric: true },
+  { header: '延迟', numeric: true },
+  { header: '状态' },
+];
+
+const REQUEST_ROWS = [
+  [
+    '2026/7/25 14:02:11',
+    '模型',
+    'anthropic/claude-sonnet-4-5-20250929-preview-extended-thinking',
+    'b0efaaf9',
+    16_200,
+    '$0.04',
+    '2840ms',
+    '成功',
+  ],
+  [
+    '2026/7/25 13:57:40',
+    '工具',
+    'mcp__cloud_workspace__list_repository_branch_protection_rules',
+    'b0efaaf9',
+    1_400,
+    '-',
+    '640ms',
+    '成功',
+  ],
+  ['2026/7/25 13:41:05', '模型', 'glm-4.7', '9d2612da', 8_600, '$0.01', '1900ms', '失败'],
+];
+
+export const Basic: Story = {
+  render: () => (
+    <div style={{ width: 640 }}>
+      <DataTable
+        ariaLabel="Providers table"
+        columns={[
+          { header: 'Provider', grow: true },
+          { header: 'Requests', numeric: true },
+          { header: 'Cost', numeric: true },
+        ]}
+        rows={[
+          ['Anthropic', 280, '$1.50'],
+          ['OpenAI', 140, '$0.84'],
+        ]}
+      />
+    </div>
+  ),
+};
+
+/**
+ * #1360 (found by the #1364 pass): every non-grow column keeps one line by
+ * recipe, so the table's min-content width is the sum of its widest cells —
+ * a dated preview model id plus a namespaced MCP tool name exceed the
+ * settings column even at full window width. The primitive owns the
+ * horizontal scroller; the container here is deliberately narrower than the
+ * table's min-content so the broken variant stays covered.
+ */
+export const WideContentScrolls: Story = {
+  render: () => (
+    <div style={{ width: 420 }}>
+      <DataTable ariaLabel="请求日志" columns={REQUEST_COLUMNS} rows={REQUEST_ROWS} />
+    </div>
+  ),
+};


### PR DESCRIPTION
Routed through #1360 — the #1364 list-pages pass traced this to the shared `DataTable` primitive.

## The defect

The recipe deliberately keeps every non-grow column on one line (`whitespace-nowrap`), so a DataTable's min-content width is the **sum of its widest cells**. With real request-log data — a dated preview model id (`anthropic/claude-sonnet-4-5-20250929-preview-extended-thinking`) plus a namespaced MCP tool name — the 8-column requests table measures **~840px intrinsic**, wider than the settings content column (~724px) even at a 1280px window. A bare `<table>` propagates that width to every ancestor, so the whole Usage page went into horizontal scroll at full window width. This was invisible until now because no story ever rendered a DataTable with data (fixed in the #1364 PR).

## The fix

Per the #1303 acceptance rule ("wide content must scroll inside its own `overflow-x: auto` container"), the primitive owns that container:

- A `data-slot="data-table-scroller"` div wraps the table and owns `overflow-x: auto`.
- The hairline box + radius move onto the scroller — a border on the `<table>` itself would scroll along with the content.
- The caller's pin class stays on the outermost element it always addressed.
- The last row sheds its `border-b`: with the box border on the scroller, `border-collapse` no longer merges the two into one bottom line.

## Coverage

- `Primitives/DataTable → WideContentScrolls`: a 420px container around the 8-column request log — the previously-broken variant, kept as the story baseline.
- Unit test re-pins the markup contract (scroller owns overflow/border/pin class; table carries no box border; last-row hairline dropped): 5/5.
- Page-level outcome (no horizontal page scroll at the 480px window floor) is locked in `e2e/settings.spec.ts` by the #1364 PR, which is based on this branch.

<img src="https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1364-screenshots/datatable-scroller-story.png" width="560">

Sole consumer today is `usage-settings-page.tsx`; health/permission are prospective consumers and inherit the container for free.

---

Two more shared-primitive findings from the same pass, documented here for routing rather than patched per-page (both are in #1362's declared scope — "label truncation, control alignment, **row wrapping**"):

1. **`settings-rows` / `.settingsFormRow` cannot fit the 480px window floor.** A row's min-content — label + status Chip + switch + paddings — measures ~306px against a ~190px content column (Memory page rows overflow by 28-35px at 620px and ~133px at 480px). `min-width: 0` on the label is not enough: the row is already at min-content. It needs the #1361 treatment (structural wrap), decided once for all form-row pages.
2. **`.settingsRow strong { white-space: nowrap }`** overflows by ~2px at the floor when the title is 6 CJK characters ("启用联网搜索"). Cosmetic, but same decision point.
