### PR TITLE
fix(desktop): polish list pages — Usage, Memory, and Web Search

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -217,6 +217,8 @@ export const test = base.extend<{
   sessionWorkbarWindow: Page;
   botSettingsWindow: Page;
   permissionSettingsWindow: Page;
+  usageSettingsWindow: Page;
+  searchSettingsWindow: Page;
   zhLocaleWindow: Page;
   enLocaleWindow: Page;
   localeSwitchWindow: Page;
@@ -323,6 +325,38 @@ export const test = base.extend<{
         seed: false,
         readinessSelector: '.settingsOsPermissionRow',
         e2eFixtureScenario: 'settings-permissions',
+        locale: 'zh',
+      },
+      use,
+    );
+  },
+  // #1364: Usage with seeded request traffic + details-on settings, so the
+  // request-log DataTable actually renders (the default window fixture keeps
+  // `showDetails` false and has no logs — the table CSS could regress without
+  // failing anything).
+  usageSettingsWindow: async ({}, use) => {
+    await withE2eWindow(
+      {
+        seed: false,
+        // The tabs bar, not the table: the renderer's first stats fetch can
+        // race the fixture seeding, so the spec refreshes until the seeded
+        // request log lands.
+        readinessSelector: '.settingsUsageTabsBar',
+        e2eFixtureScenario: 'settings-usage',
+        locale: 'zh',
+      },
+      use,
+    );
+  },
+  // #1364: Web Search with a configured Tavily key; queries are answered by
+  // the typed fixture in `main/web-search-e2e-fixture.ts` (e2e runs offline),
+  // so the hostile-width result list is reachable deterministically.
+  searchSettingsWindow: async ({}, use) => {
+    await withE2eWindow(
+      {
+        seed: false,
+        readinessSelector: '.settingsWebSearchQueryInputRow',
+        e2eFixtureScenario: 'settings-search',
         locale: 'zh',
       },
       use,

--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -318,6 +318,60 @@ test('usage and web search stay contained at the window floor', async ({ window:
   ).toBe(true);
 });
 
+/**
+ * #1364 review follow-up: the containment test above never reaches the two
+ * long-content branches — the default fixture has no request logs (so the
+ * requests DataTable never renders) and no Tavily key (so the page stops at
+ * the no-key message). These two lock the actual fixes against the states
+ * that broke: the request table scrolls inside its own container while the
+ * page stays put, and the hostile-width results (bare-URL title, long
+ * snippet) wrap inside their cards.
+ */
+test('usage request log scrolls inside its own container at the window floor', async ({
+  usageSettingsWindow: page,
+}) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  const settings = page.getByRole('main', { name: '设置内容' });
+  const scroller = settings.locator('.settingsUsageTable');
+  // The renderer's first stats fetch can race the fixture seeding on boot;
+  // refresh until the seeded request log lands.
+  await expect(async () => {
+    await settings.getByRole('button', { name: '刷新使用统计' }).click();
+    await expect(scroller).toBeVisible({ timeout: 1_000 });
+  }).toPass();
+  await expect(scroller).toHaveCSS('overflow-x', 'auto');
+  // The seeded log's nowrap columns are intrinsically wider than the floor
+  // column, so the scroller must actually be scrolling its table…
+  await expect.poll(
+    () => scroller.evaluate((element) => element.scrollWidth > element.clientWidth + 1),
+  ).toBe(true);
+  // …while the page around it stays contained.
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+});
+
+test('web search results wrap inside their cards at the window floor', async ({
+  searchSettingsWindow: page,
+}) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  const settings = page.getByRole('main', { name: '设置内容' });
+  await settings.getByLabel('联网搜索真实查询').fill('electron vibrancy 排查');
+  await settings.getByRole('button', { name: '搜索', exact: true }).click();
+
+  const results = settings.locator('.settingsWebSearchResult');
+  await expect(results).toHaveCount(3);
+  await expect.poll(
+    () =>
+      results.evaluateAll((elements) =>
+        elements.every((element) => element.scrollWidth <= element.clientWidth),
+      ),
+  ).toBe(true);
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+});
+
 test('usage keeps one summary track per metric when wide', async ({ window: page }) => {
   await page.setViewportSize({ width: 1280, height: 900 });
   const settings = await openSettings(page);

--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -266,6 +266,73 @@ test('capability diagnostics stay contained when expanded at the window floor', 
   ).toBe(true);
 });
 
+/**
+ * #1364 — list-page geometry at the window floor.
+ *
+ * Usage: the requests DataTable's nowrap column recipe gives it an intrinsic
+ * width wider than the settings column even at full window width; it must
+ * scroll inside its own container (#1360 fix) instead of dragging the page
+ * into horizontal scroll, and the five-tab bar scrolls within itself the same
+ * way. Web search: unbreakable tokens (env-var hint, result hostnames/URLs)
+ * must wrap instead of widening the page.
+ *
+ * Memory is asserted per-surface (the prompt-preview header), not as a
+ * whole-page containment check: its `.settingsFormRow` rows overflow at the
+ * floor through the shared settings-rows primitive — routed to #1360 and in
+ * #1362's row-wrapping scope, not patched per-page here.
+ */
+test('usage and web search stay contained at the window floor', async ({ window: page }) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  const settings = await openSettings(page);
+
+  await settings.getByRole('button', { name: '使用统计', exact: true }).click();
+  const tabsBar = settings.locator('.settingsUsageTabsBar');
+  await expect(tabsBar).toBeVisible();
+  await expect(tabsBar).toHaveCSS('overflow-x', 'auto');
+  await expect.poll(async () => {
+    const { trackCount, valuesContained } = await summaryGeometry(
+      settings.locator('.settingsUsageSummary'),
+    );
+    return { foldedToFewTracks: trackCount <= 2, valuesContained };
+  }).toEqual({ foldedToFewTracks: true, valuesContained: true });
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+
+  // Not `exact`: the nav entry's accessible name carries its Beta badge.
+  await settings.getByRole('button', { name: '联网搜索' }).click();
+  const disabledReason = settings.locator('.settingsWebSearchDisabledReason');
+  await expect(disabledReason).toBeVisible();
+  await expect(disabledReason).toHaveCSS('overflow-wrap', 'anywhere');
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+
+  await settings.getByRole('button', { name: '记忆', exact: true }).click();
+  const previewHeader = settings.locator('.settingsMemoryPromptPreviewHeader');
+  await expect(previewHeader).toBeVisible();
+  await expect(previewHeader).toHaveCSS('flex-wrap', 'wrap');
+  await expect.poll(
+    () =>
+      previewHeader.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+});
+
+test('usage keeps one summary track per metric when wide', async ({ window: page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const settings = await openSettings(page);
+  await settings.getByRole('button', { name: '使用统计', exact: true }).click();
+
+  // `auto-fit` must not cost the full-width layout: four metrics, four tracks.
+  await expect(settings.locator('.settingsUsageSummary')).toBeVisible();
+  await expect.poll(async () => {
+    const { trackCount, tileCount } = await summaryGeometry(
+      settings.locator('.settingsUsageSummary'),
+    );
+    return { trackCount, tileCount };
+  }).toEqual({ trackCount: 4, tileCount: 4 });
+});
+
 test('remote access opens a channel detail from the overview and returns', async ({ window: page }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
   await page.getByRole('button', { name: '设置' }).click();

--- a/apps/desktop/src/main/e2e-fixture/scenarios-settings.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-settings.ts
@@ -37,6 +37,24 @@ export async function writeSettings(
     settings.usage.range = 'all';
     settings.usage.showDetails = true;
   }
+  // Settings → 联网搜索: a configured Tavily key so the live-query controls
+  // are enabled. The query itself is answered by the typed fixture in
+  // `main/web-search-e2e-fixture.ts` — no network round-trip in e2e.
+  if (scenario === 'settings-search') {
+    settings.webSearch = {
+      ...settings.webSearch,
+      enabled: true,
+      providers: {
+        ...settings.webSearch.providers,
+        tavily: {
+          ...settings.webSearch.providers.tavily,
+          apiKey: 'e2e-tavily-fixture-key',
+          credentialSource: 'saved',
+          credentialStatus: 'valid',
+        },
+      },
+    };
+  }
   await writeJson(join(workspaceRoot, 'settings.json'), settings);
 }
 

--- a/apps/desktop/src/main/web-search-e2e-fixture.ts
+++ b/apps/desktop/src/main/web-search-e2e-fixture.ts
@@ -1,0 +1,52 @@
+import type { WebSearchResultRow } from '@maka/core';
+
+/**
+ * #1364 review follow-up: typed web-search results for the `settings-search`
+ * e2e fixture.
+ *
+ * The Web Search page's containment contract is about the rendered result
+ * list — a bare-URL title, a long proportional title, and a long snippet are
+ * the widths that used to drag the whole page into horizontal overflow at the
+ * 480px window floor. A real Tavily round-trip cannot exercise that: e2e runs
+ * offline (CI has no key and no network), so without this fixture the test
+ * would stop at the no-key message and the result CSS could regress silently.
+ *
+ * Mirrors `webSearchLiveResults` in `stories/settings/settings-pages.stories.tsx`
+ * so the story baseline and the E2E contract describe the same page. The
+ * `settings-search` scenario also seeds a configured Tavily key (see
+ * `e2e-fixture/scenarios-settings.ts`) so the query controls are enabled.
+ *
+ * Production is untouched: this returns null unless the fixture scenario is
+ * active, and the IPC handler falls through to the real `queryTavily`.
+ */
+const FIXTURE_SCENARIO = 'settings-search';
+
+export function webSearchResultsE2eFixture(): WebSearchResultRow[] | null {
+  if (process.env.MAKA_E2E_FIXTURE !== FIXTURE_SCENARIO) return null;
+  return [
+    {
+      provider: 'tavily',
+      title:
+        'Electron 窗口在 macOS Sequoia 上 vibrancy 失效的完整排查记录：从 NSVisualEffectView 到 CSS backdrop-filter 的九层封装',
+      url: 'https://blog.example-engineering-weekly.com/posts/2026/07/electron-vibrancy-regression-macos-sequoia-troubleshooting-notes-part-three',
+      snippet:
+        '本文覆盖 vibrancy 在 Sequoia 15.4 上的三类失效场景：窗口层级变化后 material 不再刷新、data-vibrancy 属性与 CSS 级联的竞态、以及 transparent 窗口在外接显示器上的合成器回退。附带最小复现仓库与九个已验证的 workaround，其中第七个（延迟一帧重设 backgroundColor）对 Electron 33 仍然有效。',
+      source: 'blog.example-engineering-weekly.com',
+    },
+    {
+      provider: 'tavily',
+      title: 'Tavily API rate limits',
+      url: 'https://docs.tavily.com/rate-limits',
+      snippet: 'Standard plans allow 100 requests per minute.',
+      source: 'docs.tavily.com',
+    },
+    {
+      provider: 'tavily',
+      title:
+        'https://raw.githubusercontent.com/example/monorepo/refs/heads/main/packages/runtime/ARCHITECTURE.md',
+      url: 'https://raw.githubusercontent.com/example/monorepo/refs/heads/main/packages/runtime/ARCHITECTURE.md',
+      snippet: 'Runtime architecture notes.',
+      source: 'raw.githubusercontent.com',
+    },
+  ];
+}

--- a/apps/desktop/src/main/web-search-ipc-main.ts
+++ b/apps/desktop/src/main/web-search-ipc-main.ts
@@ -8,6 +8,7 @@ import type { WorkspacePrivacyContext } from '@maka/core/incognito';
 import type { createSettingsStore } from '@maka/storage';
 import { resolveTavilyApiKey } from './web-search/credentials.js';
 import { queryTavily, TAVILY_TEST_LIMIT, TAVILY_TEST_QUERY } from './web-search/tavily.js';
+import { webSearchResultsE2eFixture } from './web-search-e2e-fixture.js';
 
 type SettingsStore = ReturnType<typeof createSettingsStore>;
 
@@ -49,6 +50,11 @@ export function registerWebSearchIpc(deps: WebSearchIpcDeps): void {
           message: '请先在 设置 · 联网搜索 中启用 Tavily。',
         };
       }
+      // #1364: e2e runs offline — the `settings-search` fixture answers with
+      // deterministic hostile-width results AFTER the real validation and
+      // enablement gates above, so only the Tavily round-trip is replaced.
+      const fixtureResults = webSearchResultsE2eFixture();
+      if (fixtureResults) return { ok: true as const, results: fixtureResults };
       const effectiveKey = resolveTavilyApiKey({ settings, draftKey: request?.apiKey });
       const limit = normalizeWebSearchLimit(request?.limit);
       return queryTavily({ apiKey: effectiveKey, query, limit });

--- a/apps/desktop/src/renderer/styles/settings/bot.css
+++ b/apps/desktop/src/renderer/styles/settings/bot.css
@@ -289,6 +289,13 @@
 .settingsUsagePage {
   display: grid;
   align-content: start;
+  /* #1364: pin the single column to `minmax(0, 1fr)`. With the implicit
+     `auto` track, every block's min-content propagated into the track size —
+     the five-tab bar (~453px intrinsic) and the requests table dragged the
+     whole page into horizontal scroll even though both scroll within
+     themselves. An explicit 0-floor track is the grid-level equivalent of
+     `min-width: 0` on every row. */
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--space-2-5);
 }
 
@@ -313,6 +320,11 @@
   display: flex;
   align-items: center;
   border-bottom: var(--border-width-hairline) solid var(--border);
+  /* #1364: five nowrap tabs + count pills are ~453px min-content — wider than
+     the whole content column at the 480px window floor, and the bar dragged
+     the page into horizontal scroll. Tabs stay one line by design, so the bar
+     scrolls within itself (the hairline still spans the visible width). */
+  overflow-x: auto;
 }
 
 .settingsUsageTabs {
@@ -354,6 +366,9 @@
 .settingsUsageTabPanel {
   display: grid;
   align-content: start;
+  /* #1364: same 0-floor track as `.settingsUsagePage` — the requests table's
+     intrinsic width must stop here and scroll inside its own container. */
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--space-2);
   min-height: 0;
   margin-top: var(--space-2-5);
@@ -365,10 +380,17 @@
   padding: var(--space-6);
 }
 
-.settingsUsageFilters {
-  display: grid;
-  grid-template-columns: minmax(260px, 1fr) 148px 108px 92px 92px;
-  align-items: center;
+/* #1364: was a five-track grid (`minmax(260px, 1fr) 148px 108px 92px 92px`,
+   ~724px min-content) behind a 900px viewport breakpoint. The settings column
+   is narrower than the viewport by the sidebar's width, so between the
+   breakpoint and ~1100px the grid overflowed the page — same lesson as the
+   #1361 permission rows: the threshold depends on the controls' widths, not on
+   the window, so wrap structurally instead. The filter input grows from its
+   old 260px track; the select/toggle/count/clear keep their natural widths and
+   fall to the next line when they no longer fit. */
+.settingsUsageFilters > input {
+  flex: 1 1 260px;
+  min-width: 0;
 }
 
 .settingsUsageDetailToggle {
@@ -404,11 +426,10 @@
   visibility: hidden;
 }
 
+/* #1364: the filters row wraps structurally now (see `.settingsUsageFilters >
+   input` above), so its 900px single-column fallback is gone. The toggle keeps
+   its narrow-layout alignment tweak. */
 @media (max-width: 900px) {
-  .settingsUsageFilters {
-    grid-template-columns: 1fr;
-  }
-
   .settingsUsageDetailToggle {
     justify-content: flex-start;
   }
@@ -416,7 +437,12 @@
 
 .settingsUsageSummary {
   display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
+  /* #1364: was `repeat(4, minmax(0, 1fr))` — the same hard-track division
+     #1361 fixed on the Permissions/Health summaries. At the 480px window
+     floor each metric tile collapsed to ~32px and its value overflowed.
+     `auto-fit` keeps four even tracks at full width and folds to fewer,
+     readable columns when narrow. */
+  grid-template-columns: repeat(auto-fit, minmax(min(120px, 100%), 1fr));
   gap: var(--space-1-5);
 }
 

--- a/apps/desktop/src/renderer/styles/settings/form.css
+++ b/apps/desktop/src/renderer/styles/settings/form.css
@@ -108,6 +108,10 @@
 
 .settingsPasswordField input {
   width: 100%;
+  /* #1364: `width: 100%` alone cannot shrink an input below its intrinsic
+     `size` width (~180px), so at the 480px window floor the key field
+     overflowed its row by ~90px. */
+  min-width: 0;
   padding-right: var(--space-16);
 }
 

--- a/apps/desktop/src/renderer/styles/settings/memory.css
+++ b/apps/desktop/src/renderer/styles/settings/memory.css
@@ -45,6 +45,10 @@
     display: flex;
     align-items: center;
     justify-content: space-between;
+    /* #1364: the trailing cluster (injection Chip + copy button) is an
+       inline-flex that cannot shrink; at the 480px window floor it overflowed
+       the card by ~13px. Let it wrap under the title instead. */
+    flex-wrap: wrap;
     gap: var(--space-3);
   }
 .settingsMemoryPromptPreviewHeader strong {

--- a/apps/desktop/src/renderer/styles/settings/web-search.css
+++ b/apps/desktop/src/renderer/styles/settings/web-search.css
@@ -34,6 +34,9 @@
 .settingsWebSearchKeyRow > .settingsPasswordField,
 .settingsWebSearchQueryInputRow > input {
   width: min(100%, 360px);
+  /* #1364: a text input never shrinks below its intrinsic `size` width on its
+     own (~180px) — at the 480px window floor that overflowed the row. */
+  min-width: 0;
   justify-self: end;
 }
 
@@ -50,6 +53,9 @@
   font-size: var(--font-size-ui);
   line-height: var(--leading-normal);
   text-align: right;
+  /* #1364: the hint names an env var (TAVILY_API_KEY) — an unbreakable token
+     wider than the whole content column at the 480px window floor. */
+  overflow-wrap: anywhere;
 }
 .settingsWebSearchResults {
     list-style: none;
@@ -70,6 +76,10 @@
     font-weight: var(--font-weight-semibold);
     color: var(--foreground);
     text-decoration: none;
+    /* #1364: Tavily titles are sometimes a bare URL — one unbreakable token
+       that widened the whole page (~585px of overflow at the 480px window
+       floor) because a grid item's min-content floor propagates upward. */
+    overflow-wrap: anywhere;
   }
 .settingsWebSearchResult a:hover {
     text-decoration: underline;
@@ -79,6 +89,9 @@
     font-size: var(--font-size-caption);
     text-transform: uppercase;
     letter-spacing: var(--tracking-wider);
+    /* #1364: the source is a hostname — one unbreakable token, and long ones
+       (raw.githubusercontent.com) widened the page at the 480px floor. */
+    overflow-wrap: anywhere;
   }
 .settingsWebSearchResult p {
     margin: 0;
@@ -107,6 +120,15 @@
   .settingsWebSearchStatusCluster {
     justify-content: flex-start;
     margin-left: 0;
+  }
+
+  /* #1364: the mono timestamp ("最近一次测试：…") keeps `nowrap` on wide
+     layouts, but at the 480px window floor its ~169px intrinsic width was the
+     single widest thing on the page and dragged the whole card into overflow.
+     The cluster already wraps between items; in the narrow layout the items
+     themselves may wrap too. */
+  .settingsWebSearchStatusCluster small {
+    white-space: normal;
   }
 
   .settingsWebSearchKeyRow > .settingsPasswordField,

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -682,10 +682,20 @@ const withUsagePopulatedBridge = withScopedMakaBridge({
   },
 } satisfies Record<string, unknown>);
 
+/** #1364 review follow-up: empty stats alone are not the empty BASELINE —
+ *  with default settings (`showDetails: false`) the first render is the
+ *  summary-only Alert and the EmptyState never mounts. Reuse the details-on
+ *  requests-tab settings so the story opens on the actual empty state. */
 const withUsageEmptyBridge = withScopedMakaBridge({
   ...makaBridge,
   settings: {
     ...makaBridge.settings,
+    get: async () => usagePopulatedSettings,
+    update: async (
+      patch: Parameters<typeof window.maka.settings.update>[0],
+    ): Promise<UpdateAppSettingsResult> => ({
+      settings: mergeSettings(usagePopulatedSettings, patch),
+    }),
     usageStats: async (): Promise<UsageStats> => emptyUsageStats,
   },
 } satisfies Record<string, unknown>);
@@ -1096,6 +1106,7 @@ export const WebSearchResults: Story = {
     );
   },
 };
+// Real path: 设置 → 语音.
 export const Voice: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="voice" />,

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -8,6 +8,9 @@ import type {
   HealthSignal,
   HealthSnapshot,
   LlmConnection,
+  LocalMemoryBackupInfo,
+  LocalMemoryEntryPreview,
+  LocalMemoryState,
   OsPermissionSnapshot,
   OsPermissionState,
   PermissionSnapshot,
@@ -112,6 +115,56 @@ const connectionsBridge: ConnectionsBridge = {
   },
 };
 
+/**
+ * #1364: request logs with deliberately hostile content — a dated preview
+ * model id, a namespaced MCP tool name, and full-length UUIDs — so the
+ * requests DataTable (8 columns, most `whitespace-nowrap` by primitive
+ * recipe) is exercised at its real intrinsic width. `logs` used to be `[]`,
+ * which meant no story ever rendered a DataTable at all.
+ */
+function makeUsageLog(input: {
+  id: string;
+  kind: 'model' | 'tool';
+  model: string;
+  toolName?: string;
+  status?: 'success' | 'error';
+  minutesAgo: number;
+}): UsageStats['logs'][number] {
+  return {
+    id: input.id,
+    ts: NOW - input.minutesAgo * 60_000,
+    kind: input.kind,
+    sessionId: `b0efaaf9-9e58-46c1-bfea-${input.id.padStart(12, '0')}`,
+    turnId: `turn-${input.id}`,
+    provider: 'zai-coding-plan',
+    model: input.model,
+    toolName: input.toolName,
+    inputTokens: 12_400,
+    outputTokens: 3_800,
+    costUsd: input.kind === 'model' ? 0.0412 : undefined,
+    latencyMs: input.kind === 'model' ? 2840 : 640,
+    status: input.status ?? 'success',
+  };
+}
+
+const usageLogs: UsageStats['logs'] = [
+  makeUsageLog({
+    id: '1',
+    kind: 'model',
+    model: 'anthropic/claude-sonnet-4-5-20250929-preview-extended-thinking',
+    minutesAgo: 4,
+  }),
+  makeUsageLog({
+    id: '2',
+    kind: 'tool',
+    model: 'glm-4.7',
+    toolName: 'mcp__cloud_workspace__list_repository_branch_protection_rules',
+    minutesAgo: 9,
+  }),
+  makeUsageLog({ id: '3', kind: 'model', model: 'glm-4.7', status: 'error', minutesAgo: 16 }),
+  makeUsageLog({ id: '4', kind: 'tool', model: 'glm-4.7', toolName: 'Bash', minutesAgo: 25 }),
+];
+
 const usageStats: UsageStats = {
   summary: {
     totalRequests: 420,
@@ -125,12 +178,188 @@ const usageStats: UsageStats = {
     cacheCreation: 0,
     reasoning: 0,
   },
-  logs: [],
+  logs: usageLogs,
   byProvider: [{ provider: 'zai-coding-plan', requests: 280, tokens: 124_000, costUsd: 1.5 }],
-  byModel: [{ model: 'glm-4.7', requests: 280, tokens: 124_000, costUsd: 1.5 }],
-  byTool: [{ tool: 'Bash', calls: 120, success: 118, errors: 2, avgDurationMs: 840 }],
+  byModel: [
+    {
+      model: 'anthropic/claude-sonnet-4-5-20250929-preview-extended-thinking',
+      requests: 140,
+      tokens: 62_000,
+      costUsd: 0.84,
+    },
+    { model: 'glm-4.7', requests: 280, tokens: 124_000, costUsd: 1.5 },
+  ],
+  byTool: [
+    {
+      tool: 'mcp__cloud_workspace__list_repository_branch_protection_rules',
+      calls: 12,
+      success: 11,
+      errors: 1,
+      avgDurationMs: 1240,
+    },
+    { tool: 'Bash', calls: 120, success: 118, errors: 2, avgDurationMs: 840 },
+  ],
   pricing: [{ provider: 'zai-coding-plan', model: 'glm-4.7', inputPerMTokUsd: 0, outputPerMTokUsd: 0 }],
 };
+
+const emptyUsageStats: UsageStats = {
+  summary: {
+    totalRequests: 0,
+    totalCostUsd: 0,
+    totalTokens: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    cacheTokens: 0,
+    cacheMiss: 0,
+    cacheRead: 0,
+    cacheCreation: 0,
+    reasoning: 0,
+  },
+  logs: [],
+  byProvider: [],
+  byModel: [],
+  byTool: [],
+  pricing: [],
+};
+
+/**
+ * #1364: Memory page fixtures.
+ *
+ * The bridge used to have no `memory` / `workspaceInstructions` / `app.openPath`
+ * channels at all, so the Memory story booted into two error toasts (载入本地
+ * 记忆失败 / 载入项目指令失败) and an empty page — no entry list, no backup
+ * candidates, no prompt preview ever rendered. The default story now gets a
+ * clean empty state; `MemoryPopulated` covers the list surfaces with
+ * deliberately long titles, contents, and tag sets.
+ *
+ * Mutations echo the same state back: stories only exercise the read path,
+ * and a mutation that "succeeds" without changing anything keeps the page
+ * deterministic if someone clicks around.
+ */
+function makeMemoryEntry(input: {
+  id: string;
+  title: string;
+  content: string;
+  status: LocalMemoryEntryPreview['status'];
+  tags?: readonly string[];
+  minutesAgo?: number;
+}): LocalMemoryEntryPreview {
+  const ts = NOW - (input.minutesAgo ?? 60) * 60_000;
+  return {
+    id: input.id,
+    origin: 'manual',
+    source: 'user_authored',
+    status: input.status,
+    title: input.title,
+    content: input.content,
+    createdAt: ts,
+    updatedAt: ts,
+    tags: input.tags ?? [],
+  };
+}
+
+const memoryEntries: LocalMemoryEntryPreview[] = [
+  makeMemoryEntry({
+    id: 'mem-1',
+    title: '部署流程要走灰度队列，先发 1% 再看 30 分钟错误率，确认无回归后才放全量',
+    content:
+      '生产部署必须先进灰度队列（deploy-canary），观察 30 分钟内 5xx 率与 p99 延迟，都稳定后再放全量。历史上有两次全量直发导致回滚，耗时超过一小时。相关看板：grafana.internal/d/deploy-canary-overview。',
+    status: 'active',
+    tags: ['deploy', 'canary', 'sre', 'incident-review', 'grafana'],
+    minutesAgo: 42,
+  }),
+  makeMemoryEntry({
+    id: 'mem-2',
+    title: '用户偏好中文回复',
+    content: '交流一律使用中文，代码注释保持英文。',
+    status: 'active',
+    minutesAgo: 180,
+  }),
+  makeMemoryEntry({
+    id: 'mem-3',
+    title: '旧的 API 网关地址已废弃',
+    content: '内部网关已从 gateway-legacy.internal:8443 迁移到 mesh.internal，旧地址 2026-06 起停止解析。',
+    status: 'archived',
+    tags: ['infra'],
+    minutesAgo: 4320,
+  }),
+];
+
+function makeMemoryBackup(kind: LocalMemoryBackupInfo['kind'], minutesAgo: number): LocalMemoryBackupInfo {
+  return {
+    path: `/Users/storybook/Library/Application Support/Maka/workspaces/default/memory/MEMORY.md.${kind}.bak`,
+    kind,
+    updatedAt: NOW - minutesAgo * 60_000,
+    sizeBytes: 4_812,
+    entryCount: 3,
+    activeEntryCount: 2,
+    archivedEntryCount: 1,
+    safeMode: false,
+  };
+}
+
+function makeMemoryState(input: {
+  entries: LocalMemoryEntryPreview[];
+  backups?: LocalMemoryBackupInfo[];
+}): LocalMemoryState {
+  const activeEntries = input.entries.filter((entry) => entry.status === 'active');
+  const archivedEntries = input.entries.filter((entry) => entry.status === 'archived');
+  const content = input.entries
+    .map((entry) => `## ${entry.title}\n\n${entry.content}\n`)
+    .join('\n');
+  return {
+    path: '/Users/storybook/Library/Application Support/Maka/workspaces/default/memory/MEMORY.md',
+    enabled: true,
+    agentReadEnabled: true,
+    status: 'ok',
+    content,
+    entryCount: input.entries.length,
+    activeEntryCount: activeEntries.length,
+    archivedEntryCount: archivedEntries.length,
+    entries: input.entries,
+    activeEntries,
+    archivedEntries,
+    latestEntry: input.entries[0],
+    latestBackup: input.backups?.[0],
+    backups: input.backups,
+  };
+}
+
+const emptyMemoryState = makeMemoryState({ entries: [] });
+const populatedMemoryState = makeMemoryState({
+  entries: memoryEntries,
+  backups: [makeMemoryBackup('save', 42), makeMemoryBackup('restore', 300)],
+});
+
+function makeMemoryBridgeChannels(state: LocalMemoryState) {
+  return {
+    memory: {
+      getState: async () => state,
+      setEnabled: async () => state,
+      setAgentReadEnabled: async () => state,
+      save: async () => state,
+      reset: async () => state,
+      restoreLatestBackup: async () => ({ ok: true as const, state }),
+      restoreBackup: async () => ({ ok: true as const, state }),
+      openFile: async () => ({ ok: true as const }),
+      openLatestBackup: async () => ({ ok: true as const }),
+      openBackup: async () => ({ ok: true as const }),
+    },
+    workspaceInstructions: {
+      getState: async () => ({
+        files: [
+          { file: 'AGENTS.md', status: 'available', chars: 1_820, truncated: false },
+          { file: 'CLAUDE.md', status: 'missing', chars: 0, truncated: false },
+        ],
+        detectedCount: 1,
+        fileCharLimit: 20_000,
+        promptCharLimit: 8_000,
+      }),
+      openFile: async () => ({ ok: true as const }),
+      createFile: async () => ({ ok: true as const }),
+    },
+  };
+}
 
 /**
  * Permission Center / Health Center fixtures.
@@ -375,6 +604,12 @@ const makaBridge = {
       nodeVersion: '20.18.0',
       chromeVersion: '130.0.6723.59',
     }),
+    openPath: async () => ({ ok: true as const, opened: '/Users/storybook' }),
+  },
+  ...makeMemoryBridgeChannels(emptyMemoryState),
+  webSearch: {
+    test: async () => ({ ok: true as const, results: [] }),
+    query: async () => ({ ok: true as const, results: [] }),
   },
   health: {
     getSnapshot: async () => healthSnapshot,
@@ -418,6 +653,106 @@ const withEmptyHealthBridge = withScopedMakaBridge({
   ...makaBridge,
   health: {
     getSnapshot: async () => emptyHealthSnapshot,
+  },
+} satisfies Record<string, unknown>);
+
+// #1364: list-page variants — empty vs populated vs long-content, per the
+// tracking issue's expected deliverables.
+
+const withMemoryPopulatedBridge = withScopedMakaBridge({
+  ...makaBridge,
+  ...makeMemoryBridgeChannels(populatedMemoryState),
+} satisfies Record<string, unknown>);
+
+/** Requests tab visible with the hostile-width logs (see `usageLogs`). */
+const usagePopulatedSettings = mergeSettings(createDefaultSettings(), {
+  usage: { showDetails: true, activeTab: 'requests' },
+});
+
+const withUsagePopulatedBridge = withScopedMakaBridge({
+  ...makaBridge,
+  settings: {
+    ...makaBridge.settings,
+    get: async () => usagePopulatedSettings,
+    update: async (
+      patch: Parameters<typeof window.maka.settings.update>[0],
+    ): Promise<UpdateAppSettingsResult> => ({
+      settings: mergeSettings(usagePopulatedSettings, patch),
+    }),
+  },
+} satisfies Record<string, unknown>);
+
+const withUsageEmptyBridge = withScopedMakaBridge({
+  ...makaBridge,
+  settings: {
+    ...makaBridge.settings,
+    usageStats: async (): Promise<UsageStats> => emptyUsageStats,
+  },
+} satisfies Record<string, unknown>);
+
+/** Configured Tavily key + live-query results with long titles/URLs/snippets.
+ *  Built by hand, not via `mergeSettings`: the merge treats the masked
+ *  `apiKey` sentinel as "keep current key" and would drop it. */
+const webSearchConfiguredSettings: AppSettings = (() => {
+  const base = createDefaultSettings();
+  return {
+    ...base,
+    webSearch: {
+      ...base.webSearch,
+      enabled: true,
+      providers: {
+        tavily: {
+          ...base.webSearch.providers.tavily,
+          apiKey: '••••••',
+          credentialSource: 'saved',
+          credentialStatus: 'valid',
+          credentialCheckedAt: new Date(NOW - 20 * 60_000).toISOString(),
+        },
+      },
+    },
+  };
+})();
+
+const webSearchLiveResults = [
+  {
+    provider: 'tavily' as const,
+    title:
+      'Electron 窗口在 macOS Sequoia 上 vibrancy 失效的完整排查记录：从 NSVisualEffectView 到 CSS backdrop-filter 的九层封装',
+    url: 'https://blog.example-engineering-weekly.com/posts/2026/07/electron-vibrancy-regression-macos-sequoia-troubleshooting-notes-part-three',
+    snippet:
+      '本文覆盖 vibrancy 在 Sequoia 15.4 上的三类失效场景：窗口层级变化后 material 不再刷新、data-vibrancy 属性与 CSS 级联的竞态、以及 transparent 窗口在外接显示器上的合成器回退。附带最小复现仓库与九个已验证的 workaround，其中第七个（延迟一帧重设 backgroundColor）对 Electron 33 仍然有效。',
+    source: 'blog.example-engineering-weekly.com',
+  },
+  {
+    provider: 'tavily' as const,
+    title: 'Tavily API rate limits',
+    url: 'https://docs.tavily.com/rate-limits',
+    snippet: 'Standard plans allow 100 requests per minute.',
+    source: 'docs.tavily.com',
+  },
+  {
+    provider: 'tavily' as const,
+    title: 'https://raw.githubusercontent.com/example/monorepo/refs/heads/main/packages/runtime/ARCHITECTURE.md',
+    url: 'https://raw.githubusercontent.com/example/monorepo/refs/heads/main/packages/runtime/ARCHITECTURE.md',
+    snippet: 'Runtime architecture notes.',
+    source: 'raw.githubusercontent.com',
+  },
+];
+
+const withWebSearchConfiguredBridge = withScopedMakaBridge({
+  ...makaBridge,
+  settings: {
+    ...makaBridge.settings,
+    get: async () => webSearchConfiguredSettings,
+    update: async (
+      patch: Parameters<typeof window.maka.settings.update>[0],
+    ): Promise<UpdateAppSettingsResult> => ({
+      settings: mergeSettings(webSearchConfiguredSettings, patch),
+    }),
+  },
+  webSearch: {
+    test: async () => ({ ok: true as const, results: webSearchLiveResults }),
+    query: async () => ({ ok: true as const, results: webSearchLiveResults }),
   },
 } satisfies Record<string, unknown>);
 
@@ -696,9 +1031,36 @@ export const Usage: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="usage" />,
 };
+/**
+ * #1364: the requests DataTable with hostile-width content (dated preview
+ * model ids, namespaced MCP tool names). No story rendered a DataTable at
+ * all before this — `logs` was `[]` and the requests tab defaulted to its
+ * summary-only Alert.
+ */
+// Real path: 设置 → 使用统计 → 详情记录 on → 请求日志, with recorded traffic.
+export const UsageRequestsPopulated: Story = {
+  decorators: [withUsagePopulatedBridge],
+  render: () => <SettingsStory section="usage" />,
+};
+// Real path: same tab on a fresh workspace with no recorded traffic.
+export const UsageEmpty: Story = {
+  decorators: [withUsageEmptyBridge],
+  render: () => <SettingsStory section="usage" />,
+};
 // Real path: 设置 → 记忆.
 export const Memory: Story = {
   decorators: [withSettingsBridge],
+  render: () => <SettingsStory section="memory" />,
+};
+/**
+ * #1364: entry list (long title / content / tag set), archived group, and
+ * backup-candidate rows. The default story is the clean empty state — the
+ * bridge used to lack the `memory` channel entirely, so the page booted
+ * into error toasts instead of either state.
+ */
+// Real path: 设置 → 记忆, on a workspace with saved memories and backup candidates.
+export const MemoryPopulated: Story = {
+  decorators: [withMemoryPopulatedBridge],
   render: () => <SettingsStory section="memory" />,
 };
 // Real path: 设置 → 联网搜索.
@@ -706,7 +1068,34 @@ export const WebSearch: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="search" />,
 };
-// Real path: 设置 → 语音.
+/**
+ * #1364: configured key + live-query results with a long title, a bare-URL
+ * title, and a long snippet — the result list's wrapping surface. The play
+ * step drives the real query path against the story bridge.
+ */
+// Real path: 设置 → 联网搜索 with a saved Tavily key → type a query → 搜索.
+export const WebSearchResults: Story = {
+  decorators: [withWebSearchConfiguredBridge],
+  render: () => <SettingsStory section="search" />,
+  play: async ({ canvasElement }) => {
+    const input = await waitForStoryCondition(
+      () => canvasElement.querySelector<HTMLInputElement>('input[aria-label="联网搜索真实查询"]') !== null,
+      'Web search story did not render the query input',
+    ).then(() => canvasElement.querySelector<HTMLInputElement>('input[aria-label="联网搜索真实查询"]')!);
+    const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+    setValue?.call(input, 'electron vibrancy sequoia');
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    const search = await waitForStoryButton(
+      canvasElement,
+      (candidate) => candidate.textContent?.trim() === '搜索' && !candidate.disabled,
+    );
+    search.click();
+    await waitForStoryCondition(
+      () => canvasElement.querySelectorAll('.settingsWebSearchResult').length > 0,
+      'Web search story did not render live results',
+    );
+  },
+};
 export const Voice: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="voice" />,


### PR DESCRIPTION
Sub-issue of #1303 — the visual/layout audit of the list/long-content pages (Usage / Memory / Web Search), same shape as the #1361 metric-pages pass. **Based on #1478** (the `DataTable` scroller fix this pass traced to the shared primitive); the first commit here is that branch. Closes #1364.

## Two of three pages had no usable baseline

| page | before |
| --- | --- |
| Memory | bridge had **no `memory` / `workspaceInstructions` / `app.openPath` channels** — the story booted into two error toasts and an empty page; entry list, backup candidates and prompt preview never rendered |
| Usage | `logs: []` + requests tab defaults to its summary Alert — **no story ever rendered a DataTable**, so the issue's headline theme ("DataTable overflow") had no baseline; that is also why the primitive defect in #1478 went unseen |
| Web search | the result list only renders after a live query — never covered |

New variants per the issue's expected deliverables (empty vs populated vs long-content):

- `UsageRequestsPopulated` (hostile-width rows: dated preview model id, namespaced MCP tool name, full-UUID session) / `UsageEmpty` / existing `Usage` (summary-only Alert)
- `MemoryPopulated` (long title/content/tag sets, archived group, backup-candidate rows) / `Memory` (now a clean empty state)
- `WebSearchResults` — a play step drives the real query path against a configured-key bridge, with a long title, a bare-URL title, and a long snippet. One wrinkle worth noting: the bridge settings are built by hand because `mergeSettings` treats the masked `apiKey` sentinel as "keep current key" and silently drops it.

## What the audit found (all measured, 480–1280px)

**Usage** — the page grid's implicit `auto` track let every block's min-content propagate: the five-tab bar (~453px intrinsic) and the requests table dragged the page into horizontal scroll even though both should scroll within themselves. Pinned the single column to `minmax(0, 1fr)` (page + tab panel), gave the tab bar its own `overflow-x: auto`, and replaced two hard-track grids:

- the filters row was a five-track grid (~724px min-content) behind a 900px **viewport** breakpoint — the settings column is narrower than the viewport, so 900–1100px overflowed. Same lesson as #1361: wrap structurally, no guessed threshold.
- the summary strip was `repeat(4, minmax(0, 1fr))` — the same hard-track division #1361 fixed on Permissions/Health (~32px tiles at the floor) → `auto-fit`, full-width layout unchanged (locked by a wide-layout guard).

**Web search** — three unbreakable tokens (`TAVILY_API_KEY` hint, bare-URL result titles, long result hostnames) each widened the page at the floor → `overflow-wrap: anywhere`; `min-width: 0` on the query/key inputs (a text input never shrinks below its intrinsic `size` width on its own); the mono nowrap timestamp may wrap in the narrow layout.

**Memory** — the prompt-preview header's trailing cluster (injection Chip + copy button) cannot shrink → wraps under the title.

## Routed to #1360, not patched here

Memory still overflows at the 480px floor through the shared `settings-rows` primitive: a `.settingsFormRow`'s min-content (~306px) exceeds the ~190px content column. That is exactly #1362's declared "row wrapping" scope, so it is [documented on the routing issue](#1478) rather than hacked per-page — and the e2e contract deliberately asserts Memory **per-surface** (prompt-preview header) instead of whole-page containment, with a comment explaining why.

## Verification

- Two e2e contract tests (containment + tab-bar/summary geometry at the 480px floor; full-width guard so `auto-fit` cannot cost the wide layout). **Confirmed they fail against origin/main's CSS** (`toHaveCSS('overflow-x', 'auto')` on the tab bar).
- Full settings e2e suite **13/13**; desktop unit suite **2845/2845**; format / typecheck / test:checks / check-dead-css clean.
- Probed 7 stories × 480–1280px in Storybook: zero horizontal overflow beyond the documented settings-rows remainder.

### Live-app screenshots

Usage and Web search at the 480px floor (summary folds, tab bar scrolls within itself, tokens wrap):

<img src="https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1364-screenshots/live-usage-480.png" width="380"> <img src="https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1364-screenshots/live-websearch-480.png" width="380">

The new populated baselines — requests DataTable scrolling in its own container at 1280px, and the Memory entry surfaces that had never rendered in a story:

<img src="https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1364-screenshots/usage-populated-1280.png" width="620">
<img src="https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1364-screenshots/memory-populated-1280.png" width="620">
