### PR TITLE
feat(runtime): host-manage agent graph invocations

### DIFF
--- a/apps/desktop/src/main/__tests__/desktop-backend-tool-surface.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-backend-tool-surface.test.ts
@@ -129,6 +129,41 @@ describe('Desktop backend tool surface', () => {
     assert.equal(child.skillHost.toolNames.has('SubmitPlan'), false);
   });
 
+  it('binds graph supervisor tools only to an existing root Session', async () => {
+    let graphToolRequests = 0;
+    const graphTools = [
+      tool('view_agent_graph', 'read'),
+      tool('update_agent_graph', 'subagent'),
+    ];
+    const deps = makeDeps({
+      getAgentGraphSupervisorTools: async () => {
+        graphToolRequests += 1;
+        return graphTools;
+      },
+    });
+    const input = inputFor('claude-sonnet-4-5-20250929');
+    const root = await resolveDesktopBackendToolSurface(deps, input);
+    assert.equal(root.skillHost.toolNames.has('view_agent_graph'), true);
+    assert.equal(root.skillHost.toolNames.has('update_agent_graph'), true);
+
+    const child = await resolveDesktopBackendToolSurface(deps, {
+      ...input,
+      tools: [readTool],
+    });
+    assert.deepEqual([...child.skillHost.toolNames], ['Read']);
+
+    await resolveDesktopNewSessionSkillHost(deps, {
+      projectRoot: '/tmp/project',
+      workspaceRoot: '/tmp/workspace',
+      readyConnection: {
+        connection: connectionFor('claude-sonnet-4-5-20250929'),
+        apiKey: 'preview-key',
+        model: 'claude-sonnet-4-5-20250929',
+      },
+    });
+    assert.equal(graphToolRequests, 1);
+  });
+
   it('uses the durable child snapshot for the persisted-session Skill host', async () => {
     const header = inputFor('claude-sonnet-4-5-20250929').header;
     header.subagentParent = {} as SessionHeader['subagentParent'];

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -2,7 +2,12 @@ import { app, nativeImage, safeStorage } from 'electron';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { buildPricingLookup, setActiveProxy } from '@maka/runtime';
-import type { BotRegistry, SessionManager, ShellRunProcessManager } from '@maka/runtime';
+import type {
+  AgentGraphCoordinator,
+  BotRegistry,
+  SessionManager,
+  ShellRunProcessManager,
+} from '@maka/runtime';
 import type { McpClientManager } from '@maka/mcp';
 import type {
   createConnectionStore,
@@ -11,6 +16,7 @@ import type {
   createTelemetryRepo,
   openRuntimeEventPersistence,
 } from '@maka/storage';
+import type { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
 import { migrateLegacyCredentials } from './credential-store.js';
 import type { createFileCredentialStore } from './credential-store.js';
 import { startConfigFileWatcher, type ConfigFileWatcher } from './config-file-watcher.js';
@@ -54,6 +60,8 @@ export interface AppLifecycleDeps {
   runtimePersistence: Awaited<ReturnType<typeof openRuntimeEventPersistence>>;
   mainWindowController: ReturnType<typeof createMainWindowController>;
   runtime: SessionManager;
+  agentGraphCoordinator: AgentGraphCoordinator;
+  agentGraphControlStore: ReturnType<typeof createAgentGraphControlStore>;
   streamEvents: StreamEvents;
   /** Focus-or-create for the main window; stays in main.ts next to the
    *  controller and is registered here on `second-instance` / `activate`. */
@@ -104,6 +112,8 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     runtimePersistence,
     mainWindowController,
     runtime,
+    agentGraphCoordinator,
+    agentGraphControlStore,
     streamEvents,
     focusOrCreateMainWindow,
     emitConnectionListChanged,
@@ -117,6 +127,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
   async function recoverInterruptedSessionsOnStartup(): Promise<void> {
     try {
       await runtime.recoverInterruptedSessions();
+      await agentGraphCoordinator.recover();
       if (process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME !== '1') return;
       for (const session of await runtime.listSessions()) {
         const plan = await runtime.planLatestAuthoritativeSafeBoundaryContinuation(session.id);
@@ -320,11 +331,13 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
       Promise.resolve(mainWindowController.disposeBrowserViews()),
       shellRuns.terminateAll(),
       mcpManager.close(),
+      agentGraphCoordinator.close(),
     ]);
     for (const result of results) {
       if (result.status === 'rejected') console.error('[shutdown] cleanup failed:', result.reason);
     }
     runtimePersistence.close();
+    agentGraphControlStore.close();
     await sessionStore.close?.();
   }
 }

--- a/apps/desktop/src/main/desktop-backend-tool-surface.ts
+++ b/apps/desktop/src/main/desktop-backend-tool-surface.ts
@@ -58,6 +58,10 @@ export interface DesktopBackendToolSurfaceDeps {
   builtinTools: readonly MakaTool[];
   toolAvailability: ToolAvailabilityConfig;
   planStore: PlanStore;
+  getAgentGraphSupervisorTools?: (
+    sessionId: string,
+    header: SessionHeader,
+  ) => Promise<readonly MakaTool[]>;
 }
 
 export interface DesktopBackendToolSurfaceInput {
@@ -70,6 +74,8 @@ export interface DesktopBackendToolSurfaceInput {
   readyConnection?: ReadyConnection;
   /** Avoid reading a durable plan ledger for a not-yet-persisted session preview. */
   planState?: PlanSessionState;
+  /** A new-session preview has no durable root Session to supervise yet. */
+  includeAgentGraphSupervisorTools?: boolean;
 }
 
 export interface DesktopBackendToolSurface {
@@ -161,6 +167,7 @@ export async function resolveDesktopNewSessionSkillHost(
       header,
       readyConnection: input.readyConnection,
       planState: emptyPlanSessionState(sessionId),
+      includeAgentGraphSupervisorTools: false,
     })
   ).skillHost;
 }
@@ -194,12 +201,19 @@ export async function resolveDesktopBackendToolSurface(
   const interruptedExecution = [...planState.executions]
     .reverse()
     .find((execution) => execution.status === 'interrupted');
+  const agentGraphSupervisorTools =
+    !input.tools &&
+    input.includeAgentGraphSupervisorTools !== false &&
+    deps.getAgentGraphSupervisorTools
+      ? await deps.getAgentGraphSupervisorTools(input.sessionId, input.header)
+      : [];
   const candidateTools = input.tools
     ? [...input.tools]
     : deps.isComputerUseRealModelE2e
       ? [...deps.computerUseTools]
       : [
           ...deps.builtinTools,
+          ...agentGraphSupervisorTools,
           ...buildMcpTools(deps.mcpManager),
           ...(isDeepResearchSession(input.header.labels) ? deps.deepResearchTools : []),
         ];

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -30,6 +30,7 @@ import { AntigravitySubscriptionService } from './oauth/antigravity-subscription
 import type { WorkspacePrivacyContext } from '@maka/core/incognito';
 import { ok } from '@maka/core/result';
 import {
+  AgentGraphCoordinator,
   BackendRegistry,
   FakeBackend,
   PermissionEngine,
@@ -71,6 +72,7 @@ import {
   createShellRunStore,
   createTelemetryRepo,
 } from '@maka/storage';
+import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
 import { resolveStorageRoot } from '@maka/storage/root-authority';
 import { resolveWorkspaceIdentity } from '@maka/storage/workspace-identity';
 import { McpClientManager } from '@maka/mcp';
@@ -218,6 +220,7 @@ if (e2eFixture) {
 // process, so quit needs no special teardown.
 const keepSystemAwake = createKeepSystemAwakeController(powerSaveBlocker);
 const store = createSessionStore(workspaceRoot);
+const agentGraphControlStore = createAgentGraphControlStore(workspaceRoot);
 const planStore = createPlanStore(workspaceRoot);
 const runStore = createAgentRunStore(workspaceRoot);
 const runtimePersistence = await openRuntimeEventPersistence({
@@ -389,6 +392,7 @@ const automationWiring = createMainAutomationWiring({
     // do not accumulate an unbounded pile of active sessions. The session (with
     // its run/trace) is preserved under the archive, labelled automation/cron.
     try {
+      await agentGraphCoordinator.stop(session.id);
       await goalWiring.archiveSession(session.id, () => runtime.archive(session.id));
       desktopSessionSkillHosts.delete(session.id);
       emitSessionsChanged('archived', session.id);
@@ -618,6 +622,7 @@ const {
   getWorkspacePrivacyContext,
   resolveDesktopSkillHost,
 });
+let agentGraphCoordinator: AgentGraphCoordinator;
 const desktopBackendToolSurfaceDeps = {
   isComputerUseRealModelE2e,
   ensureMcpReady,
@@ -630,6 +635,8 @@ const desktopBackendToolSurfaceDeps = {
   builtinTools,
   toolAvailability,
   planStore,
+  getAgentGraphSupervisorTools: (sessionId: string) =>
+    agentGraphCoordinator.toolsForSession(sessionId),
 };
 // Cursor-overlay teardown assigns a module-scoped `let`, so it stays in main.ts.
 onMainWindowClose = () => computerUseOverlay.destroyAll();
@@ -818,6 +825,14 @@ const runtime = new SessionManager({
   newId: randomUUID,
   now: Date.now,
 });
+agentGraphCoordinator = new AgentGraphCoordinator({
+  sessionStore: store,
+  runStore,
+  runtimeEventStore,
+  controlStore: agentGraphControlStore,
+  runtime,
+  newId: randomUUID,
+});
 let settingsIpc: SettingsIpcHandle | undefined;
 let mcpToolSnapshot = JSON.stringify(mcpManager.tools());
 mcpManager.onChange(() => {
@@ -936,6 +951,10 @@ function registerIpc(): void {
     prepareSkillInvocation: prepareDesktopSkillInvocation,
     invalidateSessionBindings: (sessionId) => botIncoming.invalidateSessionBindings(sessionId),
     clearSkillHost: (sessionId) => desktopSessionSkillHosts.delete(sessionId),
+    stopAgentGraph: async (sessionId) => {
+      const header = await store.readHeader(sessionId);
+      if (!header.subagentParent) await agentGraphCoordinator.stop(sessionId);
+    },
     ensureSessionWorkspaceAvailable,
     createSession: createDesktopSession,
     getReadyConnection,
@@ -1285,6 +1304,8 @@ wireAppLifecycle({
   runtimePersistence,
   mainWindowController,
   runtime,
+  agentGraphCoordinator,
+  agentGraphControlStore,
   streamEvents,
   focusOrCreateMainWindow,
   emitConnectionListChanged,

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -91,6 +91,7 @@ export interface SessionsIpcDeps {
   ) => Promise<PreparedSkillInvocationMessage>;
   invalidateSessionBindings?: (sessionId: string) => void;
   clearSkillHost?: (sessionId: string) => void;
+  stopAgentGraph?: (sessionId: string) => Promise<void>;
   ensureSessionWorkspaceAvailable: (sessionId: string) => Promise<void>;
   createSession: (input: CreateSessionInput) => ReturnType<SessionManager['createSession']>;
   getReadyConnection: (
@@ -190,6 +191,7 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
     prepareSkillInvocation,
     invalidateSessionBindings,
     clearSkillHost,
+    stopAgentGraph,
     ensureSessionWorkspaceAvailable,
     createSession,
     getReadyConnection,
@@ -312,6 +314,7 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
   ipcMain.handle('sessions:stop', async (_event, sessionId: string, input?: { source?: 'stop_button' }) => {
     computerUseOverlay.clearForSession(sessionId);
     computerUseTools.clearSession(sessionId);
+    await stopAgentGraph?.(sessionId);
     await runtime.stopSession(sessionId, normalizeStopSessionInput(input));
     await runtime.interruptActivePlanExecution(sessionId, 'user_stopped_execution').catch(() => null);
     emitSessionsChanged('status-change', sessionId);
@@ -479,6 +482,7 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
     for (const id of await resolveSessionActionIds(runtime, sessionId, options)) {
       computerUseOverlay.clearForSession(id);
       computerUseTools.clearSession(id);
+      await stopAgentGraph?.(id);
       await goalWiring.archiveSession(id, () => runtime.archive(id));
       invalidateSessionBindings?.(id);
       clearSkillHost?.(id);

--- a/packages/core/src/tool-catalog.ts
+++ b/packages/core/src/tool-catalog.ts
@@ -133,6 +133,9 @@ export const MAKA_CATALOG_TOOLS: readonly CatalogToolDef[] = Object.freeze(
     { name: 'agent_swarm' },
     { name: 'agent_list' },
     { name: 'agent_output' },
+    // Host-managed agent graph supervisor surface
+    { name: 'view_agent_graph' },
+    { name: 'update_agent_graph' },
   ].map(freezeTool),
 );
 

--- a/packages/headless/src/__tests__/session-capabilities.test.ts
+++ b/packages/headless/src/__tests__/session-capabilities.test.ts
@@ -144,3 +144,24 @@ test('exposes graph supervisor tools only after the coordinator is bound', async
     graphTools,
   );
 });
+
+test('settles the scoped graph before stopping the root Session', async () => {
+  const order: string[] = [];
+  const bridge = createHeadlessSessionCapabilityBridge();
+  bridge.bind(
+    {
+      stopSession: async () => {
+        order.push('session');
+      },
+    } as unknown as SessionManager,
+    {
+      stop: async (sessionId: string) => {
+        assert.equal(sessionId, 'root-session');
+        order.push('graph');
+      },
+    } as AgentGraphCoordinator,
+  );
+
+  await bridge.settle('root-session');
+  assert.deepEqual(order, ['graph', 'session']);
+});

--- a/packages/headless/src/__tests__/session-capabilities.test.ts
+++ b/packages/headless/src/__tests__/session-capabilities.test.ts
@@ -1,6 +1,12 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
-import type { SessionManager, SpawnChildSessionResult, StopSessionInput } from '@maka/runtime';
+import type {
+  AgentGraphCoordinator,
+  MakaTool,
+  SessionManager,
+  SpawnChildSessionResult,
+  StopSessionInput,
+} from '@maka/runtime';
 import { createHeadlessSessionCapabilityBridge } from '../session-capabilities.js';
 
 const childResult: SpawnChildSessionResult = {
@@ -118,4 +124,23 @@ test('settle preserves the first unrecoverable stop error after one bounded retr
 
   assert.equal(settleResult, firstStopError);
   assert.equal(stopCalls, 2);
+});
+
+test('exposes graph supervisor tools only after the coordinator is bound', async () => {
+  const bridge = createHeadlessSessionCapabilityBridge();
+  await assert.rejects(
+    bridge.capabilities.getAgentGraphSupervisorTools('root-session'),
+    /coordinator is unavailable/,
+  );
+  const graphTools = [{ name: 'view_agent_graph' }] as MakaTool[];
+  bridge.bind({} as SessionManager, {
+    toolsForSession: async (sessionId: string) => {
+      assert.equal(sessionId, 'root-session');
+      return graphTools;
+    },
+  } as AgentGraphCoordinator);
+  assert.equal(
+    await bridge.capabilities.getAgentGraphSupervisorTools('root-session'),
+    graphTools,
+  );
 });

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -10,6 +10,7 @@ import type {
 } from '@maka/core';
 import { isTerminalRuntimeEvent, isThinkingLevel, resolveModelVisionSupport } from '@maka/core';
 import {
+  AgentGraphCoordinator,
   AiSdkBackend,
   BackendRegistry,
   PermissionEngine,
@@ -33,6 +34,7 @@ import {
   createReadImageSnapshotter,
   persistProviderRequestCaptureArtifact,
 } from '@maka/storage';
+import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
 import { registerFakeBackend } from './backends.js';
 import {
   buildHarborCellOutput,
@@ -350,17 +352,35 @@ export async function runHarborCellWithStorage(
       invocation = result;
     },
   });
-  sessionCapabilities.bind(manager);
-
-  const session = await manager.createSession({
-    cwd: input.cwd,
-    backend: input.config.backend,
-    llmConnectionSlug: config.llmConnectionSlug,
-    model: config.model,
-    ...(config.thinkingLevel ? { thinkingLevel: config.thinkingLevel } : {}),
-    permissionMode: 'execute',
-    name: `harbor-cell:${input.config.id}`,
+  const graphControlStore = createAgentGraphControlStore(input.storageRoot);
+  const graphCoordinator = new AgentGraphCoordinator({
+    sessionStore,
+    runStore: agentRunStore,
+    runtimeEventStore,
+    controlStore: graphControlStore,
+    runtime: manager,
+    newId,
   });
+  sessionCapabilities.bind(manager, graphCoordinator);
+
+  const session = await (async () => {
+    try {
+      await graphCoordinator.recover();
+      return await manager.createSession({
+        cwd: input.cwd,
+        backend: input.config.backend,
+        llmConnectionSlug: config.llmConnectionSlug,
+        model: config.model,
+        ...(config.thinkingLevel ? { thinkingLevel: config.thinkingLevel } : {}),
+        permissionMode: 'execute',
+        name: `harbor-cell:${input.config.id}`,
+      });
+    } catch (error) {
+      await graphCoordinator.close();
+      graphControlStore.close();
+      throw error;
+    }
+  })();
 
   let deadlineReached = false;
   let settlementError: unknown;
@@ -429,6 +449,11 @@ export async function runHarborCellWithStorage(
     sendMessageError = error;
   } finally {
     if (settlementTimer) clearTimeout(settlementTimer);
+    try {
+      await graphCoordinator.close();
+    } finally {
+      graphControlStore.close();
+    }
   }
   await settlementAttempt;
   if (settlementError) throw settlementError;

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -352,6 +352,15 @@ export async function runHarborCellWithStorage(
       invocation = result;
     },
   });
+  const session = await manager.createSession({
+    cwd: input.cwd,
+    backend: input.config.backend,
+    llmConnectionSlug: config.llmConnectionSlug,
+    model: config.model,
+    ...(config.thinkingLevel ? { thinkingLevel: config.thinkingLevel } : {}),
+    permissionMode: 'execute',
+    name: `harbor-cell:${input.config.id}`,
+  });
   const graphControlStore = createAgentGraphControlStore(input.storageRoot);
   const graphCoordinator = new AgentGraphCoordinator({
     sessionStore,
@@ -360,27 +369,9 @@ export async function runHarborCellWithStorage(
     controlStore: graphControlStore,
     runtime: manager,
     newId,
+    rootSessionId: session.id,
   });
   sessionCapabilities.bind(manager, graphCoordinator);
-
-  const session = await (async () => {
-    try {
-      await graphCoordinator.recover();
-      return await manager.createSession({
-        cwd: input.cwd,
-        backend: input.config.backend,
-        llmConnectionSlug: config.llmConnectionSlug,
-        model: config.model,
-        ...(config.thinkingLevel ? { thinkingLevel: config.thinkingLevel } : {}),
-        permissionMode: 'execute',
-        name: `harbor-cell:${input.config.id}`,
-      });
-    } catch (error) {
-      await graphCoordinator.close();
-      graphControlStore.close();
-      throw error;
-    }
-  })();
 
   let deadlineReached = false;
   let settlementError: unknown;
@@ -390,10 +381,9 @@ export async function runHarborCellWithStorage(
       ? undefined
       : setTimeout(() => {
           deadlineReached = true;
-          settlementAttempt = manager
-            .stopSession(session.id, {
+          settlementAttempt = sessionCapabilities
+            .settle(session.id, {
               source: 'benchmark_deadline',
-              mode: 'immediate',
             })
             .catch((error) => {
               settlementError = error;
@@ -450,9 +440,20 @@ export async function runHarborCellWithStorage(
   } finally {
     if (settlementTimer) clearTimeout(settlementTimer);
     try {
-      await graphCoordinator.close();
+      if (settlementAttempt) {
+        await settlementAttempt;
+      } else {
+        await sessionCapabilities.settle(
+          session.id,
+          deadlineReached ? { source: 'benchmark_deadline' } : undefined,
+        );
+      }
     } finally {
-      graphControlStore.close();
+      try {
+        await graphCoordinator.close();
+      } finally {
+        graphControlStore.close();
+      }
     }
   }
   await settlementAttempt;

--- a/packages/headless/src/runner.ts
+++ b/packages/headless/src/runner.ts
@@ -1,11 +1,13 @@
 import { randomUUID } from 'node:crypto';
 import type { BackendKind, OrchestrationMode, TurnOrchestration } from '@maka/core';
 import {
+  AgentGraphCoordinator,
   BackendRegistry,
   SessionManager,
   buildChildAgentTools,
   type InvocationResult,
 } from '@maka/runtime';
+import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
 import {
@@ -122,6 +124,10 @@ export async function runExperimentWithStorage(
   const effectiveConfig = { ...config, systemPrompt: prompt.systemPrompt };
 
   const workspace = await prepareWorkspace(task.workspaceDir);
+  let graphCoordinator: AgentGraphCoordinator | undefined;
+  let graphControlStore:
+    | ReturnType<typeof createAgentGraphControlStore>
+    | undefined;
   try {
     const agentWorkspaceDir = deps.realBackendIsolation?.workspaceDir ?? workspace.dir;
     const verifier = normalizeVerifier(task);
@@ -165,7 +171,17 @@ export async function runExperimentWithStorage(
         invocation = result;
       },
     });
-    sessionCapabilities.bind(manager);
+    graphControlStore = createAgentGraphControlStore(deps.storageRoot);
+    graphCoordinator = new AgentGraphCoordinator({
+      sessionStore: storage.executionStores.sessionStore,
+      runStore,
+      runtimeEventStore: storage.executionStores.runtimeEventStore,
+      controlStore: graphControlStore,
+      runtime: manager,
+      newId,
+    });
+    sessionCapabilities.bind(manager, graphCoordinator);
+    await graphCoordinator.recover();
 
     const session = await manager.createSession({
       cwd: agentWorkspaceDir,
@@ -287,6 +303,8 @@ export async function runExperimentWithStorage(
       await scoringWorkspace.cleanup();
     }
   } finally {
+    await graphCoordinator?.close();
+    graphControlStore?.close();
     await workspace.cleanup();
   }
 }

--- a/packages/headless/src/runner.ts
+++ b/packages/headless/src/runner.ts
@@ -171,18 +171,6 @@ export async function runExperimentWithStorage(
         invocation = result;
       },
     });
-    graphControlStore = createAgentGraphControlStore(deps.storageRoot);
-    graphCoordinator = new AgentGraphCoordinator({
-      sessionStore: storage.executionStores.sessionStore,
-      runStore,
-      runtimeEventStore: storage.executionStores.runtimeEventStore,
-      controlStore: graphControlStore,
-      runtime: manager,
-      newId,
-    });
-    sessionCapabilities.bind(manager, graphCoordinator);
-    await graphCoordinator.recover();
-
     const session = await manager.createSession({
       cwd: agentWorkspaceDir,
       backend: config.backend,
@@ -192,6 +180,17 @@ export async function runExperimentWithStorage(
       ...(deps.orchestrationMode ? { orchestrationMode: deps.orchestrationMode } : {}),
       name: `lab:${config.id}:${task.id}`,
     });
+    graphControlStore = createAgentGraphControlStore(deps.storageRoot);
+    graphCoordinator = new AgentGraphCoordinator({
+      sessionStore: storage.executionStores.sessionStore,
+      runStore,
+      runtimeEventStore: storage.executionStores.runtimeEventStore,
+      controlStore: graphControlStore,
+      runtime: manager,
+      newId,
+      rootSessionId: session.id,
+    });
+    sessionCapabilities.bind(manager, graphCoordinator);
 
     const turnId = newId();
     // Drain the turn to completion. The trajectory + status come from the
@@ -213,6 +212,7 @@ export async function runExperimentWithStorage(
         });
       }
     }
+    await sessionCapabilities.settle(session.id);
 
     const status = invocation?.status ?? 'failed';
     const runnerCompleted = status === 'completed';
@@ -303,8 +303,14 @@ export async function runExperimentWithStorage(
       await scoringWorkspace.cleanup();
     }
   } finally {
-    await graphCoordinator?.close();
-    graphControlStore?.close();
-    await workspace.cleanup();
+    try {
+      await graphCoordinator?.close();
+    } finally {
+      try {
+        graphControlStore?.close();
+      } finally {
+        await workspace.cleanup();
+      }
+    }
   }
 }

--- a/packages/headless/src/session-capabilities.ts
+++ b/packages/headless/src/session-capabilities.ts
@@ -85,6 +85,14 @@ export function createHeadlessSessionCapabilityBridge(): {
     },
     async settle(sessionId, input) {
       const operations = [...activeOperations];
+      let graphStopError: unknown;
+      if (graphCoordinator) {
+        try {
+          await graphCoordinator.stop(sessionId);
+        } catch (error) {
+          graphStopError = error;
+        }
+      }
       let firstStopError: unknown;
       try {
         await requireManager().stopSession(sessionId, input);
@@ -102,6 +110,7 @@ export function createHeadlessSessionCapabilityBridge(): {
       const error = results.find(
         (result): result is PromiseRejectedResult => result.status === 'rejected',
       )?.reason;
+      if (graphStopError !== undefined) throw graphStopError;
       if (error !== undefined) throw error;
     },
   };

--- a/packages/headless/src/session-capabilities.ts
+++ b/packages/headless/src/session-capabilities.ts
@@ -1,5 +1,6 @@
 import type {
   AgentListResult,
+  AgentGraphCoordinator,
   AgentOutputInput,
   AgentOutputResult,
   PrepareChildAgentResumeResult,
@@ -11,6 +12,7 @@ import type {
   SpawnChildSessionInput,
   SpawnChildSessionResult,
   StopSessionInput,
+  MakaTool,
 } from '@maka/runtime';
 
 export interface HeadlessSessionCapabilities {
@@ -27,14 +29,16 @@ export interface HeadlessSessionCapabilities {
   retryChildAgent(sessionId: string, input: RetryChildAgentInput): Promise<SpawnChildAgentResult>;
   listChildAgents(sessionId: string): Promise<AgentListResult>;
   readChildAgentOutput(sessionId: string, input: AgentOutputInput): Promise<AgentOutputResult>;
+  getAgentGraphSupervisorTools(sessionId: string): Promise<readonly MakaTool[]>;
 }
 
 export function createHeadlessSessionCapabilityBridge(): {
   capabilities: HeadlessSessionCapabilities;
-  bind(manager: SessionManager): void;
+  bind(manager: SessionManager, graphCoordinator?: AgentGraphCoordinator): void;
   settle(sessionId: string, input?: StopSessionInput): Promise<void>;
 } {
   let manager: SessionManager | undefined;
+  let graphCoordinator: AgentGraphCoordinator | undefined;
   const activeOperations = new Set<Promise<unknown>>();
   const requireManager = (): SessionManager => {
     if (!manager) {
@@ -65,12 +69,19 @@ export function createHeadlessSessionCapabilityBridge(): {
       listChildAgents: async (sessionId) => await requireManager().listChildAgents(sessionId),
       readChildAgentOutput: async (sessionId, input) =>
         await requireManager().readChildAgentOutput(sessionId, input),
+      getAgentGraphSupervisorTools: async (sessionId) => {
+        if (!graphCoordinator) {
+          throw new Error('Headless agent graph coordinator is unavailable');
+        }
+        return graphCoordinator.toolsForSession(sessionId);
+      },
     },
-    bind(nextManager) {
+    bind(nextManager, nextGraphCoordinator) {
       if (manager) {
         throw new Error('Headless session capabilities are already bound');
       }
       manager = nextManager;
+      graphCoordinator = nextGraphCoordinator;
     },
     async settle(sessionId, input) {
       const operations = [...activeOperations];

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -9,6 +9,7 @@ import {
   type StoredMessage,
 } from '@maka/core';
 import {
+  AgentGraphCoordinator,
   AgentRun,
   AiSdkFlow,
   BackendRegistry,
@@ -19,6 +20,7 @@ import {
   type InvocationResult,
   type SessionStore,
 } from '@maka/runtime';
+import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
 import type { Config, ResultRecord, Task } from './contracts.js';
 import { registerFakeBackend } from './backends.js';
 import {
@@ -267,6 +269,10 @@ export async function runTaskOnceWithStorage(
   }
 
   const workspace = await prepareWorkspace(task.workspaceDir);
+  let graphCoordinator: AgentGraphCoordinator | undefined;
+  let graphControlStore:
+    | ReturnType<typeof createAgentGraphControlStore>
+    | undefined;
   try {
     const agentWorkspaceDir = deps.realBackendIsolation?.workspaceDir ?? workspace.dir;
     await appendTaskEvent(taskRunStore, taskRunId, {
@@ -345,7 +351,17 @@ export async function runTaskOnceWithStorage(
       now,
       runtimeSource: 'test',
     });
-    sessionCapabilities.bind(sessionCapabilityManager);
+    graphControlStore = createAgentGraphControlStore(deps.storageRoot);
+    graphCoordinator = new AgentGraphCoordinator({
+      sessionStore,
+      runStore: agentRunStore,
+      runtimeEventStore,
+      controlStore: graphControlStore,
+      runtime: sessionCapabilityManager,
+      newId,
+    });
+    sessionCapabilities.bind(sessionCapabilityManager, graphCoordinator);
+    await graphCoordinator.recover();
 
     const header = await sessionStore.create({
       cwd: agentWorkspaceDir,
@@ -814,6 +830,8 @@ export async function runTaskOnceWithStorage(
       settledByDeadline,
     };
   } finally {
+    await graphCoordinator?.close();
+    graphControlStore?.close();
     await workspace.cleanup();
   }
 }

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -351,18 +351,6 @@ export async function runTaskOnceWithStorage(
       now,
       runtimeSource: 'test',
     });
-    graphControlStore = createAgentGraphControlStore(deps.storageRoot);
-    graphCoordinator = new AgentGraphCoordinator({
-      sessionStore,
-      runStore: agentRunStore,
-      runtimeEventStore,
-      controlStore: graphControlStore,
-      runtime: sessionCapabilityManager,
-      newId,
-    });
-    sessionCapabilities.bind(sessionCapabilityManager, graphCoordinator);
-    await graphCoordinator.recover();
-
     const header = await sessionStore.create({
       cwd: agentWorkspaceDir,
       backend: config.backend,
@@ -375,6 +363,17 @@ export async function runTaskOnceWithStorage(
       ...(deps.orchestrationMode ? { orchestrationMode: deps.orchestrationMode } : {}),
       name: `task:${config.id}:${task.id}`,
     });
+    graphControlStore = createAgentGraphControlStore(deps.storageRoot);
+    graphCoordinator = new AgentGraphCoordinator({
+      sessionStore,
+      runStore: agentRunStore,
+      runtimeEventStore,
+      controlStore: graphControlStore,
+      runtime: sessionCapabilityManager,
+      newId,
+      rootSessionId: header.id,
+    });
+    sessionCapabilities.bind(sessionCapabilityManager, graphCoordinator);
     const turnId = newId();
     const active = createSingleRunActiveSession(backends, sessionStore, now, newId);
     parentActive = active;
@@ -830,9 +829,15 @@ export async function runTaskOnceWithStorage(
       settledByDeadline,
     };
   } finally {
-    await graphCoordinator?.close();
-    graphControlStore?.close();
-    await workspace.cleanup();
+    try {
+      await graphCoordinator?.close();
+    } finally {
+      try {
+        graphControlStore?.close();
+      } finally {
+        await workspace.cleanup();
+      }
+    }
   }
 }
 

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -29,6 +29,7 @@ const allowedServerExternalImports = new Set([
   '@maka/core/runtime-event',
   '@maka/core/session',
   '@maka/runtime',
+  '@maka/storage/agent-graph-control-store',
   '@maka/storage/execution-stores',
   '@maka/storage/runtime-policy-stores',
 ]);

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -1,5 +1,11 @@
 import { randomUUID } from 'node:crypto';
-import { BackendRegistry, FakeBackend, SessionManager } from '@maka/runtime';
+import {
+  AgentGraphCoordinator,
+  BackendRegistry,
+  FakeBackend,
+  SessionManager,
+} from '@maka/runtime';
+import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
 import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
 import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
 import type { RuntimeHostComposition, RuntimeHostCompositionContext } from './host-kernel.js';
@@ -29,6 +35,17 @@ export async function createExecutionRuntimeHostComposition(
       now: Date.now,
       runBackendActivation: (operation) => runtimePolicyActivation.runBackendActivation(operation),
     });
+    const graphControlStore = createAgentGraphControlStore(
+      context.owner.capability.canonicalPath,
+    );
+    const graphCoordinator = new AgentGraphCoordinator({
+      sessionStore: stores.sessionStore,
+      runStore: stores.agentRunStore,
+      runtimeEventStore: stores.runtimeEventStore,
+      controlStore: graphControlStore,
+      runtime: manager,
+      newId: randomUUID,
+    });
     const sessionAdmission = new SessionAdmissionGate();
     const rootAdmissionOwner = new RootAdmissionOwner(stores.agentRunStore);
     const coordinator = new RootTurnCoordinator(
@@ -56,13 +73,19 @@ export async function createExecutionRuntimeHostComposition(
       recover: async () => {
         await coordinator.prepareRecovery();
         await manager.recoverInterruptedSessionsStrict(stores);
+        await graphCoordinator.recover();
         await coordinator.recover();
       },
       close: async () => {
         try {
           await coordinator.close();
         } finally {
-          await stores.sessionStore.close?.();
+          try {
+            await graphCoordinator.close();
+          } finally {
+            graphControlStore.close();
+            await stores.sessionStore.close?.();
+          }
         }
       },
     };

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -59,7 +59,8 @@
     "./stream-graph-admission": "./dist/stream-graph-admission.js",
     "./stream-graph-dispatch": "./dist/stream-graph-dispatch.js",
     "./stream-graph-schedule-reconcile": "./dist/stream-graph-schedule-reconcile.js",
-    "./stream-graph-supervisor-tools": "./dist/stream-graph-supervisor-tools.js"
+    "./stream-graph-supervisor-tools": "./dist/stream-graph-supervisor-tools.js",
+    "./stream-graph-coordinator": "./dist/stream-graph-coordinator.js"
   },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -18,6 +18,7 @@ import type { MakaTool, MakaToolContext } from '../tool-runtime.js';
 import {
   AgentGraphCoordinator,
   agentGraphIdForRootSession,
+  type AgentGraphCoordinatorInput,
 } from '../stream-graph-coordinator.js';
 import { UPDATE_AGENT_GRAPH_TOOL_NAME } from '../stream-graph-supervisor-tools.js';
 
@@ -43,6 +44,9 @@ describe('host-managed agent graph coordinator', () => {
       | undefined;
     let coordinator: AgentGraphCoordinator | undefined;
     let recovered: AgentGraphCoordinator | undefined;
+    let delayedControlStore:
+      | ReturnType<typeof createDelayableControlStore>
+      | undefined;
     try {
       const rootSession = await manager.createSession({
         cwd: root,
@@ -66,11 +70,12 @@ describe('host-managed agent graph coordinator', () => {
       controlStore = createSqliteSessionMetadataStore(
         join(root, SQLITE_SESSION_METADATA_DATABASE_NAME),
       );
+      delayedControlStore = createDelayableControlStore(controlStore);
       coordinator = createCoordinator({
         sessionStore,
         runStore,
         runtimeEventStore,
-        controlStore,
+        controlStore: delayedControlStore.store,
         manager,
       });
       const tools = await coordinator.toolsForSession(rootSession.id);
@@ -134,7 +139,7 @@ describe('host-managed agent graph coordinator', () => {
         sessionStore,
         runStore,
         runtimeEventStore,
-        controlStore,
+        controlStore: delayedControlStore.store,
         manager,
       });
       assert.deepEqual(await recovered.recover(), [rootSession.id]);
@@ -144,6 +149,45 @@ describe('host-managed agent graph coordinator', () => {
       );
       assert.equal((await controlStore.listAgentGraphIntentClaims(graphId)).length, 1);
       assert.equal((await manager.listChildSessions(rootSession.id)).length, 1);
+
+      const recoveredTools = await recovered.toolsForSession(rootSession.id);
+      const delayedUpdate = recoveredTools.find(
+        (tool) => tool.name === UPDATE_AGENT_GRAPH_TOOL_NAME,
+      );
+      assert.ok(delayedUpdate);
+      const gate = delayedControlStore.holdNextCommit();
+      const pendingUpdate = Promise.resolve(
+        delayedUpdate.impl(
+          {
+            add_work: [
+              {
+                agent_id: 'local-read',
+                instruction: 'This pre-stop update must remain paused.',
+                input_ids: [],
+              },
+            ],
+          },
+          toolContext(
+            rootSession.id,
+            sourceRun.runId,
+            sourceTurnId,
+            'tool-call-graph-stop-race',
+          ),
+        ),
+      );
+      await gate.started;
+      try {
+        await recovered.stop(rootSession.id);
+      } finally {
+        gate.release();
+      }
+      await pendingUpdate;
+      await recovered.waitForIdle(rootSession.id);
+      assert.equal(
+        (await controlStore.listAgentGraphOperatorProvisions(graphId)).length,
+        1,
+        'a schedule commit authorized before stop must not restart reconciliation',
+      );
     } finally {
       await coordinator?.close();
       await recovered?.close();
@@ -158,6 +202,97 @@ describe('host-managed agent graph coordinator', () => {
     assert.match(graphId, /^agent_graph_[a-f0-9]{32}$/);
     assert.equal(graphId, agentGraphIdForRootSession('root-session'));
     assert.notEqual(graphId, agentGraphIdForRootSession('other-root'));
+  });
+
+  test('surfaces topology cleanup failures from close', async () => {
+    const topologyFailure = new Error('graph topology unavailable');
+    const coordinator = new AgentGraphCoordinator({
+      sessionStore: {
+        listForRecovery: async () => [],
+        readHeader: async (sessionId: string) =>
+          ({
+            id: sessionId,
+            status: 'active',
+            isArchived: false,
+          }) as never,
+      },
+      runStore: { listSessionRuns: async () => [] },
+      runtimeEventStore: { readImmutableRuntimeEvents: async () => [] },
+      controlStore: {
+        listAgentGraphOperatorProvisions: async () => {
+          throw topologyFailure;
+        },
+      },
+      runtime: {},
+      newId: randomUUID,
+      rootSessionId: 'root-session',
+    } as unknown as AgentGraphCoordinatorInput);
+    await assert.rejects(
+      coordinator.toolsForSession('another-root'),
+      /scoped to root Session root-session/,
+    );
+    await coordinator.toolsForSession('root-session');
+    await assert.rejects(
+      coordinator.close(),
+      (error: unknown) =>
+        error === topologyFailure ||
+        (error instanceof AggregateError &&
+          error.errors.some(
+            (failure) =>
+              failure === topologyFailure ||
+              (failure instanceof AggregateError && failure.errors.includes(topologyFailure)),
+      )),
+    );
+  });
+
+  test('attempts every operator stop and surfaces all close failures', async () => {
+    const graphId = agentGraphIdForRootSession('root-session');
+    const stopped: string[] = [];
+    const coordinator = new AgentGraphCoordinator({
+      sessionStore: {
+        listForRecovery: async () => [],
+        readHeader: async (sessionId: string) =>
+          ({
+            id: sessionId,
+            status: 'active',
+            isArchived: false,
+          }) as never,
+      },
+      runStore: { listSessionRuns: async () => [] },
+      runtimeEventStore: { readImmutableRuntimeEvents: async () => [] },
+      controlStore: {
+        listAgentGraphOperatorProvisions: async () =>
+          ['a', 'b'].map((suffix, index) => ({
+            graphId,
+            provisionId: `provision-${suffix}`,
+            operatorId: `operator-${suffix}`,
+            targetSessionId: `child-${suffix}`,
+            provisionedAt: index,
+            edges: [],
+          })),
+      },
+      runtime: {
+        stopSession: async (sessionId: string) => {
+          stopped.push(sessionId);
+          throw new Error(`cannot stop ${sessionId}`);
+        },
+      },
+      newId: randomUUID,
+      rootSessionId: 'root-session',
+    } as unknown as AgentGraphCoordinatorInput);
+    await coordinator.toolsForSession('root-session');
+    await assert.rejects(
+      coordinator.close(),
+      (error: unknown) =>
+        error instanceof AggregateError &&
+        (error.errors.length === 2 ||
+          error.errors.some(
+            (failure) =>
+              failure instanceof AggregateError &&
+              failure.errors.length === 2,
+          )),
+    );
+    assert.deepEqual(stopped.sort(), ['child-a', 'child-b']);
   });
 });
 
@@ -176,6 +311,53 @@ function createCoordinator(input: {
   });
 }
 
+function createDelayableControlStore(
+  store: ReturnType<typeof createSqliteSessionMetadataStore>,
+): {
+  store: ReturnType<typeof createSqliteSessionMetadataStore>;
+  holdNextCommit(): { started: Promise<void>; release(): void };
+} {
+  let gate:
+    | {
+        started(): void;
+        release: Promise<void>;
+      }
+    | undefined;
+  const proxy = new Proxy(store, {
+    get(target, property) {
+      if (property === 'commitAgentGraphScheduleUpdate') {
+        return async (...args: Parameters<typeof target.commitAgentGraphScheduleUpdate>) => {
+          const activeGate = gate;
+          gate = undefined;
+          if (activeGate) {
+            activeGate.started();
+            await activeGate.release;
+          }
+          return target.commitAgentGraphScheduleUpdate(...args);
+        };
+      }
+      const value = Reflect.get(target, property, target);
+      return typeof value === 'function' ? value.bind(target) : value;
+    },
+  });
+  return {
+    store: proxy,
+    holdNextCommit() {
+      if (gate) throw new Error('A delayed graph schedule commit is already pending');
+      let markStarted!: () => void;
+      let release!: () => void;
+      const started = new Promise<void>((resolve) => {
+        markStarted = resolve;
+      });
+      const released = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      gate = { started: markStarted, release: released };
+      return { started, release };
+    },
+  };
+}
+
 function localReadTools(): MakaTool[] {
   return ['Read', 'Glob', 'Grep'].map((name) => ({
     name,
@@ -192,12 +374,13 @@ function toolContext(
   sessionId: string,
   runId: string,
   turnId: string,
+  toolCallId = 'tool-call-graph-start',
 ): MakaToolContext {
   return {
     sessionId,
     runId,
     turnId,
-    toolCallId: 'tool-call-graph-start',
+    toolCallId,
     cwd: '/workspace',
     abortSignal: new AbortController().signal,
     emitOutput() {},

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -1,0 +1,205 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { randomUUID } from 'node:crypto';
+import { z } from 'zod';
+import {
+  createAgentRunStore,
+  createRuntimeEventStore,
+  createSessionStore,
+  createSqliteSessionMetadataStore,
+  SQLITE_SESSION_METADATA_DATABASE_NAME,
+} from '@maka/storage';
+import { FakeBackend } from '../fake-backend.js';
+import { BackendRegistry, SessionManager } from '../session-manager.js';
+import type { MakaTool, MakaToolContext } from '../tool-runtime.js';
+import {
+  AgentGraphCoordinator,
+  agentGraphIdForRootSession,
+} from '../stream-graph-coordinator.js';
+import { UPDATE_AGENT_GRAPH_TOOL_NAME } from '../stream-graph-supervisor-tools.js';
+
+describe('host-managed agent graph coordinator', () => {
+  test('boots an empty graph from agent work and recovers it without duplicate topology', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-graph-coordinator-'));
+    const sessionStore = createSessionStore(root);
+    const runStore = createAgentRunStore(root);
+    const runtimeEventStore = createRuntimeEventStore(root);
+    const backends = new BackendRegistry();
+    backends.register('fake', (context) => new FakeBackend(context));
+    const manager = new SessionManager({
+      store: sessionStore,
+      runStore,
+      runtimeEventStore,
+      backends,
+      childTools: localReadTools(),
+      newId: randomUUID,
+      now: Date.now,
+    });
+    let controlStore:
+      | ReturnType<typeof createSqliteSessionMetadataStore>
+      | undefined;
+    let coordinator: AgentGraphCoordinator | undefined;
+    let recovered: AgentGraphCoordinator | undefined;
+    try {
+      const rootSession = await manager.createSession({
+        cwd: root,
+        backend: 'fake',
+        llmConnectionSlug: 'fake',
+        permissionMode: 'ask',
+        name: 'Graph supervisor',
+      });
+      const sourceTurnId = randomUUID();
+      for await (const _event of manager.sendMessage(rootSession.id, {
+        turnId: sourceTurnId,
+        text: 'Prepare graph work.',
+      })) {
+        // Drain the ordinary root turn so its source AgentRun is durable.
+      }
+      const sourceRun = (await runStore.listSessionRuns(rootSession.id)).find(
+        (run) => run.turnId === sourceTurnId,
+      );
+      assert.ok(sourceRun);
+
+      controlStore = createSqliteSessionMetadataStore(
+        join(root, SQLITE_SESSION_METADATA_DATABASE_NAME),
+      );
+      coordinator = createCoordinator({
+        sessionStore,
+        runStore,
+        runtimeEventStore,
+        controlStore,
+        manager,
+      });
+      const tools = await coordinator.toolsForSession(rootSession.id);
+      const update = tools.find((tool) => tool.name === UPDATE_AGENT_GRAPH_TOOL_NAME);
+      assert.ok(update);
+      const graphId = agentGraphIdForRootSession(rootSession.id);
+      await assert.rejects(
+        async () =>
+          await update.impl(
+            {
+              add_work: [
+                {
+                  agent_id: 'local-read',
+                  instruction: 'This request must not become durable.',
+                  input_ids: [],
+                },
+              ],
+            },
+            toolContext('different-root', sourceRun.runId, sourceTurnId),
+          ),
+        /not authorized/,
+      );
+      assert.equal(
+        (await controlStore.listAgentGraphScheduleUpdates(graphId)).length,
+        0,
+      );
+      await update.impl(
+        {
+          add_work: [
+            {
+              agent_id: 'local-read',
+              instruction: 'Inspect the repository and report one concrete finding.',
+              input_ids: [],
+            },
+          ],
+        },
+        toolContext(rootSession.id, sourceRun.runId, sourceTurnId),
+      );
+      await coordinator.waitForIdle(rootSession.id);
+
+      const firstProvisions =
+        await controlStore.listAgentGraphOperatorProvisions(graphId);
+      assert.equal(firstProvisions.length, 1);
+      assert.equal(firstProvisions[0]?.agentId, 'local-read');
+      assert.equal((await controlStore.listAgentGraphIntentClaims(graphId)).length, 1);
+      assert.equal((await coordinator.observe(rootSession.id)).projection.operators.length, 1);
+      const childSessions = await manager.listChildSessions(rootSession.id);
+      assert.equal(childSessions.length, 1);
+      assert.equal(
+        childSessions[0]?.subagentParent?.graph?.operatorId,
+        firstProvisions[0]?.operatorId,
+      );
+      await assert.rejects(
+        coordinator.toolsForSession(childSessions[0]!.id),
+        /only to root Sessions/,
+      );
+
+      await coordinator.close();
+      coordinator = undefined;
+      recovered = createCoordinator({
+        sessionStore,
+        runStore,
+        runtimeEventStore,
+        controlStore,
+        manager,
+      });
+      assert.deepEqual(await recovered.recover(), [rootSession.id]);
+      assert.equal(
+        (await controlStore.listAgentGraphOperatorProvisions(graphId)).length,
+        1,
+      );
+      assert.equal((await controlStore.listAgentGraphIntentClaims(graphId)).length, 1);
+      assert.equal((await manager.listChildSessions(rootSession.id)).length, 1);
+    } finally {
+      await coordinator?.close();
+      await recovered?.close();
+      controlStore?.close();
+      await sessionStore.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('derives stable graph identity from the root Session', async () => {
+    const graphId = agentGraphIdForRootSession('root-session');
+    assert.match(graphId, /^agent_graph_[a-f0-9]{32}$/);
+    assert.equal(graphId, agentGraphIdForRootSession('root-session'));
+    assert.notEqual(graphId, agentGraphIdForRootSession('other-root'));
+  });
+});
+
+function createCoordinator(input: {
+  sessionStore: ReturnType<typeof createSessionStore>;
+  runStore: ReturnType<typeof createAgentRunStore>;
+  runtimeEventStore: ReturnType<typeof createRuntimeEventStore>;
+  controlStore: ReturnType<typeof createSqliteSessionMetadataStore>;
+  manager: SessionManager;
+}): AgentGraphCoordinator {
+  return new AgentGraphCoordinator({
+    ...input,
+    runtime: input.manager,
+    newId: randomUUID,
+    maxNewActivations: 4,
+  });
+}
+
+function localReadTools(): MakaTool[] {
+  return ['Read', 'Glob', 'Grep'].map((name) => ({
+    name,
+    displayName: name,
+    description: `${name} fixture`,
+    parameters: z.object({}).passthrough(),
+    permissionRequired: false,
+    categoryHint: 'read',
+    impl: async () => ({ ok: true }),
+  }));
+}
+
+function toolContext(
+  sessionId: string,
+  runId: string,
+  turnId: string,
+): MakaToolContext {
+  return {
+    sessionId,
+    runId,
+    turnId,
+    toolCallId: 'tool-call-graph-start',
+    cwd: '/workspace',
+    abortSignal: new AbortController().signal,
+    emitOutput() {},
+  };
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -132,6 +132,16 @@ export type {
   ViewAgentGraphToolInput,
   ViewAgentGraphToolResult,
 } from './stream-graph-supervisor-tools.js';
+export {
+  AgentGraphCoordinator,
+  agentGraphIdForRootSession,
+  topologyFromProvisions,
+} from './stream-graph-coordinator.js';
+export type {
+  AgentGraphCoordinatorInput,
+  AgentGraphCoordinatorRuntime,
+  AgentGraphCoordinatorSessionStore,
+} from './stream-graph-coordinator.js';
 export type {
   AgentGraphAllSettledReadinessPolicy,
   AgentGraphMapReadinessPolicy,

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -1,0 +1,476 @@
+import type {
+  AgentGraphIntentClaim,
+  AgentGraphScheduleControlStore,
+  AgentGraphScheduleUpdate,
+  AgentGraphOperatorProvision,
+  AgentRunStore,
+  RuntimeEventStore,
+  SessionHeader,
+} from '@maka/core';
+import { decodeAgentGraphIntentClaim } from '@maka/core';
+import type { MakaTool } from './tool-runtime.js';
+import type { SessionManager } from './session-manager.js';
+import {
+  readCommittedAgentGraphProjection,
+  type AgentGraphRecord,
+} from './stream-graph-projection.js';
+import {
+  buildAgentGraphReadinessSnapshot,
+  type AgentGraphReadinessPolicy,
+} from './stream-graph-readiness.js';
+import type {
+  AgentGraphSupervisorObservation,
+  AgentGraphSupervisorObserver,
+} from './stream-graph-dispatch.js';
+import {
+  reconcileAgentGraphSchedule,
+  type AgentGraphScheduleReconciliationResult,
+  type RenderAgentGraphScheduledWorkPromptInput,
+} from './stream-graph-schedule-reconcile.js';
+import { buildAgentGraphSupervisorTools } from './stream-graph-supervisor-tools.js';
+import type { AgentGraphTraceTopology } from './stream-graph-trace.js';
+import { stableHash } from './request-shape.js';
+
+const DEFAULT_MAX_NEW_ACTIVATIONS = 8;
+
+export interface AgentGraphCoordinatorSessionStore {
+  listForRecovery(): Promise<SessionHeader[]>;
+  readHeader(sessionId: string): Promise<SessionHeader>;
+}
+
+export interface AgentGraphCoordinatorRuntime {
+  provisionAgentGraphOperator: SessionManager['provisionAgentGraphOperator'];
+  runClaimedAgentGraphIntent: SessionManager['runClaimedAgentGraphIntent'];
+  stopSession: SessionManager['stopSession'];
+}
+
+export interface AgentGraphCoordinatorInput {
+  sessionStore: AgentGraphCoordinatorSessionStore;
+  runStore: Pick<AgentRunStore, 'listSessionRuns'>;
+  runtimeEventStore: Pick<RuntimeEventStore, 'readImmutableRuntimeEvents'>;
+  controlStore: AgentGraphScheduleControlStore;
+  runtime: AgentGraphCoordinatorRuntime;
+  newId: () => string;
+  maxNewActivations?: number;
+  resolvePolicies?(
+    topology: AgentGraphTraceTopology,
+    observation: Pick<AgentGraphSupervisorObservation, 'projection' | 'claims'>,
+  ): readonly AgentGraphReadinessPolicy[] | Promise<readonly AgentGraphReadinessPolicy[]>;
+  renderPrompt?(
+    input: RenderAgentGraphScheduledWorkPromptInput,
+  ): string | Promise<string>;
+  supervisor?: AgentGraphSupervisorObserver;
+  onReconciliation?(
+    rootSessionId: string,
+    result: AgentGraphScheduleReconciliationResult,
+  ): void | Promise<void>;
+  onError?(rootSessionId: string, error: unknown): void | Promise<void>;
+}
+
+interface GraphDriver {
+  rootSessionId: string;
+  graphId: string;
+  requested: boolean;
+  paused: boolean;
+  closed: boolean;
+  abortController?: AbortController;
+  task?: Promise<void>;
+  lastResult?: AgentGraphScheduleReconciliationResult;
+  lastError?: unknown;
+}
+
+/**
+ * Process-local execution authority for Session-backed agent graphs.
+ *
+ * Durable schedule/topology/claim rows and Runtime facts remain the recovery
+ * authority. This coordinator owns only single-flight wakeups and cancellation
+ * handles, so recreating it after a process restart is safe.
+ */
+export class AgentGraphCoordinator {
+  readonly #input: AgentGraphCoordinatorInput;
+  readonly #drivers = new Map<string, GraphDriver>();
+  #closed = false;
+
+  constructor(input: AgentGraphCoordinatorInput) {
+    const maxNewActivations = input.maxNewActivations ?? DEFAULT_MAX_NEW_ACTIVATIONS;
+    if (!Number.isSafeInteger(maxNewActivations) || maxNewActivations < 0) {
+      throw new Error('Agent graph coordinator activation limit must be a non-negative integer');
+    }
+    this.#input = { ...input, maxNewActivations };
+  }
+
+  /**
+   * Return the supervisor-only tools for an ordinary root Session.
+   *
+   * Child Sessions are graph operators and never receive this control surface.
+   */
+  async toolsForSession(rootSessionId: string): Promise<MakaTool[]> {
+    await this.#assertRootSupervisor(rootSessionId);
+    const driver = this.#driver(rootSessionId);
+    return buildAgentGraphSupervisorTools({
+      graphId: driver.graphId,
+      scheduleStore: this.#input.controlStore,
+      observeGraph: () => this.observe(rootSessionId),
+      authorizeScheduleUpdate: (request) => {
+        if (
+          request.graphId !== driver.graphId ||
+          request.source.sessionId !== rootSessionId
+        ) {
+          throw new Error(
+            `Agent graph schedule update is not authorized for root Session ${rootSessionId}`,
+          );
+        }
+      },
+      onScheduleUpdateCommitted: (update) => {
+        this.#assertScheduleOwnedByRoot(update, rootSessionId, driver.graphId);
+        this.wake(rootSessionId);
+      },
+    });
+  }
+
+  /** Wake reconciliation without making the caller part of the data path. */
+  wake(rootSessionId: string): void {
+    if (this.#closed) return;
+    const driver = this.#driver(rootSessionId);
+    driver.paused = false;
+    driver.requested = true;
+    if (!driver.task) {
+      driver.task = this.#drive(driver).finally(() => {
+        driver.task = undefined;
+        if (driver.requested && !driver.closed && !this.#closed) this.wake(rootSessionId);
+      });
+    }
+  }
+
+  /** Reconcile now and surface any host-level failure to explicit callers. */
+  async reconcile(rootSessionId: string): Promise<AgentGraphScheduleReconciliationResult> {
+    await this.#assertRootSupervisor(rootSessionId);
+    const driver = this.#driver(rootSessionId);
+    driver.lastError = undefined;
+    this.wake(rootSessionId);
+    await this.waitForIdle(rootSessionId);
+    if (driver.lastError !== undefined) throw driver.lastError;
+    if (!driver.lastResult) {
+      throw new Error(`Agent graph ${driver.graphId} produced no reconciliation result`);
+    }
+    return driver.lastResult;
+  }
+
+  async waitForIdle(rootSessionId: string): Promise<void> {
+    const driver = this.#driver(rootSessionId);
+    while (driver.task) await driver.task;
+  }
+
+  /**
+   * Rebuild every durable, non-archived root graph that has schedule intent.
+   *
+   * Empty ordinary Sessions are skipped; no separate in-memory registry is
+   * required for restart recovery.
+   */
+  async recover(): Promise<string[]> {
+    const recovered: string[] = [];
+    for (const header of await this.#input.sessionStore.listForRecovery()) {
+      if (header.subagentParent || header.isArchived || header.status === 'archived') continue;
+      const graphId = agentGraphIdForRootSession(header.id);
+      const updates = await this.#input.controlStore.listAgentGraphScheduleUpdates(graphId);
+      if (updates.length === 0) continue;
+      updates.forEach((update) => this.#assertScheduleOwnedByRoot(update, header.id, graphId));
+      await this.reconcile(header.id);
+      recovered.push(header.id);
+    }
+    return recovered;
+  }
+
+  async observe(rootSessionId: string): Promise<AgentGraphSupervisorObservation> {
+    await this.#assertRootSupervisor(rootSessionId);
+    const graphId = agentGraphIdForRootSession(rootSessionId);
+    const topology = await this.#readTopology(graphId);
+    return this.#observeTopology(topology);
+  }
+
+  async #observeTopology(
+    topology: AgentGraphTraceTopology,
+  ): Promise<AgentGraphSupervisorObservation> {
+    const graphId = topology.graphId;
+    const [projection, listedClaims] = await Promise.all([
+      readCommittedAgentGraphProjection({
+        graphId,
+        operators: topology.operators,
+        runStore: this.#input.runStore,
+        runtimeEventStore: this.#input.runtimeEventStore,
+      }),
+      this.#input.controlStore.listAgentGraphIntentClaims(graphId),
+    ]);
+    const claims = listedClaims
+      .map(decodeAgentGraphIntentClaim)
+      .sort((a, b) => a.intentId.localeCompare(b.intentId) || a.claimId.localeCompare(b.claimId));
+    assertUniqueClaims(graphId, claims);
+    const policies =
+      (await this.#input.resolvePolicies?.(topology, { projection, claims })) ?? [];
+    return {
+      projection,
+      readiness: buildAgentGraphReadinessSnapshot({
+        topology,
+        records: projection.records,
+        policies,
+      }),
+      claims,
+    };
+  }
+
+  /**
+   * Stop current graph execution. Durable schedule facts are retained, so a
+   * later supervisor update can wake the same graph again.
+   */
+  async stop(rootSessionId: string): Promise<void> {
+    await this.#assertRootSupervisor(rootSessionId);
+    const driver = this.#driver(rootSessionId);
+    driver.paused = true;
+    driver.requested = false;
+    driver.abortController?.abort();
+    const topology = await this.#readTopology(driver.graphId);
+    const stopped = await Promise.allSettled(
+      topology.operators.map((operator) =>
+        this.#input.runtime.stopSession(operator.sessionId, { source: 'graph_supervisor' }),
+      ),
+    );
+    await this.waitForIdle(rootSessionId);
+    const failure = stopped.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected',
+    );
+    if (failure) throw failure.reason;
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) return;
+    this.#closed = true;
+    for (const driver of this.#drivers.values()) {
+      driver.closed = true;
+      driver.abortController?.abort();
+    }
+    await Promise.allSettled(
+      [...this.#drivers.values()].map(async (driver) => {
+        const topology = await this.#readTopology(driver.graphId);
+        await Promise.allSettled(
+          topology.operators.map((operator) =>
+            this.#input.runtime.stopSession(operator.sessionId, {
+              source: 'graph_supervisor',
+            }),
+          ),
+        );
+        if (driver.task) await driver.task;
+      }),
+    );
+  }
+
+  async #drive(driver: GraphDriver): Promise<void> {
+    while (driver.requested && !driver.paused && !driver.closed && !this.#closed) {
+      driver.requested = false;
+      driver.lastError = undefined;
+      const abortController = new AbortController();
+      driver.abortController = abortController;
+      try {
+        const result = await this.#reconcileOnce(driver, abortController.signal);
+        driver.lastResult = result;
+        await notify(this.#input.onReconciliation, driver.rootSessionId, result);
+      } catch (error) {
+        driver.lastError = error;
+        await notify(this.#input.onError, driver.rootSessionId, error);
+      } finally {
+        if (driver.abortController === abortController) driver.abortController = undefined;
+      }
+    }
+  }
+
+  async #reconcileOnce(
+    driver: GraphDriver,
+    abortSignal: AbortSignal,
+  ): Promise<AgentGraphScheduleReconciliationResult> {
+    await this.#assertRootSupervisor(driver.rootSessionId);
+    const updates = await this.#input.controlStore.listAgentGraphScheduleUpdates(driver.graphId);
+    updates.forEach((update) =>
+      this.#assertScheduleOwnedByRoot(update, driver.rootSessionId, driver.graphId),
+    );
+    return reconcileAgentGraphSchedule({
+      topology: { graphId: driver.graphId, operators: [], edges: [] },
+      controlStore: this.#input.controlStore,
+      executor: this.#input.runtime,
+      stopController: this.#input.runtime,
+      provisionOperator: (input) => this.#input.runtime.provisionAgentGraphOperator(input),
+      newId: this.#input.newId,
+      maxNewActivations: this.#input.maxNewActivations!,
+      observeGraph: (topology) => this.#observeTopology(topology),
+      renderPrompt: this.#input.renderPrompt ?? renderDefaultScheduledWorkPrompt,
+      abortSignal,
+      supervisor: {
+        onObservation: this.#input.supervisor?.onObservation,
+        onActivationReady: this.#input.supervisor?.onActivationReady,
+        onRuntimeEvent: (event) => {
+          if (!driver.paused) driver.requested = true;
+          void notify(this.#input.supervisor?.onRuntimeEvent, event);
+        },
+      },
+    });
+  }
+
+  async #readTopology(graphId: string): Promise<AgentGraphTraceTopology> {
+    return topologyFromProvisions(
+      graphId,
+      await this.#input.controlStore.listAgentGraphOperatorProvisions(graphId),
+    );
+  }
+
+  async #assertRootSupervisor(rootSessionId: string): Promise<SessionHeader> {
+    if (this.#closed) throw new Error('Agent graph coordinator is closed');
+    const header = await this.#input.sessionStore.readHeader(rootSessionId);
+    if (header.id !== rootSessionId) {
+      throw new Error(`Session store returned ${header.id}, expected ${rootSessionId}`);
+    }
+    if (header.subagentParent) {
+      throw new Error('Agent graph supervisor tools are available only to root Sessions');
+    }
+    if (header.isArchived || header.status === 'archived') {
+      throw new Error('Archived Sessions cannot supervise an agent graph');
+    }
+    return header;
+  }
+
+  #assertScheduleOwnedByRoot(
+    update: AgentGraphScheduleUpdate,
+    rootSessionId: string,
+    graphId: string,
+  ): void {
+    if (update.graphId !== graphId || update.source.sessionId !== rootSessionId) {
+      throw new Error(
+        `Agent graph schedule ${update.updateId} is not owned by root Session ${rootSessionId}`,
+      );
+    }
+  }
+
+  #driver(rootSessionId: string): GraphDriver {
+    const graphId = agentGraphIdForRootSession(rootSessionId);
+    const existing = this.#drivers.get(graphId);
+    if (existing) {
+      if (existing.rootSessionId !== rootSessionId) {
+        throw new Error(`Agent graph ${graphId} is already bound to another root Session`);
+      }
+      return existing;
+    }
+    const created: GraphDriver = {
+      rootSessionId,
+      graphId,
+      requested: false,
+      paused: false,
+      closed: false,
+    };
+    this.#drivers.set(graphId, created);
+    return created;
+  }
+}
+
+export function agentGraphIdForRootSession(rootSessionId: string): string {
+  const normalized = rootSessionId.trim();
+  if (!normalized || normalized !== rootSessionId) {
+    throw new Error('Agent graph root Session id must be a non-empty canonical identity');
+  }
+  const suffix = stableHash({
+    schemaVersion: 1,
+    rootSessionId,
+  }).slice('sha256:'.length, 'sha256:'.length + 32);
+  return `agent_graph_${suffix}`;
+}
+
+export function topologyFromProvisions(
+  graphId: string,
+  provisions: readonly AgentGraphOperatorProvision[],
+): AgentGraphTraceTopology {
+  const operators = new Map<string, { operatorId: string; sessionId: string }>();
+  const sessions = new Map<string, string>();
+  const edges = new Map<
+    string,
+    { edgeId: string; fromOperatorId: string; toOperatorId: string }
+  >();
+  for (const provision of [...provisions].sort(
+    (a, b) => a.provisionedAt - b.provisionedAt || a.provisionId.localeCompare(b.provisionId),
+  )) {
+    if (provision.graphId !== graphId) {
+      throw new Error(`Graph provision ${provision.provisionId} belongs to ${provision.graphId}`);
+    }
+    const existingOperator = operators.get(provision.operatorId);
+    if (
+      existingOperator &&
+      existingOperator.sessionId !== provision.targetSessionId
+    ) {
+      throw new Error(`Graph operator ${provision.operatorId} has conflicting Session bindings`);
+    }
+    const existingSession = sessions.get(provision.targetSessionId);
+    if (existingSession && existingSession !== provision.operatorId) {
+      throw new Error(`Graph Session ${provision.targetSessionId} has multiple operators`);
+    }
+    operators.set(provision.operatorId, {
+      operatorId: provision.operatorId,
+      sessionId: provision.targetSessionId,
+    });
+    sessions.set(provision.targetSessionId, provision.operatorId);
+    for (const edge of provision.edges) {
+      const existingEdge = edges.get(edge.edgeId);
+      if (
+        existingEdge &&
+        (existingEdge.fromOperatorId !== edge.fromOperatorId ||
+          existingEdge.toOperatorId !== edge.toOperatorId)
+      ) {
+        throw new Error(`Graph edge ${edge.edgeId} has conflicting endpoints`);
+      }
+      edges.set(edge.edgeId, { ...edge });
+    }
+  }
+  return {
+    graphId,
+    operators: [...operators.values()].sort((a, b) => a.operatorId.localeCompare(b.operatorId)),
+    edges: [...edges.values()].sort((a, b) => a.edgeId.localeCompare(b.edgeId)),
+  };
+}
+
+function renderDefaultScheduledWorkPrompt(
+  input: RenderAgentGraphScheduledWorkPromptInput,
+): string {
+  if (input.inputRecords.length === 0) return input.work.instruction;
+  const references = input.inputRecords.map((record) => graphRecordReference(record));
+  return `${input.work.instruction}\n\nCommitted graph input references:\n${JSON.stringify(references, null, 2)}`;
+}
+
+function graphRecordReference(record: AgentGraphRecord): object {
+  return {
+    recordId: record.recordId,
+    operatorId: record.operatorId,
+    activationId: record.activationId,
+    facets: [...record.facets],
+    source: { ...record.source },
+  };
+}
+
+function assertUniqueClaims(graphId: string, claims: readonly AgentGraphIntentClaim[]): void {
+  const intentIds = new Set<string>();
+  for (const claim of claims) {
+    if (claim.graphId !== graphId) {
+      throw new Error(`Graph claim ${claim.claimId} belongs to ${claim.graphId}`);
+    }
+    if (intentIds.has(claim.intentId)) {
+      throw new Error(`Graph ${graphId} contains duplicate claim intent ${claim.intentId}`);
+    }
+    intentIds.add(claim.intentId);
+  }
+}
+
+function notify<T extends unknown[]>(
+  callback: ((...args: T) => void | Promise<void>) | undefined,
+  ...args: T
+): Promise<void> {
+  if (!callback) return Promise.resolve();
+  return Promise.resolve()
+    .then(() => callback(...args))
+    .then(
+      () => {},
+      () => {},
+    );
+}

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -51,6 +51,8 @@ export interface AgentGraphCoordinatorInput {
   controlStore: AgentGraphScheduleControlStore;
   runtime: AgentGraphCoordinatorRuntime;
   newId: () => string;
+  /** Restrict an attempt-local coordinator to exactly one root Session graph. */
+  rootSessionId?: string;
   maxNewActivations?: number;
   resolvePolicies?(
     topology: AgentGraphTraceTopology,
@@ -72,9 +74,12 @@ interface GraphDriver {
   graphId: string;
   requested: boolean;
   paused: boolean;
+  stopping: boolean;
+  stopGeneration: number;
   closed: boolean;
   abortController?: AbortController;
   task?: Promise<void>;
+  stopTask?: Promise<void>;
   lastResult?: AgentGraphScheduleReconciliationResult;
   lastError?: unknown;
 }
@@ -96,6 +101,12 @@ export class AgentGraphCoordinator {
     if (!Number.isSafeInteger(maxNewActivations) || maxNewActivations < 0) {
       throw new Error('Agent graph coordinator activation limit must be a non-negative integer');
     }
+    if (
+      input.rootSessionId !== undefined &&
+      (!input.rootSessionId.trim() || input.rootSessionId.trim() !== input.rootSessionId)
+    ) {
+      throw new Error('Agent graph coordinator root Session scope must be a canonical identity');
+    }
     this.#input = { ...input, maxNewActivations };
   }
 
@@ -111,7 +122,7 @@ export class AgentGraphCoordinator {
       graphId: driver.graphId,
       scheduleStore: this.#input.controlStore,
       observeGraph: () => this.observe(rootSessionId),
-      authorizeScheduleUpdate: (request) => {
+      authorizeScheduleUpdate: (request): ScheduleWakeFence => {
         if (
           request.graphId !== driver.graphId ||
           request.source.sessionId !== rootSessionId
@@ -120,10 +131,14 @@ export class AgentGraphCoordinator {
             `Agent graph schedule update is not authorized for root Session ${rootSessionId}`,
           );
         }
+        return {
+          stopGeneration: driver.stopGeneration,
+          mayResumePaused: driver.paused && !driver.stopping,
+        };
       },
-      onScheduleUpdateCommitted: (update) => {
+      onScheduleUpdateCommitted: (update, authorization) => {
         this.#assertScheduleOwnedByRoot(update, rootSessionId, driver.graphId);
-        this.wake(rootSessionId);
+        this.#wakeFromSchedule(driver, decodeScheduleWakeFence(authorization));
       },
     });
   }
@@ -132,14 +147,9 @@ export class AgentGraphCoordinator {
   wake(rootSessionId: string): void {
     if (this.#closed) return;
     const driver = this.#driver(rootSessionId);
+    if (driver.stopping) return;
     driver.paused = false;
-    driver.requested = true;
-    if (!driver.task) {
-      driver.task = this.#drive(driver).finally(() => {
-        driver.task = undefined;
-        if (driver.requested && !driver.closed && !this.#closed) this.wake(rootSessionId);
-      });
-    }
+    this.#requestDrive(driver);
   }
 
   /** Reconcile now and surface any host-level failure to explicit callers. */
@@ -170,6 +180,7 @@ export class AgentGraphCoordinator {
   async recover(): Promise<string[]> {
     const recovered: string[] = [];
     for (const header of await this.#input.sessionStore.listForRecovery()) {
+      if (this.#input.rootSessionId && header.id !== this.#input.rootSessionId) continue;
       if (header.subagentParent || header.isArchived || header.status === 'archived') continue;
       const graphId = agentGraphIdForRootSession(header.id);
       const updates = await this.#input.controlStore.listAgentGraphScheduleUpdates(graphId);
@@ -225,20 +236,38 @@ export class AgentGraphCoordinator {
   async stop(rootSessionId: string): Promise<void> {
     await this.#assertRootSupervisor(rootSessionId);
     const driver = this.#driver(rootSessionId);
+    if (driver.stopTask) return driver.stopTask;
+    const stopTask = this.#stopDriver(driver).finally(() => {
+      if (driver.stopTask === stopTask) driver.stopTask = undefined;
+    });
+    driver.stopTask = stopTask;
+    return stopTask;
+  }
+
+  async #stopDriver(driver: GraphDriver): Promise<void> {
+    driver.stopGeneration += 1;
     driver.paused = true;
+    driver.stopping = true;
     driver.requested = false;
     driver.abortController?.abort();
-    const topology = await this.#readTopology(driver.graphId);
-    const stopped = await Promise.allSettled(
-      topology.operators.map((operator) =>
-        this.#input.runtime.stopSession(operator.sessionId, { source: 'graph_supervisor' }),
-      ),
-    );
-    await this.waitForIdle(rootSessionId);
-    const failure = stopped.find(
-      (result): result is PromiseRejectedResult => result.status === 'rejected',
-    );
-    if (failure) throw failure.reason;
+    const failures: unknown[] = [];
+    const activeTask = driver.task;
+    try {
+      await this.#stopKnownOperators(driver.graphId, failures);
+      if (activeTask) {
+        try {
+          await activeTask;
+        } catch (error) {
+          failures.push(error);
+        }
+        // Re-read after the driver settles so an operator provisioned in the
+        // stop race cannot escape the first topology snapshot.
+        await this.#stopKnownOperators(driver.graphId, failures);
+      }
+    } finally {
+      driver.stopping = false;
+    }
+    throwCollectedFailures(`Failed to stop agent graph ${driver.graphId}`, failures);
   }
 
   async close(): Promise<void> {
@@ -248,18 +277,33 @@ export class AgentGraphCoordinator {
       driver.closed = true;
       driver.abortController?.abort();
     }
-    await Promise.allSettled(
+    const results = await Promise.allSettled(
       [...this.#drivers.values()].map(async (driver) => {
-        const topology = await this.#readTopology(driver.graphId);
-        await Promise.allSettled(
-          topology.operators.map((operator) =>
-            this.#input.runtime.stopSession(operator.sessionId, {
-              source: 'graph_supervisor',
-            }),
-          ),
-        );
-        if (driver.task) await driver.task;
+        const failures: unknown[] = [];
+        if (driver.stopTask) {
+          try {
+            await driver.stopTask;
+          } catch (error) {
+            failures.push(error);
+          }
+        }
+        const activeTask = driver.task;
+        await this.#stopKnownOperators(driver.graphId, failures);
+        if (activeTask) {
+          try {
+            await activeTask;
+          } catch (error) {
+            failures.push(error);
+          }
+          await this.#stopKnownOperators(driver.graphId, failures);
+        }
+        if (driver.lastError !== undefined) failures.push(driver.lastError);
+        throwCollectedFailures(`Failed to close agent graph ${driver.graphId}`, failures);
       }),
+    );
+    throwCollectedFailures(
+      'Failed to close one or more agent graph coordinators',
+      results.flatMap((result) => (result.status === 'rejected' ? [result.reason] : [])),
     );
   }
 
@@ -274,8 +318,10 @@ export class AgentGraphCoordinator {
         driver.lastResult = result;
         await notify(this.#input.onReconciliation, driver.rootSessionId, result);
       } catch (error) {
-        driver.lastError = error;
-        await notify(this.#input.onError, driver.rootSessionId, error);
+        if (!abortController.signal.aborted) {
+          driver.lastError = error;
+          await notify(this.#input.onError, driver.rootSessionId, error);
+        }
       } finally {
         if (driver.abortController === abortController) driver.abortController = undefined;
       }
@@ -322,6 +368,11 @@ export class AgentGraphCoordinator {
 
   async #assertRootSupervisor(rootSessionId: string): Promise<SessionHeader> {
     if (this.#closed) throw new Error('Agent graph coordinator is closed');
+    if (this.#input.rootSessionId && rootSessionId !== this.#input.rootSessionId) {
+      throw new Error(
+        `Agent graph coordinator is scoped to root Session ${this.#input.rootSessionId}`,
+      );
+    }
     const header = await this.#input.sessionStore.readHeader(rootSessionId);
     if (header.id !== rootSessionId) {
       throw new Error(`Session store returned ${header.id}, expected ${rootSessionId}`);
@@ -348,6 +399,11 @@ export class AgentGraphCoordinator {
   }
 
   #driver(rootSessionId: string): GraphDriver {
+    if (this.#input.rootSessionId && rootSessionId !== this.#input.rootSessionId) {
+      throw new Error(
+        `Agent graph coordinator is scoped to root Session ${this.#input.rootSessionId}`,
+      );
+    }
     const graphId = agentGraphIdForRootSession(rootSessionId);
     const existing = this.#drivers.get(graphId);
     if (existing) {
@@ -361,11 +417,79 @@ export class AgentGraphCoordinator {
       graphId,
       requested: false,
       paused: false,
+      stopping: false,
+      stopGeneration: 0,
       closed: false,
     };
     this.#drivers.set(graphId, created);
     return created;
   }
+
+  #wakeFromSchedule(driver: GraphDriver, fence: ScheduleWakeFence): void {
+    if (
+      this.#closed ||
+      driver.closed ||
+      driver.stopping ||
+      fence.stopGeneration !== driver.stopGeneration ||
+      (driver.paused && !fence.mayResumePaused)
+    ) {
+      return;
+    }
+    driver.paused = false;
+    this.#requestDrive(driver);
+  }
+
+  #requestDrive(driver: GraphDriver): void {
+    driver.requested = true;
+    if (driver.task) return;
+    driver.task = this.#drive(driver).finally(() => {
+      driver.task = undefined;
+      if (driver.requested && !driver.paused && !driver.closed && !this.#closed) {
+        this.#requestDrive(driver);
+      }
+    });
+  }
+
+  async #stopKnownOperators(graphId: string, failures: unknown[]): Promise<void> {
+    let topology: AgentGraphTraceTopology;
+    try {
+      topology = await this.#readTopology(graphId);
+    } catch (error) {
+      failures.push(error);
+      return;
+    }
+    const stopped = await Promise.allSettled(
+      topology.operators.map((operator) =>
+        this.#input.runtime.stopSession(operator.sessionId, { source: 'graph_supervisor' }),
+      ),
+    );
+    failures.push(
+      ...stopped.flatMap((result) => (result.status === 'rejected' ? [result.reason] : [])),
+    );
+  }
+}
+
+interface ScheduleWakeFence {
+  stopGeneration: number;
+  mayResumePaused: boolean;
+}
+
+function decodeScheduleWakeFence(value: unknown): ScheduleWakeFence {
+  if (
+    !value ||
+    typeof value !== 'object' ||
+    !Number.isSafeInteger((value as ScheduleWakeFence).stopGeneration) ||
+    typeof (value as ScheduleWakeFence).mayResumePaused !== 'boolean'
+  ) {
+    throw new Error('Agent graph schedule wake fence is invalid');
+  }
+  return value as ScheduleWakeFence;
+}
+
+function throwCollectedFailures(message: string, failures: readonly unknown[]): void {
+  if (failures.length === 0) return;
+  if (failures.length === 1) throw failures[0];
+  throw new AggregateError(failures, message);
 }
 
 export function agentGraphIdForRootSession(rootSessionId: string): string {

--- a/packages/runtime/src/stream-graph-schedule-reconcile.ts
+++ b/packages/runtime/src/stream-graph-schedule-reconcile.ts
@@ -141,9 +141,6 @@ export async function reconcileAgentGraphSchedule(
   if (!Number.isSafeInteger(input.maxNewActivations) || input.maxNewActivations < 0) {
     throw new Error('Agent graph maxNewActivations must be a non-negative safe integer');
   }
-  if (input.topology.operators.length === 0) {
-    throw new Error('Agent graph schedule reconciliation requires at least one operator');
-  }
 
   const processedIntentIds = new Set<string>();
   const dispatches: AgentGraphDispatchedActivation[] = [];

--- a/packages/runtime/src/stream-graph-supervisor-tools.ts
+++ b/packages/runtime/src/stream-graph-supervisor-tools.ts
@@ -251,6 +251,19 @@ export interface BuildAgentGraphSupervisorToolsInput {
   graphId: string;
   scheduleStore: AgentGraphScheduleStore;
   observeGraph(): Promise<AgentGraphSupervisorObservation>;
+  /** Host ownership check performed before append-only schedule admission. */
+  authorizeScheduleUpdate?(
+    request: AgentGraphScheduleUpdateRequest,
+  ): void | Promise<void>;
+  /**
+   * Host lifecycle hook invoked after the schedule update is durable.
+   *
+   * The tool does not execute graph work itself. A host-owned coordinator can
+   * use this notification to wake its single reconciliation driver.
+   */
+  onScheduleUpdateCommitted?(
+    update: AgentGraphScheduleUpdate,
+  ): void | Promise<void>;
 }
 
 /**
@@ -303,10 +316,12 @@ export function buildAgentGraphSupervisorTools(
         input: toolInput,
         context,
       });
+      await input.authorizeScheduleUpdate?.(request);
       if (request.finish) {
         assertFinishResultsCommitted(graphId, request.finish.resultIds, await input.observeGraph());
       }
-      await input.scheduleStore.commitAgentGraphScheduleUpdate(request);
+      const committed = await input.scheduleStore.commitAgentGraphScheduleUpdate(request);
+      await input.onScheduleUpdateCommitted?.(committed.update);
       const view = await readToolGraphView(
         input.scheduleStore,
         graphId,

--- a/packages/runtime/src/stream-graph-supervisor-tools.ts
+++ b/packages/runtime/src/stream-graph-supervisor-tools.ts
@@ -254,7 +254,7 @@ export interface BuildAgentGraphSupervisorToolsInput {
   /** Host ownership check performed before append-only schedule admission. */
   authorizeScheduleUpdate?(
     request: AgentGraphScheduleUpdateRequest,
-  ): void | Promise<void>;
+  ): unknown | Promise<unknown>;
   /**
    * Host lifecycle hook invoked after the schedule update is durable.
    *
@@ -263,6 +263,7 @@ export interface BuildAgentGraphSupervisorToolsInput {
    */
   onScheduleUpdateCommitted?(
     update: AgentGraphScheduleUpdate,
+    authorization: unknown,
   ): void | Promise<void>;
 }
 
@@ -316,12 +317,12 @@ export function buildAgentGraphSupervisorTools(
         input: toolInput,
         context,
       });
-      await input.authorizeScheduleUpdate?.(request);
+      const authorization = await input.authorizeScheduleUpdate?.(request);
       if (request.finish) {
         assertFinishResultsCommitted(graphId, request.finish.resultIds, await input.observeGraph());
       }
       const committed = await input.scheduleStore.commitAgentGraphScheduleUpdate(request);
-      await input.onScheduleUpdateCommitted?.(committed.update);
+      await input.onScheduleUpdateCommitted?.(committed.update, authorization);
       const view = await readToolGraphView(
         input.scheduleStore,
         graphId,

--- a/packages/runtime/src/stream-graph-trace.ts
+++ b/packages/runtime/src/stream-graph-trace.ts
@@ -236,9 +236,6 @@ function fingerprintTopology(graphId: string, topology: ValidatedTopology): stri
 
 function validateTopology(topology: AgentGraphTraceTopology): ValidatedTopology {
   if (!topology.graphId.trim()) throw new Error('Trace graph id must not be empty');
-  if (topology.operators.length === 0) {
-    throw new Error(`Trace graph ${topology.graphId} must contain at least one operator`);
-  }
 
   const operatorsById = new Map<string, AgentGraphOperatorBinding>();
   const operatorBySession = new Map<string, string>();

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -8,6 +8,7 @@
   "exports": {
     ".": "./dist/index.js",
     "./execution-stores": "./dist/execution-stores.js",
+    "./agent-graph-control-store": "./dist/agent-graph-control-store.js",
     "./root-authority": "./dist/root-authority.js",
     "./runtime-policy-stores": "./dist/runtime-policy-stores.js",
     "./workspace-identity": "./dist/workspace-identity.js",

--- a/packages/storage/src/agent-graph-control-store.ts
+++ b/packages/storage/src/agent-graph-control-store.ts
@@ -1,0 +1,19 @@
+import { join } from 'node:path';
+import { SQLITE_SESSION_METADATA_DATABASE_NAME } from './session-store.js';
+import {
+  createSqliteSessionMetadataStore,
+  type SqliteSessionMetadataStore,
+} from './sqlite-session-metadata-store.js';
+
+/**
+ * Open the SQLite metadata control plane used by one host-owned agent graph
+ * coordinator. Session JSONL remains the transcript authority; graph
+ * schedule/topology/claim relationships are queried from SQLite.
+ */
+export function createAgentGraphControlStore(
+  workspaceRoot: string,
+): SqliteSessionMetadataStore {
+  return createSqliteSessionMetadataStore(
+    join(workspaceRoot, SQLITE_SESSION_METADATA_DATABASE_NAME),
+  );
+}


### PR DESCRIPTION
## Summary

This is PR 2 of the narrowed delivery path for #1341, stacked on #1468.

It turns the exported graph scheduling primitives into a host-owned, recoverable graph lifecycle bound to an ordinary root supervisor Session:

- add `AgentGraphCoordinator` as the process-local single-flight execution authority for one deterministic root-Session graph identity;
- keep durable schedule updates, operator provisions, claims, Session/AgentRun facts, and committed Runtime events as recovery authority in the SQLite metadata control plane;
- allow an empty graph bootstrap so the first scheduled `agent_id` can materialize the first child Session/operator through the existing reconciler;
- expose `view_agent_graph` and `update_agent_graph` only to existing root Sessions, never to graph child Sessions or new-session previews;
- authorize schedule ownership before durable append, then wake reconciliation only after the schedule update commits;
- wake another reconcile pass from relevant Runtime activity while keeping the main-agent supervisor beside the data path rather than in its approval path;
- recover and close graph lifecycles in Desktop main, runtime-host, and all Headless execution entry points;
- integrate Desktop stop/archive with coordinator cancellation and retain durable intent for later continuation;
- use reference-only committed graph record inputs in the default scheduled prompt.

The coordinator intentionally keeps only wake/single-flight/cancellation state in memory. Restart recovery derives the graph from a stable root-Session graph id plus durable SQLite schedule/provision/claim rows and Runtime facts, so it does not require a second in-memory registry.

## Boundaries

This PR does **not** add the client graph read model/API, Graph Mode toggle, Desktop graph card, resource permits/fairness, arbitrary topology rewrites, or full graph visualization. Those remain the next slices described in #1341.

The runtime-host wiring owns recovery and shutdown here; its renderer/remote observation boundary belongs to the next Graph read-model PR.

## Validation

- workspace typecheck: pass
- Desktop full test suite: 2,846 passed
- runtime-host full test suite: 89 passed
- coordinator end-to-end test: 2 passed (empty bootstrap, root-only authorization, child Session materialization, restart recovery without duplicate provision/claim/child)
- Headless full test suite: 1,310 passed, 4 skipped; 2 pre-existing macOS system-Python 3.9 Harbor adapter failures remain in the Kimi/Codex asyncio wrappers and are outside this patch

Refs #1341

<details>
<summary>中文说明</summary>

## 概要

这是 #1341 收窄交付路径中的 PR 2，堆叠在 #1468 之上。

本 PR 把已经导出的 Graph 调度 primitives 组合成一个由 host 持有、绑定普通 root supervisor Session、并且可恢复的 Graph 生命周期：

- 新增 `AgentGraphCoordinator`，作为确定性 root-Session graph identity 的进程内 single-flight 执行权威；
- durable schedule update、operator provision、claim、Session/AgentRun fact 与 committed Runtime event 继续作为恢复权威，并存放在 SQLite metadata control plane；
- 允许从空 topology 启动，使第一个 `agent_id` schedule 可以通过现有 reconciler 创建第一个 child Session/operator；
- `view_agent_graph` / `update_agent_graph` 只暴露给已有 root Session，不暴露给 graph child Session 或新会话 preview；
- schedule ownership 在 durable append 之前校验，只有提交成功后才唤醒 reconcile；
- 相关 Runtime activity 会请求下一轮 reconcile，但 main-agent supervisor 始终站在数据路径旁边，而不是成为 record delivery 的审批门；
- Desktop main、runtime-host 和全部 Headless 执行入口都接入 recover/close 生命周期；
- Desktop stop/archive 会先停止 coordinator，同时保留 durable intent，供之后继续；
- 默认 scheduled prompt 只传递 committed graph record 的引用，不复制 payload。

Coordinator 内存中只保留 wake、single-flight 与 cancellation handle。重启后通过稳定的 root-Session graph id、SQLite 中的 schedule/provision/claim 关系以及 Runtime facts 恢复，不依赖第二份内存 registry。

## 边界

本 PR 不包含 client Graph read model/API、Graph Mode toggle、Desktop graph card、resource permit/fairness、任意 topology 改写或完整 Graph 可视化。这些仍按 #1341 中的后续切片推进。

runtime-host 在这一刀只负责 Graph recovery/shutdown 的执行权威；renderer/remote 观察边界属于下一 PR 的 Graph read model。

## 验证

- 全工作区 typecheck：通过
- Desktop 全量测试：2,846 通过
- runtime-host 全量测试：89 通过
- coordinator 端到端测试：2 通过（空图启动、root-only 授权、child Session 物化、重启恢复且不重复 provision/claim/child）
- Headless 全量测试：1,310 通过、4 skipped；另有 2 个既有的 macOS 系统 Python 3.9 Harbor adapter 失败，来自 Kimi/Codex asyncio wrapper，与本改动无关

关联 #1341

</details>
