### PR TITLE
fix(desktop): stack settings form rows on narrow cards — General and Appearance

### DIFF
--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -563,3 +563,55 @@ test('remote access prioritizes a configured channel that needs attention', asyn
     () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
   ).toBe(true);
 });
+
+/**
+ * #1362 — THE row-wrapping decision for the settings form-row pages. The
+ * `.settingsRows` card is an inline-size query container; below 460px of
+ * CARD width (not viewport width — the content column is narrower than the
+ * window by the nav sidebar) label/control rows stack vertically, and the
+ * proxy form grids collapse to one column. Switch rows are the exception:
+ * a ~40px switch always fits beside its label. Locks both directions so
+ * neither the narrow stacking nor the wide two-column layout regresses.
+ */
+test('general form rows stack at the window floor and stay two-column when wide', async ({ window: page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const settings = await openSettings(page);
+  await settings.getByRole('button', { name: '通用', exact: true }).click();
+
+  const displayNameRow = settings
+    .locator('.settingsFormRow')
+    .filter({ has: page.getByLabel('显示名称') });
+  const incognitoRow = settings.locator('.settingsFormRow').filter({ hasText: '隐身模式' });
+  const modelRow = settings.locator('.settingsRow').filter({ hasText: '默认模型' });
+  const rowTrackCount = () =>
+    modelRow.evaluate(
+      (element) => getComputedStyle(element).gridTemplateColumns.trim().split(/\s+/).length,
+    );
+
+  // Wide: unchanged layout — label and control share one line.
+  await expect(displayNameRow).toHaveCSS('flex-direction', 'row');
+  await expect.poll(rowTrackCount).toBe(2);
+
+  // Window floor: rows stack; switch rows keep the control beside the label.
+  await page.setViewportSize({ width: 480, height: 900 });
+  await expect(displayNameRow).toHaveCSS('flex-direction', 'column');
+  await expect(incognitoRow).toHaveCSS('flex-direction', 'row');
+  await expect.poll(rowTrackCount).toBe(1);
+
+  // The proxy sub-form only renders behind the switch; its 3-column grid
+  // (150px + 84px floors) was the widest thing on the page and must fold
+  // to one column on a narrow card.
+  await settings.getByRole('switch', { name: '启用代理服务器' }).click();
+  const proxyGrid = settings.locator('.settingsFormGridProxy');
+  await expect(proxyGrid).toBeVisible();
+  await expect.poll(
+    () =>
+      proxyGrid.evaluate(
+        (element) => getComputedStyle(element).gridTemplateColumns.trim().split(/\s+/).length,
+      ),
+  ).toBe(1);
+
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+});

--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -598,19 +598,54 @@ test('general form rows stack at the window floor and stay two-column when wide'
   await expect(incognitoRow).toHaveCSS('flex-direction', 'row');
   await expect.poll(rowTrackCount).toBe(1);
 
-  // The proxy sub-form only renders behind the switch; its 3-column grid
-  // (150px + 84px floors) was the widest thing on the page and must fold
-  // to one column on a narrow card.
+  // The proxy sub-form only renders behind the switches: the 3-column
+  // protocol/host/port grid (150px + 84px floors) was the widest thing on
+  // the page, and the auth username/password grid is the plain 2-column
+  // `.settingsFormGrid` — both must fold to one column on a narrow card
+  // (they are separate CSS selectors; either could regress alone).
   await settings.getByRole('switch', { name: '启用代理服务器' }).click();
-  const proxyGrid = settings.locator('.settingsFormGridProxy');
-  await expect(proxyGrid).toBeVisible();
+  await settings.getByRole('switch', { name: '启用代理认证' }).click();
+  const gridTrackCounts = () =>
+    settings
+      .locator('.settingsFormGrid')
+      .evaluateAll((elements) =>
+        elements.map(
+          (element) => getComputedStyle(element).gridTemplateColumns.trim().split(/\s+/).length,
+        ),
+      );
+  await expect(settings.locator('.settingsFormGridProxy')).toBeVisible();
+  // Both grids rendered (proxy + auth), each folded to one column.
+  await expect.poll(gridTrackCounts).toEqual([1, 1]);
+
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+});
+
+/**
+ * #1362 review follow-up: the user-facing result of the palette-label wrap —
+ * at the window floor the full name stays readable (the old nowrap+ellipsis
+ * cut "Catppuccin Mocha" to "Catppucc…" with no way to recover it).
+ */
+test('appearance palette names stay fully visible at the window floor', async ({
+  window: page,
+}) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  const settings = await openSettings(page);
+  await settings.getByRole('button', { name: '外观', exact: true }).click();
+
+  const label = settings
+    .locator('.settingsThemeLabel strong')
+    .filter({ hasText: 'Catppuccin Mocha' });
+  await expect(label).toBeVisible();
+  // Wrapping, not clipping: nothing hides past the box in either axis.
   await expect.poll(
     () =>
-      proxyGrid.evaluate(
-        (element) => getComputedStyle(element).gridTemplateColumns.trim().split(/\s+/).length,
-      ),
-  ).toBe(1);
-
+      label.evaluate((element) => ({
+        horizontallyContained: element.scrollWidth <= element.clientWidth,
+        verticallyContained: element.scrollHeight <= element.clientHeight,
+      })),
+  ).toEqual({ horizontallyContained: true, verticallyContained: true });
   await expect.poll(
     () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
   ).toBe(true);

--- a/apps/desktop/src/main/__tests__/responsive-breakpoint-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/responsive-breakpoint-contract.test.ts
@@ -41,6 +41,15 @@ import {
  *  breakpoint must be added here (and the value used in the CSS). */
 const ALLOWED_BREAKPOINT_PX = new Set([620, 720, 760, 820, 900, 980, 990, 1100]);
 
+/** #1362: same governance for @container width queries. Container queries
+ *  respond to an element's own width instead of the viewport (the settings
+ *  content column is narrower than the window by the nav sidebar, so
+ *  viewport breakpoints systematically misfire there — the #1361/#1364
+ *  lesson). The app keeps ONE container width: 460px, shared by the
+ *  permission dialog and the settings rows card. A second value must be a
+ *  conscious decision here, exactly like the @media whitelist above. */
+const ALLOWED_CONTAINER_PX = new Set([460]);
+
 // --- @media breakpoint whitelist ------------------------------------------
 
 /** Match `@media (max-width: Npx)` / `@media (min-width: Npx)` and capture N.
@@ -54,6 +63,25 @@ function findBreakpointOffenders(css: string, label: string): string[] {
     const px = Number(m[2]);
     if (!ALLOWED_BREAKPOINT_PX.has(px)) {
       offenders.push(`${label}: ${m[0]} [${px}px not in the breakpoint whitelist ${[...ALLOWED_BREAKPOINT_PX].join('/')}px]`);
+    }
+  }
+  return offenders;
+}
+
+// --- @container width whitelist --------------------------------------------
+
+/** Match `@container [name] (max-width: Npx)` / `(min-width: Npx)` and
+ *  capture N. Non-width container features (e.g. scroll-state) are out of
+ *  scope. */
+const CONTAINER_WIDTH_RE = /@container\s+[^{(]*\(\s*(max|min)-width\s*:\s*(\d+(?:\.\d+)?)px\s*\)/g;
+
+function findContainerWidthOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+  for (const m of stripped.matchAll(CONTAINER_WIDTH_RE)) {
+    const px = Number(m[2]);
+    if (!ALLOWED_CONTAINER_PX.has(px)) {
+      offenders.push(`${label}: ${m[0]} [${px}px not in the container-width whitelist ${[...ALLOWED_CONTAINER_PX].join('/')}px]`);
     }
   }
   return offenders;
@@ -89,6 +117,12 @@ describe('PR-RESPONSIVE-BREAKPOINT-CONVERGE-0 contract', () => {
     assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
   });
 
+  it('@container (max/min-width: Npx) uses only the whitelisted container widths (no ad-hoc Npx)', async () => {
+    const css = await readAllRendererCss();
+    const offenders = findContainerWidthOffenders(css, 'renderer CSS');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
   it('--maka-chat-measure is pinned to 680px exactly-once in maka-tokens.css', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
     assertCustomPropPinnedOnce(tokens, '--maka-chat-measure', '680px', 'maka-tokens.css');
@@ -121,6 +155,15 @@ describe('responsive breakpoint whitelist negative cases', () => {
   it('does not flag prefers-reduced-motion / prefers-color-scheme (not width breakpoints)', () => {
     const css = '@media (prefers-reduced-motion: reduce) { … } @media (prefers-color-scheme: dark) { … }';
     assert.deepEqual(findBreakpointOffenders(css, 't'), [], 'prefers-* queries are out of scope');
+  });
+
+  it('findContainerWidthOffenders flags a value outside the whitelist and spares 460 + non-width features', () => {
+    const ok = '@container (max-width: 460px) { … } @container settings-rows (max-width: 460px) { … }';
+    assert.deepEqual(findContainerWidthOffenders(ok, 't'), [], '460px (unnamed and named) must pass');
+    const bad = '@container (max-width: 540px) { … } @container card (min-width: 400px) { … }';
+    assert.ok(findContainerWidthOffenders(bad, 't').length === 2, '540px and 400px must fail (not whitelisted)');
+    const scrollState = '@container not scroll-state(scrollable: bottom) { … }';
+    assert.deepEqual(findContainerWidthOffenders(scrollState, 't'), [], 'scroll-state containers are not width breakpoints');
   });
 
   it('findChatMeasureOffenders flags a bare 680px width but spares var(--maka-chat-measure) and a 680px height', () => {

--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -72,9 +72,15 @@ describe('Settings form accessibility labels', () => {
     const providerCatalogBadge = styles.match(/\.providerCatalogBadge\s*\{[\s\S]*?\}/)?.[0] ?? '';
     const modelChoiceList = styles.match(/\.providerModelChoiceList\s*\{[\s\S]*?\}/)?.[0] ?? '';
     const modelChoiceScroll = styles.match(/\.providerModelChoiceScroll\s*\{[\s\S]*?\}/)?.[0] ?? '';
-    const settingsRow = styles.match(/\.settingsRow\s*\{[\s\S]*?\}/g)?.at(-1) ?? '';
+    // #1362: TWO .settingsRow rules exist now — the base label/value grid
+    // and the narrow-card stacking override inside the @container block.
+    // The base rule is the one that declares its own display.
+    const settingsRowRules = styles.match(/\.settingsRow\s*\{[\s\S]*?\}/g) ?? [];
+    const settingsRow = settingsRowRules.find((rule) => /display:\s*grid;/.test(rule)) ?? '';
+    const settingsRowStacked = settingsRowRules.find((rule) => !/display:/.test(rule)) ?? '';
     const settingsRowValue = styles.match(/\.settingsRow > span\s*\{[\s\S]*?\}/)?.[0] ?? '';
-    const settingsRowTitle = styles.match(/\.settingsRow strong\s*\{[\s\S]*?\}/)?.[0] ?? '';
+    // #1362: the title tier is one comma-grouped rule for both row kinds.
+    const settingsRowTitle = styles.match(/\.settingsRow strong,\s*\.settingsFormRow strong\s*\{[\s\S]*?\}/)?.[0] ?? '';
 
     assert.match(connectionRow, /border-radius:\s*var\(--radius-surface\);/, 'Settings connection cards should use reference implementation rounded-lg geometry');
     assert.match(connectionRow, /box-shadow:\s*0 1px 3px oklch\(from var\(--foreground\) l c h \/ 0\.03\);/, 'Settings connection cards should use the near-flat card shadow (P-SHADOW: foreground-derived, not pure-black)');
@@ -101,7 +107,15 @@ describe('Settings form accessibility labels', () => {
     assert.match(settingsRow, /grid-template-columns:\s*minmax\(150px,\s*0\.36fr\)\s+minmax\(0,\s*1fr\);/, 'Settings rows need a protected label column and shrinkable value column');
     assert.match(settingsRowValue, /overflow-wrap:\s*anywhere;/, 'Long Settings values such as workspace paths should wrap in the value column');
     assert.match(settingsRowValue, /text-align:\s*right;/, 'Short Settings values should keep the existing right-aligned summary rhythm');
-    assert.match(settingsRowTitle, /white-space:\s*nowrap;/, 'Settings row labels must not collapse to one Chinese character per line');
+    // #1362: the old `white-space: nowrap` title pin protected labels from
+    // collapsing to one Chinese character per line, but it did so by letting
+    // long titles BLEED over the value column instead. The protection is now
+    // structural — the 150px label floor above, plus the narrow-card override
+    // that stacks the row so the label gets the full card width. Titles wrap
+    // as a last resort instead of overflowing the card.
+    assert.match(settingsRowStacked, /grid-template-columns:\s*minmax\(0,\s*1fr\);/, 'Narrow cards must stack Settings rows so labels keep a full-width line, not char-per-line slivers');
+    assert.match(settingsRowTitle, /overflow-wrap:\s*anywhere;/, 'Settings row titles need a last-resort break for unbreakable runs on a squeezed label column');
+    assert.doesNotMatch(settingsRowTitle, /white-space:\s*nowrap;/, 'Settings row titles must wrap inside their column instead of bleeding over the value column');
   });
 
   it('keeps migrated Settings text fields and action buttons on shared UI primitives', async () => {

--- a/apps/desktop/src/main/__tests__/settings-theme-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-theme-contract.test.ts
@@ -196,10 +196,20 @@ describe('Settings theme page contract', () => {
       /settingsThemePreviewPane[\s\S]{0,260}oklch\([^)]*75\)/,
       'Theme preview tiles must not keep the old warm parchment hue after the gray-shell baseline',
     );
+    // #1362: palette names WRAP inside their cards instead of truncating —
+    // at the 480px window floor the old nowrap+ellipsis cut "Catppuccin
+    // Mocha" to "Catppucc…" with no way to recover the name. Scoped to the
+    // rule body ([^}]*, not [\s\S]*): the previous pattern crossed the
+    // closing brace and matched declarations in later, unrelated rules.
     assert.match(
       css,
-      /\.settingsThemeLabel strong \{[\s\S]*overflow:\s*hidden;[\s\S]*text-overflow:\s*ellipsis;[\s\S]*white-space:\s*nowrap;/,
-      'Long palette names must stay inside their option cards',
+      /\.settingsThemeLabel strong \{[^}]*overflow-wrap:\s*anywhere;/,
+      'Long palette names must wrap inside their option cards',
+    );
+    assert.doesNotMatch(
+      css,
+      /\.settingsThemeLabel strong \{[^}]*text-overflow:\s*ellipsis;/,
+      'Palette names must not regress to nowrap+ellipsis truncation (#1362)',
     );
   });
 });

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -506,6 +506,13 @@
 .settingsStructuredPage {
   display: grid;
   align-content: start;
+  /* #1362: explicit column. The implicit `auto` track sizes to the widest
+     child's max-content, so one wide child (a scrollable <pre>, a long mono
+     path) silently widened EVERY card on the page past the content column —
+     the same propagation #1364 fixed locally on .settingsUsagePage. With
+     minmax(0, 1fr) the track is the content column, and the .settingsRows
+     query containers below actually see narrow widths. */
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--space-4);
   background: transparent;
 }

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -25,6 +25,13 @@
   gap: 0;
   border: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.08);
   overflow: hidden;
+  /* #1362: the card is the query container for the row-stacking rules at the
+     bottom of this file. Rows respond to the width the card actually has —
+     the settings content column is narrower than the window by the nav
+     sidebar, so viewport @media blocks systematically fire too late/early
+     (the #1361 540px and #1364 900px lessons). Same mechanism as the
+     permission dialog's inline-size container in permission-dialog.css. */
+  container: settings-rows / inline-size;
 }
 
 /* Label/value row: title + hint stack on the left, value or a single
@@ -85,6 +92,13 @@
   transition: background var(--duration-base) var(--ease-out-strong);
 }
 
+/* #1362: the label stack is a flex item; without min-width:0 its intrinsic
+   min-content (the widest unbreakable run) sets the row's minimum and the
+   card clips at narrow widths instead of letting the text wrap. */
+.settingsFormRow > div:first-child {
+  min-width: 0;
+}
+
 /* Detail audit round 3: vertical variant for full-width controls (the
    personalization tone textarea) living inside the shared card rows. */
 .settingsFormRow[data-orient="vertical"] {
@@ -107,7 +121,10 @@
 
 /* === typography ========================================================= */
 
-/* Row titles — one tier for BOTH row kinds. */
+/* Row titles — one tier for BOTH row kinds. No `white-space: nowrap` here:
+   the label column has a fixed 150px minimum, so a nowrap title longer than
+   the column bled into the value column instead of wrapping (#1362; the
+   nowrap never affected titles that fit). */
 .settingsRow strong,
 .settingsFormRow strong {
   display: block;
@@ -115,10 +132,10 @@
   font-size: var(--font-size-heading);
   font-weight: var(--font-weight-medium);
   line-height: var(--leading-snug);
-}
-
-.settingsRow strong {
-  white-space: nowrap;
+  /* Last resort for unbreakable runs (product names like "Claude", env-var
+     tokens) on a squeezed label column: break inside the word rather than
+     bleed past the card. No effect while the title fits. */
+  overflow-wrap: anywhere;
 }
 
 /* Field labels — one tier BELOW row titles so the proxy grid's 代理协议 /
@@ -142,6 +159,8 @@
   color: var(--muted-foreground);
   font-size: var(--font-size-base);
   line-height: var(--leading-normal);
+  /* Hints carry paths and URLs — same last-resort break as the titles. */
+  overflow-wrap: anywhere;
 }
 
 .settingsRow > span {
@@ -197,6 +216,28 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-3);
+}
+
+/* #1362: non-row children of a rows card — the proxy sub-form's grids,
+   bypass field, info alert, and action row — sat flush against the card
+   edge while every sibling row is inset 24px. One horizontal inset for
+   everything inside a card. */
+.settingsRows > .settingsFormGrid,
+.settingsRows > .settingsField,
+.settingsRows > .settingsActionRow,
+.settingsRows > [data-slot="alert"] {
+  margin: var(--space-4) var(--space-6);
+}
+
+/* The Alert primitive carries `w-full`; with horizontal margins that is
+   wider than the card. The stretched grid-item width (auto) is the right
+   one here. */
+.settingsRows > [data-slot="alert"] {
+  width: auto;
+}
+
+.settingsRows > .settingsFormGrid + .settingsFormRow {
+  border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);
 }
 
 .settingsFormGridProxy {
@@ -288,5 +329,66 @@
   .settingsField input,
   .settingsField textarea {
     transition: none !important;
+  }
+}
+
+/* === narrow-card row stacking (#1362) =================================== */
+
+/* THE row-wrapping decision for every form-row page (#1303 tracking):
+   below 460px of CARD width — not viewport width — label/control rows
+   stack vertically. 460px is the app's one container breakpoint (shared
+   with permission-dialog.css) and sits just above the widest one-line
+   row minimum (150px label floor + gap + a ~180px intrinsic-width input
+   + 48px row padding ≈ 394px), with margin for the select triggers'
+   320px cap to stay usable. Switch rows are the exception: a switch is
+   ~40px wide and always fits beside its label — stacking it reads as a
+   detached orphan, so those rows keep two columns and let the label wrap. */
+@container settings-rows (max-width: 460px) {
+  .settingsRow {
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: var(--space-2-5);
+  }
+
+  .settingsRow:has(> [role="switch"]) {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  /* Values and controls sit under their label now; right-alignment against
+     the card edge would detach them from it. */
+  .settingsRow > span {
+    text-align: left;
+  }
+
+  .settingsRow[data-control-width="compact"] > input,
+  .settingsRow[data-control-width="compact"] > .settingsTimeInput,
+  .settingsRow[data-control-width="select"] > .settingsSelectTrigger {
+    justify-self: start;
+  }
+
+  .settingsFormRow {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-2-5);
+  }
+
+  .settingsFormRow:has(> [role="switch"]) {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-5);
+  }
+
+  .settingsFormGrid,
+  .settingsFormGridProxy {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  /* The Button primitive is `shrink-0` with a fixed height; on a squeezed
+     card an action button wider than the row would bleed past the card
+     edge. Let it shrink and let the label wrap, keeping the primitive's
+     32px as a floor. */
+  .settingsActionRow > [data-slot="button"] {
+    flex-shrink: 1;
+    height: auto;
+    min-height: 2rem;
   }
 }

--- a/apps/desktop/src/renderer/styles/settings/select.css
+++ b/apps/desktop/src/renderer/styles/settings/select.css
@@ -81,6 +81,16 @@
   line-height: var(--leading-snug);
 }
 
+/* #1362: inside the TRIGGER only (popup options keep their full label), a
+   selected label longer than the squeezed trigger ellipsizes instead of
+   bleeding past the button box. */
+.settingsSelectTrigger .settingsSelectMenuOption {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Heading: same 13px as the rows; hierarchy comes from weight 500 + muted ink
    + the brand mark, not a different size or an uppercase eyebrow. The mark sits
    in the 1rem leading column so it lines up under each row's selected check. */

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -206,9 +206,12 @@
   color: var(--foreground);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-semibold);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  /* #1362: palette names wrap instead of truncating — at the 480px window
+     floor the single-column tiles are ~74px of label and the old nowrap +
+     ellipsis cut "Catppuccin Mocha" to "Catppucc…" with no way to recover
+     the name. Every label fits one line on the wide 3-column grid, so this
+     only changes the squeezed state. */
+  overflow-wrap: anywhere;
 }
 
 .settingsThemeLabel small {

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -766,6 +766,49 @@ const withWebSearchConfiguredBridge = withScopedMakaBridge({
   },
 } satisfies Record<string, unknown>);
 
+/** #1362: the proxy form (protocol/host/port grid, auth grid, bypass field)
+ *  only renders behind two enabled switches — without this fixture no story
+ *  ever exercised `.settingsFormGridProxy` or the auth `.settingsFormGrid`.
+ *  Hostile widths: a long internal proxy hostname, a service-account
+ *  username, and identity fields with long CJK content. */
+const generalProxySettings = mergeSettings(createDefaultSettings(), {
+  network: {
+    proxy: {
+      enabled: true,
+      protocol: 'socks5',
+      host: 'corp-egress-gateway.ap-southeast-1.internal.example-infra.net',
+      port: 18080,
+      authEnabled: true,
+      username: 'svc-maka-desktop-proxy-rotation-2026',
+      password: 'storybook-proxy-password',
+      bypassList: [
+        'metaso.cn',
+        'baidu.com',
+        'artifact-registry.ap-southeast-1.internal.example-infra.net',
+        '*.observability.example-infra.net',
+      ],
+    },
+  },
+  personalization: {
+    displayName: '陆逊（基础设施与开发者体验平台组 · 桌面端）',
+    assistantTone:
+      '回答尽量简短，先给结论再给理由；涉及命令行操作时给出完整命令并注明工作目录；不确定的事情直接说不确定，不要编造。',
+  },
+});
+
+const withGeneralProxyBridge = withScopedMakaBridge({
+  ...makaBridge,
+  settings: {
+    ...makaBridge.settings,
+    get: async () => generalProxySettings,
+    update: async (
+      patch: Parameters<typeof window.maka.settings.update>[0],
+    ): Promise<UpdateAppSettingsResult> => ({
+      settings: mergeSettings(generalProxySettings, patch),
+    }),
+  },
+} satisfies Record<string, unknown>);
+
 type StoryBotStatuses = Awaited<ReturnType<typeof window.maka.settings.bots.listStatuses>>;
 
 const botAttentionError =
@@ -1035,6 +1078,12 @@ export const General: Story = {
 export const Appearance: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="appearance" />,
+};
+/** #1362: proxy + auth enabled so the full form-grid stack renders. */
+// Real path: 设置 → 通用 → 代理服务器 on → 代理认证 on.
+export const GeneralProxyConfigured: Story = {
+  decorators: [withGeneralProxyBridge],
+  render: () => <SettingsStory section="general" />,
 };
 // Real path: 设置 → 使用统计.
 export const Usage: Story = {


### PR DESCRIPTION
Closes #1362 (sub-issue of #1303).

> **Stacked on #1479** — the first two commits are #1478/#1479 (this branch is based on them to avoid conflicts in `settings-pages.stories.tsx` / `settings.spec.ts`). Review only the last commit: `fix(desktop): stack settings form rows on narrow cards`. I'll rebase onto main once #1479 lands.

## 基线先行

代理子表单藏在两个开关后面，**没有任何 story 渲染过它** —— `settingsFormGridProxy` 三列网格（150px + 84px 地板）和认证两列网格都没有复现面。新增 `GeneralProxyConfigured` story 用敌意宽度（长内网主机名、服务账号用户名、长 CJK 身份字段）补上基线。

## THE row-wrapping decision（从 #1360/#1361/#1364 路由至此）

`.settingsRows` 卡片成为命名 inline-size 查询容器；**卡片宽度**（不是视口宽度——内容列比窗口窄一整条侧栏，这是 #1361 的 540px 和 #1364 的 900px 两个教训的共同根因）低于 460px 时：

- 标签/控件行竖向堆叠，表单网格折成单列；
- **开关行例外**：~40px 的开关永远放得下，堆到标签下面反而像孤儿，保持两列、标签换行；
- 460px 是全 app 唯一的容器断点（与 `permission-dialog.css` 共享），`responsive-breakpoint-contract` 测试现在用与 @media 相同的白名单机制治理 `@container` 宽度。

## 顺带的结构性修复

- `.settingsStructuredPage` 补显式 `minmax(0, 1fr)` 列：隐式 auto 轨道按最宽子元素的 max-content 定宽，会把整页卡片悄悄撑出内容列（#1364 在 `.settingsUsagePage` 上局部修过的同类传播，这次收敛到共享包装器）。回归探测显示 About 与 Web Search 的窄态溢出被顺带修复，Daily Review 480px 清零，其余页面全部持平或更好。
- 行标题去掉 `white-space: nowrap`（长标题从渗出值列改为换行；nowrap 原本防"一列一字"的意图改由 150px 标签地板 + 窄卡堆叠承接，`settings-form-a11y-contract` 已按新机制更新）；标题与提示补 `overflow-wrap: anywhere` 兜底。
- 代理子表单的非行子元素（网格、白名单字段、提示条、按钮行）此前顶着卡片边缘，行却缩进 24px —— 统一卡内水平缩进。
- select 触发器内选中文案超宽时省略号截断（仅触发器，弹层选项不动）。
- 外观页调色板名换行取代截断（480px 下 "Catppuccin Mocha" 原先被切成 "Catppucc…" 且无法恢复）。
- 动作行按钮允许收缩换行（Button 原语是 `shrink-0` + 固定高，窄卡上会渗出卡外）。

## 验证

- Storybook 480→1280px **10px 步进全频段扫描**，General / GeneralProxyConfigured / Appearance 零溢出（不再犯 #1466 的采样漏带错误）
- 新 e2e 锁双向契约：地板堆叠 + 宽态两列 + 代理网格折单列 + 页面收纳；**revert 验证过**——对主干 CSS 必失败
- 桌面单测 2847/2847，settings e2e 14/14，format / typecheck / test:checks / check-dead-css 全绿
- 实机四张图（含代理表单展开）：

| | 1280px | 480px |
|---|---|---|
| 通用+代理 | ![general-1280](https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1362-screenshots/live-general-proxy-1280.png) | ![general-480](https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1362-screenshots/live-general-proxy-480.png) |
| 外观 | ![appearance-1280](https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1362-screenshots/live-appearance-1280.png) | ![appearance-480](https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1362-screenshots/live-appearance-480.png) |

修复前的 480px 现场（story）：<img src="https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1362-screenshots/1362-general-proxy-480-before.png" width="360" />

## 已知遗留（不在本 PR 修）

- 记忆页内部的 `.settingsMemoryPreview` / `.settingsMemoryBackupList` 自有网格在 480px 仍溢出（此前被 structuredPage 的 auto 轨道拉宽卡片所掩盖，本 PR 使其显形；页面级从 +133px 改善到 +120px）——#1364 的后续。
- 开放网关页的 `settingsFormGridProxy` 裸放在页面上、不在 SettingsRows 卡内，堆叠规则不覆盖（存量结构，页面级持平）。
- 模型页 story 的 bridge fixture 缺 `isExperimentalEnabled` 通道（存量，#1367 范围）。