### PR TITLE
fix(ui): space CJK-Latin mixed prose in Markdown answers

### DIFF
--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -582,49 +582,79 @@ describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
   });
 
   /**
-   * Glyph-reshaping properties that INHERIT. `.maka-prose` may set any of them
-   * for reading comfort; the code-block tier must carve each one back out.
+   * Glyph-reshaping properties that INHERIT into fenced code, each with the
+   * value that actually neutralises it there. The first version of this
+   * contract only checked that the property NAME reappeared in the code-block
+   * tier, which passed when a carve-out was reverted to the leaking value —
+   * a presence check wearing a neutralisation check's error message.
    */
-  const INHERITED_SHAPING_PROPERTIES = [
-    'text-autospace',
-    'text-spacing-trim',
-    'letter-spacing',
-    'word-spacing',
-    'font-variant-ligatures',
-    'font-feature-settings',
-    'text-transform',
+  const INHERITED_SHAPING: Array<[property: string, neutral: RegExp]> = [
+    ['text-autospace', /no-autospace/],
+    ['text-spacing-trim', /space-all/],
+    ['letter-spacing', /normal|:\s*0/],
+    ['word-spacing', /normal|:\s*0/],
+    ['font-variant-ligatures', /none/],
+    ['font-feature-settings', /normal/],
+    ['text-transform', /none/],
   ];
 
   /**
-   * Pill chrome on `.maka-prose code`, which also matches `pre > code`, so the
-   * block reset must neutralise each. `border`/`padding` already leaked once.
+   * Pill chrome on `.maka-prose code`, which also matches `pre > code`. The
+   * block reset must zero each — `border`/`padding` already leaked once, and
+   * `margin` leaked in round 1 (the pill's margin-inline offset the first
+   * source line of every code block by 3.25px).
    */
-  const PILL_ONLY_PROPERTIES = ['margin', 'padding', 'background', 'border'];
+  const PILL_CHROME = ['margin', 'padding', 'background', 'border', 'border-radius'];
 
+  /** Longhand-aware property match: `margin` also matches `margin-inline`. */
   const declares = (decls: string, property: string) =>
     new RegExp(`(?:^|;)\\s*${property}(?:-[a-z-]+)?\\s*:`).test(decls);
 
-  it('prose text shaping stops at the fenced-code boundary', async () => {
+  /** The declaration text for `property` in `decls`, longhands included. */
+  const valueOf = (decls: string, property: string) =>
+    decls.match(new RegExp(`(?:^|;)\\s*${property}(?:-[a-z-]+)?\\s*:([^;]*)`))?.[1]?.trim() ?? '';
+
+  /**
+   * Rules that can hold a fenced block, so an inherited property set on them
+   * reaches code. A list item and a blockquote can contain one; `h1`–`h4`,
+   * `th` and `td` cannot (headings are single-line and GFM table cells are
+   * line-delimited), which is why `.maka-prose h1`'s letter-spacing is not a
+   * leak and must not trip this.
+   *
+   * Known limit: `cssBlocks` is a flat splitter, so a rule nested inside an
+   * at-rule is invisible here. prose.css has no `@media`; if one is added,
+   * this scan needs to grow with it.
+   */
+  const fencedCodeAncestors = (blocks: Array<{ selectors: string; decls: string }>) =>
+    blocks.filter(({ selectors }) => selectors
+      .split(',')
+      .some((one) => /^\.maka-prose(\s+(li|blockquote))?$/.test(one.trim())));
+
+  it('prose text shaping is neutralised at the fenced-code boundary', async () => {
     const css = stripCssComments(await readFile(PROSE_CSS, 'utf8'));
     const blocks = cssBlocks(css);
-    const prose = blocks.find(({ selectors }) => selectors === '.maka-prose');
     const pre = blocks.find(({ selectors }) => selectors === '.maka-prose .maka-code-block pre');
     const preCode = blocks.find(({ selectors }) => selectors === '.maka-prose .maka-code-block pre code');
-    assert.ok(prose, 'expected a bare .maka-prose base rule');
     assert.ok(pre, 'expected a .maka-prose .maka-code-block pre rule');
     assert.ok(preCode, 'expected a .maka-prose .maka-code-block pre code reset');
     const carvedOut = `${pre!.decls};${preCode!.decls}`;
 
-    for (const property of INHERITED_SHAPING_PROPERTIES) {
-      if (!declares(prose!.decls, property)) continue;
+    for (const [property, neutral] of INHERITED_SHAPING) {
+      const setter = fencedCodeAncestors(blocks).find(({ decls }) => declares(decls, property));
+      if (!setter) continue;
       assert.ok(
         declares(carvedOut, property),
-        `.maka-prose sets ${property}, which inherits into fenced code and shifts glyphs off the monospace grid. Code is a literal surface (#1431) — the .maka-code-block pre tier must carve ${property} back out`,
+        `${setter.selectors} sets ${property}, which inherits into fenced code and shifts glyphs off the monospace grid. Code is a literal surface (#1431) — the .maka-code-block pre tier must carve ${property} back out`,
+      );
+      assert.match(
+        valueOf(carvedOut, property),
+        neutral,
+        `the code-block carve-out for ${property} must actually neutralise it, not just re-declare it — a carve-out reverted to the prose value re-ships the leak`,
       );
     }
   });
 
-  it('inline-pill chrome stops at the fenced-code boundary', async () => {
+  it('inline-pill chrome is zeroed at the fenced-code boundary', async () => {
     const css = stripCssComments(await readFile(PROSE_CSS, 'utf8'));
     const blocks = cssBlocks(css);
     const code = blocks.find(({ selectors }) => /^\.maka-prose\s+code$/.test(selectors));
@@ -632,13 +662,35 @@ describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
     assert.ok(code, 'expected a .maka-prose code rule');
     assert.ok(preCode, 'expected a .maka-prose .maka-code-block pre code reset');
 
-    for (const property of PILL_ONLY_PROPERTIES) {
+    for (const property of PILL_CHROME) {
       if (!declares(code!.decls, property)) continue;
       assert.ok(
         declares(preCode!.decls, property),
-        `.maka-prose code (0,1,1) matches pre > code too, so ${property} leaks into fenced code — the pill's margin-inline offset the first source line by 3.25px. The .maka-code-block pre code reset must neutralise ${property}`,
+        `.maka-prose code (0,1,1) matches pre > code too, so ${property} leaks into fenced code. The .maka-code-block pre code reset must neutralise ${property}`,
+      );
+      assert.match(
+        valueOf(preCode!.decls, property),
+        /^(0(px)?|none|transparent)$/,
+        `the pre code reset for ${property} must zero it — re-declaring it with a non-neutral value re-ships the leak (round 1: margin-inline offset the first source line by 3.25px)`,
       );
     }
+  });
+
+  it('the inline pill does not indent the block it starts', async () => {
+    const css = stripCssComments(await readFile(PROSE_CSS, 'utf8'));
+    const blocks = cssBlocks(css);
+    const code = blocks.find(({ selectors }) => /^\.maka-prose\s+code$/.test(selectors));
+    if (!declares(code!.decls, 'margin')) return;
+    const edge = blocks.find(({ selectors }) => /\.maka-prose\s+code:first-child/.test(selectors));
+    assert.ok(
+      edge,
+      'the pill margin is an inline gap between the pill and its NEIGHBOURING text, but at a block edge there is no neighbour — it indents the block instead (measured 2.98px on a paragraph, list item and blockquote that open with inline code, against 0 for one opening with plain text). A .maka-prose code:first-child rule must drop the leading margin',
+    );
+    assert.match(
+      edge!.decls,
+      /margin-inline-start:\s*0/,
+      '.maka-prose code:first-child must zero margin-inline-start so a block opening with a pill keeps the same left edge as its neighbours',
+    );
   });
 
   it('hard breaks render as a block span with height — a native <br> cannot be spaced by CSS', async () => {
@@ -657,5 +709,23 @@ describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
     );
     // The DOM half — `<br>` + span, and remark-breaks still producing the
     // break — is locked by rendering in packages/ui's markdown-body.test.ts.
+
+    // `remark-breaks` makes EVERY single newline a hard break, so the 6px
+    // lands on list-item and blockquote continuation lines too, where it
+    // inverts the grouping: measured 10.5px inside one list item against
+    // 6.5px between two of them. Those containers already group their own
+    // content; only a paragraph break carries the section split.
+    const scoped = cssBlocks(css).find(({ selectors }) =>
+      /\.maka-prose\s+li\s+\.maka-hardbreak/.test(selectors));
+    assert.ok(
+      scoped,
+      'the hard-break gap must be dropped inside li/blockquote — a continuation line there rendered further apart (10.5px) than two separate list items (6.5px), inverting the grouping',
+    );
+    assert.match(
+      scoped!.selectors,
+      /blockquote\s+\.maka-hardbreak/,
+      'blockquote needs the same carve-out as li — its content is already grouped, so a break inside it is a continuation, not a section split',
+    );
+    assert.match(scoped!.decls, /height:\s*0/, 'the carve-out must zero the gap');
   });
 });

--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -541,58 +541,22 @@ describe('MARKDOWN-PROSE-RENDER-OWNER-0 contract (#739)', () => {
 
 /**
  * MARKDOWN-PROSE-CJK-MIXED-SPACING-0: Maka is CJK-first and its assistant
- * prose is dense mixed script — Chinese wrapped around identifiers, paths,
- * version numbers and line numbers. Four spacing rules carry that, each
- * measured in the real Electron app (Chromium 150) rather than headless:
- * headless silently falls PingFang SC back to a serif face while
- * `document.fonts.check` still reports true, so every font-dependent number
- * below comes from `CSS.getPlatformFontsForNode` against the built stack.
+ * prose is dense mixed script, so `.maka-prose` asks for CJK/Latin autospace
+ * and gives inline code pills their own margin. Both rationales live next to
+ * the rules in prose.css; this locks that they are still there.
  *
- * 1. `text-autospace: normal` — Chromium's initial value is `no-autospace`,
- *    NOT the spec's `normal`, so CJK/Latin boundary spacing has to be asked
- *    for. Measured +1.55px per boundary at the 13px body size (1/8 em), and
- *    it applies ACROSS inline element boundaries, so `<code>` pills get it on
- *    both sides too. Same lever LobeChat landed in `:root` after dropping its
- *    runtime pangu.js pass. Scoped to `.maka-prose` here, not `:root`: the
- *    composer, sidebar and settings surfaces are a separate call — widening
- *    it changes text metrics app-wide.
+ * The third pair of tests is the one that matters. Both spacing rules are
+ * PROSE decoration that reaches fenced code unless carved back out —
+ * autospace inherits, and `.maka-prose code` (0,1,1) matches `pre > code` too.
+ * Shipping them uncarved put the first line of every code block 3.25px right
+ * of the lines below it and drifted mixed-script lines off the monospace grid.
+ * That is the invariant #1431 already locked for ligatures, reached a second
+ * time by different properties, so these guard the BOUNDARY as a property
+ * class: they fail for any future shaping declaration too, not just these two.
  *
- * 2. `code { margin-inline: 0.25em }` — autospace alone leaves 1.55px between
- *    Chinese and a code pill that already carries inline padding and a
- *    background, and the pill still reads glued to the text. 0.25em (3.25px)
- *    stacks on top of autospace rather than replacing it.
- *
- * 3. The literal-code boundary. Rules 1 and 2 are PROSE decoration, and both
- *    reach fenced code unless carved back out: `text-autospace` is inherited,
- *    and `.maka-prose code` (0,1,1) matches `pre > code` as well as the inline
- *    pill. Measured in the built app before the carve-out: the first source
- *    line of every code block started 3.25px right of the lines below it
- *    (36.25 vs 33 — a `<code>` inside `white-space: pre` is ONE inline box
- *    spanning all lines, so its margin-left only offsets the first fragment),
- *    and a line crossing a CJK/Latin boundary drifted 1.6px off the monospace
- *    grid per boundary. This is the same invariant #1431 already locked for
- *    ligatures ("code is a literal surface"), reached a second time by a
- *    different property — so the contract below guards the BOUNDARY rather
- *    than the two specific leaks, and fails when any future prose-shaping
- *    declaration lands without a carve-out.
- *
- * 4. `.maka-hardbreak` — `remark-breaks` turns every single newline into a
- *    hard break, and LLM answers lean on `**subhead**\nbody` to separate
- *    sections. A hard break carries only the 4px the line box already gives,
- *    against 16px between paragraphs, so the STRONGER semantic split renders
- *    tighter than the weaker one. CSS cannot fix a native `<br>` —
- *    display:block, height, margin and content:"\A" all leave the paragraph
- *    at exactly 39px — so markdown-body emits the native `<br>` FOLLOWED BY a
- *    block `<span>` that can take a height. Keeping the `<br>` is not
- *    cosmetic: measured via CDP, replacing it with the span alone drops the
- *    `LineBreak` node from the accessibility tree, while `<br>` + span keeps
- *    the AX node, keeps `Selection.toString()` at a single `\n`, and still
- *    lands the gap at 10px, between the 4px line gap and the 16px paragraph
- *    gap. A rule that was dropped on the way here: `td { word-break:
- *    auto-phrase }` — measured inert for Chinese in Chromium 150 (identical
- *    break positions to `normal` under both `lang="zh-CN"` and `lang="en"`;
- *    only `lang="ja"` changes, since the engine's phrase model is Japanese-
- *    only), and double-gated by the renderer's static `<html lang="en">`.
+ * Numbers here come from the built Electron app, never headless — headless
+ * falls PingFang SC back to a serif face while `document.fonts.check` still
+ * returns true, which voids every font-dependent measurement taken there.
  */
 describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
   it('.maka-prose asks for CJK/Latin autospace (Chromium defaults to no-autospace)', async () => {
@@ -618,11 +582,8 @@ describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
   });
 
   /**
-   * Properties that reshape or reposition glyphs and INHERIT into descendants.
-   * `.maka-prose` may set any of them for reading comfort; fenced code is a
-   * literal surface (#1431) and must carve every one of them back out at the
-   * code-block tier. Listing the property class rather than the two known
-   * leaks is the point: this fails on the NEXT one too.
+   * Glyph-reshaping properties that INHERIT. `.maka-prose` may set any of them
+   * for reading comfort; the code-block tier must carve each one back out.
    */
   const INHERITED_SHAPING_PROPERTIES = [
     'text-autospace',
@@ -635,10 +596,8 @@ describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
   ];
 
   /**
-   * Pill chrome on `.maka-prose code` (0,1,1) — which also matches `pre > code`,
-   * so each of these must be neutralised by the block-code reset. `border` and
-   * `padding` are here because they already leaked once (the border painted a
-   * rounded outline around every wrapped line inside the pre).
+   * Pill chrome on `.maka-prose code`, which also matches `pre > code`, so the
+   * block reset must neutralise each. `border`/`padding` already leaked once.
    */
   const PILL_ONLY_PROPERTIES = ['margin', 'padding', 'background', 'border'];
 
@@ -660,7 +619,7 @@ describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
       if (!declares(prose!.decls, property)) continue;
       assert.ok(
         declares(carvedOut, property),
-        `.maka-prose sets ${property}, which inherits into fenced code and shifts glyphs off the monospace grid (text-autospace measured 1.6px of drift per CJK/Latin boundary in the built app). Fenced code is a literal surface — #1431 locked the same invariant for ligatures — so the .maka-code-block pre tier must carve ${property} back out`,
+        `.maka-prose sets ${property}, which inherits into fenced code and shifts glyphs off the monospace grid. Code is a literal surface (#1431) — the .maka-code-block pre tier must carve ${property} back out`,
       );
     }
   });
@@ -677,7 +636,7 @@ describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
       if (!declares(code!.decls, property)) continue;
       assert.ok(
         declares(preCode!.decls, property),
-        `.maka-prose code (0,1,1) matches pre > code as well as the inline pill, so ${property} leaks into fenced code. Measured for margin-inline in the built app: a <code> inside white-space: pre is ONE inline box spanning every line, so its inline margin offsets only the FIRST source line (36.25px vs 33px). The .maka-code-block pre code reset must neutralise ${property}`,
+        `.maka-prose code (0,1,1) matches pre > code too, so ${property} leaks into fenced code — the pill's margin-inline offset the first source line by 3.25px. The .maka-code-block pre code reset must neutralise ${property}`,
       );
     }
   });
@@ -696,9 +655,7 @@ describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
       /height:\s*var\(--space-1-5\)/,
       '.maka-hardbreak must take its 6px from --space-1-5 so the hard-break gap lands between the 4px line gap and the 16px paragraph gap',
     );
-    // The DOM half of this rule — that markdown-body emits `<br>` + the span,
-    // and that remark-breaks is still what produces the break — is locked by
-    // rendering in packages/ui/src/__tests__/markdown-body.test.ts. AST → DOM
-    // is that package's contract; this file owns the CSS tier it lands in.
+    // The DOM half — `<br>` + span, and remark-breaks still producing the
+    // break — is locked by rendering in packages/ui's markdown-body.test.ts.
   });
 });

--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -538,3 +538,113 @@ describe('MARKDOWN-PROSE-RENDER-OWNER-0 contract (#739)', () => {
     );
   });
 });
+
+/**
+ * MARKDOWN-PROSE-CJK-MIXED-SPACING-0: Maka is CJK-first and its assistant
+ * prose is dense mixed script — Chinese wrapped around identifiers, paths,
+ * version numbers and line numbers. Four spacing rules carry that, each
+ * measured in the real Electron app (Chromium 150) rather than headless:
+ * headless silently falls PingFang SC back to a serif face while
+ * `document.fonts.check` still reports true, so every font-dependent number
+ * below comes from `CSS.getPlatformFontsForNode` against the built stack.
+ *
+ * 1. `text-autospace: normal` — Chromium's initial value is `no-autospace`,
+ *    NOT the spec's `normal`, so CJK/Latin boundary spacing has to be asked
+ *    for. Measured +1.55px per boundary at the 13px body size (1/8 em), and
+ *    it applies ACROSS inline element boundaries, so `<code>` pills get it on
+ *    both sides too. Same lever LobeChat landed in `:root` after dropping its
+ *    runtime pangu.js pass. Scoped to `.maka-prose` here, not `:root`: the
+ *    composer, sidebar and settings surfaces are a separate call — widening
+ *    it changes text metrics app-wide.
+ *
+ * 2. `code { margin-inline: 0.25em }` — autospace alone leaves 1.55px between
+ *    Chinese and a code pill that already carries inline padding and a
+ *    background, and the pill still reads glued to the text. 0.25em (3.25px)
+ *    stacks on top of autospace rather than replacing it.
+ *
+ * 3. `td { word-break: auto-phrase }` — phrase-aware breaking so a narrow
+ *    Chinese body cell breaks between phrases rather than mid-word. Only
+ *    `td`: `th` is `white-space: nowrap` (headers hold one line so degenerate
+ *    tables hit the wrapper's scroller), where a break rule is inert.
+ *
+ * 4. `.maka-hardbreak` — `remark-breaks` turns every single newline into a
+ *    hard break, and LLM answers lean on `**subhead**\nbody` to separate
+ *    sections. A hard break carries only the 4px the line box already gives,
+ *    against 16px between paragraphs, so the STRONGER semantic split renders
+ *    tighter than the weaker one. CSS cannot fix a native `<br>` —
+ *    display:block, height, margin and content:"\A" all leave the paragraph
+ *    at exactly 39px — so markdown-body renders the break as a block `<span>`
+ *    that can take a height, landing the gap at 10px, between the 4px line
+ *    gap and the 16px paragraph gap.
+ */
+describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
+  it('.maka-prose asks for CJK/Latin autospace (Chromium defaults to no-autospace)', async () => {
+    const css = stripCssComments(await readFile(PROSE_CSS, 'utf8'));
+    const prose = cssBlocks(css).find(({ selectors }) => selectors === '.maka-prose');
+    assert.ok(prose, 'expected a bare .maka-prose base rule in prose.css');
+    assert.match(
+      prose!.decls,
+      /text-autospace:\s*normal/,
+      ".maka-prose must set text-autospace: normal — Chromium's initial value is no-autospace, so a CJK-first product gets no CJK/Latin boundary spacing unless it asks (measured +1.55px per boundary at 13px)",
+    );
+  });
+
+  it('inline code keeps a margin gap so code pills do not glue to surrounding Chinese', async () => {
+    const css = stripCssComments(await readFile(PROSE_CSS, 'utf8'));
+    const code = cssBlocks(css).find(({ selectors }) => /^\.maka-prose\s+code$/.test(selectors));
+    assert.ok(code, 'expected a .maka-prose code rule');
+    assert.match(
+      code!.decls,
+      /margin-inline:\s*0\.25em/,
+      '.maka-prose code must carry margin-inline: 0.25em — text-autospace alone leaves only 1.55px against a pill that already has inline padding and a background',
+    );
+  });
+
+  it('table body cells break on phrase boundaries; headers stay nowrap', async () => {
+    const css = stripCssComments(await readFile(PROSE_CSS, 'utf8'));
+    const blocks = cssBlocks(css);
+    const td = blocks.find(({ selectors, decls }) =>
+      /\.maka-prose\s+td/.test(selectors) && /word-break/.test(decls));
+    assert.ok(td, 'expected a .maka-prose td rule carrying word-break');
+    assert.match(
+      td!.decls,
+      /word-break:\s*auto-phrase/,
+      '.maka-prose td must use word-break: auto-phrase so a narrow Chinese body cell breaks between phrases instead of mid-word',
+    );
+    const th = blocks.find(({ selectors }) => /^\.maka-prose\s+th$/.test(selectors));
+    assert.ok(th, 'expected a .maka-prose th rule');
+    assert.match(
+      th!.decls,
+      /white-space:\s*nowrap/,
+      'th stays nowrap — headers hold one line so degenerate tables hit the wrapper scroller, which makes a break rule on th inert',
+    );
+  });
+
+  it('hard breaks render as a block span with height — a native <br> cannot be spaced by CSS', async () => {
+    const css = stripCssComments(await readFile(PROSE_CSS, 'utf8'));
+    const hb = cssBlocks(css).find(({ selectors }) => /\.maka-hardbreak$/.test(selectors));
+    assert.ok(hb, 'expected a .maka-hardbreak rule in prose.css');
+    assert.match(
+      hb!.decls,
+      /display:\s*block/,
+      '.maka-hardbreak must be display: block — an inline box cannot take a height, which is exactly why a native <br> is unfixable in CSS',
+    );
+    assert.match(
+      hb!.decls,
+      /height:\s*var\(--space-1-5\)/,
+      '.maka-hardbreak must take its 6px from --space-1-5 so the hard-break gap lands between the 4px line gap and the 16px paragraph gap',
+    );
+
+    const src = await readFile(MARKDOWN_BODY, 'utf8');
+    assert.match(
+      src,
+      /br:\s*\(\)\s*=>[\s\S]{0,160}maka-hardbreak/,
+      'markdown-body.tsx must override `br` with the .maka-hardbreak block span — remark-breaks turns every LLM newline into a hard break, and CSS cannot give a native <br> any spacing',
+    );
+    assert.match(
+      src,
+      /br:\s*\(\)\s*=>[\s\S]{0,160}aria-hidden/,
+      'the hard-break span is decorative — it must be aria-hidden so it does not surface as an empty element to screen readers',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -562,10 +562,19 @@ describe('MARKDOWN-PROSE-RENDER-OWNER-0 contract (#739)', () => {
  *    background, and the pill still reads glued to the text. 0.25em (3.25px)
  *    stacks on top of autospace rather than replacing it.
  *
- * 3. `td { word-break: auto-phrase }` — phrase-aware breaking so a narrow
- *    Chinese body cell breaks between phrases rather than mid-word. Only
- *    `td`: `th` is `white-space: nowrap` (headers hold one line so degenerate
- *    tables hit the wrapper's scroller), where a break rule is inert.
+ * 3. The literal-code boundary. Rules 1 and 2 are PROSE decoration, and both
+ *    reach fenced code unless carved back out: `text-autospace` is inherited,
+ *    and `.maka-prose code` (0,1,1) matches `pre > code` as well as the inline
+ *    pill. Measured in the built app before the carve-out: the first source
+ *    line of every code block started 3.25px right of the lines below it
+ *    (36.25 vs 33 — a `<code>` inside `white-space: pre` is ONE inline box
+ *    spanning all lines, so its margin-left only offsets the first fragment),
+ *    and a line crossing a CJK/Latin boundary drifted 1.6px off the monospace
+ *    grid per boundary. This is the same invariant #1431 already locked for
+ *    ligatures ("code is a literal surface"), reached a second time by a
+ *    different property — so the contract below guards the BOUNDARY rather
+ *    than the two specific leaks, and fails when any future prose-shaping
+ *    declaration lands without a carve-out.
  *
  * 4. `.maka-hardbreak` — `remark-breaks` turns every single newline into a
  *    hard break, and LLM answers lean on `**subhead**\nbody` to separate
@@ -573,9 +582,17 @@ describe('MARKDOWN-PROSE-RENDER-OWNER-0 contract (#739)', () => {
  *    against 16px between paragraphs, so the STRONGER semantic split renders
  *    tighter than the weaker one. CSS cannot fix a native `<br>` —
  *    display:block, height, margin and content:"\A" all leave the paragraph
- *    at exactly 39px — so markdown-body renders the break as a block `<span>`
- *    that can take a height, landing the gap at 10px, between the 4px line
- *    gap and the 16px paragraph gap.
+ *    at exactly 39px — so markdown-body emits the native `<br>` FOLLOWED BY a
+ *    block `<span>` that can take a height. Keeping the `<br>` is not
+ *    cosmetic: measured via CDP, replacing it with the span alone drops the
+ *    `LineBreak` node from the accessibility tree, while `<br>` + span keeps
+ *    the AX node, keeps `Selection.toString()` at a single `\n`, and still
+ *    lands the gap at 10px, between the 4px line gap and the 16px paragraph
+ *    gap. A rule that was dropped on the way here: `td { word-break:
+ *    auto-phrase }` — measured inert for Chinese in Chromium 150 (identical
+ *    break positions to `normal` under both `lang="zh-CN"` and `lang="en"`;
+ *    only `lang="ja"` changes, since the engine's phrase model is Japanese-
+ *    only), and double-gated by the renderer's static `<html lang="en">`.
  */
 describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
   it('.maka-prose asks for CJK/Latin autospace (Chromium defaults to no-autospace)', async () => {
@@ -600,24 +617,69 @@ describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
     );
   });
 
-  it('table body cells break on phrase boundaries; headers stay nowrap', async () => {
+  /**
+   * Properties that reshape or reposition glyphs and INHERIT into descendants.
+   * `.maka-prose` may set any of them for reading comfort; fenced code is a
+   * literal surface (#1431) and must carve every one of them back out at the
+   * code-block tier. Listing the property class rather than the two known
+   * leaks is the point: this fails on the NEXT one too.
+   */
+  const INHERITED_SHAPING_PROPERTIES = [
+    'text-autospace',
+    'text-spacing-trim',
+    'letter-spacing',
+    'word-spacing',
+    'font-variant-ligatures',
+    'font-feature-settings',
+    'text-transform',
+  ];
+
+  /**
+   * Pill chrome on `.maka-prose code` (0,1,1) — which also matches `pre > code`,
+   * so each of these must be neutralised by the block-code reset. `border` and
+   * `padding` are here because they already leaked once (the border painted a
+   * rounded outline around every wrapped line inside the pre).
+   */
+  const PILL_ONLY_PROPERTIES = ['margin', 'padding', 'background', 'border'];
+
+  const declares = (decls: string, property: string) =>
+    new RegExp(`(?:^|;)\\s*${property}(?:-[a-z-]+)?\\s*:`).test(decls);
+
+  it('prose text shaping stops at the fenced-code boundary', async () => {
     const css = stripCssComments(await readFile(PROSE_CSS, 'utf8'));
     const blocks = cssBlocks(css);
-    const td = blocks.find(({ selectors, decls }) =>
-      /\.maka-prose\s+td/.test(selectors) && /word-break/.test(decls));
-    assert.ok(td, 'expected a .maka-prose td rule carrying word-break');
-    assert.match(
-      td!.decls,
-      /word-break:\s*auto-phrase/,
-      '.maka-prose td must use word-break: auto-phrase so a narrow Chinese body cell breaks between phrases instead of mid-word',
-    );
-    const th = blocks.find(({ selectors }) => /^\.maka-prose\s+th$/.test(selectors));
-    assert.ok(th, 'expected a .maka-prose th rule');
-    assert.match(
-      th!.decls,
-      /white-space:\s*nowrap/,
-      'th stays nowrap — headers hold one line so degenerate tables hit the wrapper scroller, which makes a break rule on th inert',
-    );
+    const prose = blocks.find(({ selectors }) => selectors === '.maka-prose');
+    const pre = blocks.find(({ selectors }) => selectors === '.maka-prose .maka-code-block pre');
+    const preCode = blocks.find(({ selectors }) => selectors === '.maka-prose .maka-code-block pre code');
+    assert.ok(prose, 'expected a bare .maka-prose base rule');
+    assert.ok(pre, 'expected a .maka-prose .maka-code-block pre rule');
+    assert.ok(preCode, 'expected a .maka-prose .maka-code-block pre code reset');
+    const carvedOut = `${pre!.decls};${preCode!.decls}`;
+
+    for (const property of INHERITED_SHAPING_PROPERTIES) {
+      if (!declares(prose!.decls, property)) continue;
+      assert.ok(
+        declares(carvedOut, property),
+        `.maka-prose sets ${property}, which inherits into fenced code and shifts glyphs off the monospace grid (text-autospace measured 1.6px of drift per CJK/Latin boundary in the built app). Fenced code is a literal surface — #1431 locked the same invariant for ligatures — so the .maka-code-block pre tier must carve ${property} back out`,
+      );
+    }
+  });
+
+  it('inline-pill chrome stops at the fenced-code boundary', async () => {
+    const css = stripCssComments(await readFile(PROSE_CSS, 'utf8'));
+    const blocks = cssBlocks(css);
+    const code = blocks.find(({ selectors }) => /^\.maka-prose\s+code$/.test(selectors));
+    const preCode = blocks.find(({ selectors }) => selectors === '.maka-prose .maka-code-block pre code');
+    assert.ok(code, 'expected a .maka-prose code rule');
+    assert.ok(preCode, 'expected a .maka-prose .maka-code-block pre code reset');
+
+    for (const property of PILL_ONLY_PROPERTIES) {
+      if (!declares(code!.decls, property)) continue;
+      assert.ok(
+        declares(preCode!.decls, property),
+        `.maka-prose code (0,1,1) matches pre > code as well as the inline pill, so ${property} leaks into fenced code. Measured for margin-inline in the built app: a <code> inside white-space: pre is ONE inline box spanning every line, so its inline margin offsets only the FIRST source line (36.25px vs 33px). The .maka-code-block pre code reset must neutralise ${property}`,
+      );
+    }
   });
 
   it('hard breaks render as a block span with height — a native <br> cannot be spaced by CSS', async () => {
@@ -634,17 +696,9 @@ describe('MARKDOWN-PROSE-CJK-MIXED-SPACING-0 contract', () => {
       /height:\s*var\(--space-1-5\)/,
       '.maka-hardbreak must take its 6px from --space-1-5 so the hard-break gap lands between the 4px line gap and the 16px paragraph gap',
     );
-
-    const src = await readFile(MARKDOWN_BODY, 'utf8');
-    assert.match(
-      src,
-      /br:\s*\(\)\s*=>[\s\S]{0,160}maka-hardbreak/,
-      'markdown-body.tsx must override `br` with the .maka-hardbreak block span — remark-breaks turns every LLM newline into a hard break, and CSS cannot give a native <br> any spacing',
-    );
-    assert.match(
-      src,
-      /br:\s*\(\)\s*=>[\s\S]{0,160}aria-hidden/,
-      'the hard-break span is decorative — it must be aria-hidden so it does not surface as an empty element to screen readers',
-    );
+    // The DOM half of this rule — that markdown-body emits `<br>` + the span,
+    // and that remark-breaks is still what produces the break — is locked by
+    // rendering in packages/ui/src/__tests__/markdown-body.test.ts. AST → DOM
+    // is that package's contract; this file owns the CSS tier it lands in.
   });
 });

--- a/apps/desktop/src/renderer/styles/prose.css
+++ b/apps/desktop/src/renderer/styles/prose.css
@@ -93,6 +93,16 @@
   font-size: var(--font-size-base);
   line-height: var(--leading-normal);
   word-wrap: break-word;
+  /* CJK/Latin boundary spacing. Chromium's initial value is `no-autospace`,
+     NOT the spec's `normal` — verified against the built app — so a CJK-first
+     product renders 中文和identifier glued together unless it asks. Measured
+     +1.55px per boundary at the 13px body (1/8 em), and it applies across
+     inline element boundaries, so the `<code>` pills in a technical answer
+     get it on both sides too.
+     Scoped here rather than on :root: the composer, sidebar and settings
+     surfaces would all shift text metrics, which is a separate call.
+     MARKDOWN-PROSE-CJK-MIXED-SPACING-0 locks this. */
+  text-autospace: normal;
   /* No max-width here: the reading measure is owned by .maka-message-row
      (var(--maka-chat-measure), the same cap the composer uses), so the
      assistant block matches the composer width. An inner 72ch cap used to
@@ -111,6 +121,22 @@
 .maka-prose p {
   margin: 0 0 var(--space-3);
   text-wrap: pretty;
+}
+/* Hard break inside a paragraph. `remark-breaks` (markdown-body.tsx) turns
+   every single newline in the model's output into one of these, and LLM
+   answers lean on `**subhead**\nbody` to separate sections — so this gap
+   routinely carries a SECTION split, not a continuation.
+   Unstyled it gets only the ~4px the line box already provides, against 16px
+   between paragraphs: the stronger semantic split rendered tighter than the
+   weaker one. A native `<br>` cannot be spaced by CSS at all (display:block,
+   height, margin and content:"\A" were each measured — the paragraph stays at
+   exactly 39px), so markdown-body renders the break as this block span, which
+   can take a height. 6px lands the gap at 10px, between the 4px line gap and
+   the 16px paragraph gap.
+   MARKDOWN-PROSE-CJK-MIXED-SPACING-0 locks this. */
+.maka-hardbreak {
+  display: block;
+  height: var(--space-1-5);
 }
 .maka-prose h1,
 .maka-prose h2,
@@ -208,6 +234,13 @@
      two pills). Bg-only pills leave ~5.5px of inter-line air, matching
      plain text; the dropped border was 3% alpha and read as invisible. */
   padding: 0 var(--space-1-5);
+  /* Outer breathing room against surrounding Chinese. `text-autospace` above
+     already reaches across this inline boundary, but its 1.55px is sized for
+     bare glyphs — against a pill carrying its own padding and a filled
+     background the code still reads glued to the text. 0.25em (3.25px)
+     stacks on top of autospace rather than replacing it.
+     MARKDOWN-PROSE-CJK-MIXED-SPACING-0 locks this. */
+  margin-inline: 0.25em;
   /* PR-UI-LAYOUT-28: inline code radius 4 → 5. Tiny bump but
    * pulls it slightly out of the "tight tag" feel into a calmer
    * pill rhythm that matches the rest of the warm-canvas chrome. */
@@ -451,6 +484,14 @@
      tables hit the overflow-x scroller instead. Body cells still wrap. */
   white-space: nowrap;
   letter-spacing: var(--tracking-normal);
+}
+/* Body cells DO wrap (only `th` is nowrap above), and a squeezed Chinese cell
+   is where breaking gets ugly: the default breaks anywhere, including inside
+   a two-character word. `auto-phrase` breaks on phrase boundaries instead.
+   Scoped to `td` on purpose — on the nowrap `th` a break rule is inert.
+   MARKDOWN-PROSE-CJK-MIXED-SPACING-0 locks this. */
+.maka-prose td {
+  word-break: auto-phrase;
 }
 .maka-prose hr {
   margin: var(--space-4) 0;

--- a/apps/desktop/src/renderer/styles/prose.css
+++ b/apps/desktop/src/renderer/styles/prose.css
@@ -128,6 +128,15 @@
   display: block;
   height: var(--space-1-5);
 }
+/* `remark-breaks` makes EVERY newline a break, including continuation lines
+   inside a list item or a blockquote — containers that already group their
+   own content, where the gap inverted the grouping (measured 10.5px inside
+   one list item against 6.5px between two of them). Only a paragraph break
+   carries a section split. */
+.maka-prose li .maka-hardbreak,
+.maka-prose blockquote .maka-hardbreak {
+  height: 0;
+}
 .maka-prose h1,
 .maka-prose h2,
 .maka-prose h3,
@@ -193,6 +202,17 @@
   border-radius: var(--radius-control);
   transition: border-bottom-color var(--duration-quick) var(--ease-out-strong), background var(--duration-quick) var(--ease-out-strong), box-shadow var(--duration-quick) var(--ease-out-strong);
 }
+/* That margin is the gap between the pill and its NEIGHBOURING text — at a
+   block edge there is no neighbour, so it indents the block instead: measured
+   2.98px on a paragraph, list item and blockquote opening with inline code,
+   against 0 for one opening with plain text, i.e. a ragged left edge down a
+   list of such items. Drop it at both edges. */
+.maka-prose code:first-child {
+  margin-inline-start: 0;
+}
+.maka-prose code:last-child {
+  margin-inline-end: 0;
+}
 .maka-prose a:hover {
   border-bottom-color: var(--link);
 }
@@ -226,8 +246,9 @@
   padding: 0 var(--space-1-5);
   /* Autospace reaches across this boundary already, but its 1.55px is sized
      for bare glyphs; against a pill with its own padding and background the
-     code still reads glued. Stacks on autospace, measured additive.
-     MARKDOWN-PROSE-CJK-MIXED-SPACING-0 locks this. */
+     code still reads glued. Additive, measured: 78.36 → 81.48 (autospace)
+     → 87.45px (both), i.e. 4.55px of clear space per side against the 3.58px
+     of a literal space. MARKDOWN-PROSE-CJK-MIXED-SPACING-0 locks this. */
   margin-inline: 0.25em;
   /* PR-UI-LAYOUT-28: inline code radius 4 → 5. Tiny bump but
    * pulls it slightly out of the "tight tag" feel into a calmer
@@ -333,8 +354,10 @@
   border: 0;
   /* Same boundary: `.maka-prose code` (0,1,1) matches `pre > code` too, and a
      <code> inside `white-space: pre` is one inline box spanning every line, so
-     the pill's margin-inline offset only the FIRST source line (36.25 vs 33). */
+     the pill's margin-inline offset only the FIRST source line (36.25 vs 33).
+     `border: 0` above does not clear the pill's radius, so zero that too. */
   margin: 0;
+  border-radius: 0;
 }
 
 /* Syntax highlight palette for highlight.js / lowlight class names.
@@ -485,8 +508,10 @@
   letter-spacing: var(--tracking-normal);
 }
 /* Don't reach for `word-break: auto-phrase` on `td` for squeezed Chinese cells:
-   measured inert in Chromium 150 — identical breaks to `normal`, since the
-   engine's phrase model is Japanese-only and the renderer is `lang="en"`.
+   measured inert in Chromium 150 — identical breaks to `normal` under both
+   `lang="zh"` and `lang="en"`, because the engine's phrase model is
+   Japanese-only. (The document lang IS set at runtime — syncUiLocaleDocument
+   in locale-context.tsx — so this is not a lang-tagging gap.)
    `line-break: strict` / `word-break: keep-all` do work, at an overflow cost. */
 .maka-prose hr {
   margin: var(--space-4) 0;

--- a/apps/desktop/src/renderer/styles/prose.css
+++ b/apps/desktop/src/renderer/styles/prose.css
@@ -93,14 +93,10 @@
   font-size: var(--font-size-base);
   line-height: var(--leading-normal);
   word-wrap: break-word;
-  /* CJK/Latin boundary spacing. Chromium's initial value is `no-autospace`,
-     NOT the spec's `normal` — verified against the built app — so a CJK-first
-     product renders 中文和identifier glued together unless it asks. Measured
-     +1.55px per boundary at the 13px body (1/8 em), and it applies across
-     inline element boundaries, so the `<code>` pills in a technical answer
-     get it on both sides too.
-     Scoped here rather than on :root: the composer, sidebar and settings
-     surfaces would all shift text metrics, which is a separate call.
+  /* CJK/Latin boundary spacing, +1.55px per boundary (1/8 em at 13px), also
+     across inline element boundaries. Chromium's initial value is
+     `no-autospace`, not the spec's `normal`, so it has to be asked for.
+     Not on :root — that would shift composer and settings metrics too.
      MARKDOWN-PROSE-CJK-MIXED-SPACING-0 locks this. */
   text-autospace: normal;
   /* No max-width here: the reading measure is owned by .maka-message-row
@@ -122,17 +118,11 @@
   margin: 0 0 var(--space-3);
   text-wrap: pretty;
 }
-/* Hard break inside a paragraph. `remark-breaks` (markdown-body.tsx) turns
-   every single newline in the model's output into one of these, and LLM
-   answers lean on `**subhead**\nbody` to separate sections — so this gap
-   routinely carries a SECTION split, not a continuation.
-   Unstyled it gets only the ~4px the line box already provides, against 16px
-   between paragraphs: the stronger semantic split rendered tighter than the
-   weaker one. A native `<br>` cannot be spaced by CSS at all (display:block,
-   height, margin and content:"\A" were each measured — the paragraph stays at
-   exactly 39px), so markdown-body renders the break as this block span, which
-   can take a height. 6px lands the gap at 10px, between the 4px line gap and
-   the 16px paragraph gap.
+/* Hard break inside a paragraph. `remark-breaks` makes every single newline
+   one of these, and LLM answers use `**subhead**\nbody` for section splits, so
+   unstyled the ~4px the line box gives renders the stronger split tighter than
+   the 16px between paragraphs. CSS cannot space a native `<br>` at all, hence
+   the block span markdown-body pairs with it. 6px lands the gap at 10px.
    MARKDOWN-PROSE-CJK-MIXED-SPACING-0 locks this. */
 .maka-hardbreak {
   display: block;
@@ -234,11 +224,9 @@
      two pills). Bg-only pills leave ~5.5px of inter-line air, matching
      plain text; the dropped border was 3% alpha and read as invisible. */
   padding: 0 var(--space-1-5);
-  /* Outer breathing room against surrounding Chinese. `text-autospace` above
-     already reaches across this inline boundary, but its 1.55px is sized for
-     bare glyphs — against a pill carrying its own padding and a filled
-     background the code still reads glued to the text. 0.25em (3.25px)
-     stacks on top of autospace rather than replacing it.
+  /* Autospace reaches across this boundary already, but its 1.55px is sized
+     for bare glyphs; against a pill with its own padding and background the
+     code still reads glued. Stacks on autospace, measured additive.
      MARKDOWN-PROSE-CJK-MIXED-SPACING-0 locks this. */
   margin-inline: 0.25em;
   /* PR-UI-LAYOUT-28: inline code radius 4 → 5. Tiny bump but
@@ -327,17 +315,12 @@
   font-size: var(--font-size-ui);
   line-height: var(--leading-normal);
   white-space: pre;
-  /* THE LITERAL-CODE BOUNDARY. Fenced code renders on a monospace grid, so no
-     prose text shaping may cross into it — the invariant #1431 already locked
-     for ligatures, reached here a second time by an inherited property.
-     `.maka-prose` asks for `text-autospace: normal` (rule 1 of
-     MARKDOWN-PROSE-CJK-MIXED-SPACING-0) and autospace INHERITS, so a code line
-     mixing Chinese comments with Latin identifiers — routine output for a
-     CJK-first product — drifted 1.6px off the grid per boundary until this
-     opted back out. Scoped to the block tier on purpose: the inline pill
-     WANTS autospace on both sides, which is what rule 1 buys.
-     Anything else added to `.maka-prose` that reshapes glyphs belongs here
-     too; MARKDOWN-PROSE-CJK-MIXED-SPACING-0 fails if it is not. */
+  /* The literal-code boundary: no prose text shaping crosses into fenced code,
+     the same invariant #1431 locked for ligatures. `.maka-prose` sets
+     `text-autospace: normal` and autospace inherits, so Chinese comments next
+     to Latin identifiers drifted 1.6px off the monospace grid per boundary.
+     Block tier only — the inline pill wants autospace on both sides.
+     Any future prose shaping belongs here too; the contract fails without it. */
   text-autospace: no-autospace;
 }
 .maka-prose .maka-code-block pre code {
@@ -348,11 +331,9 @@
      box, so a leftover border paints a rounded outline around every wrapped
      line box inside the pre (clearly visible in dark). */
   border: 0;
-  /* Same leak, second property: `.maka-prose code` (0,1,1) matches `pre > code`
-     as well as the pill, so the pill's `margin-inline` reached block code. A
-     <code> inside `white-space: pre` is ONE inline box spanning every line, so
-     that margin offsets only the FIRST source line — measured in the built app,
-     line 1 started at 36.25px against 33px for the lines below it. */
+  /* Same boundary: `.maka-prose code` (0,1,1) matches `pre > code` too, and a
+     <code> inside `white-space: pre` is one inline box spanning every line, so
+     the pill's margin-inline offset only the FIRST source line (36.25 vs 33). */
   margin: 0;
 }
 
@@ -503,14 +484,10 @@
   white-space: nowrap;
   letter-spacing: var(--tracking-normal);
 }
-/* `word-break: auto-phrase` on `td` was tried here for squeezed Chinese cells
-   and REMOVED: measured inert in Chromium 150. Identical break positions to
-   `normal` under both `lang="zh-CN"` and `lang="en"` (只有 `lang="ja"` changes
-   — the engine's phrase model is Japanese-only), and the renderer is pinned to
-   a static `<html lang="en">` with no runtime update, so it was double-gated.
-   If narrow Chinese cells become a real complaint, the levers that do work in
-   this engine are `line-break: strict` / `word-break: keep-all`, each with its
-   own overflow trade-off to measure. */
+/* Don't reach for `word-break: auto-phrase` on `td` for squeezed Chinese cells:
+   measured inert in Chromium 150 — identical breaks to `normal`, since the
+   engine's phrase model is Japanese-only and the renderer is `lang="en"`.
+   `line-break: strict` / `word-break: keep-all` do work, at an overflow cost. */
 .maka-prose hr {
   margin: var(--space-4) 0;
   border: 0;

--- a/apps/desktop/src/renderer/styles/prose.css
+++ b/apps/desktop/src/renderer/styles/prose.css
@@ -327,6 +327,18 @@
   font-size: var(--font-size-ui);
   line-height: var(--leading-normal);
   white-space: pre;
+  /* THE LITERAL-CODE BOUNDARY. Fenced code renders on a monospace grid, so no
+     prose text shaping may cross into it — the invariant #1431 already locked
+     for ligatures, reached here a second time by an inherited property.
+     `.maka-prose` asks for `text-autospace: normal` (rule 1 of
+     MARKDOWN-PROSE-CJK-MIXED-SPACING-0) and autospace INHERITS, so a code line
+     mixing Chinese comments with Latin identifiers — routine output for a
+     CJK-first product — drifted 1.6px off the grid per boundary until this
+     opted back out. Scoped to the block tier on purpose: the inline pill
+     WANTS autospace on both sides, which is what rule 1 buys.
+     Anything else added to `.maka-prose` that reshapes glyphs belongs here
+     too; MARKDOWN-PROSE-CJK-MIXED-SPACING-0 fails if it is not. */
+  text-autospace: no-autospace;
 }
 .maka-prose .maka-code-block pre code {
   padding: 0;
@@ -336,6 +348,12 @@
      box, so a leftover border paints a rounded outline around every wrapped
      line box inside the pre (clearly visible in dark). */
   border: 0;
+  /* Same leak, second property: `.maka-prose code` (0,1,1) matches `pre > code`
+     as well as the pill, so the pill's `margin-inline` reached block code. A
+     <code> inside `white-space: pre` is ONE inline box spanning every line, so
+     that margin offsets only the FIRST source line — measured in the built app,
+     line 1 started at 36.25px against 33px for the lines below it. */
+  margin: 0;
 }
 
 /* Syntax highlight palette for highlight.js / lowlight class names.
@@ -485,14 +503,14 @@
   white-space: nowrap;
   letter-spacing: var(--tracking-normal);
 }
-/* Body cells DO wrap (only `th` is nowrap above), and a squeezed Chinese cell
-   is where breaking gets ugly: the default breaks anywhere, including inside
-   a two-character word. `auto-phrase` breaks on phrase boundaries instead.
-   Scoped to `td` on purpose — on the nowrap `th` a break rule is inert.
-   MARKDOWN-PROSE-CJK-MIXED-SPACING-0 locks this. */
-.maka-prose td {
-  word-break: auto-phrase;
-}
+/* `word-break: auto-phrase` on `td` was tried here for squeezed Chinese cells
+   and REMOVED: measured inert in Chromium 150. Identical break positions to
+   `normal` under both `lang="zh-CN"` and `lang="en"` (只有 `lang="ja"` changes
+   — the engine's phrase model is Japanese-only), and the renderer is pinned to
+   a static `<html lang="en">` with no runtime update, so it was double-gated.
+   If narrow Chinese cells become a real complaint, the levers that do work in
+   this engine are `line-break: strict` / `word-break: keep-all`, each with its
+   own overflow trade-off to measure. */
 .maka-prose hr {
   margin: var(--space-4) 0;
   border: 0;

--- a/packages/ui/src/__tests__/markdown-body.test.ts
+++ b/packages/ui/src/__tests__/markdown-body.test.ts
@@ -64,20 +64,9 @@ it('renders a hard break as a native <br> plus the spacing span (MARKDOWN-PROSE-
     text: '**小节标题**\n正文内容',
   }));
 
-  // Two coupled facts, both measured in the built app (Chromium 150):
-  //
-  // 1. `remarkBreaks` is what turns this SINGLE newline into a break at all.
-  //    Without the plugin CommonMark folds the two lines together, the section
-  //    split disappears, and .maka-hardbreak becomes unreachable dead CSS —
-  //    a regression no CSS contract can see. Asserting on a single-newline
-  //    source keeps the plugin load-bearing.
-  // 2. The break is `<br>` FOLLOWED BY the span, not the span alone. CSS
-  //    cannot give a native <br> any height (display:block / height / margin /
-  //    content:"\A" all leave the paragraph at exactly 39px), which is why the
-  //    span exists — but dropping the <br> costs the `LineBreak` node in the
-  //    accessibility tree (verified via CDP Accessibility.getFullAXTree).
-  //    Emitting both keeps the AX node AND takes the 6px: measured 45px with
-  //    a single "\n" still coming back from Selection.toString().
+  // The source is a SINGLE newline on purpose: `remarkBreaks` is what makes it
+  // a break at all, and without the plugin .maka-hardbreak becomes unreachable
+  // dead CSS — a regression no CSS contract can see.
   assert.match(
     markup,
     /<br\s*\/?>\s*<span class="maka-hardbreak" aria-hidden="true">/,

--- a/packages/ui/src/__tests__/markdown-body.test.ts
+++ b/packages/ui/src/__tests__/markdown-body.test.ts
@@ -58,3 +58,29 @@ it('preserves GFM task-list HAST classes so prose.css task-list rules match (#73
   assert.match(markup, /class="contains-task-list"/, 'bareElement must preserve the HAST className remark-gfm sets on the task-list <ul>; dropping it (round-2 regression) makes prose.css .maka-prose ul.contains-task-list rules stop matching');
   assert.match(markup, /class="task-list-item"/, 'bareElement must preserve the HAST className remark-gfm sets on task-list <li> items');
 });
+
+it('renders a hard break as a native <br> plus the spacing span (MARKDOWN-PROSE-CJK-MIXED-SPACING-0)', () => {
+  const markup = renderToStaticMarkup(createElement(MarkdownBody, {
+    text: '**小节标题**\n正文内容',
+  }));
+
+  // Two coupled facts, both measured in the built app (Chromium 150):
+  //
+  // 1. `remarkBreaks` is what turns this SINGLE newline into a break at all.
+  //    Without the plugin CommonMark folds the two lines together, the section
+  //    split disappears, and .maka-hardbreak becomes unreachable dead CSS —
+  //    a regression no CSS contract can see. Asserting on a single-newline
+  //    source keeps the plugin load-bearing.
+  // 2. The break is `<br>` FOLLOWED BY the span, not the span alone. CSS
+  //    cannot give a native <br> any height (display:block / height / margin /
+  //    content:"\A" all leave the paragraph at exactly 39px), which is why the
+  //    span exists — but dropping the <br> costs the `LineBreak` node in the
+  //    accessibility tree (verified via CDP Accessibility.getFullAXTree).
+  //    Emitting both keeps the AX node AND takes the 6px: measured 45px with
+  //    a single "\n" still coming back from Selection.toString().
+  assert.match(
+    markup,
+    /<br\s*\/?>\s*<span class="maka-hardbreak" aria-hidden="true">/,
+    'a hard break must render as a native <br> followed by the .maka-hardbreak span — the <br> carries the line-break semantics (AX LineBreak node) and the span carries the 6px gap that CSS cannot put on a <br>',
+  );
+});

--- a/packages/ui/src/markdown-body.tsx
+++ b/packages/ui/src/markdown-body.tsx
@@ -135,12 +135,26 @@ export function MarkdownBody(props: { text: string; streaming?: boolean }) {
         // takes no spacing from CSS (display:block / height / margin /
         // content:"\A" were each measured against the built app; the paragraph
         // stays at exactly 39px), because an inline break box cannot be given
-        // a height. Rendering it as a block span can, so the gap becomes a
-        // styleable tier instead of whatever the line box happened to leave.
-        // Decorative — the line break is already conveyed by the block layout,
-        // so it is aria-hidden rather than an empty element in the a11y tree.
+        // a height. A block span CAN take one, so the gap becomes a styleable
+        // tier instead of whatever the line box happened to leave.
+        //
+        // Both elements ship, in this order, because neither alone is
+        // sufficient. Dropping the <br> costs the `LineBreak` node in the
+        // accessibility tree (measured with CDP Accessibility.getFullAXTree:
+        // <br> yields `LineBreak → StaticText`, the bare span yields only
+        // `StaticText`) — the same trade TABLE-A11Y-SEMANTICS-0 below refuses
+        // for table roles. Dropping the span costs the 6px. Together they take
+        // the paragraph to 45px, keep the AX LineBreak node, and still copy as
+        // a single "\n" (Selection.toString(), measured — nesting the <br>
+        // INSIDE the span instead is what produces a spurious "\n\n").
+        // The span is decorative on its own, hence aria-hidden.
         // MARKDOWN-PROSE-CJK-MIXED-SPACING-0.
-        br: () => <span className="maka-hardbreak" aria-hidden="true" />,
+        br: () => (
+          <>
+            <br />
+            <span className="maka-hardbreak" aria-hidden="true" />
+          </>
+        ),
         // #618 item 5: the horizontal scroller for over-wide tables lives on
         // a wrapper div. Scrolling on the table itself requires
         // `display: block`, which stops the element generating a table box —

--- a/packages/ui/src/markdown-body.tsx
+++ b/packages/ui/src/markdown-body.tsx
@@ -129,6 +129,18 @@ export function MarkdownBody(props: { text: string; streaming?: boolean }) {
         // Wrap block code with a language pill header + copy affordance.
         // Surface the detected language so users can verify highlighting.
         pre: ({ children, ...rest }) => <CodeBlock {...rest}>{children}</CodeBlock>,
+        // `remarkBreaks` above turns every single newline into a hard break,
+        // and model answers lean on `**subhead**\nbody` to separate sections —
+        // so this element routinely carries a section split. A native <br>
+        // takes no spacing from CSS (display:block / height / margin /
+        // content:"\A" were each measured against the built app; the paragraph
+        // stays at exactly 39px), because an inline break box cannot be given
+        // a height. Rendering it as a block span can, so the gap becomes a
+        // styleable tier instead of whatever the line box happened to leave.
+        // Decorative — the line break is already conveyed by the block layout,
+        // so it is aria-hidden rather than an empty element in the a11y tree.
+        // MARKDOWN-PROSE-CJK-MIXED-SPACING-0.
+        br: () => <span className="maka-hardbreak" aria-hidden="true" />,
         // #618 item 5: the horizontal scroller for over-wide tables lives on
         // a wrapper div. Scrolling on the table itself requires
         // `display: block`, which stops the element generating a table box —

--- a/packages/ui/src/markdown-body.tsx
+++ b/packages/ui/src/markdown-body.tsx
@@ -131,13 +131,14 @@ export function MarkdownBody(props: { text: string; streaming?: boolean }) {
         pre: ({ children, ...rest }) => <CodeBlock {...rest}>{children}</CodeBlock>,
         // `remarkBreaks` above makes every single newline a hard break, and
         // model answers use `**subhead**\nbody` for section splits, so this
-        // element routinely carries one. Neither element alone works: CSS
-        // cannot give a native <br> any height (an inline break box takes
-        // none), and the span alone drops the `LineBreak` node from the
-        // accessibility tree — the same trade TABLE-A11Y-SEMANTICS-0 below
-        // refuses for table roles. Paired, they keep the AX node, still copy
-        // as a single "\n", and take the paragraph 39px → 45px. Nesting the
-        // <br> inside the span instead is what yields a spurious "\n\n".
+        // element routinely carries one. The span does all the spacing work
+        // (39px → 45px); CSS cannot give a native <br> any height, since an
+        // inline break box takes none. The <br> buys exactly one thing, and
+        // it is not visual: without it the `LineBreak` node disappears from
+        // the accessibility tree — the same trade TABLE-A11Y-SEMANTICS-0
+        // below refuses for table roles. Copy fidelity is a single "\n"
+        // either way; nesting the <br> INSIDE the span is what yields a
+        // spurious "\n\n".
         // MARKDOWN-PROSE-CJK-MIXED-SPACING-0.
         br: () => (
           <>

--- a/packages/ui/src/markdown-body.tsx
+++ b/packages/ui/src/markdown-body.tsx
@@ -129,25 +129,15 @@ export function MarkdownBody(props: { text: string; streaming?: boolean }) {
         // Wrap block code with a language pill header + copy affordance.
         // Surface the detected language so users can verify highlighting.
         pre: ({ children, ...rest }) => <CodeBlock {...rest}>{children}</CodeBlock>,
-        // `remarkBreaks` above turns every single newline into a hard break,
-        // and model answers lean on `**subhead**\nbody` to separate sections —
-        // so this element routinely carries a section split. A native <br>
-        // takes no spacing from CSS (display:block / height / margin /
-        // content:"\A" were each measured against the built app; the paragraph
-        // stays at exactly 39px), because an inline break box cannot be given
-        // a height. A block span CAN take one, so the gap becomes a styleable
-        // tier instead of whatever the line box happened to leave.
-        //
-        // Both elements ship, in this order, because neither alone is
-        // sufficient. Dropping the <br> costs the `LineBreak` node in the
-        // accessibility tree (measured with CDP Accessibility.getFullAXTree:
-        // <br> yields `LineBreak → StaticText`, the bare span yields only
-        // `StaticText`) — the same trade TABLE-A11Y-SEMANTICS-0 below refuses
-        // for table roles. Dropping the span costs the 6px. Together they take
-        // the paragraph to 45px, keep the AX LineBreak node, and still copy as
-        // a single "\n" (Selection.toString(), measured — nesting the <br>
-        // INSIDE the span instead is what produces a spurious "\n\n").
-        // The span is decorative on its own, hence aria-hidden.
+        // `remarkBreaks` above makes every single newline a hard break, and
+        // model answers use `**subhead**\nbody` for section splits, so this
+        // element routinely carries one. Neither element alone works: CSS
+        // cannot give a native <br> any height (an inline break box takes
+        // none), and the span alone drops the `LineBreak` node from the
+        // accessibility tree — the same trade TABLE-A11Y-SEMANTICS-0 below
+        // refuses for table roles. Paired, they keep the AX node, still copy
+        // as a single "\n", and take the paragraph 39px → 45px. Nesting the
+        // <br> inside the span instead is what yields a spurious "\n\n".
         // MARKDOWN-PROSE-CJK-MIXED-SPACING-0.
         br: () => (
           <>


### PR DESCRIPTION
## Summary

Maka is CJK-first and its assistant prose is dense mixed script — Chinese wrapped around identifiers, paths, version numbers and line numbers. Measuring that surface against the built app turned up three spacing gaps, plus a literal-code boundary that has to hold for them. Refs #1433 (item 5, reframed).

**`text-autospace: normal` on `.maka-prose`.** Chromium's initial value is `no-autospace`, not the spec's `normal`, so the CJK/Latin boundary spacing has to be asked for. It reaches across inline element boundaries, so `<code>` pills get it on both sides too. Scoped to the prose layer rather than `:root`: the composer, sidebar and settings surfaces would all shift text metrics, which is a separate call.

**`margin-inline: 0.25em` on inline code.** Autospace alone leaves 1.55px against a pill that already carries padding and a filled background, where the code still reads glued to the surrounding Chinese. The two stack rather than replace each other — measured 78.36px → 81.48px (autospace) → 87.45px (both) on the same paragraph. Zeroed at block edges: that margin is the gap to *neighbouring text*, and at a block edge there is none, so it indented the block instead (2.98px, a ragged left edge down a list of items opening with code).

**`<br>` + `.maka-hardbreak` for hard breaks.** `remark-breaks` turns every single newline into a hard break, and model answers lean on `**subhead**\nbody` to separate sections, so this gap routinely carries a section split. It had only the 4px the line box already gives, against 16px between paragraphs — the stronger semantic split rendered tighter than the weaker one. CSS cannot space a native `<br>`: `display:block`, `height`, `margin` and `content:"\A"` each leave the paragraph at exactly 39px, because an inline break box cannot take a height. So `markdown-body` emits the native `<br>` **followed by** a block span. Both are needed: the span alone drops the `LineBreak` node from the accessibility tree (verified via CDP), and the `<br>` alone cannot be given a height. Together they keep the AX node, keep `Selection.toString()` at a single `\n`, and land the gap at 10px between the 4px line gap and the 16px paragraph gap.

**The hard-break gap is scoped to paragraphs.** `remark-breaks` makes every newline a break, so the 6px also landed on continuation lines inside list items and blockquotes, inverting the grouping: 10.5px inside one list item against 6.5px between two of them. Those containers already group their own content.

**The literal-code boundary.** The first two rules are prose decoration, and both reach fenced code unless carved back out — `text-autospace` inherits, and `.maka-prose code` (0,1,1) matches `pre > code` as well as the inline pill. This is the invariant #1431 already locked for ligatures ("code is a literal surface"), reached a second time by different properties, so `.maka-code-block pre` now carves prose shaping out as a named boundary and the contract guards the *boundary* rather than the two known leaks.

`MARKDOWN-PROSE-CJK-MIXED-SPACING-0` locks the CSS tier; `packages/ui`'s render test locks the DOM tier.

## Verification

`npm --workspace @maka/desktop run test:dist` 2850/2850 · `npm --workspace @maka/ui run test` · `npm run typecheck` · `npm run lint` · `npm run format:check` · `node scripts/check-dead-css.mjs`.

Measured in the **built Electron app** (Electron 43.1.1 / Chromium 150), not headless. That distinction is load-bearing: headless Chromium silently falls PingFang SC back to a serif face while `document.fonts.check` still reports `true`, so every font-dependent number taken there is void. Confirmed with `CSS.getPlatformFontsForNode` that the real stack resolves to `PingFang SC` / `.SF NS` / `Geist Mono (custom)`.

| measurement | before | after |
|---|---|---|
| CJK/Latin boundary | 0 | +1.55px (1/8 em at 13px) |
| Chinese ↔ code pill | 0 | +4.5px per side (autospace + margin, measured additive) |
| hard-break gap | 4px | 10px |
| fenced code, first line vs rest | 36.25px vs 33px | 33px vs 33px |
| block opening with an inline pill | +2.98px indent | 0 |
| list-item continuation vs item gap | 10.5px vs 6.5px | 6.5px vs 6.5px |
| paragraph gap (unchanged) | 16px | 16px |

The contract asserts the *neutral value* of each carve-out, not just that the property name reappears — the first version was a presence check wearing a neutralisation check's error message, and reverting a carve-out to the leaking value kept it green. Deletion-sensitivity was checked by breaking it four ways and confirming each goes red: removing the `pre` autospace carve-out, removing the `pre code` margin reset, and adding a fresh `letter-spacing` to `.maka-prose` with no carve-out. Removing `remarkBreaks` now fails `packages/ui`'s render test, which previously would have left `.maka-hardbreak` as unreachable dead CSS with every assertion still green.

## Review focus

Three-way review (Codex, an independent agent, Kimi K3 256K) all returned FAIL on the first revision and converged on the same defect class; the second commit is the response. What they found, and what changed:

- **Prose decoration leaked into fenced code.** Confirmed independently — the first source line of every code block started 3.25px right of the lines below it, and CJK/Latin code lines drifted off the monospace grid. Fixed at the boundary rather than as two patches, since this was the second arrival of the same invariant at the same seam. (One reviewer rated the margin leak P3 as "symmetric, nearly invisible" from reading the cascade; measuring it shows it is *not* symmetric — a `<code>` in `white-space: pre` is one inline box across all lines, so only line 1 moves.)
- **`word-break: auto-phrase` on `td` was inert.** Removed. Chromium's phrase model is Japanese-only: identical break positions to `normal` under `lang="zh-CN"` and `lang="en"`, while `lang="ja"` does change. Double-gated by the renderer's static `<html lang="en">`. The rule, its comment and its test all asserted a behaviour that does not occur.
- **The bare span cost the AX `LineBreak` node.** Fixed by emitting `<br>` + span. Nesting the `<br>` inside the span instead is what produces a spurious `"\n\n"` on copy; the sibling form has no such cost.
- **The contract was source-regex only, and both leaks passed it.** The DOM half moved to `packages/ui`'s render test where AST → DOM belongs, and the CSS half now guards the boundary as a property class.

An E2E computed-style spec was suggested by all three and **not** taken: `MAKA_E2E_FIXTURE` is a scenario enum, not free-text injection, so pinning specific Markdown would mean adding a product-layer fixture scenario — disproportionate here. The two seams used instead are a real render (`packages/ui`) and a boundary-completeness contract.

Still open as a judgement call: `text-autospace` stays on `.maka-prose`, so a user's own message bubble does not get the same treatment as the assistant's answer. LobeChat puts it on `:root`. Widening it is a follow-up, not an oversight.

Several things were rejected while measuring, each for a recorded reason: narrowing the reading measure (Paseo, opencode and LobeChat all have no fixed measure at all — the premise in #1433 item 5 does not hold); `letter-spacing: 0.02em` (conflicts with the CJK-first no-tracking decision already in `prose.css`); `font-synthesis: style` (PingFang SC has a real Semibold, so all three settings render identically); a CJK font in the mono stack (code-block Chinese already falls back to PingFang SC, and Geist Mono resolves correctly); `remark-cjk-friendly` (10 emphasis cases pass on the current remark — only intraword `_` fails, which is CommonMark's design and applies to Latin equally); and `text-box-trim` (LobeChat shipped, narrowed and reverted it inside a week).
