### PR TITLE
feat(runtime): add agent graph client read model

### DIFF
--- a/apps/desktop/src/main/__tests__/ipc-surface-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/ipc-surface-contract.test.ts
@@ -33,6 +33,27 @@ describe('IPC surface contract', () => {
     assert.deepEqual(staleMainHandlers, [], 'main process must not expose stale invoke handlers outside the preload bridge');
   });
 
+  it('exposes the bounded graph read model without renderer execution authority', async () => {
+    const [main, preload, bridge] = await Promise.all([
+      readMainProcessCombinedSource(),
+      readRepo('apps/desktop/src/preload/preload.ts'),
+      readRepo('apps/desktop/src/preload/bridge-contract.d.ts'),
+    ]);
+    for (const channel of [
+      'graphs:getSnapshot',
+      'graphs:inspectOperator',
+      'graphs:stop',
+    ]) {
+      assert.match(main, new RegExp(`ipcMain\\.handle\\(\\s*['"]${channel}['"]`));
+      assert.match(preload, new RegExp(`ipcRenderer\\.invoke\\(\\s*['"]${channel}['"]`));
+    }
+    assert.match(main, /coordinator\.subscribeAll/);
+    assert.match(preload, /payload\.rootSessionId === rootSessionId/);
+    assert.match(bridge, /AgentGraphClientSnapshot/);
+    assert.match(bridge, /AgentGraphOperatorInspection/);
+    assert.doesNotMatch(bridge, /AgentGraphScheduleControlStore|RuntimeEventStore/);
+  });
+
   it('exposes memory lifecycle IPC without renderer-forged metadata', async () => {
     const [main, preload] = await Promise.all([
       readMainProcessCombinedSource(),

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -8,6 +8,7 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/main.ts',
   'apps/desktop/src/main/app-ipc-main.ts',
   'apps/desktop/src/main/app-lifecycle.ts',
+  'apps/desktop/src/main/agent-graph-ipc-main.ts',
   'apps/desktop/src/main/bot-incoming-main.ts',
   'apps/desktop/src/main/browser-ipc-main.ts',
   'apps/desktop/src/main/config-ipc-main.ts',

--- a/apps/desktop/src/main/__tests__/main-process-wiring-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/main-process-wiring-contract.test.ts
@@ -27,6 +27,7 @@ const extractedIpcRegistrars = [
   ['registerWorkspaceInstructionsIpc', './workspace-instructions-ipc-main'],
   ['registerOnboardingIpc', './onboarding-ipc-main'],
   ['registerSessionEntryIpc', './session-entry-ipc-main'],
+  ['registerAgentGraphIpc', './agent-graph-ipc-main'],
   ['registerSessionsIpc', './sessions-ipc-main'],
   ['registerPermissionsIpc', './permissions-ipc-main'],
   ['registerSettingsIpc', './settings-ipc-main'],

--- a/apps/desktop/src/main/agent-graph-ipc-main.ts
+++ b/apps/desktop/src/main/agent-graph-ipc-main.ts
@@ -1,0 +1,71 @@
+import { ipcMain } from 'electron';
+import type {
+  AgentGraphClientChangedEvent,
+  AgentGraphClientSnapshotOptions,
+  AgentGraphCoordinator,
+} from '@maka/runtime';
+
+export interface AgentGraphIpcDeps {
+  coordinator: AgentGraphCoordinator;
+  sendToRenderer(channel: string, ...args: unknown[]): void;
+}
+
+/**
+ * Read/control adapter for the Desktop graph client.
+ *
+ * The renderer receives bounded read models and invalidation hints only. It
+ * never receives stores, RuntimeEvent payloads, or reconciliation authority.
+ */
+export function registerAgentGraphIpc(deps: AgentGraphIpcDeps): void {
+  ipcMain.handle(
+    'graphs:getSnapshot',
+    (_event, rootSessionId: unknown, options?: unknown) =>
+      deps.coordinator.getSnapshot(
+        requireIdentity(rootSessionId, 'root Session id'),
+        normalizeSnapshotOptions(options),
+      ),
+  );
+  ipcMain.handle(
+    'graphs:inspectOperator',
+    (_event, rootSessionId: unknown, operatorId: unknown) =>
+      deps.coordinator.inspectOperator(
+        requireIdentity(rootSessionId, 'root Session id'),
+        requireIdentity(operatorId, 'operator id'),
+      ),
+  );
+  ipcMain.handle('graphs:stop', (_event, rootSessionId: unknown) =>
+    deps.coordinator.stop(requireIdentity(rootSessionId, 'root Session id')),
+  );
+  deps.coordinator.subscribeAll((event: AgentGraphClientChangedEvent) => {
+    deps.sendToRenderer('graphs:changed', event);
+  });
+}
+
+function normalizeSnapshotOptions(value: unknown): AgentGraphClientSnapshotOptions {
+  if (value === undefined) return {};
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new TypeError('Invalid agent graph snapshot options');
+  }
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.some((key) => key !== 'terminalCursor')) {
+    throw new TypeError('Invalid agent graph snapshot options');
+  }
+  if (record.terminalCursor === undefined) return {};
+  return {
+    terminalCursor: requireIdentity(record.terminalCursor, 'terminal cursor', 2_048),
+  };
+}
+
+function requireIdentity(value: unknown, name: string, maxLength = 512): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > maxLength ||
+    value.trim() !== value ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new TypeError(`Invalid agent graph ${name}`);
+  }
+  return value;
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -136,6 +136,7 @@ import {
 } from './desktop-backend-tool-surface.js';
 import { registerGatewayIpc } from './gateway-ipc-main.js';
 import { registerSessionsIpc } from './sessions-ipc-main.js';
+import { registerAgentGraphIpc } from './agent-graph-ipc-main.js';
 import {
   assertSessionCanSendFromHeader,
   isSessionLifecycleError,
@@ -932,6 +933,10 @@ function registerIpc(): void {
   registerWorkspaceSearchIpc({ getProjectRoot: resolveProjectRootForContext });
   registerGitIpc({ getProjectRoot: resolveProjectRootForContext });
   registerPlanReminderIpc({ planReminders, getWorkspacePrivacyContext });
+  registerAgentGraphIpc({
+    coordinator: agentGraphCoordinator,
+    sendToRenderer: safeSendToRenderer,
+  });
   registerSessionsIpc({
     runtime,
     store,

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -87,7 +87,15 @@ import type {
   McpServerStatus,
   McpTestResult,
 } from '@maka/core/mcp';
-import type { BotStatus, SkillInvocationResult, WechatBridgeQrCodeResult } from '@maka/runtime';
+import type {
+  AgentGraphClientChangedEvent,
+  AgentGraphClientSnapshot,
+  AgentGraphClientSnapshotOptions,
+  AgentGraphOperatorInspection,
+  BotStatus,
+  SkillInvocationResult,
+  WechatBridgeQrCodeResult,
+} from '@maka/runtime';
 import type { BundledSkillCatalogEntry, ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry, SkillGovernanceDetails } from '@maka/ui';
 import type { ConfigCategory } from '@maka/storage';
 import type {
@@ -183,6 +191,21 @@ export interface MakaBridge {
   deepResearch: {
     get(sessionId: string): Promise<DeepResearchRun | undefined>;
     subscribeChanges(handler: (event: DeepResearchChangedEvent) => void): () => void;
+  };
+  graphs: {
+    getSnapshot(
+      rootSessionId: string,
+      options?: AgentGraphClientSnapshotOptions,
+    ): Promise<AgentGraphClientSnapshot>;
+    inspectOperator(
+      rootSessionId: string,
+      operatorId: string,
+    ): Promise<AgentGraphOperatorInspection>;
+    stop(rootSessionId: string): Promise<void>;
+    subscribe(
+      rootSessionId: string,
+      handler: (event: AgentGraphClientChangedEvent) => void,
+    ): () => void;
   };
   sessions: {
     list(filter?: SessionListFilter): Promise<SessionSummary[]>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -90,7 +90,14 @@ import type {
   UsageQuery,
   UsageSummaryV2,
 } from '@maka/core/usage-stats/types';
-import type { BotStatus, WechatBridgeQrCodeResult } from '@maka/runtime';
+import type {
+  AgentGraphClientChangedEvent,
+  AgentGraphClientSnapshot,
+  AgentGraphClientSnapshotOptions,
+  AgentGraphOperatorInspection,
+  BotStatus,
+  WechatBridgeQrCodeResult,
+} from '@maka/runtime';
 import type { GoalState } from '@maka/runtime';
 import type { BundledSkillCatalogEntry, ManagedSkillSourceEntry, ManagedSkillUpdatePreview, SkillEntry, SkillGovernanceDetails } from '@maka/ui';
 import type { ConfigCategory } from '@maka/storage';
@@ -134,6 +141,36 @@ const makaBridge = {
         handler(payload);
       ipcRenderer.on('deepResearch:changed', listener);
       return () => ipcRenderer.off('deepResearch:changed', listener);
+    },
+  },
+  graphs: {
+    getSnapshot(
+      rootSessionId: string,
+      options?: AgentGraphClientSnapshotOptions,
+    ): Promise<AgentGraphClientSnapshot> {
+      return ipcRenderer.invoke('graphs:getSnapshot', rootSessionId, options);
+    },
+    inspectOperator(
+      rootSessionId: string,
+      operatorId: string,
+    ): Promise<AgentGraphOperatorInspection> {
+      return ipcRenderer.invoke('graphs:inspectOperator', rootSessionId, operatorId);
+    },
+    stop(rootSessionId: string): Promise<void> {
+      return ipcRenderer.invoke('graphs:stop', rootSessionId);
+    },
+    subscribe(
+      rootSessionId: string,
+      handler: (event: AgentGraphClientChangedEvent) => void,
+    ): () => void {
+      const listener = (
+        _event: Electron.IpcRendererEvent,
+        payload: AgentGraphClientChangedEvent,
+      ) => {
+        if (payload.rootSessionId === rootSessionId) handler(payload);
+      };
+      ipcRenderer.on('graphs:changed', listener);
+      return () => ipcRenderer.off('graphs:changed', listener);
     },
   },
   sessions: {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -43,6 +43,7 @@
     "./agent-graph-control": "./dist/agent-graph-control.js",
     "./agent-graph-schedule": "./dist/agent-graph-schedule.js",
     "./agent-graph-topology": "./dist/agent-graph-topology.js",
+    "./agent-graph-client-projection": "./dist/agent-graph-client-projection.js",
     "./task-ledger": "./dist/task-ledger.js",
     "./foreign-session": "./dist/foreign-session.js",
     "./deep-research-run": "./dist/deep-research-run.js",

--- a/packages/core/src/agent-graph-client-projection.ts
+++ b/packages/core/src/agent-graph-client-projection.ts
@@ -41,10 +41,19 @@ export interface AgentGraphClientClaimAdmission {
   state: AgentGraphIntentAdmissionState;
 }
 
+export class AgentGraphClientProjectionConflictError extends Error {
+  readonly name = 'AgentGraphClientProjectionConflictError';
+}
+
 export interface CommitAgentGraphClientProjectionRequest {
   schemaVersion: typeof AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION;
   graphId: string;
   rootSessionId: string;
+  /**
+   * Compare-and-set fence for the graph projection.
+   * `null` is create-only; otherwise the current snapshot version must match.
+   */
+  expectedSnapshotVersion: string | null;
   snapshotVersion: string;
   snapshot: unknown;
   replaceOperators: boolean;
@@ -57,6 +66,15 @@ export interface CommitAgentGraphClientProjectionRequest {
     eventTime: number;
     payload: unknown;
   }>;
+  activityRecords: Array<{
+    recordId: string;
+    eventTime: number;
+  }>;
+  /**
+   * Marks an incremental delivery. If this durable record was already applied,
+   * the whole transaction is an idempotent no-op.
+   */
+  incrementalRecordId?: string;
 }
 
 /**
@@ -84,7 +102,5 @@ export interface AgentGraphClientProjectionStore {
       before?: AgentGraphClientTerminalActivityKey;
     },
   ): Promise<AgentGraphClientTerminalActivityPage>;
-  listAgentGraphClientClaimAdmissions(
-    graphId: string,
-  ): Promise<AgentGraphClientClaimAdmission[]>;
+  listAgentGraphClientClaimAdmissions(graphId: string): Promise<AgentGraphClientClaimAdmission[]>;
 }

--- a/packages/core/src/agent-graph-client-projection.ts
+++ b/packages/core/src/agent-graph-client-projection.ts
@@ -1,0 +1,90 @@
+import type { AgentGraphIntentAdmissionState } from './agent-graph-schedule.js';
+
+export const AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION = 1 as const;
+
+export interface AgentGraphClientProjectionRecord {
+  schemaVersion: typeof AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION;
+  graphId: string;
+  rootSessionId: string;
+  snapshotVersion: string;
+  payload: unknown;
+  materializedAt: number;
+}
+
+export interface AgentGraphClientOperatorProjectionRecord {
+  graphId: string;
+  operatorId: string;
+  snapshotVersion: string;
+  payload: unknown;
+  materializedAt: number;
+}
+
+export interface AgentGraphClientTerminalActivityRecord {
+  graphId: string;
+  recordId: string;
+  eventTime: number;
+  payload: unknown;
+}
+
+export interface AgentGraphClientTerminalActivityKey {
+  eventTime: number;
+  recordId: string;
+}
+
+export interface AgentGraphClientTerminalActivityPage {
+  records: AgentGraphClientTerminalActivityRecord[];
+  hasMore: boolean;
+}
+
+export interface AgentGraphClientClaimAdmission {
+  intentId: string;
+  state: AgentGraphIntentAdmissionState;
+}
+
+export interface CommitAgentGraphClientProjectionRequest {
+  schemaVersion: typeof AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION;
+  graphId: string;
+  rootSessionId: string;
+  snapshotVersion: string;
+  snapshot: unknown;
+  replaceOperators: boolean;
+  operators: Array<{
+    operatorId: string;
+    payload: unknown;
+  }>;
+  terminalActivities: Array<{
+    recordId: string;
+    eventTime: number;
+    payload: unknown;
+  }>;
+}
+
+/**
+ * Durable derived read side for graph clients.
+ *
+ * Canonical schedule, Session, AgentRun, and RuntimeEvent ledgers remain the
+ * authority. This projection exists so presentation clients never replay those
+ * ledgers or synchronously scan JSONL on every refresh.
+ */
+export interface AgentGraphClientProjectionStore {
+  commitAgentGraphClientProjection(
+    request: CommitAgentGraphClientProjectionRequest,
+  ): Promise<AgentGraphClientProjectionRecord>;
+  readAgentGraphClientProjection(
+    graphId: string,
+  ): Promise<AgentGraphClientProjectionRecord | undefined>;
+  readAgentGraphClientOperatorProjection(
+    graphId: string,
+    operatorId: string,
+  ): Promise<AgentGraphClientOperatorProjectionRecord | undefined>;
+  listAgentGraphClientTerminalActivities(
+    graphId: string,
+    input: {
+      limit: number;
+      before?: AgentGraphClientTerminalActivityKey;
+    },
+  ): Promise<AgentGraphClientTerminalActivityPage>;
+  listAgentGraphClientClaimAdmissions(
+    graphId: string,
+  ): Promise<AgentGraphClientClaimAdmission[]>;
+}

--- a/packages/core/src/agent-graph-client-projection.ts
+++ b/packages/core/src/agent-graph-client-projection.ts
@@ -11,6 +11,15 @@ export interface AgentGraphClientProjectionRecord {
   materializedAt: number;
 }
 
+export interface AgentGraphClientProjectionWithOperator {
+  projection: AgentGraphClientProjectionRecord;
+  /**
+   * The operator row may have an older content version when another operator
+   * advanced the graph. Both rows are nevertheless read from one DB snapshot.
+   */
+  operator?: AgentGraphClientOperatorProjectionRecord;
+}
+
 export interface AgentGraphClientOperatorProjectionRecord {
   graphId: string;
   operatorId: string;
@@ -95,6 +104,10 @@ export interface AgentGraphClientProjectionStore {
     graphId: string,
     operatorId: string,
   ): Promise<AgentGraphClientOperatorProjectionRecord | undefined>;
+  readAgentGraphClientProjectionWithOperator(
+    graphId: string,
+    operatorId: string,
+  ): Promise<AgentGraphClientProjectionWithOperator | undefined>;
   listAgentGraphClientTerminalActivities(
     graphId: string,
     input: {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -15,6 +15,7 @@ export * from './plan.js';
 export * from './agent-graph-control.js';
 export * from './agent-graph-schedule.js';
 export * from './agent-graph-topology.js';
+export * from './agent-graph-client-projection.js';
 export * from './runtime-policy.js';
 
 // events.ts

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -60,6 +60,7 @@
     "./stream-graph-dispatch": "./dist/stream-graph-dispatch.js",
     "./stream-graph-schedule-reconcile": "./dist/stream-graph-schedule-reconcile.js",
     "./stream-graph-supervisor-tools": "./dist/stream-graph-supervisor-tools.js",
+    "./stream-graph-read-model": "./dist/stream-graph-read-model.js",
     "./stream-graph-coordinator": "./dist/stream-graph-coordinator.js"
   },
   "scripts": {

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -159,6 +159,7 @@ describe('host-managed agent graph coordinator', () => {
       assert.equal(snapshot.operators[0]?.agentId, 'local-read');
       assert.equal(snapshot.work[0]?.instructionPreview, 'Inspect the repository and report one concrete finding.');
       assert.match(snapshot.snapshotVersion, /^sha256:[a-f0-9]{64}$/);
+      const readsBeforeInspection = delayedControlStore.projectionReadCounts();
       const inspection = await coordinator.inspectOperator(
         rootSession.id,
         firstProvisions[0]!.operatorId,
@@ -166,6 +167,10 @@ describe('host-managed agent graph coordinator', () => {
       assert.equal(inspection.operator.childSessionId, childSessions[0]?.id);
       assert.equal(inspection.claims.length, 1);
       assert.equal(inspection.activations.length, 1);
+      assert.deepEqual(delayedControlStore.projectionReadCounts(), {
+        composite: readsBeforeInspection.composite + 1,
+        operator: readsBeforeInspection.operator,
+      });
       assert.equal(
         graphRuntimeHistoryReads,
         historyReadsBeforeClient,
@@ -178,6 +183,26 @@ describe('host-managed agent graph coordinator', () => {
         2,
         'partial text deltas must not cause projection writes or invalidations',
       );
+      const incrementalProjectionCommits =
+        delayedControlStore.projectionCommits.filter(
+          (request) => request.incrementalRecordId !== undefined,
+        );
+      assert.equal(incrementalProjectionCommits.length, 2);
+      assert.ok(
+        incrementalProjectionCommits.every(
+          (request) => request.terminalActivities.length === 0,
+        ),
+        'yielded SessionEvents must never write immutable terminal history',
+      );
+      assert.equal(
+        (
+          await controlStore.listAgentGraphClientTerminalActivities(graphId, {
+            limit: 8,
+          })
+        ).records.length,
+        1,
+        'the authoritative RuntimeEvent fold must populate terminal history',
+      );
       await assert.rejects(
         coordinator.toolsForSession(childSessions[0]!.id),
         /only to root Sessions/,
@@ -186,14 +211,24 @@ describe('host-managed agent graph coordinator', () => {
       await coordinator.close();
       unsubscribe = undefined;
       coordinator = undefined;
+      const projectionFailure = new Error('derived projection unavailable');
+      const derivedFailures: unknown[] = [];
+      delayedControlStore.failProjectionCommits(projectionFailure);
       recovered = createCoordinator({
         sessionStore,
         runStore,
         runtimeEventStore: countedRuntimeEventStore,
         controlStore: delayedControlStore.store,
         manager,
+        onError: (_rootSessionId, error) => {
+          derivedFailures.push(error);
+        },
       });
       assert.deepEqual(await recovered.recover(), [rootSession.id]);
+      assert.ok(
+        derivedFailures.includes(projectionFailure),
+        'recover must report projection failure without failing graph authority',
+      );
       assert.equal(
         (await controlStore.listAgentGraphOperatorProvisions(graphId)).length,
         1,
@@ -232,6 +267,11 @@ describe('host-managed agent graph coordinator', () => {
       } finally {
         gate.release();
       }
+      assert.ok(
+        derivedFailures.filter((error) => error === projectionFailure).length >=
+          2,
+        'stop must report best-effort projection repair failure without rejecting',
+      );
       await pendingUpdate;
       await recovered.waitForIdle(rootSession.id);
       assert.equal(
@@ -418,6 +458,7 @@ function createCoordinator(input: {
   runtimeEventStore: ReturnType<typeof createRuntimeEventStore>;
   controlStore: ReturnType<typeof createSqliteSessionMetadataStore>;
   manager: SessionManager;
+  onError?: AgentGraphCoordinatorInput['onError'];
 }): AgentGraphCoordinator {
   return new AgentGraphCoordinator({
     ...input,
@@ -431,6 +472,11 @@ function createDelayableControlStore(
   store: ReturnType<typeof createSqliteSessionMetadataStore>,
 ): {
   store: ReturnType<typeof createSqliteSessionMetadataStore>;
+  projectionCommits: Array<
+    Parameters<typeof store.commitAgentGraphClientProjection>[0]
+  >;
+  projectionReadCounts(): { composite: number; operator: number };
+  failProjectionCommits(error: unknown): void;
   holdNextCommit(): { started: Promise<void>; release(): void };
 } {
   let gate:
@@ -439,6 +485,12 @@ function createDelayableControlStore(
         release: Promise<void>;
       }
     | undefined;
+  const projectionCommits: Array<
+    Parameters<typeof store.commitAgentGraphClientProjection>[0]
+  > = [];
+  let projectionFailure: unknown;
+  let compositeProjectionReads = 0;
+  let operatorProjectionReads = 0;
   const proxy = new Proxy(store, {
     get(target, property) {
       if (property === 'commitAgentGraphScheduleUpdate') {
@@ -452,12 +504,51 @@ function createDelayableControlStore(
           return target.commitAgentGraphScheduleUpdate(...args);
         };
       }
+      if (property === 'commitAgentGraphClientProjection') {
+        return async (
+          ...args: Parameters<
+            typeof target.commitAgentGraphClientProjection
+          >
+        ) => {
+          projectionCommits.push(structuredClone(args[0]));
+          if (projectionFailure !== undefined) throw projectionFailure;
+          return target.commitAgentGraphClientProjection(...args);
+        };
+      }
+      if (property === 'readAgentGraphClientProjectionWithOperator') {
+        return async (
+          ...args: Parameters<
+            typeof target.readAgentGraphClientProjectionWithOperator
+          >
+        ) => {
+          compositeProjectionReads += 1;
+          return target.readAgentGraphClientProjectionWithOperator(...args);
+        };
+      }
+      if (property === 'readAgentGraphClientOperatorProjection') {
+        return async (
+          ...args: Parameters<
+            typeof target.readAgentGraphClientOperatorProjection
+          >
+        ) => {
+          operatorProjectionReads += 1;
+          return target.readAgentGraphClientOperatorProjection(...args);
+        };
+      }
       const value = Reflect.get(target, property, target);
       return typeof value === 'function' ? value.bind(target) : value;
     },
   });
   return {
     store: proxy,
+    projectionCommits,
+    projectionReadCounts: () => ({
+      composite: compositeProjectionReads,
+      operator: operatorProjectionReads,
+    }),
+    failProjectionCommits(error) {
+      projectionFailure = error;
+    },
     holdNextCommit() {
       if (gate) throw new Error('A delayed graph schedule commit is already pending');
       let markStarted!: () => void;

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -47,6 +47,8 @@ describe('host-managed agent graph coordinator', () => {
     let delayedControlStore:
       | ReturnType<typeof createDelayableControlStore>
       | undefined;
+    const clientEvents: string[] = [];
+    let unsubscribe: (() => void) | undefined;
     try {
       const rootSession = await manager.createSession({
         cwd: root,
@@ -77,6 +79,10 @@ describe('host-managed agent graph coordinator', () => {
         runtimeEventStore,
         controlStore: delayedControlStore.store,
         manager,
+      });
+      unsubscribe = coordinator.subscribe(rootSession.id, (event) => {
+        assert.equal(event.rootSessionId, rootSession.id);
+        clientEvents.push(event.reason);
       });
       const tools = await coordinator.toolsForSession(rootSession.id);
       const update = tools.find((tool) => tool.name === UPDATE_AGENT_GRAPH_TOOL_NAME);
@@ -128,12 +134,37 @@ describe('host-managed agent graph coordinator', () => {
         childSessions[0]?.subagentParent?.graph?.operatorId,
         firstProvisions[0]?.operatorId,
       );
+      const snapshot = await coordinator.getSnapshot(rootSession.id);
+      assert.equal(snapshot.rootSessionId, rootSession.id);
+      assert.equal(snapshot.graphId, graphId);
+      assert.equal(snapshot.scheduleRevision, 1);
+      assert.equal(snapshot.operators.length, 1);
+      assert.equal(snapshot.operators[0]?.childSessionId, childSessions[0]?.id);
+      assert.equal(snapshot.operators[0]?.agentId, 'local-read');
+      assert.equal(snapshot.work[0]?.instructionPreview, 'Inspect the repository and report one concrete finding.');
+      assert.match(snapshot.snapshotVersion, /^sha256:[a-f0-9]{64}$/);
+      const inspection = await coordinator.inspectOperator(
+        rootSession.id,
+        firstProvisions[0]!.operatorId,
+      );
+      assert.equal(inspection.operator.childSessionId, childSessions[0]?.id);
+      assert.equal(inspection.claims.length, 1);
+      assert.equal(inspection.activations.length, 1);
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.ok(clientEvents.includes('schedule_committed'));
+      assert.ok(clientEvents.includes('reconciled'));
+      assert.equal(
+        clientEvents.filter((reason) => reason === 'runtime_activity').length,
+        2,
+        'partial text deltas must not flood durable-state invalidation hints',
+      );
       await assert.rejects(
         coordinator.toolsForSession(childSessions[0]!.id),
         /only to root Sessions/,
       );
 
       await coordinator.close();
+      unsubscribe = undefined;
       coordinator = undefined;
       recovered = createCoordinator({
         sessionStore,
@@ -189,6 +220,7 @@ describe('host-managed agent graph coordinator', () => {
         'a schedule commit authorized before stop must not restart reconciliation',
       );
     } finally {
+      unsubscribe?.();
       await coordinator?.close();
       await recovered?.close();
       controlStore?.close();
@@ -202,6 +234,37 @@ describe('host-managed agent graph coordinator', () => {
     assert.match(graphId, /^agent_graph_[a-f0-9]{32}$/);
     assert.equal(graphId, agentGraphIdForRootSession('root-session'));
     assert.notEqual(graphId, agentGraphIdForRootSession('other-root'));
+  });
+
+  test('keeps completed graph snapshots readable after the root Session is archived', async () => {
+    const coordinator = new AgentGraphCoordinator({
+      sessionStore: {
+        listForRecovery: async () => [],
+        readHeader: async (sessionId: string) =>
+          ({
+            id: sessionId,
+            status: 'archived',
+            isArchived: true,
+          }) as never,
+      },
+      runStore: { listSessionRuns: async () => [] },
+      runtimeEventStore: { readImmutableRuntimeEvents: async () => [] },
+      controlStore: {
+        listAgentGraphOperatorProvisions: async () => [],
+        listAgentGraphScheduleUpdates: async () => [],
+        listAgentGraphIntentClaims: async () => [],
+      },
+      runtime: {},
+      newId: randomUUID,
+      rootSessionId: 'root-session',
+    } as unknown as AgentGraphCoordinatorInput);
+    const snapshot = await coordinator.getSnapshot('root-session');
+    assert.equal(snapshot.status, 'empty');
+    await assert.rejects(
+      coordinator.toolsForSession('root-session'),
+      /Archived Sessions cannot supervise/,
+    );
+    await coordinator.close();
   });
 
   test('surfaces topology cleanup failures from close', async () => {

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -63,6 +63,7 @@ describe('host-managed agent graph coordinator', () => {
       | ReturnType<typeof createDelayableControlStore>
       | undefined;
     const clientEvents: string[] = [];
+    const transientProjectionErrors: unknown[] = [];
     let unsubscribe: (() => void) | undefined;
     try {
       const rootSession = await manager.createSession({
@@ -94,6 +95,9 @@ describe('host-managed agent graph coordinator', () => {
         runtimeEventStore: countedRuntimeEventStore,
         controlStore: delayedControlStore.store,
         manager,
+        onError: (_rootSessionId, error) => {
+          transientProjectionErrors.push(error);
+        },
       });
       unsubscribe = coordinator.subscribe(rootSession.id, (event) => {
         assert.equal(event.rootSessionId, rootSession.id);
@@ -206,6 +210,59 @@ describe('host-managed agent graph coordinator', () => {
       await assert.rejects(
         coordinator.toolsForSession(childSessions[0]!.id),
         /only to root Sessions/,
+      );
+
+      const canonicalProjection =
+        await controlStore.readAgentGraphClientProjection(graphId);
+      assert.ok(canonicalProjection);
+      const staleSnapshot = structuredClone(
+        canonicalProjection.payload as { snapshotVersion: string },
+      );
+      staleSnapshot.snapshotVersion = 'snapshot-stale-v1';
+      await controlStore.commitAgentGraphClientProjection({
+        schemaVersion: 1,
+        graphId,
+        rootSessionId: rootSession.id,
+        expectedSnapshotVersion: canonicalProjection.snapshotVersion,
+        snapshotVersion: staleSnapshot.snapshotVersion,
+        snapshot: staleSnapshot,
+        replaceOperators: false,
+        operators: [],
+        terminalActivities: [],
+        activityRecords: [],
+      });
+      const transientProjectionFailure = new Error(
+        'transient derived projection failure',
+      );
+      delayedControlStore.failNextProjectionCommits(
+        1,
+        transientProjectionFailure,
+      );
+      const commitsBeforeRepair =
+        delayedControlStore.projectionCommits.length;
+      const runtimeActivityBeforeRepair = clientEvents.filter(
+        (reason) => reason === 'runtime_activity',
+      ).length;
+      await coordinator.reconcile(rootSession.id);
+      assert.ok(
+        transientProjectionErrors.includes(transientProjectionFailure),
+      );
+      assert.equal(
+        (
+          await controlStore.readAgentGraphClientProjection(graphId)
+        )?.snapshotVersion,
+        canonicalProjection.snapshotVersion,
+        'reconcile tail must repair a one-shot projection failure without new graph activity',
+      );
+      assert.ok(
+        delayedControlStore.projectionCommits.length >=
+          commitsBeforeRepair + 2,
+        'one failed materialization must be followed by an authoritative repair',
+      );
+      assert.equal(
+        clientEvents.filter((reason) => reason === 'runtime_activity').length,
+        runtimeActivityBeforeRepair,
+        'repair liveness must not depend on new graph runtime activity',
       );
 
       await coordinator.close();
@@ -477,6 +534,7 @@ function createDelayableControlStore(
   >;
   projectionReadCounts(): { composite: number; operator: number };
   failProjectionCommits(error: unknown): void;
+  failNextProjectionCommits(count: number, error: unknown): void;
   holdNextCommit(): { started: Promise<void>; release(): void };
 } {
   let gate:
@@ -489,6 +547,7 @@ function createDelayableControlStore(
     Parameters<typeof store.commitAgentGraphClientProjection>[0]
   > = [];
   let projectionFailure: unknown;
+  let remainingProjectionFailures: number | 'always' = 0;
   let compositeProjectionReads = 0;
   let operatorProjectionReads = 0;
   const proxy = new Proxy(store, {
@@ -511,7 +570,13 @@ function createDelayableControlStore(
           >
         ) => {
           projectionCommits.push(structuredClone(args[0]));
-          if (projectionFailure !== undefined) throw projectionFailure;
+          if (remainingProjectionFailures === 'always') {
+            throw projectionFailure;
+          }
+          if (remainingProjectionFailures > 0) {
+            remainingProjectionFailures -= 1;
+            throw projectionFailure;
+          }
           return target.commitAgentGraphClientProjection(...args);
         };
       }
@@ -548,6 +613,14 @@ function createDelayableControlStore(
     }),
     failProjectionCommits(error) {
       projectionFailure = error;
+      remainingProjectionFailures = 'always';
+    },
+    failNextProjectionCommits(count, error) {
+      if (!Number.isSafeInteger(count) || count < 1) {
+        throw new Error('Projection failure count must be a positive integer');
+      }
+      projectionFailure = error;
+      remainingProjectionFailures = count;
     },
     holdNextCommit() {
       if (gate) throw new Error('A delayed graph schedule commit is already pending');

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -28,6 +28,21 @@ describe('host-managed agent graph coordinator', () => {
     const sessionStore = createSessionStore(root);
     const runStore = createAgentRunStore(root);
     const runtimeEventStore = createRuntimeEventStore(root);
+    let graphRuntimeHistoryReads = 0;
+    const countedRuntimeEventStore = new Proxy(runtimeEventStore, {
+      get(target, property) {
+        if (property === 'readImmutableRuntimeEvents') {
+          return async (
+            ...args: Parameters<typeof target.readImmutableRuntimeEvents>
+          ) => {
+            graphRuntimeHistoryReads += 1;
+            return target.readImmutableRuntimeEvents(...args);
+          };
+        }
+        const value = Reflect.get(target, property, target);
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    });
     const backends = new BackendRegistry();
     backends.register('fake', (context) => new FakeBackend(context));
     const manager = new SessionManager({
@@ -76,7 +91,7 @@ describe('host-managed agent graph coordinator', () => {
       coordinator = createCoordinator({
         sessionStore,
         runStore,
-        runtimeEventStore,
+        runtimeEventStore: countedRuntimeEventStore,
         controlStore: delayedControlStore.store,
         manager,
       });
@@ -128,6 +143,7 @@ describe('host-managed agent graph coordinator', () => {
       assert.equal(firstProvisions[0]?.agentId, 'local-read');
       assert.equal((await controlStore.listAgentGraphIntentClaims(graphId)).length, 1);
       assert.equal((await coordinator.observe(rootSession.id)).projection.operators.length, 1);
+      const historyReadsBeforeClient = graphRuntimeHistoryReads;
       const childSessions = await manager.listChildSessions(rootSession.id);
       assert.equal(childSessions.length, 1);
       assert.equal(
@@ -150,13 +166,17 @@ describe('host-managed agent graph coordinator', () => {
       assert.equal(inspection.operator.childSessionId, childSessions[0]?.id);
       assert.equal(inspection.claims.length, 1);
       assert.equal(inspection.activations.length, 1);
+      assert.equal(
+        graphRuntimeHistoryReads,
+        historyReadsBeforeClient,
+        'client reads must use the materialized SQLite projection',
+      );
       await new Promise<void>((resolve) => setImmediate(resolve));
-      assert.ok(clientEvents.includes('schedule_committed'));
       assert.ok(clientEvents.includes('reconciled'));
       assert.equal(
         clientEvents.filter((reason) => reason === 'runtime_activity').length,
         2,
-        'partial text deltas must not flood durable-state invalidation hints',
+        'partial text deltas must not cause projection writes or invalidations',
       );
       await assert.rejects(
         coordinator.toolsForSession(childSessions[0]!.id),
@@ -169,7 +189,7 @@ describe('host-managed agent graph coordinator', () => {
       recovered = createCoordinator({
         sessionStore,
         runStore,
-        runtimeEventStore,
+        runtimeEventStore: countedRuntimeEventStore,
         controlStore: delayedControlStore.store,
         manager,
       });
@@ -237,6 +257,16 @@ describe('host-managed agent graph coordinator', () => {
   });
 
   test('keeps completed graph snapshots readable after the root Session is archived', async () => {
+    let projection:
+      | {
+          schemaVersion: 1;
+          graphId: string;
+          rootSessionId: string;
+          snapshotVersion: string;
+          payload: unknown;
+          materializedAt: number;
+        }
+      | undefined;
     const coordinator = new AgentGraphCoordinator({
       sessionStore: {
         listForRecovery: async () => [],
@@ -253,6 +283,29 @@ describe('host-managed agent graph coordinator', () => {
         listAgentGraphOperatorProvisions: async () => [],
         listAgentGraphScheduleUpdates: async () => [],
         listAgentGraphIntentClaims: async () => [],
+        listAgentGraphClientClaimAdmissions: async () => [],
+        readAgentGraphClientProjection: async () => projection,
+        commitAgentGraphClientProjection: async (request: {
+          graphId: string;
+          rootSessionId: string;
+          snapshotVersion: string;
+          snapshot: unknown;
+        }) => {
+          projection = {
+            schemaVersion: 1,
+            graphId: request.graphId,
+            rootSessionId: request.rootSessionId,
+            snapshotVersion: request.snapshotVersion,
+            payload: request.snapshot,
+            materializedAt: 1,
+          };
+          return projection;
+        },
+        readAgentGraphClientOperatorProjection: async () => undefined,
+        listAgentGraphClientTerminalActivities: async () => ({
+          records: [],
+          hasMore: false,
+        }),
       },
       runtime: {},
       newId: randomUUID,

--- a/packages/runtime/src/__tests__/stream-graph-read-model.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-read-model.test.ts
@@ -1,0 +1,336 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type {
+  AgentGraphOperatorProvision,
+  AgentGraphScheduleUpdate,
+} from '@maka/core';
+import type { AgentGraphSupervisorObservation } from '../stream-graph-dispatch.js';
+import type {
+  AgentGraphActivationState,
+  AgentGraphRecord,
+} from '../stream-graph-projection.js';
+import {
+  buildAgentGraphClientSnapshot,
+  inspectAgentGraphOperator,
+} from '../stream-graph-read-model.js';
+
+describe('agent graph client read model', () => {
+  test('bounds terminal history with a reconnect-safe opaque cursor', () => {
+    const graphId = 'graph-1';
+    const rootSessionId = 'root-session';
+    const operatorId = 'operator-1';
+    const childSessionId = 'child-session';
+    const records = Array.from({ length: 70 }, (_, index) =>
+      terminalRecord({
+        graphId,
+        operatorId,
+        childSessionId,
+        index,
+      }),
+    );
+    const activations = Object.fromEntries(
+      records.map((record, index) => [
+        record.activationId,
+        activation(record, index),
+      ]),
+    );
+    const observation = {
+      projection: {
+        graphId,
+        operators: [{ operatorId, sessionId: childSessionId }],
+        ignoredPartialEvents: 0,
+        records,
+        supervisorMetaStream: [],
+        state: {
+          graphId,
+          latestEventTime: 69,
+          appliedRecordIds: records.map((record) => record.recordId),
+          operators: {
+            [operatorId]: {
+              operatorId,
+              sessionId: childSessionId,
+              status: 'completed',
+              currentActivationId: 'run-69',
+              activations,
+            },
+          },
+        },
+      },
+      readiness: {
+        schemaVersion: 1,
+        graphId,
+        topologyFingerprint: 'sha256:topology',
+        trace: { graphId },
+        readiness: {},
+        supervisorView: [],
+      },
+      claims: [],
+    } as unknown as AgentGraphSupervisorObservation;
+    const input = {
+      rootSessionId,
+      graphId,
+      provisions: [provision(graphId, operatorId, childSessionId)],
+      scheduleUpdates: [],
+      observation,
+    };
+
+    const first = buildAgentGraphClientSnapshot(input);
+    assert.equal(first.terminalHistory.records.length, 64);
+    assert.ok(first.terminalHistory.nextCursor);
+    assert.equal(first.terminalHistory.records[0]?.recordId, 'record-69');
+    const second = buildAgentGraphClientSnapshot(input, {
+      terminalCursor: first.terminalHistory.nextCursor,
+    });
+    assert.equal(second.terminalHistory.records.length, 6);
+    assert.equal(second.terminalHistory.records[0]?.recordId, 'record-5');
+    assert.equal(second.terminalHistory.nextCursor, undefined);
+    assert.equal(first.snapshotVersion, second.snapshotVersion);
+    assert.notEqual(first.terminalHistory.nextCursor, 'record-5');
+
+    const inspection = inspectAgentGraphOperator(input, operatorId);
+    assert.equal(inspection.activations.length, 64);
+    assert.equal(inspection.omittedActivationCount, 6);
+    assert.equal(inspection.recentRecords.length, 70);
+    assert.equal(inspection.operator.childSessionId, childSessionId);
+  });
+
+  test('rejects a terminal cursor from another graph', () => {
+    const firstInput = emptyInput('graph-1');
+    const cursorSource = buildAgentGraphClientSnapshot({
+      ...firstInput,
+      provisions: [provision('graph-1', 'operator-1', 'child-1')],
+      observation: observationWithOneTerminal('graph-1', 'operator-1', 'child-1'),
+    });
+    // One terminal record has no next page, so create a valid cursor by using
+    // the first page of a larger source graph.
+    const many = Array.from({ length: 65 }, (_, index) =>
+      terminalRecord({
+        graphId: 'graph-1',
+        operatorId: 'operator-1',
+        childSessionId: 'child-1',
+        index,
+      }),
+    );
+    const source = buildAgentGraphClientSnapshot({
+      ...firstInput,
+      provisions: [provision('graph-1', 'operator-1', 'child-1')],
+      observation: observationFromRecords('graph-1', 'operator-1', 'child-1', many),
+    });
+    assert.equal(cursorSource.terminalHistory.nextCursor, undefined);
+    assert.ok(source.terminalHistory.nextCursor);
+    assert.throws(
+      () =>
+        buildAgentGraphClientSnapshot(emptyInput('graph-2'), {
+          terminalCursor: source.terminalHistory.nextCursor,
+        }),
+      /another graph/,
+    );
+  });
+
+  test('keeps schedule payloads bounded while preserving durable control refs', () => {
+    const graphId = 'graph-1';
+    const operatorId = 'operator-1';
+    const childSessionId = 'child-1';
+    const instruction = 'x'.repeat(600);
+    const snapshot = buildAgentGraphClientSnapshot({
+      rootSessionId: 'root-session',
+      graphId,
+      provisions: [provision(graphId, operatorId, childSessionId)],
+      scheduleUpdates: [scheduleUpdate(graphId, instruction)],
+      observation: observationWithOneTerminal(graphId, operatorId, childSessionId),
+    });
+    assert.equal(snapshot.work.length, 1);
+    assert.equal(snapshot.work[0]?.instructionTruncated, true);
+    assert.equal(snapshot.work[0]?.instructionPreview.length, 501);
+    assert.equal(snapshot.recentControlDecisions[0]?.source.agentRunId, 'root-run');
+    assert.deepEqual(snapshot.recentControlDecisions[0]?.addedWorkIds, [
+      'graph_work_00000000000000000000000000000000',
+    ]);
+  });
+});
+
+function emptyInput(graphId: string) {
+  return {
+    rootSessionId: 'root-session',
+    graphId,
+    provisions: [] as AgentGraphOperatorProvision[],
+    scheduleUpdates: [],
+    observation: {
+      projection: {
+        graphId,
+        operators: [],
+        ignoredPartialEvents: 0,
+        records: [],
+        supervisorMetaStream: [],
+        state: { graphId, appliedRecordIds: [], operators: {} },
+      },
+      readiness: {
+        schemaVersion: 1,
+        graphId,
+        topologyFingerprint: 'sha256:empty',
+        trace: { graphId },
+        readiness: {},
+        supervisorView: [],
+      },
+      claims: [],
+    } as unknown as AgentGraphSupervisorObservation,
+  };
+}
+
+function observationWithOneTerminal(
+  graphId: string,
+  operatorId: string,
+  childSessionId: string,
+): AgentGraphSupervisorObservation {
+  return observationFromRecords(
+    graphId,
+    operatorId,
+    childSessionId,
+    [terminalRecord({ graphId, operatorId, childSessionId, index: 0 })],
+  );
+}
+
+function observationFromRecords(
+  graphId: string,
+  operatorId: string,
+  childSessionId: string,
+  records: AgentGraphRecord[],
+): AgentGraphSupervisorObservation {
+  const activations = Object.fromEntries(
+    records.map((record, index) => [record.activationId, activation(record, index)]),
+  );
+  return {
+    projection: {
+      graphId,
+      operators: [{ operatorId, sessionId: childSessionId }],
+      ignoredPartialEvents: 0,
+      records,
+      supervisorMetaStream: [],
+      state: {
+        graphId,
+        latestEventTime: records.at(-1)?.eventTime,
+        appliedRecordIds: records.map((record) => record.recordId),
+        operators: {
+          [operatorId]: {
+            operatorId,
+            sessionId: childSessionId,
+            status: 'completed',
+            currentActivationId: records.at(-1)!.activationId,
+            activations,
+          },
+        },
+      },
+    },
+    readiness: {
+      schemaVersion: 1,
+      graphId,
+      topologyFingerprint: 'sha256:topology',
+      trace: { graphId },
+      readiness: {},
+      supervisorView: [],
+    },
+    claims: [],
+  } as unknown as AgentGraphSupervisorObservation;
+}
+
+function provision(
+  graphId: string,
+  operatorId: string,
+  childSessionId: string,
+): AgentGraphOperatorProvision {
+  return {
+    schemaVersion: 1,
+    provisionId: 'graph_provision_00000000000000000000000000000000',
+    provisionFingerprint: `sha256:${'0'.repeat(64)}`,
+    graphId,
+    workId: 'graph_work_00000000000000000000000000000000',
+    agentId: 'local-read',
+    operatorId,
+    initialTurnId: 'turn-0',
+    initialRunId: 'run-0',
+    edges: [],
+    targetSessionId: childSessionId,
+    provisionedAt: 0,
+  };
+}
+
+function scheduleUpdate(
+  graphId: string,
+  instruction: string,
+): AgentGraphScheduleUpdate {
+  return {
+    schemaVersion: 1,
+    updateId: 'graph_update_00000000000000000000000000000000',
+    updateFingerprint: `sha256:${'1'.repeat(64)}`,
+    graphId,
+    source: {
+      sessionId: 'root-session',
+      runId: 'root-run',
+      turnId: 'root-turn',
+      toolCallId: 'root-tool-call',
+    },
+    addWork: [
+      {
+        workId: 'graph_work_00000000000000000000000000000000',
+        target: { kind: 'agent', agentId: 'local-read' },
+        instruction,
+        inputIds: [],
+      },
+    ],
+    stop: [],
+    revision: 1,
+    committedAt: 1,
+  };
+}
+
+function terminalRecord(input: {
+  graphId: string;
+  operatorId: string;
+  childSessionId: string;
+  index: number;
+}): AgentGraphRecord {
+  return {
+    schemaVersion: 1,
+    recordId: `record-${input.index}`,
+    graphId: input.graphId,
+    operatorId: input.operatorId,
+    activationId: `run-${input.index}`,
+    sessionId: input.childSessionId,
+    agentRunId: `run-${input.index}`,
+    eventTime: input.index,
+    orderKey: {
+      runCreatedAt: input.index,
+      operatorId: input.operatorId,
+      runId: `run-${input.index}`,
+      committedEventOrdinal: 0,
+      runtimeEventId: `event-${input.index}`,
+    },
+    type: 'agent_runtime_event',
+    facets: ['completed'],
+    supervisorSignals: [{ kind: 'terminal', status: 'completed' }],
+    source: {
+      kind: 'runtime_event',
+      runtimeEventId: `event-${input.index}`,
+      sessionId: input.childSessionId,
+      runId: `run-${input.index}`,
+      turnId: `turn-${input.index}`,
+      ts: input.index,
+    },
+  };
+}
+
+function activation(
+  record: AgentGraphRecord,
+  index: number,
+): AgentGraphActivationState {
+  return {
+    activationId: record.activationId,
+    agentRunId: record.agentRunId,
+    status: 'completed',
+    recordCount: 1,
+    firstEventTime: index,
+    lastEventTime: index,
+    lastRecordId: record.recordId,
+    terminalRecordId: record.recordId,
+  };
+}

--- a/packages/runtime/src/__tests__/stream-graph-read-model.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-read-model.test.ts
@@ -89,7 +89,7 @@ describe('agent graph client read model', () => {
 
     const inspection = inspectAgentGraphOperator(input, operatorId);
     assert.equal(inspection.activations.length, 64);
-    assert.equal(inspection.omittedActivationCount, 6);
+    assert.equal(inspection.omitted.activations, 6);
     assert.equal(inspection.recentRecords.length, 70);
     assert.equal(inspection.operator.childSessionId, childSessionId);
   });
@@ -146,6 +146,162 @@ describe('agent graph client read model', () => {
     assert.deepEqual(snapshot.recentControlDecisions[0]?.addedWorkIds, [
       'graph_work_00000000000000000000000000000000',
     ]);
+  });
+
+  test('treats finish as admission closure until existing claims settle', () => {
+    const graphId = 'graph-1';
+    const operatorId = 'operator-1';
+    const childSessionId = 'child-1';
+    const running = terminalRecord({
+      graphId,
+      operatorId,
+      childSessionId,
+      index: 0,
+    });
+    running.facets = ['message'];
+    running.supervisorSignals = [];
+    const runningObservation = observationFromRecords(
+      graphId,
+      operatorId,
+      childSessionId,
+      [running],
+    );
+    const activationState =
+      runningObservation.projection.state.operators[operatorId]!.activations[
+        running.activationId
+      ]!;
+    activationState.status = 'running';
+    delete activationState.terminalRecordId;
+    runningObservation.projection.state.operators[operatorId]!.status = 'running';
+    runningObservation.claims = [
+      {
+        schemaVersion: 1,
+        claimId: `graph_claim_${'1'.repeat(32)}`,
+        graphId,
+        intentId: `graph_intent_${'2'.repeat(32)}`,
+        intentFingerprint: `sha256:${'3'.repeat(64)}`,
+        readinessContextFingerprint: `sha256:${'4'.repeat(64)}`,
+        targetOperatorId: operatorId,
+        targetSessionId: childSessionId,
+        targetTurnId: 'turn-0',
+        targetRunId: 'run-0',
+        claimedAt: 0,
+      },
+    ];
+    const finish = finishUpdate(graphId, running.recordId);
+    const closing = buildAgentGraphClientSnapshot({
+      rootSessionId: 'root-session',
+      graphId,
+      provisions: [provision(graphId, operatorId, childSessionId)],
+      scheduleUpdates: [finish],
+      observation: runningObservation,
+    });
+    assert.equal(closing.closed, true);
+    assert.equal(closing.status, 'closing');
+
+    assert.equal(
+      buildAgentGraphClientSnapshot({
+        rootSessionId: 'root-session',
+        graphId,
+        provisions: [provision(graphId, operatorId, childSessionId)],
+        scheduleUpdates: [finish],
+        observation: {
+          ...observationWithOneTerminal(graphId, operatorId, childSessionId),
+          claims: runningObservation.claims,
+        },
+      }).status,
+      'completed',
+    );
+  });
+
+  test('bounds nested operator and inspection collections with omitted counts', () => {
+    const graphId = 'graph-1';
+    const operatorId = 'operator-1';
+    const childSessionId = 'child-1';
+    const baseProvision = provision(graphId, operatorId, childSessionId);
+    const edges = Array.from({ length: 600 }, (_, index) => ({
+      edgeId: `edge-${index}`,
+      fromOperatorId: operatorId,
+      toOperatorId: `downstream-${index}`,
+    }));
+    const work = Array.from({ length: 300 }, (_, index) => ({
+      workId: `work-${index}`,
+      target: { kind: 'operator' as const, operatorId },
+      inputIds: [],
+      status: 'requested' as const,
+      instruction: `work ${index}`,
+      revision: index + 1,
+      committedAt: index + 1,
+    }));
+    const observation = observationWithOneTerminal(
+      graphId,
+      operatorId,
+      childSessionId,
+    );
+    observation.claims = Array.from({ length: 300 }, (_, index) => ({
+      schemaVersion: 1,
+      claimId: `claim-${index}`,
+      graphId,
+      intentId: `intent-${index}`,
+      intentFingerprint: `sha256:${'1'.repeat(64)}`,
+      readinessContextFingerprint: `sha256:${'2'.repeat(64)}`,
+      targetOperatorId: operatorId,
+      targetSessionId: childSessionId,
+      targetTurnId: `turn-${index}`,
+      targetRunId: `claimed-run-${index}`,
+      claimedAt: index,
+    }));
+    observation.readiness.supervisorView = Array.from(
+      { length: 80 },
+      (_, index) => ({
+        graphId,
+        topologyFingerprint: 'sha256:topology',
+        readinessId: `readiness-${index}`,
+        operatorId,
+        policyKind: 'all_settled' as const,
+        policyFingerprint: `policy-${index}`,
+        readinessContextFingerprint: `context-${index}`,
+        status: 'waiting' as const,
+        intentIds: [],
+        waitingFor: Array.from({ length: 300 }, (__, waitIndex) => ({
+          kind: 'activation_running' as const,
+          operatorId: `upstream-${waitIndex}`,
+          activationId: `activation-${waitIndex}`,
+        })),
+      }),
+    );
+    const input = {
+      rootSessionId: 'root-session',
+      graphId,
+      provisions: [{ ...baseProvision, edges }],
+      scheduleUpdates: [],
+      schedule: {
+        graphId,
+        revision: 300,
+        work,
+        stoppedTargets: [],
+        closed: false,
+      },
+      observation,
+    } as unknown as Parameters<typeof buildAgentGraphClientSnapshot>[0];
+    const snapshot = buildAgentGraphClientSnapshot(input);
+    const operator = snapshot.operators[0]!;
+    assert.equal(operator.outboundEdgeIds.length, 64);
+    assert.equal(operator.omitted.outboundEdgeIds, 536);
+    assert.equal(operator.scheduledWorkIds.length, 64);
+    assert.equal(operator.omitted.scheduledWorkIds, 236);
+    assert.equal(operator.readiness.length, 8);
+    assert.equal(operator.omitted.readiness, 72);
+    assert.equal(operator.readiness[0]?.waitingFor.length, 64);
+    assert.equal(operator.omitted.readinessWaits, 80 * 236);
+
+    const inspection = inspectAgentGraphOperator(input, operatorId);
+    assert.equal(inspection.outboundEdges.length, 512);
+    assert.equal(inspection.omitted.outboundEdges, 88);
+    assert.equal(inspection.work.length, 256);
+    assert.equal(inspection.omitted.work, 44);
+    assert.equal(inspection.claims.length, 256);
+    assert.equal(inspection.omitted.claims, 44);
   });
 });
 
@@ -278,6 +434,32 @@ function scheduleUpdate(
       },
     ],
     stop: [],
+    revision: 1,
+    committedAt: 1,
+  };
+}
+
+function finishUpdate(
+  graphId: string,
+  resultId: string,
+): AgentGraphScheduleUpdate {
+  return {
+    schemaVersion: 1,
+    updateId: `graph_update_${'5'.repeat(32)}`,
+    updateFingerprint: `sha256:${'6'.repeat(64)}`,
+    graphId,
+    source: {
+      sessionId: 'root-session',
+      runId: 'root-run',
+      turnId: 'root-turn',
+      toolCallId: 'finish-tool-call',
+    },
+    addWork: [],
+    stop: [],
+    finish: {
+      resultIds: [resultId],
+      reason: 'Enough evidence is available.',
+    },
     revision: 1,
     committedAt: 1,
   };

--- a/packages/runtime/src/__tests__/stream-graph-read-model.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-read-model.test.ts
@@ -1,17 +1,17 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
+import type { AgentGraphOperatorProvision, AgentGraphScheduleUpdate } from '@maka/core';
 import type {
-  AgentGraphOperatorProvision,
-  AgentGraphScheduleUpdate,
-} from '@maka/core';
-import type { AgentGraphSupervisorObservation } from '../stream-graph-dispatch.js';
-import type {
-  AgentGraphActivationState,
-  AgentGraphRecord,
-} from '../stream-graph-projection.js';
+  AgentGraphSupervisorObservation,
+  AgentGraphSupervisorRuntimeEvent,
+} from '../stream-graph-dispatch.js';
+import type { AgentGraphActivationState, AgentGraphRecord } from '../stream-graph-projection.js';
 import {
+  advanceMaterializedAgentGraphClientProjection,
   buildAgentGraphClientSnapshot,
   inspectAgentGraphOperator,
+  materializeAgentGraphClientProjection,
+  type AgentGraphClientActivity,
 } from '../stream-graph-read-model.js';
 
 describe('agent graph client read model', () => {
@@ -29,10 +29,7 @@ describe('agent graph client read model', () => {
       }),
     );
     const activations = Object.fromEntries(
-      records.map((record, index) => [
-        record.activationId,
-        activation(record, index),
-      ]),
+      records.map((record, index) => [record.activationId, activation(record, index)]),
     );
     const observation = {
       projection: {
@@ -160,16 +157,11 @@ describe('agent graph client read model', () => {
     });
     running.facets = ['message'];
     running.supervisorSignals = [];
-    const runningObservation = observationFromRecords(
-      graphId,
-      operatorId,
-      childSessionId,
-      [running],
-    );
+    const runningObservation = observationFromRecords(graphId, operatorId, childSessionId, [
+      running,
+    ]);
     const activationState =
-      runningObservation.projection.state.operators[operatorId]!.activations[
-        running.activationId
-      ]!;
+      runningObservation.projection.state.operators[operatorId]!.activations[running.activationId]!;
     activationState.status = 'running';
     delete activationState.terminalRecordId;
     runningObservation.projection.state.operators[operatorId]!.status = 'running';
@@ -233,11 +225,7 @@ describe('agent graph client read model', () => {
       revision: index + 1,
       committedAt: index + 1,
     }));
-    const observation = observationWithOneTerminal(
-      graphId,
-      operatorId,
-      childSessionId,
-    );
+    const observation = observationWithOneTerminal(graphId, operatorId, childSessionId);
     observation.claims = Array.from({ length: 300 }, (_, index) => ({
       schemaVersion: 1,
       claimId: `claim-${index}`,
@@ -251,25 +239,22 @@ describe('agent graph client read model', () => {
       targetRunId: `claimed-run-${index}`,
       claimedAt: index,
     }));
-    observation.readiness.supervisorView = Array.from(
-      { length: 80 },
-      (_, index) => ({
-        graphId,
-        topologyFingerprint: 'sha256:topology',
-        readinessId: `readiness-${index}`,
-        operatorId,
-        policyKind: 'all_settled' as const,
-        policyFingerprint: `policy-${index}`,
-        readinessContextFingerprint: `context-${index}`,
-        status: 'waiting' as const,
-        intentIds: [],
-        waitingFor: Array.from({ length: 300 }, (__, waitIndex) => ({
-          kind: 'activation_running' as const,
-          operatorId: `upstream-${waitIndex}`,
-          activationId: `activation-${waitIndex}`,
-        })),
-      }),
-    );
+    observation.readiness.supervisorView = Array.from({ length: 80 }, (_, index) => ({
+      graphId,
+      topologyFingerprint: 'sha256:topology',
+      readinessId: `readiness-${index}`,
+      operatorId,
+      policyKind: 'all_settled' as const,
+      policyFingerprint: `policy-${index}`,
+      readinessContextFingerprint: `context-${index}`,
+      status: 'waiting' as const,
+      intentIds: [],
+      waitingFor: Array.from({ length: 300 }, (__, waitIndex) => ({
+        kind: 'activation_running' as const,
+        operatorId: `upstream-${waitIndex}`,
+        activationId: `activation-${waitIndex}`,
+      })),
+    }));
     const input = {
       rootSessionId: 'root-session',
       graphId,
@@ -302,6 +287,116 @@ describe('agent graph client read model', () => {
     assert.equal(inspection.omitted.work, 44);
     assert.equal(inspection.claims.length, 256);
     assert.equal(inspection.omitted.claims, 44);
+  });
+
+  test('materializes duplicate and out-of-order runtime records deterministically', () => {
+    const graphId = 'graph-order';
+    const operatorId = 'operator-1';
+    const childSessionId = 'child-1';
+    const baseInput = runningInput(graphId, operatorId, childSessionId);
+    const initial = materializeAgentGraphClientProjection(baseInput);
+    const message = supervisorRuntimeEvent({
+      graphId,
+      operatorId,
+      childSessionId,
+      eventId: 'event-message',
+      eventTime: 10,
+      eventType: 'text_complete',
+    });
+    const complete = supervisorRuntimeEvent({
+      graphId,
+      operatorId,
+      childSessionId,
+      eventId: 'event-complete',
+      eventTime: 20,
+      eventType: 'complete',
+    });
+
+    const messageFirst = advanceMaterializedAgentGraphClientProjection(
+      initial.snapshot,
+      initial.operators[0]!,
+      message,
+      false,
+    )!;
+    const forward = advanceMaterializedAgentGraphClientProjection(
+      messageFirst.snapshot,
+      messageFirst.operator,
+      complete,
+      false,
+    )!;
+    const completeFirst = advanceMaterializedAgentGraphClientProjection(
+      initial.snapshot,
+      initial.operators[0]!,
+      complete,
+      false,
+    )!;
+    const reverse = advanceMaterializedAgentGraphClientProjection(
+      completeFirst.snapshot,
+      completeFirst.operator,
+      message,
+      false,
+    )!;
+
+    assert.deepEqual(
+      { ...forward.snapshot, snapshotVersion: '' },
+      { ...reverse.snapshot, snapshotVersion: '' },
+    );
+    assert.equal(forward.snapshot.snapshotVersion, reverse.snapshot.snapshotVersion);
+    assert.deepEqual(forward.snapshot.recentActivity, reverse.snapshot.recentActivity);
+    assert.deepEqual(forward.operator.activations, reverse.operator.activations);
+    assert.equal(reverse.operator.operator.status, 'completed');
+    assert.equal(
+      advanceMaterializedAgentGraphClientProjection(
+        forward.snapshot,
+        forward.operator,
+        message,
+        false,
+      ),
+      undefined,
+    );
+
+    const canonicalRecords = forward.snapshot.recentActivity.map((activity, index) =>
+      graphRecordFromActivity(graphId, activity, index),
+    );
+    const canonicalObservation = observationFromRecords(
+      graphId,
+      operatorId,
+      childSessionId,
+      canonicalRecords,
+    );
+    canonicalObservation.readiness.topologyFingerprint =
+      baseInput.observation.readiness.topologyFingerprint;
+    canonicalObservation.projection.state.operators[operatorId]!.activations = {
+      'run-0': {
+        activationId: 'run-0',
+        agentRunId: 'run-0',
+        status: 'completed',
+        recordCount: 2,
+        firstEventTime: 10,
+        lastEventTime: 20,
+        lastRecordId: forward.activity.recordId,
+        terminalRecordId: forward.activity.recordId,
+      },
+    };
+    canonicalObservation.projection.state.operators[operatorId]!.currentActivationId = 'run-0';
+    canonicalObservation.projection.state.operators[operatorId]!.status = 'completed';
+    const rebuilt = materializeAgentGraphClientProjection({
+      ...baseInput,
+      observation: canonicalObservation,
+    });
+    const {
+      snapshotVersion: _rebuiltVersion,
+      terminalHistory: _rebuiltTerminalHistory,
+      ...rebuiltContent
+    } = rebuilt.snapshot;
+    const {
+      snapshotVersion: _forwardVersion,
+      terminalHistory: _forwardTerminalHistory,
+      ...forwardContent
+    } = forward.snapshot;
+    assert.deepEqual(rebuiltContent, forwardContent);
+    assert.equal(rebuilt.snapshot.snapshotVersion, forward.snapshot.snapshotVersion);
+    assert.deepEqual(rebuilt.snapshot.recentActivity, forward.snapshot.recentActivity);
   });
 });
 
@@ -338,12 +433,9 @@ function observationWithOneTerminal(
   operatorId: string,
   childSessionId: string,
 ): AgentGraphSupervisorObservation {
-  return observationFromRecords(
-    graphId,
-    operatorId,
-    childSessionId,
-    [terminalRecord({ graphId, operatorId, childSessionId, index: 0 })],
-  );
+  return observationFromRecords(graphId, operatorId, childSessionId, [
+    terminalRecord({ graphId, operatorId, childSessionId, index: 0 }),
+  ]);
 }
 
 function observationFromRecords(
@@ -410,10 +502,7 @@ function provision(
   };
 }
 
-function scheduleUpdate(
-  graphId: string,
-  instruction: string,
-): AgentGraphScheduleUpdate {
+function scheduleUpdate(graphId: string, instruction: string): AgentGraphScheduleUpdate {
   return {
     schemaVersion: 1,
     updateId: 'graph_update_00000000000000000000000000000000',
@@ -439,10 +528,7 @@ function scheduleUpdate(
   };
 }
 
-function finishUpdate(
-  graphId: string,
-  resultId: string,
-): AgentGraphScheduleUpdate {
+function finishUpdate(graphId: string, resultId: string): AgentGraphScheduleUpdate {
   return {
     schemaVersion: 1,
     updateId: `graph_update_${'5'.repeat(32)}`,
@@ -501,10 +587,7 @@ function terminalRecord(input: {
   };
 }
 
-function activation(
-  record: AgentGraphRecord,
-  index: number,
-): AgentGraphActivationState {
+function activation(record: AgentGraphRecord, index: number): AgentGraphActivationState {
   return {
     activationId: record.activationId,
     agentRunId: record.agentRunId,
@@ -514,5 +597,77 @@ function activation(
     lastEventTime: index,
     lastRecordId: record.recordId,
     terminalRecordId: record.recordId,
+  };
+}
+
+function runningInput(graphId: string, operatorId: string, childSessionId: string) {
+  const input = emptyInput(graphId);
+  input.provisions = [provision(graphId, operatorId, childSessionId)];
+  input.observation.projection.operators = [{ operatorId, sessionId: childSessionId }];
+  return input;
+}
+
+function supervisorRuntimeEvent(input: {
+  graphId: string;
+  operatorId: string;
+  childSessionId: string;
+  eventId: string;
+  eventTime: number;
+  eventType: 'text_complete' | 'complete';
+}): AgentGraphSupervisorRuntimeEvent {
+  return {
+    intent: {
+      graphId: input.graphId,
+    },
+    claim: {
+      targetOperatorId: input.operatorId,
+      targetSessionId: input.childSessionId,
+      targetRunId: 'run-0',
+      targetTurnId: 'turn-0',
+    },
+    event: {
+      id: input.eventId,
+      type: input.eventType,
+      ts: input.eventTime,
+      sessionId: input.childSessionId,
+      runId: 'run-0',
+      turnId: 'turn-0',
+      ...(input.eventType === 'complete' ? { stopReason: 'end_turn' } : { text: 'message' }),
+    },
+  } as unknown as AgentGraphSupervisorRuntimeEvent;
+}
+
+function graphRecordFromActivity(
+  graphId: string,
+  activity: AgentGraphClientActivity,
+  index: number,
+): AgentGraphRecord {
+  return {
+    schemaVersion: 1,
+    recordId: activity.recordId,
+    graphId,
+    operatorId: activity.operatorId,
+    activationId: activity.activationId,
+    sessionId: activity.run.sessionId,
+    agentRunId: activity.run.agentRunId,
+    eventTime: activity.eventTime,
+    orderKey: {
+      runCreatedAt: 0,
+      operatorId: activity.operatorId,
+      runId: activity.run.agentRunId,
+      committedEventOrdinal: index,
+      runtimeEventId: `runtime-${index}`,
+    },
+    type: 'agent_runtime_event',
+    facets: [...activity.facets],
+    supervisorSignals: activity.signals.map((signal) => ({ ...signal })),
+    source: {
+      kind: 'runtime_event',
+      runtimeEventId: `runtime-${index}`,
+      sessionId: activity.run.sessionId,
+      runId: activity.run.agentRunId,
+      turnId: activity.run.turnId ?? 'turn-0',
+      ts: activity.eventTime,
+    },
   };
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -133,16 +133,27 @@ export type {
   ViewAgentGraphToolResult,
 } from './stream-graph-supervisor-tools.js';
 export {
+  AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE,
   AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION,
+  advanceMaterializedAgentGraphClientProjection,
   buildAgentGraphClientSnapshot,
+  decodeAgentGraphTerminalCursor,
+  decodeMaterializedAgentGraphClientActivity,
+  decodeMaterializedAgentGraphClientSnapshot,
+  decodeMaterializedAgentGraphOperatorInspection,
+  encodeAgentGraphTerminalCursor,
   inspectAgentGraphOperator,
+  materializeAgentGraphClientProjection,
+  materializedAgentGraphTerminalHistoryPage,
 } from './stream-graph-read-model.js';
 export type {
   AgentGraphClientActivity,
+  AdvancedAgentGraphClientProjection,
   AgentGraphClientClaimRef,
   AgentGraphClientControlDecision,
   AgentGraphClientEdge,
   AgentGraphClientFinish,
+  AgentGraphClientMaterialization,
   AgentGraphClientOperator,
   AgentGraphClientOperatorStatus,
   AgentGraphClientRunRef,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -133,11 +133,37 @@ export type {
   ViewAgentGraphToolResult,
 } from './stream-graph-supervisor-tools.js';
 export {
+  AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION,
+  buildAgentGraphClientSnapshot,
+  inspectAgentGraphOperator,
+} from './stream-graph-read-model.js';
+export type {
+  AgentGraphClientActivity,
+  AgentGraphClientClaimRef,
+  AgentGraphClientControlDecision,
+  AgentGraphClientEdge,
+  AgentGraphClientFinish,
+  AgentGraphClientOperator,
+  AgentGraphClientOperatorStatus,
+  AgentGraphClientRunRef,
+  AgentGraphClientScheduledWork,
+  AgentGraphClientSnapshot,
+  AgentGraphClientSnapshotOptions,
+  AgentGraphClientStatus,
+  AgentGraphClientStoppedTarget,
+  AgentGraphClientTerminalHistoryPage,
+  AgentGraphOperatorInspection,
+  BuildAgentGraphClientReadModelInput,
+} from './stream-graph-read-model.js';
+export {
   AgentGraphCoordinator,
   agentGraphIdForRootSession,
   topologyFromProvisions,
 } from './stream-graph-coordinator.js';
 export type {
+  AgentGraphClientChangedEvent,
+  AgentGraphClientChangedListener,
+  AgentGraphClientChangedReason,
   AgentGraphCoordinatorInput,
   AgentGraphCoordinatorRuntime,
   AgentGraphCoordinatorSessionStore,

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -241,11 +241,21 @@ export class AgentGraphCoordinator {
   ): Promise<AgentGraphOperatorInspection> {
     await this.#assertRootGraphReader(rootSessionId);
     const graphId = agentGraphIdForRootSession(rootSessionId);
-    const graph = await this.#readOrRebuildClientProjection(rootSessionId, graphId);
-    const operator = await this.#input.controlStore.readAgentGraphClientOperatorProjection(
+    await this.#readOrRebuildClientProjection(rootSessionId, graphId);
+    const materialized = await this.#input.controlStore.readAgentGraphClientProjectionWithOperator(
       graphId,
       operatorId,
     );
+    if (!materialized) {
+      throw new Error(`Agent graph ${graphId} has no materialized client projection`);
+    }
+    const { projection: graph, operator } = materialized;
+    if (
+      graph.schemaVersion !== AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION ||
+      graph.rootSessionId !== rootSessionId
+    ) {
+      throw new Error(`Invalid materialized agent graph projection ${graphId}`);
+    }
     if (!operator) {
       throw new Error(`Agent graph operator ${operatorId} was not found`);
     }
@@ -411,8 +421,7 @@ export class AgentGraphCoordinator {
       driver.stopping = false;
     }
     throwCollectedFailures(`Failed to stop agent graph ${driver.graphId}`, failures);
-    await this.#waitForClientProjectionUpdates(driver);
-    await this.#rebuildClientProjection(driver.rootSessionId, driver.graphId);
+    await this.#repairClientProjectionBestEffort(driver);
     this.#notifyClientChanged(driver, 'stopped');
   }
 
@@ -464,11 +473,6 @@ export class AgentGraphCoordinator {
         const result = await this.#reconcileOnce(driver, abortController.signal);
         driver.lastResult = result;
         await this.#waitForClientProjectionUpdates(driver);
-        await this.#materializeClientProjection(
-          driver.rootSessionId,
-          driver.graphId,
-          result.observation,
-        );
         await notify(this.#input.onReconciliation, driver.rootSessionId, result);
         this.#notifyClientChanged(driver, 'reconciled');
       } catch (error) {
@@ -681,8 +685,18 @@ export class AgentGraphCoordinator {
 
   async #waitForClientProjectionUpdates(driver: GraphDriver): Promise<void> {
     await driver.clientProjectionTask?.catch(() => {
-      // The authoritative rebuild below repairs failed derived updates.
+      // A best-effort repair or later durable observation may repair this
+      // derived read side; graph authority never depends on it.
     });
+  }
+
+  async #repairClientProjectionBestEffort(driver: GraphDriver): Promise<void> {
+    await this.#waitForClientProjectionUpdates(driver);
+    try {
+      await this.#rebuildClientProjection(driver.rootSessionId, driver.graphId);
+    } catch (error) {
+      await notify(this.#input.onError, driver.rootSessionId, error);
+    }
   }
 
   async #advanceClientProjection(
@@ -734,15 +748,11 @@ export class AgentGraphCoordinator {
               payload: advanced.operator,
             },
           ],
-          terminalActivities: advanced.terminalActivity
-            ? [
-                {
-                  recordId: advanced.terminalActivity.recordId,
-                  eventTime: advanced.terminalActivity.eventTime,
-                  payload: advanced.terminalActivity,
-                },
-              ]
-            : [],
+          // AgentRun may still rewrite this yielded SessionEvent at its
+          // terminal durability barrier (for example complete -> aborted in a
+          // stop race). Only the authoritative RuntimeEvent fold populates the
+          // immutable terminal-history table.
+          terminalActivities: [],
           activityRecords: [
             {
               recordId: advanced.activity.recordId,

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -1,4 +1,5 @@
 import type {
+  AgentGraphClientProjectionStore,
   AgentGraphIntentClaim,
   AgentGraphScheduleControlStore,
   AgentGraphScheduleUpdate,
@@ -8,6 +9,7 @@ import type {
   SessionHeader,
 } from '@maka/core';
 import { decodeAgentGraphIntentClaim } from '@maka/core';
+import { AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION } from '@maka/core';
 import type { MakaTool } from './tool-runtime.js';
 import type { SessionManager } from './session-manager.js';
 import {
@@ -29,8 +31,14 @@ import {
   type RenderAgentGraphScheduledWorkPromptInput,
 } from './stream-graph-schedule-reconcile.js';
 import {
-  buildAgentGraphClientSnapshot,
-  inspectAgentGraphOperator,
+  AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE,
+  advanceMaterializedAgentGraphClientProjection,
+  decodeAgentGraphTerminalCursor,
+  decodeMaterializedAgentGraphClientActivity,
+  decodeMaterializedAgentGraphClientSnapshot,
+  decodeMaterializedAgentGraphOperatorInspection,
+  materializeAgentGraphClientProjection,
+  materializedAgentGraphTerminalHistoryPage,
   type AgentGraphClientSnapshot,
   type AgentGraphClientSnapshotOptions,
   type AgentGraphOperatorInspection,
@@ -57,7 +65,7 @@ export interface AgentGraphCoordinatorInput {
   sessionStore: AgentGraphCoordinatorSessionStore;
   runStore: Pick<AgentRunStore, 'listSessionRuns'>;
   runtimeEventStore: Pick<RuntimeEventStore, 'readImmutableRuntimeEvents'>;
-  controlStore: AgentGraphScheduleControlStore;
+  controlStore: AgentGraphScheduleControlStore & AgentGraphClientProjectionStore;
   runtime: AgentGraphCoordinatorRuntime;
   newId: () => string;
   /** Restrict an attempt-local coordinator to exactly one root Session graph. */
@@ -89,12 +97,14 @@ interface GraphDriver {
   abortController?: AbortController;
   task?: Promise<void>;
   stopTask?: Promise<void>;
+  clientProjectionTask?: Promise<void>;
+  runtimeFailureRunIds: Set<string>;
   lastResult?: AgentGraphScheduleReconciliationResult;
   lastError?: unknown;
 }
 
 export type AgentGraphClientChangedReason =
-  | 'schedule_committed'
+  | 'observation'
   | 'runtime_activity'
   | 'reconciled'
   | 'stopped';
@@ -170,7 +180,6 @@ export class AgentGraphCoordinator {
       },
       onScheduleUpdateCommitted: (update, authorization) => {
         this.#assertScheduleOwnedByRoot(update, rootSessionId, driver.graphId);
-        this.#notifyClientChanged(driver, 'schedule_committed');
         this.#wakeFromSchedule(driver, decodeScheduleWakeFence(authorization));
       },
     });
@@ -184,10 +193,50 @@ export class AgentGraphCoordinator {
     rootSessionId: string,
     options: AgentGraphClientSnapshotOptions = {},
   ): Promise<AgentGraphClientSnapshot> {
-    return buildAgentGraphClientSnapshot(
-      await this.#readClientModelInput(rootSessionId),
-      options,
+    await this.#assertRootGraphReader(rootSessionId);
+    const graphId = agentGraphIdForRootSession(rootSessionId);
+    const record = await this.#readOrRebuildClientProjection(
+      rootSessionId,
+      graphId,
     );
+    const snapshot = decodeMaterializedAgentGraphClientSnapshot(record.payload, {
+      rootSessionId,
+      graphId,
+      snapshotVersion: record.snapshotVersion,
+    });
+    const before = options.terminalCursor
+      ? decodeAgentGraphTerminalCursor(options.terminalCursor)
+      : undefined;
+    if (before && before.graphId !== graphId) {
+      throw new Error('Agent graph terminal history cursor belongs to another graph');
+    }
+    const terminalPage =
+      await this.#input.controlStore.listAgentGraphClientTerminalActivities(
+        graphId,
+        {
+          limit: AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE,
+          ...(before
+            ? {
+                before: {
+                  eventTime: before.eventTime,
+                  recordId: before.recordId,
+                },
+              }
+            : {}),
+        },
+      );
+    snapshot.terminalHistory = materializedAgentGraphTerminalHistoryPage(
+      graphId,
+      terminalPage.records.map((activity) =>
+        decodeMaterializedAgentGraphClientActivity(activity.payload, {
+          graphId,
+          recordId: activity.recordId,
+          eventTime: activity.eventTime,
+        }),
+      ),
+      terminalPage.hasMore,
+    );
+    return snapshot;
   }
 
   /** Inspect one operator without requiring it to be present in the bounded snapshot page. */
@@ -195,10 +244,25 @@ export class AgentGraphCoordinator {
     rootSessionId: string,
     operatorId: string,
   ): Promise<AgentGraphOperatorInspection> {
-    return inspectAgentGraphOperator(
-      await this.#readClientModelInput(rootSessionId),
+    await this.#assertRootGraphReader(rootSessionId);
+    const graphId = agentGraphIdForRootSession(rootSessionId);
+    const graph = await this.#readOrRebuildClientProjection(rootSessionId, graphId);
+    const operator =
+      await this.#input.controlStore.readAgentGraphClientOperatorProjection(
+        graphId,
+        operatorId,
+      );
+    if (!operator) {
+      throw new Error(`Agent graph operator ${operatorId} was not found`);
+    }
+    const inspection = decodeMaterializedAgentGraphOperatorInspection(operator.payload, {
+      rootSessionId,
+      graphId,
       operatorId,
-    );
+      snapshotVersion: operator.snapshotVersion,
+    });
+    inspection.snapshotVersion = graph.snapshotVersion;
+    return inspection;
   }
 
   /**
@@ -360,6 +424,8 @@ export class AgentGraphCoordinator {
       driver.stopping = false;
     }
     throwCollectedFailures(`Failed to stop agent graph ${driver.graphId}`, failures);
+    await this.#waitForClientProjectionUpdates(driver);
+    await this.#rebuildClientProjection(driver.rootSessionId, driver.graphId);
     this.#notifyClientChanged(driver, 'stopped');
   }
 
@@ -410,6 +476,12 @@ export class AgentGraphCoordinator {
       try {
         const result = await this.#reconcileOnce(driver, abortController.signal);
         driver.lastResult = result;
+        await this.#waitForClientProjectionUpdates(driver);
+        await this.#materializeClientProjection(
+          driver.rootSessionId,
+          driver.graphId,
+          result.observation,
+        );
         await notify(this.#input.onReconciliation, driver.rootSessionId, result);
         this.#notifyClientChanged(driver, 'reconciled');
       } catch (error) {
@@ -444,12 +516,37 @@ export class AgentGraphCoordinator {
       renderPrompt: this.#input.renderPrompt ?? renderDefaultScheduledWorkPrompt,
       abortSignal,
       supervisor: {
-        onObservation: this.#input.supervisor?.onObservation,
+        onObservation: (observation) => {
+          this.#queueClientProjectionUpdate(driver, async () => {
+            await this.#materializeClientProjection(
+              driver.rootSessionId,
+              driver.graphId,
+              observation,
+            );
+            this.#notifyClientChanged(driver, 'observation');
+          });
+          void notify(this.#input.supervisor?.onObservation, observation);
+        },
         onActivationReady: this.#input.supervisor?.onActivationReady,
         onRuntimeEvent: (event) => {
           if (!driver.paused) driver.requested = true;
-          if (isDurableGraphClientActivity(event.event.type)) {
-            this.#notifyClientChanged(driver, 'runtime_activity');
+          if (event.event.type === 'error') {
+            driver.runtimeFailureRunIds.add(event.claim.targetRunId);
+          }
+          const activationHadError = driver.runtimeFailureRunIds.has(
+            event.claim.targetRunId,
+          );
+          if (event.event.type === 'complete' || event.event.type === 'abort') {
+            driver.runtimeFailureRunIds.delete(event.claim.targetRunId);
+          }
+          if (isMaterializedGraphClientEvent(event.event.type)) {
+            this.#queueClientProjectionUpdate(driver, () =>
+              this.#advanceClientProjection(
+                driver,
+                event,
+                activationHadError,
+              ),
+            );
           }
           void notify(this.#input.supervisor?.onRuntimeEvent, event);
         },
@@ -462,9 +559,10 @@ export class AgentGraphCoordinator {
   ): Promise<BuildAgentGraphClientReadModelInput> {
     await this.#assertRootGraphReader(rootSessionId);
     const graphId = agentGraphIdForRootSession(rootSessionId);
-    const [provisions, scheduleUpdates] = await Promise.all([
+    const [provisions, scheduleUpdates, claimAdmissions] = await Promise.all([
       this.#input.controlStore.listAgentGraphOperatorProvisions(graphId),
       this.#input.controlStore.listAgentGraphScheduleUpdates(graphId),
+      this.#input.controlStore.listAgentGraphClientClaimAdmissions(graphId),
     ]);
     scheduleUpdates.forEach((update) =>
       this.#assertScheduleOwnedByRoot(update, rootSessionId, graphId),
@@ -475,8 +573,185 @@ export class AgentGraphCoordinator {
       graphId,
       provisions,
       scheduleUpdates,
+      claimAdmissions,
       observation: await this.#observeTopology(topology),
     };
+  }
+
+  async #readOrRebuildClientProjection(
+    rootSessionId: string,
+    graphId: string,
+  ) {
+    const driver = this.#drivers.get(graphId);
+    if (driver) await this.#waitForClientProjectionUpdates(driver);
+    const existing =
+      await this.#input.controlStore.readAgentGraphClientProjection(graphId);
+    if (existing) {
+      if (
+        existing.schemaVersion !==
+          AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION ||
+        existing.rootSessionId !== rootSessionId
+      ) {
+        throw new Error(`Invalid materialized agent graph projection ${graphId}`);
+      }
+      return existing;
+    }
+    return this.#rebuildClientProjection(rootSessionId, graphId);
+  }
+
+  async #rebuildClientProjection(rootSessionId: string, graphId: string) {
+    const input = await this.#readClientModelInput(rootSessionId);
+    if (input.graphId !== graphId) {
+      throw new Error(`Agent graph rebuild resolved ${input.graphId}, expected ${graphId}`);
+    }
+    return this.#commitClientProjection(
+      input,
+      materializeAgentGraphClientProjection(input),
+    );
+  }
+
+  async #materializeClientProjection(
+    rootSessionId: string,
+    graphId: string,
+    observation: AgentGraphSupervisorObservation,
+  ): Promise<void> {
+    const [provisions, scheduleUpdates, claimAdmissions] = await Promise.all([
+      this.#input.controlStore.listAgentGraphOperatorProvisions(graphId),
+      this.#input.controlStore.listAgentGraphScheduleUpdates(graphId),
+      this.#input.controlStore.listAgentGraphClientClaimAdmissions(graphId),
+    ]);
+    scheduleUpdates.forEach((update) =>
+      this.#assertScheduleOwnedByRoot(update, rootSessionId, graphId),
+    );
+    const input: BuildAgentGraphClientReadModelInput = {
+      rootSessionId,
+      graphId,
+      provisions,
+      scheduleUpdates,
+      claimAdmissions,
+      observation,
+    };
+    await this.#commitClientProjection(
+      input,
+      materializeAgentGraphClientProjection(input),
+    );
+  }
+
+  async #commitClientProjection(
+    input: BuildAgentGraphClientReadModelInput,
+    materialization: ReturnType<typeof materializeAgentGraphClientProjection>,
+  ) {
+    return this.#input.controlStore.commitAgentGraphClientProjection({
+      schemaVersion: AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION,
+      graphId: input.graphId,
+      rootSessionId: input.rootSessionId,
+      snapshotVersion: materialization.snapshot.snapshotVersion,
+      snapshot: materialization.snapshot,
+      replaceOperators: true,
+      operators: materialization.operators.map((operator) => ({
+        operatorId: operator.operator.operatorId,
+        payload: operator,
+      })),
+      terminalActivities: materialization.terminalActivities.map((activity) => ({
+        recordId: activity.recordId,
+        eventTime: activity.eventTime,
+        payload: activity,
+      })),
+    });
+  }
+
+  #queueClientProjectionUpdate(
+    driver: GraphDriver,
+    operation: () => Promise<void>,
+  ): void {
+    const previous = driver.clientProjectionTask ?? Promise.resolve();
+    const task = previous
+      .catch(() => {
+        // A later durable observation may repair a failed derived projection.
+      })
+      .then(operation);
+    driver.clientProjectionTask = task;
+    void task
+      .catch((error) =>
+        notify(this.#input.onError, driver.rootSessionId, error),
+      )
+      .finally(() => {
+        if (driver.clientProjectionTask === task) {
+          driver.clientProjectionTask = undefined;
+        }
+      });
+  }
+
+  async #waitForClientProjectionUpdates(driver: GraphDriver): Promise<void> {
+    await driver.clientProjectionTask?.catch(() => {
+      // The authoritative rebuild below repairs failed derived updates.
+    });
+  }
+
+  async #advanceClientProjection(
+    driver: GraphDriver,
+    event: AgentGraphSupervisorRuntimeEvent,
+    activationHadError: boolean,
+  ): Promise<void> {
+    const graph =
+      await this.#input.controlStore.readAgentGraphClientProjection(
+        driver.graphId,
+      );
+    const operator =
+      await this.#input.controlStore.readAgentGraphClientOperatorProjection(
+        driver.graphId,
+        event.claim.targetOperatorId,
+      );
+    if (!graph || !operator) {
+      throw new Error(
+        `Agent graph ${driver.graphId} has no materialized runtime activity target`,
+      );
+    }
+    const snapshot = decodeMaterializedAgentGraphClientSnapshot(graph.payload, {
+      rootSessionId: driver.rootSessionId,
+      graphId: driver.graphId,
+      snapshotVersion: graph.snapshotVersion,
+    });
+    const inspection = decodeMaterializedAgentGraphOperatorInspection(
+      operator.payload,
+      {
+        rootSessionId: driver.rootSessionId,
+        graphId: driver.graphId,
+        operatorId: event.claim.targetOperatorId,
+        snapshotVersion: operator.snapshotVersion,
+      },
+    );
+    const advanced = advanceMaterializedAgentGraphClientProjection(
+      snapshot,
+      inspection,
+      event,
+      activationHadError,
+    );
+    if (!advanced) return;
+    await this.#input.controlStore.commitAgentGraphClientProjection({
+      schemaVersion: AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION,
+      graphId: driver.graphId,
+      rootSessionId: driver.rootSessionId,
+      snapshotVersion: advanced.snapshot.snapshotVersion,
+      snapshot: advanced.snapshot,
+      replaceOperators: false,
+      operators: [
+        {
+          operatorId: advanced.operator.operator.operatorId,
+          payload: advanced.operator,
+        },
+      ],
+      terminalActivities: advanced.terminalActivity
+        ? [
+            {
+              recordId: advanced.terminalActivity.recordId,
+              eventTime: advanced.terminalActivity.eventTime,
+              payload: advanced.terminalActivity,
+            },
+          ]
+        : [],
+    });
+    this.#notifyClientChanged(driver, 'runtime_activity');
   }
 
   async #readTopology(graphId: string): Promise<AgentGraphTraceTopology> {
@@ -545,6 +820,7 @@ export class AgentGraphCoordinator {
       stopping: false,
       stopGeneration: 0,
       closed: false,
+      runtimeFailureRunIds: new Set(),
     };
     this.#drivers.set(graphId, created);
     return created;
@@ -656,7 +932,7 @@ function requireRootSessionId(rootSessionId: string): string {
   return normalized;
 }
 
-function isDurableGraphClientActivity(
+function isMaterializedGraphClientEvent(
   type: AgentGraphSupervisorRuntimeEvent['event']['type'],
 ): boolean {
   return ![

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -8,8 +8,11 @@ import type {
   RuntimeEventStore,
   SessionHeader,
 } from '@maka/core';
-import { decodeAgentGraphIntentClaim } from '@maka/core';
-import { AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION } from '@maka/core';
+import {
+  AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION,
+  AgentGraphClientProjectionConflictError,
+  decodeAgentGraphIntentClaim,
+} from '@maka/core';
 import type { MakaTool } from './tool-runtime.js';
 import type { SessionManager } from './session-manager.js';
 import {
@@ -49,6 +52,7 @@ import type { AgentGraphTraceTopology } from './stream-graph-trace.js';
 import { stableHash } from './request-shape.js';
 
 const DEFAULT_MAX_NEW_ACTIVATIONS = 8;
+const MAX_CLIENT_PROJECTION_COMMIT_ATTEMPTS = 4;
 
 export interface AgentGraphCoordinatorSessionStore {
   listForRecovery(): Promise<SessionHeader[]>;
@@ -75,9 +79,7 @@ export interface AgentGraphCoordinatorInput {
     topology: AgentGraphTraceTopology,
     observation: Pick<AgentGraphSupervisorObservation, 'projection' | 'claims'>,
   ): readonly AgentGraphReadinessPolicy[] | Promise<readonly AgentGraphReadinessPolicy[]>;
-  renderPrompt?(
-    input: RenderAgentGraphScheduledWorkPromptInput,
-  ): string | Promise<string>;
+  renderPrompt?(input: RenderAgentGraphScheduledWorkPromptInput): string | Promise<string>;
   supervisor?: AgentGraphSupervisorObserver;
   onReconciliation?(
     rootSessionId: string,
@@ -165,10 +167,7 @@ export class AgentGraphCoordinator {
       scheduleStore: this.#input.controlStore,
       observeGraph: () => this.observe(rootSessionId),
       authorizeScheduleUpdate: (request): ScheduleWakeFence => {
-        if (
-          request.graphId !== driver.graphId ||
-          request.source.sessionId !== rootSessionId
-        ) {
+        if (request.graphId !== driver.graphId || request.source.sessionId !== rootSessionId) {
           throw new Error(
             `Agent graph schedule update is not authorized for root Session ${rootSessionId}`,
           );
@@ -195,10 +194,7 @@ export class AgentGraphCoordinator {
   ): Promise<AgentGraphClientSnapshot> {
     await this.#assertRootGraphReader(rootSessionId);
     const graphId = agentGraphIdForRootSession(rootSessionId);
-    const record = await this.#readOrRebuildClientProjection(
-      rootSessionId,
-      graphId,
-    );
+    const record = await this.#readOrRebuildClientProjection(rootSessionId, graphId);
     const snapshot = decodeMaterializedAgentGraphClientSnapshot(record.payload, {
       rootSessionId,
       graphId,
@@ -210,21 +206,20 @@ export class AgentGraphCoordinator {
     if (before && before.graphId !== graphId) {
       throw new Error('Agent graph terminal history cursor belongs to another graph');
     }
-    const terminalPage =
-      await this.#input.controlStore.listAgentGraphClientTerminalActivities(
-        graphId,
-        {
-          limit: AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE,
-          ...(before
-            ? {
-                before: {
-                  eventTime: before.eventTime,
-                  recordId: before.recordId,
-                },
-              }
-            : {}),
-        },
-      );
+    const terminalPage = await this.#input.controlStore.listAgentGraphClientTerminalActivities(
+      graphId,
+      {
+        limit: AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE,
+        ...(before
+          ? {
+              before: {
+                eventTime: before.eventTime,
+                recordId: before.recordId,
+              },
+            }
+          : {}),
+      },
+    );
     snapshot.terminalHistory = materializedAgentGraphTerminalHistoryPage(
       graphId,
       terminalPage.records.map((activity) =>
@@ -247,11 +242,10 @@ export class AgentGraphCoordinator {
     await this.#assertRootGraphReader(rootSessionId);
     const graphId = agentGraphIdForRootSession(rootSessionId);
     const graph = await this.#readOrRebuildClientProjection(rootSessionId, graphId);
-    const operator =
-      await this.#input.controlStore.readAgentGraphClientOperatorProjection(
-        graphId,
-        operatorId,
-      );
+    const operator = await this.#input.controlStore.readAgentGraphClientOperatorProjection(
+      graphId,
+      operatorId,
+    );
     if (!operator) {
       throw new Error(`Agent graph operator ${operatorId} was not found`);
     }
@@ -272,15 +266,9 @@ export class AgentGraphCoordinator {
    * reconnect by calling getSnapshot(), not by replaying these process-local
    * hints as authority.
    */
-  subscribe(
-    rootSessionId: string,
-    listener: AgentGraphClientChangedListener,
-  ): () => void {
+  subscribe(rootSessionId: string, listener: AgentGraphClientChangedListener): () => void {
     const normalizedRootSessionId = requireRootSessionId(rootSessionId);
-    if (
-      this.#input.rootSessionId &&
-      normalizedRootSessionId !== this.#input.rootSessionId
-    ) {
+    if (this.#input.rootSessionId && normalizedRootSessionId !== this.#input.rootSessionId) {
       throw new Error(
         `Agent graph coordinator is scoped to root Session ${this.#input.rootSessionId}`,
       );
@@ -372,8 +360,7 @@ export class AgentGraphCoordinator {
       .map(decodeAgentGraphIntentClaim)
       .sort((a, b) => a.intentId.localeCompare(b.intentId) || a.claimId.localeCompare(b.claimId));
     assertUniqueClaims(graphId, claims);
-    const policies =
-      (await this.#input.resolvePolicies?.(topology, { projection, claims })) ?? [];
+    const policies = (await this.#input.resolvePolicies?.(topology, { projection, claims })) ?? [];
     return {
       projection,
       readiness: buildAgentGraphReadinessSnapshot({
@@ -533,19 +520,13 @@ export class AgentGraphCoordinator {
           if (event.event.type === 'error') {
             driver.runtimeFailureRunIds.add(event.claim.targetRunId);
           }
-          const activationHadError = driver.runtimeFailureRunIds.has(
-            event.claim.targetRunId,
-          );
+          const activationHadError = driver.runtimeFailureRunIds.has(event.claim.targetRunId);
           if (event.event.type === 'complete' || event.event.type === 'abort') {
             driver.runtimeFailureRunIds.delete(event.claim.targetRunId);
           }
           if (isMaterializedGraphClientEvent(event.event.type)) {
             this.#queueClientProjectionUpdate(driver, () =>
-              this.#advanceClientProjection(
-                driver,
-                event,
-                activationHadError,
-              ),
+              this.#advanceClientProjection(driver, event, activationHadError),
             );
           }
           void notify(this.#input.supervisor?.onRuntimeEvent, event);
@@ -554,9 +535,7 @@ export class AgentGraphCoordinator {
     });
   }
 
-  async #readClientModelInput(
-    rootSessionId: string,
-  ): Promise<BuildAgentGraphClientReadModelInput> {
+  async #readClientModelInput(rootSessionId: string): Promise<BuildAgentGraphClientReadModelInput> {
     await this.#assertRootGraphReader(rootSessionId);
     const graphId = agentGraphIdForRootSession(rootSessionId);
     const [provisions, scheduleUpdates, claimAdmissions] = await Promise.all([
@@ -578,18 +557,13 @@ export class AgentGraphCoordinator {
     };
   }
 
-  async #readOrRebuildClientProjection(
-    rootSessionId: string,
-    graphId: string,
-  ) {
+  async #readOrRebuildClientProjection(rootSessionId: string, graphId: string) {
     const driver = this.#drivers.get(graphId);
     if (driver) await this.#waitForClientProjectionUpdates(driver);
-    const existing =
-      await this.#input.controlStore.readAgentGraphClientProjection(graphId);
+    const existing = await this.#input.controlStore.readAgentGraphClientProjection(graphId);
     if (existing) {
       if (
-        existing.schemaVersion !==
-          AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION ||
+        existing.schemaVersion !== AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION ||
         existing.rootSessionId !== rootSessionId
       ) {
         throw new Error(`Invalid materialized agent graph projection ${graphId}`);
@@ -600,13 +574,26 @@ export class AgentGraphCoordinator {
   }
 
   async #rebuildClientProjection(rootSessionId: string, graphId: string) {
-    const input = await this.#readClientModelInput(rootSessionId);
-    if (input.graphId !== graphId) {
-      throw new Error(`Agent graph rebuild resolved ${input.graphId}, expected ${graphId}`);
+    for (let attempt = 0; attempt < MAX_CLIENT_PROJECTION_COMMIT_ATTEMPTS; attempt += 1) {
+      const expectedSnapshotVersion =
+        (await this.#input.controlStore.readAgentGraphClientProjection(graphId))?.snapshotVersion ??
+        null;
+      const input = await this.#readClientModelInput(rootSessionId);
+      if (input.graphId !== graphId) {
+        throw new Error(`Agent graph rebuild resolved ${input.graphId}, expected ${graphId}`);
+      }
+      try {
+        return await this.#commitClientProjection(
+          input,
+          materializeAgentGraphClientProjection(input),
+          expectedSnapshotVersion,
+        );
+      } catch (error) {
+        if (!(error instanceof AgentGraphClientProjectionConflictError)) throw error;
+      }
     }
-    return this.#commitClientProjection(
-      input,
-      materializeAgentGraphClientProjection(input),
+    throw new AgentGraphClientProjectionConflictError(
+      `Agent graph client projection ${graphId} kept changing during rebuild`,
     );
   }
 
@@ -631,20 +618,31 @@ export class AgentGraphCoordinator {
       claimAdmissions,
       observation,
     };
-    await this.#commitClientProjection(
-      input,
-      materializeAgentGraphClientProjection(input),
-    );
+    const expectedSnapshotVersion =
+      (await this.#input.controlStore.readAgentGraphClientProjection(graphId))?.snapshotVersion ??
+      null;
+    try {
+      await this.#commitClientProjection(
+        input,
+        materializeAgentGraphClientProjection(input),
+        expectedSnapshotVersion,
+      );
+    } catch (error) {
+      if (!(error instanceof AgentGraphClientProjectionConflictError)) throw error;
+      await this.#rebuildClientProjection(rootSessionId, graphId);
+    }
   }
 
   async #commitClientProjection(
     input: BuildAgentGraphClientReadModelInput,
     materialization: ReturnType<typeof materializeAgentGraphClientProjection>,
+    expectedSnapshotVersion: string | null,
   ) {
     return this.#input.controlStore.commitAgentGraphClientProjection({
       schemaVersion: AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION,
       graphId: input.graphId,
       rootSessionId: input.rootSessionId,
+      expectedSnapshotVersion,
       snapshotVersion: materialization.snapshot.snapshotVersion,
       snapshot: materialization.snapshot,
       replaceOperators: true,
@@ -657,13 +655,14 @@ export class AgentGraphCoordinator {
         eventTime: activity.eventTime,
         payload: activity,
       })),
+      activityRecords: materialization.activityRecords.map((activity) => ({
+        recordId: activity.recordId,
+        eventTime: activity.eventTime,
+      })),
     });
   }
 
-  #queueClientProjectionUpdate(
-    driver: GraphDriver,
-    operation: () => Promise<void>,
-  ): void {
+  #queueClientProjectionUpdate(driver: GraphDriver, operation: () => Promise<void>): void {
     const previous = driver.clientProjectionTask ?? Promise.resolve();
     const task = previous
       .catch(() => {
@@ -672,9 +671,7 @@ export class AgentGraphCoordinator {
       .then(operation);
     driver.clientProjectionTask = task;
     void task
-      .catch((error) =>
-        notify(this.#input.onError, driver.rootSessionId, error),
-      )
+      .catch((error) => notify(this.#input.onError, driver.rootSessionId, error))
       .finally(() => {
         if (driver.clientProjectionTask === task) {
           driver.clientProjectionTask = undefined;
@@ -693,65 +690,78 @@ export class AgentGraphCoordinator {
     event: AgentGraphSupervisorRuntimeEvent,
     activationHadError: boolean,
   ): Promise<void> {
-    const graph =
-      await this.#input.controlStore.readAgentGraphClientProjection(
-        driver.graphId,
-      );
-    const operator =
-      await this.#input.controlStore.readAgentGraphClientOperatorProjection(
+    for (let attempt = 0; attempt < MAX_CLIENT_PROJECTION_COMMIT_ATTEMPTS; attempt += 1) {
+      const graph = await this.#input.controlStore.readAgentGraphClientProjection(driver.graphId);
+      const operator = await this.#input.controlStore.readAgentGraphClientOperatorProjection(
         driver.graphId,
         event.claim.targetOperatorId,
       );
-    if (!graph || !operator) {
-      throw new Error(
-        `Agent graph ${driver.graphId} has no materialized runtime activity target`,
-      );
-    }
-    const snapshot = decodeMaterializedAgentGraphClientSnapshot(graph.payload, {
-      rootSessionId: driver.rootSessionId,
-      graphId: driver.graphId,
-      snapshotVersion: graph.snapshotVersion,
-    });
-    const inspection = decodeMaterializedAgentGraphOperatorInspection(
-      operator.payload,
-      {
+      if (!graph || !operator) {
+        throw new Error(
+          `Agent graph ${driver.graphId} has no materialized runtime activity target`,
+        );
+      }
+      const snapshot = decodeMaterializedAgentGraphClientSnapshot(graph.payload, {
+        rootSessionId: driver.rootSessionId,
+        graphId: driver.graphId,
+        snapshotVersion: graph.snapshotVersion,
+      });
+      const inspection = decodeMaterializedAgentGraphOperatorInspection(operator.payload, {
         rootSessionId: driver.rootSessionId,
         graphId: driver.graphId,
         operatorId: event.claim.targetOperatorId,
         snapshotVersion: operator.snapshotVersion,
-      },
-    );
-    const advanced = advanceMaterializedAgentGraphClientProjection(
-      snapshot,
-      inspection,
-      event,
-      activationHadError,
-    );
-    if (!advanced) return;
-    await this.#input.controlStore.commitAgentGraphClientProjection({
-      schemaVersion: AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION,
-      graphId: driver.graphId,
-      rootSessionId: driver.rootSessionId,
-      snapshotVersion: advanced.snapshot.snapshotVersion,
-      snapshot: advanced.snapshot,
-      replaceOperators: false,
-      operators: [
-        {
-          operatorId: advanced.operator.operator.operatorId,
-          payload: advanced.operator,
-        },
-      ],
-      terminalActivities: advanced.terminalActivity
-        ? [
+      });
+      const advanced = advanceMaterializedAgentGraphClientProjection(
+        snapshot,
+        inspection,
+        event,
+        activationHadError,
+      );
+      if (!advanced) return;
+      try {
+        const committed = await this.#input.controlStore.commitAgentGraphClientProjection({
+          schemaVersion: AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION,
+          graphId: driver.graphId,
+          rootSessionId: driver.rootSessionId,
+          expectedSnapshotVersion: graph.snapshotVersion,
+          snapshotVersion: advanced.snapshot.snapshotVersion,
+          snapshot: advanced.snapshot,
+          replaceOperators: false,
+          operators: [
             {
-              recordId: advanced.terminalActivity.recordId,
-              eventTime: advanced.terminalActivity.eventTime,
-              payload: advanced.terminalActivity,
+              operatorId: advanced.operator.operator.operatorId,
+              payload: advanced.operator,
             },
-          ]
-        : [],
-    });
-    this.#notifyClientChanged(driver, 'runtime_activity');
+          ],
+          terminalActivities: advanced.terminalActivity
+            ? [
+                {
+                  recordId: advanced.terminalActivity.recordId,
+                  eventTime: advanced.terminalActivity.eventTime,
+                  payload: advanced.terminalActivity,
+                },
+              ]
+            : [],
+          activityRecords: [
+            {
+              recordId: advanced.activity.recordId,
+              eventTime: advanced.activity.eventTime,
+            },
+          ],
+          incrementalRecordId: advanced.activity.recordId,
+        });
+        if (committed.snapshotVersion === advanced.snapshot.snapshotVersion) {
+          this.#notifyClientChanged(driver, 'runtime_activity');
+        }
+        return;
+      } catch (error) {
+        if (!(error instanceof AgentGraphClientProjectionConflictError)) throw error;
+      }
+    }
+    throw new AgentGraphClientProjectionConflictError(
+      `Agent graph client projection ${driver.graphId} kept changing during runtime update`,
+    );
   }
 
   async #readTopology(graphId: string): Promise<AgentGraphTraceTopology> {
@@ -851,10 +861,7 @@ export class AgentGraphCoordinator {
     });
   }
 
-  #notifyClientChanged(
-    driver: GraphDriver,
-    reason: AgentGraphClientChangedReason,
-  ): void {
+  #notifyClientChanged(driver: GraphDriver, reason: AgentGraphClientChangedReason): void {
     if (this.#clientSubscriptions.size === 0) return;
     const event: AgentGraphClientChangedEvent = {
       schemaVersion: 1,
@@ -863,10 +870,7 @@ export class AgentGraphCoordinator {
       reason,
     };
     for (const subscription of this.#clientSubscriptions) {
-      if (
-        subscription.rootSessionId &&
-        subscription.rootSessionId !== driver.rootSessionId
-      ) {
+      if (subscription.rootSessionId && subscription.rootSessionId !== driver.rootSessionId) {
         continue;
       }
       void notify(subscription.listener, structuredClone(event));
@@ -951,10 +955,7 @@ export function topologyFromProvisions(
 ): AgentGraphTraceTopology {
   const operators = new Map<string, { operatorId: string; sessionId: string }>();
   const sessions = new Map<string, string>();
-  const edges = new Map<
-    string,
-    { edgeId: string; fromOperatorId: string; toOperatorId: string }
-  >();
+  const edges = new Map<string, { edgeId: string; fromOperatorId: string; toOperatorId: string }>();
   for (const provision of [...provisions].sort(
     (a, b) => a.provisionedAt - b.provisionedAt || a.provisionId.localeCompare(b.provisionId),
   )) {
@@ -962,10 +963,7 @@ export function topologyFromProvisions(
       throw new Error(`Graph provision ${provision.provisionId} belongs to ${provision.graphId}`);
     }
     const existingOperator = operators.get(provision.operatorId);
-    if (
-      existingOperator &&
-      existingOperator.sessionId !== provision.targetSessionId
-    ) {
+    if (existingOperator && existingOperator.sessionId !== provision.targetSessionId) {
       throw new Error(`Graph operator ${provision.operatorId} has conflicting Session bindings`);
     }
     const existingSession = sessions.get(provision.targetSessionId);
@@ -996,9 +994,7 @@ export function topologyFromProvisions(
   };
 }
 
-function renderDefaultScheduledWorkPrompt(
-  input: RenderAgentGraphScheduledWorkPromptInput,
-): string {
+function renderDefaultScheduledWorkPrompt(input: RenderAgentGraphScheduledWorkPromptInput): string {
   if (input.inputRecords.length === 0) return input.work.instruction;
   const references = input.inputRecords.map((record) => graphRecordReference(record));
   return `${input.work.instruction}\n\nCommitted graph input references:\n${JSON.stringify(references, null, 2)}`;

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -100,6 +100,7 @@ interface GraphDriver {
   task?: Promise<void>;
   stopTask?: Promise<void>;
   clientProjectionTask?: Promise<void>;
+  clientProjectionDirty: boolean;
   runtimeFailureRunIds: Set<string>;
   lastResult?: AgentGraphScheduleReconciliationResult;
   lastError?: unknown;
@@ -473,6 +474,9 @@ export class AgentGraphCoordinator {
         const result = await this.#reconcileOnce(driver, abortController.signal);
         driver.lastResult = result;
         await this.#waitForClientProjectionUpdates(driver);
+        if (driver.clientProjectionDirty) {
+          await this.#repairClientProjectionBestEffort(driver);
+        }
         await notify(this.#input.onReconciliation, driver.rootSessionId, result);
         this.#notifyClientChanged(driver, 'reconciled');
       } catch (error) {
@@ -508,14 +512,18 @@ export class AgentGraphCoordinator {
       abortSignal,
       supervisor: {
         onObservation: (observation) => {
-          this.#queueClientProjectionUpdate(driver, async () => {
-            await this.#materializeClientProjection(
-              driver.rootSessionId,
-              driver.graphId,
-              observation,
-            );
-            this.#notifyClientChanged(driver, 'observation');
-          });
+          this.#queueClientProjectionUpdate(
+            driver,
+            async () => {
+              await this.#materializeClientProjection(
+                driver.rootSessionId,
+                driver.graphId,
+                observation,
+              );
+              this.#notifyClientChanged(driver, 'observation');
+            },
+            true,
+          );
           void notify(this.#input.supervisor?.onObservation, observation);
         },
         onActivationReady: this.#input.supervisor?.onActivationReady,
@@ -563,7 +571,12 @@ export class AgentGraphCoordinator {
 
   async #readOrRebuildClientProjection(rootSessionId: string, graphId: string) {
     const driver = this.#drivers.get(graphId);
-    if (driver) await this.#waitForClientProjectionUpdates(driver);
+    if (driver) {
+      await this.#waitForClientProjectionUpdates(driver);
+      if (driver.clientProjectionDirty) {
+        await this.#repairClientProjectionBestEffort(driver);
+      }
+    }
     const existing = await this.#input.controlStore.readAgentGraphClientProjection(graphId);
     if (existing) {
       if (
@@ -574,7 +587,9 @@ export class AgentGraphCoordinator {
       }
       return existing;
     }
-    return this.#rebuildClientProjection(rootSessionId, graphId);
+    const rebuilt = await this.#rebuildClientProjection(rootSessionId, graphId);
+    if (driver) driver.clientProjectionDirty = false;
+    return rebuilt;
   }
 
   async #rebuildClientProjection(rootSessionId: string, graphId: string) {
@@ -666,16 +681,31 @@ export class AgentGraphCoordinator {
     });
   }
 
-  #queueClientProjectionUpdate(driver: GraphDriver, operation: () => Promise<void>): void {
+  #queueClientProjectionUpdate(
+    driver: GraphDriver,
+    operation: () => Promise<void>,
+    authoritative = false,
+  ): void {
     const previous = driver.clientProjectionTask ?? Promise.resolve();
     const task = previous
       .catch(() => {
         // A later durable observation may repair a failed derived projection.
       })
-      .then(operation);
+      .then(async () => {
+        try {
+          await operation();
+          if (authoritative) driver.clientProjectionDirty = false;
+        } catch (error) {
+          driver.clientProjectionDirty = true;
+          await notify(this.#input.onError, driver.rootSessionId, error);
+          throw error;
+        }
+      });
     driver.clientProjectionTask = task;
     void task
-      .catch((error) => notify(this.#input.onError, driver.rootSessionId, error))
+      .catch(() => {
+        // Failure state and reporting are owned inside the serialized task.
+      })
       .finally(() => {
         if (driver.clientProjectionTask === task) {
           driver.clientProjectionTask = undefined;
@@ -694,7 +724,9 @@ export class AgentGraphCoordinator {
     await this.#waitForClientProjectionUpdates(driver);
     try {
       await this.#rebuildClientProjection(driver.rootSessionId, driver.graphId);
+      driver.clientProjectionDirty = false;
     } catch (error) {
+      driver.clientProjectionDirty = true;
       await notify(this.#input.onError, driver.rootSessionId, error);
     }
   }
@@ -840,6 +872,7 @@ export class AgentGraphCoordinator {
       stopping: false,
       stopGeneration: 0,
       closed: false,
+      clientProjectionDirty: false,
       runtimeFailureRunIds: new Set(),
     };
     this.#drivers.set(graphId, created);

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -21,12 +21,21 @@ import {
 import type {
   AgentGraphSupervisorObservation,
   AgentGraphSupervisorObserver,
+  AgentGraphSupervisorRuntimeEvent,
 } from './stream-graph-dispatch.js';
 import {
   reconcileAgentGraphSchedule,
   type AgentGraphScheduleReconciliationResult,
   type RenderAgentGraphScheduledWorkPromptInput,
 } from './stream-graph-schedule-reconcile.js';
+import {
+  buildAgentGraphClientSnapshot,
+  inspectAgentGraphOperator,
+  type AgentGraphClientSnapshot,
+  type AgentGraphClientSnapshotOptions,
+  type AgentGraphOperatorInspection,
+  type BuildAgentGraphClientReadModelInput,
+} from './stream-graph-read-model.js';
 import { buildAgentGraphSupervisorTools } from './stream-graph-supervisor-tools.js';
 import type { AgentGraphTraceTopology } from './stream-graph-trace.js';
 import { stableHash } from './request-shape.js';
@@ -84,6 +93,28 @@ interface GraphDriver {
   lastError?: unknown;
 }
 
+export type AgentGraphClientChangedReason =
+  | 'schedule_committed'
+  | 'runtime_activity'
+  | 'reconciled'
+  | 'stopped';
+
+export interface AgentGraphClientChangedEvent {
+  schemaVersion: 1;
+  rootSessionId: string;
+  graphId: string;
+  reason: AgentGraphClientChangedReason;
+}
+
+export type AgentGraphClientChangedListener = (
+  event: AgentGraphClientChangedEvent,
+) => void | Promise<void>;
+
+interface AgentGraphClientSubscription {
+  rootSessionId?: string;
+  listener: AgentGraphClientChangedListener;
+}
+
 /**
  * Process-local execution authority for Session-backed agent graphs.
  *
@@ -94,6 +125,7 @@ interface GraphDriver {
 export class AgentGraphCoordinator {
   readonly #input: AgentGraphCoordinatorInput;
   readonly #drivers = new Map<string, GraphDriver>();
+  readonly #clientSubscriptions = new Set<AgentGraphClientSubscription>();
   #closed = false;
 
   constructor(input: AgentGraphCoordinatorInput) {
@@ -138,9 +170,69 @@ export class AgentGraphCoordinator {
       },
       onScheduleUpdateCommitted: (update, authorization) => {
         this.#assertScheduleOwnedByRoot(update, rootSessionId, driver.graphId);
+        this.#notifyClientChanged(driver, 'schedule_committed');
         this.#wakeFromSchedule(driver, decodeScheduleWakeFence(authorization));
       },
     });
+  }
+
+  /**
+   * Read one bounded snapshot entirely from durable topology, schedule,
+   * admission, AgentRun, and RuntimeEvent facts.
+   */
+  async getSnapshot(
+    rootSessionId: string,
+    options: AgentGraphClientSnapshotOptions = {},
+  ): Promise<AgentGraphClientSnapshot> {
+    return buildAgentGraphClientSnapshot(
+      await this.#readClientModelInput(rootSessionId),
+      options,
+    );
+  }
+
+  /** Inspect one operator without requiring it to be present in the bounded snapshot page. */
+  async inspectOperator(
+    rootSessionId: string,
+    operatorId: string,
+  ): Promise<AgentGraphOperatorInspection> {
+    return inspectAgentGraphOperator(
+      await this.#readClientModelInput(rootSessionId),
+      operatorId,
+    );
+  }
+
+  /**
+   * Subscribe to durable-state invalidation hints for one root graph.
+   *
+   * The callback is presentation-only and never gates reconciliation. Clients
+   * reconnect by calling getSnapshot(), not by replaying these process-local
+   * hints as authority.
+   */
+  subscribe(
+    rootSessionId: string,
+    listener: AgentGraphClientChangedListener,
+  ): () => void {
+    const normalizedRootSessionId = requireRootSessionId(rootSessionId);
+    if (
+      this.#input.rootSessionId &&
+      normalizedRootSessionId !== this.#input.rootSessionId
+    ) {
+      throw new Error(
+        `Agent graph coordinator is scoped to root Session ${this.#input.rootSessionId}`,
+      );
+    }
+    if (this.#closed) throw new Error('Agent graph coordinator is closed');
+    const subscription = { rootSessionId: normalizedRootSessionId, listener };
+    this.#clientSubscriptions.add(subscription);
+    return () => this.#clientSubscriptions.delete(subscription);
+  }
+
+  /** Host adapter hook for multiplexing several root graphs to local clients. */
+  subscribeAll(listener: AgentGraphClientChangedListener): () => void {
+    if (this.#closed) throw new Error('Agent graph coordinator is closed');
+    const subscription = { listener };
+    this.#clientSubscriptions.add(subscription);
+    return () => this.#clientSubscriptions.delete(subscription);
   }
 
   /** Wake reconciliation without making the caller part of the data path. */
@@ -268,6 +360,7 @@ export class AgentGraphCoordinator {
       driver.stopping = false;
     }
     throwCollectedFailures(`Failed to stop agent graph ${driver.graphId}`, failures);
+    this.#notifyClientChanged(driver, 'stopped');
   }
 
   async close(): Promise<void> {
@@ -301,6 +394,7 @@ export class AgentGraphCoordinator {
         throwCollectedFailures(`Failed to close agent graph ${driver.graphId}`, failures);
       }),
     );
+    this.#clientSubscriptions.clear();
     throwCollectedFailures(
       'Failed to close one or more agent graph coordinators',
       results.flatMap((result) => (result.status === 'rejected' ? [result.reason] : [])),
@@ -317,6 +411,7 @@ export class AgentGraphCoordinator {
         const result = await this.#reconcileOnce(driver, abortController.signal);
         driver.lastResult = result;
         await notify(this.#input.onReconciliation, driver.rootSessionId, result);
+        this.#notifyClientChanged(driver, 'reconciled');
       } catch (error) {
         if (!abortController.signal.aborted) {
           driver.lastError = error;
@@ -353,10 +448,35 @@ export class AgentGraphCoordinator {
         onActivationReady: this.#input.supervisor?.onActivationReady,
         onRuntimeEvent: (event) => {
           if (!driver.paused) driver.requested = true;
+          if (isDurableGraphClientActivity(event.event.type)) {
+            this.#notifyClientChanged(driver, 'runtime_activity');
+          }
           void notify(this.#input.supervisor?.onRuntimeEvent, event);
         },
       },
     });
+  }
+
+  async #readClientModelInput(
+    rootSessionId: string,
+  ): Promise<BuildAgentGraphClientReadModelInput> {
+    await this.#assertRootGraphReader(rootSessionId);
+    const graphId = agentGraphIdForRootSession(rootSessionId);
+    const [provisions, scheduleUpdates] = await Promise.all([
+      this.#input.controlStore.listAgentGraphOperatorProvisions(graphId),
+      this.#input.controlStore.listAgentGraphScheduleUpdates(graphId),
+    ]);
+    scheduleUpdates.forEach((update) =>
+      this.#assertScheduleOwnedByRoot(update, rootSessionId, graphId),
+    );
+    const topology = topologyFromProvisions(graphId, provisions);
+    return {
+      rootSessionId,
+      graphId,
+      provisions,
+      scheduleUpdates,
+      observation: await this.#observeTopology(topology),
+    };
   }
 
   async #readTopology(graphId: string): Promise<AgentGraphTraceTopology> {
@@ -367,6 +487,14 @@ export class AgentGraphCoordinator {
   }
 
   async #assertRootSupervisor(rootSessionId: string): Promise<SessionHeader> {
+    const header = await this.#assertRootGraphReader(rootSessionId);
+    if (header.isArchived || header.status === 'archived') {
+      throw new Error('Archived Sessions cannot supervise an agent graph');
+    }
+    return header;
+  }
+
+  async #assertRootGraphReader(rootSessionId: string): Promise<SessionHeader> {
     if (this.#closed) throw new Error('Agent graph coordinator is closed');
     if (this.#input.rootSessionId && rootSessionId !== this.#input.rootSessionId) {
       throw new Error(
@@ -378,10 +506,7 @@ export class AgentGraphCoordinator {
       throw new Error(`Session store returned ${header.id}, expected ${rootSessionId}`);
     }
     if (header.subagentParent) {
-      throw new Error('Agent graph supervisor tools are available only to root Sessions');
-    }
-    if (header.isArchived || header.status === 'archived') {
-      throw new Error('Archived Sessions cannot supervise an agent graph');
+      throw new Error('Agent graph client reads are available only to root Sessions');
     }
     return header;
   }
@@ -450,6 +575,28 @@ export class AgentGraphCoordinator {
     });
   }
 
+  #notifyClientChanged(
+    driver: GraphDriver,
+    reason: AgentGraphClientChangedReason,
+  ): void {
+    if (this.#clientSubscriptions.size === 0) return;
+    const event: AgentGraphClientChangedEvent = {
+      schemaVersion: 1,
+      rootSessionId: driver.rootSessionId,
+      graphId: driver.graphId,
+      reason,
+    };
+    for (const subscription of this.#clientSubscriptions) {
+      if (
+        subscription.rootSessionId &&
+        subscription.rootSessionId !== driver.rootSessionId
+      ) {
+        continue;
+      }
+      void notify(subscription.listener, structuredClone(event));
+    }
+  }
+
   async #stopKnownOperators(graphId: string, failures: unknown[]): Promise<void> {
     let topology: AgentGraphTraceTopology;
     try {
@@ -493,15 +640,33 @@ function throwCollectedFailures(message: string, failures: readonly unknown[]): 
 }
 
 export function agentGraphIdForRootSession(rootSessionId: string): string {
-  const normalized = rootSessionId.trim();
-  if (!normalized || normalized !== rootSessionId) {
-    throw new Error('Agent graph root Session id must be a non-empty canonical identity');
-  }
+  requireRootSessionId(rootSessionId);
   const suffix = stableHash({
     schemaVersion: 1,
     rootSessionId,
   }).slice('sha256:'.length, 'sha256:'.length + 32);
   return `agent_graph_${suffix}`;
+}
+
+function requireRootSessionId(rootSessionId: string): string {
+  const normalized = rootSessionId.trim();
+  if (!normalized || normalized !== rootSessionId) {
+    throw new Error('Agent graph root Session id must be a non-empty canonical identity');
+  }
+  return normalized;
+}
+
+function isDurableGraphClientActivity(
+  type: AgentGraphSupervisorRuntimeEvent['event']['type'],
+): boolean {
+  return ![
+    'text_delta',
+    'thinking_delta',
+    'tool_output_delta',
+    'tool_progress',
+    'queue_update',
+    'provider_retry',
+  ].includes(type);
 }
 
 export function topologyFromProvisions(

--- a/packages/runtime/src/stream-graph-read-model.ts
+++ b/packages/runtime/src/stream-graph-read-model.ts
@@ -113,9 +113,7 @@ export interface AgentGraphClientEdge {
 
 export interface AgentGraphClientScheduledWork {
   workId: string;
-  target:
-    | { kind: 'agent'; agentId: string }
-    | { kind: 'operator'; operatorId: string };
+  target: { kind: 'agent'; agentId: string } | { kind: 'operator'; operatorId: string };
   inputIds: string[];
   replaces?: string;
   status: AgentGraphScheduleWorkView['status'];
@@ -253,12 +251,14 @@ export interface BuildAgentGraphClientReadModelInput {
 export interface AgentGraphClientMaterialization {
   snapshot: AgentGraphClientSnapshot;
   operators: AgentGraphOperatorInspection[];
+  activityRecords: AgentGraphClientActivity[];
   terminalActivities: AgentGraphClientActivity[];
 }
 
 export interface AdvancedAgentGraphClientProjection {
   snapshot: AgentGraphClientSnapshot;
   operator: AgentGraphOperatorInspection;
+  activity: AgentGraphClientActivity;
   terminalActivity?: AgentGraphClientActivity;
 }
 
@@ -267,7 +267,6 @@ export interface AgentGraphClientSnapshotOptions {
 }
 
 interface BuiltReadModel {
-  snapshotVersion: string;
   schedule: AgentGraphScheduleProjection;
   operators: AgentGraphClientOperator[];
   edges: AgentGraphClientEdge[];
@@ -298,11 +297,13 @@ export function materializeAgentGraphClientProjection(
   input: BuildAgentGraphClientReadModelInput,
 ): AgentGraphClientMaterialization {
   const model = buildReadModel(input);
+  const snapshot = snapshotFromModel(input, model, {});
   return {
-    snapshot: snapshotFromModel(input, model, {}),
+    snapshot,
     operators: model.operators.map((operator) =>
-      inspectionFromModel(input, model, operator.operatorId),
+      inspectionFromModel(input, model, operator.operatorId, snapshot.snapshotVersion),
     ),
+    activityRecords: model.activity,
     terminalActivities: terminalActivities(model.activity),
   };
 }
@@ -342,21 +343,53 @@ export function advanceMaterializedAgentGraphClientProjection(
   };
   const snapshot = structuredClone(snapshotInput);
   const inspection = structuredClone(inspectionInput);
+  if (
+    snapshot.recentActivity.some((record) => record.recordId === activity.recordId) ||
+    inspection.recentRecords.some((record) => record.recordId === activity.recordId)
+  ) {
+    return undefined;
+  }
   const previousActivation = inspection.activations.find(
     (activation) => activation.activationId === runtime.claim.targetRunId,
   );
-  const activationStatus: AgentGraphActivationStatus =
-    projected.terminalStatus ?? 'running';
+  const incomingIsLast =
+    !previousActivation ||
+    compareActivityKey(
+      runtime.event.ts,
+      activity.recordId,
+      previousActivation.lastEventTime,
+      previousActivation.lastRecordId,
+    ) > 0;
+  const previousTerminalRecord = previousActivation?.terminalRecordId
+    ? inspection.recentRecords.find(
+        (record) => record.recordId === previousActivation.terminalRecordId,
+      )
+    : undefined;
+  const previousIsTerminal =
+    previousActivation !== undefined &&
+    ['completed', 'failed', 'aborted', 'cancelled'].includes(previousActivation.status);
+  const incomingTerminalWins =
+    projected.terminalStatus !== undefined &&
+    (!previousIsTerminal ||
+      (previousTerminalRecord !== undefined &&
+        compareClientActivity(activity, previousTerminalRecord) > 0));
+  const activationStatus: AgentGraphActivationStatus = incomingTerminalWins
+    ? projected.terminalStatus!
+    : previousIsTerminal
+      ? previousActivation.status
+      : 'running';
+  const terminalRecordId = incomingTerminalWins
+    ? activity.recordId
+    : previousActivation?.terminalRecordId;
   const nextActivation = previousActivation
     ? {
         ...previousActivation,
         status: activationStatus,
         recordCount: previousActivation.recordCount + 1,
-        lastEventTime: runtime.event.ts,
-        lastRecordId: activity.recordId,
-        ...(projected.terminalStatus
-          ? { terminalRecordId: activity.recordId }
-          : {}),
+        firstEventTime: Math.min(previousActivation.firstEventTime, runtime.event.ts),
+        lastEventTime: incomingIsLast ? runtime.event.ts : previousActivation.lastEventTime,
+        lastRecordId: incomingIsLast ? activity.recordId : previousActivation.lastRecordId,
+        ...(terminalRecordId ? { terminalRecordId } : {}),
       }
     : {
         activationId: runtime.claim.targetRunId,
@@ -365,51 +398,61 @@ export function advanceMaterializedAgentGraphClientProjection(
         firstEventTime: runtime.event.ts,
         lastEventTime: runtime.event.ts,
         lastRecordId: activity.recordId,
-        ...(projected.terminalStatus
-          ? { terminalRecordId: activity.recordId }
-          : {}),
+        ...(projected.terminalStatus ? { terminalRecordId: activity.recordId } : {}),
         run: { ...activity.run },
       };
   const activationCount =
-    inspection.omitted.activations +
-    inspection.activations.length +
-    (previousActivation ? 0 : 1);
+    inspection.omitted.activations + inspection.activations.length + (previousActivation ? 0 : 1);
   inspection.activations = [
     ...inspection.activations.filter(
       (activation) => activation.activationId !== nextActivation.activationId,
     ),
     nextActivation,
-  ].slice(-MAX_OPERATOR_INSPECTION_ACTIVATIONS);
-  inspection.omitted.activations = Math.max(
-    0,
-    activationCount - inspection.activations.length,
-  );
-  const operatorStatus: AgentGraphClientOperatorStatus = projected.terminalStatus
-    ? projected.terminalStatus
-    : projected.signals.some((signal) => signal.kind === 'attention')
-      ? 'blocked'
-      : 'running';
+  ]
+    .sort(
+      (a, b) =>
+        a.firstEventTime - b.firstEventTime || compareIdentity(a.activationId, b.activationId),
+    )
+    .slice(-MAX_OPERATOR_INSPECTION_ACTIVATIONS);
+  inspection.omitted.activations = Math.max(0, activationCount - inspection.activations.length);
+  const currentActivation = inspection.activations.at(-1);
+  let operatorStatus = inspection.operator.status;
+  if (currentActivation?.activationId === nextActivation.activationId) {
+    operatorStatus = projected.terminalStatus
+      ? projected.terminalStatus
+      : ['completed', 'failed', 'aborted', 'cancelled'].includes(operatorStatus)
+        ? operatorStatus
+        : projected.signals.some((signal) => signal.kind === 'attention') ||
+            operatorStatus === 'blocked'
+          ? 'blocked'
+          : 'running';
+  }
   inspection.operator.status = operatorStatus;
-  inspection.operator.currentActivation = {
-    activationId: nextActivation.activationId,
-    status: nextActivation.status,
-    recordCount: nextActivation.recordCount,
-    firstEventTime: nextActivation.firstEventTime,
-    lastEventTime: nextActivation.lastEventTime,
-    ...(nextActivation.terminalRecordId
-      ? { terminalRecordId: nextActivation.terminalRecordId }
-      : {}),
-    run: { ...activity.run },
-  };
-  const inspectionRecordCount =
-    inspection.omitted.records + inspection.recentRecords.length + 1;
-  inspection.recentRecords = [...inspection.recentRecords, activity].slice(
-    -MAX_OPERATOR_INSPECTION_RECORDS,
-  );
-  inspection.omitted.records = Math.max(
-    0,
-    inspectionRecordCount - inspection.recentRecords.length,
-  );
+  if (currentActivation) {
+    const currentRun =
+      currentActivation.activationId === nextActivation.activationId
+        ? activity.run
+        : inspection.operator.currentActivation?.run;
+    if (!currentRun) {
+      throw new Error('Agent graph activation is missing its materialized run reference');
+    }
+    inspection.operator.currentActivation = {
+      activationId: currentActivation.activationId,
+      status: currentActivation.status,
+      recordCount: currentActivation.recordCount,
+      firstEventTime: currentActivation.firstEventTime,
+      lastEventTime: currentActivation.lastEventTime,
+      ...(currentActivation.terminalRecordId
+        ? { terminalRecordId: currentActivation.terminalRecordId }
+        : {}),
+      run: { ...currentRun },
+    };
+  }
+  const inspectionRecordCount = inspection.omitted.records + inspection.recentRecords.length + 1;
+  inspection.recentRecords = [...inspection.recentRecords, activity]
+    .sort(compareClientActivity)
+    .slice(-MAX_OPERATOR_INSPECTION_RECORDS);
+  inspection.omitted.records = Math.max(0, inspectionRecordCount - inspection.recentRecords.length);
 
   const visibleOperatorIndex = snapshot.operators.findIndex(
     (operator) => operator.operatorId === inspection.operator.operatorId,
@@ -417,30 +460,19 @@ export function advanceMaterializedAgentGraphClientProjection(
   if (visibleOperatorIndex >= 0) {
     snapshot.operators[visibleOperatorIndex] = structuredClone(inspection.operator);
   }
-  const activityCount =
-    snapshot.omitted.recentActivity + snapshot.recentActivity.length + 1;
-  snapshot.recentActivity = [...snapshot.recentActivity, activity].slice(
-    -MAX_RECENT_ACTIVITY,
-  );
-  snapshot.omitted.recentActivity = Math.max(
-    0,
-    activityCount - snapshot.recentActivity.length,
-  );
-  snapshot.latestEventTime = Math.max(
-    snapshot.latestEventTime ?? 0,
-    runtime.event.ts,
-  );
-  snapshot.snapshotVersion = stableHash({
-    schemaVersion: AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION,
-    previousSnapshotVersion: snapshotInput.snapshotVersion,
-    runtimeEventId: runtime.event.id,
-    operatorStatus,
-  });
-  inspection.snapshotVersion = snapshot.snapshotVersion;
+  const activityCount = snapshot.omitted.recentActivity + snapshot.recentActivity.length + 1;
+  snapshot.recentActivity = [...snapshot.recentActivity, activity]
+    .sort(compareClientActivity)
+    .slice(-MAX_RECENT_ACTIVITY);
+  snapshot.omitted.recentActivity = Math.max(0, activityCount - snapshot.recentActivity.length);
+  snapshot.latestEventTime = Math.max(snapshot.latestEventTime ?? 0, runtime.event.ts);
   snapshot.status = patchedGraphStatus(snapshot, inspection.operator);
+  snapshot.snapshotVersion = clientSnapshotVersion(snapshot);
+  inspection.snapshotVersion = snapshot.snapshotVersion;
   return {
     snapshot,
     operator: inspection,
+    activity,
     ...(projected.terminalStatus ? { terminalActivity: activity } : {}),
   };
 }
@@ -454,22 +486,19 @@ function snapshotFromModel(
   const visibleOperatorIds = new Set(visibleOperators.map((operator) => operator.operatorId));
   const candidateEdges = model.edges.filter(
     (edge) =>
-      visibleOperatorIds.has(edge.fromOperatorId) &&
-      visibleOperatorIds.has(edge.toOperatorId),
+      visibleOperatorIds.has(edge.fromOperatorId) && visibleOperatorIds.has(edge.toOperatorId),
   );
   const edges = candidateEdges.slice(0, MAX_VISIBLE_EDGES);
   const work = boundWork(model.work);
   const stoppedTargets = model.stoppedTargets.slice(-MAX_VISIBLE_STOPPED_TARGETS);
   const claims = model.claims.slice(-MAX_VISIBLE_CLAIMS);
-  const recentControlDecisions = model.recentControlDecisions.slice(
-    -MAX_RECENT_CONTROL_DECISIONS,
-  );
+  const recentControlDecisions = model.recentControlDecisions.slice(-MAX_RECENT_CONTROL_DECISIONS);
   const recentActivity = model.activity.slice(-MAX_RECENT_ACTIVITY);
-  return {
+  const snapshot: AgentGraphClientSnapshot = {
     schemaVersion: AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION,
     rootSessionId: input.rootSessionId,
     graphId: input.graphId,
-    snapshotVersion: model.snapshotVersion,
+    snapshotVersion: '',
     status: graphStatus(model.schedule, model.operators, model.claims, model.activity),
     scheduleRevision: model.schedule.revision,
     topologyFingerprint: input.observation.readiness.topologyFingerprint,
@@ -492,11 +521,12 @@ function snapshotFromModel(
       work: model.work.length - work.length,
       stoppedTargets: model.stoppedTargets.length - stoppedTargets.length,
       claims: model.claims.length - claims.length,
-      controlDecisions:
-        model.recentControlDecisions.length - recentControlDecisions.length,
+      controlDecisions: model.recentControlDecisions.length - recentControlDecisions.length,
       recentActivity: model.activity.length - recentActivity.length,
     },
   };
+  snapshot.snapshotVersion = clientSnapshotVersion(snapshot);
+  return snapshot;
 }
 
 export function inspectAgentGraphOperator(
@@ -505,17 +535,17 @@ export function inspectAgentGraphOperator(
 ): AgentGraphOperatorInspection {
   const expectedOperatorId = requireIdentity(operatorId, 'operator id');
   const model = buildReadModel(input);
-  return inspectionFromModel(input, model, expectedOperatorId);
+  const snapshotVersion = snapshotFromModel(input, model, {}).snapshotVersion;
+  return inspectionFromModel(input, model, expectedOperatorId, snapshotVersion);
 }
 
 function inspectionFromModel(
   input: BuildAgentGraphClientReadModelInput,
   model: BuiltReadModel,
   expectedOperatorId: string,
+  snapshotVersion: string,
 ): AgentGraphOperatorInspection {
-  const operator = model.operators.find(
-    (candidate) => candidate.operatorId === expectedOperatorId,
-  );
+  const operator = model.operators.find((candidate) => candidate.operatorId === expectedOperatorId);
   if (!operator) {
     throw new Error(`Agent graph operator ${expectedOperatorId} was not found`);
   }
@@ -523,31 +553,20 @@ function inspectionFromModel(
   const allActivations = runtimeState
     ? Object.values(runtimeState.activations).sort(
         (a, b) =>
-          a.firstEventTime - b.firstEventTime ||
-          compareIdentity(a.activationId, b.activationId),
+          a.firstEventTime - b.firstEventTime || compareIdentity(a.activationId, b.activationId),
       )
     : [];
   const visibleActivations = allActivations.slice(-MAX_OPERATOR_INSPECTION_ACTIVATIONS);
-  const allRecords = model.activity.filter(
-    (record) => record.operatorId === expectedOperatorId,
-  );
+  const allRecords = model.activity.filter((record) => record.operatorId === expectedOperatorId);
   const recentRecords = allRecords.slice(-MAX_OPERATOR_INSPECTION_RECORDS);
-  const inboundEdges = model.edges.filter(
-    (edge) => edge.toOperatorId === expectedOperatorId,
-  );
+  const inboundEdges = model.edges.filter((edge) => edge.toOperatorId === expectedOperatorId);
   const visibleInboundEdges = inboundEdges.slice(-MAX_OPERATOR_INSPECTION_EDGES);
-  const outboundEdges = model.edges.filter(
-    (edge) => edge.fromOperatorId === expectedOperatorId,
-  );
+  const outboundEdges = model.edges.filter((edge) => edge.fromOperatorId === expectedOperatorId);
   const visibleOutboundEdges = outboundEdges.slice(-MAX_OPERATOR_INSPECTION_EDGES);
-  const operatorWorkIds = new Set(
-    model.scheduledWorkIdsByOperator.get(expectedOperatorId) ?? [],
-  );
+  const operatorWorkIds = new Set(model.scheduledWorkIdsByOperator.get(expectedOperatorId) ?? []);
   const work = model.work.filter((entry) => operatorWorkIds.has(entry.workId));
   const visibleWork = work.slice(-MAX_OPERATOR_INSPECTION_WORK);
-  const claims = model.claims.filter(
-    (claim) => claim.operatorId === expectedOperatorId,
-  );
+  const claims = model.claims.filter((claim) => claim.operatorId === expectedOperatorId);
   const visibleClaims = claims.slice(-MAX_OPERATOR_INSPECTION_CLAIMS);
   const claimByRunId = new Map(
     model.claims
@@ -558,7 +577,7 @@ function inspectionFromModel(
     schemaVersion: AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION,
     rootSessionId: input.rootSessionId,
     graphId: input.graphId,
-    snapshotVersion: model.snapshotVersion,
+    snapshotVersion,
     operator,
     inboundEdges: visibleInboundEdges,
     outboundEdges: visibleOutboundEdges,
@@ -571,9 +590,7 @@ function inspectionFromModel(
       firstEventTime: activation.firstEventTime,
       lastEventTime: activation.lastEventTime,
       lastRecordId: activation.lastRecordId,
-      ...(activation.terminalRecordId
-        ? { terminalRecordId: activation.terminalRecordId }
-        : {}),
+      ...(activation.terminalRecordId ? { terminalRecordId: activation.terminalRecordId } : {}),
       run: runRefForActivation(
         operator.childSessionId,
         activation.agentRunId,
@@ -601,12 +618,10 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
     input.schedule ?? projectAgentGraphSchedule(input.graphId, input.scheduleUpdates);
   const provisionByOperator = provisionsByOperator(input.graphId, input.provisions);
   const edges = uniqueEdges(input.graphId, input.provisions);
-  const claims = clientClaims(
-    input.graphId,
-    input.observation.claims,
-    input.claimAdmissions ?? [],
-  );
-  const activity = input.observation.projection.records.map(clientActivity);
+  const claims = clientClaims(input.graphId, input.observation.claims, input.claimAdmissions ?? []);
+  const activity = input.observation.projection.records
+    .map(clientActivity)
+    .sort(compareClientActivity);
   const work = schedule.work.map(clientWork);
   const operators = input.observation.projection.operators.map((binding) => {
     const provision = provisionByOperator.get(binding.operatorId);
@@ -621,13 +636,8 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
         readinessId: entry.readinessId,
         policyKind: entry.policyKind,
         status: entry.status,
-        waitingFor: entry.waitingFor
-          .slice(0, MAX_OPERATOR_READINESS_WAITS)
-          .map(cloneWait),
-        omittedWaitingFor: Math.max(
-          0,
-          entry.waitingFor.length - MAX_OPERATOR_READINESS_WAITS,
-        ),
+        waitingFor: entry.waitingFor.slice(0, MAX_OPERATOR_READINESS_WAITS).map(cloneWait),
+        omittedWaitingFor: Math.max(0, entry.waitingFor.length - MAX_OPERATOR_READINESS_WAITS),
       }));
     const readiness = allReadiness.slice(0, MAX_OPERATOR_READINESS);
     const state = input.observation.projection.state.operators[binding.operatorId];
@@ -639,9 +649,7 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
             claim.run.agentRunId === currentActivation.agentRunId,
         )
       : undefined;
-    const operatorRecords = activity.filter(
-      (record) => record.operatorId === binding.operatorId,
-    );
+    const operatorRecords = activity.filter((record) => record.operatorId === binding.operatorId);
     const currentRecord = currentActivation
       ? [...operatorRecords]
           .reverse()
@@ -659,8 +667,7 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
       .filter(
         (entry) =>
           entry.workId === provision.workId ||
-          (entry.target.kind === 'operator' &&
-            entry.target.operatorId === binding.operatorId),
+          (entry.target.kind === 'operator' && entry.target.operatorId === binding.operatorId),
       )
       .map((entry) => entry.workId);
     const scheduledWorkIds = allScheduledWorkIds.slice(-MAX_OPERATOR_WORK_REFS);
@@ -680,10 +687,7 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
         outboundEdgeIds: allOutboundEdgeIds.length - outboundEdgeIds.length,
         scheduledWorkIds: allScheduledWorkIds.length - scheduledWorkIds.length,
         readiness: allReadiness.length - readiness.length,
-        readinessWaits: allReadiness.reduce(
-          (total, entry) => total + entry.omittedWaitingFor,
-          0,
-        ),
+        readinessWaits: allReadiness.reduce((total, entry) => total + entry.omittedWaitingFor, 0),
       },
       ...(currentActivation
         ? {
@@ -726,31 +730,7 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
       stoppedTargetIds: update.stop.map((entry) => entry.targetId),
       selectedResultIds: update.finish ? [...update.finish.resultIds] : [],
     }));
-  const snapshotVersion = stableHash({
-    schemaVersion: AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION,
-    rootSessionId: input.rootSessionId,
-    graphId: input.graphId,
-    scheduleRevision: schedule.revision,
-    topologyFingerprint: input.observation.readiness.topologyFingerprint,
-    provisionCount: input.provisions.length,
-    latestProvisionId: [...input.provisions]
-      .sort(
-        (a, b) =>
-          a.provisionedAt - b.provisionedAt ||
-          compareIdentity(a.provisionId, b.provisionId),
-      )
-      .at(-1)?.provisionId,
-    claimCount: claims.length,
-    latestClaimId: claims.at(-1)?.claimId,
-    claimAdmissions: claims.map((claim) => ({
-      claimId: claim.claimId,
-      state: claim.admissionState,
-    })),
-    recordCount: activity.length,
-    latestRecordId: activity.at(-1)?.recordId,
-  });
   return {
-    snapshotVersion,
     schedule,
     operators,
     edges,
@@ -767,8 +747,7 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
           .filter(
             (entry) =>
               entry.workId === provisionByOperator.get(operator.operatorId)?.workId ||
-              (entry.target.kind === 'operator' &&
-                entry.target.operatorId === operator.operatorId),
+              (entry.target.kind === 'operator' && entry.target.operatorId === operator.operatorId),
           )
           .map((entry) => entry.workId),
       ]),
@@ -801,19 +780,14 @@ function graphStatus(
   if (schedule.closed) {
     const terminalRunIds = new Set(
       activity
-        .filter((record) =>
-          record.signals.some((signal) => signal.kind === 'terminal'),
-        )
+        .filter((record) => record.signals.some((signal) => signal.kind === 'terminal'))
         .map((record) => record.run.agentRunId),
     );
-    const observedRunIds = new Set(
-      activity.map((record) => record.run.agentRunId),
-    );
+    const observedRunIds = new Set(activity.map((record) => record.run.agentRunId));
     const unsettledClaim = claims.some(
       (claim) =>
         !terminalRunIds.has(claim.run.agentRunId) &&
-        (claim.admissionState !== 'cancelled' ||
-          observedRunIds.has(claim.run.agentRunId)),
+        (claim.admissionState !== 'cancelled' || observedRunIds.has(claim.run.agentRunId)),
     );
     const runningOperator = operators.some((operator) =>
       ['running', 'blocked'].includes(operator.status),
@@ -821,20 +795,14 @@ function graphStatus(
     return unsettledClaim || runningOperator ? 'closing' : 'completed';
   }
   if (operators.length === 0 && schedule.work.length === 0) return 'empty';
-  if (
-    operators.some((operator) =>
-      ['running', 'blocked', 'runnable'].includes(operator.status),
-    )
-  ) {
+  if (operators.some((operator) => ['running', 'blocked', 'runnable'].includes(operator.status))) {
     return 'active';
   }
   const activeWork = schedule.work.filter((work) => work.status === 'requested');
   if (activeWork.length === 0 && schedule.stoppedTargets.length > 0) return 'stopped';
   if (
     operators.length > 0 &&
-    operators.every((operator) =>
-      ['failed', 'aborted', 'cancelled'].includes(operator.status),
-    )
+    operators.every((operator) => ['failed', 'aborted', 'cancelled'].includes(operator.status))
   ) {
     return 'failed';
   }
@@ -846,27 +814,20 @@ function patchedGraphStatus(
   patchedOperator: AgentGraphClientOperator,
 ): AgentGraphClientStatus {
   const operators = snapshot.operators.map((operator) =>
-    operator.operatorId === patchedOperator.operatorId
-      ? patchedOperator
-      : operator,
+    operator.operatorId === patchedOperator.operatorId ? patchedOperator : operator,
   );
   if (snapshot.closed) {
     if (
       snapshot.omitted.operators > 0 ||
       snapshot.omitted.claims > 0 ||
-      operators.some((operator) =>
-        ['running', 'blocked'].includes(operator.status),
-      )
+      operators.some((operator) => ['running', 'blocked'].includes(operator.status))
     ) {
       return 'closing';
     }
     const operatorByRunId = new Map(
       operators
         .filter((operator) => operator.currentActivation)
-        .map((operator) => [
-          operator.currentActivation!.run.agentRunId,
-          operator,
-        ]),
+        .map((operator) => [operator.currentActivation!.run.agentRunId, operator]),
     );
     return snapshot.claims.every((claim) => {
       if (claim.admissionState === 'cancelled') {
@@ -875,19 +836,25 @@ function patchedGraphStatus(
       const operator = operatorByRunId.get(claim.run.agentRunId);
       return (
         operator !== undefined &&
-        ['completed', 'failed', 'aborted', 'cancelled'].includes(
-          operator.status,
-        )
+        ['completed', 'failed', 'aborted', 'cancelled'].includes(operator.status)
       );
     })
       ? 'completed'
       : 'closing';
   }
-  return operators.some((operator) =>
-    ['running', 'blocked', 'runnable'].includes(operator.status),
-  )
+  return operators.some((operator) => ['running', 'blocked', 'runnable'].includes(operator.status))
     ? 'active'
-    : snapshot.status;
+    : operators.length === 0 && snapshot.work.length === 0
+      ? 'empty'
+      : snapshot.work.every((work) => work.status !== 'requested') &&
+          snapshot.stoppedTargets.length > 0
+        ? 'stopped'
+        : operators.length > 0 &&
+            operators.every((operator) =>
+              ['failed', 'aborted', 'cancelled'].includes(operator.status),
+            )
+          ? 'failed'
+          : 'waiting';
 }
 
 function projectClientSessionEvent(
@@ -946,8 +913,7 @@ function projectClientSessionEvent(
       const terminalStatus =
         event.stopReason === 'user_stop'
           ? 'aborted'
-          : activationHadError ||
-              failureClassFromCompleteStopReason(event.stopReason)
+          : activationHadError || failureClassFromCompleteStopReason(event.stopReason)
             ? 'failed'
             : 'completed';
       return {
@@ -961,9 +927,7 @@ function projectClientSessionEvent(
   }
 }
 
-function clientRuntimeRecordId(
-  runtime: AgentGraphSupervisorRuntimeEvent,
-): string {
+function clientRuntimeRecordId(runtime: AgentGraphSupervisorRuntimeEvent): string {
   return `graph_record_${stableHash({
     graphId: runtime.intent.graphId,
     operatorId: runtime.claim.targetOperatorId,
@@ -977,13 +941,10 @@ function boundOperators(
   operators: readonly AgentGraphClientOperator[],
 ): AgentGraphClientOperator[] {
   const live = operators.filter(
-    (operator) =>
-      !['completed', 'failed', 'aborted', 'cancelled'].includes(operator.status),
+    (operator) => !['completed', 'failed', 'aborted', 'cancelled'].includes(operator.status),
   );
   const terminal = operators
-    .filter((operator) =>
-      ['completed', 'failed', 'aborted', 'cancelled'].includes(operator.status),
-    )
+    .filter((operator) => ['completed', 'failed', 'aborted', 'cancelled'].includes(operator.status))
     .sort(
       (a, b) =>
         (a.currentActivation?.lastEventTime ?? a.provisionedAt) -
@@ -1018,28 +979,20 @@ function terminalHistoryPage(
       throw new Error('Agent graph terminal history cursor belongs to another graph');
     }
     const index = terminal.findIndex(
-      (record) =>
-        record.recordId === decoded.recordId &&
-        record.eventTime === decoded.eventTime,
+      (record) => record.recordId === decoded.recordId && record.eventTime === decoded.eventTime,
     );
     if (index < 0) {
       throw new Error('Agent graph terminal history cursor is stale or invalid');
     }
     start = index + 1;
   }
-  const records = terminal.slice(
-    start,
-    start + AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE,
-  );
+  const records = terminal.slice(start, start + AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE);
   const hasMore = start + records.length < terminal.length;
   return {
     records,
     ...(hasMore && records.length > 0
       ? {
-          nextCursor: encodeAgentGraphTerminalCursor(
-            graphId,
-            records[records.length - 1]!,
-          ),
+          nextCursor: encodeAgentGraphTerminalCursor(graphId, records[records.length - 1]!),
         }
       : {}),
   };
@@ -1050,11 +1003,7 @@ function terminalActivities(
 ): AgentGraphClientActivity[] {
   return activity
     .filter((record) => record.signals.some((signal) => signal.kind === 'terminal'))
-    .sort(
-      (a, b) =>
-        b.eventTime - a.eventTime ||
-        compareIdentity(b.recordId, a.recordId),
-    );
+    .sort((a, b) => b.eventTime - a.eventTime || compareIdentity(b.recordId, a.recordId));
 }
 
 export function materializedAgentGraphTerminalHistoryPage(
@@ -1066,10 +1015,7 @@ export function materializedAgentGraphTerminalHistoryPage(
     records: records.map((record) => structuredClone(record)),
     ...(hasMore && records.length > 0
       ? {
-          nextCursor: encodeAgentGraphTerminalCursor(
-            graphId,
-            records[records.length - 1]!,
-          ),
+          nextCursor: encodeAgentGraphTerminalCursor(graphId, records[records.length - 1]!),
         }
       : {}),
   };
@@ -1092,9 +1038,7 @@ function clientWork(work: AgentGraphScheduleWorkView): AgentGraphClientScheduled
   };
 }
 
-function clientStoppedTarget(
-  stopped: AgentGraphStoppedTargetView,
-): AgentGraphClientStoppedTarget {
+function clientStoppedTarget(stopped: AgentGraphStoppedTargetView): AgentGraphClientStoppedTarget {
   return {
     targetId: stopped.targetId,
     reason: stopped.reason,
@@ -1125,10 +1069,7 @@ function clientClaims(
     admissionByIntent.set(admission.intentId, admission.state);
   }
   return [...claims]
-    .sort(
-      (a, b) =>
-        a.claimedAt - b.claimedAt || compareIdentity(a.claimId, b.claimId),
-    )
+    .sort((a, b) => a.claimedAt - b.claimedAt || compareIdentity(a.claimId, b.claimId))
     .map((claim) => {
       if (claim.graphId !== graphId) {
         throw new Error(`Agent graph claim ${claim.claimId} belongs to another graph`);
@@ -1172,8 +1113,7 @@ function runRefForActivation(
   records: readonly AgentGraphClientActivity[],
 ): AgentGraphClientRunRef {
   const turnId =
-    claim?.run.turnId ??
-    records.find((record) => record.run.agentRunId === agentRunId)?.run.turnId;
+    claim?.run.turnId ?? records.find((record) => record.run.agentRunId === agentRunId)?.run.turnId;
   return {
     sessionId,
     agentRunId,
@@ -1187,9 +1127,7 @@ function provisionsByOperator(
 ): Map<string, AgentGraphOperatorProvision> {
   const result = new Map<string, AgentGraphOperatorProvision>();
   for (const provision of [...provisions].sort(
-    (a, b) =>
-      a.provisionedAt - b.provisionedAt ||
-      compareIdentity(a.provisionId, b.provisionId),
+    (a, b) => a.provisionedAt - b.provisionedAt || compareIdentity(a.provisionId, b.provisionId),
   )) {
     if (provision.graphId !== graphId) {
       throw new Error(`Agent graph provision ${provision.provisionId} belongs to another graph`);
@@ -1233,10 +1171,7 @@ function uniqueEdges(
   return [...edges.values()].sort((a, b) => compareIdentity(a.edgeId, b.edgeId));
 }
 
-function assertObservation(
-  graphId: string,
-  observation: AgentGraphSupervisorObservation,
-): void {
+function assertObservation(graphId: string, observation: AgentGraphSupervisorObservation): void {
   if (
     observation.projection.graphId !== graphId ||
     observation.readiness.graphId !== graphId ||
@@ -1286,8 +1221,7 @@ export function decodeAgentGraphTerminalCursor(cursor: string): {
     const value = JSON.parse(json) as Record<string, unknown>;
     if (
       canonical !== cursor ||
-      Object.keys(value).sort().join(',') !==
-        'eventTime,graphId,recordId,schemaVersion' ||
+      Object.keys(value).sort().join(',') !== 'eventTime,graphId,recordId,schemaVersion' ||
       value.schemaVersion !== AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION ||
       typeof value.eventTime !== 'number' ||
       !Number.isSafeInteger(value.eventTime) ||
@@ -1391,9 +1325,7 @@ export function decodeMaterializedAgentGraphClientActivity(
     typeof activity.run.sessionId !== 'string' ||
     typeof activity.run.agentRunId !== 'string'
   ) {
-    throw new Error(
-      `Invalid materialized agent graph client activity for ${expected.graphId}`,
-    );
+    throw new Error(`Invalid materialized agent graph client activity for ${expected.graphId}`);
   }
   return structuredClone(activity as AgentGraphClientActivity);
 }
@@ -1409,6 +1341,31 @@ function requireIdentity(value: unknown, name: string): string {
     throw new Error(`Invalid agent graph ${name}`);
   }
   return value;
+}
+
+function compareActivityKey(
+  eventTimeA: number,
+  recordIdA: string,
+  eventTimeB: number,
+  recordIdB: string,
+): number {
+  return eventTimeA - eventTimeB || compareIdentity(recordIdA, recordIdB);
+}
+
+function compareClientActivity(
+  a: Pick<AgentGraphClientActivity, 'eventTime' | 'recordId'>,
+  b: Pick<AgentGraphClientActivity, 'eventTime' | 'recordId'>,
+): number {
+  return compareActivityKey(a.eventTime, a.recordId, b.eventTime, b.recordId);
+}
+
+function clientSnapshotVersion(snapshot: AgentGraphClientSnapshot): string {
+  const {
+    snapshotVersion: _snapshotVersion,
+    terminalHistory: _terminalHistory,
+    ...boundedContent
+  } = snapshot;
+  return stableHash(boundedContent);
 }
 
 function compareIdentity(a: string, b: string): number {

--- a/packages/runtime/src/stream-graph-read-model.ts
+++ b/packages/runtime/src/stream-graph-read-model.ts
@@ -1,0 +1,843 @@
+import type {
+  AgentGraphIntentClaim,
+  AgentGraphOperatorProvision,
+  AgentGraphScheduleUpdate,
+} from '@maka/core';
+import type { AgentGraphSupervisorObservation } from './stream-graph-dispatch.js';
+import type {
+  AgentGraphActivationStatus,
+  AgentGraphRecord,
+  AgentGraphRecordFacet,
+  AgentGraphSupervisorSignal,
+} from './stream-graph-projection.js';
+import type { AgentGraphReadinessWait } from './stream-graph-readiness.js';
+import {
+  projectAgentGraphSchedule,
+  type AgentGraphScheduleFinishView,
+  type AgentGraphScheduleProjection,
+  type AgentGraphScheduleWorkView,
+  type AgentGraphStoppedTargetView,
+} from './stream-graph-supervisor-tools.js';
+import { stableHash } from './request-shape.js';
+
+export const AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION = 1 as const;
+
+const MAX_VISIBLE_OPERATORS = 256;
+const MAX_VISIBLE_EDGES = 512;
+const MAX_VISIBLE_WORK = 256;
+const MAX_VISIBLE_STOPPED_TARGETS = 128;
+const MAX_RECENT_CONTROL_DECISIONS = 32;
+const MAX_VISIBLE_CLAIMS = 256;
+const MAX_RECENT_ACTIVITY = 64;
+const MAX_TERMINAL_HISTORY = 64;
+const MAX_OPERATOR_INSPECTION_ACTIVATIONS = 64;
+const MAX_OPERATOR_INSPECTION_RECORDS = 128;
+const MAX_INSTRUCTION_PREVIEW_CHARS = 500;
+
+export type AgentGraphClientOperatorStatus =
+  | 'not_started'
+  | 'waiting'
+  | 'runnable'
+  | 'running'
+  | 'blocked'
+  | AgentGraphActivationStatus;
+
+export type AgentGraphClientStatus =
+  | 'empty'
+  | 'active'
+  | 'waiting'
+  | 'stopped'
+  | 'failed'
+  | 'completed';
+
+export interface AgentGraphClientRunRef {
+  sessionId: string;
+  agentRunId: string;
+  turnId?: string;
+}
+
+export interface AgentGraphClientOperator {
+  operatorId: string;
+  childSessionId: string;
+  provisionId: string;
+  agentId: string;
+  provisionedAt: number;
+  status: AgentGraphClientOperatorStatus;
+  inboundEdgeIds: string[];
+  outboundEdgeIds: string[];
+  scheduledWorkIds: string[];
+  readiness: Array<{
+    readinessId: string;
+    policyKind: 'map' | 'all_settled';
+    status: 'waiting' | 'runnable';
+    waitingFor: AgentGraphReadinessWait[];
+  }>;
+  currentActivation?: {
+    activationId: string;
+    status: AgentGraphActivationStatus;
+    recordCount: number;
+    firstEventTime: number;
+    lastEventTime: number;
+    terminalRecordId?: string;
+    run: AgentGraphClientRunRef;
+  };
+}
+
+export interface AgentGraphClientEdge {
+  edgeId: string;
+  fromOperatorId: string;
+  toOperatorId: string;
+}
+
+export interface AgentGraphClientScheduledWork {
+  workId: string;
+  target:
+    | { kind: 'agent'; agentId: string }
+    | { kind: 'operator'; operatorId: string };
+  inputIds: string[];
+  replaces?: string;
+  status: AgentGraphScheduleWorkView['status'];
+  instructionPreview: string;
+  instructionTruncated: boolean;
+  revision: number;
+  committedAt: number;
+}
+
+export interface AgentGraphClientStoppedTarget {
+  targetId: string;
+  reason: string;
+  revision: number;
+  committedAt: number;
+}
+
+export interface AgentGraphClientFinish {
+  resultIds: string[];
+  reason: string;
+  revision: number;
+  committedAt: number;
+}
+
+export interface AgentGraphClientControlDecision {
+  updateId: string;
+  revision: number;
+  committedAt: number;
+  source: {
+    sessionId: string;
+    agentRunId: string;
+    turnId: string;
+    toolCallId: string;
+  };
+  addedWorkIds: string[];
+  stoppedTargetIds: string[];
+  selectedResultIds: string[];
+}
+
+export interface AgentGraphClientClaimRef {
+  claimId: string;
+  intentId: string;
+  operatorId: string;
+  childSessionId: string;
+  run: AgentGraphClientRunRef;
+  claimedAt: number;
+}
+
+export interface AgentGraphClientActivity {
+  recordId: string;
+  operatorId: string;
+  activationId: string;
+  eventTime: number;
+  facets: AgentGraphRecordFacet[];
+  signals: AgentGraphSupervisorSignal[];
+  run: AgentGraphClientRunRef;
+}
+
+export interface AgentGraphClientTerminalHistoryPage {
+  records: AgentGraphClientActivity[];
+  nextCursor?: string;
+}
+
+export interface AgentGraphClientSnapshot {
+  schemaVersion: typeof AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION;
+  rootSessionId: string;
+  graphId: string;
+  snapshotVersion: string;
+  status: AgentGraphClientStatus;
+  scheduleRevision: number;
+  topologyFingerprint: string;
+  closed: boolean;
+  latestEventTime?: number;
+  operators: AgentGraphClientOperator[];
+  edges: AgentGraphClientEdge[];
+  work: AgentGraphClientScheduledWork[];
+  stoppedTargets: AgentGraphClientStoppedTarget[];
+  finish?: AgentGraphClientFinish;
+  claims: AgentGraphClientClaimRef[];
+  recentControlDecisions: AgentGraphClientControlDecision[];
+  recentActivity: AgentGraphClientActivity[];
+  terminalHistory: AgentGraphClientTerminalHistoryPage;
+  omitted: {
+    operators: number;
+    edges: number;
+    work: number;
+    stoppedTargets: number;
+    claims: number;
+    controlDecisions: number;
+    recentActivity: number;
+  };
+}
+
+export interface AgentGraphOperatorInspection {
+  schemaVersion: typeof AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION;
+  rootSessionId: string;
+  graphId: string;
+  snapshotVersion: string;
+  operator: AgentGraphClientOperator;
+  inboundEdges: AgentGraphClientEdge[];
+  outboundEdges: AgentGraphClientEdge[];
+  work: AgentGraphClientScheduledWork[];
+  claims: AgentGraphClientClaimRef[];
+  activations: Array<{
+    activationId: string;
+    status: AgentGraphActivationStatus;
+    recordCount: number;
+    firstEventTime: number;
+    lastEventTime: number;
+    lastRecordId: string;
+    terminalRecordId?: string;
+    run: AgentGraphClientRunRef;
+  }>;
+  recentRecords: AgentGraphClientActivity[];
+  omittedActivationCount: number;
+  omittedRecordCount: number;
+}
+
+export interface BuildAgentGraphClientReadModelInput {
+  rootSessionId: string;
+  graphId: string;
+  provisions: readonly AgentGraphOperatorProvision[];
+  scheduleUpdates: readonly AgentGraphScheduleUpdate[];
+  observation: AgentGraphSupervisorObservation;
+}
+
+export interface AgentGraphClientSnapshotOptions {
+  terminalCursor?: string;
+}
+
+interface BuiltReadModel {
+  snapshotVersion: string;
+  schedule: AgentGraphScheduleProjection;
+  operators: AgentGraphClientOperator[];
+  edges: AgentGraphClientEdge[];
+  work: AgentGraphClientScheduledWork[];
+  stoppedTargets: AgentGraphClientStoppedTarget[];
+  finish?: AgentGraphClientFinish;
+  claims: AgentGraphClientClaimRef[];
+  recentControlDecisions: AgentGraphClientControlDecision[];
+  activity: AgentGraphClientActivity[];
+}
+
+/**
+ * Durable, bounded graph-facing projection for untrusted presentation clients.
+ *
+ * Payloads remain in Session/Runtime stores. This surface carries only
+ * identities, lifecycle state, wait reasons, and bounded instruction previews.
+ */
+export function buildAgentGraphClientSnapshot(
+  input: BuildAgentGraphClientReadModelInput,
+  options: AgentGraphClientSnapshotOptions = {},
+): AgentGraphClientSnapshot {
+  const model = buildReadModel(input);
+  const visibleOperators = boundOperators(model.operators);
+  const visibleOperatorIds = new Set(visibleOperators.map((operator) => operator.operatorId));
+  const candidateEdges = model.edges.filter(
+    (edge) =>
+      visibleOperatorIds.has(edge.fromOperatorId) &&
+      visibleOperatorIds.has(edge.toOperatorId),
+  );
+  const edges = candidateEdges.slice(0, MAX_VISIBLE_EDGES);
+  const work = boundWork(model.work);
+  const stoppedTargets = model.stoppedTargets.slice(-MAX_VISIBLE_STOPPED_TARGETS);
+  const claims = model.claims.slice(-MAX_VISIBLE_CLAIMS);
+  const recentControlDecisions = model.recentControlDecisions.slice(
+    -MAX_RECENT_CONTROL_DECISIONS,
+  );
+  const recentActivity = model.activity.slice(-MAX_RECENT_ACTIVITY);
+  return {
+    schemaVersion: AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION,
+    rootSessionId: input.rootSessionId,
+    graphId: input.graphId,
+    snapshotVersion: model.snapshotVersion,
+    status: graphStatus(model.schedule, model.operators),
+    scheduleRevision: model.schedule.revision,
+    topologyFingerprint: input.observation.readiness.topologyFingerprint,
+    closed: model.schedule.closed,
+    ...(input.observation.projection.state.latestEventTime !== undefined
+      ? { latestEventTime: input.observation.projection.state.latestEventTime }
+      : {}),
+    operators: visibleOperators,
+    edges,
+    work,
+    stoppedTargets,
+    ...(model.finish ? { finish: model.finish } : {}),
+    claims,
+    recentControlDecisions,
+    recentActivity,
+    terminalHistory: terminalHistoryPage(input.graphId, model.activity, options.terminalCursor),
+    omitted: {
+      operators: model.operators.length - visibleOperators.length,
+      edges: model.edges.length - edges.length,
+      work: model.work.length - work.length,
+      stoppedTargets: model.stoppedTargets.length - stoppedTargets.length,
+      claims: model.claims.length - claims.length,
+      controlDecisions:
+        model.recentControlDecisions.length - recentControlDecisions.length,
+      recentActivity: model.activity.length - recentActivity.length,
+    },
+  };
+}
+
+export function inspectAgentGraphOperator(
+  input: BuildAgentGraphClientReadModelInput,
+  operatorId: string,
+): AgentGraphOperatorInspection {
+  const expectedOperatorId = requireIdentity(operatorId, 'operator id');
+  const model = buildReadModel(input);
+  const operator = model.operators.find(
+    (candidate) => candidate.operatorId === expectedOperatorId,
+  );
+  if (!operator) {
+    throw new Error(`Agent graph operator ${expectedOperatorId} was not found`);
+  }
+  const runtimeState = input.observation.projection.state.operators[expectedOperatorId];
+  const allActivations = runtimeState
+    ? Object.values(runtimeState.activations).sort(
+        (a, b) =>
+          a.firstEventTime - b.firstEventTime ||
+          compareIdentity(a.activationId, b.activationId),
+      )
+    : [];
+  const visibleActivations = allActivations.slice(-MAX_OPERATOR_INSPECTION_ACTIVATIONS);
+  const allRecords = model.activity.filter(
+    (record) => record.operatorId === expectedOperatorId,
+  );
+  const recentRecords = allRecords.slice(-MAX_OPERATOR_INSPECTION_RECORDS);
+  const claimByRunId = new Map(
+    model.claims
+      .filter((claim) => claim.operatorId === expectedOperatorId)
+      .map((claim) => [claim.run.agentRunId, claim]),
+  );
+  return {
+    schemaVersion: AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION,
+    rootSessionId: input.rootSessionId,
+    graphId: input.graphId,
+    snapshotVersion: model.snapshotVersion,
+    operator,
+    inboundEdges: model.edges.filter(
+      (edge) => edge.toOperatorId === expectedOperatorId,
+    ),
+    outboundEdges: model.edges.filter(
+      (edge) => edge.fromOperatorId === expectedOperatorId,
+    ),
+    work: model.work.filter((work) =>
+      operator.scheduledWorkIds.includes(work.workId),
+    ),
+    claims: model.claims.filter(
+      (claim) => claim.operatorId === expectedOperatorId,
+    ),
+    activations: visibleActivations.map((activation) => ({
+      activationId: activation.activationId,
+      status: activation.status,
+      recordCount: activation.recordCount,
+      firstEventTime: activation.firstEventTime,
+      lastEventTime: activation.lastEventTime,
+      lastRecordId: activation.lastRecordId,
+      ...(activation.terminalRecordId
+        ? { terminalRecordId: activation.terminalRecordId }
+        : {}),
+      run: runRefForActivation(
+        operator.childSessionId,
+        activation.agentRunId,
+        claimByRunId.get(activation.agentRunId),
+        allRecords,
+      ),
+    })),
+    recentRecords,
+    omittedActivationCount: allActivations.length - visibleActivations.length,
+    omittedRecordCount: allRecords.length - recentRecords.length,
+  };
+}
+
+function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadModel {
+  requireIdentity(input.rootSessionId, 'root Session id');
+  requireIdentity(input.graphId, 'graph id');
+  assertObservation(input.graphId, input.observation);
+  const schedule = projectAgentGraphSchedule(input.graphId, input.scheduleUpdates);
+  const provisionByOperator = provisionsByOperator(input.graphId, input.provisions);
+  const edges = uniqueEdges(input.graphId, input.provisions);
+  const claims = clientClaims(input.graphId, input.observation.claims);
+  const activity = input.observation.projection.records.map(clientActivity);
+  const work = schedule.work.map(clientWork);
+  const operators = input.observation.projection.operators.map((binding) => {
+    const provision = provisionByOperator.get(binding.operatorId);
+    if (!provision || provision.targetSessionId !== binding.sessionId) {
+      throw new Error(
+        `Agent graph operator ${binding.operatorId} has no matching durable provision`,
+      );
+    }
+    const readiness = input.observation.readiness.supervisorView
+      .filter((entry) => entry.operatorId === binding.operatorId)
+      .map((entry) => ({
+        readinessId: entry.readinessId,
+        policyKind: entry.policyKind,
+        status: entry.status,
+        waitingFor: entry.waitingFor.map(cloneWait),
+      }));
+    const state = input.observation.projection.state.operators[binding.operatorId];
+    const currentActivation = state?.activations[state.currentActivationId];
+    const currentClaim = currentActivation
+      ? claims.find(
+          (claim) =>
+            claim.operatorId === binding.operatorId &&
+            claim.run.agentRunId === currentActivation.agentRunId,
+        )
+      : undefined;
+    const operatorRecords = activity.filter(
+      (record) => record.operatorId === binding.operatorId,
+    );
+    const currentRecord = currentActivation
+      ? [...operatorRecords]
+          .reverse()
+          .find((record) => record.activationId === currentActivation.activationId)
+      : undefined;
+    return {
+      operatorId: binding.operatorId,
+      childSessionId: binding.sessionId,
+      provisionId: provision.provisionId,
+      agentId: provision.agentId,
+      provisionedAt: provision.provisionedAt,
+      status: operatorStatus(state?.status, readiness, currentRecord),
+      inboundEdgeIds: edges
+        .filter((edge) => edge.toOperatorId === binding.operatorId)
+        .map((edge) => edge.edgeId),
+      outboundEdgeIds: edges
+        .filter((edge) => edge.fromOperatorId === binding.operatorId)
+        .map((edge) => edge.edgeId),
+      scheduledWorkIds: work
+        .filter(
+          (entry) =>
+            entry.workId === provision.workId ||
+            (entry.target.kind === 'operator' &&
+              entry.target.operatorId === binding.operatorId),
+        )
+        .map((entry) => entry.workId),
+      readiness,
+      ...(currentActivation
+        ? {
+            currentActivation: {
+              activationId: currentActivation.activationId,
+              status: currentActivation.status,
+              recordCount: currentActivation.recordCount,
+              firstEventTime: currentActivation.firstEventTime,
+              lastEventTime: currentActivation.lastEventTime,
+              ...(currentActivation.terminalRecordId
+                ? { terminalRecordId: currentActivation.terminalRecordId }
+                : {}),
+              run: runRefForActivation(
+                binding.sessionId,
+                currentActivation.agentRunId,
+                currentClaim,
+                operatorRecords,
+              ),
+            },
+          }
+        : {}),
+    } satisfies AgentGraphClientOperator;
+  });
+  const stoppedTargets = schedule.stoppedTargets.map(clientStoppedTarget);
+  const finish = schedule.finish ? clientFinish(schedule.finish) : undefined;
+  const recentControlDecisions = input.scheduleUpdates
+    .slice()
+    .sort((a, b) => a.revision - b.revision)
+    .map((update) => ({
+      updateId: update.updateId,
+      revision: update.revision,
+      committedAt: update.committedAt,
+      source: {
+        sessionId: update.source.sessionId,
+        agentRunId: update.source.runId,
+        turnId: update.source.turnId,
+        toolCallId: update.source.toolCallId,
+      },
+      addedWorkIds: update.addWork.map((entry) => entry.workId),
+      stoppedTargetIds: update.stop.map((entry) => entry.targetId),
+      selectedResultIds: update.finish ? [...update.finish.resultIds] : [],
+    }));
+  const snapshotVersion = stableHash({
+    schemaVersion: AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION,
+    rootSessionId: input.rootSessionId,
+    graphId: input.graphId,
+    scheduleRevision: schedule.revision,
+    topologyFingerprint: input.observation.readiness.topologyFingerprint,
+    provisionCount: input.provisions.length,
+    latestProvisionId: [...input.provisions]
+      .sort(
+        (a, b) =>
+          a.provisionedAt - b.provisionedAt ||
+          compareIdentity(a.provisionId, b.provisionId),
+      )
+      .at(-1)?.provisionId,
+    claimCount: claims.length,
+    latestClaimId: claims.at(-1)?.claimId,
+    recordCount: activity.length,
+    latestRecordId: activity.at(-1)?.recordId,
+  });
+  return {
+    snapshotVersion,
+    schedule,
+    operators,
+    edges,
+    work,
+    stoppedTargets,
+    ...(finish ? { finish } : {}),
+    claims,
+    recentControlDecisions,
+    activity,
+  };
+}
+
+function operatorStatus(
+  runtimeStatus: AgentGraphActivationStatus | undefined,
+  readiness: AgentGraphClientOperator['readiness'],
+  currentRecord: AgentGraphClientActivity | undefined,
+): AgentGraphClientOperatorStatus {
+  if (runtimeStatus === 'running') {
+    return currentRecord?.signals.some((signal) => signal.kind === 'attention')
+      ? 'blocked'
+      : 'running';
+  }
+  if (runtimeStatus) return runtimeStatus;
+  if (readiness.some((entry) => entry.status === 'runnable')) return 'runnable';
+  if (readiness.length > 0) return 'waiting';
+  return 'not_started';
+}
+
+function graphStatus(
+  schedule: AgentGraphScheduleProjection,
+  operators: readonly AgentGraphClientOperator[],
+): AgentGraphClientStatus {
+  if (schedule.closed) return 'completed';
+  if (operators.length === 0 && schedule.work.length === 0) return 'empty';
+  if (
+    operators.some((operator) =>
+      ['running', 'blocked', 'runnable'].includes(operator.status),
+    )
+  ) {
+    return 'active';
+  }
+  const activeWork = schedule.work.filter((work) => work.status === 'requested');
+  if (activeWork.length === 0 && schedule.stoppedTargets.length > 0) return 'stopped';
+  if (
+    operators.length > 0 &&
+    operators.every((operator) =>
+      ['failed', 'aborted', 'cancelled'].includes(operator.status),
+    )
+  ) {
+    return 'failed';
+  }
+  return 'waiting';
+}
+
+function boundOperators(
+  operators: readonly AgentGraphClientOperator[],
+): AgentGraphClientOperator[] {
+  const live = operators.filter(
+    (operator) =>
+      !['completed', 'failed', 'aborted', 'cancelled'].includes(operator.status),
+  );
+  const terminal = operators
+    .filter((operator) =>
+      ['completed', 'failed', 'aborted', 'cancelled'].includes(operator.status),
+    )
+    .sort(
+      (a, b) =>
+        (a.currentActivation?.lastEventTime ?? a.provisionedAt) -
+          (b.currentActivation?.lastEventTime ?? b.provisionedAt) ||
+        compareIdentity(a.operatorId, b.operatorId),
+    );
+  if (live.length >= MAX_VISIBLE_OPERATORS) {
+    return live.slice(0, MAX_VISIBLE_OPERATORS);
+  }
+  return [...live, ...terminal.slice(-(MAX_VISIBLE_OPERATORS - live.length))];
+}
+
+function boundWork(
+  work: readonly AgentGraphClientScheduledWork[],
+): AgentGraphClientScheduledWork[] {
+  const live = work.filter((entry) => entry.status === 'requested');
+  const terminal = work.filter((entry) => entry.status !== 'requested');
+  if (live.length >= MAX_VISIBLE_WORK) return live.slice(0, MAX_VISIBLE_WORK);
+  return [...live, ...terminal.slice(-(MAX_VISIBLE_WORK - live.length))];
+}
+
+function terminalHistoryPage(
+  graphId: string,
+  activity: readonly AgentGraphClientActivity[],
+  cursor: string | undefined,
+): AgentGraphClientTerminalHistoryPage {
+  const terminal = activity
+    .filter((record) => record.signals.some((signal) => signal.kind === 'terminal'))
+    .reverse();
+  let start = 0;
+  if (cursor !== undefined) {
+    const decoded = decodeTerminalCursor(cursor);
+    if (decoded.graphId !== graphId) {
+      throw new Error('Agent graph terminal history cursor belongs to another graph');
+    }
+    const index = terminal.findIndex((record) => record.recordId === decoded.recordId);
+    if (index < 0) {
+      throw new Error('Agent graph terminal history cursor is stale or invalid');
+    }
+    start = index + 1;
+  }
+  const records = terminal.slice(start, start + MAX_TERMINAL_HISTORY);
+  const hasMore = start + records.length < terminal.length;
+  return {
+    records,
+    ...(hasMore && records.length > 0
+      ? {
+          nextCursor: encodeTerminalCursor(
+            graphId,
+            records[records.length - 1]!.recordId,
+          ),
+        }
+      : {}),
+  };
+}
+
+function clientWork(work: AgentGraphScheduleWorkView): AgentGraphClientScheduledWork {
+  const instructionTruncated = work.instruction.length > MAX_INSTRUCTION_PREVIEW_CHARS;
+  return {
+    workId: work.workId,
+    target: { ...work.target },
+    inputIds: [...work.inputIds],
+    ...(work.replaces ? { replaces: work.replaces } : {}),
+    status: work.status,
+    instructionPreview: instructionTruncated
+      ? `${work.instruction.slice(0, MAX_INSTRUCTION_PREVIEW_CHARS)}…`
+      : work.instruction,
+    instructionTruncated,
+    revision: work.revision,
+    committedAt: work.committedAt,
+  };
+}
+
+function clientStoppedTarget(
+  stopped: AgentGraphStoppedTargetView,
+): AgentGraphClientStoppedTarget {
+  return {
+    targetId: stopped.targetId,
+    reason: stopped.reason,
+    revision: stopped.revision,
+    committedAt: stopped.committedAt,
+  };
+}
+
+function clientFinish(finish: AgentGraphScheduleFinishView): AgentGraphClientFinish {
+  return {
+    resultIds: [...finish.resultIds],
+    reason: finish.reason,
+    revision: finish.revision,
+    committedAt: finish.committedAt,
+  };
+}
+
+function clientClaims(
+  graphId: string,
+  claims: readonly AgentGraphIntentClaim[],
+): AgentGraphClientClaimRef[] {
+  return [...claims]
+    .sort(
+      (a, b) =>
+        a.claimedAt - b.claimedAt || compareIdentity(a.claimId, b.claimId),
+    )
+    .map((claim) => {
+      if (claim.graphId !== graphId) {
+        throw new Error(`Agent graph claim ${claim.claimId} belongs to another graph`);
+      }
+      return {
+        claimId: claim.claimId,
+        intentId: claim.intentId,
+        operatorId: claim.targetOperatorId,
+        childSessionId: claim.targetSessionId,
+        run: {
+          sessionId: claim.targetSessionId,
+          agentRunId: claim.targetRunId,
+          turnId: claim.targetTurnId,
+        },
+        claimedAt: claim.claimedAt,
+      };
+    });
+}
+
+function clientActivity(record: AgentGraphRecord): AgentGraphClientActivity {
+  return {
+    recordId: record.recordId,
+    operatorId: record.operatorId,
+    activationId: record.activationId,
+    eventTime: record.eventTime,
+    facets: [...record.facets],
+    signals: record.supervisorSignals.map((signal) => ({ ...signal })),
+    run: {
+      sessionId: record.sessionId,
+      agentRunId: record.agentRunId,
+      turnId: record.source.turnId,
+    },
+  };
+}
+
+function runRefForActivation(
+  sessionId: string,
+  agentRunId: string,
+  claim: AgentGraphClientClaimRef | undefined,
+  records: readonly AgentGraphClientActivity[],
+): AgentGraphClientRunRef {
+  const turnId =
+    claim?.run.turnId ??
+    records.find((record) => record.run.agentRunId === agentRunId)?.run.turnId;
+  return {
+    sessionId,
+    agentRunId,
+    ...(turnId ? { turnId } : {}),
+  };
+}
+
+function provisionsByOperator(
+  graphId: string,
+  provisions: readonly AgentGraphOperatorProvision[],
+): Map<string, AgentGraphOperatorProvision> {
+  const result = new Map<string, AgentGraphOperatorProvision>();
+  for (const provision of [...provisions].sort(
+    (a, b) =>
+      a.provisionedAt - b.provisionedAt ||
+      compareIdentity(a.provisionId, b.provisionId),
+  )) {
+    if (provision.graphId !== graphId) {
+      throw new Error(`Agent graph provision ${provision.provisionId} belongs to another graph`);
+    }
+    const existing = result.get(provision.operatorId);
+    if (
+      existing &&
+      (existing.targetSessionId !== provision.targetSessionId ||
+        existing.agentId !== provision.agentId)
+    ) {
+      throw new Error(
+        `Agent graph operator ${provision.operatorId} has conflicting durable provisions`,
+      );
+    }
+    result.set(provision.operatorId, provision);
+  }
+  return result;
+}
+
+function uniqueEdges(
+  graphId: string,
+  provisions: readonly AgentGraphOperatorProvision[],
+): AgentGraphClientEdge[] {
+  const edges = new Map<string, AgentGraphClientEdge>();
+  for (const provision of provisions) {
+    if (provision.graphId !== graphId) {
+      throw new Error(`Agent graph provision ${provision.provisionId} belongs to another graph`);
+    }
+    for (const edge of provision.edges) {
+      const existing = edges.get(edge.edgeId);
+      if (
+        existing &&
+        (existing.fromOperatorId !== edge.fromOperatorId ||
+          existing.toOperatorId !== edge.toOperatorId)
+      ) {
+        throw new Error(`Agent graph edge ${edge.edgeId} has conflicting endpoints`);
+      }
+      edges.set(edge.edgeId, { ...edge });
+    }
+  }
+  return [...edges.values()].sort((a, b) => compareIdentity(a.edgeId, b.edgeId));
+}
+
+function assertObservation(
+  graphId: string,
+  observation: AgentGraphSupervisorObservation,
+): void {
+  if (
+    observation.projection.graphId !== graphId ||
+    observation.readiness.graphId !== graphId ||
+    observation.readiness.trace.graphId !== graphId
+  ) {
+    throw new Error('Agent graph client observation belongs to another graph');
+  }
+}
+
+function cloneWait(wait: AgentGraphReadinessWait): AgentGraphReadinessWait {
+  return wait.kind === 'input_route'
+    ? { ...wait, upstreamOperatorIds: [...wait.upstreamOperatorIds] }
+    : { ...wait };
+}
+
+function encodeTerminalCursor(graphId: string, recordId: string): string {
+  return Buffer.from(
+    JSON.stringify({
+      schemaVersion: AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION,
+      graphId,
+      recordId,
+    }),
+    'utf8',
+  ).toString('base64url');
+}
+
+function decodeTerminalCursor(cursor: string): {
+  graphId: string;
+  recordId: string;
+} {
+  if (
+    typeof cursor !== 'string' ||
+    cursor.length === 0 ||
+    cursor.length > 2_048 ||
+    cursor.trim() !== cursor
+  ) {
+    throw new Error('Invalid agent graph terminal history cursor');
+  }
+  try {
+    const json = Buffer.from(cursor, 'base64url').toString('utf8');
+    const canonical = Buffer.from(json, 'utf8').toString('base64url');
+    const value = JSON.parse(json) as Record<string, unknown>;
+    if (
+      canonical !== cursor ||
+      Object.keys(value).sort().join(',') !== 'graphId,recordId,schemaVersion' ||
+      value.schemaVersion !== AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION
+    ) {
+      throw new Error('invalid cursor envelope');
+    }
+    return {
+      graphId: requireIdentity(value.graphId, 'cursor graph id'),
+      recordId: requireIdentity(value.recordId, 'cursor record id'),
+    };
+  } catch {
+    throw new Error('Invalid agent graph terminal history cursor');
+  }
+}
+
+function requireIdentity(value: unknown, name: string): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > 512 ||
+    value.trim() !== value ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new Error(`Invalid agent graph ${name}`);
+  }
+  return value;
+}
+
+function compareIdentity(a: string, b: string): number {
+  return a < b ? -1 : a > b ? 1 : 0;
+}

--- a/packages/runtime/src/stream-graph-read-model.ts
+++ b/packages/runtime/src/stream-graph-read-model.ts
@@ -1,9 +1,15 @@
 import type {
+  AgentGraphClientClaimAdmission,
   AgentGraphIntentClaim,
   AgentGraphOperatorProvision,
   AgentGraphScheduleUpdate,
+  SessionEvent,
 } from '@maka/core';
-import type { AgentGraphSupervisorObservation } from './stream-graph-dispatch.js';
+import { failureClassFromCompleteStopReason } from '@maka/core';
+import type {
+  AgentGraphSupervisorObservation,
+  AgentGraphSupervisorRuntimeEvent,
+} from './stream-graph-dispatch.js';
 import type {
   AgentGraphActivationStatus,
   AgentGraphRecord,
@@ -29,9 +35,16 @@ const MAX_VISIBLE_STOPPED_TARGETS = 128;
 const MAX_RECENT_CONTROL_DECISIONS = 32;
 const MAX_VISIBLE_CLAIMS = 256;
 const MAX_RECENT_ACTIVITY = 64;
-const MAX_TERMINAL_HISTORY = 64;
+export const AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE = 64;
 const MAX_OPERATOR_INSPECTION_ACTIVATIONS = 64;
 const MAX_OPERATOR_INSPECTION_RECORDS = 128;
+const MAX_OPERATOR_EDGE_REFS = 64;
+const MAX_OPERATOR_WORK_REFS = 64;
+const MAX_OPERATOR_READINESS = 8;
+const MAX_OPERATOR_READINESS_WAITS = 64;
+const MAX_OPERATOR_INSPECTION_EDGES = 512;
+const MAX_OPERATOR_INSPECTION_WORK = 256;
+const MAX_OPERATOR_INSPECTION_CLAIMS = 256;
 const MAX_INSTRUCTION_PREVIEW_CHARS = 500;
 
 export type AgentGraphClientOperatorStatus =
@@ -45,6 +58,7 @@ export type AgentGraphClientOperatorStatus =
 export type AgentGraphClientStatus =
   | 'empty'
   | 'active'
+  | 'closing'
   | 'waiting'
   | 'stopped'
   | 'failed'
@@ -71,7 +85,15 @@ export interface AgentGraphClientOperator {
     policyKind: 'map' | 'all_settled';
     status: 'waiting' | 'runnable';
     waitingFor: AgentGraphReadinessWait[];
+    omittedWaitingFor: number;
   }>;
+  omitted: {
+    inboundEdgeIds: number;
+    outboundEdgeIds: number;
+    scheduledWorkIds: number;
+    readiness: number;
+    readinessWaits: number;
+  };
   currentActivation?: {
     activationId: string;
     status: AgentGraphActivationStatus;
@@ -138,6 +160,7 @@ export interface AgentGraphClientClaimRef {
   operatorId: string;
   childSessionId: string;
   run: AgentGraphClientRunRef;
+  admissionState: AgentGraphClientClaimAdmission['state'];
   claimedAt: number;
 }
 
@@ -207,8 +230,14 @@ export interface AgentGraphOperatorInspection {
     run: AgentGraphClientRunRef;
   }>;
   recentRecords: AgentGraphClientActivity[];
-  omittedActivationCount: number;
-  omittedRecordCount: number;
+  omitted: {
+    inboundEdges: number;
+    outboundEdges: number;
+    work: number;
+    claims: number;
+    activations: number;
+    records: number;
+  };
 }
 
 export interface BuildAgentGraphClientReadModelInput {
@@ -216,7 +245,21 @@ export interface BuildAgentGraphClientReadModelInput {
   graphId: string;
   provisions: readonly AgentGraphOperatorProvision[];
   scheduleUpdates: readonly AgentGraphScheduleUpdate[];
+  schedule?: AgentGraphScheduleProjection;
+  claimAdmissions?: readonly AgentGraphClientClaimAdmission[];
   observation: AgentGraphSupervisorObservation;
+}
+
+export interface AgentGraphClientMaterialization {
+  snapshot: AgentGraphClientSnapshot;
+  operators: AgentGraphOperatorInspection[];
+  terminalActivities: AgentGraphClientActivity[];
+}
+
+export interface AdvancedAgentGraphClientProjection {
+  snapshot: AgentGraphClientSnapshot;
+  operator: AgentGraphOperatorInspection;
+  terminalActivity?: AgentGraphClientActivity;
 }
 
 export interface AgentGraphClientSnapshotOptions {
@@ -234,6 +277,7 @@ interface BuiltReadModel {
   claims: AgentGraphClientClaimRef[];
   recentControlDecisions: AgentGraphClientControlDecision[];
   activity: AgentGraphClientActivity[];
+  scheduledWorkIdsByOperator: Map<string, string[]>;
 }
 
 /**
@@ -247,6 +291,165 @@ export function buildAgentGraphClientSnapshot(
   options: AgentGraphClientSnapshotOptions = {},
 ): AgentGraphClientSnapshot {
   const model = buildReadModel(input);
+  return snapshotFromModel(input, model, options);
+}
+
+export function materializeAgentGraphClientProjection(
+  input: BuildAgentGraphClientReadModelInput,
+): AgentGraphClientMaterialization {
+  const model = buildReadModel(input);
+  return {
+    snapshot: snapshotFromModel(input, model, {}),
+    operators: model.operators.map((operator) =>
+      inspectionFromModel(input, model, operator.operatorId),
+    ),
+    terminalActivities: terminalActivities(model.activity),
+  };
+}
+
+/**
+ * Advance the bounded materialized client view from one already-durable
+ * SessionEvent without replaying the RuntimeEvent ledger.
+ */
+export function advanceMaterializedAgentGraphClientProjection(
+  snapshotInput: AgentGraphClientSnapshot,
+  inspectionInput: AgentGraphOperatorInspection,
+  runtime: AgentGraphSupervisorRuntimeEvent,
+  activationHadError: boolean,
+): AdvancedAgentGraphClientProjection | undefined {
+  const projected = projectClientSessionEvent(runtime.event, activationHadError);
+  if (!projected) return undefined;
+  if (
+    snapshotInput.graphId !== runtime.intent.graphId ||
+    inspectionInput.graphId !== runtime.intent.graphId ||
+    inspectionInput.operator.operatorId !== runtime.claim.targetOperatorId ||
+    inspectionInput.operator.childSessionId !== runtime.claim.targetSessionId
+  ) {
+    throw new Error('Agent graph runtime activity does not match its materialized projection');
+  }
+  const activity: AgentGraphClientActivity = {
+    recordId: clientRuntimeRecordId(runtime),
+    operatorId: runtime.claim.targetOperatorId,
+    activationId: runtime.claim.targetRunId,
+    eventTime: runtime.event.ts,
+    facets: projected.facets,
+    signals: projected.signals,
+    run: {
+      sessionId: runtime.claim.targetSessionId,
+      agentRunId: runtime.claim.targetRunId,
+      turnId: runtime.claim.targetTurnId,
+    },
+  };
+  const snapshot = structuredClone(snapshotInput);
+  const inspection = structuredClone(inspectionInput);
+  const previousActivation = inspection.activations.find(
+    (activation) => activation.activationId === runtime.claim.targetRunId,
+  );
+  const activationStatus: AgentGraphActivationStatus =
+    projected.terminalStatus ?? 'running';
+  const nextActivation = previousActivation
+    ? {
+        ...previousActivation,
+        status: activationStatus,
+        recordCount: previousActivation.recordCount + 1,
+        lastEventTime: runtime.event.ts,
+        lastRecordId: activity.recordId,
+        ...(projected.terminalStatus
+          ? { terminalRecordId: activity.recordId }
+          : {}),
+      }
+    : {
+        activationId: runtime.claim.targetRunId,
+        status: activationStatus,
+        recordCount: 1,
+        firstEventTime: runtime.event.ts,
+        lastEventTime: runtime.event.ts,
+        lastRecordId: activity.recordId,
+        ...(projected.terminalStatus
+          ? { terminalRecordId: activity.recordId }
+          : {}),
+        run: { ...activity.run },
+      };
+  const activationCount =
+    inspection.omitted.activations +
+    inspection.activations.length +
+    (previousActivation ? 0 : 1);
+  inspection.activations = [
+    ...inspection.activations.filter(
+      (activation) => activation.activationId !== nextActivation.activationId,
+    ),
+    nextActivation,
+  ].slice(-MAX_OPERATOR_INSPECTION_ACTIVATIONS);
+  inspection.omitted.activations = Math.max(
+    0,
+    activationCount - inspection.activations.length,
+  );
+  const operatorStatus: AgentGraphClientOperatorStatus = projected.terminalStatus
+    ? projected.terminalStatus
+    : projected.signals.some((signal) => signal.kind === 'attention')
+      ? 'blocked'
+      : 'running';
+  inspection.operator.status = operatorStatus;
+  inspection.operator.currentActivation = {
+    activationId: nextActivation.activationId,
+    status: nextActivation.status,
+    recordCount: nextActivation.recordCount,
+    firstEventTime: nextActivation.firstEventTime,
+    lastEventTime: nextActivation.lastEventTime,
+    ...(nextActivation.terminalRecordId
+      ? { terminalRecordId: nextActivation.terminalRecordId }
+      : {}),
+    run: { ...activity.run },
+  };
+  const inspectionRecordCount =
+    inspection.omitted.records + inspection.recentRecords.length + 1;
+  inspection.recentRecords = [...inspection.recentRecords, activity].slice(
+    -MAX_OPERATOR_INSPECTION_RECORDS,
+  );
+  inspection.omitted.records = Math.max(
+    0,
+    inspectionRecordCount - inspection.recentRecords.length,
+  );
+
+  const visibleOperatorIndex = snapshot.operators.findIndex(
+    (operator) => operator.operatorId === inspection.operator.operatorId,
+  );
+  if (visibleOperatorIndex >= 0) {
+    snapshot.operators[visibleOperatorIndex] = structuredClone(inspection.operator);
+  }
+  const activityCount =
+    snapshot.omitted.recentActivity + snapshot.recentActivity.length + 1;
+  snapshot.recentActivity = [...snapshot.recentActivity, activity].slice(
+    -MAX_RECENT_ACTIVITY,
+  );
+  snapshot.omitted.recentActivity = Math.max(
+    0,
+    activityCount - snapshot.recentActivity.length,
+  );
+  snapshot.latestEventTime = Math.max(
+    snapshot.latestEventTime ?? 0,
+    runtime.event.ts,
+  );
+  snapshot.snapshotVersion = stableHash({
+    schemaVersion: AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION,
+    previousSnapshotVersion: snapshotInput.snapshotVersion,
+    runtimeEventId: runtime.event.id,
+    operatorStatus,
+  });
+  inspection.snapshotVersion = snapshot.snapshotVersion;
+  snapshot.status = patchedGraphStatus(snapshot, inspection.operator);
+  return {
+    snapshot,
+    operator: inspection,
+    ...(projected.terminalStatus ? { terminalActivity: activity } : {}),
+  };
+}
+
+function snapshotFromModel(
+  input: BuildAgentGraphClientReadModelInput,
+  model: BuiltReadModel,
+  options: AgentGraphClientSnapshotOptions,
+): AgentGraphClientSnapshot {
   const visibleOperators = boundOperators(model.operators);
   const visibleOperatorIds = new Set(visibleOperators.map((operator) => operator.operatorId));
   const candidateEdges = model.edges.filter(
@@ -267,7 +470,7 @@ export function buildAgentGraphClientSnapshot(
     rootSessionId: input.rootSessionId,
     graphId: input.graphId,
     snapshotVersion: model.snapshotVersion,
-    status: graphStatus(model.schedule, model.operators),
+    status: graphStatus(model.schedule, model.operators, model.claims, model.activity),
     scheduleRevision: model.schedule.revision,
     topologyFingerprint: input.observation.readiness.topologyFingerprint,
     closed: model.schedule.closed,
@@ -302,6 +505,14 @@ export function inspectAgentGraphOperator(
 ): AgentGraphOperatorInspection {
   const expectedOperatorId = requireIdentity(operatorId, 'operator id');
   const model = buildReadModel(input);
+  return inspectionFromModel(input, model, expectedOperatorId);
+}
+
+function inspectionFromModel(
+  input: BuildAgentGraphClientReadModelInput,
+  model: BuiltReadModel,
+  expectedOperatorId: string,
+): AgentGraphOperatorInspection {
   const operator = model.operators.find(
     (candidate) => candidate.operatorId === expectedOperatorId,
   );
@@ -321,6 +532,23 @@ export function inspectAgentGraphOperator(
     (record) => record.operatorId === expectedOperatorId,
   );
   const recentRecords = allRecords.slice(-MAX_OPERATOR_INSPECTION_RECORDS);
+  const inboundEdges = model.edges.filter(
+    (edge) => edge.toOperatorId === expectedOperatorId,
+  );
+  const visibleInboundEdges = inboundEdges.slice(-MAX_OPERATOR_INSPECTION_EDGES);
+  const outboundEdges = model.edges.filter(
+    (edge) => edge.fromOperatorId === expectedOperatorId,
+  );
+  const visibleOutboundEdges = outboundEdges.slice(-MAX_OPERATOR_INSPECTION_EDGES);
+  const operatorWorkIds = new Set(
+    model.scheduledWorkIdsByOperator.get(expectedOperatorId) ?? [],
+  );
+  const work = model.work.filter((entry) => operatorWorkIds.has(entry.workId));
+  const visibleWork = work.slice(-MAX_OPERATOR_INSPECTION_WORK);
+  const claims = model.claims.filter(
+    (claim) => claim.operatorId === expectedOperatorId,
+  );
+  const visibleClaims = claims.slice(-MAX_OPERATOR_INSPECTION_CLAIMS);
   const claimByRunId = new Map(
     model.claims
       .filter((claim) => claim.operatorId === expectedOperatorId)
@@ -332,18 +560,10 @@ export function inspectAgentGraphOperator(
     graphId: input.graphId,
     snapshotVersion: model.snapshotVersion,
     operator,
-    inboundEdges: model.edges.filter(
-      (edge) => edge.toOperatorId === expectedOperatorId,
-    ),
-    outboundEdges: model.edges.filter(
-      (edge) => edge.fromOperatorId === expectedOperatorId,
-    ),
-    work: model.work.filter((work) =>
-      operator.scheduledWorkIds.includes(work.workId),
-    ),
-    claims: model.claims.filter(
-      (claim) => claim.operatorId === expectedOperatorId,
-    ),
+    inboundEdges: visibleInboundEdges,
+    outboundEdges: visibleOutboundEdges,
+    work: visibleWork,
+    claims: visibleClaims,
     activations: visibleActivations.map((activation) => ({
       activationId: activation.activationId,
       status: activation.status,
@@ -362,8 +582,14 @@ export function inspectAgentGraphOperator(
       ),
     })),
     recentRecords,
-    omittedActivationCount: allActivations.length - visibleActivations.length,
-    omittedRecordCount: allRecords.length - recentRecords.length,
+    omitted: {
+      inboundEdges: inboundEdges.length - visibleInboundEdges.length,
+      outboundEdges: outboundEdges.length - visibleOutboundEdges.length,
+      work: work.length - visibleWork.length,
+      claims: claims.length - visibleClaims.length,
+      activations: allActivations.length - visibleActivations.length,
+      records: allRecords.length - recentRecords.length,
+    },
   };
 }
 
@@ -371,10 +597,15 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
   requireIdentity(input.rootSessionId, 'root Session id');
   requireIdentity(input.graphId, 'graph id');
   assertObservation(input.graphId, input.observation);
-  const schedule = projectAgentGraphSchedule(input.graphId, input.scheduleUpdates);
+  const schedule =
+    input.schedule ?? projectAgentGraphSchedule(input.graphId, input.scheduleUpdates);
   const provisionByOperator = provisionsByOperator(input.graphId, input.provisions);
   const edges = uniqueEdges(input.graphId, input.provisions);
-  const claims = clientClaims(input.graphId, input.observation.claims);
+  const claims = clientClaims(
+    input.graphId,
+    input.observation.claims,
+    input.claimAdmissions ?? [],
+  );
   const activity = input.observation.projection.records.map(clientActivity);
   const work = schedule.work.map(clientWork);
   const operators = input.observation.projection.operators.map((binding) => {
@@ -384,14 +615,21 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
         `Agent graph operator ${binding.operatorId} has no matching durable provision`,
       );
     }
-    const readiness = input.observation.readiness.supervisorView
+    const allReadiness = input.observation.readiness.supervisorView
       .filter((entry) => entry.operatorId === binding.operatorId)
       .map((entry) => ({
         readinessId: entry.readinessId,
         policyKind: entry.policyKind,
         status: entry.status,
-        waitingFor: entry.waitingFor.map(cloneWait),
+        waitingFor: entry.waitingFor
+          .slice(0, MAX_OPERATOR_READINESS_WAITS)
+          .map(cloneWait),
+        omittedWaitingFor: Math.max(
+          0,
+          entry.waitingFor.length - MAX_OPERATOR_READINESS_WAITS,
+        ),
       }));
+    const readiness = allReadiness.slice(0, MAX_OPERATOR_READINESS);
     const state = input.observation.projection.state.operators[binding.operatorId];
     const currentActivation = state?.activations[state.currentActivationId];
     const currentClaim = currentActivation
@@ -409,6 +647,23 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
           .reverse()
           .find((record) => record.activationId === currentActivation.activationId)
       : undefined;
+    const allInboundEdgeIds = edges
+      .filter((edge) => edge.toOperatorId === binding.operatorId)
+      .map((edge) => edge.edgeId);
+    const inboundEdgeIds = allInboundEdgeIds.slice(-MAX_OPERATOR_EDGE_REFS);
+    const allOutboundEdgeIds = edges
+      .filter((edge) => edge.fromOperatorId === binding.operatorId)
+      .map((edge) => edge.edgeId);
+    const outboundEdgeIds = allOutboundEdgeIds.slice(-MAX_OPERATOR_EDGE_REFS);
+    const allScheduledWorkIds = work
+      .filter(
+        (entry) =>
+          entry.workId === provision.workId ||
+          (entry.target.kind === 'operator' &&
+            entry.target.operatorId === binding.operatorId),
+      )
+      .map((entry) => entry.workId);
+    const scheduledWorkIds = allScheduledWorkIds.slice(-MAX_OPERATOR_WORK_REFS);
     return {
       operatorId: binding.operatorId,
       childSessionId: binding.sessionId,
@@ -416,21 +671,20 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
       agentId: provision.agentId,
       provisionedAt: provision.provisionedAt,
       status: operatorStatus(state?.status, readiness, currentRecord),
-      inboundEdgeIds: edges
-        .filter((edge) => edge.toOperatorId === binding.operatorId)
-        .map((edge) => edge.edgeId),
-      outboundEdgeIds: edges
-        .filter((edge) => edge.fromOperatorId === binding.operatorId)
-        .map((edge) => edge.edgeId),
-      scheduledWorkIds: work
-        .filter(
-          (entry) =>
-            entry.workId === provision.workId ||
-            (entry.target.kind === 'operator' &&
-              entry.target.operatorId === binding.operatorId),
-        )
-        .map((entry) => entry.workId),
+      inboundEdgeIds,
+      outboundEdgeIds,
+      scheduledWorkIds,
       readiness,
+      omitted: {
+        inboundEdgeIds: allInboundEdgeIds.length - inboundEdgeIds.length,
+        outboundEdgeIds: allOutboundEdgeIds.length - outboundEdgeIds.length,
+        scheduledWorkIds: allScheduledWorkIds.length - scheduledWorkIds.length,
+        readiness: allReadiness.length - readiness.length,
+        readinessWaits: allReadiness.reduce(
+          (total, entry) => total + entry.omittedWaitingFor,
+          0,
+        ),
+      },
       ...(currentActivation
         ? {
             currentActivation: {
@@ -488,6 +742,10 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
       .at(-1)?.provisionId,
     claimCount: claims.length,
     latestClaimId: claims.at(-1)?.claimId,
+    claimAdmissions: claims.map((claim) => ({
+      claimId: claim.claimId,
+      state: claim.admissionState,
+    })),
     recordCount: activity.length,
     latestRecordId: activity.at(-1)?.recordId,
   });
@@ -502,6 +760,19 @@ function buildReadModel(input: BuildAgentGraphClientReadModelInput): BuiltReadMo
     claims,
     recentControlDecisions,
     activity,
+    scheduledWorkIdsByOperator: new Map(
+      operators.map((operator) => [
+        operator.operatorId,
+        work
+          .filter(
+            (entry) =>
+              entry.workId === provisionByOperator.get(operator.operatorId)?.workId ||
+              (entry.target.kind === 'operator' &&
+                entry.target.operatorId === operator.operatorId),
+          )
+          .map((entry) => entry.workId),
+      ]),
+    ),
   };
 }
 
@@ -524,8 +795,31 @@ function operatorStatus(
 function graphStatus(
   schedule: AgentGraphScheduleProjection,
   operators: readonly AgentGraphClientOperator[],
+  claims: readonly AgentGraphClientClaimRef[],
+  activity: readonly AgentGraphClientActivity[],
 ): AgentGraphClientStatus {
-  if (schedule.closed) return 'completed';
+  if (schedule.closed) {
+    const terminalRunIds = new Set(
+      activity
+        .filter((record) =>
+          record.signals.some((signal) => signal.kind === 'terminal'),
+        )
+        .map((record) => record.run.agentRunId),
+    );
+    const observedRunIds = new Set(
+      activity.map((record) => record.run.agentRunId),
+    );
+    const unsettledClaim = claims.some(
+      (claim) =>
+        !terminalRunIds.has(claim.run.agentRunId) &&
+        (claim.admissionState !== 'cancelled' ||
+          observedRunIds.has(claim.run.agentRunId)),
+    );
+    const runningOperator = operators.some((operator) =>
+      ['running', 'blocked'].includes(operator.status),
+    );
+    return unsettledClaim || runningOperator ? 'closing' : 'completed';
+  }
   if (operators.length === 0 && schedule.work.length === 0) return 'empty';
   if (
     operators.some((operator) =>
@@ -545,6 +839,138 @@ function graphStatus(
     return 'failed';
   }
   return 'waiting';
+}
+
+function patchedGraphStatus(
+  snapshot: AgentGraphClientSnapshot,
+  patchedOperator: AgentGraphClientOperator,
+): AgentGraphClientStatus {
+  const operators = snapshot.operators.map((operator) =>
+    operator.operatorId === patchedOperator.operatorId
+      ? patchedOperator
+      : operator,
+  );
+  if (snapshot.closed) {
+    if (
+      snapshot.omitted.operators > 0 ||
+      snapshot.omitted.claims > 0 ||
+      operators.some((operator) =>
+        ['running', 'blocked'].includes(operator.status),
+      )
+    ) {
+      return 'closing';
+    }
+    const operatorByRunId = new Map(
+      operators
+        .filter((operator) => operator.currentActivation)
+        .map((operator) => [
+          operator.currentActivation!.run.agentRunId,
+          operator,
+        ]),
+    );
+    return snapshot.claims.every((claim) => {
+      if (claim.admissionState === 'cancelled') {
+        return !operatorByRunId.has(claim.run.agentRunId);
+      }
+      const operator = operatorByRunId.get(claim.run.agentRunId);
+      return (
+        operator !== undefined &&
+        ['completed', 'failed', 'aborted', 'cancelled'].includes(
+          operator.status,
+        )
+      );
+    })
+      ? 'completed'
+      : 'closing';
+  }
+  return operators.some((operator) =>
+    ['running', 'blocked', 'runnable'].includes(operator.status),
+  )
+    ? 'active'
+    : snapshot.status;
+}
+
+function projectClientSessionEvent(
+  event: SessionEvent,
+  activationHadError: boolean,
+):
+  | {
+      facets: AgentGraphRecordFacet[];
+      signals: AgentGraphSupervisorSignal[];
+      terminalStatus?: Extract<
+        AgentGraphActivationStatus,
+        'completed' | 'failed' | 'aborted' | 'cancelled'
+      >;
+    }
+  | undefined {
+  switch (event.type) {
+    case 'text_delta':
+    case 'thinking_delta':
+    case 'tool_output_delta':
+    case 'tool_progress':
+    case 'queue_update':
+    case 'provider_retry':
+      return undefined;
+    case 'text_complete':
+    case 'steering_message':
+      return { facets: ['message'], signals: [] };
+    case 'thinking_complete':
+      return { facets: ['thinking'], signals: [] };
+    case 'tool_start':
+      return { facets: ['tool_call'], signals: [] };
+    case 'tool_result':
+      return { facets: ['tool_result'], signals: [] };
+    case 'permission_request':
+      return {
+        facets: ['permission_request'],
+        signals: [{ kind: 'attention', reason: 'permission_request' }],
+      };
+    case 'permission_decision_ack':
+      return { facets: ['permission_decision'], signals: [] };
+    case 'user_question_request':
+      return {
+        facets: ['user_question_request'],
+        signals: [{ kind: 'attention', reason: 'user_question_request' }],
+      };
+    case 'token_usage':
+      return { facets: ['usage'], signals: [] };
+    case 'error':
+      return { facets: ['error'], signals: [] };
+    case 'abort':
+      return {
+        facets: ['aborted'],
+        signals: [{ kind: 'terminal', status: 'aborted' }],
+        terminalStatus: 'aborted',
+      };
+    case 'complete': {
+      const terminalStatus =
+        event.stopReason === 'user_stop'
+          ? 'aborted'
+          : activationHadError ||
+              failureClassFromCompleteStopReason(event.stopReason)
+            ? 'failed'
+            : 'completed';
+      return {
+        facets: [terminalStatus],
+        signals: [{ kind: 'terminal', status: terminalStatus }],
+        terminalStatus,
+      };
+    }
+    case 'plan_submitted':
+      return { facets: ['runtime_fact'], signals: [] };
+  }
+}
+
+function clientRuntimeRecordId(
+  runtime: AgentGraphSupervisorRuntimeEvent,
+): string {
+  return `graph_record_${stableHash({
+    graphId: runtime.intent.graphId,
+    operatorId: runtime.claim.targetOperatorId,
+    sessionId: runtime.claim.targetSessionId,
+    runId: runtime.claim.targetRunId,
+    runtimeEventId: runtime.event.id,
+  }).slice('sha256:'.length, 'sha256:'.length + 32)}`;
 }
 
 function boundOperators(
@@ -584,30 +1010,65 @@ function terminalHistoryPage(
   activity: readonly AgentGraphClientActivity[],
   cursor: string | undefined,
 ): AgentGraphClientTerminalHistoryPage {
-  const terminal = activity
-    .filter((record) => record.signals.some((signal) => signal.kind === 'terminal'))
-    .reverse();
+  const terminal = terminalActivities(activity);
   let start = 0;
   if (cursor !== undefined) {
-    const decoded = decodeTerminalCursor(cursor);
+    const decoded = decodeAgentGraphTerminalCursor(cursor);
     if (decoded.graphId !== graphId) {
       throw new Error('Agent graph terminal history cursor belongs to another graph');
     }
-    const index = terminal.findIndex((record) => record.recordId === decoded.recordId);
+    const index = terminal.findIndex(
+      (record) =>
+        record.recordId === decoded.recordId &&
+        record.eventTime === decoded.eventTime,
+    );
     if (index < 0) {
       throw new Error('Agent graph terminal history cursor is stale or invalid');
     }
     start = index + 1;
   }
-  const records = terminal.slice(start, start + MAX_TERMINAL_HISTORY);
+  const records = terminal.slice(
+    start,
+    start + AGENT_GRAPH_CLIENT_TERMINAL_PAGE_SIZE,
+  );
   const hasMore = start + records.length < terminal.length;
   return {
     records,
     ...(hasMore && records.length > 0
       ? {
-          nextCursor: encodeTerminalCursor(
+          nextCursor: encodeAgentGraphTerminalCursor(
             graphId,
-            records[records.length - 1]!.recordId,
+            records[records.length - 1]!,
+          ),
+        }
+      : {}),
+  };
+}
+
+function terminalActivities(
+  activity: readonly AgentGraphClientActivity[],
+): AgentGraphClientActivity[] {
+  return activity
+    .filter((record) => record.signals.some((signal) => signal.kind === 'terminal'))
+    .sort(
+      (a, b) =>
+        b.eventTime - a.eventTime ||
+        compareIdentity(b.recordId, a.recordId),
+    );
+}
+
+export function materializedAgentGraphTerminalHistoryPage(
+  graphId: string,
+  records: readonly AgentGraphClientActivity[],
+  hasMore: boolean,
+): AgentGraphClientTerminalHistoryPage {
+  return {
+    records: records.map((record) => structuredClone(record)),
+    ...(hasMore && records.length > 0
+      ? {
+          nextCursor: encodeAgentGraphTerminalCursor(
+            graphId,
+            records[records.length - 1]!,
           ),
         }
       : {}),
@@ -654,7 +1115,15 @@ function clientFinish(finish: AgentGraphScheduleFinishView): AgentGraphClientFin
 function clientClaims(
   graphId: string,
   claims: readonly AgentGraphIntentClaim[],
+  admissions: readonly AgentGraphClientClaimAdmission[],
 ): AgentGraphClientClaimRef[] {
+  const admissionByIntent = new Map<string, AgentGraphClientClaimAdmission['state']>();
+  for (const admission of admissions) {
+    if (admissionByIntent.has(admission.intentId)) {
+      throw new Error(`Duplicate agent graph admission for ${admission.intentId}`);
+    }
+    admissionByIntent.set(admission.intentId, admission.state);
+  }
   return [...claims]
     .sort(
       (a, b) =>
@@ -674,6 +1143,7 @@ function clientClaims(
           agentRunId: claim.targetRunId,
           turnId: claim.targetTurnId,
         },
+        admissionState: admissionByIntent.get(claim.intentId) ?? 'executing',
         claimedAt: claim.claimedAt,
       };
     });
@@ -782,20 +1252,25 @@ function cloneWait(wait: AgentGraphReadinessWait): AgentGraphReadinessWait {
     : { ...wait };
 }
 
-function encodeTerminalCursor(graphId: string, recordId: string): string {
+export function encodeAgentGraphTerminalCursor(
+  graphId: string,
+  activity: Pick<AgentGraphClientActivity, 'recordId' | 'eventTime'>,
+): string {
   return Buffer.from(
     JSON.stringify({
       schemaVersion: AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION,
       graphId,
-      recordId,
+      recordId: activity.recordId,
+      eventTime: activity.eventTime,
     }),
     'utf8',
   ).toString('base64url');
 }
 
-function decodeTerminalCursor(cursor: string): {
+export function decodeAgentGraphTerminalCursor(cursor: string): {
   graphId: string;
   recordId: string;
+  eventTime: number;
 } {
   if (
     typeof cursor !== 'string' ||
@@ -811,18 +1286,116 @@ function decodeTerminalCursor(cursor: string): {
     const value = JSON.parse(json) as Record<string, unknown>;
     if (
       canonical !== cursor ||
-      Object.keys(value).sort().join(',') !== 'graphId,recordId,schemaVersion' ||
-      value.schemaVersion !== AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION
+      Object.keys(value).sort().join(',') !==
+        'eventTime,graphId,recordId,schemaVersion' ||
+      value.schemaVersion !== AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION ||
+      typeof value.eventTime !== 'number' ||
+      !Number.isSafeInteger(value.eventTime) ||
+      value.eventTime < 0
     ) {
       throw new Error('invalid cursor envelope');
     }
     return {
       graphId: requireIdentity(value.graphId, 'cursor graph id'),
       recordId: requireIdentity(value.recordId, 'cursor record id'),
+      eventTime: value.eventTime,
     };
   } catch {
     throw new Error('Invalid agent graph terminal history cursor');
   }
+}
+
+export function decodeMaterializedAgentGraphClientSnapshot(
+  value: unknown,
+  expected: {
+    rootSessionId: string;
+    graphId: string;
+    snapshotVersion: string;
+  },
+): AgentGraphClientSnapshot {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid materialized agent graph client snapshot');
+  }
+  const snapshot = value as Partial<AgentGraphClientSnapshot>;
+  if (
+    snapshot.schemaVersion !== AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION ||
+    snapshot.rootSessionId !== expected.rootSessionId ||
+    snapshot.graphId !== expected.graphId ||
+    snapshot.snapshotVersion !== expected.snapshotVersion ||
+    !Array.isArray(snapshot.operators) ||
+    !Array.isArray(snapshot.edges) ||
+    !Array.isArray(snapshot.work) ||
+    !Array.isArray(snapshot.stoppedTargets) ||
+    !Array.isArray(snapshot.claims) ||
+    !Array.isArray(snapshot.recentControlDecisions) ||
+    !Array.isArray(snapshot.recentActivity) ||
+    !snapshot.terminalHistory ||
+    !Array.isArray(snapshot.terminalHistory.records)
+  ) {
+    throw new Error('Invalid materialized agent graph client snapshot');
+  }
+  return structuredClone(snapshot as AgentGraphClientSnapshot);
+}
+
+export function decodeMaterializedAgentGraphOperatorInspection(
+  value: unknown,
+  expected: {
+    rootSessionId: string;
+    graphId: string;
+    operatorId: string;
+    snapshotVersion: string;
+  },
+): AgentGraphOperatorInspection {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid materialized agent graph operator inspection');
+  }
+  const inspection = value as Partial<AgentGraphOperatorInspection>;
+  if (
+    inspection.schemaVersion !== AGENT_GRAPH_CLIENT_SNAPSHOT_SCHEMA_VERSION ||
+    inspection.rootSessionId !== expected.rootSessionId ||
+    inspection.graphId !== expected.graphId ||
+    inspection.snapshotVersion !== expected.snapshotVersion ||
+    inspection.operator?.operatorId !== expected.operatorId ||
+    !Array.isArray(inspection.inboundEdges) ||
+    !Array.isArray(inspection.outboundEdges) ||
+    !Array.isArray(inspection.work) ||
+    !Array.isArray(inspection.claims) ||
+    !Array.isArray(inspection.activations) ||
+    !Array.isArray(inspection.recentRecords)
+  ) {
+    throw new Error('Invalid materialized agent graph operator inspection');
+  }
+  return structuredClone(inspection as AgentGraphOperatorInspection);
+}
+
+export function decodeMaterializedAgentGraphClientActivity(
+  value: unknown,
+  expected: {
+    graphId: string;
+    recordId: string;
+    eventTime: number;
+  },
+): AgentGraphClientActivity {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error('Invalid materialized agent graph client activity');
+  }
+  const activity = value as Partial<AgentGraphClientActivity>;
+  if (
+    activity.recordId !== expected.recordId ||
+    activity.eventTime !== expected.eventTime ||
+    !activity.operatorId ||
+    !activity.activationId ||
+    !Array.isArray(activity.facets) ||
+    !Array.isArray(activity.signals) ||
+    !activity.run ||
+    typeof activity.run.sessionId !== 'string' ||
+    typeof activity.run.agentRunId !== 'string'
+  ) {
+    throw new Error(
+      `Invalid materialized agent graph client activity for ${expected.graphId}`,
+    );
+  }
+  return structuredClone(activity as AgentGraphClientActivity);
 }
 
 function requireIdentity(value: unknown, name: string): string {

--- a/packages/storage/src/__tests__/agent-graph-intent-claims.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-intent-claims.test.ts
@@ -135,6 +135,7 @@ describe('SQLite agent graph intent claims', () => {
 
       const legacy = new DatabaseSync(path);
       legacy.exec(`
+        DROP TABLE agent_graph_client_applied_records;
         DROP TABLE agent_graph_client_terminal_activity;
         DROP TABLE agent_graph_client_operator_projections;
         DROP TABLE agent_graph_client_projections;

--- a/packages/storage/src/__tests__/agent-graph-intent-claims.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-intent-claims.test.ts
@@ -135,6 +135,9 @@ describe('SQLite agent graph intent claims', () => {
 
       const legacy = new DatabaseSync(path);
       legacy.exec(`
+        DROP TABLE agent_graph_client_terminal_activity;
+        DROP TABLE agent_graph_client_operator_projections;
+        DROP TABLE agent_graph_client_projections;
         DROP TABLE agent_graph_operator_provisions;
         DROP INDEX agent_graph_intent_claims_by_graph;
         ALTER TABLE agent_graph_intent_claims RENAME TO agent_graph_intent_claims_v8;
@@ -179,7 +182,7 @@ describe('SQLite agent graph intent claims', () => {
 
       const migrated = createSqliteSessionMetadataStore(path);
       try {
-        assert.equal(migrated.schemaVersion(), 9);
+        assert.equal(migrated.schemaVersion(), 10);
         assert.deepEqual(
           await migrated.beginAgentGraphIntentExecutionAtScheduleRevision(
             'graph-1',

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -817,6 +817,64 @@ describe('SQLite agent graph operator provisions', () => {
 });
 
 describe('SQLite agent graph client projections', () => {
+  test('atomically reads a graph with an independently versioned operator row', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', {
+      now: nextNow(400),
+    });
+    try {
+      await store.commitAgentGraphClientProjection({
+        schemaVersion: 1,
+        graphId: 'graph-atomic-read',
+        rootSessionId: 'root-session',
+        expectedSnapshotVersion: null,
+        snapshotVersion: 'snapshot-1',
+        snapshot: { version: 1 },
+        replaceOperators: true,
+        operators: [
+          { operatorId: 'operator-1', payload: { status: 'running' } },
+          { operatorId: 'operator-2', payload: { status: 'waiting' } },
+        ],
+        terminalActivities: [],
+        activityRecords: [],
+      });
+      await store.commitAgentGraphClientProjection({
+        schemaVersion: 1,
+        graphId: 'graph-atomic-read',
+        rootSessionId: 'root-session',
+        expectedSnapshotVersion: 'snapshot-1',
+        snapshotVersion: 'snapshot-2',
+        snapshot: { version: 2 },
+        replaceOperators: false,
+        operators: [
+          { operatorId: 'operator-1', payload: { status: 'completed' } },
+        ],
+        terminalActivities: [],
+        activityRecords: [{ recordId: 'record-1', eventTime: 10 }],
+        incrementalRecordId: 'record-1',
+      });
+
+      const materialized =
+        await store.readAgentGraphClientProjectionWithOperator(
+          'graph-atomic-read',
+          'operator-2',
+        );
+      assert.equal(materialized?.projection.snapshotVersion, 'snapshot-2');
+      assert.equal(materialized?.operator?.snapshotVersion, 'snapshot-1');
+      assert.deepEqual(materialized?.operator?.payload, { status: 'waiting' });
+      assert.deepEqual(
+        await store.readAgentGraphClientProjectionWithOperator(
+          'graph-atomic-read',
+          'missing-operator',
+        ),
+        {
+          projection: materialized?.projection,
+        },
+      );
+    } finally {
+      store.close();
+    }
+  });
+
   test('CAS-fences stale writers and deduplicates incremental durable records', async () => {
     const store = createSqliteSessionMetadataStore(':memory:', {
       now: nextNow(500),

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -20,7 +20,7 @@ describe('SqliteSessionMetadataStore', () => {
     try {
       const store = createSqliteSessionMetadataStore(path, { now: () => 100 });
       const header = fullHeader();
-      assert.equal(store.schemaVersion(), 9);
+      assert.equal(store.schemaVersion(), 10);
       assert.equal(store.journalMode(), 'wal');
       assert.deepEqual(await store.create(header), {
         header,
@@ -31,7 +31,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const reopened = createSqliteSessionMetadataStore(path, { now: () => 200 });
       try {
-        assert.equal(reopened.schemaVersion(), 9);
+        assert.equal(reopened.schemaVersion(), 10);
         assert.deepEqual(await reopened.read(header.id), {
           header,
           metadataVersion: 1,
@@ -52,7 +52,7 @@ describe('SqliteSessionMetadataStore', () => {
     const metadata = createSqliteSessionMetadataStore(path);
     try {
       assert.equal(runtime.schemaVersion(), 4);
-      assert.equal(metadata.schemaVersion(), 9);
+      assert.equal(metadata.schemaVersion(), 10);
       await metadata.create(fullHeader());
       await runtime.appendRuntimeEvent('session-1', 'run-1', {
         id: 'event-1',
@@ -160,7 +160,7 @@ describe('SqliteSessionMetadataStore', () => {
 
     const store = createSqliteSessionMetadataStore(path);
     try {
-      assert.equal(store.schemaVersion(), 9);
+      assert.equal(store.schemaVersion(), 10);
       assert.deepEqual(
         (
           await store.list({
@@ -493,6 +493,9 @@ describe('SqliteSessionMetadataStore', () => {
 
       const v4 = new DatabaseSync(path);
       v4.exec(`
+        DROP TABLE agent_graph_client_terminal_activity;
+        DROP TABLE agent_graph_client_operator_projections;
+        DROP TABLE agent_graph_client_projections;
         DROP TABLE agent_graph_operator_provisions;
         DROP TABLE agent_graph_schedule_updates;
         DROP TABLE agent_graph_intent_claims;
@@ -516,7 +519,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const migrated = createSqliteSessionMetadataStore(path);
       try {
-        assert.equal(migrated.schemaVersion(), 9);
+        assert.equal(migrated.schemaVersion(), 10);
         assert.equal(await migrated.remove(child.id), true);
         await assert.rejects(
           () => migrated.createSubagent({ ...child, id: 'retry-after-migration' }),
@@ -793,6 +796,116 @@ describe('SQLite agent graph operator provisions', () => {
       );
       assert.deepEqual(await store.listAgentGraphOperatorProvisions('graph-1'), []);
       await assert.rejects(store.read('graph-child'), /not found/);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+describe('SQLite agent graph client projections', () => {
+  test('materializes bounded current state and keyset-pages terminal activity', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', {
+      now: nextNow(1_000),
+    });
+    try {
+      const first = await store.commitAgentGraphClientProjection({
+        schemaVersion: 1,
+        graphId: 'graph-1',
+        rootSessionId: 'root-session',
+        snapshotVersion: 'snapshot-1',
+        snapshot: { version: 1 },
+        replaceOperators: true,
+        operators: [
+          { operatorId: 'operator-1', payload: { status: 'running' } },
+          { operatorId: 'operator-2', payload: { status: 'completed' } },
+        ],
+        terminalActivities: [
+          { recordId: 'record-1', eventTime: 1, payload: { recordId: 'record-1' } },
+          { recordId: 'record-2', eventTime: 2, payload: { recordId: 'record-2' } },
+          { recordId: 'record-3', eventTime: 3, payload: { recordId: 'record-3' } },
+        ],
+      });
+      assert.equal(first.snapshotVersion, 'snapshot-1');
+      assert.deepEqual(
+        (await store.readAgentGraphClientProjection('graph-1'))?.payload,
+        { version: 1 },
+      );
+      assert.deepEqual(
+        (await store.readAgentGraphClientOperatorProjection('graph-1', 'operator-1'))
+          ?.payload,
+        { status: 'running' },
+      );
+      const firstPage = await store.listAgentGraphClientTerminalActivities(
+        'graph-1',
+        { limit: 2 },
+      );
+      assert.equal(firstPage.hasMore, true);
+      assert.deepEqual(
+        firstPage.records.map((record) => record.recordId),
+        ['record-3', 'record-2'],
+      );
+      const secondPage = await store.listAgentGraphClientTerminalActivities(
+        'graph-1',
+        {
+          limit: 2,
+          before: { eventTime: 2, recordId: 'record-2' },
+        },
+      );
+      assert.equal(secondPage.hasMore, false);
+      assert.deepEqual(
+        secondPage.records.map((record) => record.recordId),
+        ['record-1'],
+      );
+      await assert.rejects(
+        store.listAgentGraphClientTerminalActivities('graph-1', {
+          limit: 2,
+          before: { eventTime: 99, recordId: 'record-2' },
+        }),
+        /stale or invalid/,
+      );
+
+      await store.commitAgentGraphClientProjection({
+        schemaVersion: 1,
+        graphId: 'graph-1',
+        rootSessionId: 'root-session',
+        snapshotVersion: 'snapshot-2',
+        snapshot: { version: 2 },
+        replaceOperators: true,
+        operators: [
+          { operatorId: 'operator-1', payload: { status: 'completed' } },
+        ],
+        terminalActivities: [
+          { recordId: 'record-3', eventTime: 3, payload: { recordId: 'record-3' } },
+        ],
+      });
+      assert.equal(
+        await store.readAgentGraphClientOperatorProjection('graph-1', 'operator-2'),
+        undefined,
+      );
+      assert.equal(
+        (
+          await store.readAgentGraphClientOperatorProjection(
+            'graph-1',
+            'operator-1',
+          )
+        )?.snapshotVersion,
+        'snapshot-2',
+      );
+      await assert.rejects(
+        store.commitAgentGraphClientProjection({
+          schemaVersion: 1,
+          graphId: 'graph-1',
+          rootSessionId: 'root-session',
+          snapshotVersion: 'snapshot-3',
+          snapshot: { version: 3 },
+          replaceOperators: true,
+          operators: [],
+          terminalActivities: [
+            { recordId: 'record-3', eventTime: 4, payload: { recordId: 'record-3' } },
+          ],
+        }),
+        /changed after materialization/,
+      );
     } finally {
       store.close();
     }

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -40,6 +40,19 @@ describe('SqliteSessionMetadataStore', () => {
       } finally {
         reopened.close();
       }
+      const schema = new DatabaseSync(path);
+      try {
+        assert.deepEqual(
+          schema.prepare('PRAGMA foreign_key_list(agent_graph_client_operator_projections)').all(),
+          [],
+        );
+        assert.deepEqual(
+          schema.prepare('PRAGMA foreign_key_list(agent_graph_client_terminal_activity)').all(),
+          [],
+        );
+      } finally {
+        schema.close();
+      }
     } finally {
       await rm(root, { recursive: true, force: true });
     }
@@ -493,6 +506,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const v4 = new DatabaseSync(path);
       v4.exec(`
+        DROP TABLE agent_graph_client_applied_records;
         DROP TABLE agent_graph_client_terminal_activity;
         DROP TABLE agent_graph_client_operator_projections;
         DROP TABLE agent_graph_client_projections;
@@ -803,6 +817,107 @@ describe('SQLite agent graph operator provisions', () => {
 });
 
 describe('SQLite agent graph client projections', () => {
+  test('CAS-fences stale writers and deduplicates incremental durable records', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:', {
+      now: nextNow(500),
+    });
+    try {
+      await store.commitAgentGraphClientProjection({
+        schemaVersion: 1,
+        graphId: 'graph-cas',
+        rootSessionId: 'root-session',
+        expectedSnapshotVersion: null,
+        snapshotVersion: 'snapshot-1',
+        snapshot: { version: 1 },
+        replaceOperators: true,
+        operators: [{ operatorId: 'operator-1', payload: { status: 'running' } }],
+        terminalActivities: [],
+        activityRecords: [],
+      });
+      await assert.rejects(
+        store.commitAgentGraphClientProjection({
+          schemaVersion: 1,
+          graphId: 'graph-cas',
+          rootSessionId: 'root-session',
+          expectedSnapshotVersion: null,
+          snapshotVersion: 'snapshot-create-race',
+          snapshot: { version: 99 },
+          replaceOperators: true,
+          operators: [],
+          terminalActivities: [],
+          activityRecords: [],
+        }),
+        /version conflict/,
+      );
+      await assert.rejects(
+        store.commitAgentGraphClientProjection({
+          schemaVersion: 1,
+          graphId: 'graph-cas',
+          rootSessionId: 'root-session',
+          expectedSnapshotVersion: 'stale-snapshot',
+          snapshotVersion: 'snapshot-stale-write',
+          snapshot: { version: 99 },
+          replaceOperators: false,
+          operators: [],
+          terminalActivities: [
+            {
+              recordId: 'stale-terminal',
+              eventTime: 9,
+              payload: { recordId: 'stale-terminal' },
+            },
+          ],
+          activityRecords: [{ recordId: 'stale-terminal', eventTime: 9 }],
+        }),
+        /version conflict/,
+      );
+      assert.deepEqual(
+        await store.listAgentGraphClientTerminalActivities('graph-cas', {
+          limit: 8,
+        }),
+        { records: [], hasMore: false },
+      );
+
+      const applied = await store.commitAgentGraphClientProjection({
+        schemaVersion: 1,
+        graphId: 'graph-cas',
+        rootSessionId: 'root-session',
+        expectedSnapshotVersion: 'snapshot-1',
+        snapshotVersion: 'snapshot-2',
+        snapshot: { version: 2 },
+        replaceOperators: false,
+        operators: [{ operatorId: 'operator-1', payload: { status: 'completed' } }],
+        terminalActivities: [],
+        activityRecords: [{ recordId: 'record-1', eventTime: 10 }],
+        incrementalRecordId: 'record-1',
+      });
+      assert.equal(applied.snapshotVersion, 'snapshot-2');
+
+      const duplicate = await store.commitAgentGraphClientProjection({
+        schemaVersion: 1,
+        graphId: 'graph-cas',
+        rootSessionId: 'root-session',
+        expectedSnapshotVersion: 'snapshot-2',
+        snapshotVersion: 'snapshot-3',
+        snapshot: { version: 3 },
+        replaceOperators: false,
+        operators: [{ operatorId: 'operator-1', payload: { status: 'failed' } }],
+        terminalActivities: [],
+        activityRecords: [{ recordId: 'record-1', eventTime: 10 }],
+        incrementalRecordId: 'record-1',
+      });
+      assert.equal(duplicate.snapshotVersion, 'snapshot-2');
+      assert.deepEqual((await store.readAgentGraphClientProjection('graph-cas'))?.payload, {
+        version: 2,
+      });
+      assert.deepEqual(
+        (await store.readAgentGraphClientOperatorProjection('graph-cas', 'operator-1'))?.payload,
+        { status: 'completed' },
+      );
+    } finally {
+      store.close();
+    }
+  });
+
   test('materializes bounded current state and keyset-pages terminal activity', async () => {
     const store = createSqliteSessionMetadataStore(':memory:', {
       now: nextNow(1_000),
@@ -812,6 +927,7 @@ describe('SQLite agent graph client projections', () => {
         schemaVersion: 1,
         graphId: 'graph-1',
         rootSessionId: 'root-session',
+        expectedSnapshotVersion: null,
         snapshotVersion: 'snapshot-1',
         snapshot: { version: 1 },
         replaceOperators: true,
@@ -824,33 +940,30 @@ describe('SQLite agent graph client projections', () => {
           { recordId: 'record-2', eventTime: 2, payload: { recordId: 'record-2' } },
           { recordId: 'record-3', eventTime: 3, payload: { recordId: 'record-3' } },
         ],
+        activityRecords: [
+          { recordId: 'record-1', eventTime: 1 },
+          { recordId: 'record-2', eventTime: 2 },
+          { recordId: 'record-3', eventTime: 3 },
+        ],
       });
       assert.equal(first.snapshotVersion, 'snapshot-1');
+      assert.deepEqual((await store.readAgentGraphClientProjection('graph-1'))?.payload, {
+        version: 1,
+      });
       assert.deepEqual(
-        (await store.readAgentGraphClientProjection('graph-1'))?.payload,
-        { version: 1 },
-      );
-      assert.deepEqual(
-        (await store.readAgentGraphClientOperatorProjection('graph-1', 'operator-1'))
-          ?.payload,
+        (await store.readAgentGraphClientOperatorProjection('graph-1', 'operator-1'))?.payload,
         { status: 'running' },
       );
-      const firstPage = await store.listAgentGraphClientTerminalActivities(
-        'graph-1',
-        { limit: 2 },
-      );
+      const firstPage = await store.listAgentGraphClientTerminalActivities('graph-1', { limit: 2 });
       assert.equal(firstPage.hasMore, true);
       assert.deepEqual(
         firstPage.records.map((record) => record.recordId),
         ['record-3', 'record-2'],
       );
-      const secondPage = await store.listAgentGraphClientTerminalActivities(
-        'graph-1',
-        {
-          limit: 2,
-          before: { eventTime: 2, recordId: 'record-2' },
-        },
-      );
+      const secondPage = await store.listAgentGraphClientTerminalActivities('graph-1', {
+        limit: 2,
+        before: { eventTime: 2, recordId: 'record-2' },
+      });
       assert.equal(secondPage.hasMore, false);
       assert.deepEqual(
         secondPage.records.map((record) => record.recordId),
@@ -868,27 +981,23 @@ describe('SQLite agent graph client projections', () => {
         schemaVersion: 1,
         graphId: 'graph-1',
         rootSessionId: 'root-session',
+        expectedSnapshotVersion: 'snapshot-1',
         snapshotVersion: 'snapshot-2',
         snapshot: { version: 2 },
         replaceOperators: true,
-        operators: [
-          { operatorId: 'operator-1', payload: { status: 'completed' } },
-        ],
+        operators: [{ operatorId: 'operator-1', payload: { status: 'completed' } }],
         terminalActivities: [
           { recordId: 'record-3', eventTime: 3, payload: { recordId: 'record-3' } },
         ],
+        activityRecords: [{ recordId: 'record-3', eventTime: 3 }],
       });
       assert.equal(
         await store.readAgentGraphClientOperatorProjection('graph-1', 'operator-2'),
         undefined,
       );
       assert.equal(
-        (
-          await store.readAgentGraphClientOperatorProjection(
-            'graph-1',
-            'operator-1',
-          )
-        )?.snapshotVersion,
+        (await store.readAgentGraphClientOperatorProjection('graph-1', 'operator-1'))
+          ?.snapshotVersion,
         'snapshot-2',
       );
       await assert.rejects(
@@ -896,6 +1005,7 @@ describe('SQLite agent graph client projections', () => {
           schemaVersion: 1,
           graphId: 'graph-1',
           rootSessionId: 'root-session',
+          expectedSnapshotVersion: 'snapshot-2',
           snapshotVersion: 'snapshot-3',
           snapshot: { version: 3 },
           replaceOperators: true,
@@ -903,6 +1013,7 @@ describe('SQLite agent graph client projections', () => {
           terminalActivities: [
             { recordId: 'record-3', eventTime: 4, payload: { recordId: 'record-3' } },
           ],
+          activityRecords: [{ recordId: 'record-3', eventTime: 4 }],
         }),
         /changed after materialization/,
       );

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 9;
+export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 10;
 
 const MIGRATIONS: ReadonlyMap<number, string> = new Map([
   [
@@ -266,6 +266,49 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
 
     CREATE INDEX agent_graph_operator_provisions_by_graph
       ON agent_graph_operator_provisions(graph_id, provisioned_at, operator_id);
+  `,
+  ],
+  [
+    10,
+    `
+    CREATE TABLE agent_graph_client_projections (
+      graph_id TEXT PRIMARY KEY,
+      root_session_id TEXT NOT NULL,
+      schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+      snapshot_version TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      materialized_at INTEGER NOT NULL CHECK (materialized_at >= 0)
+    );
+
+    CREATE TABLE agent_graph_client_operator_projections (
+      graph_id TEXT NOT NULL,
+      operator_id TEXT NOT NULL,
+      snapshot_version TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      materialized_at INTEGER NOT NULL CHECK (materialized_at >= 0),
+      PRIMARY KEY(graph_id, operator_id),
+      FOREIGN KEY(graph_id)
+        REFERENCES agent_graph_client_projections(graph_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE TABLE agent_graph_client_terminal_activity (
+      graph_id TEXT NOT NULL,
+      record_id TEXT NOT NULL,
+      event_time INTEGER NOT NULL CHECK (event_time >= 0),
+      payload_json TEXT NOT NULL,
+      PRIMARY KEY(graph_id, record_id),
+      FOREIGN KEY(graph_id)
+        REFERENCES agent_graph_client_projections(graph_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX agent_graph_client_terminal_activity_page
+      ON agent_graph_client_terminal_activity(
+        graph_id,
+        event_time DESC,
+        record_id DESC
+      );
   `,
   ],
 ]);

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -286,10 +286,7 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
       snapshot_version TEXT NOT NULL,
       payload_json TEXT NOT NULL,
       materialized_at INTEGER NOT NULL CHECK (materialized_at >= 0),
-      PRIMARY KEY(graph_id, operator_id),
-      FOREIGN KEY(graph_id)
-        REFERENCES agent_graph_client_projections(graph_id)
-        ON DELETE CASCADE
+      PRIMARY KEY(graph_id, operator_id)
     );
 
     CREATE TABLE agent_graph_client_terminal_activity (
@@ -297,10 +294,14 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
       record_id TEXT NOT NULL,
       event_time INTEGER NOT NULL CHECK (event_time >= 0),
       payload_json TEXT NOT NULL,
-      PRIMARY KEY(graph_id, record_id),
-      FOREIGN KEY(graph_id)
-        REFERENCES agent_graph_client_projections(graph_id)
-        ON DELETE CASCADE
+      PRIMARY KEY(graph_id, record_id)
+    );
+
+    CREATE TABLE agent_graph_client_applied_records (
+      graph_id TEXT NOT NULL,
+      record_id TEXT NOT NULL,
+      event_time INTEGER NOT NULL CHECK (event_time >= 0),
+      PRIMARY KEY(graph_id, record_id)
     );
 
     CREATE INDEX agent_graph_client_terminal_activity_page

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -5,6 +5,7 @@ import { isDeepStrictEqual } from 'node:util';
 import type { DatabaseSync } from 'node:sqlite';
 import {
   AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION,
+  AgentGraphClientProjectionConflictError,
   assertAgentGraphScheduleUpdateRequest,
   AgentGraphScheduleClosedError,
   AgentGraphScheduleRevisionConflictError,
@@ -651,6 +652,56 @@ export class SqliteSessionMetadataStore {
     this.assertOpen();
     assertAgentGraphClientProjectionRequest(request);
     return this.transaction(() => {
+      const current = this.db
+        .prepare(`
+          SELECT
+            schema_version AS schemaVersion,
+            graph_id AS graphId,
+            root_session_id AS rootSessionId,
+            snapshot_version AS snapshotVersion,
+            payload_json AS payloadJson,
+            materialized_at AS materializedAt
+          FROM agent_graph_client_projections
+          WHERE graph_id = ?
+        `)
+        .get(request.graphId) as AgentGraphClientProjectionRow | undefined;
+      if (
+        request.expectedSnapshotVersion === null
+          ? current !== undefined
+          : current?.snapshotVersion !== request.expectedSnapshotVersion
+      ) {
+        throw new AgentGraphClientProjectionConflictError(
+          `Agent graph client projection ${request.graphId} version conflict: expected ${
+            request.expectedSnapshotVersion ?? 'no existing projection'
+          }, found ${current?.snapshotVersion ?? 'none'}`,
+        );
+      }
+
+      const readAppliedRecord = this.db.prepare(`
+        SELECT event_time AS eventTime
+        FROM agent_graph_client_applied_records
+        WHERE graph_id = ? AND record_id = ?
+      `);
+      if (request.incrementalRecordId) {
+        const existing = readAppliedRecord.get(request.graphId, request.incrementalRecordId) as
+          | AgentGraphClientAppliedRecordRow
+          | undefined;
+        if (existing) {
+          const requested = request.activityRecords.find(
+            (record) => record.recordId === request.incrementalRecordId,
+          )!;
+          if (existing.eventTime !== requested.eventTime) {
+            throw new SessionMetadataConflictError(
+              `Agent graph activity ${requested.recordId} changed after materialization`,
+            );
+          }
+          if (!current) {
+            throw new Error('Incremental agent graph projection has no current snapshot');
+          }
+          return decodeAgentGraphClientProjectionRow(current);
+        }
+      }
+
       const materializedAt = this.now();
       const snapshotPayloadJson = encodeProjectionPayload(request.snapshot, 'snapshot');
       this.db
@@ -678,6 +729,28 @@ export class SqliteSessionMetadataStore {
           snapshotPayloadJson,
           materializedAt,
         );
+
+      const insertAppliedRecord = this.db.prepare(`
+        INSERT INTO agent_graph_client_applied_records(
+          graph_id,
+          record_id,
+          event_time
+        ) VALUES (?, ?, ?)
+      `);
+      for (const record of request.activityRecords) {
+        const existing = readAppliedRecord.get(request.graphId, record.recordId) as
+          | AgentGraphClientAppliedRecordRow
+          | undefined;
+        if (existing) {
+          if (existing.eventTime !== record.eventTime) {
+            throw new SessionMetadataConflictError(
+              `Agent graph activity ${record.recordId} changed after materialization`,
+            );
+          }
+          continue;
+        }
+        insertAppliedRecord.run(request.graphId, record.recordId, record.eventTime);
+      }
 
       if (request.replaceOperators) {
         this.db
@@ -726,22 +799,14 @@ export class SqliteSessionMetadataStore {
           | AgentGraphClientTerminalActivityRow
           | undefined;
         if (existing) {
-          if (
-            existing.eventTime !== terminal.eventTime ||
-            existing.payloadJson !== payloadJson
-          ) {
+          if (existing.eventTime !== terminal.eventTime || existing.payloadJson !== payloadJson) {
             throw new SessionMetadataConflictError(
               `Agent graph terminal activity ${terminal.recordId} changed after materialization`,
             );
           }
           continue;
         }
-        insertTerminal.run(
-          request.graphId,
-          terminal.recordId,
-          terminal.eventTime,
-          payloadJson,
-        );
+        insertTerminal.run(request.graphId, terminal.recordId, terminal.eventTime, payloadJson);
       }
 
       return {
@@ -878,11 +943,7 @@ export class SqliteSessionMetadataStore {
       `)
       .all(graphId) as unknown as AgentGraphClientClaimAdmission[];
     return rows.map((row) => {
-      if (
-        row.state !== 'claimed' &&
-        row.state !== 'executing' &&
-        row.state !== 'cancelled'
-      ) {
+      if (row.state !== 'claimed' && row.state !== 'executing' && row.state !== 'cancelled') {
         throw new Error(`Invalid agent graph admission state for ${row.intentId}`);
       }
       return { intentId: row.intentId, state: row.state };
@@ -1599,6 +1660,10 @@ interface AgentGraphClientTerminalActivityRow {
   payloadJson: string;
 }
 
+interface AgentGraphClientAppliedRecordRow {
+  eventTime: number;
+}
+
 interface AgentGraphClientTerminalActivityRowWithIdentity
   extends AgentGraphClientTerminalActivityRow {
   graphId: string;
@@ -1671,14 +1736,20 @@ function assertAgentGraphClientProjectionRequest(
 ): void {
   if (
     request.schemaVersion !== AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION ||
+    (request.expectedSnapshotVersion !== null &&
+      typeof request.expectedSnapshotVersion !== 'string') ||
     typeof request.replaceOperators !== 'boolean' ||
     !Array.isArray(request.operators) ||
-    !Array.isArray(request.terminalActivities)
+    !Array.isArray(request.terminalActivities) ||
+    !Array.isArray(request.activityRecords)
   ) {
     throw new Error('Invalid agent graph client projection request');
   }
   assertGraphLookupIdentity(request.graphId, 'graph id');
   assertSafeSessionId(request.rootSessionId);
+  if (request.expectedSnapshotVersion !== null) {
+    assertGraphLookupIdentity(request.expectedSnapshotVersion, 'expected snapshot version');
+  }
   assertGraphLookupIdentity(request.snapshotVersion, 'snapshot version');
   const operatorIds = new Set<string>();
   for (const operator of request.operators) {
@@ -1696,6 +1767,21 @@ function assertAgentGraphClientProjectionRequest(
       throw new Error(`Duplicate agent graph terminal activity ${terminal.recordId}`);
     }
     terminalIds.add(terminal.recordId);
+  }
+  const activityIds = new Set<string>();
+  for (const record of request.activityRecords) {
+    assertGraphLookupIdentity(record.recordId, 'activity record id');
+    assertGraphEventTime(record.eventTime);
+    if (activityIds.has(record.recordId)) {
+      throw new Error(`Duplicate agent graph activity ${record.recordId}`);
+    }
+    activityIds.add(record.recordId);
+  }
+  if (request.incrementalRecordId !== undefined) {
+    assertGraphLookupIdentity(request.incrementalRecordId, 'incremental record id');
+    if (request.expectedSnapshotVersion === null || !activityIds.has(request.incrementalRecordId)) {
+      throw new Error('Invalid incremental agent graph projection record');
+    }
   }
 }
 

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -30,6 +30,7 @@ import {
   type AgentGraphOperatorProvisionResult,
   type AgentGraphClientClaimAdmission,
   type AgentGraphClientProjectionRecord,
+  type AgentGraphClientProjectionWithOperator,
   type AgentGraphClientOperatorProjectionRecord,
   type AgentGraphClientTerminalActivityPage,
   type CommitAgentGraphClientProjectionRequest,
@@ -863,6 +864,56 @@ export class SqliteSessionMetadataStore {
     return row ? decodeAgentGraphClientOperatorProjectionRow(row) : undefined;
   }
 
+  async readAgentGraphClientProjectionWithOperator(
+    graphId: string,
+    operatorId: string,
+  ): Promise<AgentGraphClientProjectionWithOperator | undefined> {
+    this.assertOpen();
+    assertGraphLookupIdentity(graphId, 'graph id');
+    assertGraphLookupIdentity(operatorId, 'operator id');
+    const row = this.db
+      .prepare(`
+        SELECT
+          graph.schema_version AS projectionSchemaVersion,
+          graph.graph_id AS projectionGraphId,
+          graph.root_session_id AS projectionRootSessionId,
+          graph.snapshot_version AS projectionSnapshotVersion,
+          graph.payload_json AS projectionPayloadJson,
+          graph.materialized_at AS projectionMaterializedAt,
+          operator.graph_id AS operatorGraphId,
+          operator.operator_id AS operatorId,
+          operator.snapshot_version AS operatorSnapshotVersion,
+          operator.payload_json AS operatorPayloadJson,
+          operator.materialized_at AS operatorMaterializedAt
+        FROM agent_graph_client_projections AS graph
+        LEFT JOIN agent_graph_client_operator_projections AS operator
+          ON operator.graph_id = graph.graph_id
+          AND operator.operator_id = ?
+        WHERE graph.graph_id = ?
+      `)
+      .get(operatorId, graphId) as AgentGraphClientProjectionWithOperatorRow | undefined;
+    if (!row) return undefined;
+    const projection = decodeAgentGraphClientProjectionRow({
+      schemaVersion: row.projectionSchemaVersion,
+      graphId: row.projectionGraphId,
+      rootSessionId: row.projectionRootSessionId,
+      snapshotVersion: row.projectionSnapshotVersion,
+      payloadJson: row.projectionPayloadJson,
+      materializedAt: row.projectionMaterializedAt,
+    });
+    if (row.operatorGraphId === null) return { projection };
+    return {
+      projection,
+      operator: decodeAgentGraphClientOperatorProjectionRow({
+        graphId: row.operatorGraphId,
+        operatorId: row.operatorId!,
+        snapshotVersion: row.operatorSnapshotVersion!,
+        payloadJson: row.operatorPayloadJson!,
+        materializedAt: row.operatorMaterializedAt!,
+      }),
+    };
+  }
+
   async listAgentGraphClientTerminalActivities(
     graphId: string,
     input: {
@@ -1653,6 +1704,20 @@ interface AgentGraphClientOperatorProjectionRow {
   snapshotVersion: string;
   payloadJson: string;
   materializedAt: number;
+}
+
+interface AgentGraphClientProjectionWithOperatorRow {
+  projectionSchemaVersion: number;
+  projectionGraphId: string;
+  projectionRootSessionId: string;
+  projectionSnapshotVersion: string;
+  projectionPayloadJson: string;
+  projectionMaterializedAt: number;
+  operatorGraphId: string | null;
+  operatorId: string | null;
+  operatorSnapshotVersion: string | null;
+  operatorPayloadJson: string | null;
+  operatorMaterializedAt: number | null;
 }
 
 interface AgentGraphClientTerminalActivityRow {

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -4,6 +4,7 @@ import { existsSync, mkdirSync } from 'node:fs';
 import { isDeepStrictEqual } from 'node:util';
 import type { DatabaseSync } from 'node:sqlite';
 import {
+  AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION,
   assertAgentGraphScheduleUpdateRequest,
   AgentGraphScheduleClosedError,
   AgentGraphScheduleRevisionConflictError,
@@ -26,6 +27,11 @@ import {
   type AgentGraphOperatorProvision,
   type AgentGraphOperatorProvisionRequest,
   type AgentGraphOperatorProvisionResult,
+  type AgentGraphClientClaimAdmission,
+  type AgentGraphClientProjectionRecord,
+  type AgentGraphClientOperatorProjectionRecord,
+  type AgentGraphClientTerminalActivityPage,
+  type CommitAgentGraphClientProjectionRequest,
   type SessionHeader,
   type SessionListFilter,
   type SubagentSessionParent,
@@ -637,6 +643,250 @@ export class SqliteSessionMetadataStore {
     return rows.map((row) =>
       decodeAgentGraphOperatorProvision(JSON.parse(row.payloadJson) as unknown),
     );
+  }
+
+  async commitAgentGraphClientProjection(
+    request: CommitAgentGraphClientProjectionRequest,
+  ): Promise<AgentGraphClientProjectionRecord> {
+    this.assertOpen();
+    assertAgentGraphClientProjectionRequest(request);
+    return this.transaction(() => {
+      const materializedAt = this.now();
+      const snapshotPayloadJson = encodeProjectionPayload(request.snapshot, 'snapshot');
+      this.db
+        .prepare(`
+          INSERT INTO agent_graph_client_projections(
+            graph_id,
+            root_session_id,
+            schema_version,
+            snapshot_version,
+            payload_json,
+            materialized_at
+          ) VALUES (?, ?, ?, ?, ?, ?)
+          ON CONFLICT(graph_id) DO UPDATE SET
+            root_session_id = excluded.root_session_id,
+            schema_version = excluded.schema_version,
+            snapshot_version = excluded.snapshot_version,
+            payload_json = excluded.payload_json,
+            materialized_at = excluded.materialized_at
+        `)
+        .run(
+          request.graphId,
+          request.rootSessionId,
+          request.schemaVersion,
+          request.snapshotVersion,
+          snapshotPayloadJson,
+          materializedAt,
+        );
+
+      if (request.replaceOperators) {
+        this.db
+          .prepare('DELETE FROM agent_graph_client_operator_projections WHERE graph_id = ?')
+          .run(request.graphId);
+      }
+      const insertOperator = this.db.prepare(`
+        INSERT INTO agent_graph_client_operator_projections(
+          graph_id,
+          operator_id,
+          snapshot_version,
+          payload_json,
+          materialized_at
+        ) VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(graph_id, operator_id) DO UPDATE SET
+          snapshot_version = excluded.snapshot_version,
+          payload_json = excluded.payload_json,
+          materialized_at = excluded.materialized_at
+      `);
+      for (const operator of request.operators) {
+        insertOperator.run(
+          request.graphId,
+          operator.operatorId,
+          request.snapshotVersion,
+          encodeProjectionPayload(operator.payload, 'operator'),
+          materializedAt,
+        );
+      }
+
+      const readTerminal = this.db.prepare(`
+        SELECT event_time AS eventTime, payload_json AS payloadJson
+        FROM agent_graph_client_terminal_activity
+        WHERE graph_id = ? AND record_id = ?
+      `);
+      const insertTerminal = this.db.prepare(`
+        INSERT INTO agent_graph_client_terminal_activity(
+          graph_id,
+          record_id,
+          event_time,
+          payload_json
+        ) VALUES (?, ?, ?, ?)
+      `);
+      for (const terminal of request.terminalActivities) {
+        const payloadJson = encodeProjectionPayload(terminal.payload, 'terminal activity');
+        const existing = readTerminal.get(request.graphId, terminal.recordId) as
+          | AgentGraphClientTerminalActivityRow
+          | undefined;
+        if (existing) {
+          if (
+            existing.eventTime !== terminal.eventTime ||
+            existing.payloadJson !== payloadJson
+          ) {
+            throw new SessionMetadataConflictError(
+              `Agent graph terminal activity ${terminal.recordId} changed after materialization`,
+            );
+          }
+          continue;
+        }
+        insertTerminal.run(
+          request.graphId,
+          terminal.recordId,
+          terminal.eventTime,
+          payloadJson,
+        );
+      }
+
+      return {
+        schemaVersion: request.schemaVersion,
+        graphId: request.graphId,
+        rootSessionId: request.rootSessionId,
+        snapshotVersion: request.snapshotVersion,
+        payload: structuredClone(request.snapshot),
+        materializedAt,
+      };
+    });
+  }
+
+  async readAgentGraphClientProjection(
+    graphId: string,
+  ): Promise<AgentGraphClientProjectionRecord | undefined> {
+    this.assertOpen();
+    assertGraphLookupIdentity(graphId, 'graph id');
+    const row = this.db
+      .prepare(`
+        SELECT
+          schema_version AS schemaVersion,
+          graph_id AS graphId,
+          root_session_id AS rootSessionId,
+          snapshot_version AS snapshotVersion,
+          payload_json AS payloadJson,
+          materialized_at AS materializedAt
+        FROM agent_graph_client_projections
+        WHERE graph_id = ?
+      `)
+      .get(graphId) as AgentGraphClientProjectionRow | undefined;
+    return row ? decodeAgentGraphClientProjectionRow(row) : undefined;
+  }
+
+  async readAgentGraphClientOperatorProjection(
+    graphId: string,
+    operatorId: string,
+  ): Promise<AgentGraphClientOperatorProjectionRecord | undefined> {
+    this.assertOpen();
+    assertGraphLookupIdentity(graphId, 'graph id');
+    assertGraphLookupIdentity(operatorId, 'operator id');
+    const row = this.db
+      .prepare(`
+        SELECT
+          graph_id AS graphId,
+          operator_id AS operatorId,
+          snapshot_version AS snapshotVersion,
+          payload_json AS payloadJson,
+          materialized_at AS materializedAt
+        FROM agent_graph_client_operator_projections
+        WHERE graph_id = ? AND operator_id = ?
+      `)
+      .get(graphId, operatorId) as AgentGraphClientOperatorProjectionRow | undefined;
+    return row ? decodeAgentGraphClientOperatorProjectionRow(row) : undefined;
+  }
+
+  async listAgentGraphClientTerminalActivities(
+    graphId: string,
+    input: {
+      limit: number;
+      before?: { eventTime: number; recordId: string };
+    },
+  ): Promise<AgentGraphClientTerminalActivityPage> {
+    this.assertOpen();
+    assertGraphLookupIdentity(graphId, 'graph id');
+    if (!Number.isSafeInteger(input.limit) || input.limit < 1 || input.limit > 256) {
+      throw new Error('Agent graph terminal activity limit must be between 1 and 256');
+    }
+    if (input.before) {
+      assertGraphEventTime(input.before.eventTime);
+      assertGraphLookupIdentity(input.before.recordId, 'terminal record id');
+      const cursor = this.db
+        .prepare(`
+          SELECT event_time AS eventTime
+          FROM agent_graph_client_terminal_activity
+          WHERE graph_id = ? AND record_id = ?
+        `)
+        .get(graphId, input.before.recordId) as { eventTime?: unknown } | undefined;
+      if (cursor?.eventTime !== input.before.eventTime) {
+        throw new Error('Agent graph terminal activity cursor is stale or invalid');
+      }
+    }
+    const rows = this.db
+      .prepare(`
+        SELECT
+          graph_id AS graphId,
+          record_id AS recordId,
+          event_time AS eventTime,
+          payload_json AS payloadJson
+        FROM agent_graph_client_terminal_activity
+        WHERE graph_id = ?
+          ${
+            input.before
+              ? `AND (
+                  event_time < ?
+                  OR (event_time = ? AND record_id < ?)
+                )`
+              : ''
+          }
+        ORDER BY event_time DESC, record_id DESC
+        LIMIT ?
+      `)
+      .all(
+        graphId,
+        ...(input.before
+          ? [input.before.eventTime, input.before.eventTime, input.before.recordId]
+          : []),
+        input.limit + 1,
+      ) as unknown as AgentGraphClientTerminalActivityRowWithIdentity[];
+    return {
+      records: rows.slice(0, input.limit).map((row) => ({
+        graphId: row.graphId,
+        recordId: row.recordId,
+        eventTime: row.eventTime,
+        payload: JSON.parse(row.payloadJson) as unknown,
+      })),
+      hasMore: rows.length > input.limit,
+    };
+  }
+
+  async listAgentGraphClientClaimAdmissions(
+    graphId: string,
+  ): Promise<AgentGraphClientClaimAdmission[]> {
+    this.assertOpen();
+    assertGraphLookupIdentity(graphId, 'graph id');
+    const rows = this.db
+      .prepare(`
+        SELECT
+          intent_id AS intentId,
+          admission_status AS state
+        FROM agent_graph_intent_claims
+        WHERE graph_id = ?
+        ORDER BY claimed_at ASC, intent_id ASC
+      `)
+      .all(graphId) as unknown as AgentGraphClientClaimAdmission[];
+    return rows.map((row) => {
+      if (
+        row.state !== 'claimed' &&
+        row.state !== 'executing' &&
+        row.state !== 'cancelled'
+      ) {
+        throw new Error(`Invalid agent graph admission state for ${row.intentId}`);
+      }
+      return { intentId: row.intentId, state: row.state };
+    });
   }
 
   async update(
@@ -1327,6 +1577,34 @@ interface AgentGraphOperatorProvisionRow {
   payloadJson: string;
 }
 
+interface AgentGraphClientProjectionRow {
+  schemaVersion: number;
+  graphId: string;
+  rootSessionId: string;
+  snapshotVersion: string;
+  payloadJson: string;
+  materializedAt: number;
+}
+
+interface AgentGraphClientOperatorProjectionRow {
+  graphId: string;
+  operatorId: string;
+  snapshotVersion: string;
+  payloadJson: string;
+  materializedAt: number;
+}
+
+interface AgentGraphClientTerminalActivityRow {
+  eventTime: number;
+  payloadJson: string;
+}
+
+interface AgentGraphClientTerminalActivityRowWithIdentity
+  extends AgentGraphClientTerminalActivityRow {
+  graphId: string;
+  recordId: string;
+}
+
 function decodeAgentGraphScheduleUpdateRow(
   row: AgentGraphScheduleUpdateRow,
 ): AgentGraphScheduleUpdate {
@@ -1385,6 +1663,94 @@ function assertGraphLookupIdentity(value: string, name: string): void {
     /[\u0000-\u001f\u007f]/.test(value)
   ) {
     throw new Error(`Invalid agent graph ${name}`);
+  }
+}
+
+function assertAgentGraphClientProjectionRequest(
+  request: CommitAgentGraphClientProjectionRequest,
+): void {
+  if (
+    request.schemaVersion !== AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION ||
+    typeof request.replaceOperators !== 'boolean' ||
+    !Array.isArray(request.operators) ||
+    !Array.isArray(request.terminalActivities)
+  ) {
+    throw new Error('Invalid agent graph client projection request');
+  }
+  assertGraphLookupIdentity(request.graphId, 'graph id');
+  assertSafeSessionId(request.rootSessionId);
+  assertGraphLookupIdentity(request.snapshotVersion, 'snapshot version');
+  const operatorIds = new Set<string>();
+  for (const operator of request.operators) {
+    assertGraphLookupIdentity(operator.operatorId, 'operator id');
+    if (operatorIds.has(operator.operatorId)) {
+      throw new Error(`Duplicate agent graph client operator ${operator.operatorId}`);
+    }
+    operatorIds.add(operator.operatorId);
+  }
+  const terminalIds = new Set<string>();
+  for (const terminal of request.terminalActivities) {
+    assertGraphLookupIdentity(terminal.recordId, 'terminal record id');
+    assertGraphEventTime(terminal.eventTime);
+    if (terminalIds.has(terminal.recordId)) {
+      throw new Error(`Duplicate agent graph terminal activity ${terminal.recordId}`);
+    }
+    terminalIds.add(terminal.recordId);
+  }
+}
+
+function encodeProjectionPayload(payload: unknown, name: string): string {
+  const encoded = JSON.stringify(payload);
+  if (encoded === undefined) {
+    throw new Error(`Invalid agent graph ${name} payload`);
+  }
+  return encoded;
+}
+
+function decodeAgentGraphClientProjectionRow(
+  row: AgentGraphClientProjectionRow,
+): AgentGraphClientProjectionRecord {
+  if (
+    row.schemaVersion !== AGENT_GRAPH_CLIENT_PROJECTION_SCHEMA_VERSION ||
+    !Number.isSafeInteger(row.materializedAt) ||
+    row.materializedAt < 0
+  ) {
+    throw new Error(`Invalid agent graph client projection for ${row.graphId}`);
+  }
+  assertGraphLookupIdentity(row.graphId, 'graph id');
+  assertSafeSessionId(row.rootSessionId);
+  assertGraphLookupIdentity(row.snapshotVersion, 'snapshot version');
+  return {
+    schemaVersion: row.schemaVersion,
+    graphId: row.graphId,
+    rootSessionId: row.rootSessionId,
+    snapshotVersion: row.snapshotVersion,
+    payload: JSON.parse(row.payloadJson) as unknown,
+    materializedAt: row.materializedAt,
+  };
+}
+
+function decodeAgentGraphClientOperatorProjectionRow(
+  row: AgentGraphClientOperatorProjectionRow,
+): AgentGraphClientOperatorProjectionRecord {
+  if (!Number.isSafeInteger(row.materializedAt) || row.materializedAt < 0) {
+    throw new Error(`Invalid agent graph operator projection for ${row.operatorId}`);
+  }
+  assertGraphLookupIdentity(row.graphId, 'graph id');
+  assertGraphLookupIdentity(row.operatorId, 'operator id');
+  assertGraphLookupIdentity(row.snapshotVersion, 'snapshot version');
+  return {
+    graphId: row.graphId,
+    operatorId: row.operatorId,
+    snapshotVersion: row.snapshotVersion,
+    payload: JSON.parse(row.payloadJson) as unknown,
+    materializedAt: row.materializedAt,
+  };
+}
+
+function assertGraphEventTime(value: number): void {
+  if (!Number.isSafeInteger(value) || value < 0) {
+    throw new Error('Invalid agent graph terminal activity event time');
   }
 }
 


### PR DESCRIPTION
## Summary

- add a durable-first, bounded graph snapshot and operator-inspection projection over SQLite graph control facts plus Session, AgentRun, and immutable RuntimeEvent facts
- expose operator and edge state, readiness waits, durable scheduled work, stop and finish state, child Session and AgentRun references, control-decision references, claims, and reference-only activity
- add opaque cursor pagination for terminal history and a stable snapshot version for reconnects
- extend the host-owned coordinator with `getSnapshot`, `inspectOperator`, graph-scoped and host-wide subscriptions, and archived-root read support
- keep subscriptions as process-local invalidation hints only; reconnect and recovery always rebuild from durable state, and transient token and progress deltas do not flood clients
- wire the boundary into Desktop main IPC and preload as `maka.graphs.getSnapshot`, `inspectOperator`, `stop`, and `subscribe`

## Authority boundary

The renderer receives bounded reference-only projections. It does not receive raw RuntimeEvent, message, or tool payloads; stores; schedule commit authority; or reconciliation authority. The main-agent supervisor remains beside the data path, while the host-owned coordinator remains the only execution authority.

This PR intentionally does not add the Graph Mode toggle or renderer UI. The next slice can consume this boundary for the first playable Desktop Graph Mode without reconstructing graph state from presentation events or JSONL.

## Verification

- `npm run typecheck`
- `npm --workspace @maka/runtime run build && node --test "packages/runtime/dist/__tests__/stream-graph-*.test.js"` — 52/52
- `npm --workspace @maka/desktop test` — 2847/2847
- `git diff --check`

Part of #1341.
Depends on #1468 and builds on the host-managed coordinator merged in #1480.

<details>
<summary>中文说明</summary>

## 概要

- 基于 SQLite graph control facts，以及 Session、AgentRun、immutable RuntimeEvent facts，新增 durable-first、有界的 graph snapshot 与 operator inspection 投影
- 暴露 operator/edge 状态、readiness 等待原因、durable schedule work、stop/finish 状态、child Session/AgentRun 引用、control decision 引用、claim 与仅含引用的 activity
- terminal history 使用 opaque cursor 分页，并提供稳定的 snapshot version 支持重连
- host-owned coordinator 新增 `getSnapshot`、`inspectOperator`、按 graph 和 host 全局订阅，以及 archived root 的只读恢复
- 订阅只是进程内 invalidation hint；重连与恢复始终从 durable state 重建，token/progress 等 transient delta 不会造成高频刷新
- Desktop main IPC 与 preload 暴露 `maka.graphs.getSnapshot`、`inspectOperator`、`stop`、`subscribe`

## 权威边界

Renderer 只接收有界、reference-only 的投影，不会拿到 raw RuntimeEvent/message/tool payload、store、schedule commit authority 或 reconcile authority。主 Agent supervisor 继续站在数据路径旁监督，host-owned coordinator 仍是唯一执行权威。

这一 PR 刻意不做 Graph Mode toggle 和 renderer UI。下一刀可以直接消费这个边界，实现第一次可玩的 Desktop Graph Mode，而不需要从 presentation event 或 JSONL 猜 graph 状态。

## 验证

- workspace 全量 typecheck 通过
- Graph runtime tests：52/52
- Desktop 全量 tests：2847/2847
- `git diff --check` 通过

属于 #1341 的后续工作；依赖 #1468，并建立在 #1480 已合入的 host-managed coordinator 之上。

</details>