### PR TITLE
docs: adopt Apache License 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,8 @@
+Maka
+Copyright 2026 The Maka Authors
+
+This product includes software developed by the Maka project.
+
+Third-party components remain subject to their respective licenses and
+attribution notices. Those notices are distributed with the applicable
+components and application artifacts.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Maka
 
 [![CI](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 [![docs](https://img.shields.io/badge/docs-%E7%AE%80%E4%BD%93%E4%B8%AD%E6%96%87-blue?logo=googletranslate&logoColor=white)](./README.zh-CN.md)
 
 ![Maka — Your work. Your agent.](./.github/assets/maka-hero.en.png)
@@ -227,3 +228,9 @@ Before submitting code, run typecheck, build, and focused tests proportionate to
 - [Backend architecture](./ARCHITECTURE.md)
 - [Product design](./DESIGN.md)
 - [Security policy](./SECURITY.md)
+
+## License
+
+Maka is licensed under the [Apache License 2.0](./LICENSE). See
+[NOTICE](./NOTICE) for attribution information. Third-party components remain
+subject to their respective licenses and notices.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,7 @@
 # Maka
 
 [![CI](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml/badge.svg)](https://github.com/Maka-Agent/maka-agent/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](./LICENSE)
 [![docs](https://img.shields.io/badge/docs-English-blue?logo=googletranslate&logoColor=white)](./README.md)
 
 ![Maka——你的工作，你的 Agent。](./.github/assets/maka-hero.zh-CN.png)
@@ -225,3 +226,8 @@ npm --workspace @maka/desktop run smoke:real-window
 - [后端架构总览](./ARCHITECTURE.zh-CN.md)
 - [产品设计](./DESIGN.md)
 - [安全政策](./SECURITY.md)
+
+## 开源协议
+
+Maka 使用 [Apache License 2.0](./LICENSE) 开源，归属信息见
+[NOTICE](./NOTICE)。第三方组件仍分别适用其自身的许可证与声明。

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,6 +2,7 @@
   "name": "@maka/desktop",
   "productName": "Maka",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "main": "dist/main/main.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "maka",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "workspaces": [
         "packages/core",
         "packages/storage",
@@ -32,6 +33,7 @@
     "apps/desktop": {
       "name": "@maka/desktop",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ant-design/icons-svg": "4.5.0",
         "@base-ui/react": "^1.5.0",
@@ -11007,6 +11009,7 @@
     "packages/cli": {
       "name": "maka-agent",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@earendil-works/pi-tui": "0.80.3",
         "@maka/core": "0.1.0",
@@ -11022,6 +11025,7 @@
     "packages/computer-use": {
       "name": "@maka/computer-use",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@maka/core": "0.1.0",
         "@maka/runtime": "0.1.0"
@@ -11029,11 +11033,13 @@
     },
     "packages/core": {
       "name": "@maka/core",
-      "version": "0.1.0"
+      "version": "0.1.0",
+      "license": "Apache-2.0"
     },
     "packages/headless": {
       "name": "@maka/headless",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@maka/core": "0.1.0",
         "@maka/runtime": "0.1.0",
@@ -11058,6 +11064,7 @@
     "packages/mcp": {
       "name": "@maka/mcp",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@maka/core": "0.1.0",
         "@modelcontextprotocol/sdk": "^1.24.3"
@@ -11066,6 +11073,7 @@
     "packages/runtime": {
       "name": "@maka/runtime",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@ai-sdk/anthropic": "^4.0.16",
         "@ai-sdk/cohere": "^4.0.11",
@@ -11094,6 +11102,7 @@
     "packages/runtime-host": {
       "name": "@maka/runtime-host",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@maka/core": "0.1.0",
         "@maka/runtime": "0.1.0",
@@ -11115,6 +11124,7 @@
     "packages/storage": {
       "name": "@maka/storage",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@maka/core": "0.1.0",
         "fs-native-extensions": "^1.5.0"
@@ -11123,6 +11133,7 @@
     "packages/ui": {
       "name": "@maka/ui",
       "version": "0.1.0",
+      "license": "Apache-2.0",
       "dependencies": {
         "@base-ui/react": "^1.5.0",
         "@maka/core": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "maka",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "private": true,
   "engines": {
     "node": ">=22.19.0"
@@ -27,7 +28,7 @@
     "test": "npm run clean && npm run build:test && npm run test:scripts && node scripts/run-workspace-tests-parallel.mjs",
     "test:dist": "npm run test:scripts && node scripts/run-workspace-tests-parallel.mjs --serial",
     "test:fast": "npm run build:test && npm run test:scripts && node scripts/run-workspace-tests-parallel.mjs",
-    "test:scripts": "node --test scripts/run-headless-tests.test.mjs scripts/run-workspace-tests-parallel.test.mjs scripts/sync-model-metadata.test.mjs scripts/cua-driver-provenance.test.mjs scripts/cu-e2e-fixture.test.mjs scripts/cu-e2e-scenarios.test.mjs scripts/cu-provider-matrix.test.mjs scripts/cu-report-sanitize.test.mjs scripts/cu-real-model-launcher.test.mjs scripts/cu-real-ax-model-e2e-contract.test.mjs scripts/cu-synthetic-model-scenario-contract.test.mjs scripts/cu-real-function-model-e2e-contract.test.mjs scripts/cu-real-anthropic-model-e2e-contract.test.mjs scripts/cu-real-runtime-model-e2e-contract.test.mjs",
+    "test:scripts": "node --test scripts/run-headless-tests.test.mjs scripts/run-workspace-tests-parallel.test.mjs scripts/sync-model-metadata.test.mjs scripts/cua-driver-provenance.test.mjs scripts/cu-e2e-fixture.test.mjs scripts/cu-e2e-scenarios.test.mjs scripts/cu-provider-matrix.test.mjs scripts/cu-report-sanitize.test.mjs scripts/cu-real-model-launcher.test.mjs scripts/cu-real-ax-model-e2e-contract.test.mjs scripts/cu-synthetic-model-scenario-contract.test.mjs scripts/cu-real-function-model-e2e-contract.test.mjs scripts/cu-real-anthropic-model-e2e-contract.test.mjs scripts/cu-real-runtime-model-e2e-contract.test.mjs scripts/license-contract.test.mjs",
     "dev": "npm --workspace @maka/desktop run dev:hmr --",
     "dev:full": "npm run build && npm --workspace @maka/desktop run start",
     "build": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/mcp run build && npm --workspace @maka/runtime run build && npm --workspace @maka/runtime-host run build && npm --workspace @maka/computer-use run build && npm --workspace @maka/headless run build && npm --workspace maka-agent run build && npm --workspace @maka/ui run build && npm --workspace @maka/desktop run build",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "maka-agent",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/computer-use/package.json
+++ b/packages/computer-use/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maka/computer-use",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maka/core",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "description": "Pure types for Maka — events, session, permission, connections.",
   "type": "module",
   "private": true,

--- a/packages/headless/package.json
+++ b/packages/headless/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maka/headless",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maka/mcp",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "description": "Provider-neutral MCP client manager for Maka.",
   "type": "module",
   "private": true,

--- a/packages/runtime-host/package.json
+++ b/packages/runtime-host/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maka/runtime-host",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "description": "Single-owner Runtime Host lifecycle, protocol, and client bootstrap.",
   "type": "module",
   "private": true,

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maka/runtime",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "description": "SessionManager, PermissionEngine, AiSdkBackend, materializer.",
   "type": "module",
   "private": true,

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maka/storage",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@maka/ui",
   "version": "0.1.0",
+  "license": "Apache-2.0",
   "private": true,
   "type": "module",
   "main": "./dist/index.js",

--- a/scripts/license-contract.test.mjs
+++ b/scripts/license-contract.test.mjs
@@ -1,0 +1,44 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import test from 'node:test';
+
+const repoRoot = new URL('../', import.meta.url);
+
+async function readRepoFile(path) {
+  return readFile(new URL(path, repoRoot), 'utf8');
+}
+
+test('repository ships the canonical Apache License 2.0 grant', async () => {
+  const license = await readRepoFile('LICENSE');
+
+  assert.match(license, /^\s*Apache License\s+Version 2\.0, January 2004/m);
+  assert.match(license, /http:\/\/www\.apache\.org\/licenses\//);
+  assert.match(license, /2\. Grant of Copyright License\./);
+  assert.match(license, /3\. Grant of Patent License\./);
+  assert.match(license, /END OF TERMS AND CONDITIONS/);
+});
+
+test('root and workspace package metadata use the Apache-2.0 SPDX identifier', async () => {
+  const rootPackage = JSON.parse(await readRepoFile('package.json'));
+  assert.equal(rootPackage.license, 'Apache-2.0');
+
+  for (const workspace of rootPackage.workspaces) {
+    const manifest = JSON.parse(await readRepoFile(`${workspace}/package.json`));
+    assert.equal(
+      manifest.license,
+      'Apache-2.0',
+      `${workspace}/package.json must declare the repository license`,
+    );
+  }
+});
+
+test('public documentation links the license and attribution notice', async () => {
+  const notice = await readRepoFile('NOTICE');
+  assert.match(notice, /Copyright 2026 The Maka Authors/);
+
+  for (const readme of ['README.md', 'README.zh-CN.md']) {
+    const content = await readRepoFile(readme);
+    assert.match(content, /\[.*Apache License 2\.0.*\]\(\.\/LICENSE\)/);
+    assert.match(content, /\[NOTICE\]\(\.\/NOTICE\)/);
+  }
+});


### PR DESCRIPTION
## Summary

- add the canonical Apache License 2.0 text and project NOTICE
- declare the Apache-2.0 SPDX identifier in the root and every workspace package
- document the license in both READMEs and add a regression contract test

## Validation

- `node --test scripts/license-contract.test.mjs` (3 passed)
- Apache `LICENSE` is byte-identical to the official `LICENSE-2.0.txt`
- package metadata JSON parse check
- `git diff --check`