### PR TITLE
fix(ui): align chat columns with composer

### DIFF
--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -37,6 +37,48 @@ const probeScroller = `(() => {
 // warm-up even starts (fonts / lazy-markdown gates delay it on slow machines).
 const WARMED_HEIGHT_FLOOR = 24 * 800;
 
+type ColumnGeometry = {
+  hostLeft: number;
+  viewportLeft: number;
+  hostViewportLeftDelta: number;
+  turnCenter: number;
+  composerCenter: number;
+  turnComposerCenterDelta: number;
+  hostDisplay: string;
+  hostFlexDirection: string;
+  hostGap: string;
+};
+
+async function probeColumnGeometry(page: import('@playwright/test').Page): Promise<ColumnGeometry> {
+  return await page.evaluate(() => {
+    const host = document.querySelector<HTMLElement>('.maka-chat.messages');
+    const viewport = document.querySelector<HTMLElement>('.maka-chatViewport');
+    const turn = document.querySelector<HTMLElement>('.maka-turn');
+    const composer = document.querySelector<HTMLElement>('.composer .maka-composer-inner');
+    if (!host || !viewport || !turn || !composer) {
+      throw new Error('Expected the active chat host, viewport, turn, and composer to be mounted');
+    }
+
+    const hostRect = host.getBoundingClientRect();
+    const viewportRect = viewport.getBoundingClientRect();
+    const turnRect = turn.getBoundingClientRect();
+    const composerRect = composer.getBoundingClientRect();
+    const hostStyle = getComputedStyle(host);
+    return {
+      hostLeft: hostRect.left,
+      viewportLeft: viewportRect.left,
+      hostViewportLeftDelta: viewportRect.left - hostRect.left,
+      turnCenter: turnRect.left + turnRect.width / 2,
+      composerCenter: composerRect.left + composerRect.width / 2,
+      turnComposerCenterDelta:
+        (turnRect.left + turnRect.width / 2) - (composerRect.left + composerRect.width / 2),
+      hostDisplay: hostStyle.display,
+      hostFlexDirection: hostStyle.flexDirection,
+      hostGap: hostStyle.gap,
+    };
+  });
+}
+
 async function settleGeometry(page: import('@playwright/test').Page, options: { pinned: boolean }): Promise<void> {
   let previousHeight = -1;
   await expect.poll(async () => {
@@ -53,6 +95,58 @@ async function settleGeometry(page: import('@playwright/test').Page, options: { 
     return settled;
   }, { timeout: 15_000, intervals: [500] }).toBe(true);
 }
+
+test('chat viewport and message column share the composer centerline', async ({ longTranscriptWindow: page }) => {
+  await expect(page.locator('.maka-turn')).toHaveCount(24);
+
+  for (const width of [900, 1180, 1440]) {
+    await page.setViewportSize({ width, height: 760 });
+    const geometry = await probeColumnGeometry(page);
+    const diagnostics = JSON.stringify({ width, ...geometry });
+    expect(Math.abs(geometry.hostViewportLeftDelta), diagnostics).toBeLessThanOrEqual(1);
+    expect(Math.abs(geometry.turnComposerCenterDelta), diagnostics).toBeLessThanOrEqual(1);
+  }
+});
+
+test('empty chat keeps its grid content flush with the viewport', async ({ window: page }) => {
+  const content = page.locator('.mainColumn[data-home-surface="true"] .maka-chatContent');
+  await expect(content).toBeVisible();
+
+  for (const width of [900, 1180, 1440]) {
+    await page.setViewportSize({ width, height: 760 });
+    const geometry = await page.evaluate(() => {
+      const host = document.querySelector<HTMLElement>('.maka-chat.messages');
+      const viewport = document.querySelector<HTMLElement>('.maka-chatViewport');
+      const content = document.querySelector<HTMLElement>('.maka-chatContent');
+      if (!host || !viewport || !content) throw new Error('Expected the empty chat scroll surface');
+      const hostRect = host.getBoundingClientRect();
+      const viewportRect = viewport.getBoundingClientRect();
+      const contentStyle = getComputedStyle(content);
+      return {
+        hostViewportLeftDelta: viewportRect.left - hostRect.left,
+        contentDisplay: contentStyle.display,
+        contentGap: contentStyle.gap,
+      };
+    });
+    const diagnostics = JSON.stringify({ width, ...geometry });
+    expect(Math.abs(geometry.hostViewportLeftDelta), diagnostics).toBeLessThanOrEqual(1);
+    expect(geometry.contentDisplay, diagnostics).toBe('grid');
+    expect(geometry.contentGap, diagnostics).toBe('0px');
+  }
+});
+
+test('chat turns keep twelve pixels of vertical separation', async ({ longTranscriptWindow: page }) => {
+  await expect(page.locator('.maka-turn')).toHaveCount(24);
+
+  const gap = await page.evaluate(() => {
+    const turns = document.querySelectorAll<HTMLElement>('.maka-turn');
+    const first = turns[0]?.getBoundingClientRect();
+    const second = turns[1]?.getBoundingClientRect();
+    if (!first || !second) throw new Error('Expected two chat turns');
+    return second.top - first.bottom;
+  });
+  expect(gap).toBe(12);
+});
 
 test('long session opens pinned to bottom and stays pinned while geometry settles', async ({ longTranscriptWindow: page }) => {
   await expect(page.locator('.maka-turn')).toHaveCount(24);

--- a/apps/desktop/src/main/__tests__/chat-message-shell-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/chat-message-shell-contract.test.ts
@@ -1,10 +1,9 @@
 /**
- * CHAT-TURN-SPACING-0 (issue #546 PR5): the chat surface uses one uniform
- * turn gap — `.maka-chat` (between turns) and `.maka-turn` (within a turn)
- * both at `--space-3` (12px) — instead of the earlier loose-between /
- * tight-within split (24px / 8px). Uniform density reads as a continuous
- * coding-agent stream rather than stacked Q+A blocks; the single token
- * keeps both on the spacing scale so neither drifts to a magic number.
+ * CHAT-TURN-SPACING-0 (issue #546 PR5): the chat content uses one uniform
+ * turn gap — `.maka-chatContent` (between turns) and `.maka-turn` (within a
+ * turn) both at `--space-3` (12px) — instead of the earlier loose-between /
+ * tight-within split (24px / 8px). The content node owns sibling layout;
+ * putting gap on the OverlayScrollbars host would offset its viewport.
  *
  * CHAT-MESSAGE-TIME-0 (issue #546 PR5): the inline message timestamp
  * (`.maka-message-time-inline`) aligns to the caption tier
@@ -22,6 +21,7 @@ import { describe, it } from 'node:test';
 import { REPO_ROOT, TOKENS_FILE, stripCssComments } from './css-test-helpers.js';
 
 const CHAT_MESSAGE_CSS = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles', 'chat-message.css');
+const CHAT_HEADER_CSS = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles', 'chat-header.css');
 
 /** Extract the declaration body of a top-level `selector { … }` rule (no
  *  nested blocks — the rules asserted here are flat declaration lists). */
@@ -30,17 +30,25 @@ function ruleBody(css: string, selector: string): string | null {
   return css.match(new RegExp(pattern, 'm'))?.[1] ?? null;
 }
 
-describe('CHAT-TURN-SPACING-0 contract (#546 PR5)', () => {
-  it('.maka-chat and .maka-turn both use gap: var(--space-3) (uniform 12/12)', async () => {
+describe('CHAT-TURN-SPACING-0 contract (#546 PR5, #1469)', () => {
+  it('.maka-chatContent and .maka-turn both use gap: var(--space-3) (uniform 12/12)', async () => {
     const css = stripCssComments(await readFile(TOKENS_FILE, 'utf8'));
-    const chat = ruleBody(css, '.maka-chat');
+    const chatHeaderCss = stripCssComments(await readFile(CHAT_HEADER_CSS, 'utf8'));
+    const chatHost = ruleBody(css, '.maka-chat');
+    const chatContent = ruleBody(chatHeaderCss, '.maka-chatContent');
     const turn = ruleBody(css, '.maka-turn');
-    assert.ok(chat, '.maka-chat rule must exist in maka-tokens.css');
+    assert.ok(chatHost, '.maka-chat rule must exist in maka-tokens.css');
+    assert.ok(chatContent, '.maka-chatContent rule must exist in chat-header.css');
     assert.ok(turn, '.maka-turn rule must exist in maka-tokens.css');
+    assert.doesNotMatch(
+      chatHost,
+      /\bgap\s*:/,
+      '.maka-chat is the OverlayScrollbars host and must not offset its viewport with a layout gap',
+    );
     assert.match(
-      chat,
+      chatContent,
       /gap:\s*var\(--space-3\)/,
-      '.maka-chat gap must be var(--space-3) (12px), uniform with .maka-turn — the between-turn gap',
+      '.maka-chatContent gap must be var(--space-3) (12px), uniform with .maka-turn — the between-turn gap',
     );
     assert.match(
       turn,

--- a/apps/desktop/src/renderer/maka-tokens.css
+++ b/apps/desktop/src/renderer/maka-tokens.css
@@ -1164,12 +1164,6 @@ html[data-os="darwin"].dark {
     flex: 1;
     overflow-y: auto;
     padding: var(--space-6) 0 var(--space-4) 0;
-    display: flex;
-    flex-direction: column;
-    /* PR5 CHAT-TURN-SPACING-0: uniform 12px turn gap (between turns =
-       within turn) — the chat reads as a continuous coding-agent stream
-       instead of stacked Q+A blocks. */
-    gap: var(--space-3);
   }
 
   /* Turn grouping (per kenji UI-04): user msg + tools + assistant answer
@@ -1179,8 +1173,12 @@ html[data-os="darwin"].dark {
   .maka-turn {
     display: flex;
     flex-direction: column;
+    /* The content wrapper owns between-turn flex layout; turns must retain
+       their measured height for content-visibility warm-up and scrolling. */
+    flex: 0 0 auto;
     /* PR5 CHAT-TURN-SPACING-0: uniform 12px within-turn gap, matching the
-       between-turn gap (.maka-chat) — one density, no between/within split. */
+       between-turn gap (.maka-chatContent) — one density, no between/within
+       split. */
     gap: var(--space-3);
     max-width: var(--maka-chat-measure);
     margin: 0 auto;

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -155,6 +155,9 @@
     position: relative;
     min-height: 100%;
     padding-inline: clamp(var(--space-6), 4vw, var(--space-10));
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
   }
 
 .maka-chat-shell {

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -223,6 +223,7 @@
   box-sizing: border-box;
   padding: clamp(var(--space-16), 10vh, 116px) 0 clamp(var(--space-5), 4vh, var(--space-10));
   display: grid;
+  gap: 0;
   align-content: center;
 }
 


### PR DESCRIPTION
## Summary

- move the 12px turn spacing from the OverlayScrollbars host to the chat content that actually owns the turn siblings
- remove the resulting 12px viewport inset / 6px message-column offset while preserving the empty-state grid and long-transcript height behavior
- add live Electron geometry coverage for host/viewport parity, message/composer centering, empty-chat layout, and turn spacing

Closes #1469

## Verification

- `npm --workspace @maka/desktop exec -- playwright test --config e2e/playwright.config.ts e2e/scroll-geometry.spec.ts` — 6 passed
- `npm --workspace @maka/desktop test` — 2869 passed
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/ui run typecheck`
- `npm run lint`
- `npm run format:check`
- live Electron/CDP at 900px, 1180px, and 1440px: host/viewport delta 0px, message/composer center delta 0px, turn gap 12px

## Root cause

`.maka-chat` is the OverlayScrollbars host. Its 12px `gap` was intended to separate chat turns, but OverlayScrollbars forces the host into a horizontal flex row containing its observer and viewport. The gap therefore became a 12px left inset before the viewport, shifting the capped message column 6px to the right. The turns themselves live under `.maka-chatContent`, so that content node now owns their vertical flex layout and spacing.
