### PR TITLE
fix(headless): disable agent tools by default

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-swarm-host-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-swarm-host-contract.test.ts
@@ -22,7 +22,10 @@ describe('AgentSwarm host registration contract', () => {
       /buildParentAgentTools\(\{\s*taskLedger: taskLedgerStore,\s*\}\)/,
     );
     assert.match(cli, /const subagentTools = input\.surface === 'tui'\s*\?\s*buildParentAgentTools\(\)/);
-    assert.match(headless, /\.\.\.buildParentAgentTools\(\)/);
+    assert.match(
+      headless,
+      /\.\.\.\(options\.agentTools\s*\?\s*buildParentAgentTools\(\)\s*:\s*\[\]\)/,
+    );
 
     for (const source of [desktop, cli, headless]) {
       assert.doesNotMatch(

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -49,8 +49,9 @@ default**:
   `Read`/`Write`/`Edit`/`Glob`/`Grep` through the supplied isolation boundary.
   Parent-facing Agent tools and child-session admission are disabled by
   default. Set `Config.agentTools: true` and pass that value to the builder to
-  opt in; Harbor accepts the equivalent canonical environment setting
-  `MAKA_AGENT_TOOLS=true` (`false` is the default).
+  opt in. The Harbor and Pier task runners project that config to the canonical
+  cell setting `MAKA_AGENT_TOOLS=true`; direct Harbor cell/CLI entrypoints accept
+  the same environment setting (`false` is the default).
   Executors can implement native file-operation methods, or rely on the
   command-backed fallback when the isolated workspace has `node` available.
   The headless helper rejects absolute paths, `..` escapes, and absolute glob

--- a/packages/headless/README.md
+++ b/packages/headless/README.md
@@ -47,6 +47,10 @@ default**:
 - If the caller wants Maka's standard tool surface, use
   `buildIsolatedHeadlessTools(executor)`: it routes `Bash` plus
   `Read`/`Write`/`Edit`/`Glob`/`Grep` through the supplied isolation boundary.
+  Parent-facing Agent tools and child-session admission are disabled by
+  default. Set `Config.agentTools: true` and pass that value to the builder to
+  opt in; Harbor accepts the equivalent canonical environment setting
+  `MAKA_AGENT_TOOLS=true` (`false` is the default).
   Executors can implement native file-operation methods, or rely on the
   command-backed fallback when the isolated workspace has `node` available.
   The headless helper rejects absolute paths, `..` escapes, and absolute glob
@@ -87,7 +91,12 @@ await runExperiment(config, task, {
   },
   registerBackends(registry, context) {
     registry.register('ai-sdk', (ctx) => {
-      const tools = [...(ctx.tools ?? buildIsolatedHeadlessTools(context.toolExecutor!))];
+      const tools = [
+        ...(ctx.tools ??
+          buildIsolatedHeadlessTools(context.toolExecutor!, {
+            agentTools: context.config.agentTools,
+          })),
+      ];
       return createAiSdkBackend({
         ...ctx,
         tools,

--- a/packages/headless/harbor/codex_agent.py
+++ b/packages/headless/harbor/codex_agent.py
@@ -441,7 +441,7 @@ class MakaCodexAgent(Codex):
             json.dumps(output, indent=2) + "\n", encoding="utf-8"
         )
 
-    def _execution_identity(self) -> dict[str, str]:
+    def _execution_identity(self) -> dict[str, Any]:
         system_prompt = self._get_env("MAKA_SYSTEM_PROMPT") or ""
         prompt_hash = "sha256:" + hashlib.sha256(
             json.dumps(
@@ -457,6 +457,7 @@ class MakaCodexAgent(Codex):
             "systemPromptHash": prompt_hash,
             "pricingProfile": self._get_env("MAKA_TRIAL_PRICING_SOURCE")
             or "unconfigured",
+            "agentTools": False,
         }
 
     def _write_execution_identity(self) -> None:

--- a/packages/headless/harbor/kimi_code_agent.py
+++ b/packages/headless/harbor/kimi_code_agent.py
@@ -290,7 +290,7 @@ class MakaKimiCodeAgent(BaseInstalledAgent):
             json.dumps(output, indent=2) + "\n", encoding="utf-8"
         )
 
-    def _execution_identity(self) -> dict[str, str]:
+    def _execution_identity(self) -> dict[str, Any]:
         system_prompt = self._get_env("MAKA_SYSTEM_PROMPT") or ""
         prompt_hash = "sha256:" + hashlib.sha256(
             json.dumps(system_prompt, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
@@ -302,6 +302,7 @@ class MakaKimiCodeAgent(BaseInstalledAgent):
             **({"reasoningEffort": effort} if effort else {}),
             "systemPromptHash": prompt_hash,
             "pricingProfile": self._get_env("MAKA_TRIAL_PRICING_SOURCE") or "unconfigured",
+            "agentTools": False,
         }
 
     def _write_execution_identity(self) -> None:

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -584,6 +584,7 @@ class MakaAgent(BaseInstalledAgent):
             "MAKA_TRIAL_CACHE_WRITE_USD_PER_1M",
             "MAKA_TRIAL_PRICING_SOURCE",
             "MAKA_REASONING_EFFORT",
+            "MAKA_AGENT_TOOLS",
             # Default per-command timeout floor for the in-container Bash tool, so
             # long builds/tests do not hit a hard-coded 2-minute ceiling.
             "MAKA_CELL_COMMAND_TIMEOUT_MS",
@@ -1714,6 +1715,7 @@ def _runner_env_summary(env: dict[str, str]) -> dict[str, str]:
         "MAKA_HARBOR_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT",
         "MAKA_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT",
         "MAKA_HEAVY_TASK_MODE",
+        "MAKA_AGENT_TOOLS",
         "MAKA_CONTEXT_STALE_TOOL_RESULT_PRUNE",
         "MAKA_CONTEXT_STALE_TOOL_RESULT_MAX_ESTIMATED_TOKENS",
         "MAKA_CONTEXT_STALE_TOOL_RESULT_MIN_RECENT_TURNS_FULL",

--- a/packages/headless/harbor/opencode_agent.py
+++ b/packages/headless/harbor/opencode_agent.py
@@ -367,7 +367,7 @@ class MakaOpenCodeAgent(OpenCode):
             json.dumps(output, indent=2) + "\n", encoding="utf-8"
         )
 
-    def _execution_identity(self) -> dict[str, str]:
+    def _execution_identity(self) -> dict[str, Any]:
         provider, model = self.model_name.split("/", 1)
         system_prompt = self._get_env("MAKA_SYSTEM_PROMPT") or ""
         prompt_hash = "sha256:" + hashlib.sha256(
@@ -381,6 +381,7 @@ class MakaOpenCodeAgent(OpenCode):
             **({"reasoningEffort": reasoning_effort} if reasoning_effort else {}),
             "systemPromptHash": prompt_hash,
             "pricingProfile": pricing_profile,
+            "agentTools": False,
         }
 
     def _write_execution_identity(self) -> None:

--- a/packages/headless/harbor/run-host-cell.mjs
+++ b/packages/headless/harbor/run-host-cell.mjs
@@ -18,6 +18,7 @@ import {
   runHarborCell,
   writeHarborCellUsageCheckpoint,
 } from '#harbor-cell';
+import { booleanEnv } from '#headless-run-env';
 
 const TRIAL_PRICING_ENV = [
   'MAKA_TRIAL_INPUT_USD_PER_1M',
@@ -51,6 +52,7 @@ export async function main(options = {}) {
   const maxSteps = harborCellMaxStepsFromEnv(env);
   const settleAfterMs = harborCellSoftTimeoutMsFromEnv(env);
   const reasoningEffort = reasoningEffortFromEnv(env.MAKA_REASONING_EFFORT);
+  const agentTools = booleanEnv(env.MAKA_AGENT_TOOLS, 'MAKA_AGENT_TOOLS') ?? false;
   const now = Date.now;
   const newId = randomId;
 
@@ -60,6 +62,7 @@ export async function main(options = {}) {
       backend: 'ai-sdk',
       llmConnectionSlug: env.MAKA_LLM_CONNECTION_SLUG || provider,
       model,
+      agentTools,
       ...(reasoningEffort ? { thinkingLevel: reasoningEffort } : {}),
       ...(env.MAKA_SYSTEM_PROMPT !== undefined ? { systemPrompt: env.MAKA_SYSTEM_PROMPT } : {}),
       ...(economyTaskMode !== undefined ? { economyTaskMode } : {}),

--- a/packages/headless/src/__tests__/cell-output.test.ts
+++ b/packages/headless/src/__tests__/cell-output.test.ts
@@ -130,6 +130,7 @@ describe('Harbor cell output contract', () => {
         systemPromptMode: 'custom',
         systemPromptHash: 'sha256:prompt-a',
         pricingProfile: 'deepseek-v4-flash-tbench-v1',
+        agentTools: true,
       },
     }) as HarborCellOutput & { executionIdentity?: unknown };
 
@@ -140,6 +141,7 @@ describe('Harbor cell output contract', () => {
       systemPromptMode: 'custom',
       systemPromptHash: 'sha256:prompt-a',
       pricingProfile: 'deepseek-v4-flash-tbench-v1',
+      agentTools: true,
     });
   });
 

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -360,6 +360,7 @@ describe('maka-headless CLI', () => {
       assert.equal(cell.executionIdentity?.model, 'fake-model');
       assert.equal(cell.executionIdentity?.reasoningEffort, 'xhigh');
       assert.equal(cell.executionIdentity?.pricingProfile, 'test-account-plan');
+      assert.equal(cell.executionIdentity?.agentTools, false);
       assert.equal(cell.toolSummary.actualToolCalls, 0);
       assert.equal(cell.steps, 1);
       assert.equal(cell.runtimeEventsPath, join(cellArtifactDir, 'runtime-events.jsonl'));

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -121,6 +121,39 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('rejects an execution identity missing the Agent tool policy', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const output = harborOutput({
+        taskId: 'task-a',
+        legacyExecutionIdentity: true,
+        executionIdentity: {
+          llmConnectionSlug: 'fake',
+          model: 'fake-model',
+          systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+          pricingProfile: 'test-profile',
+        },
+      });
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: 'test-profile',
+        taskRunner: async () => output,
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'execution_identity_mismatch');
+    });
+  });
+
   test('resumes from completed task events in the WAL', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -1092,6 +1125,7 @@ describe('fixed prompt controller', () => {
         model: 'fake-model',
         systemPromptHash: hashSystemPrompt('fixed prompt\n'),
         pricingProfile: 'test-profile',
+        agentTools: false,
       };
       const result = await runFixedPromptController({
         runId: 'run-1',
@@ -2811,6 +2845,7 @@ function harborOutput(input: {
   errorClass?: string;
   status?: TaskRunOutput['cell']['status'];
   executionIdentity?: TaskRunOutput['cell']['executionIdentity'];
+  legacyExecutionIdentity?: boolean;
   deadlineSettlement?: TaskRunOutput['cell']['deadlineSettlement'];
   verifier?: TaskRunOutput['harbor']['verifier'];
   providerTelemetryPath?: string;
@@ -2828,7 +2863,13 @@ function harborOutput(input: {
       ...(input.omitPromptHash
         ? {}
         : { promptHash: input.promptHash ?? hashSystemPrompt('fixed prompt\n') }),
-      ...(input.executionIdentity ? { executionIdentity: input.executionIdentity } : {}),
+      ...(input.executionIdentity
+        ? {
+            executionIdentity: input.legacyExecutionIdentity
+              ? input.executionIdentity
+              : { agentTools: false, ...input.executionIdentity },
+          }
+        : {}),
       ...(input.deadlineSettlement ? { deadlineSettlement: input.deadlineSettlement } : {}),
       ...(input.omitTokenSummary
         ? {}

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -87,6 +87,40 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('rejects an execution identity with the wrong Agent tool policy', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const agentConfig: Config = { ...config, agentTools: true };
+      const output = harborOutput({
+        taskId: 'task-a',
+        executionIdentity: {
+          llmConnectionSlug: 'fake',
+          model: 'fake-model',
+          systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+          pricingProfile: 'test-profile',
+          agentTools: false,
+        },
+      });
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config: agentConfig,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        resultsTsvPath: join(dir, 'results.tsv'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireExecutionIdentity: true,
+        expectedPricingProfile: 'test-profile',
+        taskRunner: async () => output,
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'execution_identity_mismatch');
+    });
+  });
+
   test('resumes from completed task events in the WAL', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -81,6 +81,7 @@ describe('Harbor adapter contract', () => {
       /economy_task_mode = True if economy_task_flag is True else economy_task_env == "true"/,
     );
     assert.match(source, /"MAKA_ECONOMY_TASK_MODE": "true" if economy_task_mode else "false"/);
+    assert.match(source, /"MAKA_AGENT_TOOLS"/);
     assert.doesNotMatch(
       source,
       /"MAKA_ECONOMY_TASK_MODE": "true" if self\._resolved_flags\.get\("economy_task_mode"\) else "false"/,
@@ -2302,6 +2303,12 @@ with tempfile.TemporaryDirectory() as tmp:
     economy_env_with_default_flag_agent._resolved_flags = {"backend": "fake", "economy_task_mode": False}
     economy_env_with_default_flag = economy_env_with_default_flag_agent._cell_env(Path("/logs/agent/instruction.txt"))
     assert economy_env_with_default_flag["MAKA_ECONOMY_TASK_MODE"] == "true", economy_env_with_default_flag
+
+    agent_tools_env = MakaAgent(Path(tmp), extra_env={
+        "MAKA_BACKEND": "fake",
+        "MAKA_AGENT_TOOLS": "true",
+    })._cell_env(Path("/logs/agent/instruction.txt"))
+    assert agent_tools_env["MAKA_AGENT_TOOLS"] == "true", agent_tools_env
 
     # Host-side LLM mode must not forward provider secrets into the task-cell env.
     host_agent = MakaAgent(Path(tmp), extra_env={

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -2873,6 +2873,7 @@ try:
         cell = json.loads((Path(tmp) / "maka-cell-output.json").read_text(encoding="utf-8"))
         assert cell["executionIdentity"]["model"] == "glm-5.2", cell
         assert cell["executionIdentity"]["reasoningEffort"] == "max", cell
+        assert cell["executionIdentity"]["agentTools"] is False, cell
         assert cell["tokenSummary"]["cachedInput"] == 40, cell
         assert cell["tokenSummary"]["input"] == 110, cell
         assert cell["tokenSummary"]["output"] == 25, cell
@@ -3081,6 +3082,7 @@ with tempfile.TemporaryDirectory() as tmp:
     cell = json.loads((logs / "maka-cell-output.json").read_text(encoding="utf-8"))
     assert cell["executionIdentity"]["model"] == "k3", cell
     assert cell["executionIdentity"]["reasoningEffort"] == "max", cell
+    assert cell["executionIdentity"]["agentTools"] is False, cell
     assert cell["runtimeRefs"]["sessionId"] == "session-1", cell
     assert cell["toolSummary"]["actualToolCallCounts"] == {"Shell": 1}, cell
     assert "tokenSummary" not in cell, cell
@@ -3436,6 +3438,7 @@ with tempfile.TemporaryDirectory() as tmp:
     assert cell["status"] == "completed", cell
     assert cell["executionIdentity"]["model"] == "gpt-5.6-sol", cell
     assert cell["executionIdentity"]["reasoningEffort"] == "max", cell
+    assert cell["executionIdentity"]["agentTools"] is False, cell
     assert cell["runtimeRefs"]["sessionId"] == "thread-1", cell
     assert cell["tokenSummary"]["input"] == 100, cell
     assert cell["tokenSummary"]["cachedInput"] == 40, cell

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -915,6 +915,7 @@ describe('runHarborCell', () => {
         systemPromptMode: 'custom',
         systemPromptHash: `sha256:${createHash('sha256').update(JSON.stringify(config.systemPrompt)).digest('hex')}`,
         pricingProfile: 'deepseek-v4-flash-tbench-v1',
+        agentTools: false,
       });
 
       const outputJson = JSON.parse(
@@ -1158,6 +1159,7 @@ describe('runHarborCell', () => {
         systemPromptMode: 'custom',
         systemPromptHash: `sha256:${createHash('sha256').update(JSON.stringify(config.systemPrompt)).digest('hex')}`,
         pricingProfile: 'deepseek-v4-flash-tbench-v1',
+        agentTools: false,
       });
     });
   });
@@ -1187,6 +1189,32 @@ describe('runHarborCell', () => {
         JSON.parse(await readFile(join(outputDir, HARBOR_CELL_OUTPUT_FILENAME), 'utf8')),
         result.output,
       );
+    });
+  });
+
+  test('env entrypoint enables Agent tools only for canonical MAKA_AGENT_TOOLS=true', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      let observedAgentTools: boolean | undefined;
+      const result = await runHarborCellFromEnv(
+        {
+          MAKA_BACKEND: 'fake',
+          MAKA_INSTRUCTION: 'solve from env',
+          MAKA_MODEL: 'fake-model',
+          MAKA_WORKDIR: workspaceDir,
+          MAKA_OUTPUT_DIR: outputDir,
+          MAKA_STORAGE_ROOT: storageRoot,
+          MAKA_AGENT_TOOLS: 'true',
+        },
+        {
+          registerBackends: (registry, context) => {
+            observedAgentTools = context.config.agentTools;
+            registerCellBackend(registry);
+          },
+        },
+      );
+
+      assert.equal(observedAgentTools, true);
+      assert.equal(result.output.executionIdentity?.agentTools, true);
     });
   });
 
@@ -1887,11 +1915,13 @@ describe('runHarborCell', () => {
     await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       const previousEnv = { ...process.env };
       const seenPrompts: string[] = [];
+      const seenAgentTools: Array<boolean | undefined> = [];
       const registerCapturingBackend = (
         registry: BackendRegistry,
         context: HeadlessBackendContext,
       ): void => {
         seenPrompts.push(context.config.systemPrompt ?? '');
+        seenAgentTools.push(context.config.agentTools);
         registry.register(
           'ai-sdk',
           (ctx) =>
@@ -1914,6 +1944,7 @@ describe('runHarborCell', () => {
         process.env.MAKA_STORAGE_ROOT = storageRoot;
         process.env.MAKA_SYSTEM_PROMPT = 'Use the host prompt.';
         process.env.MAKA_ECONOMY_TASK_MODE = 'true';
+        process.env.MAKA_AGENT_TOOLS = 'true';
         await main({ registerBackends: registerCapturingBackend });
       } finally {
         process.env = previousEnv;
@@ -1921,6 +1952,7 @@ describe('runHarborCell', () => {
 
       assert.match(seenPrompts[0] ?? '', /Use the host prompt/);
       assert.match(seenPrompts[0] ?? '', /Economy-task benchmark policy/);
+      assert.equal(seenAgentTools[0], true);
     });
   });
 
@@ -2113,6 +2145,9 @@ describe('runHarborCell', () => {
       for (const expected of ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep']) {
         assert.ok(toolNames.includes(expected), `expected provider schema tool ${expected}`);
       }
+      for (const unexpected of ['agent_spawn', 'agent_swarm', 'agent_list', 'agent_output']) {
+        assert.ok(!toolNames.includes(unexpected), `unexpected default Agent tool ${unexpected}`);
+      }
       assert.equal(
         backendInput.tools.find((tool) => tool.name === 'Bash')?.permissionRequired,
         false,
@@ -2146,6 +2181,55 @@ describe('runHarborCell', () => {
       );
       assert.equal(scopedInput.systemPrompt, 'Durable child prompt.');
       assert.equal(scopedInput.toolAvailability, undefined);
+    });
+  });
+
+  test('Harbor ai-sdk backend registration binds the deferred Agent group only when enabled', async () => {
+    await withDirs(async ({ workspaceDir, artifactStore }) => {
+      const registry = new BackendRegistry();
+      const toolExecutor = fakeToolExecutor();
+      const register = buildAiSdkCellBackendRegistration({
+        provider: 'openai',
+        model: 'gpt-5.6-sol',
+        env: { OPENAI_API_KEY: 'test-key' },
+        now: () => 123,
+        newId: () => 'id',
+      });
+      await register(registry, {
+        config: {
+          id: 'harbor-ai-sdk-agent-tools',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'openai',
+          model: 'gpt-5.6-sol',
+          systemPrompt: DEFAULT_HEADLESS_SYSTEM_PROMPT,
+          agentTools: true,
+        },
+        task: { id: 'harbor-cell', instruction: 'solve', workspaceDir },
+        storageRoot: workspaceDir,
+        workspaceDir,
+        artifactStore,
+        realBackendIsolation: { kind: 'external', label: 'Harbor task container', toolExecutor },
+        toolExecutor,
+      });
+
+      const backend = await registry.build('ai-sdk', backendContext(workspaceDir));
+      const backendInput = (
+        backend as unknown as {
+          input: {
+            tools: Array<{ name: string }>;
+            toolAvailability?: { groups?: Array<{ id: string; toolNames: string[] }> };
+          };
+        }
+      ).input;
+      const toolNames = backendInput.tools.map((tool) => tool.name);
+
+      for (const expected of ['agent_spawn', 'agent_swarm', 'agent_list', 'agent_output']) {
+        assert.ok(toolNames.includes(expected), `expected enabled Agent tool ${expected}`);
+      }
+      assert.deepEqual(
+        backendInput.toolAvailability?.groups?.find((group) => group.id === 'agent')?.toolNames,
+        ['agent_spawn', 'agent_swarm', 'agent_list', 'agent_output'],
+      );
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -137,6 +137,50 @@ class CellReportingBackend implements AgentBackend {
   async dispose(): Promise<void> {}
 }
 
+class CellChildAdmissionProbeBackend implements AgentBackend {
+  readonly kind: BackendKind = 'ai-sdk';
+  readonly sessionId: string;
+
+  constructor(
+    sessionId: string,
+    private readonly context: HeadlessBackendContext,
+    private readonly observed: { spawned?: boolean; error?: string },
+  ) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    assert.ok(this.context.spawnChildSession);
+    assert.ok(input.runId);
+    try {
+      await this.context.spawnChildSession(this.sessionId, {
+        spawnedBy: {
+          parentRunId: input.runId,
+          parentTurnId: input.turnId,
+          toolCallId: 'cell-child-admission-probe',
+        },
+        agentProfile: 'local_read',
+        prompt: 'inspect the task workspace',
+      });
+      this.observed.spawned = true;
+    } catch (error) {
+      this.observed.spawned = false;
+      this.observed.error = error instanceof Error ? error.message : String(error);
+    }
+    yield {
+      type: 'complete',
+      id: 'cell-child-admission-probe-complete',
+      turnId: input.turnId,
+      ts: Date.now(),
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
 const registerCellBackend = (registry: BackendRegistry): void => {
   registry.register(
     'fake',
@@ -928,6 +972,37 @@ describe('runHarborCell', () => {
       );
       assert.match(runtimeEvents, /"id":"cell-usage"/);
       assert.match(runtimeEvents, /"systemPromptHash":"sha256:cell-prompt"/);
+    });
+  });
+
+  test('does not provision child tools when Agent tools are disabled by default', async () => {
+    await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
+      const observed: { spawned?: boolean; error?: string } = {};
+      await runHarborCell({
+        config: { ...config, backend: 'ai-sdk' },
+        instruction: 'probe child admission',
+        cwd: workspaceDir,
+        outputDir,
+        storageRoot,
+        registerBackends: (registry, context) => {
+          registry.register(
+            'ai-sdk',
+            (ctx) => new CellChildAdmissionProbeBackend(ctx.sessionId, context, observed),
+          );
+        },
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'unit isolated executor',
+          toolExecutor: {
+            async exec() {
+              return { exitCode: 0, stdout: '', stderr: '' };
+            },
+          },
+        },
+      });
+
+      assert.equal(observed.spawned, false);
+      assert.match(observed.error ?? '', /missing tools/i);
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -435,6 +435,26 @@ describe('applyConnectionDefaults', () => {
 });
 
 describe('resolveHarborRunOptions backend guard', () => {
+  test('uses one boolean vocabulary for the Agent tool switch', async () => {
+    const defaultOptions = await resolveHarborRunOptions(
+      ['--backend', 'fake', '--instruction', 'test'],
+      {},
+    );
+    const enabledOptions = await resolveHarborRunOptions(
+      ['--backend', 'fake', '--instruction', 'test'],
+      { MAKA_AGENT_TOOLS: 'true' },
+    );
+
+    assert.equal(defaultOptions.config.agentTools, false);
+    assert.equal(enabledOptions.config.agentTools, true);
+    await assert.rejects(
+      resolveHarborRunOptions(['--backend', 'fake', '--instruction', 'test'], {
+        MAKA_AGENT_TOOLS: 'sometimes',
+      }),
+      /MAKA_AGENT_TOOLS must be a boolean/,
+    );
+  });
+
   test('preserves an explicit economy-task disable over instruction signals', async () => {
     const opts = await resolveHarborRunOptions(
       ['--backend', 'fake', '--instruction', 'summarize the log files'],

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1926,6 +1926,30 @@ describe('createHarborOracleQualifier', () => {
 });
 
 describe('buildHarborJobConfig', () => {
+  test('projects the Agent tool policy from the run config', () => {
+    const config = buildHarborJobConfig(
+      runInput({
+        config: {
+          id: 'cfg',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'deepseek',
+          model: 'deepseek-v4-flash',
+          agentTools: true,
+        },
+      }),
+      {
+        makaRepoPath: '/repo',
+        jobsDir: '/jobs/x',
+        jobName: 'trial',
+        model: 'deepseek/deepseek-v4-flash',
+      },
+    );
+    const agent = (config.agents as Array<Record<string, unknown>>)[0]!;
+    const env = agent.env as Record<string, string>;
+
+    assert.equal(env.MAKA_AGENT_TOOLS, 'true');
+  });
+
   test('pins the OpenCode adapter and max model variant without serializing credentials', () => {
     const toolchain = {
       opencodeToolchainPath: '/cache/opencode-1.17.18-linux-x64',
@@ -2149,12 +2173,13 @@ describe('buildHarborJobConfig', () => {
           model: 'deepseek/deepseek-v4-flash',
           pricing: { inputUsdPer1M: 0.145, outputUsdPer1M: 0.29 },
           agentEnv: {
+            MAKA_AGENT_TOOLS: 'false',
             MAKA_MODEL: 'deepseek-v4-pro',
             MAKA_SYSTEM_PROMPT: 'wrong prompt',
             MAKA_TRIAL_INPUT_USD_PER_1M: '9',
           },
         }),
-      /agentEnv must not override experiment identity: MAKA_MODEL, MAKA_SYSTEM_PROMPT, MAKA_TRIAL_INPUT_USD_PER_1M/,
+      /agentEnv must not override experiment identity: MAKA_AGENT_TOOLS, MAKA_MODEL, MAKA_SYSTEM_PROMPT, MAKA_TRIAL_INPUT_USD_PER_1M/,
     );
   });
 

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -444,6 +444,7 @@ function harnessArm(id: 'maka' | 'opencode', calls: string[], beforeRun?: () => 
         model: config.model,
         systemPromptHash: promptHash,
         pricingProfile: 'glm-5.2-public-2026-07-13',
+        agentTools: false,
       },
       tokenSummary: tokenSummary({
         input: 100,

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -101,6 +101,7 @@ function cellOutput(overrides: Partial<HarborCellOutput> = {}): HarborCellOutput
       systemPromptMode: 'default',
       systemPromptHash: 'sha256:abc',
       pricingProfile: 'fake-structural',
+      agentTools: false,
     },
     toolSummary: {
       providerVisibleToolCount: 0,
@@ -627,6 +628,7 @@ test('pier-graded failed cells stay scored through the fixed-prompt controller',
           systemPromptMode: 'default',
           systemPromptHash: promptHash,
           pricingProfile: 'fake-structural',
+          agentTools: false,
         },
       });
       const runner = createPierTaskRunner(
@@ -682,6 +684,7 @@ test('pier and harbor outputs drive identical controller events for an infra-fai
             systemPromptMode: 'default',
             systemPromptHash: promptHash,
             pricingProfile: 'fake-structural',
+            agentTools: false,
           },
         });
         const pierRunner = createPierTaskRunner(
@@ -775,6 +778,7 @@ test('createPierTaskRunner recovers execution identity from a budget-exhausted t
       systemPromptMode: 'default',
       systemPromptHash: 'sha256:abc',
       pricingProfile: 'fake-structural',
+      agentTools: false,
     };
     const runner = createPierTaskRunner(
       baseOptions({

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -390,6 +390,33 @@ test('createPierTaskRunner maps a completed fake trial to reward and host cell p
   });
 });
 
+test('createPierTaskRunner projects the Agent tool policy from the run config', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+
+    await runner(
+      runInput({
+        config: {
+          id: 'cfg',
+          backend: 'ai-sdk',
+          llmConnectionSlug: 'fake',
+          model: 'fake',
+          agentTools: true,
+        },
+      }),
+    );
+
+    assert.ok(captured.request?.args.includes('MAKA_AGENT_TOOLS=true'));
+  });
+});
+
 test('createPierTaskRunner passes the provider-local bare model id to pier -m', async () => {
   await withDirs(async ({ jobsDir, repo }) => {
     const captured: FakeOptions['captured'] = {};
@@ -1000,6 +1027,7 @@ test('createPierTaskRunner rejects experiment identity and pricing overrides in 
   await withDirs(async ({ jobsDir, repo }) => {
     const overrides: Array<Record<string, string>> = [
       { MAKA_MODEL: 'other-model' },
+      { MAKA_AGENT_TOOLS: 'true' },
       { MAKA_TRIAL_INPUT_USD_PER_1M: '9' },
     ];
     for (const env of overrides) {

--- a/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
+++ b/packages/headless/src/__tests__/runtime-policy-ab-lifecycle.test.ts
@@ -257,6 +257,7 @@ test('pilot candidate pass against an attested baseline timeout can launch full 
               model: 'deepseek-v4-flash',
               systemPromptHash: hashSystemPrompt(runInput.systemPrompt),
               pricingProfile: 'test-profile',
+              agentTools: false,
             },
             tokenSummary: tokenSummary({
               input: 4,
@@ -408,6 +409,7 @@ function output(input: TaskRunInput, activated: boolean): TaskRunOutput {
         model: 'deepseek-v4-flash',
         systemPromptHash: hashSystemPrompt(input.systemPrompt),
         pricingProfile: 'test-profile',
+        agentTools: false,
       },
       tokenSummary: tokenSummary({ input: 4, output: 6, reasoning: 0, total: 10, costUsd: 0.01 }),
       ...(activated

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -40,6 +40,11 @@ const fakeConfig: Config = {
   llmConnectionSlug: 'fake',
   model: 'fake-model',
 };
+const agentToolsConfig: Config = {
+  ...fakeConfig,
+  backend: 'ai-sdk',
+  agentTools: true,
+};
 
 const registerFakeBackend = (registry: BackendRegistry): void => {
   registry.register(
@@ -214,6 +219,58 @@ class ChildCapabilityBackend implements AgentBackend {
     yield {
       type: 'complete',
       id: 'capability-parent-complete',
+      turnId: input.turnId,
+      ts: Date.now(),
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
+  async respondToPermission(_decision: PermissionDecision): Promise<void> {}
+  async dispose(): Promise<void> {}
+}
+
+class ChildAdmissionProbeBackend implements AgentBackend {
+  readonly kind: BackendKind = 'ai-sdk';
+  readonly sessionId: string;
+
+  constructor(
+    sessionId: string,
+    private readonly context: HeadlessBackendContext,
+    private readonly observed: { spawned?: boolean; error?: string },
+  ) {
+    this.sessionId = sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    assert.ok(this.context.spawnChildSession);
+    assert.ok(input.runId);
+    try {
+      await this.context.spawnChildSession(this.sessionId, {
+        spawnedBy: {
+          parentRunId: input.runId,
+          parentTurnId: input.turnId,
+          toolCallId: 'child-admission-probe',
+        },
+        agentProfile: 'local_read',
+        prompt: 'inspect the task workspace',
+      });
+      this.observed.spawned = true;
+    } catch (error) {
+      this.observed.spawned = false;
+      this.observed.error = error instanceof Error ? error.message : String(error);
+    }
+    yield {
+      type: 'text_complete',
+      id: 'child-admission-probe-text',
+      turnId: input.turnId,
+      ts: Date.now(),
+      messageId: 'child-admission-probe-message',
+      text: 'child admission checked',
+    };
+    yield {
+      type: 'complete',
+      id: 'child-admission-probe-complete',
       turnId: input.turnId,
       ts: Date.now(),
       stopReason: 'end_turn',
@@ -1195,6 +1252,57 @@ describe('runTaskOnce', () => {
     });
   });
 
+  test('does not provision child tools when Agent tools are disabled by default', async () => {
+    await withDirs(async (fixtureDir, storageRoot) => {
+      const observed: { spawned?: boolean; error?: string } = {};
+      let buildCount = 0;
+      const task: Task = {
+        id: 'disabled-child-capability-task',
+        instruction: 'do the thing',
+        workspaceDir: fixtureDir,
+        verification: { command: 'true', protectedPaths: [] },
+      };
+
+      const result = await runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+        storageRoot,
+        registerBackends: (registry, context) => {
+          registry.register('ai-sdk', (ctx) => {
+            buildCount += 1;
+            if (buildCount === 1) {
+              return new ChildAdmissionProbeBackend(ctx.sessionId, context, observed);
+            }
+            return new FakeBackend({
+              sessionId: ctx.sessionId,
+              header: ctx.header,
+              store: ctx.store,
+            });
+          });
+        },
+        realBackendIsolation: {
+          kind: 'external',
+          label: 'unit isolated executor',
+          toolExecutor: {
+            async exec() {
+              return { exitCode: 0, stdout: '', stderr: '' };
+            },
+          },
+        },
+      });
+
+      assert.equal(observed.spawned, false);
+      assert.match(observed.error ?? '', /missing tools/i);
+      assert.equal(buildCount, 1);
+      assert.ok(
+        !result.projection.toolExecutors[0]?.toolNames.some((name) => name.startsWith('agent_')),
+      );
+      assert.equal(
+        result.resultRecord.status,
+        'completed',
+        JSON.stringify(result.resultRecord, null, 2),
+      );
+    });
+  });
+
   test('lets a task-run backend spawn, list, and read a linked child session', async () => {
     await withDirs(async (fixtureDir, storageRoot) => {
       const observed: {
@@ -1212,7 +1320,7 @@ describe('runTaskOnce', () => {
         verification: { command: 'true', protectedPaths: [] },
       };
 
-      const result = await runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+      const result = await runTaskOnce(agentToolsConfig, task, {
         storageRoot,
         registerBackends: (registry, context) => {
           registry.register('ai-sdk', (ctx) => {
@@ -1249,6 +1357,9 @@ describe('runTaskOnce', () => {
       assert.ok(observed.childSessionId);
       assert.deepEqual(observed.listedSessionIds, [observed.childSessionId]);
       assert.equal(observed.outputSessionId, observed.childSessionId);
+      for (const toolName of ['agent_spawn', 'agent_swarm', 'agent_list', 'agent_output']) {
+        assert.ok(result.projection.toolExecutors[0]?.toolNames.includes(toolName));
+      }
     });
   });
 
@@ -1269,7 +1380,7 @@ describe('runTaskOnce', () => {
         verification: { command: 'true', protectedPaths: [] },
       };
 
-      const result = await runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+      const result = await runTaskOnce(agentToolsConfig, task, {
         storageRoot,
         registerBackends: (registry, context) => {
           registry.register('ai-sdk', (ctx) => {
@@ -1338,7 +1449,7 @@ describe('runTaskOnce', () => {
         verification: { command: 'true', protectedPaths: [] },
       };
 
-      const run = runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+      const run = runTaskOnce(agentToolsConfig, task, {
         storageRoot,
         registerBackends: (registry, context) => {
           registry.register('ai-sdk', (ctx) => {
@@ -1405,7 +1516,7 @@ describe('runTaskOnce', () => {
         verification: { command: 'true', protectedPaths: [] },
       };
 
-      const run = runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+      const run = runTaskOnce(agentToolsConfig, task, {
         storageRoot,
         registerBackends: (registry, context) => {
           registry.register('ai-sdk', (ctx) => {
@@ -1486,7 +1597,7 @@ describe('runTaskOnce', () => {
         verification: { command: 'true', protectedPaths: [] },
       };
 
-      const run = runTaskOnce({ ...fakeConfig, backend: 'ai-sdk' }, task, {
+      const run = runTaskOnce(agentToolsConfig, task, {
         storageRoot,
         registerBackends: (registry, context) => {
           registry.register('ai-sdk', (ctx) => {
@@ -1615,7 +1726,7 @@ describe('runTaskOnce', () => {
         },
         now: () => 0,
         deadlineAtMs: 100,
-      }).runOnce({ ...fakeConfig, backend: 'ai-sdk' }, task);
+      }).runOnce(agentToolsConfig, task);
       let watchdog: ReturnType<typeof setTimeout> | undefined;
       try {
         await childStarted;

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -239,7 +239,7 @@ describe('isolated headless tools', () => {
     assert.deepEqual(seenSignals, [ctx.abortSignal, ctx.abortSignal, ctx.abortSignal]);
   });
 
-  test('standard isolated tool surface exposes externalized file tools to local-read children', () => {
+  test('standard isolated tool surface excludes parent-facing agent tools by default', () => {
     const tools = buildIsolatedHeadlessTools({
       async exec() {
         return { exitCode: 0, stdout: '', stderr: '' };
@@ -249,10 +249,10 @@ describe('isolated headless tools', () => {
     assert.equal(names[0], 'Bash');
     assert.ok(names.includes('Read'));
     assert.ok(names.includes('Write'));
-    assert.ok(names.includes('agent_spawn'));
-    assert.ok(names.includes(AGENT_SWARM_TOOL_NAME));
-    assert.ok(names.includes('agent_list'));
-    assert.ok(names.includes('agent_output'));
+    assert.ok(!names.includes('agent_spawn'));
+    assert.ok(!names.includes(AGENT_SWARM_TOOL_NAME));
+    assert.ok(!names.includes('agent_list'));
+    assert.ok(!names.includes('agent_output'));
     assert.ok(!names.includes('inventory_submit'));
     assert.ok(!names.includes('todo_update'));
     assert.ok(!names.includes('self_check_plan_submit'));
@@ -1701,7 +1701,7 @@ describe('isolated headless tools', () => {
     assert.equal(calls, 0);
   });
 
-  test('standard isolated tool availability defers parent-facing agent tools', () => {
+  test('standard isolated tool availability does not advertise agent tools or a loader', () => {
     const tools = buildIsolatedHeadlessTools({
       async exec() {
         return { exitCode: 0, stdout: '', stderr: '' };
@@ -1716,16 +1716,53 @@ describe('isolated headless tools', () => {
         parameters: {},
         impl: () => ({}),
       },
-    ).prepare([]);
+    ).prepare([
+      {
+        content: {
+          kind: 'function_call',
+          name: LOAD_TOOLS_NAME,
+          args: { group: 'agent' },
+        },
+      },
+    ]);
 
     assert.ok(plan.activeTools.includes('Bash'));
     assert.ok(plan.activeTools.includes('Read'));
+    assert.ok(!plan.activeTools.includes(LOAD_TOOLS_NAME));
+    assert.ok(!plan.activeTools.includes('agent_spawn'));
+    assert.ok(!plan.activeTools.includes(AGENT_SWARM_TOOL_NAME));
+    assert.ok(!plan.activeTools.includes('agent_list'));
+    assert.ok(!plan.activeTools.includes('agent_output'));
+    assert.ok(!plan.providerTools.some((tool) => tool.name === LOAD_TOOLS_NAME));
+    assert.ok(!plan.providerTools.some((tool) => tool.name.startsWith('agent_')));
+    assert.equal(plan.projectActiveTools, undefined);
+  });
+
+  test('explicitly enabled agent tools remain deferred behind the catalog loader', () => {
+    const tools = buildIsolatedHeadlessTools(
+      {
+        async exec() {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        },
+      },
+      { agentTools: true },
+    );
+    const plan = new ToolAvailabilityRuntime(
+      tools,
+      buildIsolatedHeadlessToolAvailability(tools.map((tool) => tool.name)),
+      {
+        name: 'invalid',
+        description: 'invalid',
+        parameters: {},
+        impl: () => ({}),
+      },
+    ).prepare([]);
+
     assert.ok(plan.activeTools.includes(LOAD_TOOLS_NAME));
     assert.ok(!plan.activeTools.includes('agent_spawn'));
     assert.ok(!plan.activeTools.includes(AGENT_SWARM_TOOL_NAME));
     assert.ok(!plan.activeTools.includes('agent_list'));
     assert.ok(!plan.activeTools.includes('agent_output'));
-
     const loaded = plan.projectActiveTools!({
       completedSteps: [{ toolCalls: [{ toolName: LOAD_TOOLS_NAME, input: { group: 'agent' } }] }],
     }).activeTools;
@@ -1763,11 +1800,7 @@ describe('isolated headless tools', () => {
   test('README real-backend sketch preserves child tool overrides', async () => {
     const readme = await readFile(new URL('../../README.md', import.meta.url), 'utf8');
 
-    assert.ok(
-      readme.includes(
-        'const tools = [...(ctx.tools ?? buildIsolatedHeadlessTools(context.toolExecutor!))];',
-      ),
-    );
+    assert.ok(readme.includes('agentTools: context.config.agentTools,'));
   });
 });
 

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -1773,11 +1773,14 @@ describe('isolated headless tools', () => {
   });
 
   test('standard isolated tool availability does not reintroduce agent tools into local-read children', () => {
-    const parentTools = buildIsolatedHeadlessTools({
-      async exec() {
-        return { exitCode: 0, stdout: '', stderr: '' };
+    const parentTools = buildIsolatedHeadlessTools(
+      {
+        async exec() {
+          return { exitCode: 0, stdout: '', stderr: '' };
+        },
       },
-    });
+      { agentTools: true },
+    );
     const childTools = buildChildAgentTools(parentTools);
     const plan = new ToolAvailabilityRuntime(
       childTools,
@@ -1800,6 +1803,7 @@ describe('isolated headless tools', () => {
   test('README real-backend sketch preserves child tool overrides', async () => {
     const readme = await readFile(new URL('../../README.md', import.meta.url), 'utf8');
 
+    assert.ok(readme.includes('ctx.tools ??'));
     assert.ok(readme.includes('agentTools: context.config.agentTools,'));
   });
 });

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -136,6 +136,8 @@ export interface HarborCellExecutionIdentity {
   systemPromptMode?: HeadlessSystemPromptMode;
   systemPromptHash: string;
   pricingProfile: string;
+  /** Present on artifacts written after Headless Agent tool gating was introduced. */
+  agentTools?: boolean;
 }
 
 export interface HarborCellDeadlineSettlement {
@@ -383,6 +385,9 @@ export function validateHarborCellExecutionIdentity(value: unknown): HarborCellE
       : {}),
     systemPromptHash: requireString(value.systemPromptHash, 'executionIdentity.systemPromptHash'),
     pricingProfile: requireString(value.pricingProfile, 'executionIdentity.pricingProfile'),
+    ...('agentTools' in value
+      ? { agentTools: requireBoolean(value.agentTools, 'executionIdentity.agentTools') }
+      : {}),
   };
 }
 

--- a/packages/headless/src/contracts.ts
+++ b/packages/headless/src/contracts.ts
@@ -161,6 +161,12 @@ export interface Config {
    * system prompt for simple data-transform tasks.
    */
   economyTaskMode?: boolean | EconomyTaskModeConfig;
+  /**
+   * Explicit opt-in for Maka's parent-facing Agent tool group. Omitted and
+   * false both leave the group unbound; true binds it behind the catalog's
+   * deferred `load_tools` activation.
+   */
+  agentTools?: boolean;
 }
 
 export interface HeavyTaskModeConfig {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1088,7 +1088,7 @@ function classifyExecutionIdentityFailure(
       identity.llmConnectionSlug !== expectedConfig.llmConnectionSlug ||
       identity.model !== expectedModel ||
       identity.reasoningEffort !== expectedConfig.thinkingLevel ||
-      (identity.agentTools ?? false) !== (expectedConfig.agentTools === true) ||
+      identity.agentTools !== (expectedConfig.agentTools === true) ||
       identity.systemPromptHash !== expectedPromptHash ||
       (expectedPricingProfile !== undefined && identity.pricingProfile !== expectedPricingProfile)
     ) {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1088,6 +1088,7 @@ function classifyExecutionIdentityFailure(
       identity.llmConnectionSlug !== expectedConfig.llmConnectionSlug ||
       identity.model !== expectedModel ||
       identity.reasoningEffort !== expectedConfig.thinkingLevel ||
+      (identity.agentTools ?? false) !== (expectedConfig.agentTools === true) ||
       identity.systemPromptHash !== expectedPromptHash ||
       (expectedPricingProfile !== undefined && identity.pricingProfile !== expectedPricingProfile)
     ) {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -328,6 +328,7 @@ export async function runHarborCellWithStorage(
     systemPromptMode: prompt.mode,
     systemPromptHash: prompt.systemPromptHash,
     pricingProfile: input.pricingProfile ?? 'unconfigured',
+    agentTools: config.agentTools === true,
   };
   await writeHarborCellExecutionIdentity(input.outputDir, executionIdentity);
 
@@ -337,7 +338,7 @@ export async function runHarborCellWithStorage(
     runStore: agentRunStore,
     runtimeEventStore,
     backends,
-    ...(input.realBackendIsolation?.toolExecutor
+    ...(config.agentTools && input.realBackendIsolation?.toolExecutor
       ? {
           childTools: buildChildAgentTools(
             buildIsolatedHeadlessTools(input.realBackendIsolation.toolExecutor),
@@ -589,9 +590,11 @@ export async function runHarborCellFromEnv(
   const maxSteps = harborCellMaxStepsFromEnv(resolvedEnv);
   const settleAfterMs = harborCellSoftTimeoutMsFromEnv(resolvedEnv);
   const reasoningEffort = reasoningEffortFromEnv(resolvedEnv.MAKA_REASONING_EFFORT);
+  const agentTools = booleanEnv(resolvedEnv.MAKA_AGENT_TOOLS, 'MAKA_AGENT_TOOLS') ?? false;
   const baseConfig = {
     id: resolvedEnv.MAKA_CONFIG_ID ?? 'harbor-cell',
     backend,
+    agentTools,
     ...(reasoningEffort ? { thinkingLevel: reasoningEffort } : {}),
     ...(resolvedEnv.MAKA_SYSTEM_PROMPT !== undefined
       ? { systemPrompt: resolvedEnv.MAKA_SYSTEM_PROMPT }
@@ -917,6 +920,7 @@ export function buildAiSdkCellBackendRegistration(input: {
       });
       const providerFetch = subscriptionFetch ?? input.fetch;
       const hostTools = buildHarborCellAiSdkTools(context.toolExecutor!, {
+        agentTools: context.config.agentTools,
         ...(context.heavyTaskEvidence ? { heavyTaskEvidence: context.heavyTaskEvidence } : {}),
         ...(context.heavyTaskProgress ? { heavyTaskProgress: context.heavyTaskProgress } : {}),
         ...(context.heavyTaskSelfCheck ? { heavyTaskSelfCheck: context.heavyTaskSelfCheck } : {}),

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -358,6 +358,7 @@ async function writeTaskRunExecutionIdentity(
     systemPromptMode: prompt.mode,
     systemPromptHash: prompt.systemPromptHash,
     pricingProfile: options.env.MAKA_TRIAL_PRICING_SOURCE ?? 'unconfigured',
+    agentTools: options.config.agentTools === true,
   });
   await writeHarborCellExecutionIdentity(options.cellArtifactDir, executionIdentity);
   return executionIdentity;
@@ -429,6 +430,7 @@ export async function resolveHarborRunOptions(
     economyTask: parsed.bools['economy-task']
       ? true
       : booleanEnv(env.MAKA_ECONOMY_TASK_MODE, 'MAKA_ECONOMY_TASK_MODE'),
+    agentTools: booleanEnv(env.MAKA_AGENT_TOOLS, 'MAKA_AGENT_TOOLS') ?? false,
   });
   const realBackendIsolation = buildIsolation(isolation, env, workdir, outDir);
   const providerEnvFetch = backend === 'ai-sdk' ? createProviderEnvFetch(env) : undefined;
@@ -555,6 +557,7 @@ function buildConfig(input: {
   backend: BackendKind;
   heavyTask: boolean;
   economyTask: boolean | undefined;
+  agentTools: boolean;
 }): Config {
   const thinkingLevel = reasoningEffortFromEnv(input.env.MAKA_REASONING_EFFORT);
   const economyTaskMode =
@@ -575,6 +578,7 @@ function buildConfig(input: {
       llmConnectionSlug: input.env.MAKA_LLM_CONNECTION_SLUG ?? 'fake',
       model: input.env.MAKA_MODEL ?? input.env.HARBOR_MODEL ?? 'fake',
       ...(thinkingLevel ? { thinkingLevel } : {}),
+      agentTools: input.agentTools,
       ...(input.heavyTask
         ? { heavyTaskMode: { enabled: true, reason: 'maka eval harbor run --heavy-task' } }
         : {}),
@@ -597,6 +601,7 @@ function buildConfig(input: {
     llmConnectionSlug: input.env.MAKA_LLM_CONNECTION_SLUG ?? modelSpec.provider,
     model: modelSpec.model,
     ...(thinkingLevel ? { thinkingLevel } : {}),
+    agentTools: input.agentTools,
     ...(input.env.MAKA_SYSTEM_PROMPT !== undefined
       ? { systemPrompt: input.env.MAKA_SYSTEM_PROMPT }
       : {}),

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -210,6 +210,7 @@ const EXPERIMENT_IDENTITY_ENV_KEYS = new Set([
   'MAKA_MODEL',
   'MAKA_PROVIDER',
   'MAKA_LLM_CONNECTION_SLUG',
+  'MAKA_AGENT_TOOLS',
   'MAKA_REASONING_EFFORT',
   'MAKA_OPENCODE_VARIANT',
   'MAKA_SYSTEM_PROMPT',
@@ -959,6 +960,7 @@ export function buildHarborJobConfig(
     MAKA_MODEL: makaModel,
     MAKA_PROVIDER: provider,
     MAKA_LLM_CONNECTION_SLUG: provider,
+    MAKA_AGENT_TOOLS: input.config.agentTools === true ? 'true' : 'false',
     // Verbatim — the controller hashes exactly these bytes and verifies the round-trip.
     MAKA_SYSTEM_PROMPT: input.systemPrompt,
   };

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -626,6 +626,7 @@ function buildPierAgentEnv(
     MAKA_MODEL: makaModel,
     MAKA_PROVIDER: provider,
     MAKA_LLM_CONNECTION_SLUG: provider,
+    MAKA_AGENT_TOOLS: input.config.agentTools === true ? 'true' : 'false',
     MAKA_REPO_ROOT: CONTAINER_MAKA_REPO,
     // MAKA_SYSTEM_PROMPT deliberately does NOT ride --ae: pier's CLI strips
     // whitespace from --ae values, and a stripped copy in the adapter's

--- a/packages/headless/src/runner.ts
+++ b/packages/headless/src/runner.ts
@@ -151,7 +151,7 @@ export async function runExperimentWithStorage(
       runStore,
       runtimeEventStore: storage.executionStores.runtimeEventStore,
       backends,
-      ...(deps.realBackendIsolation?.toolExecutor
+      ...(config.agentTools && deps.realBackendIsolation?.toolExecutor
         ? {
             childTools: buildChildAgentTools(
               buildIsolatedHeadlessTools(deps.realBackendIsolation.toolExecutor),

--- a/packages/headless/src/task-agent-controller.ts
+++ b/packages/headless/src/task-agent-controller.ts
@@ -14,6 +14,7 @@ import {
   BackendRegistry,
   RuntimeRunner,
   SessionManager,
+  AGENT_TOOL_NAMES,
   buildChildAgentTools,
   type AgentRunActiveSession,
   type InvocationResult,
@@ -295,6 +296,7 @@ export async function runTaskOnceWithStorage(
         toolNames: toolNamesForIdentity(
           Boolean(deps.realBackendIsolation?.toolExecutor),
           heavyTaskMode.enabled,
+          effectiveConfig.agentTools === true,
         ),
       }),
     });
@@ -327,7 +329,7 @@ export async function runTaskOnceWithStorage(
       runStore: agentRunStore,
       runtimeEventStore,
       backends,
-      ...(deps.realBackendIsolation?.toolExecutor
+      ...(config.agentTools && deps.realBackendIsolation?.toolExecutor
         ? {
             childTools: buildChildAgentTools(
               buildIsolatedHeadlessTools(deps.realBackendIsolation.toolExecutor),
@@ -922,8 +924,13 @@ function withOptionalStatePrompts(
   return next;
 }
 
-function toolNamesForIdentity(hasIsolatedExecutor: boolean, heavyTaskEnabled: boolean): string[] {
+function toolNamesForIdentity(
+  hasIsolatedExecutor: boolean,
+  heavyTaskEnabled: boolean,
+  agentTools: boolean,
+): string[] {
   const names = hasIsolatedExecutor ? [...ISOLATED_HEADLESS_TOOL_NAMES] : ['registered_backend'];
+  if (agentTools && hasIsolatedExecutor) names.push(...AGENT_TOOL_NAMES);
   if (heavyTaskEnabled && hasIsolatedExecutor)
     names.push(...HEAVY_TASK_PROGRESS_TOOL_NAMES, ...HEAVY_TASK_SELF_CHECK_TOOL_NAMES);
   return names;

--- a/packages/headless/src/tools.ts
+++ b/packages/headless/src/tools.ts
@@ -33,6 +33,7 @@ import {
 } from './task-ledger-experiment.js';
 
 export interface BuildIsolatedHeadlessToolsOptions {
+  agentTools?: boolean;
   heavyTaskEvidence?: HeavyTaskEvidenceRecorder;
   heavyTaskProgress?: HeavyTaskProgressRecorder;
   heavyTaskSelfCheck?: HeavyTaskSelfCheckRecorder;
@@ -96,7 +97,7 @@ export function buildIsolatedHeadlessTools(
     buildIsolatedEditTool(executor, options),
     buildIsolatedGlobTool(executor, options),
     buildIsolatedGrepTool(executor, options),
-    ...buildParentAgentTools(),
+    ...(options.agentTools ? buildParentAgentTools() : []),
   ];
   if (options.heavyTaskProgress) {
     tools.push(...buildHeavyTaskProgressTools(options.heavyTaskProgress));


### PR DESCRIPTION
## Summary

- keep the default Headless provider surface to the six isolated Bash/file tools by leaving the entire Agent group unbound
- add one explicit opt-in contract: `Config.agentTools` and `MAKA_AGENT_TOOLS=true|false`
- provision child-session tools only when the same switch is enabled, and attest the effective value in Harbor execution identity
- retain deferred `load_tools` activation when Agent tools are explicitly enabled

## Verification

- `npm run lint`
- `npm run format:check`
- `npm run typecheck --workspace=@maka/headless`
- `node --test dist/__tests__/runner.test.js` (18 passed)
- `node --test dist/__tests__/tools.test.js dist/__tests__/task-agent-controller.test.js dist/__tests__/cell-output.test.js dist/__tests__/harbor-cli-connection-defaults.test.js dist/__tests__/cli.test.js` (153 passed)
- `node --test dist/__tests__/harbor-adapter.test.js dist/__tests__/harbor-cell.test.js` (175 passed, 1 skipped)

## Review focus

This intentionally changes the Headless default. Callers that want parent Agent tools and child sessions must now set `agentTools: true`; Harbor callers use `MAKA_AGENT_TOOLS=true`. Heavy-task and task-ledger tools keep their existing explicit, default-off policies.