### PR TITLE
feat(desktop): animate sidebar drawer

### DIFF
--- a/apps/desktop/e2e/sidebar-geometry.spec.ts
+++ b/apps/desktop/e2e/sidebar-geometry.spec.ts
@@ -208,3 +208,40 @@ test('sidebar list scrolls independently and keeps the footer in view with 60 se
   // invariant #1311 locks.
   expectFooterContained(after, 'after-scroll-to-bottom');
 });
+
+test('keyboard sidebar resize bypasses drawer motion without disabling collapse motion', async ({
+  sidebarLongSessionsWindow: page,
+}) => {
+  const shell = page.locator('.maka-shell-2col');
+  const handle = page.locator('.maka-resize-handle');
+
+  await expect(shell).toHaveAttribute('data-sidebar-state', 'expanded');
+  await page.locator('html').evaluate((element) => {
+    element.removeAttribute('data-maka-e2e-fixture');
+  });
+
+  await handle.focus();
+  await expect(handle).toBeFocused();
+  expect(await shell.evaluate((element) => getComputedStyle(element).transitionDuration)).toBe('0s');
+
+  const beforeWidth = Number(await handle.getAttribute('aria-valuenow'));
+  await handle.press('ArrowRight');
+  const after = await shell.evaluate((element) => {
+    const handle = element.querySelector('.maka-resize-handle');
+    const firstTrack = getComputedStyle(element).gridTemplateColumns.split(' ')[0];
+    return {
+      ariaWidth: Number(handle?.getAttribute('aria-valuenow')),
+      trackWidth: Number.parseFloat(firstTrack ?? ''),
+    };
+  });
+
+  expect(after.ariaWidth).toBe(beforeWidth + 10);
+  expect(after.trackWidth).toBe(after.ariaWidth);
+
+  await handle.blur();
+  await expect
+    .poll(() => shell.evaluate((element) => getComputedStyle(element).transitionDuration))
+    .toBe('0.28s');
+  expect(await shell.evaluate((element) => getComputedStyle(element).transitionProperty))
+    .toContain('grid-template-columns');
+});

--- a/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-important-audit-contract.test.ts
@@ -75,11 +75,6 @@ const ALLOWLIST: ImportantAllowance[] = [
     anchor: '@media (prefers-reduced-motion: reduce)',
     reason: 'reduced-motion override',
   },
-  {
-    fileSuffix: 'apps/desktop/src/renderer/styles/sidebar.css',
-    anchor: '.maka-session-panel[data-collapsed="true"] .maka-list-stack',
-    reason: 'shared list/empty-state collapse override',
-  },
 ];
 
 const RETIRED_RING_RESET_BLOCKS = [

--- a/apps/desktop/src/main/__tests__/sidebar-motion-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-motion-contract.test.ts
@@ -1,0 +1,94 @@
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import { describe, it } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  CONTRACT_RENDERER_ROOT,
+  readRendererContractCss,
+} from './contract-css-helpers.js';
+
+describe('sidebar structural motion contract', () => {
+  it('moves the layout with the drawer tokens while the sidebar content keeps its expanded geometry', async () => {
+    const [css, appShell] = await Promise.all([
+      readRendererContractCss(),
+      readFile(resolve(CONTRACT_RENDERER_ROOT, 'app-shell.tsx'), 'utf8'),
+    ]);
+
+    const shellRule = ruleBody(css, '.maka-shell-2col');
+    assert.match(
+      shellRule,
+      /transition:\s*grid-template-columns var\(--duration-large\) var\(--ease-drawer\)/,
+      'sidebar layout changes should use the shared structural-motion tokens',
+    );
+    const expandedShellRule = ruleBody(css, '.app.maka-shell-2col');
+    assert.match(
+      expandedShellRule,
+      /grid-template-columns:\s*var\(--maka-session-list-expanded-width\)\s+var\(--maka-resize-handle-width,\s*0px\)\s+minmax\(0,\s*1fr\)/,
+      'the expanded target should read from the single authoritative remembered-width variable',
+    );
+
+    const sidebarPanelRule = ruleBody(
+      css,
+      '.maka-shell-2col .maka-panel-list > .maka-session-panel',
+    );
+    assert.match(
+      sidebarPanelRule,
+      /width:\s*var\(--maka-session-list-expanded-width\)/,
+      'the sidebar content should keep its expanded width while the grid track clips it',
+    );
+
+    const collapsedPanelRule = ruleBody(
+      css,
+      '.maka-shell-2col[data-sidebar-state="collapsed"] .maka-panel-list.maka-floating-panel',
+    );
+    assert.match(collapsedPanelRule, /opacity:\s*0/, 'collapsed sidebar content should fade out');
+    assert.match(
+      collapsedPanelRule,
+      /transform:\s*translateX\(var\(--maka-sidebar-exit-offset\)\)/,
+      'collapsed sidebar content should move slightly toward its exit edge',
+    );
+
+    assert.match(
+      appShell,
+      /'--maka-session-list-expanded-width':\s*`\$\{sessionListWidth\}px`/,
+      'the shell should expose the remembered expanded width independently from the animated track width',
+    );
+    assert.doesNotMatch(
+      appShell,
+      /<SessionListPanel[\s\S]*?sidebarCollapsed=\{sessionListCollapsed\}[\s\S]*?\/>/,
+      'the inner panel must not switch to its compact rail geometry before the outer track finishes closing',
+    );
+  });
+
+  it('keeps the chat header avoidance geometry synchronized with the drawer', async () => {
+    const css = await readRendererContractCss();
+    const chatHeaderRule = ruleBody(css, '.maka-chat-header');
+
+    assert.match(
+      chatHeaderRule,
+      /transition:\s*margin-left var\(--duration-large\) var\(--ease-drawer\)/,
+      'the chat header hit-area inset should move with the surrounding layout',
+    );
+  });
+
+  it('gives both sidebar states the same explicit three-track shape', async () => {
+    const css = await readRendererContractCss();
+    const collapsedShellRule = ruleBody(
+      css,
+      '.app.maka-shell-2col[data-sidebar-state="collapsed"]',
+    );
+
+    assert.match(
+      collapsedShellRule,
+      /grid-template-columns:\s*0px\s+var\(--maka-resize-handle-width,\s*0px\)\s+minmax\(0,\s*1fr\)/,
+      'the collapsed target must preserve all three explicit tracks so Chromium can interpolate the grid instead of falling back to one implicit column',
+    );
+  });
+});
+
+function ruleBody(css: string, selector: string): string {
+  const escaped = selector.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const body = new RegExp(`${escaped}\\s*\\{([\\s\\S]*?)\\}`).exec(css)?.[1];
+  assert.ok(body, `${selector} rule must exist`);
+  return body;
+}

--- a/apps/desktop/src/main/__tests__/sidebar-motion-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-motion-contract.test.ts
@@ -7,6 +7,15 @@ import {
   readRendererContractCss,
 } from './contract-css-helpers.js';
 
+const SESSION_LIST_PANEL_PATH = resolve(
+  CONTRACT_RENDERER_ROOT,
+  '../../../../packages/ui/src/session-list-panel.tsx',
+);
+const SESSION_LIST_STORY_PATH = resolve(
+  CONTRACT_RENDERER_ROOT,
+  '../../../../packages/ui/stories/session-list-panel.stories.tsx',
+);
+
 describe('sidebar structural motion contract', () => {
   it('moves the layout with the drawer tokens while the sidebar content keeps its expanded geometry', async () => {
     const [css, appShell] = await Promise.all([
@@ -82,6 +91,44 @@ describe('sidebar structural motion contract', () => {
       collapsedShellRule,
       /grid-template-columns:\s*0px\s+var\(--maka-resize-handle-width,\s*0px\)\s+minmax\(0,\s*1fr\)/,
       'the collapsed target must preserve all three explicit tracks so Chromium can interpolate the grid instead of falling back to one implicit column',
+    );
+  });
+
+  it('keeps keyboard resizing immediate while the separator owns focus', async () => {
+    const css = await readRendererContractCss();
+    const focusedResizeRule = ruleBody(
+      css,
+      '.maka-shell-2col:has(> .maka-resize-handle:focus)',
+    );
+
+    assert.match(
+      focusedResizeRule,
+      /transition:\s*none/,
+      'keyboard width changes must not inherit the drawer transition while the resize separator is focused',
+    );
+  });
+
+  it('keeps the shell drawer as the only sidebar collapse model', async () => {
+    const [css, panelSource, panelStories] = await Promise.all([
+      readRendererContractCss(),
+      readFile(SESSION_LIST_PANEL_PATH, 'utf8'),
+      readFile(SESSION_LIST_STORY_PATH, 'utf8'),
+    ]);
+
+    assert.doesNotMatch(
+      panelSource,
+      /sidebarCollapsed|data-collapsed/,
+      'SessionListPanel must not retain a second compact-rail collapse state',
+    );
+    assert.doesNotMatch(
+      panelStories,
+      /sidebarCollapsed|data-collapsed/,
+      'primitive stories must not advertise the superseded compact-rail path',
+    );
+    assert.doesNotMatch(
+      css,
+      /\.(?:maka-session-panel|agents-sidebar)\[data-collapsed="true"\]/,
+      'renderer CSS must not retain unreachable compact-rail branches',
     );
   });
 });

--- a/apps/desktop/src/main/__tests__/sidebar-scroll-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/sidebar-scroll-contract.test.ts
@@ -118,21 +118,6 @@ describe('sidebar session list CSS scroll contract (PR-SIDEBAR-IA-0 Phase 1)', (
     );
   });
 
-  it('.maka-session-panel[data-collapsed="true"] uses a 4-row grid because the session heading is hidden', async () => {
-    // Collapsed rail sets the session heading row to display:none. A display:none
-    // item does NOT participate in grid layout, so the collapsed panel must not
-    // keep a 5th row reserved for it — otherwise the footer drops into
-    // the minmax(0, 1fr) track and the settings button floats mid-panel.
-    const css = await readRendererContractCss();
-    const ruleBody = extractRuleBody(css, '.maka-session-panel[data-collapsed="true"]');
-    assert.ok(ruleBody, 'collapsed panel rule must exist');
-    assert.match(
-      ruleBody,
-      /grid-template-rows:\s*auto\s+auto\s+minmax\(\s*0\s*,\s*1fr\s*\)\s+auto/,
-      'collapsed panel must use a 4-row grid: the hidden session heading must not reserve a 5th track',
-    );
-  });
-
   it('keeps the sidebar shell flat without a shadow-like gray resize gutter', async () => {
     const css = await readRendererContractCss();
     const listPanel = extractRuleBody(css, '.maka-panel-list.maka-floating-panel');

--- a/apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts
@@ -152,12 +152,16 @@ describe('Storybook baseline contract', () => {
       'ConversationStates',
       'RowActions',
       'LongTitlesAndNarrow',
-      'Collapsed',
     ]) {
       assert.match(src, new RegExp(`export const ${storyName}\\b`));
     }
     assert.doesNotMatch(src, /StatusGroups|statusGroups/);
     assert.doesNotMatch(src, IMPORTS_APP_SHELL, 'Sidebar stories must not import the desktop app shell.');
+
+    const appShellStories = join(REPO_ROOT, 'apps', 'desktop', 'stories', 'app-shell.stories.tsx');
+    const appShellSource = readFileSync(appShellStories, 'utf8');
+    assert.match(appShellSource, /export const CollapsedSidebar\b/);
+    assert.match(appShellSource, /export const SidebarMotion\b/);
   });
 
   it('storyboards ToolActivity result variants before visual polish', () => {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -75,7 +75,6 @@ import { readNavigationState, selectNavigation } from './nav-selection';
 import { sessionMatchesNavSelection } from './session-nav-filter';
 import { deriveSessionRevisionNavigation } from './session-revisions';
 import {
-  SESSION_LIST_COLLAPSED_WIDTH,
   SESSION_LIST_EXPANDED_MAX_WIDTH,
   SESSION_LIST_EXPANDED_MIN_WIDTH,
 } from './session-list-layout';
@@ -1603,8 +1602,8 @@ function AppShellContent({
         data-sidebar-state={sessionListCollapsed ? 'collapsed' : 'expanded'}
         style={
           {
-          '--maka-session-list-width': `${sessionListCollapsed ? SESSION_LIST_COLLAPSED_WIDTH : sessionListWidth}px`,
-          '--maka-resize-handle-width': '0px',
+            '--maka-session-list-expanded-width': `${sessionListWidth}px`,
+            '--maka-resize-handle-width': '0px',
           } as CSSProperties
         }
       >
@@ -1640,7 +1639,6 @@ function AppShellContent({
             onOpenSettings={openSettings}
             onNew={createSession}
             rowActions={sessionRowActions}
-            sidebarCollapsed={sessionListCollapsed}
           />
         </div>
         <div

--- a/apps/desktop/src/renderer/reference-shell.css
+++ b/apps/desktop/src/renderer/reference-shell.css
@@ -47,10 +47,6 @@
   flex-shrink: 0;
 }
 
-.agents-sidebar[data-collapsed="true"] {
-  width: 0;
-}
-
 .agents-sidebar[data-resizing="true"] {
   box-shadow: none !important;
 }

--- a/apps/desktop/src/renderer/session-list-layout.ts
+++ b/apps/desktop/src/renderer/session-list-layout.ts
@@ -1,6 +1,5 @@
 import { safeLocalStorageGet } from './browser-storage.js';
 
-export const SESSION_LIST_COLLAPSED_WIDTH = 0;
 export const SESSION_LIST_EXPANDED_DEFAULT_WIDTH = 210;
 export const SESSION_LIST_EXPANDED_MIN_WIDTH = 210;
 export const SESSION_LIST_EXPANDED_MAX_WIDTH = 280;

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -23,6 +23,7 @@
   padding: 0 var(--space-2-5);
   background: transparent;
   border-bottom: 0;
+  transition: margin-left var(--duration-large) var(--ease-drawer);
   -webkit-app-region: drag;
 }
 

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -36,6 +36,7 @@
 .maka-shell-2col {
   --maka-sidebar-topbar-button-size: var(--h-control-sm);
   --maka-sidebar-topbar-gap: 8px;
+  --maka-sidebar-exit-offset: calc(var(--space-2) * -1);
   /* Alignment governance, PIXEL-MEASURED (screencapture + centroid): the
      macOS traffic lights draw ~13.5pt tall with their optical center at
      y=20.75 — NOT the theoretical 20 (position 14 + 12/2). Icon glyphs
@@ -52,13 +53,10 @@
   );
   position: relative;
   display: grid;
-  grid-template-columns:
-    var(--maka-session-list-width, var(--w-sessionlist))
-    var(--maka-resize-handle-width, 0px)
-    minmax(0, 1fr);
   align-items: stretch;
   gap: 0;
   overflow: hidden;
+  transition: grid-template-columns var(--duration-large) var(--ease-drawer);
   /* PR-CHAT-CHROME-FIX-0 (WAWQAQ msg `1e693dee` + `486b5611`):
      the shell used to carry a 172deg gradient from `--foreground-3`
      to `--background`. The session sidebar is transparent and
@@ -68,6 +66,20 @@
      detail panel. Keep the shell flat neutral; no gradient or
      divider line. */
   background: var(--surface-canvas);
+}
+
+.app.maka-shell-2col {
+  grid-template-columns:
+    var(--maka-session-list-expanded-width)
+    var(--maka-resize-handle-width, 0px)
+    minmax(0, 1fr);
+}
+
+.app.maka-shell-2col[data-sidebar-state="collapsed"] {
+  grid-template-columns:
+    0px
+    var(--maka-resize-handle-width, 0px)
+    minmax(0, 1fr);
 }
 
 .maka-panel {
@@ -86,6 +98,15 @@
 .maka-panel-list.maka-floating-panel {
   border-right: 0;
   background: transparent;
+  opacity: 1;
+  transform: translateX(0);
+  transition:
+    opacity var(--duration-quick) var(--ease-out-strong),
+    transform var(--duration-large) var(--ease-drawer);
+}
+
+.maka-shell-2col .maka-panel-list > .maka-session-panel {
+  width: var(--maka-session-list-expanded-width);
 }
 
 .maka-panel-detail.maka-floating-panel {
@@ -118,6 +139,8 @@
 
 .maka-shell-2col[data-sidebar-state="collapsed"] .maka-panel-list.maka-floating-panel {
   border-right: 0;
+  opacity: 0;
+  transform: translateX(var(--maka-sidebar-exit-offset));
 }
 
 .maka-shell-topbar-rail {
@@ -189,6 +212,10 @@
 .isResizingColumns {
   cursor: col-resize;
   user-select: none;
+}
+
+.isResizingColumns .maka-shell-2col {
+  transition: none;
 }
 
 .mainColumn {

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -218,6 +218,10 @@
   transition: none;
 }
 
+.maka-shell-2col:has(> .maka-resize-handle:focus) {
+  transition: none;
+}
+
 .mainColumn {
   min-width: 0;
   min-height: 0;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -11,15 +11,6 @@
   contain: layout paint style;
 }
 
-.maka-session-panel[data-collapsed="true"] {
-  /* Collapsed rail hides the session-list heading (display: none below). A
-     display:none item does NOT participate in grid layout, so reserving a
-     5th row for it drops the footer into the minmax(0, 1fr) track. Keep the
-     4-row layout matching the four participating children
-     (header / nav / list / footer). */
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
-}
-
 .maka-session-panel-header {
   display: grid;
   gap: var(--space-1);
@@ -36,25 +27,6 @@
   );
   box-sizing: border-box;
   -webkit-app-region: drag;
-}
-
-.maka-session-panel[data-collapsed="true"] .maka-session-panel-footer {
-  justify-items: center;
-  padding-inline: var(--space-2);
-}
-
-.maka-session-panel[data-collapsed="true"] .maka-sidebar-settings-button > span {
-  display: none;
-}
-
-.maka-session-panel[data-collapsed="true"] .maka-session-list {
-  border-top: 0;
-}
-.maka-session-panel[data-collapsed="true"] .maka-list-stack,
-.maka-session-panel[data-collapsed="true"] .maka-empty-state {
-  /* Justified: collapsed mode must suppress the shared list / empty-state
-     layout regardless of the primitive's own display utilities. */
-  display: none !important;
 }
 
 .maka-session-list {
@@ -152,25 +124,6 @@
   padding: 0 var(--space-1);
   font-size: var(--font-size-caption);
   font-variant-numeric: tabular-nums;
-}
-
-.maka-session-panel[data-collapsed="true"] .maka-sidebar-modules {
-  padding: var(--space-1) var(--space-1);
-}
-
-.maka-session-panel[data-collapsed="true"] .maka-nav-row {
-  grid-template-columns: 1fr;
-  padding: var(--space-1-5) 0;
-  place-items: center;
-}
-
-.maka-session-panel[data-collapsed="true"] .maka-nav-row span:nth-child(2),
-.maka-session-panel[data-collapsed="true"] .maka-nav-row small {
-  display: none;
-}
-
-.maka-session-panel[data-collapsed="true"] .maka-session-list-toolbar {
-  display: none;
 }
 
 .maka-list-stack {

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -144,10 +144,10 @@ const baseComposerProps: ComposerProps = {
 	  },
 };
 
-function ShellFrame(props: { children: ReactNode }) {
+function ShellFrame(props: { children: ReactNode; motionEnabled?: boolean }) {
   return (
     <div
-      data-maka-e2e-fixture="true"
+      data-maka-e2e-fixture={props.motionEnabled ? undefined : 'true'}
       style={{ background: 'var(--surface-canvas)', height: '100%', minHeight: 640 }}
     >
       {props.children}
@@ -177,10 +177,11 @@ function ComposedShell(props: {
   chat?: Partial<ChatViewProps>;
   composer?: Partial<ComposerProps>;
   detailChildren?: ReactNode;
+  motionEnabled?: boolean;
 }) {
   const [collapsed, setCollapsed] = useState(props.sidebarCollapsed ?? false);
   const [viewMode, setViewMode] = useState<SessionViewMode>('conversation');
-  const sidebarWidth = collapsed ? 0 : 260;
+  const sidebarWidth = 260;
   const sessions = sidebarSessions.map((s) =>
     s.id === activeSession.id && (props.session?.status || props.session?.blockedReason)
       ? { ...s, status: props.session.status ?? s.status, blockedReason: props.session.blockedReason ?? s.blockedReason }
@@ -195,12 +196,12 @@ function ComposedShell(props: {
   ];
 
   return (
-    <ShellFrame>
+    <ShellFrame motionEnabled={props.motionEnabled}>
       <div
         className="app maka-shell-2col agents-layout-body"
         data-sidebar-state={collapsed ? 'collapsed' : 'expanded'}
         style={{
-          ['--maka-session-list-width' as string]: `${sidebarWidth}px`,
+          ['--maka-session-list-expanded-width' as string]: `${sidebarWidth}px`,
           ['--maka-resize-handle-width' as string]: '0px',
           height: '100%',
         }}
@@ -217,23 +218,25 @@ function ComposedShell(props: {
             column. When collapsed, keep the sidebar mounted (production
             hides it via the data-sidebar-state CSS) so auto-placement
             stays aligned. */}
-        <div className="maka-panel maka-panel-list maka-floating-panel">
-          {!collapsed && (
-            <SessionListPanel
-              selection={{ section: 'sessions', filter: 'chats' }}
-              sessions={sessions}
-              activeId={active.id}
-              groups={viewMode === 'project' ? projectGroups : undefined}
-              streamingSessionIds={streamingIds}
-              viewMode={viewMode}
-              onViewModeChange={setViewMode}
-              onSelect={noop}
-              onSelectSession={noop}
-              onOpenSettings={noop}
-              onNew={noop}
-              rowActions={sidebarRowActions}
-            />
-          )}
+        <div
+          className="maka-panel maka-panel-list maka-floating-panel"
+          aria-hidden={collapsed ? 'true' : undefined}
+          inert={collapsed ? true : undefined}
+        >
+          <SessionListPanel
+            selection={{ section: 'sessions', filter: 'chats' }}
+            sessions={sessions}
+            activeId={active.id}
+            groups={viewMode === 'project' ? projectGroups : undefined}
+            streamingSessionIds={streamingIds}
+            viewMode={viewMode}
+            onViewModeChange={setViewMode}
+            onSelect={noop}
+            onSelectSession={noop}
+            onOpenSettings={noop}
+            onNew={noop}
+            rowActions={sidebarRowActions}
+          />
         </div>
         <div className="maka-resize-handle" aria-hidden="true" />
         <div
@@ -280,6 +283,13 @@ export const DefaultLayout: Story = {
 // (topbar toggle).
 export const CollapsedSidebar: Story = {
   render: () => <ComposedShell sidebarCollapsed />,
+};
+
+// Interaction-only companion to the deterministic expanded/collapsed stories.
+// Keeps real transition durations so reviewers can exercise the structural
+// drawer motion without weakening screenshot stability elsewhere.
+export const SidebarMotion: Story = {
+  render: () => <ComposedShell motionEnabled />,
 };
 
 // Real path: send a message → the turn is streaming (composer shows the

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -285,9 +285,9 @@ export const CollapsedSidebar: Story = {
   render: () => <ComposedShell sidebarCollapsed />,
 };
 
-// Interaction-only companion to the deterministic expanded/collapsed stories.
-// Keeps real transition durations so reviewers can exercise the structural
-// drawer motion without weakening screenshot stability elsewhere.
+// Real path: returning user opens any session → toggle the topbar sidebar
+// control. This interaction-only companion keeps real transition durations
+// without weakening deterministic screenshot states elsewhere.
 export const SidebarMotion: Story = {
   render: () => <ComposedShell motionEnabled />,
 };

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -27,7 +27,6 @@ export function SessionListPanel(props: {
   onOpenSettings(): void;
   onNew(): void;
   rowActions?: SessionRowActions;
-  sidebarCollapsed?: boolean;
 }) {
   const copy = getConversationCopy(useUiLocale()).sessions;
   const {
@@ -40,7 +39,6 @@ export function SessionListPanel(props: {
     <aside
       className="maka-session-panel agents-sidebar"
       aria-label={copy.listAriaLabel}
-      data-collapsed={props.sidebarCollapsed ? 'true' : undefined}
     >
       <header className="maka-session-panel-header">
         <div className="maka-sidebar-drag-strip" />

--- a/packages/ui/stories/session-list-panel.stories.tsx
+++ b/packages/ui/stories/session-list-panel.stories.tsx
@@ -67,7 +67,6 @@ function panelProps(input: {
   activeId?: string;
   streamingSessionIds?: Set<string>;
   staleSessionIds?: Set<string>;
-  sidebarCollapsed?: boolean;
 }): SessionListPanelProps {
   return {
     selection: { section: 'sessions', filter: 'chats' },
@@ -75,7 +74,6 @@ function panelProps(input: {
     ...(input.activeId ? { activeId: input.activeId } : {}),
     ...(input.streamingSessionIds ? { streamingSessionIds: input.streamingSessionIds } : {}),
     ...(input.staleSessionIds ? { staleSessionIds: input.staleSessionIds } : {}),
-    ...(input.sidebarCollapsed ? { sidebarCollapsed: input.sidebarCollapsed } : {}),
     onSelectSession: noop,
     onSelect: noop,
     onOpenSettings: noop,
@@ -339,21 +337,5 @@ export const LongTitlesAndNarrow: Story = {
         staleSessionIds: new Set(['long-title-stale']),
       })} />
     </StoryFrame>
-  ),
-};
-
-// Real path: topbar → collapse the sidebar.
-export const Collapsed: Story = {
-  render: () => (
-    <>
-      <style>{`.agents-sidebar[data-collapsed="true"] { width: 100% !important }`}</style>
-      <StoryFrame width={72}>
-        <SessionListPanel {...panelProps({
-          sessions: coreSessions,
-          activeId: 'session-running',
-          sidebarCollapsed: true,
-        })} />
-      </StoryFrame>
-    </>
   ),
 };


### PR DESCRIPTION
## Summary

- Animate the primary sidebar as a restrained native-feeling drawer using the existing motion tokens.
- Keep the sidebar's inner width stable while the shell track collapses, preventing content reflow during the transition.
- Keep pointer and keyboard width resizing immediate while reserving drawer motion for collapse/expand.
- Remove the superseded compact-rail prop, CSS, and Story so the shell drawer remains the only collapse model.
- Synchronize the chat header offset with the drawer and preserve deterministic Storybook states outside the dedicated motion story.
- Keep the right workbar out of scope because its conditional mount lifecycle is a separate interaction and ownership problem.

## Verification

- `npm --workspace @maka/desktop run typecheck`
- `npm run test:dist` (all workspaces; desktop 2,853/2,853)
- `npx playwright test --config e2e/playwright.config.ts e2e/sidebar-geometry.spec.ts` (2/2)
- `npm --workspace @maka/desktop run build`
- `npm run lint`
- `npm run format:check`
- Manually verified the live Electron app and the `Sidebar Motion` Storybook story, including expanded/collapsed layouts at a 647 px viewport and reduced-motion/resizing behavior.

## Review focus

- Whether the shell grid remains the single authoritative owner of sidebar geometry.
- Whether the motion contract tests protect the meaningful structural invariants without overfitting implementation details.
