### PR TITLE
fix(cu): align real AX e2e harness with its own tool contract

### DIFF
--- a/scripts/cu-real-ax-model-e2e-contract.test.mjs
+++ b/scripts/cu-real-ax-model-e2e-contract.test.mjs
@@ -2,10 +2,11 @@ import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 import test from 'node:test';
 
-const [launcher, harness, probe] = await Promise.all([
+const [launcher, harness, probe, monitor] = await Promise.all([
   readFile(new URL('./cu-real-ax-model-e2e-launcher.mjs', import.meta.url), 'utf8'),
   readFile(new URL('./cu-real-ax-model-e2e.mjs', import.meta.url), 'utf8'),
   readFile(new URL('./cu-physical-input-age.swift', import.meta.url), 'utf8'),
+  readFile(new URL('./cu-real-e2e-monitor.swift', import.meta.url), 'utf8'),
 ]);
 
 test('real AX model E2E owns fixture lifecycle and never activates it', () => {
@@ -96,8 +97,22 @@ test('launcher validates every READY field emitted by the safety monitor', () =>
   assert.match(launcher, /canonicalAppPath: fields\[6\]/);
   assert.match(launcher, /baseline\.mode !== 'concurrent_user'/);
   assert.match(launcher, /Number\.isFinite\(baseline\.physicalInputAge\)/);
-  assert.match(launcher, /baseline\.bundleIdentifier !== fixtureBundleId/);
-  assert.match(launcher, /baseline\.canonicalAppPath !== expectedAppPath/);
+  // The fixture is launched with `open -n -g`, so the baseline asserts it does
+  // NOT own the foreground. Both identity fields are still validated; only the
+  // direction changed, because requiring the fixture to be frontmost would
+  // contradict the launch mode and the background execution under test.
+  assert.match(launcher, /baseline\.bundleIdentifier === fixtureBundleId/);
+  assert.match(launcher, /baseline\.canonicalAppPath === expectedAppPath/);
+  assert.match(launcher, /baseline\.frontmostPID === fixturePID/);
+});
+
+test('launcher keeps the fixture out of the foreground for the whole run', () => {
+  // `--concurrent-user` only catches the OOP host PID; denying the bundle covers
+  // every process the fixture owns, so a UI process stealing focus mid-scenario
+  // also fails the run rather than silently passing.
+  assert.match(launcher, /'--deny-frontmost-bundle'/);
+  assert.match(monitor, /--deny-frontmost-bundle/);
+  assert.match(monitor, /denied bundle became frontmost during E2E/);
 });
 
 test('candidate qualification keeps artifact identity checks and supports a relocated lab', () => {

--- a/scripts/cu-real-ax-model-e2e-launcher.mjs
+++ b/scripts/cu-real-ax-model-e2e-launcher.mjs
@@ -9,9 +9,12 @@ const repoRoot = join(here, '..');
 const harnessPath = join(here, 'cu-real-ax-model-e2e.mjs');
 const monitorPath = join(here, 'cu-real-e2e-monitor.swift');
 const inputAgeSource = join(here, 'cu-physical-input-age.swift');
-const labRoot =
-  process.env.MAKA_CU_AX_MODEL_LAB_ROOT ??
-  '/Users/haoqing/Documents/Learning/codex-computer-use-lab';
+const labRoot = process.env.MAKA_CU_AX_MODEL_LAB_ROOT;
+if (!labRoot) {
+  throw new Error(
+    'MAKA_CU_AX_MODEL_LAB_ROOT is required: point it at a local checkout of the Codex CUA Lab fixture',
+  );
+}
 const statePath = join(labRoot, 'test-app/runtime/state.json');
 const fixtureBundleId = 'com.openai.codex.cualab';
 const expectedAppPath = join(labRoot, 'test-app/build/Codex CUA Lab.app');
@@ -115,9 +118,22 @@ async function waitForJson(path, label, timeoutMs = 15_000) {
 }
 
 function startMonitor(fixturePID) {
-  const child = spawn('swift', [monitorPath, '--concurrent-user', String(fixturePID)], {
-    stdio: ['ignore', 'pipe', 'pipe'],
-  });
+  const child = spawn(
+    'swift',
+    [
+      monitorPath,
+      '--concurrent-user',
+      String(fixturePID),
+      // The fixture must stay in the background for the whole run. `--concurrent-user`
+      // only catches the OOP host PID; denying the bundle covers every process the
+      // fixture owns, so a UI process stealing focus mid-run also fails the scenario.
+      '--deny-frontmost-bundle',
+      fixtureBundleId,
+    ],
+    {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
   let buffer = '';
   let stderr = '';
   let readyResolve;
@@ -194,11 +210,16 @@ function validateMonitorBaseline(baseline, fixturePID, label) {
   if (!Number.isFinite(baseline.physicalInputAge) || baseline.physicalInputAge < 0) {
     throw new Error(`${label} reported invalid physical input age`);
   }
-  if (baseline.bundleIdentifier !== fixtureBundleId) {
-    throw new Error(`${label} fixture bundle identity mismatch`);
+  // The fixture is launched with `open -n -g` precisely so that it never owns the
+  // foreground. Asserting that it stays in the background is what makes this an
+  // honest test of background execution: requiring the fixture to be frontmost
+  // would both contradict the launch mode and make the run depend on whatever
+  // else happens to be on the desktop.
+  if (baseline.bundleIdentifier === fixtureBundleId) {
+    throw new Error(`${label} fixture unexpectedly owns the frontmost application`);
   }
-  if (baseline.canonicalAppPath !== expectedAppPath) {
-    throw new Error(`${label} fixture app path mismatch`);
+  if (baseline.canonicalAppPath === expectedAppPath) {
+    throw new Error(`${label} fixture app path unexpectedly owns the frontmost application`);
   }
   if (baseline.frontmostPID === fixturePID) {
     throw new Error(`${label} synthetic fixture became frontmost`);

--- a/scripts/cu-real-ax-model-e2e.mjs
+++ b/scripts/cu-real-ax-model-e2e.mjs
@@ -398,14 +398,24 @@ const computerTool = {
     if (nextTotal > budget.total || nextActionCount > (budget.counts[action] ?? 0)) {
       rejectAttempt('action_budget_exceeded', 'AX-only scenario action budget exceeded');
     }
-    if (
-      action === 'observe' &&
-      (args.app !== fixture.appId || args.window_id !== fixtureWindowId)
-    ) {
-      rejectAttempt(
-        'target_mismatch',
-        'model observe target does not match the exact fixture identity',
-      );
+    if (action === 'observe') {
+      // The `computer` tool contract is "observe requires app OR window_id", so a
+      // model that supplies only one of them is behaving correctly. Requiring both
+      // would fail every compliant model before it ever reaches a dispatch. Assert
+      // the real invariant instead: whatever the model did supply must identify the
+      // fixture, and must not point at any other target.
+      const appProvided = args.app !== undefined;
+      const windowProvided = args.window_id !== undefined;
+      const appMatches = args.app === fixture.appId;
+      const windowMatches = args.window_id === fixtureWindowId;
+      const identifiesFixture = (appProvided && appMatches) || (windowProvided && windowMatches);
+      const contradictsFixture = (appProvided && !appMatches) || (windowProvided && !windowMatches);
+      if (!identifiesFixture || contradictsFixture) {
+        rejectAttempt(
+          'target_mismatch',
+          'model observe target does not match the exact fixture identity',
+        );
+      }
     }
     const actionStartedAt = Date.now();
     let result;


### PR DESCRIPTION
## Summary

The real AX model E2E (`appkit-ax-click`, `appkit-ax-multi-step`) could not be passed by any compliant model. Three assumptions in the harness and launcher contradicted either the tool contract or the behaviour under test.

## Problems

**1. The harness required both `app` and `window_id` for `observe`.**

The `computer` tool describes its own contract as *"observe/screenshot require app **or** window_id"*. A model that supplies only `app` is behaving correctly, but the harness rejected it:

```js
if (action === 'observe' && (args.app !== fixture.appId || args.window_id !== fixtureWindowId))
  rejectAttempt('target_mismatch', ...)
```

Observed with `claude-sonnet-5`: the model sent `{"action":"observe","app":"Codex CUA Lab"}` — `app` matched exactly — and was rejected because `window_id` was absent. It never reached a dispatch, so the run failed with `expected 1 model AX click dispatches, got 0`. `claude-opus-5` failed identically.

**2. The launcher required the fixture to be frontmost.**

The fixture is started with `CUA_LAB_BACKGROUND=1` → `open -n -g`, specifically so it does not take focus. The baseline check then asserted the frontmost application *was* the fixture. These cannot both hold on a desktop with any other window in front, and the assertion contradicts the background execution the scenario exists to verify. It also meant the most important property — that the agent does not steal focus — could not be asserted at all.

**3. The lab root defaulted to a hard-coded personal absolute path.**

`/Users/haoqing/Documents/Learning/codex-computer-use-lab`, which no longer exists.

## Changes

- `observe` now asserts the real invariant: whatever the model supplies must identify the fixture, and must not point at another target. Supplying one identifier is accepted; supplying a wrong one is still rejected.
- The baseline now asserts the fixture stays in the background, and the launcher passes `--deny-frontmost-bundle` (a flag the monitor already supported but nobody set) so focus theft by any fixture process fails the run mid-scenario, not just the OOP host PID.
- `MAKA_CU_AX_MODEL_LAB_ROOT` is now required, with an actionable error instead of a silent wrong default.

## Verification

Real desktop run, `claude-sonnet-5` via the anthropic provider, full launcher path:

```
status: pass                 scenarioId: appkit-ax-click
actionCount: 3               dispatchPathPassed: true
minimumActionsPassed: true   actionsWithinBudget: true
qualificationEligible: true

list_apps     -> success
observe       -> success   observationId bf9ff712-fd54-4dd3-8b6f-13b836665dc8
click_element -> success   sourceObservationId bf9ff712-... (same observation)

forbiddenEffects: { status: pass, violations: [] }
expectedState:    buttonClickCount -> actual 1
```

The fixture stayed in the background for the whole run (frontmost remained iTerm2), and the monitor's deny-frontmost check did not trigger.

Also confirmed independently of the model, by driving the backend directly: `observe` returned 67 elements including `{id:"4", role:"AXButton", label:"CUA Lab Primary Button"}`, and `click_element` returned `{"ok":true,"tier":"ax","evidence":{"path":"ax"}}` with `buttonClickCount` going 0 → 1. So the dispatch path was never the problem; only these assertions were.

Repository-wide Biome lint and format are clean for both files.
