### PR TITLE
ci: make Storybook smoke opt-in

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,24 +65,6 @@ jobs:
       # throw away this dist and rebuild every package a second time.
       - run: npm run test:dist
 
-  storybook-smoke:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '24'
-          cache: npm
-      - run: npm ci
-      - name: Build Storybook workspace dependency
-        run: npm --workspace @maka/core run build
-      - name: Install Chromium
-        run: npm exec -- playwright install --with-deps chromium
-      - name: Build Product Storybook
-        run: npm --workspace @maka/desktop run build-storybook
-      - name: Render Product Storybook manifest
-        run: npm --workspace @maka/desktop run smoke:storybook
-
   e2e:
     runs-on: ubuntu-latest
     steps:

--- a/apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts
@@ -39,10 +39,11 @@ function readTypescriptConfig(repoRoot: string, configPath: string) {
 }
 
 describe('Storybook baseline contract', () => {
-  it('keeps Storybook as renderer tooling, not part of mandatory build or test', () => {
+  it('keeps Storybook as renderer tooling, not part of mandatory build, test, or CI', () => {
     const rootPkg = readJson(join(REPO_ROOT, 'package.json'));
     const desktopPkg = readJson(join(REPO_ROOT, 'apps', 'desktop', 'package.json'));
     const desktopScripts = desktopPkg.scripts ?? {};
+    const ciWorkflow = readFileSync(join(REPO_ROOT, '.github', 'workflows', 'ci.yml'), 'utf8');
 
     assert.match(desktopScripts.storybook ?? '', /storybook dev\b/);
     assert.match(desktopScripts['build-storybook'] ?? '', /storybook build\b/);
@@ -55,6 +56,12 @@ describe('Storybook baseline contract', () => {
     })) {
       assert.doesNotMatch(script, /storybook/i, `${name} must not run Storybook yet`);
     }
+
+    assert.doesNotMatch(
+      ciWorkflow,
+      /\bstorybook-smoke:|build-storybook|smoke:storybook/,
+      'default CI must keep the Product Storybook smoke opt-in',
+    );
   });
 
   it('uses the renderer Vite/CSS setup so stories render against the app substrate', () => {

--- a/scripts/storybook-visual-smoke.test.mjs
+++ b/scripts/storybook-visual-smoke.test.mjs
@@ -139,19 +139,6 @@ describe('Product Storybook coverage manifest', () => {
 
     assert.equal(validateCoverageManifest(manifest, STORY_INDEX).length, 15);
   });
-
-  it('keeps CI self-contained with the core build and Chromium installation', async () => {
-    const workflow = await readFile('.github/workflows/ci.yml', 'utf8');
-    const job = workflow.slice(workflow.indexOf('  storybook-smoke:'), workflow.indexOf('  e2e:'));
-
-    assert.match(job, /npm --workspace @maka\/core run build/);
-    assert.match(job, /playwright install --with-deps chromium/);
-    assert.ok(
-      job.indexOf('npm --workspace @maka/core run build') <
-        job.indexOf('npm --workspace @maka/desktop run build-storybook'),
-      'the clean Storybook job must build @maka/core before Storybook',
-    );
-  });
 });
 
 class FakePage extends EventEmitter {


### PR DESCRIPTION
## Summary

Remove the standalone Storybook smoke job from mandatory CI because its full install, Chromium setup, and Storybook build cost is disproportionate for an optional visual-audit tool.

Keep the Product Storybook manifest, smoke runner, and behavior tests available for local or on-demand visual review. Extend the existing Storybook baseline contract so default build, test, and CI paths remain free of Storybook execution.

## Verification

- `npm run build:test`
- `npm run test:scripts` (130 tests passed)
- `npm --workspace @maka/desktop run typecheck`
- `npm run lint`
- `npm run format:check`
- `node --test apps/desktop/dist/main/__tests__/storybook-baseline-contract.test.js` (20 tests passed)