### PR TITLE
fix: preserve provider proxy base paths

### DIFF
--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -608,7 +608,7 @@ describe('createHarborTaskRunner', () => {
       assert.equal(harborEnv?.ZAI_API_KEY_FILE, undefined);
       assert.match(
         harborEnv?.MAKA_PROVIDER_PROXY_URL ?? '',
-        /^http:\/\/host\.docker\.internal:\d+$/,
+        /^http:\/\/host\.docker\.internal:\d+\/api\/coding\/paas\/v4$/,
       );
       assert.match(harborEnv?.MAKA_PROVIDER_PROXY_TOKEN ?? '', /^[a-f0-9]{64}$/);
       assert.notEqual(harborEnv?.MAKA_PROVIDER_PROXY_TOKEN, keyFile);
@@ -648,7 +648,7 @@ describe('createHarborTaskRunner', () => {
 
       assert.match(
         harborEnv?.MAKA_PROVIDER_PROXY_URL ?? '',
-        /^http:\/\/host\.docker\.internal:\d+$/,
+        /^http:\/\/host\.docker\.internal:\d+\/v1$/,
       );
       assert.match(harborEnv?.MAKA_PROVIDER_PROXY_TOKEN ?? '', /^[a-f0-9]{64}$/);
       assert.equal(harborEnv?.OPENAI_API_KEY, undefined);
@@ -773,8 +773,10 @@ describe('createHarborTaskRunner', () => {
   test('selects Anthropic x-api-key auth for the OpenCode Kimi Coding Plan proxy', async () => {
     await withRun(async ({ jobsDir, repo, keyFile }) => {
       let upstreamApiKey = '';
+      let upstreamPath = '';
       const upstream = createServer((request, response) => {
         upstreamApiKey = String(request.headers['x-api-key'] ?? '');
+        upstreamPath = request.url ?? '';
         response.writeHead(200).end('ok');
       });
       await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
@@ -811,6 +813,7 @@ describe('createHarborTaskRunner', () => {
 
         await runner(runInput());
         assert.equal(upstreamApiKey, 'sk-secret');
+        assert.equal(upstreamPath, '/coding/v1/messages');
       } finally {
         await new Promise<void>((resolve, reject) =>
           upstream.close((error) => (error ? reject(error) : resolve())),
@@ -822,8 +825,10 @@ describe('createHarborTaskRunner', () => {
   test('gives Kimi Code bearer auth and fills missing cell usage from the provider stream', async () => {
     await withRun(async ({ jobsDir, repo, keyFile }) => {
       let upstreamAuthorization = '';
+      let upstreamPath = '';
       const upstream = createServer((request, response) => {
         upstreamAuthorization = request.headers.authorization ?? '';
+        upstreamPath = request.url ?? '';
         response.writeHead(200, { 'content-type': 'text/event-stream' });
         response.end(
           [
@@ -878,6 +883,7 @@ describe('createHarborTaskRunner', () => {
 
         const output = await runner(runInput());
         assert.equal(upstreamAuthorization, 'Bearer sk-secret');
+        assert.equal(upstreamPath, '/coding/v1/chat/completions');
         assert.deepEqual(output.cell.tokenSummary, {
           input: 100,
           output: 25,

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -1089,7 +1089,7 @@ test('createPierTaskRunner wires the Kimi arm through the host proxy on a Squid-
     // never argv.
     assert.match(
       captured.envFile?.MAKA_PROVIDER_PROXY_URL ?? '',
-      /^http:\/\/host\.docker\.internal:\d+$/,
+      /^http:\/\/host\.docker\.internal:\d+\/coding\/v1$/,
     );
     assert.ok((captured.envFile?.MAKA_PROVIDER_PROXY_TOKEN ?? '').length >= 32);
     assert.notEqual(captured.envFile?.MAKA_PROVIDER_PROXY_TOKEN, 'upstream-key');
@@ -1124,7 +1124,10 @@ test('createPierTaskRunner overrides the Kimi proxy advertised host for native L
       }),
     );
     await runner(runInput());
-    assert.match(captured.envFile?.MAKA_PROVIDER_PROXY_URL ?? '', /^http:\/\/172\.17\.0\.1:\d+$/);
+    assert.match(
+      captured.envFile?.MAKA_PROVIDER_PROXY_URL ?? '',
+      /^http:\/\/172\.17\.0\.1:\d+\/coding\/v1$/,
+    );
   });
 });
 
@@ -1286,7 +1289,7 @@ test('createPierTaskRunner wires the Codex arm through the host proxy with the p
     // env-file, never argv.
     assert.match(
       captured.envFile?.MAKA_PROVIDER_PROXY_URL ?? '',
-      /^http:\/\/host\.docker\.internal:\d+$/,
+      /^http:\/\/host\.docker\.internal:\d+\/backend-api\/codex$/,
     );
     assert.ok((captured.envFile?.MAKA_PROVIDER_PROXY_TOKEN ?? '').length >= 32);
     assert.notEqual(captured.envFile?.MAKA_PROVIDER_PROXY_TOKEN, 'upstream-key');
@@ -1322,7 +1325,10 @@ test('createPierTaskRunner routes a resolver-backed Maka arm through the host pr
     await runner(runInput());
     // The host cell dials the loopback proxy with a minted token, never the
     // upstream credential.
-    assert.match(captured.envFile?.MAKA_HOST_BASE_URL ?? '', /^http:\/\/127\.0\.0\.1:\d+$/);
+    assert.match(
+      captured.envFile?.MAKA_HOST_BASE_URL ?? '',
+      /^http:\/\/127\.0\.0\.1:\d+\/backend-api\/codex$/,
+    );
     assert.ok((captured.envFile?.MAKA_HOST_API_KEY ?? '').length >= 32);
     assert.notEqual(captured.envFile?.MAKA_HOST_API_KEY, 'upstream-key');
   });
@@ -1352,7 +1358,7 @@ test('createPierTaskRunner gives a Maka container task run a container-reachable
 
     assert.match(
       captured.envFile?.MAKA_PROVIDER_PROXY_URL ?? '',
-      /^http:\/\/host\.docker\.internal:\d+$/,
+      /^http:\/\/host\.docker\.internal:\d+\/backend-api\/codex$/,
     );
     assert.ok((captured.envFile?.MAKA_PROVIDER_PROXY_TOKEN ?? '').length >= 32);
     assert.notEqual(captured.envFile?.MAKA_PROVIDER_PROXY_TOKEN, 'upstream-key');

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { createServer } from 'node:http';
+import { createServer, request as httpRequest } from 'node:http';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -27,13 +27,14 @@ test('provider auth proxy keeps the provider key host-side', async () => {
   const keyFile = join(dir, 'provider-key');
   await writeFile(keyFile, `${providerKey}\n`, 'utf8');
   const proxy = await startProviderAuthProxy({
-    upstreamBaseUrl: `http://127.0.0.1:${address.port}/api/v4`,
+    upstreamBaseUrl: `http://127.0.0.1:${address.port}/api/v4/`,
     apiKeyFile: keyFile,
     advertisedHost: '127.0.0.1',
   });
 
   try {
     assert.notEqual(proxy.token, providerKey);
+    assert.equal(new URL(proxy.baseUrl).pathname, '/api/v4');
     const unauthorized = await fetch(`${proxy.baseUrl}/chat/completions`, {
       method: 'POST',
       body: '{}',
@@ -56,6 +57,73 @@ test('provider auth proxy keeps the provider key host-side', async () => {
       upstream.close((error) => (error ? reject(error) : resolve())),
     );
     await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test('provider auth proxy rejects requests outside the upstream base path before resolving credentials', async () => {
+  let credentialResolutions = 0;
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: 'http://127.0.0.1:1/coding/v1',
+    advertisedHost: '127.0.0.1',
+    resolveUpstreamCredential: async () => {
+      credentialResolutions += 1;
+      return { value: 'upstream-key' };
+    },
+  });
+
+  try {
+    for (const path of ['/other', '/coding/v10']) {
+      const response = await fetch(`${new URL(proxy.baseUrl).origin}${path}`, {
+        headers: { authorization: `Bearer ${proxy.token}` },
+      });
+      assert.equal(response.status, 404);
+    }
+    assert.equal(credentialResolutions, 0);
+  } finally {
+    await proxy.close();
+  }
+});
+
+test('provider auth proxy ignores an absolute-form origin while preserving its path and query', async () => {
+  let upstreamPath = '';
+  const upstream = createServer((request, response) => {
+    upstreamPath = request.url ?? '';
+    response.writeHead(200).end('ok');
+  });
+  await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const address = upstream.address();
+  assert.ok(address && typeof address !== 'string');
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: `http://127.0.0.1:${address.port}/coding/v1`,
+    advertisedHost: '127.0.0.1',
+    resolveUpstreamCredential: async () => ({ value: 'upstream-key' }),
+  });
+
+  try {
+    const proxyUrl = new URL(proxy.baseUrl);
+    const status = await new Promise<number>((resolve, reject) => {
+      const request = httpRequest(
+        {
+          hostname: proxyUrl.hostname,
+          port: proxyUrl.port,
+          path: 'http://attacker.invalid/coding/v1/models/a%2Fb?view=full',
+          headers: { authorization: `Bearer ${proxy.token}` },
+        },
+        (response) => {
+          response.resume();
+          response.once('end', () => resolve(response.statusCode ?? 0));
+        },
+      );
+      request.once('error', reject);
+      request.end();
+    });
+    assert.equal(status, 200);
+    assert.equal(upstreamPath, '/coding/v1/models/a%2Fb?view=full');
+  } finally {
+    await proxy.close();
+    await new Promise<void>((resolve, reject) =>
+      upstream.close((error) => (error ? reject(error) : resolve())),
+    );
   }
 });
 
@@ -108,10 +176,12 @@ test('provider auth proxy supports Anthropic x-api-key without replacing the cli
   let upstreamApiKey = '';
   let upstreamAuthorization = '';
   let upstreamUserAgent = '';
+  let upstreamPath = '';
   const upstream = createServer((request, response) => {
     upstreamApiKey = String(request.headers['x-api-key'] ?? '');
     upstreamAuthorization = request.headers.authorization ?? '';
     upstreamUserAgent = request.headers['user-agent'] ?? '';
+    upstreamPath = request.url ?? '';
     response.writeHead(200).end('ok');
   });
   await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
@@ -139,6 +209,8 @@ test('provider auth proxy supports Anthropic x-api-key without replacing the cli
     assert.equal(upstreamApiKey, providerKey);
     assert.equal(upstreamAuthorization, '');
     assert.equal(upstreamUserAgent, 'opencode/1.17.18 ai-sdk/6');
+    assert.equal(upstreamPath, '/coding/v1/messages');
+    assert.equal(proxy.telemetry()[0]?.path, '/coding/v1/messages');
   } finally {
     await proxy.close();
     await new Promise<void>((resolve, reject) =>
@@ -626,7 +698,7 @@ test('provider auth proxy binds a caller-specified port', async () => {
     port,
   });
   try {
-    assert.equal(proxy.baseUrl, `http://host.docker.internal:${port}`);
+    assert.equal(proxy.baseUrl, `http://host.docker.internal:${port}/api`);
   } finally {
     await proxy.close();
     await rm(dir, { recursive: true, force: true });

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -165,6 +165,7 @@ export async function startProviderAuthProxy(
       `provider auth proxy requires an HTTP(S) upstream: ${upstreamBaseUrl.protocol}`,
     );
   }
+  const upstreamBasePath = normalizeProxyBasePath(upstreamBaseUrl.pathname);
   const resolveUpstreamCredential =
     input.resolveUpstreamCredential ??
     (async () => {
@@ -193,6 +194,7 @@ export async function startProviderAuthProxy(
       request,
       response,
       upstreamBaseUrl,
+      upstreamBasePath,
       resolveUpstreamCredential,
       token,
       authMode,
@@ -221,7 +223,9 @@ export async function startProviderAuthProxy(
   }
   const advertisedHost = input.advertisedHost ?? 'host.docker.internal';
   return {
-    baseUrl: `http://${advertisedHost}:${address.port}`,
+    // Keep the provider's mount path in the client-visible base URL; the proxy
+    // changes authority, while the client remains the sole owner of path joins.
+    baseUrl: `http://${advertisedHost}:${address.port}${upstreamBasePath}`,
     token,
     usage: () => usage.snapshot(),
     telemetry: () => telemetry.snapshot(),
@@ -242,6 +246,7 @@ async function forwardProviderRequest(input: {
   request: IncomingMessage;
   response: ServerResponse;
   upstreamBaseUrl: URL;
+  upstreamBasePath: string;
   resolveUpstreamCredential: ProviderUpstreamCredentialResolver;
   token: string;
   authMode: ProviderAuthProxyMode;
@@ -263,6 +268,11 @@ async function forwardProviderRequest(input: {
     }
     const startedAt = input.now();
     const incomingUrl = new URL(input.request.url ?? '/', 'http://provider-proxy');
+    // A proxy token is scoped to this provider mount, not its entire origin.
+    if (!pathIsWithinBasePath(incomingUrl.pathname, input.upstreamBasePath)) {
+      input.response.writeHead(404).end('not found');
+      return;
+    }
     requestTelemetry = input.telemetry.start({
       method: input.request.method ?? 'GET',
       path: incomingUrl.pathname,
@@ -274,7 +284,7 @@ async function forwardProviderRequest(input: {
       throw new Error('provider credential resolver returned an empty value');
     }
     const upstreamUrl = new URL(input.upstreamBaseUrl);
-    upstreamUrl.pathname = `${upstreamUrl.pathname.replace(/\/$/, '')}/${incomingUrl.pathname.replace(/^\//, '')}`;
+    upstreamUrl.pathname = incomingUrl.pathname;
     upstreamUrl.search = incomingUrl.search;
     const headers = new Headers();
     for (const [name, value] of Object.entries(input.request.headers)) {
@@ -367,6 +377,14 @@ async function forwardProviderRequest(input: {
     if (!input.response.headersSent) input.response.writeHead(502);
     input.response.end('provider proxy request failed');
   }
+}
+
+function normalizeProxyBasePath(pathname: string): string {
+  return pathname === '/' ? '' : pathname.replace(/\/+$/, '');
+}
+
+function pathIsWithinBasePath(pathname: string, basePath: string): boolean {
+  return basePath === '' || pathname === basePath || pathname.startsWith(`${basePath}/`);
 }
 
 class ProviderUsageAccumulator {


### PR DESCRIPTION
## Summary

- preserve the upstream mount path in the client-visible provider auth proxy URL
- forward the client pathname and query by substituting only the proxy authority, preventing Kimi Coding Plan from becoming `/coding/v1/v1/messages`
- reject authenticated requests outside the configured provider mount before resolving the real upstream credential
- update Harbor and Pier consumer contracts and add loopback coverage for Kimi Anthropic/OpenAI paths, trailing slashes, encoded paths, queries, and absolute-form request targets

## Verification

- `PATH=/opt/homebrew/opt/node@22/bin:/opt/homebrew/bin:/usr/bin:/bin npm --workspace @maka/headless test` — 1338 passed, 0 failed, 4 skipped
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- no real provider or paid model requests were run

## Root cause

The proxy advertised only its origin, so provider SDKs normalized and appended paths without seeing the upstream mount. The proxy then prefixed the upstream pathname again. That split path ownership between the client and proxy and produced doubled version segments for Kimi Coding Plan.

The new contract keeps path joining with the client: the proxy advertises the upstream pathname and replaces only the authority when forwarding. A mount-boundary check preserves the credential scope that the old prefixing behavior provided implicitly.
