### PR TITLE
fix(desktop): polish small form-row pages — Daily Review, Data, and About

### DIFF
--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -563,3 +563,55 @@ test('remote access prioritizes a configured channel that needs attention', asyn
     () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
   ).toBe(true);
 });
+
+/**
+ * #1362 — THE row-wrapping decision for the settings form-row pages. The
+ * `.settingsRows` card is an inline-size query container; below 460px of
+ * CARD width (not viewport width — the content column is narrower than the
+ * window by the nav sidebar) label/control rows stack vertically, and the
+ * proxy form grids collapse to one column. Switch rows are the exception:
+ * a ~40px switch always fits beside its label. Locks both directions so
+ * neither the narrow stacking nor the wide two-column layout regresses.
+ */
+test('general form rows stack at the window floor and stay two-column when wide', async ({ window: page }) => {
+  await page.setViewportSize({ width: 1280, height: 900 });
+  const settings = await openSettings(page);
+  await settings.getByRole('button', { name: '通用', exact: true }).click();
+
+  const displayNameRow = settings
+    .locator('.settingsFormRow')
+    .filter({ has: page.getByLabel('显示名称') });
+  const incognitoRow = settings.locator('.settingsFormRow').filter({ hasText: '隐身模式' });
+  const modelRow = settings.locator('.settingsRow').filter({ hasText: '默认模型' });
+  const rowTrackCount = () =>
+    modelRow.evaluate(
+      (element) => getComputedStyle(element).gridTemplateColumns.trim().split(/\s+/).length,
+    );
+
+  // Wide: unchanged layout — label and control share one line.
+  await expect(displayNameRow).toHaveCSS('flex-direction', 'row');
+  await expect.poll(rowTrackCount).toBe(2);
+
+  // Window floor: rows stack; switch rows keep the control beside the label.
+  await page.setViewportSize({ width: 480, height: 900 });
+  await expect(displayNameRow).toHaveCSS('flex-direction', 'column');
+  await expect(incognitoRow).toHaveCSS('flex-direction', 'row');
+  await expect.poll(rowTrackCount).toBe(1);
+
+  // The proxy sub-form only renders behind the switch; its 3-column grid
+  // (150px + 84px floors) was the widest thing on the page and must fold
+  // to one column on a narrow card.
+  await settings.getByRole('switch', { name: '启用代理服务器' }).click();
+  const proxyGrid = settings.locator('.settingsFormGridProxy');
+  await expect(proxyGrid).toBeVisible();
+  await expect.poll(
+    () =>
+      proxyGrid.evaluate(
+        (element) => getComputedStyle(element).gridTemplateColumns.trim().split(/\s+/).length,
+      ),
+  ).toBe(1);
+
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+});

--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -598,19 +598,54 @@ test('general form rows stack at the window floor and stay two-column when wide'
   await expect(incognitoRow).toHaveCSS('flex-direction', 'row');
   await expect.poll(rowTrackCount).toBe(1);
 
-  // The proxy sub-form only renders behind the switch; its 3-column grid
-  // (150px + 84px floors) was the widest thing on the page and must fold
-  // to one column on a narrow card.
+  // The proxy sub-form only renders behind the switches: the 3-column
+  // protocol/host/port grid (150px + 84px floors) was the widest thing on
+  // the page, and the auth username/password grid is the plain 2-column
+  // `.settingsFormGrid` — both must fold to one column on a narrow card
+  // (they are separate CSS selectors; either could regress alone).
   await settings.getByRole('switch', { name: '启用代理服务器' }).click();
-  const proxyGrid = settings.locator('.settingsFormGridProxy');
-  await expect(proxyGrid).toBeVisible();
+  await settings.getByRole('switch', { name: '启用代理认证' }).click();
+  const gridTrackCounts = () =>
+    settings
+      .locator('.settingsFormGrid')
+      .evaluateAll((elements) =>
+        elements.map(
+          (element) => getComputedStyle(element).gridTemplateColumns.trim().split(/\s+/).length,
+        ),
+      );
+  await expect(settings.locator('.settingsFormGridProxy')).toBeVisible();
+  // Both grids rendered (proxy + auth), each folded to one column.
+  await expect.poll(gridTrackCounts).toEqual([1, 1]);
+
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+});
+
+/**
+ * #1362 review follow-up: the user-facing result of the palette-label wrap —
+ * at the window floor the full name stays readable (the old nowrap+ellipsis
+ * cut "Catppuccin Mocha" to "Catppucc…" with no way to recover it).
+ */
+test('appearance palette names stay fully visible at the window floor', async ({
+  window: page,
+}) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  const settings = await openSettings(page);
+  await settings.getByRole('button', { name: '外观', exact: true }).click();
+
+  const label = settings
+    .locator('.settingsThemeLabel strong')
+    .filter({ hasText: 'Catppuccin Mocha' });
+  await expect(label).toBeVisible();
+  // Wrapping, not clipping: nothing hides past the box in either axis.
   await expect.poll(
     () =>
-      proxyGrid.evaluate(
-        (element) => getComputedStyle(element).gridTemplateColumns.trim().split(/\s+/).length,
-      ),
-  ).toBe(1);
-
+      label.evaluate((element) => ({
+        horizontallyContained: element.scrollWidth <= element.clientWidth,
+        verticallyContained: element.scrollHeight <= element.clientHeight,
+      })),
+  ).toEqual({ horizontallyContained: true, verticallyContained: true });
   await expect.poll(
     () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
   ).toBe(true);

--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -668,6 +668,11 @@ test('data, about, and daily review stay contained at the window floor', async (
   const strategy = settings.locator('.settingsConfigStrategy');
   await expect(strategy).toBeVisible();
   await expect(strategy).toHaveCSS('flex-wrap', 'wrap');
+  // The section itself, not just the page: the page-level assertion below
+  // passes even when a child overflows into clipped space (#1363 review).
+  await expect.poll(
+    () => strategy.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
   const workspaceValue = settings.locator('.settingsRow span[data-mono="true"]').first();
   await expect(workspaceValue).toBeVisible();
   await expect.poll(
@@ -685,6 +690,75 @@ test('data, about, and daily review stay contained at the window floor', async (
 
   await settings.getByRole('button', { name: '每日回顾', exact: true }).click();
   await expect(settings.locator('.settingsFeatureStatusPage')).toBeVisible();
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+});
+
+/**
+ * #1363 review: the English strategy label ("Connections with the same
+ * name:") is wider than the 480px floor's content column — with the old
+ * `white-space: nowrap` the section overflowed into clipped space that the
+ * page-level containment assertion could not see. The label wraps now.
+ */
+test('data config strategy stays contained at the window floor in English', async ({
+  enLocaleWindow: page,
+}) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  await page.getByRole('button', { name: 'Expand sidebar' }).click();
+  await page.getByRole('button', { name: 'Settings' }).click();
+  const settings = page.getByRole('main', { name: 'Settings content' });
+  await settings.getByRole('button', { name: 'Data', exact: true }).click();
+
+  const strategy = settings.locator('.settingsConfigStrategy');
+  await expect(strategy).toBeVisible();
+  await expect.poll(
+    () =>
+      strategy.evaluate((element) => ({
+        sectionContained: element.scrollWidth <= element.clientWidth,
+        labelWraps:
+          getComputedStyle(element.querySelector('.settingsHelpText')!).whiteSpace !== 'nowrap',
+      })),
+  ).toEqual({ sectionContained: true, labelWraps: true });
+});
+
+/**
+ * #1363 review: a switch row whose control side is MORE than a bare switch
+ * (Memory's label + status Chip + switch) must stack on a narrow card — the
+ * horizontal exception used to hold it to a 15px label with char-per-line
+ * help text. The chip + switch travel as one cluster.
+ */
+test('memory status row stacks at the window floor', async ({ window: page }) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  const settings = await openSettings(page);
+  await settings.getByRole('button', { name: '记忆', exact: true }).click();
+
+  const statusRow = settings.locator('.settingsFormRow').filter({ hasText: '本地 MEMORY.md' });
+  await expect(statusRow).toBeVisible();
+  await expect(statusRow).toHaveCSS('flex-direction', 'column');
+  await expect.poll(
+    () =>
+      statusRow.evaluate((element) => {
+        const label = element.querySelector('div');
+        const cluster = element.querySelector('.settingsFormRowControlCluster');
+        const rowStyle = getComputedStyle(element);
+        const contentWidth =
+          element.clientWidth -
+          Number.parseFloat(rowStyle.paddingLeft) -
+          Number.parseFloat(rowStyle.paddingRight);
+        return {
+          // The label owns the full card width when stacked — not a sliver.
+          labelUsesFullRow: !!label && label.clientWidth >= contentWidth - 1,
+          clusterContained: !!cluster && cluster.scrollWidth <= cluster.clientWidth,
+          rowContained: element.scrollWidth <= element.clientWidth,
+        };
+      }),
+  ).toEqual({ labelUsesFullRow: true, clusterContained: true, rowContained: true });
+
+  // The whole page now: #1364 deliberately asserted Memory per-surface only,
+  // because its rows overflowed through the shared settings-rows primitive.
+  // With the stacking mechanism plus the entry-list/preview/backup track
+  // fixes there is no routed-out overflow left to carve around.
   await expect.poll(
     () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
   ).toBe(true);

--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -650,3 +650,42 @@ test('appearance palette names stay fully visible at the window floor', async ({
     () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
   ).toBe(true);
 });
+
+/**
+ * #1363 — the three small form-row pages at the window floor. Daily Review
+ * and About are covered by the #1362 row-stacking mechanism; the Data page
+ * adds two page-owned surfaces: the config strategy row (nowrap label +
+ * select, one-line minimum wider than the floor column) now wraps, and the
+ * workspace path renders as a wrapping mono value.
+ */
+test('data, about, and daily review stay contained at the window floor', async ({
+  window: page,
+}) => {
+  await page.setViewportSize({ width: 480, height: 900 });
+  const settings = await openSettings(page);
+
+  await settings.getByRole('button', { name: '数据', exact: true }).click();
+  const strategy = settings.locator('.settingsConfigStrategy');
+  await expect(strategy).toBeVisible();
+  await expect(strategy).toHaveCSS('flex-wrap', 'wrap');
+  const workspaceValue = settings.locator('.settingsRow span[data-mono="true"]').first();
+  await expect(workspaceValue).toBeVisible();
+  await expect.poll(
+    () => workspaceValue.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+
+  await settings.getByRole('button', { name: '关于', exact: true }).click();
+  await expect(settings.locator('.settingsAboutPage')).toBeVisible();
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+
+  await settings.getByRole('button', { name: '每日回顾', exact: true }).click();
+  await expect(settings.locator('.settingsFeatureStatusPage')).toBeVisible();
+  await expect.poll(
+    () => settings.evaluate((element) => element.scrollWidth <= element.clientWidth),
+  ).toBe(true);
+});

--- a/apps/desktop/src/main/__tests__/responsive-breakpoint-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/responsive-breakpoint-contract.test.ts
@@ -41,6 +41,15 @@ import {
  *  breakpoint must be added here (and the value used in the CSS). */
 const ALLOWED_BREAKPOINT_PX = new Set([620, 720, 760, 820, 900, 980, 990, 1100]);
 
+/** #1362: same governance for @container width queries. Container queries
+ *  respond to an element's own width instead of the viewport (the settings
+ *  content column is narrower than the window by the nav sidebar, so
+ *  viewport breakpoints systematically misfire there — the #1361/#1364
+ *  lesson). The app keeps ONE container width: 460px, shared by the
+ *  permission dialog and the settings rows card. A second value must be a
+ *  conscious decision here, exactly like the @media whitelist above. */
+const ALLOWED_CONTAINER_PX = new Set([460]);
+
 // --- @media breakpoint whitelist ------------------------------------------
 
 /** Match `@media (max-width: Npx)` / `@media (min-width: Npx)` and capture N.
@@ -54,6 +63,25 @@ function findBreakpointOffenders(css: string, label: string): string[] {
     const px = Number(m[2]);
     if (!ALLOWED_BREAKPOINT_PX.has(px)) {
       offenders.push(`${label}: ${m[0]} [${px}px not in the breakpoint whitelist ${[...ALLOWED_BREAKPOINT_PX].join('/')}px]`);
+    }
+  }
+  return offenders;
+}
+
+// --- @container width whitelist --------------------------------------------
+
+/** Match `@container [name] (max-width: Npx)` / `(min-width: Npx)` and
+ *  capture N. Non-width container features (e.g. scroll-state) are out of
+ *  scope. */
+const CONTAINER_WIDTH_RE = /@container\s+[^{(]*\(\s*(max|min)-width\s*:\s*(\d+(?:\.\d+)?)px\s*\)/g;
+
+function findContainerWidthOffenders(css: string, label: string): string[] {
+  const stripped = stripCssComments(css);
+  const offenders: string[] = [];
+  for (const m of stripped.matchAll(CONTAINER_WIDTH_RE)) {
+    const px = Number(m[2]);
+    if (!ALLOWED_CONTAINER_PX.has(px)) {
+      offenders.push(`${label}: ${m[0]} [${px}px not in the container-width whitelist ${[...ALLOWED_CONTAINER_PX].join('/')}px]`);
     }
   }
   return offenders;
@@ -89,6 +117,12 @@ describe('PR-RESPONSIVE-BREAKPOINT-CONVERGE-0 contract', () => {
     assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
   });
 
+  it('@container (max/min-width: Npx) uses only the whitelisted container widths (no ad-hoc Npx)', async () => {
+    const css = await readAllRendererCss();
+    const offenders = findContainerWidthOffenders(css, 'renderer CSS');
+    assert.deepEqual(offenders, [], `Offenders:\n  ${offenders.join('\n  ')}`);
+  });
+
   it('--maka-chat-measure is pinned to 680px exactly-once in maka-tokens.css', async () => {
     const tokens = await readFile(TOKENS_FILE, 'utf8');
     assertCustomPropPinnedOnce(tokens, '--maka-chat-measure', '680px', 'maka-tokens.css');
@@ -121,6 +155,15 @@ describe('responsive breakpoint whitelist negative cases', () => {
   it('does not flag prefers-reduced-motion / prefers-color-scheme (not width breakpoints)', () => {
     const css = '@media (prefers-reduced-motion: reduce) { … } @media (prefers-color-scheme: dark) { … }';
     assert.deepEqual(findBreakpointOffenders(css, 't'), [], 'prefers-* queries are out of scope');
+  });
+
+  it('findContainerWidthOffenders flags a value outside the whitelist and spares 460 + non-width features', () => {
+    const ok = '@container (max-width: 460px) { … } @container settings-rows (max-width: 460px) { … }';
+    assert.deepEqual(findContainerWidthOffenders(ok, 't'), [], '460px (unnamed and named) must pass');
+    const bad = '@container (max-width: 540px) { … } @container card (min-width: 400px) { … }';
+    assert.ok(findContainerWidthOffenders(bad, 't').length === 2, '540px and 400px must fail (not whitelisted)');
+    const scrollState = '@container not scroll-state(scrollable: bottom) { … }';
+    assert.deepEqual(findContainerWidthOffenders(scrollState, 't'), [], 'scroll-state containers are not width breakpoints');
   });
 
   it('findChatMeasureOffenders flags a bare 680px width but spares var(--maka-chat-measure) and a 680px height', () => {

--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -72,9 +72,15 @@ describe('Settings form accessibility labels', () => {
     const providerCatalogBadge = styles.match(/\.providerCatalogBadge\s*\{[\s\S]*?\}/)?.[0] ?? '';
     const modelChoiceList = styles.match(/\.providerModelChoiceList\s*\{[\s\S]*?\}/)?.[0] ?? '';
     const modelChoiceScroll = styles.match(/\.providerModelChoiceScroll\s*\{[\s\S]*?\}/)?.[0] ?? '';
-    const settingsRow = styles.match(/\.settingsRow\s*\{[\s\S]*?\}/g)?.at(-1) ?? '';
+    // #1362: TWO .settingsRow rules exist now — the base label/value grid
+    // and the narrow-card stacking override inside the @container block.
+    // The base rule is the one that declares its own display.
+    const settingsRowRules = styles.match(/\.settingsRow\s*\{[\s\S]*?\}/g) ?? [];
+    const settingsRow = settingsRowRules.find((rule) => /display:\s*grid;/.test(rule)) ?? '';
+    const settingsRowStacked = settingsRowRules.find((rule) => !/display:/.test(rule)) ?? '';
     const settingsRowValue = styles.match(/\.settingsRow > span\s*\{[\s\S]*?\}/)?.[0] ?? '';
-    const settingsRowTitle = styles.match(/\.settingsRow strong\s*\{[\s\S]*?\}/)?.[0] ?? '';
+    // #1362: the title tier is one comma-grouped rule for both row kinds.
+    const settingsRowTitle = styles.match(/\.settingsRow strong,\s*\.settingsFormRow strong\s*\{[\s\S]*?\}/)?.[0] ?? '';
 
     assert.match(connectionRow, /border-radius:\s*var\(--radius-surface\);/, 'Settings connection cards should use reference implementation rounded-lg geometry');
     assert.match(connectionRow, /box-shadow:\s*0 1px 3px oklch\(from var\(--foreground\) l c h \/ 0\.03\);/, 'Settings connection cards should use the near-flat card shadow (P-SHADOW: foreground-derived, not pure-black)');
@@ -101,7 +107,15 @@ describe('Settings form accessibility labels', () => {
     assert.match(settingsRow, /grid-template-columns:\s*minmax\(150px,\s*0\.36fr\)\s+minmax\(0,\s*1fr\);/, 'Settings rows need a protected label column and shrinkable value column');
     assert.match(settingsRowValue, /overflow-wrap:\s*anywhere;/, 'Long Settings values such as workspace paths should wrap in the value column');
     assert.match(settingsRowValue, /text-align:\s*right;/, 'Short Settings values should keep the existing right-aligned summary rhythm');
-    assert.match(settingsRowTitle, /white-space:\s*nowrap;/, 'Settings row labels must not collapse to one Chinese character per line');
+    // #1362: the old `white-space: nowrap` title pin protected labels from
+    // collapsing to one Chinese character per line, but it did so by letting
+    // long titles BLEED over the value column instead. The protection is now
+    // structural — the 150px label floor above, plus the narrow-card override
+    // that stacks the row so the label gets the full card width. Titles wrap
+    // as a last resort instead of overflowing the card.
+    assert.match(settingsRowStacked, /grid-template-columns:\s*minmax\(0,\s*1fr\);/, 'Narrow cards must stack Settings rows so labels keep a full-width line, not char-per-line slivers');
+    assert.match(settingsRowTitle, /overflow-wrap:\s*anywhere;/, 'Settings row titles need a last-resort break for unbreakable runs on a squeezed label column');
+    assert.doesNotMatch(settingsRowTitle, /white-space:\s*nowrap;/, 'Settings row titles must wrap inside their column instead of bleeding over the value column');
   });
 
   it('keeps migrated Settings text fields and action buttons on shared UI primitives', async () => {

--- a/apps/desktop/src/main/__tests__/settings-theme-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-theme-contract.test.ts
@@ -196,10 +196,20 @@ describe('Settings theme page contract', () => {
       /settingsThemePreviewPane[\s\S]{0,260}oklch\([^)]*75\)/,
       'Theme preview tiles must not keep the old warm parchment hue after the gray-shell baseline',
     );
+    // #1362: palette names WRAP inside their cards instead of truncating —
+    // at the 480px window floor the old nowrap+ellipsis cut "Catppuccin
+    // Mocha" to "Catppucc…" with no way to recover the name. Scoped to the
+    // rule body ([^}]*, not [\s\S]*): the previous pattern crossed the
+    // closing brace and matched declarations in later, unrelated rules.
     assert.match(
       css,
-      /\.settingsThemeLabel strong \{[\s\S]*overflow:\s*hidden;[\s\S]*text-overflow:\s*ellipsis;[\s\S]*white-space:\s*nowrap;/,
-      'Long palette names must stay inside their option cards',
+      /\.settingsThemeLabel strong \{[^}]*overflow-wrap:\s*anywhere;/,
+      'Long palette names must wrap inside their option cards',
+    );
+    assert.doesNotMatch(
+      css,
+      /\.settingsThemeLabel strong \{[^}]*text-overflow:\s*ellipsis;/,
+      'Palette names must not regress to nowrap+ellipsis truncation (#1362)',
     );
   });
 });

--- a/apps/desktop/src/renderer/settings/memory-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/memory-settings-page.tsx
@@ -88,15 +88,21 @@ export function MemorySettingsPage(props: {
             <strong>{copy.text.localFile}</strong>
             <small>{copy.text.localFileHelp}</small>
           </div>
-          <Chip variant={memoryStatusTone(effective.status)}>
-            {memoryStatusLabel(effective.status, copy)}
-          </Chip>
-          <Switch
-            ariaLabel={copy.text.enableLocalFile}
-            checked={effective.enabled}
-            disabled={memoryControlsDisabled}
-            onChange={(enabled) => void setEnabled(enabled)}
-          />
+          {/* #1363 review: one control cluster, not two loose siblings — on a
+              narrow card the row stacks and the chip + switch stay on one
+              line together instead of holding the row horizontal and
+              crushing the label. */}
+          <span className="settingsFormRowControlCluster">
+            <Chip variant={memoryStatusTone(effective.status)}>
+              {memoryStatusLabel(effective.status, copy)}
+            </Chip>
+            <Switch
+              ariaLabel={copy.text.enableLocalFile}
+              checked={effective.enabled}
+              disabled={memoryControlsDisabled}
+              onChange={(enabled) => void setEnabled(enabled)}
+            />
+          </span>
         </div>
 
         <div className="settingsFormRow">

--- a/apps/desktop/src/renderer/styles/settings/about.css
+++ b/apps/desktop/src/renderer/styles/settings/about.css
@@ -2,6 +2,9 @@
 .settingsAboutPage {
   display: grid;
   align-content: start;
+  /* #1363: same explicit column as .settingsStructuredPage (#1362) — stop
+     intrinsic max-content propagation through the implicit `auto` track. */
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--space-4);
 }
 
@@ -102,6 +105,12 @@
   align-items: flex-start;
 }
 
+/* #1363: the label stack is a flex item — without min-width:0 its widest
+   unbreakable run sets the row minimum instead of wrapping. */
+.settingsConfigCategoryItem > span {
+  min-width: 0;
+}
+
 .settingsConfigCategoryItem small {
   display: block;
   color: var(--muted-foreground);
@@ -115,6 +124,10 @@
 .settingsConfigStrategy {
   display: flex;
   align-items: center;
+  /* #1363: the nowrap label + select trigger have a one-line minimum wider
+     than the 480px window floor's content column — the select drops to its
+     own line instead of dragging the section into overflow. */
+  flex-wrap: wrap;
   gap: var(--space-2);
   margin-top: var(--space-2-5);
 }

--- a/apps/desktop/src/renderer/styles/settings/about.css
+++ b/apps/desktop/src/renderer/styles/settings/about.css
@@ -132,7 +132,8 @@
   margin-top: var(--space-2-5);
 }
 
-.settingsConfigStrategy > .settingsHelpText {
-  white-space: nowrap;
-}
+/* #1363 review: no nowrap on the strategy label — the English copy
+   ("Connections with the same name:") is wider than the 480px floor's
+   content column and dragged the section into clipped overflow. On wide
+   layouts the label fits one line either way. */
 

--- a/apps/desktop/src/renderer/styles/settings/memory.css
+++ b/apps/desktop/src/renderer/styles/settings/memory.css
@@ -7,6 +7,10 @@
    ──────────────────────────────────────────────────────────────── */
 .settingsMemoryPreview {
     display: grid;
+    /* #1363 review follow-up: explicit column — the implicit auto track
+       sized to the reused .settingsConnectionMeta row's intrinsic width
+       (~247px) and pushed the card past the 480px floor's content column. */
+    grid-template-columns: minmax(0, 1fr);
     gap: var(--space-1);
     padding: var(--space-2-5) var(--space-3);
     border: var(--border-width-hairline) solid var(--foreground-10);
@@ -143,6 +147,8 @@
   }
 .settingsMemoryBackupList {
     display: grid;
+    /* #1363 review follow-up: same explicit column as the preview card. */
+    grid-template-columns: minmax(0, 1fr);
     gap: var(--space-1-5);
     padding: var(--space-2) var(--space-2-5);
     border: var(--border-width-hairline) solid var(--foreground-10);
@@ -178,6 +184,10 @@
 .settingsMemoryBackupCandidate {
     display: inline-flex;
     align-items: center;
+    /* #1363 review follow-up: text + three action buttons are ~218px
+       intrinsically — on the floor column the buttons flow to a second
+       line inside the pill instead of bleeding out of it. */
+    flex-wrap: wrap;
     gap: var(--space-1-5);
     padding: var(--space-0-5) var(--space-1-5);
     border: var(--border-width-hairline) solid var(--foreground-10);
@@ -236,6 +246,10 @@
     margin: 0;
     padding: 0;
     display: grid;
+    /* #1363 review follow-up: explicit column — the widest entry card's
+       intrinsic width (its nowrap actions row) sized the implicit track
+       past the 480px floor's content column. */
+    grid-template-columns: minmax(0, 1fr);
     gap: 0;
     border: var(--border-width-hairline) solid var(--foreground-10);
     border-radius: var(--radius-surface);
@@ -250,6 +264,10 @@
 
 .settingsMemoryEntryCard {
     display: grid;
+    /* #1363 review follow-up: third layer of the same implicit-track leak —
+       the card is a grid too, and its auto column sized to the widest
+       child instead of the list's column. */
+    grid-template-columns: minmax(0, 1fr);
     gap: var(--space-0-5);
     padding: var(--space-2) var(--space-3);
     border-bottom: var(--border-width-hairline) solid var(--foreground-8);
@@ -322,6 +340,9 @@
 .settingsMemoryEntryActions {
   display: flex;
   justify-content: flex-end;
+  /* #1363 review follow-up: four text buttons are ~190px on one line —
+     wider than the floor column, so they flow to a second line. */
+  flex-wrap: wrap;
 }
 
 .settingsMemoryFilter {
@@ -496,3 +517,14 @@
     white-space: nowrap;
     text-overflow: ellipsis;
   }
+
+/* #1363 review follow-up: scoped to the preview card — the shared
+   .settingsConnectionMeta stays nowrap on the wide connection cards, but
+   inside this card its two file-state clusters wrap on a narrow column. */
+.settingsMemoryPreview .settingsConnectionMeta {
+  flex-wrap: wrap;
+}
+
+.settingsMemoryBackupCandidate > span {
+  min-width: 0;
+}

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -506,6 +506,13 @@
 .settingsStructuredPage {
   display: grid;
   align-content: start;
+  /* #1362: explicit column. The implicit `auto` track sizes to the widest
+     child's max-content, so one wide child (a scrollable <pre>, a long mono
+     path) silently widened EVERY card on the page past the content column —
+     the same propagation #1364 fixed locally on .settingsUsagePage. With
+     minmax(0, 1fr) the track is the content column, and the .settingsRows
+     query containers below actually see narrow widths. */
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--space-4);
   background: transparent;
 }

--- a/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
+++ b/apps/desktop/src/renderer/styles/settings/nav-sidebar.css
@@ -238,6 +238,10 @@
 .settingsFeatureStatusPage {
   display: grid;
   align-content: start;
+  /* #1363: same explicit column as .settingsStructuredPage (#1362) — the
+     implicit `auto` track sizes to the widest child's max-content and lets
+     one wide child widen every card past the content column. */
+  grid-template-columns: minmax(0, 1fr);
   gap: var(--space-2-5);
 }
 

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -99,6 +99,21 @@
   min-width: 0;
 }
 
+/* #1363 review: a row whose control side is more than a bare switch (e.g.
+   Memory's status Chip + switch) groups them into one cluster, so the
+   stacked layout keeps them on one line together. The internal gap matches
+   the row gap, so the wide layout is pixel-identical to the former loose
+   siblings. */
+.settingsFormRowControlCluster {
+  display: inline-flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--space-5);
+  /* No min-width:0 here — the cluster's floor is its widest nowrap chip;
+     shrinking below that bleeds the chip out of the box. The LABEL side
+     owns the squeeze (it has min-width:0 and wraps). */
+}
+
 /* Detail audit round 3: vertical variant for full-width controls (the
    personalization tone textarea) living inside the shared card rows. */
 .settingsFormRow[data-orient="vertical"] {
@@ -349,7 +364,13 @@
     row-gap: var(--space-2-5);
   }
 
-  .settingsRow:has(> [role="switch"]) {
+  /* #1363 review: the exception applies only when the switch is the row's
+     ONLY control (label + switch, nothing else). A three-part row — e.g.
+     Memory's label + status Chip + switch — held horizontal would crush
+     the label to a char-per-line sliver, so it stacks like any other row.
+     `:not(input)` spares Base UI Switch's hidden sibling checkbox, which
+     is a real third child on every switch row. */
+  .settingsRow:has(> [role="switch"]):not(:has(> :nth-child(3):not(input))) {
     grid-template-columns: minmax(0, 1fr) auto;
   }
 
@@ -371,7 +392,7 @@
     gap: var(--space-2-5);
   }
 
-  .settingsFormRow:has(> [role="switch"]) {
+  .settingsFormRow:has(> [role="switch"]):not(:has(> :nth-child(3):not(input))) {
     flex-direction: row;
     align-items: center;
     gap: var(--space-5);

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -25,6 +25,13 @@
   gap: 0;
   border: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.08);
   overflow: hidden;
+  /* #1362: the card is the query container for the row-stacking rules at the
+     bottom of this file. Rows respond to the width the card actually has —
+     the settings content column is narrower than the window by the nav
+     sidebar, so viewport @media blocks systematically fire too late/early
+     (the #1361 540px and #1364 900px lessons). Same mechanism as the
+     permission dialog's inline-size container in permission-dialog.css. */
+  container: settings-rows / inline-size;
 }
 
 /* Label/value row: title + hint stack on the left, value or a single
@@ -85,6 +92,13 @@
   transition: background var(--duration-base) var(--ease-out-strong);
 }
 
+/* #1362: the label stack is a flex item; without min-width:0 its intrinsic
+   min-content (the widest unbreakable run) sets the row's minimum and the
+   card clips at narrow widths instead of letting the text wrap. */
+.settingsFormRow > div:first-child {
+  min-width: 0;
+}
+
 /* Detail audit round 3: vertical variant for full-width controls (the
    personalization tone textarea) living inside the shared card rows. */
 .settingsFormRow[data-orient="vertical"] {
@@ -107,7 +121,10 @@
 
 /* === typography ========================================================= */
 
-/* Row titles — one tier for BOTH row kinds. */
+/* Row titles — one tier for BOTH row kinds. No `white-space: nowrap` here:
+   the label column has a fixed 150px minimum, so a nowrap title longer than
+   the column bled into the value column instead of wrapping (#1362; the
+   nowrap never affected titles that fit). */
 .settingsRow strong,
 .settingsFormRow strong {
   display: block;
@@ -115,10 +132,10 @@
   font-size: var(--font-size-heading);
   font-weight: var(--font-weight-medium);
   line-height: var(--leading-snug);
-}
-
-.settingsRow strong {
-  white-space: nowrap;
+  /* Last resort for unbreakable runs (product names like "Claude", env-var
+     tokens) on a squeezed label column: break inside the word rather than
+     bleed past the card. No effect while the title fits. */
+  overflow-wrap: anywhere;
 }
 
 /* Field labels — one tier BELOW row titles so the proxy grid's 代理协议 /
@@ -142,6 +159,8 @@
   color: var(--muted-foreground);
   font-size: var(--font-size-base);
   line-height: var(--leading-normal);
+  /* Hints carry paths and URLs — same last-resort break as the titles. */
+  overflow-wrap: anywhere;
 }
 
 .settingsRow > span {
@@ -197,6 +216,28 @@
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: var(--space-3);
+}
+
+/* #1362: non-row children of a rows card — the proxy sub-form's grids,
+   bypass field, info alert, and action row — sat flush against the card
+   edge while every sibling row is inset 24px. One horizontal inset for
+   everything inside a card. */
+.settingsRows > .settingsFormGrid,
+.settingsRows > .settingsField,
+.settingsRows > .settingsActionRow,
+.settingsRows > [data-slot="alert"] {
+  margin: var(--space-4) var(--space-6);
+}
+
+/* The Alert primitive carries `w-full`; with horizontal margins that is
+   wider than the card. The stretched grid-item width (auto) is the right
+   one here. */
+.settingsRows > [data-slot="alert"] {
+  width: auto;
+}
+
+.settingsRows > .settingsFormGrid + .settingsFormRow {
+  border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.06);
 }
 
 .settingsFormGridProxy {
@@ -288,5 +329,66 @@
   .settingsField input,
   .settingsField textarea {
     transition: none !important;
+  }
+}
+
+/* === narrow-card row stacking (#1362) =================================== */
+
+/* THE row-wrapping decision for every form-row page (#1303 tracking):
+   below 460px of CARD width — not viewport width — label/control rows
+   stack vertically. 460px is the app's one container breakpoint (shared
+   with permission-dialog.css) and sits just above the widest one-line
+   row minimum (150px label floor + gap + a ~180px intrinsic-width input
+   + 48px row padding ≈ 394px), with margin for the select triggers'
+   320px cap to stay usable. Switch rows are the exception: a switch is
+   ~40px wide and always fits beside its label — stacking it reads as a
+   detached orphan, so those rows keep two columns and let the label wrap. */
+@container settings-rows (max-width: 460px) {
+  .settingsRow {
+    grid-template-columns: minmax(0, 1fr);
+    row-gap: var(--space-2-5);
+  }
+
+  .settingsRow:has(> [role="switch"]) {
+    grid-template-columns: minmax(0, 1fr) auto;
+  }
+
+  /* Values and controls sit under their label now; right-alignment against
+     the card edge would detach them from it. */
+  .settingsRow > span {
+    text-align: left;
+  }
+
+  .settingsRow[data-control-width="compact"] > input,
+  .settingsRow[data-control-width="compact"] > .settingsTimeInput,
+  .settingsRow[data-control-width="select"] > .settingsSelectTrigger {
+    justify-self: start;
+  }
+
+  .settingsFormRow {
+    flex-direction: column;
+    align-items: stretch;
+    gap: var(--space-2-5);
+  }
+
+  .settingsFormRow:has(> [role="switch"]) {
+    flex-direction: row;
+    align-items: center;
+    gap: var(--space-5);
+  }
+
+  .settingsFormGrid,
+  .settingsFormGridProxy {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  /* The Button primitive is `shrink-0` with a fixed height; on a squeezed
+     card an action button wider than the row would bleed past the card
+     edge. Let it shrink and let the label wrap, keeping the primitive's
+     32px as a floor. */
+  .settingsActionRow > [data-slot="button"] {
+    flex-shrink: 1;
+    height: auto;
+    min-height: 2rem;
   }
 }

--- a/apps/desktop/src/renderer/styles/settings/select.css
+++ b/apps/desktop/src/renderer/styles/settings/select.css
@@ -81,6 +81,16 @@
   line-height: var(--leading-snug);
 }
 
+/* #1362: inside the TRIGGER only (popup options keep their full label), a
+   selected label longer than the squeezed trigger ellipsizes instead of
+   bleeding past the button box. */
+.settingsSelectTrigger .settingsSelectMenuOption {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 /* Heading: same 13px as the rows; hierarchy comes from weight 500 + muted ink
    + the brand mark, not a different size or an uppercase eyebrow. The mark sits
    in the 1rem leading column so it lines up under each row's selected check. */

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -206,9 +206,12 @@
   color: var(--foreground);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-semibold);
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  /* #1362: palette names wrap instead of truncating — at the 480px window
+     floor the single-column tiles are ~74px of label and the old nowrap +
+     ellipsis cut "Catppuccin Mocha" to "Catppucc…" with no way to recover
+     the name. Every label fits one line on the wide 3-column grid, so this
+     only changes the squeezed state. */
+  overflow-wrap: anywhere;
 }
 
 .settingsThemeLabel small {

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -766,6 +766,49 @@ const withWebSearchConfiguredBridge = withScopedMakaBridge({
   },
 } satisfies Record<string, unknown>);
 
+/** #1362: the proxy form (protocol/host/port grid, auth grid, bypass field)
+ *  only renders behind two enabled switches — without this fixture no story
+ *  ever exercised `.settingsFormGridProxy` or the auth `.settingsFormGrid`.
+ *  Hostile widths: a long internal proxy hostname, a service-account
+ *  username, and identity fields with long CJK content. */
+const generalProxySettings = mergeSettings(createDefaultSettings(), {
+  network: {
+    proxy: {
+      enabled: true,
+      protocol: 'socks5',
+      host: 'corp-egress-gateway.ap-southeast-1.internal.example-infra.net',
+      port: 18080,
+      authEnabled: true,
+      username: 'svc-maka-desktop-proxy-rotation-2026',
+      password: 'storybook-proxy-password',
+      bypassList: [
+        'metaso.cn',
+        'baidu.com',
+        'artifact-registry.ap-southeast-1.internal.example-infra.net',
+        '*.observability.example-infra.net',
+      ],
+    },
+  },
+  personalization: {
+    displayName: '陆逊（基础设施与开发者体验平台组 · 桌面端）',
+    assistantTone:
+      '回答尽量简短，先给结论再给理由；涉及命令行操作时给出完整命令并注明工作目录；不确定的事情直接说不确定，不要编造。',
+  },
+});
+
+const withGeneralProxyBridge = withScopedMakaBridge({
+  ...makaBridge,
+  settings: {
+    ...makaBridge.settings,
+    get: async () => generalProxySettings,
+    update: async (
+      patch: Parameters<typeof window.maka.settings.update>[0],
+    ): Promise<UpdateAppSettingsResult> => ({
+      settings: mergeSettings(generalProxySettings, patch),
+    }),
+  },
+} satisfies Record<string, unknown>);
+
 type StoryBotStatuses = Awaited<ReturnType<typeof window.maka.settings.bots.listStatuses>>;
 
 const botAttentionError =
@@ -1035,6 +1078,12 @@ export const General: Story = {
 export const Appearance: Story = {
   decorators: [withSettingsBridge],
   render: () => <SettingsStory section="appearance" />,
+};
+/** #1362: proxy + auth enabled so the full form-grid stack renders. */
+// Real path: 设置 → 通用 → 代理服务器 on → 代理认证 on.
+export const GeneralProxyConfigured: Story = {
+  decorators: [withGeneralProxyBridge],
+  render: () => <SettingsStory section="general" />,
 };
 // Real path: 设置 → 使用统计.
 export const Usage: Story = {

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -603,6 +603,11 @@ const makaBridge = {
       electronVersion: '33.2.0',
       nodeVersion: '20.18.0',
       chromeVersion: '130.0.6723.59',
+      // #1363: was missing entirely — the About and Data pages' 工作区路径
+      // rows rendered an EMPTY value in every story. Deliberately long and
+      // deep so the mono value exercises its wrap contract.
+      workspacePath:
+        '/Users/storybook-fixture-user/Library/Application Support/Maka/workspaces/infra-observability-platform-desktop',
     }),
     openPath: async () => ({ ok: true as const, opened: '/Users/storybook' }),
   },


### PR DESCRIPTION
Closes #1363 (sub-issue of #1303).

> **Stacked on #1481**（前五个提交属于 #1479/#1481，为避免 stories/e2e 文件冲突基于其分支开发）。只需评审最后一个提交 `fix(desktop): polish small form-row pages`。上游合并后我会 rebase。

## 基线先行

story bridge 的 `app.info` **从来没有 `workspacePath` 字段**——About 和 Data 页的「工作区路径」行在所有 story 里渲染的都是空值，长 mono 路径的换行契约没有复现面。bridge 现在提供一条刻意加深的路径（`/Users/storybook-fixture-user/Library/Application Support/Maka/workspaces/infra-observability-platform-desktop`）。

## 修复

这三页的行都在 `.settingsRows` 卡内，**大头由 #1481 的行堆叠机制直接覆盖**（#1481 的回归探测显示 About 与 Daily Review 的窄态残留已被共享层清零）。本 PR 只补页面自有的缺口：

- `.settingsAboutPage` / `.settingsFeatureStatusPage` 补与 `.settingsStructuredPage`（#1362）相同的显式 `minmax(0, 1fr)` 列——它们是独立页面根，隐式 auto 轨道同样会被最宽子元素撑爆。
- Data 页配置导入导出的策略行（nowrap 标签 + select，单行最小宽度超过 480px 地板的内容列）改为换行；类别标签堆补 `min-width: 0`。

## 验证

- Storybook 三页 480→1280 **10px 步进**全频段零溢出
- 新 e2e（策略行换行 + 工作区 mono 值收纳 + 三页整页收纳）**revert 验证过**——对无本修复的 CSS 必失败
- 桌面单测 2857/2857、settings e2e 18/18、format/typecheck 干净
- 实机三页 × 1280/480 全部 contained：

| | 1280px | 480px |
|---|---|---|
| 每日回顾 | ![dr-1280](https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1363-screenshots/live-daily-review-1280.png) | ![dr-480](https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1363-screenshots/live-daily-review-480.png) |
| 数据 | ![data-1280](https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1363-screenshots/live-data-1280.png) | ![data-480](https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1363-screenshots/live-data-480.png) |
| 关于 | ![about-1280](https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1363-screenshots/live-about-1280.png) | ![about-480](https://raw.githubusercontent.com/UncertaintyDeterminesYou4ndMe/maka-agent/assets/1363-screenshots/live-about-480.png) |

## 未做（已评估）

- About 的加载骨架 / info 加载失败态没有加 story：状态可达但不承载本 issue 的布局契约（Alert/Skeleton 都是治理过的原语），加了只会稀释基线。
- Daily Review 的 `!hasConfigIpc` 横幅态同理（仅在 IPC 未接线的构建可达）。