### PR TITLE
fix(runtime): preserve recovered message order

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -496,6 +496,63 @@ describe('AiSdkBackend model history', () => {
     ]);
   });
 
+  test('keeps backfilled text-only assistant messages in conversation order', async () => {
+    const model = completionModel();
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    const recoveredAssistant = runtimeTextEvent({
+      id: 'rt-a',
+      turnId: 'turn-a',
+      role: 'model',
+      author: 'agent',
+      text: 'assistant A',
+    });
+    recoveredAssistant.refs = { storedMessageId: 'stored-a' };
+
+    await drain(
+      backend.send({
+        turnId: 'turn-current',
+        text: 'current user',
+        context: [],
+        runtimeContext: [
+          runtimeTextEvent({
+            id: 'rt-u-a',
+            turnId: 'turn-a',
+            role: 'user',
+            author: 'user',
+            text: 'user A',
+          }),
+          recoveredAssistant,
+          runtimeTextEvent({
+            id: 'rt-u-b',
+            turnId: 'turn-b',
+            role: 'user',
+            author: 'user',
+            text: 'user B',
+          }),
+        ],
+      }),
+    );
+
+    assert.deepEqual(promptTextSequence(model), [
+      { role: 'user', text: 'user A' },
+      { role: 'assistant', text: 'assistant A' },
+      { role: 'user', text: 'user B' },
+      { role: 'user', text: 'current user' },
+    ]);
+  });
+
   test('safe-boundary continuation does not append a duplicate current user message', async () => {
     const model = completionModel();
     const backend = new AiSdkBackend({
@@ -12454,6 +12511,18 @@ function compactPrompt(model: MockLanguageModelV4): unknown {
   return model.doStreamCalls[0]?.prompt.map((message) => ({
     role: message.role,
     content: message.content,
+  }));
+}
+
+function promptTextSequence(model: MockLanguageModelV4): Array<{
+  role: string;
+  text: string | undefined;
+}> {
+  return (model.doStreamCalls[0]?.prompt ?? []).map((message) => ({
+    role: message.role,
+    text: Array.isArray(message.content)
+      ? message.content.find((part) => part.type === 'text')?.text
+      : undefined,
   }));
 }
 

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -2503,6 +2503,19 @@ export class AiSdkBackend implements AgentBackend {
       bufferedCalls = [];
       await emitGroupedCalls(calls);
     };
+    const flushPendingSteps = async () => {
+      await flushLooseCalls();
+      for (const [stepId, text] of textByStep) {
+        textByStep.delete(stepId);
+        const reasoning = reasoningByStep.get(stepId);
+        reasoningByStep.delete(stepId);
+        await emitStep(reasoning, text, []);
+      }
+      for (const [stepId, reasoning] of reasoningByStep) {
+        reasoningByStep.delete(stepId);
+        await emitStep(reasoning, '', []);
+      }
+    };
 
     for (const item of plan.items) {
       switch (item.kind) {
@@ -2517,7 +2530,7 @@ export class AiSdkBackend implements AgentBackend {
             reasoningByStep.set(item.stepId, item);
           } else {
             // Legacy standalone reasoning (pure-reasoning turn): emit on its own.
-            await flushLooseCalls();
+            await flushPendingSteps();
             const replayReasoning = reasoningReplay(item);
             if (replayReasoning) {
               out.push({
@@ -2532,7 +2545,7 @@ export class AiSdkBackend implements AgentBackend {
           break;
         case 'text':
           if (item.role !== 'assistant') {
-            await flushLooseCalls();
+            await flushPendingSteps();
             out.push(await this.materializeRuntimeReplayItem(item));
             break;
           }
@@ -2555,30 +2568,13 @@ export class AiSdkBackend implements AgentBackend {
             }
           } else {
             // Legacy per-turn assistant text: standalone after any tool block.
-            await flushLooseCalls();
+            await flushPendingSteps();
             out.push({ role: 'assistant', content: item.content });
           }
           break;
       }
     }
-    await flushLooseCalls();
-    for (const [stepId, text] of textByStep) {
-      await emitStep(reasoningByStep.get(stepId), text, []);
-      reasoningByStep.delete(stepId);
-    }
-    // Any reasoning whose closing text never arrived (defensive): emit standalone.
-    for (const reasoning of reasoningByStep.values()) {
-      const replayReasoning = reasoningReplay(reasoning);
-      if (replayReasoning) {
-        out.push({
-          role: 'assistant',
-          content: replayReasoning.part ? [replayReasoning.part] : [],
-          ...(replayReasoning.providerOptions
-            ? { providerOptions: replayReasoning.providerOptions }
-            : {}),
-        } as ModelMessage);
-      }
-    }
+    await flushPendingSteps();
     return out;
   }
 


### PR DESCRIPTION
## Summary

- flush parked assistant replay steps before a later user or non-step message is materialized
- preserve causal provider prompt order for text-only assistant history recovered from StoredMessages
- add a provider-boundary regression for `user A -> assistant A -> user B`

## Context

Follow-up to #1462. Post-merge review found that treating every recovered assistant `storedMessageId` as a step id could park a text-only assistant message until the end of replay, moving it after a later user message.

The fix stays at the replay materializer boundary: pending assistant steps are emitted before crossing to the next conversation message.

Refs #1269.

## Verification

- `npm test`: all workspace tests passed
- headless: 1,339 passed, 1 skipped
- `npm run format:check`: 1,088 files passed
- `npm run lint`: 2,131 files passed
- `npm run typecheck`: all workspaces passed
- `git diff --check` passed
- local review-agent full base-diff review: no introduced correctness issues