### PR TITLE
fix: share Pier provider proxy across concurrent attempts

### DIFF
--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -15,7 +15,7 @@ import {
   selectTasksByIds,
 } from '#fixed-prompt-task-source';
 import { createHarborTaskRunner } from '#harbor-task-runner';
-import { createPierTaskRunner } from '#pier-task-runner';
+import { createPierProviderProxyHub, createPierTaskRunner } from '#pier-task-runner';
 import {
   buildHarnessOracleExecutionPolicyFingerprint,
   HARBOR_ORACLE_DOCKER_PLATFORM,
@@ -804,6 +804,8 @@ async function runLocked({
     throw new Error('harness credential is empty');
   const systemPromptPath = join(runRoot, 'prompts', 'default-system-prompt.txt');
   const evaluatedTaskIds = new Set(evaluationTasks.map((task) => task.id));
+  const providerProxyHub =
+    benchmarkProfile.executor === 'pier' ? await createPierProviderProxyHub() : undefined;
 
   const report = await runExperiment({
     runRoot,
@@ -828,6 +830,7 @@ async function runLocked({
           ? {
               baseUrl: execution.baseUrl,
               makaNodeToolchainPath: makaNodeToolchain.path,
+              providerProxyHub,
             }
           : {
               agentEnv: { MAKA_BASE_URL: execution.baseUrl },
@@ -908,7 +911,7 @@ async function runLocked({
         content: renderHarnessAbReportMarkdown(report),
       },
     ],
-  });
+  }).finally(() => providerProxyHub?.close());
   assertHarnessAbReportCompleted(report);
   console.log(
     `${report.runStatus}: ${report.coverage.attemptedCells}/${report.coverage.scheduledCells} cells attempted; ${report.effectiveness.pairedEvaluated} paired Pass@1 outcomes -> ${runRoot}`,

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -641,6 +641,9 @@ describe('Harbor adapter contract', () => {
     assert.match(source, /loadHarnessOracleRegistrySnapshot/);
     assert.match(source, /resolveHarnessOracleAnnotations/);
     assert.match(source, /taskIds: TERMINAL_BENCH_2_1_TASK_IDS/);
+    assert.match(source, /createPierProviderProxyHub/);
+    assert.match(source, /providerProxyHub/);
+    assert.match(source, /\.finally\(\(\) => providerProxyHub\?\.close\(\)\)/);
     assert.doesNotMatch(source, /ensureHarnessOracleQualification/);
     assert.doesNotMatch(source, /createHarborOracleQualifier/);
     assert.doesNotMatch(source, /qualification\.selectedTaskIds/);

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -18,6 +18,7 @@ import { findTrialDir } from '../harbor-task-runner.js';
 import { MAKA_NODE_TOOLCHAIN_FINGERPRINT } from '../maka-node-toolchain.js';
 import {
   buildPierRunArgs,
+  createPierProviderProxyHub,
   createPierTaskRunner,
   defaultPierProcessRunner,
   PierInfraError,
@@ -1131,10 +1132,10 @@ test('createPierTaskRunner overrides the Kimi proxy advertised host for native L
   });
 });
 
-/** One SEPARATE runner instance per port entry, one concurrent attempt each —
- * the lock's owner must be the shared host port, not a runner closure, or an
- * A/B with two Kimi arms in one process EADDRINUSEs. */
-async function runConcurrentKimiAttempts(ports: readonly number[]): Promise<number> {
+async function runConcurrentKimiAttempts(
+  ports: readonly number[],
+  providerProxyHub?: Awaited<ReturnType<typeof createPierProviderProxyHub>>,
+): Promise<number> {
   return await withDirs(async ({ jobsDir, repo }) => {
     let inFlight = 0;
     let maxInFlight = 0;
@@ -1152,6 +1153,7 @@ async function runConcurrentKimiAttempts(ports: readonly number[]): Promise<numb
           kimiCodeToolchainPath: repo,
           resolveProviderCredential: () => Promise.resolve({ value: 'upstream-key' }),
           providerProxyPort,
+          ...(providerProxyHub ? { providerProxyHub } : {}),
           runPier: async (request) => {
             inFlight += 1;
             maxInFlight = Math.max(maxInFlight, inFlight);
@@ -1191,11 +1193,22 @@ async function grabFreePorts(count: number): Promise<number[]> {
   return ports;
 }
 
-test('createPierTaskRunner serializes concurrent Kimi attempts across runners on one fixed port', async () => {
-  // A fixed port (like the default 443) admits exactly one bind: a second
-  // concurrent attempt — even from a DIFFERENT runner instance in the same
-  // process — would be a guaranteed EADDRINUSE, so the port is held one
-  // attempt at a time while both attempts still complete.
+test('createPierTaskRunner runs concurrent attempts through one fixed-port proxy hub', async () => {
+  const [fixedPort] = await grabFreePorts(1);
+  const hub = await createPierProviderProxyHub({
+    providerProxyPort: fixedPort,
+    providerProxyAdvertisedHost: '127.0.0.1',
+  });
+  try {
+    assert.equal(await runConcurrentKimiAttempts(Array(8).fill(fixedPort!), hub), 8);
+  } finally {
+    await hub.close();
+  }
+});
+
+test('createPierTaskRunner serializes fixed-port attempts when no proxy hub is provided', async () => {
+  // Backward compatibility for direct runner callers: without a run-scoped hub,
+  // each attempt owns a listener and therefore must still serialize the bind.
   const [fixedPort] = await grabFreePorts(1);
   assert.equal(await runConcurrentKimiAttempts([fixedPort!, fixedPort!]), 1);
 });

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -7,6 +7,7 @@ import { test } from 'node:test';
 import {
   listenProviderAuthProxyServer,
   startProviderAuthProxy,
+  startProviderAuthProxyHub,
   summarizeProviderTelemetry,
 } from '../provider-auth-proxy.js';
 
@@ -166,6 +167,237 @@ test('provider auth proxy resolves rotating upstream credentials for every reque
     await proxy.close();
     await new Promise<void>((resolve, reject) =>
       upstream.close((error) => (error ? reject(error) : resolve())),
+    );
+  }
+});
+
+test('provider auth proxy hub routes concurrent leases independently on one listener', async () => {
+  const upstreamRequests = new Map<string, Array<{ authorization: string; path: string }>>();
+  const startUpstream = async (name: string) => {
+    const requests: Array<{ authorization: string; path: string }> = [];
+    upstreamRequests.set(name, requests);
+    const upstream = createServer((request, response) => {
+      requests.push({
+        authorization: request.headers.authorization ?? '',
+        path: request.url ?? '',
+      });
+      response.writeHead(200).end(name);
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+    const address = upstream.address();
+    assert.ok(address && typeof address !== 'string');
+    return { upstream, url: `http://127.0.0.1:${address.port}` };
+  };
+  const [alphaUpstream, betaUpstream] = await Promise.all([
+    startUpstream('alpha'),
+    startUpstream('beta'),
+  ]);
+  const hub = await startProviderAuthProxyHub({ advertisedHost: '127.0.0.1' });
+  const alpha = hub.issue({
+    upstreamBaseUrl: `${alphaUpstream.url}/alpha/v1`,
+    resolveUpstreamCredential: async () => ({ value: 'alpha-upstream-key' }),
+  });
+  const beta = hub.issue({
+    upstreamBaseUrl: `${betaUpstream.url}/beta/v1`,
+    resolveUpstreamCredential: async () => ({ value: 'beta-upstream-key' }),
+  });
+
+  try {
+    assert.equal(new URL(alpha.baseUrl).origin, new URL(beta.baseUrl).origin);
+    assert.equal(new URL(alpha.baseUrl).pathname, '/alpha/v1');
+    assert.equal(new URL(beta.baseUrl).pathname, '/beta/v1');
+    assert.notEqual(alpha.token, beta.token);
+    const [alphaResponse, betaResponse] = await Promise.all([
+      fetch(`${alpha.baseUrl}/responses`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${alpha.token}` },
+        body: '{}',
+      }),
+      fetch(`${beta.baseUrl}/responses`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${beta.token}` },
+        body: '{}',
+      }),
+    ]);
+    assert.equal(await alphaResponse.text(), 'alpha');
+    assert.equal(await betaResponse.text(), 'beta');
+    assert.deepEqual(upstreamRequests.get('alpha'), [
+      { authorization: 'Bearer alpha-upstream-key', path: '/alpha/v1/responses' },
+    ]);
+    assert.deepEqual(upstreamRequests.get('beta'), [
+      { authorization: 'Bearer beta-upstream-key', path: '/beta/v1/responses' },
+    ]);
+
+    await alpha.close();
+    const revoked = await fetch(`${alpha.baseUrl}/responses`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${alpha.token}` },
+      body: '{}',
+    });
+    assert.equal(revoked.status, 401);
+    const stillActive = await fetch(`${beta.baseUrl}/responses`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${beta.token}` },
+      body: '{}',
+    });
+    assert.equal(await stillActive.text(), 'beta');
+  } finally {
+    await Promise.allSettled([alpha.close(), beta.close()]);
+    await hub.close();
+    await Promise.all(
+      [alphaUpstream.upstream, betaUpstream.upstream].map(
+        (upstream) =>
+          new Promise<void>((resolve, reject) =>
+            upstream.close((error) => (error ? reject(error) : resolve())),
+          ),
+      ),
+    );
+  }
+});
+
+test('provider auth proxy hub attributes usage and telemetry to each lease', async () => {
+  const startUpstream = async (input: number, output: number) => {
+    const upstream = createServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.end(
+        `data: ${JSON.stringify({
+          choices: [],
+          usage: {
+            prompt_tokens: input,
+            prompt_tokens_details: { cached_tokens: input - 1 },
+            completion_tokens: output,
+          },
+        })}\n\ndata: [DONE]\n\n`,
+      );
+    });
+    await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+    const address = upstream.address();
+    assert.ok(address && typeof address !== 'string');
+    return { upstream, url: `http://127.0.0.1:${address.port}` };
+  };
+  const [alphaUpstream, betaUpstream] = await Promise.all([
+    startUpstream(11, 3),
+    startUpstream(29, 7),
+  ]);
+  const hub = await startProviderAuthProxyHub({ advertisedHost: '127.0.0.1' });
+  const alpha = hub.issue({
+    upstreamBaseUrl: alphaUpstream.url,
+    resolveUpstreamCredential: async () => ({ value: 'alpha-key' }),
+    usageProtocol: 'openai-chat-sse',
+  });
+  const beta = hub.issue({
+    upstreamBaseUrl: betaUpstream.url,
+    resolveUpstreamCredential: async () => ({ value: 'beta-key' }),
+    usageProtocol: 'openai-chat-sse',
+  });
+
+  try {
+    await Promise.all(
+      [alpha, beta].map(async (lease) => {
+        const response = await fetch(`${lease.baseUrl}/chat/completions`, {
+          method: 'POST',
+          headers: { authorization: `Bearer ${lease.token}` },
+          body: '{}',
+        });
+        assert.equal(response.status, 200);
+        await response.text();
+      }),
+    );
+    assert.deepEqual(alpha.usage(), {
+      input: 11,
+      cacheRead: 10,
+      cacheWrite: 0,
+      output: 3,
+    });
+    assert.deepEqual(beta.usage(), {
+      input: 29,
+      cacheRead: 28,
+      cacheWrite: 0,
+      output: 7,
+    });
+    assert.deepEqual(
+      alpha.telemetry().map((request) => request.usage),
+      [alpha.usage()],
+    );
+    assert.deepEqual(
+      beta.telemetry().map((request) => request.usage),
+      [beta.usage()],
+    );
+  } finally {
+    await Promise.allSettled([alpha.close(), beta.close()]);
+    await hub.close();
+    await Promise.all(
+      [alphaUpstream.upstream, betaUpstream.upstream].map(
+        (upstream) =>
+          new Promise<void>((resolve, reject) =>
+            upstream.close((error) => (error ? reject(error) : resolve())),
+          ),
+      ),
+    );
+  }
+});
+
+test('provider auth proxy hub aborts only the closed lease requests', async () => {
+  let alphaStarted!: () => void;
+  const alphaReachedUpstream = new Promise<void>((resolve) => {
+    alphaStarted = resolve;
+  });
+  const alphaUpstream = createServer((request, response) => {
+    response.writeHead(200, { 'content-type': 'text/plain' });
+    response.write('partial');
+    alphaStarted();
+    request.once('close', () => response.end());
+  });
+  const betaUpstream = createServer((_request, response) => {
+    response.writeHead(200).end('beta');
+  });
+  await Promise.all(
+    [alphaUpstream, betaUpstream].map(
+      (upstream) => new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve)),
+    ),
+  );
+  const alphaAddress = alphaUpstream.address();
+  const betaAddress = betaUpstream.address();
+  assert.ok(alphaAddress && typeof alphaAddress !== 'string');
+  assert.ok(betaAddress && typeof betaAddress !== 'string');
+  const hub = await startProviderAuthProxyHub({ advertisedHost: '127.0.0.1' });
+  const alpha = hub.issue({
+    upstreamBaseUrl: `http://127.0.0.1:${alphaAddress.port}`,
+    resolveUpstreamCredential: async () => ({ value: 'alpha-key' }),
+  });
+  const beta = hub.issue({
+    upstreamBaseUrl: `http://127.0.0.1:${betaAddress.port}`,
+    resolveUpstreamCredential: async () => ({ value: 'beta-key' }),
+  });
+
+  try {
+    const alphaBody = fetch(`${alpha.baseUrl}/responses`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${alpha.token}` },
+      body: '{}',
+    }).then((response) => response.text());
+    await alphaReachedUpstream;
+    await alpha.close();
+    await alphaBody.catch(() => undefined);
+
+    const betaResponse = await fetch(`${beta.baseUrl}/responses`, {
+      method: 'POST',
+      headers: { authorization: `Bearer ${beta.token}` },
+      body: '{}',
+    });
+    assert.equal(await betaResponse.text(), 'beta');
+    assert.equal(alpha.telemetry().at(-1)?.outcome, 'aborted');
+    assert.equal(beta.telemetry().at(-1)?.outcome, 'completed');
+  } finally {
+    await Promise.allSettled([alpha.close(), beta.close()]);
+    await hub.close();
+    await Promise.all(
+      [alphaUpstream, betaUpstream].map(
+        (upstream) =>
+          new Promise<void>((resolve, reject) =>
+            upstream.close((error) => (error ? reject(error) : resolve())),
+          ),
+      ),
     );
   }
 });

--- a/packages/headless/src/index.ts
+++ b/packages/headless/src/index.ts
@@ -246,12 +246,15 @@ export {
 } from './harbor-failure-policy.js';
 export {
   buildPierRunArgs,
+  createPierProviderProxyHub,
   createPierTaskRunner,
   PierInfraError,
   PIER_PROVIDER_PROXY_DEFAULT_PORT,
   type BuildPierRunArgsInput,
   type PierAgent,
   type PierProcessRunner,
+  type PierProviderProxyHub,
+  type PierProviderProxyHubOptions,
   type PierRunRequest,
   type PierRunResult,
   type PierTaskPricing,

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -49,6 +49,9 @@ import {
 import {
   summarizeProviderTelemetry,
   startProviderAuthProxy,
+  startProviderAuthProxyHub,
+  type ProviderAuthProxyHub,
+  type ProviderAuthProxyRouteInput,
   type ProviderRequestTelemetry,
   type ProviderTokenUsage,
   type ProviderUpstreamCredentialResolver,
@@ -68,16 +71,10 @@ const PROVIDER_REQUEST_TELEMETRY = 'provider-request-telemetry.json';
  * 443 keeps the model endpoint on the conventional TLS port. */
 export const PIER_PROVIDER_PROXY_DEFAULT_PORT = 443;
 
-/** An in-container agent binds ONE fixed proxy port per attempt, and Pier's Squid
- * egress leaves only two usable destination ports (80/443), so concurrent
- * attempts on the same port must hold it one at a time — a second concurrent
- * bind is a guaranteed EADDRINUSE. The lock's owner is the shared host PORT,
- * not a runner instance: two runners in one process (e.g. an A/B with two
- * container-CLI arms) compete for the same bind. Hence a module-level per-port
- * queue; cross-PROCESS collisions remain the operator's scheduling concern.
- * Serializing the proxy-holding section (instead of sharing one proxy) keeps
- * usage/telemetry attribution per attempt. A pool over both Squid-legal ports
- * is deferred until concurrency actually needs it. */
+/** Compatibility fallback for callers that do not provide a run-scoped proxy
+ * hub. Such callers still bind one fixed port per attempt, so concurrent binds
+ * on the same port must serialize. Benchmark runs that need concurrency share
+ * one listener through `providerProxyHub` and do not enter this queue. */
 const proxyPortQueues = new Map<number, Promise<unknown>>();
 
 function withProxyPortLock<T>(port: number, fn: () => Promise<T>): Promise<T> {
@@ -114,6 +111,12 @@ export class PierInfraError extends Error {
 
 /** Same per-1M pricing contract as the Harbor runner (shared cost math). */
 export type PierTaskPricing = HarborTaskPricing;
+export type PierProviderProxyHub = ProviderAuthProxyHub;
+
+export interface PierProviderProxyHubOptions {
+  providerProxyPort?: number;
+  providerProxyAdvertisedHost?: string;
+}
 
 export interface PierTaskRunnerOptions {
   /** Host path to the maka repo, bind-mounted read-only at /opt/maka-agent. */
@@ -162,6 +165,10 @@ export interface PierTaskRunnerOptions {
    * docker-bridge-reachable address (e.g. 172.17.0.1) or the container's Squid
    * cannot resolve the proxy. */
   providerProxyAdvertisedHost?: string;
+  /** Run-scoped fixed-port listener shared by concurrent in-container attempts.
+   * Each attempt receives an independent token-routed lease, including its own
+   * upstream credential resolver, usage, telemetry, and abort lifecycle. */
+  providerProxyHub?: PierProviderProxyHub;
   /** Per-1M USD pricing forwarded as MAKA_TRIAL_* so the cell emits real costUsd. */
   pricing?: PierTaskPricing;
   /** Extra agent env merged last (e.g. MAKA_HARBOR_MODE). Never provider secrets. */
@@ -182,6 +189,20 @@ export interface PierTaskRunnerOptions {
   pierTimeoutMs?: number;
   /** Injectable Pier process runner (default: execFile the pier binary). */
   runPier?: PierProcessRunner;
+}
+
+/** Start the one fixed-port provider listener owned by a Pier benchmark run.
+ * Runners receive the returned hub through `providerProxyHub` and issue one
+ * isolated lease per attempt. */
+export async function createPierProviderProxyHub(
+  input: PierProviderProxyHubOptions = {},
+): Promise<PierProviderProxyHub> {
+  return await startProviderAuthProxyHub({
+    port: input.providerProxyPort ?? PIER_PROVIDER_PROXY_DEFAULT_PORT,
+    ...(input.providerProxyAdvertisedHost
+      ? { advertisedHost: input.providerProxyAdvertisedHost }
+      : {}),
+  });
 }
 
 export interface PierRunRequest {
@@ -376,7 +397,7 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
     const containerProxyPort = options.providerProxyPort ?? PIER_PROVIDER_PROXY_DEFAULT_PORT;
     const usesContainerProxy = agent !== 'maka' || traceMode === 'task-run';
     const result =
-      usesContainerProxy && containerProxyPort !== 0
+      usesContainerProxy && !options.providerProxyHub && containerProxyPort !== 0
         ? await withProxyPortLock(containerProxyPort, launchAttempt)
         : await launchAttempt();
 
@@ -740,16 +761,22 @@ async function pierProviderRuntime(
   // host.docker.internal unless native Linux supplies an explicit bridge host.
   const advertisedHost =
     agent === 'maka' && !makaContainerTaskRun ? '127.0.0.1' : options.providerProxyAdvertisedHost;
-  const proxy = await startProviderAuthProxy({
+  const routeInput: ProviderAuthProxyRouteInput = {
     upstreamBaseUrl: baseUrl,
-    ...(advertisedHost !== undefined ? { advertisedHost } : {}),
-    ...(proxyPort !== undefined ? { port: proxyPort } : {}),
     ...(options.resolveProviderCredential
       ? { resolveUpstreamCredential: options.resolveProviderCredential }
       : { apiKeyFile: options.apiKeyFile! }),
     authMode: agent === 'kimi-code' ? 'bearer' : providerProxyAuthMode(provider),
     usageProtocol: providerProxyUsageProtocol(agent, provider),
-  });
+  };
+  const proxy =
+    options.providerProxyHub && proxyPort !== undefined
+      ? options.providerProxyHub.issue(routeInput)
+      : await startProviderAuthProxy({
+          ...routeInput,
+          ...(advertisedHost !== undefined ? { advertisedHost } : {}),
+          ...(proxyPort !== undefined ? { port: proxyPort } : {}),
+        });
 
   return {
     // Proxy-minted, scoped, ephemeral token — never the real provider key. Routed

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -16,6 +16,12 @@ export interface ProviderAuthProxy {
   close(): Promise<void>;
 }
 
+export interface ProviderAuthProxyHub {
+  baseUrl: string;
+  issue(input: ProviderAuthProxyRouteInput): ProviderAuthProxy;
+  close(): Promise<void>;
+}
+
 export interface ProviderTokenUsage {
   input: number;
   cacheRead: number;
@@ -139,16 +145,10 @@ export interface ProviderUpstreamCredential {
 
 export type ProviderUpstreamCredentialResolver = () => Promise<ProviderUpstreamCredential>;
 
-type ProviderAuthProxyInput = {
+type ProviderAuthProxyRouteConfig = {
   upstreamBaseUrl: string;
-  advertisedHost?: string;
   authMode?: ProviderAuthProxyMode;
   usageProtocol?: ProviderUsageProtocol;
-  /** Fixed listen port. Defaults to an ephemeral port (0). Pier's Squid egress
-   * for offline tasks only permits destination ports 80/443, so a container
-   * reaching this proxy through Squid needs it bound to 80 or 443. Binding a
-   * privileged port can fail on Linux; callers get a clear error. */
-  port?: number;
   /** Injectable monotonic clock for deterministic tests. */
   now?: () => number;
 } & (
@@ -156,9 +156,154 @@ type ProviderAuthProxyInput = {
   | { apiKeyFile?: never; resolveUpstreamCredential: ProviderUpstreamCredentialResolver }
 );
 
+export type ProviderAuthProxyRouteInput = ProviderAuthProxyRouteConfig;
+
+type ProviderAuthProxyInput = ProviderAuthProxyRouteConfig & {
+  advertisedHost?: string;
+  /** Fixed listen port. Defaults to an ephemeral port (0). Pier's Squid egress
+   * for offline tasks only permits destination ports 80/443, so a container
+   * reaching this proxy through Squid needs it bound to 80 or 443. Binding a
+   * privileged port can fail on Linux; callers get a clear error. */
+  port?: number;
+};
+
+export interface ProviderAuthProxyHubInput {
+  advertisedHost?: string;
+  port?: number;
+}
+
 export async function startProviderAuthProxy(
   input: ProviderAuthProxyInput,
 ): Promise<ProviderAuthProxy> {
+  const hub = await startProviderAuthProxyHub({
+    ...(input.advertisedHost ? { advertisedHost: input.advertisedHost } : {}),
+    ...(input.port !== undefined ? { port: input.port } : {}),
+  });
+  let lease: ProviderAuthProxy;
+  try {
+    lease = hub.issue(input);
+  } catch (error) {
+    await hub.close();
+    throw error;
+  }
+  let closePromise: Promise<void> | undefined;
+  return {
+    ...lease,
+    close: () => {
+      closePromise ??= lease.close().then(() => hub.close());
+      return closePromise;
+    },
+  };
+}
+
+interface ProviderAuthProxyRoute {
+  readonly upstreamBaseUrl: URL;
+  readonly upstreamBasePath: string;
+  readonly resolveUpstreamCredential: ProviderUpstreamCredentialResolver;
+  readonly token: string;
+  readonly authMode: ProviderAuthProxyMode;
+  readonly usageProtocol?: ProviderUsageProtocol;
+  readonly usage: ProviderUsageAccumulator;
+  readonly telemetry: ProviderTelemetryAccumulator;
+  readonly now: () => number;
+  readonly activeRequests: Set<AbortController>;
+  readonly activeResponses: Set<ServerResponse>;
+  readonly activeForwards: Set<Promise<void>>;
+  closePromise?: Promise<void>;
+}
+
+export async function startProviderAuthProxyHub(
+  input: ProviderAuthProxyHubInput = {},
+): Promise<ProviderAuthProxyHub> {
+  const routes = new Set<ProviderAuthProxyRoute>();
+  const sockets = new Set<Socket>();
+  let closed = false;
+  let closePromise: Promise<void> | undefined;
+  const server = createServer((request, response) => {
+    const route = [...routes].find((candidate) => routeAuthorized(request, candidate));
+    if (!route) {
+      response.writeHead(401).end('unauthorized');
+      return;
+    }
+    const controller = new AbortController();
+    const abortOnRequest = () => controller.abort();
+    const abortOnResponseClose = () => {
+      if (!response.writableEnded) controller.abort();
+    };
+    request.once('aborted', abortOnRequest);
+    response.once('close', abortOnResponseClose);
+    route.activeRequests.add(controller);
+    route.activeResponses.add(response);
+    const forward = forwardProviderRequest({
+      request,
+      response,
+      upstreamBaseUrl: route.upstreamBaseUrl,
+      upstreamBasePath: route.upstreamBasePath,
+      resolveUpstreamCredential: route.resolveUpstreamCredential,
+      token: route.token,
+      authMode: route.authMode,
+      usageProtocol: route.usageProtocol,
+      usage: route.usage,
+      telemetry: route.telemetry,
+      now: route.now,
+      signal: controller.signal,
+    }).finally(() => {
+      request.off('aborted', abortOnRequest);
+      response.off('close', abortOnResponseClose);
+      route.activeRequests.delete(controller);
+      route.activeResponses.delete(response);
+      route.activeForwards.delete(forward);
+    });
+    route.activeForwards.add(forward);
+  });
+  server.on('connection', (socket) => {
+    sockets.add(socket);
+    socket.once('close', () => sockets.delete(socket));
+  });
+  await listenProviderAuthProxyServer(server, input.port ?? 0);
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    server.close();
+    throw new Error('provider auth proxy did not bind a TCP port');
+  }
+  const advertisedHost = input.advertisedHost ?? 'host.docker.internal';
+  const baseUrl = `http://${advertisedHost}:${address.port}`;
+
+  return {
+    baseUrl,
+    issue: (routeInput) => {
+      if (closed) throw new Error('provider auth proxy hub is closed');
+      const route = providerAuthProxyRoute(routeInput);
+      routes.add(route);
+      return {
+        // Preserve the route's provider mount path while every lease shares the
+        // listener authority. The client remains the sole owner of path joins.
+        baseUrl: `${baseUrl}${route.upstreamBasePath}`,
+        token: route.token,
+        usage: () => route.usage.snapshot(),
+        telemetry: () => route.telemetry.snapshot(),
+        close: () => closeProviderAuthProxyRoute(routes, route),
+      };
+    },
+    close: () => {
+      closePromise ??= (async () => {
+        closed = true;
+        const serverClosed = new Promise<void>((resolve, reject) => {
+          server.close((error) => (error ? reject(error) : resolve()));
+        });
+        const routeClosures = [...routes].map((route) =>
+          closeProviderAuthProxyRoute(routes, route),
+        );
+        for (const socket of sockets) socket.destroy();
+        await serverClosed;
+        await Promise.allSettled(routeClosures);
+      })();
+      return closePromise;
+    },
+  };
+}
+
+function providerAuthProxyRoute(input: ProviderAuthProxyRouteInput): ProviderAuthProxyRoute {
   const upstreamBaseUrl = new URL(input.upstreamBaseUrl);
   if (upstreamBaseUrl.protocol !== 'https:' && upstreamBaseUrl.protocol !== 'http:') {
     throw new Error(
@@ -173,73 +318,40 @@ export async function startProviderAuthProxy(
       if (value.length === 0) throw new Error('provider API key file is empty');
       return { value };
     });
-  const authMode = input.authMode ?? 'bearer';
-  const token = randomBytes(32).toString('hex');
-  const usage = new ProviderUsageAccumulator();
-  const telemetry = new ProviderTelemetryAccumulator();
-  const now = input.now ?? performance.now.bind(performance);
-  const activeRequests = new Set<AbortController>();
-  const activeForwards = new Set<Promise<void>>();
-  const sockets = new Set<Socket>();
-  const server = createServer((request, response) => {
-    const controller = new AbortController();
-    const abortOnRequest = () => controller.abort();
-    const abortOnResponseClose = () => {
-      if (!response.writableEnded) controller.abort();
-    };
-    request.once('aborted', abortOnRequest);
-    response.once('close', abortOnResponseClose);
-    activeRequests.add(controller);
-    const forward = forwardProviderRequest({
-      request,
-      response,
-      upstreamBaseUrl,
-      upstreamBasePath,
-      resolveUpstreamCredential,
-      token,
-      authMode,
-      usageProtocol: input.usageProtocol,
-      usage,
-      telemetry,
-      now,
-      signal: controller.signal,
-    }).finally(() => {
-      request.off('aborted', abortOnRequest);
-      response.off('close', abortOnResponseClose);
-      activeRequests.delete(controller);
-      activeForwards.delete(forward);
-    });
-    activeForwards.add(forward);
-  });
-  server.on('connection', (socket) => {
-    sockets.add(socket);
-    socket.once('close', () => sockets.delete(socket));
-  });
-  await listenProviderAuthProxyServer(server, input.port ?? 0);
-  const address = server.address();
-  if (!address || typeof address === 'string') {
-    server.close();
-    throw new Error('provider auth proxy did not bind a TCP port');
-  }
-  const advertisedHost = input.advertisedHost ?? 'host.docker.internal';
   return {
-    // Keep the provider's mount path in the client-visible base URL; the proxy
-    // changes authority, while the client remains the sole owner of path joins.
-    baseUrl: `http://${advertisedHost}:${address.port}${upstreamBasePath}`,
-    token,
-    usage: () => usage.snapshot(),
-    telemetry: () => telemetry.snapshot(),
-    close: async () => {
-      const closed = new Promise<void>((resolve, reject) => {
-        server.close((error) => (error ? reject(error) : resolve()));
-      });
-      const forwards = [...activeForwards];
-      for (const controller of activeRequests) controller.abort();
-      for (const socket of sockets) socket.destroy();
-      await closed;
-      await Promise.allSettled(forwards);
-    },
+    upstreamBaseUrl,
+    upstreamBasePath,
+    resolveUpstreamCredential,
+    token: randomBytes(32).toString('hex'),
+    authMode: input.authMode ?? 'bearer',
+    ...(input.usageProtocol ? { usageProtocol: input.usageProtocol } : {}),
+    usage: new ProviderUsageAccumulator(),
+    telemetry: new ProviderTelemetryAccumulator(),
+    now: input.now ?? performance.now.bind(performance),
+    activeRequests: new Set<AbortController>(),
+    activeResponses: new Set<ServerResponse>(),
+    activeForwards: new Set<Promise<void>>(),
   };
+}
+
+function routeAuthorized(request: IncomingMessage, route: ProviderAuthProxyRoute): boolean {
+  const presentedCredential =
+    route.authMode === 'x-api-key' ? request.headers['x-api-key'] : request.headers.authorization;
+  return authorized(presentedCredential, route.token, route.authMode);
+}
+
+function closeProviderAuthProxyRoute(
+  routes: Set<ProviderAuthProxyRoute>,
+  route: ProviderAuthProxyRoute,
+): Promise<void> {
+  route.closePromise ??= (async () => {
+    routes.delete(route);
+    const forwards = [...route.activeForwards];
+    for (const controller of route.activeRequests) controller.abort();
+    for (const response of route.activeResponses) response.destroy();
+    await Promise.allSettled(forwards);
+  })();
+  return route.closePromise;
 }
 
 async function forwardProviderRequest(input: {


### PR DESCRIPTION
## Summary

Pier's offline task containers can reach the host provider proxy only through Squid-safe ports 80/443. The previous per-attempt listener therefore serialized every attempt sharing port 443, preventing the DeepSWE harness from running four task pairs with both arms in parallel.

This change gives each Pier benchmark run one fixed-port provider proxy hub. Every attempt receives an independent token-routed lease with its own upstream credential resolver, usage and telemetry accumulators, and abort lifecycle. The benchmark runner shares the hub across both arms and closes it at run completion. Direct runner callers that do not provide a hub keep the existing fixed-port serialization fallback.

The hub also preserves each provider's upstream base path from #1499 while sharing only the listener authority, so a lease token remains scoped to its own provider mount.

## Verification

- `node --test packages/headless/dist/__tests__/provider-auth-proxy.test.js packages/headless/dist/__tests__/pier-task-runner.test.js` — 71 passed
- `npm --workspace @maka/headless test` — 1346 passed
- `npm run build`
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

No real-provider benchmark was run while developing this change.

## Remaining evidence

- [ ] Run a real DeepSWE canary from the exact PR commit with `pairConcurrency=4` and `armExecution=parallel` (up to 8 concurrent cells), then attach the manifest, attempt journal, results, provider telemetry, and cost attribution.

## Review focus

- Per-lease token routing and credential/usage isolation on one listener.
- Lease-local abort versus run-wide hub shutdown.
- Interaction with provider base-path preservation and the no-hub compatibility fallback.
