### PR TITLE
feat(runtime-host): establish task ledger authority

### DIFF
--- a/docs/session-task-ledger-lifecycle.md
+++ b/docs/session-task-ledger-lifecycle.md
@@ -136,6 +136,27 @@ behavior remains compatible with the original full-list behavior.
 PascalCase aliases are not advertised and require an explicit compatibility
 flag in main-process wiring.
 
+### Runtime Host Authority
+
+The non-serving Runtime Host composition opens the interactive Task Ledger
+writer under its Storage root owner lease. One per-Session coordinator
+implements the Runtime `TaskLedgerStore` port and serves the read-only
+`task.ledger.query` Client operation. Reads, mutations, claims, and child
+outcomes invoked through that port therefore share the same Session admission
+boundary instead of creating a second Task Ledger authority.
+
+Binding the port into the Host's real-model task and child-agent tool
+composition is part of the later Hosted execution slice. This authority slice
+establishes the port and its Client projection without claiming that
+non-serving Host tool composition is already active.
+
+Client queries return the canonical, sanitized projection in item- and
+byte-bounded pages. A content revision pins each traversal; a continuation from
+an older projection returns `revision_changed` rather than mixing snapshots
+across Host epochs. The authority preserves the existing `task-events.jsonl`,
+`tasks.json`, legacy-read, and backfill behavior. Desktop keeps its embedded
+writer until the production cutover replaces all root writers atomically.
+
 ## Child Agent Ownership
 
 `agent_spawn(task_id=...)` resolves the task in the current session and claims

--- a/packages/runtime-host/src/__tests__/connection-session.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-session.test.ts
@@ -857,6 +857,13 @@ function createHandlers(queryTurn: TurnQueryHandler): RuntimeHostComposition['ha
       message: 'not available in this test composition',
     },
   } as const;
+  const taskLedgerUnavailable: Awaited<ReturnType<OperationHandlerMap['task.ledger.query']>> = {
+    ok: false,
+    error: {
+      code: 'operation_unavailable',
+      message: 'not available in this test composition',
+    },
+  };
   return {
     ...createUnavailableDomainOperationHandlers(),
     'turn.start': async (input) => ({
@@ -873,6 +880,7 @@ function createHandlers(queryTurn: TurnQueryHandler): RuntimeHostComposition['ha
     'turn.interrupt': async () => unavailable,
     'subscription.open': async () => subscriptionUnavailable,
     'subscription.close': async () => subscriptionUnavailable,
+    'task.ledger.query': async () => taskLedgerUnavailable,
   };
 }
 

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -30,9 +30,11 @@ const allowedServerExternalImports = new Set([
   '@maka/core/runtime-policy',
   '@maka/core/runtime-event',
   '@maka/core/session',
+  '@maka/core/task-ledger',
   '@maka/runtime',
   '@maka/storage/execution-stores',
   '@maka/storage/runtime-policy-stores',
+  '@maka/storage/task-ledger-store',
   'node:async_hooks',
 ]);
 const allowedExternalImports = {
@@ -41,6 +43,7 @@ const allowedExternalImports = {
     '@maka/core/attachments',
     '@maka/core/events',
     '@maka/core/runtime-policy',
+    '@maka/core/task-ledger',
     'node:util',
   ]),
 } as const;
@@ -134,6 +137,7 @@ test('the production Candidate dependency graph remains non-serving', () => {
     'server/root-turn-coordinator.ts',
     'server/runtime-policy-coordinator.ts',
     'server/session-continuity-coordinator.ts',
+    'server/task-ledger-coordinator.ts',
   ]);
   const violations: string[] = [];
   for (const path of reached) {
@@ -143,7 +147,8 @@ test('the production Candidate dependency graph remains non-serving', () => {
       if (
         specifier === '@maka/runtime' ||
         specifier === '@maka/storage/execution-stores' ||
-        specifier === '@maka/storage/runtime-policy-stores'
+        specifier === '@maka/storage/runtime-policy-stores' ||
+        specifier === '@maka/storage/task-ledger-store'
       ) {
         violations.push(`${localPath}: ${specifier}`);
       }

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -34,7 +34,7 @@ const allowedServerExternalImports = new Set([
   '@maka/runtime',
   '@maka/storage/execution-stores',
   '@maka/storage/runtime-policy-stores',
-  '@maka/storage/task-ledger-store',
+  '@maka/storage/task-ledger-authority',
   'node:async_hooks',
 ]);
 const allowedExternalImports = {
@@ -148,7 +148,7 @@ test('the production Candidate dependency graph remains non-serving', () => {
         specifier === '@maka/runtime' ||
         specifier === '@maka/storage/execution-stores' ||
         specifier === '@maka/storage/runtime-policy-stores' ||
-        specifier === '@maka/storage/task-ledger-store'
+        specifier === '@maka/storage/task-ledger-authority'
       ) {
         violations.push(`${localPath}: ${specifier}`);
       }

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -9,13 +9,17 @@ import { test } from 'node:test';
 import type { AgentRunHeader } from '@maka/core/agent-run';
 import type { MessageContent } from '@maka/core/events';
 import type { StoredMessage } from '@maka/core/session';
+import type { Task } from '@maka/core/task-ledger';
 import { isTerminalRuntimeEvent } from '@maka/core/runtime-event';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import {
+  buildTaskLedgerTools,
   buildRecoveredTerminalRuntimeEvent,
   classifyTerminalRuntimeLedger,
   commitTerminalRunWithRuntimeFact,
   FAKE_ASK_USER_QUESTION_PROMPT,
+  type MakaTool,
+  type MakaToolContext,
 } from '@maka/runtime';
 import {
   openInteractiveExecutionStoresForRead,
@@ -28,6 +32,7 @@ import {
   tryAcquireInteractiveRootReader,
   type StorageRootCapability,
 } from '@maka/storage/root-authority';
+import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-store';
 import {
   connectRuntimeHost,
   RuntimeHostOperationError,
@@ -38,10 +43,15 @@ import {
 import {
   decodeHostFrame,
   RUNTIME_HOST_PROTOCOL_VERSION,
+  TASK_LEDGER_PAGE_MAX_ITEMS,
   type SubscriptionFrame,
+  type TaskLedgerQueryResult,
+  type TaskLedgerRevision,
   type TurnMessageSubmitInput,
   type TurnSnapshot,
 } from '../protocol/index.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+import { HostTaskLedgerCoordinator } from '../server/task-ledger-coordinator.js';
 import { FramedTransport } from '../transport/framed-transport.js';
 
 const CURRENT_PROTOCOL = {
@@ -49,6 +59,144 @@ const CURRENT_PROTOCOL = {
   max: RUNTIME_HOST_PROTOCOL_VERSION,
 } as const;
 const PROCESS_TIMEOUT_MS = 10_000;
+
+test('dual UDS Clients query persisted Task Ledger tool-port mutations across Host restart', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const initialRunId = randomUUID();
+    const initialTurnId = randomUUID();
+    // Exercise the Runtime-facing port before Host startup; Hosted tool composition is separate.
+    const toolPortProjection = await withOwnedTaskLedgerToolPort(
+      fixture,
+      async (coordinator, tools) => {
+        const context = taskLedgerToolContext(fixture, {
+          runId: initialRunId,
+          turnId: initialTurnId,
+          toolCallId: randomUUID(),
+        });
+        const create = requireTaskLedgerTool<TaskCreateInput>(tools, 'task_create');
+        const createInput = create.parameters.parse({
+          tasks: Array.from({ length: TASK_LEDGER_PAGE_MAX_ITEMS + 1 }, (_, index) => ({
+            subject: `Authority acceptance task ${index + 1}`,
+          })),
+        });
+        await create.impl(createInput, context);
+
+        const update = requireTaskLedgerTool<TaskUpdateInput>(tools, 'task_update');
+        const updateInput = update.parameters.parse({ id: 'T1', status: 'in_progress' });
+        await update.impl(updateInput, {
+          ...context,
+          toolCallId: randomUUID(),
+        });
+        return coordinator.list(fixture.sessionId, {
+          includeTerminal: true,
+          includeArchived: false,
+          classifyResumeTrust: true,
+        });
+      },
+    );
+    assert.equal(toolPortProjection.length, TASK_LEDGER_PAGE_MAX_ITEMS + 1);
+    assert.deepEqual(toolPortProjection[0]?.owner, {
+      actor: 'main_agent',
+      runId: initialRunId,
+      turnId: initialTurnId,
+    });
+
+    const host = await fixture.startHost();
+    const desktop = await connectClient(fixture.root, 'desktop');
+    const tui = await connectClient(fixture.root, 'tui');
+    let staleContinuation:
+      | {
+          revision: TaskLedgerRevision;
+          cursor: string;
+          task: Task;
+        }
+      | undefined;
+    try {
+      const desktopProjection = await collectTaskLedgerProjection(desktop, fixture.sessionId);
+      const tuiProjection = await collectTaskLedgerProjection(tui, fixture.sessionId);
+      assert.deepEqual(
+        desktopProjection.pages.map((page) => page.tasks.length),
+        [TASK_LEDGER_PAGE_MAX_ITEMS, 1],
+      );
+      assert.deepEqual(tuiProjection, desktopProjection);
+      assert.deepEqual(desktopProjection.tasks, toolPortProjection);
+
+      const byKey = await tui.request('task.ledger.query', {
+        kind: 'get',
+        sessionId: fixture.sessionId,
+        taskRef: 'T1',
+      });
+      assert.equal(byKey.kind, 'task');
+      if (byKey.kind !== 'task') throw new Error('Expected Task Ledger get result');
+      assert.equal(byKey.sessionId, fixture.sessionId);
+      assert.deepEqual(byKey.task, desktopProjection.tasks[0]);
+      assert.equal(byKey.task?.owner?.runId, initialRunId);
+      assert.equal(byKey.task?.owner?.turnId, initialTurnId);
+
+      const firstPage = desktopProjection.pages[0];
+      assert.ok(firstPage?.nextCursor);
+      staleContinuation = {
+        revision: firstPage.revision,
+        cursor: firstPage.nextCursor,
+        task: desktopProjection.tasks[1]!,
+      };
+    } finally {
+      await Promise.allSettled([desktop.close(), tui.close()]);
+      await fixture.stopHost(host);
+    }
+
+    assert.ok(staleContinuation);
+    const { revision: staleRevision, cursor: staleCursor, task: taskToChange } = staleContinuation;
+    const successorTurnId = randomUUID();
+    const changedSubject = `${taskToChange.subject} after authority reacquisition`;
+    await withOwnedTaskLedgerToolPort(fixture, async (_coordinator, tools) => {
+      const update = requireTaskLedgerTool<TaskUpdateInput>(tools, 'task_update');
+      const input = update.parameters.parse({
+        id: taskToChange.key,
+        subject: changedSubject,
+      });
+      await update.impl(
+        input,
+        taskLedgerToolContext(fixture, {
+          runId: randomUUID(),
+          turnId: successorTurnId,
+          toolCallId: randomUUID(),
+        }),
+      );
+    });
+
+    const successorHost = await fixture.startHost();
+    const successor = await connectClient(fixture.root, 'desktop');
+    try {
+      const continued = await successor.request('task.ledger.query', {
+        kind: 'list_continue',
+        sessionId: fixture.sessionId,
+        revision: staleRevision,
+        cursor: staleCursor,
+      });
+      assert.equal(continued.kind, 'revision_changed');
+      if (continued.kind !== 'revision_changed') {
+        throw new Error('Expected stale Task Ledger continuation to report revision_changed');
+      }
+      assert.equal(continued.expected, staleRevision);
+      assert.notEqual(continued.actual, staleRevision);
+
+      const changed = await successor.request('task.ledger.query', {
+        kind: 'get',
+        sessionId: fixture.sessionId,
+        taskRef: taskToChange.key,
+      });
+      assert.equal(changed.kind, 'task');
+      if (changed.kind !== 'task') throw new Error('Expected changed Task Ledger task result');
+      assert.equal(changed.sessionId, fixture.sessionId);
+      assert.equal(changed.task?.subject, changedSubject);
+      assert.equal(changed.revision, continued.actual);
+    } finally {
+      await successor.close();
+      await fixture.stopHost(successorHost);
+    }
+  });
+});
 
 test('two UDS Clients share one Runtime Policy authority and CAS winner', async () => {
   await withExecutionRoot(async (fixture) => {
@@ -1228,6 +1376,104 @@ test('old-Epoch Message submit returns only exact durable outcomes', async () =>
     await fixture.stopHost(successorHost);
   });
 });
+
+interface TaskCreateInput {
+  tasks: Array<{ subject: string; parent_id?: string }>;
+}
+
+interface TaskUpdateInput {
+  id: string;
+  status?: 'pending' | 'in_progress' | 'blocked' | 'completed' | 'failed' | 'cancelled';
+  subject?: string;
+  blockedReason?: string;
+  failureReason?: string;
+  completionEvidence?: string;
+  explicitReopen?: boolean;
+}
+
+type TaskLedgerPage = Extract<TaskLedgerQueryResult, { kind: 'page' }>;
+type TaskLedgerTool<Input> = MakaTool<Input, string> & {
+  parameters: { parse(value: unknown): Input };
+};
+
+async function withOwnedTaskLedgerToolPort<T>(
+  fixture: ExecutionFixture,
+  run: (coordinator: HostTaskLedgerCoordinator, tools: MakaTool[]) => Promise<T>,
+): Promise<T> {
+  const owner = await tryAcquireInteractiveRootOwner(fixture.capability);
+  assert.ok(owner);
+  if (!owner) throw new Error('Unable to acquire the interactive Task Ledger tool port');
+  try {
+    const writer = await openInteractiveTaskLedgerStoreForWrite(owner.lease);
+    const coordinator = new HostTaskLedgerCoordinator(writer, new SessionAdmissionGate());
+    return await run(coordinator, buildTaskLedgerTools({ store: coordinator }));
+  } finally {
+    await owner.close();
+  }
+}
+
+function requireTaskLedgerTool<Input>(
+  tools: readonly MakaTool[],
+  name: 'task_create' | 'task_update',
+): TaskLedgerTool<Input> {
+  const tool = tools.find((candidate) => candidate.name === name);
+  assert.ok(tool, `Expected ${name} Runtime tool`);
+  return tool as TaskLedgerTool<Input>;
+}
+
+function taskLedgerToolContext(
+  fixture: ExecutionFixture,
+  identity: Pick<MakaToolContext, 'runId' | 'turnId' | 'toolCallId'>,
+): MakaToolContext {
+  return {
+    sessionId: fixture.sessionId,
+    cwd: fixture.root,
+    ...identity,
+    abortSignal: new AbortController().signal,
+    emitOutput: () => {},
+  };
+}
+
+async function collectTaskLedgerProjection(
+  client: RuntimeHostConnection,
+  sessionId: string,
+): Promise<{
+  revision: TaskLedgerRevision;
+  pages: TaskLedgerPage[];
+  tasks: Task[];
+}> {
+  const pages: TaskLedgerPage[] = [];
+  let result = await client.request('task.ledger.query', {
+    kind: 'list_start',
+    sessionId,
+  });
+  assert.equal(result.kind, 'page');
+  if (result.kind !== 'page') throw new Error('Expected initial Task Ledger page');
+  const revision = result.revision;
+
+  while (true) {
+    assert.equal(result.sessionId, sessionId);
+    assert.equal(result.revision, revision);
+    pages.push(result);
+    if (result.nextCursor === null) break;
+    result = await client.request('task.ledger.query', {
+      kind: 'list_continue',
+      sessionId,
+      revision,
+      cursor: result.nextCursor,
+    });
+    assert.equal(result.kind, 'page');
+    if (result.kind !== 'page') {
+      throw new Error('Task Ledger changed while collecting a stable projection');
+    }
+  }
+
+  return {
+    revision,
+    pages,
+    tasks: pages.flatMap((page) => page.tasks),
+  };
+}
 
 interface ExecutionHostHandle {
   child: ChildProcess;

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -32,7 +32,7 @@ import {
   tryAcquireInteractiveRootReader,
   type StorageRootCapability,
 } from '@maka/storage/root-authority';
-import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-store';
+import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-authority';
 import {
   connectRuntimeHost,
   RuntimeHostOperationError,

--- a/packages/runtime-host/src/__tests__/fixtures/uncooperative-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/uncooperative-host.ts
@@ -63,6 +63,10 @@ const host = await RuntimeHostKernel.start({
         ok: false,
         error: { code: 'operation_unavailable', message: 'Operation unavailable in test Host' },
       }),
+      'task.ledger.query': async () => ({
+        ok: false,
+        error: { code: 'operation_unavailable', message: 'Operation unavailable in test Host' },
+      }),
     },
     async recover() {},
     async close() {},

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -59,6 +59,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'runtime.policy.query',
       'subscription.close',
       'subscription.open',
+      'task.ledger.query',
       'turn.interrupt',
       'turn.message.submit',
       'turn.query',

--- a/packages/runtime-host/src/__tests__/task-ledger-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/task-ledger-protocol.test.ts
@@ -1,0 +1,309 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { Task } from '@maka/core/task-ledger';
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
+import {
+  decodeTaskLedgerQueryInput,
+  decodeTaskLedgerQueryResult,
+  encodeTaskLedgerTask,
+  encodeTaskLedgerQueryResult,
+  TASK_LEDGER_CURSOR_MAX_BYTES,
+  TASK_LEDGER_OPERATION_SPECS,
+  TASK_LEDGER_PAGE_MAX_BYTES,
+  TASK_LEDGER_PAGE_MAX_ITEMS,
+  type TaskLedgerQueryResult,
+} from '../protocol/task-ledger.js';
+
+const revision = `sha256:${'a'.repeat(64)}` as const;
+const nextRevision = `sha256:${'b'.repeat(64)}` as const;
+
+describe('Task Ledger protocol', () => {
+  test('declares the closed ready query and decodes all input branches', () => {
+    const spec = TASK_LEDGER_OPERATION_SPECS['task.ledger.query'];
+    assert.equal(spec.mode, 'query');
+    assert.equal(spec.availability, 'ready');
+    assert.deepEqual(spec.errors, [
+      'host_not_ready',
+      'host_draining',
+      'operation_unavailable',
+      'invalid_request',
+      'internal_failure',
+    ]);
+
+    for (const input of [
+      { kind: 'list_start', sessionId: 'session-1' },
+      { kind: 'list_continue', sessionId: 'session-1', revision, cursor: 'opaque:2' },
+      { kind: 'get', sessionId: 'session-1', taskRef: 'T1.2' },
+    ] as const) {
+      assert.deepEqual(decodeTaskLedgerQueryInput(input), input);
+    }
+  });
+
+  test('round-trips every result branch and the current child-session owner', () => {
+    const task = validTask(0, {
+      owner: {
+        actor: 'child_agent',
+        sessionId: 'child-session-1',
+        agentId: 'child-1',
+        runId: 'run-1',
+        turnId: 'turn-1',
+      },
+      resumeTrust: 'needs_revalidation',
+    });
+    const results: TaskLedgerQueryResult[] = [
+      {
+        kind: 'page',
+        sessionId: 'session-1',
+        revision,
+        tasks: [task],
+        nextCursor: 'opaque:2',
+      },
+      { kind: 'revision_changed', expected: revision, actual: nextRevision },
+      { kind: 'task', sessionId: 'session-1', revision, task },
+      { kind: 'task', sessionId: 'session-1', revision, task: null },
+    ];
+
+    for (const result of results) {
+      const encoded = encodeTaskLedgerQueryResult(result);
+      assert.deepEqual(decodeTaskLedgerQueryResult(encoded), encoded);
+    }
+  });
+
+  test('rejects unknown fields and invalid current Task DTO values', () => {
+    const task = validTask();
+    for (const invalid of [
+      { ...task, rawEventPath: '/private/task-events.jsonl' },
+      { ...task, id: '../task' },
+      { ...task, key: 'task-1' },
+      { ...task, subject: ' Task 0 ' },
+      { ...task, status: 'done' },
+      { ...task, blockedReason: ' blocked ' },
+      { ...task, resumeTrust: 'probably_ok' },
+      { ...task, createdAt: Number.NaN },
+      { ...task, updatedAt: Number.POSITIVE_INFINITY },
+      {
+        ...task,
+        owner: { actor: 'child_agent', sessionId: 'child-session-1', socketPath: '/tmp/a' },
+      },
+    ]) {
+      assertInvalid(() =>
+        decodeTaskLedgerQueryResult({
+          kind: 'task',
+          sessionId: 'session-1',
+          revision,
+          task: invalid,
+        }),
+      );
+    }
+
+    assertInvalid(() =>
+      decodeTaskLedgerQueryInput({ kind: 'list_start', sessionId: 'session-1', cursor: '0' }),
+    );
+    assertInvalid(() =>
+      decodeTaskLedgerQueryResult({
+        kind: 'revision_changed',
+        expected: revision,
+        actual: nextRevision,
+        cursor: '0',
+      }),
+    );
+  });
+
+  test('projects legacy evidence-incomplete tasks to conservative resume trust', () => {
+    for (const task of [
+      validTask(0, { status: 'blocked' }),
+      validTask(1, { status: 'failed' }),
+      validTask(2, { status: 'completed' }),
+    ]) {
+      assert.equal(encodeTaskLedgerTask(task).resumeTrust, 'needs_revalidation');
+    }
+
+    const task = validTask(3, {
+      status: 'completed',
+      resumeTrust: 'needs_revalidation',
+    });
+    const result = {
+      kind: 'task' as const,
+      sessionId: 'session-1',
+      revision,
+      task,
+    };
+    assert.deepEqual(decodeTaskLedgerQueryResult(encodeTaskLedgerQueryResult(result)), result);
+
+    const untrustedTask = validTask(4, {
+      status: 'completed',
+      resumeTrust: 'untrusted',
+    });
+    const untrustedResult = {
+      kind: 'task' as const,
+      sessionId: 'session-1',
+      revision,
+      task: untrustedTask,
+    };
+    assert.deepEqual(encodeTaskLedgerTask(untrustedTask), untrustedTask);
+    assert.deepEqual(
+      decodeTaskLedgerQueryResult(encodeTaskLedgerQueryResult(untrustedResult)),
+      untrustedResult,
+    );
+
+    for (const resumeTrust of [undefined, 'trusted'] as const) {
+      const result = {
+        kind: 'task' as const,
+        sessionId: 'session-1',
+        revision,
+        task: validTask(5, {
+          status: 'completed',
+          ...(resumeTrust === undefined ? {} : { resumeTrust }),
+        }),
+      };
+      assertInvalid(() => decodeTaskLedgerQueryResult(result));
+    }
+  });
+
+  test('projects producer text once and accepts only wire-canonical DTOs', () => {
+    const producerTasks = [
+      validTask(0, { subject: 'A <task-ledger> B' }),
+      validTask(1, {
+        subject: '<task-ledger>',
+        status: 'completed',
+        completionEvidence: 'Verified <task-ledger> ghp_abcdefghijklmnopqrstuvwxyz123456',
+        resumeTrust: 'trusted',
+      }),
+      validTask(2, {
+        status: 'failed',
+        failureReason: '<task-ledger>',
+        resumeTrust: 'trusted',
+      }),
+      validTask(3, {
+        status: 'blocked',
+        blockedReason: '<task-ledger>',
+        resumeTrust: 'untrusted',
+      }),
+    ];
+    const encoded = encodeTaskLedgerQueryResult({
+      kind: 'page',
+      sessionId: 'session-1',
+      revision,
+      tasks: producerTasks,
+      nextCursor: null,
+    });
+    assert.equal(encoded.kind, 'page');
+    assert.equal(encoded.kind === 'page' && encoded.tasks[0]?.subject, 'A B');
+    assert.equal(encoded.kind === 'page' && encoded.tasks[1]?.subject, '[redacted]');
+    assert.equal(
+      encoded.kind === 'page' && encoded.tasks[1]?.completionEvidence,
+      'Verified [redacted]',
+    );
+    assert.equal(encoded.kind === 'page' && encoded.tasks[2]?.failureReason, undefined);
+    assert.equal(encoded.kind === 'page' && encoded.tasks[2]?.resumeTrust, 'needs_revalidation');
+    assert.equal(encoded.kind === 'page' && encoded.tasks[3]?.blockedReason, undefined);
+    assert.equal(encoded.kind === 'page' && encoded.tasks[3]?.resumeTrust, 'untrusted');
+    assert.deepEqual(
+      encoded.kind === 'page' ? encoded.tasks : [],
+      producerTasks.map(encodeTaskLedgerTask),
+    );
+    assert.deepEqual(decodeTaskLedgerQueryResult(encoded), encoded);
+
+    for (const task of producerTasks) {
+      assertInvalid(() =>
+        decodeTaskLedgerQueryResult({
+          kind: 'task',
+          sessionId: 'session-1',
+          revision,
+          task,
+        }),
+      );
+    }
+  });
+
+  test('enforces revision and UTF-8 cursor bounds', () => {
+    for (const invalidRevision of [
+      'a'.repeat(64),
+      `sha256:${'A'.repeat(64)}`,
+      `sha256:${'a'.repeat(63)}`,
+    ]) {
+      assertInvalid(() =>
+        decodeTaskLedgerQueryInput({
+          kind: 'list_continue',
+          sessionId: 'session-1',
+          revision: invalidRevision,
+          cursor: 'opaque',
+        }),
+      );
+    }
+
+    for (const cursor of ['', '界'.repeat(Math.floor(TASK_LEDGER_CURSOR_MAX_BYTES / 3) + 1)]) {
+      assertInvalid(() =>
+        decodeTaskLedgerQueryInput({
+          kind: 'list_continue',
+          sessionId: 'session-1',
+          revision,
+          cursor,
+        }),
+      );
+      assertInvalid(() =>
+        decodeTaskLedgerQueryResult({
+          kind: 'page',
+          sessionId: 'session-1',
+          revision,
+          tasks: [],
+          nextCursor: cursor,
+        }),
+      );
+    }
+  });
+
+  test('enforces item and encoded UTF-8 page bounds in both codec directions', () => {
+    const tooMany = Array.from({ length: TASK_LEDGER_PAGE_MAX_ITEMS + 1 }, (_, index) =>
+      validTask(index),
+    );
+    const byteHeavy = Array.from({ length: 48 }, (_, index) =>
+      validTask(index, {
+        status: 'completed',
+        subject: 'subject '.repeat(25).trim(),
+        completionEvidence: 'evidence '.repeat(125).trim(),
+        endedAt: 3,
+      }),
+    );
+    const oversizedByItems = page(tooMany);
+    const oversizedByBytes = page(byteHeavy);
+    assert.ok(
+      Buffer.byteLength(JSON.stringify(oversizedByBytes), 'utf8') > TASK_LEDGER_PAGE_MAX_BYTES,
+    );
+
+    for (const result of [oversizedByItems, oversizedByBytes]) {
+      assertInvalid(() => encodeTaskLedgerQueryResult(result));
+      assertInvalid(() => decodeTaskLedgerQueryResult(result));
+    }
+  });
+});
+
+function validTask(index = 0, overrides: Partial<Task> = {}): Task {
+  return {
+    id: `task-${index}`,
+    key: `T${index + 1}`,
+    subject: `Task ${index}`,
+    status: 'in_progress',
+    createdAt: 1,
+    updatedAt: 2,
+    owner: { actor: 'main_agent', runId: 'run-1' },
+    ...overrides,
+  };
+}
+
+function page(tasks: readonly unknown[]) {
+  return {
+    kind: 'page',
+    sessionId: 'session-1',
+    revision,
+    tasks,
+    nextCursor: null,
+  };
+}
+
+function assertInvalid(action: () => unknown): void {
+  assert.throws(
+    action,
+    (error: unknown) => error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame',
+  );
+}

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -19,6 +19,7 @@ export { RuntimeHostProtocolError } from './errors.js';
 export * from './message.js';
 export * from './operations.js';
 export * from './session-continuity.js';
+export * from './task-ledger.js';
 
 export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;
 export const RUNTIME_HOST_PROTOCOL_VERSION = 0 as const;

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -10,6 +10,7 @@ import {
 } from './operation-spec.js';
 import { RUNTIME_POLICY_OPERATION_SPECS } from './runtime-policy.js';
 import { SESSION_CONTINUITY_OPERATION_SPECS } from './session-continuity.js';
+import { TASK_LEDGER_OPERATION_SPECS } from './task-ledger.js';
 import { TURN_OPERATION_SPECS } from './turn.js';
 
 export type { HostLifecycleState, HostStatusInput, HostStatusResult } from './host-status.js';
@@ -57,8 +58,13 @@ const CORE_AND_MESSAGE_OPERATION_SPECS = composeOperationSpecMaps(
   MESSAGE_OPERATION_SPECS,
 );
 
-export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
+const CORE_MESSAGE_AND_TASK_LEDGER_OPERATION_SPECS = composeOperationSpecMaps(
   CORE_AND_MESSAGE_OPERATION_SPECS,
+  TASK_LEDGER_OPERATION_SPECS,
+);
+
+export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
+  CORE_MESSAGE_AND_TASK_LEDGER_OPERATION_SPECS,
   SESSION_CONTINUITY_OPERATION_SPECS,
 );
 

--- a/packages/runtime-host/src/protocol/task-ledger.ts
+++ b/packages/runtime-host/src/protocol/task-ledger.ts
@@ -1,0 +1,405 @@
+import {
+  TASK_EVIDENCE_MAX_CHARS,
+  TASK_SUBJECT_MAX_CHARS,
+  isResumeTrust,
+  isSafeTaskId,
+  isTaskKey,
+  isTaskOwner,
+  isTaskStatus,
+  normalizeTaskEvidenceText,
+  normalizeTaskSubject,
+  sanitizeTaskLedgerTask,
+  type Task,
+  type TaskOwner,
+  validateTaskEvidence,
+} from '@maka/core/task-ledger';
+import { requireEntityId, requireExactRecord, requireRecord } from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+export const TASK_LEDGER_PAGE_MAX_ITEMS = 128;
+export const TASK_LEDGER_PAGE_MAX_BYTES = 48 * 1024;
+export const TASK_LEDGER_CURSOR_MAX_BYTES = 512;
+
+const TASK_REQUIRED_FIELDS = ['id', 'key', 'subject', 'status', 'createdAt', 'updatedAt'] as const;
+const TASK_FIELDS = [
+  ...TASK_REQUIRED_FIELDS,
+  'parentId',
+  'owner',
+  'endedAt',
+  'blockedReason',
+  'failureReason',
+  'completionEvidence',
+  'resumeTrust',
+] as const;
+const TASK_OWNER_FIELDS = ['actor', 'sessionId', 'agentId', 'runId', 'turnId'] as const;
+const REDACTED_TASK_TEXT = '[redacted]';
+
+const QUERY_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'invalid_request',
+  'internal_failure',
+] as const;
+
+export type TaskLedgerRevision = `sha256:${string}`;
+export type TaskLedgerTask = Readonly<Task>;
+
+export type TaskLedgerQueryInput =
+  | { readonly kind: 'list_start'; readonly sessionId: string }
+  | {
+      readonly kind: 'list_continue';
+      readonly sessionId: string;
+      readonly revision: TaskLedgerRevision;
+      readonly cursor: string;
+    }
+  | { readonly kind: 'get'; readonly sessionId: string; readonly taskRef: string };
+
+export type TaskLedgerQueryResult =
+  | {
+      readonly kind: 'page';
+      readonly sessionId: string;
+      readonly revision: TaskLedgerRevision;
+      readonly tasks: readonly TaskLedgerTask[];
+      readonly nextCursor: string | null;
+    }
+  | {
+      readonly kind: 'revision_changed';
+      readonly expected: TaskLedgerRevision;
+      readonly actual: TaskLedgerRevision;
+    }
+  | {
+      readonly kind: 'task';
+      readonly sessionId: string;
+      readonly revision: TaskLedgerRevision;
+      readonly task: TaskLedgerTask | null;
+    };
+
+export const TASK_LEDGER_OPERATION_SPECS = {
+  'task.ledger.query': defineOperation<
+    TaskLedgerQueryInput,
+    TaskLedgerQueryResult,
+    (typeof QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeTaskLedgerQueryInput,
+    decodeOutput: decodeTaskLedgerQueryResult,
+  }),
+} as const;
+
+export function decodeTaskLedgerQueryInput(value: unknown): TaskLedgerQueryInput {
+  const record = requireRecord(value, 'task ledger query input');
+  if (record.kind === 'list_start') {
+    const input = requireExactRecord(record, 'task ledger list start input', ['kind', 'sessionId']);
+    return { kind: 'list_start', sessionId: requireEntityId(input.sessionId, 'sessionId') };
+  }
+  if (record.kind === 'list_continue') {
+    const input = requireExactRecord(record, 'task ledger list continuation input', [
+      'kind',
+      'sessionId',
+      'revision',
+      'cursor',
+    ]);
+    return {
+      kind: 'list_continue',
+      sessionId: requireEntityId(input.sessionId, 'sessionId'),
+      revision: taskLedgerRevision(input.revision, 'task ledger revision'),
+      cursor: taskLedgerCursor(input.cursor, 'task ledger cursor'),
+    };
+  }
+  if (record.kind === 'get') {
+    const input = requireExactRecord(record, 'task ledger get input', [
+      'kind',
+      'sessionId',
+      'taskRef',
+    ]);
+    return {
+      kind: 'get',
+      sessionId: requireEntityId(input.sessionId, 'sessionId'),
+      taskRef: taskReference(input.taskRef),
+    };
+  }
+  throw invalidProtocolFrame('Invalid task ledger query kind');
+}
+
+export function decodeTaskLedgerQueryResult(value: unknown): TaskLedgerQueryResult {
+  return taskLedgerQueryResult(value, 'decode');
+}
+
+export function encodeTaskLedgerQueryResult(value: unknown): TaskLedgerQueryResult {
+  return taskLedgerQueryResult(value, 'encode');
+}
+
+export function encodeTaskLedgerTask(value: unknown): TaskLedgerTask {
+  return taskLedgerTask(value, 'encode');
+}
+
+function taskLedgerQueryResult(
+  value: unknown,
+  direction: 'encode' | 'decode',
+): TaskLedgerQueryResult {
+  const record = requireRecord(value, 'task ledger query result');
+  if (record.kind === 'revision_changed') {
+    const changed = requireExactRecord(record, 'task ledger revision changed result', [
+      'kind',
+      'expected',
+      'actual',
+    ]);
+    return {
+      kind: 'revision_changed',
+      expected: taskLedgerRevision(changed.expected, 'expected task ledger revision'),
+      actual: taskLedgerRevision(changed.actual, 'actual task ledger revision'),
+    };
+  }
+  if (record.kind === 'task') {
+    const result = requireExactRecord(record, 'task ledger task result', [
+      'kind',
+      'sessionId',
+      'revision',
+      'task',
+    ]);
+    return {
+      kind: 'task',
+      sessionId: requireEntityId(result.sessionId, 'sessionId'),
+      revision: taskLedgerRevision(result.revision, 'task ledger revision'),
+      task: result.task === null ? null : taskLedgerTask(result.task, direction),
+    };
+  }
+  if (record.kind !== 'page') throw invalidProtocolFrame('Invalid task ledger query result kind');
+
+  const page = requireExactRecord(record, 'task ledger page result', [
+    'kind',
+    'sessionId',
+    'revision',
+    'tasks',
+    'nextCursor',
+  ]);
+  if (!Array.isArray(page.tasks) || page.tasks.length > TASK_LEDGER_PAGE_MAX_ITEMS) {
+    throw invalidProtocolFrame('Task ledger page exceeds item limit');
+  }
+  const decoded: TaskLedgerQueryResult = {
+    kind: 'page',
+    sessionId: requireEntityId(page.sessionId, 'sessionId'),
+    revision: taskLedgerRevision(page.revision, 'task ledger revision'),
+    tasks: page.tasks.map((task) => taskLedgerTask(task, direction)),
+    nextCursor:
+      page.nextCursor === null
+        ? null
+        : taskLedgerCursor(page.nextCursor, 'task ledger next cursor'),
+  };
+  if (jsonByteLength(decoded) > TASK_LEDGER_PAGE_MAX_BYTES) {
+    throw invalidProtocolFrame('Task ledger page exceeds byte limit');
+  }
+  return decoded;
+}
+
+function taskLedgerTask(value: unknown, direction: 'encode' | 'decode'): TaskLedgerTask {
+  const record = requireRecord(value, 'task ledger task');
+  assertAllowedKeys(record, 'task ledger task', TASK_FIELDS);
+  if (TASK_REQUIRED_FIELDS.some((field) => !Object.hasOwn(record, field))) {
+    throw invalidProtocolFrame('Invalid task ledger task fields');
+  }
+
+  const task: Task = {
+    id: stableTaskId(record.id, 'task id'),
+    key: taskKey(record.key),
+    subject: boundedTaskText(record.subject, 'subject'),
+    status: taskStatus(record.status),
+    createdAt: timestamp(record.createdAt, 'task createdAt'),
+    updatedAt: timestamp(record.updatedAt, 'task updatedAt'),
+    ...optionalStableTaskId(record, 'parentId'),
+    ...optionalOwner(record),
+    ...optionalTimestamp(record, 'endedAt'),
+    ...optionalTaskText(record, 'blockedReason'),
+    ...optionalTaskText(record, 'failureReason'),
+    ...optionalTaskText(record, 'completionEvidence'),
+    ...optionalResumeTrust(record),
+  };
+  const projected = projectTaskForWire(task);
+  if (direction === 'decode' && !hasCanonicalWireProjection(task, projected)) {
+    throw invalidProtocolFrame('Task ledger task is not sanitized');
+  }
+  return projected;
+}
+
+function optionalStableTaskId(
+  record: Record<string, unknown>,
+  field: 'parentId',
+): Pick<Task, 'parentId'> | Record<string, never> {
+  return Object.hasOwn(record, field)
+    ? { [field]: stableTaskId(record[field], `task ${field}`) }
+    : {};
+}
+
+function optionalOwner(
+  record: Record<string, unknown>,
+): Pick<Task, 'owner'> | Record<string, never> {
+  if (!Object.hasOwn(record, 'owner')) return {};
+  return { owner: taskOwner(record.owner) };
+}
+
+function taskOwner(value: unknown): TaskOwner {
+  const record = requireRecord(value, 'task owner');
+  assertAllowedKeys(record, 'task owner', TASK_OWNER_FIELDS);
+  if (!Object.hasOwn(record, 'actor') || !isTaskOwner(record)) {
+    throw invalidProtocolFrame('Invalid task owner');
+  }
+  return {
+    actor: record.actor as TaskOwner['actor'],
+    ...optionalOwnerId(record, 'sessionId'),
+    ...optionalOwnerId(record, 'agentId'),
+    ...optionalOwnerId(record, 'runId'),
+    ...optionalOwnerId(record, 'turnId'),
+  };
+}
+
+function optionalOwnerId<Field extends Exclude<keyof TaskOwner, 'actor'>>(
+  record: Record<string, unknown>,
+  field: Field,
+): Pick<TaskOwner, Field> | Record<string, never> {
+  return Object.hasOwn(record, field)
+    ? ({ [field]: stableTaskId(record[field], `task owner ${field}`) } as Pick<TaskOwner, Field>)
+    : {};
+}
+
+function optionalTimestamp(
+  record: Record<string, unknown>,
+  field: 'endedAt',
+): Pick<Task, 'endedAt'> | Record<string, never> {
+  return Object.hasOwn(record, field) ? { [field]: timestamp(record[field], `task ${field}`) } : {};
+}
+
+function optionalTaskText<Field extends 'blockedReason' | 'failureReason' | 'completionEvidence'>(
+  record: Record<string, unknown>,
+  field: Field,
+): Pick<Task, Field> | Record<string, never> {
+  return Object.hasOwn(record, field)
+    ? ({ [field]: boundedTaskText(record[field], field) } as Pick<Task, Field>)
+    : {};
+}
+
+function optionalResumeTrust(
+  record: Record<string, unknown>,
+): Pick<Task, 'resumeTrust'> | Record<string, never> {
+  if (!Object.hasOwn(record, 'resumeTrust')) return {};
+  if (!isResumeTrust(record.resumeTrust)) throw invalidProtocolFrame('Invalid task resumeTrust');
+  return { resumeTrust: record.resumeTrust };
+}
+
+function boundedTaskText(
+  value: unknown,
+  field: 'subject' | 'blockedReason' | 'failureReason' | 'completionEvidence',
+): string {
+  const maxCharacters = field === 'subject' ? TASK_SUBJECT_MAX_CHARS : TASK_EVIDENCE_MAX_CHARS;
+  if (typeof value !== 'string' || value.length === 0 || Array.from(value).length > maxCharacters) {
+    throw invalidProtocolFrame(`Invalid task ${field}`);
+  }
+  return value;
+}
+
+function projectTaskForWire(task: Task): Task {
+  const sanitized = sanitizeTaskLedgerTask(task);
+  const { blockedReason, failureReason, completionEvidence, ...identity } = sanitized;
+  const projected: Task = {
+    ...identity,
+    subject: canonicalWireSubject(sanitized.subject),
+    ...canonicalWireEvidence(blockedReason, 'blockedReason'),
+    ...canonicalWireEvidence(failureReason, 'failureReason'),
+    ...canonicalWireEvidence(completionEvidence, 'completionEvidence'),
+  };
+  if (validateTaskEvidence(projected).ok) return projected;
+  if (projected.resumeTrust !== undefined && projected.resumeTrust !== 'trusted') return projected;
+  return { ...projected, resumeTrust: 'needs_revalidation' };
+}
+
+function hasCanonicalWireProjection(task: Task, projected: Task): boolean {
+  return (
+    task.subject === projected.subject &&
+    task.blockedReason === projected.blockedReason &&
+    task.failureReason === projected.failureReason &&
+    task.completionEvidence === projected.completionEvidence &&
+    task.resumeTrust === projected.resumeTrust
+  );
+}
+
+function canonicalWireSubject(value: string): string {
+  const normalized = normalizeTaskSubject(value);
+  if (normalized.ok) return normalized.value;
+  if (value.trim().length === 0) return REDACTED_TASK_TEXT;
+  throw invalidProtocolFrame('Invalid task subject');
+}
+
+function canonicalWireEvidence<
+  Field extends 'blockedReason' | 'failureReason' | 'completionEvidence',
+>(value: string | undefined, field: Field): Pick<Task, Field> | Record<string, never> {
+  if (value === undefined) return {};
+  const normalized = normalizeTaskEvidenceText(value, field);
+  if (normalized.ok) return { [field]: normalized.value } as Pick<Task, Field>;
+  if (value.trim().length === 0) return {};
+  throw invalidProtocolFrame(`Invalid task ${field}`);
+}
+
+function stableTaskId(value: unknown, label: string): string {
+  if (!isSafeTaskId(value)) throw invalidProtocolFrame(`Invalid ${label}`);
+  return value;
+}
+
+function taskKey(value: unknown): string {
+  if (!isTaskKey(value)) throw invalidProtocolFrame('Invalid task key');
+  return value;
+}
+
+function taskReference(value: unknown): string {
+  if (!isSafeTaskId(value) && !isTaskKey(value)) {
+    throw invalidProtocolFrame('Invalid task reference');
+  }
+  return value;
+}
+
+function taskStatus(value: unknown): Task['status'] {
+  if (!isTaskStatus(value)) throw invalidProtocolFrame('Invalid task status');
+  return value;
+}
+
+function timestamp(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value;
+}
+
+function taskLedgerRevision(value: unknown, label: string): TaskLedgerRevision {
+  if (typeof value !== 'string' || !/^sha256:[a-f0-9]{64}$/.test(value)) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value as TaskLedgerRevision;
+}
+
+function taskLedgerCursor(value: unknown, label: string): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    Buffer.byteLength(value, 'utf8') > TASK_LEDGER_CURSOR_MAX_BYTES
+  ) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value;
+}
+
+function assertAllowedKeys(
+  record: Record<string, unknown>,
+  label: string,
+  keys: readonly string[],
+): void {
+  const allowed = new Set(keys);
+  if (Object.keys(record).some((key) => !allowed.has(key))) {
+    throw invalidProtocolFrame(`Unknown ${label} field`);
+  }
+}
+
+function jsonByteLength(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -7,7 +7,7 @@ import {
 } from '@maka/runtime';
 import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
 import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
-import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-store';
+import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-authority';
 import { CanonicalSessionProjectionReader } from './canonical-session-projection.js';
 import type { RuntimeHostComposition, RuntimeHostCompositionContext } from './host-kernel.js';
 import { type HostMessageRootPort, HostMessageCoordinator } from './message-coordinator.js';

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -7,6 +7,7 @@ import {
 } from '@maka/runtime';
 import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-stores';
 import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
+import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-store';
 import { CanonicalSessionProjectionReader } from './canonical-session-projection.js';
 import type { RuntimeHostComposition, RuntimeHostCompositionContext } from './host-kernel.js';
 import { type HostMessageRootPort, HostMessageCoordinator } from './message-coordinator.js';
@@ -17,6 +18,7 @@ import { RuntimePolicyActivationGate } from './runtime-policy-activation-gate.js
 import { HostRuntimePolicyCoordinator } from './runtime-policy-coordinator.js';
 import { SessionAdmissionGate } from './session-admission-gate.js';
 import { SessionContinuityCoordinator } from './session-continuity-coordinator.js';
+import { HostTaskLedgerCoordinator } from './task-ledger-coordinator.js';
 
 export async function createExecutionRuntimeHostComposition(
   context: RuntimeHostCompositionContext,
@@ -26,11 +28,13 @@ export async function createExecutionRuntimeHostComposition(
     const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
       context.owner.lease,
     );
+    const taskLedgerStore = await openInteractiveTaskLedgerStoreForWrite(context.owner.lease);
     await stores.messageReceiptStore.beginHostEpoch(context.hostEpoch);
     const backends = new BackendRegistry();
     backends.register('fake', (backendContext) => new FakeBackend(backendContext));
     const runtimePolicyActivation = new RuntimePolicyActivationGate();
     const sessionAdmission = new SessionAdmissionGate();
+    const taskLedger = new HostTaskLedgerCoordinator(taskLedgerStore, sessionAdmission);
     let rootCoordinator: RootTurnCoordinator | undefined;
     let continuity: SessionContinuityCoordinator | undefined;
     const rootPort: HostMessageRootPort = {
@@ -118,6 +122,7 @@ export async function createExecutionRuntimeHostComposition(
       ...messages.handlers,
       ...runtimePolicy.handlers,
       ...continuityCoordinator.handlers,
+      ...taskLedger.handlers,
     } satisfies DomainOperationHandlerMap;
     return {
       handlers,

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -47,6 +47,7 @@ export type SessionContinuityOperationKey = Extract<
   OperationKey,
   'subscription.open' | 'subscription.close'
 >;
+export type TaskLedgerOperationKey = Extract<OperationKey, 'task.ledger.query'>;
 export type DomainOperationHandlerMap = Pick<OperationHandlerMap, DomainOperationKey>;
 export type TurnOperationHandlerMap = Pick<OperationHandlerMap, TurnOperationKey>;
 export type RuntimePolicyOperationHandlerMap = Pick<OperationHandlerMap, RuntimePolicyOperationKey>;
@@ -55,6 +56,7 @@ export type SessionContinuityOperationHandlerMap = Pick<
   OperationHandlerMap,
   SessionContinuityOperationKey
 >;
+export type TaskLedgerOperationHandlerMap = Pick<OperationHandlerMap, TaskLedgerOperationKey>;
 
 export function composeOperationHandlers(
   ...handlerMaps: readonly Partial<OperationHandlerMap>[]

--- a/packages/runtime-host/src/server/task-ledger-coordinator.ts
+++ b/packages/runtime-host/src/server/task-ledger-coordinator.ts
@@ -13,7 +13,7 @@ import {
 import {
   authenticateInteractiveTaskLedgerWriter,
   type InteractiveTaskLedgerWriter,
-} from '@maka/storage/task-ledger-store';
+} from '@maka/storage/task-ledger-authority';
 import {
   encodeTaskLedgerTask,
   encodeTaskLedgerQueryResult,

--- a/packages/runtime-host/src/server/task-ledger-coordinator.ts
+++ b/packages/runtime-host/src/server/task-ledger-coordinator.ts
@@ -1,0 +1,221 @@
+import { createHash } from 'node:crypto';
+import {
+  findTaskByRef,
+  type Task,
+  type TaskAgentOutcome,
+  type TaskAvailableClaimScope,
+  type TaskLedgerChangedEvent,
+  type TaskLedgerListOptions,
+  type TaskLedgerMutationContext,
+  type TaskLedgerStore,
+  type TaskOwner,
+} from '@maka/core/task-ledger';
+import {
+  authenticateInteractiveTaskLedgerWriter,
+  type InteractiveTaskLedgerWriter,
+} from '@maka/storage/task-ledger-store';
+import {
+  encodeTaskLedgerTask,
+  encodeTaskLedgerQueryResult,
+  TASK_LEDGER_PAGE_MAX_BYTES,
+  TASK_LEDGER_PAGE_MAX_ITEMS,
+  type OperationOutcome,
+  type TaskLedgerQueryInput,
+  type TaskLedgerQueryResult,
+  type TaskLedgerRevision,
+  type TaskLedgerTask,
+} from '../protocol/index.js';
+import type { TaskLedgerOperationHandlerMap } from './operation-dispatcher.js';
+import { SessionAdmissionGate } from './session-admission-gate.js';
+
+const CANONICAL_LIST_OPTIONS = Object.freeze({
+  includeTerminal: true,
+  includeArchived: false,
+  classifyResumeTrust: true,
+});
+
+/** The Host-owned Task Ledger authority shared by Client queries and Runtime tools. */
+export class HostTaskLedgerCoordinator implements TaskLedgerStore {
+  readonly handlers: TaskLedgerOperationHandlerMap = {
+    'task.ledger.query': (input) => this.#query(input),
+  };
+
+  readonly #writer: InteractiveTaskLedgerWriter;
+
+  constructor(
+    writer: InteractiveTaskLedgerWriter,
+    private readonly sessionAdmission: SessionAdmissionGate,
+  ) {
+    this.#writer = authenticateInteractiveTaskLedgerWriter(writer);
+  }
+
+  list(sessionId: string, options?: TaskLedgerListOptions): Promise<Task[]> {
+    return this.sessionAdmission.run(sessionId, () => this.#writer.list(sessionId, options));
+  }
+
+  get(sessionId: string, id: string, options?: TaskLedgerListOptions): Promise<Task | undefined> {
+    return this.sessionAdmission.run(sessionId, () => this.#writer.get(sessionId, id, options));
+  }
+
+  create(
+    sessionId: string,
+    drafts: unknown,
+    context?: TaskLedgerMutationContext,
+  ): Promise<{ created: Task[]; total: number }> {
+    return this.sessionAdmission.run(sessionId, () =>
+      this.#writer.create(sessionId, drafts, context),
+    );
+  }
+
+  update(
+    sessionId: string,
+    id: string,
+    patch: unknown,
+    context?: TaskLedgerMutationContext,
+  ): Promise<{ updated: Task; total: number }> {
+    return this.sessionAdmission.run(sessionId, () =>
+      this.#writer.update(sessionId, id, patch, context),
+    );
+  }
+
+  claim(
+    sessionId: string,
+    id: string,
+    owner: TaskOwner,
+    context?: TaskLedgerMutationContext,
+  ): Promise<{ updated: Task; total: number }> {
+    return this.sessionAdmission.run(sessionId, () =>
+      this.#writer.claim(sessionId, id, owner, context),
+    );
+  }
+
+  claimAvailable(
+    sessionId: string,
+    id: string,
+    owner: TaskOwner,
+    scope: TaskAvailableClaimScope,
+    context?: TaskLedgerMutationContext,
+  ): Promise<{ updated: Task; total: number }> {
+    return this.sessionAdmission.run(sessionId, () =>
+      this.#writer.claimAvailable(sessionId, id, owner, scope, context),
+    );
+  }
+
+  settleAgentOutcome(
+    sessionId: string,
+    id: string,
+    outcome: TaskAgentOutcome,
+    context?: TaskLedgerMutationContext,
+  ): Promise<{ updated: Task; total: number }> {
+    return this.sessionAdmission.run(sessionId, () =>
+      this.#writer.settleAgentOutcome(sessionId, id, outcome, context),
+    );
+  }
+
+  subscribe(listener: (event: TaskLedgerChangedEvent) => void): () => void {
+    return this.#writer.subscribe(listener);
+  }
+
+  #query(input: TaskLedgerQueryInput): Promise<OperationOutcome<'task.ledger.query'>> {
+    return this.sessionAdmission.run(input.sessionId, async () => {
+      const tasks = (await this.#writer.list(input.sessionId, CANONICAL_LIST_OPTIONS)).map(
+        encodeTaskLedgerTask,
+      );
+      const revision = taskLedgerRevision(tasks);
+
+      if (input.kind === 'get') {
+        return success(
+          encodeTaskLedgerQueryResult({
+            kind: 'task',
+            sessionId: input.sessionId,
+            revision,
+            task: findTaskByRef(tasks, input.taskRef) ?? null,
+          }),
+        );
+      }
+
+      if (input.kind === 'list_continue' && input.revision !== revision) {
+        return success({
+          kind: 'revision_changed',
+          expected: input.revision,
+          actual: revision,
+        });
+      }
+
+      const offset = input.kind === 'list_start' ? 0 : decodeCursor(input.cursor);
+      if (
+        offset === undefined ||
+        offset > tasks.length ||
+        (input.kind === 'list_continue' && offset === tasks.length)
+      ) {
+        return invalidRequest('Task ledger cursor is invalid');
+      }
+      return success(createPage(input.sessionId, revision, tasks, offset));
+    });
+  }
+}
+
+function taskLedgerRevision(tasks: readonly TaskLedgerTask[]): TaskLedgerRevision {
+  return `sha256:${createHash('sha256').update(JSON.stringify(tasks)).digest('hex')}`;
+}
+
+function createPage(
+  sessionId: string,
+  revision: TaskLedgerRevision,
+  tasks: readonly TaskLedgerTask[],
+  offset: number,
+): TaskLedgerQueryResult {
+  const pageTasks: TaskLedgerTask[] = [];
+  for (let index = offset; index < tasks.length; index += 1) {
+    if (pageTasks.length >= TASK_LEDGER_PAGE_MAX_ITEMS) break;
+    const task = tasks[index];
+    if (!task) throw invariantFailure('Task projection index was out of bounds');
+    const candidateTasks = [...pageTasks, task];
+    const nextOffset = index + 1;
+    const candidate = {
+      kind: 'page' as const,
+      sessionId,
+      revision,
+      tasks: candidateTasks,
+      nextCursor: nextOffset < tasks.length ? encodeCursor(nextOffset) : null,
+    };
+    if (Buffer.byteLength(JSON.stringify(candidate), 'utf8') > TASK_LEDGER_PAGE_MAX_BYTES) {
+      break;
+    }
+    pageTasks.push(task);
+  }
+
+  if (pageTasks.length === 0 && offset < tasks.length) {
+    throw invariantFailure('A canonical Task exceeded the page result byte limit');
+  }
+  const nextOffset = offset + pageTasks.length;
+  return encodeTaskLedgerQueryResult({
+    kind: 'page',
+    sessionId,
+    revision,
+    tasks: pageTasks,
+    nextCursor: nextOffset < tasks.length ? encodeCursor(nextOffset) : null,
+  });
+}
+
+function encodeCursor(offset: number): string {
+  return String(offset);
+}
+
+function decodeCursor(cursor: string): number | undefined {
+  if (!/^(?:0|[1-9]\d*)$/.test(cursor)) return undefined;
+  const offset = Number(cursor);
+  return Number.isSafeInteger(offset) ? offset : undefined;
+}
+
+function success(result: TaskLedgerQueryResult): OperationOutcome<'task.ledger.query'> {
+  return { ok: true, result };
+}
+
+function invalidRequest(message: string): OperationOutcome<'task.ledger.query'> {
+  return { ok: false, error: { code: 'invalid_request', message } };
+}
+
+function invariantFailure(message: string): Error {
+  return new Error(`Task ledger coordinator invariant failed: ${message}`);
+}

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -11,7 +11,7 @@
     "./execution-stores": "./dist/execution-stores.js",
     "./root-authority": "./dist/root-authority.js",
     "./runtime-policy-stores": "./dist/runtime-policy-stores.js",
-    "./task-ledger-store": "./dist/task-ledger-store.js",
+    "./task-ledger-authority": "./dist/task-ledger-authority.js",
     "./workspace-identity": "./dist/workspace-identity.js",
     "./write-queue": "./dist/write-queue.js"
   },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -11,6 +11,7 @@
     "./execution-stores": "./dist/execution-stores.js",
     "./root-authority": "./dist/root-authority.js",
     "./runtime-policy-stores": "./dist/runtime-policy-stores.js",
+    "./task-ledger-store": "./dist/task-ledger-store.js",
     "./workspace-identity": "./dist/workspace-identity.js",
     "./write-queue": "./dist/write-queue.js"
   },

--- a/packages/storage/src/__tests__/task-ledger-authority.test.ts
+++ b/packages/storage/src/__tests__/task-ledger-authority.test.ts
@@ -7,7 +7,7 @@ import {
   authenticateInteractiveTaskLedgerWriter,
   openInteractiveTaskLedgerStoreForWrite,
   type InteractiveTaskLedgerWriter,
-} from '../task-ledger-store.js';
+} from '../task-ledger-authority.js';
 import {
   createHeadlessRootLease,
   resolveStorageRoot,

--- a/packages/storage/src/__tests__/task-ledger-authority.test.ts
+++ b/packages/storage/src/__tests__/task-ledger-authority.test.ts
@@ -1,0 +1,197 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import {
+  authenticateInteractiveTaskLedgerWriter,
+  openInteractiveTaskLedgerStoreForWrite,
+  type InteractiveTaskLedgerWriter,
+} from '../task-ledger-store.js';
+import {
+  createHeadlessRootLease,
+  resolveStorageRoot,
+  StorageRootAuthorityError,
+  tryAcquireInteractiveRootOwner,
+  type StorageRootLease,
+} from '../root-authority.js';
+
+const SESSION_ID = 'authority-session';
+
+describe('interactive task ledger authority', () => {
+  test('single-flights concurrent opens and uses one local observer surface', async () => {
+    await withInteractiveRoot(async ({ capability }) => {
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      try {
+        const [first, second] = await Promise.all([
+          openInteractiveTaskLedgerStoreForWrite(owner.lease),
+          openInteractiveTaskLedgerStoreForWrite(owner.lease),
+        ]);
+        assert.equal(first, second);
+        assert.equal(authenticateInteractiveTaskLedgerWriter(first), first);
+
+        const changes: string[][] = [];
+        const unsubscribe = first.subscribe((event) => changes.push(event.taskIds));
+        const result = await second.create(SESSION_ID, [{ subject: 'single writer' }]);
+        unsubscribe();
+
+        assert.equal(changes.length, 1);
+        assert.deepEqual(changes[0], [result.created[0]?.id]);
+      } finally {
+        if (!owner.closed) await owner.close();
+      }
+    });
+  });
+
+  test('reads a current legacy tasks.json as canonical when no event ledger exists', async () => {
+    await withInteractiveOwner(async ({ root, writer }) => {
+      await mkdir(join(root, 'sessions', SESSION_ID), { recursive: true });
+      await writeFile(
+        tasksPath(root),
+        JSON.stringify([
+          {
+            id: 'legacy-task',
+            subject: 'legacy canonical task',
+            status: 'pending',
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ]),
+        'utf8',
+      );
+
+      const listed = await writer.list(SESSION_ID);
+      assert.equal(listed.length, 1);
+      assert.equal(listed[0]?.id, 'legacy-task');
+      assert.equal(listed[0]?.key, 'T1');
+      assert.equal((await writer.get(SESSION_ID, 'T1'))?.subject, 'legacy canonical task');
+    });
+  });
+
+  test('fails closed on a corrupt event ledger even when a legacy cache exists', async () => {
+    await withInteractiveOwner(async ({ root, writer }) => {
+      await mkdir(join(root, 'sessions', SESSION_ID), { recursive: true });
+      await writeFile(
+        tasksPath(root),
+        JSON.stringify([
+          {
+            id: 'cached-task',
+            subject: 'must not become canonical',
+            status: 'pending',
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ]),
+        'utf8',
+      );
+      await writeFile(eventsPath(root), '{"not":"a task event"}\n', 'utf8');
+
+      await assert.rejects(() => writer.list(SESSION_ID), /Invalid task event JSONL line/);
+      await assert.rejects(() => writer.get(SESSION_ID, 'cached-task'), /Invalid task event JSONL/);
+      await assert.rejects(
+        () => writer.create(SESSION_ID, [{ subject: 'must not overwrite' }]),
+        /Invalid task event JSONL/,
+      );
+    });
+  });
+
+  test('rejects canonical reads and mutations after the owner releases its lease', async () => {
+    await withInteractiveRoot(async ({ capability }) => {
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      const writer = await openInteractiveTaskLedgerStoreForWrite(owner.lease);
+      await writer.create(SESSION_ID, [{ subject: 'before close' }]);
+      await owner.close();
+
+      await assert.rejects(() => writer.list(SESSION_ID), isInvalidLease);
+      await assert.rejects(
+        () => writer.create(SESSION_ID, [{ subject: 'after close' }]),
+        isInvalidLease,
+      );
+    });
+  });
+
+  test('rejects headless leases and forged writer facades', async () => {
+    await withTempDir(async (base) => {
+      const headless = await resolveStorageRoot({
+        path: join(base, 'headless'),
+        kind: 'headless',
+      });
+      await assert.rejects(
+        () =>
+          openInteractiveTaskLedgerStoreForWrite(
+            createHeadlessRootLease(headless, 'write') as unknown as StorageRootLease<
+              'interactive',
+              'write'
+            >,
+          ),
+        isInvalidLease,
+      );
+    });
+
+    await withInteractiveOwner(async ({ writer }) => {
+      assert.throws(
+        () =>
+          authenticateInteractiveTaskLedgerWriter({
+            ...writer,
+          } as InteractiveTaskLedgerWriter),
+        isInvalidLease,
+      );
+    });
+  });
+});
+
+async function withInteractiveOwner(
+  run: (input: { root: string; writer: InteractiveTaskLedgerWriter }) => Promise<void>,
+): Promise<void> {
+  await withInteractiveRoot(async ({ root, capability }) => {
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner);
+    if (!owner) return;
+    try {
+      await run({
+        root,
+        writer: await openInteractiveTaskLedgerStoreForWrite(owner.lease),
+      });
+    } finally {
+      if (!owner.closed) await owner.close();
+    }
+  });
+}
+
+async function withInteractiveRoot(
+  run: (input: {
+    root: string;
+    capability: Awaited<ReturnType<typeof resolveStorageRoot<'interactive'>>>;
+  }) => Promise<void>,
+): Promise<void> {
+  await withTempDir(async (base) => {
+    const root = join(base, 'interactive');
+    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    await run({ root, capability });
+  });
+}
+
+async function withTempDir(run: (base: string) => Promise<void>): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-task-ledger-authority-'));
+  try {
+    await run(base);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+function tasksPath(root: string): string {
+  return join(root, 'sessions', SESSION_ID, 'tasks.json');
+}
+
+function eventsPath(root: string): string {
+  return join(root, 'sessions', SESSION_ID, 'task-events.jsonl');
+}
+
+function isInvalidLease(error: unknown): boolean {
+  return error instanceof StorageRootAuthorityError && error.code === 'invalid_lease';
+}

--- a/packages/storage/src/task-ledger-authority.ts
+++ b/packages/storage/src/task-ledger-authority.ts
@@ -1,0 +1,93 @@
+import type { TaskLedgerStore } from '@maka/core/task-ledger';
+import {
+  assertStorageRootLease,
+  runWithStorageRootLease,
+  StorageRootAuthorityError,
+  type StorageRootLease,
+} from './root-authority.js';
+import { createTaskLedgerStore } from './task-ledger-store.js';
+import {
+  getTaskLedgerCanonicalReader,
+  type TaskLedgerCanonicalReader,
+} from './task-ledger-store-internal.js';
+
+export type { TaskLedgerCanonicalReader } from './task-ledger-store-internal.js';
+
+const writerBrand: unique symbol = Symbol('InteractiveTaskLedgerWriter');
+const writers = new WeakSet<object>();
+const writerByLease = new WeakMap<object, InteractiveTaskLedgerWriter>();
+const writerOpeningByLease = new WeakMap<object, Promise<InteractiveTaskLedgerWriter>>();
+
+export interface InteractiveTaskLedgerWriter extends TaskLedgerStore, TaskLedgerCanonicalReader {
+  readonly kind: 'interactive';
+  readonly access: 'write';
+  readonly [writerBrand]: true;
+}
+
+export function authenticateInteractiveTaskLedgerWriter(
+  writer: InteractiveTaskLedgerWriter,
+): InteractiveTaskLedgerWriter {
+  if (!writers.has(writer)) {
+    throw new StorageRootAuthorityError(
+      'invalid_lease',
+      'Expected an authentic interactive task ledger writer',
+    );
+  }
+  return writer;
+}
+
+export async function openInteractiveTaskLedgerStoreForWrite(
+  lease: StorageRootLease<'interactive', 'write'>,
+): Promise<InteractiveTaskLedgerWriter> {
+  await assertStorageRootLease(lease, 'interactive', 'write');
+  const existing = writerByLease.get(lease);
+  if (existing) return existing;
+  const opening = writerOpeningByLease.get(lease);
+  if (opening) return opening;
+
+  const pending = Promise.resolve().then(async () => {
+    const store = await runWithStorageRootLease(lease, 'interactive', 'write', async (root) =>
+      createTaskLedgerStore(root),
+    );
+    await assertStorageRootLease(lease, 'interactive', 'write');
+    const recoveredExisting = writerByLease.get(lease);
+    if (recoveredExisting) return recoveredExisting;
+    const writer = createInteractiveWriterFacade(lease, store, getTaskLedgerCanonicalReader(store));
+    writers.add(writer);
+    writerByLease.set(lease, writer);
+    return writer;
+  });
+  writerOpeningByLease.set(lease, pending);
+  try {
+    return await pending;
+  } finally {
+    if (writerOpeningByLease.get(lease) === pending) writerOpeningByLease.delete(lease);
+  }
+}
+
+function createInteractiveWriterFacade(
+  lease: StorageRootLease<'interactive', 'write'>,
+  store: TaskLedgerStore,
+  canonicalReader: TaskLedgerCanonicalReader,
+): InteractiveTaskLedgerWriter {
+  const run = <T>(operation: () => Promise<T>) =>
+    runWithStorageRootLease(lease, 'interactive', 'write', async () => operation());
+  const writer: InteractiveTaskLedgerWriter = {
+    kind: 'interactive',
+    access: 'write',
+    [writerBrand]: true,
+    list: (sessionId, options) => run(() => canonicalReader.list(sessionId, options)),
+    get: (sessionId, id, options) => run(() => canonicalReader.get(sessionId, id, options)),
+    create: (sessionId, drafts, context) => run(() => store.create(sessionId, drafts, context)),
+    update: (sessionId, id, patch, context) =>
+      run(() => store.update(sessionId, id, patch, context)),
+    claim: (sessionId, id, owner, context) => run(() => store.claim(sessionId, id, owner, context)),
+    claimAvailable: (sessionId, id, owner, scope, context) =>
+      run(() => store.claimAvailable(sessionId, id, owner, scope, context)),
+    settleAgentOutcome: (sessionId, id, outcome, context) =>
+      run(() => store.settleAgentOutcome(sessionId, id, outcome, context)),
+    subscribe: (listener) => store.subscribe(listener),
+  };
+  Object.freeze(writer);
+  return writer;
+}

--- a/packages/storage/src/task-ledger-store-internal.ts
+++ b/packages/storage/src/task-ledger-store-internal.ts
@@ -1,0 +1,25 @@
+import type { Task, TaskLedgerListOptions, TaskLedgerStore } from '@maka/core/task-ledger';
+
+export interface TaskLedgerCanonicalReader {
+  list(sessionId: string, options?: TaskLedgerListOptions): Promise<Task[]>;
+  get(sessionId: string, id: string, options?: TaskLedgerListOptions): Promise<Task | undefined>;
+}
+
+// Package-private bridge: this module must stay outside both the root barrel and package exports.
+const canonicalReaderByStore = new WeakMap<object, TaskLedgerCanonicalReader>();
+
+export function registerTaskLedgerCanonicalReader(
+  store: TaskLedgerStore,
+  reader: TaskLedgerCanonicalReader,
+): void {
+  if (canonicalReaderByStore.has(store)) {
+    throw new Error('Task ledger store already has a canonical reader');
+  }
+  canonicalReaderByStore.set(store, Object.freeze(reader));
+}
+
+export function getTaskLedgerCanonicalReader(store: TaskLedgerStore): TaskLedgerCanonicalReader {
+  const reader = canonicalReaderByStore.get(store);
+  if (!reader) throw new Error('Task ledger store is missing its internal canonical reader');
+  return reader;
+}

--- a/packages/storage/src/task-ledger-store.ts
+++ b/packages/storage/src/task-ledger-store.ts
@@ -34,77 +34,12 @@ import {
 } from '@maka/core/task-ledger';
 import { chainWrite } from './write-queue.js';
 import { assertSafeSessionId } from './session-store.js';
-import {
-  assertStorageRootLease,
-  runWithStorageRootLease,
-  StorageRootAuthorityError,
-  type StorageRootLease,
-} from './root-authority.js';
+import { registerTaskLedgerCanonicalReader } from './task-ledger-store-internal.js';
 
 export type { TaskLedgerStore } from '@maka/core/task-ledger';
 
-const writerBrand: unique symbol = Symbol('InteractiveTaskLedgerWriter');
-const writers = new WeakSet<object>();
-const writerByLease = new WeakMap<object, InteractiveTaskLedgerWriter>();
-const writerOpeningByLease = new WeakMap<object, Promise<InteractiveTaskLedgerWriter>>();
-
-export interface TaskLedgerCanonicalReader {
-  list(sessionId: string, options?: TaskLedgerListOptions): Promise<Task[]>;
-  get(sessionId: string, id: string, options?: TaskLedgerListOptions): Promise<Task | undefined>;
-}
-
-export interface InteractiveTaskLedgerWriter extends TaskLedgerStore, TaskLedgerCanonicalReader {
-  readonly kind: 'interactive';
-  readonly access: 'write';
-  readonly [writerBrand]: true;
-}
-
 export function createTaskLedgerStore(workspaceRoot: string): TaskLedgerStore {
   return new FileTaskLedgerStore(workspaceRoot);
-}
-
-export function authenticateInteractiveTaskLedgerWriter(
-  writer: InteractiveTaskLedgerWriter,
-): InteractiveTaskLedgerWriter {
-  if (!writers.has(writer)) {
-    throw new StorageRootAuthorityError(
-      'invalid_lease',
-      'Expected an authentic interactive task ledger writer',
-    );
-  }
-  return writer;
-}
-
-export async function openInteractiveTaskLedgerStoreForWrite(
-  lease: StorageRootLease<'interactive', 'write'>,
-): Promise<InteractiveTaskLedgerWriter> {
-  await assertStorageRootLease(lease, 'interactive', 'write');
-  const existing = writerByLease.get(lease);
-  if (existing) return existing;
-  const opening = writerOpeningByLease.get(lease);
-  if (opening) return opening;
-
-  const pending = Promise.resolve().then(async () => {
-    const store = await runWithStorageRootLease(
-      lease,
-      'interactive',
-      'write',
-      async (root) => new FileTaskLedgerStore(root),
-    );
-    await assertStorageRootLease(lease, 'interactive', 'write');
-    const recoveredExisting = writerByLease.get(lease);
-    if (recoveredExisting) return recoveredExisting;
-    const writer = createInteractiveWriterFacade(lease, store);
-    writers.add(writer);
-    writerByLease.set(lease, writer);
-    return writer;
-  });
-  writerOpeningByLease.set(lease, pending);
-  try {
-    return await pending;
-  } finally {
-    if (writerOpeningByLease.get(lease) === pending) writerOpeningByLease.delete(lease);
-  }
 }
 
 class FileTaskLedgerStore implements TaskLedgerStore {
@@ -114,6 +49,10 @@ class FileTaskLedgerStore implements TaskLedgerStore {
 
   constructor(workspaceRoot: string) {
     this.sessionsRoot = join(workspaceRoot, 'sessions');
+    registerTaskLedgerCanonicalReader(this, {
+      list: (sessionId, options) => this.#listCanonical(sessionId, options),
+      get: (sessionId, id, options) => this.#getCanonical(sessionId, id, options),
+    });
   }
 
   async list(sessionId: string, options: TaskLedgerListOptions = {}): Promise<Task[]> {
@@ -133,13 +72,13 @@ class FileTaskLedgerStore implements TaskLedgerStore {
     return findTaskByRef(tasks, id);
   }
 
-  async listCanonical(sessionId: string, options: TaskLedgerListOptions = {}): Promise<Task[]> {
+  async #listCanonical(sessionId: string, options: TaskLedgerListOptions = {}): Promise<Task[]> {
     assertSafeSessionId(sessionId);
     const { tasks } = await this.readForMutateWithSource(sessionId);
     return this.applyListOptions(tasks, options);
   }
 
-  async getCanonical(
+  async #getCanonical(
     sessionId: string,
     id: string,
     options: TaskLedgerListOptions = {},
@@ -147,7 +86,7 @@ class FileTaskLedgerStore implements TaskLedgerStore {
     assertSafeSessionId(sessionId);
     if (!isSafeTaskId(id))
       throw new Error('Task id must be a stable token (alphanumeric plus . _ : -, max 64 chars)');
-    return findTaskByRef(await this.listCanonical(sessionId, options), id);
+    return findTaskByRef(await this.#listCanonical(sessionId, options), id);
   }
 
   subscribe(listener: (event: TaskLedgerChangedEvent) => void): () => void {
@@ -734,32 +673,6 @@ class FileTaskLedgerStore implements TaskLedgerStore {
       }
     }
   }
-}
-
-function createInteractiveWriterFacade(
-  lease: StorageRootLease<'interactive', 'write'>,
-  store: FileTaskLedgerStore,
-): InteractiveTaskLedgerWriter {
-  const run = <T>(operation: () => Promise<T>) =>
-    runWithStorageRootLease(lease, 'interactive', 'write', async () => operation());
-  const writer: InteractiveTaskLedgerWriter = {
-    kind: 'interactive',
-    access: 'write',
-    [writerBrand]: true,
-    list: (sessionId, options) => run(() => store.listCanonical(sessionId, options)),
-    get: (sessionId, id, options) => run(() => store.getCanonical(sessionId, id, options)),
-    create: (sessionId, drafts, context) => run(() => store.create(sessionId, drafts, context)),
-    update: (sessionId, id, patch, context) =>
-      run(() => store.update(sessionId, id, patch, context)),
-    claim: (sessionId, id, owner, context) => run(() => store.claim(sessionId, id, owner, context)),
-    claimAvailable: (sessionId, id, owner, scope, context) =>
-      run(() => store.claimAvailable(sessionId, id, owner, scope, context)),
-    settleAgentOutcome: (sessionId, id, outcome, context) =>
-      run(() => store.settleAgentOutcome(sessionId, id, outcome, context)),
-    subscribe: (listener) => store.subscribe(listener),
-  };
-  Object.freeze(writer);
-  return writer;
 }
 
 function decodeTaskSnapshots(text: string): TaskLedgerEventTaskSnapshot[] {

--- a/packages/storage/src/task-ledger-store.ts
+++ b/packages/storage/src/task-ledger-store.ts
@@ -34,11 +34,77 @@ import {
 } from '@maka/core/task-ledger';
 import { chainWrite } from './write-queue.js';
 import { assertSafeSessionId } from './session-store.js';
+import {
+  assertStorageRootLease,
+  runWithStorageRootLease,
+  StorageRootAuthorityError,
+  type StorageRootLease,
+} from './root-authority.js';
 
 export type { TaskLedgerStore } from '@maka/core/task-ledger';
 
+const writerBrand: unique symbol = Symbol('InteractiveTaskLedgerWriter');
+const writers = new WeakSet<object>();
+const writerByLease = new WeakMap<object, InteractiveTaskLedgerWriter>();
+const writerOpeningByLease = new WeakMap<object, Promise<InteractiveTaskLedgerWriter>>();
+
+export interface TaskLedgerCanonicalReader {
+  list(sessionId: string, options?: TaskLedgerListOptions): Promise<Task[]>;
+  get(sessionId: string, id: string, options?: TaskLedgerListOptions): Promise<Task | undefined>;
+}
+
+export interface InteractiveTaskLedgerWriter extends TaskLedgerStore, TaskLedgerCanonicalReader {
+  readonly kind: 'interactive';
+  readonly access: 'write';
+  readonly [writerBrand]: true;
+}
+
 export function createTaskLedgerStore(workspaceRoot: string): TaskLedgerStore {
   return new FileTaskLedgerStore(workspaceRoot);
+}
+
+export function authenticateInteractiveTaskLedgerWriter(
+  writer: InteractiveTaskLedgerWriter,
+): InteractiveTaskLedgerWriter {
+  if (!writers.has(writer)) {
+    throw new StorageRootAuthorityError(
+      'invalid_lease',
+      'Expected an authentic interactive task ledger writer',
+    );
+  }
+  return writer;
+}
+
+export async function openInteractiveTaskLedgerStoreForWrite(
+  lease: StorageRootLease<'interactive', 'write'>,
+): Promise<InteractiveTaskLedgerWriter> {
+  await assertStorageRootLease(lease, 'interactive', 'write');
+  const existing = writerByLease.get(lease);
+  if (existing) return existing;
+  const opening = writerOpeningByLease.get(lease);
+  if (opening) return opening;
+
+  const pending = Promise.resolve().then(async () => {
+    const store = await runWithStorageRootLease(
+      lease,
+      'interactive',
+      'write',
+      async (root) => new FileTaskLedgerStore(root),
+    );
+    await assertStorageRootLease(lease, 'interactive', 'write');
+    const recoveredExisting = writerByLease.get(lease);
+    if (recoveredExisting) return recoveredExisting;
+    const writer = createInteractiveWriterFacade(lease, store);
+    writers.add(writer);
+    writerByLease.set(lease, writer);
+    return writer;
+  });
+  writerOpeningByLease.set(lease, pending);
+  try {
+    return await pending;
+  } finally {
+    if (writerOpeningByLease.get(lease) === pending) writerOpeningByLease.delete(lease);
+  }
 }
 
 class FileTaskLedgerStore implements TaskLedgerStore {
@@ -65,6 +131,23 @@ class FileTaskLedgerStore implements TaskLedgerStore {
       throw new Error('Task id must be a stable token (alphanumeric plus . _ : -, max 64 chars)');
     const tasks = await this.list(sessionId, options);
     return findTaskByRef(tasks, id);
+  }
+
+  async listCanonical(sessionId: string, options: TaskLedgerListOptions = {}): Promise<Task[]> {
+    assertSafeSessionId(sessionId);
+    const { tasks } = await this.readForMutateWithSource(sessionId);
+    return this.applyListOptions(tasks, options);
+  }
+
+  async getCanonical(
+    sessionId: string,
+    id: string,
+    options: TaskLedgerListOptions = {},
+  ): Promise<Task | undefined> {
+    assertSafeSessionId(sessionId);
+    if (!isSafeTaskId(id))
+      throw new Error('Task id must be a stable token (alphanumeric plus . _ : -, max 64 chars)');
+    return findTaskByRef(await this.listCanonical(sessionId, options), id);
   }
 
   subscribe(listener: (event: TaskLedgerChangedEvent) => void): () => void {
@@ -651,6 +734,32 @@ class FileTaskLedgerStore implements TaskLedgerStore {
       }
     }
   }
+}
+
+function createInteractiveWriterFacade(
+  lease: StorageRootLease<'interactive', 'write'>,
+  store: FileTaskLedgerStore,
+): InteractiveTaskLedgerWriter {
+  const run = <T>(operation: () => Promise<T>) =>
+    runWithStorageRootLease(lease, 'interactive', 'write', async () => operation());
+  const writer: InteractiveTaskLedgerWriter = {
+    kind: 'interactive',
+    access: 'write',
+    [writerBrand]: true,
+    list: (sessionId, options) => run(() => store.listCanonical(sessionId, options)),
+    get: (sessionId, id, options) => run(() => store.getCanonical(sessionId, id, options)),
+    create: (sessionId, drafts, context) => run(() => store.create(sessionId, drafts, context)),
+    update: (sessionId, id, patch, context) =>
+      run(() => store.update(sessionId, id, patch, context)),
+    claim: (sessionId, id, owner, context) => run(() => store.claim(sessionId, id, owner, context)),
+    claimAvailable: (sessionId, id, owner, scope, context) =>
+      run(() => store.claimAvailable(sessionId, id, owner, scope, context)),
+    settleAgentOutcome: (sessionId, id, outcome, context) =>
+      run(() => store.settleAgentOutcome(sessionId, id, outcome, context)),
+    subscribe: (listener) => store.subscribe(listener),
+  };
+  Object.freeze(writer);
+  return writer;
 }
 
 function decodeTaskSnapshots(text: string): TaskLedgerEventTaskSnapshot[] {


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Context

This PR establishes the complete non-serving Task Ledger authority slice for the Runtime Host migration tracked by #1167.

It places canonical Task Ledger writes and Host-facing reads behind one lease-authenticated authority while preserving the current persistence format and all production entrypoints.

## What changes

### Canonical Storage authority

- Preserve `task-events.jsonl`, `tasks.json`, legacy loading/backfill, and the existing embedded rendering behavior; this slice introduces no persistence migration.
- Expose the narrow, kind-checked writer facade only from `@maka/storage/task-ledger-authority`; the ordinary root Task Ledger API remains independent of root authority. The facade is authenticated by the Interactive root lease, concurrent opens under the same lease are singleflight, and revoked, released, forged, or Headless authority fails closed.
- Keep the existing fail-soft reader for embedded UI projection, while adding a strict canonical reader for Host authority. A corrupt event ledger cannot silently become an empty or cache-derived canonical ledger.

### Runtime port and closed Host query

- Add one `HostTaskLedgerCoordinator` that implements the existing Runtime `TaskLedgerStore` port and serves the read-only `task.ledger.query` operation.
- Route query, create, update, claim, settle, and subscription access through the same per-Session admission gate.
- Provide exact `list_start`, `list_continue`, and `get` requests with revision-pinned cursors, a 128-item limit, and a 48 KiB encoded page limit.
- Produce the privacy-normalized wire Task DTO once, then compute revision, lookup, pagination, and byte budget from that exact projection.
- Preserve diagnostic trust states. Legacy tasks whose required evidence is missing remain readable but are conservatively marked `needs_revalidation`; existing `untrusted`, `repaired`, `stale`, and `needs_revalidation` states are not upgraded or erased.

## Evidence

The real acceptance path mutates the file-backed ledger through the Runtime-facing Task Ledger tool port, then starts the production non-serving Host composition. Two independent UDS Clients read the same bounded projection and pagination, the Host is stopped, the successor reclaims authority, and stale revision/cursor state returns `revision_changed` after a further durable mutation.

Storage passes 527 tests with one existing Windows skip, and Runtime Host passes all 169 tests. The affected package typechecks, production build, changed-file Biome checks, diff checks, and independent correctness and maintainability reviews also pass.

## Scope

This slice does not wire the coordinator into hosted real-model Backend/Prompt/Tool composition. That remains a later Hosted execution slice built on this Runtime port. It also does not add Client mutation RPCs, subscriptions, a generic Store RPC, production Candidate/Desktop/TUI wiring, persistence migration, or the M4/M5 cutover.

Part of #1167. Related to #853.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 背景

本 PR 建立 Runtime Host 迁移所需的完整、非生产 Task Ledger authority slice，整体由 #1167 跟踪。

它在保留现有持久化格式与全部生产入口的前提下，把 canonical Task Ledger 写入与 Host 读取收敛到同一个经过 lease 认证的 authority 后面。

## 改动内容

### Canonical Storage authority

- 保留 `task-events.jsonl`、`tasks.json`、legacy loading/backfill 与既有 embedded rendering 行为；本 slice 不引入持久化迁移。
- 窄、经过 root kind 检查的 writer facade 只从 `@maka/storage/task-ledger-authority` 暴露；普通根 Task Ledger API 不依赖 root authority。该 facade 由 Interactive root lease 认证，同一 lease 下的并发 open 使用 singleflight；被撤销、已释放、伪造或来自 Headless 的 authority 均 fail closed。
- 保留 embedded UI projection 使用的既有 fail-soft reader，同时增加 Host authority 使用的严格 canonical reader。损坏的 event ledger 不能静默降级为空账本或由 cache 推导出的 canonical ledger。

### Runtime port 与封闭 Host query

- 增加一个 `HostTaskLedgerCoordinator`，同时实现既有 Runtime `TaskLedgerStore` port，并提供只读 `task.ledger.query` operation。
- Query、create、update、claim、settle 与 subscription access 统一经过同一个 per-Session admission gate。
- 提供精确的 `list_start`、`list_continue` 与 `get` request，cursor 绑定 revision，单页上限为 128 项和 48 KiB 编码结果。
- 只生成一次经过隐私规范化的 wire Task DTO；revision、lookup、pagination 与 byte budget 均以这一最终 projection 为准。
- 保留诊断性 trust state。缺少必要 evidence 的 legacy task 仍可读取，但会保守标记为 `needs_revalidation`；既有 `untrusted`、`repaired`、`stale` 与 `needs_revalidation` 不会被升级或抹除。

## 验证证据

真实验收路径先通过 Runtime-facing Task Ledger tool port 修改文件型 ledger，再启动 production non-serving Host composition。两个独立 UDS Client 读取同一份有界 projection 与分页结果；Host 停止后由 successor 重新取得 authority，并在进一步 durable mutation 后让旧 revision/cursor 返回 `revision_changed`。

Storage 527 项测试通过，另有 1 项既有 Windows skip；Runtime Host 169 项全部通过。受影响包 typecheck、production build、变更文件 Biome 检查、diff 检查，以及独立的正确性与可维护性审查也均通过。

## 范围

本 slice 不把 coordinator 接入 hosted real-model Backend/Prompt/Tool composition；该接线属于后续建立在此 Runtime port 之上的 Hosted execution slice。它也不增加 Client mutation RPC、subscription、通用 Store RPC、production Candidate/Desktop/TUI wiring、持久化迁移，或 M4/M5 cutover。

属于 #1167；关联 #853。

</details>
