### PR TITLE
fix(headless): equalize Pier model deadlines

### DIFF
--- a/packages/headless/harbor/codex_agent.py
+++ b/packages/headless/harbor/codex_agent.py
@@ -24,6 +24,7 @@ from harness_compat import (
 )
 from process_scope import cleanup_process_scope, scoped_command
 from provider_proxy import provider_proxy_endpoint, warn_if_pier_unreachable_proxy_port
+from deadline_policy import deadline_policy_from_env
 from trial_pricing import estimate_cost, pricing_from_env
 
 _TOOLCHAIN_ROOT = Path("/opt/maka-codex-toolchain")
@@ -449,6 +450,7 @@ class MakaCodexAgent(Codex):
             ).encode("utf-8")
         ).hexdigest()
         effort = self._get_env("MAKA_REASONING_EFFORT")
+        deadline_policy = deadline_policy_from_env(self._get_env)
         return {
             "llmConnectionSlug": self._get_env("MAKA_LLM_CONNECTION_SLUG")
             or "openai",
@@ -458,6 +460,11 @@ class MakaCodexAgent(Codex):
             "pricingProfile": self._get_env("MAKA_TRIAL_PRICING_SOURCE")
             or "unconfigured",
             "agentTools": False,
+            **(
+                {"deadlinePolicy": deadline_policy}
+                if deadline_policy is not None
+                else {}
+            ),
         }
 
     def _write_execution_identity(self) -> None:

--- a/packages/headless/harbor/deadline_policy.py
+++ b/packages/headless/harbor/deadline_policy.py
@@ -1,0 +1,44 @@
+"""Shared task-native model-budget attestation for Pier benchmark adapters."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Callable
+from typing import Any
+
+POLICY_ID = "task-native-full-budget-v1"
+_POSITIVE_INT_RE = re.compile(r"[1-9][0-9]*")
+
+
+def deadline_policy_from_env(
+    get_env: Callable[[str], str | None],
+) -> dict[str, Any] | None:
+    policy_id = get_env("MAKA_BENCHMARK_DEADLINE_POLICY")
+    if not policy_id:
+        return None
+    if policy_id != POLICY_ID:
+        raise RuntimeError(f"MAKA_BENCHMARK_DEADLINE_POLICY must be {POLICY_ID}")
+    model_budget_sec = _positive_int(get_env("MAKA_CELL_TIMEOUT_SEC"), "MAKA_CELL_TIMEOUT_SEC")
+    settlement_grace_sec = _positive_int(
+        get_env("MAKA_CELL_SETTLEMENT_GRACE_SEC"),
+        "MAKA_CELL_SETTLEMENT_GRACE_SEC",
+    )
+    hard_timeout_sec = _positive_int(
+        get_env("MAKA_CELL_HARD_TIMEOUT_SEC"),
+        "MAKA_CELL_HARD_TIMEOUT_SEC",
+    )
+    if hard_timeout_sec != model_budget_sec + settlement_grace_sec:
+        raise RuntimeError("MAKA_CELL_HARD_TIMEOUT_SEC must equal T + G")
+    return {
+        "id": policy_id,
+        "modelBudgetSec": model_budget_sec,
+        "settlementGraceSec": settlement_grace_sec,
+        "hardTimeoutSec": hard_timeout_sec,
+    }
+
+
+def _positive_int(raw: str | None, name: str) -> int:
+    value = raw.strip() if raw is not None else ""
+    if _POSITIVE_INT_RE.fullmatch(value) is None:
+        raise RuntimeError(f"{name} must be a positive integer")
+    return int(value)

--- a/packages/headless/harbor/kimi_code_agent.py
+++ b/packages/headless/harbor/kimi_code_agent.py
@@ -24,6 +24,7 @@ from harness_compat import (
 )
 from process_scope import cleanup_process_scope, scoped_command
 from provider_proxy import provider_proxy_endpoint, warn_if_pier_unreachable_proxy_port
+from deadline_policy import deadline_policy_from_env
 
 _TOOLCHAIN_ROOT = Path("/opt/maka-kimi-code-toolchain")
 _TOOLCHAIN_NODE = _TOOLCHAIN_ROOT / "bin" / "node"
@@ -296,6 +297,7 @@ class MakaKimiCodeAgent(BaseInstalledAgent):
             json.dumps(system_prompt, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
         ).hexdigest()
         effort = self._get_env("MAKA_REASONING_EFFORT")
+        deadline_policy = deadline_policy_from_env(self._get_env)
         return {
             "llmConnectionSlug": self._get_env("MAKA_LLM_CONNECTION_SLUG") or "kimi-coding-plan",
             "model": self._get_env("MAKA_MODEL") or self.model_name or "k3",
@@ -303,6 +305,11 @@ class MakaKimiCodeAgent(BaseInstalledAgent):
             "systemPromptHash": prompt_hash,
             "pricingProfile": self._get_env("MAKA_TRIAL_PRICING_SOURCE") or "unconfigured",
             "agentTools": False,
+            **(
+                {"deadlinePolicy": deadline_policy}
+                if deadline_policy is not None
+                else {}
+            ),
         }
 
     def _write_execution_identity(self) -> None:

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -41,6 +41,7 @@ from process_scope import (
     scoped_process_cleanup_command as _scoped_process_cleanup_command,
 )
 from provider_proxy import provider_proxy_endpoint, warn_if_pier_unreachable_proxy_port
+from deadline_policy import deadline_policy_from_env
 from trial_pricing import estimate_cost, pricing_from_env
 
 # Default wall-clock budget for a single bridged tool command when the client
@@ -394,7 +395,7 @@ class MakaAgent(BaseInstalledAgent):
                 f"2>&1 | tee {shlex.quote(run_log_path.as_posix())}"
             )
             command = f"bash -lc {shlex.quote(shell_script)}"
-            await self.exec_as_agent(environment, command=command, env=env, timeout_sec=self._cell_timeout_sec())
+            await self.exec_as_agent(environment, command=command, env=env, timeout_sec=self._cell_hard_timeout_sec())
             await self._download_cell_output(environment)
         output = self._read_cell_output(required=True)
         self._apply_cell_output(context, output)
@@ -466,6 +467,15 @@ class MakaAgent(BaseInstalledAgent):
 
     def _cell_soft_timeout_ms(self, env: dict[str, str] | None = None) -> int:
         timeout_sec = self._cell_timeout_sec(env)
+        policy = self._benchmark_deadline_policy(env)
+        if policy is not None:
+            soft_timeout_ms = timeout_sec * 1000
+            if soft_timeout_ms > _MAX_NODE_TIMER_MS:
+                raise RuntimeError(
+                    "MAKA_CELL_SOFT_TIMEOUT_MS exceeds the Node timer limit "
+                    f"of {_MAX_NODE_TIMER_MS}ms"
+                )
+            return soft_timeout_ms
         grace_sec = self._cell_settlement_grace_sec(env)
         if grace_sec >= timeout_sec:
             raise RuntimeError(
@@ -478,6 +488,32 @@ class MakaAgent(BaseInstalledAgent):
                 f"of {_MAX_NODE_TIMER_MS}ms"
             )
         return soft_timeout_ms
+
+    def _cell_hard_timeout_sec(self, env: dict[str, str] | None = None) -> int:
+        policy = self._benchmark_deadline_policy(env)
+        return (
+            int(policy["hardTimeoutSec"])
+            if policy is not None
+            else self._cell_timeout_sec(env)
+        )
+
+    def _benchmark_deadline_policy(
+        self, env: dict[str, str] | None = None
+    ) -> dict[str, int | str] | None:
+        policy = deadline_policy_from_env(
+            lambda key: env.get(key) if env is not None else self._get_env(key)
+        )
+        if policy is None:
+            return None
+        # Keep the adapter's lenient legacy parsers honest when the strict
+        # benchmark policy is active.
+        if policy["modelBudgetSec"] != self._cell_timeout_sec(env):
+            raise RuntimeError("deadline policy model budget did not match MAKA_CELL_TIMEOUT_SEC")
+        if policy["settlementGraceSec"] != self._cell_settlement_grace_sec(env):
+            raise RuntimeError(
+                "deadline policy grace did not match MAKA_CELL_SETTLEMENT_GRACE_SEC"
+            )
+        return policy
 
     def _host_side_llm_enabled(self) -> bool:
         return bool(
@@ -506,14 +542,14 @@ class MakaAgent(BaseInstalledAgent):
                 stderr=asyncio.subprocess.PIPE,
             )
             try:
-                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self._cell_timeout_sec())
+                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self._cell_hard_timeout_sec())
             except BaseException as error:
                 if process.returncode is None:
                     process.kill()
                 stdout, stderr = await process.communicate()
                 run_log_path.write_bytes(stdout + stderr)
                 if isinstance(error, asyncio.TimeoutError):
-                    raise RuntimeError(f"Maka host cell exceeded {self._cell_timeout_sec()}s") from error
+                    raise RuntimeError(f"Maka host cell exceeded {self._cell_hard_timeout_sec()}s") from error
                 raise
             run_log_path.write_bytes(stdout + stderr)
             if process.returncode == 124:
@@ -593,6 +629,10 @@ class MakaAgent(BaseInstalledAgent):
             # runtime's shorter interactive defaults.
             "MAKA_STREAM_CONNECT_TIMEOUT_MS",
             "MAKA_STREAM_IDLE_TIMEOUT_MS",
+            "MAKA_BENCHMARK_DEADLINE_POLICY",
+            "MAKA_CELL_TIMEOUT_SEC",
+            "MAKA_CELL_SETTLEMENT_GRACE_SEC",
+            "MAKA_CELL_HARD_TIMEOUT_SEC",
             # Benchmark-safe deterministic continuation. These are consumed by
             # run-host-cell.mjs/run-cell.mjs, not by the provider backend.
             "MAKA_HARBOR_CONTINUATION",
@@ -794,7 +834,7 @@ class MakaAgent(BaseInstalledAgent):
                 environment,
                 command=f"bash -lc {shlex.quote(shell_script)}",
                 env=env,
-                timeout_sec=self._cell_timeout_sec(env),
+                timeout_sec=self._cell_hard_timeout_sec(env),
             )
         finally:
             await self._download_task_run_artifacts(environment)
@@ -909,7 +949,7 @@ class MakaAgent(BaseInstalledAgent):
             },
         )
 
-        timeout_sec = self._cell_timeout_sec(env)
+        timeout_sec = self._cell_hard_timeout_sec(env)
         proc: asyncio.subprocess.Process | None = None
         async with _ToolExecutorServer(self, environment) as executor:
             env["MAKA_HARBOR_TOOL_EXECUTOR_URL"] = executor.url
@@ -1743,6 +1783,8 @@ def _runner_env_summary(env: dict[str, str]) -> dict[str, str]:
         "MAKA_CELL_TIMEOUT_SEC",
         "MAKA_CELL_SOFT_TIMEOUT_MS",
         "MAKA_CELL_SETTLEMENT_GRACE_SEC",
+        "MAKA_CELL_HARD_TIMEOUT_SEC",
+        "MAKA_BENCHMARK_DEADLINE_POLICY",
     ]
     return {key: env[key] for key in allowed_keys if key in env}
 

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -88,6 +88,7 @@ const PRICING = {
   source: 'kimi-coding-plan-account-plan',
 };
 const HARBOR_SETUP_TEARDOWN_GRACE_SEC = 15 * 60;
+const PIER_DEADLINE_SETTLEMENT_GRACE_SEC = 30;
 const ORACLE_EVIDENCE_RESOLUTION_TIMEOUT_MS = 15_000;
 const BACKGROUND_RUN_ENV = 'MAKA_HARNESS_AB_BACKGROUND_RUN';
 const BACKGROUND_STARTED_AT_ENV = 'MAKA_HARNESS_AB_DETACHED_STARTED_AT';
@@ -563,6 +564,14 @@ export function buildHarnessAbManifest({
       // version is hashed into the toolchain fingerprint. Absent for Harbor
       // benchmarks so Terminal-Bench manifests stay byte-identical.
       ...(pierVersion === null ? {} : { executor: { id: 'pier', version: pierVersion } }),
+      ...(benchmarkProfile.executor === 'pier'
+        ? {
+            deadlinePolicy: {
+              id: 'task-native-full-budget-v1',
+              settlementGraceSec: PIER_DEADLINE_SETTLEMENT_GRACE_SEC,
+            },
+          }
+        : {}),
       timeoutPolicy: 'task-native',
       timeoutMultiplier: 1,
       outerTimeoutGraceSec: HARBOR_SETUP_TEARDOWN_GRACE_SEC,
@@ -831,6 +840,7 @@ async function runLocked({
               baseUrl: execution.baseUrl,
               makaNodeToolchainPath: makaNodeToolchain.path,
               providerProxyHub,
+              deadlineSettlementGraceSec: PIER_DEADLINE_SETTLEMENT_GRACE_SEC,
             }
           : {
               agentEnv: { MAKA_BASE_URL: execution.baseUrl },
@@ -882,6 +892,9 @@ async function runLocked({
         ],
         pairConcurrency: manifest.maxConcurrency,
         armExecution: manifest.metadata.execution.armExecution,
+        ...(benchmarkProfile.executor === 'pier'
+          ? { expectedDeadlineSettlementGraceSec: PIER_DEADLINE_SETTLEMENT_GRACE_SEC }
+          : {}),
       });
       return buildHarnessAbReport(
         summary,

--- a/packages/headless/src/__tests__/cell-output.test.ts
+++ b/packages/headless/src/__tests__/cell-output.test.ts
@@ -131,6 +131,12 @@ describe('Harbor cell output contract', () => {
         systemPromptHash: 'sha256:prompt-a',
         pricingProfile: 'deepseek-v4-flash-tbench-v1',
         agentTools: true,
+        deadlinePolicy: {
+          id: 'task-native-full-budget-v1',
+          modelBudgetSec: 5400,
+          settlementGraceSec: 30,
+          hardTimeoutSec: 5430,
+        },
       },
     }) as HarborCellOutput & { executionIdentity?: unknown };
 
@@ -142,6 +148,12 @@ describe('Harbor cell output contract', () => {
       systemPromptHash: 'sha256:prompt-a',
       pricingProfile: 'deepseek-v4-flash-tbench-v1',
       agentTools: true,
+      deadlinePolicy: {
+        id: 'task-native-full-budget-v1',
+        modelBudgetSec: 5400,
+        settlementGraceSec: 30,
+        hardTimeoutSec: 5430,
+      },
     });
   });
 

--- a/packages/headless/src/__tests__/cli.test.ts
+++ b/packages/headless/src/__tests__/cli.test.ts
@@ -305,6 +305,67 @@ describe('maka-headless CLI', () => {
     }
   });
 
+  test('harbor run task-run attests the controller-owned deadline policy', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'maka-headless-harbor-cli-'));
+    try {
+      const fixture = join(dir, 'fixture');
+      const outDir = join(dir, 'out');
+      const cellArtifactDir = join(dir, 'cell-artifacts');
+      await mkdir(fixture, { recursive: true });
+
+      const result = await runCli(
+        [
+          'harbor',
+          'run',
+          '--mode',
+          'task-run',
+          '--backend',
+          'fake',
+          '--isolation',
+          'none',
+          '--instruction',
+          'solve it',
+          '--workdir',
+          fixture,
+          '--task-id',
+          'deadline-attestation',
+          '--out',
+          outDir,
+        ],
+        {
+          env: {
+            MAKA_BENCHMARK_DEADLINE_POLICY: 'task-native-full-budget-v1',
+            MAKA_CELL_ARTIFACT_DIR: cellArtifactDir,
+            MAKA_CELL_HARD_TIMEOUT_SEC: '5430',
+            MAKA_CELL_SETTLEMENT_GRACE_SEC: '30',
+            MAKA_CELL_SOFT_TIMEOUT_MS: '5400000',
+            MAKA_CELL_TIMEOUT_SEC: '5400',
+            MAKA_MODEL: 'fake-model',
+          },
+        },
+      );
+
+      assert.equal(result.code, 0, result.stderr);
+      const cell = validateHarborCellOutput(
+        JSON.parse(await readFile(join(cellArtifactDir, 'maka-cell-output.json'), 'utf8')),
+      );
+      assert.deepEqual(cell.executionIdentity?.deadlinePolicy, {
+        id: 'task-native-full-budget-v1',
+        modelBudgetSec: 5400,
+        settlementGraceSec: 30,
+        hardTimeoutSec: 5430,
+      });
+      assert.deepEqual(
+        JSON.parse(
+          await readFile(join(cellArtifactDir, 'maka-cell-execution-identity.json'), 'utf8'),
+        ).deadlinePolicy,
+        cell.executionIdentity?.deadlinePolicy,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
   test('harbor run task-run writes external Harbor verifier export without fake verifier authority', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'maka-headless-harbor-cli-'));
     try {

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -2140,10 +2140,21 @@ describe('fixed prompt controller', () => {
     });
   });
 
-  test('keeps verifier-graded deadline settlements as scored benchmark outcomes', async () => {
+  test('normalizes verifier-graded deadline settlement taxonomy without resampling or rewriting the raw trace', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
+      const runtimeEventsPath = join(dir, 'runtime-events.jsonl');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      await writeFile(runtimeEventsPath, '{"status":"aborted","source":"runtime"}\n', 'utf8');
+      let calls = 0;
+      const rawOutput = harborOutput({
+        taskId: 'task-a',
+        reward: 0,
+        status: 'failed',
+        errorClass: 'aborted',
+        deadlineSettlement: { source: 'benchmark.deadline', mode: 'immediate' },
+      });
+      rawOutput.cell.runtimeEventsPath = runtimeEventsPath;
 
       const result = await runFixedPromptController({
         runId: 'run-1',
@@ -2153,14 +2164,10 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        taskRunner: async () =>
-          harborOutput({
-            taskId: 'task-a',
-            reward: 0,
-            status: 'failed',
-            errorClass: 'aborted',
-            deadlineSettlement: { source: 'benchmark.deadline', mode: 'immediate' },
-          }),
+        taskRunner: async () => {
+          calls += 1;
+          return rawOutput;
+        },
         now: () => 100,
         newId: idFactory(),
       });
@@ -2169,6 +2176,62 @@ describe('fixed prompt controller', () => {
       assert.equal(result.events[0]?.passed, false);
       assert.equal(result.events[0]?.scored, true);
       assert.equal(result.events[0]?.eligible, true);
+      assert.equal(result.events[0]?.errorClass, 'budget_exhausted');
+      assert.equal(calls, 1);
+      assert.equal(rawOutput.cell.errorClass, 'aborted');
+      assert.equal(
+        await readFile(runtimeEventsPath, 'utf8'),
+        '{"status":"aborted","source":"runtime"}\n',
+      );
+    });
+  });
+
+  test('rejects a task-native deadline attestation that does not match T/G/H', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      let calls = 0;
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [
+          {
+            id: 'task-a',
+            path: '/bench/task-a',
+            metadata: { agentTimeoutSec: 5400 },
+          },
+        ],
+        expectedDeadlineSettlementGraceSec: 30,
+        requireExecutionIdentity: true,
+        taskRunner: async () => {
+          calls += 1;
+          return harborOutput({
+            taskId: 'task-a',
+            executionIdentity: {
+              llmConnectionSlug: 'fake',
+              model: 'fake-model',
+              systemPromptHash: hashSystemPrompt('fixed prompt\n'),
+              pricingProfile: 'test-profile',
+              deadlinePolicy: {
+                id: 'task-native-full-budget-v1',
+                modelBudgetSec: 5370,
+                settlementGraceSec: 30,
+                hardTimeoutSec: 5400,
+              },
+            },
+          });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'execution_identity_mismatch');
+      assert.equal(calls, 1);
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -70,7 +70,7 @@ describe('Harbor adapter contract', () => {
     assert.match(source, /MAKA_CELL_TIMEOUT_SEC/);
     assert.match(source, /MAKA_CELL_SETTLEMENT_GRACE_SEC/);
     assert.match(source, /MAKA_CELL_SOFT_TIMEOUT_MS/);
-    assert.match(source, /timeout_sec=self\._cell_timeout_sec\(\)/);
+    assert.match(source, /timeout_sec=self\._cell_hard_timeout_sec\(\)/);
     assert.match(source, /process\.returncode == 124/);
     assert.match(source, /deepseek\/deepseek-v4-flash/);
     assert.doesNotMatch(source, /deepseek\/deepseek-chat/);
@@ -2225,6 +2225,15 @@ with tempfile.TemporaryDirectory() as tmp:
         "MAKA_CELL_TIMEOUT_SEC": "1800",
         "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
     })._cell_soft_timeout_ms() == 1740000
+    fair_deadline_env = {
+        "MAKA_CELL_TIMEOUT_SEC": "5400",
+        "MAKA_CELL_SETTLEMENT_GRACE_SEC": "30",
+        "MAKA_CELL_HARD_TIMEOUT_SEC": "5430",
+        "MAKA_BENCHMARK_DEADLINE_POLICY": "task-native-full-budget-v1",
+    }
+    fair_deadline_agent = MakaAgent(Path(tmp), extra_env=fair_deadline_env)
+    assert fair_deadline_agent._cell_soft_timeout_ms() == 5400000
+    assert fair_deadline_agent._cell_hard_timeout_sec() == 5430
     try:
         MakaAgent(Path(tmp), extra_env={
             "MAKA_CELL_TIMEOUT_SEC": "2147514",
@@ -3403,6 +3412,10 @@ with tempfile.TemporaryDirectory() as tmp:
             "MAKA_TRIAL_CACHE_READ_USD_PER_1M": "0.5",
             "MAKA_TRIAL_OUTPUT_USD_PER_1M": "30",
             "MAKA_TRIAL_PRICING_SOURCE": "openai-gpt-5.6-sol-2026-07-20",
+            "MAKA_BENCHMARK_DEADLINE_POLICY": "task-native-full-budget-v1",
+            "MAKA_CELL_TIMEOUT_SEC": "5400",
+            "MAKA_CELL_SETTLEMENT_GRACE_SEC": "30",
+            "MAKA_CELL_HARD_TIMEOUT_SEC": "5430",
         },
     )
     environment = Environment()
@@ -3442,6 +3455,12 @@ with tempfile.TemporaryDirectory() as tmp:
     assert cell["executionIdentity"]["model"] == "gpt-5.6-sol", cell
     assert cell["executionIdentity"]["reasoningEffort"] == "max", cell
     assert cell["executionIdentity"]["agentTools"] is False, cell
+    assert cell["executionIdentity"]["deadlinePolicy"] == {
+        "id": "task-native-full-budget-v1",
+        "modelBudgetSec": 5400,
+        "settlementGraceSec": 30,
+        "hardTimeoutSec": 5430,
+    }, cell
     assert cell["runtimeRefs"]["sessionId"] == "thread-1", cell
     assert cell["tokenSummary"]["input"] == 100, cell
     assert cell["tokenSummary"]["cachedInput"] == 40, cell

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1151,7 +1151,7 @@ describe('runHarborCell', () => {
     });
   });
 
-  test('does not start a continuation turn after the settlement deadline latches', async () => {
+  test('does not issue a new provider request after the model-budget deadline latches', async () => {
     await withDirs(async ({ workspaceDir, outputDir, storageRoot }) => {
       let backend: DeadlineStepCapBackend | undefined;
       const result = await withTimeout(
@@ -1223,6 +1223,12 @@ describe('runHarborCell', () => {
         outputDir,
         storageRoot,
         pricingProfile: 'deepseek-v4-flash-tbench-v1',
+        deadlinePolicy: {
+          id: 'task-native-full-budget-v1',
+          modelBudgetSec: 5400,
+          settlementGraceSec: 30,
+          hardTimeoutSec: 5430,
+        },
         registerBackends: (registry) => {
           registry.register('fake', (ctx) => new IdentityObservingBackend(ctx.sessionId));
         },
@@ -1235,6 +1241,12 @@ describe('runHarborCell', () => {
         systemPromptHash: `sha256:${createHash('sha256').update(JSON.stringify(config.systemPrompt)).digest('hex')}`,
         pricingProfile: 'deepseek-v4-flash-tbench-v1',
         agentTools: false,
+        deadlinePolicy: {
+          id: 'task-native-full-budget-v1',
+          modelBudgetSec: 5400,
+          settlementGraceSec: 30,
+          hardTimeoutSec: 5430,
+        },
       });
     });
   });

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -830,6 +830,10 @@ test('harness A/B resolves the DeepSWE benchmark axis orthogonally to competitor
     pierVersion: '0.3.0',
   });
   assert.deepEqual(pierManifest.metadata.benchmark.executor, { id: 'pier', version: '0.3.0' });
+  assert.deepEqual(pierManifest.metadata.benchmark.deadlinePolicy, {
+    id: 'task-native-full-budget-v1',
+    settlementGraceSec: 30,
+  });
 
   // The Terminal-Bench default keeps its historical order seed byte-for-byte.
   const tbenchManifest = buildHarnessAbManifest({
@@ -843,6 +847,7 @@ test('harness A/B resolves the DeepSWE benchmark axis orthogonally to competitor
   // No executor key for Harbor benchmarks: the manifest payload (and with it
   // the resume fingerprint) must stay byte-identical to historical runs.
   assert.equal('executor' in tbenchManifest.metadata.benchmark, false);
+  assert.equal('deadlinePolicy' in tbenchManifest.metadata.benchmark, false);
 });
 
 test('harness A/B benchmark profiles bind their executor and resolve from env', async () => {

--- a/packages/headless/src/__tests__/harness-ab-manifest.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-manifest.test.ts
@@ -58,6 +58,10 @@ describe('harness A/B manifest', () => {
         timeoutPolicy: 'task-native',
         timeoutMultiplier: 1,
         outerTimeoutGraceSec: 900,
+        deadlinePolicy: {
+          id: 'task-native-full-budget-v1',
+          settlementGraceSec: 30,
+        },
       },
       metric: 'pass@1',
       execution: { armExecution: 'parallel' },
@@ -179,6 +183,10 @@ function manifestInput(taskIds: readonly string[]) {
       timeoutPolicy: 'task-native' as const,
       timeoutMultiplier: 1 as const,
       outerTimeoutGraceSec: 900,
+      deadlinePolicy: {
+        id: 'task-native-full-budget-v1' as const,
+        settlementGraceSec: 30,
+      },
     },
     taskIds,
     orderSeed: 'maka-glm-5.2-v1',

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -266,6 +266,7 @@ test('buildPierRunArgs emits the pier CLI contract for the Maka arm', () => {
     jobName: 'trial',
     environment: 'docker',
     timeoutMultiplier: 1,
+    agentTimeoutMultiplier: 1 + 30 / 5400,
     mounts: [{ type: 'bind', source: '/repo', target: '/opt/maka-agent', read_only: true }],
     agentEnv: { MAKA_MODEL: 'k3', MAKA_PROVIDER: 'kimi-coding-plan' },
   });
@@ -279,10 +280,85 @@ test('buildPierRunArgs emits the pier CLI contract for the Maka arm', () => {
   assert.match(joined, /-n 1/);
   assert.match(joined, /--yes/);
   assert.ok(args.includes('--mounts-json'));
+  const agentTimeoutMultiplierFlag = args.indexOf('--agent-timeout-multiplier');
+  assert.equal(args[agentTimeoutMultiplierFlag + 1], String(1 + 30 / 5400));
   assert.ok(args.includes('--ae'));
   assert.ok(args.includes('MAKA_MODEL=k3'));
   // No provider secret and no env-file were requested.
   assert.ok(!args.includes('--env-file'));
+});
+
+test('createPierTaskRunner gives only Maka a T+G agent phase while preserving other Pier phases', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const makaCaptured: FakeOptions['captured'] = {};
+    const makaRunner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'maka',
+        deadlineSettlementGraceSec: 30,
+        runPier: fakePier({
+          reward: 0,
+          captured: makaCaptured,
+          cell: cellOutput({
+            executionIdentity: {
+              ...cellOutput().executionIdentity!,
+              deadlinePolicy: {
+                id: 'task-native-full-budget-v1',
+                modelBudgetSec: 5400,
+                settlementGraceSec: 30,
+                hardTimeoutSec: 5430,
+              },
+            },
+          }),
+        }),
+      }),
+    );
+    await makaRunner(
+      runInput({
+        task: {
+          id: 'dasel',
+          path: '/tasks/dasel-html-document-format',
+          metadata: { agentTimeoutSec: 5400, buildTimeoutSec: 1800, verifierTimeoutSec: 1800 },
+        },
+      }),
+    );
+
+    const makaArgs = makaCaptured.request?.args ?? [];
+    const agentMultiplierFlag = makaArgs.indexOf('--agent-timeout-multiplier');
+    assert.equal(makaArgs[agentMultiplierFlag + 1], String(5430 / 5400));
+    assert.equal(makaArgs[makaArgs.indexOf('--timeout-multiplier') + 1], '1');
+    assert.ok(!makaArgs.includes('--environment-build-timeout-multiplier'));
+    assert.ok(!makaArgs.includes('--agent-setup-timeout-multiplier'));
+    assert.ok(!makaArgs.includes('--verifier-timeout-multiplier'));
+    assert.ok(makaArgs.includes('MAKA_CELL_TIMEOUT_SEC=5400'));
+    assert.ok(makaArgs.includes('MAKA_CELL_SETTLEMENT_GRACE_SEC=30'));
+    assert.ok(makaArgs.includes('MAKA_CELL_HARD_TIMEOUT_SEC=5430'));
+    assert.ok(makaArgs.includes('MAKA_STREAM_CONNECT_TIMEOUT_MS=5400000'));
+    assert.ok(makaArgs.includes('MAKA_STREAM_IDLE_TIMEOUT_MS=5400000'));
+    assert.equal(
+      makaCaptured.request?.timeoutMs,
+      (2 * 1800 + 360 + 5400 + 30 + 2 * 1800) * 1_000 + 15 * 60_000,
+    );
+
+    const codexArgs = buildPierRunArgs({
+      agent: 'codex',
+      model: 'gpt-5.6-sol',
+      taskPath: '/tasks/dasel',
+      jobsDir: '/jobs',
+      jobName: 'trial',
+      environment: 'docker',
+      timeoutMultiplier: 1,
+      mounts: [],
+      agentEnv: {},
+      agentKwargs: { version: CODEX_TOOLCHAIN_SPEC.codex.version },
+    });
+    assert.ok(!codexArgs.includes('--agent-timeout-multiplier'));
+    assert.equal(codexArgs[codexArgs.indexOf('--timeout-multiplier') + 1], '1');
+    assert.ok(!codexArgs.includes('--environment-build-timeout-multiplier'));
+    assert.ok(!codexArgs.includes('--agent-setup-timeout-multiplier'));
+    assert.ok(!codexArgs.includes('--verifier-timeout-multiplier'));
+  });
 });
 
 test('createPierTaskRunner mounts the pinned Maka Node runtime for container task-run mode', async () => {

--- a/packages/headless/src/benchmark-deadline-policy.ts
+++ b/packages/headless/src/benchmark-deadline-policy.ts
@@ -1,0 +1,52 @@
+import { assertPositiveInt } from './numeric-guards.js';
+
+export const TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID = 'task-native-full-budget-v1';
+
+export interface BenchmarkDeadlinePolicy {
+  id: typeof TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID;
+  /** Task-native agent timeout: the interval during which model work may start. */
+  modelBudgetSec: number;
+  /** Tail reserved only for stopping the runtime and persisting artifacts. */
+  settlementGraceSec: number;
+  /** Outer Maka agent watchdog. Always modelBudgetSec + settlementGraceSec. */
+  hardTimeoutSec: number;
+}
+
+export interface BenchmarkDeadlinePolicyManifest {
+  id: typeof TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID;
+  settlementGraceSec: number;
+}
+
+export function resolveTaskNativeDeadlinePolicy(
+  modelBudgetSec: number,
+  settlementGraceSec: number,
+): BenchmarkDeadlinePolicy {
+  assertPositiveInt('modelBudgetSec', modelBudgetSec);
+  assertPositiveInt('settlementGraceSec', settlementGraceSec);
+  if (!Number.isSafeInteger(modelBudgetSec) || !Number.isSafeInteger(settlementGraceSec)) {
+    throw new Error('modelBudgetSec and settlementGraceSec must be safe integers');
+  }
+  const hardTimeoutSec = modelBudgetSec + settlementGraceSec;
+  if (!Number.isSafeInteger(hardTimeoutSec)) {
+    throw new Error('modelBudgetSec + settlementGraceSec must be a safe integer');
+  }
+  return {
+    id: TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID,
+    modelBudgetSec,
+    settlementGraceSec,
+    hardTimeoutSec,
+  };
+}
+
+export function benchmarkDeadlinePoliciesEqual(
+  actual: BenchmarkDeadlinePolicy | undefined,
+  expected: BenchmarkDeadlinePolicy | undefined,
+): boolean {
+  if (actual === undefined || expected === undefined) return actual === expected;
+  return (
+    actual.id === expected.id &&
+    actual.modelBudgetSec === expected.modelBudgetSec &&
+    actual.settlementGraceSec === expected.settlementGraceSec &&
+    actual.hardTimeoutSec === expected.hardTimeoutSec
+  );
+}

--- a/packages/headless/src/benchmark-deadline-policy.ts
+++ b/packages/headless/src/benchmark-deadline-policy.ts
@@ -1,4 +1,5 @@
 import { assertPositiveInt } from './numeric-guards.js';
+import { positiveIntEnv, type RunHarborCellEnv } from './headless-run-env.js';
 
 export const TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID = 'task-native-full-budget-v1';
 
@@ -49,4 +50,28 @@ export function benchmarkDeadlinePoliciesEqual(
     actual.settlementGraceSec === expected.settlementGraceSec &&
     actual.hardTimeoutSec === expected.hardTimeoutSec
   );
+}
+
+export function benchmarkDeadlinePolicyFromEnv(
+  env: RunHarborCellEnv,
+): BenchmarkDeadlinePolicy | undefined {
+  const id = env.MAKA_BENCHMARK_DEADLINE_POLICY;
+  if (id === undefined) return undefined;
+  if (id !== TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID) {
+    throw new Error(
+      `MAKA_BENCHMARK_DEADLINE_POLICY must be ${TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID}`,
+    );
+  }
+  const policy = resolveTaskNativeDeadlinePolicy(
+    positiveIntEnv(env.MAKA_CELL_TIMEOUT_SEC, 'MAKA_CELL_TIMEOUT_SEC')!,
+    positiveIntEnv(env.MAKA_CELL_SETTLEMENT_GRACE_SEC, 'MAKA_CELL_SETTLEMENT_GRACE_SEC')!,
+  );
+  const attestedHardTimeout = positiveIntEnv(
+    env.MAKA_CELL_HARD_TIMEOUT_SEC,
+    'MAKA_CELL_HARD_TIMEOUT_SEC',
+  );
+  if (attestedHardTimeout !== policy.hardTimeoutSec) {
+    throw new Error('MAKA_CELL_HARD_TIMEOUT_SEC must equal T + G');
+  }
+  return policy;
 }

--- a/packages/headless/src/cell-output.ts
+++ b/packages/headless/src/cell-output.ts
@@ -1,5 +1,9 @@
 import type { RuntimeEvent } from '@maka/core';
 import type { ThinkingLevel } from '@maka/core';
+import {
+  TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID,
+  type BenchmarkDeadlinePolicy,
+} from './benchmark-deadline-policy.js';
 import type { ContextBudgetPolicy, InvocationResult } from '@maka/runtime';
 import type { HeadlessSystemPromptMode } from './contracts.js';
 
@@ -138,6 +142,9 @@ export interface HarborCellExecutionIdentity {
   pricingProfile: string;
   /** Present on artifacts written after Headless Agent tool gating was introduced. */
   agentTools?: boolean;
+  /** Present when a benchmark controller freezes the task-native model budget
+   * separately from the settlement-only tail. */
+  deadlinePolicy?: BenchmarkDeadlinePolicy;
 }
 
 export interface HarborCellDeadlineSettlement {
@@ -388,7 +395,49 @@ export function validateHarborCellExecutionIdentity(value: unknown): HarborCellE
     ...('agentTools' in value
       ? { agentTools: requireBoolean(value.agentTools, 'executionIdentity.agentTools') }
       : {}),
+    ...('deadlinePolicy' in value
+      ? { deadlinePolicy: validateBenchmarkDeadlinePolicy(value.deadlinePolicy) }
+      : {}),
   };
+}
+
+function validateBenchmarkDeadlinePolicy(value: unknown): BenchmarkDeadlinePolicy {
+  if (!isRecord(value)) {
+    throw new Error('executionIdentity.deadlinePolicy must be a JSON object');
+  }
+  const id = requireString(
+    value.id,
+    'executionIdentity.deadlinePolicy.id',
+  ) as BenchmarkDeadlinePolicy['id'];
+  if (id !== TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID) {
+    throw new Error(
+      `executionIdentity.deadlinePolicy.id must be ${TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID}`,
+    );
+  }
+  const modelBudgetSec = requireNumber(
+    value.modelBudgetSec,
+    'executionIdentity.deadlinePolicy.modelBudgetSec',
+  );
+  const settlementGraceSec = requireNumber(
+    value.settlementGraceSec,
+    'executionIdentity.deadlinePolicy.settlementGraceSec',
+  );
+  const hardTimeoutSec = requireNumber(
+    value.hardTimeoutSec,
+    'executionIdentity.deadlinePolicy.hardTimeoutSec',
+  );
+  if (
+    !Number.isSafeInteger(modelBudgetSec) ||
+    modelBudgetSec <= 0 ||
+    !Number.isSafeInteger(settlementGraceSec) ||
+    settlementGraceSec <= 0 ||
+    hardTimeoutSec !== modelBudgetSec + settlementGraceSec
+  ) {
+    throw new Error(
+      'executionIdentity.deadlinePolicy must satisfy positive integer T/G and H = T + G',
+    );
+  }
+  return { id, modelBudgetSec, settlementGraceSec, hardTimeoutSec };
 }
 
 function requireThinkingLevel(value: unknown, path: string): ThinkingLevel {

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -18,6 +18,11 @@ import type { MakaChangeAuditRecord } from './change-audit.js';
 import type { HarborBillingMode } from './harbor-task-runner.js';
 import { assertFinitePositive, assertPositiveInt, assertRatio } from './numeric-guards.js';
 import { hashHeadlessSystemPrompt } from './system-prompts.js';
+import {
+  benchmarkDeadlinePoliciesEqual,
+  resolveTaskNativeDeadlinePolicy,
+  type BenchmarkDeadlinePolicy,
+} from './benchmark-deadline-policy.js';
 
 export const FIXED_PROMPT_WAL_SCHEMA_VERSION = 1;
 export const BUDGET_EXHAUSTED_RUNTIME_UNAVAILABLE_REASON = 'budget_exhausted_before_cell_output';
@@ -385,6 +390,9 @@ export interface RunFixedPromptControllerInput {
   requireExecutionIdentity?: boolean;
   requireFinalUsage?: boolean;
   expectedPricingProfile?: string;
+  /** When set, require every task's execution identity to attest the same
+   * task-native T and controller-owned settlement grace. */
+  expectedDeadlineSettlementGraceSec?: number;
   billingMode?: HarborBillingMode;
   /** Refuse resume when a model attempt was durably admitted but no terminal
    * event exists, preserving single-sample benchmark semantics. */
@@ -425,6 +433,25 @@ export async function runFixedPromptController(
   }
   const terminalInfraFailures = input.protectPassAtOne || input.infraFailurePolicy === 'terminal';
   assertUniqueTaskIds(input.tasks.map((task) => task.id));
+  const expectedDeadlinePolicies =
+    input.expectedDeadlineSettlementGraceSec === undefined
+      ? undefined
+      : new Map(
+          input.tasks.map((task) => {
+            if (task.metadata?.agentTimeoutSec === undefined) {
+              throw new Error(
+                `task ${task.id} must declare agentTimeoutSec for deadline attestation`,
+              );
+            }
+            return [
+              task.id,
+              resolveTaskNativeDeadlinePolicy(
+                task.metadata.agentTimeoutSec,
+                input.expectedDeadlineSettlementGraceSec!,
+              ),
+            ];
+          }),
+        );
   const systemPrompt = await readFile(input.systemPromptPath, 'utf8');
   const expectedPromptHash = hashSystemPrompt(systemPrompt);
   const config = { ...input.config, systemPrompt };
@@ -517,6 +544,7 @@ export async function runFixedPromptController(
           requireExecutionIdentity: input.requireExecutionIdentity,
           requireFinalUsage: input.requireFinalUsage,
           expectedPricingProfile: input.expectedPricingProfile,
+          expectedDeadlinePolicy: expectedDeadlinePolicies?.get(task.id),
           billingMode: input.billingMode,
           resumeFingerprint: input.resumeFingerprint,
           id: newId(),
@@ -680,6 +708,7 @@ async function runTaskAndBuildEvent(input: {
   requireExecutionIdentity?: boolean;
   requireFinalUsage?: boolean;
   expectedPricingProfile?: string;
+  expectedDeadlinePolicy?: BenchmarkDeadlinePolicy;
   billingMode?: HarborBillingMode;
   resumeFingerprint?: string;
   id: string;
@@ -726,6 +755,7 @@ async function runTaskAndBuildEvent(input: {
         requireExecutionIdentity: input.requireExecutionIdentity,
         requireFinalUsage: input.requireFinalUsage,
         expectedPricingProfile: input.expectedPricingProfile,
+        expectedDeadlinePolicy: input.expectedDeadlinePolicy,
         billingMode: input.billingMode,
         resumeFingerprint: input.resumeFingerprint,
         id: input.id,
@@ -765,6 +795,7 @@ async function runTaskAndBuildEvent(input: {
           requireExecutionIdentity: input.requireExecutionIdentity,
           requireFinalUsage: input.requireFinalUsage,
           expectedPricingProfile: input.expectedPricingProfile,
+          expectedDeadlinePolicy: input.expectedDeadlinePolicy,
           billingMode: input.billingMode,
           resumeFingerprint: input.resumeFingerprint,
           id: input.id,
@@ -789,6 +820,7 @@ async function runTaskAndBuildEvent(input: {
     requireExecutionIdentity: input.requireExecutionIdentity,
     requireFinalUsage: input.requireFinalUsage,
     expectedPricingProfile: input.expectedPricingProfile,
+    expectedDeadlinePolicy: input.expectedDeadlinePolicy,
     billingMode: input.billingMode,
     resumeFingerprint: input.resumeFingerprint,
     taskId: input.task.id,
@@ -806,6 +838,7 @@ function taskEventFromOutput(input: {
   requireExecutionIdentity?: boolean;
   requireFinalUsage?: boolean;
   expectedPricingProfile?: string;
+  expectedDeadlinePolicy?: BenchmarkDeadlinePolicy;
   billingMode?: HarborBillingMode;
   resumeFingerprint?: string;
   taskId: string;
@@ -824,6 +857,7 @@ function taskEventFromOutput(input: {
     input.expectedPromptHash,
     input.expectedConfig,
     input.expectedPricingProfile,
+    input.expectedDeadlinePolicy,
   );
   if (identityMismatch) {
     return taskPlumbingFailedEvent({
@@ -846,6 +880,7 @@ function taskEventFromOutput(input: {
     input.requireExecutionIdentity ?? false,
     input.requireFinalUsage ?? false,
     input.expectedPricingProfile,
+    input.expectedDeadlinePolicy,
     input.billingMode,
   );
   if (plumbingFailure) {
@@ -881,7 +916,11 @@ function taskCompletedEvent(input: {
       output.cell.errorClass === 'policy_denied') &&
       output.harbor.verifier !== undefined);
   const passed = verifierGraded && output.harbor.reward > 0;
-  const errorClass = passed ? undefined : (output.cell.errorClass ?? 'verification_failed');
+  const errorClass = passed
+    ? undefined
+    : deadlineSettled
+      ? 'budget_exhausted'
+      : (output.cell.errorClass ?? 'verification_failed');
   const scored = verifierGraded && !isUnscoredCellFailure(errorClass);
   const agentFailure = output.cell.status === 'failed' && errorClass === 'tool_step_cap_reached';
   return {
@@ -1005,6 +1044,7 @@ function classifyPlumbingFailure(
   requireExecutionIdentity: boolean,
   requireFinalUsage: boolean,
   expectedPricingProfile: string | undefined,
+  expectedDeadlinePolicy: BenchmarkDeadlinePolicy | undefined,
   billingMode: HarborBillingMode | undefined,
 ):
   | {
@@ -1018,6 +1058,7 @@ function classifyPlumbingFailure(
     expectedConfig,
     requireExecutionIdentity,
     expectedPricingProfile,
+    expectedDeadlinePolicy,
   );
   if (identityFailure) return identityFailure;
   if (output.cell.status === 'completed' && output.cell.promptHash === undefined) {
@@ -1063,6 +1104,7 @@ function classifyExecutionIdentityFailure(
   expectedConfig: Config,
   requireExecutionIdentity: boolean,
   expectedPricingProfile: string | undefined,
+  expectedDeadlinePolicy: BenchmarkDeadlinePolicy | undefined,
 ):
   | {
       errorClass: Extract<
@@ -1090,12 +1132,15 @@ function classifyExecutionIdentityFailure(
       identity.reasoningEffort !== expectedConfig.thinkingLevel ||
       identity.agentTools !== (expectedConfig.agentTools === true) ||
       identity.systemPromptHash !== expectedPromptHash ||
-      (expectedPricingProfile !== undefined && identity.pricingProfile !== expectedPricingProfile)
+      (expectedPricingProfile !== undefined &&
+        identity.pricingProfile !== expectedPricingProfile) ||
+      (expectedDeadlinePolicy !== undefined &&
+        !benchmarkDeadlinePoliciesEqual(identity.deadlinePolicy, expectedDeadlinePolicy))
     ) {
       return {
         errorClass: 'execution_identity_mismatch',
         error:
-          'Harbor cell execution identity did not match the configured connection, model, and prompt',
+          'Harbor cell execution identity did not match the configured connection, model, prompt, pricing, or deadline policy',
       };
     }
   }
@@ -1107,6 +1152,7 @@ function classifyExplicitIdentityMismatch(
   expectedPromptHash: string,
   expectedConfig: Config,
   expectedPricingProfile: string | undefined,
+  expectedDeadlinePolicy: BenchmarkDeadlinePolicy | undefined,
 ): { errorClass: 'execution_identity_mismatch'; error: string } | undefined {
   if (!identity) return undefined;
   const failure = classifyExecutionIdentityFailure(
@@ -1115,6 +1161,7 @@ function classifyExplicitIdentityMismatch(
     expectedConfig,
     false,
     expectedPricingProfile,
+    expectedDeadlinePolicy,
   );
   return failure?.errorClass === 'execution_identity_mismatch'
     ? { errorClass: failure.errorClass, error: failure.error }
@@ -1173,6 +1220,7 @@ function taskBudgetExhaustedEvent(input: {
   requireExecutionIdentity?: boolean;
   requireFinalUsage?: boolean;
   expectedPricingProfile?: string;
+  expectedDeadlinePolicy?: BenchmarkDeadlinePolicy;
   billingMode?: HarborBillingMode;
   resumeFingerprint?: string;
   id: string;
@@ -1192,6 +1240,7 @@ function taskBudgetExhaustedEvent(input: {
       input.expectedPromptHash,
       input.expectedConfig,
       input.expectedPricingProfile,
+      input.expectedDeadlinePolicy,
     );
     evidenceFailure =
       identityMismatch ??
@@ -1212,6 +1261,7 @@ function taskBudgetExhaustedEvent(input: {
               input.requireExecutionIdentity ?? false,
               input.requireFinalUsage ?? false,
               input.expectedPricingProfile,
+              input.expectedDeadlinePolicy,
               input.billingMode,
             ));
   } else {
@@ -1221,6 +1271,7 @@ function taskBudgetExhaustedEvent(input: {
       input.expectedConfig,
       input.requireExecutionIdentity ?? false,
       input.expectedPricingProfile,
+      input.expectedDeadlinePolicy,
     );
     if (evidenceFailure?.errorClass === 'missing_execution_identity') {
       evidenceFailure = {

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -75,8 +75,7 @@ import {
   type RunHarborCellEnv,
 } from './headless-run-env.js';
 import {
-  resolveTaskNativeDeadlinePolicy,
-  TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID,
+  benchmarkDeadlinePolicyFromEnv,
   type BenchmarkDeadlinePolicy,
 } from './benchmark-deadline-policy.js';
 import {
@@ -711,30 +710,6 @@ export async function runHarborCellFromEnv(
   } finally {
     await providerEnvFetch?.close();
   }
-}
-
-function benchmarkDeadlinePolicyFromEnv(
-  env: RunHarborCellEnv,
-): BenchmarkDeadlinePolicy | undefined {
-  const id = env.MAKA_BENCHMARK_DEADLINE_POLICY;
-  const modelBudget = env.MAKA_CELL_TIMEOUT_SEC;
-  const settlementGrace = env.MAKA_CELL_SETTLEMENT_GRACE_SEC;
-  const hardTimeout = env.MAKA_CELL_HARD_TIMEOUT_SEC;
-  if (id === undefined) return undefined;
-  if (id !== TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID) {
-    throw new Error(
-      `MAKA_BENCHMARK_DEADLINE_POLICY must be ${TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID}`,
-    );
-  }
-  const policy = resolveTaskNativeDeadlinePolicy(
-    positiveIntEnv(modelBudget, 'MAKA_CELL_TIMEOUT_SEC')!,
-    positiveIntEnv(settlementGrace, 'MAKA_CELL_SETTLEMENT_GRACE_SEC')!,
-  );
-  const attestedHardTimeout = positiveIntEnv(hardTimeout, 'MAKA_CELL_HARD_TIMEOUT_SEC');
-  if (attestedHardTimeout !== policy.hardTimeoutSec) {
-    throw new Error('MAKA_CELL_HARD_TIMEOUT_SEC must equal T + G');
-  }
-  return policy;
 }
 
 export function reasoningEffortFromEnv(

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -75,6 +75,11 @@ import {
   type RunHarborCellEnv,
 } from './headless-run-env.js';
 import {
+  resolveTaskNativeDeadlinePolicy,
+  TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID,
+  type BenchmarkDeadlinePolicy,
+} from './benchmark-deadline-policy.js';
+import {
   buildHarborCellContextBudgetBackendOptions,
   buildHarborCellContextBudgetPolicySnapshot,
   buildHarborCellTaskLedgerExperimentPolicy,
@@ -136,6 +141,7 @@ export interface RunHarborCellInput {
   continuationPolicy?: HarborCellContinuationPolicy;
   taskToolSummaryEnabled?: boolean;
   settleAfterMs?: number;
+  deadlinePolicy?: BenchmarkDeadlinePolicy;
   now?: () => number;
   newId?: () => string;
 }
@@ -329,6 +335,7 @@ export async function runHarborCellWithStorage(
     systemPromptHash: prompt.systemPromptHash,
     pricingProfile: input.pricingProfile ?? 'unconfigured',
     agentTools: config.agentTools === true,
+    ...(input.deadlinePolicy ? { deadlinePolicy: input.deadlinePolicy } : {}),
   };
   await writeHarborCellExecutionIdentity(input.outputDir, executionIdentity);
 
@@ -589,6 +596,7 @@ export async function runHarborCellFromEnv(
   const taskLedgerExperimentPolicy = buildHarborCellTaskLedgerExperimentPolicy(resolvedEnv);
   const maxSteps = harborCellMaxStepsFromEnv(resolvedEnv);
   const settleAfterMs = harborCellSoftTimeoutMsFromEnv(resolvedEnv);
+  const deadlinePolicy = benchmarkDeadlinePolicyFromEnv(resolvedEnv);
   const reasoningEffort = reasoningEffortFromEnv(resolvedEnv.MAKA_REASONING_EFFORT);
   const agentTools = booleanEnv(resolvedEnv.MAKA_AGENT_TOOLS, 'MAKA_AGENT_TOOLS') ?? false;
   const baseConfig = {
@@ -686,6 +694,7 @@ export async function runHarborCellFromEnv(
       ...(continuationPolicy ? { continuationPolicy } : {}),
       ...(taskLedgerExperimentPolicy ? { taskToolSummaryEnabled: true } : {}),
       ...(settleAfterMs !== undefined ? { settleAfterMs } : {}),
+      ...(deadlinePolicy ? { deadlinePolicy } : {}),
       ...(registerBackends ? { registerBackends } : {}),
       ...(backendNeedsIsolation(backend)
         ? {
@@ -702,6 +711,30 @@ export async function runHarborCellFromEnv(
   } finally {
     await providerEnvFetch?.close();
   }
+}
+
+function benchmarkDeadlinePolicyFromEnv(
+  env: RunHarborCellEnv,
+): BenchmarkDeadlinePolicy | undefined {
+  const id = env.MAKA_BENCHMARK_DEADLINE_POLICY;
+  const modelBudget = env.MAKA_CELL_TIMEOUT_SEC;
+  const settlementGrace = env.MAKA_CELL_SETTLEMENT_GRACE_SEC;
+  const hardTimeout = env.MAKA_CELL_HARD_TIMEOUT_SEC;
+  if (id === undefined) return undefined;
+  if (id !== TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID) {
+    throw new Error(
+      `MAKA_BENCHMARK_DEADLINE_POLICY must be ${TASK_NATIVE_FULL_BUDGET_DEADLINE_POLICY_ID}`,
+    );
+  }
+  const policy = resolveTaskNativeDeadlinePolicy(
+    positiveIntEnv(modelBudget, 'MAKA_CELL_TIMEOUT_SEC')!,
+    positiveIntEnv(settlementGrace, 'MAKA_CELL_SETTLEMENT_GRACE_SEC')!,
+  );
+  const attestedHardTimeout = positiveIntEnv(hardTimeout, 'MAKA_CELL_HARD_TIMEOUT_SEC');
+  if (attestedHardTimeout !== policy.hardTimeoutSec) {
+    throw new Error('MAKA_CELL_HARD_TIMEOUT_SEC must equal T + G');
+  }
+  return policy;
 }
 
 export function reasoningEffortFromEnv(

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -7,6 +7,10 @@ import type { BackendKind, ProviderType } from '@maka/core';
 import { PROVIDER_DEFAULTS, normalizeProviderType } from '@maka/core';
 import type { Config, Task } from './contracts.js';
 import {
+  benchmarkDeadlinePolicyFromEnv,
+  type BenchmarkDeadlinePolicy,
+} from './benchmark-deadline-policy.js';
+import {
   type HarborCellExecutionIdentity,
   combineInvocations,
   validateHarborCellExecutionIdentity,
@@ -75,6 +79,7 @@ interface HarborRunOptions {
   maxRuntimeSteps?: number;
   maxWallTimeMs?: number;
   softTimeoutMs?: number;
+  deadlinePolicy?: BenchmarkDeadlinePolicy;
   replayPriorAttemptRuntimeContext: boolean;
   now: () => number;
   newId: () => string;
@@ -159,6 +164,7 @@ async function runHarborCellMode(
       storageRoot: options.storageRoot,
       ...(options.contextBudgetPolicy ? { contextBudgetPolicy: options.contextBudgetPolicy } : {}),
       ...(options.softTimeoutMs !== undefined ? { settleAfterMs: options.softTimeoutMs } : {}),
+      ...(options.deadlinePolicy ? { deadlinePolicy: options.deadlinePolicy } : {}),
       ...(options.registerBackends ? { registerBackends: options.registerBackends } : {}),
       ...(options.realBackendIsolation
         ? { realBackendIsolation: options.realBackendIsolation }
@@ -359,6 +365,7 @@ async function writeTaskRunExecutionIdentity(
     systemPromptHash: prompt.systemPromptHash,
     pricingProfile: options.env.MAKA_TRIAL_PRICING_SOURCE ?? 'unconfigured',
     agentTools: options.config.agentTools === true,
+    ...(options.deadlinePolicy ? { deadlinePolicy: options.deadlinePolicy } : {}),
   });
   await writeHarborCellExecutionIdentity(options.cellArtifactDir, executionIdentity);
   return executionIdentity;
@@ -422,6 +429,7 @@ export async function resolveHarborRunOptions(
     '--max-wall-time-sec',
   );
   const softTimeoutMs = harborCellSoftTimeoutMsFromEnv(env);
+  const deadlinePolicy = benchmarkDeadlinePolicyFromEnv(env);
   const config = buildConfig({
     parsed,
     env,
@@ -474,6 +482,7 @@ export async function resolveHarborRunOptions(
     ...(maxRuntimeSteps !== undefined ? { maxRuntimeSteps } : {}),
     ...(maxWallTimeSec !== undefined ? { maxWallTimeMs: maxWallTimeSec * 1000 } : {}),
     ...(softTimeoutMs !== undefined ? { softTimeoutMs } : {}),
+    ...(deadlinePolicy ? { deadlinePolicy } : {}),
     replayPriorAttemptRuntimeContext:
       parsed.bools['replay-prior-attempt-runtime-context'] ||
       truthyEnv(env.MAKA_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT),

--- a/packages/headless/src/harness-ab-manifest.ts
+++ b/packages/headless/src/harness-ab-manifest.ts
@@ -2,6 +2,7 @@ import { createHash } from 'node:crypto';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import { buildAbRunManifest, buildRunManifestFingerprint } from './ab-manifest.js';
 import type { AbRunManifest } from './ab-types.js';
+import type { BenchmarkDeadlinePolicyManifest } from './benchmark-deadline-policy.js';
 import type { HarnessOracleAnnotation } from './harness-oracle-registry.js';
 
 export type HarnessAbArmId = 'maka' | 'opencode' | 'kimi-code' | 'codex';
@@ -220,6 +221,7 @@ export interface HarnessAbRunManifestInput {
      * version the toolchain fingerprint also hashes. Absent for Harbor
      * benchmarks so existing Terminal-Bench manifests stay byte-identical. */
     executor?: { id: 'pier'; version: string };
+    deadlinePolicy?: BenchmarkDeadlinePolicyManifest;
     timeoutPolicy: 'task-native';
     timeoutMultiplier: 1;
     outerTimeoutGraceSec: number;

--- a/packages/headless/src/harness-ab-run.ts
+++ b/packages/headless/src/harness-ab-run.ts
@@ -30,6 +30,7 @@ export interface RunHarnessAbComparisonInput {
   arms: readonly [HarnessAbRuntimeArm, HarnessAbRuntimeArm];
   pairConcurrency?: number;
   armExecution?: 'parallel' | 'sequential';
+  expectedDeadlineSettlementGraceSec?: number;
   now?: () => number;
   newId?: () => string;
 }
@@ -95,6 +96,11 @@ export async function runHarnessAbComparisonUnlocked(
         requireExecutionIdentity: true,
         requireFinalUsage: true,
         expectedPricingProfile: runtimeArm.expectedPricingProfile,
+        ...(input.expectedDeadlineSettlementGraceSec !== undefined
+          ? {
+              expectedDeadlineSettlementGraceSec: input.expectedDeadlineSettlementGraceSec,
+            }
+          : {}),
         ...(runtimeArm.billingMode ? { billingMode: runtimeArm.billingMode } : {}),
         resumeFingerprint: input.resumeFingerprint,
         taskRunner: runtimeArm.harborRunner,

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -56,6 +56,10 @@ import {
   type ProviderTokenUsage,
   type ProviderUpstreamCredentialResolver,
 } from './provider-auth-proxy.js';
+import {
+  resolveTaskNativeDeadlinePolicy,
+  type BenchmarkDeadlinePolicy,
+} from './benchmark-deadline-policy.js';
 
 const CONTAINER_MAKA_REPO = '/opt/maka-agent';
 const TRIAL_CELL_OUTPUT = 'agent/maka-cell-output.json';
@@ -180,6 +184,9 @@ export interface PierTaskRunnerOptions {
    * explicit Docker target platform cannot be wired through `pier run`. */
   environment?: string;
   timeoutMultiplier?: number;
+  /** Opts a Pier benchmark into the full task-native model budget plus a
+   * settlement-only tail. The task metadata remains the authority for T. */
+  deadlineSettlementGraceSec?: number;
   /** Wall-clock ceiling for a single `pier run`; a hung Docker/Pier would
    * otherwise stall the unattended loop forever. Defaults to pier's maximum
    * legitimate trial lifecycle (2 x build + agent + 2 x verifier task-native
@@ -250,6 +257,13 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
       `Codex adapter version must match toolchain version ${CODEX_TOOLCHAIN_SPEC.codex.version}`,
     );
   }
+  if (
+    options.deadlineSettlementGraceSec !== undefined &&
+    options.timeoutMultiplier !== undefined &&
+    options.timeoutMultiplier !== 1
+  ) {
+    throw new Error('benchmark deadline policy requires timeoutMultiplier 1');
+  }
   const runPier = options.runPier ?? defaultPierProcessRunner;
   const pierBin = options.pierBin ?? 'pier';
   // The bare adapter import path (`maka_agent:MakaAgent`) resolves only when the
@@ -278,6 +292,13 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
     // Same benchmark invariant as the Harbor runner (shared implementation):
     // agentEnv must not override experiment identity or MAKA_TRIAL_* pricing.
     assertNoExperimentIdentityOverrides(attemptAgentEnv);
+    const deadlinePolicy =
+      options.deadlineSettlementGraceSec === undefined
+        ? undefined
+        : resolveTaskNativeDeadlinePolicy(
+            requiredAgentTimeoutSec(input),
+            options.deadlineSettlementGraceSec,
+          );
 
     const traceMode = harborTraceMode(attemptAgentEnv);
     const providerTelemetryPath = join(jobsDir, PROVIDER_REQUEST_TELEMETRY);
@@ -297,7 +318,13 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
         // closes the proxy: a failure in this window (env-file write, arg
         // assembly) must not leak the listening socket.
         try {
-          const aeEnv = buildPierAgentEnv(input, options, agent, providerRuntime?.agentEnv ?? {});
+          const aeEnv = buildPierAgentEnv(
+            input,
+            options,
+            agent,
+            providerRuntime?.agentEnv ?? {},
+            deadlinePolicy,
+          );
           const processEnv: Record<string, string> = {
             PYTHONPATH: pythonPath,
             // MAKA_BACKEND is a CliFlag whose env_fallback reads os.environ only, so
@@ -326,6 +353,12 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
             jobName,
             environment: options.environment ?? 'docker',
             timeoutMultiplier: options.timeoutMultiplier ?? 1,
+            ...(agent === 'maka' && deadlinePolicy
+              ? {
+                  agentTimeoutMultiplier:
+                    deadlinePolicy.hardTimeoutSec / deadlinePolicy.modelBudgetSec,
+                }
+              : {}),
             mounts,
             agentEnv: aeEnv,
             ...(usesEnvFile ? { envFile: envFilePath } : {}),
@@ -355,7 +388,9 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
             timeoutMs:
               options.pierTimeoutMs ??
               resolveNativeTrialTimeoutMs({
-                nativePhasesSec: pierMaxTrialPhasesSec(input.task.metadata),
+                nativePhasesSec:
+                  pierMaxTrialPhasesSec(input.task.metadata) +
+                  (agent === 'maka' ? (deadlinePolicy?.settlementGraceSec ?? 0) : 0),
                 timeoutMultiplier: options.timeoutMultiplier ?? 1,
               }),
             env: processEnv,
@@ -540,6 +575,7 @@ export interface BuildPierRunArgsInput {
   jobName: string;
   environment: string;
   timeoutMultiplier: number;
+  agentTimeoutMultiplier?: number;
   mounts: ReadonlyArray<Record<string, unknown>>;
   agentEnv: Record<string, string>;
   envFile?: string;
@@ -581,6 +617,9 @@ export function buildPierRunArgs(input: BuildPierRunArgsInput): string[] {
     '--yes',
     '--quiet',
   ];
+  if (input.agentTimeoutMultiplier !== undefined) {
+    args.push('--agent-timeout-multiplier', String(input.agentTimeoutMultiplier));
+  }
   if (input.envFile) args.push('--env-file', input.envFile);
   for (const [key, value] of Object.entries(input.agentKwargs ?? {})) {
     args.push('--ak', `${key}=${value}`);
@@ -640,6 +679,7 @@ function buildPierAgentEnv(
   options: PierTaskRunnerOptions,
   agent: PierAgent,
   providerAgentEnv: Record<string, string>,
+  deadlinePolicy: BenchmarkDeadlinePolicy | undefined,
 ): Record<string, string> {
   const provider = options.provider ?? 'deepseek';
   const makaModel = modelIdForProvider(options.model, provider);
@@ -690,7 +730,30 @@ function buildPierAgentEnv(
       env.MAKA_STREAM_IDLE_TIMEOUT_MS = String(streamTimeoutMs);
     }
   }
+  if (deadlinePolicy) {
+    // These are controller-owned after user env merges: both arms must attest
+    // the same task-native T/G/H, and an override must not silently alter it.
+    env.MAKA_BENCHMARK_DEADLINE_POLICY = deadlinePolicy.id;
+    env.MAKA_CELL_TIMEOUT_SEC = String(deadlinePolicy.modelBudgetSec);
+    env.MAKA_CELL_SETTLEMENT_GRACE_SEC = String(deadlinePolicy.settlementGraceSec);
+    env.MAKA_CELL_HARD_TIMEOUT_SEC = String(deadlinePolicy.hardTimeoutSec);
+    const modelBudgetMs = deadlinePolicy.modelBudgetSec * 1_000;
+    if (agent === 'maka' && Number.isSafeInteger(modelBudgetMs)) {
+      env.MAKA_STREAM_CONNECT_TIMEOUT_MS = String(modelBudgetMs);
+      env.MAKA_STREAM_IDLE_TIMEOUT_MS = String(modelBudgetMs);
+    }
+  }
   return env;
+}
+
+function requiredAgentTimeoutSec(input: TaskRunInput): number {
+  const timeoutSec = input.task.metadata?.agentTimeoutSec;
+  if (timeoutSec === undefined) {
+    throw new Error(
+      `task ${input.task.id} must declare agentTimeoutSec for the benchmark deadline policy`,
+    );
+  }
+  return timeoutSec;
 }
 
 async function pierProviderRuntime(


### PR DESCRIPTION
## Summary

DeepSWE gave the Maka arm less effective model time than the Codex arm. The task-native agent timeout is `T`, but the Maka adapter started benchmark settlement at `T - G` while Pier cancelled Codex near `T`; with `T=5400s` and `G=30s`, this explains the observed Maka cutoff near 5370s.

This change makes the controller-owned policy explicit:

- both arms receive the full task-native model budget `T`;
- Maka stops new model work at `T`, uses `G` only to stop the runtime and persist artifacts, and has an outer agent watchdog `H = T + G`;
- Pier 0.3.0's agent-specific timeout multiplier extends only the Maka agent phase to `H`, while Codex remains at `T` and build, setup, and verifier phases remain unchanged;
- the manifest and per-attempt execution identity attest the policy in both cell and task-run modes, and the controller rejects a missing or mismatched `T/G/H`;
- verifier-graded benchmark deadline settlements use the benchmark-facing `budget_exhausted` taxonomy without rewriting the raw runtime trace (`aborted`) or resampling the task.

The legacy adapter timeout path remains unchanged unless the benchmark policy is explicitly enabled.

## Verification

- TDD: added the narrow deadline, Pier phase isolation, identity, taxonomy, trace-preservation, and no-resampling tests before implementation; the initial headless typecheck failed on the missing policy surface.
- Review regression TDD: the real `harbor run --mode task-run` test first failed because its execution identity omitted `deadlinePolicy`; the shared parser/task-run writer fix made the same test pass.
- `npm --workspace @maka/headless test` — 1349 passed, 0 failed.
- `node --test packages/headless/dist/__tests__/cli.test.js packages/headless/dist/__tests__/harbor-cell.test.js packages/headless/dist/__tests__/fixed-prompt-controller.test.js packages/headless/dist/__tests__/pier-task-runner.test.js` — 289 passed, 0 failed.
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `PYTHONPYCACHEPREFIX=/tmp/maka-deadline-pyc python3 -m py_compile packages/headless/harbor/deadline_policy.py packages/headless/harbor/maka_agent.py packages/headless/harbor/codex_agent.py packages/headless/harbor/kimi_code_agent.py`
- `git diff --check`

No real model or paid benchmark was run for this change.

## Why not `T - G`

Settlement is cleanup, not model work. Charging `G` against only the Maka arm changes the experiment from a head-to-head comparison at task budget `T` into two different budget treatments. Shrinking Codex to `T - G` would make the arms equally short but would still violate the benchmark's native budget. Pier's agent-specific multiplier provides the smaller, auditable seam: Maka gets a cleanup tail without changing any other phase or allowing a new model request after `T`.

## Remaining evidence

- [ ] Run the zero-cost fake-backend smoke from the exact PR commit and confirm both arms attest the same task-derived `T/G/H`.
- [ ] After the smoke is clean, run one minimal paired paid canary from the exact PR commit and compare provider request timestamps, deadline settlement, execution identity, raw trace, verifier output, and cost attribution.

This branch is rebased onto the merged #1502 shared-proxy change. The #1502 canary tested proxy isolation on a different exact commit; its timings motivated this fix but cannot validate this deadline policy.

## Review focus

- Pier 0.3.0 receives `--agent-timeout-multiplier=H/T` only for Maka; Codex, build, setup, and verifier retain their task-native limits.
- Controller-owned environment values cannot be overridden by arm configuration; Codex/Kimi adapters and both Maka cell/task-run identity writers attest the same shared policy before model work.
- `budget_exhausted` is normalized only at the benchmark event boundary; raw cell output and runtime events remain unchanged.
