### PR TITLE
fix(headless): cancel provider credential resolution

### DIFF
--- a/packages/headless/src/__tests__/codex-oauth-harness.test.ts
+++ b/packages/headless/src/__tests__/codex-oauth-harness.test.ts
@@ -138,6 +138,73 @@ test('Codex OAuth broker refreshes and persists authority across a long run', as
   }
 });
 
+test('Codex OAuth broker cancels an in-flight refresh with the request signal', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-codex-oauth-cancel-test-'));
+  let releaseRefresh = () => {};
+  let resolution: Promise<unknown> | undefined;
+  try {
+    const store = createFileCredentialStore(root);
+    const accountId = 'acct-shared';
+    let now = 1_000_000;
+    await store.setSecret(
+      'codex-subscription',
+      'oauth_token',
+      JSON.stringify({
+        access_token: jwt(accountId, 'current'),
+        refresh_token: 'refresh-current',
+        expires_at: now + 3_600_000,
+        account_id: accountId,
+      }),
+    );
+    let markRefreshStarted!: () => void;
+    const refreshStarted = new Promise<void>((resolve) => {
+      markRefreshStarted = resolve;
+    });
+    let observedSignal: AbortSignal | undefined;
+    const { resolveProviderCredential } = await createCodexOAuthHarnessCredentialBinding({
+      credentialsRoot: root,
+      connectionSlug: 'codex-subscription',
+      now: () => now,
+      fetchFn: async (_input, init) => {
+        observedSignal = init?.signal ?? undefined;
+        markRefreshStarted();
+        return await new Promise<Response>((resolve, reject) => {
+          releaseRefresh = () =>
+            resolve(
+              new Response(
+                JSON.stringify({
+                  access_token: jwt(accountId, 'refreshed'),
+                  refresh_token: 'refresh-next',
+                  expires_in: 3_600,
+                }),
+                { status: 200, headers: { 'content-type': 'application/json' } },
+              ),
+            );
+          observedSignal?.addEventListener(
+            'abort',
+            () => {
+              reject(observedSignal?.reason);
+            },
+            { once: true },
+          );
+        });
+      },
+    });
+    now += 3_600_001;
+    const controller = new AbortController();
+    resolution = resolveProviderCredential(controller.signal);
+
+    await refreshStarted;
+    assert.equal(observedSignal, controller.signal);
+    controller.abort();
+    await assert.rejects(resolution, /credentials are unavailable/);
+  } finally {
+    releaseRefresh();
+    await resolution?.catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 function jwt(accountId: string, suffix: string): string {
   const encoded = Buffer.from(
     JSON.stringify({ 'https://api.openai.com/auth': { chatgpt_account_id: accountId }, suffix }),

--- a/packages/headless/src/__tests__/codex-oauth-harness.test.ts
+++ b/packages/headless/src/__tests__/codex-oauth-harness.test.ts
@@ -138,10 +138,13 @@ test('Codex OAuth broker refreshes and persists authority across a long run', as
   }
 });
 
-test('Codex OAuth broker cancels an in-flight refresh with the request signal', async () => {
+test('Codex OAuth broker cancels an in-flight refresh with the request signal', {
+  timeout: 5_000,
+}, async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-codex-oauth-cancel-test-'));
   let releaseRefresh = () => {};
   let resolution: Promise<unknown> | undefined;
+  let rejectionTimeout: ReturnType<typeof setTimeout> | undefined;
   try {
     const store = createFileCredentialStore(root);
     const accountId = 'acct-shared';
@@ -197,8 +200,20 @@ test('Codex OAuth broker cancels an in-flight refresh with the request signal', 
     await refreshStarted;
     assert.equal(observedSignal, controller.signal);
     controller.abort();
-    await assert.rejects(resolution, /credentials are unavailable/);
+    await assert.rejects(
+      Promise.race([
+        resolution,
+        new Promise((_, reject) => {
+          rejectionTimeout = setTimeout(
+            () => reject(new Error('credential resolution did not observe cancellation')),
+            250,
+          );
+        }),
+      ]),
+      /credentials are unavailable/,
+    );
   } finally {
+    if (rejectionTimeout) clearTimeout(rejectionTimeout);
     releaseRefresh();
     await resolution?.catch(() => undefined);
     await rm(root, { recursive: true, force: true });

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -858,6 +858,62 @@ test('provider auth proxy aborts an in-flight upstream request on close', async 
   }
 });
 
+test('provider auth proxy cancels credential resolution on close', { timeout: 5_000 }, async () => {
+  let markCredentialRequestStarted!: () => void;
+  let markCredentialSocketClosed!: () => void;
+  let releaseCredentialRequest = () => {};
+  const credentialRequestStarted = new Promise<void>((resolve) => {
+    markCredentialRequestStarted = resolve;
+  });
+  const credentialSocketClosed = new Promise<void>((resolve) => {
+    markCredentialSocketClosed = resolve;
+  });
+  const credentialServer = createServer((request, response) => {
+    markCredentialRequestStarted();
+    request.socket.once('close', markCredentialSocketClosed);
+    releaseCredentialRequest = () => {
+      if (!response.writableEnded) response.end('upstream-key');
+    };
+  });
+  await new Promise<void>((resolve) => credentialServer.listen(0, '127.0.0.1', resolve));
+  const address = credentialServer.address();
+  assert.ok(address && typeof address !== 'string');
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: 'http://127.0.0.1:1',
+    advertisedHost: '127.0.0.1',
+    resolveUpstreamCredential: async (signal?: AbortSignal) => {
+      const response = await fetch(`http://127.0.0.1:${address.port}/credential`, {
+        ...(signal ? { signal } : {}),
+      });
+      return { value: await response.text() };
+    },
+  });
+  const providerResponse = fetch(`${proxy.baseUrl}/responses`, {
+    headers: { authorization: `Bearer ${proxy.token}` },
+  }).catch(() => undefined);
+
+  try {
+    await credentialRequestStarted;
+    const closeAttempt = proxy.close();
+    const closed = await Promise.race([
+      closeAttempt.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 250)),
+    ]);
+    assert.equal(closed, true);
+    const credentialSocketWasClosed = await Promise.race([
+      credentialSocketClosed.then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 250)),
+    ]);
+    assert.equal(credentialSocketWasClosed, true);
+    await providerResponse;
+  } finally {
+    releaseCredentialRequest();
+    await proxy.close();
+    credentialServer.closeAllConnections();
+    await new Promise<void>((resolve) => credentialServer.close(() => resolve()));
+  }
+});
+
 test('provider auth proxy aborts the upstream stream when its client disconnects', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-client-disconnect-'));
   let upstreamClosed!: () => void;

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -914,6 +914,42 @@ test('provider auth proxy cancels credential resolution on close', { timeout: 5_
   }
 });
 
+test('provider auth proxy closes when credential resolution ignores cancellation', {
+  timeout: 5_000,
+}, async () => {
+  let markCredentialResolutionStarted!: () => void;
+  let releaseCredentialResolution = () => {};
+  const credentialResolutionStarted = new Promise<void>((resolve) => {
+    markCredentialResolutionStarted = resolve;
+  });
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: 'http://127.0.0.1:1',
+    advertisedHost: '127.0.0.1',
+    resolveUpstreamCredential: async () => {
+      markCredentialResolutionStarted();
+      return await new Promise((resolve) => {
+        releaseCredentialResolution = () => resolve({ value: 'upstream-key' });
+      });
+    },
+  });
+  const providerResponse = fetch(`${proxy.baseUrl}/responses`, {
+    headers: { authorization: `Bearer ${proxy.token}` },
+  }).catch(() => undefined);
+
+  try {
+    await credentialResolutionStarted;
+    const closed = await Promise.race([
+      proxy.close().then(() => true),
+      new Promise<false>((resolve) => setTimeout(() => resolve(false), 250)),
+    ]);
+    assert.equal(closed, true);
+    await providerResponse;
+  } finally {
+    releaseCredentialResolution();
+    await proxy.close();
+  }
+});
+
 test('provider auth proxy aborts the upstream stream when its client disconnects', async () => {
   const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-client-disconnect-'));
   let upstreamClosed!: () => void;

--- a/packages/headless/src/codex-oauth-harness.ts
+++ b/packages/headless/src/codex-oauth-harness.ts
@@ -22,13 +22,20 @@ export async function createCodexOAuthHarnessCredentialBinding(
   input: CodexOAuthHarnessCredentialBindingInput,
 ): Promise<CodexOAuthHarnessCredentialBinding> {
   const credentialStore = createFileCredentialStore(input.credentialsRoot);
-  const resolveTokens = async () => {
+  const resolveTokens = async (signal?: AbortSignal) => {
+    const signalBoundFetch: typeof fetch | undefined = signal
+      ? (resource, init) =>
+          (input.fetchFn ?? fetch)(resource, {
+            ...init,
+            signal,
+          })
+      : input.fetchFn;
     const tokens = await resolveOAuthSubscriptionTokens({
       providerType: 'openai-codex',
       slug: input.connectionSlug,
       credentialStore,
       ...(input.now ? { now: input.now } : {}),
-      ...(input.fetchFn ? { fetchFn: input.fetchFn } : {}),
+      ...(signalBoundFetch ? { fetchFn: signalBoundFetch } : {}),
     });
     if (!tokens) throw new Error('Maka Codex OAuth credentials are unavailable');
     return tokens;
@@ -36,8 +43,8 @@ export async function createCodexOAuthHarnessCredentialBinding(
   const initialTokens = await resolveTokens();
   const expectedAccountId = extractCodexAccountId(initialTokens.access_token);
   if (!expectedAccountId) throw new Error('Maka Codex OAuth credential has no account identity');
-  const resolveCredential: ProviderUpstreamCredentialResolver = async () => {
-    const tokens = await resolveTokens();
+  const resolveCredential: ProviderUpstreamCredentialResolver = async (signal) => {
+    const tokens = await resolveTokens(signal);
     const accountId = extractCodexAccountId(tokens.access_token);
     if (accountId !== expectedAccountId) {
       throw new Error('Codex OAuth account changed during the run');

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -143,7 +143,9 @@ export interface ProviderUpstreamCredential {
   headers?: Readonly<Record<string, string>>;
 }
 
-export type ProviderUpstreamCredentialResolver = () => Promise<ProviderUpstreamCredential>;
+export type ProviderUpstreamCredentialResolver = (
+  signal?: AbortSignal,
+) => Promise<ProviderUpstreamCredential>;
 
 type ProviderAuthProxyRouteConfig = {
   upstreamBaseUrl: string;
@@ -313,8 +315,13 @@ function providerAuthProxyRoute(input: ProviderAuthProxyRouteInput): ProviderAut
   const upstreamBasePath = normalizeProxyBasePath(upstreamBaseUrl.pathname);
   const resolveUpstreamCredential =
     input.resolveUpstreamCredential ??
-    (async () => {
-      const value = (await readFile(input.apiKeyFile, 'utf8')).trim();
+    (async (signal) => {
+      const value = (
+        await readFile(input.apiKeyFile, {
+          encoding: 'utf8',
+          ...(signal ? { signal } : {}),
+        })
+      ).trim();
       if (value.length === 0) throw new Error('provider API key file is empty');
       return { value };
     });
@@ -391,7 +398,10 @@ async function forwardProviderRequest(input: {
       protocol: input.usageProtocol,
       startedAt,
     });
-    const upstreamCredential = await input.resolveUpstreamCredential();
+    const upstreamCredential = await resolveUpstreamCredentialUntilAborted(
+      input.resolveUpstreamCredential,
+      input.signal,
+    );
     if (upstreamCredential.value.length === 0) {
       throw new Error('provider credential resolver returned an empty value');
     }
@@ -488,6 +498,24 @@ async function forwardProviderRequest(input: {
     if (input.response.destroyed) return;
     if (!input.response.headersSent) input.response.writeHead(502);
     input.response.end('provider proxy request failed');
+  }
+}
+
+async function resolveUpstreamCredentialUntilAborted(
+  resolveUpstreamCredential: ProviderUpstreamCredentialResolver,
+  signal: AbortSignal,
+): Promise<ProviderUpstreamCredential> {
+  if (signal.aborted) throw signal.reason ?? new Error('provider proxy request aborted');
+  let rejectOnAbort!: (reason?: unknown) => void;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    rejectOnAbort = reject;
+  });
+  const onAbort = () => rejectOnAbort(signal.reason ?? new Error('provider proxy request aborted'));
+  signal.addEventListener('abort', onAbort, { once: true });
+  try {
+    return await Promise.race([resolveUpstreamCredential(signal), aborted]);
+  } finally {
+    signal.removeEventListener('abort', onAbort);
   }
 }
 


### PR DESCRIPTION
## Summary

Provider-proxy shutdown aborted active upstream model requests but could remain blocked while an asynchronous credential resolver was still running.

This change keeps cancellation at the existing request lifecycle seam:

- the proxy passes its per-request `AbortSignal` into credential resolution;
- API-key reads and the Codex OAuth refresh fetch observe that signal;
- a `Promise.race` still bounds proxy shutdown when an existing custom resolver ignores the optional signal.

The resolver API remains backward-compatible and this PR stays independent of DeepSWE deadline policy.

## Verification

- `npm run build --workspace=@maka/headless`
- `/opt/homebrew/opt/node@22/bin/node --test packages/headless/dist/__tests__/provider-auth-proxy.test.js packages/headless/dist/__tests__/codex-oauth-harness.test.js` — 27 passed, 0 failed
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `git diff --check`
- CI: typecheck, test, and e2e passed

The regression tests cover both a real cancellable credential HTTP request and a resolver that ignores cancellation, and bound the Codex cancellation assertion so a regression fails quickly instead of hanging the suite.

No model call or benchmark was run.

## Review focus

- `ProviderUpstreamCredentialResolver` keeps its signal optional for existing direct callers.
- Signal propagation releases cooperative resolver resources; the race preserves close liveness for non-cooperative resolvers.
- No OAuth transaction manager, deadline state, timeout subsystem, or provider-specific proxy path is introduced.
