### PR TITLE
fix(headless): equalize DeepSWE agent deadlines

### DIFF
--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -11,6 +11,7 @@ import re
 import secrets
 import shlex
 import threading
+import time
 from datetime import datetime, timezone
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
@@ -123,6 +124,20 @@ _MAX_NODE_TIMER_MS = 2_147_483_647
 # ASCII decimal positive integer literal only; [0-9] (not \d) rejects Unicode
 # digits on both sides. Matches the TS host's lenientPositiveIntEnv.
 _POSITIVE_INT_RE = re.compile(r"[1-9][0-9]*")
+
+
+def _positive_int_literal(raw: str | None) -> int | None:
+    if not raw:
+        return None
+    stripped = raw.strip()
+    if _POSITIVE_INT_RE.fullmatch(stripped) is None:
+        return None
+    try:
+        value = int(stripped)
+    except ValueError:
+        # CPython caps integer-string conversion length; an over-long value is malformed.
+        return None
+    return value if value <= _MAX_SAFE_INTEGER else None
 
 
 class MakaAgent(BaseInstalledAgent):
@@ -368,6 +383,7 @@ class MakaAgent(BaseInstalledAgent):
         environment: BaseEnvironment,
         context: AgentContext,
     ) -> None:
+        self._deadline_started_monotonic = time.monotonic()
         if self._harbor_mode() == "task-run":
             if self._task_run_in_container():
                 await self._run_task_run_container(instruction, environment, context)
@@ -394,7 +410,12 @@ class MakaAgent(BaseInstalledAgent):
                 f"2>&1 | tee {shlex.quote(run_log_path.as_posix())}"
             )
             command = f"bash -lc {shlex.quote(shell_script)}"
-            await self.exec_as_agent(environment, command=command, env=env, timeout_sec=self._cell_timeout_sec())
+            await self.exec_as_agent(
+                environment,
+                command=command,
+                env=env,
+                timeout_sec=self._cell_hard_timeout_sec(env),
+            )
             await self._download_cell_output(environment)
         output = self._read_cell_output(required=True)
         self._apply_cell_output(context, output)
@@ -437,18 +458,7 @@ class MakaAgent(BaseInstalledAgent):
             if env is not None
             else self._get_env("MAKA_CELL_TIMEOUT_SEC")
         )
-        if not raw:
-            return self._DEFAULT_CELL_TIMEOUT_SEC
-        stripped = raw.strip()
-        if _POSITIVE_INT_RE.fullmatch(stripped) is None:
-            return self._DEFAULT_CELL_TIMEOUT_SEC
-        try:
-            value = int(stripped)
-        except ValueError:
-            # CPython caps integer-string conversion length; an over-long value
-            # is malformed, not a giant timeout.
-            return self._DEFAULT_CELL_TIMEOUT_SEC
-        return value if value <= _MAX_SAFE_INTEGER else self._DEFAULT_CELL_TIMEOUT_SEC
+        return _positive_int_literal(raw) or self._DEFAULT_CELL_TIMEOUT_SEC
 
     def _cell_settlement_grace_sec(self, env: dict[str, str] | None = None) -> int:
         raw = (
@@ -456,28 +466,45 @@ class MakaAgent(BaseInstalledAgent):
             if env is not None
             else self._get_env("MAKA_CELL_SETTLEMENT_GRACE_SEC")
         )
-        if not raw:
-            return self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
-        try:
-            value = int(raw)
-        except (TypeError, ValueError):
-            return self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
-        return value if value > 0 else self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
+        return _positive_int_literal(raw) or self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
 
     def _cell_soft_timeout_ms(self, env: dict[str, str] | None = None) -> int:
         timeout_sec = self._cell_timeout_sec(env)
         grace_sec = self._cell_settlement_grace_sec(env)
-        if grace_sec >= timeout_sec:
+        phase_timeout_sec = self._agent_phase_timeout_sec(env)
+        soft_timeout_sec = min(timeout_sec, phase_timeout_sec - grace_sec)
+        if soft_timeout_sec <= 0:
             raise RuntimeError(
-                "MAKA_CELL_SETTLEMENT_GRACE_SEC must be smaller than MAKA_CELL_TIMEOUT_SEC"
+                "MAKA_CELL_SETTLEMENT_GRACE_SEC must be smaller than "
+                "MAKA_AGENT_PHASE_TIMEOUT_SEC"
             )
-        soft_timeout_ms = (timeout_sec - grace_sec) * 1000
+        soft_timeout_ms = int((soft_timeout_sec - self._deadline_elapsed_sec()) * 1000)
+        if soft_timeout_ms <= 0:
+            raise asyncio.TimeoutError("Maka model budget exhausted before cell start")
         if soft_timeout_ms > _MAX_NODE_TIMER_MS:
             raise RuntimeError(
                 "MAKA_CELL_SOFT_TIMEOUT_MS exceeds the Node timer limit "
                 f"of {_MAX_NODE_TIMER_MS}ms"
             )
         return soft_timeout_ms
+
+    def _agent_phase_timeout_sec(self, env: dict[str, str] | None = None) -> int:
+        raw = (
+            env.get("MAKA_AGENT_PHASE_TIMEOUT_SEC")
+            if env is not None
+            else self._get_env("MAKA_AGENT_PHASE_TIMEOUT_SEC")
+        )
+        return _positive_int_literal(raw) or self._cell_timeout_sec(env)
+
+    def _deadline_elapsed_sec(self) -> float:
+        started = getattr(self, "_deadline_started_monotonic", None)
+        return 0.0 if started is None else max(0.0, time.monotonic() - started)
+
+    def _cell_hard_timeout_sec(self, env: dict[str, str] | None = None) -> float:
+        remaining = self._agent_phase_timeout_sec(env) - self._deadline_elapsed_sec()
+        if remaining <= 0:
+            raise asyncio.TimeoutError("Maka agent phase exhausted before cell start")
+        return remaining
 
     def _host_side_llm_enabled(self) -> bool:
         return bool(
@@ -506,14 +533,19 @@ class MakaAgent(BaseInstalledAgent):
                 stderr=asyncio.subprocess.PIPE,
             )
             try:
-                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self._cell_timeout_sec())
+                stdout, stderr = await asyncio.wait_for(
+                    process.communicate(),
+                    timeout=self._cell_hard_timeout_sec(),
+                )
             except BaseException as error:
                 if process.returncode is None:
                     process.kill()
                 stdout, stderr = await process.communicate()
                 run_log_path.write_bytes(stdout + stderr)
                 if isinstance(error, asyncio.TimeoutError):
-                    raise RuntimeError(f"Maka host cell exceeded {self._cell_timeout_sec()}s") from error
+                    raise RuntimeError(
+                        f"Maka host cell exceeded its {self._agent_phase_timeout_sec()}s agent phase"
+                    ) from error
                 raise
             run_log_path.write_bytes(stdout + stderr)
             if process.returncode == 124:
@@ -794,7 +826,7 @@ class MakaAgent(BaseInstalledAgent):
                 environment,
                 command=f"bash -lc {shlex.quote(shell_script)}",
                 env=env,
-                timeout_sec=self._cell_timeout_sec(env),
+                timeout_sec=self._cell_hard_timeout_sec(env),
             )
         finally:
             await self._download_task_run_artifacts(environment)
@@ -909,7 +941,7 @@ class MakaAgent(BaseInstalledAgent):
             },
         )
 
-        timeout_sec = self._cell_timeout_sec(env)
+        timeout_sec = self._cell_hard_timeout_sec(env)
         proc: asyncio.subprocess.Process | None = None
         async with _ToolExecutorServer(self, environment) as executor:
             env["MAKA_HARBOR_TOOL_EXECUTOR_URL"] = executor.url
@@ -1124,7 +1156,7 @@ class MakaAgent(BaseInstalledAgent):
         stdin_payload: bytes,
         stdout_path: Path,
         stderr_path: Path,
-        timeout_sec: int,
+        timeout_sec: float,
     ) -> tuple[bytes, bytes]:
         stdout_chunks: list[bytes] = []
         stderr_chunks: list[bytes] = []

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -383,10 +383,24 @@ class MakaAgent(BaseInstalledAgent):
         environment: BaseEnvironment,
         context: AgentContext,
     ) -> None:
-        self._deadline_started_monotonic = time.monotonic()
         if self._harbor_mode() == "task-run":
             if self._task_run_in_container():
-                await self._run_task_run_container(instruction, environment, context)
+                phase_started_monotonic = time.monotonic()
+                phase_timeout_sec = _positive_int_literal(
+                    self._get_env("MAKA_AGENT_PHASE_TIMEOUT_SEC")
+                )
+                model_deadline_at_ms = (
+                    time.time_ns() // 1_000_000 + self._cell_timeout_sec() * 1000
+                    if phase_timeout_sec is not None
+                    else None
+                )
+                await self._run_task_run_container(
+                    instruction,
+                    environment,
+                    context,
+                    phase_started_monotonic=phase_started_monotonic,
+                    model_deadline_at_ms=model_deadline_at_ms,
+                )
             else:
                 await self._run_task_run_host(instruction, environment, context)
             return
@@ -410,12 +424,7 @@ class MakaAgent(BaseInstalledAgent):
                 f"2>&1 | tee {shlex.quote(run_log_path.as_posix())}"
             )
             command = f"bash -lc {shlex.quote(shell_script)}"
-            await self.exec_as_agent(
-                environment,
-                command=command,
-                env=env,
-                timeout_sec=self._cell_hard_timeout_sec(env),
-            )
+            await self.exec_as_agent(environment, command=command, env=env, timeout_sec=self._cell_timeout_sec())
             await self._download_cell_output(environment)
         output = self._read_cell_output(required=True)
         self._apply_cell_output(context, output)
@@ -466,45 +475,28 @@ class MakaAgent(BaseInstalledAgent):
             if env is not None
             else self._get_env("MAKA_CELL_SETTLEMENT_GRACE_SEC")
         )
-        return _positive_int_literal(raw) or self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
+        if not raw:
+            return self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
+        try:
+            value = int(raw)
+        except (TypeError, ValueError):
+            return self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
+        return value if value > 0 else self._DEFAULT_CELL_SETTLEMENT_GRACE_SEC
 
     def _cell_soft_timeout_ms(self, env: dict[str, str] | None = None) -> int:
         timeout_sec = self._cell_timeout_sec(env)
         grace_sec = self._cell_settlement_grace_sec(env)
-        phase_timeout_sec = self._agent_phase_timeout_sec(env)
-        soft_timeout_sec = min(timeout_sec, phase_timeout_sec - grace_sec)
-        if soft_timeout_sec <= 0:
+        if grace_sec >= timeout_sec:
             raise RuntimeError(
-                "MAKA_CELL_SETTLEMENT_GRACE_SEC must be smaller than "
-                "MAKA_AGENT_PHASE_TIMEOUT_SEC"
+                "MAKA_CELL_SETTLEMENT_GRACE_SEC must be smaller than MAKA_CELL_TIMEOUT_SEC"
             )
-        soft_timeout_ms = int((soft_timeout_sec - self._deadline_elapsed_sec()) * 1000)
-        if soft_timeout_ms <= 0:
-            raise asyncio.TimeoutError("Maka model budget exhausted before cell start")
+        soft_timeout_ms = (timeout_sec - grace_sec) * 1000
         if soft_timeout_ms > _MAX_NODE_TIMER_MS:
             raise RuntimeError(
                 "MAKA_CELL_SOFT_TIMEOUT_MS exceeds the Node timer limit "
                 f"of {_MAX_NODE_TIMER_MS}ms"
             )
         return soft_timeout_ms
-
-    def _agent_phase_timeout_sec(self, env: dict[str, str] | None = None) -> int:
-        raw = (
-            env.get("MAKA_AGENT_PHASE_TIMEOUT_SEC")
-            if env is not None
-            else self._get_env("MAKA_AGENT_PHASE_TIMEOUT_SEC")
-        )
-        return _positive_int_literal(raw) or self._cell_timeout_sec(env)
-
-    def _deadline_elapsed_sec(self) -> float:
-        started = getattr(self, "_deadline_started_monotonic", None)
-        return 0.0 if started is None else max(0.0, time.monotonic() - started)
-
-    def _cell_hard_timeout_sec(self, env: dict[str, str] | None = None) -> float:
-        remaining = self._agent_phase_timeout_sec(env) - self._deadline_elapsed_sec()
-        if remaining <= 0:
-            raise asyncio.TimeoutError("Maka agent phase exhausted before cell start")
-        return remaining
 
     def _host_side_llm_enabled(self) -> bool:
         return bool(
@@ -533,19 +525,14 @@ class MakaAgent(BaseInstalledAgent):
                 stderr=asyncio.subprocess.PIPE,
             )
             try:
-                stdout, stderr = await asyncio.wait_for(
-                    process.communicate(),
-                    timeout=self._cell_hard_timeout_sec(),
-                )
+                stdout, stderr = await asyncio.wait_for(process.communicate(), timeout=self._cell_timeout_sec())
             except BaseException as error:
                 if process.returncode is None:
                     process.kill()
                 stdout, stderr = await process.communicate()
                 run_log_path.write_bytes(stdout + stderr)
                 if isinstance(error, asyncio.TimeoutError):
-                    raise RuntimeError(
-                        f"Maka host cell exceeded its {self._agent_phase_timeout_sec()}s agent phase"
-                    ) from error
+                    raise RuntimeError(f"Maka host cell exceeded {self._cell_timeout_sec()}s") from error
                 raise
             run_log_path.write_bytes(stdout + stderr)
             if process.returncode == 124:
@@ -782,6 +769,9 @@ class MakaAgent(BaseInstalledAgent):
         instruction: str,
         environment: BaseEnvironment,
         context: AgentContext,
+        *,
+        phase_started_monotonic: float,
+        model_deadline_at_ms: int | None,
     ) -> None:
         """Run the full task-run controller inside Pier's task container."""
         self.logs_dir.mkdir(parents=True, exist_ok=True)
@@ -796,7 +786,11 @@ class MakaAgent(BaseInstalledAgent):
             str(getattr(getattr(environment, "task_env_config", None), "workdir", "") or ".")
         )
         out_dir = agent_dir / "maka-task-run"
-        env = self._container_task_run_env(instruction_path, out_dir)
+        env = self._container_task_run_env(
+            instruction_path,
+            out_dir,
+            model_deadline_at_ms=model_deadline_at_ms,
+        )
         command = _headless_harbor_command(
             cli_path=_CONTAINER_HEADLESS_CLI,
             instruction_path=instruction_path,
@@ -826,7 +820,7 @@ class MakaAgent(BaseInstalledAgent):
                 environment,
                 command=f"bash -lc {shlex.quote(shell_script)}",
                 env=env,
-                timeout_sec=self._cell_hard_timeout_sec(env),
+                timeout_sec=self._task_run_hard_timeout_sec(env, phase_started_monotonic),
             )
         finally:
             await self._download_task_run_artifacts(environment)
@@ -838,6 +832,8 @@ class MakaAgent(BaseInstalledAgent):
         self,
         instruction_path: Path,
         out_dir: Path,
+        *,
+        model_deadline_at_ms: int | None,
     ) -> dict[str, str]:
         env = {
             key: value
@@ -851,7 +847,11 @@ class MakaAgent(BaseInstalledAgent):
         env["MAKA_OUTPUT_DIR"] = str(out_dir)
         env["MAKA_STORAGE_ROOT"] = str(out_dir / "runs")
         env["MAKA_CELL_ARTIFACT_DIR"] = EnvironmentPaths.agent_dir.as_posix()
-        env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms(env))
+        if model_deadline_at_ms is None:
+            env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms(env))
+        else:
+            env.pop("MAKA_CELL_SOFT_TIMEOUT_MS", None)
+            env["MAKA_CELL_DEADLINE_AT_MS"] = str(model_deadline_at_ms)
 
         proxy_url = self._get_env("MAKA_PROVIDER_PROXY_URL")
         proxy_token = self._get_env("MAKA_PROVIDER_PROXY_TOKEN")
@@ -864,6 +864,19 @@ class MakaAgent(BaseInstalledAgent):
             env["MAKA_HOST_API_KEY"] = proxy_token
             env["NODE_USE_ENV_PROXY"] = "1"
         return env
+
+    def _task_run_hard_timeout_sec(
+        self,
+        env: dict[str, str],
+        phase_started_monotonic: float,
+    ) -> float:
+        phase_timeout_sec = _positive_int_literal(env.get("MAKA_AGENT_PHASE_TIMEOUT_SEC"))
+        if phase_timeout_sec is None:
+            return float(self._cell_timeout_sec(env))
+        remaining = phase_timeout_sec - max(0.0, time.monotonic() - phase_started_monotonic)
+        if remaining <= 0:
+            raise asyncio.TimeoutError("Maka agent phase exhausted before task-run start")
+        return remaining
 
     async def _download_task_run_artifacts(self, environment: BaseEnvironment) -> None:
         await self._download_cell_output(environment)
@@ -941,7 +954,7 @@ class MakaAgent(BaseInstalledAgent):
             },
         )
 
-        timeout_sec = self._cell_hard_timeout_sec(env)
+        timeout_sec = self._cell_timeout_sec(env)
         proc: asyncio.subprocess.Process | None = None
         async with _ToolExecutorServer(self, environment) as executor:
             env["MAKA_HARBOR_TOOL_EXECUTOR_URL"] = executor.url
@@ -1156,7 +1169,7 @@ class MakaAgent(BaseInstalledAgent):
         stdin_payload: bytes,
         stdout_path: Path,
         stderr_path: Path,
-        timeout_sec: float,
+        timeout_sec: int,
     ) -> tuple[bytes, bytes]:
         stdout_chunks: list[bytes] = []
         stderr_chunks: list[bytes] = []

--- a/packages/headless/harbor/run-harness-ab.mjs
+++ b/packages/headless/harbor/run-harness-ab.mjs
@@ -15,7 +15,11 @@ import {
   selectTasksByIds,
 } from '#fixed-prompt-task-source';
 import { createHarborTaskRunner } from '#harbor-task-runner';
-import { createPierProviderProxyHub, createPierTaskRunner } from '#pier-task-runner';
+import {
+  createPierProviderProxyHub,
+  createPierTaskRunner,
+  PIER_MAKA_SETTLEMENT_GRACE_SEC,
+} from '#pier-task-runner';
 import {
   buildHarnessOracleExecutionPolicyFingerprint,
   HARBOR_ORACLE_DOCKER_PLATFORM,
@@ -565,6 +569,9 @@ export function buildHarnessAbManifest({
       ...(pierVersion === null ? {} : { executor: { id: 'pier', version: pierVersion } }),
       timeoutPolicy: 'task-native',
       timeoutMultiplier: 1,
+      ...(benchmarkProfile.executor === 'pier'
+        ? { agentSettlementGraceSec: PIER_MAKA_SETTLEMENT_GRACE_SEC }
+        : {}),
       outerTimeoutGraceSec: HARBOR_SETUP_TEARDOWN_GRACE_SEC,
     },
     taskIds,

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -2144,6 +2144,14 @@ describe('fixed prompt controller', () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const rawOutput = harborOutput({
+        taskId: 'task-a',
+        reward: 0,
+        status: 'failed',
+        errorClass: 'aborted',
+        deadlineSettlement: { source: 'benchmark.deadline', mode: 'immediate' },
+      });
+      let taskRuns = 0;
 
       const result = await runFixedPromptController({
         runId: 'run-1',
@@ -2153,22 +2161,21 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         resultsTsvPath: join(dir, 'results.tsv'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
-        taskRunner: async () =>
-          harborOutput({
-            taskId: 'task-a',
-            reward: 0,
-            status: 'failed',
-            errorClass: 'aborted',
-            deadlineSettlement: { source: 'benchmark.deadline', mode: 'immediate' },
-          }),
+        taskRunner: async () => {
+          taskRuns += 1;
+          return rawOutput;
+        },
         now: () => 100,
         newId: idFactory(),
       });
 
+      assert.equal(taskRuns, 1);
+      assert.equal(rawOutput.cell.errorClass, 'aborted');
       assert.equal(result.events[0]?.type, 'task_completed');
       assert.equal(result.events[0]?.passed, false);
       assert.equal(result.events[0]?.scored, true);
       assert.equal(result.events[0]?.eligible, true);
+      assert.equal(result.events[0]?.errorClass, 'budget_exhausted');
     });
   });
 

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -70,7 +70,7 @@ describe('Harbor adapter contract', () => {
     assert.match(source, /MAKA_CELL_TIMEOUT_SEC/);
     assert.match(source, /MAKA_CELL_SETTLEMENT_GRACE_SEC/);
     assert.match(source, /MAKA_CELL_SOFT_TIMEOUT_MS/);
-    assert.match(source, /timeout_sec=self\._cell_timeout_sec\(\)/);
+    assert.match(source, /timeout_sec=self\._cell_hard_timeout_sec\(env\)/);
     assert.match(source, /process\.returncode == 124/);
     assert.match(source, /deepseek\/deepseek-v4-flash/);
     assert.doesNotMatch(source, /deepseek\/deepseek-chat/);
@@ -1927,7 +1927,7 @@ with tempfile.TemporaryDirectory() as tmp:
     assert container_env["MAKA_OUTPUT_DIR"] == "/logs/agent/maka-task-run", container_env
     assert container_env["MAKA_CELL_ARTIFACT_DIR"] == "/logs/agent", container_env
     assert container_env["MAKA_STORAGE_ROOT"] == "/logs/agent/maka-task-run/runs", container_env
-    assert container_kwargs["timeout_sec"] == 7200, container_kwargs
+    assert 7199 < container_kwargs["timeout_sec"] <= 7200, container_kwargs
     assert "/logs/agent/maka-task-run" in container_environment.download_dirs
     assert "/logs/agent/maka-cell-output.json" in container_environment.downloads
     assert json.loads(
@@ -2225,6 +2225,46 @@ with tempfile.TemporaryDirectory() as tmp:
         "MAKA_CELL_TIMEOUT_SEC": "1800",
         "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
     })._cell_soft_timeout_ms() == 1740000
+    pier_deadline_agent = MakaAgent(Path(tmp), extra_env={
+        "MAKA_CELL_TIMEOUT_SEC": "1800",
+        "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
+        "MAKA_AGENT_PHASE_TIMEOUT_SEC": "1860",
+    })
+    pier_deadline_agent._deadline_started_monotonic = 100.0
+    original_monotonic = time.monotonic
+    time.monotonic = lambda: 110.0
+    try:
+        assert pier_deadline_agent._cell_soft_timeout_ms() == 1790000
+        assert pier_deadline_agent._cell_hard_timeout_sec() == 1850
+    finally:
+        time.monotonic = original_monotonic
+    harbor_deadline_agent = MakaAgent(Path(tmp), extra_env={
+        "MAKA_CELL_TIMEOUT_SEC": "1800",
+        "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
+    })
+    harbor_deadline_agent._deadline_started_monotonic = 100.0
+    time.monotonic = lambda: 110.0
+    try:
+        assert harbor_deadline_agent._cell_soft_timeout_ms() == 1730000
+        assert harbor_deadline_agent._cell_hard_timeout_sec() == 1790
+    finally:
+        time.monotonic = original_monotonic
+    exhausted_agent = MakaAgent(Path(tmp), extra_env={
+        "MAKA_CELL_TIMEOUT_SEC": "1800",
+        "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
+        "MAKA_AGENT_PHASE_TIMEOUT_SEC": "1860",
+    })
+    exhausted_agent._deadline_started_monotonic = 100.0
+    time.monotonic = lambda: 1900.0
+    try:
+        try:
+            exhausted_agent._cell_soft_timeout_ms()
+        except asyncio.TimeoutError as exc:
+            assert "budget exhausted before cell start" in str(exc), str(exc)
+        else:
+            raise AssertionError("expected an exhausted model budget to reject cell start")
+    finally:
+        time.monotonic = original_monotonic
     try:
         MakaAgent(Path(tmp), extra_env={
             "MAKA_CELL_TIMEOUT_SEC": "2147514",

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -8,6 +8,7 @@ import { describe, test, type TestContext } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { promisify } from 'node:util';
 import { HARBOR_CELL_CONTEXT_ENV_KEYS, resolveHarborCellAiSdkEnv } from '../harbor-cell.js';
+import { isBudgetExhaustedTrialException } from '../harbor-task-runner.js';
 
 const repoRoot = resolve(fileURLToPath(new URL('../../../..', import.meta.url)));
 const execFileAsync = promisify(execFile);
@@ -70,7 +71,7 @@ describe('Harbor adapter contract', () => {
     assert.match(source, /MAKA_CELL_TIMEOUT_SEC/);
     assert.match(source, /MAKA_CELL_SETTLEMENT_GRACE_SEC/);
     assert.match(source, /MAKA_CELL_SOFT_TIMEOUT_MS/);
-    assert.match(source, /timeout_sec=self\._cell_hard_timeout_sec\(env\)/);
+    assert.match(source, /timeout_sec=self\._cell_timeout_sec\(\)/);
     assert.match(source, /process\.returncode == 124/);
     assert.match(source, /deepseek\/deepseek-v4-flash/);
     assert.doesNotMatch(source, /deepseek\/deepseek-chat/);
@@ -88,6 +89,15 @@ describe('Harbor adapter contract', () => {
     );
     assert.doesNotMatch(source, /and raw else None/);
     assert.doesNotMatch(source, /MAKA_INSTRUCTION_EOF/);
+  });
+
+  test('maka_agent.py emits a host-cell timeout recognized as budget exhaustion', async () => {
+    const source = await readRepoFile('packages/headless/harbor/maka_agent.py');
+    const template = source.match(/f"(Maka host cell exceeded [^"]+)"/)?.[1];
+    assert.ok(template, 'host-cell timeout message template');
+    const message = template.replace('{self._cell_timeout_sec()}', '1800');
+
+    assert.equal(isBudgetExhaustedTrialException(`RuntimeError: ${message}`), true);
   });
 
   test('headless Harbor text files do not contain hidden or unexpected control characters', async () => {
@@ -1551,6 +1561,7 @@ import json
 import os
 import sys
 import tempfile
+import time
 import types
 from pathlib import Path
 
@@ -1927,12 +1938,48 @@ with tempfile.TemporaryDirectory() as tmp:
     assert container_env["MAKA_OUTPUT_DIR"] == "/logs/agent/maka-task-run", container_env
     assert container_env["MAKA_CELL_ARTIFACT_DIR"] == "/logs/agent", container_env
     assert container_env["MAKA_STORAGE_ROOT"] == "/logs/agent/maka-task-run/runs", container_env
-    assert 7199 < container_kwargs["timeout_sec"] <= 7200, container_kwargs
+    assert container_kwargs["timeout_sec"] == 7200, container_kwargs
     assert "/logs/agent/maka-task-run" in container_environment.download_dirs
     assert "/logs/agent/maka-cell-output.json" in container_environment.downloads
     assert json.loads(
         Path(container_context.metadata["maka_cell_output"]).read_text(encoding="utf-8")
     )["status"] == "completed"
+
+    pier_agent = ContainerTaskRunAgent(Path(tmp), extra_env={
+        "MAKA_BACKEND": "ai-sdk",
+        "MAKA_HARBOR_MODE": "task-run",
+        "MAKA_NODE_TOOLCHAIN_FINGERPRINT": "sha256:test-node",
+        "MAKA_CELL_TIMEOUT_SEC": "1800",
+        "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
+        "MAKA_AGENT_PHASE_TIMEOUT_SEC": "1860",
+    })
+    pier_agent._resolved_flags = {
+        "maka_repo": "/opt/maka-agent",
+        "backend": "ai-sdk",
+    }
+    pier_agent._run_task_run_host = forbidden_host_task_run
+    pier_environment = ContainerTaskRunEnvironment()
+    pier_context = AgentContext()
+    deadline_started_at_ms = int(time.time() * 1000)
+    maka_agent_mod._NetworkAllowlist = FakeNetworkAllowlist
+    try:
+        asyncio.run(
+            pier_agent.run(
+                "finish the task",
+                pier_environment,
+                pier_context,
+            )
+        )
+    finally:
+        maka_agent_mod._NetworkAllowlist = original_network_allowlist
+    deadline_finished_at_ms = int(time.time() * 1000)
+    pier_command, pier_kwargs = pier_agent.container_execs[1]
+    pier_env = pier_kwargs["env"]
+    model_deadline_at_ms = int(pier_env["MAKA_CELL_DEADLINE_AT_MS"])
+    assert deadline_started_at_ms + 1800000 <= model_deadline_at_ms
+    assert model_deadline_at_ms <= deadline_finished_at_ms + 1800000
+    assert "MAKA_CELL_SOFT_TIMEOUT_MS" not in pier_env, pier_env
+    assert 1859 < pier_kwargs["timeout_sec"] <= 1860, pier_kwargs
 
     container_install_agent = ContainerTaskRunAgent(Path(tmp), extra_env={
         "MAKA_BACKEND": "fake",
@@ -2225,46 +2272,6 @@ with tempfile.TemporaryDirectory() as tmp:
         "MAKA_CELL_TIMEOUT_SEC": "1800",
         "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
     })._cell_soft_timeout_ms() == 1740000
-    pier_deadline_agent = MakaAgent(Path(tmp), extra_env={
-        "MAKA_CELL_TIMEOUT_SEC": "1800",
-        "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
-        "MAKA_AGENT_PHASE_TIMEOUT_SEC": "1860",
-    })
-    pier_deadline_agent._deadline_started_monotonic = 100.0
-    original_monotonic = time.monotonic
-    time.monotonic = lambda: 110.0
-    try:
-        assert pier_deadline_agent._cell_soft_timeout_ms() == 1790000
-        assert pier_deadline_agent._cell_hard_timeout_sec() == 1850
-    finally:
-        time.monotonic = original_monotonic
-    harbor_deadline_agent = MakaAgent(Path(tmp), extra_env={
-        "MAKA_CELL_TIMEOUT_SEC": "1800",
-        "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
-    })
-    harbor_deadline_agent._deadline_started_monotonic = 100.0
-    time.monotonic = lambda: 110.0
-    try:
-        assert harbor_deadline_agent._cell_soft_timeout_ms() == 1730000
-        assert harbor_deadline_agent._cell_hard_timeout_sec() == 1790
-    finally:
-        time.monotonic = original_monotonic
-    exhausted_agent = MakaAgent(Path(tmp), extra_env={
-        "MAKA_CELL_TIMEOUT_SEC": "1800",
-        "MAKA_CELL_SETTLEMENT_GRACE_SEC": "60",
-        "MAKA_AGENT_PHASE_TIMEOUT_SEC": "1860",
-    })
-    exhausted_agent._deadline_started_monotonic = 100.0
-    time.monotonic = lambda: 1900.0
-    try:
-        try:
-            exhausted_agent._cell_soft_timeout_ms()
-        except asyncio.TimeoutError as exc:
-            assert "budget exhausted before cell start" in str(exc), str(exc)
-        else:
-            raise AssertionError("expected an exhausted model budget to reject cell start")
-    finally:
-        time.monotonic = original_monotonic
     try:
         MakaAgent(Path(tmp), extra_env={
             "MAKA_CELL_TIMEOUT_SEC": "2147514",

--- a/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
+++ b/packages/headless/src/__tests__/harbor-cli-connection-defaults.test.ts
@@ -559,6 +559,17 @@ describe('resolveHarborRunOptions backend guard', () => {
     );
   });
 
+  test('task-run preserves the adapter absolute model deadline', async () => {
+    const opts = await resolveHarborRunOptions(
+      ['--mode', 'task-run', '--backend', 'fake', '--instruction', 'test'],
+      {
+        MAKA_CELL_DEADLINE_AT_MS: '2800000',
+      },
+    );
+
+    assert.equal(opts.deadlineAtMs, 2_800_000);
+  });
+
   test('explicit host authority overrides stale ambient provider authority', async () => {
     const opts = await resolveHarborRunOptions(
       ['--instruction', 'test', '--isolation', 'harbor-local'],

--- a/packages/headless/src/__tests__/harness-ab-cli.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-cli.test.ts
@@ -808,6 +808,7 @@ test('harness A/B resolves the DeepSWE benchmark axis orthogonally to competitor
   });
   assert.deepEqual(manifest.metadata.benchmark.dataset, 'deep-swe');
   assert.equal(manifest.metadata.benchmark.version, '1.1');
+  assert.equal(manifest.metadata.benchmark.agentSettlementGraceSec, 30);
   assert.equal(manifest.metadata.order.seed, 'deep-swe-1.1:gpt-5.6-sol:harness-comparison:v1');
   assert.equal(manifest.evaluationTaskIds.length, 30);
   assert.deepEqual(manifest.arms[0].metadata.config.execution, {
@@ -843,6 +844,7 @@ test('harness A/B resolves the DeepSWE benchmark axis orthogonally to competitor
   // No executor key for Harbor benchmarks: the manifest payload (and with it
   // the resume fingerprint) must stay byte-identical to historical runs.
   assert.equal('executor' in tbenchManifest.metadata.benchmark, false);
+  assert.equal('agentSettlementGraceSec' in tbenchManifest.metadata.benchmark, false);
 });
 
 test('harness A/B benchmark profiles bind their executor and resolve from env', async () => {

--- a/packages/headless/src/__tests__/harness-ab-manifest.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-manifest.test.ts
@@ -100,6 +100,29 @@ describe('harness A/B manifest', () => {
     assert.notEqual(changed.arms[1].fingerprint, original.arms[1].fingerprint);
   });
 
+  test('changes identity when the Pier settlement allowance changes', () => {
+    const originalInput = manifestInput(['a', 'b', 'c']);
+    const original = buildHarnessAbRunManifest({
+      ...originalInput,
+      benchmark: {
+        ...originalInput.benchmark,
+        dataset: 'deep-swe',
+        version: '1.1',
+        executor: { id: 'pier', version: '0.3.0' },
+        agentSettlementGraceSec: 30,
+      },
+    });
+    const changed = buildHarnessAbRunManifest({
+      ...originalInput,
+      benchmark: {
+        ...original.metadata.benchmark,
+        agentSettlementGraceSec: 31,
+      },
+    });
+
+    assert.notEqual(changed.fingerprint, original.fingerprint);
+  });
+
   test('records advisory Oracle annotations without changing frozen A/B selection', () => {
     const oracleEvidence = {
       registryUrl:

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -266,6 +266,7 @@ test('buildPierRunArgs emits the pier CLI contract for the Maka arm', () => {
     jobName: 'trial',
     environment: 'docker',
     timeoutMultiplier: 1,
+    agentTimeoutMultiplier: 1.0055555555555555,
     mounts: [{ type: 'bind', source: '/repo', target: '/opt/maka-agent', read_only: true }],
     agentEnv: { MAKA_MODEL: 'k3', MAKA_PROVIDER: 'kimi-coding-plan' },
   });
@@ -277,12 +278,55 @@ test('buildPierRunArgs emits the pier CLI contract for the Maka arm', () => {
   assert.match(joined, /--job-name trial/);
   assert.match(joined, /-k 1/);
   assert.match(joined, /-n 1/);
+  assert.match(joined, /--agent-timeout-multiplier 1\.0055555555555555/);
   assert.match(joined, /--yes/);
   assert.ok(args.includes('--mounts-json'));
   assert.ok(args.includes('--ae'));
   assert.ok(args.includes('MAKA_MODEL=k3'));
   // No provider secret and no env-file were requested.
   assert.ok(!args.includes('--env-file'));
+});
+
+test('createPierTaskRunner gives Maka a controller-owned settlement tail', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'maka',
+        agentEnv: {
+          MAKA_CELL_TIMEOUT_SEC: '1',
+          MAKA_CELL_SETTLEMENT_GRACE_SEC: '1',
+          MAKA_AGENT_PHASE_TIMEOUT_SEC: '1',
+        },
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+
+    await runner(
+      runInput({
+        task: {
+          id: 'dasel',
+          path: '/tasks/dasel-html-document-format',
+          metadata: {
+            agentTimeoutSec: 5_400,
+            buildTimeoutSec: 1_800,
+            verifierTimeoutSec: 1_800,
+          },
+        },
+      }),
+    );
+
+    const request = captured.request;
+    assert.ok(request);
+    const agentTimeoutFlag = request.args.indexOf('--agent-timeout-multiplier');
+    assert.equal(request.args[agentTimeoutFlag + 1], '1.0055555555555555');
+    assert.ok(request.args.includes('MAKA_CELL_TIMEOUT_SEC=5400'));
+    assert.ok(request.args.includes('MAKA_CELL_SETTLEMENT_GRACE_SEC=30'));
+    assert.ok(request.args.includes('MAKA_AGENT_PHASE_TIMEOUT_SEC=5430'));
+    assert.equal(request.timeoutMs, 13_890_000);
+  });
 });
 
 test('createPierTaskRunner mounts the pinned Maka Node runtime for container task-run mode', async () => {
@@ -456,7 +500,8 @@ test('createPierTaskRunner derives the wall-clock watchdog from the task-native 
     // pier/trial/trial.py:333). The watchdog must cover the complete
     // legitimate lifecycle 2xbuild + setup + agent + 2xverifier = 12960s, or
     // cold builds, slow setups, and verifier retries get killed as infra.
-    // Contract: derived value covers that ceiling plus grace.
+    // Maka alone also reserves its 30s settlement tail. Contract: the derived
+    // value covers that ceiling plus both settlement and outer process grace.
     const deepSweMetadata = {
       agentTimeoutSec: 5400,
       verifierTimeoutSec: 1800,
@@ -469,7 +514,7 @@ test('createPierTaskRunner derives the wall-clock watchdog from the task-native 
     );
     assert.equal(
       captured.request?.timeoutMs,
-      (2 * 1800 + 360 + 5400 + 2 * 1800) * 1_000 + 15 * 60_000,
+      (2 * 1800 + 360 + 5400 + 30 + 2 * 1800) * 1_000 + 15 * 60_000,
     );
     assert.ok((captured.request?.timeoutMs ?? 0) >= 12_960_000);
 
@@ -1240,6 +1285,7 @@ test('buildPierRunArgs targets the Codex adapter and forwards constructor kwargs
     agentKwargs: { version: '0.144.6', reasoning_effort: 'xhigh' },
   });
   assert.match(args.join(' '), /--agent-import-path codex_agent:MakaCodexAgent/);
+  assert.ok(!args.includes('--agent-timeout-multiplier'));
   assert.ok(args.includes('--ak'));
   assert.ok(args.includes('version=0.144.6'));
   assert.ok(args.includes('reasoning_effort=xhigh'));
@@ -1296,7 +1342,19 @@ test('createPierTaskRunner wires the Codex arm through the host proxy with the p
         runPier: fakePier({ reward: 0, captured }),
       }),
     );
-    const output = await runner(runInput());
+    const output = await runner(
+      runInput({
+        task: {
+          id: 'dasel',
+          path: '/tasks/dasel-html-document-format',
+          metadata: {
+            agentTimeoutSec: 5_400,
+            buildTimeoutSec: 1_800,
+            verifierTimeoutSec: 1_800,
+          },
+        },
+      }),
+    );
     assert.equal(output.harbor.reward, 0);
     // The proxy URL and a minted (non-real) token reach the container via
     // env-file, never argv.
@@ -1308,6 +1366,8 @@ test('createPierTaskRunner wires the Codex arm through the host proxy with the p
     assert.notEqual(captured.envFile?.MAKA_PROVIDER_PROXY_TOKEN, 'upstream-key');
     const args = captured.request?.args ?? [];
     // Constructor kwargs ride --ak; the pinned-toolchain fingerprint rides --ae.
+    assert.ok(!args.includes('--agent-timeout-multiplier'));
+    assert.equal(captured.request?.timeoutMs, 13_860_000);
     assert.ok(args.includes(`version=${CODEX_TOOLCHAIN_SPEC.codex.version}`));
     assert.ok(args.includes('reasoning_effort=xhigh'));
     assert.ok(args.includes(`MAKA_CODEX_TOOLCHAIN_FINGERPRINT=${CODEX_TOOLCHAIN_FINGERPRINT}`));

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -295,7 +295,9 @@ test('createPierTaskRunner gives Maka a controller-owned settlement tail', async
         jobsDir,
         makaRepoPath: repo,
         agent: 'maka',
+        makaNodeToolchainPath: '/toolchains/maka-node',
         agentEnv: {
+          MAKA_HARBOR_MODE: 'task-run',
           MAKA_CELL_TIMEOUT_SEC: '1',
           MAKA_CELL_SETTLEMENT_GRACE_SEC: '1',
           MAKA_AGENT_PHASE_TIMEOUT_SEC: '1',
@@ -326,6 +328,44 @@ test('createPierTaskRunner gives Maka a controller-owned settlement tail', async
     assert.ok(request.args.includes('MAKA_CELL_SETTLEMENT_GRACE_SEC=30'));
     assert.ok(request.args.includes('MAKA_AGENT_PHASE_TIMEOUT_SEC=5430'));
     assert.equal(request.timeoutMs, 13_890_000);
+  });
+});
+
+test('createPierTaskRunner preserves caller timeouts for Maka cell mode', async () => {
+  await withDirs(async ({ jobsDir, repo }) => {
+    const captured: FakeOptions['captured'] = {};
+    const runner = createPierTaskRunner(
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        agent: 'maka',
+        agentEnv: {
+          MAKA_CELL_TIMEOUT_SEC: '600',
+          MAKA_CELL_SETTLEMENT_GRACE_SEC: '30',
+        },
+        runPier: fakePier({ reward: 0, captured }),
+      }),
+    );
+
+    await runner(
+      runInput({
+        task: {
+          id: 'dasel',
+          path: '/tasks/dasel-html-document-format',
+          metadata: {
+            agentTimeoutSec: 5_400,
+            buildTimeoutSec: 1_800,
+            verifierTimeoutSec: 1_800,
+          },
+        },
+      }),
+    );
+
+    const args = captured.request?.args ?? [];
+    assert.ok(!args.includes('--agent-timeout-multiplier'));
+    assert.ok(args.includes('MAKA_CELL_TIMEOUT_SEC=600'));
+    assert.ok(args.includes('MAKA_CELL_SETTLEMENT_GRACE_SEC=30'));
+    assert.ok(!args.some((arg) => arg.startsWith('MAKA_AGENT_PHASE_TIMEOUT_SEC=')));
   });
 });
 
@@ -489,7 +529,13 @@ test('createPierTaskRunner derives the wall-clock watchdog from the task-native 
   await withDirs(async ({ jobsDir, repo }) => {
     const captured: FakeOptions['captured'] = {};
     const runner = createPierTaskRunner(
-      baseOptions({ jobsDir, makaRepoPath: repo, runPier: fakePier({ reward: 0, captured }) }),
+      baseOptions({
+        jobsDir,
+        makaRepoPath: repo,
+        makaNodeToolchainPath: '/toolchains/maka-node',
+        agentEnv: { MAKA_HARBOR_MODE: 'task-run' },
+        runPier: fakePier({ reward: 0, captured }),
+      }),
     );
     // DeepSWE-shaped budget (113/113 tasks): build 1800s + agent 5400s +
     // verifier 1800s, plus pier's fixed agent_setup phase (360s,

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -881,7 +881,11 @@ function taskCompletedEvent(input: {
       output.cell.errorClass === 'policy_denied') &&
       output.harbor.verifier !== undefined);
   const passed = verifierGraded && output.harbor.reward > 0;
-  const errorClass = passed ? undefined : (output.cell.errorClass ?? 'verification_failed');
+  const errorClass = passed
+    ? undefined
+    : deadlineSettled
+      ? 'budget_exhausted'
+      : (output.cell.errorClass ?? 'verification_failed');
   const scored = verifierGraded && !isUnscoredCellFailure(errorClass);
   const agentFailure = output.cell.status === 'failed' && errorClass === 'tool_step_cap_reached';
   return {

--- a/packages/headless/src/harbor-cli.ts
+++ b/packages/headless/src/harbor-cli.ts
@@ -75,6 +75,7 @@ interface HarborRunOptions {
   maxRuntimeSteps?: number;
   maxWallTimeMs?: number;
   softTimeoutMs?: number;
+  deadlineAtMs?: number;
   replayPriorAttemptRuntimeContext: boolean;
   now: () => number;
   newId: () => string;
@@ -201,9 +202,11 @@ async function runHarborTaskRunMode(
     ...(options.realBackendIsolation ? { realBackendIsolation: options.realBackendIsolation } : {}),
     now: options.now,
     newId: options.newId,
-    ...(options.softTimeoutMs !== undefined
-      ? { deadlineAtMs: options.now() + options.softTimeoutMs }
-      : {}),
+    ...(options.deadlineAtMs !== undefined
+      ? { deadlineAtMs: options.deadlineAtMs }
+      : options.softTimeoutMs !== undefined
+        ? { deadlineAtMs: options.now() + options.softTimeoutMs }
+        : {}),
   };
   const run = options.autonomous
     ? await runAutonomousTaskWithStorage(
@@ -422,6 +425,10 @@ export async function resolveHarborRunOptions(
     '--max-wall-time-sec',
   );
   const softTimeoutMs = harborCellSoftTimeoutMsFromEnv(env);
+  const deadlineAtMs = optionalPositiveInt(
+    env.MAKA_CELL_DEADLINE_AT_MS,
+    'MAKA_CELL_DEADLINE_AT_MS',
+  );
   const config = buildConfig({
     parsed,
     env,
@@ -474,6 +481,7 @@ export async function resolveHarborRunOptions(
     ...(maxRuntimeSteps !== undefined ? { maxRuntimeSteps } : {}),
     ...(maxWallTimeSec !== undefined ? { maxWallTimeMs: maxWallTimeSec * 1000 } : {}),
     ...(softTimeoutMs !== undefined ? { softTimeoutMs } : {}),
+    ...(deadlineAtMs !== undefined ? { deadlineAtMs } : {}),
     replayPriorAttemptRuntimeContext:
       parsed.bools['replay-prior-attempt-runtime-context'] ||
       truthyEnv(env.MAKA_REPLAY_PRIOR_ATTEMPT_RUNTIME_CONTEXT),

--- a/packages/headless/src/harness-ab-manifest.ts
+++ b/packages/headless/src/harness-ab-manifest.ts
@@ -222,6 +222,8 @@ export interface HarnessAbRunManifestInput {
     executor?: { id: 'pier'; version: string };
     timeoutPolicy: 'task-native';
     timeoutMultiplier: 1;
+    /** Maka-only Pier agent-phase tail reserved for artifact settlement. */
+    agentSettlementGraceSec?: number;
     outerTimeoutGraceSec: number;
   };
   taskIds: readonly string[];

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -263,8 +263,13 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
     const agent = options.agent ?? 'maka';
     const timeoutMultiplier = options.timeoutMultiplier ?? 1;
     const taskAgentTimeoutSec = input.task.metadata?.agentTimeoutSec;
+    const attemptAgentEnv = mergeAgentEnv(options.agentEnv, input.agentEnv);
+    const traceMode = harborTraceMode(attemptAgentEnv);
     const makaDeadline =
-      agent === 'maka' && timeoutMultiplier === 1 && taskAgentTimeoutSec !== undefined
+      agent === 'maka' &&
+      traceMode === 'task-run' &&
+      timeoutMultiplier === 1 &&
+      taskAgentTimeoutSec !== undefined
         ? {
             modelBudgetSec: taskAgentTimeoutSec,
             settlementGraceSec: PIER_MAKA_SETTLEMENT_GRACE_SEC,
@@ -284,13 +289,11 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
     await rm(jobsDir, { recursive: true, force: true });
     await mkdir(jobsDir, { recursive: true });
 
-    const attemptAgentEnv = mergeAgentEnv(options.agentEnv, input.agentEnv);
     assertNoProviderSecretsInAgentEnv(attemptAgentEnv);
     // Same benchmark invariant as the Harbor runner (shared implementation):
     // agentEnv must not override experiment identity or MAKA_TRIAL_* pricing.
     assertNoExperimentIdentityOverrides(attemptAgentEnv);
 
-    const traceMode = harborTraceMode(attemptAgentEnv);
     const providerTelemetryPath = join(jobsDir, PROVIDER_REQUEST_TELEMETRY);
     let providerUsage: ProviderTokenUsage | null = null;
     let providerTelemetry: ProviderRequestTelemetry[] = [];

--- a/packages/headless/src/pier-task-runner.ts
+++ b/packages/headless/src/pier-task-runner.ts
@@ -70,6 +70,7 @@ const PROVIDER_REQUEST_TELEMETRY = 'provider-request-telemetry.json';
  * container reaching the host proxy through Squid must present one of those.
  * 443 keeps the model endpoint on the conventional TLS port. */
 export const PIER_PROVIDER_PROXY_DEFAULT_PORT = 443;
+export const PIER_MAKA_SETTLEMENT_GRACE_SEC = 30;
 
 /** Compatibility fallback for callers that do not provide a run-scoped proxy
  * hub. Such callers still bind one fixed port per attempt, so concurrent binds
@@ -260,6 +261,16 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
 
   const runner: TaskRunner = async (input: TaskRunInput): Promise<TaskRunOutput> => {
     const agent = options.agent ?? 'maka';
+    const timeoutMultiplier = options.timeoutMultiplier ?? 1;
+    const taskAgentTimeoutSec = input.task.metadata?.agentTimeoutSec;
+    const makaDeadline =
+      agent === 'maka' && timeoutMultiplier === 1 && taskAgentTimeoutSec !== undefined
+        ? {
+            modelBudgetSec: taskAgentTimeoutSec,
+            settlementGraceSec: PIER_MAKA_SETTLEMENT_GRACE_SEC,
+            phaseTimeoutSec: taskAgentTimeoutSec + PIER_MAKA_SETTLEMENT_GRACE_SEC,
+          }
+        : undefined;
     const jobsDir = join(
       options.jobsDir,
       sanitize(input.runId),
@@ -297,7 +308,13 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
         // closes the proxy: a failure in this window (env-file write, arg
         // assembly) must not leak the listening socket.
         try {
-          const aeEnv = buildPierAgentEnv(input, options, agent, providerRuntime?.agentEnv ?? {});
+          const aeEnv = buildPierAgentEnv(
+            input,
+            options,
+            agent,
+            providerRuntime?.agentEnv ?? {},
+            makaDeadline,
+          );
           const processEnv: Record<string, string> = {
             PYTHONPATH: pythonPath,
             // MAKA_BACKEND is a CliFlag whose env_fallback reads os.environ only, so
@@ -325,7 +342,13 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
             jobsDir,
             jobName,
             environment: options.environment ?? 'docker',
-            timeoutMultiplier: options.timeoutMultiplier ?? 1,
+            timeoutMultiplier,
+            ...(makaDeadline
+              ? {
+                  agentTimeoutMultiplier:
+                    makaDeadline.phaseTimeoutSec / makaDeadline.modelBudgetSec,
+                }
+              : {}),
             mounts,
             agentEnv: aeEnv,
             ...(usesEnvFile ? { envFile: envFilePath } : {}),
@@ -355,8 +378,10 @@ export function createPierTaskRunner(options: PierTaskRunnerOptions): TaskRunner
             timeoutMs:
               options.pierTimeoutMs ??
               resolveNativeTrialTimeoutMs({
-                nativePhasesSec: pierMaxTrialPhasesSec(input.task.metadata),
-                timeoutMultiplier: options.timeoutMultiplier ?? 1,
+                nativePhasesSec:
+                  pierMaxTrialPhasesSec(input.task.metadata) +
+                  (makaDeadline?.settlementGraceSec ?? 0),
+                timeoutMultiplier,
               }),
             env: processEnv,
           });
@@ -540,6 +565,7 @@ export interface BuildPierRunArgsInput {
   jobName: string;
   environment: string;
   timeoutMultiplier: number;
+  agentTimeoutMultiplier?: number;
   mounts: ReadonlyArray<Record<string, unknown>>;
   agentEnv: Record<string, string>;
   envFile?: string;
@@ -581,6 +607,9 @@ export function buildPierRunArgs(input: BuildPierRunArgsInput): string[] {
     '--yes',
     '--quiet',
   ];
+  if (input.agentTimeoutMultiplier !== undefined) {
+    args.push('--agent-timeout-multiplier', String(input.agentTimeoutMultiplier));
+  }
   if (input.envFile) args.push('--env-file', input.envFile);
   for (const [key, value] of Object.entries(input.agentKwargs ?? {})) {
     args.push('--ak', `${key}=${value}`);
@@ -640,6 +669,11 @@ function buildPierAgentEnv(
   options: PierTaskRunnerOptions,
   agent: PierAgent,
   providerAgentEnv: Record<string, string>,
+  makaDeadline?: {
+    modelBudgetSec: number;
+    settlementGraceSec: number;
+    phaseTimeoutSec: number;
+  },
 ): Record<string, string> {
   const provider = options.provider ?? 'deepseek';
   const makaModel = modelIdForProvider(options.model, provider);
@@ -676,6 +710,11 @@ function buildPierAgentEnv(
   }
   Object.assign(env, providerAgentEnv);
   Object.assign(env, mergeAgentEnv(options.agentEnv, input.agentEnv) ?? {});
+  if (makaDeadline) {
+    env.MAKA_CELL_TIMEOUT_SEC = String(makaDeadline.modelBudgetSec);
+    env.MAKA_CELL_SETTLEMENT_GRACE_SEC = String(makaDeadline.settlementGraceSec);
+    env.MAKA_AGENT_PHASE_TIMEOUT_SEC = String(makaDeadline.phaseTimeoutSec);
+  }
   // Lenient by shared contract with the Python adapter: a malformed value must
   // fall back to the task metadata rather than fail the run.
   const cellTimeoutSec =


### PR DESCRIPTION
## Summary

- Give both DeepSWE arms the full task-native model budget T.
- For Maka only, extend Pier's agent phase to H = T + G with `--agent-timeout-multiplier`; Codex, setup, build, and verifier remain unchanged.
- At the Pier Maka adapter `run()` entry, derive one absolute model deadline from T and pass it through the existing task-run CLI to `TaskAgentController.deadlineAtMs`. Node startup latency therefore consumes T instead of shifting the cutoff later.
- Keep ordinary Harbor cell, host-cell, and host task-run timeout behavior unchanged.
- Normalize verifier-graded benchmark deadline settlements to `budget_exhausted` while preserving the raw cell/runtime `aborted` trace.
- Record G in the existing harness manifest and resume fingerprint.

### First principles

T is model budget. G is settlement capacity. H is the outer agent-phase backstop. Subtracting G from T underfunded Maka; multiplying the whole Pier trial would alter unrelated phases.

The implementation therefore changes only the existing owners:

- Pier runner: T/G/H derivation and Maka-only agent-phase extension;
- Pier Maka container task-run adapter: absolute T and remaining H;
- existing Node `deadlineAtMs`: runtime settlement at T;
- fixed-prompt controller: benchmark-facing taxonomy;
- existing manifest: auditable G.

No parallel deadline policy module, provider admission protocol, OAuth lifecycle abstraction, or new WAL type is introduced.

## Verification

- TDD reproduced and fixed the host-cell timeout-message classification regression.
- TDD reproduced and fixed ordinary Harbor's timeout drift.
- TDD verified that the Pier Maka adapter emits an absolute T and that task-run preserves it without recomputing from Node startup time.
- 263 related deterministic tests passed across adapter, CLI, Pier runner, task controller, fixed-prompt controller, and manifest suites.
- `npm run format:check`
- `npm run lint`
- `npm run typecheck` — passed across all workspaces
- Python source compilation and `git diff --check` passed

No model call or benchmark was run.

## Canary boundary

Earlier paid canary data establishes only the original 5370s-versus-5400s symptom. It does not validate this implementation. After review and CI, the next evidence should be a free deterministic smoke and, only with explicit authorization, the smallest paid head-to-head canary.
