### PR TITLE
fix(settings): segmented track, portalled popup layering, and a first-party time picker

### DIFF
--- a/apps/desktop/src/main/__tests__/segmented-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/segmented-contract.test.ts
@@ -25,10 +25,26 @@ describe('segmented control chrome contract', () => {
   it('owns the full recipe in styles/segmented.css, wired into the entry file', async () => {
     const recipe = stripCssComments(await readFile(resolve(RENDERER, 'styles', 'segmented.css'), 'utf8'));
 
-    assert.match(recipe, /\.maka-segmented\s*\{[^}]*flex-wrap:\s*wrap/);
+    const rootRule = recipe.match(/\.maka-segmented\s*\{[^}]*\}/)?.[0] ?? '';
+    // The track is one unbroken switch: it neither folds across rows nor
+    // shrinks below its content (the label stack beside it absorbs the
+    // squeeze, and below 460px the whole row stacks). Wrapping produced a
+    // ragged two-row plate in the en locale.
+    assert.match(rootRule, /flex-wrap:\s*nowrap/, 'the segmented track never folds across rows');
+    assert.match(rootRule, /flex:\s*0 0 auto/, 'the track keeps its intrinsic width; the label wraps instead');
+    // Concentric with the app radius scale — a 999px pill read as a foreign
+    // shape beside the 6px fields it shares a settings card with.
+    assert.match(rootRule, /border-radius:\s*var\(--radius-surface\)/, 'track sits on the surface radius tier');
+    assert.doesNotMatch(rootRule, /--radius-pill/, 'the pill radius is off the concentric scale');
+
     const buttonRule = recipe.match(/\.maka-segmented button\s*\{[^}]*\}/)?.[0] ?? '';
     assert.match(buttonRule, /font-size:\s*var\(--font-size-ui\)/, 'controls sit on the ui tier, not caption');
-    assert.match(buttonRule, /white-space:\s*nowrap/, 'labels wrap as whole options, never inside a button');
+    assert.match(buttonRule, /white-space:\s*nowrap/, 'labels never break inside a button');
+    assert.match(
+      buttonRule,
+      /border-radius:\s*var\(--radius-control\)/,
+      'segment buttons sit one tier in from the track, keeping the curves concentric',
+    );
     assert.match(buttonRule, /transition:/);
     assert.match(recipe, /\.maka-segmented button:enabled:hover:not\(\[data-pressed\]\)/);
     assert.match(recipe, /\.maka-segmented button:enabled:active:not\(\[data-pressed\]\)/);

--- a/apps/desktop/src/main/__tests__/z-index-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/z-index-contract.test.ts
@@ -15,6 +15,7 @@
 
 import { strict as assert } from 'node:assert';
 import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import { REPO_ROOT, TOKENS_FILE, readAllRendererCss, stripCssComments } from './css-test-helpers.js';
 
@@ -123,5 +124,53 @@ describe('PR-FE-BUG-HUNT-9 z-index contract', () => {
       /z-index:\s*var\(--z-overlay\)\s*;/,
       'SettingsSelect positioner must share SelectPopup\'s --z-overlay layer. The positioner creates the root stacking context for portaled selects; if it stays at --z-dropdown, the popup cannot reliably win hit-tests over composer chrome when it opens upward.',
     );
+  });
+
+  /**
+   * The rule above only proves the CSS class carries the layer — it says
+   * nothing about whether a given call site remembered to apply it. That
+   * gap shipped a real bug: `PermissionModeSelect` rendered a bare
+   * `<SelectPositioner>`, so Settings → 通用 → 默认权限模式 portalled its
+   * popup *below* the `.settingsModal` layer. The popup was in the DOM
+   * with `aria-expanded="true"`, but invisible and unclickable — the
+   * modal won every hit-test. DOM-level e2e cannot see it; only paint
+   * order can.
+   *
+   * The layer now lives on the wrapped `SelectPositioner`/`PopoverPositioner`
+   * in `packages/ui/src/ui.tsx`, so every consumer inherits it. This test
+   * pins that, and pins that the layer is NOT written onto the popup —
+   * Base UI renders popups `position: static`, where `z-index` is inert
+   * and reads as protection that isn't there.
+   */
+  it('carries the overlay layer on the positioner wrappers, never on the static popup', async () => {
+    const ui = await readFile(
+      resolve(REPO_ROOT, 'packages', 'ui', 'src', 'ui.tsx'),
+      'utf8',
+    );
+
+    // `[^>]*` keeps each match inside a single self-closing JSX tag, so a
+    // later element's layer can't be mistaken for this one's.
+    const element = (tag: string): string =>
+      ui.match(new RegExp(`<${tag.replace('.', '\\.')}\\b[^>]*/>`))?.[0] ?? '';
+
+    for (const tag of ['BaseSelect.Positioner', 'BasePopover.Positioner']) {
+      const el = element(tag);
+      assert.notEqual(el, '', `${tag} wrapper not found in packages/ui/src/ui.tsx`);
+      assert.match(
+        el,
+        /z-\[var\(--z-overlay\)\]/,
+        `${tag} must carry the --z-overlay layer: the popup it wraps is position:static, so a z-index there does nothing and the portalled subtree paints under .settingsModal.`,
+      );
+    }
+
+    for (const tag of ['BaseSelect.Popup', 'BasePopover.Popup']) {
+      const el = element(tag);
+      assert.notEqual(el, '', `${tag} wrapper not found in packages/ui/src/ui.tsx`);
+      assert.doesNotMatch(
+        el,
+        /z-\[var\(--z-overlay\)\]/,
+        `${tag} must NOT carry the overlay layer — it is position:static, so the z-index is inert and only disguises a missing layer on the positioner.`,
+      );
+    }
   });
 });

--- a/apps/desktop/src/renderer/locales/settings-daily-review-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-daily-review-copy.ts
@@ -16,6 +16,8 @@ export type DailyReviewSettingsCopy = {
   executeTime: string;
   executeTimeHelp: string;
   executeTimeAria: string;
+  executeTimeHour: string;
+  executeTimeMinute: string;
   sections: Record<DailyReviewSection, { title: string; detail: string }>;
   deep: string;
   deepHelp: string;
@@ -37,7 +39,7 @@ const SETTINGS_DAILY_REVIEW_COPY = {
   zh: {
     defaultModel: '跟随对话默认', saveFailed: '保存每日回顾设置失败', runSuccess: { daily: '已生成每日回顾', deep: '已生成深度分析' }, runSuccessDetail: '可在「每日回顾」面板查看。', runFailed: '生成回顾失败',
     aria: '每日回顾', unavailable: '当前版本仅本地数字聚合，定时生成 / LLM 摘要尚未连接到后端。', loadFailed: (error) => `读取每日回顾设置失败：${error}`,
-    enabled: '启用每日回顾', enabledHelp: '每天自动分析前一天的工作内容，提供摘要与建议。', executeTime: '执行时间', executeTimeHelp: '默认 08:00 本地时间触发。', executeTimeAria: '每日回顾执行时间',
+    enabled: '启用每日回顾', enabledHelp: '每天自动分析前一天的工作内容，提供摘要与建议。', executeTime: '执行时间', executeTimeHelp: '默认 08:00 本地时间触发。', executeTimeAria: '每日回顾执行时间', executeTimeHour: '时', executeTimeMinute: '分',
     sections: { summary: { title: '对话摘要', detail: '昨天聊了什么，关键结论是什么。' }, gaps: { title: '遗漏提醒', detail: '开始但未完成的讨论、可能忽略的要点。' }, usage: { title: '使用洞察', detail: '模型选择、Token 消耗、工具使用效率。' }, code: { title: '代码建议', detail: '基于对话中的代码讨论，给出优化建议。' } },
     deep: '深度分析', deepHelp: '消耗更多资源，对更长时间周期进行深入调研。', model: '分析模型', modelHelp: '用于生成回顾和分析的模型连接；默认跟随当前对话默认模型。', modelAria: '分析模型连接',
     includeCli: '包含 Claude Code CLI 会话', includeCliHelp: '将已同步的 Claude Code 对话纳入分析范围。', notify: '生成后发送外部通知', notifyHelp: '当前运行时尚未接入报告自动推送。机器人通道可以在「机器人对话」里配置，但每日回顾不会假装已发送。',
@@ -46,7 +48,7 @@ const SETTINGS_DAILY_REVIEW_COPY = {
   en: {
     defaultModel: 'Follow conversation default', saveFailed: 'Failed to save Daily Review settings', runSuccess: { daily: 'Daily Review generated', deep: 'Deep analysis generated' }, runSuccessDetail: 'View it in the Daily Review panel.', runFailed: 'Failed to generate review',
     aria: 'Daily Review', unavailable: 'This version supports local numeric aggregation only. Scheduled generation and LLM summaries are not connected to the backend.', loadFailed: (error) => `Failed to load Daily Review settings: ${error}`,
-    enabled: 'Enable Daily Review', enabledHelp: 'Automatically analyze the previous day’s work and provide summaries and suggestions.', executeTime: 'Run time', executeTimeHelp: 'Runs at 08:00 local time by default.', executeTimeAria: 'Daily Review run time',
+    enabled: 'Enable Daily Review', enabledHelp: 'Automatically analyze the previous day’s work and provide summaries and suggestions.', executeTime: 'Run time', executeTimeHelp: 'Runs at 08:00 local time by default.', executeTimeAria: 'Daily Review run time', executeTimeHour: 'Hour', executeTimeMinute: 'Minute',
     sections: { summary: { title: 'Conversation summary', detail: 'What you discussed yesterday and the key conclusions.' }, gaps: { title: 'Missed items', detail: 'Discussions that started but did not finish and points that may have been overlooked.' }, usage: { title: 'Usage insights', detail: 'Model choices, token consumption, and tool-use efficiency.' }, code: { title: 'Code suggestions', detail: 'Optimization suggestions based on code discussed in conversations.' } },
     deep: 'Deep analysis', deepHelp: 'Use more resources to investigate a longer time period.', model: 'Analysis model', modelHelp: 'The model connection used for reviews and analysis; follows the current conversation default unless changed.', modelAria: 'Analysis model connection',
     includeCli: 'Include Claude Code CLI sessions', includeCliHelp: 'Include synced Claude Code conversations in the analysis.', notify: 'Send an external notification after generation', notifyHelp: 'Automatic report delivery is not connected yet. Bot channels can be configured under Bot chat, but Daily Review will not claim a report was sent.',

--- a/apps/desktop/src/renderer/settings/daily-review-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/daily-review-settings-page.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useMemo, useState } from 'react';
 import type { DailyReviewConfig, DailyReviewMode, LlmConnection } from '@maka/core';
-import { Alert, AlertDescription, Button, Input, SettingsSelect, SettingsSwitch as Switch, useMountedRef, useToast, useUiLocale } from '@maka/ui';
+import { Alert, AlertDescription, Button, SettingsSelect, SettingsSwitch as Switch, TimePicker, useMountedRef, useToast, useUiLocale } from '@maka/ui';
 import { buildCatalogDailyReviewModelOptions } from '../model-catalog-choices';
 import { getDailyReviewSettingsCopy, type DailyReviewSettingsCopy } from '../locales/settings-daily-review-copy';
 import { settingsActionErrorMessage } from './settings-error-copy';
@@ -166,19 +166,21 @@ export function DailyReviewSettingsPage(props: { connections: readonly LlmConnec
             <strong>{copy.executeTime}</strong>
             <small>{copy.executeTimeHelp}</small>
           </div>
-          <Input
-            type="time"
-            aria-label={copy.executeTimeAria}
+          {/* Was a native time field. WebKit draws that control's popup
+              itself — platform-blue columns, platform metrics, no dark
+              mode — and no `::-webkit-*` selector reaches it, so the only
+              way onto the design system was to own the popup. TimePicker
+              keeps the same `HH:MM` value contract, so the persisted
+              config shape is unchanged. */}
+          <TimePicker
+            ariaLabel={copy.executeTimeAria}
             className="settingsTimeInput"
             value={effectiveConfig?.executeTime ?? '08:00'}
             disabled={formDisabled || savingKey === 'executeTime'}
-            onChange={(event) => {
-              // Native time-pickers only fire `change` once the value
-              // is a complete HH:MM (or cleared); the earlier hand-
-              // rolled regex would silently drop any intermediate
-              // state the user typed (e.g. `08:0`), making the picker
-              // feel stuck. Trust the browser.
-              void patchConfig('executeTime', { executeTime: event.target.value });
+            hourLabel={copy.executeTimeHour}
+            minuteLabel={copy.executeTimeMinute}
+            onChange={(executeTime) => {
+              void patchConfig('executeTime', { executeTime });
             }}
           />
         </div>

--- a/apps/desktop/src/renderer/styles/segmented.css
+++ b/apps/desktop/src/renderer/styles/segmented.css
@@ -9,12 +9,22 @@
   width: fit-content;
   display: inline-flex;
   align-items: center;
-  /* Narrow containers wrap whole options to the next row; labels never
-     break inside a button (nowrap below). Keeps every option reachable
-     and 22px tall at any width. */
-  flex-wrap: wrap;
+  /* The track never breaks across rows. A segmented control reads as ONE
+     switch: wrapping split it into a ragged two-row plate (visible in the
+     en locale, where "Follow system / 中文 / English" is ~25% wider than
+     the zh labels and dropped "English" onto its own line). Instead the
+     group refuses to shrink and the label stack beside it — which already
+     carries `min-width: 0` and wraps — absorbs the squeeze. Below the
+     460px card container the whole row stacks (rows.css), so the track
+     gets the full width rather than ever needing to fold. */
+  flex: 0 0 auto;
+  flex-wrap: nowrap;
   gap: var(--space-0-5);
-  border-radius: var(--radius-pill);
+  /* Concentric with the app radius scale, not a pill: at 999px the track
+     read as a foreign shape beside the 6px inputs/selects it shares a card
+     with. Outer sits on --radius-surface; the buttons shrink by the 2px
+     track padding so both curves stay concentric. */
+  border-radius: var(--radius-surface);
   background: var(--foreground-5);
   padding: var(--space-0-5);
 }
@@ -22,7 +32,13 @@
 .maka-segmented button {
   min-height: 22px;
   border: 0;
-  border-radius: var(--radius-pill);
+  /* Concentric with the 8px track: 8px outer - 2px track padding = 6px,
+     which IS --radius-control — and a segment button is a control, so the
+     tier token says it directly. Deliberately not the calc() shrink form:
+     CSS requires whitespace around `-`, but the radius-converge contract
+     splits values on whitespace, so the only spelling that satisfies both
+     would be invalid CSS resolving to 0. */
+  border-radius: var(--radius-control);
   background: transparent;
   color: var(--foreground-secondary);
   padding: 0 var(--space-2);

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -217,6 +217,13 @@
    cap); keying off the row makes the contract local and obvious. */
 .settingsRow[data-control-width="compact"] > input,
 .settingsRow[data-control-width="compact"] > .settingsTimeInput {
+  /* `width: auto` over the Input primitive's `w-full`: a 140px flat cap
+     stretched the box to 140px while `08:00` + the picker glyph only ink
+     ~80px, leaving a ~60px dead strip inside the field's right edge. The
+     field now hugs its content and stays pinned to the same right rail as
+     the switch rows above it; 140px remains the ceiling for the wider
+     compact controls that share this bucket. */
+  width: auto;
   max-width: 140px;
   justify-self: end;
 }

--- a/docs/permission-onboarding-plan.md
+++ b/docs/permission-onboarding-plan.md
@@ -1,0 +1,134 @@
+# Drag-to-grant permission onboarding (macOS)
+
+Status: **proposal, not built.** Written 2026-07-27 for maka.
+
+## The problem
+
+macOS gates Accessibility and Screen Recording behind TCC, and the stock
+flow is hostile: the user must open System Settings, find Privacy &
+Security, find the right pane, press `+`, navigate a file picker to
+`/Applications`, choose `Maka.app`, then come back and tick a checkbox.
+Six steps, and the file picker is where most people give up.
+
+maka today does the honest-but-minimal thing: `permissions-actions.ts`
+deep-links into the right pane and stops there
+(`apps/desktop/src/main/permissions-actions.ts:52`). Everything after the
+deep link is on the user.
+
+Apple's design intent is that the user *explicitly* adds the app — that
+part is not worth circumventing. But System Settings also accepts an
+`.app` bundle **dropped** onto the permission list, which satisfies the
+same intent in one gesture. That is the whole trick.
+
+## What we're copying, and from where
+
+Two independent implementations of the same idea:
+
+- [`riko2chen/AskForPermission`](https://github.com/riko2chen/AskForPermission)
+  — MIT, native Swift/AppKit. Not directly usable (maka is Electron) but
+  its window-location approach is the correct one.
+- Alma (closed-source; behaviour observed in the local `~/alma-re`
+  study archive). Electron, so its shape maps onto maka almost directly.
+
+**We take the technique, not the code.** No Alma source is copied into
+this repo, and `~/alma-re` stays out of the tree.
+
+## The mechanism
+
+Four APIs, only one of which is exotic:
+
+| Piece | API | Notes |
+|---|---|---|
+| Non-focus-stealing card | `BrowserWindow` `{type:'panel', focusable:false, transparent:true, frame:false}` + `setAlwaysOnTop(true,'screen-saver')` + `showInactive()` | All four are load-bearing. Drop any one and the card steals focus, which drops System Settings' drop-target highlight mid-drag. |
+| Follows the Settings window | `CGWindowListCopyWindowInfo` | **Not reachable from Electron** — see below. |
+| The drag itself | `webContents.startDrag({file, icon})` | Stock Electron. Writes a `kUTTypeFileURL` onto `NSPasteboard`, which is what makes the drop legible to another process. An HTML5 `dragstart` cannot cross the process boundary. |
+| Grant detection | `systemPreferences.isTrustedAccessibilityClient(false)` / `getMediaAccessStatus('screen')` on a ~1.5s poll | There is no usable notification for these; polling is the state of the art. |
+
+### The one hard constraint
+
+Electron exposes no API for another application's window geometry —
+`screen.*` covers displays and the cursor only. The single
+permission-free source on macOS is `CGWindowListCopyWindowInfo`: window
+*images* require Screen Recording, but the *metadata* (`kCGWindowBounds`,
+`kCGWindowOwnerPID`) does not. That distinction is what avoids the
+chicken-and-egg of asking for Accessibility using an API that itself
+requires Accessibility.
+
+Explicitly ruled out: `osascript` / System Events
+(`get position of window 1 of process "System Settings"`) needs both
+Accessibility and an Automation grant — exactly the deadlock we're
+trying to escape.
+
+So the docking effect costs one native call. Three ways to get it:
+
+1. **Prebuilt Swift CLI in `Resources/`, spawned as a child process.**
+   ~50KB universal binary, signed and notarised with the app. No
+   node-gyp, no N-API/ABI coupling, cannot crash the main process.
+   **Recommended.**
+2. **Compile Swift at runtime on first use, cache the binary.** Alma's
+   approach. Zero build-system work, but it hard-depends on Xcode
+   Command Line Tools at runtime — absent on most non-developer Macs —
+   and Alma's version fails *silently* when they are.
+3. **Node addon (koffi / N-API).** Avoids a process spawn per tick, but
+   buys ABI coupling and a rebuild every Electron bump for a call made
+   ~5×/second. Not worth it.
+
+Note the cost model in (1) and (2): a tracker polling at 200ms spawns a
+process 5×/second for the life of the overlay. Acceptable for a
+short-lived onboarding overlay; it should not become a general facility.
+
+## Staging
+
+**Stage 1 — pure Electron, no native code.** Everything except docking:
+the panel window, the deep link, the drag, the poller, the grant→close
+lifecycle, the copy. The card anchors to
+`screen.getCursorScreenPoint()` — the user just clicked our button, so
+the cursor is a good proxy for where they are looking. This is the whole
+feature minus the polish, and it ships without touching the build.
+
+**Stage 2 — add the locator binary** as progressive enhancement. When it
+returns a frame, the card docks to the Settings window and follows it;
+when it returns `null`, fall back to the Stage 1 anchor. Unlike Alma,
+log the degradation loudly — a silent fallback is indistinguishable
+from a bug.
+
+## Design notes worth stealing
+
+- **The drag image should look like the destination row**, not like the
+  app icon: a small canvas-rendered replica of a System Settings list
+  row (icon + "Maka"). What you drag looks like what it becomes, which
+  is what makes the gesture read as obvious.
+- **Flight animation:** quadratic Bézier with the control point lifted
+  `clamp(0.18 × distance, 44, 140)`px, over ~720ms on a critically
+  damped spring. The arc is what signals "this belongs over there".
+  Skip it in Stage 1 — with no real target it is decoration. Gate it on
+  `prefers-reduced-motion` either way.
+- **Screen Recording needs an extra beat:** macOS caches the old denial,
+  so a freshly granted app often still reads `denied`. The honest fix is
+  copy — after ~8s, tell the user a relaunch is required.
+
+## Gaps to fix rather than inherit
+
+Both references have holes worth not copying:
+
+- **No detection that the user closed System Settings or gave up.** The
+  card just freezes in place, always-on-top across every Space, until
+  it is dismissed by hand. maka should treat "Settings went away" and a
+  give-up timeout as real states.
+- **No dev-mode affordance.** When there is no `.app` to drag, the
+  mousedown silently does nothing. Fall back to "reveal in Finder" or a
+  copy-path button so the flow degrades to something usable.
+- **Stacked pollers.** Alma pushes a new subscriber and restarts the
+  tracker on each entry point, so two paths onto the same window stack
+  duplicate timers. One tracker per window, owned by the window.
+
+## Scope
+
+Roughly: one main-process module (window + tracker + lifecycle), one IPC
+channel for the drag, one renderer route for the card, copy in both
+locales, plus Stage 2's locator binary and its build/signing step.
+`apps/desktop/src/main/computer-use/cursor-overlay-window.ts` already
+does transparent / always-on-top / all-workspaces / `showInactive` and
+is the right thing to model the window on — possibly to generalise.
+
+This is its own PR, separate from any settings-control work.

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -83,6 +83,7 @@ export * from './primitives/segmented.js';
 export * from './primitives/settings-select.js';
 export * from './primitives/settings-switch.js';
 export * from './primitives/input.js';
+export * from './primitives/time-picker.js';
 export * from './primitives/textarea.js';
 export * from './primitives/input-group.js';
 export * from './primitives/toolbar.js';

--- a/packages/ui/src/primitives/time-picker.tsx
+++ b/packages/ui/src/primitives/time-picker.tsx
@@ -1,0 +1,223 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useRef, useState, type ReactElement, type RefObject } from "react";
+import { Clock } from "../icons.js";
+import { cn } from "../utils.js";
+import { inputClasses } from "./input.js";
+import {
+  PopoverPopup,
+  PopoverPortal,
+  PopoverPositioner,
+  PopoverRoot,
+  PopoverTrigger,
+} from "../ui.js";
+
+/**
+ * TimePicker — a maka-chrome replacement for `<input type="time">`.
+ *
+ * The native control was the only field in Settings that dropped out of
+ * the design system: WebKit draws its own dropdown (a pair of columns in
+ * the platform accent blue, platform metrics, no dark-mode participation)
+ * and none of it is styleable — `::-webkit-*` reaches the in-field
+ * spinner glyphs, never the popup. So the popup has to be ours.
+ *
+ * Shape: the trigger keeps the field's look (same `inputClasses` chrome
+ * as every other settings input) and shows `HH:MM` plus a clock glyph.
+ * The popup is two independent columns — hours 00-23 and minutes on a
+ * `minuteStep` grid — because a daily schedule is picked as "which hour"
+ * then "which minute", not as one flat list of 288 options.
+ *
+ * Value contract matches the native element it replaces: a `HH:MM`
+ * 24-hour string, so callers (and the persisted config) are unchanged.
+ * A malformed or empty incoming value falls back to `fallback` rather
+ * than rendering an empty trigger.
+ */
+
+const HOURS = Array.from({ length: 24 }, (_, i) => i);
+
+export interface TimePickerProps {
+  /** `HH:MM`, 24-hour. */
+  value: string;
+  onChange(next: string): void;
+  ariaLabel: string;
+  disabled?: boolean;
+  /** Minute granularity; must divide 60. Defaults to 5. */
+  minuteStep?: number;
+  /** Shown when `value` is missing or malformed. Defaults to `08:00`. */
+  fallback?: string;
+  className?: string;
+  /** Labels for the two columns, so the popup is not English-only. */
+  hourLabel: string;
+  minuteLabel: string;
+}
+
+const TIME_RE = /^([01]\d|2[0-3]):([0-5]\d)$/;
+
+export function parseTime(value: string, fallback: string): { hour: number; minute: number } {
+  const source = TIME_RE.test(value) ? value : fallback;
+  const match = TIME_RE.exec(source);
+  // `fallback` is a developer-supplied constant; if it is malformed too
+  // we still owe the caller a renderable value rather than a throw.
+  if (!match) return { hour: 8, minute: 0 };
+  return { hour: Number(match[1]), minute: Number(match[2]) };
+}
+
+export function formatTime(hour: number, minute: number): string {
+  return `${String(hour).padStart(2, "0")}:${String(minute).padStart(2, "0")}`;
+}
+
+export function TimePicker(props: TimePickerProps): ReactElement {
+  const fallback = props.fallback ?? "08:00";
+  const step = props.minuteStep && 60 % props.minuteStep === 0 ? props.minuteStep : 5;
+  const minutes = useMemo(
+    () => Array.from({ length: 60 / step }, (_, i) => i * step),
+    [step],
+  );
+  const { hour, minute } = parseTime(props.value, fallback);
+  const [open, setOpen] = useState(false);
+  // Centring has to wait for the open transition to finish. Base UI moves
+  // focus into the popup as part of opening, and focusing a row scrolls
+  // it into view — which silently undid a centring done any earlier.
+  const [settled, setSettled] = useState(false);
+  const selectedHourRef = useRef<HTMLButtonElement>(null);
+
+  const commit = useCallback(
+    (nextHour: number, nextMinute: number) => {
+      const next = formatTime(nextHour, nextMinute);
+      if (next !== props.value) props.onChange(next);
+    },
+    [props.onChange, props.value],
+  );
+
+  return (
+    <PopoverRoot
+      open={open}
+      onOpenChange={setOpen}
+      onOpenChangeComplete={(isOpen) => setSettled(isOpen)}
+    >
+      <PopoverTrigger
+        aria-label={props.ariaLabel}
+        disabled={props.disabled}
+        className={cn(
+          inputClasses,
+          // The field chrome is width-greedy (`w-full`); a time field has
+          // one fixed-width value, so it hugs instead and lets the row's
+          // control-width bucket place it.
+          "w-auto items-center justify-between gap-2 tabular-nums",
+          "data-[popup-open]:border-ring data-[popup-open]:ring-2 data-[popup-open]:ring-ring/16",
+          props.className,
+        )}
+      >
+        <span>{formatTime(hour, minute)}</span>
+        <Clock size={14} aria-hidden="true" className="shrink-0 text-foreground-secondary" />
+      </PopoverTrigger>
+      <PopoverPortal>
+        <PopoverPositioner align="end" sideOffset={6}>
+          {/* Land focus on the CURRENT hour, not the first row. Base UI
+              otherwise focuses row "00", which both reads wrong to a
+              keyboard user and scrolls the column away from the value
+              they came to change. */}
+          <PopoverPopup className="flex gap-1" initialFocus={selectedHourRef}>
+            <TimeColumn
+              label={props.hourLabel}
+              values={HOURS}
+              selected={hour}
+              settled={settled}
+              selectedItemRef={selectedHourRef}
+              onSelect={(next) => commit(next, minute)}
+            />
+            <TimeColumn
+              label={props.minuteLabel}
+              values={minutes}
+              selected={minute}
+              settled={settled}
+              onSelect={(next) => commit(hour, next)}
+            />
+          </PopoverPopup>
+        </PopoverPositioner>
+      </PopoverPortal>
+    </PopoverRoot>
+  );
+}
+
+function TimeColumn(props: {
+  label: string;
+  values: readonly number[];
+  selected: number;
+  /** True once the popup's open transition (and its focus move) is done. */
+  settled: boolean;
+  /** Lifted so the popup can take initial focus on the selected row. */
+  selectedItemRef?: RefObject<HTMLButtonElement | null>;
+  onSelect(value: number): void;
+}): ReactElement {
+  const listRef = useRef<HTMLDivElement>(null);
+  const ownSelectedRef = useRef<HTMLButtonElement>(null);
+  const selectedRef = props.selectedItemRef ?? ownSelectedRef;
+
+  // A 24-row hour column opens scrolled to the top, which hides the
+  // current value whenever it is past ~09:00. Centre it on open (not on
+  // every change — that would fight the user's own scrolling).
+  //
+  // Gated on `settled`, not on `open`: Base UI mounts the popup before it
+  // has measured it (every rect reads 0, so a write here commits scrollTop
+  // 0 — the wrong answer, indistinguishable from "already at the top") and
+  // then moves focus into it, whose scroll-into-view overwrites whatever
+  // we set. `onOpenChangeComplete` fires after both.
+  useEffect(() => {
+    if (!props.settled) return;
+    let frame = 0;
+    let attempts = 0;
+    const centre = () => {
+      const node = selectedRef.current;
+      const list = listRef.current;
+      if (!node || !list) return;
+      if (list.clientHeight === 0 || node.clientHeight === 0) {
+        // Give up after ~10 frames so a permanently-collapsed popup can't
+        // spin a rAF loop for the life of the component.
+        if (attempts++ < 10) frame = requestAnimationFrame(centre);
+        return;
+      }
+      // Rect delta, not `offsetTop`: the list box is not a positioned
+      // ancestor, so `offsetTop` measures from the popup instead.
+      const delta = node.getBoundingClientRect().top - list.getBoundingClientRect().top;
+      list.scrollTop += delta - (list.clientHeight - node.clientHeight) / 2;
+    };
+    frame = requestAnimationFrame(centre);
+    return () => cancelAnimationFrame(frame);
+  }, [props.settled]);
+
+  return (
+    <div className="flex min-w-0 flex-col">
+      <div className="px-2 py-1 text-xs font-medium text-foreground-secondary">{props.label}</div>
+      <div
+        ref={listRef}
+        role="listbox"
+        aria-label={props.label}
+        className="max-h-50 overflow-y-auto"
+      >
+        {props.values.map((value) => {
+          const isSelected = value === props.selected;
+          return (
+            <button
+              key={value}
+              ref={isSelected ? selectedRef : undefined}
+              type="button"
+              role="option"
+              aria-selected={isSelected}
+              onClick={() => props.onSelect(value)}
+              className={cn(
+                "flex w-full cursor-default items-center justify-center rounded-sm px-3 py-1.5 text-sm tabular-nums outline-none transition-colors",
+                "hover:bg-muted focus-visible:bg-muted",
+                isSelected
+                  ? "bg-muted font-medium text-foreground"
+                  : "text-foreground-secondary",
+              )}
+            >
+              {String(value).padStart(2, "0")}
+            </button>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -10,6 +10,7 @@ import { RadioGroup as BaseRadioGroup } from '@base-ui/react/radio-group';
 import { Switch as BaseSwitch } from '@base-ui/react/switch';
 import { Toggle as BaseToggle } from '@base-ui/react/toggle';
 import { ToggleGroup as BaseToggleGroup } from '@base-ui/react/toggle-group';
+import { Popover as BasePopover } from '@base-ui/react/popover';
 import { Select as BaseSelect } from '@base-ui/react/select';
 import { Separator as BaseSeparator } from '@base-ui/react/separator';
 import { Check, ChevronDown, X } from './icons.js';
@@ -314,19 +315,33 @@ export const SelectTrigger = forwardRef<
 
 export const SelectValue = BaseSelect.Value;
 export const SelectPortal = BaseSelect.Portal;
-export const SelectPositioner = BaseSelect.Positioner;
+/**
+ * The overlay layer belongs on the POSITIONER, not the popup.
+ *
+ * Base UI renders the popup `position: static` inside an absolutely
+ * positioned positioner. `z-index` has no effect on a static box, so the
+ * layer that used to sit on `SelectPopup` was inert; what actually kept
+ * settings selects above the modal was `.settingsSelectPositioner`
+ * (styles/settings/select.css), applied by hand at each call site. Any
+ * call site that forgot it portalled a popup that paints *below* the
+ * `.settingsModal` layer — invisible, and unclickable because the modal
+ * wins the hit-test. Settings → 通用 → 默认权限模式 shipped that way and
+ * read as "clicking does nothing at all".
+ *
+ * Carrying the layer here makes it structural: every Select consumer
+ * gets it by construction instead of by remembering a class name.
+ */
+export const SelectPositioner = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Positioner>>(function SelectPositioner(
+  { className, ...props },
+  ref,
+) {
+  return <BaseSelect.Positioner ref={ref} className={cn('z-[var(--z-overlay)]', className)} data-slot="select-positioner" {...props} />;
+});
 export const SelectPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Popup>>(function SelectPopup(
   { className, ...props },
   ref,
 ) {
-  // The Settings modal uses `--z-modal` (200) — the previous bare
-  // popup layer (Tailwind utility worth 50) was below it, so any
-  // `<SettingsSelect>` opened inside a modal (e.g. Daily Review
-  // → 分析模型) rendered its popup beneath the modal content and
-  // read as "can't select". Pin the popup to `--z-overlay` (300)
-  // so it always floats above the modal it was triggered from
-  // (WAWQAQ msg `d3ea9a33` 2026-06-26).
-  return <BaseSelect.Popup ref={ref} className={cn('z-[var(--z-overlay)] min-w-40 rounded-md bg-popover p-1 text-popover-foreground shadow-maka-panel', className)} data-slot="select-popup" {...props} />;
+  return <BaseSelect.Popup ref={ref} className={cn('min-w-40 rounded-md bg-popover p-1 text-popover-foreground shadow-maka-panel', className)} data-slot="select-popup" {...props} />;
 });
 export const SelectGroup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BaseSelect.Group>>(function SelectGroup(
   { className, ...props },
@@ -367,6 +382,42 @@ export const SelectItem = forwardRef<HTMLDivElement, React.ComponentPropsWithout
         <BaseSelect.ItemText>{children}</BaseSelect.ItemText>
       </span>
     </BaseSelect.Item>
+  );
+});
+
+/**
+ * Popover — the anchored-surface primitive for pickers that are NOT a
+ * single-value list (Select already covers those). Added for the time
+ * picker, whose popup holds two independent columns and so has no single
+ * "selected item" for Select to own.
+ *
+ * The popup pins the same `--z-overlay` layer as `SelectPopup`: the
+ * Settings modal sits on its own layer, and a bare Tailwind z-utility
+ * would render the popup *beneath* the modal that triggered it — the bug
+ * fixed for Select in WAWQAQ msg `d3ea9a33`.
+ */
+export const PopoverRoot = BasePopover.Root;
+export const PopoverTrigger = BasePopover.Trigger;
+export const PopoverPortal = BasePopover.Portal;
+/** Carries the overlay layer for the same reason `SelectPositioner` does —
+ *  the popup below is `position: static`, so a z-index there is inert. */
+export const PopoverPositioner = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BasePopover.Positioner>>(function PopoverPositioner(
+  { className, ...props },
+  ref,
+) {
+  return <BasePopover.Positioner ref={ref} className={cn('z-[var(--z-overlay)]', className)} data-slot="popover-positioner" {...props} />;
+});
+export const PopoverPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BasePopover.Popup>>(function PopoverPopup(
+  { className, ...props },
+  ref,
+) {
+  return (
+    <BasePopover.Popup
+      ref={ref}
+      className={cn('rounded-md bg-popover p-1 text-popover-foreground shadow-maka-panel outline-none', className)}
+      data-slot="popover-popup"
+      {...props}
+    />
   );
 });
 


### PR DESCRIPTION
Four control-level defects reported from the settings surface, plus a plan for the permission-onboarding work.

### 1. Interface language control broke in English

`.maka-segmented` carried `flex-wrap: wrap`, so any locale whose labels ran wider than the row folded an option onto a second line. English hit it — "Follow system / 中文 / English" is ~25% wider than the zh labels, and "English" dropped below the track, turning one switch into a ragged two-row plate.

Measured over the `settings-general` (en) fixture: **50px tall on two baselines → 26px on one.**

The track now refuses to wrap or shrink; the label stack beside it already carries `min-width: 0` and absorbs the squeeze, and below the 460px card container the whole row stacks as before.

### 2. Segmented radius was off the design scale

The track sat on `--radius-pill` (999px) while every field and select it shares a card with sits on the 6/8/12 scale, so it read as a foreign shape. Track → `--radius-surface` (8px), segment buttons → `--radius-control` (6px), concentric across the 2px track padding. This lands on **all five** `Segmented` consumers, including the usage-stats range selector.

Deliberately not the `calc(var(--radius-*) - Npx)` shrink form: the radius-converge contract splits corner values on whitespace, so it only admits the unspaced `calc(var(--x)-2px)` — which is invalid CSS (the spec requires whitespace around `-`) and computes to `0px`. Verified in the renderer. Filed separately; `search-modal.css:32` currently ships that bug and renders square corners.

### 3. 默认权限模式 was unclickable — root cause

Base UI renders Select popups `position: static` inside an absolutely-positioned positioner, so the `z-[var(--z-overlay)]` on `SelectPopup` was **inert** — a static box ignores z-index. What actually kept settings selects above `.settingsModal` (z-index 35) was the `.settingsSelectPositioner` class, applied by hand per call site. `PermissionModeSelect` was the only Select that never got it, so its popup painted *under* the modal: in the DOM with `aria-expanded="true"`, invisible, and unclickable because the modal won every hit-test.

The layer now lives on wrapped `SelectPositioner` / `PopoverPositioner`, so consumers get it by construction. `z-index-contract` grows a case pinning both halves — positioners must carry the layer, popups must not.

Verified with **trusted** CDP input, which respects paint order: before, clicking an option left the trigger on 询问权限; after, it commits 自动执行. Synthetic `el.dispatchEvent` bypasses hit-testing and passes against a popup nobody can click — worth knowing for future UI checks.

### 4. Daily-review execution time

Two problems. The field inherited the Input primitive's `w-full` under a flat 140px cap, so `08:00` plus the glyph (~80px of ink) left a ~60px dead strip inside its right edge — **140px → 94px**, hugging its content on the same right rail as the switch rows.

And the popup was WebKit's: platform-accent columns, platform metrics, no dark mode, and unreachable by `::-webkit-*`. New `TimePicker` primitive owns it — same field chrome as its neighbours, two columns (hours, minutes on a 5-min grid), and the same `HH:MM` value contract, so the persisted config shape is unchanged.

Two ordering hazards, both found by measurement: Base UI mounts the popup before measuring it (every rect reads 0, so a naive scroll write commits 0 — indistinguishable from "already at the top"), then moves focus into it, whose scroll-into-view overwrites whatever was set. Centring is gated on `onOpenChangeComplete`, and initial focus is pinned to the *selected* hour rather than row 00.

### Also

`docs/permission-onboarding-plan.md` — a plan for the Codex-style drag-to-grant TCC onboarding. The load-bearing finding: the whole flow is stock Electron (`type:'panel'` + `focusable:false` + `showInactive()`, and `webContents.startDrag({file, icon})` for the drag) **except** locating the System Settings window, which needs `CGWindowListCopyWindowInfo` — the one permission-free source, avoiding the chicken-and-egg of using an Accessibility-gated API to request Accessibility. Staged so Stage 1 ships with no native code. Technique only; no vendor code copied.

### Gates

2855 desktop + 250 ui tests green · biome clean · 0 dead CSS · contracts re-pinned to the new intent rather than deleted.