### PR TITLE
feat(desktop): add playable Graph Mode

### DIFF
--- a/apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts
@@ -30,6 +30,11 @@ describe('Desktop Graph Mode host contract', () => {
     assert.match(panel, /\.getSnapshot\(props\.rootSessionId\)/);
     assert.match(panel, /window\.maka\.graphs\.subscribe\(props\.rootSessionId, refresh\)/);
     assert.match(panel, /subscribe\(props\.rootSessionId, refresh\);[\s\S]*refresh\(\)/);
+    assert.match(panel, /refreshRef\.current = refresh/);
+    assert.match(panel, /if \(refreshRef\.current === refresh\)/);
+    assert.match(panel, /if \(!props\.enabled && !hasGraphActivity && !error\) return null/);
+    assert.match(panel, /\{error \? \([\s\S]*copy\.loadFailed[\s\S]*refreshRef\.current\(\)/);
+    assert.doesNotMatch(panel, /error && !snapshot/);
     assert.match(panel, /snapshot\.scheduleRevision > 0/);
     assert.match(panel, /window\.maka\.graphs\.stop\(props\.rootSessionId\)/);
     assert.match(panel, /props\.onOpenSession\(operator\.childSessionId\)/);
@@ -45,5 +50,7 @@ describe('Desktop Graph Mode host contract', () => {
     assert.match(panel, /Loading graph state/);
     assert.match(panel, /打开子会话/);
     assert.match(panel, /Open child session/);
+    assert.match(panel, /可见 \$\{settled\}\/\$\{total\} 已结束/);
+    assert.match(panel, /\$\{settled\}\/\$\{total\} visible settled/);
   });
 });

--- a/apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts
@@ -39,6 +39,7 @@ describe('Desktop Graph Mode host contract', () => {
     assert.match(panel, /window\.maka\.graphs\.stop\(props\.rootSessionId\)/);
     assert.match(panel, /props\.onOpenSession\(operator\.childSessionId\)/);
     assert.match(shell, /<AgentGraphPanel/);
+    assert.match(shell, /activeId &&[\s\S]*activeSessionForView &&[\s\S]*!activeSessionForView\.subagentParent/);
   });
 
   it('keeps graph panel copy localized', async () => {

--- a/apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { fileURLToPath } from 'node:url';
+import { describe, it } from 'node:test';
+import { readRendererShellSources } from './renderer-shell-source-helpers.js';
+
+describe('Desktop Graph Mode host contract', () => {
+  it('uses the shared command parser and trusted one-turn override', async () => {
+    const renderer = await readRendererShellSources(['app-shell.tsx', 'app-shell-chat-actions.ts']);
+    assert.match(renderer, /parseGraphCommand\(text\)/);
+    assert.match(renderer, /send\(graphCommand\.task, pending, \{/);
+    assert.match(renderer, /turnOrchestration: \{ mode: 'graph', source: 'slash_command' \}/);
+  });
+
+  it('persists graph as the exclusive session orchestration mode', async () => {
+    const renderer = await readRendererShellSources(['app-shell.tsx', 'app-shell-chat-actions.ts']);
+    assert.match(renderer, /activeSessionForView\?\.orchestrationMode \?\? 'default'/);
+    assert.match(renderer, /active \? 'graph' : 'default'/);
+    assert.match(renderer, /newChatGraphModeActive[\s\S]*\? 'graph'/);
+    assert.match(renderer, /if \(active\) setNewChatSwarmModeActive\(false\)/);
+    assert.match(renderer, /if \(active\) setNewChatGraphModeActive\(false\)/);
+  });
+
+  it('renders the bounded graph read model and opens linked child Sessions', async () => {
+    const panel = await readFile(
+      fileURLToPath(new URL('../../../src/renderer/agent-graph-panel.tsx', import.meta.url)),
+      'utf8',
+    );
+    const shell = await readRendererShellSources(['app-shell.tsx']);
+    assert.match(panel, /\.getSnapshot\(props\.rootSessionId\)/);
+    assert.match(panel, /window\.maka\.graphs\.subscribe\(props\.rootSessionId, refresh\)/);
+    assert.match(panel, /subscribe\(props\.rootSessionId, refresh\);[\s\S]*refresh\(\)/);
+    assert.match(panel, /snapshot\.scheduleRevision > 0/);
+    assert.match(panel, /window\.maka\.graphs\.stop\(props\.rootSessionId\)/);
+    assert.match(panel, /props\.onOpenSession\(operator\.childSessionId\)/);
+    assert.match(shell, /<AgentGraphPanel/);
+  });
+
+  it('keeps graph panel copy localized', async () => {
+    const panel = await readFile(
+      fileURLToPath(new URL('../../../src/renderer/agent-graph-panel.tsx', import.meta.url)),
+      'utf8',
+    );
+    assert.match(panel, /正在读取 Graph 状态/);
+    assert.match(panel, /Loading graph state/);
+    assert.match(panel, /打开子会话/);
+    assert.match(panel, /Open child session/);
+  });
+});

--- a/apps/desktop/src/main/__tests__/materialize-turns.test.ts
+++ b/apps/desktop/src/main/__tests__/materialize-turns.test.ts
@@ -744,3 +744,31 @@ describe('automation turn attribution (F6)', () => {
     assert.equal(turns[0]?.user?.automationOrigin, undefined);
   });
 });
+
+describe('Agent Graph supervisor turn attribution', () => {
+  it('projects a durable graph wake origin onto the turn user entry', () => {
+    const turns = materializeTurns([
+      {
+        type: 'user',
+        id: 'u-graph',
+        turnId: 't-graph',
+        ts: 1,
+        text: 'model-facing checkpoint',
+        displayText: 'Agent graph reached a supervisor checkpoint.',
+        origin: {
+          kind: 'agent_graph',
+          graphId: 'graph-1',
+          wakeId: 'graph-1:snapshot-1',
+        },
+      },
+    ] as StoredMessage[]);
+    assert.deepEqual(turns[0]?.user?.agentGraphOrigin, {
+      graphId: 'graph-1',
+      wakeId: 'graph-1:snapshot-1',
+    });
+    assert.equal(
+      turns[0]?.user?.text,
+      'Agent graph reached a supervisor checkpoint.',
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/materialize-turns.test.ts
+++ b/apps/desktop/src/main/__tests__/materialize-turns.test.ts
@@ -759,12 +759,14 @@ describe('Agent Graph supervisor turn attribution', () => {
           kind: 'agent_graph',
           graphId: 'graph-1',
           wakeId: 'graph-1:snapshot-1',
+          attemptId: 'attempt-1',
         },
       },
     ] as StoredMessage[]);
     assert.deepEqual(turns[0]?.user?.agentGraphOrigin, {
       graphId: 'graph-1',
       wakeId: 'graph-1:snapshot-1',
+      attemptId: 'attempt-1',
     });
     assert.equal(
       turns[0]?.user?.text,

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -109,6 +109,11 @@ describe('permission response IPC boundary', () => {
       'allow must revalidate the workspace before resuming a parked tool; deny must remain available',
     );
     assert.doesNotMatch(handler, /runtime\.respondToPermission\(sessionId,\s*response\)/);
+    assert.match(
+      handler,
+      /await runtime\.respondToPermission\(sessionId, normalized\);[\s\S]*notifyAgentGraphPermissionResponse\?\.\(sessionId\)/,
+      'graph wake settlement must run only after the normalized permission response is accepted',
+    );
   });
 
   it('normalizes turn action inputs before regenerate / branch runtime calls', () => {

--- a/apps/desktop/src/main/__tests__/session-revision-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-revision-contract.test.ts
@@ -59,7 +59,7 @@ describe('session revision (edit-and-resend) contract', () => {
     );
     assert.match(
       shell,
-      /if \(\(skillIds\.length === 0 && text\.trim\(\) === '\/compact'\) \|\| swarmCommand\) \{[\s\S]*revisionCommandUnsupported/,
+      /if \(\(skillIds\.length === 0 && text\.trim\(\) === '\/compact'\) \|\| swarmCommand \|\| graphCommand\) \{[\s\S]*revisionCommandUnsupported/,
       'revision drafts must reject local slash commands before preparing a durable version',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/session-revision-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-revision-contract.test.ts
@@ -92,7 +92,7 @@ describe('session revision (edit-and-resend) contract', () => {
     const turn = await readFile(resolve(REPO_ROOT, 'packages/ui/src/chat-turn.tsx'), 'utf8');
     assert.match(
       turn,
-      /props\.onEditUserMessage && !turn\.user\.automationOrigin/,
+      /props\.onEditUserMessage &&[\s\S]*!turn\.user\.automationOrigin &&[\s\S]*!turn\.user\.agentGraphOrigin/,
     );
     assert.match(
       turn,

--- a/apps/desktop/src/main/__tests__/swarm-mode-host-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/swarm-mode-host-contract.test.ts
@@ -39,7 +39,7 @@ describe('Desktop Swarm Mode host contract', () => {
     const renderer = await readRendererShellSources(['app-shell.tsx', 'app-shell-chat-actions.ts']);
 
     assert.match(renderer, /activeSessionForView\?\.orchestrationMode \?\? 'default'/);
-    assert.match(renderer, /newChatOrchestrationMode: newChatSwarmModeActive \? 'swarm' : 'default'/);
+    assert.match(renderer, /newChatSwarmModeActive[\s\S]*\? 'swarm'[\s\S]*: 'default'/);
     assert.match(renderer, /orchestrationMode: newChatOrchestrationMode/);
   });
 });

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -130,6 +130,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
   async function recoverInterruptedSessionsOnStartup(): Promise<void> {
     try {
       await runtime.recoverInterruptedSessions();
+      await agentGraphSupervisorWakeCoordinator.recover();
       await agentGraphCoordinator.recover();
       if (process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME !== '1') return;
       for (const session of await runtime.listSessions()) {

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import { buildPricingLookup, setActiveProxy } from '@maka/runtime';
 import type {
   AgentGraphCoordinator,
+  AgentGraphSupervisorWakeCoordinator,
   BotRegistry,
   SessionManager,
   ShellRunProcessManager,
@@ -61,6 +62,7 @@ export interface AppLifecycleDeps {
   mainWindowController: ReturnType<typeof createMainWindowController>;
   runtime: SessionManager;
   agentGraphCoordinator: AgentGraphCoordinator;
+  agentGraphSupervisorWakeCoordinator: AgentGraphSupervisorWakeCoordinator;
   agentGraphControlStore: ReturnType<typeof createAgentGraphControlStore>;
   streamEvents: StreamEvents;
   /** Focus-or-create for the main window; stays in main.ts next to the
@@ -113,6 +115,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     mainWindowController,
     runtime,
     agentGraphCoordinator,
+    agentGraphSupervisorWakeCoordinator,
     agentGraphControlStore,
     streamEvents,
     focusOrCreateMainWindow,
@@ -332,6 +335,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
       shellRuns.terminateAll(),
       mcpManager.close(),
       agentGraphCoordinator.close(),
+      agentGraphSupervisorWakeCoordinator.close(),
     ]);
     for (const result of results) {
       if (result.status === 'rejected') console.error('[shutdown] cleanup failed:', result.reason);

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -31,6 +31,7 @@ import type { WorkspacePrivacyContext } from '@maka/core/incognito';
 import { ok } from '@maka/core/result';
 import {
   AgentGraphCoordinator,
+  AgentGraphSupervisorWakeCoordinator,
   BackendRegistry,
   FakeBackend,
   PermissionEngine,
@@ -624,6 +625,7 @@ const {
   resolveDesktopSkillHost,
 });
 let agentGraphCoordinator: AgentGraphCoordinator;
+let agentGraphSupervisorWakeCoordinator: AgentGraphSupervisorWakeCoordinator;
 const desktopBackendToolSurfaceDeps = {
   isComputerUseRealModelE2e,
   ensureMcpReady,
@@ -826,6 +828,26 @@ const runtime = new SessionManager({
   newId: randomUUID,
   now: Date.now,
 });
+agentGraphSupervisorWakeCoordinator = new AgentGraphSupervisorWakeCoordinator({
+  activityRegistry: sessionActivities,
+  readMessages: (sessionId) => runtime.getMessages(sessionId),
+  readSnapshot: (rootSessionId) => agentGraphCoordinator.getSnapshot(rootSessionId),
+  startTurn: async (sessionId, input, activity) => {
+    await ensureSessionCanSend(sessionId);
+    const iterator = runtime.sendMessage(sessionId, input);
+    return (
+      await streamEvents(sessionId, iterator, {
+        turnId: input.turnId,
+        goalBoundary: 'none',
+        activity,
+      })
+    ).outcome;
+  },
+  newId: randomUUID,
+  onError: (rootSessionId) => {
+    emitSessionsChanged('status-change', rootSessionId);
+  },
+});
 agentGraphCoordinator = new AgentGraphCoordinator({
   sessionStore: store,
   runStore,
@@ -833,6 +855,9 @@ agentGraphCoordinator = new AgentGraphCoordinator({
   controlStore: agentGraphControlStore,
   runtime,
   newId: randomUUID,
+  onReconciliation: (rootSessionId, result) => {
+    agentGraphSupervisorWakeCoordinator.notify(rootSessionId, result);
+  },
 });
 let settingsIpc: SettingsIpcHandle | undefined;
 let mcpToolSnapshot = JSON.stringify(mcpManager.tools());
@@ -1310,6 +1335,7 @@ wireAppLifecycle({
   mainWindowController,
   runtime,
   agentGraphCoordinator,
+  agentGraphSupervisorWakeCoordinator,
   agentGraphControlStore,
   streamEvents,
   focusOrCreateMainWindow,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1010,6 +1010,9 @@ function registerIpc(): void {
       const header = await store.readHeader(sessionId);
       if (!header.subagentParent) await agentGraphCoordinator.stop(sessionId);
     },
+    notifyAgentGraphPermissionResponse: (sessionId) => {
+      agentGraphSupervisorWakeCoordinator.notifyPermissionResponse(sessionId);
+    },
     ensureSessionWorkspaceAvailable,
     createSession: createDesktopSession,
     getReadyConnection,

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -830,7 +830,7 @@ const runtime = new SessionManager({
 });
 agentGraphSupervisorWakeCoordinator = new AgentGraphSupervisorWakeCoordinator({
   activityRegistry: sessionActivities,
-  readMessages: (sessionId) => runtime.getMessages(sessionId),
+  wakeStore: agentGraphControlStore,
   readSnapshot: (rootSessionId) => agentGraphCoordinator.getSnapshot(rootSessionId),
   startTurn: async (sessionId, input, activity) => {
     await ensureSessionCanSend(sessionId);

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -832,16 +832,41 @@ agentGraphSupervisorWakeCoordinator = new AgentGraphSupervisorWakeCoordinator({
   activityRegistry: sessionActivities,
   wakeStore: agentGraphControlStore,
   readSnapshot: (rootSessionId) => agentGraphCoordinator.getSnapshot(rootSessionId),
-  startTurn: async (sessionId, input, activity) => {
-    await ensureSessionCanSend(sessionId);
-    const iterator = runtime.sendMessage(sessionId, input);
-    return (
-      await streamEvents(sessionId, iterator, {
-        turnId: input.turnId,
-        goalBoundary: 'none',
-        activity,
-      })
-    ).outcome;
+  startTurn: async (sessionId, input, activity, abortSignal) => {
+    let stopPromise: Promise<void> | undefined;
+    const stop = () => {
+      stopPromise ??= runtime.stopSession(sessionId, { source: 'graph_supervisor' });
+    };
+    abortSignal.addEventListener('abort', stop, { once: true });
+    if (abortSignal.aborted) stop();
+    try {
+      await ensureSessionCanSend(sessionId);
+      if (abortSignal.aborted) {
+        return { kind: 'aborted', turnId: input.turnId };
+      }
+      const iterator = runtime.sendMessage(sessionId, input);
+      return (
+        await streamEvents(sessionId, iterator, {
+          turnId: input.turnId,
+          goalBoundary: 'none',
+          activity,
+        })
+      ).outcome;
+    } finally {
+      abortSignal.removeEventListener('abort', stop);
+      await stopPromise;
+    }
+  },
+  inspectAttempt: async (rootSessionId, attemptId, turnId) => {
+    const runs = (await runStore.listSessionRuns(rootSessionId)).filter(
+      (run) => run.agentGraphWakeAttemptId === attemptId && run.turnId === turnId,
+    );
+    if (runs.length > 1) {
+      throw new Error(
+        `Agent graph supervisor wake attempt ${attemptId} has multiple AgentRuns`,
+      );
+    }
+    return runs[0]?.status ?? 'missing';
   },
   newId: randomUUID,
   onError: (rootSessionId) => {

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -92,6 +92,7 @@ export interface SessionsIpcDeps {
   invalidateSessionBindings?: (sessionId: string) => void;
   clearSkillHost?: (sessionId: string) => void;
   stopAgentGraph?: (sessionId: string) => Promise<void>;
+  notifyAgentGraphPermissionResponse?: (sessionId: string) => void;
   ensureSessionWorkspaceAvailable: (sessionId: string) => Promise<void>;
   createSession: (input: CreateSessionInput) => ReturnType<SessionManager['createSession']>;
   getReadyConnection: (
@@ -192,6 +193,7 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
     invalidateSessionBindings,
     clearSkillHost,
     stopAgentGraph,
+    notifyAgentGraphPermissionResponse,
     ensureSessionWorkspaceAvailable,
     createSession,
     getReadyConnection,
@@ -326,7 +328,8 @@ export function registerSessionsIpc(deps: SessionsIpcDeps): void {
     if (normalized.decision === 'allow') {
       await ensureSessionWorkspaceAvailable(sessionId);
     }
-    return runtime.respondToPermission(sessionId, normalized);
+    await runtime.respondToPermission(sessionId, normalized);
+    notifyAgentGraphPermissionResponse?.(sessionId);
   });
   ipcMain.handle('sessions:respondToUserQuestion', async (_event, sessionId: string, response) => {
     const normalized = normalizeUserQuestionResponse(response);

--- a/apps/desktop/src/renderer/agent-graph-panel.tsx
+++ b/apps/desktop/src/renderer/agent-graph-panel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState, type JSX } from 'react';
+import { useEffect, useMemo, useRef, useState, type JSX } from 'react';
 import type { UiLocale } from '@maka/core';
 import type {
   AgentGraphClientOperator,
@@ -12,12 +12,13 @@ type GraphPanelCopy = {
   stop: string;
   stopping: string;
   stopFailed: string;
+  loadFailed: string;
   openSession: string;
   operators: string;
   selectedResults: string;
   noOperators: string;
   hiddenOperators(count: number): string;
-  progress(settled: number, total: number): string;
+  progress(settled: number, total: number, hasOmitted: boolean): string;
   status(status: AgentGraphClientSnapshot['status']): string;
   operatorStatus(status: AgentGraphClientOperator['status']): string;
   wait(operator: AgentGraphClientOperator): string | undefined;
@@ -32,12 +33,14 @@ export function getAgentGraphPanelCopy(locale: UiLocale): GraphPanelCopy {
       stop: '停止 Graph',
       stopping: '停止中…',
       stopFailed: '停止 Graph 失败，请重试。',
+      loadFailed: 'Graph 状态刷新失败。',
       openSession: '打开子会话',
       operators: 'Operators',
       selectedResults: '已选择结果',
       noOperators: '等待主 Agent 创建 operator…',
       hiddenOperators: (count) => `另有 ${count} 个 operator`,
-      progress: (settled, total) => `${settled}/${total} 已结束`,
+      progress: (settled, total, hasOmitted) =>
+        hasOmitted ? `可见 ${settled}/${total} 已结束` : `${settled}/${total} 已结束`,
       status: (status) =>
         ({
           empty: '等待调度',
@@ -70,12 +73,14 @@ export function getAgentGraphPanelCopy(locale: UiLocale): GraphPanelCopy {
     stop: 'Stop graph',
     stopping: 'Stopping…',
     stopFailed: 'Could not stop the graph. Try again.',
+    loadFailed: 'Could not refresh graph state.',
     openSession: 'Open child session',
     operators: 'Operators',
     selectedResults: 'Selected results',
     noOperators: 'Waiting for the main agent to create an operator…',
     hiddenOperators: (count) => `${count} more operator${count === 1 ? '' : 's'}`,
-    progress: (settled, total) => `${settled}/${total} settled`,
+    progress: (settled, total, hasOmitted) =>
+      hasOmitted ? `${settled}/${total} visible settled` : `${settled}/${total} settled`,
     status: (status) =>
       ({
         empty: 'Awaiting schedule',
@@ -113,6 +118,7 @@ export function AgentGraphPanel(props: {
   const [error, setError] = useState(false);
   const [stopPending, setStopPending] = useState(false);
   const [stopError, setStopError] = useState(false);
+  const refreshRef = useRef<() => void>(() => {});
   const copy = getAgentGraphPanelCopy(props.locale);
 
   useEffect(() => {
@@ -131,6 +137,7 @@ export function AgentGraphPanel(props: {
         queued = true;
         return;
       }
+      setLoading(true);
       task = window.maka.graphs
         .getSnapshot(props.rootSessionId)
         .then((next) => {
@@ -140,7 +147,7 @@ export function AgentGraphPanel(props: {
           }
         })
         .catch(() => {
-          if (!disposed && props.enabled) setError(true);
+          if (!disposed) setError(true);
         })
         .finally(() => {
           if (disposed) return;
@@ -153,10 +160,12 @@ export function AgentGraphPanel(props: {
         });
     };
 
+    refreshRef.current = refresh;
     const unsubscribe = window.maka.graphs.subscribe(props.rootSessionId, refresh);
     refresh();
     return () => {
       disposed = true;
+      if (refreshRef.current === refresh) refreshRef.current = () => {};
       unsubscribe();
     };
   }, [props.rootSessionId, props.enabled]);
@@ -173,7 +182,7 @@ export function AgentGraphPanel(props: {
     (snapshot.scheduleRevision > 0 ||
       snapshot.operators.length > 0 ||
       snapshot.omitted.operators > 0);
-  if (!props.enabled && !hasGraphActivity) return null;
+  if (!props.enabled && !hasGraphActivity && !error) return null;
 
   const stopGraph = async (): Promise<void> => {
     if (stopPending) return;
@@ -197,7 +206,12 @@ export function AgentGraphPanel(props: {
           <strong>{copy.title}</strong>
           {snapshot ? (
             <span className="maka-agent-graph-progress">
-              {copy.status(snapshot.status)} · {copy.progress(progress.settled, progress.total)}
+              {copy.status(snapshot.status)} ·{' '}
+              {copy.progress(
+                progress.settled,
+                progress.total,
+                snapshot.omitted.operators > 0,
+              )}
             </span>
           ) : null}
         </div>
@@ -219,24 +233,17 @@ export function AgentGraphPanel(props: {
       ) : null}
 
       {loading && !snapshot ? <p className="maka-agent-graph-empty">{copy.loading}</p> : null}
-      {error && !snapshot ? (
-        <button
-          type="button"
-          className="maka-agent-graph-retry"
-          onClick={() => {
-            setLoading(true);
-            window.maka.graphs
-              .getSnapshot(props.rootSessionId)
-              .then((next) => {
-                setSnapshot(next);
-                setError(false);
-              })
-              .catch(() => setError(true))
-              .finally(() => setLoading(false));
-          }}
-        >
-          {copy.retry}
-        </button>
+      {error ? (
+        <p className="maka-agent-graph-error" role="alert">
+          <span>{copy.loadFailed}</span>{' '}
+          <button
+            type="button"
+            className="maka-agent-graph-retry"
+            onClick={() => refreshRef.current()}
+          >
+            {copy.retry}
+          </button>
+        </p>
       ) : null}
 
       {snapshot ? (

--- a/apps/desktop/src/renderer/agent-graph-panel.tsx
+++ b/apps/desktop/src/renderer/agent-graph-panel.tsx
@@ -1,0 +1,322 @@
+import { useEffect, useMemo, useState, type JSX } from 'react';
+import type { UiLocale } from '@maka/core';
+import type {
+  AgentGraphClientOperator,
+  AgentGraphClientSnapshot,
+} from '@maka/runtime';
+
+type GraphPanelCopy = {
+  title: string;
+  loading: string;
+  retry: string;
+  stop: string;
+  stopping: string;
+  stopFailed: string;
+  openSession: string;
+  operators: string;
+  selectedResults: string;
+  noOperators: string;
+  hiddenOperators(count: number): string;
+  progress(settled: number, total: number): string;
+  status(status: AgentGraphClientSnapshot['status']): string;
+  operatorStatus(status: AgentGraphClientOperator['status']): string;
+  wait(operator: AgentGraphClientOperator): string | undefined;
+};
+
+export function getAgentGraphPanelCopy(locale: UiLocale): GraphPanelCopy {
+  if (locale === 'zh') {
+    return {
+      title: 'Agent Graph',
+      loading: '正在读取 Graph 状态…',
+      retry: '重试',
+      stop: '停止 Graph',
+      stopping: '停止中…',
+      stopFailed: '停止 Graph 失败，请重试。',
+      openSession: '打开子会话',
+      operators: 'Operators',
+      selectedResults: '已选择结果',
+      noOperators: '等待主 Agent 创建 operator…',
+      hiddenOperators: (count) => `另有 ${count} 个 operator`,
+      progress: (settled, total) => `${settled}/${total} 已结束`,
+      status: (status) =>
+        ({
+          empty: '等待调度',
+          active: '运行中',
+          closing: '收尾中',
+          waiting: '等待中',
+          stopped: '已停止',
+          failed: '失败',
+          completed: '已完成',
+        })[status],
+      operatorStatus: (status) =>
+        ({
+          not_started: '未启动',
+          waiting: '等待',
+          runnable: '可运行',
+          running: '运行中',
+          blocked: '受阻',
+          completed: '完成',
+          failed: '失败',
+          aborted: '中止',
+          cancelled: '取消',
+        })[status],
+      wait: waitReasonZh,
+    };
+  }
+  return {
+    title: 'Agent Graph',
+    loading: 'Loading graph state…',
+    retry: 'Retry',
+    stop: 'Stop graph',
+    stopping: 'Stopping…',
+    stopFailed: 'Could not stop the graph. Try again.',
+    openSession: 'Open child session',
+    operators: 'Operators',
+    selectedResults: 'Selected results',
+    noOperators: 'Waiting for the main agent to create an operator…',
+    hiddenOperators: (count) => `${count} more operator${count === 1 ? '' : 's'}`,
+    progress: (settled, total) => `${settled}/${total} settled`,
+    status: (status) =>
+      ({
+        empty: 'Awaiting schedule',
+        active: 'Running',
+        closing: 'Finishing',
+        waiting: 'Waiting',
+        stopped: 'Stopped',
+        failed: 'Failed',
+        completed: 'Completed',
+      })[status],
+    operatorStatus: (status) =>
+      ({
+        not_started: 'Not started',
+        waiting: 'Waiting',
+        runnable: 'Runnable',
+        running: 'Running',
+        blocked: 'Blocked',
+        completed: 'Completed',
+        failed: 'Failed',
+        aborted: 'Aborted',
+        cancelled: 'Cancelled',
+      })[status],
+    wait: waitReasonEn,
+  };
+}
+
+export function AgentGraphPanel(props: {
+  rootSessionId: string;
+  enabled: boolean;
+  locale: UiLocale;
+  onOpenSession(sessionId: string): void;
+}): JSX.Element | null {
+  const [snapshot, setSnapshot] = useState<AgentGraphClientSnapshot>();
+  const [loading, setLoading] = useState(props.enabled);
+  const [error, setError] = useState(false);
+  const [stopPending, setStopPending] = useState(false);
+  const [stopError, setStopError] = useState(false);
+  const copy = getAgentGraphPanelCopy(props.locale);
+
+  useEffect(() => {
+    let disposed = false;
+    let queued = false;
+    let task: Promise<void> | undefined;
+
+    setSnapshot(undefined);
+    setError(false);
+    setStopError(false);
+    setLoading(props.enabled);
+
+    const refresh = (): void => {
+      if (disposed) return;
+      if (task) {
+        queued = true;
+        return;
+      }
+      task = window.maka.graphs
+        .getSnapshot(props.rootSessionId)
+        .then((next) => {
+          if (!disposed) {
+            setSnapshot(next);
+            setError(false);
+          }
+        })
+        .catch(() => {
+          if (!disposed && props.enabled) setError(true);
+        })
+        .finally(() => {
+          if (disposed) return;
+          setLoading(false);
+          task = undefined;
+          if (queued) {
+            queued = false;
+            refresh();
+          }
+        });
+    };
+
+    const unsubscribe = window.maka.graphs.subscribe(props.rootSessionId, refresh);
+    refresh();
+    return () => {
+      disposed = true;
+      unsubscribe();
+    };
+  }, [props.rootSessionId, props.enabled]);
+
+  const progress = useMemo(() => {
+    const settled = snapshot?.operators.filter((operator) =>
+      ['completed', 'failed', 'aborted', 'cancelled'].includes(operator.status),
+    ).length ?? 0;
+    return { settled, total: snapshot?.operators.length ?? 0 };
+  }, [snapshot]);
+
+  const hasGraphActivity =
+    snapshot !== undefined &&
+    (snapshot.scheduleRevision > 0 ||
+      snapshot.operators.length > 0 ||
+      snapshot.omitted.operators > 0);
+  if (!props.enabled && !hasGraphActivity) return null;
+
+  const stopGraph = async (): Promise<void> => {
+    if (stopPending) return;
+    setStopPending(true);
+    setStopError(false);
+    try {
+      await window.maka.graphs.stop(props.rootSessionId);
+    } catch {
+      setStopError(true);
+    } finally {
+      setStopPending(false);
+    }
+  };
+  const stopAvailable =
+    snapshot !== undefined && ['active', 'waiting', 'closing'].includes(snapshot.status);
+
+  return (
+    <section className="maka-agent-graph-panel" aria-label={copy.title}>
+      <header className="maka-agent-graph-heading">
+        <div>
+          <strong>{copy.title}</strong>
+          {snapshot ? (
+            <span className="maka-agent-graph-progress">
+              {copy.status(snapshot.status)} · {copy.progress(progress.settled, progress.total)}
+            </span>
+          ) : null}
+        </div>
+        {stopAvailable ? (
+          <button
+            type="button"
+            className="maka-agent-graph-stop"
+            disabled={stopPending}
+            onClick={() => void stopGraph()}
+          >
+            {stopPending ? copy.stopping : copy.stop}
+          </button>
+        ) : null}
+      </header>
+      {stopError ? (
+        <p className="maka-agent-graph-error" role="alert">
+          {copy.stopFailed}
+        </p>
+      ) : null}
+
+      {loading && !snapshot ? <p className="maka-agent-graph-empty">{copy.loading}</p> : null}
+      {error && !snapshot ? (
+        <button
+          type="button"
+          className="maka-agent-graph-retry"
+          onClick={() => {
+            setLoading(true);
+            window.maka.graphs
+              .getSnapshot(props.rootSessionId)
+              .then((next) => {
+                setSnapshot(next);
+                setError(false);
+              })
+              .catch(() => setError(true))
+              .finally(() => setLoading(false));
+          }}
+        >
+          {copy.retry}
+        </button>
+      ) : null}
+
+      {snapshot ? (
+        <>
+          <div className="maka-agent-graph-section-label">{copy.operators}</div>
+          {snapshot.operators.length === 0 ? (
+            <p className="maka-agent-graph-empty">{copy.noOperators}</p>
+          ) : (
+            <ul className="maka-agent-graph-operators">
+              {snapshot.operators.slice(0, 8).map((operator) => {
+                const wait = copy.wait(operator);
+                const work = snapshot.work.find((candidate) =>
+                  operator.scheduledWorkIds.includes(candidate.workId),
+                );
+                return (
+                  <li key={operator.operatorId} data-status={operator.status}>
+                    <span className="maka-agent-graph-status-dot" aria-hidden="true" />
+                    <span className="maka-agent-graph-operator-copy">
+                      <strong>{operator.agentId}</strong>
+                      <span>{work?.instructionPreview ?? operator.operatorId}</span>
+                      {wait ? <span className="maka-agent-graph-wait">{wait}</span> : null}
+                    </span>
+                    <span className="maka-agent-graph-operator-status">
+                      {copy.operatorStatus(operator.status)}
+                    </span>
+                    <button
+                      type="button"
+                      className="maka-agent-graph-open"
+                      onClick={() => props.onOpenSession(operator.childSessionId)}
+                    >
+                      {copy.openSession}
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+          {snapshot.operators.length > 8 || snapshot.omitted.operators > 0 ? (
+            <div className="maka-agent-graph-omitted">
+              {copy.hiddenOperators(
+                Math.max(0, snapshot.operators.length - 8) + snapshot.omitted.operators,
+              )}
+            </div>
+          ) : null}
+          {snapshot.finish ? (
+            <div className="maka-agent-graph-results">
+              <span>{copy.selectedResults}</span>
+              <code>{snapshot.finish.resultIds.join(', ')}</code>
+            </div>
+          ) : null}
+        </>
+      ) : null}
+    </section>
+  );
+}
+
+function firstWait(operator: AgentGraphClientOperator) {
+  return operator.readiness.find((readiness) => readiness.status === 'waiting')?.waitingFor[0];
+}
+
+function waitReasonEn(operator: AgentGraphClientOperator): string | undefined {
+  const wait = firstWait(operator);
+  if (!wait) return undefined;
+  if (wait.kind === 'input_route') {
+    return `Waiting for input from ${wait.upstreamOperatorIds.join(', ')}`;
+  }
+  if (wait.kind === 'activation_missing') {
+    return `Waiting for ${wait.operatorId} activation`;
+  }
+  return `Waiting for ${wait.operatorId} to settle`;
+}
+
+function waitReasonZh(operator: AgentGraphClientOperator): string | undefined {
+  const wait = firstWait(operator);
+  if (!wait) return undefined;
+  if (wait.kind === 'input_route') {
+    return `等待 ${wait.upstreamOperatorIds.join('、')} 的输入`;
+  }
+  if (wait.kind === 'activation_missing') {
+    return `等待 ${wait.operatorId} activation`;
+  }
+  return `等待 ${wait.operatorId} 结束`;
+}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -24,6 +24,7 @@ import {
   collapseSessionRevisions,
   filterLinkedSessionTree,
   hasSettledInitialOnboarding,
+  parseGraphCommand,
   parseSwarmCommand,
   projectRevisionLinkedSessionTree,
   resolveUiLocale,
@@ -49,6 +50,7 @@ import {
 import { useKeyboardHelp } from './keyboard-help';
 import { useCommandPalette } from './command-palette';
 import { ChatMessageSurface } from './chat-message-surface';
+import { AgentGraphPanel } from './agent-graph-panel';
 import { ChatComposerRegion } from './chat-composer-region';
 import { ChatWorkbar } from './chat-workbar';
 import {
@@ -240,6 +242,7 @@ function AppShellContent({
   const [newChatQuickChatMode, setNewChatQuickChatMode] = useState<QuickChatMode | undefined>();
   const [pendingCollaborationModeBySession, setPendingCollaborationModeBySession] = useState<Record<string, boolean>>({});
   const [newChatSwarmModeActive, setNewChatSwarmModeActive] = useState(false);
+  const [newChatGraphModeActive, setNewChatGraphModeActive] = useState(false);
   const [pendingOrchestrationModeBySession, setPendingOrchestrationModeBySession] = useState<Record<string, boolean>>({});
   // P3: session ids with a live embedded-browser view. The right-side
   // BrowserPanel mounts only for these, so ordinary chats reserve no space.
@@ -667,6 +670,7 @@ function AppShellContent({
     const sessionId = activeIdRef.current;
     if (!sessionId) {
       setNewChatSwarmModeActive(active);
+      if (active) setNewChatGraphModeActive(false);
       return true;
     }
     if (!addPendingSessionAction(
@@ -688,6 +692,44 @@ function AppShellContent({
         toastApi.error(
           shellCopy.swarmModeFailedTitle,
           localizedShellErrorMessage(error, shellCopy.swarmModeFallback, uiLocale),
+        );
+      }
+      return false;
+    } finally {
+      clearPendingSessionAction(
+        sessionId,
+        orchestrationModeChangeRegistry.keysRef,
+        setPendingOrchestrationModeBySession,
+      );
+    }
+  }
+
+  async function setGraphMode(active: boolean): Promise<boolean> {
+    const sessionId = activeIdRef.current;
+    if (!sessionId) {
+      setNewChatGraphModeActive(active);
+      if (active) setNewChatSwarmModeActive(false);
+      return true;
+    }
+    if (!addPendingSessionAction(
+      sessionId,
+      orchestrationModeChangeRegistry.keysRef,
+      setPendingOrchestrationModeBySession,
+    )) return false;
+
+    try {
+      const next = await window.maka.sessions.setOrchestrationMode(
+        sessionId,
+        active ? 'graph' : 'default',
+      );
+      setSessions((current) => current.map((session) => session.id === next.id ? next : session));
+      await refreshSessions();
+      return true;
+    } catch (error) {
+      if (activeIdRef.current === sessionId) {
+        toastApi.error(
+          shellCopy.graphModeFailedTitle,
+          localizedShellErrorMessage(error, shellCopy.graphModeFallback, uiLocale),
         );
       }
       return false;
@@ -1121,7 +1163,11 @@ function AppShellContent({
     validPendingNewChatModel,
     pendingNewChatThinkingLevel: newChatThinkingLevel ?? null,
     newChatCollaborationMode: newChatPlanModeActive ? 'plan' : 'agent',
-    newChatOrchestrationMode: newChatSwarmModeActive ? 'swarm' : 'default',
+    newChatOrchestrationMode: newChatGraphModeActive
+      ? 'graph'
+      : newChatSwarmModeActive
+        ? 'swarm'
+        : 'default',
   });
 
   const { handleTurnFooterAction } = useStableActions(createAppShellTurnActions, {
@@ -1167,6 +1213,7 @@ function AppShellContent({
       revision && activeIdRef.current === revision.draftSessionId,
     );
     const swarmCommand = parseSwarmCommand(text);
+    const graphCommand = parseGraphCommand(text);
     if (
       revisionSend &&
       revision &&
@@ -1184,7 +1231,7 @@ function AppShellContent({
         toastApi.info(actionCopy.revisionUnavailableTitle, actionCopy.revisionAttachmentsUnsupported);
         return false;
       }
-      if ((skillIds.length === 0 && text.trim() === '/compact') || swarmCommand) {
+      if ((skillIds.length === 0 && text.trim() === '/compact') || swarmCommand || graphCommand) {
         toastApi.info(actionCopy.revisionUnavailableTitle, actionCopy.revisionCommandUnsupported);
         return false;
       }
@@ -1237,6 +1284,40 @@ function AppShellContent({
       const ok = await send(swarmCommand.task, pending, {
         ...(skillIds.length > 0 ? { skillIds } : {}),
         turnOrchestration: { mode: 'swarm', source: 'slash_command' },
+        ...(quotes ? { quotes } : {}),
+      });
+      if (ok !== false && pending) clearSubmittedAttachments(pending);
+      if (ok !== false && quotes) clearQuotes();
+      return ok;
+    }
+    if (graphCommand) {
+      if (graphCommand.kind === 'status') {
+        const active = activeIdRef.current
+          ? (activeSessionForView?.orchestrationMode ?? 'default') === 'graph'
+          : newChatGraphModeActive;
+        toastApi.info(
+          active ? shellCopy.graphModeEnabledTitle : shellCopy.graphModeDisabledTitle,
+          shellCopy.graphModeStatusDescription,
+        );
+        return true;
+      }
+      if (graphCommand.kind === 'set_mode') {
+        const changed = await setGraphMode(graphCommand.mode === 'graph');
+        if (changed) {
+          toastApi.info(
+            graphCommand.mode === 'graph'
+              ? shellCopy.graphModeEnabledTitle
+              : shellCopy.graphModeDisabledTitle,
+            shellCopy.graphModeStatusDescription,
+          );
+        }
+        return changed;
+      }
+      const pending = pendingAttachments.length > 0 ? pendingAttachments : undefined;
+      const quotes = pendingQuotes.length > 0 ? pendingQuotes : undefined;
+      const ok = await send(graphCommand.task, pending, {
+        ...(skillIds.length > 0 ? { skillIds } : {}),
+        turnOrchestration: { mode: 'graph', source: 'slash_command' },
         ...(quotes ? { quotes } : {}),
       });
       if (ok !== false && pending) clearSubmittedAttachments(pending);
@@ -1880,6 +1961,14 @@ function AppShellContent({
                 conversationItems={planConversationItems}
               />
               )}
+              {navSelection.section === 'sessions' && activeId ? (
+                <AgentGraphPanel
+                  rootSessionId={activeId}
+                  enabled={(activeSessionForView?.orchestrationMode ?? 'default') === 'graph'}
+                  locale={uiLocale}
+                  onOpenSession={openSessionInChat}
+                />
+              ) : null}
               {navSelection.section === 'sessions' && (
                 <PlanExecutionPanel planMode={planMode} />
               )}
@@ -2044,6 +2133,24 @@ function AppShellContent({
                 }
                 onSwarmModeChange={(active) => {
                   void setSwarmMode(active);
+                }}
+                graphModeActive={activeId
+                  ? (activeSessionForView?.orchestrationMode ?? 'default') === 'graph'
+                  : newChatGraphModeActive}
+                graphModePending={activeId ? pendingOrchestrationModeBySession[activeId] === true : false}
+                graphModeDisabledReason={
+                  activeId && pendingOrchestrationModeBySession[activeId] === true
+                    ? shellCopy.graphModeChanging
+                    : activeStreamingLive
+                        ? shellCopy.graphModeStreaming
+                      : activeId && activeSessionForView?.status === 'running'
+                          ? shellCopy.graphModeRunning
+                        : activeId && activeSessionForView?.status === 'waiting_for_user'
+                            ? shellCopy.graphModeWaiting
+                          : undefined
+                }
+                onGraphModeChange={(active) => {
+                  void setGraphMode(active);
                 }}
               />
             </div>

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1961,7 +1961,10 @@ function AppShellContent({
                 conversationItems={planConversationItems}
               />
               )}
-              {navSelection.section === 'sessions' && activeId ? (
+              {navSelection.section === 'sessions' &&
+              activeId &&
+              activeSessionForView &&
+              !activeSessionForView.subagentParent ? (
                 <AgentGraphPanel
                   rootSessionId={activeId}
                   enabled={(activeSessionForView?.orchestrationMode ?? 'default') === 'graph'}

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -433,6 +433,15 @@ type ShellCopy = {
     swarmModeEnabledTitle: string;
     swarmModeDisabledTitle: string;
     swarmModeStatusDescription: string;
+    graphModeChanging: string;
+    graphModeStreaming: string;
+    graphModeRunning: string;
+    graphModeWaiting: string;
+    graphModeFailedTitle: string;
+    graphModeFallback: string;
+    graphModeEnabledTitle: string;
+    graphModeDisabledTitle: string;
+    graphModeStatusDescription: string;
     resizeWorkbar: string;
   };
 };
@@ -1105,6 +1114,15 @@ const SHELL_COPY_BY_LOCALE = {
       swarmModeEnabledTitle: 'Swarm Mode 已开启',
       swarmModeDisabledTitle: 'Swarm Mode 未开启',
       swarmModeStatusDescription: '使用 /swarm on、/swarm off，或 /swarm <任务> 单次运行。',
+      graphModeChanging: 'Graph Mode 正在切换，完成后再继续操作。',
+      graphModeStreaming: '当前对话正在流式输出，等结束后再切换 Graph Mode。',
+      graphModeRunning: '当前对话正在运行，等结束后再切换 Graph Mode。',
+      graphModeWaiting: '当前有工具调用正在等待确认，处理后再切换 Graph Mode。',
+      graphModeFailedTitle: '切换 Graph Mode 失败',
+      graphModeFallback: 'Graph Mode 暂时无法切换，请稍后重试。',
+      graphModeEnabledTitle: 'Graph Mode 已开启',
+      graphModeDisabledTitle: 'Graph Mode 未开启',
+      graphModeStatusDescription: '使用 /graph on、/graph off，或 /graph <任务> 单次运行。',
       resizeWorkbar: '调整会话工作栏宽度',
     },
   },
@@ -1606,6 +1624,15 @@ const SHELL_COPY_BY_LOCALE = {
       swarmModeEnabledTitle: 'Swarm Mode is on',
       swarmModeDisabledTitle: 'Swarm Mode is off',
       swarmModeStatusDescription: 'Use /swarm on, /swarm off, or /swarm <task> for one turn.',
+      graphModeChanging: 'Graph Mode is changing. Wait for it to finish before continuing.',
+      graphModeStreaming: 'This conversation is streaming. Wait for it to finish before changing Graph Mode.',
+      graphModeRunning: 'This conversation is running. Wait for it to finish before changing Graph Mode.',
+      graphModeWaiting: 'A tool call is waiting for confirmation. Respond before changing Graph Mode.',
+      graphModeFailedTitle: 'Could not change Graph Mode',
+      graphModeFallback: 'Graph Mode could not be changed. Try again later.',
+      graphModeEnabledTitle: 'Graph Mode is on',
+      graphModeDisabledTitle: 'Graph Mode is off',
+      graphModeStatusDescription: 'Use /graph on, /graph off, or /graph <task> for one turn.',
       resizeWorkbar: 'Resize conversation workbar',
     },
   },

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -24,6 +24,7 @@
 @import "./styles/chat-header.css";
 @import "./styles/task-ledger.css";
 @import "./styles/plan-mode.css";
+@import "./styles/agent-graph.css";
 @import "./styles/error.css";
 @import "./styles/toast.css";
 @import "./styles/help.css";

--- a/apps/desktop/src/renderer/styles/agent-graph.css
+++ b/apps/desktop/src/renderer/styles/agent-graph.css
@@ -1,0 +1,169 @@
+.maka-agent-graph-panel {
+  width: min(var(--maka-chat-measure), calc(100% - var(--space-8)));
+  max-height: min(300px, 36vh);
+  margin: var(--space-2) auto;
+  padding: var(--space-3);
+  overflow: auto;
+  border: var(--border-width-hairline) solid var(--border);
+  border-radius: var(--radius-surface);
+  background: var(--background-elevated);
+  box-shadow: 0 8px 24px oklch(from var(--foreground) l c h / 0.05);
+  color: var(--foreground);
+}
+
+.maka-agent-graph-heading,
+.maka-agent-graph-heading > div,
+.maka-agent-graph-results {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+}
+
+.maka-agent-graph-heading {
+  justify-content: space-between;
+}
+
+.maka-agent-graph-heading strong {
+  font-size: var(--font-size-ui);
+  font-weight: var(--font-weight-semibold);
+}
+
+.maka-agent-graph-progress,
+.maka-agent-graph-section-label,
+.maka-agent-graph-empty,
+.maka-agent-graph-error,
+.maka-agent-graph-omitted,
+.maka-agent-graph-results {
+  color: var(--muted-foreground);
+  font-size: var(--font-size-caption);
+  line-height: var(--leading-snug);
+}
+
+.maka-agent-graph-error {
+  margin: var(--space-2) 0 0;
+  color: var(--destructive-text);
+}
+
+.maka-agent-graph-section-label {
+  margin-top: var(--space-3);
+  margin-bottom: var(--space-1);
+  font-weight: var(--font-weight-medium);
+}
+
+.maka-agent-graph-operators {
+  display: grid;
+  gap: var(--space-1);
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.maka-agent-graph-operators li {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto auto;
+  align-items: center;
+  gap: var(--space-2);
+  min-height: var(--h-control-md);
+  padding: var(--space-1-5) var(--space-2);
+  border-radius: var(--radius-control);
+  background: var(--foreground-2);
+}
+
+.maka-agent-graph-status-dot {
+  width: 7px;
+  height: 7px;
+  border-radius: var(--radius-pill);
+  background: var(--muted-foreground);
+}
+
+.maka-agent-graph-operators li[data-status="running"] .maka-agent-graph-status-dot,
+.maka-agent-graph-operators li[data-status="runnable"] .maka-agent-graph-status-dot {
+  background: var(--status-running);
+}
+
+.maka-agent-graph-operators li[data-status="completed"] .maka-agent-graph-status-dot {
+  background: var(--success);
+}
+
+.maka-agent-graph-operators li[data-status="failed"] .maka-agent-graph-status-dot,
+.maka-agent-graph-operators li[data-status="aborted"] .maka-agent-graph-status-dot {
+  background: var(--destructive);
+}
+
+.maka-agent-graph-operator-copy {
+  min-width: 0;
+  display: grid;
+  gap: var(--space-0-5);
+}
+
+.maka-agent-graph-operator-copy strong,
+.maka-agent-graph-operator-copy span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.maka-agent-graph-operator-copy strong {
+  font-size: var(--font-size-ui);
+  font-weight: var(--font-weight-medium);
+}
+
+.maka-agent-graph-operator-copy span,
+.maka-agent-graph-operator-status,
+.maka-agent-graph-open,
+.maka-agent-graph-stop,
+.maka-agent-graph-retry {
+  font-size: var(--font-size-caption);
+  line-height: var(--leading-snug);
+}
+
+.maka-agent-graph-wait {
+  color: var(--warning-text);
+}
+
+.maka-agent-graph-operator-status {
+  color: var(--muted-foreground);
+  white-space: nowrap;
+}
+
+.maka-agent-graph-open,
+.maka-agent-graph-stop,
+.maka-agent-graph-retry {
+  min-height: var(--h-control-sm);
+  padding: 0 var(--space-2);
+  border: var(--border-width-hairline) solid var(--border);
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--foreground);
+}
+
+.maka-agent-graph-open:hover,
+.maka-agent-graph-stop:hover,
+.maka-agent-graph-retry:hover {
+  background: var(--state-hover-bg);
+}
+
+.maka-agent-graph-results {
+  align-items: baseline;
+  margin-top: var(--space-2);
+}
+
+.maka-agent-graph-results code {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--foreground-secondary);
+  font-family: var(--font-mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+@media (max-width: 720px) {
+  .maka-agent-graph-operators li {
+    grid-template-columns: auto minmax(0, 1fr) auto;
+  }
+
+  .maka-agent-graph-operator-status {
+    display: none;
+  }
+}

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -177,7 +177,7 @@ export interface MakaPiTranscriptMetadata {
   model: string;
   connectionSlug: string;
   permissionMode: string;
-  orchestrationMode?: 'default' | 'swarm';
+  orchestrationMode?: 'default' | 'swarm' | 'graph';
   thinkingLevel?: ThinkingLevel;
   thinkingLevels?: readonly ThinkingLevel[];
   sessionId?: string | null;
@@ -1278,6 +1278,8 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
   }
   if (metadata.orchestrationMode === 'swarm') {
     parts.push(ansi.accent('swarm'));
+  } else if (metadata.orchestrationMode === 'graph') {
+    parts.push(ansi.accent('graph'));
   }
   const usage = metadata.usage;
   if (usage) {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -44,6 +44,7 @@
     "./agent-graph-schedule": "./dist/agent-graph-schedule.js",
     "./agent-graph-topology": "./dist/agent-graph-topology.js",
     "./agent-graph-client-projection": "./dist/agent-graph-client-projection.js",
+    "./agent-graph-supervisor-wake": "./dist/agent-graph-supervisor-wake.js",
     "./task-ledger": "./dist/task-ledger.js",
     "./foreign-session": "./dist/foreign-session.js",
     "./deep-research-run": "./dist/deep-research-run.js",

--- a/packages/core/src/__tests__/graph-command.test.ts
+++ b/packages/core/src/__tests__/graph-command.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { parseGraphCommand } from '../graph-command.js';
+
+describe('/graph parser', () => {
+  test('parses bare and explicit status commands', () => {
+    assert.deepEqual(parseGraphCommand('/graph'), { kind: 'status' });
+    assert.deepEqual(parseGraphCommand('  /graph status  '), { kind: 'status' });
+  });
+
+  test('parses persistent mode changes only when the whole tail matches', () => {
+    assert.deepEqual(parseGraphCommand('/graph on'), { kind: 'set_mode', mode: 'graph' });
+    assert.deepEqual(parseGraphCommand('/graph off'), { kind: 'set_mode', mode: 'default' });
+    assert.deepEqual(parseGraphCommand('/graph on the repository'), {
+      kind: 'run_once',
+      task: 'on the repository',
+    });
+  });
+
+  test('preserves a one-shot task as clean user text', () => {
+    assert.deepEqual(parseGraphCommand('/graph inspect runtime, UI, and tests'), {
+      kind: 'run_once',
+      task: 'inspect runtime, UI, and tests',
+    });
+  });
+
+  test('does not claim lookalike slash commands', () => {
+    assert.equal(parseGraphCommand('/graphing now'), null);
+    assert.equal(parseGraphCommand('please /graph this'), null);
+  });
+});

--- a/packages/core/src/__tests__/orchestration.test.ts
+++ b/packages/core/src/__tests__/orchestration.test.ts
@@ -24,6 +24,14 @@ describe('orchestration contract', () => {
     });
   });
 
+  test('graph mode preserves the graph identity without granting swarm authority', () => {
+    assert.deepEqual(resolveEffectiveOrchestration('graph', undefined), {
+      mode: 'graph',
+      source: 'session',
+      agentSwarmAuthorization: 'none',
+    });
+  });
+
   test('a trusted turn override wins without changing the persisted session mode', () => {
     assert.deepEqual(
       resolveEffectiveOrchestration('default', { mode: 'swarm', source: 'host_api' }),
@@ -45,6 +53,7 @@ describe('orchestration contract', () => {
 
   test('validators accept only the public contract values', () => {
     assert.equal(isOrchestrationMode('swarm'), true);
+    assert.equal(isOrchestrationMode('graph'), true);
     assert.equal(isOrchestrationMode('parallel'), false);
     assert.equal(isTurnOrchestrationSource('slash_command'), true);
     assert.equal(isTurnOrchestrationSource('model_text'), false);

--- a/packages/core/src/__tests__/runtime-event.test.ts
+++ b/packages/core/src/__tests__/runtime-event.test.ts
@@ -46,7 +46,8 @@ describe('RuntimeEvent role / author / status enums', () => {
   });
 
   test('locks the author enum (agent ≠ model) and guard', () => {
-    expect(RUNTIME_EVENT_AUTHORS).toEqual(['user', 'agent', 'tool', 'system']);
+    expect(RUNTIME_EVENT_AUTHORS).toEqual(['user', 'host', 'agent', 'tool', 'system']);
+    expect(isRuntimeEventAuthor('host')).toBe(true);
     expect(isRuntimeEventAuthor('agent')).toBe(true);
     expect(isRuntimeEventAuthor('model')).toBe(false);
     expect(isRuntimeEventAuthor(null)).toBe(false);

--- a/packages/core/src/agent-graph-supervisor-wake.ts
+++ b/packages/core/src/agent-graph-supervisor-wake.ts
@@ -3,6 +3,7 @@ export const AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION = 1 as const;
 export type AgentGraphSupervisorWakeStatus =
   | 'pending'
   | 'running'
+  | 'waiting_permission'
   | 'delivered'
   | 'retryable_failed';
 
@@ -26,7 +27,7 @@ export interface AgentGraphSupervisorWakeAttemptRecord {
   wakeId: string;
   attemptId: string;
   turnId: string;
-  status: 'running' | 'delivered' | 'retryable_failed';
+  status: 'running' | 'waiting_permission' | 'delivered' | 'retryable_failed';
   failureReason?: string;
   startedAt: number;
   completedAt?: number;
@@ -51,7 +52,7 @@ export interface CompleteAgentGraphSupervisorWakeAttemptRequest {
   graphId: string;
   wakeId: string;
   attemptId: string;
-  status: 'delivered' | 'retryable_failed';
+  status: 'waiting_permission' | 'delivered' | 'retryable_failed';
   failureReason?: string;
 }
 
@@ -77,6 +78,7 @@ export interface AgentGraphSupervisorWakeStore {
     graphId: string,
     wakeId: string,
   ): Promise<AgentGraphSupervisorWakeAttemptRecord[]>;
+  listUnsettledAgentGraphSupervisorWakes(): Promise<AgentGraphSupervisorWakeRecord[]>;
   listRetryableAgentGraphSupervisorWakes(): Promise<AgentGraphSupervisorWakeRecord[]>;
   recoverAgentGraphSupervisorWakes(): Promise<number>;
 }

--- a/packages/core/src/agent-graph-supervisor-wake.ts
+++ b/packages/core/src/agent-graph-supervisor-wake.ts
@@ -1,0 +1,82 @@
+export const AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION = 1 as const;
+
+export type AgentGraphSupervisorWakeStatus =
+  | 'pending'
+  | 'running'
+  | 'delivered'
+  | 'retryable_failed';
+
+export interface AgentGraphSupervisorWakeRecord {
+  schemaVersion: typeof AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION;
+  graphId: string;
+  wakeId: string;
+  snapshotVersion: string;
+  rootSessionId: string;
+  status: AgentGraphSupervisorWakeStatus;
+  attemptCount: number;
+  currentAttemptId?: string;
+  currentTurnId?: string;
+  failureReason?: string;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface AgentGraphSupervisorWakeAttemptRecord {
+  graphId: string;
+  wakeId: string;
+  attemptId: string;
+  turnId: string;
+  status: 'running' | 'delivered' | 'retryable_failed';
+  failureReason?: string;
+  startedAt: number;
+  completedAt?: number;
+}
+
+export interface ClaimAgentGraphSupervisorWakeRequest {
+  schemaVersion: typeof AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION;
+  graphId: string;
+  wakeId: string;
+  snapshotVersion: string;
+  rootSessionId: string;
+}
+
+export interface BeginAgentGraphSupervisorWakeAttemptRequest {
+  graphId: string;
+  wakeId: string;
+  attemptId: string;
+  turnId: string;
+}
+
+export interface CompleteAgentGraphSupervisorWakeAttemptRequest {
+  graphId: string;
+  wakeId: string;
+  attemptId: string;
+  status: 'delivered' | 'retryable_failed';
+  failureReason?: string;
+}
+
+export interface AgentGraphSupervisorWakeStore {
+  claimAgentGraphSupervisorWake(
+    request: ClaimAgentGraphSupervisorWakeRequest,
+  ): Promise<{ wake: AgentGraphSupervisorWakeRecord; created: boolean }>;
+  beginAgentGraphSupervisorWakeAttempt(
+    request: BeginAgentGraphSupervisorWakeAttemptRequest,
+  ): Promise<{
+    wake: AgentGraphSupervisorWakeRecord;
+    attempt?: AgentGraphSupervisorWakeAttemptRecord;
+    acquired: boolean;
+  }>;
+  completeAgentGraphSupervisorWakeAttempt(
+    request: CompleteAgentGraphSupervisorWakeAttemptRequest,
+  ): Promise<AgentGraphSupervisorWakeRecord>;
+  readAgentGraphSupervisorWake(
+    graphId: string,
+    wakeId: string,
+  ): Promise<AgentGraphSupervisorWakeRecord | undefined>;
+  listAgentGraphSupervisorWakeAttempts(
+    graphId: string,
+    wakeId: string,
+  ): Promise<AgentGraphSupervisorWakeAttemptRecord[]>;
+  listRetryableAgentGraphSupervisorWakes(): Promise<AgentGraphSupervisorWakeRecord[]>;
+  recoverAgentGraphSupervisorWakes(): Promise<number>;
+}

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -81,6 +81,8 @@ export interface AgentRunHeader {
   continuationSource?: AgentRunContinuationSource;
   /** Non-user trigger for this run (e.g. a scheduled automation fire). */
   automationId?: string;
+  /** Durable graph milestone that caused this host-authored supervisor turn. */
+  agentGraphWakeId?: string;
   failureClass?: string;
   failureMessage?: string;
   abortSource?: string;
@@ -190,6 +192,7 @@ const AGENT_RUN_HEADER_SHAPE = defineObjectShape<AgentRunHeader>()(
     'workspaceIdentity',
     'continuationSource',
     'automationId',
+    'agentGraphWakeId',
     'failureClass',
     'failureMessage',
     'abortSource',
@@ -243,6 +246,7 @@ export function decodeAgentRunHeader(value: unknown): AgentRunHeader {
       value.parentSessionId,
       value.workspaceIdentity,
       value.automationId,
+      value.agentGraphWakeId,
       value.failureClass,
       value.failureMessage,
       value.abortSource,

--- a/packages/core/src/agent-run.ts
+++ b/packages/core/src/agent-run.ts
@@ -83,6 +83,8 @@ export interface AgentRunHeader {
   automationId?: string;
   /** Durable graph milestone that caused this host-authored supervisor turn. */
   agentGraphWakeId?: string;
+  /** Durable delivery attempt for this host-authored supervisor turn. */
+  agentGraphWakeAttemptId?: string;
   failureClass?: string;
   failureMessage?: string;
   abortSource?: string;
@@ -193,6 +195,7 @@ const AGENT_RUN_HEADER_SHAPE = defineObjectShape<AgentRunHeader>()(
     'continuationSource',
     'automationId',
     'agentGraphWakeId',
+    'agentGraphWakeAttemptId',
     'failureClass',
     'failureMessage',
     'abortSource',
@@ -247,6 +250,7 @@ export function decodeAgentRunHeader(value: unknown): AgentRunHeader {
       value.workspaceIdentity,
       value.automationId,
       value.agentGraphWakeId,
+      value.agentGraphWakeAttemptId,
       value.failureClass,
       value.failureMessage,
       value.abortSource,

--- a/packages/core/src/graph-command.ts
+++ b/packages/core/src/graph-command.ts
@@ -1,0 +1,19 @@
+import type { OrchestrationMode } from './orchestration.js';
+
+export type ParsedGraphCommand =
+  | { kind: 'status' }
+  | { kind: 'set_mode'; mode: OrchestrationMode }
+  | { kind: 'run_once'; task: string };
+
+/** Parse the exact `/graph` command without treating lookalike prompts as commands. */
+export function parseGraphCommand(input: string): ParsedGraphCommand | null {
+  const trimmed = input.trim();
+  const commandToken = trimmed.split(/\s+/, 1)[0] ?? '';
+  if (commandToken !== '/graph') return null;
+
+  const tail = trimmed.slice(commandToken.length).trim();
+  if (!tail || tail === 'status') return { kind: 'status' };
+  if (tail === 'on') return { kind: 'set_mode', mode: 'graph' };
+  if (tail === 'off') return { kind: 'set_mode', mode: 'default' };
+  return { kind: 'run_once', task: tail };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -11,6 +11,7 @@ export * from './mcp.js';
 export * from './collaboration.js';
 export * from './orchestration.js';
 export * from './swarm-command.js';
+export * from './graph-command.js';
 export * from './plan.js';
 export * from './agent-graph-control.js';
 export * from './agent-graph-schedule.js';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export * from './agent-graph-control.js';
 export * from './agent-graph-schedule.js';
 export * from './agent-graph-topology.js';
 export * from './agent-graph-client-projection.js';
+export * from './agent-graph-supervisor-wake.js';
 export * from './runtime-policy.js';
 
 // events.ts

--- a/packages/core/src/orchestration.ts
+++ b/packages/core/src/orchestration.ts
@@ -1,4 +1,4 @@
-export const ORCHESTRATION_MODES = ['default', 'swarm'] as const;
+export const ORCHESTRATION_MODES = ['default', 'swarm', 'graph'] as const;
 
 export type OrchestrationMode = (typeof ORCHESTRATION_MODES)[number];
 

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -65,7 +65,7 @@ export function isRuntimeEventRole(value: unknown): value is RuntimeEventRole {
  * Not every (author, role) combination is meaningful, but the runtime —
  * not this type module — owns the policy that constrains them.
  */
-export const RUNTIME_EVENT_AUTHORS = ['user', 'agent', 'tool', 'system'] as const;
+export const RUNTIME_EVENT_AUTHORS = ['user', 'host', 'agent', 'tool', 'system'] as const;
 export type RuntimeEventAuthor = (typeof RUNTIME_EVENT_AUTHORS)[number];
 
 export function isRuntimeEventAuthor(value: unknown): value is RuntimeEventAuthor {
@@ -552,9 +552,10 @@ function isTurnOrigin(value: unknown): value is TurnOrigin {
   }
   return (
     value.kind === 'agent_graph' &&
-    Object.keys(value).length === 3 &&
+    Object.keys(value).length === 4 &&
     typeof value.graphId === 'string' &&
-    typeof value.wakeId === 'string'
+    typeof value.wakeId === 'string' &&
+    typeof value.attemptId === 'string'
   );
 }
 

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -15,6 +15,7 @@
  */
 
 import type { AttachmentRef, QuoteRef } from './events.js';
+import type { TurnOrigin } from './runtime-inputs.js';
 import type { PermissionRequestPayload, PermissionResponse } from './permission.js';
 import type { UserQuestionRequest } from './user-question.js';
 import type {
@@ -119,6 +120,8 @@ export interface RuntimeEventTextContent {
    * only; UI/transcript/rewind projections should prefer it when present.
    */
   displayText?: string;
+  /** Durable provenance for a host-authored user-role turn. */
+  origin?: TurnOrigin;
   /**
    * Optional user-bound attachments carried with the text turn. Adapters
    * MUST preserve these when converting legacy UserMessage rows so
@@ -380,7 +383,7 @@ const RUNTIME_EVENT_SHAPE = defineObjectShape<RuntimeEvent>()(
 );
 const TEXT_CONTENT_SHAPE = defineObjectShape<RuntimeEventTextContent>()(
   ['kind', 'text'],
-  ['displayText', 'attachments', 'quotes', 'steering'],
+  ['displayText', 'origin', 'attachments', 'quotes', 'steering'],
 );
 const THINKING_CONTENT_SHAPE = defineObjectShape<RuntimeEventThinkingContent>()(
   ['kind', 'text'],
@@ -502,6 +505,7 @@ function isRuntimeEventContent(value: unknown): value is RuntimeEventContent {
         hasExactShape(value, TEXT_CONTENT_SHAPE) &&
         typeof value.text === 'string' &&
         isOptionalString(value.displayText) &&
+        (value.origin === undefined || isTurnOrigin(value.origin)) &&
         (value.attachments === undefined ||
           (Array.isArray(value.attachments) && value.attachments.every(isAttachmentRef))) &&
         (value.steering === undefined || value.steering === true)
@@ -539,6 +543,19 @@ function isRuntimeEventContent(value: unknown): value is RuntimeEventContent {
     default:
       return false;
   }
+}
+
+function isTurnOrigin(value: unknown): value is TurnOrigin {
+  if (!isRecord(value)) return false;
+  if (value.kind === 'automation') {
+    return Object.keys(value).length === 2 && typeof value.automationId === 'string';
+  }
+  return (
+    value.kind === 'agent_graph' &&
+    Object.keys(value).length === 3 &&
+    typeof value.graphId === 'string' &&
+    typeof value.wakeId === 'string'
+  );
 }
 
 function isRuntimeEventActions(value: unknown): value is RuntimeEventActions {

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -88,8 +88,15 @@ export interface UserMessageInput {
   origin?: TurnOrigin;
 }
 
-/** Non-user trigger source for a turn (e.g. a scheduled automation fire). */
-export type TurnOrigin = { kind: 'automation'; automationId: string };
+/** Non-user trigger source for a turn. */
+export type TurnOrigin =
+  | { kind: 'automation'; automationId: string }
+  | {
+      kind: 'agent_graph';
+      graphId: string;
+      /** Durable, graph-snapshot-scoped idempotency key for this supervisor wake. */
+      wakeId: string;
+    };
 
 export interface AgentSpec {
   id: string;

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -96,6 +96,8 @@ export type TurnOrigin =
       graphId: string;
       /** Durable, graph-snapshot-scoped idempotency key for this supervisor wake. */
       wakeId: string;
+      /** Durable identity of one delivery attempt for the wake. */
+      attemptId: string;
     };
 
 export interface AgentSpec {

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -600,7 +600,7 @@ export interface UserMessage {
    *  hand-type. Mirrors TurnOrigin in runtime-inputs. */
   origin?:
     | { kind: 'automation'; automationId: string }
-    | { kind: 'agent_graph'; graphId: string; wakeId: string };
+    | { kind: 'agent_graph'; graphId: string; wakeId: string; attemptId: string };
 }
 
 /** Prefer the human-facing view of a user message when one was stored. */
@@ -840,7 +840,7 @@ type AutomationOrigin = Extract<MessageOrigin, { kind: 'automation' }>;
 type AgentGraphOrigin = Extract<MessageOrigin, { kind: 'agent_graph' }>;
 const AUTOMATION_ORIGIN_SHAPE = defineObjectShape<AutomationOrigin>()(['kind', 'automationId'], []);
 const AGENT_GRAPH_ORIGIN_SHAPE = defineObjectShape<AgentGraphOrigin>()(
-  ['kind', 'graphId', 'wakeId'],
+  ['kind', 'graphId', 'wakeId', 'attemptId'],
   [],
 );
 
@@ -1015,7 +1015,8 @@ function isAgentGraphOrigin(value: unknown): value is AgentGraphOrigin {
     hasExactShape(value, AGENT_GRAPH_ORIGIN_SHAPE) &&
     value.kind === 'agent_graph' &&
     typeof value.graphId === 'string' &&
-    typeof value.wakeId === 'string'
+    typeof value.wakeId === 'string' &&
+    typeof value.attemptId === 'string'
   );
 }
 

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -596,9 +596,11 @@ export interface UserMessage {
   attachments?: AttachmentRef[];
   /** Inline quoted excerpts carried into this message; rendered as chips. */
   quotes?: QuoteRef[];
-  /** Non-user trigger source (automation fire). Lets the chat mark turns the
-   *  user did not hand-type. Mirrors TurnOrigin in runtime-inputs. */
-  origin?: { kind: 'automation'; automationId: string };
+  /** Non-user trigger source. Lets the chat mark turns the user did not
+   *  hand-type. Mirrors TurnOrigin in runtime-inputs. */
+  origin?:
+    | { kind: 'automation'; automationId: string }
+    | { kind: 'agent_graph'; graphId: string; wakeId: string };
 }
 
 /** Prefer the human-facing view of a user message when one was stored. */
@@ -833,8 +835,14 @@ const SYSTEM_NOTE_MESSAGE_SHAPE = defineObjectShape<SystemNoteMessage>()(
 );
 type AssistantThinking = NonNullable<AssistantMessage['thinking']>;
 const ASSISTANT_THINKING_SHAPE = defineObjectShape<AssistantThinking>()(['text'], ['signature']);
-type AutomationOrigin = NonNullable<UserMessage['origin']>;
+type MessageOrigin = NonNullable<UserMessage['origin']>;
+type AutomationOrigin = Extract<MessageOrigin, { kind: 'automation' }>;
+type AgentGraphOrigin = Extract<MessageOrigin, { kind: 'agent_graph' }>;
 const AUTOMATION_ORIGIN_SHAPE = defineObjectShape<AutomationOrigin>()(['kind', 'automationId'], []);
+const AGENT_GRAPH_ORIGIN_SHAPE = defineObjectShape<AgentGraphOrigin>()(
+  ['kind', 'graphId', 'wakeId'],
+  [],
+);
 
 const SYSTEM_NOTE_KINDS = new Set([
   'session_start',
@@ -871,7 +879,7 @@ function decodeStoredMessage(
         isOptionalString(message.displayText) &&
         (message.attachments === undefined ||
           (Array.isArray(message.attachments) && message.attachments.every(isAttachmentRef))) &&
-        (message.origin === undefined || isAutomationOrigin(message.origin))
+        (message.origin === undefined || isMessageOrigin(message.origin))
       )
         return message as unknown as UserMessage;
       break;
@@ -999,6 +1007,20 @@ function isAutomationOrigin(value: unknown): value is AutomationOrigin {
     value.kind === 'automation' &&
     typeof value.automationId === 'string'
   );
+}
+
+function isAgentGraphOrigin(value: unknown): value is AgentGraphOrigin {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, AGENT_GRAPH_ORIGIN_SHAPE) &&
+    value.kind === 'agent_graph' &&
+    typeof value.graphId === 'string' &&
+    typeof value.wakeId === 'string'
+  );
+}
+
+function isMessageOrigin(value: unknown): value is MessageOrigin {
+  return isAutomationOrigin(value) || isAgentGraphOrigin(value);
 }
 
 function isOptionalFiniteDuration(value: unknown): boolean {

--- a/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
+++ b/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { createSqliteSessionMetadataStore } from '@maka/storage';
+import { AgentGraphSupervisorWakeCoordinator } from '../agent-graph-supervisor-wake.js';
+import { SessionActivityRegistry, type GoalTurnOutcome } from '../goal-turn-lifecycle.js';
+import type { AgentGraphClientSnapshot } from '../stream-graph-read-model.js';
+import type { AgentGraphScheduleReconciliationResult } from '../stream-graph-schedule-reconcile.js';
+
+describe('Agent Graph supervisor wake delivery', () => {
+  test('retries failures before and after prompt persistence, delivering only a completed turn', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    const persistedAttempts: string[] = [];
+    let attempt = 0;
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async () => snapshot(),
+      startTurn: async (_sessionId, input): Promise<GoalTurnOutcome> => {
+        attempt += 1;
+        if (attempt === 1) throw new Error('failed before prompt persistence');
+        persistedAttempts.push(input.origin?.kind === 'agent_graph' ? input.origin.attemptId : '');
+        if (attempt === 2) {
+          return { kind: 'errored', turnId: input.turnId, reason: 'provider failed' };
+        }
+        return { kind: 'completed', turnId: input.turnId };
+      },
+      newId: sequentialIds(),
+    });
+    try {
+      coordinator.notify('root-session', reconciliation());
+      await coordinator.waitForIdle();
+      const wake = await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1');
+      assert.equal(wake?.status, 'delivered');
+      assert.equal(wake?.attemptCount, 3);
+      assert.equal(new Set(persistedAttempts).size, 2);
+      assert.deepEqual(
+        (await store.listAgentGraphSupervisorWakeAttempts('graph-1', 'graph-1:snapshot-1')).map(
+          (candidate) => candidate.status,
+        ),
+        ['retryable_failed', 'retryable_failed', 'delivered'],
+      );
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
+
+  test('retries a suspended outcome instead of treating its persisted prompt as delivery', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    let attempt = 0;
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async () => snapshot(),
+      startTurn: async (_sessionId, input): Promise<GoalTurnOutcome> => {
+        attempt += 1;
+        return attempt === 1
+          ? { kind: 'suspended', turnId: input.turnId, reason: 'permission handoff' }
+          : { kind: 'completed', turnId: input.turnId };
+      },
+      newId: sequentialIds(),
+    });
+    try {
+      coordinator.notify('root-session', reconciliation());
+      await coordinator.waitForIdle();
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.attemptCount,
+        2,
+      );
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
+
+  test('recovers a crash-interrupted running attempt and redelivers it', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    await store.claimAgentGraphSupervisorWake({
+      schemaVersion: 1,
+      graphId: 'graph-1',
+      wakeId: 'graph-1:snapshot-1',
+      snapshotVersion: 'snapshot-1',
+      rootSessionId: 'root-session',
+    });
+    await store.beginAgentGraphSupervisorWakeAttempt({
+      graphId: 'graph-1',
+      wakeId: 'graph-1:snapshot-1',
+      attemptId: 'crashed-attempt',
+      turnId: 'crashed-turn',
+    });
+    let delivered = 0;
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async () => snapshot(),
+      startTurn: async (_sessionId, input) => {
+        delivered += 1;
+        return { kind: 'completed', turnId: input.turnId };
+      },
+      newId: sequentialIds(),
+    });
+    try {
+      assert.equal(await coordinator.recover(), 1);
+      await coordinator.waitForIdle();
+      assert.equal(delivered, 1);
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.status,
+        'delivered',
+      );
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
+
+  test('close aborts a queued activity acquisition and never starts a turn afterward', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    const activities = new SessionActivityRegistry();
+    const busy = activities.reserve('root-session');
+    let turns = 0;
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: activities,
+      wakeStore: store,
+      readSnapshot: async () => snapshot(),
+      startTurn: async (_sessionId, input) => {
+        turns += 1;
+        return { kind: 'completed', turnId: input.turnId };
+      },
+      newId: sequentialIds(),
+    });
+    try {
+      coordinator.notify('root-session', reconciliation());
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      await coordinator.close();
+      busy.release();
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(turns, 0);
+    } finally {
+      busy.release();
+      await coordinator.close();
+      store.close();
+    }
+  });
+});
+
+function snapshot(): AgentGraphClientSnapshot {
+  return {
+    schemaVersion: 1,
+    rootSessionId: 'root-session',
+    graphId: 'graph-1',
+    snapshotVersion: 'snapshot-1',
+    status: 'waiting',
+    scheduleRevision: 1,
+    topologyFingerprint: 'topology-1',
+    closed: false,
+    operators: [],
+    edges: [],
+    work: [],
+    stoppedTargets: [],
+    claims: [],
+    recentControlDecisions: [],
+    recentActivity: [],
+    terminalHistory: { records: [] },
+    omitted: {
+      operators: 0,
+      edges: 0,
+      work: 0,
+      stoppedTargets: 0,
+      claims: 0,
+      controlDecisions: 0,
+      recentActivity: 0,
+    },
+  };
+}
+
+function reconciliation(): AgentGraphScheduleReconciliationResult {
+  return {
+    status: 'reconciled',
+    dispatches: [{}],
+    failures: [],
+  } as unknown as AgentGraphScheduleReconciliationResult;
+}
+
+function sequentialIds(): () => string {
+  let value = 0;
+  return () => `id-${++value}`;
+}

--- a/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
+++ b/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
@@ -78,6 +78,83 @@ describe('Agent Graph supervisor wake delivery', () => {
     }
   });
 
+  test('retries a parked attempt only after its permission response loses the live waiter', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    let attempt = 0;
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async () => snapshot(),
+      startTurn: async (_sessionId, input): Promise<GoalTurnOutcome> => {
+        attempt += 1;
+        return attempt === 1
+          ? { kind: 'suspended', turnId: input.turnId, reason: 'permission handoff' }
+          : { kind: 'completed', turnId: input.turnId };
+      },
+      inspectAttempt: async () => 'waiting_permission',
+      newId: sequentialIds(),
+    });
+    try {
+      coordinator.notify('root-session', reconciliation());
+      await coordinator.waitForIdle();
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.status,
+        'waiting_permission',
+      );
+
+      coordinator.notifyPermissionResponse('root-session');
+      await coordinator.waitForIdle();
+
+      const wake = await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1');
+      assert.equal(wake?.status, 'delivered');
+      assert.equal(wake?.attemptCount, 2);
+      assert.deepEqual(
+        (await store.listAgentGraphSupervisorWakeAttempts('graph-1', 'graph-1:snapshot-1')).map(
+          (candidate) => candidate.status,
+        ),
+        ['retryable_failed', 'delivered'],
+      );
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
+
+  test('does not strand a permission response racing the suspended wake commit', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    let attempt = 0;
+    let coordinator!: AgentGraphSupervisorWakeCoordinator;
+    coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async () => snapshot(),
+      startTurn: async (_sessionId, input, activity): Promise<GoalTurnOutcome> => {
+        attempt += 1;
+        if (attempt === 1) {
+          activity.release();
+          coordinator.notifyPermissionResponse('root-session');
+          await new Promise<void>((resolve) => setImmediate(resolve));
+          return { kind: 'suspended', turnId: input.turnId, reason: 'permission handoff' };
+        }
+        return { kind: 'completed', turnId: input.turnId };
+      },
+      inspectAttempt: async () => 'waiting_permission',
+      newId: sequentialIds(),
+    });
+    try {
+      coordinator.notify('root-session', reconciliation());
+      await coordinator.waitForIdle();
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.status,
+        'delivered',
+      );
+      assert.equal(attempt, 2);
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
+
   test('recovers a crash-interrupted running attempt and redelivers it', async () => {
     const store = createSqliteSessionMetadataStore(':memory:');
     await store.claimAgentGraphSupervisorWake({
@@ -148,7 +225,7 @@ describe('Agent Graph supervisor wake delivery', () => {
     }
   });
 
-  test('keeps a recovered waiting-permission AgentRun parked', async () => {
+  test('retries a recovered waiting-permission attempt after its live waiter is lost', async () => {
     const store = createSqliteSessionMetadataStore(':memory:');
     await createRunningAttempt(store);
     let delivered = 0;
@@ -166,10 +243,10 @@ describe('Agent Graph supervisor wake delivery', () => {
     try {
       assert.equal(await coordinator.recover(), 1);
       await coordinator.waitForIdle();
-      assert.equal(delivered, 0);
+      assert.equal(delivered, 1);
       assert.equal(
         (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.status,
-        'waiting_permission',
+        'delivered',
       );
     } finally {
       await coordinator.close();

--- a/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
+++ b/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
@@ -24,6 +24,7 @@ describe('Agent Graph supervisor wake delivery', () => {
         }
         return { kind: 'completed', turnId: input.turnId };
       },
+      inspectAttempt: async () => 'missing',
       newId: sequentialIds(),
     });
     try {
@@ -45,7 +46,7 @@ describe('Agent Graph supervisor wake delivery', () => {
     }
   });
 
-  test('retries a suspended outcome instead of treating its persisted prompt as delivery', async () => {
+  test('parks a suspended outcome without redelivering its persisted prompt', async () => {
     const store = createSqliteSessionMetadataStore(':memory:');
     let attempt = 0;
     const coordinator = new AgentGraphSupervisorWakeCoordinator({
@@ -54,10 +55,9 @@ describe('Agent Graph supervisor wake delivery', () => {
       readSnapshot: async () => snapshot(),
       startTurn: async (_sessionId, input): Promise<GoalTurnOutcome> => {
         attempt += 1;
-        return attempt === 1
-          ? { kind: 'suspended', turnId: input.turnId, reason: 'permission handoff' }
-          : { kind: 'completed', turnId: input.turnId };
+        return { kind: 'suspended', turnId: input.turnId, reason: 'permission handoff' };
       },
+      inspectAttempt: async () => 'waiting_permission',
       newId: sequentialIds(),
     });
     try {
@@ -65,8 +65,13 @@ describe('Agent Graph supervisor wake delivery', () => {
       await coordinator.waitForIdle();
       assert.equal(
         (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.attemptCount,
-        2,
+        1,
       );
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.status,
+        'waiting_permission',
+      );
+      assert.equal(attempt, 1);
     } finally {
       await coordinator.close();
       store.close();
@@ -97,6 +102,7 @@ describe('Agent Graph supervisor wake delivery', () => {
         delivered += 1;
         return { kind: 'completed', turnId: input.turnId };
       },
+      inspectAttempt: async () => 'failed',
       newId: sequentialIds(),
     });
     try {
@@ -106,6 +112,64 @@ describe('Agent Graph supervisor wake delivery', () => {
       assert.equal(
         (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.status,
         'delivered',
+      );
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
+
+  test('converges a completed crash-window AgentRun without duplicate delivery', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    await createRunningAttempt(store);
+    let delivered = 0;
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async () => snapshot(),
+      startTurn: async (_sessionId, input) => {
+        delivered += 1;
+        return { kind: 'completed', turnId: input.turnId };
+      },
+      inspectAttempt: async () => 'completed',
+      newId: sequentialIds(),
+    });
+    try {
+      assert.equal(await coordinator.recover(), 1);
+      await coordinator.waitForIdle();
+      assert.equal(delivered, 0);
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.status,
+        'delivered',
+      );
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
+
+  test('keeps a recovered waiting-permission AgentRun parked', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    await createRunningAttempt(store);
+    let delivered = 0;
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async () => snapshot(),
+      startTurn: async (_sessionId, input) => {
+        delivered += 1;
+        return { kind: 'completed', turnId: input.turnId };
+      },
+      inspectAttempt: async () => 'waiting_permission',
+      newId: sequentialIds(),
+    });
+    try {
+      assert.equal(await coordinator.recover(), 1);
+      await coordinator.waitForIdle();
+      assert.equal(delivered, 0);
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.status,
+        'waiting_permission',
       );
     } finally {
       await coordinator.close();
@@ -126,6 +190,7 @@ describe('Agent Graph supervisor wake delivery', () => {
         turns += 1;
         return { kind: 'completed', turnId: input.turnId };
       },
+      inspectAttempt: async () => 'missing',
       newId: sequentialIds(),
     });
     try {
@@ -141,7 +206,65 @@ describe('Agent Graph supervisor wake delivery', () => {
       store.close();
     }
   });
+
+  test('close aborts an in-flight wake turn and leaves its attempt retryable', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    const started = deferred();
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async () => snapshot(),
+      startTurn: async (_sessionId, input, _activity, abortSignal) => {
+        started.resolve();
+        await new Promise<void>((resolve) => {
+          if (abortSignal.aborted) resolve();
+          else abortSignal.addEventListener('abort', () => resolve(), { once: true });
+        });
+        return { kind: 'aborted', turnId: input.turnId };
+      },
+      inspectAttempt: async () => 'missing',
+      newId: sequentialIds(),
+    });
+    try {
+      coordinator.notify('root-session', reconciliation());
+      await started.promise;
+      await coordinator.close();
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.status,
+        'retryable_failed',
+      );
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
 });
+
+async function createRunningAttempt(
+  store: ReturnType<typeof createSqliteSessionMetadataStore>,
+): Promise<void> {
+  await store.claimAgentGraphSupervisorWake({
+    schemaVersion: 1,
+    graphId: 'graph-1',
+    wakeId: 'graph-1:snapshot-1',
+    snapshotVersion: 'snapshot-1',
+    rootSessionId: 'root-session',
+  });
+  await store.beginAgentGraphSupervisorWakeAttempt({
+    graphId: 'graph-1',
+    wakeId: 'graph-1:snapshot-1',
+    attemptId: 'crashed-attempt',
+    turnId: 'crashed-turn',
+  });
+}
+
+function deferred(): { promise: Promise<void>; resolve(): void } {
+  let resolve!: () => void;
+  const promise = new Promise<void>((next) => {
+    resolve = next;
+  });
+  return { promise, resolve };
+}
 
 function snapshot(): AgentGraphClientSnapshot {
   return {

--- a/packages/runtime/src/__tests__/agent-run-recovery.test.ts
+++ b/packages/runtime/src/__tests__/agent-run-recovery.test.ts
@@ -4,7 +4,7 @@ import type { AgentRunHeader } from '@maka/core';
 import { classifyAgentRunRecovery } from '../agent-run-recovery.js';
 
 describe('AgentRun startup recovery', () => {
-  test('leaves a graph supervisor wake permission handoff parked', () => {
+  test('fails a graph supervisor permission handoff once its live waiter is lost', () => {
     const header: AgentRunHeader = {
       runId: 'run-1',
       sessionId: 'session-1',
@@ -21,6 +21,9 @@ describe('AgentRun startup recovery', () => {
       updatedAt: 2,
     };
 
-    assert.equal(classifyAgentRunRecovery(header, []), undefined);
+    const decision = classifyAgentRunRecovery(header, []);
+    assert.equal(decision?.status, 'failed');
+    assert.equal(decision?.failureClass, 'app_restarted');
+    assert.equal(decision?.diagnostic?.recoveryReason, 'stale_permission_wait');
   });
 });

--- a/packages/runtime/src/__tests__/agent-run-recovery.test.ts
+++ b/packages/runtime/src/__tests__/agent-run-recovery.test.ts
@@ -1,0 +1,26 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { AgentRunHeader } from '@maka/core';
+import { classifyAgentRunRecovery } from '../agent-run-recovery.js';
+
+describe('AgentRun startup recovery', () => {
+  test('leaves a graph supervisor wake permission handoff parked', () => {
+    const header: AgentRunHeader = {
+      runId: 'run-1',
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      status: 'waiting_permission',
+      backendKind: 'fake',
+      llmConnectionSlug: 'fake',
+      modelId: 'fake-model',
+      cwd: '/tmp/workspace',
+      permissionMode: 'ask',
+      agentGraphWakeId: 'wake-1',
+      agentGraphWakeAttemptId: 'attempt-1',
+      createdAt: 1,
+      updatedAt: 2,
+    };
+
+    assert.equal(classifyAgentRunRecovery(header, []), undefined);
+  });
+});

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -383,7 +383,7 @@ describe('AiSdkBackend deferred agent tools', () => {
     assert.match(capturedPrompts[0] ?? '', /only tool in its assistant step/);
   });
 
-  test('Graph Mode injects the supervisor prompt and pins graph controls at step 0', async () => {
+  test('Graph Mode injects the supervisor prompt and pins controls plus agent output at step 0', async () => {
     const capturedTools: string[][] = [];
     const capturedPrompts: string[] = [];
     const graphTools: MakaTool[] = [
@@ -420,16 +420,6 @@ describe('AiSdkBackend deferred agent tools', () => {
     });
 
     const backend = agentBackend(model, [], {
-      toolAvailability: {
-        economy: true,
-        groups: [
-          {
-            id: 'graph',
-            label: 'Agent graph controls',
-            toolNames: ['view_agent_graph', 'update_agent_graph'],
-          },
-        ],
-      },
       extraTools: graphTools,
     });
     await drain(
@@ -447,6 +437,7 @@ describe('AiSdkBackend deferred agent tools', () => {
 
     assert.ok(capturedTools[0]?.includes('view_agent_graph'));
     assert.ok(capturedTools[0]?.includes('update_agent_graph'));
+    assert.ok(capturedTools[0]?.includes(AGENT_OUTPUT_TOOL_NAME));
     assert.match(capturedPrompts[0] ?? '', /Orchestration Mode: Graph/);
     assert.match(capturedPrompts[0] ?? '', /supervisor beside the data path/);
   });

--- a/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
+++ b/packages/runtime/src/__tests__/deferred-tools-backend.test.ts
@@ -78,6 +78,7 @@ interface BackendOpts {
   toolAvailability?: ToolAvailabilityConfig | null;
   recordLlmCall?: (record: LlmCallRecord) => void;
   durable?: ReturnType<typeof createDurableTurnHarness>;
+  extraTools?: readonly MakaTool[];
 }
 
 function backend(
@@ -122,7 +123,7 @@ function agentBackend(
     modelId: 'mock-model-id',
     permissionEngine: new PermissionEngine({ newId: () => 'perm', now: () => 1 }),
     modelFactory: () => model,
-    tools: buildParentAgentTools(),
+    tools: [...buildParentAgentTools(), ...(opts.extraTools ?? [])],
     ...(opts.durable ? { loadTurnRuntimeEvents: opts.durable.loadTurnRuntimeEvents } : {}),
     ...(resolved ? { toolAvailability: resolved } : {}),
     spawnChildSession: async (input) => {
@@ -380,6 +381,74 @@ describe('AiSdkBackend deferred agent tools', () => {
     assert.match(capturedPrompts[0] ?? '', /preferred default execution strategy/);
     assert.match(capturedPrompts[0] ?? '', /You may continue directly/);
     assert.match(capturedPrompts[0] ?? '', /only tool in its assistant step/);
+  });
+
+  test('Graph Mode injects the supervisor prompt and pins graph controls at step 0', async () => {
+    const capturedTools: string[][] = [];
+    const capturedPrompts: string[] = [];
+    const graphTools: MakaTool[] = [
+      {
+        name: 'view_agent_graph',
+        description: 'View graph',
+        parameters: z.object({}),
+        permissionRequired: false,
+        impl: () => ({ ok: true }),
+      },
+      {
+        name: 'update_agent_graph',
+        description: 'Update graph',
+        parameters: z.object({}),
+        permissionRequired: false,
+        impl: () => ({ ok: true }),
+      },
+    ];
+    const model = new MockLanguageModelV4({
+      doStream: async ({ tools: stepTools, prompt }) => {
+        capturedTools.push((stepTools ?? []).map((tool) => tool.name));
+        capturedPrompts.push(JSON.stringify(prompt));
+        return {
+          stream: convertArrayToReadableStream<LanguageModelV4StreamPart>([
+            { type: 'stream-start', warnings: [] },
+            {
+              type: 'finish',
+              finishReason: { unified: 'stop', raw: 'stop' },
+              usage: ZERO_USAGE,
+            },
+          ]),
+        };
+      },
+    });
+
+    const backend = agentBackend(model, [], {
+      toolAvailability: {
+        economy: true,
+        groups: [
+          {
+            id: 'graph',
+            label: 'Agent graph controls',
+            toolNames: ['view_agent_graph', 'update_agent_graph'],
+          },
+        ],
+      },
+      extraTools: graphTools,
+    });
+    await drain(
+      backend.send({
+        turnId: 'turn-graph-mode',
+        text: 'coordinate the graph',
+        context: [],
+        orchestration: {
+          mode: 'graph',
+          source: 'turn_override',
+          agentSwarmAuthorization: 'none',
+        },
+      }),
+    );
+
+    assert.ok(capturedTools[0]?.includes('view_agent_graph'));
+    assert.ok(capturedTools[0]?.includes('update_agent_graph'));
+    assert.match(capturedPrompts[0] ?? '', /Orchestration Mode: Graph/);
+    assert.match(capturedPrompts[0] ?? '', /supervisor beside the data path/);
   });
 
   test('agent tools are hidden by default and visible after load_tools(agent)', async () => {

--- a/packages/runtime/src/__tests__/goal-turn-lifecycle.test.ts
+++ b/packages/runtime/src/__tests__/goal-turn-lifecycle.test.ts
@@ -52,6 +52,19 @@ describe('Goal turn lifecycle', () => {
     assert.equal(registry.whenIdle('session-1'), undefined);
   });
 
+  test('aborts a queued exclusive admission without acquiring after the session becomes idle', async () => {
+    const registry = new SessionActivityRegistry();
+    const busy = registry.reserve('session-1');
+    const controller = new AbortController();
+    const queued = registry.acquire('session-1', controller.signal);
+    controller.abort();
+    await assert.rejects(queued, (error: unknown) => {
+      return error instanceof Error && error.name === 'AbortError';
+    });
+    busy.release();
+    assert.equal(registry.whenIdle('session-1'), undefined);
+  });
+
   test('projects terminal permission handoff as suspended', async () => {
     async function* events(): AsyncIterable<SessionEvent> {
       yield complete('turn-1', 'permission_handoff');

--- a/packages/runtime/src/__tests__/goal-turn-lifecycle.test.ts
+++ b/packages/runtime/src/__tests__/goal-turn-lifecycle.test.ts
@@ -78,6 +78,18 @@ describe('Goal turn lifecycle', () => {
     });
   });
 
+  test('settles a permission handoff from the later terminal event in the same stream', async () => {
+    async function* events(): AsyncIterable<SessionEvent> {
+      yield complete('turn-1', 'permission_handoff');
+      yield complete('turn-1', 'end_turn');
+    }
+
+    assert.deepEqual(await drainGoalTurn({ events: events(), turnId: 'turn-1' }), {
+      kind: 'completed',
+      turnId: 'turn-1',
+    });
+  });
+
   test('classifies continuation outcomes at the lifecycle boundary', async () => {
     const turnId = 'turn-1';
     const cases: Array<{

--- a/packages/runtime/src/__tests__/graph-mode.test.ts
+++ b/packages/runtime/src/__tests__/graph-mode.test.ts
@@ -1,0 +1,16 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { renderGraphModePrompt } from '../graph-mode.js';
+
+describe('Graph Mode shared prompt', () => {
+  test('keeps the supervisor beside the data path and requires committed results', () => {
+    const prompt = renderGraphModePrompt();
+    assert.match(prompt, /main-agent supervisor beside the data path/);
+    assert.match(prompt, /update_agent_graph/);
+    assert.match(prompt, /view_agent_graph/);
+    assert.match(prompt, /committed record ids/);
+    assert.match(prompt, /agent_output/);
+    assert.match(prompt, /childSessionId and currentRunId/);
+    assert.match(prompt, /Stay available to the user/);
+  });
+});

--- a/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
@@ -191,6 +191,32 @@ describe('storedMessageToRuntimeEvent', () => {
     });
   });
 
+  test('host-authored user-role messages preserve their canonical provenance', () => {
+    const e = storedMessageToRuntimeEvent(
+      {
+        ...user('u-graph', 'graph checkpoint'),
+        origin: {
+          kind: 'agent_graph',
+          graphId: 'graph-1',
+          wakeId: 'wake-1',
+          attemptId: 'attempt-1',
+        },
+      },
+      ctx,
+    );
+    expect(e?.role).toBe('user');
+    expect(e?.author).toBe('host');
+    expect(e?.content).toMatchObject({
+      kind: 'text',
+      origin: {
+        kind: 'agent_graph',
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        attemptId: 'attempt-1',
+      },
+    });
+  });
+
   test('user message displayText round-trips through RuntimeEvent draft projection', () => {
     const typed = '/skill:alpha 帮我整理';
     const envelope = 'The user explicitly invoked…\n\n<user-message>\n帮我整理\n</user-message>';

--- a/packages/runtime/src/__tests__/runtime-event-backfill.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-backfill.test.ts
@@ -57,6 +57,41 @@ describe('runtime event backfill', () => {
     expect(result.events.map((event) => event.invocationId)).toEqual(['persisted-invocation']);
   });
 
+  test('backfills a host-authored graph wake without attributing it to the user', () => {
+    const result = backfillRuntimeEventsFromStoredMessages({
+      run,
+      messages: [
+        {
+          type: 'user',
+          id: 'legacy-graph-wake',
+          turnId: 'turn-1',
+          ts: 101,
+          text: 'graph checkpoint',
+          origin: {
+            kind: 'agent_graph',
+            graphId: 'graph-1',
+            wakeId: 'wake-1',
+            attemptId: 'attempt-1',
+          },
+        },
+      ],
+      newId: nextIds(),
+      now: () => 999,
+    });
+
+    expect(result.events[0]?.role).toBe('user');
+    expect(result.events[0]?.author).toBe('host');
+    expect(result.events[0]?.content).toMatchObject({
+      kind: 'text',
+      origin: {
+        kind: 'agent_graph',
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        attemptId: 'attempt-1',
+      },
+    });
+  });
+
   test('backfills only low-risk RuntimeEvents from legacy StoredMessage rows', () => {
     const messages: StoredMessage[] = [
       {

--- a/packages/runtime/src/__tests__/runtime-runner.test.ts
+++ b/packages/runtime/src/__tests__/runtime-runner.test.ts
@@ -1,6 +1,11 @@
 import { describe, test } from 'node:test';
 import { expect } from '../test-helpers.js';
-import { RuntimeRunner, runtimeGateFromCallback, type RuntimeGate } from '../runtime-runner.js';
+import {
+  RuntimeRunner,
+  buildInitialUserRuntimeEvent,
+  runtimeGateFromCallback,
+  type RuntimeGate,
+} from '../runtime-runner.js';
 import type { AttachmentRef } from '@maka/core/events';
 import type {
   InvocationContext,
@@ -213,6 +218,36 @@ describe('RuntimeRunner', () => {
     // The flow event follows the user event and is on a different lane.
     expect(result.events[1]!.role).toBe('model');
     expect(result.events[1]!.author).toBe('agent');
+  });
+
+  test('preserves a host-authored initial user-role RuntimeEvent', async () => {
+    const providers = makeProviders();
+    const flow = new ScriptFlow((ctx) => [flowTerminalEvent(ctx, 'completed')]);
+    const runner = new RuntimeRunner({ flow, providers });
+    const request = makeRequest({
+      text: 'graph checkpoint',
+      initialRuntimeEvent: buildInitialUserRuntimeEvent({
+        id: 'evt-host',
+        invocationId: 'inv-host',
+        runId: 'run-host',
+        sessionId: 'sess-1',
+        turnId: 'turn-1',
+        ts: 1,
+        text: 'graph checkpoint',
+        origin: {
+          kind: 'agent_graph',
+          graphId: 'graph-1',
+          wakeId: 'wake-1',
+          attemptId: 'attempt-1',
+        },
+      }),
+    });
+
+    const result = await runner.run(request);
+
+    expect(result.events[0]?.role).toBe('user');
+    expect(result.events[0]?.author).toBe('host');
+    expect(result.events[0]?.content?.kind).toBe('text');
   });
 
   test('initial event declares the tool boundary protocol only when the durable boundary is active', async () => {

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -88,17 +88,22 @@ describe('host-managed agent graph coordinator', () => {
       delayedControlStore = createDelayableControlStore(controlStore);
       const activities = new SessionActivityRegistry();
       let supervisorWakeTurnCount = 0;
+      const supervisorWakeErrors: unknown[] = [];
       supervisorWake = new AgentGraphSupervisorWakeCoordinator({
         activityRegistry: activities,
-        readMessages: (sessionId) => manager.getMessages(sessionId),
+        wakeStore: delayedControlStore.store,
         readSnapshot: (sessionId) => (coordinator ?? recovered)!.getSnapshot(sessionId),
         startTurn: async (sessionId, input) => {
           supervisorWakeTurnCount += 1;
           for await (const _event of manager.sendMessage(sessionId, input)) {
             // A real root AgentRun consumes the durable graph wake prompt.
           }
+          return { kind: 'completed', turnId: input.turnId };
         },
         newId: randomUUID,
+        onError: (_rootSessionId, error) => {
+          supervisorWakeErrors.push(error);
+        },
       });
       coordinator = createCoordinator({
         sessionStore,
@@ -159,6 +164,7 @@ describe('host-managed agent graph coordinator', () => {
       );
       originalSupervisorActivity.release();
       await supervisorWake.waitForIdle();
+      assert.deepEqual(supervisorWakeErrors, []);
       assert.equal(supervisorWakeTurnCount, 1);
       const graphWake = (await manager.getMessages(rootSession.id)).find(
         (message) => message.type === 'user' && message.origin?.kind === 'agent_graph',
@@ -167,6 +173,7 @@ describe('host-managed agent graph coordinator', () => {
       assert.ok(graphWake.origin?.kind === 'agent_graph');
       assert.equal(graphWake.origin.graphId, agentGraphIdForRootSession(rootSession.id));
       assert.match(graphWake.origin.wakeId, /sha256:[a-f0-9]{64}$/);
+      assert.match(graphWake.origin.attemptId, /^[0-9a-f-]{36}$/);
       assert.match(graphWake.text, /view_agent_graph/);
       assert.ok(
         (await manager.getMessages(rootSession.id)).some(
@@ -174,6 +181,24 @@ describe('host-managed agent graph coordinator', () => {
         ),
         'the original root Agent must run again and produce a deliverable response',
       );
+      const wakeRun = (await runStore.listSessionRuns(rootSession.id)).find(
+        (run) => run.turnId === graphWake.turnId,
+      );
+      assert.ok(wakeRun);
+      assert.equal(wakeRun.agentGraphWakeId, graphWake.origin.wakeId);
+      assert.equal(wakeRun.agentGraphWakeAttemptId, graphWake.origin.attemptId);
+      assert.equal(
+        (await runtimeEventStore.readImmutableRuntimeEvents(rootSession.id, wakeRun.runId))[0]
+          ?.author,
+        'host',
+        'canonical provenance must distinguish the host-authored wake from human input',
+      );
+      const durableWake = await controlStore.readAgentGraphSupervisorWake(
+        graphWake.origin.graphId,
+        graphWake.origin.wakeId,
+      );
+      assert.equal(durableWake?.status, 'delivered');
+      assert.equal(durableWake?.attemptCount, 1);
 
       const firstProvisions = await controlStore.listAgentGraphOperatorProvisions(graphId);
       assert.equal(firstProvisions.length, 1);
@@ -298,6 +323,7 @@ describe('host-managed agent graph coordinator', () => {
       const projectionFailure = new Error('derived projection unavailable');
       const derivedFailures: unknown[] = [];
       delayedControlStore.failProjectionCommits(projectionFailure);
+      assert.equal(await supervisorWake.recover(), 0);
       recovered = createCoordinator({
         sessionStore,
         runStore,

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -14,6 +14,8 @@ import {
 } from '@maka/storage';
 import { FakeBackend } from '../fake-backend.js';
 import { BackendRegistry, SessionManager } from '../session-manager.js';
+import { SessionActivityRegistry } from '../goal-turn-lifecycle.js';
+import { AgentGraphSupervisorWakeCoordinator } from '../agent-graph-supervisor-wake.js';
 import type { MakaTool, MakaToolContext } from '../tool-runtime.js';
 import {
   AgentGraphCoordinator,
@@ -32,9 +34,7 @@ describe('host-managed agent graph coordinator', () => {
     const countedRuntimeEventStore = new Proxy(runtimeEventStore, {
       get(target, property) {
         if (property === 'readImmutableRuntimeEvents') {
-          return async (
-            ...args: Parameters<typeof target.readImmutableRuntimeEvents>
-          ) => {
+          return async (...args: Parameters<typeof target.readImmutableRuntimeEvents>) => {
             graphRuntimeHistoryReads += 1;
             return target.readImmutableRuntimeEvents(...args);
           };
@@ -54,14 +54,11 @@ describe('host-managed agent graph coordinator', () => {
       newId: randomUUID,
       now: Date.now,
     });
-    let controlStore:
-      | ReturnType<typeof createSqliteSessionMetadataStore>
-      | undefined;
+    let controlStore: ReturnType<typeof createSqliteSessionMetadataStore> | undefined;
     let coordinator: AgentGraphCoordinator | undefined;
     let recovered: AgentGraphCoordinator | undefined;
-    let delayedControlStore:
-      | ReturnType<typeof createDelayableControlStore>
-      | undefined;
+    let supervisorWake: AgentGraphSupervisorWakeCoordinator | undefined;
+    let delayedControlStore: ReturnType<typeof createDelayableControlStore> | undefined;
     const clientEvents: string[] = [];
     const transientProjectionErrors: unknown[] = [];
     let unsubscribe: (() => void) | undefined;
@@ -89,12 +86,29 @@ describe('host-managed agent graph coordinator', () => {
         join(root, SQLITE_SESSION_METADATA_DATABASE_NAME),
       );
       delayedControlStore = createDelayableControlStore(controlStore);
+      const activities = new SessionActivityRegistry();
+      let supervisorWakeTurnCount = 0;
+      supervisorWake = new AgentGraphSupervisorWakeCoordinator({
+        activityRegistry: activities,
+        readMessages: (sessionId) => manager.getMessages(sessionId),
+        readSnapshot: (sessionId) => (coordinator ?? recovered)!.getSnapshot(sessionId),
+        startTurn: async (sessionId, input) => {
+          supervisorWakeTurnCount += 1;
+          for await (const _event of manager.sendMessage(sessionId, input)) {
+            // A real root AgentRun consumes the durable graph wake prompt.
+          }
+        },
+        newId: randomUUID,
+      });
       coordinator = createCoordinator({
         sessionStore,
         runStore,
         runtimeEventStore: countedRuntimeEventStore,
         controlStore: delayedControlStore.store,
         manager,
+        onReconciliation: (rootSessionId, result) => {
+          supervisorWake!.notify(rootSessionId, result);
+        },
         onError: (_rootSessionId, error) => {
           transientProjectionErrors.push(error);
         },
@@ -123,10 +137,8 @@ describe('host-managed agent graph coordinator', () => {
           ),
         /not authorized/,
       );
-      assert.equal(
-        (await controlStore.listAgentGraphScheduleUpdates(graphId)).length,
-        0,
-      );
+      assert.equal((await controlStore.listAgentGraphScheduleUpdates(graphId)).length, 0);
+      const originalSupervisorActivity = activities.reserve(rootSession.id);
       await update.impl(
         {
           add_work: [
@@ -140,9 +152,30 @@ describe('host-managed agent graph coordinator', () => {
         toolContext(rootSession.id, sourceRun.runId, sourceTurnId),
       );
       await coordinator.waitForIdle(rootSession.id);
+      assert.equal(
+        supervisorWakeTurnCount,
+        0,
+        'the host wake must wait until the original supervisor turn returns',
+      );
+      originalSupervisorActivity.release();
+      await supervisorWake.waitForIdle();
+      assert.equal(supervisorWakeTurnCount, 1);
+      const graphWake = (await manager.getMessages(rootSession.id)).find(
+        (message) => message.type === 'user' && message.origin?.kind === 'agent_graph',
+      );
+      assert.ok(graphWake?.type === 'user');
+      assert.ok(graphWake.origin?.kind === 'agent_graph');
+      assert.equal(graphWake.origin.graphId, agentGraphIdForRootSession(rootSession.id));
+      assert.match(graphWake.origin.wakeId, /sha256:[a-f0-9]{64}$/);
+      assert.match(graphWake.text, /view_agent_graph/);
+      assert.ok(
+        (await manager.getMessages(rootSession.id)).some(
+          (message) => message.type === 'assistant' && message.turnId === graphWake.turnId,
+        ),
+        'the original root Agent must run again and produce a deliverable response',
+      );
 
-      const firstProvisions =
-        await controlStore.listAgentGraphOperatorProvisions(graphId);
+      const firstProvisions = await controlStore.listAgentGraphOperatorProvisions(graphId);
       assert.equal(firstProvisions.length, 1);
       assert.equal(firstProvisions[0]?.agentId, 'local-read');
       assert.equal((await controlStore.listAgentGraphIntentClaims(graphId)).length, 1);
@@ -161,7 +194,10 @@ describe('host-managed agent graph coordinator', () => {
       assert.equal(snapshot.operators.length, 1);
       assert.equal(snapshot.operators[0]?.childSessionId, childSessions[0]?.id);
       assert.equal(snapshot.operators[0]?.agentId, 'local-read');
-      assert.equal(snapshot.work[0]?.instructionPreview, 'Inspect the repository and report one concrete finding.');
+      assert.equal(
+        snapshot.work[0]?.instructionPreview,
+        'Inspect the repository and report one concrete finding.',
+      );
       assert.match(snapshot.snapshotVersion, /^sha256:[a-f0-9]{64}$/);
       const readsBeforeInspection = delayedControlStore.projectionReadCounts();
       const inspection = await coordinator.inspectOperator(
@@ -187,15 +223,12 @@ describe('host-managed agent graph coordinator', () => {
         2,
         'partial text deltas must not cause projection writes or invalidations',
       );
-      const incrementalProjectionCommits =
-        delayedControlStore.projectionCommits.filter(
-          (request) => request.incrementalRecordId !== undefined,
-        );
+      const incrementalProjectionCommits = delayedControlStore.projectionCommits.filter(
+        (request) => request.incrementalRecordId !== undefined,
+      );
       assert.equal(incrementalProjectionCommits.length, 2);
       assert.ok(
-        incrementalProjectionCommits.every(
-          (request) => request.terminalActivities.length === 0,
-        ),
+        incrementalProjectionCommits.every((request) => request.terminalActivities.length === 0),
         'yielded SessionEvents must never write immutable terminal history',
       );
       assert.equal(
@@ -212,8 +245,7 @@ describe('host-managed agent graph coordinator', () => {
         /only to root Sessions/,
       );
 
-      const canonicalProjection =
-        await controlStore.readAgentGraphClientProjection(graphId);
+      const canonicalProjection = await controlStore.readAgentGraphClientProjection(graphId);
       assert.ok(canonicalProjection);
       const staleSnapshot = structuredClone(
         canonicalProjection.payload as { snapshotVersion: string },
@@ -231,32 +263,27 @@ describe('host-managed agent graph coordinator', () => {
         terminalActivities: [],
         activityRecords: [],
       });
-      const transientProjectionFailure = new Error(
-        'transient derived projection failure',
-      );
-      delayedControlStore.failNextProjectionCommits(
-        1,
-        transientProjectionFailure,
-      );
-      const commitsBeforeRepair =
-        delayedControlStore.projectionCommits.length;
+      const transientProjectionFailure = new Error('transient derived projection failure');
+      delayedControlStore.failNextProjectionCommits(1, transientProjectionFailure);
+      const commitsBeforeRepair = delayedControlStore.projectionCommits.length;
       const runtimeActivityBeforeRepair = clientEvents.filter(
         (reason) => reason === 'runtime_activity',
       ).length;
       await coordinator.reconcile(rootSession.id);
-      assert.ok(
-        transientProjectionErrors.includes(transientProjectionFailure),
-      );
+      await supervisorWake.waitForIdle();
       assert.equal(
-        (
-          await controlStore.readAgentGraphClientProjection(graphId)
-        )?.snapshotVersion,
+        supervisorWakeTurnCount,
+        1,
+        'the same durable graph snapshot must not wake the supervisor twice',
+      );
+      assert.ok(transientProjectionErrors.includes(transientProjectionFailure));
+      assert.equal(
+        (await controlStore.readAgentGraphClientProjection(graphId))?.snapshotVersion,
         canonicalProjection.snapshotVersion,
         'reconcile tail must repair a one-shot projection failure without new graph activity',
       );
       assert.ok(
-        delayedControlStore.projectionCommits.length >=
-          commitsBeforeRepair + 2,
+        delayedControlStore.projectionCommits.length >= commitsBeforeRepair + 2,
         'one failed materialization must be followed by an authoritative repair',
       );
       assert.equal(
@@ -277,19 +304,25 @@ describe('host-managed agent graph coordinator', () => {
         runtimeEventStore: countedRuntimeEventStore,
         controlStore: delayedControlStore.store,
         manager,
+        onReconciliation: (rootSessionId, result) => {
+          supervisorWake!.notify(rootSessionId, result);
+        },
         onError: (_rootSessionId, error) => {
           derivedFailures.push(error);
         },
       });
       assert.deepEqual(await recovered.recover(), [rootSession.id]);
+      await supervisorWake.waitForIdle();
+      assert.equal(
+        supervisorWakeTurnCount,
+        1,
+        'restart recovery must honor the persisted graph wake idempotency marker',
+      );
       assert.ok(
         derivedFailures.includes(projectionFailure),
         'recover must report projection failure without failing graph authority',
       );
-      assert.equal(
-        (await controlStore.listAgentGraphOperatorProvisions(graphId)).length,
-        1,
-      );
+      assert.equal((await controlStore.listAgentGraphOperatorProvisions(graphId)).length, 1);
       assert.equal((await controlStore.listAgentGraphIntentClaims(graphId)).length, 1);
       assert.equal((await manager.listChildSessions(rootSession.id)).length, 1);
 
@@ -310,12 +343,7 @@ describe('host-managed agent graph coordinator', () => {
               },
             ],
           },
-          toolContext(
-            rootSession.id,
-            sourceRun.runId,
-            sourceTurnId,
-            'tool-call-graph-stop-race',
-          ),
+          toolContext(rootSession.id, sourceRun.runId, sourceTurnId, 'tool-call-graph-stop-race'),
         ),
       );
       await gate.started;
@@ -325,8 +353,7 @@ describe('host-managed agent graph coordinator', () => {
         gate.release();
       }
       assert.ok(
-        derivedFailures.filter((error) => error === projectionFailure).length >=
-          2,
+        derivedFailures.filter((error) => error === projectionFailure).length >= 2,
         'stop must report best-effort projection repair failure without rejecting',
       );
       await pendingUpdate;
@@ -340,6 +367,7 @@ describe('host-managed agent graph coordinator', () => {
       unsubscribe?.();
       await coordinator?.close();
       await recovered?.close();
+      await supervisorWake?.close();
       controlStore?.close();
       await sessionStore.close?.();
       await rm(root, { recursive: true, force: true });
@@ -454,7 +482,7 @@ describe('host-managed agent graph coordinator', () => {
             (failure) =>
               failure === topologyFailure ||
               (failure instanceof AggregateError && failure.errors.includes(topologyFailure)),
-      )),
+          )),
     );
   });
 
@@ -500,9 +528,7 @@ describe('host-managed agent graph coordinator', () => {
         error instanceof AggregateError &&
         (error.errors.length === 2 ||
           error.errors.some(
-            (failure) =>
-              failure instanceof AggregateError &&
-              failure.errors.length === 2,
+            (failure) => failure instanceof AggregateError && failure.errors.length === 2,
           )),
     );
     assert.deepEqual(stopped.sort(), ['child-a', 'child-b']);
@@ -515,6 +541,7 @@ function createCoordinator(input: {
   runtimeEventStore: ReturnType<typeof createRuntimeEventStore>;
   controlStore: ReturnType<typeof createSqliteSessionMetadataStore>;
   manager: SessionManager;
+  onReconciliation?: AgentGraphCoordinatorInput['onReconciliation'];
   onError?: AgentGraphCoordinatorInput['onError'];
 }): AgentGraphCoordinator {
   return new AgentGraphCoordinator({
@@ -525,13 +552,9 @@ function createCoordinator(input: {
   });
 }
 
-function createDelayableControlStore(
-  store: ReturnType<typeof createSqliteSessionMetadataStore>,
-): {
+function createDelayableControlStore(store: ReturnType<typeof createSqliteSessionMetadataStore>): {
   store: ReturnType<typeof createSqliteSessionMetadataStore>;
-  projectionCommits: Array<
-    Parameters<typeof store.commitAgentGraphClientProjection>[0]
-  >;
+  projectionCommits: Array<Parameters<typeof store.commitAgentGraphClientProjection>[0]>;
   projectionReadCounts(): { composite: number; operator: number };
   failProjectionCommits(error: unknown): void;
   failNextProjectionCommits(count: number, error: unknown): void;
@@ -543,9 +566,7 @@ function createDelayableControlStore(
         release: Promise<void>;
       }
     | undefined;
-  const projectionCommits: Array<
-    Parameters<typeof store.commitAgentGraphClientProjection>[0]
-  > = [];
+  const projectionCommits: Array<Parameters<typeof store.commitAgentGraphClientProjection>[0]> = [];
   let projectionFailure: unknown;
   let remainingProjectionFailures: number | 'always' = 0;
   let compositeProjectionReads = 0;
@@ -564,11 +585,7 @@ function createDelayableControlStore(
         };
       }
       if (property === 'commitAgentGraphClientProjection') {
-        return async (
-          ...args: Parameters<
-            typeof target.commitAgentGraphClientProjection
-          >
-        ) => {
+        return async (...args: Parameters<typeof target.commitAgentGraphClientProjection>) => {
           projectionCommits.push(structuredClone(args[0]));
           if (remainingProjectionFailures === 'always') {
             throw projectionFailure;
@@ -582,9 +599,7 @@ function createDelayableControlStore(
       }
       if (property === 'readAgentGraphClientProjectionWithOperator') {
         return async (
-          ...args: Parameters<
-            typeof target.readAgentGraphClientProjectionWithOperator
-          >
+          ...args: Parameters<typeof target.readAgentGraphClientProjectionWithOperator>
         ) => {
           compositeProjectionReads += 1;
           return target.readAgentGraphClientProjectionWithOperator(...args);
@@ -592,9 +607,7 @@ function createDelayableControlStore(
       }
       if (property === 'readAgentGraphClientOperatorProjection') {
         return async (
-          ...args: Parameters<
-            typeof target.readAgentGraphClientOperatorProjection
-          >
+          ...args: Parameters<typeof target.readAgentGraphClientOperatorProjection>
         ) => {
           operatorProjectionReads += 1;
           return target.readAgentGraphClientOperatorProjection(...args);

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -100,6 +100,13 @@ describe('host-managed agent graph coordinator', () => {
           }
           return { kind: 'completed', turnId: input.turnId };
         },
+        inspectAttempt: async (sessionId, attemptId, turnId) => {
+          const run = (await runStore.listSessionRuns(sessionId)).find(
+            (candidate) =>
+              candidate.agentGraphWakeAttemptId === attemptId && candidate.turnId === turnId,
+          );
+          return run?.status ?? 'missing';
+        },
         newId: randomUUID,
         onError: (_rootSessionId, error) => {
           supervisorWakeErrors.push(error);

--- a/packages/runtime/src/__tests__/stream-graph-supervisor-tools.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-supervisor-tools.test.ts
@@ -46,6 +46,8 @@ describe('stream graph supervisor tools', () => {
       assert.equal((await store.listAgentGraphScheduleUpdates('graph-supervised')).length, 1);
       assert.deepEqual(first.schedule.work[0]?.inputIds, ['result-a', 'result-b']);
       assert.equal(first.runtime.operators[0]?.status, 'running');
+      assert.equal(first.runtime.operators[0]?.childSessionId, 'session-writer');
+      assert.equal(first.runtime.operators[0]?.currentRunId, 'run-writer');
       assert.deepEqual(first.runtime.readiness[0]?.waitingFor, [
         { kind: 'input_route', upstreamOperatorIds: ['researcher'] },
       ]);

--- a/packages/runtime/src/agent-graph-supervisor-wake.ts
+++ b/packages/runtime/src/agent-graph-supervisor-wake.ts
@@ -71,6 +71,24 @@ export class AgentGraphSupervisorWakeCoordinator {
     void task.finally(() => this.#tasks.delete(task));
   }
 
+  /**
+   * Reconciles a parked wake after the user answers a permission prompt.
+   *
+   * A live waiter keeps the original startTurn activity lease until the same
+   * attempt settles. If the stream already ended suspended, admission here
+   * proves that waiter is gone and makes the wake eligible for a fresh turn.
+   */
+  notifyPermissionResponse(rootSessionId: string): void {
+    if (this.#closed) return;
+    const task = this.#settlePermissionResponse(rootSessionId).catch((error) => {
+      if (!this.#closed && !isAbortError(error)) {
+        return notifyError(this.#input.onError, rootSessionId, error);
+      }
+    });
+    this.#tasks.add(task);
+    void task.finally(() => this.#tasks.delete(task));
+  }
+
   /** Converges persisted wakes from AgentRun facts and resumes only safe retries. */
   async recover(): Promise<number> {
     if (this.#closed) return 0;
@@ -234,8 +252,8 @@ export class AgentGraphSupervisorWakeCoordinator {
     wakeId: string,
     attemptId: string,
     failureReason: string,
-  ): Promise<void> {
-    await this.#input.wakeStore.completeAgentGraphSupervisorWakeAttempt({
+  ): Promise<AgentGraphSupervisorWakeRecord> {
+    return this.#input.wakeStore.completeAgentGraphSupervisorWakeAttempt({
       graphId,
       wakeId,
       attemptId,
@@ -262,16 +280,6 @@ export class AgentGraphSupervisorWakeCoordinator {
       });
       return 1;
     }
-    if (runStatus === 'waiting_permission') {
-      if (wake.status === 'waiting_permission') return 0;
-      await this.#input.wakeStore.completeAgentGraphSupervisorWakeAttempt({
-        graphId: wake.graphId,
-        wakeId: wake.wakeId,
-        attemptId,
-        status: 'waiting_permission',
-      });
-      return 1;
-    }
     await this.#markRetryable(
       wake.graphId,
       wake.wakeId,
@@ -281,6 +289,50 @@ export class AgentGraphSupervisorWakeCoordinator {
         : `host_restart:${runStatus}`,
     );
     return 1;
+  }
+
+  async #settlePermissionResponse(rootSessionId: string): Promise<void> {
+    const activity = await this.#input.activityRegistry.acquire(
+      rootSessionId,
+      this.#abortController.signal,
+    );
+    const retryable: AgentGraphSupervisorWakeRecord[] = [];
+    try {
+      if (this.#closed) return;
+      const unsettled = (
+        await this.#input.wakeStore.listUnsettledAgentGraphSupervisorWakes()
+      ).filter((wake) => wake.rootSessionId === rootSessionId);
+      for (const wake of unsettled) {
+        const attemptId = wake.currentAttemptId;
+        const turnId = wake.currentTurnId;
+        if (!attemptId || !turnId) {
+          throw new Error(
+            `Parked Agent graph supervisor wake ${wake.graphId}/${wake.wakeId} has no current attempt`,
+          );
+        }
+        const runStatus = await this.#input.inspectAttempt(rootSessionId, attemptId, turnId);
+        if (runStatus === 'completed') {
+          await this.#input.wakeStore.completeAgentGraphSupervisorWakeAttempt({
+            graphId: wake.graphId,
+            wakeId: wake.wakeId,
+            attemptId,
+            status: 'delivered',
+          });
+          continue;
+        }
+        retryable.push(
+          await this.#markRetryable(
+            wake.graphId,
+            wake.wakeId,
+            attemptId,
+            `permission_waiter_lost:${runStatus}`,
+          ),
+        );
+      }
+    } finally {
+      activity.release();
+    }
+    for (const wake of retryable) this.#scheduleRecoveredWake(wake);
   }
 }
 

--- a/packages/runtime/src/agent-graph-supervisor-wake.ts
+++ b/packages/runtime/src/agent-graph-supervisor-wake.ts
@@ -1,18 +1,30 @@
-import type { StoredMessage, UserMessageInput } from '@maka/core';
-import type { SessionActivityLease, SessionActivityRegistry } from './goal-turn-lifecycle.js';
+import {
+  AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION,
+  type AgentGraphSupervisorWakeRecord,
+  type AgentGraphSupervisorWakeStore,
+  type UserMessageInput,
+} from '@maka/core';
+import type {
+  GoalTurnOutcome,
+  SessionActivityLease,
+  SessionActivityRegistry,
+} from './goal-turn-lifecycle.js';
 import type { AgentGraphClientSnapshot } from './stream-graph-read-model.js';
 import type { AgentGraphScheduleReconciliationResult } from './stream-graph-schedule-reconcile.js';
 
+const DEFAULT_MAX_DELIVERY_ATTEMPTS = 3;
+
 export interface AgentGraphSupervisorWakeInput {
   activityRegistry: SessionActivityRegistry;
-  readMessages(sessionId: string): Promise<StoredMessage[]>;
+  wakeStore: AgentGraphSupervisorWakeStore;
   readSnapshot(rootSessionId: string): Promise<AgentGraphClientSnapshot>;
   startTurn(
     sessionId: string,
     input: UserMessageInput,
     activity: SessionActivityLease,
-  ): Promise<unknown>;
+  ): Promise<GoalTurnOutcome>;
   newId(): string;
+  maxDeliveryAttempts?: number;
   onError?(rootSessionId: string, error: unknown): void | Promise<void>;
 }
 
@@ -20,28 +32,47 @@ export interface AgentGraphSupervisorWakeInput {
  * Host-side control-plane bridge from graph quiescence back to the root
  * supervisor Agent.
  *
- * The graph coordinator remains independent from Agent turns. This bridge
- * waits for the current root turn to settle, then starts a fresh, visibly
- * host-authored Graph turn. The durable message origin is the idempotency
- * authority across concurrent callbacks and process recovery.
+ * SQLite owns wake admission and delivery state. A persisted prompt or Run is
+ * only an attempt: the wake becomes delivered after the host observes a
+ * completed root turn. Interrupted attempts remain retryable across callbacks
+ * and process recovery.
  */
 export class AgentGraphSupervisorWakeCoordinator {
   readonly #input: AgentGraphSupervisorWakeInput;
   readonly #tasks = new Set<Promise<void>>();
   readonly #pendingWakeIds = new Set<string>();
+  readonly #abortController = new AbortController();
+  readonly #maxDeliveryAttempts: number;
   #closed = false;
 
   constructor(input: AgentGraphSupervisorWakeInput) {
     this.#input = input;
+    this.#maxDeliveryAttempts = input.maxDeliveryAttempts ?? DEFAULT_MAX_DELIVERY_ATTEMPTS;
+    if (!Number.isSafeInteger(this.#maxDeliveryAttempts) || this.#maxDeliveryAttempts < 1) {
+      throw new Error('Agent graph supervisor wake attempts must be a positive safe integer');
+    }
   }
 
   notify(rootSessionId: string, result: AgentGraphScheduleReconciliationResult): void {
     if (this.#closed || !isSupervisorMilestone(result)) return;
-    const task = this.#wake(rootSessionId, result).catch((error) =>
-      notifyError(this.#input.onError, rootSessionId, error),
-    );
+    const task = this.#wake(rootSessionId, result).catch((error) => {
+      if (!this.#closed && !isAbortError(error)) {
+        return notifyError(this.#input.onError, rootSessionId, error);
+      }
+    });
     this.#tasks.add(task);
     void task.finally(() => this.#tasks.delete(task));
+  }
+
+  /** Makes crash-interrupted attempts eligible and actively resumes them. */
+  async recover(): Promise<number> {
+    if (this.#closed) return 0;
+    const recovered = await this.#input.wakeStore.recoverAgentGraphSupervisorWakes();
+    if (this.#closed) return recovered;
+    for (const wake of await this.#input.wakeStore.listRetryableAgentGraphSupervisorWakes()) {
+      this.#scheduleRecoveredWake(wake);
+    }
+    return recovered;
   }
 
   async waitForIdle(): Promise<void> {
@@ -49,7 +80,9 @@ export class AgentGraphSupervisorWakeCoordinator {
   }
 
   async close(): Promise<void> {
+    if (this.#closed) return;
     this.#closed = true;
+    this.#abortController.abort();
     await this.waitForIdle();
   }
 
@@ -58,40 +91,136 @@ export class AgentGraphSupervisorWakeCoordinator {
     result: AgentGraphScheduleReconciliationResult,
   ): Promise<void> {
     const snapshot = await this.#input.readSnapshot(rootSessionId);
-    if (snapshot.closed || snapshot.scheduleRevision === 0) return;
+    if (this.#closed || snapshot.closed || snapshot.scheduleRevision === 0) return;
     const wakeId = `${snapshot.graphId}:${snapshot.snapshotVersion}`;
     if (this.#pendingWakeIds.has(wakeId)) return;
     this.#pendingWakeIds.add(wakeId);
     try {
-      if (await hasPersistedWake(this.#input, rootSessionId, wakeId)) return;
-      const activity = await this.#input.activityRegistry.acquire(rootSessionId);
-      try {
-        // A competing callback or a recovered turn may have committed while
-        // this wake waited behind the user's original supervisor turn.
-        if (await hasPersistedWake(this.#input, rootSessionId, wakeId)) return;
-        await this.#input.startTurn(
-          rootSessionId,
-          {
-            turnId: this.#input.newId(),
-            text: renderAgentGraphSupervisorWakePrompt(snapshot, result),
-            displayText: 'Agent graph reached a supervisor checkpoint.',
-            turnOrchestration: { mode: 'graph', source: 'host_api' },
-            origin: {
-              kind: 'agent_graph',
-              graphId: snapshot.graphId,
-              wakeId,
-            },
-          },
-          activity,
-        );
-      } finally {
-        // The Desktop stream owns and normally releases this lease. release()
-        // is idempotent, so this also covers failures before streaming starts.
-        activity.release();
-      }
+      const claimed = await this.#input.wakeStore.claimAgentGraphSupervisorWake({
+        schemaVersion: AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION,
+        graphId: snapshot.graphId,
+        wakeId,
+        snapshotVersion: snapshot.snapshotVersion,
+        rootSessionId,
+      });
+      if (this.#closed || claimed.wake.status === 'delivered') return;
+      await this.#deliverWake(claimed.wake, snapshot, result);
     } finally {
       this.#pendingWakeIds.delete(wakeId);
     }
+  }
+
+  #scheduleRecoveredWake(wake: AgentGraphSupervisorWakeRecord): void {
+    if (this.#closed || this.#pendingWakeIds.has(wake.wakeId)) return;
+    this.#pendingWakeIds.add(wake.wakeId);
+    const task = this.#resumeWake(wake)
+      .catch((error) => {
+        if (!this.#closed && !isAbortError(error)) {
+          return notifyError(this.#input.onError, wake.rootSessionId, error);
+        }
+      })
+      .finally(() => this.#pendingWakeIds.delete(wake.wakeId));
+    this.#tasks.add(task);
+    void task.finally(() => this.#tasks.delete(task));
+  }
+
+  async #resumeWake(wake: AgentGraphSupervisorWakeRecord): Promise<void> {
+    const snapshot = await this.#input.readSnapshot(wake.rootSessionId);
+    if (
+      this.#closed ||
+      snapshot.closed ||
+      snapshot.graphId !== wake.graphId ||
+      snapshot.scheduleRevision === 0
+    ) {
+      return;
+    }
+    await this.#deliverWake(wake, snapshot);
+  }
+
+  async #deliverWake(
+    wake: AgentGraphSupervisorWakeRecord,
+    snapshot: AgentGraphClientSnapshot,
+    result?: AgentGraphScheduleReconciliationResult,
+  ): Promise<void> {
+    let lastFailure: string | undefined;
+    for (let index = 0; index < this.#maxDeliveryAttempts; index += 1) {
+      const activity = await this.#input.activityRegistry.acquire(
+        wake.rootSessionId,
+        this.#abortController.signal,
+      );
+      try {
+        if (this.#closed) return;
+        const attemptId = this.#input.newId();
+        const turnId = this.#input.newId();
+        const admission = await this.#input.wakeStore.beginAgentGraphSupervisorWakeAttempt({
+          graphId: wake.graphId,
+          wakeId: wake.wakeId,
+          attemptId,
+          turnId,
+        });
+        if (!admission.acquired) return;
+        if (this.#closed) {
+          await this.#markRetryable(wake.graphId, wake.wakeId, attemptId, 'host_shutdown');
+          return;
+        }
+
+        try {
+          const outcome = await this.#input.startTurn(
+            wake.rootSessionId,
+            {
+              turnId,
+              text: renderAgentGraphSupervisorWakePrompt(snapshot, result),
+              displayText: 'Agent graph reached a supervisor checkpoint.',
+              turnOrchestration: { mode: 'graph', source: 'host_api' },
+              origin: {
+                kind: 'agent_graph',
+                graphId: wake.graphId,
+                wakeId: wake.wakeId,
+                attemptId,
+              },
+            },
+            activity,
+          );
+          if (outcome.kind === 'completed') {
+            await this.#input.wakeStore.completeAgentGraphSupervisorWakeAttempt({
+              graphId: wake.graphId,
+              wakeId: wake.wakeId,
+              attemptId,
+              status: 'delivered',
+            });
+            return;
+          }
+          lastFailure = wakeOutcomeFailure(outcome);
+          await this.#markRetryable(wake.graphId, wake.wakeId, attemptId, lastFailure);
+        } catch (error) {
+          lastFailure = errorMessage(error);
+          await this.#markRetryable(wake.graphId, wake.wakeId, attemptId, lastFailure);
+        }
+      } finally {
+        activity.release();
+      }
+      if (this.#closed) return;
+    }
+    throw new Error(
+      `Agent graph supervisor wake was not delivered after ${this.#maxDeliveryAttempts} attempts: ${
+        lastFailure ?? 'unknown failure'
+      }`,
+    );
+  }
+
+  async #markRetryable(
+    graphId: string,
+    wakeId: string,
+    attemptId: string,
+    failureReason: string,
+  ): Promise<void> {
+    await this.#input.wakeStore.completeAgentGraphSupervisorWakeAttempt({
+      graphId,
+      wakeId,
+      attemptId,
+      status: 'retryable_failed',
+      failureReason: failureReason.slice(0, 4_000) || 'unknown failure',
+    });
   }
 }
 
@@ -106,32 +235,34 @@ function isSupervisorMilestone(result: AgentGraphScheduleReconciliationResult): 
   return result.dispatches.length > 0 || result.failures.length > 0;
 }
 
-async function hasPersistedWake(
-  input: AgentGraphSupervisorWakeInput,
-  rootSessionId: string,
-  wakeId: string,
-): Promise<boolean> {
-  return (await input.readMessages(rootSessionId)).some(
-    (message) =>
-      message.type === 'user' &&
-      message.origin?.kind === 'agent_graph' &&
-      message.origin.wakeId === wakeId,
-  );
+function wakeOutcomeFailure(outcome: Exclude<GoalTurnOutcome, { kind: 'completed' }>): string {
+  if (outcome.kind === 'errored' || outcome.kind === 'suspended') {
+    return `${outcome.kind}: ${outcome.reason}`;
+  }
+  return 'aborted';
 }
 
 function renderAgentGraphSupervisorWakePrompt(
   snapshot: AgentGraphClientSnapshot,
-  result: AgentGraphScheduleReconciliationResult,
+  result?: AgentGraphScheduleReconciliationResult,
 ): string {
   return [
     '<agent-graph-supervisor-checkpoint>',
     `Graph ${snapshot.graphId} reached a durable supervisor checkpoint.`,
-    `Reconciliation status: ${result.status}. Snapshot: ${snapshot.snapshotVersion}.`,
+    `Reconciliation status: ${result?.status ?? 'recovered'}. Snapshot: ${snapshot.snapshotVersion}.`,
     'Inspect the graph with view_agent_graph. Use agent_output for child results when needed.',
     'Then either schedule the next work with update_agent_graph or finish the graph with the selected result record IDs.',
     'Report the useful outcome to the user when the graph is complete.',
     '</agent-graph-supervisor-checkpoint>',
   ].join('\n');
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
 }
 
 async function notifyError(

--- a/packages/runtime/src/agent-graph-supervisor-wake.ts
+++ b/packages/runtime/src/agent-graph-supervisor-wake.ts
@@ -1,0 +1,147 @@
+import type { StoredMessage, UserMessageInput } from '@maka/core';
+import type { SessionActivityLease, SessionActivityRegistry } from './goal-turn-lifecycle.js';
+import type { AgentGraphClientSnapshot } from './stream-graph-read-model.js';
+import type { AgentGraphScheduleReconciliationResult } from './stream-graph-schedule-reconcile.js';
+
+export interface AgentGraphSupervisorWakeInput {
+  activityRegistry: SessionActivityRegistry;
+  readMessages(sessionId: string): Promise<StoredMessage[]>;
+  readSnapshot(rootSessionId: string): Promise<AgentGraphClientSnapshot>;
+  startTurn(
+    sessionId: string,
+    input: UserMessageInput,
+    activity: SessionActivityLease,
+  ): Promise<unknown>;
+  newId(): string;
+  onError?(rootSessionId: string, error: unknown): void | Promise<void>;
+}
+
+/**
+ * Host-side control-plane bridge from graph quiescence back to the root
+ * supervisor Agent.
+ *
+ * The graph coordinator remains independent from Agent turns. This bridge
+ * waits for the current root turn to settle, then starts a fresh, visibly
+ * host-authored Graph turn. The durable message origin is the idempotency
+ * authority across concurrent callbacks and process recovery.
+ */
+export class AgentGraphSupervisorWakeCoordinator {
+  readonly #input: AgentGraphSupervisorWakeInput;
+  readonly #tasks = new Set<Promise<void>>();
+  readonly #pendingWakeIds = new Set<string>();
+  #closed = false;
+
+  constructor(input: AgentGraphSupervisorWakeInput) {
+    this.#input = input;
+  }
+
+  notify(rootSessionId: string, result: AgentGraphScheduleReconciliationResult): void {
+    if (this.#closed || !isSupervisorMilestone(result)) return;
+    const task = this.#wake(rootSessionId, result).catch((error) =>
+      notifyError(this.#input.onError, rootSessionId, error),
+    );
+    this.#tasks.add(task);
+    void task.finally(() => this.#tasks.delete(task));
+  }
+
+  async waitForIdle(): Promise<void> {
+    while (this.#tasks.size > 0) await Promise.all([...this.#tasks]);
+  }
+
+  async close(): Promise<void> {
+    this.#closed = true;
+    await this.waitForIdle();
+  }
+
+  async #wake(
+    rootSessionId: string,
+    result: AgentGraphScheduleReconciliationResult,
+  ): Promise<void> {
+    const snapshot = await this.#input.readSnapshot(rootSessionId);
+    if (snapshot.closed || snapshot.scheduleRevision === 0) return;
+    const wakeId = `${snapshot.graphId}:${snapshot.snapshotVersion}`;
+    if (this.#pendingWakeIds.has(wakeId)) return;
+    this.#pendingWakeIds.add(wakeId);
+    try {
+      if (await hasPersistedWake(this.#input, rootSessionId, wakeId)) return;
+      const activity = await this.#input.activityRegistry.acquire(rootSessionId);
+      try {
+        // A competing callback or a recovered turn may have committed while
+        // this wake waited behind the user's original supervisor turn.
+        if (await hasPersistedWake(this.#input, rootSessionId, wakeId)) return;
+        await this.#input.startTurn(
+          rootSessionId,
+          {
+            turnId: this.#input.newId(),
+            text: renderAgentGraphSupervisorWakePrompt(snapshot, result),
+            displayText: 'Agent graph reached a supervisor checkpoint.',
+            turnOrchestration: { mode: 'graph', source: 'host_api' },
+            origin: {
+              kind: 'agent_graph',
+              graphId: snapshot.graphId,
+              wakeId,
+            },
+          },
+          activity,
+        );
+      } finally {
+        // The Desktop stream owns and normally releases this lease. release()
+        // is idempotent, so this also covers failures before streaming starts.
+        activity.release();
+      }
+    } finally {
+      this.#pendingWakeIds.delete(wakeId);
+    }
+  }
+}
+
+function isSupervisorMilestone(result: AgentGraphScheduleReconciliationResult): boolean {
+  if (
+    result.status === 'cancelled' ||
+    result.status === 'stale' ||
+    result.status === 'limit_reached'
+  ) {
+    return false;
+  }
+  return result.dispatches.length > 0 || result.failures.length > 0;
+}
+
+async function hasPersistedWake(
+  input: AgentGraphSupervisorWakeInput,
+  rootSessionId: string,
+  wakeId: string,
+): Promise<boolean> {
+  return (await input.readMessages(rootSessionId)).some(
+    (message) =>
+      message.type === 'user' &&
+      message.origin?.kind === 'agent_graph' &&
+      message.origin.wakeId === wakeId,
+  );
+}
+
+function renderAgentGraphSupervisorWakePrompt(
+  snapshot: AgentGraphClientSnapshot,
+  result: AgentGraphScheduleReconciliationResult,
+): string {
+  return [
+    '<agent-graph-supervisor-checkpoint>',
+    `Graph ${snapshot.graphId} reached a durable supervisor checkpoint.`,
+    `Reconciliation status: ${result.status}. Snapshot: ${snapshot.snapshotVersion}.`,
+    'Inspect the graph with view_agent_graph. Use agent_output for child results when needed.',
+    'Then either schedule the next work with update_agent_graph or finish the graph with the selected result record IDs.',
+    'Report the useful outcome to the user when the graph is complete.',
+    '</agent-graph-supervisor-checkpoint>',
+  ].join('\n');
+}
+
+async function notifyError(
+  observer: AgentGraphSupervisorWakeInput['onError'],
+  rootSessionId: string,
+  error: unknown,
+): Promise<void> {
+  try {
+    await observer?.(rootSessionId, error);
+  } catch {
+    // Wake diagnostics must not become graph data-path failures.
+  }
+}

--- a/packages/runtime/src/agent-graph-supervisor-wake.ts
+++ b/packages/runtime/src/agent-graph-supervisor-wake.ts
@@ -1,5 +1,6 @@
 import {
   AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION,
+  type AgentRunHeader,
   type AgentGraphSupervisorWakeRecord,
   type AgentGraphSupervisorWakeStore,
   type UserMessageInput,
@@ -22,7 +23,13 @@ export interface AgentGraphSupervisorWakeInput {
     sessionId: string,
     input: UserMessageInput,
     activity: SessionActivityLease,
+    abortSignal: AbortSignal,
   ): Promise<GoalTurnOutcome>;
+  inspectAttempt(
+    rootSessionId: string,
+    attemptId: string,
+    turnId: string,
+  ): Promise<AgentRunHeader['status'] | 'missing'>;
   newId(): string;
   maxDeliveryAttempts?: number;
   onError?(rootSessionId: string, error: unknown): void | Promise<void>;
@@ -64,10 +71,14 @@ export class AgentGraphSupervisorWakeCoordinator {
     void task.finally(() => this.#tasks.delete(task));
   }
 
-  /** Makes crash-interrupted attempts eligible and actively resumes them. */
+  /** Converges persisted wakes from AgentRun facts and resumes only safe retries. */
   async recover(): Promise<number> {
     if (this.#closed) return 0;
-    const recovered = await this.#input.wakeStore.recoverAgentGraphSupervisorWakes();
+    let recovered = await this.#input.wakeStore.recoverAgentGraphSupervisorWakes();
+    for (const wake of await this.#input.wakeStore.listUnsettledAgentGraphSupervisorWakes()) {
+      if (this.#closed) return recovered;
+      recovered += await this.#recoverUnsettledWake(wake);
+    }
     if (this.#closed) return recovered;
     for (const wake of await this.#input.wakeStore.listRetryableAgentGraphSupervisorWakes()) {
       this.#scheduleRecoveredWake(wake);
@@ -180,6 +191,7 @@ export class AgentGraphSupervisorWakeCoordinator {
               },
             },
             activity,
+            this.#abortController.signal,
           );
           if (outcome.kind === 'completed') {
             await this.#input.wakeStore.completeAgentGraphSupervisorWakeAttempt({
@@ -187,6 +199,15 @@ export class AgentGraphSupervisorWakeCoordinator {
               wakeId: wake.wakeId,
               attemptId,
               status: 'delivered',
+            });
+            return;
+          }
+          if (outcome.kind === 'suspended') {
+            await this.#input.wakeStore.completeAgentGraphSupervisorWakeAttempt({
+              graphId: wake.graphId,
+              wakeId: wake.wakeId,
+              attemptId,
+              status: 'waiting_permission',
             });
             return;
           }
@@ -221,6 +242,45 @@ export class AgentGraphSupervisorWakeCoordinator {
       status: 'retryable_failed',
       failureReason: failureReason.slice(0, 4_000) || 'unknown failure',
     });
+  }
+
+  async #recoverUnsettledWake(wake: AgentGraphSupervisorWakeRecord): Promise<number> {
+    const attemptId = wake.currentAttemptId;
+    const turnId = wake.currentTurnId;
+    if (!attemptId || !turnId) {
+      throw new Error(
+        `Unsettled Agent graph supervisor wake ${wake.graphId}/${wake.wakeId} has no current attempt`,
+      );
+    }
+    const runStatus = await this.#input.inspectAttempt(wake.rootSessionId, attemptId, turnId);
+    if (runStatus === 'completed') {
+      await this.#input.wakeStore.completeAgentGraphSupervisorWakeAttempt({
+        graphId: wake.graphId,
+        wakeId: wake.wakeId,
+        attemptId,
+        status: 'delivered',
+      });
+      return 1;
+    }
+    if (runStatus === 'waiting_permission') {
+      if (wake.status === 'waiting_permission') return 0;
+      await this.#input.wakeStore.completeAgentGraphSupervisorWakeAttempt({
+        graphId: wake.graphId,
+        wakeId: wake.wakeId,
+        attemptId,
+        status: 'waiting_permission',
+      });
+      return 1;
+    }
+    await this.#markRetryable(
+      wake.graphId,
+      wake.wakeId,
+      attemptId,
+      runStatus === 'failed' || runStatus === 'cancelled'
+        ? `agent_run_${runStatus}`
+        : `host_restart:${runStatus}`,
+    );
+    return 1;
   }
 }
 

--- a/packages/runtime/src/agent-run-recovery.ts
+++ b/packages/runtime/src/agent-run-recovery.ts
@@ -26,9 +26,6 @@ export function classifyAgentRunRecovery(
   events: readonly AgentRunEvent[],
 ): AgentRunRecoveryDecision | undefined {
   if (isTerminalRunStatus(header.status)) return undefined;
-  if (header.agentGraphWakeAttemptId && header.status === 'waiting_permission') {
-    return undefined;
-  }
 
   const lastEvent = lastNonCorruptEvent(events);
   const hasCorruptEvent = events.some((event) => event.type === 'event_corrupt');

--- a/packages/runtime/src/agent-run-recovery.ts
+++ b/packages/runtime/src/agent-run-recovery.ts
@@ -26,6 +26,9 @@ export function classifyAgentRunRecovery(
   events: readonly AgentRunEvent[],
 ): AgentRunRecoveryDecision | undefined {
   if (isTerminalRunStatus(header.status)) return undefined;
+  if (header.agentGraphWakeAttemptId && header.status === 'waiting_permission') {
+    return undefined;
+  }
 
   const lastEvent = lastNonCorruptEvent(events);
   const hasCorruptEvent = events.some((event) => event.type === 'event_corrupt');

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -935,7 +935,10 @@ export class AgentRun {
         ? { automationId: this.input.userInput.origin.automationId }
         : {}),
       ...(this.input.userInput.origin?.kind === 'agent_graph'
-        ? { agentGraphWakeId: this.input.userInput.origin.wakeId }
+        ? {
+            agentGraphWakeId: this.input.userInput.origin.wakeId,
+            agentGraphWakeAttemptId: this.input.userInput.origin.attemptId,
+          }
         : {}),
     };
     try {

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -627,6 +627,7 @@ export class AgentRun {
       ...(this.input.userInput.displayText !== undefined
         ? { displayText: this.input.userInput.displayText }
         : {}),
+      ...(this.input.userInput.origin !== undefined ? { origin: this.input.userInput.origin } : {}),
       ...(this.input.userInput.attachments !== undefined
         ? { attachments: this.input.userInput.attachments }
         : {}),
@@ -932,6 +933,9 @@ export class AgentRun {
       ...(this.input.userInput.agentName ? { agentName: this.input.userInput.agentName } : {}),
       ...(this.input.userInput.origin?.kind === 'automation'
         ? { automationId: this.input.userInput.origin.automationId }
+        : {}),
+      ...(this.input.userInput.origin?.kind === 'agent_graph'
+        ? { agentGraphWakeId: this.input.userInput.origin.wakeId }
         : {}),
     };
     try {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -166,6 +166,7 @@ import {
 } from './provider-request-telemetry.js';
 import { ToolAvailabilityRuntime, type ToolAvailabilityConfig } from './tool-availability.js';
 import { renderSwarmModePrompt } from './swarm-mode.js';
+import { renderGraphModePrompt } from './graph-mode.js';
 import {
   applyRuntimeEventContextBudget,
   buildContextBudgetDiagnosticShell,
@@ -859,9 +860,15 @@ export class AiSdkBackend implements AgentBackend {
     // the execute-boundary gating, and the diagnostics. Seed prior-turn group
     // activations from the durable ledger (the current turn is excluded — it has
     // not committed yet) so a group loaded earlier stays advertised.
+    const requiredOrchestrationTools =
+      this.currentOrchestration.mode === 'swarm'
+        ? new Set(['agent_swarm'])
+        : this.currentOrchestration.mode === 'graph'
+          ? new Set(['view_agent_graph', 'update_agent_graph'])
+          : new Set<string>();
     const plan = this.toolAvailabilityRuntime.prepare(
       (input.runtimeContext ?? []).filter((event) => event.turnId !== turnId),
-      this.currentOrchestration.mode === 'swarm' ? new Set(['agent_swarm']) : new Set(),
+      requiredOrchestrationTools,
     );
     const providerTools = plan.providerTools;
     let activeToolResultPruneDiagnosticPatch: ActiveToolResultPruneDiagnosticPatch = {};
@@ -940,6 +947,7 @@ export class AiSdkBackend implements AgentBackend {
         const systemPrompt = joinPromptFragments([
           await this.resolveSystemPrompt(),
           this.currentOrchestration?.mode === 'swarm' ? renderSwarmModePrompt() : undefined,
+          this.currentOrchestration?.mode === 'graph' ? renderGraphModePrompt() : undefined,
         ]);
         const turnTailPrompt = input.continuation
           ? undefined

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -864,7 +864,7 @@ export class AiSdkBackend implements AgentBackend {
       this.currentOrchestration.mode === 'swarm'
         ? new Set(['agent_swarm'])
         : this.currentOrchestration.mode === 'graph'
-          ? new Set(['view_agent_graph', 'update_agent_graph'])
+          ? new Set(['view_agent_graph', 'update_agent_graph', 'agent_output'])
           : new Set<string>();
     const plan = this.toolAvailabilityRuntime.prepare(
       (input.runtimeContext ?? []).filter((event) => event.turnId !== turnId),

--- a/packages/runtime/src/goal-turn-lifecycle.ts
+++ b/packages/runtime/src/goal-turn-lifecycle.ts
@@ -163,7 +163,7 @@ function observeGoalTurnOutcome(
   current: GoalTurnOutcome | undefined,
   event: SessionEvent,
 ): GoalTurnOutcome | undefined {
-  if (current) return current;
+  if (current && current.kind !== 'suspended') return current;
   const failureClass =
     event.type === 'complete' ? failureClassFromCompleteStopReason(event.stopReason) : undefined;
   if (event.type === 'error' || failureClass !== undefined) {
@@ -176,9 +176,9 @@ function observeGoalTurnOutcome(
   if (event.type === 'abort' || (event.type === 'complete' && event.stopReason === 'user_stop')) {
     return { kind: 'aborted', turnId: event.turnId };
   }
-  if (event.type !== 'complete') return undefined;
+  if (event.type !== 'complete') return current;
   if (event.stopReason === 'permission_handoff') {
-    return {
+    return current ?? {
       kind: 'suspended',
       turnId: event.turnId,
       reason: 'Turn is waiting for user permission.',

--- a/packages/runtime/src/goal-turn-lifecycle.ts
+++ b/packages/runtime/src/goal-turn-lifecycle.ts
@@ -57,13 +57,45 @@ export class SessionActivityRegistry {
   }
 
   /** Waits until the session is idle, then atomically owns the next activity slot. */
-  async acquire(sessionId: string): Promise<SessionActivityLease> {
+  async acquire(sessionId: string, abortSignal?: AbortSignal): Promise<SessionActivityLease> {
     for (;;) {
+      throwIfAborted(abortSignal);
       const lease = this.reserveIfIdle(sessionId);
       if (lease) return lease;
-      await this.whenIdle(sessionId)!;
+      await waitForIdleOrAbort(this.whenIdle(sessionId)!, abortSignal);
     }
   }
+}
+
+function throwIfAborted(abortSignal?: AbortSignal): void {
+  if (!abortSignal?.aborted) return;
+  throw new DOMException('Session activity acquisition was aborted', 'AbortError');
+}
+
+async function waitForIdleOrAbort(
+  whenIdle: Promise<void>,
+  abortSignal?: AbortSignal,
+): Promise<void> {
+  if (!abortSignal) return whenIdle;
+  throwIfAborted(abortSignal);
+  await new Promise<void>((resolve, reject) => {
+    const onAbort = () => {
+      cleanup();
+      reject(new DOMException('Session activity acquisition was aborted', 'AbortError'));
+    };
+    const cleanup = () => abortSignal.removeEventListener('abort', onAbort);
+    abortSignal.addEventListener('abort', onAbort, { once: true });
+    void whenIdle.then(
+      () => {
+        cleanup();
+        resolve();
+      },
+      (error) => {
+        cleanup();
+        reject(error);
+      },
+    );
+  });
 }
 
 export interface DrainGoalTurnInput {

--- a/packages/runtime/src/graph-mode.ts
+++ b/packages/runtime/src/graph-mode.ts
@@ -1,0 +1,15 @@
+export function renderGraphModePrompt(): string {
+  return [
+    '<orchestration_mode>',
+    '# Orchestration Mode: Graph',
+    'Graph Mode is active for this session. You are the main-agent supervisor beside the data path.',
+    'Use update_agent_graph to schedule bounded work onto dynamically provisioned child-Session operators when a graph materially improves the task.',
+    'Use view_agent_graph to observe committed records, readiness, waits, failures, and durable schedule state; do not make normal record delivery wait for your approval.',
+    'Keep topology changes monotonic: add work and input frontiers, stop obsolete work when necessary, and do not assume arbitrary edge deletion, rewiring, or cycles.',
+    'Operator inputs and selected results must be committed record ids. Never treat partial model chunks as durable graph facts.',
+    'Stay available to the user while operators execute. Intervene only through the typed graph controls, and explain material supervision decisions.',
+    'Before finishing, inspect the graph. Use agent_output with the runtime operator childSessionId and currentRunId to read the authoritative child output behind candidate records, then select committed result ids with update_agent_graph.finish and synthesize those results for the user.',
+    'You may continue directly when the request is small or a graph would add ceremony without useful decomposition.',
+    '</orchestration_mode>',
+  ].join('\n');
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -196,6 +196,7 @@ export type {
 export { PermissionEngine, createDefaultPermissionEngineDeps } from './permission-engine.js';
 export type { EvaluateResult, EvaluateInput, PermissionEngineDeps } from './permission-engine.js';
 export { renderSwarmModePrompt } from './swarm-mode.js';
+export { renderGraphModePrompt } from './graph-mode.js';
 
 export {
   MAX_ADDITIONAL_PERMISSION_JUSTIFICATION_CHARS,

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -108,6 +108,8 @@ export type {
   ReconcileAgentGraphScheduleInput,
   RenderAgentGraphScheduledWorkPromptInput,
 } from './stream-graph-schedule-reconcile.js';
+export { AgentGraphSupervisorWakeCoordinator } from './agent-graph-supervisor-wake.js';
+export type { AgentGraphSupervisorWakeInput } from './agent-graph-supervisor-wake.js';
 export {
   AGENT_GRAPH_SUPERVISOR_TOOL_NAMES,
   UPDATE_AGENT_GRAPH_TOOL_NAME,

--- a/packages/runtime/src/runtime-event-adapters.ts
+++ b/packages/runtime/src/runtime-event-adapters.ts
@@ -100,7 +100,7 @@ export function storedMessageToRuntimeEvent(
         ts: d.ts,
         partial: false,
         role: 'user',
-        author: 'user',
+        author: message.origin ? 'host' : 'user',
         content: {
           kind: 'text',
           text: message.text,

--- a/packages/runtime/src/runtime-event-adapters.ts
+++ b/packages/runtime/src/runtime-event-adapters.ts
@@ -105,6 +105,7 @@ export function storedMessageToRuntimeEvent(
           kind: 'text',
           text: message.text,
           ...(message.displayText !== undefined ? { displayText: message.displayText } : {}),
+          ...(message.origin !== undefined ? { origin: message.origin } : {}),
           ...(message.attachments !== undefined && message.attachments.length > 0
             ? { attachments: message.attachments }
             : {}),
@@ -251,6 +252,7 @@ export function runtimeEventToStoredMessageDraft(
       ts: event.ts,
       text: content.text,
       ...(content.displayText !== undefined ? { displayText: content.displayText } : {}),
+      ...(content.origin !== undefined ? { origin: content.origin } : {}),
       ...(content.attachments !== undefined && content.attachments.length > 0
         ? { attachments: content.attachments }
         : {}),

--- a/packages/runtime/src/runtime-event-backfill.ts
+++ b/packages/runtime/src/runtime-event-backfill.ts
@@ -91,6 +91,7 @@ export function backfillRuntimeEventsFromStoredMessages(
             kind: 'text',
             text: message.text,
             ...(message.displayText !== undefined ? { displayText: message.displayText } : {}),
+            ...(message.origin !== undefined ? { origin: message.origin } : {}),
             ...(message.attachments !== undefined && message.attachments.length > 0
               ? { attachments: message.attachments }
               : {}),

--- a/packages/runtime/src/runtime-event-backfill.ts
+++ b/packages/runtime/src/runtime-event-backfill.ts
@@ -86,7 +86,7 @@ export function backfillRuntimeEventsFromStoredMessages(
           ...base,
           id: newId(),
           role: 'user',
-          author: 'user',
+          author: message.origin ? 'host' : 'user',
           content: {
             kind: 'text',
             text: message.text,

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -439,6 +439,7 @@ function projectText(
       ...(event.content.displayText !== undefined
         ? { displayText: event.content.displayText }
         : {}),
+      ...(event.content.origin !== undefined ? { origin: event.content.origin } : {}),
       ...(event.content.attachments !== undefined && event.content.attachments.length > 0
         ? { attachments: event.content.attachments }
         : {}),
@@ -1145,6 +1146,7 @@ function semanticMessage(message: StoredMessage): unknown {
         turnId: message.turnId,
         text: message.text,
         displayText: message.displayText,
+        origin: message.origin,
         attachments: message.attachments ?? [],
         quotes: message.quotes ?? [],
       };

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -42,6 +42,7 @@ import type {
 import { createDefaultInvocationProviders } from './invocation-context.js';
 import type { FlowInput, RunnableAgentFlow } from './agent-flow.js';
 import type { RuntimeContinuation } from './runtime-resume.js';
+import type { TurnOrigin } from '@maka/core/runtime-inputs';
 
 // ============================================================================
 // RuntimeGate — narrow preflight seam
@@ -120,6 +121,7 @@ export interface InitialUserRuntimeEventInput {
   text: string;
   /** Human-facing view when it differs from `text`; see RuntimeEventTextContent. */
   displayText?: string;
+  origin?: TurnOrigin;
   attachments?: InvocationRequest['attachments'];
   quotes?: InvocationRequest['quotes'];
   toolBoundaryProtocol?: ToolBoundaryProtocol;
@@ -489,6 +491,7 @@ export function buildInitialUserRuntimeEvent(input: InitialUserRuntimeEventInput
       kind: 'text',
       text: input.text,
       ...(input.displayText !== undefined ? { displayText: input.displayText } : {}),
+      ...(input.origin !== undefined ? { origin: input.origin } : {}),
       ...(input.attachments !== undefined && input.attachments.length > 0
         ? { attachments: input.attachments }
         : {}),

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -486,7 +486,7 @@ export function buildInitialUserRuntimeEvent(input: InitialUserRuntimeEventInput
     ...(input.branch ? { branch: input.branch } : {}),
     partial: false,
     role: 'user',
-    author: 'user',
+    author: input.origin ? 'host' : 'user',
     content: {
       kind: 'text',
       text: input.text,
@@ -510,13 +510,15 @@ function assertInitialRuntimeEventMatchesRequest(
     runId: string;
   },
 ): void {
+  const expectedAuthor =
+    event.content?.kind === 'text' && event.content.origin !== undefined ? 'host' : 'user';
   if (
     event.sessionId !== request.sessionId ||
     event.invocationId !== request.invocationId ||
     event.runId !== request.runId ||
     event.turnId !== request.turnId ||
     event.role !== 'user' ||
-    event.author !== 'user' ||
+    event.author !== expectedAuthor ||
     event.content?.kind !== 'text'
   ) {
     throw new Error('initial RuntimeEvent does not match the invocation request');

--- a/packages/runtime/src/stream-graph-supervisor-tools.ts
+++ b/packages/runtime/src/stream-graph-supervisor-tools.ts
@@ -204,8 +204,10 @@ export interface AgentGraphToolScheduleView {
 
 export interface AgentGraphToolRuntimeOperatorView {
   operatorId: string;
+  childSessionId: string;
   status: 'not_started' | AgentGraphActivationStatus;
   currentActivationId?: string;
+  currentRunId?: string;
   lastEventTime?: number;
 }
 
@@ -252,9 +254,7 @@ export interface BuildAgentGraphSupervisorToolsInput {
   scheduleStore: AgentGraphScheduleStore;
   observeGraph(): Promise<AgentGraphSupervisorObservation>;
   /** Host ownership check performed before append-only schedule admission. */
-  authorizeScheduleUpdate?(
-    request: AgentGraphScheduleUpdateRequest,
-  ): unknown | Promise<unknown>;
+  authorizeScheduleUpdate?(request: AgentGraphScheduleUpdateRequest): unknown | Promise<unknown>;
   /**
    * Host lifecycle hook invoked after the schedule update is durable.
    *
@@ -575,10 +575,12 @@ function agentGraphToolRuntimeView(
       const state = observation.projection.state.operators[binding.operatorId];
       return {
         operatorId: binding.operatorId,
+        childSessionId: binding.sessionId,
         status: state?.status ?? 'not_started',
         ...(state
           ? {
               currentActivationId: state.currentActivationId,
+              currentRunId: state.activations[state.currentActivationId]?.agentRunId,
               lastEventTime: state.activations[state.currentActivationId]?.lastEventTime,
             }
           : {}),

--- a/packages/storage/src/__tests__/agent-graph-intent-claims.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-intent-claims.test.ts
@@ -185,7 +185,7 @@ describe('SQLite agent graph intent claims', () => {
 
       const migrated = createSqliteSessionMetadataStore(path);
       try {
-        assert.equal(migrated.schemaVersion(), 11);
+        assert.equal(migrated.schemaVersion(), 12);
         assert.deepEqual(
           await migrated.beginAgentGraphIntentExecutionAtScheduleRevision(
             'graph-1',

--- a/packages/storage/src/__tests__/agent-graph-intent-claims.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-intent-claims.test.ts
@@ -135,6 +135,8 @@ describe('SQLite agent graph intent claims', () => {
 
       const legacy = new DatabaseSync(path);
       legacy.exec(`
+        DROP TABLE agent_graph_supervisor_wake_attempts;
+        DROP TABLE agent_graph_supervisor_wakes;
         DROP TABLE agent_graph_client_applied_records;
         DROP TABLE agent_graph_client_terminal_activity;
         DROP TABLE agent_graph_client_operator_projections;
@@ -183,7 +185,7 @@ describe('SQLite agent graph intent claims', () => {
 
       const migrated = createSqliteSessionMetadataStore(path);
       try {
-        assert.equal(migrated.schemaVersion(), 10);
+        assert.equal(migrated.schemaVersion(), 11);
         assert.deepEqual(
           await migrated.beginAgentGraphIntentExecutionAtScheduleRevision(
             'graph-1',

--- a/packages/storage/src/__tests__/agent-graph-supervisor-wakes.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-supervisor-wakes.test.ts
@@ -1,4 +1,8 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import { describe, test } from 'node:test';
 import { AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION } from '@maka/core';
 import { createSqliteSessionMetadataStore } from '../sqlite-session-metadata-store.js';
@@ -43,6 +47,28 @@ describe('SQLite Agent Graph supervisor wakes', () => {
       });
       assert.equal(second.acquired, true);
       assert.equal(second.wake.attemptCount, 2);
+      const parked = await store.completeAgentGraphSupervisorWakeAttempt({
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        attemptId: 'attempt-2',
+        status: 'waiting_permission',
+      });
+      assert.equal(parked.status, 'waiting_permission');
+      assert.equal(
+        (await store.listAgentGraphSupervisorWakeAttempts('graph-1', 'wake-1'))[1]?.completedAt,
+        undefined,
+      );
+      assert.equal(
+        (
+          await store.beginAgentGraphSupervisorWakeAttempt({
+            graphId: 'graph-1',
+            wakeId: 'wake-1',
+            attemptId: 'attempt-3',
+            turnId: 'turn-3',
+          })
+        ).acquired,
+        false,
+      );
       const delivered = await store.completeAgentGraphSupervisorWakeAttempt({
         graphId: 'graph-1',
         wakeId: 'wake-1',
@@ -72,7 +98,7 @@ describe('SQLite Agent Graph supervisor wakes', () => {
     }
   });
 
-  test('recovers both pre-run pending wakes and crash-interrupted running attempts', async () => {
+  test('recovers pre-run pending wakes without guessing the AgentRun state', async () => {
     let now = 20;
     const store = createSqliteSessionMetadataStore(':memory:', { now: () => now++ });
     try {
@@ -97,22 +123,74 @@ describe('SQLite Agent Graph supervisor wakes', () => {
         turnId: 'turn-running',
       });
 
-      assert.equal(await store.recoverAgentGraphSupervisorWakes(), 2);
+      assert.equal(await store.recoverAgentGraphSupervisorWakes(), 1);
       assert.equal(
         (await store.readAgentGraphSupervisorWake('graph-pending', 'wake-pending'))?.status,
         'retryable_failed',
       );
       assert.equal(
         (await store.readAgentGraphSupervisorWake('graph-running', 'wake-running'))?.status,
-        'retryable_failed',
+        'running',
       );
       assert.equal(
         (await store.listAgentGraphSupervisorWakeAttempts('graph-running', 'wake-running'))[0]
           ?.failureReason,
-        'host_restart',
+        undefined,
+      );
+      assert.deepEqual(
+        (await store.listUnsettledAgentGraphSupervisorWakes()).map((wake) => wake.wakeId),
+        ['wake-running'],
       );
     } finally {
       store.close();
+    }
+  });
+
+  test('migrates version 11 wake attempts without losing correlation', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-supervisor-wake-v11-'));
+    const path = join(root, 'sessions.sqlite');
+    try {
+      const initial = createSqliteSessionMetadataStore(path);
+      await initial.claimAgentGraphSupervisorWake({
+        schemaVersion: AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION,
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        snapshotVersion: 'snapshot-1',
+        rootSessionId: 'session-1',
+      });
+      await initial.beginAgentGraphSupervisorWakeAttempt({
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        attemptId: 'attempt-1',
+        turnId: 'turn-1',
+      });
+      initial.close();
+
+      const v11 = new DatabaseSync(path);
+      v11
+        .prepare(
+          `UPDATE session_metadata_schema SET version = 11 WHERE scope = 'session_metadata'`,
+        )
+        .run();
+      v11.close();
+
+      const migrated = createSqliteSessionMetadataStore(path);
+      assert.equal(migrated.schemaVersion(), 12);
+      assert.equal(
+        (await migrated.readAgentGraphSupervisorWake('graph-1', 'wake-1'))?.status,
+        'running',
+      );
+      assert.equal(
+        (await migrated.listAgentGraphSupervisorWakeAttempts('graph-1', 'wake-1'))[0]?.attemptId,
+        'attempt-1',
+      );
+      migrated.close();
+
+      const verified = new DatabaseSync(path);
+      assert.deepEqual(verified.prepare('PRAGMA foreign_key_check').all(), []);
+      verified.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
     }
   });
 });

--- a/packages/storage/src/__tests__/agent-graph-supervisor-wakes.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-supervisor-wakes.test.ts
@@ -1,0 +1,118 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION } from '@maka/core';
+import { createSqliteSessionMetadataStore } from '../sqlite-session-metadata-store.js';
+
+describe('SQLite Agent Graph supervisor wakes', () => {
+  test('tracks retry attempts separately and marks delivery only after completion', async () => {
+    let now = 10;
+    const store = createSqliteSessionMetadataStore(':memory:', { now: () => now++ });
+    try {
+      const claim = await store.claimAgentGraphSupervisorWake({
+        schemaVersion: AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION,
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        snapshotVersion: 'snapshot-1',
+        rootSessionId: 'session-1',
+      });
+      assert.equal(claim.created, true);
+      assert.equal(claim.wake.status, 'pending');
+
+      const first = await store.beginAgentGraphSupervisorWakeAttempt({
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        attemptId: 'attempt-1',
+        turnId: 'turn-1',
+      });
+      assert.equal(first.acquired, true);
+      assert.equal(first.wake.status, 'running');
+      assert.equal(first.wake.attemptCount, 1);
+      await store.completeAgentGraphSupervisorWakeAttempt({
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        attemptId: 'attempt-1',
+        status: 'retryable_failed',
+        failureReason: 'provider failed after prompt persistence',
+      });
+
+      const second = await store.beginAgentGraphSupervisorWakeAttempt({
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        attemptId: 'attempt-2',
+        turnId: 'turn-2',
+      });
+      assert.equal(second.acquired, true);
+      assert.equal(second.wake.attemptCount, 2);
+      const delivered = await store.completeAgentGraphSupervisorWakeAttempt({
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        attemptId: 'attempt-2',
+        status: 'delivered',
+      });
+      assert.equal(delivered.status, 'delivered');
+      assert.deepEqual(
+        (await store.listAgentGraphSupervisorWakeAttempts('graph-1', 'wake-1')).map(
+          (attempt) => attempt.status,
+        ),
+        ['retryable_failed', 'delivered'],
+      );
+      assert.equal(
+        (
+          await store.beginAgentGraphSupervisorWakeAttempt({
+            graphId: 'graph-1',
+            wakeId: 'wake-1',
+            attemptId: 'attempt-3',
+            turnId: 'turn-3',
+          })
+        ).acquired,
+        false,
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  test('recovers both pre-run pending wakes and crash-interrupted running attempts', async () => {
+    let now = 20;
+    const store = createSqliteSessionMetadataStore(':memory:', { now: () => now++ });
+    try {
+      await store.claimAgentGraphSupervisorWake({
+        schemaVersion: AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION,
+        graphId: 'graph-pending',
+        wakeId: 'wake-pending',
+        snapshotVersion: 'snapshot-pending',
+        rootSessionId: 'session-pending',
+      });
+      await store.claimAgentGraphSupervisorWake({
+        schemaVersion: AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION,
+        graphId: 'graph-running',
+        wakeId: 'wake-running',
+        snapshotVersion: 'snapshot-running',
+        rootSessionId: 'session-running',
+      });
+      await store.beginAgentGraphSupervisorWakeAttempt({
+        graphId: 'graph-running',
+        wakeId: 'wake-running',
+        attemptId: 'attempt-running',
+        turnId: 'turn-running',
+      });
+
+      assert.equal(await store.recoverAgentGraphSupervisorWakes(), 2);
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-pending', 'wake-pending'))?.status,
+        'retryable_failed',
+      );
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-running', 'wake-running'))?.status,
+        'retryable_failed',
+      );
+      assert.equal(
+        (await store.listAgentGraphSupervisorWakeAttempts('graph-running', 'wake-running'))[0]
+          ?.failureReason,
+        'host_restart',
+      );
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -20,7 +20,7 @@ describe('SqliteSessionMetadataStore', () => {
     try {
       const store = createSqliteSessionMetadataStore(path, { now: () => 100 });
       const header = fullHeader();
-      assert.equal(store.schemaVersion(), 10);
+      assert.equal(store.schemaVersion(), 11);
       assert.equal(store.journalMode(), 'wal');
       assert.deepEqual(await store.create(header), {
         header,
@@ -31,7 +31,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const reopened = createSqliteSessionMetadataStore(path, { now: () => 200 });
       try {
-        assert.equal(reopened.schemaVersion(), 10);
+        assert.equal(reopened.schemaVersion(), 11);
         assert.deepEqual(await reopened.read(header.id), {
           header,
           metadataVersion: 1,
@@ -65,7 +65,7 @@ describe('SqliteSessionMetadataStore', () => {
     const metadata = createSqliteSessionMetadataStore(path);
     try {
       assert.equal(runtime.schemaVersion(), 4);
-      assert.equal(metadata.schemaVersion(), 10);
+      assert.equal(metadata.schemaVersion(), 11);
       await metadata.create(fullHeader());
       await runtime.appendRuntimeEvent('session-1', 'run-1', {
         id: 'event-1',
@@ -173,7 +173,7 @@ describe('SqliteSessionMetadataStore', () => {
 
     const store = createSqliteSessionMetadataStore(path);
     try {
-      assert.equal(store.schemaVersion(), 10);
+      assert.equal(store.schemaVersion(), 11);
       assert.deepEqual(
         (
           await store.list({
@@ -506,6 +506,8 @@ describe('SqliteSessionMetadataStore', () => {
 
       const v4 = new DatabaseSync(path);
       v4.exec(`
+        DROP TABLE agent_graph_supervisor_wake_attempts;
+        DROP TABLE agent_graph_supervisor_wakes;
         DROP TABLE agent_graph_client_applied_records;
         DROP TABLE agent_graph_client_terminal_activity;
         DROP TABLE agent_graph_client_operator_projections;
@@ -533,7 +535,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const migrated = createSqliteSessionMetadataStore(path);
       try {
-        assert.equal(migrated.schemaVersion(), 10);
+        assert.equal(migrated.schemaVersion(), 11);
         assert.equal(await migrated.remove(child.id), true);
         await assert.rejects(
           () => migrated.createSubagent({ ...child, id: 'retry-after-migration' }),

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -20,7 +20,7 @@ describe('SqliteSessionMetadataStore', () => {
     try {
       const store = createSqliteSessionMetadataStore(path, { now: () => 100 });
       const header = fullHeader();
-      assert.equal(store.schemaVersion(), 11);
+      assert.equal(store.schemaVersion(), 12);
       assert.equal(store.journalMode(), 'wal');
       assert.deepEqual(await store.create(header), {
         header,
@@ -31,7 +31,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const reopened = createSqliteSessionMetadataStore(path, { now: () => 200 });
       try {
-        assert.equal(reopened.schemaVersion(), 11);
+        assert.equal(reopened.schemaVersion(), 12);
         assert.deepEqual(await reopened.read(header.id), {
           header,
           metadataVersion: 1,
@@ -65,7 +65,7 @@ describe('SqliteSessionMetadataStore', () => {
     const metadata = createSqliteSessionMetadataStore(path);
     try {
       assert.equal(runtime.schemaVersion(), 4);
-      assert.equal(metadata.schemaVersion(), 11);
+      assert.equal(metadata.schemaVersion(), 12);
       await metadata.create(fullHeader());
       await runtime.appendRuntimeEvent('session-1', 'run-1', {
         id: 'event-1',
@@ -173,7 +173,7 @@ describe('SqliteSessionMetadataStore', () => {
 
     const store = createSqliteSessionMetadataStore(path);
     try {
-      assert.equal(store.schemaVersion(), 11);
+      assert.equal(store.schemaVersion(), 12);
       assert.deepEqual(
         (
           await store.list({
@@ -535,7 +535,7 @@ describe('SqliteSessionMetadataStore', () => {
 
       const migrated = createSqliteSessionMetadataStore(path);
       try {
-        assert.equal(migrated.schemaVersion(), 11);
+        assert.equal(migrated.schemaVersion(), 12);
         assert.equal(await migrated.remove(child.id), true);
         await assert.rejects(
           () => migrated.createSubagent({ ...child, id: 'retry-after-migration' }),

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 11;
+export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 12;
 
 const MIGRATIONS: ReadonlyMap<number, string> = new Map([
   [
@@ -347,6 +347,77 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
         REFERENCES agent_graph_supervisor_wakes(graph_id, wake_id)
         ON DELETE CASCADE
     );
+
+    CREATE INDEX agent_graph_supervisor_wakes_by_status
+      ON agent_graph_supervisor_wakes(status, updated_at, graph_id, wake_id);
+  `,
+  ],
+  [
+    12,
+    `
+    DROP INDEX agent_graph_supervisor_wakes_by_status;
+
+    CREATE TABLE agent_graph_supervisor_wakes_v12 (
+      graph_id TEXT NOT NULL,
+      wake_id TEXT NOT NULL,
+      schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+      snapshot_version TEXT NOT NULL,
+      root_session_id TEXT NOT NULL,
+      status TEXT NOT NULL
+        CHECK (
+          status IN (
+            'pending',
+            'running',
+            'waiting_permission',
+            'delivered',
+            'retryable_failed'
+          )
+        ),
+      attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+      current_attempt_id TEXT,
+      current_turn_id TEXT,
+      failure_reason TEXT,
+      created_at INTEGER NOT NULL CHECK (created_at >= 0),
+      updated_at INTEGER NOT NULL CHECK (updated_at >= 0),
+      PRIMARY KEY(graph_id, wake_id)
+    );
+
+    CREATE TABLE agent_graph_supervisor_wake_attempts_v12 (
+      graph_id TEXT NOT NULL,
+      wake_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL UNIQUE,
+      turn_id TEXT NOT NULL,
+      status TEXT NOT NULL
+        CHECK (
+          status IN (
+            'running',
+            'waiting_permission',
+            'delivered',
+            'retryable_failed'
+          )
+        ),
+      failure_reason TEXT,
+      started_at INTEGER NOT NULL CHECK (started_at >= 0),
+      completed_at INTEGER,
+      PRIMARY KEY(graph_id, wake_id, attempt_id),
+      FOREIGN KEY(graph_id, wake_id)
+        REFERENCES agent_graph_supervisor_wakes_v12(graph_id, wake_id)
+        ON DELETE CASCADE
+    );
+
+    INSERT INTO agent_graph_supervisor_wakes_v12
+    SELECT * FROM agent_graph_supervisor_wakes;
+
+    INSERT INTO agent_graph_supervisor_wake_attempts_v12
+    SELECT * FROM agent_graph_supervisor_wake_attempts;
+
+    DROP TABLE agent_graph_supervisor_wake_attempts;
+    DROP TABLE agent_graph_supervisor_wakes;
+
+    ALTER TABLE agent_graph_supervisor_wakes_v12
+      RENAME TO agent_graph_supervisor_wakes;
+    ALTER TABLE agent_graph_supervisor_wake_attempts_v12
+      RENAME TO agent_graph_supervisor_wake_attempts;
 
     CREATE INDEX agent_graph_supervisor_wakes_by_status
       ON agent_graph_supervisor_wakes(status, updated_at, graph_id, wake_id);

--- a/packages/storage/src/sqlite-session-metadata-schema.ts
+++ b/packages/storage/src/sqlite-session-metadata-schema.ts
@@ -1,6 +1,6 @@
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 10;
+export const SQLITE_SESSION_METADATA_SCHEMA_VERSION = 11;
 
 const MIGRATIONS: ReadonlyMap<number, string> = new Map([
   [
@@ -310,6 +310,46 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
         event_time DESC,
         record_id DESC
       );
+  `,
+  ],
+  [
+    11,
+    `
+    CREATE TABLE agent_graph_supervisor_wakes (
+      graph_id TEXT NOT NULL,
+      wake_id TEXT NOT NULL,
+      schema_version INTEGER NOT NULL CHECK (schema_version = 1),
+      snapshot_version TEXT NOT NULL,
+      root_session_id TEXT NOT NULL,
+      status TEXT NOT NULL
+        CHECK (status IN ('pending', 'running', 'delivered', 'retryable_failed')),
+      attempt_count INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+      current_attempt_id TEXT,
+      current_turn_id TEXT,
+      failure_reason TEXT,
+      created_at INTEGER NOT NULL CHECK (created_at >= 0),
+      updated_at INTEGER NOT NULL CHECK (updated_at >= 0),
+      PRIMARY KEY(graph_id, wake_id)
+    );
+
+    CREATE TABLE agent_graph_supervisor_wake_attempts (
+      graph_id TEXT NOT NULL,
+      wake_id TEXT NOT NULL,
+      attempt_id TEXT NOT NULL UNIQUE,
+      turn_id TEXT NOT NULL,
+      status TEXT NOT NULL
+        CHECK (status IN ('running', 'delivered', 'retryable_failed')),
+      failure_reason TEXT,
+      started_at INTEGER NOT NULL CHECK (started_at >= 0),
+      completed_at INTEGER,
+      PRIMARY KEY(graph_id, wake_id, attempt_id),
+      FOREIGN KEY(graph_id, wake_id)
+        REFERENCES agent_graph_supervisor_wakes(graph_id, wake_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX agent_graph_supervisor_wakes_by_status
+      ON agent_graph_supervisor_wakes(status, updated_at, graph_id, wake_id);
   `,
   ],
 ]);

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -697,7 +697,11 @@ export class SqliteSessionMetadataStore {
     assertAgentGraphSupervisorWakeAttempt(request);
     return this.transaction(() => {
       const wake = this.requireAgentGraphSupervisorWakeSync(request.graphId, request.wakeId);
-      if (wake.status === 'delivered' || wake.status === 'running') {
+      if (
+        wake.status === 'delivered' ||
+        wake.status === 'running' ||
+        wake.status === 'waiting_permission'
+      ) {
         return { wake, acquired: false };
       }
       const now = this.now();
@@ -757,38 +761,45 @@ export class SqliteSessionMetadataStore {
         request.wakeId,
         request.attemptId,
       );
-      if (
-        wake.currentAttemptId !== request.attemptId ||
-        attempt.status !== 'running' ||
-        wake.status !== 'running'
-      ) {
+      if (wake.currentAttemptId !== request.attemptId || attempt.status !== wake.status) {
         if (wake.status === request.status && attempt.status === request.status) return wake;
         throw new SessionMetadataConflictError(
           'Agent graph supervisor wake attempt is no longer current',
         );
       }
+      if (attempt.status !== 'running' && attempt.status !== 'waiting_permission') {
+        if (wake.status === request.status && attempt.status === request.status) return wake;
+        throw new SessionMetadataConflictError(
+          'Agent graph supervisor wake attempt is already terminal',
+        );
+      }
+      if (attempt.status === 'waiting_permission' && request.status === 'waiting_permission') {
+        return wake;
+      }
       const now = this.now();
       const failureReason =
         request.status === 'retryable_failed' ? request.failureReason : undefined;
+      const completedAt = request.status === 'waiting_permission' ? null : now;
       this.db
         .prepare(`
           UPDATE agent_graph_supervisor_wake_attempts
           SET status = ?, failure_reason = ?, completed_at = ?
-          WHERE graph_id = ? AND wake_id = ? AND attempt_id = ? AND status = 'running'
+          WHERE graph_id = ? AND wake_id = ? AND attempt_id = ? AND status = ?
         `)
         .run(
           request.status,
           failureReason ?? null,
-          now,
+          completedAt,
           request.graphId,
           request.wakeId,
           request.attemptId,
+          attempt.status,
         );
       this.db
         .prepare(`
           UPDATE agent_graph_supervisor_wakes
           SET status = ?, failure_reason = ?, updated_at = ?
-          WHERE graph_id = ? AND wake_id = ? AND current_attempt_id = ? AND status = 'running'
+          WHERE graph_id = ? AND wake_id = ? AND current_attempt_id = ? AND status = ?
         `)
         .run(
           request.status,
@@ -797,6 +808,7 @@ export class SqliteSessionMetadataStore {
           request.graphId,
           request.wakeId,
           request.attemptId,
+          wake.status,
         );
       return this.requireAgentGraphSupervisorWakeSync(request.graphId, request.wakeId);
     });
@@ -863,26 +875,42 @@ export class SqliteSessionMetadataStore {
     return rows.map(decodeAgentGraphSupervisorWakeRow);
   }
 
+  async listUnsettledAgentGraphSupervisorWakes(): Promise<AgentGraphSupervisorWakeRecord[]> {
+    this.assertOpen();
+    const rows = this.db
+      .prepare(`
+        SELECT
+          schema_version AS schemaVersion,
+          graph_id AS graphId,
+          wake_id AS wakeId,
+          snapshot_version AS snapshotVersion,
+          root_session_id AS rootSessionId,
+          status,
+          attempt_count AS attemptCount,
+          current_attempt_id AS currentAttemptId,
+          current_turn_id AS currentTurnId,
+          failure_reason AS failureReason,
+          created_at AS createdAt,
+          updated_at AS updatedAt
+        FROM agent_graph_supervisor_wakes
+        WHERE status IN ('running', 'waiting_permission')
+        ORDER BY updated_at ASC, graph_id ASC, wake_id ASC
+      `)
+      .all() as unknown as AgentGraphSupervisorWakeRow[];
+    return rows.map(decodeAgentGraphSupervisorWakeRow);
+  }
+
   async recoverAgentGraphSupervisorWakes(): Promise<number> {
     this.assertOpen();
     return this.transaction(() => {
       const now = this.now();
-      this.db
-        .prepare(`
-          UPDATE agent_graph_supervisor_wake_attempts
-          SET status = 'retryable_failed',
-              failure_reason = 'host_restart',
-              completed_at = ?
-          WHERE status = 'running'
-        `)
-        .run(now);
       const recovered = this.db
         .prepare(`
           UPDATE agent_graph_supervisor_wakes
           SET status = 'retryable_failed',
               failure_reason = 'host_restart',
               updated_at = ?
-          WHERE status IN ('pending', 'running')
+          WHERE status = 'pending'
         `)
         .run(now).changes;
       return Number(recovered);
@@ -2097,7 +2125,9 @@ function decodeAgentGraphSupervisorWakeRow(
 ): AgentGraphSupervisorWakeRecord {
   if (
     row.schemaVersion !== AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION ||
-    !['pending', 'running', 'delivered', 'retryable_failed'].includes(row.status) ||
+    !['pending', 'running', 'waiting_permission', 'delivered', 'retryable_failed'].includes(
+      row.status,
+    ) ||
     !Number.isSafeInteger(row.attemptCount) ||
     row.attemptCount < 0 ||
     !Number.isSafeInteger(row.createdAt) ||
@@ -2131,7 +2161,7 @@ function decodeAgentGraphSupervisorWakeAttemptRow(
   row: AgentGraphSupervisorWakeAttemptRow,
 ): AgentGraphSupervisorWakeAttemptRecord {
   if (
-    !['running', 'delivered', 'retryable_failed'].includes(row.status) ||
+    !['running', 'waiting_permission', 'delivered', 'retryable_failed'].includes(row.status) ||
     !Number.isSafeInteger(row.startedAt) ||
     row.startedAt < 0 ||
     (row.completedAt !== null && (!Number.isSafeInteger(row.completedAt) || row.completedAt < 0))
@@ -2234,7 +2264,11 @@ function assertAgentGraphSupervisorWakeCompletion(
   assertGraphLookupIdentity(request.graphId, 'graph id');
   assertGraphLookupIdentity(request.wakeId, 'supervisor wake id');
   assertGraphLookupIdentity(request.attemptId, 'supervisor wake attempt id');
-  if (request.status !== 'delivered' && request.status !== 'retryable_failed') {
+  if (
+    request.status !== 'waiting_permission' &&
+    request.status !== 'delivered' &&
+    request.status !== 'retryable_failed'
+  ) {
     throw new Error('Invalid agent graph supervisor wake completion status');
   }
   if (

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -33,6 +33,12 @@ import {
   type AgentGraphClientProjectionWithOperator,
   type AgentGraphClientOperatorProjectionRecord,
   type AgentGraphClientTerminalActivityPage,
+  AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION,
+  type AgentGraphSupervisorWakeAttemptRecord,
+  type AgentGraphSupervisorWakeRecord,
+  type BeginAgentGraphSupervisorWakeAttemptRequest,
+  type ClaimAgentGraphSupervisorWakeRequest,
+  type CompleteAgentGraphSupervisorWakeAttemptRequest,
   type CommitAgentGraphClientProjectionRequest,
   type SessionHeader,
   type SessionListFilter,
@@ -629,6 +635,258 @@ export class SqliteSessionMetadataStore {
       `)
       .all(graphId) as unknown as AgentGraphScheduleUpdateRow[];
     return rows.map(decodeAgentGraphScheduleUpdateRow);
+  }
+
+  async claimAgentGraphSupervisorWake(
+    request: ClaimAgentGraphSupervisorWakeRequest,
+  ): Promise<{ wake: AgentGraphSupervisorWakeRecord; created: boolean }> {
+    this.assertOpen();
+    assertAgentGraphSupervisorWakeClaim(request);
+    return this.transaction(() => {
+      const existing = this.readAgentGraphSupervisorWakeSync(request.graphId, request.wakeId);
+      if (existing) {
+        if (
+          existing.snapshotVersion !== request.snapshotVersion ||
+          existing.rootSessionId !== request.rootSessionId
+        ) {
+          throw new SessionMetadataConflictError(
+            'Agent graph supervisor wake identity was reused for another snapshot',
+          );
+        }
+        return { wake: existing, created: false };
+      }
+      const now = this.now();
+      this.db
+        .prepare(`
+          INSERT INTO agent_graph_supervisor_wakes(
+            graph_id,
+            wake_id,
+            schema_version,
+            snapshot_version,
+            root_session_id,
+            status,
+            attempt_count,
+            created_at,
+            updated_at
+          ) VALUES (?, ?, ?, ?, ?, 'pending', 0, ?, ?)
+        `)
+        .run(
+          request.graphId,
+          request.wakeId,
+          request.schemaVersion,
+          request.snapshotVersion,
+          request.rootSessionId,
+          now,
+          now,
+        );
+      return {
+        wake: this.requireAgentGraphSupervisorWakeSync(request.graphId, request.wakeId),
+        created: true,
+      };
+    });
+  }
+
+  async beginAgentGraphSupervisorWakeAttempt(
+    request: BeginAgentGraphSupervisorWakeAttemptRequest,
+  ): Promise<{
+    wake: AgentGraphSupervisorWakeRecord;
+    attempt?: AgentGraphSupervisorWakeAttemptRecord;
+    acquired: boolean;
+  }> {
+    this.assertOpen();
+    assertAgentGraphSupervisorWakeAttempt(request);
+    return this.transaction(() => {
+      const wake = this.requireAgentGraphSupervisorWakeSync(request.graphId, request.wakeId);
+      if (wake.status === 'delivered' || wake.status === 'running') {
+        return { wake, acquired: false };
+      }
+      const now = this.now();
+      const updated = this.db
+        .prepare(`
+          UPDATE agent_graph_supervisor_wakes
+          SET status = 'running',
+              attempt_count = attempt_count + 1,
+              current_attempt_id = ?,
+              current_turn_id = ?,
+              failure_reason = NULL,
+              updated_at = ?
+          WHERE graph_id = ?
+            AND wake_id = ?
+            AND status IN ('pending', 'retryable_failed')
+        `)
+        .run(request.attemptId, request.turnId, now, request.graphId, request.wakeId);
+      if (updated.changes !== 1) {
+        return {
+          wake: this.requireAgentGraphSupervisorWakeSync(request.graphId, request.wakeId),
+          acquired: false,
+        };
+      }
+      this.db
+        .prepare(`
+          INSERT INTO agent_graph_supervisor_wake_attempts(
+            graph_id,
+            wake_id,
+            attempt_id,
+            turn_id,
+            status,
+            started_at
+          ) VALUES (?, ?, ?, ?, 'running', ?)
+        `)
+        .run(request.graphId, request.wakeId, request.attemptId, request.turnId, now);
+      return {
+        wake: this.requireAgentGraphSupervisorWakeSync(request.graphId, request.wakeId),
+        attempt: this.requireAgentGraphSupervisorWakeAttemptSync(
+          request.graphId,
+          request.wakeId,
+          request.attemptId,
+        ),
+        acquired: true,
+      };
+    });
+  }
+
+  async completeAgentGraphSupervisorWakeAttempt(
+    request: CompleteAgentGraphSupervisorWakeAttemptRequest,
+  ): Promise<AgentGraphSupervisorWakeRecord> {
+    this.assertOpen();
+    assertAgentGraphSupervisorWakeCompletion(request);
+    return this.transaction(() => {
+      const wake = this.requireAgentGraphSupervisorWakeSync(request.graphId, request.wakeId);
+      const attempt = this.requireAgentGraphSupervisorWakeAttemptSync(
+        request.graphId,
+        request.wakeId,
+        request.attemptId,
+      );
+      if (
+        wake.currentAttemptId !== request.attemptId ||
+        attempt.status !== 'running' ||
+        wake.status !== 'running'
+      ) {
+        if (wake.status === request.status && attempt.status === request.status) return wake;
+        throw new SessionMetadataConflictError(
+          'Agent graph supervisor wake attempt is no longer current',
+        );
+      }
+      const now = this.now();
+      const failureReason =
+        request.status === 'retryable_failed' ? request.failureReason : undefined;
+      this.db
+        .prepare(`
+          UPDATE agent_graph_supervisor_wake_attempts
+          SET status = ?, failure_reason = ?, completed_at = ?
+          WHERE graph_id = ? AND wake_id = ? AND attempt_id = ? AND status = 'running'
+        `)
+        .run(
+          request.status,
+          failureReason ?? null,
+          now,
+          request.graphId,
+          request.wakeId,
+          request.attemptId,
+        );
+      this.db
+        .prepare(`
+          UPDATE agent_graph_supervisor_wakes
+          SET status = ?, failure_reason = ?, updated_at = ?
+          WHERE graph_id = ? AND wake_id = ? AND current_attempt_id = ? AND status = 'running'
+        `)
+        .run(
+          request.status,
+          failureReason ?? null,
+          now,
+          request.graphId,
+          request.wakeId,
+          request.attemptId,
+        );
+      return this.requireAgentGraphSupervisorWakeSync(request.graphId, request.wakeId);
+    });
+  }
+
+  async readAgentGraphSupervisorWake(
+    graphId: string,
+    wakeId: string,
+  ): Promise<AgentGraphSupervisorWakeRecord | undefined> {
+    this.assertOpen();
+    assertGraphLookupIdentity(graphId, 'graph id');
+    assertGraphLookupIdentity(wakeId, 'supervisor wake id');
+    return this.readAgentGraphSupervisorWakeSync(graphId, wakeId);
+  }
+
+  async listAgentGraphSupervisorWakeAttempts(
+    graphId: string,
+    wakeId: string,
+  ): Promise<AgentGraphSupervisorWakeAttemptRecord[]> {
+    this.assertOpen();
+    assertGraphLookupIdentity(graphId, 'graph id');
+    assertGraphLookupIdentity(wakeId, 'supervisor wake id');
+    const rows = this.db
+      .prepare(`
+        SELECT
+          graph_id AS graphId,
+          wake_id AS wakeId,
+          attempt_id AS attemptId,
+          turn_id AS turnId,
+          status,
+          failure_reason AS failureReason,
+          started_at AS startedAt,
+          completed_at AS completedAt
+        FROM agent_graph_supervisor_wake_attempts
+        WHERE graph_id = ? AND wake_id = ?
+        ORDER BY started_at ASC, attempt_id ASC
+      `)
+      .all(graphId, wakeId) as unknown as AgentGraphSupervisorWakeAttemptRow[];
+    return rows.map(decodeAgentGraphSupervisorWakeAttemptRow);
+  }
+
+  async listRetryableAgentGraphSupervisorWakes(): Promise<AgentGraphSupervisorWakeRecord[]> {
+    this.assertOpen();
+    const rows = this.db
+      .prepare(`
+        SELECT
+          schema_version AS schemaVersion,
+          graph_id AS graphId,
+          wake_id AS wakeId,
+          snapshot_version AS snapshotVersion,
+          root_session_id AS rootSessionId,
+          status,
+          attempt_count AS attemptCount,
+          current_attempt_id AS currentAttemptId,
+          current_turn_id AS currentTurnId,
+          failure_reason AS failureReason,
+          created_at AS createdAt,
+          updated_at AS updatedAt
+        FROM agent_graph_supervisor_wakes
+        WHERE status = 'retryable_failed'
+        ORDER BY updated_at ASC, graph_id ASC, wake_id ASC
+      `)
+      .all() as unknown as AgentGraphSupervisorWakeRow[];
+    return rows.map(decodeAgentGraphSupervisorWakeRow);
+  }
+
+  async recoverAgentGraphSupervisorWakes(): Promise<number> {
+    this.assertOpen();
+    return this.transaction(() => {
+      const now = this.now();
+      this.db
+        .prepare(`
+          UPDATE agent_graph_supervisor_wake_attempts
+          SET status = 'retryable_failed',
+              failure_reason = 'host_restart',
+              completed_at = ?
+          WHERE status = 'running'
+        `)
+        .run(now);
+      const recovered = this.db
+        .prepare(`
+          UPDATE agent_graph_supervisor_wakes
+          SET status = 'retryable_failed',
+              failure_reason = 'host_restart',
+              updated_at = ?
+          WHERE status IN ('pending', 'running')
+        `)
+        .run(now).changes;
+      return Number(recovered);
+    });
   }
 
   async listAgentGraphOperatorProvisions(graphId: string): Promise<AgentGraphOperatorProvision[]> {
@@ -1622,6 +1880,73 @@ export class SqliteSessionMetadataStore {
     return revision;
   }
 
+  private readAgentGraphSupervisorWakeSync(
+    graphId: string,
+    wakeId: string,
+  ): AgentGraphSupervisorWakeRecord | undefined {
+    const row = this.db
+      .prepare(`
+        SELECT
+          schema_version AS schemaVersion,
+          graph_id AS graphId,
+          wake_id AS wakeId,
+          snapshot_version AS snapshotVersion,
+          root_session_id AS rootSessionId,
+          status,
+          attempt_count AS attemptCount,
+          current_attempt_id AS currentAttemptId,
+          current_turn_id AS currentTurnId,
+          failure_reason AS failureReason,
+          created_at AS createdAt,
+          updated_at AS updatedAt
+        FROM agent_graph_supervisor_wakes
+        WHERE graph_id = ? AND wake_id = ?
+      `)
+      .get(graphId, wakeId) as AgentGraphSupervisorWakeRow | undefined;
+    return row ? decodeAgentGraphSupervisorWakeRow(row) : undefined;
+  }
+
+  private requireAgentGraphSupervisorWakeSync(
+    graphId: string,
+    wakeId: string,
+  ): AgentGraphSupervisorWakeRecord {
+    const wake = this.readAgentGraphSupervisorWakeSync(graphId, wakeId);
+    if (!wake) {
+      throw new SessionMetadataConflictError(
+        `Agent graph supervisor wake ${graphId}/${wakeId} was not claimed`,
+      );
+    }
+    return wake;
+  }
+
+  private requireAgentGraphSupervisorWakeAttemptSync(
+    graphId: string,
+    wakeId: string,
+    attemptId: string,
+  ): AgentGraphSupervisorWakeAttemptRecord {
+    const row = this.db
+      .prepare(`
+        SELECT
+          graph_id AS graphId,
+          wake_id AS wakeId,
+          attempt_id AS attemptId,
+          turn_id AS turnId,
+          status,
+          failure_reason AS failureReason,
+          started_at AS startedAt,
+          completed_at AS completedAt
+        FROM agent_graph_supervisor_wake_attempts
+        WHERE graph_id = ? AND wake_id = ? AND attempt_id = ?
+      `)
+      .get(graphId, wakeId, attemptId) as AgentGraphSupervisorWakeAttemptRow | undefined;
+    if (!row) {
+      throw new SessionMetadataConflictError(
+        `Agent graph supervisor wake attempt ${attemptId} was not found`,
+      );
+    }
+    return decodeAgentGraphSupervisorWakeAttemptRow(row);
+  }
+
   private hasTombstone(sessionId: string): boolean {
     return (
       this.db
@@ -1729,6 +2054,32 @@ interface AgentGraphClientAppliedRecordRow {
   eventTime: number;
 }
 
+interface AgentGraphSupervisorWakeRow {
+  schemaVersion: number;
+  graphId: string;
+  wakeId: string;
+  snapshotVersion: string;
+  rootSessionId: string;
+  status: string;
+  attemptCount: number;
+  currentAttemptId: string | null;
+  currentTurnId: string | null;
+  failureReason: string | null;
+  createdAt: number;
+  updatedAt: number;
+}
+
+interface AgentGraphSupervisorWakeAttemptRow {
+  graphId: string;
+  wakeId: string;
+  attemptId: string;
+  turnId: string;
+  status: string;
+  failureReason: string | null;
+  startedAt: number;
+  completedAt: number | null;
+}
+
 interface AgentGraphClientTerminalActivityRowWithIdentity
   extends AgentGraphClientTerminalActivityRow {
   graphId: string;
@@ -1739,6 +2090,68 @@ function decodeAgentGraphScheduleUpdateRow(
   row: AgentGraphScheduleUpdateRow,
 ): AgentGraphScheduleUpdate {
   return decodeAgentGraphScheduleUpdate(JSON.parse(row.payloadJson) as unknown);
+}
+
+function decodeAgentGraphSupervisorWakeRow(
+  row: AgentGraphSupervisorWakeRow,
+): AgentGraphSupervisorWakeRecord {
+  if (
+    row.schemaVersion !== AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION ||
+    !['pending', 'running', 'delivered', 'retryable_failed'].includes(row.status) ||
+    !Number.isSafeInteger(row.attemptCount) ||
+    row.attemptCount < 0 ||
+    !Number.isSafeInteger(row.createdAt) ||
+    row.createdAt < 0 ||
+    !Number.isSafeInteger(row.updatedAt) ||
+    row.updatedAt < 0
+  ) {
+    throw new Error(`Invalid agent graph supervisor wake ${row.graphId}/${row.wakeId}`);
+  }
+  assertGraphLookupIdentity(row.graphId, 'graph id');
+  assertGraphLookupIdentity(row.wakeId, 'supervisor wake id');
+  assertGraphLookupIdentity(row.snapshotVersion, 'snapshot version');
+  assertSafeSessionId(row.rootSessionId);
+  return {
+    schemaVersion: row.schemaVersion,
+    graphId: row.graphId,
+    wakeId: row.wakeId,
+    snapshotVersion: row.snapshotVersion,
+    rootSessionId: row.rootSessionId,
+    status: row.status as AgentGraphSupervisorWakeRecord['status'],
+    attemptCount: row.attemptCount,
+    ...(row.currentAttemptId ? { currentAttemptId: row.currentAttemptId } : {}),
+    ...(row.currentTurnId ? { currentTurnId: row.currentTurnId } : {}),
+    ...(row.failureReason ? { failureReason: row.failureReason } : {}),
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+function decodeAgentGraphSupervisorWakeAttemptRow(
+  row: AgentGraphSupervisorWakeAttemptRow,
+): AgentGraphSupervisorWakeAttemptRecord {
+  if (
+    !['running', 'delivered', 'retryable_failed'].includes(row.status) ||
+    !Number.isSafeInteger(row.startedAt) ||
+    row.startedAt < 0 ||
+    (row.completedAt !== null && (!Number.isSafeInteger(row.completedAt) || row.completedAt < 0))
+  ) {
+    throw new Error(`Invalid agent graph supervisor wake attempt ${row.attemptId}`);
+  }
+  assertGraphLookupIdentity(row.graphId, 'graph id');
+  assertGraphLookupIdentity(row.wakeId, 'supervisor wake id');
+  assertGraphLookupIdentity(row.attemptId, 'supervisor wake attempt id');
+  assertGraphLookupIdentity(row.turnId, 'supervisor wake turn id');
+  return {
+    graphId: row.graphId,
+    wakeId: row.wakeId,
+    attemptId: row.attemptId,
+    turnId: row.turnId,
+    status: row.status as AgentGraphSupervisorWakeAttemptRecord['status'],
+    ...(row.failureReason ? { failureReason: row.failureReason } : {}),
+    startedAt: row.startedAt,
+    ...(row.completedAt !== null ? { completedAt: row.completedAt } : {}),
+  };
 }
 
 function subagentSpawnScope(parent: SubagentSessionParent): {
@@ -1793,6 +2206,42 @@ function assertGraphLookupIdentity(value: string, name: string): void {
     /[\u0000-\u001f\u007f]/.test(value)
   ) {
     throw new Error(`Invalid agent graph ${name}`);
+  }
+}
+
+function assertAgentGraphSupervisorWakeClaim(request: ClaimAgentGraphSupervisorWakeRequest): void {
+  if (request.schemaVersion !== AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION) {
+    throw new Error('Invalid agent graph supervisor wake schema');
+  }
+  assertGraphLookupIdentity(request.graphId, 'graph id');
+  assertGraphLookupIdentity(request.wakeId, 'supervisor wake id');
+  assertGraphLookupIdentity(request.snapshotVersion, 'snapshot version');
+  assertSafeSessionId(request.rootSessionId);
+}
+
+function assertAgentGraphSupervisorWakeAttempt(
+  request: BeginAgentGraphSupervisorWakeAttemptRequest,
+): void {
+  assertGraphLookupIdentity(request.graphId, 'graph id');
+  assertGraphLookupIdentity(request.wakeId, 'supervisor wake id');
+  assertGraphLookupIdentity(request.attemptId, 'supervisor wake attempt id');
+  assertGraphLookupIdentity(request.turnId, 'supervisor wake turn id');
+}
+
+function assertAgentGraphSupervisorWakeCompletion(
+  request: CompleteAgentGraphSupervisorWakeAttemptRequest,
+): void {
+  assertGraphLookupIdentity(request.graphId, 'graph id');
+  assertGraphLookupIdentity(request.wakeId, 'supervisor wake id');
+  assertGraphLookupIdentity(request.attemptId, 'supervisor wake attempt id');
+  if (request.status !== 'delivered' && request.status !== 'retryable_failed') {
+    throw new Error('Invalid agent graph supervisor wake completion status');
+  }
+  if (
+    request.status === 'retryable_failed' &&
+    (!request.failureReason?.trim() || request.failureReason.length > 4_000)
+  ) {
+    throw new Error('Agent graph supervisor wake failure reason must be non-empty and bounded');
   }
 }
 

--- a/packages/ui/src/__tests__/conversation-localization.test.tsx
+++ b/packages/ui/src/__tests__/conversation-localization.test.tsx
@@ -184,6 +184,29 @@ describe('localized conversation journey', () => {
     );
   });
 
+  it('localizes the active Graph Mode indicator', () => {
+    const zh = render(
+      'zh',
+      <Composer
+        onSend={() => {}}
+        onStop={() => {}}
+        graphModeActive
+        onGraphModeChange={() => {}}
+      />,
+    );
+    const en = render(
+      'en',
+      <Composer
+        onSend={() => {}}
+        onStop={() => {}}
+        graphModeActive
+        onGraphModeChange={() => {}}
+      />,
+    );
+    assert.match(zh, /Graph 模式已启用/);
+    assert.match(en, /Graph mode is on/);
+  });
+
   it('keeps the ＋ menu reachable while streaming (#1444)', () => {
     const markup = render(
       'zh',

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -429,6 +429,16 @@ export const TurnView = memo(function TurnView(props: {
           <span>{copy.automationTriggered}</span>
         </Marker>
       )}
+      {turn.user?.agentGraphOrigin && (
+        <Marker
+          variant="automation-origin"
+          role="note"
+          title={copy.agentGraphTitle(turn.user.agentGraphOrigin.graphId)}
+        >
+          <GitBranch size={12} aria-hidden="true" />
+          <span>{copy.agentGraphTriggered}</span>
+        </Marker>
+      )}
       {turn.user && (
         <Message
           variant="user"
@@ -444,7 +454,9 @@ export const TurnView = memo(function TurnView(props: {
             quotes={turn.user.quotes}
             onReadAttachmentBytes={props.onReadAttachmentBytes}
             onEditUserMessage={
-              props.onEditUserMessage && !turn.user.automationOrigin
+              props.onEditUserMessage &&
+              !turn.user.automationOrigin &&
+              !turn.user.agentGraphOrigin
                 ? () => props.onEditUserMessage?.(turn.turnId)
                 : undefined
             }

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -222,6 +222,10 @@ export const Composer = forwardRef<
     swarmModePending?: boolean;
     swarmModeDisabledReason?: string;
     onSwarmModeChange?(active: boolean): void | Promise<void>;
+    graphModeActive?: boolean;
+    graphModePending?: boolean;
+    graphModeDisabledReason?: string;
+    onGraphModeChange?(active: boolean): void | Promise<void>;
     /**
      * Composer mention popups. Both are optional and the whole feature no-ops
      * when absent (SSR contracts render Composer with minimal props):
@@ -775,7 +779,7 @@ export const Composer = forwardRef<
                 actions still no-op mid-turn (`runImportAction` / drop
                 target), so the attach item is disabled rather than
                 vanishing the whole menu (and Plan/Swarm / expert teams). */}
-            {(props.onPickAttachments || (props.expertTeams?.length ?? 0) > 0 || props.onPlanModeChange || props.onSwarmModeChange) ? (
+            {(props.onPickAttachments || (props.expertTeams?.length ?? 0) > 0 || props.onPlanModeChange || props.onSwarmModeChange || props.onGraphModeChange) ? (
               <Menu>
                 <MenuTrigger
                   render={({ onClick: menuToggleClick, ...triggerRest }) => (
@@ -829,7 +833,7 @@ export const Composer = forwardRef<
                   {/* #1433 subtraction: Plan/Swarm live here as switch
                       items instead of standalone toolbar switches — the
                       toolbar keeps only add / permission / model / send. */}
-                  {props.onPlanModeChange || props.onSwarmModeChange ? (
+                  {props.onPlanModeChange || props.onSwarmModeChange || props.onGraphModeChange ? (
                     <>
                       {/* Separator only when an attachment/expert-team group
                           precedes it — a modes-only menu must not lead with
@@ -875,6 +879,26 @@ export const Composer = forwardRef<
                           }
                         >
                           {copy.swarmModeLabel}
+                        </MenuCheckboxItem>
+                      ) : null}
+                      {props.onGraphModeChange ? (
+                        <MenuCheckboxItem
+                          variant="switch"
+                          checked={props.graphModeActive === true}
+                          disabled={
+                            props.disabled
+                            || props.graphModePending === true
+                            || Boolean(props.graphModeDisabledReason)
+                          }
+                          onCheckedChange={(checked) => {
+                            void props.onGraphModeChange?.(checked);
+                          }}
+                          title={
+                            props.graphModeDisabledReason
+                            ?? (props.graphModeActive ? copy.disableGraphMode : copy.enableGraphMode)
+                          }
+                        >
+                          {copy.graphModeLabel}
                         </MenuCheckboxItem>
                       ) : null}
                     </>
@@ -951,6 +975,26 @@ export const Composer = forwardRef<
                 }
               >
                 {copy.swarmModeLabel}
+                <X size={12} aria-hidden="true" />
+              </button>
+            ) : null}
+            {props.graphModeActive ? (
+              <button
+                type="button"
+                className="maka-composer-mode-indicator"
+                data-mode="graph"
+                disabled={
+                  props.disabled
+                  || props.graphModePending === true
+                  || Boolean(props.graphModeDisabledReason)
+                }
+                onClick={() => {
+                  void props.onGraphModeChange?.(false);
+                }}
+                aria-label={copy.graphModeOnTitle}
+                title={props.graphModeDisabledReason ?? copy.graphModeOnTitle}
+              >
+                {copy.graphModeLabel}
                 <X size={12} aria-hidden="true" />
               </button>
             ) : null}

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -227,6 +227,8 @@ export interface ConversationCopy {
     derivativesAriaLabel: string;
     automationTriggered: string;
     automationTitle: (id: string) => string;
+    agentGraphTriggered: string;
+    agentGraphTitle: (graphId: string) => string;
     thinkingTruncatedTitle: string;
     outputTruncatedTitle: string;
     removeAttachmentAriaLabel: (name: string) => string;
@@ -384,7 +386,7 @@ const CONVERSATION_COPY = {
     },
     messages: {
       you: '你', assistant: 'Maka', processing: '正在处理…', continuing: '继续中…', providerRetryScheduled: (seconds, attempt, maxAttempts) => `${seconds} 秒后重试（${attempt}/${maxAttempts}）`, providerRetryStarted: (attempt, maxAttempts) => `正在重试（${attempt}/${maxAttempts}）`, safeResumePending: '正在验证…', safeResume: '安全恢复', thinking: '深度思考', truncated: '已截断', copied: '已复制', copying: '复制中', copyFailed: '复制失败', copy: '复制', copyMessage: '复制消息', editMessage: '编辑并重发', editMessageDisabledRunning: '当前回答仍在进行中，结束后再编辑', editMessageDisabledAttachments: '包含附件的历史消息暂不支持编辑并重发', editMessageDisabledQuotes: '包含引用的历史消息暂不支持编辑并重发', editMessageDisabledTransformedText: '通过显式技能发送的历史消息暂不支持编辑并重发', copyThinking: '复制思考过程',
-      imageAriaLabel: (name) => `查看图片 ${name}`, userAriaLabel: '你发送的消息', assistantAriaLabel: 'Maka 的回答', answerActionsAriaLabel: '本轮回答操作', sourceAriaLabel: '本轮回答的来源', derivativesAriaLabel: '本轮回答的衍生', automationTriggered: '定时任务触发', automationTitle: (id) => `由定时任务触发 · ${id}`,
+      imageAriaLabel: (name) => `查看图片 ${name}`, userAriaLabel: '你发送的消息', assistantAriaLabel: 'Maka 的回答', answerActionsAriaLabel: '本轮回答操作', sourceAriaLabel: '本轮回答的来源', derivativesAriaLabel: '本轮回答的衍生', automationTriggered: '定时任务触发', automationTitle: (id) => `由定时任务触发 · ${id}`, agentGraphTriggered: 'Agent Graph 自动继续', agentGraphTitle: (graphId) => `由 Agent Graph 调度器触发 · ${graphId}`,
       thinkingTruncatedTitle: '部分 reasoning 已截断；显示的是最近的内容', outputTruncatedTitle: '助手输出已超过单次回合上限，超出部分未渲染。如需完整内容请重新生成或查看持久化的会话日志。', removeAttachmentAriaLabel: (name) => `移除 ${name}`, quoteLabel: '引用', quoteExpandAriaLabel: '展开引用全文', quoteCollapseAriaLabel: '收起引用', removeQuoteAriaLabel: '移除引用', aborted: '(已中断)', abortedByStop: '(已中断 · 由停止按钮触发)',
     },
     chat: {
@@ -523,7 +525,7 @@ const CONVERSATION_COPY = {
     },
     messages: {
       you: 'You', assistant: 'Maka', processing: 'Working…', continuing: 'Continuing…', providerRetryScheduled: (seconds, attempt, maxAttempts) => `Retrying in ${seconds}s (${attempt}/${maxAttempts})`, providerRetryStarted: (attempt, maxAttempts) => `Retrying (${attempt}/${maxAttempts})`, safeResumePending: 'Checking…', safeResume: 'Safe recovery', thinking: 'Thinking', truncated: 'Truncated', copied: 'Copied', copying: 'Copying', copyFailed: 'Copy failed', copy: 'Copy', copyMessage: 'Copy message', editMessage: 'Edit & resend', editMessageDisabledRunning: 'Wait for this answer to finish before editing', editMessageDisabledAttachments: 'Edit & resend does not yet support messages with attachments', editMessageDisabledQuotes: 'Edit & resend does not yet support messages with quotes', editMessageDisabledTransformedText: 'Edit & resend does not yet support messages sent with an explicit skill', copyThinking: 'Copy reasoning',
-      imageAriaLabel: (name) => `View image ${name}`, userAriaLabel: 'Your message', assistantAriaLabel: "Maka's response", answerActionsAriaLabel: 'Response actions', sourceAriaLabel: 'Source of this response', derivativesAriaLabel: 'Responses derived from this one', automationTriggered: 'Triggered by automation', automationTitle: (id) => `Triggered by automation · ${id}`,
+      imageAriaLabel: (name) => `View image ${name}`, userAriaLabel: 'Your message', assistantAriaLabel: "Maka's response", answerActionsAriaLabel: 'Response actions', sourceAriaLabel: 'Source of this response', derivativesAriaLabel: 'Responses derived from this one', automationTriggered: 'Triggered by automation', automationTitle: (id) => `Triggered by automation · ${id}`, agentGraphTriggered: 'Continued by Agent Graph', agentGraphTitle: (graphId) => `Triggered by the Agent Graph scheduler · ${graphId}`,
       thinkingTruncatedTitle: 'Some reasoning was truncated; showing the most recent content', outputTruncatedTitle: 'The assistant output exceeded the per-turn limit. Regenerate it or inspect the persisted session log for the complete content.', removeAttachmentAriaLabel: (name) => `Remove ${name}`, quoteLabel: 'Quote', quoteExpandAriaLabel: 'Show the full quoted excerpt', quoteCollapseAriaLabel: 'Collapse the quoted excerpt', removeQuoteAriaLabel: 'Remove quote', aborted: '(Interrupted)', abortedByStop: '(Interrupted · Stop button)',
     },
     chat: {

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -92,6 +92,10 @@ export interface ConversationCopy {
     enableSwarmMode: string;
     disableSwarmMode: string;
     swarmModeOnTitle: string;
+    graphModeLabel: string;
+    enableGraphMode: string;
+    disableGraphMode: string;
+    graphModeOnTitle: string;
     /** Inline hint shown above the composer when no model connection exists yet. */
     noModelHint: string;
     /** Link-button on that hint that opens Settings · 模型. */
@@ -337,6 +341,8 @@ const CONVERSATION_COPY = {
       planModeOnTitle: 'Plan 模式已启用，点击关闭',
       swarmModeLabel: 'Swarm', enableSwarmMode: '开启 Swarm Mode', disableSwarmMode: '退出 Swarm Mode',
       swarmModeOnTitle: 'Swarm 模式已启用，点击关闭',
+      graphModeLabel: 'Graph', enableGraphMode: '开启 Graph Mode', disableGraphMode: '退出 Graph Mode',
+      graphModeOnTitle: 'Graph 模式已启用，点击关闭',
       noModelHint: '还没有可用的模型连接，无法发送。', noModelAction: '前往模型设置', noModelSendTitle: '先添加一个模型连接才能发送。',
     },
     model: {
@@ -474,6 +480,8 @@ const CONVERSATION_COPY = {
       planModeOnTitle: 'Plan mode is on — click to turn off',
       swarmModeLabel: 'Swarm', enableSwarmMode: 'Enable Swarm Mode', disableSwarmMode: 'Disable Swarm Mode',
       swarmModeOnTitle: 'Swarm mode is on — click to turn off',
+      graphModeLabel: 'Graph', enableGraphMode: 'Enable Graph Mode', disableGraphMode: 'Disable Graph Mode',
+      graphModeOnTitle: 'Graph mode is on — click to turn off',
       noModelHint: 'No model connection yet, so sending is unavailable.', noModelAction: 'Go to model settings', noModelSendTitle: 'Add a model connection before sending.',
     },
     model: {

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -22,6 +22,8 @@ export interface ChatItem {
   quotes?: QuoteRef[];
   /** Present when the turn was fired by an automation, not hand-typed. */
   automationOrigin?: { automationId: string };
+  /** Present when the host resumed the root Agent at a durable graph milestone. */
+  agentGraphOrigin?: { graphId: string; wakeId: string };
 }
 
 /**
@@ -478,6 +480,14 @@ export function materializeTurns(messages: StoredMessage[]): TurnViewModel[] {
         ...(message.attachments && message.attachments.length > 0 ? { attachments: message.attachments } : {}),
         ...(message.quotes && message.quotes.length > 0 ? { quotes: message.quotes } : {}),
         ...(message.origin?.kind === 'automation' ? { automationOrigin: { automationId: message.origin.automationId } } : {}),
+        ...(message.origin?.kind === 'agent_graph'
+          ? {
+              agentGraphOrigin: {
+                graphId: message.origin.graphId,
+                wakeId: message.origin.wakeId,
+              },
+            }
+          : {}),
       };
     } else if (message.type === 'assistant') {
       // A turn now holds one AssistantMessage per model step. Concatenate their

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -23,7 +23,7 @@ export interface ChatItem {
   /** Present when the turn was fired by an automation, not hand-typed. */
   automationOrigin?: { automationId: string };
   /** Present when the host resumed the root Agent at a durable graph milestone. */
-  agentGraphOrigin?: { graphId: string; wakeId: string };
+  agentGraphOrigin?: { graphId: string; wakeId: string; attemptId: string };
 }
 
 /**
@@ -485,6 +485,7 @@ export function materializeTurns(messages: StoredMessage[]): TurnViewModel[] {
               agentGraphOrigin: {
                 graphId: message.origin.graphId,
                 wakeId: message.origin.wakeId,
+                attemptId: message.origin.attemptId,
               },
             }
           : {}),


### PR DESCRIPTION
## Summary

This is PR 4 of the playable Graph Mode path proposed in #1341. It turns the host-managed graph primitives into a first Desktop-facing workflow while keeping the main agent beside the data path as supervisor.

- add trusted `graph` orchestration at the Session and per-turn boundaries, including `/graph`, `/graph status`, `/graph on`, `/graph off`, and `/graph <task>`
- inject the shared Graph Mode supervisor prompt and keep `view_agent_graph` / `update_agent_graph` available from step 0
- add a Composer Graph switch with the same pending/running/waiting safety boundaries as Swarm Mode
- render a bounded live Graph panel from the existing durable client read model, including operator status, wait reason, progress, selected results, stop, and linked child-Session navigation
- reconnect from a durable snapshot for both persistent and one-shot Graph Mode, so a missed invalidation or Desktop restart does not hide existing graph activity
- expose each runtime operator child Session/run reference to the trusted supervisor view, allowing the main agent to read authoritative child output through the existing `agent_output` tool before selecting committed result record ids
- add English/Chinese copy and host, runtime, core, and UI contract coverage

This deliberately does **not** add a graph canvas, arbitrary topology rewriting/cycles, resource permits, global fairness, or full backpressure policy.

Stacked on #1468 and the already-merged child PRs #1474, #1480, and #1483.

Advances #1341.

## Verification

- `npm run typecheck`
- core Graph command/orchestration tests: 9 passed
- runtime Graph prompt/supervisor/deferred-tool tests: 20 passed
- UI localization test: 14 passed
- `npm test --workspace @maka/desktop`: 2851 passed
- `npm run build:renderer --workspace @maka/desktop`
- `git diff --check`

The complete Runtime suite was also exercised locally; its Graph coverage passed, while two pre-existing macOS sandbox/environment checks remain non-green on this machine (`/usr/local` executable-root expectation and Homebrew `rg`/PCRE2 dylib loading inside the filesystem worker sandbox).

<details>
<summary>中文说明</summary>

## 概要

这是 #1341 “首次可玩的 Graph Mode”交付路径中的第 4 个 PR。它把已有的 host-managed graph primitives 接进 Desktop，同时保持主 Agent 始终站在数据路径旁边做 supervisor，而不是成为每条 record 的审批门。

- 在 Session 和单 turn override 边界加入可信 `graph` orchestration，并支持 `/graph`、`/graph status`、`/graph on`、`/graph off`、`/graph <任务>`
- 注入共享的 Graph Mode supervisor prompt，并保证 `view_agent_graph` / `update_agent_graph` 从 step 0 可用
- 在 Composer 的添加菜单里加入 Graph 开关，并复用 Swarm Mode 的 pending/running/waiting 安全边界
- 通过既有 durable client read model 展示紧凑的实时 Graph 面板：operator 状态、等待原因、进度、选中结果、停止操作和 child Session 跳转
- persistent 与 one-shot Graph Mode 都会从 durable snapshot 重连，避免错过 invalidation 或 Desktop 重启后看不到已有 graph activity
- 在可信 supervisor view 中暴露 operator 的 child Session/run 引用，主 Agent 可通过既有 `agent_output` 读取权威 child 输出，再选择 committed result record ids
- 增加中英文文案，以及 host、runtime、core、UI 契约测试

本 PR 明确不包含 graph canvas、任意拓扑重写/环、resource permits、全局公平性和完整 backpressure policy。

本 PR stack 在 #1468 之上，并包含已经合入该 stack 的 #1474、#1480、#1483。

推进 #1341。

## 验证

- `npm run typecheck`
- Core Graph command/orchestration：9 个测试通过
- Runtime Graph prompt/supervisor/deferred-tool：20 个测试通过
- UI localization：14 个测试通过
- `npm test --workspace @maka/desktop`：2851 个测试通过
- `npm run build:renderer --workspace @maka/desktop`
- `git diff --check`

本地也执行了完整 Runtime suite；Graph 相关覆盖均通过，但当前机器上仍有两个既有的 macOS sandbox/environment 检查未通过：`/usr/local` executable-root 预期，以及 filesystem worker sandbox 内 Homebrew `rg`/PCRE2 dylib 加载问题。

</details>