### PR TITLE
fix(chat): align the session health notice to the composer measure

### DIFF
--- a/apps/desktop/e2e/session-health-notice.spec.ts
+++ b/apps/desktop/e2e/session-health-notice.spec.ts
@@ -14,9 +14,39 @@
 
 import { test, expect } from './fixtures';
 
+// The notice is a PEER of the composer form (both are children of
+// `.mainColumn`), not a child of it, so nothing inherits the composer's
+// measure for it — it has to opt in with the same
+// `min(--maka-chat-measure, 100% - 2*--space-6)` box. It shipped with a bare
+// `margin: 0 var(--space-3)` instead, so on any window wider than the 680px
+// measure the notice ran the full chat column while the composer card stayed
+// centered at 680 — two mismatched edges stacked on each other. Left/right
+// edges are the assertion; width alone would pass a notice that is the right
+// size but off-center.
+async function probeNoticeAlignment(page: import('@playwright/test').Page) {
+  return await page.evaluate(() => {
+    const notice = document.querySelector<HTMLElement>('.maka-session-health-notice');
+    const composer = document.querySelector<HTMLElement>('.composer .maka-composer-inner');
+    if (!notice || !composer) {
+      throw new Error('Expected both the health notice and the composer card to be mounted');
+    }
+    const noticeBox = notice.getBoundingClientRect();
+    const composerBox = composer.getBoundingClientRect();
+    return {
+      leftDelta: Math.abs(noticeBox.left - composerBox.left),
+      rightDelta: Math.abs(noticeBox.right - composerBox.right),
+    };
+  });
+}
+
 test('locked stale sessions show the health notice even with a ready default', async ({ staleSessionsWindow: page }) => {
   // Active = stale fake session (locked by its history): notice shows.
   await expect(page.getByText('会话已过期 · 请先配置真实模型')).toBeVisible();
+
+  // The notice shares the composer card's edges — see probeNoticeAlignment.
+  const alignment = await probeNoticeAlignment(page);
+  expect(alignment.leftDelta).toBeLessThanOrEqual(1);
+  expect(alignment.rightDelta).toBeLessThanOrEqual(1);
 
   // Switch to the locked legacy session → its deleted-connection notice.
   await page.getByRole('button', { name: '展开侧边栏' }).click();

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -32,14 +32,23 @@
 }
 
 /* #1032: hard-block session health notice sits above the composer,
-   outside the message scroll area (sibling of maka-composer-interaction-slot). */
+   outside the message scroll area (sibling of maka-composer-interaction-slot).
+   It is a peer of the composer form, so it must resolve to the SAME box as the
+   composer card: capped at the chat measure, centered, and inset by the
+   composer's own `--space-6` gutters. The old `margin: 0 var(--space-3)` left it
+   uncapped, so on a wide window the notice ran the full chat column while the
+   composer stayed at 680px — a visibly mismatched edge. Same formula as
+   `.maka-composer-no-model-hint` / `.maka-composer-revision-notice`. */
 .maka-session-health-notice {
-  margin: 0 var(--space-3) var(--space-2);
+  width: min(var(--maka-chat-measure), calc(100% - (2 * var(--space-6))));
+  max-width: var(--maka-chat-measure);
+  margin: 0 auto var(--space-2);
   -webkit-app-region: no-drag;
 }
 
 .maka-session-health-notice-alert {
-  width: auto;
+  width: 100%;
+  box-sizing: border-box;
 }
 
 .maka-session-health-notice-action {


### PR DESCRIPTION
## What

The session-health notice above the composer rendered at a different width than the composer card itself, so their left/right edges did not line up.

## Why

The notice is a **peer** of the composer form — both are children of `.mainColumn` — so it inherits nothing from the composer's box. It shipped with a bare `margin: 0 var(--space-3)` and no measure cap, so on any window wider than the 680px `--maka-chat-measure` the notice ran the full chat column while the composer card stayed centered at 680.

The two other above-composer notices (`.maka-composer-no-model-hint`, `.maka-composer-revision-notice`) already solve this with a shared formula; this one was simply missed.

## How

```css
.maka-session-health-notice {
  width: min(var(--maka-chat-measure), calc(100% - (2 * var(--space-6))));
  max-width: var(--maka-chat-measure);
  margin: 0 auto var(--space-2);
}
```

The `calc` term matches the composer form's own `--space-6` gutters, so the edges also line up on windows narrower than the measure. The inner `Alert` moves from `width: auto` to `width: 100%` + `box-sizing: border-box` so it fills the narrowed wrapper rather than resolving its own width.

## Verification

- Added a geometry assertion to the existing `session-health-notice` e2e journey: the notice's left and right edges must match `.maka-composer-inner`'s within 1px.
- **Confirmed the assertion actually catches the bug** — stashed the CSS fix, rebuilt the renderer, and the spec fails; restored it and it passes.
- `npm --workspace @maka/desktop run test` — 2855/2855 pass, including the `session-health-notice-layout-contract` suite (which requires the rule to keep a `margin:` declaration).
