### PR TITLE
feat(skills): let the panel delete user-scope skills

### DIFF
--- a/apps/desktop/src/main/__tests__/skills.test.ts
+++ b/apps/desktop/src/main/__tests__/skills.test.ts
@@ -275,8 +275,12 @@ description: Workspace workflow.
       const entries = await listGovernedSkillEntries(workspaceRoot, options);
       assert.deepEqual(entries.map((skill) => skill.scope).sort(), ['project', 'user', 'workspace']);
       assert.equal(entries.find((skill) => skill.id === 'project-helper')?.ref, 'project:maka:project-helper');
-      assert.equal(entries.find((skill) => skill.id === 'user-helper')?.manageable, false);
+      // User-scope skills are the user's own installs under ~/.maka|.agents,
+      // so the panel deletes them. Project-scope skills live in the repo and
+      // are left to git — see isManageableSkill.
+      assert.equal(entries.find((skill) => skill.id === 'user-helper')?.manageable, true);
       assert.equal(entries.find((skill) => skill.id === 'workspace-helper')?.manageable, true);
+      assert.equal(entries.find((skill) => skill.id === 'project-helper')?.manageable, false);
 
       const pinned = await setSkillPinned(
         workspaceRoot,
@@ -682,6 +686,90 @@ description: 用于测试删除已安装技能。
 
       // Deleting an absent skill is a clean not_found, not a throw.
       assert.deepEqual(await deleteSkill(workspaceRoot, 'starter-skill'), { ok: false, reason: 'not_found' });
+    });
+  });
+
+  it('deletes a user-scope skill by ref and leaves project-scope skills alone', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const projectRoot = join(workspaceRoot, 'project');
+      const homeDir = join(workspaceRoot, 'home');
+      await mkdir(projectRoot, { recursive: true });
+      await mkdir(homeDir, { recursive: true });
+      await writeSkillAt(join(homeDir, '.agents', 'skills'), 'user-helper', 'User Helper', 'User workflow.');
+      await writeSkillAt(join(projectRoot, '.maka', 'skills'), 'project-helper', 'Project Helper', 'Project workflow.');
+      const options = { cwd: projectRoot, homeDir };
+
+      assert.deepEqual(
+        await deleteSkill(workspaceRoot, 'user:agents:user-helper', options),
+        { ok: true },
+      );
+      await assert.rejects(lstat(join(homeDir, '.agents', 'skills', 'user-helper')), { code: 'ENOENT' });
+
+      // Project scope is a policy refusal, not a path block, and the repo file
+      // must still be on disk afterwards.
+      assert.deepEqual(
+        await deleteSkill(workspaceRoot, 'project:maka:project-helper', options),
+        { ok: false, reason: 'blocked_scope' },
+      );
+      await lstat(join(projectRoot, '.maka', 'skills', 'project-helper'));
+
+      // A ref for a skill that no longer exists is a clean not_found.
+      assert.deepEqual(
+        await deleteSkill(workspaceRoot, 'user:agents:user-helper', options),
+        { ok: false, reason: 'not_found' },
+      );
+    });
+  });
+
+  it('refuses to delete a user-scope skill reached through a symlinked directory', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const outside = await mkdtemp(join(tmpdir(), 'maka-skill-user-delete-outside-'));
+      try {
+        const homeDir = join(workspaceRoot, 'home');
+        // A real skill outside the scan roots, linked into ~/.agents/skills.
+        await writeSkillAt(outside, 'linked-helper', 'Linked Helper', 'Linked workflow.');
+        await mkdir(join(homeDir, '.agents', 'skills'), { recursive: true });
+        await symlink(join(outside, 'linked-helper'), join(homeDir, '.agents', 'skills', 'linked-helper'));
+
+        const options = { cwd: workspaceRoot, homeDir };
+        // `not_found`, not `blocked_path`: discovery itself skips symlinked
+        // dir entries, so a linked skill never reaches the inventory and the
+        // delete has no ref to match. The lstat symlink guard inside
+        // deleteSkillByRef is defence in depth behind this.
+        assert.deepEqual(
+          await deleteSkill(workspaceRoot, 'user:agents:linked-helper', options),
+          { ok: false, reason: 'not_found' },
+        );
+        // The link target survives — deletion never followed the link out.
+        await lstat(join(outside, 'linked-helper', 'SKILL.md'));
+      } finally {
+        await rm(outside, { recursive: true, force: true });
+      }
+    });
+  });
+
+  it('refuses a ref that resolves outside the enumerated discovery dirs', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const homeDir = join(workspaceRoot, 'home');
+      await mkdir(homeDir, { recursive: true });
+      await writeSkillAt(join(homeDir, '.agents', 'skills'), 'user-helper', 'User Helper', 'User workflow.');
+      const options = { cwd: workspaceRoot, homeDir };
+
+      // Refs are matched against the scan, so a forged one never resolves to a
+      // path at all — no traversal, no delete.
+      for (const forged of [
+        'user:agents:../../../etc',
+        'user:agents:user-helper/../../..',
+        'custom:0:user-helper',
+        'workspace:legacy:user-helper',
+      ]) {
+        assert.deepEqual(
+          await deleteSkill(workspaceRoot, forged, options),
+          { ok: false, reason: 'not_found' },
+          `forged ref ${forged} must not resolve`,
+        );
+      }
+      await lstat(join(homeDir, '.agents', 'skills', 'user-helper', 'SKILL.md'));
     });
   });
 
@@ -1476,9 +1564,9 @@ description: Exercise workspace-contained open paths.
     assert.match(renderer, /onUpdateManagedSkill=\{\(skillId, options\) => updateManagedSkill\(skillId, options\)\}/);
     assert.match(renderer, /onSetSkillEnabled=\{\(skillId, enabled\) => setSkillEnabled\(skillId, enabled\)\}/);
     assert.match(renderer, /onSetSkillPinned=\{\(skillRef, pinned\) => setSkillPinned\(skillRef, pinned\)\}/);
-    assert.match(renderer, /onDeleteSkill=\{\(skillId\) => deleteSkill\(skillId\)\}/);
+    assert.match(renderer, /onDeleteSkill=\{\(skillRef\) => deleteSkill\(skillRef\)\}/);
     assert.match(preload, /createStarter\(\)/);
-    assert.match(preload, /delete\(id: string\)/);
+    assert.match(preload, /delete\(idOrRef: string\)/);
     assert.match(preload, /open\(id: string, target: 'file' \| 'directory' = 'file'\)/);
     assert.match(preload, /previewUpdate\(skillId: string\)/);
     assert.match(preload, /updateManaged\(skillId: string, options\?: \{ force\?: boolean; expectedCurrentSha256\?: string; expectedSourceSha256\?: string \}\)/);
@@ -1604,11 +1692,14 @@ description: Exercise workspace-contained open paths.
     // Per-row delete: destructive two-step confirm (no dialog precedent here).
     // First click arms 确认删除; a second within the window fires onDeleteSkill.
     // aria-label names the skill and reflects the armed state (keyboard-safe).
-    assert.match(skillPanel, /onDeleteSkill\?\(skillId: string\): void \| Promise<void>/);
+    assert.match(skillPanel, /onDeleteSkill\?\(skillRef: string\): void \| Promise<void>/);
     assert.match(skillPanel, /className="maka-skill-library-delete-button"/);
     assert.match(skillPanel, /function requestDeleteSkill\(skill: SkillEntry\)/);
-    assert.match(skillPanel, /setConfirmingDeleteSkillId\(skill\.id\)[\s\S]*setTimeout\([\s\S]*setConfirmingDeleteSkillId\(null\)/, 'armed delete state must auto-revert so a stray first click cannot linger');
-    assert.match(skillPanel, /void props\.onDeleteSkill\(skill\.id\)/);
+    // Armed state is keyed by ref, not id: the same id can appear in several
+    // scopes and an id-keyed confirm would arm every copy at once.
+    assert.match(skillPanel, /const ref = skill\.ref \?\? skill\.id;/);
+    assert.match(skillPanel, /setConfirmingDeleteSkillId\(ref\)[\s\S]*setTimeout\([\s\S]*setConfirmingDeleteSkillId\(null\)/, 'armed delete state must auto-revert so a stray first click cannot linger');
+    assert.match(skillPanel, /void props\.onDeleteSkill\(ref\)/);
     assert.match(skillPanel, /aria-label=\{confirmingDelete \? copy\.row\.confirmDeleteAriaLabel\(skill\.name\) : copy\.row\.deleteAriaLabel\(skill\.name\)\}/);
     assert.match(skillPanel, /confirmingDelete \? copy\.row\.confirmDelete : copy\.row\.delete/);
     assert.match(skillPanel, /<div[\s\S]*className="maka-skill-library-row"[\s\S]*<\/div>/, 'Skill row body must be information, not the open-file control');

--- a/apps/desktop/src/main/skills.ts
+++ b/apps/desktop/src/main/skills.ts
@@ -108,8 +108,29 @@ export interface SkillEntry {
   /** Legacy id preference matched multiple refs and needs explicit choices. */
   needsReview: boolean;
   discoveryDiagnosticReason?: SkillDiscoveryDiagnostic['reason'];
-  /** Only legacy workspace installs can be updated or deleted by this panel. */
+  /** Whether this panel can delete the skill. See {@link isManageableSkill}. */
   manageable: boolean;
+}
+
+/**
+ * Scopes the Skills panel is allowed to delete from.
+ *
+ * `workspace`/`legacy` is the original `{workspaceRoot}/skills/` install dir.
+ * `user` covers `~/.maka/skills` and `~/.agents/skills` — those are the user's
+ * own installs, so refusing to delete them left the panel showing skills it
+ * could not manage with no explanation for why the button was missing.
+ *
+ * `project` is deliberately excluded: `{cwd}/.maka/skills` and
+ * `{cwd}/.agents/skills` live inside the user's repo and are normally tracked
+ * by git. Deleting repo files from an agent panel is a different, more
+ * surprising action than removing something the user installed for themselves,
+ * so it stays out until it is asked for explicitly. `custom` is excluded for
+ * the same reason — its containment root is the scan dir itself, supplied by
+ * whoever constructed the scan, so there is no user-owned root to anchor to.
+ */
+export function isManageableSkill(scope: SkillScope, source: SkillDiscoverySource): boolean {
+  if (scope === 'user') return true;
+  return scope === 'workspace' && source === 'legacy';
 }
 
 export interface SkillGovernanceDetails {
@@ -152,7 +173,13 @@ export type CreateStarterSkillResult =
 
 export type DeleteSkillResult =
   | { ok: true }
-  | { ok: false; reason: 'not_found' | 'blocked_path' | 'delete_failed' };
+  /**
+   * `blocked_scope` is distinct from `blocked_path`: the skill was found and
+   * its path is sound, but its discovery scope is not one this panel deletes
+   * from (see {@link isManageableSkill}). Keeping it separate stops a policy
+   * refusal from reading as a path-traversal block in logs and toasts.
+   */
+  | { ok: false; reason: 'not_found' | 'blocked_path' | 'blocked_scope' | 'delete_failed' };
 
 export type SkillOpenTarget = 'file' | 'directory';
 export type ResolveSkillOpenPathResult =
@@ -326,7 +353,7 @@ function toRejectedSkillEntry(skill: RejectedSkillDefinition): SkillEntry {
     source: skill.source,
     contextStatus: 'invalid',
     needsReview: false,
-    manageable: skill.scope === 'workspace' && skill.source === 'legacy',
+    manageable: isManageableSkill(skill.scope, skill.source),
   };
 }
 
@@ -383,7 +410,7 @@ export function toSkillEntry(
     ...(decision?.rank !== undefined ? { contextRank: decision.rank } : {}),
     ...(decision?.shadowedBy ? { shadowedBy: decision.shadowedBy } : {}),
     needsReview,
-    manageable: skill.scope === 'workspace' && skill.source === 'legacy',
+    manageable: isManageableSkill(skill.scope, skill.source),
     ...(skill.sourceType === 'managed' && skill.managedUpdateStatus ? { managedUpdateStatus: skill.managedUpdateStatus } : {}),
   };
 }
@@ -640,15 +667,98 @@ export async function createStarterSkill(root: string): Promise<CreateStarterSki
 }
 
 /**
- * Delete an installed skill directory under {root}/skills/<id>. Path-hardened
- * exactly like createStarterSkill / installManagedSkill: the skills dir and the
- * skill dir must both be real, contained directories (no symlinks, no escape
- * outside the workspace) before anything is removed. The recursive rm also
- * clears any managed-skill baseline metadata under the skill's .maka/ subtree.
+ * Delete a discovered skill directory by scope-aware `ref`.
+ *
+ * The caller only ever supplies the ref string; the directory to remove is
+ * re-derived from a fresh discovery scan, never from renderer-supplied input.
+ * On top of that the target must clear four checks before anything is removed:
+ *
+ *  1. its scope is deletable ({@link isManageableSkill}),
+ *  2. it is a real directory and not a symlink (so the rm cannot follow a link
+ *     out of the scan root),
+ *  3. its parent is one of the discovery dirs this scan actually enumerated —
+ *     the tight check, since the containment root for user scope is the whole
+ *     home dir,
+ *  4. and it is still inside its discovery root after realpath resolution.
+ *
+ * Mirrors `resolveSkillOpenPath`'s ref branch, with (1) and (3) added because
+ * this operation is destructive and irreversible.
  */
-export async function deleteSkill(root: string, id: string): Promise<DeleteSkillResult> {
-  if (!isSafeSkillId(id)) return { ok: false, reason: 'not_found' };
+async function deleteSkillByRef(
+  root: string,
+  ref: string,
+  options: SkillReadOptions = {},
+): Promise<DeleteSkillResult> {
+  if (ref.length > 512) return { ok: false, reason: 'not_found' };
 
+  const discovery = resolveSkillDiscoveryPaths(options.cwd ?? root, root, options.homeDir);
+  const scan = await scanSkillsWithDiagnostics(discovery);
+  const skill = [...scan.inventory, ...scan.rejected].find((candidate) => candidate.ref === ref);
+  if (!skill) return { ok: false, reason: 'not_found' };
+  if (!isManageableSkill(skill.scope, skill.source)) return { ok: false, reason: 'blocked_scope' };
+
+  let skillReal: string;
+  try {
+    const skillStat = await lstat(skill.path);
+    if (!skillStat.isDirectory() || skillStat.isSymbolicLink()) return { ok: false, reason: 'blocked_path' };
+    skillReal = await realpath(skill.path);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { ok: false, reason: 'not_found' };
+    return { ok: false, reason: 'blocked_path' };
+  }
+
+  // The skill must sit DIRECTLY in a dir the scan enumerated. Comparing against
+  // discovery dirs rather than `discoveryRoot` is what keeps a user-scope
+  // delete pinned to ~/.maka/skills or ~/.agents/skills instead of anywhere
+  // under $HOME.
+  const parentReal = dirname(skillReal);
+  const discoveryDirsReal = await Promise.all(
+    discovery.entries.map((entry) => realpath(entry.dir).catch(() => null)),
+  );
+  if (!discoveryDirsReal.some((dir) => dir !== null && dir === parentReal)) {
+    return { ok: false, reason: 'blocked_path' };
+  }
+
+  try {
+    const containmentReal = await realpath(skill.discoveryRoot);
+    if (!isPathInside(containmentReal, skillReal)) return { ok: false, reason: 'blocked_path' };
+  } catch {
+    return { ok: false, reason: 'blocked_path' };
+  }
+
+  try {
+    await rm(skillReal, { recursive: true });
+    return { ok: true };
+  } catch {
+    return { ok: false, reason: 'delete_failed' };
+  }
+}
+
+/**
+ * Delete an installed skill directory. Accepts either a scope-aware `ref`
+ * (`user:agents:<id>`, `workspace:legacy:<id>`, …) which routes to
+ * {@link deleteSkillByRef}, or a bare workspace id for the original
+ * {root}/skills/<id> path kept below.
+ *
+ * The bare-id path is path-hardened exactly like createStarterSkill /
+ * installManagedSkill: the skills dir and the skill dir must both be real,
+ * contained directories (no symlinks, no escape outside the workspace) before
+ * anything is removed. The recursive rm also clears any managed-skill baseline
+ * metadata under the skill's .maka/ subtree.
+ */
+export async function deleteSkill(
+  root: string,
+  idOrRef: string,
+  options: SkillReadOptions = {},
+): Promise<DeleteSkillResult> {
+  // A ref always contains ':', which `isSafeSkillId` rejects — so a value that
+  // fails the id check but looks like a ref is routed rather than refused.
+  if (!isSafeSkillId(idOrRef)) {
+    if (!idOrRef.includes(':')) return { ok: false, reason: 'not_found' };
+    return deleteSkillByRef(root, idOrRef, options);
+  }
+
+  const id = idOrRef;
   const skillsDir = join(root, 'skills');
   let skillsReal: string;
   try {

--- a/apps/desktop/src/main/workspace-resources-ipc-main.ts
+++ b/apps/desktop/src/main/workspace-resources-ipc-main.ts
@@ -233,8 +233,13 @@ export function registerWorkspaceResourcesIpc(deps: WorkspaceResourcesIpcDeps): 
     if (!result.ok) return result;
     return { ok: true as const, created: result.created, skill: toSkillEntry(result.skill), filePath: result.filePath };
   });
-  ipcMain.handle('skills:delete', async (_event, id: string) => {
-    return deleteSkill(deps.workspaceRoot, id);
+  ipcMain.handle('skills:delete', async (_event, idOrRef: string) => {
+    // Same cwd plumbing as skills:open — a scope-aware ref only resolves if the
+    // delete scans the same project-level discovery dirs the list did.
+    const cwd = await deps.getCurrentProjectRoot?.();
+    const result = await deleteSkill(deps.workspaceRoot, idOrRef, cwd ? { cwd } : {});
+    if (result.ok && cwd) deps.invalidateSkillSelectionReport?.(cwd);
+    return result;
   });
   ipcMain.handle('skills:open', async (_event, id: string, target: 'file' | 'directory' = 'file') => {
     const cwd = await deps.getCurrentProjectRoot?.();

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -721,9 +721,9 @@ export interface MakaBridge {
       | { ok: true; created: boolean; skill: SkillEntry; filePath: string }
       | { ok: false; reason: 'blocked_path' | 'already_exists' | 'write_failed' }
     >;
-    delete(id: string): Promise<
+    delete(idOrRef: string): Promise<
       | { ok: true }
-      | { ok: false; reason: 'not_found' | 'blocked_path' | 'delete_failed' }
+      | { ok: false; reason: 'not_found' | 'blocked_path' | 'blocked_scope' | 'delete_failed' }
     >;
     open(id: string, target?: 'file' | 'directory'): Promise<
       | { ok: true; target: 'file' | 'directory' }

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -1128,11 +1128,11 @@ const makaBridge = {
     > {
       return ipcRenderer.invoke('skills:createStarter');
     },
-    delete(id: string): Promise<
+    delete(idOrRef: string): Promise<
       | { ok: true }
-      | { ok: false; reason: 'not_found' | 'blocked_path' | 'delete_failed' }
+      | { ok: false; reason: 'not_found' | 'blocked_path' | 'blocked_scope' | 'delete_failed' }
     > {
-      return ipcRenderer.invoke('skills:delete', id);
+      return ipcRenderer.invoke('skills:delete', idOrRef);
     },
     open(id: string, target: 'file' | 'directory' = 'file'): Promise<
       | { ok: true; target: 'file' | 'directory' }

--- a/apps/desktop/src/renderer/app-shell-skill-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-skill-actions.ts
@@ -34,7 +34,7 @@ export interface AppShellSkillActions {
   ): Promise<boolean>;
   setSkillEnabled(skillId: string, enabled: boolean): Promise<void>;
   setSkillPinned(skillRef: string, pinned: boolean): Promise<void>;
-  deleteSkill(skillId: string): Promise<void>;
+  deleteSkill(skillRef: string): Promise<void>;
   openSkill(skillId: string): Promise<void>;
 }
 
@@ -277,9 +277,9 @@ export function createAppShellSkillActions(deps: {
     }
   }
 
-  async function deleteSkill(skillId: string) {
+  async function deleteSkill(skillRef: string) {
     try {
-      const result = await window.maka.skills.delete(skillId);
+      const result = await window.maka.skills.delete(skillRef);
       if (!result.ok) {
         if (isSkillsSurfaceActive()) toastApi.error(copy.deleteFailedTitle, copy.deleteFailures[result.reason]);
         return;
@@ -290,7 +290,10 @@ export function createAppShellSkillActions(deps: {
       await refreshBundledSkillCatalog({
         shouldShowError: isSkillsSurfaceActive,
       });
-      if (isSkillsSurfaceActive()) toastApi.success(copy.deletedTitle, copy.deletedDescription(skillId));
+      // The ref is scope-qualified (`user:agents:gh-cli`); the toast shows the
+      // bare skill id, which is what the row itself is labelled with.
+      const displayId = skillRef.slice(skillRef.lastIndexOf(':') + 1);
+      if (isSkillsSurfaceActive()) toastApi.success(copy.deletedTitle, copy.deletedDescription(displayId));
     } catch (error) {
       if (isSkillsSurfaceActive()) {
         toastApi.error(copy.deleteFailedTitle, localizedShellErrorMessage(error, copy.deleteFallback, uiLocale));

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1705,7 +1705,7 @@ function AppShellContent({
                   onUpdateManagedSkill={(skillId, options) => updateManagedSkill(skillId, options)}
                   onSetSkillEnabled={(skillId, enabled) => setSkillEnabled(skillId, enabled)}
                   onSetSkillPinned={(skillRef, pinned) => setSkillPinned(skillRef, pinned)}
-                  onDeleteSkill={(skillId) => deleteSkill(skillId)}
+                  onDeleteSkill={(skillRef) => deleteSkill(skillRef)}
                 />
               ) : navSelection.section === 'extensions' && navSelection.module === 'mcp' ? (
                 <McpPage hubHeader={extensionsHubHeader} />

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -300,7 +300,7 @@ type ShellCopy = {
       'not_managed' | 'source_missing' | 'metadata_error' | 'blocked_path' | 'read_failed',
       string
     >;
-    deleteFailures: Record<'not_found' | 'blocked_path' | 'delete_failed', string>;
+    deleteFailures: Record<'not_found' | 'blocked_path' | 'blocked_scope' | 'delete_failed', string>;
     runtimeFailures: Record<'not_found' | 'blocked_path' | 'state_error' | 'write_failed', string>;
   };
   sessionSettingsActions: {
@@ -832,7 +832,7 @@ const SHELL_COPY_BY_LOCALE = {
       deleteFailedTitle: '无法删除 Skill',
       deleteFallback: '无法删除 Skill，请稍后重试。',
       deletedTitle: '已删除 Skill',
-      deletedDescription: (id: string) => `${id} 已从当前工作区移除。`,
+      deletedDescription: (id: string) => `${id} 已移除。`,
       openFailedTitle: '无法打开 Skill',
       openFallback: '无法打开 Skill，请稍后重试。',
       createFailures: {
@@ -879,6 +879,7 @@ const SHELL_COPY_BY_LOCALE = {
       deleteFailures: {
         not_found: '当前工作区找不到这个 Skill。',
         blocked_path: 'Skill 路径不允许删除。',
+        blocked_scope: '项目内的 Skill 由仓库管理，请直接在项目里删除。',
         delete_failed: '删除 Skill 失败，请检查文件权限。',
       },
       runtimeFailures: {
@@ -1292,7 +1293,7 @@ const SHELL_COPY_BY_LOCALE = {
       deleteFailedTitle: 'Could not delete Skill',
       deleteFallback: 'The Skill could not be deleted. Try again later.',
       deletedTitle: 'Skill deleted',
-      deletedDescription: (id: string) => `${id} was removed from the current workspace.`,
+      deletedDescription: (id: string) => `${id} was removed.`,
       openFailedTitle: 'Could not open Skill',
       openFallback: 'The Skill could not be opened. Try again later.',
       createFailures: {
@@ -1340,6 +1341,7 @@ const SHELL_COPY_BY_LOCALE = {
       deleteFailures: {
         not_found: 'This Skill was not found in the current workspace.',
         blocked_path: 'The Skill path cannot be deleted.',
+        blocked_scope: 'Project Skills are managed by the repository. Delete it from the project instead.',
         delete_failed: 'The Skill could not be deleted. Check file permissions.',
       },
       runtimeFailures: {

--- a/packages/ui/src/module-pages.tsx
+++ b/packages/ui/src/module-pages.tsx
@@ -60,7 +60,7 @@ export function SkillsPage(props: {
   onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): boolean | Promise<boolean>;
   onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
   onSetSkillPinned?(skillRef: string, pinned: boolean): void | Promise<void>;
-  onDeleteSkill?(skillId: string): void | Promise<void>;
+  onDeleteSkill?(skillRef: string): void | Promise<void>;
 }) {
   const copy = getSharedUiCopy(useUiLocale()).modules;
   const auditReport = deriveCapabilityAuditReport({

--- a/packages/ui/src/skills-panel.tsx
+++ b/packages/ui/src/skills-panel.tsx
@@ -47,7 +47,7 @@ function SkillLibraryPanel(props: {
   onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): boolean | Promise<boolean>;
   onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
   onSetSkillPinned?(skillRef: string, pinned: boolean): void | Promise<void>;
-  onDeleteSkill?(skillId: string): void | Promise<void>;
+  onDeleteSkill?(skillRef: string): void | Promise<void>;
   actionBusy?: boolean;
   refreshPending?: boolean;
   createPending?: boolean;
@@ -92,17 +92,20 @@ function SkillLibraryPanel(props: {
       deleteConfirmTimerRef.current = null;
     }
   }
+  // Keyed by ref, not id: the same skill id can be discovered in more than one
+  // scope, and an id-keyed confirm would arm the delete on every copy at once.
   function requestDeleteSkill(skill: SkillEntry) {
     if (!props.onDeleteSkill) return;
-    if (confirmingDeleteSkillId !== skill.id) {
+    const ref = skill.ref ?? skill.id;
+    if (confirmingDeleteSkillId !== ref) {
       clearDeleteConfirmTimer();
-      setConfirmingDeleteSkillId(skill.id);
+      setConfirmingDeleteSkillId(ref);
       deleteConfirmTimerRef.current = setTimeout(() => setConfirmingDeleteSkillId(null), DELETE_CONFIRM_TIMEOUT_MS);
       return;
     }
     clearDeleteConfirmTimer();
     setConfirmingDeleteSkillId(null);
-    void props.onDeleteSkill(skill.id);
+    void props.onDeleteSkill(ref);
   }
   const [marketCategory, setMarketCategory] = useState<ManagedSkillCategory | typeof MARKET_CATEGORY_ALL>(MARKET_CATEGORY_ALL);
   const [marketSort, setMarketSort] = useState<MarketSort>('name');
@@ -464,8 +467,8 @@ function SkillLibraryPanel(props: {
               const updating = props.updatingSkillId === skill.id;
               const toggling = props.togglingSkillId === skillRef;
               const reviewing = reviewingSkillId === skill.id;
-              const deleting = props.deletingSkillId === skill.id;
-              const confirmingDelete = confirmingDeleteSkillId === skill.id;
+              const deleting = props.deletingSkillId === skillRef;
+              const confirmingDelete = confirmingDeleteSkillId === skillRef;
               const reviewableManagedUpdate = skill.managedUpdateStatus === 'update_available' || skill.managedUpdateStatus === 'local_modified';
               const canToggleSkill =
                 !isDiscoveryDiagnostic &&
@@ -792,7 +795,7 @@ export function SkillsModuleMain(props: {
   onUpdateManagedSkill?(skillId: string, options?: { force?: boolean; expectedCurrentSha256?: string; expectedSourceSha256?: string }): boolean | Promise<boolean>;
   onSetSkillEnabled?(skillId: string, enabled: boolean): void | Promise<void>;
   onSetSkillPinned?(skillRef: string, pinned: boolean): void | Promise<void>;
-  onDeleteSkill?(skillId: string): void | Promise<void>;
+  onDeleteSkill?(skillRef: string): void | Promise<void>;
 }) {
   const copy = getSkillsCopy(useUiLocale());
   const [pendingSkillAction, setPendingSkillAction] = useState<string | null>(null);


### PR DESCRIPTION
## What

The Skills panel now deletes user-scope skills (`~/.maka/skills`, `~/.agents/skills`), not just skills under `{workspaceRoot}/skills/`.

## Why

`deleteSkill` could only resolve `join(root, 'skills', id)`, so the UI hid the button for anything else via `manageable`. The hidden-button behaviour was *correct* — the backend genuinely couldn't delete those — but the effect was that the app's own bundled skill showed 删除 while all 25 of the user's own installs did not, with nothing explaining why. So this fixes the backend limit rather than the UI symptom.

## How

Deletion is addressed by scope-aware `ref` instead of a bare workspace id. `deleteSkillByRef` receives **only the ref string** and re-derives the directory from a fresh discovery scan — a renderer-supplied path is never trusted. The target must then clear four checks before the recursive `rm`:

1. its scope is deletable (`isManageableSkill`),
2. it is a real directory, not a symlink,
3. **its parent is one of the discovery dirs the scan actually enumerated**,
4. it is still inside its discovery root after `realpath` resolution.

(3) is the load-bearing check. The containment root for user scope is the entire home dir, so `isPathInside(home, …)` alone would be nearly meaningless; anchoring to the enumerated scan dirs is what keeps a delete pinned to `~/.maka/skills` / `~/.agents/skills`.

The panel also keys the armed-delete state on ref rather than id — the same id can be discovered in several scopes, and an id-keyed confirm armed every copy at once.

### Deliberate carve-out: project scope

`{cwd}/.maka/skills` and `{cwd}/.agents/skills` stay undeletable, but now return a distinct `blocked_scope` with an explanatory toast instead of just missing a button. Those files live in the user's repo and are normally tracked by git; removing them belongs to the project, not to this panel. Keeping the reason separate from `blocked_path` stops a policy refusal from reading as a path-traversal block in logs.

Easy to reverse — it is one branch in `isManageableSkill`.

### Behaviour note

Deletion remains a **permanent recursive `rm`** (no trash) behind the existing two-step, 4-second confirm. That is unchanged from how workspace-scope deletion already worked, and was an explicit call — `shell.trashItem` was considered and rejected in favour of matching existing behaviour.

## Tests

Four new cases in `skills.test.ts`, all against a real temp filesystem:

- user-scope delete by ref actually removes the directory;
- project-scope returns `blocked_scope` **and the repo file is still on disk** afterwards;
- a symlinked user skill is `not_found` — discovery skips symlinked dir entries, so it never reaches the symlink guard (which stays as defence in depth), and the link target survives;
- forged refs (`user:agents:../../../etc`, wrong-scope refs, …) resolve to nothing.

Updated the existing `manageable` contract: `user-helper` → `true`, `project-helper` → `false`.

## Verification

- `node --test dist/main/**/*.test.js` — **2879/2879 pass**.
- `npm run typecheck` — clean. It caught a miss: `bridge-contract.d.ts` is the authoritative renderer-facing API declaration, and without updating it the new `blocked_scope` reason would have been swallowed by the type system.

### Two things to know

1. **`main` is currently red on `check-console`**, independent of this PR — `permission-overlay-main.ts` from #1515 has three ungated `console.warn` sites not in the ALLOW map. That blocks `npm run test` locally and will likely fail CI here too. Not introduced by this branch; happy to send a separate one-line unblock.
2. **The e2e fixture does not sandbox `HOME`** (`buildE2eEnv` leaves it alone). So there is no e2e for user-scope deletion — writing one would have the suite delete real skills out of the developer's home dir. Adding a HOME sandbox to the fixture is the prerequisite and is left out of scope. The destructive path is covered by the unit tests above; the UI wiring is pinned by the source-contract assertions.