### PR TITLE
fix(ci): restore a green main after the TCC overlay landing

### DIFF
--- a/scripts/build-cursor-overlay.mjs
+++ b/scripts/build-cursor-overlay.mjs
@@ -79,7 +79,10 @@ export async function buildPermissionOverlay({ logLevel = 'info' } = {}) {
     outfile: join(outDir, 'permission-overlay-preload.cjs'),
     logLevel,
   });
-  await copyFile(join(srcOverlay, 'permission-overlay.html'), join(outDir, 'permission-overlay.html'));
+  await copyFile(
+    join(srcOverlay, 'permission-overlay.html'),
+    join(outDir, 'permission-overlay.html'),
+  );
   return outDir;
 }
 

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -48,6 +48,10 @@ const ALLOW = new Map([
     'scheduler failures are main-process diagnostics and do not expose secrets.',
   ],
   [
+    'apps/desktop/src/main/permission-overlay/permission-overlay-main.ts',
+    'TCC overlay diagnostics (locale lookup, missing .app bundle); no secrets (#1515).',
+  ],
+  [
     'apps/desktop/src/main/main-window.ts',
     'real-window smoke diagnostics are dev/test gated and stdout-parsed by capture tooling.',
   ],


### PR DESCRIPTION
## Why

`origin/main` at `17362dcf` (#1515) is red on two repo checks, and both fail on **every** branch cut from it — not just on #1515 itself. I hit them while opening #1517.

- `format:check` — `scripts/build-cursor-overlay.mjs` has a `copyFile(...)` call past Biome's line width.
- `check-console` (part of `npm run test:checks`, which gates `npm test`) — `permission-overlay-main.ts` adds three `console.warn` sites that are not in the ALLOW map.

## How

Ran the formatter on the one file, and allow-listed the overlay diagnostics per the instructions in `check-console.mjs` itself.

The allow-list entry is the right call rather than gating or removing the logs: these are the same category as the `app-lifecycle.ts` and `daily-review-main.ts` entries already on the list — main-process operational warnings (locale lookup failure, missing `.app` bundle) that carry no secrets. The executable path one of them prints is resolved locally in `permission-overlay-main.ts` and never comes from renderer input.

## Verification

```
npm run format:check   → Checked 1119 files. No fixes applied.
check-console          → OK — 21 files explicitly allow-listed, no other console sites found.
check-a11y             → OK
check-copy             → OK
```