### PR TITLE
feat(runtime): establish Phase 3A recovery persistence authority

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -26,6 +26,8 @@ This page is the authority map for Maka documentation. Code and contract tests r
 - [Deep Research durable workspace](./deep-research-durable-workspace.md)
 - [Session task ledger lifecycle](./session-task-ledger-lifecycle.md)
 - [Execution identity and evidence spine](./execution-evidence-spine.md)
+- [Runtime resume extraction ledger](./architecture/runtime-resume-extraction-ledger.zh-CN.md)
+- [Runtime resume Phase 3–4 implementation route](./architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md)
 - [AHE target protocol and evidence export](./ahe-target-protocol.md)
 - [Skill catalog policy](./skill-catalog-policy.md)
 - [Agent Swarm](./agent-swarm.md)

--- a/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
+++ b/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
@@ -49,6 +49,9 @@ Phase 3B/4A 的 workspace checkpoint 是后续独立切片，不进入 PR A。
 - resume 对 terminal parked 和任意 scanner corruption 设独立硬闸门；diagnostic 只负责解释，
   不能成为唯一安全条件；
 - tool-bearing writer 在事务内用同一 prospective transition validator 证明候选 prefix；
+- PR A 首版刻意采用 workspace-wide semantic fail-stop：任一 session 的 canonical tool-ledger
+  corruption 都会阻止该 SQLite workspace 后续所有 tool-bearing boundary；普通非工具事件仍可写。
+  这是 correctness-first 的隔离取舍，不是偶然副作用；
 - SQLite 与 JSONL 共享唯一 lossless canonical RuntimeEvent codec；validator 消费 codec
   返回的 event，store 持久化同一次编码返回的稳定 JSON bytes；
 - SQLite 对每个 invocation 强制唯一 `(sessionId, runId, turnId)` execution spine；
@@ -141,8 +144,10 @@ future newer schema            -> fail closed
 | JSONL ordinary/tool exact retry 与 conflicting retry | JSONL storage test | 已覆盖 |
 | JSONL event 与目标 Run header identity | JSONL storage test | 已覆盖 |
 | invocation 跨 session/run/turn 漂移 | core scanner + SQLite authority test | 已覆盖 |
+| unrelated session corruption 阻断新 session tool boundary | storage authority test | 已覆盖 |
 | corrupt ledger 上的 T1/T2/recovery exact retry | storage authority test | 已覆盖 |
 | SQLite terminal raw/canonical-equivalent retry | SQLite storage test | 已覆盖 |
+| JSONL terminal target Run identity 与 exact retry post-effect 收敛 | JSONL storage test | 已覆盖 |
 | journal ID online/rebuild 同源派生 | storage authority test | 已覆盖 |
 | audit fact 不产生 message row | runtime read-model test | 已覆盖 |
 
@@ -206,6 +211,9 @@ PR A 后续清偿项不阻塞当前 correctness merge gate：
 
 - 从 public commit input 删除冗余 `journalEventId`，完全由 store 派生；
 - 为全局 prospective scan 增加 event count / duration 指标，再演进为可重建的增量 reducer；
+- 增量 reducer 落地后，把 transition scan 缩到 candidate execution spine；event、invocation、
+  operation 的全局唯一性由 SQL identity constraints/projection 承担，full scan 移到 store open
+  或显式 integrity check；
 - JSONL 是 legacy/readable fallback，不承担跨进程的全局 invocation uniqueness；恢复 authority
   需要 SQLite。
 

--- a/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
+++ b/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
@@ -46,6 +46,12 @@ Phase 3B/4A 的 workspace checkpoint 是后续独立切片，不进入 PR A。
 - mutable partial corruption fail-soft，immutable corruption fail-closed；
 - SQL row identity 与 payload identity 交叉校验；
 - online、close/reopen、rebuild、Resolver 的黄金等价性。
+- resume 对 terminal parked 和任意 scanner corruption 设独立硬闸门；diagnostic 只负责解释，
+  不能成为唯一安全条件；
+- tool-bearing writer 在事务内用同一 prospective transition validator 证明候选 prefix；
+- SQLite 只持久化 decoder + JSON round-trip 后的 canonical RuntimeEvent；
+- projection-local journal ID 由 operation/event 派生，调用者不能选择；
+- schema 4 的 nullable-dispatch legacy projection 可读但隔离，不进入 recovery 或 canonical rebuild。
 
 ### 3.2 明确不带入 PR A
 
@@ -78,7 +84,7 @@ future newer schema            -> fail closed
 | `runtime-event.ts` | PR A | 增加 exact recovery fact envelope decoder |
 | `runtime-event-store.ts` | PR A | 增加单一 bundle capability |
 | `tool-args-identity.ts` | PR A | strict JSON + domain separation |
-| `tool-ledger-scanner.ts` | PR A | 共享 lane、duplicate/order/identity scanner |
+| `tool-ledger-scanner.ts` | PR A | 共享 exact lane、duplicate/order/identity scanner 与 prospective transition validator |
 | `tool-recovery-fact.ts` | PR A | truthful observation 与 terminal decision |
 | `tool-recovery-bundle.ts` | PR A | writer/rebuild/Resolver 共享 bundle 与 causal interpreter |
 
@@ -104,20 +110,30 @@ future newer schema            -> fail closed
 | 场景 | 新测试位置 | 状态 |
 |---|---|---|
 | strict JSON hash / domain separation | core authority test | 已覆盖 |
+| `__proto__`、sparse/accessor/custom array identity | core authority test | 已覆盖 |
 | semantic lane smuggling | core + storage authority test | 已覆盖 |
+| partial authority、branch-qualified authority | core authority test | 已覆盖 |
 | generic SQLite/JSONL writer bypass | storage tests | 已覆盖 |
+| duplicate call、早到 response、unbound T2 的 prospective rejection | core + storage tests | 已覆盖 |
 | T1 wrong hash | storage authority test | 已覆盖 |
 | duplicate call / operation / event | core + rebuild tests | 已覆盖 |
 | dispatch-before-call | core + rebuild tests | 已覆盖 |
 | completed missing/mismatched outcome | core bundle validator | 已覆盖 |
 | completed/parked exact retry | storage authority test | 已覆盖 |
-| reconcile/outcome/decision crash rollback | storage authority test | 已覆盖 |
-| populated mainline schema 4 upgrade | storage authority test | 已覆盖 |
+| reconcile/outcome/decision exception rollback | storage authority test | 已覆盖 |
+| reconcile/outcome/decision SIGKILL rollback + post-COMMIT | storage process crash test | POSIX 覆盖；Windows 按有限支持跳过 |
+| exact/conflicting bundle、rebuild/commit 多进程竞争 | storage multi-process test | 已覆盖 |
+| populated mainline schema 4 prepared/completed tool rows | storage authority test | 已覆盖并隔离 |
 | #1346 capability rejection | storage authority test | 已覆盖 |
 | immutable row/payload mismatch | storage authority test | 已覆盖 |
 | corrupt mutable partial | storage authority test | 已覆盖 |
 | online = reopen = rebuild = Resolver | runtime equivalence test | 已覆盖 |
+| prepared、normal T2 success/error、parked、recovered completion | runtime equivalence test | 已覆盖 |
+| 多 operation 交错后 journal/projection rebuild | storage authority test | 已覆盖 |
 | parked 不再进入 reconcile | storage + runtime equivalence test | 已覆盖 |
+| parked / orphan corruption 不得产生 safe replay | runtime planner test | 已覆盖 |
+| decoder canonical persistence 与有损 JSON 拒绝 | storage authority test | 已覆盖 |
+| journal ID online/rebuild 同源派生 | storage authority test | 已覆盖 |
 | audit fact 不产生 message row | runtime read-model test | 已覆盖 |
 
 ## 6. 旧 commit 去向
@@ -168,6 +184,8 @@ PR A 没带入 file checkpoint、continuation 或 host lifecycle。
 - PR A 定向测试全部通过；
 - 三个包完整测试通过，或明确记录与本改动无关的平台既有失败；
 - SQLite transaction crash matrix 通过；
+- 所有成功接受的 tool-bearing transition 均满足 `scan.hasCorruption === false`；
+- `recovery.hasCorruption` 与 terminal parked 均独立阻断 provider continuation；
 - 文档中的能力边界与代码一致；
 - 工作树不包含用户的 workspace/测试文件。
 

--- a/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
+++ b/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
@@ -4,7 +4,7 @@
 - 更新日期：2026-07-27
 - 集成实验来源：`origin/codex/runtime-resume-phase3a@24bb5f33`
 - PR A 旧重写来源：`codex/runtime-recovery-authority@c843519e`
-- 当前平铺基线：`upstream/main@0e80fe18`
+- 当前平铺基线：`upstream/main@466f238b`
 - 当前平铺分支：`codex/runtime-recovery-authority-v2`
 
 ## 1. 目的
@@ -36,7 +36,8 @@ Phase 3B/4A 的 workspace checkpoint 是后续独立切片，不进入 PR A。
 ### 3.1 保留并重写的能力
 
 - 精确的 reconcile-result / recovery-decision v1 schema；
-- domain-separated、strict-JSON tool args identity；
+- strict-JSON admissibility 与冻结的 mainline v1 tool args hash bytes；未来的 domain separation
+  必须由显式 dispatch/hash v2 引入，不能原地改变 `t1_after_preflight_v1`；
 - call、dispatch、outcome、reconcile、decision semantic lane；
 - generic append/import 对保留事实的 authority gate；
 - 一个 SQLite recovery bundle transaction；
@@ -90,7 +91,7 @@ future newer schema            -> fail closed
 | `runtime-event.ts` | PR A | 增加 exact recovery fact envelope decoder |
 | `canonical-runtime-event.ts` | PR A | 唯一 lossless decoder、strict JSON 与稳定 bytes owner |
 | `runtime-event-store.ts` | PR A | 增加单一 bundle capability |
-| `tool-args-identity.ts` | PR A | strict JSON + domain separation |
+| `tool-args-identity.ts` | PR A | strict JSON 校验 + mainline v1 hash 字节兼容；v2 才允许 domain separation |
 | `tool-ledger-scanner.ts` | PR A | 共享 exact lane、duplicate/order/identity scanner 与 prospective transition validator |
 | `tool-recovery-fact.ts` | PR A | truthful observation 与 terminal decision |
 | `tool-recovery-bundle.ts` | PR A | writer/rebuild/Resolver 共享 bundle 与 causal interpreter |
@@ -116,8 +117,10 @@ future newer schema            -> fail closed
 
 | 场景 | 新测试位置 | 状态 |
 |---|---|---|
-| strict JSON hash / domain separation | core authority test | 已覆盖 |
-| `__proto__`、sparse/accessor/custom array identity | core authority test | 已覆盖 |
+| strict JSON admissibility + mainline v1 hash compatibility | core authority test | 已覆盖 |
+| `required` / `enum` 特殊排序与 ordinary array 的 mainline v1 literal vectors | core authority test | 已覆盖 |
+| 历史 `__proto__` hash omission 与 strict RuntimeEvent JSON data-property 保留 | core authority test | 已覆盖 |
+| sparse/accessor/custom array identity rejection | core authority test | 已覆盖 |
 | semantic lane smuggling | core + storage authority test | 已覆盖 |
 | partial authority、branch-qualified authority | core authority test | 已覆盖 |
 | generic SQLite/JSONL writer bypass | storage tests | 已覆盖 |
@@ -132,6 +135,9 @@ future newer schema            -> fail closed
 | exact/conflicting bundle、rebuild/commit 多进程竞争 | storage multi-process test | 已覆盖 |
 | 多进程同时打开并持有同一 WAL 数据库、初始化失败有界退出 | storage multi-process test | 已覆盖 |
 | populated mainline schema 4 prepared/completed tool rows | storage authority test | 已覆盖并隔离 |
+| populated mainline schema 4 T1 dispatch + special args hash | storage authority test | 已覆盖并可重建 |
+| schema 4→5 optimistic stale read 后锁内重读 | storage schema test | 确定性覆盖 |
+| schema 4→5 多进程并发打开升级 | storage multi-process test | 已覆盖 smoke path |
 | #1346 capability rejection | storage authority test | 已覆盖 |
 | immutable row/payload mismatch | storage authority test | 已覆盖 |
 | corrupt mutable partial | storage authority test | 已覆盖 |
@@ -193,9 +199,9 @@ PR A 没带入 file checkpoint、continuation 或 host lifecycle。
   Runtime Resolver/read-model/resume diagnostics、对应测试与本路线文档；
 - 未出现 file checkpoint carrier、filesystem worker、SessionManager/Desktop/CLI host wiring
   或 Git carrier 路径。
-- 分支已重放到 `upstream/main@0e80fe18` 的 interaction authority 之后；唯一内容冲突位于
-  RuntimeEvent read-model 测试，同时保留了上游 question-answer acknowledgement 与 PR A
-  recovery audit fact 的不可见投影契约。
+- 分支已再次重放到 `upstream/main@466f238b`；本轮唯一内容冲突位于 Desktop settings E2E，
+  保留上游当前更精确的三按钮 permission fixture，因此该文件最终不出现在 PR A 的重放提交中；
+  recovery authority 的 18 个其余提交以及两个 schema 4 blocker 修复均由 range-diff 证明语义等价。
 
 合并门槛：
 

--- a/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
+++ b/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
@@ -49,7 +49,10 @@ Phase 3B/4A 的 workspace checkpoint 是后续独立切片，不进入 PR A。
 - resume 对 terminal parked 和任意 scanner corruption 设独立硬闸门；diagnostic 只负责解释，
   不能成为唯一安全条件；
 - tool-bearing writer 在事务内用同一 prospective transition validator 证明候选 prefix；
-- SQLite 只持久化 decoder + JSON round-trip 后的 canonical RuntimeEvent；
+- SQLite 与 JSONL 共享唯一 lossless canonical RuntimeEvent codec；validator 消费 codec
+  返回的 event，store 持久化同一次编码返回的稳定 JSON bytes；
+- SQLite 对每个 invocation 强制唯一 `(sessionId, runId, turnId)` execution spine；
+- JSONL immutable append 对 exact retry 物理去重，并在落盘前验证目标 Run header；
 - projection-local journal ID 由 operation/event 派生，调用者不能选择；
 - schema 4 的 nullable-dispatch legacy projection 可读但隔离，不进入 recovery 或 canonical rebuild。
 
@@ -82,6 +85,7 @@ future newer schema            -> fail closed
 | 文件 | 归属 | 处理 |
 |---|---|---|
 | `runtime-event.ts` | PR A | 增加 exact recovery fact envelope decoder |
+| `canonical-runtime-event.ts` | PR A | 唯一 lossless decoder、strict JSON 与稳定 bytes owner |
 | `runtime-event-store.ts` | PR A | 增加单一 bundle capability |
 | `tool-args-identity.ts` | PR A | strict JSON + domain separation |
 | `tool-ledger-scanner.ts` | PR A | 共享 exact lane、duplicate/order/identity scanner 与 prospective transition validator |
@@ -93,8 +97,8 @@ future newer schema            -> fail closed
 | 文件 | 归属 | 处理 |
 |---|---|---|
 | `sqlite-runtime-schema.ts` | PR A | schema 5 + `runtime_recovery_authority@1` |
-| `sqlite-runtime-store.ts` | PR A | T1/T2 gate、atomic recovery bundle、projection rebuild |
-| `agent-run-store.ts` | PR A | JSONL generic writer 拒绝保留 tool facts |
+| `sqlite-runtime-store.ts` | PR A | 全局 prospective gate、invocation spine、atomic recovery bundle、projection rebuild |
+| `agent-run-store.ts` | PR A | JSONL authority gate、header identity 与 immutable exact retry 去重 |
 
 ### Runtime
 
@@ -133,6 +137,12 @@ future newer schema            -> fail closed
 | parked 不再进入 reconcile | storage + runtime equivalence test | 已覆盖 |
 | parked / orphan corruption 不得产生 safe replay | runtime planner test | 已覆盖 |
 | decoder canonical persistence 与有损 JSON 拒绝 | storage authority test | 已覆盖 |
+| nested undefined、provider `toJSON`、recovery evidence 改写 | storage authority test | 已覆盖 |
+| JSONL ordinary/tool exact retry 与 conflicting retry | JSONL storage test | 已覆盖 |
+| JSONL event 与目标 Run header identity | JSONL storage test | 已覆盖 |
+| invocation 跨 session/run/turn 漂移 | core scanner + SQLite authority test | 已覆盖 |
+| corrupt ledger 上的 T1/T2/recovery exact retry | storage authority test | 已覆盖 |
+| SQLite terminal raw/canonical-equivalent retry | SQLite storage test | 已覆盖 |
 | journal ID online/rebuild 同源派生 | storage authority test | 已覆盖 |
 | audit fact 不产生 message row | runtime read-model test | 已覆盖 |
 
@@ -185,9 +195,19 @@ PR A 没带入 file checkpoint、continuation 或 host lifecycle。
 - 三个包完整测试通过，或明确记录与本改动无关的平台既有失败；
 - SQLite transaction crash matrix 通过；
 - 所有成功接受的 tool-bearing transition 均满足 `scan.hasCorruption === false`；
+- JSONL exact retry 不增加物理行，冲突 retry 不改变原 ledger；
+- 一个 SQLite invocation 只能对应一个 `(sessionId, runId, turnId)`；
+- canonical codec 拒绝任何 nested loss、accessor/custom prototype 或 `toJSON` 改写；
 - `recovery.hasCorruption` 与 terminal parked 均独立阻断 provider continuation；
 - 文档中的能力边界与代码一致；
 - 工作树不包含用户的 workspace/测试文件。
+
+PR A 后续清偿项不阻塞当前 correctness merge gate：
+
+- 从 public commit input 删除冗余 `journalEventId`，完全由 store 派生；
+- 为全局 prospective scan 增加 event count / duration 指标，再演进为可重建的增量 reducer；
+- JSONL 是 legacy/readable fallback，不承担跨进程的全局 invocation uniqueness；恢复 authority
+  需要 SQLite。
 
 ## 8. #1346 的关闭条件
 

--- a/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
+++ b/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
@@ -4,7 +4,7 @@
 - 更新日期：2026-07-27
 - 集成实验来源：`origin/codex/runtime-resume-phase3a@24bb5f33`
 - PR A 旧重写来源：`codex/runtime-recovery-authority@c843519e`
-- 当前平铺基线：`upstream/main@9d9a47b9`
+- 当前平铺基线：`upstream/main@0e80fe18`
 - 当前平铺分支：`codex/runtime-recovery-authority-v2`
 
 ## 1. 目的
@@ -130,6 +130,7 @@ future newer schema            -> fail closed
 | reconcile/outcome/decision exception rollback | storage authority test | 已覆盖 |
 | reconcile/outcome/decision SIGKILL rollback + post-COMMIT | storage process crash test | POSIX 覆盖；Windows 按有限支持跳过 |
 | exact/conflicting bundle、rebuild/commit 多进程竞争 | storage multi-process test | 已覆盖 |
+| 多进程同时打开并持有同一 WAL 数据库、初始化失败有界退出 | storage multi-process test | 已覆盖 |
 | populated mainline schema 4 prepared/completed tool rows | storage authority test | 已覆盖并隔离 |
 | #1346 capability rejection | storage authority test | 已覆盖 |
 | immutable row/payload mismatch | storage authority test | 已覆盖 |
@@ -186,12 +187,15 @@ PR A 没带入 file checkpoint、continuation 或 host lifecycle。
 2026-07-27 本轮结果：
 
 - 旧 PR A 的 8 个 commit 全部显示为 removed；
-- 新平铺 PR A 的 4 个 commit 全部显示为 added；
+- 新平铺 PR A 最初的 4 个实现 commit 与后续 10 个审查收敛 commit 全部显示为 added；
 - 没有 commit 被错误标记为等价 cherry-pick；
 - `upstream/main...HEAD` 只涉及 core recovery contract、SQLite/JSONL authority、
   Runtime Resolver/read-model/resume diagnostics、对应测试与本路线文档；
 - 未出现 file checkpoint carrier、filesystem worker、SessionManager/Desktop/CLI host wiring
   或 Git carrier 路径。
+- 分支已重放到 `upstream/main@0e80fe18` 的 interaction authority 之后；唯一内容冲突位于
+  RuntimeEvent read-model 测试，同时保留了上游 question-answer acknowledgement 与 PR A
+  recovery audit fact 的不可见投影契约。
 
 合并门槛：
 

--- a/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
+++ b/docs/architecture/runtime-resume-extraction-ledger.zh-CN.md
@@ -1,0 +1,182 @@
+# Runtime Resume #1346 拆分与提取账本
+
+- 状态：Active
+- 更新日期：2026-07-27
+- 集成实验来源：`origin/codex/runtime-resume-phase3a@24bb5f33`
+- PR A 旧重写来源：`codex/runtime-recovery-authority@c843519e`
+- 当前平铺基线：`upstream/main@9d9a47b9`
+- 当前平铺分支：`codex/runtime-recovery-authority-v2`
+
+## 1. 目的
+
+#1346 是设计与集成实验，不再作为可合并交付单元。生产实现按“一个 PR 证明一个完整不变量”
+重新落地，禁止按旧 commit 边界机械 cherry-pick。
+
+| 切片 | 唯一需要证明的不变量 |
+|---|---|
+| PR A | recovery fact 只有一个原子写入权威，且 online/reopen/rebuild/Resolver 必然同构 |
+| PR B | continuation cursor 只来自 immutable RuntimeEvents，同一 source boundary 只有一个 claim |
+| PR C | T1 选择 file reconcile 时必须有可信 evidence；自动恢复只做 after-state finalize |
+| PR D | store、worker、registry、后台恢复任务各有唯一 host owner 和完整关闭顺序 |
+
+Phase 3B/4A 的 workspace checkpoint 是后续独立切片，不进入 PR A。
+
+## 2. 提取规则
+
+1. 每个新 PR 从当时最新 `upstream/main` 建立平铺分支。
+2. 先迁移或重写能表达黑盒不变量的测试，再补最小生产代码。
+3. 不 cherry-pick merge commit。
+4. 同时跨越两个不变量的旧 commit 只能按 hunk 阅读和手工重写。
+5. 不为让旧测试通过而恢复已否决的 public API。
+6. 每个 PR 必须执行 path diff、range-diff 和 production-shaped crash tests。
+7. PR A–C 合并后关闭 #1346，但保留其讨论作为设计与审查记录。
+
+## 3. PR A 的提取结论
+
+### 3.1 保留并重写的能力
+
+- 精确的 reconcile-result / recovery-decision v1 schema；
+- domain-separated、strict-JSON tool args identity；
+- call、dispatch、outcome、reconcile、decision semantic lane；
+- generic append/import 对保留事实的 authority gate；
+- 一个 SQLite recovery bundle transaction；
+- completed 必须引用同 execution identity 的成功 outcome；
+- parked 是 v1 的永久终态，只有 exact bundle retry 幂等；
+- tool projection 可以只从 immutable RuntimeEvents 重建；
+- mutable partial corruption fail-soft，immutable corruption fail-closed；
+- SQL row identity 与 payload identity 交叉校验；
+- online、close/reopen、rebuild、Resolver 的黄金等价性。
+
+### 3.2 明确不带入 PR A
+
+- recovery contract registry、observer、reconciler；
+- Write/Edit file checkpoint；
+- continuation planning、claim 或 provider replay；
+- Desktop/CLI 自动 resume 接线；
+- Git carrier、restricted verifier、retry/reattach 原型；
+- #1346 SQLite 数据迁移、downgrade 或 mixed-version reader。
+
+### 3.3 实验格式断代
+
+#1346 从未发布、没有用户，其 SQLite 数据是一次性实验数据。PR A 不猜测兼容：
+
+```text
+#1346 experimental capability  -> unsupported, fail closed
+mainline schema 4              -> supported migration to schema 5
+PR A capability                -> runtime_recovery_authority@1
+future newer schema            -> fail closed
+```
+
+这项决策只删除未发布实验格式的迁移负担，不删除正式 mainline 数据升级责任。
+
+## 4. PR A 文件账本
+
+### Core
+
+| 文件 | 归属 | 处理 |
+|---|---|---|
+| `runtime-event.ts` | PR A | 增加 exact recovery fact envelope decoder |
+| `runtime-event-store.ts` | PR A | 增加单一 bundle capability |
+| `tool-args-identity.ts` | PR A | strict JSON + domain separation |
+| `tool-ledger-scanner.ts` | PR A | 共享 lane、duplicate/order/identity scanner |
+| `tool-recovery-fact.ts` | PR A | truthful observation 与 terminal decision |
+| `tool-recovery-bundle.ts` | PR A | writer/rebuild/Resolver 共享 bundle 与 causal interpreter |
+
+### Storage
+
+| 文件 | 归属 | 处理 |
+|---|---|---|
+| `sqlite-runtime-schema.ts` | PR A | schema 5 + `runtime_recovery_authority@1` |
+| `sqlite-runtime-store.ts` | PR A | T1/T2 gate、atomic recovery bundle、projection rebuild |
+| `agent-run-store.ts` | PR A | JSONL generic writer 拒绝保留 tool facts |
+
+### Runtime
+
+| 文件 | 归属 | 处理 |
+|---|---|---|
+| `recovery-resolver.ts` | PR A | 只消费共享 scanner/interpreter，不维护第二套 map |
+| `runtime-event-read-model.ts` | PR A | recovery audit fact 不产生聊天消息 |
+| `runtime-commit-sink.ts` | PR A | 使用 core canonical args identity |
+| `runtime-resume.ts` | PR A | 保留真实 corruption machine code 与 terminal parked |
+
+## 5. PR A 测试账本
+
+| 场景 | 新测试位置 | 状态 |
+|---|---|---|
+| strict JSON hash / domain separation | core authority test | 已覆盖 |
+| semantic lane smuggling | core + storage authority test | 已覆盖 |
+| generic SQLite/JSONL writer bypass | storage tests | 已覆盖 |
+| T1 wrong hash | storage authority test | 已覆盖 |
+| duplicate call / operation / event | core + rebuild tests | 已覆盖 |
+| dispatch-before-call | core + rebuild tests | 已覆盖 |
+| completed missing/mismatched outcome | core bundle validator | 已覆盖 |
+| completed/parked exact retry | storage authority test | 已覆盖 |
+| reconcile/outcome/decision crash rollback | storage authority test | 已覆盖 |
+| populated mainline schema 4 upgrade | storage authority test | 已覆盖 |
+| #1346 capability rejection | storage authority test | 已覆盖 |
+| immutable row/payload mismatch | storage authority test | 已覆盖 |
+| corrupt mutable partial | storage authority test | 已覆盖 |
+| online = reopen = rebuild = Resolver | runtime equivalence test | 已覆盖 |
+| parked 不再进入 reconcile | storage + runtime equivalence test | 已覆盖 |
+| audit fact 不产生 message row | runtime read-model test | 已覆盖 |
+
+## 6. 旧 commit 去向
+
+旧 PR A 的八个非 merge commit只作为阅读来源，不整体 cherry-pick：
+
+| 旧 commit | 处理 |
+|---|---|
+| `34805553` core fact authority | 测试与最小 schema 手工重写 |
+| `68ee74de` SQLite bundle | transaction 思路手工重写 |
+| `f464cfb1` runtime causality | 被共享 scanner/interpreter 替代 |
+| `5f2b0ae5` restart tests | 有效场景重写到新 fixture |
+| `4de05393` writer bypass | 收敛为 core generic authority gate |
+| `b36486b7` evidence identity | 收敛为 strict hash + bundle validator |
+| `b0683358` rebuild races | duplicate/order 场景重写 |
+| `c843519e` JSONL validation | 仅提取 generic writer gate |
+
+#1346 中其余 commit 按职责进入 PR B、PR C、PR D 或直接 defer/drop；Git carrier、restricted
+verification、auto redo、retry/reattach 不从实验分支迁移。
+
+## 7. Diff 审计与合并门槛
+
+提交前执行：
+
+```text
+git diff --name-status upstream/main...HEAD
+git log --no-merges --name-only upstream/main..HEAD
+git range-diff upstream/main..codex/runtime-recovery-authority upstream/main..HEAD
+git diff --stat codex/runtime-recovery-authority HEAD -- <PR-A-owned-paths>
+```
+
+range-diff 的目标不是伪造 commit 等价，而是确认旧实现中的有效场景都有明确去向。路径审计必须证明
+PR A 没带入 file checkpoint、continuation 或 host lifecycle。
+
+2026-07-27 本轮结果：
+
+- 旧 PR A 的 8 个 commit 全部显示为 removed；
+- 新平铺 PR A 的 4 个 commit 全部显示为 added；
+- 没有 commit 被错误标记为等价 cherry-pick；
+- `upstream/main...HEAD` 只涉及 core recovery contract、SQLite/JSONL authority、
+  Runtime Resolver/read-model/resume diagnostics、对应测试与本路线文档；
+- 未出现 file checkpoint carrier、filesystem worker、SessionManager/Desktop/CLI host wiring
+  或 Git carrier 路径。
+
+合并门槛：
+
+- core、storage、runtime build 通过；
+- PR A 定向测试全部通过；
+- 三个包完整测试通过，或明确记录与本改动无关的平台既有失败；
+- SQLite transaction crash matrix 通过；
+- 文档中的能力边界与代码一致；
+- 工作树不包含用户的 workspace/测试文件。
+
+## 8. #1346 的关闭条件
+
+PR A–C 合并后：
+
+1. 在 #1346 最后评论列出 replacement PR；
+2. 明确未迁移的原型和原因；
+3. 保持 Draft 并关闭，不 squash/merge；
+4. PR body 与 review thread 保留为历史证据；
+5. PR D 可独立推进，不阻塞 #1346 关闭。

--- a/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
+++ b/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
@@ -1,0 +1,268 @@
+# Runtime Resume Phase 3–4 实施路线
+
+- 状态：Implementation tracked
+- 更新日期：2026-07-27
+- 事实权威：immutable RuntimeEvents
+- 主要平台：Linux、macOS；Windows 有限支持
+- 拆分审计：`runtime-resume-extraction-ledger.zh-CN.md`
+
+## 1. 四个正交平面
+
+```text
+operation plane     工具副作用是否已收敛
+continuation plane  provider 将看到哪一段 immutable history
+workspace plane     当前文件系统是否对应 history boundary
+host plane          谁拥有 store、worker、恢复任务与关闭顺序
+```
+
+RuntimeEvent 是语义事实的唯一权威，但不能替代执行所有权的原子仲裁：
+
+| 层级 | 权威 | 职责 |
+|---|---|---|
+| recovery semantics | immutable RuntimeEvents | call、dispatch、outcome、observation、decision |
+| execution ownership | admission/claim CAS | 一个 source boundary 只能有一个执行者 |
+| projection | SQLite tables | 可删除、可从事件重建 |
+| workspace artifact | checkpoint provider | 保存/验证 workspace 状态，不能单独授权 continuation |
+
+## 2. Phase 3A：工具恢复
+
+### PR A — Recovery persistence authority
+
+不变量：
+
+> 保留 recovery fact 只有一个 atomic writer；completed 必须引用匹配的成功 outcome；
+> online/reopen/rebuild/Resolver 对同一 immutable ledger 得到同一解释。
+
+关键实现：
+
+1. tool facts 被划分为 call、dispatch、outcome、reconcile、decision 五条权威 lane；
+2. 一个物理 RuntimeEvent 只能进入一条 lane；
+3. generic writer 不能持久化 dispatch、operation-linked outcome 或 recovery fact；
+4. T1 从真实 function call 重新计算 canonical args identity；
+5. recovery bundle 在一个 SQLite transaction 中写 reconcile、可选 outcome、terminal decision；
+6. completed 和 parked 都是 v1 terminal；parked 不存在第二次 attempt；
+7. scanner 和 recovery interpreter 由 writer、rebuild、Resolver 共享。
+
+### PR B — Continuation correctness
+
+不变量：
+
+> continuation cursor 只来自 immutable RuntimeEvents；同一 source boundary 至多一个 durable
+> claim；祖先与直接 source 使用同一 replay policy。
+
+实施顺序：
+
+1. store 提供 immutable prefix cursor，而不是用 `events.length`；
+2. claim key 绑定 source run + immutable high-water/digest；
+3. claim 创建使用 SQLite unique constraint/transaction，而非“先查后建”；
+4. plan 与 execution revalidation 使用同一 envelope；
+5. immediate source 与 ancestor segment 共用 provider suffix trimming；
+6. mutable partial 只用于 UI，不能进入 cursor；
+7. clone 有 recovery refs 时必须完整重写 ID，或明确拒绝。
+
+Crash matrix：
+
+- claim durable 前/后崩溃；
+- startup resume 与手动 resume 并发；
+- 二代、三代 continuation；
+- interrupted text/thinking suffix；
+- partial snapshot 与 immutable cursor 并存。
+
+### PR C — File evidence + finalize-only recovery
+
+不变量：
+
+> T1 选择 `reconcile` 时必须已持久化可信文件 evidence；恢复只能在 current 明确匹配
+> expected-after 时补 outcome，不能根据陈旧 before 自动写文件。
+
+首版策略：
+
+| observation | 动作 |
+|---|---|
+| `matches_expected_state` | cleanup/finalize，合成 outcome，提交 PR A bundle |
+| `matches_prior_state` | park，reason=`redo_disabled_pending_cas` |
+| `diverged` | park，不覆盖外部写入 |
+| `unreadable` | park，不猜测 |
+
+原因：atomic rename 只保证不产生半文件，不提供 conditional replace。最终 hash 检查与 rename 之间
+仍有 TOCTOU，尤其 crash 后旧 checkpoint 的窗口可能长达数小时或数天。因此首版不自动 redo。
+
+文件 evidence 至少绑定：
+
+- trusted workspace identity 与 canonical target；
+- operation/call/dispatch identity；
+- before identity 与 expected-after identity；
+- transform/algorithm version；
+- worker 生成的 production-shaped result；
+- size、regular-file、symlink、UTF-8 等观察边界。
+
+正常执行与 prepare 必须共用 Write/Edit transform；filesystem worker 保持 permission profile、
+sandbox、one-call grant 和 abort boundary 的执行所有权。
+
+### PR D — Host owner lifecycle
+
+不变量：
+
+> SQLite、filesystem worker、contract registry、background resume task 各有唯一 owner；
+> 初始化失败、取消、退出均反向、恰好一次释放。
+
+PR D 不改变 recovery semantics。它覆盖：
+
+- CLI interactive owner；
+- Desktop startup/shutdown；
+- background promise rejection；
+- store 已开但 worker 初始化失败；
+- in-flight recovery 时退出；
+- double close；
+- Desktop 与 CLI 同 workspace 的 owner 冲突策略。
+
+## 3. Native 与 Git 的能力边界
+
+### 无 Git CLI / 非 Git workspace
+
+Native 支持止于单次 operation：
+
+- Write/Edit 的 before/expected-after evidence；
+- 崩溃后 after-state finalize；
+- 不能证明时 park；
+- 不建设 native workspace manifest 或 CAS object store；
+- 不提供 workspace-wide drift、isolated restore 或 durable rebaseline。
+
+### 有 Git CLI 且 workspace 是 eligible repository
+
+Git 是 workspace continuity carrier，而不是单文件因果证明的前置条件：
+
+- workspace snapshot；
+- RuntimeEvent boundary 与 Git tree/commit 绑定；
+- workspace-wide drift detection；
+- isolated worktree restore；
+- durable rebaseline；
+- object retention 与 GC。
+
+## 4. Phase 3B：Checkpoint 语义
+
+### PR E — Checkpoint contracts
+
+先定义纯语义和 fake provider，不接 Git：
+
+```ts
+interface WorkspaceBoundary {
+  workspaceIdentity: string;
+  workspaceEpoch: number;
+  immutableRuntimeHighWater: number;
+  immutableRuntimeDigest: string;
+  checkpointRef: string;
+  checkpointPolicyHash: string;
+}
+```
+
+需要证明：
+
+- checkpoint 绑定的是 immutable boundary，不是 mutable UI snapshot；
+- cwd 切换产生明确 workspace transition；
+- checkpoint provider 只能 capture/verify/materialize，不能自行批准 resume；
+- required/optional/legacy host policy 有稳定结果；
+- plan 与 execution revalidation 使用同一 boundary。
+
+### PR F — Canonical checkpoint bundle
+
+把 checkpoint accepted fact 与 RuntimeEvent boundary 原子绑定：
+
+- fact 只有一个 canonical writer；
+- projection 可重建；
+- checkpoint ref、workspace identity、epoch、high-water、digest 全部交叉校验；
+- artifact 已生成但 fact 未提交时允许 GC；
+- fact 已提交但 artifact 缺失时 fail closed。
+
+## 5. Phase 4A：Git observe/capture
+
+### PR G — Observe-only Git carrier
+
+先只读验证：
+
+- repository/worktree identity；
+- HEAD/tree/index/dirty state；
+- ignored/untracked policy；
+- submodule、LFS、sparse checkout、case sensitivity 能力探测；
+- 不写 ref、不改用户 index、不改 working tree。
+
+不合格仓库降级到 native operation recovery，不伪装具备 workspace continuity。
+
+### PR H — Production capture + retention
+
+- 使用 Maka 自有 ref namespace 或独立 object ownership；
+- capture 不修改用户 branch/index；
+- checkpoint fact 接受后才成为 durable root；
+- quota、retention、orphan GC；
+- p50/p95 capture 延迟和磁盘增量 telemetry；
+- host lifecycle 完成后才默认启用。
+
+## 6. Phase 4B/4C：恢复与 rebaseline
+
+### Isolated restore
+
+workspace drift 时默认恢复到隔离 worktree/目录，不覆盖用户当前工作：
+
+1. verify checkpoint；
+2. materialize isolated workspace；
+3. 写 workspace transition fact；
+4. continuation 在新 identity/epoch 下开始；
+5. 用户当前目录保持不变。
+
+### Durable rebaseline
+
+“以当前文件为准继续”不是忽略错误：
+
+1. capture 当前 workspace；
+2. 持久化新 baseline fact；
+3. increment workspace epoch；
+4. 告知模型必须重新读取受影响文件；
+5. continuation 只引用新 boundary。
+
+## 7. 依赖顺序
+
+```text
+PR A persistence authority
+ ├─> PR B continuation correctness
+ └─> PR C file finalize-only recovery
+
+PR B + PR C
+ └─> PR E checkpoint contracts
+      └─> PR F canonical checkpoint bundle
+           └─> PR G observe-only Git
+                └─> PR H capture + retention
+                     ├─> isolated restore
+                     └─> durable rebaseline
+
+PR D host lifecycle 必须在 production capture/auto-resume 默认开启前完成。
+```
+
+## 8. 工程门槛
+
+每个 PR 必须：
+
+- 只改变一个事实权威或所有权边界；
+- 先有 production-shaped RED tests；
+- 包含 crash/reopen matrix；
+- fail-closed code 是稳定 machine code；
+- 不把平台假设伪装为跨平台保证；
+- 文档、类型、writer、reader、rebuild、Resolver 同步更新；
+- range-diff/path diff 证明没有带入相邻阶段代码。
+
+性能与可靠性指标在启用前定义：
+
+- SQLite bundle commit p50/p95；
+- rebuild 对总 immutable history 的成本；
+- checkpoint capture p50/p95；
+- `workspace_drift`、`mode_mismatch`、`artifact_missing` park 比例；
+- 自动恢复成功率必须把长命令、大仓库、dirty workspace 纳入分母。
+
+## 9. 不做的承诺
+
+- PR A 不提供真实工具自动恢复；
+- PR B 不恢复 workspace；
+- PR C 不自动 redo stale before-state；
+- 无 Git 环境不提供 workspace snapshot；
+- Git carrier 不覆盖用户当前工作区；
+- 无法证明的 Bash/远程 API 副作用不自动重试；
+- process-crash transaction atomicity 不等于断电级 durability。

--- a/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
+++ b/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
@@ -55,6 +55,12 @@ RuntimeEvent 是语义事实的唯一权威，但不能替代执行所有权的�
 14. SQLite 强制一个 invocation 只对应一个 `(sessionId, runId, turnId)`；
 15. journal ID 只由 store 派生；正式 schema 4 的无 dispatch legacy rows保守隔离。
 
+PR A 首版的 prospective gate 是 workspace-wide semantic fail-stop：任何 session 中已存在的
+canonical tool-ledger corruption 都会拒绝同一 SQLite workspace 后续所有 tool-bearing write。
+这会扩大故障域并在写事务内产生全历史扫描成本，但它是明确的 correctness-first 选择。后续只能
+用可从 immutable events 重建的增量 reducer 收缩到 candidate execution spine；不能用可变缓存
+替代事实权威。
+
 PR A 的证明矩阵包括：
 
 - prepared、normal T2 success/error、permanent parked、recovered completion；
@@ -80,7 +86,8 @@ PR A 的证明矩阵包括：
 实施顺序：
 
 1. store 以 PR A canonical bytes 在一个一致性读事务中返回 immutable prefix、event-seq
-   high-water 与 domain-separated digest，而不是用 `events.length`；
+   high-water 与 domain-separated digest，而不是用 `events.length`；读取既有 row 后必须重新调用
+   `encodeCanonicalRuntimeEvent(event).json`，禁止直接 hash legacy `payload_json` 原始文本；
 2. claim key 绑定 source run + immutable high-water/digest；
 3. claim 创建使用 SQLite unique constraint/transaction，而非“先查后建”；
 4. plan 与 execution revalidation 使用同一 envelope；

--- a/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
+++ b/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
@@ -41,7 +41,27 @@ RuntimeEvent 是语义事实的唯一权威，但不能替代执行所有权的�
 4. T1 从真实 function call 重新计算 canonical args identity；
 5. recovery bundle 在一个 SQLite transaction 中写 reconcile、可选 outcome、terminal decision；
 6. completed 和 parked 都是 v1 terminal；parked 不存在第二次 attempt；
-7. scanner 和 recovery interpreter 由 writer、rebuild、Resolver 共享。
+7. scanner 和 recovery interpreter 由 writer、rebuild、Resolver 共享；
+8. `parked` 和 `recovery.hasCorruption` 是 resume 的硬闸门，不能依赖 diagnostic switch
+   间接阻断；
+9. generic、batch、T1、T2、recovery bundle writer 在事务内对
+   `existing + candidates` 运行同一个 prospective transition validator；
+10. function call/response 只允许各自白名单内的 state delta；artifact、continuation marker、
+    terminal status 或 branch 不能夹带进 tool authority lane；
+11. strict args identity 明确处理 `__proto__` 并拒绝 sparse/accessor/custom array；
+12. SQLite 保存 decoder canonical value，journal ID 只由 store 派生；
+13. 正式 schema 4 的无 dispatch legacy rows 保守隔离，不参与 recovery/rebuild。
+
+PR A 的证明矩阵包括：
+
+- prepared、normal T2 success/error、permanent parked、recovered completion；
+- 多 operation 交错；
+- online、reopen、rebuild、Resolver 等价；
+- recovery bundle 三个事务内部 SIGKILL 边界与 COMMIT 后 SIGKILL；
+- exact bundle、completed-vs-parked、rebuild-vs-commit 多进程竞争。
+
+进程 crash harness 以 Linux/macOS 为发布证明平台；Windows 仍为有限支持，不能用其 skip
+反向宣称跨平台 durability。
 
 ### PR B — Continuation correctness
 

--- a/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
+++ b/docs/architecture/runtime-resume-phase3-phase4-workspace-checkpoint-design.zh-CN.md
@@ -44,13 +44,16 @@ RuntimeEvent 是语义事实的唯一权威，但不能替代执行所有权的�
 7. scanner 和 recovery interpreter 由 writer、rebuild、Resolver 共享；
 8. `parked` 和 `recovery.hasCorruption` 是 resume 的硬闸门，不能依赖 diagnostic switch
    间接阻断；
-9. generic、batch、T1、T2、recovery bundle writer 在事务内对
-   `existing + candidates` 运行同一个 prospective transition validator；
+9. generic、batch、T1、T2、recovery bundle writer 在事务内对全局 immutable ledger
+   与 candidates 运行同一个 prospective transition validator；exact retry 也必须先过此闸门；
 10. function call/response 只允许各自白名单内的 state delta；artifact、continuation marker、
     terminal status 或 branch 不能夹带进 tool authority lane；
 11. strict args identity 明确处理 `__proto__` 并拒绝 sparse/accessor/custom array；
-12. SQLite 保存 decoder canonical value，journal ID 只由 store 派生；
-13. 正式 schema 4 的无 dispatch legacy rows 保守隔离，不参与 recovery/rebuild。
+12. 唯一 canonical RuntimeEvent codec 负责 decode、normalization、strict JSON、稳定 bytes 与
+    lossless round-trip；SQLite/JSONL、未来 prefix digest 均复用它；
+13. JSONL immutable exact retry 物理去重，写前验证 Run header identity；
+14. SQLite 强制一个 invocation 只对应一个 `(sessionId, runId, turnId)`；
+15. journal ID 只由 store 派生；正式 schema 4 的无 dispatch legacy rows保守隔离。
 
 PR A 的证明矩阵包括：
 
@@ -59,6 +62,10 @@ PR A 的证明矩阵包括：
 - online、reopen、rebuild、Resolver 等价；
 - recovery bundle 三个事务内部 SIGKILL 边界与 COMMIT 后 SIGKILL；
 - exact bundle、completed-vs-parked、rebuild-vs-commit 多进程竞争。
+- JSONL ordinary/tool exact retry、conflicting retry、path/header identity；
+- nested undefined / `toJSON` 有损改写与 SQLite terminal canonical retry；
+- invocation 跨 session/run/turn 漂移；
+- corrupt immutable ledger 上 T1/T2/recovery exact retry 均 fail closed。
 
 进程 crash harness 以 Linux/macOS 为发布证明平台；Windows 仍为有限支持，不能用其 skip
 反向宣称跨平台 durability。
@@ -72,7 +79,8 @@ PR A 的证明矩阵包括：
 
 实施顺序：
 
-1. store 提供 immutable prefix cursor，而不是用 `events.length`；
+1. store 以 PR A canonical bytes 在一个一致性读事务中返回 immutable prefix、event-seq
+   high-water 与 domain-separated digest，而不是用 `events.length`；
 2. claim key 绑定 source run + immutable high-water/digest；
 3. claim 创建使用 SQLite unique constraint/transaction，而非“先查后建”；
 4. plan 与 execution revalidation 使用同一 envelope；
@@ -111,6 +119,7 @@ Crash matrix：
 
 - trusted workspace identity 与 canonical target；
 - operation/call/dispatch identity；
+- recovery contract id、version、evidence kind 与 evidence digest；
 - before identity 与 expected-after identity；
 - transform/algorithm version；
 - worker 生成的 production-shaped result；
@@ -118,6 +127,10 @@ Crash matrix：
 
 正常执行与 prepare 必须共用 Write/Edit transform；filesystem worker 保持 permission profile、
 sandbox、one-call grant 和 abort boundary 的执行所有权。
+
+PR C 沿用 PR A 的 durable vocabulary：`matches_expected_state` 可 finalize；
+`matches_prior_state`、`diverged`、`unreadable` 均提交 terminal parked decision。UI 可以把
+`matches_prior_state` 映射为 `redo_disabled_pending_cas`，但不新增第二套 durable fact 名称。
 
 ### PR D — Host owner lifecycle
 
@@ -135,6 +148,11 @@ PR D 不改变 recovery semantics。它覆盖：
 - in-flight recovery 时退出；
 - double close；
 - Desktop 与 CLI 同 workspace 的 owner 冲突策略。
+
+Host owner 使用显式 `opening -> ready -> closing -> closed` 状态机；`close()` 共享一个
+幂等 Promise。关闭顺序固定为：停止 admission、取消后台 recovery、等待任务收敛、关闭 registry
+与 filesystem worker、关闭 stores，最后释放 workspace owner lock。后台 Promise 在创建时就必须
+登记 rejection owner。
 
 ## 3. Native 与 Git 的能力边界
 
@@ -164,6 +182,11 @@ Git 是 workspace continuity carrier，而不是单文件因果证明的前置�
 ### PR E — Checkpoint contracts
 
 先定义纯语义和 fake provider，不接 Git：
+
+在第一个通用 Phase 3B 审计事实落盘前，先引入 generic invisible `runtimeFact` envelope。
+现有 `actions.toolRecovery` 保持不变，避免返工；workspace transition 与 checkpoint 使用通用
+envelope。旧 read-model 对未知 fact 可跳过展示，但 recovery consumer 必须 fail closed。这个前置
+不追溯阻塞已经存在的 PR A tool recovery facts。
 
 ```ts
 interface WorkspaceBoundary {

--- a/knip.json
+++ b/knip.json
@@ -17,8 +17,12 @@
         "scripts/browser-observe-act-smoke.mjs"
       ],
       "project": ["src/**/*.{ts,tsx}", "e2e/**/*.ts", "stories/**/*.{ts,tsx}", "scripts/**/*.mjs"],
-      "ignoreDependencies": ["@fontsource-variable/geist", "@fontsource-variable/geist-mono"],
-      "ignoreBinaries": ["taskkill"]
+      "ignoreDependencies": [
+        "@fontsource-variable/geist",
+        "@fontsource-variable/geist-mono",
+        "electron-builder"
+      ],
+      "ignoreBinaries": ["taskkill", "electron-builder"]
     },
     "packages/ui": {
       "entry": ["src/**/*.test.ts", "src/**/*.test.tsx", "stories/**/*.@(ts|tsx)"],

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -10,6 +10,10 @@
   "exports": {
     ".": "./dist/index.js",
     "./runtime-event": "./dist/runtime-event.js",
+    "./tool-args-identity": "./dist/tool-args-identity.js",
+    "./tool-ledger-scanner": "./dist/tool-ledger-scanner.js",
+    "./tool-recovery-fact": "./dist/tool-recovery-fact.js",
+    "./tool-recovery-bundle": "./dist/tool-recovery-bundle.js",
     "./runtime-policy": "./dist/runtime-policy.js",
     "./execution-evidence": "./dist/execution-evidence.js",
     "./events": "./dist/events.js",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,6 +9,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": "./dist/index.js",
+    "./canonical-runtime-event": "./dist/canonical-runtime-event.js",
     "./runtime-event": "./dist/runtime-event.js",
     "./tool-args-identity": "./dist/tool-args-identity.js",
     "./tool-ledger-scanner": "./dist/tool-ledger-scanner.js",

--- a/packages/core/src/__tests__/tool-recovery-authority.test.ts
+++ b/packages/core/src/__tests__/tool-recovery-authority.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { decodeRuntimeEvent, type RuntimeEvent } from '../runtime-event.js';
-import { canonicalToolArgsHash } from '../tool-args-identity.js';
+import { canonicalToolArgsHash, stableJsonStringify } from '../tool-args-identity.js';
 import {
   scanToolLedger,
   validateGenericToolLedgerAppend,
@@ -15,6 +15,28 @@ import {
 
 const EXPECTED_ARGS_HASH =
   'sha256:763712445cbfb7feebe3bd4ba14e29425f05e40b8cd14aef0896853dca24b4d9';
+const MAINLINE_V1_HASH_VECTORS = [
+  [
+    { path: 'prepared.txt' },
+    'sha256:b10a9dfa507aac2940a27bdd3670fd7582d52705de906eb13c1ab37b553031e1',
+  ],
+  [
+    { required: ['b', 'a'] },
+    'sha256:0002fcd132216e3442d4ab7579d9659019019c6b7000456fbef198b7ae53ee43',
+  ],
+  [
+    { nested: { enum: ['z', 'a'] } },
+    'sha256:a1545a7c4bb9197d99d49327067d31da23188091e1bf6641e2a1698d9a906eca',
+  ],
+  [
+    JSON.parse('{"__proto__":{"admin":true}}') as unknown,
+    'sha256:ad5ecbd9c66b763ad3505d4ac9ddc7a86cffcecd8fd7f2c0ffb342c34da285e9',
+  ],
+  [
+    { ordinaryArray: ['b', 'a'] },
+    'sha256:4b6be45e18e1a7c6566dd72a0fa0c01b0f059bb3128ecd7a3265d5221f7b8351',
+  ],
+] as const;
 const OBSERVATION_DIGEST =
   'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
 
@@ -37,19 +59,25 @@ describe('recovery persistence authority', () => {
     );
   });
 
-  it('keeps __proto__ JSON properties distinct from an empty object', () => {
-    const empty = canonicalToolArgsHash('Write', {});
-    const withPrototypeNamedProperty = canonicalToolArgsHash(
-      'Write',
-      JSON.parse('{"__proto__":{"admin":true}}'),
-    );
-    const nestedPrototypeNamedProperty = canonicalToolArgsHash(
-      'Write',
-      JSON.parse('{"nested":{"__proto__":{"admin":true}}}'),
-    );
+  it('matches frozen mainline v1 hashes for special and ordinary array fields', () => {
+    for (const [args, expected] of MAINLINE_V1_HASH_VECTORS) {
+      assert.equal(canonicalToolArgsHash('X', args), expected);
+    }
+  });
 
-    assert.notEqual(withPrototypeNamedProperty, empty);
-    assert.notEqual(nestedPrototypeNamedProperty, canonicalToolArgsHash('Write', { nested: {} }));
+  it('keeps strict event JSON lossless while freezing the mainline v1 __proto__ hash', () => {
+    const empty = canonicalToolArgsHash('Write', {});
+    const withPrototypeNamedProperty = JSON.parse('{"__proto__":{"admin":true}}') as unknown;
+    const nestedPrototypeNamedProperty = JSON.parse(
+      '{"nested":{"__proto__":{"admin":true}}}',
+    ) as unknown;
+
+    assert.notEqual(stableJsonStringify(withPrototypeNamedProperty), stableJsonStringify({}));
+    assert.equal(canonicalToolArgsHash('Write', withPrototypeNamedProperty), empty);
+    assert.equal(
+      canonicalToolArgsHash('Write', nestedPrototypeNamedProperty),
+      canonicalToolArgsHash('Write', { nested: {} }),
+    );
   });
 
   it('rejects arrays that cannot be represented as exact strict JSON arrays', () => {

--- a/packages/core/src/__tests__/tool-recovery-authority.test.ts
+++ b/packages/core/src/__tests__/tool-recovery-authority.test.ts
@@ -269,6 +269,25 @@ describe('recovery persistence authority', () => {
     assert.equal(scan.operations.length, 2);
   });
 
+  it('rejects one invocation identity spanning multiple execution spines', () => {
+    const otherRun = callEvent({
+      id: 'call-event-2',
+      runId: 'run-2',
+      turnId: 'turn-2',
+      content: {
+        kind: 'function_call',
+        id: 'provider-call-2',
+        name: 'Read',
+        args: {},
+      },
+    });
+
+    const scan = scanToolLedger([callEvent(), otherRun]);
+
+    assert.equal(scan.hasCorruption, true);
+    assert.ok(scan.issues.some(({ code }) => code === 'invocation_identity_conflict'));
+  });
+
   it('rejects prospective generic transitions that would corrupt a clean ledger', () => {
     const duplicateCall = callEvent({ id: 'call-event-duplicate' });
     assert.deepEqual(

--- a/packages/core/src/__tests__/tool-recovery-authority.test.ts
+++ b/packages/core/src/__tests__/tool-recovery-authority.test.ts
@@ -5,6 +5,7 @@ import { canonicalToolArgsHash } from '../tool-args-identity.js';
 import {
   scanToolLedger,
   validateGenericToolLedgerAppend,
+  validateToolLedgerTransition,
   validateToolLedgerEventLane,
 } from '../tool-ledger-scanner.js';
 import {
@@ -34,6 +35,47 @@ describe('recovery persistence authority', () => {
       () => canonicalToolArgsHash('Write', { [Symbol('hidden')]: 'value' }),
       /strict JSON/,
     );
+  });
+
+  it('keeps __proto__ JSON properties distinct from an empty object', () => {
+    const empty = canonicalToolArgsHash('Write', {});
+    const withPrototypeNamedProperty = canonicalToolArgsHash(
+      'Write',
+      JSON.parse('{"__proto__":{"admin":true}}'),
+    );
+    const nestedPrototypeNamedProperty = canonicalToolArgsHash(
+      'Write',
+      JSON.parse('{"nested":{"__proto__":{"admin":true}}}'),
+    );
+
+    assert.notEqual(withPrototypeNamedProperty, empty);
+    assert.notEqual(nestedPrototypeNamedProperty, canonicalToolArgsHash('Write', { nested: {} }));
+  });
+
+  it('rejects arrays that cannot be represented as exact strict JSON arrays', () => {
+    const sparse = new Array(1);
+    const withExtraProperty = [1] as number[] & { extra?: number };
+    withExtraProperty.extra = 2;
+    const withAccessor = [1];
+    Object.defineProperty(withAccessor, '0', {
+      enumerable: true,
+      configurable: true,
+      get: () => 1,
+    });
+    const withCustomPrototype = [1];
+    Object.setPrototypeOf(withCustomPrototype, Object.create(Array.prototype));
+
+    for (const value of [sparse, withExtraProperty, withAccessor, withCustomPrototype]) {
+      assert.throws(() => canonicalToolArgsHash('Write', value), /strict JSON/);
+    }
+  });
+
+  it('accepts null-prototype records as exact JSON objects', () => {
+    const value = Object.create(null) as Record<string, unknown>;
+    value.path = 'notes.txt';
+    value.content = 'after';
+
+    assert.equal(canonicalToolArgsHash('Write', value), EXPECTED_ARGS_HASH);
   });
 
   it('rejects RuntimeEvents that claim more than one tool-ledger semantic lane', () => {
@@ -70,6 +112,22 @@ describe('recovery persistence authority', () => {
       ok: false,
       code: 'semantic_lane_conflict',
       eventId: 'outcome-event-1',
+    });
+
+    const outcomeWithContinuation = outcomeEvent();
+    outcomeWithContinuation.actions = { stateDelta: { continuationStart: true } };
+    assert.deepEqual(validateToolLedgerEventLane(outcomeWithContinuation), {
+      ok: false,
+      code: 'semantic_lane_conflict',
+      eventId: 'outcome-event-1',
+    });
+
+    const callWithArtifact = callEvent();
+    callWithArtifact.actions = { artifactDelta: { bytes: 10 } };
+    assert.deepEqual(validateToolLedgerEventLane(callWithArtifact), {
+      ok: false,
+      code: 'semantic_lane_conflict',
+      eventId: 'call-event-1',
     });
   });
 
@@ -136,6 +194,113 @@ describe('recovery persistence authority', () => {
       ['event_order_conflict', 'duplicate_call', 'duplicate_operation'],
     );
     assert.equal(scan.hasCorruption, true);
+  });
+
+  it('revalidates an earlier response when a later dispatch binds the operation', () => {
+    const unboundResponse = outcomeEvent();
+    unboundResponse.refs = { toolCallId: 'provider-call-1' };
+
+    const scan = scanToolLedger([callEvent(), unboundResponse, dispatchEvent()]);
+
+    assert.equal(scan.hasCorruption, true);
+    assert.ok(scan.issues.some(({ code }) => code === 'event_order_conflict'));
+    assert.ok(scan.issues.some(({ code }) => code === 'identity_conflict'));
+  });
+
+  it('authenticates every dispatch hash against the canonical call arguments', () => {
+    const dispatch = dispatchEvent();
+    dispatch.actions!.toolDispatch!.canonicalArgsHash = 'sha256:wrong';
+
+    const scan = scanToolLedger([callEvent(), dispatch]);
+
+    assert.equal(scan.hasCorruption, true);
+    assert.ok(scan.issues.some(({ code }) => code === 'canonical_args_hash_conflict'));
+  });
+
+  it('rejects partial events that carry an authoritative tool fact', () => {
+    const partialDispatch = dispatchEvent();
+    partialDispatch.partial = true;
+
+    const scan = scanToolLedger([partialDispatch]);
+
+    assert.deepEqual(scan.issues, [
+      {
+        code: 'semantic_lane_conflict',
+        eventId: 'dispatch-event-1',
+      },
+    ]);
+  });
+
+  it('rejects branch-qualified tool authority until branch is part of durable identity', () => {
+    const branchedCall = callEvent();
+    branchedCall.branch = 'child-1';
+
+    assert.deepEqual(validateToolLedgerEventLane(branchedCall), {
+      ok: false,
+      code: 'semantic_lane_conflict',
+      eventId: 'call-event-1',
+    });
+  });
+
+  it('uses unambiguous tuple identity for provider call keys', () => {
+    const first = callEvent({
+      id: 'call-a',
+      invocationId: 'a\0b',
+      content: {
+        kind: 'function_call',
+        id: 'c',
+        name: 'Read',
+        args: {},
+      },
+    });
+    const second = callEvent({
+      id: 'call-b',
+      invocationId: 'a',
+      content: {
+        kind: 'function_call',
+        id: 'b\0c',
+        name: 'Read',
+        args: {},
+      },
+    });
+
+    const scan = scanToolLedger([first, second]);
+    assert.equal(scan.hasCorruption, false);
+    assert.equal(scan.operations.length, 2);
+  });
+
+  it('rejects prospective generic transitions that would corrupt a clean ledger', () => {
+    const duplicateCall = callEvent({ id: 'call-event-duplicate' });
+    assert.deepEqual(
+      validateToolLedgerTransition({
+        existingEvents: [callEvent()],
+        candidateEvents: [duplicateCall],
+        expectedTransition: 'generic_append',
+      }),
+      {
+        ok: false,
+        code: 'duplicate_call',
+        eventId: 'call-event-duplicate',
+        toolCallId: 'provider-call-1',
+      },
+    );
+
+    const unboundResponse = outcomeEvent();
+    unboundResponse.refs = { toolCallId: 'provider-call-1' };
+    assert.deepEqual(
+      validateToolLedgerTransition({
+        existingEvents: [callEvent(), dispatchEvent()],
+        candidateEvents: [unboundResponse],
+        expectedTransition: 'generic_append',
+      }),
+      {
+        ok: false,
+        code: 'identity_conflict',
+        eventId: 'outcome-event-1',
+        operationId: 'operation-1',
+        toolCallId: 'provider-call-1',
+      },
+    );
   });
 
   it('rejects a recovery bundle whose T1 hash authenticates itself instead of the call args', () => {

--- a/packages/core/src/__tests__/tool-recovery-authority.test.ts
+++ b/packages/core/src/__tests__/tool-recovery-authority.test.ts
@@ -1,0 +1,348 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { decodeRuntimeEvent, type RuntimeEvent } from '../runtime-event.js';
+import { canonicalToolArgsHash } from '../tool-args-identity.js';
+import {
+  scanToolLedger,
+  validateGenericToolLedgerAppend,
+  validateToolLedgerEventLane,
+} from '../tool-ledger-scanner.js';
+import {
+  interpretScannedToolRecovery,
+  validateToolRecoveryEventBundle,
+} from '../tool-recovery-bundle.js';
+
+const EXPECTED_ARGS_HASH =
+  'sha256:6d6986f1e1432963178ce8c64f6fb4a1ba30f6176991750cc70558e417d93058';
+const OBSERVATION_DIGEST =
+  'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
+
+describe('recovery persistence authority', () => {
+  it('derives one domain-separated identity from strict JSON tool arguments', () => {
+    assert.equal(
+      canonicalToolArgsHash('Write', { content: 'after', path: 'notes.txt' }),
+      EXPECTED_ARGS_HASH,
+    );
+    assert.equal(
+      canonicalToolArgsHash('Write', { path: 'notes.txt', content: 'after' }),
+      EXPECTED_ARGS_HASH,
+    );
+    assert.throws(() => canonicalToolArgsHash('Write', { value: undefined }), /strict JSON/);
+    assert.throws(() => canonicalToolArgsHash('Write', { value: Number.NaN }), /strict JSON/);
+    assert.throws(() => canonicalToolArgsHash('Write', { value: 1n }), /strict JSON/);
+    assert.throws(
+      () => canonicalToolArgsHash('Write', { [Symbol('hidden')]: 'value' }),
+      /strict JSON/,
+    );
+  });
+
+  it('rejects RuntimeEvents that claim more than one tool-ledger semantic lane', () => {
+    const callWithDispatch = callEvent();
+    callWithDispatch.actions = dispatchEvent().actions;
+    assert.deepEqual(validateToolLedgerEventLane(callWithDispatch), {
+      ok: false,
+      code: 'semantic_lane_conflict',
+      eventId: 'call-event-1',
+    });
+
+    const terminalDispatch = dispatchEvent();
+    terminalDispatch.status = 'completed';
+    assert.deepEqual(validateToolLedgerEventLane(terminalDispatch), {
+      ok: false,
+      code: 'semantic_lane_conflict',
+      eventId: 'dispatch-event-1',
+    });
+
+    const recoveryWithContent = reconcileEvent();
+    recoveryWithContent.content = {
+      kind: 'text',
+      text: 'not a canonical recovery fact',
+    };
+    assert.deepEqual(validateToolLedgerEventLane(recoveryWithContent), {
+      ok: false,
+      code: 'semantic_lane_conflict',
+      eventId: 'reconcile-event-1',
+    });
+
+    const outcomeWithAuthority = outcomeEvent();
+    outcomeWithAuthority.actions = { endInvocation: true };
+    assert.deepEqual(validateToolLedgerEventLane(outcomeWithAuthority), {
+      ok: false,
+      code: 'semantic_lane_conflict',
+      eventId: 'outcome-event-1',
+    });
+  });
+
+  it('reserves durable boundary and recovery facts from generic writers', () => {
+    assert.deepEqual(validateGenericToolLedgerAppend(dispatchEvent()), {
+      ok: false,
+      code: 'reserved_tool_boundary_fact',
+      eventId: 'dispatch-event-1',
+    });
+    assert.deepEqual(validateGenericToolLedgerAppend(outcomeEvent()), {
+      ok: false,
+      code: 'reserved_tool_boundary_fact',
+      eventId: 'outcome-event-1',
+    });
+    assert.deepEqual(validateGenericToolLedgerAppend(reconcileEvent()), {
+      ok: false,
+      code: 'reserved_recovery_fact',
+      eventId: 'reconcile-event-1',
+    });
+    assert.deepEqual(validateGenericToolLedgerAppend(callEvent()), { ok: true });
+  });
+
+  it('decodes only the exact recovery fact version and payload shape', () => {
+    assert.deepEqual(decodeRuntimeEvent(reconcileEvent()), reconcileEvent());
+    const unknownVersion = structuredClone(reconcileEvent()) as unknown as {
+      actions: { toolRecovery: { version: number } };
+    };
+    unknownVersion.actions.toolRecovery.version = 999;
+    assert.throws(() => decodeRuntimeEvent(unknownVersion), /RuntimeEvent schema/);
+  });
+
+  it('reports duplicate call identity, duplicate operation identity, and physical order', () => {
+    const duplicateCall = { ...callEvent(), id: 'call-event-2' };
+    const otherCall = callEvent({
+      id: 'call-event-other',
+      content: {
+        kind: 'function_call',
+        id: 'provider-call-2',
+        name: 'Write',
+        args: { path: 'other.txt', content: 'after' },
+      },
+    });
+    const duplicateOperation = dispatchEvent({
+      id: 'dispatch-event-other',
+      actions: {
+        toolDispatch: {
+          ...dispatchEvent().actions!.toolDispatch!,
+          providerToolCallId: 'provider-call-2',
+        },
+      },
+      refs: { operationId: 'operation-1', toolCallId: 'provider-call-2' },
+    });
+
+    const scan = scanToolLedger([
+      dispatchEvent(),
+      callEvent(),
+      duplicateCall,
+      otherCall,
+      duplicateOperation,
+    ]);
+
+    assert.deepEqual(
+      scan.issues.map(({ code }) => code),
+      ['event_order_conflict', 'duplicate_call', 'duplicate_operation'],
+    );
+    assert.equal(scan.hasCorruption, true);
+  });
+
+  it('rejects a recovery bundle whose T1 hash authenticates itself instead of the call args', () => {
+    const dispatch = dispatchEvent();
+    dispatch.actions!.toolDispatch!.canonicalArgsHash = 'sha256:wrong';
+
+    assert.deepEqual(
+      validateToolRecoveryEventBundle({
+        operation: {
+          ...operationIdentity(),
+          canonicalArgsHash: 'sha256:wrong',
+        },
+        callEvent: callEvent(),
+        dispatchEvent: dispatch,
+        reconcileEvent: reconcileEvent(),
+        outcomeEvent: outcomeEvent(),
+        decisionEvent: decisionEvent(),
+      }),
+      {
+        ok: false,
+        code: 'canonical_args_hash_conflict',
+        message: 'Recovery bundle argument hash does not match its canonical function call',
+      },
+    );
+  });
+
+  it('accepts completed only with one matching outcome and canonical evidence order', () => {
+    assert.deepEqual(
+      validateToolRecoveryEventBundle({
+        operation: operationIdentity(),
+        callEvent: callEvent(),
+        dispatchEvent: dispatchEvent(),
+        reconcileEvent: reconcileEvent(),
+        outcomeEvent: outcomeEvent(),
+        decisionEvent: decisionEvent(),
+      }),
+      {
+        ok: true,
+        reconcile: reconcileEvent().actions!.toolRecovery!.payload,
+        decision: decisionEvent().actions!.toolRecovery!.payload,
+      },
+    );
+  });
+
+  it('gives Resolver and rebuild one recovery-bundle interpretation', () => {
+    const events = [
+      callEvent(),
+      dispatchEvent(),
+      reconcileEvent(),
+      outcomeEvent(),
+      decisionEvent(),
+    ];
+    const operation = scanToolLedger(events).operations[0]!;
+
+    assert.equal(
+      interpretScannedToolRecovery(
+        operation,
+        new Map(events.map((event, index) => [event.id, index])),
+      ).kind,
+      'valid',
+    );
+
+    const wrongOrder = [
+      callEvent(),
+      dispatchEvent(),
+      outcomeEvent(),
+      reconcileEvent(),
+      decisionEvent(),
+    ];
+    assert.deepEqual(
+      interpretScannedToolRecovery(
+        scanToolLedger(wrongOrder).operations[0]!,
+        new Map(wrongOrder.map((event, index) => [event.id, index])),
+      ),
+      {
+        kind: 'corruption',
+        code: 'event_order_conflict',
+        message: 'Recovery facts violate canonical RuntimeEvent causal order',
+      },
+    );
+  });
+});
+
+function operationIdentity() {
+  return {
+    operationId: 'operation-1',
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    turnId: 'turn-1',
+    providerToolCallId: 'provider-call-1',
+    toolName: 'Write',
+    canonicalArgsHash: EXPECTED_ARGS_HASH,
+    recoveryMode: 'reconcile' as const,
+    callEventId: 'call-event-1',
+    dispatchEventId: 'dispatch-event-1',
+  };
+}
+
+function baseEvent(overrides: Partial<RuntimeEvent>): RuntimeEvent {
+  return {
+    id: 'event-1',
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}
+
+function callEvent(overrides: Partial<RuntimeEvent> = {}): RuntimeEvent {
+  return baseEvent({
+    id: 'call-event-1',
+    role: 'model',
+    author: 'agent',
+    content: {
+      kind: 'function_call',
+      id: 'provider-call-1',
+      name: 'Write',
+      args: { path: 'notes.txt', content: 'after' },
+    },
+    ...overrides,
+  });
+}
+
+function dispatchEvent(overrides: Partial<RuntimeEvent> = {}): RuntimeEvent {
+  return baseEvent({
+    id: 'dispatch-event-1',
+    actions: {
+      toolDispatch: {
+        protocol: 't1_after_preflight_v1',
+        operationId: 'operation-1',
+        providerToolCallId: 'provider-call-1',
+        toolName: 'Write',
+        canonicalArgsHash: EXPECTED_ARGS_HASH,
+        recoveryMode: 'reconcile',
+      },
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+    ...overrides,
+  });
+}
+
+function reconcileEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'reconcile-event-1',
+    ts: 2,
+    actions: {
+      toolRecovery: {
+        kind: 'maka.tool.reconcile_result',
+        version: 1,
+        payload: {
+          protocol: 'tool_reconcile_v1',
+          operationId: 'operation-1',
+          observation: 'matches_expected_state',
+          observationSchema: 'state_identity_v1',
+          observationDigest: OBSERVATION_DIGEST,
+        },
+      },
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  });
+}
+
+function outcomeEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'outcome-event-1',
+    ts: 3,
+    role: 'tool',
+    author: 'tool',
+    content: {
+      kind: 'function_response',
+      id: 'provider-call-1',
+      name: 'Write',
+      result: 'ok',
+      isError: false,
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  });
+}
+
+function decisionEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'decision-event-1',
+    ts: 4,
+    actions: {
+      toolRecovery: {
+        kind: 'maka.tool.recovery_decision',
+        version: 1,
+        payload: {
+          protocol: 'tool_recovery_v1',
+          operationId: 'operation-1',
+          disposition: 'completed',
+          reasonCode: 'reconcile_matches_expected_state',
+          outcomeEventId: 'outcome-event-1',
+          evidenceEventIds: [
+            'call-event-1',
+            'dispatch-event-1',
+            'reconcile-event-1',
+            'outcome-event-1',
+          ],
+        },
+      },
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  });
+}

--- a/packages/core/src/__tests__/tool-recovery-authority.test.ts
+++ b/packages/core/src/__tests__/tool-recovery-authority.test.ts
@@ -14,12 +14,12 @@ import {
 } from '../tool-recovery-bundle.js';
 
 const EXPECTED_ARGS_HASH =
-  'sha256:6d6986f1e1432963178ce8c64f6fb4a1ba30f6176991750cc70558e417d93058';
+  'sha256:763712445cbfb7feebe3bd4ba14e29425f05e40b8cd14aef0896853dca24b4d9';
 const OBSERVATION_DIGEST =
   'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
 
 describe('recovery persistence authority', () => {
-  it('derives one domain-separated identity from strict JSON tool arguments', () => {
+  it('preserves the mainline T1 identity bytes for strict JSON tool arguments', () => {
     assert.equal(
       canonicalToolArgsHash('Write', { content: 'after', path: 'notes.txt' }),
       EXPECTED_ARGS_HASH,

--- a/packages/core/src/canonical-runtime-event.ts
+++ b/packages/core/src/canonical-runtime-event.ts
@@ -1,0 +1,60 @@
+import { isDeepStrictEqual } from 'node:util';
+import type { RuntimeEvent } from './runtime-event.js';
+import { decodeRuntimeEvent } from './runtime-event.js';
+import { stableJsonStringify } from './tool-args-identity.js';
+
+export interface CanonicalRuntimeEventEncoding {
+  event: RuntimeEvent;
+  json: string;
+}
+
+/**
+ * Owns the one lossless JSON representation used for immutable RuntimeEvents.
+ *
+ * The structural decoder may intentionally normalize optional presentation
+ * fields. After that normalization, every nested value must still be strict
+ * JSON: no undefined, accessors, custom prototypes, toJSON hooks, sparse
+ * arrays, or other values whose persisted meaning could differ from the value
+ * validated by a writer.
+ */
+export function encodeCanonicalRuntimeEvent(value: unknown): CanonicalRuntimeEventEncoding {
+  const decoded = normalizeRuntimeEventEnvelope(decodeRuntimeEvent(value));
+  let json: string;
+  try {
+    json = stableJsonStringify(decoded);
+  } catch (cause) {
+    throw new Error('RuntimeEvent is not losslessly serializable', { cause });
+  }
+  const event = decodeRuntimeEvent(JSON.parse(json));
+  if (!isDeepStrictEqual(decoded, event)) {
+    throw new Error('RuntimeEvent is not losslessly serializable');
+  }
+  return { event, json };
+}
+
+function normalizeRuntimeEventEnvelope(event: RuntimeEvent): RuntimeEvent {
+  const normalized = omitUndefinedEnvelopeFields(event) as unknown as RuntimeEvent;
+  for (const key of ['content', 'actions', 'refs'] as const) {
+    const nested = normalized[key];
+    if (nested && typeof nested === 'object') {
+      Object.defineProperty(normalized, key, {
+        ...Object.getOwnPropertyDescriptor(normalized, key),
+        value: omitUndefinedEnvelopeFields(nested),
+      });
+    }
+  }
+  return normalized;
+}
+
+function omitUndefinedEnvelopeFields(value: object): object {
+  const result = Object.create(Object.getPrototypeOf(value)) as Record<PropertyKey, unknown>;
+  for (const key of Reflect.ownKeys(value)) {
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !Object.hasOwn(descriptor, 'value')) {
+      throw new Error('RuntimeEvent is not losslessly serializable');
+    }
+    if (descriptor.value === undefined) continue;
+    Object.defineProperty(result, key, descriptor);
+  }
+  return result;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -192,11 +192,14 @@ export type {
   ToolLedgerLaneValidation,
   ToolLedgerScanOperation,
   ToolLedgerScanResult,
+  ToolLedgerTransitionKind,
+  ToolLedgerTransitionValidation,
 } from './tool-ledger-scanner.js';
 export {
   scanToolLedger,
   validateGenericToolLedgerAppend,
   validateToolLedgerEventLane,
+  validateToolLedgerTransition,
 } from './tool-ledger-scanner.js';
 export type {
   ToolReconcileObservation,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -179,6 +179,56 @@ export {
 // runtime-event-store.ts
 export type { RuntimeEventStore } from './runtime-event-store.js';
 export { DurableStoreWriteError } from './runtime-event-store.js';
+export type {
+  RuntimeRecoveryBundleCommit,
+  RuntimeRecoveryBundleStore,
+} from './runtime-event-store.js';
+export { TOOL_RECOVERY_BUNDLE_CAPABILITY_V1 } from './runtime-event-store.js';
+export type {
+  ToolLedgerIssue,
+  ToolLedgerIssueCode,
+  GenericToolLedgerAppendValidation,
+  ToolLedgerLane,
+  ToolLedgerLaneValidation,
+  ToolLedgerScanOperation,
+  ToolLedgerScanResult,
+} from './tool-ledger-scanner.js';
+export {
+  scanToolLedger,
+  validateGenericToolLedgerAppend,
+  validateToolLedgerEventLane,
+} from './tool-ledger-scanner.js';
+export type {
+  ToolReconcileObservation,
+  ToolReconcileResultFact,
+  ToolRecoveryCompletedDecisionFact,
+  ToolRecoveryDecisionFact,
+  ToolRecoveryFactEnvelope,
+  ToolRecoveryParkedDecisionFact,
+  ToolRecoveryParkReason,
+} from './tool-recovery-fact.js';
+export {
+  TOOL_RECONCILE_RESULT_FACT_KIND,
+  TOOL_RECOVERY_DECISION_FACT_KIND,
+  TOOL_RECOVERY_FACT_VERSION,
+  isToolReconcileResultFact,
+  isToolRecoveryDecisionFact,
+  isToolRecoveryFactEnvelope,
+} from './tool-recovery-fact.js';
+export type {
+  ScannedToolRecoveryInterpretation,
+  ToolRecoveryBundleValidationCode,
+  ToolRecoveryBundleValidationResult,
+  ToolRecoveryEventBundle,
+  ToolRecoveryOperationIdentity,
+} from './tool-recovery-bundle.js';
+export {
+  ToolRecoveryBundleValidationError,
+  assertToolRecoveryEventBundle,
+  interpretScannedToolRecovery,
+  validateToolRecoveryEventBundle,
+} from './tool-recovery-bundle.js';
+export { canonicalToolArgsHash, stableJsonStringify } from './tool-args-identity.js';
 
 // session.ts
 export type {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -232,6 +232,10 @@ export {
   validateToolRecoveryEventBundle,
 } from './tool-recovery-bundle.js';
 export { canonicalToolArgsHash, stableJsonStringify } from './tool-args-identity.js';
+export {
+  encodeCanonicalRuntimeEvent,
+  type CanonicalRuntimeEventEncoding,
+} from './canonical-runtime-event.js';
 
 // session.ts
 export type {

--- a/packages/core/src/runtime-event-store.ts
+++ b/packages/core/src/runtime-event-store.ts
@@ -1,5 +1,14 @@
 import type { RuntimeEvent } from './runtime-event.js';
 
+export const TOOL_RECOVERY_BUNDLE_CAPABILITY_V1 = 'tool_recovery_bundle_v1' as const;
+
+export interface RuntimeRecoveryBundleCommit {
+  operationId: string;
+  reconcileRuntimeEvent: RuntimeEvent;
+  outcomeRuntimeEvent?: RuntimeEvent;
+  decisionRuntimeEvent: RuntimeEvent;
+}
+
 /** A requested stable-storage barrier failed; read-back cannot upgrade it to success. */
 export class DurableStoreWriteError extends Error {
   readonly name = 'DurableStoreWriteError';
@@ -31,4 +40,9 @@ export interface RuntimeEventStore {
   /** Physical append-log rows only; excludes mutable partial snapshots. */
   readImmutableRuntimeEvents?(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
   readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]>;
+}
+
+export interface RuntimeRecoveryBundleStore extends RuntimeEventStore {
+  readonly recoveryBundleCapability: typeof TOOL_RECOVERY_BUNDLE_CAPABILITY_V1;
+  commitToolRecoveryBundle(input: RuntimeRecoveryBundleCommit): Promise<void>;
 }

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -43,6 +43,7 @@ import {
   isUserQuestionRequest,
 } from './interaction-record-schema.js';
 import { isTokenUsageFields } from './usage-record-schema.js';
+import { isToolRecoveryFactEnvelope, type ToolRecoveryFactEnvelope } from './tool-recovery-fact.js';
 
 // ============================================================================
 // Role / Author / Status
@@ -293,6 +294,8 @@ export interface RuntimeEventActions {
   tokenUsage?: RuntimeEventTokenUsage;
   /** Durable, non-model-visible T1 tool-dispatch fact. */
   toolDispatch?: RuntimeEventToolDispatch;
+  /** Reserved recovery fact; only the atomic recovery-bundle writer may persist it. */
+  toolRecovery?: ToolRecoveryFactEnvelope;
   /** Protocols that were actually active from the first event of this run. */
   runtimeProtocol?: RuntimeEventProtocolMarker;
 }
@@ -423,6 +426,7 @@ const RUNTIME_ACTIONS_SHAPE = defineObjectShape<RuntimeEventActions>()(
     'endInvocation',
     'tokenUsage',
     'toolDispatch',
+    'toolRecovery',
     'runtimeProtocol',
   ],
 );
@@ -610,6 +614,7 @@ function isRuntimeEventActions(value: unknown): value is RuntimeEventActions {
     (value.endInvocation === undefined || typeof value.endInvocation === 'boolean') &&
     (value.tokenUsage === undefined || isRuntimeTokenUsage(value.tokenUsage)) &&
     (value.toolDispatch === undefined || isRuntimeToolDispatch(value.toolDispatch)) &&
+    (value.toolRecovery === undefined || isToolRecoveryFactEnvelope(value.toolRecovery)) &&
     (value.runtimeProtocol === undefined || isRuntimeProtocolMarker(value.runtimeProtocol))
   );
 }

--- a/packages/core/src/tool-args-identity.ts
+++ b/packages/core/src/tool-args-identity.ts
@@ -1,9 +1,13 @@
 import { createHash } from 'node:crypto';
 
-const TOOL_ARGS_IDENTITY_DOMAIN = 'canonical_tool_args_v1';
-
 /**
  * Returns the identity of the exact provider-visible tool name and arguments.
+ *
+ * `t1_after_preflight_v1` already persists the mainline identity bytes for
+ * stableHash({ toolName, args }). Keep that wire identity stable while using
+ * strict JSON canonicalization to reject values that mainline would otherwise
+ * coerce ambiguously. A different hash domain requires a versioned dispatch
+ * protocol rather than an in-place change to this function.
  *
  * Only JSON values are accepted. Silently coercing `undefined`, bigint, Date,
  * non-finite numbers, accessors, or custom prototypes would create collisions
@@ -12,7 +16,6 @@ const TOOL_ARGS_IDENTITY_DOMAIN = 'canonical_tool_args_v1';
 export function canonicalToolArgsHash(toolName: string, args: unknown): `sha256:${string}` {
   if (toolName.length === 0) throw new Error('Tool argument identity requires a tool name');
   const body = stableJsonStringify({
-    protocol: TOOL_ARGS_IDENTITY_DOMAIN,
     toolName,
     args,
   });

--- a/packages/core/src/tool-args-identity.ts
+++ b/packages/core/src/tool-args-identity.ts
@@ -29,7 +29,31 @@ function canonicalizeStrictJson(value: unknown): unknown {
     if (!Number.isFinite(value)) throw new Error('Tool arguments must be strict JSON values');
     return value;
   }
-  if (Array.isArray(value)) return value.map(canonicalizeStrictJson);
+  if (Array.isArray(value)) {
+    if (Object.getPrototypeOf(value) !== Array.prototype) {
+      throw new Error('Tool arguments must be strict JSON values');
+    }
+    const ownKeys = Reflect.ownKeys(value);
+    if (
+      ownKeys.length !== value.length + 1 ||
+      ownKeys.some(
+        (key) =>
+          typeof key !== 'string' ||
+          (key !== 'length' && !isCanonicalArrayIndex(key, value.length)),
+      )
+    ) {
+      throw new Error('Tool arguments must be strict JSON values');
+    }
+    const result: unknown[] = [];
+    for (let index = 0; index < value.length; index += 1) {
+      const descriptor = Object.getOwnPropertyDescriptor(value, String(index));
+      if (!descriptor || !descriptor.enumerable || !Object.hasOwn(descriptor, 'value')) {
+        throw new Error('Tool arguments must be strict JSON values');
+      }
+      result.push(canonicalizeStrictJson(descriptor.value));
+    }
+    return result;
+  }
   if (typeof value !== 'object') throw new Error('Tool arguments must be strict JSON values');
 
   const prototype = Object.getPrototypeOf(value);
@@ -37,7 +61,10 @@ function canonicalizeStrictJson(value: unknown): unknown {
     throw new Error('Tool arguments must be strict JSON values');
   }
   const record = value as Record<string, unknown>;
-  const result: Record<string, unknown> = {};
+  // A null prototype keeps JSON property names such as "__proto__" as data.
+  // Assigning that key to a normal object would invoke Object.prototype's
+  // legacy setter and collapse distinct provider arguments to the same hash.
+  const result = Object.create(null) as Record<string, unknown>;
   const keys = Object.keys(record);
   if (
     Reflect.ownKeys(record).some(
@@ -54,4 +81,10 @@ function canonicalizeStrictJson(value: unknown): unknown {
     result[key] = canonicalizeStrictJson(descriptor.value);
   }
   return result;
+}
+
+function isCanonicalArrayIndex(key: string, length: number): boolean {
+  if (!/^(0|[1-9]\d*)$/.test(key)) return false;
+  const index = Number(key);
+  return Number.isSafeInteger(index) && index >= 0 && index < length && String(index) === key;
 }

--- a/packages/core/src/tool-args-identity.ts
+++ b/packages/core/src/tool-args-identity.ts
@@ -1,0 +1,57 @@
+import { createHash } from 'node:crypto';
+
+const TOOL_ARGS_IDENTITY_DOMAIN = 'canonical_tool_args_v1';
+
+/**
+ * Returns the identity of the exact provider-visible tool name and arguments.
+ *
+ * Only JSON values are accepted. Silently coercing `undefined`, bigint, Date,
+ * non-finite numbers, accessors, or custom prototypes would create collisions
+ * between arguments that the provider/runtime did not actually agree on.
+ */
+export function canonicalToolArgsHash(toolName: string, args: unknown): `sha256:${string}` {
+  if (toolName.length === 0) throw new Error('Tool argument identity requires a tool name');
+  const body = stableJsonStringify({
+    protocol: TOOL_ARGS_IDENTITY_DOMAIN,
+    toolName,
+    args,
+  });
+  return `sha256:${createHash('sha256').update(body).digest('hex')}`;
+}
+
+export function stableJsonStringify(value: unknown): string {
+  return JSON.stringify(canonicalizeStrictJson(value));
+}
+
+function canonicalizeStrictJson(value: unknown): unknown {
+  if (value === null || typeof value === 'string' || typeof value === 'boolean') return value;
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw new Error('Tool arguments must be strict JSON values');
+    return value;
+  }
+  if (Array.isArray(value)) return value.map(canonicalizeStrictJson);
+  if (typeof value !== 'object') throw new Error('Tool arguments must be strict JSON values');
+
+  const prototype = Object.getPrototypeOf(value);
+  if (prototype !== Object.prototype && prototype !== null) {
+    throw new Error('Tool arguments must be strict JSON values');
+  }
+  const record = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  const keys = Object.keys(record);
+  if (
+    Reflect.ownKeys(record).some(
+      (key) => typeof key !== 'string' || !Object.getOwnPropertyDescriptor(record, key)?.enumerable,
+    )
+  ) {
+    throw new Error('Tool arguments must be strict JSON values');
+  }
+  for (const key of keys.sort()) {
+    const descriptor = Object.getOwnPropertyDescriptor(record, key);
+    if (!descriptor || !Object.hasOwn(descriptor, 'value')) {
+      throw new Error('Tool arguments must be strict JSON values');
+    }
+    result[key] = canonicalizeStrictJson(descriptor.value);
+  }
+  return result;
+}

--- a/packages/core/src/tool-args-identity.ts
+++ b/packages/core/src/tool-args-identity.ts
@@ -15,10 +15,11 @@ import { createHash } from 'node:crypto';
  */
 export function canonicalToolArgsHash(toolName: string, args: unknown): `sha256:${string}` {
   if (toolName.length === 0) throw new Error('Tool argument identity requires a tool name');
-  const body = stableJsonStringify({
-    toolName,
-    args,
-  });
+  // Validation and identity serialization are deliberately separate. Runtime
+  // events need the strict, lossless serializer below; the persisted v1 T1
+  // protocol must retain mainline's historical stableHash byte semantics.
+  stableJsonStringify(args);
+  const body = stringifyMainlineV1ToolArgsIdentity(toolName, args);
   return `sha256:${createHash('sha256').update(body).digest('hex')}`;
 }
 
@@ -90,4 +91,42 @@ function isCanonicalArrayIndex(key: string, length: number): boolean {
   if (!/^(0|[1-9]\d*)$/.test(key)) return false;
   const index = Number(key);
   return Number.isSafeInteger(index) && index >= 0 && index < length && String(index) === key;
+}
+
+function stringifyMainlineV1ToolArgsIdentity(toolName: string, args: unknown): string {
+  return JSON.stringify(canonicalizeMainlineV1({ toolName, args }));
+}
+
+function canonicalizeMainlineV1(value: unknown, parentKey?: string): unknown {
+  if (
+    value === null ||
+    typeof value === 'string' ||
+    typeof value === 'number' ||
+    typeof value === 'boolean'
+  ) {
+    return value;
+  }
+  if (Array.isArray(value)) {
+    const items = value.map((item) => canonicalizeMainlineV1(item));
+    return parentKey === 'required' || parentKey === 'enum'
+      ? items
+          .slice()
+          .sort((a, b) =>
+            JSON.stringify(canonicalizeMainlineV1(a)).localeCompare(
+              JSON.stringify(canonicalizeMainlineV1(b)),
+            ),
+          )
+      : items;
+  }
+
+  const record = value as Record<string, unknown>;
+  const result: Record<string, unknown> = {};
+  for (const key of Object.keys(record).sort()) {
+    // Mainline v1 assigned into a normal object, so this key invoked the
+    // legacy Object.prototype setter and was absent from the serialized bytes.
+    // Skip it explicitly to freeze those bytes without mutating a prototype.
+    if (key === '__proto__') continue;
+    result[key] = canonicalizeMainlineV1(record[key], key);
+  }
+  return result;
 }

--- a/packages/core/src/tool-ledger-scanner.ts
+++ b/packages/core/src/tool-ledger-scanner.ts
@@ -1,4 +1,6 @@
+import { isDeepStrictEqual } from 'node:util';
 import type { RuntimeEvent } from './runtime-event.js';
+import { canonicalToolArgsHash } from './tool-args-identity.js';
 
 export type ToolLedgerLane =
   | 'ordinary'
@@ -17,6 +19,7 @@ export type ToolLedgerIssueCode =
   | 'duplicate_response'
   | 'orphan_dispatch'
   | 'orphan_response'
+  | 'canonical_args_hash_conflict'
   | 'identity_conflict'
   | 'event_order_conflict';
 
@@ -55,6 +58,27 @@ export type GenericToolLedgerAppendValidation =
       ok: false;
       code: 'semantic_lane_conflict' | 'reserved_tool_boundary_fact' | 'reserved_recovery_fact';
       eventId: string;
+    };
+
+export type ToolLedgerTransitionKind =
+  | 'generic_append'
+  | 't1_prepare'
+  | 't2_outcome'
+  | 'recovery_bundle';
+
+export type ToolLedgerTransitionValidation =
+  | { ok: true }
+  | {
+      ok: false;
+      code:
+        | ToolLedgerIssueCode
+        | 'semantic_lane_conflict'
+        | 'reserved_tool_boundary_fact'
+        | 'reserved_recovery_fact'
+        | 'transition_shape_conflict';
+      eventId: string;
+      operationId?: string;
+      toolCallId?: string;
     };
 
 /**
@@ -105,6 +129,42 @@ export function validateGenericToolLedgerAppend(
 }
 
 /**
+ * Validates the ledger that would exist after one writer transaction.
+ *
+ * Event-local lane checks cannot detect duplicate calls, a response that
+ * becomes invalid when a later dispatch binds the operation, or other
+ * prefix-dependent corruption. Every tool-bearing writer uses this function
+ * before committing its candidate events.
+ */
+export function validateToolLedgerTransition(input: {
+  existingEvents: readonly RuntimeEvent[];
+  candidateEvents: readonly RuntimeEvent[];
+  expectedTransition: ToolLedgerTransitionKind;
+}): ToolLedgerTransitionValidation {
+  const existing = scanToolLedger(input.existingEvents);
+  if (existing.hasCorruption) return issueValidation(existing.issues[0]!);
+
+  const existingById = new Map(input.existingEvents.map((event) => [event.id, event]));
+  const candidates: RuntimeEvent[] = [];
+  for (const candidate of input.candidateEvents) {
+    const prior = existingById.get(candidate.id);
+    if (!prior) {
+      candidates.push(candidate);
+      continue;
+    }
+    if (!isDeepStrictEqual(prior, candidate)) {
+      return { ok: false, code: 'duplicate_event_id', eventId: candidate.id };
+    }
+  }
+  const shape = validateTransitionShape(candidates, input.expectedTransition);
+  if (!shape.ok) return shape;
+
+  const prospective = scanToolLedger([...input.existingEvents, ...candidates]);
+  if (prospective.hasCorruption) return issueValidation(prospective.issues[0]!);
+  return { ok: true };
+}
+
+/**
  * Scans immutable RuntimeEvents once, in physical ledger order. It owns the
  * duplicate/order/identity interpretation shared by Resolver and projection
  * rebuild; neither consumer may rebuild these maps independently.
@@ -127,13 +187,12 @@ export function scanToolLedger(events: readonly RuntimeEvent[]): ToolLedgerScanR
       continue;
     }
     seenEventIds.add(event.id);
-    if (event.partial) continue;
-
     const lane = validateToolLedgerEventLane(event);
     if (!lane.ok) {
-      addIssue(undefined, lane);
+      addIssue(undefined, { code: lane.code, eventId: lane.eventId });
       continue;
     }
+    if (event.partial) continue;
 
     if (lane.lane === 'function_call') {
       const content = event.content;
@@ -237,6 +296,43 @@ export function scanToolLedger(events: readonly RuntimeEvent[]): ToolLedgerScanR
           toolCallId: dispatch.providerToolCallId,
         });
       }
+      const callContent = operation.callEvent?.content;
+      if (callContent?.kind === 'function_call') {
+        let canonicalArgsHash: string | undefined;
+        try {
+          canonicalArgsHash = canonicalToolArgsHash(callContent.name, callContent.args);
+        } catch {
+          // A provider call that is not strict JSON cannot authenticate T1.
+        }
+        if (canonicalArgsHash !== dispatch.canonicalArgsHash) {
+          addIssue(operation, {
+            code: 'canonical_args_hash_conflict',
+            eventId: event.id,
+            operationId: dispatch.operationId,
+            toolCallId: dispatch.providerToolCallId,
+          });
+        }
+      }
+      if (operation.responseEvent) {
+        addIssue(operation, {
+          code: 'event_order_conflict',
+          eventId: event.id,
+          operationId: dispatch.operationId,
+          toolCallId: dispatch.providerToolCallId,
+        });
+        if (
+          operation.responseEvent.refs?.operationId !== dispatch.operationId ||
+          operation.responseEvent.refs?.toolCallId !== dispatch.providerToolCallId ||
+          !sameExecutionIdentity(event, operation.responseEvent)
+        ) {
+          addIssue(operation, {
+            code: 'identity_conflict',
+            eventId: operation.responseEvent.id,
+            operationId: dispatch.operationId,
+            toolCallId: dispatch.providerToolCallId,
+          });
+        }
+      }
       continue;
     }
 
@@ -315,19 +411,19 @@ function matchesLaneEnvelope(
   event: RuntimeEvent,
   lane: Exclude<ToolLedgerLane, 'ordinary'>,
 ): boolean {
-  if (event.partial || event.status !== undefined) return false;
+  if (event.partial || event.status !== undefined || event.branch !== undefined) return false;
   switch (lane) {
     case 'function_call':
       return (
         event.role === 'model' &&
         event.author === 'agent' &&
-        hasNoAuthoritativeToolActions(event.actions)
+        matchesFunctionCallActions(event.actions)
       );
     case 'function_response':
       return (
         event.role === 'tool' &&
         event.author === 'tool' &&
-        hasNoAuthoritativeToolActions(event.actions)
+        matchesFunctionResponseActions(event.actions)
       );
     case 'tool_dispatch':
       return (
@@ -349,6 +445,58 @@ function matchesLaneEnvelope(
   }
 }
 
+function validateTransitionShape(
+  events: readonly RuntimeEvent[],
+  expectedTransition: ToolLedgerTransitionKind,
+): ToolLedgerTransitionValidation {
+  if (events.length === 0) return { ok: true };
+  const lanes = events.map((event) => validateToolLedgerEventLane(event));
+  const invalid = lanes.find((lane) => !lane.ok);
+  if (invalid && !invalid.ok) return invalid;
+
+  if (expectedTransition === 'generic_append') {
+    for (const event of events) {
+      const validation = validateGenericToolLedgerAppend(event);
+      if (!validation.ok) return validation;
+    }
+    return { ok: true };
+  }
+
+  const actual = lanes.map((lane) => (lane.ok ? lane.lane : 'ordinary'));
+  const valid =
+    (expectedTransition === 't1_prepare' &&
+      ((actual.length === 2 && actual[0] === 'function_call' && actual[1] === 'tool_dispatch') ||
+        (actual.length === 1 && actual[0] === 'tool_dispatch'))) ||
+    (expectedTransition === 't2_outcome' &&
+      actual.length === 1 &&
+      actual[0] === 'function_response' &&
+      events[0]?.refs?.operationId !== undefined) ||
+    (expectedTransition === 'recovery_bundle' &&
+      ((actual.length === 2 &&
+        actual[0] === 'reconcile_result' &&
+        actual[1] === 'recovery_decision') ||
+        (actual.length === 3 &&
+          actual[0] === 'reconcile_result' &&
+          actual[1] === 'function_response' &&
+          actual[2] === 'recovery_decision')));
+  if (valid) return { ok: true };
+  return {
+    ok: false,
+    code: 'transition_shape_conflict',
+    eventId: events[0]?.id ?? 'unknown',
+  };
+}
+
+function issueValidation(issue: ToolLedgerIssue): ToolLedgerTransitionValidation {
+  return {
+    ok: false,
+    code: issue.code,
+    eventId: issue.eventId,
+    ...(issue.operationId ? { operationId: issue.operationId } : {}),
+    ...(issue.toolCallId ? { toolCallId: issue.toolCallId } : {}),
+  };
+}
+
 function sameExecutionIdentity(first: RuntimeEvent | undefined, second: RuntimeEvent): boolean {
   return (
     first !== undefined &&
@@ -365,13 +513,34 @@ function hasOnlyKeys(value: object | undefined, expected: readonly string[]): bo
   return keys.length === expected.length && expected.every((key) => Object.hasOwn(value, key));
 }
 
-function hasNoAuthoritativeToolActions(actions: RuntimeEvent['actions']): boolean {
+function matchesFunctionCallActions(actions: RuntimeEvent['actions']): boolean {
   if (!actions) return true;
-  return Object.keys(actions).every((key) =>
-    ['stateDelta', 'artifactDelta', 'tokenUsage'].includes(key),
+  if (!hasOnlyKeys(actions, ['stateDelta'])) return false;
+  const stateDelta = actions.stateDelta;
+  if (!stateDelta) return false;
+  const keys = Object.keys(stateDelta);
+  return (
+    keys.length > 0 &&
+    keys.every(
+      (key) =>
+        ['activityKind', 'displayName', 'intent'].includes(key) &&
+        typeof stateDelta[key] === 'string',
+    )
+  );
+}
+
+function matchesFunctionResponseActions(actions: RuntimeEvent['actions']): boolean {
+  if (!actions) return true;
+  if (!hasOnlyKeys(actions, ['stateDelta'])) return false;
+  const stateDelta = actions.stateDelta;
+  return (
+    stateDelta !== undefined &&
+    hasOnlyKeys(stateDelta, ['durationMs']) &&
+    typeof stateDelta.durationMs === 'number' &&
+    Number.isFinite(stateDelta.durationMs)
   );
 }
 
 function toolCallIdentity(invocationId: string, toolCallId: string): string {
-  return `${invocationId}\0${toolCallId}`;
+  return JSON.stringify([invocationId, toolCallId]);
 }

--- a/packages/core/src/tool-ledger-scanner.ts
+++ b/packages/core/src/tool-ledger-scanner.ts
@@ -20,6 +20,7 @@ export type ToolLedgerIssueCode =
   | 'orphan_dispatch'
   | 'orphan_response'
   | 'canonical_args_hash_conflict'
+  | 'invocation_identity_conflict'
   | 'identity_conflict'
   | 'event_order_conflict';
 
@@ -175,6 +176,7 @@ export function scanToolLedger(events: readonly RuntimeEvent[]): ToolLedgerScanR
   const seenEventIds = new Set<string>();
   const byToolCall = new Map<string, ToolLedgerScanOperation>();
   const byOperation = new Map<string, ToolLedgerScanOperation>();
+  const invocationSpines = new Map<string, string>();
 
   const addIssue = (operation: ToolLedgerScanOperation | undefined, issue: ToolLedgerIssue) => {
     issues.push(issue);
@@ -187,6 +189,16 @@ export function scanToolLedger(events: readonly RuntimeEvent[]): ToolLedgerScanR
       continue;
     }
     seenEventIds.add(event.id);
+    const spine = JSON.stringify([event.sessionId, event.runId, event.turnId]);
+    const existingSpine = invocationSpines.get(event.invocationId);
+    if (existingSpine !== undefined && existingSpine !== spine) {
+      addIssue(undefined, {
+        code: 'invocation_identity_conflict',
+        eventId: event.id,
+      });
+    } else {
+      invocationSpines.set(event.invocationId, spine);
+    }
     const lane = validateToolLedgerEventLane(event);
     if (!lane.ok) {
       addIssue(undefined, { code: lane.code, eventId: lane.eventId });

--- a/packages/core/src/tool-ledger-scanner.ts
+++ b/packages/core/src/tool-ledger-scanner.ts
@@ -1,0 +1,377 @@
+import type { RuntimeEvent } from './runtime-event.js';
+
+export type ToolLedgerLane =
+  | 'ordinary'
+  | 'function_call'
+  | 'tool_dispatch'
+  | 'function_response'
+  | 'reconcile_result'
+  | 'recovery_decision';
+
+export type ToolLedgerIssueCode =
+  | 'duplicate_event_id'
+  | 'semantic_lane_conflict'
+  | 'duplicate_call'
+  | 'duplicate_operation'
+  | 'duplicate_dispatch'
+  | 'duplicate_response'
+  | 'orphan_dispatch'
+  | 'orphan_response'
+  | 'identity_conflict'
+  | 'event_order_conflict';
+
+export interface ToolLedgerIssue {
+  code: ToolLedgerIssueCode;
+  eventId: string;
+  operationId?: string;
+  toolCallId?: string;
+}
+
+export interface ToolLedgerScanOperation {
+  toolCallId: string;
+  toolName?: string;
+  operationId?: string;
+  callEvent?: RuntimeEvent;
+  dispatchEvent?: RuntimeEvent;
+  responseEvent?: RuntimeEvent;
+  reconcileEvents: RuntimeEvent[];
+  decisionEvents: RuntimeEvent[];
+  issues: ToolLedgerIssue[];
+}
+
+export interface ToolLedgerScanResult {
+  operations: ToolLedgerScanOperation[];
+  issues: ToolLedgerIssue[];
+  hasCorruption: boolean;
+}
+
+export type ToolLedgerLaneValidation =
+  | { ok: true; lane: ToolLedgerLane }
+  | { ok: false; code: 'semantic_lane_conflict'; eventId: string };
+
+export type GenericToolLedgerAppendValidation =
+  | { ok: true }
+  | {
+      ok: false;
+      code: 'semantic_lane_conflict' | 'reserved_tool_boundary_fact' | 'reserved_recovery_fact';
+      eventId: string;
+    };
+
+/**
+ * Enforces the semantic boundary for durable tool-ledger facts.
+ *
+ * RuntimeEvent's structural schema intentionally permits content and actions
+ * to coexist. Tool persistence is narrower: call, dispatch, response and each
+ * recovery fact are distinct facts so one physical row cannot be interpreted
+ * differently by online projection, rebuild, and recovery.
+ */
+export function validateToolLedgerEventLane(event: RuntimeEvent): ToolLedgerLaneValidation {
+  const recoveryKind = event.actions?.toolRecovery?.kind;
+  const lanes = [
+    event.content?.kind === 'function_call' ? 'function_call' : undefined,
+    event.actions?.toolDispatch ? 'tool_dispatch' : undefined,
+    event.content?.kind === 'function_response' ? 'function_response' : undefined,
+    recoveryKind === 'maka.tool.reconcile_result' ? 'reconcile_result' : undefined,
+    recoveryKind === 'maka.tool.recovery_decision' ? 'recovery_decision' : undefined,
+  ].filter((lane): lane is Exclude<ToolLedgerLane, 'ordinary'> => lane !== undefined);
+
+  if (lanes.length === 0) return { ok: true, lane: 'ordinary' };
+  if (lanes.length !== 1 || !matchesLaneEnvelope(event, lanes[0])) {
+    return { ok: false, code: 'semantic_lane_conflict', eventId: event.id };
+  }
+  return { ok: true, lane: lanes[0] };
+}
+
+/**
+ * Generic RuntimeEvent append/import APIs may carry ordinary conversation
+ * events and unbound provider calls/responses. They are not an alternate
+ * authority for T1 dispatch, operation-bound T2 outcome, or recovery facts.
+ */
+export function validateGenericToolLedgerAppend(
+  event: RuntimeEvent,
+): GenericToolLedgerAppendValidation {
+  const lane = validateToolLedgerEventLane(event);
+  if (!lane.ok) return lane;
+  if (lane.lane === 'reconcile_result' || lane.lane === 'recovery_decision') {
+    return { ok: false, code: 'reserved_recovery_fact', eventId: event.id };
+  }
+  if (
+    lane.lane === 'tool_dispatch' ||
+    (lane.lane === 'function_response' && event.refs?.operationId !== undefined)
+  ) {
+    return { ok: false, code: 'reserved_tool_boundary_fact', eventId: event.id };
+  }
+  return { ok: true };
+}
+
+/**
+ * Scans immutable RuntimeEvents once, in physical ledger order. It owns the
+ * duplicate/order/identity interpretation shared by Resolver and projection
+ * rebuild; neither consumer may rebuild these maps independently.
+ */
+export function scanToolLedger(events: readonly RuntimeEvent[]): ToolLedgerScanResult {
+  const operations: ToolLedgerScanOperation[] = [];
+  const issues: ToolLedgerIssue[] = [];
+  const seenEventIds = new Set<string>();
+  const byToolCall = new Map<string, ToolLedgerScanOperation>();
+  const byOperation = new Map<string, ToolLedgerScanOperation>();
+
+  const addIssue = (operation: ToolLedgerScanOperation | undefined, issue: ToolLedgerIssue) => {
+    issues.push(issue);
+    operation?.issues.push(issue);
+  };
+
+  for (const event of events) {
+    if (seenEventIds.has(event.id)) {
+      addIssue(undefined, { code: 'duplicate_event_id', eventId: event.id });
+      continue;
+    }
+    seenEventIds.add(event.id);
+    if (event.partial) continue;
+
+    const lane = validateToolLedgerEventLane(event);
+    if (!lane.ok) {
+      addIssue(undefined, lane);
+      continue;
+    }
+
+    if (lane.lane === 'function_call') {
+      const content = event.content;
+      if (content?.kind !== 'function_call') continue;
+      const toolCallKey = toolCallIdentity(event.invocationId, content.id);
+      const existing = byToolCall.get(toolCallKey);
+      if (existing) {
+        if (!existing.callEvent) {
+          existing.callEvent = event;
+          if (existing.toolName !== content.name) {
+            addIssue(existing, {
+              code: 'identity_conflict',
+              eventId: event.id,
+              toolCallId: content.id,
+              ...(existing.operationId ? { operationId: existing.operationId } : {}),
+            });
+          }
+          continue;
+        }
+        addIssue(existing, {
+          code: 'duplicate_call',
+          eventId: event.id,
+          toolCallId: content.id,
+          ...(existing.operationId ? { operationId: existing.operationId } : {}),
+        });
+        continue;
+      }
+      const operation: ToolLedgerScanOperation = {
+        toolCallId: content.id,
+        toolName: content.name,
+        callEvent: event,
+        reconcileEvents: [],
+        decisionEvents: [],
+        issues: [],
+      };
+      byToolCall.set(toolCallKey, operation);
+      operations.push(operation);
+      continue;
+    }
+
+    if (lane.lane === 'tool_dispatch') {
+      const dispatch = event.actions?.toolDispatch;
+      if (!dispatch) continue;
+      const toolCallKey = toolCallIdentity(event.invocationId, dispatch.providerToolCallId);
+      let operation = byToolCall.get(toolCallKey);
+      if (!operation) {
+        operation = {
+          toolCallId: dispatch.providerToolCallId,
+          toolName: dispatch.toolName,
+          operationId: dispatch.operationId,
+          dispatchEvent: event,
+          reconcileEvents: [],
+          decisionEvents: [],
+          issues: [],
+        };
+        byToolCall.set(toolCallKey, operation);
+        operations.push(operation);
+        addIssue(operation, {
+          code: 'event_order_conflict',
+          eventId: event.id,
+          operationId: dispatch.operationId,
+          toolCallId: dispatch.providerToolCallId,
+        });
+      } else if (operation.dispatchEvent) {
+        addIssue(operation, {
+          code: 'duplicate_dispatch',
+          eventId: event.id,
+          operationId: dispatch.operationId,
+          toolCallId: dispatch.providerToolCallId,
+        });
+        continue;
+      }
+
+      const existingOperation = byOperation.get(dispatch.operationId);
+      if (existingOperation && existingOperation !== operation) {
+        const issue: ToolLedgerIssue = {
+          code: 'duplicate_operation',
+          eventId: event.id,
+          operationId: dispatch.operationId,
+          toolCallId: dispatch.providerToolCallId,
+        };
+        issues.push(issue);
+        existingOperation.issues.push(issue);
+        operation.issues.push(issue);
+        continue;
+      }
+
+      operation.operationId = dispatch.operationId;
+      operation.dispatchEvent = event;
+      byOperation.set(dispatch.operationId, operation);
+      if (
+        operation.toolName !== dispatch.toolName ||
+        event.refs?.operationId !== dispatch.operationId ||
+        event.refs?.toolCallId !== dispatch.providerToolCallId ||
+        (operation.callEvent !== undefined && !sameExecutionIdentity(operation.callEvent, event))
+      ) {
+        addIssue(operation, {
+          code: 'identity_conflict',
+          eventId: event.id,
+          operationId: dispatch.operationId,
+          toolCallId: dispatch.providerToolCallId,
+        });
+      }
+      continue;
+    }
+
+    if (lane.lane === 'function_response') {
+      const content = event.content;
+      if (content?.kind !== 'function_response') continue;
+      const toolCallKey = toolCallIdentity(event.invocationId, content.id);
+      const operation = byToolCall.get(toolCallKey);
+      if (!operation) {
+        const orphan: ToolLedgerScanOperation = {
+          toolCallId: content.id,
+          toolName: content.name,
+          responseEvent: event,
+          reconcileEvents: [],
+          decisionEvents: [],
+          issues: [],
+        };
+        operations.push(orphan);
+        byToolCall.set(toolCallKey, orphan);
+        addIssue(orphan, {
+          code: 'orphan_response',
+          eventId: event.id,
+          toolCallId: content.id,
+        });
+        continue;
+      }
+      if (operation.responseEvent) {
+        addIssue(operation, {
+          code: 'duplicate_response',
+          eventId: event.id,
+          toolCallId: content.id,
+          ...(operation.operationId ? { operationId: operation.operationId } : {}),
+        });
+        continue;
+      }
+      operation.responseEvent = event;
+      if (
+        operation.toolName !== content.name ||
+        !sameExecutionIdentity(operation.callEvent, event) ||
+        (operation.operationId !== undefined &&
+          (event.refs?.operationId !== operation.operationId ||
+            event.refs.toolCallId !== operation.toolCallId))
+      ) {
+        addIssue(operation, {
+          code: 'identity_conflict',
+          eventId: event.id,
+          toolCallId: content.id,
+          ...(operation.operationId ? { operationId: operation.operationId } : {}),
+        });
+      }
+      continue;
+    }
+
+    if (lane.lane === 'reconcile_result' || lane.lane === 'recovery_decision') {
+      const fact = event.actions?.toolRecovery;
+      if (!fact) continue;
+      const operation = byOperation.get(fact.payload.operationId);
+      if (!operation) {
+        addIssue(undefined, {
+          code: 'event_order_conflict',
+          eventId: event.id,
+          operationId: fact.payload.operationId,
+          ...(event.refs?.toolCallId ? { toolCallId: event.refs.toolCallId } : {}),
+        });
+        continue;
+      }
+      if (lane.lane === 'reconcile_result') operation.reconcileEvents.push(event);
+      else operation.decisionEvents.push(event);
+    }
+  }
+
+  return { operations, issues, hasCorruption: issues.length > 0 };
+}
+
+function matchesLaneEnvelope(
+  event: RuntimeEvent,
+  lane: Exclude<ToolLedgerLane, 'ordinary'>,
+): boolean {
+  if (event.partial || event.status !== undefined) return false;
+  switch (lane) {
+    case 'function_call':
+      return (
+        event.role === 'model' &&
+        event.author === 'agent' &&
+        hasNoAuthoritativeToolActions(event.actions)
+      );
+    case 'function_response':
+      return (
+        event.role === 'tool' &&
+        event.author === 'tool' &&
+        hasNoAuthoritativeToolActions(event.actions)
+      );
+    case 'tool_dispatch':
+      return (
+        event.content === undefined &&
+        event.role === 'system' &&
+        event.author === 'system' &&
+        hasOnlyKeys(event.actions, ['toolDispatch']) &&
+        hasOnlyKeys(event.refs, ['operationId', 'toolCallId'])
+      );
+    case 'reconcile_result':
+    case 'recovery_decision':
+      return (
+        event.content === undefined &&
+        event.role === 'system' &&
+        event.author === 'system' &&
+        hasOnlyKeys(event.actions, ['toolRecovery']) &&
+        hasOnlyKeys(event.refs, ['operationId', 'toolCallId'])
+      );
+  }
+}
+
+function sameExecutionIdentity(first: RuntimeEvent | undefined, second: RuntimeEvent): boolean {
+  return (
+    first !== undefined &&
+    first.sessionId === second.sessionId &&
+    first.invocationId === second.invocationId &&
+    first.runId === second.runId &&
+    first.turnId === second.turnId
+  );
+}
+
+function hasOnlyKeys(value: object | undefined, expected: readonly string[]): boolean {
+  if (!value) return false;
+  const keys = Object.keys(value);
+  return keys.length === expected.length && expected.every((key) => Object.hasOwn(value, key));
+}
+
+function hasNoAuthoritativeToolActions(actions: RuntimeEvent['actions']): boolean {
+  if (!actions) return true;
+  return Object.keys(actions).every((key) =>
+    ['stateDelta', 'artifactDelta', 'tokenUsage'].includes(key),
+  );
+}
+
+function toolCallIdentity(invocationId: string, toolCallId: string): string {
+  return `${invocationId}\0${toolCallId}`;
+}

--- a/packages/core/src/tool-recovery-bundle.ts
+++ b/packages/core/src/tool-recovery-bundle.ts
@@ -1,0 +1,402 @@
+import { canonicalToolArgsHash } from './tool-args-identity.js';
+import {
+  validateToolLedgerEventLane,
+  type ToolLedgerScanOperation,
+} from './tool-ledger-scanner.js';
+import type { RuntimeEvent } from './runtime-event.js';
+import {
+  isToolRecoveryFactEnvelope,
+  type ToolReconcileResultFact,
+  type ToolRecoveryDecisionFact,
+} from './tool-recovery-fact.js';
+
+export interface ToolRecoveryOperationIdentity {
+  operationId: string;
+  invocationId: string;
+  runId: string;
+  turnId: string;
+  providerToolCallId: string;
+  toolName: string;
+  canonicalArgsHash: string;
+  recoveryMode: NonNullable<NonNullable<RuntimeEvent['actions']>['toolDispatch']>['recoveryMode'];
+  callEventId: string;
+  dispatchEventId: string;
+}
+
+export interface ToolRecoveryEventBundle {
+  operation: ToolRecoveryOperationIdentity;
+  callEvent: RuntimeEvent;
+  dispatchEvent: RuntimeEvent;
+  reconcileEvent: RuntimeEvent;
+  outcomeEvent?: RuntimeEvent;
+  decisionEvent: RuntimeEvent;
+}
+
+export type ToolRecoveryBundleValidationCode =
+  | 'call_identity_conflict'
+  | 'canonical_args_hash_conflict'
+  | 'dispatch_identity_conflict'
+  | 'reconcile_fact_invalid'
+  | 'decision_fact_invalid'
+  | 'recovery_fact_identity_conflict'
+  | 'operation_identity_conflict'
+  | 'recovery_mode_unsupported'
+  | 'outcome_required'
+  | 'outcome_for_parked'
+  | 'outcome_identity_conflict'
+  | 'outcome_not_successful'
+  | 'outcome_reference_conflict'
+  | 'reconcile_decision_conflict'
+  | 'evidence_order_conflict';
+
+export type ToolRecoveryBundleValidationResult =
+  | { ok: true; reconcile: ToolReconcileResultFact; decision: ToolRecoveryDecisionFact }
+  | { ok: false; code: ToolRecoveryBundleValidationCode; message: string };
+
+export type ScannedToolRecoveryInterpretation =
+  | { kind: 'absent' }
+  | {
+      kind: 'valid';
+      reconcile: ToolReconcileResultFact;
+      decision: ToolRecoveryDecisionFact;
+      reconcileEvent: RuntimeEvent;
+      decisionEvent: RuntimeEvent;
+      outcomeEvent?: RuntimeEvent;
+    }
+  | {
+      kind: 'corruption';
+      code:
+        | ToolRecoveryBundleValidationCode
+        | 'recovery_fact_shape_conflict'
+        | 'event_order_conflict';
+      message: string;
+    };
+
+export class ToolRecoveryBundleValidationError extends Error {
+  readonly name = 'ToolRecoveryBundleValidationError';
+
+  constructor(
+    readonly code: ToolRecoveryBundleValidationCode,
+    message: string,
+  ) {
+    super(message);
+  }
+}
+
+export function validateToolRecoveryEventBundle(
+  input: ToolRecoveryEventBundle,
+): ToolRecoveryBundleValidationResult {
+  const { operation } = input;
+  const call = input.callEvent.content;
+  if (
+    input.callEvent.id !== operation.callEventId ||
+    call?.kind !== 'function_call' ||
+    call.id !== operation.providerToolCallId ||
+    call.name !== operation.toolName ||
+    validateToolLedgerEventLane(input.callEvent).ok !== true ||
+    !hasExecutionIdentity(input.callEvent, operation)
+  ) {
+    return invalid('call_identity_conflict', 'Recovery bundle call identity conflict');
+  }
+  let actualHash: string;
+  try {
+    actualHash = canonicalToolArgsHash(call.name, call.args);
+  } catch {
+    return invalid(
+      'canonical_args_hash_conflict',
+      'Recovery bundle argument hash does not match its canonical function call',
+    );
+  }
+  if (actualHash !== operation.canonicalArgsHash) {
+    return invalid(
+      'canonical_args_hash_conflict',
+      'Recovery bundle argument hash does not match its canonical function call',
+    );
+  }
+
+  const dispatch = input.dispatchEvent.actions?.toolDispatch;
+  if (
+    input.dispatchEvent.id !== operation.dispatchEventId ||
+    !dispatch ||
+    dispatch.operationId !== operation.operationId ||
+    dispatch.providerToolCallId !== operation.providerToolCallId ||
+    dispatch.toolName !== operation.toolName ||
+    dispatch.canonicalArgsHash !== operation.canonicalArgsHash ||
+    dispatch.recoveryMode !== operation.recoveryMode ||
+    validateToolLedgerEventLane(input.dispatchEvent).ok !== true ||
+    !hasExecutionIdentity(input.dispatchEvent, operation) ||
+    input.dispatchEvent.sessionId !== input.callEvent.sessionId ||
+    input.dispatchEvent.refs?.operationId !== operation.operationId ||
+    input.dispatchEvent.refs?.toolCallId !== operation.providerToolCallId
+  ) {
+    return invalid('dispatch_identity_conflict', 'Recovery bundle dispatch identity conflict');
+  }
+  if (operation.recoveryMode !== 'reconcile') {
+    return invalid('recovery_mode_unsupported', 'Recovery bundle requires reconcile recovery mode');
+  }
+
+  const reconcileEnvelope = input.reconcileEvent.actions?.toolRecovery;
+  if (
+    !isToolRecoveryFactEnvelope(reconcileEnvelope) ||
+    reconcileEnvelope.kind !== 'maka.tool.reconcile_result'
+  ) {
+    return invalid(
+      'reconcile_fact_invalid',
+      'Recovery bundle requires one canonical reconcile result fact',
+    );
+  }
+  const decisionEnvelope = input.decisionEvent.actions?.toolRecovery;
+  if (
+    !isToolRecoveryFactEnvelope(decisionEnvelope) ||
+    decisionEnvelope.kind !== 'maka.tool.recovery_decision'
+  ) {
+    return invalid(
+      'decision_fact_invalid',
+      'Recovery bundle requires one canonical recovery decision fact',
+    );
+  }
+  const reconcile = reconcileEnvelope.payload;
+  const decision = decisionEnvelope.payload;
+
+  if (
+    validateToolLedgerEventLane(input.reconcileEvent).ok !== true ||
+    validateToolLedgerEventLane(input.decisionEvent).ok !== true ||
+    !hasExecutionIdentity(input.reconcileEvent, operation) ||
+    !hasExecutionIdentity(input.decisionEvent, operation) ||
+    input.reconcileEvent.sessionId !== input.callEvent.sessionId ||
+    input.decisionEvent.sessionId !== input.callEvent.sessionId ||
+    input.reconcileEvent.refs?.operationId !== operation.operationId ||
+    input.reconcileEvent.refs?.toolCallId !== operation.providerToolCallId ||
+    input.decisionEvent.refs?.operationId !== operation.operationId ||
+    input.decisionEvent.refs?.toolCallId !== operation.providerToolCallId
+  ) {
+    return invalid('recovery_fact_identity_conflict', 'Recovery fact execution identity conflict');
+  }
+  if (
+    reconcile.operationId !== operation.operationId ||
+    decision.operationId !== operation.operationId
+  ) {
+    return invalid(
+      'operation_identity_conflict',
+      'Recovery bundle fact operation identity conflict',
+    );
+  }
+
+  const expectedEvidence = [
+    operation.callEventId,
+    operation.dispatchEventId,
+    input.reconcileEvent.id,
+  ];
+  if (decision.disposition === 'completed') {
+    if (!input.outcomeEvent) {
+      return invalid(
+        'outcome_required',
+        'Completed recovery decision requires a persisted outcome',
+      );
+    }
+    if (
+      input.outcomeEvent.sessionId !== input.callEvent.sessionId ||
+      validateToolLedgerEventLane(input.outcomeEvent).ok !== true ||
+      !isMatchingOutcome(input.outcomeEvent, operation)
+    ) {
+      return invalid(
+        'outcome_identity_conflict',
+        'Completed recovery outcome execution identity conflict',
+      );
+    }
+    if (
+      input.outcomeEvent.content?.kind === 'function_response' &&
+      input.outcomeEvent.content.isError
+    ) {
+      return invalid(
+        'outcome_not_successful',
+        'Completed recovery decision requires a successful synthesized outcome',
+      );
+    }
+    if (decision.outcomeEventId !== input.outcomeEvent.id) {
+      return invalid(
+        'outcome_reference_conflict',
+        'Completed recovery decision outcome reference conflict',
+      );
+    }
+    if (reconcile.observation !== 'matches_expected_state') {
+      return invalid(
+        'reconcile_decision_conflict',
+        'Completed recovery decision requires a matching expected-state observation',
+      );
+    }
+    expectedEvidence.push(input.outcomeEvent.id);
+  } else {
+    if (input.outcomeEvent) {
+      return invalid(
+        'outcome_for_parked',
+        'Parked recovery decision must not commit a provider outcome',
+      );
+    }
+    if (
+      reconcile.observation === 'matches_expected_state' ||
+      decision.reasonCode !== parkedReasonFor(reconcile.observation)
+    ) {
+      return invalid(
+        'reconcile_decision_conflict',
+        'Parked recovery decision does not match the reconcile result',
+      );
+    }
+  }
+
+  if (
+    decision.evidenceEventIds.length !== expectedEvidence.length ||
+    decision.evidenceEventIds.some((eventId, index) => eventId !== expectedEvidence[index])
+  ) {
+    return invalid(
+      'evidence_order_conflict',
+      'Recovery decision evidence does not match the canonical causal order',
+    );
+  }
+  return { ok: true, reconcile, decision };
+}
+
+export function assertToolRecoveryEventBundle(input: ToolRecoveryEventBundle): {
+  reconcile: ToolReconcileResultFact;
+  decision: ToolRecoveryDecisionFact;
+} {
+  const result = validateToolRecoveryEventBundle(input);
+  if (!result.ok) throw new ToolRecoveryBundleValidationError(result.code, result.message);
+  return { reconcile: result.reconcile, decision: result.decision };
+}
+
+/**
+ * Interprets the recovery tail of one scanner-owned operation. Resolver and
+ * projection rebuild must consume this result instead of independently
+ * assembling facts or defining their own causal-order rules.
+ */
+export function interpretScannedToolRecovery(
+  operation: ToolLedgerScanOperation,
+  eventOrder: ReadonlyMap<string, number>,
+): ScannedToolRecoveryInterpretation {
+  if (operation.reconcileEvents.length === 0 && operation.decisionEvents.length === 0) {
+    return { kind: 'absent' };
+  }
+  if (
+    operation.reconcileEvents.length !== 1 ||
+    operation.decisionEvents.length !== 1 ||
+    !operation.callEvent ||
+    !operation.dispatchEvent ||
+    !operation.operationId
+  ) {
+    return {
+      kind: 'corruption',
+      code: 'recovery_fact_shape_conflict',
+      message: 'Recovery requires exactly one reconcile fact and one terminal decision',
+    };
+  }
+  const dispatch = operation.dispatchEvent.actions?.toolDispatch;
+  if (!dispatch) {
+    return {
+      kind: 'corruption',
+      code: 'recovery_fact_shape_conflict',
+      message: 'Recovery requires one canonical dispatch fact',
+    };
+  }
+
+  const reconcileEvent = operation.reconcileEvents[0]!;
+  const decisionEvent = operation.decisionEvents[0]!;
+  const validation = validateToolRecoveryEventBundle({
+    operation: {
+      operationId: operation.operationId,
+      invocationId: operation.dispatchEvent.invocationId,
+      runId: operation.dispatchEvent.runId,
+      turnId: operation.dispatchEvent.turnId,
+      providerToolCallId: operation.toolCallId,
+      toolName: operation.toolName ?? dispatch.toolName,
+      canonicalArgsHash: dispatch.canonicalArgsHash,
+      recoveryMode: dispatch.recoveryMode,
+      callEventId: operation.callEvent.id,
+      dispatchEventId: operation.dispatchEvent.id,
+    },
+    callEvent: operation.callEvent,
+    dispatchEvent: operation.dispatchEvent,
+    reconcileEvent,
+    outcomeEvent: operation.responseEvent,
+    decisionEvent,
+  });
+  if (!validation.ok) {
+    return {
+      kind: 'corruption',
+      code: validation.code,
+      message: validation.message,
+    };
+  }
+  const facts = [
+    operation.callEvent,
+    operation.dispatchEvent,
+    reconcileEvent,
+    ...(operation.responseEvent ? [operation.responseEvent] : []),
+    decisionEvent,
+  ];
+  const positions = facts.map((event) => eventOrder.get(event.id));
+  if (
+    !positions.every(
+      (position, index) =>
+        position !== undefined && (index === 0 || position > (positions[index - 1] ?? -1)),
+    )
+  ) {
+    return {
+      kind: 'corruption',
+      code: 'event_order_conflict',
+      message: 'Recovery facts violate canonical RuntimeEvent causal order',
+    };
+  }
+  return {
+    kind: 'valid',
+    reconcile: validation.reconcile,
+    decision: validation.decision,
+    reconcileEvent,
+    decisionEvent,
+    ...(operation.responseEvent ? { outcomeEvent: operation.responseEvent } : {}),
+  };
+}
+
+function hasExecutionIdentity(
+  event: RuntimeEvent,
+  operation: ToolRecoveryOperationIdentity,
+): boolean {
+  return (
+    !event.partial &&
+    event.invocationId === operation.invocationId &&
+    event.runId === operation.runId &&
+    event.turnId === operation.turnId
+  );
+}
+
+function isMatchingOutcome(event: RuntimeEvent, operation: ToolRecoveryOperationIdentity): boolean {
+  const content = event.content;
+  return (
+    hasExecutionIdentity(event, operation) &&
+    content?.kind === 'function_response' &&
+    content.id === operation.providerToolCallId &&
+    content.name === operation.toolName &&
+    event.refs?.operationId === operation.operationId &&
+    event.refs?.toolCallId === operation.providerToolCallId
+  );
+}
+
+function invalid(
+  code: ToolRecoveryBundleValidationCode,
+  message: string,
+): ToolRecoveryBundleValidationResult {
+  return { ok: false, code, message };
+}
+
+function parkedReasonFor(
+  observation: Exclude<ToolReconcileResultFact['observation'], 'matches_expected_state'>,
+): 'reconcile_matches_prior_state' | 'reconcile_diverged' | 'reconcile_unreadable' {
+  switch (observation) {
+    case 'matches_prior_state':
+      return 'reconcile_matches_prior_state';
+    case 'diverged':
+      return 'reconcile_diverged';
+    case 'unreadable':
+      return 'reconcile_unreadable';
+  }
+}

--- a/packages/core/src/tool-recovery-fact.ts
+++ b/packages/core/src/tool-recovery-fact.ts
@@ -1,0 +1,163 @@
+export const TOOL_RECONCILE_RESULT_FACT_KIND = 'maka.tool.reconcile_result' as const;
+export const TOOL_RECOVERY_DECISION_FACT_KIND = 'maka.tool.recovery_decision' as const;
+export const TOOL_RECOVERY_FACT_VERSION = 1 as const;
+
+export type ToolReconcileObservation =
+  | 'matches_expected_state'
+  | 'matches_prior_state'
+  | 'diverged'
+  | 'unreadable';
+
+export interface ToolReconcileResultFact {
+  protocol: 'tool_reconcile_v1';
+  operationId: string;
+  observation: ToolReconcileObservation;
+  observationSchema: 'state_identity_v1';
+  observationDigest: `sha256:${string}`;
+}
+
+export type ToolRecoveryParkReason =
+  | 'reconcile_matches_prior_state'
+  | 'reconcile_diverged'
+  | 'reconcile_unreadable';
+
+export interface ToolRecoveryCompletedDecisionFact {
+  protocol: 'tool_recovery_v1';
+  operationId: string;
+  disposition: 'completed';
+  reasonCode: 'reconcile_matches_expected_state';
+  outcomeEventId: string;
+  evidenceEventIds: string[];
+}
+
+export interface ToolRecoveryParkedDecisionFact {
+  protocol: 'tool_recovery_v1';
+  operationId: string;
+  disposition: 'parked';
+  reasonCode: ToolRecoveryParkReason;
+  evidenceEventIds: string[];
+}
+
+export type ToolRecoveryDecisionFact =
+  | ToolRecoveryCompletedDecisionFact
+  | ToolRecoveryParkedDecisionFact;
+
+export type ToolRecoveryFactEnvelope =
+  | {
+      kind: typeof TOOL_RECONCILE_RESULT_FACT_KIND;
+      version: typeof TOOL_RECOVERY_FACT_VERSION;
+      payload: ToolReconcileResultFact;
+    }
+  | {
+      kind: typeof TOOL_RECOVERY_DECISION_FACT_KIND;
+      version: typeof TOOL_RECOVERY_FACT_VERSION;
+      payload: ToolRecoveryDecisionFact;
+    };
+
+const PARK_REASONS = new Set<ToolRecoveryParkReason>([
+  'reconcile_matches_prior_state',
+  'reconcile_diverged',
+  'reconcile_unreadable',
+]);
+
+export function isToolRecoveryFactEnvelope(value: unknown): value is ToolRecoveryFactEnvelope {
+  if (!hasExactKeys(value, ['kind', 'version', 'payload'])) return false;
+  if (value.version !== TOOL_RECOVERY_FACT_VERSION) return false;
+  if (value.kind === TOOL_RECONCILE_RESULT_FACT_KIND) {
+    return isToolReconcileResultFact(value.payload);
+  }
+  if (value.kind === TOOL_RECOVERY_DECISION_FACT_KIND) {
+    return isToolRecoveryDecisionFact(value.payload);
+  }
+  return false;
+}
+
+export function isToolReconcileResultFact(value: unknown): value is ToolReconcileResultFact {
+  if (
+    !hasExactKeys(value, [
+      'protocol',
+      'operationId',
+      'observation',
+      'observationSchema',
+      'observationDigest',
+    ])
+  ) {
+    return false;
+  }
+  return (
+    value.protocol === 'tool_reconcile_v1' &&
+    isNonEmptyString(value.operationId) &&
+    value.observationSchema === 'state_identity_v1' &&
+    isSha256Digest(value.observationDigest) &&
+    ['matches_expected_state', 'matches_prior_state', 'diverged', 'unreadable'].includes(
+      String(value.observation),
+    )
+  );
+}
+
+export function isToolRecoveryDecisionFact(value: unknown): value is ToolRecoveryDecisionFact {
+  if (
+    !isRecord(value) ||
+    value.protocol !== 'tool_recovery_v1' ||
+    !isNonEmptyString(value.operationId) ||
+    !isDistinctNonEmptyStringArray(value.evidenceEventIds)
+  ) {
+    return false;
+  }
+  if (value.disposition === 'completed') {
+    return (
+      hasExactKeys(value, [
+        'protocol',
+        'operationId',
+        'disposition',
+        'reasonCode',
+        'outcomeEventId',
+        'evidenceEventIds',
+      ]) &&
+      value.reasonCode === 'reconcile_matches_expected_state' &&
+      isNonEmptyString(value.outcomeEventId)
+    );
+  }
+  return (
+    value.disposition === 'parked' &&
+    hasExactKeys(value, [
+      'protocol',
+      'operationId',
+      'disposition',
+      'reasonCode',
+      'evidenceEventIds',
+    ]) &&
+    typeof value.reasonCode === 'string' &&
+    PARK_REASONS.has(value.reasonCode as ToolRecoveryParkReason)
+  );
+}
+
+function hasExactKeys(
+  value: unknown,
+  required: readonly string[],
+): value is Record<string, unknown> {
+  if (!isRecord(value)) return false;
+  const keys = Object.keys(value);
+  return keys.length === required.length && required.every((key) => Object.hasOwn(value, key));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0;
+}
+
+function isSha256Digest(value: unknown): value is `sha256:${string}` {
+  return typeof value === 'string' && /^sha256:[0-9a-f]{64}$/.test(value);
+}
+
+function isDistinctNonEmptyStringArray(value: unknown): value is string[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every(isNonEmptyString) &&
+    new Set(value).size === value.length
+  );
+}

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -83,6 +83,15 @@ class ReportingBackend implements AgentBackend {
     });
     yield { type: 'text_complete', id: 'report-text', turnId, ts, messageId, text: 'done' };
     yield {
+      type: 'tool_start',
+      id: 'report-tool-start',
+      turnId,
+      ts,
+      toolUseId: 'tool-1',
+      toolName: 'bash',
+      args: { command: 'printf artifact' },
+    };
+    yield {
       type: 'tool_result',
       id: 'report-artifact',
       turnId,

--- a/packages/runtime/src/__tests__/recovery-authority-equivalence.test.ts
+++ b/packages/runtime/src/__tests__/recovery-authority-equivalence.test.ts
@@ -6,6 +6,7 @@ import { describe, it } from 'node:test';
 import { canonicalToolArgsHash, type RuntimeEvent } from '@maka/core';
 import { createSqliteRuntimeStore } from '@maka/storage';
 import { resolveRuntimeRecovery } from '../recovery-resolver.js';
+import { buildResumePlanFromRuntimeEvents } from '../runtime-resume.js';
 
 const ARGS_HASH = canonicalToolArgsHash('Write', {
   path: 'notes.txt',
@@ -77,6 +78,91 @@ describe('recovery authority equivalence', () => {
     }
   });
 
+  it('keeps prepared, normal T2, and parked states equivalent across reopen and rebuild', async () => {
+    const cases = [
+      {
+        name: 'prepared',
+        expectedProjection: 'prepared',
+        expectedDecision: 'indeterminate',
+      },
+      {
+        name: 'normal-success',
+        expectedProjection: 'outcome_committed',
+        expectedDecision: 'completed',
+        outcomeIsError: false,
+      },
+      {
+        name: 'normal-error',
+        expectedProjection: 'outcome_committed',
+        expectedDecision: 'completed',
+        outcomeIsError: true,
+      },
+      {
+        name: 'parked',
+        expectedProjection: 'recovery_parked',
+        expectedDecision: 'parked',
+        parked: true,
+      },
+    ] as const;
+
+    for (const scenario of cases) {
+      const root = await mkdtemp(join(tmpdir(), `maka-recovery-${scenario.name}-`));
+      const dbPath = join(root, 'runtime.sqlite');
+      const store = createSqliteRuntimeStore(dbPath);
+      try {
+        await store.commitToolPrepared({
+          operationId: 'operation-1',
+          journalEventId: 'operation-1_prepared',
+          runtimeEvent: callEvent(),
+          dispatchRuntimeEvent: dispatchEvent(),
+          providerToolCallId: 'provider-call-1',
+          toolName: 'Write',
+          canonicalArgsHash: ARGS_HASH,
+          recoveryMode: 'reconcile',
+          committedAt: 10,
+        });
+        if ('outcomeIsError' in scenario) {
+          await store.commitToolOutcome({
+            operationId: 'operation-1',
+            journalEventId: 'operation-1_outcome',
+            runtimeEvent: outcomeEvent(scenario.outcomeIsError),
+            committedAt: 20,
+          });
+        } else if ('parked' in scenario) {
+          await store.commitToolRecoveryBundle({
+            operationId: 'operation-1',
+            reconcileRuntimeEvent: reconcileEvent('diverged'),
+            decisionRuntimeEvent: parkedDecisionEvent(),
+          });
+        }
+
+        const immutable = await store.readImmutableRuntimeEvents('session-1', 'run-1');
+        const online = await store.readToolOperation('operation-1');
+        const resolution = resolveRuntimeRecovery(immutable);
+        assert.equal(online?.currentState, scenario.expectedProjection, scenario.name);
+        assert.equal(resolution.decisions[0]?.status, scenario.expectedDecision, scenario.name);
+
+        store.close();
+        const reopened = createSqliteRuntimeStore(dbPath);
+        try {
+          assert.deepEqual(await reopened.readToolOperation('operation-1'), online, scenario.name);
+          await reopened.rebuildToolProjectionsFromRuntimeEvents();
+          assert.deepEqual(await reopened.readToolOperation('operation-1'), online, scenario.name);
+          assert.deepEqual(
+            resolveRuntimeRecovery(await reopened.readImmutableRuntimeEvents('session-1', 'run-1')),
+            resolution,
+            scenario.name,
+          );
+        } finally {
+          reopened.close();
+        }
+      } finally {
+        store.close();
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+
   it('preserves duplicate event identity and semantic-lane diagnostics', () => {
     const duplicate = callEvent();
     const invalid = outcomeEvent();
@@ -93,12 +179,13 @@ describe('recovery authority equivalence', () => {
   });
 
   it('treats a valid parked recovery bundle as terminal', () => {
-    const resolution = resolveRuntimeRecovery([
+    const events = [
       callEvent(),
       dispatchEvent(),
       reconcileEvent('diverged'),
       parkedDecisionEvent(),
-    ]);
+    ];
+    const resolution = resolveRuntimeRecovery(events);
 
     assert.deepEqual(resolution.decisions, [
       {
@@ -114,6 +201,39 @@ describe('recovery authority equivalence', () => {
     ]);
     assert.equal(resolution.hasCorruption, false);
     assert.equal(resolution.requiresReconciliation, false);
+
+    const plan = buildResumePlanFromRuntimeEvents(events);
+    assert.equal(plan.disposition, 'blocked');
+    assert.equal(plan.requiresVerification, false);
+    assert.deepEqual(plan.rejectionReasons, ['dangling_tool_state']);
+    assert.deepEqual(
+      plan.diagnostics.map((diagnostic) => diagnostic.code),
+      ['tool_recovery_parked'],
+    );
+  });
+
+  it('blocks resume whenever the recovery ledger contains top-level corruption', () => {
+    const orphanReconcile = reconcileEvent();
+    orphanReconcile.id = 'orphan-reconcile-event';
+    orphanReconcile.actions!.toolRecovery!.payload.operationId = 'unknown-operation';
+    orphanReconcile.refs = {
+      operationId: 'unknown-operation',
+      toolCallId: 'unknown-provider-call',
+    };
+    const events = [callEvent(), outcomeEvent(), orphanReconcile];
+
+    const resolution = resolveRuntimeRecovery(events);
+    assert.equal(resolution.hasCorruption, true);
+    assert.equal(resolution.decisions[0]?.status, 'completed');
+
+    const plan = buildResumePlanFromRuntimeEvents(events);
+    assert.equal(plan.disposition, 'blocked');
+    assert.deepEqual(plan.rejectionReasons, ['dangling_tool_state']);
+    assert.deepEqual(
+      plan.diagnostics.map((diagnostic) => diagnostic.code),
+      ['tool_ledger_corruption'],
+    );
+    assert.equal(plan.diagnostics[0]?.detail?.issueCode, 'event_order_conflict');
   });
 });
 
@@ -211,7 +331,7 @@ function parkedDecisionEvent(): RuntimeEvent {
   });
 }
 
-function outcomeEvent(): RuntimeEvent {
+function outcomeEvent(isError = false): RuntimeEvent {
   return baseEvent({
     id: 'outcome-event-1',
     ts: 3,
@@ -221,8 +341,8 @@ function outcomeEvent(): RuntimeEvent {
       kind: 'function_response',
       id: 'provider-call-1',
       name: 'Write',
-      result: 'ok',
-      isError: false,
+      result: isError ? 'failed' : 'ok',
+      isError,
     },
     refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
   });

--- a/packages/runtime/src/__tests__/recovery-authority-equivalence.test.ts
+++ b/packages/runtime/src/__tests__/recovery-authority-equivalence.test.ts
@@ -1,0 +1,256 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { canonicalToolArgsHash, type RuntimeEvent } from '@maka/core';
+import { createSqliteRuntimeStore } from '@maka/storage';
+import { resolveRuntimeRecovery } from '../recovery-resolver.js';
+
+const ARGS_HASH = canonicalToolArgsHash('Write', {
+  path: 'notes.txt',
+  content: 'after',
+});
+const OBSERVATION_DIGEST =
+  'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
+
+describe('recovery authority equivalence', () => {
+  it('gives online projection, reopen, rebuild, and Resolver one terminal interpretation', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-recovery-equivalence-'));
+    const dbPath = join(root, 'runtime.sqlite');
+    const store = createSqliteRuntimeStore(dbPath);
+    try {
+      await store.commitToolPrepared({
+        operationId: 'operation-1',
+        journalEventId: 'operation-1_prepared',
+        runtimeEvent: callEvent(),
+        dispatchRuntimeEvent: dispatchEvent(),
+        providerToolCallId: 'provider-call-1',
+        toolName: 'Write',
+        canonicalArgsHash: ARGS_HASH,
+        recoveryMode: 'reconcile',
+        committedAt: 10,
+      });
+      await store.commitToolRecoveryBundle({
+        operationId: 'operation-1',
+        reconcileRuntimeEvent: reconcileEvent(),
+        outcomeRuntimeEvent: outcomeEvent(),
+        decisionRuntimeEvent: decisionEvent(),
+      });
+
+      const immutable = await store.readImmutableRuntimeEvents('session-1', 'run-1');
+      const online = await store.readToolOperation('operation-1');
+      const resolution = resolveRuntimeRecovery(immutable);
+      assert.equal(online?.currentState, 'recovery_completed');
+      assert.deepEqual(resolution.decisions, [
+        {
+          toolCallId: 'provider-call-1',
+          toolName: 'Write',
+          operationId: 'operation-1',
+          status: 'completed',
+          reason: 'recovery_bundle_completed',
+          settlementOrigin: 'recovery_bundle',
+          callRuntimeEventId: 'call-event-1',
+          dispatchRuntimeEventId: 'dispatch-event-1',
+          responseRuntimeEventId: 'outcome-event-1',
+          responseIsError: false,
+        },
+      ]);
+      assert.equal(resolution.requiresReconciliation, false);
+
+      store.close();
+      const reopened = createSqliteRuntimeStore(dbPath);
+      try {
+        assert.deepEqual(await reopened.readToolOperation('operation-1'), online);
+        await reopened.rebuildToolProjectionsFromRuntimeEvents();
+        assert.deepEqual(await reopened.readToolOperation('operation-1'), online);
+        assert.deepEqual(
+          resolveRuntimeRecovery(await reopened.readImmutableRuntimeEvents('session-1', 'run-1')),
+          resolution,
+        );
+      } finally {
+        reopened.close();
+      }
+    } finally {
+      store.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('preserves duplicate event identity and semantic-lane diagnostics', () => {
+    const duplicate = callEvent();
+    const invalid = outcomeEvent();
+    invalid.actions = dispatchEvent().actions;
+
+    const resolution = resolveRuntimeRecovery([callEvent(), duplicate, invalid]);
+
+    assert.deepEqual(
+      resolution.issues.map(({ code }) => code),
+      ['duplicate_event_id', 'semantic_lane_conflict'],
+    );
+    assert.equal(resolution.hasCorruption, true);
+    assert.equal(resolution.requiresReconciliation, false);
+  });
+
+  it('treats a valid parked recovery bundle as terminal', () => {
+    const resolution = resolveRuntimeRecovery([
+      callEvent(),
+      dispatchEvent(),
+      reconcileEvent('diverged'),
+      parkedDecisionEvent(),
+    ]);
+
+    assert.deepEqual(resolution.decisions, [
+      {
+        toolCallId: 'provider-call-1',
+        toolName: 'Write',
+        operationId: 'operation-1',
+        status: 'parked',
+        reason: 'reconcile_diverged',
+        settlementOrigin: 'recovery_bundle',
+        callRuntimeEventId: 'call-event-1',
+        dispatchRuntimeEventId: 'dispatch-event-1',
+      },
+    ]);
+    assert.equal(resolution.hasCorruption, false);
+    assert.equal(resolution.requiresReconciliation, false);
+  });
+});
+
+function baseEvent(overrides: Partial<RuntimeEvent>): RuntimeEvent {
+  return {
+    id: 'event-1',
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}
+
+function callEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'call-event-1',
+    role: 'model',
+    author: 'agent',
+    content: {
+      kind: 'function_call',
+      id: 'provider-call-1',
+      name: 'Write',
+      args: { path: 'notes.txt', content: 'after' },
+    },
+  });
+}
+
+function dispatchEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'dispatch-event-1',
+    actions: {
+      toolDispatch: {
+        protocol: 't1_after_preflight_v1',
+        operationId: 'operation-1',
+        providerToolCallId: 'provider-call-1',
+        toolName: 'Write',
+        canonicalArgsHash: ARGS_HASH,
+        recoveryMode: 'reconcile',
+      },
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  });
+}
+
+function reconcileEvent(
+  observation:
+    | 'matches_expected_state'
+    | 'matches_prior_state'
+    | 'diverged'
+    | 'unreadable' = 'matches_expected_state',
+): RuntimeEvent {
+  return baseEvent({
+    id: 'reconcile-event-1',
+    ts: 2,
+    actions: {
+      toolRecovery: {
+        kind: 'maka.tool.reconcile_result',
+        version: 1,
+        payload: {
+          protocol: 'tool_reconcile_v1',
+          operationId: 'operation-1',
+          observation,
+          observationSchema: 'state_identity_v1',
+          observationDigest: OBSERVATION_DIGEST,
+        },
+      },
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  });
+}
+
+function parkedDecisionEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'decision-event-1',
+    ts: 4,
+    actions: {
+      toolRecovery: {
+        kind: 'maka.tool.recovery_decision',
+        version: 1,
+        payload: {
+          protocol: 'tool_recovery_v1',
+          operationId: 'operation-1',
+          disposition: 'parked',
+          reasonCode: 'reconcile_diverged',
+          evidenceEventIds: ['call-event-1', 'dispatch-event-1', 'reconcile-event-1'],
+        },
+      },
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  });
+}
+
+function outcomeEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'outcome-event-1',
+    ts: 3,
+    role: 'tool',
+    author: 'tool',
+    content: {
+      kind: 'function_response',
+      id: 'provider-call-1',
+      name: 'Write',
+      result: 'ok',
+      isError: false,
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  });
+}
+
+function decisionEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'decision-event-1',
+    ts: 4,
+    actions: {
+      toolRecovery: {
+        kind: 'maka.tool.recovery_decision',
+        version: 1,
+        payload: {
+          protocol: 'tool_recovery_v1',
+          operationId: 'operation-1',
+          disposition: 'completed',
+          reasonCode: 'reconcile_matches_expected_state',
+          outcomeEventId: 'outcome-event-1',
+          evidenceEventIds: [
+            'call-event-1',
+            'dispatch-event-1',
+            'reconcile-event-1',
+            'outcome-event-1',
+          ],
+        },
+      },
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  });
+}

--- a/packages/runtime/src/__tests__/recovery-resolver.test.ts
+++ b/packages/runtime/src/__tests__/recovery-resolver.test.ts
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
+import { canonicalToolArgsHash } from '@maka/core';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import { resolveRuntimeRecovery } from '../recovery-resolver.js';
 
@@ -257,7 +258,7 @@ function toolDispatchEvent(overrides: { toolName?: string } = {}): RuntimeEvent 
         operationId: 'operation-1',
         providerToolCallId: 'call-1',
         toolName: overrides.toolName ?? 'Bash',
-        canonicalArgsHash: 'args-hash-1',
+        canonicalArgsHash: canonicalToolArgsHash('Bash', { command: 'do-it' }),
         recoveryMode: 'never_auto_retry',
       },
     },

--- a/packages/runtime/src/__tests__/recovery-resolver.test.ts
+++ b/packages/runtime/src/__tests__/recovery-resolver.test.ts
@@ -61,6 +61,7 @@ describe('RecoveryResolver', () => {
         callRuntimeEventId: 'function-call-1',
         responseRuntimeEventId: 'function-response-1',
         responseIsError: true,
+        settlementOrigin: 'pre_t1_synthetic',
       },
     ]);
     assert.equal(resolution.requiresReconciliation, false);
@@ -210,7 +211,7 @@ describe('RecoveryResolver', () => {
     assert.equal(resolution.decisions[0]?.status, 'indeterminate');
     assert.equal(resolution.decisions[0]?.reason, 'legacy_dispatch_unknown');
     assert.equal(resolution.hasCorruption, true);
-    assert.equal(resolution.requiresReconciliation, true);
+    assert.equal(resolution.requiresReconciliation, false);
   });
 
   it('classifies a response linked to a different operation as corruption', () => {

--- a/packages/runtime/src/__tests__/runtime-commit-sink.test.ts
+++ b/packages/runtime/src/__tests__/runtime-commit-sink.test.ts
@@ -22,6 +22,19 @@ describe('RuntimeCommitSink identities', () => {
     assert.match(first, /^toolop_[a-f0-9]{32}$/);
   });
 
+  it('keeps tuple identity unambiguous when provider strings contain NUL', () => {
+    assert.notEqual(
+      buildToolOperationId({
+        invocationId: 'a\0b',
+        providerToolCallId: 'c',
+      }),
+      buildToolOperationId({
+        invocationId: 'a',
+        providerToolCallId: 'b\0c',
+      }),
+    );
+  });
+
   it('hashes stable-json tool identity while preserving semantic argument differences', () => {
     assert.equal(
       canonicalToolArgsHash('Read', { path: '/workspace/a', offset: 1 }),

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -893,6 +893,56 @@ describe('projectRuntimeEventsToStoredMessages', () => {
     expect(out.diagnostics).toEqual([]);
   });
 
+  test('terminal recovery bundle facts are accepted without creating legacy message rows', () => {
+    const out = projectRuntimeEventsToStoredMessages(
+      [
+        ev({
+          id: 'toolop-1-reconcile',
+          role: 'system',
+          author: 'system',
+          actions: {
+            toolRecovery: {
+              kind: 'maka.tool.reconcile_result',
+              version: 1,
+              payload: {
+                protocol: 'tool_reconcile_v1',
+                operationId: 'toolop-1',
+                observation: 'unreadable',
+                observationSchema: 'state_identity_v1',
+                observationDigest:
+                  'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+              },
+            },
+          },
+          refs: { toolCallId: 'tool-1', operationId: 'toolop-1' },
+        }),
+        ev({
+          id: 'toolop-1-decision',
+          role: 'system',
+          author: 'system',
+          actions: {
+            toolRecovery: {
+              kind: 'maka.tool.recovery_decision',
+              version: 1,
+              payload: {
+                protocol: 'tool_recovery_v1',
+                operationId: 'toolop-1',
+                disposition: 'parked',
+                reasonCode: 'reconcile_unreadable',
+                evidenceEventIds: ['call-1', 'dispatch-1', 'toolop-1-reconcile'],
+              },
+            },
+          },
+          refs: { toolCallId: 'tool-1', operationId: 'toolop-1' },
+        }),
+      ],
+      { runHeaders: [header] },
+    );
+
+    expect(out.messages).toEqual([]);
+    expect(out.diagnostics).toEqual([]);
+  });
+
   test('continuation-start recovery facts are accepted without creating legacy message rows', () => {
     const out = projectRuntimeEventsToStoredMessages(
       [

--- a/packages/runtime/src/__tests__/runtime-resume.test.ts
+++ b/packages/runtime/src/__tests__/runtime-resume.test.ts
@@ -456,7 +456,7 @@ describe('runtime resume phase 1 safe-boundary continuation', () => {
       ],
       safeBoundaryFacts(),
     );
-    assert.deepEqual(mixed.rejectionReasons, ['runtime_identity_mismatch']);
+    assert.deepEqual(mixed.rejectionReasons, ['dangling_tool_state', 'runtime_identity_mismatch']);
 
     const reused = buildSafeBoundaryContinuationPlan([textEvent('user-1', 'user', 'continue')], {
       ...safeBoundaryFacts(),

--- a/packages/runtime/src/__tests__/runtime-resume.test.ts
+++ b/packages/runtime/src/__tests__/runtime-resume.test.ts
@@ -113,7 +113,7 @@ describe('runtime resume phase 0 projection', () => {
     assert.deepEqual(plan.rejectionReasons, ['dangling_tool_state']);
     assert.deepEqual(
       plan.diagnostics.map((diagnostic) => diagnostic.code),
-      ['unmatched_tool_result'],
+      ['tool_ledger_corruption', 'unmatched_tool_result'],
     );
     assert.deepEqual(
       buildResumeReplayRuntimeEvents(plan.runtimeEvents).map((event) => event.id),

--- a/packages/runtime/src/__tests__/tool-runtime-sqlite-boundary.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-sqlite-boundary.test.ts
@@ -85,10 +85,16 @@ describe('ToolRuntime with real SQLite boundary', () => {
         (event) => event.type === 'tool_start' || event.type === 'tool_result',
       );
       assert.equal(durableEvents.length, 2);
-      for (const event of durableEvents) {
-        const mapped = mapSessionEventToRuntimeEvent(event, context, memory);
-        await store.appendRuntimeEvent('session-1', 'run-1', mapped);
-      }
+      const mappedEvents = durableEvents.map((event) =>
+        mapSessionEventToRuntimeEvent(event, context, memory),
+      );
+      assert.deepEqual(
+        mappedEvents,
+        events.filter(
+          (event) =>
+            event.content?.kind === 'function_call' || event.content?.kind === 'function_response',
+        ),
+      );
 
       assert.equal((await store.readRuntimeEvents('session-1', 'run-1')).length, 3);
       assert.equal((await store.readImmutableRuntimeEvents('session-1', 'run-1')).length, 3);
@@ -145,16 +151,17 @@ describe('ToolRuntime with real SQLite boundary', () => {
       });
 
       const memory = createSessionEventMapMemory();
-      for (const event of published.filter(
-        (item) => item.type === 'tool_start' || item.type === 'tool_result',
-      )) {
-        await store.appendRuntimeEvent(
-          'session-1',
-          'run-1',
-          mapSessionEventToRuntimeEvent(event, invocationContext(), memory),
-        );
-      }
+      const mappedEvents = published
+        .filter((item) => item.type === 'tool_start' || item.type === 'tool_result')
+        .map((event) => mapSessionEventToRuntimeEvent(event, invocationContext(), memory));
       const events = await store.readRuntimeEvents('session-1', 'run-1');
+      assert.deepEqual(
+        mappedEvents,
+        events.filter(
+          (event) =>
+            event.content?.kind === 'function_call' || event.content?.kind === 'function_response',
+        ),
+      );
       assert.equal(events.length, 3);
       assert.equal(events[2]?.content?.kind, 'function_response');
       assert.equal(

--- a/packages/runtime/src/recovery-resolver.ts
+++ b/packages/runtime/src/recovery-resolver.ts
@@ -3,24 +3,41 @@ import {
   type RuntimeEvent,
   type ToolBoundaryProtocol,
 } from '@maka/core/runtime-event';
+import {
+  scanToolLedger,
+  type ToolLedgerIssueCode,
+  type ToolLedgerScanOperation,
+} from '@maka/core/tool-ledger-scanner';
+import { interpretScannedToolRecovery } from '@maka/core/tool-recovery-bundle';
 
 export type ToolRecoveryDecisionStatus =
   | 'completed'
+  | 'parked'
   | 'definitely_not_dispatched'
   | 'indeterminate'
   | 'corruption';
 
 export type ToolRecoveryDecisionReason =
   | 'matching_response'
+  | 'recovery_bundle_completed'
   | 'dispatch_without_response'
   | 'new_protocol_before_dispatch'
   | 'legacy_dispatch_unknown'
   | 'orphan_dispatch'
   | 'orphan_response'
+  | 'duplicate_call'
+  | 'duplicate_operation'
   | 'duplicate_dispatch'
   | 'duplicate_response'
   | 'identity_conflict'
-  | 'protocol_marker_invalid';
+  | 'event_order_conflict'
+  | 'protocol_marker_invalid'
+  | 'recovery_fact_corruption'
+  | 'reconcile_matches_prior_state'
+  | 'reconcile_diverged'
+  | 'reconcile_unreadable';
+
+export type ToolSettlementOrigin = 'normal_t2' | 'pre_t1_synthetic' | 'recovery_bundle';
 
 export interface ToolRecoveryDecision {
   toolCallId: string;
@@ -28,17 +45,20 @@ export interface ToolRecoveryDecision {
   operationId?: string;
   status: ToolRecoveryDecisionStatus;
   reason: ToolRecoveryDecisionReason;
+  settlementOrigin?: ToolSettlementOrigin;
   callRuntimeEventId?: string;
   dispatchRuntimeEventId?: string;
   responseRuntimeEventId?: string;
   responseIsError?: boolean;
 }
 
+export type RuntimeRecoveryIssueCode = 'protocol_marker_invalid' | ToolLedgerIssueCode;
+
 export interface RuntimeRecoveryResolution {
   toolBoundaryProtocol?: ToolBoundaryProtocol;
   decisions: ToolRecoveryDecision[];
   issues: Array<{
-    code: 'protocol_marker_invalid';
+    code: RuntimeRecoveryIssueCode;
     eventId: string;
   }>;
   hasCorruption: boolean;
@@ -53,10 +73,7 @@ export function resolveRuntimeRecovery(events: readonly RuntimeEvent[]): Runtime
       : undefined;
   const issues: RuntimeRecoveryResolution['issues'] = [];
   if (firstProtocol !== undefined && toolBoundaryProtocol === undefined && events[0]) {
-    issues.push({
-      code: 'protocol_marker_invalid' as const,
-      eventId: events[0].id,
-    });
+    issues.push({ code: 'protocol_marker_invalid', eventId: events[0].id });
   }
   issues.push(
     ...events
@@ -64,95 +81,112 @@ export function resolveRuntimeRecovery(events: readonly RuntimeEvent[]): Runtime
       .filter((event) => event.actions?.runtimeProtocol !== undefined)
       .map((event) => ({ code: 'protocol_marker_invalid' as const, eventId: event.id })),
   );
-  const decisions: ToolRecoveryDecision[] = [];
-  const decisionsByToolCallId = new Map<string, ToolRecoveryDecision>();
-  for (const event of events) {
-    if (event.partial || event.content?.kind !== 'function_call') continue;
-    const decision: ToolRecoveryDecision = {
-      toolCallId: event.content.id,
-      toolName: event.content.name,
-      status: toolBoundaryProtocol ? 'definitely_not_dispatched' : 'indeterminate',
-      reason: toolBoundaryProtocol ? 'new_protocol_before_dispatch' : 'legacy_dispatch_unknown',
-      callRuntimeEventId: event.id,
-    };
-    decisions.push(decision);
-    decisionsByToolCallId.set(decision.toolCallId, decision);
-  }
-  for (const event of events) {
-    if (event.partial) continue;
-    const dispatch = event.actions?.toolDispatch;
-    if (!dispatch) continue;
-    const decision = decisionsByToolCallId.get(dispatch.providerToolCallId);
-    if (!decision) {
-      decisions.push({
-        toolCallId: dispatch.providerToolCallId,
-        toolName: dispatch.toolName,
-        operationId: dispatch.operationId,
-        status: 'corruption',
-        reason: 'orphan_dispatch',
-        dispatchRuntimeEventId: event.id,
-      });
-      continue;
-    }
-    if (decision.dispatchRuntimeEventId !== undefined) {
-      decision.status = 'corruption';
-      decision.reason = 'duplicate_dispatch';
-      continue;
-    }
-    decision.operationId = dispatch.operationId;
-    decision.dispatchRuntimeEventId = event.id;
-    if (
-      decision.toolName !== dispatch.toolName ||
-      event.refs?.operationId !== dispatch.operationId ||
-      event.refs?.toolCallId !== dispatch.providerToolCallId
-    ) {
-      decision.status = 'corruption';
-      decision.reason = 'identity_conflict';
-      continue;
-    }
-    decision.status = 'indeterminate';
-    decision.reason = 'dispatch_without_response';
-  }
-  for (const event of events) {
-    if (event.partial || event.content?.kind !== 'function_response') continue;
-    const decision = decisionsByToolCallId.get(event.content.id);
-    if (!decision) {
-      decisions.push({
-        toolCallId: event.content.id,
-        toolName: event.content.name,
-        status: 'corruption',
-        reason: 'orphan_response',
-        responseRuntimeEventId: event.id,
-        responseIsError: event.content.isError === true,
-      });
-      continue;
-    }
-    if (decision.responseRuntimeEventId !== undefined) {
-      decision.status = 'corruption';
-      decision.reason = 'duplicate_response';
-      continue;
-    }
-    decision.responseRuntimeEventId = event.id;
-    decision.responseIsError = event.content.isError === true;
-    if (decision.status === 'corruption') continue;
-    if (
-      decision.toolName !== event.content.name ||
-      (decision.operationId !== undefined && event.refs?.operationId !== decision.operationId) ||
-      (event.refs?.toolCallId !== undefined && event.refs.toolCallId !== decision.toolCallId)
-    ) {
-      decision.status = 'corruption';
-      decision.reason = 'identity_conflict';
-      continue;
-    }
-    decision.status = 'completed';
-    decision.reason = 'matching_response';
-  }
+
+  const scan = scanToolLedger(events);
+  issues.push(...scan.issues.map(({ code, eventId }) => ({ code, eventId })));
+  const eventOrder = new Map(events.map((event, index) => [event.id, index] as const));
+  const decisions = scan.operations.map((operation) =>
+    decisionFromOperation(operation, toolBoundaryProtocol, eventOrder),
+  );
+
+  const hasCorruption =
+    issues.length > 0 || decisions.some((decision) => decision.status === 'corruption');
   return {
     ...(toolBoundaryProtocol ? { toolBoundaryProtocol } : {}),
     decisions,
     issues,
-    hasCorruption:
-      issues.length > 0 || decisions.some((decision) => decision.status === 'corruption'),
-    requiresReconciliation: decisions.some((decision) => decision.status === 'indeterminate'),
+    hasCorruption,
+    requiresReconciliation:
+      !hasCorruption && decisions.some((decision) => decision.status === 'indeterminate'),
   };
+}
+
+function decisionFromOperation(
+  operation: ToolLedgerScanOperation,
+  toolBoundaryProtocol: ToolBoundaryProtocol | undefined,
+  eventOrder: ReadonlyMap<string, number>,
+): ToolRecoveryDecision {
+  const decision: ToolRecoveryDecision = {
+    toolCallId: operation.toolCallId,
+    ...(operation.toolName ? { toolName: operation.toolName } : {}),
+    ...(operation.operationId ? { operationId: operation.operationId } : {}),
+    status: toolBoundaryProtocol ? 'definitely_not_dispatched' : 'indeterminate',
+    reason: toolBoundaryProtocol ? 'new_protocol_before_dispatch' : 'legacy_dispatch_unknown',
+    ...(operation.callEvent ? { callRuntimeEventId: operation.callEvent.id } : {}),
+    ...(operation.dispatchEvent ? { dispatchRuntimeEventId: operation.dispatchEvent.id } : {}),
+    ...(operation.responseEvent
+      ? {
+          responseRuntimeEventId: operation.responseEvent.id,
+          responseIsError:
+            operation.responseEvent.content?.kind === 'function_response'
+              ? operation.responseEvent.content.isError === true
+              : false,
+        }
+      : {}),
+  };
+
+  if (!operation.callEvent && operation.dispatchEvent) {
+    decision.status = 'corruption';
+    decision.reason = 'orphan_dispatch';
+    return decision;
+  }
+  if (!operation.callEvent && operation.responseEvent) {
+    decision.status = 'corruption';
+    decision.reason = 'orphan_response';
+    return decision;
+  }
+  const corruption = operationCorruptionReason(operation);
+  if (corruption) {
+    decision.status = 'corruption';
+    decision.reason = corruption;
+    return decision;
+  }
+
+  if (operation.responseEvent) {
+    decision.status = 'completed';
+    decision.reason = 'matching_response';
+    decision.settlementOrigin = operation.dispatchEvent ? 'normal_t2' : 'pre_t1_synthetic';
+  } else if (operation.dispatchEvent) {
+    decision.status = 'indeterminate';
+    decision.reason = 'dispatch_without_response';
+  }
+
+  if (operation.reconcileEvents.length === 0 && operation.decisionEvents.length === 0) {
+    return decision;
+  }
+  const recovery = interpretScannedToolRecovery(operation, eventOrder);
+  if (recovery.kind !== 'valid') {
+    decision.status = 'corruption';
+    decision.reason = 'recovery_fact_corruption';
+    delete decision.settlementOrigin;
+    return decision;
+  }
+
+  decision.settlementOrigin = 'recovery_bundle';
+  if (recovery.decision.disposition === 'completed') {
+    decision.status = 'completed';
+    decision.reason = 'recovery_bundle_completed';
+  } else {
+    decision.status = 'parked';
+    decision.reason = recovery.decision.reasonCode;
+  }
+  return decision;
+}
+
+function operationCorruptionReason(
+  operation: ToolLedgerScanOperation,
+): ToolRecoveryDecisionReason | undefined {
+  const priority: Array<[ToolLedgerIssueCode, ToolRecoveryDecisionReason]> = [
+    ['duplicate_call', 'duplicate_call'],
+    ['duplicate_operation', 'duplicate_operation'],
+    ['duplicate_dispatch', 'duplicate_dispatch'],
+    ['duplicate_response', 'duplicate_response'],
+    ['orphan_response', 'orphan_response'],
+    ['identity_conflict', 'identity_conflict'],
+    ['event_order_conflict', 'event_order_conflict'],
+  ];
+  for (const [code, reason] of priority) {
+    if (operation.issues.some((issue) => issue.code === code)) return reason;
+  }
+  return undefined;
 }

--- a/packages/runtime/src/recovery-resolver.ts
+++ b/packages/runtime/src/recovery-resolver.ts
@@ -29,6 +29,7 @@ export type ToolRecoveryDecisionReason =
   | 'duplicate_operation'
   | 'duplicate_dispatch'
   | 'duplicate_response'
+  | 'canonical_args_hash_conflict'
   | 'identity_conflict'
   | 'event_order_conflict'
   | 'protocol_marker_invalid'
@@ -182,6 +183,7 @@ function operationCorruptionReason(
     ['duplicate_dispatch', 'duplicate_dispatch'],
     ['duplicate_response', 'duplicate_response'],
     ['orphan_response', 'orphan_response'],
+    ['canonical_args_hash_conflict', 'canonical_args_hash_conflict'],
     ['identity_conflict', 'identity_conflict'],
     ['event_order_conflict', 'event_order_conflict'],
   ];

--- a/packages/runtime/src/runtime-commit-sink.ts
+++ b/packages/runtime/src/runtime-commit-sink.ts
@@ -1,6 +1,9 @@
 import { createHash } from 'node:crypto';
-import type { RuntimeEvent, ToolRecoveryMode } from '@maka/core';
-import { stableHash } from './request-shape.js';
+import {
+  canonicalToolArgsHash as canonicalToolArgsHashCore,
+  type RuntimeEvent,
+  type ToolRecoveryMode,
+} from '@maka/core';
 
 export type { ToolRecoveryMode } from '@maka/core';
 
@@ -54,6 +57,5 @@ export function buildToolOperationId(input: ToolOperationIdInput): string {
 }
 
 export function canonicalToolArgsHash(toolName: string, normalizedArgs: unknown): string {
-  if (!toolName) throw new Error('Tool argument identity requires a tool name');
-  return stableHash({ toolName, args: normalizedArgs });
+  return canonicalToolArgsHashCore(toolName, normalizedArgs);
 }

--- a/packages/runtime/src/runtime-commit-sink.ts
+++ b/packages/runtime/src/runtime-commit-sink.ts
@@ -48,9 +48,7 @@ export function buildToolOperationId(input: ToolOperationIdInput): string {
     throw new Error('Tool operation identity requires invocationId and providerToolCallId');
   }
   const digest = createHash('sha256')
-    .update(input.invocationId)
-    .update('\0')
-    .update(input.providerToolCallId)
+    .update(JSON.stringify([input.invocationId, input.providerToolCallId]))
     .digest('hex')
     .slice(0, 32);
   return `toolop_${digest}`;

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -206,6 +206,12 @@ export function projectRuntimeEventsToStoredMessages(
       projected = true;
     }
 
+    if (event.actions?.toolRecovery) {
+      // Recovery observations and decisions are canonical audit facts. The
+      // matching function_call/function_response own any provider-visible row.
+      projected = true;
+    }
+
     if (event.actions?.stateDelta?.continuationStart === true) {
       // Continuation start is a canonical lineage/recovery fact with no
       // legacy chat row. Its following model events own the visible output.

--- a/packages/runtime/src/runtime-resume.ts
+++ b/packages/runtime/src/runtime-resume.ts
@@ -13,6 +13,7 @@ export type ToolOperationStatus =
   | 'failed'
   | 'indeterminate'
   | 'not_dispatched'
+  | 'parked'
   | 'corruption';
 
 export interface ToolOperation {
@@ -79,6 +80,8 @@ export type ResumePlanDiagnosticCode =
   | 'resume_candidate_missing'
   | 'tool_not_dispatched'
   | 'tool_recovery_corruption'
+  | 'duplicate_event_id'
+  | 'semantic_lane_conflict'
   | 'protocol_marker_invalid';
 
 export type ResumeRejectionReason =
@@ -843,11 +846,25 @@ function collectResumeDiagnostics(
   }
 
   for (const issue of recovery.issues) {
-    diagnostics.push({
-      code: 'protocol_marker_invalid',
-      message: 'runtime protocol marker is only valid on the first canonical event',
-      eventId: issue.eventId,
-    });
+    if (issue.code === 'protocol_marker_invalid') {
+      diagnostics.push({
+        code: issue.code,
+        message: 'runtime protocol marker is only valid on the first canonical event',
+        eventId: issue.eventId,
+      });
+    } else if (issue.code === 'duplicate_event_id') {
+      diagnostics.push({
+        code: issue.code,
+        message: 'immutable RuntimeEvent identity is duplicated',
+        eventId: issue.eventId,
+      });
+    } else if (issue.code === 'semantic_lane_conflict') {
+      diagnostics.push({
+        code: issue.code,
+        message: 'RuntimeEvent claims more than one authoritative tool semantic lane',
+        eventId: issue.eventId,
+      });
+    }
   }
 
   for (const decision of recovery.decisions) {
@@ -911,6 +928,8 @@ function deriveRejectionReasons(
       case 'pending_tool_result':
       case 'tool_not_dispatched':
       case 'tool_recovery_corruption':
+      case 'duplicate_event_id':
+      case 'semantic_lane_conflict':
       case 'protocol_marker_invalid':
       case 'unmatched_tool_result':
       case 'tool_name_mismatch':

--- a/packages/runtime/src/runtime-resume.ts
+++ b/packages/runtime/src/runtime-resume.ts
@@ -79,7 +79,9 @@ export type ResumePlanDiagnosticCode =
   | 'resume_feature_disabled'
   | 'resume_candidate_missing'
   | 'tool_not_dispatched'
+  | 'tool_recovery_parked'
   | 'tool_recovery_corruption'
+  | 'tool_ledger_corruption'
   | 'duplicate_event_id'
   | 'semantic_lane_conflict'
   | 'protocol_marker_invalid';
@@ -516,7 +518,9 @@ export function buildResumePlanFromRuntimeEvents(
   const rejectionReasons = deriveRejectionReasons(diagnostics);
   const requiresVerification = operations.some((operation) => operation.status === 'indeterminate');
   const disposition: ResumePlanDisposition =
-    rejectionReasons.length === 0 && !requiresVerification ? 'safe_replay' : 'blocked';
+    rejectionReasons.length === 0 && !requiresVerification && !recovery.hasCorruption
+      ? 'safe_replay'
+      : 'blocked';
 
   return {
     disposition,
@@ -842,6 +846,14 @@ function collectResumeDiagnostics(
         toolCallId: operation.toolCallId,
         toolName: operation.toolName,
       });
+    } else if (operation.status === 'parked') {
+      diagnostics.push({
+        code: 'tool_recovery_parked',
+        message: 'tool recovery reached a terminal parked decision',
+        eventId: operation.callRuntimeEventId,
+        toolCallId: operation.toolCallId,
+        toolName: operation.toolName,
+      });
     }
   }
 
@@ -863,6 +875,13 @@ function collectResumeDiagnostics(
         code: issue.code,
         message: 'RuntimeEvent claims more than one authoritative tool semantic lane',
         eventId: issue.eventId,
+      });
+    } else {
+      diagnostics.push({
+        code: 'tool_ledger_corruption',
+        message: `immutable tool ledger is corrupt: ${issue.code}`,
+        eventId: issue.eventId,
+        detail: { issueCode: issue.code },
       });
     }
   }
@@ -927,7 +946,9 @@ function deriveRejectionReasons(
         break;
       case 'pending_tool_result':
       case 'tool_not_dispatched':
+      case 'tool_recovery_parked':
       case 'tool_recovery_corruption':
+      case 'tool_ledger_corruption':
       case 'duplicate_event_id':
       case 'semantic_lane_conflict':
       case 'protocol_marker_invalid':

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -2780,7 +2780,7 @@ function isAmbiguousComputerFailure(raw: unknown): boolean {
 }
 
 function durableAttemptKey(turnId: string, toolUseId: string): string {
-  return `${turnId}\0${toolUseId}`;
+  return JSON.stringify([turnId, toolUseId]);
 }
 
 function providerToolErrorMessage(output: unknown): string | undefined {

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -718,6 +718,25 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('re-establishes stable storage on an exact durable RuntimeEvent retry', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      const event = makeRuntimeEvent({ id: 'ordinary-event-1' });
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', event);
+
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', event, {
+        durable: true,
+      });
+
+      assert.deepEqual(
+        (await runtimeEventStore.readImmutableRuntimeEvents('session-1', 'run-1')).map(
+          (item) => item.id,
+        ),
+        ['ordinary-event-1'],
+      );
+    });
+  });
+
   it('keeps an exact tool call retry idempotent in JSONL', async () => {
     await withStores(async (runStore, runtimeEventStore) => {
       await runStore.createRun(makeHeader());
@@ -1129,6 +1148,55 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('cleans a retained partial snapshot on an exact final-event retry', async () => {
+    await withStores(async (runStore, runtimeEventStore, root) => {
+      await runStore.createRun(makeHeader());
+      const partial = makeRuntimeEvent({
+        id: 'runtime-partial',
+        partial: true,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'hello' },
+        refs: { providerEventId: 'message-1' },
+      });
+      const final = makeRuntimeEvent({
+        id: 'runtime-final',
+        ts: 2,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'hello world' },
+        refs: { providerEventId: 'message-1' },
+      });
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', partial);
+      const partialsDirectory = join(
+        root,
+        'sessions',
+        'session-1',
+        'runs',
+        'run-1',
+        'runtime-partials',
+      );
+      const [partialFilename] = await readdir(partialsDirectory);
+      assert.ok(partialFilename);
+      const partialPath = join(partialsDirectory, partialFilename);
+      const retainedSnapshot = await readFile(partialPath);
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', final);
+
+      // Simulate a crash after the immutable append but before replaceable
+      // partial cleanup, then drive recovery through the public exact retry.
+      await writeFile(partialPath, retainedSnapshot);
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', final);
+
+      assert.deepEqual(await readdir(partialsDirectory), []);
+      assert.deepEqual(
+        (await runtimeEventStore.readImmutableRuntimeEvents('session-1', 'run-1')).map(
+          (event) => event.id,
+        ),
+        ['runtime-final'],
+      );
+    });
+  });
+
   it('produces equivalent durable replay for differently chunked final output', async () => {
     const replayFor = async (chunks: readonly string[]) => {
       let replay: RuntimeEvent[] = [];
@@ -1339,6 +1407,41 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('rejects a terminal event whose identity does not match the target run', async () => {
+    for (const mismatch of [
+      { sessionId: 'other-session' },
+      { runId: 'other-run' },
+      { turnId: 'other-turn' },
+      { invocationId: 'other-invocation' },
+    ] satisfies Array<Partial<RuntimeEvent>>) {
+      await withStores(async (runStore, runtimeEventStore, root) => {
+        await runStore.createRun(makeHeader({ invocationId: 'turn-1' }));
+        const terminal = makeRuntimeEvent({
+          id: 'runtime-terminal',
+          role: 'system',
+          author: 'system',
+          status: 'completed',
+          content: undefined,
+          actions: { endInvocation: true },
+          ...mismatch,
+        });
+
+        await assert.rejects(
+          runtimeEventStore.ensureTerminalRuntimeEventDurable('session-1', 'run-1', terminal),
+          /RuntimeEvent identity does not match its run/,
+        );
+        const ledger = await readFile(
+          join(root, 'sessions', 'session-1', 'runs', 'run-1', 'runtime-events.jsonl'),
+          'utf8',
+        ).catch((error) => {
+          if ((error as NodeJS.ErrnoException).code === 'ENOENT') return '';
+          throw error;
+        });
+        assert.equal(ledger, '');
+      });
+    }
+  });
+
   it('rejects complete schema-invalid and path-mismatched runtime events', async () => {
     await withStores(async (runStore, runtimeEventStore, root) => {
       await runStore.createRun(makeHeader({ invocationId: 'turn-1' }));
@@ -1456,8 +1559,11 @@ describe('AgentRunStore', () => {
         join(root, 'sessions', 'session-1', 'message-proofs', 'steering', 'message-steering.json'),
       );
       const reopened = createRuntimeEventStore(root);
-      await reopened.repairImmutableSteeringMessageProofsForRecovery('session-1');
       await reopened.appendRuntimeEvent('session-1', 'run-1', steering);
+      assert.deepEqual(
+        await reopened.readImmutableSteeringMessageProof('session-1', 'message-steering'),
+        { event: steering },
+      );
 
       const conflicting = makeRuntimeEvent({
         ...steering,
@@ -1484,7 +1590,9 @@ describe('AgentRunStore', () => {
     });
   });
 
-  it('reports a durable canonical steering event when proof publication fails', async () => {
+  it('reports a durable canonical steering event when proof publication fails', {
+    skip: process.platform === 'win32',
+  }, async () => {
     await withStores(async (runStore, runtimeEventStore, root) => {
       await runStore.createRun(makeHeader());
       const steering = makeRuntimeEvent({

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -634,6 +634,73 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('keeps authoritative tool facts out of the JSONL generic writer', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      const dispatch = makeRuntimeEvent({
+        id: 'dispatch-reserved',
+        role: 'system',
+        author: 'system',
+        content: undefined,
+        actions: {
+          toolDispatch: {
+            protocol: 't1_after_preflight_v1',
+            operationId: 'operation-1',
+            providerToolCallId: 'call-1',
+            toolName: 'Write',
+            canonicalArgsHash: 'sha256:reserved',
+            recoveryMode: 'reconcile',
+          },
+        },
+        refs: { operationId: 'operation-1', toolCallId: 'call-1' },
+      });
+      const outcome = makeRuntimeEvent({
+        id: 'outcome-reserved',
+        role: 'tool',
+        author: 'tool',
+        content: {
+          kind: 'function_response',
+          id: 'call-1',
+          name: 'Write',
+          result: 'ok',
+        },
+        refs: { operationId: 'operation-1', toolCallId: 'call-1' },
+      });
+      const recovery = makeRuntimeEvent({
+        id: 'recovery-reserved',
+        role: 'system',
+        author: 'system',
+        content: undefined,
+        actions: {
+          toolRecovery: {
+            kind: 'maka.tool.reconcile_result',
+            version: 1,
+            payload: {
+              protocol: 'tool_reconcile_v1',
+              operationId: 'operation-1',
+              observation: 'unreadable',
+              observationSchema: 'state_identity_v1',
+              observationDigest:
+                'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+            },
+          },
+        },
+        refs: { operationId: 'operation-1', toolCallId: 'call-1' },
+      });
+
+      for (const event of [dispatch, outcome, recovery]) {
+        await assert.rejects(
+          runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', event),
+          /atomic tool|atomic recovery/,
+        );
+      }
+      assert.deepEqual(
+        await runtimeEventStore.readImmutableRuntimeEvents('session-1', 'run-1'),
+        [],
+      );
+    });
+  });
+
   it('returns an empty runtime event list when the runtime ledger is missing', async () => {
     await withStores(async (runStore, runtimeEventStore) => {
       await runStore.createRun(makeHeader());

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -701,6 +701,38 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('rejects a duplicate provider call identity in the JSONL ledger', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      const call = makeRuntimeEvent({
+        id: 'call-event-1',
+        role: 'model',
+        author: 'agent',
+        content: {
+          kind: 'function_call',
+          id: 'provider-call-1',
+          name: 'Write',
+          args: { path: 'notes.txt', content: 'after' },
+        },
+      });
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', call);
+
+      await assert.rejects(
+        runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', {
+          ...call,
+          id: 'call-event-duplicate',
+        }),
+        /duplicate_call/,
+      );
+      assert.deepEqual(
+        (await runtimeEventStore.readImmutableRuntimeEvents('session-1', 'run-1')).map(
+          ({ id }) => id,
+        ),
+        ['call-event-1'],
+      );
+    });
+  });
+
   it('returns an empty runtime event list when the runtime ledger is missing', async () => {
     await withStores(async (runStore, runtimeEventStore) => {
       await runStore.createRun(makeHeader());
@@ -879,6 +911,22 @@ describe('AgentRunStore', () => {
   it('coalesces tool stream heartbeats until the durable tool result arrives', async () => {
     await withStores(async (runStore, runtimeEventStore) => {
       await runStore.createRun(makeHeader());
+      await runtimeEventStore.appendRuntimeEvent(
+        'session-1',
+        'run-1',
+        makeRuntimeEvent({
+          id: 'runtime-tool-call',
+          role: 'model',
+          author: 'agent',
+          content: {
+            kind: 'function_call',
+            id: 'tool-call-1',
+            name: 'Bash',
+            args: { command: 'echo done' },
+          },
+          refs: { toolCallId: 'tool-call-1' },
+        }),
+      );
       for (let index = 0; index < 100; index += 1) {
         await runtimeEventStore.appendRuntimeEvent(
           'session-1',
@@ -894,7 +942,7 @@ describe('AgentRunStore', () => {
         );
       }
 
-      assert.equal((await runtimeEventStore.readRuntimeEvents('session-1', 'run-1')).length, 1);
+      assert.equal((await runtimeEventStore.readRuntimeEvents('session-1', 'run-1')).length, 2);
 
       await runtimeEventStore.appendRuntimeEvent(
         'session-1',
@@ -917,7 +965,7 @@ describe('AgentRunStore', () => {
       const events = await runtimeEventStore.readRuntimeEvents('session-1', 'run-1');
       assert.deepEqual(
         events.map((event) => event.id),
-        ['runtime-tool-result'],
+        ['runtime-tool-call', 'runtime-tool-result'],
       );
     });
   });

--- a/packages/storage/src/__tests__/agent-run-store.test.ts
+++ b/packages/storage/src/__tests__/agent-run-store.test.ts
@@ -701,6 +701,92 @@ describe('AgentRunStore', () => {
     });
   });
 
+  it('keeps an exact ordinary RuntimeEvent retry idempotent in JSONL', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      const event = makeRuntimeEvent({ id: 'ordinary-event-1' });
+
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', event);
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', event);
+
+      assert.deepEqual(
+        (await runtimeEventStore.readImmutableRuntimeEvents('session-1', 'run-1')).map(
+          (item) => item.id,
+        ),
+        ['ordinary-event-1'],
+      );
+    });
+  });
+
+  it('keeps an exact tool call retry idempotent in JSONL', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      const call = makeRuntimeEvent({
+        id: 'call-event-1',
+        role: 'model',
+        author: 'agent',
+        content: {
+          kind: 'function_call',
+          id: 'provider-call-1',
+          name: 'Write',
+          args: { path: 'note.txt', content: 'hello' },
+        },
+        refs: { toolCallId: 'provider-call-1' },
+      });
+
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', call);
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', call);
+
+      assert.deepEqual(
+        (await runtimeEventStore.readImmutableRuntimeEvents('session-1', 'run-1')).map(
+          (item) => item.id,
+        ),
+        ['call-event-1'],
+      );
+    });
+  });
+
+  it('rejects a conflicting RuntimeEvent retry without changing JSONL', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader());
+      const original = makeRuntimeEvent({ id: 'ordinary-event-1' });
+      await runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', original);
+
+      await assert.rejects(
+        runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', {
+          ...original,
+          ts: original.ts + 1,
+        }),
+        /RuntimeEvent identity conflict/,
+      );
+      assert.deepEqual(await runtimeEventStore.readImmutableRuntimeEvents('session-1', 'run-1'), [
+        original,
+      ]);
+    });
+  });
+
+  it('rejects a RuntimeEvent whose identity does not match the target run header', async () => {
+    await withStores(async (runStore, runtimeEventStore) => {
+      await runStore.createRun(makeHeader({ invocationId: 'turn-1' }));
+
+      for (const event of [
+        makeRuntimeEvent({ sessionId: 'other-session' }),
+        makeRuntimeEvent({ runId: 'other-run' }),
+        makeRuntimeEvent({ turnId: 'other-turn' }),
+        makeRuntimeEvent({ invocationId: 'other-invocation' }),
+      ]) {
+        await assert.rejects(
+          runtimeEventStore.appendRuntimeEvent('session-1', 'run-1', event),
+          /RuntimeEvent identity does not match its run/,
+        );
+      }
+      assert.deepEqual(
+        await runtimeEventStore.readImmutableRuntimeEvents('session-1', 'run-1'),
+        [],
+      );
+    });
+  });
+
   it('rejects a duplicate provider call identity in the JSONL ledger', async () => {
     await withStores(async (runStore, runtimeEventStore) => {
       await runStore.createRun(makeHeader());

--- a/packages/storage/src/__tests__/fixtures/sqlite-recovery-concurrency-child.ts
+++ b/packages/storage/src/__tests__/fixtures/sqlite-recovery-concurrency-child.ts
@@ -1,0 +1,150 @@
+import { existsSync, writeSync } from 'node:fs';
+import type { RuntimeEvent, ToolRecoveryFactEnvelope } from '@maka/core';
+import { createSqliteRuntimeStore } from '../../sqlite-runtime-store.js';
+
+const mode = requiredEnv('MAKA_SQLITE_RECOVERY_CONCURRENCY_MODE');
+const dbPath = requiredEnv('MAKA_SQLITE_RECOVERY_CONCURRENCY_DB');
+const startPath = requiredEnv('MAKA_SQLITE_RECOVERY_CONCURRENCY_START');
+const store = createSqliteRuntimeStore(dbPath);
+
+writeSync(1, 'READY\n');
+while (!existsSync(startPath)) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+}
+
+try {
+  if (mode === 'completed') {
+    await store.commitToolRecoveryBundle(completedBundle());
+  } else if (mode === 'parked') {
+    await store.commitToolRecoveryBundle(parkedBundle());
+  } else if (mode === 'rebuild') {
+    await store.rebuildToolProjectionsFromRuntimeEvents();
+  } else {
+    throw new Error(`Unknown concurrency mode ${mode}`);
+  }
+  writeSync(1, 'RESULT ok\n');
+} catch (error) {
+  writeSync(2, `RESULT error ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exitCode = 2;
+} finally {
+  store.close();
+}
+
+function completedBundle() {
+  return {
+    operationId: 'operation-1',
+    reconcileRuntimeEvent: recoveryFact(
+      'completed-reconcile',
+      'maka.tool.reconcile_result',
+      {
+        protocol: 'tool_reconcile_v1',
+        operationId: 'operation-1',
+        observation: 'matches_expected_state',
+        observationSchema: 'state_identity_v1',
+        observationDigest:
+          'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+      3,
+    ),
+    outcomeRuntimeEvent: outcomeEvent(),
+    decisionRuntimeEvent: recoveryFact(
+      'completed-decision',
+      'maka.tool.recovery_decision',
+      {
+        protocol: 'tool_recovery_v1',
+        operationId: 'operation-1',
+        disposition: 'completed',
+        reasonCode: 'reconcile_matches_expected_state',
+        outcomeEventId: 'completed-outcome',
+        evidenceEventIds: [
+          'call-event-1',
+          'dispatch-event-1',
+          'completed-reconcile',
+          'completed-outcome',
+        ],
+      },
+      5,
+    ),
+  } as const;
+}
+
+function parkedBundle() {
+  return {
+    operationId: 'operation-1',
+    reconcileRuntimeEvent: recoveryFact(
+      'parked-reconcile',
+      'maka.tool.reconcile_result',
+      {
+        protocol: 'tool_reconcile_v1',
+        operationId: 'operation-1',
+        observation: 'diverged',
+        observationSchema: 'state_identity_v1',
+        observationDigest:
+          'sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb',
+      },
+      3,
+    ),
+    decisionRuntimeEvent: recoveryFact(
+      'parked-decision',
+      'maka.tool.recovery_decision',
+      {
+        protocol: 'tool_recovery_v1',
+        operationId: 'operation-1',
+        disposition: 'parked',
+        reasonCode: 'reconcile_diverged',
+        evidenceEventIds: ['call-event-1', 'dispatch-event-1', 'parked-reconcile'],
+      },
+      4,
+    ),
+  } as const;
+}
+
+function outcomeEvent(): RuntimeEvent {
+  return {
+    ...baseEvent('completed-outcome', 4),
+    role: 'tool',
+    author: 'tool',
+    content: {
+      kind: 'function_response',
+      id: 'provider-call-1',
+      name: 'Write',
+      result: 'ok',
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  };
+}
+
+function recoveryFact(
+  id: string,
+  kind: 'maka.tool.reconcile_result' | 'maka.tool.recovery_decision',
+  payload: Record<string, unknown>,
+  ts: number,
+): RuntimeEvent {
+  return {
+    ...baseEvent(id, ts),
+    actions: {
+      toolRecovery: { kind, version: 1, payload } as unknown as ToolRecoveryFactEnvelope,
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  };
+}
+
+function baseEvent(id: string, ts: number): RuntimeEvent {
+  return {
+    id,
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts,
+    partial: false,
+    role: 'system',
+    author: 'system',
+  };
+}
+
+function requiredEnv(name: string): string {
+  const value = process.env[name];
+  if (!value) throw new Error(`Missing ${name}`);
+  return value;
+}

--- a/packages/storage/src/__tests__/fixtures/sqlite-recovery-concurrency-child.ts
+++ b/packages/storage/src/__tests__/fixtures/sqlite-recovery-concurrency-child.ts
@@ -5,15 +5,23 @@ import { createSqliteRuntimeStore } from '../../sqlite-runtime-store.js';
 const mode = requiredEnv('MAKA_SQLITE_RECOVERY_CONCURRENCY_MODE');
 const dbPath = requiredEnv('MAKA_SQLITE_RECOVERY_CONCURRENCY_DB');
 const startPath = requiredEnv('MAKA_SQLITE_RECOVERY_CONCURRENCY_START');
-const store = createSqliteRuntimeStore(dbPath);
+const stopPath = process.env.MAKA_SQLITE_RECOVERY_CONCURRENCY_STOP;
 
 writeSync(1, 'READY\n');
 while (!existsSync(startPath)) {
   Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
 }
 
+let store: ReturnType<typeof createSqliteRuntimeStore> | undefined;
 try {
-  if (mode === 'completed') {
+  store = createSqliteRuntimeStore(dbPath);
+  writeSync(1, 'OPENED\n');
+  if (mode === 'open_only') {
+    if (!stopPath) throw new Error('Missing MAKA_SQLITE_RECOVERY_CONCURRENCY_STOP');
+    while (!existsSync(stopPath)) {
+      Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 5);
+    }
+  } else if (mode === 'completed') {
     await store.commitToolRecoveryBundle(completedBundle());
   } else if (mode === 'parked') {
     await store.commitToolRecoveryBundle(parkedBundle());
@@ -27,7 +35,7 @@ try {
   writeSync(2, `RESULT error ${error instanceof Error ? error.message : String(error)}\n`);
   process.exitCode = 2;
 } finally {
-  store.close();
+  store?.close();
 }
 
 function completedBundle() {

--- a/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
+++ b/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
@@ -19,8 +19,8 @@ const ARGS_HASH = canonicalToolArgsHash('Write', {
 // Mainline schema 4 persisted stableHash({ toolName, args }) for this exact
 // provider call. Keep the literal independent from the current hash helper so
 // an accidental identity-epoch change remains observable during migration.
-const MAINLINE_SCHEMA_4_READ_ARGS_HASH =
-  'sha256:5949a5bf23e5928b160ea0444cd16391f47365c3cd8b6d33a7381d585baf1db2';
+const MAINLINE_SCHEMA_4_SPECIAL_ARGS_HASH =
+  'sha256:0002fcd132216e3442d4ab7579d9659019019c6b7000456fbef198b7ae53ee43';
 const OBSERVATION_DIGEST =
   'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
 
@@ -38,8 +38,8 @@ describe('SQLite recovery persistence authority', () => {
       content: {
         kind: 'function_call',
         id: 'schema-4-provider-call',
-        name: 'Read',
-        args: { path: 'prepared.txt' },
+        name: 'X',
+        args: { required: ['b', 'a'] },
       },
     });
     const dispatch = baseEvent({
@@ -50,8 +50,8 @@ describe('SQLite recovery persistence authority', () => {
           protocol: 't1_after_preflight_v1',
           operationId: 'schema-4-operation',
           providerToolCallId: 'schema-4-provider-call',
-          toolName: 'Read',
-          canonicalArgsHash: MAINLINE_SCHEMA_4_READ_ARGS_HASH,
+          toolName: 'X',
+          canonicalArgsHash: MAINLINE_SCHEMA_4_SPECIAL_ARGS_HASH,
           recoveryMode: 'replay_safe',
         },
       },
@@ -106,8 +106,8 @@ describe('SQLite recovery persistence authority', () => {
           runId: 'run-1',
           turnId: 'turn-1',
           providerToolCallId: 'schema-4-provider-call',
-          toolName: 'Read',
-          canonicalArgsHash: MAINLINE_SCHEMA_4_READ_ARGS_HASH,
+          toolName: 'X',
+          canonicalArgsHash: MAINLINE_SCHEMA_4_SPECIAL_ARGS_HASH,
           recoveryMode: 'replay_safe',
           currentState: 'prepared',
           callEventId: 'schema-4-call',

--- a/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
+++ b/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
@@ -20,23 +20,95 @@ const OBSERVATION_DIGEST =
   'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
 
 describe('SQLite recovery persistence authority', () => {
-  it('upgrades a populated mainline schema 4 database without losing immutable events', async () => {
+  it('upgrades and quarantines populated mainline schema 4 tool projections', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-recovery-mainline-upgrade-'));
     const dbPath = join(root, 'runtime.sqlite');
     const store = createSqliteRuntimeStore(dbPath);
-    await store.appendRuntimeEvent('session-1', 'run-1', userEvent());
+    const preparedCall = callEvent();
+    preparedCall.id = 'legacy-prepared-call';
+    preparedCall.content = {
+      kind: 'function_call',
+      id: 'legacy-prepared-provider-call',
+      name: 'Read',
+      args: { path: 'prepared.txt' },
+    };
+    const completedCall = callEvent();
+    completedCall.id = 'legacy-completed-call';
+    completedCall.content = {
+      kind: 'function_call',
+      id: 'legacy-completed-provider-call',
+      name: 'Read',
+      args: { path: 'completed.txt' },
+    };
+    const completedResponse = outcomeEvent();
+    completedResponse.id = 'legacy-completed-response';
+    completedResponse.content = {
+      kind: 'function_response',
+      id: 'legacy-completed-provider-call',
+      name: 'Read',
+      result: 'contents',
+    };
+    completedResponse.refs = { toolCallId: 'legacy-completed-provider-call' };
+    await store.importRuntimeEventsBatch({
+      sessionId: 'session-1',
+      runId: 'run-1',
+      events: [preparedCall, completedCall, completedResponse],
+    });
     store.close();
 
     const db = new DatabaseSync(dbPath);
+    const insertOperation = db.prepare(`
+      INSERT INTO tool_operations(
+        operation_id, invocation_id, run_id, turn_id, provider_tool_call_id,
+        tool_name, canonical_args_hash, recovery_mode, current_state,
+        call_event_id, dispatch_event_id, result_event_id, version
+      ) VALUES (?, 'invocation-1', 'run-1', 'turn-1', ?, 'Read', ?, 'replay_safe', ?, ?, NULL, ?, ?)
+    `);
+    insertOperation.run(
+      'legacy-prepared-operation',
+      'legacy-prepared-provider-call',
+      canonicalToolArgsHash('Read', { path: 'prepared.txt' }),
+      'prepared',
+      'legacy-prepared-call',
+      null,
+      1,
+    );
+    insertOperation.run(
+      'legacy-completed-operation',
+      'legacy-completed-provider-call',
+      canonicalToolArgsHash('Read', { path: 'completed.txt' }),
+      'outcome_committed',
+      'legacy-completed-call',
+      'legacy-completed-response',
+      2,
+    );
     db.exec('DROP TABLE runtime_capabilities; PRAGMA user_version = 4;');
     db.close();
 
     try {
       const upgraded = createSqliteRuntimeStore(dbPath);
       try {
-        assert.deepEqual(await upgraded.readImmutableRuntimeEvents('session-1', 'run-1'), [
-          userEvent(),
-        ]);
+        assert.equal(
+          (await upgraded.readToolOperation('legacy-prepared-operation'))?.currentState,
+          'prepared',
+        );
+        assert.equal(
+          (await upgraded.readToolOperation('legacy-completed-operation'))?.currentState,
+          'outcome_committed',
+        );
+        assert.deepEqual(await upgraded.listUnsettledToolOperations(), []);
+        assert.deepEqual(await upgraded.rebuildToolProjectionsFromRuntimeEvents(), {
+          operations: 0,
+          journalEvents: 0,
+        });
+        assert.equal(
+          (await upgraded.readToolOperation('legacy-prepared-operation'))?.currentState,
+          'prepared',
+        );
+        assert.equal(
+          (await upgraded.readToolOperation('legacy-completed-operation'))?.currentState,
+          'outcome_committed',
+        );
         assert.equal(upgraded.recoveryBundleCapability, TOOL_RECOVERY_BUNDLE_CAPABILITY_V1);
       } finally {
         upgraded.close();
@@ -100,7 +172,7 @@ describe('SQLite recovery persistence authority', () => {
       await assert.rejects(
         store.commitToolPrepared({
           operationId: 'operation-1',
-          journalEventId: 'journal-prepared-1',
+          journalEventId: 'operation-1_prepared',
           runtimeEvent: callEvent(),
           dispatchRuntimeEvent: dispatch,
           providerToolCallId: 'provider-call-1',
@@ -110,6 +182,101 @@ describe('SQLite recovery persistence authority', () => {
           committedAt: 10,
         }),
         /canonical function call/,
+      );
+      assert.deepEqual(await store.readImmutableRuntimeEvents('session-1', 'run-1'), []);
+    });
+  });
+
+  it('derives projection-local journal identities instead of trusting callers', async () => {
+    await withStore(async (store) => {
+      await assert.rejects(
+        store.commitToolPrepared({
+          operationId: 'operation-1',
+          journalEventId: 'caller-selected-id',
+          runtimeEvent: callEvent(),
+          dispatchRuntimeEvent: dispatchEvent(),
+          providerToolCallId: 'provider-call-1',
+          toolName: 'Write',
+          canonicalArgsHash: ARGS_HASH,
+          recoveryMode: 'reconcile',
+          committedAt: 10,
+        }),
+        /journal identity/,
+      );
+      assert.deepEqual(await store.readImmutableRuntimeEvents('session-1', 'run-1'), []);
+    });
+  });
+
+  it('rejects duplicate call identities through the generic writer', async () => {
+    await withStore(async (store) => {
+      await store.appendRuntimeEvent('session-1', 'run-1', callEvent());
+      await assert.rejects(
+        store.appendRuntimeEvent('session-1', 'run-1', {
+          ...callEvent(),
+          id: 'call-event-duplicate',
+        }),
+        /duplicate_call/,
+      );
+      assert.deepEqual(
+        (await store.readImmutableRuntimeEvents('session-1', 'run-1')).map(({ id }) => id),
+        ['call-event-1'],
+      );
+    });
+  });
+
+  it('rejects an unbound generic response after T1', async () => {
+    await withStore(async (store) => {
+      await prepare(store);
+      const unboundResponse = outcomeEvent();
+      unboundResponse.refs = { toolCallId: 'provider-call-1' };
+
+      await assert.rejects(
+        store.appendRuntimeEvent('session-1', 'run-1', unboundResponse),
+        /identity_conflict/,
+      );
+      assert.equal((await store.readToolOperation('operation-1'))?.currentState, 'prepared');
+    });
+  });
+
+  it('rejects a T1 dispatch after a pre-T1 synthetic response settled the call', async () => {
+    await withStore(async (store) => {
+      const unboundResponse = outcomeEvent();
+      unboundResponse.refs = { toolCallId: 'provider-call-1' };
+      await store.importRuntimeEventsBatch({
+        sessionId: 'session-1',
+        runId: 'run-1',
+        events: [callEvent(), unboundResponse],
+      });
+
+      await assert.rejects(
+        store.commitToolPrepared({
+          operationId: 'operation-1',
+          journalEventId: 'operation-1_prepared',
+          runtimeEvent: callEvent(),
+          dispatchRuntimeEvent: dispatchEvent(),
+          providerToolCallId: 'provider-call-1',
+          toolName: 'Write',
+          canonicalArgsHash: ARGS_HASH,
+          recoveryMode: 'reconcile',
+          committedAt: 10,
+        }),
+        /event_order_conflict/,
+      );
+      assert.equal(await store.readToolOperation('operation-1'), undefined);
+    });
+  });
+
+  it('rejects an out-of-order tool-bearing batch import atomically', async () => {
+    await withStore(async (store) => {
+      const unboundResponse = outcomeEvent();
+      unboundResponse.refs = { toolCallId: 'provider-call-1' };
+      await assert.rejects(
+        store.importRuntimeEventsBatch({
+          sessionId: 'session-1',
+          runId: 'run-1',
+          events: [unboundResponse, callEvent()],
+        }),
+        /orphan_response/,
       );
       assert.deepEqual(await store.readImmutableRuntimeEvents('session-1', 'run-1'), []);
     });
@@ -171,6 +338,91 @@ describe('SQLite recovery persistence authority', () => {
       } finally {
         reopened.close();
       }
+    });
+  });
+
+  it('rebuilds interleaved operations to the same projections and journal identities', async () => {
+    await withStore(async (store) => {
+      await prepare(store);
+      const secondHash = canonicalToolArgsHash('Write', {
+        path: 'other.txt',
+        content: 'after',
+      });
+      const secondCall = callEvent();
+      secondCall.id = 'call-event-2';
+      secondCall.content = {
+        kind: 'function_call',
+        id: 'provider-call-2',
+        name: 'Write',
+        args: { path: 'other.txt', content: 'after' },
+      };
+      const secondDispatch = dispatchEvent();
+      secondDispatch.id = 'dispatch-event-2';
+      secondDispatch.actions!.toolDispatch = {
+        protocol: 't1_after_preflight_v1',
+        operationId: 'operation-2',
+        providerToolCallId: 'provider-call-2',
+        toolName: 'Write',
+        canonicalArgsHash: secondHash,
+        recoveryMode: 'reconcile',
+      };
+      secondDispatch.refs = { operationId: 'operation-2', toolCallId: 'provider-call-2' };
+      await store.commitToolPrepared({
+        operationId: 'operation-2',
+        journalEventId: 'operation-2_prepared',
+        runtimeEvent: secondCall,
+        dispatchRuntimeEvent: secondDispatch,
+        providerToolCallId: 'provider-call-2',
+        toolName: 'Write',
+        canonicalArgsHash: secondHash,
+        recoveryMode: 'reconcile',
+        committedAt: 11,
+      });
+      const secondOutcome = outcomeEvent();
+      secondOutcome.id = 'outcome-event-2';
+      secondOutcome.content = {
+        kind: 'function_response',
+        id: 'provider-call-2',
+        name: 'Write',
+        result: 'ok',
+      };
+      secondOutcome.refs = { operationId: 'operation-2', toolCallId: 'provider-call-2' };
+      await store.commitToolOutcome({
+        operationId: 'operation-2',
+        journalEventId: 'operation-2_outcome',
+        runtimeEvent: secondOutcome,
+        committedAt: 20,
+      });
+      await store.commitToolOutcome({
+        operationId: 'operation-1',
+        journalEventId: 'operation-1_outcome',
+        runtimeEvent: outcomeEvent(),
+        committedAt: 21,
+      });
+
+      const onlineOperations = await Promise.all([
+        store.readToolOperation('operation-1'),
+        store.readToolOperation('operation-2'),
+      ]);
+      const onlineJournals = await Promise.all([
+        store.readToolJournal('operation-1'),
+        store.readToolJournal('operation-2'),
+      ]);
+      await store.rebuildToolProjectionsFromRuntimeEvents();
+      assert.deepEqual(
+        await Promise.all([
+          store.readToolOperation('operation-1'),
+          store.readToolOperation('operation-2'),
+        ]),
+        onlineOperations,
+      );
+      assert.deepEqual(
+        await Promise.all([
+          store.readToolJournal('operation-1'),
+          store.readToolJournal('operation-2'),
+        ]),
+        onlineJournals,
+      );
     });
   });
 
@@ -267,6 +519,38 @@ describe('SQLite recovery persistence authority', () => {
       } finally {
         reopened.close();
       }
+    });
+  });
+
+  it('persists the decoder canonical RuntimeEvent and makes raw retries idempotent', async () => {
+    await withStore(async (store) => {
+      const raw = userEvent();
+      raw.content = {
+        kind: 'text',
+        text: 'write it',
+        displayText: 'write it',
+        attachments: [],
+        quotes: [],
+      };
+
+      await store.appendRuntimeEvent('session-1', 'run-1', raw);
+      await store.appendRuntimeEvent('session-1', 'run-1', raw);
+
+      assert.deepEqual(await store.readImmutableRuntimeEvents('session-1', 'run-1'), [userEvent()]);
+    });
+  });
+
+  it('rejects RuntimeEvents that lose required fields during JSON serialization', async () => {
+    await withStore(async (store) => {
+      const lossy = callEvent();
+      if (lossy.content?.kind !== 'function_call') throw new Error('invalid fixture');
+      lossy.content.args = undefined;
+
+      await assert.rejects(
+        store.appendRuntimeEvent('session-1', 'run-1', lossy),
+        /RuntimeEvent schema/,
+      );
+      assert.deepEqual(await store.readImmutableRuntimeEvents('session-1', 'run-1'), []);
     });
   });
 

--- a/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
+++ b/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
@@ -743,6 +743,36 @@ describe('SQLite recovery persistence authority', () => {
     });
   });
 
+  it('fail-stops a new session tool boundary when another session ledger is corrupt', async () => {
+    await withStore(async (store, dbPath) => {
+      await prepare(store);
+      store.close();
+      injectDuplicateCall(dbPath, 3);
+
+      const reopened = createSqliteRuntimeStore(dbPath);
+      const unrelatedCall = callEvent();
+      unrelatedCall.id = 'unrelated-call-event';
+      unrelatedCall.sessionId = 'session-2';
+      unrelatedCall.invocationId = 'invocation-2';
+      unrelatedCall.runId = 'run-2';
+      unrelatedCall.turnId = 'turn-2';
+      if (unrelatedCall.content?.kind !== 'function_call') {
+        throw new Error('invalid unrelated call fixture');
+      }
+      unrelatedCall.content.id = 'provider-call-2';
+      unrelatedCall.refs = { toolCallId: 'provider-call-2' };
+      try {
+        await assert.rejects(
+          reopened.appendRuntimeEvent('session-2', 'run-2', unrelatedCall),
+          /duplicate_call/,
+        );
+        assert.deepEqual(await reopened.readImmutableRuntimeEvents('session-2', 'run-2'), []);
+      } finally {
+        reopened.close();
+      }
+    });
+  });
+
   it('rejects duplicate call identity while rebuilding canonical projections', async () => {
     await withStore(async (store, dbPath) => {
       await prepare(store);

--- a/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
+++ b/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
@@ -224,6 +224,39 @@ describe('SQLite recovery persistence authority', () => {
     });
   });
 
+  it('rejects one invocation identity crossing run, turn, or session boundaries', async () => {
+    await withStore(async (store) => {
+      await store.appendRuntimeEvent('session-1', 'run-1', userEvent());
+
+      for (const event of [
+        baseEvent({
+          id: 'other-run-event',
+          runId: 'run-2',
+          content: { kind: 'text', text: 'other run' },
+        }),
+        baseEvent({
+          id: 'other-turn-event',
+          turnId: 'turn-2',
+          content: { kind: 'text', text: 'other turn' },
+        }),
+        baseEvent({
+          id: 'other-session-event',
+          sessionId: 'session-2',
+          content: { kind: 'text', text: 'other session' },
+        }),
+      ]) {
+        await assert.rejects(
+          store.appendRuntimeEvent(event.sessionId, event.runId, event),
+          /invocation identity conflict/,
+        );
+      }
+      assert.deepEqual(
+        (await store.readImmutableRuntimeEvents('session-1', 'run-1')).map((event) => event.id),
+        ['user-event-1'],
+      );
+    });
+  });
+
   it('rejects an unbound generic response after T1', async () => {
     await withStore(async (store) => {
       await prepare(store);
@@ -492,7 +525,7 @@ describe('SQLite recovery persistence authority', () => {
           outcomeRuntimeEvent: outcomeEvent(),
           decisionRuntimeEvent: decisionEvent(),
         }),
-        /already settled/,
+        /duplicate_event_id/,
       );
     });
   });
@@ -548,9 +581,70 @@ describe('SQLite recovery persistence authority', () => {
 
       await assert.rejects(
         store.appendRuntimeEvent('session-1', 'run-1', lossy),
-        /RuntimeEvent schema/,
+        /RuntimeEvent schema|losslessly serializable/,
       );
       assert.deepEqual(await store.readImmutableRuntimeEvents('session-1', 'run-1'), []);
+    });
+  });
+
+  it('rejects nested JSON loss in a function response before persistence', async () => {
+    await withStore(async (store) => {
+      await store.appendRuntimeEvent('session-1', 'run-1', callEvent());
+      const lossy = outcomeEvent();
+      if (lossy.content?.kind !== 'function_response') throw new Error('invalid fixture');
+      lossy.content.result = { value: undefined };
+      lossy.refs = { toolCallId: 'provider-call-1' };
+
+      await assert.rejects(
+        store.appendRuntimeEvent('session-1', 'run-1', lossy),
+        /losslessly serializable/,
+      );
+      assert.deepEqual(
+        (await store.readImmutableRuntimeEvents('session-1', 'run-1')).map((event) => event.id),
+        ['call-event-1'],
+      );
+    });
+  });
+
+  it('rejects provider metadata that rewrites itself through toJSON', async () => {
+    await withStore(async (store) => {
+      const lossy = callEvent();
+      if (lossy.content?.kind !== 'function_call') throw new Error('invalid fixture');
+      lossy.content.providerOptions = {
+        value: 1,
+        toJSON() {
+          return { value: 2 };
+        },
+      };
+
+      await assert.rejects(
+        store.appendRuntimeEvent('session-1', 'run-1', lossy),
+        /losslessly serializable/,
+      );
+      assert.deepEqual(await store.readImmutableRuntimeEvents('session-1', 'run-1'), []);
+    });
+  });
+
+  it('rejects recovery evidence whose JSON bytes can rewrite validated event ids', async () => {
+    await withStore(async (store) => {
+      await prepare(store);
+      const decision = decisionEvent();
+      const fact = decision.actions?.toolRecovery;
+      if (fact?.kind !== 'maka.tool.recovery_decision') throw new Error('invalid fixture');
+      Object.defineProperty(fact.payload.evidenceEventIds, 'toJSON', {
+        value: () => ['call-event-1', 'dispatch-event-1', 'reconcile-event-1', 'forged-outcome'],
+      });
+
+      await assert.rejects(
+        store.commitToolRecoveryBundle({
+          operationId: 'operation-1',
+          reconcileRuntimeEvent: reconcileEvent(),
+          outcomeRuntimeEvent: outcomeEvent(),
+          decisionRuntimeEvent: decision,
+        }),
+        /losslessly serializable/,
+      );
+      assert.equal((await store.readToolOperation('operation-1'))?.currentState, 'prepared');
     });
   });
 
@@ -577,6 +671,72 @@ describe('SQLite recovery persistence authority', () => {
           /row\/payload identity mismatch/,
         );
         assert.equal((await reopened.readToolOperation('operation-1'))?.currentState, 'prepared');
+      } finally {
+        reopened.close();
+      }
+    });
+  });
+
+  it('fails an exact T1 retry closed when the immutable ledger is already corrupt', async () => {
+    await withStore(async (store, dbPath) => {
+      await prepare(store);
+      store.close();
+      injectDuplicateCall(dbPath, 3);
+
+      const reopened = createSqliteRuntimeStore(dbPath);
+      try {
+        await assert.rejects(prepare(reopened), /duplicate_call/);
+      } finally {
+        reopened.close();
+      }
+    });
+  });
+
+  it('fails an exact T2 retry closed when the immutable ledger is already corrupt', async () => {
+    await withStore(async (store, dbPath) => {
+      await prepare(store);
+      await store.commitToolOutcome({
+        operationId: 'operation-1',
+        journalEventId: 'operation-1_outcome',
+        runtimeEvent: outcomeEvent(),
+        committedAt: 20,
+      });
+      store.close();
+      injectDuplicateCall(dbPath, 4);
+
+      const reopened = createSqliteRuntimeStore(dbPath);
+      try {
+        await assert.rejects(
+          reopened.commitToolOutcome({
+            operationId: 'operation-1',
+            journalEventId: 'operation-1_outcome',
+            runtimeEvent: outcomeEvent(),
+            committedAt: 20,
+          }),
+          /duplicate_call/,
+        );
+      } finally {
+        reopened.close();
+      }
+    });
+  });
+
+  it('fails an exact recovery retry closed when the immutable ledger is already corrupt', async () => {
+    await withStore(async (store, dbPath) => {
+      await prepare(store);
+      const bundle = {
+        operationId: 'operation-1',
+        reconcileRuntimeEvent: reconcileEvent(),
+        outcomeRuntimeEvent: outcomeEvent(),
+        decisionRuntimeEvent: decisionEvent(),
+      } as const;
+      await store.commitToolRecoveryBundle(bundle);
+      store.close();
+      injectDuplicateCall(dbPath, 6);
+
+      const reopened = createSqliteRuntimeStore(dbPath);
+      try {
+        await assert.rejects(reopened.commitToolRecoveryBundle(bundle), /duplicate_call/);
       } finally {
         reopened.close();
       }
@@ -699,6 +859,32 @@ describe('SQLite recovery persistence authority', () => {
 });
 
 type Store = ReturnType<typeof createSqliteRuntimeStore>;
+
+function injectDuplicateCall(dbPath: string, eventSeq: number): void {
+  const db = new DatabaseSync(dbPath);
+  try {
+    const duplicate = callEvent();
+    duplicate.id = `call-event-duplicate-${eventSeq}`;
+    db.prepare(`
+      INSERT INTO runtime_events (
+        event_id, session_id, invocation_id, run_id, turn_id,
+        event_seq, event_kind, payload_json, committed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      duplicate.id,
+      duplicate.sessionId,
+      duplicate.invocationId,
+      duplicate.runId,
+      duplicate.turnId,
+      eventSeq,
+      'function_call',
+      JSON.stringify(duplicate),
+      duplicate.ts,
+    );
+  } finally {
+    db.close();
+  }
+}
 
 async function withStore(run: (store: Store, dbPath: string) => Promise<void>): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), 'maka-recovery-authority-'));

--- a/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
+++ b/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
@@ -1,0 +1,594 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
+import { describe, it } from 'node:test';
+import {
+  TOOL_RECOVERY_BUNDLE_CAPABILITY_V1,
+  canonicalToolArgsHash,
+  type RuntimeEvent,
+} from '@maka/core';
+import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
+import type { SqliteRuntimeStoreFailpoint } from '../sqlite-runtime-store.js';
+
+const ARGS_HASH = canonicalToolArgsHash('Write', {
+  path: 'notes.txt',
+  content: 'after',
+});
+const OBSERVATION_DIGEST =
+  'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
+
+describe('SQLite recovery persistence authority', () => {
+  it('upgrades a populated mainline schema 4 database without losing immutable events', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-recovery-mainline-upgrade-'));
+    const dbPath = join(root, 'runtime.sqlite');
+    const store = createSqliteRuntimeStore(dbPath);
+    await store.appendRuntimeEvent('session-1', 'run-1', userEvent());
+    store.close();
+
+    const db = new DatabaseSync(dbPath);
+    db.exec('DROP TABLE runtime_capabilities; PRAGMA user_version = 4;');
+    db.close();
+
+    try {
+      const upgraded = createSqliteRuntimeStore(dbPath);
+      try {
+        assert.deepEqual(await upgraded.readImmutableRuntimeEvents('session-1', 'run-1'), [
+          userEvent(),
+        ]);
+        assert.equal(upgraded.recoveryBundleCapability, TOOL_RECOVERY_BUNDLE_CAPABILITY_V1);
+      } finally {
+        upgraded.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects the old experimental capability marker instead of guessing compatibility', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-recovery-epoch-'));
+    const dbPath = join(root, 'runtime.sqlite');
+    const store = createSqliteRuntimeStore(dbPath);
+    store.close();
+    const db = new DatabaseSync(dbPath);
+    db.prepare('DELETE FROM runtime_capabilities').run();
+    db.prepare('INSERT INTO runtime_capabilities(capability, version) VALUES (?, ?)').run(
+      'tool_recovery_bundle',
+      1,
+    );
+    db.close();
+    try {
+      assert.throws(
+        () => createSqliteRuntimeStore(dbPath),
+        /runtime_recovery_authority@1 is unavailable/,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('rejects reserved recovery facts through every generic append path', async () => {
+    await withStore(async (store) => {
+      await assert.rejects(
+        store.appendRuntimeEvent('session-1', 'run-1', reconcileEvent()),
+        /atomic recovery bundle writer/,
+      );
+      await assert.rejects(
+        store.importRuntimeEventsBatch({
+          sessionId: 'session-1',
+          runId: 'run-1',
+          events: [reconcileEvent()],
+        }),
+        /atomic recovery bundle writer/,
+      );
+      await assert.rejects(
+        store.appendRuntimeEvent('session-1', 'run-1', dispatchEvent()),
+        /atomic tool boundary writer/,
+      );
+      await assert.rejects(
+        store.appendRuntimeEvent('session-1', 'run-1', outcomeEvent()),
+        /atomic tool boundary writer/,
+      );
+    });
+  });
+
+  it('recomputes T1 identity from the persisted function-call arguments', async () => {
+    await withStore(async (store) => {
+      const dispatch = dispatchEvent();
+      dispatch.actions!.toolDispatch!.canonicalArgsHash = 'sha256:wrong';
+      await assert.rejects(
+        store.commitToolPrepared({
+          operationId: 'operation-1',
+          journalEventId: 'journal-prepared-1',
+          runtimeEvent: callEvent(),
+          dispatchRuntimeEvent: dispatch,
+          providerToolCallId: 'provider-call-1',
+          toolName: 'Write',
+          canonicalArgsHash: 'sha256:wrong',
+          recoveryMode: 'reconcile',
+          committedAt: 10,
+        }),
+        /canonical function call/,
+      );
+      assert.deepEqual(await store.readImmutableRuntimeEvents('session-1', 'run-1'), []);
+    });
+  });
+
+  it('rejects a T2 row that also claims another authoritative semantic lane', async () => {
+    await withStore(async (store) => {
+      await prepare(store);
+      const outcome = outcomeEvent();
+      outcome.actions = { endInvocation: true };
+      await assert.rejects(
+        store.commitToolOutcome({
+          operationId: 'operation-1',
+          journalEventId: 'operation-1_outcome',
+          runtimeEvent: outcome,
+          committedAt: 20,
+        }),
+        /semantic lane/,
+      );
+      assert.equal((await store.readToolOperation('operation-1'))?.currentState, 'prepared');
+      assert.deepEqual(
+        (await store.readImmutableRuntimeEvents('session-1', 'run-1')).map(({ id }) => id),
+        ['call-event-1', 'dispatch-event-1'],
+      );
+    });
+  });
+
+  it('atomically settles completed recovery and rebuilds the same projection after reopen', async () => {
+    await withStore(async (store, dbPath) => {
+      assert.equal(store.recoveryBundleCapability, TOOL_RECOVERY_BUNDLE_CAPABILITY_V1);
+      await prepare(store);
+      await store.commitToolRecoveryBundle({
+        operationId: 'operation-1',
+        reconcileRuntimeEvent: reconcileEvent(),
+        outcomeRuntimeEvent: outcomeEvent(),
+        decisionRuntimeEvent: decisionEvent(),
+      });
+
+      const onlineOperation = await store.readToolOperation('operation-1');
+      const onlineJournal = await store.readToolJournal('operation-1');
+      assert.equal(onlineOperation?.currentState, 'recovery_completed');
+      assert.equal(onlineOperation?.resultEventId, 'outcome-event-1');
+      assert.deepEqual(
+        onlineJournal.map(({ state }) => state),
+        ['prepared', 'reconcile_observed', 'outcome_committed', 'recovery_completed'],
+      );
+
+      store.close();
+      const reopened = createSqliteRuntimeStore(dbPath);
+      try {
+        assert.deepEqual(await reopened.readToolOperation('operation-1'), onlineOperation);
+        assert.deepEqual(await reopened.readToolJournal('operation-1'), onlineJournal);
+        assert.deepEqual(await reopened.rebuildToolProjectionsFromRuntimeEvents(), {
+          operations: 1,
+          journalEvents: 4,
+        });
+        assert.deepEqual(await reopened.readToolOperation('operation-1'), onlineOperation);
+        assert.deepEqual(await reopened.readToolJournal('operation-1'), onlineJournal);
+      } finally {
+        reopened.close();
+      }
+    });
+  });
+
+  it('rolls the whole recovery bundle back at every internal crash boundary', async () => {
+    for (const failpoint of [
+      'after_recovery_reconcile',
+      'after_recovery_outcome',
+      'after_recovery_decision',
+    ] as const satisfies readonly SqliteRuntimeStoreFailpoint[]) {
+      const root = await mkdtemp(join(tmpdir(), 'maka-recovery-failpoint-'));
+      const dbPath = join(root, 'runtime.sqlite');
+      let active: SqliteRuntimeStoreFailpoint | undefined;
+      const store = createSqliteRuntimeStore(dbPath, {
+        failpoint: (point) => {
+          if (point === active) throw new Error(`recovery failpoint: ${point}`);
+        },
+      });
+      try {
+        await prepare(store);
+        active = failpoint;
+        await assert.rejects(
+          store.commitToolRecoveryBundle({
+            operationId: 'operation-1',
+            reconcileRuntimeEvent: reconcileEvent(),
+            outcomeRuntimeEvent: outcomeEvent(),
+            decisionRuntimeEvent: decisionEvent(),
+          }),
+          new RegExp(failpoint),
+        );
+        active = undefined;
+        assert.deepEqual(
+          (await store.readImmutableRuntimeEvents('session-1', 'run-1')).map(({ id }) => id),
+          ['call-event-1', 'dispatch-event-1'],
+        );
+        assert.equal((await store.readToolOperation('operation-1'))?.currentState, 'prepared');
+        assert.deepEqual(
+          (await store.readToolJournal('operation-1')).map(({ state }) => state),
+          ['prepared'],
+        );
+      } finally {
+        store.close();
+        await rm(root, { recursive: true, force: true });
+      }
+    }
+  });
+
+  it('makes one parked bundle terminal and only permits its exact retry', async () => {
+    await withStore(async (store) => {
+      await prepare(store);
+      const parked = {
+        operationId: 'operation-1',
+        reconcileRuntimeEvent: reconcileEvent('diverged'),
+        decisionRuntimeEvent: decisionEvent('parked'),
+      } as const;
+      await store.commitToolRecoveryBundle(parked);
+      await store.commitToolRecoveryBundle(parked);
+
+      assert.equal((await store.readToolOperation('operation-1'))?.currentState, 'recovery_parked');
+      assert.deepEqual(
+        (await store.readToolJournal('operation-1')).map(({ state }) => state),
+        ['prepared', 'reconcile_observed', 'recovery_parked'],
+      );
+      await assert.rejects(
+        store.commitToolRecoveryBundle({
+          operationId: 'operation-1',
+          reconcileRuntimeEvent: reconcileEvent(),
+          outcomeRuntimeEvent: outcomeEvent(),
+          decisionRuntimeEvent: decisionEvent(),
+        }),
+        /already settled/,
+      );
+    });
+  });
+
+  it('fails immutable row/payload identity mismatches closed', async () => {
+    await withStore(async (store, dbPath) => {
+      await store.appendRuntimeEvent('session-1', 'run-1', userEvent());
+      store.close();
+
+      const db = new DatabaseSync(dbPath);
+      const payload = { ...userEvent(), runId: 'run-other' };
+      db.prepare('UPDATE runtime_events SET payload_json = ? WHERE event_id = ?').run(
+        JSON.stringify(payload),
+        'user-event-1',
+      );
+      db.close();
+
+      const reopened = createSqliteRuntimeStore(dbPath);
+      try {
+        await assert.rejects(
+          reopened.readImmutableRuntimeEvents('session-1', 'run-1'),
+          /row\/payload identity mismatch/,
+        );
+      } finally {
+        reopened.close();
+      }
+    });
+  });
+
+  it('rejects row/payload identity corruption through the online bundle writer', async () => {
+    await withStore(async (store, dbPath) => {
+      await prepare(store);
+      store.close();
+
+      const db = new DatabaseSync(dbPath);
+      db.prepare(`UPDATE runtime_events SET run_id = 'run-other' WHERE event_id = ?`).run(
+        'call-event-1',
+      );
+      db.close();
+
+      const reopened = createSqliteRuntimeStore(dbPath);
+      try {
+        await assert.rejects(
+          reopened.commitToolRecoveryBundle({
+            operationId: 'operation-1',
+            reconcileRuntimeEvent: reconcileEvent(),
+            outcomeRuntimeEvent: outcomeEvent(),
+            decisionRuntimeEvent: decisionEvent(),
+          }),
+          /row\/payload identity mismatch/,
+        );
+        assert.equal((await reopened.readToolOperation('operation-1'))?.currentState, 'prepared');
+      } finally {
+        reopened.close();
+      }
+    });
+  });
+
+  it('rejects duplicate call identity while rebuilding canonical projections', async () => {
+    await withStore(async (store, dbPath) => {
+      await prepare(store);
+      store.close();
+
+      const db = new DatabaseSync(dbPath);
+      const row = db
+        .prepare(`
+          SELECT session_id, invocation_id, run_id, turn_id, event_kind,
+            payload_json, committed_at
+          FROM runtime_events
+          WHERE event_id = 'call-event-1'
+        `)
+        .get() as {
+        session_id: string;
+        invocation_id: string;
+        run_id: string;
+        turn_id: string;
+        event_kind: string;
+        payload_json: string;
+        committed_at: number;
+      };
+      const payload = JSON.parse(row.payload_json) as RuntimeEvent;
+      payload.id = 'call-event-duplicate';
+      db.prepare(`
+        INSERT INTO runtime_events(
+          event_id, session_id, invocation_id, run_id, turn_id,
+          event_seq, event_kind, payload_json, committed_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        payload.id,
+        row.session_id,
+        row.invocation_id,
+        row.run_id,
+        row.turn_id,
+        3,
+        row.event_kind,
+        JSON.stringify(payload),
+        row.committed_at,
+      );
+      db.close();
+
+      const reopened = createSqliteRuntimeStore(dbPath);
+      try {
+        await assert.rejects(reopened.rebuildToolProjectionsFromRuntimeEvents(), /duplicate_call/);
+      } finally {
+        reopened.close();
+      }
+    });
+  });
+
+  it('rejects dispatch-before-call physical order while rebuilding projections', async () => {
+    await withStore(async (store, dbPath) => {
+      await prepare(store);
+      store.close();
+
+      const db = new DatabaseSync(dbPath);
+      db.prepare(`UPDATE runtime_events SET event_seq = 100 WHERE event_id = 'call-event-1'`).run();
+      db.prepare(
+        `UPDATE runtime_events SET event_seq = 1 WHERE event_id = 'dispatch-event-1'`,
+      ).run();
+      db.prepare(`UPDATE runtime_events SET event_seq = 2 WHERE event_id = 'call-event-1'`).run();
+      db.close();
+
+      const reopened = createSqliteRuntimeStore(dbPath);
+      try {
+        await assert.rejects(
+          reopened.rebuildToolProjectionsFromRuntimeEvents(),
+          /event_order_conflict/,
+        );
+      } finally {
+        reopened.close();
+      }
+    });
+  });
+
+  it('skips a corrupt mutable partial snapshot without hiding immutable history', async () => {
+    await withStore(async (store, dbPath) => {
+      await store.appendRuntimeEvent('session-1', 'run-1', userEvent());
+      await store.appendRuntimeEvent('session-1', 'run-1', partialTextEvent());
+      store.close();
+
+      const db = new DatabaseSync(dbPath);
+      db.prepare('UPDATE runtime_partial_snapshots SET payload_json = ?').run('{broken json');
+      db.close();
+
+      const reopened = createSqliteRuntimeStore(dbPath);
+      try {
+        assert.deepEqual(await reopened.readRuntimeEvents('session-1', 'run-1'), [userEvent()]);
+      } finally {
+        reopened.close();
+      }
+    });
+  });
+
+  it('skips a mutable partial whose SQL identity disagrees with its payload', async () => {
+    await withStore(async (store, dbPath) => {
+      await store.appendRuntimeEvent('session-1', 'run-1', userEvent());
+      await store.appendRuntimeEvent('session-1', 'run-1', partialTextEvent());
+      store.close();
+
+      const db = new DatabaseSync(dbPath);
+      db.prepare(`UPDATE runtime_partial_snapshots SET invocation_id = 'invocation-other'`).run();
+      db.close();
+
+      const reopened = createSqliteRuntimeStore(dbPath);
+      try {
+        assert.deepEqual(await reopened.readRuntimeEvents('session-1', 'run-1'), [userEvent()]);
+      } finally {
+        reopened.close();
+      }
+    });
+  });
+});
+
+type Store = ReturnType<typeof createSqliteRuntimeStore>;
+
+async function withStore(run: (store: Store, dbPath: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-recovery-authority-'));
+  const dbPath = join(root, 'runtime.sqlite');
+  const store = createSqliteRuntimeStore(dbPath);
+  try {
+    await run(store, dbPath);
+  } finally {
+    store.close();
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function prepare(store: Store): Promise<void> {
+  await store.commitToolPrepared({
+    operationId: 'operation-1',
+    journalEventId: 'operation-1_prepared',
+    runtimeEvent: callEvent(),
+    dispatchRuntimeEvent: dispatchEvent(),
+    providerToolCallId: 'provider-call-1',
+    toolName: 'Write',
+    canonicalArgsHash: ARGS_HASH,
+    recoveryMode: 'reconcile',
+    committedAt: 10,
+  });
+}
+
+function baseEvent(overrides: Partial<RuntimeEvent>): RuntimeEvent {
+  return {
+    id: 'event-1',
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 1,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}
+
+function userEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'user-event-1',
+    role: 'user',
+    author: 'user',
+    content: { kind: 'text', text: 'write it' },
+  });
+}
+
+function partialTextEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'partial-event-1',
+    ts: 2,
+    partial: true,
+    role: 'model',
+    author: 'agent',
+    content: { kind: 'text', text: 'in progress' },
+    refs: { providerEventId: 'provider-text-1' },
+  });
+}
+
+function callEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'call-event-1',
+    role: 'model',
+    author: 'agent',
+    content: {
+      kind: 'function_call',
+      id: 'provider-call-1',
+      name: 'Write',
+      args: { path: 'notes.txt', content: 'after' },
+    },
+  });
+}
+
+function dispatchEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'dispatch-event-1',
+    actions: {
+      toolDispatch: {
+        protocol: 't1_after_preflight_v1',
+        operationId: 'operation-1',
+        providerToolCallId: 'provider-call-1',
+        toolName: 'Write',
+        canonicalArgsHash: ARGS_HASH,
+        recoveryMode: 'reconcile',
+      },
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  });
+}
+
+function reconcileEvent(
+  observation:
+    | 'matches_expected_state'
+    | 'matches_prior_state'
+    | 'diverged'
+    | 'unreadable' = 'matches_expected_state',
+): RuntimeEvent {
+  return baseEvent({
+    id: 'reconcile-event-1',
+    ts: 2,
+    actions: {
+      toolRecovery: {
+        kind: 'maka.tool.reconcile_result',
+        version: 1,
+        payload: {
+          protocol: 'tool_reconcile_v1',
+          operationId: 'operation-1',
+          observation,
+          observationSchema: 'state_identity_v1',
+          observationDigest: OBSERVATION_DIGEST,
+        },
+      },
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  });
+}
+
+function outcomeEvent(): RuntimeEvent {
+  return baseEvent({
+    id: 'outcome-event-1',
+    ts: 3,
+    role: 'tool',
+    author: 'tool',
+    content: {
+      kind: 'function_response',
+      id: 'provider-call-1',
+      name: 'Write',
+      result: 'ok',
+      isError: false,
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  });
+}
+
+function decisionEvent(disposition: 'completed' | 'parked' = 'completed'): RuntimeEvent {
+  return baseEvent({
+    id: 'decision-event-1',
+    ts: 4,
+    actions: {
+      toolRecovery:
+        disposition === 'completed'
+          ? {
+              kind: 'maka.tool.recovery_decision',
+              version: 1,
+              payload: {
+                protocol: 'tool_recovery_v1',
+                operationId: 'operation-1',
+                disposition: 'completed',
+                reasonCode: 'reconcile_matches_expected_state',
+                outcomeEventId: 'outcome-event-1',
+                evidenceEventIds: [
+                  'call-event-1',
+                  'dispatch-event-1',
+                  'reconcile-event-1',
+                  'outcome-event-1',
+                ],
+              },
+            }
+          : {
+              kind: 'maka.tool.recovery_decision',
+              version: 1,
+              payload: {
+                protocol: 'tool_recovery_v1',
+                operationId: 'operation-1',
+                disposition: 'parked',
+                reasonCode: 'reconcile_diverged',
+                evidenceEventIds: ['call-event-1', 'dispatch-event-1', 'reconcile-event-1'],
+              },
+            },
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  });
+}

--- a/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
+++ b/packages/storage/src/__tests__/recovery-persistence-authority.test.ts
@@ -16,10 +16,112 @@ const ARGS_HASH = canonicalToolArgsHash('Write', {
   path: 'notes.txt',
   content: 'after',
 });
+// Mainline schema 4 persisted stableHash({ toolName, args }) for this exact
+// provider call. Keep the literal independent from the current hash helper so
+// an accidental identity-epoch change remains observable during migration.
+const MAINLINE_SCHEMA_4_READ_ARGS_HASH =
+  'sha256:5949a5bf23e5928b160ea0444cd16391f47365c3cd8b6d33a7381d585baf1db2';
 const OBSERVATION_DIGEST =
   'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' as const;
 
 describe('SQLite recovery persistence authority', () => {
+  it('rebuilds a real schema 4 T1 dispatch written with the mainline args identity', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-recovery-mainline-t1-upgrade-'));
+    const dbPath = join(root, 'runtime.sqlite');
+    const store = createSqliteRuntimeStore(dbPath);
+    store.close();
+
+    const call = baseEvent({
+      id: 'schema-4-call',
+      role: 'model',
+      author: 'agent',
+      content: {
+        kind: 'function_call',
+        id: 'schema-4-provider-call',
+        name: 'Read',
+        args: { path: 'prepared.txt' },
+      },
+    });
+    const dispatch = baseEvent({
+      id: 'schema-4-dispatch',
+      ts: 2,
+      actions: {
+        toolDispatch: {
+          protocol: 't1_after_preflight_v1',
+          operationId: 'schema-4-operation',
+          providerToolCallId: 'schema-4-provider-call',
+          toolName: 'Read',
+          canonicalArgsHash: MAINLINE_SCHEMA_4_READ_ARGS_HASH,
+          recoveryMode: 'replay_safe',
+        },
+      },
+      refs: {
+        operationId: 'schema-4-operation',
+        toolCallId: 'schema-4-provider-call',
+      },
+    });
+
+    const db = new DatabaseSync(dbPath);
+    const insertEvent = db.prepare(`
+      INSERT INTO runtime_events(
+        event_id, session_id, invocation_id, run_id, turn_id,
+        event_seq, event_kind, payload_json, committed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    insertEvent.run(
+      call.id,
+      call.sessionId,
+      call.invocationId,
+      call.runId,
+      call.turnId,
+      1,
+      'function_call',
+      JSON.stringify(call),
+      call.ts,
+    );
+    insertEvent.run(
+      dispatch.id,
+      dispatch.sessionId,
+      dispatch.invocationId,
+      dispatch.runId,
+      dispatch.turnId,
+      2,
+      'tool_dispatch',
+      JSON.stringify(dispatch),
+      dispatch.ts,
+    );
+    db.exec('DROP TABLE runtime_capabilities; PRAGMA user_version = 4;');
+    db.close();
+
+    try {
+      const upgraded = createSqliteRuntimeStore(dbPath);
+      try {
+        assert.deepEqual(await upgraded.rebuildToolProjectionsFromRuntimeEvents(), {
+          operations: 1,
+          journalEvents: 1,
+        });
+        assert.deepEqual(await upgraded.readToolOperation('schema-4-operation'), {
+          operationId: 'schema-4-operation',
+          invocationId: 'invocation-1',
+          runId: 'run-1',
+          turnId: 'turn-1',
+          providerToolCallId: 'schema-4-provider-call',
+          toolName: 'Read',
+          canonicalArgsHash: MAINLINE_SCHEMA_4_READ_ARGS_HASH,
+          recoveryMode: 'replay_safe',
+          currentState: 'prepared',
+          callEventId: 'schema-4-call',
+          dispatchEventId: 'schema-4-dispatch',
+          version: 1,
+        });
+      } finally {
+        upgraded.close();
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('upgrades and quarantines populated mainline schema 4 tool projections', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-recovery-mainline-upgrade-'));
     const dbPath = join(root, 'runtime.sqlite');

--- a/packages/storage/src/__tests__/runtime-event-transfer.test.ts
+++ b/packages/storage/src/__tests__/runtime-event-transfer.test.ts
@@ -3,8 +3,8 @@ import { appendFile, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
-import type { RuntimeEvent } from '@maka/core';
-import { createRuntimeEventStore } from '../agent-run-store.js';
+import type { AgentRunHeader, RuntimeEvent } from '@maka/core';
+import { createAgentRunStore, createRuntimeEventStore } from '../agent-run-store.js';
 import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
 import {
   exportRuntimeEventsToJsonl,
@@ -19,6 +19,9 @@ describe('runtime event JSONL compatibility transfer', () => {
     const legacy = createRuntimeEventStore(root);
     const sqlite = createSqliteRuntimeStore(join(root, 'runtime.sqlite'));
     try {
+      const runs = createAgentRunStore(root);
+      await runs.createRun(runHeader());
+      await runs.createRun(runHeader({ runId: 'run-2', invocationId: 'run-2', turnId: 'turn-2' }));
       await legacy.appendRuntimeEvent('session-1', 'run-1', runtimeEvent('event-1'));
       await legacy.appendRuntimeEvent('session-1', 'run-1', runtimeEvent('event-2', { ts: 2 }));
       await legacy.appendRuntimeEvent(
@@ -68,6 +71,7 @@ describe('runtime event JSONL compatibility transfer', () => {
     const legacy = createRuntimeEventStore(root);
     const sqlite = createSqliteRuntimeStore(join(root, 'runtime.sqlite'));
     try {
+      await createAgentRunStore(root).createRun(runHeader());
       await legacy.appendRuntimeEvent('session-1', 'run-1', runtimeEvent('event-1'));
       await legacy.appendRuntimeEvent('session-1', 'run-1', runtimeEvent('event-2', { ts: 2 }));
       // Older versions wrote stream partial snapshots straight into the JSONL
@@ -186,6 +190,7 @@ describe('runtime event JSONL compatibility transfer', () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-runtime-persistence-'));
     const legacy = createRuntimeEventStore(root);
     try {
+      await createAgentRunStore(root).createRun(runHeader());
       await legacy.appendRuntimeEvent('session-1', 'run-1', runtimeEvent('event-1'));
 
       const opened = await openRuntimeEventPersistence({
@@ -253,6 +258,24 @@ function runtimeEvent(id: string, overrides: Partial<RuntimeEvent> = {}): Runtim
     role: 'user',
     author: 'user',
     content: { kind: 'text', text: id },
+    ...overrides,
+  };
+}
+
+function runHeader(overrides: Partial<AgentRunHeader> = {}): AgentRunHeader {
+  return {
+    runId: 'run-1',
+    invocationId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    status: 'created',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/workspace',
+    permissionMode: 'ask',
+    createdAt: 1,
+    updatedAt: 1,
     ...overrides,
   };
 }

--- a/packages/storage/src/__tests__/sqlite-recovery-concurrency.test.ts
+++ b/packages/storage/src/__tests__/sqlite-recovery-concurrency.test.ts
@@ -4,6 +4,7 @@ import { writeFile } from 'node:fs/promises';
 import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
 import { canonicalToolArgsHash, scanToolLedger, type RuntimeEvent } from '@maka/core';
@@ -102,6 +103,30 @@ describe('SQLite recovery authority multi-process races', () => {
         results.map(({ code }) => code),
         [0, 0],
       );
+    });
+  });
+
+  it('serializes concurrent schema 4 to 5 upgrades', async () => {
+    await withPreparedDatabase(async ({ dbPath, startPath }) => {
+      const db = new DatabaseSync(dbPath);
+      try {
+        db.exec('DROP TABLE runtime_capabilities; PRAGMA user_version = 4;');
+      } finally {
+        db.close();
+      }
+
+      const results = await runOpenWorkers(dbPath, startPath);
+      assert.deepEqual(
+        results.map(({ code }) => code),
+        [0, 0],
+      );
+
+      const upgraded = createSqliteRuntimeStore(dbPath);
+      try {
+        assert.equal(upgraded.schemaVersion(), 5);
+      } finally {
+        upgraded.close();
+      }
     });
   });
 

--- a/packages/storage/src/__tests__/sqlite-recovery-concurrency.test.ts
+++ b/packages/storage/src/__tests__/sqlite-recovery-concurrency.test.ts
@@ -1,0 +1,208 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { writeFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, it } from 'node:test';
+import { fileURLToPath } from 'node:url';
+import { canonicalToolArgsHash, scanToolLedger, type RuntimeEvent } from '@maka/core';
+import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
+
+describe('SQLite recovery authority multi-process races', () => {
+  it('makes an exact concurrent recovery bundle idempotent', async () => {
+    await withPreparedDatabase(async ({ dbPath, startPath }) => {
+      const results = await runWorkers(dbPath, startPath, ['completed', 'completed']);
+      assert.deepEqual(
+        results.map(({ code }) => code),
+        [0, 0],
+      );
+
+      const store = createSqliteRuntimeStore(dbPath);
+      try {
+        assert.equal(
+          (await store.readToolOperation('operation-1'))?.currentState,
+          'recovery_completed',
+        );
+        assert.equal((await store.readImmutableRuntimeEvents('session-1', 'run-1')).length, 5);
+      } finally {
+        store.close();
+      }
+    });
+  });
+
+  it('serializes conflicting completed and parked bundles to one terminal decision', async () => {
+    await withPreparedDatabase(async ({ dbPath, startPath }) => {
+      const results = await runWorkers(dbPath, startPath, ['completed', 'parked']);
+      assert.deepEqual(results.map(({ code }) => code).sort(), [0, 2]);
+
+      const store = createSqliteRuntimeStore(dbPath);
+      try {
+        const operation = await store.readToolOperation('operation-1');
+        assert.ok(
+          operation?.currentState === 'recovery_completed' ||
+            operation?.currentState === 'recovery_parked',
+        );
+        const events = await store.readImmutableRuntimeEvents('session-1', 'run-1');
+        assert.equal(scanToolLedger(events).hasCorruption, false);
+      } finally {
+        store.close();
+      }
+    });
+  });
+
+  it('serializes projection rebuild against recovery commit', async () => {
+    await withPreparedDatabase(async ({ dbPath, startPath }) => {
+      const results = await runWorkers(dbPath, startPath, ['completed', 'rebuild']);
+      assert.deepEqual(
+        results.map(({ code }) => code),
+        [0, 0],
+      );
+
+      const store = createSqliteRuntimeStore(dbPath);
+      try {
+        assert.equal(
+          (await store.readToolOperation('operation-1'))?.currentState,
+          'recovery_completed',
+        );
+        assert.equal(
+          scanToolLedger(await store.readImmutableRuntimeEvents('session-1', 'run-1'))
+            .hasCorruption,
+          false,
+        );
+      } finally {
+        store.close();
+      }
+    });
+  });
+});
+
+async function withPreparedDatabase(
+  run: (input: { dbPath: string; startPath: string }) => Promise<void>,
+): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-recovery-race-'));
+  const dbPath = join(root, 'runtime.sqlite');
+  const startPath = join(root, 'start');
+  const store = createSqliteRuntimeStore(dbPath);
+  try {
+    await store.commitToolPrepared(preparedCommit());
+    store.close();
+    await run({ dbPath, startPath });
+  } finally {
+    store.close();
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function runWorkers(
+  dbPath: string,
+  startPath: string,
+  modes: readonly string[],
+): Promise<Array<{ code: number | null; stdout: string; stderr: string }>> {
+  const workers = modes.map((mode) => {
+    const child = spawn(
+      process.execPath,
+      [fileURLToPath(new URL('./fixtures/sqlite-recovery-concurrency-child.js', import.meta.url))],
+      {
+        env: {
+          ...process.env,
+          MAKA_SQLITE_RECOVERY_CONCURRENCY_MODE: mode,
+          MAKA_SQLITE_RECOVERY_CONCURRENCY_DB: dbPath,
+          MAKA_SQLITE_RECOVERY_CONCURRENCY_START: startPath,
+        },
+        stdio: ['ignore', 'pipe', 'pipe'],
+      },
+    );
+    return { child, ready: waitForReady(child) };
+  });
+  await Promise.all(workers.map(({ ready }) => ready));
+  await writeFile(startPath, 'go');
+  return Promise.all(
+    workers.map(
+      ({ child }) =>
+        new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
+          let stdout = '';
+          let stderr = '';
+          child.stdout?.on('data', (chunk) => {
+            stdout += String(chunk);
+          });
+          child.stderr?.on('data', (chunk) => {
+            stderr += String(chunk);
+          });
+          child.once('error', reject);
+          child.once('exit', (code) => resolve({ code, stdout, stderr }));
+        }),
+    ),
+  );
+}
+
+function waitForReady(child: ReturnType<typeof spawn>): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (chunk) => {
+      stdout += String(chunk);
+      if (stdout.includes('READY\n')) resolve();
+    });
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk);
+    });
+    child.once('exit', (code) => {
+      reject(new Error(`worker exited before READY: ${code} ${stderr}`));
+    });
+    child.once('error', reject);
+  });
+}
+
+function preparedCommit() {
+  const args = { path: 'notes.txt', content: 'after' };
+  const hash = canonicalToolArgsHash('Write', args);
+  return {
+    operationId: 'operation-1',
+    journalEventId: 'operation-1_prepared',
+    runtimeEvent: {
+      ...baseEvent('call-event-1', 1),
+      role: 'model' as const,
+      author: 'agent' as const,
+      content: {
+        kind: 'function_call' as const,
+        id: 'provider-call-1',
+        name: 'Write',
+        args,
+      },
+    },
+    dispatchRuntimeEvent: {
+      ...baseEvent('dispatch-event-1', 2),
+      actions: {
+        toolDispatch: {
+          protocol: 't1_after_preflight_v1' as const,
+          operationId: 'operation-1',
+          providerToolCallId: 'provider-call-1',
+          toolName: 'Write',
+          canonicalArgsHash: hash,
+          recoveryMode: 'reconcile' as const,
+        },
+      },
+      refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+    },
+    providerToolCallId: 'provider-call-1',
+    toolName: 'Write',
+    canonicalArgsHash: hash,
+    recoveryMode: 'reconcile' as const,
+    committedAt: 2,
+  };
+}
+
+function baseEvent(id: string, ts: number): RuntimeEvent {
+  return {
+    id,
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts,
+    partial: false,
+    role: 'system',
+    author: 'system',
+  };
+}

--- a/packages/storage/src/__tests__/sqlite-recovery-concurrency.test.ts
+++ b/packages/storage/src/__tests__/sqlite-recovery-concurrency.test.ts
@@ -9,6 +9,25 @@ import { fileURLToPath } from 'node:url';
 import { canonicalToolArgsHash, scanToolLedger, type RuntimeEvent } from '@maka/core';
 import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
 
+const WORKER_READY_TIMEOUT_MS = 15_000;
+const WORKER_EXECUTION_TIMEOUT_MS = 30_000;
+const WORKER_SHUTDOWN_TIMEOUT_MS = 5_000;
+
+interface WorkerResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+interface WorkerHandle {
+  mode: string;
+  child: ReturnType<typeof spawn>;
+  ready: Promise<void>;
+  opened: Promise<void>;
+  result: Promise<WorkerResult>;
+  output(): Pick<WorkerResult, 'stdout' | 'stderr'>;
+}
+
 describe('SQLite recovery authority multi-process races', () => {
   it('makes an exact concurrent recovery bundle idempotent', async () => {
     await withPreparedDatabase(async ({ dbPath, startPath }) => {
@@ -75,6 +94,27 @@ describe('SQLite recovery authority multi-process races', () => {
       }
     });
   });
+
+  it('allows concurrent processes to keep the same initialized WAL database open', async () => {
+    await withPreparedDatabase(async ({ dbPath, startPath }) => {
+      const results = await runOpenWorkers(dbPath, startPath);
+      assert.deepEqual(
+        results.map(({ code }) => code),
+        [0, 0],
+      );
+    });
+  });
+
+  it('captures a fast worker initialization failure after releasing the barrier', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-recovery-race-invalid-db-'));
+    try {
+      const results = await runWorkers(root, join(root, 'start'), ['completed']);
+      assert.equal(results[0]?.code, 2);
+      assert.match(results[0]?.stderr ?? '', /RESULT error/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
 });
 
 async function withPreparedDatabase(
@@ -98,60 +138,184 @@ async function runWorkers(
   dbPath: string,
   startPath: string,
   modes: readonly string[],
-): Promise<Array<{ code: number | null; stdout: string; stderr: string }>> {
-  const workers = modes.map((mode) => {
-    const child = spawn(
-      process.execPath,
-      [fileURLToPath(new URL('./fixtures/sqlite-recovery-concurrency-child.js', import.meta.url))],
-      {
-        env: {
-          ...process.env,
-          MAKA_SQLITE_RECOVERY_CONCURRENCY_MODE: mode,
-          MAKA_SQLITE_RECOVERY_CONCURRENCY_DB: dbPath,
-          MAKA_SQLITE_RECOVERY_CONCURRENCY_START: startPath,
-        },
-        stdio: ['ignore', 'pipe', 'pipe'],
-      },
+): Promise<WorkerResult[]> {
+  const workers = modes.map((mode) => startWorker(dbPath, startPath, mode));
+  try {
+    await withTimeout(
+      Promise.all(workers.map(({ ready }) => ready)),
+      WORKER_READY_TIMEOUT_MS,
+      'workers to reach the start barrier',
     );
-    return { child, ready: waitForReady(child) };
-  });
-  await Promise.all(workers.map(({ ready }) => ready));
-  await writeFile(startPath, 'go');
-  return Promise.all(
-    workers.map(
-      ({ child }) =>
-        new Promise<{ code: number | null; stdout: string; stderr: string }>((resolve, reject) => {
-          let stdout = '';
-          let stderr = '';
-          child.stdout?.on('data', (chunk) => {
-            stdout += String(chunk);
-          });
-          child.stderr?.on('data', (chunk) => {
-            stderr += String(chunk);
-          });
-          child.once('error', reject);
-          child.once('exit', (code) => resolve({ code, stdout, stderr }));
-        }),
-    ),
-  );
+    await writeFile(startPath, 'go');
+    return await withTimeout(
+      Promise.all(workers.map(({ result }) => result)),
+      WORKER_EXECUTION_TIMEOUT_MS,
+      'workers to finish their SQLite operations',
+    );
+  } catch (error) {
+    await stopWorkers(workers);
+    const diagnostics = workers.map(formatWorkerDiagnostics).join('\n');
+    throw new Error(`${error instanceof Error ? error.message : String(error)}\n${diagnostics}`);
+  }
 }
 
-function waitForReady(child: ReturnType<typeof spawn>): Promise<void> {
-  return new Promise((resolve, reject) => {
-    let stdout = '';
-    let stderr = '';
-    child.stdout?.on('data', (chunk) => {
-      stdout += String(chunk);
-      if (stdout.includes('READY\n')) resolve();
-    });
-    child.stderr?.on('data', (chunk) => {
-      stderr += String(chunk);
-    });
-    child.once('exit', (code) => {
-      reject(new Error(`worker exited before READY: ${code} ${stderr}`));
-    });
-    child.once('error', reject);
+async function runOpenWorkers(dbPath: string, startPath: string): Promise<WorkerResult[]> {
+  const stopPath = `${startPath}.stop`;
+  const workers = ['open_only', 'open_only'].map((mode) =>
+    startWorker(dbPath, startPath, mode, stopPath),
+  );
+  try {
+    await withTimeout(
+      Promise.all(workers.map(({ ready }) => ready)),
+      WORKER_READY_TIMEOUT_MS,
+      'workers to reach the concurrent-open start barrier',
+    );
+    await writeFile(startPath, 'go');
+    await withTimeout(
+      Promise.all(workers.map(({ opened }) => opened)),
+      WORKER_READY_TIMEOUT_MS,
+      'workers to open the same SQLite database',
+    );
+    await writeFile(stopPath, 'close');
+    return await withTimeout(
+      Promise.all(workers.map(({ result }) => result)),
+      WORKER_EXECUTION_TIMEOUT_MS,
+      'concurrent-open workers to close',
+    );
+  } catch (error) {
+    await stopWorkers(workers);
+    const diagnostics = workers.map(formatWorkerDiagnostics).join('\n');
+    throw new Error(`${error instanceof Error ? error.message : String(error)}\n${diagnostics}`);
+  }
+}
+
+function startWorker(
+  dbPath: string,
+  startPath: string,
+  mode: string,
+  stopPath?: string,
+): WorkerHandle {
+  const child = spawn(
+    process.execPath,
+    [fileURLToPath(new URL('./fixtures/sqlite-recovery-concurrency-child.js', import.meta.url))],
+    {
+      env: {
+        ...process.env,
+        MAKA_SQLITE_RECOVERY_CONCURRENCY_MODE: mode,
+        MAKA_SQLITE_RECOVERY_CONCURRENCY_DB: dbPath,
+        MAKA_SQLITE_RECOVERY_CONCURRENCY_START: startPath,
+        ...(stopPath ? { MAKA_SQLITE_RECOVERY_CONCURRENCY_STOP: stopPath } : {}),
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    },
+  );
+  let stdout = '';
+  let stderr = '';
+  let readySeen = false;
+  let openedSeen = false;
+  let resolveReady!: () => void;
+  let rejectReady!: (error: Error) => void;
+  let resolveOpened!: () => void;
+  let rejectOpened!: (error: Error) => void;
+  const ready = new Promise<void>((resolve, reject) => {
+    resolveReady = resolve;
+    rejectReady = reject;
   });
+  const opened = new Promise<void>((resolve, reject) => {
+    resolveOpened = resolve;
+    rejectOpened = reject;
+  });
+  const result = new Promise<WorkerResult>((resolve, reject) => {
+    child.once('error', (error) => {
+      rejectReady(error);
+      rejectOpened(error);
+      reject(error);
+    });
+    child.once('close', (code) => {
+      if (!readySeen) {
+        rejectReady(new Error(`worker ${mode} exited before READY: ${code} ${stderr}`));
+      }
+      if (!openedSeen) {
+        rejectOpened(new Error(`worker ${mode} exited before OPENED: ${code} ${stderr}`));
+      }
+      resolve({ code, stdout, stderr });
+    });
+  });
+  // A worker can fail before the coordinator reaches the phase that awaits one
+  // of these promises. Attach handlers immediately so the diagnostic path, not
+  // the process-level unhandled-rejection policy, owns the failure.
+  void opened.catch(() => {});
+  void result.catch(() => {});
+  child.stdout?.on('data', (chunk) => {
+    stdout += String(chunk);
+    if (!readySeen && stdout.includes('READY\n')) {
+      readySeen = true;
+      resolveReady();
+    }
+    if (!openedSeen && stdout.includes('OPENED\n')) {
+      openedSeen = true;
+      resolveOpened();
+    }
+  });
+  child.stderr?.on('data', (chunk) => {
+    stderr += String(chunk);
+  });
+  return {
+    mode,
+    child,
+    ready,
+    opened,
+    result,
+    output: () => ({ stdout, stderr }),
+  };
+}
+
+async function stopWorkers(workers: readonly WorkerHandle[]): Promise<void> {
+  for (const { child } of workers) {
+    if (child.exitCode === null && child.signalCode === null) {
+      child.kill('SIGKILL');
+    }
+  }
+  await Promise.race([
+    Promise.allSettled(workers.map(({ result }) => result)),
+    new Promise<void>((resolve) => setTimeout(resolve, WORKER_SHUTDOWN_TIMEOUT_MS)),
+  ]);
+}
+
+function formatWorkerDiagnostics(worker: WorkerHandle): string {
+  const { stdout, stderr } = worker.output();
+  const state =
+    worker.child.exitCode !== null
+      ? `exit=${worker.child.exitCode}`
+      : worker.child.signalCode !== null
+        ? `signal=${worker.child.signalCode}`
+        : 'still-running';
+  return [
+    `worker mode=${worker.mode} pid=${worker.child.pid ?? 'unknown'} ${state}`,
+    `stdout=${JSON.stringify(stdout)}`,
+    `stderr=${JSON.stringify(stderr)}`,
+  ].join('\n');
+}
+
+async function withTimeout<T>(
+  promise: Promise<T>,
+  timeoutMs: number,
+  description: string,
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Timed out after ${timeoutMs}ms waiting for ${description}`)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer !== undefined) clearTimeout(timer);
+  }
 }
 
 function preparedCommit() {

--- a/packages/storage/src/__tests__/sqlite-runtime-crash.test.ts
+++ b/packages/storage/src/__tests__/sqlite-runtime-crash.test.ts
@@ -12,6 +12,9 @@ import {
   type SqliteRuntimeStoreFailpoint,
 } from '../sqlite-runtime-store.js';
 
+const CRASH_READ_ARGS_HASH = canonicalToolArgsHash('Read', {
+  path: '/workspace/README.md',
+});
 const childMode = process.env.MAKA_SQLITE_CRASH_CHILD;
 
 if (childMode) {
@@ -300,10 +303,6 @@ function functionResponseEvent(): RuntimeEvent {
     refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
   };
 }
-
-const CRASH_READ_ARGS_HASH = canonicalToolArgsHash('Read', {
-  path: '/workspace/README.md',
-});
 
 function recoveryCommit() {
   return {

--- a/packages/storage/src/__tests__/sqlite-runtime-crash.test.ts
+++ b/packages/storage/src/__tests__/sqlite-runtime-crash.test.ts
@@ -66,6 +66,45 @@ if (childMode) {
         assert.deepEqual(await store.listUnsettledToolOperations(), []);
       });
     });
+
+    for (const mode of [
+      'inside_recovery_reconcile',
+      'inside_recovery_outcome',
+      'inside_recovery_decision',
+    ]) {
+      it(`rolls back the whole recovery bundle when killed at ${mode}`, {
+        timeout: 30_000,
+      }, async () => {
+        await withKilledChild(mode, async (store) => {
+          assert.deepEqual(
+            (await store.readRuntimeEvents('session-1', 'run-1')).map((event) => event.id),
+            ['call-event-1', 'dispatch-event-1'],
+          );
+          assert.equal((await store.readToolOperation('operation-1'))?.currentState, 'prepared');
+        });
+      });
+    }
+
+    it('retains the whole recovery bundle when killed after COMMIT', {
+      timeout: 30_000,
+    }, async () => {
+      await withKilledChild('after_recovery_commit', async (store) => {
+        assert.deepEqual(
+          (await store.readRuntimeEvents('session-1', 'run-1')).map((event) => event.id),
+          [
+            'call-event-1',
+            'dispatch-event-1',
+            'reconcile-event-1',
+            'response-event-1',
+            'decision-event-1',
+          ],
+        );
+        assert.equal(
+          (await store.readToolOperation('operation-1'))?.currentState,
+          'recovery_completed',
+        );
+      });
+    });
   });
 }
 
@@ -130,16 +169,31 @@ async function runCrashChild(mode: string): Promise<void> {
   const markerPath = requiredEnv('MAKA_SQLITE_CRASH_MARKER');
   let runtimeInsertCount = 0;
   const failpoint = (point: SqliteRuntimeStoreFailpoint) => {
-    if (point !== 'after_runtime_event_insert') return;
-    runtimeInsertCount += 1;
-    if (mode === 'inside_t1' && runtimeInsertCount === 1) blockUntilKilled();
-    if (mode === 'inside_t2' && runtimeInsertCount === 2) blockUntilKilled();
+    if (point === 'after_runtime_event_insert') {
+      runtimeInsertCount += 1;
+      if (mode === 'inside_t1' && runtimeInsertCount === 1) blockUntilKilled();
+      if (mode === 'inside_t2' && runtimeInsertCount === 2) blockUntilKilled();
+    }
+    if (point === 'after_recovery_reconcile' && mode === 'inside_recovery_reconcile') {
+      blockUntilKilled();
+    }
+    if (point === 'after_recovery_outcome' && mode === 'inside_recovery_outcome') {
+      blockUntilKilled();
+    }
+    if (point === 'after_recovery_decision' && mode === 'inside_recovery_decision') {
+      blockUntilKilled();
+    }
   };
   const store = createSqliteRuntimeStore(dbPath, { failpoint });
   await store.commitToolPrepared(preparedCommit());
   if (mode === 'after_effect') {
     writeFileSync(markerPath, 'effect-happened');
     blockUntilKilled();
+  }
+  if (mode.startsWith('inside_recovery_') || mode === 'after_recovery_commit') {
+    await store.commitToolRecoveryBundle(recoveryCommit());
+    if (mode === 'after_recovery_commit') blockUntilKilled();
+    throw new Error(`Recovery crash mode ${mode} missed its failpoint`);
   }
   await store.commitToolOutcome(outcomeCommit());
   if (mode === 'after_t2') blockUntilKilled();
@@ -161,13 +215,13 @@ function requiredEnv(name: string): string {
 function preparedCommit() {
   return {
     operationId: 'operation-1',
-    journalEventId: 'journal-prepared-1',
+    journalEventId: 'operation-1_prepared',
     runtimeEvent: functionCallEvent(),
     dispatchRuntimeEvent: toolDispatchEvent(),
     providerToolCallId: 'provider-call-1',
     toolName: 'Read',
     canonicalArgsHash: CRASH_READ_ARGS_HASH,
-    recoveryMode: 'replay_safe' as const,
+    recoveryMode: 'reconcile' as const,
     committedAt: 1,
   };
 }
@@ -175,7 +229,7 @@ function preparedCommit() {
 function outcomeCommit() {
   return {
     operationId: 'operation-1',
-    journalEventId: 'journal-outcome-1',
+    journalEventId: 'operation-1_outcome',
     runtimeEvent: functionResponseEvent(),
     committedAt: 2,
   };
@@ -199,7 +253,7 @@ function toolDispatchEvent(): RuntimeEvent {
         providerToolCallId: 'provider-call-1',
         toolName: 'Read',
         canonicalArgsHash: CRASH_READ_ARGS_HASH,
-        recoveryMode: 'replay_safe',
+        recoveryMode: 'reconcile',
       },
     },
     refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
@@ -250,3 +304,75 @@ function functionResponseEvent(): RuntimeEvent {
 const CRASH_READ_ARGS_HASH = canonicalToolArgsHash('Read', {
   path: '/workspace/README.md',
 });
+
+function recoveryCommit() {
+  return {
+    operationId: 'operation-1',
+    reconcileRuntimeEvent: reconcileEvent(),
+    outcomeRuntimeEvent: functionResponseEvent(),
+    decisionRuntimeEvent: decisionEvent(),
+  };
+}
+
+function reconcileEvent(): RuntimeEvent {
+  return {
+    id: 'reconcile-event-1',
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 2,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    actions: {
+      toolRecovery: {
+        kind: 'maka.tool.reconcile_result',
+        version: 1,
+        payload: {
+          protocol: 'tool_reconcile_v1',
+          operationId: 'operation-1',
+          observation: 'matches_expected_state',
+          observationSchema: 'state_identity_v1',
+          observationDigest:
+            'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+        },
+      },
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  };
+}
+
+function decisionEvent(): RuntimeEvent {
+  return {
+    id: 'decision-event-1',
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts: 3,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    actions: {
+      toolRecovery: {
+        kind: 'maka.tool.recovery_decision',
+        version: 1,
+        payload: {
+          protocol: 'tool_recovery_v1',
+          operationId: 'operation-1',
+          disposition: 'completed',
+          reasonCode: 'reconcile_matches_expected_state',
+          outcomeEventId: 'response-event-1',
+          evidenceEventIds: [
+            'call-event-1',
+            'dispatch-event-1',
+            'reconcile-event-1',
+            'response-event-1',
+          ],
+        },
+      },
+    },
+    refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
+  };
+}

--- a/packages/storage/src/__tests__/sqlite-runtime-crash.test.ts
+++ b/packages/storage/src/__tests__/sqlite-runtime-crash.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
 import { fileURLToPath } from 'node:url';
-import type { RuntimeEvent } from '@maka/core';
+import { canonicalToolArgsHash, type RuntimeEvent } from '@maka/core';
 import {
   createSqliteRuntimeStore,
   type SqliteRuntimeStoreFailpoint,
@@ -166,7 +166,7 @@ function preparedCommit() {
     dispatchRuntimeEvent: toolDispatchEvent(),
     providerToolCallId: 'provider-call-1',
     toolName: 'Read',
-    canonicalArgsHash: 'sha256:args-1',
+    canonicalArgsHash: CRASH_READ_ARGS_HASH,
     recoveryMode: 'replay_safe' as const,
     committedAt: 1,
   };
@@ -198,7 +198,7 @@ function toolDispatchEvent(): RuntimeEvent {
         operationId: 'operation-1',
         providerToolCallId: 'provider-call-1',
         toolName: 'Read',
-        canonicalArgsHash: 'sha256:args-1',
+        canonicalArgsHash: CRASH_READ_ARGS_HASH,
         recoveryMode: 'replay_safe',
       },
     },
@@ -246,3 +246,7 @@ function functionResponseEvent(): RuntimeEvent {
     refs: { operationId: 'operation-1', toolCallId: 'provider-call-1' },
   };
 }
+
+const CRASH_READ_ARGS_HASH = canonicalToolArgsHash('Read', {
+  path: '/workspace/README.md',
+});

--- a/packages/storage/src/__tests__/sqlite-runtime-schema.test.ts
+++ b/packages/storage/src/__tests__/sqlite-runtime-schema.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { DatabaseSync } from 'node:sqlite';
+import { describe, it } from 'node:test';
+import { migrateSqliteRuntimeDatabase } from '../sqlite-runtime-schema.js';
+
+describe('SQLite runtime schema migration', () => {
+  it('re-reads user_version under the write lock before applying migrations', () => {
+    const real = new DatabaseSync(':memory:');
+    let migrationLocked = false;
+    let lockedVersionRead = false;
+    const db = new Proxy(real, {
+      get(target, property) {
+        if (property === 'exec') {
+          return (sql: string) => {
+            const statement = sql.trim().toUpperCase();
+            if (statement === 'BEGIN IMMEDIATE') migrationLocked = true;
+            if (statement.includes('CREATE TABLE RUNTIME_EVENTS')) {
+              assert.equal(
+                lockedVersionRead,
+                true,
+                'pending migrations require a fresh user_version read under the write lock',
+              );
+            }
+            try {
+              return target.exec(sql);
+            } finally {
+              if (statement === 'COMMIT' || statement === 'ROLLBACK') {
+                migrationLocked = false;
+              }
+            }
+          };
+        }
+        if (property === 'prepare') {
+          return (sql: string) => {
+            if (sql.trim().toUpperCase() === 'PRAGMA USER_VERSION' && migrationLocked) {
+              lockedVersionRead = true;
+            }
+            return target.prepare(sql);
+          };
+        }
+        const value = Reflect.get(target, property, target) as unknown;
+        return typeof value === 'function' ? value.bind(target) : value;
+      },
+    }) as DatabaseSync;
+
+    try {
+      migrateSqliteRuntimeDatabase(db);
+      assert.equal(lockedVersionRead, true);
+    } finally {
+      real.close();
+    }
+  });
+});

--- a/packages/storage/src/__tests__/sqlite-runtime-schema.test.ts
+++ b/packages/storage/src/__tests__/sqlite-runtime-schema.test.ts
@@ -4,6 +4,34 @@ import { describe, it } from 'node:test';
 import { migrateSqliteRuntimeDatabase } from '../sqlite-runtime-schema.js';
 
 describe('SQLite runtime schema migration', () => {
+  it('uses the locked current version after an optimistic stale read', () => {
+    const executed: string[] = [];
+    let versionReads = 0;
+    const db = {
+      prepare(sql: string) {
+        assert.equal(sql, 'PRAGMA user_version');
+        return {
+          get() {
+            versionReads += 1;
+            return { user_version: versionReads === 1 ? 4 : 5 };
+          },
+        };
+      },
+      exec(sql: string) {
+        executed.push(sql);
+      },
+    } as unknown as DatabaseSync;
+
+    migrateSqliteRuntimeDatabase(db);
+
+    assert.equal(versionReads, 2);
+    assert.deepEqual(executed, ['BEGIN IMMEDIATE', 'COMMIT']);
+    assert.equal(
+      executed.some((sql) => sql.includes('runtime_capabilities')),
+      false,
+    );
+  });
+
   it('re-reads user_version under the write lock before applying migrations', () => {
     const real = new DatabaseSync(':memory:');
     let migrationLocked = false;

--- a/packages/storage/src/__tests__/sqlite-runtime-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-runtime-store.test.ts
@@ -28,6 +28,38 @@ describe('SqliteRuntimeStore', () => {
     });
   });
 
+  it('makes a raw canonical-equivalent terminal durability retry idempotent', async () => {
+    await withStore(async (store) => {
+      const terminal: RuntimeEvent = {
+        id: 'terminal-event-1',
+        sessionId: 'session-1',
+        invocationId: 'invocation-1',
+        runId: 'run-1',
+        turnId: 'turn-1',
+        ts: 5,
+        partial: false,
+        role: 'system',
+        author: 'system',
+        status: 'completed',
+        content: {
+          kind: 'text',
+          text: 'done',
+          displayText: 'done',
+          attachments: [],
+          quotes: [],
+        },
+        actions: { endInvocation: true },
+      };
+
+      await store.appendRuntimeEvent('session-1', 'run-1', terminal);
+      await store.ensureTerminalRuntimeEventDurable('session-1', 'run-1', terminal);
+
+      const events = await store.readImmutableRuntimeEvents('session-1', 'run-1');
+      assert.equal(events.length, 1);
+      assert.deepEqual(events[0]?.content, { kind: 'text', text: 'done' });
+    });
+  });
+
   it('commits function_call, dispatch fact, and operation projection atomically in T1', async () => {
     await withStore(async (store) => {
       const call = functionCallEvent();
@@ -256,7 +288,7 @@ describe('SqliteRuntimeStore', () => {
           recoveryMode: 'replay_safe',
           committedAt: 30,
         }),
-        /operation identity conflict/,
+        /duplicate_event_id/,
       );
     });
   });

--- a/packages/storage/src/__tests__/sqlite-runtime-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-runtime-store.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
-import type { RuntimeEvent } from '@maka/core';
+import { canonicalToolArgsHash, type RuntimeEvent } from '@maka/core';
 import {
   SQLITE_RUNTIME_SCHEMA_VERSION,
   createSqliteRuntimeStore,
@@ -40,7 +40,7 @@ describe('SqliteRuntimeStore', () => {
         dispatchRuntimeEvent: dispatch,
         providerToolCallId: 'provider-call-1',
         toolName: 'Read',
-        canonicalArgsHash: 'sha256:args-1',
+        canonicalArgsHash: READ_ARGS_HASH,
         recoveryMode: 'replay_safe',
         committedAt: 10,
       } as const;
@@ -56,7 +56,7 @@ describe('SqliteRuntimeStore', () => {
         turnId: 'turn-1',
         providerToolCallId: 'provider-call-1',
         toolName: 'Read',
-        canonicalArgsHash: 'sha256:args-1',
+        canonicalArgsHash: READ_ARGS_HASH,
         recoveryMode: 'replay_safe',
         currentState: 'prepared',
         callEventId: 'call-event-1',
@@ -110,14 +110,14 @@ describe('SqliteRuntimeStore', () => {
                 operationId: 'operation-t1-failure',
                 providerToolCallId: 'provider-call-1',
                 toolName: 'Read',
-                canonicalArgsHash: 'sha256:t1-failure',
+                canonicalArgsHash: READ_ARGS_HASH,
                 recoveryMode: 'replay_safe',
               },
             },
           }),
           providerToolCallId: 'provider-call-1',
           toolName: 'Read',
-          canonicalArgsHash: 'sha256:t1-failure',
+          canonicalArgsHash: READ_ARGS_HASH,
           recoveryMode: 'replay_safe',
           committedAt: 11,
         }),
@@ -158,7 +158,7 @@ describe('SqliteRuntimeStore', () => {
         turnId: 'turn-1',
         providerToolCallId: 'provider-call-1',
         toolName: 'Read',
-        canonicalArgsHash: 'sha256:args-1',
+        canonicalArgsHash: READ_ARGS_HASH,
         recoveryMode: 'replay_safe',
         currentState: 'outcome_committed',
         callEventId: 'call-event-1',
@@ -230,7 +230,14 @@ describe('SqliteRuntimeStore', () => {
         store.commitToolPrepared({
           operationId: 'operation-1',
           journalEventId: 'journal-prepared-drift',
-          runtimeEvent: functionCallEvent(),
+          runtimeEvent: functionCallEvent({
+            content: {
+              kind: 'function_call',
+              id: 'provider-call-1',
+              name: 'Read',
+              args: { path: '/workspace/repo/OTHER.md' },
+            },
+          }),
           dispatchRuntimeEvent: toolDispatchEvent({
             actions: {
               toolDispatch: {
@@ -238,14 +245,14 @@ describe('SqliteRuntimeStore', () => {
                 operationId: 'operation-1',
                 providerToolCallId: 'provider-call-1',
                 toolName: 'Read',
-                canonicalArgsHash: 'sha256:different-args',
+                canonicalArgsHash: DIFFERENT_READ_ARGS_HASH,
                 recoveryMode: 'replay_safe',
               },
             },
           }),
           providerToolCallId: 'provider-call-1',
           toolName: 'Read',
-          canonicalArgsHash: 'sha256:different-args',
+          canonicalArgsHash: DIFFERENT_READ_ARGS_HASH,
           recoveryMode: 'replay_safe',
           committedAt: 30,
         }),
@@ -453,7 +460,7 @@ function toolDispatchEvent(overrides: Partial<RuntimeEvent> = {}): RuntimeEvent 
         operationId: 'operation-1',
         providerToolCallId: 'provider-call-1',
         toolName: 'Read',
-        canonicalArgsHash: 'sha256:args-1',
+        canonicalArgsHash: READ_ARGS_HASH,
         recoveryMode: 'replay_safe',
       },
     },
@@ -470,8 +477,15 @@ function commitPrepared(store: Store) {
     dispatchRuntimeEvent: toolDispatchEvent(),
     providerToolCallId: 'provider-call-1',
     toolName: 'Read',
-    canonicalArgsHash: 'sha256:args-1',
+    canonicalArgsHash: READ_ARGS_HASH,
     recoveryMode: 'replay_safe',
     committedAt: 10,
   });
 }
+
+const READ_ARGS_HASH = canonicalToolArgsHash('Read', {
+  path: '/workspace/repo/README.md',
+});
+const DIFFERENT_READ_ARGS_HASH = canonicalToolArgsHash('Read', {
+  path: '/workspace/repo/OTHER.md',
+});

--- a/packages/storage/src/__tests__/sqlite-runtime-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-runtime-store.test.ts
@@ -35,7 +35,7 @@ describe('SqliteRuntimeStore', () => {
 
       const input = {
         operationId: 'operation-1',
-        journalEventId: 'journal-prepared-1',
+        journalEventId: 'operation-1_prepared',
         runtimeEvent: call,
         dispatchRuntimeEvent: dispatch,
         providerToolCallId: 'provider-call-1',
@@ -99,7 +99,7 @@ describe('SqliteRuntimeStore', () => {
       await assert.rejects(
         store.commitToolPrepared({
           operationId: 'operation-t1-failure',
-          journalEventId: 'journal-t1-failure',
+          journalEventId: 'operation-t1-failure_prepared',
           runtimeEvent: functionCallEvent({ id: 'call-t1-failure' }),
           dispatchRuntimeEvent: toolDispatchEvent({
             id: 'dispatch-t1-failure',
@@ -138,7 +138,7 @@ describe('SqliteRuntimeStore', () => {
 
       const result = await store.commitToolOutcome({
         operationId: 'operation-1',
-        journalEventId: 'journal-outcome-1',
+        journalEventId: 'operation-1_outcome',
         runtimeEvent: outcome,
         committedAt: 20,
       });
@@ -182,7 +182,7 @@ describe('SqliteRuntimeStore', () => {
       await assert.rejects(
         store.commitToolOutcome({
           operationId: 'operation-1',
-          journalEventId: 'journal-outcome-failure',
+          journalEventId: 'operation-1_outcome',
           runtimeEvent: functionResponseEvent({ id: 'response-t2-failure' }),
           committedAt: 21,
         }),
@@ -211,13 +211,13 @@ describe('SqliteRuntimeStore', () => {
 
       const firstOutcome = await store.commitToolOutcome({
         operationId: 'operation-1',
-        journalEventId: 'journal-outcome-1',
+        journalEventId: 'operation-1_outcome',
         runtimeEvent: functionResponseEvent(),
         committedAt: 20,
       });
       const duplicateOutcome = await store.commitToolOutcome({
         operationId: 'operation-1',
-        journalEventId: 'journal-outcome-1',
+        journalEventId: 'operation-1_outcome',
         runtimeEvent: functionResponseEvent(),
         committedAt: 20,
       });
@@ -229,7 +229,7 @@ describe('SqliteRuntimeStore', () => {
       await assert.rejects(
         store.commitToolPrepared({
           operationId: 'operation-1',
-          journalEventId: 'journal-prepared-drift',
+          journalEventId: 'operation-1_prepared',
           runtimeEvent: functionCallEvent({
             content: {
               kind: 'function_call',
@@ -266,7 +266,7 @@ describe('SqliteRuntimeStore', () => {
       await commitPrepared(store);
       await store.commitToolOutcome({
         operationId: 'operation-1',
-        journalEventId: 'journal-outcome-1',
+        journalEventId: 'operation-1_outcome',
         runtimeEvent: functionResponseEvent(),
         committedAt: 20,
       });
@@ -356,6 +356,7 @@ describe('SqliteRuntimeStore', () => {
           refs: { providerEventId: 'message-1' },
         }),
       );
+      await store.appendRuntimeEvent('session-1', 'run-1', functionCallEvent());
       await store.appendRuntimeEvent(
         'session-1',
         'run-1',
@@ -366,9 +367,9 @@ describe('SqliteRuntimeStore', () => {
 
       assert.deepEqual(
         (await store.readRuntimeEvents('session-1', 'run-1')).map((event) => event.id),
-        ['text-final', 'response-event-1'],
+        ['text-final', 'call-event-1', 'response-event-1'],
       );
-      assert.equal((await store.readImmutableRuntimeEvents('session-1', 'run-1')).length, 2);
+      assert.equal((await store.readImmutableRuntimeEvents('session-1', 'run-1')).length, 3);
     });
   });
 });
@@ -472,7 +473,7 @@ function toolDispatchEvent(overrides: Partial<RuntimeEvent> = {}): RuntimeEvent 
 function commitPrepared(store: Store) {
   return store.commitToolPrepared({
     operationId: 'operation-1',
-    journalEventId: 'journal-prepared-1',
+    journalEventId: 'operation-1_prepared',
     runtimeEvent: functionCallEvent(),
     dispatchRuntimeEvent: toolDispatchEvent(),
     providerToolCallId: 'provider-call-1',

--- a/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts
@@ -10,7 +10,10 @@ import {
   SessionMetadataConflictError,
   type SqliteSessionMetadataStoreFailpoint,
 } from '../sqlite-session-metadata-store.js';
-import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
+import {
+  createSqliteRuntimeStore,
+  SQLITE_RUNTIME_SCHEMA_VERSION,
+} from '../sqlite-runtime-store.js';
 
 describe('SqliteSessionMetadataStore', () => {
   test('round-trips every SessionHeader field and reopens the same schema', async () => {
@@ -50,7 +53,7 @@ describe('SqliteSessionMetadataStore', () => {
     const runtime = createSqliteRuntimeStore(path);
     const metadata = createSqliteSessionMetadataStore(path);
     try {
-      assert.equal(runtime.schemaVersion(), 4);
+      assert.equal(runtime.schemaVersion(), SQLITE_RUNTIME_SCHEMA_VERSION);
       assert.equal(metadata.schemaVersion(), 7);
       await metadata.create(fullHeader());
       await runtime.appendRuntimeEvent('session-1', 'run-1', {

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -945,8 +945,18 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
         throw new Error(`RuntimeEvent ${event.id} appears more than once in run ${runId}`);
       }
       if (matching.length === 1) {
-        if (isDeepStrictEqual(matching[0], event)) return;
-        throw new Error(`RuntimeEvent identity conflict for ${event.id}`);
+        if (!isDeepStrictEqual(matching[0], event)) {
+          throw new Error(`RuntimeEvent identity conflict for ${event.id}`);
+        }
+        await this.settleImmutableRuntimeEventPostEffects({
+          sessionId,
+          runId,
+          event,
+          path: this.runtimeEventsPath(sessionId, runId),
+          ensureDurability:
+            options.durable === true || immutableSteeringMessageId(event) !== undefined,
+        });
+        return;
       }
       if (isToolLedgerBearingEvent(event)) {
         const validation = validateToolLedgerTransition({
@@ -970,26 +980,54 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
           durabilityRoot: this.durabilityRoot,
         },
       );
-      if (steeringMessageId) {
-        try {
-          await this.ensureImmutableSteeringMessageProof(event, steeringMessageId);
-        } catch (error) {
-          if (!(error instanceof DurableStoreWriteError)) throw error;
-          throw new RuntimeEventPostEffectError(
-            `RuntimeEvent ${event.id} is durable but its steering proof was not published`,
-            error,
-          );
-        }
-      }
-      const completedPartialKey = completedPartialRuntimeStreamKey(event);
-      if (completedPartialKey) {
-        await rm(this.runtimePartialPath(sessionId, runId, completedPartialKey), {
-          force: true,
-        }).catch(() => {
-          // The immutable final is already durable. Reads suppress any stale snapshot.
-        });
-      }
+      await this.settleImmutableRuntimeEventPostEffects({
+        sessionId,
+        runId,
+        event,
+        path: this.runtimeEventsPath(sessionId, runId),
+        ensureDurability: false,
+      });
     });
+  }
+
+  private async settleImmutableRuntimeEventPostEffects(input: {
+    sessionId: string;
+    runId: string;
+    event: RuntimeEvent;
+    path: string;
+    ensureDurability: boolean;
+  }): Promise<void> {
+    if (input.ensureDurability) {
+      try {
+        await syncFile(input.path);
+        await syncDirectoryChain(dirname(input.path), this.durabilityRoot);
+      } catch (error) {
+        throw new DurableStoreWriteError(
+          `RuntimeEvent did not reach stable storage: ${input.path}`,
+          error,
+        );
+      }
+    }
+    const steeringMessageId = immutableSteeringMessageId(input.event);
+    if (steeringMessageId) {
+      try {
+        await this.ensureImmutableSteeringMessageProof(input.event, steeringMessageId);
+      } catch (error) {
+        if (!(error instanceof DurableStoreWriteError)) throw error;
+        throw new RuntimeEventPostEffectError(
+          `RuntimeEvent ${input.event.id} is durable but its steering proof was not published`,
+          error,
+        );
+      }
+    }
+    const completedPartialKey = completedPartialRuntimeStreamKey(input.event);
+    if (completedPartialKey) {
+      await rm(this.runtimePartialPath(input.sessionId, input.runId, completedPartialKey), {
+        force: true,
+      }).catch(() => {
+        // The immutable final is already durable. Reads suppress any stale snapshot.
+      });
+    }
   }
 
   async ensureTerminalRuntimeEventDurable(
@@ -1009,6 +1047,7 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
     await this.withQueue(sessionId, runId, async () => {
       const path = this.runtimeEventsPath(sessionId, runId);
       const header = await this.readRunHeader(sessionId, runId);
+      decodeRuntimeEvent(canonicalEvent, header);
       const existing = await readRuntimeEventJsonl(path, header);
       const matching = existing.filter((candidate) => candidate.id === canonicalEvent.id);
       if (matching.length > 1) {

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -24,6 +24,7 @@ import { syncDirectory, syncDirectoryChain, syncFile } from './stable-storage.js
 import { chainWrite } from './write-queue.js';
 import {
   DurableStoreWriteError,
+  decodeRuntimeEvent as decodeCanonicalRuntimeEvent,
   decodeMessageContent,
   isCanonicalAttachmentRef,
   isTerminalRuntimeEvent,
@@ -31,6 +32,7 @@ import {
   MAX_ATTACHMENT_COUNT,
   messageContentsEqual,
   validateGenericToolLedgerAppend,
+  validateToolLedgerTransition,
   type AgentRunEvent,
   type AgentRunEventType,
   type AgentRunHeader,
@@ -834,6 +836,22 @@ function assertNoReservedToolLedgerFact(event: RuntimeEvent): void {
   throw new Error(`RuntimeEvent ${event.id} violates its semantic lane`);
 }
 
+function canonicalizeRuntimeEventForStorage(event: RuntimeEvent): RuntimeEvent {
+  // Persist the decoder's normalized value, then decode the JSON round-trip
+  // again so schema-invalid serialization loss cannot enter the ledger.
+  const decoded = decodeCanonicalRuntimeEvent(event);
+  return decodeCanonicalRuntimeEvent(JSON.parse(JSON.stringify(decoded, sanitizeJson)));
+}
+
+function isToolLedgerBearingEvent(event: RuntimeEvent): boolean {
+  return (
+    event.content?.kind === 'function_call' ||
+    event.content?.kind === 'function_response' ||
+    event.actions?.toolDispatch !== undefined ||
+    event.actions?.toolRecovery !== undefined
+  );
+}
+
 function historyCompactProjectionCoverage(event: AgentRunEvent): number | undefined {
   const checkpoint = event.data?.checkpoint;
   if (!checkpoint || typeof checkpoint !== 'object') return undefined;
@@ -862,18 +880,19 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
     event: RuntimeEvent,
     options: { durable?: boolean } = {},
   ): Promise<void> {
+    const canonicalEvent = canonicalizeRuntimeEventForStorage(event);
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
-    assertNoReservedToolLedgerFact(event);
-    const steeringMessageId = immutableSteeringMessageId(event);
+    assertNoReservedToolLedgerFact(canonicalEvent);
+    const steeringMessageId = immutableSteeringMessageId(canonicalEvent);
     if (steeringMessageId) {
       await this.withImmutableSteeringQueue(sessionId, async () => {
-        if (await this.preflightImmutableSteeringMessage(event, steeringMessageId)) return;
-        await this.appendRuntimeEventForRun(sessionId, runId, event, options);
+        if (await this.preflightImmutableSteeringMessage(canonicalEvent, steeringMessageId)) return;
+        await this.appendRuntimeEventForRun(sessionId, runId, canonicalEvent, options);
       });
       return;
     }
-    await this.appendRuntimeEventForRun(sessionId, runId, event, options);
+    await this.appendRuntimeEventForRun(sessionId, runId, canonicalEvent, options);
   }
 
   private async appendRuntimeEventForRun(
@@ -919,6 +938,22 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
         }
         return;
       }
+      if (isToolLedgerBearingEvent(event)) {
+        const existingEvents = await readRuntimeEventJsonl(
+          this.runtimeEventsPath(sessionId, runId),
+          await this.readRunHeader(sessionId, runId),
+        );
+        const validation = validateToolLedgerTransition({
+          existingEvents,
+          candidateEvents: [event],
+          expectedTransition: 'generic_append',
+        });
+        if (!validation.ok) {
+          throw new Error(
+            `Tool ledger transition rejected: ${validation.code} at ${validation.eventId}`,
+          );
+        }
+      }
       const steeringMessageId = immutableSteeringMessageId(event);
       await appendJsonl(
         this.runtimeEventsPath(sessionId, runId),
@@ -956,10 +991,11 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
     runId: string,
     event: RuntimeEvent,
   ): Promise<void> {
+    const canonicalEvent = canonicalizeRuntimeEventForStorage(event);
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
-    assertNoReservedToolLedgerFact(event);
-    if (event.partial || !isTerminalRuntimeEvent(event)) {
+    assertNoReservedToolLedgerFact(canonicalEvent);
+    if (canonicalEvent.partial || !isTerminalRuntimeEvent(canonicalEvent)) {
       throw new Error(
         'Only a final terminal RuntimeEvent can cross the terminal durability barrier',
       );
@@ -968,14 +1004,15 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
       const path = this.runtimeEventsPath(sessionId, runId);
       const header = await this.readRunHeader(sessionId, runId);
       const existing = await readRuntimeEventJsonl(path, header);
-      const matching = existing.filter((candidate) => candidate.id === event.id);
+      const matching = existing.filter((candidate) => candidate.id === canonicalEvent.id);
       if (matching.length > 1) {
-        throw new Error(`RuntimeEvent ${event.id} appears more than once in run ${runId}`);
+        throw new Error(`RuntimeEvent ${canonicalEvent.id} appears more than once in run ${runId}`);
       }
       if (matching.length === 1) {
-        const canonical = JSON.parse(JSON.stringify(event, sanitizeJson)) as RuntimeEvent;
-        if (!isDeepStrictEqual(matching[0], canonical)) {
-          throw new Error(`RuntimeEvent ${event.id} does not match the durable ledger record`);
+        if (!isDeepStrictEqual(matching[0], canonicalEvent)) {
+          throw new Error(
+            `RuntimeEvent ${canonicalEvent.id} does not match the durable ledger record`,
+          );
         }
         try {
           await syncFile(path);
@@ -992,7 +1029,7 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
       if (existingTerminal) {
         throw new Error(`Run ${runId} already has terminal RuntimeEvent ${existingTerminal.id}`);
       }
-      await appendJsonl(path, JSON.stringify(event, sanitizeJson) + '\n', {
+      await appendJsonl(path, JSON.stringify(canonicalEvent, sanitizeJson) + '\n', {
         durable: true,
         durabilityRoot: this.durabilityRoot,
       });

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -30,6 +30,7 @@ import {
   MAX_ATTACHMENT_BYTES,
   MAX_ATTACHMENT_COUNT,
   messageContentsEqual,
+  validateGenericToolLedgerAppend,
   type AgentRunEvent,
   type AgentRunEventType,
   type AgentRunHeader,
@@ -821,6 +822,18 @@ function historyCompactProjectionIsSourceBound(event: AgentRunEvent): boolean {
   return (source as { kind?: unknown }).kind === 'runtime_event_projection';
 }
 
+function assertNoReservedToolLedgerFact(event: RuntimeEvent): void {
+  const validation = validateGenericToolLedgerAppend(event);
+  if (validation.ok) return;
+  if (validation.code === 'reserved_recovery_fact') {
+    throw new Error('Tool recovery facts require the atomic recovery bundle writer');
+  }
+  if (validation.code === 'reserved_tool_boundary_fact') {
+    throw new Error('Durable tool facts require the atomic tool boundary writer');
+  }
+  throw new Error(`RuntimeEvent ${event.id} violates its semantic lane`);
+}
+
 function historyCompactProjectionCoverage(event: AgentRunEvent): number | undefined {
   const checkpoint = event.data?.checkpoint;
   if (!checkpoint || typeof checkpoint !== 'object') return undefined;
@@ -851,6 +864,7 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
   ): Promise<void> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
+    assertNoReservedToolLedgerFact(event);
     const steeringMessageId = immutableSteeringMessageId(event);
     if (steeringMessageId) {
       await this.withImmutableSteeringQueue(sessionId, async () => {
@@ -944,6 +958,7 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
   ): Promise<void> {
     assertSafeId(sessionId, 'Invalid session id');
     assertSafeId(runId, 'Invalid run id');
+    assertNoReservedToolLedgerFact(event);
     if (event.partial || !isTerminalRuntimeEvent(event)) {
       throw new Error(
         'Only a final terminal RuntimeEvent can cross the terminal durability barrier',

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -24,8 +24,8 @@ import { syncDirectory, syncDirectoryChain, syncFile } from './stable-storage.js
 import { chainWrite } from './write-queue.js';
 import {
   DurableStoreWriteError,
-  decodeRuntimeEvent as decodeCanonicalRuntimeEvent,
   decodeMessageContent,
+  encodeCanonicalRuntimeEvent,
   isCanonicalAttachmentRef,
   isTerminalRuntimeEvent,
   MAX_ATTACHMENT_BYTES,
@@ -837,10 +837,7 @@ function assertNoReservedToolLedgerFact(event: RuntimeEvent): void {
 }
 
 function canonicalizeRuntimeEventForStorage(event: RuntimeEvent): RuntimeEvent {
-  // Persist the decoder's normalized value, then decode the JSON round-trip
-  // again so schema-invalid serialization loss cannot enter the ledger.
-  const decoded = decodeCanonicalRuntimeEvent(event);
-  return decodeCanonicalRuntimeEvent(JSON.parse(JSON.stringify(decoded, sanitizeJson)));
+  return encodeCanonicalRuntimeEvent(event).event;
 }
 
 function isToolLedgerBearingEvent(event: RuntimeEvent): boolean {
@@ -902,7 +899,8 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
     options: { durable?: boolean },
   ): Promise<void> {
     await this.withQueue(sessionId, runId, async () => {
-      await mkdir(this.runDir(sessionId, runId), { recursive: true });
+      const header = await this.readRunHeader(sessionId, runId);
+      decodeRuntimeEvent(event, header);
       const partial = partialRuntimeStream(event);
       if (partial) {
         const partialPath = this.runtimePartialPath(sessionId, runId, partial.key);
@@ -912,7 +910,7 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
           if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
           const immutableEvents = await readRuntimeEventJsonl(
             this.runtimeEventsPath(sessionId, runId),
-            await this.readRunHeader(sessionId, runId),
+            header,
           );
           if (
             immutableEvents.some((item) => completedPartialRuntimeStreamKey(item) === partial.key)
@@ -938,11 +936,19 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
         }
         return;
       }
+      const existingEvents = await readRuntimeEventJsonl(
+        this.runtimeEventsPath(sessionId, runId),
+        header,
+      );
+      const matching = existingEvents.filter((item) => item.id === event.id);
+      if (matching.length > 1) {
+        throw new Error(`RuntimeEvent ${event.id} appears more than once in run ${runId}`);
+      }
+      if (matching.length === 1) {
+        if (isDeepStrictEqual(matching[0], event)) return;
+        throw new Error(`RuntimeEvent identity conflict for ${event.id}`);
+      }
       if (isToolLedgerBearingEvent(event)) {
-        const existingEvents = await readRuntimeEventJsonl(
-          this.runtimeEventsPath(sessionId, runId),
-          await this.readRunHeader(sessionId, runId),
-        );
         const validation = validateToolLedgerTransition({
           existingEvents,
           candidateEvents: [event],
@@ -957,7 +963,7 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
       const steeringMessageId = immutableSteeringMessageId(event);
       await appendJsonl(
         this.runtimeEventsPath(sessionId, runId),
-        JSON.stringify(event, sanitizeJson) + '\n',
+        encodeCanonicalRuntimeEvent(event).json + '\n',
         {
           ...options,
           ...(steeringMessageId ? { durable: true } : {}),
@@ -1029,7 +1035,7 @@ class FileRuntimeEventStore implements DurableRuntimeEventStore {
       if (existingTerminal) {
         throw new Error(`Run ${runId} already has terminal RuntimeEvent ${existingTerminal.id}`);
       }
-      await appendJsonl(path, JSON.stringify(canonicalEvent, sanitizeJson) + '\n', {
+      await appendJsonl(path, encodeCanonicalRuntimeEvent(canonicalEvent).json + '\n', {
         durable: true,
         durabilityRoot: this.durabilityRoot,
       });

--- a/packages/storage/src/sqlite-runtime-schema.ts
+++ b/packages/storage/src/sqlite-runtime-schema.ts
@@ -130,24 +130,36 @@ export function configureSqliteRuntimeDatabase(db: DatabaseSync): void {
 }
 
 export function migrateSqliteRuntimeDatabase(db: DatabaseSync): void {
-  const current = readUserVersion(db);
-  if (current > SQLITE_RUNTIME_SCHEMA_VERSION) {
+  const observedVersion = readUserVersion(db);
+  if (observedVersion > SQLITE_RUNTIME_SCHEMA_VERSION) {
     throw new Error(
-      `SQLite runtime schema ${current} is newer than supported version ${SQLITE_RUNTIME_SCHEMA_VERSION}`,
+      `SQLite runtime schema ${observedVersion} is newer than supported version ${SQLITE_RUNTIME_SCHEMA_VERSION}`,
     );
   }
-  for (let version = current + 1; version <= SQLITE_RUNTIME_SCHEMA_VERSION; version += 1) {
-    const sql = MIGRATIONS.get(version);
-    if (!sql) throw new Error(`Missing SQLite runtime migration ${version}`);
-    db.exec('BEGIN IMMEDIATE');
-    try {
+  if (observedVersion === SQLITE_RUNTIME_SCHEMA_VERSION) return;
+
+  // The optimistic read keeps established databases on a read-only open path.
+  // Any pending upgrade is serialized by one write transaction, then re-reads
+  // user_version under that lock so a concurrent opener cannot apply a
+  // migration another process just committed.
+  db.exec('BEGIN IMMEDIATE');
+  try {
+    const current = readUserVersion(db);
+    if (current > SQLITE_RUNTIME_SCHEMA_VERSION) {
+      throw new Error(
+        `SQLite runtime schema ${current} is newer than supported version ${SQLITE_RUNTIME_SCHEMA_VERSION}`,
+      );
+    }
+    for (let version = current + 1; version <= SQLITE_RUNTIME_SCHEMA_VERSION; version += 1) {
+      const sql = MIGRATIONS.get(version);
+      if (!sql) throw new Error(`Missing SQLite runtime migration ${version}`);
       db.exec(sql);
       db.exec(`PRAGMA user_version = ${version}`);
-      db.exec('COMMIT');
-    } catch (error) {
-      rollback(db);
-      throw error;
     }
+    db.exec('COMMIT');
+  } catch (error) {
+    rollback(db);
+    throw error;
   }
 }
 

--- a/packages/storage/src/sqlite-runtime-schema.ts
+++ b/packages/storage/src/sqlite-runtime-schema.ts
@@ -1,6 +1,8 @@
 import type { DatabaseSync } from 'node:sqlite';
 
-export const SQLITE_RUNTIME_SCHEMA_VERSION = 4;
+export const SQLITE_RUNTIME_SCHEMA_VERSION = 5;
+export const RUNTIME_RECOVERY_AUTHORITY_CAPABILITY = 'runtime_recovery_authority';
+export const RUNTIME_RECOVERY_AUTHORITY_CAPABILITY_VERSION = 1;
 
 const MIGRATIONS: ReadonlyMap<number, string> = new Map([
   [
@@ -98,6 +100,18 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
     `
     ALTER TABLE tool_operations ADD COLUMN dispatch_event_id TEXT
       REFERENCES runtime_events(event_id);
+  `,
+  ],
+  [
+    5,
+    `
+    CREATE TABLE runtime_capabilities (
+      capability TEXT PRIMARY KEY,
+      version INTEGER NOT NULL CHECK (version > 0)
+    );
+
+    INSERT INTO runtime_capabilities(capability, version)
+      VALUES ('runtime_recovery_authority', 1);
   `,
   ],
 ]);

--- a/packages/storage/src/sqlite-runtime-schema.ts
+++ b/packages/storage/src/sqlite-runtime-schema.ts
@@ -117,10 +117,16 @@ const MIGRATIONS: ReadonlyMap<number, string> = new Map([
 ]);
 
 export function configureSqliteRuntimeDatabase(db: DatabaseSync): void {
-  db.exec('PRAGMA journal_mode = WAL');
+  // Bound lock acquisition before touching persistent journal state. WAL mode is
+  // database-persistent, so established workspaces only need to verify it rather
+  // than making every concurrent opener execute the setting form of the pragma.
+  db.exec('PRAGMA busy_timeout = 5000');
+  const journalMode = readJournalMode(db);
+  if (journalMode !== 'wal') {
+    db.exec('PRAGMA journal_mode = WAL');
+  }
   db.exec('PRAGMA synchronous = FULL');
   db.exec('PRAGMA foreign_keys = ON');
-  db.exec('PRAGMA busy_timeout = 5000');
 }
 
 export function migrateSqliteRuntimeDatabase(db: DatabaseSync): void {
@@ -152,6 +158,14 @@ export function readUserVersion(db: DatabaseSync): number {
     throw new Error('Invalid SQLite runtime schema version');
   }
   return value;
+}
+
+function readJournalMode(db: DatabaseSync): string {
+  const row = db.prepare('PRAGMA journal_mode').get() as { journal_mode?: unknown } | undefined;
+  if (typeof row?.journal_mode !== 'string') {
+    throw new Error('Invalid SQLite runtime journal mode');
+  }
+  return row.journal_mode.toLowerCase();
 }
 
 function rollback(db: DatabaseSync): void {

--- a/packages/storage/src/sqlite-runtime-store.ts
+++ b/packages/storage/src/sqlite-runtime-store.ts
@@ -5,16 +5,30 @@ import { dirname } from 'node:path';
 import type { DatabaseSync } from 'node:sqlite';
 import { isDeepStrictEqual } from 'node:util';
 import {
+  canonicalToolArgsHash,
+  decodeRuntimeEvent,
   isPartialRuntimeEvent,
   isTerminalRuntimeEvent,
+  scanToolLedger,
+  TOOL_RECOVERY_BUNDLE_CAPABILITY_V1,
+  validateGenericToolLedgerAppend,
+  validateToolLedgerEventLane,
   type RuntimeEvent,
-  type RuntimeEventStore,
+  type RuntimeRecoveryBundleCommit,
+  type RuntimeRecoveryBundleStore,
+  type ToolRecoveryDecisionFact,
   type ToolRecoveryMode,
 } from '@maka/core';
+import {
+  assertToolRecoveryEventBundle,
+  interpretScannedToolRecovery,
+} from '@maka/core/tool-recovery-bundle';
 import {
   configureSqliteRuntimeDatabase,
   migrateSqliteRuntimeDatabase,
   readUserVersion,
+  RUNTIME_RECOVERY_AUTHORITY_CAPABILITY,
+  RUNTIME_RECOVERY_AUTHORITY_CAPABILITY_VERSION,
 } from './sqlite-runtime-schema.js';
 
 export { SQLITE_RUNTIME_SCHEMA_VERSION } from './sqlite-runtime-schema.js';
@@ -27,11 +41,19 @@ function loadDatabaseSync(): typeof import('node:sqlite').DatabaseSync {
   return (require('node:sqlite') as typeof import('node:sqlite')).DatabaseSync;
 }
 
-export type ToolJournalState = 'prepared' | 'outcome_committed';
+export type ToolJournalState =
+  | 'prepared'
+  | 'reconcile_observed'
+  | 'outcome_committed'
+  | 'recovery_completed'
+  | 'recovery_parked';
 
 export type SqliteRuntimeStoreFailpoint =
   | 'after_runtime_event_insert'
-  | 'after_journal_event_insert';
+  | 'after_journal_event_insert'
+  | 'after_recovery_reconcile'
+  | 'after_recovery_outcome'
+  | 'after_recovery_decision';
 
 export interface SqliteRuntimeStoreOptions {
   failpoint?: (point: SqliteRuntimeStoreFailpoint) => void;
@@ -80,7 +102,7 @@ export interface ToolOperationRecord {
   toolName: string;
   canonicalArgsHash: string;
   recoveryMode: ToolRecoveryMode;
-  currentState: 'prepared' | 'outcome_committed';
+  currentState: 'prepared' | 'outcome_committed' | 'recovery_completed' | 'recovery_parked';
   callEventId: string;
   dispatchEventId?: string;
   resultEventId?: string;
@@ -109,9 +131,10 @@ export function createSqliteRuntimeStore(
   return new SqliteRuntimeStore(path, options);
 }
 
-export class SqliteRuntimeStore implements RuntimeEventStore {
+export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
   readonly durability = 'canonical' as const;
   readonly toolBoundaryProtocol = 't1_after_preflight_v1' as const;
+  readonly recoveryBundleCapability = TOOL_RECOVERY_BUNDLE_CAPABILITY_V1;
   private readonly db: DatabaseSync;
   private closed = false;
 
@@ -122,8 +145,15 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
     if (path !== ':memory:') mkdirSync(dirname(path), { recursive: true });
     const DatabaseSync = loadDatabaseSync();
     this.db = new DatabaseSync(path);
-    configureSqliteRuntimeDatabase(this.db);
-    migrateSqliteRuntimeDatabase(this.db);
+    try {
+      configureSqliteRuntimeDatabase(this.db);
+      migrateSqliteRuntimeDatabase(this.db);
+      assertRecoveryAuthorityCapability(this.db);
+    } catch (error) {
+      this.db.close();
+      this.closed = true;
+      throw error;
+    }
   }
 
   schemaVersion(): number {
@@ -151,6 +181,7 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
   }
 
   async appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void> {
+    assertNoReservedToolLedgerFact(event);
     await this.importRuntimeEvent(sessionId, runId, event);
   }
 
@@ -159,6 +190,7 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
     runId: string,
     event: RuntimeEvent,
   ): Promise<void> {
+    assertNoReservedToolLedgerFact(event);
     if (isPartialRuntimeEvent(event) || !isTerminalRuntimeEvent(event)) {
       throw new Error(
         'Only a final terminal RuntimeEvent can cross the terminal durability barrier',
@@ -187,6 +219,7 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
     runId: string,
     event: RuntimeEvent,
   ): Promise<boolean> {
+    assertNoReservedToolLedgerFact(event);
     if (sessionId !== event.sessionId || runId !== event.runId) {
       throw new Error(`RuntimeEvent store identity does not match event ${event.id}`);
     }
@@ -200,6 +233,7 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
     source?: { path: string; fingerprint: string };
   }): Promise<RuntimeEventBatchImportResult> {
     for (const event of input.events) {
+      assertNoReservedToolLedgerFact(event);
       if (event.sessionId !== input.sessionId || event.runId !== input.runId) {
         throw new Error(`RuntimeEvent store identity does not match event ${event.id}`);
       }
@@ -244,27 +278,33 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
     const immutable = await this.readImmutableRuntimeEvents(sessionId, runId);
     const partials = this.db
       .prepare(`
-      SELECT payload_json, text_content, after_event_id
+      SELECT stream_key, session_id, invocation_id, run_id, turn_id,
+        payload_json, text_content, after_event_id
       FROM runtime_partial_snapshots
       WHERE session_id = ? AND run_id = ?
       ORDER BY updated_at ASC, stream_key ASC
     `)
-      .all(sessionId, runId) as Array<{
-      payload_json: string;
-      text_content: string;
-      after_event_id: string | null;
-    }>;
+      .all(sessionId, runId) as unknown as RuntimePartialStorageRow[];
     return mergeRuntimePartialSnapshots(
       immutable,
-      partials.map((row) => {
-        const event = JSON.parse(row.payload_json) as RuntimeEvent;
-        if (event.content?.kind === 'text' || event.content?.kind === 'thinking') {
-          event.content = { ...event.content, text: row.text_content };
+      partials.flatMap((row) => {
+        try {
+          const event = decodeRuntimePartialStorageRow(row);
+          if (event.content?.kind === 'text' || event.content?.kind === 'thinking') {
+            event.content = { ...event.content, text: row.text_content };
+          }
+          return [
+            {
+              event,
+              ...(row.after_event_id ? { afterEventId: row.after_event_id } : {}),
+            },
+          ];
+        } catch {
+          // Mutable partial snapshots are presentation state, never ledger
+          // authority. A corrupt snapshot is skipped without hiding immutable
+          // RuntimeEvents from the same run.
+          return [];
         }
-        return {
-          event,
-          ...(row.after_event_id ? { afterEventId: row.after_event_id } : {}),
-        };
       }),
     );
   }
@@ -272,13 +312,13 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
   async readImmutableRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]> {
     const rows = this.db
       .prepare(`
-      SELECT payload_json
+      SELECT event_id, session_id, invocation_id, run_id, turn_id, payload_json
       FROM runtime_events
       WHERE session_id = ? AND run_id = ?
       ORDER BY event_seq ASC, event_id ASC
     `)
-      .all(sessionId, runId) as Array<{ payload_json: string }>;
-    return rows.map((row) => JSON.parse(row.payload_json) as RuntimeEvent);
+      .all(sessionId, runId) as unknown as RuntimeEventStorageRow[];
+    return rows.map(decodeRuntimeEventStorageRow);
   }
 
   async readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]> {
@@ -378,52 +418,60 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
 
   async commitToolOutcome(input: CommitToolOutcomeInput): Promise<ToolCommitResult> {
     assertOutcomeInput(input);
-    return this.transaction(() => {
+    return this.transaction(() => this.commitToolOutcomeSync(input));
+  }
+
+  async commitToolRecoveryBundle(input: RuntimeRecoveryBundleCommit): Promise<void> {
+    if (input.outcomeRuntimeEvent) assertNoReservedRecoveryFact(input.outcomeRuntimeEvent);
+    this.transaction(() => {
       const operation = this.readToolOperationSync(input.operationId);
       if (!operation) throw new Error(`Unknown tool operation ${input.operationId}`);
-      assertOutcomeIdentity(operation, input.runtimeEvent);
-      if (operation.resultEventId) {
-        if (operation.resultEventId !== input.runtimeEvent.id) {
-          throw new Error(`Tool operation outcome conflict for ${input.operationId}`);
-        }
-        assertStoredRuntimeEventEquals(
-          input.runtimeEvent,
-          this.readRuntimeEventJson(input.runtimeEvent.id),
-        );
-        return { created: false, runtimeEventSeq: this.runtimeEventSeq(input.runtimeEvent.id) };
+      if (!operation.dispatchEventId) {
+        throw new Error('Recovery bundle requires a durable dispatch RuntimeEvent');
       }
-      const runtimeEventSeq = this.insertRuntimeEvent(input.runtimeEvent, input.committedAt, false);
-      this.options.failpoint?.('after_runtime_event_insert');
-      this.db
-        .prepare(`
-        INSERT INTO tool_journal_events (
-          journal_event_id, operation_id, invocation_id, run_id, turn_id, state,
-          runtime_event_id, canonical_args_hash, recovery_mode, committed_at
-        ) VALUES (?, ?, ?, ?, ?, 'outcome_committed', ?, ?, ?, ?)
-      `)
-        .run(
-          input.journalEventId,
-          input.operationId,
-          operation.invocationId,
-          operation.runId,
-          operation.turnId,
-          input.runtimeEvent.id,
-          operation.canonicalArgsHash,
-          operation.recoveryMode,
-          input.committedAt,
-        );
-      this.options.failpoint?.('after_journal_event_insert');
-      const updated = this.db
-        .prepare(`
-        UPDATE tool_operations
-        SET current_state = 'outcome_committed', result_event_id = ?, version = version + 1
-        WHERE operation_id = ? AND current_state = 'prepared' AND result_event_id IS NULL
-      `)
-        .run(input.runtimeEvent.id, input.operationId);
-      if (updated.changes !== 1) {
-        throw new Error(`Tool operation compare-and-set failed for ${input.operationId}`);
+      assertToolRecoveryEventBundle({
+        operation: recoveryOperationIdentity(operation),
+        callEvent: this.readRequiredRuntimeEvent(operation.callEventId),
+        dispatchEvent: this.readRequiredRuntimeEvent(operation.dispatchEventId),
+        reconcileEvent: input.reconcileRuntimeEvent,
+        outcomeEvent: input.outcomeRuntimeEvent,
+        decisionEvent: input.decisionRuntimeEvent,
+      });
+      assertStrictRuntimeEventOrder([
+        this.runtimeEventSeq(operation.callEventId),
+        this.runtimeEventSeq(operation.dispatchEventId),
+      ]);
+
+      if (operation.currentState !== 'prepared' || operation.resultEventId !== undefined) {
+        this.assertExactRecoveryBundleAlreadyCommitted(input, operation);
+        return;
       }
-      return { created: true, runtimeEventSeq };
+
+      this.commitRecoveryFactSync(operation, input.reconcileRuntimeEvent, 'reconcile_observed');
+      this.options.failpoint?.('after_recovery_reconcile');
+      if (input.outcomeRuntimeEvent) {
+        this.commitToolOutcomeSync({
+          operationId: input.operationId,
+          journalEventId: `${input.operationId}_outcome`,
+          runtimeEvent: input.outcomeRuntimeEvent,
+          committedAt: input.outcomeRuntimeEvent.ts,
+        });
+        this.options.failpoint?.('after_recovery_outcome');
+      }
+
+      const decision = input.decisionRuntimeEvent.actions?.toolRecovery;
+      if (!decision || decision.kind !== 'maka.tool.recovery_decision') {
+        throw new Error('Recovery bundle requires a recovery decision');
+      }
+      const current = this.readToolOperationSync(input.operationId);
+      if (!current) throw new Error(`Unknown tool operation ${input.operationId}`);
+      this.commitRecoveryFactSync(
+        current,
+        input.decisionRuntimeEvent,
+        decision.payload.disposition === 'completed' ? 'recovery_completed' : 'recovery_parked',
+        decision.payload,
+      );
+      this.options.failpoint?.('after_recovery_decision');
     });
   }
 
@@ -473,57 +521,48 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
           `Cannot rebuild legacy tool operation ${legacy.operation_id} without a dispatch RuntimeEvent`,
         );
       }
-      const events = (
-        this.db
-          .prepare(`
-        SELECT payload_json FROM runtime_events
+      const rows = this.db
+        .prepare(`
+        SELECT event_id, session_id, invocation_id, run_id, turn_id,
+          event_seq, payload_json, committed_at
+        FROM runtime_events
         ORDER BY invocation_id ASC, event_seq ASC, event_id ASC
       `)
-          .all() as Array<{ payload_json: string }>
-      ).map((row) => JSON.parse(row.payload_json) as RuntimeEvent);
-      const calls = new Map<string, RuntimeEvent>();
-      const dispatches: Array<{
-        event: RuntimeEvent;
-        call: RuntimeEvent;
-        dispatch: NonNullable<NonNullable<RuntimeEvent['actions']>['toolDispatch']>;
-      }> = [];
-      const responses = new Map<string, RuntimeEvent>();
-
-      for (const event of events) {
-        if (event.partial) continue;
-        if (event.content?.kind === 'function_call') {
-          calls.set(toolCallProjectionKey(event.invocationId, event.content.id), event);
-          continue;
-        }
-        const dispatch = event.actions?.toolDispatch;
-        if (dispatch) {
-          const call = calls.get(
-            toolCallProjectionKey(event.invocationId, dispatch.providerToolCallId),
-          );
-          if (
-            !call ||
-            call.content?.kind !== 'function_call' ||
-            call.content.name !== dispatch.toolName ||
-            event.refs?.operationId !== dispatch.operationId ||
-            event.refs?.toolCallId !== dispatch.providerToolCallId
-          ) {
-            throw new Error(`Corrupt tool dispatch RuntimeEvent ${event.id}`);
-          }
-          dispatches.push({ event, call, dispatch });
-          continue;
-        }
-        if (event.content?.kind === 'function_response' && event.refs?.operationId) {
-          const previous = responses.get(event.refs.operationId);
-          if (previous && !isDeepStrictEqual(previous, event)) {
-            throw new Error(`Conflicting tool response for ${event.refs.operationId}`);
-          }
-          responses.set(event.refs.operationId, event);
-        }
+        .all() as unknown as Array<
+        RuntimeEventStorageRow & { event_seq: number; committed_at: number }
+      >;
+      const events = rows.map(decodeRuntimeEventStorageRow);
+      const eventOrder = new Map(events.map((event, index) => [event.id, index] as const));
+      const committedAt = new Map(
+        rows.map((row, index) => [events[index]!.id, row.committed_at] as const),
+      );
+      const scan = scanToolLedger(events);
+      if (scan.hasCorruption) {
+        const first = scan.issues[0];
+        throw new Error(
+          `Corrupt tool RuntimeEvent ledger: ${first?.code ?? 'unknown'} at ${first?.eventId ?? 'unknown'}`,
+        );
       }
+      const projected = scan.operations.filter((operation) => operation.dispatchEvent);
 
       this.db.exec('DELETE FROM tool_journal_events; DELETE FROM tool_operations;');
       let journalEvents = 0;
-      for (const { event, call, dispatch } of dispatches) {
+      for (const operation of projected) {
+        const call = operation.callEvent;
+        const event = operation.dispatchEvent;
+        const dispatch = event?.actions?.toolDispatch;
+        if (!call || !event || !dispatch) {
+          throw new Error('Tool projection scan produced an incomplete dispatched operation');
+        }
+        const recovery = interpretScannedToolRecovery(operation, eventOrder);
+        if (recovery.kind === 'corruption') {
+          throw new Error(
+            `Corrupt tool recovery bundle for ${dispatch.operationId}: ${recovery.code}`,
+          );
+        }
+        const reconcileEvent = recovery.kind === 'valid' ? recovery.reconcileEvent : undefined;
+        const decisionEvent = recovery.kind === 'valid' ? recovery.decisionEvent : undefined;
+
         this.db
           .prepare(`
           INSERT INTO tool_journal_events (
@@ -540,22 +579,39 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
             event.id,
             dispatch.canonicalArgsHash,
             dispatch.recoveryMode,
-            event.ts,
+            committedAt.get(event.id) ?? event.ts,
           );
         journalEvents += 1;
-        const response = responses.get(dispatch.operationId);
-        if (
-          response &&
-          (response.content?.kind !== 'function_response' ||
-            response.invocationId !== event.invocationId ||
-            response.runId !== event.runId ||
-            response.turnId !== event.turnId ||
-            response.content.id !== dispatch.providerToolCallId ||
-            response.content.name !== dispatch.toolName ||
-            response.refs?.toolCallId !== dispatch.providerToolCallId)
-        ) {
-          throw new Error(`Corrupt tool response RuntimeEvent ${response.id}`);
-        }
+        const response = operation.responseEvent;
+        const decision = recovery.kind === 'valid' ? recovery.decision : undefined;
+        const currentState = decision
+          ? decision.disposition === 'completed'
+            ? 'recovery_completed'
+            : 'recovery_parked'
+          : response
+            ? 'outcome_committed'
+            : 'prepared';
+        const tail = [
+          ...(reconcileEvent
+            ? [{ event: reconcileEvent, state: 'reconcile_observed' as const }]
+            : []),
+          ...(response ? [{ event: response, state: 'outcome_committed' as const }] : []),
+          ...(decisionEvent
+            ? [
+                {
+                  event: decisionEvent,
+                  state:
+                    decision?.disposition === 'parked'
+                      ? ('recovery_parked' as const)
+                      : ('recovery_completed' as const),
+                },
+              ]
+            : []),
+        ].sort(
+          (a, b) =>
+            requireRuntimeEventOrder(eventOrder, a.event.id) -
+            requireRuntimeEventOrder(eventOrder, b.event.id),
+        );
         this.db
           .prepare(`
           INSERT INTO tool_operations (
@@ -573,36 +629,188 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
             dispatch.toolName,
             dispatch.canonicalArgsHash,
             dispatch.recoveryMode,
-            response ? 'outcome_committed' : 'prepared',
+            currentState,
             call.id,
             event.id,
             response?.id ?? null,
-            response ? 2 : 1,
+            1 + tail.length,
           );
-        if (response) {
+        for (const item of tail) {
           this.db
             .prepare(`
             INSERT INTO tool_journal_events (
               journal_event_id, operation_id, invocation_id, run_id, turn_id, state,
-              runtime_event_id, canonical_args_hash, recovery_mode, committed_at
-            ) VALUES (?, ?, ?, ?, ?, 'outcome_committed', ?, ?, ?, ?)
+              runtime_event_id, canonical_args_hash, recovery_mode, metadata_json, committed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
           `)
             .run(
-              `${dispatch.operationId}_outcome`,
+              journalEventIdFor(dispatch.operationId, item.event, item.state),
               dispatch.operationId,
-              response.invocationId,
-              response.runId,
-              response.turnId,
-              response.id,
+              item.event.invocationId,
+              item.event.runId,
+              item.event.turnId,
+              item.state,
+              item.event.id,
               dispatch.canonicalArgsHash,
               dispatch.recoveryMode,
-              response.ts,
+              item.event.actions?.toolRecovery
+                ? JSON.stringify(item.event.actions.toolRecovery)
+                : null,
+              committedAt.get(item.event.id) ?? item.event.ts,
             );
           journalEvents += 1;
         }
       }
-      return { operations: dispatches.length, journalEvents };
+      return { operations: projected.length, journalEvents };
     });
+  }
+
+  private commitToolOutcomeSync(input: CommitToolOutcomeInput): ToolCommitResult {
+    const operation = this.readToolOperationSync(input.operationId);
+    if (!operation) throw new Error(`Unknown tool operation ${input.operationId}`);
+    assertOutcomeIdentity(operation, input.runtimeEvent);
+    if (operation.resultEventId) {
+      if (operation.resultEventId !== input.runtimeEvent.id) {
+        throw new Error(`Tool operation outcome conflict for ${input.operationId}`);
+      }
+      assertStoredRuntimeEventEquals(
+        input.runtimeEvent,
+        this.readRuntimeEventJson(input.runtimeEvent.id),
+      );
+      return { created: false, runtimeEventSeq: this.runtimeEventSeq(input.runtimeEvent.id) };
+    }
+    const runtimeEventSeq = this.insertRuntimeEvent(input.runtimeEvent, input.committedAt, false);
+    this.options.failpoint?.('after_runtime_event_insert');
+    this.insertToolJournalEvent(
+      operation,
+      input.runtimeEvent,
+      'outcome_committed',
+      input.journalEventId,
+    );
+    const updated = this.db
+      .prepare(`
+      UPDATE tool_operations
+      SET current_state = 'outcome_committed', result_event_id = ?, version = version + 1
+      WHERE operation_id = ? AND current_state = 'prepared' AND result_event_id IS NULL
+    `)
+      .run(input.runtimeEvent.id, input.operationId);
+    if (updated.changes !== 1) {
+      throw new Error(`Tool operation compare-and-set failed for ${input.operationId}`);
+    }
+    return { created: true, runtimeEventSeq };
+  }
+
+  private commitRecoveryFactSync(
+    operation: ToolOperationRecord,
+    event: RuntimeEvent,
+    state: 'reconcile_observed' | 'recovery_completed' | 'recovery_parked',
+    decision?: ToolRecoveryDecisionFact,
+  ): void {
+    this.insertRuntimeEvent(event, event.ts, false);
+    this.options.failpoint?.('after_runtime_event_insert');
+    this.insertToolJournalEvent(operation, event, state);
+    if (state === 'reconcile_observed') {
+      const updated = this.db
+        .prepare('UPDATE tool_operations SET version = version + 1 WHERE operation_id = ?')
+        .run(operation.operationId);
+      if (updated.changes !== 1) {
+        throw new Error(`Tool operation compare-and-set failed for ${operation.operationId}`);
+      }
+      return;
+    }
+
+    if (
+      state === 'recovery_completed' &&
+      (decision?.disposition !== 'completed' ||
+        operation.currentState !== 'outcome_committed' ||
+        operation.resultEventId !== decision.outcomeEventId)
+    ) {
+      throw new Error('Completed recovery decision does not match the persisted outcome');
+    }
+    if (
+      state === 'recovery_parked' &&
+      (decision?.disposition !== 'parked' ||
+        operation.currentState !== 'prepared' ||
+        operation.resultEventId !== undefined)
+    ) {
+      throw new Error('Parked recovery decision does not match the prepared operation');
+    }
+    const updated = this.db
+      .prepare(`
+      UPDATE tool_operations
+      SET current_state = ?, version = version + 1
+      WHERE operation_id = ? AND current_state = ?
+    `)
+      .run(
+        state,
+        operation.operationId,
+        state === 'recovery_completed' ? 'outcome_committed' : 'prepared',
+      );
+    if (updated.changes !== 1) {
+      throw new Error(`Tool operation compare-and-set failed for ${operation.operationId}`);
+    }
+  }
+
+  private insertToolJournalEvent(
+    operation: ToolOperationRecord,
+    event: RuntimeEvent,
+    state: ToolJournalState,
+    journalEventId = `${event.id}_journal`,
+  ): void {
+    this.db
+      .prepare(`
+      INSERT INTO tool_journal_events (
+        journal_event_id, operation_id, invocation_id, run_id, turn_id, state,
+        runtime_event_id, canonical_args_hash, recovery_mode, metadata_json, committed_at
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `)
+      .run(
+        journalEventId,
+        operation.operationId,
+        operation.invocationId,
+        operation.runId,
+        operation.turnId,
+        state,
+        event.id,
+        operation.canonicalArgsHash,
+        operation.recoveryMode,
+        event.actions?.toolRecovery ? JSON.stringify(event.actions.toolRecovery) : null,
+        event.ts,
+      );
+    this.options.failpoint?.('after_journal_event_insert');
+  }
+
+  private assertExactRecoveryBundleAlreadyCommitted(
+    input: RuntimeRecoveryBundleCommit,
+    operation: ToolOperationRecord,
+  ): void {
+    const decision = input.decisionRuntimeEvent.actions?.toolRecovery;
+    const completed =
+      decision?.kind === 'maka.tool.recovery_decision' &&
+      decision.payload.disposition === 'completed';
+    if (
+      (completed &&
+        (!input.outcomeRuntimeEvent ||
+          operation.currentState !== 'recovery_completed' ||
+          operation.resultEventId !== input.outcomeRuntimeEvent.id)) ||
+      (!completed &&
+        (input.outcomeRuntimeEvent !== undefined ||
+          operation.currentState !== 'recovery_parked' ||
+          operation.resultEventId !== undefined))
+    ) {
+      throw new Error(`Tool operation ${operation.operationId} is already settled`);
+    }
+    for (const event of [
+      input.reconcileRuntimeEvent,
+      ...(input.outcomeRuntimeEvent ? [input.outcomeRuntimeEvent] : []),
+      input.decisionRuntimeEvent,
+    ]) {
+      const stored = this.readRuntimeEventJson(event.id);
+      if (stored === undefined) {
+        throw new Error(`Tool recovery bundle is incomplete for ${operation.operationId}`);
+      }
+      assertStoredRuntimeEventEquals(event, stored);
+    }
   }
 
   private transaction<T>(operation: () => T): T {
@@ -723,13 +931,13 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
   private hasCompletedPartialStream(sessionId: string, runId: string, streamKey: string): boolean {
     const rows = this.db
       .prepare(`
-      SELECT payload_json FROM runtime_events WHERE session_id = ? AND run_id = ?
+      SELECT event_id, session_id, invocation_id, run_id, turn_id, payload_json
+      FROM runtime_events
+      WHERE session_id = ? AND run_id = ?
     `)
-      .all(sessionId, runId) as Array<{ payload_json: string }>;
+      .all(sessionId, runId) as unknown as RuntimeEventStorageRow[];
     return rows.some(
-      (row) =>
-        completedPartialRuntimeStreamKey(JSON.parse(row.payload_json) as RuntimeEvent) ===
-        streamKey,
+      (row) => completedPartialRuntimeStreamKey(decodeRuntimeEventStorageRow(row)) === streamKey,
     );
   }
 
@@ -757,10 +965,19 @@ export class SqliteRuntimeStore implements RuntimeEventStore {
   private readRuntimeEventJson(eventId: string): string | undefined {
     const row = this.db
       .prepare(`
-      SELECT payload_json FROM runtime_events WHERE event_id = ?
+      SELECT event_id, session_id, invocation_id, run_id, turn_id, payload_json
+      FROM runtime_events
+      WHERE event_id = ?
     `)
-      .get(eventId) as { payload_json: string } | undefined;
+      .get(eventId) as RuntimeEventStorageRow | undefined;
+    if (row) decodeRuntimeEventStorageRow(row);
     return row?.payload_json;
+  }
+
+  private readRequiredRuntimeEvent(eventId: string): RuntimeEvent {
+    const stored = this.readRuntimeEventJson(eventId);
+    if (stored === undefined) throw new Error(`Missing RuntimeEvent ${eventId}`);
+    return decodeStoredRuntimeEvent(stored);
   }
 
   private readToolOperationSync(operationId: string): ToolOperationRecord | undefined {
@@ -786,7 +1003,7 @@ interface ToolOperationRow {
   tool_name: string;
   canonical_args_hash: string;
   recovery_mode: ToolRecoveryMode;
-  current_state: 'prepared' | 'outcome_committed';
+  current_state: 'prepared' | 'outcome_committed' | 'recovery_completed' | 'recovery_parked';
   call_event_id: string;
   dispatch_event_id: string | null;
   result_event_id: string | null;
@@ -844,11 +1061,25 @@ function toolJournalRecordFromRow(row: ToolJournalRow): ToolJournalEventRecord {
 }
 
 function assertPreparedInput(input: CommitToolPreparedInput): void {
+  assertNoReservedRecoveryFact(input.runtimeEvent);
+  assertNoReservedRecoveryFact(input.dispatchRuntimeEvent);
   const content = input.runtimeEvent.content;
   if (content?.kind !== 'function_call')
     throw new Error('T1 requires a function_call RuntimeEvent');
   if (content.id !== input.providerToolCallId || content.name !== input.toolName) {
     throw new Error('T1 RuntimeEvent identity does not match the tool operation');
+  }
+  let derivedArgsHash: string;
+  try {
+    derivedArgsHash = canonicalToolArgsHash(content.name, content.args);
+  } catch {
+    throw new Error('T1 argument hash does not match its canonical function call');
+  }
+  if (
+    derivedArgsHash !== input.canonicalArgsHash ||
+    validateToolLedgerEventLane(input.runtimeEvent).ok !== true
+  ) {
+    throw new Error('T1 argument hash does not match its canonical function call');
   }
   const dispatch = input.dispatchRuntimeEvent.actions?.toolDispatch;
   if (
@@ -859,7 +1090,8 @@ function assertPreparedInput(input: CommitToolPreparedInput): void {
     dispatch.providerToolCallId !== input.providerToolCallId ||
     dispatch.toolName !== input.toolName ||
     dispatch.canonicalArgsHash !== input.canonicalArgsHash ||
-    dispatch.recoveryMode !== input.recoveryMode
+    dispatch.recoveryMode !== input.recoveryMode ||
+    validateToolLedgerEventLane(input.dispatchRuntimeEvent).ok !== true
   ) {
     throw new Error('T1 requires a matching tool-dispatch RuntimeEvent');
   }
@@ -867,6 +1099,7 @@ function assertPreparedInput(input: CommitToolPreparedInput): void {
 }
 
 function assertOutcomeInput(input: CommitToolOutcomeInput): void {
+  assertNoReservedRecoveryFact(input.runtimeEvent);
   const content = input.runtimeEvent.content;
   if (content?.kind !== 'function_response') {
     throw new Error('T2 requires a function_response RuntimeEvent');
@@ -878,6 +1111,9 @@ function assertOutcomeInput(input: CommitToolOutcomeInput): void {
     throw new Error(
       'T2 requires operation and tool-call refs on the function_response RuntimeEvent',
     );
+  }
+  if (validateToolLedgerEventLane(input.runtimeEvent).ok !== true) {
+    throw new Error('T2 requires one canonical function-response semantic lane');
   }
 }
 
@@ -928,6 +1164,7 @@ function assertOutcomeIdentity(operation: ToolOperationRecord, event: RuntimeEve
 }
 
 function assertRuntimeEventIdentity(event: RuntimeEvent): void {
+  decodeRuntimeEvent(event);
   for (const [field, value] of Object.entries({
     id: event.id,
     sessionId: event.sessionId,
@@ -942,10 +1179,136 @@ function assertRuntimeEventIdentity(event: RuntimeEvent): void {
 
 function assertStoredRuntimeEventEquals(event: RuntimeEvent, storedJson: string | undefined): void {
   if (storedJson === undefined) return;
-  const stored = JSON.parse(storedJson) as RuntimeEvent;
+  const stored = decodeStoredRuntimeEvent(storedJson);
   if (!isDeepStrictEqual(stored, event)) {
     throw new Error(`RuntimeEvent identity conflict for ${event.id}`);
   }
+}
+
+function assertNoReservedRecoveryFact(event: RuntimeEvent): void {
+  if (event.actions?.toolRecovery !== undefined) {
+    throw new Error('Tool recovery facts require the atomic recovery bundle writer');
+  }
+}
+
+function assertNoReservedToolLedgerFact(event: RuntimeEvent): void {
+  const validation = validateGenericToolLedgerAppend(event);
+  if (validation.ok) return;
+  if (validation.code === 'reserved_recovery_fact') {
+    throw new Error('Tool recovery facts require the atomic recovery bundle writer');
+  }
+  if (validation.code === 'reserved_tool_boundary_fact') {
+    throw new Error('Durable tool facts require the atomic tool boundary writer');
+  }
+  throw new Error(`RuntimeEvent ${event.id} violates its semantic lane`);
+}
+
+function recoveryOperationIdentity(operation: ToolOperationRecord) {
+  if (!operation.dispatchEventId) {
+    throw new Error('Recovery bundle requires a durable dispatch RuntimeEvent');
+  }
+  return {
+    operationId: operation.operationId,
+    invocationId: operation.invocationId,
+    runId: operation.runId,
+    turnId: operation.turnId,
+    providerToolCallId: operation.providerToolCallId,
+    toolName: operation.toolName,
+    canonicalArgsHash: operation.canonicalArgsHash,
+    recoveryMode: operation.recoveryMode,
+    callEventId: operation.callEventId,
+    dispatchEventId: operation.dispatchEventId,
+  };
+}
+
+function assertStrictRuntimeEventOrder(eventSequences: readonly number[]): void {
+  if (
+    eventSequences.some(
+      (eventSequence, index) => index > 0 && eventSequence <= (eventSequences[index - 1] ?? -1),
+    )
+  ) {
+    throw new Error('Recovery facts violate canonical RuntimeEvent causal order');
+  }
+}
+
+function requireRuntimeEventOrder(
+  eventOrder: ReadonlyMap<string, number>,
+  eventId: string,
+): number {
+  const order = eventOrder.get(eventId);
+  if (order === undefined) throw new Error(`Missing RuntimeEvent order for ${eventId}`);
+  return order;
+}
+
+function journalEventIdFor(
+  operationId: string,
+  event: RuntimeEvent,
+  state: Exclude<ToolJournalState, 'prepared'>,
+): string {
+  return state === 'outcome_committed' ? `${operationId}_outcome` : `${event.id}_journal`;
+}
+
+function assertRecoveryAuthorityCapability(db: DatabaseSync): void {
+  const row = db
+    .prepare('SELECT version FROM runtime_capabilities WHERE capability = ?')
+    .get(RUNTIME_RECOVERY_AUTHORITY_CAPABILITY) as { version?: unknown } | undefined;
+  if (row?.version !== RUNTIME_RECOVERY_AUTHORITY_CAPABILITY_VERSION) {
+    throw new Error(
+      `SQLite runtime recovery capability ${RUNTIME_RECOVERY_AUTHORITY_CAPABILITY}@${RUNTIME_RECOVERY_AUTHORITY_CAPABILITY_VERSION} is unavailable`,
+    );
+  }
+}
+
+interface RuntimeEventStorageRow {
+  event_id: string;
+  session_id: string;
+  invocation_id: string;
+  run_id: string;
+  turn_id: string;
+  payload_json: string;
+}
+
+interface RuntimePartialStorageRow {
+  stream_key: string;
+  session_id: string;
+  invocation_id: string;
+  run_id: string;
+  turn_id: string;
+  payload_json: string;
+  text_content: string;
+  after_event_id: string | null;
+}
+
+function decodeRuntimeEventStorageRow(row: RuntimeEventStorageRow): RuntimeEvent {
+  const event = decodeStoredRuntimeEvent(row.payload_json);
+  if (
+    event.id !== row.event_id ||
+    event.sessionId !== row.session_id ||
+    event.invocationId !== row.invocation_id ||
+    event.runId !== row.run_id ||
+    event.turnId !== row.turn_id
+  ) {
+    throw new Error(`RuntimeEvent row/payload identity mismatch for ${row.event_id}`);
+  }
+  return event;
+}
+
+function decodeRuntimePartialStorageRow(row: RuntimePartialStorageRow): RuntimeEvent {
+  const event = decodeStoredRuntimeEvent(row.payload_json);
+  if (
+    event.sessionId !== row.session_id ||
+    event.invocationId !== row.invocation_id ||
+    event.runId !== row.run_id ||
+    event.turnId !== row.turn_id ||
+    partialRuntimeStream(event)?.key !== row.stream_key
+  ) {
+    throw new Error(`Runtime partial row/payload identity mismatch for ${row.stream_key}`);
+  }
+  return event;
+}
+
+function decodeStoredRuntimeEvent(storedJson: string): RuntimeEvent {
+  return decodeRuntimeEvent(JSON.parse(storedJson));
 }
 
 function runtimeEventKind(event: RuntimeEvent): string {
@@ -955,10 +1318,6 @@ function runtimeEventKind(event: RuntimeEvent): string {
     (event.actions?.toolDispatch ? 'tool_dispatch' : undefined) ??
     (event.actions?.endInvocation ? 'invocation_end' : 'runtime_fact')
   );
-}
-
-function toolCallProjectionKey(invocationId: string, providerToolCallId: string): string {
-  return `${invocationId}\0${providerToolCallId}`;
 }
 
 interface RuntimePartialSnapshot {

--- a/packages/storage/src/sqlite-runtime-store.ts
+++ b/packages/storage/src/sqlite-runtime-store.ts
@@ -13,6 +13,7 @@ import {
   TOOL_RECOVERY_BUNDLE_CAPABILITY_V1,
   validateGenericToolLedgerAppend,
   validateToolLedgerEventLane,
+  validateToolLedgerTransition,
   type RuntimeEvent,
   type RuntimeRecoveryBundleCommit,
   type RuntimeRecoveryBundleStore,
@@ -249,6 +250,14 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
           return { created: [], sourceAlreadyImported: true };
         }
       }
+      if (input.events.some(isToolLedgerBearingEvent)) {
+        this.assertToolLedgerTransition(
+          input.sessionId,
+          input.runId,
+          input.events,
+          'generic_append',
+        );
+      }
       const created = input.events.map((event) => this.importRuntimeEventSync(event));
       if (input.source) {
         this.db
@@ -366,6 +375,12 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
           runtimeEventSeq: this.runtimeEventSeq(input.dispatchRuntimeEvent.id),
         };
       }
+      this.assertToolLedgerTransition(
+        input.runtimeEvent.sessionId,
+        input.runtimeEvent.runId,
+        [input.runtimeEvent, input.dispatchRuntimeEvent],
+        't1_prepare',
+      );
       this.insertRuntimeEvent(input.runtimeEvent, input.committedAt, true);
       const runtimeEventSeq = this.insertRuntimeEvent(
         input.dispatchRuntimeEvent,
@@ -441,11 +456,20 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
         this.runtimeEventSeq(operation.callEventId),
         this.runtimeEventSeq(operation.dispatchEventId),
       ]);
-
       if (operation.currentState !== 'prepared' || operation.resultEventId !== undefined) {
         this.assertExactRecoveryBundleAlreadyCommitted(input, operation);
         return;
       }
+      this.assertToolLedgerTransition(
+        input.reconcileRuntimeEvent.sessionId,
+        input.reconcileRuntimeEvent.runId,
+        [
+          input.reconcileRuntimeEvent,
+          ...(input.outcomeRuntimeEvent ? [input.outcomeRuntimeEvent] : []),
+          input.decisionRuntimeEvent,
+        ],
+        'recovery_bundle',
+      );
 
       this.commitRecoveryFactSync(operation, input.reconcileRuntimeEvent, 'reconcile_observed');
       this.options.failpoint?.('after_recovery_reconcile');
@@ -486,7 +510,9 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
         tool_name, canonical_args_hash, recovery_mode, current_state,
         call_event_id, dispatch_event_id, result_event_id, version
       FROM tool_operations
-      WHERE current_state = 'prepared' AND result_event_id IS NULL
+      WHERE current_state = 'prepared'
+        AND result_event_id IS NULL
+        AND dispatch_event_id IS NOT NULL
       ORDER BY invocation_id ASC, operation_id ASC
     `)
       .all() as unknown as ToolOperationRow[];
@@ -509,18 +535,6 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
 
   async rebuildToolProjectionsFromRuntimeEvents(): Promise<ToolProjectionRebuildResult> {
     return this.transaction(() => {
-      const legacy = this.db
-        .prepare(`
-        SELECT operation_id FROM tool_operations
-        WHERE dispatch_event_id IS NULL
-        LIMIT 1
-      `)
-        .get() as { operation_id: string } | undefined;
-      if (legacy) {
-        throw new Error(
-          `Cannot rebuild legacy tool operation ${legacy.operation_id} without a dispatch RuntimeEvent`,
-        );
-      }
       const rows = this.db
         .prepare(`
         SELECT event_id, session_id, invocation_id, run_id, turn_id,
@@ -545,7 +559,16 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
       }
       const projected = scan.operations.filter((operation) => operation.dispatchEvent);
 
-      this.db.exec('DELETE FROM tool_journal_events; DELETE FROM tool_operations;');
+      // Mainline schema 4 can contain pre-authority projections without a
+      // dispatch RuntimeEvent. They remain readable but quarantined from
+      // recovery; only projections backed by canonical T1 facts are rebuilt.
+      this.db.exec(`
+        DELETE FROM tool_journal_events
+        WHERE operation_id IN (
+          SELECT operation_id FROM tool_operations WHERE dispatch_event_id IS NOT NULL
+        );
+        DELETE FROM tool_operations WHERE dispatch_event_id IS NOT NULL;
+      `);
       let journalEvents = 0;
       for (const operation of projected) {
         const call = operation.callEvent;
@@ -679,6 +702,12 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
       );
       return { created: false, runtimeEventSeq: this.runtimeEventSeq(input.runtimeEvent.id) };
     }
+    this.assertToolLedgerTransition(
+      input.runtimeEvent.sessionId,
+      input.runtimeEvent.runId,
+      [input.runtimeEvent],
+      't2_outcome',
+    );
     const runtimeEventSeq = this.insertRuntimeEvent(input.runtimeEvent, input.committedAt, false);
     this.options.failpoint?.('after_runtime_event_insert');
     this.insertToolJournalEvent(
@@ -686,6 +715,7 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
       input.runtimeEvent,
       'outcome_committed',
       input.journalEventId,
+      input.committedAt,
     );
     const updated = this.db
       .prepare(`
@@ -756,6 +786,7 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     event: RuntimeEvent,
     state: ToolJournalState,
     journalEventId = `${event.id}_journal`,
+    committedAt = event.ts,
   ): void {
     this.db
       .prepare(`
@@ -775,7 +806,7 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
         operation.canonicalArgsHash,
         operation.recoveryMode,
         event.actions?.toolRecovery ? JSON.stringify(event.actions.toolRecovery) : null,
-        event.ts,
+        committedAt,
       );
     this.options.failpoint?.('after_journal_event_insert');
   }
@@ -829,11 +860,46 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     }
   }
 
+  private assertToolLedgerTransition(
+    sessionId: string,
+    runId: string,
+    candidateEvents: readonly RuntimeEvent[],
+    expectedTransition: Parameters<typeof validateToolLedgerTransition>[0]['expectedTransition'],
+  ): void {
+    const rows = this.db
+      .prepare(`
+        SELECT event_id, session_id, invocation_id, run_id, turn_id, payload_json
+        FROM runtime_events
+        WHERE session_id = ? AND run_id = ?
+        ORDER BY event_seq ASC, event_id ASC
+      `)
+      .all(sessionId, runId) as unknown as RuntimeEventStorageRow[];
+    const validation = validateToolLedgerTransition({
+      existingEvents: rows.map(decodeRuntimeEventStorageRow),
+      candidateEvents: candidateEvents.map(canonicalizeRuntimeEventForStorage),
+      expectedTransition,
+    });
+    if (!validation.ok) {
+      throw new Error(
+        `Tool ledger transition rejected: ${validation.code} at ${validation.eventId}`,
+      );
+    }
+  }
+
   private importRuntimeEventSync(event: RuntimeEvent): boolean {
-    const partial = partialRuntimeStream(event);
-    if (partial) return this.upsertRuntimePartial(event, partial);
-    const existing = this.readRuntimeEventJson(event.id) !== undefined;
-    this.insertRuntimeEvent(event, event.ts, true);
+    const canonicalEvent = canonicalizeRuntimeEventForStorage(event);
+    const partial = partialRuntimeStream(canonicalEvent);
+    if (partial) return this.upsertRuntimePartial(canonicalEvent, partial);
+    if (isToolLedgerBearingEvent(canonicalEvent)) {
+      this.assertToolLedgerTransition(
+        canonicalEvent.sessionId,
+        canonicalEvent.runId,
+        [canonicalEvent],
+        'generic_append',
+      );
+    }
+    const existing = this.readRuntimeEventJson(canonicalEvent.id) !== undefined;
+    this.insertRuntimeEvent(canonicalEvent, canonicalEvent.ts, true);
     return !existing;
   }
 
@@ -842,36 +908,39 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     committedAt: number,
     allowExactDuplicate: boolean,
   ): number {
-    assertRuntimeEventIdentity(event);
-    const existingJson = this.readRuntimeEventJson(event.id);
+    const canonicalEvent = canonicalizeRuntimeEventForStorage(event);
+    assertRuntimeEventIdentity(canonicalEvent);
+    const existingJson = this.readRuntimeEventJson(canonicalEvent.id);
     if (existingJson !== undefined) {
-      assertStoredRuntimeEventEquals(event, existingJson);
-      this.deleteCompletedPartialSnapshot(event);
+      assertStoredRuntimeEventEquals(canonicalEvent, existingJson);
+      this.deleteCompletedPartialSnapshot(canonicalEvent);
       if (!allowExactDuplicate) {
-        throw new Error(`RuntimeEvent ${event.id} already exists outside this tool transaction`);
+        throw new Error(
+          `RuntimeEvent ${canonicalEvent.id} already exists outside this tool transaction`,
+        );
       }
-      return this.runtimeEventSeq(event.id);
+      return this.runtimeEventSeq(canonicalEvent.id);
     }
-    const next = this.nextRuntimeEventSeq(event.invocationId);
+    const next = this.nextRuntimeEventSeq(canonicalEvent.invocationId);
     this.db
       .prepare(`
       INSERT INTO runtime_events (
         event_id, session_id, invocation_id, run_id, turn_id, event_seq,
         event_kind, payload_json, committed_at
       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `)
+      `)
       .run(
-        event.id,
-        event.sessionId,
-        event.invocationId,
-        event.runId,
-        event.turnId,
+        canonicalEvent.id,
+        canonicalEvent.sessionId,
+        canonicalEvent.invocationId,
+        canonicalEvent.runId,
+        canonicalEvent.turnId,
         next,
-        runtimeEventKind(event),
-        JSON.stringify(event),
+        runtimeEventKind(canonicalEvent),
+        JSON.stringify(canonicalEvent),
         committedAt,
       );
-    this.deleteCompletedPartialSnapshot(event);
+    this.deleteCompletedPartialSnapshot(canonicalEvent);
     return next;
   }
 
@@ -1061,6 +1130,9 @@ function toolJournalRecordFromRow(row: ToolJournalRow): ToolJournalEventRecord {
 }
 
 function assertPreparedInput(input: CommitToolPreparedInput): void {
+  if (input.journalEventId !== `${input.operationId}_prepared`) {
+    throw new Error('T1 journal identity must be derived from the tool operation');
+  }
   assertNoReservedRecoveryFact(input.runtimeEvent);
   assertNoReservedRecoveryFact(input.dispatchRuntimeEvent);
   const content = input.runtimeEvent.content;
@@ -1099,6 +1171,9 @@ function assertPreparedInput(input: CommitToolPreparedInput): void {
 }
 
 function assertOutcomeInput(input: CommitToolOutcomeInput): void {
+  if (input.journalEventId !== `${input.operationId}_outcome`) {
+    throw new Error('T2 journal identity must be derived from the tool operation');
+  }
   assertNoReservedRecoveryFact(input.runtimeEvent);
   const content = input.runtimeEvent.content;
   if (content?.kind !== 'function_response') {
@@ -1180,9 +1255,17 @@ function assertRuntimeEventIdentity(event: RuntimeEvent): void {
 function assertStoredRuntimeEventEquals(event: RuntimeEvent, storedJson: string | undefined): void {
   if (storedJson === undefined) return;
   const stored = decodeStoredRuntimeEvent(storedJson);
-  if (!isDeepStrictEqual(stored, event)) {
+  if (!isDeepStrictEqual(stored, canonicalizeRuntimeEventForStorage(event))) {
     throw new Error(`RuntimeEvent identity conflict for ${event.id}`);
   }
+}
+
+function canonicalizeRuntimeEventForStorage(event: RuntimeEvent): RuntimeEvent {
+  // Decoder normalization is the canonical persisted representation. The
+  // second decode proves that JSON serialization did not erase any field that
+  // the RuntimeEvent schema requires (for example function-call args).
+  const decoded = decodeRuntimeEvent(event);
+  return decodeRuntimeEvent(JSON.parse(JSON.stringify(decoded)));
 }
 
 function assertNoReservedRecoveryFact(event: RuntimeEvent): void {
@@ -1201,6 +1284,15 @@ function assertNoReservedToolLedgerFact(event: RuntimeEvent): void {
     throw new Error('Durable tool facts require the atomic tool boundary writer');
   }
   throw new Error(`RuntimeEvent ${event.id} violates its semantic lane`);
+}
+
+function isToolLedgerBearingEvent(event: RuntimeEvent): boolean {
+  return (
+    event.content?.kind === 'function_call' ||
+    event.content?.kind === 'function_response' ||
+    event.actions?.toolDispatch !== undefined ||
+    event.actions?.toolRecovery !== undefined
+  );
 }
 
 function recoveryOperationIdentity(operation: ToolOperationRecord) {

--- a/packages/storage/src/sqlite-runtime-store.ts
+++ b/packages/storage/src/sqlite-runtime-store.ts
@@ -7,6 +7,7 @@ import { isDeepStrictEqual } from 'node:util';
 import {
   canonicalToolArgsHash,
   decodeRuntimeEvent,
+  encodeCanonicalRuntimeEvent,
   isPartialRuntimeEvent,
   isTerminalRuntimeEvent,
   scanToolLedger,
@@ -182,8 +183,9 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
   }
 
   async appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void> {
-    assertNoReservedToolLedgerFact(event);
-    await this.importRuntimeEvent(sessionId, runId, event);
+    const canonicalEvent = canonicalizeRuntimeEventForStorage(event);
+    assertNoReservedToolLedgerFact(canonicalEvent);
+    await this.importRuntimeEvent(sessionId, runId, canonicalEvent);
   }
 
   async ensureTerminalRuntimeEventDurable(
@@ -191,20 +193,23 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     runId: string,
     event: RuntimeEvent,
   ): Promise<void> {
-    assertNoReservedToolLedgerFact(event);
-    if (isPartialRuntimeEvent(event) || !isTerminalRuntimeEvent(event)) {
+    const canonicalEvent = canonicalizeRuntimeEventForStorage(event);
+    assertNoReservedToolLedgerFact(canonicalEvent);
+    if (isPartialRuntimeEvent(canonicalEvent) || !isTerminalRuntimeEvent(canonicalEvent)) {
       throw new Error(
         'Only a final terminal RuntimeEvent can cross the terminal durability barrier',
       );
     }
     const existing = await this.readImmutableRuntimeEvents(sessionId, runId);
-    const matching = existing.filter((candidate) => candidate.id === event.id);
+    const matching = existing.filter((candidate) => candidate.id === canonicalEvent.id);
     if (matching.length > 1) {
-      throw new Error(`RuntimeEvent ${event.id} appears more than once in run ${runId}`);
+      throw new Error(`RuntimeEvent ${canonicalEvent.id} appears more than once in run ${runId}`);
     }
     if (matching.length === 1) {
-      if (!isDeepStrictEqual(matching[0], event)) {
-        throw new Error(`RuntimeEvent ${event.id} does not match the durable ledger record`);
+      if (!isDeepStrictEqual(matching[0], canonicalEvent)) {
+        throw new Error(
+          `RuntimeEvent ${canonicalEvent.id} does not match the durable ledger record`,
+        );
       }
       return;
     }
@@ -212,7 +217,7 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     if (existingTerminal) {
       throw new Error(`Run ${runId} already has terminal RuntimeEvent ${existingTerminal.id}`);
     }
-    await this.importRuntimeEvent(sessionId, runId, event);
+    await this.importRuntimeEvent(sessionId, runId, canonicalEvent);
   }
 
   async importRuntimeEvent(
@@ -220,11 +225,12 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     runId: string,
     event: RuntimeEvent,
   ): Promise<boolean> {
-    assertNoReservedToolLedgerFact(event);
-    if (sessionId !== event.sessionId || runId !== event.runId) {
-      throw new Error(`RuntimeEvent store identity does not match event ${event.id}`);
+    const canonicalEvent = canonicalizeRuntimeEventForStorage(event);
+    assertNoReservedToolLedgerFact(canonicalEvent);
+    if (sessionId !== canonicalEvent.sessionId || runId !== canonicalEvent.runId) {
+      throw new Error(`RuntimeEvent store identity does not match event ${canonicalEvent.id}`);
     }
-    return this.transaction(() => this.importRuntimeEventSync(event));
+    return this.transaction(() => this.importRuntimeEventSync(canonicalEvent));
   }
 
   async importRuntimeEventsBatch(input: {
@@ -233,7 +239,8 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     events: readonly RuntimeEvent[];
     source?: { path: string; fingerprint: string };
   }): Promise<RuntimeEventBatchImportResult> {
-    for (const event of input.events) {
+    const events = input.events.map(canonicalizeRuntimeEventForStorage);
+    for (const event of events) {
       assertNoReservedToolLedgerFact(event);
       if (event.sessionId !== input.sessionId || event.runId !== input.runId) {
         throw new Error(`RuntimeEvent store identity does not match event ${event.id}`);
@@ -250,15 +257,10 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
           return { created: [], sourceAlreadyImported: true };
         }
       }
-      if (input.events.some(isToolLedgerBearingEvent)) {
-        this.assertToolLedgerTransition(
-          input.sessionId,
-          input.runId,
-          input.events,
-          'generic_append',
-        );
+      if (events.some(isToolLedgerBearingEvent)) {
+        this.assertToolLedgerTransition(events, 'generic_append');
       }
-      const created = input.events.map((event) => this.importRuntimeEventSync(event));
+      const created = events.map((event) => this.importRuntimeEventSync(event));
       if (input.source) {
         this.db
           .prepare(`
@@ -357,34 +359,37 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
   }
 
   async commitToolPrepared(input: CommitToolPreparedInput): Promise<ToolCommitResult> {
-    assertPreparedInput(input);
+    const canonicalInput: CommitToolPreparedInput = {
+      ...input,
+      runtimeEvent: canonicalizeRuntimeEventForStorage(input.runtimeEvent),
+      dispatchRuntimeEvent: canonicalizeRuntimeEventForStorage(input.dispatchRuntimeEvent),
+    };
+    assertPreparedInput(canonicalInput);
     return this.transaction(() => {
-      const existing = this.readToolOperationSync(input.operationId);
+      this.assertToolLedgerTransition(
+        [canonicalInput.runtimeEvent, canonicalInput.dispatchRuntimeEvent],
+        't1_prepare',
+      );
+      const existing = this.readToolOperationSync(canonicalInput.operationId);
       if (existing) {
-        assertPreparedIdentity(existing, input);
+        assertPreparedIdentity(existing, canonicalInput);
         assertStoredRuntimeEventEquals(
-          input.runtimeEvent,
-          this.readRuntimeEventJson(input.runtimeEvent.id),
+          canonicalInput.runtimeEvent,
+          this.readRuntimeEventJson(canonicalInput.runtimeEvent.id),
         );
         assertStoredRuntimeEventEquals(
-          input.dispatchRuntimeEvent,
-          this.readRuntimeEventJson(input.dispatchRuntimeEvent.id),
+          canonicalInput.dispatchRuntimeEvent,
+          this.readRuntimeEventJson(canonicalInput.dispatchRuntimeEvent.id),
         );
         return {
           created: false,
-          runtimeEventSeq: this.runtimeEventSeq(input.dispatchRuntimeEvent.id),
+          runtimeEventSeq: this.runtimeEventSeq(canonicalInput.dispatchRuntimeEvent.id),
         };
       }
-      this.assertToolLedgerTransition(
-        input.runtimeEvent.sessionId,
-        input.runtimeEvent.runId,
-        [input.runtimeEvent, input.dispatchRuntimeEvent],
-        't1_prepare',
-      );
-      this.insertRuntimeEvent(input.runtimeEvent, input.committedAt, true);
+      this.insertRuntimeEvent(canonicalInput.runtimeEvent, canonicalInput.committedAt, true);
       const runtimeEventSeq = this.insertRuntimeEvent(
-        input.dispatchRuntimeEvent,
-        input.committedAt,
+        canonicalInput.dispatchRuntimeEvent,
+        canonicalInput.committedAt,
         false,
       );
       this.options.failpoint?.('after_runtime_event_insert');
@@ -396,15 +401,15 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
         ) VALUES (?, ?, ?, ?, ?, 'prepared', ?, ?, ?, ?)
       `)
         .run(
-          input.journalEventId,
-          input.operationId,
-          input.runtimeEvent.invocationId,
-          input.runtimeEvent.runId,
-          input.runtimeEvent.turnId,
-          input.dispatchRuntimeEvent.id,
-          input.canonicalArgsHash,
-          input.recoveryMode,
-          input.committedAt,
+          canonicalInput.journalEventId,
+          canonicalInput.operationId,
+          canonicalInput.runtimeEvent.invocationId,
+          canonicalInput.runtimeEvent.runId,
+          canonicalInput.runtimeEvent.turnId,
+          canonicalInput.dispatchRuntimeEvent.id,
+          canonicalInput.canonicalArgsHash,
+          canonicalInput.recoveryMode,
+          canonicalInput.committedAt,
         );
       this.options.failpoint?.('after_journal_event_insert');
       this.db
@@ -416,31 +421,45 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 'prepared', ?, ?, 1)
       `)
         .run(
-          input.operationId,
-          input.runtimeEvent.invocationId,
-          input.runtimeEvent.runId,
-          input.runtimeEvent.turnId,
-          input.providerToolCallId,
-          input.toolName,
-          input.canonicalArgsHash,
-          input.recoveryMode,
-          input.runtimeEvent.id,
-          input.dispatchRuntimeEvent.id,
+          canonicalInput.operationId,
+          canonicalInput.runtimeEvent.invocationId,
+          canonicalInput.runtimeEvent.runId,
+          canonicalInput.runtimeEvent.turnId,
+          canonicalInput.providerToolCallId,
+          canonicalInput.toolName,
+          canonicalInput.canonicalArgsHash,
+          canonicalInput.recoveryMode,
+          canonicalInput.runtimeEvent.id,
+          canonicalInput.dispatchRuntimeEvent.id,
         );
       return { created: true, runtimeEventSeq };
     });
   }
 
   async commitToolOutcome(input: CommitToolOutcomeInput): Promise<ToolCommitResult> {
-    assertOutcomeInput(input);
-    return this.transaction(() => this.commitToolOutcomeSync(input));
+    const canonicalInput: CommitToolOutcomeInput = {
+      ...input,
+      runtimeEvent: canonicalizeRuntimeEventForStorage(input.runtimeEvent),
+    };
+    assertOutcomeInput(canonicalInput);
+    return this.transaction(() => this.commitToolOutcomeSync(canonicalInput));
   }
 
   async commitToolRecoveryBundle(input: RuntimeRecoveryBundleCommit): Promise<void> {
-    if (input.outcomeRuntimeEvent) assertNoReservedRecoveryFact(input.outcomeRuntimeEvent);
+    const canonicalInput: RuntimeRecoveryBundleCommit = {
+      ...input,
+      reconcileRuntimeEvent: canonicalizeRuntimeEventForStorage(input.reconcileRuntimeEvent),
+      ...(input.outcomeRuntimeEvent
+        ? { outcomeRuntimeEvent: canonicalizeRuntimeEventForStorage(input.outcomeRuntimeEvent) }
+        : {}),
+      decisionRuntimeEvent: canonicalizeRuntimeEventForStorage(input.decisionRuntimeEvent),
+    };
+    if (canonicalInput.outcomeRuntimeEvent) {
+      assertNoReservedRecoveryFact(canonicalInput.outcomeRuntimeEvent);
+    }
     this.transaction(() => {
-      const operation = this.readToolOperationSync(input.operationId);
-      if (!operation) throw new Error(`Unknown tool operation ${input.operationId}`);
+      const operation = this.readToolOperationSync(canonicalInput.operationId);
+      if (!operation) throw new Error(`Unknown tool operation ${canonicalInput.operationId}`);
       if (!operation.dispatchEventId) {
         throw new Error('Recovery bundle requires a durable dispatch RuntimeEvent');
       }
@@ -448,50 +467,52 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
         operation: recoveryOperationIdentity(operation),
         callEvent: this.readRequiredRuntimeEvent(operation.callEventId),
         dispatchEvent: this.readRequiredRuntimeEvent(operation.dispatchEventId),
-        reconcileEvent: input.reconcileRuntimeEvent,
-        outcomeEvent: input.outcomeRuntimeEvent,
-        decisionEvent: input.decisionRuntimeEvent,
+        reconcileEvent: canonicalInput.reconcileRuntimeEvent,
+        outcomeEvent: canonicalInput.outcomeRuntimeEvent,
+        decisionEvent: canonicalInput.decisionRuntimeEvent,
       });
       assertStrictRuntimeEventOrder([
         this.runtimeEventSeq(operation.callEventId),
         this.runtimeEventSeq(operation.dispatchEventId),
       ]);
-      if (operation.currentState !== 'prepared' || operation.resultEventId !== undefined) {
-        this.assertExactRecoveryBundleAlreadyCommitted(input, operation);
-        return;
-      }
       this.assertToolLedgerTransition(
-        input.reconcileRuntimeEvent.sessionId,
-        input.reconcileRuntimeEvent.runId,
         [
-          input.reconcileRuntimeEvent,
-          ...(input.outcomeRuntimeEvent ? [input.outcomeRuntimeEvent] : []),
-          input.decisionRuntimeEvent,
+          canonicalInput.reconcileRuntimeEvent,
+          ...(canonicalInput.outcomeRuntimeEvent ? [canonicalInput.outcomeRuntimeEvent] : []),
+          canonicalInput.decisionRuntimeEvent,
         ],
         'recovery_bundle',
       );
+      if (operation.currentState !== 'prepared' || operation.resultEventId !== undefined) {
+        this.assertExactRecoveryBundleAlreadyCommitted(canonicalInput, operation);
+        return;
+      }
 
-      this.commitRecoveryFactSync(operation, input.reconcileRuntimeEvent, 'reconcile_observed');
+      this.commitRecoveryFactSync(
+        operation,
+        canonicalInput.reconcileRuntimeEvent,
+        'reconcile_observed',
+      );
       this.options.failpoint?.('after_recovery_reconcile');
-      if (input.outcomeRuntimeEvent) {
+      if (canonicalInput.outcomeRuntimeEvent) {
         this.commitToolOutcomeSync({
-          operationId: input.operationId,
-          journalEventId: `${input.operationId}_outcome`,
-          runtimeEvent: input.outcomeRuntimeEvent,
-          committedAt: input.outcomeRuntimeEvent.ts,
+          operationId: canonicalInput.operationId,
+          journalEventId: `${canonicalInput.operationId}_outcome`,
+          runtimeEvent: canonicalInput.outcomeRuntimeEvent,
+          committedAt: canonicalInput.outcomeRuntimeEvent.ts,
         });
         this.options.failpoint?.('after_recovery_outcome');
       }
 
-      const decision = input.decisionRuntimeEvent.actions?.toolRecovery;
+      const decision = canonicalInput.decisionRuntimeEvent.actions?.toolRecovery;
       if (!decision || decision.kind !== 'maka.tool.recovery_decision') {
         throw new Error('Recovery bundle requires a recovery decision');
       }
-      const current = this.readToolOperationSync(input.operationId);
-      if (!current) throw new Error(`Unknown tool operation ${input.operationId}`);
+      const current = this.readToolOperationSync(canonicalInput.operationId);
+      if (!current) throw new Error(`Unknown tool operation ${canonicalInput.operationId}`);
       this.commitRecoveryFactSync(
         current,
-        input.decisionRuntimeEvent,
+        canonicalInput.decisionRuntimeEvent,
         decision.payload.disposition === 'completed' ? 'recovery_completed' : 'recovery_parked',
         decision.payload,
       );
@@ -692,6 +713,7 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     const operation = this.readToolOperationSync(input.operationId);
     if (!operation) throw new Error(`Unknown tool operation ${input.operationId}`);
     assertOutcomeIdentity(operation, input.runtimeEvent);
+    this.assertToolLedgerTransition([input.runtimeEvent], 't2_outcome');
     if (operation.resultEventId) {
       if (operation.resultEventId !== input.runtimeEvent.id) {
         throw new Error(`Tool operation outcome conflict for ${input.operationId}`);
@@ -702,12 +724,6 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
       );
       return { created: false, runtimeEventSeq: this.runtimeEventSeq(input.runtimeEvent.id) };
     }
-    this.assertToolLedgerTransition(
-      input.runtimeEvent.sessionId,
-      input.runtimeEvent.runId,
-      [input.runtimeEvent],
-      't2_outcome',
-    );
     const runtimeEventSeq = this.insertRuntimeEvent(input.runtimeEvent, input.committedAt, false);
     this.options.failpoint?.('after_runtime_event_insert');
     this.insertToolJournalEvent(
@@ -861,8 +877,6 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
   }
 
   private assertToolLedgerTransition(
-    sessionId: string,
-    runId: string,
     candidateEvents: readonly RuntimeEvent[],
     expectedTransition: Parameters<typeof validateToolLedgerTransition>[0]['expectedTransition'],
   ): void {
@@ -870,10 +884,9 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
       .prepare(`
         SELECT event_id, session_id, invocation_id, run_id, turn_id, payload_json
         FROM runtime_events
-        WHERE session_id = ? AND run_id = ?
-        ORDER BY event_seq ASC, event_id ASC
+        ORDER BY invocation_id ASC, event_seq ASC, event_id ASC
       `)
-      .all(sessionId, runId) as unknown as RuntimeEventStorageRow[];
+      .all() as unknown as RuntimeEventStorageRow[];
     const validation = validateToolLedgerTransition({
       existingEvents: rows.map(decodeRuntimeEventStorageRow),
       candidateEvents: candidateEvents.map(canonicalizeRuntimeEventForStorage),
@@ -886,17 +899,57 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     }
   }
 
+  private assertInvocationIdentity(events: readonly RuntimeEvent[]): void {
+    const candidates = new Map<string, { sessionId: string; runId: string; turnId: string }>();
+    for (const event of events) {
+      const identity = {
+        sessionId: event.sessionId,
+        runId: event.runId,
+        turnId: event.turnId,
+      };
+      const prior = candidates.get(event.invocationId);
+      if (
+        prior &&
+        (prior.sessionId !== identity.sessionId ||
+          prior.runId !== identity.runId ||
+          prior.turnId !== identity.turnId)
+      ) {
+        throw new Error(`RuntimeEvent invocation identity conflict for ${event.invocationId}`);
+      }
+      candidates.set(event.invocationId, identity);
+    }
+    for (const [invocationId, identity] of candidates) {
+      const rows = this.db
+        .prepare(`
+          SELECT DISTINCT session_id, run_id, turn_id
+          FROM runtime_events
+          WHERE invocation_id = ?
+        `)
+        .all(invocationId) as Array<{
+        session_id: string;
+        run_id: string;
+        turn_id: string;
+      }>;
+      if (
+        rows.some(
+          (row) =>
+            row.session_id !== identity.sessionId ||
+            row.run_id !== identity.runId ||
+            row.turn_id !== identity.turnId,
+        )
+      ) {
+        throw new Error(`RuntimeEvent invocation identity conflict for ${invocationId}`);
+      }
+    }
+  }
+
   private importRuntimeEventSync(event: RuntimeEvent): boolean {
     const canonicalEvent = canonicalizeRuntimeEventForStorage(event);
+    this.assertInvocationIdentity([canonicalEvent]);
     const partial = partialRuntimeStream(canonicalEvent);
     if (partial) return this.upsertRuntimePartial(canonicalEvent, partial);
     if (isToolLedgerBearingEvent(canonicalEvent)) {
-      this.assertToolLedgerTransition(
-        canonicalEvent.sessionId,
-        canonicalEvent.runId,
-        [canonicalEvent],
-        'generic_append',
-      );
+      this.assertToolLedgerTransition([canonicalEvent], 'generic_append');
     }
     const existing = this.readRuntimeEventJson(canonicalEvent.id) !== undefined;
     this.insertRuntimeEvent(canonicalEvent, canonicalEvent.ts, true);
@@ -908,7 +961,9 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     committedAt: number,
     allowExactDuplicate: boolean,
   ): number {
-    const canonicalEvent = canonicalizeRuntimeEventForStorage(event);
+    const encoding = encodeCanonicalRuntimeEvent(event);
+    const canonicalEvent = encoding.event;
+    this.assertInvocationIdentity([canonicalEvent]);
     assertRuntimeEventIdentity(canonicalEvent);
     const existingJson = this.readRuntimeEventJson(canonicalEvent.id);
     if (existingJson !== undefined) {
@@ -937,7 +992,7 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
         canonicalEvent.turnId,
         next,
         runtimeEventKind(canonicalEvent),
-        JSON.stringify(canonicalEvent),
+        encoding.json,
         committedAt,
       );
     this.deleteCompletedPartialSnapshot(canonicalEvent);
@@ -1261,11 +1316,7 @@ function assertStoredRuntimeEventEquals(event: RuntimeEvent, storedJson: string 
 }
 
 function canonicalizeRuntimeEventForStorage(event: RuntimeEvent): RuntimeEvent {
-  // Decoder normalization is the canonical persisted representation. The
-  // second decode proves that JSON serialization did not erase any field that
-  // the RuntimeEvent schema requires (for example function-call args).
-  const decoded = decodeRuntimeEvent(event);
-  return decodeRuntimeEvent(JSON.parse(JSON.stringify(decoded)));
+  return encodeCanonicalRuntimeEvent(event).event;
 }
 
 function assertNoReservedRecoveryFact(event: RuntimeEvent): void {

--- a/packages/storage/src/stable-storage.ts
+++ b/packages/storage/src/stable-storage.ts
@@ -2,7 +2,10 @@ import { open } from 'node:fs/promises';
 import { dirname, isAbsolute, relative, resolve, sep } from 'node:path';
 
 export async function syncFile(path: string): Promise<void> {
-  const handle = await open(path, 'r');
+  // Windows rejects fsync on a read-only handle (EPERM). Durable store files
+  // are writer-owned, so reopen the existing file read/write without creating
+  // or truncating it before re-establishing the stable-storage barrier.
+  const handle = await open(path, 'r+');
   try {
     await handle.sync();
   } finally {

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -68,6 +68,10 @@ const ALLOW = new Map([
     'PR110b: credential lookup failure logs error class only (no message / secret bytes); never reaches renderer.',
   ],
   [
+    'apps/desktop/src/main/permission-overlay/permission-overlay-main.ts',
+    'macOS permission onboarding lifecycle diagnostics stay in the main process and contain no credential or file contents.',
+  ],
+  [
     'packages/runtime/src/bots/bot-registry.ts',
     'message routed through generalizedErrorMessage (xuan raw-error sweep).',
   ],


### PR DESCRIPTION
## Summary

This is the first flat replacement slice extracted from the #1346 integration experiment. It establishes the Phase 3A recovery persistence authority without bringing file reconciliation, continuation execution, or host wiring into the same review boundary.

The invariant proved by this PR is:

> Recovery facts have one atomic persistence authority, and online projection, close/reopen, projection rebuild, and `RecoveryResolver` derive the same terminal interpretation from immutable RuntimeEvents.

## What changed

- Added a lossless canonical RuntimeEvent codec and strict-JSON tool argument validation while preserving the deployed `t1_after_preflight_v1` hash bytes. Any future domain-separated hash requires an explicit versioned dispatch protocol.
- Defined exact call, dispatch, outcome, reconcile, and decision semantic lanes with one shared scanner and prospective transition validator.
- Added exact v1 reconcile-result and recovery-decision facts plus a shared causal bundle interpreter.
- Made one SQLite transaction the only authority for reconcile + optional synthesized outcome + terminal decision.
- Made completed decisions require an identity-matching persisted outcome; parked is a permanent v1 terminal state with exact retry only.
- Made SQLite tool projections disposable and rebuildable solely from immutable RuntimeEvents.
- Made writer, rebuild, Resolver, and resume gates consume the same scanner/interpreter instead of parallel state machines.
- Hardened JSONL fallback writes with reserved-fact gates, target Run identity validation, physical exact-retry deduplication, stable-storage retry, steering-proof convergence, and partial cleanup.
- Hardened SQLite multi-process startup and tests: bounded worker coordination, immediate exit capture, concurrent WAL opener coverage, and no repeated setting-form `journal_mode=WAL` on established databases.

## Safety model

- Immutable RuntimeEvents are the semantic authority; SQLite journal/projection rows are derived state.
- Generic append/import paths cannot smuggle reserved durable tool or recovery facts.
- Immutable corruption fails closed. Mutable partial corruption remains fail-soft and cannot alter durable high-water.
- One invocation may map to only one `(sessionId, runId, turnId)` execution spine.
- The first implementation intentionally uses a workspace-wide semantic fail-stop: corruption in any canonical tool ledger blocks later tool-bearing boundaries in that SQLite workspace. This favors correctness over fault-domain size and write-path cost; a rebuildable incremental reducer is the planned optimization.
- Mainline schema 4 upgrades to schema 5. Existing `t1_after_preflight_v1` dispatches retain the exact deployed mainline hash bytes, including the historical `required`/`enum` ordering and `__proto__` behavior. Unreleased #1346 experimental recovery data is explicitly unsupported rather than guessed or migrated.

## Deliberate non-goals

This PR does **not** add:

- recovery contract registries, observers, or reconcilers;
- Write/Edit file checkpoints or automatic redo;
- continuation claims, provider replay, or automatic resume;
- Desktop/CLI resume wiring or host lifecycle changes;
- Git checkpoint carriers, restricted verification, retry, or reattach prototypes.

Those remain independent follow-up slices so each PR can prove and roll back one invariant.

## Validation

After rebasing onto `upstream/main@466f238b`:

- `npm run build` — passed across all workspaces, including the Desktop renderer build.
- `npm run typecheck` — passed across all workspaces.
- Recovery authority, schema-4 migration, deterministic stale-read, multi-process opener, Resolver, equivalence, commit-sink, and real SQLite boundary suites — 79/79 passed.
- Frozen mainline-v1 literal vectors cover ordinary arguments, `required`, nested `enum`, ordinary arrays, and historical `__proto__` behavior.
- A real schema-4 call + `t1_after_preflight_v1` dispatch fixture rebuilds successfully under schema 5.
- The full Storage suite terminates instead of hanging. The Windows local run still exposes existing unrelated platform failures around symlink privileges, SQLite file cleanup `EBUSY`, and source-path fixtures; none are in the PR A focused suites or changed paths.
- POSIX SIGKILL durability remains a Linux/macOS CI proof requirement; Windows support remains intentionally limited for those crash cases.
## Rebase note

The branch is rebased onto `upstream/main@466f238b`. The only content conflict was an incidental overlap in the Desktop settings E2E fixture; the resolution retained upstream's newer exact three-action permission contract, so that file contributes no PR A diff. `git range-diff` keeps the remaining recovery-authority commits and both schema-4 blocker fixes semantically equivalent.
## Relationship to #1346

#1346 remains the integration/design record. This PR replaces only its recovery-persistence-authority slice. #1346 should remain Draft until the continuation and conservative prepared-file replacement slices are merged as separate PRs.

Detailed extraction and ownership ledger: `docs/architecture/runtime-resume-extraction-ledger.zh-CN.md`.