### PR TITLE
fix(settings): keep permission labels visible at window floor

### DIFF
--- a/apps/desktop/e2e/settings.spec.ts
+++ b/apps/desktop/e2e/settings.spec.ts
@@ -144,29 +144,18 @@ test('permission rows keep their text at the window floor', async ({ permissionS
   await expect(settings.getByRole('heading', { name: '系统权限' })).toBeVisible();
 
   // Prove the fixture renders the shape this contract is about before measuring
-  // it: a row carrying MORE THAN ONE grant button is the one whose body the
-  // `auto` actions track used to squeeze to 0px. Reading the host's real TCC
-  // state would silently skip this — see `main/permission-snapshot-e2e-fixture.ts`.
-  //
-  // The count is `>= 2`, not `=== 2`: #1515 gave the drag-grantable permissions
-  // a third button (前往系统设置 + 拖拽授权 + 请求授权), so the fixture's
-  // `screen_recording` row — requestable, openable AND drag-grantable — now
-  // draws three. Pinning the exact number matched zero rows and turned this
-  // guard off silently, which is the failure mode the assertion exists to
-  // prevent. Widening the actions track only makes the squeeze worse, so the
-  // wider row is strictly the better subject.
+  // it: the requestable + openable screen-recording row also draws the guided
+  // drag action, and that three-button row is the one whose body the `auto`
+  // actions track could otherwise squeeze to 0px.
+  // Reading the host's real TCC state would silently skip this — see
+  // `main/permission-snapshot-e2e-fixture.ts`.
   const rows = settings.locator('.settingsOsPermissionRow');
   await expect(rows).toHaveCount(5);
-  const multiButtonRows = await rows.evaluateAll((elements) =>
-    elements
-      .map((element, index) => ({
-        index,
-        buttons: element.querySelectorAll('.settingsOsPermissionActions button').length,
-      }))
-      .filter((row) => row.buttons >= 2)
-      .map((row) => row.index),
-  );
-  expect(multiButtonRows.length).toBeGreaterThan(0);
+  const guidedRows = rows.filter({
+    has: page.getByRole('button', { name: '引导授权', exact: true }),
+  });
+  await expect(guidedRows).toHaveCount(1);
+  await expect(guidedRows.getByRole('button')).toHaveCount(3);
 
   await expect.poll(
     () =>

--- a/apps/desktop/src/main/permission-snapshot-e2e-fixture.ts
+++ b/apps/desktop/src/main/permission-snapshot-e2e-fixture.ts
@@ -5,7 +5,7 @@ import type { OsPermissionSnapshot, OsPermissionState, PermissionSnapshot } from
  * fixture.
  *
  * The Permission Center's narrow-layout contract is about what happens when a
- * row carries grant buttons: the row grid's `auto` actions track used to beat
+ * row carries several grant buttons: the row grid's `auto` actions track used to beat
  * the body's `minmax(0, 1fr)` and squeeze it to 0px, hiding which permission
  * the row was even about. Reading the host's real TCC state cannot exercise
  * that — a fully-granted dev machine renders no buttons at all, and Linux CI
@@ -13,8 +13,8 @@ import type { OsPermissionSnapshot, OsPermissionState, PermissionSnapshot } from
  * without testing anything.
  *
  * This fixture pins the states that matter instead:
- *   - `screen_recording` — `not_determined` + requestable + openable, the only
- *     shape that renders BOTH buttons (the original squeeze);
+ *   - `screen_recording` — `not_determined` + requestable + openable, the
+ *     three-action shape (open, guided drag, request) that exercises the squeeze;
  *   - `microphone` — `denied`, one button;
  *   - `accessibility` / `notifications` — `granted`, no buttons;
  *   - `automation` — `unsupported`, which carries the widest status Badge

--- a/apps/desktop/src/renderer/styles/settings/permission.css
+++ b/apps/desktop/src/renderer/styles/settings/permission.css
@@ -563,7 +563,9 @@
      then take the full width they wrapped onto, left-aligned under the text. */
   .settingsOsPermissionRow {
     row-gap: var(--space-2-5);
-    padding-inline: var(--space-2-5);
+    /* Keep 170px for the longest mixed-script title at the 480px window
+       floor; 10px padding left only 166px and clipped its closing glyph. */
+    padding-inline: var(--space-2);
   }
 
   .settingsOsPermissionIcon {

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -402,6 +402,13 @@
     row-gap: var(--space-2-5);
   }
 
+  /* Repeat the control-width variants so the narrow track has enough
+     specificity to beat their wide declarations above. */
+  .settingsRow[data-control-width="compact"],
+  .settingsRow[data-control-width="select"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   /* #1363 review: the exception applies only when the switch is the row's
      ONLY control (label + switch, nothing else). A three-part row — e.g.
      Memory's label + status Chip + switch — held horizontal would crush


### PR DESCRIPTION
## Summary

- Preserve readable permission rows at the 480px window floor by reclaiming four pixels of horizontal padding. The previous 166px body width clipped the closing glyph in the mixed-script `自动化（Apple Events）` title; 170px contains it while keeping the three actions wrapped below.
- Make the existing permissions geometry E2E target the guided screen-recording row explicitly and assert its complete three-button shape, so fixture drift cannot silently turn the contract into a no-op.
- Update the deterministic fixture documentation to match the permission onboarding UI.
- Restore the 460px settings-card stacking rule after #1524: its wide compact/select track selectors had higher specificity than the narrow override, leaving select rows in two columns at the window floor.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm --workspace @maka/desktop run e2e -- e2e/settings.spec.ts --grep 'permission rows keep their text at the window floor'`
- `npm --workspace @maka/desktop run e2e -- e2e/settings.spec.ts --grep 'general form rows stack at the window floor and stay two-column when wide'`
- `node --test apps/desktop/dist/main/__tests__/settings-row-track-contract.test.js apps/desktop/dist/main/__tests__/responsive-breakpoint-contract.test.js`
