### PR TITLE
fix(settings): give the label the row slack narrow controls cannot use

### DIFF
--- a/apps/desktop/src/main/__tests__/settings-row-track-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-row-track-contract.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Settings row track contract.
+ *
+ * `.settingsRow` splits label and control across two grid tracks. The
+ * default split gives the control `1fr` against the label's `0.36fr`,
+ * which is correct only for a control that actually fills its column.
+ * Switches (32px) and the time field (~84px) do not, so on a 718px row
+ * the label was pinned to 173px with 465px of empty track beside it —
+ * and the hint wrapped after ~9 characters, mid-word, because Chinese
+ * has no spaces to break at.
+ *
+ * The rule is therefore per control bucket, and each bucket's track is
+ * pinned here because the numbers are the whole point: an intrinsic
+ * track collapses a select's `w-full` trigger to its selected text
+ * (measured 320px → 118px), and a flat 320px cap eats the label instead
+ * (82px at a 468px card, just above the 460px stacking breakpoint).
+ * Only the both-caps form survives every width.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { readAllRendererCss, stripCssComments } from './css-test-helpers.js';
+
+/** Rule body for an exact selector, anchored so prefixes don't match. */
+function ruleBody(css: string, selector: string): string {
+  const escaped = selector.replace(/[.[\]/+*()>:="-]/g, (ch) => `\\${ch}`);
+  const re = new RegExp(`(?:^|\\n|\\})\\s*${escaped}[^{}]*\\{([^}]*)\\}`, 'm');
+  return css.match(re)?.[1] ?? '';
+}
+
+describe('settings row track contract', () => {
+  it('gives the label the slack that narrow controls cannot use', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+
+    // Switch rows and the compact bucket size their control to content.
+    // `auto` is what makes the label take everything else; an `fr` here
+    // is the bug this contract exists to prevent.
+    const intrinsic = ruleBody(css, '.settingsRow[data-control-width="compact"]');
+    assert.ok(intrinsic, '.settingsRow[data-control-width="compact"] track rule must exist');
+    assert.match(
+      intrinsic,
+      /grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto/,
+      'narrow controls must size to content so the label keeps the rest of the row',
+    );
+
+    // The switch selector shares that rule; assert it is still attached to
+    // it, since a tag-qualified rewrite of this selector has rotted before.
+    assert.match(
+      css,
+      /\.settingsRow:has\(>\s*\[role="switch"\]\)[^{]*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto/,
+      'switch-only rows must share the intrinsic-control track',
+    );
+  });
+
+  it('caps the select track by BOTH an absolute and a proportional bound', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const select = ruleBody(css, '.settingsRow[data-control-width="select"]');
+    assert.ok(select, '.settingsRow[data-control-width="select"] track rule must exist');
+
+    // `min(320px, 45%)`: the 320px alone leaves an 82px label at a 468px
+    // card; the percentage alone would let the trigger grow unbounded on
+    // a wide card. Both bounds, or the split breaks at one end.
+    assert.match(
+      select,
+      /grid-template-columns:\s*minmax\(0,\s*1fr\)\s+minmax\(0,\s*min\(320px,\s*45%\)\)/,
+      'select track must be capped by min(320px, 45%) — see the header for what each bound prevents',
+    );
+    assert.doesNotMatch(
+      select,
+      /grid-template-columns:[^;]*\bauto\b/,
+      'an intrinsic select track collapses the w-full trigger to its selected option text',
+    );
+  });
+
+  it('keeps the default row split for controls that do fill their column', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    // Exact `.settingsRow {` — no suffix, so `:hover` / `> [role=…]` and
+    // the bucket rules above can't stand in for the base declaration.
+    const base = css.match(/(?:^|\n|\})\s*\.settingsRow\s*\{([^}]*)\}/)?.[1] ?? '';
+    assert.ok(base, '.settingsRow base rule must exist');
+    assert.match(
+      base,
+      /grid-template-columns:\s*minmax\(150px,\s*0\.36fr\)\s+minmax\(0,\s*1fr\)/,
+      'the base split still applies to rows whose control fills the value column',
+    );
+  });
+});

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -61,6 +61,37 @@
   justify-self: end;
 }
 
+/* Narrow controls give their slack back to the label.
+   ---------------------------------------------------
+   The default track split hands the control column `1fr` against the
+   label's `0.36fr`. That is right for a control that fills its column,
+   and wrong for one that cannot: a switch is 32px and a time field ~94px,
+   so on a 718px row the label was pinned to 173px with 465px of empty
+   track beside it. The hint then wrapped after ~9 characters — mid-word
+   in Chinese, which has no spaces to break at — while most of the row sat
+   blank. Sizing these two buckets to their content and giving the rest to
+   the label is the same trade the 460px container rule below already
+   makes, for the same reason; it was just never applied at full width.
+
+   Selects need a different shape — see the rule below. */
+.settingsRow:has(> [role="switch"]):not(:has(> :nth-child(3):not(input))),
+.settingsRow[data-control-width="compact"] {
+  grid-template-columns: minmax(0, 1fr) auto;
+}
+
+/* Selects can't take the intrinsic track above: their trigger is `w-full`
+   under a 320px cap, so an `auto` track collapses it to the width of
+   whatever option happens to be selected (measured: 320px → 118px).
+   They get an explicit cap instead, and it has to be BOTH absolute and
+   proportional. A flat `minmax(0, 320px)` holds 320px all the way down
+   and eats the label instead — at a 468px card (just above the 460px
+   stacking breakpoint) that leaves the label 82px. Capping by share as
+   well keeps the split sane at every width: measured 353/302 at a 720px
+   card, 214/188 at 468px. */
+.settingsRow[data-control-width="select"] {
+  grid-template-columns: minmax(0, 1fr) minmax(0, min(320px, 45%));
+}
+
 .settingsRow:last-child {
   border-bottom: 0;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2932,6 +2932,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2949,6 +2952,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2966,6 +2972,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2983,6 +2992,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3000,6 +3012,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3017,6 +3032,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -2932,9 +2932,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2952,9 +2949,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2972,9 +2966,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2992,9 +2983,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3012,9 +3000,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3032,9 +3017,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [


### PR DESCRIPTION
Every hint in 每日回顾 wrapped after ~9 characters — **mid-word**, since Chinese has no spaces to break at — while most of the row sat empty.

### Cause

`.settingsRow` splits label and control as `0.36fr / 1fr`. That's right for a control that fills its column, and wrong for one that can't. Measured on a 718px row:

| | before |
|---|---|
| label column | **173px** |
| switch width | **32px** |
| dead track between them | **465px** |

The description was being squeezed into a quarter of the row so a 32px toggle could own the rest.

### Fix — per control bucket

| bucket | track |
|---|---|
| switch-only, compact | `minmax(0, 1fr) auto` |
| select | `minmax(0, 1fr) minmax(0, min(320px, 45%))` |
| everything else | unchanged |

This is the same trade the 460px container rule already made — *"a switch is ~40px wide and always fits beside its label"* — just never applied at full width, which is where the page actually gets read.

### Why selects needed a different shape

They can't take the intrinsic track: the trigger is `w-full` under a 320px cap, so `auto` collapses it to whatever option happens to be selected (measured **320px → 118px**). But a flat `minmax(0, 320px)` keeps the trigger and eats the label instead — **82px** at a 468px card, just above the 460px stacking breakpoint. Only capping by *both* bounds holds at every width:

| card width | label / trigger |
|---:|---|
| 720px | 353 / 302 |
| 568px | 269 / 233 |
| 468px | 214 / 188 |

### Result

每日回顾: ten of eleven hints drop to a single line; the last (分析模型) from three lines to two. 通用 improves the same way — both select rows go from two lines to one, and no control changed position.

Pinned in a new contract test with the numbers, since this file has already had one layout selector rot silently and the numbers are the argument.

### Gates

2879 desktop tests green · biome clean · 0 dead CSS.