### PR TITLE
fix(settings): let the narrow-control buckets stack again at the window floor

### DIFF
--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -412,6 +412,21 @@
     grid-template-columns: minmax(0, 1fr) auto;
   }
 
+  /* #1524 gave the compact and select buckets their own full-width track
+     splits at `.settingsRow[data-control-width="…"]` — specificity 0,2,0.
+     A container query adds NO specificity to the rules inside it, so those
+     two outrank the plain `.settingsRow` stacking rule above (0,1,0) and
+     those rows kept two columns all the way down. Restate them here at
+     matching specificity so they stack like every other row.
+
+     The `justify-self: start` rules just below are the tell that stacking
+     was always the intent for these buckets: start-aligning a control only
+     makes sense once it sits under its label rather than beside it. */
+  .settingsRow[data-control-width="compact"],
+  .settingsRow[data-control-width="select"] {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
   /* Values and controls sit under their label now; right-alignment against
      the card edge would detach them from it. */
   .settingsRow > span {


### PR DESCRIPTION
## Why

`e2e/settings.spec.ts:583` has been failing on **main** since #1524 landed (`a1e05654`).

#1524 gave the compact and select control buckets their own full-width track splits:

```css
.settingsRow[data-control-width="select"] {   /* specificity 0,2,0 */
  grid-template-columns: minmax(0, 1fr) minmax(0, min(320px, 45%));
}
```

The row-stacking rule is a plain `.settingsRow` — **0,1,0** — inside `@container settings-rows (max-width: 460px)`.

**A container query adds no specificity to the rules it wraps.** So below the 460px card breakpoint the two new rules kept winning and those rows never folded: the select row held two tracks instead of collapsing to one. The `compact` bucket has the same defect; the spec only happens to measure a select row.

## How

Restate both buckets inside the container query at matching specificity.

The `justify-self: start` rules already in that block are the tell that stacking was always the intent for these buckets — start-aligning a control only makes sense once it sits *under* its label rather than beside it. #1524 didn't change that intent; it landed a rule that outranked it.

## Verification

Verified **causally**, not by inspection — on the same base and the same build:

| | `settings.spec.ts:583` |
|---|---|
| fix reverted (stash) | ✘ `Received: 2` |
| fix applied | ✓ passes |

Also:
- `settings.spec.ts` full file: 19/20.
- The one remaining failure, `settings.spec.ts:141` (permission rows), **fails identically with this change stashed** — a local-environment issue on my machine, and green in CI at `96ea7c7f`.
- `npm run test` exit 0, `npm run typecheck` exit 0, `format:check` clean.

#1524's own `settings-row-track-contract.test.ts` still passes — it asserts the full-width rules, which are untouched.