### PR TITLE
fix(design-system): give the EmptyState card the border it only coloured

### DIFF
--- a/packages/ui/src/__tests__/empty-state.test.ts
+++ b/packages/ui/src/__tests__/empty-state.test.ts
@@ -1,0 +1,53 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { EmptyState } from '../empty-state.js';
+
+// The block EmptyState is an IN-PAGE card, and its edge is the only thing
+// separating it from the surface behind it: measured live, the card composites
+// to the same pure white as the panel it sits on, so `bg-card/70` contributes
+// no contrast at all. The border is the separation.
+//
+// It shipped with `border-border` and no width utility. That sets a colour and
+// nothing else, so the rendered border-width was 0 and the edge the author
+// meant to draw never existed — what outlined the card was the incidental
+// `0 0 0 1px var(--border)` ring inside `shadow-maka-panel`.
+
+function cardClass(): string {
+  const markup = renderToStaticMarkup(
+    createElement(EmptyState, { title: 'Nothing here', body: 'Add something.' }),
+  );
+  const match = /class="([^"]*maka-empty-state[^"]*)"/.exec(markup);
+  assert.ok(match, 'the block EmptyState should render a .maka-empty-state root');
+  return match[1] ?? '';
+}
+
+test('the block EmptyState draws a real border, not just a border colour', () => {
+  const cls = cardClass();
+  assert.match(
+    cls,
+    /(^|\s)border(\s|$)/,
+    'border-border alone sets no width — the card needs the `border` utility too',
+  );
+  assert.match(cls, /(^|\s)border-border(\s|$)/, 'the border colour must stay on the token');
+});
+
+test('the block EmptyState does not wear the overlay shadow', () => {
+  // `shadow-maka-panel` is the floating-overlay family (mention popup, model
+  // picker, select popup, dialog). Its `0 0 0 1px var(--border)` ring is what
+  // used to stand in for the missing border here; keeping both would draw the
+  // edge twice, and an in-page card has no reason to cast a popup's shadow.
+  assert.doesNotMatch(cardClass(), /shadow-maka-panel/);
+});
+
+test('the inline EmptyState variant stays chrome-free', () => {
+  // The inline variant is a bare <p> used where a card would be too heavy;
+  // it must not pick up the card recipe.
+  const markup = renderToStaticMarkup(
+    createElement(EmptyState, { variant: 'inline', title: 'Nothing here', body: '' }),
+  );
+  assert.match(markup, /data-slot="empty-state-inline"/);
+  assert.doesNotMatch(markup, /maka-empty-state[^-]/);
+  assert.doesNotMatch(markup, /border-border/);
+});

--- a/packages/ui/src/empty-state.tsx
+++ b/packages/ui/src/empty-state.tsx
@@ -51,8 +51,16 @@ export function EmptyState(props: EmptyStateProps) {
       </p>
     );
   }
+  // `border` before `border-border`: on its own, `border-border` sets only a
+  // colour, so the card shipped at border-width 0 and the edge the author
+  // meant to draw never rendered. What was actually outlining the card was
+  // the `0 0 0 1px var(--border)` ring inside `shadow-maka-panel` — and that
+  // shadow is the OVERLAY family (mention popup, model picker, select popup,
+  // dialog). This is an in-page card, so it carried a floating panel's
+  // drop shadow for no reason and leaned on its ring for the missing border.
+  // One real hairline instead, same token as .settingsRows / the skill cards.
   const className = cn(
-    'maka-empty-state rounded-md border-border bg-card/70 p-8 text-card-foreground shadow-maka-panel',
+    'maka-empty-state rounded-md border border-border bg-card/70 p-8 text-card-foreground',
     props.extraClassName,
   );
   return (


### PR DESCRIPTION
## What

`EmptyState`'s card recipe was `… rounded-md border-border bg-card/70 …` — a border **colour** with no width utility. Tailwind renders that at `border-width: 0`, so the edge never existed. Measured on the live Skills market surface before the fix:

```
borderWidth: 0px
boxShadow:   … oklch(0.17 0.005 286 / 0.1) 0 0 0 1px, … 0 14px 40px …
```

What was outlining the card was incidental — the `0 0 0 1px var(--border)` ring inside `shadow-maka-panel`.

## Why it's worse than a normal missing hairline

The card has **no fill contrast to fall back on**. Measured in the same probe:

| | colour |
|---|---|
| card background | `oklab(1 0 0 / 0.7)` |
| panel behind it | `oklch(1 0 0)` |

70% white composited over pure white *is* pure white. `bg-card/70` was presumably written for a gray page plate (`--surface-canvas`), but this card sits on a panel that paints pure white. So the border isn't decoration here — it's the only thing separating the card from the page.

## How

Add the `border` width utility, and drop `shadow-maka-panel`.

That shadow is the floating-overlay family — mention popup, model picker, select popup, dialog — and `EmptyState` was its only in-page consumer, so the card was casting a popup's `0 14px 40px` shadow as well as leaning on its ring for the missing border. After the fix there is exactly one 1px edge, on the same token `.settingsRows` and `.maka-skill-market-card` already use.

Verified live after the change: `borderWidth: 1px`, `boxShadow: none`.

## Scope checks

- The sidebar's `.maka-session-empty-state` variant is unaffected — `empty-state.css` strips border/background/shadow/padding there with `!important`.
- Audited the other `border-border` sites: the rest are correct (`border-b border-border`, `border border-border`). `item.tsx`'s `outline` variant *looks* like the same bug but isn't — its base class carries `border border-transparent`, so the variant only overrides the colour.

## Also in scope, and already done

The knip leftover from #1515 (`src/overlay/permission-overlay{,-preload}.ts` unreachable) is **already fixed on main** — both files are in `knip.json`'s desktop `entry` list and `npx knip --workspace apps/desktop` is clean. Nothing to do.

## Tests

New render contract (`packages/ui/src/__tests__/empty-state.test.ts`): the card class must carry a real `border`, must keep the colour on the token, must not wear the overlay shadow, and the `inline` variant must stay chrome-free.

Gates: `@maka/ui` 253/253 · desktop `test` and `typecheck` exit 0 · `format:check` clean · `knip --workspace apps/desktop` clean.