### PR TITLE
test(e2e): sandbox HOME and cover user-scope skill deletion

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -40,13 +40,23 @@ async function seedE2eInvocableSkills(userDataDir: string): Promise<void> {
   const projectRoot = path.join(userDataDir, 'project');
   const projectSkillRoot = path.join(projectRoot, '.maka', 'skills');
   const workspaceSkillRoot = path.join(workspaceRoot, 'skills');
+  // Under the sandboxed HOME (see buildE2eEnv), so `~/.agents/skills` here is
+  // the throwaway dir, never the developer's. This is the only user-scope
+  // skill the suite sees, which is what makes the delete journey assertable.
+  const userSkillRoot = path.join(userDataDir, 'home', '.agents', 'skills');
   await Promise.all([
     mkdir(path.join(projectSkillRoot, 'project-only'), { recursive: true }),
     mkdir(path.join(projectSkillRoot, 'host-incompatible'), { recursive: true }),
     mkdir(path.join(projectSkillRoot, 'agent-write'), { recursive: true }),
     mkdir(path.join(projectSkillRoot, 'deep-research-only'), { recursive: true }),
     mkdir(path.join(workspaceSkillRoot, 'workspace-only'), { recursive: true }),
+    mkdir(path.join(userSkillRoot, 'user-only'), { recursive: true }),
   ]);
+  await writeFile(
+    path.join(userSkillRoot, 'user-only', 'SKILL.md'),
+    `---\nname: User Only\ndescription: User-scoped install, deletable from the panel.\n---\n# User Only`,
+    'utf8',
+  );
   await Promise.all([
     writeFile(
       path.join(projectSkillRoot, 'project-only', 'SKILL.md'),
@@ -92,6 +102,7 @@ async function seedE2eInvocableSkills(userDataDir: string): Promise<void> {
  */
 function buildE2eEnv(
   userDataDir: string,
+  homeDir: string,
   e2eFixtureScenario?: string,
   locale?: 'zh' | 'en',
   platform?: 'darwin' | 'win32' | 'linux',
@@ -120,6 +131,17 @@ function buildE2eEnv(
   // unset under xvfb).
   env.MAKA_SKIP_SHELL_ENV = '1';
   env.MAKA_E2E_USER_DATA_DIR = userDataDir;
+  // Sandbox the home directory. User-scope skill discovery reads
+  // `~/.maka/skills` and `~/.agents/skills` via `os.homedir()`, and the Skills
+  // panel can now DELETE from those (#1517) — so without this a suite run
+  // would enumerate, and could remove, the developer's own installed skills.
+  // Overriding HOME sandboxes every consumer of the home dir at once, rather
+  // than plumbing an override through each skills API and hoping none is
+  // missed; `os.homedir()` returns $HOME on POSIX and %USERPROFILE% on
+  // Windows, so both are set. userData is pinned separately above, so this
+  // does not move the app's data dir.
+  env.HOME = homeDir;
+  env.USERPROFILE = homeDir;
   if (e2eFixtureScenario) env.MAKA_E2E_FIXTURE = e2eFixtureScenario;
   if (locale) env.MAKA_E2E_FIXTURE_LOCALE = locale;
   if (platform) env.MAKA_E2E_FIXTURE_PLATFORM = platform;
@@ -130,6 +152,21 @@ function buildE2eEnv(
   // visible window.
   if (process.env.CI && process.platform === 'linux') env.MAKA_E2E_SHOW_WINDOW = '1';
   return env;
+}
+
+/**
+ * The sandboxed HOME of the run currently under test. Set by withE2eWindow
+ * before Electron launches.
+ *
+ * Read it from inside a test BODY, never as a fixture: a fixture would have no
+ * declared dependency on the window fixture, so Playwright could resolve it
+ * before the window is set up and hand back a stale path.
+ */
+let currentHomeDir = '';
+
+export function e2eHomeDir(): string {
+  if (!currentHomeDir) throw new Error('e2eHomeDir() is only valid inside a test that opened a window');
+  return currentHomeDir;
 }
 
 /**
@@ -152,6 +189,11 @@ async function withE2eWindow(
   use: (page: Page) => Promise<void>,
 ): Promise<void> {
   const userDataDir = await mkdtemp(path.join(tmpdir(), 'maka-e2e-'));
+  // Lives inside the throwaway userData dir so the existing teardown removes
+  // it too — there is no second path to leak.
+  const homeDir = path.join(userDataDir, 'home');
+  await mkdir(homeDir, { recursive: true });
+  currentHomeDir = homeDir;
   let app: ElectronApplication | undefined;
   const mainLogs: string[] = [];
   const rendererLogs: string[] = [];
@@ -164,7 +206,7 @@ async function withE2eWindow(
     app = await electron.launch({
       args: ['.'],
       cwd: DESKTOP_ROOT,
-      env: buildE2eEnv(userDataDir, e2eFixtureScenario, locale, platform),
+      env: buildE2eEnv(userDataDir, homeDir, e2eFixtureScenario, locale, platform),
     });
     app.on('console', (message) => {
       mainLogs.push(message.text());

--- a/apps/desktop/e2e/skill-delete-scope.spec.ts
+++ b/apps/desktop/e2e/skill-delete-scope.spec.ts
@@ -1,0 +1,64 @@
+// User-scope skill deletion E2E (#1517).
+//
+// The delete path is the one place the Skills panel removes files from the
+// user's HOME rather than from app-managed workspace data, so the journey that
+// matters is the whole round trip: the button is offered for the scopes the
+// backend can actually delete, two clicks remove the directory from disk, and
+// the row is gone on the refresh that follows.
+//
+// This spec only exists because `buildE2eEnv` now sandboxes HOME. Before that,
+// running it would have deleted a real skill out of the developer's
+// `~/.agents/skills`. The unit tests in `skills.test.ts` cover the containment
+// guards against a temp filesystem; what they cannot cover is the renderer
+// sending a scope-aware ref through IPC and the list agreeing afterwards.
+
+import { access } from 'node:fs/promises';
+import path from 'node:path';
+import { e2eHomeDir, test, expect } from './fixtures.js';
+
+test('deletes a user-scope skill from disk and drops it from the list', async ({
+  invocableSkillsWindow: page,
+}) => {
+  const skillDir = path.join(e2eHomeDir(), '.agents', 'skills', 'user-only');
+  // The sandbox is real: the seeded skill is on disk before anything happens.
+  await access(skillDir);
+
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  const sidebar = page.getByRole('complementary', { name: '对话列表' });
+  await sidebar.getByRole('button', { name: '扩展', exact: true }).click();
+  await page.getByRole('main', { name: '扩展' }).waitFor();
+
+  const installed = page.getByRole('tab', { name: '已安装' });
+  if (await installed.isVisible().catch(() => false)) await installed.click();
+
+  const row = page.locator('.maka-skill-library-list li').filter({ hasText: 'User Only' });
+  await expect(row).toHaveCount(1);
+
+  // Two-step confirm: the first click only arms the button, so the skill must
+  // still be on disk at this point — a single stray click cannot delete.
+  const deleteButton = row.getByRole('button', { name: /删除/ });
+  await deleteButton.click();
+  await access(skillDir);
+
+  await deleteButton.click();
+
+  await expect(row).toHaveCount(0);
+  await expect.poll(() => access(skillDir).then(() => 'present', () => 'gone')).toBe('gone');
+});
+
+test('offers no delete for a project-scope skill', async ({ invocableSkillsWindow: page }) => {
+  // Project skills live in the user's repo and are left to git — the backend
+  // refuses them with `blocked_scope`, and the panel must not offer a button
+  // that cannot work.
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  const sidebar = page.getByRole('complementary', { name: '对话列表' });
+  await sidebar.getByRole('button', { name: '扩展', exact: true }).click();
+  await page.getByRole('main', { name: '扩展' }).waitFor();
+
+  const installed = page.getByRole('tab', { name: '已安装' });
+  if (await installed.isVisible().catch(() => false)) await installed.click();
+
+  const projectRow = page.locator('.maka-skill-library-list li').filter({ hasText: 'Project Only' });
+  await expect(projectRow).toHaveCount(1);
+  await expect(projectRow.getByRole('button', { name: /删除/ })).toHaveCount(0);
+});


### PR DESCRIPTION
## Why

#1517 let the Skills panel delete from `~/.maka/skills` and `~/.agents/skills`. `buildE2eEnv` never overrode `HOME`, so an E2E run enumerated the **developer's real user-scope skills** — and any spec that exercised the delete button would have removed one for real.

That is exactly why #1517 shipped without an e2e for its own destructive path. This closes that gap.

## How

Set `HOME` (and `USERPROFILE`) to a directory inside the throwaway userData dir that teardown already removes — no second path to leak.

Overriding the home dir sandboxes **every** consumer at once, rather than threading a `homeDir` option through each skills API and hoping none is missed. That distinction matters here: if `skills:list` and `skills:delete` ever disagreed about which directories they mean, the bug would be both invisible and destructive.

`userData` is pinned separately via `app.setPath`, so this does not move the app's data dir.

### `e2eHomeDir()`, not a fixture

The sandbox path is exposed as a plain accessor read from the test body. A fixture would have no declared dependency on the window fixture, so Playwright could resolve it before the window is set up and hand back a stale path.

## New coverage

The invocable-skills seeder gains one user-scope skill under the sandbox, which is what makes the journey assertable. The spec covers what the unit tests in `skills.test.ts` cannot — the renderer sending a scope-aware ref through IPC, and the list agreeing afterwards:

- a user-scope skill is removed from disk and drops out of the list — with the directory **still intact after the first of the two confirm clicks**, so a single stray click provably cannot delete;
- a project-scope skill offers no delete button at all.

## Verification

**The disk assertion is not vacuous.** Inverted it to expect `'present'` after the delete; it fails with `Received: "gone"`. (The original form used `expect(promise).rejects`, which I could not convince myself wasn't passing for the wrong reason — replaced with an explicit `expect.poll`.)

**The sandbox introduces no new failures.** Full e2e on this branch: **69 passed, 3 failed**. All three baselined with the change stashed and the app rebuilt:

| spec | with sandbox | stashed baseline |
|---|---|---|
| `settings.spec.ts:141` | ✘ | ✘ pre-existing |
| `sidebar-navigation.spec.ts:10` | ✘ | ✘ pre-existing |
| `sidebar-navigation.spec.ts:30` | ✘ | ✓ flaky (flips both ways) |

The first two fail identically without this change — local-environment issues on my machine, green in CI.

Gates: desktop `test` and `typecheck` exit 0 · `format:check` clean · `knip --workspace apps/desktop` clean.