### PR TITLE
feat(permissions): dock the drag-to-grant card to the Settings window

### DIFF
--- a/apps/desktop/.gitignore
+++ b/apps/desktop/.gitignore
@@ -1,3 +1,5 @@
 # Playwright E2E run artifacts: traces, videos, screenshots, last-run state.
 test-results/
 resources/workers/
+# Compiled by build:resources from native/settings-window-locator/locator.swift.
+resources/native/

--- a/apps/desktop/electron-builder.config.mjs
+++ b/apps/desktop/electron-builder.config.mjs
@@ -13,6 +13,15 @@ export default {
       to: 'bundled-tools.json',
     },
     {
+      // Built by build:resources from native/settings-window-locator.
+      // Without this the drag-to-grant card cannot find System Settings in
+      // a packaged app — and, before the reason-aware fallback, killed
+      // itself one second after opening because "no binary" looked
+      // identical to "the user closed the pane".
+      from: 'resources/native',
+      to: 'native',
+    },
+    {
       from: 'resources/workers/filesystem-worker.js',
       to: 'workers/filesystem-worker.js',
     },

--- a/apps/desktop/native/settings-window-locator/locator.swift
+++ b/apps/desktop/native/settings-window-locator/locator.swift
@@ -1,0 +1,98 @@
+// settings-window-locator — where is the System Settings window?
+//
+// Electron exposes no API for another application's window geometry, and
+// this is the one thing the drag-to-grant card needs that it cannot get
+// itself. Hence ~90 lines of Swift and a process spawn.
+//
+// TWO deliberate choices, both of which the reference implementations get
+// wrong or do differently:
+//
+// 1. CGWindowListCopyWindowInfo, never the Accessibility API. AX would
+//    require this app to already be a trusted Accessibility client, which
+//    is precisely the permission the card exists to request — a
+//    chicken-and-egg. Window *images* need Screen Recording; the window
+//    *metadata* read here (bounds, owner pid, layer) needs no TCC grant
+//    at all. That is what makes the locator usable before any grant.
+//
+// 2. Coordinates come back in CoreGraphics space — origin at the top-left
+//    of the primary display, y growing downward — and are NOT converted
+//    to AppKit's bottom-left space. Electron's `setBounds` is top-left
+//    origin, so CG is already the right space. Converting to AppKit (as
+//    Alma does, with a comment claiming that is what setBounds wants)
+//    puts the card in the right place only when the Settings window
+//    happens to be vertically centred, and off by twice the displacement
+//    otherwise.
+//
+// Output is a single line of JSON on stdout. Every failure is a JSON
+// object with ok:false, never a crash and never a non-zero exit for an
+// expected condition, so the caller can treat parse-failure as "no idea"
+// and fall back.
+
+import AppKit
+import CoreGraphics
+import Foundation
+
+// System Settings kept the System Preferences bundle id across the Ventura
+// rename, so one identifier covers both.
+let settingsBundleID = "com.apple.systempreferences"
+
+func emit(_ json: String) {
+    print(json)
+}
+
+func fail(_ reason: String) -> Never {
+    emit("{\"ok\":false,\"reason\":\"\(reason)\"}")
+    exit(0)
+}
+
+// The pid comes from the bundle identifier rather than from
+// kCGWindowOwnerName: the owner name is a process name that has already
+// changed once (System Preferences -> System Settings) and is a poor
+// thing to match on.
+guard let app = NSRunningApplication
+    .runningApplications(withBundleIdentifier: settingsBundleID)
+    .first
+else {
+    fail("not_running")
+}
+let pid = app.processIdentifier
+
+guard let windows = CGWindowListCopyWindowInfo(
+    [.optionOnScreenOnly, .excludeDesktopElements],
+    kCGNullWindowID
+) as? [[String: Any]] else {
+    fail("window_list_failed")
+}
+
+// layer 0 excludes panels, sheets and the shadow/toolbar helper windows
+// that share the pid; the size floor drops the small transient ones that
+// still report layer 0 while a sheet is animating.
+var best: CGRect?
+for info in windows {
+    guard let owner = info[kCGWindowOwnerPID as String] as? pid_t, owner == pid,
+          let layer = info[kCGWindowLayer as String] as? Int, layer == 0,
+          let bounds = info[kCGWindowBounds as String] as? [String: CGFloat]
+    else { continue }
+
+    let frame = CGRect(
+        x: bounds["X"] ?? 0,
+        y: bounds["Y"] ?? 0,
+        width: bounds["Width"] ?? 0,
+        height: bounds["Height"] ?? 0
+    )
+    guard frame.width > 320, frame.height > 240 else { continue }
+    if let current = best, current.width * current.height >= frame.width * frame.height {
+        continue
+    }
+    best = frame
+}
+
+guard let frame = best else { fail("no_settings_window") }
+
+// `%.0f` — these feed Electron's setBounds, which takes integers anyway.
+emit("""
+{"ok":true,"x":\(String(format: "%.0f", frame.minX)),\
+"y":\(String(format: "%.0f", frame.minY)),\
+"width":\(String(format: "%.0f", frame.width)),\
+"height":\(String(format: "%.0f", frame.height))}
+""")

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -16,7 +16,7 @@
     "build-storybook": "storybook build -c .storybook --output-dir storybook-static",
     "smoke:storybook": "node ../../scripts/storybook-visual-smoke.mjs",
     "build": "npm run build:resources && npm run build:main && npm run build:preload && npm run build:overlay && npm run build:renderer",
-    "build:resources": "node scripts/copy-runtime-filesystem-worker.mjs",
+    "build:resources": "node scripts/copy-runtime-filesystem-worker.mjs && node scripts/build-settings-window-locator.mjs",
     "build:test": "npm run build:main && npm run build:preload && npm run build:overlay",
     "clean:main": "node ../../scripts/clean-paths.mjs dist/main tsconfig.main.tsbuildinfo",
     "build:main": "tsc -p tsconfig.main.json",

--- a/apps/desktop/scripts/build-settings-window-locator.mjs
+++ b/apps/desktop/scripts/build-settings-window-locator.mjs
@@ -1,0 +1,87 @@
+// Compile the settings-window locator into apps/desktop/resources/native.
+//
+// Build-time, not run-time. Alma compiles the equivalent Swift with
+// `swiftc` on the user's machine at first use, which trades a build step
+// for a hard runtime dependency on the Xcode Command Line Tools — absent
+// on most non-developer Macs, and its failure path is a console warning
+// nobody sees. Doing it here means the risk lands on a build machine that
+// either has the toolchain or doesn't, visibly.
+//
+// Missing toolchain is NOT a build failure: the locator is a progressive
+// enhancement. Without the binary the permission card still opens, still
+// drags, still detects the grant — it just anchors to the cursor instead
+// of docking to the Settings window. So we warn loudly and continue,
+// rather than making a macOS-only nicety a hard gate on `npm run build`.
+
+import { execFile } from 'node:child_process';
+import { mkdir, rm, stat } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+
+const run = promisify(execFile);
+const desktopRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const source = resolve(desktopRoot, 'native', 'settings-window-locator', 'locator.swift');
+const outDir = resolve(desktopRoot, 'resources', 'native');
+const target = resolve(outDir, 'settings-window-locator');
+
+/** Both slices, so the artifact matches the universal cua-driver already pinned. */
+const ARCHS = [
+  { arch: 'arm64', triple: 'arm64-apple-macos13' },
+  { arch: 'x86_64', triple: 'x86_64-apple-macos13' },
+];
+
+function skip(reason) {
+  console.warn(
+    `[settings-window-locator] SKIPPED — ${reason}.\n`
+    + '  The permission card will fall back to cursor anchoring instead of\n'
+    + '  docking to the System Settings window. This is a degraded but\n'
+    + '  working state, not a broken build.',
+  );
+}
+
+if (process.platform !== 'darwin') {
+  skip('not macOS');
+  process.exit(0);
+}
+
+const swiftc = await run('/usr/bin/xcrun', ['--find', 'swiftc']).catch(() => null);
+if (!swiftc) {
+  skip('swiftc not found (install the Xcode Command Line Tools)');
+  process.exit(0);
+}
+
+const swiftcPath = swiftc.stdout.trim();
+
+// An explicit -target needs an explicit -sdk: without it swiftc looks for
+// the standard library under the *host* triple and fails with
+// "unable to load standard library for target".
+const sdk = await run('/usr/bin/xcrun', ['--show-sdk-path']).catch(() => null);
+if (!sdk) {
+  skip('no macOS SDK found (xcrun --show-sdk-path failed)');
+  process.exit(0);
+}
+const sdkPath = sdk.stdout.trim();
+
+await mkdir(outDir, { recursive: true });
+
+const slices = [];
+try {
+  for (const { arch, triple } of ARCHS) {
+    const slice = resolve(outDir, `settings-window-locator.${arch}`);
+    await run(swiftcPath, ['-O', '-target', triple, '-sdk', sdkPath, '-o', slice, source]);
+    slices.push(slice);
+  }
+  // `lipo -create` even for one slice keeps the output shape identical.
+  await run('/usr/bin/lipo', ['-create', ...slices, '-output', target]);
+  const built = await stat(target);
+  console.log(
+    `settings-window-locator built → ${target} (${(built.size / 1024).toFixed(0)} KB, ${ARCHS.map((a) => a.arch).join(' + ')})`,
+  );
+} catch (error) {
+  skip(`compile failed: ${error?.stderr?.trim?.() || error?.message || error}`);
+} finally {
+  // The per-arch slices are inputs, not artifacts; leaving them behind
+  // would ship two extra copies inside the app bundle.
+  await Promise.all(slices.map((slice) => rm(slice, { force: true })));
+}

--- a/apps/desktop/src/main/__tests__/card-flight.test.ts
+++ b/apps/desktop/src/main/__tests__/card-flight.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Card flight geometry contract.
+ *
+ * The properties worth pinning are the ones that make the motion mean
+ * something: it must ARC (a slide reads as an unrelated popup appearing),
+ * it must NOT overshoot the target (overshoot reads as imprecision when
+ * the card is claiming "your target is exactly here"), and it must end
+ * exactly on the docked rect — a few pixels off and the card sits visibly
+ * crooked against the Settings window it is supposed to belong to.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  ARC_MAX_PX,
+  ARC_MIN_PX,
+  FLIGHT_MS,
+  frameAt,
+  runFlight,
+  springProgress,
+  type Rect,
+} from '../permission-overlay/card-flight.js';
+
+const button: Rect = { x: 1000, y: 700, width: 96, height: 28 };
+const docked: Rect = { x: 400, y: 200, width: 530, height: 109 };
+
+describe('card flight geometry', () => {
+  it('starts on the button and lands exactly on the docked rect', () => {
+    assert.deepEqual(frameAt(button, docked, 0), {
+      x: button.x, y: button.y, width: button.width, height: button.height,
+    });
+    assert.deepEqual(frameAt(button, docked, 1), docked);
+  });
+
+  it('arcs above the straight line instead of sliding along it', () => {
+    const mid = frameAt(button, docked, 0.5);
+    const midCy = mid.y + mid.height / 2;
+    const straightCy =
+      (button.y + button.height / 2)
+      + ((docked.y + docked.height / 2) - (button.y + button.height / 2)) * springProgress(0.5);
+    // Screen coordinates: "above" is a smaller y.
+    assert.ok(
+      midCy < straightCy - 10,
+      `midpoint must bow upward off the straight path (arc ${straightCy - midCy}px)`,
+    );
+  });
+
+  it('never overshoots the destination', () => {
+    // Critically damped: progress approaches 1 from below, never past it.
+    for (let i = 0; i <= 100; i++) {
+      const p = springProgress(i / 100);
+      assert.ok(p <= 1 + 1e-9, `springProgress(${i / 100}) = ${p} overshot`);
+      assert.ok(p >= 0, `springProgress(${i / 100}) = ${p} went negative`);
+    }
+  });
+
+  it('advances monotonically — no stalls or backtracking', () => {
+    let previous = -1;
+    for (let i = 0; i <= 100; i++) {
+      const p = springProgress(i / 100);
+      assert.ok(p >= previous, `progress went backwards at t=${i / 100}`);
+      previous = p;
+    }
+  });
+
+  it('clamps the arc height for very short and very long flights', () => {
+    const near: Rect = { x: 402, y: 202, width: 96, height: 28 };
+    const nearMid = frameAt(near, docked, 0.5);
+    const nearStraightCy =
+      (near.y + near.height / 2)
+      + ((docked.y + docked.height / 2) - (near.y + near.height / 2)) * springProgress(0.5);
+    // Even a near-zero-distance hop still visibly arcs (ARC_MIN_PX).
+    assert.ok(nearStraightCy - (nearMid.y + nearMid.height / 2) > ARC_MIN_PX / 4);
+
+    const far: Rect = { x: 5000, y: 3000, width: 96, height: 28 };
+    const farMid = frameAt(far, docked, 0.5);
+    const farStraightCy =
+      (far.y + far.height / 2)
+      + ((docked.y + docked.height / 2) - (far.y + far.height / 2)) * springProgress(0.5);
+    // ...and a cross-screen flight does not loop absurdly high.
+    assert.ok(farStraightCy - (farMid.y + farMid.height / 2) <= ARC_MAX_PX + 1);
+  });
+
+  it('grows from the button footprint into the card', () => {
+    const quarter = frameAt(button, docked, 0.25);
+    assert.ok(quarter.width > button.width && quarter.width < docked.width);
+    assert.ok(quarter.height > button.height && quarter.height < docked.height);
+  });
+});
+
+describe('flight runner', () => {
+  function harness(reducedMotion = false) {
+    let clock = 0;
+    const frames: Rect[] = [];
+    let done = false;
+    const ticks: Array<() => void> = [];
+    const cancel = runFlight({
+      from: button,
+      to: docked,
+      reducedMotion,
+      now: () => clock,
+      setFrame: (rect) => frames.push(rect),
+      requestTick: (fn) => ticks.push(fn),
+      onDone: () => { done = true; },
+    });
+    return {
+      frames, ticks, cancel,
+      isDone: () => done,
+      advance(ms: number) { clock += ms; const pending = ticks.splice(0); pending.forEach((fn) => fn()); },
+    };
+  }
+
+  it('jumps straight to the destination under reduced motion', () => {
+    const h = harness(true);
+    assert.deepEqual(h.frames, [docked], 'no intermediate frames when motion is reduced');
+    assert.equal(h.isDone(), true);
+    assert.equal(h.ticks.length, 0, 'and no animation scheduled');
+  });
+
+  it('animates to completion and reports done exactly once', () => {
+    const h = harness();
+    for (let i = 0; i < 60 && !h.isDone(); i++) h.advance(16);
+    assert.equal(h.isDone(), true);
+    assert.deepEqual(h.frames.at(-1), docked, 'must settle exactly on the docked rect');
+    assert.ok(h.frames.length > 5, 'should have produced real intermediate frames');
+  });
+
+  it('stops moving the window once cancelled mid-flight', () => {
+    const h = harness();
+    h.advance(FLIGHT_MS / 4);
+    const seen = h.frames.length;
+    h.cancel();
+    h.advance(FLIGHT_MS);
+    assert.equal(h.frames.length, seen, 'a tick after cancel must not move a destroyed window');
+    assert.equal(h.isDone(), false, 'and must not report completion');
+  });
+});

--- a/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
@@ -11,6 +11,7 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import {
+  DOCK_LOST_TICKS,
   GIVE_UP_MS,
   GRANT_CLOSE_DELAY_MS,
   GRANT_POLL_MS,
@@ -66,6 +67,7 @@ function createHarness(overrides: Partial<PermissionOverlayDeps> = {}) {
   const clock = createClock();
   interface FakeWindow {
     win: PermissionOverlayWindowLike;
+    bounds: Array<{ x: number; y: number; width: number; height: number }>;
     sent: Array<{ channel: string; payload: unknown }>;
     destroyed: boolean;
     shown: boolean;
@@ -85,6 +87,7 @@ function createHarness(overrides: Partial<PermissionOverlayDeps> = {}) {
       // One object throughout: the window methods mutate the same record
       // the test asserts against, so there is no copy to fall out of sync.
       const entry = {
+        bounds: [] as Array<{ x: number; y: number; width: number; height: number }>,
         sent: [] as Array<{ channel: string; payload: unknown }>,
         destroyed: false,
         shown: false,
@@ -92,7 +95,7 @@ function createHarness(overrides: Partial<PermissionOverlayDeps> = {}) {
         gone: () => {},
       } as unknown as FakeWindow;
       entry.win = {
-        setBounds: () => {},
+        setBounds: (next) => { entry.bounds.push(next); },
         showInactive: () => { entry.shown = true; },
         isDestroyed: () => entry.destroyed,
         destroy: () => { entry.destroyed = true; },
@@ -342,5 +345,95 @@ describe('app bundle resolution for the drag', () => {
     });
     assert.equal(result.ok, false);
     assert.equal(result.ok === false && result.reason, 'not_darwin');
+  });
+});
+
+describe('docking to the System Settings window', () => {
+  /** Drive the async docking tick to completion. */
+  const settle = () => new Promise((r) => setTimeout(r, 0));
+
+  function dockHarness(frames: Array<{ x: number; y: number; width: number; height: number } | null>) {
+    let call = 0;
+    const h = createHarness({
+      // 1440x900 work area, card 360x96 (see createHarness).
+      locateSettingsWindow: async () => frames[Math.min(call++, frames.length - 1)],
+    });
+    return h;
+  }
+
+  it('docks BELOW the Settings window so the card never covers the drop target', async () => {
+    const h = dockHarness([{ x: 400, y: 100, width: 720, height: 600 }]);
+    await h.controller.start('accessibility');
+    h.windows[0].ready();
+
+    h.clock.tickIntervals();
+    await settle();
+
+    const bounds = h.windows[0].bounds.at(-1);
+    assert.ok(bounds, 'the card should have been repositioned');
+    // Window spans y 100..700; the card must start below it, not over it.
+    assert.ok(
+      bounds.y >= 700,
+      `card must sit below the window's bottom edge (700), got ${bounds.y}`,
+    );
+    // Centred on the window: 400 + (720-360)/2 = 580.
+    assert.equal(bounds.x, 580);
+  });
+
+  it('tucks the card inside the lower edge when there is no room below', async () => {
+    // Window runs to y=880 on a 900-tall work area; 96px of card will not fit.
+    const h = dockHarness([{ x: 400, y: 280, width: 720, height: 600 }]);
+    await h.controller.start('accessibility');
+    h.windows[0].ready();
+    h.clock.tickIntervals();
+    await settle();
+
+    const bounds = h.windows[0].bounds.at(-1);
+    assert.ok(bounds, 'the card should have been repositioned');
+    assert.ok(bounds.y + 96 <= 900, `card ran off the bottom: ${JSON.stringify(bounds)}`);
+    assert.ok(bounds.y > 280, 'card should still be near the window, not flung to the top');
+  });
+
+  it('only moves the window when the target actually moved', async () => {
+    const frame = { x: 400, y: 100, width: 720, height: 600 };
+    const h = dockHarness([frame, frame, frame]);
+    await h.controller.start('accessibility');
+    h.windows[0].ready();
+
+    for (let i = 0; i < 3; i++) { h.clock.tickIntervals(); await settle(); }
+
+    // Three ticks, one identical target: setBounds must not fight a user
+    // who is dragging the Settings window.
+    assert.equal(h.windows[0].bounds.length, 1, 'repeated identical frames must not re-set bounds');
+  });
+
+  it('closes the card once Settings has been gone for several ticks', async () => {
+    const h = dockHarness([{ x: 400, y: 100, width: 720, height: 600 }, null]);
+    await h.controller.start('accessibility');
+    h.windows[0].ready();
+
+    h.clock.tickIntervals();
+    await settle();
+    assert.equal(h.windows[0].destroyed, false);
+
+    // A single miss is not enough — Settings may just be busy.
+    h.clock.tickIntervals();
+    await settle();
+    assert.equal(h.windows[0].destroyed, false, 'one miss must not close the card');
+
+    for (let i = 0; i < DOCK_LOST_TICKS; i++) { h.clock.tickIntervals(); await settle(); }
+    assert.equal(h.windows[0].destroyed, true, 'a sustained absence means the user closed Settings');
+    assert.equal(h.clock.pending(), 0, 'and every timer goes with it');
+  });
+
+  it('keeps the cursor anchor when no locator is available', async () => {
+    const h = createHarness(); // no locateSettingsWindow
+    await h.controller.start('accessibility');
+    h.windows[0].ready();
+    h.clock.tickIntervals();
+    await settle();
+
+    assert.equal(h.windows[0].bounds.length, 0, 'without a locator the card must not be moved');
+    assert.equal(h.windows[0].destroyed, false, 'and it must not be treated as "Settings gone"');
   });
 });

--- a/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
@@ -437,3 +437,54 @@ describe('docking to the System Settings window', () => {
     assert.equal(h.windows[0].destroyed, false, 'and it must not be treated as "Settings gone"');
   });
 });
+
+describe('docking across multiple displays', () => {
+  const settle = () => new Promise((r) => setTimeout(r, 0));
+
+  /**
+   * Real geometry from a three-display Mac: the built-in panel is the
+   * primary at (0,0), and two externals sit ABOVE it at negative y, one
+   * of them at negative x. Negative origins are normal, not exotic.
+   */
+  const PRIMARY = { x: 0, y: 33, width: 1512, height: 949 };
+  const LEFT_ABOVE = { x: -1072, y: -1050, width: 1920, height: 1050 };
+
+  it('clamps to the display holding System Settings, not the one holding the cursor', async () => {
+    const bounds: Array<{ x: number; y: number; width: number; height: number }> = [];
+    // Settings is on the top-left external; the cursor is on the primary.
+    const settings = { x: -800, y: -900, width: 723, height: 837 };
+
+    const h = createHarness({
+      cardSize: { width: 530, height: 109 },
+      getAnchor: () => ({ x: 700, y: 500, workArea: PRIMARY }),
+      workAreaForPoint: (x: number, y: number) =>
+        (x < 0 || y < 0 ? LEFT_ABOVE : PRIMARY),
+      locateSettingsWindow: async () => settings,
+      createWindow: (b) => {
+        bounds.push(b);
+        return {
+          setBounds: (next) => bounds.push(next),
+          showInactive: () => {}, isDestroyed: () => false, destroy: () => {},
+          send: () => {}, onReady: () => {}, onGone: () => {},
+        };
+      },
+    });
+
+    await h.controller.start('accessibility');
+    h.clock.tickIntervals();
+    await settle();
+
+    const docked = bounds.at(-1);
+    assert.ok(docked, 'the card should have been docked');
+    // Centred under Settings: -800 + (723-530)/2 = -703.5 -> -704/-703.
+    assert.ok(
+      docked.x < 0,
+      `card must stay on the display holding Settings (expected ~-703, got x=${docked.x}). `
+      + 'Clamping to the cursor display drags it onto another monitor.',
+    );
+    assert.ok(
+      docked.y < 0,
+      `card must sit below Settings on that display (expected ~-55, got y=${docked.y})`,
+    );
+  });
+});

--- a/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
@@ -356,7 +356,10 @@ describe('docking to the System Settings window', () => {
     let call = 0;
     const h = createHarness({
       // 1440x900 work area, card 360x96 (see createHarness).
-      locateSettingsWindow: async () => frames[Math.min(call++, frames.length - 1)],
+      locateSettingsWindow: async () => {
+        const f = frames[Math.min(call++, frames.length - 1)];
+        return f ? { ok: true, frame: f } : { ok: false, reason: 'not_running' };
+      },
     });
     return h;
   }
@@ -402,12 +405,16 @@ describe('docking to the System Settings window', () => {
 
     for (let i = 0; i < 3; i++) { h.clock.tickIntervals(); await settle(); }
 
-    // Three ticks, one identical target: setBounds must not fight a user
-    // who is dragging the Settings window.
+    // One placement at start(), and nothing after: repeated identical
+    // frames must not re-set bounds and fight a user who is dragging the
+    // Settings window.
     assert.equal(h.windows[0].bounds.length, 1, 'repeated identical frames must not re-set bounds');
   });
 
   it('closes the card once Settings has been gone for several ticks', async () => {
+    // start() consumes the first frame for the initial placement, so every
+    // tick after this sees `null` — i.e. Settings disappeared after we had
+    // definitely seen it.
     const h = dockHarness([{ x: 400, y: 100, width: 720, height: 600 }, null]);
     await h.controller.start('accessibility');
     h.windows[0].ready();
@@ -433,7 +440,9 @@ describe('docking to the System Settings window', () => {
     h.clock.tickIntervals();
     await settle();
 
-    assert.equal(h.windows[0].bounds.length, 0, 'without a locator the card must not be moved');
+    // One placement at the cursor anchor, and no docking tracker at all.
+    assert.equal(h.windows[0].bounds.length, 1, 'placed once, at the cursor anchor');
+    assert.equal(h.clock.intervals.size, 1, 'only the grant poll — no docking tracker without a locator');
     assert.equal(h.windows[0].destroyed, false, 'and it must not be treated as "Settings gone"');
   });
 });
@@ -459,7 +468,7 @@ describe('docking across multiple displays', () => {
       getAnchor: () => ({ x: 700, y: 500, workArea: PRIMARY }),
       workAreaForPoint: (x: number, y: number) =>
         (x < 0 || y < 0 ? LEFT_ABOVE : PRIMARY),
-      locateSettingsWindow: async () => settings,
+      locateSettingsWindow: async () => ({ ok: true, frame: settings }),
       createWindow: (b) => {
         bounds.push(b);
         return {
@@ -486,5 +495,53 @@ describe('docking across multiple displays', () => {
       docked.y < 0,
       `card must sit below Settings on that display (expected ~-55, got y=${docked.y})`,
     );
+  });
+});
+
+describe('docking failures must not kill the card', () => {
+  const settle = () => new Promise((r) => setTimeout(r, 0));
+
+  it('survives a locator that can never work (missing binary)', async () => {
+    // What production actually produces in a packaged build: the dep IS
+    // supplied, and it fails every time. The card must stay on its cursor
+    // anchor, not conclude the user closed System Settings.
+    const h = createHarness({
+      locateSettingsWindow: async () => ({ ok: false, reason: 'binary_missing' }),
+    });
+    await h.controller.start('accessibility');
+    h.windows[0].ready();
+
+    for (let i = 0; i < DOCK_LOST_TICKS + 3; i++) { h.clock.tickIntervals(); await settle(); }
+
+    assert.equal(
+      h.windows[0].destroyed, false,
+      'a locator that cannot run means "cannot dock", not "Settings went away"',
+    );
+    assert.equal(h.controller.isOpen(), true);
+  });
+
+  it('gives System Settings time to appear before counting it missing', async () => {
+    // `openSystemSettings` resolves when the deep link is handed off, not
+    // when the window exists. A cold launch easily exceeds 5 ticks (1s).
+    let calls = 0;
+    const h = createHarness({
+      locateSettingsWindow: async () => {
+        calls += 1;
+        return calls > 8
+          ? { ok: true, frame: { x: 400, y: 100, width: 720, height: 600 } }
+          : { ok: false, reason: 'not_running' };
+      },
+    });
+    await h.controller.start('accessibility');
+    h.windows[0].ready();
+
+    for (let i = 0; i < 8; i++) { h.clock.tickIntervals(); await settle(); }
+    assert.equal(
+      h.windows[0].destroyed, false,
+      'the card must not give up before Settings has ever appeared',
+    );
+
+    h.clock.tickIntervals(); await settle();
+    assert.ok(h.windows[0].bounds.length > 0, 'and it should dock once Settings shows up');
   });
 });

--- a/apps/desktop/src/main/__tests__/settings-window-locator.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-window-locator.test.ts
@@ -1,0 +1,97 @@
+/**
+ * Locator boundary contract.
+ *
+ * The locator is the one place the card trusts output from a separate
+ * process. Every failure mode has to land on `null` at the caller, because
+ * the fallback (cursor anchoring) is a working state and a thrown error
+ * here would take down an onboarding flow over a missing 89KB binary.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  locateSettingsWindow,
+  type LocateDeps,
+} from '../permission-overlay/settings-window-locator.js';
+
+function deps(overrides: Partial<LocateDeps> = {}): LocateDeps {
+  return {
+    binaryPath: '/fake/settings-window-locator',
+    platform: 'darwin',
+    timeoutMs: 150,
+    exists: () => true,
+    runBinary: async () => ({ stdout: '{"ok":true,"x":10,"y":20,"width":700,"height":800}' }),
+    ...overrides,
+  };
+}
+
+describe('settings window locator', () => {
+  it('parses a located window', async () => {
+    const result = await locateSettingsWindow(deps());
+    assert.deepEqual(result, { ok: true, frame: { x: 10, y: 20, width: 700, height: 800 } });
+  });
+
+  it('passes through the reasons the binary actually emits', async () => {
+    for (const reason of ['not_running', 'no_settings_window', 'window_list_failed']) {
+      const result = await locateSettingsWindow(
+        deps({ runBinary: async () => ({ stdout: `{"ok":false,"reason":"${reason}"}` }) }),
+      );
+      assert.deepEqual(result, { ok: false, reason });
+    }
+  });
+
+  it('does not trust an unknown reason string', async () => {
+    // A reason we do not emit means the thing on the other end is not the
+    // binary we think it is; treat it as malformed rather than forwarding.
+    const result = await locateSettingsWindow(
+      deps({ runBinary: async () => ({ stdout: '{"ok":false,"reason":"../../etc/passwd"}' }) }),
+    );
+    assert.deepEqual(result, { ok: false, reason: 'bad_output' });
+  });
+
+  it('rejects malformed, non-numeric, and zero-area output', async () => {
+    const bad = [
+      'not json at all',
+      '',
+      'null',
+      '[]',
+      '{"ok":true}',
+      '{"ok":true,"x":"10","y":20,"width":700,"height":800}',
+      '{"ok":true,"x":10,"y":20,"width":0,"height":800}',
+      '{"ok":true,"x":10,"y":20,"width":700,"height":-5}',
+      '{"ok":true,"x":null,"y":20,"width":700,"height":800}',
+    ];
+    for (const stdout of bad) {
+      const result = await locateSettingsWindow(deps({ runBinary: async () => ({ stdout }) }));
+      assert.equal(result.ok, false, `${JSON.stringify(stdout)} must not parse as a frame`);
+      assert.equal(result.ok === false && result.reason, 'bad_output', JSON.stringify(stdout));
+    }
+  });
+
+  it('reports a NaN/Infinity frame as malformed rather than moving a window to it', async () => {
+    const result = await locateSettingsWindow(
+      deps({ runBinary: async () => ({ stdout: '{"ok":true,"x":1e999,"y":20,"width":700,"height":800}' }) }),
+    );
+    assert.deepEqual(result, { ok: false, reason: 'bad_output' });
+  });
+
+  it('degrades when the binary is missing or the spawn fails', async () => {
+    assert.deepEqual(
+      await locateSettingsWindow(deps({ exists: () => false })),
+      { ok: false, reason: 'binary_missing' },
+    );
+    assert.deepEqual(
+      await locateSettingsWindow(deps({ runBinary: async () => null })),
+      { ok: false, reason: 'spawn_failed' },
+    );
+  });
+
+  it('never runs the binary off darwin', async () => {
+    let ran = false;
+    const result = await locateSettingsWindow(
+      deps({ platform: 'linux', runBinary: async () => { ran = true; return null; } }),
+    );
+    assert.deepEqual(result, { ok: false, reason: 'unsupported_platform' });
+    assert.equal(ran, false, 'the platform gate must come before the spawn');
+  });
+});

--- a/apps/desktop/src/main/permission-overlay/card-flight.ts
+++ b/apps/desktop/src/main/permission-overlay/card-flight.ts
@@ -1,0 +1,128 @@
+/**
+ * The card's flight from the button to the System Settings window.
+ *
+ * This is the part of the effect that carries the meaning: a card that
+ * simply appears next to Settings reads as an unrelated popup, while one
+ * that arcs out of the button the user just pressed reads as "this thing
+ * came from there and belongs over here". So the path is deliberately an
+ * arc, not a slide.
+ *
+ * Pure geometry — no timers, no Electron. The caller samples `frameAt(t)`
+ * on whatever clock it has, which is what makes the curve and the spring
+ * testable without animating anything.
+ */
+
+export interface Rect { x: number; y: number; width: number; height: number }
+
+/** Total flight time. Long enough to read as motion, short enough that it
+ *  never feels like a wait before the user can start dragging. */
+export const FLIGHT_MS = 620;
+
+/**
+ * How high the arc bows, as a fraction of the distance travelled, clamped
+ * so a short hop still visibly arcs and a cross-screen flight does not
+ * loop absurdly high.
+ */
+export const ARC_RATIO = 0.18;
+export const ARC_MIN_PX = 44;
+export const ARC_MAX_PX = 140;
+
+/**
+ * Critically damped spring, normalised to reach ~1 at t=1.
+ *
+ * Critically damped, not underdamped: the card must not overshoot past
+ * the Settings window and swing back. Overshoot looks playful in a demo
+ * and reads as imprecision when the thing is claiming "your target is
+ * exactly here".
+ */
+export function springProgress(t: number): number {
+  if (t <= 0) return 0;
+  if (t >= 1) return 1;
+  const omega = 6;
+  return 1 - Math.exp(-omega * t) * (1 + omega * t);
+}
+
+function lift(from: Rect, to: Rect): number {
+  const dx = to.x - from.x;
+  const dy = to.y - from.y;
+  const distance = Math.hypot(dx, dy);
+  return Math.min(Math.max(distance * ARC_RATIO, ARC_MIN_PX), ARC_MAX_PX);
+}
+
+/**
+ * Position + size at normalised time `t` (0..1).
+ *
+ * The arc is a quadratic Bézier whose control point sits at the midpoint
+ * lifted UPWARD (negative y, screen coordinates). Size interpolates
+ * separately on the same eased clock, so the card grows from the button's
+ * footprint into the docked card rather than sliding at full size.
+ */
+export function frameAt(from: Rect, to: Rect, t: number): Rect {
+  const eased = springProgress(t);
+  const arc = lift(from, to);
+
+  // Quadratic Bézier on the CENTRES, so the arc is not skewed by the
+  // card growing from a small button.
+  const fromCx = from.x + from.width / 2;
+  const fromCy = from.y + from.height / 2;
+  const toCx = to.x + to.width / 2;
+  const toCy = to.y + to.height / 2;
+  const ctrlX = (fromCx + toCx) / 2;
+  const ctrlY = (fromCy + toCy) / 2 - arc;
+
+  const inv = 1 - eased;
+  const cx = inv * inv * fromCx + 2 * inv * eased * ctrlX + eased * eased * toCx;
+  const cy = inv * inv * fromCy + 2 * inv * eased * ctrlY + eased * eased * toCy;
+
+  const width = from.width + (to.width - from.width) * eased;
+  const height = from.height + (to.height - from.height) * eased;
+
+  return {
+    x: Math.round(cx - width / 2),
+    y: Math.round(cy - height / 2),
+    width: Math.round(width),
+    height: Math.round(height),
+  };
+}
+
+export interface FlightDeps {
+  from: Rect;
+  to: Rect;
+  /** Monotonic clock, injected so tests do not wait. */
+  now(): number;
+  setFrame(rect: Rect): void;
+  requestTick(fn: () => void): void;
+  onDone(): void;
+  /** Honour the system setting: skip straight to the destination. */
+  reducedMotion: boolean;
+}
+
+/**
+ * Run the flight. Returns a cancel function — the card can be dismissed
+ * or the grant can land mid-flight, and a tick that fires after that must
+ * not move a destroyed window.
+ */
+export function runFlight(deps: FlightDeps): () => void {
+  if (deps.reducedMotion) {
+    deps.setFrame(deps.to);
+    deps.onDone();
+    return () => {};
+  }
+
+  const start = deps.now();
+  let cancelled = false;
+
+  const step = (): void => {
+    if (cancelled) return;
+    const t = Math.min(1, (deps.now() - start) / FLIGHT_MS);
+    deps.setFrame(frameAt(deps.from, deps.to, t));
+    if (t >= 1) {
+      deps.onDone();
+      return;
+    }
+    deps.requestTick(step);
+  };
+
+  deps.requestTick(step);
+  return () => { cancelled = true; };
+}

--- a/apps/desktop/src/main/permission-overlay/permission-overlay-controller.ts
+++ b/apps/desktop/src/main/permission-overlay/permission-overlay-controller.ts
@@ -57,8 +57,18 @@ export interface PermissionOverlayDeps {
   /** Card size, in DIP. */
   cardSize: { width: number; height: number };
   createWindow(bounds: { x: number; y: number; width: number; height: number }): PermissionOverlayWindowLike;
-  /** Work area of the display the card should appear on. */
+  /** Cursor position + the work area of the display it sits on. */
   getAnchor(): { x: number; y: number; workArea: { x: number; y: number; width: number; height: number } };
+  /**
+   * Work area of the display containing an arbitrary screen point.
+   *
+   * Docking must clamp against the display holding SYSTEM SETTINGS, which
+   * is not necessarily the one holding the cursor. Displays routinely have
+   * negative origins (an external above or left of the built-in panel), so
+   * clamping to the wrong one does not merely nudge the card — it drags it
+   * onto a different monitor.
+   */
+  workAreaForPoint?(x: number, y: number): { x: number; y: number; width: number; height: number };
   openSystemSettings(id: DragGrantPermissionId): Promise<{ ok: boolean; message?: string }>;
   /** Non-prompting read of the current grant state. */
   isGranted(id: DragGrantPermissionId): boolean;
@@ -186,7 +196,10 @@ export function createPermissionOverlayController(
    */
   function dockedBounds(frame: SettingsWindowFrame): Bounds {
     const { width, height } = deps.cardSize;
-    const { workArea } = deps.getAnchor();
+    // The display under the Settings window's centre — see workAreaForPoint.
+    const workArea = deps.workAreaForPoint
+      ? deps.workAreaForPoint(frame.x + frame.width / 2, frame.y + frame.height / 2)
+      : deps.getAnchor().workArea;
     const clamp = (value: number, min: number, max: number): number =>
       Math.round(Math.min(Math.max(value, min), max));
 

--- a/apps/desktop/src/main/permission-overlay/permission-overlay-controller.ts
+++ b/apps/desktop/src/main/permission-overlay/permission-overlay-controller.ts
@@ -23,6 +23,7 @@
 
 import type { DragGrantPermissionId } from '@maka/core';
 import { isDragGrantPermissionId } from '@maka/core';
+import type { LocatorResult } from './settings-window-locator.js';
 import type { SettingsWindowFrame } from './settings-window-locator.js';
 import { runFlight, type Rect } from './card-flight.js';
 
@@ -83,7 +84,7 @@ export interface PermissionOverlayDeps {
    * it. Absent (or resolving null) keeps the Stage 1 cursor anchor, which
    * is a working state — see docs/permission-onboarding-plan.md.
    */
-  locateSettingsWindow?(): Promise<SettingsWindowFrame | null>;
+  locateSettingsWindow?(): Promise<LocatorResult>;
   onGranted?(id: DragGrantPermissionId): void;
   log?(message: string): void;
   /** Animation clock + frame scheduler. Injected so tests never animate. */
@@ -140,6 +141,12 @@ export function createPermissionOverlayController(
   let closing: NodeJS.Timeout | null = null;
   let dock: NodeJS.Timeout | null = null;
   let cancelFlight: (() => void) | null = null;
+  // Docking memory, hoisted so the pre-flight locate in `start()` can seed
+  // it: without that, the first tick re-writes bounds the flight already
+  // delivered, and a card that has been located once still looks "never
+  // seen" to the went-away check.
+  let lastDockKey = '';
+  let everLocated = false;
 
   function stopTimers(): void {
     if (poll) { deps.clearInterval(poll); poll = null; }
@@ -240,33 +247,49 @@ export function createPermissionOverlayController(
     });
   }
 
-  function beginDocking(): void {
+  function beginDocking(target: PermissionOverlayWindowLike): void {
     const locate = deps.locateSettingsWindow;
     if (!locate) return;
-    let lastKey = '';
     let misses = 0;
 
     dock = deps.setInterval(() => {
-      if (!win || win.isDestroyed()) return;
-      void locate().then((frame) => {
-        if (!win || win.isDestroyed()) return;
-        if (!frame) {
-          // Stage 1 could not tell "Settings was closed" from "no locator",
-          // so an abandoned card just froze in place. Now that the locator
-          // can say, treat a sustained absence as the user walking away.
+      if (win !== target || target.isDestroyed()) return;
+      void locate().then((result) => {
+        // Identity, not just liveness: `locate()` is a real async spawn, so
+        // this continuation can land after teardown and after a NEW card
+        // opened. Checking only "some window is alive" would move that new
+        // window using the previous session's geometry.
+        if (win !== target || target.isDestroyed()) return;
+        if (!result.ok) {
+          // A locator that CANNOT run is not evidence about System
+          // Settings. Treating it as "the user closed the pane" is how a
+          // build shipped without the binary would kill its own card one
+          // second after opening it.
+          if (result.reason !== 'not_running' && result.reason !== 'no_settings_window') {
+            deps.log?.(`[permission-overlay] locator unavailable (${result.reason}) — staying on the cursor anchor`);
+            if (dock) { deps.clearInterval(dock); dock = null; }
+            return;
+          }
+          if (!everLocated) return;
           if (++misses < DOCK_LOST_TICKS) return;
           deps.log?.('[permission-overlay] System Settings went away — closing the card');
           teardown();
           return;
         }
+        const frame = result.frame;
+        everLocated = true;
         misses = 0;
         const next = dockedBounds(frame);
         const key = `${next.x},${next.y},${next.width},${next.height}`;
         // Only touch the window when the target actually moved: setBounds
         // on every tick fights the user's own drag of the Settings window.
-        if (key === lastKey) return;
-        lastKey = key;
-        win.setBounds(next);
+        // While the entrance flight owns the bounds, record the target but
+        // do not write it: the flight's 16ms steps would overwrite us and we
+        // would overwrite the flight, visibly fighting for its whole 620ms.
+        if (cancelFlight) { lastDockKey = ''; return; }
+        if (key === lastDockKey) return;
+        lastDockKey = key;
+        target.setBounds(next);
       });
     }, DOCK_POLL_MS);
   }
@@ -309,6 +332,8 @@ export function createPermissionOverlayController(
       }
 
       active = id;
+      lastDockKey = '';
+      everLocated = false;
       // Launch from the button when the caller told us where it is, so the
       // card is seen to come OUT of the control the user just pressed.
       // Without a source rect it simply appears at the resting position.
@@ -326,9 +351,30 @@ export function createPermissionOverlayController(
         created.send('permission-overlay:show', deps.buildCardPayload(id));
         created.showInactive();
       });
-      if (canFly) flyTo(created, sourceRect!, resting);
+      // Resolve the docked position BEFORE flying, so the card makes one
+      // continuous move from the button to where it will actually live.
+      // Flying to the cursor anchor first and letting the tracker correct
+      // it afterwards is what made the two fight over the same bounds.
+      let destination = resting;
+      if (deps.locateSettingsWindow) {
+        try {
+          const located = await deps.locateSettingsWindow();
+          if (located.ok) {
+            destination = dockedBounds(located.frame);
+            everLocated = true;
+            lastDockKey = `${destination.x},${destination.y},${destination.width},${destination.height}`;
+          }
+        } catch {
+          // A locator that throws is a "cannot dock", not a failure to open.
+        }
+      }
+      // `start()` awaited above; the card may have been dismissed meanwhile.
+      if (win !== created || created.isDestroyed()) return { ok: true };
+
+      if (canFly) flyTo(created, sourceRect!, destination);
+      else created.setBounds(destination);
       beginWatching(id);
-      beginDocking();
+      beginDocking(created);
       return { ok: true };
     },
 

--- a/apps/desktop/src/main/permission-overlay/permission-overlay-controller.ts
+++ b/apps/desktop/src/main/permission-overlay/permission-overlay-controller.ts
@@ -9,12 +9,13 @@
  * float a non-focusable card the user can drag the app out of, watch for
  * the grant, and get out of the way.
  *
- * Stage 1 (see docs/permission-onboarding-plan.md) is deliberately pure
- * Electron. The card is anchored to the cursor rather than docked to the
- * System Settings window, because locating a foreign window needs
- * `CGWindowListCopyWindowInfo` and therefore native code. Everything
- * else — the panel window, the drag, the poll — is stock, so Stage 1
- * ships without touching the build. Stage 2 adds the locator and docks.
+ * Docking is progressive enhancement. Locating a foreign window needs
+ * `CGWindowListCopyWindowInfo`, i.e. native code, so `locateSettingsWindow`
+ * is optional: with it the card docks under the Settings window and
+ * follows it; without it (no locator binary, or Settings not found) the
+ * card anchors to the cursor, which is the Stage 1 behaviour that shipped
+ * and works. Everything else — panel window, drag, grant poll — is stock
+ * Electron. See docs/permission-onboarding-plan.md.
  *
  * Every dependency is injected so the state machine is testable under
  * `node --test` with no Electron runtime and no real timers.
@@ -22,6 +23,8 @@
 
 import type { DragGrantPermissionId } from '@maka/core';
 import { isDragGrantPermissionId } from '@maka/core';
+import type { SettingsWindowFrame } from './settings-window-locator.js';
+import { runFlight, type Rect } from './card-flight.js';
 
 // The id list lives in @maka/core so the Permission Center row and this
 // flow cannot disagree about which permissions the gesture applies to.
@@ -35,6 +38,8 @@ export type OverlayStartResult =
       reason: 'invalid_id' | 'unsupported_platform' | 'already_open' | 'open_settings_failed';
       message?: string;
     };
+
+export interface Bounds { x: number; y: number; width: number; height: number }
 
 /** The window surface the controller drives; faked in tests. */
 export interface PermissionOverlayWindowLike {
@@ -63,8 +68,19 @@ export interface PermissionOverlayDeps {
   clearTimeout(handle: NodeJS.Timeout): void;
   /** Payload the card renders (app icon + name + copy). */
   buildCardPayload(id: DragGrantPermissionId): unknown;
+  /**
+   * Optional: locate the System Settings window so the card can dock to
+   * it. Absent (or resolving null) keeps the Stage 1 cursor anchor, which
+   * is a working state — see docs/permission-onboarding-plan.md.
+   */
+  locateSettingsWindow?(): Promise<SettingsWindowFrame | null>;
   onGranted?(id: DragGrantPermissionId): void;
   log?(message: string): void;
+  /** Animation clock + frame scheduler. Injected so tests never animate. */
+  now?(): number;
+  requestTick?(fn: () => void): void;
+  /** System "reduce motion" setting; true skips the flight entirely. */
+  reducedMotion?(): boolean;
 }
 
 /** Poll cadence for the grant check. macOS exposes no usable notification
@@ -81,9 +97,22 @@ export const GRANT_CLOSE_DELAY_MS = 1_200;
  * enough that a forgotten card cleans itself up.
  */
 export const GIVE_UP_MS = 10 * 60 * 1_000;
+/**
+ * Docking tick. Each one spawns the locator, so this is 5 processes a
+ * second — affordable for a short-lived onboarding card and not something
+ * to generalise. Below ~100ms the spawn cost shows; above ~500ms the card
+ * visibly lags a window the user is dragging.
+ */
+export const DOCK_POLL_MS = 200;
+/** Gap between the Settings window and the card. */
+export const DOCK_GAP_PX = 8;
+/** Consecutive misses before we conclude Settings is gone, not just busy. */
+export const DOCK_LOST_TICKS = 5;
 
 export interface PermissionOverlayController {
-  start(id: unknown): Promise<OverlayStartResult>;
+  /** `sourceRect` is the on-screen rect of the button the user pressed, so
+   *  the card can launch from it. Omitted → no flight, card just appears. */
+  start(id: unknown, sourceRect?: Rect | null): Promise<OverlayStartResult>;
   /** Tear the card down: the × button, app quit, or a test. */
   dismiss(): void;
   isOpen(): boolean;
@@ -99,11 +128,15 @@ export function createPermissionOverlayController(
   let poll: NodeJS.Timeout | null = null;
   let giveUp: NodeJS.Timeout | null = null;
   let closing: NodeJS.Timeout | null = null;
+  let dock: NodeJS.Timeout | null = null;
+  let cancelFlight: (() => void) | null = null;
 
   function stopTimers(): void {
     if (poll) { deps.clearInterval(poll); poll = null; }
     if (giveUp) { deps.clearTimeout(giveUp); giveUp = null; }
     if (closing) { deps.clearTimeout(closing); closing = null; }
+    if (dock) { deps.clearInterval(dock); dock = null; }
+    if (cancelFlight) { cancelFlight(); cancelFlight = null; }
   }
 
   function teardown(): void {
@@ -137,6 +170,94 @@ export function createPermissionOverlayController(
     };
   }
 
+  /**
+   * Place the card against the System Settings window.
+   *
+   * BELOW the window, not over it. The card is always-on-top; parking it
+   * across the Privacy list would cover the very rows the user has to
+   * drop onto, which is worse than not docking at all. Sitting under the
+   * window also makes "drag it up into the list" literally true.
+   *
+   * Centred on the whole window rather than on the content pane. Alma
+   * offsets by a hardcoded 170px sidebar to centre over the pane; that
+   * number is exactly the kind of internal-layout constant that rots
+   * across macOS releases, and being 100px off-centre costs nothing while
+   * being wrong about the sidebar width looks broken.
+   */
+  function dockedBounds(frame: SettingsWindowFrame): Bounds {
+    const { width, height } = deps.cardSize;
+    const { workArea } = deps.getAnchor();
+    const clamp = (value: number, min: number, max: number): number =>
+      Math.round(Math.min(Math.max(value, min), max));
+
+    const x = clamp(
+      frame.x + (frame.width - width) / 2,
+      workArea.x,
+      workArea.x + workArea.width - width,
+    );
+    const below = frame.y + frame.height + DOCK_GAP_PX;
+    // No room underneath (Settings near the bottom of the display): tuck
+    // the card just inside the window's lower edge instead of letting the
+    // clamp shove it somewhere unrelated.
+    const y = below + height <= workArea.y + workArea.height
+      ? below
+      : clamp(frame.y + frame.height - height - DOCK_GAP_PX, workArea.y, workArea.y + workArea.height - height);
+    return { x, y: Math.round(y), width, height };
+  }
+
+  /**
+   * Fly the card from `from` to `to`. The destination is the resting
+   * position we know NOW; if the locator resolves a docked position a
+   * moment later, the docking tracker retargets from wherever the flight
+   * left the card, which reads as one continuous move rather than a jump.
+   */
+  function flyTo(target: PermissionOverlayWindowLike, from: Rect, to: Rect): void {
+    if (cancelFlight) cancelFlight();
+    cancelFlight = runFlight({
+      from,
+      to,
+      reducedMotion: deps.reducedMotion?.() ?? false,
+      now: deps.now!,
+      requestTick: deps.requestTick!,
+      setFrame: (rect) => {
+        if (win !== target || target.isDestroyed()) return;
+        target.setBounds(rect);
+      },
+      onDone: () => { cancelFlight = null; },
+    });
+  }
+
+  function beginDocking(): void {
+    const locate = deps.locateSettingsWindow;
+    if (!locate) return;
+    let lastKey = '';
+    let misses = 0;
+
+    dock = deps.setInterval(() => {
+      if (!win || win.isDestroyed()) return;
+      void locate().then((frame) => {
+        if (!win || win.isDestroyed()) return;
+        if (!frame) {
+          // Stage 1 could not tell "Settings was closed" from "no locator",
+          // so an abandoned card just froze in place. Now that the locator
+          // can say, treat a sustained absence as the user walking away.
+          if (++misses < DOCK_LOST_TICKS) return;
+          deps.log?.('[permission-overlay] System Settings went away — closing the card');
+          teardown();
+          return;
+        }
+        misses = 0;
+        const next = dockedBounds(frame);
+        const key = `${next.x},${next.y},${next.width},${next.height}`;
+        // Only touch the window when the target actually moved: setBounds
+        // on every tick fights the user's own drag of the Settings window.
+        if (key === lastKey) return;
+        lastKey = key;
+        win.setBounds(next);
+      });
+    }, DOCK_POLL_MS);
+  }
+
   function beginWatching(id: DragGrantPermissionId): void {
     poll = deps.setInterval(() => {
       if (!win || win.isDestroyed()) { teardown(); return; }
@@ -156,7 +277,7 @@ export function createPermissionOverlayController(
   }
 
   return {
-    async start(id: unknown): Promise<OverlayStartResult> {
+    async start(id: unknown, sourceRect?: Rect | null): Promise<OverlayStartResult> {
       if (!isDragGrantPermission(id)) return { ok: false, reason: 'invalid_id' };
       if (deps.platform !== 'darwin') return { ok: false, reason: 'unsupported_platform' };
       // Re-entry is not an error the user should see, but it must not
@@ -175,7 +296,12 @@ export function createPermissionOverlayController(
       }
 
       active = id;
-      const created = deps.createWindow(cardBounds());
+      // Launch from the button when the caller told us where it is, so the
+      // card is seen to come OUT of the control the user just pressed.
+      // Without a source rect it simply appears at the resting position.
+      const resting = cardBounds();
+      const canFly = Boolean(sourceRect && deps.now && deps.requestTick);
+      const created = deps.createWindow(canFly ? { ...sourceRect! } : resting);
       win = created;
       created.onGone(() => {
         // The window can also go away on its own (user closed it, render
@@ -187,7 +313,9 @@ export function createPermissionOverlayController(
         created.send('permission-overlay:show', deps.buildCardPayload(id));
         created.showInactive();
       });
+      if (canFly) flyTo(created, sourceRect!, resting);
       beginWatching(id);
+      beginDocking();
       return { ok: true };
     },
 

--- a/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
+++ b/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
@@ -30,7 +30,6 @@ import {
   defaultExists,
   defaultRunBinary,
   locateSettingsWindow,
-  type SettingsWindowFrame,
 } from './settings-window-locator.js';
 import { getPermissionOverlayCopy } from './permission-overlay-copy.js';
 import {
@@ -141,7 +140,10 @@ export function createPermissionOverlayMain(
     workAreaForPoint: (x, y) => screen.getDisplayNearestPoint({ x: Math.round(x), y: Math.round(y) }).workArea,
     openSystemSettings: async (id) => {
       const result = await openSystemPermissionPane(id);
-      return result.ok ? { ok: true } : { ok: false, message: result.message ?? result.reason };
+      // Deliberately no `message` fallback to `result.reason`: that put a
+      // raw enum ("unsupported_permission") in the user's toast body. The
+      // renderer has localized copy keyed on the reason.
+      return result.ok ? { ok: true } : { ok: false, message: result.message };
     },
     isGranted,
     setInterval: (fn, ms) => setInterval(fn, ms),
@@ -176,16 +178,15 @@ export function createPermissionOverlayMain(
         return false;
       }
     },
-    locateSettingsWindow: async (): Promise<SettingsWindowFrame | null> => {
-      const result = await locateSettingsWindow({
-        binaryPath: locatorBinaryPath(app),
-        platform: process.platform,
-        timeoutMs: LOCATOR_TIMEOUT_MS,
-        exists: defaultExists,
-        runBinary: defaultRunBinary,
-      });
-      return result.ok ? result.frame : null;
-    },
+    // The REASON matters, not just success: "no binary" must not be
+    // mistaken for "the user closed System Settings".
+    locateSettingsWindow: () => locateSettingsWindow({
+      binaryPath: locatorBinaryPath(app),
+      platform: process.platform,
+      timeoutMs: LOCATOR_TIMEOUT_MS,
+      exists: defaultExists,
+      runBinary: defaultRunBinary,
+    }),
     createWindow: (bounds) => {
       const win = new BrowserWindow({
         ...bounds,

--- a/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
+++ b/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
@@ -25,6 +25,13 @@ import { fileURLToPath } from 'node:url';
 import type { UiLocale } from '@maka/core';
 import { openSystemPermissionPane } from '../permissions-actions.js';
 import { resolveAppBundle } from './app-bundle.js';
+import type { Rect } from './card-flight.js';
+import {
+  defaultExists,
+  defaultRunBinary,
+  locateSettingsWindow,
+  type SettingsWindowFrame,
+} from './settings-window-locator.js';
 import { getPermissionOverlayCopy } from './permission-overlay-copy.js';
 import {
   createPermissionOverlayController,
@@ -53,6 +60,23 @@ function overlayAssetDir(): string {
   // dist/main/permission-overlay -> dist/overlay
   return join(here, '..', '..', 'overlay');
 }
+
+/**
+ * The locator binary. Built by `build:locator` into `resources/native`,
+ * which electron-builder ships as `Contents/Resources/native`. Absent in
+ * a build without the Xcode toolchain — the card then falls back to
+ * cursor anchoring rather than failing.
+ */
+function locatorBinaryPath(app: Electron['app']): string {
+  // dist/main/permission-overlay -> apps/desktop, then resources/native.
+  const devPath = join(here, '..', '..', '..', 'resources', 'native', 'settings-window-locator');
+  if (!app.isPackaged) return devPath;
+  return join(process.resourcesPath, 'native', 'settings-window-locator');
+}
+
+/** Locator timeout. Well under the 200ms docking tick so a slow call
+ *  cannot let two spawns overlap. */
+const LOCATOR_TIMEOUT_MS = 150;
 
 export interface PermissionOverlayMainDeps {
   /**
@@ -124,6 +148,28 @@ export function createPermissionOverlayMain(
       };
     },
     log: (message) => console.warn(message),
+    // The main process has no requestAnimationFrame; a 16ms timer is the
+    // closest thing, and the flight is short enough that drift is invisible.
+    now: () => performance.now(),
+    requestTick: (fn) => { setTimeout(fn, 16); },
+    reducedMotion: () => {
+      try {
+        return systemPreferences.getAnimationSettings().prefersReducedMotion;
+      } catch {
+        // Never let an animation preference lookup break the flow.
+        return false;
+      }
+    },
+    locateSettingsWindow: async (): Promise<SettingsWindowFrame | null> => {
+      const result = await locateSettingsWindow({
+        binaryPath: locatorBinaryPath(app),
+        platform: process.platform,
+        timeoutMs: LOCATOR_TIMEOUT_MS,
+        exists: defaultExists,
+        runBinary: defaultRunBinary,
+      });
+      return result.ok ? result.frame : null;
+    },
     createWindow: (bounds) => {
       const win = new BrowserWindow({
         ...bounds,
@@ -282,6 +328,21 @@ function attachCardGestures(win: import('electron').BrowserWindow): void {
   });
 }
 
+/**
+ * The launch rect is renderer-supplied, so it is validated rather than
+ * trusted: it only ever decides where an animation starts, and a garbage
+ * value would put the card at NaN and make it invisible. Anything not a
+ * finite, positive-area rect degrades to "no flight".
+ */
+function sanitizeSourceRect(value: unknown): Rect | null {
+  if (!value || typeof value !== 'object') return null;
+  const v = value as Record<string, unknown>;
+  const nums = [v.x, v.y, v.width, v.height];
+  if (!nums.every((n) => typeof n === 'number' && Number.isFinite(n))) return null;
+  if ((v.width as number) <= 0 || (v.height as number) <= 0) return null;
+  return { x: v.x as number, y: v.y as number, width: v.width as number, height: v.height as number };
+}
+
 export interface PermissionOverlayIpcDeps {
   controller: PermissionOverlayController;
 }
@@ -296,8 +357,8 @@ export function registerPermissionOverlayIpc(deps: PermissionOverlayIpcDeps): vo
   const electron = requireElectron('electron') as Electron;
   const { ipcMain } = electron;
 
-  ipcMain.handle('permissions:startDragOnboarding', async (_event, id: unknown) => {
-    return deps.controller.start(id);
+  ipcMain.handle('permissions:startDragOnboarding', async (_event, id: unknown, sourceRect: unknown) => {
+    return deps.controller.start(id, sanitizeSourceRect(sourceRect));
   });
 }
 

--- a/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
+++ b/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
@@ -138,6 +138,7 @@ export function createPermissionOverlayMain(
       const display = screen.getDisplayNearestPoint(point);
       return { x: point.x, y: point.y, workArea: display.workArea };
     },
+    workAreaForPoint: (x, y) => screen.getDisplayNearestPoint({ x: Math.round(x), y: Math.round(y) }).workArea,
     openSystemSettings: async (id) => {
       const result = await openSystemPermissionPane(id);
       return result.ok ? { ok: true } : { ok: false, message: result.message ?? result.reason };

--- a/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
+++ b/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
@@ -92,8 +92,9 @@ export function createPermissionOverlayMain(
   deps: PermissionOverlayMainDeps,
 ): PermissionOverlayController {
   let locale: UiLocale = 'en';
+  let iconDataUrl: string | null = null;
   const electron = requireElectron('electron') as Electron;
-  const { BrowserWindow, app, nativeImage, screen, systemPreferences } = electron;
+  const { BrowserWindow, app, screen, systemPreferences } = electron;
 
   function isGranted(id: DragGrantPermissionId): boolean {
     if (process.platform !== 'darwin') return false;
@@ -103,16 +104,30 @@ export function createPermissionOverlayMain(
     return systemPreferences.getMediaAccessStatus('screen') === 'granted';
   }
 
-  function appIconDataUrl(bundlePath: string | null): string | null {
+  /**
+   * The icon of the bundle the user is about to drag.
+   *
+   * `app.getFileIcon`, not `nativeImage.createFromPath` on the `.icns`:
+   * nativeImage decodes PNG/JPEG and friends, NOT icns, so probing
+   * `Contents/Resources/icon.icns` returns an empty image and the card
+   * renders a blank tile. (The file is there — that is exactly how this
+   * shipped broken.) `getFileIcon` asks the OS for the icon the bundle
+   * actually displays, which is also the right answer semantically: what
+   * you see on the card is what Finder and the Privacy list will show.
+   *
+   * Async, hence resolved once per run in the `start()` wrapper below
+   * rather than inside the synchronous payload builder.
+   */
+  async function resolveAppIconDataUrl(bundlePath: string | null): Promise<string | null> {
     if (!bundlePath) return null;
-    for (const name of ['icon.icns', 'electron.icns']) {
-      const candidate = join(bundlePath, 'Contents', 'Resources', name);
-      if (!existsSync(candidate)) continue;
-      const image = nativeImage.createFromPath(candidate);
-      if (image.isEmpty()) continue;
-      return image.resize({ width: 64, height: 64 }).toDataURL();
+    try {
+      const icon = await app.getFileIcon(bundlePath, { size: 'large' });
+      if (icon.isEmpty()) return null;
+      return icon.resize({ width: 64, height: 64 }).toDataURL();
+    } catch {
+      // A missing icon is cosmetic; never let it break the flow.
+      return null;
     }
-    return null;
   }
 
   const controller = createPermissionOverlayController({
@@ -142,7 +157,7 @@ export function createPermissionOverlayMain(
       return {
         permission: id,
         appName: app.getName(),
-        iconDataUrl: appIconDataUrl(bundlePath),
+        iconDataUrl,
         draggable: bundlePath !== null,
         copy: serializeCopy(locale, id, app.getName()),
       };
@@ -232,13 +247,19 @@ export function createPermissionOverlayMain(
   // not a reason to block the flow — the last known value still renders.
   return {
     ...controller,
-    async start(id: unknown) {
+    async start(id: unknown, sourceRect?: Rect | null) {
       try {
         locale = await deps.resolveLocale();
       } catch (error) {
         console.warn('[permission-overlay] locale lookup failed, keeping', locale, error);
       }
-      return controller.start(id);
+      const bundle = resolveAppBundle({
+        executablePath: app.getPath('exe'),
+        platform: process.platform,
+        exists: existsSync,
+      });
+      iconDataUrl = await resolveAppIconDataUrl(bundle.ok ? bundle.bundlePath : null);
+      return controller.start(id, sourceRect);
     },
   };
 }
@@ -277,7 +298,7 @@ function attachCardGestures(win: import('electron').BrowserWindow): void {
       exists: existsSync,
     });
 
-  win.webContents.on('ipc-message', (_event, channel, payload: unknown) => {
+  win.webContents.on('ipc-message', async (_event, channel, payload: unknown) => {
     if (channel === 'permission-overlay:dismiss') {
       if (!win.isDestroyed()) win.close();
       return;
@@ -318,10 +339,13 @@ function attachCardGestures(win: import('electron').BrowserWindow): void {
       if (!fromRenderer.isEmpty()) icon = fromRenderer;
     }
     if (icon.isEmpty()) {
-      const fallback = nativeImage.createFromPath(
-        join(resolved.bundlePath, 'Contents', 'Resources', 'icon.icns'),
-      );
-      if (!fallback.isEmpty()) icon = fallback.resize({ width: 64, height: 64 });
+      // Same trap as the card's tile: nativeImage cannot decode `.icns`,
+      // so reading Contents/Resources/icon.icns here yields an empty image
+      // and the drag would carry no picture at all. Ask the OS instead.
+      try {
+        const fallback = await app.getFileIcon(resolved.bundlePath, { size: 'large' });
+        if (!fallback.isEmpty()) icon = fallback.resize({ width: 64, height: 64 });
+      } catch { /* a drag with no image still drags. */ }
     }
 
     if (!win.isDestroyed()) win.webContents.startDrag({ file: resolved.bundlePath, icon });

--- a/apps/desktop/src/main/permission-overlay/settings-window-locator.ts
+++ b/apps/desktop/src/main/permission-overlay/settings-window-locator.ts
@@ -1,0 +1,119 @@
+/**
+ * Where is the System Settings window?
+ *
+ * Thin wrapper over the bundled `settings-window-locator` binary (Swift,
+ * `native/settings-window-locator/locator.swift`). Electron cannot answer
+ * this — `screen.*` covers displays and the cursor, never a foreign
+ * window — so this is the one native call the drag-to-grant card needs.
+ *
+ * Everything about this module is written to degrade rather than fail:
+ * the binary may be absent (a build without the Xcode toolchain), the
+ * user may have closed Settings, the process may hang. Each case resolves
+ * to `null`, and the caller falls back to cursor anchoring — which is the
+ * Stage 1 behaviour that shipped and works.
+ *
+ * The returned rect is in CoreGraphics space (top-left origin), which is
+ * already what Electron's `setBounds` expects. See the Swift source for
+ * why converting to AppKit coordinates is a bug and not a nicety.
+ */
+
+import { execFile } from 'node:child_process';
+import { existsSync } from 'node:fs';
+
+export interface SettingsWindowFrame {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export type LocatorFailure =
+  | 'unsupported_platform'
+  | 'binary_missing'
+  | 'not_running'
+  | 'no_settings_window'
+  | 'window_list_failed'
+  | 'spawn_failed'
+  | 'timed_out'
+  | 'bad_output';
+
+export type LocatorResult =
+  | { ok: true; frame: SettingsWindowFrame }
+  | { ok: false; reason: LocatorFailure };
+
+export interface LocateDeps {
+  binaryPath: string;
+  platform: NodeJS.Platform;
+  timeoutMs: number;
+  exists(path: string): boolean;
+  runBinary(path: string, timeoutMs: number): Promise<{ stdout: string } | null>;
+}
+
+function parseFrame(stdout: string): LocatorResult {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout.trim());
+  } catch {
+    return { ok: false, reason: 'bad_output' };
+  }
+  if (!parsed || typeof parsed !== 'object') return { ok: false, reason: 'bad_output' };
+  const value = parsed as Record<string, unknown>;
+
+  if (value.ok !== true) {
+    const reason = value.reason;
+    // Only the reasons the binary actually emits are passed through; an
+    // unknown string is treated as malformed rather than trusted.
+    return {
+      ok: false,
+      reason:
+        reason === 'not_running' || reason === 'no_settings_window' || reason === 'window_list_failed'
+          ? reason
+          : 'bad_output',
+    };
+  }
+
+  const { x, y, width, height } = value;
+  if (![x, y, width, height].every((n) => typeof n === 'number' && Number.isFinite(n))) {
+    return { ok: false, reason: 'bad_output' };
+  }
+  // A zero-area window is not something to dock to.
+  if ((width as number) <= 0 || (height as number) <= 0) {
+    return { ok: false, reason: 'bad_output' };
+  }
+  return {
+    ok: true,
+    frame: { x: x as number, y: y as number, width: width as number, height: height as number },
+  };
+}
+
+export async function locateSettingsWindow(deps: LocateDeps): Promise<LocatorResult> {
+  if (deps.platform !== 'darwin') return { ok: false, reason: 'unsupported_platform' };
+  if (!deps.exists(deps.binaryPath)) return { ok: false, reason: 'binary_missing' };
+
+  const output = await deps.runBinary(deps.binaryPath, deps.timeoutMs);
+  if (!output) return { ok: false, reason: 'spawn_failed' };
+  return parseFrame(output.stdout);
+}
+
+/**
+ * Default runner. `execFile` with a timeout, and a hard `killSignal` so a
+ * wedged locator cannot hold the tracker's tick: the caller polls this on
+ * an interval, and a hung child would otherwise pile up.
+ */
+export function defaultRunBinary(path: string, timeoutMs: number): Promise<{ stdout: string } | null> {
+  return new Promise((resolve) => {
+    execFile(
+      path,
+      [],
+      { timeout: timeoutMs, killSignal: 'SIGKILL', maxBuffer: 64 * 1024 },
+      (error, stdout) => {
+        // A timeout kill and a spawn failure both land here; the caller
+        // cannot act differently on either, so both become null.
+        if (error) resolve(null);
+        else resolve({ stdout });
+      },
+    );
+  });
+}
+
+export const defaultExists = existsSync;

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -345,7 +345,11 @@ export interface MakaBridge {
      * `accessibility` and `screen_recording` — the two permissions with
      * no programmatic consent dialog.
      */
-    startDragOnboarding(permId: string): Promise<PermissionOverlayStartResult>;
+    startDragOnboarding(
+      permId: string,
+      /** Screen rect of the button pressed, so the card can fly out of it. */
+      sourceRect?: { x: number; y: number; width: number; height: number },
+    ): Promise<PermissionOverlayStartResult>;
   };
   capabilities: {
     getSnapshot(): Promise<CapabilitySnapshotCollection>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -424,8 +424,11 @@ const makaBridge = {
     requestAccess(permId: string): Promise<PermissionActionResult> {
       return ipcRenderer.invoke('permissions:requestAccess', permId);
     },
-    startDragOnboarding(permId: string): Promise<PermissionOverlayStartResult> {
-      return ipcRenderer.invoke('permissions:startDragOnboarding', permId);
+    startDragOnboarding(
+      permId: string,
+      sourceRect?: { x: number; y: number; width: number; height: number },
+    ): Promise<PermissionOverlayStartResult> {
+      return ipcRenderer.invoke('permissions:startDragOnboarding', permId, sourceRect);
     },
   },
   capabilities: {

--- a/apps/desktop/src/renderer/locales/permission-center-copy.ts
+++ b/apps/desktop/src/renderer/locales/permission-center-copy.ts
@@ -19,7 +19,7 @@ export type PermissionCenterCopy = {
   noData: string;
   readAgain: string;
   actionFailed: string;
-  actionFailures: Record<'invalid_id' | 'unsupported_platform' | 'unsupported_permission' | 'failed', string>;
+  actionFailures: Record<'invalid_id' | 'unsupported_platform' | 'unsupported_permission' | 'failed' | 'already_open' | 'open_settings_failed', string>;
   title: string;
   subtitle: string;
   lastRead: string;
@@ -98,7 +98,7 @@ const PERMISSION_CENTER_COPY = {
     },
     loading: '正在加载权限快照', readFailed: '无法读取权限快照', noData: '权限服务未返回数据。', readAgain: '重新读取',
     actionFailed: '权限操作失败',
-    actionFailures: { invalid_id: '内部错误：权限 id 无法识别。', unsupported_platform: '当前操作系统不支持这个权限操作。', unsupported_permission: '当前平台没有提供这个权限的直接入口。', failed: '权限操作未成功，请稍后重试。' },
+    actionFailures: { invalid_id: '内部错误：权限 id 无法识别。', unsupported_platform: '当前操作系统不支持这个权限操作。', unsupported_permission: '当前平台没有提供这个权限的直接入口。', failed: '权限操作未成功，请稍后重试。', already_open: '已经有一张授权引导卡打开了，请先关掉它。', open_settings_failed: '打不开系统设置，请手动前往「隐私与安全性」。' },
     title: '权限与能力', subtitle: '查看 Maka 需要的系统权限和当前授权状态，直接从这里前往「系统设置 → 隐私与安全性」完成授权或撤销，不必自己翻菜单。',
     lastRead: '最近读取：', detectAgain: '重新检测', summaryAria: '权限概览', granted: '已授权', pending: '等待授权', denied: '已拒绝', other: '未知 / 不支持',
     osSection: '系统权限', osSectionHelp: 'Maka 读到的 OS 级权限状态。点击右侧按钮可以直接前往「系统设置 → 隐私与安全性」对应分区。', osListAria: '系统权限列表',
@@ -140,7 +140,7 @@ const PERMISSION_CENTER_COPY = {
     },
     loading: 'Loading permission snapshot', readFailed: 'Could not read permission snapshot', noData: 'The permission service returned no data.', readAgain: 'Read again',
     actionFailed: 'Permission action failed',
-    actionFailures: { invalid_id: 'Internal error: the permission ID was not recognized.', unsupported_platform: 'This operating system does not support the permission action.', unsupported_permission: 'This platform does not provide a direct entry point for the permission.', failed: 'The permission action did not succeed. Try again later.' },
+    actionFailures: { invalid_id: 'Internal error: the permission ID was not recognized.', unsupported_platform: 'This operating system does not support the permission action.', unsupported_permission: 'This platform does not provide a direct entry point for the permission.', failed: 'The permission action did not succeed. Try again later.', already_open: 'A permission guide card is already open — close it first.', open_settings_failed: 'Could not open System Settings. Open Privacy & Security manually.' },
     title: 'Permissions and capabilities', subtitle: 'Review the system permissions Maka needs and their current state. Open the matching Privacy & Security section directly to grant or revoke access.',
     lastRead: 'Last read: ', detectAgain: 'Check again', summaryAria: 'Permission overview', granted: 'Granted', pending: 'Waiting', denied: 'Denied', other: 'Unknown / unsupported',
     osSection: 'System permissions', osSectionHelp: 'OS-level permission states reported to Maka. Use the action on the right to open the matching Privacy & Security section in System Settings.', osListAria: 'System permission list',

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -95,6 +95,7 @@ export function PermissionCenterPage() {
   async function runPermissionAction(
     permId: OsPermissionId,
     kind: 'request' | 'openSettings' | 'dragGrant',
+    sourceRect?: { x: number; y: number; width: number; height: number },
   ) {
     const actionKey = `${permId}:${kind}`;
     if (!permissionActionGuard.begin(actionKey)) return;
@@ -104,7 +105,7 @@ export function PermissionCenterPage() {
         kind === 'request'
           ? await window.maka.permissions.requestAccess(permId)
           : kind === 'dragGrant'
-            ? await window.maka.permissions.startDragOnboarding(permId)
+            ? await window.maka.permissions.startDragOnboarding(permId, sourceRect)
             : await window.maka.permissions.openSystemSettings(permId);
       if (result.ok) {
         // Refresh snapshot so the user sees the new state when they
@@ -196,7 +197,7 @@ export function PermissionCenterPage() {
               pendingKey={pendingPermAction === `${id}:request` ? 'request' : pendingPermAction === `${id}:openSettings` ? 'openSettings' : null}
               onRequest={() => void runPermissionAction(id, 'request')}
               onOpenSettings={() => void runPermissionAction(id, 'openSettings')}
-              onDragGrant={() => void runPermissionAction(id, 'dragGrant')}
+              onDragGrant={(sourceRect) => void runPermissionAction(id, 'dragGrant', sourceRect)}
             />
           ))}
         </ul>
@@ -449,7 +450,7 @@ function OsPermissionRow(props: {
   pendingKey: 'request' | 'openSettings' | 'dragGrant' | null;
   onRequest: () => void;
   onOpenSettings: () => void;
-  onDragGrant: () => void;
+  onDragGrant: (sourceRect?: { x: number; y: number; width: number; height: number }) => void;
 }) {
   const { snapshot, busy, pendingKey } = props;
   const permissionCopy = props.copy.osPermissions[snapshot.id];
@@ -524,7 +525,18 @@ function OsPermissionRow(props: {
           <Button
             type="button"
             size="sm"
-            onClick={props.onDragGrant}
+            onClick={(event) => {
+              // Screen coordinates, so the overlay (a separate window) can
+              // launch from this button. `screenX/screenY` is the app
+              // window's own origin; the DOM rect is relative to it.
+              const rect = event.currentTarget.getBoundingClientRect();
+              props.onDragGrant({
+                x: Math.round(window.screenX + rect.left),
+                y: Math.round(window.screenY + rect.top),
+                width: Math.round(rect.width),
+                height: Math.round(rect.height),
+              });
+            }}
             disabled={busy}
             aria-busy={pendingKey === 'dragGrant' ? 'true' : undefined}
           >

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -194,7 +194,7 @@ export function PermissionCenterPage() {
               copy={copy}
               locale={locale}
               busy={pendingPermAction !== null}
-              pendingKey={pendingPermAction === `${id}:request` ? 'request' : pendingPermAction === `${id}:openSettings` ? 'openSettings' : null}
+              pendingKey={pendingPermAction === `${id}:request` ? 'request' : pendingPermAction === `${id}:openSettings` ? 'openSettings' : pendingPermAction === `${id}:dragGrant` ? 'dragGrant' : null}
               onRequest={() => void runPermissionAction(id, 'request')}
               onOpenSettings={() => void runPermissionAction(id, 'openSettings')}
               onDragGrant={(sourceRect) => void runPermissionAction(id, 'dragGrant', sourceRect)}
@@ -289,6 +289,14 @@ function permissionActionFailureCopy(reason: string, message: string | undefined
       return copy.actionFailures.unsupported_platform;
     case 'unsupported_permission':
       return copy.actionFailures.unsupported_permission;
+    // Reasons only the drag-to-grant path can return. Without these the
+    // toast fell through to "please retry", which is wrong for
+    // already_open (retrying can never help — close the other card) and
+    // leaked the raw enum for open_settings_failed.
+    case 'already_open':
+      return copy.actionFailures.already_open;
+    case 'open_settings_failed':
+      return copy.actionFailures.open_settings_failed;
     case 'failed':
       return message ?? copy.actionFailures.failed;
     default:

--- a/docs/permission-onboarding-plan.md
+++ b/docs/permission-onboarding-plan.md
@@ -1,6 +1,6 @@
 # Drag-to-grant permission onboarding (macOS)
 
-Status: **Stage 1 built** (`apps/desktop/src/main/permission-overlay/`,
+Status: **Stage 1 + Stage 2 built** (`apps/desktop/src/main/permission-overlay/`,
 `apps/desktop/src/overlay/permission-overlay.*`). Stage 2 is still a proposal.
 Written 2026-07-27 for maka.
 
@@ -99,7 +99,30 @@ no window or timer stacking on re-entry, teardown on grant / dismiss /
 window-gone, and a give-up timeout so an abandoned flow cannot leave an
 immortal always-on-top card (a hole both reference implementations have).
 
-**Stage 2 — add the locator binary** as progressive enhancement. Not built. When it
+**Stage 2 — the locator binary. DONE.** `native/settings-window-locator/`
+compiled by `build:resources` into `resources/native` as a universal
+binary (~89KB). The card docks under the Settings window, follows it on a
+200ms tick, and flies out of the button that launched it.
+
+Deliberate departures from both references:
+
+- **Docks BELOW the window, not over it.** The card is always-on-top;
+  parking it across the Privacy list would cover the rows the user has to
+  drop onto. It also makes "drag it up into the list" literally true.
+- **Centred on the whole window**, not offset by a hardcoded 170px
+  sidebar. That constant is exactly what rots across macOS releases.
+- **Returns CG (top-left) coordinates**, skipping the AppKit conversion —
+  see the landmine section above.
+- **Detects that Settings went away** (5 consecutive locator misses) and
+  closes, instead of freezing an always-on-top card in place.
+- **Missing binary is not an error.** No Xcode toolchain at build time →
+  the build warns and continues, and the card falls back to the Stage 1
+  cursor anchor.
+
+Not covered by this stage: Developer ID signing / notarization of the
+binary. That pipeline is already owed by the pinned cua-driver artifact
+(`docs/cua-driver-artifact-integrity.md`, `distributionReady: false`);
+the locator inherits it when it lands rather than justifying it alone. When it
 returns a frame, the card docks to the Settings window and follows it;
 when it returns `null`, fall back to the Stage 1 anchor. Unlike Alma,
 log the degradation loudly — a silent fallback is indistinguishable


### PR DESCRIPTION
Stage 2 of [docs/permission-onboarding-plan.md](docs/permission-onboarding-plan.md). Stage 1 (#1515) shipped a card that opened the right pane and could be dragged — it just had no idea where System Settings was, so it sat by the cursor.

## The locator

~90 lines of Swift, compiled by `build:resources` into a universal binary (**89 KB**). It's the one thing Electron genuinely cannot do: `screen.*` covers displays and the cursor, never a foreign window.

Two choices in it are load-bearing:

- **`CGWindowListCopyWindowInfo`, never the Accessibility API.** AX would require us to already be a trusted Accessibility client — which is the very permission the card exists to request. Window *images* need Screen Recording; the *metadata* read here needs no grant at all. That's what makes the locator usable *before* any grant exists.
- **CoreGraphics coordinates, no AppKit conversion.** Electron's `setBounds` is top-left origin, so CG is already the right space. The AppKit conversion the reference performs — with a comment claiming it's what `setBounds` wants — is correct only when the Settings window happens to be vertically centred, and off by *twice* the displacement otherwise.

Verified live: run against a real Settings window it returns `{x:542, y:98, width:723, height:837}`.

## Docking, deliberately different from the references

The card sits **below** the Settings window, not over it. It's always-on-top; parking it across the Privacy list would cover the very rows the user has to drop onto — worse than not docking at all. It also makes *"drag it up into the list"* literally true.

It centres on the **whole window** rather than offsetting by a hardcoded 170px sidebar. That constant is exactly the kind of internal-layout number that rots across macOS releases; being 100px off-centre costs nothing, being wrong about the sidebar looks broken.

**A gap both references leave open:** neither can distinguish "Settings was closed" from "no locator", so an abandoned flow freezes an always-on-top card in place. Five consecutive misses now means the user walked away, and the card closes itself.

## The flight

Quadratic Bézier on the card's centre, critically damped spring, 620ms, arc height clamped to 18% of distance (44–140px). **Critically** damped, not underdamped: overshooting past the target looks playful in a demo and reads as imprecision from something claiming "your target is exactly here". Skipped entirely under `prefersReducedMotion`.

Pure geometry in its own module, so the curve is tested without animating anything.

The launch rect comes from the renderer and is therefore **validated, not trusted** — it only decides where an animation starts, and a garbage value would put the card at NaN.

## Nothing here is a hard gate

| condition | behaviour |
|---|---|
| no Xcode toolchain at build time | build warns, continues |
| no binary at runtime | falls back to Stage 1 cursor anchor |
| Settings not found | same fallback |
| Settings closed mid-flow | card closes itself |

Signing/notarization of the binary is **not** included — that pipeline is already owed by the pinned cua-driver artifact (`distributionReady: false`), and the locator inherits it rather than justifying it alone.

## Verification

- The locator returns the correct rect for a real System Settings window
- **21** controller tests — docking placement, no-room tuck, no redundant `setBounds`, close-on-absence, no-locator fallback
- **7** locator-boundary tests — malformed, hostile, and zero-area output all degrade to `null`
- **9** flight-geometry tests — arcs, never overshoots, lands exactly, cancels mid-flight

**Not verified: the composed runtime path on screen.** Both TCC grants already exist for Electron on this machine, so the production "already granted → don't lie" guard short-circuits before a card can open, and I wasn't willing to revoke a real permission to get around it. Worth a look on a machine where Accessibility is ungranted.

## Gates

2905 desktop tests green · typecheck clean · biome clean · 0 dead CSS.