### PR TITLE
fix(oauth): refresh Codex connection after login

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -266,6 +266,7 @@ export const test = base.extend<{
   localeSwitchWindow: Page;
   invocableSkillsWindow: Page;
   planRemindersWindow: Page;
+  oauthReloginWindow: Page;
 }>({
   // Seeded: a pre-staged connection clears onboarding so the composer is ready.
   // Used by chat / session / settings / attachment specs.
@@ -440,6 +441,17 @@ export const test = base.extend<{
         seed: false,
         readinessSelector: '.maka-plan-card',
         e2eFixtureScenario: 'plan-reminders',
+        locale: 'zh',
+      },
+      use,
+    );
+  },
+  oauthReloginWindow: async ({}, use) => {
+    await withE2eWindow(
+      {
+        seed: false,
+        readinessSelector: '[role="dialog"]',
+        e2eFixtureScenario: 'oauth-relogin',
         locale: 'zh',
       },
       use,

--- a/apps/desktop/e2e/oauth-refresh.spec.ts
+++ b/apps/desktop/e2e/oauth-refresh.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from './fixtures.js';
+
+test('Codex OAuth completion refreshes the open Settings connection without closing it', async ({
+  oauthReloginWindow: page,
+}) => {
+  const dialog = page.getByRole('dialog', { name: 'OpenAI Codex Fixture' });
+  const connectionRow = page.locator('[data-connection-slug="codex-subscription"]');
+
+  await expect(dialog).toBeVisible();
+  await expect(connectionRow).toHaveAttribute('title', /需要重新登录/);
+  await expect(dialog.getByText('等待 OAuth 登录')).toBeVisible();
+
+  await dialog.getByRole('button', { name: '登录', exact: true }).click();
+
+  // The fixture completes through the real preload/IPC/login-hook path. The
+  // detail stays mounted throughout: success must update both its account
+  // notice and the connection row behind it, without a close/reopen cycle.
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText('OAuth 已登录', { exact: true })).toBeVisible();
+  await expect(connectionRow).not.toHaveAttribute('title', /需要重新登录/);
+  await expect(connectionRow).not.toHaveAttribute('data-disabled', 'true');
+});

--- a/apps/desktop/src/main/__tests__/claude-subscription-experimental-gate.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-subscription-experimental-gate.test.ts
@@ -440,8 +440,15 @@ describe('Claude OAuth model connection bridge', () => {
     const completeRegion = src.slice(completeIdx, completeIdx + 1200);
     assert.match(
       completeRegion,
-      /if\s*\(\s*result\.ok\s*\)\s*\{[\s\S]*await (?:deps\.)?syncOpenAiCodexConnection\(\);[\s\S]*(?:deps\.)?emitConnectionListChanged\(\);/,
-      'successful Codex OAuth completion must sync the connection and notify renderer',
+      /if\s*\(\s*result\.ok\s*\)\s*\{[\s\S]*await (?:deps\.)?activateOpenAiCodexConnection\(\);[\s\S]*(?:deps\.)?emitConnectionListChanged\(\);[\s\S]*void (?:deps\.)?syncOpenAiCodexConnection\(\)/,
+      'successful Codex OAuth completion must activate immediately, notify renderer, then discover models in the background',
+    );
+    const accountStateIdx = src.indexOf("openai-codex:get-account-state");
+    const accountStateRegion = src.slice(accountStateIdx, accountStateIdx + 500);
+    assert.doesNotMatch(
+      accountStateRegion,
+      /syncOpenAiCodexConnection/,
+      'Codex account-state reads must not trigger slow or mutating model discovery',
     );
     assert.match(
       src,

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -962,8 +962,8 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     // catches enabled-model refresh failures.
     assert.match(
       src,
-      /async function refreshAfterModalClose\(\)[\s\S]*?await refreshAllCards\(\)[\s\S]*?await props\.onConnectionsChanged\(\)/,
-      'modal onClose must call refreshAllCards so the card updates after login',
+      /async function refreshAfterOAuthChange\(\)[\s\S]*?await refreshAllCards\(\)[\s\S]*?await props\.onConnectionsChanged\(\)/,
+      'OAuth changes must refresh both the account card and connection list',
     );
     assert.match(
       src,
@@ -972,8 +972,13 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       src,
-      /onClose=\{\(\)\s*=>\s*\{[\s\S]*?void refreshAfterModalClose\(\)/,
+      /onClose=\{\(\)\s*=>\s*\{[\s\S]*?void refreshAfterOAuthChange\(\)/,
       'modal onClose must call the fail-soft refresh helper',
+    );
+    assert.match(
+      src,
+      /<SubscriptionLoginModal[\s\S]*onLoginSuccess=\{refreshAfterOAuthChange\}/,
+      'successful Codex OAuth must refresh immediately without waiting for modal close',
     );
     // 5. Card render shows "已登录" badge when authenticated.
     assert.match(
@@ -997,7 +1002,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     const sectionMatch = src.match(/function ModelOAuthSection[\s\S]*?function ClaudeSubscriptionModal/);
     assert.ok(sectionMatch, 'ModelOAuthSection must exist');
     const section = sectionMatch[0]!;
-    const refreshMatch = section.match(/async function refreshAllCards\(\)[\s\S]*?async function refreshAfterModalClose/);
+    const refreshMatch = section.match(/async function refreshAllCards\(\)[\s\S]*?async function refreshAfterOAuthChange/);
     assert.ok(refreshMatch, 'refreshAllCards must exist inside ModelOAuthSection');
     const refresh = refreshMatch[0]!;
 
@@ -1053,7 +1058,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     );
     assert.match(
       section,
-      /async function refreshAfterModalClose\(\) \{[\s\S]*const refreshed = await refreshAllCards\(\);[\s\S]*if \(!modelOAuthMountedRef\.current \|\| !refreshed\) return;[\s\S]*await props\.onConnectionsChanged\(\);/,
+      /async function refreshAfterOAuthChange\(\) \{[\s\S]*const refreshed = await refreshAllCards\(\);[\s\S]*if \(!modelOAuthMountedRef\.current \|\| !refreshed\) return;[\s\S]*await props\.onConnectionsChanged\(\);/,
       'modal close continuation must not refresh enabled providers after a stale OAuth card refresh',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/oauth-model-connections-openai-codex.test.ts
+++ b/apps/desktop/src/main/__tests__/oauth-model-connections-openai-codex.test.ts
@@ -37,7 +37,11 @@ function makeService(opts: {
   token?: string | null;
   fetchModels?: (conn: LlmConnection, token: string) => Promise<ModelInfo[]>;
   accountState?: { runtimeState: string };
-}): { sync: () => Promise<LlmConnection | null>; getSaved: () => LlmConnection | null } {
+}): {
+  activate: () => Promise<LlmConnection | null>;
+  sync: () => Promise<LlmConnection | null>;
+  getSaved: () => LlmConnection | null;
+} {
   let saved: LlmConnection | null = null;
   const existing = opts.existing ?? null;
   const connectionStore = {
@@ -77,7 +81,11 @@ function makeService(opts: {
     githubCopilotSubscription: {} as never,
     fetchModels: opts.fetchModels,
   } as never);
-  return { sync: () => service.syncOpenAiCodexConnection(), getSaved: () => saved };
+  return {
+    activate: () => service.activateOpenAiCodexConnection(),
+    sync: () => service.syncOpenAiCodexConnection(),
+    getSaved: () => saved,
+  };
 }
 
 describe('syncOpenAiCodexConnection live discovery behavior', () => {
@@ -86,6 +94,52 @@ describe('syncOpenAiCodexConnection live discovery behavior', () => {
       PROVIDER_REGISTRY['openai-codex'].modelDiscovery,
       { kind: 'protocol', auth: 'openai-codex' },
     );
+  });
+
+  it('activates a newly authenticated connection without waiting for model discovery', async () => {
+    let discoveryCalls = 0;
+    const { activate, getSaved } = makeService({
+      existing: makeExisting({
+        enabled: false,
+        lastTestStatus: 'needs_reauth',
+        modelSource: 'fallback',
+      }),
+      token: 'tok',
+      fetchModels: async () => {
+        discoveryCalls += 1;
+        return [{ id: 'gpt-5.6-sol' }];
+      },
+    });
+
+    const result = await activate();
+
+    assert.equal(discoveryCalls, 0);
+    assert.equal(result?.enabled, true);
+    assert.equal(result?.lastTestStatus, 'verified');
+    assert.equal(result?.lastTestMessage, 'Codex OAuth 已登录。');
+    assert.deepEqual(
+      result?.models?.map((model) => model.id),
+      PROVIDER_DEFAULTS['openai-codex'].fallbackModels,
+    );
+    assert.equal(getSaved()?.enabled, true);
+  });
+
+  it('preserves a non-empty fetched model cache during immediate activation', async () => {
+    const existing = makeExisting({
+      enabled: false,
+      lastTestStatus: 'needs_reauth',
+      models: [{ id: 'gpt-5.6-sol' }, { id: 'gpt-5.5' }],
+      modelSource: 'fetched',
+      modelsFetchedAt: 42,
+    });
+    const { activate } = makeService({ existing, token: 'tok' });
+
+    const result = await activate();
+
+    assert.deepEqual(result?.models, existing.models);
+    assert.equal(result?.modelSource, 'fetched');
+    assert.equal(result?.modelsFetchedAt, 42);
+    assert.equal(result?.enabled, true);
   });
 
   it('stamps modelSource=fetched and persists discovered models on success', async () => {

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -386,13 +386,13 @@ export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState 
     case 'fetched-empty':
       return { ...state, activeSessionId: TURN_SESSION_ID, openSettingsSection: 'models' };
     case 'oauth-relogin':
-      // Open the codex-oauth connection's detail sheet (not just the 模型
+      // Open the persisted Codex connection's detail sheet (not just the 模型
       // section) so the needs_reauth re-login affordance is captured.
       return {
         ...state,
         activeSessionId: TURN_SESSION_ID,
         openSettingsSection: 'models',
-        openConnectionDetailSlug: 'codex-oauth',
+        openConnectionDetailSlug: 'codex-subscription',
       };
     case 'connection-error':
       return { ...state, activeSessionId: ERROR_SESSION_ID, openSettingsSection: 'models' };

--- a/apps/desktop/src/main/e2e-fixture/scenarios-settings.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-settings.ts
@@ -150,7 +150,7 @@ export async function writeConnections(workspaceRoot: string, now: number, scena
     // subscription token store (empty here), so the button reads 登录; the
     // hasSecret===true → 重新登录 label is pinned by the detail-sheet contract.
     connections.push({
-      slug: 'codex-oauth',
+      slug: 'codex-subscription',
       name: 'OpenAI Codex Fixture',
       providerType: 'openai-codex',
       defaultModel: 'gpt-5.5',
@@ -185,7 +185,7 @@ function connectionFocusSlug(scenario: E2eFixtureScenario): string | null {
     case 'fetched-empty':
       return 'empty-fetched';
     case 'oauth-relogin':
-      return 'codex-oauth';
+      return 'codex-subscription';
     case 'connection-error':
       return 'broken-provider';
     default:

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -23,6 +23,7 @@ import { assembleDesktopTools } from './tool-assembly.js';
 import { createToolArtifactPersistence } from './tool-artifact-persistence.js';
 import { ClaudeSubscriptionService } from './oauth/claude-subscription-service.js';
 import { OpenAiCodexService } from './oauth/openai-codex-service.js';
+import { createOpenAiCodexE2eFixtureService } from './openai-codex-e2e-fixture.js';
 import { GitHubCopilotSubscriptionService } from './oauth/github-copilot-subscription-service.js';
 import { CursorSubscriptionService } from './oauth/cursor-subscription-service.js';
 import { AntigravitySubscriptionService } from './oauth/antigravity-subscription-service.js';
@@ -272,11 +273,13 @@ const claudeSubscription = new ClaudeSubscriptionService({
 // IPC payloads never carry tokens, each gated behind its own
 // MAKA_*_EXPERIMENTAL env var. Antigravity is a `preview` placeholder
 // until the Google client_id question is resolved.
-const openAiCodex = new OpenAiCodexService({
-  userDataDir: app.getPath('userData'),
-  openExternal: (url) => shell.openExternal(url),
-  credentialStore,
-});
+const openAiCodex = e2eFixture?.scenario === 'oauth-relogin'
+  ? createOpenAiCodexE2eFixtureService()
+  : new OpenAiCodexService({
+      userDataDir: app.getPath('userData'),
+      openExternal: (url) => shell.openExternal(url),
+      credentialStore,
+    });
 const githubCopilotSubscription = new GitHubCopilotSubscriptionService({ credentialStore });
 const buildSubscriptionModelFetch = createSubscriptionModelFetch({
   claudeSubscription,
@@ -287,9 +290,11 @@ const oauthModelConnections = createOAuthModelConnectionsMainService({
   claudeSubscription,
   openAiCodex,
   githubCopilotSubscription,
+  ...(e2eFixture?.scenario === 'oauth-relogin'
+    ? { fetchModels: async () => [{ id: 'gpt-5.6-sol' }] }
+    : {}),
 });
 const isClaudeSubscriptionAuthenticatedState = oauthModelConnections.isClaudeSubscriptionAuthenticatedState;
-const isOpenAiCodexAuthenticatedState = oauthModelConnections.isOpenAiCodexAuthenticatedState;
 
 function syncClaudeSubscriptionConnection(): Promise<LlmConnection | null> {
   return oauthModelConnections.syncClaudeSubscriptionConnection();
@@ -297,6 +302,10 @@ function syncClaudeSubscriptionConnection(): Promise<LlmConnection | null> {
 
 function syncOpenAiCodexConnection(): Promise<LlmConnection | null> {
   return oauthModelConnections.syncOpenAiCodexConnection();
+}
+
+function activateOpenAiCodexConnection(): Promise<LlmConnection | null> {
+  return oauthModelConnections.activateOpenAiCodexConnection();
 }
 
 function syncGitHubCopilotConnection(): Promise<LlmConnection | null> {
@@ -964,8 +973,8 @@ function registerIpc(): void {
     cursorSubscription,
     antigravitySubscription,
     isClaudeSubscriptionAuthenticatedState,
-    isOpenAiCodexAuthenticatedState,
     syncClaudeSubscriptionConnection,
+    activateOpenAiCodexConnection,
     syncOpenAiCodexConnection,
     syncGitHubCopilotConnection,
     emitConnectionListChanged,

--- a/apps/desktop/src/main/oauth-model-connections-main.ts
+++ b/apps/desktop/src/main/oauth-model-connections-main.ts
@@ -96,6 +96,51 @@ export function createOAuthModelConnectionsMainService(deps: OAuthModelConnectio
     return state.runtimeState === 'authenticated' || state.runtimeState === 'refreshing';
   }
 
+  /**
+   * Make a newly authenticated Codex account visible to the product without
+   * waiting for live model discovery. OAuth completion has already persisted
+   * the credential at this point, so the connection can immediately become
+   * usable with the last fetched model list (or the curated fallback list).
+   *
+   * `syncOpenAiCodexConnection` still runs afterwards to replace this
+   * optimistic snapshot with the account's authoritative model catalog.
+   */
+  async function activateOpenAiCodexConnection(): Promise<LlmConnection | null> {
+    if (!isOpenAiCodexExperimentalEnabled()) return null;
+    const state = await deps.openAiCodex.getAccountState();
+    const existing = await deps.connectionStore.get(CODEX_SUBSCRIPTION_CONNECTION_SLUG);
+    if (!isOpenAiCodexAuthenticatedState(state)) return existing;
+
+    const defaults = PROVIDER_DEFAULTS['openai-codex'];
+    const fallbackModels = defaults.fallbackModels.map((id) => ({ id }));
+    const fetchedModels = existing?.modelSource === 'fetched'
+      ? normalizeOpenAiCodexModels(existing.models, [])
+      : [];
+    const models = fetchedModels.length > 0 ? fetchedModels : fallbackModels;
+    const now = Date.now();
+    return deps.connectionStore.save({
+      slug: CODEX_SUBSCRIPTION_CONNECTION_SLUG,
+      name: existing?.name ?? 'Codex OAuth',
+      providerType: 'openai-codex',
+      baseUrl: defaults.baseUrl,
+      defaultModel: normalizeOpenAiCodexDefaultModel(
+        existing?.defaultModel,
+        models.map((entry) => entry.id),
+        defaults.fallbackModels[0] || '',
+      ),
+      enabled: true,
+      enabledModelIds: existing?.enabledModelIds,
+      models,
+      modelSource: fetchedModels.length > 0 ? 'fetched' : 'fallback',
+      modelsFetchedAt: fetchedModels.length > 0 ? existing?.modelsFetchedAt : undefined,
+      lastTestStatus: 'verified',
+      lastTestAt: new Date(now).toISOString(),
+      lastTestMessage: 'Codex OAuth 已登录。',
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    });
+  }
+
   async function syncGitHubCopilotConnection(
     discoveredModels?: Awaited<ReturnType<typeof fetchProviderModels>>,
   ): Promise<LlmConnection | null> {
@@ -381,6 +426,7 @@ export function createOAuthModelConnectionsMainService(deps: OAuthModelConnectio
     resolveConnectionSecret,
     hasConnectionSecret,
     syncClaudeSubscriptionConnection,
+    activateOpenAiCodexConnection,
     syncOpenAiCodexConnection,
     syncGitHubCopilotConnection,
     syncOAuthModelConnections,

--- a/apps/desktop/src/main/openai-codex-e2e-fixture.ts
+++ b/apps/desktop/src/main/openai-codex-e2e-fixture.ts
@@ -1,0 +1,79 @@
+import type { OpenAiCodexService } from './oauth/openai-codex-service.js';
+
+/**
+ * Deterministic loopback OAuth service for the `oauth-relogin` Electron E2E.
+ *
+ * This seam is selected only through the dev-only MAKA_E2E_FIXTURE gate in
+ * main.ts. It drives the production preload, IPC handlers, shared renderer
+ * login hook, connection store, and connection event bus without opening a
+ * browser or contacting OpenAI.
+ */
+export function createOpenAiCodexE2eFixtureService(): OpenAiCodexService {
+  const authRequestId = 'e2e-codex-auth-request';
+  let runtimeState: 'not_logged_in' | 'authorizing' | 'authenticated' = 'not_logged_in';
+
+  const service = {
+    async getAuthorizationUrl() {
+      return { authRequestId, stateHint: 'e2e-state' };
+    },
+    async openAuthorizationUrl(requestId: string) {
+      if (requestId !== authRequestId) {
+        return {
+          ok: false as const,
+          reason: 'authorization_pending' as const,
+          message: 'E2E authorization session does not exist.',
+        };
+      }
+      runtimeState = 'authorizing';
+      return { ok: true as const };
+    },
+    async completeAuthorization(requestId: string) {
+      if (requestId !== authRequestId || runtimeState !== 'authorizing') {
+        return {
+          ok: false as const,
+          reason: 'authorization_pending' as const,
+          message: 'E2E authorization is not pending.',
+        };
+      }
+      runtimeState = 'authenticated';
+      return { ok: true as const };
+    },
+    cancelAuthorization(requestId?: string) {
+      if (!requestId || requestId === authRequestId) runtimeState = 'not_logged_in';
+    },
+    async getAccountState() {
+      return runtimeState === 'authenticated'
+        ? {
+            provider: 'openai-codex' as const,
+            runtimeState,
+            accountId: 'e2e-openai-account',
+            email: 'oauth-refresh@maka.test',
+          }
+        : { provider: 'openai-codex' as const, runtimeState };
+    },
+    async refreshTokens() {
+      return runtimeState === 'authenticated'
+        ? { ok: true as const }
+        : {
+            ok: false as const,
+            reason: 'refresh_failed' as const,
+            message: 'E2E account is not authenticated.',
+          };
+    },
+    async logout() {
+      runtimeState = 'not_logged_in';
+      return { ok: true as const };
+    },
+    async getAccessTokenInternal() {
+      return runtimeState === 'authenticated' ? 'e2e-codex-access-token' : null;
+    },
+    async hasStoredCredential() {
+      return runtimeState === 'authenticated';
+    },
+  };
+
+  // OpenAiCodexService is a class with private implementation state, while
+  // this fixture intentionally implements only the public surface consumed by
+  // main. Keep the cast at this single dev-only boundary.
+  return service as unknown as OpenAiCodexService;
+}

--- a/apps/desktop/src/main/subscription-ipc-main.ts
+++ b/apps/desktop/src/main/subscription-ipc-main.ts
@@ -34,10 +34,8 @@ interface SubscriptionIpcDeps {
   isClaudeSubscriptionAuthenticatedState(
     state: Awaited<ReturnType<ClaudeSubscriptionService['getAccountState']>>,
   ): boolean;
-  isOpenAiCodexAuthenticatedState(
-    state: Awaited<ReturnType<OpenAiCodexService['getAccountState']>>,
-  ): boolean;
   syncClaudeSubscriptionConnection(): Promise<LlmConnection | null>;
+  activateOpenAiCodexConnection(): Promise<LlmConnection | null>;
   syncOpenAiCodexConnection(): Promise<LlmConnection | null>;
   syncGitHubCopilotConnection(models?: NonNullable<LlmConnection['models']>): Promise<LlmConnection | null>;
   emitConnectionListChanged(): void;
@@ -227,8 +225,17 @@ export function registerSubscriptionIpc(deps: SubscriptionIpcDeps): void {
       }
       const result = await deps.openAiCodex.completeAuthorization(authRequestId);
       if (result.ok) {
-        await deps.syncOpenAiCodexConnection();
+        // OAuth success is authoritative as soon as the credential is stored.
+        // Publish a usable connection immediately; live model discovery can
+        // take up to its network timeout and must not hold the login UI on the
+        // stale `needs_reauth` state.
+        await deps.activateOpenAiCodexConnection();
         deps.emitConnectionListChanged();
+        void deps.syncOpenAiCodexConnection()
+          .then(() => deps.emitConnectionListChanged())
+          .catch((error: unknown) => {
+            console.warn('[maka] Codex model discovery after OAuth failed', error);
+          });
       }
       return result;
     },
@@ -250,11 +257,9 @@ export function registerSubscriptionIpc(deps: SubscriptionIpcDeps): void {
         runtimeState: 'not_logged_in' as const,
       };
     }
-    const state = await deps.openAiCodex.getAccountState();
-    if (deps.isOpenAiCodexAuthenticatedState(state)) {
-      await deps.syncOpenAiCodexConnection();
-    }
-    return state;
+    // Status reads stay read-only and fast. Connection synchronization is
+    // driven by OAuth completion, explicit token refresh, and startup.
+    return deps.openAiCodex.getAccountState();
   });
   ipcMain.handle('openai-codex:refresh-tokens', async () => {
     if (!isOpenAiCodexExperimentalEnabled()) return codexDisabledResponse;

--- a/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
+++ b/apps/desktop/src/renderer/settings/provider-oauth-section.tsx
@@ -120,7 +120,7 @@ export function ModelOAuthSection(props: { query?: string; onConnectionsChanged(
     return true;
   }
 
-  async function refreshAfterModalClose() {
+  async function refreshAfterOAuthChange() {
     const refreshed = await refreshAllCards();
     if (!modelOAuthMountedRef.current || !refreshed) return;
     try {
@@ -189,7 +189,7 @@ export function ModelOAuthSection(props: { query?: string; onConnectionsChanged(
         <ClaudeSubscriptionModal
           onClose={() => {
             setOpenModal(null);
-            void refreshAfterModalClose();
+            void refreshAfterOAuthChange();
           }}
         />
       )}
@@ -197,17 +197,18 @@ export function ModelOAuthSection(props: { query?: string; onConnectionsChanged(
         <GitHubCopilotSubscriptionModal
           onClose={() => {
             setOpenModal(null);
-            void refreshAfterModalClose();
+            void refreshAfterOAuthChange();
           }}
         />
       )}
       {openModal === 'codex' && (
         <SubscriptionLoginModal
+          onLoginSuccess={refreshAfterOAuthChange}
           onClose={() => {
             setOpenModal(null);
             // Always re-fetch after the modal closes — the user may
             // have logged in, logged out, or cancelled.
-            void refreshAfterModalClose();
+            void refreshAfterOAuthChange();
           }}
         />
       )}
@@ -237,7 +238,7 @@ function ClaudeSubscriptionModal(props: { onClose(): void }) {
   );
 }
 
-function SubscriptionLoginModal(props: { onClose(): void }) {
+function SubscriptionLoginModal(props: { onClose(): void; onLoginSuccess(): void | Promise<void> }) {
   const locale = useUiLocale();
   const copy = getProviderSettingsCopy(locale).oauthSection;
   const display: SubscriptionDisplay = {
@@ -253,6 +254,7 @@ function SubscriptionLoginModal(props: { onClose(): void }) {
   const flow = useOAuthLoginFlow({
     bridge: window.maka.openAiCodex as unknown as OAuthLoginFlowBridge,
     display: { name: display.name, shortName: display.shortName },
+    onLoginSuccess: props.onLoginSuccess,
   });
 
   return (
@@ -397,4 +399,3 @@ function presentSnapshotDetail(state: SubscriptionSnapshot | null, display: Subs
   const _exhaustive: never = state.runtimeState;
   return _exhaustive;
 }
-

--- a/apps/desktop/src/renderer/settings/use-oauth-login-flow.ts
+++ b/apps/desktop/src/renderer/settings/use-oauth-login-flow.ts
@@ -94,7 +94,8 @@ export function useOAuthLoginFlow(params: {
   display: OAuthLoginFlowDisplay;
   // Fired after a successful completeAuthorization (browser handoff done).
   // The detail sheet uses it to re-probe hasSecret + reload connection status;
-  // the modal leaves it undefined and relies on its own snapshot refresh.
+  // catalog modals use it to refresh both their account card and the shared
+  // model connection list without waiting for the modal to close.
   onLoginSuccess?: () => void | Promise<void>;
   // When present, startLogin runs this one-shot import instead of the
   // getAuthUrl -> openAuthUrl -> completeAuthorization handoff, and the

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -60,6 +60,10 @@ const ALLOW = new Map([
     'OAuth model sync logs provider-level failure reason only; no tokens or raw provider bodies.',
   ],
   [
+    'apps/desktop/src/main/subscription-ipc-main.ts',
+    'best-effort post-OAuth model discovery diagnostic; main-process only and never logs credentials.',
+  ],
+  [
     'apps/desktop/src/main/onboarding-service.ts',
     'PR110b: credential lookup failure logs error class only (no message / secret bytes); never reaches renderer.',
   ],


### PR DESCRIPTION
## Summary

- mark a newly authenticated Codex connection usable immediately after credentials are stored
- keep account-state reads fast and read-only, while model discovery finishes in the background
- refresh OAuth catalog cards and the shared connection list as soon as login succeeds
- add a deterministic Electron E2E covering needs_reauth to authenticated without closing Settings

## Validation

- npm run typecheck --workspace @maka/desktop
- npm run lint
- npm test --workspace @maka/desktop (2,889 tests passed)
- npm run e2e --workspace @maka/desktop -- oauth-refresh.spec.ts