### PR TITLE
chore(release): drop the unpacked app bundle after packaging

### DIFF
--- a/scripts/macos-arm64-release.test.mjs
+++ b/scripts/macos-arm64-release.test.mjs
@@ -163,9 +163,13 @@ test('release package script runs the single arm64 pipeline in order', async () 
     ['npm', ['run', 'check:release']],
     ['npm', ['--workspace', '@maka/desktop', 'run', 'package:macos-arm64']],
   ]);
-  assert.equal(removed.length, 1);
+  assert.equal(removed.length, 2);
+  assert.ok(removed[0][0].endsWith('/apps/desktop/release'));
   assert.equal(removed[0][1].recursive, true);
   assert.equal(removed[0][1].force, true);
+  assert.ok(removed[1][0].endsWith('/apps/desktop/release/mac-arm64'));
+  assert.equal(removed[1][1].recursive, true);
+  assert.equal(removed[1][1].force, true);
   assert.ok(result.endsWith(`/apps/desktop/release/Maka-${desktopManifest.version}-mac-arm64.dmg`));
 });
 

--- a/scripts/package-macos-arm64.mjs
+++ b/scripts/package-macos-arm64.mjs
@@ -66,6 +66,7 @@ export async function packageMacosArm64({
   await remove(releaseDirectory, { recursive: true, force: true });
   await run('npm', ['--workspace', '@maka/desktop', 'run', 'package:macos-arm64']);
   await assertFile(dmgPath);
+  await remove(join(releaseDirectory, 'mac-arm64'), { recursive: true, force: true });
 
   return dmgPath;
 }


### PR DESCRIPTION
## Summary

`electron-builder` leaves `release/mac-arm64/Maka.app` next to the DMG it produces. Nothing in the repository reads that directory — `scripts/package-macos-arm64.mjs`, `scripts/verify-macos-arm64-dmg.mjs`, and `.github/workflows/release-macos-arm64.yml` all reference `release/Maka-<version>-mac-arm64.dmg` only, and the verifier mounts the DMG into its own temporary directory rather than reusing the unpacked tree.

Left on disk, that bundle registers with Spotlight and LaunchServices under the same bundle id as the installed copy, so searching for the app on a machine that has ever packaged locally returns two identical results. Removing it once the DMG exists keeps the release directory to the artifact that is actually published.

Trade-off: after packaging you can no longer double-click the unpacked app directly; install from the DMG instead. Local development is unaffected — it runs through `npm run dev`, and packaging already requires the full signing and notarization environment (`CSC_LINK`, `APPLE_API_KEY`, …).

## Verification

- `node --test scripts/macos-arm64-release.test.mjs` — 15 passing. The pipeline-order test now asserts both removals and their paths; it failed as expected (`actual: 1, expected: 2`) before the script change.
- `biome check scripts/package-macos-arm64.mjs scripts/macos-arm64-release.test.mjs` — clean.
- Not run: a real `npm run package:macos-arm64`, which needs the release signing certificate and notarization credentials. The removal is sequenced after `assertFile(dmgPath)`, so a failed build still leaves the unpacked tree in place for inspection.