### PR TITLE
fix(runtime): resolve macOS worker executable dependencies

### DIFF
--- a/packages/runtime/src/__tests__/filesystem-worker-client.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker-client.test.ts
@@ -27,6 +27,7 @@ import {
 import {
   FILESYSTEM_WORKER_PROTOCOL_VERSION,
   FilesystemWorkerRequestSchema,
+  type FilesystemWorkerErrorCode,
   type FilesystemWorkerRequest,
   type FilesystemWorkerResult,
 } from '../filesystem-worker/protocol.js';
@@ -231,6 +232,29 @@ describe('filesystem worker operation-scoped Seatbelt profile', () => {
       ['.git', '.agents', '.codex'],
     );
   });
+
+  test('preserves sandbox context on worker operation failures', async () => {
+    const workspace = await temporaryDirectory('maka-worker-client-denial-context-');
+    const target = join(workspace, 'file.ts');
+    await writeFile(target, 'const value = 1;', 'utf8');
+    const { client } = fakeClient({ operationErrorCode: 'filesystem_denied' });
+
+    await assert.rejects(
+      client.execute({
+        operation: grepOperation(target),
+        cwd: workspace,
+        mode: 'ask',
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof FilesystemWorkerClientError);
+        assert.equal(error.reason, 'filesystem_denied');
+        assert.equal(error.stage, 'operation');
+        assert.equal(error.backend, 'macos-seatbelt');
+        assert.equal(error.profileName, 'workspace-write');
+        return true;
+      },
+    );
+  });
 });
 
 describe('filesystem worker Linux path context', () => {
@@ -266,7 +290,7 @@ describe('filesystem worker Linux path context', () => {
   });
 });
 
-function fakeClient(): {
+function fakeClient(options: { operationErrorCode?: FilesystemWorkerErrorCode } = {}): {
   client: FilesystemWorkerClient;
   requests: FilesystemWorkerRequest[];
   transforms: SandboxTransformRequest[];
@@ -301,12 +325,24 @@ function fakeClient(): {
       requests.push(request);
       return {
         exitCode: 0,
-        stdout: JSON.stringify({
-          version: FILESYSTEM_WORKER_PROTOCOL_VERSION,
-          requestId: request.requestId,
-          ok: true,
-          result: fakeResult(request),
-        }),
+        stdout: JSON.stringify(
+          options.operationErrorCode
+            ? {
+                version: FILESYSTEM_WORKER_PROTOCOL_VERSION,
+                requestId: request.requestId,
+                ok: false,
+                error: {
+                  code: options.operationErrorCode,
+                  message: 'Sandbox denied the filesystem operation.',
+                },
+              }
+            : {
+                version: FILESYSTEM_WORKER_PROTOCOL_VERSION,
+                requestId: request.requestId,
+                ok: true,
+                result: fakeResult(request),
+              },
+        ),
         stderrTail: '',
         timedOut: false,
         aborted: false,

--- a/packages/runtime/src/__tests__/filesystem-worker-launch-spec.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker-launch-spec.test.ts
@@ -20,3 +20,50 @@ test('Linux Electron worker launch does not require a macOS Frameworks directory
     assert.equal(result.spec.env.ELECTRON_RUN_AS_NODE, '1');
   }
 });
+
+test('macOS worker launch includes inspected ripgrep runtime directories', async () => {
+  const executable = await realpath(process.execPath);
+  const getLaunchSpec = createFilesystemWorkerLaunchSpecProvider({
+    runtime: 'node',
+    platform: 'darwin',
+    executable,
+    resourceLocation: { kind: 'runtime' },
+    rgCandidates: [executable],
+    inspectMacosExecutableDependencies: async (candidate) => ({
+      ok: true,
+      dependencyCount: 1,
+      runtimeReadableRoots: ['/opt/toolchain/lib'],
+      executableRoots: ['/opt/toolchain/bin', '/opt/toolchain/lib'],
+    }),
+  });
+
+  const result = await getLaunchSpec();
+
+  assert.equal(result.ok, true);
+  if (!result.ok) return;
+  assert.deepEqual(result.spec.args.slice(-2), ['--grep-executable', executable]);
+  assert.ok(result.spec.runtimeReadableRoots.includes('/opt/toolchain/lib'));
+  assert.ok(result.spec.executableRoots.includes('/opt/toolchain/bin'));
+  assert.ok(result.spec.executableRoots.includes('/opt/toolchain/lib'));
+});
+
+test('macOS worker omits ripgrep when dependency inspection fails', async () => {
+  const executable = await realpath(process.execPath);
+  const getLaunchSpec = createFilesystemWorkerLaunchSpecProvider({
+    runtime: 'node',
+    platform: 'darwin',
+    executable,
+    resourceLocation: { kind: 'runtime' },
+    rgCandidates: [executable],
+    inspectMacosExecutableDependencies: async () => ({
+      ok: false,
+      reason: 'dependency_unresolved',
+      message: 'fixture failure',
+    }),
+  });
+
+  const result = await getLaunchSpec();
+
+  assert.equal(result.ok, true);
+  if (result.ok) assert.equal(result.spec.args.includes('--grep-executable'), false);
+});

--- a/packages/runtime/src/__tests__/filesystem-worker.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker.test.ts
@@ -101,6 +101,18 @@ describe('filesystem worker operations', () => {
       assert.equal(failed.error.code, 'filesystem_error');
       assert.match(failed.error.message, /rg: invalid regular expression/);
     }
+
+    const sandboxDenied = await executeFilesystemWorkerRequest(request, {
+      grepExecutable: '/usr/bin/rg',
+      runGrep: async () => ({
+        exitCode: 9,
+        stdout: '',
+        stderrTail:
+          'dyld: Library not loaded: /opt/toolchain/lib/libsearch.dylib (file system sandbox blocked open())',
+      }),
+    });
+    assert.equal(sandboxDenied.ok, false);
+    if (!sandboxDenied.ok) assert.equal(sandboxDenied.error.code, 'filesystem_denied');
   });
 
   test('reads a validated image through the approved path capability', async () => {

--- a/packages/runtime/src/__tests__/macos-executable-dependencies.test.ts
+++ b/packages/runtime/src/__tests__/macos-executable-dependencies.test.ts
@@ -18,18 +18,19 @@ describe('macOS executable dependency resolution', () => {
         [lexicalPcre, canonicalPcre],
         [canonicalPcre, canonicalPcre],
       ]),
-      dependencies: new Map([
+      loadCommands: new Map([
         [
           executable,
-          machoDependencies(executable, [
-            lexicalPcre,
-            '/usr/lib/libiconv.2.dylib',
-            '/usr/lib/libSystem.B.dylib',
-          ]),
+          machoLoadCommands({
+            dependencies: [lexicalPcre, '/usr/lib/libiconv.2.dylib', '/usr/lib/libSystem.B.dylib'],
+          }),
         ],
         [
           canonicalPcre,
-          machoDependencies(canonicalPcre, [lexicalPcre, '/usr/lib/libSystem.B.dylib']),
+          machoLoadCommands({
+            id: lexicalPcre,
+            dependencies: ['/usr/lib/libSystem.B.dylib'],
+          }),
         ],
       ]),
     });
@@ -62,19 +63,24 @@ describe('macOS executable dependency resolution', () => {
         [loaderLibrary, loaderLibrary],
         [executableLibrary, executableLibrary],
       ]),
-      dependencies: new Map([
-        [executable, machoDependencies(executable, ['@rpath/libsearch.dylib'])],
+      loadCommands: new Map([
+        [
+          executable,
+          machoLoadCommands({
+            dependencies: ['@rpath/libsearch.dylib'],
+            runpaths: ['@executable_path/../lib'],
+          }),
+        ],
         [
           library,
-          machoDependencies(library, [
-            '@loader_path/libloader.dylib',
-            '@executable_path/libexec.dylib',
-          ]),
+          machoLoadCommands({
+            id: '@rpath/libsearch.dylib',
+            dependencies: ['@loader_path/libloader.dylib', '@executable_path/libexec.dylib'],
+          }),
         ],
-        [loaderLibrary, machoDependencies(loaderLibrary, ['/usr/lib/libSystem.B.dylib'])],
-        [executableLibrary, machoDependencies(executableLibrary, [])],
+        [loaderLibrary, machoLoadCommands({ dependencies: ['/usr/lib/libSystem.B.dylib'] })],
+        [executableLibrary, machoLoadCommands()],
       ]),
-      loadCommands: new Map([[executable, machoRunpaths(['@executable_path/../lib'])]]),
     });
 
     const result = await resolveMacosExecutableDependencies(executable, fixture);
@@ -88,14 +94,47 @@ describe('macOS executable dependency resolution', () => {
     ]);
   });
 
+  test('ignores an unresolved rpath install ID on an absolute dependency', async () => {
+    const executable = '/apps/bin/rg';
+    const library = '/apps/lib/libfoo.dylib';
+    const fixture = dependencyFixture({
+      files: new Map([
+        [executable, executable],
+        [library, library],
+      ]),
+      loadCommands: new Map([
+        [executable, machoLoadCommands({ dependencies: [library] })],
+        [
+          library,
+          machoLoadCommands({
+            id: '@rpath/libfoo.dylib',
+            dependencies: ['/usr/lib/libSystem.B.dylib'],
+          }),
+        ],
+      ]),
+    });
+
+    const result = await resolveMacosExecutableDependencies(executable, fixture);
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.dependencyCount, 1);
+    assert.deepEqual(result.runtimeReadableRoots, ['/apps/lib']);
+  });
+
   test('fails closed when an rpath dependency cannot be resolved', async () => {
     const executable = '/apps/bin/rg';
     const fixture = dependencyFixture({
       files: new Map([[executable, executable]]),
-      dependencies: new Map([
-        [executable, machoDependencies(executable, ['@rpath/libmissing.dylib'])],
+      loadCommands: new Map([
+        [
+          executable,
+          machoLoadCommands({
+            dependencies: ['@rpath/libmissing.dylib'],
+            runpaths: ['/apps/lib'],
+          }),
+        ],
       ]),
-      loadCommands: new Map([[executable, machoRunpaths(['/apps/lib'])]]),
     });
 
     const result = await resolveMacosExecutableDependencies(executable, fixture);
@@ -117,10 +156,10 @@ describe('macOS executable dependency resolution', () => {
         [first, first],
         [second, second],
       ]),
-      dependencies: new Map([
-        [executable, machoDependencies(executable, [first])],
-        [first, machoDependencies(first, [second])],
-        [second, machoDependencies(second, [])],
+      loadCommands: new Map([
+        [executable, machoLoadCommands({ dependencies: [first] })],
+        [first, machoLoadCommands({ dependencies: [second] })],
+        [second, machoLoadCommands()],
       ]),
       maxDepth: 1,
     });
@@ -134,17 +173,13 @@ describe('macOS executable dependency resolution', () => {
 
 function dependencyFixture(input: {
   files: ReadonlyMap<string, string>;
-  dependencies: ReadonlyMap<string, string>;
-  loadCommands?: ReadonlyMap<string, string>;
+  loadCommands: ReadonlyMap<string, string>;
   maxDepth?: number;
 }) {
   return {
     resolveFile: async (path: string) => input.files.get(path),
     runOtool: async (request: MacosOtoolRequest) => {
-      const output =
-        request.mode === 'dependencies'
-          ? input.dependencies.get(request.imagePath)
-          : (input.loadCommands?.get(request.imagePath) ?? '');
+      const output = input.loadCommands.get(request.imagePath);
       if (output === undefined) throw new Error(`Missing otool fixture: ${request.imagePath}`);
       return output;
     },
@@ -152,22 +187,25 @@ function dependencyFixture(input: {
   };
 }
 
-function machoDependencies(image: string, dependencies: readonly string[]): string {
-  return [
-    `${image}:`,
-    ...dependencies.map(
-      (dependency) => `\t${dependency} (compatibility version 1.0.0, current version 1.0.0)`,
+function machoLoadCommands(
+  input: { id?: string; dependencies?: readonly string[]; runpaths?: readonly string[] } = {},
+): string {
+  const commands = [
+    ...(input.id ? [machoDylibCommand('LC_ID_DYLIB', input.id)] : []),
+    ...(input.dependencies ?? []).map((dependency) =>
+      machoDylibCommand('LC_LOAD_DYLIB', dependency),
     ),
-  ].join('\n');
-}
-
-function machoRunpaths(runpaths: readonly string[]): string {
-  return runpaths
-    .map(
-      (runpath, index) => `Load command ${index}
-          cmd LC_RPATH
+    ...(input.runpaths ?? []).map(
+      (runpath) => `          cmd LC_RPATH
       cmdsize 48
          path ${runpath} (offset 12)`,
-    )
-    .join('\n');
+    ),
+  ];
+  return commands.map((command, index) => `Load command ${index}\n${command}`).join('\n');
+}
+
+function machoDylibCommand(command: string, name: string): string {
+  return `          cmd ${command}
+      cmdsize 56
+         name ${name} (offset 24)`;
 }

--- a/packages/runtime/src/__tests__/macos-executable-dependencies.test.ts
+++ b/packages/runtime/src/__tests__/macos-executable-dependencies.test.ts
@@ -1,0 +1,173 @@
+import assert from 'node:assert/strict';
+import { dirname } from 'node:path';
+import { describe, test } from 'node:test';
+
+import {
+  resolveMacosExecutableDependencies,
+  type MacosOtoolRequest,
+} from '../filesystem-worker/macos-executable-dependencies.js';
+
+describe('macOS executable dependency resolution', () => {
+  test('adds lexical and canonical directories for recursive absolute dependencies', async () => {
+    const executable = '/opt/homebrew/Cellar/ripgrep/15.1.0/bin/rg';
+    const lexicalPcre = '/opt/homebrew/opt/pcre2/lib/libpcre2-8.0.dylib';
+    const canonicalPcre = '/opt/homebrew/Cellar/pcre2/10.45/lib/libpcre2-8.0.dylib';
+    const fixture = dependencyFixture({
+      files: new Map([
+        [executable, executable],
+        [lexicalPcre, canonicalPcre],
+        [canonicalPcre, canonicalPcre],
+      ]),
+      dependencies: new Map([
+        [
+          executable,
+          machoDependencies(executable, [
+            lexicalPcre,
+            '/usr/lib/libiconv.2.dylib',
+            '/usr/lib/libSystem.B.dylib',
+          ]),
+        ],
+        [
+          canonicalPcre,
+          machoDependencies(canonicalPcre, [lexicalPcre, '/usr/lib/libSystem.B.dylib']),
+        ],
+      ]),
+    });
+
+    const result = await resolveMacosExecutableDependencies(executable, fixture);
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.dependencyCount, 1);
+    assert.deepEqual(result.runtimeReadableRoots, [
+      '/opt/homebrew/opt/pcre2/lib',
+      '/opt/homebrew/Cellar/pcre2/10.45/lib',
+    ]);
+    assert.deepEqual(result.executableRoots, [
+      dirname(executable),
+      '/opt/homebrew/opt/pcre2/lib',
+      '/opt/homebrew/Cellar/pcre2/10.45/lib',
+    ]);
+  });
+
+  test('resolves rpath, loader_path, and executable_path dependencies recursively', async () => {
+    const executable = '/Applications/Maka.app/Contents/Resources/bin/rg';
+    const library = '/Applications/Maka.app/Contents/Resources/lib/libsearch.dylib';
+    const loaderLibrary = '/Applications/Maka.app/Contents/Resources/lib/libloader.dylib';
+    const executableLibrary = '/Applications/Maka.app/Contents/Resources/bin/libexec.dylib';
+    const fixture = dependencyFixture({
+      files: new Map([
+        [executable, executable],
+        [library, library],
+        [loaderLibrary, loaderLibrary],
+        [executableLibrary, executableLibrary],
+      ]),
+      dependencies: new Map([
+        [executable, machoDependencies(executable, ['@rpath/libsearch.dylib'])],
+        [
+          library,
+          machoDependencies(library, [
+            '@loader_path/libloader.dylib',
+            '@executable_path/libexec.dylib',
+          ]),
+        ],
+        [loaderLibrary, machoDependencies(loaderLibrary, ['/usr/lib/libSystem.B.dylib'])],
+        [executableLibrary, machoDependencies(executableLibrary, [])],
+      ]),
+      loadCommands: new Map([[executable, machoRunpaths(['@executable_path/../lib'])]]),
+    });
+
+    const result = await resolveMacosExecutableDependencies(executable, fixture);
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.dependencyCount, 3);
+    assert.deepEqual(result.runtimeReadableRoots, [
+      '/Applications/Maka.app/Contents/Resources/lib',
+      '/Applications/Maka.app/Contents/Resources/bin',
+    ]);
+  });
+
+  test('fails closed when an rpath dependency cannot be resolved', async () => {
+    const executable = '/apps/bin/rg';
+    const fixture = dependencyFixture({
+      files: new Map([[executable, executable]]),
+      dependencies: new Map([
+        [executable, machoDependencies(executable, ['@rpath/libmissing.dylib'])],
+      ]),
+      loadCommands: new Map([[executable, machoRunpaths(['/apps/lib'])]]),
+    });
+
+    const result = await resolveMacosExecutableDependencies(executable, fixture);
+
+    assert.deepEqual(result, {
+      ok: false,
+      reason: 'dependency_unresolved',
+      message: 'A Mach-O dependency could not be resolved to an existing file.',
+    });
+  });
+
+  test('bounds recursive dependency graphs', async () => {
+    const executable = '/apps/bin/rg';
+    const first = '/apps/lib/libfirst.dylib';
+    const second = '/apps/lib/libsecond.dylib';
+    const fixture = dependencyFixture({
+      files: new Map([
+        [executable, executable],
+        [first, first],
+        [second, second],
+      ]),
+      dependencies: new Map([
+        [executable, machoDependencies(executable, [first])],
+        [first, machoDependencies(first, [second])],
+        [second, machoDependencies(second, [])],
+      ]),
+      maxDepth: 1,
+    });
+
+    const result = await resolveMacosExecutableDependencies(executable, fixture);
+
+    assert.equal(result.ok, false);
+    if (!result.ok) assert.equal(result.reason, 'dependency_limit_exceeded');
+  });
+});
+
+function dependencyFixture(input: {
+  files: ReadonlyMap<string, string>;
+  dependencies: ReadonlyMap<string, string>;
+  loadCommands?: ReadonlyMap<string, string>;
+  maxDepth?: number;
+}) {
+  return {
+    resolveFile: async (path: string) => input.files.get(path),
+    runOtool: async (request: MacosOtoolRequest) => {
+      const output =
+        request.mode === 'dependencies'
+          ? input.dependencies.get(request.imagePath)
+          : (input.loadCommands?.get(request.imagePath) ?? '');
+      if (output === undefined) throw new Error(`Missing otool fixture: ${request.imagePath}`);
+      return output;
+    },
+    ...(input.maxDepth !== undefined ? { maxDepth: input.maxDepth } : {}),
+  };
+}
+
+function machoDependencies(image: string, dependencies: readonly string[]): string {
+  return [
+    `${image}:`,
+    ...dependencies.map(
+      (dependency) => `\t${dependency} (compatibility version 1.0.0, current version 1.0.0)`,
+    ),
+  ].join('\n');
+}
+
+function machoRunpaths(runpaths: readonly string[]): string {
+  return runpaths
+    .map(
+      (runpath, index) => `Load command ${index}
+          cmd LC_RPATH
+      cmdsize 48
+         path ${runpath} (offset 12)`,
+    )
+    .join('\n');
+}

--- a/packages/runtime/src/__tests__/sandbox-detect.test.ts
+++ b/packages/runtime/src/__tests__/sandbox-detect.test.ts
@@ -22,6 +22,17 @@ describe('isLikelySandboxDenial regex branches', () => {
     );
   });
 
+  test('matches macOS dyld file system sandbox failures', () => {
+    assert.equal(
+      isLikelySandboxDenial({
+        stdout: '',
+        stderr: 'dyld: file system sandbox blocked mmap() of a dependent library',
+        sandboxed: true,
+      }),
+      true,
+    );
+  });
+
   test('matches "sandbox...denied" branch', () => {
     assert.equal(
       isLikelySandboxDenial({

--- a/packages/runtime/src/filesystem-worker/client.ts
+++ b/packages/runtime/src/filesystem-worker/client.ts
@@ -283,6 +283,10 @@ export class FilesystemWorkerClient {
         requestId,
         response.error.message,
         response.error.code === 'not_found' || response.error.code === 'edit_conflict',
+        {
+          backend: transformed.exec.sandboxType,
+          profileName: effectiveProfile.name ?? effectiveProfile.type,
+        },
       );
     }
     if (

--- a/packages/runtime/src/filesystem-worker/launch-spec.ts
+++ b/packages/runtime/src/filesystem-worker/launch-spec.ts
@@ -6,6 +6,10 @@ import {
   resolveFilesystemWorkerBundle,
   type FilesystemWorkerResourceLocation,
 } from './resource-resolver.js';
+import {
+  resolveMacosExecutableDependencies,
+  type MacosExecutableDependencyResolution,
+} from './macos-executable-dependencies.js';
 
 export interface FilesystemWorkerLaunchSpec {
   program: string;
@@ -33,6 +37,10 @@ export interface CreateFilesystemWorkerLaunchSpecProviderInput {
   hostEnv?: NodeJS.ProcessEnv;
   rgCandidates?: readonly string[];
   tmpdir?: string;
+  /** @internal Test seam for deterministic Mach-O dependency inspection. */
+  inspectMacosExecutableDependencies?: (
+    executable: string,
+  ) => Promise<MacosExecutableDependencyResolution>;
 }
 
 export function createFilesystemWorkerLaunchSpecProvider(
@@ -84,18 +92,17 @@ async function resolveLaunchSpec(
     };
   }
   const dependencyRoots = await resolveRuntimeDependencyRoots(program);
-  const grepExecutable = await resolveRipgrepExecutable(
+  const platform = input.platform ?? process.platform;
+  const grep = await resolveRipgrepExecutable(
     input.rgCandidates ?? defaultRipgrepCandidates(input.hostEnv ?? process.env),
+    platform,
+    input.inspectMacosExecutableDependencies ?? resolveMacosExecutableDependencies,
   );
   const electronFrameworks =
-    input.runtime === 'electron' && (input.platform ?? process.platform) === 'darwin'
+    input.runtime === 'electron' && platform === 'darwin'
       ? await resolveReadableRoot(resolve(dirname(program), '..', 'Frameworks'))
       : undefined;
-  if (
-    input.runtime === 'electron' &&
-    (input.platform ?? process.platform) === 'darwin' &&
-    !electronFrameworks
-  ) {
+  if (input.runtime === 'electron' && platform === 'darwin' && !electronFrameworks) {
     return {
       ok: false,
       reason: 'runtime_executable_unavailable',
@@ -106,15 +113,20 @@ async function resolveLaunchSpec(
     ok: true,
     spec: {
       program,
-      args: [bundle.path, ...(grepExecutable ? ['--grep-executable', grepExecutable] : [])],
+      args: [bundle.path, ...(grep ? ['--grep-executable', grep.executable] : [])],
       env: buildFilesystemWorkerEnv(input.runtime, input.hostEnv, input.tmpdir),
-      runtimeReadableRoots: unique([bundle.path, runtimeRoot, ...dependencyRoots]),
+      runtimeReadableRoots: unique([
+        bundle.path,
+        runtimeRoot,
+        ...dependencyRoots,
+        ...(grep?.runtimeReadableRoots ?? []),
+      ]),
       executableRoots: unique([
         program,
         runtimeRoot,
         ...(electronFrameworks ? [electronFrameworks] : []),
         ...dependencyRoots,
-        ...(grepExecutable ? [grepExecutable] : []),
+        ...(grep ? [grep.executable, ...grep.executableRoots] : []),
       ]),
     },
   };
@@ -122,10 +134,33 @@ async function resolveLaunchSpec(
 
 async function resolveRipgrepExecutable(
   candidates: readonly string[],
-): Promise<string | undefined> {
+  platform: NodeJS.Platform,
+  inspectMacosExecutableDependencies: (
+    executable: string,
+  ) => Promise<MacosExecutableDependencyResolution>,
+): Promise<
+  | {
+      executable: string;
+      runtimeReadableRoots: readonly string[];
+      executableRoots: readonly string[];
+    }
+  | undefined
+> {
+  const inspected = new Set<string>();
   for (const candidate of candidates) {
     const executable = await resolveExecutable(candidate);
-    if (executable) return executable;
+    if (!executable || inspected.has(executable)) continue;
+    inspected.add(executable);
+    if (platform !== 'darwin') {
+      return { executable, runtimeReadableRoots: [], executableRoots: [] };
+    }
+    const dependencies = await inspectMacosExecutableDependencies(executable);
+    if (!dependencies.ok) continue;
+    return {
+      executable,
+      runtimeReadableRoots: dependencies.runtimeReadableRoots,
+      executableRoots: dependencies.executableRoots,
+    };
   }
   return undefined;
 }

--- a/packages/runtime/src/filesystem-worker/macos-executable-dependencies.ts
+++ b/packages/runtime/src/filesystem-worker/macos-executable-dependencies.ts
@@ -27,7 +27,6 @@ export type MacosExecutableDependencyResolution =
     };
 
 export interface MacosOtoolRequest {
-  readonly mode: 'dependencies' | 'load_commands';
   readonly imagePath: string;
   readonly timeoutMs: number;
 }
@@ -90,21 +89,19 @@ export async function resolveMacosExecutableDependencies(
       visited.add(image.path);
 
       const timeoutMs = remainingTimeout(deadline, now);
-      const [dependencyOutput, loadCommandOutput] = await Promise.all([
-        runOtool({ mode: 'dependencies', imagePath: image.path, timeoutMs }),
-        runOtool({ mode: 'load_commands', imagePath: image.path, timeoutMs }),
-      ]);
+      const loadCommandOutput = await runOtool({ imagePath: image.path, timeoutMs });
       remainingTimeout(deadline, now);
 
+      const loadCommands = parseMachOLoadCommands(loadCommandOutput);
       const ownRunpaths = resolveRunpaths(
-        parseMachORunpaths(loadCommandOutput),
+        loadCommands.runpaths,
         dirname(image.path),
         executableDirectory,
         image.inheritedRunpaths,
       );
       const runpaths = unique([...ownRunpaths, ...image.inheritedRunpaths]);
 
-      for (const installName of parseMachODependencies(dependencyOutput)) {
+      for (const installName of loadCommands.dependencies) {
         if (isSystemRuntimePath(installName)) continue;
         const candidates = expandInstallName(
           installName,
@@ -146,34 +143,54 @@ export async function resolveMacosExecutableDependencies(
   };
 }
 
-function parseMachODependencies(output: string): readonly string[] {
-  const dependencies: string[] = [];
-  const marker = ' (compatibility version ';
-  for (const line of output.split(/\r?\n/)) {
-    const value = line.trim();
-    const markerIndex = value.indexOf(marker);
-    if (markerIndex <= 0) continue;
-    dependencies.push(value.slice(0, markerIndex));
-  }
-  return unique(dependencies);
+// `otool -L` mixes LC_ID_DYLIB into dependency output; only load commands belong here.
+const MACHO_DYLIB_LOAD_COMMANDS = new Set([
+  'LC_LOAD_DYLIB',
+  'LC_LOAD_WEAK_DYLIB',
+  'LC_REEXPORT_DYLIB',
+  'LC_LAZY_LOAD_DYLIB',
+  'LC_LOAD_UPWARD_DYLIB',
+]);
+
+interface ParsedMachOLoadCommands {
+  readonly dependencies: readonly string[];
+  readonly runpaths: readonly string[];
 }
 
-function parseMachORunpaths(output: string): readonly string[] {
+function parseMachOLoadCommands(output: string): ParsedMachOLoadCommands {
+  const dependencies: string[] = [];
   const runpaths: string[] = [];
-  let readingRpath = false;
+  let command: string | undefined;
+
   for (const line of output.split(/\r?\n/)) {
     const value = line.trim();
     if (value.startsWith('cmd ')) {
-      readingRpath = value === 'cmd LC_RPATH';
+      command = value.slice('cmd '.length);
       continue;
     }
-    if (!readingRpath) continue;
-    const match = /^path\s+(.+?)\s+\(offset\s+\d+\)$/.exec(value);
-    if (!match?.[1]) continue;
-    runpaths.push(match[1]);
-    readingRpath = false;
+
+    if (command === 'LC_RPATH') {
+      const match = /^path\s+(.+?)\s+\(offset\s+\d+\)$/.exec(value);
+      if (match?.[1]) {
+        runpaths.push(match[1]);
+        command = undefined;
+      }
+      continue;
+    }
+
+    if (command && MACHO_DYLIB_LOAD_COMMANDS.has(command)) {
+      const match = /^name\s+(.+?)\s+\(offset\s+\d+\)$/.exec(value);
+      if (match?.[1]) {
+        dependencies.push(match[1]);
+        command = undefined;
+      }
+    }
   }
-  return unique(runpaths);
+
+  return {
+    dependencies: unique(dependencies),
+    runpaths: unique(runpaths),
+  };
 }
 
 function resolveRunpaths(
@@ -285,11 +302,10 @@ async function resolveExistingFile(path: string): Promise<string | undefined> {
 }
 
 async function runSystemOtool(request: MacosOtoolRequest): Promise<string> {
-  const flag = request.mode === 'dependencies' ? '-L' : '-l';
   return await new Promise<string>((resolvePromise, reject) => {
     execFile(
       OTOOL_EXECUTABLE,
-      [flag, request.imagePath],
+      ['-l', request.imagePath],
       {
         encoding: 'utf8',
         timeout: request.timeoutMs,

--- a/packages/runtime/src/filesystem-worker/macos-executable-dependencies.ts
+++ b/packages/runtime/src/filesystem-worker/macos-executable-dependencies.ts
@@ -1,0 +1,329 @@
+import { execFile } from 'node:child_process';
+import { stat, realpath } from 'node:fs/promises';
+import { dirname, isAbsolute, normalize, resolve } from 'node:path';
+
+const OTOOL_EXECUTABLE = '/usr/bin/otool';
+const DEFAULT_TIMEOUT_MS = 5_000;
+const DEFAULT_MAX_IMAGES = 64;
+const DEFAULT_MAX_DEPTH = 8;
+const MAX_OTOOL_OUTPUT_BYTES = 1024 * 1024;
+
+export type MacosExecutableDependencyFailureReason =
+  | 'inspection_failed'
+  | 'dependency_unresolved'
+  | 'dependency_limit_exceeded';
+
+export type MacosExecutableDependencyResolution =
+  | {
+      ok: true;
+      runtimeReadableRoots: readonly string[];
+      executableRoots: readonly string[];
+      dependencyCount: number;
+    }
+  | {
+      ok: false;
+      reason: MacosExecutableDependencyFailureReason;
+      message: string;
+    };
+
+export interface MacosOtoolRequest {
+  readonly mode: 'dependencies' | 'load_commands';
+  readonly imagePath: string;
+  readonly timeoutMs: number;
+}
+
+export type MacosOtoolRunner = (request: MacosOtoolRequest) => Promise<string>;
+
+export interface ResolveMacosExecutableDependenciesOptions {
+  runOtool?: MacosOtoolRunner;
+  resolveFile?: (path: string) => Promise<string | undefined>;
+  now?: () => number;
+  timeoutMs?: number;
+  maxImages?: number;
+  maxDepth?: number;
+}
+
+interface PendingImage {
+  readonly path: string;
+  readonly depth: number;
+  readonly inheritedRunpaths: readonly string[];
+}
+
+export async function resolveMacosExecutableDependencies(
+  executable: string,
+  options: ResolveMacosExecutableDependenciesOptions = {},
+): Promise<MacosExecutableDependencyResolution> {
+  const resolveFile = options.resolveFile ?? resolveExistingFile;
+  const rootExecutable = await resolveFile(executable);
+  if (!rootExecutable) {
+    return failure('inspection_failed', 'The executable is unavailable for dependency inspection.');
+  }
+
+  const now = options.now ?? Date.now;
+  const deadline = now() + (options.timeoutMs ?? DEFAULT_TIMEOUT_MS);
+  const maxImages = options.maxImages ?? DEFAULT_MAX_IMAGES;
+  const maxDepth = options.maxDepth ?? DEFAULT_MAX_DEPTH;
+  const runOtool = options.runOtool ?? runSystemOtool;
+  const executableDirectory = dirname(rootExecutable);
+  const runtimeReadableRoots = new Set<string>();
+  const executableRoots = new Set<string>([dirname(executable), executableDirectory]);
+  const visited = new Set<string>();
+  const queue: PendingImage[] = [
+    {
+      path: rootExecutable,
+      depth: 0,
+      inheritedRunpaths: [],
+    },
+  ];
+  let dependencyCount = 0;
+
+  try {
+    while (queue.length > 0) {
+      const image = queue.shift();
+      if (!image || visited.has(image.path)) continue;
+      if (visited.size >= maxImages || image.depth > maxDepth) {
+        throw new DependencyResolutionError(
+          'dependency_limit_exceeded',
+          'Mach-O dependency inspection exceeded its bounded graph limits.',
+        );
+      }
+      visited.add(image.path);
+
+      const timeoutMs = remainingTimeout(deadline, now);
+      const [dependencyOutput, loadCommandOutput] = await Promise.all([
+        runOtool({ mode: 'dependencies', imagePath: image.path, timeoutMs }),
+        runOtool({ mode: 'load_commands', imagePath: image.path, timeoutMs }),
+      ]);
+      remainingTimeout(deadline, now);
+
+      const ownRunpaths = resolveRunpaths(
+        parseMachORunpaths(loadCommandOutput),
+        dirname(image.path),
+        executableDirectory,
+        image.inheritedRunpaths,
+      );
+      const runpaths = unique([...ownRunpaths, ...image.inheritedRunpaths]);
+
+      for (const installName of parseMachODependencies(dependencyOutput)) {
+        if (isSystemRuntimePath(installName)) continue;
+        const candidates = expandInstallName(
+          installName,
+          dirname(image.path),
+          executableDirectory,
+          runpaths,
+        );
+        const dependency = await resolveFirstDependency(candidates, resolveFile);
+        if (!dependency) {
+          throw new DependencyResolutionError(
+            'dependency_unresolved',
+            'A Mach-O dependency could not be resolved to an existing file.',
+          );
+        }
+        if (dependency.system || dependency.realPath === image.path) continue;
+
+        dependencyCount += 1;
+        addRuntimeDirectory(runtimeReadableRoots, executableRoots, dirname(dependency.lexicalPath));
+        addRuntimeDirectory(runtimeReadableRoots, executableRoots, dirname(dependency.realPath));
+        queue.push({
+          path: dependency.realPath,
+          depth: image.depth + 1,
+          inheritedRunpaths: runpaths,
+        });
+      }
+    }
+  } catch (error) {
+    if (error instanceof DependencyResolutionError) {
+      return failure(error.reason, error.message);
+    }
+    return failure('inspection_failed', 'Mach-O dependency inspection failed.');
+  }
+
+  return {
+    ok: true,
+    runtimeReadableRoots: [...runtimeReadableRoots],
+    executableRoots: [...executableRoots],
+    dependencyCount,
+  };
+}
+
+function parseMachODependencies(output: string): readonly string[] {
+  const dependencies: string[] = [];
+  const marker = ' (compatibility version ';
+  for (const line of output.split(/\r?\n/)) {
+    const value = line.trim();
+    const markerIndex = value.indexOf(marker);
+    if (markerIndex <= 0) continue;
+    dependencies.push(value.slice(0, markerIndex));
+  }
+  return unique(dependencies);
+}
+
+function parseMachORunpaths(output: string): readonly string[] {
+  const runpaths: string[] = [];
+  let readingRpath = false;
+  for (const line of output.split(/\r?\n/)) {
+    const value = line.trim();
+    if (value.startsWith('cmd ')) {
+      readingRpath = value === 'cmd LC_RPATH';
+      continue;
+    }
+    if (!readingRpath) continue;
+    const match = /^path\s+(.+?)\s+\(offset\s+\d+\)$/.exec(value);
+    if (!match?.[1]) continue;
+    runpaths.push(match[1]);
+    readingRpath = false;
+  }
+  return unique(runpaths);
+}
+
+function resolveRunpaths(
+  runpaths: readonly string[],
+  loaderDirectory: string,
+  executableDirectory: string,
+  inheritedRunpaths: readonly string[],
+): readonly string[] {
+  return unique(
+    runpaths.flatMap((runpath) =>
+      expandPathExpression(runpath, loaderDirectory, executableDirectory, inheritedRunpaths),
+    ),
+  );
+}
+
+function expandInstallName(
+  installName: string,
+  loaderDirectory: string,
+  executableDirectory: string,
+  runpaths: readonly string[],
+): readonly string[] {
+  return expandPathExpression(installName, loaderDirectory, executableDirectory, runpaths);
+}
+
+function expandPathExpression(
+  value: string,
+  loaderDirectory: string,
+  executableDirectory: string,
+  runpaths: readonly string[],
+): readonly string[] {
+  if (isAbsolute(value)) return [normalize(value)];
+  const loaderSuffix = tokenSuffix(value, '@loader_path');
+  if (loaderSuffix !== undefined) return [resolve(loaderDirectory, loaderSuffix)];
+  const executableSuffix = tokenSuffix(value, '@executable_path');
+  if (executableSuffix !== undefined) return [resolve(executableDirectory, executableSuffix)];
+  const rpathSuffix = tokenSuffix(value, '@rpath');
+  if (rpathSuffix !== undefined) {
+    return runpaths.map((runpath) => resolve(runpath, rpathSuffix));
+  }
+  return [];
+}
+
+function tokenSuffix(value: string, token: string): string | undefined {
+  if (value === token) return '';
+  return value.startsWith(`${token}/`) ? value.slice(token.length + 1) : undefined;
+}
+
+async function resolveFirstDependency(
+  candidates: readonly string[],
+  resolveFile: (path: string) => Promise<string | undefined>,
+): Promise<
+  | {
+      lexicalPath: string;
+      realPath: string;
+      system: boolean;
+    }
+  | undefined
+> {
+  for (const candidate of candidates) {
+    if (isSystemRuntimePath(candidate)) {
+      return { lexicalPath: candidate, realPath: candidate, system: true };
+    }
+    const realPath = await resolveFile(candidate);
+    if (realPath) return { lexicalPath: candidate, realPath, system: false };
+  }
+  return undefined;
+}
+
+function isSystemRuntimePath(path: string): boolean {
+  return (
+    path === '/System' ||
+    path.startsWith('/System/') ||
+    path === '/usr/lib' ||
+    path.startsWith('/usr/lib/') ||
+    path === '/Library/Apple' ||
+    path.startsWith('/Library/Apple/')
+  );
+}
+
+function addRuntimeDirectory(
+  runtimeReadableRoots: Set<string>,
+  executableRoots: Set<string>,
+  path: string,
+): void {
+  if (!isAbsolute(path) || isSystemRuntimePath(path)) return;
+  runtimeReadableRoots.add(normalize(path));
+  executableRoots.add(normalize(path));
+}
+
+function remainingTimeout(deadline: number, now: () => number): number {
+  const remaining = deadline - now();
+  if (remaining <= 0) {
+    throw new DependencyResolutionError(
+      'dependency_limit_exceeded',
+      'Mach-O dependency inspection exceeded its time limit.',
+    );
+  }
+  return remaining;
+}
+
+async function resolveExistingFile(path: string): Promise<string | undefined> {
+  try {
+    const metadata = await stat(path);
+    if (!metadata.isFile()) return undefined;
+    return await realpath(path);
+  } catch {
+    return undefined;
+  }
+}
+
+async function runSystemOtool(request: MacosOtoolRequest): Promise<string> {
+  const flag = request.mode === 'dependencies' ? '-L' : '-l';
+  return await new Promise<string>((resolvePromise, reject) => {
+    execFile(
+      OTOOL_EXECUTABLE,
+      [flag, request.imagePath],
+      {
+        encoding: 'utf8',
+        timeout: request.timeoutMs,
+        killSignal: 'SIGKILL',
+        maxBuffer: MAX_OTOOL_OUTPUT_BYTES,
+      },
+      (error, stdout) => {
+        if (error) {
+          reject(error);
+          return;
+        }
+        resolvePromise(stdout);
+      },
+    );
+  });
+}
+
+class DependencyResolutionError extends Error {
+  constructor(
+    readonly reason: MacosExecutableDependencyFailureReason,
+    message: string,
+  ) {
+    super(message);
+    this.name = 'DependencyResolutionError';
+  }
+}
+
+function failure(
+  reason: MacosExecutableDependencyFailureReason,
+  message: string,
+): MacosExecutableDependencyResolution {
+  return { ok: false, reason, message };
+}
+
+function unique(values: readonly string[]): readonly string[] {
+  return [...new Set(values)];
+}

--- a/packages/runtime/src/filesystem-worker/operations.ts
+++ b/packages/runtime/src/filesystem-worker/operations.ts
@@ -17,6 +17,7 @@ import {
   type FilesystemWorkerResult,
   type FilesystemWorkerTarget,
 } from './protocol.js';
+import { isLikelySandboxDenial } from '../sandbox/detect.js';
 
 const DEFAULT_GLOB_LIMIT = 200;
 const MAX_GREP_OUTPUT_BYTES = 8 * 1024 * 1024;
@@ -239,7 +240,9 @@ export async function executeFilesystemOperation(
       if (result.exitCode !== 0) {
         const detail = result.stderrTail.trim();
         throw operationError(
-          'filesystem_error',
+          isLikelySandboxDenial({ stdout: result.stdout, stderr: detail, sandboxed: true })
+            ? 'filesystem_denied'
+            : 'filesystem_error',
           detail
             ? `Grep failed while searching files.\n${detail}`
             : 'Grep failed while searching files.',

--- a/packages/runtime/src/sandbox/detect.ts
+++ b/packages/runtime/src/sandbox/detect.ts
@@ -1,5 +1,5 @@
 const SANDBOX_DENIAL_PATTERN =
-  /operation not permitted|sandbox-exec|sandbox(?:ed)?[^\n]*den(?:y|ied)/i;
+  /operation not permitted|sandbox-exec|file system sandbox blocked|sandbox(?:ed)?[^\n]*den(?:y|ied)/i;
 
 export function isLikelySandboxDenial(input: {
   stdout: string;


### PR DESCRIPTION
## Summary

- Resolve the macOS filesystem worker executable's Mach-O dependency graph with `/usr/bin/otool`, including absolute install names, `@loader_path`, `@executable_path`, and `@rpath`.
- Add only the discovered lexical and canonical dependency directories to the operation-scoped Seatbelt runtime roots, allowing Homebrew `rg` to load its libraries without granting broad Homebrew access.
- Fail closed when inspection is unavailable or bounded graph limits are exceeded, and preserve typed Seatbelt denial metadata for runtime diagnostics.

Refs #843

## Verification

- Biome formatting and lint passed for all changed files.
- Targeted TypeScript checking passed for all changed source and test files.
- 44 focused resolver, launch-spec, worker, client, and sandbox-denial tests passed.
- macOS Seatbelt smoke passed 3/3: workspace write/outside denial, exact one-call grant isolation, and file/directory Grep using the current Homebrew `rg`.
- Real dependency inspection resolved the current `rg` PCRE2 roots through both Homebrew's `opt` symlink and canonical Cellar path.
- Full `@maka/runtime` typecheck was not run because this local checkout is missing the optional Slack and Baileys packages; the changed-file TypeScript check passed.

## Review focus

The resolver intentionally grants directory-level read/map permissions only for discovered third-party dependencies. Unresolved dependencies, inspection failures, timeouts, and graph-limit violations do not broaden the sandbox policy.

<details>
<summary>中文说明</summary>

## 摘要

- 使用 `/usr/bin/otool` 解析 macOS 文件系统 worker 可执行文件的 Mach-O 依赖图，支持绝对安装名、`@loader_path`、`@executable_path` 和 `@rpath`。
- 只将解析得到的软链接目录和规范化依赖目录加入当前操作的 Seatbelt runtime roots，使 Homebrew `rg` 能加载动态库，同时避免开放整个 Homebrew 目录。
- 依赖检查不可用、依赖无法解析、超时或依赖图超过限制时保持 fail closed，并为 runtime diagnostics 保留明确的 Seatbelt 拒绝信息。

## 验证

- 所有修改文件均通过 Biome 格式和 lint 检查。
- 所有修改过的源码和测试文件均通过针对性的 TypeScript 检查。
- 44 个解析器、launch spec、worker、client 和 sandbox denial 相关测试全部通过。
- macOS Seatbelt smoke 3/3 通过：工作区写入与外部拒绝、单次精确授权隔离，以及使用当前 Homebrew `rg` 的文件/目录 Grep。
- 使用本机真实环境验证，成功通过 Homebrew `opt` 软链接和 Cellar 真实路径解析当前 `rg` 的 PCRE2 依赖目录。
- 未执行完整的 `@maka/runtime` typecheck，因为当前本地依赖中缺少可选的 Slack 和 Baileys 包；本次修改文件的 TypeScript 检查已通过。

## 审查重点

解析器只为实际发现的第三方依赖增加目录级 read/map 权限。依赖无法解析、检查失败、超时或超过依赖图限制时，不会扩大 sandbox policy。

</details>