### PR TITLE
fix(desktop): recover stale storage root identity

### DIFF
--- a/apps/desktop/src/main/__tests__/storage-root-startup.test.ts
+++ b/apps/desktop/src/main/__tests__/storage-root-startup.test.ts
@@ -1,0 +1,120 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import {
+  resolveStorageRoot,
+  STORAGE_ROOT_MARKER_FILE,
+  StorageRootAuthorityError,
+} from '@maka/storage/root-authority';
+import { resolveDesktopStorageRoot } from '../storage-root-startup.js';
+
+test('opens a valid desktop storage root without asking for repair', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-desktop-root-'));
+  let repairAsked = false;
+  try {
+    const resolved = await resolveDesktopStorageRoot(root, {
+      confirmRepair: async () => {
+        repairAsked = true;
+        return false;
+      },
+    });
+
+    assert.ok(resolved);
+    assert.equal(repairAsked, false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('repairs a stale desktop storage root after explicit confirmation', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-desktop-root-'));
+  try {
+    const initialized = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
+    const marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+      rootIdentity: { dev: string };
+    };
+    marker.rootIdentity.dev = (BigInt(marker.rootIdentity.dev) + 1n).toString();
+    await writeFile(markerPath, `${JSON.stringify(marker)}\n`);
+
+    const resolved = await resolveDesktopStorageRoot(root, {
+      confirmRepair: async () => true,
+    });
+
+    assert.equal(resolved?.rootId, initialized.rootId);
+    assert.equal(
+      (await resolveStorageRoot({ path: root, kind: 'interactive' })).rootId,
+      initialized.rootId,
+    );
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('leaves a conflicting desktop storage root untouched when repair is declined', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-desktop-root-'));
+  try {
+    await resolveStorageRoot({ path: root, kind: 'interactive' });
+    const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
+    const marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+      rootIdentity: { dev: string };
+    };
+    marker.rootIdentity.dev = (BigInt(marker.rootIdentity.dev) + 1n).toString();
+    const conflictingMarker = `${JSON.stringify(marker)}\n`;
+    await writeFile(markerPath, conflictingMarker);
+
+    const resolved = await resolveDesktopStorageRoot(root, {
+      confirmRepair: async () => false,
+    });
+
+    assert.equal(resolved, undefined);
+    assert.equal(await readFile(markerPath, 'utf8'), conflictingMarker);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('rejects repair when the storage root is replaced during confirmation', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-desktop-root-'));
+  const root = join(base, 'root');
+  const replacement = join(base, 'replacement');
+  await Promise.all([mkdir(root), mkdir(replacement)]);
+  try {
+    await Promise.all([
+      resolveStorageRoot({ path: root, kind: 'interactive' }),
+      resolveStorageRoot({ path: replacement, kind: 'interactive' }),
+    ]);
+    const rootMarkerPath = join(root, STORAGE_ROOT_MARKER_FILE);
+    const replacementMarkerPath = join(replacement, STORAGE_ROOT_MARKER_FILE);
+    await makeMarkerDeviceStale(rootMarkerPath);
+    const replacementMarker = await makeMarkerDeviceStale(replacementMarkerPath);
+
+    await assert.rejects(
+      () =>
+        resolveDesktopStorageRoot(root, {
+          confirmRepair: async () => {
+            await rename(root, join(base, 'original'));
+            await rename(replacement, root);
+            return true;
+          },
+        }),
+      (error: unknown) =>
+        error instanceof StorageRootAuthorityError && error.code === 'root_identity_changed',
+    );
+    assert.equal(await readFile(join(root, STORAGE_ROOT_MARKER_FILE), 'utf8'), replacementMarker);
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+async function makeMarkerDeviceStale(markerPath: string): Promise<string> {
+  const marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+    rootIdentity: { dev: string };
+  };
+  marker.rootIdentity.dev = (BigInt(marker.rootIdentity.dev) + 1n).toString();
+  const staleMarker = `${JSON.stringify(marker)}\n`;
+  await writeFile(markerPath, staleMarker);
+  return staleMarker;
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1,4 +1,4 @@
-import { app, ipcMain, powerSaveBlocker, shell } from 'electron';
+import { app, dialog, ipcMain, powerSaveBlocker, shell } from 'electron';
 import { randomUUID } from 'node:crypto';
 import { join } from 'node:path';
 import { wireAppLifecycle } from './app-lifecycle.js';
@@ -71,7 +71,6 @@ import {
   createShellRunStore,
   createTelemetryRepo,
 } from '@maka/storage';
-import { resolveStorageRoot } from '@maka/storage/root-authority';
 import { resolveWorkspaceIdentity } from '@maka/storage/workspace-identity';
 import { McpClientManager } from '@maka/mcp';
 import { registerMcpIpcMain } from './mcp-ipc-main.js';
@@ -148,6 +147,7 @@ import {
   isSessionWorkspaceUnavailableError,
   resolveProjectContextRoot,
 } from './project-context-root.js';
+import { resolveDesktopStorageRoot } from './storage-root-startup.js';
 
 // E2E switches must never fire in a packaged build, and must never run against
 // the real user data: a stray MAKA_E2E on a build/dev machine would otherwise
@@ -220,7 +220,31 @@ if (e2eFixture) {
   console.log(`[e2e-fixture] scenario=${e2eFixture.scenario} workspace=${workspaceRoot}`);
   await seedE2eFixture({ workspaceRoot, fixture: e2eFixture, credentialStore });
 } else {
-  await resolveStorageRoot({ path: workspaceRoot, kind: 'interactive' });
+  const storageRoot = await resolveDesktopStorageRoot(workspaceRoot, {
+    confirmRepair: confirmDesktopStorageRootRepair,
+  });
+  if (!storageRoot) {
+    app.exit(0);
+    await new Promise<never>(() => {});
+  }
+}
+
+async function confirmDesktopStorageRootRepair(): Promise<boolean> {
+  await app.whenReady();
+  const isChinese = resolveSystemUiLocale(app.getPreferredSystemLanguages()) === 'zh';
+  const { response } = await dialog.showMessageBox({
+    type: 'warning',
+    title: isChinese ? 'Maka 工作区需要修复' : 'Maka workspace needs repair',
+    message: isChinese ? 'Maka 无法验证这个工作区。' : 'Maka cannot verify this workspace.',
+    detail: isChinese
+      ? `系统中的磁盘标识可能发生了变化。仅当这是本机原来的 Maka 工作区、而不是复制出的工作区时，才选择修复。\n\n${workspaceRoot}`
+      : `The disk identity may have changed. Repair only if this is the original Maka workspace on this computer, not a copied workspace.\n\n${workspaceRoot}`,
+    buttons: isChinese ? ['修复工作区', '退出'] : ['Repair Workspace', 'Exit'],
+    defaultId: 1,
+    cancelId: 1,
+    noLink: true,
+  });
+  return response === 0;
 }
 // 保持系统唤醒 (settings.system.keepSystemAwake): holds an Electron
 // `powerSaveBlocker` so in-process scheduled tasks keep firing while the

--- a/apps/desktop/src/main/storage-root-startup.ts
+++ b/apps/desktop/src/main/storage-root-startup.ts
@@ -1,0 +1,35 @@
+import {
+  prepareStorageRootIdentityRepair,
+  repairStorageRootIdentity,
+  resolveStorageRoot,
+  StorageRootAuthorityError,
+  type StorageRootCapability,
+} from '@maka/storage/root-authority';
+
+export interface DesktopStorageRootRecovery {
+  confirmRepair(): Promise<boolean>;
+}
+
+export async function resolveDesktopStorageRoot(
+  path: string,
+  recovery: DesktopStorageRootRecovery,
+): Promise<StorageRootCapability<'interactive'> | undefined> {
+  try {
+    return await resolveStorageRoot({ path, kind: 'interactive' });
+  } catch (error) {
+    if (
+      !(error instanceof StorageRootAuthorityError) ||
+      error.code !== 'root_identity_collision'
+    ) {
+      throw error;
+    }
+  }
+
+  const candidate = await prepareStorageRootIdentityRepair({
+    path,
+    kind: 'interactive',
+  });
+  if (!candidate) return resolveStorageRoot({ path, kind: 'interactive' });
+  if (!(await recovery.confirmRepair())) return undefined;
+  return repairStorageRootIdentity(candidate);
+}

--- a/packages/storage/src/__tests__/root-authority.test.ts
+++ b/packages/storage/src/__tests__/root-authority.test.ts
@@ -6,6 +6,7 @@ import {
   lstat,
   mkdir,
   mkdtemp,
+  open,
   readdir,
   readFile,
   rename,
@@ -17,6 +18,7 @@ import {
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
+import { unlock, waitForLock } from 'fs-native-extensions';
 import {
   adoptStorageRootOnImport,
   assertStorageRootCapability,
@@ -24,6 +26,8 @@ import {
   createHeadlessRootLease,
   discoverMarkedStorageRoot,
   prepareStorageRootControlDirectory,
+  prepareStorageRootIdentityRepair,
+  repairStorageRootIdentity,
   resolveExistingStorageRoot,
   resolveRootControlNamespace,
   resolveStorageRoot,
@@ -107,6 +111,129 @@ describe('storage root authority', () => {
 
       assert.equal(throughAlias.canonicalPath, direct.canonicalPath);
       assert.equal(throughAlias.rootId, direct.rootId);
+    });
+  });
+
+  test('rejects a marker from another device even when its inode matches', async () => {
+    await withRoots(async ({ root }) => {
+      await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
+      const marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+        rootIdentity: { dev: string; ino: string };
+      };
+      marker.rootIdentity.dev = (BigInt(marker.rootIdentity.dev) + 1n).toString();
+      await writeFile(markerPath, `${JSON.stringify(marker)}\n`);
+
+      await assert.rejects(
+        () => resolveStorageRoot({ path: root, kind: 'interactive' }),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'root_identity_collision',
+      );
+    });
+  });
+
+  test('explicitly repairs a stale root identity without changing its root id', async () => {
+    await withRoots(async ({ root }) => {
+      const initialized = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
+      const marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+        rootIdentity: { dev: string; ino: string };
+      };
+      marker.rootIdentity.dev = (BigInt(marker.rootIdentity.dev) + 1n).toString();
+      await writeFile(markerPath, `${JSON.stringify(marker)}\n`);
+
+      const candidate = await prepareStorageRootIdentityRepair({
+        path: root,
+        kind: 'interactive',
+      });
+      assert.ok(candidate);
+      const repaired = await repairStorageRootIdentity(candidate);
+      const rootStat = await lstat(root, { bigint: true });
+      const repairedMarker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+        rootId: string;
+        rootIdentity: { dev: string; ino: string };
+      };
+
+      assert.equal(repaired.rootId, initialized.rootId);
+      assert.equal(repairedMarker.rootId, initialized.rootId);
+      assert.deepEqual(repairedMarker.rootIdentity, {
+        dev: rootStat.dev.toString(),
+        ino: rootStat.ino.toString(),
+      });
+      assert.equal(
+        (await resolveStorageRoot({ path: root, kind: 'interactive' })).rootId,
+        initialized.rootId,
+      );
+    });
+  });
+
+  test('rejects a prepared repair when its marker changes before commit', async () => {
+    await withRoots(async ({ root }) => {
+      await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
+      const marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+        rootId: string;
+        rootIdentity: { dev: string };
+      };
+      marker.rootIdentity.dev = (BigInt(marker.rootIdentity.dev) + 1n).toString();
+      await writeFile(markerPath, `${JSON.stringify(marker)}\n`);
+      const candidate = await prepareStorageRootIdentityRepair({
+        path: root,
+        kind: 'interactive',
+      });
+      assert.ok(candidate);
+
+      marker.rootId = '0'.repeat(64);
+      const replacedMarker = `${JSON.stringify(marker)}\n`;
+      await writeFile(markerPath, replacedMarker);
+
+      await assert.rejects(
+        () => repairStorageRootIdentity(candidate),
+        (error: unknown) =>
+          error instanceof StorageRootAuthorityError && error.code === 'root_identity_changed',
+      );
+      assert.equal(await readFile(markerPath, 'utf8'), replacedMarker);
+    });
+  });
+
+  test('reopens the current marker when a concurrent repair replaces the locked inode', async () => {
+    await withRoots(async ({ root }) => {
+      await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
+      const marker = JSON.parse(await readFile(markerPath, 'utf8')) as {
+        rootIdentity: { dev: string };
+      };
+      marker.rootIdentity.dev = (BigInt(marker.rootIdentity.dev) + 1n).toString();
+      await writeFile(markerPath, `${JSON.stringify(marker)}\n`);
+
+      const [first, second] = await Promise.all([
+        prepareStorageRootIdentityRepair({ path: root, kind: 'interactive' }),
+        prepareStorageRootIdentityRepair({ path: root, kind: 'interactive' }),
+      ]);
+      assert.ok(first);
+      assert.ok(second);
+
+      const gate = await open(markerPath, 'r+');
+      await waitForLock(gate.fd);
+      const repairs = Promise.allSettled([
+        repairStorageRootIdentity(first),
+        repairStorageRootIdentity(second),
+      ]);
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      unlock(gate.fd);
+      await gate.close();
+
+      const results = await repairs;
+      assert.equal(results.filter((result) => result.status === 'fulfilled').length, 1);
+      const rejected = results.find((result) => result.status === 'rejected');
+      assert.ok(rejected);
+      assert.ok(rejected.reason instanceof StorageRootAuthorityError);
+      assert.notEqual(rejected.reason.code, 'invalid_marker');
+      assert.ok(
+        rejected.reason.code === 'root_identity_changed' ||
+          rejected.reason.code === 'root_identity_collision',
+      );
+      await resolveStorageRoot({ path: root, kind: 'interactive' });
     });
   });
 

--- a/packages/storage/src/fs-native-extensions.d.ts
+++ b/packages/storage/src/fs-native-extensions.d.ts
@@ -4,5 +4,6 @@ declare module 'fs-native-extensions' {
   }
 
   export function tryLock(fd: number, options?: LockOptions): boolean;
+  export function waitForLock(fd: number, options?: LockOptions): Promise<void>;
   export function unlock(fd: number): void;
 }

--- a/packages/storage/src/root-authority.ts
+++ b/packages/storage/src/root-authority.ts
@@ -1,21 +1,23 @@
 import { randomBytes } from 'node:crypto';
-import { type BigIntStats } from 'node:fs';
+import { type BigIntStats, constants as fsConstants } from 'node:fs';
 import { chmod, lstat, mkdir, open, realpath, stat, type FileHandle } from 'node:fs/promises';
 import { userInfo } from 'node:os';
 import { isAbsolute, join, normalize, parse, resolve } from 'node:path';
-import { tryLock, unlock } from 'fs-native-extensions';
+import { tryLock, unlock, waitForLock } from 'fs-native-extensions';
 
 import { publishMarkerFile, readBoundedMarkerFile } from './marker-file.js';
 
 export const STORAGE_ROOT_MARKER_FILE = '.maka-storage-root.json';
 export const STORAGE_ROOT_MARKER_SCHEMA_VERSION = 1 as const;
 const MAX_STORAGE_ROOT_MARKER_BYTES = 1_024;
+const MAX_ROOT_MARKER_LOCK_ATTEMPTS = 2;
 
 export type StorageRootKind = 'interactive' | 'headless';
 export type StorageRootAccess = 'read' | 'write';
 
 const capabilityBrand: unique symbol = Symbol('StorageRootCapability');
 const leaseBrand: unique symbol = Symbol('StorageRootLease');
+const repairBrand: unique symbol = Symbol('StorageRootIdentityRepairCandidate');
 
 export interface StorageRootCapability<K extends StorageRootKind = StorageRootKind> {
   readonly kind: K;
@@ -55,6 +57,13 @@ export interface ResolveExistingStorageRootInput<K extends StorageRootKind>
 
 export type AdoptStorageRootOnImportInput<K extends StorageRootKind> =
   ResolveExistingStorageRootInput<K>;
+
+export interface StorageRootIdentityRepairCandidate<K extends StorageRootKind = StorageRootKind> {
+  readonly kind: K;
+  readonly canonicalPath: string;
+  readonly rootId: string;
+  readonly [repairBrand]: true;
+}
 
 export interface InteractiveRootOwner {
   readonly capability: StorageRootCapability<'interactive'>;
@@ -105,9 +114,15 @@ interface RootMarker {
   };
 }
 
+interface StorageRootIdentityRepairRecord<K extends StorageRootKind = StorageRootKind>
+  extends CapabilityRecord<K> {
+  marker: RootMarker;
+}
+
 const capabilities = new WeakMap<object, CapabilityRecord>();
 const leases = new WeakMap<object, LeaseRecord>();
 const interactiveRootLocks = new WeakMap<object, { access: StorageRootAccess }>();
+const storageRootIdentityRepairs = new WeakMap<object, StorageRootIdentityRepairRecord>();
 
 export type StorageRootAuthorityErrorCode =
   | 'invalid_root'
@@ -118,6 +133,7 @@ export type StorageRootAuthorityErrorCode =
   | 'root_kind_mismatch'
   | 'root_identity_collision'
   | 'root_identity_changed'
+  | 'invalid_repair'
   | 'invalid_capability'
   | 'invalid_lease'
   | 'invalid_owner'
@@ -263,6 +279,96 @@ export async function adoptStorageRootOnImport<K extends StorageRootKind>(
         markerMismatchMessage: `Imported storage root identity changed: ${canonicalPath}`,
       });
       return createCapability(input.kind, canonicalPath, marker.rootId, identity);
+    },
+  );
+}
+
+export async function prepareStorageRootIdentityRepair<K extends StorageRootKind>(
+  input: ResolveStorageRootInput<K>,
+): Promise<StorageRootIdentityRepairCandidate<K> | undefined> {
+  assertStorageRootKind(input.kind);
+  return withAuthorityFailure(
+    'root_io_failed',
+    'Unable to prepare the storage root identity repair',
+    async () => {
+      const { canonicalPath, rootStat } = await resolveExistingRootPath(input.path);
+      const identity = { dev: rootStat.dev, ino: rootStat.ino };
+      const identityChangedMessage = `Storage root identity changed while preparing its repair: ${canonicalPath}`;
+      await assertRootPathIdentity(canonicalPath, identity, identityChangedMessage);
+      let marker: RootMarker;
+      try {
+        marker = await readAndValidateRootMarker(canonicalPath, input.kind);
+      } catch (error) {
+        await assertRootPathIdentity(canonicalPath, identity, identityChangedMessage);
+        throw error;
+      }
+      await assertRootPathIdentity(canonicalPath, identity, identityChangedMessage);
+      if (markerMatchesIdentity(marker, identity)) return undefined;
+
+      const record: StorageRootIdentityRepairRecord<K> = {
+        kind: input.kind,
+        canonicalPath,
+        rootId: marker.rootId,
+        identity,
+        marker,
+      };
+      const candidate = Object.freeze({
+        kind: record.kind,
+        canonicalPath: record.canonicalPath,
+        rootId: record.rootId,
+      }) as StorageRootIdentityRepairCandidate<K>;
+      storageRootIdentityRepairs.set(candidate, record);
+      return candidate;
+    },
+  );
+}
+
+/**
+ * Explicit recovery boundary for a root whose host-local filesystem identity
+ * is stale. Callers must obtain user intent for this exact candidate first.
+ */
+export async function repairStorageRootIdentity<K extends StorageRootKind>(
+  candidate: StorageRootIdentityRepairCandidate<K>,
+): Promise<StorageRootCapability<K>> {
+  const record = storageRootIdentityRepairs.get(candidate) as
+    | StorageRootIdentityRepairRecord<K>
+    | undefined;
+  if (!record) {
+    throw new StorageRootAuthorityError(
+      'invalid_repair',
+      'Expected a prepared storage root identity repair',
+    );
+  }
+  storageRootIdentityRepairs.delete(candidate);
+
+  return withAuthorityFailure(
+    'root_io_failed',
+    'Unable to repair the storage root identity',
+    async () => {
+      const identityChangedMessage = `Storage root identity changed while repairing its marker: ${record.canonicalPath}`;
+      await assertRootPathIdentity(record.canonicalPath, record.identity, identityChangedMessage);
+      const marker = await readAndValidateRootMarker(record.canonicalPath, record.kind);
+      await assertRootPathIdentity(record.canonicalPath, record.identity, identityChangedMessage);
+      if (!rootMarkersEqual(marker, record.marker)) {
+        throw new StorageRootAuthorityError(
+          'root_identity_changed',
+          `Storage root marker changed while awaiting repair: ${record.canonicalPath}`,
+        );
+      }
+      const repaired = await replaceRootMarkerIdentity(
+        record.canonicalPath,
+        record.identity,
+        record.marker,
+      );
+      await confirmRootSnapshot({
+        root: record.canonicalPath,
+        identity: record.identity,
+        readMarker: () => readAndValidateRootMarker(record.canonicalPath, record.kind),
+        expectedRootId: record.rootId,
+        markerMismatchCode: 'root_identity_changed',
+        markerMismatchMessage: `Repaired storage root identity changed: ${record.canonicalPath}`,
+      });
+      return createCapability(record.kind, record.canonicalPath, repaired.rootId, record.identity);
     },
   );
 }
@@ -731,52 +837,141 @@ async function replaceRootMarkerIdentity(
   identity: RootIdentity,
   sourceMarker: RootMarker,
 ): Promise<RootMarker> {
-  const current = await readAndValidateRootMarker(root, sourceMarker.kind);
-  if (current.rootId !== sourceMarker.rootId) {
+  return withExclusiveRootMarker(root, sourceMarker.kind, async (current) => {
+    assertRootMarkerUnchanged(root, current, sourceMarker);
+    const marker: RootMarker = {
+      ...current,
+      rootIdentity: {
+        dev: identity.dev.toString(),
+        ino: identity.ino.toString(),
+      },
+    };
+    const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
+    await publishMarkerFile({
+      root,
+      markerFile: STORAGE_ROOT_MARKER_FILE,
+      contents: `${JSON.stringify(marker)}\n`,
+      maxBytes: MAX_STORAGE_ROOT_MARKER_BYTES,
+      publication: 'replace',
+      beforePublish: async () => {
+        await assertRootPathIdentity(
+          root,
+          identity,
+          `Storage root identity changed before updating its marker: ${root}`,
+        );
+        assertRootMarkerUnchanged(
+          root,
+          await readAndValidateRootMarker(root, sourceMarker.kind),
+          sourceMarker,
+        );
+      },
+      invalidFile: () =>
+        new StorageRootAuthorityError(
+          'invalid_marker',
+          `Storage root marker candidate exceeds the size limit: ${markerPath}`,
+        ),
+    });
+    await assertRootPathIdentity(
+      root,
+      identity,
+      `Storage root identity changed after updating its marker: ${root}`,
+    );
+    const adopted = await readAndValidateRootMarker(root, sourceMarker.kind);
+    if (adopted.rootId !== sourceMarker.rootId || !markerMatchesIdentity(adopted, identity)) {
+      throw new StorageRootAuthorityError(
+        'root_identity_changed',
+        `Storage root marker changed while updating its identity: ${root}`,
+      );
+    }
+    return adopted;
+  });
+}
+
+async function withExclusiveRootMarker<T>(
+  root: string,
+  expectedKind: StorageRootKind,
+  operation: (marker: RootMarker) => Promise<T>,
+): Promise<T> {
+  const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
+  for (let attempt = 0; attempt < MAX_ROOT_MARKER_LOCK_ATTEMPTS; attempt += 1) {
+    const handle = await openRootMarkerForWrite(root, markerPath);
+    let locked = false;
+    try {
+      await waitForLock(handle.fd);
+      locked = true;
+      const [handleStat, pathStat] = await Promise.all([
+        handle.stat({ bigint: true }),
+        lstat(markerPath, { bigint: true }),
+      ]);
+      if (
+        !handleStat.isFile() ||
+        !pathStat.isFile() ||
+        handleStat.size > BigInt(MAX_STORAGE_ROOT_MARKER_BYTES)
+      ) {
+        throw new StorageRootAuthorityError(
+          'invalid_marker',
+          `Storage root marker must be one bounded regular file: ${markerPath}`,
+        );
+      }
+      if (handleStat.dev !== pathStat.dev || handleStat.ino !== pathStat.ino) {
+        if (attempt + 1 < MAX_ROOT_MARKER_LOCK_ATTEMPTS) continue;
+        throw new StorageRootAuthorityError(
+          'root_identity_changed',
+          `Storage root marker changed while acquiring its lock: ${root}`,
+        );
+      }
+      const marker = parseRootMarker(await handle.readFile('utf8'), markerPath);
+      if (marker.kind !== expectedKind) {
+        throw new StorageRootAuthorityError(
+          'root_kind_mismatch',
+          `Storage root ${root} is ${marker.kind}, not ${expectedKind}`,
+        );
+      }
+      return await operation(marker);
+    } finally {
+      if (locked) unlock(handle.fd);
+      await handle.close();
+    }
+  }
+  throw new StorageRootAuthorityError(
+    'root_identity_changed',
+    `Storage root marker changed while acquiring its lock: ${root}`,
+  );
+}
+
+async function openRootMarkerForWrite(root: string, markerPath: string): Promise<FileHandle> {
+  try {
+    return await open(markerPath, markerWriteFlags());
+  } catch (error) {
+    if (isNodeError(error, 'ENOENT')) {
+      throw new StorageRootAuthorityError('root_unmarked', `Storage root is not marked: ${root}`);
+    }
+    if (isInvalidMarkerPathError(error)) {
+      throw invalidRootMarker(markerPath, error);
+    }
+    throw error;
+  }
+}
+
+function assertRootMarkerUnchanged(root: string, current: RootMarker, expected: RootMarker): void {
+  if (!rootMarkersEqual(current, expected)) {
     throw new StorageRootAuthorityError(
       'root_identity_collision',
-      `Storage root marker changed while adopting an import: ${root}`,
+      `Storage root marker changed while updating its identity: ${root}`,
     );
   }
-  const marker: RootMarker = {
-    ...current,
-    rootIdentity: {
-      dev: identity.dev.toString(),
-      ino: identity.ino.toString(),
-    },
-  };
-  const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
-  await publishMarkerFile({
-    root,
-    markerFile: STORAGE_ROOT_MARKER_FILE,
-    contents: `${JSON.stringify(marker)}\n`,
-    maxBytes: MAX_STORAGE_ROOT_MARKER_BYTES,
-    publication: 'replace',
-    beforePublish: () =>
-      assertRootPathIdentity(
-        root,
-        identity,
-        `Storage root identity changed before adopting its marker: ${root}`,
-      ),
-    invalidFile: () =>
-      new StorageRootAuthorityError(
-        'invalid_marker',
-        `Storage root marker candidate exceeds the size limit: ${markerPath}`,
-      ),
-  });
-  await assertRootPathIdentity(
-    root,
-    identity,
-    `Storage root identity changed after adopting its marker: ${root}`,
+}
+
+function markerWriteFlags(): number {
+  return fsConstants.O_RDWR | (fsConstants.O_NONBLOCK ?? 0) | (fsConstants.O_NOFOLLOW ?? 0);
+}
+
+function invalidRootMarker(markerPath: string, cause?: unknown): StorageRootAuthorityError {
+  return new StorageRootAuthorityError(
+    'invalid_marker',
+    `Invalid storage root marker at ${markerPath}${cause instanceof Error ? `: ${cause.message}` : ''}`,
+    cause === undefined ? undefined : { cause },
   );
-  const adopted = await readAndValidateRootMarker(root, sourceMarker.kind);
-  if (adopted.rootId !== sourceMarker.rootId || !markerMatchesIdentity(adopted, identity)) {
-    throw new StorageRootAuthorityError(
-      'root_identity_changed',
-      `Storage root marker changed while adopting an import: ${root}`,
-    );
-  }
-  return adopted;
 }
 
 async function assertRootPathIdentity(
@@ -806,38 +1001,37 @@ async function readAndValidateRootMarker(
 
 async function readRootMarker(root: string): Promise<RootMarker> {
   const markerPath = join(root, STORAGE_ROOT_MARKER_FILE);
-  let marker: unknown;
+  let contents: string;
   try {
-    marker = JSON.parse(
-      await readBoundedMarkerFile({
-        path: markerPath,
-        maxBytes: MAX_STORAGE_ROOT_MARKER_BYTES,
-        invalidFile: () =>
-          new StorageRootAuthorityError(
-            'invalid_marker',
-            `Storage root marker must be one bounded regular file: ${markerPath}`,
-          ),
-      }),
-    );
+    contents = await readBoundedMarkerFile({
+      path: markerPath,
+      maxBytes: MAX_STORAGE_ROOT_MARKER_BYTES,
+      invalidFile: () =>
+        new StorageRootAuthorityError(
+          'invalid_marker',
+          `Storage root marker must be one bounded regular file: ${markerPath}`,
+        ),
+    });
   } catch (error) {
     if (error instanceof StorageRootAuthorityError) throw error;
     if (isNodeError(error, 'ENOENT')) {
       throw new StorageRootAuthorityError('root_unmarked', `Storage root is not marked: ${root}`);
     }
-    if (error instanceof SyntaxError || isInvalidMarkerPathError(error)) {
-      throw new StorageRootAuthorityError(
-        'invalid_marker',
-        `Invalid storage root marker at ${markerPath}: ${error instanceof Error ? error.message : String(error)}`,
-        { cause: error },
-      );
-    }
+    if (isInvalidMarkerPathError(error)) throw invalidRootMarker(markerPath, error);
     throw error;
   }
+  return parseRootMarker(contents, markerPath);
+}
+
+function parseRootMarker(contents: string, markerPath: string): RootMarker {
+  let marker: unknown;
+  try {
+    marker = JSON.parse(contents);
+  } catch (error) {
+    throw invalidRootMarker(markerPath, error);
+  }
   if (!isRootMarker(marker)) {
-    throw new StorageRootAuthorityError(
-      'invalid_marker',
-      `Invalid storage root marker at ${markerPath}`,
-    );
+    throw invalidRootMarker(markerPath);
   }
   return marker;
 }
@@ -869,6 +1063,16 @@ function markerMatchesIdentity(marker: RootMarker, identity: RootIdentity): bool
   return (
     marker.rootIdentity.dev === identity.dev.toString() &&
     marker.rootIdentity.ino === identity.ino.toString()
+  );
+}
+
+function rootMarkersEqual(left: RootMarker, right: RootMarker): boolean {
+  return (
+    left.schemaVersion === right.schemaVersion &&
+    left.kind === right.kind &&
+    left.rootId === right.rootId &&
+    left.rootIdentity.dev === right.rootIdentity.dev &&
+    left.rootIdentity.ino === right.rootIdentity.ino
   );
 }
 


### PR DESCRIPTION
## Summary

- keep automatic storage-root resolution strict on `dev + ino`, preserving copied-root rejection
- offer an explicit desktop recovery prompt when the persisted host identity no longer matches
- bind confirmation to a one-shot storage-root snapshot, then lock, revalidate, and atomically rebind the exact marker while preserving `rootId`

## Verification

- `npm --workspace @maka/storage test` — 557 passed, 1 skipped
- `npm --workspace @maka/desktop test` — 2895 passed
- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- fresh-eye review reran the marker publication race and concurrent repair race — no P0-P3 findings

## Root cause

macOS can renumber a mounted volume device while preserving the workspace directory inode. Schema-v1 markers cannot distinguish that event from a copied root with the same inode, so automatic recovery would violate copied-root isolation. This change keeps automatic checks fail-closed and makes rebinding an explicit, snapshot-bound user action.