### PR TITLE
fix(settings): give the label the row, not the accessory

### DIFF
--- a/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-form-a11y-contract.test.ts
@@ -104,7 +104,12 @@ describe('Settings form accessibility labels', () => {
     assert.doesNotMatch(connectionBadge, /rounded-\[var\(--radius-pill\)\]/, 'Settings connection badges (Chip primitive) must not regress to pill-shaped chrome');
     assert.doesNotMatch(settingsBadge, /rounded-\[var\(--radius-pill\)\]/, 'Generic Settings badges (Chip primitive) must not regress to pill-shaped chrome');
     assert.match(settingsRow, /display:\s*grid;/, 'Settings rows should use a stable label/value grid instead of flex auto sizing');
-    assert.match(settingsRow, /grid-template-columns:\s*minmax\(150px,\s*0\.36fr\)\s+minmax\(0,\s*1fr\);/, 'Settings rows need a protected label column and shrinkable value column');
+    // The track split itself is pinned by settings-row-track-contract, which
+    // is the one home for that rule. This file used to restate it as
+    // `minmax(150px, 0.36fr) minmax(0, 1fr)` under the banner "protected
+    // label column" — the split that starved the label, so the duplicate was
+    // both redundant and wrong, and the second copy is what a fix has to
+    // hunt down. Assert the shape here, not the numbers.
     assert.match(settingsRowValue, /overflow-wrap:\s*anywhere;/, 'Long Settings values such as workspace paths should wrap in the value column');
     assert.match(settingsRowValue, /text-align:\s*right;/, 'Short Settings values should keep the existing right-aligned summary rhythm');
     // #1362: the old `white-space: nowrap` title pin protected labels from

--- a/apps/desktop/src/main/__tests__/settings-row-track-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-row-track-contract.test.ts
@@ -1,20 +1,38 @@
 /**
  * Settings row track contract.
  *
- * `.settingsRow` splits label and control across two grid tracks. The
- * default split gives the control `1fr` against the label's `0.36fr`,
- * which is correct only for a control that actually fills its column.
- * Switches (32px) and the time field (~84px) do not, so on a 718px row
- * the label was pinned to 173px with 465px of empty track beside it —
- * and the hint wrapped after ~9 characters, mid-word, because Chinese
- * has no spaces to break at.
+ * `.settingsRow` splits label and control across two grid tracks, and the
+ * rule is one sentence: THE LABEL IS THE CONTENT, the right column is the
+ * accessory. So the right track is sized to what it holds, capped so it
+ * cannot starve the label, and the label takes everything else.
  *
- * The rule is therefore per control bucket, and each bucket's track is
- * pinned here because the numbers are the whole point: an intrinsic
- * track collapses a select's `w-full` trigger to its selected text
- * (measured 320px → 118px), and a flat 320px cap eats the label instead
- * (82px at a 468px card, just above the 460px stacking breakpoint).
- * Only the both-caps form survives every width.
+ * The default used to be `minmax(150px, 0.36fr) minmax(0, 1fr)` — the
+ * accessory got 1fr and the content was rationed to 0.36fr. #1524 noticed
+ * the symptom but fixed it per control bucket, adding `minmax(0, 1fr) auto`
+ * for switches and the compact time field while leaving the backwards
+ * default in place "for rows whose control fills the value column".
+ *
+ * No such row exists. Every right column in the app is a switch, a ~94px
+ * time field, a select capped at min(320px, 45%), or — 28 rows across the
+ * 数据 / 开放网关 / 通用 / 关于 pages, via SettingRow — a short read-only
+ * string. So the enumerated exceptions were the rule, and the default was
+ * a defect that the contract was holding in place: on a ~1076px row the
+ * value used ~64px of a ~791px track while the label was pinned to ~285px
+ * and wrapped its hint to four lines, mid-word, because Chinese has no
+ * spaces to break at.
+ *
+ * Stating it as the default is the point — it is what makes the next row
+ * someone adds come out right without being enumerated here first.
+ *
+ * The cap is load-bearing in both directions, which is why the numbers are
+ * pinned below:
+ *   - bare `auto` sizes to max-content, and the 数据 page's workspace path
+ *     is a ~690px unbroken string; that starves the label exactly the way
+ *     0.36fr did, just from the other side.
+ *   - a select's `w-full` trigger collapses under an intrinsic track
+ *     (measured 320px → 118px), and a flat 320px cap eats the label
+ *     instead (82px at a 468px card, just above the 460px stacking
+ *     breakpoint). Only the both-caps form survives every width.
  */
 
 import { strict as assert } from 'node:assert';
@@ -28,27 +46,52 @@ function ruleBody(css: string, selector: string): string {
   return css.match(re)?.[1] ?? '';
 }
 
+/** The base `.settingsRow {` rule — no suffix, so `:hover` / `> [role=…]`
+ *  and the bucket rules cannot stand in for the base declaration. */
+function baseRowBody(css: string): string {
+  return css.match(/(?:^|\n|\})\s*\.settingsRow\s*\{([^}]*)\}/)?.[1] ?? '';
+}
+
 describe('settings row track contract', () => {
-  it('gives the label the slack that narrow controls cannot use', async () => {
+  it('gives the label the flexible track and sizes the value to its content', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const base = baseRowBody(css);
+    assert.ok(base, '.settingsRow base rule must exist');
+
+    assert.match(
+      base,
+      /grid-template-columns:\s*minmax\(0,\s*1fr\)\s+fit-content\(45%\)/,
+      'the label must take the flexible track and the value must size to content under a cap — see the header for why the reverse wrapped Chinese hints mid-word',
+    );
+  });
+
+  it('caps the value track, because an intrinsic one starves the label too', async () => {
+    const css = stripCssComments(await readAllRendererCss());
+    const base = baseRowBody(css);
+
+    // `fit-content(45%)`, never a bare `auto`: the workspace path on the
+    // 数据 page is a ~690px unbroken string and would claim the row.
+    assert.doesNotMatch(
+      base,
+      /grid-template-columns:[^;]*\s\bauto\b/,
+      'a bare auto track sizes to max-content; a long mono path would then starve the label',
+    );
+  });
+
+  it('never puts a sub-1fr proportional track before the label', async () => {
     const css = stripCssComments(await readAllRendererCss());
 
-    // Switch rows and the compact bucket size their control to content.
-    // `auto` is what makes the label take everything else; an `fr` here
-    // is the bug this contract exists to prevent.
-    const intrinsic = ruleBody(css, '.settingsRow[data-control-width="compact"]');
-    assert.ok(intrinsic, '.settingsRow[data-control-width="compact"] track rule must exist');
-    assert.match(
-      intrinsic,
-      /grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto/,
-      'narrow controls must size to content so the label keeps the rest of the row',
-    );
+    // The shape of the original defect, in any `.settingsRow` rule: a
+    // fractional first track smaller than 1fr rations the label by share
+    // instead of letting the accessory size itself.
+    const offenders = [...css.matchAll(/\.settingsRow[^{}]*\{[^}]*\}/g)]
+      .map((m) => m[0])
+      .filter((rule) => /grid-template-columns:\s*minmax\([^)]*,\s*0?\.\d+fr\)/.test(rule));
 
-    // The switch selector shares that rule; assert it is still attached to
-    // it, since a tag-qualified rewrite of this selector has rotted before.
-    assert.match(
-      css,
-      /\.settingsRow:has\(>\s*\[role="switch"\]\)[^{]*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto/,
-      'switch-only rows must share the intrinsic-control track',
+    assert.deepEqual(
+      offenders.map((r) => r.split('{')[0].trim()),
+      [],
+      'a label track narrower than 1fr by share is the backwards split this contract exists to prevent',
     );
   });
 
@@ -57,9 +100,6 @@ describe('settings row track contract', () => {
     const select = ruleBody(css, '.settingsRow[data-control-width="select"]');
     assert.ok(select, '.settingsRow[data-control-width="select"] track rule must exist');
 
-    // `min(320px, 45%)`: the 320px alone leaves an 82px label at a 468px
-    // card; the percentage alone would let the trigger grow unbounded on
-    // a wide card. Both bounds, or the split breaks at one end.
     assert.match(
       select,
       /grid-template-columns:\s*minmax\(0,\s*1fr\)\s+minmax\(0,\s*min\(320px,\s*45%\)\)/,
@@ -72,16 +112,18 @@ describe('settings row track contract', () => {
     );
   });
 
-  it('keeps the default row split for controls that do fill their column', async () => {
+  it('keeps switch rows two-column when the card stacks everything else', async () => {
     const css = stripCssComments(await readAllRendererCss());
-    // Exact `.settingsRow {` — no suffix, so `:hover` / `> [role=…]` and
-    // the bucket rules above can't stand in for the base declaration.
-    const base = css.match(/(?:^|\n|\})\s*\.settingsRow\s*\{([^}]*)\}/)?.[1] ?? '';
-    assert.ok(base, '.settingsRow base rule must exist');
+
+    // A switch is ~40px and always fits beside its label, so stacking it
+    // reads as a detached orphan. This is the one row kind that stays
+    // horizontal below the 460px container breakpoint. The selector must
+    // stay tag-agnostic: Base UI renders Switch's root as a SPAN, and a
+    // tag-qualified rewrite of this selector has rotted silently before.
     assert.match(
-      base,
-      /grid-template-columns:\s*minmax\(150px,\s*0\.36fr\)\s+minmax\(0,\s*1fr\)/,
-      'the base split still applies to rows whose control fills the value column',
+      css,
+      /\.settingsRow:has\(>\s*\[role="switch"\]\)[^{]*\{[^}]*grid-template-columns:\s*minmax\(0,\s*1fr\)\s+auto/,
+      'switch-only rows must keep two columns inside the narrow-container block',
     );
   });
 });

--- a/apps/desktop/src/renderer/styles/settings/rows.css
+++ b/apps/desktop/src/renderer/styles/settings/rows.css
@@ -35,10 +35,41 @@
 }
 
 /* Label/value row: title + hint stack on the left, value or a single
-   control on the right column. */
+   control on the right column.
+
+   THE LABEL IS THE CONTENT; the right column is the accessory. So the
+   right track is sized to what it actually holds and the label takes
+   everything else — `fit-content(45%)`, not a proportional share.
+
+   This used to read `minmax(150px, 0.36fr) minmax(0, 1fr)`, which is
+   backwards: it handed the accessory 1fr and rationed the content to
+   0.36fr. Nothing in this codebase ever fills that 1fr — every right
+   column is a switch, a ~94px time field, a capped select, or (28 rows
+   across 5 pages, via SettingRow) a short read-only string. Measured on
+   the 数据 and 开放网关 pages at a ~1076px row: the value used ~64px of
+   a ~791px track while the label was pinned to ~285px and wrapped its
+   hint to four lines — mid-word in Chinese, which has no spaces to break
+   at — with ~730px sitting blank between them.
+
+   #1524 already made this trade for switches and the compact bucket, but
+   it enumerated control types instead of stating the rule, so read-only
+   values — the most common right column in the app — kept the backwards
+   default. Stating it as the default is what makes it hold for the next
+   row someone adds.
+
+   `fit-content(45%)` rather than `auto` because the cap is load-bearing:
+   the workspace path on the 数据 page is a ~690px unbroken string, and an
+   `auto` track sizes to max-content, which would starve the label exactly
+   the way the old default did — just in the other direction. 45% matches
+   the share the select bucket below already caps at. A value longer than
+   the cap wraps, which is the documented intent for mono paths (see the
+   `[data-mono]` rule further down).
+
+   Controls that genuinely fill their track opt out: see the select rule
+   below, whose `w-full` trigger collapses under an intrinsic track. */
 .settingsRow {
   display: grid;
-  grid-template-columns: minmax(150px, 0.36fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr) fit-content(45%);
   align-items: center;
   gap: var(--space-4);
   /* Same padding as .settingsFormRow below so the two row kinds read
@@ -61,25 +92,15 @@
   justify-self: end;
 }
 
-/* Narrow controls give their slack back to the label.
-   ---------------------------------------------------
-   The default track split hands the control column `1fr` against the
-   label's `0.36fr`. That is right for a control that fills its column,
-   and wrong for one that cannot: a switch is 32px and a time field ~94px,
-   so on a 718px row the label was pinned to 173px with 465px of empty
-   track beside it. The hint then wrapped after ~9 characters — mid-word
-   in Chinese, which has no spaces to break at — while most of the row sat
-   blank. Sizing these two buckets to their content and giving the rest to
-   the label is the same trade the 460px container rule below already
-   makes, for the same reason; it was just never applied at full width.
+/* #1524's switch and `[data-control-width="compact"]` track splits lived
+   here. Both said `minmax(0, 1fr) auto` — which is what the default above
+   now says, only stated as the rule rather than as two exceptions to it.
+   A 32px switch and a ~94px time field both sit well under the 45% cap,
+   so they size identically and the rules were pure duplication. The
+   `compact` attribute stays: it still carries the control-width and
+   stacking rules further down.
 
-   Selects need a different shape — see the rule below. */
-.settingsRow:has(> [role="switch"]):not(:has(> :nth-child(3):not(input))),
-.settingsRow[data-control-width="compact"] {
-  grid-template-columns: minmax(0, 1fr) auto;
-}
-
-/* Selects can't take the intrinsic track above: their trigger is `w-full`
+   Selects can't take the intrinsic track above: their trigger is `w-full`
    under a 320px cap, so an `auto` track collapses it to the width of
    whatever option happens to be selected (measured: 320px → 118px).
    They get an explicit cap instead, and it has to be BOTH absolute and


### PR DESCRIPTION
Reported: the description column on settings rows wraps far too narrow, with a large blank gap beside it. It is one root cause, not one page — `.settingsRow`'s default track split, shared by **28 rows across 5 pages**.

## The defect

```css
grid-template-columns: minmax(150px, 0.36fr) minmax(0, 1fr);
```

The label IS the content; the right column is the accessory. This handed the accessory `1fr` and rationed the content to `0.36fr`. Measured on 数据 / 开放网关: the value used ~64px of a ~791px track while the label sat at ~285px and wrapped its hint to **four lines** — mid-word, because Chinese has no spaces to break at — with ~730px of blank row between them.

## Why it survived #1524

#1524 saw the symptom and fixed it *per control bucket*, adding `minmax(0, 1fr) auto` for switches and the compact time field, leaving the default in place "for rows whose control fills the value column".

**No such row exists.** Every right column in the app is a switch, a ~94px time field, a select capped at `min(320px, 45%)`, or a short read-only string. The enumerated exceptions *were* the rule; the default was the defect. Enumerating control types is also why read-only values — the most common right column — were never covered.

## The fix

```css
grid-template-columns: minmax(0, 1fr) fit-content(45%);
```

Stated as the default, so the next row someone adds comes out right without being enumerated first. Both bucket rules are **deleted** rather than left as duplicates — a 32px switch and a ~94px time field sit far under the cap and size identically to before.

`fit-content(45%)` rather than `auto` because the cap is load-bearing **in both directions**: the workspace path is a ~690px unbroken string, and an intrinsic track sizes to max-content, starving the label exactly the way `0.36fr` did — just from the other side. That path now wraps, which the `[data-mono]` rule has always documented as the intent for long values.

## Measured, before → after (story card, 720px)

| page | label width | hint lines (avg) | hint lines (max) |
|---|---|---|---|
| 数据 | 173 → **501px** | 3.00 → **1.33** | 4 → **2** |
| 开放网关 | 173 → **479px** | 3.05 → **1.42** | 4 → **2** |
| 通用 | 173 → **353px** | 1.50 → **1.00** | 2 → **1** |
| 关于 | 173 → **463px** | 2.00 → **1.00** | 2 → **1** |

Captured before/after screenshots of both pages by toggling only the grid track on the same DOM.

## Contracts

Two of them pinned the old split, and the fix failed both — the same shape as the recent radius work: a rule justified by a case that does not exist, holding a defect in place.

- **`settings-row-track-contract`** asserted the base was `minmax(150px, 0.36fr) minmax(0, 1fr)` "for controls that do fill their column". Rewritten around the rule rather than the buckets, plus a new guard that fails **any** `.settingsRow` track whose first column is a sub-`1fr` proportional share — the shape of the original defect.
- **`settings-form-a11y-contract`** restated the same numbers under the banner *"protected label column"* — the split that starved the label. **Removed** rather than updated: the track has one home, and a second copy is just something a future fix has to hunt down.

## Gate

lint · format:check · typecheck · build · knip · check-dead-css — clean, plus **2897** main-process tests passing.