### PR TITLE
fix(permission): stop mode changes escalating boundaries and skipping backends

### DIFF
--- a/apps/desktop/src/main/__tests__/permission-mode-sync-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-mode-sync-contract.test.ts
@@ -1,0 +1,92 @@
+/**
+ * Changing the global default permission mode must not escalate a session
+ * whose restrictive mode is a security boundary.
+ *
+ * The composer's picker is GLOBAL — it writes `chatDefaults.permissionMode`,
+ * and `applySettingsRuntimeEffects` then pushes that mode onto existing
+ * sessions. Several flows deliberately create sessions at `explore` as their
+ * read-only boundary: Deep Research, bot conversations (whose prompts come
+ * from a remote sender), expert-team review crews, and cron automations.
+ *
+ * Before this contract only Deep Research was exempt, by label, so flipping
+ * the picker in an unrelated chat silently moved bot / expert-team / cron
+ * sessions to `execute` or `bypass`. Bot sessions re-pinned themselves on the
+ * next inbound message; expert-team and cron sessions never did.
+ */
+
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { createSettingsRuntimeEffects } from '../settings-runtime-effects.js';
+
+interface FakeSession {
+  id: string;
+  permissionMode: string;
+  labels: string[];
+  status: string;
+}
+
+function harness(sessions: FakeSession[]) {
+  const setCalls: Array<{ id: string; mode: string }> = [];
+  const settings = {
+    chatDefaults: { permissionMode: 'bypass' },
+  } as unknown as Parameters<
+    ReturnType<typeof createSettingsRuntimeEffects>['applySettingsRuntimeEffects']
+  >[0];
+
+  const effects = createSettingsRuntimeEffects({
+    settingsStore: { get: async () => settings } as never,
+    botRegistry: {} as never,
+    openGateway: {} as never,
+    keepSystemAwake: { apply: () => {} } as never,
+    runtime: {
+      listSessions: async () => sessions,
+      setPermissionMode: async (id: string, mode: string) => { setCalls.push({ id, mode }); },
+    } as never,
+    safeSendToRenderer: () => {},
+    emitSessionsChanged: () => {},
+  });
+
+  return { effects, settings, setCalls };
+}
+
+const CHAT = { id: 'chat', permissionMode: 'ask', labels: [], status: 'idle' };
+
+describe('global permission-mode sync', () => {
+  it('never escalates a session sitting in explore, whoever conferred it', async () => {
+    // `explore` is structurally unreachable as a global default
+    // (ChatDefaultPermissionMode excludes it) and the picker never offers
+    // it — so a session in `explore` was put there deliberately.
+    const pinned: FakeSession[] = [
+      { id: 'deep-research', permissionMode: 'explore', labels: ['deep-research'], status: 'idle' },
+      { id: 'bot', permissionMode: 'explore', labels: ['bot', 'telegram'], status: 'idle' },
+      { id: 'expert-team', permissionMode: 'explore', labels: ['expert-team:review'], status: 'idle' },
+      { id: 'cron', permissionMode: 'explore', labels: ['automation', 'cron'], status: 'idle' },
+    ];
+    const h = harness([...pinned, CHAT]);
+
+    await h.effects.applySettingsRuntimeEffects(h.settings, { chatDefaults: { permissionMode: 'bypass' } } as never);
+
+    assert.deepEqual(
+      h.setCalls.map((c) => c.id).sort(),
+      ['chat'],
+      'only the ordinary chat may follow the new default; every explore-pinned session must be left alone',
+    );
+  });
+
+  it('still applies the new default to ordinary sessions', async () => {
+    const h = harness([CHAT, { id: 'chat2', permissionMode: 'execute', labels: [], status: 'idle' }]);
+    await h.effects.applySettingsRuntimeEffects(h.settings, { chatDefaults: { permissionMode: 'bypass' } } as never);
+    assert.deepEqual(h.setCalls.map((c) => c.id).sort(), ['chat', 'chat2']);
+    assert.ok(h.setCalls.every((c) => c.mode === 'bypass'));
+  });
+
+  it('leaves busy sessions to be reconciled later rather than mutating mid-run', async () => {
+    const h = harness([
+      { id: 'running', permissionMode: 'ask', labels: [], status: 'running' },
+      { id: 'waiting', permissionMode: 'ask', labels: [], status: 'waiting_for_user' },
+      CHAT,
+    ]);
+    await h.effects.applySettingsRuntimeEffects(h.settings, { chatDefaults: { permissionMode: 'bypass' } } as never);
+    assert.deepEqual(h.setCalls.map((c) => c.id), ['chat']);
+  });
+});

--- a/apps/desktop/src/main/settings-runtime-effects.ts
+++ b/apps/desktop/src/main/settings-runtime-effects.ts
@@ -90,6 +90,24 @@ export function createSettingsRuntimeEffects(
     const sessions = await runtime.listSessions();
     await Promise.all(sessions.map(async (session) => {
       if (session.permissionMode === mode) return;
+      // A conferred boundary is not the user's styling choice to overwrite.
+      //
+      // `explore` is structurally unreachable as a global default
+      // (`ChatDefaultPermissionMode` excludes it) and the picker never
+      // offers it, so a session sitting in `explore` was put there by a
+      // deliberate seed: Deep Research, a bot conversation, an expert-team
+      // review crew, a cron automation. Each one chose read-only as its
+      // security boundary. Flipping the global default is the user
+      // restyling their own chats; it must not silently dissolve a
+      // boundary they never set and cannot see from here.
+      //
+      // Only Deep Research was exempt before, by label — so bot,
+      // expert-team and cron sessions were all being escalated, and only
+      // bot self-healed (on its next inbound message).
+      if (session.permissionMode === 'explore') return;
+      // Kept alongside the check above: this one says "Deep Research is
+      // always exempt", which still holds if such a session is ever moved
+      // off `explore` by some other path.
       if (isDeepResearchSession(session.labels)) return;
       if (session.status === 'running' || session.status === 'waiting_for_user') return;
       try {

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -511,4 +511,13 @@ describe('changesBackendConfig', () => {
     assert.equal(changesBackendConfig({ llmConnectionSlug: 'a' }), true);
     assert.equal(changesBackendConfig({ model: 'm' }), true);
   });
+
+  test('permissionMode triggers, so a mode change is enforced and not merely stored', () => {
+    // The backend snapshots the header at construction and decides every
+    // tool call against that snapshot. Persisting a lower mode without
+    // rebuilding leaves the live session enforcing the OLD one — which is
+    // how the bot guard's re-pin to `explore` became advisory.
+    assert.equal(changesBackendConfig({ permissionMode: 'explore' }), true);
+    assert.equal(changesBackendConfig({ permissionMode: 'bypass' }), true);
+  });
 });

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -4102,7 +4102,18 @@ export function changesBackendConfig(patch: Partial<SessionHeader>): boolean {
     'model' in patch ||
     'thinkingLevel' in patch ||
     'cwd' in patch ||
-    'collaborationMode' in patch
+    'collaborationMode' in patch ||
+    // AiSdkBackend snapshots the header at construction and ToolRuntime
+    // reads `header.permissionMode` at every decision, so a mode change
+    // that does not rebuild the backend is persisted but NOT enforced —
+    // the live session keeps deciding with the old mode.
+    //
+    // `setPermissionMode` disposes the backend for exactly this reason.
+    // `updateSession` did not, so every other path that lowers a mode was
+    // advisory: notably the bot-incoming guard re-pinning a conversation
+    // to `explore`, which left an already-built `execute`/`bypass` backend
+    // serving the remote sender.
+    'permissionMode' in patch
   );
 }
 


### PR DESCRIPTION
Two ways a session's permission mode ended up different from the mode actually being **enforced**.

## 1. Flipping the global default escalated sessions that never chose it

The composer's picker is global — it writes `chatDefaults.permissionMode`, and `applySettingsRuntimeEffects` pushes that mode onto every existing session, exempting only Deep Research **by label**.

But four flows deliberately create sessions at `explore` as their read-only boundary:

| flow | created at | exempt before? |
|---|---|---|
| Deep Research | `explore` | ✅ |
| Bot conversations (prompted by a **remote sender**) | `explore` | ❌ |
| Expert-team review crews | `explore` | ❌ |
| Cron automations | `explore` | ❌ |

So changing the picker in an unrelated chat silently moved three of them to `execute`/`bypass`. Bot sessions re-pinned on their next inbound message; **expert-team and cron sessions never did.**

Now exempt by **mode** rather than by label: `explore` is structurally unreachable as a global default (`ChatDefaultPermissionMode` excludes it) and the picker never offers it, so a session sitting in `explore` was put there by a deliberate seed. That covers every current flow *and any future one* without anyone having to remember to add it — which is exactly what went wrong when only Deep Research was listed.

## 2. A lowered mode was persisted but not enforced

`AiSdkBackend` snapshots the header at construction and `ToolRuntime` reads `header.permissionMode` at **every** decision, so a mode change only takes effect if the backend is rebuilt. `setPermissionMode` disposes the backend for exactly this reason and says so in a comment.

`changesBackendConfig` — which is what `updateSession` consults — did not list `permissionMode`.

So every path that lowered a mode via `updateSession` was advisory. The one that matters: the bot-incoming guard re-pins a bound conversation to `explore` before handling a remote message. If that session already had a live `execute`/`bypass` backend (e.g. the user had opened it in the desktop app and sent a message), the re-pin wrote `explore` to storage and left the **permissive backend serving the remote sender**.

Adding `permissionMode` closes it for every caller, not just that one.

## Tests

New contract pins that no explore-pinned session is escalated, that ordinary sessions still follow the new default, and that busy (`running` / `waiting_for_user`) sessions are still left to reconcile later. `changesBackendConfig` gains a case for the mode.

## Gates

1208 core + 2667 runtime + 2900 desktop tests green · biome clean.

Second of the permission-review fixes; #1541 was the first.