### PR TITLE
fix(desktop): add OAuth account channels to Models story bridge

### DIFF
--- a/apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/storybook-baseline-contract.test.ts
@@ -429,6 +429,49 @@ describe('Storybook baseline contract', () => {
     assert.doesNotMatch(storyPath, /src\/renderer/, 'desktop Storybook stories must stay out of the renderer build tree');
   });
 
+  /**
+   * The Models page mounts `ModelOAuthSection`, which reads its card state
+   * straight off `window.maka` rather than through the `ConnectionsBridge`
+   * prop. A channel the story bridge does not carry rejects on mount, and the
+   * page still renders — every card frozen at its static "可用" label, the
+   * Claude card hidden behind an experimental gate that never answered, and no
+   * error banner. That is a screen the app never shows, which is exactly what
+   * apps/desktop/stories/FIDELITY.md exists to keep out of Storybook.
+   *
+   * The channel list is derived from the renderer so a new one goes red here
+   * instead of silently degrading the story. It is names only: a fixture that
+   * carries `claudeSubscription` but not its gate method still passes the
+   * derived half, so the gate is named separately below.
+   */
+  it('gives the Models settings page the subscription channels its cards read on mount', () => {
+    const oauthSection = readFileSync(
+      join(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'settings', 'provider-oauth-section.tsx'),
+      'utf8',
+    );
+    const channels = [...new Set([...oauthSection.matchAll(/window\.maka\.(\w+)/g)].map((match) => match[1]))].sort();
+    assert.ok(channels.length > 0, 'ModelOAuthSection must reach the preload bridge for its card state');
+
+    const story = readFileSync(
+      join(REPO_ROOT, 'apps', 'desktop', 'stories', 'settings', 'settings-pages.stories.tsx'),
+      'utf8',
+    );
+    const bridge = story.slice(story.indexOf('const makaBridge = {'), story.indexOf('const withSettingsBridge'));
+    assert.ok(bridge, 'settings-pages.stories.tsx must define the bridge its settings pages render against');
+
+    const missing = channels.filter((channel) => !new RegExp(`^  ${channel}:`, 'm').test(bridge));
+    assert.deepEqual(
+      missing,
+      [],
+      `the Models story bridge is missing channels ModelOAuthSection calls on mount:\n${missing.join('\n')}`,
+    );
+
+    assert.match(
+      bridge,
+      /isExperimentalEnabled/,
+      'the Claude card stays hidden until the experimental gate answers, so the story bridge must answer it',
+    );
+  });
+
   it('storyboards command palette and content search modal states before visual polish', () => {
     const storybookMain = readFileSync(join(REPO_ROOT, 'apps', 'desktop', '.storybook', 'main.ts'), 'utf8');
     const storyPath = join(REPO_ROOT, 'apps', 'desktop', 'stories', 'command-search.stories.tsx');

--- a/apps/desktop/stories/settings/settings-pages.stories.tsx
+++ b/apps/desktop/stories/settings/settings-pages.stories.tsx
@@ -592,6 +592,32 @@ const makaBridge = {
     },
   },
   connections: connectionsBridge,
+  // The OAuth cards on 模型 read their live state off window.maka rather than
+  // through the connections bridge, so the page needs these channels to render
+  // the state a user actually sees: without them the gate call rejects on
+  // mount, the Claude card never appears, and every other card stays at its
+  // static 可用 label. Each card's login modal has its own fixture in
+  // Product/Settings/Providers.
+  claudeSubscription: {
+    isExperimentalEnabled: async () => true,
+    getAccountState: async () => ({
+      runtimeState: 'authenticated',
+      profile: { email: 'claude@example.com' },
+    }),
+  },
+  openAiCodex: {
+    getAccountState: async () => ({
+      runtimeState: 'authenticated',
+      email: 'codex@example.com',
+      plan: 'Plus',
+    }),
+  },
+  githubCopilotSubscription: {
+    getAccountState: async () => ({ runtimeState: 'not_logged_in' }),
+  },
+  xaiOAuth: {
+    getAccountState: async () => ({ runtimeState: 'not_logged_in' }),
+  },
   app: {
     info: async () => ({
       platform: STORY_PLATFORM,


### PR DESCRIPTION
The Models settings page story rendered against a bridge with no subscription channels, so ModelOAuthSection's experimental-gate call rejected on mount: the Claude card never appeared and the other three stayed frozen at their static 可用 label, a screen the app never shows. I added claudeSubscription (including isExperimentalEnabled), openAiCodex, githubCopilotSubscription and xaiOAuth to that story bridge, plus a contract assertion that derives the required channel list from provider-oauth-section.tsx so a newly added channel fails loudly instead of quietly degrading the story. The remaining visual audit in the issue is left for after #1421 lands, since it rewrites the same form and fixtures. Fixes #1367.

I pushed this to my fork first and the project's own CI workflows pass on the commit.
