### PR TITLE
feat(runtime): reconstruct replayable agent graph timeline

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2,7 +2,7 @@
 
 # Maka Backend Architecture
 
-> This is the entry point for Maka Agent backend architecture. It does not repeat each deep-dive article. It establishes the system spine and helps readers reach the right chapter by engineering question. The current series covers Runtime, tools and context, durable Headless tasks, Self-check, and the AHE self-iteration boundary.
+> This is the entry point for Maka Agent backend architecture. It does not repeat each deep-dive article. It establishes the system spine and helps readers reach the right chapter by engineering question. The current series covers Runtime, tools and context, durable Headless tasks, Self-check, the AHE self-iteration boundary, and Graph scheduling over child Sessions.
 
 ## Architecture in one sentence
 
@@ -16,9 +16,13 @@ flowchart LR
     R --> L["Runtime Event Log"]
     R --> H["Headless Task Event Log"]
     T --> L
+    S --> G["Agent Graph Control Plane"]
+    G --> R
 
     L --> C["Provider Context Projection"]
     L --> V["Session / UI Read Models"]
+    L --> GP["Graph Records / Client Projection"]
+    GP --> G
     L -. "trajectory refs" .-> H
 
     H --> P["TaskRun Projection"]
@@ -27,9 +31,9 @@ flowchart LR
     E --> A["External Evolution Loop"]
 ```
 
-Read left to right. Entry points hand user intent to Runtime; model and tool execution produce facts; those facts are projected into model context, interactive views, durable task state, and evolution evidence. Providers, concrete storage implementations, and UI components are omitted so the diagram can preserve the backend spine shared by this series.
+Read left to right. Entry points hand user intent to Runtime; model and tool execution produce facts; those facts are projected into model context, interactive views, Graph scheduling inputs, durable task state, and evolution evidence. Graph coordinates child Sessions from durable schedule metadata but sends execution back through the same Runtime. Providers, concrete storage implementations, and UI components are omitted so the diagram can preserve the backend spine shared by this series.
 
-## A three-layer mental model
+## A four-layer mental model
 
 ### 1. Execution facts
 
@@ -37,19 +41,25 @@ An Agent Run produces model messages, Tool Calls, Tool Results, permission decis
 
 Relevant chapters: 1, 2, and 3.
 
-### 2. Durable tasks
+### 2. Coordinated Agent work
+
+When dependent Agent work benefits from dynamic topology, Graph treats child Sessions as operator containers, Session-inline AgentRuns as activations, and committed RuntimeEvents as reference-only records. SQLite owns schedule, topology, admission, and supervisor-wake metadata; Runtime keeps execution authority. The main Agent stays beside the graph to observe, intervene, and synthesize without gating normal record delivery.
+
+Relevant chapter: 7.
+
+### 3. Durable tasks
 
 When a task outlives one Turn or process, Headless uses an independent task identity, Task Event Log, and TaskRun projection to preserve progress across Attempts. Self-check provides bounded feedback inside that task loop but does not own final fact authority.
 
 Relevant chapters: 4 and 5.
 
-### 3. Evolution
+### 4. Evolution
 
 AHE organizes outcomes and traces from multiple TaskRuns into evolution evidence bound to target identity. It remains outside the interactive Runtime and advances system changes through a constrained change surface, falsifiable manifests, candidate evaluation, and rollback lineage.
 
 Relevant chapter: 6.
 
-## Six-chapter index
+## Seven-chapter index
 
 | Chapter | Core question | Implementation status | Read |
 |---|---|---|---|
@@ -59,6 +69,7 @@ Relevant chapter: 6.
 | 4. The Durable Task Loop | How does Maka continue a task that outlives a Turn, Run, or process? | Current + Target | [English](./docs/architecture/durable-task-loop-headless-draft.md) · [中文](./docs/architecture/durable-task-loop-headless-draft.zh-CN.md) |
 | 5. Self-Check Is Not Self-Trust | How can an Agent inspect and repair its work without turning self-report into authority? | Current + Target | [English](./docs/architecture/self-check-bounded-feedback-loop-draft.md) · [中文](./docs/architecture/self-check-bounded-feedback-loop-draft.zh-CN.md) |
 | 6. Self-Iteration Happens Outside the Runtime | How does Maka turn run experience into falsifiable and reversible system improvement? | Current + Target | [English](./docs/architecture/ahe-self-iteration-boundary-draft.md) · [中文](./docs/architecture/ahe-self-iteration-boundary-draft.zh-CN.md) |
+| 7. Graph Is a Schedule, Not a Second Runtime | How does Maka coordinate dynamic dependent Agent work while the main Agent supervises beside the data path? | Current | [English](./docs/architecture/agent-graph-stream-scheduling-draft.md) · [中文](./docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md) |
 
 **Current + Target** means the article covers verified implementation and visibly labeled target direction. It does not mean Target sections are implemented. The `implementation_status` and `last_verified` fields in each article's front matter are the more precise status source.
 
@@ -84,13 +95,17 @@ Read `4 → 5`, then revisit Chapter 2's rule that context pruning must not dele
 
 Read `1 → 4 → 5 → 6`. Chapter 6 depends on the Event Log, TaskRun projection, and authority boundaries established earlier.
 
+### Changing Graph, child Sessions, or multi-Agent scheduling
+
+Read `1 → 7`. Chapter 1 establishes RuntimeEvent and AgentRun authority; Chapter 7 explains how Graph projects those facts into records, binds operators to child Sessions, linearizes schedule and admission in SQLite, and returns control to the root supervisor Agent. Add `2 → 3` when changing how child output is retrieved or compacted.
+
 ## Code boundaries
 
 | Area | Primary responsibility |
 |---|---|
 | `packages/core` | Pure contracts for Session, Runtime Event, AgentRun, and permission |
-| `packages/storage` | File-backed stores for sessions, settings, and run ledgers |
-| `packages/runtime` | SessionManager, AgentRun, model adapters, tool execution, context, and recovery |
+| `packages/storage` | Durable stores for sessions, settings, run ledgers, and the SQLite metadata control plane |
+| `packages/runtime` | SessionManager, AgentRun, model adapters, tool execution, context, recovery, and Graph reconciliation |
 | `packages/headless` | TaskRun, Autonomous Loop, Self-check, result export, and AHE protocol |
 | `apps/desktop/src/main` | Electron main-process composition, IPC, and product-entry adapters |
 
@@ -100,7 +115,7 @@ The “code map” in each deep-dive article is the preferred implementation ent
 - [`docs/archive/runtime-v2-architecture-evolution.md`](./docs/archive/runtime-v2-architecture-evolution.md)
 - [`docs/archive/runtime-v2-implementation-notes.md`](./docs/archive/runtime-v2-implementation-notes.md)
 
-Those documents provide historical design context and implementation notes. The six chapters indexed here are the narrative entry point for current backend mechanisms.
+Those documents provide historical design context and implementation notes. The seven chapters indexed here are the narrative entry point for current backend mechanisms.
 
 ## Documentation layout
 

--- a/ARCHITECTURE.zh-CN.md
+++ b/ARCHITECTURE.zh-CN.md
@@ -2,7 +2,7 @@
 
 # Maka Backend Architecture
 
-> 这是 Maka Agent 后端架构的总入口。它不重复每篇专题文章，而是先给出系统主线，再帮助读者按问题快速找到对应章节。当前系列聚焦 Runtime、工具与上下文、Headless 长程任务、Self-check 和 AHE 自迭代边界。
+> 这是 Maka Agent 后端架构的总入口。它不重复每篇专题文章，而是先给出系统主线，再帮助读者按问题快速找到对应章节。当前系列聚焦 Runtime、工具与上下文、Headless 长程任务、Self-check、AHE 自迭代边界，以及建立在 child Session 之上的 Graph 调度。
 
 ## 一句话架构
 
@@ -16,9 +16,13 @@ flowchart LR
     R --> L["Runtime Event Log"]
     R --> H["Headless Task Event Log"]
     T --> L
+    S --> G["Agent Graph Control Plane"]
+    G --> R
 
     L --> C["Provider Context Projection"]
     L --> V["Session / UI Read Models"]
+    L --> GP["Graph Records / Client Projection"]
+    GP --> G
     L -. "trajectory refs" .-> H
 
     H --> P["TaskRun Projection"]
@@ -27,9 +31,9 @@ flowchart LR
     E --> A["External Evolution Loop"]
 ```
 
-从左向右读：入口把用户意图交给 Runtime；模型和工具执行产生事实；同一组事实随后被投影成模型上下文、交互界面、长程任务状态和演化证据。图中省略了 provider、具体存储实现和 UI 组件，只保留本系列文档共同解释的后端主线。
+从左向右读：入口把用户意图交给 Runtime；模型和工具执行产生事实；同一组事实随后被投影成模型上下文、交互界面、Graph 调度输入、长程任务状态和演化证据。Graph 从持久 schedule metadata 协调 child Session，但执行仍回到同一套 Runtime。图中省略了 provider、具体存储实现和 UI 组件，只保留本系列文档共同解释的后端主线。
 
-## 三层心智模型
+## 四层心智模型
 
 ### 1. 运行事实层
 
@@ -37,19 +41,25 @@ flowchart LR
 
 对应章节：第一章、第二章、第三章。
 
-### 2. 长程任务层
+### 2. Agent work 协调层
+
+当相互依赖的 Agent work 需要动态 topology 时，Graph 把 child Session 视为 operator 容器，把 Session-inline AgentRun 视为 activation，把已提交 RuntimeEvent 视为 reference-only record。SQLite 拥有 schedule、topology、admission 与 supervisor wake metadata，Runtime 继续拥有 execution authority。主 Agent 始终在图旁观察、干预和综合，但不阻塞正常 record delivery。
+
+对应章节：第七章。
+
+### 3. 长程任务层
 
 当任务长于一次 Turn 或一个进程时，Headless 通过独立的 Task identity、Task Event Log 和 TaskRun projection 保存跨 Attempt 的进度。Self-check 在这个任务循环内提供一次受限反馈，但不拥有最终事实 authority。
 
 对应章节：第四章、第五章。
 
-### 3. 演化层
+### 4. 演化层
 
 AHE 把多次 TaskRun 的结果和 trace 组织成带 target identity 的演化证据。它位于交互 Runtime 外部，通过受限 change surface、可证伪 manifest、candidate evaluation 和 rollback lineage 推进系统改进。
 
 对应章节：第六章。
 
-## 六章索引
+## 七章索引
 
 | 章节 | 核心问题 | 实现状态 | 阅读 |
 |---|---|---|---|
@@ -59,6 +69,7 @@ AHE 把多次 TaskRun 的结果和 trace 组织成带 target identity 的演化�
 | 4. The Durable Task Loop | 一个任务长于 Turn、Run 和进程时，Maka 如何持续推进？ | Current + Target | [中文](./docs/architecture/durable-task-loop-headless-draft.zh-CN.md) · [English](./docs/architecture/durable-task-loop-headless-draft.md) |
 | 5. Self-Check Is Not Self-Trust | Agent 如何检查和修复自己的工作，而不把自述变成 authority？ | Current + Target | [中文](./docs/architecture/self-check-bounded-feedback-loop-draft.zh-CN.md) · [English](./docs/architecture/self-check-bounded-feedback-loop-draft.md) |
 | 6. Self-Iteration Happens Outside the Runtime | Maka 如何把运行经验变成可证伪、可回滚的系统改进？ | Current + Target | [中文](./docs/architecture/ahe-self-iteration-boundary-draft.zh-CN.md) · [English](./docs/architecture/ahe-self-iteration-boundary-draft.md) |
+| 7. Graph Is a Schedule, Not a Second Runtime | Maka 如何协调动态依赖的 Agent work，同时让主 Agent 始终在 data path 旁监督？ | Current | [中文](./docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md) · [English](./docs/architecture/agent-graph-stream-scheduling-draft.md) |
 
 这里的 **Current + Target** 表示文章同时记录已验证实现与明确标注的目标方向，不表示 Target 部分已经落地。每篇文章 front matter 中的 `implementation_status` 和 `last_verified` 是更细的状态来源。
 
@@ -84,13 +95,17 @@ AHE 把多次 TaskRun 的结果和 trace 组织成带 target identity 的演化�
 
 按 `1 → 4 → 5 → 6` 阅读。第六章依赖前面建立的 Event Log、TaskRun projection 和 authority 边界。
 
+### 修改 Graph、child Session 或 multi-Agent scheduling
+
+按 `1 → 7` 阅读。第一章建立 RuntimeEvent 与 AgentRun authority；第七章解释 Graph 如何把这些事实投影成 record、把 operator 绑定到 child Session、在 SQLite 中 linearize schedule 与 admission，并把控制权交还 root supervisor Agent。如果改动涉及 child output 的读取或 compaction，再补 `2 → 3`。
+
 ## 代码边界
 
 | 区域 | 主要职责 |
 |---|---|
 | `packages/core` | Session、Runtime Event、AgentRun、permission 等纯 contract |
-| `packages/storage` | Session、settings、run ledger 等 file-backed store |
-| `packages/runtime` | SessionManager、AgentRun、模型适配、工具执行、上下文与恢复 |
+| `packages/storage` | Session、settings、run ledger 与 SQLite metadata control plane 等持久 store |
+| `packages/runtime` | SessionManager、AgentRun、模型适配、工具执行、上下文、恢复与 Graph reconciliation |
 | `packages/headless` | TaskRun、Autonomous Loop、Self-check、结果导出与 AHE protocol |
 | `apps/desktop/src/main` | Electron main-process composition、IPC 与产品入口适配 |
 
@@ -100,7 +115,7 @@ AHE 把多次 TaskRun 的结果和 trace 组织成带 target identity 的演化�
 - [`docs/archive/runtime-v2-architecture-evolution.md`](./docs/archive/runtime-v2-architecture-evolution.md)
 - [`docs/archive/runtime-v2-implementation-notes.md`](./docs/archive/runtime-v2-implementation-notes.md)
 
-这些文档提供历史设计背景和实现笔记；本页索引的六章是当前后端机制的叙事入口。
+这些文档提供历史设计背景和实现笔记；本页索引的七章是当前后端机制的叙事入口。
 
 ## 文档目录约定
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ This page is the authority map for Maka documentation. Code and contract tests r
 - [AHE target protocol and evidence export](./ahe-target-protocol.md)
 - [Skill catalog policy](./skill-catalog-policy.md)
 - [Agent Swarm](./agent-swarm.md)
+- [Agent Graph stream scheduling](./architecture/agent-graph-stream-scheduling-draft.md) ([中文](./architecture/agent-graph-stream-scheduling-draft.zh-CN.md))
 - [Expert teams runtime](./expert-team-runtime.md)
 - [IM 扫码接入 runtime architecture](./architecture/bot-onboarding-runtime.zh-CN.md)
 - [Backend architecture chapters](./architecture/)

--- a/docs/agent-swarm.md
+++ b/docs/agent-swarm.md
@@ -20,10 +20,14 @@ It is intentionally a structured-concurrency convenience over existing child
 | One specialist result, or the next task depends on the previous result | `agent_spawn` sequentially | The dependency is explicit and each result can refine the next prompt. |
 | Several finite, independent items with one final synthesis | `agent_swarm` | Bounded worker-pool execution, stable ordered results, and isolated failures. |
 | Durable ownership, task claiming, or worker communication | Agent Team | Members have roles, mailbox collaboration, and Task Ledger coordination. |
-| DAG dependencies, retry policies, arbitrary workflow resume, dynamic expansion, or distributed execution | Rive | Workflow state and recovery need a durable orchestration authority. |
+| Dynamic dependent Agent work supervised from the root conversation | Agent Graph | Child Sessions are operators, committed RuntimeEvents are records, and SQLite owns durable schedule and admission state. |
+| Explicit workflow steps, arbitrary workflow resume, or distributed execution | Rive | Workflow state and recovery need a dedicated workflow authority. |
 
 The main Agent should call Swarm deliberately. The runtime does not infer that a
 request is parallelizable and does not automatically fan work out.
+
+For the deeper boundary between foreground fan-out and durable dynamic
+scheduling, see [Graph Is a Schedule, Not a Second Runtime](./architecture/agent-graph-stream-scheduling-draft.md).
 
 ## Contract
 

--- a/docs/architecture/agent-graph-stream-scheduling-draft.md
+++ b/docs/architecture/agent-graph-stream-scheduling-draft.md
@@ -422,7 +422,7 @@ Graph can also reconstruct a single reference-only timeline across its control a
 - root Session AgentRuns that authored schedule decisions or delivered wake turns;
 - the committed child RuntimeEvent projection for every provisioned operator.
 
-The resulting event stream covers supervisor-turn start and termination, schedule commit and finish, operator provision, intent claim, current admission state, activation start, committed record, activation terminal, wake claim, wake attempt, wake settlement, and current wake state.
+The pageable event stream covers supervisor-turn start and termination, schedule commit and finish, operator provision, intent claim, activation start, committed record, activation terminal, wake claim, wake attempt, and wake settlement. The response returns current admission and wake state separately in page-level `currentState`; these mutable snapshots are not cursor-bearing historical events.
 
 Timeline events deliberately omit schedule instructions, finish reasons, child message content, and tool payloads. They retain the IDs, facets, source RuntimeEvent reference, and Run coordinates needed to answer questions such as:
 

--- a/docs/architecture/agent-graph-stream-scheduling-draft.md
+++ b/docs/architecture/agent-graph-stream-scheduling-draft.md
@@ -1,0 +1,593 @@
+---
+doc_id: architecture.agent-graph-stream-scheduling
+title: "Chapter 7: Graph Is a Schedule, Not a Second Runtime—Streaming Agent Work Under a Main-Agent Supervisor"
+language: en
+source_language: zh-CN
+counterpart: ./agent-graph-stream-scheduling-draft.zh-CN.md
+implementation_status: current
+document_status: draft
+translation_status: synced
+last_verified: 2026-07-28
+owners:
+  - maka-backend
+---
+
+# Chapter 7: Graph Is a Schedule, Not a Second Runtime—Streaming Agent Work Under a Main-Agent Supervisor
+
+> This chapter answers one question: how can Maka coordinate dependent, dynamically expanding Agent work as a graph without inventing another Agent runtime? Maka treats each child Session as an operator container, each Session-inline AgentRun as an activation, and each committed RuntimeEvent as a reference-only stream record. A SQLite control plane stores topology, schedule intent, admission, and supervisor wake state. The existing Session and Runtime ledgers still own execution facts. The main Agent stays beside the graph as an always-available supervisor; it observes and changes the schedule, but normal record delivery never waits for its approval. **Graph is a durable schedule over Runtime facts, not a second execution universe.**
+
+This chapter builds directly on Chapter 1. The Runtime Event Log remains the semantic authority for what an Agent did. Graph adds identities and projections that answer different questions: which child Session is one operator, which committed records flow to another operator, which work the supervisor requested, which intent was admitted exactly once, and when the root Agent should be woken to inspect a stable checkpoint.
+
+It is written for engineers changing Graph contracts, child Sessions, scheduling, recovery, or Desktop integration. It describes the implementation verified on 2026-07-28. The chapter does not describe arbitrary cyclic workflows, distributed execution, graph-wide resource optimization, or a visual workflow authoring system.
+
+## Start with work that changes shape while it runs
+
+Suppose a user asks Maka to review a cross-cutting change:
+
+1. one specialist inspects Runtime invariants;
+2. another inspects storage and recovery;
+3. their committed findings reveal that a Desktop inspection is also necessary;
+4. the main Agent asks a synthesis specialist to compare selected findings;
+5. the main Agent reads the authoritative child outputs and chooses the final result records.
+
+This is not merely a batch. Later work depends on facts produced by earlier work, and the useful topology is not fully known at the beginning. It is also not a reason to replace the Agent loop. Every specialist still needs an ordinary model/tool loop, permissions, history, context compaction, usage accounting, stop, recovery, and inspection.
+
+The useful abstraction is therefore:
+
+```text
+child Session              → operator container
+Session-inline AgentRun    → operator activation
+committed RuntimeEvent     → immutable stream record
+record visible over edge   → route
+deterministic input state  → readiness intent
+durable admission row      → exactly-once execution identity
+supervisor schedule update → control-plane decision
+```
+
+The graph layer coordinates those existing things. It does not duplicate them.
+
+## Conclusion first
+
+The current design rests on six boundaries:
+
+1. **Runtime remains the execution authority.** Graph does not introduce a GraphRun event ledger or a second model/tool loop.
+2. **A durable child Session is the operator boundary.** Follow-up activations reuse its runtime snapshot, history, lifecycle, usage, and product identity.
+3. **Only committed RuntimeEvents become graph records.** Partial chunks and process-local callbacks are never durable dataflow facts.
+4. **Readiness is a deterministic projection; admission is a SQLite decision.** Recomputing a runnable intent cannot execute it twice.
+5. **The main Agent supervises beside the data path.** Observation callbacks, Desktop invalidations, and supervisor turns may fail or retry without blocking record projection.
+6. **Schedule closure and runtime quiescence are different.** “Nothing runnable now” does not mean “the supervisor has finished the graph.”
+
+These boundaries let Graph reuse the hard parts Maka already has: Session creation and lifecycle, AgentRun identity, RuntimeEvent persistence, permission handling, context compaction, child-output inspection, usage and tool activity, Desktop conversation components, and restart recovery.
+
+## The identity model
+
+Graph deliberately keeps several identities instead of compressing them into a generic “node status.”
+
+| Identity | Meaning | Durable authority |
+|---|---|---|
+| Root Session | User-facing conversation whose main Agent supervises the graph | Session store |
+| Graph | Scheduling namespace derived from one root Session | SQLite Graph control plane |
+| Work | One supervisor-requested instruction and input frontier | Schedule update log |
+| Operator | Stable graph binding to one child Session | Operator provision |
+| Child Session | Reusable execution and product container for one operator | Session store and metadata control plane |
+| Activation | One Session-inline execution of that operator | AgentRun |
+| Turn / Run | Exact user-input and execution identities inside the child Session | Session and AgentRun ledgers |
+| RuntimeEvent | Canonical semantic execution fact | Runtime Event Log |
+| Record | Bounded Graph projection referencing one committed RuntimeEvent | Recomputed projection |
+| Route | Observation that a record is visible across one direct edge | Recomputed trace projection |
+| Readiness intent | Deterministic candidate derived from routes and policy | Recomputed readiness projection |
+| Claim | Durable admission of one intent to exact Session, Turn, and Run identities | SQLite Graph control plane |
+| Supervisor wake | Durable request to run a root-Agent checkpoint turn | SQLite Graph control plane |
+
+The most important hierarchy is:
+
+```text
+root Session
+└── graph
+    ├── schedule revisions
+    ├── operator
+    │   └── child Session
+    │       ├── activation / AgentRun
+    │       │   └── committed RuntimeEvents → graph records
+    │       └── later activation / AgentRun
+    ├── operator
+    │   └── child Session
+    └── admission claims and supervisor wakes
+```
+
+An operator is not an AgentRun. The stable operator-to-Session binding is what makes later follow-up work natural: the Session persists while each activation receives a fresh Turn and Run identity.
+
+## Two planes over one existing Runtime
+
+The implementation is easiest to understand as a control plane beside a data plane.
+
+```mermaid
+flowchart LR
+    U["User"] --> M["Root Session<br/>Main Agent supervisor"]
+
+    subgraph CP["SQLite Graph control plane"]
+        S["Schedule revisions<br/>add / stop / replace / finish"]
+        T["Monotonic topology<br/>operator provisions"]
+        C["Intent claims<br/>admission state"]
+        W["Supervisor wakes<br/>delivery attempts"]
+        RM["Bounded client projection"]
+    end
+
+    subgraph DP["Existing Session / Runtime data plane"]
+        O1["Operator A<br/>Child Session"]
+        O2["Operator B<br/>Child Session"]
+        A1["AgentRun activation"]
+        A2["AgentRun activation"]
+        L1["Runtime Event Log"]
+        L2["Runtime Event Log"]
+    end
+
+    M -->|"view / update tools"| S
+    S --> T
+    T --> O1
+    T --> O2
+    C --> A1
+    C --> A2
+    O1 --> A1 --> L1
+    O2 --> A2 --> L2
+    L1 -. "reference-only records and routes" .-> RM
+    L2 -. "reference-only records and routes" .-> RM
+    RM --> W
+    W -->|"new root turn"| M
+```
+
+The arrows between the control and data planes are typed boundaries:
+
+- provisioning atomically creates the child Session relationship and operator metadata;
+- claiming binds a deterministic intent to preallocated Turn and Run identities before execution;
+- Runtime executes through the ordinary Session-inline child path;
+- observation folds immutable RuntimeEvents back into Graph records and client projections;
+- a durable wake starts a normal root Session turn after a useful checkpoint.
+
+No Graph callback becomes the owner of model output, tool results, or terminal state.
+
+## Why a child Session is the operator container
+
+Earlier child-agent designs can put an execution under the parent Session and distinguish it only by a child AgentRun. That is enough for a short foreground call, but it is a poor operator boundary for long-lived Graph work.
+
+A linked child Session naturally reuses:
+
+- Session creation, stop, archive, and recovery;
+- a frozen subagent runtime snapshot, including profile, system prompt, tool surface, and permission ceiling;
+- multiple Session-inline AgentRuns for later follow-ups;
+- RuntimeEvent and message persistence;
+- context construction and compaction;
+- usage, tool-activity, and artifact accounting;
+- Desktop and TUI conversation inspection;
+- `agent_output` over an exact child Session and current Run;
+- future multi-client observation through the same Runtime host.
+
+The child stores durable lineage back to the root:
+
+```text
+parentSessionId
+spawnedBy.parentRunId
+spawnedBy.parentTurnId
+spawnedBy.toolCallId
+graph.graphId
+graph.workId
+graph.operatorId
+```
+
+The parent does not need a mutable array of child IDs. Reverse lookup and Graph topology are read-model concerns. Cross-Session provenance also stays out of `AgentRun.parentRunId`, allowing Runs inside the child Session to keep ordinary Session-inline history semantics.
+
+## From RuntimeEvent to stream record
+
+### Projection, not copying
+
+`readCommittedAgentGraphProjection()` reads immutable RuntimeEvents for every operator binding and emits bounded `AgentGraphRecord` values. A record carries identity, order, facets, supervisor signals, and a reference to the source Session, Run, and RuntimeEvent. It does not copy the full message, tool arguments, or tool result payload.
+
+This separation matters:
+
+- Graph can route and schedule from small stable values;
+- authoritative child output remains in the Runtime ledger;
+- access control and archival stay on the original resource;
+- a read model cannot silently become a competing event store.
+
+When the main Agent needs the actual answer behind a candidate record, it uses `agent_output` with the operator's `childSessionId` and `currentRunId`.
+
+### Commit is the stream boundary
+
+Only non-partial, immutable RuntimeEvents enter the Graph projection. Provider chunks and yielded `SessionEvent`s may update a best-effort client view, but they are not Graph facts. Terminal history is populated only by the authoritative RuntimeEvent fold because a stop race may still rewrite a yielded completion into an aborted terminal fact at the Runtime durability barrier.
+
+The rule is:
+
+> A fact may enter Graph only after the Runtime has committed the semantic event that Graph references.
+
+### Record facets and signals
+
+Records expose bounded facets such as message, thinking, error, tool call, tool dispatch, tool result, artifact update, permission request, permission decision, user-question request, transfer, usage, completed, failed, aborted, cancelled, and generic runtime fact.
+
+The same record may also carry supervisor-facing signals such as attention or terminal state. This is a meta-stream over the same record identity, not another fact. A supervisor signal cannot change what downstream operators receive.
+
+### Stable replay order
+
+Records have a deterministic total order:
+
+1. event time;
+2. Run creation time;
+3. operator identity;
+4. Run identity;
+5. committed event ordinal;
+6. RuntimeEvent identity;
+7. record identity.
+
+Each activation also links to its previous record. Replay validates one terminal transition per activation and rejects records after termination. The projection can therefore be rebuilt from Runtime ledgers after restart without treating callback arrival order as authority.
+
+## Topology and routing
+
+### A DAG of existing operator bindings
+
+The trace topology contains operators and directed edges. Validation rejects missing operators, self-loops, duplicate endpoints, and cycles, then derives a deterministic topological order.
+
+For each committed source record, the trace projection creates a reference-only route on every direct outgoing edge. The edge owns visibility, not readiness policy. A downstream adapter decides whether one visible route, a settled activation frontier, or an explicit supervisor selection is enough to start work.
+
+### Dynamic topology is monotonic
+
+The current product path supports monotonic addition:
+
+- `agent_id` work provisions a new child Session and new operator;
+- `operator_id` work creates a later activation on an existing operator;
+- input record producers determine edges into a newly provisioned operator;
+- provision identities, child Session identity, initial Turn, and initial Run are preallocated deterministically;
+- retry observes the existing provision or creates it once.
+
+The first version does not provide arbitrary edge deletion, node deletion, rewiring, or cycles. A supervisor can stop or supersede work, but historical topology and facts remain explainable.
+
+## Readiness is not admission
+
+The reusable Runtime primitives define two policy projections.
+
+### `map`
+
+`map` produces one deterministic intent for each routed record visible to the operator. With no input route, the operator reports an `input_route` wait.
+
+### `all_settled`
+
+`all_settled` names one immutable activation from every direct upstream operator. It waits for a missing or running activation, then produces one intent over the sealed inputs.
+
+The explicit activation frontier is essential. If a child Session later receives a follow-up activation, that new Run must not silently change the meaning of an already-declared join.
+
+Both policies produce deterministic intent IDs and readiness-context fingerprints. They do not start Runtime work. A supervisor can observe the same waiting or runnable projection, but is not consulted while it is derived.
+
+The current Desktop host profile does not install autonomous `map` or `all_settled` policies by default. Its main Agent explicitly advances the dynamic graph with `add_work` and committed `input_ids`. The policy primitives remain available to another host adapter without changing the execution runtime.
+
+## The supervisor schedule
+
+Graph Mode gives only the root Agent a compact control surface:
+
+- `view_agent_graph` reads durable schedule state, runtime state, readiness, waits, and bounded recent activity;
+- `update_agent_graph` appends one idempotent schedule decision containing `add_work`, `stop`, `finish`, or an allowed combination;
+- `agent_output` reads authoritative output from a selected child Session Run.
+
+Child Sessions never receive the Graph supervisor tools.
+
+### Revision-linearized intent
+
+Every schedule update records:
+
+- source root Session, Run, Turn, and tool call;
+- a stable update identity and fingerprint;
+- zero or more work additions;
+- zero or more stop decisions;
+- an optional finish decision;
+- a strictly increasing Graph revision and commit time.
+
+SQLite owns the revision order. A tool retry with the same source and content is idempotent. A conflicting reuse of identity fails instead of creating ambiguous control history.
+
+### Work and input frontiers
+
+One work item targets either a catalog `agent_id` or an existing `operator_id`. It includes an instruction, committed input record IDs, and optionally the work or activation that it replaces.
+
+Input IDs are not copied prompts. They are a durable frontier. The default scheduled prompt carries bounded record references—record, operator, activation, facets, and RuntimeEvent source—but not the upstream payload. A host may provide another prompt renderer. Work that needs semantic source content must put that content in the instruction or use an explicitly authorized Runtime retrieval path; an edge alone does not grant cross-Session payload access.
+
+### Stop, replace, and finish
+
+Stopping can target work or an activation. Work not yet admitted becomes cancelled; an executing child Session is stopped through the normal Runtime stop path; terminal executions remain historical facts.
+
+`replaces` makes supersession explicit instead of mutating an old work row.
+
+`finish` selects committed Graph record IDs and closes fresh admission. It cannot be combined with new work. Already-claimed work remains recoverable because a closure decision must not strand an execution whose exact Run identity was durably admitted.
+
+## Claim before execution
+
+Readiness and schedule reconciliation can be repeated many times. Exactly-once execution identity comes from the claim protocol:
+
+1. compute a deterministic intent and readiness-context fingerprint;
+2. render and fingerprint the execution prompt;
+3. preallocate target operator, child Session, Turn, and Run identities;
+4. conditionally claim against the expected schedule revision;
+5. conditionally advance admission from `claimed` to `executing`;
+6. call the existing Session-inline child execution primitive;
+7. treat AgentRun and RuntimeEvent ledgers as authority once the Run exists.
+
+If the process retries after the Run was created, `runClaimedAgentGraphIntent()` inspects or recovers that exact Run. It does not invoke the provider a second time. Claims are admission authority only; they do not compete with Runtime terminal facts.
+
+The child Session serializes its claimed Graph activations. Different operators may run concurrently, while two activations of the same Session retain ordinary per-Session ordering.
+
+## Reconciliation: drive until quiescent, then ask the supervisor
+
+The host coordinator owns a process-local single-flight driver for each root Graph. Durable rows, not the in-memory driver, remain restart authority.
+
+One reconciliation pass:
+
+1. reads schedule revisions, provisions, claims, AgentRuns, and committed RuntimeEvents;
+2. reconstructs monotonic topology and the current observation;
+3. applies stop and supersession decisions;
+4. provisions catalog-agent work that still lacks an operator;
+5. resolves scheduled work and any configured readiness intents;
+6. rejects or defers uncommitted inputs;
+7. claims and begins eligible activations against the current revision;
+8. dispatches different operators concurrently through child Sessions;
+9. folds new RuntimeEvents and repeats until quiescent, cancelled, stale, failed, or bounded by the activation limit.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Observe
+    Observe --> ApplyControl
+    ApplyControl --> Provision
+    Provision --> Resolve
+    Resolve --> Claim: eligible intent
+    Resolve --> Quiescent: no eligible intent
+    Claim --> Execute
+    Execute --> Observe: RuntimeEvent committed
+    Quiescent --> WakeSupervisor: useful dispatch or failure
+    WakeSupervisor --> Observe: supervisor adds work
+    WakeSupervisor --> Closed: supervisor finishes
+    Closed --> [*]
+```
+
+Quiescence is local to the current facts and policy. It means no additional activation is presently eligible. It does not mean the user task is complete. Only a durable `finish` update closes fresh Graph admission.
+
+Structural reconciliation also does not own resource permits or global fairness. Shared child-run capacity, provider backpressure, or cross-Graph prioritization belong to host admission layers around the dispatcher.
+
+## The main Agent stays beside the graph
+
+The main Agent is neither a node that every record must traverse nor a callback inside child execution. It is an external supervisor with three responsibilities:
+
+1. **Observe:** inspect compact schedule, topology, operator state, waits, failures, and candidate result records.
+2. **Control:** add dependent work, follow up an existing operator, stop or replace obsolete work, and close the schedule.
+3. **Synthesize:** read authoritative child outputs, select committed result records, and answer the user.
+
+This position preserves both autonomy and responsiveness. Operators can continue from durable control decisions while the root Agent remains a normal conversation participant. The user can inspect or stop the graph through the host without turning the supervisor into a data-delivery bottleneck.
+
+Observer callbacks are presentation-only and fire-and-forget. A broken Desktop listener or supervisor observation hook cannot fail an operator activation.
+
+## Durable supervisor wakes
+
+A useful checkpoint must eventually bring the main Agent back even if no user message arrives. The host therefore persists supervisor wakes in SQLite.
+
+A wake is keyed by Graph and client snapshot version. It progresses through:
+
+```text
+pending → running → delivered
+                  ↘ waiting_permission
+                  ↘ retryable_failed → running
+```
+
+For each delivery attempt, the host preallocates a root Turn identity and starts a normal root Session turn with an `agent_graph` origin. The prompt asks the main Agent to inspect the Graph, read child output when necessary, and either schedule more work or finish.
+
+“Prompt persisted” does not mean “wake delivered.” Delivery is complete only when the host observes the root AgentRun complete. A permission suspension is parked explicitly. After restart, the wake coordinator compares stored attempts with AgentRun facts, marks interrupted attempts retryable, and resumes only safe deliveries.
+
+The Session activity registry serializes this host-created turn with other root Session activity. Multiple clients can observe the same durable Session and Graph state without becoming scheduler owners.
+
+## Persistence and authority
+
+Graph uses SQLite as a workspace/session metadata control plane, not as a replacement for transcript or Runtime ledgers.
+
+| Data | Authority | Why |
+|---|---|---|
+| Child Session configuration and parent relation | Session storage plus metadata transaction | Product identity and frozen runtime snapshot |
+| Agent execution lifecycle | AgentRun ledger | Exact Turn/Run state and terminal semantics |
+| Messages, tools, permissions, usage, terminal facts | Runtime Event Log | Canonical interaction facts |
+| Schedule revisions | SQLite | Ordered, idempotent supervisor control decisions |
+| Operator provisions and topology relations | SQLite | Atomic child Session/operator identity |
+| Intent claims and admission state | SQLite | Revision-linearized exactly-once admission |
+| Supervisor wakes and attempts | SQLite | Recoverable root-turn delivery |
+| Graph records, routes, readiness, replay timeline | Deterministic projection | Rebuildable views over durable facts |
+| Desktop snapshot and terminal activity page | SQLite materialized read side | Bounded, efficient client reads |
+
+SQLite failure on an authoritative schedule, provision, claim, or wake operation is an error. The coordinator does not scan JSONL as a substitute Graph control plane.
+
+The materialized Desktop projection is different: it is derived state. An incremental projection commit may fail without invalidating Runtime or schedule authority. The coordinator marks the projection dirty, retries a best-effort rebuild at reconciliation boundaries, and also repairs before client reads. Successful rebuild clears the dirty state.
+
+## Three status planes must stay separate
+
+A client may observe all of the following at once:
+
+```text
+work.status                       = requested
+claim.admissionState              = executing
+operator.currentActivation.status = completed
+```
+
+This is not a contradiction.
+
+- Work status records supervisor intent and whether it was stopped or superseded.
+- Claim admission records whether one deterministic intent was admitted or cancelled.
+- Activation status records what Runtime actually did.
+
+Flattening them into one generic node state would erase causality. The bounded client read model instead derives a presentation status while retaining work, claims, control decisions, and Run references for inspection.
+
+## Reconstructing one replayable Graph timeline
+
+Graph can also reconstruct a single reference-only timeline across its control and data planes. `getTimeline()` joins:
+
+- one transactionally consistent SQLite snapshot of schedule updates, operator provisions, current admissions, and supervisor wakes with their attempts;
+- root Session AgentRuns that authored schedule decisions or delivered wake turns;
+- the committed child RuntimeEvent projection for every provisioned operator.
+
+The resulting event stream covers supervisor-turn start and termination, schedule commit and finish, operator provision, intent claim, current admission state, activation start, committed record, activation terminal, wake claim, wake attempt, wake settlement, and current wake state.
+
+Timeline events deliberately omit schedule instructions, finish reasons, child message content, and tool payloads. They retain the IDs, facets, source RuntimeEvent reference, and Run coordinates needed to answer questions such as:
+
+- Which supervisor turn created this work?
+- Which operator and child Session received it?
+- Which exact activation produced a candidate record?
+- Did the graph wake the supervisor before the final schedule decision?
+
+Reconstruction sorts by event time, then a stable event-kind rank and type-specific identity tie-break. The exposed `sequence` is a deterministic reconstruction order, not a claim that SQLite and Runtime ledgers share one physical commit sequence. Same-millisecond Runtime records preserve their committed ledger order.
+
+Pages default to 100 events and are capped at 256. The opaque cursor binds Graph, event identity, and event time; pages report total events plus omissions before and after the page.
+
+Coverage is explicit rather than implied. Runtime records are complete for the immutable ledgers read, but current SQLite schemas retain only the latest admission state and latest wake state, not every overwritten transition. Reconciliation-loop iterations are also not persisted as historical events. The timeline reports all three limitations:
+
+```text
+admission_transition_history_not_persisted
+supervisor_wake_transition_history_not_persisted
+reconcile_history_not_persisted
+```
+
+The timeline is therefore replayable and useful for diagnosis without pretending to be a new authority. Each event points back to the store that owns the underlying fact.
+
+## Desktop product wiring
+
+Desktop composes the current host-managed Graph profile:
+
+- Graph can be a Session orchestration mode or a one-turn override;
+- `/graph on`, `/graph off`, and `/graph <task>` expose those choices;
+- only a root Session receives `view_agent_graph`, `update_agent_graph`, and `agent_output`;
+- Electron main owns the coordinator, wake coordinator, SQLite store, Runtime adapter, and startup recovery;
+- renderer IPC exposes bounded snapshot, operator inspection, stop, and invalidation hints;
+- the Agent Graph panel shows aggregate state, visible operators, waits, selected results, and links to open child Sessions;
+- stopping the Graph aborts reconciliation and stops known child Sessions through Runtime;
+- startup first repairs interrupted Runtime state, then wakes and Graph schedules.
+
+Renderer invalidations are hints. A reconnecting client calls `getSnapshot()` and reads durable state; it does not replay process-local notifications as facts.
+
+The current panel is an operational view, not a node-and-edge authoring canvas. The main Agent remains the topology author through typed schedule updates.
+
+## End-to-end sequence
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant M as Main Agent
+    participant SQL as SQLite control plane
+    participant G as Graph coordinator
+    participant CS as Child Session operator
+    participant R as AgentRun / RuntimeEvent log
+    participant D as Desktop read model
+
+    U->>M: Graph-mode task
+    M->>SQL: update_agent_graph(add_work)
+    SQL-->>G: durable schedule revision
+    G->>SQL: provision operator + child Session relation
+    G->>SQL: claim intent with Turn/Run IDs
+    G->>CS: run claimed activation
+    CS->>R: ordinary model/tool execution
+    R-->>G: committed RuntimeEvents
+    G->>D: materialize records and operator state
+    G->>SQL: claim supervisor wake at checkpoint
+    SQL-->>M: host starts root supervisor Turn
+    M->>G: view_agent_graph
+    M->>R: agent_output(child Session, Run)
+    M->>SQL: add dependent work or finish(result record IDs)
+    SQL-->>D: closed schedule and selected results
+    M-->>U: synthesized answer
+```
+
+Notice that the child result does not travel through the supervisor callback. Runtime commits it first. Graph projects a reference. The main Agent later decides whether and when to read the authoritative payload.
+
+## Failure and recovery invariants
+
+The current implementation protects these invariants:
+
+- a schedule update is append-only, revision ordered, and idempotent by source identity;
+- operator provision is monotonic and retry-safe;
+- a provisioned operator always resolves to the same linked child Session;
+- one intent resolves to at most one claim and exact Turn/Run identity;
+- an existing claimed Run is observed or recovered, never blindly executed again;
+- records reference committed non-partial RuntimeEvents only;
+- callback and renderer failures cannot change Graph execution;
+- closing the schedule prevents fresh admission but does not abandon existing claims;
+- Graph stop retains durable schedule facts and historical Runtime facts;
+- startup recovery derives work from SQLite control rows and Runtime ledgers, not an in-memory registry;
+- a supervisor wake is delivered only after a completed root AgentRun;
+- a failed derived client projection can be rebuilt without changing authority.
+- the replay timeline never exposes child or schedule payloads and reports incomplete transition coverage explicitly.
+
+These invariants are more important than the shape of any one UI or prompt. New host adapters must preserve them.
+
+## Current limits and non-goals
+
+The current Graph should not be mistaken for a general distributed stream processor.
+
+- Topology is a directed acyclic graph with monotonic additions; arbitrary deletion, rewiring, and cycles are not implemented.
+- Desktop advances dependent work through explicit supervisor schedule updates by default; automatic policy-driven topology is not silently inferred.
+- `map` and `all_settled` are structural readiness primitives, not a full windowing, watermark, keyed-state, or backpressure system.
+- The structural scheduler does not own global resource permits, fairness, provider rate limits, or distributed leases.
+- Quiescence is not graph completion; `finish` is an explicit supervisor decision.
+- The read model is bounded and reference-only. Full child content requires the authoritative Runtime read path.
+- The Desktop panel is an inspection and stop surface, not a visual graph editor.
+- The coordinator exposes a paginated replay timeline, but Desktop IPC and the current Agent Graph panel do not yet render it as an interactive chronological visualization.
+- Admission and wake rows currently expose only their latest state to timeline reconstruction, and reconcile-loop history is not persisted.
+
+These are deliberate boundaries. They keep Graph useful without moving workflow semantics, resource management, or product presentation into the Agent runtime.
+
+## Graph, Swarm, Agent Team, and Rive
+
+The four mechanisms solve different coordination problems.
+
+| Need | Mechanism | Ownership model |
+|---|---|---|
+| Finite independent fan-out followed by one synthesis | Agent Swarm | One foreground tool call owns a bounded worker pool |
+| One linked specialist execution or follow-up | `agent_spawn` / child Session | Parent Agent owns explicit delegation |
+| Roles, mailbox collaboration, and Task Ledger coordination | Agent Team | Team members own durable collaboration state |
+| Dynamic dependent Agent work supervised from a root conversation | Agent Graph | SQLite schedule/control plane over child Sessions and Runtime records |
+| Explicit workflow steps, arbitrary resume policy, or distributed workflow authority | Rive | Workflow runtime owns workflow state |
+
+Graph occupies the space between foreground fan-out and a separate workflow runtime. It is dynamic and durable enough to coordinate dependent Agent work, while retaining the Session Runtime as the only execution universe.
+
+## Code-reading map
+
+Read the implementation in this order:
+
+1. `packages/core/src/orchestration.ts` and `graph-command.ts`: Session and one-turn Graph mode.
+2. `packages/runtime/src/graph-mode.ts`: the main-Agent supervisor contract.
+3. `packages/core/src/agent-graph-schedule.ts`: work, stop, finish, revisions, and store protocol.
+4. `packages/core/src/agent-graph-topology.ts`: monotonic operator provision.
+5. `packages/runtime/src/stream-graph-projection.ts`: RuntimeEvent-to-record projection and replay.
+6. `packages/runtime/src/stream-graph-trace.ts`: topology validation and reference-only routes.
+7. `packages/runtime/src/stream-graph-readiness.ts`: `map` and sealed `all_settled` readiness.
+8. `packages/core/src/agent-graph-control.ts` and `packages/runtime/src/stream-graph-admission.ts`: durable intent claims.
+9. `packages/runtime/src/stream-graph-dispatch.ts`: structural drive-to-quiescence loop.
+10. `packages/runtime/src/stream-graph-schedule-reconcile.ts`: schedule, dynamic provision, stop, claim, and dispatch convergence.
+11. `packages/runtime/src/session-manager.ts`: child Session provision and claimed activation execution.
+12. `packages/runtime/src/stream-graph-coordinator.ts`: host-owned single-flight lifecycle, client projection repair, and root-only timeline access.
+13. `packages/runtime/src/agent-graph-timeline.ts`: reference-only control/data-plane reconstruction, stable order, coverage, and pagination.
+14. `packages/runtime/src/agent-graph-supervisor-wake.ts`: durable return path to the root Agent.
+15. `packages/storage/src/sqlite-session-metadata-schema.ts` and `sqlite-session-metadata-store.ts`: Graph control-plane transactions and timeline metadata snapshot.
+16. `apps/desktop/src/main/main.ts`, `agent-graph-ipc-main.ts`, and `apps/desktop/src/renderer/agent-graph-panel.tsx`: product composition and bounded UI.
+
+The most relevant contract tests are colocated under:
+
+- `packages/runtime/src/__tests__/stream-graph-*.test.ts`
+- `packages/runtime/src/__tests__/agent-graph-timeline.test.ts`
+- `packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts`
+- `packages/runtime/src/__tests__/session-manager.test.ts`
+- `packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts`
+- `packages/storage/src/__tests__/agent-graph-timeline-metadata.test.ts`
+- `apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts`
+
+## Summary
+
+Maka Graph starts from a stream-processing observation:
+
+```text
+subagent work   behaves like an operator
+Agent messages behave like stream records
+dependencies   behave like routes and input frontiers
+coordination   behaves like scheduling over a graph
+```
+
+The implementation makes that observation concrete without rewriting the Agent runtime. Child Sessions provide stable operator containers. AgentRuns provide activations. RuntimeEvents provide immutable facts. Deterministic projections provide records, routes, and readiness. SQLite provides revision-linearized schedule, topology, admission, client materialization, and supervisor wake state. Desktop provides a host and an operational view.
+
+The main Agent remains the distinctive part of the design. It stays beside the graph: available to the user, able to inspect any operator, free to add or stop work, and responsible for selecting and synthesizing the final records. The data path can advance without waiting for model approval, while judgment remains in the conversation where the user can see and influence it.
+
+That is the architectural promise: **reuse one trustworthy Runtime, add a durable Graph control plane, and keep the supervising Agent close enough to understand and change the schedule without becoming its bottleneck.**

--- a/docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md
+++ b/docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md
@@ -422,7 +422,7 @@ Graph 还可以跨 control plane 与 data plane 重建一条统一的 reference-
 - 创建 schedule decision 或执行 wake turn 的 root Session AgentRuns；
 - 每个 provisioned operator 的 committed child RuntimeEvent projection。
 
-最终 event stream 覆盖 supervisor-turn start/termination、schedule commit/finish、operator provision、intent claim、current admission state、activation start、committed record、activation terminal、wake claim、wake attempt、wake settlement 和 current wake state。
+可分页 event stream 覆盖 supervisor-turn start/termination、schedule commit/finish、operator provision、intent claim、activation start、committed record、activation terminal、wake claim、wake attempt 和 wake settlement。Response 会在 page-level `currentState` 中单独返回 current admission 与 wake state；这些 mutable snapshot 不是携带 cursor 的 historical event。
 
 Timeline event 有意不暴露 schedule instruction、finish reason、child message content 或 tool payload，只保留回答以下问题所需的 ID、facet、source RuntimeEvent reference 与 Run coordinate：
 

--- a/docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md
+++ b/docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md
@@ -1,0 +1,593 @@
+---
+doc_id: architecture.agent-graph-stream-scheduling
+title: "第七章：Graph 是调度，不是第二套 Runtime——主 Agent 监督下的流式 Agent Work"
+language: zh-CN
+source_language: zh-CN
+counterpart: ./agent-graph-stream-scheduling-draft.md
+implementation_status: current
+document_status: draft
+translation_status: synced
+last_verified: 2026-07-28
+owners:
+  - maka-backend
+---
+
+# 第七章：Graph 是调度，不是第二套 Runtime——主 Agent 监督下的流式 Agent Work
+
+> 本章回答一个问题：Maka 如何把相互依赖、运行中动态展开的 Agent work 组织成图，同时不再发明一套 Agent runtime？Maka 把每个 child Session 视为 operator 容器，把每次 Session-inline AgentRun 视为 activation，把每个已提交 RuntimeEvent 视为 reference-only stream record。SQLite control plane 保存 topology、schedule intent、admission 和 supervisor wake；已有的 Session 与 Runtime ledger 继续拥有运行事实。主 Agent 始终在图旁担任 supervisor：它观察和修改 schedule，但正常 record delivery 不等待它批准。**Graph 是建立在 Runtime 事实之上的持久调度，不是第二个运行宇宙。**
+
+本章直接建立在第一章之上。Runtime Event Log 仍然是“Agent 实际做了什么”的语义 authority。Graph 只是增加了一组 identity 和 projection，用来回答另外几类问题：哪个 child Session 是一个 operator、哪些已提交 record 会流向另一个 operator、supervisor 请求了哪些 work、哪个 intent 被精确 admission 一次，以及何时应该唤醒 root Agent 检查一个稳定 checkpoint。
+
+本文面向修改 Graph contract、child Session、调度、恢复或 Desktop 接线的工程师，描述截至 2026-07-28 已验证的实现。它不描述任意有环 workflow、分布式执行、图级资源优化，也不把当前实现说成可视化 workflow authoring system。
+
+## 从运行中才逐渐显形的工作开始
+
+假设用户让 Maka review 一个跨层改动：
+
+1. 一个 specialist 检查 Runtime invariant；
+2. 另一个 specialist 检查 storage 与 recovery；
+3. 两者提交的 findings 暴露出还需要一次 Desktop 检查；
+4. 主 Agent 再让一个 synthesis specialist 对比选中的 findings；
+5. 主 Agent 读取权威 child output，并选择最终 result records。
+
+这不只是一个 batch。后续 work 依赖前面产生的事实，而且有用的 topology 在一开始并不完全已知。但这也不是替换 Agent loop 的理由：每个 specialist 仍然需要普通的 model/tool loop、permission、history、context compaction、usage accounting、stop、recovery 和 inspection。
+
+因此真正有用的抽象是：
+
+```text
+child Session              → operator 容器
+Session-inline AgentRun    → operator activation
+已提交 RuntimeEvent        → immutable stream record
+record 沿 edge 可见         → route
+确定性的 input state       → readiness intent
+持久 admission row         → exactly-once execution identity
+supervisor schedule update → control-plane decision
+```
+
+Graph layer 只协调这些既有对象，不复制它们。
+
+## 先说结论
+
+当前设计建立在六条边界上：
+
+1. **Runtime 继续拥有执行 authority。** Graph 不引入 GraphRun event ledger，也不复制 model/tool loop。
+2. **持久 child Session 是 operator 边界。** 后续 activation 复用它的 runtime snapshot、history、lifecycle、usage 和产品 identity。
+3. **只有已提交 RuntimeEvent 才能成为 Graph record。** partial chunk 和进程内 callback 永远不是持久 dataflow fact。
+4. **Readiness 是确定性 projection，admission 是 SQLite decision。** 重算 runnable intent 不会把同一工作执行两次。
+5. **主 Agent 在 data path 旁监督。** observation callback、Desktop invalidation 和 supervisor turn 可以失败或重试，但不能阻塞 record projection。
+6. **Schedule closure 与 runtime quiescence 是两回事。** “此刻没有 runnable work”不等于“supervisor 已完成 Graph”。
+
+这些边界让 Graph 直接复用 Maka 已经解决的困难部分：Session 创建与生命周期、AgentRun identity、RuntimeEvent 持久化、permission、context compaction、child-output inspection、usage 和 tool activity、Desktop conversation component，以及重启恢复。
+
+## Identity 模型
+
+Graph 有意保留多种 identity，而不把它们压扁成一个泛化的“node status”。
+
+| Identity | 含义 | 持久 authority |
+|---|---|---|
+| Root Session | 用户面对的会话，其主 Agent 监督 Graph | Session store |
+| Graph | 由一个 root Session 派生的调度 namespace | SQLite Graph control plane |
+| Work | 一条 supervisor instruction 与 input frontier | Schedule update log |
+| Operator | 到一个 child Session 的稳定 Graph binding | Operator provision |
+| Child Session | 一个 operator 可复用的执行与产品容器 | Session store 与 metadata control plane |
+| Activation | 该 operator 的一次 Session-inline execution | AgentRun |
+| Turn / Run | Child Session 内精确的输入与执行 identity | Session 与 AgentRun ledger |
+| RuntimeEvent | canonical semantic execution fact | Runtime Event Log |
+| Record | 引用一个已提交 RuntimeEvent 的有界 Graph projection | 可重建 projection |
+| Route | Record 沿一条 direct edge 对下游可见 | 可重建 trace projection |
+| Readiness intent | 由 route 和 policy 确定性派生的候选 | 可重建 readiness projection |
+| Claim | 把一个 intent 持久 admission 到精确 Session、Turn、Run | SQLite Graph control plane |
+| Supervisor wake | 请求运行一次 root-Agent checkpoint turn | SQLite Graph control plane |
+
+最重要的层级是：
+
+```text
+root Session
+└── graph
+    ├── schedule revisions
+    ├── operator
+    │   └── child Session
+    │       ├── activation / AgentRun
+    │       │   └── committed RuntimeEvents → graph records
+    │       └── later activation / AgentRun
+    ├── operator
+    │   └── child Session
+    └── admission claims and supervisor wakes
+```
+
+Operator 不是 AgentRun。稳定的 operator-to-Session binding 才让 follow-up 自然成立：Session 保持不变，每次 activation 获得新的 Turn 与 Run identity。
+
+## 同一套 Runtime 上的两个 plane
+
+最容易理解当前实现的方法，是把它看成 data plane 旁边的一层 control plane。
+
+```mermaid
+flowchart LR
+    U["User"] --> M["Root Session<br/>Main Agent supervisor"]
+
+    subgraph CP["SQLite Graph control plane"]
+        S["Schedule revisions<br/>add / stop / replace / finish"]
+        T["Monotonic topology<br/>operator provisions"]
+        C["Intent claims<br/>admission state"]
+        W["Supervisor wakes<br/>delivery attempts"]
+        RM["Bounded client projection"]
+    end
+
+    subgraph DP["Existing Session / Runtime data plane"]
+        O1["Operator A<br/>Child Session"]
+        O2["Operator B<br/>Child Session"]
+        A1["AgentRun activation"]
+        A2["AgentRun activation"]
+        L1["Runtime Event Log"]
+        L2["Runtime Event Log"]
+    end
+
+    M -->|"view / update tools"| S
+    S --> T
+    T --> O1
+    T --> O2
+    C --> A1
+    C --> A2
+    O1 --> A1 --> L1
+    O2 --> A2 --> L2
+    L1 -. "reference-only records and routes" .-> RM
+    L2 -. "reference-only records and routes" .-> RM
+    RM --> W
+    W -->|"new root turn"| M
+```
+
+Control plane 与 data plane 之间的箭头都是 typed boundary：
+
+- provision 把 child Session relation 与 operator metadata 原子创建；
+- claim 在执行前，把确定性 intent 绑定到预分配的 Turn 与 Run identity；
+- Runtime 通过普通的 Session-inline child path 执行；
+- observation 把 immutable RuntimeEvent fold 回 Graph record 与 client projection；
+- durable wake 在有价值的 checkpoint 后启动一次普通 root Session turn。
+
+任何 Graph callback 都不会成为 model output、tool result 或 terminal state 的 owner。
+
+## 为什么 child Session 是 operator 容器
+
+较早的 child-agent 设计可以把执行直接放在 parent Session 下，只用一个 child AgentRun 区分它。这足够支撑短暂的 foreground call，却不是长寿命 Graph work 的良好 operator 边界。
+
+Linked child Session 可以自然复用：
+
+- Session 创建、停止、归档与恢复；
+- 冻结的 subagent runtime snapshot，包括 profile、system prompt、tool surface 和 permission ceiling；
+- 后续 follow-up 所需的多次 Session-inline AgentRun；
+- RuntimeEvent 与 message 持久化；
+- context 构造与 compaction；
+- usage、tool activity 与 artifact accounting；
+- Desktop 与 TUI 的会话检查组件；
+- 基于精确 child Session 和 current Run 的 `agent_output`；
+- 未来通过同一 Runtime host 实现的多 client 观察。
+
+Child 会持久保存回到 root 的 lineage：
+
+```text
+parentSessionId
+spawnedBy.parentRunId
+spawnedBy.parentTurnId
+spawnedBy.toolCallId
+graph.graphId
+graph.workId
+graph.operatorId
+```
+
+Parent 不需要维护可变 child ID 数组。反向查询与 Graph topology 是 read-model concern。Cross-Session provenance 也不会塞进 `AgentRun.parentRunId`，所以 child Session 内的 Runs 仍然保留普通 Session-inline history semantics。
+
+## 从 RuntimeEvent 到 stream record
+
+### Projection，而不是复制
+
+`readCommittedAgentGraphProjection()` 读取每个 operator binding 的 immutable RuntimeEvents，产生有界的 `AgentGraphRecord`。Record 携带 identity、order、facet、supervisor signal，以及到 source Session、Run、RuntimeEvent 的引用；它不复制完整 message、tool arguments 或 tool result payload。
+
+这层分离带来几个结果：
+
+- Graph 可以用小而稳定的值做 route 与 schedule；
+- 权威 child output 仍留在 Runtime ledger；
+- access control 与 archive 继续附着在原始 resource 上；
+- read model 不会悄悄变成竞争性的 event store。
+
+主 Agent 需要读取某个 candidate record 背后的真实答案时，使用 operator 的 `childSessionId` 和 `currentRunId` 调用 `agent_output`。
+
+### Commit 是 stream boundary
+
+只有 non-partial、immutable RuntimeEvent 才进入 Graph projection。Provider chunk 与已 yield 的 `SessionEvent` 可以更新 best-effort client view，但不是 Graph fact。Terminal history 只由 authoritative RuntimeEvent fold 写入，因为 stop race 仍可能在 Runtime durability barrier 把已 yield 的 completion 改写为 aborted terminal fact。
+
+规则是：
+
+> 只有当 Runtime 已提交 Graph 所引用的 semantic event，该事实才能进入 Graph。
+
+### Record facet 与 signal
+
+Record 暴露有界 facet，例如 message、thinking、error、tool call、tool dispatch、tool result、artifact update、permission request、permission decision、user-question request、transfer、usage、completed、failed、aborted、cancelled 和 generic runtime fact。
+
+同一 record 还可以带 attention 或 terminal 等 supervisor-facing signal。它们是同一 record identity 上的 meta-stream，不是第二份事实。Supervisor signal 不能改变下游 operator 收到什么。
+
+### 稳定 replay 顺序
+
+Record 使用确定性的 total order：
+
+1. event time；
+2. Run creation time；
+3. operator identity；
+4. Run identity；
+5. committed event ordinal；
+6. RuntimeEvent identity；
+7. record identity。
+
+每个 activation 还链接前一个 record。Replay 验证每个 activation 只有一次 terminal transition，并拒绝终止后的 record。因此重启后可以从 Runtime ledger 重建 projection，而不把 callback arrival order 当成 authority。
+
+## Topology 与 routing
+
+### Existing operator binding 组成的 DAG
+
+Trace topology 包含 operator 与 directed edge。校验会拒绝缺失 operator、self-loop、重复 endpoint 和 cycle，再派生确定性 topological order。
+
+对每个已提交 source record，trace projection 都会在每条 direct outgoing edge 上创建 reference-only route。Edge 只拥有 visibility，不拥有 readiness policy。下游 adapter 决定一条 visible route、一个 settled activation frontier，还是 supervisor 显式选择，足以启动 work。
+
+### 动态 topology 只做 monotonic add
+
+当前产品路径支持单调增加：
+
+- `agent_id` work provision 一个新 child Session 与新 operator；
+- `operator_id` work 在已有 operator 上创建后续 activation；
+- input record 的 producer 决定新 operator 的入边；
+- provision、child Session、initial Turn 和 initial Run identity 都被确定性预分配；
+- retry 要么观察到已有 provision，要么只创建一次。
+
+首版不支持任意删边、删点、rewire 或 cycle。Supervisor 可以 stop 或 supersede work，但历史 topology 与事实保持可解释。
+
+## Readiness 不是 admission
+
+可复用 Runtime primitive 定义了两种 policy projection。
+
+### `map`
+
+`map` 对 operator 可见的每条 routed record 产生一个确定性 intent。没有 input route 时，operator 报告 `input_route` wait。
+
+### `all_settled`
+
+`all_settled` 为每个 direct upstream operator 指定一个 immutable activation。它等待 activation 出现并结束，然后在 sealed inputs 上产生一个 intent。
+
+显式 activation frontier 很关键。如果同一个 child Session 后来执行 follow-up activation，新 Run 不能悄悄改变已声明 join 的含义。
+
+两种 policy 都只产生确定性 intent ID 与 readiness-context fingerprint，不启动 Runtime work。Supervisor 可以观察相同的 waiting/runnable projection，但 readiness 派生过程不需要它批准。
+
+当前 Desktop host profile 默认不安装自动 `map` 或 `all_settled` policy。主 Agent 通过 `add_work` 与已提交 `input_ids` 显式推进动态图。Policy primitives 可以被其它 host adapter 使用，而不需要修改 execution runtime。
+
+## Supervisor schedule
+
+Graph Mode 只给 root Agent 一组紧凑 control surface：
+
+- `view_agent_graph` 读取持久 schedule state、runtime state、readiness、wait 与有界 recent activity；
+- `update_agent_graph` 追加一条 idempotent schedule decision，包含 `add_work`、`stop`、`finish` 或允许的组合；
+- `agent_output` 读取选定 child Session Run 的权威输出。
+
+Child Session 永远不会获得 Graph supervisor tools。
+
+### Revision-linearized intent
+
+每条 schedule update 记录：
+
+- source root Session、Run、Turn 和 tool call；
+- stable update identity 与 fingerprint；
+- 零到多个 work addition；
+- 零到多个 stop decision；
+- 可选 finish decision；
+- 严格递增的 Graph revision 与 commit time。
+
+SQLite 拥有 revision order。同 source 与内容的 tool retry 是幂等的；冲突 identity reuse 会失败，而不是产生含糊 control history。
+
+### Work 与 input frontier
+
+一个 work item 只会指向 catalog `agent_id` 或已有 `operator_id` 之一，并携带 instruction、已提交 input record IDs，以及可选的被替换 work 或 activation。
+
+Input IDs 不是复制出来的 prompt，而是 durable frontier。默认 scheduled prompt 只携带有界 record reference——record、operator、activation、facet 与 RuntimeEvent source——不会复制 upstream payload。Host 可以提供其它 prompt renderer。真正需要 semantic source content 的 work，必须把内容写入 instruction，或使用显式授权的 Runtime retrieval path；edge 本身不授予 cross-Session payload access。
+
+### Stop、replace 与 finish
+
+Stop 可以指向 work 或 activation。尚未 admission 的 work 变成 cancelled；正在执行的 child Session 通过普通 Runtime stop path 停止；已终止执行继续作为历史事实存在。
+
+`replaces` 显式表达 supersession，而不是修改旧 work row。
+
+`finish` 选择已提交 Graph record IDs，并关闭 fresh admission。它不能与新 work 同时提交。已经 claim 的 work 仍然可恢复，因为 closure decision 不能把一个已经持久 admission、拥有精确 Run identity 的执行遗弃。
+
+## 先 claim，再执行
+
+Readiness 与 schedule reconciliation 可以重复计算很多次。Exactly-once execution identity 来自 claim protocol：
+
+1. 计算确定性 intent 与 readiness-context fingerprint；
+2. render 并 fingerprint execution prompt；
+3. 预分配 target operator、child Session、Turn 与 Run identity；
+4. 在 expected schedule revision 上 conditional claim；
+5. conditional 把 admission 从 `claimed` 推进到 `executing`；
+6. 调用已有 Session-inline child execution primitive；
+7. 一旦 Run 存在，就以 AgentRun 与 RuntimeEvent ledger 为 authority。
+
+如果 Run 创建后进程重试，`runClaimedAgentGraphIntent()` 会检查或恢复那个精确 Run，不会再次调用 provider。Claim 只是 admission authority，不与 Runtime terminal fact 竞争。
+
+Child Session 会串行化自己的 claimed Graph activation。不同 operator 可以并发，同一 Session 的两个 activation 仍遵守普通 per-Session order。
+
+## Reconciliation：推进到 quiescent，再请 supervisor 判断
+
+Host coordinator 为每个 root Graph 维护一个进程内 single-flight driver。持久 row，而不是这个内存 driver，仍然是 restart authority。
+
+一次 reconciliation 会：
+
+1. 读取 schedule revision、provision、claim、AgentRun 与已提交 RuntimeEvent；
+2. 重建 monotonic topology 与当前 observation；
+3. 应用 stop 与 supersession decision；
+4. 为尚无 operator 的 catalog-agent work 做 provision；
+5. 解析 scheduled work 与已配置 readiness intent；
+6. 拒绝或 defer 未提交 input；
+7. 在当前 revision 上 claim 并 begin eligible activation；
+8. 通过 child Session 并发 dispatch 不同 operator；
+9. fold 新 RuntimeEvent，并重复直到 quiescent、cancelled、stale、failed 或达到 activation bound。
+
+```mermaid
+stateDiagram-v2
+    [*] --> Observe
+    Observe --> ApplyControl
+    ApplyControl --> Provision
+    Provision --> Resolve
+    Resolve --> Claim: eligible intent
+    Resolve --> Quiescent: no eligible intent
+    Claim --> Execute
+    Execute --> Observe: RuntimeEvent committed
+    Quiescent --> WakeSupervisor: useful dispatch or failure
+    WakeSupervisor --> Observe: supervisor adds work
+    WakeSupervisor --> Closed: supervisor finishes
+    Closed --> [*]
+```
+
+Quiescence 只描述当前事实与 policy：此刻没有更多 activation eligible。它不表示用户任务完成。只有持久 `finish` update 才会关闭 fresh Graph admission。
+
+Structural reconciliation 也不拥有 resource permit 或 global fairness。Shared child-run capacity、provider backpressure 与 cross-Graph priority 属于 dispatcher 外围的 host admission layer。
+
+## 主 Agent 始终在图旁
+
+主 Agent 既不是每条 record 必经的 node，也不是 child execution 内部 callback。它是 external supervisor，承担三类职责：
+
+1. **Observe：**检查紧凑 schedule、topology、operator state、wait、failure 与 candidate result record。
+2. **Control：**添加 dependent work、follow up 已有 operator、stop/replace 失去价值的 work，并关闭 schedule。
+3. **Synthesize：**读取权威 child output、选择已提交 result record，并回答用户。
+
+这个位置同时保留自治与响应性。Operator 可以按照持久 control decision 推进，root Agent 仍然是普通 conversation participant。用户可以通过 host 观察或停止 Graph，而不把 supervisor 变成 data-delivery bottleneck。
+
+Observer callback 只用于 presentation，并且 fire-and-forget。损坏的 Desktop listener 或 supervisor observation hook 不能让 operator activation 失败。
+
+## 持久 supervisor wake
+
+一个有用 checkpoint 即使没有新的用户消息，也必须最终把主 Agent 带回来。因此 host 会在 SQLite 中持久保存 supervisor wake。
+
+Wake 状态流转为：
+
+```text
+pending → running → delivered
+                  ↘ waiting_permission
+                  ↘ retryable_failed → running
+```
+
+每次 delivery attempt 都预分配 root Turn identity，并以 `agent_graph` origin 启动一次普通 root Session turn。Prompt 要求主 Agent inspect Graph，在需要时读取 child output，然后继续 schedule 或 finish。
+
+“Prompt 已持久化”不等于“wake 已 delivered”。只有 host 观察到 root AgentRun completed，delivery 才完成。Permission suspension 会被显式 parked。重启后，wake coordinator 会对比 stored attempt 与 AgentRun fact，把被中断 attempt 标记为 retryable，只恢复安全的 delivery。
+
+Session activity registry 会把这个 host-created turn 与其它 root Session activity 串行化。多个 client 可以观察同一个持久 Session 与 Graph state，但不会成为 scheduler owner。
+
+## Persistence 与 authority
+
+Graph 把 SQLite 用作 workspace/session metadata control plane，而不是 transcript 或 Runtime ledger 的替代品。
+
+| 数据 | Authority | 原因 |
+|---|---|---|
+| Child Session 配置与 parent relation | Session storage 加 metadata transaction | 产品 identity 与冻结 runtime snapshot |
+| Agent execution lifecycle | AgentRun ledger | 精确 Turn/Run state 与 terminal semantics |
+| Message、tool、permission、usage、terminal fact | Runtime Event Log | Canonical interaction facts |
+| Schedule revision | SQLite | 有序、幂等的 supervisor control decision |
+| Operator provision 与 topology relation | SQLite | 原子的 child Session/operator identity |
+| Intent claim 与 admission state | SQLite | Revision-linearized exactly-once admission |
+| Supervisor wake 与 attempt | SQLite | 可恢复的 root-turn delivery |
+| Graph record、route、readiness、replay timeline | 确定性 projection | 建立在持久事实上的可重建 view |
+| Desktop snapshot 与 terminal activity page | SQLite materialized read side | 有界、高效的 client read |
+
+权威 schedule、provision、claim 或 wake 操作发生 SQLite failure 时应直接报错。Coordinator 不会扫描 JSONL 来替代 Graph control plane。
+
+Materialized Desktop projection 不同：它是 derived state。Incremental projection commit 可以失败，而不影响 Runtime 或 schedule authority。Coordinator 会把 projection 标记为 dirty，在 reconciliation 边界做 best-effort rebuild，并在 client read 前再次 repair；成功 rebuild 后才清除 dirty state。
+
+## 三个 status plane 不能压扁
+
+Client 可能同时观察到：
+
+```text
+work.status                       = requested
+claim.admissionState              = executing
+operator.currentActivation.status = completed
+```
+
+这不是矛盾。
+
+- Work status 记录 supervisor intent，以及它是否被 stopped 或 superseded。
+- Claim admission 记录某个确定性 intent 是否已 admission 或 cancelled。
+- Activation status 记录 Runtime 实际发生了什么。
+
+把三者压成一个 generic node state 会抹掉因果。Bounded client read model 可以派生 presentation status，但仍保留 work、claim、control decision 与 Run reference 供检查。
+
+## 重建一条 replayable Graph timeline
+
+Graph 还可以跨 control plane 与 data plane 重建一条统一的 reference-only timeline。`getTimeline()` 会 join：
+
+- 一份 transactionally consistent SQLite snapshot，其中包含 schedule update、operator provision、current admission，以及 supervisor wake 与 attempt；
+- 创建 schedule decision 或执行 wake turn 的 root Session AgentRuns；
+- 每个 provisioned operator 的 committed child RuntimeEvent projection。
+
+最终 event stream 覆盖 supervisor-turn start/termination、schedule commit/finish、operator provision、intent claim、current admission state、activation start、committed record、activation terminal、wake claim、wake attempt、wake settlement 和 current wake state。
+
+Timeline event 有意不暴露 schedule instruction、finish reason、child message content 或 tool payload，只保留回答以下问题所需的 ID、facet、source RuntimeEvent reference 与 Run coordinate：
+
+- 哪个 supervisor turn 创建了这项 work？
+- 哪个 operator 和 child Session 接收了它？
+- 哪个精确 activation 产生了 candidate record？
+- Graph 是否在 final schedule decision 前唤醒了 supervisor？
+
+重建顺序先按 event time，再按稳定 event-kind rank 与 type-specific identity tie-break 排序。公开的 `sequence` 是 deterministic reconstruction order，不表示 SQLite 与 Runtime ledger 共享一个物理 commit sequence。同一毫秒内的 Runtime record 保留 committed ledger order。
+
+每页默认 100 个 event，上限 256。Opaque cursor 绑定 Graph、event identity 与 event time；页面同时报告 total event、前置 omission 与后置 omission。
+
+Coverage 会被显式报告，而不是靠读者猜测。对于本次读取的 immutable ledger，Runtime record 是 complete 的；但当前 SQLite schema 只保留最新 admission state 与最新 wake state，不保留每个被覆盖的 transition。Reconciliation-loop iteration 也没有作为历史 event 持久化。Timeline 会报告全部三项限制：
+
+```text
+admission_transition_history_not_persisted
+supervisor_wake_transition_history_not_persisted
+reconcile_history_not_persisted
+```
+
+因此 timeline 可以 replay、可以用于诊断，却不会冒充新的 authority。每个 event 都能指回真正拥有 underlying fact 的 store。
+
+## Desktop 产品接线
+
+Desktop 组合了当前 host-managed Graph profile：
+
+- Graph 可以是 Session orchestration mode，也可以是 one-turn override；
+- `/graph on`、`/graph off` 与 `/graph <task>` 暴露这些选择；
+- 只有 root Session 获得 `view_agent_graph`、`update_agent_graph` 与 `agent_output`；
+- Electron main 拥有 coordinator、wake coordinator、SQLite store、Runtime adapter 与 startup recovery；
+- renderer IPC 只暴露 bounded snapshot、operator inspection、stop 与 invalidation hint；
+- Agent Graph panel 展示 aggregate state、visible operator、wait、selected result，并可打开 child Session；
+- Stop Graph 会 abort reconciliation，并通过 Runtime 停止已知 child Session；
+- Startup 先 repair interrupted Runtime state，再恢复 wake 与 Graph schedule。
+
+Renderer invalidation 只是 hint。重新连接的 client 调用 `getSnapshot()` 读取持久 state，不把进程内 notification replay 成事实。
+
+当前 panel 是 operational view，不是 node-and-edge authoring canvas。主 Agent 仍通过 typed schedule update 编写 topology。
+
+## End-to-end sequence
+
+```mermaid
+sequenceDiagram
+    participant U as User
+    participant M as Main Agent
+    participant SQL as SQLite control plane
+    participant G as Graph coordinator
+    participant CS as Child Session operator
+    participant R as AgentRun / RuntimeEvent log
+    participant D as Desktop read model
+
+    U->>M: Graph-mode task
+    M->>SQL: update_agent_graph(add_work)
+    SQL-->>G: durable schedule revision
+    G->>SQL: provision operator + child Session relation
+    G->>SQL: claim intent with Turn/Run IDs
+    G->>CS: run claimed activation
+    CS->>R: ordinary model/tool execution
+    R-->>G: committed RuntimeEvents
+    G->>D: materialize records and operator state
+    G->>SQL: claim supervisor wake at checkpoint
+    SQL-->>M: host starts root supervisor Turn
+    M->>G: view_agent_graph
+    M->>R: agent_output(child Session, Run)
+    M->>SQL: add dependent work or finish(result record IDs)
+    SQL-->>D: closed schedule and selected results
+    M-->>U: synthesized answer
+```
+
+注意 child result 不经过 supervisor callback 传输。Runtime 先提交它，Graph 再 projection 出一个引用；主 Agent 随后决定是否以及何时读取权威 payload。
+
+## Failure 与 recovery invariant
+
+当前实现保护这些 invariant：
+
+- schedule update append-only、按 revision 排序，并按 source identity 幂等；
+- operator provision 单调且 retry-safe；
+- provisioned operator 永远解析到同一个 linked child Session；
+- 一个 intent 最多对应一个 claim 与精确 Turn/Run identity；
+- 已存在的 claimed Run 会被观察或恢复，不会盲目再次执行；
+- record 只引用已提交 non-partial RuntimeEvent；
+- callback 与 renderer failure 不能改变 Graph execution；
+- closure 阻止 fresh admission，但不遗弃 existing claim；
+- Graph stop 保留 durable schedule fact 与 historical Runtime fact；
+- startup recovery 从 SQLite control row 与 Runtime ledger 派生工作，而不是依赖内存 registry；
+- supervisor wake 只有在 root AgentRun completed 后才算 delivered；
+- derived client projection 失败后可以 rebuild，而不改变 authority。
+- replay timeline 不暴露 child 或 schedule payload，并显式报告不完整的 transition coverage。
+
+这些 invariant 比任何单个 UI 或 prompt 的形状都重要。新的 host adapter 必须保留它们。
+
+## 当前限制与 non-goal
+
+当前 Graph 不能被误解为通用 distributed stream processor。
+
+- Topology 是只做 monotonic add 的 directed acyclic graph；任意 deletion、rewire 与 cycle 尚未实现。
+- Desktop 默认通过 supervisor schedule update 显式推进 dependent work，不会暗中推断自动 policy-driven topology。
+- `map` 与 `all_settled` 是 structural readiness primitive，不是完整 window、watermark、keyed state 或 backpressure system。
+- Structural scheduler 不拥有 global resource permit、fairness、provider rate limit 或 distributed lease。
+- Quiescence 不是 graph completion；`finish` 是显式 supervisor decision。
+- Read model 有界且 reference-only；完整 child content 必须走权威 Runtime read path。
+- Desktop panel 是 inspection 与 stop surface，不是 visual graph editor。
+- Coordinator 已暴露 paginated replay timeline，但 Desktop IPC 与当前 Agent Graph panel 尚未把它渲染成交互式 chronological visualization。
+- Admission 与 wake row 目前只向 timeline reconstruction 暴露 latest state，reconcile-loop history 也没有持久化。
+
+这些都是有意保留的边界。它们让 Graph 有用，同时不把 workflow semantic、resource management 或 product presentation 塞进 Agent runtime。
+
+## Graph、Swarm、Agent Team 与 Rive
+
+四种机制解决不同的协调问题。
+
+| 需求 | 机制 | Ownership model |
+|---|---|---|
+| 有限独立 fan-out，随后一次 synthesis | Agent Swarm | 一个 foreground tool call 拥有有界 worker pool |
+| 一次 linked specialist execution 或 follow-up | `agent_spawn` / child Session | Parent Agent 显式拥有 delegation |
+| Role、mailbox collaboration 与 Task Ledger coordination | Agent Team | Team member 拥有持久 collaboration state |
+| 从 root conversation 监督动态依赖 Agent work | Agent Graph | Child Session 与 Runtime record 之上的 SQLite schedule/control plane |
+| 显式 workflow step、任意 resume policy 或分布式 workflow authority | Rive | Workflow runtime 拥有 workflow state |
+
+Graph 位于 foreground fan-out 与独立 workflow runtime 之间：足够动态、持久，可以协调 dependent Agent work；同时 Session Runtime 仍是唯一 execution universe。
+
+## 代码阅读地图
+
+建议按以下顺序阅读：
+
+1. `packages/core/src/orchestration.ts` 与 `graph-command.ts`：Session 与 one-turn Graph mode。
+2. `packages/runtime/src/graph-mode.ts`：main-Agent supervisor contract。
+3. `packages/core/src/agent-graph-schedule.ts`：work、stop、finish、revision 与 store protocol。
+4. `packages/core/src/agent-graph-topology.ts`：monotonic operator provision。
+5. `packages/runtime/src/stream-graph-projection.ts`：RuntimeEvent-to-record projection 与 replay。
+6. `packages/runtime/src/stream-graph-trace.ts`：topology validation 与 reference-only route。
+7. `packages/runtime/src/stream-graph-readiness.ts`：`map` 与 sealed `all_settled` readiness。
+8. `packages/core/src/agent-graph-control.ts` 与 `packages/runtime/src/stream-graph-admission.ts`：durable intent claim。
+9. `packages/runtime/src/stream-graph-dispatch.ts`：structural drive-to-quiescence loop。
+10. `packages/runtime/src/stream-graph-schedule-reconcile.ts`：schedule、dynamic provision、stop、claim 与 dispatch convergence。
+11. `packages/runtime/src/session-manager.ts`：child Session provision 与 claimed activation execution。
+12. `packages/runtime/src/stream-graph-coordinator.ts`：host-owned single-flight lifecycle、client projection repair 与 root-only timeline access。
+13. `packages/runtime/src/agent-graph-timeline.ts`：reference-only control/data-plane reconstruction、stable order、coverage 与 pagination。
+14. `packages/runtime/src/agent-graph-supervisor-wake.ts`：回到 root Agent 的持久路径。
+15. `packages/storage/src/sqlite-session-metadata-schema.ts` 与 `sqlite-session-metadata-store.ts`：Graph control-plane transaction 与 timeline metadata snapshot。
+16. `apps/desktop/src/main/main.ts`、`agent-graph-ipc-main.ts` 与 `apps/desktop/src/renderer/agent-graph-panel.tsx`：产品组合与 bounded UI。
+
+最相关的 contract tests 位于：
+
+- `packages/runtime/src/__tests__/stream-graph-*.test.ts`
+- `packages/runtime/src/__tests__/agent-graph-timeline.test.ts`
+- `packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts`
+- `packages/runtime/src/__tests__/session-manager.test.ts`
+- `packages/storage/src/__tests__/sqlite-session-metadata-store.test.ts`
+- `packages/storage/src/__tests__/agent-graph-timeline-metadata.test.ts`
+- `apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts`
+
+## 总结
+
+Maka Graph 从一个流处理视角出发：
+
+```text
+subagent work   表现得像 operator
+Agent message  表现得像 stream record
+dependency     表现得像 route 与 input frontier
+coordination   表现得像 graph 上的 scheduling
+```
+
+实现把这个观察具体化，却没有改写 Agent runtime。Child Session 提供稳定 operator container；AgentRun 提供 activation；RuntimeEvent 提供 immutable fact；确定性 projection 提供 record、route 与 readiness；SQLite 提供 revision-linearized schedule、topology、admission、client materialization 与 supervisor wake；Desktop 提供 host 与 operational view。
+
+主 Agent 是这个设计最有辨识度的部分。它始终在图旁：对用户保持可用，可以检查任意 operator，可以添加或停止 work，并负责选择和综合最终 record。Data path 无需等待模型批准即可推进，而 judgment 留在用户能够看见和影响的 conversation 中。
+
+这就是该架构的承诺：**复用一套可信 Runtime，增加一层持久 Graph control plane，让监督 Agent 足够靠近 schedule、能够理解和修改它，同时不成为它的 bottleneck。**

--- a/packages/core/src/agent-graph-timeline.ts
+++ b/packages/core/src/agent-graph-timeline.ts
@@ -1,0 +1,48 @@
+import type { AgentGraphIntentClaim } from './agent-graph-control.js';
+import type {
+  AgentGraphIntentAdmissionState,
+  AgentGraphScheduleUpdate,
+} from './agent-graph-schedule.js';
+import type { AgentGraphOperatorProvision } from './agent-graph-topology.js';
+import type {
+  AgentGraphSupervisorWakeAttemptRecord,
+  AgentGraphSupervisorWakeRecord,
+} from './agent-graph-supervisor-wake.js';
+
+/**
+ * Current admission fact stored beside an immutable graph intent claim.
+ *
+ * This is deliberately named a snapshot: v1 metadata stores retain the
+ * current admission state, not every overwritten transition.
+ */
+export interface AgentGraphIntentAdmissionSnapshot {
+  graphId: string;
+  intentId: string;
+  state: AgentGraphIntentAdmissionState;
+  updatedAt: number;
+  cancellationReason?: string;
+}
+
+export interface AgentGraphSupervisorWakeTimelineSnapshot {
+  wake: AgentGraphSupervisorWakeRecord;
+  attempts: AgentGraphSupervisorWakeAttemptRecord[];
+}
+
+/**
+ * One transactionally consistent read of the SQLite graph control plane.
+ *
+ * AgentRun and RuntimeEvent ledgers remain separate authorities and are joined
+ * by the runtime trace reader after this metadata snapshot is acquired.
+ */
+export interface AgentGraphTimelineMetadataSnapshot {
+  graphId: string;
+  scheduleUpdates: AgentGraphScheduleUpdate[];
+  operatorProvisions: AgentGraphOperatorProvision[];
+  intentClaims: AgentGraphIntentClaim[];
+  intentAdmissions: AgentGraphIntentAdmissionSnapshot[];
+  supervisorWakes: AgentGraphSupervisorWakeTimelineSnapshot[];
+}
+
+export interface AgentGraphTimelineMetadataStore {
+  readAgentGraphTimelineMetadata(graphId: string): Promise<AgentGraphTimelineMetadataSnapshot>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -18,6 +18,7 @@ export * from './agent-graph-schedule.js';
 export * from './agent-graph-topology.js';
 export * from './agent-graph-client-projection.js';
 export * from './agent-graph-supervisor-wake.js';
+export * from './agent-graph-timeline.js';
 export * from './runtime-policy.js';
 
 // events.ts

--- a/packages/runtime/package.json
+++ b/packages/runtime/package.json
@@ -61,7 +61,8 @@
     "./stream-graph-schedule-reconcile": "./dist/stream-graph-schedule-reconcile.js",
     "./stream-graph-supervisor-tools": "./dist/stream-graph-supervisor-tools.js",
     "./stream-graph-read-model": "./dist/stream-graph-read-model.js",
-    "./stream-graph-coordinator": "./dist/stream-graph-coordinator.js"
+    "./stream-graph-coordinator": "./dist/stream-graph-coordinator.js",
+    "./agent-graph-timeline": "./dist/agent-graph-timeline.js"
   },
   "scripts": {
     "clean": "node ../../scripts/clean-paths.mjs dist tsconfig.tsbuildinfo",

--- a/packages/runtime/src/__tests__/agent-graph-timeline.test.ts
+++ b/packages/runtime/src/__tests__/agent-graph-timeline.test.ts
@@ -1,0 +1,426 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { AgentGraphTimelineMetadataSnapshot, AgentRunHeader, RuntimeEvent } from '@maka/core';
+import {
+  buildAgentGraphTimeline,
+  paginateAgentGraphTimeline,
+  readAgentGraphTimelinePage,
+} from '../agent-graph-timeline.js';
+import { readCommittedAgentGraphProjection } from '../stream-graph-projection.js';
+
+describe('agent graph replay timeline', () => {
+  test('reconstructs control, child records, parent completion, and supervisor wake chronologically', async () => {
+    const fixture = await timelineFixture();
+    const events = buildAgentGraphTimeline(fixture);
+
+    assert.deepEqual(
+      events.map((event) => event.sequence),
+      Array.from({ length: events.length }, (_unused, index) => index + 1),
+    );
+    assert.deepEqual(
+      events
+        .filter(
+          (event): event is Extract<(typeof events)[number], { kind: 'record_committed' }> =>
+            event.kind === 'record_committed' && event.eventTime === 110,
+        )
+        .map((event) => event.sourceRuntimeEventId),
+      ['child-tool-call', 'child-tool-result'],
+      'same-millisecond runtime records retain committed ledger order',
+    );
+    const firstRootTerminal = requireEvent(
+      events,
+      'supervisor_turn_terminal',
+      (event) => event.kind === 'supervisor_turn_terminal' && event.run.runId === 'root-run-1',
+    );
+    const childTerminal = requireEvent(events, 'activation_terminal');
+    const wakeAttempt = requireEvent(events, 'supervisor_wake_attempted');
+    const wakeRootStart = requireEvent(
+      events,
+      'supervisor_turn_started',
+      (event) => event.kind === 'supervisor_turn_started' && event.run.runId === 'root-run-2',
+    );
+    const finish = requireEvent(events, 'schedule_finished');
+    assert.ok(firstRootTerminal.eventTime < childTerminal.eventTime);
+    assert.ok(childTerminal.eventTime < wakeAttempt.eventTime);
+    assert.equal(wakeRootStart.eventTime, wakeAttempt.eventTime);
+    assert.ok(wakeRootStart.eventTime < finish.eventTime);
+    if (wakeRootStart.kind !== 'supervisor_turn_started') assert.fail('unexpected event');
+    assert.deepEqual(wakeRootStart.wake, {
+      wakeId: 'wake-1',
+      attemptId: 'attempt-1',
+    });
+
+    const admission = requireEvent(events, 'intent_admission_snapshot');
+    assert.equal(admission.kind, 'intent_admission_snapshot');
+    assert.equal(admission.state, 'executing');
+    assert.equal(admission.transitionHistory, 'current_only');
+    assert.equal(childTerminal.kind, 'activation_terminal');
+    assert.equal(childTerminal.status, 'completed');
+    const wakeState = requireEvent(events, 'supervisor_wake_state_snapshot');
+    assert.equal(wakeState.kind, 'supervisor_wake_state_snapshot');
+    assert.equal(wakeState.status, 'delivered');
+    assert.equal(wakeState.transitionHistory, 'current_only');
+
+    const serialized = JSON.stringify(events);
+    assert.doesNotMatch(serialized, /SECRET_(INSTRUCTION|FINISH_REASON|CHILD_OUTPUT|TOOL_ARG)/);
+    assert.match(serialized, /child-tool-result/);
+  });
+
+  test('paginates with a validated stable cursor and reports bounded omissions', async () => {
+    const fixture = await timelineFixture();
+    const events = buildAgentGraphTimeline(fixture);
+    const seen: string[] = [];
+    let cursor: string | undefined;
+    let pageNumber = 0;
+    do {
+      const page = paginateAgentGraphTimeline(events, 'root-session', 'graph-1', {
+        ...(cursor ? { cursor } : {}),
+        limit: 3,
+      });
+      seen.push(...page.events.map((event) => event.eventId));
+      assert.equal(page.omittedBefore, pageNumber * 3);
+      assert.equal(page.omittedAfter, Math.max(0, events.length - seen.length));
+      assert.deepEqual(page.coverage.limitations, [
+        'admission_transition_history_not_persisted',
+        'supervisor_wake_transition_history_not_persisted',
+        'reconcile_history_not_persisted',
+      ]);
+      cursor = page.nextCursor;
+      pageNumber += 1;
+    } while (cursor);
+    assert.deepEqual(
+      seen,
+      events.map((event) => event.eventId),
+    );
+
+    const first = paginateAgentGraphTimeline(events, 'root-session', 'graph-1', { limit: 1 });
+    await assert.rejects(
+      async () =>
+        paginateAgentGraphTimeline(events, 'root-session', 'another-graph', {
+          cursor: first.nextCursor,
+        }),
+      /another graph/,
+    );
+
+    const cursorPage = paginateAgentGraphTimeline(events, 'root-session', 'graph-1', {
+      limit: 2,
+    });
+    const withEarlierEvent = events.map((event) => ({
+      ...event,
+      sequence: event.sequence + 1,
+    }));
+    withEarlierEvent.unshift({
+      ...events[0]!,
+      eventId: 'graph_timeline_late_discovery',
+      eventTime: Math.max(0, events[0]!.eventTime - 1),
+      sequence: 1,
+    });
+    const resumed = paginateAgentGraphTimeline(withEarlierEvent, 'root-session', 'graph-1', {
+      cursor: cursorPage.nextCursor,
+      limit: 1,
+    });
+    assert.equal(resumed.events[0]?.eventId, events[2]?.eventId);
+    assert.equal(resumed.omittedBefore, 3);
+  });
+
+  test('joins a transactionally read SQLite metadata snapshot with immutable run ledgers', async () => {
+    const fixture = await timelineFixture();
+    const runsBySession = new Map<string, AgentRunHeader[]>([
+      ['root-session', [...fixture.rootRuns]],
+      ['child-session', [fixture.childRun]],
+    ]);
+    const eventsByRun = new Map([['child-run', fixture.childEvents]]);
+    let metadataReads = 0;
+    const page = await readAgentGraphTimelinePage({
+      rootSessionId: 'root-session',
+      graphId: 'graph-1',
+      controlStore: {
+        async readAgentGraphTimelineMetadata() {
+          metadataReads += 1;
+          return fixture.metadata;
+        },
+      },
+      runStore: {
+        async listSessionRuns(sessionId) {
+          return runsBySession.get(sessionId) ?? [];
+        },
+      },
+      runtimeEventStore: {
+        async readImmutableRuntimeEvents(_sessionId, runId) {
+          return eventsByRun.get(runId) ?? [];
+        },
+      },
+      options: { limit: 256 },
+    });
+
+    assert.equal(metadataReads, 1);
+    assert.equal(page.omittedAfter, 0);
+    assert.equal(page.totalEvents, page.events.length);
+    assert.ok(page.events.some((event) => event.kind === 'schedule_finished'));
+    assert.ok(page.events.some((event) => event.kind === 'record_committed'));
+  });
+});
+
+async function timelineFixture() {
+  const rootRun1 = runHeader({
+    sessionId: 'root-session',
+    runId: 'root-run-1',
+    turnId: 'root-turn-1',
+    status: 'completed',
+    createdAt: 90,
+    completedAt: 115,
+  });
+  const rootRun2 = runHeader({
+    sessionId: 'root-session',
+    runId: 'root-run-2',
+    turnId: 'root-turn-2',
+    status: 'completed',
+    createdAt: 122,
+    completedAt: 150,
+    agentGraphWakeId: 'wake-1',
+    agentGraphWakeAttemptId: 'attempt-1',
+  });
+  const childRun = runHeader({
+    sessionId: 'child-session',
+    runId: 'child-run',
+    turnId: 'child-turn',
+    status: 'completed',
+    createdAt: 102,
+    completedAt: 120,
+  });
+  const childEvents: RuntimeEvent[] = [
+    runtimeEvent(childRun, {
+      id: 'child-input',
+      ts: 104,
+      role: 'user',
+      author: 'host',
+      content: { kind: 'text', text: 'SECRET_INSTRUCTION' },
+    }),
+    runtimeEvent(childRun, {
+      id: 'child-tool-call',
+      ts: 110,
+      role: 'model',
+      author: 'agent',
+      content: {
+        kind: 'function_call',
+        id: 'call-1',
+        name: 'Read',
+        args: { path: 'SECRET_TOOL_ARG' },
+      },
+    }),
+    runtimeEvent(childRun, {
+      id: 'child-tool-result',
+      ts: 110,
+      role: 'tool',
+      author: 'tool',
+      content: {
+        kind: 'function_response',
+        id: 'call-1',
+        name: 'Read',
+        result: 'SECRET_CHILD_OUTPUT',
+      },
+    }),
+    runtimeEvent(childRun, {
+      id: 'child-final',
+      ts: 119,
+      role: 'model',
+      author: 'agent',
+      content: { kind: 'text', text: 'SECRET_CHILD_OUTPUT' },
+    }),
+    runtimeEvent(childRun, {
+      id: 'child-terminal',
+      ts: 120,
+      status: 'completed',
+      actions: { endInvocation: true },
+    }),
+  ];
+  const projection = await readCommittedAgentGraphProjection({
+    graphId: 'graph-1',
+    operators: [{ operatorId: 'operator-1', sessionId: 'child-session' }],
+    runStore: {
+      async listSessionRuns() {
+        return [childRun];
+      },
+    },
+    runtimeEventStore: {
+      async readImmutableRuntimeEvents() {
+        return childEvents;
+      },
+    },
+  });
+  const metadata: AgentGraphTimelineMetadataSnapshot = {
+    graphId: 'graph-1',
+    scheduleUpdates: [
+      {
+        schemaVersion: 1,
+        updateId: `graph_update_${'a'.repeat(32)}`,
+        updateFingerprint: `sha256:${'a'.repeat(64)}`,
+        graphId: 'graph-1',
+        source: {
+          sessionId: 'root-session',
+          runId: 'root-run-1',
+          turnId: 'root-turn-1',
+          toolCallId: 'schedule-call-1',
+        },
+        addWork: [
+          {
+            workId: `graph_work_${'b'.repeat(32)}`,
+            target: { kind: 'agent', agentId: 'local-read' },
+            instruction: 'SECRET_INSTRUCTION',
+            inputIds: [],
+          },
+        ],
+        stop: [],
+        revision: 1,
+        committedAt: 100,
+      },
+      {
+        schemaVersion: 1,
+        updateId: `graph_update_${'c'.repeat(32)}`,
+        updateFingerprint: `sha256:${'c'.repeat(64)}`,
+        graphId: 'graph-1',
+        source: {
+          sessionId: 'root-session',
+          runId: 'root-run-2',
+          turnId: 'root-turn-2',
+          toolCallId: 'schedule-call-2',
+        },
+        addWork: [],
+        stop: [],
+        finish: {
+          resultIds: [projection.records.at(-2)!.recordId],
+          reason: 'SECRET_FINISH_REASON',
+        },
+        revision: 2,
+        committedAt: 145,
+      },
+    ],
+    operatorProvisions: [
+      {
+        schemaVersion: 1,
+        provisionId: `graph_provision_${'d'.repeat(32)}`,
+        provisionFingerprint: `sha256:${'d'.repeat(64)}`,
+        graphId: 'graph-1',
+        workId: `graph_work_${'b'.repeat(32)}`,
+        agentId: 'local-read',
+        operatorId: 'operator-1',
+        initialTurnId: 'child-turn',
+        initialRunId: 'child-run',
+        edges: [],
+        targetSessionId: 'child-session',
+        provisionedAt: 101,
+      },
+    ],
+    intentClaims: [
+      {
+        schemaVersion: 1,
+        claimId: `graph_claim_${'e'.repeat(32)}`,
+        graphId: 'graph-1',
+        intentId: `graph_intent_${'f'.repeat(32)}`,
+        intentFingerprint: `sha256:${'e'.repeat(64)}`,
+        readinessContextFingerprint: `sha256:${'f'.repeat(64)}`,
+        targetOperatorId: 'operator-1',
+        targetSessionId: 'child-session',
+        targetTurnId: 'child-turn',
+        targetRunId: 'child-run',
+        claimedAt: 102,
+      },
+    ],
+    intentAdmissions: [
+      {
+        graphId: 'graph-1',
+        intentId: `graph_intent_${'f'.repeat(32)}`,
+        state: 'executing',
+        updatedAt: 103,
+      },
+    ],
+    supervisorWakes: [
+      {
+        wake: {
+          schemaVersion: 1,
+          graphId: 'graph-1',
+          wakeId: 'wake-1',
+          snapshotVersion: 'snapshot-1',
+          rootSessionId: 'root-session',
+          status: 'delivered',
+          attemptCount: 1,
+          currentAttemptId: 'attempt-1',
+          currentTurnId: 'root-turn-2',
+          createdAt: 121,
+          updatedAt: 130,
+        },
+        attempts: [
+          {
+            graphId: 'graph-1',
+            wakeId: 'wake-1',
+            attemptId: 'attempt-1',
+            turnId: 'root-turn-2',
+            status: 'delivered',
+            startedAt: 122,
+            completedAt: 130,
+          },
+        ],
+      },
+    ],
+  };
+  return {
+    rootSessionId: 'root-session',
+    graphId: 'graph-1',
+    metadata,
+    rootRuns: [rootRun1, rootRun2],
+    projection,
+    childRun,
+    childEvents,
+  };
+}
+
+function runHeader(
+  input: Pick<
+    AgentRunHeader,
+    | 'sessionId'
+    | 'runId'
+    | 'turnId'
+    | 'status'
+    | 'createdAt'
+    | 'completedAt'
+    | 'agentGraphWakeId'
+    | 'agentGraphWakeAttemptId'
+  >,
+): AgentRunHeader {
+  return {
+    ...input,
+    invocationId: `invocation-${input.runId}`,
+    backendKind: 'ai-sdk',
+    llmConnectionSlug: 'deepseek',
+    modelId: 'deepseek-chat',
+    cwd: '/workspace',
+    permissionMode: 'explore',
+    updatedAt: input.completedAt ?? input.createdAt,
+  };
+}
+
+function runtimeEvent(
+  run: AgentRunHeader,
+  overrides: Partial<RuntimeEvent> & Pick<RuntimeEvent, 'id' | 'ts'>,
+): RuntimeEvent {
+  return {
+    invocationId: run.invocationId!,
+    runId: run.runId,
+    sessionId: run.sessionId,
+    turnId: run.turnId,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}
+
+function requireEvent<K extends string>(
+  events: ReturnType<typeof buildAgentGraphTimeline>,
+  kind: K,
+  predicate: (event: ReturnType<typeof buildAgentGraphTimeline>[number]) => boolean = () => true,
+) {
+  const event = events.find((candidate) => candidate.kind === kind && predicate(candidate));
+  assert.ok(event, `missing ${kind}`);
+  return event;
+}

--- a/packages/runtime/src/__tests__/agent-graph-timeline.test.ts
+++ b/packages/runtime/src/__tests__/agent-graph-timeline.test.ts
@@ -3,6 +3,7 @@ import { describe, test } from 'node:test';
 import type { AgentGraphTimelineMetadataSnapshot, AgentRunHeader, RuntimeEvent } from '@maka/core';
 import {
   buildAgentGraphTimeline,
+  buildAgentGraphTimelineCurrentState,
   paginateAgentGraphTimeline,
   readAgentGraphTimelinePage,
 } from '../agent-graph-timeline.js';
@@ -12,6 +13,11 @@ describe('agent graph replay timeline', () => {
   test('reconstructs control, child records, parent completion, and supervisor wake chronologically', async () => {
     const fixture = await timelineFixture();
     const events = buildAgentGraphTimeline(fixture);
+    const currentState = buildAgentGraphTimelineCurrentState(
+      fixture.metadata,
+      fixture.rootSessionId,
+      fixture.graphId,
+    );
 
     assert.deepEqual(
       events.map((event) => event.sequence),
@@ -50,18 +56,27 @@ describe('agent graph replay timeline', () => {
       attemptId: 'attempt-1',
     });
 
-    const admission = requireEvent(events, 'intent_admission_snapshot');
-    assert.equal(admission.kind, 'intent_admission_snapshot');
-    assert.equal(admission.state, 'executing');
-    assert.equal(admission.transitionHistory, 'current_only');
+    assert.deepEqual(currentState.admissions, [
+      {
+        intentId: `graph_intent_${'f'.repeat(32)}`,
+        state: 'executing',
+        updatedAt: 103,
+      },
+    ]);
     assert.equal(childTerminal.kind, 'activation_terminal');
     assert.equal(childTerminal.status, 'completed');
-    const wakeState = requireEvent(events, 'supervisor_wake_state_snapshot');
-    assert.equal(wakeState.kind, 'supervisor_wake_state_snapshot');
-    assert.equal(wakeState.status, 'delivered');
-    assert.equal(wakeState.transitionHistory, 'current_only');
+    assert.deepEqual(currentState.supervisorWakes, [
+      {
+        wakeId: 'wake-1',
+        status: 'delivered',
+        attemptCount: 1,
+        updatedAt: 130,
+        currentAttemptId: 'attempt-1',
+        currentTurnId: 'root-turn-2',
+      },
+    ]);
 
-    const serialized = JSON.stringify(events);
+    const serialized = JSON.stringify({ events, currentState });
     assert.doesNotMatch(serialized, /SECRET_(INSTRUCTION|FINISH_REASON|CHILD_OUTPUT|TOOL_ARG)/);
     assert.match(serialized, /child-tool-result/);
   });
@@ -69,11 +84,16 @@ describe('agent graph replay timeline', () => {
   test('paginates with a validated stable cursor and reports bounded omissions', async () => {
     const fixture = await timelineFixture();
     const events = buildAgentGraphTimeline(fixture);
+    const currentState = buildAgentGraphTimelineCurrentState(
+      fixture.metadata,
+      fixture.rootSessionId,
+      fixture.graphId,
+    );
     const seen: string[] = [];
     let cursor: string | undefined;
     let pageNumber = 0;
     do {
-      const page = paginateAgentGraphTimeline(events, 'root-session', 'graph-1', {
+      const page = paginateAgentGraphTimeline(events, 'root-session', 'graph-1', currentState, {
         ...(cursor ? { cursor } : {}),
         limit: 3,
       });
@@ -93,16 +113,18 @@ describe('agent graph replay timeline', () => {
       events.map((event) => event.eventId),
     );
 
-    const first = paginateAgentGraphTimeline(events, 'root-session', 'graph-1', { limit: 1 });
+    const first = paginateAgentGraphTimeline(events, 'root-session', 'graph-1', currentState, {
+      limit: 1,
+    });
     await assert.rejects(
       async () =>
-        paginateAgentGraphTimeline(events, 'root-session', 'another-graph', {
+        paginateAgentGraphTimeline(events, 'root-session', 'another-graph', currentState, {
           cursor: first.nextCursor,
         }),
       /another graph/,
     );
 
-    const cursorPage = paginateAgentGraphTimeline(events, 'root-session', 'graph-1', {
+    const cursorPage = paginateAgentGraphTimeline(events, 'root-session', 'graph-1', currentState, {
       limit: 2,
     });
     const withEarlierEvent = events.map((event) => ({
@@ -115,12 +137,64 @@ describe('agent graph replay timeline', () => {
       eventTime: Math.max(0, events[0]!.eventTime - 1),
       sequence: 1,
     });
-    const resumed = paginateAgentGraphTimeline(withEarlierEvent, 'root-session', 'graph-1', {
-      cursor: cursorPage.nextCursor,
-      limit: 1,
-    });
+    const resumed = paginateAgentGraphTimeline(
+      withEarlierEvent,
+      'root-session',
+      'graph-1',
+      currentState,
+      {
+        cursor: cursorPage.nextCursor,
+        limit: 1,
+      },
+    );
     assert.equal(resumed.events[0]?.eventId, events[2]?.eventId);
     assert.equal(resumed.omittedBefore, 3);
+  });
+
+  test('keeps historical pagination cursors valid when mutable control snapshots change', async () => {
+    const fixture = await timelineFixture();
+    const claimedMetadata = structuredClone(fixture.metadata);
+    claimedMetadata.intentAdmissions[0] = {
+      ...claimedMetadata.intentAdmissions[0]!,
+      state: 'claimed',
+      updatedAt: 102,
+    };
+    const claimedEvents = buildAgentGraphTimeline({
+      ...fixture,
+      metadata: claimedMetadata,
+    });
+    const claimedState = buildAgentGraphTimelineCurrentState(
+      claimedMetadata,
+      fixture.rootSessionId,
+      fixture.graphId,
+    );
+    const firstPage = paginateAgentGraphTimeline(
+      claimedEvents,
+      fixture.rootSessionId,
+      fixture.graphId,
+      claimedState,
+      { limit: 4 },
+    );
+
+    const executingEvents = buildAgentGraphTimeline(fixture);
+    const executingState = buildAgentGraphTimelineCurrentState(
+      fixture.metadata,
+      fixture.rootSessionId,
+      fixture.graphId,
+    );
+    assert.deepEqual(
+      executingEvents.map((event) => [event.eventId, event.eventTime]),
+      claimedEvents.map((event) => [event.eventId, event.eventTime]),
+    );
+    const secondPage = paginateAgentGraphTimeline(
+      executingEvents,
+      fixture.rootSessionId,
+      fixture.graphId,
+      executingState,
+      { cursor: firstPage.nextCursor, limit: 4 },
+    );
+    assert.equal(secondPage.currentState.admissions[0]?.state, 'executing');
+    assert.equal(secondPage.omittedBefore, 4);
   });
 
   test('joins a transactionally read SQLite metadata snapshot with immutable run ledgers', async () => {
@@ -158,6 +232,52 @@ describe('agent graph replay timeline', () => {
     assert.equal(page.totalEvents, page.events.length);
     assert.ok(page.events.some((event) => event.kind === 'schedule_finished'));
     assert.ok(page.events.some((event) => event.kind === 'record_committed'));
+    assert.equal(page.currentState.admissions[0]?.state, 'executing');
+  });
+
+  test('emits activation_started from a durable claimed AgentRun before its first RuntimeEvent', async () => {
+    const fixture = await timelineFixture();
+    const page = await readAgentGraphTimelinePage({
+      rootSessionId: fixture.rootSessionId,
+      graphId: fixture.graphId,
+      controlStore: {
+        async readAgentGraphTimelineMetadata() {
+          return fixture.metadata;
+        },
+      },
+      runStore: {
+        async listSessionRuns(sessionId) {
+          if (sessionId === fixture.rootSessionId) return [...fixture.rootRuns];
+          if (sessionId === fixture.childRun.sessionId) {
+            return [{ ...fixture.childRun, status: 'running', completedAt: undefined }];
+          }
+          return [];
+        },
+      },
+      runtimeEventStore: {
+        async readImmutableRuntimeEvents() {
+          return [];
+        },
+      },
+      options: { limit: 256 },
+    });
+
+    const activation = requireEvent(page.events, 'activation_started');
+    assert.equal(activation.kind, 'activation_started');
+    assert.equal(activation.eventTime, fixture.childRun.createdAt);
+    assert.deepEqual(activation.activation, {
+      sessionId: 'child-session',
+      runId: 'child-run',
+      turnId: 'child-turn',
+    });
+    assert.equal(
+      page.events.some((event) => event.kind === 'record_committed'),
+      false,
+    );
+    assert.equal(
+      page.events.some((event) => event.kind === 'activation_terminal'),
+      false,
+    );
   });
 });
 
@@ -368,6 +488,7 @@ async function timelineFixture() {
     graphId: 'graph-1',
     metadata,
     rootRuns: [rootRun1, rootRun2],
+    childRuns: [childRun],
     projection,
     childRun,
     childEvents,

--- a/packages/runtime/src/agent-graph-timeline.ts
+++ b/packages/runtime/src/agent-graph-timeline.ts
@@ -1,0 +1,735 @@
+import { Buffer } from 'node:buffer';
+import type {
+  AgentGraphIntentAdmissionState,
+  AgentGraphScheduleUpdateSource,
+  AgentGraphSupervisorWakeStatus,
+  AgentGraphTimelineMetadataSnapshot,
+  AgentGraphTimelineMetadataStore,
+  AgentRunHeader,
+  AgentRunStore,
+  RuntimeEventStore,
+} from '@maka/core';
+import { stableHash } from './request-shape.js';
+import {
+  readCommittedAgentGraphProjection,
+  type AgentGraphActivationStatus,
+  type AgentGraphOperatorBinding,
+  type AgentGraphProjection,
+  type AgentGraphRecord,
+  type AgentGraphRecordFacet,
+} from './stream-graph-projection.js';
+
+export const AGENT_GRAPH_TIMELINE_SCHEMA_VERSION = 1 as const;
+export const AGENT_GRAPH_TIMELINE_DEFAULT_PAGE_SIZE = 100;
+export const AGENT_GRAPH_TIMELINE_MAX_PAGE_SIZE = 256;
+
+export type AgentGraphTimelineCoverageLimitation =
+  | 'admission_transition_history_not_persisted'
+  | 'supervisor_wake_transition_history_not_persisted'
+  | 'reconcile_history_not_persisted';
+
+export interface AgentGraphTimelineRunRef {
+  sessionId: string;
+  runId: string;
+  turnId: string;
+}
+
+interface AgentGraphTimelineEventBase {
+  schemaVersion: typeof AGENT_GRAPH_TIMELINE_SCHEMA_VERSION;
+  eventId: string;
+  graphId: string;
+  eventTime: number;
+  /** Deterministic reconstruction order; it is not a cross-ledger commit sequence. */
+  sequence: number;
+}
+
+export type AgentGraphTimelineEvent =
+  | (AgentGraphTimelineEventBase & {
+      kind: 'supervisor_turn_started';
+      run: AgentGraphTimelineRunRef;
+      wake?: { wakeId: string; attemptId: string };
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'supervisor_turn_terminal';
+      run: AgentGraphTimelineRunRef;
+      status: Extract<AgentRunHeader['status'], 'completed' | 'failed' | 'cancelled'>;
+      wake?: { wakeId: string; attemptId: string };
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'schedule_committed';
+      updateId: string;
+      revision: number;
+      source: AgentGraphScheduleUpdateSource;
+      workIds: string[];
+      stoppedTargetIds: string[];
+      closesGraph: boolean;
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'schedule_finished';
+      updateId: string;
+      revision: number;
+      source: AgentGraphScheduleUpdateSource;
+      resultIds: string[];
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'operator_provisioned';
+      provisionId: string;
+      workId: string;
+      agentId: string;
+      operatorId: string;
+      targetSessionId: string;
+      initialTurnId: string;
+      initialRunId: string;
+      edgeIds: string[];
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'intent_claimed';
+      claimId: string;
+      intentId: string;
+      operatorId: string;
+      activation: AgentGraphTimelineRunRef;
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'intent_admission_snapshot';
+      intentId: string;
+      state: AgentGraphIntentAdmissionState;
+      transitionHistory: 'current_only';
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'activation_started';
+      operatorId: string;
+      activation: AgentGraphTimelineRunRef;
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'record_committed';
+      recordId: string;
+      operatorId: string;
+      activation: AgentGraphTimelineRunRef;
+      facets: AgentGraphRecordFacet[];
+      sourceRuntimeEventId: string;
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'activation_terminal';
+      operatorId: string;
+      activation: AgentGraphTimelineRunRef;
+      status: Extract<AgentGraphActivationStatus, 'completed' | 'failed' | 'aborted' | 'cancelled'>;
+      terminalRecordId: string;
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'supervisor_wake_claimed';
+      wakeId: string;
+      snapshotVersion: string;
+      rootSessionId: string;
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'supervisor_wake_attempted';
+      wakeId: string;
+      attemptId: string;
+      turnId: string;
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'supervisor_wake_settled';
+      wakeId: string;
+      attemptId: string;
+      turnId: string;
+      status: 'delivered' | 'retryable_failed';
+    })
+  | (AgentGraphTimelineEventBase & {
+      kind: 'supervisor_wake_state_snapshot';
+      wakeId: string;
+      status: AgentGraphSupervisorWakeStatus;
+      transitionHistory: 'current_only';
+    });
+
+export interface AgentGraphTimelinePage {
+  schemaVersion: typeof AGENT_GRAPH_TIMELINE_SCHEMA_VERSION;
+  graphId: string;
+  rootSessionId: string;
+  events: AgentGraphTimelineEvent[];
+  totalEvents: number;
+  omittedBefore: number;
+  omittedAfter: number;
+  nextCursor?: string;
+  coverage: {
+    runtimeRecords: 'complete';
+    limitations: AgentGraphTimelineCoverageLimitation[];
+  };
+}
+
+export interface AgentGraphTimelinePageOptions {
+  cursor?: string;
+  limit?: number;
+}
+
+export interface ReadAgentGraphTimelinePageInput {
+  rootSessionId: string;
+  graphId: string;
+  controlStore: AgentGraphTimelineMetadataStore;
+  runStore: Pick<AgentRunStore, 'listSessionRuns'>;
+  runtimeEventStore: Pick<RuntimeEventStore, 'readImmutableRuntimeEvents'>;
+  options?: AgentGraphTimelinePageOptions;
+}
+
+export interface BuildAgentGraphTimelineInput {
+  rootSessionId: string;
+  graphId: string;
+  metadata: AgentGraphTimelineMetadataSnapshot;
+  rootRuns: readonly AgentRunHeader[];
+  projection: AgentGraphProjection;
+}
+
+type WithoutSequence<T> = T extends unknown ? Omit<T, 'sequence'> : never;
+type AgentGraphTimelineEventWithoutSequence = WithoutSequence<AgentGraphTimelineEvent>;
+
+interface PendingTimelineEvent {
+  event: AgentGraphTimelineEventWithoutSequence;
+  rank: number;
+  tieBreak: string;
+}
+
+const EVENT_RANK = {
+  supervisor_turn_started: 10,
+  schedule_committed: 20,
+  schedule_finished: 21,
+  operator_provisioned: 30,
+  intent_claimed: 40,
+  intent_admission_snapshot: 41,
+  activation_started: 50,
+  record_committed: 60,
+  activation_terminal: 61,
+  supervisor_turn_terminal: 70,
+  supervisor_wake_claimed: 80,
+  supervisor_wake_attempted: 81,
+  supervisor_wake_settled: 82,
+  supervisor_wake_state_snapshot: 83,
+} as const satisfies Record<AgentGraphTimelineEvent['kind'], number>;
+
+export async function readAgentGraphTimelinePage(
+  input: ReadAgentGraphTimelinePageInput,
+): Promise<AgentGraphTimelinePage> {
+  assertIdentity(input.rootSessionId, 'root Session id');
+  assertIdentity(input.graphId, 'graph id');
+  const metadata = await input.controlStore.readAgentGraphTimelineMetadata(input.graphId);
+  if (metadata.graphId !== input.graphId) {
+    throw new Error(`Agent graph timeline metadata belongs to ${metadata.graphId}`);
+  }
+  for (const update of metadata.scheduleUpdates) {
+    if (update.source.sessionId !== input.rootSessionId) {
+      throw new Error(
+        `Agent graph schedule ${update.updateId} is not owned by root Session ${input.rootSessionId}`,
+      );
+    }
+  }
+  const operators: AgentGraphOperatorBinding[] = metadata.operatorProvisions.map((provision) => ({
+    operatorId: provision.operatorId,
+    sessionId: provision.targetSessionId,
+  }));
+  const [rootRuns, projection] = await Promise.all([
+    input.runStore.listSessionRuns(input.rootSessionId),
+    readCommittedAgentGraphProjection({
+      graphId: input.graphId,
+      operators,
+      runStore: input.runStore,
+      runtimeEventStore: input.runtimeEventStore,
+    }),
+  ]);
+  return paginateAgentGraphTimeline(
+    buildAgentGraphTimeline({
+      rootSessionId: input.rootSessionId,
+      graphId: input.graphId,
+      metadata,
+      rootRuns,
+      projection,
+    }),
+    input.rootSessionId,
+    input.graphId,
+    input.options,
+  );
+}
+
+export function buildAgentGraphTimeline(
+  input: BuildAgentGraphTimelineInput,
+): AgentGraphTimelineEvent[] {
+  if (input.metadata.graphId !== input.graphId || input.projection.graphId !== input.graphId) {
+    throw new Error('Agent graph timeline sources belong to different graphs');
+  }
+  const pending: PendingTimelineEvent[] = [];
+  const push = (event: AgentGraphTimelineEventWithoutSequence, tieBreak = event.eventId): void => {
+    pending.push({ event, rank: EVENT_RANK[event.kind], tieBreak });
+  };
+
+  const relevantRootRunIds = new Set(
+    input.metadata.scheduleUpdates.map((update) => update.source.runId),
+  );
+  const wakeAttemptIds = new Set(
+    input.metadata.supervisorWakes.flatMap(({ attempts }) =>
+      attempts.map((attempt) => attempt.attemptId),
+    ),
+  );
+  for (const run of input.rootRuns) {
+    const wake =
+      run.agentGraphWakeId && run.agentGraphWakeAttemptId
+        ? { wakeId: run.agentGraphWakeId, attemptId: run.agentGraphWakeAttemptId }
+        : undefined;
+    if (!relevantRootRunIds.has(run.runId) && !wakeAttemptIds.has(wake?.attemptId ?? '')) {
+      continue;
+    }
+    assertRunRef(run, input.rootSessionId);
+    const runRef = timelineRunRef(run);
+    push({
+      ...eventBase(
+        input.graphId,
+        'supervisor_turn_started',
+        {
+          sessionId: run.sessionId,
+          runId: run.runId,
+        },
+        run.createdAt,
+      ),
+      kind: 'supervisor_turn_started',
+      run: runRef,
+      ...(wake ? { wake } : {}),
+    });
+    if (
+      run.completedAt !== undefined &&
+      (run.status === 'completed' || run.status === 'failed' || run.status === 'cancelled')
+    ) {
+      push({
+        ...eventBase(
+          input.graphId,
+          'supervisor_turn_terminal',
+          {
+            sessionId: run.sessionId,
+            runId: run.runId,
+            status: run.status,
+          },
+          run.completedAt,
+        ),
+        kind: 'supervisor_turn_terminal',
+        run: runRef,
+        status: run.status,
+        ...(wake ? { wake } : {}),
+      });
+    }
+  }
+
+  for (const update of input.metadata.scheduleUpdates) {
+    push({
+      ...eventBase(
+        input.graphId,
+        'schedule_committed',
+        { updateId: update.updateId },
+        update.committedAt,
+      ),
+      kind: 'schedule_committed',
+      updateId: update.updateId,
+      revision: update.revision,
+      source: { ...update.source },
+      workIds: update.addWork.map((work) => work.workId),
+      stoppedTargetIds: update.stop.map((stopped) => stopped.targetId),
+      closesGraph: update.finish !== undefined,
+    });
+    if (update.finish) {
+      push({
+        ...eventBase(
+          input.graphId,
+          'schedule_finished',
+          { updateId: update.updateId },
+          update.committedAt,
+        ),
+        kind: 'schedule_finished',
+        updateId: update.updateId,
+        revision: update.revision,
+        source: { ...update.source },
+        resultIds: [...update.finish.resultIds],
+      });
+    }
+  }
+
+  for (const provision of input.metadata.operatorProvisions) {
+    push({
+      ...eventBase(
+        input.graphId,
+        'operator_provisioned',
+        { provisionId: provision.provisionId },
+        provision.provisionedAt,
+      ),
+      kind: 'operator_provisioned',
+      provisionId: provision.provisionId,
+      workId: provision.workId,
+      agentId: provision.agentId,
+      operatorId: provision.operatorId,
+      targetSessionId: provision.targetSessionId,
+      initialTurnId: provision.initialTurnId,
+      initialRunId: provision.initialRunId,
+      edgeIds: provision.edges.map((edge) => edge.edgeId),
+    });
+  }
+
+  const admissionByIntent = new Map(
+    input.metadata.intentAdmissions.map((admission) => [admission.intentId, admission]),
+  );
+  for (const claim of input.metadata.intentClaims) {
+    const admission = admissionByIntent.get(claim.intentId);
+    if (!admission || admission.graphId !== input.graphId) {
+      throw new Error(`Agent graph claim ${claim.intentId} has no admission snapshot`);
+    }
+    push({
+      ...eventBase(input.graphId, 'intent_claimed', { claimId: claim.claimId }, claim.claimedAt),
+      kind: 'intent_claimed',
+      claimId: claim.claimId,
+      intentId: claim.intentId,
+      operatorId: claim.targetOperatorId,
+      activation: {
+        sessionId: claim.targetSessionId,
+        runId: claim.targetRunId,
+        turnId: claim.targetTurnId,
+      },
+    });
+    push({
+      ...eventBase(
+        input.graphId,
+        'intent_admission_snapshot',
+        { intentId: claim.intentId, state: admission.state, updatedAt: admission.updatedAt },
+        admission.updatedAt,
+      ),
+      kind: 'intent_admission_snapshot',
+      intentId: claim.intentId,
+      state: admission.state,
+      transitionHistory: 'current_only',
+    });
+  }
+  if (admissionByIntent.size !== input.metadata.intentClaims.length) {
+    throw new Error(`Agent graph ${input.graphId} has an orphan admission snapshot`);
+  }
+
+  const recordByRun = new Map<string, AgentGraphRecord[]>();
+  for (const record of input.projection.records) {
+    const records = recordByRun.get(record.agentRunId) ?? [];
+    records.push(record);
+    recordByRun.set(record.agentRunId, records);
+    push(
+      {
+        ...eventBase(
+          input.graphId,
+          'record_committed',
+          { recordId: record.recordId },
+          record.eventTime,
+        ),
+        kind: 'record_committed',
+        recordId: record.recordId,
+        operatorId: record.operatorId,
+        activation: {
+          sessionId: record.sessionId,
+          runId: record.agentRunId,
+          turnId: record.source.turnId,
+        },
+        facets: [...record.facets],
+        sourceRuntimeEventId: record.source.runtimeEventId,
+      },
+      recordTieBreak(record),
+    );
+  }
+  for (const operator of input.projection.operators) {
+    const state = input.projection.state.operators[operator.operatorId];
+    if (!state) continue;
+    for (const activation of Object.values(state.activations)) {
+      const records = recordByRun.get(activation.agentRunId) ?? [];
+      const first = records[0];
+      if (!first) continue;
+      push({
+        ...eventBase(
+          input.graphId,
+          'activation_started',
+          { operatorId: operator.operatorId, runId: activation.agentRunId },
+          first.orderKey.runCreatedAt,
+        ),
+        kind: 'activation_started',
+        operatorId: operator.operatorId,
+        activation: {
+          sessionId: operator.sessionId,
+          runId: activation.agentRunId,
+          turnId: first.source.turnId,
+        },
+      });
+      if (activation.terminalRecordId && isTerminalActivationStatus(activation.status)) {
+        const terminal = records.find((record) => record.recordId === activation.terminalRecordId);
+        if (!terminal) {
+          throw new Error(
+            `Agent graph activation ${activation.activationId} lost its terminal record`,
+          );
+        }
+        push({
+          ...eventBase(
+            input.graphId,
+            'activation_terminal',
+            { terminalRecordId: activation.terminalRecordId },
+            terminal.eventTime,
+          ),
+          kind: 'activation_terminal',
+          operatorId: operator.operatorId,
+          activation: {
+            sessionId: operator.sessionId,
+            runId: activation.agentRunId,
+            turnId: terminal.source.turnId,
+          },
+          status: activation.status,
+          terminalRecordId: activation.terminalRecordId,
+        });
+      }
+    }
+  }
+
+  for (const { wake, attempts } of input.metadata.supervisorWakes) {
+    if (wake.graphId !== input.graphId || wake.rootSessionId !== input.rootSessionId) {
+      throw new Error(`Agent graph supervisor wake ${wake.wakeId} belongs to another graph`);
+    }
+    push({
+      ...eventBase(
+        input.graphId,
+        'supervisor_wake_claimed',
+        { wakeId: wake.wakeId },
+        wake.createdAt,
+      ),
+      kind: 'supervisor_wake_claimed',
+      wakeId: wake.wakeId,
+      snapshotVersion: wake.snapshotVersion,
+      rootSessionId: wake.rootSessionId,
+    });
+    for (const attempt of attempts) {
+      push({
+        ...eventBase(
+          input.graphId,
+          'supervisor_wake_attempted',
+          { attemptId: attempt.attemptId },
+          attempt.startedAt,
+        ),
+        kind: 'supervisor_wake_attempted',
+        wakeId: attempt.wakeId,
+        attemptId: attempt.attemptId,
+        turnId: attempt.turnId,
+      });
+      if (
+        attempt.completedAt !== undefined &&
+        (attempt.status === 'delivered' || attempt.status === 'retryable_failed')
+      ) {
+        push({
+          ...eventBase(
+            input.graphId,
+            'supervisor_wake_settled',
+            { attemptId: attempt.attemptId, status: attempt.status },
+            attempt.completedAt,
+          ),
+          kind: 'supervisor_wake_settled',
+          wakeId: attempt.wakeId,
+          attemptId: attempt.attemptId,
+          turnId: attempt.turnId,
+          status: attempt.status,
+        });
+      }
+    }
+    push({
+      ...eventBase(
+        input.graphId,
+        'supervisor_wake_state_snapshot',
+        { wakeId: wake.wakeId, status: wake.status, updatedAt: wake.updatedAt },
+        wake.updatedAt,
+      ),
+      kind: 'supervisor_wake_state_snapshot',
+      wakeId: wake.wakeId,
+      status: wake.status,
+      transitionHistory: 'current_only',
+    });
+  }
+
+  pending.sort(
+    (a, b) =>
+      a.event.eventTime - b.event.eventTime ||
+      a.rank - b.rank ||
+      a.tieBreak.localeCompare(b.tieBreak) ||
+      a.event.eventId.localeCompare(b.event.eventId),
+  );
+  const seen = new Set<string>();
+  return pending.map(({ event }, index) => {
+    if (seen.has(event.eventId)) {
+      throw new Error(`Duplicate agent graph timeline event ${event.eventId}`);
+    }
+    seen.add(event.eventId);
+    return { ...event, sequence: index + 1 } as AgentGraphTimelineEvent;
+  });
+}
+
+export function paginateAgentGraphTimeline(
+  events: readonly AgentGraphTimelineEvent[],
+  rootSessionId: string,
+  graphId: string,
+  options: AgentGraphTimelinePageOptions = {},
+): AgentGraphTimelinePage {
+  const limit = options.limit ?? AGENT_GRAPH_TIMELINE_DEFAULT_PAGE_SIZE;
+  if (!Number.isSafeInteger(limit) || limit < 1 || limit > AGENT_GRAPH_TIMELINE_MAX_PAGE_SIZE) {
+    throw new Error(
+      `Agent graph timeline limit must be between 1 and ${AGENT_GRAPH_TIMELINE_MAX_PAGE_SIZE}`,
+    );
+  }
+  let start = 0;
+  if (options.cursor) {
+    const cursor = decodeAgentGraphTimelineCursor(options.cursor);
+    if (cursor.graphId !== graphId) {
+      throw new Error('Agent graph timeline cursor belongs to another graph');
+    }
+    const index = events.findIndex(
+      (event) => event.eventId === cursor.eventId && event.eventTime === cursor.eventTime,
+    );
+    if (index < 0) throw new Error('Agent graph timeline cursor is stale or invalid');
+    start = index + 1;
+  }
+  const pageEvents = events.slice(start, start + limit).map(cloneTimelineEvent);
+  const omittedAfter = Math.max(0, events.length - start - pageEvents.length);
+  return {
+    schemaVersion: AGENT_GRAPH_TIMELINE_SCHEMA_VERSION,
+    graphId,
+    rootSessionId,
+    events: pageEvents,
+    totalEvents: events.length,
+    omittedBefore: start,
+    omittedAfter,
+    ...(omittedAfter > 0 && pageEvents.length > 0
+      ? { nextCursor: encodeAgentGraphTimelineCursor(graphId, pageEvents.at(-1)!) }
+      : {}),
+    coverage: {
+      runtimeRecords: 'complete',
+      limitations: [
+        'admission_transition_history_not_persisted',
+        'supervisor_wake_transition_history_not_persisted',
+        'reconcile_history_not_persisted',
+      ],
+    },
+  };
+}
+
+export function encodeAgentGraphTimelineCursor(
+  graphId: string,
+  event: Pick<AgentGraphTimelineEvent, 'eventId' | 'eventTime'>,
+): string {
+  return Buffer.from(
+    JSON.stringify({
+      schemaVersion: AGENT_GRAPH_TIMELINE_SCHEMA_VERSION,
+      graphId,
+      eventId: event.eventId,
+      eventTime: event.eventTime,
+    }),
+    'utf8',
+  ).toString('base64url');
+}
+
+export function decodeAgentGraphTimelineCursor(cursor: string): {
+  graphId: string;
+  eventId: string;
+  eventTime: number;
+} {
+  if (
+    typeof cursor !== 'string' ||
+    cursor.length === 0 ||
+    cursor.length > 2_048 ||
+    cursor.trim() !== cursor
+  ) {
+    throw new Error('Invalid agent graph timeline cursor');
+  }
+  try {
+    const json = Buffer.from(cursor, 'base64url').toString('utf8');
+    const canonical = Buffer.from(json, 'utf8').toString('base64url');
+    const value = JSON.parse(json) as Record<string, unknown>;
+    if (
+      canonical !== cursor ||
+      Object.keys(value).sort().join(',') !== 'eventId,eventTime,graphId,schemaVersion' ||
+      value.schemaVersion !== AGENT_GRAPH_TIMELINE_SCHEMA_VERSION ||
+      typeof value.eventTime !== 'number' ||
+      !Number.isSafeInteger(value.eventTime) ||
+      value.eventTime < 0
+    ) {
+      throw new Error('invalid cursor envelope');
+    }
+    return {
+      graphId: cursorIdentity(value.graphId),
+      eventId: cursorIdentity(value.eventId),
+      eventTime: value.eventTime,
+    };
+  } catch {
+    throw new Error('Invalid agent graph timeline cursor');
+  }
+}
+
+function eventBase(
+  graphId: string,
+  kind: AgentGraphTimelineEvent['kind'],
+  identity: unknown,
+  eventTime: number,
+): Omit<AgentGraphTimelineEventBase, 'sequence'> {
+  if (!Number.isSafeInteger(eventTime) || eventTime < 0) {
+    throw new Error(`Invalid agent graph timeline timestamp for ${kind}`);
+  }
+  return {
+    schemaVersion: AGENT_GRAPH_TIMELINE_SCHEMA_VERSION,
+    eventId: `graph_timeline_${stableHash({ graphId, kind, identity }).slice('sha256:'.length, 48)}`,
+    graphId,
+    eventTime,
+  };
+}
+
+function timelineRunRef(run: AgentRunHeader): AgentGraphTimelineRunRef {
+  return {
+    sessionId: run.sessionId,
+    runId: run.runId,
+    turnId: run.turnId,
+  };
+}
+
+function assertRunRef(run: AgentRunHeader, sessionId: string): void {
+  if (run.sessionId !== sessionId) {
+    throw new Error(`AgentRun ${run.runId} belongs to ${run.sessionId}, expected ${sessionId}`);
+  }
+}
+
+function recordTieBreak(record: AgentGraphRecord): string {
+  return [
+    String(record.orderKey.runCreatedAt).padStart(16, '0'),
+    record.orderKey.operatorId,
+    record.orderKey.runId,
+    String(record.orderKey.committedEventOrdinal).padStart(12, '0'),
+    record.orderKey.runtimeEventId,
+  ].join('\0');
+}
+
+function isTerminalActivationStatus(
+  status: AgentGraphActivationStatus,
+): status is Extract<AgentGraphActivationStatus, 'completed' | 'failed' | 'aborted' | 'cancelled'> {
+  return status !== 'running';
+}
+
+function cloneTimelineEvent(event: AgentGraphTimelineEvent): AgentGraphTimelineEvent {
+  return structuredClone(event);
+}
+
+function assertIdentity(value: string, name: string): void {
+  if (
+    !value ||
+    value.length > 512 ||
+    value.trim() !== value ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new Error(`Invalid agent graph timeline ${name}`);
+  }
+}
+
+function cursorIdentity(value: unknown): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    value.length > 512 ||
+    value.trim() !== value ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new Error('invalid cursor identity');
+  }
+  return value;
+}

--- a/packages/runtime/src/agent-graph-timeline.ts
+++ b/packages/runtime/src/agent-graph-timeline.ts
@@ -11,7 +11,7 @@ import type {
 } from '@maka/core';
 import { stableHash } from './request-shape.js';
 import {
-  readCommittedAgentGraphProjection,
+  readCommittedAgentGraphProjectionWithRuns,
   type AgentGraphActivationStatus,
   type AgentGraphOperatorBinding,
   type AgentGraphProjection,
@@ -90,12 +90,6 @@ export type AgentGraphTimelineEvent =
       activation: AgentGraphTimelineRunRef;
     })
   | (AgentGraphTimelineEventBase & {
-      kind: 'intent_admission_snapshot';
-      intentId: string;
-      state: AgentGraphIntentAdmissionState;
-      transitionHistory: 'current_only';
-    })
-  | (AgentGraphTimelineEventBase & {
       kind: 'activation_started';
       operatorId: string;
       activation: AgentGraphTimelineRunRef;
@@ -133,13 +127,33 @@ export type AgentGraphTimelineEvent =
       attemptId: string;
       turnId: string;
       status: 'delivered' | 'retryable_failed';
-    })
-  | (AgentGraphTimelineEventBase & {
-      kind: 'supervisor_wake_state_snapshot';
-      wakeId: string;
-      status: AgentGraphSupervisorWakeStatus;
-      transitionHistory: 'current_only';
     });
+
+export interface AgentGraphTimelineCurrentAdmission {
+  intentId: string;
+  state: AgentGraphIntentAdmissionState;
+  updatedAt: number;
+}
+
+export interface AgentGraphTimelineCurrentSupervisorWake {
+  wakeId: string;
+  status: AgentGraphSupervisorWakeStatus;
+  attemptCount: number;
+  updatedAt: number;
+  currentAttemptId?: string;
+  currentTurnId?: string;
+}
+
+/**
+ * Mutable control-plane state observed while reconstructing this page.
+ *
+ * It intentionally lives outside the pageable immutable event stream so a
+ * state transition cannot invalidate an already-issued historical cursor.
+ */
+export interface AgentGraphTimelineCurrentState {
+  admissions: AgentGraphTimelineCurrentAdmission[];
+  supervisorWakes: AgentGraphTimelineCurrentSupervisorWake[];
+}
 
 export interface AgentGraphTimelinePage {
   schemaVersion: typeof AGENT_GRAPH_TIMELINE_SCHEMA_VERSION;
@@ -150,6 +164,7 @@ export interface AgentGraphTimelinePage {
   omittedBefore: number;
   omittedAfter: number;
   nextCursor?: string;
+  currentState: AgentGraphTimelineCurrentState;
   coverage: {
     runtimeRecords: 'complete';
     limitations: AgentGraphTimelineCoverageLimitation[];
@@ -175,6 +190,7 @@ export interface BuildAgentGraphTimelineInput {
   graphId: string;
   metadata: AgentGraphTimelineMetadataSnapshot;
   rootRuns: readonly AgentRunHeader[];
+  childRuns: readonly AgentRunHeader[];
   projection: AgentGraphProjection;
 }
 
@@ -193,7 +209,6 @@ const EVENT_RANK = {
   schedule_finished: 21,
   operator_provisioned: 30,
   intent_claimed: 40,
-  intent_admission_snapshot: 41,
   activation_started: 50,
   record_committed: 60,
   activation_terminal: 61,
@@ -201,7 +216,6 @@ const EVENT_RANK = {
   supervisor_wake_claimed: 80,
   supervisor_wake_attempted: 81,
   supervisor_wake_settled: 82,
-  supervisor_wake_state_snapshot: 83,
 } as const satisfies Record<AgentGraphTimelineEvent['kind'], number>;
 
 export async function readAgentGraphTimelinePage(
@@ -224,9 +238,9 @@ export async function readAgentGraphTimelinePage(
     operatorId: provision.operatorId,
     sessionId: provision.targetSessionId,
   }));
-  const [rootRuns, projection] = await Promise.all([
+  const [rootRuns, projected] = await Promise.all([
     input.runStore.listSessionRuns(input.rootSessionId),
-    readCommittedAgentGraphProjection({
+    readCommittedAgentGraphProjectionWithRuns({
       graphId: input.graphId,
       operators,
       runStore: input.runStore,
@@ -239,10 +253,12 @@ export async function readAgentGraphTimelinePage(
       graphId: input.graphId,
       metadata,
       rootRuns,
-      projection,
+      childRuns: projected.runs,
+      projection: projected.projection,
     }),
     input.rootSessionId,
     input.graphId,
+    buildAgentGraphTimelineCurrentState(metadata, input.rootSessionId, input.graphId),
     input.options,
   );
 }
@@ -366,13 +382,26 @@ export function buildAgentGraphTimeline(
     });
   }
 
-  const admissionByIntent = new Map(
-    input.metadata.intentAdmissions.map((admission) => [admission.intentId, admission]),
+  const operatorSessionById = new Map(
+    input.metadata.operatorProvisions.map((provision) => [
+      provision.operatorId,
+      provision.targetSessionId,
+    ]),
   );
+  const childRunByIdentity = new Map<string, AgentRunHeader>();
+  for (const run of input.childRuns) {
+    const key = `${run.sessionId}\0${run.runId}`;
+    if (childRunByIdentity.has(key)) {
+      throw new Error(`Agent graph timeline contains duplicate AgentRun ${run.runId}`);
+    }
+    childRunByIdentity.set(key, run);
+  }
   for (const claim of input.metadata.intentClaims) {
-    const admission = admissionByIntent.get(claim.intentId);
-    if (!admission || admission.graphId !== input.graphId) {
-      throw new Error(`Agent graph claim ${claim.intentId} has no admission snapshot`);
+    if (
+      claim.graphId !== input.graphId ||
+      operatorSessionById.get(claim.targetOperatorId) !== claim.targetSessionId
+    ) {
+      throw new Error(`Agent graph claim ${claim.intentId} has no matching operator binding`);
     }
     push({
       ...eventBase(input.graphId, 'intent_claimed', { claimId: claim.claimId }, claim.claimedAt),
@@ -386,21 +415,24 @@ export function buildAgentGraphTimeline(
         turnId: claim.targetTurnId,
       },
     });
+    const run = childRunByIdentity.get(`${claim.targetSessionId}\0${claim.targetRunId}`);
+    if (!run) continue;
+    if (run.turnId !== claim.targetTurnId) {
+      throw new Error(
+        `Agent graph activation ${claim.targetRunId} belongs to turn ${run.turnId}, expected ${claim.targetTurnId}`,
+      );
+    }
     push({
       ...eventBase(
         input.graphId,
-        'intent_admission_snapshot',
-        { intentId: claim.intentId, state: admission.state, updatedAt: admission.updatedAt },
-        admission.updatedAt,
+        'activation_started',
+        { operatorId: claim.targetOperatorId, runId: run.runId },
+        run.createdAt,
       ),
-      kind: 'intent_admission_snapshot',
-      intentId: claim.intentId,
-      state: admission.state,
-      transitionHistory: 'current_only',
+      kind: 'activation_started',
+      operatorId: claim.targetOperatorId,
+      activation: timelineRunRef(run),
     });
-  }
-  if (admissionByIntent.size !== input.metadata.intentClaims.length) {
-    throw new Error(`Agent graph ${input.graphId} has an orphan admission snapshot`);
   }
 
   const recordByRun = new Map<string, AgentGraphRecord[]>();
@@ -435,23 +467,6 @@ export function buildAgentGraphTimeline(
     if (!state) continue;
     for (const activation of Object.values(state.activations)) {
       const records = recordByRun.get(activation.agentRunId) ?? [];
-      const first = records[0];
-      if (!first) continue;
-      push({
-        ...eventBase(
-          input.graphId,
-          'activation_started',
-          { operatorId: operator.operatorId, runId: activation.agentRunId },
-          first.orderKey.runCreatedAt,
-        ),
-        kind: 'activation_started',
-        operatorId: operator.operatorId,
-        activation: {
-          sessionId: operator.sessionId,
-          runId: activation.agentRunId,
-          turnId: first.source.turnId,
-        },
-      });
       if (activation.terminalRecordId && isTerminalActivationStatus(activation.status)) {
         const terminal = records.find((record) => record.recordId === activation.terminalRecordId);
         if (!terminal) {
@@ -528,18 +543,6 @@ export function buildAgentGraphTimeline(
         });
       }
     }
-    push({
-      ...eventBase(
-        input.graphId,
-        'supervisor_wake_state_snapshot',
-        { wakeId: wake.wakeId, status: wake.status, updatedAt: wake.updatedAt },
-        wake.updatedAt,
-      ),
-      kind: 'supervisor_wake_state_snapshot',
-      wakeId: wake.wakeId,
-      status: wake.status,
-      transitionHistory: 'current_only',
-    });
   }
 
   pending.sort(
@@ -559,10 +562,59 @@ export function buildAgentGraphTimeline(
   });
 }
 
+export function buildAgentGraphTimelineCurrentState(
+  metadata: AgentGraphTimelineMetadataSnapshot,
+  rootSessionId: string,
+  graphId: string,
+): AgentGraphTimelineCurrentState {
+  if (metadata.graphId !== graphId) {
+    throw new Error(`Agent graph timeline metadata belongs to ${metadata.graphId}`);
+  }
+  const claimIntentIds = new Set(metadata.intentClaims.map((claim) => claim.intentId));
+  if (claimIntentIds.size !== metadata.intentClaims.length) {
+    throw new Error(`Agent graph ${graphId} has duplicate intent claims`);
+  }
+  const admissionIntentIds = new Set<string>();
+  const admissions = metadata.intentAdmissions.map((admission) => {
+    if (admission.graphId !== graphId || !claimIntentIds.has(admission.intentId)) {
+      throw new Error(`Agent graph admission ${admission.intentId} belongs to another graph`);
+    }
+    if (admissionIntentIds.has(admission.intentId)) {
+      throw new Error(`Agent graph ${graphId} has duplicate admission snapshots`);
+    }
+    admissionIntentIds.add(admission.intentId);
+    return {
+      intentId: admission.intentId,
+      state: admission.state,
+      updatedAt: admission.updatedAt,
+    };
+  });
+  if (admissionIntentIds.size !== claimIntentIds.size) {
+    throw new Error(`Agent graph ${graphId} has a missing or duplicate admission snapshot`);
+  }
+  const supervisorWakes = metadata.supervisorWakes.map(({ wake }) => {
+    if (wake.graphId !== graphId || wake.rootSessionId !== rootSessionId) {
+      throw new Error(`Agent graph supervisor wake ${wake.wakeId} belongs to another graph`);
+    }
+    return {
+      wakeId: wake.wakeId,
+      status: wake.status,
+      attemptCount: wake.attemptCount,
+      updatedAt: wake.updatedAt,
+      ...(wake.currentAttemptId ? { currentAttemptId: wake.currentAttemptId } : {}),
+      ...(wake.currentTurnId ? { currentTurnId: wake.currentTurnId } : {}),
+    };
+  });
+  admissions.sort((a, b) => a.intentId.localeCompare(b.intentId));
+  supervisorWakes.sort((a, b) => a.wakeId.localeCompare(b.wakeId));
+  return { admissions, supervisorWakes };
+}
+
 export function paginateAgentGraphTimeline(
   events: readonly AgentGraphTimelineEvent[],
   rootSessionId: string,
   graphId: string,
+  currentState: AgentGraphTimelineCurrentState,
   options: AgentGraphTimelinePageOptions = {},
 ): AgentGraphTimelinePage {
   const limit = options.limit ?? AGENT_GRAPH_TIMELINE_DEFAULT_PAGE_SIZE;
@@ -593,6 +645,7 @@ export function paginateAgentGraphTimeline(
     totalEvents: events.length,
     omittedBefore: start,
     omittedAfter,
+    currentState: cloneTimelineCurrentState(currentState),
     ...(omittedAfter > 0 && pageEvents.length > 0
       ? { nextCursor: encodeAgentGraphTimelineCursor(graphId, pageEvents.at(-1)!) }
       : {}),
@@ -708,6 +761,15 @@ function isTerminalActivationStatus(
 
 function cloneTimelineEvent(event: AgentGraphTimelineEvent): AgentGraphTimelineEvent {
   return structuredClone(event);
+}
+
+function cloneTimelineCurrentState(
+  currentState: AgentGraphTimelineCurrentState,
+): AgentGraphTimelineCurrentState {
+  return {
+    admissions: currentState.admissions.map((admission) => ({ ...admission })),
+    supervisorWakes: currentState.supervisorWakes.map((wake) => ({ ...wake })),
+  };
 }
 
 function assertIdentity(value: string, name: string): void {

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -66,6 +66,25 @@ export type {
   ReadCommittedAgentGraphProjectionInput,
 } from './stream-graph-projection.js';
 export {
+  AGENT_GRAPH_TIMELINE_DEFAULT_PAGE_SIZE,
+  AGENT_GRAPH_TIMELINE_MAX_PAGE_SIZE,
+  AGENT_GRAPH_TIMELINE_SCHEMA_VERSION,
+  buildAgentGraphTimeline,
+  decodeAgentGraphTimelineCursor,
+  encodeAgentGraphTimelineCursor,
+  paginateAgentGraphTimeline,
+  readAgentGraphTimelinePage,
+} from './agent-graph-timeline.js';
+export type {
+  AgentGraphTimelineCoverageLimitation,
+  AgentGraphTimelineEvent,
+  AgentGraphTimelinePage,
+  AgentGraphTimelinePageOptions,
+  AgentGraphTimelineRunRef,
+  BuildAgentGraphTimelineInput,
+  ReadAgentGraphTimelinePageInput,
+} from './agent-graph-timeline.js';
+export {
   AGENT_GRAPH_TRACE_SCHEMA_VERSION,
   buildAgentGraphTraceSnapshot,
 } from './stream-graph-trace.js';

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -70,6 +70,7 @@ export {
   AGENT_GRAPH_TIMELINE_MAX_PAGE_SIZE,
   AGENT_GRAPH_TIMELINE_SCHEMA_VERSION,
   buildAgentGraphTimeline,
+  buildAgentGraphTimelineCurrentState,
   decodeAgentGraphTimelineCursor,
   encodeAgentGraphTimelineCursor,
   paginateAgentGraphTimeline,
@@ -77,6 +78,9 @@ export {
 } from './agent-graph-timeline.js';
 export type {
   AgentGraphTimelineCoverageLimitation,
+  AgentGraphTimelineCurrentAdmission,
+  AgentGraphTimelineCurrentState,
+  AgentGraphTimelineCurrentSupervisorWake,
   AgentGraphTimelineEvent,
   AgentGraphTimelinePage,
   AgentGraphTimelinePageOptions,

--- a/packages/runtime/src/stream-graph-coordinator.ts
+++ b/packages/runtime/src/stream-graph-coordinator.ts
@@ -2,6 +2,7 @@ import type {
   AgentGraphClientProjectionStore,
   AgentGraphIntentClaim,
   AgentGraphScheduleControlStore,
+  AgentGraphTimelineMetadataStore,
   AgentGraphScheduleUpdate,
   AgentGraphOperatorProvision,
   AgentRunStore,
@@ -50,6 +51,11 @@ import {
 import { buildAgentGraphSupervisorTools } from './stream-graph-supervisor-tools.js';
 import type { AgentGraphTraceTopology } from './stream-graph-trace.js';
 import { stableHash } from './request-shape.js';
+import {
+  readAgentGraphTimelinePage,
+  type AgentGraphTimelinePage,
+  type AgentGraphTimelinePageOptions,
+} from './agent-graph-timeline.js';
 
 const DEFAULT_MAX_NEW_ACTIVATIONS = 8;
 const MAX_CLIENT_PROJECTION_COMMIT_ATTEMPTS = 4;
@@ -69,7 +75,9 @@ export interface AgentGraphCoordinatorInput {
   sessionStore: AgentGraphCoordinatorSessionStore;
   runStore: Pick<AgentRunStore, 'listSessionRuns'>;
   runtimeEventStore: Pick<RuntimeEventStore, 'readImmutableRuntimeEvents'>;
-  controlStore: AgentGraphScheduleControlStore & AgentGraphClientProjectionStore;
+  controlStore: AgentGraphScheduleControlStore &
+    AgentGraphClientProjectionStore &
+    AgentGraphTimelineMetadataStore;
   runtime: AgentGraphCoordinatorRuntime;
   newId: () => string;
   /** Restrict an attempt-local coordinator to exactly one root Session graph. */
@@ -233,6 +241,28 @@ export class AgentGraphCoordinator {
       terminalPage.hasMore,
     );
     return snapshot;
+  }
+
+  /**
+   * Reconstruct one stable, reference-only control/data-plane timeline page.
+   *
+   * SQLite supplies one metadata snapshot; AgentRun and immutable RuntimeEvent
+   * ledgers supply root-turn and operator activity without exposing payloads.
+   */
+  async getTimeline(
+    rootSessionId: string,
+    options: AgentGraphTimelinePageOptions = {},
+  ): Promise<AgentGraphTimelinePage> {
+    await this.#assertRootGraphReader(rootSessionId);
+    const graphId = agentGraphIdForRootSession(rootSessionId);
+    return readAgentGraphTimelinePage({
+      rootSessionId,
+      graphId,
+      controlStore: this.#input.controlStore,
+      runStore: this.#input.runStore,
+      runtimeEventStore: this.#input.runtimeEventStore,
+      options,
+    });
   }
 
   /** Inspect one operator without requiring it to be present in the bounded snapshot page. */

--- a/packages/runtime/src/stream-graph-projection.ts
+++ b/packages/runtime/src/stream-graph-projection.ts
@@ -185,6 +185,11 @@ export interface ReadCommittedAgentGraphProjectionInput {
   runtimeEventStore: Pick<RuntimeEventStore, 'readImmutableRuntimeEvents'>;
 }
 
+export interface AgentGraphProjectionWithRuns {
+  projection: AgentGraphProjection;
+  runs: AgentRunHeader[];
+}
+
 interface OrderedRuntimeEvent {
   operator: AgentGraphOperatorBinding;
   run: AgentRunHeader;
@@ -199,6 +204,12 @@ interface MutableAgentGraphOperatorState extends Omit<AgentGraphOperatorState, '
 export async function readCommittedAgentGraphProjection(
   input: ReadCommittedAgentGraphProjectionInput,
 ): Promise<AgentGraphProjection> {
+  return (await readCommittedAgentGraphProjectionWithRuns(input)).projection;
+}
+
+export async function readCommittedAgentGraphProjectionWithRuns(
+  input: ReadCommittedAgentGraphProjectionInput,
+): Promise<AgentGraphProjectionWithRuns> {
   assertGraphIdentity(input.graphId, input.operators);
   const readImmutableRuntimeEvents = input.runtimeEventStore.readImmutableRuntimeEvents;
   if (!readImmutableRuntimeEvents) {
@@ -240,12 +251,15 @@ export async function readCommittedAgentGraphProjection(
       ? replayAgentGraphRecords(projected.records)
       : { graphId: input.graphId, appliedRecordIds: [], operators: {} };
   return {
-    graphId: input.graphId,
-    operators: input.operators.map((operator) => ({ ...operator })),
-    ignoredPartialEvents: projected.ignoredPartialEvents,
-    records: projected.records,
-    supervisorMetaStream: projected.supervisorMetaStream,
-    state,
+    runs: streams.map((stream) => ({ ...stream.run })),
+    projection: {
+      graphId: input.graphId,
+      operators: input.operators.map((operator) => ({ ...operator })),
+      ignoredPartialEvents: projected.ignoredPartialEvents,
+      records: projected.records,
+      supervisorMetaStream: projected.supervisorMetaStream,
+      state,
+    },
   };
 }
 

--- a/packages/storage/src/__tests__/agent-graph-timeline-metadata.test.ts
+++ b/packages/storage/src/__tests__/agent-graph-timeline-metadata.test.ts
@@ -1,0 +1,119 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  AGENT_GRAPH_INTENT_CLAIM_SCHEMA_VERSION,
+  AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
+  AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION,
+} from '@maka/core';
+import { createSqliteSessionMetadataStore } from '../sqlite-session-metadata-store.js';
+
+describe('SQLite agent graph timeline metadata', () => {
+  test('reads one graph control-plane snapshot with current admission and wake attempts', async () => {
+    let now = 100;
+    const store = createSqliteSessionMetadataStore(':memory:', { now: () => now++ });
+    try {
+      await store.commitAgentGraphScheduleUpdate({
+        schemaVersion: AGENT_GRAPH_SCHEDULE_UPDATE_SCHEMA_VERSION,
+        updateId: `graph_update_${'a'.repeat(32)}`,
+        updateFingerprint: `sha256:${'b'.repeat(64)}`,
+        graphId: 'graph-1',
+        source: {
+          sessionId: 'root-session',
+          runId: 'root-run',
+          turnId: 'root-turn',
+          toolCallId: 'schedule-call',
+        },
+        addWork: [
+          {
+            workId: `graph_work_${'c'.repeat(32)}`,
+            target: { kind: 'operator', operatorId: 'operator-1' },
+            instruction: 'Sensitive schedule instruction.',
+            inputIds: [],
+          },
+        ],
+        stop: [],
+      });
+      await store.claimAgentGraphIntentAtScheduleRevision(
+        {
+          schemaVersion: AGENT_GRAPH_INTENT_CLAIM_SCHEMA_VERSION,
+          claimId: `graph_claim_${'d'.repeat(32)}`,
+          graphId: 'graph-1',
+          intentId: `graph_intent_${'e'.repeat(32)}`,
+          intentFingerprint: `sha256:${'f'.repeat(64)}`,
+          readinessContextFingerprint: `sha256:${'1'.repeat(64)}`,
+          targetOperatorId: 'operator-1',
+          targetSessionId: 'child-session',
+          targetTurnId: 'child-turn',
+          targetRunId: 'child-run',
+        },
+        1,
+      );
+      await store.beginAgentGraphIntentExecutionAtScheduleRevision(
+        'graph-1',
+        `graph_intent_${'e'.repeat(32)}`,
+        1,
+      );
+      await store.claimAgentGraphSupervisorWake({
+        schemaVersion: AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION,
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        snapshotVersion: 'snapshot-1',
+        rootSessionId: 'root-session',
+      });
+      await store.beginAgentGraphSupervisorWakeAttempt({
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        attemptId: 'attempt-1',
+        turnId: 'wake-turn',
+      });
+      await store.completeAgentGraphSupervisorWakeAttempt({
+        graphId: 'graph-1',
+        wakeId: 'wake-1',
+        attemptId: 'attempt-1',
+        status: 'delivered',
+      });
+
+      const snapshot = await store.readAgentGraphTimelineMetadata('graph-1');
+      assert.equal(snapshot.graphId, 'graph-1');
+      assert.equal(snapshot.scheduleUpdates.length, 1);
+      assert.equal(snapshot.operatorProvisions.length, 0);
+      assert.equal(snapshot.intentClaims.length, 1);
+      assert.deepEqual(snapshot.intentAdmissions, [
+        {
+          graphId: 'graph-1',
+          intentId: `graph_intent_${'e'.repeat(32)}`,
+          state: 'executing',
+          updatedAt: 102,
+        },
+      ]);
+      assert.equal(snapshot.supervisorWakes.length, 1);
+      assert.equal(snapshot.supervisorWakes[0]?.wake.status, 'delivered');
+      assert.deepEqual(
+        snapshot.supervisorWakes[0]?.attempts.map((attempt) => ({
+          attemptId: attempt.attemptId,
+          status: attempt.status,
+          startedAt: attempt.startedAt,
+          completedAt: attempt.completedAt,
+        })),
+        [
+          {
+            attemptId: 'attempt-1',
+            status: 'delivered',
+            startedAt: 104,
+            completedAt: 105,
+          },
+        ],
+      );
+      assert.deepEqual(await store.readAgentGraphTimelineMetadata('another-graph'), {
+        graphId: 'another-graph',
+        scheduleUpdates: [],
+        operatorProvisions: [],
+        intentClaims: [],
+        intentAdmissions: [],
+        supervisorWakes: [],
+      });
+    } finally {
+      store.close();
+    }
+  });
+});

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -22,6 +22,7 @@ import {
   type AgentGraphScheduleUpdateResult,
   type AgentGraphIntentAdmissionState,
   type AgentGraphIntentAdmissionTransition,
+  type AgentGraphIntentAdmissionSnapshot,
   type AgentGraphIntentClaim,
   type AgentGraphIntentClaimRequest,
   type AgentGraphIntentClaimResult,
@@ -36,6 +37,7 @@ import {
   AGENT_GRAPH_SUPERVISOR_WAKE_SCHEMA_VERSION,
   type AgentGraphSupervisorWakeAttemptRecord,
   type AgentGraphSupervisorWakeRecord,
+  type AgentGraphTimelineMetadataSnapshot,
   type BeginAgentGraphSupervisorWakeAttemptRequest,
   type ClaimAgentGraphSupervisorWakeRequest,
   type CompleteAgentGraphSupervisorWakeAttemptRequest,
@@ -931,6 +933,134 @@ export class SqliteSessionMetadataStore {
     return rows.map((row) =>
       decodeAgentGraphOperatorProvision(JSON.parse(row.payloadJson) as unknown),
     );
+  }
+
+  async readAgentGraphTimelineMetadata(
+    graphId: string,
+  ): Promise<AgentGraphTimelineMetadataSnapshot> {
+    this.assertOpen();
+    assertGraphLookupIdentity(graphId, 'graph id');
+    return this.readTransaction(() => {
+      const scheduleUpdates = (
+        this.db
+          .prepare(`
+            SELECT payload_json AS payloadJson
+            FROM agent_graph_schedule_updates
+            WHERE graph_id = ?
+            ORDER BY revision ASC
+          `)
+          .all(graphId) as unknown as AgentGraphScheduleUpdateRow[]
+      ).map(decodeAgentGraphScheduleUpdateRow);
+      const operatorProvisions = (
+        this.db
+          .prepare(`
+            SELECT payload_json AS payloadJson
+            FROM agent_graph_operator_provisions
+            WHERE graph_id = ?
+            ORDER BY provisioned_at ASC, operator_id ASC
+          `)
+          .all(graphId) as unknown as AgentGraphOperatorProvisionRow[]
+      ).map((row) => decodeAgentGraphOperatorProvision(JSON.parse(row.payloadJson) as unknown));
+      const intentClaims = (
+        this.db
+          .prepare(`
+            SELECT
+              schema_version AS schemaVersion,
+              claim_id AS claimId,
+              graph_id AS graphId,
+              intent_id AS intentId,
+              intent_fingerprint AS intentFingerprint,
+              readiness_context_fingerprint AS readinessContextFingerprint,
+              target_operator_id AS targetOperatorId,
+              target_session_id AS targetSessionId,
+              target_turn_id AS targetTurnId,
+              target_run_id AS targetRunId,
+              claimed_at AS claimedAt
+            FROM agent_graph_intent_claims
+            WHERE graph_id = ?
+            ORDER BY claimed_at ASC, intent_id ASC
+          `)
+          .all(graphId) as unknown as AgentGraphIntentClaim[]
+      ).map(decodeAgentGraphIntentClaim);
+      const intentAdmissions = (
+        this.db
+          .prepare(`
+            SELECT
+              graph_id AS graphId,
+              intent_id AS intentId,
+              admission_status AS state,
+              admission_updated_at AS updatedAt,
+              cancellation_reason AS cancellationReason
+            FROM agent_graph_intent_claims
+            WHERE graph_id = ?
+            ORDER BY claimed_at ASC, intent_id ASC
+          `)
+          .all(graphId) as unknown as AgentGraphIntentAdmissionSnapshotRow[]
+      ).map(decodeAgentGraphIntentAdmissionSnapshotRow);
+      const wakeRows = this.db
+        .prepare(`
+          SELECT
+            schema_version AS schemaVersion,
+            graph_id AS graphId,
+            wake_id AS wakeId,
+            snapshot_version AS snapshotVersion,
+            root_session_id AS rootSessionId,
+            status,
+            attempt_count AS attemptCount,
+            current_attempt_id AS currentAttemptId,
+            current_turn_id AS currentTurnId,
+            failure_reason AS failureReason,
+            created_at AS createdAt,
+            updated_at AS updatedAt
+          FROM agent_graph_supervisor_wakes
+          WHERE graph_id = ?
+          ORDER BY created_at ASC, wake_id ASC
+        `)
+        .all(graphId) as unknown as AgentGraphSupervisorWakeRow[];
+      const attemptRows = this.db
+        .prepare(`
+          SELECT
+            graph_id AS graphId,
+            wake_id AS wakeId,
+            attempt_id AS attemptId,
+            turn_id AS turnId,
+            status,
+            failure_reason AS failureReason,
+            started_at AS startedAt,
+            completed_at AS completedAt
+          FROM agent_graph_supervisor_wake_attempts
+          WHERE graph_id = ?
+          ORDER BY started_at ASC, attempt_id ASC
+        `)
+        .all(graphId) as unknown as AgentGraphSupervisorWakeAttemptRow[];
+      const attemptsByWake = new Map<string, AgentGraphSupervisorWakeAttemptRecord[]>();
+      for (const row of attemptRows) {
+        const attempt = decodeAgentGraphSupervisorWakeAttemptRow(row);
+        const attempts = attemptsByWake.get(attempt.wakeId) ?? [];
+        attempts.push(attempt);
+        attemptsByWake.set(attempt.wakeId, attempts);
+      }
+      const supervisorWakes = wakeRows.map((row) => {
+        const wake = decodeAgentGraphSupervisorWakeRow(row);
+        const attempts = attemptsByWake.get(wake.wakeId) ?? [];
+        attemptsByWake.delete(wake.wakeId);
+        return {
+          wake,
+          attempts,
+        };
+      });
+      if (attemptsByWake.size > 0) {
+        throw new Error(`Agent graph ${graphId} has orphan supervisor wake attempts`);
+      }
+      return {
+        graphId,
+        scheduleUpdates,
+        operatorProvisions,
+        intentClaims,
+        intentAdmissions,
+        supervisorWakes,
+      };
+    });
   }
 
   async commitAgentGraphClientProjection(
@@ -1999,6 +2129,22 @@ export class SqliteSessionMetadataStore {
     }
   }
 
+  private readTransaction<T>(operation: () => T): T {
+    this.db.exec('BEGIN');
+    try {
+      const result = operation();
+      this.db.exec('COMMIT');
+      return result;
+    } catch (error) {
+      try {
+        this.db.exec('ROLLBACK');
+      } catch {
+        // Preserve the original storage or protocol failure.
+      }
+      throw error;
+    }
+  }
+
   private assertOpen(): void {
     if (this.closed) throw new Error('SQLite session metadata store is closed');
   }
@@ -2040,6 +2186,14 @@ interface AgentGraphScheduleUpdateRow {
 
 interface AgentGraphOperatorProvisionRow {
   payloadJson: string;
+}
+
+interface AgentGraphIntentAdmissionSnapshotRow {
+  graphId: string;
+  intentId: string;
+  state: string;
+  updatedAt: number;
+  cancellationReason: string | null;
 }
 
 interface AgentGraphClientProjectionRow {
@@ -2112,6 +2266,26 @@ interface AgentGraphClientTerminalActivityRowWithIdentity
   extends AgentGraphClientTerminalActivityRow {
   graphId: string;
   recordId: string;
+}
+
+function decodeAgentGraphIntentAdmissionSnapshotRow(
+  row: AgentGraphIntentAdmissionSnapshotRow,
+): AgentGraphIntentAdmissionSnapshot {
+  assertGraphLookupIdentity(row.graphId, 'graph id');
+  assertGraphIntentId(row.intentId);
+  if (row.state !== 'claimed' && row.state !== 'executing' && row.state !== 'cancelled') {
+    throw new Error(`Invalid agent graph admission state for ${row.intentId}`);
+  }
+  if (!Number.isSafeInteger(row.updatedAt) || row.updatedAt < 0) {
+    throw new Error(`Invalid agent graph admission timestamp for ${row.intentId}`);
+  }
+  return {
+    graphId: row.graphId,
+    intentId: row.intentId,
+    state: row.state,
+    updatedAt: row.updatedAt,
+    ...(row.cancellationReason ? { cancellationReason: row.cancellationReason } : {}),
+  };
 }
 
 function decodeAgentGraphScheduleUpdateRow(


### PR DESCRIPTION
## Summary

- add a transactionally consistent SQLite control-plane snapshot for Graph schedule updates, operator provisions, intent claims/current admissions, and supervisor wakes/attempts
- reconstruct a typed, chronological Graph timeline by joining that metadata with root/child AgentRuns and immutable RuntimeEvents at query time
- expose deterministic same-millisecond ordering, validated cursor pagination, explicit omission counts, and `AgentGraphCoordinator.getTimeline()`
- keep immutable schedule/runtime history in the pageable stream while returning mutable admission/wake state separately in page-level `currentState`
- return reference-only record facets and identities; schedule instructions, reasons, tool arguments/results, and child message payloads are not copied into the trace

## Why this shape

This is the first implementation slice of #1529. It deliberately uses a query-time join over existing authorities instead of introducing a second trace authority or changing scheduler/runtime semantics.

The existing SQLite schema stores the current admission and wake state but not every overwritten transition, and reconcile passes are not durable facts yet. Mutable admission/wake snapshots therefore live outside the pageable historical stream so their state changes cannot invalidate an issued cursor. The response also reports the missing transition history through `coverage.limitations`:

- `admission_transition_history_not_persisted`
- `supervisor_wake_transition_history_not_persisted`
- `reconcile_history_not_persisted`

That makes the v1 trace useful and honest while leaving an append-only transition ledger and Desktop timeline UI as follow-up slices.

## Result

A completed Graph run can now reconstruct:

`root turn → schedule commit → operator/child Session → intent → durable AgentRun activation → runtime records → child terminal → supervisor wake/attempt → later root turn → selected result → schedule finish`

The cursor is based on durable event identity/time rather than the page index, so it remains valid when an earlier event is discovered later. `sequence` is documented as deterministic reconstruction order, not a cross-ledger commit sequence.

`activation_started` comes from the claimed child AgentRun's durable `createdAt`, including the live window before its first RuntimeEvent. Terminal activation remains RuntimeEvent-authoritative.

## Validation

- `npm run typecheck`
- `npm run build --workspace @maka/core`
- `npm run build --workspace @maka/storage`
- `npm run build --workspace @maka/runtime`
- `node --test packages/runtime/dist/__tests__/agent-graph-timeline.test.js packages/runtime/dist/__tests__/stream-graph-projection.test.js packages/runtime/dist/__tests__/stream-graph-coordinator.test.js`
- focused Biome format/lint checks

The full runtime suite completed with 2 unrelated local macOS/Homebrew sandbox failures out of 2,551 tests: the sandbox could not load ripgrep's `/opt/homebrew/opt/pcre2` dylib, and an executable-root assertion expected `/usr/local`. The new timeline tests pass.

Part of #1529.

<details>
<summary>中文说明</summary>

## 本 PR 做了什么

- 在 SQLite 控制面增加一次事务内读取的 Graph metadata snapshot，覆盖 schedule、operator provision、intent claim/当前 admission、supervisor wake/attempt。
- 查询时再与 root/child AgentRun 和 immutable RuntimeEvent 做 join，生成类型化、按时间排序、可分页的 Graph timeline。
- 同毫秒事件使用确定性的全序；cursor 基于 durable event identity/time，而不是不稳定的数组下标。
- pageable events 只承载 immutable schedule/runtime history；mutable admission/wake 状态独立放在 page-level `currentState`，状态变化不会让旧 cursor 失效。
- trace 只返回 identity、关联和 record facet，不复制 instruction、reason、tool args/result 或 child message 内容。

## 为什么不是新建一套 trace authority

这是 #1529 的第一个实现切片。首版直接复用现有权威 stores，不增加新的 scheduler/runtime 语义，也不引入第二套事实源。

当前 SQLite 表只保留 admission/wake 的最新状态，不保留所有被覆盖的中间 transition；reconcile pass 目前也没有 durable ledger。因此 mutable current state 不进入分页历史流，同时 API 通过 `coverage.limitations` 明确报告这些边界，而不是假装已经拥有完整历史。

`activation_started` 直接来自 claim 所关联 child AgentRun 的 durable `createdAt`，即便还没有第一条 RuntimeEvent 也可见；terminal 仍以 RuntimeEvent 为权威。后续可以单独增加 append-only transition ledger，再接 Desktop timeline UI。

</details>
