### PR TITLE
feat(cu): surface element state and tree position to the model

### DIFF
--- a/packages/computer-use/src/cua-driver-backend.ts
+++ b/packages/computer-use/src/cua-driver-backend.ts
@@ -1015,6 +1015,11 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
         role: element.role,
         ...(element.label ? { label: element.label } : {}),
         ...(element.value !== undefined ? { value: element.value } : {}),
+        ...(element.enabled !== undefined ? { enabled: element.enabled } : {}),
+        ...(element.selected !== undefined ? { selected: element.selected } : {}),
+        ...(element.parent_index !== undefined
+          ? { parentElementId: String(element.parent_index) }
+          : {}),
         frame: {
           x: element.frame.x,
           y: element.frame.y,

--- a/packages/computer-use/src/cua-driver-snapshot.ts
+++ b/packages/computer-use/src/cua-driver-snapshot.ts
@@ -38,6 +38,9 @@ export interface CuaSnapshotElement {
   value?: unknown;
   depth?: unknown;
   frame?: unknown;
+  enabled?: unknown;
+  selected?: unknown;
+  parent_index?: unknown;
 }
 
 function finitePositive(value: unknown): value is number {
@@ -152,6 +155,9 @@ export function normalizeCuaSnapshotElement(element: CuaSnapshotElement):
       value?: string;
       depth: number;
       frame: { x: number; y: number; w: number; h: number };
+      enabled?: boolean;
+      selected?: boolean;
+      parent_index?: number;
     }
   | undefined {
   if (typeof element.element_index !== 'number') return undefined;
@@ -178,6 +184,12 @@ export function normalizeCuaSnapshotElement(element: CuaSnapshotElement):
     ...(typeof element.value === 'string' ? { value: element.value } : {}),
     depth: typeof element.depth === 'number' ? element.depth : 0,
     frame: { x: frame.x, y: frame.y, w: frame.w, h: frame.h },
+    // Interaction state and tree position. The driver already reports these;
+    // dropping them here is what forced the model to treat every row as
+    // equally actionable and equally rootless.
+    ...(typeof element.enabled === 'boolean' ? { enabled: element.enabled } : {}),
+    ...(typeof element.selected === 'boolean' ? { selected: element.selected } : {}),
+    ...(typeof element.parent_index === 'number' ? { parent_index: element.parent_index } : {}),
   };
 }
 

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -93,6 +93,12 @@ export interface CuObservedElement {
   role: string;
   label?: string;
   value?: string;
+  /** False when the control is present but cannot currently be actuated. */
+  enabled?: boolean;
+  /** Selection state for controls that carry one (checkbox, radio, tab, row). */
+  selected?: boolean;
+  /** `elementId` of this element's parent, when the observation reports a tree. */
+  parentElementId?: string;
   frame?: { x: number; y: number; width: number; height: number };
   identity?: {
     token?: string;
@@ -661,6 +667,17 @@ function observationText(observation: CuObservation): string {
       role: element.role,
       ...(element.label ? { label: element.label } : {}),
       ...(element.value !== undefined ? { value: element.value } : {}),
+      // Interaction state: without it the model cannot tell a control it may
+      // not actuate from one it simply failed to hit, and retries the same
+      // dead element across a long run.
+      ...(element.enabled !== undefined ? { enabled: element.enabled } : {}),
+      ...(element.selected !== undefined ? { selected: element.selected } : {}),
+      // Tree position: a flat list hides which panel, dialog, or row group an
+      // element belongs to, which matters as soon as a modal or secondary
+      // window is on screen.
+      ...(element.parentElementId !== undefined
+        ? { parent_element_id: element.parentElementId }
+        : {}),
       ...(element.frame ? { frame: element.frame } : {}),
     })),
   });


### PR DESCRIPTION
## Summary

`get_window_state` reports each element's interaction state and its parent, but `normalizeCuaSnapshotElement` dropped those fields. They never reached `CuObservedElement` and never appeared in `observationText`, so the model saw a flat list in which every row looked equally actionable and equally rootless.

## Why it matters in a long run

**Without `enabled`**, a control that is present but not actuatable is indistinguishable from one the model simply failed to hit. The model retries the same dead element instead of looking for what actually enables it.

**Without a parent link**, there is no way to tell which panel, dialog, or row group an element belongs to. This becomes concrete as soon as a modal or secondary window is open and two rows share a label — the model has coordinates and a role, but no structure.

## Change

Pass `enabled`, `selected`, and `parent_index` (as `parentElementId`) through the three layers that were dropping them:

```
cua-driver-snapshot.ts   normalizeCuaSnapshotElement  — keep the fields
cua-driver-backend.ts    observeWindow                — map into CuObservedElement
computer-use-tools.ts    observationText              — project to the model
```

All three are optional and omitted when absent, so the projection stays additive — no existing field changes shape.

Model-visible element before / after:

```json
// before
{"element_id": "4", "role": "AXButton", "label": "Send", "frame": {...}}

// after
{"element_id": "4", "role": "AXButton", "label": "Send",
 "parent_element_id": "0", "frame": {...}}
```

## Verification

Against the real driver on a live window: of 62 observed elements, 59 now carry `parentElementId`.

```
{"id":"1","role":"AXButton","label":"CUA Lab Reset","parent":"0"}
{"id":"4","role":"AXButton","label":"CUA Lab Primary Button","parent":"0"}
{"id":"5","role":"AXTextField","label":"CUA Lab Set Value Field","parent":"0"}
```

- `@maka/computer-use` — 137/137 passed
- `@maka/runtime` — 2686 passed, 8 failed; the same 8 fail on a clean `origin/main` build (unrelated pre-existing failures in extraction-contract / workspace-instructions / prepareStep)
- Biome lint + format — clean

## Note on `enabled` / `selected`

The pinned cua-driver v0.7.1 does not emit them yet. Its element rows are exactly:

```
depth · element_index · element_token · frame · label · parent_index · role
```

Upstream added `enabled` / `selected` by v0.12.6. This change reads them when present, so they light up on the driver upgrade with no further work here. `parentElementId` works on the pinned version today, which is what the verification above exercises.
