### PR TITLE
fix(runtime): surface sandbox-blocked tool failures

### DIFF
--- a/apps/desktop/src/main/__tests__/app-shell-turn-view-model.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-turn-view-model.test.ts
@@ -1,6 +1,69 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
+import type { StoredMessage } from '@maka/core';
+import { deriveAppShellTurnViewModel } from '../../renderer/app-shell-turn-view-model.js';
 import { latestInterruptedResumeTurnId } from '../../renderer/interrupted-resume.js';
+
+function derive(messages: StoredMessage[]) {
+  return deriveAppShellTurnViewModel({
+    activeId: 'session-1',
+    messages,
+    pendingTurnActions: new Set(),
+    uiLocale: 'zh',
+    pendingKeyOf: (sessionId, turnId, actionId) => `${sessionId}:${turnId}:${actionId}`,
+  });
+}
+
+function failedToolMessages(input: {
+  sandboxDenied: boolean;
+  includeOrdinaryFailure?: boolean;
+  errorClass?: string;
+}): StoredMessage[] {
+  const turnId = 'turn-1';
+  const messages: StoredMessage[] = [
+    { type: 'user', id: 'user-1', turnId, ts: 1, text: 'run it' },
+    { type: 'tool_call', id: 'tool-1', turnId, ts: 2, toolName: 'Grep', args: {} },
+    {
+      type: 'tool_result',
+      id: 'result-1',
+      turnId,
+      ts: 3,
+      toolUseId: 'tool-1',
+      isError: true,
+      content: {
+        kind: 'text',
+        text: 'Operation not permitted',
+        ...(input.sandboxDenied
+          ? { sandboxDenial: { likely: true as const, backend: 'macos-seatbelt' as const } }
+          : {}),
+      },
+    },
+  ];
+  if (input.includeOrdinaryFailure) {
+    messages.push(
+      { type: 'tool_call', id: 'tool-2', turnId, ts: 4, toolName: 'Read', args: {} },
+      {
+        type: 'tool_result',
+        id: 'result-2',
+        turnId,
+        ts: 5,
+        toolUseId: 'tool-2',
+        isError: true,
+        content: { kind: 'text', text: 'File not found' },
+      },
+    );
+  }
+  messages.push({
+    type: 'turn_state',
+    id: 'state-1',
+    turnId,
+    ts: 6,
+    status: 'failed',
+    ...(input.errorClass ? { errorClass: input.errorClass } : {}),
+    partialOutputRetained: true,
+  });
+  return messages;
+}
 
 describe('deriveAppShellTurnViewModel interrupted recovery', () => {
   it('offers safe resume only for the latest app-restarted failed turn', () => {
@@ -18,5 +81,47 @@ describe('deriveAppShellTurnViewModel interrupted recovery', () => {
     ]);
 
     assert.equal(turnId, undefined);
+  });
+});
+
+describe('deriveAppShellTurnViewModel sandbox denial presentation', () => {
+  it('omits the duplicate failed-turn banner for a sandbox-only tool failure', () => {
+    const viewModel = derive(failedToolMessages({
+      sandboxDenied: true,
+    }));
+
+    assert.equal(viewModel.turnFailedReasonLabels['turn-1'], undefined);
+    assert.equal(viewModel.turnFailedRecoveryLabels['turn-1'], undefined);
+  });
+
+  it('keeps the failed-turn banner for an ordinary tool failure', () => {
+    const viewModel = derive(failedToolMessages({
+      sandboxDenied: false,
+      errorClass: 'tool_failed',
+    }));
+
+    assert.equal(typeof viewModel.turnFailedReasonLabels['turn-1'], 'string');
+    assert.equal(typeof viewModel.turnFailedRecoveryLabels['turn-1'], 'string');
+  });
+
+  it('keeps the failed-turn banner when a sandbox denial and ordinary failure coexist', () => {
+    const viewModel = derive(failedToolMessages({
+      sandboxDenied: true,
+      includeOrdinaryFailure: true,
+      errorClass: 'tool_failed',
+    }));
+
+    assert.equal(typeof viewModel.turnFailedReasonLabels['turn-1'], 'string');
+    assert.equal(typeof viewModel.turnFailedRecoveryLabels['turn-1'], 'string');
+  });
+
+  it('keeps the failed-turn banner for a separate turn-level failure', () => {
+    const viewModel = derive(failedToolMessages({
+      sandboxDenied: true,
+      errorClass: 'network',
+    }));
+
+    assert.equal(typeof viewModel.turnFailedReasonLabels['turn-1'], 'string');
+    assert.equal(typeof viewModel.turnFailedRecoveryLabels['turn-1'], 'string');
   });
 });

--- a/apps/desktop/src/renderer/app-shell-turn-view-model.ts
+++ b/apps/desktop/src/renderer/app-shell-turn-view-model.ts
@@ -2,14 +2,16 @@ import type { StoredMessage, UiLocale } from '@maka/core';
 import {
   deriveTurnLineageMap,
   formatTurnDuration,
+  isSandboxDeniedTool,
   materializeTurns,
   type TurnFooterActionMeta,
   type TurnLineageBadge,
+  type TurnViewModel,
 } from '@maka/ui';
-import { deriveFailedTurnRecovery, describeTurnErrorClass } from './session-status-presentation';
-import { deriveTurnFooterActions } from './turn-footer-actions';
-import { deriveTurnLineageBadges } from './derive-turn-lineage-badges';
-import { latestInterruptedResumeTurnId } from './interrupted-resume';
+import { deriveFailedTurnRecovery, describeTurnErrorClass } from './session-status-presentation.js';
+import { deriveTurnFooterActions } from './turn-footer-actions.js';
+import { deriveTurnLineageBadges } from './derive-turn-lineage-badges.js';
+import { latestInterruptedResumeTurnId } from './interrupted-resume.js';
 
 export interface AppShellTurnViewModel {
   turnFooterActionsByTurn: Record<string, ReadonlyArray<TurnFooterActionMeta>>;
@@ -17,6 +19,20 @@ export interface AppShellTurnViewModel {
   turnFailedRecoveryLabels: Record<string, string>;
   turnLineageBadgesByTurn: Record<string, TurnLineageBadge[]>;
   resumeCandidateTurnId?: string;
+}
+
+function isSandboxOnlyToolFailure(turn: TurnViewModel): boolean {
+  const erroredTools = turn.tools.filter((tool) => tool.status === 'errored');
+  if (erroredTools.length === 0 || !erroredTools.every(isSandboxDeniedTool)) return false;
+
+  const errorClass = turn.errorClass?.toLowerCase();
+  return (
+    errorClass === undefined
+    || errorClass === 'unknown'
+    || errorClass === 'tool_failed'
+    || errorClass === 'sandbox_denial'
+    || errorClass === 'sandbox_denied'
+  );
 }
 
 export function deriveAppShellTurnViewModel(input: {
@@ -61,7 +77,7 @@ export function deriveAppShellTurnViewModel(input: {
       ...(metaSummary ? { metaSummary } : {}),
     });
 
-    if (turn.status === 'failed') {
+    if (turn.status === 'failed' && !isSandboxOnlyToolFailure(turn)) {
       failedLabels[turn.turnId] = describeTurnErrorClass(turn.errorClass, input.uiLocale);
       failedRecoveryLabels[turn.turnId] = deriveFailedTurnRecovery({
         errorClass: turn.errorClass,

--- a/packages/core/src/__tests__/tool-result-record-schema.test.ts
+++ b/packages/core/src/__tests__/tool-result-record-schema.test.ts
@@ -64,6 +64,44 @@ describe('legacy subagent tool result compatibility', () => {
   });
 });
 
+describe('sandbox denial tool result metadata', () => {
+  test('accepts a canonical text result carrying a sandbox denial signal', () => {
+    const result = {
+      kind: 'text',
+      text: 'Filesystem access was denied.',
+      sandboxDenial: {
+        likely: true,
+        backend: 'macos-seatbelt',
+      },
+    } as const;
+
+    assert.deepEqual(decodeCanonicalToolResultContent(result), result);
+    assert.deepEqual(
+      toolResultContent(decodeStoredMessageForRecovery(storedToolResult(result))),
+      result,
+    );
+  });
+
+  test('rejects malformed or widened sandbox denial signals', () => {
+    for (const sandboxDenial of [
+      { likely: false },
+      { likely: true, backend: 'none' },
+      { likely: true, backend: 'macos-seatbelt', recovery: 'require_escalated' },
+      { likely: true, unexpected: true },
+    ]) {
+      assert.throws(
+        () =>
+          decodeCanonicalToolResultContent({
+            kind: 'text',
+            text: 'denied',
+            sandboxDenial,
+          }),
+        /Invalid tool result content/,
+      );
+    }
+  });
+});
+
 function legacySubagentResult(): Record<string, unknown> {
   return {
     kind: 'subagent',

--- a/packages/core/src/canonical-runtime-event.ts
+++ b/packages/core/src/canonical-runtime-event.ts
@@ -1,4 +1,4 @@
-import { isDeepStrictEqual } from 'node:util';
+import * as nodeUtil from 'node:util';
 import type { RuntimeEvent } from './runtime-event.js';
 import { decodeRuntimeEvent } from './runtime-event.js';
 import { stableJsonStringify } from './tool-args-identity.js';
@@ -26,7 +26,7 @@ export function encodeCanonicalRuntimeEvent(value: unknown): CanonicalRuntimeEve
     throw new Error('RuntimeEvent is not losslessly serializable', { cause });
   }
   const event = decodeRuntimeEvent(JSON.parse(json));
-  if (!isDeepStrictEqual(decoded, event)) {
+  if (!nodeUtil.isDeepStrictEqual(decoded, event)) {
     throw new Error('RuntimeEvent is not losslessly serializable');
   }
   return { event, json };

--- a/packages/core/src/events.ts
+++ b/packages/core/src/events.ts
@@ -444,9 +444,12 @@ type ShellRunResultMetadata = {
   sandboxDenial?: SandboxDenialRecovery;
 };
 
-export interface SandboxDenialRecovery {
+export interface SandboxDenialSignal {
   likely: true;
   backend?: 'macos-seatbelt' | 'linux';
+}
+
+export interface SandboxDenialRecovery extends SandboxDenialSignal {
   recovery: 'require_escalated';
 }
 
@@ -470,7 +473,7 @@ type ShellRunToolResultContent =
       ));
 
 export type ToolResultContent =
-  | { kind: 'text'; text: string }
+  | { kind: 'text'; text: string; sandboxDenial?: SandboxDenialSignal }
   | { kind: 'json'; value: unknown }
   | { kind: 'file_diff'; paths: string[]; diff: string }
   | { kind: 'file_write'; path: string; bytes: number }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -37,6 +37,7 @@ export type {
   ShellRunStateResult,
   ShellRunUpdateOwnership,
   ShellRunUpdate,
+  SandboxDenialSignal,
   SandboxDenialRecovery,
   AdditionalPermissionRequestEvent,
   SandboxEscalationRequestEvent,

--- a/packages/core/src/shell-run-result.ts
+++ b/packages/core/src/shell-run-result.ts
@@ -2,6 +2,7 @@ import type {
   ShellRunSnapshotResult,
   ShellRunStateResult,
   ShellRunUpdate,
+  SandboxDenialSignal,
   SandboxDenialRecovery,
   ToolResultContent,
 } from './events.js';
@@ -101,7 +102,12 @@ const CURRENT_SHELL_RUN_RESULT_SHAPE = defineObjectShape<ShellRunToolResultRecor
   ],
 );
 
-const SANDBOX_DENIAL_SHAPE = defineObjectShape<SandboxDenialRecovery>()(
+const SANDBOX_DENIAL_SIGNAL_SHAPE = defineObjectShape<SandboxDenialSignal>()(
+  ['likely'],
+  ['backend'],
+);
+
+const SANDBOX_DENIAL_RECOVERY_SHAPE = defineObjectShape<SandboxDenialRecovery>()(
   ['likely', 'recovery'],
   ['backend'],
 );
@@ -483,11 +489,20 @@ function isOptionalString(value: unknown): boolean {
   return value === undefined || typeof value === 'string';
 }
 
+export function isSandboxDenialSignal(value: unknown): value is SandboxDenialSignal {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, SANDBOX_DENIAL_SIGNAL_SHAPE) &&
+    value.likely === true &&
+    (value.backend === undefined || value.backend === 'macos-seatbelt' || value.backend === 'linux')
+  );
+}
+
 function isOptionalSandboxDenial(value: unknown): boolean {
   return (
     value === undefined ||
     (isRecord(value) &&
-      hasExactShape(value, SANDBOX_DENIAL_SHAPE) &&
+      hasExactShape(value, SANDBOX_DENIAL_RECOVERY_SHAPE) &&
       value.likely === true &&
       (value.backend === undefined ||
         value.backend === 'macos-seatbelt' ||

--- a/packages/core/src/tool-args-identity.ts
+++ b/packages/core/src/tool-args-identity.ts
@@ -1,4 +1,4 @@
-import { createHash } from 'node:crypto';
+import * as nodeCrypto from 'node:crypto';
 
 /**
  * Returns the identity of the exact provider-visible tool name and arguments.
@@ -20,7 +20,7 @@ export function canonicalToolArgsHash(toolName: string, args: unknown): `sha256:
   // protocol must retain mainline's historical stableHash byte semantics.
   stableJsonStringify(args);
   const body = stringifyMainlineV1ToolArgsIdentity(toolName, args);
-  return `sha256:${createHash('sha256').update(body).digest('hex')}`;
+  return `sha256:${nodeCrypto.createHash('sha256').update(body).digest('hex')}`;
 }
 
 export function stableJsonStringify(value: unknown): string {

--- a/packages/core/src/tool-ledger-scanner.ts
+++ b/packages/core/src/tool-ledger-scanner.ts
@@ -1,4 +1,4 @@
-import { isDeepStrictEqual } from 'node:util';
+import * as nodeUtil from 'node:util';
 import type { RuntimeEvent } from './runtime-event.js';
 import { canonicalToolArgsHash } from './tool-args-identity.js';
 
@@ -153,7 +153,7 @@ export function validateToolLedgerTransition(input: {
       candidates.push(candidate);
       continue;
     }
-    if (!isDeepStrictEqual(prior, candidate)) {
+    if (!nodeUtil.isDeepStrictEqual(prior, candidate)) {
       return { ok: false, code: 'duplicate_event_id', eventId: candidate.id };
     }
   }

--- a/packages/core/src/tool-result-record-schema.ts
+++ b/packages/core/src/tool-result-record-schema.ts
@@ -1,5 +1,6 @@
 import {
   decodeCanonicalShellToolResultContent,
+  isSandboxDenialSignal,
   normalizeShellToolResultContent,
 } from './shell-run-result.js';
 import { isPermissionMode } from './permission.js';
@@ -19,7 +20,7 @@ type ExploreResult = Result<'explore_agent'>;
 type AgentSwarmResult = Result<'agent_swarm'>;
 type RiveResult = Result<'rive_workflow'>;
 
-const TEXT_SHAPE = defineObjectShape<Result<'text'>>()(['kind', 'text'], []);
+const TEXT_SHAPE = defineObjectShape<Result<'text'>>()(['kind', 'text'], ['sandboxDenial']);
 const JSON_SHAPE = defineObjectShape<Result<'json'>>()(['kind', 'value'], []);
 const FILE_DIFF_SHAPE = defineObjectShape<Result<'file_diff'>>()(['kind', 'paths', 'diff'], []);
 const FILE_WRITE_SHAPE = defineObjectShape<Result<'file_write'>>()(['kind', 'path', 'bytes'], []);
@@ -219,7 +220,11 @@ function isNonShellToolResultContent(value: unknown): value is ToolResultContent
   if (!isRecord(value) || typeof value.kind !== 'string') return false;
   switch (value.kind) {
     case 'text':
-      return hasExactShape(value, TEXT_SHAPE) && typeof value.text === 'string';
+      return (
+        hasExactShape(value, TEXT_SHAPE) &&
+        typeof value.text === 'string' &&
+        (value.sandboxDenial === undefined || isSandboxDenialSignal(value.sandboxDenial))
+      );
     case 'json':
       return hasExactShape(value, JSON_SHAPE) && Object.hasOwn(value, 'value');
     case 'file_diff':

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -66,6 +66,7 @@ import { HistoryCompactSummarizerError } from '../history-compact-summarizer.js'
 import type { AutoApprovalReviewContext } from '../approval-reviewer.js';
 import type { SandboxDiagnosticsSnapshot } from '../sandbox/diagnostics.js';
 import { SandboxCommandError } from '../sandbox/errors.js';
+import { FilesystemWorkerClientError } from '../filesystem-worker/client.js';
 import { RunTrace } from '../run-trace.js';
 import {
   bindRuntimeInteractionRun,
@@ -318,10 +319,13 @@ describe('AiSdkBackend model history', () => {
 
   test('records structured sandbox failure metadata on tool failure traces', async () => {
     const traces: RunTraceEvent[] = [];
+    const messages: ToolResultMessage[] = [];
     const backend = new AiSdkBackend({
       sessionId: 'session-1',
       header: header('bypass'),
-      appendMessage: async () => {},
+      appendMessage: async (message) => {
+        if (message.type === 'tool_result') messages.push(message);
+      },
       connection: connection(),
       apiKey: 'sk-test',
       modelId: 'mock-model-id',
@@ -375,6 +379,112 @@ describe('AiSdkBackend model history', () => {
       profileName: 'workspace-write',
     });
     assert.equal(JSON.stringify(failure).includes('/private/workspace/path'), false);
+    assert.equal(
+      messages[0]?.content.kind === 'text' ? messages[0].content.sandboxDenial : undefined,
+      undefined,
+    );
+  });
+
+  test('persists a sandbox denial signal for explicit filesystem worker sandbox denials', async () => {
+    const messages: ToolResultMessage[] = [];
+    const events: SessionEvent[] = [];
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header('bypass'),
+      appendMessage: async (message) => {
+        if (message.type === 'tool_result') messages.push(message);
+      },
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: idGenerator(), now: () => 1 }),
+      modelFactory: () => ({}),
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    const tool: MakaTool = {
+      name: 'Grep',
+      description: 'search',
+      parameters: {},
+      permissionRequired: false,
+      impl: async () => {
+        throw new FilesystemWorkerClientError({
+          reason: 'sandbox_denied',
+          stage: 'operation',
+          backend: 'macos-seatbelt',
+          recoverable: false,
+          message: 'Filesystem access was denied.',
+        });
+      },
+    };
+    const execute = runtimeExecute(backend, tool, 'turn-1', {
+      push: (event) => events.push(event),
+    });
+
+    await execute(
+      { pattern: 'needle', path: '/workspace' },
+      { toolCallId: 'tool-1', abortSignal: new AbortController().signal },
+    );
+
+    const expected = { likely: true, backend: 'macos-seatbelt' } as const;
+    assert.deepEqual(
+      messages[0]?.content.kind === 'text' ? messages[0].content.sandboxDenial : undefined,
+      expected,
+    );
+    const event = events.find(
+      (candidate): candidate is Extract<SessionEvent, { type: 'tool_result' }> =>
+        candidate.type === 'tool_result',
+    );
+    assert.deepEqual(
+      event?.content.kind === 'text' ? event.content.sandboxDenial : undefined,
+      expected,
+    );
+  });
+
+  test('does not label ordinary filesystem permission errors as sandbox denials', async () => {
+    const messages: ToolResultMessage[] = [];
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header('bypass'),
+      appendMessage: async (message) => {
+        if (message.type === 'tool_result') messages.push(message);
+      },
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: idGenerator(), now: () => 1 }),
+      modelFactory: () => ({}),
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+    const tool: MakaTool = {
+      name: 'Read',
+      description: 'read',
+      parameters: {},
+      permissionRequired: false,
+      impl: async () => {
+        throw new FilesystemWorkerClientError({
+          reason: 'filesystem_denied',
+          stage: 'operation',
+          backend: 'macos-seatbelt',
+          recoverable: false,
+          message: 'Filesystem access was denied.',
+        });
+      },
+    };
+    const execute = runtimeExecute(backend, tool, 'turn-1', { push: () => {} });
+
+    await execute(
+      { path: '/workspace/private.txt' },
+      { toolCallId: 'tool-1', abortSignal: new AbortController().signal },
+    );
+
+    assert.equal(
+      messages[0]?.content.kind === 'text' ? messages[0].content.sandboxDenial : undefined,
+      undefined,
+    );
   });
 
   test('omits an empty system prompt from the provider request', async () => {

--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { Buffer } from 'node:buffer';
 import { createHash } from 'node:crypto';
 import { describe, test } from 'node:test';
+import { encodeCanonicalRuntimeEvent } from '@maka/core';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import {
   ARCHIVED_TOOL_RESULT_PLACEHOLDER_KIND,
@@ -10,6 +11,7 @@ import {
   buildHistoryCompactBlockFromSummary,
   buildSynthesisCacheBlocksFromHydratedArchives,
   deserializeToolResultArchive,
+  mergeContextBudgetDiagnostic,
   renderHistoryCompactBlock,
   retrieveArchivedToolResultsForReplay,
   retrieveRuntimeEventHistoryAround,
@@ -1728,6 +1730,69 @@ describe('context-budget search and rewrite diagnostics', () => {
     assert.equal(budgeted.diagnostic.historyRewriteGate, 'phase6-high-water');
     assert.equal(budgeted.diagnostic.historyRewriteVersion, 'phase6-v1');
     assert.equal(budgeted.diagnostic.historyRewriteResetReason, 'explicit_test_reset');
+  });
+});
+
+describe('context-budget diagnostic merges', () => {
+  test('omits count-record fields that are absent from both inputs', () => {
+    const merged = mergeContextBudgetDiagnostic(
+      {
+        enabled: true,
+        estimatedTokensBefore: 287,
+        estimatedTokensAfter: 287,
+        keptTurns: 1,
+        droppedTurns: 0,
+        keptEvents: 6,
+        droppedEvents: 0,
+        historyCompactSkippedReasonCounts: { below_high_water: 1 },
+      },
+      {
+        historyCompactBlocksLoaded: 0,
+        historyCompactBlocksAvailable: 0,
+        historyCompactSkippedReasonCounts: {
+          below_high_water: 2,
+          already_compacted: 1,
+        },
+      },
+    );
+
+    assert.equal(Object.hasOwn(merged, 'archiveRetrievalFailureReasonCounts'), false);
+    assert.equal(Object.hasOwn(merged, 'synthesisCacheSkippedReasonCounts'), false);
+    assert.equal(Object.hasOwn(merged, 'historyCompactLoadSkippedReasonCounts'), false);
+    assert.deepEqual(merged.historyCompactSkippedReasonCounts, {
+      below_high_water: 3,
+      already_compacted: 1,
+    });
+  });
+
+  test('produces a losslessly serializable token usage diagnostic', () => {
+    const contextBudget = mergeContextBudgetDiagnostic(
+      {
+        enabled: true,
+        estimatedTokensBefore: 287,
+        estimatedTokensAfter: 287,
+        keptTurns: 1,
+        droppedTurns: 0,
+        keptEvents: 6,
+        droppedEvents: 0,
+        historyCompactSkippedReasonCounts: { below_high_water: 1 },
+      },
+      {
+        historyCompactBlocksLoaded: 0,
+        historyCompactBlocksAvailable: 0,
+      },
+    );
+    const event = baseEvent({
+      actions: {
+        tokenUsage: {
+          input: 9_131,
+          output: 44,
+          contextBudget,
+        },
+      },
+    });
+
+    assert.doesNotThrow(() => encodeCanonicalRuntimeEvent(event));
   });
 });
 

--- a/packages/runtime/src/__tests__/filesystem-worker-client.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker-client.test.ts
@@ -233,7 +233,7 @@ describe('filesystem worker operation-scoped Seatbelt profile', () => {
     );
   });
 
-  test('preserves sandbox context on worker operation failures', async () => {
+  test('preserves sandbox context without changing ordinary filesystem denial semantics', async () => {
     const workspace = await temporaryDirectory('maka-worker-client-denial-context-');
     const target = join(workspace, 'file.ts');
     await writeFile(target, 'const value = 1;', 'utf8');
@@ -251,6 +251,28 @@ describe('filesystem worker operation-scoped Seatbelt profile', () => {
         assert.equal(error.stage, 'operation');
         assert.equal(error.backend, 'macos-seatbelt');
         assert.equal(error.profileName, 'workspace-write');
+        return true;
+      },
+    );
+  });
+
+  test('preserves an explicit sandbox denial from the worker protocol', async () => {
+    const workspace = await temporaryDirectory('maka-worker-client-sandbox-denial-');
+    const target = join(workspace, 'file.ts');
+    await writeFile(target, 'const value = 1;', 'utf8');
+    const { client } = fakeClient({ operationErrorCode: 'sandbox_denied' });
+
+    await assert.rejects(
+      client.execute({
+        operation: grepOperation(target),
+        cwd: workspace,
+        mode: 'ask',
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof FilesystemWorkerClientError);
+        assert.equal(error.reason, 'sandbox_denied');
+        assert.equal(error.stage, 'operation');
+        assert.equal(error.backend, 'macos-seatbelt');
         return true;
       },
     );

--- a/packages/runtime/src/__tests__/filesystem-worker.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker.test.ts
@@ -112,7 +112,7 @@ describe('filesystem worker operations', () => {
       }),
     });
     assert.equal(sandboxDenied.ok, false);
-    if (!sandboxDenied.ok) assert.equal(sandboxDenied.error.code, 'filesystem_denied');
+    if (!sandboxDenied.ok) assert.equal(sandboxDenied.error.code, 'sandbox_denied');
   });
 
   test('reads a validated image through the approved path capability', async () => {

--- a/packages/runtime/src/context-budget.ts
+++ b/packages/runtime/src/context-budget.ts
@@ -518,43 +518,53 @@ export function mergeContextBudgetDiagnostic(
   return {
     ...base,
     ...patch,
-    archiveRetrievalFailureReasonCounts: mergeCountRecords(
+    ...mergeCountRecordField(
+      'archiveRetrievalFailureReasonCounts',
       base.archiveRetrievalFailureReasonCounts,
       patch.archiveRetrievalFailureReasonCounts,
     ),
-    archiveRetrievalSkippedReasonCounts: mergeCountRecords(
+    ...mergeCountRecordField(
+      'archiveRetrievalSkippedReasonCounts',
       base.archiveRetrievalSkippedReasonCounts,
       patch.archiveRetrievalSkippedReasonCounts,
     ),
-    synthesisCacheSkippedReasonCounts: mergeCountRecords(
+    ...mergeCountRecordField(
+      'synthesisCacheSkippedReasonCounts',
       base.synthesisCacheSkippedReasonCounts,
       patch.synthesisCacheSkippedReasonCounts,
     ),
-    synthesisCacheInvalidationReasonCounts: mergeCountRecords(
+    ...mergeCountRecordField(
+      'synthesisCacheInvalidationReasonCounts',
       base.synthesisCacheInvalidationReasonCounts,
       patch.synthesisCacheInvalidationReasonCounts,
     ),
-    synthesisCacheLoadSkippedReasonCounts: mergeCountRecords(
+    ...mergeCountRecordField(
+      'synthesisCacheLoadSkippedReasonCounts',
       base.synthesisCacheLoadSkippedReasonCounts,
       patch.synthesisCacheLoadSkippedReasonCounts,
     ),
-    synthesisCacheWriteSkippedReasonCounts: mergeCountRecords(
+    ...mergeCountRecordField(
+      'synthesisCacheWriteSkippedReasonCounts',
       base.synthesisCacheWriteSkippedReasonCounts,
       patch.synthesisCacheWriteSkippedReasonCounts,
     ),
-    synthesisCacheEvictionReasonCounts: mergeCountRecords(
+    ...mergeCountRecordField(
+      'synthesisCacheEvictionReasonCounts',
       base.synthesisCacheEvictionReasonCounts,
       patch.synthesisCacheEvictionReasonCounts,
     ),
-    historyCompactSkippedReasonCounts: mergeCountRecords(
+    ...mergeCountRecordField(
+      'historyCompactSkippedReasonCounts',
       base.historyCompactSkippedReasonCounts,
       patch.historyCompactSkippedReasonCounts,
     ),
-    historyCompactLoadSkippedReasonCounts: mergeCountRecords(
+    ...mergeCountRecordField(
+      'historyCompactLoadSkippedReasonCounts',
       base.historyCompactLoadSkippedReasonCounts,
       patch.historyCompactLoadSkippedReasonCounts,
     ),
-    historyCompactWriteSkippedReasonCounts: mergeCountRecords(
+    ...mergeCountRecordField(
+      'historyCompactWriteSkippedReasonCounts',
       base.historyCompactWriteSkippedReasonCounts,
       patch.historyCompactWriteSkippedReasonCounts,
     ),
@@ -622,6 +632,15 @@ function mergeCountRecords(
     out[key] = (out[key] ?? 0) + value;
   }
   return out;
+}
+
+function mergeCountRecordField<K extends keyof ContextBudgetDiagnostic>(
+  key: K,
+  left: Record<string, number> | undefined,
+  right: Record<string, number> | undefined,
+): Pick<ContextBudgetDiagnostic, K> | Record<string, never> {
+  const merged = mergeCountRecords(left, right);
+  return merged === undefined ? {} : ({ [key]: merged } as Pick<ContextBudgetDiagnostic, K>);
 }
 
 function mergeCompactionDecisionDiagnostics(

--- a/packages/runtime/src/filesystem-worker/operations.ts
+++ b/packages/runtime/src/filesystem-worker/operations.ts
@@ -241,7 +241,7 @@ export async function executeFilesystemOperation(
         const detail = result.stderrTail.trim();
         throw operationError(
           isLikelySandboxDenial({ stdout: result.stdout, stderr: detail, sandboxed: true })
-            ? 'filesystem_denied'
+            ? 'sandbox_denied'
             : 'filesystem_error',
           detail
             ? `Grep failed while searching files.\n${detail}`

--- a/packages/runtime/src/filesystem-worker/protocol.ts
+++ b/packages/runtime/src/filesystem-worker/protocol.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod';
 import { validateAdditionalPermissionProfile } from '@maka/core/additional-permissions';
 
-export const FILESYSTEM_WORKER_PROTOCOL_VERSION = 2 as const;
+export const FILESYSTEM_WORKER_PROTOCOL_VERSION = 3 as const;
 
 const path = z.string().min(1).max(4096);
 const cwd = z.string().min(1).max(4096);
@@ -158,6 +158,7 @@ export const FilesystemWorkerErrorCodeSchema = z.enum([
   'not_found',
   'edit_conflict',
   'grep_unavailable',
+  'sandbox_denied',
   'filesystem_denied',
   'filesystem_error',
 ]);

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -5,6 +5,7 @@ import {
 } from '@maka/core';
 import type {
   SessionEvent,
+  SandboxDenialSignal,
   ToolActivityKind,
   ToolOutputStream,
   ToolResultContent,
@@ -76,7 +77,7 @@ import {
 import { ChildAgentRunLimiter } from './child-agent-run-limiter.js';
 import type { AgentProfile } from './agent-catalog.js';
 import type { SubagentExecutionRef } from './subagent-execution.js';
-import { serializeSandboxError } from './sandbox/errors.js';
+import { sandboxErrorMetadata, serializeSandboxError } from './sandbox/errors.js';
 import {
   RuntimeInteractionAdmissionRejectedError,
   RuntimeInteractionClosedError,
@@ -665,10 +666,12 @@ export class ToolRuntime {
     turnId: string,
     text: string,
     queue: DurableSessionEventSink,
+    sandboxDenial?: SandboxDenialSignal,
   ): Promise<void> {
     const content: ToolResultContent = {
       kind: 'text',
       text: formatSyntheticToolErrorText(text),
+      ...(sandboxDenial ? { sandboxDenial } : {}),
     };
     const durableAttempt = this.durableToolAttempts.get(durableAttemptKey(turnId, toolUseId));
     const durableOutcome = await durableAttempt?.commitOutcome(content, true);
@@ -1589,11 +1592,13 @@ export class ToolRuntime {
         if (hasSandboxDenial(content)) {
           const denialKey = sandboxDenialKey(tool.name, this.input.header.cwd, executionArgs);
           this.recentSandboxDenials.add(denialKey);
-          this.recentSandboxDenials.add(
-            sandboxDenialKey('Bash', this.input.header.cwd, {
-              command: content.cmd,
-            }),
-          );
+          if (content.kind === 'terminal' || content.kind === 'shell_run') {
+            this.recentSandboxDenials.add(
+              sandboxDenialKey('Bash', this.input.header.cwd, {
+                command: content.cmd,
+              }),
+            );
+          }
           trace?.emit(
             'sandbox',
             'sandbox_denial_detected',
@@ -1774,7 +1779,13 @@ export class ToolRuntime {
         tool.categoryHint === 'computer_use'
           ? `Computer Use failed: ${classifyError(err)}`
           : formatSyntheticToolErrorText(err);
-      await this.writeSyntheticToolResult(toolUseId, turnId, msg, queue);
+      await this.writeSyntheticToolResult(
+        toolUseId,
+        turnId,
+        msg,
+        queue,
+        sandboxDenialSignalFromError(err),
+      );
       this.input.recordToolInvocation?.({
         sessionId: this.input.sessionId,
         turnId,
@@ -2674,11 +2685,21 @@ function buildTerminalFailureMessage(
 
 function hasSandboxDenial(
   content: ToolResultContent,
-): content is Extract<ToolResultContent, { kind: 'terminal' } | { kind: 'shell_run' }> {
-  return (
-    (content.kind === 'terminal' || content.kind === 'shell_run') &&
-    content.sandboxDenial?.likely === true
-  );
+): content is Extract<ToolResultContent, { kind: 'text' | 'terminal' | 'shell_run' }> {
+  return 'sandboxDenial' in content && content.sandboxDenial?.likely === true;
+}
+
+function sandboxDenialSignalFromError(error: unknown): SandboxDenialSignal | undefined {
+  const metadata = sandboxErrorMetadata(error);
+  if (!metadata) return undefined;
+  const backend =
+    metadata.backend === 'macos-seatbelt' || metadata.backend === 'linux'
+      ? metadata.backend
+      : undefined;
+  if (metadata.reason === 'sandbox_denial' || metadata.reason === 'sandbox_denied') {
+    return { likely: true, ...(backend ? { backend } : {}) };
+  }
+  return undefined;
 }
 
 function sandboxDenialKey(toolName: string, cwd: string, args: unknown): string {

--- a/packages/ui/src/__tests__/tool-activity-presentation.test.ts
+++ b/packages/ui/src/__tests__/tool-activity-presentation.test.ts
@@ -172,6 +172,92 @@ describe('tool activity presentation', () => {
     assert.match(markup, /1 个失败/);
   });
 
+  it('presents a command sandbox denial as blocked instead of failed', () => {
+    const item: ToolActivityItem = {
+      toolUseId: 'tool-sandbox-blocked',
+      toolName: 'Bash',
+      activityKind: 'command',
+      intent: '写入工作区外文件',
+      status: 'errored',
+      args: { command: 'printf blocked > ../outside.txt' },
+      result: {
+        kind: 'terminal',
+        cwd: '/tmp/maka',
+        cmd: 'printf blocked > ../outside.txt',
+        status: 'failed',
+        exitCode: 1,
+        output: pipeOutput('', 'Operation not permitted\n'),
+        sandboxDenial: {
+          likely: true,
+          backend: 'macos-seatbelt',
+          recovery: 'require_escalated',
+        },
+      },
+    };
+
+    const collapsed = renderTool(item);
+    assert.match(collapsed, /1 个可能被沙箱阻止/);
+    assert.doesNotMatch(collapsed, /1 个失败/);
+
+    const expanded = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [item],
+      open: true,
+    }));
+    assert.match(expanded, /可能被沙箱阻止/);
+    assert.match(expanded, /操作可能被沙箱阻止/);
+    assert.match(expanded, /失败前可能已经产生部分结果/);
+    assert.doesNotMatch(expanded, /因此未执行/);
+    assert.doesNotMatch(expanded, /工具调用失败/);
+  });
+
+  it('presents a filesystem worker sandbox denial as blocked instead of failed', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-filesystem-sandbox-blocked',
+        toolName: 'Grep',
+        activityKind: 'search',
+        intent: '搜索文件',
+        status: 'errored',
+        args: { pattern: 'needle', path: '/workspace' },
+        result: {
+          kind: 'text',
+          text: 'Filesystem access was denied.',
+          sandboxDenial: {
+            likely: true,
+            backend: 'macos-seatbelt',
+          },
+        },
+      } satisfies ToolActivityItem],
+      open: true,
+    }));
+
+    assert.match(markup, /可能被沙箱阻止/);
+    assert.match(markup, /操作可能被沙箱阻止/);
+    assert.match(markup, /Filesystem access was denied/);
+    assert.doesNotMatch(markup, /工具调用失败/);
+  });
+
+  it('keeps an ordinary filesystem permission error in the generic failure state', () => {
+    const markup = renderToStaticMarkup(createElement(ToolActivity, {
+      items: [{
+        toolUseId: 'tool-filesystem-denied',
+        toolName: 'Read',
+        activityKind: 'read',
+        intent: '读取受限文件',
+        status: 'errored',
+        args: { path: '/workspace/private.txt' },
+        result: {
+          kind: 'text',
+          text: 'Filesystem access was denied.',
+        },
+      } satisfies ToolActivityItem],
+      open: true,
+    }));
+
+    assert.match(markup, /工具调用失败/);
+    assert.doesNotMatch(markup, /可能被沙箱阻止/);
+  });
+
   it('shows diagnostic flags without exposing transport chunk counts', () => {
     const markup = renderToStaticMarkup(createElement(ToolActivity, {
       items: [{

--- a/packages/ui/src/__tests__/tool-trow-summary.test.ts
+++ b/packages/ui/src/__tests__/tool-trow-summary.test.ts
@@ -80,6 +80,36 @@ describe('tool trow summary aggregation', () => {
     assert.equal(summarizeTrowTools(items), '读取 1 个文件，搜索 1 次，1 个失败');
   });
 
+  it('counts sandbox denials separately from ordinary failures', () => {
+    const items: ToolActivityItem[] = [
+      {
+        toolUseId: 'g1',
+        toolName: 'Grep',
+        activityKind: 'search',
+        status: 'errored',
+        args: {},
+        result: {
+          kind: 'text',
+          text: 'Filesystem access was denied.',
+          sandboxDenial: { likely: true, backend: 'macos-seatbelt' },
+        },
+      },
+      {
+        toolUseId: 'b1',
+        toolName: 'Bash',
+        activityKind: 'command',
+        status: 'errored',
+        args: {},
+        result: { kind: 'text', text: 'Command failed.' },
+      },
+    ];
+
+    assert.equal(
+      summarizeTrowTools(items),
+      '搜索 1 次，运行 1 条命令，1 个可能被沙箱阻止，1 个失败',
+    );
+  });
+
   it('marks an errored row with a visible 失败 word inside an expanded group', () => {
     const markup = renderToStaticMarkup(createElement(ToolTrow, {
       items: [
@@ -92,6 +122,30 @@ describe('tool trow summary aggregation', () => {
     // A collapsed errored row must not rely on the destructive tint alone —
     // the failure is a word, not just a color.
     assert.match(markup, /运行测试 · 失败/);
+  });
+
+  it('marks a sandbox-denied row without labeling it as failed', () => {
+    const markup = renderToStaticMarkup(createElement(ToolTrow, {
+      items: [
+        { toolUseId: 'w1', toolName: 'Write', activityKind: 'edit', status: 'waiting_permission', args: {}, intent: '写入配置' },
+        {
+          toolUseId: 'g1',
+          toolName: 'Grep',
+          activityKind: 'search',
+          status: 'errored',
+          args: {},
+          intent: '搜索源码',
+          result: {
+            kind: 'text',
+            text: 'Filesystem access was denied.',
+            sandboxDenial: { likely: true, backend: 'macos-seatbelt' },
+          },
+        },
+      ] satisfies ToolActivityItem[],
+    }));
+
+    assert.match(markup, /搜索源码 · 可能被沙箱阻止/);
+    assert.doesNotMatch(markup, /搜索源码 · 失败/);
   });
 
   it('ToolTrowRow never reintroduces the per-row settle fade or the motion abstraction', () => {

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -23,6 +23,7 @@ import {
   processingNeedsAttention,
   summarizeProcessing,
 } from './tool-activity/trow-summary.js';
+import { isSandboxDeniedTool } from './tool-activity/sandbox-denial.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
 
@@ -976,7 +977,21 @@ function ProcessingBlock(props: { entries: FoldedTimelineChild[] }) {
   if (running) everRunningRef.current = true;
   const settled = !running;
   const settling = settled && everRunningRef.current;
-  const hasError = entries.some((entry) => entry.kind === 'tools' && entry.items.some((item) => item.status === 'errored'));
+  const hasSandboxBlocked = entries.some(
+    (entry) => entry.kind === 'tools' && entry.items.some(isSandboxDeniedTool),
+  );
+  const hasError = entries.some(
+    (entry) =>
+      entry.kind === 'tools' &&
+      entry.items.some(
+        (item) => item.status === 'errored' && !isSandboxDeniedTool(item),
+      ),
+  );
+  const settledTone = hasError
+    ? 'text-[color:var(--destructive)]'
+    : hasSandboxBlocked
+      ? 'text-[color:var(--warning-text,var(--info-text))]'
+      : 'text-[color:var(--muted-foreground)]';
   const activityKind = processingActivityKind(entries);
   const summary = summarizeProcessing(entries, { live: running, locale });
   return (
@@ -994,12 +1009,12 @@ function ProcessingBlock(props: { entries: FoldedTimelineChild[] }) {
           kind={activityKind}
           size={16}
           aria-hidden="true"
-          className={cn('shrink-0', hasError ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]')}
+          className={cn('shrink-0', settledTone)}
         />
         {running ? (
           <TextShimmer active delayed className="min-w-0 truncate text-[length:var(--font-size-base)]">{summary}</TextShimmer>
         ) : (
-          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', hasError ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]', settling && SETTLE_FADE)}>{summary}</span>
+          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', settledTone, settling && SETTLE_FADE)}>{summary}</span>
         )}
         <ChevronRight
           size={14}

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -14,6 +14,7 @@ export * from './skills-copy.js';
 export * from './daily-review-copy.js';
 export * from './plan-reminder-copy.js';
 export * from './tool-activity/copy.js';
+export * from './tool-activity/sandbox-denial.js';
 export * from './chat-input-behavior.js';
 export * from './composer-mention-popup.js';
 export * from './use-composer-skill-draft.js';

--- a/packages/ui/src/primitives/chat.tsx
+++ b/packages/ui/src/primitives/chat.tsx
@@ -371,6 +371,7 @@ const toolVariants = cva("", {
         + " " + WP_CARD_BORDER
         + " data-[status=running]:[border-color:oklch(from_var(--status-running)_l_c_h_/_0.4)]"
         + " data-[status=completed]:[border-color:var(--border)]"
+        + " data-[status=blocked]:[border-color:oklch(from_var(--warning)_l_c_h_/_0.4)] data-[status=blocked]:bg-[oklch(from_var(--warning)_l_c_h_/_0.04)]"
         + " data-[status=errored]:[border-color:oklch(from_var(--destructive)_l_c_h_/_0.4)] data-[status=errored]:bg-[oklch(from_var(--destructive)_l_c_h_/_0.04)]"
         + " data-[status=interrupted]:[border-color:var(--border)] data-[status=interrupted]:bg-[var(--foreground-3)] data-[status=interrupted]:opacity-[0.7]",
       // The Collapsible trigger/header: 8px · name · meta grid. The open-state
@@ -385,6 +386,7 @@ const toolVariants = cva("", {
         + " " + WP_DOT_BG
         + " data-[status=running]:bg-[var(--status-running)] data-[status=running]:[box-shadow:0_0_0_3px_oklch(from_var(--status-running)_l_c_h_/_0.15)] data-[status=running]:[animation:maka-tool-pulse_1.5s_ease-in-out_infinite]"
         + " data-[status=completed]:bg-[var(--success)]"
+        + " data-[status=blocked]:bg-[var(--warning)]"
         + " data-[status=errored]:bg-[var(--destructive)]"
         + " data-[status=interrupted]:bg-[var(--muted-foreground)]",
       // `.maka-tool-name` — the mono tool name, ellipsized.

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -660,16 +660,20 @@ function ToolErrorBanner(props: {
         ? <ShieldAlert size={16} aria-hidden="true" />
         : <AlertOctagon size={16} aria-hidden="true" />}
       <AlertTitle>{bannerCopy.title}</AlertTitle>
-      {(props.sandboxBlocked || errorText) && (
+      {props.sandboxBlocked ? (
         <AlertDescription className="flex flex-col gap-1 text-xs leading-normal whitespace-pre-wrap [word-break:break-word]">
-          {props.sandboxBlocked && <span>{copyText.sandboxBlocked.description}</span>}
+          <span>{copyText.sandboxBlocked.description}</span>
           {errorText && (
             <span className="[font-family:var(--font-mono)]">
               {summarizeErrorText(errorText)}
             </span>
           )}
         </AlertDescription>
-      )}
+      ) : errorText ? (
+        <AlertDescription className="[font-family:var(--font-mono)] text-xs leading-normal whitespace-pre-wrap [word-break:break-word]">
+          {summarizeErrorText(errorText)}
+        </AlertDescription>
+      ) : null}
       {errorText && (
         <AlertAction>
           <UiButton

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -11,6 +11,7 @@ import {
   Repeat,
   Search,
   Settings,
+  ShieldAlert,
   SquarePen,
   Terminal,
   X,
@@ -44,6 +45,7 @@ import {
   toolStatusLabel,
   withLiveStreamFallback,
 } from './tool-activity/result-projection.js';
+import { isSandboxDeniedTool } from './tool-activity/sandbox-denial.js';
 import { Alert, AlertAction, AlertDescription, AlertTitle } from './primitives/alert.js';
 import { Collapsible, CollapsibleTrigger, CollapsiblePanel } from './primitives/collapsible.js';
 import { previewVariants, TextShimmer, toolVariants } from './primitives/chat.js';
@@ -210,16 +212,17 @@ function ToolActivityCard({ item, open: openProp }: { item: ToolActivityItem; op
   const disclosure = useToolDisclosure(presentation);
   const open = openProp ?? disclosure.open;
   const duration = formatDuration(item.durationMs);
+  const visualStatus = isSandboxDeniedTool(item) ? 'blocked' : item.status;
   return (
     <Collapsible
       data-slot="tool"
       className={toolVariants({ part: 'item' })}
-      data-status={item.status}
+      data-status={visualStatus}
       open={open}
       onOpenChange={disclosure.setOpen}
     >
       <CollapsibleTrigger className={toolVariants({ part: 'header' })}>
-        <span className={toolVariants({ part: 'dot' })} data-status={item.status} aria-hidden="true" />
+        <span className={toolVariants({ part: 'dot' })} data-status={visualStatus} aria-hidden="true" />
         <span className={toolVariants({ part: 'name' })}>{resolveToolDisplayName(item, locale)}</span>
         <span className={toolVariants({ part: 'meta' })}>
           {duration && <span className={toolVariants({ part: 'duration' })}>{duration}</span>}
@@ -242,15 +245,17 @@ function ToolActivityCard({ item, open: openProp }: { item: ToolActivityItem; op
 function ToolCardBody({ item }: { item: ToolActivityItem }) {
   const locale = useUiLocale();
   const cancelled = isCancelledToolResult(item.result);
+  const sandboxBlocked = isSandboxDeniedTool(item);
   // Cancel maps to interrupted at materialize/live-projection; keep defensive
   // checks so a stale errored+cancelled item still does not look like failure.
-  const errored = item.status === 'errored' && !cancelled;
+  const failedOutcome = item.status === 'errored' && !cancelled;
+  const errored = failedOutcome && !sandboxBlocked;
   const permissionDenied = isPermissionDeniedToolResult(item.result);
   const running = item.status === 'running' || item.status === 'pending';
   const ptyControlResult = item.toolName === 'WriteStdin' && item.result?.kind === 'shell_run';
   // Rich kinds + tool-specific cards own their chrome — never nest in the shared well.
   const ownsPanel = resultOwnsOwnPanel(item);
-  const showErrorBanner = errored && !ptyControlResult;
+  const showErrorBanner = failedOutcome && !ptyControlResult;
   // Every tool: human invocation line from args — never pretty-printed JSON.
   // Skip when the result panel already prints the command (terminal/shell_run).
   const invocationLine = !permissionDenied && !ownsPanel
@@ -289,13 +294,18 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
       showInvocation
       || !!resultHeadline
       || showLiveStream
-      || (showResult && !errored)
+      || (showResult && !failedOutcome)
       || (!!item.args && !permissionDenied && !invocationLine && !showResult && !showLiveStream)
     );
 
   return (
     <div className="mt-1 flex flex-col gap-1.5">
-      {showErrorBanner && <ToolErrorBanner result={displayResult ?? item.result} />}
+      {showErrorBanner && (
+        <ToolErrorBanner
+          result={displayResult ?? item.result}
+          sandboxBlocked={sandboxBlocked}
+        />
+      )}
       {showResult && ownsPanel && displayResult && (
         isConnectorTool(item.toolName) && displayResult.kind === 'json' ? (
           <LoadToolResultPreview args={item.args} value={displayResult.value} />
@@ -313,7 +323,11 @@ function ToolCardBody({ item }: { item: ToolActivityItem }) {
       {hasSharedPanelContent && (
         <div
           data-slot="tool-output"
-          className={cn(TOOL_OUTPUT_PANEL_CLASS, errored && 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]')}
+          className={cn(
+            TOOL_OUTPUT_PANEL_CLASS,
+            errored && 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]',
+            sandboxBlocked && 'border-[oklch(from_var(--warning)_l_c_h_/_0.32)]',
+          )}
         >
           {showInvocation && (
             <code className={TOOL_OUTPUT_COMMAND_CLASS}>{invocationLine}</code>
@@ -431,7 +445,15 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   if (running) everRunningRef.current = true;
   const settled = !running;
   const settling = settled && everRunningRef.current;
-  const hasError = items.some((item) => item.status === 'errored');
+  const hasSandboxBlocked = items.some(isSandboxDeniedTool);
+  const hasError = items.some(
+    (item) => item.status === 'errored' && !isSandboxDeniedTool(item),
+  );
+  const settledTone = hasError
+    ? 'text-[color:var(--destructive)]'
+    : hasSandboxBlocked
+      ? 'text-[color:var(--warning-text,var(--info-text))]'
+      : 'text-[color:var(--muted-foreground)]';
   // #tool-jitter: the group icon stays on the first bucket's kind (the same
   // first-seen order the summary clauses use), not the active tool's kind — so
   // a mixed-kind group's icon doesn't flip as the active tool changes mid-run.
@@ -447,11 +469,11 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
   return (
     <Collapsible className="flex flex-col" data-trow="group" data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">
-        <ToolKindIcon kind={firstPresentation.kind} size={16} aria-hidden="true" className={cn('shrink-0', hasError ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]')} />
+        <ToolKindIcon kind={firstPresentation.kind} size={16} aria-hidden="true" className={cn('shrink-0', settledTone)} />
         {running ? (
           <TextShimmer active delayed className="min-w-0 truncate text-[length:var(--font-size-base)]">{summary}</TextShimmer>
         ) : (
-          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', hasError ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]', settling && SETTLE_FADE)}>{summary}</span>
+          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', settledTone, settling && SETTLE_FADE)}>{summary}</span>
         )}
         <ChevronRight
           size={14}
@@ -492,28 +514,39 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
   // instead of stacking N opacity-0→1 fades, so a batch settle no longer 1234567.
   const running = isToolRowRunning(item.status);
   const settled = isToolRowSettled(item.status);
-  const errored = item.status === 'errored';
+  const sandboxBlocked = isSandboxDeniedTool(item);
+  const errored = item.status === 'errored' && !sandboxBlocked;
   // One row language with the multi-tool summary row: a kind icon + a
   // user-language phrase, never the old status-dot + mono tool-name + status
   // word. Running shimmers the model's intent (or the friendly tool name);
   // settled prefers the intent, falls back to the display name.
-  const summaryTone = errored ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]';
-  // An errored row stays collapsed, so the destructive tint is not enough —
-  // the failure is spelled out as a word on the row label.
+  const summaryTone = errored
+    ? 'text-[color:var(--destructive)]'
+    : sandboxBlocked
+      ? 'text-[color:var(--warning-text,var(--info-text))]'
+      : 'text-[color:var(--muted-foreground)]';
+  // Settled attention states stay collapsed, so tint alone is not enough:
+  // spell out whether the operation failed or the sandbox blocked it.
   const rowLabel = item.intent ? formatToolIntent(item.intent) : resolveToolDisplayName(item, locale);
   return (
-    <Collapsible className="flex flex-col" data-trow="row" data-status={item.status} data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
+    <Collapsible className="flex flex-col" data-trow="row" data-status={sandboxBlocked ? 'blocked' : item.status} data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
       <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">
         <ToolKindIcon
           kind={presentation.kind}
           size={16}
           aria-hidden="true"
-          className={cn('shrink-0', errored ? 'text-[color:var(--destructive)]' : 'text-[color:var(--muted-foreground)]')}
+          className={cn('shrink-0', summaryTone)}
         />
         {running ? (
           <TextShimmer active delayed className="min-w-0 truncate text-[length:var(--font-size-base)]">{presentation.summary}</TextShimmer>
         ) : (
-          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone)}>{errored ? `${rowLabel} · ${getToolActivityCopy(locale).group.failedSuffix}` : rowLabel}</span>
+          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone)}>
+            {errored
+              ? `${rowLabel} · ${getToolActivityCopy(locale).group.failedSuffix}`
+              : sandboxBlocked
+                ? `${rowLabel} · ${getToolActivityCopy(locale).group.sandboxBlockedSuffix}`
+                : rowLabel}
+          </span>
         )}
         {/* Quiet meta sits right after the label (near the text, not pinned to
             the far edge): duration + chevron ride in on hover / open, matching
@@ -593,9 +626,13 @@ function ToolOutputStream(props: {
 // Preserve the retired `.maka-tool-error*` leaf utilities onto Alert (#332 PR3c) —
 // Alert owns the shell; these are the few declarations it doesn't set, kept arbitrary
 // so they map 1:1 to the old CSS (`[align-self:start]`, not Tailwind's `flex-start`).
-function ToolErrorBanner(props: { result: ToolActivityItem['result'] }) {
+function ToolErrorBanner(props: {
+  result: ToolActivityItem['result'];
+  sandboxBlocked?: boolean;
+}) {
   const locale = useUiLocale();
   const copyText = getToolActivityCopy(locale);
+  const bannerCopy = props.sandboxBlocked ? copyText.sandboxBlocked : copyText.error;
   // Tool stderr / raw provider errors occasionally slip credential paths,
   // bearer tokens, or API keys through main-side redaction. Apply a
   // defensive UI-level mask before display *and* before clipboard copy so
@@ -618,12 +655,19 @@ function ToolErrorBanner(props: { result: ToolActivityItem['result'] }) {
   }
 
   return (
-    <Alert variant="error" className="mb-2.5">
-      <AlertOctagon size={16} aria-hidden="true" />
-      <AlertTitle>{copyText.error.title}</AlertTitle>
-      {errorText && (
-        <AlertDescription className="[font-family:var(--font-mono)] text-xs leading-normal whitespace-pre-wrap [word-break:break-word]">
-          {summarizeErrorText(errorText)}
+    <Alert variant={props.sandboxBlocked ? 'warning' : 'error'} className="mb-2.5">
+      {props.sandboxBlocked
+        ? <ShieldAlert size={16} aria-hidden="true" />
+        : <AlertOctagon size={16} aria-hidden="true" />}
+      <AlertTitle>{bannerCopy.title}</AlertTitle>
+      {(props.sandboxBlocked || errorText) && (
+        <AlertDescription className="flex flex-col gap-1 text-xs leading-normal whitespace-pre-wrap [word-break:break-word]">
+          {props.sandboxBlocked && <span>{copyText.sandboxBlocked.description}</span>}
+          {errorText && (
+            <span className="[font-family:var(--font-mono)]">
+              {summarizeErrorText(errorText)}
+            </span>
+          )}
         </AlertDescription>
       )}
       {errorText && (
@@ -635,7 +679,7 @@ function ToolErrorBanner(props: { result: ToolActivityItem['result'] }) {
             className="[align-self:start] data-[pending=true]:cursor-progress data-[copy-feedback=copied]:text-[color:var(--link)] data-[copy-feedback=copied]:border-[oklch(from_var(--link)_l_c_h_/_0.35)] data-[copy-feedback=failed]:text-[color:var(--destructive)] data-[copy-feedback=failed]:border-[oklch(from_var(--destructive)_l_c_h_/_0.35)]"
             data-pending={copyPending ? 'true' : undefined}
             data-copy-feedback={copyPhase ?? undefined}
-            aria-label={copyText.error.copyAriaLabel(copyLabel)}
+            aria-label={bannerCopy.copyAriaLabel(copyLabel)}
             aria-busy={copyPending ? 'true' : undefined}
             disabled={copyPending}
             onClick={() => void copy()}

--- a/packages/ui/src/tool-activity/copy.ts
+++ b/packages/ui/src/tool-activity/copy.ts
@@ -25,6 +25,7 @@ export interface ToolActivityCopy {
     waitingPermission: string;
     completed: string;
     failed: string;
+    sandboxBlocked: string;
     interrupted: string;
     cancelled: string;
     timedOut: string;
@@ -34,6 +35,7 @@ export interface ToolActivityCopy {
     title: string;
     callCount: (count: number) => string;
     failedSuffix: string;
+    sandboxBlockedSuffix: string;
   };
   output: {
     redacted: string;
@@ -46,9 +48,15 @@ export interface ToolActivityCopy {
   };
   copy: { idle: string; pending: string; copied: string; failed: string };
   error: { title: string; copyAriaLabel: (label: string) => string };
+  sandboxBlocked: {
+    title: string;
+    description: string;
+    copyAriaLabel: (label: string) => string;
+  };
   summary: {
     kind: Record<ToolActivityKind, (count: number) => string>;
     failed: (count: number) => string;
+    sandboxBlocked: (count: number) => string;
     join: (clauses: readonly string[]) => string;
     live: (summary: string) => string;
     /** Live current-activity label when a processing group's tools are done
@@ -176,14 +184,15 @@ export interface ToolActivityCopy {
 
 const TOOL_ACTIVITY_COPY = {
   zh: {
-    status: { pending: '排队中', running: '运行中', waitingPermission: '等待权限', completed: '已完成', failed: '失败', interrupted: '已中断', cancelled: '已取消', timedOut: '已超时' },
-    group: { ariaLabel: '工具调用记录', title: '工具调用', callCount: (count) => `${count} 次调用`, failedSuffix: '失败' },
+    status: { pending: '排队中', running: '运行中', waitingPermission: '等待权限', completed: '已完成', failed: '失败', sandboxBlocked: '可能被沙箱阻止', interrupted: '已中断', cancelled: '已取消', timedOut: '已超时' },
+    group: { ariaLabel: '工具调用记录', title: '工具调用', callCount: (count) => `${count} 次调用`, failedSuffix: '失败', sandboxBlockedSuffix: '可能被沙箱阻止' },
     output: { redacted: '[已脱敏]', redactedAriaLabel: '已脱敏', truncated: '输出已截断', close: '关闭', closeAriaLabel: '关闭预览', showRaw: '显示原始诊断', hideRaw: '隐藏原始诊断' },
     copy: { idle: '复制', pending: '复制中…', copied: '已复制', failed: '复制失败' },
     error: { title: '工具调用失败', copyAriaLabel: (label) => `${label}错误信息` },
+    sandboxBlocked: { title: '操作可能被沙箱阻止', description: '沙箱可能阻止了该调用中的至少一项操作。失败前可能已经产生部分结果，请检查输出和工作区状态后再决定是否重试。', copyAriaLabel: (label) => `${label}沙箱诊断信息` },
     summary: {
       kind: { read: (n) => `读取 ${n} 个文件`, search: (n) => `搜索 ${n} 次`, websearch: (n) => `联网搜索 ${n} 次`, webfetch: (n) => `抓取 ${n} 个网页`, edit: (n) => `编辑 ${n} 个文件`, command: (n) => `运行 ${n} 条命令`, explore: (n) => `探索 ${n} 次`, browser: (n) => `浏览器操作 ${n} 次`, tool: (n) => `调用 ${n} 个工具` },
-      failed: (n) => `${n} 个失败`, join: (clauses) => clauses.join('，'), live: (summary) => `正在${summary}`,
+      failed: (n) => `${n} 个失败`, sandboxBlocked: (n) => `${n} 个可能被沙箱阻止`, join: (clauses) => clauses.join('，'), live: (summary) => `正在${summary}`,
       thinkingActivity: '深度思考',
     },
     automation: { created: (name) => `自动化任务已创建：${name}`, nextFire: (value) => `下次触发：${value}`, deleted: '自动化任务已删除', notFound: '未找到该任务（可能已完成或已删除）', list: (count) => `自动化任务列表 (${count})`, empty: '当前会话暂无自动化任务' },
@@ -209,14 +218,15 @@ const TOOL_ACTIVITY_COPY = {
     },
   },
   en: {
-    status: { pending: 'Pending', running: 'Running', waitingPermission: 'Waiting for permission', completed: 'Completed', failed: 'Failed', interrupted: 'Interrupted', cancelled: 'Cancelled', timedOut: 'Timed out' },
-    group: { ariaLabel: 'Tool call history', title: 'Tool calls', callCount: (count) => `${count} ${count === 1 ? 'call' : 'calls'}`, failedSuffix: 'Failed' },
+    status: { pending: 'Pending', running: 'Running', waitingPermission: 'Waiting for permission', completed: 'Completed', failed: 'Failed', sandboxBlocked: 'Possibly blocked by sandbox', interrupted: 'Interrupted', cancelled: 'Cancelled', timedOut: 'Timed out' },
+    group: { ariaLabel: 'Tool call history', title: 'Tool calls', callCount: (count) => `${count} ${count === 1 ? 'call' : 'calls'}`, failedSuffix: 'Failed', sandboxBlockedSuffix: 'Possibly blocked by sandbox' },
     output: { redacted: '[Redacted]', redactedAriaLabel: 'Redacted', truncated: 'Output truncated', close: 'Close', closeAriaLabel: 'Close preview', showRaw: 'Show raw diagnostics', hideRaw: 'Hide raw diagnostics' },
     copy: { idle: 'Copy', pending: 'Copying…', copied: 'Copied', failed: 'Copy failed' },
     error: { title: 'Tool call failed', copyAriaLabel: (label) => `${label} error details` },
+    sandboxBlocked: { title: 'Operation may have been blocked by sandbox', description: 'The sandbox may have blocked at least one action in this call. Some effects may have occurred before it failed; check the output and workspace state before retrying.', copyAriaLabel: (label) => `${label} sandbox diagnostics` },
     summary: {
       kind: { read: (n) => `Read ${n} ${n === 1 ? 'file' : 'files'}`, search: (n) => `Searched ${n} ${n === 1 ? 'time' : 'times'}`, websearch: (n) => `Ran ${n} web ${n === 1 ? 'search' : 'searches'}`, webfetch: (n) => `Fetched ${n} web ${n === 1 ? 'page' : 'pages'}`, edit: (n) => `Edited ${n} ${n === 1 ? 'file' : 'files'}`, command: (n) => `Ran ${n} ${n === 1 ? 'command' : 'commands'}`, explore: (n) => `Explored ${n} ${n === 1 ? 'time' : 'times'}`, browser: (n) => `Performed ${n} browser ${n === 1 ? 'action' : 'actions'}`, tool: (n) => `Called ${n} ${n === 1 ? 'tool' : 'tools'}` },
-      failed: (n) => `${n} failed`, join: (clauses) => clauses.join(', '), live: (summary) => `Working: ${summary}`,
+      failed: (n) => `${n} failed`, sandboxBlocked: (n) => `${n} possibly blocked by sandbox`, join: (clauses) => clauses.join(', '), live: (summary) => `Working: ${summary}`,
       thinkingActivity: 'Thinking',
     },
     automation: { created: (name) => `Automation created: ${name}`, nextFire: (value) => `Next run: ${value}`, deleted: 'Automation deleted', notFound: 'Automation not found (it may have completed or been deleted)', list: (count) => `Automations (${count})`, empty: 'No automations in this conversation' },

--- a/packages/ui/src/tool-activity/result-projection.ts
+++ b/packages/ui/src/tool-activity/result-projection.ts
@@ -3,6 +3,7 @@ import type { ToolActivityItem } from '../materialize.js';
 import { formatQuietJsonValue } from './builtin-preview.js';
 import { isConnectorTool } from './presentation.js';
 import { getToolActivityCopy } from './copy.js';
+import { isSandboxDeniedTool } from './sandbox-denial.js';
 
 // Mirror of runtime's AUTOMATION_TOOL_NAME. @maka/ui must not depend on
 // @maka/runtime, so the unified Automation tool's name is duplicated here as
@@ -151,6 +152,7 @@ export function toolStatusLabel(item: ToolActivityItem, locale: UiLocale = 'zh')
   const copy = getToolActivityCopy(locale).status;
   // Outer label follows call status. Panel notes still show task cancel state.
   if (item.status === 'interrupted' && isCancelledToolResult(item.result)) return copy.cancelled;
+  if (isSandboxDeniedTool(item)) return copy.sandboxBlocked;
   if (
     (item.result?.kind === 'terminal' || item.result?.kind === 'shell_run')
     && item.result.status === 'timed_out'

--- a/packages/ui/src/tool-activity/sandbox-denial.ts
+++ b/packages/ui/src/tool-activity/sandbox-denial.ts
@@ -1,0 +1,16 @@
+import type { ToolResultContent } from '@maka/core';
+import type { ToolActivityItem } from '../materialize.js';
+
+export function isSandboxDeniedToolResult(
+  result: ToolResultContent | undefined,
+): boolean {
+  return (
+    result !== undefined &&
+    'sandboxDenial' in result &&
+    result.sandboxDenial?.likely === true
+  );
+}
+
+export function isSandboxDeniedTool(item: ToolActivityItem): boolean {
+  return item.status === 'errored' && isSandboxDeniedToolResult(item.result);
+}

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -7,7 +7,7 @@ import {
   type ShellOutput,
   type ToolResultContent,
 } from '@maka/core';
-import { AlertCircle, Ban, Check, Clock, GitBranch, Loader2, Plug } from '../icons.js';
+import { AlertCircle, Ban, Check, Clock, GitBranch, Loader2, Plug, ShieldAlert } from '../icons.js';
 import { previewVariants } from '../primitives/chat.js';
 import { redactSecrets } from '../redact.js';
 import { useUiLocale } from '../locale-context.js';
@@ -16,6 +16,7 @@ import { AgentSwarmPreview, ExploreAgentPreview, SubagentPreview } from './agent
 import { formatQuietJsonValue } from './builtin-preview.js';
 import { TOOL_LINE_CAP, capLines, formatUserVisibleToolText } from './preview-utils.js';
 import { getToolActivityCopy } from './copy.js';
+import { isSandboxDeniedToolResult } from './sandbox-denial.js';
 
 /**
  * Shared Codex-like tool output well — one surface for live and settled
@@ -75,6 +76,7 @@ export function ToolResultPreview(props: {
         status={content.status}
         failureMessage={content.failureMessage}
         output={isShellOutput(content.output) ? content.output : undefined}
+        sandboxBlocked={isSandboxDeniedToolResult(content)}
       />
     );
   }
@@ -241,8 +243,10 @@ function TerminalPreview(props: {
   status?: string;
   failureMessage?: string;
   output?: ShellOutput;
+  sandboxBlocked?: boolean;
 }) {
-  const copy = getToolActivityCopy(useUiLocale()).result;
+  const activityCopy = getToolActivityCopy(useUiLocale());
+  const copy = activityCopy.result;
   const cancelled = isCancelledStatus(props.status);
   const timedOut = props.status === 'timed_out';
   const succeeded = props.status === 'completed';
@@ -250,12 +254,15 @@ function TerminalPreview(props: {
   // arg into the chat without masking it.
   const safeCmd = redactSecrets(props.cmd);
   const attention = !succeeded || cancelled || timedOut;
+  const attentionBorder = props.sandboxBlocked
+    ? 'border-[oklch(from_var(--warning)_l_c_h_/_0.32)]'
+    : 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]';
 
   return (
     <div
       data-slot="tool-output"
       data-kind="terminal"
-      className={cn(TOOL_OUTPUT_PANEL_CLASS, attention && 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]')}
+      className={cn(TOOL_OUTPUT_PANEL_CLASS, attention && attentionBorder)}
     >
       {safeCmd.length > 0 && (
         <code className={TOOL_OUTPUT_COMMAND_CLASS}>{safeCmd}</code>
@@ -266,7 +273,7 @@ function TerminalPreview(props: {
         <p className={TOOL_OUTPUT_NOTE_CLASS}>{copy.terminalUnavailable}</p>
       )}
       {props.failureMessage && (
-        <p className={cn(TOOL_OUTPUT_NOTE_CLASS, 'text-[color:var(--destructive)]')}>
+        <p className={cn(TOOL_OUTPUT_NOTE_CLASS, props.sandboxBlocked ? 'text-[color:var(--warning-text,var(--info-text))]' : 'text-[color:var(--destructive)]')}>
           {redactSecrets(props.failureMessage)}
         </p>
       )}
@@ -280,7 +287,14 @@ function TerminalPreview(props: {
           {props.exitCode !== undefined ? `${copy.timedOut} · ${copy.exitCode(props.exitCode)}` : copy.timedOut}
         </p>
       )}
-      {!succeeded && !cancelled && !timedOut && (
+      {props.sandboxBlocked && !cancelled && !timedOut && (
+        <p className={cn(TOOL_OUTPUT_NOTE_CLASS, 'text-[color:var(--warning-text,var(--info-text))]')}>
+          {props.exitCode !== undefined
+            ? `${activityCopy.status.sandboxBlocked} · ${copy.exitCode(props.exitCode)}`
+            : activityCopy.status.sandboxBlocked}
+        </p>
+      )}
+      {!succeeded && !cancelled && !timedOut && !props.sandboxBlocked && (
         <p className={cn(TOOL_OUTPUT_NOTE_CLASS, 'text-[color:var(--destructive)]')}>
           {props.exitCode !== undefined ? `${copy.failed} · ${copy.exitCode(props.exitCode)}` : copy.failed}
         </p>
@@ -298,9 +312,13 @@ function ShellRunPreview(props: {
   const locale = useUiLocale();
   const copy = getToolActivityCopy(locale).result;
   const { result } = props;
+  const sandboxBlocked = isSandboxDeniedToolResult(result);
   const safeCmd = redactSecrets(result.cmd);
   const output = isShellOutput(result.output) ? result.output : undefined;
   const attention = result.status === 'failed' || result.status === 'orphaned' || (result.exitCode !== undefined && result.exitCode !== 0);
+  const attentionBorder = sandboxBlocked
+    ? 'border-[oklch(from_var(--warning)_l_c_h_/_0.32)]'
+    : 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]';
 
   if (result.mode === 'pty') {
     return (
@@ -309,6 +327,7 @@ function ShellRunPreview(props: {
         output={output?.mode === 'pty' ? output : undefined}
         safeCmd={safeCmd}
         attention={attention}
+        sandboxBlocked={sandboxBlocked}
         source={props.source}
       />
     );
@@ -316,14 +335,18 @@ function ShellRunPreview(props: {
   const safeRef = redactSecrets(result.ref);
   const statusLabel = props.source === 'owned'
     ? copy.managedBySource
-    : props.source === 'unavailable' ? copy.sourceUnavailable : shellRunStatusLabel(result.status, locale);
+    : props.source === 'unavailable'
+      ? copy.sourceUnavailable
+      : sandboxBlocked
+        ? getToolActivityCopy(locale).status.sandboxBlocked
+        : shellRunStatusLabel(result.status, locale);
   const pipeOutput = output?.mode === 'pipes' ? output : undefined;
 
   return (
     <div
       data-slot="tool-output"
       data-kind="shell_run"
-      className={cn(TOOL_OUTPUT_PANEL_CLASS, attention && 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]')}
+      className={cn(TOOL_OUTPUT_PANEL_CLASS, attention && attentionBorder)}
     >
       {safeCmd.length > 0 && (
         <code className={TOOL_OUTPUT_COMMAND_CLASS}>{safeCmd}</code>
@@ -334,7 +357,7 @@ function ShellRunPreview(props: {
         {safeRef ? ` · ${safeRef}` : ''}
       </p>
       {result.failureMessage && (
-        <p className={cn(TOOL_OUTPUT_NOTE_CLASS, 'text-[color:var(--destructive)]')}>
+        <p className={cn(TOOL_OUTPUT_NOTE_CLASS, sandboxBlocked ? 'text-[color:var(--warning-text,var(--info-text))]' : 'text-[color:var(--destructive)]')}>
           {redactSecrets(result.failureMessage)}
         </p>
       )}
@@ -355,6 +378,7 @@ function PtyShellSurface(props: {
   output?: Extract<ShellOutput, { mode: 'pty' }>;
   safeCmd: string;
   attention: boolean;
+  sandboxBlocked: boolean;
   source?: 'owned' | 'unavailable';
 }) {
   const copy = getToolActivityCopy(useUiLocale()).result;
@@ -366,7 +390,11 @@ function PtyShellSurface(props: {
       className={cn(
         TOOL_OUTPUT_PANEL_CLASS,
         'gap-0 overflow-hidden p-0',
-        props.attention && 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]',
+        props.attention && (
+          props.sandboxBlocked
+            ? 'border-[oklch(from_var(--warning)_l_c_h_/_0.32)]'
+            : 'border-[oklch(from_var(--destructive)_l_c_h_/_0.28)]'
+        ),
       )}
     >
       <header className="flex min-w-0 items-center px-3 pt-2.5 pb-1">
@@ -391,13 +419,18 @@ function PtyShellSurface(props: {
           </p>
         )}
         {result.failureMessage && (
-          <p className={cn(TOOL_OUTPUT_NOTE_CLASS, 'text-[color:var(--destructive)]')}>
+          <p className={cn(TOOL_OUTPUT_NOTE_CLASS, props.sandboxBlocked ? 'text-[color:var(--warning-text,var(--info-text))]' : 'text-[color:var(--destructive)]')}>
             {redactSecrets(result.failureMessage)}
           </p>
         )}
       </div>
       <footer className="flex min-h-8 items-center justify-end gap-1.5 px-3 pt-1 pb-2.5 text-[length:var(--font-size-base)] text-[color:var(--muted-foreground)]">
-        <ShellRunStatus status={result.status} exitCode={result.exitCode} source={props.source} />
+        <ShellRunStatus
+          status={result.status}
+          exitCode={result.exitCode}
+          source={props.source}
+          sandboxBlocked={props.sandboxBlocked}
+        />
       </footer>
     </div>
   );
@@ -407,11 +440,16 @@ function ShellRunStatus(props: {
   status: Extract<ToolResultContent, { kind: 'shell_run' }>['status'];
   exitCode?: number;
   source?: 'owned' | 'unavailable';
+  sandboxBlocked?: boolean;
 }) {
-  const copy = getToolActivityCopy(useUiLocale()).result;
+  const activityCopy = getToolActivityCopy(useUiLocale());
+  const copy = activityCopy.result;
   if (props.source === 'owned') return <><GitBranch size={15} aria-hidden="true" />{copy.managedBySource}</>;
   if (props.source === 'unavailable') return <><GitBranch size={15} aria-hidden="true" />{copy.sourceUnavailable}</>;
   const suffix = props.exitCode !== undefined && props.exitCode !== 0 ? ` · ${copy.exitCode(props.exitCode)}` : '';
+  if (props.sandboxBlocked) {
+    return <><ShieldAlert size={15} aria-hidden="true" />{activityCopy.status.sandboxBlocked}{suffix}</>;
+  }
   switch (props.status) {
     case 'running':
       return <><Loader2 size={15} aria-hidden="true" className="animate-spin" />{copy.running}</>;

--- a/packages/ui/src/tool-activity/trow-summary.ts
+++ b/packages/ui/src/tool-activity/trow-summary.ts
@@ -17,6 +17,7 @@ import type { FoldedTimelineChild } from '../timeline-fold.js';
 import { loadToolDisplayName } from '../tool-format.js';
 import { getToolActivityCopy } from './copy.js';
 import { formatUserVisibleToolText } from './preview-utils.js';
+import { isSandboxDeniedTool } from './sandbox-denial.js';
 
 export type TrowActivityKind = ToolActivityKind;
 
@@ -92,9 +93,9 @@ export function trowActivityKind(
   }
 }
 
-/** Chinese count clause per bucket, e.g. read(3) → "读取 3 个文件". */
-function isFailed(status: ToolActivityItem['status']): boolean {
-  return status === 'errored';
+/** Count clause per bucket, e.g. read(3) -> "读取 3 个文件". */
+function isFailed(item: ToolActivityItem): boolean {
+  return item.status === 'errored' && !isSandboxDeniedTool(item);
 }
 
 /**
@@ -114,13 +115,16 @@ export function summarizeTrowTools(
   const order: TrowActivityKind[] = [];
   const counts = new Map<TrowActivityKind, number>();
   let failed = 0;
+  let sandboxBlocked = 0;
   for (const item of items) {
     const kind = trowActivityKind(item.toolName, item.activityKind);
     if (!counts.has(kind)) order.push(kind);
     counts.set(kind, (counts.get(kind) ?? 0) + 1);
-    if (isFailed(item.status)) failed += 1;
+    if (isSandboxDeniedTool(item)) sandboxBlocked += 1;
+    else if (isFailed(item)) failed += 1;
   }
   const clauses = order.map((kind) => copy.kind[kind](counts.get(kind) ?? 0));
+  if (sandboxBlocked > 0) clauses.push(copy.sandboxBlocked(sandboxBlocked));
   if (failed > 0) clauses.push(copy.failed(failed));
   const base = copy.join(clauses);
   return options?.live ? copy.live(base) : base;
@@ -208,8 +212,13 @@ function processingLiveSummary(
 ): string {
   const copy = getToolActivityCopy(locale).summary;
   const line = copy.live(currentProcessingActivity(children, locale) ?? copy.thinkingActivity);
-  const failed = processingTools(children).filter((tool) => isFailed(tool.status)).length;
-  return failed > 0 ? copy.join([line, copy.failed(failed)]) : line;
+  const tools = processingTools(children);
+  const sandboxBlocked = tools.filter(isSandboxDeniedTool).length;
+  const failed = tools.filter(isFailed).length;
+  const clauses = [line];
+  if (sandboxBlocked > 0) clauses.push(copy.sandboxBlocked(sandboxBlocked));
+  if (failed > 0) clauses.push(copy.failed(failed));
+  return copy.join(clauses);
 }
 
 /**


### PR DESCRIPTION
## Summary

- Preserve structured sandbox-denial metadata for command and filesystem-worker failures instead of collapsing them into generic tool errors.
- Present sandbox-blocked tool rows and output panels with dedicated warning copy, while suppressing the duplicate generic failed-turn banner.
- Keep strict RuntimeEvent persistence lossless by omitting absent context-budget counters, and use bundle-safe Node builtin imports required by the desktop build.

## Verification

- `npm run build:test`
- `npm run typecheck`
- Focused Core, Runtime, UI, and Desktop tests: 294 passed
- Biome check for all 29 changed TypeScript files
- `npm run test:checks -w @maka/desktop` (console, accessibility, and copy checks)
- Desktop development app starts successfully

## Review focus

- The new status is diagnostic only: it does not automatically retry or elevate a command.
- Ordinary filesystem permission errors remain generic failures; only explicit or likely sandbox denials receive the sandbox-specific presentation.
- Partial command effects remain visible, and the copy asks users to inspect output and workspace state before retrying.

<details>
<summary>中文说明</summary>

### 改动内容

- 为命令和 filesystem worker 的 sandbox denial 保留结构化元数据，不再全部折叠成普通工具失败。
- 前端使用“可能被沙箱阻止”的独立状态和警告样式，并避免同时显示重复的整轮“未知错误”提示。
- 修复 context-budget 可选计数字段写入 `undefined` 后导致 RuntimeEvent 无法持久化的问题。
- 调整 Node 内置模块导入方式，保证 Desktop 构建和启动兼容。

### 行为边界

“可能被沙箱阻止”只是一项诊断结果，不会自动提权或重试。Agent 仍需发起新的、显式声明权限的工具调用，并经过既有审批流程。普通运行失败不会被错误标记为 sandbox denial。

### 验证结果

构建、全仓类型检查、Biome、Desktop 静态检查，以及 294 个相关自动化测试均已通过。

</details>