### PR TITLE
fix(runtime): surface swarm child progress

### DIFF
--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -269,6 +269,177 @@ describe('AgentSwarm adapter', () => {
     );
   });
 
+  test('projects item-scoped child tool and provider retry progress for spawned and resumed items', async () => {
+    const output: Array<{ stream: string; chunk: string }> = [];
+    const result = await buildAgentSwarmTool().impl(
+      {
+        resume_run_ids: { 'source-run': 'Continue the source review.' },
+        items: [swarmItem(0)],
+        max_concurrency: 2,
+      },
+      context({
+        emitOutput: (stream, chunk) => output.push({ stream, chunk }),
+        prepareChildAgentResume: async (sourceRunId) => preparedResume(sourceRunId),
+        resumeChildAgent: async (input) => {
+          input.onEvent?.(childToolStart('resume-tool', 'Read', 'resume-secret.txt'));
+          input.onEvent?.(childToolResult('resume-tool', false, 'resume secret body'));
+          return {
+            ...childResult(10),
+            runId: 'resumed-run',
+            resumedFromRunId: input.sourceRunId,
+          };
+        },
+        spawnChildSession: async (input) => {
+          input.onEvent?.(childProviderRetry('scheduled'));
+          input.onEvent?.(childProviderRetry('started'));
+          return childResult(0);
+        },
+      }),
+    );
+
+    assert.equal(result.status, 'completed');
+    assert.ok(
+      output.some(
+        ({ chunk }) => chunk === 'Agent swarm item resume-1 · child tool started: Read\n',
+      ),
+    );
+    assert.ok(
+      output.some(
+        ({ chunk }) => chunk === 'Agent swarm item resume-1 · child tool finished: Read\n',
+      ),
+    );
+    assert.ok(
+      output.some(
+        ({ chunk }) =>
+          chunk ===
+          'Agent swarm item item-0 · child provider retry scheduled: attempt 2/10 in 250ms (rate_limit)\n',
+      ),
+    );
+    assert.ok(
+      output.some(
+        ({ chunk }) =>
+          chunk ===
+          'Agent swarm item item-0 · child provider retry started: attempt 2/10 (rate_limit)\n',
+      ),
+    );
+    assert.doesNotMatch(JSON.stringify(output), /resume-secret\.txt|resume secret body/);
+  });
+
+  test('projects child progress from the adaptive retry execution path', async () => {
+    const output: Array<{ stream: string; chunk: string }> = [];
+    let retryObservedOnEvent = false;
+    const siblingGate = deferred<SpawnChildAgentResult>();
+    const pending = buildAgentSwarmTool({
+      adaptiveSwarmPolicy: {
+        initialLaunchLimit: 2,
+        initialLaunchIntervalMs: 1,
+        rateLimitRetryBaseMs: 1,
+        rateLimitRetryFactor: 2,
+        capacityShrinkIntervalMs: 1,
+        capacityRecoveryIntervalMs: 100,
+      },
+    }).impl(
+      { items: [swarmItem(0), swarmItem(1)], max_concurrency: 2 },
+      context({
+        emitOutput: (stream, chunk) => output.push({ stream, chunk }),
+        spawnChildSession: async (input) =>
+          input.prompt === 'task-1'
+            ? await siblingGate.promise
+            : {
+                ...childResult(0, 'failed'),
+                childSessionId: 'child-session-0',
+                failureClass: 'RateLimit',
+                summary: 'provider 429',
+              },
+        retryChildAgent: async (input) => {
+          retryObservedOnEvent = typeof input.onEvent === 'function';
+          input.onEvent?.(childToolStart('retry-tool', 'Search', 'retry-secret-query'));
+          return {
+            ...childResult(0),
+            childSessionId: 'child-session-0',
+            runId: 'run-0-retry',
+          };
+        },
+      }),
+    );
+
+    await waitFor(() => retryObservedOnEvent);
+    siblingGate.resolve(childResult(1));
+    const result = await pending;
+
+    assert.equal(result.status, 'completed');
+    assert.equal(retryObservedOnEvent, true);
+    assert.ok(
+      output.some(
+        ({ chunk }) => chunk === 'Agent swarm item item-0 · child tool started: Search\n',
+      ),
+    );
+    assert.doesNotMatch(JSON.stringify(output), /retry-secret-query/);
+  });
+
+  test('bounds projected child progress across the whole concurrent batch', async () => {
+    const output: Array<{ stream: string; chunk: string }> = [];
+    const result = await buildAgentSwarmTool().impl(
+      {
+        items: Array.from({ length: AGENT_SWARM_MAX_CONCURRENCY }, (_, index) => swarmItem(index)),
+        max_concurrency: AGENT_SWARM_MAX_CONCURRENCY,
+      },
+      context({
+        emitOutput: (stream, chunk) => output.push({ stream, chunk }),
+        spawnChildSession: async (input) => {
+          for (let index = 0; index < 300; index += 1) {
+            input.onEvent?.(
+              childToolStart(
+                `${input.prompt}-tool-${index}`,
+                'Read',
+                `batch-secret-${input.prompt}-${index}`,
+              ),
+            );
+          }
+          return childResultForPrompt(input.prompt);
+        },
+      }),
+    );
+
+    const projected = output.filter(({ chunk }) => chunk.includes('· child tool started:'));
+    assert.equal(result.status, 'completed');
+    assert.equal(projected.length, 128);
+    assert.ok(projected.reduce((total, { chunk }) => total + chunk.length, 0) <= 16_384);
+    assert.doesNotMatch(JSON.stringify(output), /batch-secret/);
+  });
+
+  test('bounds projected child progress characters across the whole batch', async () => {
+    const output: Array<{ stream: string; chunk: string }> = [];
+    const result = await buildAgentSwarmTool().impl(
+      {
+        items: [swarmItem(0), swarmItem(1), swarmItem(2)],
+        max_concurrency: 3,
+      },
+      context({
+        emitOutput: (stream, chunk) => output.push({ stream, chunk }),
+        spawnChildSession: async (input) => {
+          input.onEvent?.(
+            childToolStart(
+              `${input.prompt}-oversized-tool`,
+              'R'.repeat(20_000),
+              `char-budget-secret-${input.prompt}`,
+            ),
+          );
+          return childResultForPrompt(input.prompt);
+        },
+      }),
+    );
+
+    const projected = output.filter(({ chunk }) => chunk.includes('· child tool started:'));
+    assert.equal(result.status, 'completed');
+    assert.equal(projected.length, 2);
+    assert.equal(
+      projected.reduce((total, { chunk }) => total + chunk.length, 0),
+      16_384,
+    );
+    assert.doesNotMatch(JSON.stringify(output), /char-budget-secret/);
+  });
+
   test('accepts resume-only input and enforces the shared total item bound', () => {
     const schema = buildAgentSwarmTool().parameters as {
       safeParse(input: unknown): { success: boolean; data?: AgentSwarmToolInput };
@@ -1212,6 +1383,54 @@ function childResult(
 function childResultForPrompt(prompt: string): SpawnChildAgentResult {
   const index = prompt === 'single' ? 99 : Number(prompt.slice('task-'.length));
   return childResult(index);
+}
+
+function childToolStart(
+  toolUseId: string,
+  toolName: string,
+  secret: string,
+): Extract<SessionEvent, { type: 'tool_start' }> {
+  return {
+    type: 'tool_start',
+    id: `start-${toolUseId}`,
+    turnId: 'child-turn',
+    ts: 1,
+    toolUseId,
+    toolName,
+    args: { secret },
+  };
+}
+
+function childToolResult(
+  toolUseId: string,
+  isError: boolean,
+  secret: string,
+): Extract<SessionEvent, { type: 'tool_result' }> {
+  return {
+    type: 'tool_result',
+    id: `result-${toolUseId}`,
+    turnId: 'child-turn',
+    ts: 2,
+    toolUseId,
+    isError,
+    content: { kind: 'text', text: secret },
+  };
+}
+
+function childProviderRetry(
+  phase: 'scheduled' | 'started',
+): Extract<SessionEvent, { type: 'provider_retry' }> {
+  return {
+    type: 'provider_retry',
+    id: `provider-retry-${phase}`,
+    turnId: 'child-turn',
+    ts: 3,
+    phase,
+    attempt: 2,
+    maxAttempts: 10,
+    reason: 'rate_limit',
+    ...(phase === 'scheduled' ? { delayMs: 250 } : {}),
+  } as Extract<SessionEvent, { type: 'provider_retry' }>;
 }
 
 function preparedResume(sourceRunId: string) {

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -20,6 +20,12 @@ import {
   type AdaptiveSwarmPolicy,
   type AdaptiveSwarmItemResult,
 } from './adaptive-swarm.js';
+import {
+  CHILD_AGENT_PROGRESS_BATCH_MAX_CHARS,
+  CHILD_AGENT_PROGRESS_BATCH_MAX_EVENTS,
+  ChildAgentProgressProjector,
+  createChildAgentProgressBudget,
+} from './child-agent-progress.js';
 import type { SpawnChildAgentResult } from './session-manager.js';
 import type { SubagentExecutionRef } from './subagent-execution.js';
 import type { MakaTool, MakaToolContext } from './tool-runtime.js';
@@ -167,6 +173,17 @@ export function buildAgentSwarmTool(
         length: prepared.items.length,
       });
       const artifactIds = prepared.items.map(() => new Set<string>());
+      const progressBudget = createChildAgentProgressBudget(
+        CHILD_AGENT_PROGRESS_BATCH_MAX_EVENTS,
+        CHILD_AGENT_PROGRESS_BATCH_MAX_CHARS,
+      );
+      const progressProjectors = prepared.items.map(
+        (item) =>
+          new ChildAgentProgressProjector(ctx, {
+            prefix: `Agent swarm item ${item.itemId} · child`,
+            sharedBudget: progressBudget,
+          }),
+      );
       const rows = await runAdaptiveSwarm<
         PreparedAgentSwarmItem,
         ChildExecutionResult,
@@ -213,6 +230,7 @@ export function buildAgentSwarmTool(
                     ...(retry.execution ? { execution: retry.execution } : {}),
                     abortSignal: deadline.signal,
                     onReady,
+                    onEvent: (event) => progressProjectors[index]!.observe(event),
                   })) as SpawnChildAgentResult)
                 : (() => {
                     throw new Error('retryChildAgent capability is unavailable');
@@ -223,6 +241,7 @@ export function buildAgentSwarmTool(
                     prompt: item.task,
                     abortSignal: deadline.signal,
                     onReady,
+                    onEvent: (event) => progressProjectors[index]!.observe(event),
                   })) as SpawnChildAgentResult)
                 : ((await ctx.spawnChildSession!({
                     agentProfile: item.definition.profile,
@@ -233,6 +252,7 @@ export function buildAgentSwarmTool(
                     },
                     abortSignal: deadline.signal,
                     onReady,
+                    onEvent: (event) => progressProjectors[index]!.observe(event),
                   })) as ChildExecutionResult);
             const effectiveResult: ChildExecutionResult = deadline.timedOut()
               ? timedOutChildResult(result, itemTimeoutMs)

--- a/packages/runtime/src/child-agent-progress.ts
+++ b/packages/runtime/src/child-agent-progress.ts
@@ -1,0 +1,98 @@
+import type { SessionEvent } from '@maka/core/events';
+import type { MakaToolContext } from './tool-runtime.js';
+
+export const CHILD_AGENT_PROGRESS_MAX_EVENTS = 64;
+export const CHILD_AGENT_PROGRESS_MAX_CHARS = 8_192;
+export const CHILD_AGENT_PROGRESS_BATCH_MAX_EVENTS = 128;
+export const CHILD_AGENT_PROGRESS_BATCH_MAX_CHARS = 16_384;
+
+export interface ChildAgentProgressBudget {
+  readonly maxEvents: number;
+  readonly maxChars: number;
+  projectedEvents: number;
+  projectedChars: number;
+}
+
+export interface ChildAgentProgressProjectorOptions {
+  prefix?: string;
+  sharedBudget?: ChildAgentProgressBudget;
+}
+
+export function createChildAgentProgressBudget(
+  maxEvents: number,
+  maxChars: number,
+): ChildAgentProgressBudget {
+  return {
+    maxEvents,
+    maxChars,
+    projectedEvents: 0,
+    projectedChars: 0,
+  };
+}
+
+export class ChildAgentProgressProjector {
+  private readonly tools = new Map<string, string>();
+  private readonly prefix: string;
+  private projectedEvents = 0;
+  private projectedChars = 0;
+
+  constructor(
+    private readonly ctx: Pick<MakaToolContext, 'emitOutput'>,
+    private readonly options: ChildAgentProgressProjectorOptions = {},
+  ) {
+    this.prefix = options.prefix ?? 'Child';
+  }
+
+  observe(event: SessionEvent): void {
+    if (event.type === 'tool_start') {
+      if (!this.hasCapacity()) return;
+      const name = event.displayName ?? event.toolName;
+      this.tools.set(event.toolUseId, name);
+      this.emit('stdout', `${this.prefix} tool started: ${name}\n`);
+      return;
+    }
+    if (event.type === 'tool_result') {
+      const name = this.tools.get(event.toolUseId) ?? 'tool';
+      this.tools.delete(event.toolUseId);
+      this.emit(
+        event.isError ? 'stderr' : 'stdout',
+        `${this.prefix} tool ${event.isError ? 'failed' : 'finished'}: ${name}\n`,
+      );
+      return;
+    }
+    if (event.type === 'provider_retry') {
+      const retry =
+        event.phase === 'scheduled'
+          ? `scheduled: attempt ${event.attempt}/${event.maxAttempts} in ${event.delayMs}ms`
+          : `started: attempt ${event.attempt}/${event.maxAttempts}`;
+      this.emit('stderr', `${this.prefix} provider retry ${retry} (${event.reason})\n`);
+    }
+  }
+
+  private emit(stream: 'stdout' | 'stderr', chunk: string): void {
+    if (!this.hasCapacity()) return;
+    const shared = this.options.sharedBudget;
+    const localRemaining = CHILD_AGENT_PROGRESS_MAX_CHARS - this.projectedChars;
+    const sharedRemaining = shared ? shared.maxChars - shared.projectedChars : localRemaining;
+    const remaining = Math.min(localRemaining, sharedRemaining);
+
+    const bounded = chunk.slice(0, remaining);
+    this.projectedEvents += 1;
+    this.projectedChars += bounded.length;
+    if (shared) {
+      shared.projectedEvents += 1;
+      shared.projectedChars += bounded.length;
+    }
+    this.ctx.emitOutput(stream, bounded);
+  }
+
+  private hasCapacity(): boolean {
+    const shared = this.options.sharedBudget;
+    return (
+      this.projectedEvents < CHILD_AGENT_PROGRESS_MAX_EVENTS &&
+      this.projectedChars < CHILD_AGENT_PROGRESS_MAX_CHARS &&
+      (!shared ||
+        (shared.projectedEvents < shared.maxEvents && shared.projectedChars < shared.maxChars))
+    );
+  }
+}

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -5,7 +5,6 @@ import {
   type TaskLedgerStore,
   type ToolResultContent,
 } from '@maka/core';
-import type { SessionEvent } from '@maka/core/events';
 import type { MakaTool, MakaToolContext } from './tool-runtime.js';
 import {
   AGENT_WORKSPACE_SAME_WORKSPACE,
@@ -19,6 +18,7 @@ import {
 } from './agent-catalog.js';
 import { AGENT_TEAM_CHILD_TOOL_NAMES } from './agent-team-tool-names.js';
 import { AGENT_SWARM_TOOL_NAME, buildAgentSwarmTool } from './agent-swarm-tools.js';
+import { ChildAgentProgressProjector } from './child-agent-progress.js';
 
 export const AGENT_SPAWN_TOOL_NAME = 'agent_spawn';
 export const AGENT_LIST_TOOL_NAME = 'agent_list';
@@ -43,8 +43,6 @@ const AGENT_SPAWN_ISOLATION_MODES = [
   AGENT_WORKSPACE_SAME_WORKSPACE,
   AGENT_WORKSPACE_WORKTREE,
 ] as const;
-const CHILD_PROGRESS_MAX_EVENTS = 64;
-const CHILD_PROGRESS_MAX_CHARS = 8_192;
 const CHILD_PROGRESS_ERROR_MAX_CHARS = 1_000;
 
 type SubagentToolResult = Extract<ToolResultContent, { kind: 'subagent' }>;
@@ -267,41 +265,6 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
       } satisfies SubagentToolResult;
     },
   };
-}
-
-class ChildAgentProgressProjector {
-  private readonly tools = new Map<string, string>();
-  private projectedEvents = 0;
-  private projectedChars = 0;
-
-  constructor(private readonly ctx: Pick<MakaToolContext, 'emitOutput'>) {}
-
-  observe(event: SessionEvent): void {
-    if (this.projectedEvents >= CHILD_PROGRESS_MAX_EVENTS) return;
-    if (event.type === 'tool_start') {
-      const name = event.displayName ?? event.toolName;
-      this.tools.set(event.toolUseId, name);
-      this.emit('stdout', `Child tool started: ${name}\n`);
-      return;
-    }
-    if (event.type === 'tool_result') {
-      const name = this.tools.get(event.toolUseId) ?? 'tool';
-      this.tools.delete(event.toolUseId);
-      this.emit(
-        event.isError ? 'stderr' : 'stdout',
-        `Child tool ${event.isError ? 'failed' : 'finished'}: ${name}\n`,
-      );
-    }
-  }
-
-  private emit(stream: 'stdout' | 'stderr', chunk: string): void {
-    const remaining = CHILD_PROGRESS_MAX_CHARS - this.projectedChars;
-    if (remaining <= 0) return;
-    const bounded = chunk.slice(0, remaining);
-    this.projectedEvents += 1;
-    this.projectedChars += bounded.length;
-    this.ctx.emitOutput(stream, bounded);
-  }
 }
 
 function boundedChildError(error: unknown): string {


### PR DESCRIPTION
## Summary

- project child tool lifecycle events into each `agent_swarm` item
- surface bounded provider retry scheduling and start events while slow children are running
- reuse the same projector for `agent_spawn` and cap progress per item and across the batch
- keep tool arguments, result bodies, and model text out of parent-facing progress

## Root cause

`agent_spawn` supplied an `onEvent` observer to child execution, but the spawn, resume, and adaptive retry paths in `agent_swarm` supplied only `onReady`. Child work and provider retries remained active in the child ledger while the parent exposed no intermediate activity.

## Impact

Long-running Swarm items now show item-scoped progress instead of appearing hung. Progress remains presentation-only and bounded to 64 events/8,192 characters per item and 128 events/16,384 characters per batch.

## Validation

- `node --test packages/runtime/dist/__tests__/agent-swarm-tools.test.js packages/runtime/dist/__tests__/subagent-tools.test.js` (51 passed)
- `npm run typecheck`
- `npm run lint`
- `npm run build`
- Full `npm test` reached one unrelated existing macOS executable-root assertion in `builtin-tools.test.ts`; all new and targeted tests passed.

Closes #1559
