### PR TITLE
feat(runtime): isolate implementation operators in Git worktrees

### DIFF
--- a/apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/graph-mode-host-contract.test.ts
@@ -54,4 +54,13 @@ describe('Desktop Graph Mode host contract', () => {
     assert.match(panel, /可见 \$\{settled\}\/\$\{total\} 已结束/);
     assert.match(panel, /\$\{settled\}\/\$\{total\} visible settled/);
   });
+
+  it('provides a host-owned Git worktree executor to linked child Sessions', async () => {
+    const main = await readFile(
+      fileURLToPath(new URL('../../../src/main/main.ts', import.meta.url)),
+      'utf8',
+    );
+    assert.match(main, /createGitWorktreeChildExecutor\(\{ storageRoot: workspaceRoot \}\)/);
+    assert.match(main, /new SessionManager\(\{[\s\S]*worktreeChildExecutor,/);
+  });
 });

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -64,6 +64,7 @@ import {
   createDeepResearchStore,
   createReadImageSnapshotter,
   createConnectionStore,
+  createGitWorktreeChildExecutor,
   createPlanReminderStore,
   createPlanStore,
   createProjectCatalog,
@@ -266,6 +267,7 @@ const keepSystemAwake = createKeepSystemAwakeController(powerSaveBlocker);
 const store = createSessionStore(workspaceRoot);
 const agentGraphControlStore = createAgentGraphControlStore(workspaceRoot);
 const projectCatalog = createProjectCatalog(workspaceRoot);
+const worktreeChildExecutor = createGitWorktreeChildExecutor({ storageRoot: workspaceRoot });
 const planStore = createPlanStore(workspaceRoot);
 const runStore = createAgentRunStore(workspaceRoot);
 const runtimePersistence = await openRuntimeEventPersistence({
@@ -848,6 +850,7 @@ const runtime = new SessionManager({
   shellRuns,
   backends,
   childTools: childAgentTools,
+  worktreeChildExecutor,
   safeBoundaryResumeEnabled: process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME === '1',
   onContinuationLifecycleEvent: (event) => {
     console.info('[runtime-resume]', JSON.stringify(event));

--- a/apps/desktop/src/main/tool-assembly.ts
+++ b/apps/desktop/src/main/tool-assembly.ts
@@ -279,8 +279,8 @@ export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
     economy: economyEnabled,
     groups: buildDeferredToolGroupsFromCatalog('desktop', desktopBoundToolNames),
   };
-  // Child agents stay file-only for local reads; parent runtime refs such as
-  // maka://runtime/background-tasks/<id> are not part of their tool surface.
+  // Build the union needed by catalog child profiles. SessionManager applies
+  // each profile's narrower allowlist; parent-facing runtime refs are omitted.
   const childAgentTools = buildChildAgentTools([
     ...buildDesktopBuiltinTools({
       archiveResources: { readArchivedToolResultResource },

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -416,9 +416,8 @@ describe('Maka CLI runtime bootstrap', () => {
           }>;
         };
         assert.deepEqual(
-          childAgents.definitions.find(
-            (definition) => definition.id === IMPLEMENTATION_AGENT_ID,
-          )?.availability,
+          childAgents.definitions.find((definition) => definition.id === IMPLEMENTATION_AGENT_ID)
+            ?.availability,
           {
             status: 'unavailable',
             reason: 'workspace_isolation_unavailable',

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -22,6 +22,7 @@ import {
   GOAL_RESUME_TOOL_NAME,
   GOAL_SET_TOOL_NAME,
   GOAL_STATUS_TOOL_NAME,
+  IMPLEMENTATION_AGENT_ID,
   type AiSdkBackendInput,
   type MakaTool,
   type SessionStore,
@@ -344,7 +345,7 @@ describe('Maka CLI runtime bootstrap', () => {
     });
   });
 
-  test('wires TUI subagent capabilities and a child-safe tool surface', async () => {
+  test('wires TUI subagent capabilities and a profile-filtered child tool surface', async () => {
     await withWorkspace(async (workspaceRoot) => {
       const connectionStore = createConnectionStore(workspaceRoot);
       await connectionStore.create({
@@ -400,15 +401,30 @@ describe('Maka CLI runtime bootstrap', () => {
         });
         assert.deepEqual(
           runtimeDeps.childTools?.map((tool) => tool.name),
-          ['Read', 'Glob', 'Grep'],
+          ['Read', 'Glob', 'Grep', 'Write', 'Edit', 'Bash'],
         );
         assert.equal(
           runtimeDeps.childTools?.some((tool) =>
-            ['Bash', 'Write', 'Edit', AGENT_SPAWN_TOOL_NAME, AGENT_SWARM_TOOL_NAME].includes(
-              tool.name,
-            ),
+            [AGENT_SPAWN_TOOL_NAME, AGENT_SWARM_TOOL_NAME].includes(tool.name),
           ),
           false,
+        );
+        const childAgents = (await backendInput.listChildAgents?.()) as {
+          definitions: Array<{
+            id: string;
+            availability: { status: string; reason?: string };
+          }>;
+        };
+        assert.deepEqual(
+          childAgents.definitions.find(
+            (definition) => definition.id === IMPLEMENTATION_AGENT_ID,
+          )?.availability,
+          {
+            status: 'unavailable',
+            reason: 'workspace_isolation_unavailable',
+            workspace: 'worktree',
+            requiredRuntime: 'worktree_child_executor',
+          },
         );
         assert.equal(context.skills.host.toolNames.has(AGENT_SPAWN_TOOL_NAME), true);
         assert.equal(context.skills.host.toolNames.has(AGENT_SWARM_TOOL_NAME), true);

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -283,9 +283,11 @@ export async function createMakaCliRuntimeContext(
         }
       : {}),
   });
-  // Child sessions get fresh file-only tools. In particular, their Read tool
-  // cannot inspect parent runtime resources and no write/shell/agent tool is
-  // present for the catalog allowlist to select.
+  // Child sessions get fresh catalog tools. Their Read tool cannot inspect
+  // parent runtime resources, and the SessionManager narrows this union to the
+  // selected profile after checking host capabilities (for example, a
+  // worktree executor for implementation children). Agent tools are excluded
+  // so children cannot recursively spawn from this surface.
   const childAgentTools =
     input.surface === 'tui'
       ? buildChildAgentTools(

--- a/packages/core/src/__tests__/subagent-workspace.test.ts
+++ b/packages/core/src/__tests__/subagent-workspace.test.ts
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  SUBAGENT_WORKSPACE_BINDING_SCHEMA_VERSION,
+  isSubagentWorkspaceBinding,
+  type SubagentWorkspaceBinding,
+} from '../subagent-workspace.js';
+
+describe('subagent workspace binding', () => {
+  test('accepts the strict durable Git worktree shape', () => {
+    assert.equal(isSubagentWorkspaceBinding(binding()), true);
+  });
+
+  test('rejects unknown fields, unsafe leases, and malformed commits', () => {
+    assert.equal(isSubagentWorkspaceBinding({ ...binding(), extra: true }), false);
+    assert.equal(isSubagentWorkspaceBinding({ ...binding(), leaseId: '../shared' }), false);
+    assert.equal(isSubagentWorkspaceBinding({ ...binding(), baseCommit: 'HEAD' }), false);
+  });
+});
+
+function binding(): SubagentWorkspaceBinding {
+  return {
+    schemaVersion: SUBAGENT_WORKSPACE_BINDING_SCHEMA_VERSION,
+    kind: 'git_worktree',
+    leaseId: `subagent_worktree_${'a'.repeat(32)}`,
+    gitCommonDir: '/workspace/repository/.git',
+    worktreePath: '/workspace/state/subagent-worktrees/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    branch: 'maka/subagent/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+    baseCommit: 'b'.repeat(40),
+  };
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export * from './agent-graph-timeline.js';
 export * from './runtime-policy.js';
 export * from './interaction.js';
 export * from './project.js';
+export * from './subagent-workspace.js';
 
 // events.ts
 export type {

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -16,6 +16,7 @@ import type { ThinkingLevel } from './model-thinking.js';
 import type { CollaborationMode } from './collaboration.js';
 import type { OrchestrationMode, TurnOrchestration } from './orchestration.js';
 import type { SessionStartMode } from './explore-agent.js';
+import type { SubagentWorkspaceBinding } from './subagent-workspace.js';
 
 export type { TurnOrchestration } from './orchestration.js';
 
@@ -47,6 +48,7 @@ export interface CreateSessionInput {
   subagentParent?: SubagentSessionParent;
   subagentRuntime?: SubagentSessionRuntime;
   subagentSpawn?: SubagentSessionSpawn;
+  subagentWorkspace?: SubagentWorkspaceBinding;
   revisionRootSessionId?: string;
   revisionParentSessionId?: string;
   revisionOfTurnId?: string;

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -41,6 +41,7 @@ import {
   decodePersistedToolResultContentForRecovery,
   normalizeToolResultContentForRead,
 } from './tool-result-record-schema.js';
+import type { SubagentWorkspaceBinding } from './subagent-workspace.js';
 
 export { isDeepResearchSession } from './explore-agent.js';
 export { isExpertTeamSession } from './expert-team.js';
@@ -196,6 +197,8 @@ export interface SessionHeader {
   subagentRuntime?: SubagentSessionRuntime;
   /** Immutable idempotency and initial-run identity for child creation. */
   subagentSpawn?: SubagentSessionSpawn;
+  /** Immutable host-managed filesystem isolation for this child Session. */
+  subagentWorkspace?: SubagentWorkspaceBinding;
   /** Stable root id for an edit-and-resend version family. */
   revisionRootSessionId?: string;
   /** Immediate previous version in the same conversation slot. */
@@ -250,6 +253,7 @@ export interface SessionSummary {
   branchOfTurnId?: string;
   subagentParent?: SubagentSessionParent;
   subagentRuntime?: SubagentSessionRuntimeSummary;
+  subagentWorkspace?: SubagentWorkspaceBinding;
   revisionRootSessionId?: string;
   revisionParentSessionId?: string;
   revisionOfTurnId?: string;

--- a/packages/core/src/subagent-workspace.ts
+++ b/packages/core/src/subagent-workspace.ts
@@ -1,0 +1,74 @@
+export const SUBAGENT_WORKSPACE_BINDING_SCHEMA_VERSION = 1 as const;
+
+const SUBAGENT_WORKTREE_LEASE_PATTERN = /^subagent_worktree_[a-f0-9]{32}$/;
+const GIT_COMMIT_PATTERN = /^[a-f0-9]{40}(?:[a-f0-9]{24})?$/;
+const MAX_PATH_CHARS = 16_384;
+const MAX_BRANCH_CHARS = 1_024;
+const CONTROL_CHARACTERS = /[\u0000-\u001f\u007f]/;
+
+/**
+ * Immutable workspace ownership attached to a linked child Session.
+ *
+ * The Session remains the runtime identity. This binding records the
+ * host-managed filesystem lease that gives the child an isolated Git worktree
+ * without teaching the graph scheduler about Git.
+ */
+export interface SubagentWorkspaceBinding {
+  schemaVersion: typeof SUBAGENT_WORKSPACE_BINDING_SCHEMA_VERSION;
+  kind: 'git_worktree';
+  leaseId: string;
+  gitCommonDir: string;
+  worktreePath: string;
+  branch: string;
+  baseCommit: string;
+}
+
+export interface ProvisionSubagentWorktreeInput {
+  leaseId: string;
+  sourceSessionId: string;
+  sourceCwd: string;
+  sourceProjectId?: string | null;
+}
+
+export interface SubagentWorktreeExecutor {
+  provision(input: ProvisionSubagentWorktreeInput): Promise<SubagentWorkspaceBinding>;
+  ensure(binding: SubagentWorkspaceBinding): Promise<void>;
+}
+
+export function isSubagentWorkspaceBinding(value: unknown): value is SubagentWorkspaceBinding {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
+  const binding = value as Record<string, unknown>;
+  const keys = Object.keys(binding).sort();
+  const expected = [
+    'baseCommit',
+    'branch',
+    'gitCommonDir',
+    'kind',
+    'leaseId',
+    'schemaVersion',
+    'worktreePath',
+  ].sort();
+  return (
+    keys.length === expected.length &&
+    keys.every((key, index) => key === expected[index]) &&
+    binding.schemaVersion === SUBAGENT_WORKSPACE_BINDING_SCHEMA_VERSION &&
+    binding.kind === 'git_worktree' &&
+    typeof binding.leaseId === 'string' &&
+    SUBAGENT_WORKTREE_LEASE_PATTERN.test(binding.leaseId) &&
+    isBoundedText(binding.gitCommonDir, MAX_PATH_CHARS) &&
+    isBoundedText(binding.worktreePath, MAX_PATH_CHARS) &&
+    isBoundedText(binding.branch, MAX_BRANCH_CHARS) &&
+    !binding.branch.startsWith('-') &&
+    typeof binding.baseCommit === 'string' &&
+    GIT_COMMIT_PATTERN.test(binding.baseCommit)
+  );
+}
+
+function isBoundedText(value: unknown, maxChars: number): value is string {
+  return (
+    typeof value === 'string' &&
+    value.length > 0 &&
+    value.length <= maxChars &&
+    !CONTROL_CHARACTERS.test(value)
+  );
+}

--- a/packages/headless/src/__tests__/tools.test.ts
+++ b/packages/headless/src/__tests__/tools.test.ts
@@ -261,10 +261,7 @@ describe('isolated headless tools', () => {
     assert.equal(names.filter((name) => name === 'Bash').length, 1);
     assert.deepEqual(
       buildChildAgentTools(tools).map((tool) => tool.name),
-      ['Read', 'Glob', 'Grep'],
-    );
-    assert.ok(
-      !buildChildAgentTools(tools).some((tool) => ['Bash', 'Write', 'Edit'].includes(tool.name)),
+      ['Read', 'Glob', 'Grep', 'Write', 'Edit', 'Bash'],
     );
   });
 
@@ -1772,7 +1769,7 @@ describe('isolated headless tools', () => {
     assert.ok(loaded.includes('agent_output'));
   });
 
-  test('standard isolated tool availability does not reintroduce agent tools into local-read children', () => {
+  test('standard isolated child tool availability omits parent-facing agent tools', () => {
     const parentTools = buildIsolatedHeadlessTools(
       {
         async exec() {
@@ -1793,7 +1790,14 @@ describe('isolated headless tools', () => {
       },
     ).prepare([]);
 
-    assert.deepEqual([...plan.activeTools].sort(), ['Glob', 'Grep', 'Read']);
+    assert.deepEqual([...plan.activeTools].sort(), [
+      'Bash',
+      'Edit',
+      'Glob',
+      'Grep',
+      'Read',
+      'Write',
+    ]);
     assert.equal(plan.projectActiveTools, undefined);
     assert.ok(!plan.activeTools.includes(LOAD_TOOLS_NAME));
     assert.ok(!plan.activeTools.includes('agent_spawn'));

--- a/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
+++ b/packages/runtime/src/__tests__/agent-swarm-tools.test.ts
@@ -112,36 +112,35 @@ describe('AgentSwarm adapter', () => {
     );
   });
 
-  test('preflights the complete batch before starting any child', async () => {
+  test('delegates worktree availability checks to the child runtime', async () => {
     const tool = buildAgentSwarmTool();
     let starts = 0;
 
-    await assert.rejects(
-      Promise.resolve(
-        tool.impl(
+    const result = (await tool.impl(
+      {
+        items: [
+          swarmItem(0),
           {
-            items: [
-              swarmItem(0),
-              {
-                item_id: 'implementation',
-                profile: IMPLEMENTATION_AGENT_PROFILE,
-                task: 'Edit the repository.',
-                write_back: AGENT_WRITE_BACK_PATCH,
-                isolation: AGENT_WORKSPACE_WORKTREE,
-              },
-            ],
+            item_id: 'implementation',
+            profile: IMPLEMENTATION_AGENT_PROFILE,
+            task: 'Edit the repository.',
+            write_back: AGENT_WRITE_BACK_PATCH,
+            isolation: AGENT_WORKSPACE_WORKTREE,
           },
-          context({
-            spawnChildSession: async () => {
-              starts += 1;
-              return childResult(0);
-            },
-          }),
-        ),
-      ),
-      /worktree child executor/,
+        ],
+      },
+      context({
+        spawnChildSession: async () => {
+          starts += 1;
+          return childResult(starts);
+        },
+      }),
+    )) as AgentSwarmToolResult;
+    assert.equal(starts, 2);
+    assert.deepEqual(
+      result.items.map((item) => item.status),
+      ['completed', 'completed'],
     );
-    assert.equal(starts, 0);
   });
 
   test('accepts prompt_template with string items and rejects ambiguous template input', () => {

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -200,6 +200,81 @@ describe('SessionManager graph operator provisioning', () => {
     expect(result.provision.initialRunId).toBe(result.header.subagentSpawn?.initialRunId);
     expect(await runStore.listSessionRuns(result.header.id)).toEqual([]);
   });
+
+  test('binds implementation operators to a durable project worktree', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const provisioned: unknown[] = [];
+    const binding = {
+      schemaVersion: 1 as const,
+      kind: 'git_worktree' as const,
+      leaseId: `subagent_worktree_${'a'.repeat(32)}`,
+      gitCommonDir: '/tmp/project/.git',
+      worktreePath: '/tmp/worktrees/implementation-a',
+      branch: `maka/subagent/${'a'.repeat(32)}`,
+      baseCommit: 'b'.repeat(40),
+    };
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends: new BackendRegistry(),
+      childTools: ['Read', 'Glob', 'Grep', 'Write', 'Edit', 'Bash'].map(testTool),
+      worktreeChildExecutor: {
+        provision: async (input) => {
+          provisioned.push(input);
+          return {
+            ...binding,
+            leaseId: input.leaseId,
+            worktreePath: `/tmp/worktrees/${input.leaseId}`,
+            branch: `maka/subagent/${input.leaseId.slice('subagent_worktree_'.length)}`,
+          };
+        },
+        ensure: async () => {},
+      },
+      newId: nextId(),
+      now: nextNow(40),
+    });
+    const parent = await manager.createSession(
+      makeInput({
+        cwd: '/tmp/project',
+        projectId: 'project-1',
+        permissionMode: 'execute',
+      }),
+    );
+    await runStore.createRun(
+      makeRunHeader({
+        sessionId: parent.id,
+        runId: 'supervisor-run',
+        turnId: 'supervisor-turn',
+        cwd: '/tmp/project',
+      }),
+    );
+
+    const result = await manager.provisionAgentGraphOperator({
+      graphId: 'graph-worktree',
+      workId: `graph_work_${'4'.repeat(32)}`,
+      agentId: IMPLEMENTATION_AGENT_ID,
+      operatorId: `graph_operator_${'5'.repeat(32)}`,
+      source: {
+        sessionId: parent.id,
+        runId: 'supervisor-run',
+        turnId: 'supervisor-turn',
+        toolCallId: 'schedule-tool',
+      },
+      edges: [],
+      expectedScheduleRevision: 1,
+    });
+
+    expect(provisioned).toHaveLength(1);
+    expect(result.header.projectId).toBe('project-1');
+    expect(result.header.cwd).toBe(result.header.subagentWorkspace?.worktreePath);
+    expect(result.header.subagentWorkspace?.kind).toBe('git_worktree');
+    expect(result.header.subagentWorkspace?.branch).toMatch(/^maka\/subagent\//);
+    expect(headerToSummary(result.header).subagentWorkspace).toEqual(
+      result.header.subagentWorkspace,
+    );
+  });
 });
 
 describe('SessionManager claimed graph intent execution', () => {
@@ -18039,6 +18114,7 @@ class MemorySessionStore implements SessionStore {
       ...(input.subagentParent ? { subagentParent: input.subagentParent } : {}),
       ...(input.subagentRuntime ? { subagentRuntime: input.subagentRuntime } : {}),
       ...(input.subagentSpawn ? { subagentSpawn: input.subagentSpawn } : {}),
+      ...(input.subagentWorkspace ? { subagentWorkspace: input.subagentWorkspace } : {}),
       ...(input.revisionRootSessionId
         ? { revisionRootSessionId: input.revisionRootSessionId }
         : {}),

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -217,7 +217,7 @@ describe('subagent tools', () => {
     });
   });
 
-  test('built-in catalog exposes implementation as a worktree-only fail-closed contract', async () => {
+  test('built-in catalog exposes implementation only when a worktree executor is available', async () => {
     expect(IMPLEMENTATION_AGENT_DEFINITION.id).toBe(IMPLEMENTATION_AGENT_ID);
     expect(IMPLEMENTATION_AGENT_DEFINITION.profile).toBe(IMPLEMENTATION_AGENT_PROFILE);
     expect(IMPLEMENTATION_AGENT_DEFINITION.contract).toEqual({
@@ -275,6 +275,33 @@ describe('subagent tools', () => {
       ),
       /worktree child executor/,
     );
+
+    const runnableAvailability = listBuiltinAgentDefinitions({
+      parentPermissionMode: 'execute',
+      worktreeChildExecutorAvailable: true,
+      tools: [
+        testCatalogTool('Read', 'read'),
+        testCatalogTool('Glob', 'read'),
+        testCatalogTool('Grep', 'read'),
+        testCatalogTool('Write', 'file_write'),
+        testCatalogTool('Edit', 'file_write'),
+        testCatalogTool('Bash', 'shell_unsafe'),
+      ],
+    }).find((definition) => definition.id === IMPLEMENTATION_AGENT_ID)?.availability;
+    expect(runnableAvailability).toEqual({ status: 'available' });
+    assertAgentDefinitionRunnable({
+      parentPermissionMode: 'execute',
+      worktreeChildExecutorAvailable: true,
+      definition: IMPLEMENTATION_AGENT_DEFINITION,
+      tools: [
+        testCatalogTool('Read', 'read'),
+        testCatalogTool('Glob', 'read'),
+        testCatalogTool('Grep', 'read'),
+        testCatalogTool('Write', 'file_write'),
+        testCatalogTool('Edit', 'file_write'),
+        testCatalogTool('Bash', 'shell_unsafe'),
+      ],
+    });
   });
 
   test('agent definition availability reports missing tools and parent permission mismatches without running', () => {
@@ -394,11 +421,24 @@ describe('subagent tools', () => {
       },
     ]);
 
-    expect(tools.map((tool) => tool.name)).toEqual(['Read', 'Glob', 'Grep', 'WebSearch']);
-    expect([...CHILD_AGENT_TOOL_NAMES]).toEqual(['Read', 'Glob', 'Grep', 'WebSearch']);
-    expect(tools.some((tool) => tool.name === 'Bash')).toBe(false);
-    expect(tools.some((tool) => tool.name === 'Write')).toBe(false);
-    expect(tools.some((tool) => tool.name === 'Edit')).toBe(false);
+    expect(tools.map((tool) => tool.name)).toEqual([
+      'Read',
+      'Glob',
+      'Grep',
+      'WebSearch',
+      'Write',
+      'Edit',
+      'Bash',
+    ]);
+    expect([...CHILD_AGENT_TOOL_NAMES]).toEqual([
+      'Read',
+      'Glob',
+      'Grep',
+      'WebSearch',
+      'Write',
+      'Edit',
+      'Bash',
+    ]);
   });
 
   test('keeps host-provided ArchiveRead available for child recovery', () => {
@@ -429,7 +469,7 @@ describe('subagent tools', () => {
       await runTool(runtime, tools, 'Grep', { pattern: 'SUBAGENT_CHILD_TOOL_MARKER' }, events);
 
       expect(events.some((event) => event.type === 'permission_request')).toBe(false);
-      expect(tools.has('Bash')).toBe(false);
+      expect(tools.has('Bash')).toBe(true);
     } finally {
       await rm(cwd, { recursive: true, force: true });
     }
@@ -961,7 +1001,7 @@ describe('subagent tools', () => {
     expect(spawned).toBe(false);
   });
 
-  test('agent_spawn validates profile contracts and rejects unavailable worktree agents before spawning', async () => {
+  test('agent_spawn validates profile contracts and delegates worktree availability to runtime', async () => {
     const tool = buildSubagentSpawnTool();
     const schema = tool.parameters as {
       safeParse(input: unknown): { success: boolean; data?: unknown };
@@ -1050,30 +1090,42 @@ describe('subagent tools', () => {
         .success,
     ).toBe(false);
 
-    await expectRejects(
-      Promise.resolve(
-        tool.impl(
-          {
-            profile: IMPLEMENTATION_AGENT_PROFILE,
-            task: 'Edit files.',
-            write_back: AGENT_WRITE_BACK_PATCH,
-            isolation: AGENT_WORKSPACE_WORKTREE,
-          },
-          {
-            sessionId: 'session-1',
-            turnId: 'parent-turn',
-            cwd: '/tmp/cwd',
-            toolCallId: 'tool-1',
-            abortSignal: new AbortController().signal,
-            emitOutput: () => {},
-            spawnChildSession: async () => {
-              throw new Error('spawn should not be called');
-            },
-          },
-        ),
-      ),
-      /worktree child executor/,
+    const calls: unknown[] = [];
+    await tool.impl(
+      {
+        profile: IMPLEMENTATION_AGENT_PROFILE,
+        task: 'Edit files.',
+        write_back: AGENT_WRITE_BACK_PATCH,
+        isolation: AGENT_WORKSPACE_WORKTREE,
+      },
+      {
+        sessionId: 'session-1',
+        turnId: 'parent-turn',
+        cwd: '/tmp/cwd',
+        toolCallId: 'tool-1',
+        abortSignal: new AbortController().signal,
+        emitOutput: () => {},
+        spawnChildSession: async (input) => {
+          calls.push(input);
+          return {
+            childSessionId: 'child-session',
+            agentId: IMPLEMENTATION_AGENT_ID,
+            agentName: 'Implementation',
+            turnId: 'child-turn',
+            runId: 'child-run',
+            status: 'completed',
+            permissionMode: 'execute',
+            summary: 'done',
+            artifactIds: [],
+          };
+        },
+      },
     );
+    expect(calls).toHaveLength(1);
+    expect(calls[0]).toMatchObject({
+      agentProfile: IMPLEMENTATION_AGENT_PROFILE,
+      prompt: 'Edit files.',
+    });
   });
 
   test('agent projection tools delegate through read-only context capabilities', async () => {

--- a/packages/runtime/src/agent-catalog.ts
+++ b/packages/runtime/src/agent-catalog.ts
@@ -102,6 +102,7 @@ export interface AgentDefinitionListItem {
 export interface AgentDefinitionListOptions {
   parentPermissionMode?: PermissionMode;
   tools?: readonly MakaTool[];
+  worktreeChildExecutorAvailable?: boolean;
 }
 
 export const LOCAL_READ_AGENT_DEFINITION: AgentDefinition = {
@@ -217,6 +218,7 @@ export function listBuiltinAgentDefinitions(
             parentPermissionMode: options.parentPermissionMode,
             definition,
             tools: options.tools,
+            worktreeChildExecutorAvailable: options.worktreeChildExecutorAvailable,
           })
         : { status: 'unknown' },
     permissionMode: definition.permissionMode,
@@ -266,9 +268,13 @@ export function evaluateAgentDefinitionAvailability(input: {
   parentPermissionMode: PermissionMode;
   definition: AgentDefinition;
   tools: readonly MakaTool[];
+  worktreeChildExecutorAvailable?: boolean;
 }): AgentDefinitionAvailability {
   const { parentPermissionMode, definition, tools } = input;
-  if (definition.contract.workspace === AGENT_WORKSPACE_WORKTREE) {
+  if (
+    definition.contract.workspace === AGENT_WORKSPACE_WORKTREE &&
+    !input.worktreeChildExecutorAvailable
+  ) {
     return {
       status: 'unavailable',
       reason: 'workspace_isolation_unavailable',
@@ -328,12 +334,14 @@ export function assertAgentDefinitionRunnable(input: {
   parentPermissionMode: PermissionMode;
   definition: AgentDefinition;
   tools: readonly MakaTool[];
+  worktreeChildExecutorAvailable?: boolean;
 }): void {
   const { parentPermissionMode, definition, tools } = input;
   const availability = evaluateAgentDefinitionAvailability({
     parentPermissionMode,
     definition,
     tools,
+    worktreeChildExecutorAvailable: input.worktreeChildExecutorAvailable,
   });
   if (availability.status !== 'unavailable') return;
 

--- a/packages/runtime/src/agent-swarm-tools.ts
+++ b/packages/runtime/src/agent-swarm-tools.ts
@@ -730,12 +730,6 @@ function preflightAgentSwarmInput(input: AgentSwarmToolInput): {
         `Agent profile "${definition.profile}" requires isolation "${definition.contract.workspace}", not "${isolation}".`,
       );
     }
-    if (isolation !== AGENT_WORKSPACE_SAME_WORKSPACE) {
-      throw new Error(
-        `Agent profile "${definition.profile}" requires "${isolation}" workspace isolation, but this runtime does not provide a worktree child executor yet.`,
-      );
-    }
-
     return {
       index: resumes.length + index,
       itemId: item.item_id,

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -85,6 +85,8 @@ import type {
   RuntimeEvent,
   RuntimeEventStore,
   ToolBoundaryProtocol,
+  SubagentWorkspaceBinding,
+  SubagentWorktreeExecutor,
 } from '@maka/core';
 import { AGENT_GRAPH_OPERATOR_PROVISION_SCHEMA_VERSION } from '@maka/core';
 import { type RuntimeEventTerminalFact } from './runtime-event-read-model.js';
@@ -149,6 +151,7 @@ import {
   getBuiltinAgentDefinition,
   listBuiltinAgentDefinitions,
   requireBuiltinAgentDefinitionByProfile,
+  AGENT_WORKSPACE_WORKTREE,
   type AgentProfile,
   type AgentDefinition,
   type AgentDefinitionListItem,
@@ -530,6 +533,8 @@ interface SessionManagerBaseDeps {
   newId: () => string;
   now: () => number;
   childTools?: readonly MakaTool[];
+  /** Host-owned filesystem isolation for worktree-backed child Sessions. */
+  worktreeChildExecutor?: SubagentWorktreeExecutor;
   listArtifactsForTurn?: (sessionId: string, turnId: string) => Promise<ArtifactRecord[]>;
   runtimeSource?: InvocationSource;
   runtimeInvocationObserver?: (result: InvocationResult) => void | Promise<void>;
@@ -647,6 +652,47 @@ export class SessionManager {
   async listChildSessions(parentSessionId: string): Promise<SessionSummary[]> {
     const sessions = await this.deps.store.list({ subagentParentSessionId: parentSessionId });
     return childSessionsForParent(sessions, parentSessionId);
+  }
+
+  private async provisionChildWorkspace(
+    parent: SessionHeader,
+    definition: AgentDefinition,
+    requestFingerprint: string,
+  ): Promise<SubagentWorkspaceBinding | undefined> {
+    if (definition.contract.workspace !== AGENT_WORKSPACE_WORKTREE) return undefined;
+    const executor = this.deps.worktreeChildExecutor;
+    if (!executor) {
+      throw new Error(
+        `Agent "${definition.id}" is unavailable: "worktree" workspace isolation requires a worktree child executor.`,
+      );
+    }
+    const fingerprint = requestFingerprint.startsWith('sha256:')
+      ? requestFingerprint.slice('sha256:'.length)
+      : requestFingerprint;
+    if (!/^[a-f0-9]{64}$/.test(fingerprint)) {
+      throw new Error('Child workspace request fingerprint must be SHA-256');
+    }
+    return executor.provision({
+      leaseId: `subagent_worktree_${fingerprint.slice(0, 32)}`,
+      sourceSessionId: parent.id,
+      sourceCwd: parent.cwd,
+      ...(parent.projectId !== undefined ? { sourceProjectId: parent.projectId } : {}),
+    });
+  }
+
+  private async ensureChildWorkspace(header: SessionHeader): Promise<void> {
+    const binding = header.subagentWorkspace;
+    if (!binding) return;
+    const executor = this.deps.worktreeChildExecutor;
+    if (!executor) {
+      throw new Error(
+        `Child Session ${header.id} requires a worktree child executor for ${binding.worktreePath}`,
+      );
+    }
+    if (header.cwd !== binding.worktreePath) {
+      throw new Error(`Child Session ${header.id} workspace binding disagrees with its cwd`);
+    }
+    await executor.ensure(binding);
   }
 
   /** Invalidate backend snapshots now, or immediately after active turns settle. */
@@ -1416,6 +1462,7 @@ export class SessionManager {
   ): AsyncIterable<SessionEvent> {
     const execution = this.runtimeKernel.claimExecution(sessionId);
     try {
+      await this.ensureChildWorkspace(await this.deps.store.readHeader(sessionId));
       yield* this.runtimeKernel.startChildTurn(sessionId, input, execution);
     } finally {
       execution.release();
@@ -1511,6 +1558,7 @@ export class SessionManager {
       parentPermissionMode: parentHeader.permissionMode,
       definition,
       tools: this.deps.childTools ?? [],
+      worktreeChildExecutorAvailable: this.deps.worktreeChildExecutor !== undefined,
     });
 
     const initialTurnId = this.deps.newId();
@@ -1532,6 +1580,7 @@ export class SessionManager {
         definitionVersion: definition.definitionVersion,
         agentId: definition.id,
         profile: definition.profile,
+        workspace: definition.contract.workspace,
         permissionMode: definition.permissionMode,
         toolNames: [...definition.tools],
         categoryPolicy: { ...definition.categoryPolicy },
@@ -1539,6 +1588,11 @@ export class SessionManager {
       },
       parentPermissionCeiling: parentHeader.permissionMode,
     });
+    const workspace = await this.provisionChildWorkspace(
+      parentHeader,
+      definition,
+      provisionFingerprint,
+    );
     const request: AgentGraphOperatorProvisionRequest = {
       schemaVersion: AGENT_GRAPH_OPERATOR_PROVISION_SCHEMA_VERSION,
       provisionId: `graph_provision_${identityHash}`,
@@ -1554,7 +1608,8 @@ export class SessionManager {
     const result = await create.call(
       this.deps.store,
       {
-        cwd: parentHeader.cwd,
+        cwd: workspace?.worktreePath ?? parentHeader.cwd,
+        ...(parentHeader.projectId !== undefined ? { projectId: parentHeader.projectId } : {}),
         name: definition.name,
         backend: parentHeader.backend,
         llmConnectionSlug: parentHeader.llmConnectionSlug,
@@ -1597,6 +1652,7 @@ export class SessionManager {
           initialTurnId,
           initialRunId,
         },
+        ...(workspace ? { subagentWorkspace: workspace } : {}),
       },
       request,
       input.expectedScheduleRevision,
@@ -1606,7 +1662,8 @@ export class SessionManager {
       relation?.graphId !== input.graphId ||
       relation.workId !== input.workId ||
       relation.operatorId !== result.provision.operatorId ||
-      result.header.id !== result.provision.targetSessionId
+      result.header.id !== result.provision.targetSessionId ||
+      !sameSubagentWorkspace(result.header.subagentWorkspace, workspace)
     ) {
       throw new Error('Stored graph operator provision returned mismatched Session metadata');
     }
@@ -1710,6 +1767,7 @@ export class SessionManager {
 
     const { claim } = input;
     const child = await this.deps.store.readHeader(claim.targetSessionId);
+    await this.ensureChildWorkspace(child);
     const snapshot = child.subagentRuntime;
     if (
       child.id !== claim.targetSessionId ||
@@ -1919,12 +1977,18 @@ export class SessionManager {
       parentPermissionMode: parentHeader.permissionMode,
       definition,
       tools: availableChildTools,
+      worktreeChildExecutorAvailable: this.deps.worktreeChildExecutor !== undefined,
     });
 
     const proposedTurnId = input.turnId ?? this.deps.newId();
     const proposedRunId = input.runId ?? this.deps.newId();
+    const workspace = await this.provisionChildWorkspace(
+      parentHeader,
+      definition,
+      requestFingerprint,
+    );
     const creation = await this.deps.store.createSubagent({
-      cwd: parentHeader.cwd,
+      cwd: workspace?.worktreePath ?? parentHeader.cwd,
       ...(parentHeader.projectId !== undefined ? { projectId: parentHeader.projectId } : {}),
       name: input.name ?? definition.name,
       backend: parentHeader.backend,
@@ -1960,11 +2024,17 @@ export class SessionManager {
         initialTurnId: proposedTurnId,
         initialRunId: proposedRunId,
       },
+      ...(workspace ? { subagentWorkspace: workspace } : {}),
     });
     const child = creation.header;
     const snapshot = child.subagentRuntime;
     const spawn = child.subagentSpawn;
-    if (!snapshot || !spawn || !child.subagentParent) {
+    if (
+      !snapshot ||
+      !spawn ||
+      !child.subagentParent ||
+      !sameSubagentWorkspace(child.subagentWorkspace, workspace)
+    ) {
       throw new Error('Stored child session is missing its durable runtime or spawn identity');
     }
     try {
@@ -2234,10 +2304,12 @@ export class SessionManager {
     }
 
     const sessionHeader = await this.deps.store.readHeader(sessionId);
+    await this.ensureChildWorkspace(sessionHeader);
     assertAgentDefinitionRunnable({
       parentPermissionMode: sessionHeader.permissionMode,
       definition,
       tools: this.deps.childTools ?? [],
+      worktreeChildExecutorAvailable: this.deps.worktreeChildExecutor !== undefined,
     });
     const visited = new Set<string>();
     let cursor: AgentRunHeader | undefined = source;
@@ -3055,6 +3127,7 @@ export class SessionManager {
     const definitions = listBuiltinAgentDefinitions({
       parentPermissionMode: header.permissionMode,
       tools: this.deps.childTools ?? [],
+      worktreeChildExecutorAvailable: this.deps.worktreeChildExecutor !== undefined,
     });
     if (!this.deps.runStore) return { definitions, executions: [], runs: [] };
     const runs = await this.deps.runStore.listSessionRuns(sessionId);
@@ -4196,6 +4269,7 @@ export function headerToSummary(h: SessionHeader): SessionSummary {
     ...(h.subagentRuntime
       ? { subagentRuntime: subagentSessionRuntimeSummary(h.subagentRuntime) }
       : {}),
+    ...(h.subagentWorkspace ? { subagentWorkspace: h.subagentWorkspace } : {}),
     ...(h.revisionRootSessionId ? { revisionRootSessionId: h.revisionRootSessionId } : {}),
     ...(h.revisionParentSessionId ? { revisionParentSessionId: h.revisionParentSessionId } : {}),
     ...(h.revisionOfTurnId ? { revisionOfTurnId: h.revisionOfTurnId } : {}),
@@ -4218,6 +4292,22 @@ export function headerToSummary(h: SessionHeader): SessionSummary {
 
 function isNotFoundError(error: unknown): error is NodeJS.ErrnoException {
   return error instanceof Error && 'code' in error && error.code === 'ENOENT';
+}
+
+function sameSubagentWorkspace(
+  left: SubagentWorkspaceBinding | undefined,
+  right: SubagentWorkspaceBinding | undefined,
+): boolean {
+  if (!left || !right) return left === right;
+  return (
+    left.schemaVersion === right.schemaVersion &&
+    left.kind === right.kind &&
+    left.leaseId === right.leaseId &&
+    left.gitCommonDir === right.gitCommonDir &&
+    left.worktreePath === right.worktreePath &&
+    left.branch === right.branch &&
+    left.baseCommit === right.baseCommit
+  );
 }
 
 function childSessionSpawnKey(

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -32,11 +32,7 @@ export const AGENT_TOOL_NAMES = [
 ] as const;
 const CHILD_RECOVERY_TOOL_NAMES = ['ArchiveRead'] as const;
 export const CHILD_AGENT_TOOL_NAMES = [
-  ...new Set(
-    BUILTIN_AGENT_DEFINITIONS.filter(
-      (definition) => definition.contract.workspace === AGENT_WORKSPACE_SAME_WORKSPACE,
-    ).flatMap((definition) => definition.tools),
-  ),
+  ...new Set(BUILTIN_AGENT_DEFINITIONS.flatMap((definition) => definition.tools)),
 ] as readonly string[];
 const AGENT_SPAWN_WRITE_BACK_MODES = [AGENT_WRITE_BACK_SUMMARY, AGENT_WRITE_BACK_PATCH] as const;
 const AGENT_SPAWN_ISOLATION_MODES = [
@@ -51,7 +47,6 @@ export function buildChildAgentTools(tools: readonly MakaTool[]): MakaTool[] {
   const seen = new Set<string>();
   const out: MakaTool[] = [];
   for (const definition of BUILTIN_AGENT_DEFINITIONS) {
-    if (definition.contract.workspace !== AGENT_WORKSPACE_SAME_WORKSPACE) continue;
     for (const tool of buildToolsForAgentDefinition(tools, definition)) {
       if (seen.has(tool.name)) continue;
       seen.add(tool.name);
@@ -153,11 +148,6 @@ export function buildSubagentSpawnTool(deps: { taskLedger?: TaskLedgerStore } = 
       if (requestedIsolation !== definition.contract.workspace) {
         throw new Error(
           `Agent profile "${definition.profile}" requires isolation "${definition.contract.workspace}", not "${requestedIsolation}".`,
-        );
-      }
-      if (requestedIsolation !== AGENT_WORKSPACE_SAME_WORKSPACE) {
-        throw new Error(
-          `Agent profile "${definition.profile}" requires "${requestedIsolation}" workspace isolation, but this runtime does not provide a worktree child executor yet.`,
         );
       }
       if (!ctx.spawnChildSession) {

--- a/packages/storage/src/__tests__/git-worktree-child-executor.test.ts
+++ b/packages/storage/src/__tests__/git-worktree-child-executor.test.ts
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdir, mkdtemp, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterEach, describe, test } from 'node:test';
+import { createGitWorktreeChildExecutor } from '../git-worktree-child-executor.js';
+import { createGitRepositoryWithWorktree } from './fixtures/git-repository.js';
+
+const execFileAsync = promisify(execFile);
+const cleanup: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(cleanup.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+describe('Git worktree child executor', () => {
+  test('provisions deterministic isolated worktrees for concurrent child leases', async () => {
+    const root = await temporaryRoot();
+    const repository = join(root, 'repository');
+    await createGitRepositoryWithWorktree(repository, join(root, 'existing-worktree'), 'existing');
+    const executor = createGitWorktreeChildExecutor({ storageRoot: join(root, 'storage') });
+    const [left, right] = await Promise.all([
+      executor.provision({
+        leaseId: `subagent_worktree_${'1'.repeat(32)}`,
+        sourceSessionId: 'parent-session',
+        sourceCwd: repository,
+        sourceProjectId: 'project-1',
+      }),
+      executor.provision({
+        leaseId: `subagent_worktree_${'2'.repeat(32)}`,
+        sourceSessionId: 'parent-session',
+        sourceCwd: repository,
+        sourceProjectId: 'project-1',
+      }),
+    ]);
+
+    assert.notEqual(left.worktreePath, right.worktreePath);
+    assert.notEqual(left.branch, right.branch);
+    assert.equal((await stat(left.worktreePath)).isDirectory(), true);
+    assert.equal((await stat(right.worktreePath)).isDirectory(), true);
+    assert.equal(await git(left.worktreePath, 'branch', '--show-current'), left.branch);
+    assert.equal(await git(right.worktreePath, 'branch', '--show-current'), right.branch);
+    assert.equal(left.baseCommit, await git(repository, 'rev-parse', 'HEAD'));
+    assert.equal(right.baseCommit, left.baseCommit);
+
+    await writeFile(join(left.worktreePath, 'left.txt'), 'left\n', 'utf8');
+    await writeFile(join(right.worktreePath, 'right.txt'), 'right\n', 'utf8');
+    assert.match(await git(left.worktreePath, 'status', '--short'), /left\.txt/);
+    assert.match(await git(right.worktreePath, 'status', '--short'), /right\.txt/);
+    assert.equal(await git(repository, 'status', '--short'), '');
+  });
+
+  test('reuses the durable branch/path binding across executor restart and child edits', async () => {
+    const root = await temporaryRoot();
+    const repository = join(root, 'repository');
+    await createGitRepositoryWithWorktree(repository, join(root, 'existing-worktree'), 'existing');
+    const storageRoot = join(root, 'storage');
+    const request = {
+      leaseId: `subagent_worktree_${'3'.repeat(32)}`,
+      sourceSessionId: 'parent-session',
+      sourceCwd: repository,
+    };
+    const first = await createGitWorktreeChildExecutor({ storageRoot }).provision(request);
+    await writeFile(join(first.worktreePath, 'work.txt'), 'work\n', 'utf8');
+
+    const restarted = createGitWorktreeChildExecutor({ storageRoot });
+    const second = await restarted.provision(request);
+    assert.deepEqual(second, first);
+    await restarted.ensure(first);
+  });
+
+  test('fails closed when a fresh lease would omit uncommitted parent work', async () => {
+    const root = await temporaryRoot();
+    const repository = join(root, 'repository');
+    await createGitRepositoryWithWorktree(repository, join(root, 'existing-worktree'), 'existing');
+    await writeFile(join(repository, 'dirty.txt'), 'dirty\n', 'utf8');
+    const executor = createGitWorktreeChildExecutor({ storageRoot: join(root, 'storage') });
+
+    await assert.rejects(
+      executor.provision({
+        leaseId: `subagent_worktree_${'4'.repeat(32)}`,
+        sourceSessionId: 'parent-session',
+        sourceCwd: repository,
+      }),
+      /no uncommitted changes/,
+    );
+  });
+
+  test('rejects non-Git project roots', async () => {
+    const root = await temporaryRoot();
+    const source = join(root, 'folder');
+    await writeFileAfterMkdir(source, 'file.txt', 'plain\n');
+    const executor = createGitWorktreeChildExecutor({ storageRoot: join(root, 'storage') });
+
+    await assert.rejects(
+      executor.provision({
+        leaseId: `subagent_worktree_${'5'.repeat(32)}`,
+        sourceSessionId: 'parent-session',
+        sourceCwd: source,
+      }),
+      /requires a Git project/,
+    );
+  });
+});
+
+async function temporaryRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-worktree-child-'));
+  cleanup.push(root);
+  return root;
+}
+
+async function writeFileAfterMkdir(root: string, name: string, contents: string): Promise<void> {
+  await mkdir(root, { recursive: true });
+  await writeFile(join(root, name), contents, 'utf8');
+}
+
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd, encoding: 'utf8' });
+  return stdout.trim();
+}

--- a/packages/storage/src/__tests__/sqlite-session-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-session-store.test.ts
@@ -3,7 +3,12 @@ import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import type { CreateSessionInput, SessionHeader } from '@maka/core';
+import {
+  SUBAGENT_WORKSPACE_BINDING_SCHEMA_VERSION,
+  type CreateSessionInput,
+  type SessionHeader,
+  type SubagentWorkspaceBinding,
+} from '@maka/core';
 import {
   createLegacyFileSessionStore,
   createSessionStore,
@@ -228,6 +233,83 @@ describe('default SQLite session metadata store', () => {
     }
   });
 
+  test('persists an immutable child worktree binding across summaries and reopen', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-default-session-worktree-'));
+    const store = createSessionStore(root);
+    const workspace = makeSubagentWorkspace();
+    let childId = '';
+    try {
+      const parent = await store.create(
+        makeInput({ name: 'Parent', cwd: '/workspace/repository', projectId: 'project-1' }),
+      );
+      const { header: child } = await store.createSubagent(
+        makeInput({
+          name: 'Implementation child',
+          cwd: workspace.worktreePath,
+          projectId: 'project-1',
+          permissionMode: 'execute',
+          subagentParent: {
+            kind: 'subagent',
+            parentSessionId: parent.id,
+            spawnedBy: {
+              parentRunId: 'parent-run',
+              parentTurnId: 'parent-turn',
+              toolCallId: 'tool-call',
+            },
+            lifecycle: 'foreground',
+          },
+          subagentRuntime: {
+            schemaVersion: 1,
+            definitionVersion: 1,
+            agentId: 'implementation',
+            agentName: 'Implementation',
+            profile: 'implementation',
+            systemPrompt: 'Implement the assigned task.',
+            toolNames: ['Read', 'Glob', 'Grep', 'Write', 'Edit', 'Bash'],
+            categoryPolicy: {
+              read: 'allow',
+              file_write: 'allow',
+              shell_safe: 'allow',
+              shell_unsafe: 'allow',
+            },
+            permissionCeiling: 'execute',
+          },
+          subagentSpawn: {
+            schemaVersion: 1,
+            requestFingerprint: 'c'.repeat(64),
+            initialTurnId: 'child-turn',
+            initialRunId: 'child-run',
+          },
+          subagentWorkspace: workspace,
+        }),
+      );
+      childId = child.id;
+
+      assert.deepEqual(child.subagentWorkspace, workspace);
+      assert.deepEqual(
+        (await store.list()).find((session) => session.id === child.id)?.subagentWorkspace,
+        workspace,
+      );
+      await assert.rejects(
+        () =>
+          store.updateHeader(child.id, {
+            subagentWorkspace: { ...workspace, branch: 'maka/subagent/rebound' },
+          }),
+        /workspace binding is immutable/,
+      );
+    } finally {
+      await store.close?.();
+    }
+
+    const reopened = createSessionStore(root);
+    try {
+      assert.deepEqual((await reopened.readHeaderSnapshot(childId)).subagentWorkspace, workspace);
+    } finally {
+      await reopened.close?.();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('imports an existing JSONL catalog once and preserves later SQLite-only updates', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-default-session-migration-'));
     const legacy = createLegacyFileSessionStore(root);
@@ -402,5 +484,17 @@ function makeInput(overrides: Partial<CreateSessionInput> = {}): CreateSessionIn
     name: 'Session',
     labels: [],
     ...overrides,
+  };
+}
+
+function makeSubagentWorkspace(): SubagentWorkspaceBinding {
+  return {
+    schemaVersion: SUBAGENT_WORKSPACE_BINDING_SCHEMA_VERSION,
+    kind: 'git_worktree',
+    leaseId: `subagent_worktree_${'c'.repeat(32)}`,
+    gitCommonDir: '/workspace/repository/.git',
+    worktreePath: `/workspace/state/subagent-worktrees/${'c'.repeat(32)}`,
+    branch: `maka/subagent/${'c'.repeat(32)}`,
+    baseCommit: 'd'.repeat(40),
   };
 }

--- a/packages/storage/src/git-worktree-child-executor.ts
+++ b/packages/storage/src/git-worktree-child-executor.ts
@@ -1,0 +1,334 @@
+import { execFile } from 'node:child_process';
+import { mkdir, realpath, stat } from 'node:fs/promises';
+import { isAbsolute, join, normalize } from 'node:path';
+import { promisify } from 'node:util';
+import {
+  SUBAGENT_WORKSPACE_BINDING_SCHEMA_VERSION,
+  isSubagentWorkspaceBinding,
+  type ProvisionSubagentWorktreeInput,
+  type SubagentWorkspaceBinding,
+  type SubagentWorktreeExecutor,
+} from '@maka/core';
+import { resolveProjectLocation } from './project-catalog.js';
+
+const execFileAsync = promisify(execFile);
+const LEASE_PATTERN = /^subagent_worktree_([a-f0-9]{32})$/;
+const GIT_TIMEOUT_MS = 2 * 60 * 1_000;
+
+export interface CreateGitWorktreeChildExecutorInput {
+  storageRoot: string;
+}
+
+/**
+ * Host-owned Git worktree allocator for linked child Sessions.
+ *
+ * Lease identity, branch, and path are deterministic. A retry therefore
+ * adopts the same worktree instead of creating a second filesystem side
+ * effect. Worktrees intentionally survive terminal child runs so Session
+ * resume/follow-up keeps the exact workspace.
+ */
+export function createGitWorktreeChildExecutor(
+  input: CreateGitWorktreeChildExecutorInput,
+): SubagentWorktreeExecutor {
+  return new GitWorktreeChildExecutor(join(input.storageRoot, 'subagent-worktrees'));
+}
+
+class GitWorktreeChildExecutor implements SubagentWorktreeExecutor {
+  private readonly inFlight = new Map<string, Promise<SubagentWorkspaceBinding>>();
+  private readonly repositoryTails = new Map<string, Promise<void>>();
+
+  constructor(private readonly worktreeRoot: string) {}
+
+  async provision(input: ProvisionSubagentWorktreeInput): Promise<SubagentWorkspaceBinding> {
+    const suffix = leaseSuffix(input.leaseId);
+    const existing = this.inFlight.get(input.leaseId);
+    if (existing) return existing;
+    const task = this.provisionOnce(input, suffix).finally(() => {
+      if (this.inFlight.get(input.leaseId) === task) this.inFlight.delete(input.leaseId);
+    });
+    this.inFlight.set(input.leaseId, task);
+    return task;
+  }
+
+  async ensure(binding: SubagentWorkspaceBinding): Promise<void> {
+    if (!isSubagentWorkspaceBinding(binding)) {
+      throw new Error('Invalid subagent worktree binding');
+    }
+    const inspected = await this.inspectOwnedWorktree(binding.worktreePath, binding.branch);
+    if (!inspected) {
+      throw new Error(`Subagent worktree is unavailable: ${binding.worktreePath}`);
+    }
+    if (
+      inspected.gitCommonDir !== normalize(binding.gitCommonDir) ||
+      inspected.baseCommit !== binding.baseCommit
+    ) {
+      throw new Error(`Subagent worktree binding changed: ${binding.worktreePath}`);
+    }
+    const lease = await gitConfigGet(inspected.worktreePath, branchLeaseConfigKey(binding.branch));
+    if (lease !== binding.leaseId) {
+      throw new Error(`Subagent worktree lease changed: ${binding.worktreePath}`);
+    }
+  }
+
+  private async provisionOnce(
+    input: ProvisionSubagentWorktreeInput,
+    suffix: string,
+  ): Promise<SubagentWorkspaceBinding> {
+    if (!input.sourceSessionId) throw new Error('Subagent worktree source Session is required');
+    const source = await resolveProjectLocation({ path: input.sourceCwd });
+    if (source.kind !== 'git' || !source.git) {
+      throw new Error('Worktree child execution requires a Git project');
+    }
+    const root = await ensureDirectory(this.worktreeRoot);
+    const worktreePath = join(root, suffix);
+    const branch = `maka/subagent/${suffix}`;
+    const gitCommonDir = normalize(source.git.commonDir);
+    return this.withRepositoryAllocation(gitCommonDir, () =>
+      this.provisionResolved(input.leaseId, source.git!.worktreeRoot, {
+        worktreePath,
+        branch,
+        gitCommonDir,
+      }),
+    );
+  }
+
+  private async provisionResolved(
+    leaseId: string,
+    sourceWorktreeRoot: string,
+    target: {
+      worktreePath: string;
+      branch: string;
+      gitCommonDir: string;
+    },
+  ): Promise<SubagentWorkspaceBinding> {
+    const { worktreePath, branch, gitCommonDir } = target;
+    const adopted = await this.inspectOwnedWorktree(worktreePath, branch);
+    if (adopted) {
+      if (adopted.gitCommonDir !== gitCommonDir) {
+        throw new Error(`Subagent worktree belongs to another Git repository: ${worktreePath}`);
+      }
+      return this.finalizeBinding(leaseId, adopted);
+    }
+
+    const branchCommit = await gitRevParseOptional(sourceWorktreeRoot, branch);
+    const storedLease = await gitConfigGet(sourceWorktreeRoot, branchLeaseConfigKey(branch));
+    if (branchCommit && storedLease !== leaseId) {
+      throw new Error(`Subagent worktree branch is already owned: ${branch}`);
+    }
+
+    let baseCommit: string;
+    if (branchCommit) {
+      baseCommit =
+        (await gitConfigGet(sourceWorktreeRoot, branchBaseConfigKey(branch))) ?? branchCommit;
+      await runGit(sourceWorktreeRoot, ['worktree', 'add', '--quiet', worktreePath, branch]);
+    } else {
+      await assertCleanGitWorktree(sourceWorktreeRoot);
+      baseCommit = await gitRevParse(sourceWorktreeRoot, 'HEAD');
+      await runGit(sourceWorktreeRoot, [
+        'worktree',
+        'add',
+        '--quiet',
+        '-b',
+        branch,
+        worktreePath,
+        baseCommit,
+      ]);
+    }
+
+    const inspected = await this.inspectOwnedWorktree(worktreePath, branch);
+    if (!inspected || inspected.gitCommonDir !== gitCommonDir) {
+      throw new Error(`Git did not create the expected subagent worktree: ${worktreePath}`);
+    }
+    await setBranchLease(worktreePath, branch, leaseId, baseCommit);
+    return {
+      schemaVersion: SUBAGENT_WORKSPACE_BINDING_SCHEMA_VERSION,
+      kind: 'git_worktree',
+      leaseId,
+      gitCommonDir,
+      worktreePath: inspected.worktreePath,
+      branch,
+      baseCommit,
+    };
+  }
+
+  private async withRepositoryAllocation<T>(
+    gitCommonDir: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.repositoryTails.get(gitCommonDir) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => current);
+    this.repositoryTails.set(gitCommonDir, tail);
+    await previous;
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.repositoryTails.get(gitCommonDir) === tail) {
+        this.repositoryTails.delete(gitCommonDir);
+      }
+    }
+  }
+
+  private async finalizeBinding(
+    leaseId: string,
+    inspected: InspectedWorktree,
+  ): Promise<SubagentWorkspaceBinding> {
+    const lease = await gitConfigGet(
+      inspected.worktreePath,
+      branchLeaseConfigKey(inspected.branch),
+    );
+    if (lease && lease !== leaseId) {
+      throw new Error(`Subagent worktree lease changed: ${inspected.worktreePath}`);
+    }
+    const baseCommit =
+      (await gitConfigGet(inspected.worktreePath, branchBaseConfigKey(inspected.branch))) ??
+      (await gitRevParse(inspected.worktreePath, inspected.branch));
+    await setBranchLease(inspected.worktreePath, inspected.branch, leaseId, baseCommit);
+    return {
+      schemaVersion: SUBAGENT_WORKSPACE_BINDING_SCHEMA_VERSION,
+      kind: 'git_worktree',
+      leaseId,
+      gitCommonDir: inspected.gitCommonDir,
+      worktreePath: inspected.worktreePath,
+      branch: inspected.branch,
+      baseCommit,
+    };
+  }
+
+  private async inspectOwnedWorktree(
+    path: string,
+    expectedBranch: string,
+  ): Promise<InspectedWorktree | undefined> {
+    if (!(await isDirectory(path))) return undefined;
+    const location = await resolveProjectLocation({ path });
+    if (location.kind !== 'git' || !location.git?.isWorktree) {
+      throw new Error(`Subagent workspace is not a linked Git worktree: ${path}`);
+    }
+    const branch = (
+      await runGit(location.git.worktreeRoot, ['symbolic-ref', '--quiet', '--short', 'HEAD'])
+    ).trim();
+    if (branch !== expectedBranch) {
+      throw new Error(`Subagent worktree branch changed from ${expectedBranch} to ${branch}`);
+    }
+    const baseCommit =
+      (await gitConfigGet(location.git.worktreeRoot, branchBaseConfigKey(branch))) ??
+      (await gitRevParse(location.git.worktreeRoot, branch));
+    return {
+      worktreePath: normalize(await realpath(location.git.worktreeRoot)),
+      gitCommonDir: normalize(location.git.commonDir),
+      branch,
+      baseCommit,
+    };
+  }
+}
+
+interface InspectedWorktree {
+  worktreePath: string;
+  gitCommonDir: string;
+  branch: string;
+  baseCommit: string;
+}
+
+async function assertCleanGitWorktree(path: string): Promise<void> {
+  const status = await runGit(path, [
+    'status',
+    '--porcelain=v1',
+    '--untracked-files=normal',
+    '--ignore-submodules=none',
+  ]);
+  if (status.trim()) {
+    throw new Error(
+      'Worktree child execution requires the source Git worktree to have no uncommitted changes',
+    );
+  }
+}
+
+async function setBranchLease(
+  cwd: string,
+  branch: string,
+  leaseId: string,
+  baseCommit: string,
+): Promise<void> {
+  await runGit(cwd, ['config', '--local', branchLeaseConfigKey(branch), leaseId]);
+  await runGit(cwd, ['config', '--local', branchBaseConfigKey(branch), baseCommit]);
+}
+
+function branchLeaseConfigKey(branch: string): string {
+  return `branch.${branch}.maka-worktree-lease`;
+}
+
+function branchBaseConfigKey(branch: string): string {
+  return `branch.${branch}.maka-worktree-base`;
+}
+
+async function gitConfigGet(cwd: string, key: string): Promise<string | undefined> {
+  try {
+    const output = await runGit(cwd, ['config', '--local', '--get', key]);
+    return output.trim() || undefined;
+  } catch (error) {
+    if (gitExitCode(error) === 1) return undefined;
+    throw error;
+  }
+}
+
+async function gitRevParse(cwd: string, ref: string): Promise<string> {
+  return (await runGit(cwd, ['rev-parse', '--verify', ref])).trim();
+}
+
+async function gitRevParseOptional(cwd: string, ref: string): Promise<string | undefined> {
+  try {
+    return await gitRevParse(cwd, ref);
+  } catch (error) {
+    if (gitExitCode(error) === 128) return undefined;
+    throw error;
+  }
+}
+
+async function runGit(cwd: string, args: readonly string[]): Promise<string> {
+  const env: NodeJS.ProcessEnv = { ...process.env, GIT_OPTIONAL_LOCKS: '0' };
+  delete env.GIT_DIR;
+  delete env.GIT_WORK_TREE;
+  delete env.GIT_INDEX_FILE;
+  delete env.GIT_COMMON_DIR;
+  const { stdout } = await execFileAsync('git', ['-C', cwd, ...args], {
+    env,
+    encoding: 'utf8',
+    maxBuffer: 1024 * 1024,
+    timeout: GIT_TIMEOUT_MS,
+    windowsHide: true,
+  });
+  return stdout;
+}
+
+function gitExitCode(error: unknown): number | undefined {
+  if (!error || typeof error !== 'object' || !('code' in error)) return undefined;
+  return typeof error.code === 'number' ? error.code : undefined;
+}
+
+function leaseSuffix(leaseId: string): string {
+  const match = LEASE_PATTERN.exec(leaseId);
+  if (!match?.[1]) throw new Error(`Invalid subagent worktree lease id: ${leaseId}`);
+  return match[1];
+}
+
+async function ensureDirectory(path: string): Promise<string> {
+  await mkdir(path, { recursive: true });
+  const canonical = normalize(await realpath(path));
+  if (!isAbsolute(canonical) || !(await stat(canonical)).isDirectory()) {
+    throw new Error(`Invalid subagent worktree root: ${path}`);
+  }
+  return canonical;
+}
+
+async function isDirectory(path: string): Promise<boolean> {
+  try {
+    return (await stat(path)).isDirectory();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
+    throw error;
+  }
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -52,5 +52,6 @@ export * from './runtime-event-transfer.js';
 export * from './mcp-config-store.js';
 export * from './workspace-identity.js';
 export * from './project-catalog.js';
+export * from './git-worktree-child-executor.js';
 export * from './project-session-migration.js';
 export * from './session-bundle-policy.js';

--- a/packages/storage/src/session-store.ts
+++ b/packages/storage/src/session-store.ts
@@ -30,6 +30,7 @@ import {
   isSubagentSessionParent,
   isSubagentSessionRuntime,
   isSubagentSessionSpawn,
+  isSubagentWorkspaceBinding,
   isSessionStatus,
   normalizeUserSessionName,
   subagentSessionRuntimeSummary,
@@ -468,6 +469,7 @@ class FileSessionStore implements SessionStore {
       ...(input.subagentParent ? { subagentParent: input.subagentParent } : {}),
       ...(input.subagentRuntime ? { subagentRuntime: input.subagentRuntime } : {}),
       ...(input.subagentSpawn ? { subagentSpawn: input.subagentSpawn } : {}),
+      ...(input.subagentWorkspace ? { subagentWorkspace: input.subagentWorkspace } : {}),
       ...(input.revisionRootSessionId
         ? { revisionRootSessionId: input.revisionRootSessionId }
         : {}),
@@ -684,6 +686,9 @@ class FileSessionStore implements SessionStore {
     }
     if (Object.prototype.hasOwnProperty.call(patch, 'subagentSpawn')) {
       throw new Error('Subagent session spawn identity is immutable');
+    }
+    if (Object.prototype.hasOwnProperty.call(patch, 'subagentWorkspace')) {
+      throw new Error('Subagent session workspace binding is immutable');
     }
     let nextHeader: SessionHeader | undefined;
     await this.withQueue(sessionId, async () => {
@@ -1260,7 +1265,11 @@ function assertValidSessionLineage(header: SessionHeader): void {
 
 function isValidSubagentSessionLineage(header: SessionHeader): boolean {
   if (header.subagentParent === undefined) {
-    return header.subagentRuntime === undefined && header.subagentSpawn === undefined;
+    return (
+      header.subagentRuntime === undefined &&
+      header.subagentSpawn === undefined &&
+      header.subagentWorkspace === undefined
+    );
   }
   if (
     !isSubagentSessionParent(header.subagentParent) ||
@@ -1276,9 +1285,13 @@ function isValidSubagentSessionLineage(header: SessionHeader): boolean {
     return false;
   }
   return (
-    (header.subagentRuntime === undefined && header.subagentSpawn === undefined) ||
+    (header.subagentRuntime === undefined &&
+      header.subagentSpawn === undefined &&
+      header.subagentWorkspace === undefined) ||
     (isSubagentSessionRuntime(header.subagentRuntime) &&
       isSubagentSessionSpawn(header.subagentSpawn) &&
+      (header.subagentWorkspace === undefined ||
+        isSubagentWorkspaceBinding(header.subagentWorkspace)) &&
       isPermissionModeWithinCeiling(
         header.permissionMode,
         header.subagentRuntime.permissionCeiling,
@@ -1318,6 +1331,7 @@ function toSummary(header: SessionHeader, messages: StoredMessage[] = []): Sessi
     ...(header.subagentRuntime
       ? { subagentRuntime: subagentSessionRuntimeSummary(header.subagentRuntime) }
       : {}),
+    ...(header.subagentWorkspace ? { subagentWorkspace: header.subagentWorkspace } : {}),
     ...(header.revisionRootSessionId
       ? { revisionRootSessionId: header.revisionRootSessionId }
       : {}),

--- a/packages/storage/src/sqlite-session-metadata-store.ts
+++ b/packages/storage/src/sqlite-session-metadata-store.ts
@@ -1437,6 +1437,9 @@ export class SqliteSessionMetadataStore {
     if (Object.prototype.hasOwnProperty.call(patch, 'subagentSpawn')) {
       throw new Error('Subagent session spawn identity is immutable');
     }
+    if (Object.prototype.hasOwnProperty.call(patch, 'subagentWorkspace')) {
+      throw new Error('Subagent session workspace binding is immutable');
+    }
     return this.transaction(() => {
       const current = this.readRecordSync(sessionId);
       if (!current) throw new SessionNotFoundError(sessionId);


### PR DESCRIPTION
## Summary

Follow-up to #1341: make code-changing child operators usable without teaching the graph scheduler about Git.

- add a host-owned `SubagentWorktreeExecutor` capability and a strict, immutable workspace binding on linked child Sessions;
- provision deterministic per-child Git branches and worktree paths, including same-lease retry/restart adoption;
- persist the binding in SQLite Session metadata and restore it through Session summaries;
- enable the `implementation` catalog profile only when the host supplies the executor, across Graph, `agent_spawn`, and Swarm paths;
- wire the real executor into Desktop and expose Write/Edit/Bash only through the implementation profile's existing catalog policy;
- retain terminal child worktrees so Session resume, follow-up, inspection, and patch handoff keep the exact filesystem state.

Two Graph implementation operators now receive distinct worktrees and can edit concurrently. Allocation for one Git common directory is serialized to avoid `.git/config` lock races; Agent execution remains concurrent.

## Safety and boundaries

- The Graph scheduler remains Git-agnostic. Workspace isolation is a host capability consumed during child Session materialization.
- Fresh allocation fails closed for non-Git projects and dirty source worktrees, rather than silently omitting uncommitted parent state.
- Lease, branch, path, common-dir, and base commit are validated on every resume/activation.
- This slice does not merge child branches, delete retained worktrees, or add worktree UI. Those remain explicit lifecycle/product follow-ups.

## Validation

- `npm run build`
- `npm run lint -- --diagnostic-level=error`
- Core: 1,248 passed
- Storage: 715 passed, 1 skipped
- Runtime focused suites: 326 passed
- Desktop: 2,953 passed
- Headless isolated-tool suite: 54 passed
- Real Git tests cover concurrent A/B isolation, parent cleanliness, retry/restart reuse, dirty-source rejection, and non-Git rejection.

Full Runtime/Headless sweeps also surfaced pre-existing environment-specific failures unrelated to this diff: one macOS executable-root assertion and two Python 3.9 Harbor adapter tests.

<details>
<summary>中文说明</summary>

这是 #1341 的后续能力：让会改代码的 Graph operator 真正拥有独立 worktree，同时不把 Git 逻辑塞进 graph scheduler。

- 新增 host-owned `SubagentWorktreeExecutor`，并把不可变的 workspace binding 持久化到 child Session 的 SQLite metadata；
- 每个 child 使用确定性的 branch/path/lease，同一次任务重试或进程重启后会复用原 worktree；
- `implementation` profile 只有在 host 提供 executor 时才可用，Graph、`agent_spawn`、Swarm 统一走 SessionManager 的能力判断；
- Desktop 已接入真实 Git executor，implementation child 可以使用 Write/Edit/Bash，而其它 profile 仍按 catalog allowlist 收窄；
- child 结束后暂时保留 worktree，因此 Session 恢复、继续追问、观察和 patch handoff 都能看到同一份文件状态。

现在 Graph 中 A/B 两个 implementation operator 会得到不同的 worktree，可以并行改代码。同一 Git 仓库的“分配事务”会短暂串行，以避免 `.git/config` lock 冲突；Agent 的实际执行仍然并行。

安全边界：非 Git 项目直接失败；父 worktree 有未提交修改时也直接失败，避免 child 静默遗漏用户本地修改。本 PR 不负责自动 merge、自动清理 worktree 或新增 worktree UI。

</details>
