### PR TITLE
feat(providers): discover remote model catalogs

### DIFF
--- a/apps/desktop/src/main/__tests__/claude-subscription-experimental-gate.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-subscription-experimental-gate.test.ts
@@ -348,7 +348,11 @@ describe('Claude OAuth model connection bridge', () => {
       'resolveConnectionSecret must map claude-subscription to its stored OAuth access token',
     );
     assert.match(src, /connections:test[\s\S]*const apiKey = await resolveConnectionSecret\(slug\)/, 'connections:test must use resolveConnectionSecret');
-    assert.match(src, /connections:fetchModels[\s\S]*const apiKey = await resolveConnectionSecret\(slug\)/, 'connections:fetchModels must use resolveConnectionSecret');
+    assert.match(
+      src,
+      /discoverConnectionModels[\s\S]*const apiKey = await deps\.resolveConnectionSecret\(slug\)/,
+      'connections:fetchModels must use resolveConnectionSecret through the discovery service',
+    );
     assert.match(src, /connections:hasSecret[\s\S]*return hasConnectionSecret\(connection\)/, 'connections:hasSecret must report OAuth login presence for claude-subscription through the read-only hasConnectionSecret (hasStoredCredential), not the refreshing resolveConnectionSecret');
     assert.match(src, /getApiKey:\s*\(slug:\s*string\)\s*=>\s*resolveConnectionSecret\(slug\)/, 'chat send readiness must use OAuth tokens through resolveConnectionSecret');
   });

--- a/apps/desktop/src/main/__tests__/connection-credential-ipc-hardening-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/connection-credential-ipc-hardening-contract.test.ts
@@ -3,6 +3,10 @@ import { describe, it } from 'node:test';
 import { readMainProcessCombinedSourceSync } from './main-process-contract-source-helpers.js';
 
 const mainSource = readMainProcessCombinedSourceSync();
+const discoveryService =
+  mainSource.match(
+    /export async function discoverConnectionModels\([\s\S]*?\n\}/,
+  )?.[0] ?? '';
 
 function handlerBlock(channel: string): string {
   const start = mainSource.indexOf(`ipcMain.handle('${channel}'`);
@@ -111,6 +115,7 @@ describe('connection credential IPC hardening contract', () => {
         'resolveConnectionSecret(',
         'testConnection(',
         'fetchProviderModels(',
+        'discoverConnectionModels(',
       ]) {
         const sideEffectAt = handler.indexOf(sideEffect);
         if (sideEffectAt !== -1) {
@@ -153,7 +158,7 @@ describe('connection credential IPC hardening contract', () => {
       'update must preserve the main-owned account endpoint for OAuth providers',
     );
     assert.match(mainSource, /connections:test[\s\S]*const apiKey = await resolveConnectionSecret\(slug\)/);
-    assert.match(mainSource, /connections:fetchModels[\s\S]*const apiKey = await resolveConnectionSecret\(slug\)/);
+    assert.match(discoveryService, /const apiKey = await deps\.resolveConnectionSecret\(slug\)/);
     // hasSecret is the exception: a read-only status probe (session
     // health notice) that must use the read-only hasConnectionSecret,
     // so observing it never refreshes OAuth tokens or hits the network.
@@ -169,7 +174,11 @@ describe('connection credential IPC hardening contract', () => {
     const testHandler = handlerBlock('connections:test');
     const fetchHandler = handlerBlock('connections:fetchModels');
     assert.match(testHandler, /providerAuthRequiresSecret\(connection\.providerType\)[\s\S]*!apiKey/);
-    assert.match(fetchHandler, /providerAuthRequiresSecret\(connection\.providerType\)[\s\S]*!apiKey/);
+    assert.match(fetchHandler, /discoverConnectionModels\(\{[\s\S]*resolveConnectionSecret/);
+    assert.match(
+      discoveryService,
+      /providerAuthRequiresSecret\(connection\.providerType\)[\s\S]*!apiKey/,
+    );
     assert.match(
       mainSource,
       /async function resolveModelContext[\s\S]*providerAuthRequiresSecret\(connection\.providerType\)[\s\S]*!apiKey/,

--- a/apps/desktop/src/main/__tests__/connection-model-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/connection-model-discovery.test.ts
@@ -4,7 +4,30 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
 import { createConnectionStore } from '@maka/storage';
-import { discoverConnectionModels } from '../connection-model-discovery.js';
+import {
+  ConnectionModelDiscoveryPreconditionError,
+  discoverConnectionModels,
+} from '../connection-model-discovery.js';
+
+test('precondition failures are explicitly safe to preserve across IPC', async () => {
+  await assert.rejects(
+    discoverConnectionModels(
+      {
+        connectionStore: {
+          get: async () => null,
+          update: async () => {
+            throw new Error('update must not run for a missing connection');
+          },
+        },
+        resolveConnectionSecret: async () => null,
+      },
+      'missing',
+    ),
+    (error: unknown) =>
+      error instanceof ConnectionModelDiscoveryPreconditionError &&
+      error.message === '找不到模型连接：missing',
+  );
+});
 
 test('an empty discovery result leaves the last successful catalog intact', async () => {
   const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-model-discovery-'));

--- a/apps/desktop/src/main/__tests__/connection-model-discovery.test.ts
+++ b/apps/desktop/src/main/__tests__/connection-model-discovery.test.ts
@@ -1,0 +1,114 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { createConnectionStore } from '@maka/storage';
+import { discoverConnectionModels } from '../connection-model-discovery.js';
+
+test('an empty discovery result leaves the last successful catalog intact', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-model-discovery-'));
+  try {
+    const connectionStore = createConnectionStore(workspaceRoot);
+    const created = await connectionStore.create({
+      slug: 'zai-main',
+      name: 'Z.ai',
+      providerType: 'zai-coding-plan',
+      defaultModel: 'glm-5',
+    });
+    await connectionStore.update(created.slug, {
+      models: [{ id: 'glm-5' }],
+      modelSource: 'fetched',
+      modelsFetchedAt: 1_800_000_000_000,
+    });
+    await connectionStore.update(created.slug, { apiKey: 'rotated-secret' });
+
+    await assert.rejects(
+      discoverConnectionModels(
+        {
+          connectionStore,
+          resolveConnectionSecret: async () => 'rotated-secret',
+          fetchModels: async () => [],
+          now: () => 1_900_000_000_000,
+        },
+        created.slug,
+      ),
+      /no usable models/,
+    );
+
+    const persisted = await connectionStore.get(created.slug);
+    assert.deepEqual(persisted?.models, [{ id: 'glm-5' }]);
+    assert.equal(persisted?.modelSource, 'fetched');
+    assert.equal(persisted?.modelsFetchedAt, 1_800_000_000_000);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('a fallback-only provider cannot turn its static snapshot into a fetched catalog', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-model-discovery-'));
+  try {
+    const connectionStore = createConnectionStore(workspaceRoot);
+    const created = await connectionStore.create({
+      slug: 'volcengine-ark',
+      name: 'Volcengine Ark',
+      providerType: 'volcengine-ark',
+      defaultModel: 'doubao-seed-2-0-pro-260215',
+    });
+
+    await assert.rejects(
+      discoverConnectionModels(
+        {
+          connectionStore,
+          resolveConnectionSecret: async () => 'ark-inference-key',
+          fetchModels: async () => [{ id: 'doubao-seed-2-0-pro-260215' }],
+        },
+        created.slug,
+      ),
+      /does not support remote model discovery/,
+    );
+
+    const persisted = await connectionStore.get(created.slug);
+    assert.equal(persisted?.models, undefined);
+    assert.equal(persisted?.modelSource, undefined);
+    assert.equal(persisted?.modelsFetchedAt, undefined);
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});
+
+test('a successful discovery atomically replaces the persisted catalog and provenance', async () => {
+  const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-model-discovery-'));
+  try {
+    const connectionStore = createConnectionStore(workspaceRoot);
+    const created = await connectionStore.create({
+      slug: 'zai-main',
+      name: 'Z.ai',
+      providerType: 'zai-coding-plan',
+      defaultModel: 'glm-old',
+    });
+
+    const result = await discoverConnectionModels(
+      {
+        connectionStore,
+        resolveConnectionSecret: async () => 'zai-secret',
+        fetchModels: async () => [{ id: 'glm-new' }],
+        now: () => 1_900_000_000_000,
+      },
+      created.slug,
+    );
+
+    assert.deepEqual(result, {
+      models: [{ id: 'glm-new' }],
+      source: 'fetched',
+      fetchedAt: 1_900_000_000_000,
+    });
+    const persisted = await connectionStore.get(created.slug);
+    assert.deepEqual(persisted?.models, [{ id: 'glm-new' }]);
+    assert.equal(persisted?.modelSource, 'fetched');
+    assert.equal(persisted?.modelsFetchedAt, 1_900_000_000_000);
+    assert.equal(persisted?.defaultModel, 'glm-new');
+  } finally {
+    await rm(workspaceRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/src/main/__tests__/custom-relay-provider-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/custom-relay-provider-contract.test.ts
@@ -72,7 +72,10 @@ describe('Custom relay provider setup contract', () => {
     assert.match(form, /if \(isCustomRelay && !normalizedDefaultModel\) return setError\(copy\.defaultModelRequired\);/);
     assert.match(form, /baseUrl: resolvedBaseUrl,/);
     assert.match(form, /defaultModel: normalizedDefaultModel \|\| recommendedDefaultModel,/);
-    assert.match(form, /if \(isCustomRelay\) await props\.bridge\.fetchModels\(connection\.slug\)\.catch\(\(\) => undefined\);/);
+    assert.match(
+      form,
+      /const supportsRemoteDiscovery = defaults\.modelDiscovery\.kind !== 'fallback';[\s\S]*if \(supportsRemoteDiscovery\) \{[\s\S]*await props\.bridge\.fetchModels\(connection\.slug\)/,
+    );
     assert.match(form, /aria-label=\{copy\.defaultModelAria\}/);
     assert.match(form, /<small>\{copy\.defaultModelHelp\}<\/small>/);
 

--- a/apps/desktop/src/main/__tests__/custom-relay-provider-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/custom-relay-provider-contract.test.ts
@@ -74,7 +74,7 @@ describe('Custom relay provider setup contract', () => {
     assert.match(form, /defaultModel: normalizedDefaultModel \|\| recommendedDefaultModel,/);
     assert.match(
       form,
-      /const supportsRemoteDiscovery = defaults\.modelDiscovery\.kind !== 'fallback';[\s\S]*if \(supportsRemoteDiscovery\) \{[\s\S]*await props\.bridge\.fetchModels\(connection\.slug\)/,
+      /const supportsRemoteDiscovery = providerSupportsModelDiscovery\(props\.providerType\);[\s\S]*if \(supportsRemoteDiscovery\) \{[\s\S]*await props\.bridge\.fetchModels\(connection\.slug\)[\s\S]*if \(!isCustomRelay\) modelDiscoveryError = error/,
     );
     assert.match(form, /aria-label=\{copy\.defaultModelAria\}/);
     assert.match(form, /<small>\{copy\.defaultModelHelp\}<\/small>/);

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -60,6 +60,7 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/bot-incoming-main.ts',
   'apps/desktop/src/main/browser-ipc-main.ts',
   'apps/desktop/src/main/config-ipc-main.ts',
+  'apps/desktop/src/main/connection-model-discovery.ts',
   'apps/desktop/src/main/create-connection-with-credential.ts',
   'apps/desktop/src/main/connections-ipc-main.ts',
   'apps/desktop/src/main/daily-review-ipc-main.ts',

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -296,6 +296,11 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
       /connections:fetchModels[\s\S]*generalizedErrorMessageChinese\(error,\s*'拉取模型列表失败'\)/,
       'main-process fetchModels errors must be localized before crossing IPC to renderer toasts',
     );
+    assert.match(
+      main,
+      /error instanceof ConnectionModelDiscoveryPreconditionError[\s\S]*throw error/,
+      'safe discovery precondition copy must survive IPC error generalization',
+    );
     assert.doesNotMatch(
       main,
       /No OAuth login stored for this connection|No API key set for this connection|Failed to fetch provider models/,
@@ -316,7 +321,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.match(src, /\.\.\.\(normalizedApiKey \? \{ apiKey: normalizedApiKey \} : \{\}\)/);
     assert.match(
       src,
-      /const supportsRemoteDiscovery = defaults\.modelDiscovery\.kind !== 'fallback';[\s\S]*if \(supportsRemoteDiscovery\) \{[\s\S]*props\.bridge\.fetchModels\(connection\.slug\)[\s\S]*props\.onCreated\(connection\.slug, modelDiscoveryError\)/,
+      /const supportsRemoteDiscovery = providerSupportsModelDiscovery\(props\.providerType\);[\s\S]*if \(supportsRemoteDiscovery\) \{[\s\S]*props\.bridge\.fetchModels\(connection\.slug\)[\s\S]*props\.onCreated\(connection\.slug, modelDiscoveryError\)/,
       'new connections with a discovery strategy must fetch the current catalog immediately',
     );
     assert.doesNotMatch(src, /ProviderPageHeader|providerInlineEditor/, 'creation must not retain an in-pane child editor');
@@ -338,7 +343,7 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
 
     assert.match(
       detail,
-      /const supportsRemoteDiscovery = defaults\.modelDiscovery\.kind !== 'fallback';/,
+      /const supportsRemoteDiscovery = providerSupportsModelDiscovery\(connection\.providerType\);/,
       'connection detail must derive refresh support from the provider discovery contract',
     );
     assert.match(

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -346,6 +346,24 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
       /if \([\s\S]*supportsRemoteDiscovery[\s\S]*&&[\s\S]*\(wroteNewKey \|\| hasBaseUrlChange \|\| models\.length === 0\)[\s\S]*\) \{[\s\S]*refreshModels\(\{ silent: true \}\)/,
       'saving a new credential or endpoint must refresh the remote model catalog',
     );
+
+    const component = await readFile(
+      resolve(
+        REPO_ROOT,
+        'apps',
+        'desktop',
+        'src',
+        'renderer',
+        'settings',
+        'provider-connection-detail.tsx',
+      ),
+      'utf8',
+    );
+    assert.match(
+      component,
+      /\{supportsRemoteDiscovery && \([\s\S]*onClick=\{\(\) => void refreshModels\(\)\}[\s\S]*\)\}/,
+      'fallback-only providers must not render a model-refresh action',
+    );
   });
 
   it('OAuth login uses the same centered connection dialog as API providers', async () => {

--- a/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/model-oauth-section-contract.test.ts
@@ -316,10 +316,36 @@ describe('Model OAuth catalog contract (PR-MODEL-OAUTH-ALL-0 + PR-CLAUDE-CARD-MO
     assert.match(src, /\.\.\.\(normalizedApiKey \? \{ apiKey: normalizedApiKey \} : \{\}\)/);
     assert.match(
       src,
-      /defaults\.category === 'local'[\s\S]*props\.bridge\.fetchModels\(connection\.slug\)[\s\S]*props\.onCreated\(connection\.slug, modelDiscoveryError\)/,
-      'new local-provider connections must immediately discover the daemon model catalog',
+      /const supportsRemoteDiscovery = defaults\.modelDiscovery\.kind !== 'fallback';[\s\S]*if \(supportsRemoteDiscovery\) \{[\s\S]*props\.bridge\.fetchModels\(connection\.slug\)[\s\S]*props\.onCreated\(connection\.slug, modelDiscoveryError\)/,
+      'new connections with a discovery strategy must fetch the current catalog immediately',
     );
     assert.doesNotMatch(src, /ProviderPageHeader|providerInlineEditor/, 'creation must not retain an in-pane child editor');
+  });
+
+  it('refreshes discoverable providers after credential or endpoint changes', async () => {
+    const detail = await readFile(
+      resolve(
+        REPO_ROOT,
+        'apps',
+        'desktop',
+        'src',
+        'renderer',
+        'settings',
+        'use-connection-detail.ts',
+      ),
+      'utf8',
+    );
+
+    assert.match(
+      detail,
+      /const supportsRemoteDiscovery = defaults\.modelDiscovery\.kind !== 'fallback';/,
+      'connection detail must derive refresh support from the provider discovery contract',
+    );
+    assert.match(
+      detail,
+      /if \([\s\S]*supportsRemoteDiscovery[\s\S]*&&[\s\S]*\(wroteNewKey \|\| hasBaseUrlChange \|\| models\.length === 0\)[\s\S]*\) \{[\s\S]*refreshModels\(\{ silent: true \}\)/,
+      'saving a new credential or endpoint must refresh the remote model catalog',
+    );
   });
 
   it('OAuth login uses the same centered connection dialog as API providers', async () => {

--- a/apps/desktop/src/main/connection-model-discovery.ts
+++ b/apps/desktop/src/main/connection-model-discovery.ts
@@ -1,0 +1,49 @@
+import {
+  PROVIDER_DEFAULTS,
+  providerAuthRequiresSecret,
+  type ModelDiscoveryResult,
+} from '@maka/core/llm-connections';
+import { fetchProviderModels } from '@maka/runtime';
+import type { ConnectionStore } from '@maka/storage';
+
+export interface ConnectionModelDiscoveryDeps {
+  connectionStore: Pick<ConnectionStore, 'get' | 'update'>;
+  resolveConnectionSecret(slug: string): Promise<string | null>;
+  fetchModels?: typeof fetchProviderModels;
+  now?: () => number;
+}
+
+export async function discoverConnectionModels(
+  deps: ConnectionModelDiscoveryDeps,
+  slug: string,
+): Promise<ModelDiscoveryResult> {
+  const connection = await deps.connectionStore.get(slug);
+  if (!connection) throw new Error(`找不到模型连接：${slug}`);
+  const defaults = PROVIDER_DEFAULTS[connection.providerType];
+  if (!defaults || defaults.modelDiscovery.kind === 'fallback') {
+    throw new Error(`Provider "${connection.providerType}" does not support remote model discovery`);
+  }
+  const apiKey = await deps.resolveConnectionSecret(slug);
+  if (providerAuthRequiresSecret(connection.providerType) && !apiKey) {
+    throw new Error(
+      defaults.authKind === 'oauth_token'
+        ? '这个 OAuth 模型连接还没有登录'
+        : '这个模型连接还没有保存 API key',
+    );
+  }
+  const fetchedAt = (deps.now ?? Date.now)();
+  const models = await (deps.fetchModels ?? fetchProviderModels)(connection, apiKey ?? '');
+  if (models.length === 0) {
+    throw new Error('Provider returned no usable models');
+  }
+  await deps.connectionStore.update(slug, {
+    models,
+    modelSource: 'fetched',
+    modelsFetchedAt: fetchedAt,
+  });
+  return {
+    models,
+    source: 'fetched',
+    fetchedAt,
+  };
+}

--- a/apps/desktop/src/main/connection-model-discovery.ts
+++ b/apps/desktop/src/main/connection-model-discovery.ts
@@ -1,6 +1,7 @@
 import {
   PROVIDER_DEFAULTS,
   providerAuthRequiresSecret,
+  providerSupportsModelDiscovery,
   type ModelDiscoveryResult,
 } from '@maka/core/llm-connections';
 import { fetchProviderModels } from '@maka/runtime';
@@ -13,19 +14,25 @@ export interface ConnectionModelDiscoveryDeps {
   now?: () => number;
 }
 
+export class ConnectionModelDiscoveryPreconditionError extends Error {
+  override readonly name = 'ConnectionModelDiscoveryPreconditionError';
+}
+
 export async function discoverConnectionModels(
   deps: ConnectionModelDiscoveryDeps,
   slug: string,
 ): Promise<ModelDiscoveryResult> {
   const connection = await deps.connectionStore.get(slug);
-  if (!connection) throw new Error(`找不到模型连接：${slug}`);
+  if (!connection) throw new ConnectionModelDiscoveryPreconditionError(`找不到模型连接：${slug}`);
   const defaults = PROVIDER_DEFAULTS[connection.providerType];
-  if (!defaults || defaults.modelDiscovery.kind === 'fallback') {
-    throw new Error(`Provider "${connection.providerType}" does not support remote model discovery`);
+  if (!defaults || !providerSupportsModelDiscovery(connection.providerType)) {
+    throw new ConnectionModelDiscoveryPreconditionError(
+      `Provider "${connection.providerType}" does not support remote model discovery`,
+    );
   }
   const apiKey = await deps.resolveConnectionSecret(slug);
   if (providerAuthRequiresSecret(connection.providerType) && !apiKey) {
-    throw new Error(
+    throw new ConnectionModelDiscoveryPreconditionError(
       defaults.authKind === 'oauth_token'
         ? '这个 OAuth 模型连接还没有登录'
         : '这个模型连接还没有保存 API key',

--- a/apps/desktop/src/main/connections-ipc-main.ts
+++ b/apps/desktop/src/main/connections-ipc-main.ts
@@ -12,7 +12,10 @@ import { PROVIDER_DEFAULTS, providerAuthRequiresSecret } from '@maka/core/llm-co
 import type { LlmConnection } from '@maka/core/llm-connections';
 import { testConnection } from '@maka/runtime';
 import { createConnectionStore } from '@maka/storage';
-import { discoverConnectionModels } from './connection-model-discovery.js';
+import {
+  ConnectionModelDiscoveryPreconditionError,
+  discoverConnectionModels,
+} from './connection-model-discovery.js';
 import { createFileCredentialStore } from './credential-store.js';
 import { createConnectionWithCredential } from './create-connection-with-credential.js';
 import { connectionTestStatusPatch } from './connection-test-status.js';
@@ -228,6 +231,7 @@ export function registerConnectionsIpc(deps: ConnectionsIpcDeps): void {
       emitConnectionListChanged();
       return result;
     } catch (error) {
+      if (error instanceof ConnectionModelDiscoveryPreconditionError) throw error;
       throw new Error(generalizedErrorMessageChinese(error, '拉取模型列表失败'));
     }
   });

--- a/apps/desktop/src/main/connections-ipc-main.ts
+++ b/apps/desktop/src/main/connections-ipc-main.ts
@@ -10,8 +10,9 @@ import type {
 } from '@maka/core';
 import { PROVIDER_DEFAULTS, providerAuthRequiresSecret } from '@maka/core/llm-connections';
 import type { LlmConnection } from '@maka/core/llm-connections';
-import { fetchProviderModels, testConnection } from '@maka/runtime';
+import { testConnection } from '@maka/runtime';
 import { createConnectionStore } from '@maka/storage';
+import { discoverConnectionModels } from './connection-model-discovery.js';
 import { createFileCredentialStore } from './credential-store.js';
 import { createConnectionWithCredential } from './create-connection-with-credential.js';
 import { connectionTestStatusPatch } from './connection-test-status.js';
@@ -219,28 +220,13 @@ export function registerConnectionsIpc(deps: ConnectionsIpcDeps): void {
   });
   ipcMain.handle('connections:fetchModels', async (_event, slug: string) => {
     slug = normalizeConnectionSlugForIpc(slug, 'connection slug');
-    const connection = await connectionStore.get(slug);
-    if (!connection) throw new Error(`找不到模型连接：${slug}`);
-    const apiKey = await resolveConnectionSecret(slug);
-    if (providerAuthRequiresSecret(connection.providerType) && !apiKey) {
-      throw new Error(PROVIDER_DEFAULTS[connection.providerType].authKind === 'oauth_token'
-        ? '这个 OAuth 模型连接还没有登录'
-        : '这个模型连接还没有保存 API key');
-    }
     try {
-      const fetchedAt = Date.now();
-      const models = await fetchProviderModels(connection, apiKey ?? '');
-      await connectionStore.update(slug, {
-        models,
-        modelSource: 'fetched',
-        modelsFetchedAt: fetchedAt,
-      });
+      const result = await discoverConnectionModels({
+        connectionStore,
+        resolveConnectionSecret,
+      }, slug);
       emitConnectionListChanged();
-      return {
-        models,
-        source: 'fetched',
-        fetchedAt,
-      };
+      return result;
     } catch (error) {
       throw new Error(generalizedErrorMessageChinese(error, '拉取模型列表失败'));
     }

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -5,7 +5,11 @@ import {
   validateSlug,
   type ProviderType,
 } from '@maka/core';
-import { providerAuthRequiresSecret, providerAuthSupportsApiKey } from '@maka/core/llm-connections';
+import {
+  providerAuthRequiresSecret,
+  providerAuthSupportsApiKey,
+  providerSupportsModelDiscovery,
+} from '@maka/core/llm-connections';
 import { Alert, AlertDescription, AlertTitle, Button, Chip, Input, useMountedRef, useUiLocale } from '@maka/ui';
 import { buildCatalogRecommendedDefaultModel } from '../model-catalog-choices';
 import { PasswordInput } from './password-input';
@@ -48,7 +52,7 @@ export function AddProviderForm(props: {
   const isCustomRelay = defaults.category === 'custom';
   const isExperimental = defaults.status === 'phase3-experimental';
   const isWiredOAuth = isWiredOAuthProvider(props.providerType);
-  const supportsRemoteDiscovery = defaults.modelDiscovery.kind !== 'fallback';
+  const supportsRemoteDiscovery = providerSupportsModelDiscovery(props.providerType);
   const supportsApiKey = providerAuthSupportsApiKey(props.providerType);
   const requiresApiKey = providerAuthRequiresSecret(props.providerType) && supportsApiKey;
   const usesApiKeyDialog = usesQuickApiKeyDialog(props.providerType);
@@ -96,7 +100,7 @@ export function AddProviderForm(props: {
         try {
           await props.bridge.fetchModels(connection.slug);
         } catch (error) {
-          modelDiscoveryError = error;
+          if (!isCustomRelay) modelDiscoveryError = error;
         }
       }
       if (!addProviderMountedRef.current) return;

--- a/apps/desktop/src/renderer/settings/provider-add-form.tsx
+++ b/apps/desktop/src/renderer/settings/provider-add-form.tsx
@@ -48,6 +48,7 @@ export function AddProviderForm(props: {
   const isCustomRelay = defaults.category === 'custom';
   const isExperimental = defaults.status === 'phase3-experimental';
   const isWiredOAuth = isWiredOAuthProvider(props.providerType);
+  const supportsRemoteDiscovery = defaults.modelDiscovery.kind !== 'fallback';
   const supportsApiKey = providerAuthSupportsApiKey(props.providerType);
   const requiresApiKey = providerAuthRequiresSecret(props.providerType) && supportsApiKey;
   const usesApiKeyDialog = usesQuickApiKeyDialog(props.providerType);
@@ -90,17 +91,14 @@ export function AddProviderForm(props: {
         ...(normalizedApiKey ? { apiKey: normalizedApiKey } : {}),
       });
       if (!addProviderMountedRef.current) return;
-      // Local connections should reflect the daemon actually running on this
-      // machine instead of remaining on a static or empty fallback catalog.
       let modelDiscoveryError: unknown;
-      if (defaults.category === 'local') {
+      if (supportsRemoteDiscovery) {
         try {
           await props.bridge.fetchModels(connection.slug);
         } catch (error) {
           modelDiscoveryError = error;
         }
       }
-      if (isCustomRelay) await props.bridge.fetchModels(connection.slug).catch(() => undefined);
       if (!addProviderMountedRef.current) return;
       await props.onCreated(connection.slug, modelDiscoveryError);
     } catch (err) {

--- a/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-detail.tsx
@@ -107,6 +107,7 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
     usesGitHubCopilotLogin,
     oauthLoginService,
     hasFixedOAuthBaseUrl,
+    supportsRemoteDiscovery,
     credentialProbePending,
     hasUsableCredential,
     apiKeyStatusHint,
@@ -245,9 +246,11 @@ function ConnectionDetailInner(props: ConnectionDetailProps) {
             <Button variant="secondary" type="button" disabled={detailActionBusy || !hasUsableCredential} onClick={runTest}>
               {testing ? copy.testing : copy.testConnection}
             </Button>
-            <Button variant="quiet" type="button" disabled={detailActionBusy || !hasUsableCredential} onClick={() => void refreshModels()}>
-              {fetchingModels ? copy.updating : copy.updateModels}
-            </Button>
+            {supportsRemoteDiscovery && (
+              <Button variant="quiet" type="button" disabled={detailActionBusy || !hasUsableCredential} onClick={() => void refreshModels()}>
+                {fetchingModels ? copy.updating : copy.updateModels}
+              </Button>
+            )}
             {!props.isDefault && connection.enabled && (
               <Button variant="quiet" type="button" disabled={detailActionBusy} onClick={setAsDefault}>
                 {settingDefault ? copy.setting : copy.setDefault}

--- a/apps/desktop/src/renderer/settings/use-connection-detail.ts
+++ b/apps/desktop/src/renderer/settings/use-connection-detail.ts
@@ -7,7 +7,11 @@ import {
   type ModelInfo,
   type ProviderType,
 } from '@maka/core';
-import { providerAuthRequiresSecret, providerAuthSupportsApiKey } from '@maka/core/llm-connections';
+import {
+  providerAuthRequiresSecret,
+  providerAuthSupportsApiKey,
+  providerSupportsModelDiscovery,
+} from '@maka/core/llm-connections';
 import { useMountedRef, useToast, useUiLocale } from '@maka/ui';
 import { getProviderSettingsCopy } from '../locales/settings-provider-copy';
 import { buildCatalogModelChoices } from '../model-catalog-choices';
@@ -107,7 +111,7 @@ export function useConnectionDetail(props: ConnectionDetailProps) {
   const oauthLoginService = needsOAuth ? oauthLoginServiceFor(connection.providerType) : null;
   const usesGitHubCopilotLogin = connection.providerType === 'github-copilot';
   const hasFixedOAuthBaseUrl = needsOAuth && Boolean(defaults.baseUrl);
-  const supportsRemoteDiscovery = defaults.modelDiscovery.kind !== 'fallback';
+  const supportsRemoteDiscovery = providerSupportsModelDiscovery(connection.providerType);
   const requiresCredential = providerAuthRequiresSecret(connection.providerType);
   const probesCredential = supportsApiKey || needsOAuth;
   const credentialProbePending = requiresCredential && (hasSecret === 'loading' || hasSecret === 'error');

--- a/apps/desktop/src/renderer/settings/use-connection-detail.ts
+++ b/apps/desktop/src/renderer/settings/use-connection-detail.ts
@@ -463,6 +463,7 @@ export function useConnectionDetail(props: ConnectionDetailProps) {
     usesGitHubCopilotLogin,
     oauthLoginService,
     hasFixedOAuthBaseUrl,
+    supportsRemoteDiscovery,
     credentialProbePending,
     hasUsableCredential,
     apiKeyStatusHint,

--- a/apps/desktop/src/renderer/settings/use-connection-detail.ts
+++ b/apps/desktop/src/renderer/settings/use-connection-detail.ts
@@ -84,8 +84,8 @@ export function useConnectionDetail(props: ConnectionDetailProps) {
   const [enabledModelIds, setEnabledModelIds] = useState(() => connectionEnabledModelIds(connection));
   // Backend persists the model-list source alongside the model cache, so a
   // Settings restart no longer has to infer "fetched" from a non-empty array.
-  // A successful provider response may legitimately contain 0 models; source
-  // and length remain separate facts.
+  // Discovery rejects empty catalogs before persistence, while source remains
+  // explicit for compatibility with already-persisted connection records.
   const [modelSource, setModelSource] = useState<'fetched' | 'fallback'>(
     connection.modelSource ?? 'fallback',
   );
@@ -107,6 +107,7 @@ export function useConnectionDetail(props: ConnectionDetailProps) {
   const oauthLoginService = needsOAuth ? oauthLoginServiceFor(connection.providerType) : null;
   const usesGitHubCopilotLogin = connection.providerType === 'github-copilot';
   const hasFixedOAuthBaseUrl = needsOAuth && Boolean(defaults.baseUrl);
+  const supportsRemoteDiscovery = defaults.modelDiscovery.kind !== 'fallback';
   const requiresCredential = providerAuthRequiresSecret(connection.providerType);
   const probesCredential = supportsApiKey || needsOAuth;
   const credentialProbePending = requiresCredential && (hasSecret === 'loading' || hasSecret === 'error');
@@ -239,7 +240,11 @@ export function useConnectionDetail(props: ConnectionDetailProps) {
       // dropdown only contains the static fallback list (e.g. Z.ai → just
       // glm-4.7 / 4.6 / 4.5), which looks like Maka doesn't support newer
       // models. Auto-fetch on save closes that gap.
-      if ((!requiresCredential || nextHasSecret) && (wroteNewKey || models.length === 0)) {
+      if (
+        supportsRemoteDiscovery &&
+        (!requiresCredential || nextHasSecret) &&
+        (wroteNewKey || hasBaseUrlChange || models.length === 0)
+      ) {
         void refreshModels({ silent: true });
       }
     } catch (error) {
@@ -331,11 +336,9 @@ export function useConnectionDetail(props: ConnectionDetailProps) {
     const lifecycle = connectionDetailLifecycleRef.current;
     setFetchingModels(true);
     try {
-      // Backend (xuan `81ed044`) returns a `ModelDiscoveryResult` envelope —
-      // `{ models, source: 'fetched' | 'fallback', fetchedAt }` — and throws
-      // a generalizedErrorMessage on failure. We trust `result.source`
-      // verbatim instead of inferring from list length, so a provider that
-      // legitimately returns 0 models still reads as 'fetched'.
+      // Backend returns a `ModelDiscoveryResult` envelope and rejects empty or
+      // malformed catalogs before persistence. Trust its explicit source
+      // instead of reconstructing cache provenance in the renderer.
       const result = await props.bridge.fetchModels(connection.slug);
       if (!isConnectionDetailCurrent(lifecycle)) return;
       setModels(result.models);

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -27,12 +27,18 @@ import {
   persistedBaseUrl,
   providerAuthRequiresSecret,
   providerAuthSupportsApiKey,
+  providerSupportsModelDiscovery,
   reconcileConnectionAfterModelFetch,
   validateConnectionBaseUrl,
   type ProviderType,
 } from '../llm-connections.js';
 
 describe('provider compatibility contract', () => {
+  it('derives remote model discovery support from the registry strategy', () => {
+    assert.equal(providerSupportsModelDiscovery('openai'), true);
+    assert.equal(providerSupportsModelDiscovery('volcengine-ark'), false);
+  });
+
   it('exposes only supported first-class provider ids in stable order', () => {
     assert.deepEqual(Object.keys(PROVIDER_DEFAULTS), [
       'anthropic',

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -300,7 +300,7 @@ describe('provider compatibility contract', () => {
     assert.ok(!provider.baseUrl.includes('models.github.ai'));
   });
 
-  it('owns Volcengine Ark Coding Plan as a fallback-only interactive coding access path', () => {
+  it('owns Volcengine Ark Coding Plan as a remotely discoverable coding access path', () => {
     const provider = (
       PROVIDER_REGISTRY as Partial<
         Record<string, (typeof PROVIDER_REGISTRY)[keyof typeof PROVIDER_REGISTRY]>
@@ -313,7 +313,7 @@ describe('provider compatibility contract', () => {
     assert.equal(provider.authKind, 'api_key');
     assert.equal(provider.protocol, 'openai');
     assert.deepEqual(provider.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
-    assert.deepEqual(provider.modelDiscovery, { kind: 'fallback' });
+    assert.deepEqual(provider.modelDiscovery, { kind: 'protocol' });
     assert.equal(provider.catalogGroup, 'plans');
     assert.deepEqual(provider.fallbackModels, [
       'ark-code-latest',
@@ -700,7 +700,7 @@ describe('provider compatibility contract', () => {
       requireBaseUrl: true,
       replayAssistantReasoningAs: 'reasoning',
     });
-    assert.deepEqual(cloudflare.modelDiscovery, { kind: 'fallback' });
+    assert.deepEqual(cloudflare.modelDiscovery, { kind: 'cloudflare' });
     assert.equal(cloudflare.category, 'overseas');
     assert.equal(cloudflare.catalogGroup, 'api');
     assert.equal(cloudflare.modelsDevId, 'cloudflare-workers-ai');
@@ -882,7 +882,7 @@ describe('provider compatibility contract', () => {
     assert.equal(plan.authKind, 'api_key');
     assert.equal(plan.protocol, 'openai');
     assert.deepEqual(plan.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
-    assert.deepEqual(plan.modelDiscovery, { kind: 'fallback' });
+    assert.deepEqual(plan.modelDiscovery, { kind: 'protocol' });
     assert.equal(plan.category, 'domestic');
     assert.equal(plan.catalogGroup, 'plans');
     assert.equal(plan.catalogBadge, 'Coding');
@@ -904,7 +904,7 @@ describe('provider compatibility contract', () => {
     assert.equal(plan.authKind, 'api_key');
     assert.equal(plan.protocol, 'openai');
     assert.deepEqual(plan.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
-    assert.deepEqual(plan.modelDiscovery, { kind: 'fallback' });
+    assert.deepEqual(plan.modelDiscovery, { kind: 'protocol' });
     assert.equal(plan.category, 'domestic');
     assert.equal(plan.catalogGroup, 'plans');
     assert.equal(plan.catalogBadge, 'Token');
@@ -957,7 +957,7 @@ describe('provider compatibility contract', () => {
     assert.equal(plan.status, 'ready');
     assert.equal(plan.protocol, 'openai');
     assert.deepEqual(plan.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
-    assert.deepEqual(plan.modelDiscovery, { kind: 'fallback' });
+    assert.deepEqual(plan.modelDiscovery, { kind: 'protocol' });
     assert.equal(plan.category, 'domestic');
     assert.equal(plan.catalogGroup, 'plans');
     assert.equal(plan.catalogBadge, 'Plan');
@@ -981,7 +981,7 @@ describe('provider compatibility contract', () => {
     assert.equal(plan.status, 'ready');
     assert.equal(plan.protocol, 'openai');
     assert.deepEqual(plan.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
-    assert.deepEqual(plan.modelDiscovery, { kind: 'fallback' });
+    assert.deepEqual(plan.modelDiscovery, { kind: 'protocol' });
     assert.equal(plan.category, 'overseas');
     assert.equal(plan.catalogGroup, 'plans');
     assert.equal(plan.catalogBadge, 'Plan');
@@ -1042,7 +1042,7 @@ describe('provider compatibility contract', () => {
     assert.equal(plan.authKind, 'api_key');
     assert.equal(plan.protocol, 'openai');
     assert.deepEqual(plan.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
-    assert.deepEqual(plan.modelDiscovery, { kind: 'fallback' });
+    assert.deepEqual(plan.modelDiscovery, { kind: 'protocol' });
     assert.equal(plan.category, 'domestic');
     assert.equal(plan.catalogGroup, 'plans');
     assert.equal(plan.catalogBadge, 'Token');
@@ -1081,7 +1081,7 @@ describe('provider compatibility contract', () => {
     assert.equal(plan.authKind, 'api_key');
     assert.equal(plan.protocol, 'openai');
     assert.deepEqual(plan.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
-    assert.deepEqual(plan.modelDiscovery, { kind: 'fallback' });
+    assert.deepEqual(plan.modelDiscovery, { kind: 'protocol' });
     assert.equal(plan.category, 'overseas');
     assert.equal(plan.catalogGroup, 'plans');
     assert.equal(plan.catalogBadge, 'Token');
@@ -1131,7 +1131,7 @@ describe('provider compatibility contract', () => {
       assert.equal(plan.authKind, 'api_key');
       assert.equal(plan.protocol, 'openai');
       assert.deepEqual(plan.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
-      assert.deepEqual(plan.modelDiscovery, { kind: 'fallback' });
+      assert.deepEqual(plan.modelDiscovery, { kind: 'protocol' });
       assert.equal(plan.category, region.category);
       assert.equal(plan.catalogGroup, 'plans');
       assert.equal(plan.catalogBadge, 'Token');
@@ -1187,7 +1187,7 @@ describe('provider compatibility contract', () => {
     assert.equal(plan.authKind, 'api_key');
     assert.equal(plan.protocol, 'openai');
     assert.deepEqual(plan.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
-    assert.deepEqual(plan.modelDiscovery, { kind: 'fallback' });
+    assert.deepEqual(plan.modelDiscovery, { kind: 'protocol' });
     assert.equal(plan.category, 'domestic');
     assert.equal(plan.catalogGroup, 'plans');
     assert.equal(plan.catalogBadge, 'Plan');
@@ -1214,7 +1214,7 @@ describe('provider compatibility contract', () => {
     assert.equal(plan.authKind, 'api_key');
     assert.equal(plan.protocol, 'openai');
     assert.deepEqual(plan.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
-    assert.deepEqual(plan.modelDiscovery, { kind: 'fallback' });
+    assert.deepEqual(plan.modelDiscovery, { kind: 'protocol' });
     assert.equal(plan.category, 'overseas');
     assert.equal(plan.catalogGroup, 'plans');
     assert.equal(plan.catalogBadge, 'Plan');
@@ -1268,7 +1268,11 @@ describe('provider compatibility contract', () => {
     assert.equal(ark.authKind, 'api_key');
     assert.equal(ark.protocol, 'openai');
     assert.deepEqual(ark.runtimeAdapter, { kind: 'openai-compatible', name: 'provider' });
-    assert.deepEqual(ark.modelDiscovery, { kind: 'fallback' });
+    assert.deepEqual(ark.modelDiscovery, {
+      kind: 'fallback',
+      reason:
+        'Ark model discovery is a control-plane API that requires AK/SK signing; inference API keys cannot call it',
+    });
     assert.equal(ark.category, 'domestic');
     assert.equal(ark.catalogGroup, 'api');
     assert.equal(ark.signupUrl, 'https://console.volcengine.com/ark/region:ark+cn-beijing/model');

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -1089,6 +1089,24 @@ describe('ModelCatalogEntry', () => {
     );
   });
 
+  it('treats the registry snapshot as authoritative for fallback-only providers', () => {
+    const entries = buildConnectionModelCatalogEntries({
+      connection: {
+        slug: 'volcengine-ark',
+        providerType: 'volcengine-ark',
+        defaultModel: 'doubao-seed-2-0-pro-260215',
+        models: [{ id: 'stale-cli-snapshot' }],
+        modelSource: 'fetched',
+        modelsFetchedAt: 1,
+      },
+    });
+
+    assert.ok(entries.some((entry) => entry.id === 'doubao-seed-2-0-pro-260215'));
+    assert.ok(!entries.some((entry) => entry.id === 'stale-cli-snapshot'));
+    assert.ok(entries.every((entry) => entry.source === 'static_catalog'));
+    assert.ok(entries.every((entry) => entry.provenance.modelSource === 'fallback'));
+  });
+
   it('carries display names separately from stable model ids', () => {
     const [fetchedEntry] = buildModelCatalogEntries({
       providerType: 'openai-codex',

--- a/packages/core/src/__tests__/provider-auth.test.ts
+++ b/packages/core/src/__tests__/provider-auth.test.ts
@@ -66,7 +66,7 @@ describe('ProviderAuth contract', () => {
     expect(contract.actionAvailability.fetch_models).toBe('available');
   });
 
-  test('Cloudflare Workers AI uses API-token auth with honest snapshot model discovery', () => {
+  test('Cloudflare Workers AI uses API-token auth with native model discovery', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'cloudflare-workers-ai',
       hasSecret: true,
@@ -76,10 +76,10 @@ describe('ProviderAuth contract', () => {
     expect(contract.setupMode).toBe('api_key');
     expect(contract.requiresSecret).toBe(true);
     expect(contract.actionAvailability.test_credentials).toBe('available');
-    expect(contract.actionAvailability.fetch_models).toBe('hidden');
+    expect(contract.actionAvailability.fetch_models).toBe('available');
   });
 
-  test('Volcengine Ark Coding Plan uses an isolated API key and hides unsupported refresh', () => {
+  test('Volcengine Ark Coding Plan uses an isolated API key and remote refresh', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'volcengine-coding-plan',
       hasSecret: true,
@@ -89,10 +89,10 @@ describe('ProviderAuth contract', () => {
     expect(contract.setupMode).toBe('api_key');
     expect(contract.requiresSecret).toBe(true);
     expect(contract.actionAvailability.test_credentials).toBe('available');
-    expect(contract.actionAvailability.fetch_models).toBe('hidden');
+    expect(contract.actionAvailability.fetch_models).toBe('available');
   });
 
-  test('Tencent Token Plan uses an independent API key and fallback-model flow', () => {
+  test('Tencent Token Plan uses an independent API key and remote model flow', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'tencent-token-plan',
       hasSecret: true,
@@ -102,10 +102,10 @@ describe('ProviderAuth contract', () => {
     expect(contract.setupMode).toBe('api_key');
     expect(contract.requiresSecret).toBe(true);
     expect(contract.actionAvailability.test_credentials).toBe('available');
-    expect(contract.actionAvailability.fetch_models).toBe('hidden');
+    expect(contract.actionAvailability.fetch_models).toBe('available');
   });
 
-  test('Alibaba Token Plan variants use an independent API key and fallback-model flow', () => {
+  test('Alibaba Token Plan variants use an independent API key and remote model flow', () => {
     for (const providerType of ['alibaba-token-plan-cn', 'alibaba-token-plan'] as const) {
       const contract = deriveProviderAuthContract({ providerType, hasSecret: true });
 
@@ -113,7 +113,7 @@ describe('ProviderAuth contract', () => {
       expect(contract.setupMode).toBe('api_key');
       expect(contract.requiresSecret).toBe(true);
       expect(contract.actionAvailability.test_credentials).toBe('available');
-      expect(contract.actionAvailability.fetch_models).toBe('hidden');
+      expect(contract.actionAvailability.fetch_models).toBe('available');
     }
   });
 
@@ -122,7 +122,7 @@ describe('ProviderAuth contract', () => {
     'xiaomi-token-plan-sgp',
     'xiaomi-token-plan-ams',
   ] as const) {
-    test(`${providerType} uses an independent API key and fallback-model flow`, () => {
+    test(`${providerType} uses an independent API key and remote model flow`, () => {
       const contract = deriveProviderAuthContract({
         providerType,
         hasSecret: true,
@@ -132,11 +132,11 @@ describe('ProviderAuth contract', () => {
       expect(contract.setupMode).toBe('api_key');
       expect(contract.requiresSecret).toBe(true);
       expect(contract.actionAvailability.test_credentials).toBe('available');
-      expect(contract.actionAvailability.fetch_models).toBe('hidden');
+      expect(contract.actionAvailability.fetch_models).toBe('available');
     });
   }
 
-  test('Tencent Coding Plan uses the shared API-key credential and fallback-model flow', () => {
+  test('Tencent Coding Plan uses the shared API-key credential and remote model flow', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'tencent-coding-plan',
       hasSecret: true,
@@ -146,10 +146,10 @@ describe('ProviderAuth contract', () => {
     expect(contract.setupMode).toBe('api_key');
     expect(contract.requiresSecret).toBe(true);
     expect(contract.actionAvailability.test_credentials).toBe('available');
-    expect(contract.actionAvailability.fetch_models).toBe('hidden');
+    expect(contract.actionAvailability.fetch_models).toBe('available');
   });
 
-  test('Alibaba Coding Plan (China) uses an independent API key and fallback-model flow', () => {
+  test('Alibaba Coding Plan (China) uses an independent API key and remote model flow', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'alibaba-coding-plan-cn',
       hasSecret: true,
@@ -159,10 +159,10 @@ describe('ProviderAuth contract', () => {
     expect(contract.setupMode).toBe('api_key');
     expect(contract.requiresSecret).toBe(true);
     expect(contract.actionAvailability.test_credentials).toBe('available');
-    expect(contract.actionAvailability.fetch_models).toBe('hidden');
+    expect(contract.actionAvailability.fetch_models).toBe('available');
   });
 
-  test('Alibaba Coding Plan (global) uses an independent API key and fallback-model flow', () => {
+  test('Alibaba Coding Plan (global) uses an independent API key and remote model flow', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'alibaba-coding-plan',
       hasSecret: true,
@@ -172,7 +172,7 @@ describe('ProviderAuth contract', () => {
     expect(contract.setupMode).toBe('api_key');
     expect(contract.requiresSecret).toBe(true);
     expect(contract.actionAvailability.test_credentials).toBe('available');
-    expect(contract.actionAvailability.fetch_models).toBe('hidden');
+    expect(contract.actionAvailability.fetch_models).toBe('available');
   });
 
   test('StepFun Global uses an independent API-key credential and model-discovery flow', () => {
@@ -201,7 +201,7 @@ describe('ProviderAuth contract', () => {
     expect(contract.actionAvailability.fetch_models).toBe('available');
   });
 
-  test('StepFun Step Plan China uses an independent API-key credential and snapshot-model flow', () => {
+  test('StepFun Step Plan China uses an independent API-key credential and remote model flow', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'stepfun-step-plan',
       hasSecret: true,
@@ -211,10 +211,10 @@ describe('ProviderAuth contract', () => {
     expect(contract.setupMode).toBe('api_key');
     expect(contract.requiresSecret).toBe(true);
     expect(contract.actionAvailability.test_credentials).toBe('available');
-    expect(contract.actionAvailability.fetch_models).toBe('hidden');
+    expect(contract.actionAvailability.fetch_models).toBe('available');
   });
 
-  test('StepFun Step Plan Global uses an independent API-key credential and snapshot-model flow', () => {
+  test('StepFun Step Plan Global uses an independent API-key credential and remote model flow', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'stepfun-ai-step-plan',
       hasSecret: true,
@@ -224,10 +224,10 @@ describe('ProviderAuth contract', () => {
     expect(contract.setupMode).toBe('api_key');
     expect(contract.requiresSecret).toBe(true);
     expect(contract.actionAvailability.test_credentials).toBe('available');
-    expect(contract.actionAvailability.fetch_models).toBe('hidden');
+    expect(contract.actionAvailability.fetch_models).toBe('available');
   });
 
-  test('Volcengine Ark China uses the shared API-key credential and snapshot-model flow', () => {
+  test('Volcengine Ark China keeps refresh hidden because discovery requires control-plane credentials', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'volcengine-ark',
       hasSecret: true,

--- a/packages/core/src/__tests__/provider-catalog-contract.test.ts
+++ b/packages/core/src/__tests__/provider-catalog-contract.test.ts
@@ -154,4 +154,21 @@ describe('provider catalog contract — structural invariants over CATALOG_PROVI
       }
     }
   });
+
+  it('requires an operational reason for every ready remote provider without live discovery', () => {
+    for (const [type, def] of Object.entries(PROVIDER_REGISTRY)) {
+      if (
+        def.status !== 'ready' ||
+        def.category === 'local' ||
+        def.category === 'custom' ||
+        def.modelDiscovery.kind !== 'fallback'
+      ) {
+        continue;
+      }
+      assert.ok(
+        def.modelDiscovery.reason.trim().length > 0,
+        `${type} must explain why its inference credential cannot discover models`,
+      );
+    }
+  });
 });

--- a/packages/core/src/__tests__/provider-contract-matrix.test.ts
+++ b/packages/core/src/__tests__/provider-contract-matrix.test.ts
@@ -122,8 +122,13 @@ describe('provider contract matrix — discovery derivation', () => {
     assert.equal(localai.state === 'generated' && localai.discovery?.auth, 'optional');
   });
 
-  it('marks fireworks / cohere / ollama discovery as override', () => {
-    for (const providerType of ['fireworks-ai', 'cohere', 'ollama'] as const) {
+  it('marks provider-native discovery as override', () => {
+    for (const providerType of [
+      'fireworks-ai',
+      'cohere',
+      'ollama',
+      'cloudflare-workers-ai',
+    ] as const) {
       const cell = cellFor(providerType, 'discovery');
       assert.equal(cell.state, 'override', `${providerType} discovery should be override`);
     }
@@ -133,19 +138,32 @@ describe('provider contract matrix — discovery derivation', () => {
     assert.equal(cellFor('github-copilot', 'discovery').state, 'override');
   });
 
-  it('marks fallback discovery not-applicable with a no-/models reverse assertion', () => {
+  it('generates protocol discovery for providers migrated from static fallback snapshots', () => {
     for (const providerType of [
-      'volcengine-ark',
       'tencent-coding-plan',
-      'cloudflare-workers-ai',
+      'volcengine-coding-plan',
+      'tencent-token-plan',
+      'xiaomi-token-plan-cn',
+      'stepfun-step-plan',
+      'alibaba-coding-plan',
+      'alibaba-token-plan',
     ] as const) {
       const cell = cellFor(providerType, 'discovery');
-      assert.equal(cell.state, 'not-applicable', `${providerType} discovery should be N/A`);
-      assert.equal(
-        cell.state === 'not-applicable' ? cell.reverseAssertion : undefined,
-        'must-not-request-models-endpoint',
-      );
+      assert.equal(cell.state, 'generated', `${providerType} discovery should be generated`);
     }
+  });
+
+  it('keeps inference-key-inaccessible control-plane discovery explicitly not applicable', () => {
+    const cell = cellFor('volcengine-ark', 'discovery');
+    assert.equal(cell.state, 'not-applicable');
+    assert.match(
+      cell.state === 'not-applicable' ? cell.reason : '',
+      /control-plane API.*AK\/SK signing/,
+    );
+    assert.equal(
+      cell.state === 'not-applicable' ? cell.reverseAssertion : undefined,
+      'must-not-request-models-endpoint',
+    );
   });
 });
 
@@ -274,7 +292,10 @@ describe('provider contract matrix — derivation is a total function over a fix
         status: 'phase3-experimental',
         protocol: 'openai',
         runtimeAdapter: { kind: 'unavailable' },
-        modelDiscovery: { kind: 'fallback' },
+        modelDiscovery: {
+          kind: 'fallback',
+          reason: 'The inference credential cannot access a model-list API',
+        },
         category: 'oauth',
       },
     };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1225,6 +1225,7 @@ export {
   normalizeConnectionBaseUrl,
   normalizeProviderType,
   persistedBaseUrl,
+  providerSupportsModelDiscovery,
   validateConnectionBaseUrl,
   validateSlug,
 } from './llm-connections.js';

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -206,6 +206,11 @@ export function providerAuthSupportsApiKey(providerType: ProviderType): boolean 
   return authKind === 'api_key' || authKind === 'optional_api_key';
 }
 
+export function providerSupportsModelDiscovery(providerType: ProviderType): boolean {
+  const discovery = PROVIDER_DEFAULTS[providerType]?.modelDiscovery;
+  return discovery !== undefined && discovery.kind !== 'fallback';
+}
+
 export function backendKindOf(c: Pick<LlmConnection, 'providerType'>): BackendKind {
   // Unknown providerType (legacy seed, or a connection persisted on a branch
   // that registers a provider this build doesn't know) → treat as non-real,

--- a/packages/core/src/model-catalog.ts
+++ b/packages/core/src/model-catalog.ts
@@ -4,7 +4,7 @@ import type {
   ModelInfo,
   ProviderType,
 } from './llm-connections.js';
-import { PROVIDER_DEFAULTS } from './llm-connections.js';
+import { PROVIDER_DEFAULTS, providerSupportsModelDiscovery } from './llm-connections.js';
 import type { PricingConfig } from './usage-stats/types.js';
 import { curatedCatalogFallbackModelsForProvider, lookupModelMetadata } from './model-metadata.js';
 
@@ -195,15 +195,19 @@ export function buildConnectionModelCatalogEntries(
   // that registers a provider this build doesn't know) → no catalog entries.
   // Mirrors `isFakeBackend` in connection-readiness.ts.
   if (!defaults) return [];
+  const supportsModelDiscovery = providerSupportsModelDiscovery(connection.providerType);
   const catalogFallbackModels = curatedCatalogFallbackModelsForProvider(connection.providerType);
+  const fallbackModels = [...(catalogFallbackModels ?? defaults.fallbackModels)];
   return buildModelCatalogEntries({
     providerType: connection.providerType,
     connectionSlug: connection.slug,
     defaultModel: connection.defaultModel,
-    models: connection.models,
-    modelSource: connection.modelSource,
-    modelsFetchedAt: connection.modelsFetchedAt,
-    fallbackModels: input.fallbackModels ?? [...(catalogFallbackModels ?? defaults.fallbackModels)],
+    models: supportsModelDiscovery ? connection.models : undefined,
+    modelSource: supportsModelDiscovery ? connection.modelSource : 'fallback',
+    modelsFetchedAt: supportsModelDiscovery ? connection.modelsFetchedAt : undefined,
+    fallbackModels: supportsModelDiscovery
+      ? (input.fallbackModels ?? fallbackModels)
+      : fallbackModels,
     now: input.now,
     staleAfterMs: input.staleAfterMs,
     providerAvailable: input.providerAvailable,

--- a/packages/core/src/provider-auth.ts
+++ b/packages/core/src/provider-auth.ts
@@ -2,6 +2,7 @@ import {
   PROVIDER_DEFAULTS,
   isWiredOAuthProvider,
   providerAuthRequiresSecret,
+  providerSupportsModelDiscovery,
   type ConnectionAuth,
   type ConnectionLastTestStatus,
   type LlmConnection,
@@ -84,7 +85,7 @@ export function deriveProviderAuthContract(input: ProviderAuthContractInput): Pr
       },
     };
   }
-  const supportsModelDiscovery = defaults.modelDiscovery.kind !== 'fallback';
+  const supportsModelDiscovery = providerSupportsModelDiscovery(input.providerType);
   const actionAvailability = hiddenActions();
 
   if (!enabled) {

--- a/packages/core/src/provider-contract-matrix.ts
+++ b/packages/core/src/provider-contract-matrix.ts
@@ -109,7 +109,7 @@ export type ProviderContractReverseAssertion = 'must-not-request-models-endpoint
 export interface ProviderContractNotApplicableCell {
   state: 'not-applicable';
   dimension: ProviderContractDimension;
-  /** Machine-readable justification derived from the declaration. */
+  /** Human-readable justification derived from the provider declaration. */
   reason: string;
   /** An assertion the executor must still hold even though the dimension is N/A. */
   reverseAssertion?: ProviderContractReverseAssertion;

--- a/packages/core/src/provider-contract-matrix.ts
+++ b/packages/core/src/provider-contract-matrix.ts
@@ -266,8 +266,15 @@ function discoveryCell(providerType: ProviderType, def: ProviderDefaults): Provi
       return {
         state: 'not-applicable',
         dimension: 'discovery',
-        reason: 'declares-static-fallback-model-snapshot',
+        reason: discovery.reason,
         reverseAssertion: 'must-not-request-models-endpoint',
+      };
+    case 'cloudflare':
+      return {
+        state: 'override',
+        dimension: 'discovery',
+        overrideKey: overrideKeyFor(providerType, 'discovery'),
+        contract: 'Cloudflare Workers AI native paginated /ai/models/search discovery',
       };
     case 'fireworks':
       return {

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -43,7 +43,8 @@ export type ProviderModelDiscovery =
       publicAccount: string;
       query: Readonly<Record<string, string>>;
     }
-  | { kind: 'fallback' }
+  | { kind: 'cloudflare' }
+  | { kind: 'fallback'; reason: string }
   | { kind: 'ollama' }
   | { kind: 'cohere' };
 
@@ -90,10 +91,8 @@ if (xiaomi.id !== 'xiaomi' || !xiaomi.api) {
 const xiaomiModelIds = toolCallingModelIds('Xiaomi', GENERATED_MODELS_DEV_METADATA.xiaomi, [
   'mimo-v2.5',
 ]);
-// Xiaomi MiMo Token Plan is a coding-only subscription whose /v1 endpoint publishes no
-// /models discovery contract, so this checked-in allowlist is authoritative. models.dev's
-// snapshot still carries the deprecated mimo-v2-pro and the speech-only mimo-v2-tts, which
-// must never enter the chat/tool-calling fallback set — pin the two documented MiMo chat models.
+// Keep the bootstrap snapshot limited to the two documented MiMo chat models. The remote
+// /models response becomes authoritative as soon as the user saves a working plan credential.
 const xiaomiTokenPlanModelIds = ['mimo-v2.5-pro', 'mimo-v2.5'] as const;
 const xiaomiTokenPlanCn = GENERATED_MODELS_DEV_PROVIDER_FACTS['xiaomi-token-plan-cn'];
 if (xiaomiTokenPlanCn.id !== 'xiaomi-token-plan-cn' || !xiaomiTokenPlanCn.api) {
@@ -640,7 +639,7 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'protocol' },
     category: 'domestic',
     catalogGroup: 'plans',
     catalogBadge: 'Coding',
@@ -659,7 +658,7 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'protocol' },
     category: 'domestic',
     catalogGroup: 'plans',
     catalogBadge: 'Coding',
@@ -677,7 +676,7 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'protocol' },
     category: 'domestic',
     catalogGroup: 'plans',
     catalogBadge: 'Token',
@@ -951,7 +950,7 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'protocol' },
     category: 'domestic',
     catalogGroup: 'plans',
     catalogBadge: 'Token',
@@ -971,7 +970,7 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'protocol' },
     category: 'overseas',
     catalogGroup: 'plans',
     catalogBadge: 'Token',
@@ -991,7 +990,7 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'protocol' },
     category: 'overseas',
     catalogGroup: 'plans',
     catalogBadge: 'Token',
@@ -1249,7 +1248,7 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'protocol' },
     category: 'domestic',
     catalogGroup: 'plans',
     catalogBadge: 'Plan',
@@ -1268,7 +1267,7 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'protocol' },
     category: 'overseas',
     catalogGroup: 'plans',
     catalogBadge: 'Plan',
@@ -1306,7 +1305,11 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: {
+      kind: 'fallback',
+      reason:
+        'Ark model discovery is a control-plane API that requires AK/SK signing; inference API keys cannot call it',
+    },
     category: 'domestic',
     catalogGroup: 'api',
     catalogBadge: 'API',
@@ -1400,7 +1403,7 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'protocol' },
     category: 'domestic',
     catalogGroup: 'plans',
     catalogBadge: 'Plan',
@@ -1419,7 +1422,7 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'protocol' },
     category: 'overseas',
     catalogGroup: 'plans',
     catalogBadge: 'Plan',
@@ -1439,7 +1442,7 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'protocol' },
     category: 'domestic',
     catalogGroup: 'plans',
     catalogBadge: 'Token',
@@ -1459,7 +1462,7 @@ const providerRegistry = {
     status: 'ready',
     protocol: 'openai',
     runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'protocol' },
     category: 'overseas',
     catalogGroup: 'plans',
     catalogBadge: 'Token',
@@ -1484,7 +1487,7 @@ const providerRegistry = {
       requireBaseUrl: true,
       replayAssistantReasoningAs: 'reasoning',
     },
-    modelDiscovery: { kind: 'fallback' },
+    modelDiscovery: { kind: 'cloudflare' },
     category: 'overseas',
     catalogGroup: 'api',
     catalogBadge: 'API',

--- a/packages/runtime/src/__tests__/model-fetcher.test.ts
+++ b/packages/runtime/src/__tests__/model-fetcher.test.ts
@@ -11,117 +11,26 @@ after(async () => {
 });
 
 describe('fetchProviderModels', () => {
-  test('Alibaba Coding Plan discovers the current remote catalog instead of returning its bundled snapshot', async () => {
-    const requests: Array<{ url: string; authorization: string | undefined }> = [];
-    const server = await startJsonServer((request, response) => {
-      requests.push({ url: request.url ?? '', authorization: request.headers.authorization });
-      respondJson(response, 200, {
-        object: 'list',
-        data: [{ id: 'qwen-next-after-release', object: 'model' }],
-      });
-    });
-
-    const models = await fetchProviderModels(
-      {
-        slug: 'alibaba-coding-plan',
-        name: 'Alibaba Coding Plan',
-        providerType: 'alibaba-coding-plan',
-        baseUrl: `${server.url}/v1`,
-        defaultModel: 'qwen3-coder-plus',
-        enabled: true,
-        createdAt: 1,
-        updatedAt: 1,
-      },
-      'alibaba-coding-plan-test-key',
-    );
-
-    assert.deepEqual(models, [{ id: 'qwen-next-after-release' }]);
-    assert.deepEqual(requests, [
-      {
-        url: '/v1/models',
-        authorization: 'Bearer alibaba-coding-plan-test-key',
-      },
-    ]);
-  });
-
-  test('fallback-only OpenAI-compatible providers use their inference credential for remote discovery', async () => {
-    const requests: Array<{ url: string; authorization: string | undefined }> = [];
-    const server = await startJsonServer((request, response) => {
-      requests.push({ url: request.url ?? '', authorization: request.headers.authorization });
-      respondJson(response, 200, {
-        object: 'list',
-        data: [{ id: 'provider-model-after-release', object: 'model' }],
-      });
-    });
-    const providerTypes = [
-      'tencent-coding-plan',
-      'volcengine-coding-plan',
-      'tencent-token-plan',
-      'xiaomi-token-plan-cn',
-      'xiaomi-token-plan-sgp',
-      'xiaomi-token-plan-ams',
-      'stepfun-step-plan',
-      'stepfun-ai-step-plan',
-      'alibaba-coding-plan-cn',
-      'alibaba-token-plan-cn',
-      'alibaba-token-plan',
-    ] as const;
-
-    for (const providerType of providerTypes) {
-      const models = await fetchProviderModels(
-        {
-          slug: providerType,
-          name: providerType,
-          providerType,
-          baseUrl: `${server.url}/v1`,
-          defaultModel: 'bundled-model',
-          enabled: true,
-          createdAt: 1,
-          updatedAt: 1,
-        },
-        'provider-inference-key',
-      );
-      assert.deepEqual(models, [{ id: 'provider-model-after-release' }], providerType);
-    }
-
-    assert.equal(requests.length, providerTypes.length);
-    assert.ok(
-      requests.every(
-        (request) =>
-          request.url === '/v1/models' && request.authorization === 'Bearer provider-inference-key',
-      ),
-    );
-  });
-
   test('Cloudflare Workers AI discovers text-generation models through its native paginated API', async () => {
     const requests: Array<{ url: string; authorization: string | undefined }> = [];
     const server = await startJsonServer((request, response) => {
       requests.push({ url: request.url ?? '', authorization: request.headers.authorization });
       const page = new URL(request.url ?? '', 'http://test.local').searchParams.get('page');
+      const result =
+        page === '2'
+          ? [{ name: '@cf/qwen/qwen-next' }]
+          : Array.from({ length: 50 }, (_, index) => ({
+              name: `@cf/example/text-model-${index}`,
+            }));
       respondJson(response, 200, {
         success: true,
-        result:
-          page === '2'
-            ? [
-                {
-                  id: 'numeric-internal-id-2',
-                  name: '@cf/qwen/qwen-next',
-                  task: { id: 'text-generation', name: 'Text Generation' },
-                },
-              ]
-            : [
-                {
-                  id: 'numeric-internal-id-1',
-                  name: '@cf/meta/llama-next',
-                  task: { id: 'text-generation', name: 'Text Generation' },
-                },
-                {
-                  id: 'image-model',
-                  name: '@cf/black-forest-labs/flux-next',
-                  task: { id: 'text-to-image', name: 'Text to Image' },
-                },
-              ],
-        result_info: { page: Number(page), total_pages: 2 },
+        result,
+        result_info: {
+          page: Number(page),
+          per_page: 50,
+          count: result.length,
+          total_count: 51,
+        },
       });
     });
 
@@ -139,17 +48,56 @@ describe('fetchProviderModels', () => {
       'cloudflare-api-token',
     );
 
-    assert.deepEqual(models, [{ id: '@cf/meta/llama-next' }, { id: '@cf/qwen/qwen-next' }]);
+    assert.equal(models.length, 51);
+    assert.equal(models[0]?.id, '@cf/example/text-model-0');
+    assert.equal(models[50]?.id, '@cf/qwen/qwen-next');
     assert.deepEqual(requests, [
       {
-        url: '/client/v4/accounts/account-123/ai/models/search?page=1&per_page=50',
+        url: '/client/v4/accounts/account-123/ai/models/search?page=1&per_page=50&task=Text+Generation',
         authorization: 'Bearer cloudflare-api-token',
       },
       {
-        url: '/client/v4/accounts/account-123/ai/models/search?page=2&per_page=50',
+        url: '/client/v4/accounts/account-123/ai/models/search?page=2&per_page=50&task=Text+Generation',
         authorization: 'Bearer cloudflare-api-token',
       },
     ]);
+  });
+
+  test('Cloudflare Workers AI bounds pagination before an oversized catalog can be persisted', async () => {
+    let requestCount = 0;
+    const server = await startJsonServer((_request, response) => {
+      requestCount += 1;
+      respondJson(response, 200, {
+        success: true,
+        result: Array.from({ length: 50 }, (_, index) => ({
+          name: `@cf/example/page-${requestCount}-model-${index}`,
+        })),
+        result_info: {
+          page: requestCount,
+          per_page: 50,
+          count: 50,
+          total_count: 10_000,
+        },
+      });
+    });
+
+    await assert.rejects(
+      fetchProviderModels(
+        {
+          slug: 'cloudflare-workers-ai',
+          name: 'Cloudflare Workers AI',
+          providerType: 'cloudflare-workers-ai',
+          baseUrl: `${server.url}/client/v4/accounts/account-123/ai/v1`,
+          defaultModel: '@cf/example/default',
+          enabled: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        'cloudflare-api-token',
+      ),
+      /Failed to fetch provider models/,
+    );
+    assert.equal(requestCount, 41);
   });
 
   test('OpenCode Zen and Go discover exact account model ids with their shared API-key auth shape', async () => {
@@ -804,14 +752,14 @@ describe('fetchProviderModels', () => {
     );
   });
 
-  test('discovery rejects empty responses so callers preserve the last usable snapshot', async () => {
+  test('normalization leaves empty-catalog policy to the caller that owns persistence', async () => {
     const server = await startJsonServer((_request, response) => {
       respondJson(response, 200, { data: [] });
     });
 
-    await assert.rejects(
-      fetchProviderModels({ ...zaiConnection(), baseUrl: server.url }, 'zai-live-secret'),
-      /Failed to fetch provider models/,
+    assert.deepEqual(
+      await fetchProviderModels({ ...zaiConnection(), baseUrl: server.url }, 'zai-live-secret'),
+      [],
     );
   });
 

--- a/packages/runtime/src/__tests__/model-fetcher.test.ts
+++ b/packages/runtime/src/__tests__/model-fetcher.test.ts
@@ -11,6 +11,147 @@ after(async () => {
 });
 
 describe('fetchProviderModels', () => {
+  test('Alibaba Coding Plan discovers the current remote catalog instead of returning its bundled snapshot', async () => {
+    const requests: Array<{ url: string; authorization: string | undefined }> = [];
+    const server = await startJsonServer((request, response) => {
+      requests.push({ url: request.url ?? '', authorization: request.headers.authorization });
+      respondJson(response, 200, {
+        object: 'list',
+        data: [{ id: 'qwen-next-after-release', object: 'model' }],
+      });
+    });
+
+    const models = await fetchProviderModels(
+      {
+        slug: 'alibaba-coding-plan',
+        name: 'Alibaba Coding Plan',
+        providerType: 'alibaba-coding-plan',
+        baseUrl: `${server.url}/v1`,
+        defaultModel: 'qwen3-coder-plus',
+        enabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      'alibaba-coding-plan-test-key',
+    );
+
+    assert.deepEqual(models, [{ id: 'qwen-next-after-release' }]);
+    assert.deepEqual(requests, [
+      {
+        url: '/v1/models',
+        authorization: 'Bearer alibaba-coding-plan-test-key',
+      },
+    ]);
+  });
+
+  test('fallback-only OpenAI-compatible providers use their inference credential for remote discovery', async () => {
+    const requests: Array<{ url: string; authorization: string | undefined }> = [];
+    const server = await startJsonServer((request, response) => {
+      requests.push({ url: request.url ?? '', authorization: request.headers.authorization });
+      respondJson(response, 200, {
+        object: 'list',
+        data: [{ id: 'provider-model-after-release', object: 'model' }],
+      });
+    });
+    const providerTypes = [
+      'tencent-coding-plan',
+      'volcengine-coding-plan',
+      'tencent-token-plan',
+      'xiaomi-token-plan-cn',
+      'xiaomi-token-plan-sgp',
+      'xiaomi-token-plan-ams',
+      'stepfun-step-plan',
+      'stepfun-ai-step-plan',
+      'alibaba-coding-plan-cn',
+      'alibaba-token-plan-cn',
+      'alibaba-token-plan',
+    ] as const;
+
+    for (const providerType of providerTypes) {
+      const models = await fetchProviderModels(
+        {
+          slug: providerType,
+          name: providerType,
+          providerType,
+          baseUrl: `${server.url}/v1`,
+          defaultModel: 'bundled-model',
+          enabled: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        'provider-inference-key',
+      );
+      assert.deepEqual(models, [{ id: 'provider-model-after-release' }], providerType);
+    }
+
+    assert.equal(requests.length, providerTypes.length);
+    assert.ok(
+      requests.every(
+        (request) =>
+          request.url === '/v1/models' && request.authorization === 'Bearer provider-inference-key',
+      ),
+    );
+  });
+
+  test('Cloudflare Workers AI discovers text-generation models through its native paginated API', async () => {
+    const requests: Array<{ url: string; authorization: string | undefined }> = [];
+    const server = await startJsonServer((request, response) => {
+      requests.push({ url: request.url ?? '', authorization: request.headers.authorization });
+      const page = new URL(request.url ?? '', 'http://test.local').searchParams.get('page');
+      respondJson(response, 200, {
+        success: true,
+        result:
+          page === '2'
+            ? [
+                {
+                  id: 'numeric-internal-id-2',
+                  name: '@cf/qwen/qwen-next',
+                  task: { id: 'text-generation', name: 'Text Generation' },
+                },
+              ]
+            : [
+                {
+                  id: 'numeric-internal-id-1',
+                  name: '@cf/meta/llama-next',
+                  task: { id: 'text-generation', name: 'Text Generation' },
+                },
+                {
+                  id: 'image-model',
+                  name: '@cf/black-forest-labs/flux-next',
+                  task: { id: 'text-to-image', name: 'Text to Image' },
+                },
+              ],
+        result_info: { page: Number(page), total_pages: 2 },
+      });
+    });
+
+    const models = await fetchProviderModels(
+      {
+        slug: 'cloudflare-workers-ai',
+        name: 'Cloudflare Workers AI',
+        providerType: 'cloudflare-workers-ai',
+        baseUrl: `${server.url}/client/v4/accounts/account-123/ai/v1`,
+        defaultModel: '@cf/meta/llama-next',
+        enabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      'cloudflare-api-token',
+    );
+
+    assert.deepEqual(models, [{ id: '@cf/meta/llama-next' }, { id: '@cf/qwen/qwen-next' }]);
+    assert.deepEqual(requests, [
+      {
+        url: '/client/v4/accounts/account-123/ai/models/search?page=1&per_page=50',
+        authorization: 'Bearer cloudflare-api-token',
+      },
+      {
+        url: '/client/v4/accounts/account-123/ai/models/search?page=2&per_page=50',
+        authorization: 'Bearer cloudflare-api-token',
+      },
+    ]);
+  });
+
   test('OpenCode Zen and Go discover exact account model ids with their shared API-key auth shape', async () => {
     const requests: Array<{ url: string; authorization: string | undefined }> = [];
     const server = await startJsonServer((request, response) => {
@@ -623,7 +764,7 @@ describe('fetchProviderModels', () => {
     let capturedAccountId: string | string[] | undefined;
     const server = await startJsonServer((request, response) => {
       capturedAccountId = request.headers['chatgpt-account-id'];
-      respondJson(response, 200, { models: [] });
+      respondJson(response, 200, { models: [{ slug: 'gpt-5.6-sol' }] });
     });
     await fetchProviderModels(
       {
@@ -663,9 +804,30 @@ describe('fetchProviderModels', () => {
     );
   });
 
-  test('successful empty provider responses stay fetched-empty instead of falling back', async () => {
+  test('discovery rejects empty responses so callers preserve the last usable snapshot', async () => {
     const server = await startJsonServer((_request, response) => {
       respondJson(response, 200, { data: [] });
+    });
+
+    await assert.rejects(
+      fetchProviderModels({ ...zaiConnection(), baseUrl: server.url }, 'zai-live-secret'),
+      /Failed to fetch provider models/,
+    );
+  });
+
+  test('discovery trims model IDs, drops malformed entries, and deduplicates before persistence', async () => {
+    const server = await startJsonServer((_request, response) => {
+      respondJson(response, 200, {
+        data: [
+          { id: ' model-a ' },
+          { id: 'model-a' },
+          { id: '' },
+          { id: 42 },
+          { id: 'bad\nmodel' },
+          { id: 'x'.repeat(513) },
+          { id: 'model-b', name: 'Model B' },
+        ],
+      });
     });
 
     const models = await fetchProviderModels(
@@ -673,7 +835,7 @@ describe('fetchProviderModels', () => {
       'zai-live-secret',
     );
 
-    assert.deepEqual(models, []);
+    assert.deepEqual(models, [{ id: 'model-a' }, { id: 'model-b', displayName: 'Model B' }]);
   });
 });
 

--- a/packages/runtime/src/__tests__/model-fetcher.test.ts
+++ b/packages/runtime/src/__tests__/model-fetcher.test.ts
@@ -17,11 +17,13 @@ describe('fetchProviderModels', () => {
       requests.push({ url: request.url ?? '', authorization: request.headers.authorization });
       const page = new URL(request.url ?? '', 'http://test.local').searchParams.get('page');
       const result =
-        page === '2'
-          ? [{ name: '@cf/qwen/qwen-next' }]
-          : Array.from({ length: 50 }, (_, index) => ({
-              name: `@cf/example/text-model-${index}`,
-            }));
+        page === '3'
+          ? []
+          : page === '2'
+            ? [{ name: '@cf/qwen/qwen-next' }]
+            : Array.from({ length: 50 }, (_, index) => ({
+                name: `@cf/example/text-model-${index}`,
+              }));
       respondJson(response, 200, {
         success: true,
         result,
@@ -60,7 +62,50 @@ describe('fetchProviderModels', () => {
         url: '/client/v4/accounts/account-123/ai/models/search?page=2&per_page=50&task=Text+Generation',
         authorization: 'Bearer cloudflare-api-token',
       },
+      {
+        url: '/client/v4/accounts/account-123/ai/models/search?page=3&per_page=50&task=Text+Generation',
+        authorization: 'Bearer cloudflare-api-token',
+      },
     ]);
+  });
+
+  test('Cloudflare Workers AI accepts exactly 2,048 models and rejects the first excess item', async () => {
+    for (const modelCount of [2_048, 2_049]) {
+      let requestCount = 0;
+      const server = await startJsonServer((request, response) => {
+        requestCount += 1;
+        const page = Number(
+          new URL(request.url ?? '', 'http://test.local').searchParams.get('page'),
+        );
+        const pageStart = (page - 1) * 50;
+        const result = Array.from(
+          { length: Math.max(0, Math.min(50, modelCount - pageStart)) },
+          (_, index) => ({ name: `@cf/example/model-${pageStart + index}` }),
+        );
+        respondJson(response, 200, { success: true, result });
+      });
+
+      const request = fetchProviderModels(
+        {
+          slug: 'cloudflare-workers-ai',
+          name: 'Cloudflare Workers AI',
+          providerType: 'cloudflare-workers-ai',
+          baseUrl: `${server.url}/client/v4/accounts/account-123/ai/v1`,
+          defaultModel: '@cf/example/default',
+          enabled: true,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+        'cloudflare-api-token',
+      );
+      if (modelCount === 2_048) {
+        assert.equal((await request).length, 2_048);
+        assert.equal(requestCount, 42);
+      } else {
+        await assert.rejects(request, /Failed to fetch provider models/);
+        assert.equal(requestCount, 41);
+      }
+    }
   });
 
   test('Cloudflare Workers AI bounds pagination before an oversized catalog can be persisted', async () => {

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -1336,18 +1336,21 @@ describe('models.dev provider conformance', () => {
       assert.equal(request.headers.authorization, 'Bearer cloudflare-workers-ai-test-token');
       if (
         request.method === 'GET' &&
-        request.url ===
-          '/client/v4/accounts/account-123/ai/models/search?page=1&per_page=50&task=Text+Generation'
+        request.url?.startsWith('/client/v4/accounts/account-123/ai/models/search?')
       ) {
+        const page = new URL(request.url, 'http://test.local').searchParams.get('page');
         respondJson(response, 200, {
           success: true,
-          result: [
-            {
-              name: modelId,
-              task: { id: 'text-generation', name: 'Text Generation' },
-            },
-          ],
-          result_info: { page: 1, total_pages: 1 },
+          result:
+            page === '1'
+              ? [
+                  {
+                    name: modelId,
+                    task: { id: 'text-generation', name: 'Text Generation' },
+                  },
+                ]
+              : [],
+          result_info: { page: Number(page), per_page: 50 },
         });
         return;
       }

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -1329,11 +1329,27 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.text, 'Echoed hello.');
   });
 
-  test('Cloudflare Workers AI uses snapshot models and completes its documented two-stage tool-call loop', async () => {
+  test('Cloudflare Workers AI discovers native models and completes its documented two-stage tool-call loop', async () => {
     const modelId = '@cf/moonshotai/kimi-k2.6';
     const requestBodies: Array<Record<string, unknown>> = [];
     const server = await startJsonServer(async (request, response) => {
       assert.equal(request.headers.authorization, 'Bearer cloudflare-workers-ai-test-token');
+      if (
+        request.method === 'GET' &&
+        request.url === '/client/v4/accounts/account-123/ai/models/search?page=1&per_page=50'
+      ) {
+        respondJson(response, 200, {
+          success: true,
+          result: [
+            {
+              name: modelId,
+              task: { id: 'text-generation', name: 'Text Generation' },
+            },
+          ],
+          result_info: { page: 1, total_pages: 1 },
+        });
+        return;
+      }
       assert.equal(request.method, 'POST');
       assert.equal(request.url, '/client/v4/accounts/account-123/ai/v1/chat/completions');
       const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
@@ -1394,9 +1410,7 @@ describe('models.dev provider conformance', () => {
     };
 
     const models = await fetchProviderModels(connection, 'cloudflare-workers-ai-test-token');
-    assert.equal(requestBodies.length, 0, 'snapshot fallback must not invent a discovery request');
-    assert.equal(models[0]?.id, modelId);
-    assert.ok(models.every((model) => model.id.startsWith('@cf/')));
+    assert.deepEqual(models, [{ id: modelId }]);
 
     const result = await generateText({
       model: getAIModel({
@@ -1578,11 +1592,15 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.text, 'Echoed hello.');
   });
 
-  test('Tencent Coding Plan uses fallback models and preserves its exact model id through a two-stage tool-call loop', async () => {
+  test('Tencent Coding Plan discovers models and preserves its exact model id through a two-stage tool-call loop', async () => {
     const modelId = 'glm-5';
     const requestBodies: Array<Record<string, unknown>> = [];
     const server = await startJsonServer(async (request, response) => {
       assert.equal(request.headers.authorization, 'Bearer tencent-coding-plan-test-key');
+      if (request.method === 'GET' && request.url === '/coding/v3/models') {
+        respondJson(response, 200, { object: 'list', data: [{ id: modelId }] });
+        return;
+      }
       assert.equal(request.method, 'POST');
       assert.equal(request.url, '/coding/v3/chat/completions');
       const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
@@ -1643,10 +1661,7 @@ describe('models.dev provider conformance', () => {
     };
 
     const models = await fetchProviderModels(connection, 'tencent-coding-plan-test-key');
-    assert.deepEqual(
-      models.map(({ id }) => id),
-      ['tc-code-latest', 'glm-5', 'minimax-m2.5', 'kimi-k2.5'],
-    );
+    assert.deepEqual(models, [{ id: modelId }]);
 
     const result = await generateText({
       model: getAIModel({ connection, apiKey: 'tencent-coding-plan-test-key', modelId }),
@@ -1699,11 +1714,15 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.text, 'Echoed hello.');
   });
 
-  test('Volcengine Ark Coding Plan preserves fallback model reasoning through a two-stage tool-call loop', async () => {
+  test('Volcengine Ark Coding Plan preserves discovered model reasoning through a two-stage tool-call loop', async () => {
     const modelId = 'glm-5.2';
     const requestBodies: Array<Record<string, unknown>> = [];
     const server = await startJsonServer(async (request, response) => {
       assert.equal(request.headers.authorization, 'Bearer volcengine-coding-plan-test-key');
+      if (request.method === 'GET' && request.url === '/api/coding/v3/models') {
+        respondJson(response, 200, { object: 'list', data: [{ id: modelId }] });
+        return;
+      }
       assert.equal(request.method, 'POST');
       assert.equal(request.url, '/api/coding/v3/chat/completions');
       const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
@@ -1764,23 +1783,7 @@ describe('models.dev provider conformance', () => {
     };
 
     const models = await fetchProviderModels(connection, 'volcengine-coding-plan-test-key');
-    assert.deepEqual(
-      models.map(({ id }) => id),
-      [
-        'ark-code-latest',
-        'doubao-seed-2.0-code',
-        'doubao-seed-2.0-pro',
-        'doubao-seed-2.0-lite',
-        'doubao-seed-code',
-        'minimax-m2.7',
-        'minimax-m3',
-        'glm-5.2',
-        'deepseek-v4-flash',
-        'deepseek-v4-pro',
-        'kimi-k2.6',
-        'kimi-k2.7-code',
-      ],
-    );
+    assert.deepEqual(models, [{ id: modelId }]);
 
     const result = await generateText({
       model: getAIModel({ connection, apiKey: 'volcengine-coding-plan-test-key', modelId }),
@@ -1833,11 +1836,15 @@ describe('models.dev provider conformance', () => {
     assert.equal(result.text, 'Echoed hello.');
   });
 
-  test('Tencent Token Plan uses its official snapshot and preserves the exact model id through a two-stage tool-call loop', async () => {
+  test('Tencent Token Plan uses remote discovery and preserves the exact model id through a two-stage tool-call loop', async () => {
     const modelId = 'hy3';
     const requestBodies: Array<Record<string, unknown>> = [];
     const server = await startJsonServer(async (request, response) => {
       assert.equal(request.headers.authorization, 'Bearer tencent-token-plan-test-key');
+      if (request.method === 'GET' && request.url === '/plan/v3/models') {
+        respondJson(response, 200, { object: 'list', data: [{ id: modelId }] });
+        return;
+      }
       assert.equal(request.method, 'POST');
       assert.equal(request.url, '/plan/v3/chat/completions');
       const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
@@ -1898,21 +1905,7 @@ describe('models.dev provider conformance', () => {
     };
 
     const models = await fetchProviderModels(connection, 'tencent-token-plan-test-key');
-    assert.deepEqual(
-      models.map(({ id }) => id),
-      [
-        'tc-code-latest',
-        'deepseek-v4-flash-202605',
-        'deepseek-v4-pro-202606',
-        'minimax-m2.5',
-        'minimax-m2.7',
-        'glm-5',
-        'glm-5.1',
-        'kimi-k2.5',
-        'hy3',
-        'hy3-preview',
-      ],
-    );
+    assert.deepEqual(models, [{ id: modelId }]);
 
     const result = await generateText({
       model: getAIModel({ connection, apiKey: 'tencent-token-plan-test-key', modelId }),
@@ -2101,21 +2094,23 @@ describe('models.dev provider conformance', () => {
       providerType: 'stepfun-step-plan',
       name: 'StepFun Step Plan (China)',
       apiKey: 'stepfun-step-plan-test-key',
-      models: ['step-3.7-flash', 'step-3.5-flash-2603', 'step-3.5-flash', 'step-router-v1'],
     },
     {
       label: 'Global',
       providerType: 'stepfun-ai-step-plan',
       name: 'StepFun Step Plan (Global)',
       apiKey: 'stepfun-global-step-plan-test-key',
-      models: ['step-3.7-flash', 'step-3.5-flash-2603', 'step-3.5-flash'],
     },
   ] as const)
-    test(`StepFun Step Plan ${stepfunPlan.label} preserves its snapshot model through the documented two-stage tool-call loop`, async () => {
+    test(`StepFun Step Plan ${stepfunPlan.label} preserves its discovered model through the documented two-stage tool-call loop`, async () => {
       const modelId = 'step-3.7-flash';
       const requestBodies: Array<Record<string, unknown>> = [];
       const server = await startJsonServer(async (request, response) => {
         assert.equal(request.headers.authorization, `Bearer ${stepfunPlan.apiKey}`);
+        if (request.method === 'GET' && request.url === '/step_plan/v1/models') {
+          respondJson(response, 200, { object: 'list', data: [{ id: modelId }] });
+          return;
+        }
         assert.equal(request.method, 'POST');
         assert.equal(request.url, '/step_plan/v1/chat/completions');
         const body = JSON.parse(await readBody(request)) as Record<string, unknown>;
@@ -2176,10 +2171,7 @@ describe('models.dev provider conformance', () => {
       };
 
       const models = await fetchProviderModels(connection, stepfunPlan.apiKey);
-      assert.deepEqual(
-        models.map((model) => model.id),
-        [...stepfunPlan.models],
-      );
+      assert.deepEqual(models, [{ id: modelId }]);
 
       const result = await generateText({
         model: getAIModel({ connection, apiKey: stepfunPlan.apiKey, modelId: models[0]!.id }),
@@ -2235,7 +2227,7 @@ describe('models.dev provider conformance', () => {
       assert.equal(result.text, 'Echoed hello.');
     });
 
-  test('Volcengine Ark preserves its snapshot model id through the documented two-stage tool-call loop', async () => {
+  test('Volcengine Ark preserves its fallback model id through the documented two-stage tool-call loop', async () => {
     const modelId = 'doubao-seed-2-0-pro-260215';
     const requestBodies: Array<Record<string, unknown>> = [];
     const server = await startJsonServer(async (request, response) => {

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -1336,7 +1336,8 @@ describe('models.dev provider conformance', () => {
       assert.equal(request.headers.authorization, 'Bearer cloudflare-workers-ai-test-token');
       if (
         request.method === 'GET' &&
-        request.url === '/client/v4/accounts/account-123/ai/models/search?page=1&per_page=50'
+        request.url ===
+          '/client/v4/accounts/account-123/ai/models/search?page=1&per_page=50&task=Text+Generation'
       ) {
         respondJson(response, 200, {
           success: true,

--- a/packages/runtime/src/__tests__/provider-contract-overrides.ts
+++ b/packages/runtime/src/__tests__/provider-contract-overrides.ts
@@ -88,20 +88,20 @@ export const PROVIDER_CONTRACT_OVERRIDE_BINDINGS: readonly ProviderContractOverr
 async function runCloudflareDiscovery(): Promise<void> {
   const server = await startJsonServer((request, response) => {
     assert.equal(request.method, 'GET');
-    assert.equal(
-      request.url,
-      '/client/v4/accounts/account-123/ai/models/search?page=1&per_page=50&task=Text+Generation',
-    );
+    const page = new URL(request.url ?? '', 'http://test.local').searchParams.get('page');
     assert.equal(request.headers.authorization, 'Bearer cloudflare-test-token');
     respondJson(response, 200, {
       success: true,
-      result: [
-        {
-          name: '@cf/meta/llama-text',
-          task: { id: 'text-generation', name: 'Text Generation' },
-        },
-      ],
-      result_info: { page: 1, total_pages: 1 },
+      result:
+        page === '1'
+          ? [
+              {
+                name: '@cf/meta/llama-text',
+                task: { id: 'text-generation', name: 'Text Generation' },
+              },
+            ]
+          : [],
+      result_info: { page: Number(page), per_page: 50 },
     });
   });
   const connection: LlmConnection = {

--- a/packages/runtime/src/__tests__/provider-contract-overrides.ts
+++ b/packages/runtime/src/__tests__/provider-contract-overrides.ts
@@ -69,6 +69,11 @@ export const PROVIDER_CONTRACT_OVERRIDE_BINDINGS: readonly ProviderContractOverr
     run: runCohereDiscovery,
   },
   {
+    keys: ['cloudflare-workers-ai:discovery'],
+    title: 'Cloudflare Workers AI discovers text-generation models through its native catalog',
+    run: runCloudflareDiscovery,
+  },
+  {
     keys: ['zenmux:reasoning-replay'],
     title: 'ZenMux replays signed reasoning details in the streamed runtime tool loop',
     run: runZenMuxSignedReasoningReplay,
@@ -79,6 +84,45 @@ export const PROVIDER_CONTRACT_OVERRIDE_BINDINGS: readonly ProviderContractOverr
     run: runCustomOpenAIResponsesRelayWire,
   },
 ];
+
+async function runCloudflareDiscovery(): Promise<void> {
+  const server = await startJsonServer((request, response) => {
+    assert.equal(request.method, 'GET');
+    assert.equal(
+      request.url,
+      '/client/v4/accounts/account-123/ai/models/search?page=1&per_page=50',
+    );
+    assert.equal(request.headers.authorization, 'Bearer cloudflare-test-token');
+    respondJson(response, 200, {
+      success: true,
+      result: [
+        {
+          name: '@cf/meta/llama-text',
+          task: { id: 'text-generation', name: 'Text Generation' },
+        },
+        {
+          name: '@cf/black-forest-labs/flux-image',
+          task: { id: 'text-to-image', name: 'Text to Image' },
+        },
+      ],
+      result_info: { page: 1, total_pages: 1 },
+    });
+  });
+  const connection: LlmConnection = {
+    slug: 'cloudflare-workers-ai',
+    name: 'Cloudflare Workers AI',
+    providerType: 'cloudflare-workers-ai',
+    baseUrl: `${server.url}/client/v4/accounts/account-123/ai/v1`,
+    defaultModel: '@cf/meta/llama-text',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+
+  assert.deepEqual(await fetchProviderModels(connection, 'cloudflare-test-token'), [
+    { id: '@cf/meta/llama-text' },
+  ]);
+}
 
 async function runGitHubCopilotDiscovery(): Promise<void> {
   const server = await startJsonServer((request, response) => {

--- a/packages/runtime/src/__tests__/provider-contract-overrides.ts
+++ b/packages/runtime/src/__tests__/provider-contract-overrides.ts
@@ -90,7 +90,7 @@ async function runCloudflareDiscovery(): Promise<void> {
     assert.equal(request.method, 'GET');
     assert.equal(
       request.url,
-      '/client/v4/accounts/account-123/ai/models/search?page=1&per_page=50',
+      '/client/v4/accounts/account-123/ai/models/search?page=1&per_page=50&task=Text+Generation',
     );
     assert.equal(request.headers.authorization, 'Bearer cloudflare-test-token');
     respondJson(response, 200, {
@@ -99,10 +99,6 @@ async function runCloudflareDiscovery(): Promise<void> {
         {
           name: '@cf/meta/llama-text',
           task: { id: 'text-generation', name: 'Text Generation' },
-        },
-        {
-          name: '@cf/black-forest-labs/flux-image',
-          task: { id: 'text-to-image', name: 'Text to Image' },
         },
       ],
       result_info: { page: 1, total_pages: 1 },

--- a/packages/runtime/src/model-fetcher.ts
+++ b/packages/runtime/src/model-fetcher.ts
@@ -20,9 +20,8 @@ import {
 
 const MODEL_FETCH_TIMEOUT_MS = 10_000;
 const CLOUDFLARE_MODEL_PAGE_SIZE = 50;
-const CLOUDFLARE_MODEL_MAX_PAGES = Math.ceil(
-  CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION / CLOUDFLARE_MODEL_PAGE_SIZE,
-);
+const CLOUDFLARE_MODEL_MAX_REQUEST_PAGES =
+  Math.ceil(CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION / CLOUDFLARE_MODEL_PAGE_SIZE) + 1;
 
 type RawProviderModel = {
   id?: string;
@@ -221,7 +220,7 @@ async function fetchCloudflareModels(baseUrl: string, apiKey: string): Promise<M
   const models: ModelInfo[] = [];
   let page = 1;
   let rawModelCount = 0;
-  while (page <= CLOUDFLARE_MODEL_MAX_PAGES) {
+  while (page <= CLOUDFLARE_MODEL_MAX_REQUEST_PAGES) {
     const url = cloudflareModelsUrl(baseUrl, page);
     const response = await proxiedFetch(url, {
       headers: { authorization: `Bearer ${apiKey}` },
@@ -245,7 +244,7 @@ async function fetchCloudflareModels(baseUrl: string, apiKey: string): Promise<M
         return typeof model.name === 'string' ? [{ id: model.name }] : [];
       }),
     );
-    if (data.result.length < CLOUDFLARE_MODEL_PAGE_SIZE) return models;
+    if (data.result.length === 0) return models;
     page += 1;
   }
   throw new Error('Provider returned too many models');

--- a/packages/runtime/src/model-fetcher.ts
+++ b/packages/runtime/src/model-fetcher.ts
@@ -19,6 +19,10 @@ import {
 } from './subscription-credentials.js';
 
 const MODEL_FETCH_TIMEOUT_MS = 10_000;
+const CLOUDFLARE_MODEL_PAGE_SIZE = 50;
+const CLOUDFLARE_MODEL_MAX_PAGES = Math.ceil(
+  CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION / CLOUDFLARE_MODEL_PAGE_SIZE,
+);
 
 type RawProviderModel = {
   id?: string;
@@ -57,10 +61,6 @@ type RawCohereModel = {
 
 type RawCloudflareModel = {
   name?: unknown;
-  task?: {
-    id?: unknown;
-    name?: unknown;
-  };
 };
 
 type RawGitHubCopilotModel = {
@@ -97,7 +97,7 @@ export async function fetchProviderModels(
   apiKey: string,
 ): Promise<ModelInfo[]> {
   try {
-    return validateDiscoveredModels(await fetchProviderModelsStrict(connection, apiKey));
+    return normalizeDiscoveredModels(await fetchProviderModelsStrict(connection, apiKey));
   } catch (error) {
     // Preserve status-bearing discovery errors so the sync layer can classify
     // auth/protocol/network failures; only wrap unknown errors for display.
@@ -220,8 +220,8 @@ async function fetchProviderModelsStrict(
 async function fetchCloudflareModels(baseUrl: string, apiKey: string): Promise<ModelInfo[]> {
   const models: ModelInfo[] = [];
   let page = 1;
-  let totalPages = 1;
-  do {
+  let rawModelCount = 0;
+  while (page <= CLOUDFLARE_MODEL_MAX_PAGES) {
     const url = cloudflareModelsUrl(baseUrl, page);
     const response = await proxiedFetch(url, {
       headers: { authorization: `Bearer ${apiKey}` },
@@ -231,36 +231,24 @@ async function fetchCloudflareModels(baseUrl: string, apiKey: string): Promise<M
     const data = (await response.json()) as {
       success?: unknown;
       result?: unknown;
-      result_info?: { total_pages?: unknown };
     };
     if (data.success !== true || !Array.isArray(data.result)) {
       throw new Error('Invalid Cloudflare models response');
     }
+    rawModelCount += data.result.length;
+    if (rawModelCount > CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION) {
+      throw new Error('Provider returned too many models');
+    }
     models.push(
       ...data.result.flatMap((raw) => {
         const model = raw as RawCloudflareModel;
-        const taskId = typeof model.task?.id === 'string' ? model.task.id.trim().toLowerCase() : '';
-        const taskName =
-          typeof model.task?.name === 'string' ? model.task.name.trim().toLowerCase() : '';
-        if (
-          typeof model.name !== 'string' ||
-          (taskId !== 'text-generation' && taskName !== 'text generation')
-        ) {
-          return [];
-        }
-        return [{ id: model.name }];
+        return typeof model.name === 'string' ? [{ id: model.name }] : [];
       }),
     );
-    const reportedTotalPages = data.result_info?.total_pages;
-    totalPages =
-      typeof reportedTotalPages === 'number' &&
-      Number.isInteger(reportedTotalPages) &&
-      reportedTotalPages >= page
-        ? reportedTotalPages
-        : page;
+    if (data.result.length < CLOUDFLARE_MODEL_PAGE_SIZE) return models;
     page += 1;
-  } while (page <= totalPages);
-  return models;
+  }
+  throw new Error('Provider returned too many models');
 }
 
 function cloudflareModelsUrl(baseUrl: string, page: number): string {
@@ -269,11 +257,15 @@ function cloudflareModelsUrl(baseUrl: string, page: number): string {
     throw new Error('Cloudflare Workers AI base URL must end with /ai/v1');
   }
   url.pathname = url.pathname.replace(/\/ai\/v1\/?$/, '/ai/models/search');
-  url.search = new URLSearchParams({ page: String(page), per_page: '50' }).toString();
+  url.search = new URLSearchParams({
+    page: String(page),
+    per_page: String(CLOUDFLARE_MODEL_PAGE_SIZE),
+    task: 'Text Generation',
+  }).toString();
   return url.toString();
 }
 
-function validateDiscoveredModels(models: ModelInfo[]): ModelInfo[] {
+function normalizeDiscoveredModels(models: ModelInfo[]): ModelInfo[] {
   const unique = new Map<string, ModelInfo>();
   for (const model of models) {
     if (typeof model?.id !== 'string') continue;
@@ -290,9 +282,6 @@ function validateDiscoveredModels(models: ModelInfo[]): ModelInfo[] {
     if (unique.size > CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION) {
       throw new Error('Provider returned too many models');
     }
-  }
-  if (unique.size === 0) {
-    throw new Error('Provider returned no usable models');
   }
   return [...unique.values()];
 }

--- a/packages/runtime/src/model-fetcher.ts
+++ b/packages/runtime/src/model-fetcher.ts
@@ -6,6 +6,10 @@ import {
   type ModelInfo,
 } from '@maka/core/llm-connections';
 import { generalizedErrorMessage } from '@maka/core/redaction';
+import {
+  CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION,
+  CONNECTION_MODEL_ID_MAX_LENGTH,
+} from '@maka/core/runtime-policy';
 import { proxiedFetch } from './bots/proxied-fetch.js';
 import { anthropicV1Url, googleApiUrl } from './provider-urls.js';
 import { claudeSubscriptionHeaders, openAiCodexHeaders } from './subscription-auth.js';
@@ -51,6 +55,14 @@ type RawCohereModel = {
   context_length?: number;
 };
 
+type RawCloudflareModel = {
+  name?: unknown;
+  task?: {
+    id?: unknown;
+    name?: unknown;
+  };
+};
+
 type RawGitHubCopilotModel = {
   id?: string;
   name?: string;
@@ -85,7 +97,7 @@ export async function fetchProviderModels(
   apiKey: string,
 ): Promise<ModelInfo[]> {
   try {
-    return await fetchProviderModelsStrict(connection, apiKey);
+    return validateDiscoveredModels(await fetchProviderModelsStrict(connection, apiKey));
   } catch (error) {
     // Preserve status-bearing discovery errors so the sync layer can classify
     // auth/protocol/network failures; only wrap unknown errors for display.
@@ -129,6 +141,9 @@ async function fetchProviderModelsStrict(
   }
   if (discovery.kind === 'cohere') {
     return fetchCohereModels(baseUrl, apiKey);
+  }
+  if (discovery.kind === 'cloudflare') {
+    return fetchCloudflareModels(baseUrl, apiKey);
   }
   if (discovery.auth === 'github-copilot') {
     return fetchGitHubCopilotModels(baseUrl, apiKey);
@@ -200,6 +215,86 @@ async function fetchProviderModelsStrict(
     case 'cohere':
       throw new Error('Cohere requires native model discovery');
   }
+}
+
+async function fetchCloudflareModels(baseUrl: string, apiKey: string): Promise<ModelInfo[]> {
+  const models: ModelInfo[] = [];
+  let page = 1;
+  let totalPages = 1;
+  do {
+    const url = cloudflareModelsUrl(baseUrl, page);
+    const response = await proxiedFetch(url, {
+      headers: { authorization: `Bearer ${apiKey}` },
+      timeoutMs: MODEL_FETCH_TIMEOUT_MS,
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const data = (await response.json()) as {
+      success?: unknown;
+      result?: unknown;
+      result_info?: { total_pages?: unknown };
+    };
+    if (data.success !== true || !Array.isArray(data.result)) {
+      throw new Error('Invalid Cloudflare models response');
+    }
+    models.push(
+      ...data.result.flatMap((raw) => {
+        const model = raw as RawCloudflareModel;
+        const taskId = typeof model.task?.id === 'string' ? model.task.id.trim().toLowerCase() : '';
+        const taskName =
+          typeof model.task?.name === 'string' ? model.task.name.trim().toLowerCase() : '';
+        if (
+          typeof model.name !== 'string' ||
+          (taskId !== 'text-generation' && taskName !== 'text generation')
+        ) {
+          return [];
+        }
+        return [{ id: model.name }];
+      }),
+    );
+    const reportedTotalPages = data.result_info?.total_pages;
+    totalPages =
+      typeof reportedTotalPages === 'number' &&
+      Number.isInteger(reportedTotalPages) &&
+      reportedTotalPages >= page
+        ? reportedTotalPages
+        : page;
+    page += 1;
+  } while (page <= totalPages);
+  return models;
+}
+
+function cloudflareModelsUrl(baseUrl: string, page: number): string {
+  const url = new URL(baseUrl);
+  if (!/\/ai\/v1\/?$/.test(url.pathname)) {
+    throw new Error('Cloudflare Workers AI base URL must end with /ai/v1');
+  }
+  url.pathname = url.pathname.replace(/\/ai\/v1\/?$/, '/ai/models/search');
+  url.search = new URLSearchParams({ page: String(page), per_page: '50' }).toString();
+  return url.toString();
+}
+
+function validateDiscoveredModels(models: ModelInfo[]): ModelInfo[] {
+  const unique = new Map<string, ModelInfo>();
+  for (const model of models) {
+    if (typeof model?.id !== 'string') continue;
+    const id = model.id.trim();
+    if (
+      !id ||
+      id.length > CONNECTION_MODEL_ID_MAX_LENGTH ||
+      /[\u0000-\u001f\u007f]/.test(id) ||
+      unique.has(id)
+    ) {
+      continue;
+    }
+    unique.set(id, { ...model, id });
+    if (unique.size > CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION) {
+      throw new Error('Provider returned too many models');
+    }
+  }
+  if (unique.size === 0) {
+    throw new Error('Provider returned no usable models');
+  }
+  return [...unique.values()];
 }
 
 export async function fetchGitHubCopilotModels(

--- a/packages/storage/src/__tests__/connection-store.test.ts
+++ b/packages/storage/src/__tests__/connection-store.test.ts
@@ -978,7 +978,7 @@ describe('FileConnectionStore', () => {
     });
   });
 
-  test('invalidates model cache metadata when credentials or base URL change', async () => {
+  test('preserves the last successful model catalog when credentials or base URL change', async () => {
     await withConnectionStore(async (store) => {
       const created = await store.create({
         slug: 'zai-main',
@@ -994,9 +994,9 @@ describe('FileConnectionStore', () => {
 
       await store.update(created.slug, { apiKey: 'new-secret' });
       let next = await store.get(created.slug);
-      assert.equal(next?.models, undefined);
-      assert.equal(next?.modelSource, undefined);
-      assert.equal(next?.modelsFetchedAt, undefined);
+      assert.deepEqual(next?.models, [{ id: 'glm-5' }]);
+      assert.equal(next?.modelSource, 'fetched');
+      assert.equal(next?.modelsFetchedAt, 1_800_000_000_000);
 
       await store.update(created.slug, {
         models: [{ id: 'glm-5.1' }],
@@ -1005,9 +1005,9 @@ describe('FileConnectionStore', () => {
       });
       await store.update(created.slug, { baseUrl: 'https://api.z.ai/api/coding/paas/v4' });
       next = await store.get(created.slug);
-      assert.equal(next?.models, undefined);
-      assert.equal(next?.modelSource, undefined);
-      assert.equal(next?.modelsFetchedAt, undefined);
+      assert.deepEqual(next?.models, [{ id: 'glm-5.1' }]);
+      assert.equal(next?.modelSource, 'fetched');
+      assert.equal(next?.modelsFetchedAt, 1_800_000_000_001);
     });
   });
 

--- a/packages/storage/src/connection-store.ts
+++ b/packages/storage/src/connection-store.ts
@@ -103,19 +103,13 @@ class FileConnectionStore implements ConnectionStore {
         Object.prototype.hasOwnProperty.call(patch, 'models') ||
         Object.prototype.hasOwnProperty.call(patch, 'modelSource') ||
         Object.prototype.hasOwnProperty.call(patch, 'modelsFetchedAt');
-      const clearsModelCache =
-        !updatesModelCache && (patch.apiKey !== undefined || patch.baseUrl !== undefined);
       const clearsTestStatus =
         !updatesTestStatus &&
         (patch.apiKey !== undefined ||
           patch.baseUrl !== undefined ||
           patch.defaultModel !== undefined ||
           patch.models !== undefined);
-      const models = updatesModelCache
-        ? patch.models
-        : clearsModelCache
-          ? undefined
-          : current.models;
+      const models = updatesModelCache ? patch.models : current.models;
       let defaultModel = patch.defaultModel ?? current.defaultModel;
       let enabledModelIds = connectionEnabledModelIds({
         defaultModel,
@@ -146,16 +140,8 @@ class FileConnectionStore implements ConnectionStore {
         enabled: patch.enabled ?? current.enabled,
         enabledModelIds,
         models,
-        modelSource: updatesModelCache
-          ? patch.modelSource
-          : clearsModelCache
-            ? undefined
-            : current.modelSource,
-        modelsFetchedAt: updatesModelCache
-          ? patch.modelsFetchedAt
-          : clearsModelCache
-            ? undefined
-            : current.modelsFetchedAt,
+        modelSource: updatesModelCache ? patch.modelSource : current.modelSource,
+        modelsFetchedAt: updatesModelCache ? patch.modelsFetchedAt : current.modelsFetchedAt,
         lastTestStatus: updatesTestStatus
           ? patch.lastTestStatus
           : clearsTestStatus


### PR DESCRIPTION
## Summary

Closes #1571.

- Move 12 previously fallback-only Tencent, Volcengine Coding Plan, Xiaomi, StepFun, and Alibaba providers to credential-backed protocol discovery.
- Add native Cloudflare Workers AI discovery through `/ai/models/search`, with server-side text-generation filtering, official empty-page pagination, and exact 2,048-model bounds.
- Keep Volcengine Ark direct API fallback-only because discovery requires control-plane AK/SK signing, and make its registry snapshot authoritative over stale persisted fetch caches without removing explicit user model choices.
- Normalize and bound discovered model IDs while leaving authoritative-empty OAuth semantics intact; interactive refresh rejects empty catalogs and preserves the last successful cache.
- Centralize model-discovery capability in the provider registry contract, auto-refresh discoverable connections on create/credential/endpoint changes, and preserve custom-relay silent discovery behavior.
- Cover registry strategy, protocol wires, pagination boundaries, cache/provenance invariants, fallback policy, and renderer/main integration with executable contracts.

## Verification

- `npm run build:test`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm --workspace @maka/core test` — 1250 passed
- `npm --workspace @maka/storage test` — 710 passed, 1 environment-dependent test skipped
- `npm --workspace @maka/runtime test` — 2751 passed, 9 environment-dependent tests skipped
- `npm --workspace @maka/desktop test` — 2957 passed
- Focused provider discovery/conformance suite — 171 passed
- `npm --workspace @maka/desktop run e2e -- e2e/providers.spec.ts` — 4 passed

No screenshot: this changes discovery behavior, cache ownership, and refresh timing without changing the rendered UI.