### PR TITLE
fix(runtime): omit duplicate Bash commands from model results

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -2892,6 +2892,170 @@ describe('AiSdkBackend model history', () => {
     ]);
   });
 
+  test('replays durable Bash results without duplicating commands in provider output', async () => {
+    const model = completionModel();
+    const durableResults = [
+      {
+        kind: 'terminal' as const,
+        cwd: '/workspace',
+        cmd: 'printf completed-marker',
+        status: 'completed' as const,
+        exitCode: 0,
+        output: {
+          mode: 'pipes' as const,
+          stdout: 'completed',
+          stderr: '',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          redacted: false,
+        },
+      },
+      {
+        kind: 'terminal' as const,
+        cwd: '/workspace',
+        cmd: 'printf failed-marker',
+        status: 'failed' as const,
+        exitCode: 2,
+        output: {
+          mode: 'pipes' as const,
+          stdout: '',
+          stderr: 'failed',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          redacted: false,
+        },
+        sandboxDenial: {
+          likely: true as const,
+          backend: 'macos-seatbelt' as const,
+          recovery: 'require_escalated' as const,
+        },
+      },
+      {
+        kind: 'terminal' as const,
+        cwd: '/workspace',
+        cmd: 'printf timeout-marker',
+        status: 'timed_out' as const,
+        exitCode: 124,
+        output: {
+          mode: 'pipes' as const,
+          stdout: 'partial timeout',
+          stderr: '',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          redacted: false,
+        },
+      },
+      {
+        kind: 'terminal' as const,
+        cwd: '/workspace',
+        cmd: 'printf cancelled-marker',
+        status: 'cancelled' as const,
+        exitCode: 130,
+        output: {
+          mode: 'pipes' as const,
+          stdout: '',
+          stderr: 'cancelled',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          redacted: false,
+        },
+      },
+      {
+        kind: 'terminal' as const,
+        cwd: '/workspace',
+        cmd: 'printf truncated-marker',
+        status: 'completed' as const,
+        exitCode: 0,
+        output: {
+          mode: 'pipes' as const,
+          stdout: 'tail',
+          stderr: 'error tail',
+          stdoutTruncated: true,
+          stderrTruncated: true,
+          redacted: true,
+        },
+      },
+    ];
+    const runtimeContext: RuntimeEvent[] = [
+      runtimeTextEvent({
+        id: 'rt-u',
+        turnId: 'turn-prev',
+        role: 'user',
+        author: 'user',
+        text: 'run all commands',
+      }),
+      ...durableResults.map((result, index) =>
+        runtimeEvent({
+          id: `rt-call-${index}`,
+          turnId: 'turn-prev',
+          role: 'model',
+          author: 'agent',
+          content: {
+            kind: 'function_call',
+            id: `tool-${index}`,
+            name: 'Bash',
+            args: { command: result.cmd },
+          },
+        }),
+      ),
+      ...durableResults.map((result, index) =>
+        runtimeEvent({
+          id: `rt-result-${index}`,
+          turnId: 'turn-prev',
+          role: 'tool',
+          author: 'tool',
+          content: {
+            kind: 'function_response',
+            id: `tool-${index}`,
+            name: 'Bash',
+            result,
+            isError: result.status !== 'completed',
+          },
+        }),
+      ),
+    ];
+    const backend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => model,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(
+      backend.send({
+        turnId: 'turn-current',
+        text: 'continue',
+        context: [],
+        runtimeContext,
+      }),
+    );
+
+    const prompt = compactPrompt(model) as Array<{ role: string; content: any[] }>;
+    const serializedPrompt = JSON.stringify(prompt);
+    const toolResults = prompt.find((message) => message.role === 'tool')?.content ?? [];
+    assert.equal(toolResults.length, durableResults.length);
+    for (const [index, durable] of durableResults.entries()) {
+      assert.equal(
+        serializedPrompt.split(durable.cmd).length - 1,
+        1,
+        `command ${index} should remain only in its paired Bash call`,
+      );
+      const output = toolResults[index]?.output;
+      assert.equal(output?.type, durable.status === 'completed' ? 'json' : 'error-json');
+      assert.equal(Object.hasOwn(output?.value ?? {}, 'cmd'), false);
+      const { cmd: _cmd, ...expected } = durable;
+      assert.deepEqual(output?.value, expected);
+      assert.equal(durableResults[index]?.cmd, durable.cmd);
+    }
+  });
+
   test('archives stale RuntimeEvent tool results before replay placeholder rewrite', async () => {
     const model = completionModel();
     const archiveRequests: Array<{

--- a/packages/runtime/src/__tests__/builtin-tools.test.ts
+++ b/packages/runtime/src/__tests__/builtin-tools.test.ts
@@ -179,6 +179,37 @@ describe('builtin tool executor facts', () => {
 });
 
 describe('builtin Bash description declares the executing shell', () => {
+  test('executor Bash keeps its durable command out of provider-facing results', async () => {
+    const bash = buildBuiltinTools({
+      executor: fakeExecutor({
+        exec: async () => ({
+          exitCode: 0,
+          stdout: 'done',
+          stderr: '',
+          timedOut: false,
+          aborted: false,
+        }),
+      }),
+    }).find((tool) => tool.name === 'Bash')!;
+    const result = await runTool(bash, { command: 'printf executor-marker' }, '/workspace');
+    const modelOutput = await bash.toModelOutput?.({
+      toolCallId: 'tool-1',
+      input: { command: 'printf executor-marker' },
+      output: result,
+    });
+
+    assert.equal((result as { cmd?: unknown }).cmd, 'printf executor-marker');
+    assert.equal(
+      Object.hasOwn(
+        modelOutput && 'value' in modelOutput && typeof modelOutput.value === 'object'
+          ? (modelOutput.value ?? {})
+          : {},
+        'cmd',
+      ),
+      false,
+    );
+  });
+
   test('executor Bash executes with the same shell it declares', async () => {
     // /bin/echo stands in for pwsh.exe: if the shell reaches the local
     // executor's spawn, stdout echoes the PowerShell flags back instead of a

--- a/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
@@ -976,7 +976,7 @@ describe('buildModelHistoryFromRuntimeEvents', () => {
     ]);
   });
 
-  test('runtime replay plan normalizes an exact legacy terminal result', () => {
+  test('runtime replay plan normalizes a legacy Bash result without changing durable input', () => {
     const events: RuntimeEvent[] = [
       ev({
         role: 'model',
@@ -1017,7 +1017,6 @@ describe('buildModelHistoryFromRuntimeEvents', () => {
     expect(result?.kind === 'tool_result' ? result.output : undefined).toEqual({
       kind: 'terminal',
       cwd: '/tmp/work',
-      cmd: 'printf ok',
       status: 'completed',
       exitCode: 0,
       output: {
@@ -1029,6 +1028,11 @@ describe('buildModelHistoryFromRuntimeEvents', () => {
         redacted: false,
       },
     });
+    expect(
+      events[1]?.content?.kind === 'function_response'
+        ? (events[1].content.result as { cmd?: unknown }).cmd
+        : undefined,
+    ).toBe('printf ok');
   });
 
   test('runtime replay plan rejects a mixed legacy/current shell result', () => {

--- a/packages/runtime/src/__tests__/shell-tools.test.ts
+++ b/packages/runtime/src/__tests__/shell-tools.test.ts
@@ -126,6 +126,57 @@ describe('Bash tool shell is threaded through to execution, not just the descrip
   });
 });
 
+describe('Bash provider-facing result projection', () => {
+  test('managed Bash removes only the duplicated foreground command', async () => {
+    const tool = buildManagedBashTool(fakeShellRuns());
+    const terminal = {
+      kind: 'terminal',
+      cwd: '/workspace',
+      cmd: 'printf foreground',
+      status: 'completed',
+      exitCode: 0,
+      output: {
+        mode: 'pipes',
+        stdout: 'foreground',
+        stderr: '',
+        stdoutTruncated: false,
+        stderrTruncated: false,
+        redacted: false,
+      },
+    };
+    const background = {
+      kind: 'shell_run',
+      ref: 'maka://runtime/background-tasks/sr_test',
+      mode: 'pipes',
+      status: 'running',
+      cwd: '/workspace',
+      cmd: 'printf background',
+      startedAt: 1,
+      updatedAt: 1,
+      revision: 1,
+    };
+
+    assert.deepEqual(
+      await tool.toModelOutput?.({ toolCallId: 'foreground', input: {}, output: terminal }),
+      {
+        type: 'json',
+        value: {
+          kind: 'terminal',
+          cwd: '/workspace',
+          status: 'completed',
+          exitCode: 0,
+          output: terminal.output,
+        },
+      },
+    );
+    assert.deepEqual(
+      await tool.toModelOutput?.({ toolCallId: 'background', input: {}, output: background }),
+      { type: 'json', value: background },
+    );
+    assert.equal(terminal.cmd, 'printf foreground');
+  });
+});
+
 describe('shapeTerminalResult sandbox denial projection', () => {
   test('surfaces sandboxDenial when a sandboxed command fails with a denial message', () => {
     const result = shapeTerminalResult({

--- a/packages/runtime/src/__tests__/tool-runtime-settlement.test.ts
+++ b/packages/runtime/src/__tests__/tool-runtime-settlement.test.ts
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import type { LlmConnection, SessionHeader } from '@maka/core';
 import { PermissionEngine } from '../permission-engine.js';
+import { buildForegroundBashTool, buildManagedBashTool } from '../shell-tools.js';
 import { ToolRuntime, type MakaTool, type ToolRuntimeInput } from '../tool-runtime.js';
 
 describe('ToolRuntime settlement', () => {
@@ -26,6 +27,151 @@ describe('ToolRuntime settlement', () => {
       result,
       modelOutput: { type: 'json', value: result },
     });
+  });
+
+  it('keeps the durable Bash command while omitting it from the live model output', async () => {
+    const runtime = makeRuntime();
+    const bash = buildForegroundBashTool({
+      description: 'shell',
+      execute: async () => ({
+        exitCode: 0,
+        stdout: 'done',
+        stderr: '',
+        stdoutTruncated: true,
+        stderrTruncated: false,
+      }),
+    });
+    bash.permissionRequired = false;
+
+    const settlement = await runtime.settleToolCall({
+      tool: bash,
+      turnId: 'turn-1',
+      stepId: 'step-1',
+      toolCallId: 'call-1',
+      input: { command: 'printf durable-command' },
+      abortSignal: new AbortController().signal,
+      eventSink: {
+        push: () => {},
+        pushAndWaitUntilConsumed: async () => {},
+      },
+    });
+
+    assert.equal((settlement.result as { cmd?: unknown }).cmd, 'printf durable-command');
+    assert.deepEqual(settlement.modelOutput, {
+      type: 'json',
+      value: {
+        kind: 'terminal',
+        cwd: '/workspace/repo',
+        status: 'completed',
+        exitCode: 0,
+        output: {
+          mode: 'pipes',
+          stdout: 'done',
+          stderr: '',
+          stdoutTruncated: true,
+          stderrTruncated: false,
+          redacted: false,
+        },
+      },
+    });
+  });
+
+  it('projects every managed foreground Bash terminal state without its command', async () => {
+    const terminalResults = [
+      {
+        kind: 'terminal' as const,
+        cwd: '/workspace/repo',
+        cmd: 'printf completed',
+        status: 'completed' as const,
+        exitCode: 0,
+        output: {
+          mode: 'pipes' as const,
+          stdout: 'tail',
+          stderr: '',
+          stdoutTruncated: true,
+          stderrTruncated: false,
+          redacted: false,
+        },
+      },
+      {
+        kind: 'terminal' as const,
+        cwd: '/workspace/repo',
+        cmd: 'printf failed',
+        status: 'failed' as const,
+        exitCode: 2,
+        output: {
+          mode: 'pipes' as const,
+          stdout: '',
+          stderr: 'failed',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          redacted: false,
+        },
+        sandboxDenial: {
+          likely: true as const,
+          backend: 'macos-seatbelt' as const,
+          recovery: 'require_escalated' as const,
+        },
+      },
+      {
+        kind: 'terminal' as const,
+        cwd: '/workspace/repo',
+        cmd: 'printf timed-out',
+        status: 'timed_out' as const,
+        exitCode: 124,
+        output: {
+          mode: 'pipes' as const,
+          stdout: 'partial',
+          stderr: '',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          redacted: false,
+        },
+      },
+      {
+        kind: 'terminal' as const,
+        cwd: '/workspace/repo',
+        cmd: 'printf cancelled',
+        status: 'cancelled' as const,
+        exitCode: 130,
+        output: {
+          mode: 'pipes' as const,
+          stdout: '',
+          stderr: 'cancelled',
+          stdoutTruncated: false,
+          stderrTruncated: false,
+          redacted: true,
+        },
+      },
+    ];
+
+    for (const [index, terminal] of terminalResults.entries()) {
+      const runtime = makeRuntime();
+      const bash = buildManagedBashTool({
+        runForegroundBash: async () => terminal,
+        runBackgroundBash: async () => {
+          throw new Error('not used');
+        },
+      });
+      bash.permissionRequired = false;
+      const settlement = await runtime.settleToolCall({
+        tool: bash,
+        turnId: 'turn-1',
+        stepId: 'step-1',
+        toolCallId: `call-${index}`,
+        input: { command: terminal.cmd },
+        abortSignal: new AbortController().signal,
+        eventSink: {
+          push: () => {},
+          pushAndWaitUntilConsumed: async () => {},
+        },
+      });
+      const { cmd: _cmd, ...projected } = terminal;
+
+      assert.deepEqual(settlement.result, terminal);
+      assert.deepEqual(settlement.modelOutput, { type: 'json', value: projected });
+      assert.equal(terminalResults[index]?.cmd, terminal.cmd);
+    }
   });
 
   it('preserves live provider error mapping', async () => {

--- a/packages/runtime/src/bash-model-output.ts
+++ b/packages/runtime/src/bash-model-output.ts
@@ -1,0 +1,23 @@
+import type { ToolResultOutput } from './model-protocol.js';
+import { toolResultOutput } from './tool-result-output.js';
+
+/**
+ * Keep the canonical Bash result intact for durable storage while removing the
+ * command already present in the paired provider-visible Bash call.
+ */
+export function projectBashToolResultForModel(output: unknown): unknown {
+  if (
+    !output ||
+    typeof output !== 'object' ||
+    Array.isArray(output) ||
+    (output as { kind?: unknown }).kind !== 'terminal'
+  ) {
+    return output;
+  }
+  const { cmd: _cmd, ...projected } = output as Record<string, unknown>;
+  return projected;
+}
+
+export function bashToolResultToModelOutput(output: unknown): ToolResultOutput {
+  return toolResultOutput(projectBashToolResultForModel(output), false);
+}

--- a/packages/runtime/src/builtin-tools.ts
+++ b/packages/runtime/src/builtin-tools.ts
@@ -26,6 +26,7 @@ import {
   type PermissionProfile,
 } from '@maka/core';
 import { computeEditedSource } from './edit-replace.js';
+import { bashToolResultToModelOutput } from './bash-model-output.js';
 import {
   buildManagedBashTool,
   buildStopBackgroundTaskTool,
@@ -743,6 +744,7 @@ function buildExecutorBashTool(
       })
       .strict(),
     permissionRequired: true,
+    toModelOutput: ({ output }) => bashToolResultToModelOutput(output),
     executionFacts: executor.facts,
     ...(sandboxOptions.planAdditionalPermissions
       ? { planAdditionalPermissions: sandboxOptions.planAdditionalPermissions }

--- a/packages/runtime/src/model-history.ts
+++ b/packages/runtime/src/model-history.ts
@@ -45,6 +45,7 @@ import {
 import { normalizeShellToolResultContent, normalizeToolResultContentForRead } from '@maka/core';
 import type { AttachmentRef, QuoteRef } from '@maka/core/events';
 import type { ModelMessage, UserContent, UserModelMessage } from './model-protocol.js';
+import { projectBashToolResultForModel } from './bash-model-output.js';
 
 // ============================================================================
 // Output type
@@ -566,6 +567,9 @@ export function buildRuntimeEventModelReplayPlan(
             invalidResultMessage =
               'function_response contains an invalid legacy subagent tool result';
           }
+        }
+        if (!invalidResultMessage && event.content.name === 'Bash') {
+          normalizedResult = projectBashToolResultForModel(normalizedResult);
         }
         if (invalidResultMessage) {
           const call = callsById.get(event.content.id);

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -35,6 +35,7 @@ import {
   isWellFormedTerminalInput,
 } from './shell-run-contract.js';
 import type { ChildFdInput } from './child-fd-input.js';
+import { bashToolResultToModelOutput } from './bash-model-output.js';
 
 export interface ForegroundBashExecuteInput {
   command: string;
@@ -129,6 +130,7 @@ export function buildForegroundBashTool(options: BuildForegroundBashToolOptions)
       timeout_ms: z.number().int().positive().max(maxTimeoutMs).optional(),
     }),
     permissionRequired: true,
+    toModelOutput: ({ output }) => bashToolResultToModelOutput(output),
     ...(options.executionFacts ? { executionFacts: options.executionFacts } : {}),
     impl: async ({ command, timeout_ms }, ctx) => {
       const timeoutMs = timeout_ms ?? options.defaultTimeoutMs?.(command);
@@ -255,6 +257,7 @@ export function buildManagedBashTool(
         }
       }),
     permissionRequired: true,
+    toModelOutput: ({ output }) => bashToolResultToModelOutput(output),
     ...(options.executionFacts ? { executionFacts: options.executionFacts } : {}),
     ...(options.sandbox ? { sandbox: options.sandbox } : {}),
     ...(options.planAdditionalPermissions


### PR DESCRIPTION
## Summary

- add one shared Bash provider-facing projection that removes cmd only from foreground terminal results
- keep the complete redacted command in durable tool results for WAL, audit, and UI recovery
- apply the same projection during live settlement and RuntimeEvent replay
- leave background shell_run results and every non-command terminal field unchanged

## Regression coverage

- live foreground settlement through local, managed, and builtin executor Bash paths
- successful, failed, timed-out, cancelled, and truncated terminal results
- durable replay with multiple Bash calls in one assistant step
- legacy terminal normalization without mutating the source RuntimeEvent
- background Bash command retention

## Validation

- npm run build:test
- npm run format:check
- npm run lint
- npm run typecheck
- npm --workspace @maka/runtime test (2,759 passed, 0 failed, 9 environment skips)
- npm --workspace @maka/runtime-host run test:dist (213 passed, 0 failed)
- serial all-workspace runner passed before the final upstream sync; on the final base, a repeat made progress without assertion failures but exceeded the 10-minute outer limit in Runtime Host, whose isolated suite then passed in 41.9 seconds

No UI or persisted schema changes are included, so visual regression testing is not applicable.

Closes #1562