### PR TITLE
fix(desktop): prevent window creation during quit cleanup

### DIFF
--- a/apps/desktop/src/main/__tests__/app-quit-coordinator.test.ts
+++ b/apps/desktop/src/main/__tests__/app-quit-coordinator.test.ts
@@ -1,0 +1,132 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createAppQuitCoordinator } from '../app-quit-coordinator.js';
+
+describe('app quit coordinator', () => {
+  it('focuses or creates the main window while the app is running', () => {
+    let focusOrCreateCount = 0;
+    let windowCreationSignal: AbortSignal | undefined;
+    const coordinator = createAppQuitCoordinator({
+      cleanup: async () => {},
+      focusOrCreateWindow: (signal?: AbortSignal) => {
+        focusOrCreateCount += 1;
+        windowCreationSignal = signal;
+      },
+      onCleanupError: () => {},
+      resumeQuit: () => {},
+    });
+
+    coordinator.focusOrCreateWindow();
+
+    assert.equal(focusOrCreateCount, 1);
+    assert.equal(windowCreationSignal?.aborted, false);
+    assert.equal(coordinator.getWindowCreationSignal(), windowCreationSignal);
+  });
+
+  it('runs async cleanup once and resumes quitting when it settles', async () => {
+    let cleanupCount = 0;
+    let focusOrCreateCount = 0;
+    let resumeQuitCount = 0;
+    let releaseCleanup: () => void = () => {};
+    const cleanupPending = new Promise<void>((resolve) => {
+      releaseCleanup = resolve;
+    });
+    const coordinator = createAppQuitCoordinator({
+      cleanup: async () => {
+        cleanupCount += 1;
+        await cleanupPending;
+      },
+      focusOrCreateWindow: () => {
+        focusOrCreateCount += 1;
+      },
+      onCleanupError: () => {},
+      resumeQuit: () => {
+        resumeQuitCount += 1;
+      },
+    });
+    let preventedCount = 0;
+    const event = {
+      preventDefault: () => {
+        preventedCount += 1;
+      },
+    };
+
+    coordinator.handleBeforeQuit(event);
+    coordinator.handleBeforeQuit(event);
+    assert.equal(cleanupCount, 1);
+    assert.equal(preventedCount, 2);
+    assert.equal(resumeQuitCount, 0);
+
+    releaseCleanup();
+    await cleanupPending;
+    await Promise.resolve();
+
+    assert.equal(resumeQuitCount, 1);
+
+    coordinator.focusOrCreateWindow();
+    coordinator.handleBeforeQuit(event);
+
+    assert.equal(focusOrCreateCount, 0);
+    assert.equal(preventedCount, 2);
+    assert.equal(cleanupCount, 1);
+    assert.equal(resumeQuitCount, 1);
+  });
+
+  it('does not reopen the main window after quit cleanup starts', () => {
+    let focusOrCreateCount = 0;
+    const coordinator = createAppQuitCoordinator({
+      cleanup: () => new Promise<void>(() => {}),
+      focusOrCreateWindow: () => {
+        focusOrCreateCount += 1;
+      },
+      onCleanupError: () => {},
+      resumeQuit: () => {},
+    });
+    const windowCreationSignal = coordinator.getWindowCreationSignal();
+
+    coordinator.handleBeforeQuit({ preventDefault: () => {} });
+    coordinator.focusOrCreateWindow();
+
+    assert.equal(focusOrCreateCount, 0);
+    assert.equal(windowCreationSignal?.aborted, true);
+    assert.equal(coordinator.getWindowCreationSignal(), undefined);
+  });
+
+  it('reports cleanup failure without leaking an unhandled rejection', async () => {
+    const cleanupError = new Error('close failed');
+    const reportedErrors: unknown[] = [];
+    let focusOrCreateCount = 0;
+    let resumeQuitCount = 0;
+    const deps = {
+      cleanup: async () => {
+        throw cleanupError;
+      },
+      focusOrCreateWindow: () => {
+        focusOrCreateCount += 1;
+      },
+      onCleanupError: (error: unknown) => {
+        reportedErrors.push(error);
+      },
+      resumeQuit: () => {
+        resumeQuitCount += 1;
+      },
+    };
+    const coordinator = createAppQuitCoordinator(deps);
+
+    coordinator.handleBeforeQuit({ preventDefault: () => {} });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    let secondQuitPrevented = false;
+    coordinator.focusOrCreateWindow();
+    coordinator.handleBeforeQuit({
+      preventDefault: () => {
+        secondQuitPrevented = true;
+      },
+    });
+
+    assert.deepEqual(reportedErrors, [cleanupError]);
+    assert.equal(focusOrCreateCount, 0);
+    assert.equal(resumeQuitCount, 1);
+    assert.equal(secondQuitPrevented, false);
+    assert.equal(coordinator.getWindowCreationSignal(), undefined);
+  });
+});

--- a/apps/desktop/src/main/__tests__/session-startup-recovery-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-startup-recovery-contract.test.ts
@@ -33,14 +33,24 @@ describe('session startup recovery contract', () => {
     // combined main-process source so the ordering + recovery pins follow it.
     const src = await readMainProcessCombinedSource();
     const sessionManager = await readFile(join(REPO_ROOT, 'packages/runtime/src/session-manager.ts'), 'utf8');
-    const backgroundBlock = src.match(/async function runBackgroundStartup\(\): Promise<void> \{[\s\S]*?\n  \}/)?.[0] ?? '';
+    const backgroundBlock =
+      src.match(/async function runBackgroundStartup\(\): Promise<void> \{[\s\S]*?\n  \}/)?.[0] ??
+      '';
+    const cleanupBlock =
+      src.match(/async function runBeforeQuitCleanup\(\): Promise<void> \{[\s\S]*?\n  \}/)?.[0] ??
+      '';
 
     assert.match(src, /async function recoverInterruptedSessionsOnStartup\(\): Promise<void>/);
     assert.match(backgroundBlock, /await recoverInterruptedSessionsOnStartup\(\);/, 'recovery must run inside background startup');
     assert.match(
       src,
-      /const backgroundStartup = runBackgroundStartup\(\);[\s\S]*?await mainWindowController\.createWindow\(\);[\s\S]*?await backgroundStartup;/,
+      /backgroundStartup = runBackgroundStartup\(\);[\s\S]*?await mainWindowController\.createWindow\(initialWindowSignal\);[\s\S]*?await backgroundStartup;/,
       'window creation must not wait on background startup, but the process must await it before settling',
+    );
+    assert.match(
+      cleanupBlock,
+      /await backgroundStartup;[\s\S]*?automationWiring\.scheduler\.dispose\(\)/,
+      'quit cleanup must let background startup settle before disposing resources it may start',
     );
     assert.match(
       sessionManager,

--- a/apps/desktop/src/main/__tests__/single-instance-lock-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/single-instance-lock-contract.test.ts
@@ -5,6 +5,14 @@ import { resolve } from 'node:path';
 import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
 
 const MAIN_TS = resolve(import.meta.dirname, '../../../../../apps/desktop/src/main/main.ts');
+const APP_LIFECYCLE_TS = resolve(
+  import.meta.dirname,
+  '../../../../../apps/desktop/src/main/app-lifecycle.ts',
+);
+const MAIN_WINDOW_TS = resolve(
+  import.meta.dirname,
+  '../../../../../apps/desktop/src/main/main-window.ts',
+);
 
 describe('single-instance lock contract', () => {
   it('requests the lock before any workspace/store setup, and exits the losing process immediately', async () => {
@@ -41,22 +49,26 @@ describe('single-instance lock contract', () => {
     // dock) must not be a silent no-op. `focus()` alone is a no-op with no
     // window -- the handler must fall back to createWindow().
     const helperMatch = src.match(
-      /function focusOrCreateMainWindow\(\): void \{([\s\S]*?)\n\}/,
+      /function focusOrCreateMainWindow\(signal: AbortSignal\): void \{([\s\S]*?)\n\}/,
     );
     assert.ok(helperMatch, 'a focusOrCreateMainWindow (or equivalently named) helper must exist');
     const helperBody = helperMatch![1];
     assert.match(helperBody, /hasOpenWindows\(\)/, 'helper must branch on whether a window currently exists');
     assert.match(helperBody, /mainWindowController\.focus\(\)/, 'helper must focus the existing window when one exists');
-    assert.match(helperBody, /mainWindowController\.createWindow\(\)/, 'helper must create a window when none exists');
+    assert.match(
+      helperBody,
+      /void mainWindowController\s*\.createWindow\(signal\)\s*\.catch\(/,
+      'helper must create a window with the quit signal and handle event-listener failures locally',
+    );
 
     assert.match(
       src,
-      /app\.on\('second-instance', focusOrCreateMainWindow\)/,
-      'second-instance must be wired to the shared focus-or-create helper, not a bare focus() call',
+      /app\.on\('second-instance', quitCoordinator\.focusOrCreateWindow\)/,
+      'second-instance must be wired to the shared quit-aware focus-or-create helper, not a bare focus() call',
     );
     assert.match(
       src,
-      /app\.on\('activate', focusOrCreateMainWindow\)/,
+      /app\.on\('activate', quitCoordinator\.focusOrCreateWindow\)/,
       'activate should share the exact same behavior as second-instance',
     );
   });
@@ -69,5 +81,43 @@ describe('single-instance lock contract', () => {
     const hasOpenWindows = mainWindow.match(/hasOpenWindows\(\) \{([\s\S]*?)\n    \}/)?.[1] ?? '';
     assert.match(hasOpenWindows, /mainWindow !== null && !mainWindow\.isDestroyed\(\)/);
     assert.doesNotMatch(hasOpenWindows, /BrowserWindow\.getAllWindows/);
+  });
+
+  it('routes every window creation through the quit signal before constructing BrowserWindow', async () => {
+    const [lifecycle, mainWindow] = await Promise.all([
+      readFile(APP_LIFECYCLE_TS, 'utf8'),
+      readFile(MAIN_WINDOW_TS, 'utf8'),
+    ]);
+
+    assert.match(
+      lifecycle,
+      /const initialWindowSignal = quitCoordinator\.getWindowCreationSignal\(\);[\s\S]*if \(!initialWindowSignal\) return;[\s\S]*await mainWindowController\.createWindow\(initialWindowSignal\)/,
+      'the initial window must carry the same quit signal and stop if cleanup already started',
+    );
+    assert.doesNotMatch(
+      lifecycle,
+      /await mainWindowController\.createWindow\(\)/,
+      'startup must not bypass the quit coordinator',
+    );
+
+    const createWindowBody =
+      mainWindow.match(
+        /async function createWindow\(signal: AbortSignal\): Promise<void> \{([\s\S]*?)\n  \}/,
+      )?.[1] ?? '';
+    const constructWindow = createWindowBody.indexOf('new BrowserWindow(');
+    const lastAwaitBeforeConstruction = createWindowBody
+      .slice(0, constructWindow)
+      .lastIndexOf('await ');
+    const abortGate = createWindowBody.indexOf(
+      'if (signal.aborted) return;',
+      lastAwaitBeforeConstruction,
+    );
+    assert.notEqual(lastAwaitBeforeConstruction, -1, 'window creation must retain asynchronous preparation');
+    assert.notEqual(abortGate, -1, 'window creation must re-check the quit signal after preparation');
+    assert.notEqual(constructWindow, -1, 'the contract must locate BrowserWindow construction');
+    assert.ok(
+      lastAwaitBeforeConstruction < abortGate && abortGate < constructWindow,
+      'an in-flight request must re-check the quit signal after awaits and immediately before BrowserWindow construction',
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
+++ b/apps/desktop/src/main/__tests__/subscription-shared-credential-store.test.ts
@@ -538,14 +538,22 @@ describe('OAuth subscription token authority (shared CredentialStore)', () => {
   it('finishes credential migration before the first window can issue OAuth mutations', async () => {
     const src = await readMainProcessCombinedSource();
     const credentialStartup = src.indexOf('await runCredentialStartup();');
-    const backgroundStartup = src.indexOf('const backgroundStartup = runBackgroundStartup();');
-    const createWindow = src.indexOf('await mainWindowController.createWindow();', backgroundStartup);
-    const secondInstance = src.indexOf("app.on('second-instance', focusOrCreateMainWindow);");
-    const activate = src.indexOf("app.on('activate', focusOrCreateMainWindow);");
+    const initialWindowSignal = src.indexOf(
+      'const initialWindowSignal = quitCoordinator.getWindowCreationSignal();',
+    );
+    const backgroundStartup = src.indexOf('backgroundStartup = runBackgroundStartup();');
+    const createWindow = src.indexOf(
+      'await mainWindowController.createWindow(initialWindowSignal);',
+      backgroundStartup,
+    );
+    const secondInstance = src.indexOf("app.on('second-instance'");
+    const activate = src.indexOf("app.on('activate'");
 
     assert.notEqual(credentialStartup, -1, 'startup must expose an awaited credential migration phase');
     assert.ok(
-      credentialStartup < backgroundStartup && backgroundStartup < createWindow,
+      credentialStartup < initialWindowSignal &&
+        initialWindowSignal < backgroundStartup &&
+        backgroundStartup < createWindow,
       'credential migration must finish before background startup opens the interactive window',
     );
     assert.ok(

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -36,6 +36,7 @@ import type { assembleDesktopTools } from './tool-assembly.js';
 import type { StreamEvents } from './session-stream.js';
 import type { SettingsIpcHandle } from './settings-ipc-main.js';
 import { runProjectStartupMigration } from './project-startup-migration.js';
+import { createAppQuitCoordinator } from './app-quit-coordinator.js';
 
 type AssembledTools = ReturnType<typeof assembleDesktopTools>;
 type PricingLookup = ReturnType<typeof buildPricingLookup>;
@@ -70,7 +71,7 @@ export interface AppLifecycleDeps {
   streamEvents: StreamEvents;
   /** Focus-or-create for the main window; stays in main.ts next to the
    *  controller and is registered here on `second-instance` / `activate`. */
-  focusOrCreateMainWindow: () => void;
+  focusOrCreateMainWindow: (signal: AbortSignal) => void;
   emitConnectionListChanged: () => void;
   emitSessionsChanged: (reason: 'migrated') => void;
   handleExternalSettingsChange: () => Promise<void>;
@@ -131,7 +132,14 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     setLookupPricing,
   } = deps;
 
+  let backgroundStartup: Promise<void> | undefined;
   let configWatcher: ConfigFileWatcher | undefined;
+  const quitCoordinator = createAppQuitCoordinator({
+    cleanup: runBeforeQuitCleanup,
+    focusOrCreateWindow: focusOrCreateMainWindow,
+    onCleanupError: (error) => console.error('[shutdown] cleanup failed:', error),
+    resumeQuit: () => app.quit(),
+  });
 
   async function recoverInterruptedSessionsOnStartup(): Promise<void> {
     try {
@@ -237,10 +245,12 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     // main.ts. SQLite keeps live file handles, so resetting the workspace
     // here after store construction would detach the canonical database.
     await runCredentialStartup();
-    app.on('second-instance', focusOrCreateMainWindow);
-    app.on('activate', focusOrCreateMainWindow);
-    const backgroundStartup = runBackgroundStartup();
-    await mainWindowController.createWindow();
+    const initialWindowSignal = quitCoordinator.getWindowCreationSignal();
+    if (!initialWindowSignal) return;
+    app.on('second-instance', quitCoordinator.focusOrCreateWindow);
+    app.on('activate', quitCoordinator.focusOrCreateWindow);
+    backgroundStartup = runBackgroundStartup();
+    await mainWindowController.createWindow(initialWindowSignal);
     // Keep the process alive until background work settles so schedulers
     // / bridges aren't torn down mid-start by a fast window-all-closed.
     await backgroundStartup;
@@ -321,21 +331,14 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     if (process.platform !== 'darwin') app.quit();
   });
 
-  let beforeQuitCleanupComplete = false;
-  let beforeQuitCleanupStarted = false;
-
-  app.on('before-quit', (event) => {
-    if (beforeQuitCleanupComplete) return;
-    event.preventDefault();
-    if (beforeQuitCleanupStarted) return;
-    beforeQuitCleanupStarted = true;
-    void runBeforeQuitCleanup().finally(() => {
-      beforeQuitCleanupComplete = true;
-      app.quit();
-    });
-  });
+  app.on('before-quit', quitCoordinator.handleBeforeQuit);
 
   async function runBeforeQuitCleanup(): Promise<void> {
+    try {
+      await backgroundStartup;
+    } catch (error) {
+      console.error('[shutdown] background startup failed:', error);
+    }
     automationWiring.scheduler.dispose();
     goalWiring.coordinator.dispose();
     goalWiring.manager.dispose();

--- a/apps/desktop/src/main/app-quit-coordinator.ts
+++ b/apps/desktop/src/main/app-quit-coordinator.ts
@@ -1,0 +1,48 @@
+export interface AppQuitEvent {
+  preventDefault(): void;
+}
+
+export interface AppQuitCoordinator {
+  focusOrCreateWindow(): void;
+  getWindowCreationSignal(): AbortSignal | undefined;
+  handleBeforeQuit(event: AppQuitEvent): void;
+}
+
+export interface AppQuitCoordinatorDeps {
+  cleanup(): Promise<void>;
+  focusOrCreateWindow(signal: AbortSignal): void;
+  onCleanupError(error: unknown): void;
+  resumeQuit(): void;
+}
+
+type AppQuitPhase = 'running' | 'cleaning' | 'ready-to-exit';
+
+export function createAppQuitCoordinator(deps: AppQuitCoordinatorDeps): AppQuitCoordinator {
+  let phase: AppQuitPhase = 'running';
+  const windowCreationAbort = new AbortController();
+
+  return {
+    focusOrCreateWindow(): void {
+      if (phase !== 'running') return;
+      deps.focusOrCreateWindow(windowCreationAbort.signal);
+    },
+    getWindowCreationSignal(): AbortSignal | undefined {
+      return phase === 'running' ? windowCreationAbort.signal : undefined;
+    },
+    handleBeforeQuit(event): void {
+      if (phase === 'ready-to-exit') return;
+      event.preventDefault();
+      if (phase === 'cleaning') return;
+      phase = 'cleaning';
+      windowCreationAbort.abort();
+      const finishCleanup = () => {
+        phase = 'ready-to-exit';
+        deps.resumeQuit();
+      };
+      void deps.cleanup().then(finishCleanup, (error) => {
+        deps.onCleanupError(error);
+        finishCleanup();
+      });
+    },
+  };
+}

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -16,7 +16,7 @@ type SettingsReader = {
 };
 
 export interface MainWindowController {
-  createWindow(): Promise<void>;
+  createWindow(signal: AbortSignal): Promise<void>;
   send(channel: string, ...args: unknown[]): void;
   // PR-SHOW-AFTER-FIRST-COMMIT: reveal the hidden window after the renderer's
   // first React commit. Idempotent + e2e-fixture-safe (see notifyRendererReady).
@@ -143,7 +143,8 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     await browserViews?.disposeAll();
   }
 
-  async function createWindow(): Promise<void> {
+  async function createWindow(signal: AbortSignal): Promise<void> {
+    if (signal.aborted) return;
     await mkdir(workspaceRoot, { recursive: true });
     installApplicationMenu();
     // Restore previously-saved bounds when available; first launch and
@@ -167,6 +168,10 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     // theme variant we're about to screenshot, so the very first frame
     // doesn't capture a light-on-dark or dark-on-light flash.
     const persistedTheme = (await settingsStore.get()).appearance?.theme ?? 'auto';
+    // Quit cleanup permanently closes process-scoped stores. Re-check after
+    // asynchronous preparation so an in-flight request cannot attach a new
+    // renderer to resources that teardown has already started closing.
+    if (signal.aborted) return;
     const themePref = e2eFixture?.theme ?? persistedTheme;
     const isDark =
       themePref === 'dark' ||

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -598,11 +598,13 @@ const mainWindowController = createMainWindowController({
 // Shared by 'second-instance' and 'activate': focus the existing window, or
 // create one if all windows were closed while the app (macOS: still in the
 // dock) stayed running -- a second launch attempt must not be a silent no-op.
-function focusOrCreateMainWindow(): void {
+function focusOrCreateMainWindow(signal: AbortSignal): void {
   if (mainWindowController.hasOpenWindows()) {
     mainWindowController.focus();
   } else {
-    void mainWindowController.createWindow();
+    void mainWindowController
+      .createWindow(signal)
+      .catch((error) => console.error('[window] failed to create:', error));
   }
 }
 const safeSendToRenderer = mainWindowController.send;


### PR DESCRIPTION
## Summary

- model application shutdown as one `running → cleaning → ready-to-exit` lifecycle and reject window requests once cleanup becomes irreversible
- propagate one quit-owned `AbortSignal` through initial and event-driven window creation, including a re-check after the final asynchronous preparation step
- wait for concurrent background startup before disposing the resources it can activate, and continue the resumed quit path when cleanup rejects

## Verification

- `npm run clean:main && npm run build:main && npm run test:dist` in `apps/desktop` — 2965 passed
- `npm run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check`

## Root cause

The first Electron `before-quit` event is prevented while asynchronous cleanup closes process-scoped resources, including the SQLite session store. During that interval, the already-registered `second-instance` and macOS `activate` listeners could still call `createWindow()`. A request that had already entered the asynchronous window factory could also resume after cleanup began.

That invalid transition created a new renderer in a main process whose canonical stores had already been permanently closed. Its startup IPC calls then failed with `SQLite session metadata store is closed`, leaving the UI on its loading skeleton. The same uncoordinated boundary allowed background startup to activate watchers or schedulers after teardown had disposed them.

This change makes the lifecycle owner the single authority for both shutdown phase and window-creation cancellation. It does not recreate closed stores or add renderer retries.

## Review focus

`activate` and `second-instance` events received during irreversible cleanup are intentionally ignored. The coordinator does not call `app.relaunch()`: restart ownership must remain with the caller that knows whether quit came from the updater (`quitAndInstall`) or an ordinary user exit. A launch after the old process has exited starts normally.

The cancellation contract is “do not construct a new `BrowserWindow` after cleanup starts.” A window constructed before that boundary is an existing window and follows Electron's normal resumed-quit close path.
