### PR TITLE
feat(cli): add a read-only /context diagnostics view

### DIFF
--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -22,6 +22,7 @@ import {
 import {
   GoalManager,
   SessionActivityRegistry,
+  type ContextDiagnostics,
   type GoalTurnOutcome,
   type ShellRunUpdate,
 } from '@maka/runtime';
@@ -6660,6 +6661,100 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('/context renders persisted request diagnostics without preparing a model turn', async () => {
+    const terminal = new FakeTerminal();
+    Object.defineProperty(terminal, 'columns', { value: 36 });
+    const driver = new SlashCommandDriver();
+    driver.contextDiagnostics = {
+      status: 'available',
+      providerId: 'anthropic',
+      modelId: 'claude-test',
+      completedAt: 20,
+      inputTokens: 40,
+      contextWindow: 200,
+      segments: [
+        { kind: 'system_instructions', bytes: 400, estimatedTokens: 100 },
+        { kind: 'tool_definitions', bytes: 800, estimatedTokens: 200 },
+        { kind: 'messages', bytes: 1_200, estimatedTokens: 300 },
+      ],
+      compaction: {
+        kind: 'history',
+        phase: 'pre_turn',
+        eventCount: 12,
+        turnCount: 3,
+        estimatedTokens: 77,
+      },
+    };
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/context');
+    terminal.input('\r');
+
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('Context'));
+    const out = plainTerminalOutput(terminal.output()).replace(/\s+/g, ' ');
+    assert.match(out, /anthropic \/ claude-test/);
+    assert.match(out, /40 tokens \(provider-reported\)/);
+    assert.match(out, /200 tokens \(request-model snapshot\)/);
+    assert.match(out, /System instructions: ≈100 tokens/);
+    assert.match(out, /Compaction: history pre-turn/);
+    assert.deepEqual(driver.prompts, []);
+    assert.equal(driver.contextDiagnosticsRequests, 1);
+    assert.equal(
+      plainTerminalOutput(terminal.screenOutput())
+        .split(/\r?\n/)
+        .every((line) => visibleWidth(line) <= terminal.columns),
+      true,
+    );
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
+  test('/context shows an explicit empty state before any completed request', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/context');
+    terminal.input('\r');
+
+    await waitFor(() =>
+      plainTerminalOutput(terminal.output()).includes(
+        'No completed provider request exists for this session.',
+      ),
+    );
+    assert.deepEqual(driver.prompts, []);
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('/new clears the transcript and starts a fresh session', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver([
@@ -9919,6 +10014,11 @@ class SlashCommandDriver implements MakaSessionDriver {
   readonly moves: string[] = [];
   startNewSessionCalls = 0;
   resumeCalls = 0;
+  contextDiagnosticsRequests = 0;
+  contextDiagnostics: ContextDiagnostics = {
+    status: 'unavailable',
+    reason: 'no_completed_request',
+  };
   protected sessionId = 'session-1';
   protected orchestrationMode: OrchestrationMode = 'default';
 
@@ -9929,6 +10029,11 @@ class SlashCommandDriver implements MakaSessionDriver {
 
   async listSessions(): Promise<SessionSummary[]> {
     return this.sessions;
+  }
+
+  async getContextDiagnostics(): Promise<ContextDiagnostics> {
+    this.contextDiagnosticsRequests += 1;
+    return this.contextDiagnostics;
   }
 
   preparePrompt(

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -6700,11 +6700,18 @@ describe('Maka Pi TUI runner', () => {
 
     await waitFor(() => plainTerminalOutput(terminal.output()).includes('Context'));
     const out = plainTerminalOutput(terminal.output()).replace(/\s+/g, ' ');
-    assert.match(out, /anthropic \/ claude-test/);
-    assert.match(out, /40 tokens \(provider-reported\)/);
-    assert.match(out, /200 tokens \(request-model snapshot\)/);
-    assert.match(out, /System instructions: ≈100 tokens/);
-    assert.match(out, /Compaction: history pre-turn/);
+    assert.match(
+      out,
+      /Context Latest completed request anthropic · claude-test Usage Used: 40 tokens provider-reported Total: 200 tokens request-model snapshot Free: 160 tokens calculated Share: 20% calculated/,
+    );
+    assert.match(
+      out,
+      /Estimated breakdown System instructions: ≈100 tokens Tool definitions: ≈200 tokens Messages: ≈300 tokens/,
+    );
+    assert.match(
+      out,
+      /History compaction pre-turn · 12 events \/ 3 turns ≈77 tokens · local estimate/,
+    );
     assert.deepEqual(driver.prompts, []);
     assert.equal(driver.contextDiagnosticsRequests, 1);
     assert.equal(
@@ -6723,9 +6730,17 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
-  test('/context shows an explicit empty state before any completed request', async () => {
+  test('/context labels unavailable request diagnostics', async () => {
     const terminal = new FakeTerminal();
+    Object.defineProperty(terminal, 'columns', { value: 36 });
     const driver = new SlashCommandDriver();
+    driver.contextDiagnostics = {
+      status: 'available',
+      providerId: 'anthropic',
+      modelId: 'claude-test',
+      completedAt: 20,
+      segments: [],
+    };
     const run = runMakaPiTui({
       title: 'Maka',
       driver,
@@ -6739,10 +6754,21 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/context');
     terminal.input('\r');
 
-    await waitFor(() =>
-      plainTerminalOutput(terminal.output()).includes(
-        'No completed provider request exists for this session.',
-      ),
+    await waitFor(() => plainTerminalOutput(terminal.output()).includes('provider report missing'));
+    const out = plainTerminalOutput(terminal.output()).replace(/\s+/g, ' ');
+    assert.match(
+      out,
+      /Usage Used: unavailable provider report missing Total: unavailable request-model snapshot missing Free: unavailable requires Used and Total Share: unavailable requires Used and Total/,
+    );
+    assert.match(
+      out,
+      /Estimated breakdown Unavailable no captured request segments History compaction Unavailable for this request/,
+    );
+    assert.equal(
+      plainTerminalOutput(terminal.screenOutput())
+        .split(/\r?\n/)
+        .every((line) => visibleWidth(line) <= terminal.columns),
+      true,
     );
     assert.deepEqual(driver.prompts, []);
 
@@ -6753,6 +6779,51 @@ describe('Maka Pi TUI runner', () => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
+  });
+
+  test('/context explains why diagnostics are unavailable', async () => {
+    const cases: Array<{
+      reason: 'no_completed_request' | 'trace_unavailable';
+      message: string;
+    }> = [
+      {
+        reason: 'no_completed_request',
+        message: 'No completed provider request exists for this session.',
+      },
+      {
+        reason: 'trace_unavailable',
+        message: 'Provider request trace data could not be read.',
+      },
+    ];
+
+    for (const { reason, message } of cases) {
+      const terminal = new FakeTerminal();
+      const driver = new SlashCommandDriver();
+      driver.contextDiagnostics = { status: 'unavailable', reason };
+      const run = runMakaPiTui({
+        title: 'Maka',
+        driver,
+        cwd: '/repo',
+        model: 'claude-sonnet-4-5',
+        connectionSlug: 'claude-subscription',
+        permissionMode: 'ask',
+        terminal,
+      });
+
+      terminal.input('/context');
+      terminal.input('\r');
+
+      await waitFor(() => plainTerminalOutput(terminal.output()).includes(message));
+      assert.deepEqual(driver.prompts, []);
+
+      exitMaka(terminal);
+      await Promise.race([
+        run,
+        delay(50).then(() => {
+          throw new Error('TUI did not close during test cleanup');
+        }),
+      ]);
+    }
   });
 
   test('/new clears the transcript and starts a fresh session', async () => {

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -15,7 +15,11 @@ import type {
   UserQuestionResponse,
 } from '@maka/core';
 import { createMakaSessionDriver } from '../session-driver.js';
-import type { RuntimeContinuation, SafeBoundaryContinuationPlan } from '@maka/runtime';
+import type {
+  ContextDiagnostics,
+  RuntimeContinuation,
+  SafeBoundaryContinuationPlan,
+} from '@maka/runtime';
 
 describe('Maka session driver', () => {
   test('creates an ask-permission session from the first prompt and streams the turn', async () => {
@@ -1032,6 +1036,35 @@ describe('Maka session driver', () => {
     assert.equal(driver.retractQueued?.(), '');
     assert.deepEqual(runtime.steered, []);
   });
+
+  test('context diagnostics follow the active persisted session across switch and resume', async () => {
+    const runtime = new RecordingRuntime();
+    const cwd = process.cwd();
+    runtime.sessionSummaries = [sessionSummary({ id: 'session-2', cwd })];
+    runtime.contextDiagnostics.set('session-2', {
+      status: 'available',
+      providerId: 'anthropic',
+      modelId: 'claude-test',
+      completedAt: 10,
+      inputTokens: 40,
+      contextWindow: 200,
+      segments: [],
+    });
+    const driver = createMakaSessionDriver({
+      runtime,
+      cwd,
+      llmConnectionSlug: 'anthropic',
+      model: 'claude-sonnet-4-5',
+    });
+
+    await driver.switchSession('session-2');
+    const beforeResume = await driver.getContextDiagnostics?.();
+    await collect(driver.resumeLatest!());
+    const afterResume = await driver.getContextDiagnostics?.();
+
+    assert.deepEqual(afterResume, beforeResume);
+    assert.deepEqual(runtime.contextReads, ['session-2', 'session-2']);
+  });
 });
 
 class RecordingRuntime {
@@ -1064,6 +1097,8 @@ class RecordingRuntime {
   readonly branchedBefore: Array<{ sessionId: string; sourceTurnId: string }> = [];
   readonly sessionMessages = new Map<string, StoredMessage[]>();
   readonly executionBoundaries = new Map<string, ExecutionBoundary>();
+  readonly contextDiagnostics = new Map<string, ContextDiagnostics>();
+  readonly contextReads: string[] = [];
   sessionSummaries: SessionSummary[] = [];
   updatedSessionName = 'New Chat';
 
@@ -1272,6 +1307,16 @@ class RecordingRuntime {
           network: { kind: 'restricted' },
         },
         revision: 0,
+      }
+    );
+  }
+
+  async getContextDiagnostics(sessionId: string): Promise<ContextDiagnostics> {
+    this.contextReads.push(sessionId);
+    return (
+      this.contextDiagnostics.get(sessionId) ?? {
+        status: 'unavailable',
+        reason: 'no_completed_request',
       }
     );
   }

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -33,7 +33,7 @@ import {
   type ForeignSessionSummary,
 } from '@maka/core/foreign-session';
 import type { ForeignSessionStore } from '@maka/storage';
-import type { GoalTurnOutcome, SessionActivityLease } from '@maka/runtime';
+import type { ContextDiagnostics, GoalTurnOutcome, SessionActivityLease } from '@maka/runtime';
 import type { ModelChoice } from './connection-target.js';
 import {
   listApiKeyOnboardableProviders,
@@ -2161,6 +2161,32 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const slashCommands: MakaSlashCommand[] = [
     {
+      name: 'context',
+      description: 'Show latest request context usage',
+      run: (parts: string[]) => {
+        if (parts.length !== 1) {
+          state.entries.push({
+            kind: 'notice',
+            level: 'error',
+            text: 'Usage: /context',
+          });
+          requestRender();
+          return;
+        }
+        void runControl(async () => {
+          const diagnostics: ContextDiagnostics = input.driver.getContextDiagnostics
+            ? await input.driver.getContextDiagnostics()
+            : { status: 'unavailable', reason: 'trace_unavailable' };
+          state.entries.push({
+            kind: 'notice',
+            level: 'info',
+            text: formatContextDiagnostics(diagnostics),
+          });
+          requestRender();
+        });
+      },
+    },
+    {
       name: 'compact',
       description: 'Compact session context',
       run: (parts: string[]) => {
@@ -2646,6 +2672,66 @@ const BOTTOM_PICKER_MARGIN_ROWS = 4;
 // full slash-command menu, so a bare `/` shows every command rather than
 // silently clipping the last command.
 const EDITOR_AUTOCOMPLETE_MAX_VISIBLE = 24;
+
+function formatContextDiagnostics(diagnostics: ContextDiagnostics): string {
+  if (diagnostics.status === 'unavailable') {
+    return diagnostics.reason === 'no_completed_request'
+      ? 'Context unavailable\nNo completed provider request exists for this session.'
+      : 'Context unavailable\nProvider request trace data could not be read.';
+  }
+
+  const lines = [
+    'Context — latest completed request',
+    `Request: ${diagnostics.providerId} / ${diagnostics.modelId}`,
+    diagnostics.inputTokens === undefined
+      ? 'Context used: unavailable (provider usage missing)'
+      : `Context used: ${formatContextCount(diagnostics.inputTokens)} tokens (provider-reported)`,
+    diagnostics.contextWindow === undefined
+      ? 'Context total: unavailable (window not captured for this request)'
+      : `Context total: ${formatContextCount(diagnostics.contextWindow)} tokens (request-model snapshot)`,
+  ];
+  if (diagnostics.inputTokens !== undefined && diagnostics.contextWindow !== undefined) {
+    const free = Math.max(0, diagnostics.contextWindow - diagnostics.inputTokens);
+    const percent = Math.round((diagnostics.inputTokens / diagnostics.contextWindow) * 100);
+    lines.push(
+      `Context free: ${formatContextCount(free)} tokens (derived)`,
+      `Context used: ${percent}% (derived)`,
+    );
+  } else {
+    lines.push('Context free and percentage: unavailable');
+  }
+
+  lines.push('Breakdown (local estimates from serialized request bytes)');
+  if (diagnostics.segments.length === 0) {
+    lines.push('  unavailable (no captured request segments)');
+  } else {
+    const labels: Record<(typeof diagnostics.segments)[number]['kind'], string> = {
+      system_instructions: 'System instructions',
+      tool_definitions: 'Tool definitions',
+      messages: 'Messages',
+      other: 'Other request options',
+    };
+    for (const segment of diagnostics.segments) {
+      lines.push(
+        `  ${labels[segment.kind]}: ≈${formatContextCount(segment.estimatedTokens)} tokens`,
+      );
+    }
+  }
+
+  if (diagnostics.compaction) {
+    const compaction = diagnostics.compaction;
+    lines.push(
+      `Compaction: history ${compaction.phase.replace('_', '-')} · ${formatContextCount(compaction.eventCount)} events / ${formatContextCount(compaction.turnCount)} turns · ≈${formatContextCount(compaction.estimatedTokens)} tokens`,
+    );
+  } else {
+    lines.push('Compaction: unavailable for this request');
+  }
+  return lines.join('\n');
+}
+
+function formatContextCount(value: number): string {
+  return value.toLocaleString('en-US');
+}
 
 function flattenLinkedSessionTree(
   roots: readonly SessionSummary[],

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -2681,35 +2681,51 @@ function formatContextDiagnostics(diagnostics: ContextDiagnostics): string {
   }
 
   const lines = [
-    'Context — latest completed request',
-    `Request: ${diagnostics.providerId} / ${diagnostics.modelId}`,
-    diagnostics.inputTokens === undefined
-      ? 'Context used: unavailable (provider usage missing)'
-      : `Context used: ${formatContextCount(diagnostics.inputTokens)} tokens (provider-reported)`,
-    diagnostics.contextWindow === undefined
-      ? 'Context total: unavailable (window not captured for this request)'
-      : `Context total: ${formatContextCount(diagnostics.contextWindow)} tokens (request-model snapshot)`,
+    'Context',
+    'Latest completed request',
+    `${diagnostics.providerId} · ${diagnostics.modelId}`,
+    '',
+    'Usage',
   ];
+  const pushMetric = (label: string, value: string, source: string): void => {
+    lines.push(`  ${label}: ${value}`, `    ${source}`);
+  };
+  pushMetric(
+    'Used',
+    diagnostics.inputTokens === undefined
+      ? 'unavailable'
+      : `${formatContextCount(diagnostics.inputTokens)} tokens`,
+    diagnostics.inputTokens === undefined ? 'provider report missing' : 'provider-reported',
+  );
+  pushMetric(
+    'Total',
+    diagnostics.contextWindow === undefined
+      ? 'unavailable'
+      : `${formatContextCount(diagnostics.contextWindow)} tokens`,
+    diagnostics.contextWindow === undefined
+      ? 'request-model snapshot missing'
+      : 'request-model snapshot',
+  );
+
   if (diagnostics.inputTokens !== undefined && diagnostics.contextWindow !== undefined) {
     const free = Math.max(0, diagnostics.contextWindow - diagnostics.inputTokens);
     const percent = Math.round((diagnostics.inputTokens / diagnostics.contextWindow) * 100);
-    lines.push(
-      `Context free: ${formatContextCount(free)} tokens (derived)`,
-      `Context used: ${percent}% (derived)`,
-    );
+    pushMetric('Free', `${formatContextCount(free)} tokens`, 'calculated');
+    pushMetric('Share', `${percent}%`, 'calculated');
   } else {
-    lines.push('Context free and percentage: unavailable');
+    pushMetric('Free', 'unavailable', 'requires Used and Total');
+    pushMetric('Share', 'unavailable', 'requires Used and Total');
   }
 
-  lines.push('Breakdown (local estimates from serialized request bytes)');
+  lines.push('', 'Estimated breakdown');
   if (diagnostics.segments.length === 0) {
-    lines.push('  unavailable (no captured request segments)');
+    lines.push('  Unavailable', '    no captured request segments');
   } else {
     const labels: Record<(typeof diagnostics.segments)[number]['kind'], string> = {
       system_instructions: 'System instructions',
       tool_definitions: 'Tool definitions',
       messages: 'Messages',
-      other: 'Other request options',
+      other: 'Other options',
     };
     for (const segment of diagnostics.segments) {
       lines.push(
@@ -2721,10 +2737,13 @@ function formatContextDiagnostics(diagnostics: ContextDiagnostics): string {
   if (diagnostics.compaction) {
     const compaction = diagnostics.compaction;
     lines.push(
-      `Compaction: history ${compaction.phase.replace('_', '-')} · ${formatContextCount(compaction.eventCount)} events / ${formatContextCount(compaction.turnCount)} turns · ≈${formatContextCount(compaction.estimatedTokens)} tokens`,
+      '',
+      'History compaction',
+      `  ${compaction.phase.replace('_', '-')} · ${formatContextCount(compaction.eventCount)} events / ${formatContextCount(compaction.turnCount)} turns`,
+      `  ≈${formatContextCount(compaction.estimatedTokens)} tokens · local estimate`,
     );
   } else {
-    lines.push('Compaction: unavailable for this request');
+    lines.push('', 'History compaction', '  Unavailable for this request');
   }
   return lines.join('\n');
 }

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -18,7 +18,11 @@ import type { OrchestrationMode } from '@maka/core/orchestration';
 import type { SessionSummary, StoredMessage } from '@maka/core/session';
 import { userFacingText } from '@maka/core/session';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
-import type { RuntimeContinuation, SafeBoundaryContinuationPlan } from '@maka/runtime';
+import type {
+  ContextDiagnostics,
+  RuntimeContinuation,
+  SafeBoundaryContinuationPlan,
+} from '@maka/runtime';
 import { DEFAULT_SESSION_NAME } from '@maka/core';
 
 const execFileAsync = promisify(execFile);
@@ -37,6 +41,7 @@ export interface MakaSessionRuntime {
   listSessions(): Promise<SessionSummary[]>;
   readExecutionBoundary(sessionId: string): Promise<ExecutionBoundary>;
   getMessages(sessionId: string): Promise<StoredMessage[]>;
+  getContextDiagnostics?(sessionId: string): Promise<ContextDiagnostics>;
   sendMessage(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
   compactSession(sessionId: string, input?: { turnId?: string }): AsyncIterable<SessionEvent>;
   planLatestAuthoritativeSafeBoundaryContinuation?(
@@ -169,6 +174,7 @@ export interface MakaSessionDriver {
   startNewSession(): void;
   stop(): Promise<void>;
   getSessionId(): string | null;
+  getContextDiagnostics?(): Promise<ContextDiagnostics>;
   getOrchestrationMode?(): OrchestrationMode;
 }
 
@@ -241,6 +247,14 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   async *compactSession(): AsyncIterable<SessionEvent> {
     if (!this.sessionId) throw new Error('Cannot compact before a session starts.');
     yield* this.input.runtime.compactSession(this.sessionId, { turnId: this.newId() });
+  }
+
+  async getContextDiagnostics(): Promise<ContextDiagnostics> {
+    if (!this.sessionId) return { status: 'unavailable', reason: 'no_completed_request' };
+    const read = this.input.runtime.getContextDiagnostics;
+    return read
+      ? read.call(this.input.runtime, this.sessionId)
+      : { status: 'unavailable', reason: 'trace_unavailable' };
   }
 
   async *resumeLatest(): AsyncIterable<SessionEvent> {

--- a/packages/headless/src/__tests__/provider-request-trace.test.ts
+++ b/packages/headless/src/__tests__/provider-request-trace.test.ts
@@ -192,6 +192,7 @@ test('exports the Run-header trace failure latch when its sentinel event is miss
         captureArtifactId: 'artifact-capture-1',
         providerId: 'openai',
         modelId: 'k3',
+        contextWindow: 200_000,
         requestHash: 'sha256:request-1',
         requestBytes: 100,
         segments: [],
@@ -213,6 +214,7 @@ test('exports the Run-header trace failure latch when its sentinel event is miss
     });
     const result = await traceAnalysis.readProviderRequestTrace(traceEventsPath);
 
+    assert.equal(result.attempts[0]?.contextWindow, 200_000);
     assert.throws(
       () => traceAnalysis.assertProviderRequestTraceComplete(result),
       /trace write failed evidence/i,

--- a/packages/headless/src/provider-request-trace.ts
+++ b/packages/headless/src/provider-request-trace.ts
@@ -384,6 +384,7 @@ function attemptFromEvent(
     !isNonNegativeInteger(data.step) ||
     !isPositiveInteger(data.attempt) ||
     !isNonNegativeInteger(data.requestBytes) ||
+    (data.contextWindow !== undefined && !isPositiveInteger(data.contextWindow)) ||
     !isNonNegativeFiniteNumber(data.startedAt) ||
     !isNonNegativeFiniteNumber(data.completedAt) ||
     !isAttemptStatus(data.status) ||
@@ -415,6 +416,7 @@ function attemptFromEvent(
   const cacheWriteInputTokens = data.cacheWriteInputTokens as number | undefined;
   const outputTokens = data.outputTokens as number | undefined;
   const reasoningTokens = data.reasoningTokens as number | undefined;
+  const contextWindow = data.contextWindow as number | undefined;
   const cacheReadInputSource = data.cacheReadInputSource as
     | ProviderRequestAttemptRecord['cacheReadInputSource']
     | undefined;
@@ -435,6 +437,7 @@ function attemptFromEvent(
       captureArtifactId: data.captureArtifactId as string,
       providerId: data.providerId as string,
       modelId: data.modelId as string,
+      ...(contextWindow !== undefined ? { contextWindow } : {}),
       requestHash: data.requestHash as string,
       requestBytes: data.requestBytes,
       segments: segments as PreparedRequestSegment[],

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -9183,7 +9183,10 @@ describe('AiSdkBackend RunTrace', () => {
       sessionId: 'session-1',
       header: header(),
       appendMessage: async () => {},
-      connection: connection(),
+      connection: {
+        ...connection(),
+        models: [{ id: 'mock-model-id', contextWindow: 200_000 }],
+      },
       apiKey: 'sk-test',
       modelId: 'mock-model-id',
       modelFactory: () => model,
@@ -9209,6 +9212,7 @@ describe('AiSdkBackend RunTrace', () => {
     assert.equal(attempts[0]?.step, 0);
     assert.equal(attempts[0]?.attempt, 1);
     assert.equal(attempts[0]?.status, 'completed');
+    assert.equal(attempts[0]?.contextWindow, 200_000);
     assert.equal(attempts[0]?.captureId, captures[0]?.captureId);
     assert.equal(attempts[0]?.cacheMissInputSource, 'derived');
     assert.equal(

--- a/packages/runtime/src/__tests__/context-diagnostics.test.ts
+++ b/packages/runtime/src/__tests__/context-diagnostics.test.ts
@@ -1,0 +1,257 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { AgentRunEvent, AgentRunHeader, AgentRunStore } from '@maka/core';
+import { createAgentRunStore } from '@maka/storage';
+import { readLatestContextDiagnostics } from '../context-diagnostics.js';
+
+test('reads the latest completed provider request instead of a later failed attempt', async () => {
+  const store = runStore([
+    {
+      header: runHeader('run-1', 1),
+      events: [attemptEvent('run-1', 'attempt-1', 10, 'completed', 'model-old', 10, 100)],
+    },
+    {
+      header: runHeader('run-2', 2),
+      events: [
+        attemptEvent('run-2', 'attempt-2', 20, 'completed', 'model-new', 40, 200),
+        attemptEvent('run-2', 'attempt-3', 30, 'failed', 'model-failed', undefined, 300),
+      ],
+    },
+  ]);
+
+  const diagnostics = await readLatestContextDiagnostics(store, 'session-1');
+
+  assert.deepEqual(diagnostics, {
+    status: 'available',
+    providerId: 'anthropic',
+    modelId: 'model-new',
+    completedAt: 20,
+    inputTokens: 40,
+    contextWindow: 200,
+    segments: [],
+  });
+});
+
+test('groups the completed request segments into explicit local estimates', async () => {
+  const store = runStore([
+    {
+      header: runHeader('run-1', 1),
+      events: [
+        attemptEvent('run-1', 'attempt-1', 10, 'completed', 'model', 610, 1_000, [
+          { kind: 'system_prompt', index: 0, cacheable: true, hash: 'system', bytes: 400 },
+          { kind: 'tool_schema', index: 0, cacheable: true, hash: 'tool', bytes: 800 },
+          { kind: 'message', index: 0, cacheable: true, hash: 'message', bytes: 1_200 },
+          {
+            kind: 'provider_options',
+            index: 0,
+            cacheable: false,
+            hash: 'options',
+            bytes: 40,
+          },
+        ]),
+      ],
+    },
+  ]);
+
+  const diagnostics = await readLatestContextDiagnostics(store, 'session-1');
+
+  assert.equal(diagnostics.status, 'available');
+  if (diagnostics.status !== 'available') return;
+  assert.deepEqual(diagnostics.segments, [
+    { kind: 'system_instructions', bytes: 400, estimatedTokens: 100 },
+    { kind: 'tool_definitions', bytes: 800, estimatedTokens: 200 },
+    { kind: 'messages', bytes: 1_200, estimatedTokens: 300 },
+    { kind: 'other', bytes: 40, estimatedTokens: 10 },
+  ]);
+});
+
+test('reports that no completed request exists instead of inferring session values', async () => {
+  const diagnostics = await readLatestContextDiagnostics(
+    runStore([{ header: runHeader('run-1', 1), events: [] }]),
+    'session-1',
+  );
+
+  assert.deepEqual(diagnostics, {
+    status: 'unavailable',
+    reason: 'no_completed_request',
+  });
+});
+
+test('does not fall back when the latest completed request trace is invalid', async () => {
+  const older = attemptEvent('run-1', 'attempt-1', 10, 'completed', 'model-old', 10, 100);
+  const invalidLatest = attemptEvent('run-1', 'attempt-2', 20, 'completed', 'model-new', 20, 200);
+  invalidLatest.data = {
+    ...invalidLatest.data,
+    segments: 'invalid',
+  } as AgentRunEvent['data'];
+
+  const diagnostics = await readLatestContextDiagnostics(
+    runStore([{ header: runHeader('run-1', 1), events: [older, invalidLatest] }]),
+    'session-1',
+  );
+
+  assert.deepEqual(diagnostics, {
+    status: 'unavailable',
+    reason: 'trace_unavailable',
+  });
+});
+
+test('reports the latest history compaction that preceded the displayed request', async () => {
+  const store = runStore([
+    {
+      header: runHeader('run-1', 1),
+      events: [
+        checkpointEvent('run-1', 5, 12, 3, 77),
+        attemptEvent('run-1', 'attempt-1', 10, 'completed', 'model', 40, 200),
+        checkpointEvent('run-1', 12, 20, 5, 88),
+      ],
+    },
+  ]);
+
+  const diagnostics = await readLatestContextDiagnostics(store, 'session-1');
+
+  assert.equal(diagnostics.status, 'available');
+  if (diagnostics.status !== 'available') return;
+  assert.deepEqual(diagnostics.compaction, {
+    kind: 'history',
+    phase: 'pre_turn',
+    eventCount: 12,
+    turnCount: 3,
+    estimatedTokens: 77,
+  });
+});
+
+test('reads the same diagnostics after reopening the durable run ledger', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-context-diagnostics-'));
+  try {
+    const writer = createAgentRunStore(root);
+    const header = runHeader('run-1', 1);
+    await writer.createRun(header);
+    await writer.appendEvent(
+      'session-1',
+      'run-1',
+      attemptEvent('run-1', 'attempt-1', 10, 'completed', 'model', 40, 200),
+    );
+
+    const diagnostics = await readLatestContextDiagnostics(createAgentRunStore(root), 'session-1');
+
+    assert.equal(diagnostics.status, 'available');
+    if (diagnostics.status !== 'available') return;
+    assert.equal(diagnostics.inputTokens, 40);
+    assert.equal(diagnostics.contextWindow, 200);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function runStore(
+  runs: Array<{ header: AgentRunHeader; events: AgentRunEvent[] }>,
+): Pick<AgentRunStore, 'listSessionRuns' | 'readEvents'> {
+  return {
+    listSessionRuns: async () => runs.map((run) => run.header),
+    readEvents: async (_sessionId, runId) =>
+      runs.find((run) => run.header.runId === runId)?.events ?? [],
+  };
+}
+
+function runHeader(runId: string, createdAt: number): AgentRunHeader {
+  return {
+    runId,
+    sessionId: 'session-1',
+    turnId: `turn-${runId}`,
+    status: 'completed',
+    backendKind: 'ai-sdk',
+    llmConnectionSlug: 'anthropic-main',
+    modelId: 'model',
+    cwd: '/repo',
+    permissionMode: 'ask',
+    createdAt,
+    updatedAt: createdAt,
+  };
+}
+
+function attemptEvent(
+  runId: string,
+  attemptId: string,
+  completedAt: number,
+  status: 'completed' | 'failed',
+  modelId: string,
+  inputTokens: number | undefined,
+  contextWindow: number,
+  segments: Array<Record<string, unknown>> = [],
+): AgentRunEvent {
+  const turnId = `turn-${runId}`;
+  return {
+    type: 'provider_request_attempt_recorded',
+    id: attemptId,
+    runId,
+    sessionId: 'session-1',
+    turnId,
+    ts: completedAt,
+    data: {
+      traceId: `trace-${attemptId}`,
+      attemptId,
+      turnId,
+      step: 0,
+      attempt: 1,
+      captureId: `capture-${attemptId}`,
+      captureArtifactId: `artifact-${attemptId}`,
+      providerId: 'anthropic',
+      modelId,
+      contextWindow,
+      requestHash: `hash-${attemptId}`,
+      requestBytes: 0,
+      segments,
+      startedAt: completedAt - 1,
+      completedAt,
+      status,
+      latencyMs: 1,
+      ...(inputTokens === undefined ? {} : { inputTokens }),
+    },
+  };
+}
+
+function checkpointEvent(
+  runId: string,
+  ts: number,
+  eventCount: number,
+  turnCount: number,
+  estimatedTokens: number,
+): AgentRunEvent {
+  return {
+    type: 'history_compact_checkpoint_recorded',
+    id: `checkpoint-${ts}`,
+    runId,
+    sessionId: 'session-1',
+    turnId: `turn-${runId}`,
+    ts,
+    data: {
+      checkpoint: {
+        kind: 'maka.history_compact_checkpoint',
+        version: 2,
+        checkpointId: `history-${ts}`,
+        sessionId: 'session-1',
+        createdAt: ts,
+        highWaterName: 'history',
+        highWaterSeq: ts,
+        coverage: {
+          eventCount,
+          turnCount,
+          through: {
+            runId,
+            turnId: `turn-${runId}`,
+            runtimeEventId: `runtime-${ts}`,
+          },
+          sourceDigest: `digest-${ts}`,
+        },
+        phase: 'pre_turn',
+        summary: 'Earlier context summary.',
+        limitations: ['Estimated summary.'],
+        estimatedTokens,
+      },
+    },
+  };
+}

--- a/packages/runtime/src/__tests__/context-diagnostics.test.ts
+++ b/packages/runtime/src/__tests__/context-diagnostics.test.ts
@@ -35,6 +35,38 @@ test('reads the latest completed provider request instead of a later failed atte
   });
 });
 
+test('ignores non-inline child runs when reading session context', async () => {
+  const store = runStore([
+    {
+      header: runHeader('run-parent', 1),
+      events: [
+        checkpointEvent('run-parent', 5, 12, 3, 77),
+        attemptEvent('run-parent', 'attempt-parent', 10, 'completed', 'model-parent', 40, 200),
+      ],
+    },
+    {
+      header: { ...runHeader('run-child', 2), parentRunId: 'run-parent' },
+      events: [
+        checkpointEvent('run-child', 8, 99, 9, 999),
+        attemptEvent('run-child', 'attempt-child', 20, 'completed', 'model-child', 50, 500),
+      ],
+    },
+  ]);
+
+  const diagnostics = await readLatestContextDiagnostics(store, 'session-1');
+
+  assert.equal(diagnostics.status, 'available');
+  if (diagnostics.status !== 'available') return;
+  assert.equal(diagnostics.modelId, 'model-parent');
+  assert.deepEqual(diagnostics.compaction, {
+    kind: 'history',
+    phase: 'pre_turn',
+    eventCount: 12,
+    turnCount: 3,
+    estimatedTokens: 77,
+  });
+});
+
 test('groups the completed request segments into explicit local estimates', async () => {
   const store = runStore([
     {

--- a/packages/runtime/src/__tests__/provider-request-telemetry.test.ts
+++ b/packages/runtime/src/__tests__/provider-request-telemetry.test.ts
@@ -264,6 +264,56 @@ describe('provider request capture commit', () => {
 });
 
 describe('provider request tracker', () => {
+  test('records the request model context window on completed attempts', async () => {
+    const attempts: telemetry.ProviderRequestAttemptRecord[] = [];
+    const tracker = new telemetry.ProviderRequestTracker({
+      traceId: 'trace-context',
+      turnId: 'turn-context',
+      contextWindow: 200_000,
+      now: () => Date.now(),
+      newId: () => 'id',
+      persistCapture: async () => ({ artifactId: 'artifact' }),
+      recordAttempt: async (attempt) => {
+        attempts.push(attempt);
+      },
+    });
+
+    const result = await tracker.trackStream({
+      providerId: 'anthropic',
+      modelId: 'claude-test',
+      params: preparedParams('hello'),
+      doStream: async () => ({ stream: streamOf([finishPart()]) }),
+    });
+    await drain(result.stream);
+
+    assert.equal(attempts[0]?.contextWindow, 200_000);
+  });
+
+  test('omits a non-positive request model context window', async () => {
+    const attempts: telemetry.ProviderRequestAttemptRecord[] = [];
+    const tracker = new telemetry.ProviderRequestTracker({
+      traceId: 'trace-context',
+      turnId: 'turn-context',
+      contextWindow: 0,
+      now: () => Date.now(),
+      newId: () => 'id',
+      persistCapture: async () => ({ artifactId: 'artifact' }),
+      recordAttempt: async (attempt) => {
+        attempts.push(attempt);
+      },
+    });
+
+    const result = await tracker.trackStream({
+      providerId: 'openai',
+      modelId: 'unknown-model',
+      params: preparedParams('hello'),
+      doStream: async () => ({ stream: streamOf([finishPart()]) }),
+    });
+    await drain(result.stream);
+
+    assert.equal(attempts[0]?.contextWindow, undefined);
+  });
+
   test('persists a logical capture before each physical attempt and reuses it for retries', async () => {
     const captures: Array<{
       captureId: string;

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -776,6 +776,10 @@ export class AiSdkBackend implements AgentBackend {
       ? new ProviderRequestTracker({
           traceId: providerRequestTraceId,
           turnId,
+          contextWindow: resolveSelectedModelContextWindow(
+            this.input.connection,
+            this.input.modelId,
+          ),
           now: this.now,
           newId: this.newId,
           persistCapture: recordProviderRequestCapture!,

--- a/packages/runtime/src/context-diagnostics.ts
+++ b/packages/runtime/src/context-diagnostics.ts
@@ -1,4 +1,4 @@
-import type { AgentRunStore } from '@maka/core';
+import { isSessionInlineRun, type AgentRunStore } from '@maka/core';
 import {
   validateHistoryCompactCheckpointShape,
   type HistoryCompactCheckpoint,
@@ -42,7 +42,7 @@ export async function readLatestContextDiagnostics(
 ): Promise<ContextDiagnostics> {
   try {
     // ponytail: command-time O(session ledger); add a completed-attempt projection if measured.
-    const runs = await runStore.listSessionRuns(sessionId);
+    const runs = (await runStore.listSessionRuns(sessionId)).filter(isSessionInlineRun);
     let latestCompleted: { ts: number; attempt: AttemptCandidate | undefined } | undefined;
     const checkpoints: CheckpointCandidate[] = [];
     for (const run of runs) {

--- a/packages/runtime/src/context-diagnostics.ts
+++ b/packages/runtime/src/context-diagnostics.ts
@@ -1,0 +1,181 @@
+import type { AgentRunStore } from '@maka/core';
+import {
+  validateHistoryCompactCheckpointShape,
+  type HistoryCompactCheckpoint,
+} from './history-compact-checkpoint.js';
+
+export type ContextDiagnosticsUnavailableReason = 'no_completed_request' | 'trace_unavailable';
+
+export interface ContextDiagnosticsSegment {
+  kind: 'system_instructions' | 'tool_definitions' | 'messages' | 'other';
+  bytes: number;
+  estimatedTokens: number;
+}
+
+export interface ContextDiagnosticsCompaction {
+  kind: 'history';
+  phase: 'pre_turn' | 'mid_turn';
+  eventCount: number;
+  turnCount: number;
+  estimatedTokens: number;
+}
+
+export type ContextDiagnostics =
+  | {
+      status: 'unavailable';
+      reason: ContextDiagnosticsUnavailableReason;
+    }
+  | {
+      status: 'available';
+      providerId: string;
+      modelId: string;
+      completedAt: number;
+      inputTokens?: number;
+      contextWindow?: number;
+      segments: ContextDiagnosticsSegment[];
+      compaction?: ContextDiagnosticsCompaction;
+    };
+
+export async function readLatestContextDiagnostics(
+  runStore: Pick<AgentRunStore, 'listSessionRuns' | 'readEvents'>,
+  sessionId: string,
+): Promise<ContextDiagnostics> {
+  try {
+    // ponytail: command-time O(session ledger); add a completed-attempt projection if measured.
+    const runs = await runStore.listSessionRuns(sessionId);
+    let latestCompleted: { ts: number; attempt: AttemptCandidate | undefined } | undefined;
+    const checkpoints: CheckpointCandidate[] = [];
+    for (const run of runs) {
+      const events = await runStore.readEvents(sessionId, run.runId);
+      for (const event of events) {
+        const checkpoint = event.data?.checkpoint;
+        if (
+          event.type === 'history_compact_checkpoint_recorded' &&
+          validateHistoryCompactCheckpointShape(checkpoint, sessionId)
+        ) {
+          checkpoints.push({ eventId: event.id, ts: event.ts, checkpoint });
+          continue;
+        }
+        if (event.type !== 'provider_request_attempt_recorded') continue;
+        if (event.data?.status !== 'completed') continue;
+        const completed = { ts: event.ts, attempt: attemptCandidate(event.data) };
+        if (!latestCompleted || completed.ts >= latestCompleted.ts) {
+          latestCompleted = completed;
+        }
+      }
+    }
+    if (!latestCompleted) return { status: 'unavailable', reason: 'no_completed_request' };
+    if (!latestCompleted.attempt) return { status: 'unavailable', reason: 'trace_unavailable' };
+    const latest = latestCompleted.attempt;
+    const checkpoint = checkpoints
+      .filter((candidate) => candidate.ts <= latest.startedAt)
+      .sort(
+        (left, right) => right.ts - left.ts || right.eventId.localeCompare(left.eventId),
+      )[0]?.checkpoint;
+    return {
+      status: 'available',
+      providerId: latest.providerId,
+      modelId: latest.modelId,
+      completedAt: latest.completedAt,
+      ...(latest.inputTokens !== undefined ? { inputTokens: latest.inputTokens } : {}),
+      ...(latest.contextWindow !== undefined ? { contextWindow: latest.contextWindow } : {}),
+      segments: latest.segments,
+      ...(checkpoint
+        ? {
+            compaction: {
+              kind: 'history',
+              phase: checkpoint.phase === 'mid_turn' ? 'mid_turn' : 'pre_turn',
+              eventCount: checkpoint.coverage.eventCount,
+              turnCount: checkpoint.coverage.turnCount,
+              estimatedTokens: checkpoint.estimatedTokens,
+            } satisfies ContextDiagnosticsCompaction,
+          }
+        : {}),
+    };
+  } catch {
+    return { status: 'unavailable', reason: 'trace_unavailable' };
+  }
+}
+
+interface AttemptCandidate {
+  providerId: string;
+  modelId: string;
+  startedAt: number;
+  completedAt: number;
+  inputTokens?: number;
+  contextWindow?: number;
+  segments: ContextDiagnosticsSegment[];
+}
+
+interface CheckpointCandidate {
+  eventId: string;
+  ts: number;
+  checkpoint: HistoryCompactCheckpoint;
+}
+
+function attemptCandidate(data: Record<string, unknown> | undefined): AttemptCandidate | undefined {
+  if (
+    data?.status !== 'completed' ||
+    typeof data.providerId !== 'string' ||
+    typeof data.modelId !== 'string' ||
+    !isNonNegativeNumber(data.startedAt) ||
+    !isNonNegativeNumber(data.completedAt) ||
+    !Array.isArray(data.segments) ||
+    (data.inputTokens !== undefined && !isNonNegativeInteger(data.inputTokens)) ||
+    (data.contextWindow !== undefined && !isPositiveInteger(data.contextWindow))
+  ) {
+    return undefined;
+  }
+  const segments = contextSegmentEstimates(data.segments);
+  if (!segments) return undefined;
+  return {
+    providerId: data.providerId,
+    modelId: data.modelId,
+    startedAt: data.startedAt,
+    completedAt: data.completedAt,
+    ...(data.inputTokens !== undefined ? { inputTokens: data.inputTokens as number } : {}),
+    ...(data.contextWindow !== undefined ? { contextWindow: data.contextWindow as number } : {}),
+    segments,
+  };
+}
+
+function contextSegmentEstimates(segments: unknown[]): ContextDiagnosticsSegment[] | undefined {
+  const bytes = new Map<ContextDiagnosticsSegment['kind'], number>();
+  for (const segment of segments) {
+    if (!segment || typeof segment !== 'object') return undefined;
+    const value = segment as Record<string, unknown>;
+    const kind = contextSegmentKind(value.kind);
+    if (!kind || !isNonNegativeInteger(value.bytes)) return undefined;
+    bytes.set(kind, (bytes.get(kind) ?? 0) + value.bytes);
+  }
+  const order: ContextDiagnosticsSegment['kind'][] = [
+    'system_instructions',
+    'tool_definitions',
+    'messages',
+    'other',
+  ];
+  return order.flatMap((kind) => {
+    const value = bytes.get(kind) ?? 0;
+    return value > 0 ? [{ kind, bytes: value, estimatedTokens: Math.ceil(value / 4) }] : [];
+  });
+}
+
+function contextSegmentKind(value: unknown): ContextDiagnosticsSegment['kind'] | undefined {
+  if (value === 'system_prompt') return 'system_instructions';
+  if (value === 'tool_schema') return 'tool_definitions';
+  if (value === 'message') return 'messages';
+  if (value === 'provider_options') return 'other';
+  return undefined;
+}
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) >= 0;
+}
+
+function isNonNegativeNumber(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function isPositiveInteger(value: unknown): value is number {
+  return Number.isInteger(value) && (value as number) > 0;
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -287,6 +287,13 @@ export { AiSdkBackend } from './ai-sdk-backend.js';
 export { isSupportedImagePath, validateImageBytes } from './image-file.js';
 export { findFirstChangedCacheableSegment } from './request-shape.js';
 export { createProviderRequestCaptureRecorder } from './provider-request-telemetry.js';
+export { readLatestContextDiagnostics } from './context-diagnostics.js';
+export type {
+  ContextDiagnostics,
+  ContextDiagnosticsCompaction,
+  ContextDiagnosticsSegment,
+  ContextDiagnosticsUnavailableReason,
+} from './context-diagnostics.js';
 export type {
   PreparedProviderRequestCapture,
   PreparedRequestSegment,

--- a/packages/runtime/src/provider-request-telemetry.ts
+++ b/packages/runtime/src/provider-request-telemetry.ts
@@ -59,6 +59,7 @@ export interface ProviderRequestAttemptRecord extends ProviderRequestUsage {
   captureArtifactId: string;
   providerId: string;
   modelId: string;
+  contextWindow?: number;
   requestHash: string;
   requestBytes: number;
   segments: PreparedRequestSegment[];
@@ -73,6 +74,7 @@ export interface ProviderRequestAttemptRecord extends ProviderRequestUsage {
 export interface ProviderRequestTrackerInput {
   traceId: string;
   turnId: string;
+  contextWindow?: number;
   now: () => number;
   newId: () => string;
   persistCapture: (
@@ -158,6 +160,7 @@ export class ProviderRequestTracker {
       if (abortListener) input.abortSignal?.removeEventListener('abort', abortListener);
       const completedAt = this.input.now();
       const usage = strictProviderRequestUsage(finish?.usage);
+      const contextWindow = positiveInteger(this.input.contextWindow);
       const record: ProviderRequestAttemptRecord = {
         traceId: this.input.traceId,
         attemptId,
@@ -168,6 +171,7 @@ export class ProviderRequestTracker {
         captureArtifactId: capture.ref.artifactId,
         providerId: input.providerId,
         modelId: input.modelId,
+        ...(contextWindow !== undefined ? { contextWindow } : {}),
         requestHash: capture.capture.requestHash,
         requestBytes: capture.capture.requestBytes,
         segments: capture.capture.segments,
@@ -513,4 +517,8 @@ function firstToken(...values: Array<number | undefined>): number | undefined {
 
 function finiteToken(value: unknown): number | undefined {
   return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+}
+
+function positiveInteger(value: unknown): number | undefined {
+  return typeof value === 'number' && Number.isInteger(value) && value > 0 ? value : undefined;
 }

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -120,6 +120,7 @@ import type {
   ProviderRequestAttemptRecord,
   ProviderRequestCaptureLedgerRecord,
 } from './provider-request-telemetry.js';
+import { readLatestContextDiagnostics, type ContextDiagnostics } from './context-diagnostics.js';
 import type { ShellRunProcessManager } from './shell-run-manager.js';
 import type { ActiveFullCompactBlock } from './active-full-compact.js';
 import type { SemanticCompactBlock } from './semantic-compact.js';
@@ -797,6 +798,13 @@ export class SessionManager {
 
   async getMessages(sessionId: string): Promise<StoredMessage[]> {
     return (await this.getSessionView(sessionId)).messages;
+  }
+
+  async getContextDiagnostics(sessionId: string): Promise<ContextDiagnostics> {
+    const runStore = this.deps.runStore;
+    return runStore
+      ? readLatestContextDiagnostics(runStore, sessionId)
+      : { status: 'unavailable', reason: 'trace_unavailable' };
   }
 
   async listTurns(sessionId: string): Promise<TurnRecord[]> {


### PR DESCRIPTION
## Summary

- Add a local, read-only `/context` command that describes the latest completed model request without sending a message, modifying context, or triggering compaction.
- Present used, total, free, and share values in a scan-friendly hierarchy while distinguishing provider-reported, request-snapshot, calculated, and locally estimated data.
- Break down estimated usage across system instructions, tool definitions, messages, and other options, with related history-compaction details when available.
- Read diagnostics from durable provider-request traces so results remain consistent after session switch, restart, or resume, with explicit unavailable states for missing data.

```txt
/context

Note: Context
Latest completed request
anthropic.messages · k3

Usage
  Used: 4,217 tokens
    provider-reported
  Total: 262,144 tokens
    request-model snapshot
  Free: 257,927 tokens
    calculated
  Share: 2%
    calculated

Estimated breakdown
  System instructions: ≈551 tokens
  Tool definitions: ≈3,514 tokens
  Messages: ≈1,590 tokens
  Other options: ≈16 tokens

History compaction
  Unavailable for this request
```

Closes #1423

## Verification

- `npm --workspace @maka/runtime test` — 2,748 passed, 7 skipped.
- `npm --workspace maka-agent run test:dist` — 672 passed.
- `node --test packages/headless/dist/__tests__/provider-request-trace.test.js` — 23 passed.

## Review focus

Context diagnostics are scoped to the latest completed provider request, not the session-selected model. After switching models, `/context` continues showing the previous request model and captured context window until a request with the new model completes. Failed or in-progress attempts do not replace that snapshot. Only session-inline runs participate; legacy child-agent runs are excluded.
