### PR TITLE
feat(providers): add Volcengine Ark Agent Plan

### DIFF
--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -830,8 +830,8 @@ describe('icon + typography governance contract', () => {
     );
     assert.match(
       componentSrc,
-      /case 'volcengine-ark':\s*case 'volcengine-coding-plan':\s*return <img src=\{volcengineBrandMark\} alt="" \/>/,
-      'direct Ark and Coding Plan must share the single governed Volcengine asset route',
+      /case 'volcengine-ark':\s*case 'volcengine-coding-plan':\s*case 'volcengine-agent-plan':\s*return <img src=\{volcengineBrandMark\} alt="" \/>/,
+      'direct Ark, Coding Plan, and Agent Plan must share the single governed Volcengine asset route',
     );
   });
 

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -449,6 +449,7 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
       return <img src={stepfunBrandMark} alt="" />;
     case 'volcengine-ark':
     case 'volcengine-coding-plan':
+    case 'volcengine-agent-plan':
       return <img src={volcengineBrandMark} alt="" />;
     default:
       return <GenericProviderMark />;

--- a/apps/desktop/src/renderer/settings/provider-display-copy.ts
+++ b/apps/desktop/src/renderer/settings/provider-display-copy.ts
@@ -168,6 +168,10 @@ export const PROVIDER_DISPLAY_COPY = {
     zh: { name: '火山方舟 Coding Plan', description: '火山引擎 Coding 订阅 · OpenAI 兼容', badge: 'Coding' },
     en: { name: 'Volcengine Ark Coding Plan (China)', description: 'Volcengine Ark coding subscription · OpenAI-compatible', badge: 'Coding' },
   },
+  'volcengine-agent-plan': {
+    zh: { name: '火山方舟 Agent Plan', description: '火山引擎 Agent 订阅 · Responses API', badge: 'Agent' },
+    en: { name: 'Volcengine Ark Agent Plan (China)', description: 'Volcengine Ark agent subscription · Responses API', badge: 'Agent' },
+  },
   'tencent-token-plan': {
     zh: { name: 'Tencent Token Plan', description: '腾讯云 Token 套餐，个人智能体与编码工具', badge: 'Token' },
     en: { name: 'Tencent Token Plan', description: 'Tencent Cloud token plan for personal agents and coding tools.', badge: 'Token' },

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -46,6 +46,7 @@ describe('provider compatibility contract', () => {
       'minimax-coding-plan',
       'tencent-coding-plan',
       'volcengine-coding-plan',
+      'volcengine-agent-plan',
       'tencent-token-plan',
       'openai',
       'google',
@@ -135,6 +136,7 @@ describe('provider compatibility contract', () => {
       'stepfun-ai',
       'volcengine-ark',
       'volcengine-coding-plan',
+      'volcengine-agent-plan',
       'tencent-token-plan',
       'stepfun-step-plan',
       'deepinfra',
@@ -190,6 +192,7 @@ describe('provider compatibility contract', () => {
       'stepfun-ai',
       'volcengine-ark',
       'volcengine-coding-plan',
+      'volcengine-agent-plan',
       'tencent-token-plan',
       'stepfun-step-plan',
       'deepinfra',
@@ -1284,6 +1287,51 @@ describe('provider compatibility contract', () => {
     assert.equal(ark.signupUrl, 'https://console.volcengine.com/ark/region:ark+cn-beijing/model');
     assert.equal(ark.modelsDevId, undefined);
     assert.deepEqual(ark.fallbackModels, ['doubao-seed-2-0-pro-260215']);
+  });
+
+  it('owns Volcengine Agent Plan as an independent Responses access path', () => {
+    const agentPlan = (
+      PROVIDER_REGISTRY as Partial<
+        Record<string, (typeof PROVIDER_REGISTRY)[keyof typeof PROVIDER_REGISTRY]>
+      >
+    )['volcengine-agent-plan'];
+
+    assert.ok(agentPlan, 'Volcengine Agent Plan must have its own persisted provider id');
+    assert.equal(agentPlan.label, 'Volcengine Ark Agent Plan (China)');
+    assert.equal(agentPlan.baseUrl, 'https://ark.cn-beijing.volces.com/api/plan/v3');
+    assert.equal(agentPlan.authKind, 'api_key');
+    assert.equal(agentPlan.protocol, 'openai');
+    assert.deepEqual(agentPlan.runtimeAdapter, {
+      kind: 'openai',
+      apiProtocol: 'openai-responses',
+    });
+    assert.deepEqual(agentPlan.modelDiscovery, {
+      kind: 'fallback',
+      reason:
+        'Agent Plan model discovery uses an account-authenticated subscription control-plane API; the dedicated inference API key cannot call it',
+    });
+    assert.equal(agentPlan.category, 'domestic');
+    assert.equal(agentPlan.catalogGroup, 'plans');
+    assert.equal(agentPlan.catalogBadge, 'Agent');
+    assert.equal(agentPlan.signupUrl, 'https://console.volcengine.com/ark/agent-plan');
+    assert.equal(agentPlan.modelsDevId, undefined);
+    assert.deepEqual(agentPlan.fallbackModels, [
+      'ark-code-latest',
+      'doubao-seed-2.0-mini',
+      'doubao-seed-2.0-lite',
+      'deepseek-v4-flash',
+      'doubao-seed-2.1-turbo',
+      'doubao-seed-evolving',
+      'doubao-seed-2.0-code',
+      'doubao-seed-2.0-pro',
+      'minimax-m2.7',
+      'minimax-m3',
+      'glm-5.2',
+      'kimi-k2.6',
+      'kimi-k2.7-code',
+      'deepseek-v4-pro',
+      'kimi-k3',
+    ]);
   });
 });
 

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -1308,7 +1308,7 @@ describe('provider compatibility contract', () => {
     assert.deepEqual(agentPlan.modelDiscovery, {
       kind: 'fallback',
       reason:
-        'Agent Plan model discovery uses an account-authenticated subscription control-plane API; the dedicated inference API key cannot call it',
+        'Agent Plan inference data plane does not expose a model-list endpoint for its dedicated API key',
     });
     assert.equal(agentPlan.category, 'domestic');
     assert.equal(agentPlan.catalogGroup, 'plans');

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -1327,6 +1327,7 @@ describe('provider compatibility contract', () => {
       'minimax-m2.7',
       'minimax-m3',
       'glm-5.2',
+      'glm-latest',
       'kimi-k2.6',
       'kimi-k2.7-code',
       'deepseek-v4-pro',

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -242,9 +242,54 @@ describe('ModelCatalogEntry', () => {
     assert.equal(entries[0]?.contextWindow, 256_000);
     assert.equal(entries[0]?.maxOutputTokens, 32_000);
     assert.deepEqual(entries[0]?.capabilities, {
+      vision: true,
       reasoning: true,
       functionCalling: true,
     });
+
+    for (const entry of entries) {
+      assert.equal(entry.docsUrl, 'https://www.volcengine.com/docs/82379/2366394', entry.id);
+      assert.ok(entry.contextWindow, entry.id);
+      assert.ok(entry.maxOutputTokens, entry.id);
+      assert.equal(entry.capabilities.reasoning, true, entry.id);
+      assert.equal(entry.capabilities.functionCalling, true, entry.id);
+    }
+
+    for (const modelId of [
+      'ark-code-latest',
+      'doubao-seed-2.0-mini',
+      'doubao-seed-2.0-lite',
+      'doubao-seed-2.1-turbo',
+      'doubao-seed-evolving',
+      'minimax-m3',
+      'kimi-k2.6',
+      'kimi-k2.7-code',
+      'kimi-k3',
+    ]) {
+      assert.equal(
+        entries.find((entry) => entry.id === modelId)?.capabilities.vision,
+        true,
+        modelId,
+      );
+    }
+
+    for (const modelId of [
+      'deepseek-v4-flash',
+      'deepseek-v4-pro',
+      'glm-5.2',
+      'glm-latest',
+      'minimax-m2.7',
+    ]) {
+      assert.equal(
+        entries.find((entry) => entry.id === modelId)?.capabilities.vision,
+        undefined,
+        modelId,
+      );
+    }
+
+    const glmLatest = entries.find((entry) => entry.id === 'glm-latest');
+    assert.equal(glmLatest?.contextWindow, 1_024_000);
+    assert.equal(glmLatest?.maxOutputTokens, 128_000);
 
     const deepseek = entries.find((entry) => entry.id === 'deepseek-v4-pro');
     assert.equal(deepseek?.contextWindow, 1_024_000);

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -239,6 +239,8 @@ describe('ModelCatalogEntry', () => {
     assert.equal(entries[0]?.displayName, 'Ark Code Latest');
     assert.equal(entries[0]?.source, 'static_catalog');
     assert.equal(entries[0]?.provenance.modelSource, 'fallback');
+    assert.equal(entries[0]?.contextWindow, 256_000);
+    assert.equal(entries[0]?.maxOutputTokens, 32_000);
     assert.deepEqual(entries[0]?.capabilities, {
       reasoning: true,
       functionCalling: true,

--- a/packages/core/src/__tests__/model-catalog.test.ts
+++ b/packages/core/src/__tests__/model-catalog.test.ts
@@ -226,6 +226,35 @@ describe('ModelCatalogEntry', () => {
     });
   });
 
+  it('uses the official Volcengine Agent Plan text-model snapshot without inventing data-plane discovery', () => {
+    const entries = buildConnectionModelCatalogEntries({
+      connection: {
+        slug: 'volcengine-agent-plan',
+        providerType: 'volcengine-agent-plan',
+        defaultModel: 'ark-code-latest',
+      },
+    });
+
+    assert.equal(entries[0]?.id, 'ark-code-latest');
+    assert.equal(entries[0]?.displayName, 'Ark Code Latest');
+    assert.equal(entries[0]?.source, 'static_catalog');
+    assert.equal(entries[0]?.provenance.modelSource, 'fallback');
+    assert.deepEqual(entries[0]?.capabilities, {
+      reasoning: true,
+      functionCalling: true,
+    });
+
+    const deepseek = entries.find((entry) => entry.id === 'deepseek-v4-pro');
+    assert.equal(deepseek?.contextWindow, 1_024_000);
+    assert.equal(deepseek?.maxOutputTokens, 384_000);
+    assert.equal(deepseek?.capabilities.vision, undefined);
+
+    const retiring = entries.find((entry) => entry.id === 'doubao-seed-2.0-code');
+    assert.equal(retiring?.lifecycle, 'deprecated');
+    assert.equal(retiring?.contextWindow, 256_000);
+    assert.equal(retiring?.maxOutputTokens, 128_000);
+  });
+
   it('uses the checked-in StepFun China snapshot until account discovery succeeds', () => {
     const entries = buildConnectionModelCatalogEntries({
       connection: {

--- a/packages/core/src/__tests__/provider-auth.test.ts
+++ b/packages/core/src/__tests__/provider-auth.test.ts
@@ -92,7 +92,7 @@ describe('ProviderAuth contract', () => {
     expect(contract.actionAvailability.fetch_models).toBe('available');
   });
 
-  test('Volcengine Agent Plan uses its dedicated API key without exposing control-plane refresh', () => {
+  test('Volcengine Agent Plan hides refresh because its inference data plane has no model list', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'volcengine-agent-plan',
       hasSecret: true,

--- a/packages/core/src/__tests__/provider-auth.test.ts
+++ b/packages/core/src/__tests__/provider-auth.test.ts
@@ -92,6 +92,19 @@ describe('ProviderAuth contract', () => {
     expect(contract.actionAvailability.fetch_models).toBe('available');
   });
 
+  test('Volcengine Agent Plan uses its dedicated API key without exposing control-plane refresh', () => {
+    const contract = deriveProviderAuthContract({
+      providerType: 'volcengine-agent-plan',
+      hasSecret: true,
+    });
+
+    expect(contract.providerType).toBe('volcengine-agent-plan');
+    expect(contract.setupMode).toBe('api_key');
+    expect(contract.requiresSecret).toBe(true);
+    expect(contract.actionAvailability.test_credentials).toBe('available');
+    expect(contract.actionAvailability.fetch_models).toBe('hidden');
+  });
+
   test('Tencent Token Plan uses an independent API key and remote model flow', () => {
     const contract = deriveProviderAuthContract({
       providerType: 'tencent-token-plan',

--- a/packages/core/src/__tests__/provider-contract-matrix.test.ts
+++ b/packages/core/src/__tests__/provider-contract-matrix.test.ts
@@ -220,6 +220,15 @@ describe('provider contract matrix — wire and reasoning derivation', () => {
     assert.equal(cellFor('zenmux', 'reasoning-replay').state, 'override');
   });
 
+  it('marks Agent Plan stateless Responses reasoning replay as override', () => {
+    const cell = cellFor('volcengine-agent-plan', 'reasoning-replay');
+    assert.equal(cell.state, 'override');
+    assert.equal(
+      cell.state === 'override' ? cell.overrideKey : undefined,
+      'volcengine-agent-plan:reasoning-replay',
+    );
+  });
+
   it('marks native-SDK adapters not-applicable for reasoning replay', () => {
     for (const providerType of ['anthropic', 'openai', 'google', 'cohere'] as const) {
       assert.equal(

--- a/packages/core/src/__tests__/runtime-event.test.ts
+++ b/packages/core/src/__tests__/runtime-event.test.ts
@@ -73,6 +73,36 @@ test('Core decoder matches the shared RuntimeEvent validation corpus', () => {
   }
 });
 
+test('Stored assistant reasoning parts survive recovery decoding', () => {
+  const parts = [
+    {
+      text: 'first summary',
+      providerOptions: {
+        openai: { itemId: 'rs_first', reasoningEncryptedContent: 'encrypted-first' },
+      },
+    },
+    {
+      text: 'second summary',
+      providerOptions: {
+        openai: { itemId: 'rs_second', reasoningEncryptedContent: 'encrypted-second' },
+      },
+    },
+  ];
+  const stored = decodeStoredMessageForRecovery({
+    type: 'assistant',
+    id: 'message-1',
+    turnId: 'turn-1',
+    ts: 1,
+    text: 'answer',
+    thinking: { text: 'first summarysecond summary', parts },
+    modelId: 'ark-code-latest',
+  });
+
+  assert.equal(stored.type, 'assistant');
+  if (stored.type !== 'assistant') throw new Error('unreachable');
+  assert.deepEqual(stored.thinking?.parts, parts);
+});
+
 describe('RuntimeEvent role / author / status enums', () => {
   test('locks the role enum and guard', () => {
     expect(RUNTIME_EVENT_ROLES).toEqual(['user', 'model', 'tool', 'system']);

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -188,21 +188,34 @@ const VOLCENGINE_CODING_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
   'kimi-k2.7-code': planModel('Kimi-K2.7-Code', true, 256_000, 32_000),
 };
 const VOLCENGINE_AGENT_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
-  'ark-code-latest': agentPlanModel('Ark Code Latest', 256_000, 32_000),
-  'doubao-seed-2.0-mini': agentPlanModel('Doubao Seed 2.0 Mini', 256_000, 128_000),
-  'doubao-seed-2.0-lite': agentPlanModel('Doubao Seed 2.0 Lite', 256_000, 128_000),
+  'ark-code-latest': agentPlanModel('Ark Code Latest', 256_000, 32_000, { vision: true }),
+  'doubao-seed-2.0-mini': agentPlanModel('Doubao Seed 2.0 Mini', 256_000, 128_000, {
+    vision: true,
+  }),
+  'doubao-seed-2.0-lite': agentPlanModel('Doubao Seed 2.0 Lite', 256_000, 128_000, {
+    vision: true,
+  }),
   'deepseek-v4-flash': agentPlanModel('DeepSeek-V4-Flash', 1_024_000, 384_000),
-  'doubao-seed-2.1-turbo': agentPlanModel('Doubao Seed 2.1 Turbo', 256_000, 256_000),
-  'doubao-seed-evolving': agentPlanModel('Doubao Seed Evolving', 1_024_000, 256_000),
-  'doubao-seed-2.0-code': agentPlanModel('Doubao Seed 2.0 Code', 256_000, 128_000, 'deprecated'),
-  'doubao-seed-2.0-pro': agentPlanModel('Doubao Seed 2.0 Pro', 256_000, 128_000, 'deprecated'),
+  'doubao-seed-2.1-turbo': agentPlanModel('Doubao Seed 2.1 Turbo', 256_000, 256_000, {
+    vision: true,
+  }),
+  'doubao-seed-evolving': agentPlanModel('Doubao Seed Evolving', 1_024_000, 256_000, {
+    vision: true,
+  }),
+  'doubao-seed-2.0-code': agentPlanModel('Doubao Seed 2.0 Code', 256_000, 128_000, {
+    lifecycle: 'deprecated',
+  }),
+  'doubao-seed-2.0-pro': agentPlanModel('Doubao Seed 2.0 Pro', 256_000, 128_000, {
+    lifecycle: 'deprecated',
+  }),
   'minimax-m2.7': agentPlanModel('MiniMax-M2.7', 200_000, 128_000),
-  'minimax-m3': agentPlanModel('MiniMax-M3', 512_000, 128_000),
+  'minimax-m3': agentPlanModel('MiniMax-M3', 512_000, 128_000, { vision: true }),
   'glm-5.2': agentPlanModel('GLM-5.2', 1_024_000, 128_000),
-  'kimi-k2.6': agentPlanModel('Kimi-K2.6', 256_000, 32_000),
-  'kimi-k2.7-code': agentPlanModel('Kimi-K2.7-Code', 256_000, 32_000),
+  'glm-latest': agentPlanModel('GLM Latest', 1_024_000, 128_000),
+  'kimi-k2.6': agentPlanModel('Kimi-K2.6', 256_000, 32_000, { vision: true }),
+  'kimi-k2.7-code': agentPlanModel('Kimi-K2.7-Code', 256_000, 32_000, { vision: true }),
   'deepseek-v4-pro': agentPlanModel('DeepSeek-V4-Pro', 1_024_000, 384_000),
-  'kimi-k3': agentPlanModel('Kimi-K3', 1_024_000, 128_000),
+  'kimi-k3': agentPlanModel('Kimi-K3', 1_024_000, 128_000, { vision: true }),
 };
 
 // Ollama Cloud accepts reasoning_effort for every active reasoning model in its
@@ -394,17 +407,23 @@ function planModel(
 
 function agentPlanModel(
   displayName: string,
-  contextWindow?: number,
-  maxOutputTokens?: number,
-  lifecycle: ModelMetadata['lifecycle'] = 'active',
+  contextWindow: number,
+  maxOutputTokens: number,
+  options: {
+    lifecycle?: ModelMetadata['lifecycle'];
+    vision?: true;
+  } = {},
 ): ModelMetadata {
   return {
     displayName,
-    lifecycle,
+    lifecycle: options.lifecycle ?? 'active',
     docsUrl: VOLCENGINE_AGENT_PLAN_DOCS,
-    ...(contextWindow === undefined ? {} : { contextWindow }),
-    ...(maxOutputTokens === undefined ? {} : { maxOutputTokens }),
-    capabilities: REASONING_FUNCTION_CALLING,
+    contextWindow,
+    maxOutputTokens,
+    capabilities: {
+      ...REASONING_FUNCTION_CALLING,
+      ...(options.vision ? { vision: true } : {}),
+    },
   };
 }
 

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -172,6 +172,7 @@ const SILICONFLOW_MODEL_OVERRIDES: Record<string, ModelMetadata> = Object.fromEn
 );
 
 const VOLCENGINE_CODING_PLAN_DOCS = 'https://www.volcengine.com/docs/82379/1925114';
+const VOLCENGINE_AGENT_PLAN_DOCS = 'https://www.volcengine.com/docs/82379/2366394';
 const VOLCENGINE_CODING_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
   'ark-code-latest': planModel('Ark Code Latest', false),
   'doubao-seed-2.0-code': planModel('Doubao Seed 2.0 Code', true),
@@ -185,6 +186,23 @@ const VOLCENGINE_CODING_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
   'deepseek-v4-pro': planModel('DeepSeek-V4-Pro', false, 1_024_000, 384_000),
   'kimi-k2.6': planModel('Kimi-K2.6', true, 256_000, 32_000),
   'kimi-k2.7-code': planModel('Kimi-K2.7-Code', true, 256_000, 32_000),
+};
+const VOLCENGINE_AGENT_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
+  'ark-code-latest': agentPlanModel('Ark Code Latest'),
+  'doubao-seed-2.0-mini': agentPlanModel('Doubao Seed 2.0 Mini', 256_000, 128_000),
+  'doubao-seed-2.0-lite': agentPlanModel('Doubao Seed 2.0 Lite', 256_000, 128_000),
+  'deepseek-v4-flash': agentPlanModel('DeepSeek-V4-Flash', 1_024_000, 384_000),
+  'doubao-seed-2.1-turbo': agentPlanModel('Doubao Seed 2.1 Turbo', 256_000, 256_000),
+  'doubao-seed-evolving': agentPlanModel('Doubao Seed Evolving', 1_024_000, 256_000),
+  'doubao-seed-2.0-code': agentPlanModel('Doubao Seed 2.0 Code', 256_000, 128_000, 'deprecated'),
+  'doubao-seed-2.0-pro': agentPlanModel('Doubao Seed 2.0 Pro', 256_000, 128_000, 'deprecated'),
+  'minimax-m2.7': agentPlanModel('MiniMax-M2.7', 200_000, 128_000),
+  'minimax-m3': agentPlanModel('MiniMax-M3', 512_000, 128_000),
+  'glm-5.2': agentPlanModel('GLM-5.2', 1_024_000, 128_000),
+  'kimi-k2.6': agentPlanModel('Kimi-K2.6', 256_000, 32_000),
+  'kimi-k2.7-code': agentPlanModel('Kimi-K2.7-Code', 256_000, 32_000),
+  'deepseek-v4-pro': agentPlanModel('DeepSeek-V4-Pro', 1_024_000, 384_000),
+  'kimi-k3': agentPlanModel('Kimi-K3', 1_024_000, 128_000),
 };
 
 // Ollama Cloud accepts reasoning_effort for every active reasoning model in its
@@ -279,6 +297,7 @@ const STATIC_MODEL_METADATA: Partial<Record<ProviderType, Record<string, ModelMe
     },
   },
   'volcengine-coding-plan': VOLCENGINE_CODING_PLAN_MODEL_METADATA,
+  'volcengine-agent-plan': VOLCENGINE_AGENT_PLAN_MODEL_METADATA,
   'tencent-token-plan': {
     hy3: { thinkingOptions: { efforts: ['low', 'medium', 'high'] } },
     'hy3-preview': { thinkingOptions: { efforts: ['low', 'medium', 'high'] } },
@@ -370,6 +389,22 @@ function planModel(
     ...(contextWindow === undefined ? {} : { contextWindow }),
     ...(maxOutputTokens === undefined ? {} : { maxOutputTokens }),
     capabilities: { ...REASONING_FUNCTION_CALLING, vision },
+  };
+}
+
+function agentPlanModel(
+  displayName: string,
+  contextWindow?: number,
+  maxOutputTokens?: number,
+  lifecycle: ModelMetadata['lifecycle'] = 'active',
+): ModelMetadata {
+  return {
+    displayName,
+    lifecycle,
+    docsUrl: VOLCENGINE_AGENT_PLAN_DOCS,
+    ...(contextWindow === undefined ? {} : { contextWindow }),
+    ...(maxOutputTokens === undefined ? {} : { maxOutputTokens }),
+    capabilities: REASONING_FUNCTION_CALLING,
   };
 }
 

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -188,7 +188,7 @@ const VOLCENGINE_CODING_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
   'kimi-k2.7-code': planModel('Kimi-K2.7-Code', true, 256_000, 32_000),
 };
 const VOLCENGINE_AGENT_PLAN_MODEL_METADATA: Record<string, ModelMetadata> = {
-  'ark-code-latest': agentPlanModel('Ark Code Latest'),
+  'ark-code-latest': agentPlanModel('Ark Code Latest', 256_000, 32_000),
   'doubao-seed-2.0-mini': agentPlanModel('Doubao Seed 2.0 Mini', 256_000, 128_000),
   'doubao-seed-2.0-lite': agentPlanModel('Doubao Seed 2.0 Lite', 256_000, 128_000),
   'deepseek-v4-flash': agentPlanModel('DeepSeek-V4-Flash', 1_024_000, 384_000),

--- a/packages/core/src/provider-contract-matrix.ts
+++ b/packages/core/src/provider-contract-matrix.ts
@@ -389,8 +389,22 @@ function reasoningReplayCell(
       },
     };
   }
+  if (
+    providerType === 'volcengine-agent-plan' &&
+    adapter.kind === 'openai' &&
+    adapter.apiProtocol === 'openai-responses'
+  ) {
+    return {
+      state: 'override',
+      dimension: 'reasoning-replay',
+      overrideKey: overrideKeyFor(providerType, 'reasoning-replay'),
+      contract:
+        'Stateless OpenAI Responses reasoning items retain their encrypted content across Maka-owned durable replay',
+    };
+  }
   // Native Anthropic / OpenAI / Google / Cohere SDKs own signed reasoning replay
-  // opaquely; the maka provider layer adds no wire transform to derive from.
+  // opaquely; except for the stateless Agent Plan contract above, the Maka
+  // provider layer adds no wire transform to derive from.
   return {
     state: 'not-applicable',
     dimension: 'reasoning-replay',

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -274,6 +274,7 @@ const volcengineAgentPlanModelIds = [
   'minimax-m2.7',
   'minimax-m3',
   'glm-5.2',
+  'glm-latest',
   'kimi-k2.6',
   'kimi-k2.7-code',
   'deepseek-v4-pro',

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -262,6 +262,23 @@ const volcengineCodingPlanModelIds = [
   'kimi-k2.6',
   'kimi-k2.7-code',
 ] as const;
+const volcengineAgentPlanModelIds = [
+  'ark-code-latest',
+  'doubao-seed-2.0-mini',
+  'doubao-seed-2.0-lite',
+  'deepseek-v4-flash',
+  'doubao-seed-2.1-turbo',
+  'doubao-seed-evolving',
+  'doubao-seed-2.0-code',
+  'doubao-seed-2.0-pro',
+  'minimax-m2.7',
+  'minimax-m3',
+  'glm-5.2',
+  'kimi-k2.6',
+  'kimi-k2.7-code',
+  'deepseek-v4-pro',
+  'kimi-k3',
+] as const;
 const tencentTokenPlan = GENERATED_MODELS_DEV_PROVIDER_FACTS['tencent-token-plan'];
 if (tencentTokenPlan.id !== 'tencent-token-plan') {
   throw new Error(
@@ -665,6 +682,28 @@ const providerRegistry = {
     signupUrl: 'https://www.volcengine.com/activity/codingplan',
     readyOrder: 26,
     catalogOrder: 26,
+  },
+  'volcengine-agent-plan': {
+    label: 'Volcengine Ark Agent Plan (China)',
+    description: 'Volcengine Ark subscription for interactive personal agents and coding tools.',
+    baseUrl: 'https://ark.cn-beijing.volces.com/api/plan/v3',
+    authKind: 'api_key',
+    backendKind: 'ai-sdk',
+    fallbackModels: [...volcengineAgentPlanModelIds],
+    status: 'ready',
+    protocol: 'openai',
+    runtimeAdapter: { kind: 'openai', apiProtocol: 'openai-responses' },
+    modelDiscovery: {
+      kind: 'fallback',
+      reason:
+        'Agent Plan model discovery uses an account-authenticated subscription control-plane API; the dedicated inference API key cannot call it',
+    },
+    category: 'domestic',
+    catalogGroup: 'plans',
+    catalogBadge: 'Agent',
+    signupUrl: 'https://console.volcengine.com/ark/agent-plan',
+    readyOrder: 26.5,
+    catalogOrder: 26.5,
   },
   'tencent-token-plan': {
     label: tencentTokenPlan.name,

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -696,7 +696,7 @@ const providerRegistry = {
     modelDiscovery: {
       kind: 'fallback',
       reason:
-        'Agent Plan model discovery uses an account-authenticated subscription control-plane API; the dedicated inference API key cannot call it',
+        'Agent Plan inference data plane does not expose a model-list endpoint for its dedicated API key',
     },
     category: 'domestic',
     catalogGroup: 'plans',

--- a/packages/core/src/session.ts
+++ b/packages/core/src/session.ts
@@ -610,13 +610,7 @@ export interface AssistantMessage {
   turnId: string;
   ts: number;
   text: string;
-  thinking?: {
-    text: string;
-    /** Anthropic signed thinking for replay. */
-    signature?: string;
-    /** Provider-owned replay metadata that must survive missing-ledger recovery. */
-    providerOptions?: Record<string, unknown>;
-  };
+  thinking?: AssistantThinking;
   /**
    * First-observed order of visible content inside this assistant step.
    * RuntimeEvent projection records partial text/thinking and the paired tool
@@ -627,6 +621,23 @@ export interface AssistantMessage {
   contentOrder?: AssistantStepContentKind[];
   /** Actual model used for this turn. */
   modelId: string;
+}
+
+export interface AssistantThinkingPart {
+  text: string;
+  /** Anthropic signed thinking for replay. */
+  signature?: string;
+  /** Provider-owned replay metadata that must survive missing-ledger recovery. */
+  providerOptions?: Record<string, unknown>;
+}
+
+export interface AssistantThinking extends AssistantThinkingPart {
+  /**
+   * Ordered provider reasoning items when one assistant step contains more than
+   * one independently replayable item. The aggregate text remains available on
+   * the parent for existing readers; single-item rows keep the legacy shape.
+   */
+  parts?: AssistantThinkingPart[];
 }
 
 export type AssistantStepContentKind = 'thinking' | 'text' | 'tools';
@@ -831,10 +842,13 @@ const SYSTEM_NOTE_MESSAGE_SHAPE = defineObjectShape<SystemNoteMessage>()(
   ['type', 'id', 'ts', 'kind'],
   ['turnId', 'data'],
 );
-type AssistantThinking = NonNullable<AssistantMessage['thinking']>;
-const ASSISTANT_THINKING_SHAPE = defineObjectShape<AssistantThinking>()(
+const ASSISTANT_THINKING_PART_SHAPE = defineObjectShape<AssistantThinkingPart>()(
   ['text'],
   ['signature', 'providerOptions'],
+);
+const ASSISTANT_THINKING_SHAPE = defineObjectShape<AssistantThinking>()(
+  ['text'],
+  ['signature', 'providerOptions', 'parts'],
 );
 type MessageOrigin = NonNullable<UserMessage['origin']>;
 type AutomationOrigin = Extract<MessageOrigin, { kind: 'automation' }>;
@@ -998,13 +1012,27 @@ function hasMessageEnvelope(value: Record<string, unknown>, turnRequired: boolea
   );
 }
 
+function isAssistantThinkingPart(value: unknown): value is AssistantThinkingPart {
+  return (
+    isRecord(value) &&
+    hasExactShape(value, ASSISTANT_THINKING_PART_SHAPE) &&
+    typeof value.text === 'string' &&
+    isOptionalString(value.signature) &&
+    (value.providerOptions === undefined || isRecord(value.providerOptions))
+  );
+}
+
 function isAssistantThinking(value: unknown): value is AssistantThinking {
   return (
     isRecord(value) &&
     hasExactShape(value, ASSISTANT_THINKING_SHAPE) &&
     typeof value.text === 'string' &&
     isOptionalString(value.signature) &&
-    (value.providerOptions === undefined || isRecord(value.providerOptions))
+    (value.providerOptions === undefined || isRecord(value.providerOptions)) &&
+    (value.parts === undefined ||
+      (Array.isArray(value.parts) &&
+        value.parts.length > 0 &&
+        value.parts.every(isAssistantThinkingPart)))
   );
 }
 

--- a/packages/headless/src/__tests__/provider-env.test.ts
+++ b/packages/headless/src/__tests__/provider-env.test.ts
@@ -194,6 +194,14 @@ test('Volcengine Coding Plan is unavailable to non-interactive headless credenti
   );
 });
 
+test('Volcengine Agent Plan is unavailable to non-interactive headless credential loading', () => {
+  assert.equal(providerCredentialEnv('volcengine-agent-plan'), undefined);
+  assert.throws(
+    () => requireProviderCredentialEnv('volcengine-agent-plan'),
+    /provider does not support API key files: volcengine-agent-plan/,
+  );
+});
+
 test('Tencent Token Plan is unavailable to non-interactive headless credential loading', () => {
   assert.equal(providerCredentialEnv('tencent-token-plan'), undefined);
   assert.throws(

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -11712,6 +11712,233 @@ describe('AiSdkBackend thinking persistence', () => {
     );
   });
 
+  test('preserves every OpenAI Responses reasoning item through stream persistence and replay', async () => {
+    const chunks: LanguageModelV4StreamPart[] = [
+      { type: 'stream-start', warnings: [] },
+      { type: 'reasoning-start', id: 'r1' },
+      {
+        type: 'reasoning-delta',
+        id: 'r1',
+        delta: 'first summary',
+        providerMetadata: { openai: { itemId: 'rs_first' } },
+      },
+      {
+        type: 'reasoning-end',
+        id: 'r1',
+        providerMetadata: {
+          openai: {
+            itemId: 'rs_first',
+            reasoningEncryptedContent: 'encrypted-first',
+          },
+        },
+      },
+      { type: 'reasoning-start', id: 'r2' },
+      {
+        type: 'reasoning-delta',
+        id: 'r2',
+        delta: 'second summary',
+        providerMetadata: { openai: { itemId: 'rs_second' } },
+      },
+      {
+        type: 'reasoning-end',
+        id: 'r2',
+        providerMetadata: {
+          openai: {
+            itemId: 'rs_second',
+            reasoningEncryptedContent: 'encrypted-second',
+          },
+        },
+      },
+      { type: 'text-start', id: 't1' },
+      { type: 'text-delta', id: 't1', delta: 'Final answer.' },
+      { type: 'text-end', id: 't1' },
+      {
+        type: 'finish',
+        finishReason: { unified: 'stop', raw: 'stop' },
+        usage: {
+          inputTokens: { total: 1, noCache: 1, cacheRead: 0, cacheWrite: 0 },
+          outputTokens: { total: 3, text: 1, reasoning: 2 },
+        },
+      },
+    ];
+    const firstModel = new MockLanguageModelV4({
+      doStream: {
+        stream: simulateReadableStream({ chunks, initialDelayInMs: null, chunkDelayInMs: null }),
+      },
+    });
+    const planConnection: LlmConnection = {
+      slug: 'volcengine-agent-plan',
+      name: 'Volcengine Ark Agent Plan (China)',
+      providerType: 'volcengine-agent-plan',
+      defaultModel: 'ark-code-latest',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    const appended: StoredMessage[] = [];
+    const firstBackend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async (message) => {
+        appended.push(message);
+      },
+      connection: planConnection,
+      apiKey: 'ark-plan-token',
+      modelId: 'ark-code-latest',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => firstModel,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    const events: SessionEvent[] = [];
+    for await (const event of firstBackend.send({
+      turnId: 'turn-prev',
+      text: 'solve it',
+      context: [],
+    })) {
+      events.push(event);
+    }
+
+    const thinkingCompletes = events.filter(
+      (event): event is Extract<SessionEvent, { type: 'thinking_complete' }> =>
+        event.type === 'thinking_complete',
+    );
+    assert.deepEqual(
+      thinkingCompletes.map((event) => [event.text, event.providerOptions]),
+      [
+        [
+          'first summary',
+          {
+            openai: {
+              itemId: 'rs_first',
+              reasoningEncryptedContent: 'encrypted-first',
+            },
+          },
+        ],
+        [
+          'second summary',
+          {
+            openai: {
+              itemId: 'rs_second',
+              reasoningEncryptedContent: 'encrypted-second',
+            },
+          },
+        ],
+      ],
+    );
+
+    const persistedAssistant = appended.find(
+      (message): message is AssistantMessage => message.type === 'assistant',
+    );
+    assert.ok(persistedAssistant);
+    assert.deepEqual(
+      (
+        persistedAssistant.thinking as
+          | {
+              parts?: Array<{
+                text: string;
+                providerOptions?: Record<string, unknown>;
+              }>;
+            }
+          | undefined
+      )?.parts,
+      thinkingCompletes.map(({ text, providerOptions }) => ({ text, providerOptions })),
+    );
+
+    const ctx = {
+      sessionId: 'session-1',
+      invocationId: 'inv-1',
+      runId: 'run-prev',
+      turnId: 'turn-prev',
+      now: () => 7,
+      newId: idGenerator(),
+    } as unknown as InvocationContext;
+    const memory = createSessionEventMapMemory();
+    const runtimeContext = events.map((event) => mapSessionEventToRuntimeEvent(event, ctx, memory));
+    const projection = projectRuntimeEventsToStoredMessages(runtimeContext, {
+      runHeaders: [
+        {
+          runId: 'run-prev',
+          sessionId: 'session-1',
+          turnId: 'turn-prev',
+          status: 'completed',
+          backendKind: 'ai-sdk',
+          llmConnectionSlug: planConnection.slug,
+          modelId: 'ark-code-latest',
+          cwd: '/tmp/maka',
+          permissionMode: 'ask',
+          createdAt: 1,
+          updatedAt: 2,
+        },
+      ],
+    });
+    const projectedAssistant = projection.messages.find(
+      (message): message is AssistantMessage => message.type === 'assistant',
+    );
+    assert.ok(projectedAssistant);
+    assert.deepEqual(
+      projectedAssistant.thinking?.parts,
+      thinkingCompletes.map(({ text, providerOptions }) => ({ text, providerOptions })),
+    );
+
+    const secondModel = completionModel();
+    const secondBackend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: planConnection,
+      apiKey: 'ark-plan-token',
+      modelId: 'ark-code-latest',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => secondModel,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(
+      secondBackend.send({
+        turnId: 'turn-current',
+        text: 'follow up',
+        context: [],
+        runtimeContext,
+      }),
+    );
+
+    const prompt = compactPrompt(secondModel) as ModelMessage[];
+    const assistant = prompt.find(
+      (message) => message.role === 'assistant' && Array.isArray(message.content),
+    );
+    assert.ok(assistant && Array.isArray(assistant.content));
+    assert.deepEqual(
+      assistant.content.filter((part) => part.type === 'reasoning'),
+      [
+        {
+          type: 'reasoning',
+          text: 'first summary',
+          providerOptions: {
+            openai: {
+              itemId: 'rs_first',
+              reasoningEncryptedContent: 'encrypted-first',
+            },
+          },
+        },
+        {
+          type: 'reasoning',
+          text: 'second summary',
+          providerOptions: {
+            openai: {
+              itemId: 'rs_second',
+              reasoningEncryptedContent: 'encrypted-second',
+            },
+          },
+        },
+      ],
+    );
+  });
+
   test('thinking-only tool step (no text) replays reasoning + tool call in one assistant message without an empty text block', async () => {
     // Anthropic interleaved thinking's most common step shape: the step reasons,
     // calls a tool, and produces NO closing text — the backend still flushes the

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -11603,6 +11603,115 @@ describe('AiSdkBackend thinking persistence', () => {
     assert.ok(prompt.indexOf('reasoning about the tool result') < prompt.indexOf('tool-1'));
   });
 
+  test('OpenAI Responses reasoning from a tool step is replayed with its encrypted content', async () => {
+    const ctx = {
+      sessionId: 'session-1',
+      invocationId: 'inv-1',
+      runId: 'run-prev',
+      turnId: 'turn-prev',
+      now: () => 7,
+      newId: idGenerator(),
+    } as unknown as InvocationContext;
+    const memory = createSessionEventMapMemory();
+    const priorEvents: SessionEvent[] = [
+      {
+        type: 'tool_start',
+        id: 'e1',
+        turnId: 'turn-prev',
+        ts: 1,
+        toolUseId: 'tool-1',
+        toolName: 'Read',
+        args: { path: 'package.json' },
+        stepId: 'm1',
+      },
+      {
+        type: 'tool_result',
+        id: 'e2',
+        turnId: 'turn-prev',
+        ts: 2,
+        toolUseId: 'tool-1',
+        isError: false,
+        content: { kind: 'text', text: 'file contents' },
+      },
+      {
+        type: 'thinking_complete',
+        id: 'e3',
+        turnId: 'turn-prev',
+        ts: 3,
+        messageId: 'm1',
+        text: 'reasoning about the tool',
+        providerOptions: {
+          openai: {
+            itemId: 'rs_ark',
+            reasoningEncryptedContent: 'encrypted-ark-reasoning',
+          },
+        },
+      },
+      {
+        type: 'text_complete',
+        id: 'e4',
+        turnId: 'turn-prev',
+        ts: 4,
+        messageId: 'm1',
+        text: '',
+      },
+    ];
+    const runtimeContext = priorEvents.map((event) =>
+      mapSessionEventToRuntimeEvent(event, ctx, memory),
+    );
+    const secondModel = completionModel();
+    const secondBackend = new AiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: {
+        slug: 'volcengine-agent-plan',
+        name: 'Volcengine Ark Agent Plan (China)',
+        providerType: 'volcengine-agent-plan',
+        defaultModel: 'ark-code-latest',
+        enabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      apiKey: 'ark-plan-token',
+      modelId: 'ark-code-latest',
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
+      modelFactory: () => secondModel,
+      tools: [],
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drain(
+      secondBackend.send({
+        turnId: 'turn-current',
+        text: 'follow up',
+        context: [],
+        runtimeContext,
+      }),
+    );
+
+    const prompt = compactPrompt(secondModel) as ModelMessage[];
+    const assistant = prompt.find(
+      (message) => message.role === 'assistant' && Array.isArray(message.content),
+    );
+    assert.ok(assistant && Array.isArray(assistant.content));
+    const reasoning = assistant.content.find((part) => part.type === 'reasoning');
+    assert.deepEqual(reasoning, {
+      type: 'reasoning',
+      text: 'reasoning about the tool',
+      providerOptions: {
+        openai: {
+          itemId: 'rs_ark',
+          reasoningEncryptedContent: 'encrypted-ark-reasoning',
+        },
+      },
+    });
+    assert.ok(
+      assistant.content.some((part) => part.type === 'tool-call' && part.toolCallId === 'tool-1'),
+    );
+  });
+
   test('thinking-only tool step (no text) replays reasoning + tool call in one assistant message without an empty text block', async () => {
     // Anthropic interleaved thinking's most common step shape: the step reasons,
     // calls a tool, and produces NO closing text — the backend still flushes the

--- a/packages/runtime/src/__tests__/context-budget-mid-turn-policy.test.ts
+++ b/packages/runtime/src/__tests__/context-budget-mid-turn-policy.test.ts
@@ -71,6 +71,12 @@ describe('window-bounded reserve derivation (issue #882 PR 3 review P2)', () => 
     assert.deepEqual(policy?.historyCompact?.midTurn, { enabled: true, reserveTokens: 16_384 });
   });
 
+  test('uses the official Agent Plan default-model window instead of the unknown-model fallback', () => {
+    const policy = buildDefaultContextBudgetPolicy(agentPlanConnection(), { env: {} });
+    assert.equal(policy?.maxHistoryEstimatedTokens, 256_000 - 16_384);
+    assert.deepEqual(policy?.historyCompact?.midTurn, { enabled: true, reserveTokens: 16_384 });
+  });
+
   test('keeps the classic 16384 reserve when the window is unknown (metadata-less model)', () => {
     const policy = buildDefaultContextBudgetPolicy(
       {
@@ -114,6 +120,18 @@ function connection(): LlmConnection {
     name: 'Anthropic',
     providerType: 'anthropic',
     defaultModel: 'claude-sonnet-4-5-20250929',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function agentPlanConnection(): LlmConnection {
+  return {
+    slug: 'volcengine-agent-plan',
+    name: 'Volcengine Agent Plan',
+    providerType: 'volcengine-agent-plan',
+    defaultModel: 'ark-code-latest',
     enabled: true,
     createdAt: 1,
     updatedAt: 1,

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -79,6 +79,34 @@ describe('ModelAdapter stream and error normalization', () => {
       toolResults: true,
       signedThinking: false,
       unsignedThinking: true,
+      openAiResponsesThinking: false,
+    });
+  });
+
+  test('supports Responses reasoning replay for Volcengine Agent Plan', () => {
+    const adapter = new ModelAdapter({
+      connection: {
+        slug: 'volcengine-agent-plan',
+        name: 'Volcengine Ark Agent Plan (China)',
+        providerType: 'volcengine-agent-plan',
+        defaultModel: 'ark-code-latest',
+        enabled: true,
+        createdAt: 1,
+        updatedAt: 1,
+      },
+      apiKey: 'ark-plan-token',
+      modelId: 'ark-code-latest',
+      modelFactory: () => ({}),
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    assert.deepEqual(adapter.runtimeEventReplaySupport(), {
+      toolCalls: true,
+      toolResults: true,
+      signedThinking: false,
+      unsignedThinking: false,
+      openAiResponsesThinking: true,
     });
   });
 
@@ -251,6 +279,48 @@ describe('ModelAdapter stream and error normalization', () => {
       | Extract<ModelStreamEvent, { kind: 'thinking-signature' }>
       | undefined;
     assert.equal(signatureEvent?.signature, 'sig-xyz');
+  });
+
+  test('preserves OpenAI Responses reasoning metadata through stream normalization', () => {
+    const adapter = newAdapter();
+    type Chunk = Parameters<typeof adapter.translateChunk>[0];
+    const chunks: Chunk[] = [
+      {
+        type: 'reasoning-delta',
+        delta: 'inspect',
+        providerMetadata: { openai: { itemId: 'rs_ark' } },
+      },
+      {
+        type: 'reasoning-end',
+        providerMetadata: {
+          openai: {
+            itemId: 'rs_ark',
+            reasoningEncryptedContent: 'encrypted-ark-reasoning',
+          },
+        },
+      },
+    ];
+
+    assert.deepEqual(
+      chunks.flatMap((chunk) => adapter.translateChunk(chunk)),
+      [
+        {
+          kind: 'thinking',
+          text: 'inspect',
+          providerOptions: { openai: { itemId: 'rs_ark' } },
+        },
+        {
+          kind: 'thinking',
+          text: '',
+          providerOptions: {
+            openai: {
+              itemId: 'rs_ark',
+              reasoningEncryptedContent: 'encrypted-ark-reasoning',
+            },
+          },
+        },
+      ],
+    );
   });
 
   test('classifies provider errors and maps finish reasons through adapter-owned helpers', () => {

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -37,13 +37,22 @@ describe('buildProviderOptions: thinking level', () => {
   });
 
   test('Volcengine Agent Plan keeps Responses stateless while preserving reasoning replay', () => {
-    assert.deepEqual(buildProviderOptions(conn('volcengine-agent-plan'), 'ark-code-latest'), {
+    const expectedOptions = {
       openai: {
         store: false,
         forceReasoning: true,
       },
-    });
+    };
+    assert.deepEqual(
+      buildProviderOptions(conn('volcengine-agent-plan'), 'ark-code-latest'),
+      expectedOptions,
+    );
     assert.deepEqual(thinkingVariantsForModel('volcengine-agent-plan', 'ark-code-latest'), []);
+    assert.deepEqual(thinkingVariantsForModel('volcengine-agent-plan', 'kimi-k3'), []);
+    assert.deepEqual(
+      buildProviderOptions(conn('volcengine-agent-plan'), 'kimi-k3', 'high'),
+      expectedOptions,
+    );
   });
 
   test('anthropic effort model (opus-4-8) sends effort field directly; no budgetTokens mapping', () => {

--- a/packages/runtime/src/__tests__/model-factory-thinking.test.ts
+++ b/packages/runtime/src/__tests__/model-factory-thinking.test.ts
@@ -36,6 +36,16 @@ describe('buildProviderOptions: thinking level', () => {
     }
   });
 
+  test('Volcengine Agent Plan keeps Responses stateless while preserving reasoning replay', () => {
+    assert.deepEqual(buildProviderOptions(conn('volcengine-agent-plan'), 'ark-code-latest'), {
+      openai: {
+        store: false,
+        forceReasoning: true,
+      },
+    });
+    assert.deepEqual(thinkingVariantsForModel('volcengine-agent-plan', 'ark-code-latest'), []);
+  });
+
   test('anthropic effort model (opus-4-8) sends effort field directly; no budgetTokens mapping', () => {
     assert.deepEqual(buildProviderOptions(conn('anthropic'), 'claude-opus-4-8', 'high'), {
       anthropic: { cacheControl: { type: 'ephemeral' }, effort: 'high' },

--- a/packages/runtime/src/__tests__/provider-conformance.test.ts
+++ b/packages/runtime/src/__tests__/provider-conformance.test.ts
@@ -668,6 +668,30 @@ describe('models.dev provider conformance', () => {
     assert.deepEqual(requests[2]?.body.contents, [{ role: 'user', parts: [{ text: 'Hi' }] }]);
   });
 
+  test('Volcengine Agent Plan connection probes do not retain the synthetic response', async () => {
+    let body: Record<string, unknown> | undefined;
+    const server = await startJsonServer(async (request, response) => {
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/api/plan/v3/responses');
+      assert.equal(request.headers.authorization, 'Bearer ark-plan-token');
+      body = JSON.parse(await readBody(request)) as Record<string, unknown>;
+      respondJson(response, 200, {});
+    });
+    const connection: LlmConnection = {
+      slug: 'volcengine-agent-plan',
+      name: 'Volcengine Ark Agent Plan (China)',
+      providerType: 'volcengine-agent-plan',
+      baseUrl: `${server.url}/api/plan/v3`,
+      defaultModel: 'ark-code-latest',
+      enabled: true,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+
+    assert.equal((await testConnection(connection, 'ark-plan-token')).ok, true);
+    assert.equal(body?.store, false);
+  });
+
   test('Vercel Gateway preserves its public discovery boundary and exact model id through a reasoning tool loop', async () => {
     const modelId = 'xai/grok-4.3';
     const requestBodies: Array<Record<string, unknown>> = [];

--- a/packages/runtime/src/__tests__/provider-contract-overrides.ts
+++ b/packages/runtime/src/__tests__/provider-contract-overrides.ts
@@ -81,7 +81,28 @@ export const PROVIDER_CONTRACT_OVERRIDE_BINDINGS: readonly ProviderContractOverr
   {
     keys: ['openai-responses-compatible:exact-model-id', 'openai-responses-compatible:tool-loop'],
     title: 'Custom OpenAI Responses relay preserves exact model ids and tool results',
-    run: runCustomOpenAIResponsesRelayWire,
+    run: () =>
+      runOpenAIResponsesWire({
+        providerType: 'openai-responses-compatible',
+        slug: 'responses-relay',
+        name: 'Responses Relay',
+        basePath: '/relay/v1',
+        modelId: 'relay-responses-model',
+        apiKey: 'responses-relay-key',
+      }),
+  },
+  {
+    keys: ['volcengine-agent-plan:exact-model-id', 'volcengine-agent-plan:tool-loop'],
+    title: 'Volcengine Agent Plan uses its dedicated key on the OpenAI Responses tool wire',
+    run: () =>
+      runOpenAIResponsesWire({
+        providerType: 'volcengine-agent-plan',
+        slug: 'volcengine-agent-plan',
+        name: 'Volcengine Ark Agent Plan (China)',
+        basePath: '/api/plan/v3',
+        modelId: 'ark-code-latest',
+        apiKey: 'volcengine-agent-plan-test-key',
+      }),
   },
 ];
 
@@ -825,13 +846,20 @@ async function runCohereDiscovery(): Promise<void> {
   assert.equal(result.text, 'Echoed hello.');
 }
 
-async function runCustomOpenAIResponsesRelayWire(): Promise<void> {
-  const modelId = 'relay-responses-model';
+async function runOpenAIResponsesWire(input: {
+  providerType: LlmConnection['providerType'];
+  slug: string;
+  name: string;
+  basePath: string;
+  modelId: string;
+  apiKey: string;
+}): Promise<void> {
+  const { providerType, slug, name, basePath, modelId, apiKey } = input;
   const requestBodies: Array<Record<string, unknown>> = [];
   const server = await startJsonServer(async (request, response) => {
     assert.equal(request.method, 'POST');
-    assert.equal(request.url, '/relay/v1/responses');
-    assert.equal(request.headers.authorization, 'Bearer responses-relay-key');
+    assert.equal(request.url, `${basePath}/responses`);
+    assert.equal(request.headers.authorization, `Bearer ${apiKey}`);
     requestBodies.push(JSON.parse(await readBody(request)) as Record<string, unknown>);
     if (requestBodies.length === 1) {
       respondJson(response, 200, {
@@ -873,10 +901,10 @@ async function runCustomOpenAIResponsesRelayWire(): Promise<void> {
     });
   });
   const connection: LlmConnection = {
-    slug: 'responses-relay',
-    name: 'Responses Relay',
-    providerType: 'openai-responses-compatible',
-    baseUrl: `${server.url}/relay/v1`,
+    slug,
+    name,
+    providerType,
+    baseUrl: `${server.url}${basePath}`,
     defaultModel: modelId,
     enabled: true,
     createdAt: 1,
@@ -884,7 +912,7 @@ async function runCustomOpenAIResponsesRelayWire(): Promise<void> {
   };
 
   const result = await generateText({
-    model: getAIModel({ connection, apiKey: 'responses-relay-key', modelId }),
+    model: getAIModel({ connection, apiKey, modelId }),
     prompt: 'Call echo with hello.',
     stopWhen: isStepCount(2),
     tools: {

--- a/packages/runtime/src/__tests__/provider-contract-overrides.ts
+++ b/packages/runtime/src/__tests__/provider-contract-overrides.ts
@@ -92,7 +92,11 @@ export const PROVIDER_CONTRACT_OVERRIDE_BINDINGS: readonly ProviderContractOverr
       }),
   },
   {
-    keys: ['volcengine-agent-plan:exact-model-id', 'volcengine-agent-plan:tool-loop'],
+    keys: [
+      'volcengine-agent-plan:exact-model-id',
+      'volcengine-agent-plan:tool-loop',
+      'volcengine-agent-plan:reasoning-replay',
+    ],
     title: 'Volcengine Agent Plan uses its dedicated key on the OpenAI Responses tool wire',
     run: () =>
       runOpenAIResponsesWire({
@@ -871,6 +875,16 @@ async function runOpenAIResponsesWire(input: {
         status: 'completed',
         model: modelId,
         output: [
+          ...(statelessReasoning
+            ? [
+                {
+                  type: 'reasoning',
+                  id: 'rs_relay_tool',
+                  summary: [{ type: 'summary_text', text: 'Use echo.' }],
+                  encrypted_content: 'encrypted-relay-reasoning',
+                },
+              ]
+            : []),
           {
             type: 'function_call',
             id: 'fc_relay_echo',
@@ -934,6 +948,17 @@ async function runOpenAIResponsesWire(input: {
   if (statelessReasoning) {
     assert.equal(requestBodies[0]?.store, false);
     assert.deepEqual(requestBodies[0]?.include, ['reasoning.encrypted_content']);
+    assert.deepEqual(
+      (requestBodies[1].input as Array<Record<string, unknown>>).find(
+        ({ type }) => type === 'reasoning',
+      ),
+      {
+        type: 'reasoning',
+        id: 'rs_relay_tool',
+        summary: [{ type: 'summary_text', text: 'Use echo.' }],
+        encrypted_content: 'encrypted-relay-reasoning',
+      },
+    );
   }
   assert.deepEqual(
     (requestBodies[1].input as Array<Record<string, unknown>>).find(

--- a/packages/runtime/src/__tests__/provider-contract-overrides.ts
+++ b/packages/runtime/src/__tests__/provider-contract-overrides.ts
@@ -17,7 +17,7 @@ import type { LlmConnection } from '@maka/core';
 import { generateText, isStepCount, streamText, tool } from 'ai';
 import { z } from 'zod';
 import { fetchProviderModels } from '../model-fetcher.js';
-import { getAIModel } from '../model-factory.js';
+import { buildProviderOptions, getAIModel } from '../model-factory.js';
 import { buildSubscriptionModelFetch } from '../subscription-model-fetch.js';
 import {
   readBody,
@@ -102,6 +102,7 @@ export const PROVIDER_CONTRACT_OVERRIDE_BINDINGS: readonly ProviderContractOverr
         basePath: '/api/plan/v3',
         modelId: 'ark-code-latest',
         apiKey: 'volcengine-agent-plan-test-key',
+        statelessReasoning: true,
       }),
   },
 ];
@@ -853,8 +854,9 @@ async function runOpenAIResponsesWire(input: {
   basePath: string;
   modelId: string;
   apiKey: string;
+  statelessReasoning?: boolean;
 }): Promise<void> {
-  const { providerType, slug, name, basePath, modelId, apiKey } = input;
+  const { providerType, slug, name, basePath, modelId, apiKey, statelessReasoning } = input;
   const requestBodies: Array<Record<string, unknown>> = [];
   const server = await startJsonServer(async (request, response) => {
     assert.equal(request.method, 'POST');
@@ -914,6 +916,7 @@ async function runOpenAIResponsesWire(input: {
   const result = await generateText({
     model: getAIModel({ connection, apiKey, modelId }),
     prompt: 'Call echo with hello.',
+    ...(statelessReasoning ? { providerOptions: buildProviderOptions(connection, modelId) } : {}),
     stopWhen: isStepCount(2),
     tools: {
       echo: tool({
@@ -928,6 +931,10 @@ async function runOpenAIResponsesWire(input: {
     requestBodies.map((body) => body.model),
     [modelId, modelId],
   );
+  if (statelessReasoning) {
+    assert.equal(requestBodies[0]?.store, false);
+    assert.deepEqual(requestBodies[0]?.include, ['reasoning.encrypted_content']);
+  }
   assert.deepEqual(
     (requestBodies[1].input as Array<Record<string, unknown>>).find(
       ({ type }) => type === 'function_call_output',

--- a/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-adapters.test.ts
@@ -325,6 +325,47 @@ describe('storedMessageToRuntimeEvents', () => {
     expect(out[1]?.refs?.storedMessageId).toBe('a2');
   });
 
+  test('assistant with multiple reasoning parts → one replay event per part', () => {
+    const out = storedMessageToRuntimeEvents(
+      assistant('a-parts', 'answer', {
+        text: 'firstsecond',
+        parts: [
+          {
+            text: 'first',
+            providerOptions: {
+              openai: { itemId: 'rs_first', reasoningEncryptedContent: 'encrypted-first' },
+            },
+          },
+          {
+            text: 'second',
+            providerOptions: {
+              openai: { itemId: 'rs_second', reasoningEncryptedContent: 'encrypted-second' },
+            },
+          },
+        ],
+      }),
+      ctx,
+    );
+
+    expect(out.map((event) => event.content)).toEqual([
+      { kind: 'text', text: 'answer' },
+      {
+        kind: 'thinking',
+        text: 'first',
+        providerOptions: {
+          openai: { itemId: 'rs_first', reasoningEncryptedContent: 'encrypted-first' },
+        },
+      },
+      {
+        kind: 'thinking',
+        text: 'second',
+        providerOptions: {
+          openai: { itemId: 'rs_second', reasoningEncryptedContent: 'encrypted-second' },
+        },
+      },
+    ]);
+  });
+
   test('user message → single event (same as singular)', () => {
     const out = storedMessageToRuntimeEvents(user('u', 'hello'), ctx);
     expect(out).toHaveLength(1);

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -77,6 +77,7 @@ import type {
   JSONValue,
   ModelFinishReason,
   ModelMessage,
+  ReasoningPart,
   ModelToolSet,
   NormalizedUsage,
   ModelFailureKind,
@@ -2379,6 +2380,10 @@ export class AiSdkBackend implements AgentBackend {
     type ToolCallItem = Extract<RuntimeEventModelReplayItem, { kind: 'tool_call' }>;
     type ToolResultItem = Extract<RuntimeEventModelReplayItem, { kind: 'tool_result' }>;
     type ThinkingItem = Extract<RuntimeEventModelReplayItem, { kind: 'thinking' }>;
+    type ReplayReasoning = {
+      part?: ReasoningPart;
+      providerOptions?: NonNullable<ModelMessage['providerOptions']>;
+    };
     const out: ModelMessage[] = [];
     let bufferedCalls: ToolCallItem[] = [];
     const results = new Map<string, ToolResultItem>();
@@ -2386,7 +2391,7 @@ export class AiSdkBackend implements AgentBackend {
     const textByStep = new Map<string, string>();
 
     const replaySupport = this.modelAdapter.runtimeEventReplaySupport();
-    const reasoningReplay = (item: ThinkingItem) => {
+    const reasoningReplay = (item: ThinkingItem): ReplayReasoning | undefined => {
       if (item.signature) {
         return replaySupport.signedThinking
           ? {
@@ -2397,6 +2402,32 @@ export class AiSdkBackend implements AgentBackend {
               },
             }
           : undefined;
+      }
+      if (replaySupport.openAiResponsesThinking) {
+        const openai = item.providerOptions?.openai;
+        if (openai && typeof openai === 'object' && !Array.isArray(openai)) {
+          const { itemId, reasoningEncryptedContent } = openai as {
+            itemId?: unknown;
+            reasoningEncryptedContent?: unknown;
+          };
+          if (typeof itemId === 'string' && itemId.length > 0) {
+            return {
+              part: {
+                type: 'reasoning' as const,
+                text: item.text,
+                providerOptions: {
+                  openai: {
+                    itemId,
+                    ...(typeof reasoningEncryptedContent === 'string' ||
+                    reasoningEncryptedContent === null
+                      ? { reasoningEncryptedContent }
+                      : {}),
+                  },
+                },
+              },
+            };
+          }
+        }
       }
       if (!replaySupport.unsignedThinking) return undefined;
       const kimiReasoningField = kimiReasoningFieldFromProviderOptions(item.providerOptions);

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -38,6 +38,7 @@ import type {
 import type {
   StoredMessage,
   AssistantMessage,
+  AssistantThinkingPart,
   ToolCallMessage,
   ToolResultMessage,
   PermissionDecisionMessage,
@@ -712,6 +713,7 @@ export class AiSdkBackend implements AgentBackend {
     let stepThinking = '';
     let sawStepThinking = false;
     let stepThinkingProviderOptions: NonNullable<ModelMessage['providerOptions']> | undefined;
+    let stepResponsesThinkingParts: AssistantThinkingPart[] = [];
     let stepSignature: string | undefined;
     const startedAt = this.now();
 
@@ -728,6 +730,18 @@ export class AiSdkBackend implements AgentBackend {
       const hasThinking = sawStepThinking || stepSignature !== undefined;
       if (stepText.length === 0 && !hasThinking) return;
       const stepId = currentStepMessageId;
+      const thinkingParts: AssistantThinkingPart[] =
+        stepResponsesThinkingParts.length > 0
+          ? stepResponsesThinkingParts
+          : [
+              {
+                text: stepThinking,
+                ...(stepSignature !== undefined ? { signature: stepSignature } : {}),
+                ...(stepThinkingProviderOptions !== undefined
+                  ? { providerOptions: stepThinkingProviderOptions }
+                  : {}),
+              },
+            ];
       const msg: AssistantMessage = {
         type: 'assistant',
         id: stepId,
@@ -739,28 +753,33 @@ export class AiSdkBackend implements AgentBackend {
           ? {
               thinking: {
                 text: stepThinking,
-                ...(stepSignature !== undefined ? { signature: stepSignature } : {}),
-                ...(stepThinkingProviderOptions !== undefined
-                  ? { providerOptions: stepThinkingProviderOptions }
+                ...(thinkingParts.length === 1 && thinkingParts[0]!.signature !== undefined
+                  ? { signature: thinkingParts[0]!.signature }
                   : {}),
+                ...(thinkingParts.length === 1 && thinkingParts[0]!.providerOptions !== undefined
+                  ? { providerOptions: thinkingParts[0]!.providerOptions }
+                  : {}),
+                ...(thinkingParts.length > 1 ? { parts: thinkingParts } : {}),
               },
             }
           : {}),
       };
       await this.input.appendMessage(msg);
       if (hasThinking) {
-        queue.push({
-          type: 'thinking_complete',
-          id: this.newId(),
-          turnId,
-          ts: this.now(),
-          messageId: stepId,
-          text: stepThinking,
-          ...(stepSignature !== undefined ? { signature: stepSignature } : {}),
-          ...(stepThinkingProviderOptions !== undefined
-            ? { providerOptions: stepThinkingProviderOptions }
-            : {}),
-        } satisfies ThinkingCompleteEvent);
+        for (const part of thinkingParts) {
+          queue.push({
+            type: 'thinking_complete',
+            id: this.newId(),
+            turnId,
+            ts: this.now(),
+            messageId: stepId,
+            text: part.text,
+            ...(part.signature !== undefined ? { signature: part.signature } : {}),
+            ...(part.providerOptions !== undefined
+              ? { providerOptions: part.providerOptions }
+              : {}),
+          } satisfies ThinkingCompleteEvent);
+        }
       }
       queue.push({
         type: 'text_complete',
@@ -774,6 +793,7 @@ export class AiSdkBackend implements AgentBackend {
       stepThinking = '';
       sawStepThinking = false;
       stepThinkingProviderOptions = undefined;
+      stepResponsesThinkingParts = [];
       stepSignature = undefined;
     };
     let tokenUsage: NormalizedAiSdkUsage | undefined;
@@ -1373,6 +1393,33 @@ export class AiSdkBackend implements AgentBackend {
                   stepThinking += event.text;
                   if (event.providerOptions !== undefined) {
                     stepThinkingProviderOptions = event.providerOptions;
+                  }
+                  const openai = event.providerOptions?.openai;
+                  const itemId =
+                    openai && typeof openai === 'object' && !Array.isArray(openai)
+                      ? (openai as { itemId?: unknown }).itemId
+                      : undefined;
+                  if (typeof itemId === 'string' && itemId.length > 0) {
+                    let part = stepResponsesThinkingParts.find(
+                      (candidate) =>
+                        (candidate.providerOptions?.openai as { itemId?: unknown } | undefined)
+                          ?.itemId === itemId,
+                    );
+                    if (!part) {
+                      part = {
+                        text:
+                          stepResponsesThinkingParts.length === 0 && event.text.length === 0
+                            ? stepThinking
+                            : '',
+                        providerOptions: event.providerOptions,
+                      };
+                      stepResponsesThinkingParts.push(part);
+                    } else {
+                      part.providerOptions = event.providerOptions;
+                    }
+                    part.text += event.text;
+                  } else if (stepResponsesThinkingParts.length > 0) {
+                    stepResponsesThinkingParts.at(-1)!.text += event.text;
                   }
                   queue.push({
                     type: 'thinking_delta',
@@ -2387,7 +2434,7 @@ export class AiSdkBackend implements AgentBackend {
     const out: ModelMessage[] = [];
     let bufferedCalls: ToolCallItem[] = [];
     const results = new Map<string, ToolResultItem>();
-    const reasoningByStep = new Map<string, ThinkingItem>();
+    const reasoningByStep = new Map<string, ThinkingItem[]>();
     const textByStep = new Map<string, string>();
 
     const replaySupport = this.modelAdapter.runtimeEventReplaySupport();
@@ -2473,13 +2520,17 @@ export class AiSdkBackend implements AgentBackend {
     // Emit one assistant message for a step: reasoning (if any), text (if any),
     // then the step's tool calls, followed by those calls' tool results.
     const emitStep = async (
-      reasoning: ThinkingItem | undefined,
+      reasoning: readonly ThinkingItem[] | undefined,
       text: string,
       calls: readonly ToolCallItem[],
     ) => {
       const content: unknown[] = [];
-      const replayReasoning = reasoning ? reasoningReplay(reasoning) : undefined;
-      if (replayReasoning?.part) content.push(replayReasoning.part);
+      const replayReasoning = reasoning
+        ?.map(reasoningReplay)
+        .filter((item): item is ReplayReasoning => item !== undefined);
+      for (const item of replayReasoning ?? []) {
+        if (item.part) content.push(item.part);
+      }
       if (text.length > 0) content.push({ type: 'text', text });
       for (const call of calls) {
         content.push({
@@ -2490,13 +2541,14 @@ export class AiSdkBackend implements AgentBackend {
           ...(call.providerOptions !== undefined ? { providerOptions: call.providerOptions } : {}),
         });
       }
-      if (content.length > 0 || replayReasoning?.providerOptions) {
+      const replayProviderOptions = replayReasoning?.find(
+        (item) => item.providerOptions !== undefined,
+      )?.providerOptions;
+      if (content.length > 0 || replayProviderOptions) {
         out.push({
           role: 'assistant',
           content,
-          ...(replayReasoning?.providerOptions
-            ? { providerOptions: replayReasoning.providerOptions }
-            : {}),
+          ...(replayProviderOptions ? { providerOptions: replayProviderOptions } : {}),
         } as ModelMessage);
       }
       await pushToolResults(calls);
@@ -2558,7 +2610,9 @@ export class AiSdkBackend implements AgentBackend {
           break;
         case 'thinking':
           if (item.stepId !== undefined) {
-            reasoningByStep.set(item.stepId, item);
+            const stepReasoning = reasoningByStep.get(item.stepId) ?? [];
+            stepReasoning.push(item);
+            reasoningByStep.set(item.stepId, stepReasoning);
           } else {
             // Legacy standalone reasoning (pure-reasoning turn): emit on its own.
             await flushPendingSteps();

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -1,6 +1,6 @@
 import type { ErrorEvent, CompleteEvent } from '@maka/core/events';
 import { providerAuthRequiresSecret, type LlmConnection } from '@maka/core/llm-connections';
-import { lookupModelMetadata } from '@maka/core/model-metadata';
+import { lookupModelMetadata, openAiAdapterApiProtocol } from '@maka/core/model-metadata';
 import { generalizedErrorMessage } from '@maka/core/redaction';
 import type { CacheMissInputSource } from '@maka/core/usage-stats/types';
 import type {
@@ -127,6 +127,7 @@ export class ModelAdapter {
       toolResults: true,
       signedThinking: usesAnthropicMessages(this.input.connection, this.input.modelId),
       unsignedThinking: usesKimiOpenAiChat(this.input.connection, this.input.modelId),
+      openAiResponsesThinking: usesOpenAiResponses(this.input.connection, this.input.modelId),
     };
   }
 
@@ -374,6 +375,16 @@ function usesKimiOpenAiChat(connection: LlmConnection, modelId: string): boolean
   );
 }
 
+function usesOpenAiResponses(connection: LlmConnection, modelId: string): boolean {
+  const runtime = resolveModelRuntime(connection, modelId);
+  if (runtime.adapter.kind !== 'openai') return false;
+  return (
+    runtime.adapter.apiProtocol === 'openai-responses' ||
+    runtime.apiProtocol === 'openai-responses' ||
+    openAiAdapterApiProtocol(modelId, connection.providerType) === 'openai-responses'
+  );
+}
+
 function fixedAnthropicThinkingBudget(
   providerOptions: Record<string, unknown> | undefined,
 ): number {
@@ -390,6 +401,7 @@ export interface ModelAdapterRuntimeEventReplaySupport {
   toolResults: boolean;
   signedThinking: boolean;
   unsignedThinking: boolean;
+  openAiResponsesThinking: boolean;
 }
 
 /**
@@ -444,6 +456,28 @@ function reasoningSignatureFromChunk(chunk: AiSdkStreamChunk): string | undefine
   return typeof signature === 'string' && signature.length > 0 ? signature : undefined;
 }
 
+function openAiResponsesReasoningProviderOptionsFromChunk(
+  chunk: AiSdkStreamChunk,
+): NonNullable<ModelMessage['providerOptions']> | undefined {
+  const meta = chunk.providerMetadata;
+  if (!meta || typeof meta !== 'object') return undefined;
+  const openai = (meta as { openai?: unknown }).openai;
+  if (!openai || typeof openai !== 'object' || Array.isArray(openai)) return undefined;
+  const { itemId, reasoningEncryptedContent } = openai as {
+    itemId?: unknown;
+    reasoningEncryptedContent?: unknown;
+  };
+  if (typeof itemId !== 'string' || itemId.length === 0) return undefined;
+  return {
+    openai: {
+      itemId,
+      ...(typeof reasoningEncryptedContent === 'string' || reasoningEncryptedContent === null
+        ? { reasoningEncryptedContent }
+        : {}),
+    },
+  };
+}
+
 /**
  * Translate one raw AI SDK stream chunk into zero or more Maka-owned
  * `ModelStreamEvent`s. The sole site that parses SDK chunk names; the backend
@@ -469,6 +503,7 @@ function translateChunk(
               ? chunk.delta
               : undefined;
       const signature = reasoningSignatureFromChunk(chunk);
+      const responsesProviderOptions = openAiResponsesReasoningProviderOptionsFromChunk(chunk);
       const events: ModelStreamEvent[] = [];
       if (signature) events.push({ kind: 'thinking-signature', signature });
       // The signed reasoning chunk arrives as a standalone delta with empty
@@ -478,20 +513,28 @@ function translateChunk(
         events.push({
           kind: 'thinking',
           text: restoreKimiEmptyReasoning(text),
-          ...(kimiOpenAiTransportState
-            ? {
-                providerOptions: kimiReasoningFieldProviderOptions(
-                  kimiOpenAiTransportState.reasoningField,
-                ),
-              }
-            : {}),
+          ...(responsesProviderOptions
+            ? { providerOptions: responsesProviderOptions }
+            : kimiOpenAiTransportState
+              ? {
+                  providerOptions: kimiReasoningFieldProviderOptions(
+                    kimiOpenAiTransportState.reasoningField,
+                  ),
+                }
+              : {}),
         });
       }
       return events;
     }
     case 'reasoning-end': {
       const signature = reasoningSignatureFromChunk(chunk);
-      return signature ? [{ kind: 'thinking-signature', signature }] : [];
+      const responsesProviderOptions = openAiResponsesReasoningProviderOptionsFromChunk(chunk);
+      return [
+        ...(signature ? [{ kind: 'thinking-signature' as const, signature }] : []),
+        ...(responsesProviderOptions
+          ? [{ kind: 'thinking' as const, text: '', providerOptions: responsesProviderOptions }]
+          : []),
+      ];
     }
     // Step boundaries (`start-step` / `finish-step`) and the terminal `finish`
     // carry no text/thinking to stream. The backend owns step accounting: it

--- a/packages/runtime/src/model-factory.ts
+++ b/packages/runtime/src/model-factory.ts
@@ -373,6 +373,13 @@ export function buildProviderOptions(
           ...(level ? { reasoningEffort: level === 'off' ? 'none' : level } : {}),
         },
       };
+    case 'volcengine-agent-plan':
+      return {
+        openai: {
+          store: false,
+          forceReasoning: true,
+        },
+      };
     case 'xai':
     case 'xai-oauth':
       return modelId === 'grok-4.5'

--- a/packages/runtime/src/runtime-event-adapters.ts
+++ b/packages/runtime/src/runtime-event-adapters.ts
@@ -170,28 +170,29 @@ export function storedMessageToRuntimeEvents(
 
   if (message.type === 'assistant' && message.thinking) {
     const d = resolveCtx(ctx, message);
-    out.push({
-      id: d.newId(),
-      invocationId: d.invocationId,
-      runId: d.runId,
-      sessionId: d.sessionId,
-      turnId: d.turnId,
-      ts: d.ts,
-      partial: false,
-      role: 'model',
-      author: 'agent',
-      content: {
-        kind: 'thinking',
-        text: message.thinking.text,
-        ...(message.thinking.signature !== undefined
-          ? { signature: message.thinking.signature }
-          : {}),
-        ...(message.thinking.providerOptions !== undefined
-          ? { providerOptions: structuredClone(message.thinking.providerOptions) }
-          : {}),
-      },
-      refs: { storedMessageId: message.id },
-    });
+    const parts = message.thinking.parts ?? [message.thinking];
+    for (const part of parts) {
+      out.push({
+        id: d.newId(),
+        invocationId: d.invocationId,
+        runId: d.runId,
+        sessionId: d.sessionId,
+        turnId: d.turnId,
+        ts: d.ts,
+        partial: false,
+        role: 'model',
+        author: 'agent',
+        content: {
+          kind: 'thinking',
+          text: part.text,
+          ...(part.signature !== undefined ? { signature: part.signature } : {}),
+          ...(part.providerOptions !== undefined
+            ? { providerOptions: structuredClone(part.providerOptions) }
+            : {}),
+        },
+        refs: { storedMessageId: message.id },
+      });
+    }
   }
 
   return out;

--- a/packages/runtime/src/runtime-event-backfill.ts
+++ b/packages/runtime/src/runtime-event-backfill.ts
@@ -115,24 +115,25 @@ export function backfillRuntimeEventsFromStoredMessages(
           refs: { storedMessageId: message.id },
         });
         if (message.thinking) {
-          events.push({
-            ...base,
-            id: newId(),
-            role: 'model',
-            author: 'agent',
-            content: {
-              kind: 'thinking',
-              text: message.thinking.text,
-              ...(message.thinking.signature !== undefined
-                ? { signature: message.thinking.signature }
-                : {}),
-              ...(message.thinking.providerOptions !== undefined
-                ? { providerOptions: structuredClone(message.thinking.providerOptions) }
-                : {}),
-            },
-            actions: { stateDelta: recoveryState(now, message) },
-            refs: { storedMessageId: message.id },
-          });
+          const parts = message.thinking.parts ?? [message.thinking];
+          for (const part of parts) {
+            events.push({
+              ...base,
+              id: newId(),
+              role: 'model',
+              author: 'agent',
+              content: {
+                kind: 'thinking',
+                text: part.text,
+                ...(part.signature !== undefined ? { signature: part.signature } : {}),
+                ...(part.providerOptions !== undefined
+                  ? { providerOptions: structuredClone(part.providerOptions) }
+                  : {}),
+              },
+              actions: { stateDelta: recoveryState(now, message) },
+              refs: { storedMessageId: message.id },
+            });
+          }
         }
         break;
 

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -95,7 +95,7 @@ interface ProjectionState {
    * step's assistant row gets). Per-step turns have several entries per turn, so
    * keying by message id (not turn) attaches each step's reasoning to its own row.
    */
-  thinkingByMessageId: Map<string, PendingThinking>;
+  thinkingByMessageId: Map<string, PendingThinking[]>;
   contentOrderByMessageId: Map<string, AssistantStepContentKind[]>;
 }
 
@@ -246,13 +246,15 @@ export function projectRuntimeEventsToStoredMessages(
     }
   }
 
-  for (const pending of state.thinkingByMessageId.values()) {
-    diagnostic(
-      state,
-      pending.event,
-      'unsupported_event',
-      'thinking content has no assistant text row with a matching message id',
-    );
+  for (const pendingItems of state.thinkingByMessageId.values()) {
+    for (const pending of pendingItems) {
+      diagnostic(
+        state,
+        pending.event,
+        'unsupported_event',
+        'thinking content has no assistant text row with a matching message id',
+      );
+    }
   }
 
   return { messages, diagnostics: state.diagnostics };
@@ -588,7 +590,9 @@ function projectThinking(
   // attach eagerly if it already exists (older ordering), else park by message id
   // for projectText's attachPendingThinking to claim.
   if (attachThinkingToAssistant(event, pending, messages)) return true;
-  state.thinkingByMessageId.set(messageId, pending);
+  const pendingItems = state.thinkingByMessageId.get(messageId) ?? [];
+  pendingItems.push(pending);
+  state.thinkingByMessageId.set(messageId, pendingItems);
   return true;
 }
 
@@ -1004,9 +1008,9 @@ function attachPendingThinking(
   messages: StoredMessage[],
   assistantMessageId: string,
 ): void {
-  const pending = state.thinkingByMessageId.get(assistantMessageId);
-  if (!pending) return;
-  if (attachThinkingToAssistant(event, pending, messages)) {
+  const pendingItems = state.thinkingByMessageId.get(assistantMessageId);
+  if (!pendingItems) return;
+  if (pendingItems.every((pending) => attachThinkingToAssistant(event, pending, messages))) {
     state.thinkingByMessageId.delete(assistantMessageId);
   }
 }
@@ -1022,12 +1026,31 @@ function attachThinkingToAssistant(
     const message = messages[index]!;
     if (message.type !== 'assistant' || message.turnId !== event.turnId) continue;
     if (message.id !== pending.messageId) continue;
-    message.thinking = {
+    const incoming = {
       text: pending.text,
       ...(pending.signature !== undefined ? { signature: pending.signature } : {}),
       ...(pending.providerOptions !== undefined
         ? { providerOptions: structuredClone(pending.providerOptions) }
         : {}),
+    };
+    if (!message.thinking) {
+      message.thinking = incoming;
+      return true;
+    }
+    const parts = message.thinking.parts ?? [
+      {
+        text: message.thinking.text,
+        ...(message.thinking.signature !== undefined
+          ? { signature: message.thinking.signature }
+          : {}),
+        ...(message.thinking.providerOptions !== undefined
+          ? { providerOptions: structuredClone(message.thinking.providerOptions) }
+          : {}),
+      },
+    ];
+    message.thinking = {
+      text: message.thinking.text + pending.text,
+      parts: [...parts, incoming],
     };
     return true;
   }

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -139,6 +139,7 @@ async function probeOpenAIResponses(
     },
     body: JSON.stringify({
       model,
+      store: false,
       max_output_tokens: 16,
       input: [{ role: 'user', content: 'Hi' }],
     }),


### PR DESCRIPTION
## Summary

- add Volcengine Ark Agent Plan as an independent persisted provider instead of conflating it with Ark direct API or Coding Plan
- use the official dedicated `https://ark.cn-beijing.volces.com/api/plan/v3` endpoint, API-key credential contract, and OpenAI Responses wire
- seed the official Agent Plan text-model snapshot and metadata while keeping refresh hidden because its authenticated inference data plane exposes no model-list resource
- reuse the governed Volcengine brand path and add localized catalog copy
- keep `models.dev` and non-interactive headless provider credential mappings unchanged

Official references:

- [Agent Plan model and limit reference](https://www.volcengine.com/docs/82379/2366394)
- [Agent Plan Codex configuration](https://www.volcengine.com/docs/82379/2556054)
- [Ark CLI Agent Plan resource discovery](https://github.com/volcengine/ark-cli/blob/b1a7ee8a9231ce5e1cfafde8c20a55a2f50a33f3/skills/arkcli-resources/references/arkcli-resources-list.md)

## Verification

- `npm run format`
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `npm run build:test`
- Core full suite: 1,258 tests passed
- Core provider/catalog/auth contracts: 216 tests passed
- Runtime provider conformance matrix: 120 tests passed
- Desktop icon and display-copy contracts: 37 tests passed
- Headless provider credential contracts: 40 tests passed
- Follow-up Core/Runtime discovery contracts: 278 tests passed
- Live credential model-list probe: invalid credentials return 401, while a valid dedicated Agent Plan key authenticates and then receives 404 from both `/api/plan/v3/models` and `/api/plan/v1/models`

No live inference request was run. The valid subscription key was used only for read-only model-list probes, and no key or response content was logged. The deterministic runtime contract verifies the exact `/responses` URL, bearer credential, model ID, and two-step tool-result replay.
