### PR TITLE
feat(cli): expose one-shot Cloud Session activation protocol

### DIFF
--- a/packages/cli/src/__tests__/activation-command.test.ts
+++ b/packages/cli/src/__tests__/activation-command.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { access, mkdir, mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { after, before, describe, test } from 'node:test';
@@ -97,6 +97,7 @@ function fakeDeps(
     onClose?: () => void;
     safeBoundaryResume?: boolean;
     onResume?: () => void;
+    onSandboxBoundaryResponse?: (response: { requestId: string; decision: 'deny' }) => void;
     sendMessage?: (
       runtime: MakaActivationRuntime,
       sessionId: string,
@@ -134,7 +135,9 @@ function fakeDeps(
       }
       await observer?.(options.result ?? completedResult(sessionId));
     },
-    async respondToPermission() {},
+    async respondToSandboxBoundary(_sessionId, response) {
+      options.onSandboxBoundaryResponse?.(response);
+    },
     async stopSession() {},
   };
 
@@ -313,8 +316,43 @@ describe('maka activate JSONL protocol', () => {
     assert.equal(lines.join('\n').includes('sk-test-secret'), false);
   });
 
-  test('returns blocked for a denied non-interactive permission request', async () => {
+  test('emits a terminal fatal outcome for malformed JSON input', async () => {
     const lines: string[] = [];
+    const result = await runMakaActivationCli(
+      [
+        '--state-root',
+        ROOTS.stateRoot,
+        '--workspace-root',
+        ROOTS.workspaceRoot,
+        '--config-root',
+        ROOTS.configRoot,
+      ],
+      {
+        ...fakeDeps({ input: '{"schemaVersion": 1' }),
+        newId: () => 'generated-id',
+        writeStdout: (text) => lines.push(text.trim()),
+      },
+    );
+
+    assert.equal(result, 2);
+    assert.deepEqual(
+      lines.map((line) => JSON.parse(line).type),
+      ['start', 'outcome'],
+    );
+    assert.deepEqual(JSON.parse(lines.at(-1)!), {
+      protocol: 'maka.activation',
+      schemaVersion: 1,
+      type: 'outcome',
+      activationId: 'generated-id',
+      cloudSessionId: 'unknown',
+      status: 'fatal_failure',
+      reason: 'malformed_input',
+    });
+  });
+
+  test('returns blocked after denying a non-interactive sandbox boundary request', async () => {
+    const lines: string[] = [];
+    const responses: Array<{ requestId: string; decision: 'deny' }> = [];
     const result = await runMakaActivationCli(
       [
         '--state-root',
@@ -332,20 +370,21 @@ describe('maka activate JSONL protocol', () => {
             finalOutput: undefined,
             failure: { class: 'permission_denied' },
           },
+          onSandboxBoundaryResponse: (response) => responses.push(response),
           events: [
             {
-              type: 'permission_request',
-              kind: 'tool_permission',
-              id: 'permission-event',
+              type: 'sandbox_boundary_request',
+              id: 'boundary-event',
               turnId: 'turn-1',
               ts: 1,
-              requestId: 'request-1',
+              requestId: 'boundary-1',
               toolUseId: 'tool-1',
-              toolName: 'Bash',
-              category: 'shell_unsafe',
-              reason: 'shell_dangerous',
-              args: { command: 'echo ok' },
-              rememberForTurnAllowed: false,
+              justification: 'write generated output',
+              expansion: {
+                filesystem: {
+                  entries: [{ path: '/tmp/output', access: 'write', scope: 'subtree' }],
+                },
+              },
             },
           ],
         }),
@@ -354,8 +393,124 @@ describe('maka activate JSONL protocol', () => {
     );
 
     assert.equal(result, 3);
+    assert.deepEqual(responses, [{ requestId: 'boundary-1', decision: 'deny' }]);
     assert.equal(JSON.parse(lines.at(-1)!).status, 'blocked');
     assert.equal(JSON.parse(lines.at(-1)!).reason, 'permission_denied');
+  });
+
+  test('returns blocked for an unresolved production sandbox tool failure', async () => {
+    const lines: string[] = [];
+    const boundaryFailure = {
+      kind: 'text',
+      text: 'Write requires an approved session sandbox boundary expansion.',
+      sandboxFailure: {
+        reason: 'sandbox_boundary_required',
+        requiredExpansion: {
+          filesystem: {
+            entries: [{ path: '/tmp/output', access: 'write', scope: 'subtree' }],
+          },
+        },
+      },
+    } as const;
+    const result = await runMakaActivationCli(
+      [
+        '--state-root',
+        ROOTS.stateRoot,
+        '--workspace-root',
+        ROOTS.workspaceRoot,
+        '--config-root',
+        ROOTS.configRoot,
+      ],
+      {
+        ...fakeDeps({
+          result: {
+            ...completedResult(),
+            finalOutput: 'continued after the failed write',
+            events: [
+              {
+                id: 'event-boundary-result',
+                invocationId: 'invocation-1',
+                runId: 'run-1',
+                sessionId: 'maka-session-1',
+                turnId: 'turn-1',
+                ts: 1,
+                partial: false,
+                role: 'tool',
+                author: 'tool',
+                content: {
+                  kind: 'function_response',
+                  id: 'tool-boundary',
+                  name: 'Write',
+                  isError: true,
+                  result: boundaryFailure,
+                },
+              },
+            ],
+          },
+          events: [
+            {
+              type: 'tool_result',
+              id: 'event-boundary-result',
+              turnId: 'turn-1',
+              ts: 1,
+              toolUseId: 'tool-boundary',
+              isError: true,
+              content: boundaryFailure,
+            },
+          ],
+        }),
+        writeStdout: (text) => lines.push(text.trim()),
+      },
+    );
+
+    assert.equal(result, 3);
+    assert.deepEqual(JSON.parse(lines.at(-1)!), {
+      protocol: 'maka.activation',
+      schemaVersion: 1,
+      type: 'outcome',
+      activationId: 'activation-1',
+      cloudSessionId: 'cloud-session-1',
+      makaSessionId: 'maka-session-1',
+      status: 'blocked',
+      reason: 'permission_required',
+      requiredAction: 'grant_permission',
+    });
+  });
+
+  test('retries non-permission blocked sessions instead of requesting permission', async () => {
+    for (const blockedReason of ['auth', 'tool_failed'] as const) {
+      const lines: string[] = [];
+      const result = await runMakaActivationCli(
+        [
+          '--state-root',
+          ROOTS.stateRoot,
+          '--workspace-root',
+          ROOTS.workspaceRoot,
+          '--config-root',
+          ROOTS.configRoot,
+        ],
+        {
+          ...fakeDeps({
+            input: JSON.stringify(validRequest({ makaSessionId: 'maka-session-1' })),
+            sessions: [summary({ status: 'blocked', blockedReason })],
+          }),
+          writeStdout: (text) => lines.push(text.trim()),
+        },
+      );
+
+      assert.equal(result, 4);
+      assert.deepEqual(JSON.parse(lines.at(-1)!), {
+        protocol: 'maka.activation',
+        schemaVersion: 1,
+        type: 'outcome',
+        activationId: 'activation-1',
+        cloudSessionId: 'cloud-session-1',
+        makaSessionId: 'maka-session-1',
+        status: 'retryable_failure',
+        reason: blockedReason,
+        requiredAction: 'retry_activation',
+      });
+    }
   });
 
   test('resumes an existing compatible session without creating another one', async () => {
@@ -464,6 +619,25 @@ describe('maka activate filesystem boundaries', () => {
       );
       assert.equal(result, 2);
       assert.equal(JSON.parse(lines.at(-1)!).reason, 'unsafe_roots');
+      await assert.rejects(access(join(root, 'config')), { code: 'ENOENT' });
+
+      const reverseLines: string[] = [];
+      const reverseResult = await runMakaActivationCli(
+        [
+          '--state-root',
+          join(root, 'state'),
+          '--workspace-root',
+          join(root, 'workspace'),
+          '--config-root',
+          root,
+        ],
+        {
+          ...fakeDeps(),
+          writeStdout: (text) => reverseLines.push(text.trim()),
+        },
+      );
+      assert.equal(reverseResult, 2);
+      assert.equal(JSON.parse(reverseLines.at(-1)!).reason, 'unsafe_roots');
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/cli/src/__tests__/activation-command.test.ts
+++ b/packages/cli/src/__tests__/activation-command.test.ts
@@ -1,0 +1,471 @@
+import assert from 'node:assert/strict';
+import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { after, before, describe, test } from 'node:test';
+import type { SessionEvent } from '@maka/core/events';
+import type { SessionSummary } from '@maka/core/session';
+import type { InvocationResult, RuntimeContinuation } from '@maka/runtime';
+import {
+  decodeActivationRequest,
+  parseMakaActivateArgs,
+  runMakaActivationCli,
+  type MakaActivationContext,
+  type MakaActivationDeps,
+  type MakaActivationRuntime,
+} from '../activation-command.js';
+import { parseMakaCliArgs } from '../cli.js';
+
+const ROOTS = {
+  stateRoot: '/tmp/maka-state',
+  workspaceRoot: '/tmp/maka-workspace',
+  configRoot: '/tmp/maka-config',
+};
+
+before(async () => {
+  await Promise.all(Object.values(ROOTS).map((root) => mkdir(root, { recursive: true })));
+});
+
+after(async () => {
+  await Promise.all(Object.values(ROOTS).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+function validRequest(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    schemaVersion: 1,
+    activationId: 'activation-1',
+    cloudSessionId: 'cloud-session-1',
+    stimulus: { type: 'message', payload: { text: 'Inspect the workspace' } },
+    ...overrides,
+  };
+}
+
+function summary(overrides: Partial<SessionSummary> = {}): SessionSummary {
+  return {
+    id: 'maka-session-1',
+    cwd: ROOTS.workspaceRoot,
+    name: 'activation',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'local',
+    connectionLocked: true,
+    model: 'fixture-model',
+    permissionMode: 'explore',
+    ...overrides,
+  };
+}
+
+function completedResult(sessionId = 'maka-session-1'): InvocationResult {
+  return {
+    invocationId: 'invocation-1',
+    runId: 'run-1',
+    sessionId,
+    turnId: 'turn-1',
+    status: 'completed',
+    finalOutput: 'done',
+    events: [
+      {
+        id: 'event-1',
+        invocationId: 'invocation-1',
+        runId: 'run-1',
+        sessionId,
+        turnId: 'turn-1',
+        ts: 1,
+        partial: false,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'done', apiKey: 'sk-test-secret' } as never,
+      },
+    ],
+    startedAt: 1,
+    finishedAt: 2,
+  };
+}
+
+function fakeDeps(
+  options: {
+    input?: string;
+    sessions?: SessionSummary[];
+    result?: InvocationResult;
+    events?: SessionEvent[];
+    onContext?: (input: Parameters<NonNullable<MakaActivationDeps['createContext']>>[0]) => void;
+    onCreateSession?: () => void;
+    onClose?: () => void;
+    safeBoundaryResume?: boolean;
+    onResume?: () => void;
+    sendMessage?: (
+      runtime: MakaActivationRuntime,
+      sessionId: string,
+      input: { turnId: string; text: string },
+    ) => AsyncIterable<SessionEvent>;
+  } = {},
+): MakaActivationDeps {
+  let observer: ((result: InvocationResult) => void | Promise<void>) | undefined;
+  const sessions = options.sessions ?? [];
+  const runtime: MakaActivationRuntime = {
+    async createSession() {
+      options.onCreateSession?.();
+      return summary();
+    },
+    listSessions: async () => sessions,
+    ...(options.safeBoundaryResume
+      ? {
+          planLatestAuthoritativeSafeBoundaryContinuation: async () => ({
+            disposition: 'continue' as const,
+            rejectionReasons: [],
+            diagnostics: [],
+            continuation: {} as RuntimeContinuation,
+          }),
+          async *resumeSafeBoundaryContinuation() {
+            options.onResume?.();
+            await observer?.(options.result ?? completedResult('maka-session-1'));
+          },
+        }
+      : {}),
+    async *sendMessage(sessionId, input) {
+      if (options.sendMessage) {
+        yield* options.sendMessage(runtime, sessionId, input);
+      } else {
+        for (const event of options.events ?? []) yield event;
+      }
+      await observer?.(options.result ?? completedResult(sessionId));
+    },
+    async respondToPermission() {},
+    async stopSession() {},
+  };
+
+  return {
+    createContext: async (input) => {
+      options.onContext?.(input);
+      observer = input.runtimeInvocationObserver;
+      const context: MakaActivationContext = {
+        runtime,
+        target: {
+          connection: {
+            slug: 'local',
+            name: 'Fixture',
+            providerType: 'ollama',
+            enabled: true,
+            defaultModel: 'fixture-model',
+          },
+          apiKey: '',
+          model: 'fixture-model',
+        },
+        close: async () => options.onClose?.(),
+      };
+      return context;
+    },
+    listSessions: async () => sessions,
+    workspaceRoot: () => ROOTS.workspaceRoot,
+    processCwd: () => ROOTS.workspaceRoot,
+    stdinIsTTY: () => false,
+    readStdin: async () => options.input ?? JSON.stringify(validRequest()),
+    readFile: async () => options.input ?? JSON.stringify(validRequest()),
+    writeStdout: () => {},
+    writeStderr: () => {},
+    onSigint: () => () => {},
+    setTimer: (handler, ms) => setTimeout(handler, ms),
+    clearTimer: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+    newId: () => 'turn-1',
+  };
+}
+
+describe('maka activate argument and request contracts', () => {
+  test('routes activate through the CLI parser', () => {
+    assert.deepEqual(parseMakaCliArgs(['activate'], '0.1.0'), {
+      kind: 'activate',
+      args: [],
+    });
+  });
+
+  test('requires explicit non-overlapping roots and accepts JSON input options', () => {
+    assert.deepEqual(
+      parseMakaActivateArgs([
+        '--state-root',
+        ROOTS.stateRoot,
+        '--workspace-root',
+        ROOTS.workspaceRoot,
+        '--config-root',
+        ROOTS.configRoot,
+        '--input',
+        '-',
+        '--timeout',
+        '2.5',
+        '--max-steps',
+        '4',
+        '--permission-mode',
+        'bypass',
+      ]),
+      {
+        kind: 'activate',
+        options: {
+          ...ROOTS,
+          input: '-',
+          timeoutMs: 2500,
+          maxSteps: 4,
+          permissionMode: 'bypass',
+        },
+      },
+    );
+    assert.equal(parseMakaActivateArgs(['--state-root', ROOTS.stateRoot]).kind, 'error');
+    assert.equal(
+      parseMakaActivateArgs([
+        '--state-root',
+        ROOTS.stateRoot,
+        '--workspace-root',
+        ROOTS.workspaceRoot,
+        '--config-root',
+        ROOTS.configRoot,
+        'prompt-in-argv',
+      ]).kind,
+      'error',
+    );
+  });
+
+  test('decodes versioned message and resumed activation requests', () => {
+    assert.deepEqual(
+      decodeActivationRequest(
+        validRequest({
+          makaSessionId: 'maka-session-1',
+          stimulus: { type: 'schedule', payload: { job: 'nightly' } },
+        }),
+      ),
+      {
+        schemaVersion: 1,
+        activationId: 'activation-1',
+        cloudSessionId: 'cloud-session-1',
+        makaSessionId: 'maka-session-1',
+        stimulus: { type: 'schedule', payload: { job: 'nightly' } },
+      },
+    );
+    assert.throws(
+      () => decodeActivationRequest(validRequest({ schemaVersion: 2 })),
+      /unsupported activation schema/,
+    );
+    assert.throws(
+      () => decodeActivationRequest({ ...validRequest(), unexpected: true }),
+      /unsupported activation field/,
+    );
+  });
+
+  test('rejects malformed input before runtime startup', async () => {
+    let started = false;
+    const result = await runMakaActivationCli(
+      [
+        '--state-root',
+        ROOTS.stateRoot,
+        '--workspace-root',
+        ROOTS.workspaceRoot,
+        '--config-root',
+        ROOTS.configRoot,
+      ],
+      {
+        ...fakeDeps({ input: '{"schemaVersion":2}' }),
+        createContext: async () => {
+          started = true;
+          throw new Error('must not start');
+        },
+      },
+    );
+    assert.equal(result, 2);
+    assert.equal(started, false);
+  });
+});
+
+describe('maka activate JSONL protocol', () => {
+  test('emits start, redacted runtime events, and exactly one completed outcome', async () => {
+    const lines: string[] = [];
+    let closed = false;
+    let terminalSawClosed = false;
+    const result = await runMakaActivationCli(
+      [
+        '--state-root',
+        ROOTS.stateRoot,
+        '--workspace-root',
+        ROOTS.workspaceRoot,
+        '--config-root',
+        ROOTS.configRoot,
+      ],
+      {
+        ...fakeDeps({
+          onClose: () => {
+            closed = true;
+          },
+        }),
+        writeStdout: (text) => {
+          lines.push(text.trim());
+          if (text.includes('"type":"outcome"')) terminalSawClosed = closed;
+        },
+      },
+    );
+
+    assert.equal(result, 0);
+    assert.equal(terminalSawClosed, true);
+    assert.equal(lines.length, 3);
+    assert.equal(JSON.parse(lines[0]!).type, 'start');
+    assert.equal(JSON.parse(lines[1]!).type, 'runtime_event');
+    assert.equal(JSON.parse(lines[2]!).type, 'outcome');
+    assert.equal(JSON.parse(lines[2]!).status, 'completed');
+    assert.equal(lines.join('\n').includes('sk-test-secret'), false);
+  });
+
+  test('returns blocked for a denied non-interactive permission request', async () => {
+    const lines: string[] = [];
+    const result = await runMakaActivationCli(
+      [
+        '--state-root',
+        ROOTS.stateRoot,
+        '--workspace-root',
+        ROOTS.workspaceRoot,
+        '--config-root',
+        ROOTS.configRoot,
+      ],
+      {
+        ...fakeDeps({
+          result: {
+            ...completedResult(),
+            status: 'failed',
+            finalOutput: undefined,
+            failure: { class: 'permission_denied' },
+          },
+          events: [
+            {
+              type: 'permission_request',
+              kind: 'tool_permission',
+              id: 'permission-event',
+              turnId: 'turn-1',
+              ts: 1,
+              requestId: 'request-1',
+              toolUseId: 'tool-1',
+              toolName: 'Bash',
+              category: 'shell_unsafe',
+              reason: 'shell_dangerous',
+              args: { command: 'echo ok' },
+              rememberForTurnAllowed: false,
+            },
+          ],
+        }),
+        writeStdout: (text) => lines.push(text.trim()),
+      },
+    );
+
+    assert.equal(result, 3);
+    assert.equal(JSON.parse(lines.at(-1)!).status, 'blocked');
+    assert.equal(JSON.parse(lines.at(-1)!).reason, 'permission_denied');
+  });
+
+  test('resumes an existing compatible session without creating another one', async () => {
+    let created = false;
+    let resumed = false;
+    let requestedConnection: string | undefined;
+    const lines: string[] = [];
+    const result = await runMakaActivationCli(
+      [
+        '--state-root',
+        ROOTS.stateRoot,
+        '--workspace-root',
+        ROOTS.workspaceRoot,
+        '--config-root',
+        ROOTS.configRoot,
+      ],
+      {
+        ...fakeDeps({
+          input: JSON.stringify(validRequest({ makaSessionId: 'maka-session-1' })),
+          sessions: [summary()],
+          onCreateSession: () => {
+            created = true;
+          },
+          onContext: (input) => {
+            requestedConnection = input.requestedConnectionSlug;
+          },
+          safeBoundaryResume: true,
+          onResume: () => {
+            resumed = true;
+          },
+        }),
+        writeStdout: (text) => lines.push(text.trim()),
+      },
+    );
+
+    assert.equal(result, 0);
+    assert.equal(created, false);
+    assert.equal(resumed, true);
+    assert.equal(requestedConnection, 'local');
+    assert.equal(JSON.parse(lines.at(-1)!).makaSessionId, 'maka-session-1');
+  });
+
+  test('maps timeout to retryable_failure and emits one terminal outcome', async () => {
+    const lines: string[] = [];
+    let release: (() => void) | undefined;
+    const result = await runMakaActivationCli(
+      [
+        '--state-root',
+        ROOTS.stateRoot,
+        '--workspace-root',
+        ROOTS.workspaceRoot,
+        '--config-root',
+        ROOTS.configRoot,
+        '--timeout',
+        '0.01',
+      ],
+      {
+        ...fakeDeps({
+          sendMessage: async function* () {
+            await new Promise<void>((resolve) => {
+              release = resolve;
+            });
+          },
+        }),
+        writeStdout: (text) => lines.push(text.trim()),
+      },
+    );
+    release?.();
+
+    assert.equal(result, 4);
+    const outcomes = lines.filter((line) => JSON.parse(line).type === 'outcome');
+    assert.equal(outcomes.length, 1);
+    assert.deepEqual(JSON.parse(outcomes[0]!), {
+      protocol: 'maka.activation',
+      schemaVersion: 1,
+      type: 'outcome',
+      activationId: 'activation-1',
+      cloudSessionId: 'cloud-session-1',
+      makaSessionId: 'maka-session-1',
+      status: 'retryable_failure',
+      reason: 'timeout',
+    });
+  });
+});
+
+describe('maka activate filesystem boundaries', () => {
+  test('rejects workspace/state/config overlap before bootstrap', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-activation-'));
+    try {
+      await mkdir(join(root, 'state'));
+      await mkdir(join(root, 'workspace'));
+      const lines: string[] = [];
+      const result = await runMakaActivationCli(
+        [
+          '--state-root',
+          join(root, 'state'),
+          '--workspace-root',
+          root,
+          '--config-root',
+          join(root, 'config'),
+        ],
+        {
+          ...fakeDeps(),
+          writeStdout: (text) => lines.push(text.trim()),
+        },
+      );
+      assert.equal(result, 2);
+      assert.equal(JSON.parse(lines.at(-1)!).reason, 'unsafe_roots');
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -78,6 +78,40 @@ describe('Maka CLI runtime bootstrap', () => {
     });
   });
 
+  test('routes activation resume lifecycle diagnostics to stderr', async () => {
+    await withWorkspace(async (workspaceRoot) => {
+      const connectionStore = createConnectionStore(workspaceRoot);
+      await connectionStore.create({
+        slug: 'local',
+        name: 'Local Ollama',
+        providerType: 'ollama',
+        defaultModel: 'llama3.2',
+      });
+
+      const context = await createMakaCliRuntimeContext({
+        surface: 'activation',
+        workspaceRoot,
+        cwd: workspaceRoot,
+      });
+      const runtimeDeps = (context.runtime as unknown as RuntimeWithPrivateDeps).deps;
+      const info: unknown[] = [];
+      const error: unknown[] = [];
+      const originalInfo = console.info;
+      const originalError = console.error;
+      console.info = (...args: unknown[]) => info.push(args);
+      console.error = (...args: unknown[]) => error.push(args);
+      try {
+        runtimeDeps.onContinuationLifecycleEvent?.({ type: 'plan_approved' });
+        assert.equal(info.length, 0);
+        assert.equal(error.length, 1);
+      } finally {
+        console.info = originalInfo;
+        console.error = originalError;
+        await context.close();
+      }
+    });
+  });
+
   test('loads the default connection and can create an ai-sdk session', async () => {
     await withWorkspace(async (workspaceRoot) => {
       const connectionStore = createConnectionStore(workspaceRoot);
@@ -1102,6 +1136,7 @@ interface RuntimeWithPrivateDeps {
     onSessionTitleChanged?: (sessionId: string) => void;
     childTools?: readonly MakaTool[];
     worktreeChildExecutor?: unknown;
+    onContinuationLifecycleEvent?: (event: unknown) => void;
   };
 }
 

--- a/packages/cli/src/activation-command.ts
+++ b/packages/cli/src/activation-command.ts
@@ -1,0 +1,775 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, realpath, stat, readFile } from 'node:fs/promises';
+import { isAbsolute, relative, resolve } from 'node:path';
+import type { SessionEvent } from '@maka/core/events';
+import type { PermissionMode } from '@maka/core/permission';
+import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
+import type { SessionSummary } from '@maka/core/session';
+import type {
+  InvocationResult,
+  RuntimeContinuation,
+  SafeBoundaryContinuationPlan,
+} from '@maka/runtime';
+import type { RuntimeEvent } from '@maka/core/runtime-event';
+import { redactSecrets } from '@maka/core/redaction';
+import { createSessionStore } from '@maka/storage';
+import { resolveStorageRoot } from '@maka/storage/root-authority';
+import {
+  createMakaCliRuntimeContext,
+  type CreateMakaCliRuntimeContextInput,
+  type MakaCliRuntimeContext,
+} from './runtime-bootstrap.js';
+
+const PROTOCOL = 'maka.activation' as const;
+const SCHEMA_VERSION = 1 as const;
+const MAX_RUNTIME_EVENTS = 256;
+const MAX_RUNTIME_EVENT_BYTES = 64 * 1024;
+const MAX_OUTPUT_BYTES = 256 * 1024;
+const ACTIVATION_STIMULUS_TYPES = new Set(['message', 'schedule', 'system']);
+
+export type MakaActivationStatus = 'completed' | 'blocked' | 'retryable_failure' | 'fatal_failure';
+
+export type MakaActivationBlockedReason = 'permission_denied' | 'permission_required';
+export type MakaActivationRequiredAction = 'grant_permission' | 'retry_activation';
+
+export interface MakaActivationOptions {
+  stateRoot: string;
+  workspaceRoot: string;
+  configRoot: string;
+  input: string;
+  timeoutMs?: number;
+  maxSteps?: number;
+  permissionMode?: Exclude<PermissionMode, 'ask'>;
+  connection?: string;
+  model?: string;
+}
+
+export type ParseMakaActivateArgsResult =
+  | { kind: 'activate'; options: MakaActivationOptions }
+  | { kind: 'help'; text: string }
+  | { kind: 'error'; message: string };
+
+export interface ActivationStimulus {
+  type: string;
+  payload: unknown;
+}
+
+export interface MakaActivationRequest {
+  schemaVersion: 1;
+  activationId: string;
+  cloudSessionId: string;
+  makaSessionId?: string;
+  stimulus: ActivationStimulus;
+}
+
+export interface MakaActivationContext {
+  runtime: MakaActivationRuntime;
+  target: {
+    connection: {
+      slug: string;
+      name?: string;
+      providerType?: string;
+      enabled?: boolean;
+      defaultModel?: string;
+    };
+    apiKey?: string;
+    model: string;
+  };
+  cwd?: string;
+  close(): Promise<void>;
+}
+
+export interface MakaActivationRuntime {
+  createSession(input: CreateSessionInput): Promise<SessionSummary>;
+  listSessions?(): Promise<SessionSummary[]>;
+  planLatestAuthoritativeSafeBoundaryContinuation?(
+    sessionId: string,
+  ): Promise<SafeBoundaryContinuationPlan>;
+  resumeSafeBoundaryContinuation?(continuation: RuntimeContinuation): AsyncIterable<SessionEvent>;
+  sendMessage(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
+  respondToPermission(
+    sessionId: string,
+    response: { requestId: string; decision: 'deny'; rememberForTurn?: boolean },
+  ): Promise<void>;
+  stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
+}
+
+export interface MakaActivationDeps {
+  createContext(input: CreateMakaCliRuntimeContextInput): Promise<MakaActivationContext>;
+  listSessions(workspaceRoot: string): Promise<SessionSummary[]>;
+  workspaceRoot(): string;
+  processCwd(): string;
+  stdinIsTTY(): boolean;
+  readStdin(): Promise<string>;
+  readFile(path: string): Promise<string>;
+  writeStdout(text: string): void;
+  writeStderr(text: string): void;
+  onSigint(handler: () => void): () => void;
+  setTimer(handler: () => void, ms: number): unknown;
+  clearTimer(timer: unknown): void;
+  newId(): string;
+  canonicalDirectory?(path: string): Promise<string>;
+}
+
+interface ActivationStartLine {
+  protocol: typeof PROTOCOL;
+  schemaVersion: typeof SCHEMA_VERSION;
+  type: 'start';
+  activationId: string;
+  cloudSessionId: string;
+  makaSessionId?: string;
+  workspaceRoot: string;
+}
+
+interface ActivationRuntimeEventLine {
+  protocol: typeof PROTOCOL;
+  schemaVersion: typeof SCHEMA_VERSION;
+  type: 'runtime_event';
+  activationId: string;
+  cloudSessionId: string;
+  makaSessionId?: string;
+  event: RuntimeEvent;
+  truncated?: boolean;
+}
+
+interface ActivationOutcomeLine {
+  protocol: typeof PROTOCOL;
+  schemaVersion: typeof SCHEMA_VERSION;
+  type: 'outcome';
+  activationId: string;
+  cloudSessionId: string;
+  makaSessionId?: string;
+  status: MakaActivationStatus;
+  reason?: string;
+  requiredAction?: MakaActivationRequiredAction;
+  response?: unknown;
+}
+
+export function parseMakaActivateArgs(argv: readonly string[]): ParseMakaActivateArgsResult {
+  const values = new Map<string, string>();
+  const valueFlags = new Set([
+    'state-root',
+    'workspace-root',
+    'config-root',
+    'input',
+    'timeout',
+    'max-steps',
+    'permission-mode',
+    'connection',
+    'model',
+  ]);
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    if (arg === '--help' || arg === '-h') return { kind: 'help', text: makaActivateHelpText() };
+    if (!arg.startsWith('--') || !valueFlags.has(arg.slice(2))) {
+      return { kind: 'error', message: `unexpected argument: ${arg}` };
+    }
+    const name = arg.slice(2);
+    if (values.has(name)) return { kind: 'error', message: `option repeated: ${arg}` };
+    const value = argv[index + 1];
+    if (value === undefined || (value.startsWith('--') && value !== '-')) {
+      return { kind: 'error', message: `option ${arg} needs a value` };
+    }
+    values.set(name, value);
+    index += 1;
+  }
+
+  const stateRoot = values.get('state-root');
+  const workspaceRoot = values.get('workspace-root');
+  const configRoot = values.get('config-root');
+  if (!stateRoot || !workspaceRoot || !configRoot) {
+    return {
+      kind: 'error',
+      message: 'activate requires --state-root, --workspace-root, and --config-root',
+    };
+  }
+  for (const [name, value] of [
+    ['state-root', stateRoot],
+    ['workspace-root', workspaceRoot],
+    ['config-root', configRoot],
+  ] as const) {
+    if (!isAbsolute(value)) return { kind: 'error', message: `--${name} must be an absolute path` };
+  }
+
+  const timeout = values.get('timeout');
+  const timeoutSeconds = timeout === undefined ? undefined : Number(timeout);
+  if (timeoutSeconds !== undefined && (!Number.isFinite(timeoutSeconds) || timeoutSeconds <= 0)) {
+    return { kind: 'error', message: '--timeout must be a positive number of seconds' };
+  }
+  const maxSteps = values.get('max-steps');
+  const parsedMaxSteps = maxSteps === undefined ? undefined : Number(maxSteps);
+  if (parsedMaxSteps !== undefined && (!Number.isInteger(parsedMaxSteps) || parsedMaxSteps < 1)) {
+    return { kind: 'error', message: '--max-steps must be a positive integer' };
+  }
+  const permissionMode = values.get('permission-mode');
+  if (
+    permissionMode !== undefined &&
+    permissionMode !== 'explore' &&
+    permissionMode !== 'execute' &&
+    permissionMode !== 'bypass'
+  ) {
+    return { kind: 'error', message: '--permission-mode must be explore, execute, or bypass' };
+  }
+  return {
+    kind: 'activate',
+    options: {
+      stateRoot,
+      workspaceRoot,
+      configRoot,
+      input: values.get('input') ?? '-',
+      ...(timeoutSeconds === undefined ? {} : { timeoutMs: Math.ceil(timeoutSeconds * 1000) }),
+      ...(parsedMaxSteps === undefined ? {} : { maxSteps: parsedMaxSteps }),
+      ...(permissionMode === undefined ? {} : { permissionMode }),
+      ...(values.get('connection') === undefined ? {} : { connection: values.get('connection') }),
+      ...(values.get('model') === undefined ? {} : { model: values.get('model') }),
+    },
+  };
+}
+
+export function decodeActivationRequest(value: unknown): MakaActivationRequest {
+  if (!isRecord(value)) throw new Error('activation request must be a JSON object');
+  const allowed = new Set([
+    'schemaVersion',
+    'activationId',
+    'cloudSessionId',
+    'makaSessionId',
+    'stimulus',
+  ]);
+  for (const key of Object.keys(value)) {
+    if (!allowed.has(key)) throw new Error(`unsupported activation field: ${key}`);
+  }
+  if (value.schemaVersion !== SCHEMA_VERSION) throw new Error('unsupported activation schema');
+  for (const key of ['activationId', 'cloudSessionId'] as const) {
+    if (typeof value[key] !== 'string' || value[key].trim() === '') {
+      throw new Error(`activation ${key} must be a non-empty string`);
+    }
+  }
+  if (
+    value.makaSessionId !== undefined &&
+    (typeof value.makaSessionId !== 'string' || value.makaSessionId.trim() === '')
+  ) {
+    throw new Error('activation makaSessionId must be a non-empty string');
+  }
+  if (
+    !isRecord(value.stimulus) ||
+    typeof value.stimulus.type !== 'string' ||
+    value.stimulus.type.trim() === '' ||
+    !ACTIVATION_STIMULUS_TYPES.has(value.stimulus.type)
+  ) {
+    throw new Error('activation stimulus must include a type');
+  }
+  return {
+    schemaVersion: SCHEMA_VERSION,
+    activationId: value.activationId,
+    cloudSessionId: value.cloudSessionId,
+    ...(value.makaSessionId === undefined ? {} : { makaSessionId: value.makaSessionId }),
+    stimulus: { type: value.stimulus.type, payload: value.stimulus.payload },
+  };
+}
+
+export async function runMakaActivationCli(
+  argv: readonly string[],
+  overrides: Partial<MakaActivationDeps> = {},
+): Promise<number> {
+  const deps = { ...defaultMakaActivationDeps(), ...overrides };
+  const parsed = parseMakaActivateArgs(argv);
+  if (parsed.kind === 'help') {
+    deps.writeStdout(`${parsed.text}\n`);
+    return 0;
+  }
+  if (parsed.kind === 'error') {
+    deps.writeStderr(`maka activate: ${parsed.message}\n`);
+    return 2;
+  }
+
+  const options = parsed.options;
+  let request: MakaActivationRequest;
+  try {
+    const raw = options.input === '-' ? await deps.readStdin() : await deps.readFile(options.input);
+    request = decodeActivationRequest(JSON.parse(raw));
+  } catch (error) {
+    deps.writeStderr(`maka activate: ${safeErrorMessage(error)}\n`);
+    return 2;
+  }
+
+  const write = lineWriter(deps.writeStdout);
+  write({
+    protocol: PROTOCOL,
+    schemaVersion: SCHEMA_VERSION,
+    type: 'start',
+    activationId: request.activationId,
+    cloudSessionId: request.cloudSessionId,
+    ...(request.makaSessionId ? { makaSessionId: request.makaSessionId } : {}),
+    workspaceRoot: resolve(options.workspaceRoot),
+  } satisfies ActivationStartLine);
+
+  let roots: ValidatedRoots;
+  try {
+    roots = await validateRoots(options);
+  } catch (error) {
+    emitOutcome(deps.writeStdout, request, undefined, 'fatal_failure', 'unsafe_roots');
+    deps.writeStderr(`maka activate: ${safeErrorMessage(error)}\n`);
+    return 2;
+  }
+
+  let sessions: SessionSummary[] = [];
+  let existing: SessionSummary | undefined;
+  try {
+    sessions = await deps.listSessions(roots.stateRoot);
+    existing = request.makaSessionId
+      ? sessions.find((session) => session.id === request.makaSessionId)
+      : undefined;
+    if (request.makaSessionId && !existing) {
+      return await finishWithoutContext(deps, request, write, 'fatal_failure', 'session_not_found');
+    }
+    if (existing && (!existing.cwd || !(await sameDirectory(existing.cwd, roots.workspaceRoot)))) {
+      return await finishWithoutContext(
+        deps,
+        request,
+        write,
+        'fatal_failure',
+        'session_cwd_mismatch',
+      );
+    }
+    if (existing && (existing.status === 'blocked' || existing.status === 'waiting_for_user')) {
+      return await finishWithoutContext(
+        deps,
+        request,
+        write,
+        'blocked',
+        existing.blockedReason ?? 'permission_required',
+        existing.id,
+        'grant_permission',
+      );
+    }
+  } catch (error) {
+    return await finishWithoutContext(
+      deps,
+      request,
+      write,
+      'fatal_failure',
+      'session_lookup_failed',
+    );
+  }
+
+  let context: MakaActivationContext | undefined;
+  let session: SessionSummary | undefined = existing;
+  let invocation: InvocationResult | undefined;
+  let timedOut = false;
+  let interrupted = false;
+  let streamFailed = false;
+  let stopPromise: Promise<void> | undefined;
+  let eventCount = 0;
+  let eventBytes = 0;
+  let eventTruncated = false;
+  let terminalWritten = false;
+  const writeRuntimeEvent = (event: RuntimeEvent): void => {
+    if (terminalWritten || eventTruncated || eventCount >= MAX_RUNTIME_EVENTS) {
+      eventTruncated = true;
+      return;
+    }
+    const safeEvent = redactJson(event) as RuntimeEvent;
+    const eventLine = {
+      protocol: PROTOCOL,
+      schemaVersion: SCHEMA_VERSION,
+      type: 'runtime_event',
+      activationId: request.activationId,
+      cloudSessionId: request.cloudSessionId,
+      ...(session?.id ? { makaSessionId: session.id } : {}),
+      event: safeEvent,
+    } satisfies ActivationRuntimeEventLine;
+    const bytes = Buffer.byteLength(JSON.stringify(eventLine), 'utf8');
+    if (eventBytes + bytes > MAX_RUNTIME_EVENT_BYTES) {
+      eventTruncated = true;
+      return;
+    }
+    eventBytes += bytes;
+    eventCount += 1;
+    write(eventLine);
+  };
+  try {
+    context = await deps.createContext({
+      surface: 'activation',
+      workspaceRoot: roots.workspaceRoot,
+      stateRoot: roots.stateRoot,
+      configRoot: roots.configRoot,
+      cwd: roots.workspaceRoot,
+      ...(existing || options.connection
+        ? { requestedConnectionSlug: existing?.llmConnectionSlug ?? options.connection }
+        : {}),
+      ...(existing || options.model ? { requestedModel: existing?.model ?? options.model } : {}),
+      ...(existing
+        ? { sessionCwdOverride: { sessionId: existing.id, cwd: roots.workspaceRoot } }
+        : {}),
+      ...(options.maxSteps === undefined ? {} : { maxSteps: options.maxSteps }),
+      runtimeSource: 'gateway',
+      safeBoundaryResumeEnabled: true,
+      runtimeInvocationObserver: (result) => {
+        invocation = result;
+        for (const event of result.events) writeRuntimeEvent(event);
+      },
+    });
+    if (!session) {
+      session = await context.runtime.createSession({
+        cwd: roots.workspaceRoot,
+        name: `Cloud activation ${request.activationId}`.slice(0, 80),
+        backend: 'ai-sdk',
+        llmConnectionSlug: context.target.connection.slug,
+        model: context.target.model,
+        permissionMode: options.permissionMode ?? 'explore',
+      });
+    }
+    const stop = (): void => {
+      if (stopPromise || !session) return;
+      stopPromise = context!.runtime.stopSession(session.id, { source: 'stop_button' });
+      void stopPromise.catch(() => {});
+    };
+    const removeSigint = deps.onSigint(() => {
+      interrupted = true;
+      stop();
+    });
+    let resolveTimeout: (() => void) | undefined;
+    const timeoutSignal =
+      options.timeoutMs === undefined
+        ? undefined
+        : new Promise<void>((resolve) => {
+            resolveTimeout = resolve;
+          });
+    const timer =
+      options.timeoutMs === undefined
+        ? undefined
+        : deps.setTimer(() => {
+            timedOut = true;
+            stop();
+            resolveTimeout?.();
+          }, options.timeoutMs);
+    try {
+      const text = activationStimulusText(request.stimulus);
+      const stream = await activationStream(
+        context.runtime,
+        session.id,
+        { turnId: deps.newId(), text },
+        existing !== undefined,
+      );
+      const drain = (async () => {
+        for await (const event of stream) {
+          if (event.type === 'permission_request') {
+            writeRuntimeEvent(sessionEventToRuntimeEvent(event, session!.id));
+            await context!.runtime.respondToPermission(session!.id, {
+              requestId: event.requestId,
+              decision: 'deny',
+            });
+          }
+        }
+      })();
+      if (timeoutSignal) await Promise.race([drain, timeoutSignal]);
+      else await drain;
+      await stopPromise;
+    } catch (error) {
+      streamFailed = true;
+      await stopPromise?.catch(() => undefined);
+      if (!timedOut && !interrupted)
+        deps.writeStderr(`maka activate: ${safeErrorMessage(error)}\n`);
+    } finally {
+      removeSigint();
+      if (timer !== undefined) deps.clearTimer(timer);
+      await context.close();
+    }
+  } catch (error) {
+    if (context) await context.close().catch(() => undefined);
+    deps.writeStderr(`maka activate: ${safeErrorMessage(error)}\n`);
+    return emitOutcome(deps.writeStdout, request, session?.id, 'fatal_failure', 'bootstrap_failed');
+  }
+
+  if (eventTruncated && !terminalWritten) {
+    write({
+      protocol: PROTOCOL,
+      schemaVersion: SCHEMA_VERSION,
+      type: 'runtime_event',
+      activationId: request.activationId,
+      cloudSessionId: request.cloudSessionId,
+      ...(session?.id ? { makaSessionId: session.id } : {}),
+      event: { truncated: true } as unknown as RuntimeEvent,
+      truncated: true,
+    });
+  }
+  const finish = (
+    status: MakaActivationStatus,
+    reason?: string,
+    response?: unknown,
+    requiredAction?: MakaActivationRequiredAction,
+  ): number => {
+    if (terminalWritten)
+      return status === 'completed'
+        ? 0
+        : status === 'blocked'
+          ? 3
+          : status === 'retryable_failure'
+            ? 4
+            : 2;
+    terminalWritten = true;
+    return emitOutcome(
+      deps.writeStdout,
+      request,
+      session?.id,
+      status,
+      reason,
+      response,
+      requiredAction,
+    );
+  };
+  if (interrupted) return finish('retryable_failure', 'interrupted');
+  if (timedOut) return finish('retryable_failure', 'timeout');
+  if (streamFailed) return finish('retryable_failure', 'runtime_error');
+  if (!invocation) return finish('fatal_failure', 'missing_invocation');
+  if (invocation.status === 'completed' && invocation.finalOutput !== undefined) {
+    return finish('completed', undefined, invocation.finalOutput);
+  }
+  if (invocation.status === 'completed') return finish('fatal_failure', 'missing_response');
+  const failureClass = invocation.failure?.class ?? 'runtime_failure';
+  const blocked = failureClass === 'permission_denied' || failureClass === 'permission_required';
+  return finish(
+    blocked ? 'blocked' : 'retryable_failure',
+    blocked ? failureClass : 'runtime_failure',
+    undefined,
+    blocked ? 'grant_permission' : undefined,
+  );
+}
+
+async function finishWithoutContext(
+  deps: MakaActivationDeps,
+  request: MakaActivationRequest,
+  write: (line: object) => void,
+  status: MakaActivationStatus,
+  reason: string,
+  sessionId?: string,
+  requiredAction?: MakaActivationRequiredAction,
+): Promise<number> {
+  return emitOutcome(
+    deps.writeStdout,
+    request,
+    sessionId,
+    status,
+    reason,
+    undefined,
+    requiredAction,
+  );
+}
+
+function emitOutcome(
+  output: (text: string) => void,
+  request: MakaActivationRequest,
+  sessionId: string | undefined,
+  status: MakaActivationStatus,
+  reason?: string,
+  response?: unknown,
+  requiredAction?: MakaActivationRequiredAction,
+): number {
+  const outcome: ActivationOutcomeLine = {
+    protocol: PROTOCOL,
+    schemaVersion: SCHEMA_VERSION,
+    type: 'outcome',
+    activationId: request.activationId,
+    cloudSessionId: request.cloudSessionId,
+    ...(sessionId ? { makaSessionId: sessionId } : {}),
+    status,
+    ...(reason ? { reason } : {}),
+    ...(requiredAction ? { requiredAction } : {}),
+    ...(response === undefined ? {} : { response: boundedRedactedJson(response) }),
+  };
+  output(`${JSON.stringify(redactJson(outcome))}\n`);
+  return status === 'completed'
+    ? 0
+    : status === 'blocked'
+      ? 3
+      : status === 'retryable_failure'
+        ? 4
+        : 2;
+}
+
+function boundedRedactedJson(value: unknown): unknown {
+  const redacted = redactJson(value);
+  const serialized = JSON.stringify(redacted);
+  if (serialized === undefined || Buffer.byteLength(serialized, 'utf8') <= MAX_OUTPUT_BYTES) {
+    return redacted;
+  }
+  return redactSecrets(serialized).slice(0, MAX_OUTPUT_BYTES);
+}
+
+function lineWriter(output: (text: string) => void): (line: object) => void {
+  let emittedOutcome = false;
+  return (line) => {
+    if ((line as { type?: string }).type === 'outcome') {
+      if (emittedOutcome) return;
+      emittedOutcome = true;
+    }
+    output(`${JSON.stringify(redactJson(line))}\n`);
+  };
+}
+
+interface ValidatedRoots {
+  stateRoot: string;
+  workspaceRoot: string;
+  configRoot: string;
+}
+
+async function validateRoots(options: MakaActivationOptions): Promise<ValidatedRoots> {
+  const workspaceRoot = await canonicalExistingDirectory(options.workspaceRoot);
+  const stateRoot = await canonicalCreateDirectory(options.stateRoot);
+  const configRoot = await canonicalCreateDirectory(options.configRoot);
+  const roots: Array<[string, string]> = [
+    ['state', stateRoot],
+    ['workspace', workspaceRoot],
+    ['config', configRoot],
+  ];
+  for (let i = 0; i < roots.length; i += 1) {
+    for (let j = i + 1; j < roots.length; j += 1) {
+      if (pathsOverlap(roots[i]![1], roots[j]![1])) {
+        throw new Error(`${roots[i]![0]} root overlaps ${roots[j]![0]} root`);
+      }
+    }
+  }
+  return { stateRoot, workspaceRoot, configRoot };
+}
+
+async function canonicalExistingDirectory(path: string): Promise<string> {
+  const canonical = await realpath(resolve(path));
+  const info = await stat(canonical);
+  if (!info.isDirectory()) throw new Error(`root is not a directory: ${path}`);
+  return canonical;
+}
+
+async function canonicalCreateDirectory(path: string): Promise<string> {
+  await mkdir(resolve(path), { recursive: true });
+  return canonicalExistingDirectory(path);
+}
+
+async function sameDirectory(left: string, right: string): Promise<boolean> {
+  try {
+    return (await canonicalExistingDirectory(left)) === right;
+  } catch {
+    return resolve(left) === resolve(right);
+  }
+}
+
+function pathsOverlap(left: string, right: string): boolean {
+  const rel = relative(left, right);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
+}
+
+function activationStimulusText(stimulus: ActivationStimulus): string {
+  const payload = stimulus.payload;
+  if (!isRecord(payload)) return JSON.stringify({ type: stimulus.type, payload });
+  for (const key of ['text', 'prompt', 'message'] as const) {
+    if (typeof payload[key] === 'string' && payload[key].trim()) return payload[key];
+  }
+  return JSON.stringify({ type: stimulus.type, payload });
+}
+
+async function activationStream(
+  runtime: MakaActivationRuntime,
+  sessionId: string,
+  input: UserMessageInput,
+  allowSafeBoundaryResume: boolean,
+): Promise<AsyncIterable<SessionEvent>> {
+  const planLatest = runtime.planLatestAuthoritativeSafeBoundaryContinuation;
+  const resume = runtime.resumeSafeBoundaryContinuation;
+  if (allowSafeBoundaryResume && planLatest && resume) {
+    const plan = await planLatest.call(runtime, sessionId);
+    if (plan.disposition === 'continue' && plan.continuation) {
+      return resume.call(runtime, plan.continuation);
+    }
+  }
+  return runtime.sendMessage(sessionId, input);
+}
+
+function sessionEventToRuntimeEvent(event: SessionEvent, sessionId: string): RuntimeEvent {
+  return {
+    id: event.id,
+    invocationId: `activation-${sessionId}`,
+    runId: event.turnId,
+    sessionId,
+    turnId: event.turnId,
+    ts: event.ts,
+    partial: false,
+    role: 'tool',
+    author: 'system',
+    content: { kind: 'text', text: event.type },
+  } as RuntimeEvent;
+}
+
+function redactJson(value: unknown): unknown {
+  try {
+    const serialized = JSON.stringify(value);
+    return serialized === undefined ? value : JSON.parse(redactSecrets(serialized));
+  } catch {
+    return '[redacted]';
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, any> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function safeErrorMessage(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  return redactSecrets(message).slice(0, 500);
+}
+
+function makaActivateHelpText(): string {
+  return [
+    'Usage: maka activate --state-root <path> --workspace-root <path> --config-root <path>',
+    '',
+    'Read a versioned activation request from stdin or --input <file> and emit JSONL.',
+    '',
+    'Options:',
+    '  --state-root <path>       Session-owned state directory (required)',
+    '  --workspace-root <path>   Activation workspace directory (required)',
+    '  --config-root <path>      Configuration directory (required)',
+    '  --input <path>            JSON request file, or - for stdin (default: -)',
+    '  --timeout <seconds>       Invocation timeout',
+    '  --max-steps <count>       Tool-step cap',
+    '  --permission-mode <mode>  explore|execute|bypass',
+    '  --connection <slug>       Model connection override',
+    '  --model <id>              Model override',
+  ].join('\n');
+}
+
+function defaultMakaActivationDeps(): MakaActivationDeps {
+  return {
+    createContext: createMakaCliRuntimeContext,
+    listSessions: (workspaceRoot) => createMakaCliRuntimeContextListSessions(workspaceRoot),
+    workspaceRoot: () => resolve(process.cwd()),
+    processCwd: () => process.cwd(),
+    stdinIsTTY: () => process.stdin.isTTY === true,
+    readStdin: readProcessStdin,
+    readFile: async (path) => readFile(path, 'utf8'),
+    writeStdout: (text) => process.stdout.write(text),
+    writeStderr: (text) => process.stderr.write(text),
+    onSigint: (handler) => {
+      process.on('SIGINT', handler);
+      return () => process.off('SIGINT', handler);
+    },
+    setTimer: (handler, ms) => {
+      const timer = setTimeout(handler, ms);
+      timer.unref();
+      return timer;
+    },
+    clearTimer: (timer) => clearTimeout(timer as ReturnType<typeof setTimeout>),
+    newId: randomUUID,
+  };
+}
+
+async function createMakaCliRuntimeContextListSessions(
+  workspaceRoot: string,
+): Promise<SessionSummary[]> {
+  await resolveStorageRoot({ path: workspaceRoot, kind: 'interactive' });
+  return createSessionStore(workspaceRoot).list();
+}
+
+async function readProcessStdin(): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of process.stdin)
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  return Buffer.concat(chunks).toString('utf8');
+}

--- a/packages/cli/src/activation-command.ts
+++ b/packages/cli/src/activation-command.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { mkdir, realpath, stat, readFile } from 'node:fs/promises';
-import { isAbsolute, relative, resolve } from 'node:path';
+import { isAbsolute, resolve } from 'node:path';
 import type { SessionEvent } from '@maka/core/events';
 import type { PermissionMode } from '@maka/core/permission';
 import type { CreateSessionInput, UserMessageInput } from '@maka/core/runtime-inputs';
@@ -12,13 +12,18 @@ import type {
 } from '@maka/runtime';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import { redactSecrets } from '@maka/core/redaction';
-import { createSessionStore } from '@maka/storage';
+import { assertSessionBundleRootLayout, createSessionStore } from '@maka/storage';
 import { resolveStorageRoot } from '@maka/storage/root-authority';
 import {
   createMakaCliRuntimeContext,
   type CreateMakaCliRuntimeContextInput,
   type MakaCliRuntimeContext,
 } from './runtime-bootstrap.js';
+import {
+  invocationHasSandboxBoundaryFailure,
+  invocationRecoveredSandboxBoundaryFailure,
+  sessionEventSandboxBoundaryFailureReason,
+} from './sandbox-boundary-failure.js';
 
 const PROTOCOL = 'maka.activation' as const;
 const SCHEMA_VERSION = 1 as const;
@@ -87,9 +92,9 @@ export interface MakaActivationRuntime {
   ): Promise<SafeBoundaryContinuationPlan>;
   resumeSafeBoundaryContinuation?(continuation: RuntimeContinuation): AsyncIterable<SessionEvent>;
   sendMessage(sessionId: string, input: UserMessageInput): AsyncIterable<SessionEvent>;
-  respondToPermission(
+  respondToSandboxBoundary(
     sessionId: string,
-    response: { requestId: string; decision: 'deny'; rememberForTurn?: boolean },
+    response: { requestId: string; decision: 'deny' },
   ): Promise<void>;
   stopSession(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
 }
@@ -288,8 +293,29 @@ export async function runMakaActivationCli(
     const raw = options.input === '-' ? await deps.readStdin() : await deps.readFile(options.input);
     request = decodeActivationRequest(JSON.parse(raw));
   } catch (error) {
+    const malformedRequest: MakaActivationRequest = {
+      schemaVersion: SCHEMA_VERSION,
+      activationId: deps.newId(),
+      cloudSessionId: 'unknown',
+      stimulus: { type: 'system', payload: {} },
+    };
+    const write = lineWriter(deps.writeStdout);
+    write({
+      protocol: PROTOCOL,
+      schemaVersion: SCHEMA_VERSION,
+      type: 'start',
+      activationId: malformedRequest.activationId,
+      cloudSessionId: malformedRequest.cloudSessionId,
+      workspaceRoot: resolve(options.workspaceRoot),
+    } satisfies ActivationStartLine);
     deps.writeStderr(`maka activate: ${safeErrorMessage(error)}\n`);
-    return 2;
+    return emitOutcome(
+      deps.writeStdout,
+      malformedRequest,
+      undefined,
+      'fatal_failure',
+      'malformed_input',
+    );
   }
 
   const write = lineWriter(deps.writeStdout);
@@ -332,12 +358,24 @@ export async function runMakaActivationCli(
       );
     }
     if (existing && (existing.status === 'blocked' || existing.status === 'waiting_for_user')) {
+      const blockedReason = existing.blockedReason ?? 'unknown';
+      if (blockedReason !== 'permission_required') {
+        return await finishWithoutContext(
+          deps,
+          request,
+          write,
+          'retryable_failure',
+          blockedReason,
+          existing.id,
+          'retry_activation',
+        );
+      }
       return await finishWithoutContext(
         deps,
         request,
         write,
         'blocked',
-        existing.blockedReason ?? 'permission_required',
+        blockedReason,
         existing.id,
         'grant_permission',
       );
@@ -355,6 +393,8 @@ export async function runMakaActivationCli(
   let context: MakaActivationContext | undefined;
   let session: SessionSummary | undefined = existing;
   let invocation: InvocationResult | undefined;
+  let streamBoundaryFailure = false;
+  const boundaryFailureInvocationIds = new Set<string>();
   let timedOut = false;
   let interrupted = false;
   let streamFailed = false;
@@ -405,6 +445,13 @@ export async function runMakaActivationCli(
       runtimeSource: 'gateway',
       safeBoundaryResumeEnabled: true,
       runtimeInvocationObserver: (result) => {
+        if (invocationHasSandboxBoundaryFailure(result)) {
+          if (invocationRecoveredSandboxBoundaryFailure(result)) {
+            boundaryFailureInvocationIds.delete(result.invocationId);
+          } else {
+            boundaryFailureInvocationIds.add(result.invocationId);
+          }
+        }
         invocation = result;
         for (const event of result.events) writeRuntimeEvent(event);
       },
@@ -453,9 +500,10 @@ export async function runMakaActivationCli(
       );
       const drain = (async () => {
         for await (const event of stream) {
-          if (event.type === 'permission_request') {
+          if (sessionEventSandboxBoundaryFailureReason(event)) streamBoundaryFailure = true;
+          if (event.type === 'sandbox_boundary_request') {
             writeRuntimeEvent(sessionEventToRuntimeEvent(event, session!.id));
-            await context!.runtime.respondToPermission(session!.id, {
+            await context!.runtime.respondToSandboxBoundary(session!.id, {
               requestId: event.requestId,
               decision: 'deny',
             });
@@ -521,6 +569,12 @@ export async function runMakaActivationCli(
   if (interrupted) return finish('retryable_failure', 'interrupted');
   if (timedOut) return finish('retryable_failure', 'timeout');
   if (streamFailed) return finish('retryable_failure', 'runtime_error');
+  if (
+    (streamBoundaryFailure && !invocationRecoveredSandboxBoundaryFailure(invocation)) ||
+    boundaryFailureInvocationIds.size > 0
+  ) {
+    return finish('blocked', 'permission_required', undefined, 'grant_permission');
+  }
   if (!invocation) return finish('fatal_failure', 'missing_invocation');
   if (invocation.status === 'completed' && invocation.finalOutput !== undefined) {
     return finish('completed', undefined, invocation.finalOutput);
@@ -614,22 +668,31 @@ interface ValidatedRoots {
 }
 
 async function validateRoots(options: MakaActivationOptions): Promise<ValidatedRoots> {
+  await assertActivationRootLayout(options);
   const workspaceRoot = await canonicalExistingDirectory(options.workspaceRoot);
   const stateRoot = await canonicalCreateDirectory(options.stateRoot);
   const configRoot = await canonicalCreateDirectory(options.configRoot);
-  const roots: Array<[string, string]> = [
-    ['state', stateRoot],
-    ['workspace', workspaceRoot],
-    ['config', configRoot],
-  ];
-  for (let i = 0; i < roots.length; i += 1) {
-    for (let j = i + 1; j < roots.length; j += 1) {
-      if (pathsOverlap(roots[i]![1], roots[j]![1])) {
-        throw new Error(`${roots[i]![0]} root overlaps ${roots[j]![0]} root`);
-      }
-    }
-  }
+  await assertActivationRootLayout({ stateRoot, workspaceRoot, configRoot });
   return { stateRoot, workspaceRoot, configRoot };
+}
+
+async function assertActivationRootLayout(
+  roots: Pick<MakaActivationOptions, 'stateRoot' | 'workspaceRoot' | 'configRoot'>,
+): Promise<void> {
+  await Promise.all([
+    assertSessionBundleRootLayout({
+      stateRoot: roots.stateRoot,
+      configRoot: roots.workspaceRoot,
+    }),
+    assertSessionBundleRootLayout({
+      stateRoot: roots.stateRoot,
+      configRoot: roots.configRoot,
+    }),
+    assertSessionBundleRootLayout({
+      stateRoot: roots.workspaceRoot,
+      configRoot: roots.configRoot,
+    }),
+  ]);
 }
 
 async function canonicalExistingDirectory(path: string): Promise<string> {
@@ -650,11 +713,6 @@ async function sameDirectory(left: string, right: string): Promise<boolean> {
   } catch {
     return resolve(left) === resolve(right);
   }
-}
-
-function pathsOverlap(left: string, right: string): boolean {
-  const rel = relative(left, right);
-  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
 
 function activationStimulusText(stimulus: ActivationStimulus): string {

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -24,6 +24,7 @@ import { createApiKeyOnboardingSurface } from './onboarding.js';
 export type MakaCliCommand =
   | { kind: 'tui'; resumeSessionId?: string }
   | { kind: 'run'; args: string[] }
+  | { kind: 'activate'; args: string[] }
   | { kind: 'eval'; args: string[] }
   | { kind: 'inspect'; args: string[] }
   | { kind: 'help'; text: string }
@@ -47,6 +48,7 @@ export function parseMakaCliArgs(argv: string[], version: string): MakaCliComman
     return { kind: 'tui', resumeSessionId: sessionId };
   }
   if (first === 'run' || first === '-p') return { kind: 'run', args: argv.slice(1) };
+  if (first === 'activate') return { kind: 'activate', args: argv.slice(1) };
   if (first === 'eval') return { kind: 'eval', args: argv.slice(1) };
   if (first === 'inspect') return { kind: 'inspect', args: argv.slice(1) };
   return {
@@ -98,6 +100,7 @@ function helpText(): string {
     '  maka              Start the TUI',
     '  maka-agent        Start the TUI',
     '  maka run ...      Run one non-interactive model turn',
+    '  maka activate ... Run one Cloud Session activation and emit JSONL',
     '  maka -p ...       Alias for maka run',
     '  maka eval ...     Run evaluation and autonomous task commands',
     '  maka inspect ...  Inspect Session, AgentRun, or TaskRun evidence',
@@ -163,6 +166,10 @@ export async function runMakaCli(argv: string[] = process.argv.slice(2)): Promis
     case 'run': {
       const { runMakaTextCli } = await import('./run-command.js');
       return runMakaTextCli(command.args);
+    }
+    case 'activate': {
+      const { runMakaActivationCli } = await import('./activation-command.js');
+      return runMakaActivationCli(command.args);
     }
     case 'eval': {
       const { runMakaEvalCli } = await import('@maka/headless/eval-router');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,20 @@ export {
   type ParseMakaRunArgsResult,
 } from './run-command.js';
 export {
+  decodeActivationRequest,
+  parseMakaActivateArgs,
+  runMakaActivationCli,
+  type MakaActivationContext,
+  type MakaActivationBlockedReason,
+  type MakaActivationDeps,
+  type MakaActivationOptions,
+  type MakaActivationRequest,
+  type MakaActivationRuntime,
+  type MakaActivationRequiredAction,
+  type MakaActivationStatus,
+  type ParseMakaActivateArgsResult,
+} from './activation-command.js';
+export {
   selectMakaRunSession,
   type MakaRunSessionSelection,
   type MakaRunSessionSelectionDeps,

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -14,6 +14,11 @@ import {
 } from './runtime-bootstrap.js';
 import type { ReadySessionTarget } from './connection-target.js';
 import { selectMakaRunSession } from './run-session-selection.js';
+import {
+  invocationHasSandboxBoundaryFailure,
+  invocationRecoveredSandboxBoundaryFailure,
+  sessionEventSandboxBoundaryFailureReason,
+} from './sandbox-boundary-failure.js';
 import { resolveMakaWorkspaceRoot } from './workspace-root.js';
 
 export interface MakaRunOptions {
@@ -343,15 +348,11 @@ export async function runMakaTextCli(
           decision: 'deny',
         });
       }
-      if (
-        event.type === 'tool_result' &&
-        event.isError &&
-        event.content.kind === 'text' &&
-        event.content.sandboxFailure
-      ) {
+      const sandboxFailureReason = sessionEventSandboxBoundaryFailureReason(event);
+      if (sandboxFailureReason) {
         streamBoundaryFailure = true;
         deps.writeStderr(
-          event.content.sandboxFailure.reason === 'requires_bypass'
+          sandboxFailureReason === 'requires_bypass'
             ? 'maka run: sandbox bypass requires an explicit --yolo\n'
             : 'maka run: sandbox boundary expansion is unavailable in non-interactive mode\n',
         );
@@ -492,55 +493,4 @@ function withTrailingNewline(text: string): string {
 
 function errorMessage(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
-}
-
-function invocationHasSandboxBoundaryFailure(result: InvocationResult): boolean {
-  for (const event of result.events) {
-    if (event.content?.kind !== 'function_response') continue;
-    const failure = isRecord(event.content.result)
-      ? event.content.result.sandboxFailure
-      : undefined;
-    if (
-      isRecord(failure) &&
-      (failure.reason === 'sandbox_boundary_required' || failure.reason === 'requires_bypass')
-    ) {
-      return true;
-    }
-  }
-  return false;
-}
-
-function invocationRecoveredSandboxBoundaryFailure(result: InvocationResult | undefined): boolean {
-  if (!invocationCompletedWithOutput(result)) return false;
-  let unresolvedBoundaryFailure = false;
-  let recoveredBoundaryFailure = false;
-  for (const event of result.events) {
-    if (event.content?.kind !== 'function_response') continue;
-    const failure = isRecord(event.content.result)
-      ? event.content.result.sandboxFailure
-      : undefined;
-    if (
-      event.content.isError &&
-      isRecord(failure) &&
-      (failure.reason === 'sandbox_boundary_required' || failure.reason === 'requires_bypass')
-    ) {
-      unresolvedBoundaryFailure = true;
-      continue;
-    }
-    if (unresolvedBoundaryFailure && !event.content.isError) {
-      unresolvedBoundaryFailure = false;
-      recoveredBoundaryFailure = true;
-    }
-  }
-  return recoveredBoundaryFailure && !unresolvedBoundaryFailure;
-}
-
-function invocationCompletedWithOutput(
-  result: InvocationResult | undefined,
-): result is InvocationResult & { status: 'completed'; finalOutput: string } {
-  return result?.status === 'completed' && typeof result.finalOutput === 'string';
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -806,7 +806,8 @@ export async function createMakaCliRuntimeContext(
       input.safeBoundaryResumeEnabled ??
       (input.surface === 'activation' || process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME === '1'),
     onContinuationLifecycleEvent: (event) => {
-      console.info('[runtime-resume]', JSON.stringify(event));
+      const writeDiagnostic = input.surface === 'activation' ? console.error : console.info;
+      writeDiagnostic('[runtime-resume]', JSON.stringify(event));
     },
     inspectContinuationSafety: createLocalContinuationSafetyInspector({
       readSessionCwd: async (sessionId) => (await store.readHeader(sessionId)).cwd,

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -53,6 +53,7 @@ import {
   type HostCapabilitiesResolver,
   type MakaTool,
   type InvocationResult,
+  type InvocationSource,
   type ShellRunUpdate,
   type SkillSource,
   type ModelMessage,
@@ -161,7 +162,7 @@ export interface SessionRecapGenerator {
 }
 
 export interface CreateMakaCliRuntimeContextInput {
-  surface: 'tui' | 'run';
+  surface: 'tui' | 'run' | 'activation';
   /** Legacy root; both new roots default to this path. */
   workspaceRoot: string;
   /** Optional portable session-owned state root. */
@@ -177,6 +178,10 @@ export interface CreateMakaCliRuntimeContextInput {
   /** Canonical cwd used for one resumed session without rewriting its stored header. */
   sessionCwdOverride?: { sessionId: string; cwd: string };
   runtimeInvocationObserver?: (result: InvocationResult) => void | Promise<void>;
+  /** Invocation provenance used by hosted activation callers. */
+  runtimeSource?: InvocationSource;
+  /** Enables authoritative safe-boundary continuation for hosted activation callers. */
+  safeBoundaryResumeEnabled?: boolean;
   onSessionTitleChanged?: (sessionId: string) => void;
   /**
    * Optional cron executor. When provided, the Automation tool advertises the
@@ -796,7 +801,10 @@ export async function createMakaCliRuntimeContext(
       : {}),
     shellRuns,
     backends,
-    safeBoundaryResumeEnabled: process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME === '1',
+    runtimeSource: input.runtimeSource ?? (input.surface === 'activation' ? 'gateway' : undefined),
+    safeBoundaryResumeEnabled:
+      input.safeBoundaryResumeEnabled ??
+      (input.surface === 'activation' || process.env.MAKA_RUNTIME_SAFE_BOUNDARY_RESUME === '1'),
     onContinuationLifecycleEvent: (event) => {
       console.info('[runtime-resume]', JSON.stringify(event));
     },

--- a/packages/cli/src/sandbox-boundary-failure.ts
+++ b/packages/cli/src/sandbox-boundary-failure.ts
@@ -1,0 +1,72 @@
+import type { SessionEvent } from '@maka/core/events';
+import type { InvocationResult } from '@maka/runtime';
+
+export type SandboxBoundaryFailureReason = 'sandbox_boundary_required' | 'requires_bypass';
+
+export function sessionEventSandboxBoundaryFailureReason(
+  event: SessionEvent,
+): SandboxBoundaryFailureReason | undefined {
+  if (
+    event.type !== 'tool_result' ||
+    !event.isError ||
+    event.content.kind !== 'text' ||
+    !event.content.sandboxFailure
+  ) {
+    return undefined;
+  }
+  return normalizeSandboxBoundaryFailureReason(event.content.sandboxFailure.reason);
+}
+
+export function invocationHasSandboxBoundaryFailure(result: InvocationResult): boolean {
+  return result.events.some(
+    (event) => runtimeEventSandboxBoundaryFailureReason(event) !== undefined,
+  );
+}
+
+export function invocationRecoveredSandboxBoundaryFailure(
+  result: InvocationResult | undefined,
+): boolean {
+  if (!invocationCompletedWithOutput(result)) return false;
+  let unresolvedBoundaryFailure = false;
+  let recoveredBoundaryFailure = false;
+  for (const event of result.events) {
+    if (event.content?.kind !== 'function_response') continue;
+    if (event.content.isError && runtimeEventSandboxBoundaryFailureReason(event)) {
+      unresolvedBoundaryFailure = true;
+      continue;
+    }
+    if (unresolvedBoundaryFailure && !event.content.isError) {
+      unresolvedBoundaryFailure = false;
+      recoveredBoundaryFailure = true;
+    }
+  }
+  return recoveredBoundaryFailure && !unresolvedBoundaryFailure;
+}
+
+function runtimeEventSandboxBoundaryFailureReason(
+  event: InvocationResult['events'][number],
+): SandboxBoundaryFailureReason | undefined {
+  if (event.content?.kind !== 'function_response' || !isRecord(event.content.result)) {
+    return undefined;
+  }
+  const failure = event.content.result.sandboxFailure;
+  return isRecord(failure) ? normalizeSandboxBoundaryFailureReason(failure.reason) : undefined;
+}
+
+function normalizeSandboxBoundaryFailureReason(
+  reason: unknown,
+): SandboxBoundaryFailureReason | undefined {
+  return reason === 'sandbox_boundary_required' || reason === 'requires_bypass'
+    ? reason
+    : undefined;
+}
+
+function invocationCompletedWithOutput(
+  result: InvocationResult | undefined,
+): result is InvocationResult & { status: 'completed'; finalOutput: string } {
+  return result?.status === 'completed' && typeof result.finalOutput === 'string';
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}


### PR DESCRIPTION
Closes #1554

## Summary
- add strict `maka activate` JSONL entry point with versioned request/output contracts
- require explicit non-overlapping state, workspace, and config roots
- support new/resumed sessions, safe-boundary continuation, bounded redacted runtime events, deterministic outcomes, timeout, and clean shutdown
- keep existing `maka run` text output unchanged

## Scope
Session Bundle, CAS/SessionRepository, sandbox lifecycle, activation leases/deduplication, cross-activation approval workflow, and Cloud Session fork remain out of scope.

## Verification
- `npm --workspace maka-agent run build`
- `node --test packages/cli/dist/__tests__/activation-command.test.js`
- `npm --workspace maka-agent run test:dist` (661 passed)
- `npm --workspace maka-agent run typecheck` (CLI/dependencies pass; existing desktop preload `@maka/ui` dist artifact is unavailable in this worktree)