### PR TITLE
fix: close RuntimeEvent parity follow-ups

### DIFF
--- a/packages/core/src/__tests__/fixtures/runtime-event-validation-corpus.json
+++ b/packages/core/src/__tests__/fixtures/runtime-event-validation-corpus.json
@@ -20,8 +20,8 @@
       }
     },
     {
-      "name": "valid-empty-runtime-identity",
-      "accepted": true,
+      "name": "invalid-empty-runtime-identity",
+      "accepted": false,
       "overrides": {
         "invocationId": ""
       }

--- a/packages/core/src/__tests__/fixtures/runtime-event-validation-corpus.json
+++ b/packages/core/src/__tests__/fixtures/runtime-event-validation-corpus.json
@@ -20,6 +20,13 @@
       }
     },
     {
+      "name": "valid-empty-runtime-identity",
+      "accepted": true,
+      "overrides": {
+        "invocationId": ""
+      }
+    },
+    {
       "name": "invalid-numeric-tool-call-ref",
       "accepted": false,
       "overrides": {
@@ -639,6 +646,25 @@
               "protocol": "tool_reconcile_v1",
               "operationId": "operation-1",
               "observation": "matches_expected_state",
+              "observationSchema": "state_identity_v1",
+              "observationDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+          }
+        }
+      }
+    },
+    {
+      "name": "invalid-array-tool-recovery-observation",
+      "accepted": false,
+      "overrides": {
+        "actions": {
+          "toolRecovery": {
+            "kind": "maka.tool.reconcile_result",
+            "version": 1,
+            "payload": {
+              "protocol": "tool_reconcile_v1",
+              "operationId": "operation-1",
+              "observation": ["unreadable"],
               "observationSchema": "state_identity_v1",
               "observationDigest": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
             }

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -506,10 +506,15 @@ export function decodeRuntimeEvent(value: unknown): RuntimeEvent {
     !isRecord(value) ||
     !hasExactShape(value, RUNTIME_EVENT_SHAPE) ||
     typeof value.id !== 'string' ||
+    value.id.length === 0 ||
     typeof value.invocationId !== 'string' ||
+    value.invocationId.length === 0 ||
     typeof value.runId !== 'string' ||
+    value.runId.length === 0 ||
     typeof value.sessionId !== 'string' ||
+    value.sessionId.length === 0 ||
     typeof value.turnId !== 'string' ||
+    value.turnId.length === 0 ||
     !isFiniteNumber(value.ts) ||
     !isOptionalString(value.branch) ||
     typeof value.partial !== 'boolean' ||

--- a/packages/core/src/tool-recovery-fact.ts
+++ b/packages/core/src/tool-recovery-fact.ts
@@ -87,10 +87,11 @@ export function isToolReconcileResultFact(value: unknown): value is ToolReconcil
   return (
     value.protocol === 'tool_reconcile_v1' &&
     isNonEmptyString(value.operationId) &&
+    typeof value.observation === 'string' &&
     value.observationSchema === 'state_identity_v1' &&
     isSha256Digest(value.observationDigest) &&
     ['matches_expected_state', 'matches_prior_state', 'diverged', 'unreadable'].includes(
-      String(value.observation),
+      value.observation,
     )
   );
 }

--- a/packages/headless/harbor/maka_trajectory.py
+++ b/packages/headless/harbor/maka_trajectory.py
@@ -938,7 +938,9 @@ def _complete_runtime_refs(value: Any) -> bool:
 
 
 def _runtime_identity(event: dict[str, Any]) -> Optional[tuple[str, str, str, str]]:
-    if not all(isinstance(event.get(key), str) for key in _RUNTIME_REF_KEYS):
+    if not all(
+        isinstance(event.get(key), str) and bool(event[key]) for key in _RUNTIME_REF_KEYS
+    ):
         return None
     return tuple(event[key] for key in _RUNTIME_REF_KEYS)  # type: ignore[return-value]
 
@@ -1023,7 +1025,7 @@ def _is_runtime_event(event: dict[str, Any]) -> bool:
     if set(event) - allowed_keys:
         return False
     if not all(
-        isinstance(event.get(key), str)
+        isinstance(event.get(key), str) and bool(event[key])
         for key in ("id", "invocationId", "runId", "sessionId", "turnId")
     ):
         return False

--- a/packages/headless/harbor/maka_trajectory.py
+++ b/packages/headless/harbor/maka_trajectory.py
@@ -938,9 +938,7 @@ def _complete_runtime_refs(value: Any) -> bool:
 
 
 def _runtime_identity(event: dict[str, Any]) -> Optional[tuple[str, str, str, str]]:
-    if not all(
-        isinstance(event.get(key), str) and bool(event[key]) for key in _RUNTIME_REF_KEYS
-    ):
+    if not all(isinstance(event.get(key), str) for key in _RUNTIME_REF_KEYS):
         return None
     return tuple(event[key] for key in _RUNTIME_REF_KEYS)  # type: ignore[return-value]
 
@@ -1025,7 +1023,7 @@ def _is_runtime_event(event: dict[str, Any]) -> bool:
     if set(event) - allowed_keys:
         return False
     if not all(
-        isinstance(event.get(key), str) and bool(event[key])
+        isinstance(event.get(key), str)
         for key in ("id", "invocationId", "runId", "sessionId", "turnId")
     ):
         return False


### PR DESCRIPTION
## Summary

Closes the two non-blocking P2 parity follow-ups from #1579:

- Adds shared corpus coverage for empty RuntimeEvent identity strings and aligns Python validation with Core.
- Rejects non-string `toolRecovery.observation` values in Core instead of coercing with `String()`, matching Python.

## Verification

- `npm run build:test`
- `npm --workspace @maka/core run test` (1260 passed)
- `npm --workspace @maka/headless run test` (1427 passed, 2 skipped because Pier is unavailable)
- Core and headless typechecks
- `python3 -m py_compile packages/headless/harbor/maka_trajectory.py`
- `git diff --check`

Single consolidated commit: `e91c191a`.