### PR TITLE
feat(runtime-host): add connection effects authority

### DIFF
--- a/packages/core/src/__tests__/runtime-policy-codec.test.ts
+++ b/packages/core/src/__tests__/runtime-policy-codec.test.ts
@@ -5,6 +5,7 @@ import {
   decodeCanonicalConnectionCatalogEntry,
   decodeCanonicalRuntimePolicy,
   normalizeCreateCatalogConnectionInput,
+  normalizeConnectionModelDiscoveryResult,
   normalizeRuntimePolicyMutation,
   normalizeSetCredentialInput,
   RuntimePolicyDomainDecodeError,
@@ -63,6 +64,35 @@ test('normalizes catalog inputs while canonical entries reject noncanonical endp
       }),
     RuntimePolicyDomainDecodeError,
   );
+});
+
+test('normalizes exact bounded model discovery results', () => {
+  assert.deepEqual(
+    normalizeConnectionModelDiscoveryResult({
+      models: [{ id: 'gpt-5', capabilities: { chat: true } }],
+      source: 'fetched',
+      fetchedAt: 42,
+    }),
+    {
+      models: [{ id: 'gpt-5', capabilities: { chat: true } }],
+      source: 'fetched',
+      fetchedAt: 42,
+    },
+  );
+  for (const invalid of [
+    {
+      models: [{ id: 'duplicate' }, { id: 'duplicate' }],
+      source: 'fetched',
+      fetchedAt: 42,
+    },
+    { models: [{ id: 'gpt-5' }], source: 'unknown', fetchedAt: 42 },
+    { models: [{ id: 'gpt-5' }], source: 'fetched', fetchedAt: 42, rawBody: 'secret' },
+  ]) {
+    assert.throws(
+      () => normalizeConnectionModelDiscoveryResult(invalid),
+      RuntimePolicyDomainDecodeError,
+    );
+  }
 });
 
 test('credential domain validation requires material but leaves capacity to callers', () => {

--- a/packages/core/src/runtime-policy.ts
+++ b/packages/core/src/runtime-policy.ts
@@ -9,7 +9,11 @@ import type { ChatDefaultPermissionMode, ProxyProtocol } from './settings.js';
 import { WEB_SEARCH_PROVIDERS, type WebSearchProvider } from './web-search.js';
 
 export { WEB_SEARCH_PROVIDERS };
-export { RuntimePolicyDomainDecodeError } from './runtime-policy/domain-codec.js';
+export type { ConnectionTestErrorClass, ModelDiscoverySource } from './llm-connections.js';
+export {
+  decodeRuntimePolicyEntityId,
+  RuntimePolicyDomainDecodeError,
+} from './runtime-policy/domain-codec.js';
 export {
   decodeCanonicalRuntimePolicy,
   normalizeRuntimePolicyMutation,
@@ -34,6 +38,7 @@ export {
   normalizeConnectionCatalogEntryDraft,
   normalizeConnectionCatalogEntryUpdate,
   normalizeConnectionCatalogEntryUpdateForProvider,
+  normalizeConnectionModelDiscoveryResult,
   normalizeCreateCatalogConnectionInput,
   normalizeRemoveCatalogConnectionInput,
   normalizeSetDefaultConnectionTargetInput,

--- a/packages/core/src/runtime-policy/connection-catalog-codec.ts
+++ b/packages/core/src/runtime-policy/connection-catalog-codec.ts
@@ -4,6 +4,7 @@ import type {
   ConnectionCatalogEntryDraft,
   ConnectionCatalogEntryUpdate,
   ConnectionModel,
+  ConnectionModelDiscoveryResult,
   ConnectionTarget,
   ConnectionTestSummary,
   ConnectionVersionBasis,
@@ -318,6 +319,35 @@ export function decodeConnectionTestSummary(value: unknown): ConnectionTestSumma
     status: item.status,
     checkedAt: nonEmptyStringValue(item.checkedAt, 'connection test checkedAt', 128),
     ...(item.errorClass === undefined ? {} : { errorClass: item.errorClass }),
+  };
+}
+
+export function normalizeConnectionModelDiscoveryResult(
+  value: unknown,
+): ConnectionModelDiscoveryResult {
+  const item = exactRecord(value, 'model discovery result', ['models', 'source', 'fetchedAt']);
+  if (
+    !Array.isArray(item.models) ||
+    item.models.length > CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION
+  ) {
+    throw domainError('model discovery models must be a bounded array');
+  }
+  const models = item.models.map(decodeConnectionModel);
+  if (new Set(models.map((model) => model.id)).size !== models.length) {
+    throw domainError('model discovery model ids must be unique');
+  }
+  if (item.source !== 'fetched' && item.source !== 'fallback') {
+    throw domainError('model discovery source is invalid');
+  }
+  return {
+    models,
+    source: item.source,
+    fetchedAt: integerValue(
+      item.fetchedAt,
+      'model discovery fetchedAt',
+      0,
+      Number.MAX_SAFE_INTEGER,
+    ),
   };
 }
 

--- a/packages/core/src/runtime-policy/domain-codec.ts
+++ b/packages/core/src/runtime-policy/domain-codec.ts
@@ -83,6 +83,10 @@ export function entityIdValue(value: unknown, context: string): EntityId {
   return parsed;
 }
 
+export function decodeRuntimePolicyEntityId(value: unknown): EntityId {
+  return entityIdValue(value, 'runtime policy entity id');
+}
+
 export function assertCanonicalValue(original: unknown, canonical: unknown, context: string): void {
   if (!sameValue(original, canonical)) throw domainError(`${context} must be canonical`);
 }

--- a/packages/runtime-host/src/__tests__/connection-effect-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-effect-coordinator.test.ts
@@ -1,0 +1,420 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type {
+  ConnectionCatalogEntry,
+  ConnectionCatalogEntryDraft,
+  CredentialStatus,
+} from '@maka/core/runtime-policy';
+import type { ConnectionEffectFetchTransport, ConnectionTestEffectOutcome } from '@maka/runtime';
+import {
+  openInteractiveRuntimePolicyStoresForWrite,
+  type RuntimePolicyStoresWriter,
+} from '@maka/storage/runtime-policy-stores';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
+import { HostConnectionEffectCoordinator } from '../server/connection-effect-coordinator.js';
+import type { ConnectionContext } from '../server/operation-dispatcher.js';
+import { RuntimePolicyActivationGate } from '../server/runtime-policy-activation-gate.js';
+
+const context: ConnectionContext = {
+  hostEpoch: 'connection-effect-test-epoch',
+  connectionId: 'connection-effect-test-client',
+  surface: 'desktop',
+  principal: 'local_os_user',
+  acquireResidency: () => ({ release: () => undefined }),
+};
+
+test('serializes one connection, runs different connections concurrently, and continues after provider failure', async () => {
+  await withFixture(async ({ stores }) => {
+    const first = await createConnection(stores, 0, connectionDraft('queue-first', 'ollama'));
+    const second = await createConnection(stores, 1, connectionDraft('queue-second', 'ollama'));
+    const firstStarted = deferred<void>();
+    const releaseFirst = deferred<void>();
+    const secondStarted = deferred<void>();
+    const otherStarted = deferred<void>();
+    const starts: string[] = [];
+    let firstConnectionRuns = 0;
+    let transportCloses = 0;
+
+    const coordinator = new HostConnectionEffectCoordinator({
+      stores,
+      activation: new RuntimePolicyActivationGate(),
+      createTransport: () =>
+        recordingTransport(() => {
+          transportCloses += 1;
+        }),
+      runModelDiscovery: async (connection) => {
+        if (connection.connectionId === second.connectionId) {
+          starts.push('other');
+          otherStarted.resolve(undefined);
+          return { ok: true, models: [{ id: 'other-model' }] };
+        }
+        firstConnectionRuns += 1;
+        if (firstConnectionRuns === 1) {
+          starts.push('first');
+          firstStarted.resolve(undefined);
+          await releaseFirst.promise;
+          return { ok: false, error: { kind: 'network' } };
+        }
+        starts.push('second');
+        secondStarted.resolve(undefined);
+        return { ok: true, models: [{ id: 'recovered-model' }] };
+      },
+    });
+
+    const failed = coordinator.handlers['connection.models.fetch'](
+      { connectionId: first.connectionId },
+      context,
+    );
+    const recovered = coordinator.handlers['connection.models.fetch'](
+      { connectionId: first.connectionId },
+      context,
+    );
+    const concurrent = coordinator.handlers['connection.models.fetch'](
+      { connectionId: second.connectionId },
+      context,
+    );
+
+    await Promise.all([firstStarted.promise, otherStarted.promise]);
+    assert.deepEqual(starts, ['first', 'other']);
+    releaseFirst.resolve(undefined);
+    await secondStarted.promise;
+
+    assert.deepEqual(await failed, {
+      ok: true,
+      result: { kind: 'failed', errorClass: 'network' },
+    });
+    assert.equal((await recovered).ok, true);
+    assert.equal((await concurrent).ok, true);
+    assert.deepEqual(starts, ['first', 'other', 'second']);
+    assert.equal(transportCloses, 3);
+
+    const snapshot = await stores.connectionCatalog.getSnapshot();
+    assert.deepEqual(
+      snapshot.connections.find(({ connectionId }) => connectionId === first.connectionId)?.models,
+      [{ id: 'recovered-model' }],
+    );
+    assert.deepEqual(
+      snapshot.connections.find(({ connectionId }) => connectionId === second.connectionId)?.models,
+      [{ id: 'other-model' }],
+    );
+  });
+});
+
+test('beginDrain rejects new effects while close waits for an already accepted effect', async () => {
+  await withFixture(async ({ stores }) => {
+    const connection = await createConnection(stores, 0, connectionDraft('drain', 'ollama'));
+    const started = deferred<void>();
+    const release = deferred<void>();
+    const coordinator = new HostConnectionEffectCoordinator({
+      stores,
+      activation: new RuntimePolicyActivationGate(),
+      runModelDiscovery: async () => {
+        started.resolve(undefined);
+        await release.promise;
+        return { ok: true, models: [{ id: 'accepted-model' }] };
+      },
+    });
+
+    const accepted = coordinator.handlers['connection.models.fetch'](
+      { connectionId: connection.connectionId },
+      context,
+    );
+    await started.promise;
+    coordinator.beginDrain();
+
+    assert.deepEqual(
+      await coordinator.handlers['connection.models.fetch'](
+        { connectionId: connection.connectionId },
+        context,
+      ),
+      {
+        ok: false,
+        error: { code: 'host_draining', message: 'Runtime Host is draining' },
+      },
+    );
+
+    let closeSettled = false;
+    const close = coordinator.close().then(() => {
+      closeSettled = true;
+    });
+    await Promise.resolve();
+    assert.equal(closeSettled, false);
+
+    release.resolve(undefined);
+    assert.equal((await accepted).ok, true);
+    await close;
+    assert.equal(closeSettled, true);
+  });
+});
+
+test('provider discovery failure preserves the existing catalog and returns no secret', async () => {
+  await withFixture(async ({ stores }) => {
+    const connection = await createConnection(stores, 0, connectionDraft('discovery', 'openai'));
+    const secret = 'discovery-credential-must-not-escape';
+    await setConnectionCredential(stores, connection, secret);
+    let run = 0;
+    let invalidations = 0;
+    let transportCloses = 0;
+    const coordinator = new HostConnectionEffectCoordinator({
+      stores,
+      activation: new RuntimePolicyActivationGate(),
+      now: () => 123,
+      onCommittedMutation: async () => {
+        invalidations += 1;
+      },
+      createTransport: () =>
+        recordingTransport(() => {
+          transportCloses += 1;
+        }),
+      runModelDiscovery: async (_connection, apiKey) => {
+        assert.equal(apiKey, secret);
+        run += 1;
+        if (run === 1) return { ok: true, models: [{ id: 'cached-model' }] };
+        return { ok: false, error: { kind: 'auth' } };
+      },
+    });
+
+    const seeded = await coordinator.handlers['connection.models.fetch'](
+      { connectionId: connection.connectionId },
+      context,
+    );
+    assert.equal(seeded.ok, true);
+    const beforeFailure = await stores.connectionCatalog.getSnapshot();
+
+    const failed = await coordinator.handlers['connection.models.fetch'](
+      { connectionId: connection.connectionId },
+      context,
+    );
+
+    assert.deepEqual(failed, {
+      ok: true,
+      result: { kind: 'failed', errorClass: 'auth' },
+    });
+    assert.deepEqual(await stores.connectionCatalog.getSnapshot(), beforeFailure);
+    assert.equal(invalidations, 1);
+    assert.equal(transportCloses, 2);
+    assertRedacted(failed, [secret]);
+    assertRedacted(beforeFailure, [secret]);
+  });
+});
+
+test('connection test derives a persisted summary from one bounded projection', async () => {
+  await withFixture(async ({ stores }) => {
+    const connection = await createConnection(stores, 0, connectionDraft('test-failure', 'openai'));
+    const secret = 'test-credential-must-not-escape';
+    await setConnectionCredential(stores, connection, secret);
+    let transportCloses = 0;
+    const coordinator = new HostConnectionEffectCoordinator({
+      stores,
+      activation: new RuntimePolicyActivationGate(),
+      now: () => Date.parse('2026-07-29T12:00:00.000Z'),
+      createTransport: () =>
+        recordingTransport(() => {
+          transportCloses += 1;
+        }),
+      runConnectionTest: async (_connection, apiKey, _options, modelId) => {
+        assert.equal(apiKey, secret);
+        assert.equal(modelId, 'gpt-5');
+        return {
+          ok: false,
+          error: { kind: 'auth', statusCode: 401 },
+          modelId: 'gpt-5',
+          latencyMs: 17,
+        };
+      },
+    });
+
+    const outcome = await coordinator.handlers['connection.test.run'](
+      { connectionId: connection.connectionId, modelId: 'gpt-5' },
+      context,
+    );
+
+    assert.equal(outcome.ok, true);
+    if (!outcome.ok || outcome.result.kind !== 'committed') {
+      throw new Error('connection test did not commit');
+    }
+    assert.deepEqual(outcome.result.test, {
+      kind: 'failed',
+      checkedAt: '2026-07-29T12:00:00.000Z',
+      modelId: 'gpt-5',
+      latencyMs: 17,
+      statusCode: 401,
+      errorClass: 'auth',
+    });
+    assert.equal(transportCloses, 1);
+
+    const persisted = await stores.connectionCatalog.getSnapshot();
+    assert.deepEqual(persisted.connections[0]?.lastTest, {
+      status: 'needs_reauth',
+      checkedAt: outcome.result.test.checkedAt,
+      errorClass: 'auth',
+    });
+    assertRedacted(outcome, [secret]);
+    assertRedacted(persisted, [secret]);
+  });
+});
+
+test('projects credential changes during provider I/O as semantic superseded and closes transport', async () => {
+  await withFixture(async ({ stores }) => {
+    const connection = await createConnection(stores, 0, connectionDraft('superseded', 'openai'));
+    await setConnectionCredential(stores, connection, 'credential-v1');
+    const started = deferred<void>();
+    const release = deferred<void>();
+    let transportCloses = 0;
+    const coordinator = new HostConnectionEffectCoordinator({
+      stores,
+      activation: new RuntimePolicyActivationGate(),
+      createTransport: () =>
+        recordingTransport(() => {
+          transportCloses += 1;
+        }),
+      runConnectionTest: async () => {
+        started.resolve(undefined);
+        await release.promise;
+        return {
+          ok: true,
+          modelId: 'gpt-5',
+          latencyMs: 9,
+        };
+      },
+    });
+
+    const pending = coordinator.handlers['connection.test.run'](
+      { connectionId: connection.connectionId, modelId: 'gpt-5' },
+      context,
+    );
+    await started.promise;
+    const status = await connectionCredentialStatus(stores, connection);
+    assert.equal(status.configured, true);
+    if (!status.configured) throw new Error('connection credential was not configured');
+    assert.equal(
+      (
+        await stores.credentialVault.set({
+          locator: connectionCredential(connection),
+          expected: { credentialId: status.credentialId, revision: status.revision },
+          secret: 'credential-v2',
+        })
+      ).kind,
+      'committed',
+    );
+    release.resolve(undefined);
+
+    assert.deepEqual(await pending, {
+      ok: true,
+      result: { kind: 'superseded', changed: ['credential'] },
+    });
+    assert.equal(transportCloses, 1);
+    assert.equal(
+      (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest,
+      undefined,
+    );
+  });
+});
+
+type Writer = RuntimePolicyStoresWriter;
+
+async function withFixture(
+  run: (fixture: { root: string; stores: Writer }) => Promise<void>,
+): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-connection-effects-'));
+  const root = join(base, 'interactive');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  if (!owner) return;
+  try {
+    const stores = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+    await run({ root, stores });
+  } finally {
+    try {
+      await owner.close();
+    } finally {
+      await rm(base, { recursive: true, force: true });
+    }
+  }
+}
+
+async function createConnection(
+  stores: Writer,
+  expectedCatalogRevision: number,
+  connection: ConnectionCatalogEntryDraft,
+): Promise<ConnectionCatalogEntry> {
+  const result = await stores.connectionCatalog.create({ expectedCatalogRevision, connection });
+  assert.equal(result.kind, 'committed');
+  if (result.kind !== 'committed') throw new Error('connection creation did not commit');
+  const created = result.snapshot.connections.find(({ slug }) => slug === connection.slug);
+  assert.ok(created);
+  return created;
+}
+
+function connectionDraft(
+  slug: string,
+  providerType: ConnectionCatalogEntryDraft['providerType'],
+): ConnectionCatalogEntryDraft {
+  return {
+    slug,
+    name: slug,
+    providerType,
+    enabled: true,
+    enabledModelIds: ['gpt-5'],
+  };
+}
+
+function connectionCredential(connection: ConnectionCatalogEntry) {
+  return {
+    scope: 'connection' as const,
+    connectionId: connection.connectionId,
+    kind: 'api_key' as const,
+  };
+}
+
+async function setConnectionCredential(
+  stores: Writer,
+  connection: ConnectionCatalogEntry,
+  secret: string,
+): Promise<void> {
+  const result = await stores.credentialVault.set({
+    locator: connectionCredential(connection),
+    expected: null,
+    secret,
+  });
+  assert.equal(result.kind, 'committed');
+}
+
+async function connectionCredentialStatus(
+  stores: Writer,
+  connection: ConnectionCatalogEntry,
+): Promise<CredentialStatus> {
+  const result = await stores.credentialVault.getStatus(connectionCredential(connection));
+  assert.equal(result.kind, 'status');
+  if (result.kind !== 'status') throw new Error('credential query did not return status');
+  return result.status;
+}
+
+function recordingTransport(onClose: () => void): ConnectionEffectFetchTransport {
+  return {
+    fetch: globalThis.fetch,
+    close: async () => {
+      onClose();
+    },
+  };
+}
+
+function deferred<T>(): {
+  readonly promise: Promise<T>;
+  resolve(value: T): void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((settle) => {
+    resolve = settle;
+  });
+  return { promise, resolve };
+}
+
+function assertRedacted(value: unknown, forbidden: readonly string[]): void {
+  const serialized = JSON.stringify(value);
+  for (const text of forbidden) assert.equal(serialized.includes(text), false);
+}

--- a/packages/runtime-host/src/__tests__/connection-effects-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/connection-effects-protocol.test.ts
@@ -1,0 +1,187 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  CONNECTION_EFFECT_OPERATION_SPECS,
+  decodeClientFrame,
+  decodeHostFrame,
+} from '../protocol/index.js';
+import { RuntimeHostProtocolError } from '../protocol/errors.js';
+
+const EXPECTED = {
+  connectionId: '00000000-0000-4000-8000-000000000001',
+  revision: 1,
+};
+
+describe('Runtime Host connection effects protocol', () => {
+  test('declares two ready commands with bounded mutation errors', () => {
+    assert.deepEqual(Object.keys(CONNECTION_EFFECT_OPERATION_SPECS).sort(), [
+      'connection.models.fetch',
+      'connection.test.run',
+    ]);
+    for (const operation of Object.keys(CONNECTION_EFFECT_OPERATION_SPECS) as Array<
+      keyof typeof CONNECTION_EFFECT_OPERATION_SPECS
+    >) {
+      assert.deepEqual(
+        {
+          mode: CONNECTION_EFFECT_OPERATION_SPECS[operation].mode,
+          availability: CONNECTION_EFFECT_OPERATION_SPECS[operation].availability,
+          errors: CONNECTION_EFFECT_OPERATION_SPECS[operation].errors,
+        },
+        {
+          mode: 'command',
+          availability: 'ready',
+          errors: [
+            'host_not_ready',
+            'host_draining',
+            'operation_unavailable',
+            'invalid_request',
+            'internal_failure',
+            'persistence_failed',
+            'commit_outcome_unknown',
+          ],
+        },
+      );
+    }
+  });
+
+  test('requires a stable connection identity and an explicit nullable test model', () => {
+    const fetch = request('connection.models.fetch', { connectionId: EXPECTED.connectionId });
+    const connectionTest = request('connection.test.run', {
+      connectionId: EXPECTED.connectionId,
+      modelId: 'model-1',
+    });
+    const defaultModelTest = request('connection.test.run', {
+      connectionId: EXPECTED.connectionId,
+      modelId: null,
+    });
+    assert.deepEqual(decodeClientFrame(fetch), fetch);
+    assert.deepEqual(decodeClientFrame(connectionTest), connectionTest);
+    assert.deepEqual(decodeClientFrame(defaultModelTest), defaultModelTest);
+
+    assertInvalidRequest('connection.models.fetch', {
+      connectionId: EXPECTED.connectionId,
+      secret: 'forbidden',
+    });
+    assertInvalidRequest('connection.test.run', { connectionId: EXPECTED.connectionId });
+    assertInvalidRequest('connection.test.run', {
+      connectionId: EXPECTED.connectionId,
+      modelId: 'x'.repeat(1_025),
+    });
+  });
+
+  test('accepts bounded model summaries and rejects model arrays or raw failures', () => {
+    const committedResult = {
+      kind: 'committed',
+      catalogRevision: 2,
+      connection: { ...EXPECTED, revision: 2 },
+      modelCount: 2_048,
+      source: 'fetched',
+      fetchedAt: 1_000,
+    };
+    const committed = response('connection.models.fetch', committedResult);
+    assert.deepEqual(decodeHostFrame(committed), committed);
+
+    for (const result of [
+      { kind: 'failed', errorClass: 'timeout' },
+      { kind: 'rejected', reason: 'credential_not_configured' },
+      { kind: 'superseded', changed: ['credential', 'network_proxy'] },
+    ]) {
+      const frame = response('connection.models.fetch', result);
+      assert.deepEqual(decodeHostFrame(frame), frame);
+    }
+
+    assertInvalidResponse('connection.models.fetch', {
+      ...committedResult,
+      models: [{ id: 'secret-model-list' }],
+    });
+    assertInvalidResponse('connection.models.fetch', {
+      kind: 'failed',
+      errorClass: 'network',
+      message: 'raw provider response',
+    });
+    assertInvalidResponse('connection.models.fetch', {
+      kind: 'superseded',
+      changed: ['credential', 'credential'],
+    });
+  });
+
+  test('keeps one exact and bounded connection test projection', () => {
+    const verified = response('connection.test.run', {
+      kind: 'committed',
+      catalogRevision: 2,
+      connection: { ...EXPECTED, revision: 2 },
+      test: {
+        kind: 'verified',
+        checkedAt: '2026-07-29T00:00:00.000Z',
+        modelId: 'model-1',
+        latencyMs: 42,
+      },
+    });
+    const failedResult = {
+      kind: 'committed',
+      catalogRevision: 2,
+      connection: { ...EXPECTED, revision: 2 },
+      test: {
+        kind: 'failed',
+        checkedAt: '2026-07-29T00:00:00.000Z',
+        modelId: 'model-1',
+        latencyMs: 42,
+        statusCode: 401,
+        errorClass: 'auth',
+      },
+    };
+    const failed = response('connection.test.run', failedResult);
+    const invalidResponse = response('connection.test.run', {
+      ...failedResult,
+      test: {
+        ...failedResult.test,
+        statusCode: null,
+        errorClass: 'invalid_response',
+      },
+    });
+    assert.deepEqual(decodeHostFrame(verified), verified);
+    assert.deepEqual(decodeHostFrame(failed), failed);
+    assert.deepEqual(decodeHostFrame(invalidResponse), invalidResponse);
+
+    assertInvalidResponse('connection.test.run', {
+      ...failedResult,
+      summary: {
+        status: 'needs_reauth',
+        checkedAt: '2026-07-29T00:00:00.000Z',
+        errorClass: 'auth',
+      },
+    });
+    assertInvalidResponse('connection.test.run', {
+      ...failedResult,
+      test: { ...failedResult.test, providerBody: 'secret response' },
+    });
+    assertInvalidResponse('connection.test.run', {
+      ...failedResult,
+      test: { ...failedResult.test, modelId: 'x'.repeat(1_025) },
+    });
+    assertInvalidResponse('connection.test.run', {
+      ...failedResult,
+      test: { ...failedResult.test, statusCode: 600 },
+    });
+  });
+});
+
+function request(operation: string, input: unknown) {
+  return { requestId: 'request-1', operation, input };
+}
+
+function response(operation: string, result: unknown) {
+  return { requestId: 'request-1', operation, ok: true, result };
+}
+
+function assertInvalidRequest(operation: string, input: unknown): void {
+  assert.throws(() => decodeClientFrame(request(operation, input)), isInvalidFrame);
+}
+
+function assertInvalidResponse(operation: string, result: unknown): void {
+  assert.throws(() => decodeHostFrame(response(operation, result)), isInvalidFrame);
+}
+
+function isInvalidFrame(error: unknown): boolean {
+  return error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame';
+}

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -2,12 +2,14 @@ import assert from 'node:assert/strict';
 import { fork, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { appendFile, chmod, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import { createServer, type Server } from 'node:http';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import type { AgentRunHeader } from '@maka/core/agent-run';
 import type { MessageContent } from '@maka/core/events';
+import type { ConnectionCatalogEntry } from '@maka/core/runtime-policy';
 import type { StoredMessage } from '@maka/core/session';
 import type { Task } from '@maka/core/task-ledger';
 import { isTerminalRuntimeEvent } from '@maka/core/runtime-event';
@@ -25,6 +27,7 @@ import {
   openInteractiveExecutionStoresForRead,
   openInteractiveExecutionStoresForWrite,
 } from '@maka/storage/execution-stores';
+import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
 import {
   resolveRootControlNamespace,
   resolveStorageRoot,
@@ -44,6 +47,7 @@ import {
   decodeHostFrame,
   RUNTIME_HOST_PROTOCOL_VERSION,
   TASK_LEDGER_PAGE_MAX_ITEMS,
+  type ConnectionCatalogQueryResult,
   type InteractionPendingSnapshot,
   type SubscriptionFrame,
   type TaskLedgerQueryResult,
@@ -60,6 +64,10 @@ const CURRENT_PROTOCOL = {
   max: RUNTIME_HOST_PROTOCOL_VERSION,
 } as const;
 const PROCESS_TIMEOUT_MS = 10_000;
+const CONNECTION_EFFECT_MODEL_IDS = Array.from(
+  { length: 129 },
+  (_, index) => `connection-effect-model-${String(index + 1).padStart(3, '0')}`,
+);
 
 test('dual UDS Clients query persisted Task Ledger tool-port mutations across Host restart', async () => {
   await withExecutionRoot(async (fixture) => {
@@ -236,6 +244,116 @@ test('two UDS Clients share one Runtime Policy authority and CAS winner', async 
       await fixture.stopHost(host);
     }
   });
+});
+
+test('two UDS Clients run connection effects against one canonical catalog', async () => {
+  const provider = await startConnectionEffectProvider();
+  try {
+    await withExecutionRoot(async (fixture) => {
+      const secret = 'connection-effect-secret';
+      const connection = await fixture.seedConnectionEffect(provider.baseUrl, secret);
+      const host = await fixture.startHost();
+      const desktop = await connectClient(fixture.root, 'desktop');
+      const tui = await connectClient(fixture.root, 'tui');
+      try {
+        assert.equal(desktop.hostEpoch, tui.hostEpoch);
+        assert.notEqual(desktop.connectionId, tui.connectionId);
+        const fetchInput = { connectionId: connection.connectionId };
+        const fetched = await desktop.request('connection.models.fetch', {
+          ...fetchInput,
+        });
+        assert.equal(fetched.kind, 'committed');
+        if (fetched.kind !== 'committed') return;
+        assert.equal(fetched.modelCount, CONNECTION_EFFECT_MODEL_IDS.length);
+        assert.equal(fetched.source, 'fetched');
+
+        const firstPage = await tui.request('connection.catalog.query', { kind: 'start' });
+        assert.equal(firstPage.kind, 'page');
+        if (firstPage.kind !== 'page') return;
+        type CatalogPage = Extract<ConnectionCatalogQueryResult, { readonly kind: 'page' }>;
+        const pages: CatalogPage[] = [firstPage];
+        let observed: CatalogPage = firstPage;
+        while (observed.nextCursor) {
+          const nextResult: ConnectionCatalogQueryResult = await tui.request(
+            'connection.catalog.query',
+            {
+              kind: 'continue',
+              revision: observed.revision,
+              cursor: observed.nextCursor,
+            },
+          );
+          assert.equal(nextResult.kind, 'page');
+          if (nextResult.kind !== 'page') return;
+          pages.push(nextResult);
+          observed = nextResult;
+        }
+        assert.ok(pages.length > 1);
+        assert.ok(pages.every((page) => page.revision === fetched.catalogRevision));
+        assert.deepEqual(
+          pages.flatMap((page) =>
+            page.items.flatMap((item) => (item.kind === 'model' ? [item.model.id] : [])),
+          ),
+          CONNECTION_EFFECT_MODEL_IDS,
+        );
+
+        const testInput = {
+          connectionId: connection.connectionId,
+          modelId: CONNECTION_EFFECT_MODEL_IDS[0]!,
+        };
+        const tested = await tui.request('connection.test.run', {
+          ...testInput,
+        });
+        assert.equal(tested.kind, 'committed');
+        if (tested.kind !== 'committed') return;
+        assert.equal(tested.test.kind, 'verified');
+
+        const canonical = await desktop.request('connection.catalog.query', { kind: 'start' });
+        assert.equal(canonical.kind, 'page');
+        if (canonical.kind !== 'page') return;
+        const header = canonical.items.find(
+          (item) => item.kind === 'connection' && item.connectionId === connection.connectionId,
+        );
+        assert.equal(header?.kind, 'connection');
+        if (header?.kind === 'connection') {
+          assert.deepEqual(header.lastTest, {
+            status: 'verified',
+            checkedAt: tested.test.checkedAt,
+          });
+        }
+        assert.equal(
+          JSON.stringify([fetchInput, fetched, pages, testInput, tested, canonical]).includes(
+            secret,
+          ),
+          false,
+        );
+        assert.equal(provider.requests.length, 2);
+        assert.ok(
+          provider.requests.every(({ authorization }) => authorization === `Bearer ${secret}`),
+        );
+        assert.deepEqual(
+          provider.requests.map(({ method, url }) => ({
+            method,
+            url,
+          })),
+          [
+            {
+              method: 'GET',
+              url: '/v1/models',
+            },
+            {
+              method: 'POST',
+              url: '/v1/chat/completions',
+            },
+          ],
+        );
+      } finally {
+        await Promise.allSettled([desktop.close(), tui.close()]);
+        await fixture.stopHost(host);
+      }
+    });
+  } finally {
+    await provider.close();
+  }
 });
 
 test('two Clients share one execution after the starting Client disconnects', async () => {
@@ -1921,6 +2039,49 @@ class ExecutionFixture {
     }
   }
 
+  async seedConnectionEffect(baseUrl: string, secret: string): Promise<ConnectionCatalogEntry> {
+    const owner = await tryAcquireInteractiveRootOwner(this.capability);
+    assert.ok(owner);
+    if (!owner) throw new Error('Unable to acquire execution root for connection effect setup');
+    try {
+      const stores = await openInteractiveRuntimePolicyStoresForWrite(owner.lease);
+      const current = await stores.connectionCatalog.getSnapshot();
+      const created = await stores.connectionCatalog.create({
+        expectedCatalogRevision: current.revision,
+        connection: {
+          slug: 'connection-effect-provider',
+          name: 'Connection effect provider',
+          providerType: 'moonshot',
+          baseUrl,
+          enabled: true,
+          enabledModelIds: [CONNECTION_EFFECT_MODEL_IDS[0]!],
+        },
+      });
+      assert.equal(created.kind, 'committed');
+      if (created.kind !== 'committed') {
+        throw new Error('Connection effect setup did not create a connection');
+      }
+      const connection = created.snapshot.connections.find(
+        ({ slug }) => slug === 'connection-effect-provider',
+      );
+      assert.ok(connection);
+      if (!connection) throw new Error('Connection effect setup omitted its connection');
+      const credential = await stores.credentialVault.set({
+        locator: {
+          scope: 'connection',
+          connectionId: connection.connectionId,
+          kind: 'api_key',
+        },
+        expected: null,
+        secret,
+      });
+      assert.equal(credential.kind, 'committed');
+      return connection;
+    } finally {
+      await owner.close();
+    }
+  }
+
   seedRunWithoutUserMessage(
     turnId: string,
     content: string | MessageContent,
@@ -2188,6 +2349,59 @@ async function connectClient(
   });
   assert.equal(result.kind, 'connected');
   return result.connection;
+}
+
+async function startConnectionEffectProvider(): Promise<{
+  readonly baseUrl: string;
+  readonly requests: Array<{
+    readonly method: string;
+    readonly url: string;
+    readonly authorization: string | undefined;
+  }>;
+  close(): Promise<void>;
+}> {
+  const requests: Array<{
+    method: string;
+    url: string;
+    authorization: string | undefined;
+  }> = [];
+  const server = createServer((request, response) => {
+    requests.push({
+      method: request.method ?? '',
+      url: request.url ?? '',
+      authorization: request.headers.authorization,
+    });
+    response.statusCode = 200;
+    response.setHeader('content-type', 'application/json');
+    response.end(
+      request.method === 'GET'
+        ? JSON.stringify({ data: CONNECTION_EFFECT_MODEL_IDS.map((id) => ({ id })) })
+        : JSON.stringify({ choices: [] }),
+    );
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      server.off('error', reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (!address || typeof address === 'string') {
+    await closeHttpServer(server);
+    throw new Error('Connection effect provider did not bind a TCP address');
+  }
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}/v1`,
+    requests,
+    close: () => closeHttpServer(server),
+  };
+}
+
+function closeHttpServer(server: Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
 }
 
 async function sendStartWithoutReadingResponse(

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -246,8 +246,8 @@ test('two UDS Clients share one Runtime Policy authority and CAS winner', async 
   });
 });
 
-test('two UDS Clients run connection effects against one canonical catalog', async () => {
-  const provider = await startConnectionEffectProvider();
+test('two UDS Clients await slow connection effects against one canonical catalog', async () => {
+  const provider = await startConnectionEffectProvider({ responseDelayMs: 2_100 });
   try {
     await withExecutionRoot(async (fixture) => {
       const secret = 'connection-effect-secret';
@@ -2351,7 +2351,7 @@ async function connectClient(
   return result.connection;
 }
 
-async function startConnectionEffectProvider(): Promise<{
+async function startConnectionEffectProvider(options: { responseDelayMs?: number } = {}): Promise<{
   readonly baseUrl: string;
   readonly requests: Array<{
     readonly method: string;
@@ -2371,13 +2371,21 @@ async function startConnectionEffectProvider(): Promise<{
       url: request.url ?? '',
       authorization: request.headers.authorization,
     });
-    response.statusCode = 200;
-    response.setHeader('content-type', 'application/json');
-    response.end(
-      request.method === 'GET'
-        ? JSON.stringify({ data: CONNECTION_EFFECT_MODEL_IDS.map((id) => ({ id })) })
-        : JSON.stringify({ choices: [] }),
-    );
+    const respond = () => {
+      response.statusCode = 200;
+      response.setHeader('content-type', 'application/json');
+      response.end(
+        request.method === 'GET'
+          ? JSON.stringify({ data: CONNECTION_EFFECT_MODEL_IDS.map((id) => ({ id })) })
+          : JSON.stringify({ choices: [] }),
+      );
+    };
+    const responseDelayMs = options.responseDelayMs ?? 0;
+    if (responseDelayMs > 0) {
+      setTimeout(respond, responseDelayMs);
+    } else {
+      respond();
+    }
   });
   await new Promise<void>((resolve, reject) => {
     server.once('error', reject);

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -52,6 +52,8 @@ describe('Runtime Host bootstrap protocol', () => {
       'connection.catalog.remove',
       'connection.catalog.set-default-target',
       'connection.catalog.update',
+      'connection.models.fetch',
+      'connection.test.run',
       'credential.vault.delete',
       'credential.vault.query',
       'credential.vault.set',

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -38,6 +38,7 @@ import {
 
 const DEFAULT_CONNECT_TIMEOUT_MS = 500;
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 2_000;
+const DEFAULT_REQUEST_TIMEOUT_MS = 2_000;
 
 export interface ConnectRuntimeHostInput {
   rootPath: string;
@@ -138,7 +139,7 @@ interface PendingRequest {
   accept(value: unknown): unknown;
   resolve(value: unknown): void;
   reject(error: Error): void;
-  timer: NodeJS.Timeout;
+  timer?: NodeJS.Timeout;
 }
 
 class RuntimeHostConnectionImpl implements RuntimeHostConnection {
@@ -171,28 +172,37 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   request<K extends DirectRequestOperationKey>(
     operation: K,
     input: OperationInput<K>,
-    timeoutMs = DEFAULT_HANDSHAKE_TIMEOUT_MS,
+    timeoutMs?: number,
   ): Promise<OperationOutput<K>> {
-    return this.#requestOperation(operation, input, timeoutMs, (result) => result);
+    return this.#requestOperation(
+      operation,
+      input,
+      timeoutMs ?? defaultRequestTimeoutMs(operation),
+      (result) => result,
+    );
   }
 
   #requestOperation<K extends OperationKey, Result>(
     operation: K,
     input: OperationInput<K>,
-    timeoutMs: number,
+    timeoutMs: number | undefined,
     accept: (result: OperationOutput<K>) => Result,
   ): Promise<Result> {
-    const boundedTimeoutMs = requireTimeout(timeoutMs, 'timeoutMs');
+    const boundedTimeoutMs =
+      timeoutMs === undefined ? undefined : requireTimeout(timeoutMs, 'timeoutMs');
     if (this.#terminalError) return Promise.reject(this.#terminalError);
     const requestId = randomUUID();
     const result = new Promise<Result>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        const error = new RuntimeHostTransportError(
-          'read_timeout',
-          `Timed out waiting for Runtime Host ${operation} response`,
-        );
-        this.#fail(error);
-      }, boundedTimeoutMs);
+      const timer =
+        boundedTimeoutMs === undefined
+          ? undefined
+          : setTimeout(() => {
+              const error = new RuntimeHostTransportError(
+                'read_timeout',
+                `Timed out waiting for Runtime Host ${operation} response`,
+              );
+              this.#fail(error);
+            }, boundedTimeoutMs);
       this.#pendingRequests.set(requestId, {
         operation,
         accept: (value) => accept(value as OperationOutput<K>),
@@ -295,7 +305,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
       return;
     }
     this.#pendingRequests.delete(frame.requestId);
-    clearTimeout(pending.timer);
+    if (pending.timer) clearTimeout(pending.timer);
     if (frame.ok) {
       try {
         pending.resolve(pending.accept(frame.result));
@@ -372,7 +382,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     if (this.#terminalError) return;
     this.#terminalError = error;
     for (const pending of this.#pendingRequests.values()) {
-      clearTimeout(pending.timer);
+      if (pending.timer) clearTimeout(pending.timer);
       pending.reject(error);
     }
     this.#pendingRequests.clear();
@@ -586,6 +596,17 @@ function requireTimeout(value: number, label: string): number {
     throw new RangeError(`${label} must be an integer between 1 and 120000`);
   }
   return value;
+}
+
+function defaultRequestTimeoutMs(operation: DirectRequestOperationKey): number | undefined {
+  switch (operation) {
+    case 'connection.models.fetch':
+    case 'connection.test.run':
+      // Completion effects own provider deadlines and may wait behind same-connection FIFO work.
+      return undefined;
+    default:
+      return DEFAULT_REQUEST_TIMEOUT_MS;
+  }
 }
 
 interface PhaseDeadline {

--- a/packages/runtime-host/src/protocol/connection-effects.ts
+++ b/packages/runtime-host/src/protocol/connection-effects.ts
@@ -1,0 +1,332 @@
+import {
+  CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION,
+  decodeConnectionModelId,
+  decodeConnectionTestSummary,
+  decodeConnectionVersionBasis,
+  RuntimePolicyDomainDecodeError,
+  type ConnectionVersionBasis,
+  type ModelDiscoverySource,
+} from '@maka/core/runtime-policy';
+import { requireCount, requireEntityId, requireExactRecord, requireRecord } from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+const EFFECT_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'invalid_request',
+  'internal_failure',
+  'persistence_failed',
+  'commit_outcome_unknown',
+] as const;
+
+export const CONNECTION_EFFECT_CHANGED_DOMAINS = [
+  'connection',
+  'credential',
+  'network_proxy',
+] as const;
+export type ConnectionEffectChangedDomain = (typeof CONNECTION_EFFECT_CHANGED_DOMAINS)[number];
+
+export const CONNECTION_EFFECT_REJECTION_REASONS = [
+  'connection_not_found',
+  'connection_disabled',
+  'provider_action_unavailable',
+  'credential_not_configured',
+] as const;
+export type ConnectionEffectRejectionReason = (typeof CONNECTION_EFFECT_REJECTION_REASONS)[number];
+
+export const CONNECTION_EFFECT_FAILURE_CLASSES = [
+  'auth',
+  'timeout',
+  'provider_unavailable',
+  'network',
+  'invalid_response',
+  'unknown',
+] as const;
+export type ConnectionEffectFailureClass = (typeof CONNECTION_EFFECT_FAILURE_CLASSES)[number];
+
+export interface ConnectionModelFetchInput {
+  readonly connectionId: string;
+}
+
+export interface ConnectionTestRunInput {
+  readonly connectionId: string;
+  readonly modelId: string | null;
+}
+
+interface ConnectionEffectCommitted {
+  readonly kind: 'committed';
+  readonly catalogRevision: number;
+  readonly connection: ConnectionVersionBasis;
+}
+
+interface ConnectionEffectRejected {
+  readonly kind: 'rejected';
+  readonly reason: ConnectionEffectRejectionReason;
+}
+
+interface ConnectionEffectSuperseded {
+  readonly kind: 'superseded';
+  readonly changed: readonly ConnectionEffectChangedDomain[];
+}
+
+interface ConnectionEffectFailed {
+  readonly kind: 'failed';
+  readonly errorClass: ConnectionEffectFailureClass;
+}
+
+export type ConnectionModelFetchResult =
+  | (ConnectionEffectCommitted & {
+      readonly modelCount: number;
+      readonly source: ModelDiscoverySource;
+      readonly fetchedAt: number;
+    })
+  | ConnectionEffectRejected
+  | ConnectionEffectSuperseded
+  | ConnectionEffectFailed;
+
+export type ConnectionTestProjection =
+  | {
+      readonly kind: 'verified';
+      readonly checkedAt: string;
+      readonly modelId: string;
+      readonly latencyMs: number;
+    }
+  | {
+      readonly kind: 'failed';
+      readonly checkedAt: string;
+      readonly modelId: string | null;
+      readonly latencyMs: number | null;
+      readonly statusCode: number | null;
+      readonly errorClass: ConnectionEffectFailureClass;
+    };
+
+export type ConnectionTestRunResult =
+  | (ConnectionEffectCommitted & {
+      readonly test: ConnectionTestProjection;
+    })
+  | ConnectionEffectRejected
+  | ConnectionEffectSuperseded;
+
+export const CONNECTION_EFFECT_OPERATION_SPECS = {
+  'connection.models.fetch': defineOperation<
+    ConnectionModelFetchInput,
+    ConnectionModelFetchResult,
+    (typeof EFFECT_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: EFFECT_ERRORS,
+    decodeInput: decodeConnectionModelFetchInput,
+    decodeOutput: decodeConnectionModelFetchResult,
+  }),
+  'connection.test.run': defineOperation<
+    ConnectionTestRunInput,
+    ConnectionTestRunResult,
+    (typeof EFFECT_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: EFFECT_ERRORS,
+    decodeInput: decodeConnectionTestRunInput,
+    decodeOutput: decodeConnectionTestRunResult,
+  }),
+} as const;
+
+export function decodeConnectionModelFetchInput(value: unknown): ConnectionModelFetchInput {
+  const input = requireExactRecord(value, 'connection model fetch input', ['connectionId']);
+  return { connectionId: requireEntityId(input.connectionId, 'connectionId') };
+}
+
+export function decodeConnectionTestRunInput(value: unknown): ConnectionTestRunInput {
+  const input = requireExactRecord(value, 'connection test input', ['connectionId', 'modelId']);
+  return {
+    connectionId: requireEntityId(input.connectionId, 'connectionId'),
+    modelId:
+      input.modelId === null ? null : decodeDomain(() => decodeConnectionModelId(input.modelId)),
+  };
+}
+
+export function decodeConnectionModelFetchResult(value: unknown): ConnectionModelFetchResult {
+  const result = requireRecord(value, 'connection model fetch result');
+  if (result.kind === 'committed') {
+    const committed = requireExactRecord(result, 'connection model fetch committed result', [
+      'kind',
+      'catalogRevision',
+      'connection',
+      'modelCount',
+      'source',
+      'fetchedAt',
+    ]);
+    return {
+      ...decodeCommitted(committed, 'connection model fetch committed result'),
+      modelCount: boundedInteger(
+        committed.modelCount,
+        'model count',
+        1,
+        CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION,
+      ),
+      source: modelDiscoverySource(committed.source),
+      fetchedAt: requireCount(committed.fetchedAt, 'models fetched at'),
+    };
+  }
+  if (result.kind === 'failed') {
+    const failed = requireExactRecord(result, 'connection model fetch failed result', [
+      'kind',
+      'errorClass',
+    ]);
+    return { kind: 'failed', errorClass: effectFailureClass(failed.errorClass) };
+  }
+  return decodeNonEffectResult(result, 'connection model fetch result');
+}
+
+export function decodeConnectionTestRunResult(value: unknown): ConnectionTestRunResult {
+  const result = requireRecord(value, 'connection test result');
+  if (result.kind === 'committed') {
+    const committed = requireExactRecord(result, 'connection test committed result', [
+      'kind',
+      'catalogRevision',
+      'connection',
+      'test',
+    ]);
+    return {
+      ...decodeCommitted(committed, 'connection test committed result'),
+      test: decodeConnectionTestProjection(committed.test),
+    };
+  }
+  return decodeNonEffectResult(result, 'connection test result');
+}
+
+function decodeConnectionTestProjection(value: unknown): ConnectionTestProjection {
+  const projection = requireRecord(value, 'connection test projection');
+  if (projection.kind === 'verified') {
+    const verified = requireExactRecord(projection, 'verified connection test projection', [
+      'kind',
+      'checkedAt',
+      'modelId',
+      'latencyMs',
+    ]);
+    return {
+      kind: 'verified',
+      checkedAt: connectionTestCheckedAt(verified.checkedAt),
+      modelId: decodeDomain(() => decodeConnectionModelId(verified.modelId)),
+      latencyMs: requireCount(verified.latencyMs, 'connection test latency'),
+    };
+  }
+  const failed = requireExactRecord(projection, 'failed connection test projection', [
+    'kind',
+    'checkedAt',
+    'modelId',
+    'latencyMs',
+    'statusCode',
+    'errorClass',
+  ]);
+  if (failed.kind !== 'failed') throw invalidProtocolFrame('Invalid connection test projection');
+  return {
+    kind: 'failed',
+    checkedAt: connectionTestCheckedAt(failed.checkedAt),
+    modelId:
+      failed.modelId === null ? null : decodeDomain(() => decodeConnectionModelId(failed.modelId)),
+    latencyMs:
+      failed.latencyMs === null ? null : requireCount(failed.latencyMs, 'connection test latency'),
+    statusCode:
+      failed.statusCode === null
+        ? null
+        : boundedInteger(failed.statusCode, 'connection test status code', 100, 599),
+    errorClass: effectFailureClass(failed.errorClass),
+  };
+}
+
+function connectionTestCheckedAt(value: unknown): string {
+  return decodeDomain(() => decodeConnectionTestSummary({ status: 'verified', checkedAt: value }))
+    .checkedAt;
+}
+
+function decodeCommitted(value: Record<string, unknown>, label: string): ConnectionEffectCommitted {
+  if (value.kind !== 'committed') throw invalidProtocolFrame(`Invalid ${label}`);
+  return {
+    kind: 'committed',
+    catalogRevision: requireCount(value.catalogRevision, 'connection catalog revision'),
+    connection: decodeDomain(() => decodeConnectionVersionBasis(value.connection)),
+  };
+}
+
+function decodeNonEffectResult(
+  value: Record<string, unknown>,
+  label: string,
+): ConnectionEffectRejected | ConnectionEffectSuperseded {
+  if (value.kind === 'rejected') {
+    const rejected = requireExactRecord(value, label, ['kind', 'reason']);
+    return { kind: 'rejected', reason: rejectionReason(rejected.reason) };
+  }
+  if (value.kind === 'superseded') {
+    const superseded = requireExactRecord(value, label, ['kind', 'changed']);
+    if (
+      !Array.isArray(superseded.changed) ||
+      superseded.changed.length === 0 ||
+      superseded.changed.length > CONNECTION_EFFECT_CHANGED_DOMAINS.length
+    ) {
+      throw invalidProtocolFrame('Invalid connection effect changed domains');
+    }
+    const changed = superseded.changed.map(effectChangedDomain);
+    if (new Set(changed).size !== changed.length) {
+      throw invalidProtocolFrame('Duplicate connection effect changed domain');
+    }
+    return { kind: 'superseded', changed };
+  }
+  throw invalidProtocolFrame(`Invalid ${label}`);
+}
+
+function rejectionReason(value: unknown): ConnectionEffectRejectionReason {
+  if (
+    typeof value === 'string' &&
+    (CONNECTION_EFFECT_REJECTION_REASONS as readonly string[]).includes(value)
+  ) {
+    return value as ConnectionEffectRejectionReason;
+  }
+  throw invalidProtocolFrame('Invalid connection effect rejection reason');
+}
+
+function effectChangedDomain(value: unknown): ConnectionEffectChangedDomain {
+  if (
+    typeof value === 'string' &&
+    (CONNECTION_EFFECT_CHANGED_DOMAINS as readonly string[]).includes(value)
+  ) {
+    return value as ConnectionEffectChangedDomain;
+  }
+  throw invalidProtocolFrame('Invalid connection effect changed domain');
+}
+
+function effectFailureClass(value: unknown): ConnectionEffectFailureClass {
+  if (
+    typeof value === 'string' &&
+    (CONNECTION_EFFECT_FAILURE_CLASSES as readonly string[]).includes(value)
+  ) {
+    return value as ConnectionEffectFailureClass;
+  }
+  throw invalidProtocolFrame('Invalid connection effect failure class');
+}
+
+function modelDiscoverySource(value: unknown): ModelDiscoverySource {
+  if (value === 'fetched' || value === 'fallback') return value;
+  throw invalidProtocolFrame('Invalid model discovery source');
+}
+
+function boundedInteger(value: unknown, label: string, min: number, max: number): number {
+  if (!Number.isSafeInteger(value) || (value as number) < min || (value as number) > max) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value as number;
+}
+
+function decodeDomain<T>(operation: () => T): T {
+  try {
+    return operation();
+  } catch (error) {
+    if (error instanceof RuntimePolicyDomainDecodeError) {
+      throw invalidProtocolFrame(error.message);
+    }
+    throw error;
+  }
+}

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -1,5 +1,6 @@
 import { ARTIFACT_OPERATION_SPECS } from './artifact.js';
 import { requireExactRecord, requireId, requireRecord, requireString } from './codec.js';
+import { CONNECTION_EFFECT_OPERATION_SPECS } from './connection-effects.js';
 import { invalidProtocolFrame } from './errors.js';
 import { HOST_STATUS_OPERATION_SPECS } from './host-status.js';
 import { INTERACTION_OPERATION_SPECS } from './interaction.js';
@@ -69,6 +70,7 @@ export type {
   TurnStartInput,
   TurnStopInput,
 } from './turn.js';
+export * from './connection-effects.js';
 export * from './runtime-policy.js';
 export * from './skill-catalog.js';
 
@@ -77,8 +79,13 @@ const HOST_AND_TURN_OPERATION_SPECS = composeOperationSpecMaps(
   TURN_OPERATION_SPECS,
 );
 
-const CORE_OPERATION_SPECS = composeOperationSpecMaps(
+const CORE_AND_CONNECTION_EFFECT_OPERATION_SPECS = composeOperationSpecMaps(
   HOST_AND_TURN_OPERATION_SPECS,
+  CONNECTION_EFFECT_OPERATION_SPECS,
+);
+
+const CORE_OPERATION_SPECS = composeOperationSpecMaps(
+  CORE_AND_CONNECTION_EFFECT_OPERATION_SPECS,
   RUNTIME_POLICY_OPERATION_SPECS,
 );
 

--- a/packages/runtime-host/src/server/connection-effect-coordinator.ts
+++ b/packages/runtime-host/src/server/connection-effect-coordinator.ts
@@ -1,0 +1,392 @@
+import type {
+  ConnectionCatalogEntry,
+  ConnectionModelDiscoveryResult,
+  ConnectionTestErrorClass,
+  ConnectionTestSummary,
+  RuntimePolicy,
+} from '@maka/core/runtime-policy';
+import {
+  createConnectionEffectFetchTransport,
+  runConnectionModelDiscoveryEffect,
+  runConnectionTestEffect,
+  type ConnectionEffectErrorKind,
+  type ConnectionEffectFetchDependency,
+  type ConnectionEffectFetchTransport,
+  type ConnectionEffectProxySnapshot,
+  type ConnectionModelDiscoveryEffectOutcome,
+  type ConnectionTestEffectOutcome,
+} from '@maka/runtime';
+import {
+  authenticateRuntimePolicyStoresWriter,
+  RuntimePolicyStoreError,
+  type BeginConnectionTestResult,
+  type BeginModelFetchResult,
+  type ConnectionEffectCompletionResult,
+  type RuntimePolicyOperationSecretMaterial,
+  type RuntimePolicyStoresWriter,
+} from '@maka/storage/runtime-policy-stores';
+import type {
+  ConnectionEffectChangedDomain,
+  ConnectionEffectFailureClass,
+  ConnectionEffectRejectionReason,
+  ConnectionModelFetchInput,
+  ConnectionModelFetchResult,
+  ConnectionTestProjection,
+  ConnectionTestRunInput,
+  ConnectionTestRunResult,
+  OperationOutcome,
+} from '../protocol/index.js';
+import type { ConnectionEffectOperationHandlerMap } from './operation-dispatcher.js';
+import { RuntimePolicyActivationGate } from './runtime-policy-activation-gate.js';
+
+type ModelDiscoveryRunner = (
+  connection: ConnectionCatalogEntry,
+  apiKey: string,
+  options: ConnectionEffectFetchDependency,
+) => Promise<ConnectionModelDiscoveryEffectOutcome>;
+
+type ConnectionTestRunner = (
+  connection: ConnectionCatalogEntry,
+  apiKey: string,
+  options: ConnectionEffectFetchDependency,
+  modelId?: string,
+) => Promise<ConnectionTestEffectOutcome>;
+
+export interface HostConnectionEffectCoordinatorOptions {
+  readonly stores: RuntimePolicyStoresWriter;
+  readonly activation: RuntimePolicyActivationGate;
+  readonly onCommittedMutation?: () => Promise<void>;
+  readonly now?: () => number;
+  readonly runModelDiscovery?: ModelDiscoveryRunner;
+  readonly runConnectionTest?: ConnectionTestRunner;
+  readonly createTransport?: (
+    proxy: ConnectionEffectProxySnapshot | null,
+  ) => ConnectionEffectFetchTransport;
+}
+
+/** Runs provider I/O outside Storage lanes and conditionally commits canonical results. */
+export class HostConnectionEffectCoordinator {
+  readonly handlers: ConnectionEffectOperationHandlerMap = {
+    'connection.models.fetch': (input) => this.#fetchModels(input),
+    'connection.test.run': (input) => this.#testConnection(input),
+  };
+
+  readonly #stores: RuntimePolicyStoresWriter;
+  readonly #activation: RuntimePolicyActivationGate;
+  readonly #onCommittedMutation: () => Promise<void>;
+  readonly #now: () => number;
+  readonly #runModelDiscovery: ModelDiscoveryRunner;
+  readonly #runConnectionTest: ConnectionTestRunner;
+  readonly #createTransport: (
+    proxy: ConnectionEffectProxySnapshot | null,
+  ) => ConnectionEffectFetchTransport;
+  readonly #tails = new Map<string, Promise<void>>();
+  #accepting = true;
+  #closePromise: Promise<void> | undefined;
+
+  constructor(options: HostConnectionEffectCoordinatorOptions) {
+    this.#stores = authenticateRuntimePolicyStoresWriter(options.stores);
+    this.#activation = options.activation;
+    this.#onCommittedMutation = options.onCommittedMutation ?? (async () => {});
+    this.#now = options.now ?? Date.now;
+    this.#runModelDiscovery = options.runModelDiscovery ?? runConnectionModelDiscoveryEffect;
+    this.#runConnectionTest = options.runConnectionTest ?? runConnectionTestEffect;
+    this.#createTransport = options.createTransport ?? createConnectionEffectFetchTransport;
+  }
+
+  beginDrain(): void {
+    this.#accepting = false;
+  }
+
+  close(): Promise<void> {
+    if (this.#closePromise) return this.#closePromise;
+    this.beginDrain();
+    this.#closePromise = Promise.all([...this.#tails.values()]).then(() => undefined);
+    return this.#closePromise;
+  }
+
+  #fetchModels(
+    input: ConnectionModelFetchInput,
+  ): Promise<OperationOutcome<'connection.models.fetch'>> {
+    return this.#admit(input.connectionId, 'connection.models.fetch', async () => {
+      const prepared = await this.#stores.operations.beginModelFetch(input.connectionId);
+      if (prepared.kind !== 'ready') return preparationResult(prepared);
+
+      const effect = await this.#withTransport(prepared, (fetch) =>
+        this.#runModelDiscovery(prepared.connection, connectionSecret(prepared.secretMaterial), {
+          fetch,
+        }),
+      );
+      if (!effect.ok || effect.models.length === 0) {
+        return {
+          kind: 'failed',
+          errorClass: effect.ok ? 'invalid_response' : effect.error.kind,
+        };
+      }
+
+      const result: ConnectionModelDiscoveryResult = {
+        models: effect.models,
+        source: 'fetched',
+        fetchedAt: this.#now(),
+      };
+      const completion = await this.#complete(() =>
+        this.#stores.operations.completeModelFetch(prepared.ticket, result),
+      );
+      return completion.kind === 'committed'
+        ? {
+            kind: 'committed',
+            catalogRevision: completion.snapshot.revision,
+            connection: committedConnectionBasis(
+              completion.snapshot.connections,
+              prepared.connection.connectionId,
+            ),
+            modelCount: result.models.length,
+            source: result.source,
+            fetchedAt: result.fetchedAt,
+          }
+        : projectSuperseded(completion);
+    });
+  }
+
+  #testConnection(input: ConnectionTestRunInput): Promise<OperationOutcome<'connection.test.run'>> {
+    return this.#admit(input.connectionId, 'connection.test.run', async () => {
+      const prepared = await this.#stores.operations.beginConnectionTest(
+        input.connectionId,
+        input.modelId,
+      );
+      if (prepared.kind !== 'ready') return preparationResult(prepared);
+
+      const effect = await this.#withTransport(prepared, (fetch) =>
+        this.#runConnectionTest(
+          prepared.connection,
+          connectionSecret(prepared.secretMaterial),
+          { fetch },
+          prepared.modelId ?? undefined,
+        ),
+      );
+      const projected = projectConnectionTest(effect, this.#now());
+      const completion = await this.#complete(() =>
+        this.#stores.operations.completeConnectionTest(
+          prepared.ticket,
+          connectionTestSummary(projected),
+        ),
+      );
+      return completion.kind === 'committed'
+        ? {
+            kind: 'committed',
+            catalogRevision: completion.snapshot.revision,
+            connection: committedConnectionBasis(
+              completion.snapshot.connections,
+              prepared.connection.connectionId,
+            ),
+            test: projected,
+          }
+        : projectSuperseded(completion);
+    });
+  }
+
+  #admit<K extends 'connection.models.fetch' | 'connection.test.run'>(
+    connectionId: string,
+    operation: K,
+    run: () => Promise<Extract<OperationOutcome<K>, { ok: true }>['result']>,
+  ): Promise<OperationOutcome<K>> {
+    if (!this.#accepting) {
+      return Promise.resolve({
+        ok: false,
+        error: { code: 'host_draining', message: 'Runtime Host is draining' },
+      } as OperationOutcome<K>);
+    }
+    return this.#enqueue(connectionId, async () => {
+      try {
+        return { ok: true, result: await run() } as OperationOutcome<K>;
+      } catch (error) {
+        return storeFailure<K>(error);
+      }
+    });
+  }
+
+  async #withTransport<T>(
+    prepared: Pick<
+      BeginModelFetchReady | BeginConnectionTestReady,
+      'networkProxy' | 'secretMaterial'
+    >,
+    run: (fetch: typeof globalThis.fetch) => Promise<T>,
+  ): Promise<T> {
+    const transport = this.#createTransport(
+      toProxySnapshot(prepared.networkProxy, prepared.secretMaterial),
+    );
+    try {
+      return await run(transport.fetch);
+    } finally {
+      await transport.close();
+    }
+  }
+
+  async #complete(
+    commit: () => Promise<ConnectionEffectCompletionResult>,
+  ): Promise<ConnectionEffectCompletionResult> {
+    return this.#activation.runMutation(async () => {
+      try {
+        const result = await commit();
+        if (result.kind === 'committed') await this.#invalidateCommittedPolicy();
+        return result;
+      } catch (error) {
+        if (error instanceof RuntimePolicyStoreError && error.code === 'commit_outcome_unknown') {
+          await this.#invalidateCommittedPolicy();
+        }
+        throw error;
+      }
+    });
+  }
+
+  async #invalidateCommittedPolicy(): Promise<void> {
+    try {
+      await this.#onCommittedMutation();
+    } catch {
+      this.#activation.poison();
+    }
+  }
+
+  #enqueue<T>(connectionId: string, run: () => Promise<T>): Promise<T> {
+    const previous = this.#tails.get(connectionId) ?? Promise.resolve();
+    const pending = previous.then(run, run);
+    const tail = pending.then(
+      () => undefined,
+      () => undefined,
+    );
+    this.#tails.set(connectionId, tail);
+    void tail.finally(() => {
+      if (this.#tails.get(connectionId) === tail) this.#tails.delete(connectionId);
+    });
+    return pending;
+  }
+}
+
+type BeginModelFetchReady = Extract<BeginModelFetchResult, { readonly kind: 'ready' }>;
+type BeginConnectionTestReady = Extract<BeginConnectionTestResult, { readonly kind: 'ready' }>;
+
+function preparationResult(
+  prepared: Exclude<BeginModelFetchResult, { readonly kind: 'ready' }>,
+): Extract<ConnectionModelFetchResult, { readonly kind: 'rejected' }>;
+function preparationResult(
+  prepared: Exclude<BeginConnectionTestResult, { readonly kind: 'ready' }>,
+): Extract<ConnectionTestRunResult, { readonly kind: 'rejected' }>;
+function preparationResult(
+  prepared: Exclude<BeginModelFetchResult | BeginConnectionTestResult, { readonly kind: 'ready' }>,
+): Extract<ConnectionModelFetchResult, { readonly kind: 'rejected' }> {
+  return {
+    kind: 'rejected',
+    reason: prepared.kind satisfies ConnectionEffectRejectionReason,
+  };
+}
+
+function projectSuperseded(
+  completion: Extract<ConnectionEffectCompletionResult, { readonly kind: 'superseded' }>,
+): Extract<ConnectionModelFetchResult | ConnectionTestRunResult, { readonly kind: 'superseded' }> {
+  return {
+    kind: 'superseded',
+    changed: completion.changed.map((domain) => domain satisfies ConnectionEffectChangedDomain),
+  };
+}
+
+function connectionSecret(material: RuntimePolicyOperationSecretMaterial): string {
+  return material.connection?.secret ?? '';
+}
+
+function toProxySnapshot(
+  proxy: RuntimePolicy['networkProxy'],
+  material: RuntimePolicyOperationSecretMaterial,
+): ConnectionEffectProxySnapshot | null {
+  if (!proxy.enabled) return null;
+  if (proxy.authEnabled && !material.networkProxy) {
+    throw new Error('Connection effect proxy admission omitted credential material');
+  }
+  return {
+    enabled: true,
+    type: proxy.protocol,
+    host: proxy.host,
+    port: proxy.port,
+    ...(proxy.authEnabled
+      ? {
+          username: proxy.username,
+          password: material.networkProxy!.secret,
+        }
+      : {}),
+    bypassList: [...new Set([...proxy.bypassList, ...proxy.autoBypassDomains])],
+  };
+}
+
+function projectConnectionTest(
+  outcome: ConnectionTestEffectOutcome,
+  checkedAt: number,
+): ConnectionTestProjection {
+  const checkedAtIso = new Date(checkedAt).toISOString();
+  if (outcome.ok) {
+    return {
+      kind: 'verified',
+      checkedAt: checkedAtIso,
+      modelId: outcome.modelId,
+      latencyMs: outcome.latencyMs,
+    };
+  }
+
+  return {
+    kind: 'failed',
+    checkedAt: checkedAtIso,
+    modelId: outcome.modelId ?? null,
+    latencyMs: outcome.latencyMs ?? null,
+    statusCode: outcome.error.statusCode ?? null,
+    errorClass: outcome.error.kind,
+  };
+}
+
+function connectionTestSummary(projection: ConnectionTestProjection): ConnectionTestSummary {
+  return projection.kind === 'verified'
+    ? { status: 'verified', checkedAt: projection.checkedAt }
+    : {
+        status: projection.errorClass === 'auth' ? 'needs_reauth' : 'error',
+        checkedAt: projection.checkedAt,
+        errorClass: toConnectionTestErrorClass(projection.errorClass),
+      };
+}
+
+function toConnectionTestErrorClass(kind: ConnectionEffectErrorKind): ConnectionTestErrorClass {
+  return kind === 'invalid_response' ? 'unknown' : kind;
+}
+
+function committedConnectionBasis(
+  connections: readonly ConnectionCatalogEntry[],
+  connectionId: string,
+) {
+  const connection = connections.find((candidate) => candidate.connectionId === connectionId);
+  if (!connection) throw new Error('Connection effect commit omitted its connection');
+  return { connectionId, revision: connection.revision };
+}
+
+function storeFailure<K extends 'connection.models.fetch' | 'connection.test.run'>(
+  error: unknown,
+): OperationOutcome<K> {
+  if (!(error instanceof RuntimePolicyStoreError)) throw error;
+  switch (error.code) {
+    case 'commit_outcome_unknown':
+      return operationFailure(
+        'commit_outcome_unknown',
+        'Connection effect commit outcome is unknown',
+      );
+    case 'io_failed':
+    case 'invalid_document':
+      return operationFailure('persistence_failed', 'Connection effect persistence failed');
+    case 'invalid_policy_input':
+    case 'invalid_connection_input':
+      return operationFailure('invalid_request', 'Connection effect request is invalid');
+    case 'invalid_credential_input':
+      throw new Error('Connection effect admitted an invalid credential operation');
+  }
+}
+
+function operationFailure<K extends 'connection.models.fetch' | 'connection.test.run'>(
+  code: 'commit_outcome_unknown' | 'persistence_failed' | 'invalid_request',
+  message: string,
+): OperationOutcome<K> {
+  return { ok: false, error: { code, message } } as OperationOutcome<K>;
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -15,6 +15,7 @@ import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledge
 import { CanonicalSessionProjectionReader } from './canonical-session-projection.js';
 import { HostCanonicalPermissionOutcomeReader } from './canonical-permission-outcome-reader.js';
 import { HostArtifactCoordinator } from './artifact-coordinator.js';
+import { HostConnectionEffectCoordinator } from './connection-effect-coordinator.js';
 import type { RuntimeHostComposition, RuntimeHostCompositionContext } from './host-kernel.js';
 import { HostInteractionCoordinator } from './interaction-coordinator.js';
 import { type HostMessageRootPort, HostMessageCoordinator } from './message-coordinator.js';
@@ -44,6 +45,14 @@ export async function createExecutionRuntimeHostComposition(
     const backends = new BackendRegistry();
     backends.register('fake', (backendContext) => new FakeBackend(backendContext));
     const runtimePolicyActivation = new RuntimePolicyActivationGate();
+    const invalidateRuntimePolicy = async () => {
+      try {
+        await manager.refreshIdleBackends();
+      } catch (error) {
+        context.requestDrain();
+        throw error;
+      }
+    };
     const sessionAdmission = new SessionAdmissionGate();
     const taskLedger = new HostTaskLedgerCoordinator(taskLedgerStore, sessionAdmission);
     const openedGraphControlStore = createAgentGraphControlStore(
@@ -113,6 +122,7 @@ export async function createExecutionRuntimeHostComposition(
       draining = true;
       messages.beginDrain();
       interactions.beginDrain();
+      connectionEffects.beginDrain();
       skills.beginDrain();
     };
     const interactions = new HostInteractionCoordinator({
@@ -188,21 +198,20 @@ export async function createExecutionRuntimeHostComposition(
     const runtimePolicy = new HostRuntimePolicyCoordinator(
       runtimePolicyStores,
       runtimePolicyActivation,
-      async () => {
-        try {
-          await manager.refreshIdleBackends();
-        } catch (error) {
-          context.requestDrain();
-          throw error;
-        }
-      },
+      invalidateRuntimePolicy,
     );
+    const connectionEffects = new HostConnectionEffectCoordinator({
+      stores: runtimePolicyStores,
+      activation: runtimePolicyActivation,
+      onCommittedMutation: invalidateRuntimePolicy,
+    });
     const artifacts = new HostArtifactCoordinator(openedArtifactStore, context.requestDrain);
     const handlers = {
       ...coordinator.handlers,
       ...messages.handlers,
       ...interactions.handlers,
       ...runtimePolicy.handlers,
+      ...connectionEffects.handlers,
       ...continuityCoordinator.handlers,
       ...taskLedger.handlers,
       ...artifacts.handlers,
@@ -234,6 +243,11 @@ export async function createExecutionRuntimeHostComposition(
         try {
           await recover();
           recovered = true;
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
+          await connectionEffects.close();
         } catch (error) {
           errors.push(error);
         }

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -39,6 +39,10 @@ export type RuntimePolicyOperationKey = Extract<
   OperationKey,
   `runtime.policy.${string}` | `connection.catalog.${string}` | `credential.vault.${string}`
 >;
+export type ConnectionEffectOperationKey = Extract<
+  OperationKey,
+  'connection.models.fetch' | 'connection.test.run'
+>;
 export type MessageOperationKey = Extract<
   OperationKey,
   'turn.message.submit' | 'queue.retract' | 'turn.interrupt'
@@ -54,6 +58,10 @@ export type SkillCatalogOperationKey = Extract<OperationKey, `skill.catalog.${st
 export type DomainOperationHandlerMap = Pick<OperationHandlerMap, DomainOperationKey>;
 export type TurnOperationHandlerMap = Pick<OperationHandlerMap, TurnOperationKey>;
 export type RuntimePolicyOperationHandlerMap = Pick<OperationHandlerMap, RuntimePolicyOperationKey>;
+export type ConnectionEffectOperationHandlerMap = Pick<
+  OperationHandlerMap,
+  ConnectionEffectOperationKey
+>;
 export type MessageOperationHandlerMap = Pick<OperationHandlerMap, MessageOperationKey>;
 export type InteractionOperationHandlerMap = Pick<OperationHandlerMap, InteractionOperationKey>;
 export type SessionContinuityOperationHandlerMap = Pick<

--- a/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
+++ b/packages/runtime/src/__tests__/claude-subscription-runtime.test.ts
@@ -11,20 +11,15 @@ describe('Claude subscription runtime wiring', () => {
   });
 
   test('testConnection never burns Claude OAuth quota with a synthetic messages probe', async () => {
-    const src = await readFile(new URL('../../src/test-connection.ts', import.meta.url), 'utf8');
-    const branchIdx = src.indexOf("connection.providerType === 'claude-subscription'");
-    assert.notEqual(branchIdx, -1, 'Claude OAuth test branch must exist');
-    const branchRegion = src.slice(
-      branchIdx,
-      src.indexOf('const r = await proxiedFetch', branchIdx),
-    );
-    assert.match(
-      branchRegion,
-      /return \{ ok: true, latencyMs: Date\.now\(\) - t0, modelTested: model \}/,
-      'Claude OAuth connection test should validate stored login presence without calling the chat endpoint',
-    );
-    assert.doesNotMatch(branchRegion, /anthropicV1Url\(baseUrl, '\/messages'\)/);
-    assert.doesNotMatch(branchRegion, /messages:\s*\[\{ role: 'user', content: 'Hi' \}\]/);
+    let requests = 0;
+    const result = await testConnection(claudeOAuthConnection(), 'oauth-access-token', undefined, {
+      fetch: async () => {
+        requests += 1;
+        throw new Error('Claude OAuth connection test must not issue a request');
+      },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(requests, 0);
   });
 
   test('model factory constructs Anthropic with authToken for claude-subscription', async () => {

--- a/packages/runtime/src/__tests__/model-fetcher.test.ts
+++ b/packages/runtime/src/__tests__/model-fetcher.test.ts
@@ -145,6 +145,150 @@ describe('fetchProviderModels', () => {
     assert.equal(requestCount, 41);
   });
 
+  test('Cohere accepts bounded multi-page discovery and rejects repeated tokens or excess entries', async () => {
+    const pages: string[] = [];
+    const normal = await startJsonServer((request, response) => {
+      const token = new URL(request.url ?? '', 'http://test.local').searchParams.get('page_token');
+      pages.push(token ?? 'first');
+      respondJson(
+        response,
+        200,
+        token
+          ? {
+              models: [
+                {
+                  name: 'command-r-plus',
+                  endpoints: ['chat'],
+                  context_length: 128_000,
+                },
+              ],
+            }
+          : {
+              models: [{ name: 'command-a', endpoints: ['chat'] }],
+              next_page_token: 'page-2',
+            },
+      );
+    });
+    assert.deepEqual(await fetchProviderModels(cohereConnection(normal.url), 'cohere-key'), [
+      { id: 'command-a' },
+      { id: 'command-r-plus', contextWindow: 128_000 },
+    ]);
+    assert.deepEqual(pages, ['first', 'page-2']);
+
+    let repeatedRequests = 0;
+    const repeated = await startJsonServer((_request, response) => {
+      repeatedRequests += 1;
+      respondJson(response, 200, {
+        models: [],
+        next_page_token: 'same-token',
+      });
+    });
+    await assert.rejects(
+      fetchProviderModels(cohereConnection(repeated.url), 'cohere-key'),
+      /Failed to fetch provider models/,
+    );
+    assert.equal(repeatedRequests, 2);
+
+    const oversized = await startJsonServer((_request, response) => {
+      respondJson(response, 200, {
+        models: Array.from({ length: 2_049 }, (_, index) => ({
+          name: `command-${index}`,
+          endpoints: ['chat'],
+        })),
+      });
+    });
+    await assert.rejects(
+      fetchProviderModels(cohereConnection(oversized.url), 'cohere-key'),
+      /Failed to fetch provider models/,
+    );
+  });
+
+  test('Fireworks bounds account concurrency while preserving normal pagination', async () => {
+    let activeModelRequests = 0;
+    let maxActiveModelRequests = 0;
+    const server = await startJsonServer((request, response) => {
+      const url = new URL(request.url ?? '', 'http://test.local');
+      if (url.pathname === '/v1/accounts') {
+        respondJson(response, 200, {
+          accounts: Array.from({ length: 6 }, (_, index) => ({
+            name: `accounts/team-${index}`,
+          })),
+        });
+        return;
+      }
+
+      activeModelRequests += 1;
+      maxActiveModelRequests = Math.max(maxActiveModelRequests, activeModelRequests);
+      setTimeout(() => {
+        activeModelRequests -= 1;
+        const account = url.pathname.match(/^\/v1\/accounts\/([^/]+)\/models$/)?.[1] ?? 'unknown';
+        const pageToken = url.searchParams.get('pageToken');
+        respondJson(response, 200, {
+          models: [{ name: `accounts/${account}/models/${pageToken ?? 'first'}` }],
+          ...(account === 'team-0' && !pageToken ? { nextPageToken: 'second' } : {}),
+        });
+      }, 10);
+    });
+
+    const models = await fetchProviderModels(fireworksConnection(server.url), 'fireworks-key');
+    assert.equal(maxActiveModelRequests, 4);
+    assert.equal(models.length, 8);
+    assert.ok(models.some(({ id }) => id === 'accounts/team-0/models/second'));
+    assert.ok(models.some(({ id }) => id === 'accounts/fireworks/models/first'));
+  });
+
+  test('Fireworks rejects excess account fanout, total raw entries, and repeated page tokens', async () => {
+    const tooManyAccounts = await startJsonServer((request, response) => {
+      assert.equal(new URL(request.url ?? '', 'http://test.local').pathname, '/v1/accounts');
+      respondJson(response, 200, {
+        accounts: Array.from({ length: 32 }, (_, index) => ({
+          name: `accounts/team-${index}`,
+        })),
+      });
+    });
+    await assert.rejects(
+      fetchProviderModels(fireworksConnection(tooManyAccounts.url), 'fireworks-key'),
+      /Failed to fetch provider models/,
+    );
+
+    const tooManyEntries = await startJsonServer((request, response) => {
+      const path = new URL(request.url ?? '', 'http://test.local').pathname;
+      if (path === '/v1/accounts') {
+        respondJson(response, 200, { accounts: [{ name: 'accounts/team' }] });
+        return;
+      }
+      const account = path.includes('/accounts/team/') ? 'team' : 'fireworks';
+      respondJson(response, 200, {
+        models: Array.from({ length: account === 'team' ? 1_024 : 1_025 }, (_, index) => ({
+          name: `accounts/${account}/models/${index}`,
+        })),
+      });
+    });
+    await assert.rejects(
+      fetchProviderModels(fireworksConnection(tooManyEntries.url), 'fireworks-key'),
+      /Failed to fetch provider models/,
+    );
+
+    let repeatedRequests = 0;
+    const repeatedToken = await startJsonServer((request, response) => {
+      const path = new URL(request.url ?? '', 'http://test.local').pathname;
+      if (path === '/v1/accounts') {
+        respondJson(response, 200, { accounts: [] });
+        return;
+      }
+      repeatedRequests += 1;
+      respondJson(response, 200, {
+        models: [],
+        nextPageToken: 'same-token',
+      });
+    });
+    await assert.rejects(
+      fetchProviderModels(fireworksConnection(repeatedToken.url), 'fireworks-key'),
+      /Failed to fetch provider models/,
+    );
+    assert.equal(repeatedRequests, 2);
+  });
+
   test('OpenCode Zen and Go discover exact account model ids with their shared API-key auth shape', async () => {
     const requests: Array<{ url: string; authorization: string | undefined }> = [];
     const server = await startJsonServer((request, response) => {
@@ -873,6 +1017,32 @@ function googleConnection(): LlmConnection {
     name: 'Google Gemini',
     providerType: 'google',
     defaultModel: 'gemini-2.5-flash',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function cohereConnection(baseUrl: string): LlmConnection {
+  return {
+    slug: 'cohere',
+    name: 'Cohere',
+    providerType: 'cohere',
+    baseUrl: `${baseUrl}/v2`,
+    defaultModel: 'command-a',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function fireworksConnection(baseUrl: string): LlmConnection {
+  return {
+    slug: 'fireworks',
+    name: 'Fireworks',
+    providerType: 'fireworks-ai',
+    baseUrl: `${baseUrl}/inference/v1`,
+    defaultModel: 'accounts/fireworks/models/default',
     enabled: true,
     createdAt: 1,
     updatedAt: 1,

--- a/packages/runtime/src/__tests__/model-fetcher.test.ts
+++ b/packages/runtime/src/__tests__/model-fetcher.test.ts
@@ -2,7 +2,11 @@ import assert from 'node:assert/strict';
 import { createServer, type IncomingMessage, type ServerResponse } from 'node:http';
 import { after, describe, test } from 'node:test';
 import type { LlmConnection } from '@maka/core';
-import { fetchProviderModels, ProviderModelDiscoveryHttpError } from '../model-fetcher.js';
+import {
+  fetchProviderModels,
+  ProviderModelDiscoveryHttpError,
+  runConnectionModelDiscoveryEffect,
+} from '../model-fetcher.js';
 
 const servers: Array<{ close(): Promise<void> }> = [];
 
@@ -164,7 +168,7 @@ describe('fetchProviderModels', () => {
               ],
             }
           : {
-              models: [{ name: 'command-a', endpoints: ['chat'] }],
+              models: [{ endpoints: 'legacy-format' }, { name: 'command-a', endpoints: ['chat'] }],
               next_page_token: 'page-2',
             },
       );
@@ -973,6 +977,69 @@ describe('fetchProviderModels', () => {
     );
 
     assert.deepEqual(models, [{ id: 'model-a' }, { id: 'model-b', displayName: 'Model B' }]);
+  });
+
+  test('connection discovery classifies structurally invalid JSON from a real HTTP response', async () => {
+    const secret = 'raw-provider-secret';
+    for (const body of [
+      null,
+      { data: { id: 'not-an-array', secret } },
+      { data: [null, { id: secret }] },
+      { data: [42, { id: secret }] },
+    ]) {
+      const server = await startJsonServer((_request, response) => {
+        respondJson(response, 200, body);
+      });
+
+      const outcome = await runConnectionModelDiscoveryEffect(
+        { ...zaiConnection(), baseUrl: server.url },
+        'zai-live-secret',
+        { fetch: globalThis.fetch },
+      );
+
+      assert.deepEqual(outcome, { ok: false, error: { kind: 'invalid_response' } });
+      assert.equal(JSON.stringify(outcome).includes(secret), false);
+    }
+  });
+
+  test('connection discovery keeps ignoring object entries without model IDs', async () => {
+    const server = await startJsonServer((_request, response) => {
+      respondJson(response, 200, {
+        data: [{ name: 'missing-id' }, { id: 'glm-valid' }],
+      });
+    });
+
+    assert.deepEqual(
+      await runConnectionModelDiscoveryEffect(
+        { ...zaiConnection(), baseUrl: server.url },
+        'zai-live-secret',
+        { fetch: globalThis.fetch },
+      ),
+      { ok: true, models: [{ id: 'glm-valid' }] },
+    );
+  });
+
+  test('connection discovery ignores metadata-only objects before validating model details', async () => {
+    const server = await startJsonServer((_request, response) => {
+      respondJson(response, 200, {
+        data: [
+          { name: 'metadata', tags: 'legacy-format' },
+          { id: 'glm-valid', tags: ['reasoning'] },
+        ],
+      });
+    });
+
+    assert.deepEqual(
+      await runConnectionModelDiscoveryEffect(
+        { ...zaiConnection(), baseUrl: server.url },
+        'zai-live-secret',
+        { fetch: globalThis.fetch },
+      ),
+      {
+        ok: true,
+        models: [{ id: 'glm-valid', capabilities: { reasoning: true } }],
+      },
+    );
   });
 });
 

--- a/packages/runtime/src/connection-effect-fetch.ts
+++ b/packages/runtime/src/connection-effect-fetch.ts
@@ -1,0 +1,198 @@
+import { proxiedFetch, type ProxiedFetchInit } from './bots/proxied-fetch.js';
+import { ConnectionEffectInvalidResponseError } from './connection-effect-outcome.js';
+
+export type ConnectionEffectFetch = typeof globalThis.fetch;
+export const CONNECTION_EFFECT_JSON_BODY_MAX_BYTES = 4 * 1024 * 1024;
+export const CONNECTION_EFFECT_ERROR_BODY_MAX_BYTES = 16 * 1024;
+
+export interface ConnectionEffectFetchOptions {
+  readonly fetch?: ConnectionEffectFetch;
+}
+
+export interface ConnectionEffectFetchDependency {
+  readonly fetch: ConnectionEffectFetch;
+}
+
+export class ConnectionEffectFetchError extends Error {
+  constructor(
+    public readonly kind: 'timeout' | 'network',
+    options?: ErrorOptions,
+  ) {
+    super(kind === 'timeout' ? 'Fetch timeout' : 'Network request failed', options);
+    this.name = 'ConnectionEffectFetchError';
+  }
+}
+
+export interface ConnectionEffectResponse {
+  readonly ok: boolean;
+  readonly status: number;
+  readJson<T>(): Promise<T>;
+  readText(maxBytes?: number): Promise<string>;
+  cancel(): Promise<void>;
+}
+
+export async function fetchForConnectionEffect(
+  fetchFn: ConnectionEffectFetch | undefined,
+  input: string | URL,
+  init: ProxiedFetchInit = {},
+): Promise<ConnectionEffectResponse> {
+  if (!fetchFn) {
+    return manageConnectionEffectResponse(await proxiedFetch(input.toString(), init));
+  }
+
+  const { timeoutMs = 15_000, signal, ...requestInit } = init;
+  const controller = new AbortController();
+  let timedOut = false;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+
+  const abortFromCaller = () => {
+    if (isTimeoutReason(signal?.reason)) timedOut = true;
+    controller.abort(signal?.reason);
+  };
+  if (signal) {
+    if (signal.aborted) abortFromCaller();
+    else signal.addEventListener('abort', abortFromCaller, { once: true });
+  }
+  if (timeoutMs > 0) {
+    timer = setTimeout(() => {
+      timedOut = true;
+      controller.abort(new ConnectionEffectFetchError('timeout'));
+    }, timeoutMs);
+  }
+
+  try {
+    const response = await fetchFn(input, {
+      ...requestInit,
+      signal: controller.signal,
+    } as RequestInit);
+    return manageConnectionEffectResponse(response, {
+      didTimeOut: () => timedOut,
+      finish: () => {
+        if (timer) clearTimeout(timer);
+        signal?.removeEventListener('abort', abortFromCaller);
+      },
+    });
+  } catch (error) {
+    if (timer) clearTimeout(timer);
+    signal?.removeEventListener('abort', abortFromCaller);
+    throw connectionEffectFetchFailure(error, timedOut);
+  }
+}
+
+function manageConnectionEffectResponse(
+  response: Response,
+  lifecycle?: {
+    readonly didTimeOut: () => boolean;
+    readonly finish: () => void;
+  },
+): ConnectionEffectResponse {
+  let claimed = false;
+  let finished = false;
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    lifecycle?.finish();
+  };
+  const claim = () => {
+    if (claimed) {
+      throw new ConnectionEffectInvalidResponseError(
+        'Connection effect response body was already handled',
+      );
+    }
+    claimed = true;
+  };
+  const cancel = async (): Promise<void> => {
+    if (claimed) return;
+    claimed = true;
+    try {
+      await response.body?.cancel();
+    } catch {
+      // Cancellation is best-effort; the owning transport is still closed by the effect.
+    } finally {
+      finish();
+    }
+    if (lifecycle?.didTimeOut() === true) {
+      throw new ConnectionEffectFetchError('timeout');
+    }
+  };
+  const readText = async (maxBytes = CONNECTION_EFFECT_ERROR_BODY_MAX_BYTES): Promise<string> => {
+    claim();
+    try {
+      return new TextDecoder().decode(await readBoundedBody(response, maxBytes));
+    } catch (error) {
+      throw connectionEffectFetchFailure(error, lifecycle?.didTimeOut() === true);
+    } finally {
+      finish();
+    }
+  };
+
+  return {
+    ok: response.ok,
+    status: response.status,
+    readJson: async <T>(): Promise<T> => {
+      const text = await readText(CONNECTION_EFFECT_JSON_BODY_MAX_BYTES);
+      try {
+        return JSON.parse(text) as T;
+      } catch (error) {
+        throw new ConnectionEffectInvalidResponseError('Invalid provider JSON response', {
+          cause: error,
+        });
+      }
+    },
+    readText,
+    cancel,
+  };
+}
+
+async function readBoundedBody(response: Response, maxBytes: number): Promise<Uint8Array> {
+  if (!Number.isSafeInteger(maxBytes) || maxBytes < 0) {
+    throw new ConnectionEffectInvalidResponseError('Invalid connection effect body limit');
+  }
+  const contentLength = Number(response.headers.get('content-length'));
+  if (Number.isFinite(contentLength) && contentLength > maxBytes) {
+    await response.body?.cancel().catch(() => {});
+    throw new ConnectionEffectInvalidResponseError('Provider response body exceeded its limit');
+  }
+  if (!response.body) return new Uint8Array();
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalBytes = 0;
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      totalBytes += value.byteLength;
+      if (totalBytes > maxBytes) {
+        await reader.cancel().catch(() => {});
+        throw new ConnectionEffectInvalidResponseError('Provider response body exceeded its limit');
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const body = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    body.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return body;
+}
+
+function connectionEffectFetchFailure(error: unknown, timedOut: boolean): Error {
+  if (timedOut) return new ConnectionEffectFetchError('timeout', { cause: error });
+  if (
+    error instanceof ConnectionEffectFetchError ||
+    error instanceof ConnectionEffectInvalidResponseError
+  ) {
+    return error;
+  }
+  return new ConnectionEffectFetchError('network', { cause: error });
+}
+
+function isTimeoutReason(reason: unknown): boolean {
+  return reason instanceof Error && reason.name === 'TimeoutError';
+}

--- a/packages/runtime/src/connection-effect-outcome.ts
+++ b/packages/runtime/src/connection-effect-outcome.ts
@@ -1,0 +1,63 @@
+import type { ModelDiscoverySource, ModelInfo, ProviderType } from '@maka/core/llm-connections';
+
+export interface ConnectionEffectConnection {
+  readonly providerType: ProviderType;
+  readonly baseUrl?: string;
+  readonly defaultModel?: string;
+  readonly enabledModelIds?: readonly string[];
+  readonly models?: readonly ModelInfo[];
+  readonly modelSource?: ModelDiscoverySource;
+}
+
+export type ConnectionEffectErrorKind =
+  | 'auth'
+  | 'timeout'
+  | 'provider_unavailable'
+  | 'network'
+  | 'invalid_response'
+  | 'unknown';
+
+export interface ConnectionEffectError {
+  readonly kind: ConnectionEffectErrorKind;
+  readonly statusCode?: number;
+}
+
+export type ConnectionModelDiscoveryEffectOutcome =
+  | { readonly ok: true; readonly models: readonly ModelInfo[] }
+  | { readonly ok: false; readonly error: ConnectionEffectError };
+
+export type ConnectionTestEffectOutcome =
+  | {
+      readonly ok: true;
+      readonly modelId: string;
+      readonly latencyMs: number;
+    }
+  | {
+      readonly ok: false;
+      readonly error: ConnectionEffectError;
+      readonly modelId?: string;
+      readonly latencyMs?: number;
+    };
+
+export class ConnectionEffectHttpError extends Error {
+  constructor(public readonly status: number) {
+    super(`HTTP ${status}`);
+    this.name = 'ConnectionEffectHttpError';
+  }
+}
+
+export class ConnectionEffectInvalidResponseError extends Error {
+  constructor(message = 'Invalid provider response', options?: ErrorOptions) {
+    super(message, options);
+    this.name = 'ConnectionEffectInvalidResponseError';
+  }
+}
+
+export function classifyConnectionEffectStatus(statusCode: number): ConnectionEffectError {
+  if (statusCode === 401 || statusCode === 403) return { kind: 'auth', statusCode };
+  if (statusCode === 408) return { kind: 'timeout', statusCode };
+  if (statusCode === 429 || (statusCode >= 500 && statusCode <= 599)) {
+    return { kind: 'provider_unavailable', statusCode };
+  }
+  return { kind: 'unknown', statusCode };
+}

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -1080,14 +1080,32 @@ export type {
   SemanticCompactSummarizer,
   SemanticCompactSummaryRequest,
 } from './semantic-compact.js';
-export { testConnection } from './test-connection.js';
+export { runConnectionTestEffect, testConnection } from './test-connection.js';
 export {
   fetchGitHubCopilotModels,
   fetchOpenAiCodexModels,
   fetchProviderModels,
   OpenAiCodexDiscoveryError,
   ProviderModelDiscoveryHttpError,
+  runConnectionModelDiscoveryEffect,
 } from './model-fetcher.js';
+export type {
+  ConnectionEffectFetch,
+  ConnectionEffectFetchDependency,
+  ConnectionEffectFetchOptions,
+} from './connection-effect-fetch.js';
+export type {
+  ConnectionEffectConnection,
+  ConnectionEffectError,
+  ConnectionEffectErrorKind,
+  ConnectionModelDiscoveryEffectOutcome,
+  ConnectionTestEffectOutcome,
+} from './connection-effect-outcome.js';
+export { createConnectionEffectFetchTransport } from './network/scoped-fetch-transport.js';
+export type {
+  ConnectionEffectFetchTransport,
+  ConnectionEffectProxySnapshot,
+} from './network/scoped-fetch-transport.js';
 
 export { materializeSession, applyAppendedMessage, setToolStatus } from './materializer.js';
 export type { ToolActivityItem, ChatItem, SessionViewModel } from './materializer.js';

--- a/packages/runtime/src/model-fetcher.ts
+++ b/packages/runtime/src/model-fetcher.ts
@@ -9,19 +9,44 @@ import { generalizedErrorMessage } from '@maka/core/redaction';
 import {
   CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION,
   CONNECTION_MODEL_ID_MAX_LENGTH,
+  normalizeConnectionModelDiscoveryResult,
 } from '@maka/core/runtime-policy';
-import { proxiedFetch } from './bots/proxied-fetch.js';
 import { anthropicV1Url, googleApiUrl } from './provider-urls.js';
 import { claudeSubscriptionHeaders, openAiCodexHeaders } from './subscription-auth.js';
 import {
   GITHUB_COPILOT_API_VERSION,
   GITHUB_COPILOT_COMPAT_HEADERS,
 } from './subscription-credentials.js';
+import {
+  ConnectionEffectFetchError,
+  fetchForConnectionEffect,
+  type ConnectionEffectFetch,
+  type ConnectionEffectFetchDependency,
+  type ConnectionEffectFetchOptions,
+  type ConnectionEffectResponse,
+} from './connection-effect-fetch.js';
+import {
+  ConnectionEffectHttpError,
+  ConnectionEffectInvalidResponseError,
+  classifyConnectionEffectStatus,
+  type ConnectionEffectConnection,
+  type ConnectionEffectError,
+  type ConnectionModelDiscoveryEffectOutcome,
+} from './connection-effect-outcome.js';
 
 const MODEL_FETCH_TIMEOUT_MS = 10_000;
 const CLOUDFLARE_MODEL_PAGE_SIZE = 50;
 const CLOUDFLARE_MODEL_MAX_REQUEST_PAGES =
   Math.ceil(CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION / CLOUDFLARE_MODEL_PAGE_SIZE) + 1;
+const COHERE_MODEL_PAGE_SIZE = 1_000;
+const COHERE_MODEL_MAX_REQUEST_PAGES =
+  Math.ceil(CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION / COHERE_MODEL_PAGE_SIZE) + 1;
+const FIREWORKS_PAGE_SIZE = 200;
+const FIREWORKS_MAX_REQUEST_PAGES =
+  Math.ceil(CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION / FIREWORKS_PAGE_SIZE) + 1;
+const FIREWORKS_MAX_ACCOUNTS = 32;
+const FIREWORKS_ACCOUNT_CONCURRENCY = 4;
+const PROVIDER_PAGE_TOKEN_MAX_LENGTH = 2_048;
 
 type RawProviderModel = {
   id?: string;
@@ -94,9 +119,12 @@ type FireworksModelDiscovery = Extract<
 export async function fetchProviderModels(
   connection: LlmConnection,
   apiKey: string,
+  options: ConnectionEffectFetchOptions = {},
 ): Promise<ModelInfo[]> {
   try {
-    return normalizeDiscoveredModels(await fetchProviderModelsStrict(connection, apiKey));
+    return normalizeDiscoveredModels(
+      await fetchProviderModelsStrict(connection, apiKey, options.fetch),
+    );
   } catch (error) {
     // Preserve status-bearing discovery errors so the sync layer can classify
     // auth/protocol/network failures; only wrap unknown errors for display.
@@ -110,9 +138,27 @@ export async function fetchProviderModels(
   }
 }
 
-async function fetchProviderModelsStrict(
-  connection: LlmConnection,
+export async function runConnectionModelDiscoveryEffect(
+  connection: ConnectionEffectConnection,
   apiKey: string,
+  options: ConnectionEffectFetchDependency,
+): Promise<ConnectionModelDiscoveryEffectOutcome> {
+  try {
+    return {
+      ok: true,
+      models: normalizeConnectionEffectModels(
+        await fetchProviderModelsStrict(connection, apiKey, options.fetch),
+      ),
+    };
+  } catch (error) {
+    return { ok: false, error: classifyDiscoveryError(error) };
+  }
+}
+
+async function fetchProviderModelsStrict(
+  connection: ConnectionEffectConnection,
+  apiKey: string,
+  fetchFn: ConnectionEffectFetch | undefined,
 ): Promise<ModelInfo[]> {
   const baseUrl = effectiveBaseUrl(connection);
   const definition = PROVIDER_DEFAULTS[connection.providerType];
@@ -128,64 +174,75 @@ async function fetchProviderModelsStrict(
     return definition.fallbackModels.map((id) => ({ id }));
   }
   if (discovery.kind === 'ollama') {
-    const r = await proxiedFetch(`${ollamaRoot(baseUrl)}/api/tags`, {
+    const r = await fetchForConnectionEffect(fetchFn, `${ollamaRoot(baseUrl)}/api/tags`, {
       timeoutMs: MODEL_FETCH_TIMEOUT_MS,
     });
-    if (!r.ok) throw new Error(`HTTP ${r.status}`);
-    const data = (await r.json()) as { models?: Array<{ name?: string }> };
+    if (!r.ok) {
+      await r.cancel();
+      throw new ConnectionEffectHttpError(r.status);
+    }
+    const data = await readProviderJson<{ models?: Array<{ name?: string }> }>(r);
     return (data.models ?? []).flatMap((model) => (model.name ? [{ id: model.name }] : []));
   }
   if (discovery.kind === 'fireworks') {
-    return fetchFireworksModels(baseUrl, apiKey, discovery);
+    return fetchFireworksModels(baseUrl, apiKey, discovery, fetchFn);
   }
   if (discovery.kind === 'cohere') {
-    return fetchCohereModels(baseUrl, apiKey);
+    return fetchCohereModels(baseUrl, apiKey, fetchFn);
   }
   if (discovery.kind === 'cloudflare') {
-    return fetchCloudflareModels(baseUrl, apiKey);
+    return fetchCloudflareModels(baseUrl, apiKey, fetchFn);
   }
   if (discovery.auth === 'github-copilot') {
-    return fetchGitHubCopilotModels(baseUrl, apiKey);
+    return fetchGitHubCopilotModels(baseUrl, apiKey, fetchFn);
   }
   if (discovery.auth === 'openai-codex') {
-    return fetchOpenAiCodexModels(baseUrl, apiKey);
+    return fetchOpenAiCodexModels(baseUrl, apiKey, fetchFn);
   }
 
   switch (definition.protocol) {
     case 'anthropic': {
-      const r = await proxiedFetch(anthropicV1Url(baseUrl, '/models'), {
+      const r = await fetchForConnectionEffect(fetchFn, anthropicV1Url(baseUrl, '/models'), {
         headers: anthropicModelHeaders(
           discovery.auth === 'claude-subscription' ? discovery.auth : undefined,
           apiKey,
         ),
         timeoutMs: MODEL_FETCH_TIMEOUT_MS,
       });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const data = (await r.json()) as { data?: RawProviderModel[] };
+      if (!r.ok) {
+        await r.cancel();
+        throw new ConnectionEffectHttpError(r.status);
+      }
+      const data = await readProviderJson<{ data?: RawProviderModel[] }>(r);
       const models = (data.data ?? [])
         .map(toModelInfo)
         .filter((model): model is ModelInfo => model !== null);
       return filterDiscoveredModels(models, discovery.filter, definition.fallbackModels);
     }
     case 'openai': {
-      const r = await proxiedFetch(modelListUrl(baseUrl, discovery.path, discovery.query), {
-        headers: {
-          'content-type': 'application/json',
-          ...(apiKey &&
-          (discovery.auth === 'oauth-bearer' ||
-            (discovery.auth !== 'none' && providerAuthSupportsApiKey(connection.providerType)))
-            ? { authorization: `Bearer ${apiKey}` }
-            : {}),
+      const r = await fetchForConnectionEffect(
+        fetchFn,
+        modelListUrl(baseUrl, discovery.path, discovery.query),
+        {
+          headers: {
+            'content-type': 'application/json',
+            ...(apiKey &&
+            (discovery.auth === 'oauth-bearer' ||
+              (discovery.auth !== 'none' && providerAuthSupportsApiKey(connection.providerType)))
+              ? { authorization: `Bearer ${apiKey}` }
+              : {}),
+          },
+          timeoutMs: MODEL_FETCH_TIMEOUT_MS,
         },
-        timeoutMs: MODEL_FETCH_TIMEOUT_MS,
-      });
+      );
       if (!r.ok) {
+        await r.cancel();
         if (connection.providerType === 'xai-oauth') {
           throw new ProviderModelDiscoveryHttpError(r.status);
         }
-        throw new Error(`HTTP ${r.status}`);
+        throw new ConnectionEffectHttpError(r.status);
       }
-      const data = (await r.json()) as { data?: RawProviderModel[] } | RawProviderModel[];
+      const data = await readProviderJson<{ data?: RawProviderModel[] } | RawProviderModel[]>(r);
       const rawModels =
         discovery.responseShape === 'array-or-data'
           ? Array.isArray(data)
@@ -201,11 +258,14 @@ async function fetchProviderModelsStrict(
       return filterDiscoveredModels(models, discovery.filter, definition.fallbackModels);
     }
     case 'google': {
-      const r = await proxiedFetch(googleApiUrl(baseUrl, '/models', apiKey), {
+      const r = await fetchForConnectionEffect(fetchFn, googleApiUrl(baseUrl, '/models', apiKey), {
         timeoutMs: MODEL_FETCH_TIMEOUT_MS,
       });
-      if (!r.ok) throw new Error(`HTTP ${r.status}`);
-      const data = (await r.json()) as { models?: Array<{ name?: string }> };
+      if (!r.ok) {
+        await r.cancel();
+        throw new ConnectionEffectHttpError(r.status);
+      }
+      const data = await readProviderJson<{ models?: Array<{ name?: string }> }>(r);
       return (data.models ?? []).flatMap((model) => {
         const id = model.name?.split('/').pop();
         return id ? [{ id }] : [];
@@ -216,27 +276,36 @@ async function fetchProviderModelsStrict(
   }
 }
 
-async function fetchCloudflareModels(baseUrl: string, apiKey: string): Promise<ModelInfo[]> {
+async function fetchCloudflareModels(
+  baseUrl: string,
+  apiKey: string,
+  fetchFn: ConnectionEffectFetch | undefined,
+): Promise<ModelInfo[]> {
   const models: ModelInfo[] = [];
   let page = 1;
   let rawModelCount = 0;
+  const signal = AbortSignal.timeout(MODEL_FETCH_TIMEOUT_MS);
   while (page <= CLOUDFLARE_MODEL_MAX_REQUEST_PAGES) {
     const url = cloudflareModelsUrl(baseUrl, page);
-    const response = await proxiedFetch(url, {
+    const response = await fetchForConnectionEffect(fetchFn, url, {
       headers: { authorization: `Bearer ${apiKey}` },
+      signal,
       timeoutMs: MODEL_FETCH_TIMEOUT_MS,
     });
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const data = (await response.json()) as {
+    if (!response.ok) {
+      await response.cancel();
+      throw new ConnectionEffectHttpError(response.status);
+    }
+    const data = await readProviderJson<{
       success?: unknown;
       result?: unknown;
-    };
+    }>(response);
     if (data.success !== true || !Array.isArray(data.result)) {
-      throw new Error('Invalid Cloudflare models response');
+      throw new ConnectionEffectInvalidResponseError('Invalid Cloudflare models response');
     }
     rawModelCount += data.result.length;
     if (rawModelCount > CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION) {
-      throw new Error('Provider returned too many models');
+      throw new ConnectionEffectInvalidResponseError('Provider returned too many models');
     }
     models.push(
       ...data.result.flatMap((raw) => {
@@ -247,7 +316,7 @@ async function fetchCloudflareModels(baseUrl: string, apiKey: string): Promise<M
     if (data.result.length === 0) return models;
     page += 1;
   }
-  throw new Error('Provider returned too many models');
+  throw new ConnectionEffectInvalidResponseError('Provider returned too many models');
 }
 
 function cloudflareModelsUrl(baseUrl: string, page: number): string {
@@ -279,31 +348,48 @@ function normalizeDiscoveredModels(models: ModelInfo[]): ModelInfo[] {
     }
     unique.set(id, { ...model, id });
     if (unique.size > CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION) {
-      throw new Error('Provider returned too many models');
+      throw new ConnectionEffectInvalidResponseError('Provider returned too many models');
     }
   }
   return [...unique.values()];
 }
 
+function normalizeConnectionEffectModels(models: ModelInfo[]): readonly ModelInfo[] {
+  try {
+    return normalizeConnectionModelDiscoveryResult({
+      models: normalizeDiscoveredModels(models),
+      source: 'fetched',
+      fetchedAt: 0,
+    }).models;
+  } catch (error) {
+    throw new ConnectionEffectInvalidResponseError('Provider returned invalid model metadata', {
+      cause: error,
+    });
+  }
+}
+
 export async function fetchGitHubCopilotModels(
   baseUrl: string,
   accessToken: string,
-  fetchFn?: typeof fetch,
+  fetchFn?: ConnectionEffectFetch,
 ): Promise<ModelInfo[]> {
-  const response = await (fetchFn ?? proxiedFetch)(`${stripTrailing(baseUrl)}/models`, {
+  const response = await fetchForConnectionEffect(fetchFn, `${stripTrailing(baseUrl)}/models`, {
     headers: {
       Authorization: `Bearer ${accessToken}`,
       ...GITHUB_COPILOT_COMPAT_HEADERS,
       'Openai-Intent': 'conversation-edits',
       'X-GitHub-Api-Version': GITHUB_COPILOT_API_VERSION,
     },
-    ...(fetchFn
-      ? { signal: AbortSignal.timeout(MODEL_FETCH_TIMEOUT_MS) }
-      : { timeoutMs: MODEL_FETCH_TIMEOUT_MS }),
+    timeoutMs: MODEL_FETCH_TIMEOUT_MS,
   });
-  if (!response.ok) throw new Error(`HTTP ${response.status}`);
-  const payload = (await response.json()) as { data?: RawGitHubCopilotModel[] };
-  if (!Array.isArray(payload.data)) throw new Error('Invalid GitHub Copilot models response');
+  if (!response.ok) {
+    await response.cancel();
+    throw new ConnectionEffectHttpError(response.status);
+  }
+  const payload = await readProviderJson<{ data?: RawGitHubCopilotModel[] }>(response);
+  if (!Array.isArray(payload.data)) {
+    throw new ConnectionEffectInvalidResponseError('Invalid GitHub Copilot models response');
+  }
   return payload.data.flatMap(toGitHubCopilotModelInfo);
 }
 
@@ -319,17 +405,17 @@ type RawOpenAiCodexModel = {
  * can classify auth failures (401/403) vs protocol errors (4xx) vs transient
  * network failures without string-matching the message.
  */
-export class OpenAiCodexDiscoveryError extends Error {
-  constructor(public readonly status: number) {
-    super(`HTTP ${status}`);
+export class OpenAiCodexDiscoveryError extends ConnectionEffectHttpError {
+  constructor(status: number) {
+    super(status);
     this.name = 'OpenAiCodexDiscoveryError';
   }
 }
 
 /** Structured status for standard provider `/models` endpoints. */
-export class ProviderModelDiscoveryHttpError extends Error {
-  constructor(public readonly status: number) {
-    super(`HTTP ${status}`);
+export class ProviderModelDiscoveryHttpError extends ConnectionEffectHttpError {
+  constructor(status: number) {
+    super(status);
     this.name = 'ProviderModelDiscoveryHttpError';
   }
 }
@@ -346,9 +432,10 @@ export class ProviderModelDiscoveryHttpError extends Error {
 export async function fetchOpenAiCodexModels(
   baseUrl: string,
   accessToken: string,
-  fetchFn?: typeof fetch,
+  fetchFn?: ConnectionEffectFetch,
 ): Promise<ModelInfo[]> {
-  const response = await (fetchFn ?? proxiedFetch)(
+  const response = await fetchForConnectionEffect(
+    fetchFn,
     `${stripTrailing(baseUrl)}/models?client_version=1.0.0`,
     {
       headers: {
@@ -356,14 +443,17 @@ export async function fetchOpenAiCodexModels(
         ...openAiCodexHeaders(accessToken),
         'content-type': 'application/json',
       },
-      ...(fetchFn
-        ? { signal: AbortSignal.timeout(MODEL_FETCH_TIMEOUT_MS) }
-        : { timeoutMs: MODEL_FETCH_TIMEOUT_MS }),
+      timeoutMs: MODEL_FETCH_TIMEOUT_MS,
     },
   );
-  if (!response.ok) throw new OpenAiCodexDiscoveryError(response.status);
-  const payload = (await response.json()) as { models?: RawOpenAiCodexModel[] };
-  if (!Array.isArray(payload?.models)) throw new Error('Invalid OpenAI Codex models response');
+  if (!response.ok) {
+    await response.cancel();
+    throw new OpenAiCodexDiscoveryError(response.status);
+  }
+  const payload = await readProviderJson<{ models?: RawOpenAiCodexModel[] }>(response);
+  if (!Array.isArray(payload?.models)) {
+    throw new ConnectionEffectInvalidResponseError('Invalid OpenAI Codex models response');
+  }
   const visible = payload.models.filter((model) => {
     if (!model || typeof model.slug !== 'string' || !model.slug.trim()) return false;
     const visibility =
@@ -435,24 +525,55 @@ function toGitHubCopilotModelInfo(model: RawGitHubCopilotModel): ModelInfo[] {
   ];
 }
 
-async function fetchCohereModels(baseUrl: string, apiKey: string): Promise<ModelInfo[]> {
+async function fetchCohereModels(
+  baseUrl: string,
+  apiKey: string,
+  fetchFn: ConnectionEffectFetch | undefined,
+): Promise<ModelInfo[]> {
   const root = stripTrailing(baseUrl).replace(/\/v2$/, '');
   const models: ModelInfo[] = [];
+  const seenPageTokens = new Set<string>();
+  const signal = AbortSignal.timeout(MODEL_FETCH_TIMEOUT_MS);
   let pageToken: string | undefined;
-  do {
-    const query = new URLSearchParams({ endpoint: 'chat', page_size: '1000' });
-    if (pageToken) query.set('page_token', pageToken);
-    const response = await proxiedFetch(`${root}/v1/models?${query.toString()}`, {
-      headers: { authorization: `Bearer ${apiKey}` },
-      timeoutMs: MODEL_FETCH_TIMEOUT_MS,
+  let pageCount = 0;
+  let rawModelCount = 0;
+  while (true) {
+    pageCount += 1;
+    if (pageCount > COHERE_MODEL_MAX_REQUEST_PAGES) {
+      throw new ConnectionEffectInvalidResponseError('Provider returned too many model pages');
+    }
+    const query = new URLSearchParams({
+      endpoint: 'chat',
+      page_size: String(COHERE_MODEL_PAGE_SIZE),
     });
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
-    const data = (await response.json()) as {
+    if (pageToken) query.set('page_token', pageToken);
+    const response = await fetchForConnectionEffect(
+      fetchFn,
+      `${root}/v1/models?${query.toString()}`,
+      {
+        headers: { authorization: `Bearer ${apiKey}` },
+        signal,
+        timeoutMs: MODEL_FETCH_TIMEOUT_MS,
+      },
+    );
+    if (!response.ok) {
+      await response.cancel();
+      throw new ConnectionEffectHttpError(response.status);
+    }
+    const data = await readProviderJson<{
       models?: RawCohereModel[];
-      next_page_token?: string;
-    };
+      next_page_token?: unknown;
+    }>(response);
+    if (data.models !== undefined && !Array.isArray(data.models)) {
+      throw new ConnectionEffectInvalidResponseError('Invalid Cohere models response');
+    }
+    const rawModels = data.models ?? [];
+    rawModelCount += rawModels.length;
+    if (rawModelCount > CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION) {
+      throw new ConnectionEffectInvalidResponseError('Provider returned too many models');
+    }
     models.push(
-      ...(data.models ?? []).flatMap((model) => {
+      ...rawModels.flatMap((model) => {
         if (!model.name || model.is_deprecated === true || !model.endpoints?.includes('chat'))
           return [];
         return [
@@ -465,9 +586,13 @@ async function fetchCohereModels(baseUrl: string, apiKey: string): Promise<Model
         ];
       }),
     );
-    pageToken = data.next_page_token || undefined;
-  } while (pageToken);
-  return models;
+    pageToken = nextProviderPageToken(data.next_page_token);
+    if (!pageToken) return models;
+    if (seenPageTokens.has(pageToken)) {
+      throw new ConnectionEffectInvalidResponseError('Provider repeated a model page token');
+    }
+    seenPageTokens.add(pageToken);
+  }
 }
 
 function filterDiscoveredModels(
@@ -499,42 +624,74 @@ async function fetchFireworksModels(
   baseUrl: string,
   apiKey: string,
   discovery: FireworksModelDiscovery,
+  fetchFn: ConnectionEffectFetch | undefined,
 ): Promise<ModelInfo[]> {
   const root = stripTrailing(baseUrl).replace(/\/inference\/v1$/, '');
   const headers = {
     'content-type': 'application/json',
     authorization: `Bearer ${apiKey}`,
   };
+  const signal = AbortSignal.timeout(MODEL_FETCH_TIMEOUT_MS);
   const fetchPages = async <T>(
     path: string,
     query: Readonly<Record<string, string>>,
     itemKey: 'accounts' | 'models',
+    maxItems: number,
+    reserveItems?: (count: number) => void,
   ): Promise<T[]> => {
     const items: T[] = [];
+    const seenPageTokens = new Set<string>();
     let pageToken: string | undefined;
-    do {
+    let pageCount = 0;
+    while (true) {
+      pageCount += 1;
+      if (pageCount > FIREWORKS_MAX_REQUEST_PAGES) {
+        throw new ConnectionEffectInvalidResponseError('Provider returned too many model pages');
+      }
       const search = new URLSearchParams(query);
       if (pageToken) search.set('pageToken', pageToken);
-      const response = await proxiedFetch(`${root}${path}?${search.toString()}`, {
-        headers,
-        timeoutMs: MODEL_FETCH_TIMEOUT_MS,
-      });
-      if (!response.ok) throw new Error(`HTTP ${response.status}`);
-      const data = (await response.json()) as {
+      const response = await fetchForConnectionEffect(
+        fetchFn,
+        `${root}${path}?${search.toString()}`,
+        {
+          headers,
+          signal,
+          timeoutMs: MODEL_FETCH_TIMEOUT_MS,
+        },
+      );
+      if (!response.ok) {
+        await response.cancel();
+        throw new ConnectionEffectHttpError(response.status);
+      }
+      const data = await readProviderJson<{
         accounts?: T[];
         models?: T[];
-        nextPageToken?: string;
-      };
-      items.push(...(data[itemKey] ?? []));
-      pageToken = data.nextPageToken || undefined;
-    } while (pageToken);
-    return items;
+        nextPageToken?: unknown;
+      }>(response);
+      const pageItems = data[itemKey];
+      if (pageItems !== undefined && !Array.isArray(pageItems)) {
+        throw new ConnectionEffectInvalidResponseError('Invalid Fireworks models response');
+      }
+      const rawItems = pageItems ?? [];
+      reserveItems?.(rawItems.length);
+      items.push(...rawItems);
+      if (items.length > maxItems) {
+        throw new ConnectionEffectInvalidResponseError(`Provider returned too many ${itemKey}`);
+      }
+      pageToken = nextProviderPageToken(data.nextPageToken);
+      if (!pageToken) return items;
+      if (seenPageTokens.has(pageToken)) {
+        throw new ConnectionEffectInvalidResponseError('Provider repeated a model page token');
+      }
+      seenPageTokens.add(pageToken);
+    }
   };
 
   const accounts = await fetchPages<{ name?: string }>(
     discovery.accountsPath,
-    { pageSize: '200' },
+    { pageSize: String(FIREWORKS_PAGE_SIZE) },
     'accounts',
+    FIREWORKS_MAX_ACCOUNTS,
   );
   const accountNames = [
     ...accounts.flatMap((account) =>
@@ -542,11 +699,34 @@ async function fetchFireworksModels(
     ),
     discovery.publicAccount,
   ].filter((name, index, names) => names.indexOf(name) === index);
-  const modelLists = await Promise.all(
-    accountNames.map((accountName) =>
-      fetchPages<RawFireworksModel>(`/v1/${accountName}/models`, discovery.query, 'models'),
-    ),
-  );
+  if (accountNames.length > FIREWORKS_MAX_ACCOUNTS) {
+    throw new ConnectionEffectInvalidResponseError('Provider returned too many accounts');
+  }
+  let rawModelCount = 0;
+  const reserveModels = (count: number) => {
+    rawModelCount += count;
+    if (rawModelCount > CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION) {
+      throw new ConnectionEffectInvalidResponseError('Provider returned too many models');
+    }
+  };
+  const modelLists: RawFireworksModel[][] = [];
+  for (let index = 0; index < accountNames.length; index += FIREWORKS_ACCOUNT_CONCURRENCY) {
+    modelLists.push(
+      ...(await Promise.all(
+        accountNames
+          .slice(index, index + FIREWORKS_ACCOUNT_CONCURRENCY)
+          .map((accountName) =>
+            fetchPages<RawFireworksModel>(
+              `/v1/${accountName}/models`,
+              discovery.query,
+              'models',
+              CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION,
+              reserveModels,
+            ),
+          ),
+      )),
+    );
+  }
 
   return modelLists.flat().flatMap((model) => {
     if (!model.name) return [];
@@ -616,4 +796,31 @@ function stripTrailing(u: string): string {
 
 function ollamaRoot(baseUrl: string): string {
   return stripTrailing(baseUrl).replace(/\/v1$/, '');
+}
+
+async function readProviderJson<T>(response: ConnectionEffectResponse): Promise<T> {
+  return response.readJson<T>();
+}
+
+function nextProviderPageToken(value: unknown): string | undefined {
+  if (value === undefined || value === null || value === '') return undefined;
+  if (
+    typeof value !== 'string' ||
+    value.length > PROVIDER_PAGE_TOKEN_MAX_LENGTH ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new ConnectionEffectInvalidResponseError('Invalid provider model page token');
+  }
+  return value;
+}
+
+function classifyDiscoveryError(error: unknown): ConnectionEffectError {
+  if (error instanceof ConnectionEffectFetchError) return { kind: error.kind };
+  if (error instanceof ConnectionEffectHttpError) {
+    return classifyConnectionEffectStatus(error.status);
+  }
+  if (error instanceof ConnectionEffectInvalidResponseError || error instanceof SyntaxError) {
+    return { kind: 'invalid_response' };
+  }
+  return { kind: 'unknown' };
 }

--- a/packages/runtime/src/model-fetcher.ts
+++ b/packages/runtime/src/model-fetcher.ts
@@ -181,8 +181,10 @@ async function fetchProviderModelsStrict(
       await r.cancel();
       throw new ConnectionEffectHttpError(r.status);
     }
-    const data = await readProviderJson<{ models?: Array<{ name?: string }> }>(r);
-    return (data.models ?? []).flatMap((model) => (model.name ? [{ id: model.name }] : []));
+    const data = await readProviderJson<{ models?: unknown }>(r);
+    return providerObjectArray<{ name?: string }>(data.models, 'Ollama models').flatMap((model) =>
+      model.name ? [{ id: model.name }] : [],
+    );
   }
   if (discovery.kind === 'fireworks') {
     return fetchFireworksModels(baseUrl, apiKey, discovery, fetchFn);
@@ -213,8 +215,8 @@ async function fetchProviderModelsStrict(
         await r.cancel();
         throw new ConnectionEffectHttpError(r.status);
       }
-      const data = await readProviderJson<{ data?: RawProviderModel[] }>(r);
-      const models = (data.data ?? [])
+      const data = await readProviderJson<{ data?: unknown }>(r);
+      const models = providerObjectArray<RawProviderModel>(data.data, 'Anthropic models')
         .map(toModelInfo)
         .filter((model): model is ModelInfo => model !== null);
       return filterDiscoveredModels(models, discovery.filter, definition.fallbackModels);
@@ -242,15 +244,15 @@ async function fetchProviderModelsStrict(
         }
         throw new ConnectionEffectHttpError(r.status);
       }
-      const data = await readProviderJson<{ data?: RawProviderModel[] } | RawProviderModel[]>(r);
+      const data = await readProviderJson<{ data?: unknown } | unknown[]>(r);
       const rawModels =
         discovery.responseShape === 'array-or-data'
           ? Array.isArray(data)
-            ? data
-            : (data.data ?? [])
+            ? providerObjectArray<RawProviderModel>(data, 'provider models')
+            : providerObjectArray<RawProviderModel>(data.data, 'provider models')
           : Array.isArray(data)
             ? []
-            : (data.data ?? []);
+            : providerObjectArray<RawProviderModel>(data.data, 'provider models');
       const models = rawModels
         .filter((model) => discovery.filter !== 'language-models' || model.type === 'language')
         .map(toModelInfo)
@@ -265,11 +267,13 @@ async function fetchProviderModelsStrict(
         await r.cancel();
         throw new ConnectionEffectHttpError(r.status);
       }
-      const data = await readProviderJson<{ models?: Array<{ name?: string }> }>(r);
-      return (data.models ?? []).flatMap((model) => {
-        const id = model.name?.split('/').pop();
-        return id ? [{ id }] : [];
-      });
+      const data = await readProviderJson<{ models?: unknown }>(r);
+      return providerObjectArray<{ name?: string }>(data.models, 'Google models').flatMap(
+        (model) => {
+          const id = model.name?.split('/').pop();
+          return id ? [{ id }] : [];
+        },
+      );
     }
     case 'cohere':
       throw new Error('Cohere requires native model discovery');
@@ -300,20 +304,22 @@ async function fetchCloudflareModels(
       success?: unknown;
       result?: unknown;
     }>(response);
-    if (data.success !== true || !Array.isArray(data.result)) {
+    if (data.success !== true) {
       throw new ConnectionEffectInvalidResponseError('Invalid Cloudflare models response');
     }
-    rawModelCount += data.result.length;
+    const rawModels = providerObjectArray<RawCloudflareModel>(
+      data.result,
+      'Cloudflare models',
+      true,
+    );
+    rawModelCount += rawModels.length;
     if (rawModelCount > CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION) {
       throw new ConnectionEffectInvalidResponseError('Provider returned too many models');
     }
     models.push(
-      ...data.result.flatMap((raw) => {
-        const model = raw as RawCloudflareModel;
-        return typeof model.name === 'string' ? [{ id: model.name }] : [];
-      }),
+      ...rawModels.flatMap((model) => (typeof model.name === 'string' ? [{ id: model.name }] : [])),
     );
-    if (data.result.length === 0) return models;
+    if (rawModels.length === 0) return models;
     page += 1;
   }
   throw new ConnectionEffectInvalidResponseError('Provider returned too many models');
@@ -386,11 +392,12 @@ export async function fetchGitHubCopilotModels(
     await response.cancel();
     throw new ConnectionEffectHttpError(response.status);
   }
-  const payload = await readProviderJson<{ data?: RawGitHubCopilotModel[] }>(response);
-  if (!Array.isArray(payload.data)) {
-    throw new ConnectionEffectInvalidResponseError('Invalid GitHub Copilot models response');
-  }
-  return payload.data.flatMap(toGitHubCopilotModelInfo);
+  const payload = await readProviderJson<{ data?: unknown }>(response);
+  return providerObjectArray<RawGitHubCopilotModel>(
+    payload.data,
+    'GitHub Copilot models',
+    true,
+  ).flatMap(toGitHubCopilotModelInfo);
 }
 
 type RawOpenAiCodexModel = {
@@ -450,11 +457,13 @@ export async function fetchOpenAiCodexModels(
     await response.cancel();
     throw new OpenAiCodexDiscoveryError(response.status);
   }
-  const payload = await readProviderJson<{ models?: RawOpenAiCodexModel[] }>(response);
-  if (!Array.isArray(payload?.models)) {
-    throw new ConnectionEffectInvalidResponseError('Invalid OpenAI Codex models response');
-  }
-  const visible = payload.models.filter((model) => {
+  const payload = await readProviderJson<{ models?: unknown }>(response);
+  const models = providerObjectArray<RawOpenAiCodexModel>(
+    payload.models,
+    'OpenAI Codex models',
+    true,
+  );
+  const visible = models.filter((model) => {
     if (!model || typeof model.slug !== 'string' || !model.slug.trim()) return false;
     const visibility =
       typeof model.visibility === 'string' ? model.visibility.trim().toLowerCase() : '';
@@ -485,12 +494,22 @@ function contextWindowOfOpenAiCodexModel(model: RawOpenAiCodexModel): number | u
 
 function toGitHubCopilotModelInfo(model: RawGitHubCopilotModel): ModelInfo[] {
   if (
+    typeof model.id !== 'string' ||
     !model.id ||
     model.model_picker_enabled !== true ||
     model.policy?.state === 'disabled' ||
     model.capabilities?.supports?.tool_calls !== true
   )
     return [];
+  assertOptionalArray(model.supported_endpoints, 'model supported_endpoints');
+  assertOptionalArray(
+    model.capabilities.supports.reasoning_effort,
+    'model capabilities.supports.reasoning_effort',
+  );
+  assertOptionalArray(
+    model.capabilities.limits?.vision?.supported_media_types,
+    'model capabilities.limits.vision.supported_media_types',
+  );
   const endpoints = model.supported_endpoints ?? [];
   const apiProtocol = endpoints.includes('/v1/messages')
     ? ('anthropic-messages' as const)
@@ -509,7 +528,9 @@ function toGitHubCopilotModelInfo(model: RawGitHubCopilotModel): ModelInfo[] {
     supports.min_thinking_budget !== undefined;
   const vision =
     supports.vision === true ||
-    limits?.vision?.supported_media_types?.some((type) => type.startsWith('image/')) === true;
+    limits?.vision?.supported_media_types?.some(
+      (type) => typeof type === 'string' && type.startsWith('image/'),
+    ) === true;
   const contextWindow = limits?.max_context_window_tokens ?? limits?.max_prompt_tokens;
   return [
     {
@@ -560,22 +581,19 @@ async function fetchCohereModels(
       await response.cancel();
       throw new ConnectionEffectHttpError(response.status);
     }
-    const data = await readProviderJson<{
-      models?: RawCohereModel[];
-      next_page_token?: unknown;
-    }>(response);
-    if (data.models !== undefined && !Array.isArray(data.models)) {
-      throw new ConnectionEffectInvalidResponseError('Invalid Cohere models response');
-    }
-    const rawModels = data.models ?? [];
+    const data = await readProviderJson<{ models?: unknown; next_page_token?: unknown }>(response);
+    const rawModels = providerObjectArray<RawCohereModel>(data.models, 'Cohere models');
     rawModelCount += rawModels.length;
     if (rawModelCount > CONNECTION_CATALOG_MAX_MODELS_PER_CONNECTION) {
       throw new ConnectionEffectInvalidResponseError('Provider returned too many models');
     }
     models.push(
       ...rawModels.flatMap((model) => {
-        if (!model.name || model.is_deprecated === true || !model.endpoints?.includes('chat'))
+        if (typeof model.name !== 'string' || !model.name || model.is_deprecated === true) {
           return [];
+        }
+        assertOptionalArray(model.endpoints, 'model endpoints');
+        if (!model.endpoints?.includes('chat')) return [];
         return [
           {
             id: model.name,
@@ -632,7 +650,7 @@ async function fetchFireworksModels(
     authorization: `Bearer ${apiKey}`,
   };
   const signal = AbortSignal.timeout(MODEL_FETCH_TIMEOUT_MS);
-  const fetchPages = async <T>(
+  const fetchPages = async <T extends object>(
     path: string,
     query: Readonly<Record<string, string>>,
     itemKey: 'accounts' | 'models',
@@ -664,15 +682,11 @@ async function fetchFireworksModels(
         throw new ConnectionEffectHttpError(response.status);
       }
       const data = await readProviderJson<{
-        accounts?: T[];
-        models?: T[];
+        accounts?: unknown;
+        models?: unknown;
         nextPageToken?: unknown;
       }>(response);
-      const pageItems = data[itemKey];
-      if (pageItems !== undefined && !Array.isArray(pageItems)) {
-        throw new ConnectionEffectInvalidResponseError('Invalid Fireworks models response');
-      }
-      const rawItems = pageItems ?? [];
+      const rawItems = providerObjectArray<T>(data[itemKey], `Fireworks ${itemKey}`);
       reserveItems?.(rawItems.length);
       items.push(...rawItems);
       if (items.length > maxItems) {
@@ -747,7 +761,14 @@ async function fetchFireworksModels(
 }
 
 function toModelInfo(model: RawProviderModel): ModelInfo | null {
-  if (!model.id) return null;
+  if (typeof model.id !== 'string' || !model.id) return null;
+  assertOptionalArray(model.input_modalities, 'model input_modalities');
+  assertOptionalArray(model.output_modalities, 'model output_modalities');
+  assertOptionalArray(model.tags, 'model tags');
+  const providers = providerObjectArray<NonNullable<RawProviderModel['providers']>[number]>(
+    model.providers,
+    'model providers',
+  );
   const contextWindow = model.context_length ?? model.context_window;
   const capabilities: NonNullable<ModelInfo['capabilities']> = {};
   if (model.input_modalities?.includes('image')) capabilities.vision = true;
@@ -760,7 +781,7 @@ function toModelInfo(model: RawProviderModel): ModelInfo | null {
   if (model.tags?.includes('reasoning')) capabilities.reasoning = true;
   if (model.tags?.includes('tool-use')) capabilities.functionCalling = true;
   if (model.providers) {
-    capabilities.functionCalling = model.providers.some(
+    capabilities.functionCalling = providers.some(
       (provider) => provider.status === 'live' && provider.supports_tools === true,
     );
   }
@@ -799,7 +820,35 @@ function ollamaRoot(baseUrl: string): string {
 }
 
 async function readProviderJson<T>(response: ConnectionEffectResponse): Promise<T> {
-  return response.readJson<T>();
+  const value = await response.readJson<unknown>();
+  if (value === null || typeof value !== 'object') {
+    throw new ConnectionEffectInvalidResponseError('Invalid provider JSON response structure');
+  }
+  return value as T;
+}
+
+function providerObjectArray<T extends object>(
+  value: unknown,
+  label: string,
+  required = false,
+): T[] {
+  if (value === undefined && !required) return [];
+  if (
+    !Array.isArray(value) ||
+    value.some((item) => item === null || typeof item !== 'object' || Array.isArray(item))
+  ) {
+    throw new ConnectionEffectInvalidResponseError(`Invalid ${label} response`);
+  }
+  return value as T[];
+}
+
+function assertOptionalArray(
+  value: unknown,
+  label: string,
+): asserts value is unknown[] | undefined {
+  if (value !== undefined && !Array.isArray(value)) {
+    throw new ConnectionEffectInvalidResponseError(`Invalid ${label}`);
+  }
 }
 
 function nextProviderPageToken(value: unknown): string | undefined {

--- a/packages/runtime/src/model-runtime.ts
+++ b/packages/runtime/src/model-runtime.ts
@@ -1,9 +1,9 @@
 import {
   PROVIDER_DEFAULTS,
   effectiveBaseUrl,
-  type LlmConnection,
   type ModelInfo,
   type ProviderRuntimeAdapter,
+  type ProviderType,
 } from '@maka/core/llm-connections';
 import { lookupModelProviderOverride } from '@maka/core/model-metadata';
 
@@ -14,8 +14,14 @@ export interface ResolvedModelRuntime {
   apiProtocol?: ModelInfo['apiProtocol'];
 }
 
+export interface ModelRuntimeConnection {
+  readonly providerType: ProviderType;
+  readonly baseUrl?: string;
+  readonly models?: readonly ModelInfo[];
+}
+
 export function resolveModelRuntime(
-  connection: LlmConnection,
+  connection: ModelRuntimeConnection,
   modelId: string,
 ): ResolvedModelRuntime {
   const override = lookupModelProviderOverride(connection.providerType, modelId);

--- a/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
+++ b/packages/runtime/src/network/__tests__/scoped-fetch-transport.test.ts
@@ -1,0 +1,489 @@
+import assert from 'node:assert/strict';
+import { createServer } from 'node:http';
+import net from 'node:net';
+import { afterEach, describe, test } from 'node:test';
+import { PROXY_DEFAULTS, type ProxySettings } from '@maka/core/settings/network-settings';
+import {
+  CONNECTION_EFFECT_ERROR_BODY_MAX_BYTES,
+  CONNECTION_EFFECT_JSON_BODY_MAX_BYTES,
+  ConnectionEffectFetchError,
+  fetchForConnectionEffect,
+} from '../../connection-effect-fetch.js';
+import { fetchProviderModels, runConnectionModelDiscoveryEffect } from '../../model-fetcher.js';
+import { runConnectionTestEffect, testConnection } from '../../test-connection.js';
+import { setActiveProxy } from '../active-proxy-state.js';
+import { createConnectionEffectFetchTransport } from '../scoped-fetch-transport.js';
+
+afterEach(() => setActiveProxy(null));
+
+describe('connection effect network transport', () => {
+  test('concurrent discovery uses immutable per-effect proxy snapshots', async () => {
+    const firstProxy = await startConnectProxy(() =>
+      jsonResponse(200, modelPayload('first-model')),
+    );
+    const secondProxy = await startConnectProxy(() =>
+      jsonResponse(200, modelPayload('second-model')),
+    );
+    const firstSettings: ProxySettings = {
+      ...PROXY_DEFAULTS,
+      enabled: true,
+      host: '127.0.0.1',
+      port: firstProxy.port,
+      username: 'effect-one',
+      password: 'secret-one',
+      bypassList: [],
+    };
+    const secondSettings: ProxySettings = {
+      ...PROXY_DEFAULTS,
+      enabled: true,
+      host: '127.0.0.1',
+      port: secondProxy.port,
+      username: 'effect-two',
+      password: 'secret-two',
+      bypassList: [],
+    };
+    const firstTransport = createConnectionEffectFetchTransport(firstSettings);
+    const secondTransport = createConnectionEffectFetchTransport(secondSettings);
+
+    firstSettings.port = secondProxy.port;
+    firstSettings.password = 'mutated-after-capture';
+
+    try {
+      const [first, second] = await Promise.all([
+        runConnectionModelDiscoveryEffect(openAiConnection('first'), 'provider-key', {
+          fetch: firstTransport.fetch,
+        }),
+        runConnectionModelDiscoveryEffect(openAiConnection('second'), 'provider-key', {
+          fetch: secondTransport.fetch,
+        }),
+      ]);
+
+      assert.deepEqual(first, { ok: true, models: [{ id: 'first-model' }] });
+      assert.deepEqual(second, { ok: true, models: [{ id: 'second-model' }] });
+      assert.deepEqual(firstProxy.proxyAuthorization, [
+        `Basic ${Buffer.from('effect-one:secret-one').toString('base64')}`,
+      ]);
+      assert.deepEqual(secondProxy.proxyAuthorization, [
+        `Basic ${Buffer.from('effect-two:secret-two').toString('base64')}`,
+      ]);
+    } finally {
+      await Promise.all([
+        firstTransport.close(),
+        secondTransport.close(),
+        firstProxy.close(),
+        secondProxy.close(),
+      ]);
+    }
+  });
+
+  test('close terminates owned proxy resources and rejects later fetches', async () => {
+    const proxy = await startConnectProxy(() => {
+      const body = modelPayload('stream-model');
+      return `HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: ${
+        Buffer.byteLength(body) + 100
+      }\r\n\r\n${body}`;
+    }, false);
+    const transport = createConnectionEffectFetchTransport({
+      ...PROXY_DEFAULTS,
+      enabled: true,
+      host: '127.0.0.1',
+      port: proxy.port,
+      bypassList: [],
+    });
+
+    try {
+      const response = await transport.fetch('http://provider.invalid/v1/models');
+      assert.equal(response.status, 200);
+      assert.equal(proxy.sockets.size, 1);
+
+      const socket = [...proxy.sockets][0]!;
+      const socketClosed = waitForSocketClose(socket);
+      await Promise.all([transport.close(), transport.close(), socketClosed]);
+      assert.equal(proxy.sockets.size, 0);
+      await assert.rejects(
+        () => transport.fetch('http://provider.invalid/v1/models'),
+        /transport is closed/,
+      );
+    } finally {
+      await transport.close();
+      await proxy.close();
+    }
+  });
+
+  test('close terminates resources owned by a direct transport', async () => {
+    const sockets = new Set<net.Socket>();
+    const server = createServer((_request, response) => {
+      response.writeHead(200, {
+        'content-type': 'application/json',
+        'content-length': '1000',
+      });
+      response.write('{"data":[');
+    });
+    server.on('connection', (socket) => {
+      sockets.add(socket);
+      socket.on('close', () => sockets.delete(socket));
+    });
+    const port = await listen(server);
+    const transport = createConnectionEffectFetchTransport(null);
+
+    try {
+      const response = await transport.fetch(`http://127.0.0.1:${port}/models`);
+      assert.equal(response.status, 200);
+      assert.equal(sockets.size, 1);
+
+      const socket = [...sockets][0]!;
+      const socketClosed = waitForSocketClose(socket);
+      await Promise.all([transport.close(), transport.close(), socketClosed]);
+      assert.equal(sockets.size, 0);
+    } finally {
+      await transport.close();
+      for (const socket of sockets) socket.destroy();
+      await closeServer(server);
+    }
+  });
+
+  test('body timeout remains active after response headers arrive', async () => {
+    const server = createServer((_request, response) => {
+      response.writeHead(200, {
+        'content-type': 'application/json',
+        'content-length': '1000',
+      });
+      response.write('{"data":[');
+    });
+    const port = await listen(server);
+    const transport = createConnectionEffectFetchTransport(null);
+
+    try {
+      const response = await fetchForConnectionEffect(
+        transport.fetch,
+        `http://127.0.0.1:${port}/models`,
+        { timeoutMs: 50 },
+      );
+      await assert.rejects(
+        response.readJson(),
+        (error: unknown) => error instanceof ConnectionEffectFetchError && error.kind === 'timeout',
+      );
+    } finally {
+      await transport.close();
+      await closeServer(server);
+    }
+  });
+
+  test('oversized provider JSON and error bodies fail without escaping their bounds', async () => {
+    const server = createServer((request, response) => {
+      if (request.url?.startsWith('/models/')) {
+        return respond(
+          response,
+          200,
+          JSON.stringify({
+            data: [
+              {
+                id: 'oversized-model',
+                display_name: 'x'.repeat(CONNECTION_EFFECT_JSON_BODY_MAX_BYTES),
+              },
+            ],
+          }),
+        );
+      }
+      respond(response, 401, 's'.repeat(CONNECTION_EFFECT_ERROR_BODY_MAX_BYTES + 1));
+    });
+    const port = await listen(server);
+    const transport = createConnectionEffectFetchTransport(null);
+
+    try {
+      const discovery = await runConnectionModelDiscoveryEffect(
+        {
+          ...openAiConnection('models'),
+          baseUrl: `http://127.0.0.1:${port}/models/v1`,
+        },
+        'provider-key',
+        { fetch: transport.fetch },
+      );
+      assert.deepEqual(discovery, { ok: false, error: { kind: 'invalid_response' } });
+
+      const connectionTest = await runConnectionTestEffect(
+        {
+          providerType: 'moonshot',
+          baseUrl: `http://127.0.0.1:${port}/test/v1`,
+          enabledModelIds: ['moonshot-v1-8k'],
+        },
+        'provider-key',
+        { fetch: transport.fetch },
+      );
+      assert.equal(connectionTest.ok, false);
+      if (!connectionTest.ok) {
+        assert.deepEqual(connectionTest.error, { kind: 'invalid_response' });
+      }
+    } finally {
+      await transport.close();
+      await closeServer(server);
+    }
+  });
+
+  test('successful probes cancel an unused response body', async () => {
+    let responseClosed: Promise<void> | undefined;
+    const server = createServer((_request, response) => {
+      responseClosed = new Promise((resolve) => response.once('close', resolve));
+      response.writeHead(200, {
+        'content-type': 'application/json',
+        'content-length': '1000',
+      });
+      response.write('{"choices":[');
+    });
+    const port = await listen(server);
+    const transport = createConnectionEffectFetchTransport(null);
+
+    try {
+      const outcome = await runConnectionTestEffect(
+        {
+          providerType: 'moonshot',
+          baseUrl: `http://127.0.0.1:${port}/v1`,
+          enabledModelIds: ['moonshot-v1-8k'],
+        },
+        'provider-key',
+        { fetch: transport.fetch },
+      );
+      assert.equal(outcome.ok, true);
+      assert.ok(responseClosed);
+      await responseClosed;
+    } finally {
+      await transport.close();
+      await closeServer(server);
+    }
+  });
+
+  test('legacy discovery fallback still resolves the Desktop active proxy', async () => {
+    const proxy = await startConnectProxy(() =>
+      jsonResponse(200, modelPayload('desktop-global-model')),
+    );
+    setActiveProxy({
+      ...PROXY_DEFAULTS,
+      enabled: true,
+      host: '127.0.0.1',
+      port: proxy.port,
+      bypassList: [],
+    });
+
+    try {
+      assert.deepEqual(await fetchProviderModels(openAiConnection('desktop'), 'provider-key'), [
+        { id: 'desktop-global-model' },
+      ]);
+      assert.equal(proxy.requestCount, 1);
+    } finally {
+      setActiveProxy(null);
+      await proxy.close();
+    }
+  });
+
+  test('discovery exposes closed classifications without provider response bodies', async () => {
+    const server = createServer((request, response) => {
+      const path = request.url ?? '';
+      if (path.startsWith('/auth/')) return respond(response, 401, 'auth-body-secret');
+      if (path.startsWith('/timeout/')) return respond(response, 408, 'timeout-body-secret');
+      if (path.startsWith('/unavailable/')) {
+        return respond(response, 503, 'provider-body-secret');
+      }
+      if (path.startsWith('/metadata/')) {
+        return respond(
+          response,
+          200,
+          JSON.stringify({
+            data: [{ id: 'model-with-invalid-metadata', display_name: 'x'.repeat(513) }],
+          }),
+        );
+      }
+      if (path.startsWith('/invalid/')) return respond(response, 200, '{not-json');
+      return respond(response, 400, 'unknown-body-secret');
+    });
+    const port = await listen(server);
+    const transport = createConnectionEffectFetchTransport(null);
+
+    try {
+      const cases = [
+        ['auth', 'auth'],
+        ['timeout', 'timeout'],
+        ['unavailable', 'provider_unavailable'],
+        ['metadata', 'invalid_response'],
+        ['invalid', 'invalid_response'],
+        ['unknown', 'unknown'],
+      ] as const;
+      for (const [path, expectedKind] of cases) {
+        const outcome = await runConnectionModelDiscoveryEffect(
+          {
+            ...openAiConnection(path),
+            baseUrl: `http://127.0.0.1:${port}/${path}/v1`,
+          },
+          'provider-key',
+          { fetch: transport.fetch },
+        );
+        assert.equal(outcome.ok, false);
+        if (outcome.ok) continue;
+        assert.equal(outcome.error.kind, expectedKind);
+        assert.doesNotMatch(JSON.stringify(outcome), /body-secret|not-json/);
+      }
+
+      const network = await runConnectionModelDiscoveryEffect(
+        {
+          ...openAiConnection('network'),
+          baseUrl: 'http://127.0.0.1:1/v1',
+        },
+        'provider-key',
+        { fetch: transport.fetch },
+      );
+      assert.deepEqual(network, { ok: false, error: { kind: 'network' } });
+    } finally {
+      await transport.close();
+      await closeServer(server);
+    }
+  });
+
+  test('connection testing reuses provider logic with an explicit direct transport', async () => {
+    const server = createServer((request, response) => {
+      assert.equal(request.method, 'POST');
+      assert.equal(request.url, '/v1/chat/completions');
+      respond(response, 401, 'raw-provider-auth-detail');
+    });
+    const port = await listen(server);
+    const transport = createConnectionEffectFetchTransport(null);
+
+    try {
+      const connection = {
+        ...openAiConnection('test'),
+        providerType: 'moonshot' as const,
+        baseUrl: `http://127.0.0.1:${port}/v1`,
+        enabledModelIds: ['moonshot-v1-8k'],
+      };
+      const outcome = await runConnectionTestEffect(connection, 'provider-key', {
+        fetch: transport.fetch,
+      });
+
+      assert.equal(outcome.ok, false);
+      if (outcome.ok) return;
+      assert.deepEqual(outcome.error, { kind: 'auth', statusCode: 401 });
+      assert.equal(outcome.modelId, undefined);
+      assert.equal(typeof outcome.latencyMs, 'number');
+      assert.deepEqual(Object.keys(outcome).sort(), ['error', 'latencyMs', 'ok']);
+      assert.doesNotMatch(JSON.stringify(outcome), /raw-provider-auth-detail|errorMessage/);
+
+      const legacy = await testConnection(connection, 'provider-key', undefined, {
+        fetch: transport.fetch,
+      });
+      assert.match(legacy.errorMessage ?? '', /raw-provider-auth-detail/);
+    } finally {
+      await transport.close();
+      await closeServer(server);
+    }
+  });
+});
+
+function openAiConnection(slug: string) {
+  return {
+    slug,
+    name: slug,
+    providerType: 'openai' as const,
+    baseUrl: 'http://provider.invalid/v1',
+    defaultModel: 'gpt-test',
+    enabled: true,
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function modelPayload(model: string): string {
+  return JSON.stringify({ data: [{ id: model }] });
+}
+
+function jsonResponse(status: number, body: string): string {
+  return `HTTP/1.1 ${status} OK\r\nContent-Type: application/json\r\nContent-Length: ${Buffer.byteLength(
+    body,
+  )}\r\nConnection: close\r\n\r\n${body}`;
+}
+
+function respond(response: import('node:http').ServerResponse, status: number, body: string): void {
+  response.writeHead(status, { 'content-type': 'application/json' });
+  response.end(body);
+}
+
+interface ConnectProxy {
+  readonly port: number;
+  readonly sockets: Set<net.Socket>;
+  readonly proxyAuthorization: string[];
+  readonly requestCount: number;
+  close(): Promise<void>;
+}
+
+async function startConnectProxy(
+  responseForRequest: () => string,
+  closeAfterResponse = true,
+): Promise<ConnectProxy> {
+  const sockets = new Set<net.Socket>();
+  const proxyAuthorization: string[] = [];
+  let requestCount = 0;
+  const server = net.createServer((socket) => {
+    sockets.add(socket);
+    socket.on('close', () => sockets.delete(socket));
+    socket.on('error', () => sockets.delete(socket));
+
+    let buffer = Buffer.alloc(0);
+    let tunnelEstablished = false;
+    socket.on('data', (chunk) => {
+      buffer = Buffer.concat([buffer, Buffer.from(chunk)]);
+      while (true) {
+        const headerEnd = buffer.indexOf('\r\n\r\n');
+        if (headerEnd < 0) return;
+        const requestHead = buffer.subarray(0, headerEnd).toString('latin1');
+        buffer = buffer.subarray(headerEnd + 4);
+        const authorization = requestHead.match(/\r\nproxy-authorization:\s*([^\r\n]+)/i)?.[1];
+        if (authorization) proxyAuthorization.push(authorization);
+        if (!tunnelEstablished && requestHead.startsWith('CONNECT ')) {
+          tunnelEstablished = true;
+          socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+          continue;
+        }
+
+        requestCount += 1;
+        assert.match(requestHead, /^GET (?:http:\/\/provider\.invalid)?\/v1\/models HTTP\/1\.1/);
+        const response = responseForRequest();
+        if (closeAfterResponse) socket.end(response);
+        else socket.write(response);
+        return;
+      }
+    });
+  });
+  const port = await listen(server);
+
+  return {
+    port,
+    sockets,
+    proxyAuthorization,
+    get requestCount() {
+      return requestCount;
+    },
+    async close() {
+      for (const socket of sockets) socket.destroy();
+      await closeServer(server);
+    },
+  };
+}
+
+function listen(server: net.Server): Promise<number> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      assert.ok(address && typeof address === 'object');
+      resolve(address.port);
+    });
+  });
+}
+
+function closeServer(server: net.Server): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.close((error) => (error ? reject(error) : resolve()));
+  });
+}
+
+function waitForSocketClose(socket: net.Socket): Promise<void> {
+  if (socket.destroyed) return Promise.resolve();
+  return new Promise((resolve) => socket.once('close', () => resolve()));
+}

--- a/packages/runtime/src/network/scoped-fetch-transport.ts
+++ b/packages/runtime/src/network/scoped-fetch-transport.ts
@@ -1,0 +1,66 @@
+import type { ProxySettings } from '@maka/core/settings/network-settings';
+import { Agent, fetch as undiciFetch, type Dispatcher } from 'undici';
+import type { ConnectionEffectFetch } from '../connection-effect-fetch.js';
+import { matchesBypassList } from './bypass-matcher.js';
+import { buildProxyDispatcher } from './proxy-dispatcher.js';
+
+export interface ConnectionEffectProxySnapshot {
+  readonly enabled: boolean;
+  readonly type: ProxySettings['type'];
+  readonly host: string;
+  readonly port: number;
+  readonly username?: string;
+  readonly password?: string;
+  readonly bypassList: readonly string[];
+}
+
+export interface ConnectionEffectFetchTransport {
+  readonly fetch: ConnectionEffectFetch;
+  close(): Promise<void>;
+}
+
+export function createConnectionEffectFetchTransport(
+  proxy: ConnectionEffectProxySnapshot | null,
+): ConnectionEffectFetchTransport {
+  const proxySnapshot: ProxySettings | null = proxy?.enabled
+    ? { ...proxy, bypassList: [...proxy.bypassList] }
+    : null;
+  const directDispatcher = new Agent();
+  let proxyDispatcher: Dispatcher | undefined;
+  let closePromise: Promise<void> | undefined;
+  let closed = false;
+
+  const fetch: ConnectionEffectFetch = async (input, init) => {
+    if (closed) throw new Error('Connection effect fetch transport is closed');
+
+    const url =
+      typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+    const useProxy =
+      proxySnapshot !== null && !matchesBypassList(new URL(url).hostname, proxySnapshot.bypassList);
+    if (useProxy) proxyDispatcher ??= buildProxyDispatcher(proxySnapshot) as Dispatcher;
+
+    return (await undiciFetch(
+      input as Parameters<typeof undiciFetch>[0],
+      {
+        ...init,
+        dispatcher: useProxy ? proxyDispatcher : directDispatcher,
+      } as Parameters<typeof undiciFetch>[1],
+    )) as unknown as Response;
+  };
+
+  const close = (): Promise<void> => {
+    if (closePromise) return closePromise;
+    closed = true;
+    closePromise = Promise.all([
+      directDispatcher
+        .destroy(new Error('Connection effect fetch transport closed'))
+        .catch(() => {}),
+      proxyDispatcher
+        ?.destroy(new Error('Connection effect fetch transport closed'))
+        .catch(() => {}),
+    ]).then(() => undefined);
+    return closePromise;
+  };
+
+  return { fetch, close };
+}

--- a/packages/runtime/src/test-connection.ts
+++ b/packages/runtime/src/test-connection.ts
@@ -1,15 +1,32 @@
 import {
   PROVIDER_DEFAULTS,
   connectionEnabledModelIds,
+  type ConnectionTestErrorClass,
   type ConnectionTestResult,
   type LlmConnection,
 } from '@maka/core/llm-connections';
 import { openAiAdapterApiProtocol } from '@maka/core/model-metadata';
-import { proxiedFetch } from './bots/proxied-fetch.js';
 import { anthropicV1Url, googleApiUrl } from './provider-urls.js';
 import { resolveModelRuntime } from './model-runtime.js';
 import { claudeSubscriptionHeaders } from './subscription-auth.js';
 import { fetchGitHubCopilotModels } from './model-fetcher.js';
+import {
+  CONNECTION_EFFECT_ERROR_BODY_MAX_BYTES,
+  ConnectionEffectFetchError,
+  fetchForConnectionEffect,
+  type ConnectionEffectFetch,
+  type ConnectionEffectFetchDependency,
+  type ConnectionEffectFetchOptions,
+  type ConnectionEffectResponse,
+} from './connection-effect-fetch.js';
+import {
+  ConnectionEffectHttpError,
+  ConnectionEffectInvalidResponseError,
+  classifyConnectionEffectStatus,
+  type ConnectionEffectConnection,
+  type ConnectionEffectError,
+  type ConnectionTestEffectOutcome,
+} from './connection-effect-outcome.js';
 
 const CONNECTION_TEST_TIMEOUT_MS = 15_000;
 
@@ -19,7 +36,7 @@ const CONNECTION_TEST_TIMEOUT_MS = 15_000;
  * default/fallback order.
  */
 function resolveConnectionTestModel(
-  connection: LlmConnection,
+  connection: ConnectionEffectConnection,
   model: string | undefined,
   fallbackModels: readonly string[],
 ): string | undefined {
@@ -49,8 +66,56 @@ export async function testConnection(
   connection: LlmConnection,
   apiKey: string,
   model?: string,
+  options: ConnectionEffectFetchOptions = {},
 ): Promise<ConnectionTestResult> {
   const t0 = Date.now();
+  try {
+    return await testConnectionStrict(connection, apiKey, model, options.fetch, t0);
+  } catch (error) {
+    return connectionTestFailure(error, t0, true);
+  }
+}
+
+export async function runConnectionTestEffect(
+  connection: ConnectionEffectConnection,
+  apiKey: string,
+  options: ConnectionEffectFetchDependency,
+  model?: string,
+): Promise<ConnectionTestEffectOutcome> {
+  const t0 = Date.now();
+  try {
+    const result = await testConnectionStrict(connection, apiKey, model, options.fetch, t0);
+    if (result.ok) {
+      if (!result.modelTested || result.latencyMs === undefined) {
+        return { ok: false, error: { kind: 'invalid_response' } };
+      }
+      return {
+        ok: true,
+        modelId: result.modelTested,
+        latencyMs: result.latencyMs,
+      };
+    }
+    return {
+      ok: false,
+      error: classifyConnectionTestResult(result),
+      ...connectionTestMeasurements(result),
+    };
+  } catch (error) {
+    return {
+      ok: false,
+      error: classifyConnectionTestError(error),
+      latencyMs: Date.now() - t0,
+    };
+  }
+}
+
+async function testConnectionStrict(
+  connection: ConnectionEffectConnection,
+  apiKey: string,
+  model: string | undefined,
+  fetchFn: ConnectionEffectFetch | undefined,
+  t0: number,
+): Promise<ConnectionTestResult> {
   const defaults = PROVIDER_DEFAULTS[connection.providerType];
   // Unknown providerType → can't pick an auth path or fallback model. Return a
   // clear failure rather than crashing. Mirrors `isFakeBackend`.
@@ -66,46 +131,37 @@ export async function testConnection(
   }
   const { adapter, baseUrl, apiProtocol } = resolveModelRuntime(connection, testModel);
 
-  try {
-    switch (adapter.kind) {
-      case 'anthropic':
-      case 'claude-subscription':
-        return await probeAnthropic(connection, baseUrl, secret, testModel, t0);
-      case 'openai': {
-        const resolvedApiProtocol =
-          adapter.apiProtocol ??
-          apiProtocol ??
-          openAiAdapterApiProtocol(testModel, connection.providerType);
-        return resolvedApiProtocol === 'openai-responses'
-          ? await probeOpenAIResponses(baseUrl, secret, testModel, t0)
-          : await probeOpenAI(connection, baseUrl, secret, testModel, t0);
-      }
-      case 'openai-codex':
-      case 'openai-compatible':
-        return await probeOpenAI(connection, baseUrl, secret, testModel, t0);
-      case 'github-copilot':
-        return await probeGitHubCopilot(baseUrl, secret, testModel, t0);
-      case 'google':
-        return await probeGoogle(
-          baseUrl,
-          secret,
-          testModel,
-          t0,
-          adapter.normalizeBaseUrl !== false,
-        );
-      case 'cohere':
-        return await probeCohere(baseUrl, secret, testModel, t0);
-      case 'unavailable':
-        throw new Error(`${connection.providerType} is experimental and not wired yet`);
+  switch (adapter.kind) {
+    case 'anthropic':
+    case 'claude-subscription':
+      return await probeAnthropic(connection, baseUrl, secret, testModel, t0, fetchFn);
+    case 'openai': {
+      const resolvedApiProtocol =
+        adapter.apiProtocol ??
+        apiProtocol ??
+        openAiAdapterApiProtocol(testModel, connection.providerType);
+      return resolvedApiProtocol === 'openai-responses'
+        ? await probeOpenAIResponses(baseUrl, secret, testModel, t0, fetchFn)
+        : await probeOpenAI(connection, baseUrl, secret, testModel, t0, fetchFn);
     }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    return {
-      ok: false,
-      errorMessage: message,
-      errorClass: message.toLowerCase().includes('timeout') ? 'timeout' : 'network',
-      latencyMs: Date.now() - t0,
-    };
+    case 'openai-codex':
+    case 'openai-compatible':
+      return await probeOpenAI(connection, baseUrl, secret, testModel, t0, fetchFn);
+    case 'github-copilot':
+      return await probeGitHubCopilot(baseUrl, secret, testModel, t0, fetchFn);
+    case 'google':
+      return await probeGoogle(
+        baseUrl,
+        secret,
+        testModel,
+        t0,
+        adapter.normalizeBaseUrl !== false,
+        fetchFn,
+      );
+    case 'cohere':
+      return await probeCohere(baseUrl, secret, testModel, t0, fetchFn);
+    case 'unavailable':
+      throw new Error(`${connection.providerType} is experimental and not wired yet`);
   }
 }
 
@@ -114,8 +170,9 @@ async function probeGitHubCopilot(
   apiKey: string,
   model: string,
   t0: number,
+  fetchFn: ConnectionEffectFetch | undefined,
 ): Promise<ConnectionTestResult> {
-  const models = await fetchGitHubCopilotModels(baseUrl, apiKey);
+  const models = await fetchGitHubCopilotModels(baseUrl, apiKey, fetchFn);
   if (!models.some(({ id }) => id === model)) {
     return {
       ok: false,
@@ -130,8 +187,9 @@ async function probeOpenAIResponses(
   apiKey: string,
   model: string,
   t0: number,
+  fetchFn: ConnectionEffectFetch | undefined,
 ): Promise<ConnectionTestResult> {
-  const r = await proxiedFetch(`${stripTrailing(baseUrl)}/responses`, {
+  const r = await fetchForConnectionEffect(fetchFn, `${stripTrailing(baseUrl)}/responses`, {
     method: 'POST',
     headers: {
       authorization: `Bearer ${apiKey}`,
@@ -146,6 +204,7 @@ async function probeOpenAIResponses(
     timeoutMs: CONNECTION_TEST_TIMEOUT_MS,
   });
   if (!r.ok) return httpFailure(r, t0);
+  await r.cancel();
   return { ok: true, latencyMs: Date.now() - t0, modelTested: model };
 }
 
@@ -154,8 +213,9 @@ async function probeCohere(
   apiKey: string,
   model: string,
   t0: number,
+  fetchFn: ConnectionEffectFetch | undefined,
 ): Promise<ConnectionTestResult> {
-  const r = await proxiedFetch(`${stripTrailing(baseUrl)}/chat`, {
+  const r = await fetchForConnectionEffect(fetchFn, `${stripTrailing(baseUrl)}/chat`, {
     method: 'POST',
     headers: {
       authorization: `Bearer ${apiKey}`,
@@ -169,15 +229,17 @@ async function probeCohere(
     timeoutMs: CONNECTION_TEST_TIMEOUT_MS,
   });
   if (!r.ok) return httpFailure(r, t0);
+  await r.cancel();
   return { ok: true, latencyMs: Date.now() - t0, modelTested: model };
 }
 
 async function probeAnthropic(
-  connection: LlmConnection,
+  connection: Pick<ConnectionEffectConnection, 'providerType'>,
   baseUrl: string,
   secret: string,
   model: string,
   t0: number,
+  fetchFn: ConnectionEffectFetch | undefined,
 ): Promise<ConnectionTestResult> {
   const headers: Record<string, string> =
     connection.providerType === 'claude-subscription'
@@ -203,7 +265,7 @@ async function probeAnthropic(
     return { ok: true, latencyMs: Date.now() - t0, modelTested: model };
   }
 
-  const r = await proxiedFetch(anthropicV1Url(baseUrl, '/messages'), {
+  const r = await fetchForConnectionEffect(fetchFn, anthropicV1Url(baseUrl, '/messages'), {
     method: 'POST',
     headers,
     body: JSON.stringify({
@@ -214,15 +276,17 @@ async function probeAnthropic(
     timeoutMs: CONNECTION_TEST_TIMEOUT_MS,
   });
   if (!r.ok) return httpFailure(r, t0);
+  await r.cancel();
   return { ok: true, latencyMs: Date.now() - t0, modelTested: model };
 }
 
 async function probeOpenAI(
-  connection: LlmConnection,
+  connection: Pick<ConnectionEffectConnection, 'providerType'>,
   baseUrl: string,
   apiKey: string,
   model: string,
   t0: number,
+  fetchFn: ConnectionEffectFetch | undefined,
 ): Promise<ConnectionTestResult> {
   if (connection.providerType === 'openai-codex') {
     // Codex Subscription credentials are ChatGPT account-scoped OAuth
@@ -234,7 +298,7 @@ async function probeOpenAI(
     // chat with the provider error class.
     return { ok: true, latencyMs: Date.now() - t0, modelTested: model };
   }
-  const r = await proxiedFetch(`${stripTrailing(baseUrl)}/chat/completions`, {
+  const r = await fetchForConnectionEffect(fetchFn, `${stripTrailing(baseUrl)}/chat/completions`, {
     method: 'POST',
     headers: {
       ...(apiKey ? { authorization: `Bearer ${apiKey}` } : {}),
@@ -248,6 +312,7 @@ async function probeOpenAI(
     timeoutMs: CONNECTION_TEST_TIMEOUT_MS,
   });
   if (!r.ok) return httpFailure(r, t0);
+  await r.cancel();
   return { ok: true, latencyMs: Date.now() - t0, modelTested: model };
 }
 
@@ -257,11 +322,12 @@ async function probeGoogle(
   model: string,
   t0: number,
   normalizeBaseUrl: boolean,
+  fetchFn: ConnectionEffectFetch | undefined,
 ): Promise<ConnectionTestResult> {
   const url = normalizeBaseUrl
     ? googleApiUrl(baseUrl, `/models/${encodeURIComponent(model)}:generateContent`, apiKey)
     : `${stripTrailing(baseUrl)}/models/${encodeURIComponent(model)}:generateContent`;
-  const r = await proxiedFetch(url, {
+  const r = await fetchForConnectionEffect(fetchFn, url, {
     method: 'POST',
     headers: {
       ...(normalizeBaseUrl ? {} : { 'x-goog-api-key': apiKey }),
@@ -274,12 +340,14 @@ async function probeGoogle(
     timeoutMs: CONNECTION_TEST_TIMEOUT_MS,
   });
   if (!r.ok) return httpFailure(r, t0);
+  await r.cancel();
   return { ok: true, latencyMs: Date.now() - t0, modelTested: model };
 }
 
-async function httpFailure(r: Response, t0: number): Promise<ConnectionTestResult> {
+async function httpFailure(r: ConnectionEffectResponse, t0: number): Promise<ConnectionTestResult> {
   const statusCode = r.status;
   if (statusCode === 429) {
+    await r.cancel();
     return {
       ok: false,
       errorMessage:
@@ -289,9 +357,10 @@ async function httpFailure(r: Response, t0: number): Promise<ConnectionTestResul
       latencyMs: Date.now() - t0,
     };
   }
+  const errorBody = await r.readText(CONNECTION_EFFECT_ERROR_BODY_MAX_BYTES);
   return {
     ok: false,
-    errorMessage: `${statusCode} ${(await r.text()).slice(0, 200)}`,
+    errorMessage: `${statusCode} ${errorBody.slice(0, 200)}`,
     statusCode,
     errorClass: classifyHttpStatus(statusCode),
     latencyMs: Date.now() - t0,
@@ -306,4 +375,68 @@ function classifyHttpStatus(statusCode: number): ConnectionTestResult['errorClas
   if (statusCode === 401 || statusCode === 403) return 'auth';
   if (statusCode >= 500) return 'provider_unavailable';
   return 'unknown';
+}
+
+function connectionTestFailure(
+  error: unknown,
+  t0: number,
+  preserveLegacyTimeoutClassification = false,
+): ConnectionTestResult {
+  const message = error instanceof Error ? error.message : String(error);
+  return {
+    ok: false,
+    errorMessage: message,
+    errorClass:
+      (error instanceof ConnectionEffectFetchError && error.kind === 'timeout') ||
+      (preserveLegacyTimeoutClassification && message.toLowerCase().includes('timeout'))
+        ? 'timeout'
+        : 'network',
+    latencyMs: Date.now() - t0,
+  };
+}
+
+function classifyConnectionTestError(error: unknown): ConnectionEffectError {
+  if (error instanceof ConnectionEffectFetchError) return { kind: error.kind };
+  if (error instanceof ConnectionEffectHttpError) {
+    return classifyConnectionEffectStatus(error.status);
+  }
+  if (error instanceof ConnectionEffectInvalidResponseError || error instanceof SyntaxError) {
+    return { kind: 'invalid_response' };
+  }
+  return { kind: 'unknown' };
+}
+
+function classifyConnectionTestResult(result: ConnectionTestResult): ConnectionEffectError {
+  if (result.statusCode !== undefined) {
+    const statusError = classifyConnectionEffectStatus(result.statusCode);
+    if (statusError.kind !== 'unknown') return statusError;
+  }
+  return {
+    kind: connectionTestErrorKind(result.errorClass),
+    ...(result.statusCode === undefined ? {} : { statusCode: result.statusCode }),
+  };
+}
+
+function connectionTestMeasurements(
+  result: ConnectionTestResult,
+): Pick<Extract<ConnectionTestEffectOutcome, { readonly ok: false }>, 'modelId' | 'latencyMs'> {
+  return {
+    ...(result.modelTested === undefined ? {} : { modelId: result.modelTested }),
+    ...(result.latencyMs === undefined ? {} : { latencyMs: result.latencyMs }),
+  };
+}
+
+function connectionTestErrorKind(
+  errorClass: ConnectionTestErrorClass | undefined,
+): ConnectionEffectError['kind'] {
+  switch (errorClass) {
+    case 'auth':
+    case 'timeout':
+    case 'provider_unavailable':
+    case 'network':
+      return errorClass;
+    case 'unknown':
+    case undefined:
+      return 'unknown';
+  }
 }

--- a/packages/storage/src/__tests__/runtime-policy-stores.test.ts
+++ b/packages/storage/src/__tests__/runtime-policy-stores.test.ts
@@ -439,6 +439,1113 @@ describe('runtime policy stores', () => {
     });
   });
 
+  test('conditionally commits discovery and test facts from the latest admitted state with one-shot tickets', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-success', 'openai', 'Effects success'),
+      );
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: connectionCredential(connection, 'api_key'),
+            expected: null,
+            secret: 'effect-secret',
+          })
+        ).kind,
+        'committed',
+      );
+
+      assert.deepEqual(
+        await stores.operations.beginModelFetch('00000000-0000-4000-8000-000000000001'),
+        { kind: 'connection_not_found' },
+      );
+
+      const fetch = await stores.operations.beginModelFetch(connection.connectionId);
+      const testTicket = await stores.operations.beginConnectionTest(
+        connection.connectionId,
+        'gpt-5',
+      );
+      assert.equal(fetch.kind, 'ready');
+      assert.equal(testTicket.kind, 'ready');
+      if (fetch.kind !== 'ready' || testTicket.kind !== 'ready') return;
+      assert.equal(testTicket.modelId, 'gpt-5');
+      assert.equal(fetch.secretMaterial.connection?.secret, 'effect-secret');
+
+      await assert.rejects(
+        () =>
+          stores.operations.completeModelFetch(testTicket.ticket as never, {
+            models: [{ id: 'wrong-ticket-must-not-write' }],
+            source: 'fetched',
+            fetchedAt: 10,
+          }),
+        isStoreError('invalid_connection_input'),
+      );
+
+      const tested = await stores.operations.completeConnectionTest(testTicket.ticket, {
+        status: 'needs_reauth',
+        checkedAt: '2026-07-29T12:00:00.000Z',
+        errorClass: 'auth',
+      });
+      assert.equal(tested.kind, 'committed');
+      if (tested.kind !== 'committed') return;
+      assert.deepEqual(tested.snapshot.connections[0]?.lastTest, {
+        status: 'needs_reauth',
+        checkedAt: '2026-07-29T12:00:00.000Z',
+        errorClass: 'auth',
+      });
+
+      const discovered = await stores.operations.completeModelFetch(fetch.ticket, {
+        models: [{ id: 'gpt-5.1' }, { id: 'gpt-5.2' }],
+        source: 'fetched',
+        fetchedAt: 42,
+      });
+      assert.equal(discovered.kind, 'committed');
+      if (discovered.kind !== 'committed') return;
+      const afterDiscovery = discovered.snapshot.connections[0];
+      assert.ok(afterDiscovery);
+      assert.deepEqual(afterDiscovery.models, [{ id: 'gpt-5.1' }, { id: 'gpt-5.2' }]);
+      assert.deepEqual(afterDiscovery.enabledModelIds, ['gpt-5.1']);
+      assert.equal(afterDiscovery.modelSource, 'fetched');
+      assert.equal(afterDiscovery.modelsFetchedAt, 42);
+
+      assert.equal(JSON.stringify([tested, discovered]).includes('effect-secret'), false);
+
+      await assert.rejects(
+        () =>
+          stores.operations.completeModelFetch(fetch.ticket, {
+            models: [{ id: 'replay-must-not-write' }],
+            source: 'fetched',
+            fetchedAt: 43,
+          }),
+        isStoreError('invalid_connection_input'),
+      );
+      await assert.rejects(
+        () =>
+          stores.operations.completeConnectionTest(testTicket.ticket, {
+            status: 'verified',
+            checkedAt: '2026-07-29T12:01:00.000Z',
+          }),
+        isStoreError('invalid_connection_input'),
+      );
+    });
+  });
+
+  test('repairs the canonical default target when discovery removes its model', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-default', 'ollama', 'Effects default'),
+      );
+      const defaultTarget = await stores.connectionCatalog.setDefaultTarget({
+        expectedCatalogRevision: 1,
+        target: { connectionId: connection.connectionId, modelId: 'gpt-5' },
+      });
+      assert.equal(defaultTarget.kind, 'committed');
+
+      const prepared = await stores.operations.beginModelFetch(connection.connectionId);
+      assert.equal(prepared.kind, 'ready');
+      if (prepared.kind !== 'ready') return;
+      const completed = await stores.operations.completeModelFetch(prepared.ticket, {
+        models: [{ id: 'llama3.3' }, { id: 'qwen3' }],
+        source: 'fetched',
+        fetchedAt: 43,
+      });
+      assert.equal(completed.kind, 'committed');
+      if (completed.kind !== 'committed') return;
+      const expected = { connectionId: connection.connectionId, modelId: 'llama3.3' };
+      assert.deepEqual(completed.snapshot.defaultTarget, expected);
+      assert.deepEqual((await stores.connectionCatalog.getSnapshot()).defaultTarget, expected);
+    });
+  });
+
+  test('admits only canonical explicit connection test models', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-test-model', 'openai', 'Effects test model'),
+      );
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: connectionCredential(connection, 'api_key'),
+            expected: null,
+            secret: 'test-model-secret',
+          })
+        ).kind,
+        'committed',
+      );
+
+      assert.equal(
+        (await stores.operations.beginConnectionTest(connection.connectionId, 'gpt-5')).kind,
+        'ready',
+      );
+      await assert.rejects(
+        () => stores.operations.beginConnectionTest(connection.connectionId, 'injected-model'),
+        isStoreError('invalid_connection_input'),
+      );
+
+      const discovery = await stores.operations.beginModelFetch(connection.connectionId);
+      assert.equal(discovery.kind, 'ready');
+      if (discovery.kind !== 'ready') return;
+      assert.equal(
+        (
+          await stores.operations.completeModelFetch(discovery.ticket, {
+            models: [{ id: 'canonical-fetched-model' }],
+            source: 'fetched',
+            fetchedAt: 1,
+          })
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (
+          await stores.operations.beginConnectionTest(
+            connection.connectionId,
+            'canonical-fetched-model',
+          )
+        ).kind,
+        'ready',
+      );
+      await assert.rejects(
+        () => stores.operations.beginConnectionTest(connection.connectionId, 'gpt-5'),
+        isStoreError('invalid_connection_input'),
+      );
+      assert.equal(
+        (await stores.operations.beginConnectionTest(connection.connectionId, null)).kind,
+        'ready',
+      );
+    });
+  });
+
+  test('preserves verified state for equivalent discovery and clears it on model protocol changes', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-model-protocol', 'openai', 'Effects model protocol'),
+      );
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: connectionCredential(connection, 'api_key'),
+            expected: null,
+            secret: 'model-protocol-secret',
+          })
+        ).kind,
+        'committed',
+      );
+
+      const initialDiscovery = await stores.operations.beginModelFetch(connection.connectionId);
+      assert.equal(initialDiscovery.kind, 'ready');
+      if (initialDiscovery.kind !== 'ready') return;
+      assert.equal(
+        (
+          await stores.operations.completeModelFetch(initialDiscovery.ticket, {
+            models: [{ id: 'gpt-5', apiProtocol: 'openai-chat' }],
+            source: 'fetched',
+            fetchedAt: 1,
+          })
+        ).kind,
+        'committed',
+      );
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T11:59:00.000Z');
+
+      const equivalentDiscovery = await stores.operations.beginModelFetch(connection.connectionId);
+      assert.equal(equivalentDiscovery.kind, 'ready');
+      if (equivalentDiscovery.kind !== 'ready') return;
+      const equivalent = await stores.operations.completeModelFetch(equivalentDiscovery.ticket, {
+        models: [{ id: 'gpt-5', apiProtocol: 'openai-chat' }],
+        source: 'fetched',
+        fetchedAt: 2,
+      });
+      assert.equal(equivalent.kind, 'committed');
+      if (equivalent.kind !== 'committed') return;
+      assert.deepEqual(equivalent.snapshot.connections[0]?.lastTest, {
+        status: 'verified',
+        checkedAt: '2026-07-29T11:59:00.000Z',
+      });
+
+      const testTicket = await stores.operations.beginConnectionTest(
+        connection.connectionId,
+        'gpt-5',
+      );
+      const rediscovery = await stores.operations.beginModelFetch(connection.connectionId);
+      assert.equal(testTicket.kind, 'ready');
+      assert.equal(rediscovery.kind, 'ready');
+      if (testTicket.kind !== 'ready' || rediscovery.kind !== 'ready') return;
+
+      assert.equal(
+        (
+          await stores.operations.completeModelFetch(rediscovery.ticket, {
+            models: [{ id: 'gpt-5', apiProtocol: 'openai-responses' }],
+            source: 'fetched',
+            fetchedAt: 3,
+          })
+        ).kind,
+        'committed',
+      );
+      assert.deepEqual(
+        await stores.operations.completeConnectionTest(testTicket.ticket, {
+          status: 'verified',
+          checkedAt: '2026-07-29T12:00:00.000Z',
+        }),
+        { kind: 'superseded', changed: ['connection'] },
+      );
+
+      const current = (await stores.connectionCatalog.getSnapshot()).connections[0];
+      assert.deepEqual(current?.models, [{ id: 'gpt-5', apiProtocol: 'openai-responses' }]);
+      assert.equal(current?.lastTest, undefined);
+    });
+  });
+
+  test('clears verified state when enabled model selection changes', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-selection-invalidation', 'openai', 'Selection invalidation'),
+      );
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: connectionCredential(connection, 'api_key'),
+            expected: null,
+            secret: 'selection-secret',
+          })
+        ).kind,
+        'committed',
+      );
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T12:10:00.000Z');
+      const current = (await stores.connectionCatalog.getSnapshot()).connections[0]!;
+
+      const updated = await stores.connectionCatalog.update({
+        expected: connectionBasis(current),
+        changes: {
+          name: current.name,
+          baseUrl: current.baseUrl,
+          enabled: true,
+          enabledModelIds: ['gpt-5-mini'],
+        },
+      });
+      assert.equal(updated.kind, 'committed');
+      if (updated.kind !== 'committed') return;
+      assert.equal(updated.snapshot.connections[0]?.lastTest, undefined);
+    });
+  });
+
+  test('clears verified state only for admitted connection credential mutations', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-credential-invalidation', 'openai', 'Credential invalidation'),
+      );
+      const locator = connectionCredential(connection, 'api_key');
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator,
+            expected: null,
+            secret: 'credential-v1',
+          })
+        ).kind,
+        'committed',
+      );
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T12:20:00.000Z');
+      const initialStatus = await getCredentialStatus(stores.credentialVault, locator);
+
+      await assert.rejects(
+        () =>
+          stores.credentialVault.set({
+            locator: connectionCredential(connection, 'oauth_token'),
+            expected: null,
+            secret: 'invalid-oauth-credential',
+          }),
+        isStoreError('invalid_credential_input'),
+      );
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest?.status,
+        'verified',
+      );
+
+      const staleSet = await stores.credentialVault.set({
+        locator,
+        expected: {
+          credentialId: credentialBasis(initialStatus).credentialId,
+          revision: credentialBasis(initialStatus).revision + 1,
+        },
+        secret: 'stale-credential',
+      });
+      assert.equal(staleSet.kind, 'credential_stale');
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest?.status,
+        'verified',
+      );
+
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator,
+            expected: credentialExpectation(initialStatus),
+            secret: 'credential-v2',
+          })
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest,
+        undefined,
+      );
+
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T12:21:00.000Z');
+      const rotatedStatus = await getCredentialStatus(stores.credentialVault, locator);
+      const staleDelete = await stores.credentialVault.delete({
+        expected: credentialBasis(initialStatus),
+      });
+      assert.equal(staleDelete.kind, 'credential_stale');
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest?.status,
+        'verified',
+      );
+
+      assert.equal(
+        (
+          await stores.credentialVault.delete({
+            expected: credentialBasis(rotatedStatus),
+          })
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest,
+        undefined,
+      );
+    });
+  });
+
+  test('reports unknown outcome when credential persistence fails after clearing verified state', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    await withInteractiveOwner(async ({ root, stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-credential-failure', 'openai', 'Credential failure'),
+      );
+      const locator = connectionCredential(connection, 'api_key');
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator,
+            expected: null,
+            secret: 'credential-before-failure',
+          })
+        ).kind,
+        'committed',
+      );
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T12:30:00.000Z');
+      const status = await getCredentialStatus(stores.credentialVault, locator);
+
+      const probe = await open(root, 'r');
+      const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+        sync: typeof probe.sync;
+      };
+      const originalSync = fileHandlePrototype.sync;
+      await probe.close();
+      let syncCalls = 0;
+      const syncMock = mock.method(
+        fileHandlePrototype,
+        'sync',
+        async function (this: typeof probe) {
+          syncCalls += 1;
+          if (syncCalls === 3) throw new Error('injected credential persistence failure');
+          return originalSync.call(this);
+        },
+      );
+      try {
+        await assert.rejects(
+          () =>
+            stores.credentialVault.set({
+              locator,
+              expected: credentialExpectation(status),
+              secret: 'credential-after-failure',
+            }),
+          isStoreError('commit_outcome_unknown'),
+        );
+      } finally {
+        syncMock.mock.restore();
+      }
+
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest,
+        undefined,
+      );
+      assert.equal(
+        (await getCredentialStatus(stores.credentialVault, locator)).revision,
+        status.revision,
+      );
+    });
+  });
+
+  test('invalidates verified state only when the effective network proxy basis changes', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-proxy-invalidation', 'openai', 'Proxy invalidation'),
+      );
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: connectionCredential(connection, 'api_key'),
+            expected: null,
+            secret: 'proxy-invalidation-secret',
+          })
+        ).kind,
+        'committed',
+      );
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T12:40:00.000Z');
+
+      assert.equal(
+        (
+          await stores.runtimePolicy.mutate(
+            networkProxyMutation(0, {
+              host: 'proxy-one.internal',
+              authEnabled: false,
+              username: '',
+            }),
+          )
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest,
+        undefined,
+      );
+
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T12:41:00.000Z');
+      assert.equal(
+        (
+          await stores.runtimePolicy.mutate(
+            networkProxyMutation(1, {
+              host: 'proxy-two.internal',
+              authEnabled: false,
+              username: '',
+            }),
+          )
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest,
+        undefined,
+      );
+
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T12:42:00.000Z');
+      assert.equal(
+        (
+          await stores.runtimePolicy.mutate(
+            networkProxyMutation(2, {
+              host: 'proxy-two.internal',
+              authEnabled: false,
+              username: '',
+              bypassList: ['127.0.0.1'],
+              autoBypassDomains: ['localhost'],
+            }),
+          )
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest?.status,
+        'verified',
+      );
+    });
+  });
+
+  test('validates proxy policy mutations before clearing and reports failed follow-up commits as unknown', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    await withInteractiveOwner(async ({ root, stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-proxy-policy-failure', 'openai', 'Proxy policy failure'),
+      );
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: connectionCredential(connection, 'api_key'),
+            expected: null,
+            secret: 'proxy-policy-failure-secret',
+          })
+        ).kind,
+        'committed',
+      );
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T12:50:00.000Z');
+
+      await assert.rejects(
+        () => stores.runtimePolicy.mutate(networkProxyMutation(0, { host: '   ' })),
+        isStoreError('invalid_policy_input'),
+      );
+      assert.deepEqual(
+        await stores.runtimePolicy.mutate(
+          networkProxyMutation(1, {
+            host: 'stale.proxy.internal',
+            authEnabled: false,
+            username: '',
+          }),
+        ),
+        { kind: 'revision_conflict', expectedRevision: 1, actualRevision: 0 },
+      );
+      const oversizedBypassList = Array.from(
+        { length: 100 },
+        (_value, index) => `${index}-${'x'.repeat(500)}`,
+      );
+      await assert.rejects(
+        () =>
+          stores.runtimePolicy.mutate(
+            networkProxyMutation(0, {
+              authEnabled: false,
+              username: '',
+              bypassList: oversizedBypassList,
+              autoBypassDomains: [],
+            }),
+          ),
+        isStoreError('invalid_policy_input'),
+      );
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest?.status,
+        'verified',
+      );
+
+      const probe = await open(root, 'r');
+      const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+        sync: typeof probe.sync;
+      };
+      const originalSync = fileHandlePrototype.sync;
+      await probe.close();
+      let syncCalls = 0;
+      const syncMock = mock.method(
+        fileHandlePrototype,
+        'sync',
+        async function (this: typeof probe) {
+          syncCalls += 1;
+          if (syncCalls === 3) throw new Error('injected proxy policy persistence failure');
+          return originalSync.call(this);
+        },
+      );
+      try {
+        await assert.rejects(
+          () =>
+            stores.runtimePolicy.mutate(
+              networkProxyMutation(0, {
+                host: 'failed.proxy.internal',
+                authEnabled: false,
+                username: '',
+              }),
+            ),
+          isStoreError('commit_outcome_unknown'),
+        );
+      } finally {
+        syncMock.mock.restore();
+      }
+
+      assert.equal(syncCalls, 3);
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest,
+        undefined,
+      );
+      assert.equal((await stores.runtimePolicy.getSnapshot()).revision, 0);
+    });
+  });
+
+  test('invalidates verified state for active proxy password rotation and deletion', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-proxy-credential', 'openai', 'Proxy credential'),
+      );
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: connectionCredential(connection, 'api_key'),
+            expected: null,
+            secret: 'proxy-credential-connection-secret',
+          })
+        ).kind,
+        'committed',
+      );
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T13:00:00.000Z');
+
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: proxyCredential(),
+            expected: null,
+            secret: 'proxy-password-v1',
+          })
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest?.status,
+        'verified',
+        'an inactive proxy credential is not part of the verification basis',
+      );
+      assert.equal((await stores.runtimePolicy.mutate(networkProxyMutation(0))).kind, 'committed');
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest,
+        undefined,
+      );
+
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T13:01:00.000Z');
+      const initialStatus = await getCredentialStatus(stores.credentialVault, proxyCredential());
+      await assert.rejects(
+        () =>
+          stores.credentialVault.set({
+            locator: proxyCredential(),
+            expected: credentialExpectation(initialStatus),
+            secret: 'x'.repeat(64 * 1024 + 1),
+          }),
+        isStoreError('invalid_credential_input'),
+      );
+      const staleSet = await stores.credentialVault.set({
+        locator: proxyCredential(),
+        expected: {
+          credentialId: credentialBasis(initialStatus).credentialId,
+          revision: credentialBasis(initialStatus).revision + 1,
+        },
+        secret: 'stale-proxy-password',
+      });
+      assert.equal(staleSet.kind, 'credential_stale');
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest?.status,
+        'verified',
+      );
+
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: proxyCredential(),
+            expected: credentialExpectation(initialStatus),
+            secret: 'proxy-password-v2',
+          })
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest,
+        undefined,
+      );
+
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T13:02:00.000Z');
+      const rotatedStatus = await getCredentialStatus(stores.credentialVault, proxyCredential());
+      const staleDelete = await stores.credentialVault.delete({
+        expected: credentialBasis(initialStatus),
+      });
+      assert.equal(staleDelete.kind, 'credential_stale');
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest?.status,
+        'verified',
+      );
+
+      assert.equal(
+        (
+          await stores.credentialVault.delete({
+            expected: credentialBasis(rotatedStatus),
+          })
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest,
+        undefined,
+      );
+    });
+  });
+
+  test('reports unknown outcome when active proxy password persistence fails after clearing', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    await withInteractiveOwner(async ({ root, stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-proxy-credential-failure', 'openai', 'Proxy credential failure'),
+      );
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: connectionCredential(connection, 'api_key'),
+            expected: null,
+            secret: 'proxy-failure-connection-secret',
+          })
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: proxyCredential(),
+            expected: null,
+            secret: 'proxy-password-before-failure',
+          })
+        ).kind,
+        'committed',
+      );
+      assert.equal((await stores.runtimePolicy.mutate(networkProxyMutation(0))).kind, 'committed');
+      await verifyConnection(stores, connection.connectionId, '2026-07-29T13:10:00.000Z');
+      const status = await getCredentialStatus(stores.credentialVault, proxyCredential());
+
+      const probe = await open(root, 'r');
+      const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+        sync: typeof probe.sync;
+      };
+      const originalSync = fileHandlePrototype.sync;
+      await probe.close();
+      let syncCalls = 0;
+      const syncMock = mock.method(
+        fileHandlePrototype,
+        'sync',
+        async function (this: typeof probe) {
+          syncCalls += 1;
+          if (syncCalls === 3) throw new Error('injected proxy credential persistence failure');
+          return originalSync.call(this);
+        },
+      );
+      try {
+        await assert.rejects(
+          () =>
+            stores.credentialVault.set({
+              locator: proxyCredential(),
+              expected: credentialExpectation(status),
+              secret: 'proxy-password-after-failure',
+            }),
+          isStoreError('commit_outcome_unknown'),
+        );
+      } finally {
+        syncMock.mock.restore();
+      }
+
+      assert.equal(syncCalls, 3);
+      assert.equal(
+        (await stores.connectionCatalog.getSnapshot()).connections[0]?.lastTest,
+        undefined,
+      );
+      assert.equal(
+        (await getCredentialStatus(stores.credentialVault, proxyCredential())).revision,
+        status.revision,
+      );
+    });
+  });
+
+  test('commits a connection test when a proxy bypass pattern moves between equivalent lists', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-proxy-bypass', 'openai', 'Effects proxy bypass'),
+      );
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: connectionCredential(connection, 'api_key'),
+            expected: null,
+            secret: 'proxy-bypass-connection-secret',
+          })
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (
+          await stores.runtimePolicy.mutate(
+            networkProxyMutation(0, {
+              bypassList: ['localhost', 'gateway.example'],
+              autoBypassDomains: ['127.0.0.1'],
+            }),
+          )
+        ).kind,
+        'committed',
+      );
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: proxyCredential(),
+            expected: null,
+            secret: 'proxy-bypass-secret',
+          })
+        ).kind,
+        'committed',
+      );
+
+      const testTicket = await stores.operations.beginConnectionTest(
+        connection.connectionId,
+        'gpt-5',
+      );
+      assert.equal(testTicket.kind, 'ready');
+      if (testTicket.kind !== 'ready') return;
+      assert.equal(
+        (
+          await stores.runtimePolicy.mutate(
+            networkProxyMutation(1, {
+              bypassList: ['localhost'],
+              autoBypassDomains: ['127.0.0.1', 'gateway.example'],
+            }),
+          )
+        ).kind,
+        'committed',
+      );
+
+      const completed = await stores.operations.completeConnectionTest(testTicket.ticket, {
+        status: 'verified',
+        checkedAt: '2026-07-29T12:01:00.000Z',
+      });
+      assert.equal(completed.kind, 'committed');
+      if (completed.kind !== 'committed') return;
+      assert.deepEqual(completed.snapshot.connections[0]?.lastTest, {
+        status: 'verified',
+        checkedAt: '2026-07-29T12:01:00.000Z',
+      });
+    });
+  });
+
+  test('supersedes effects on connection, credential, proxy, proxy credential, and slug ABA changes', async () => {
+    await withInteractiveOwner(async ({ stores }) => {
+      let connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-fence', 'openai', 'Effects fence'),
+      );
+      const locator = connectionCredential(connection, 'api_key');
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator,
+            expected: null,
+            secret: 'connection-v1',
+          })
+        ).kind,
+        'committed',
+      );
+
+      const endpointTicket = await stores.operations.beginModelFetch(connection.connectionId);
+      assert.equal(endpointTicket.kind, 'ready');
+      if (endpointTicket.kind !== 'ready') return;
+      const endpointUpdate = await stores.connectionCatalog.update({
+        expected: connectionBasis(connection),
+        changes: {
+          name: connection.name,
+          baseUrl: 'https://gateway.example/v1',
+          enabled: true,
+          enabledModelIds: connection.enabledModelIds,
+        },
+      });
+      assert.equal(endpointUpdate.kind, 'committed');
+      if (endpointUpdate.kind !== 'committed') return;
+      connection = endpointUpdate.snapshot.connections[0]!;
+      assert.deepEqual(
+        await stores.operations.completeModelFetch(endpointTicket.ticket, {
+          models: [{ id: 'endpoint-stale' }],
+          source: 'fetched',
+          fetchedAt: 1,
+        }),
+        { kind: 'superseded', changed: ['connection'] },
+      );
+
+      const modelSelectionTicket = await stores.operations.beginConnectionTest(
+        connection.connectionId,
+        null,
+      );
+      assert.equal(modelSelectionTicket.kind, 'ready');
+      if (modelSelectionTicket.kind !== 'ready') return;
+      const modelSelectionUpdate = await stores.connectionCatalog.update({
+        expected: connectionBasis(connection),
+        changes: {
+          name: connection.name,
+          baseUrl: connection.baseUrl,
+          enabled: true,
+          enabledModelIds: ['gpt-5-mini'],
+        },
+      });
+      assert.equal(modelSelectionUpdate.kind, 'committed');
+      if (modelSelectionUpdate.kind !== 'committed') return;
+      connection = modelSelectionUpdate.snapshot.connections[0]!;
+      assert.deepEqual(
+        await stores.operations.completeConnectionTest(modelSelectionTicket.ticket, {
+          status: 'verified',
+          checkedAt: '2026-07-29T12:01:00.000Z',
+        }),
+        { kind: 'superseded', changed: ['connection'] },
+      );
+
+      const credentialTicket = await stores.operations.beginConnectionTest(
+        connection.connectionId,
+        null,
+      );
+      assert.equal(credentialTicket.kind, 'ready');
+      if (credentialTicket.kind !== 'ready') return;
+      const status = await getCredentialStatus(stores.credentialVault, locator);
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator,
+            expected: credentialExpectation(status),
+            secret: 'connection-v2',
+          })
+        ).kind,
+        'committed',
+      );
+      assert.deepEqual(
+        await stores.operations.completeConnectionTest(credentialTicket.ticket, {
+          status: 'verified',
+          checkedAt: '2026-07-29T12:02:00.000Z',
+        }),
+        { kind: 'superseded', changed: ['credential'] },
+      );
+
+      assert.equal(
+        (await stores.runtimePolicy.mutate(networkProxyMutation(0, { host: 'proxy-one.internal' })))
+          .kind,
+        'committed',
+      );
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: proxyCredential(),
+            expected: null,
+            secret: 'proxy-v1',
+          })
+        ).kind,
+        'committed',
+      );
+      const proxyTicket = await stores.operations.beginModelFetch(connection.connectionId);
+      assert.equal(proxyTicket.kind, 'ready');
+      if (proxyTicket.kind !== 'ready') return;
+      assert.equal(
+        (await stores.runtimePolicy.mutate(networkProxyMutation(1, { host: 'proxy-two.internal' })))
+          .kind,
+        'committed',
+      );
+      assert.deepEqual(
+        await stores.operations.completeModelFetch(proxyTicket.ticket, {
+          models: [{ id: 'proxy-stale' }],
+          source: 'fetched',
+          fetchedAt: 2,
+        }),
+        { kind: 'superseded', changed: ['network_proxy'] },
+      );
+
+      const proxyCredentialTicket = await stores.operations.beginConnectionTest(
+        connection.connectionId,
+        null,
+      );
+      assert.equal(proxyCredentialTicket.kind, 'ready');
+      if (proxyCredentialTicket.kind !== 'ready') return;
+      const proxyStatus = await getCredentialStatus(stores.credentialVault, proxyCredential());
+      assert.equal(
+        (
+          await stores.credentialVault.set({
+            locator: proxyCredential(),
+            expected: credentialExpectation(proxyStatus),
+            secret: 'proxy-v2',
+          })
+        ).kind,
+        'committed',
+      );
+      assert.deepEqual(
+        await stores.operations.completeConnectionTest(proxyCredentialTicket.ticket, {
+          status: 'verified',
+          checkedAt: '2026-07-29T12:03:00.000Z',
+        }),
+        { kind: 'superseded', changed: ['credential'] },
+      );
+
+      const abaTicket = await stores.operations.beginModelFetch(connection.connectionId);
+      assert.equal(abaTicket.kind, 'ready');
+      if (abaTicket.kind !== 'ready') return;
+      const removed = await stores.connectionCatalog.remove({
+        expected: connectionBasis(connection),
+      });
+      assert.equal(removed.kind, 'committed');
+      if (removed.kind !== 'committed') return;
+      const replacement = await createConnection(
+        stores,
+        removed.snapshot.revision,
+        connectionDraft(connection.slug, 'openai', 'Replacement'),
+      );
+      assert.notEqual(replacement.connectionId, connection.connectionId);
+      assert.deepEqual(
+        await stores.operations.completeModelFetch(abaTicket.ticket, {
+          models: [{ id: 'aba-stale' }],
+          source: 'fetched',
+          fetchedAt: 3,
+        }),
+        { kind: 'superseded', changed: ['connection', 'credential'] },
+      );
+      assert.deepEqual(replacement.models, []);
+    });
+  });
+
+  test('preserves unknown commit semantics and consumes the completion ticket', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    await withInteractiveOwner(async ({ root, stores }) => {
+      const connection = await createConnection(
+        stores,
+        0,
+        connectionDraft('effects-unknown', 'ollama', 'Effects unknown'),
+      );
+      const prepared = await stores.operations.beginModelFetch(connection.connectionId);
+      assert.equal(prepared.kind, 'ready');
+      if (prepared.kind !== 'ready') return;
+      const result = {
+        models: [{ id: 'llama3.3' }],
+        source: 'fetched' as const,
+        fetchedAt: 99,
+      };
+
+      const probe = await open(root, 'r');
+      const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+        sync: typeof probe.sync;
+      };
+      const originalSync = fileHandlePrototype.sync;
+      await probe.close();
+      let syncCalls = 0;
+      const syncMock = mock.method(
+        fileHandlePrototype,
+        'sync',
+        async function (this: typeof probe) {
+          syncCalls += 1;
+          if (syncCalls === 2) throw new Error('injected post-publication sync failure');
+          return originalSync.call(this);
+        },
+      );
+      try {
+        await assert.rejects(
+          () => stores.operations.completeModelFetch(prepared.ticket, result),
+          isStoreError('commit_outcome_unknown'),
+        );
+      } finally {
+        syncMock.mock.restore();
+      }
+
+      assert.equal(syncCalls, 2);
+      assert.deepEqual((await stores.connectionCatalog.getSnapshot()).connections[0]?.models, [
+        { id: 'llama3.3' },
+      ]);
+      await assert.rejects(
+        () => stores.operations.completeModelFetch(prepared.ticket, result),
+        isStoreError('invalid_connection_input'),
+      );
+    });
+  });
+
   test('allows only Copilot OAuth tokens through the public credential setter', async () => {
     await withInteractiveOwner(async ({ stores }) => {
       const claude = await createConnection(
@@ -929,6 +2036,21 @@ async function createConnection(
   const created = result.snapshot.connections.find((item) => item.slug === connection.slug);
   assert.ok(created);
   return created;
+}
+
+async function verifyConnection(
+  stores: Writer,
+  connectionId: string,
+  checkedAt: string,
+): Promise<void> {
+  const prepared = await stores.operations.beginConnectionTest(connectionId, null);
+  assert.equal(prepared.kind, 'ready');
+  if (prepared.kind !== 'ready') throw new Error('connection test preparation did not succeed');
+  const completed = await stores.operations.completeConnectionTest(prepared.ticket, {
+    status: 'verified',
+    checkedAt,
+  });
+  assert.equal(completed.kind, 'committed');
 }
 
 function connectionDraft(

--- a/packages/storage/src/runtime-policy-stores.ts
+++ b/packages/storage/src/runtime-policy-stores.ts
@@ -31,12 +31,20 @@ export {
   type RuntimePolicyStoreErrorCode,
 } from './runtime-policy/errors.js';
 export type {
+  BeginConnectionTestResult,
+  BeginModelFetchResult,
+  ConnectionEffectChangedDomain,
+  ConnectionEffectCompletionResult,
+  ConnectionEffectPreparationFailure,
+  ConnectionTestTicket,
   CredentialStatusQueryResult,
+  ModelFetchTicket,
   ProviderAuthKind,
   RuntimePolicyCredentialMaterial,
   RuntimePolicyOperationCoordinator,
   RuntimePolicyOperationSecretMaterial,
   ResolveExecutionConnectionResult,
+  UnavailableProviderActionAvailability,
 } from './runtime-policy/operations.js';
 
 const readerBrand: unique symbol = Symbol('RuntimePolicyStoresReader');
@@ -188,6 +196,12 @@ function createWriterFacade(coordinator: RuntimePolicyCoordinator): RuntimePolic
     operations: {
       resolveExecutionConnection: (connectionSlug) =>
         coordinator.resolveExecutionConnection(connectionSlug),
+      beginModelFetch: (connectionId) => coordinator.beginModelFetch(connectionId),
+      completeModelFetch: (ticket, result) => coordinator.completeModelFetch(ticket, result),
+      beginConnectionTest: (connectionId, modelId) =>
+        coordinator.beginConnectionTest(connectionId, modelId),
+      completeConnectionTest: (ticket, result) =>
+        coordinator.completeConnectionTest(ticket, result),
     },
   };
   freezeFacade(stores);

--- a/packages/storage/src/runtime-policy/connection-catalog-document.ts
+++ b/packages/storage/src/runtime-policy/connection-catalog-document.ts
@@ -3,8 +3,10 @@ import {
   CONNECTION_CATALOG_MAX_CONNECTIONS,
   decodeCanonicalConnectionCatalogEntry,
   decodeConnectionTarget,
+  decodeConnectionTestSummary,
   decodeConnectionVersionBasis,
   normalizeConnectionCatalogEntryUpdateForProvider,
+  normalizeConnectionModelDiscoveryResult,
   normalizeCreateCatalogConnectionInput,
   normalizeRemoveCatalogConnectionInput,
   normalizeSetDefaultConnectionTargetInput,
@@ -12,13 +14,16 @@ import {
   type ConnectionCatalogEntry,
   type ConnectionCatalogMutationResult,
   type ConnectionCatalogSnapshot,
+  type ConnectionModelDiscoveryResult,
   type ConnectionTarget,
+  type ConnectionTestSummary,
   type ConnectionVersionBasis,
   type CreateCatalogConnectionInput,
   type RemoveCatalogConnectionInput,
   type SetDefaultConnectionTargetInput,
   type UpdateCatalogConnectionInput,
 } from '@maka/core/runtime-policy';
+import { reconcileConnectionAfterModelFetch } from '@maka/core/llm-connections';
 import { deepFreeze, nextRevision, record, revision, unique } from './codec.js';
 import {
   codecError,
@@ -41,6 +46,15 @@ export interface ConnectionCatalogDocument {
   readonly revision: number;
   readonly defaultTarget: ConnectionTarget | null;
   readonly connections: readonly ConnectionCatalogEntry[];
+}
+
+export interface ConnectionTestModelBasis {
+  readonly enabledModelIds: readonly string[];
+  readonly modelSource: ConnectionCatalogEntry['modelSource'];
+  readonly models: readonly {
+    readonly id: string;
+    readonly apiProtocol: ConnectionCatalogEntry['models'][number]['apiProtocol'];
+  }[];
 }
 
 export class ConnectionCatalogDocumentOwner {
@@ -142,6 +156,10 @@ export class ConnectionCatalogDocumentOwner {
       normalizeConnectionCatalogEntryUpdateForProvider(input.changes, previous.providerType),
     );
     const endpointChanged = previous.baseUrl !== changes.baseUrl;
+    const testBasisChanged =
+      endpointChanged ||
+      previous.enabled !== changes.enabled ||
+      !sameStringArray(previous.enabledModelIds, changes.enabledModelIds);
     const connections = [...current.connections];
     connections[index] = {
       connectionId: previous.connectionId,
@@ -159,7 +177,7 @@ export class ConnectionCatalogDocumentOwner {
       ...(endpointChanged || previous.modelsFetchedAt === undefined
         ? {}
         : { modelsFetchedAt: previous.modelsFetchedAt }),
-      ...(endpointChanged || previous.lastTest === undefined
+      ...(testBasisChanged || previous.lastTest === undefined
         ? {}
         : { lastTest: previous.lastTest }),
     };
@@ -216,6 +234,144 @@ export class ConnectionCatalogDocumentOwner {
     return committed(next);
   }
 
+  async writeModelFetchResult(
+    root: string,
+    current: ConnectionCatalogDocument,
+    expected: ConnectionVersionBasis,
+    rawResult: ConnectionModelDiscoveryResult,
+  ): Promise<ConnectionCatalogSnapshot> {
+    const result = decodeConnectionInput(() => normalizeConnectionModelDiscoveryResult(rawResult));
+    if (result.models.length === 0) {
+      throw codecError('invalid_connection_input', 'Model discovery result must not be empty');
+    }
+    const index = findConnectionIndex(current, expected);
+    const previous = current.connections[index];
+    if (!previous || previous.revision !== expected.revision) {
+      throw codecError('invalid_document', 'Coordinator admitted a stale model discovery result');
+    }
+    const currentDefaultTarget =
+      current.defaultTarget?.connectionId === previous.connectionId
+        ? current.defaultTarget
+        : undefined;
+    const reconciled =
+      result.source === 'fetched'
+        ? reconcileConnectionAfterModelFetch(
+            {
+              defaultModel: currentDefaultTarget?.modelId ?? previous.enabledModelIds[0],
+              enabledModelIds: previous.enabledModelIds,
+            },
+            result.models,
+          )
+        : {
+            defaultModel: currentDefaultTarget?.modelId ?? previous.enabledModelIds[0] ?? '',
+            enabledModelIds: previous.enabledModelIds,
+          };
+    const defaultTarget = currentDefaultTarget
+      ? { connectionId: previous.connectionId, modelId: reconciled.defaultModel }
+      : current.defaultTarget;
+    const discovered: ConnectionCatalogEntry = {
+      ...previous,
+      revision: nextRevision(previous.revision),
+      enabledModelIds: reconciled.enabledModelIds,
+      models: result.models,
+      modelSource: result.source,
+      modelsFetchedAt: result.fetchedAt,
+    };
+    const testBasisChanged = !sameConnectionTestModelBasis(
+      connectionTestModelBasis(previous),
+      connectionTestModelBasis(discovered),
+    );
+    const { lastTest: _lastTest, ...discoveredWithoutLastTest } = discovered;
+    return this.writePatchedResult(
+      root,
+      current,
+      index,
+      testBasisChanged ? discoveredWithoutLastTest : discovered,
+      defaultTarget,
+    );
+  }
+
+  async writeConnectionTestResult(
+    root: string,
+    current: ConnectionCatalogDocument,
+    expected: ConnectionVersionBasis,
+    rawResult: ConnectionTestSummary,
+  ): Promise<ConnectionCatalogSnapshot> {
+    const result = decodeConnectionInput(() => decodeConnectionTestSummary(rawResult));
+    const index = findConnectionIndex(current, expected);
+    const previous = current.connections[index];
+    if (!previous || previous.revision !== expected.revision) {
+      throw codecError('invalid_document', 'Coordinator admitted a stale connection test result');
+    }
+    return this.writePatchedResult(root, current, index, {
+      ...previous,
+      revision: nextRevision(previous.revision),
+      lastTest: result,
+    });
+  }
+
+  async clearConnectionLastTest(
+    root: string,
+    current: ConnectionCatalogDocument,
+    connectionId: string,
+  ): Promise<boolean> {
+    const index = findConnectionIndex(current, { connectionId });
+    const previous = current.connections[index];
+    if (!previous) {
+      throw codecError('invalid_document', 'Coordinator admitted an unknown connection');
+    }
+    if (previous.lastTest === undefined) return false;
+    const { lastTest: _lastTest, ...withoutLastTest } = previous;
+    await this.writePatchedResult(root, current, index, {
+      ...withoutLastTest,
+      revision: nextRevision(previous.revision),
+    });
+    return true;
+  }
+
+  async clearAllConnectionLastTests(
+    root: string,
+    current: ConnectionCatalogDocument,
+  ): Promise<boolean> {
+    if (current.connections.every((connection) => connection.lastTest === undefined)) return false;
+    const connections = current.connections.map((connection) => {
+      if (connection.lastTest === undefined) return connection;
+      const { lastTest: _lastTest, ...withoutLastTest } = connection;
+      return {
+        ...withoutLastTest,
+        revision: nextRevision(connection.revision),
+      };
+    });
+    await this.write(root, {
+      ...current,
+      revision: nextRevision(current.revision),
+      connections,
+    });
+    return true;
+  }
+
+  private async writePatchedResult(
+    root: string,
+    current: ConnectionCatalogDocument,
+    index: number,
+    patched: ConnectionCatalogEntry,
+    defaultTarget: ConnectionTarget | null = current.defaultTarget,
+  ): Promise<ConnectionCatalogSnapshot> {
+    const connections = [...current.connections];
+    connections[index] = patched;
+    if (defaultTarget && !isValidTarget(defaultTarget, connections)) {
+      throw codecError('invalid_document', 'Connection effect produced an invalid default target');
+    }
+    const next = {
+      ...current,
+      revision: nextRevision(current.revision),
+      defaultTarget,
+      connections,
+    };
+    await this.write(root, next);
+    return catalogSnapshot(next);
+  }
+
   private async write(root: string, document: ConnectionCatalogDocument): Promise<void> {
     if (serializeJsonDocument(document).length > CATALOG_DOCUMENT_MAX_BYTES) {
       throw new RuntimePolicyStoreError(
@@ -249,6 +405,35 @@ export function findConnection(
   return document.connections.find((item) => sameConnectionIdentity(item, identity));
 }
 
+export function connectionTestModelBasis(
+  connection: ConnectionCatalogEntry,
+): ConnectionTestModelBasis {
+  return {
+    enabledModelIds: [...connection.enabledModelIds],
+    modelSource: connection.modelSource,
+    models: connection.models.map((model) => ({
+      id: model.id,
+      apiProtocol: model.apiProtocol,
+    })),
+  };
+}
+
+export function sameConnectionTestModelBasis(
+  actual: ConnectionTestModelBasis,
+  expected: ConnectionTestModelBasis,
+): boolean {
+  return (
+    sameStringArray(actual.enabledModelIds, expected.enabledModelIds) &&
+    actual.modelSource === expected.modelSource &&
+    actual.models.length === expected.models.length &&
+    actual.models.every(
+      (model, index) =>
+        model.id === expected.models[index]?.id &&
+        model.apiProtocol === expected.models[index]?.apiProtocol,
+    )
+  );
+}
+
 function findConnectionIndex(
   document: ConnectionCatalogDocument,
   identity: Pick<ConnectionVersionBasis, 'connectionId'>,
@@ -269,6 +454,12 @@ function isValidTarget(
 ): boolean {
   const connection = connections.find((item) => sameConnectionIdentity(item, target));
   return Boolean(connection?.enabled && connection.enabledModelIds.includes(target.modelId));
+}
+
+function sameStringArray(actual: readonly string[], expected: readonly string[]): boolean {
+  return (
+    actual.length === expected.length && actual.every((value, index) => value === expected[index])
+  );
 }
 
 function revisionConflict(expectedRevision: number, actualRevision: number) {

--- a/packages/storage/src/runtime-policy/coordinator.ts
+++ b/packages/storage/src/runtime-policy/coordinator.ts
@@ -1,10 +1,14 @@
 import {
+  decodeConnectionModelId,
   decodeConnectionSlug,
+  decodeRuntimePolicyEntityId,
   decodeCredentialLocator,
   normalizeDeleteCredentialInput,
   normalizeRemoveCatalogConnectionInput,
   normalizeSetCredentialInput,
   type ConnectionCatalogEntry,
+  type ConnectionModelDiscoveryResult,
+  type ConnectionTestSummary,
   type CreateCatalogConnectionInput,
   type CredentialLocator,
   type CredentialStatus,
@@ -16,14 +20,18 @@ import {
   type SetDefaultConnectionTargetInput,
   type UpdateCatalogConnectionInput,
 } from '@maka/core/runtime-policy';
-import { deriveProviderAuthContract } from '@maka/core/provider-auth';
-import { PROVIDER_DEFAULTS } from '@maka/core/llm-connections';
+import { deriveProviderAuthContract, type ProviderAuthAction } from '@maka/core/provider-auth';
+import { effectiveBaseUrl, PROVIDER_DEFAULTS, type ProviderType } from '@maka/core/llm-connections';
 import { deepFreeze } from './codec.js';
 import {
   catalogSnapshot,
   connectionBasis,
   ConnectionCatalogDocumentOwner,
+  connectionTestModelBasis,
   findConnection,
+  sameConnectionTestModelBasis,
+  type ConnectionCatalogDocument,
+  type ConnectionTestModelBasis,
 } from './connection-catalog-document.js';
 import {
   credentialMaterial,
@@ -42,6 +50,12 @@ import {
 import {
   connectionCredentialLocator,
   type CredentialStatusQueryResult,
+  type BeginConnectionTestResult,
+  type BeginModelFetchResult,
+  type ConnectionEffectChangedDomain,
+  type ConnectionEffectCompletionResult,
+  type ConnectionTestTicket,
+  type ModelFetchTicket,
   type RuntimePolicyCredentialMaterial,
   type RuntimePolicyOperationSecretMaterial,
   type ResolveExecutionConnectionResult,
@@ -52,8 +66,53 @@ type RootExecutor = <T>(operation: (root: string) => Promise<T>) => Promise<T>;
 
 interface PreparedConnectionMaterial {
   readonly kind: 'ready';
+  readonly connection: ConnectionCatalogEntry;
+  readonly connectionCredentialStatus: CredentialStatus | null;
+  readonly proxyCredentialStatus: CredentialStatus | null;
   readonly secretMaterial: RuntimePolicyOperationSecretMaterial;
   readonly networkProxy: RuntimePolicy['networkProxy'];
+}
+
+type ConnectionTicketKind = 'model_fetch' | 'connection_test';
+type TicketState = 'available' | 'in_flight' | 'consumed';
+
+type EffectiveProxyConfigurationBasis =
+  | { readonly kind: 'direct' }
+  | {
+      readonly kind: 'proxy';
+      readonly protocol: RuntimePolicy['networkProxy']['protocol'];
+      readonly host: string;
+      readonly port: number;
+      readonly authentication:
+        | { readonly kind: 'none' }
+        | { readonly kind: 'credentials'; readonly username: string };
+      readonly bypassPatterns: readonly string[];
+    };
+
+interface CommonSemanticConnectionBasis {
+  readonly connectionId: string;
+  readonly providerType: ProviderType;
+  readonly enabled: true;
+  readonly effectiveEndpoint: string;
+  readonly credential: CredentialStatus | null;
+  readonly effectiveProxy: EffectiveProxyConfigurationBasis;
+  readonly proxyCredential: CredentialStatus | null;
+}
+
+type SemanticConnectionBasis =
+  | (CommonSemanticConnectionBasis & {
+      readonly kind: 'model_fetch';
+      readonly enabledModelIds: readonly string[];
+    })
+  | (CommonSemanticConnectionBasis & {
+      readonly kind: 'connection_test';
+      readonly model: ConnectionTestModelBasis;
+    });
+
+interface ConnectionTicketRecord {
+  readonly kind: ConnectionTicketKind;
+  readonly basis: SemanticConnectionBasis;
+  state: TicketState;
 }
 
 export class RuntimePolicyCoordinator {
@@ -61,6 +120,7 @@ export class RuntimePolicyCoordinator {
   private readonly policy = new RuntimePolicyDocumentOwner();
   private readonly catalog = new ConnectionCatalogDocumentOwner();
   private readonly vault = new CredentialVaultDocumentOwner();
+  private readonly tickets = new WeakMap<object, ConnectionTicketRecord>();
 
   constructor(private readonly execute: RootExecutor) {}
 
@@ -92,8 +152,11 @@ export class RuntimePolicyCoordinator {
   getCredentialStatus(rawLocator: CredentialLocator): Promise<CredentialStatusQueryResult> {
     return this.inLane(async (root) => {
       const locator = decodeCredentialInput(() => decodeCredentialLocator(rawLocator));
-      if (!(await this.validateConnectionCredentialLocator(root, locator))) {
-        return deepFreeze({ kind: 'connection_not_found' as const });
+      if (locator.scope === 'connection') {
+        const catalog = await this.catalog.read(root);
+        if (!this.validateConnectionCredentialLocator(catalog, locator)) {
+          return deepFreeze({ kind: 'connection_not_found' as const });
+        }
       }
       const status = credentialStatus(await this.vault.read(root), locator);
       return deepFreeze({ kind: 'status' as const, status });
@@ -101,7 +164,29 @@ export class RuntimePolicyCoordinator {
   }
 
   mutatePolicy(input: MutateRuntimePolicyInput) {
-    return this.inLane((root) => this.policy.mutate(root, input));
+    return this.inLane(async (root) => {
+      const current = await this.policy.read(root);
+      const prepared = this.policy.prepareMutation(current, input);
+      if (prepared.kind !== 'ready') return prepared;
+      const proxyChanged = !sameEffectiveProxyConfiguration(
+        effectiveProxyConfigurationBasis(prepared.current.policy.networkProxy),
+        effectiveProxyConfigurationBasis(prepared.next.policy.networkProxy),
+      );
+      const cleared = proxyChanged
+        ? await this.catalog.clearAllConnectionLastTests(root, await this.catalog.read(root))
+        : false;
+      try {
+        return await this.policy.commitMutation(root, prepared);
+      } catch (error) {
+        if (cleared) {
+          throw commitOutcomeUnknown(
+            'Connection verification was cleared before network proxy update completed',
+            error,
+          );
+        }
+        throw error;
+      }
+    });
   }
 
   createConnection(input: CreateCatalogConnectionInput) {
@@ -155,8 +240,9 @@ export class RuntimePolicyCoordinator {
     return this.inLane(async (root) => {
       const input = decodeCredentialInput(() => normalizeSetCredentialInput(rawInput));
       const { locator } = input;
+      let catalog: ConnectionCatalogDocument | null = null;
       if (locator.scope === 'connection') {
-        const catalog = await this.catalog.read(root);
+        catalog = await this.catalog.read(root);
         const connection = findConnection(catalog, locator);
         if (!connection) {
           return deepFreeze({ kind: 'connection_not_found' as const });
@@ -178,17 +264,48 @@ export class RuntimePolicyCoordinator {
           );
         }
       }
-      return this.vault.set(root, input);
+      const prepared = this.vault.prepareSet(await this.vault.read(root), input);
+      if (prepared.kind !== 'ready') return prepared;
+      const cleared = await this.clearCredentialDependentLastTests(root, locator, catalog);
+      try {
+        return await this.vault.commitSet(root, prepared);
+      } catch (error) {
+        if (cleared) {
+          throw commitOutcomeUnknown(
+            'Connection verification was cleared before credential update completed',
+            error,
+          );
+        }
+        throw error;
+      }
     });
   }
 
   deleteCredential(rawInput: DeleteCredentialInput) {
     return this.inLane(async (root) => {
       const { expected } = decodeCredentialInput(() => normalizeDeleteCredentialInput(rawInput));
-      if (!(await this.validateConnectionCredentialLocator(root, expected.locator))) {
-        return deepFreeze({ kind: 'connection_not_found' as const });
+      const { locator } = expected;
+      let catalog: ConnectionCatalogDocument | null = null;
+      if (locator.scope === 'connection') {
+        catalog = await this.catalog.read(root);
+        if (!this.validateConnectionCredentialLocator(catalog, locator)) {
+          return deepFreeze({ kind: 'connection_not_found' as const });
+        }
       }
-      return this.vault.delete(root, { expected });
+      const prepared = this.vault.prepareDelete(await this.vault.read(root), { expected });
+      if (prepared.kind !== 'ready') return prepared;
+      const cleared = await this.clearCredentialDependentLastTests(root, locator, catalog);
+      try {
+        return await this.vault.commitDelete(root, prepared);
+      } catch (error) {
+        if (cleared) {
+          throw commitOutcomeUnknown(
+            'Connection verification was cleared before credential deletion completed',
+            error,
+          );
+        }
+        throw error;
+      }
     });
   }
 
@@ -221,6 +338,131 @@ export class RuntimePolicyCoordinator {
     });
   }
 
+  beginModelFetch(rawConnectionId: string): Promise<BeginModelFetchResult> {
+    return this.inLane(async (root) => {
+      const connectionId = decodeConnectionInput(() =>
+        decodeRuntimePolicyEntityId(rawConnectionId),
+      );
+      const prepared = await this.prepareConnectionOperation(root, connectionId, 'fetch_models');
+      if (prepared.kind !== 'ready') return prepared;
+      const ticket = this.issueTicket('model_fetch', modelFetchSemanticBasis(prepared));
+      return deepFreeze({
+        kind: 'ready' as const,
+        ticket: ticket as ModelFetchTicket,
+        connection: structuredClone(prepared.connection),
+        secretMaterial: prepared.secretMaterial,
+        networkProxy: structuredClone(prepared.networkProxy),
+      });
+    });
+  }
+
+  async completeModelFetch(
+    ticket: ModelFetchTicket,
+    result: ConnectionModelDiscoveryResult,
+  ): Promise<ConnectionEffectCompletionResult> {
+    const claimed = this.claimTicket(ticket, 'model_fetch');
+    return this.completeClaimedTicket(claimed, () =>
+      this.inLane(async (root) => {
+        const catalog = await this.catalog.read(root);
+        const checked = await this.checkSemanticConnectionBasis(root, catalog, claimed.basis);
+        if (checked.changed.length > 0 || !checked.connection) {
+          return deepFreeze({ kind: 'superseded' as const, changed: checked.changed });
+        }
+        const snapshot = await this.catalog.writeModelFetchResult(
+          root,
+          catalog,
+          connectionBasis(checked.connection),
+          result,
+        );
+        return deepFreeze({ kind: 'committed' as const, snapshot });
+      }),
+    );
+  }
+
+  beginConnectionTest(
+    rawConnectionId: string,
+    rawModelId: string | null,
+  ): Promise<BeginConnectionTestResult> {
+    return this.inLane(async (root) => {
+      const connectionId = decodeConnectionInput(() =>
+        decodeRuntimePolicyEntityId(rawConnectionId),
+      );
+      const prepared = await this.prepareConnectionOperation(
+        root,
+        connectionId,
+        'test_credentials',
+      );
+      if (prepared.kind !== 'ready') return prepared;
+      const modelId =
+        rawModelId === null
+          ? null
+          : decodeConnectionInput(() => decodeConnectionModelId(rawModelId));
+      if (modelId !== null && !isCanonicalConnectionTestModel(prepared.connection, modelId)) {
+        throw codecError(
+          'invalid_connection_input',
+          'Connection test model is not in the canonical model set',
+        );
+      }
+      const ticket = this.issueTicket('connection_test', connectionTestSemanticBasis(prepared));
+      return deepFreeze({
+        kind: 'ready' as const,
+        ticket: ticket as ConnectionTestTicket,
+        connection: structuredClone(prepared.connection),
+        modelId,
+        secretMaterial: prepared.secretMaterial,
+        networkProxy: structuredClone(prepared.networkProxy),
+      });
+    });
+  }
+
+  async completeConnectionTest(
+    ticket: ConnectionTestTicket,
+    result: ConnectionTestSummary,
+  ): Promise<ConnectionEffectCompletionResult> {
+    const claimed = this.claimTicket(ticket, 'connection_test');
+    return this.completeClaimedTicket(claimed, () =>
+      this.inLane(async (root) => {
+        const catalog = await this.catalog.read(root);
+        const checked = await this.checkSemanticConnectionBasis(root, catalog, claimed.basis);
+        if (checked.changed.length > 0 || !checked.connection) {
+          return deepFreeze({ kind: 'superseded' as const, changed: checked.changed });
+        }
+        const snapshot = await this.catalog.writeConnectionTestResult(
+          root,
+          catalog,
+          connectionBasis(checked.connection),
+          result,
+        );
+        return deepFreeze({ kind: 'committed' as const, snapshot });
+      }),
+    );
+  }
+
+  private async prepareConnectionOperation(
+    root: string,
+    connectionId: string,
+    action: ProviderAuthAction,
+  ): Promise<
+    PreparedConnectionMaterial | Exclude<BeginModelFetchResult, { readonly kind: 'ready' }>
+  > {
+    const catalog = await this.catalog.read(root);
+    const connection = findConnection(catalog, { connectionId });
+    if (!connection) return deepFreeze({ kind: 'connection_not_found' as const });
+    if (!connection.enabled) return deepFreeze({ kind: 'connection_disabled' as const });
+
+    const contract = deriveProviderAuthContract({
+      providerType: connection.providerType,
+      enabled: true,
+      hasSecret: true,
+      lastTestStatus: connection.lastTest?.status,
+    });
+    const availability = contract.actionAvailability[action];
+    if (availability !== 'available') {
+      return deepFreeze({ kind: 'provider_action_unavailable' as const, availability });
+    }
+    return this.prepareConnectionMaterial(root, connection, contract.requiresSecret);
+  }
+
   private async prepareConnectionMaterial(
     root: string,
     connection: ConnectionCatalogEntry,
@@ -236,6 +478,8 @@ export class RuntimePolicyCoordinator {
     const proxyLocator = requiresNetworkProxyCredential(networkProxy)
       ? networkProxyCredentialLocator()
       : null;
+    let connectionCredentialStatus: CredentialStatus | null = null;
+    let proxyCredentialStatus: CredentialStatus | null = null;
     const secretMaterial: {
       connection?: RuntimePolicyCredentialMaterial;
       networkProxy?: RuntimePolicyCredentialMaterial;
@@ -245,6 +489,7 @@ export class RuntimePolicyCoordinator {
       const vault = await this.vault.read(root);
       if (locator) {
         const status = credentialStatus(vault, locator);
+        connectionCredentialStatus = status;
         const entry = findCredential(vault, locator);
         if (!entry) {
           if (requiresConnectionSecret) {
@@ -259,6 +504,7 @@ export class RuntimePolicyCoordinator {
       }
       if (proxyLocator) {
         const status = credentialStatus(vault, proxyLocator);
+        proxyCredentialStatus = status;
         const entry = findCredential(vault, proxyLocator);
         if (!entry) {
           return deepFreeze({
@@ -272,17 +518,19 @@ export class RuntimePolicyCoordinator {
 
     return {
       kind: 'ready',
+      connection,
+      connectionCredentialStatus,
+      proxyCredentialStatus,
       secretMaterial,
       networkProxy,
     };
   }
 
-  private async validateConnectionCredentialLocator(
-    root: string,
+  private validateConnectionCredentialLocator(
+    catalog: ConnectionCatalogDocument,
     locator: CredentialLocator,
-  ): Promise<boolean> {
+  ): boolean {
     if (locator.scope !== 'connection') return true;
-    const catalog = await this.catalog.read(root);
     const connection = findConnection(catalog, locator);
     if (!connection) return false;
     const required = connectionCredentialLocator(
@@ -296,6 +544,103 @@ export class RuntimePolicyCoordinator {
       );
     }
     return true;
+  }
+
+  private async clearCredentialDependentLastTests(
+    root: string,
+    locator: CredentialLocator,
+    connectionCatalog: ConnectionCatalogDocument | null,
+  ): Promise<boolean> {
+    if (locator.scope === 'connection') {
+      return this.catalog.clearConnectionLastTest(root, connectionCatalog!, locator.connectionId);
+    }
+    if (locator.scope !== 'network_proxy') return false;
+    const policy = await this.policy.read(root);
+    if (!requiresNetworkProxyCredential(policy.policy.networkProxy)) return false;
+    return this.catalog.clearAllConnectionLastTests(root, await this.catalog.read(root));
+  }
+
+  private async checkSemanticConnectionBasis(
+    root: string,
+    catalog: Awaited<ReturnType<ConnectionCatalogDocumentOwner['read']>>,
+    basis: SemanticConnectionBasis,
+  ): Promise<{
+    readonly connection: ConnectionCatalogEntry | undefined;
+    readonly changed: ConnectionEffectChangedDomain[];
+  }> {
+    const connection = findConnection(catalog, { connectionId: basis.connectionId });
+    const changed: ConnectionEffectChangedDomain[] = [];
+    if (
+      !connection ||
+      connection.providerType !== basis.providerType ||
+      !connection.enabled ||
+      canonicalEffectiveEndpoint(connection) !== basis.effectiveEndpoint ||
+      (basis.kind === 'model_fetch' &&
+        !sameStringArray(connection.enabledModelIds, basis.enabledModelIds)) ||
+      (basis.kind === 'connection_test' &&
+        !sameConnectionTestModelBasis(connectionTestModelBasis(connection), basis.model))
+    ) {
+      changed.push('connection');
+    }
+
+    const policy = await this.policy.read(root);
+    if (
+      !sameEffectiveProxyConfiguration(
+        effectiveProxyConfigurationBasis(policy.policy.networkProxy),
+        basis.effectiveProxy,
+      )
+    ) {
+      changed.push('network_proxy');
+    }
+
+    if (basis.credential || basis.proxyCredential) {
+      const vault = await this.vault.read(root);
+      const connectionCredentialChanged = Boolean(
+        basis.credential &&
+          !sameCredentialStatus(
+            credentialStatus(vault, basis.credential.locator),
+            basis.credential,
+          ),
+      );
+      const proxyCredentialChanged = Boolean(
+        basis.proxyCredential &&
+          !sameCredentialStatus(
+            credentialStatus(vault, basis.proxyCredential.locator),
+            basis.proxyCredential,
+          ),
+      );
+      if (connectionCredentialChanged || proxyCredentialChanged) changed.push('credential');
+    }
+    return { connection, changed };
+  }
+
+  private issueTicket(kind: ConnectionTicketKind, basis: SemanticConnectionBasis): object {
+    const ticket = Object.freeze(Object.create(null)) as object;
+    this.tickets.set(ticket, { kind, basis, state: 'available' });
+    return ticket;
+  }
+
+  private claimTicket(ticket: object, expectedKind: ConnectionTicketKind): ConnectionTicketRecord {
+    const record = ticket && typeof ticket === 'object' ? this.tickets.get(ticket) : undefined;
+    if (!record || record.kind !== expectedKind || record.state !== 'available') {
+      throw codecError(
+        'invalid_connection_input',
+        `Expected an authentic available ${ticketLabel(expectedKind)} ticket`,
+      );
+    }
+    record.state = 'in_flight';
+    return record;
+  }
+
+  private async completeClaimedTicket<T>(
+    ticket: ConnectionTicketRecord,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    try {
+      return await operation();
+    } finally {
+      ticket.state = 'consumed';
+    }
   }
 
   private inLane<T>(operation: (root: string) => Promise<T>): Promise<T> {
@@ -320,6 +665,143 @@ export class RuntimePolicyCoordinator {
       if (!entered) reservation.release();
     });
   }
+}
+
+function commonSemanticConnectionBasis(
+  prepared: PreparedConnectionMaterial,
+): CommonSemanticConnectionBasis {
+  return {
+    connectionId: prepared.connection.connectionId,
+    providerType: prepared.connection.providerType,
+    enabled: true,
+    effectiveEndpoint: canonicalEffectiveEndpoint(prepared.connection),
+    credential: prepared.connectionCredentialStatus,
+    effectiveProxy: effectiveProxyConfigurationBasis(prepared.networkProxy),
+    proxyCredential: prepared.proxyCredentialStatus,
+  };
+}
+
+function modelFetchSemanticBasis(
+  prepared: PreparedConnectionMaterial,
+): Extract<SemanticConnectionBasis, { readonly kind: 'model_fetch' }> {
+  return {
+    kind: 'model_fetch',
+    ...commonSemanticConnectionBasis(prepared),
+    enabledModelIds: [...prepared.connection.enabledModelIds],
+  };
+}
+
+function connectionTestSemanticBasis(
+  prepared: PreparedConnectionMaterial,
+): Extract<SemanticConnectionBasis, { readonly kind: 'connection_test' }> {
+  return {
+    kind: 'connection_test',
+    ...commonSemanticConnectionBasis(prepared),
+    model: connectionTestModelBasis(prepared.connection),
+  };
+}
+
+function isCanonicalConnectionTestModel(
+  connection: ConnectionCatalogEntry,
+  modelId: string,
+): boolean {
+  const basis = connectionTestModelBasis(connection);
+  const inCanonicalModels = basis.models.some((model) => model.id === modelId);
+  return basis.modelSource === 'fetched'
+    ? inCanonicalModels
+    : inCanonicalModels || basis.enabledModelIds.includes(modelId);
+}
+
+function canonicalEffectiveEndpoint(connection: ConnectionCatalogEntry): string {
+  const endpoint = effectiveBaseUrl(connection);
+  try {
+    return new URL(endpoint).toString();
+  } catch {
+    throw codecError('invalid_document', 'Connection has an invalid effective endpoint');
+  }
+}
+
+function effectiveProxyConfigurationBasis(
+  networkProxy: RuntimePolicy['networkProxy'],
+): EffectiveProxyConfigurationBasis {
+  if (!networkProxy.enabled) return { kind: 'direct' };
+  return {
+    kind: 'proxy',
+    protocol: networkProxy.protocol,
+    host: networkProxy.host.trim().toLowerCase(),
+    port: networkProxy.port,
+    authentication: networkProxy.authEnabled
+      ? { kind: 'credentials', username: networkProxy.username }
+      : { kind: 'none' },
+    bypassPatterns: normalizeProxyPatterns([
+      ...networkProxy.bypassList,
+      ...networkProxy.autoBypassDomains,
+    ]),
+  };
+}
+
+function sameEffectiveProxyConfiguration(
+  actual: EffectiveProxyConfigurationBasis,
+  expected: EffectiveProxyConfigurationBasis,
+): boolean {
+  if (actual.kind !== expected.kind) return false;
+  if (actual.kind === 'direct' || expected.kind === 'direct') return true;
+  return (
+    actual.protocol === expected.protocol &&
+    actual.host === expected.host &&
+    actual.port === expected.port &&
+    sameProxyAuthentication(actual.authentication, expected.authentication) &&
+    sameStringArray(actual.bypassPatterns, expected.bypassPatterns)
+  );
+}
+
+function sameProxyAuthentication(
+  actual: Extract<EffectiveProxyConfigurationBasis, { kind: 'proxy' }>['authentication'],
+  expected: Extract<EffectiveProxyConfigurationBasis, { kind: 'proxy' }>['authentication'],
+): boolean {
+  if (actual.kind !== expected.kind) return false;
+  return (
+    actual.kind === 'none' ||
+    (expected.kind === 'credentials' && actual.username === expected.username)
+  );
+}
+
+function normalizeProxyPatterns(patterns: readonly string[]): readonly string[] {
+  return [
+    ...new Set(
+      patterns
+        .map((pattern) => pattern.trim().toLowerCase())
+        .filter((pattern) => pattern.length > 0),
+    ),
+  ].sort();
+}
+
+function sameStringArray(actual: readonly string[], expected: readonly string[]): boolean {
+  return (
+    actual.length === expected.length && actual.every((value, index) => value === expected[index])
+  );
+}
+
+function sameCredentialStatus(actual: CredentialStatus, expected: CredentialStatus): boolean {
+  return (
+    sameCredentialLocator(actual.locator, expected.locator) &&
+    actual.configured === expected.configured &&
+    actual.credentialId === expected.credentialId &&
+    actual.revision === expected.revision
+  );
+}
+
+function sameCredentialLocator(actual: CredentialLocator, expected: CredentialLocator): boolean {
+  return (
+    actual.scope === expected.scope &&
+    actual.kind === expected.kind &&
+    (actual.scope !== 'connection' ||
+      (expected.scope === 'connection' && actual.connectionId === expected.connectionId))
+  );
+}
+
+function ticketLabel(kind: ConnectionTicketKind): string {
+  return kind === 'model_fetch' ? 'model fetch' : 'connection test';
 }
 
 interface MutationReservation {

--- a/packages/storage/src/runtime-policy/credential-vault-document.ts
+++ b/packages/storage/src/runtime-policy/credential-vault-document.ts
@@ -43,6 +43,16 @@ export interface CredentialVaultDocument {
   readonly entries: readonly CredentialVaultEntry[];
 }
 
+interface PreparedCredentialSet {
+  readonly kind: 'ready';
+  readonly document: CredentialVaultDocument;
+}
+
+interface PreparedCredentialDelete {
+  readonly kind: 'ready';
+  readonly document: CredentialVaultDocument;
+}
+
 export class CredentialVaultDocumentOwner {
   async read(root: string): Promise<CredentialVaultDocument> {
     const value = await readBoundedJsonDocument(root, FILE, VAULT_DOCUMENT_MAX_BYTES);
@@ -73,9 +83,17 @@ export class CredentialVaultDocumentOwner {
   }
 
   async set(root: string, rawInput: SetCredentialInput): Promise<CredentialMutationResult> {
+    const prepared = this.prepareSet(await this.read(root), rawInput);
+    if (prepared.kind !== 'ready') return prepared;
+    return this.commitSet(root, prepared);
+  }
+
+  prepareSet(
+    current: CredentialVaultDocument,
+    rawInput: SetCredentialInput,
+  ): PreparedCredentialSet | CredentialMutationResult {
     const input = decodeCredentialInput(() => normalizeSetCredentialInput(rawInput));
     assertCredentialInputSecretLimit(input.secret, 'set credential secret');
-    const current = await this.read(root);
     const index = findCredentialIndex(current, input.locator);
     const previous = index < 0 ? undefined : current.entries[index];
     if (!matchesExpectation(previous, input.expected)) {
@@ -109,13 +127,29 @@ export class CredentialVaultDocumentOwner {
       revision: nextRevision(current.revision),
       entries,
     };
-    await this.write(root, next);
-    return committed(next);
+    this.assertDocumentSize(next);
+    return { kind: 'ready', document: next };
+  }
+
+  async commitSet(
+    root: string,
+    prepared: PreparedCredentialSet,
+  ): Promise<CredentialMutationResult> {
+    await this.write(root, prepared.document);
+    return committed(prepared.document);
   }
 
   async delete(root: string, rawInput: DeleteCredentialInput): Promise<CredentialMutationResult> {
+    const prepared = this.prepareDelete(await this.read(root), rawInput);
+    if (prepared.kind !== 'ready') return prepared;
+    return this.commitDelete(root, prepared);
+  }
+
+  prepareDelete(
+    current: CredentialVaultDocument,
+    rawInput: DeleteCredentialInput,
+  ): PreparedCredentialDelete | CredentialMutationResult {
     const input = decodeCredentialInput(() => normalizeDeleteCredentialInput(rawInput));
-    const current = await this.read(root);
     const index = findCredentialIndex(current, input.expected.locator);
     const previous = index < 0 ? undefined : current.entries[index];
     if (!sameCredentialBasis(previous, input.expected)) {
@@ -126,8 +160,16 @@ export class CredentialVaultDocumentOwner {
       revision: nextRevision(current.revision),
       entries: current.entries.filter((_entry, candidate) => candidate !== index),
     };
-    await this.write(root, next);
-    return committed(next);
+    this.assertDocumentSize(next);
+    return { kind: 'ready', document: next };
+  }
+
+  async commitDelete(
+    root: string,
+    prepared: PreparedCredentialDelete,
+  ): Promise<CredentialMutationResult> {
+    await this.write(root, prepared.document);
+    return committed(prepared.document);
   }
 
   async deleteConnectionCredentials(
@@ -170,13 +212,17 @@ export class CredentialVaultDocumentOwner {
   }
 
   private async write(root: string, document: CredentialVaultDocument): Promise<void> {
+    this.assertDocumentSize(document);
+    await writeJsonDocument(root, FILE, document, VAULT_DOCUMENT_MAX_BYTES);
+  }
+
+  private assertDocumentSize(document: CredentialVaultDocument): void {
     if (serializeJsonDocument(document).length > VAULT_DOCUMENT_MAX_BYTES) {
       throw new RuntimePolicyStoreError(
         'invalid_credential_input',
         `credential vault exceeds its ${VAULT_DOCUMENT_MAX_BYTES} byte limit`,
       );
     }
-    await writeJsonDocument(root, FILE, document, VAULT_DOCUMENT_MAX_BYTES);
   }
 }
 

--- a/packages/storage/src/runtime-policy/operations.ts
+++ b/packages/storage/src/runtime-policy/operations.ts
@@ -1,13 +1,24 @@
 import type {
   ConnectionCatalogEntry,
+  ConnectionCatalogSnapshot,
+  ConnectionModelDiscoveryResult,
+  ConnectionTestSummary,
   CredentialLocator,
   CredentialStatus,
   CredentialVersionBasis,
   RuntimePolicy,
 } from '@maka/core/runtime-policy';
+import type { ProviderAuthActionAvailability } from '@maka/core/provider-auth';
 import type { ProviderDefaults } from '@maka/core/llm-connections';
 
+declare const operationTicketBrand: unique symbol;
+
 export type ProviderAuthKind = ProviderDefaults['authKind'];
+export type ConnectionEffectChangedDomain = 'connection' | 'credential' | 'network_proxy';
+export type UnavailableProviderActionAvailability = Exclude<
+  ProviderAuthActionAvailability,
+  'available'
+>;
 
 export interface RuntimePolicyCredentialMaterial extends CredentialVersionBasis {
   readonly secret: string;
@@ -22,6 +33,51 @@ export type CredentialStatusQueryResult =
   | { readonly kind: 'status'; readonly status: CredentialStatus }
   | { readonly kind: 'connection_not_found' };
 
+export interface ModelFetchTicket {
+  readonly [operationTicketBrand]: 'model_fetch';
+}
+
+export interface ConnectionTestTicket {
+  readonly [operationTicketBrand]: 'connection_test';
+}
+
+export type ConnectionEffectPreparationFailure =
+  | { readonly kind: 'connection_not_found' }
+  | { readonly kind: 'connection_disabled' }
+  | {
+      readonly kind: 'provider_action_unavailable';
+      readonly availability: UnavailableProviderActionAvailability;
+    }
+  | { readonly kind: 'credential_not_configured'; readonly status: CredentialStatus };
+
+export type BeginModelFetchResult =
+  | ConnectionEffectPreparationFailure
+  | {
+      readonly kind: 'ready';
+      readonly ticket: ModelFetchTicket;
+      readonly connection: ConnectionCatalogEntry;
+      readonly secretMaterial: RuntimePolicyOperationSecretMaterial;
+      readonly networkProxy: RuntimePolicy['networkProxy'];
+    };
+
+export type BeginConnectionTestResult =
+  | ConnectionEffectPreparationFailure
+  | {
+      readonly kind: 'ready';
+      readonly ticket: ConnectionTestTicket;
+      readonly connection: ConnectionCatalogEntry;
+      readonly modelId: string | null;
+      readonly secretMaterial: RuntimePolicyOperationSecretMaterial;
+      readonly networkProxy: RuntimePolicy['networkProxy'];
+    };
+
+export type ConnectionEffectCompletionResult =
+  | { readonly kind: 'committed'; readonly snapshot: ConnectionCatalogSnapshot }
+  | {
+      readonly kind: 'superseded';
+      readonly changed: readonly ConnectionEffectChangedDomain[];
+    };
+
 export type ResolveExecutionConnectionResult =
   | { readonly kind: 'not_found' }
   | { readonly kind: 'disabled' }
@@ -35,6 +91,19 @@ export type ResolveExecutionConnectionResult =
 
 export interface RuntimePolicyOperationCoordinator {
   resolveExecutionConnection(connectionSlug: string): Promise<ResolveExecutionConnectionResult>;
+  beginModelFetch(connectionId: string): Promise<BeginModelFetchResult>;
+  completeModelFetch(
+    ticket: ModelFetchTicket,
+    result: ConnectionModelDiscoveryResult,
+  ): Promise<ConnectionEffectCompletionResult>;
+  beginConnectionTest(
+    connectionId: string,
+    modelId: string | null,
+  ): Promise<BeginConnectionTestResult>;
+  completeConnectionTest(
+    ticket: ConnectionTestTicket,
+    result: ConnectionTestSummary,
+  ): Promise<ConnectionEffectCompletionResult>;
 }
 
 export function connectionCredentialLocator(

--- a/packages/storage/src/runtime-policy/policy-document.ts
+++ b/packages/storage/src/runtime-policy/policy-document.ts
@@ -31,6 +31,12 @@ export interface RuntimePolicyDocument {
   readonly policy: RuntimePolicy;
 }
 
+export interface PreparedRuntimePolicyMutation {
+  readonly kind: 'ready';
+  readonly current: RuntimePolicyDocument;
+  readonly next: RuntimePolicyDocument;
+}
+
 export class RuntimePolicyDocumentOwner {
   async read(root: string): Promise<RuntimePolicyDocument> {
     const value = await readBoundedJsonDocument(root, FILE, POLICY_DOCUMENT_MAX_BYTES);
@@ -56,8 +62,19 @@ export class RuntimePolicyDocumentOwner {
     root: string,
     rawInput: MutateRuntimePolicyInput,
   ): Promise<MutateRuntimePolicyResult> {
-    const input = decodePolicyInput(() => normalizeRuntimePolicyMutation(rawInput));
     const current = await this.read(root);
+    const prepared = this.prepareMutation(current, rawInput);
+    if (prepared.kind !== 'ready') return prepared;
+    return this.commitMutation(root, prepared);
+  }
+
+  prepareMutation(
+    current: RuntimePolicyDocument,
+    rawInput: MutateRuntimePolicyInput,
+  ):
+    | PreparedRuntimePolicyMutation
+    | Exclude<MutateRuntimePolicyResult, { readonly kind: 'committed' }> {
+    const input = decodePolicyInput(() => normalizeRuntimePolicyMutation(rawInput));
     if (current.revision !== input.expectedRevision) {
       return deepFreeze({
         kind: 'revision_conflict',
@@ -65,7 +82,7 @@ export class RuntimePolicyDocumentOwner {
         actualRevision: current.revision,
       });
     }
-    const next: RuntimePolicyDocument = {
+    const next = {
       schemaVersion: SCHEMA_VERSION,
       revision: nextRevision(current.revision),
       policy: applyMutation(current.policy, input.operation),
@@ -76,8 +93,15 @@ export class RuntimePolicyDocumentOwner {
         `runtime policy exceeds its ${POLICY_DOCUMENT_MAX_BYTES} byte limit`,
       );
     }
-    await writeJsonDocument(root, FILE, next, POLICY_DOCUMENT_MAX_BYTES);
-    return deepFreeze({ kind: 'committed', snapshot: policySnapshot(next) });
+    return { kind: 'ready', current, next };
+  }
+
+  async commitMutation(
+    root: string,
+    prepared: PreparedRuntimePolicyMutation,
+  ): Promise<Extract<MutateRuntimePolicyResult, { readonly kind: 'committed' }>> {
+    await writeJsonDocument(root, FILE, prepared.next, POLICY_DOCUMENT_MAX_BYTES);
+    return deepFreeze({ kind: 'committed', snapshot: policySnapshot(prepared.next) });
   }
 }
 


### PR DESCRIPTION

<details open>
<summary><strong>English</strong></summary>

## Summary

Move model discovery and connection testing behind one Runtime Host authority.
This closes the complete Connection Effects slice tracked by #1167 without
changing the production Desktop/TUI ownership switch.

## What changed

- Add the exact `connection.models.fetch` and `connection.test.run` Host
  operations. This is intentionally not a generic effect RPC.
- Prepare an authenticated, immutable connection/credential/proxy snapshot in
  the Store lane, perform provider I/O outside that lane, then conditionally
  commit against the current semantic facts.
- Serialize effects for one connection while allowing different connections to
  progress concurrently. Client disconnect does not cancel admitted work;
  drain rejects new effects and waits for accepted work.
- Reuse the existing provider discovery and test implementations through an
  explicit per-effect fetch transport with bounded body reads, deadlines, and
  owned proxy/direct dispatcher cleanup.
- Keep long-running completion effects off the generic two-second Client
  response timer unless the caller explicitly supplies a timeout. Provider
  deadlines and Host fail-stop remain the execution bounds.
- Validate provider JSON at its structural boundary. Malformed payloads become
  typed `invalid_response` outcomes, while metadata objects without a model
  identity remain safely ignorable.
- Commit successful discovery into the canonical model catalog. Connection
  tests persist only a redacted summary; model lists remain available through
  the existing revision-pinned catalog pagination.
- Invalidate stale verification when its actual dependencies change, including
  model protocol/selection, credentials, effective proxy policy, and active
  proxy credentials.

## Design notes

Provider I/O never holds the Store mutation lane or Runtime activation gate.
One-shot tickets make a late completion either commit against the exact
semantic basis or return a typed `superseded` result. Empty/failed discovery
preserves the current catalog, and no operation returns secrets, proxy
credentials, raw provider bodies, or unbounded model arrays.

This slice does not add automatic retries, single-flight discovery, a durable
effect journal, OAuth ownership, Hosted Backend composition, or production
surface cutover.

## Validation

The final branch is rebased on current `main`. Root build, typecheck, and the
relevant Core, Runtime, Storage, and Runtime Host suites pass. Coverage includes
the real Store, local HTTP providers, malformed provider payloads, a slow
completion beyond the generic Client timeout, and the two-client UDS path.

Part of #1167 and #853.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 摘要

将模型发现与连接测试收归同一个 Runtime Host authority。本 PR 完整关闭
#1167 中的 Connection Effects slice，但不提前切换 Desktop/TUI 的生产所有权。

## 改动

- 增加精确的 `connection.models.fetch` 与 `connection.test.run` Host operation，
  不引入通用 effect RPC。
- 在 Store lane 内准备经过认证且不可变的 connection/credential/proxy snapshot，
  在 lane 外执行 provider I/O，再根据当前语义事实做条件提交。
- 同一 connection 的 effect 串行，不同 connection 可以并发。Client 断开不会取消
  已接纳工作；drain 拒绝新 effect，并等待已接纳工作完成。
- 通过显式的 per-effect fetch transport 复用现有 provider discovery/test 实现，
  对 body、deadline 以及 proxy/direct dispatcher 的资源回收建立明确边界。
- 长时 completion effect 在调用方没有显式提供 timeout 时，不复用通用的两秒
  Client response timer；执行边界仍由 provider deadline 与 Host fail-stop 提供。
- 在 provider JSON 的结构边界进行验证。畸形 payload 返回 typed
  `invalid_response`，缺少模型身份的元数据对象仍可安全忽略。
- discovery 成功后写入 canonical model catalog；connection test 只持久化脱敏摘要。
  完整模型列表继续通过现有绑定 revision 的 catalog pagination 读取。
- 当模型协议/选择、凭据、effective proxy policy 或活动 proxy credential 变化时，
  清除已经失效的验证结果。

## 设计说明

Provider I/O 不持有 Store mutation lane 或 Runtime activation gate。一次性 ticket
保证迟到结果只能基于原有完整语义事实提交，否则返回 typed `superseded`。空结果或
失败的 discovery 保留现有 catalog；任何 operation 都不会返回 secret、proxy
credential、原始 provider body 或无界模型数组。

本 slice 不包含自动重试、single-flight discovery、durable effect journal、OAuth
所有权、Hosted Backend composition 或生产 surface cutover。

## 验证

最终分支已 rebase 到当前 `main`。根级 build、typecheck 以及相关 Core、Runtime、
Storage 和 Runtime Host 测试通过；覆盖真实 Store、本地 HTTP provider、畸形
provider payload、超过通用 Client timeout 的慢 completion，以及双 Client UDS
路径。

属于 #1167 与 #853 的一部分。

</details>
