### PR TITLE
feat(runtime-host): extract Usage/Pricing authority

### DIFF
--- a/apps/desktop/src/main/__tests__/daily-review-usage-readiness.test.ts
+++ b/apps/desktop/src/main/__tests__/daily-review-usage-readiness.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { createTelemetryRepo } from '@maka/storage';
+import { createDailyReviewMainService } from '../daily-review-main.js';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+test('Daily Review waits for shared usage readiness before reading telemetry', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-daily-review-usage-ready-'));
+  const seeded = createTelemetryRepo(root);
+  const telemetryRepo = createTelemetryRepo(root, { createIfMissing: false });
+  const loadGate = deferred();
+
+  try {
+    const now = Date.now();
+    await seeded.load();
+    await seeded.insertLlmCall({
+      id: 'usage_daily_review_ready',
+      providerId: 'openai',
+      modelId: 'gpt-5',
+      inputTokens: 10,
+      outputTokens: 20,
+      cacheHitInputTokens: 0,
+      cacheMissInputTokens: 10,
+      cachedInputTokens: 0,
+      cacheWriteInputTokens: 0,
+      reasoningTokens: 0,
+      totalTokens: 30,
+      costUsd: 0.001,
+      latencyMs: 5,
+      status: 'success',
+      startedAt: now - 5,
+      date: new Date(now).toISOString().slice(0, 10),
+      ts: now,
+    });
+    await seeded.close();
+
+    const service = createDailyReviewMainService({
+      telemetryRepo,
+      ensureUsageReady: async () => {
+        await loadGate.promise;
+        await telemetryRepo.load();
+      },
+      listSessions: async () => [],
+      archiveStore: {},
+      connectionStore: {},
+      resolveConnectionSecret: async () => null,
+      buildSubscriptionModelFetch: () => undefined,
+    } as unknown as Parameters<typeof createDailyReviewMainService>[0]);
+
+    const summaryPending = service.buildSummaryForRange(0, 1);
+    await Promise.resolve();
+    assert.throws(() => telemetryRepo.summary({ range: 'all' }));
+    loadGate.resolve();
+    const summary = await summaryPending;
+    assert.equal(summary.totals.requestCount, 1);
+  } finally {
+    await Promise.allSettled([seeded.close(), telemetryRepo.close()]);
+    await rm(root, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/src/main/__tests__/desktop-backend-tool-surface.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-backend-tool-surface.test.ts
@@ -379,6 +379,7 @@ function makeFactoryDeps(
     },
     permissionEngine: new PermissionEngine({ newId: () => 'permission-id', now: () => 1 }),
     telemetryRepo: {},
+    ensureUsageReady: async () => {},
     artifactStore: {},
     desktopSessionSkillHosts: new Map(),
     sandboxDiagnosticsProvider: { resolve: async () => undefined },

--- a/apps/desktop/src/main/__tests__/session-stream-usage-readiness.test.ts
+++ b/apps/desktop/src/main/__tests__/session-stream-usage-readiness.test.ts
@@ -1,0 +1,134 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { SessionHeader } from '@maka/core';
+import {
+  buildPricingLookup,
+  createSandboxDiagnosticsProvider,
+  PermissionEngine,
+  type BackendFactoryContext,
+} from '@maka/runtime';
+import {
+  createPlanStore,
+  createTelemetryRepo,
+} from '@maka/storage';
+import {
+  createAiSdkBackendFactory,
+  type AiSdkBackendFactoryDeps,
+} from '../session-stream.js';
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+test('the first Desktop backend waits for raw telemetry readiness', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-desktop-usage-ready-'));
+  const loadGate = deferred();
+  const telemetryRepo = createTelemetryRepo(root);
+  let lookupPricing = buildPricingLookup();
+  let readyConnectionReads = 0;
+
+  try {
+    const ensureUsageReady = async () => {
+      await loadGate.promise;
+      await telemetryRepo.load();
+      lookupPricing = buildPricingLookup(telemetryRepo.listPricingOverrides());
+    };
+    const factory = createAiSdkBackendFactory({
+      isComputerUseRealModelE2e: false,
+      ensureMcpReady: async () => {},
+      getReadyConnection: async () => {
+        readyConnectionReads += 1;
+        return {
+          connection: {
+            slug: 'openai-main',
+            name: 'OpenAI',
+            providerType: 'openai',
+            defaultModel: 'gpt-4o',
+            enabled: true,
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          apiKey: 'test-key',
+          model: 'gpt-4o',
+        };
+      },
+      buildSubscriptionModelFetch: () => undefined,
+      systemPromptService: {
+        buildLocalMemoryPromptFragment: async () => undefined,
+        buildBackendSystemPrompt: () => '',
+        buildTurnTailPrompt: () => undefined,
+      },
+      mcpManager: {},
+      permissionEngine: new PermissionEngine({ newId: () => 'permission-1', now: () => 1 }),
+      taskLedgerStore: {},
+      telemetryRepo,
+      ensureUsageReady,
+      artifactStore: {},
+      deepResearchTools: [],
+      desktopSessionSkillHosts: new Map(),
+      computerUseTools: [],
+      agentTeamLeadTools: [],
+      builtinTools: [],
+      toolAvailability: { economy: false, groups: [] },
+      sandboxDiagnosticsProvider: createSandboxDiagnosticsProvider({ platform: 'win32' }),
+      persistToolArtifacts: async () => {},
+      persistArchivedToolResult: async () => {},
+      readArchivedToolResult: async () => undefined,
+      runtimeCommitStore: undefined,
+      planStore: createPlanStore(root),
+      safeSendToRenderer: () => {},
+      getRuntime: () => ({}),
+      getLookupPricing: () => lookupPricing,
+    } as unknown as AiSdkBackendFactoryDeps);
+
+    const backendPending = Promise.resolve(factory(factoryContext(root)));
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    assert.equal(readyConnectionReads, 0);
+
+    loadGate.resolve();
+    const backend = await backendPending;
+    assert.equal(readyConnectionReads, 1);
+    await backend.dispose();
+  } finally {
+    await telemetryRepo.close().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function factoryContext(root: string): BackendFactoryContext {
+  const header: SessionHeader = {
+    id: 'session-1',
+    workspaceRoot: root,
+    cwd: root,
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Usage readiness test',
+    titleIsManual: true,
+    isFlagged: false,
+    labels: [],
+    isArchived: false,
+    status: 'active',
+    statusUpdatedAt: 1,
+    hasUnread: false,
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'openai-main',
+    connectionLocked: true,
+    model: 'gpt-4o',
+    permissionMode: 'ask',
+    schemaVersion: 1,
+  };
+  return {
+    sessionId: header.id,
+    workspaceRoot: root,
+    header,
+    store: { appendMessage: async () => {} } as unknown as BackendFactoryContext['store'],
+    tools: [],
+  };
+}

--- a/apps/desktop/src/main/__tests__/usage-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/usage-ipc-main.test.ts
@@ -1,0 +1,196 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { PricingConfig } from '@maka/core/usage-stats/types';
+import { createTelemetryRepo } from '@maka/storage';
+import { registerUsageIpc, type UsageIpcDeps } from '../usage-ipc-main.js';
+
+type Handler = (...args: any[]) => any;
+
+function deferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+test('usage IPC leaves settings usage session-derived while detailed usage waits for raw repo readiness', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-usage-ipc-ready-'));
+  const seeded = createTelemetryRepo(root);
+  const telemetryRepo = createTelemetryRepo(root, { createIfMissing: false });
+  const ready = deferred();
+  const handlers = new Map<string, Handler>();
+  const calls: string[] = [];
+
+  try {
+    await seeded.load();
+    await seeded.insertLlmCall(llmRecord('usage_ipc_ready'));
+    await seeded.close();
+    registerUsageIpc({
+      ipcMain: {
+        handle(channel: string, handler: Handler) {
+          handlers.set(channel, handler as Handler);
+        },
+      },
+      settingsStore: {
+        usageStats: async () => {
+          calls.push('settings');
+          return { source: 'sessions' };
+        },
+      },
+      telemetryRepo,
+      ensureUsageReady: async () => {
+        calls.push('ready:start');
+        await ready.promise;
+        await telemetryRepo.load();
+        calls.push('ready:end');
+      },
+      refreshPricingLookup: () => {},
+      sendToRenderer: () => {},
+    } as unknown as UsageIpcDeps);
+
+    const settings = await handlers.get('settings:usageStats')?.({});
+    assert.deepEqual(settings, { source: 'sessions' });
+    assert.deepEqual(calls, ['settings']);
+
+    const summaryPending = handlers.get('usage:summary')?.({}, { range: 'all' });
+    await Promise.resolve();
+    assert.deepEqual(calls, ['settings', 'ready:start']);
+    ready.resolve();
+    const summary = await summaryPending;
+    assert.equal(summary.ok, true);
+    assert.equal(summary.data.totalRequests, 1);
+    assert.deepEqual(calls, ['settings', 'ready:start', 'ready:end']);
+  } finally {
+    await Promise.allSettled([seeded.close(), telemetryRepo.close()]);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('legacy pricing IPC mutations serialize through the raw compatibility repo', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-usage-ipc-pricing-'));
+  const legacy = pricing('openai:legacy');
+  await writeFile(
+    join(root, 'telemetry.json'),
+    JSON.stringify({
+      usageRecords: [],
+      toolInvocations: [],
+      pricingOverrides: [legacy],
+    }),
+    'utf8',
+  );
+  const telemetryRepo = createTelemetryRepo(root);
+  const handlers = new Map<string, Handler>();
+  const firstWrite = deferred();
+  const firstWriteStarted = deferred();
+  const events: string[] = [];
+  const originalUpsert = telemetryRepo.upsertPricing.bind(telemetryRepo);
+  telemetryRepo.upsertPricing = async (value) => {
+    events.push(`upsert:${value.modelKey}`);
+    if (value.modelKey === 'openai:first') {
+      firstWriteStarted.resolve();
+      await firstWrite.promise;
+    }
+    await originalUpsert(value);
+  };
+  const originalDelete = telemetryRepo.deletePricing.bind(telemetryRepo);
+  telemetryRepo.deletePricing = async (modelKey) => {
+    events.push(`delete:${modelKey}`);
+    await originalDelete(modelKey);
+  };
+
+  try {
+    let readiness: Promise<void> | undefined;
+    const ensureUsageReady = () => {
+      readiness ??= telemetryRepo.load();
+      return readiness;
+    };
+    registerUsageIpc({
+      ipcMain: {
+        handle(channel: string, handler: Handler) {
+          handlers.set(channel, handler as Handler);
+        },
+      },
+      settingsStore: {},
+      telemetryRepo,
+      ensureUsageReady,
+      refreshPricingLookup: () => {
+        events.push(`refresh:${telemetryRepo.listPricingOverrides().length}`);
+      },
+      sendToRenderer: (channel: string) => {
+        events.push(`notify:${channel}`);
+      },
+    } as unknown as UsageIpcDeps);
+
+    const list = handlers.get('usage:pricing:list');
+    const put = handlers.get('usage:pricing:put');
+    const reset = handlers.get('usage:pricing:reset');
+    assert.ok(list);
+    assert.ok(put);
+    assert.ok(reset);
+    assert.deepEqual(await list({}), { ok: true, data: [legacy] });
+
+    const first = put({}, pricing('openai:first'));
+    const second = put({}, pricing('openai:second'));
+    const third = reset({}, 'openai:legacy');
+    await firstWriteStarted.promise;
+    assert.deepEqual(events, ['upsert:openai:first']);
+
+    firstWrite.resolve();
+    assert.equal((await first).ok, true);
+    assert.equal((await second).ok, true);
+    assert.equal((await third).ok, true);
+    assert.deepEqual(
+      telemetryRepo.listPricingOverrides().map((item) => item.modelKey),
+      ['openai:first', 'openai:second'],
+    );
+    assert.deepEqual(events, [
+      'upsert:openai:first',
+      'refresh:2',
+      'notify:usage:pricing:changed',
+      'upsert:openai:second',
+      'refresh:3',
+      'notify:usage:pricing:changed',
+      'delete:openai:legacy',
+      'refresh:2',
+      'notify:usage:pricing:changed',
+    ]);
+  } finally {
+    await telemetryRepo.close().catch(() => undefined);
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function pricing(modelKey: string): PricingConfig {
+  return {
+    modelKey,
+    inputUsdPer1M: 1,
+    outputUsdPer1M: 2,
+  };
+}
+
+function llmRecord(id: string) {
+  const now = Date.now();
+  return {
+    id,
+    providerId: 'openai',
+    modelId: 'gpt-5',
+    inputTokens: 10,
+    outputTokens: 20,
+    cacheHitInputTokens: 0,
+    cacheMissInputTokens: 10,
+    cachedInputTokens: 0,
+    cacheWriteInputTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 30,
+    costUsd: 0.001,
+    latencyMs: 5,
+    status: 'success' as const,
+    startedAt: now - 5,
+    date: new Date(now).toISOString().slice(0, 10),
+    ts: now,
+  };
+}

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -1,7 +1,7 @@
 import { app, nativeImage, safeStorage } from 'electron';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
-import { buildPricingLookup, setActiveProxy } from '@maka/runtime';
+import { setActiveProxy } from '@maka/runtime';
 import type {
   AgentGraphCoordinator,
   AgentGraphSupervisorWakeCoordinator,
@@ -39,8 +39,6 @@ import { runProjectStartupMigration } from './project-startup-migration.js';
 import { createAppQuitCoordinator } from './app-quit-coordinator.js';
 
 type AssembledTools = ReturnType<typeof assembleDesktopTools>;
-type PricingLookup = ReturnType<typeof buildPricingLookup>;
-
 export interface AppLifecycleDeps {
   isIsolatedE2e: boolean;
   e2eFixture: ReturnType<typeof resolveE2eFixture>;
@@ -51,6 +49,7 @@ export interface AppLifecycleDeps {
   connectionStore: ReturnType<typeof createConnectionStore>;
   settingsStore: ReturnType<typeof createSettingsStore>;
   telemetryRepo: ReturnType<typeof createTelemetryRepo>;
+  ensureUsageReady: () => Promise<void>;
   keepSystemAwake: KeepSystemAwakeController;
   botRegistry: BotRegistry;
   openGateway: OpenGatewayService;
@@ -78,9 +77,6 @@ export interface AppLifecycleDeps {
   /** Accessor for the settings IPC handle, which is assigned inside
    *  main.ts's `registerIpc()`; teardown disposes it if present. */
   getSettingsIpc: () => SettingsIpcHandle | undefined;
-  /** Reassigns the module-scoped pricing lookup in main.ts, which is read
-   *  live by the session streamer and the usage IPC handler. */
-  setLookupPricing: (value: PricingLookup) => void;
 }
 
 /**
@@ -106,6 +102,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     connectionStore,
     settingsStore,
     telemetryRepo,
+    ensureUsageReady,
     keepSystemAwake,
     botRegistry,
     openGateway,
@@ -129,7 +126,6 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     emitSessionsChanged,
     handleExternalSettingsChange,
     getSettingsIpc,
-    setLookupPricing,
   } = deps;
 
   let backgroundStartup: Promise<void> | undefined;
@@ -295,8 +291,8 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
    * Non-critical startup work that must NOT block the first window paint.
    *
    * `setActiveProxy` must be applied before any network-bearing step
-   * (`botRegistry.applySettings`, `openGateway.sync`); pricing depends on
-   * `telemetryRepo.load()`. Everything here is best-effort and logged on
+   * (`botRegistry.applySettings`, `openGateway.sync`); usage readiness loads
+   * the embedded telemetry compatibility repo. Everything here is best-effort and logged on
    * failure — none of it should prevent the user from seeing and interacting
    * with the app shell.
    */
@@ -311,8 +307,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     // Re-hold the power-save blocker at launch if the user left it enabled, so
     // scheduled tasks survive machine sleep across restarts.
     keepSystemAwake.apply(settings.system.keepSystemAwake);
-    await telemetryRepo.load();
-    setLookupPricing(buildPricingLookup(telemetryRepo.listPricingOverrides()));
+    await ensureUsageReady();
     await migrateSessionProjectsOnStartup();
     await recoverInterruptedSessionsOnStartup();
     await botRegistry.applySettings(settings.botChat);
@@ -356,6 +351,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
       mcpManager.close(),
       agentGraphCoordinator.close(),
       agentGraphSupervisorWakeCoordinator.close(),
+      telemetryRepo.close(),
     ]);
     for (const result of results) {
       if (result.status === 'rejected') console.error('[shutdown] cleanup failed:', result.reason);

--- a/apps/desktop/src/main/daily-review-main.ts
+++ b/apps/desktop/src/main/daily-review-main.ts
@@ -46,6 +46,7 @@ interface DailyReviewMainServiceDeps {
   archiveStore: DailyReviewArchiveStore;
   connectionStore: ConnectionStore;
   telemetryRepo: TelemetryRepo;
+  ensureUsageReady(): Promise<void>;
   listSessions(): Promise<readonly SessionSummary[]>;
   resolveConnectionSecret(slug: string): Promise<string | null>;
   buildSubscriptionModelFetch(
@@ -60,6 +61,7 @@ export function createDailyReviewMainService(deps: DailyReviewMainServiceDeps): 
   let schedulerLastMinuteKey: string | null = null;
 
   async function buildSummaryForRange(offsetDays: number, daySpan: number): Promise<DailyReviewSummary> {
+    await deps.ensureUsageReady();
     const offset = Number.isFinite(offsetDays) ? Math.trunc(offsetDays) : 0;
     const rawSpan = Number.isFinite(daySpan) ? Math.trunc(daySpan) : 1;
     const span = Math.max(1, Math.min(30, rawSpan));

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -714,6 +714,19 @@ const systemPromptService = createSystemPromptMainService({
   hostCapabilities: desktopProductToolSurface.hostCapabilities,
 });
 let lookupPricing = buildPricingLookup();
+let usageReadiness: Promise<void> | undefined;
+function ensureUsageReady(): Promise<void> {
+  if (!usageReadiness) {
+    const readiness = telemetryRepo.load().then(() => {
+      lookupPricing = buildPricingLookup(telemetryRepo.listPricingOverrides());
+    });
+    usageReadiness = readiness;
+    void readiness.catch(() => {
+      if (usageReadiness === readiness) usageReadiness = undefined;
+    });
+  }
+  return usageReadiness;
+}
 // Track the last status fields that affect persisted diagnostics. The reason
 // is part of the key because a running bridge can remain degraded while a
 // newer, more useful failure replaces the previous one.
@@ -808,6 +821,7 @@ backends.register('ai-sdk', createAiSdkBackendFactory({
   systemPromptService,
   permissionEngine,
   telemetryRepo,
+  ensureUsageReady,
   artifactStore,
   desktopSessionSkillHosts,
   sandboxDiagnosticsProvider,
@@ -975,6 +989,7 @@ const dailyReview = createDailyReviewMainService({
   archiveStore: dailyReviewArchiveStore,
   connectionStore,
   telemetryRepo,
+  ensureUsageReady,
   listSessions: async () => collapseSessionRevisions(await runtime.listSessions()),
   resolveConnectionSecret,
   buildSubscriptionModelFetch,
@@ -1137,6 +1152,7 @@ function registerIpc(): void {
     settingsStore,
     connectionStore,
     telemetryRepo,
+    ensureUsageReady,
     botRegistry,
     getComputerUseCapabilityInput: computerUseCapabilityInput,
   });
@@ -1176,8 +1192,10 @@ function registerIpc(): void {
   registerGatewayIpc({ openGateway });
   registerDailyReviewIpc({ dailyReview, dailyReviewArchiveStore, mainWindowController });
   registerUsageIpc({
+    ipcMain,
     settingsStore,
     telemetryRepo,
+    ensureUsageReady,
     refreshPricingLookup: () => {
       lookupPricing = buildPricingLookup(telemetryRepo.listPricingOverrides());
     },
@@ -1381,6 +1399,7 @@ wireAppLifecycle({
   connectionStore,
   settingsStore,
   telemetryRepo,
+  ensureUsageReady,
   keepSystemAwake,
   botRegistry,
   openGateway,
@@ -1404,9 +1423,6 @@ wireAppLifecycle({
   emitSessionsChanged,
   handleExternalSettingsChange,
   getSettingsIpc: () => settingsIpc,
-  setLookupPricing: (value) => {
-    lookupPricing = value;
-  },
 });
 
 function computerUseCapabilityInput() {

--- a/apps/desktop/src/main/permissions-ipc-main.ts
+++ b/apps/desktop/src/main/permissions-ipc-main.ts
@@ -31,12 +31,20 @@ export interface PermissionsIpcDeps {
   settingsStore: SettingsStore;
   connectionStore: ConnectionStore;
   telemetryRepo: TelemetryRepo;
+  ensureUsageReady: () => Promise<void>;
   botRegistry: BotRegistry;
   getComputerUseCapabilityInput: () => ComputerUseCapabilityInput;
 }
 
 export function registerPermissionsIpc(deps: PermissionsIpcDeps): void {
-  const { settingsStore, connectionStore, telemetryRepo, botRegistry, getComputerUseCapabilityInput } = deps;
+  const {
+    settingsStore,
+    connectionStore,
+    telemetryRepo,
+    ensureUsageReady,
+    botRegistry,
+    getComputerUseCapabilityInput,
+  } = deps;
 
   ipcMain.handle('permissions:getSnapshot', () => resolvePermissionSnapshot());
   ipcMain.handle('permissions:openSystemSettings', async (_event, permId: unknown) => {
@@ -57,6 +65,7 @@ export function registerPermissionsIpc(deps: PermissionsIpcDeps): void {
     });
   });
   ipcMain.handle('health:getSnapshot', async () => {
+    await ensureUsageReady();
     const now = Date.now();
     const permissions = resolvePermissionSnapshot(now);
     const settings = await settingsStore.get();

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -67,6 +67,7 @@ export interface AiSdkBackendFactoryDeps extends DesktopBackendToolSurfaceDeps {
   systemPromptService: SystemPromptMainService;
   permissionEngine: PermissionEngine;
   telemetryRepo: TelemetryRepo;
+  ensureUsageReady: () => Promise<void>;
   artifactStore: ArtifactStore;
   desktopSessionSkillHosts: Map<string, HostCapabilities>;
   sandboxDiagnosticsProvider: AssembledTools['sandboxDiagnosticsProvider'];
@@ -96,6 +97,7 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
     systemPromptService,
     permissionEngine,
     telemetryRepo,
+    ensureUsageReady,
     artifactStore,
     desktopSessionSkillHosts,
     sandboxDiagnosticsProvider,
@@ -111,6 +113,7 @@ export function createAiSdkBackendFactory(deps: AiSdkBackendFactoryDeps): Backen
   } = deps;
 
   return async (ctx) => {
+    await ensureUsageReady();
     const toolSurface = await resolveDesktopBackendToolSurface(deps, ctx);
     const {
       connection,

--- a/apps/desktop/src/main/usage-ipc-main.ts
+++ b/apps/desktop/src/main/usage-ipc-main.ts
@@ -1,14 +1,11 @@
-import { ipcMain } from 'electron';
+import type { IpcMain } from 'electron';
 import type { UsageRange } from '@maka/core';
-import type {
-  UsageGroupBy,
-  UsageQuery,
-} from '@maka/core/usage-stats/types';
+import { tryResult } from '@maka/core/result';
 import {
   normalizePricingConfig,
   normalizePricingModelKey,
 } from '@maka/core/usage-stats/pricing';
-import { tryResult } from '@maka/core/result';
+import type { UsageGroupBy, UsageQuery } from '@maka/core/usage-stats/types';
 import type { createSettingsStore, createTelemetryRepo } from '@maka/storage';
 import type { createMainWindowController } from './main-window.js';
 
@@ -16,50 +13,82 @@ type SettingsStore = ReturnType<typeof createSettingsStore>;
 type TelemetryRepo = ReturnType<typeof createTelemetryRepo>;
 type MainWindowController = ReturnType<typeof createMainWindowController>;
 
-interface UsageIpcDeps {
+export interface UsageIpcDeps {
+  ipcMain: Pick<IpcMain, 'handle'>;
   settingsStore: SettingsStore;
   telemetryRepo: TelemetryRepo;
+  ensureUsageReady: () => Promise<void>;
   refreshPricingLookup: () => void;
   sendToRenderer: MainWindowController['send'];
 }
 
 export function registerUsageIpc(deps: UsageIpcDeps): void {
-  ipcMain.handle('settings:usageStats', (_event, range?: UsageRange) =>
+  let pricingMutationQueue: Promise<void> = Promise.resolve();
+  const enqueuePricingMutation = <T>(operation: () => Promise<T>): Promise<T> => {
+    const result = pricingMutationQueue.then(operation);
+    pricingMutationQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  };
+
+  deps.ipcMain.handle('settings:usageStats', (_event, range?: UsageRange) =>
     deps.settingsStore.usageStats(range),
   );
-  ipcMain.handle('usage:summary', (_event, query: UsageQuery) =>
-    tryResult(async () => deps.telemetryRepo.summary(query), 'USAGE_SUMMARY_FAILED'),
-  );
-  ipcMain.handle('usage:buckets', (_event, query: UsageQuery & { groupBy: UsageGroupBy }) =>
-    tryResult(async () => deps.telemetryRepo.buckets(query, query.groupBy), 'USAGE_BUCKETS_FAILED'),
-  );
-  ipcMain.handle('usage:logs', (_event, query: UsageQuery & { offset?: number; limit?: number }) =>
-    tryResult(async () => deps.telemetryRepo.logs(query, query.offset, query.limit), 'USAGE_LOGS_FAILED'),
-  );
-  ipcMain.handle('usage:pricing:list', () =>
-    tryResult(async () => deps.telemetryRepo.listPricingOverrides(), 'USAGE_PRICING_LIST_FAILED'),
-  );
-  ipcMain.handle('usage:pricing:put', (_event, pricing: unknown) =>
+  deps.ipcMain.handle('usage:summary', (_event, query: UsageQuery) =>
     tryResult(async () => {
-      const normalized = normalizePricingConfig(pricing);
-      if (!normalized.ok) {
-        throw new Error(normalized.error);
-      }
-      await deps.telemetryRepo.upsertPricing(normalized.value);
-      deps.refreshPricingLookup();
-      deps.sendToRenderer('usage:pricing:changed');
-      return normalized.value;
-    }, 'USAGE_PRICING_PUT_FAILED'),
+      await deps.ensureUsageReady();
+      return deps.telemetryRepo.summary(query);
+    }, 'USAGE_SUMMARY_FAILED'),
   );
-  ipcMain.handle('usage:pricing:reset', (_event, modelKey: unknown) =>
+  deps.ipcMain.handle('usage:buckets', (_event, query: UsageQuery & { groupBy: UsageGroupBy }) =>
     tryResult(async () => {
-      const keyResult = normalizePricingModelKey(modelKey);
-      if (!keyResult.ok) {
-        throw new Error(keyResult.error);
-      }
-      await deps.telemetryRepo.deletePricing(keyResult.value);
-      deps.refreshPricingLookup();
-      deps.sendToRenderer('usage:pricing:changed');
-    }, 'USAGE_PRICING_RESET_FAILED'),
+      await deps.ensureUsageReady();
+      return deps.telemetryRepo.buckets(query, query.groupBy);
+    }, 'USAGE_BUCKETS_FAILED'),
+  );
+  deps.ipcMain.handle(
+    'usage:logs',
+    (_event, query: UsageQuery & { offset?: number; limit?: number }) =>
+      tryResult(async () => {
+        await deps.ensureUsageReady();
+        return deps.telemetryRepo.logs(query, query.offset, query.limit);
+      }, 'USAGE_LOGS_FAILED'),
+  );
+  deps.ipcMain.handle('usage:pricing:list', () =>
+    tryResult(async () => {
+      await deps.ensureUsageReady();
+      return deps.telemetryRepo.listPricingOverrides();
+    }, 'USAGE_PRICING_LIST_FAILED'),
+  );
+  deps.ipcMain.handle('usage:pricing:put', (_event, pricing: unknown) =>
+    tryResult(
+      () =>
+        enqueuePricingMutation(async () => {
+          await deps.ensureUsageReady();
+          const normalized = normalizePricingConfig(pricing);
+          if (!normalized.ok) throw new Error(normalized.error);
+          await deps.telemetryRepo.upsertPricing(normalized.value);
+          deps.refreshPricingLookup();
+          deps.sendToRenderer('usage:pricing:changed');
+          return normalized.value;
+        }),
+      'USAGE_PRICING_PUT_FAILED',
+    ),
+  );
+  deps.ipcMain.handle('usage:pricing:reset', (_event, modelKey: unknown) =>
+    tryResult(
+      () =>
+        enqueuePricingMutation(async () => {
+          await deps.ensureUsageReady();
+          const keyResult = normalizePricingModelKey(modelKey);
+          if (!keyResult.ok) throw new Error(keyResult.error);
+          await deps.telemetryRepo.deletePricing(keyResult.value);
+          deps.refreshPricingLookup();
+          deps.sendToRenderer('usage:pricing:changed');
+        }),
+      'USAGE_PRICING_RESET_FAILED',
+    ),
   );
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -76,6 +76,7 @@
     "./settings/result": "./dist/settings/result.js",
     "./usage-stats/types": "./dist/usage-stats/types.js",
     "./usage-stats/pricing": "./dist/usage-stats/pricing.js",
+    "./usage-record-schema": "./dist/usage-record-schema.js",
     "./session-send-projection": "./dist/session-send-projection.js",
     "./tool-catalog": "./dist/tool-catalog.js"
   },

--- a/packages/core/src/usage-stats/__tests__/pricing.test.ts
+++ b/packages/core/src/usage-stats/__tests__/pricing.test.ts
@@ -18,9 +18,76 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import {
   PRICING_MODEL_KEY_MAX_CHARS,
+  canonicalPricingConfigsEqual,
+  comparePricingModelKeys,
   normalizePricingConfig,
   normalizePricingModelKey,
+  validateCanonicalPricingConfig,
 } from '../pricing.js';
+
+describe('comparePricingModelKeys', () => {
+  it('strictly orders exact-distinct canonically equivalent Unicode keys', () => {
+    const composed = '\u00e9';
+    const decomposed = 'e\u0301';
+
+    assert.notEqual(composed, decomposed);
+    assert.equal(comparePricingModelKeys(composed, composed), 0);
+    assert.equal(comparePricingModelKeys(decomposed, composed), -1);
+    assert.equal(comparePricingModelKeys(composed, decomposed), 1);
+    assert.deepEqual([composed, decomposed].sort(comparePricingModelKeys), [decomposed, composed]);
+  });
+});
+
+describe('canonical PricingConfig contract', () => {
+  const canonical = {
+    modelKey: 'openai:gpt-5',
+    inputUsdPer1M: 1.25,
+    outputUsdPer1M: 10,
+    cacheReadUsdPer1M: 0.25,
+  };
+
+  it('accepts only the exact already-normalized shape', () => {
+    assert.deepEqual(validateCanonicalPricingConfig(canonical), {
+      ok: true,
+      value: canonical,
+    });
+    for (const value of [
+      { ...canonical, modelKey: ' openai:gpt-5 ' },
+      { ...canonical, unknown: true },
+      { modelKey: canonical.modelKey, outputUsdPer1M: canonical.outputUsdPer1M },
+      { ...canonical, cacheWriteUsdPer1M: undefined },
+    ]) {
+      assert.equal(validateCanonicalPricingConfig(value).ok, false);
+    }
+  });
+
+  it('compares canonical values including optional-field presence', () => {
+    assert.equal(canonicalPricingConfigsEqual(canonical, { ...canonical }), true);
+    assert.equal(
+      canonicalPricingConfigsEqual(canonical, {
+        ...canonical,
+        cacheReadUsdPer1M: 0.5,
+      }),
+      false,
+    );
+    assert.equal(
+      canonicalPricingConfigsEqual(
+        {
+          modelKey: canonical.modelKey,
+          inputUsdPer1M: canonical.inputUsdPer1M,
+          outputUsdPer1M: canonical.outputUsdPer1M,
+        },
+        {
+          modelKey: canonical.modelKey,
+          inputUsdPer1M: canonical.inputUsdPer1M,
+          outputUsdPer1M: canonical.outputUsdPer1M,
+          cacheReadUsdPer1M: undefined,
+        },
+      ),
+      false,
+    );
+  });
+});
 
 describe('normalizePricingModelKey (PR-UI-IPC-3)', () => {
   describe('accept', () => {

--- a/packages/core/src/usage-stats/pricing.ts
+++ b/packages/core/src/usage-stats/pricing.ts
@@ -9,7 +9,7 @@
  *   - negative rate → "credit / refund" misread in cost display
  *   - `NaN` rate    → math propagates `NaN`, dashboard shows garbage
  *   - `Infinity`    → math propagates `Infinity`, dashboard breaks
- *   - non-string `modelKey` → `localeCompare` crashes the sort
+ *   - non-string `modelKey` → key ordering crashes
  *   - empty `modelKey`     → orphan entry; match-by-key fails
  *   - non-object pricing   → TypeError accessing fields
  *
@@ -41,12 +41,35 @@ export type NormalizePricingModelKeyResult =
   | { ok: true; value: string }
   | { ok: false; error: string };
 
+const CANONICAL_PRICING_CONFIG_SHAPE = {
+  modelKey: 'required',
+  inputUsdPer1M: 'required',
+  outputUsdPer1M: 'required',
+  cacheReadUsdPer1M: 'optional',
+  cacheWriteUsdPer1M: 'optional',
+} as const satisfies {
+  readonly [Key in keyof PricingConfig]-?: 'required' | 'optional';
+};
+const CANONICAL_PRICING_CONFIG_KEYS = Object.freeze(
+  Object.keys(CANONICAL_PRICING_CONFIG_SHAPE) as Array<keyof PricingConfig>,
+);
+const CANONICAL_PRICING_CONFIG_KEY_SET = new Set<string>(CANONICAL_PRICING_CONFIG_KEYS);
+
 /**
  * Max code-point length for `modelKey`. 128 chars is well past
  * any provider key Maka ships (`anthropic:claude-sonnet-4-5` =
  * ~30 chars) but bounds adversarial input.
  */
 export const PRICING_MODEL_KEY_MAX_CHARS = 128;
+
+/**
+ * Locale-independent strict total order for exact JavaScript strings.
+ * Canonically equivalent Unicode spellings remain distinct keys.
+ */
+export function comparePricingModelKeys(left: string, right: string): -1 | 0 | 1 {
+  if (left === right) return 0;
+  return left < right ? -1 : 1;
+}
 
 /**
  * Validate + canonicalize a pricing `modelKey`.
@@ -143,6 +166,44 @@ export function normalizePricingConfig(input: unknown): NormalizePricingResult {
     ...(cacheWrite !== undefined ? { cacheWriteUsdPer1M: cacheWrite } : {}),
   };
   return { ok: true, value: canonical };
+}
+
+/**
+ * Validate that a runtime value is already in canonical PricingConfig form.
+ * Unlike normalization, this rejects unknown fields, omitted required fields,
+ * explicit undefined optionals, and values that normalization would alter.
+ */
+export function validateCanonicalPricingConfig(input: unknown): NormalizePricingResult {
+  if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+    return { ok: false, error: 'pricing must be an object' };
+  }
+  const record = input as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (
+    keys.some((key) => !CANONICAL_PRICING_CONFIG_KEY_SET.has(key)) ||
+    Object.entries(CANONICAL_PRICING_CONFIG_SHAPE).some(
+      ([key, presence]) => presence === 'required' && !Object.hasOwn(record, key),
+    )
+  ) {
+    return { ok: false, error: 'pricing has missing or unknown fields' };
+  }
+
+  const normalized = normalizePricingConfig(record);
+  if (!normalized.ok) return normalized;
+  if (!canonicalPricingConfigsEqual(normalized.value, record as unknown as PricingConfig)) {
+    return { ok: false, error: 'pricing is not canonical' };
+  }
+  return normalized;
+}
+
+/** Exact equality for two already-canonical pricing configurations. */
+export function canonicalPricingConfigsEqual(
+  left: Readonly<PricingConfig>,
+  right: Readonly<PricingConfig>,
+): boolean {
+  return CANONICAL_PRICING_CONFIG_KEYS.every(
+    (key) => left[key] === right[key] && Object.hasOwn(left, key) === Object.hasOwn(right, key),
+  );
 }
 
 /**

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -33,6 +33,7 @@ const allowedServerExternalImports = new Set([
   '@maka/core/runtime-event',
   '@maka/core/session',
   '@maka/core/task-ledger',
+  '@maka/core/usage-stats/types',
   '@maka/runtime',
   '@maka/storage/agent-graph-control-store',
   '@maka/storage/artifact-stores',
@@ -40,6 +41,7 @@ const allowedServerExternalImports = new Set([
   '@maka/storage/interaction-store',
   '@maka/storage/runtime-policy-stores',
   '@maka/storage/task-ledger-authority',
+  '@maka/storage/usage-stores',
   'node:async_hooks',
 ]);
 const allowedExternalImports = {
@@ -51,6 +53,8 @@ const allowedExternalImports = {
     '@maka/core/interaction',
     '@maka/core/runtime-policy',
     '@maka/core/task-ledger',
+    '@maka/core/usage-stats/pricing',
+    '@maka/core/usage-stats/types',
     'node:util',
   ]),
 } as const;

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -58,6 +58,8 @@ describe('Runtime Host bootstrap protocol', () => {
       'host.status',
       'interaction.answer',
       'interaction.query',
+      'pricing.mutate',
+      'pricing.query',
       'queue.retract',
       'runtime.policy.mutate',
       'runtime.policy.query',
@@ -72,6 +74,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'turn.query',
       'turn.start',
       'turn.stop',
+      'usage.query',
     ]);
     const errors = [
       'host_not_ready',

--- a/packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-client-correlation.test.ts
@@ -1,0 +1,345 @@
+import assert from 'node:assert/strict';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { createServer, type Server } from 'node:net';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import {
+  prepareStorageRootControlDirectory,
+  resolveStorageRoot,
+} from '@maka/storage/root-authority';
+import { connectRuntimeHost, type RuntimeHostConnection } from '../client/index.js';
+import { prepareRuntimeHostEndpoint } from '../control/endpoint.js';
+import { removeHostRegistration, writeHostRegistration } from '../control/registration.js';
+import {
+  decodeClientFrame,
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
+  RuntimeHostProtocolError,
+  type OperationInput,
+  type OperationOutput,
+  type RequestFrame,
+  type ResponseFrame,
+} from '../protocol/index.js';
+import { FramedTransport } from '../transport/framed-transport.js';
+
+const PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+const REQUEST_TIMEOUT_MS = 1_000;
+
+const mismatchCases = [
+  {
+    name: 'usage offset',
+    operation: 'usage.query',
+    input: {
+      kind: 'logs',
+      source: 'tool',
+      query: { range: 'all' },
+      offset: 50,
+    },
+    result: {
+      kind: 'logs',
+      source: 'tool',
+      rows: [],
+      offset: 49,
+      total: 49,
+      nextOffset: null,
+    },
+  },
+  {
+    name: 'usage log source',
+    operation: 'usage.query',
+    input: {
+      kind: 'logs',
+      source: 'tool',
+      query: { range: 'all' },
+      offset: 50,
+    },
+    result: {
+      kind: 'logs',
+      source: 'llm',
+      rows: [],
+      offset: 50,
+      total: 50,
+      nextOffset: null,
+    },
+  },
+  {
+    name: 'usage result kind',
+    operation: 'usage.query',
+    input: {
+      kind: 'logs',
+      source: 'tool',
+      query: { range: 'all' },
+      offset: 50,
+    },
+    result: {
+      kind: 'buckets',
+      buckets: [],
+      offset: 50,
+      total: 50,
+      nextOffset: null,
+    },
+  },
+  {
+    name: 'pricing revision',
+    operation: 'pricing.query',
+    input: { kind: 'continue', revision: 7, offset: 50 },
+    result: {
+      kind: 'page',
+      revision: 8,
+      offset: 50,
+      overrides: [],
+      nextOffset: null,
+    },
+  },
+  {
+    name: 'pricing start result kind',
+    operation: 'pricing.query',
+    input: { kind: 'start' },
+    result: {
+      kind: 'revision_changed',
+      expectedRevision: 7,
+      actualRevision: 8,
+    },
+  },
+  {
+    name: 'pricing revision-change expectation',
+    operation: 'pricing.query',
+    input: { kind: 'continue', revision: 7, offset: 50 },
+    result: {
+      kind: 'revision_changed',
+      expectedRevision: 8,
+      actualRevision: 9,
+    },
+  },
+  {
+    name: 'pricing mutation expectation',
+    operation: 'pricing.mutate',
+    input: {
+      expectedRevision: 7,
+      mutation: { kind: 'delete', modelKey: 'provider:model' },
+    },
+    result: {
+      kind: 'revision_conflict',
+      expectedRevision: 8,
+      actualRevision: 9,
+    },
+  },
+  {
+    name: 'pricing non-conflicting revision conflict',
+    operation: 'pricing.mutate',
+    input: {
+      expectedRevision: 7,
+      mutation: { kind: 'delete', modelKey: 'provider:model' },
+    },
+    result: {
+      kind: 'revision_conflict',
+      expectedRevision: 7,
+      actualRevision: 7,
+    },
+  },
+] as const;
+
+describe('Usage/Pricing client response correlation', () => {
+  for (const mismatch of mismatchCases) {
+    test(`fails the connection for a canonical response with mismatched ${mismatch.name}`, {
+      skip: process.platform === 'win32',
+    }, async () => {
+      await withProtocolPeer(
+        async (transport, hostEpoch) => {
+          const request = await acceptConnectionAndReadRequest(transport, hostEpoch);
+          assert.equal(request.operation, mismatch.operation);
+          await transport.write({
+            requestId: request.requestId,
+            operation: mismatch.operation,
+            ok: true,
+            result: mismatch.result,
+          } as ResponseFrame);
+          await transport.closed;
+        },
+        async (connection) => {
+          const request = requestUnchecked(connection, mismatch.operation, mismatch.input);
+          await assert.rejects(request, isInvalidFrame);
+          await connection.closed;
+          await assert.rejects(requestUnchecked(connection, 'host.status', {}), isInvalidFrame);
+        },
+      );
+    });
+  }
+
+  test('rejects local invalid input without poisoning transport and correlates a private canonical copy', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    await withProtocolPeer(
+      async (transport, hostEpoch) => {
+        const request = await acceptConnectionAndReadRequest(transport, hostEpoch);
+        assert.equal(request.operation, 'usage.query');
+        assert.deepEqual(request.input, {
+          kind: 'logs',
+          source: 'tool',
+          query: { range: 'all', toolName: 'Read' },
+          offset: 50,
+          limit: 10,
+        });
+        await transport.write({
+          requestId: request.requestId,
+          operation: 'usage.query',
+          ok: true,
+          result: {
+            kind: 'logs',
+            source: 'tool',
+            rows: [],
+            offset: 50,
+            total: 50,
+            nextOffset: null,
+          },
+        });
+        await transport.closed;
+      },
+      async (connection) => {
+        let invalidRequest!: Promise<OperationOutput<'usage.query'>>;
+        assert.doesNotThrow(() => {
+          invalidRequest = connection.request('usage.query', {
+            kind: 'logs',
+            source: 'tool',
+            query: { range: 'all', providerId: 'not-a-tool-filter' },
+          } as unknown as OperationInput<'usage.query'>);
+        });
+        await assert.rejects(invalidRequest, isInvalidFrame);
+
+        const input = {
+          kind: 'logs' as const,
+          source: 'tool' as const,
+          query: { range: 'all' as const, toolName: 'Read' },
+          offset: 50,
+          limit: 10,
+        };
+        const response = connection.request('usage.query', input, REQUEST_TIMEOUT_MS);
+        input.offset = 51;
+        input.query.toolName = 'Write';
+        assert.deepEqual(await response, {
+          kind: 'logs',
+          source: 'tool',
+          rows: [],
+          offset: 50,
+          total: 50,
+          nextOffset: null,
+        });
+      },
+    );
+  });
+});
+
+function requestUnchecked(
+  connection: RuntimeHostConnection,
+  operation: RequestFrame['operation'],
+  input: unknown,
+): Promise<unknown> {
+  const request = connection.request as unknown as (
+    operation: RequestFrame['operation'],
+    input: unknown,
+    timeoutMs: number,
+  ) => Promise<unknown>;
+  return request.call(connection, operation, input, REQUEST_TIMEOUT_MS);
+}
+
+async function withProtocolPeer(
+  serve: (transport: FramedTransport, hostEpoch: string) => Promise<void>,
+  run: (connection: RuntimeHostConnection) => Promise<void>,
+): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-usage-pricing-correlation-'));
+  const root = join(base, 'root');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const { controlDirectory } = await prepareStorageRootControlDirectory(capability);
+  const hostEpoch = randomUUID();
+  const endpoint = await prepareRuntimeHostEndpoint({
+    rootId: capability.rootId,
+    hostEpoch,
+  });
+  let resolveServer!: () => void;
+  let rejectServer!: (error: unknown) => void;
+  const serverTask = new Promise<void>((resolve, reject) => {
+    resolveServer = resolve;
+    rejectServer = reject;
+  });
+  const server = createServer((socket) => {
+    void serve(new FramedTransport(socket), hostEpoch).then(resolveServer, rejectServer);
+  });
+  try {
+    await listen(server, endpoint.path);
+    await endpoint.prepareAfterListen();
+    await writeHostRegistration(controlDirectory, {
+      kind: 'maka-runtime-host',
+      schemaVersion: RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION,
+      rootId: capability.rootId,
+      hostEpoch,
+      endpoint: endpoint.path,
+      protocolMin: RUNTIME_HOST_PROTOCOL_VERSION,
+      protocolMax: RUNTIME_HOST_PROTOCOL_VERSION,
+      state: 'ready',
+      pid: process.pid,
+      createdAt: new Date().toISOString(),
+    });
+    const connected = await connectRuntimeHost({
+      rootPath: root,
+      surface: 'tui',
+      protocol: PROTOCOL,
+    });
+    assert.equal(connected.kind, 'connected');
+    if (connected.kind !== 'connected') throw new Error('Protocol peer did not connect');
+    try {
+      await run(connected.connection);
+    } finally {
+      await connected.connection.close();
+    }
+    await serverTask;
+  } finally {
+    await closeServer(server);
+    await removeHostRegistration(controlDirectory, hostEpoch).catch(() => undefined);
+    await endpoint.cleanup().catch(() => undefined);
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+async function acceptConnectionAndReadRequest(
+  transport: FramedTransport,
+  hostEpoch: string,
+): Promise<RequestFrame> {
+  const hello = decodeClientFrame(await transport.read(REQUEST_TIMEOUT_MS));
+  assert.ok('kind' in hello && hello.kind === 'hello');
+  await transport.write({
+    kind: 'accepted',
+    hostEpoch,
+    connectionId: 'usage-pricing-correlation',
+    selectedProtocol: RUNTIME_HOST_PROTOCOL_VERSION,
+    state: 'ready',
+  });
+  const request = decodeClientFrame(await transport.read(REQUEST_TIMEOUT_MS));
+  assert.ok(!('kind' in request));
+  return request as RequestFrame;
+}
+
+function listen(server: Server, path: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(path, resolve);
+  });
+}
+
+function closeServer(server: Server): Promise<void> {
+  if (!server.listening) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+function isInvalidFrame(error: unknown): boolean {
+  return error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame';
+}

--- a/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
@@ -1,9 +1,19 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import {
   comparePricingModelKeys,
   PRICING_MODEL_KEY_MAX_CHARS,
 } from '@maka/core/usage-stats/pricing';
+import type { UsageBucket } from '@maka/core/usage-stats/types';
+import {
+  resolveRootControlNamespace,
+  resolveStorageRoot,
+  tryAcquireInteractiveRootOwner,
+} from '@maka/storage/root-authority';
+import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
 import {
   decodeClientFrame,
   decodeHostFrame,
@@ -18,7 +28,19 @@ import {
   USAGE_PAGE_MAX_BYTES,
   USAGE_PAGE_MAX_ITEMS,
   USAGE_PROJECTION_TEXT_MAX_BYTES,
+  type LlmUsageLogProjection,
+  type ToolUsageLogProjection,
 } from '../protocol/index.js';
+import type { ConnectionContext } from '../server/operation-dispatcher.js';
+import { HostUsagePricingCoordinator } from '../server/usage-pricing-coordinator.js';
+
+const CONNECTION_CONTEXT: ConnectionContext = {
+  hostEpoch: 'usage-pricing-protocol-test',
+  connectionId: 'usage-pricing-protocol-test-connection',
+  surface: 'tui',
+  principal: 'local_os_user',
+  acquireResidency: () => ({ release() {} }),
+};
 
 describe('Usage/Pricing protocol', () => {
   test('registers only the closed ready operations with current Kernel metadata', () => {
@@ -255,6 +277,76 @@ describe('Usage/Pricing protocol', () => {
       { kind: 'buckets', buckets: [validBucket()], offset: 1, total: 1, nextOffset: null },
     ]) {
       assert.throws(() => usageResponse(result), invalidFrame);
+    }
+  });
+
+  test('keeps long usage identities distinct through the real coordinator and protocol', async () => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-usage-identity-projection-'));
+    const capability = await resolveStorageRoot({
+      path: join(base, 'interactive-root'),
+      kind: 'interactive',
+    });
+    const owner = await tryAcquireInteractiveRootOwner(capability);
+    assert.ok(owner, 'test must acquire the real Interactive write lease');
+    const stores = await openInteractiveUsageStoresForWrite(owner.lease);
+
+    try {
+      const longCommon = '界'.repeat(400);
+      const identities = [
+        `identity\u0000${longCommon}-alpha`,
+        `identity\u0001${longCommon}-omega`,
+        'short\u0000identity',
+        'short\u0001identity',
+        `${'x'.repeat(1_100)}\ud800`,
+        `${'x'.repeat(1_100)}\ud801`,
+      ] as const;
+      await Promise.all(
+        identities.flatMap((identity, index) => [
+          stores.telemetry.recordLlmCall(longUsageRecord(identity, index + 1)),
+          stores.telemetry.recordToolInvocation(longToolRecord(identity, index + 11)),
+        ]),
+      );
+      const coordinator = new HostUsagePricingCoordinator(stores, () => {});
+
+      const llmRows = await queryUsageRows(coordinator, 'llm');
+      const toolRows = await queryUsageRows(coordinator, 'tool');
+      const buckets = await queryUsageBuckets(coordinator);
+
+      for (const field of [
+        'id',
+        'callId',
+        'connectionSlug',
+        'providerId',
+        'modelId',
+        'sessionId',
+        'turnId',
+      ] as const) {
+        assertDistinctBoundedIdentities(llmRows.map((row) => row[field]));
+      }
+      for (const field of [
+        'id',
+        'toolCallId',
+        'toolName',
+        'providerId',
+        'modelId',
+        'sessionId',
+        'turnId',
+      ] as const) {
+        assertDistinctBoundedIdentities(toolRows.map((row) => row[field]));
+      }
+      assertDistinctBoundedIdentities(buckets.map((bucket) => bucket.key));
+      assert.equal(new Set(buckets.map((bucket) => bucket.label)).size, 3);
+      assert.deepEqual(await queryUsageRows(coordinator, 'llm'), llmRows);
+      assert.deepEqual(await queryUsageRows(coordinator, 'tool'), toolRows);
+      assert.deepEqual(await queryUsageBuckets(coordinator), buckets);
+    } finally {
+      await stores.close().catch(() => undefined);
+      await owner.close();
+      await rm(join(resolveRootControlNamespace(), capability.rootId), {
+        recursive: true,
+        force: true,
+      });
+      await rm(base, { recursive: true, force: true });
     }
   });
 
@@ -536,6 +628,125 @@ function validToolLog() {
     bytesOut: 3,
     startedAt: 1,
   };
+}
+
+function longUsageRecord(identity: string, ts: number) {
+  return {
+    id: identity,
+    sessionId: identity,
+    turnId: identity,
+    callId: identity,
+    connectionSlug: identity,
+    providerId: identity,
+    modelId: identity,
+    inputTokens: 1,
+    outputTokens: 2,
+    cacheHitInputTokens: 0,
+    cacheMissInputTokens: 1,
+    cachedInputTokens: 0,
+    cacheWriteInputTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 3,
+    latencyMs: 10,
+    costUsd: 0.01,
+    startedAt: ts,
+    date: '2026-07-29',
+    ts,
+    status: 'success' as const,
+  };
+}
+
+function longToolRecord(identity: string, ts: number) {
+  return {
+    id: identity,
+    sessionId: identity,
+    turnId: identity,
+    toolCallId: identity,
+    toolName: identity,
+    providerId: identity,
+    modelId: identity,
+    durationMs: 10,
+    status: 'success' as const,
+    bytesIn: 1,
+    bytesOut: 2,
+    startedAt: ts,
+    date: '2026-07-29',
+    ts,
+  };
+}
+
+async function queryUsageRows(
+  coordinator: HostUsagePricingCoordinator,
+  source: 'llm',
+): Promise<readonly LlmUsageLogProjection[]>;
+async function queryUsageRows(
+  coordinator: HostUsagePricingCoordinator,
+  source: 'tool',
+): Promise<readonly ToolUsageLogProjection[]>;
+async function queryUsageRows(
+  coordinator: HostUsagePricingCoordinator,
+  source: 'llm' | 'tool',
+): Promise<readonly (LlmUsageLogProjection | ToolUsageLogProjection)[]> {
+  const outcome = await coordinator.handlers['usage.query'](
+    { kind: 'logs', source, query: { range: 'all' } },
+    CONNECTION_CONTEXT,
+  );
+  const frame = decodeHostFrame(
+    JSON.parse(
+      encodeProtocolFrame({
+        requestId: `usage-${source}-identity-query`,
+        operation: 'usage.query',
+        ...outcome,
+      }).toString('utf8'),
+    ),
+  );
+  if (
+    'kind' in frame ||
+    frame.operation !== 'usage.query' ||
+    !frame.ok ||
+    frame.result.kind !== 'logs' ||
+    frame.result.source !== source
+  ) {
+    throw new Error(`Expected ${source} usage rows`);
+  }
+  return frame.result.rows;
+}
+
+async function queryUsageBuckets(
+  coordinator: HostUsagePricingCoordinator,
+): Promise<readonly UsageBucket[]> {
+  const outcome = await coordinator.handlers['usage.query'](
+    { kind: 'buckets', query: { range: 'all' }, groupBy: 'provider' },
+    CONNECTION_CONTEXT,
+  );
+  const frame = decodeHostFrame(
+    JSON.parse(
+      encodeProtocolFrame({
+        requestId: 'usage-bucket-identity-query',
+        operation: 'usage.query',
+        ...outcome,
+      }).toString('utf8'),
+    ),
+  );
+  if (
+    'kind' in frame ||
+    frame.operation !== 'usage.query' ||
+    !frame.ok ||
+    frame.result.kind !== 'buckets'
+  ) {
+    throw new Error('Expected usage buckets');
+  }
+  return frame.result.buckets;
+}
+
+function assertDistinctBoundedIdentities(values: readonly (string | undefined)[]): void {
+  assert.equal(values.length, 6);
+  assert.ok(values.every((value): value is string => typeof value === 'string'));
+  assert.equal(new Set(values).size, values.length);
+  for (const value of values) {
+    assert.ok(Buffer.byteLength(value, 'utf8') <= USAGE_PROJECTION_TEXT_MAX_BYTES);
+    assert.equal(/[\u0000-\u001f\u007f-\u009f]/u.test(value), false);
+  }
 }
 
 function pricing(modelKey: string) {

--- a/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-protocol.test.ts
@@ -1,0 +1,578 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  comparePricingModelKeys,
+  PRICING_MODEL_KEY_MAX_CHARS,
+} from '@maka/core/usage-stats/pricing';
+import {
+  decodeClientFrame,
+  decodeHostFrame,
+  decodeUsageQueryInput,
+  encodePricingQueryResult,
+  encodeProtocolFrame,
+  HOST_OPERATION_SPECS,
+  PRICING_PAGE_MAX_BYTES,
+  PRICING_PAGE_MAX_ITEMS,
+  RUNTIME_HOST_MAX_FRAME_BYTES,
+  RuntimeHostProtocolError,
+  USAGE_PAGE_MAX_BYTES,
+  USAGE_PAGE_MAX_ITEMS,
+  USAGE_PROJECTION_TEXT_MAX_BYTES,
+} from '../protocol/index.js';
+
+describe('Usage/Pricing protocol', () => {
+  test('registers only the closed ready operations with current Kernel metadata', () => {
+    assert.deepEqual(
+      Object.keys(HOST_OPERATION_SPECS).filter(
+        (key) => key.startsWith('usage.') || key.startsWith('pricing.'),
+      ),
+      ['usage.query', 'pricing.query', 'pricing.mutate'],
+    );
+    assert.deepEqual(operationMetadata('usage.query'), {
+      mode: 'query',
+      availability: 'ready',
+    });
+    assert.deepEqual(operationMetadata('pricing.query'), {
+      mode: 'query',
+      availability: 'ready',
+    });
+    assert.deepEqual(operationMetadata('pricing.mutate'), {
+      mode: 'command',
+      availability: 'ready',
+    });
+    const mutationErrors = HOST_OPERATION_SPECS['pricing.mutate'].errors;
+    assert.equal(new Set(mutationErrors).size, mutationErrors.length);
+  });
+
+  test('decodes exact bounded usage queries', () => {
+    assert.deepEqual(
+      decodeUsageQueryInput({
+        kind: 'logs',
+        source: 'llm',
+        query: { range: 'all' },
+      }),
+      {
+        kind: 'logs',
+        source: 'llm',
+        query: { range: 'all' },
+        offset: 0,
+        limit: USAGE_PAGE_MAX_ITEMS,
+      },
+    );
+    assert.deepEqual(
+      decodeUsageQueryInput({
+        kind: 'buckets',
+        query: {
+          range: { from: 1, to: 2 },
+          connectionSlug: 'primary',
+          providerId: 'provider',
+          modelId: 'model',
+          status: 'success',
+        },
+        groupBy: 'model',
+        offset: 2,
+        limit: 3,
+      }),
+      {
+        kind: 'buckets',
+        query: {
+          range: { from: 1, to: 2 },
+          connectionSlug: 'primary',
+          providerId: 'provider',
+          modelId: 'model',
+          status: 'success',
+        },
+        groupBy: 'model',
+        offset: 2,
+        limit: 3,
+      },
+    );
+    assert.deepEqual(
+      decodeUsageQueryInput({
+        kind: 'buckets',
+        query: { range: 'all', toolName: 'Read', status: 'error' },
+        groupBy: 'tool',
+      }),
+      {
+        kind: 'buckets',
+        query: { range: 'all', toolName: 'Read', status: 'error' },
+        groupBy: 'tool',
+        offset: 0,
+        limit: USAGE_PAGE_MAX_ITEMS,
+      },
+    );
+    assert.deepEqual(
+      decodeUsageQueryInput({
+        kind: 'logs',
+        source: 'tool',
+        query: { range: 'all', toolName: 'Read', status: 'success' },
+      }),
+      {
+        kind: 'logs',
+        source: 'tool',
+        query: { range: 'all', toolName: 'Read', status: 'success' },
+        offset: 0,
+        limit: USAGE_PAGE_MAX_ITEMS,
+      },
+    );
+
+    for (const input of [
+      { kind: 'summary', query: { range: 'all' }, offset: 0 },
+      { kind: 'summary', query: { range: 'all', toolName: 'Read' } },
+      { kind: 'logs', query: { range: 'all' } },
+      { kind: 'logs', source: 'llm', query: { range: 'all', toolName: 'Read' } },
+      { kind: 'logs', source: 'tool', query: { range: 'all', providerId: 'provider' } },
+      { kind: 'logs', source: 'tool', query: { range: 'all', modelId: 'model' } },
+      { kind: 'logs', source: 'llm', query: { range: 'all', unknown: true } },
+      { kind: 'logs', source: 'llm', query: { range: { from: 2, to: 1 } } },
+      { kind: 'logs', source: 'llm', query: { range: 'all' }, offset: -1 },
+      { kind: 'logs', source: 'llm', query: { range: 'all' }, offset: 0.5 },
+      { kind: 'logs', source: 'llm', query: { range: 'all' }, limit: 0 },
+      { kind: 'logs', source: 'llm', query: { range: 'all' }, limit: 1.5 },
+      {
+        kind: 'logs',
+        source: 'llm',
+        query: { range: 'all' },
+        limit: USAGE_PAGE_MAX_ITEMS + 1,
+      },
+      {
+        kind: 'buckets',
+        query: { range: 'all', toolName: 'Read' },
+        groupBy: 'model',
+      },
+      {
+        kind: 'buckets',
+        query: { range: 'all', connectionSlug: 'primary' },
+        groupBy: 'tool',
+      },
+      { kind: 'buckets', query: { range: 'all' }, groupBy: 'week' },
+      { kind: 'export', query: { range: 'all' } },
+    ]) {
+      assert.throws(() => usageRequest(input), invalidFrame);
+    }
+  });
+
+  test('enforces exact usage results and both page bounds', () => {
+    assert.doesNotThrow(() => usageResponse({ kind: 'summary', summary: validSummary() }));
+    assert.doesNotThrow(() =>
+      usageResponse({
+        kind: 'buckets',
+        buckets: [validBucket()],
+        offset: 0,
+        total: 2,
+        nextOffset: 1,
+      }),
+    );
+    assert.doesNotThrow(() =>
+      usageResponse({
+        kind: 'logs',
+        source: 'llm',
+        rows: [validLog()],
+        offset: 0,
+        total: 1,
+        nextOffset: null,
+      }),
+    );
+    assert.doesNotThrow(() =>
+      usageResponse({
+        kind: 'logs',
+        source: 'tool',
+        rows: [validToolLog()],
+        offset: 0,
+        total: 1,
+        nextOffset: null,
+      }),
+    );
+
+    const tooMany = Array.from({ length: USAGE_PAGE_MAX_ITEMS + 1 }, () => validBucket());
+    const byteHeavy = Array.from({ length: 50 }, (_, index) => ({
+      ...validLog(index),
+      errorClass: '\\'.repeat(USAGE_PROJECTION_TEXT_MAX_BYTES),
+    }));
+    const oversized = {
+      kind: 'logs',
+      source: 'llm',
+      rows: byteHeavy,
+      offset: 0,
+      total: 50,
+      nextOffset: null,
+    };
+    assert.ok(Buffer.byteLength(JSON.stringify(oversized), 'utf8') > USAGE_PAGE_MAX_BYTES);
+
+    for (const result of [
+      {
+        kind: 'buckets',
+        buckets: tooMany,
+        offset: 0,
+        total: tooMany.length,
+        nextOffset: null,
+      },
+      oversized,
+      {
+        kind: 'logs',
+        source: 'llm',
+        rows: [{ ...validLog(), errorClass: 'x'.repeat(USAGE_PROJECTION_TEXT_MAX_BYTES + 1) }],
+        offset: 0,
+        total: 1,
+        nextOffset: null,
+      },
+      {
+        kind: 'logs',
+        source: 'llm',
+        rows: [{ ...validLog(), systemPromptHash: 'not-on-the-wire' }],
+        offset: 0,
+        total: 1,
+        nextOffset: null,
+      },
+      { kind: 'summary', summary: { ...validSummary(), totalRequests: 0.5 } },
+      {
+        kind: 'buckets',
+        buckets: [{ ...validBucket(), requests: 0.5 }],
+        offset: 0,
+        total: 1,
+        nextOffset: null,
+      },
+      {
+        kind: 'logs',
+        source: 'llm',
+        rows: [{ ...validLog(), inputTokens: 0.5 }],
+        offset: 0,
+        total: 1,
+        nextOffset: null,
+      },
+      {
+        kind: 'logs',
+        source: 'tool',
+        rows: [{ ...validToolLog(), source: 'llm' }],
+        offset: 0,
+        total: 1,
+        nextOffset: null,
+      },
+      { kind: 'buckets', buckets: [validBucket()], offset: 0, total: 1, nextOffset: 2 },
+      { kind: 'buckets', buckets: [], offset: 0, total: 1, nextOffset: 0 },
+      { kind: 'buckets', buckets: [validBucket()], offset: 1, total: 3, nextOffset: 3 },
+      { kind: 'buckets', buckets: [validBucket()], offset: 0, total: 2, nextOffset: null },
+      { kind: 'buckets', buckets: [validBucket()], offset: 1, total: 1, nextOffset: null },
+    ]) {
+      assert.throws(() => usageResponse(result), invalidFrame);
+    }
+  });
+
+  test('decodes revision-pinned numeric-offset pricing pages and revision-CAS mutation', () => {
+    assert.doesNotThrow(() => pricingRequest('pricing.query', { kind: 'start' }));
+    assert.doesNotThrow(() =>
+      pricingRequest('pricing.query', { kind: 'continue', revision: 3, offset: 17 }),
+    );
+    for (const input of [
+      {},
+      { kind: 'start', offset: 0 },
+      { kind: 'continue', revision: -1, offset: 1 },
+      { kind: 'continue', revision: 0.5, offset: 1 },
+      { kind: 'continue', revision: 0, offset: -1 },
+      { kind: 'continue', revision: 0, offset: 0.5 },
+    ]) {
+      assert.throws(() => pricingRequest('pricing.query', input), invalidFrame);
+    }
+
+    assert.doesNotThrow(() =>
+      pricingRequest('pricing.mutate', {
+        expectedRevision: 0,
+        mutation: { kind: 'upsert', pricing: pricing('provider:model') },
+      }),
+    );
+    assert.doesNotThrow(() =>
+      pricingRequest('pricing.mutate', {
+        expectedRevision: 1,
+        mutation: { kind: 'delete', modelKey: 'provider:model' },
+      }),
+    );
+    for (const input of [
+      { expectedRevision: -1, mutation: { kind: 'delete', modelKey: 'model' } },
+      { expectedRevision: 0.5, mutation: { kind: 'delete', modelKey: 'model' } },
+      { expectedRevision: 0, mutation: { kind: 'delete', modelKey: '', ticket: 'x' } },
+      {
+        expectedRevision: 0,
+        mutation: { kind: 'upsert', pricing: pricing(' provider:model ') },
+      },
+      {
+        expectedRevision: 0,
+        mutation: { kind: 'upsert', pricing: { ...pricing('model'), extra: true } },
+      },
+      { expectedRevision: 0, mutation: { kind: 'reset' } },
+    ]) {
+      assert.throws(() => pricingRequest('pricing.mutate', input), invalidFrame);
+    }
+
+    assert.deepEqual(
+      encodePricingQueryResult({
+        kind: 'page',
+        revision: 3,
+        offset: 0,
+        overrides: [pricing('m')],
+        nextOffset: 1,
+      }),
+      {
+        kind: 'page',
+        revision: 3,
+        offset: 0,
+        overrides: [pricing('m')],
+        nextOffset: 1,
+      },
+    );
+    assert.deepEqual(
+      encodePricingQueryResult({
+        kind: 'revision_changed',
+        expectedRevision: 2,
+        actualRevision: 3,
+      }),
+      { kind: 'revision_changed', expectedRevision: 2, actualRevision: 3 },
+    );
+    assert.throws(
+      () =>
+        encodePricingQueryResult({
+          kind: 'page',
+          revision: 0,
+          offset: 0,
+          overrides: Array.from({ length: PRICING_PAGE_MAX_ITEMS + 1 }, (_, index) =>
+            pricing(`model-${index}`),
+          ),
+          nextOffset: null,
+        }),
+      invalidFrame,
+    );
+    for (const result of [
+      {
+        kind: 'page',
+        revision: 1,
+        offset: 2,
+        overrides: [],
+        nextOffset: 2,
+      },
+      {
+        kind: 'page',
+        revision: 1,
+        offset: 2,
+        overrides: [pricing('m')],
+        nextOffset: 4,
+      },
+      {
+        kind: 'page',
+        revision: 1,
+        offset: 0,
+        overrides: [pricing('z'), pricing('a')],
+        nextOffset: null,
+      },
+      {
+        kind: 'revision_changed',
+        expectedRevision: 3,
+        actualRevision: 3,
+      },
+    ]) {
+      assert.throws(() => pricingResponse('pricing.query', result), invalidFrame);
+    }
+    for (const result of [
+      { kind: 'committed', revision: 1 },
+      { kind: 'unchanged', revision: 1 },
+      { kind: 'revision_conflict', expectedRevision: 0, actualRevision: 1 },
+    ]) {
+      assert.doesNotThrow(() => pricingResponse('pricing.mutate', result));
+    }
+    assert.throws(
+      () =>
+        pricingResponse('pricing.mutate', {
+          kind: 'revision_conflict',
+          expectedRevision: 7,
+          actualRevision: 7,
+        }),
+      invalidFrame,
+    );
+  });
+
+  test('uses exact-string pricing order without merging Unicode normalization forms', () => {
+    const decomposed = 'e\u0301';
+    const composed = '\u00e9';
+    const page = encodePricingQueryResult({
+      kind: 'page',
+      revision: 2,
+      offset: 0,
+      overrides: [pricing(decomposed), pricing(composed)],
+      nextOffset: null,
+    });
+    assert.equal(page.kind, 'page');
+    if (page.kind !== 'page') throw new Error('Expected a pricing page');
+    assert.deepEqual(
+      page.overrides.map((item) => item.modelKey),
+      [decomposed, composed],
+    );
+    assert.notEqual(page.overrides[0]?.modelKey, page.overrides[1]?.modelKey);
+    assert.throws(
+      () =>
+        encodePricingQueryResult({
+          kind: 'page',
+          revision: 2,
+          offset: 0,
+          overrides: [pricing(composed), pricing(decomposed)],
+          nextOffset: null,
+        }),
+      invalidFrame,
+    );
+  });
+
+  test('bounds a page of maximum-length CJK pricing items below the frame limit', () => {
+    const cjkOverrides = Array.from({ length: PRICING_PAGE_MAX_ITEMS }, (_, index) =>
+      maximumCjkPricing(index),
+    ).sort((left, right) => comparePricingModelKeys(left.modelKey, right.modelKey));
+    const maximumPage = encodePricingQueryResult({
+      kind: 'page',
+      revision: Number.MAX_SAFE_INTEGER,
+      offset: 0,
+      overrides: cjkOverrides.slice(0, 86),
+      nextOffset: 86,
+    });
+    assert.equal(maximumPage.kind, 'page');
+    if (maximumPage.kind !== 'page') throw new Error('Expected a pricing page');
+    assert.equal(maximumPage.overrides[0]?.modelKey.length, PRICING_MODEL_KEY_MAX_CHARS);
+    assert.ok(Buffer.byteLength(maximumPage.overrides[0]!.modelKey, 'utf8') > 128);
+    const pageBytes = Buffer.byteLength(JSON.stringify(maximumPage), 'utf8');
+    assert.ok(pageBytes <= PRICING_PAGE_MAX_BYTES);
+    assert.ok(
+      encodeProtocolFrame({
+        requestId: 'maximum-cjk-pricing-page',
+        operation: 'pricing.query',
+        ok: true,
+        result: maximumPage,
+      }).byteLength <= RUNTIME_HOST_MAX_FRAME_BYTES,
+    );
+    assert.throws(
+      () =>
+        encodePricingQueryResult({
+          kind: 'page',
+          revision: Number.MAX_SAFE_INTEGER,
+          offset: 0,
+          overrides: cjkOverrides.slice(0, 87),
+          nextOffset: 87,
+        }),
+      invalidFrame,
+    );
+  });
+});
+
+function operationMetadata(key: 'usage.query' | 'pricing.query' | 'pricing.mutate') {
+  const { mode, availability } = HOST_OPERATION_SPECS[key];
+  return { mode, availability };
+}
+
+function validSummary() {
+  return {
+    range: { from: 0, to: 1 },
+    totalRequests: 1,
+    totalCostUsd: 0.01,
+    totalTokens: {
+      input: 1,
+      output: 2,
+      cacheMiss: 1,
+      cacheRead: 0,
+      cacheWrite: 0,
+      reasoning: 0,
+      total: 3,
+    },
+    cacheHitRequests: 0,
+    cacheCreateRequests: 0,
+    errorRequests: 0,
+  };
+}
+
+function validBucket() {
+  return {
+    key: 'provider',
+    label: 'provider',
+    requests: 1,
+    inputTokens: 1,
+    outputTokens: 2,
+    cacheMissTokens: 1,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    cacheMissInputSource: 'explicit',
+    reasoningTokens: 0,
+    totalTokens: 3,
+    costUsd: 0.01,
+    avgLatencyMs: 10,
+    errorRate: 0,
+  };
+}
+
+function validLog(index = 0) {
+  return {
+    source: 'llm',
+    id: `usage-${index}`,
+    ts: index + 1,
+    providerId: 'provider',
+    modelId: 'model',
+    inputTokens: 1,
+    outputTokens: 2,
+    cacheMissTokens: 1,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    cacheMissInputSource: 'explicit',
+    reasoningTokens: 0,
+    totalTokens: 3,
+    costUsd: 0.01,
+    latencyMs: 10,
+    status: 'success',
+  };
+}
+
+function validToolLog() {
+  return {
+    source: 'tool',
+    id: 'tool-1',
+    ts: 1,
+    toolCallId: 'call-1',
+    toolName: 'Read',
+    durationMs: 10,
+    status: 'success',
+    resultSummary: { kind: 'text', itemCount: 1 },
+    bytesIn: 2,
+    bytesOut: 3,
+    startedAt: 1,
+  };
+}
+
+function pricing(modelKey: string) {
+  return { modelKey, inputUsdPer1M: 1, outputUsdPer1M: 2 };
+}
+
+function maximumCjkPricing(index: number) {
+  return {
+    modelKey: String.fromCodePoint(0x4e00 + index).repeat(PRICING_MODEL_KEY_MAX_CHARS),
+    inputUsdPer1M: Number.MAX_VALUE,
+    outputUsdPer1M: Number.MAX_VALUE,
+    cacheReadUsdPer1M: Number.MAX_VALUE,
+    cacheWriteUsdPer1M: Number.MAX_VALUE,
+  };
+}
+
+function usageRequest(input: unknown): void {
+  decodeClientFrame({ requestId: 'usage-request', operation: 'usage.query', input });
+}
+
+function usageResponse(result: unknown): void {
+  decodeHostFrame({
+    requestId: 'usage-response',
+    operation: 'usage.query',
+    ok: true,
+    result,
+  });
+}
+
+function pricingRequest(operation: 'pricing.query' | 'pricing.mutate', input: unknown): void {
+  decodeClientFrame({ requestId: 'pricing-request', operation, input });
+}
+
+function pricingResponse(operation: 'pricing.query' | 'pricing.mutate', result: unknown): void {
+  decodeHostFrame({ requestId: 'pricing-response', operation, ok: true, result });
+}
+
+function invalidFrame(error: unknown): boolean {
+  return error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame';
+}

--- a/packages/runtime-host/src/__tests__/usage-pricing-root-identity.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-root-identity.test.ts
@@ -1,0 +1,64 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
+import {
+  resolveRootControlNamespace,
+  resolveStorageRoot,
+  STORAGE_ROOT_MARKER_FILE,
+  tryAcquireInteractiveRootOwner,
+} from '@maka/storage/root-authority';
+import type { ConnectionContext } from '../server/operation-dispatcher.js';
+import { HostUsagePricingCoordinator } from '../server/usage-pricing-coordinator.js';
+
+const CONNECTION_CONTEXT: ConnectionContext = {
+  hostEpoch: 'root-identity-test',
+  connectionId: 'root-identity-test-connection',
+  surface: 'tui',
+  principal: 'local_os_user',
+  acquireResidency: () => ({ release() {} }),
+};
+
+test('a deleted live root marker requests poison drain exactly once', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-usage-pricing-root-identity-'));
+  const root = join(base, 'interactive-root');
+  const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner);
+  try {
+    const stores = await openInteractiveUsageStoresForWrite(owner.lease);
+    let drainRequests = 0;
+    const coordinator = new HostUsagePricingCoordinator(stores, () => {
+      drainRequests += 1;
+    });
+
+    await rm(join(root, STORAGE_ROOT_MARKER_FILE));
+    const expected = {
+      ok: false,
+      error: {
+        code: 'persistence_failed',
+        message: 'Pricing authority persistence failed',
+      },
+    } as const;
+
+    assert.deepEqual(
+      await coordinator.handlers['pricing.query']({ kind: 'start' }, CONNECTION_CONTEXT),
+      expected,
+    );
+    assert.equal(drainRequests, 1);
+    assert.deepEqual(
+      await coordinator.handlers['pricing.query']({ kind: 'start' }, CONNECTION_CONTEXT),
+      expected,
+    );
+    assert.equal(drainRequests, 1);
+  } finally {
+    await owner.close();
+    await rm(join(resolveRootControlNamespace(), capability.rootId), {
+      recursive: true,
+      force: true,
+    });
+    await rm(base, { recursive: true, force: true });
+  }
+});

--- a/packages/runtime-host/src/__tests__/usage-pricing-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/usage-pricing-two-client-uds.test.ts
@@ -1,0 +1,733 @@
+import assert from 'node:assert/strict';
+import { lstat, mkdir, mkdtemp, open, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, mock, test } from 'node:test';
+import { PRICING_MODEL_KEY_MAX_CHARS } from '@maka/core/usage-stats/pricing';
+import type { PricingConfig } from '@maka/core/usage-stats/types';
+import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
+import {
+  createHeadlessRootLease,
+  resolveRootControlNamespace,
+  resolveStorageRoot,
+  StorageRootAuthorityError,
+  tryAcquireInteractiveRootOwner,
+  type StorageRootLease,
+  type InteractiveRootOwner,
+} from '@maka/storage/root-authority';
+import { connectRuntimeHost, type RuntimeHostConnection } from '../client/index.js';
+import {
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  type ClientSurface,
+  type PricingQueryResult,
+} from '../protocol/index.js';
+import { createExecutionRuntimeHostComposition } from '../server/execution-composition.js';
+import { RuntimeHostKernel } from '../server/index.js';
+import type { ConnectionContext } from '../server/operation-dispatcher.js';
+import { HostUsagePricingCoordinator } from '../server/usage-pricing-coordinator.js';
+
+const PROTOCOL = {
+  min: RUNTIME_HOST_PROTOCOL_VERSION,
+  max: RUNTIME_HOST_PROTOCOL_VERSION,
+} as const;
+const REQUEST_TIMEOUT_MS = 5_000;
+const CONNECTION_CONTEXT: ConnectionContext = {
+  hostEpoch: 'usage-pricing-test',
+  connectionId: 'usage-pricing-test-connection',
+  surface: 'tui',
+  principal: 'local_os_user',
+  acquireResidency: () => ({ release() {} }),
+};
+
+test('Headless root leases cannot open the Interactive usage authority', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-usage-pricing-headless-'));
+  try {
+    const capability = await resolveStorageRoot({
+      path: join(base, 'headless-root'),
+      kind: 'headless',
+    });
+    const headlessLease = createHeadlessRootLease(capability, 'write');
+    await assert.rejects(
+      openInteractiveUsageStoresForWrite(
+        headlessLease as unknown as StorageRootLease<'interactive', 'write'>,
+      ),
+      (error: unknown) =>
+        error instanceof StorageRootAuthorityError && error.code === 'invalid_lease',
+    );
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('usage authority drain rejects a new pricing mutation with typed lifecycle failure', async () => {
+  const base = await mkdtemp(join(tmpdir(), 'maka-usage-pricing-drain-'));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'interactive-root'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner, 'test must acquire the real Interactive write lease');
+  try {
+    const stores = await openInteractiveUsageStoresForWrite(owner.lease);
+    let drainRequests = 0;
+    const coordinator = new HostUsagePricingCoordinator(stores, () => {
+      drainRequests += 1;
+    });
+    await stores.beginDrain();
+    assert.deepEqual(
+      await coordinator.handlers['pricing.mutate'](
+        {
+          expectedRevision: 0,
+          mutation: { kind: 'upsert', pricing: pricing('provider:model', 1) },
+        },
+        CONNECTION_CONTEXT,
+      ),
+      {
+        ok: false,
+        error: { code: 'host_draining', message: 'Runtime Host is draining' },
+      },
+    );
+    assert.equal(drainRequests, 0);
+    await stores.close();
+  } finally {
+    await owner.close();
+    await rm(join(resolveRootControlNamespace(), capability.rootId), {
+      recursive: true,
+      force: true,
+    });
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test('pricing commit-unknown requests drain before the typed failure and poisoned read', {
+  skip: process.platform === 'win32',
+}, async () => {
+  await withUsageAuthority('pricing-commit-unknown', async ({ root, stores }) => {
+    let drainRequests = 0;
+    const coordinator = new HostUsagePricingCoordinator(stores, () => {
+      drainRequests += 1;
+    });
+    const restoreSync = await failNextDirectorySync(root);
+    let mutation;
+    try {
+      mutation = await coordinator.handlers['pricing.mutate'](
+        {
+          expectedRevision: 0,
+          mutation: { kind: 'upsert', pricing: pricing('provider:unknown', 1) },
+        },
+        CONNECTION_CONTEXT,
+      );
+    } finally {
+      restoreSync();
+    }
+    assert.deepEqual(mutation, {
+      ok: false,
+      error: {
+        code: 'commit_outcome_unknown',
+        message: 'Pricing mutation commit outcome is unknown',
+      },
+    });
+    assert.equal(drainRequests, 1);
+    assert.deepEqual(
+      await coordinator.handlers['pricing.query']({ kind: 'start' }, CONNECTION_CONTEXT),
+      {
+        ok: false,
+        error: {
+          code: 'persistence_failed',
+          message: 'Pricing authority persistence failed',
+        },
+      },
+    );
+    assert.equal(drainRequests, 1);
+  });
+});
+
+test('pricing publication failure requests drain while expected failures do not', async () => {
+  await withUsageAuthority('pricing-publication', async ({ root, stores }) => {
+    let drainRequests = 0;
+    const coordinator = new HostUsagePricingCoordinator(stores, () => {
+      drainRequests += 1;
+    });
+    assert.deepEqual(
+      await coordinator.handlers['pricing.mutate'](
+        {
+          expectedRevision: 1,
+          mutation: { kind: 'delete', modelKey: 'provider:missing' },
+        },
+        CONNECTION_CONTEXT,
+      ),
+      {
+        ok: true,
+        result: {
+          kind: 'revision_conflict',
+          expectedRevision: 1,
+          actualRevision: 0,
+        },
+      },
+    );
+    assert.deepEqual(
+      await coordinator.handlers['pricing.mutate'](
+        {
+          expectedRevision: 0,
+          mutation: {
+            kind: 'upsert',
+            pricing: { ...pricing('provider:invalid', 1), inputUsdPer1M: -1 },
+          },
+        },
+        CONNECTION_CONTEXT,
+      ),
+      {
+        ok: false,
+        error: { code: 'invalid_request', message: 'Pricing mutation is invalid' },
+      },
+    );
+    assert.equal(drainRequests, 0);
+    assert.deepEqual(
+      await coordinator.handlers['usage.query'](
+        {
+          kind: 'logs',
+          source: 'llm',
+          query: { range: 'all' },
+          offset: 1,
+        },
+        CONNECTION_CONTEXT,
+      ),
+      {
+        ok: false,
+        error: { code: 'invalid_request', message: 'Usage offset is invalid' },
+      },
+    );
+    assert.equal(drainRequests, 0);
+
+    await rm(join(root, 'pricing.json'));
+    await mkdir(join(root, 'pricing.json'));
+    assert.deepEqual(
+      await coordinator.handlers['pricing.mutate'](
+        {
+          expectedRevision: 0,
+          mutation: { kind: 'upsert', pricing: pricing('provider:publication', 1) },
+        },
+        CONNECTION_CONTEXT,
+      ),
+      {
+        ok: false,
+        error: {
+          code: 'persistence_failed',
+          message: 'Pricing authority persistence failed',
+        },
+      },
+    );
+    assert.equal(drainRequests, 1);
+  });
+});
+
+test('telemetry poisoned read fails closed and requests drain once', {
+  skip: process.platform === 'win32',
+}, async () => {
+  await withUsageAuthority('telemetry-commit-unknown', async ({ root, stores }) => {
+    let drainRequests = 0;
+    const coordinator = new HostUsagePricingCoordinator(stores, () => {
+      drainRequests += 1;
+    });
+    const restoreSync = await failNextDirectorySync(root);
+    try {
+      await assert.rejects(stores.telemetry.recordToolInvocation(toolRecord('tool-poison', 30)));
+    } finally {
+      restoreSync();
+    }
+    const query = {
+      kind: 'logs',
+      source: 'tool',
+      query: { range: 'all' },
+    } as const;
+    const expected = {
+      ok: false,
+      error: {
+        code: 'persistence_failed',
+        message: 'Usage authority persistence failed',
+      },
+    } as const;
+    assert.deepEqual(
+      await coordinator.handlers['usage.query'](query, CONNECTION_CONTEXT),
+      expected,
+    );
+    assert.equal(drainRequests, 1);
+    assert.deepEqual(
+      await coordinator.handlers['usage.query'](query, CONNECTION_CONTEXT),
+      expected,
+    );
+    assert.equal(drainRequests, 1);
+  });
+});
+
+describe('production Usage/Pricing UDS', () => {
+  test('two clients share usage projection and one revision-CAS pricing authority', {
+    skip: process.platform === 'win32',
+    timeout: 60_000,
+  }, async () => {
+    const base = await mkdtemp(join(tmpdir(), 'maka-usage-pricing-two-client-'));
+    const root = join(base, 'root');
+    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    let host: RuntimeHostKernel | undefined;
+    let successor: RuntimeHostKernel | undefined;
+    let firstOwner: InteractiveRootOwner | undefined;
+    let successorOwner: InteractiveRootOwner | undefined;
+    let preHostUsageStores:
+      | Awaited<ReturnType<typeof openInteractiveUsageStoresForWrite>>
+      | undefined;
+    const clients: RuntimeHostConnection[] = [];
+    let endpoint: string | undefined;
+
+    try {
+      firstOwner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(firstOwner, 'test must acquire the real Interactive write lease');
+      preHostUsageStores = await openInteractiveUsageStoresForWrite(firstOwner.lease);
+      await Promise.all([
+        preHostUsageStores.telemetry.recordLlmCall(usageRecord('usage-a', 10, 'openai', 'gpt-a')),
+        preHostUsageStores.telemetry.recordLlmCall(
+          usageRecord('usage-b', 20, 'anthropic', 'claude-b', 'error'),
+        ),
+        preHostUsageStores.telemetry.recordToolInvocation(toolRecord('tool-a', 30)),
+      ]);
+      host = await RuntimeHostKernel.start({
+        owner: firstOwner,
+        idleGraceMs: 30_000,
+        compositionFactory: createExecutionRuntimeHostComposition,
+      });
+      firstOwner = undefined;
+      preHostUsageStores = undefined;
+      endpoint = host.endpoint;
+
+      const [desktop, tui] = await Promise.all([
+        connectClient(root, 'desktop'),
+        connectClient(root, 'tui'),
+      ]);
+      clients.push(desktop, tui);
+      const [desktopUsage, tuiUsage] = await Promise.all([readUsage(desktop), readUsage(tui)]);
+      assert.deepEqual(tuiUsage, desktopUsage);
+      assert.equal(desktopUsage.summary.kind, 'summary');
+      assert.equal(desktopUsage.summary.summary.totalRequests, 2);
+      assert.equal(desktopUsage.buckets.kind, 'buckets');
+      assert.equal(desktopUsage.buckets.total, 2);
+      assert.equal(desktopUsage.logs.kind, 'logs');
+      assert.deepEqual(
+        desktopUsage.logs.rows.map((row) => row.id),
+        ['usage-b', 'usage-a'],
+      );
+      assert.equal(desktopUsage.toolLogs.kind, 'logs');
+      assert.equal(desktopUsage.toolLogs.source, 'tool');
+      assert.deepEqual(desktopUsage.toolLogs.rows, [
+        {
+          source: 'tool',
+          id: 'tool-a',
+          ts: 30,
+          toolCallId: 'call-tool-a',
+          toolName: 'Read',
+          providerId: 'openai',
+          modelId: 'gpt-a',
+          durationMs: 12,
+          status: 'success',
+          argsSummary: '{"path":"README.md"}',
+          resultSummary: { kind: 'text', itemCount: 1 },
+          bytesIn: 20,
+          bytesOut: 40,
+          startedAt: 30,
+          sessionId: 'session-a',
+          turnId: 'turn-a',
+        },
+      ]);
+
+      const initial = requirePricingPage(
+        await desktop.request('pricing.query', { kind: 'start' }, REQUEST_TIMEOUT_MS),
+      );
+      assert.deepEqual(initial, {
+        kind: 'page',
+        revision: 0,
+        offset: 0,
+        overrides: [],
+        nextOffset: null,
+      });
+      const decomposedModelKey = 'e\u0301';
+      const composedModelKey = '\u00e9';
+      const candidates = [pricing(decomposedModelKey, 1), pricing(composedModelKey, 2)] as const;
+      const outcomes = await Promise.all([
+        desktop.request(
+          'pricing.mutate',
+          {
+            expectedRevision: initial.revision,
+            mutation: { kind: 'upsert', pricing: candidates[0] },
+          },
+          REQUEST_TIMEOUT_MS,
+        ),
+        tui.request(
+          'pricing.mutate',
+          {
+            expectedRevision: initial.revision,
+            mutation: { kind: 'upsert', pricing: candidates[1] },
+          },
+          REQUEST_TIMEOUT_MS,
+        ),
+      ]);
+      assert.deepEqual(outcomes.map((outcome) => outcome.kind).sort(), [
+        'committed',
+        'revision_conflict',
+      ]);
+      const loserIndex = outcomes.findIndex((outcome) => outcome.kind === 'revision_conflict');
+      const conflict = outcomes[loserIndex];
+      assert.ok(conflict?.kind === 'revision_conflict');
+      if (!conflict || conflict.kind !== 'revision_conflict') {
+        throw new Error('Expected one pricing revision conflict');
+      }
+      assert.deepEqual(conflict, {
+        kind: 'revision_conflict',
+        expectedRevision: 0,
+        actualRevision: 1,
+      });
+
+      const loser = loserIndex === 0 ? desktop : tui;
+      const loserPricing = candidates[loserIndex];
+      const afterConflict = requirePricingPage(
+        await loser.request('pricing.query', { kind: 'start' }, REQUEST_TIMEOUT_MS),
+      );
+      assert.equal(afterConflict.revision, conflict.actualRevision);
+      const retry = await loser.request(
+        'pricing.mutate',
+        {
+          expectedRevision: afterConflict.revision,
+          mutation: { kind: 'upsert', pricing: loserPricing },
+        },
+        REQUEST_TIMEOUT_MS,
+      );
+      assert.deepEqual(retry, { kind: 'committed', revision: 2 });
+
+      const [desktopPricing, tuiPricing] = await Promise.all([
+        readPricing(desktop),
+        readPricing(tui),
+      ]);
+      assert.deepEqual(tuiPricing, desktopPricing);
+      assert.equal(desktopPricing.revision, 2);
+      assert.deepEqual(
+        desktopPricing.overrides.map((item) => item.modelKey),
+        [decomposedModelKey, composedModelKey],
+      );
+      assert.notEqual(desktopPricing.overrides[0]?.modelKey, desktopPricing.overrides[1]?.modelKey);
+
+      let revision = desktopPricing.revision;
+      for (let index = 0; index < 126; index += 1) {
+        const result = await desktop.request(
+          'pricing.mutate',
+          {
+            expectedRevision: revision,
+            mutation: { kind: 'upsert', pricing: maximumCjkPricing(index) },
+          },
+          REQUEST_TIMEOUT_MS,
+        );
+        assert.equal(result.kind, 'committed');
+        if (result.kind !== 'committed') throw new Error('CJK pricing seed did not commit');
+        revision = result.revision;
+      }
+      assert.equal(revision, 128);
+
+      const firstFullPage = requirePricingPage(
+        await desktop.request('pricing.query', { kind: 'start' }, REQUEST_TIMEOUT_MS),
+      );
+      assert.ok(firstFullPage.nextOffset);
+      const changed = await tui.request(
+        'pricing.mutate',
+        {
+          expectedRevision: firstFullPage.revision,
+          mutation: {
+            kind: 'upsert',
+            pricing: {
+              ...maximumCjkPricing(0),
+              inputUsdPer1M: 1,
+              outputUsdPer1M: 2,
+            },
+          },
+        },
+        REQUEST_TIMEOUT_MS,
+      );
+      assert.deepEqual(changed, { kind: 'committed', revision: 129 });
+      const stale = await desktop.request(
+        'pricing.query',
+        {
+          kind: 'continue',
+          revision: firstFullPage.revision,
+          offset: firstFullPage.nextOffset,
+        },
+        REQUEST_TIMEOUT_MS,
+      );
+      assert.deepEqual(stale, {
+        kind: 'revision_changed',
+        expectedRevision: 128,
+        actualRevision: 129,
+      });
+
+      const [fullDesktopPricing, fullTuiPricing] = await Promise.all([
+        readPricing(desktop),
+        readPricing(tui),
+      ]);
+      assert.deepEqual(fullTuiPricing, fullDesktopPricing);
+      assert.equal(fullDesktopPricing.revision, 129);
+      assert.equal(fullDesktopPricing.overrides.length, 128);
+      assert.ok(fullDesktopPricing.pageCount > 1);
+      assert.equal(
+        fullDesktopPricing.overrides.filter(
+          (item) => item.modelKey.length === PRICING_MODEL_KEY_MAX_CHARS,
+        ).length,
+        126,
+      );
+
+      await Promise.all([desktop.close(), tui.close()]);
+      clients.length = 0;
+      await host.close();
+      host = undefined;
+      await assert.rejects(lstat(endpoint), { code: 'ENOENT' });
+
+      successorOwner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(successorOwner, 'successor must reacquire the released Interactive owner');
+      successor = await RuntimeHostKernel.start({
+        owner: successorOwner,
+        idleGraceMs: 30_000,
+        compositionFactory: createExecutionRuntimeHostComposition,
+      });
+      successorOwner = undefined;
+      const [desktopAfterRestart, tuiAfterRestart] = await Promise.all([
+        connectClient(root, 'desktop'),
+        connectClient(root, 'tui'),
+      ]);
+      clients.push(desktopAfterRestart, tuiAfterRestart);
+      const [usageAfterRestart, pricingAfterRestart, pricingFromSecondClient] = await Promise.all([
+        readUsage(desktopAfterRestart),
+        readPricing(desktopAfterRestart),
+        readPricing(tuiAfterRestart),
+      ]);
+      assert.deepEqual(pricingFromSecondClient, pricingAfterRestart);
+      assert.equal(pricingAfterRestart.revision, 129);
+      assert.equal(pricingAfterRestart.overrides.length, 128);
+      assert.ok(pricingAfterRestart.pageCount > 1);
+      assert.equal(usageAfterRestart.summary.kind, 'summary');
+      if (usageAfterRestart.summary.kind === 'summary') {
+        assert.equal(usageAfterRestart.summary.summary.totalRequests, 2);
+      }
+      assert.equal(usageAfterRestart.toolLogs.kind, 'logs');
+      if (usageAfterRestart.toolLogs.kind === 'logs') {
+        assert.deepEqual(
+          usageAfterRestart.toolLogs.rows.map((row) => row.id),
+          ['tool-a'],
+        );
+      }
+    } finally {
+      const cleanupErrors: unknown[] = [];
+      const closedClients = await Promise.allSettled(clients.map((client) => client.close()));
+      cleanupErrors.push(...rejectedReasons(closedClients));
+      await host?.close().catch((error: unknown) => cleanupErrors.push(error));
+      await successor?.close().catch((error: unknown) => cleanupErrors.push(error));
+      if (firstOwner && !firstOwner.closed) {
+        await preHostUsageStores?.close().catch((error: unknown) => cleanupErrors.push(error));
+      }
+      await firstOwner?.close().catch((error: unknown) => cleanupErrors.push(error));
+      await successorOwner?.close().catch((error: unknown) => cleanupErrors.push(error));
+      await rm(join(resolveRootControlNamespace(), capability.rootId), {
+        recursive: true,
+        force: true,
+      }).catch((error: unknown) => cleanupErrors.push(error));
+      await rm(base, { recursive: true, force: true }).catch((error: unknown) =>
+        cleanupErrors.push(error),
+      );
+      if (cleanupErrors.length > 0) {
+        throw new AggregateError(cleanupErrors, 'Usage/Pricing UDS cleanup failed');
+      }
+    }
+  });
+});
+
+async function connectClient(
+  rootPath: string,
+  surface: ClientSurface,
+): Promise<RuntimeHostConnection> {
+  const result = await connectRuntimeHost({
+    rootPath,
+    surface,
+    protocol: PROTOCOL,
+    connectTimeoutMs: REQUEST_TIMEOUT_MS,
+    handshakeTimeoutMs: REQUEST_TIMEOUT_MS,
+  });
+  if (result.kind !== 'connected') {
+    throw new Error(`Runtime Host Client did not connect: ${result.kind}`);
+  }
+  return result.connection;
+}
+
+async function readUsage(client: RuntimeHostConnection) {
+  const query = { range: { from: 0, to: 100 } } as const;
+  const [summary, buckets, logs, toolLogs] = await Promise.all([
+    client.request('usage.query', { kind: 'summary', query }, REQUEST_TIMEOUT_MS),
+    client.request(
+      'usage.query',
+      { kind: 'buckets', query, groupBy: 'provider' },
+      REQUEST_TIMEOUT_MS,
+    ),
+    client.request('usage.query', { kind: 'logs', source: 'llm', query }, REQUEST_TIMEOUT_MS),
+    client.request(
+      'usage.query',
+      {
+        kind: 'logs',
+        source: 'tool',
+        query: { range: query.range, toolName: 'Read', status: 'success' },
+      },
+      REQUEST_TIMEOUT_MS,
+    ),
+  ]);
+  return { summary, buckets, logs, toolLogs };
+}
+
+async function readPricing(client: RuntimeHostConnection): Promise<{
+  revision: number;
+  overrides: readonly Readonly<PricingConfig>[];
+  pageCount: number;
+}> {
+  const first = requirePricingPage(
+    await client.request('pricing.query', { kind: 'start' }, REQUEST_TIMEOUT_MS),
+  );
+  const overrides = [...first.overrides];
+  let nextOffset = first.nextOffset;
+  let pageCount = 1;
+  while (nextOffset !== null) {
+    const page = requirePricingPage(
+      await client.request(
+        'pricing.query',
+        { kind: 'continue', revision: first.revision, offset: nextOffset },
+        REQUEST_TIMEOUT_MS,
+      ),
+    );
+    assert.equal(page.revision, first.revision);
+    assert.equal(page.offset, nextOffset);
+    overrides.push(...page.overrides);
+    nextOffset = page.nextOffset;
+    pageCount += 1;
+  }
+  return { revision: first.revision, overrides, pageCount };
+}
+
+function requirePricingPage(
+  result: PricingQueryResult,
+): Extract<PricingQueryResult, { kind: 'page' }> {
+  assert.equal(result.kind, 'page');
+  if (result.kind !== 'page') throw new Error('Pricing revision changed during page read');
+  return result;
+}
+
+function usageRecord(
+  id: string,
+  ts: number,
+  providerId: string,
+  modelId: string,
+  status: 'success' | 'error' = 'success',
+) {
+  return {
+    id,
+    providerId,
+    modelId,
+    inputTokens: 10,
+    outputTokens: 5,
+    cacheHitInputTokens: 2,
+    cacheMissInputTokens: 8,
+    cachedInputTokens: 2,
+    cacheWriteInputTokens: 1,
+    reasoningTokens: 0,
+    totalTokens: 15,
+    latencyMs: 25,
+    costUsd: 0.01,
+    startedAt: ts,
+    date: '2026-07-29',
+    ts,
+    status,
+  };
+}
+
+function toolRecord(id: string, ts: number) {
+  return {
+    id,
+    sessionId: 'session-a',
+    turnId: 'turn-a',
+    toolCallId: `call-${id}`,
+    toolName: 'Read',
+    providerId: 'openai',
+    modelId: 'gpt-a',
+    durationMs: 12,
+    status: 'success' as const,
+    argsSummary: '{"path":"README.md"}',
+    resultSummary: { kind: 'text', itemCount: 1 },
+    bytesIn: 20,
+    bytesOut: 40,
+    startedAt: ts,
+    date: '2026-07-29',
+    ts,
+  };
+}
+
+function pricing(modelKey: string, inputUsdPer1M: number) {
+  return { modelKey, inputUsdPer1M, outputUsdPer1M: inputUsdPer1M * 2 };
+}
+
+function maximumCjkPricing(index: number): PricingConfig {
+  return {
+    modelKey: String.fromCodePoint(0x4e00 + index).repeat(PRICING_MODEL_KEY_MAX_CHARS),
+    inputUsdPer1M: Number.MAX_VALUE,
+    outputUsdPer1M: Number.MAX_VALUE,
+    cacheReadUsdPer1M: Number.MAX_VALUE,
+    cacheWriteUsdPer1M: Number.MAX_VALUE,
+  };
+}
+
+function rejectedReasons(results: readonly PromiseSettledResult<unknown>[]): unknown[] {
+  return results.flatMap((result) => (result.status === 'rejected' ? [result.reason] : []));
+}
+
+async function failNextDirectorySync(root: string): Promise<() => void> {
+  const probe = await open(root, 'r');
+  const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+    sync: typeof probe.sync;
+  };
+  const originalSync = fileHandlePrototype.sync;
+  await probe.close();
+  let injected = false;
+  const syncMock = mock.method(fileHandlePrototype, 'sync', async function (this: typeof probe) {
+    const metadata = await this.stat();
+    if (!injected && metadata.isDirectory()) {
+      injected = true;
+      throw new Error('injected usage authority directory sync failure');
+    }
+    return originalSync.call(this);
+  });
+  return () => syncMock.mock.restore();
+}
+
+async function withUsageAuthority(
+  name: string,
+  run: (context: {
+    root: string;
+    stores: Awaited<ReturnType<typeof openInteractiveUsageStoresForWrite>>;
+  }) => Promise<void>,
+): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), `maka-usage-pricing-${name}-`));
+  const capability = await resolveStorageRoot({
+    path: join(base, 'interactive-root'),
+    kind: 'interactive',
+  });
+  const owner = await tryAcquireInteractiveRootOwner(capability);
+  assert.ok(owner, 'test must acquire the real Interactive write lease');
+  const stores = await openInteractiveUsageStoresForWrite(owner.lease);
+  try {
+    await run({ root: capability.canonicalPath, stores });
+  } finally {
+    await stores.close().catch(() => undefined);
+    await owner.close();
+    await rm(join(resolveRootControlNamespace(), capability.rootId), {
+      recursive: true,
+      force: true,
+    });
+    await rm(base, { recursive: true, force: true });
+  }
+}

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -14,6 +14,7 @@ import {
   type HostIncompatible,
   type HostRegistration,
   type HostStatusResult,
+  HOST_OPERATION_SPECS,
   type OperationInput,
   type OperationKey,
   type OperationOutput,
@@ -30,6 +31,7 @@ import {
   validateProtocolRange,
 } from '../protocol/index.js';
 import { FramedTransport, RuntimeHostTransportError } from '../transport/framed-transport.js';
+import type { OperationSpec } from '../protocol/operation-spec.js';
 import {
   ClientSessionSubscription,
   RuntimeHostSubscriptionError,
@@ -184,6 +186,17 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
   ): Promise<Result> {
     const boundedTimeoutMs = requireTimeout(timeoutMs, 'timeoutMs');
     if (this.#terminalError) return Promise.reject(this.#terminalError);
+    const spec = HOST_OPERATION_SPECS[operation] as OperationSpec<
+      OperationInput<K>,
+      OperationOutput<K>,
+      HostOperationErrorCode
+    >;
+    let canonicalInput: OperationInput<K>;
+    try {
+      canonicalInput = spec.decodeInput(input);
+    } catch (error) {
+      return Promise.reject(asError(error));
+    }
     const requestId = randomUUID();
     const result = new Promise<Result>((resolve, reject) => {
       const timer = setTimeout(() => {
@@ -195,13 +208,17 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
       }, boundedTimeoutMs);
       this.#pendingRequests.set(requestId, {
         operation,
-        accept: (value) => accept(value as OperationOutput<K>),
+        accept: (value) => {
+          const output = value as OperationOutput<K>;
+          spec.assertOutputForInput?.(canonicalInput, output);
+          return accept(output);
+        },
         resolve: (value) => resolve(value as Result),
         reject,
         timer,
       });
     });
-    const frame = { requestId, operation, input } as RequestFrame;
+    const frame = { requestId, operation, input: canonicalInput } as RequestFrame;
     void this.#transport.write(frame).catch((error: unknown) => this.#fail(asError(error)));
     return result;
   }

--- a/packages/runtime-host/src/protocol/operation-spec.ts
+++ b/packages/runtime-host/src/protocol/operation-spec.ts
@@ -27,6 +27,7 @@ export interface OperationSpec<Input, Output, ErrorCode extends HostOperationErr
   errors: readonly ErrorCode[];
   decodeInput(value: unknown): Input;
   decodeOutput(value: unknown): Output;
+  assertOutputForInput?(input: Input, output: Output): void;
 }
 
 type AnyOperationSpec = OperationSpec<unknown, unknown, HostOperationErrorCode>;

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -15,6 +15,7 @@ import { SESSION_CONTINUITY_OPERATION_SPECS } from './session-continuity.js';
 import { SKILL_CATALOG_OPERATION_SPECS } from './skill-catalog.js';
 import { TASK_LEDGER_OPERATION_SPECS } from './task-ledger.js';
 import { TURN_OPERATION_SPECS } from './turn.js';
+import { USAGE_PRICING_OPERATION_SPECS } from './usage-pricing.js';
 
 export type { HostLifecycleState, HostStatusInput, HostStatusResult } from './host-status.js';
 export type { HostOperationError, HostOperationErrorCode } from './operation-spec.js';
@@ -71,6 +72,7 @@ export type {
 } from './turn.js';
 export * from './runtime-policy.js';
 export * from './skill-catalog.js';
+export * from './usage-pricing.js';
 
 const HOST_AND_TURN_OPERATION_SPECS = composeOperationSpecMaps(
   HOST_STATUS_OPERATION_SPECS,
@@ -109,9 +111,14 @@ const CORE_MESSAGE_TASK_LEDGER_INTERACTION_CONTINUITY_AND_ARTIFACT_OPERATION_SPE
     ARTIFACT_OPERATION_SPECS,
   );
 
-export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
+const ALL_WITH_SKILL_CATALOG_OPERATION_SPECS = composeOperationSpecMaps(
   CORE_MESSAGE_TASK_LEDGER_INTERACTION_CONTINUITY_AND_ARTIFACT_OPERATION_SPECS,
   SKILL_CATALOG_OPERATION_SPECS,
+);
+
+export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
+  ALL_WITH_SKILL_CATALOG_OPERATION_SPECS,
+  USAGE_PRICING_OPERATION_SPECS,
 );
 
 export type OperationSpecMap = typeof HOST_OPERATION_SPECS;

--- a/packages/runtime-host/src/protocol/usage-pricing.ts
+++ b/packages/runtime-host/src/protocol/usage-pricing.ts
@@ -1,0 +1,1008 @@
+import {
+  comparePricingModelKeys,
+  normalizePricingModelKey,
+  validateCanonicalPricingConfig,
+} from '@maka/core/usage-stats/pricing';
+import type {
+  CacheMissInputSource,
+  PricingConfig,
+  ToolInvocationResultSummary,
+  UsageBucket,
+  UsageGroupBy,
+  UsageQuery,
+  UsageSummaryV2,
+} from '@maka/core/usage-stats/types';
+import { requireCount, requireExactRecord, requireRecord } from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+export const USAGE_PAGE_MAX_ITEMS = 100;
+export const USAGE_PAGE_MAX_BYTES = 48 * 1024;
+export const USAGE_PROJECTION_TEXT_MAX_BYTES = 1024;
+export const PRICING_PAGE_MAX_ITEMS = 128;
+export const PRICING_PAGE_MAX_BYTES = 48 * 1024;
+
+const QUERY_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'persistence_failed',
+  'internal_failure',
+] as const;
+const USAGE_QUERY_ERRORS = [...QUERY_ERRORS, 'invalid_request'] as const;
+const PRICING_QUERY_ERRORS = [...QUERY_ERRORS, 'invalid_request'] as const;
+const MUTATION_ERRORS = [...QUERY_ERRORS, 'invalid_request', 'commit_outcome_unknown'] as const;
+const LLM_USAGE_QUERY_FIELDS = new Set([
+  'range',
+  'connectionSlug',
+  'providerId',
+  'modelId',
+  'status',
+]);
+const TOOL_USAGE_QUERY_FIELDS = new Set(['range', 'toolName', 'status']);
+const USAGE_BUCKET_FIELDS = new Set([
+  'key',
+  'label',
+  'requests',
+  'inputTokens',
+  'outputTokens',
+  'cacheMissTokens',
+  'cacheReadTokens',
+  'cacheWriteTokens',
+  'cacheMissInputSource',
+  'reasoningTokens',
+  'totalTokens',
+  'costUsd',
+  'avgLatencyMs',
+  'errorRate',
+]);
+const LLM_USAGE_LOG_FIELDS = new Set([
+  'source',
+  'id',
+  'ts',
+  'callKind',
+  'callId',
+  'connectionSlug',
+  'providerId',
+  'modelId',
+  'inputTokens',
+  'outputTokens',
+  'cacheMissTokens',
+  'cacheReadTokens',
+  'cacheWriteTokens',
+  'cacheMissInputSource',
+  'reasoningTokens',
+  'totalTokens',
+  'costUsd',
+  'latencyMs',
+  'status',
+  'errorClass',
+  'sessionId',
+  'turnId',
+]);
+const TOOL_USAGE_LOG_FIELDS = new Set([
+  'source',
+  'id',
+  'ts',
+  'toolCallId',
+  'toolName',
+  'providerId',
+  'modelId',
+  'durationMs',
+  'status',
+  'errorClass',
+  'argsSummary',
+  'resultSummary',
+  'bytesIn',
+  'bytesOut',
+  'startedAt',
+  'sessionId',
+  'turnId',
+]);
+const TOOL_RESULT_SUMMARY_FIELDS = new Set([
+  'kind',
+  'status',
+  'itemCount',
+  'startedItemCount',
+  'completedItemCount',
+  'failedItemCount',
+  'cancelledItemCount',
+  'artifactCount',
+]);
+
+export type LlmUsageQuery = Omit<UsageQuery, 'toolName'>;
+
+export interface ToolUsageQuery {
+  readonly range: UsageQuery['range'];
+  readonly toolName?: string;
+  readonly status?: UsageQuery['status'];
+}
+
+export interface LlmUsageLogProjection {
+  readonly source: 'llm';
+  readonly id: string;
+  readonly ts: number;
+  readonly callKind?: 'main' | 'semantic_compact';
+  readonly callId?: string;
+  readonly connectionSlug?: string;
+  readonly providerId: string;
+  readonly modelId: string;
+  readonly inputTokens: number;
+  readonly outputTokens: number;
+  readonly cacheMissTokens: number;
+  readonly cacheReadTokens: number;
+  readonly cacheWriteTokens: number;
+  readonly cacheMissInputSource?: CacheMissInputSource;
+  readonly reasoningTokens: number;
+  readonly totalTokens: number;
+  readonly costUsd: number;
+  readonly latencyMs: number;
+  readonly status: 'success' | 'error' | 'aborted';
+  readonly errorClass?: string;
+  readonly sessionId?: string;
+  readonly turnId?: string;
+}
+
+export interface ToolUsageLogProjection {
+  readonly source: 'tool';
+  readonly id: string;
+  readonly ts: number;
+  readonly toolCallId?: string;
+  readonly toolName: string;
+  readonly providerId?: string;
+  readonly modelId?: string;
+  readonly durationMs: number;
+  readonly status: 'success' | 'error' | 'aborted';
+  readonly errorClass?: string;
+  readonly argsSummary?: string;
+  readonly resultSummary?: ToolInvocationResultSummary;
+  readonly bytesIn: number;
+  readonly bytesOut: number;
+  readonly startedAt: number;
+  readonly sessionId?: string;
+  readonly turnId?: string;
+}
+
+export type UsageLogProjection = LlmUsageLogProjection | ToolUsageLogProjection;
+
+export type UsageQueryInput =
+  | { readonly kind: 'summary'; readonly query: LlmUsageQuery }
+  | {
+      readonly kind: 'buckets';
+      readonly query: LlmUsageQuery;
+      readonly groupBy: Exclude<UsageGroupBy, 'tool'>;
+      readonly offset?: number;
+      readonly limit?: number;
+    }
+  | {
+      readonly kind: 'buckets';
+      readonly query: ToolUsageQuery;
+      readonly groupBy: 'tool';
+      readonly offset?: number;
+      readonly limit?: number;
+    }
+  | {
+      readonly kind: 'logs';
+      readonly source: 'llm';
+      readonly query: LlmUsageQuery;
+      readonly offset?: number;
+      readonly limit?: number;
+    }
+  | {
+      readonly kind: 'logs';
+      readonly source: 'tool';
+      readonly query: ToolUsageQuery;
+      readonly offset?: number;
+      readonly limit?: number;
+    };
+
+export type UsageQueryResult =
+  | { readonly kind: 'summary'; readonly summary: UsageSummaryV2 }
+  | {
+      readonly kind: 'buckets';
+      readonly buckets: readonly UsageBucket[];
+      readonly offset: number;
+      readonly total: number;
+      readonly nextOffset: number | null;
+    }
+  | {
+      readonly kind: 'logs';
+      readonly source: 'llm';
+      readonly rows: readonly LlmUsageLogProjection[];
+      readonly offset: number;
+      readonly total: number;
+      readonly nextOffset: number | null;
+    }
+  | {
+      readonly kind: 'logs';
+      readonly source: 'tool';
+      readonly rows: readonly ToolUsageLogProjection[];
+      readonly offset: number;
+      readonly total: number;
+      readonly nextOffset: number | null;
+    };
+
+export type PricingQueryInput =
+  | { readonly kind: 'start' }
+  | { readonly kind: 'continue'; readonly revision: number; readonly offset: number };
+
+export type PricingQueryResult =
+  | {
+      readonly kind: 'page';
+      readonly revision: number;
+      readonly offset: number;
+      readonly overrides: readonly Readonly<PricingConfig>[];
+      readonly nextOffset: number | null;
+    }
+  | {
+      readonly kind: 'revision_changed';
+      readonly expectedRevision: number;
+      readonly actualRevision: number;
+    };
+
+export type PricingMutation =
+  | { readonly kind: 'upsert'; readonly pricing: PricingConfig }
+  | { readonly kind: 'delete'; readonly modelKey: string };
+
+export interface PricingMutateInput {
+  readonly expectedRevision: number;
+  readonly mutation: PricingMutation;
+}
+
+export type PricingMutateResult =
+  | { readonly kind: 'committed' | 'unchanged'; readonly revision: number }
+  | {
+      readonly kind: 'revision_conflict';
+      readonly expectedRevision: number;
+      readonly actualRevision: number;
+    };
+
+export const USAGE_PRICING_OPERATION_SPECS = {
+  'usage.query': defineOperation<
+    UsageQueryInput,
+    UsageQueryResult,
+    (typeof USAGE_QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: USAGE_QUERY_ERRORS,
+    decodeInput: decodeUsageQueryInput,
+    decodeOutput: decodeUsageQueryResult,
+    assertOutputForInput: assertUsageQueryOutputForInput,
+  }),
+  'pricing.query': defineOperation<
+    PricingQueryInput,
+    PricingQueryResult,
+    (typeof PRICING_QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: PRICING_QUERY_ERRORS,
+    decodeInput: decodePricingQueryInput,
+    decodeOutput: decodePricingQueryResult,
+    assertOutputForInput: assertPricingQueryOutputForInput,
+  }),
+  'pricing.mutate': defineOperation<
+    PricingMutateInput,
+    PricingMutateResult,
+    (typeof MUTATION_ERRORS)[number]
+  >({
+    mode: 'command',
+    availability: 'ready',
+    errors: MUTATION_ERRORS,
+    decodeInput: decodePricingMutateInput,
+    decodeOutput: decodePricingMutateResult,
+    assertOutputForInput: assertPricingMutateOutputForInput,
+  }),
+} as const;
+
+export function decodeUsageQueryInput(value: unknown): UsageQueryInput {
+  const input = requireRecord(value, 'usage query input');
+  if (input.kind === 'summary') {
+    const exact = requireExactRecord(input, 'usage summary input', ['kind', 'query']);
+    return { kind: 'summary', query: decodeLlmUsageQuery(exact.query) };
+  }
+  if (input.kind === 'buckets') {
+    assertOptionalExactKeys(
+      input,
+      'usage buckets input',
+      ['kind', 'query', 'groupBy'],
+      ['offset', 'limit'],
+    );
+    const groupBy = decodeUsageGroupBy(input.groupBy);
+    const page = { offset: decodeOffset(input.offset), limit: decodeLimit(input.limit) };
+    return groupBy === 'tool'
+      ? { kind: 'buckets', query: decodeToolUsageQuery(input.query), groupBy, ...page }
+      : { kind: 'buckets', query: decodeLlmUsageQuery(input.query), groupBy, ...page };
+  }
+  if (input.kind === 'logs') {
+    assertOptionalExactKeys(
+      input,
+      'usage logs input',
+      ['kind', 'source', 'query'],
+      ['offset', 'limit'],
+    );
+    const page = { offset: decodeOffset(input.offset), limit: decodeLimit(input.limit) };
+    if (input.source === 'llm') {
+      return {
+        kind: 'logs',
+        source: 'llm',
+        query: decodeLlmUsageQuery(input.query),
+        ...page,
+      };
+    }
+    if (input.source === 'tool') {
+      return {
+        kind: 'logs',
+        source: 'tool',
+        query: decodeToolUsageQuery(input.query),
+        ...page,
+      };
+    }
+    throw invalidProtocolFrame('Invalid usage log source');
+  }
+  throw invalidProtocolFrame('Invalid usage query kind');
+}
+
+export function decodeUsageQueryResult(value: unknown): UsageQueryResult {
+  const result = requireRecord(value, 'usage query result');
+  if (result.kind === 'summary') {
+    const exact = requireExactRecord(result, 'usage summary result', ['kind', 'summary']);
+    return { kind: 'summary', summary: decodeUsageSummary(exact.summary) };
+  }
+  if (result.kind === 'buckets') {
+    const exact = requireExactRecord(result, 'usage buckets result', [
+      'kind',
+      'buckets',
+      'offset',
+      'total',
+      'nextOffset',
+    ]);
+    return decodeUsagePage('buckets', exact, decodeUsageBucket);
+  }
+  if (result.kind === 'logs') {
+    const exact = requireExactRecord(result, 'usage logs result', [
+      'kind',
+      'source',
+      'rows',
+      'offset',
+      'total',
+      'nextOffset',
+    ]);
+    if (exact.source === 'llm') {
+      return decodeUsageLogPage('llm', exact, decodeLlmUsageLog);
+    }
+    if (exact.source === 'tool') {
+      return decodeUsageLogPage('tool', exact, decodeToolUsageLog);
+    }
+    throw invalidProtocolFrame('Invalid usage log source');
+  }
+  throw invalidProtocolFrame('Invalid usage query result kind');
+}
+
+export const encodeUsageQueryResult = decodeUsageQueryResult;
+
+export function decodePricingQueryInput(value: unknown): PricingQueryInput {
+  const input = requireRecord(value, 'pricing query input');
+  if (input.kind === 'start') {
+    requireExactRecord(input, 'pricing query start input', ['kind']);
+    return { kind: 'start' };
+  }
+  if (input.kind === 'continue') {
+    const exact = requireExactRecord(input, 'pricing query continuation input', [
+      'kind',
+      'revision',
+      'offset',
+    ]);
+    return {
+      kind: 'continue',
+      revision: requireCount(exact.revision, 'pricing revision'),
+      offset: requireCount(exact.offset, 'pricing offset'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid pricing query kind');
+}
+
+export function decodePricingQueryResult(value: unknown): PricingQueryResult {
+  const result = requireRecord(value, 'pricing query result');
+  if (result.kind === 'revision_changed') {
+    const exact = requireExactRecord(result, 'pricing revision changed result', [
+      'kind',
+      'expectedRevision',
+      'actualRevision',
+    ]);
+    const decoded = {
+      kind: 'revision_changed',
+      expectedRevision: requireCount(exact.expectedRevision, 'expected pricing revision'),
+      actualRevision: requireCount(exact.actualRevision, 'actual pricing revision'),
+    } as const;
+    if (decoded.expectedRevision === decoded.actualRevision) {
+      throw invalidProtocolFrame('Pricing revision did not change');
+    }
+    return decoded;
+  }
+  if (result.kind !== 'page') throw invalidProtocolFrame('Invalid pricing query result kind');
+  const exact = requireExactRecord(result, 'pricing page result', [
+    'kind',
+    'revision',
+    'offset',
+    'overrides',
+    'nextOffset',
+  ]);
+  if (!Array.isArray(exact.overrides) || exact.overrides.length > PRICING_PAGE_MAX_ITEMS) {
+    throw invalidProtocolFrame('Pricing overrides exceed item limit');
+  }
+  const overrides = exact.overrides.map(decodePricingConfig);
+  if (
+    overrides.some(
+      (item, index) =>
+        index > 0 && comparePricingModelKeys(overrides[index - 1]!.modelKey, item.modelKey) >= 0,
+    )
+  ) {
+    throw invalidProtocolFrame('Pricing overrides are not canonically ordered');
+  }
+  const offset = requireCount(exact.offset, 'pricing offset');
+  const nextOffset =
+    exact.nextOffset === null ? null : requireCount(exact.nextOffset, 'pricing next offset');
+  const advancedOffset = offset + overrides.length;
+  if (nextOffset !== null && (overrides.length === 0 || nextOffset !== advancedOffset)) {
+    throw invalidProtocolFrame('Pricing page does not make canonical progress');
+  }
+  const decoded: PricingQueryResult = {
+    kind: 'page',
+    revision: requireCount(exact.revision, 'pricing revision'),
+    offset,
+    overrides,
+    nextOffset,
+  };
+  assertJsonBytes(decoded, PRICING_PAGE_MAX_BYTES, 'Pricing page');
+  return decoded;
+}
+
+export const encodePricingQueryResult = decodePricingQueryResult;
+
+export function decodePricingMutateInput(value: unknown): PricingMutateInput {
+  const input = requireExactRecord(value, 'pricing mutation input', [
+    'expectedRevision',
+    'mutation',
+  ]);
+  const expectedRevision = requireCount(input.expectedRevision, 'expected pricing revision');
+  const mutation = requireRecord(input.mutation, 'pricing mutation');
+  if (mutation.kind === 'upsert') {
+    const exact = requireExactRecord(mutation, 'pricing upsert mutation', ['kind', 'pricing']);
+    return {
+      expectedRevision,
+      mutation: { kind: 'upsert', pricing: decodePricingConfig(exact.pricing) },
+    };
+  }
+  if (mutation.kind === 'delete') {
+    const exact = requireExactRecord(mutation, 'pricing delete mutation', ['kind', 'modelKey']);
+    const normalized = normalizePricingModelKey(exact.modelKey);
+    if (!normalized.ok) throw invalidProtocolFrame('Invalid pricing model key');
+    return {
+      expectedRevision,
+      mutation: { kind: 'delete', modelKey: normalized.value },
+    };
+  }
+  throw invalidProtocolFrame('Invalid pricing mutation kind');
+}
+
+export function decodePricingMutateResult(value: unknown): PricingMutateResult {
+  const result = requireRecord(value, 'pricing mutation result');
+  if (result.kind === 'committed' || result.kind === 'unchanged') {
+    const exact = requireExactRecord(result, 'pricing mutation outcome', ['kind', 'revision']);
+    return { kind: result.kind, revision: requireCount(exact.revision, 'pricing revision') };
+  }
+  if (result.kind === 'revision_conflict') {
+    const exact = requireExactRecord(result, 'pricing revision conflict', [
+      'kind',
+      'expectedRevision',
+      'actualRevision',
+    ]);
+    const decoded = {
+      kind: 'revision_conflict',
+      expectedRevision: requireCount(exact.expectedRevision, 'expected pricing revision'),
+      actualRevision: requireCount(exact.actualRevision, 'actual pricing revision'),
+    } as const;
+    if (decoded.expectedRevision === decoded.actualRevision) {
+      throw invalidProtocolFrame('Pricing revision did not conflict');
+    }
+    return decoded;
+  }
+  throw invalidProtocolFrame('Invalid pricing mutation result kind');
+}
+
+function assertUsageQueryOutputForInput(input: UsageQueryInput, output: UsageQueryResult): void {
+  if (output.kind !== input.kind) {
+    throw invalidProtocolFrame('Usage response kind does not match its request');
+  }
+  if (input.kind === 'summary') return;
+  if (output.kind === 'summary') {
+    throw invalidProtocolFrame('Usage response kind does not match its request');
+  }
+  const expectedOffset = input.offset ?? 0;
+  if (output.offset !== expectedOffset) {
+    throw invalidProtocolFrame('Usage response offset does not match its request');
+  }
+  if (input.kind === 'logs' && output.kind === 'logs' && output.source !== input.source) {
+    throw invalidProtocolFrame('Usage log source does not match its request');
+  }
+}
+
+function assertPricingQueryOutputForInput(
+  input: PricingQueryInput,
+  output: PricingQueryResult,
+): void {
+  if (input.kind === 'start') {
+    if (output.kind !== 'page' || output.offset !== 0) {
+      throw invalidProtocolFrame('Pricing start response does not match its request');
+    }
+    return;
+  }
+  if (output.kind === 'revision_changed') {
+    if (output.expectedRevision !== input.revision) {
+      throw invalidProtocolFrame('Pricing revision change does not match its request');
+    }
+    return;
+  }
+  if (output.revision !== input.revision || output.offset !== input.offset) {
+    throw invalidProtocolFrame('Pricing page does not match its request');
+  }
+}
+
+function assertPricingMutateOutputForInput(
+  input: PricingMutateInput,
+  output: PricingMutateResult,
+): void {
+  if (output.kind === 'revision_conflict') {
+    if (output.expectedRevision !== input.expectedRevision) {
+      throw invalidProtocolFrame('Pricing conflict does not match its request');
+    }
+    return;
+  }
+  const expectedRevision =
+    output.kind === 'committed' ? input.expectedRevision + 1 : input.expectedRevision;
+  if (output.revision !== expectedRevision) {
+    throw invalidProtocolFrame('Pricing mutation result does not match its request');
+  }
+}
+
+function decodeLlmUsageQuery(value: unknown): LlmUsageQuery {
+  const query = requireRecord(value, 'usage query');
+  assertAllowedKeys(query, LLM_USAGE_QUERY_FIELDS, 'LLM usage query');
+  if (!Object.hasOwn(query, 'range')) throw invalidProtocolFrame('Invalid usage query fields');
+  return {
+    range: decodeUsageRange(query.range),
+    ...optionalQueryText(query, 'connectionSlug'),
+    ...optionalQueryText(query, 'providerId'),
+    ...optionalQueryText(query, 'modelId'),
+    ...(query.status === undefined ? {} : { status: decodeUsageStatus(query.status) }),
+  };
+}
+
+function decodeToolUsageQuery(value: unknown): ToolUsageQuery {
+  const query = requireRecord(value, 'tool usage query');
+  assertAllowedKeys(query, TOOL_USAGE_QUERY_FIELDS, 'tool usage query');
+  if (!Object.hasOwn(query, 'range')) {
+    throw invalidProtocolFrame('Invalid tool usage query fields');
+  }
+  return {
+    range: decodeUsageRange(query.range),
+    ...optionalQueryText(query, 'toolName'),
+    ...(query.status === undefined ? {} : { status: decodeUsageStatus(query.status) }),
+  };
+}
+
+function decodeUsageRange(value: unknown): UsageQuery['range'] {
+  if (value === '24h' || value === '7d' || value === '30d' || value === 'all') return value;
+  const range = requireExactRecord(value, 'usage range', ['from', 'to']);
+  const from = nonnegativeFinite(range.from, 'usage range from');
+  const to = nonnegativeFinite(range.to, 'usage range to');
+  if (from > to) throw invalidProtocolFrame('Invalid usage range');
+  return { from, to };
+}
+
+function decodeUsageStatus(value: unknown): NonNullable<UsageQuery['status']> {
+  if (value === 'success' || value === 'error' || value === 'aborted' || value === 'all') {
+    return value;
+  }
+  throw invalidProtocolFrame('Invalid usage query status');
+}
+
+function decodeUsageGroupBy(value: unknown): UsageGroupBy {
+  if (
+    value === 'provider' ||
+    value === 'model' ||
+    value === 'tool' ||
+    value === 'day' ||
+    value === 'hour'
+  ) {
+    return value;
+  }
+  throw invalidProtocolFrame('Invalid usage groupBy');
+}
+
+function decodeOffset(value: unknown): number {
+  return value === undefined ? 0 : requireCount(value, 'usage offset');
+}
+
+function decodeLimit(value: unknown): number {
+  if (value === undefined) return USAGE_PAGE_MAX_ITEMS;
+  const limit = requireCount(value, 'usage limit');
+  if (limit === 0 || limit > USAGE_PAGE_MAX_ITEMS) {
+    throw invalidProtocolFrame('Invalid usage limit');
+  }
+  return limit;
+}
+
+function decodeUsagePage(
+  kind: 'buckets',
+  result: Record<string, unknown>,
+  decodeItem: (value: unknown) => UsageBucket,
+): Extract<UsageQueryResult, { kind: 'buckets' }>;
+function decodeUsagePage(
+  kind: 'buckets',
+  result: Record<string, unknown>,
+  decodeItem: (value: unknown) => UsageBucket,
+): Extract<UsageQueryResult, { kind: 'buckets' }> {
+  const rawItems = result.buckets;
+  if (!Array.isArray(rawItems) || rawItems.length > USAGE_PAGE_MAX_ITEMS) {
+    throw invalidProtocolFrame('Usage page exceeds item limit');
+  }
+  const items = rawItems.map(decodeItem);
+  const page = decodeUsagePagePosition(result, items.length);
+  const decoded = { kind, buckets: items, ...page } as const;
+  assertJsonBytes(decoded, USAGE_PAGE_MAX_BYTES, 'Usage page');
+  return decoded;
+}
+
+function decodeUsageLogPage(
+  source: 'llm',
+  result: Record<string, unknown>,
+  decodeItem: (value: unknown) => LlmUsageLogProjection,
+): Extract<UsageQueryResult, { kind: 'logs'; source: 'llm' }>;
+function decodeUsageLogPage(
+  source: 'tool',
+  result: Record<string, unknown>,
+  decodeItem: (value: unknown) => ToolUsageLogProjection,
+): Extract<UsageQueryResult, { kind: 'logs'; source: 'tool' }>;
+function decodeUsageLogPage(
+  source: 'llm' | 'tool',
+  result: Record<string, unknown>,
+  decodeItem: (value: unknown) => UsageLogProjection,
+): Extract<UsageQueryResult, { kind: 'logs' }> {
+  const rawItems = result.rows;
+  if (!Array.isArray(rawItems) || rawItems.length > USAGE_PAGE_MAX_ITEMS) {
+    throw invalidProtocolFrame('Usage page exceeds item limit');
+  }
+  const items = rawItems.map(decodeItem);
+  const page = decodeUsagePagePosition(result, items.length);
+  const decoded = { kind: 'logs', source, rows: items, ...page } as Extract<
+    UsageQueryResult,
+    { kind: 'logs' }
+  >;
+  assertJsonBytes(decoded, USAGE_PAGE_MAX_BYTES, 'Usage page');
+  return decoded;
+}
+
+function decodeUsagePagePosition(
+  result: Record<string, unknown>,
+  itemCount: number,
+): { readonly offset: number; readonly total: number; readonly nextOffset: number | null } {
+  const offset = requireCount(result.offset, 'usage result offset');
+  const total = requireCount(result.total, 'usage result total');
+  const nextOffset =
+    result.nextOffset === null ? null : requireCount(result.nextOffset, 'usage next offset');
+  if (offset > total || itemCount > total - offset) {
+    throw invalidProtocolFrame('Usage page exceeds remaining total');
+  }
+  const advancedOffset = offset + itemCount;
+  if (nextOffset === null) {
+    if (advancedOffset !== total) {
+      throw invalidProtocolFrame('Terminal usage page does not reach total');
+    }
+  } else if (itemCount === 0 || nextOffset !== advancedOffset || advancedOffset >= total) {
+    throw invalidProtocolFrame('Usage page does not make canonical progress');
+  }
+  return { offset, total, nextOffset };
+}
+
+function decodeUsageSummary(value: unknown): UsageSummaryV2 {
+  const summary = requireExactRecord(value, 'usage summary', [
+    'range',
+    'totalRequests',
+    'totalCostUsd',
+    'totalTokens',
+    'cacheHitRequests',
+    'cacheCreateRequests',
+    'errorRequests',
+  ]);
+  const range = requireExactRecord(summary.range, 'usage summary range', ['from', 'to']);
+  const tokens = requireExactRecord(summary.totalTokens, 'usage summary tokens', [
+    'input',
+    'output',
+    'cacheMiss',
+    'cacheRead',
+    'cacheWrite',
+    'reasoning',
+    'total',
+  ]);
+  return {
+    range: {
+      from: nonnegativeFinite(range.from, 'usage summary range from'),
+      to: nonnegativeFinite(range.to, 'usage summary range to'),
+    },
+    totalRequests: requireCount(summary.totalRequests, 'usage total requests'),
+    totalCostUsd: nonnegativeFinite(summary.totalCostUsd, 'usage total cost'),
+    totalTokens: {
+      input: requireCount(tokens.input, 'usage input tokens'),
+      output: requireCount(tokens.output, 'usage output tokens'),
+      cacheMiss: requireCount(tokens.cacheMiss, 'usage cache miss tokens'),
+      cacheRead: requireCount(tokens.cacheRead, 'usage cache read tokens'),
+      cacheWrite: requireCount(tokens.cacheWrite, 'usage cache write tokens'),
+      reasoning: requireCount(tokens.reasoning, 'usage reasoning tokens'),
+      total: requireCount(tokens.total, 'usage total tokens'),
+    },
+    cacheHitRequests: requireCount(summary.cacheHitRequests, 'usage cache hit requests'),
+    cacheCreateRequests: requireCount(summary.cacheCreateRequests, 'usage cache create requests'),
+    errorRequests: requireCount(summary.errorRequests, 'usage error requests'),
+  };
+}
+
+function decodeUsageBucket(value: unknown): UsageBucket {
+  const bucket = requireRecord(value, 'usage bucket');
+  assertAllowedKeys(bucket, USAGE_BUCKET_FIELDS, 'usage bucket');
+  requireFields(bucket, [
+    'key',
+    'label',
+    'requests',
+    'inputTokens',
+    'outputTokens',
+    'cacheMissTokens',
+    'cacheReadTokens',
+    'cacheWriteTokens',
+    'reasoningTokens',
+    'totalTokens',
+    'costUsd',
+    'avgLatencyMs',
+    'errorRate',
+  ]);
+  const errorRate = nonnegativeFinite(bucket.errorRate, 'usage bucket error rate');
+  if (errorRate > 1) throw invalidProtocolFrame('Invalid usage bucket error rate');
+  return {
+    key: projectionText(bucket.key, 'usage bucket key'),
+    label: projectionText(bucket.label, 'usage bucket label'),
+    requests: requireCount(bucket.requests, 'usage bucket requests'),
+    inputTokens: requireCount(bucket.inputTokens, 'usage bucket input tokens'),
+    outputTokens: requireCount(bucket.outputTokens, 'usage bucket output tokens'),
+    cacheMissTokens: requireCount(bucket.cacheMissTokens, 'usage bucket cache miss tokens'),
+    cacheReadTokens: requireCount(bucket.cacheReadTokens, 'usage bucket cache read tokens'),
+    cacheWriteTokens: requireCount(bucket.cacheWriteTokens, 'usage bucket cache write tokens'),
+    ...(bucket.cacheMissInputSource === undefined
+      ? {}
+      : { cacheMissInputSource: decodeCacheMissInputSource(bucket.cacheMissInputSource) }),
+    reasoningTokens: requireCount(bucket.reasoningTokens, 'usage bucket reasoning tokens'),
+    totalTokens: requireCount(bucket.totalTokens, 'usage bucket total tokens'),
+    costUsd: nonnegativeFinite(bucket.costUsd, 'usage bucket cost'),
+    avgLatencyMs: nonnegativeFinite(bucket.avgLatencyMs, 'usage bucket average latency'),
+    errorRate,
+  };
+}
+
+function decodeLlmUsageLog(value: unknown): LlmUsageLogProjection {
+  const row = requireRecord(value, 'usage log row');
+  assertAllowedKeys(row, LLM_USAGE_LOG_FIELDS, 'LLM usage log row');
+  requireFields(row, [
+    'source',
+    'id',
+    'ts',
+    'providerId',
+    'modelId',
+    'inputTokens',
+    'outputTokens',
+    'cacheMissTokens',
+    'cacheReadTokens',
+    'cacheWriteTokens',
+    'reasoningTokens',
+    'totalTokens',
+    'costUsd',
+    'latencyMs',
+    'status',
+  ]);
+  if (row.source !== 'llm') throw invalidProtocolFrame('Invalid LLM usage log source');
+  return {
+    source: 'llm',
+    id: projectionText(row.id, 'usage log id'),
+    ts: nonnegativeFinite(row.ts, 'usage log timestamp'),
+    ...optionalEnum(row, 'callKind', ['main', 'semantic_compact'] as const),
+    ...optionalProjectionText(row, 'callId'),
+    ...optionalProjectionText(row, 'connectionSlug'),
+    providerId: projectionText(row.providerId, 'usage log provider'),
+    modelId: projectionText(row.modelId, 'usage log model'),
+    inputTokens: requireCount(row.inputTokens, 'usage log input tokens'),
+    outputTokens: requireCount(row.outputTokens, 'usage log output tokens'),
+    cacheMissTokens: requireCount(row.cacheMissTokens, 'usage log cache miss tokens'),
+    cacheReadTokens: requireCount(row.cacheReadTokens, 'usage log cache read tokens'),
+    cacheWriteTokens: requireCount(row.cacheWriteTokens, 'usage log cache write tokens'),
+    ...(row.cacheMissInputSource === undefined
+      ? {}
+      : { cacheMissInputSource: decodeCacheMissInputSource(row.cacheMissInputSource) }),
+    reasoningTokens: requireCount(row.reasoningTokens, 'usage log reasoning tokens'),
+    totalTokens: requireCount(row.totalTokens, 'usage log total tokens'),
+    costUsd: nonnegativeFinite(row.costUsd, 'usage log cost'),
+    latencyMs: nonnegativeFinite(row.latencyMs, 'usage log latency'),
+    status: decodeUsageLogStatus(row.status),
+    ...optionalProjectionText(row, 'errorClass'),
+    ...optionalProjectionText(row, 'sessionId'),
+    ...optionalProjectionText(row, 'turnId'),
+  };
+}
+
+function decodeToolUsageLog(value: unknown): ToolUsageLogProjection {
+  const row = requireRecord(value, 'tool usage log row');
+  assertAllowedKeys(row, TOOL_USAGE_LOG_FIELDS, 'tool usage log row');
+  requireFields(row, [
+    'source',
+    'id',
+    'ts',
+    'toolName',
+    'durationMs',
+    'status',
+    'bytesIn',
+    'bytesOut',
+    'startedAt',
+  ]);
+  if (row.source !== 'tool') throw invalidProtocolFrame('Invalid tool usage log source');
+  return {
+    source: 'tool',
+    id: projectionText(row.id, 'tool usage log id'),
+    ts: nonnegativeFinite(row.ts, 'tool usage log timestamp'),
+    ...optionalProjectionText(row, 'toolCallId'),
+    toolName: projectionText(row.toolName, 'tool usage log name'),
+    ...optionalProjectionText(row, 'providerId'),
+    ...optionalProjectionText(row, 'modelId'),
+    durationMs: nonnegativeFinite(row.durationMs, 'tool usage log duration'),
+    status: decodeUsageLogStatus(row.status),
+    ...optionalProjectionText(row, 'errorClass'),
+    ...optionalProjectionText(row, 'argsSummary'),
+    ...(row.resultSummary === undefined
+      ? {}
+      : { resultSummary: decodeToolResultSummary(row.resultSummary) }),
+    bytesIn: requireCount(row.bytesIn, 'tool usage log bytes in'),
+    bytesOut: requireCount(row.bytesOut, 'tool usage log bytes out'),
+    startedAt: nonnegativeFinite(row.startedAt, 'tool usage log start time'),
+    ...optionalProjectionText(row, 'sessionId'),
+    ...optionalProjectionText(row, 'turnId'),
+  };
+}
+
+function decodeToolResultSummary(value: unknown): ToolInvocationResultSummary {
+  const summary = requireRecord(value, 'tool result summary');
+  assertAllowedKeys(summary, TOOL_RESULT_SUMMARY_FIELDS, 'tool result summary');
+  requireFields(summary, ['kind']);
+  return {
+    kind: projectionText(summary.kind, 'tool result summary kind'),
+    ...optionalProjectionText(summary, 'status'),
+    ...optionalCount(summary, 'itemCount'),
+    ...optionalCount(summary, 'startedItemCount'),
+    ...optionalCount(summary, 'completedItemCount'),
+    ...optionalCount(summary, 'failedItemCount'),
+    ...optionalCount(summary, 'cancelledItemCount'),
+    ...optionalCount(summary, 'artifactCount'),
+  };
+}
+
+function decodePricingConfig(value: unknown): PricingConfig {
+  const canonical = validateCanonicalPricingConfig(value);
+  if (!canonical.ok) throw invalidProtocolFrame('Invalid pricing config');
+  return canonical.value;
+}
+
+function optionalQueryText<Field extends keyof UsageQuery>(
+  query: Record<string, unknown>,
+  field: Field,
+): Partial<Pick<UsageQuery, Field>> {
+  if (query[field] === undefined) return {};
+  const value = boundedText(query[field], `usage query ${String(field)}`, 512);
+  if (/[\u0000-\u001f\u007f]/u.test(value)) {
+    throw invalidProtocolFrame(`Invalid usage query ${String(field)}`);
+  }
+  return { [field]: value } as Partial<Pick<UsageQuery, Field>>;
+}
+
+function optionalProjectionText<Field extends string>(
+  record: Record<string, unknown>,
+  field: Field,
+): Record<Field, string> | Record<string, never> {
+  return record[field] === undefined
+    ? {}
+    : ({ [field]: projectionText(record[field], `usage ${field}`) } as Record<Field, string>);
+}
+
+function optionalEnum<Field extends string, Value extends string>(
+  record: Record<string, unknown>,
+  field: Field,
+  values: readonly Value[],
+): Record<Field, Value> | Record<string, never> {
+  const value = record[field];
+  if (value === undefined) return {};
+  if (typeof value !== 'string' || !values.includes(value as Value)) {
+    throw invalidProtocolFrame(`Invalid usage ${field}`);
+  }
+  return { [field]: value } as Record<Field, Value>;
+}
+
+function optionalCount<Field extends string>(
+  record: Record<string, unknown>,
+  field: Field,
+): Record<Field, number> | Record<string, never> {
+  return record[field] === undefined
+    ? {}
+    : ({ [field]: requireCount(record[field], `usage ${field}`) } as Record<Field, number>);
+}
+
+function decodeCacheMissInputSource(value: unknown): CacheMissInputSource {
+  if (value === 'explicit' || value === 'derived') return value;
+  throw invalidProtocolFrame('Invalid cache miss input source');
+}
+
+function decodeUsageLogStatus(value: unknown): UsageLogProjection['status'] {
+  if (value === 'success' || value === 'error' || value === 'aborted') return value;
+  throw invalidProtocolFrame('Invalid usage log status');
+}
+
+function boundedText(value: unknown, label: string, maxBytes: number): string {
+  if (
+    typeof value !== 'string' ||
+    value.length === 0 ||
+    Buffer.byteLength(value, 'utf8') > maxBytes
+  ) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value;
+}
+
+function projectionText(value: unknown, label: string): string {
+  const text = boundedText(value, label, USAGE_PROJECTION_TEXT_MAX_BYTES);
+  if (/[\u0000-\u001f\u007f]/u.test(text)) throw invalidProtocolFrame(`Invalid ${label}`);
+  return text;
+}
+
+function nonnegativeFinite(value: unknown, label: string): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value < 0) {
+    throw invalidProtocolFrame(`Invalid ${label}`);
+  }
+  return value;
+}
+
+function requireFields(record: Record<string, unknown>, required: readonly string[]): void {
+  if (required.some((field) => !Object.hasOwn(record, field))) {
+    throw invalidProtocolFrame('Invalid protocol fields');
+  }
+}
+
+function assertAllowedKeys(
+  record: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+  label: string,
+): void {
+  if (Object.keys(record).some((field) => !allowed.has(field))) {
+    throw invalidProtocolFrame(`Unknown ${label} field`);
+  }
+}
+
+function assertOptionalExactKeys(
+  record: Record<string, unknown>,
+  label: string,
+  required: readonly string[],
+  optional: readonly string[],
+): void {
+  requireFields(record, required);
+  assertAllowedKeys(record, new Set([...required, ...optional]), label);
+}
+
+function assertJsonBytes(value: unknown, maxBytes: number, label: string): void {
+  if (Buffer.byteLength(JSON.stringify(value), 'utf8') > maxBytes) {
+    throw invalidProtocolFrame(`${label} exceeds byte limit`);
+  }
+}

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -12,6 +12,7 @@ import { openInteractiveExecutionStoresForWrite } from '@maka/storage/execution-
 import { runWithStorageRootLease } from '@maka/storage/root-authority';
 import { openInteractiveRuntimePolicyStoresForWrite } from '@maka/storage/runtime-policy-stores';
 import { openInteractiveTaskLedgerStoreForWrite } from '@maka/storage/task-ledger-authority';
+import { openInteractiveUsageStoresForWrite } from '@maka/storage/usage-stores';
 import { CanonicalSessionProjectionReader } from './canonical-session-projection.js';
 import { HostCanonicalPermissionOutcomeReader } from './canonical-permission-outcome-reader.js';
 import { HostArtifactCoordinator } from './artifact-coordinator.js';
@@ -28,24 +29,29 @@ import { SessionContinuityCoordinator } from './session-continuity-coordinator.j
 import { HostSkillCatalogCoordinator } from './skill-catalog-coordinator.js';
 import { SkillCatalogRepository } from './skill-catalog-repository.js';
 import { HostTaskLedgerCoordinator } from './task-ledger-coordinator.js';
+import { HostUsagePricingCoordinator } from './usage-pricing-coordinator.js';
 
 export async function createExecutionRuntimeHostComposition(
   context: RuntimeHostCompositionContext,
 ): Promise<RuntimeHostComposition> {
   const stores = await openInteractiveExecutionStoresForWrite(context.owner.lease);
   let graphControlStore: ReturnType<typeof createAgentGraphControlStore> | undefined;
+  let usageStores: Awaited<ReturnType<typeof openInteractiveUsageStoresForWrite>> | undefined;
   try {
     const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
       context.owner.lease,
     );
     const taskLedgerStore = await openInteractiveTaskLedgerStoreForWrite(context.owner.lease);
     const openedArtifactStore = await openInteractiveArtifactStoreForWrite(context.owner.lease);
+    const openedUsageStores = await openInteractiveUsageStoresForWrite(context.owner.lease);
+    usageStores = openedUsageStores;
     await stores.messageReceiptStore.beginHostEpoch(context.hostEpoch);
     const backends = new BackendRegistry();
     backends.register('fake', (backendContext) => new FakeBackend(backendContext));
     const runtimePolicyActivation = new RuntimePolicyActivationGate();
     const sessionAdmission = new SessionAdmissionGate();
     const taskLedger = new HostTaskLedgerCoordinator(taskLedgerStore, sessionAdmission);
+    const usagePricing = new HostUsagePricingCoordinator(openedUsageStores, context.requestDrain);
     const openedGraphControlStore = createAgentGraphControlStore(
       context.owner.capability.canonicalPath,
     );
@@ -108,12 +114,18 @@ export async function createExecutionRuntimeHostComposition(
     let recoveryTask: Promise<void> | undefined;
     let rootCloseTask: Promise<void> | undefined;
     let closeTask: Promise<void> | undefined;
+    let usageDrain: Promise<void> | undefined;
     const beginDrain = () => {
       if (draining) return;
       draining = true;
       messages.beginDrain();
       interactions.beginDrain();
       skills.beginDrain();
+      usageDrain ??= openedUsageStores.beginDrain();
+      usageDrain.then(
+        () => undefined,
+        () => undefined,
+      );
     };
     const interactions = new HostInteractionCoordinator({
       store: stores.interactionStore,
@@ -207,6 +219,7 @@ export async function createExecutionRuntimeHostComposition(
       ...taskLedger.handlers,
       ...artifacts.handlers,
       ...skills.handlers,
+      ...usagePricing.handlers,
     } satisfies DomainOperationHandlerMap;
     const recover = () => {
       recoveryTask ??= (async () => {
@@ -276,6 +289,11 @@ export async function createExecutionRuntimeHostComposition(
           errors.push(error);
         }
         try {
+          await openedUsageStores.close();
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
           await stores.sessionStore.close?.();
         } catch (error) {
           errors.push(error);
@@ -298,6 +316,11 @@ export async function createExecutionRuntimeHostComposition(
     const errors: unknown[] = [error];
     try {
       graphControlStore?.close();
+    } catch (closeError) {
+      errors.push(closeError);
+    }
+    try {
+      await usageStores?.close();
     } catch (closeError) {
       errors.push(closeError);
     }

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -51,6 +51,7 @@ export type SessionContinuityOperationKey = Extract<
 export type TaskLedgerOperationKey = Extract<OperationKey, 'task.ledger.query'>;
 export type ArtifactOperationKey = Extract<OperationKey, `artifact.${string}`>;
 export type SkillCatalogOperationKey = Extract<OperationKey, `skill.catalog.${string}`>;
+export type UsagePricingOperationKey = Extract<OperationKey, 'usage.query' | `pricing.${string}`>;
 export type DomainOperationHandlerMap = Pick<OperationHandlerMap, DomainOperationKey>;
 export type TurnOperationHandlerMap = Pick<OperationHandlerMap, TurnOperationKey>;
 export type RuntimePolicyOperationHandlerMap = Pick<OperationHandlerMap, RuntimePolicyOperationKey>;
@@ -63,6 +64,7 @@ export type SessionContinuityOperationHandlerMap = Pick<
 export type TaskLedgerOperationHandlerMap = Pick<OperationHandlerMap, TaskLedgerOperationKey>;
 export type ArtifactOperationHandlerMap = Pick<OperationHandlerMap, ArtifactOperationKey>;
 export type SkillCatalogOperationHandlerMap = Pick<OperationHandlerMap, SkillCatalogOperationKey>;
+export type UsagePricingOperationHandlerMap = Pick<OperationHandlerMap, UsagePricingOperationKey>;
 
 export function composeOperationHandlers(
   ...handlerMaps: readonly Partial<OperationHandlerMap>[]

--- a/packages/runtime-host/src/server/usage-pricing-coordinator.ts
+++ b/packages/runtime-host/src/server/usage-pricing-coordinator.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import type {
   PricingConfig,
   ToolInvocationRecord,
@@ -378,7 +379,7 @@ function logPageResult(
 function projectUsageBucket(bucket: UsageBucket): UsageBucket {
   return {
     ...bucket,
-    key: projectText(bucket.key),
+    key: projectIdentity(bucket.key),
     label: projectText(bucket.label),
   };
 }
@@ -388,15 +389,15 @@ function projectUsageLog(row: UsageLogRow): LlmUsageLogProjection {
     .cacheMissInputSource;
   return {
     source: 'llm',
-    id: projectText(row.id),
+    id: projectIdentity(row.id),
     ts: row.ts,
     ...(row.callKind === undefined ? {} : { callKind: row.callKind }),
-    ...(row.callId === undefined ? {} : { callId: projectText(row.callId) }),
+    ...(row.callId === undefined ? {} : { callId: projectIdentity(row.callId) }),
     ...(row.connectionSlug === undefined
       ? {}
-      : { connectionSlug: projectText(row.connectionSlug) }),
-    providerId: projectText(row.providerId),
-    modelId: projectText(row.modelId),
+      : { connectionSlug: projectIdentity(row.connectionSlug) }),
+    providerId: projectIdentity(row.providerId),
+    modelId: projectIdentity(row.modelId),
     inputTokens: row.inputTokens,
     outputTokens: row.outputTokens,
     cacheMissTokens: row.cacheMissTokens,
@@ -411,8 +412,8 @@ function projectUsageLog(row: UsageLogRow): LlmUsageLogProjection {
     latencyMs: row.latencyMs,
     status: row.status,
     ...(row.errorClass === undefined ? {} : { errorClass: projectText(row.errorClass) }),
-    ...(row.sessionId === undefined ? {} : { sessionId: projectText(row.sessionId) }),
-    ...(row.turnId === undefined ? {} : { turnId: projectText(row.turnId) }),
+    ...(row.sessionId === undefined ? {} : { sessionId: projectIdentity(row.sessionId) }),
+    ...(row.turnId === undefined ? {} : { turnId: projectIdentity(row.turnId) }),
   };
 }
 
@@ -426,12 +427,12 @@ function projectToolUsageLog(
 ): ToolUsageLogProjection {
   return {
     source: 'tool',
-    id: projectText(row.id),
+    id: projectIdentity(row.id),
     ts: row.ts,
-    ...(row.toolCallId === undefined ? {} : { toolCallId: projectText(row.toolCallId) }),
-    toolName: projectText(row.toolName),
-    ...(row.providerId === undefined ? {} : { providerId: projectText(row.providerId) }),
-    ...(row.modelId === undefined ? {} : { modelId: projectText(row.modelId) }),
+    ...(row.toolCallId === undefined ? {} : { toolCallId: projectIdentity(row.toolCallId) }),
+    toolName: projectIdentity(row.toolName),
+    ...(row.providerId === undefined ? {} : { providerId: projectIdentity(row.providerId) }),
+    ...(row.modelId === undefined ? {} : { modelId: projectIdentity(row.modelId) }),
     durationMs: row.durationMs,
     status: row.status,
     ...(row.errorClass === undefined ? {} : { errorClass: projectText(row.errorClass) }),
@@ -450,24 +451,68 @@ function projectToolUsageLog(
     bytesIn: row.bytesIn,
     bytesOut: row.bytesOut,
     startedAt: row.startedAt,
-    ...(row.sessionId === undefined ? {} : { sessionId: projectText(row.sessionId) }),
-    ...(row.turnId === undefined ? {} : { turnId: projectText(row.turnId) }),
+    ...(row.sessionId === undefined ? {} : { sessionId: projectIdentity(row.sessionId) }),
+    ...(row.turnId === undefined ? {} : { turnId: projectIdentity(row.turnId) }),
   };
+}
+
+const IDENTITY_HASH_HEX_CHARS = 16;
+const IDENTITY_HASH_SEPARATOR = '~';
+const IDENTITY_HASH_SUFFIX_BYTES = IDENTITY_HASH_SEPARATOR.length + IDENTITY_HASH_HEX_CHARS;
+
+function projectIdentity(value: string): string {
+  const prefixMaxBytes = USAGE_PROJECTION_TEXT_MAX_BYTES - IDENTITY_HASH_SUFFIX_BYTES;
+  let projected = '';
+  let prefix = '';
+  let bytes = 0;
+  let prefixBytes = 0;
+  let canonicalized = false;
+  let prefixTruncated = false;
+  let truncated = false;
+
+  for (const codePoint of value) {
+    const canonical = projectCodePoint(codePoint);
+    if (canonical !== codePoint) canonicalized = true;
+    const size = Buffer.byteLength(canonical, 'utf8');
+    if (!truncated && bytes + size <= USAGE_PROJECTION_TEXT_MAX_BYTES) {
+      projected += canonical;
+      bytes += size;
+    } else {
+      truncated = true;
+    }
+    if (!prefixTruncated && prefixBytes + size <= prefixMaxBytes) {
+      prefix += canonical;
+      prefixBytes += size;
+    } else {
+      prefixTruncated = true;
+    }
+  }
+
+  if (!truncated && !canonicalized) return projected || '\ufffd';
+  const hashSuffix =
+    IDENTITY_HASH_SEPARATOR +
+    createHash('sha256').update(value, 'utf16le').digest('hex').slice(0, IDENTITY_HASH_HEX_CHARS);
+  return prefix + hashSuffix;
 }
 
 function projectText(value: string): string {
   let projected = '';
   let bytes = 0;
   for (const codePoint of value) {
-    const scalar = codePoint.codePointAt(0);
-    const canonical =
-      scalar !== undefined && (scalar <= 0x1f || scalar === 0x7f) ? '\ufffd' : codePoint;
+    const canonical = projectCodePoint(codePoint);
     const size = Buffer.byteLength(canonical, 'utf8');
     if (bytes + size > USAGE_PROJECTION_TEXT_MAX_BYTES) break;
     projected += canonical;
     bytes += size;
   }
   return projected || '\ufffd';
+}
+
+function projectCodePoint(codePoint: string): string {
+  const scalar = codePoint.codePointAt(0);
+  return scalar !== undefined && (scalar <= 0x1f || (scalar >= 0x7f && scalar <= 0x9f))
+    ? '\ufffd'
+    : codePoint;
 }
 
 function jsonBytes(value: unknown): number {

--- a/packages/runtime-host/src/server/usage-pricing-coordinator.ts
+++ b/packages/runtime-host/src/server/usage-pricing-coordinator.ts
@@ -1,0 +1,475 @@
+import type {
+  PricingConfig,
+  ToolInvocationRecord,
+  UsageBucket,
+  UsageLogRow,
+} from '@maka/core/usage-stats/types';
+import {
+  authenticateInteractiveUsageStoresWriter,
+  classifyInteractiveUsageStoresFailure,
+  type InteractiveUsageStoresFailureClassification,
+  type InteractiveUsageStoresWriter,
+} from '@maka/storage/usage-stores';
+import {
+  encodePricingQueryResult,
+  encodeUsageQueryResult,
+  PRICING_PAGE_MAX_BYTES,
+  PRICING_PAGE_MAX_ITEMS,
+  USAGE_PAGE_MAX_BYTES,
+  USAGE_PAGE_MAX_ITEMS,
+  USAGE_PROJECTION_TEXT_MAX_BYTES,
+  type OperationOutcome,
+  type PricingMutateInput,
+  type PricingQueryInput,
+  type PricingQueryResult,
+  type LlmUsageLogProjection,
+  type ToolUsageLogProjection,
+  type UsageLogProjection,
+  type UsageQueryInput,
+  type UsageQueryResult,
+} from '../protocol/index.js';
+import type { UsagePricingOperationHandlerMap } from './operation-dispatcher.js';
+
+/** Root-scoped projection over the authentic lease-bound usage stores. */
+export class HostUsagePricingCoordinator {
+  readonly handlers: UsagePricingOperationHandlerMap = {
+    'usage.query': (input) => this.#queryUsage(input),
+    'pricing.query': (input) => this.#queryPricing(input),
+    'pricing.mutate': (input) => this.#mutatePricing(input),
+  };
+
+  readonly #stores: InteractiveUsageStoresWriter;
+  readonly #requestDrain: () => void;
+  #poisonDrainRequested = false;
+
+  constructor(stores: InteractiveUsageStoresWriter, requestDrain: () => void) {
+    this.#stores = authenticateInteractiveUsageStoresWriter(stores);
+    this.#requestDrain = requestDrain;
+  }
+
+  async #queryUsage(input: UsageQueryInput): Promise<OperationOutcome<'usage.query'>> {
+    try {
+      if (input.kind === 'summary') {
+        return {
+          ok: true,
+          result: encodeUsageQueryResult({
+            kind: 'summary',
+            summary: await this.#stores.telemetry.summary(input.query),
+          }),
+        };
+      }
+      if (input.kind === 'buckets') {
+        const offset = input.offset ?? 0;
+        const limit = input.limit ?? USAGE_PAGE_MAX_ITEMS;
+        const buckets = await this.#stores.telemetry.buckets(input.query, input.groupBy);
+        if (offset > buckets.length) return invalidUsageOffset();
+        return {
+          ok: true,
+          result: encodeUsageQueryResult(
+            usagePage('buckets', buckets.map(projectUsageBucket), buckets.length, offset, limit),
+          ),
+        };
+      }
+      const offset = input.offset ?? 0;
+      const limit = input.limit ?? USAGE_PAGE_MAX_ITEMS;
+      if (input.source === 'tool') {
+        const page = await this.#stores.telemetry.toolLogs(input.query, offset, limit);
+        if (offset > page.total) return invalidUsageOffset();
+        return {
+          ok: true,
+          result: encodeUsageQueryResult(
+            usageLogPage('tool', page.rows.map(projectToolUsageLog), page.total, offset, limit),
+          ),
+        };
+      }
+      const page = await this.#stores.telemetry.logs(input.query, offset, limit);
+      if (offset > page.total) return invalidUsageOffset();
+      return {
+        ok: true,
+        result: encodeUsageQueryResult(
+          usageLogPage('llm', page.rows.map(projectUsageLog), page.total, offset, limit),
+        ),
+      };
+    } catch (error) {
+      return this.#mapReadFailure<'usage.query'>(error, 'Usage authority');
+    }
+  }
+
+  async #queryPricing(input: PricingQueryInput): Promise<OperationOutcome<'pricing.query'>> {
+    try {
+      const snapshot = await this.#stores.pricing.snapshot();
+      if (input.kind === 'continue' && input.revision !== snapshot.revision) {
+        return {
+          ok: true,
+          result: encodePricingQueryResult({
+            kind: 'revision_changed',
+            expectedRevision: input.revision,
+            actualRevision: snapshot.revision,
+          }),
+        };
+      }
+      const offset = input.kind === 'start' ? 0 : input.offset;
+      if (
+        offset > snapshot.overrides.length ||
+        (input.kind === 'continue' && offset === snapshot.overrides.length)
+      ) {
+        return {
+          ok: false,
+          error: { code: 'invalid_request', message: 'Pricing offset is invalid' },
+        };
+      }
+      return {
+        ok: true,
+        result: createPricingPage(snapshot.revision, snapshot.overrides, offset),
+      };
+    } catch (error) {
+      return this.#mapReadFailure<'pricing.query'>(error, 'Pricing authority');
+    }
+  }
+
+  async #mutatePricing(input: PricingMutateInput): Promise<OperationOutcome<'pricing.mutate'>> {
+    try {
+      const stored =
+        input.mutation.kind === 'upsert'
+          ? await this.#stores.pricing.upsert(input.expectedRevision, input.mutation.pricing)
+          : await this.#stores.pricing.delete(input.expectedRevision, input.mutation.modelKey);
+      return {
+        ok: true,
+        result: {
+          kind: stored.changed ? 'committed' : 'unchanged',
+          revision: stored.snapshot.revision,
+        },
+      };
+    } catch (error) {
+      return this.#mapMutationFailure(classifyInteractiveUsageStoresFailure(error));
+    }
+  }
+
+  #mapMutationFailure(
+    failure: InteractiveUsageStoresFailureClassification,
+  ): OperationOutcome<'pricing.mutate'> {
+    switch (failure.kind) {
+      case 'revision_conflict':
+        return {
+          ok: true,
+          result: {
+            kind: 'revision_conflict',
+            expectedRevision: failure.expectedRevision,
+            actualRevision: failure.actualRevision,
+          },
+        };
+      case 'invalid_request':
+        return {
+          ok: false,
+          error: { code: 'invalid_request', message: 'Pricing mutation is invalid' },
+        };
+      case 'lifecycle':
+        return {
+          ok: false,
+          error: { code: 'host_draining', message: 'Runtime Host is draining' },
+        };
+      case 'commit_outcome_unknown':
+        this.#requestPoisonDrain();
+        return {
+          ok: false,
+          error: {
+            code: 'commit_outcome_unknown',
+            message: 'Pricing mutation commit outcome is unknown',
+          },
+        };
+      case 'persistence_failed':
+        if (failure.needsDrain) this.#requestPoisonDrain();
+        return {
+          ok: false,
+          error: {
+            code: 'persistence_failed',
+            message: 'Pricing authority persistence failed',
+          },
+        };
+      case 'unknown':
+        throw failure.error;
+    }
+  }
+
+  #mapReadFailure<K extends 'usage.query' | 'pricing.query'>(
+    error: unknown,
+    authority: string,
+  ): OperationOutcome<K> {
+    const failure = classifyInteractiveUsageStoresFailure(error);
+    switch (failure.kind) {
+      case 'invalid_request':
+        return {
+          ok: false,
+          error: { code: 'invalid_request', message: `${authority} request is invalid` },
+        } as OperationOutcome<K>;
+      case 'lifecycle':
+        return {
+          ok: false,
+          error: { code: 'host_draining', message: 'Runtime Host is draining' },
+        } as OperationOutcome<K>;
+      case 'commit_outcome_unknown':
+        this.#requestPoisonDrain();
+        return {
+          ok: false,
+          error: { code: 'persistence_failed', message: `${authority} persistence failed` },
+        } as OperationOutcome<K>;
+      case 'persistence_failed':
+        if (failure.needsDrain) this.#requestPoisonDrain();
+        return {
+          ok: false,
+          error: { code: 'persistence_failed', message: `${authority} persistence failed` },
+        } as OperationOutcome<K>;
+      case 'revision_conflict':
+        throw error;
+      case 'unknown':
+        throw failure.error;
+    }
+  }
+
+  #requestPoisonDrain(): void {
+    if (this.#poisonDrainRequested) return;
+    this.#poisonDrainRequested = true;
+    this.#requestDrain();
+  }
+}
+
+function invalidUsageOffset(): OperationOutcome<'usage.query'> {
+  return {
+    ok: false,
+    error: { code: 'invalid_request', message: 'Usage offset is invalid' },
+  };
+}
+
+function createPricingPage(
+  revision: number,
+  overrides: readonly Readonly<PricingConfig>[],
+  offset: number,
+): PricingQueryResult {
+  const items: Readonly<PricingConfig>[] = [];
+  for (let index = offset; index < overrides.length; index += 1) {
+    if (items.length >= PRICING_PAGE_MAX_ITEMS) break;
+    const item = overrides[index];
+    if (!item) break;
+    const candidate = [...items, item];
+    const nextOffset = offset + candidate.length;
+    const page: PricingQueryResult = {
+      kind: 'page',
+      revision,
+      offset,
+      overrides: candidate,
+      nextOffset: nextOffset < overrides.length ? nextOffset : null,
+    };
+    if (jsonBytes(page) > PRICING_PAGE_MAX_BYTES) {
+      if (items.length === 0) {
+        throw new Error('Canonical pricing override exceeds the wire page limit');
+      }
+      break;
+    }
+    items.push(item);
+  }
+  const nextOffset = offset + items.length;
+  return encodePricingQueryResult({
+    kind: 'page',
+    revision,
+    offset,
+    overrides: items,
+    nextOffset: nextOffset < overrides.length ? nextOffset : null,
+  });
+}
+
+function usagePage(
+  kind: 'buckets',
+  allItems: readonly UsageBucket[],
+  total: number,
+  offset: number,
+  limit: number,
+): Extract<UsageQueryResult, { kind: 'buckets' }>;
+function usagePage(
+  kind: 'buckets',
+  allItems: readonly UsageBucket[],
+  total: number,
+  offset: number,
+  limit: number,
+): Extract<UsageQueryResult, { kind: 'buckets' }> {
+  const source = allItems.slice(offset, offset + limit);
+  const items: UsageBucket[] = [];
+  for (const item of source) {
+    const candidate = [...items, item];
+    const nextOffset = offset + candidate.length;
+    if (
+      jsonBytes(
+        bucketPageResult(candidate, total, offset, nextOffset < total ? nextOffset : null),
+      ) > USAGE_PAGE_MAX_BYTES
+    ) {
+      break;
+    }
+    items.push(item);
+  }
+  if (items.length === 0 && offset < total) {
+    throw new Error('Canonical usage item exceeds the wire page limit');
+  }
+  const nextOffset = offset + items.length;
+  return bucketPageResult(items, total, offset, nextOffset < total ? nextOffset : null);
+}
+
+function bucketPageResult(
+  items: readonly UsageBucket[],
+  total: number,
+  offset: number,
+  nextOffset: number | null,
+): Extract<UsageQueryResult, { kind: 'buckets' }> {
+  return { kind: 'buckets', buckets: items, offset, total, nextOffset };
+}
+
+function usageLogPage(
+  source: 'llm',
+  allItems: readonly LlmUsageLogProjection[],
+  total: number,
+  offset: number,
+  limit: number,
+): Extract<UsageQueryResult, { kind: 'logs'; source: 'llm' }>;
+function usageLogPage(
+  source: 'tool',
+  allItems: readonly ToolUsageLogProjection[],
+  total: number,
+  offset: number,
+  limit: number,
+): Extract<UsageQueryResult, { kind: 'logs'; source: 'tool' }>;
+function usageLogPage(
+  source: 'llm' | 'tool',
+  allItems: readonly UsageLogProjection[],
+  total: number,
+  offset: number,
+  limit: number,
+): Extract<UsageQueryResult, { kind: 'logs' }> {
+  const items: UsageLogProjection[] = [];
+  for (const item of allItems.slice(0, limit)) {
+    const candidate = [...items, item];
+    const nextOffset = offset + candidate.length;
+    if (
+      jsonBytes(
+        logPageResult(source, candidate, total, offset, nextOffset < total ? nextOffset : null),
+      ) > USAGE_PAGE_MAX_BYTES
+    ) {
+      break;
+    }
+    items.push(item);
+  }
+  if (items.length === 0 && offset < total) {
+    throw new Error('Canonical usage item exceeds the wire page limit');
+  }
+  const nextOffset = offset + items.length;
+  return logPageResult(source, items, total, offset, nextOffset < total ? nextOffset : null);
+}
+
+function logPageResult(
+  source: 'llm' | 'tool',
+  rows: readonly UsageLogProjection[],
+  total: number,
+  offset: number,
+  nextOffset: number | null,
+): Extract<UsageQueryResult, { kind: 'logs' }> {
+  return { kind: 'logs', source, rows, offset, total, nextOffset } as Extract<
+    UsageQueryResult,
+    { kind: 'logs' }
+  >;
+}
+
+function projectUsageBucket(bucket: UsageBucket): UsageBucket {
+  return {
+    ...bucket,
+    key: projectText(bucket.key),
+    label: projectText(bucket.label),
+  };
+}
+
+function projectUsageLog(row: UsageLogRow): LlmUsageLogProjection {
+  const cacheMissInputSource = (row as UsageLogRow & { readonly cacheMissInputSource?: unknown })
+    .cacheMissInputSource;
+  return {
+    source: 'llm',
+    id: projectText(row.id),
+    ts: row.ts,
+    ...(row.callKind === undefined ? {} : { callKind: row.callKind }),
+    ...(row.callId === undefined ? {} : { callId: projectText(row.callId) }),
+    ...(row.connectionSlug === undefined
+      ? {}
+      : { connectionSlug: projectText(row.connectionSlug) }),
+    providerId: projectText(row.providerId),
+    modelId: projectText(row.modelId),
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    cacheMissTokens: row.cacheMissTokens,
+    cacheReadTokens: row.cacheReadTokens,
+    cacheWriteTokens: row.cacheWriteTokens,
+    ...(cacheMissInputSource === 'explicit' || cacheMissInputSource === 'derived'
+      ? { cacheMissInputSource }
+      : {}),
+    reasoningTokens: row.reasoningTokens,
+    totalTokens: row.totalTokens,
+    costUsd: row.costUsd,
+    latencyMs: row.latencyMs,
+    status: row.status,
+    ...(row.errorClass === undefined ? {} : { errorClass: projectText(row.errorClass) }),
+    ...(row.sessionId === undefined ? {} : { sessionId: projectText(row.sessionId) }),
+    ...(row.turnId === undefined ? {} : { turnId: projectText(row.turnId) }),
+  };
+}
+
+function projectToolUsageLog(
+  row: ToolInvocationRecord & {
+    readonly id: string;
+    readonly bytesIn: number;
+    readonly bytesOut: number;
+    readonly ts: number;
+  },
+): ToolUsageLogProjection {
+  return {
+    source: 'tool',
+    id: projectText(row.id),
+    ts: row.ts,
+    ...(row.toolCallId === undefined ? {} : { toolCallId: projectText(row.toolCallId) }),
+    toolName: projectText(row.toolName),
+    ...(row.providerId === undefined ? {} : { providerId: projectText(row.providerId) }),
+    ...(row.modelId === undefined ? {} : { modelId: projectText(row.modelId) }),
+    durationMs: row.durationMs,
+    status: row.status,
+    ...(row.errorClass === undefined ? {} : { errorClass: projectText(row.errorClass) }),
+    ...(row.argsSummary === undefined ? {} : { argsSummary: projectText(row.argsSummary) }),
+    ...(row.resultSummary === undefined
+      ? {}
+      : {
+          resultSummary: {
+            ...row.resultSummary,
+            kind: projectText(row.resultSummary.kind),
+            ...(row.resultSummary.status === undefined
+              ? {}
+              : { status: projectText(row.resultSummary.status) }),
+          },
+        }),
+    bytesIn: row.bytesIn,
+    bytesOut: row.bytesOut,
+    startedAt: row.startedAt,
+    ...(row.sessionId === undefined ? {} : { sessionId: projectText(row.sessionId) }),
+    ...(row.turnId === undefined ? {} : { turnId: projectText(row.turnId) }),
+  };
+}
+
+function projectText(value: string): string {
+  let projected = '';
+  let bytes = 0;
+  for (const codePoint of value) {
+    const scalar = codePoint.codePointAt(0);
+    const canonical =
+      scalar !== undefined && (scalar <= 0x1f || scalar === 0x7f) ? '\ufffd' : codePoint;
+    const size = Buffer.byteLength(canonical, 'utf8');
+    if (bytes + size > USAGE_PROJECTION_TEXT_MAX_BYTES) break;
+    projected += canonical;
+    bytes += size;
+  }
+  return projected || '\ufffd';
+}
+
+function jsonBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}

--- a/packages/runtime/src/__tests__/cost.test.ts
+++ b/packages/runtime/src/__tests__/cost.test.ts
@@ -3,7 +3,8 @@ import { describe, test } from 'node:test';
 
 import { computeCost } from '../telemetry/cost.js';
 import { recordLlmCall } from '../telemetry/record-llm-call.js';
-import type { PersistedLlmCallRecord } from '../telemetry/types.js';
+import { recordToolInvocation } from '../telemetry/record-tool-invocation.js';
+import type { PersistedLlmCallRecord, PersistedToolInvocationRecord } from '../telemetry/types.js';
 
 describe('computeCost', () => {
   test('charges full input price only for cache-miss input', () => {
@@ -78,13 +79,13 @@ describe('recordLlmCall', () => {
   test('preserves a runtime-provided cost fact instead of recomputing it', async () => {
     const inserted: PersistedLlmCallRecord[] = [];
 
-    recordLlmCall(
+    await recordLlmCall(
       {
         repo: {
-          insertLlmCall: (record) => {
+          insertLlmCall: async (record) => {
             inserted.push(record);
           },
-          insertToolInvocation: () => {},
+          insertToolInvocation: async () => {},
         },
         lookupPricing: () => {
           throw new Error('lookup should not run when costUsd is already present');
@@ -103,8 +104,226 @@ describe('recordLlmCall', () => {
       },
     );
 
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
     assert.equal(inserted[0]?.costUsd, 0.123);
+  });
+
+  test('settles only after publication and preserves main token fields and diagnostics', async () => {
+    let publish!: () => void;
+    const publication = new Promise<void>((resolve) => {
+      publish = resolve;
+    });
+    const inserted: PersistedLlmCallRecord[] = [];
+    let settled = false;
+
+    const recording = recordLlmCall(
+      {
+        repo: {
+          insertLlmCall: (record) => {
+            inserted.push(record);
+            return publication;
+          },
+          insertToolInvocation: async () => {},
+        },
+        lookupPricing: () => null,
+      },
+      {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        callKind: 'semantic_compact',
+        callId: 'compact-1',
+        connectionSlug: 'connection-1',
+        providerId: 'anthropic',
+        modelId: 'claude',
+        inputTokens: 20,
+        outputTokens: 8,
+        cacheHitInputTokens: 7,
+        cachedInputTokens: 6,
+        cacheWriteInputTokens: 3,
+        reasoningTokens: 2,
+        totalTokens: 30,
+        rawFinishReason: 'stop',
+        rawUsage: {
+          prompt_tokens: 20,
+          completion_tokens: 8,
+          total_tokens: 28,
+          prompt_cache_hit_tokens: 7,
+          prompt_cache_miss_tokens: 10,
+          prompt_tokens_details: { cached_tokens: 7 },
+          completion_tokens_details: { reasoning_tokens: 2 },
+        },
+        latencyMs: 5,
+        status: 'success',
+        startedAt: 100,
+        systemPromptHash: 'system-hash',
+        prefixHash: 'prefix-hash',
+        prefixChangeReason: 'first_turn',
+        requestShapeHash: 'request-hash',
+        requestShapeChangeReason: 'tool_schema_changed',
+        toolSchemaChangeReason: 'tool_source_enabled',
+        promptSegments: [{ kind: 'system_prompt', chars: 40, estimatedTokens: 10 }],
+        contextBudget: {
+          enabled: true,
+          estimatedTokensBefore: 30,
+          estimatedTokensAfter: 20,
+          keptTurns: 2,
+          droppedTurns: 1,
+          keptEvents: 4,
+          droppedEvents: 2,
+        },
+      },
+    );
+    const settlement = recording.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+
+    assert.equal(settled, false);
+    assert.equal(inserted[0]?.id, 'usage_compact-1');
+    assert.equal(inserted[0]?.cacheHitInputTokens, 7);
+    assert.equal(inserted[0]?.cachedInputTokens, 7);
+    assert.equal(inserted[0]?.cacheMissInputTokens, 10);
+    assert.equal(inserted[0]?.cacheMissInputSource, 'derived');
+    assert.equal(inserted[0]?.cacheWriteInputTokens, 3);
+    assert.equal(inserted[0]?.reasoningTokens, 2);
+    assert.equal(inserted[0]?.totalTokens, 30);
+    assert.deepEqual(inserted[0]?.rawUsage, {
+      prompt_tokens: 20,
+      completion_tokens: 8,
+      total_tokens: 28,
+      prompt_cache_hit_tokens: 7,
+      prompt_cache_miss_tokens: 10,
+      prompt_tokens_details: { cached_tokens: 7 },
+      completion_tokens_details: { reasoning_tokens: 2 },
+    });
+    assert.deepEqual(inserted[0]?.promptSegments, [
+      { kind: 'system_prompt', chars: 40, estimatedTokens: 10 },
+    ]);
+    assert.equal(inserted[0]?.contextBudget?.droppedEvents, 2);
+    assert.equal(inserted[0]?.toolSchemaChangeReason, 'tool_source_enabled');
+
+    publish();
+    await settlement;
+    assert.equal(settled, true);
+  });
+
+  test('contains writer failures at the best-effort telemetry boundary', async () => {
+    const messages: string[] = [];
+    const originalConsoleError = console.error;
+    console.error = (message?: unknown) => {
+      messages.push(String(message));
+    };
+    try {
+      await assert.doesNotReject(() =>
+        recordLlmCall(
+          {
+            repo: {
+              insertLlmCall: async () => {
+                throw new Error('publication failed');
+              },
+              insertToolInvocation: async () => {},
+            },
+            lookupPricing: () => null,
+          },
+          {
+            providerId: 'openai',
+            modelId: 'gpt-5',
+            inputTokens: 1,
+            outputTokens: 1,
+            latencyMs: 1,
+            status: 'success',
+            startedAt: 1,
+          },
+        ),
+      );
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    assert.equal(messages.length, 1);
+    assert.match(messages[0] ?? '', /^\[telemetry\] recordLlmCall failed:/);
+  });
+});
+
+describe('recordToolInvocation', () => {
+  test('settles only after normalized record publication completes', async () => {
+    let publish!: () => void;
+    const publication = new Promise<void>((resolve) => {
+      publish = resolve;
+    });
+    const inserted: PersistedToolInvocationRecord[] = [];
+    let settled = false;
+
+    const recording = recordToolInvocation(
+      {
+        repo: {
+          insertLlmCall: async () => {},
+          insertToolInvocation: (record) => {
+            inserted.push(record);
+            return publication;
+          },
+        },
+      },
+      {
+        toolCallId: 'call-1',
+        toolName: 'Bash',
+        durationMs: 5,
+        status: 'success',
+        resultSummary: { kind: 'shell', status: 'completed', itemCount: 1 },
+        startedAt: 100,
+      },
+    );
+    const settlement = recording.then(() => {
+      settled = true;
+    });
+    await Promise.resolve();
+
+    assert.equal(settled, false);
+    assert.equal(inserted[0]?.id, 'tool_call-1');
+    assert.equal(inserted[0]?.ts, 105);
+    assert.equal(inserted[0]?.bytesIn, 0);
+    assert.equal(inserted[0]?.bytesOut, 0);
+    assert.deepEqual(inserted[0]?.resultSummary, {
+      kind: 'shell',
+      status: 'completed',
+      itemCount: 1,
+    });
+
+    publish();
+    await settlement;
+    assert.equal(settled, true);
+  });
+
+  test('contains writer failures at the best-effort telemetry boundary', async () => {
+    const messages: string[] = [];
+    const originalConsoleError = console.error;
+    console.error = (message?: unknown) => {
+      messages.push(String(message));
+    };
+    try {
+      await assert.doesNotReject(() =>
+        recordToolInvocation(
+          {
+            repo: {
+              insertLlmCall: async () => {},
+              insertToolInvocation: async () => {
+                throw new Error('publication failed');
+              },
+            },
+          },
+          {
+            toolCallId: 'call-failed',
+            toolName: 'Read',
+            durationMs: 2,
+            status: 'error',
+            startedAt: 100,
+          },
+        ),
+      );
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    assert.equal(messages.length, 1);
+    assert.match(messages[0] ?? '', /^\[telemetry\] recordToolInvocation failed:/);
   });
 });

--- a/packages/runtime/src/telemetry/record-llm-call.ts
+++ b/packages/runtime/src/telemetry/record-llm-call.ts
@@ -9,53 +9,51 @@ export interface LlmRecorderDeps {
   lookupPricing: (modelKey: string) => PricingConfig | null;
 }
 
-export function recordLlmCall(deps: LlmRecorderDeps, record: LlmCallRecord): void {
-  queueMicrotask(() => {
-    try {
-      const cacheHitInputTokens = record.cacheHitInputTokens ?? record.cachedInputTokens ?? 0;
-      const cacheWriteInputTokens = record.cacheWriteInputTokens ?? 0;
-      const derivedCacheMissInputTokens = record.cacheMissInputTokens === undefined;
-      const cacheMissInputTokens =
-        record.cacheMissInputTokens ??
-        Math.max(0, record.inputTokens - cacheHitInputTokens - cacheWriteInputTokens);
-      const cacheMissInputSource =
-        record.cacheMissInputSource ?? (derivedCacheMissInputTokens ? 'derived' : undefined);
-      const cachedInputTokens = cacheHitInputTokens;
-      const reasoningTokens = record.reasoningTokens ?? 0;
-      const totalTokens =
-        record.totalTokens ?? record.inputTokens + record.outputTokens + reasoningTokens;
-      const costUsd =
-        record.costUsd ??
-        computeCost(
-          {
-            inputTokens: record.inputTokens,
-            outputTokens: record.outputTokens,
-            cacheHitInputTokens,
-            cacheMissInputTokens,
-            cacheWriteInputTokens,
-          },
-          deps.lookupPricing(`${record.providerId}:${record.modelId}`),
-        ).totalCost;
-      const ts = record.startedAt + record.latencyMs;
-      const recordId = record.callId
-        ? `usage_${record.callId}`
-        : `usage_${record.turnId ?? randomUUID()}`;
-      deps.repo.insertLlmCall({
-        ...record,
-        id: recordId,
-        cacheHitInputTokens,
-        cacheMissInputTokens,
-        ...(cacheMissInputSource !== undefined ? { cacheMissInputSource } : {}),
-        cachedInputTokens,
-        cacheWriteInputTokens,
-        reasoningTokens,
-        totalTokens,
-        costUsd,
-        date: new Date(ts).toISOString().slice(0, 10),
-        ts,
-      });
-    } catch (error) {
-      console.error(`[telemetry] recordLlmCall failed: ${generalizedErrorMessage(error)}`);
-    }
-  });
+export async function recordLlmCall(deps: LlmRecorderDeps, record: LlmCallRecord): Promise<void> {
+  try {
+    const cacheHitInputTokens = record.cacheHitInputTokens ?? record.cachedInputTokens ?? 0;
+    const cacheWriteInputTokens = record.cacheWriteInputTokens ?? 0;
+    const derivedCacheMissInputTokens = record.cacheMissInputTokens === undefined;
+    const cacheMissInputTokens =
+      record.cacheMissInputTokens ??
+      Math.max(0, record.inputTokens - cacheHitInputTokens - cacheWriteInputTokens);
+    const cacheMissInputSource =
+      record.cacheMissInputSource ?? (derivedCacheMissInputTokens ? 'derived' : undefined);
+    const cachedInputTokens = cacheHitInputTokens;
+    const reasoningTokens = record.reasoningTokens ?? 0;
+    const totalTokens =
+      record.totalTokens ?? record.inputTokens + record.outputTokens + reasoningTokens;
+    const costUsd =
+      record.costUsd ??
+      computeCost(
+        {
+          inputTokens: record.inputTokens,
+          outputTokens: record.outputTokens,
+          cacheHitInputTokens,
+          cacheMissInputTokens,
+          cacheWriteInputTokens,
+        },
+        deps.lookupPricing(`${record.providerId}:${record.modelId}`),
+      ).totalCost;
+    const ts = record.startedAt + record.latencyMs;
+    const recordId = record.callId
+      ? `usage_${record.callId}`
+      : `usage_${record.turnId ?? randomUUID()}`;
+    await deps.repo.insertLlmCall({
+      ...record,
+      id: recordId,
+      cacheHitInputTokens,
+      cacheMissInputTokens,
+      ...(cacheMissInputSource !== undefined ? { cacheMissInputSource } : {}),
+      cachedInputTokens,
+      cacheWriteInputTokens,
+      reasoningTokens,
+      totalTokens,
+      costUsd,
+      date: new Date(ts).toISOString().slice(0, 10),
+      ts,
+    });
+  } catch (error) {
+    console.error(`[telemetry] recordLlmCall failed: ${generalizedErrorMessage(error)}`);
+  }
 }

--- a/packages/runtime/src/telemetry/record-tool-invocation.ts
+++ b/packages/runtime/src/telemetry/record-tool-invocation.ts
@@ -9,23 +9,24 @@ export interface ToolRecorderDeps {
   repo: TelemetryRepoLite;
 }
 
-export function recordToolInvocation(deps: ToolRecorderDeps, record: ToolInvocationRecord): void {
-  queueMicrotask(() => {
-    try {
-      const ts = record.startedAt + record.durationMs;
-      deps.repo.insertToolInvocation({
-        ...record,
-        id: `tool_${record.toolCallId ?? randomUUID()}`,
-        argsSummary: truncate(record.argsSummary ?? ''),
-        bytesIn: record.bytesIn ?? 0,
-        bytesOut: record.bytesOut ?? 0,
-        date: new Date(ts).toISOString().slice(0, 10),
-        ts,
-      });
-    } catch (error) {
-      console.error(`[telemetry] recordToolInvocation failed: ${generalizedErrorMessage(error)}`);
-    }
-  });
+export async function recordToolInvocation(
+  deps: ToolRecorderDeps,
+  record: ToolInvocationRecord,
+): Promise<void> {
+  try {
+    const ts = record.startedAt + record.durationMs;
+    await deps.repo.insertToolInvocation({
+      ...record,
+      id: `tool_${record.toolCallId ?? randomUUID()}`,
+      argsSummary: truncate(record.argsSummary ?? ''),
+      bytesIn: record.bytesIn ?? 0,
+      bytesOut: record.bytesOut ?? 0,
+      date: new Date(ts).toISOString().slice(0, 10),
+      ts,
+    });
+  } catch (error) {
+    console.error(`[telemetry] recordToolInvocation failed: ${generalizedErrorMessage(error)}`);
+  }
 }
 
 function truncate(value: string): string {

--- a/packages/runtime/src/telemetry/types.ts
+++ b/packages/runtime/src/telemetry/types.ts
@@ -1,8 +1,8 @@
 import type { LlmCallRecord, ToolInvocationRecord } from '@maka/core/usage-stats/types';
 
 export interface TelemetryRepoLite {
-  insertLlmCall(record: PersistedLlmCallRecord): void;
-  insertToolInvocation(record: PersistedToolInvocationRecord): void;
+  insertLlmCall(record: PersistedLlmCallRecord): Promise<void>;
+  insertToolInvocation(record: PersistedToolInvocationRecord): Promise<void>;
 }
 
 export type PersistedLlmCallRecord = LlmCallRecord & {

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,9 +12,11 @@
     "./execution-stores": "./dist/execution-stores.js",
     "./agent-graph-control-store": "./dist/agent-graph-control-store.js",
     "./interaction-store": "./dist/interaction-store.js",
+    "./pricing-store": "./dist/pricing-store.js",
     "./root-authority": "./dist/root-authority.js",
     "./runtime-policy-stores": "./dist/runtime-policy-stores.js",
     "./task-ledger-authority": "./dist/task-ledger-authority.js",
+    "./usage-stores": "./dist/usage-stores.js",
     "./workspace-identity": "./dist/workspace-identity.js",
     "./write-queue": "./dist/write-queue.js"
   },

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,7 +12,6 @@
     "./execution-stores": "./dist/execution-stores.js",
     "./agent-graph-control-store": "./dist/agent-graph-control-store.js",
     "./interaction-store": "./dist/interaction-store.js",
-    "./pricing-store": "./dist/pricing-store.js",
     "./root-authority": "./dist/root-authority.js",
     "./runtime-policy-stores": "./dist/runtime-policy-stores.js",
     "./task-ledger-authority": "./dist/task-ledger-authority.js",

--- a/packages/storage/src/__tests__/pricing-store.test.ts
+++ b/packages/storage/src/__tests__/pricing-store.test.ts
@@ -12,6 +12,44 @@ import {
 } from '../pricing-store.js';
 
 describe('PricingStore', () => {
+  test('single-flights concurrent load and allows retry after failure', async () => {
+    await withRoot(async (root) => {
+      const path = join(root, 'pricing.json');
+      await writeFile(path, '{');
+      const store = createPricingStore(root);
+
+      const first = store.load();
+      const concurrent = store.load();
+      assert.equal(concurrent, first);
+      await assert.rejects(() => first, SyntaxError);
+
+      await writeFile(
+        path,
+        JSON.stringify({ version: 1, revision: 0, overrides: [] }, null, 2) + '\n',
+      );
+      await store.load();
+      assert.deepEqual(store.snapshot(), { revision: 0, overrides: [] });
+      await store.close();
+    });
+  });
+
+  test('close joins a load started in the same tick', async () => {
+    await withRoot(async (root) => {
+      const store = createPricingStore(root);
+
+      let loadSettled = false;
+      const load = store.load().finally(() => {
+        loadSettled = true;
+      });
+      await store.close();
+      assert.equal(loadSettled, true);
+      await load;
+
+      assert.match(await readFile(join(root, 'pricing.json'), 'utf8'), /"version": 1/);
+      assert.throws(() => store.snapshot(), /draining or closed/);
+    });
+  });
+
   test('serializes revision CAS so only one mutation at a revision commits', async () => {
     await withRoot(async (root) => {
       const store = createPricingStore(root);

--- a/packages/storage/src/__tests__/pricing-store.test.ts
+++ b/packages/storage/src/__tests__/pricing-store.test.ts
@@ -1,0 +1,233 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, open, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, mock, test } from 'node:test';
+import {
+  createPricingStore,
+  PricingCommitUnknownError,
+  PricingRevisionConflictError,
+  PricingStorePublicationError,
+  PricingValidationError,
+} from '../pricing-store.js';
+
+describe('PricingStore', () => {
+  test('serializes revision CAS so only one mutation at a revision commits', async () => {
+    await withRoot(async (root) => {
+      const store = createPricingStore(root);
+      await store.load();
+
+      const results = await Promise.allSettled([
+        store.upsert(0, pricing('openai:gpt-5')),
+        store.upsert(0, pricing('anthropic:claude')),
+      ]);
+
+      assert.equal(results.filter((result) => result.status === 'fulfilled').length, 1);
+      const rejected = results.find((result) => result.status === 'rejected');
+      assert(rejected?.status === 'rejected');
+      assert(rejected.reason instanceof PricingRevisionConflictError);
+      assert.equal(rejected.reason.actualRevision, 1);
+      assert.equal(store.snapshot().revision, 1);
+      await store.close();
+    });
+  });
+
+  test('rejects invalid values without advancing revision', async () => {
+    await withRoot(async (root) => {
+      const store = createPricingStore(root);
+      await store.load();
+
+      assert.throws(
+        () => store.upsert(0, { ...pricing('openai:gpt-5'), inputUsdPer1M: -1 }),
+        PricingValidationError,
+      );
+      assert.equal(store.snapshot().revision, 0);
+      await store.close();
+    });
+  });
+
+  test('persists a stable revision document and reloads it', async () => {
+    await withRoot(async (root) => {
+      const first = createPricingStore(root);
+      await first.load();
+      await first.upsert(0, pricing('openai:gpt-5'));
+      await first.close();
+
+      const second = createPricingStore(root);
+      await second.load();
+      assert.deepEqual(second.snapshot(), {
+        revision: 1,
+        overrides: [pricing('openai:gpt-5')],
+      });
+      assert.match(await readFile(join(root, 'pricing.json'), 'utf8'), /"revision": 1/);
+      await second.close();
+    });
+  });
+
+  test('normalizes mutation input and uses canonical equality for no-op detection', async () => {
+    await withRoot(async (root) => {
+      const store = createPricingStore(root);
+      await store.load();
+      const first = await store.upsert(0, {
+        ...pricing(' openai:gpt-5 '),
+        ignored: true,
+      } as ReturnType<typeof pricing>);
+      assert.equal(first.changed, true);
+
+      const second = await store.upsert(1, pricing('openai:gpt-5'));
+      assert.equal(second.changed, false);
+      assert.equal(second.snapshot.revision, 1);
+      assert.deepEqual(second.snapshot.overrides, [pricing('openai:gpt-5')]);
+      assert.doesNotMatch(await readFile(join(root, 'pricing.json'), 'utf8'), /ignored/);
+      await store.close();
+    });
+  });
+
+  test('persists exact-distinct Unicode keys in shared comparator order across reopen', async () => {
+    await withRoot(async (root) => {
+      const composed = '\u00e9';
+      const decomposed = 'e\u0301';
+      const first = createPricingStore(root);
+      await first.load();
+      await first.upsert(0, pricing(composed));
+      await first.upsert(1, pricing(decomposed));
+      const snapshot = first.snapshot();
+      assert.deepEqual(
+        snapshot.overrides.map((item) => item.modelKey),
+        [decomposed, composed],
+      );
+      await first.close();
+
+      const before = await readFile(join(root, 'pricing.json'), 'utf8');
+      assert.deepEqual(
+        (JSON.parse(before) as { overrides: Array<{ modelKey: string }> }).overrides.map(
+          (item) => item.modelKey,
+        ),
+        [decomposed, composed],
+      );
+      const second = createPricingStore(root);
+      await second.load();
+      assert.deepEqual(second.snapshot(), snapshot);
+      await second.close();
+      assert.equal(await readFile(join(root, 'pricing.json'), 'utf8'), before);
+    });
+  });
+
+  test('rejects noncanonical and unsorted version 1 documents without rewriting them', async () => {
+    await withRoot(async (root) => {
+      const documents = [
+        {
+          version: 1,
+          revision: 0,
+          overrides: [{ ...pricing('openai:gpt-5'), unknown: true }],
+        },
+        {
+          version: 1,
+          revision: 0,
+          overrides: [pricing(' openai:gpt-5 ')],
+        },
+        {
+          version: 1,
+          revision: 0,
+          overrides: [pricing('z:model'), pricing('a:model')],
+        },
+      ];
+      for (const document of documents) {
+        const bytes = JSON.stringify(document, null, 2) + '\n';
+        await writeFile(join(root, 'pricing.json'), bytes);
+        const store = createPricingStore(root);
+        await assert.rejects(() => store.load(), PricingValidationError);
+        assert.equal(await readFile(join(root, 'pricing.json'), 'utf8'), bytes);
+      }
+    });
+  });
+
+  test('latches directory preparation failure across mutation, flush, and close', async () => {
+    await withRoot(async (root) => {
+      const store = createPricingStore(root);
+      await store.load();
+      await rm(root, { recursive: true });
+      await writeFile(root, 'not a directory');
+
+      const failure = await store.upsert(0, pricing('openai:gpt-5')).then(
+        () => undefined,
+        (error: unknown) => error,
+      );
+      assert(failure instanceof PricingStorePublicationError);
+      await assert.rejects(
+        () => store.flush(),
+        (error) => error === failure,
+      );
+      await assert.rejects(
+        () => store.close(),
+        (error) => error === failure,
+      );
+    });
+  });
+
+  test('poisons reads after rename succeeds but directory sync fails', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    await withRoot(async (root) => {
+      const store = createPricingStore(root);
+      await store.load();
+      const fault = new Error('injected pricing directory sync failure');
+      const probe = await open(root, 'r');
+      const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+        sync: typeof probe.sync;
+      };
+      const originalSync = fileHandlePrototype.sync;
+      await probe.close();
+      let injected = false;
+      const syncMock = mock.method(
+        fileHandlePrototype,
+        'sync',
+        async function (this: typeof probe) {
+          const metadata = await this.stat();
+          if (!injected && metadata.isDirectory()) {
+            injected = true;
+            throw fault;
+          }
+          return originalSync.call(this);
+        },
+      );
+      let failure: unknown;
+      try {
+        failure = await store.upsert(0, pricing('openai:gpt-5')).then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+      } finally {
+        syncMock.mock.restore();
+      }
+
+      assert(failure instanceof PricingCommitUnknownError);
+      assert.match(await readFile(join(root, 'pricing.json'), 'utf8'), /"revision": 1/);
+      assert.throws(
+        () => store.snapshot(),
+        (error) => error === failure,
+      );
+      await assert.rejects(
+        () => store.flush(),
+        (error) => error === failure,
+      );
+      await assert.rejects(
+        () => store.close(),
+        (error) => error === failure,
+      );
+    });
+  });
+});
+
+function pricing(modelKey: string) {
+  return { modelKey, inputUsdPer1M: 1.25, outputUsdPer1M: 10 };
+}
+
+async function withRoot(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-pricing-store-'));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}

--- a/packages/storage/src/__tests__/telemetry-repo.test.ts
+++ b/packages/storage/src/__tests__/telemetry-repo.test.ts
@@ -1,15 +1,15 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, open, readFile, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
-import { describe, test } from 'node:test';
-import { createTelemetryRepo } from '../telemetry-repo.js';
+import { describe, mock, test } from 'node:test';
+import { createTelemetryRepo, TelemetryRepoPublicationError } from '../telemetry-repo.js';
 
 describe('FileTelemetryRepo', () => {
   test('upserts LLM calls by id and aggregates the latest record', async () => {
     await withRepo(async (repo) => {
       await repo.load();
-      repo.insertLlmCall(
+      await repo.insertLlmCall(
         llmRecord({
           id: 'usage_turn_1',
           inputTokens: 10,
@@ -18,7 +18,7 @@ describe('FileTelemetryRepo', () => {
           totalTokens: 30,
         }),
       );
-      repo.insertLlmCall(
+      await repo.insertLlmCall(
         llmRecord({
           id: 'usage_turn_1',
           inputTokens: 30,
@@ -27,7 +27,6 @@ describe('FileTelemetryRepo', () => {
           totalTokens: 70,
         }),
       );
-      await flushWrites();
 
       const summary = repo.summary({ range: 'all' });
       const logs = repo.logs({ range: 'all' });
@@ -46,7 +45,7 @@ describe('FileTelemetryRepo', () => {
   test('carries the tool-availability diagnostic and tool-schema change reason through logs()', async () => {
     await withRepo(async (repo) => {
       await repo.load();
-      repo.insertLlmCall(
+      await repo.insertLlmCall(
         llmRecord({
           id: 'usage_diag',
           systemPromptHash: 'sys-hash',
@@ -61,7 +60,6 @@ describe('FileTelemetryRepo', () => {
           },
         }),
       );
-      await flushWrites();
 
       const row = repo.logs({ range: 'all' }).rows[0];
       assert.equal(row?.systemPromptHash, 'sys-hash');
@@ -72,17 +70,106 @@ describe('FileTelemetryRepo', () => {
     });
   });
 
+  test('strictly admits current token aliases and diagnostic shapes', async () => {
+    await withRepo(async (repo) => {
+      await repo.load();
+      await repo.insertLlmCall(
+        llmRecord({
+          cachedInputTokens: 4,
+          cacheHitInputTokens: 4,
+          rawUsage: {
+            prompt_tokens: 10,
+            prompt_tokens_details: { cached_tokens: 4 },
+          },
+          promptSegments: [{ kind: 'system_prompt', chars: 12, estimatedTokens: 3 }],
+          contextBudget: {
+            enabled: true,
+            estimatedTokensBefore: 10,
+            estimatedTokensAfter: 8,
+            keptTurns: 1,
+            droppedTurns: 0,
+            keptEvents: 2,
+            droppedEvents: 0,
+          },
+        }),
+      );
+
+      assert.equal(repo.logs({ range: 'all' }).rows[0]?.cacheReadTokens, 4);
+    });
+  });
+
+  test('owns admitted records and returns detached frozen diagnostics', async () => {
+    await withRepo(async (repo, root) => {
+      await repo.load();
+      const record = llmRecord({
+        contextBudget: {
+          enabled: true,
+          estimatedTokensBefore: 10,
+          estimatedTokensAfter: 8,
+          keptTurns: 1,
+          droppedTurns: 0,
+          keptEvents: 2,
+          droppedEvents: 0,
+        },
+      });
+      const inserted = repo.insertLlmCall(record);
+      const callerContext = record.contextBudget as { keptTurns: number };
+      callerContext.keptTurns = 99;
+      record.inputTokens = 999;
+      await inserted;
+
+      const first = repo.logs({ range: 'all' }).rows[0];
+      assert.equal(repo.summary({ range: 'all' }).totalTokens.input, 10);
+      assert.equal(first?.contextBudget?.keptTurns, 1);
+      assert.equal(Object.isFrozen(first?.contextBudget), true);
+      assert.throws(() => {
+        (first?.contextBudget as { keptTurns: number }).keptTurns = 77;
+      }, TypeError);
+      assert.equal(repo.logs({ range: 'all' }).rows[0]?.contextBudget?.keptTurns, 1);
+      const bytes = await readFile(join(root, 'telemetry.json'), 'utf8');
+      assert.match(bytes, /"inputTokens": 10/);
+      assert.match(bytes, /"keptTurns": 1/);
+    });
+  });
+
+  test('rejects unknown fields and invalid diagnostics at writer admission', async () => {
+    await withRepo(async (repo) => {
+      await repo.load();
+      await assert.rejects(
+        () => repo.insertLlmCall(llmRecord({ unexpected: true })),
+        /invalid LLM row keys/,
+      );
+      await assert.rejects(
+        () =>
+          repo.insertLlmCall(
+            llmRecord({
+              contextBudget: {
+                enabled: 'yes',
+                estimatedTokensBefore: 1,
+                estimatedTokensAfter: 1,
+                keptTurns: 0,
+                droppedTurns: 0,
+                keptEvents: 0,
+                droppedEvents: 0,
+              },
+            }),
+          ),
+        /invalid contextBudget/,
+      );
+      assert.deepEqual(repo.logs({ range: 'all' }), { rows: [], total: 0 });
+    });
+  });
+
   test('carries auxiliary LLM call identity through logs()', async () => {
     await withRepo(async (repo) => {
       await repo.load();
-      repo.insertLlmCall(
+      await repo.insertLlmCall(
         llmRecord({
           id: 'usage_semantic_compact_turn_1_2_3',
           callKind: 'semantic_compact',
           callId: 'semantic_compact_turn_1_2_3',
         }),
       );
-      await flushWrites();
 
       const row = repo.logs({ range: 'all' }).rows[0];
       assert.equal(row?.callKind, 'semantic_compact');
@@ -93,10 +180,10 @@ describe('FileTelemetryRepo', () => {
   test('filters logs by range, status, provider, model, and pagination', async () => {
     await withRepo(async (repo) => {
       await repo.load();
-      repo.insertLlmCall(
+      await repo.insertLlmCall(
         llmRecord({ id: 'old', ts: 1, status: 'success', providerId: 'openai', modelId: 'gpt-4o' }),
       );
-      repo.insertLlmCall(
+      await repo.insertLlmCall(
         llmRecord({
           id: 'new-success',
           ts: 20,
@@ -105,7 +192,25 @@ describe('FileTelemetryRepo', () => {
           modelId: 'gpt-4o',
         }),
       );
-      repo.insertLlmCall(
+      await repo.insertLlmCall(
+        llmRecord({
+          id: 'middle-success',
+          ts: 15,
+          status: 'success',
+          providerId: 'openai',
+          modelId: 'gpt-4o',
+          contextBudget: {
+            enabled: true,
+            estimatedTokensBefore: 10,
+            estimatedTokensAfter: 8,
+            keptTurns: 1,
+            droppedTurns: 0,
+            keptEvents: 2,
+            droppedEvents: 0,
+          },
+        }),
+      );
+      await repo.insertLlmCall(
         llmRecord({
           id: 'new-error',
           ts: 30,
@@ -114,23 +219,36 @@ describe('FileTelemetryRepo', () => {
           modelId: 'claude',
         }),
       );
-      await flushWrites();
 
       const logs = repo.logs(
         { range: { from: 10, to: 40 }, status: 'success', providerId: 'openai', modelId: 'gpt-4o' },
-        0,
-        10,
+        1,
+        1,
       );
 
-      assert.equal(logs.total, 1);
-      assert.equal(logs.rows[0]?.id, 'new-success');
+      assert.equal(logs.total, 2);
+      assert.deepEqual(
+        logs.rows.map((row) => row.id),
+        ['middle-success'],
+      );
+      assert.equal(Object.isFrozen(logs), true);
+      assert.equal(Object.isFrozen(logs.rows), true);
+      assert.equal(Object.isFrozen(logs.rows[0]?.contextBudget), true);
+      assert.throws(() => {
+        (logs.rows[0]?.contextBudget as { keptTurns: number }).keptTurns = 99;
+      }, TypeError);
+      assert.equal(
+        repo.logs({ range: 'all' }).rows.find((row) => row.id === 'middle-success')?.contextBudget
+          ?.keptTurns,
+        1,
+      );
     });
   });
 
   test('filters and returns latest LLM runtime probes by connection slug', async () => {
     await withRepo(async (repo) => {
       await repo.load();
-      repo.insertLlmCall(
+      await repo.insertLlmCall(
         llmRecord({
           id: 'conn-a-old',
           connectionSlug: 'conn-a',
@@ -139,7 +257,7 @@ describe('FileTelemetryRepo', () => {
           status: 'success',
         }),
       );
-      repo.insertLlmCall(
+      await repo.insertLlmCall(
         llmRecord({
           id: 'conn-b-new',
           connectionSlug: 'conn-b',
@@ -148,7 +266,7 @@ describe('FileTelemetryRepo', () => {
           status: 'error',
         }),
       );
-      repo.insertLlmCall(
+      await repo.insertLlmCall(
         llmRecord({
           id: 'conn-a-new',
           connectionSlug: 'conn-a',
@@ -157,7 +275,6 @@ describe('FileTelemetryRepo', () => {
           status: 'aborted',
         }),
       );
-      await flushWrites();
 
       const logs = repo.logs({ range: 'all', connectionSlug: 'conn-a' });
       const latest = repo.latestLlmRuntimeProbe('conn-a', 'glm-4.7');
@@ -173,7 +290,7 @@ describe('FileTelemetryRepo', () => {
   test('builds provider, model, day, hour, and tool buckets', async () => {
     await withRepo(async (repo) => {
       await repo.load();
-      repo.insertLlmCall(
+      await repo.insertLlmCall(
         llmRecord({
           id: 'usage_1',
           providerId: 'openai',
@@ -182,7 +299,7 @@ describe('FileTelemetryRepo', () => {
           date: '2026-01-01',
         }),
       );
-      repo.insertLlmCall(
+      await repo.insertLlmCall(
         llmRecord({
           id: 'usage_2',
           providerId: 'openai',
@@ -191,13 +308,12 @@ describe('FileTelemetryRepo', () => {
           date: '2026-01-01',
         }),
       );
-      repo.insertToolInvocation(
+      await repo.insertToolInvocation(
         toolRecord({ id: 'tool_1', toolName: 'Bash', durationMs: 30, status: 'success' }),
       );
-      repo.insertToolInvocation(
+      await repo.insertToolInvocation(
         toolRecord({ id: 'tool_2', toolName: 'Bash', durationMs: 90, status: 'error' }),
       );
-      await flushWrites();
 
       assert.equal(repo.buckets({ range: 'all' }, 'provider')[0]?.key, 'openai');
       assert.equal(repo.buckets({ range: 'all' }, 'model').length, 2);
@@ -212,10 +328,57 @@ describe('FileTelemetryRepo', () => {
     });
   });
 
+  test('separates LLM and tool logs and rejects inapplicable filters', async () => {
+    await withRepo(async (repo) => {
+      await repo.load();
+      await repo.insertLlmCall(llmRecord());
+      await repo.insertToolInvocation(
+        toolRecord({
+          id: 'bash',
+          toolName: 'Bash',
+          resultSummary: { kind: 'shell', completedItemCount: 1 },
+        }),
+      );
+      await repo.insertToolInvocation(toolRecord({ id: 'read', toolName: 'Read' }));
+
+      assert.deepEqual(
+        repo.logs({ range: 'all' }).rows.map((row) => row.id),
+        ['usage_1'],
+      );
+      assert.deepEqual(
+        repo.toolLogs({ range: 'all', toolName: 'Bash' }).rows.map((row) => row.id),
+        ['bash'],
+      );
+      const toolResult = repo.toolLogs({ range: 'all', toolName: 'Bash' }).rows[0]?.resultSummary;
+      assert.equal(Object.isFrozen(toolResult), true);
+      assert.throws(() => {
+        (toolResult as { completedItemCount: number }).completedItemCount = 9;
+      }, TypeError);
+      assert.equal(
+        repo.toolLogs({ range: 'all', toolName: 'Bash' }).rows[0]?.resultSummary
+          ?.completedItemCount,
+        1,
+      );
+      assert.throws(
+        () => repo.logs({ range: 'all', toolName: 'Bash' }),
+        /toolName is not applicable to LLM logs/,
+      );
+      assert.throws(
+        () =>
+          repo.toolLogs({
+            range: 'all',
+            providerId: 'openai',
+          } as Parameters<typeof repo.toolLogs>[0]),
+        /accept only range, toolName, and status/,
+      );
+    });
+  });
+
   test('persists pricing overrides and reloads them from disk', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-'));
+    const first = createTelemetryRepo(root);
+    const second = createTelemetryRepo(root);
     try {
-      const first = createTelemetryRepo(root);
       await first.load();
       await first.upsertPricing({
         modelKey: 'openai:gpt-4o',
@@ -223,23 +386,21 @@ describe('FileTelemetryRepo', () => {
         outputUsdPer1M: 10,
       });
 
-      const second = createTelemetryRepo(root);
       await second.load();
 
       assert.deepEqual(second.listPricingOverrides(), [
         { modelKey: 'openai:gpt-4o', inputUsdPer1M: 2.5, outputUsdPer1M: 10 },
       ]);
     } finally {
-      await flushWrites();
+      await Promise.all([first.close(), second.close()]);
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
     }
   });
 
   test('load creates an empty telemetry file only when missing', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-missing-'));
+    const repo = createTelemetryRepo(root);
     try {
-      const repo = createTelemetryRepo(root);
-
       await repo.load();
       const raw = await readFile(join(root, 'telemetry.json'), 'utf8');
 
@@ -247,85 +408,208 @@ describe('FileTelemetryRepo', () => {
       assert.match(raw, /"usageRecords": \[\]/);
       assert.match(raw, /"toolInvocations": \[\]/);
     } finally {
-      await flushWrites();
+      await repo.close();
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
     }
   });
 
   test('load accepts legacy telemetry files with only known array sections', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-legacy-'));
+    const repo = createTelemetryRepo(root);
     try {
       await writeFile(
         join(root, 'telemetry.json'),
         JSON.stringify({ usageRecords: [] }) + '\n',
         'utf8',
       );
-      const repo = createTelemetryRepo(root);
-
       await repo.load();
 
       assert.deepEqual(repo.logs({ range: 'all' }), { rows: [], total: 0 });
       assert.deepEqual(repo.listPricingOverrides(), []);
     } finally {
-      await flushWrites();
+      await repo.close();
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
     }
   });
 
   test('load rejects corrupt telemetry.json without overwriting usage history bytes', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-corrupt-'));
+    const repo = createTelemetryRepo(root);
     try {
       const corrupt = '{"usageRecords":[{"id":"usage_1"}]';
       await writeFile(join(root, 'telemetry.json'), corrupt, 'utf8');
-      const repo = createTelemetryRepo(root);
-
       await assert.rejects(() => repo.load(), SyntaxError);
       assert.equal(await readFile(join(root, 'telemetry.json'), 'utf8'), corrupt);
     } finally {
-      await flushWrites();
+      await repo.close();
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
     }
   });
 
   test('load rejects wrong telemetry schema without overwriting bytes', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-wrong-schema-'));
+    const repo = createTelemetryRepo(root);
     try {
       const wrongShape = JSON.stringify({ reminders: [] }, null, 2) + '\n';
       await writeFile(join(root, 'telemetry.json'), wrongShape, 'utf8');
-      const repo = createTelemetryRepo(root);
-
       await assert.rejects(() => repo.load(), /expected known telemetry sections/);
       assert.equal(await readFile(join(root, 'telemetry.json'), 'utf8'), wrongShape);
     } finally {
-      await flushWrites();
+      await repo.close();
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
     }
   });
 
   test('load rejects known telemetry sections with non-array values', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-bad-section-'));
+    const repo = createTelemetryRepo(root);
     try {
       const wrongShape = JSON.stringify({ usageRecords: {} }, null, 2) + '\n';
       await writeFile(join(root, 'telemetry.json'), wrongShape, 'utf8');
-      const repo = createTelemetryRepo(root);
-
       await assert.rejects(() => repo.load(), /usageRecords must be an array/);
       assert.equal(await readFile(join(root, 'telemetry.json'), 'utf8'), wrongShape);
     } finally {
-      await flushWrites();
+      await repo.close();
       await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
+    }
+  });
+
+  test('version 1 rejects unknown fields and invalid canonical values without rewriting bytes', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-canonical-invalid-'));
+    const repo = createTelemetryRepo(root);
+    try {
+      const invalidCanonical =
+        JSON.stringify(
+          {
+            version: 1,
+            usageRecords: [{ ...llmRecord(), inputTokens: -1, unexpected: true }],
+            toolInvocations: [],
+          },
+          null,
+          2,
+        ) + '\n';
+      await writeFile(join(root, 'telemetry.json'), invalidCanonical);
+
+      await assert.rejects(() => repo.load(), /invalid LLM row keys/);
+      assert.equal(await readFile(join(root, 'telemetry.json'), 'utf8'), invalidCanonical);
+    } finally {
+      await repo.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('surfaces publication failure through mutation, flush, and close', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-publication-'));
+    try {
+      const repo = createTelemetryRepo(root);
+      await repo.load();
+      await rm(join(root, 'telemetry.json'));
+      await mkdir(join(root, 'telemetry.json'));
+
+      await assert.rejects(() => repo.insertLlmCall(llmRecord()), /Unable to publish telemetry/);
+      assert.equal(repo.summary({ range: 'all' }).totalRequests, 0);
+      await assert.rejects(() => repo.flush(), /Unable to publish telemetry/);
+      await assert.rejects(() => repo.close(), /Unable to publish telemetry/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('poisons reads after rename succeeds but directory sync fails', {
+    skip: process.platform === 'win32',
+  }, async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-commit-unknown-'));
+    try {
+      const repo = createTelemetryRepo(root);
+      await repo.load();
+      const fault = new Error('injected telemetry directory sync failure');
+      const probe = await open(root, 'r');
+      const fileHandlePrototype = Object.getPrototypeOf(probe) as {
+        sync: typeof probe.sync;
+      };
+      const originalSync = fileHandlePrototype.sync;
+      await probe.close();
+      let injected = false;
+      const syncMock = mock.method(
+        fileHandlePrototype,
+        'sync',
+        async function (this: typeof probe) {
+          const metadata = await this.stat();
+          if (!injected && metadata.isDirectory()) {
+            injected = true;
+            throw fault;
+          }
+          return originalSync.call(this);
+        },
+      );
+      let failure: unknown;
+      try {
+        failure = await repo.insertLlmCall(llmRecord()).then(
+          () => undefined,
+          (error: unknown) => error,
+        );
+      } finally {
+        syncMock.mock.restore();
+      }
+
+      assert(failure instanceof TelemetryRepoPublicationError);
+      assert.equal(failure.commitUnknown, true);
+      assert.match(await readFile(join(root, 'telemetry.json'), 'utf8'), /"usage_1"/);
+      assert.throws(
+        () => repo.summary({ range: 'all' }),
+        (error) => error === failure,
+      );
+      await assert.rejects(
+        () => repo.flush(),
+        (error) => error === failure,
+      );
+      await assert.rejects(
+        () => repo.close(),
+        (error) => error === failure,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('close settles and aggregates telemetry and managed pricing failures', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-close-failures-'));
+    try {
+      const repo = createTelemetryRepo(root);
+      await repo.load();
+      await Promise.all([rm(join(root, 'telemetry.json')), rm(join(root, 'pricing.json'))]);
+      await Promise.all([mkdir(join(root, 'telemetry.json')), mkdir(join(root, 'pricing.json'))]);
+
+      const pricingFailure = repo.upsertPricing({
+        modelKey: 'openai:gpt-4o',
+        inputUsdPer1M: 2.5,
+        outputUsdPer1M: 10,
+      });
+      const pricingRejected = assert.rejects(
+        () => pricingFailure,
+        /Unable to publish pricing authority/,
+      );
+      await assert.rejects(() => repo.insertLlmCall(llmRecord()), /Unable to publish telemetry/);
+      await pricingRejected;
+      await assert.rejects(
+        () => repo.close(),
+        (error) => error instanceof AggregateError && error.errors.length === 2,
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
     }
   });
 });
 
 async function withRepo(
-  fn: (repo: ReturnType<typeof createTelemetryRepo>) => Promise<void>,
+  fn: (repo: ReturnType<typeof createTelemetryRepo>, root: string) => Promise<void>,
 ): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-'));
+  const repo = createTelemetryRepo(root);
   try {
-    await fn(createTelemetryRepo(root));
+    await fn(repo, root);
   } finally {
-    await flushWrites();
+    await repo.close();
     await rm(root, { recursive: true, force: true, maxRetries: 5, retryDelay: 20 });
   }
 }
@@ -367,8 +651,4 @@ function toolRecord(overrides: Record<string, unknown> = {}) {
     startedAt: Date.UTC(2026, 0, 1) - 10,
     ...overrides,
   } as Parameters<ReturnType<typeof createTelemetryRepo>['insertToolInvocation']>[0];
-}
-
-function flushWrites(): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, 20));
 }

--- a/packages/storage/src/__tests__/telemetry-repo.test.ts
+++ b/packages/storage/src/__tests__/telemetry-repo.test.ts
@@ -6,6 +6,80 @@ import { describe, mock, test } from 'node:test';
 import { createTelemetryRepo, TelemetryRepoPublicationError } from '../telemetry-repo.js';
 
 describe('FileTelemetryRepo', () => {
+  test('single-flights concurrent load and allows retry after failure', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-load-retry-'));
+    const path = join(root, 'telemetry.json');
+    const repo = createTelemetryRepo(root);
+    try {
+      await writeFile(path, '{');
+
+      const first = repo.load();
+      const concurrent = repo.load();
+      assert.equal(concurrent, first);
+      await assert.rejects(() => first, SyntaxError);
+
+      await writeFile(
+        path,
+        JSON.stringify({ version: 1, usageRecords: [], toolInvocations: [] }, null, 2) + '\n',
+      );
+      await repo.load();
+      assert.equal(repo.summary({ range: 'all' }).totalRequests, 0);
+    } finally {
+      await repo.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('close joins a load started in the same tick and closes managed pricing', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-load-close-'));
+    const repo = createTelemetryRepo(root);
+    try {
+      let loadSettled = false;
+      const load = repo.load().finally(() => {
+        loadSettled = true;
+      });
+      await repo.close();
+      assert.equal(loadSettled, true);
+      await load;
+
+      assert.match(await readFile(join(root, 'telemetry.json'), 'utf8'), /"version": 1/);
+      assert.match(await readFile(join(root, 'pricing.json'), 'utf8'), /"version": 1/);
+      assert.throws(() => repo.summary({ range: 'all' }), /draining or closed/);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('retry does not reuse legacy pricing from a failed load attempt', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-telemetry-stale-load-'));
+    const repo = createTelemetryRepo(root);
+    try {
+      await writeFile(
+        join(root, 'telemetry.json'),
+        JSON.stringify({
+          pricingOverrides: [{ modelKey: 'openai:stale', inputUsdPer1M: 1, outputUsdPer1M: 2 }],
+        }),
+      );
+      await writeFile(join(root, 'pricing.json'), '{');
+      await assert.rejects(() => repo.load(), SyntaxError);
+
+      await Promise.all([rm(join(root, 'telemetry.json')), rm(join(root, 'pricing.json'))]);
+      await repo.load();
+      assert.deepEqual(repo.listPricingOverrides(), []);
+      assert.deepEqual(
+        (
+          JSON.parse(await readFile(join(root, 'pricing.json'), 'utf8')) as {
+            overrides: unknown[];
+          }
+        ).overrides,
+        [],
+      );
+    } finally {
+      await repo.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test('upserts LLM calls by id and aggregates the latest record', async () => {
     await withRepo(async (repo) => {
       await repo.load();

--- a/packages/storage/src/__tests__/usage-stores.test.ts
+++ b/packages/storage/src/__tests__/usage-stores.test.ts
@@ -1,0 +1,316 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import {
+  PricingCommitUnknownError,
+  PricingRevisionConflictError,
+  PricingStoreClosedError,
+  PricingStoreNotLoadedError,
+  PricingStorePublicationError,
+  PricingValidationError,
+} from '../pricing-store.js';
+import {
+  resolveStorageRoot,
+  StorageRootAuthorityError,
+  tryAcquireInteractiveRootOwner,
+} from '../root-authority.js';
+import {
+  TelemetryQueryValidationError,
+  TelemetryRepoClosedError,
+  TelemetryRepoNotLoadedError,
+  TelemetryRepoPublicationError,
+} from '../telemetry-repo.js';
+import {
+  classifyInteractiveUsageStoresFailure,
+  InteractiveUsageStoresClosedError,
+  openInteractiveUsageStoresForWrite,
+} from '../usage-stores.js';
+
+describe('InteractiveUsageStores', () => {
+  test('classifies facade failures without exposing concrete errors to callers', () => {
+    assert.deepEqual(
+      classifyInteractiveUsageStoresFailure(new PricingRevisionConflictError(3, 4)),
+      { kind: 'revision_conflict', expectedRevision: 3, actualRevision: 4 },
+    );
+    for (const error of [
+      new PricingValidationError('bad mutation'),
+      new TelemetryQueryValidationError('bad query'),
+    ]) {
+      assert.deepEqual(classifyInteractiveUsageStoresFailure(error), {
+        kind: 'invalid_request',
+      });
+    }
+    for (const error of [
+      new InteractiveUsageStoresClosedError(),
+      new PricingStoreClosedError(),
+      new TelemetryRepoClosedError(),
+      new StorageRootAuthorityError('invalid_lease', 'revoked'),
+    ]) {
+      assert.deepEqual(classifyInteractiveUsageStoresFailure(error), {
+        kind: 'lifecycle',
+      });
+    }
+    for (const error of [
+      new PricingCommitUnknownError({ cause: new Error('directory sync') }),
+      new TelemetryRepoPublicationError(true, { cause: new Error('directory sync') }),
+    ]) {
+      assert.deepEqual(classifyInteractiveUsageStoresFailure(error), {
+        kind: 'commit_outcome_unknown',
+        needsDrain: true,
+      });
+    }
+    for (const error of [
+      new PricingStorePublicationError({ cause: new Error('rename') }),
+      new TelemetryRepoPublicationError(false, { cause: new Error('rename') }),
+    ]) {
+      assert.deepEqual(classifyInteractiveUsageStoresFailure(error), {
+        kind: 'persistence_failed',
+        needsDrain: true,
+      });
+    }
+    for (const error of [
+      new PricingStoreNotLoadedError(),
+      new TelemetryRepoNotLoadedError(),
+      new StorageRootAuthorityError('lock_failed', 'lock failed'),
+    ]) {
+      assert.deepEqual(classifyInteractiveUsageStoresFailure(error), {
+        kind: 'persistence_failed',
+        needsDrain: false,
+      });
+    }
+
+    const unknown = new Error('unknown');
+    assert.deepEqual(classifyInteractiveUsageStoresFailure(unknown), {
+      kind: 'unknown',
+      error: unknown,
+    });
+  });
+
+  test('migrates legacy usage, tools, and pricing idempotently', async () => {
+    await withInteractiveRoot(async ({ root, capability }) => {
+      const legacy = {
+        usageRecords: [llmRecord({ cachedInputTokens: 3, cacheHitInputTokens: undefined })],
+        toolInvocations: [toolRecord()],
+        pricingOverrides: [pricing('openai:gpt-5')],
+      };
+      await writeFile(join(root, 'telemetry.json'), JSON.stringify(legacy, null, 2) + '\n');
+
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert(owner);
+      const stores = await openInteractiveUsageStoresForWrite(owner.lease);
+      assert.equal((await stores.telemetry.logs({ range: 'all' })).total, 1);
+      assert.deepEqual(await stores.pricing.snapshot(), {
+        revision: 0,
+        overrides: [pricing('openai:gpt-5')],
+      });
+      await stores.close();
+      await owner.close();
+
+      const firstTelemetry = await readFile(join(root, 'telemetry.json'), 'utf8');
+      const firstPricing = await readFile(join(root, 'pricing.json'), 'utf8');
+      assert.match(firstTelemetry, /"version": 1/);
+      assert.doesNotMatch(firstTelemetry, /pricingOverrides/);
+
+      const successor = await tryAcquireInteractiveRootOwner(capability);
+      assert(successor);
+      const reopened = await openInteractiveUsageStoresForWrite(successor.lease);
+      assert.equal((await reopened.telemetry.buckets({ range: 'all' }, 'tool'))[0]?.requests, 1);
+      assert.deepEqual(await reopened.pricing.snapshot(), {
+        revision: 0,
+        overrides: [pricing('openai:gpt-5')],
+      });
+      await reopened.close();
+      await successor.close();
+      assert.equal(await readFile(join(root, 'telemetry.json'), 'utf8'), firstTelemetry);
+      assert.equal(await readFile(join(root, 'pricing.json'), 'utf8'), firstPricing);
+    });
+  });
+
+  test('an existing pricing authority wins over stale embedded overrides', async () => {
+    await withInteractiveRoot(async ({ root, capability }) => {
+      await writeFile(
+        join(root, 'telemetry.json'),
+        JSON.stringify({
+          usageRecords: [],
+          toolInvocations: [],
+          pricingOverrides: [{ modelKey: '', inputUsdPer1M: -1 }],
+        }),
+      );
+      await writeFile(
+        join(root, 'pricing.json'),
+        JSON.stringify({
+          version: 1,
+          revision: 7,
+          overrides: [pricing('current:model')],
+        }),
+      );
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert(owner);
+      const stores = await openInteractiveUsageStoresForWrite(owner.lease);
+      assert.deepEqual(await stores.pricing.snapshot(), {
+        revision: 7,
+        overrides: [pricing('current:model')],
+      });
+      await stores.close();
+      await owner.close();
+    });
+  });
+
+  test('migrates and reopens more than 128 legacy pricing overrides without loss', async () => {
+    await withInteractiveRoot(async ({ root, capability }) => {
+      const overrides = Array.from({ length: 140 }, (_, index) =>
+        pricing(`provider:model-${String(139 - index).padStart(3, '0')}`),
+      );
+      await writeFile(
+        join(root, 'telemetry.json'),
+        JSON.stringify({ usageRecords: [], toolInvocations: [], pricingOverrides: overrides }),
+      );
+
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert(owner);
+      const stores = await openInteractiveUsageStoresForWrite(owner.lease);
+      const migrated = await stores.pricing.snapshot();
+      assert.equal(migrated.overrides.length, 140);
+      assert.deepEqual(
+        migrated.overrides.map((item) => item.modelKey),
+        overrides.map((item) => item.modelKey).sort(),
+      );
+      await stores.close();
+      await owner.close();
+
+      const successor = await tryAcquireInteractiveRootOwner(capability);
+      assert(successor);
+      const reopened = await openInteractiveUsageStoresForWrite(successor.lease);
+      assert.deepEqual(await reopened.pricing.snapshot(), migrated);
+      await reopened.close();
+      await successor.close();
+    });
+  });
+
+  test('drain waits accepted writes and rejects new admission', async () => {
+    await withInteractiveRoot(async ({ root, capability }) => {
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert(owner);
+      const stores = await openInteractiveUsageStoresForWrite(owner.lease);
+      const accepted = stores.telemetry.recordLlmCall(llmRecord());
+      const drained = stores.beginDrain();
+
+      assert.throws(
+        () => stores.telemetry.recordToolInvocation(toolRecord()),
+        InteractiveUsageStoresClosedError,
+      );
+      await Promise.all([accepted, drained]);
+      await stores.close();
+      assert.match(await readFile(join(root, 'telemetry.json'), 'utf8'), /"usage_1"/);
+      await owner.close();
+    });
+  });
+
+  test('lease-bound facade exposes separate LLM and filtered tool logs', async () => {
+    await withInteractiveRoot(async ({ capability }) => {
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert(owner);
+      const stores = await openInteractiveUsageStoresForWrite(owner.lease);
+      await stores.telemetry.recordLlmCall(llmRecord());
+      await stores.telemetry.recordToolInvocation(toolRecord());
+
+      assert.equal((await stores.telemetry.logs({ range: 'all' })).total, 1);
+      const tools = await stores.telemetry.toolLogs({
+        range: 'all',
+        toolName: 'Bash',
+        status: 'success',
+      });
+      assert.equal(tools.total, 1);
+      assert.equal(tools.rows[0]?.toolName, 'Bash');
+      await assert.rejects(
+        () => stores.telemetry.logs({ range: 'all', toolName: 'Bash' }),
+        /toolName is not applicable to LLM logs/,
+      );
+      await stores.close();
+      await owner.close();
+    });
+  });
+
+  test('every facade read observes lease revocation', async () => {
+    await withInteractiveRoot(async ({ capability }) => {
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert(owner);
+      const stores = await openInteractiveUsageStoresForWrite(owner.lease);
+      await owner.close();
+
+      await assert.rejects(
+        () => stores.telemetry.summary({ range: 'all' }),
+        (error) => error instanceof StorageRootAuthorityError && error.code === 'invalid_lease',
+      );
+      await assert.rejects(
+        () => stores.pricing.snapshot(),
+        (error) => error instanceof StorageRootAuthorityError && error.code === 'invalid_lease',
+      );
+    });
+  });
+});
+
+async function withInteractiveRoot(
+  run: (input: {
+    root: string;
+    capability: Awaited<ReturnType<typeof resolveStorageRoot<'interactive'>>>;
+  }) => Promise<void>,
+): Promise<void> {
+  const base = await mkdtemp(join(tmpdir(), 'maka-usage-stores-'));
+  try {
+    const root = join(base, 'interactive');
+    const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+    await run({ root, capability });
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+}
+
+function llmRecord(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'usage_1',
+    providerId: 'openai',
+    modelId: 'gpt-5',
+    inputTokens: 10,
+    outputTokens: 20,
+    cacheHitInputTokens: 0,
+    cacheMissInputTokens: 10,
+    cachedInputTokens: 0,
+    cacheWriteInputTokens: 0,
+    reasoningTokens: 0,
+    totalTokens: 30,
+    costUsd: 0.001,
+    latencyMs: 100,
+    status: 'success',
+    date: '2026-01-01',
+    ts: Date.UTC(2026, 0, 1),
+    startedAt: Date.UTC(2026, 0, 1) - 100,
+    ...overrides,
+  } as Parameters<
+    Awaited<ReturnType<typeof openInteractiveUsageStoresForWrite>>['telemetry']['recordLlmCall']
+  >[0];
+}
+
+function toolRecord() {
+  return {
+    id: 'tool_1',
+    toolName: 'Bash',
+    durationMs: 30,
+    status: 'success',
+    bytesIn: 1,
+    bytesOut: 2,
+    date: '2026-01-01',
+    ts: Date.UTC(2026, 0, 1),
+    startedAt: Date.UTC(2026, 0, 1),
+  } as Parameters<
+    Awaited<
+      ReturnType<typeof openInteractiveUsageStoresForWrite>
+    >['telemetry']['recordToolInvocation']
+  >[0];
+}
+
+function pricing(modelKey: string) {
+  return { modelKey, inputUsdPer1M: 1.25, outputUsdPer1M: 10 };
+}

--- a/packages/storage/src/__tests__/usage-stores.test.ts
+++ b/packages/storage/src/__tests__/usage-stores.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdir, mkdtemp, readFile, rename, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
@@ -13,8 +13,10 @@ import {
 } from '../pricing-store.js';
 import {
   resolveStorageRoot,
+  STORAGE_ROOT_MARKER_FILE,
   StorageRootAuthorityError,
   tryAcquireInteractiveRootOwner,
+  type StorageRootAuthorityErrorCode,
 } from '../root-authority.js';
 import {
   TelemetryQueryValidationError,
@@ -47,6 +49,7 @@ describe('InteractiveUsageStores', () => {
       new PricingStoreClosedError(),
       new TelemetryRepoClosedError(),
       new StorageRootAuthorityError('invalid_lease', 'revoked'),
+      new StorageRootAuthorityError('invalid_owner', 'inauthentic'),
     ]) {
       assert.deepEqual(classifyInteractiveUsageStoresFailure(error), {
         kind: 'lifecycle',
@@ -70,15 +73,39 @@ describe('InteractiveUsageStores', () => {
         needsDrain: true,
       });
     }
-    for (const error of [
-      new PricingStoreNotLoadedError(),
-      new TelemetryRepoNotLoadedError(),
-      new StorageRootAuthorityError('lock_failed', 'lock failed'),
-    ]) {
+    for (const error of [new PricingStoreNotLoadedError(), new TelemetryRepoNotLoadedError()]) {
       assert.deepEqual(classifyInteractiveUsageStoresFailure(error), {
         kind: 'persistence_failed',
         needsDrain: false,
       });
+    }
+    const rootAuthorityNeedsDrain = {
+      invalid_root: false,
+      invalid_root_kind: false,
+      root_not_found: false,
+      root_unmarked: true,
+      invalid_marker: true,
+      root_kind_mismatch: true,
+      root_identity_collision: true,
+      root_identity_changed: true,
+      invalid_repair: false,
+      invalid_capability: false,
+      invalid_lock_artifact: false,
+      insecure_control_directory: false,
+      root_io_failed: false,
+      control_io_failed: false,
+      lock_failed: false,
+    } as const satisfies Record<
+      Exclude<StorageRootAuthorityErrorCode, 'invalid_lease' | 'invalid_owner'>,
+      boolean
+    >;
+    for (const [code, needsDrain] of Object.entries(rootAuthorityNeedsDrain)) {
+      assert.deepEqual(
+        classifyInteractiveUsageStoresFailure(
+          new StorageRootAuthorityError(code as StorageRootAuthorityErrorCode, code),
+        ),
+        { kind: 'persistence_failed', needsDrain },
+      );
     }
 
     const unknown = new Error('unknown');
@@ -86,6 +113,83 @@ describe('InteractiveUsageStores', () => {
       kind: 'unknown',
       error: unknown,
     });
+  });
+
+  test('classifies a renamed or replaced live root as a draining persistence failure', async () => {
+    for (const replacement of [false, true]) {
+      await withInteractiveRoot(async ({ root, capability }) => {
+        const owner = await tryAcquireInteractiveRootOwner(capability);
+        assert(owner);
+        const stores = await openInteractiveUsageStoresForWrite(owner.lease);
+        await rename(root, `${root}-moved`);
+        if (replacement) await mkdir(root);
+        try {
+          await assert.rejects(
+            () => stores.pricing.snapshot(),
+            (error: unknown) => {
+              assert.ok(error instanceof StorageRootAuthorityError);
+              assert.equal(error.code, 'root_identity_changed');
+              assert.deepEqual(classifyInteractiveUsageStoresFailure(error), {
+                kind: 'persistence_failed',
+                needsDrain: true,
+              });
+              return true;
+            },
+          );
+        } finally {
+          await owner.close();
+        }
+      });
+    }
+  });
+
+  test('classifies poisoned live root markers as draining persistence failures', async () => {
+    const scenarios: ReadonlyArray<{
+      code: 'root_unmarked' | 'invalid_marker' | 'root_kind_mismatch';
+      poison(markerPath: string): Promise<void>;
+    }> = [
+      {
+        code: 'root_unmarked',
+        poison: (markerPath) => rm(markerPath),
+      },
+      {
+        code: 'invalid_marker',
+        poison: (markerPath) => writeFile(markerPath, '{'),
+      },
+      {
+        code: 'root_kind_mismatch',
+        poison: async (markerPath) => {
+          const marker = JSON.parse(await readFile(markerPath, 'utf8')) as { kind: string };
+          marker.kind = 'headless';
+          await writeFile(markerPath, `${JSON.stringify(marker)}\n`);
+        },
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      await withInteractiveRoot(async ({ root, capability }) => {
+        const owner = await tryAcquireInteractiveRootOwner(capability);
+        assert(owner);
+        const stores = await openInteractiveUsageStoresForWrite(owner.lease);
+        await scenario.poison(join(root, STORAGE_ROOT_MARKER_FILE));
+        try {
+          await assert.rejects(
+            () => stores.pricing.snapshot(),
+            (error: unknown) => {
+              assert.ok(error instanceof StorageRootAuthorityError);
+              assert.equal(error.code, scenario.code);
+              assert.deepEqual(classifyInteractiveUsageStoresFailure(error), {
+                kind: 'persistence_failed',
+                needsDrain: true,
+              });
+              return true;
+            },
+          );
+        } finally {
+          await owner.close();
+        }
+      });
+    }
   });
 
   test('migrates legacy usage, tools, and pricing idempotently', async () => {

--- a/packages/storage/src/failure-utils.ts
+++ b/packages/storage/src/failure-utils.ts
@@ -1,0 +1,6 @@
+export function throwDeduplicatedFailures(message: string, failures: readonly unknown[]): void {
+  const unique = [...new Set(failures)];
+  if (unique.length === 0) return;
+  if (unique.length === 1) throw unique[0];
+  throw new AggregateError(unique, message);
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -22,6 +22,8 @@ export type {
 } from './credential-store.js';
 export * from './settings-store.js';
 export * from './telemetry-repo.js';
+export * from './pricing-store.js';
+export * from './usage-stores.js';
 export {
   ARTIFACT_BINARY_PREVIEW_LIMIT_BYTES,
   ARTIFACT_TEXT_PREVIEW_LIMIT_BYTES,

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -22,7 +22,6 @@ export type {
 } from './credential-store.js';
 export * from './settings-store.js';
 export * from './telemetry-repo.js';
-export * from './pricing-store.js';
 export * from './usage-stores.js';
 export {
   ARTIFACT_BINARY_PREVIEW_LIMIT_BYTES,

--- a/packages/storage/src/pricing-store.ts
+++ b/packages/storage/src/pricing-store.ts
@@ -9,6 +9,7 @@ import {
   validateCanonicalPricingConfig,
 } from '@maka/core/usage-stats/pricing';
 import type { PricingConfig } from '@maka/core/usage-stats/types';
+import { throwDeduplicatedFailures } from './failure-utils.js';
 import { syncDirectory } from './stable-storage.js';
 
 const PRICING_DOCUMENT_VERSION = 1;
@@ -112,6 +113,7 @@ class FilePricingStore implements PricingStore {
   private queue: Promise<void> = Promise.resolve();
   private failure: PricingCommitUnknownError | PricingStorePublicationError | undefined;
   private state: 'open' | 'draining' | 'closed' = 'open';
+  private loadPromise: Promise<void> | undefined;
   private closePromise: Promise<void> | undefined;
 
   constructor(
@@ -123,9 +125,21 @@ class FilePricingStore implements PricingStore {
     this.document = makeDocument(0, []);
   }
 
-  async load(): Promise<void> {
-    if (this.loaded) return;
+  load(): Promise<void> {
+    if (this.loaded) return Promise.resolve();
     this.assertOpen();
+    if (this.loadPromise) return this.loadPromise;
+    const operation = this.loadFromDisk();
+    this.loadPromise = operation;
+    void operation.catch(() => {
+      if (this.state === 'open' && this.loadPromise === operation) {
+        this.loadPromise = undefined;
+      }
+    });
+    return operation;
+  }
+
+  private async loadFromDisk(): Promise<void> {
     try {
       this.document = decodeDocument(JSON.parse(await readFile(this.path, 'utf8')));
     } catch (error) {
@@ -181,9 +195,21 @@ class FilePricingStore implements PricingStore {
   close(): Promise<void> {
     if (this.closePromise) return this.closePromise;
     this.state = 'draining';
-    this.closePromise = this.flush().finally(() => {
-      this.state = 'closed';
-    });
+    this.closePromise = Promise.allSettled([
+      this.loadPromise ?? Promise.resolve(),
+      this.queue.then(() => {
+        if (this.failure) throw this.failure;
+      }),
+    ])
+      .then((results) => {
+        throwDeduplicatedFailures(
+          'Unable to close pricing store',
+          results.flatMap((result) => (result.status === 'rejected' ? [result.reason] : [])),
+        );
+      })
+      .finally(() => {
+        this.state = 'closed';
+      });
     return this.closePromise;
   }
 

--- a/packages/storage/src/pricing-store.ts
+++ b/packages/storage/src/pricing-store.ts
@@ -1,0 +1,360 @@
+import { randomUUID } from 'node:crypto';
+import { mkdir, open, readFile, rename, rm } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+import {
+  canonicalPricingConfigsEqual,
+  comparePricingModelKeys,
+  normalizePricingConfig,
+  normalizePricingModelKey,
+  validateCanonicalPricingConfig,
+} from '@maka/core/usage-stats/pricing';
+import type { PricingConfig } from '@maka/core/usage-stats/types';
+import { syncDirectory } from './stable-storage.js';
+
+const PRICING_DOCUMENT_VERSION = 1;
+
+interface PricingDocument {
+  readonly version: 1;
+  readonly revision: number;
+  readonly overrides: readonly Readonly<PricingConfig>[];
+}
+
+export interface PricingSnapshot {
+  readonly revision: number;
+  readonly overrides: readonly Readonly<PricingConfig>[];
+}
+
+export interface PricingMutationResult {
+  readonly committed: boolean;
+  readonly changed: boolean;
+  readonly snapshot: PricingSnapshot;
+}
+
+export interface PricingStore {
+  snapshot(): PricingSnapshot;
+  upsert(expectedRevision: number, pricing: PricingConfig): Promise<PricingMutationResult>;
+  delete(expectedRevision: number, modelKey: string): Promise<PricingMutationResult>;
+  load(): Promise<void>;
+  flush(): Promise<void>;
+  beginDrain(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export interface CreatePricingStoreOptions {
+  readonly createIfMissing?: boolean;
+  readonly initialOverrides?: readonly unknown[];
+}
+
+export class PricingStoreClosedError extends Error {
+  constructor() {
+    super('Pricing store is draining or closed');
+    this.name = 'PricingStoreClosedError';
+  }
+}
+
+export class PricingStoreNotLoadedError extends Error {
+  constructor() {
+    super('Pricing store has not been loaded');
+    this.name = 'PricingStoreNotLoadedError';
+  }
+}
+
+export class PricingRevisionConflictError extends Error {
+  constructor(
+    readonly expectedRevision: number,
+    readonly actualRevision: number,
+  ) {
+    super(`Pricing revision conflict: expected ${expectedRevision}, actual ${actualRevision}`);
+    this.name = 'PricingRevisionConflictError';
+  }
+}
+
+export class PricingValidationError extends Error {
+  constructor(message: string) {
+    super(`Invalid pricing authority: ${message}`);
+    this.name = 'PricingValidationError';
+  }
+}
+
+export class PricingStorePublicationError extends Error {
+  readonly domain = 'pricing_authority';
+
+  constructor(options: { cause: unknown }) {
+    super('Unable to publish pricing authority', options);
+    this.name = 'PricingStorePublicationError';
+  }
+}
+
+export class PricingCommitUnknownError extends Error {
+  readonly domain = 'pricing_authority';
+
+  constructor(options: { cause: unknown }) {
+    super('Pricing commit outcome is unknown; reload before retrying', options);
+    this.name = 'PricingCommitUnknownError';
+  }
+}
+
+export function createPricingStore(
+  workspaceRoot: string,
+  options: CreatePricingStoreOptions = {},
+): PricingStore {
+  return new FilePricingStore(
+    workspaceRoot,
+    options.createIfMissing ?? true,
+    options.initialOverrides ?? [],
+  );
+}
+
+class FilePricingStore implements PricingStore {
+  private readonly path: string;
+  private document: PricingDocument;
+  private loaded = false;
+  private queue: Promise<void> = Promise.resolve();
+  private failure: PricingCommitUnknownError | PricingStorePublicationError | undefined;
+  private state: 'open' | 'draining' | 'closed' = 'open';
+  private closePromise: Promise<void> | undefined;
+
+  constructor(
+    workspaceRoot: string,
+    private readonly createIfMissing: boolean,
+    private readonly initialOverrides: readonly unknown[],
+  ) {
+    this.path = join(workspaceRoot, 'pricing.json');
+    this.document = makeDocument(0, []);
+  }
+
+  async load(): Promise<void> {
+    if (this.loaded) return;
+    this.assertOpen();
+    try {
+      this.document = decodeDocument(JSON.parse(await readFile(this.path, 'utf8')));
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      this.document = makeDocument(0, normalizeLegacyOverrides(this.initialOverrides));
+      if (this.createIfMissing) await this.publish(this.document);
+    }
+    this.loaded = true;
+  }
+
+  snapshot(): PricingSnapshot {
+    this.assertReady();
+    if (this.failure instanceof PricingCommitUnknownError) throw this.failure;
+    return cloneSnapshot(this.document);
+  }
+
+  upsert(expectedRevision: number, pricing: PricingConfig): Promise<PricingMutationResult> {
+    assertRevision(expectedRevision, 'expectedRevision');
+    const normalized = normalizePricingConfig(pricing);
+    if (!normalized.ok) throw new PricingValidationError(normalized.error);
+    const admitted = freezePricing(normalized.value);
+    return this.enqueueMutation(expectedRevision, (current) => {
+      const existing = current.find((item) => item.modelKey === admitted.modelKey);
+      if (existing && canonicalPricingConfigsEqual(existing, admitted)) return current;
+      return [...current.filter((item) => item.modelKey !== admitted.modelKey), admitted].sort(
+        (left, right) => comparePricingModelKeys(left.modelKey, right.modelKey),
+      );
+    });
+  }
+
+  delete(expectedRevision: number, modelKey: string): Promise<PricingMutationResult> {
+    assertRevision(expectedRevision, 'expectedRevision');
+    const normalized = normalizePricingModelKey(modelKey);
+    if (!normalized.ok) throw new PricingValidationError(normalized.error);
+    return this.enqueueMutation(expectedRevision, (current) =>
+      current.some((item) => item.modelKey === normalized.value)
+        ? current.filter((item) => item.modelKey !== normalized.value)
+        : current,
+    );
+  }
+
+  async flush(): Promise<void> {
+    this.assertLoaded();
+    await this.queue;
+    if (this.failure) throw this.failure;
+  }
+
+  beginDrain(): Promise<void> {
+    if (this.state === 'open') this.state = 'draining';
+    return this.flush();
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.state = 'draining';
+    this.closePromise = this.flush().finally(() => {
+      this.state = 'closed';
+    });
+    return this.closePromise;
+  }
+
+  private enqueueMutation(
+    expectedRevision: number,
+    mutate: (current: readonly Readonly<PricingConfig>[]) => readonly Readonly<PricingConfig>[],
+  ): Promise<PricingMutationResult> {
+    this.assertReady();
+    const operation = this.queue.then(async () => {
+      if (this.failure) throw this.failure;
+      const current = this.document;
+      if (current.revision !== expectedRevision) {
+        throw new PricingRevisionConflictError(expectedRevision, current.revision);
+      }
+      const overrides = mutate(current.overrides);
+      if (overrides === current.overrides) {
+        return { committed: false, changed: false, snapshot: cloneSnapshot(current) };
+      }
+      if (current.revision === Number.MAX_SAFE_INTEGER) {
+        throw new PricingValidationError('revision cannot advance beyond Number.MAX_SAFE_INTEGER');
+      }
+      const candidate = makeDocument(current.revision + 1, overrides);
+      try {
+        await this.publish(candidate);
+      } catch (error) {
+        if (
+          error instanceof PricingCommitUnknownError ||
+          error instanceof PricingStorePublicationError
+        ) {
+          this.failure = error;
+        }
+        throw error;
+      }
+      this.document = candidate;
+      return { committed: true, changed: true, snapshot: cloneSnapshot(candidate) };
+    });
+    this.queue = operation.then(
+      () => undefined,
+      () => undefined,
+    );
+    return operation;
+  }
+
+  private async publish(document: PricingDocument): Promise<void> {
+    const directory = dirname(this.path);
+    const temporaryPath = `${this.path}.${randomUUID()}.tmp`;
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    let published = false;
+    try {
+      await mkdir(directory, { recursive: true });
+      handle = await open(temporaryPath, 'wx', 0o600);
+      await handle.writeFile(JSON.stringify(document, null, 2) + '\n', 'utf8');
+      await handle.sync();
+      await handle.close();
+      handle = undefined;
+      await rename(temporaryPath, this.path);
+      published = true;
+      await syncDirectory(directory);
+    } catch (cause) {
+      if (published) throw new PricingCommitUnknownError({ cause });
+      throw new PricingStorePublicationError({ cause });
+    } finally {
+      await handle?.close().catch(() => undefined);
+      if (!published) await rm(temporaryPath, { force: true }).catch(() => undefined);
+    }
+  }
+
+  private assertLoaded(): void {
+    if (!this.loaded) throw new PricingStoreNotLoadedError();
+  }
+
+  private assertOpen(): void {
+    if (this.state !== 'open') throw new PricingStoreClosedError();
+  }
+
+  private assertReady(): void {
+    this.assertOpen();
+    this.assertLoaded();
+  }
+}
+
+function decodeDocument(input: unknown): PricingDocument {
+  if (!isRecord(input)) throw new PricingValidationError('expected an object');
+  const keys = Object.keys(input);
+  if (
+    keys.length !== 3 ||
+    !keys.includes('version') ||
+    !keys.includes('revision') ||
+    !keys.includes('overrides')
+  ) {
+    throw new PricingValidationError('document must contain exactly version, revision, overrides');
+  }
+  if (input.version !== PRICING_DOCUMENT_VERSION) {
+    throw new PricingValidationError(`expected version ${PRICING_DOCUMENT_VERSION}`);
+  }
+  assertRevision(input.revision, 'revision');
+  if (!Array.isArray(input.overrides)) {
+    throw new PricingValidationError('overrides must be an array');
+  }
+  return makeDocument(input.revision, decodeCanonicalOverrides(input.overrides));
+}
+
+function normalizeLegacyOverrides(input: readonly unknown[]): readonly Readonly<PricingConfig>[] {
+  const result = input.map((value, index) => {
+    const normalized = normalizePricingConfig(value);
+    if (!normalized.ok) {
+      throw new PricingValidationError(`overrides[${index}]: ${normalized.error}`);
+    }
+    return freezePricing(normalized.value);
+  });
+  const keys = new Set<string>();
+  for (const item of result) {
+    if (keys.has(item.modelKey)) {
+      throw new PricingValidationError(`duplicate modelKey: ${item.modelKey}`);
+    }
+    keys.add(item.modelKey);
+  }
+  return result.sort((left, right) => comparePricingModelKeys(left.modelKey, right.modelKey));
+}
+
+function decodeCanonicalOverrides(input: readonly unknown[]): readonly Readonly<PricingConfig>[] {
+  const result = input.map((value, index) => {
+    const canonical = validateCanonicalPricingConfig(value);
+    if (!canonical.ok) {
+      throw new PricingValidationError(`overrides[${index}]: ${canonical.error}`);
+    }
+    return freezePricing(canonical.value);
+  });
+  for (let index = 1; index < result.length; index += 1) {
+    const previous = result[index - 1];
+    const current = result[index];
+    if (!previous || !current) continue;
+    const order = comparePricingModelKeys(previous.modelKey, current.modelKey);
+    if (order === 0) {
+      throw new PricingValidationError(`duplicate modelKey: ${current.modelKey}`);
+    }
+    if (order > 0) {
+      throw new PricingValidationError('overrides must be sorted by modelKey');
+    }
+  }
+  return result;
+}
+
+function makeDocument(
+  revision: number,
+  overrides: readonly Readonly<PricingConfig>[],
+): PricingDocument {
+  return Object.freeze({
+    version: PRICING_DOCUMENT_VERSION,
+    revision,
+    overrides: Object.freeze(overrides.map(freezePricing)),
+  });
+}
+
+function cloneSnapshot(document: PricingDocument): PricingSnapshot {
+  return Object.freeze({
+    revision: document.revision,
+    overrides: Object.freeze(document.overrides.map(freezePricing)),
+  });
+}
+
+function freezePricing(pricing: PricingConfig): Readonly<PricingConfig> {
+  return Object.freeze({ ...pricing });
+}
+
+function assertRevision(value: unknown, label: string): asserts value is number {
+  if (!Number.isSafeInteger(value) || (value as number) < 0) {
+    throw new PricingValidationError(`${label} must be a nonnegative safe integer`);
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/storage/src/telemetry-file-schema.ts
+++ b/packages/storage/src/telemetry-file-schema.ts
@@ -1,0 +1,520 @@
+import type { LlmCallRecord, ToolInvocationRecord } from '@maka/core/usage-stats/types';
+import { isContextBudgetDiagnostic, isPromptSegmentEstimate } from '@maka/core/usage-record-schema';
+
+export type PersistedLlmCallRecord = LlmCallRecord & {
+  id: string;
+  cacheHitInputTokens: number;
+  cacheMissInputTokens: number;
+  cachedInputTokens: number;
+  cacheWriteInputTokens: number;
+  reasoningTokens: number;
+  totalTokens: number;
+  costUsd: number;
+  date: string;
+  ts: number;
+};
+
+export type PersistedToolInvocationRecord = ToolInvocationRecord & {
+  id: string;
+  argsSummary?: string;
+  bytesIn: number;
+  bytesOut: number;
+  date: string;
+  ts: number;
+};
+
+export interface TelemetryFile {
+  readonly version: 1;
+  readonly usageRecords: readonly PersistedLlmCallRecord[];
+  readonly toolInvocations: readonly PersistedToolInvocationRecord[];
+}
+
+export interface DecodedTelemetryFile {
+  readonly file: TelemetryFile;
+  readonly legacyPricingOverrides: readonly unknown[];
+  readonly requiresCanonicalPublication: boolean;
+}
+
+type ExactKeyShape<Value extends object> = {
+  readonly [Key in keyof Value]-?: true;
+};
+
+function exactKeys<Value extends object>(shape: ExactKeyShape<Value>): ReadonlySet<string> {
+  return new Set(Object.keys(shape));
+}
+
+const FILE_KEYS = new Set(['version', 'usageRecords', 'toolInvocations']);
+const LLM_KEYS = exactKeys<PersistedLlmCallRecord>({
+  sessionId: true,
+  turnId: true,
+  callKind: true,
+  callId: true,
+  connectionSlug: true,
+  providerId: true,
+  modelId: true,
+  inputTokens: true,
+  outputTokens: true,
+  cacheHitInputTokens: true,
+  cacheMissInputTokens: true,
+  cachedInputTokens: true,
+  cacheWriteInputTokens: true,
+  reasoningTokens: true,
+  totalTokens: true,
+  rawFinishReason: true,
+  rawUsage: true,
+  latencyMs: true,
+  status: true,
+  errorClass: true,
+  costUsd: true,
+  startedAt: true,
+  systemPromptHash: true,
+  prefixHash: true,
+  prefixChangeReason: true,
+  requestShapeHash: true,
+  requestShapeChangeReason: true,
+  toolSchemaChangeReason: true,
+  toolAvailability: true,
+  cacheMissInputSource: true,
+  promptSegments: true,
+  contextBudget: true,
+  id: true,
+  date: true,
+  ts: true,
+});
+const TOOL_KEYS = exactKeys<PersistedToolInvocationRecord>({
+  sessionId: true,
+  turnId: true,
+  toolCallId: true,
+  toolName: true,
+  providerId: true,
+  modelId: true,
+  durationMs: true,
+  status: true,
+  errorClass: true,
+  argsSummary: true,
+  resultSummary: true,
+  bytesIn: true,
+  bytesOut: true,
+  startedAt: true,
+  id: true,
+  date: true,
+  ts: true,
+});
+const PREFIX_CHANGE_REASONS = new Set([
+  'first_turn',
+  'system_prompt_changed',
+  'tool_schema_changed',
+  'provider_options_changed',
+  'model_or_provider_changed',
+  'history_projection_changed',
+  'stable',
+  'unknown',
+]);
+const TOOL_SCHEMA_CHANGE_REASONS = new Set([
+  'tool_schema_changed',
+  'tool_source_enabled',
+  'tool_source_state_changed',
+]);
+
+export function emptyTelemetryFile(): TelemetryFile {
+  return { version: 1, usageRecords: [], toolInvocations: [] };
+}
+
+export function decodeTelemetryFile(input: unknown): DecodedTelemetryFile {
+  if (!isRecord(input)) throw invalid('expected an object');
+  if (input.version === undefined) return decodeLegacyTelemetryFile(input);
+  if (!hasOnlyKeys(input, FILE_KEYS)) {
+    throw invalid('expected exactly version, usageRecords, toolInvocations');
+  }
+  if (input.version !== 1) throw invalid('expected version 1');
+  assertArray(input, 'usageRecords');
+  assertArray(input, 'toolInvocations');
+  return {
+    file: {
+      version: 1,
+      usageRecords: input.usageRecords.map(decodePersistedLlmCallRecord),
+      toolInvocations: input.toolInvocations.map(decodePersistedToolInvocationRecord),
+    },
+    legacyPricingOverrides: [],
+    requiresCanonicalPublication: false,
+  };
+}
+
+function decodeLegacyTelemetryFile(input: Record<string, unknown>): DecodedTelemetryFile {
+  const hasKnownSection =
+    'usageRecords' in input || 'toolInvocations' in input || 'pricingOverrides' in input;
+  if (!hasKnownSection) throw invalid('expected known telemetry sections');
+  assertOptionalArray(input, 'usageRecords');
+  assertOptionalArray(input, 'toolInvocations');
+  assertOptionalArray(input, 'pricingOverrides');
+  const usageRecords = (input.usageRecords ?? []) as unknown[];
+  const toolInvocations = (input.toolInvocations ?? []) as unknown[];
+  const pricingOverrides = (input.pricingOverrides ?? []) as unknown[];
+  return {
+    file: {
+      version: 1,
+      usageRecords: usageRecords.map((row) =>
+        decodePersistedLlmCallRecord(normalizeLlmCallRecord(row)),
+      ),
+      toolInvocations: toolInvocations.map((row) =>
+        decodePersistedToolInvocationRecord(normalizeToolInvocationRecord(row)),
+      ),
+    },
+    legacyPricingOverrides: pricingOverrides,
+    requiresCanonicalPublication: true,
+  };
+}
+
+export function normalizeLlmCallRecord(input: unknown): PersistedLlmCallRecord {
+  if (!isRecord(input)) throw invalid('LLM record must be an object');
+  const row = input as Partial<PersistedLlmCallRecord>;
+  const inputTokens = finiteNumber(row.inputTokens) ?? 0;
+  const outputTokens = finiteNumber(row.outputTokens) ?? 0;
+  const cacheHitInputTokens =
+    finiteNumber(row.cacheHitInputTokens) ?? finiteNumber(row.cachedInputTokens) ?? 0;
+  const cacheWriteInputTokens = finiteNumber(row.cacheWriteInputTokens) ?? 0;
+  const cacheMissInputTokens =
+    finiteNumber(row.cacheMissInputTokens) ??
+    Math.max(0, inputTokens - cacheHitInputTokens - cacheWriteInputTokens);
+  const reasoningTokens = finiteNumber(row.reasoningTokens) ?? 0;
+  const ts = finiteNumber(row.ts) ?? finiteNumber(row.startedAt) ?? 0;
+  return {
+    ...pickKnown(input, LLM_KEYS),
+    id: typeof row.id === 'string' ? row.id : `usage_${row.turnId ?? ts}`,
+    providerId: typeof row.providerId === 'string' ? row.providerId : 'unknown',
+    modelId: typeof row.modelId === 'string' ? row.modelId : 'unknown',
+    inputTokens,
+    outputTokens,
+    cacheHitInputTokens,
+    cacheMissInputTokens,
+    cachedInputTokens: cacheHitInputTokens,
+    cacheWriteInputTokens,
+    reasoningTokens,
+    totalTokens: finiteNumber(row.totalTokens) ?? inputTokens + outputTokens + reasoningTokens,
+    costUsd: finiteNumber(row.costUsd) ?? 0,
+    latencyMs: finiteNumber(row.latencyMs) ?? 0,
+    status: row.status === 'error' || row.status === 'aborted' ? row.status : 'success',
+    startedAt: finiteNumber(row.startedAt) ?? ts,
+    date: typeof row.date === 'string' ? row.date : new Date(ts).toISOString().slice(0, 10),
+    ts,
+  } as PersistedLlmCallRecord;
+}
+
+export function normalizeToolInvocationRecord(input: unknown): PersistedToolInvocationRecord {
+  if (!isRecord(input)) throw invalid('tool invocation must be an object');
+  const row = input as Partial<PersistedToolInvocationRecord>;
+  const ts = finiteNumber(row.ts) ?? finiteNumber(row.startedAt) ?? 0;
+  return {
+    ...pickKnown(input, TOOL_KEYS),
+    id: typeof row.id === 'string' ? row.id : `tool_${row.toolCallId ?? row.turnId ?? ts}`,
+    toolName: typeof row.toolName === 'string' ? row.toolName : 'unknown',
+    durationMs: finiteNumber(row.durationMs) ?? 0,
+    status: row.status === 'error' || row.status === 'aborted' ? row.status : 'success',
+    bytesIn: finiteNumber(row.bytesIn) ?? 0,
+    bytesOut: finiteNumber(row.bytesOut) ?? 0,
+    startedAt: finiteNumber(row.startedAt) ?? ts,
+    date: typeof row.date === 'string' ? row.date : new Date(ts).toISOString().slice(0, 10),
+    ts,
+  } as PersistedToolInvocationRecord;
+}
+
+export function decodePersistedLlmCallRecord(input: unknown): PersistedLlmCallRecord {
+  if (!isRecord(input) || !hasOnlyKeys(input, LLM_KEYS)) throw invalid('invalid LLM row keys');
+  if (!strings(input, ['id', 'providerId', 'modelId', 'date'])) {
+    throw invalid('invalid required LLM string');
+  }
+  if (
+    !nonNegativeNumbers(input, [
+      'inputTokens',
+      'outputTokens',
+      'cacheHitInputTokens',
+      'cacheMissInputTokens',
+      'cachedInputTokens',
+      'cacheWriteInputTokens',
+      'reasoningTokens',
+      'totalTokens',
+      'latencyMs',
+      'costUsd',
+      'startedAt',
+      'ts',
+    ])
+  ) {
+    throw invalid('invalid required LLM number');
+  }
+  if (input.cachedInputTokens !== input.cacheHitInputTokens) {
+    throw invalid('cachedInputTokens must equal cacheHitInputTokens');
+  }
+  if (!['success', 'error', 'aborted'].includes(input.status as string)) {
+    throw invalid('invalid LLM status');
+  }
+  if (
+    !optionalStrings(input, [
+      'sessionId',
+      'turnId',
+      'callId',
+      'connectionSlug',
+      'rawFinishReason',
+      'errorClass',
+      'systemPromptHash',
+      'prefixHash',
+      'requestShapeHash',
+    ])
+  ) {
+    throw invalid('invalid optional LLM string');
+  }
+  if (!optionalEnum(input.callKind, new Set(['main', 'semantic_compact']))) {
+    throw invalid('invalid callKind');
+  }
+  if (!optionalEnum(input.prefixChangeReason, PREFIX_CHANGE_REASONS)) {
+    throw invalid('invalid prefixChangeReason');
+  }
+  if (!optionalEnum(input.requestShapeChangeReason, PREFIX_CHANGE_REASONS)) {
+    throw invalid('invalid requestShapeChangeReason');
+  }
+  if (!optionalEnum(input.toolSchemaChangeReason, TOOL_SCHEMA_CHANGE_REASONS)) {
+    throw invalid('invalid toolSchemaChangeReason');
+  }
+  if (!optionalEnum(input.cacheMissInputSource, new Set(['explicit', 'derived']))) {
+    throw invalid('invalid cacheMissInputSource');
+  }
+  if (input.rawUsage !== undefined && !isRawUsage(input.rawUsage)) {
+    throw invalid('invalid rawUsage');
+  }
+  if (input.toolAvailability !== undefined && !isToolAvailability(input.toolAvailability)) {
+    throw invalid('invalid toolAvailability');
+  }
+  if (
+    input.promptSegments !== undefined &&
+    (!Array.isArray(input.promptSegments) ||
+      !input.promptSegments.every(
+        (segment) => isPromptSegmentEstimate(segment) && hasNoNegativeNumbers(segment),
+      ))
+  ) {
+    throw invalid('invalid promptSegments');
+  }
+  if (
+    input.contextBudget !== undefined &&
+    (!isContextBudgetDiagnostic(input.contextBudget) || !hasNoNegativeNumbers(input.contextBudget))
+  ) {
+    throw invalid('invalid contextBudget');
+  }
+  return cloneAndFreeze(input) as unknown as PersistedLlmCallRecord;
+}
+
+export function decodePersistedToolInvocationRecord(input: unknown): PersistedToolInvocationRecord {
+  if (!isRecord(input) || !hasOnlyKeys(input, TOOL_KEYS)) throw invalid('invalid tool row keys');
+  if (!strings(input, ['id', 'toolName', 'date'])) {
+    throw invalid('invalid required tool string');
+  }
+  if (!nonNegativeNumbers(input, ['durationMs', 'bytesIn', 'bytesOut', 'startedAt', 'ts'])) {
+    throw invalid('invalid required tool number');
+  }
+  if (!['success', 'error', 'aborted'].includes(input.status as string)) {
+    throw invalid('invalid tool status');
+  }
+  if (
+    !optionalStrings(input, [
+      'sessionId',
+      'turnId',
+      'toolCallId',
+      'providerId',
+      'modelId',
+      'errorClass',
+      'argsSummary',
+    ])
+  ) {
+    throw invalid('invalid optional tool string');
+  }
+  if (input.resultSummary !== undefined && !isToolResultSummary(input.resultSummary)) {
+    throw invalid('invalid tool resultSummary');
+  }
+  return cloneAndFreeze(input) as unknown as PersistedToolInvocationRecord;
+}
+
+const RAW_USAGE_KEYS = new Set([
+  'prompt_tokens',
+  'completion_tokens',
+  'total_tokens',
+  'prompt_cache_hit_tokens',
+  'prompt_cache_miss_tokens',
+  'prompt_tokens_details',
+  'completion_tokens_details',
+]);
+const RAW_USAGE_NUMBERS = [
+  'prompt_tokens',
+  'completion_tokens',
+  'total_tokens',
+  'prompt_cache_hit_tokens',
+  'prompt_cache_miss_tokens',
+] as const;
+
+function isRawUsage(input: unknown): boolean {
+  return (
+    isRecord(input) &&
+    hasOnlyKeys(input, RAW_USAGE_KEYS) &&
+    optionalNonNegativeNumbers(input, RAW_USAGE_NUMBERS) &&
+    isTokenDetails(input.prompt_tokens_details, 'cached_tokens') &&
+    isTokenDetails(input.completion_tokens_details, 'reasoning_tokens')
+  );
+}
+
+function isTokenDetails(input: unknown, key: string): boolean {
+  return (
+    input === undefined ||
+    (isRecord(input) && hasOnlyKeys(input, new Set([key])) && optionalNonNegative(input[key]))
+  );
+}
+
+const TOOL_AVAILABILITY_NUMBERS = [
+  'visibleToolCount',
+  'fullToolCount',
+  'hiddenToolCount',
+  'visibleToolSchemaChars',
+  'fullToolSchemaChars',
+  'toolSchemaCharReduction',
+  'estimatedToolSchemaTokenReduction',
+] as const;
+const TOOL_AVAILABILITY_KEYS = new Set([
+  'mode',
+  'enabledSourceIds',
+  'availableSourceIds',
+  'connectorToolName',
+  'visibleToolNamesBySource',
+  ...TOOL_AVAILABILITY_NUMBERS,
+]);
+
+function isToolAvailability(input: unknown): boolean {
+  return (
+    isRecord(input) &&
+    hasOnlyKeys(input, TOOL_AVAILABILITY_KEYS) &&
+    input.mode === 'economy' &&
+    isStringArray(input.enabledSourceIds) &&
+    optionalStringArray(input.availableSourceIds) &&
+    optionalString(input.connectorToolName) &&
+    (input.visibleToolNamesBySource === undefined ||
+      (isRecord(input.visibleToolNamesBySource) &&
+        Object.values(input.visibleToolNamesBySource).every(isStringArray))) &&
+    optionalNonNegativeNumbers(input, TOOL_AVAILABILITY_NUMBERS)
+  );
+}
+
+function isToolResultSummary(input: unknown): boolean {
+  const numberKeys = [
+    'itemCount',
+    'startedItemCount',
+    'completedItemCount',
+    'failedItemCount',
+    'cancelledItemCount',
+    'artifactCount',
+  ] as const;
+  return (
+    isRecord(input) &&
+    hasOnlyKeys(input, new Set(['kind', 'status', ...numberKeys])) &&
+    typeof input.kind === 'string' &&
+    optionalString(input.status) &&
+    optionalNonNegativeNumbers(input, numberKeys)
+  );
+}
+
+function assertArray(
+  value: Record<string, unknown>,
+  key: 'usageRecords' | 'toolInvocations',
+): asserts value is Record<string, unknown> & Record<typeof key, unknown[]> {
+  if (!Array.isArray(value[key])) throw invalid(`${key} must be an array`);
+}
+
+function assertOptionalArray(
+  value: Record<string, unknown>,
+  key: 'usageRecords' | 'toolInvocations' | 'pricingOverrides',
+): void {
+  if (key in value && !Array.isArray(value[key])) throw invalid(`${key} must be an array`);
+}
+
+function pickKnown(
+  value: Record<string, unknown>,
+  allowed: ReadonlySet<string>,
+): Record<string, unknown> {
+  return Object.fromEntries(Object.entries(value).filter(([key]) => allowed.has(key)));
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: ReadonlySet<string>): boolean {
+  return Object.keys(value).every((key) => allowed.has(key));
+}
+
+function strings(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return keys.every((key) => typeof value[key] === 'string');
+}
+
+function optionalStrings(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return keys.every((key) => optionalString(value[key]));
+}
+
+function nonNegativeNumbers(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  return keys.every((key) => isNonNegativeFinite(value[key]));
+}
+
+function optionalNonNegativeNumbers(
+  value: Record<string, unknown>,
+  keys: readonly string[],
+): boolean {
+  return keys.every((key) => optionalNonNegative(value[key]));
+}
+
+function optionalNonNegative(value: unknown): boolean {
+  return value === undefined || isNonNegativeFinite(value);
+}
+
+function isNonNegativeFinite(value: unknown): value is number {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0;
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  return isNonNegativeFinite(value) ? value : undefined;
+}
+
+function optionalEnum(value: unknown, allowed: ReadonlySet<string>): boolean {
+  return value === undefined || (typeof value === 'string' && allowed.has(value));
+}
+
+function optionalString(value: unknown): boolean {
+  return value === undefined || typeof value === 'string';
+}
+
+function optionalStringArray(value: unknown): boolean {
+  return value === undefined || isStringArray(value);
+}
+
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((item) => typeof item === 'string');
+}
+
+function hasNoNegativeNumbers(value: unknown): boolean {
+  if (typeof value === 'number') return value >= 0;
+  if (Array.isArray(value)) return value.every(hasNoNegativeNumbers);
+  if (isRecord(value)) return Object.values(value).every(hasNoNegativeNumbers);
+  return true;
+}
+
+function cloneAndFreeze<T>(value: T): T {
+  let clone: T;
+  try {
+    clone = structuredClone(value);
+  } catch (error) {
+    throw invalid(`record must be structured-cloneable: ${String(error)}`);
+  }
+  return deepFreeze(clone);
+}
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== 'object' || value === null || Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value)) deepFreeze(nested);
+  return Object.freeze(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function invalid(message: string): Error {
+  return new Error(`Invalid telemetry file: ${message}`);
+}

--- a/packages/storage/src/telemetry-repo.ts
+++ b/packages/storage/src/telemetry-repo.ts
@@ -1,4 +1,5 @@
-import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { randomUUID } from 'node:crypto';
+import { mkdir, open, readFile, rename, rm } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import type {
   PricingConfig,
@@ -7,210 +8,366 @@ import type {
   UsageLogRow,
   UsageQuery,
   UsageSummaryV2,
-  LlmCallRecord,
-  ToolInvocationRecord,
 } from '@maka/core/usage-stats/types';
+import { createPricingStore, type PricingStore } from './pricing-store.js';
+import { syncDirectory } from './stable-storage.js';
+import {
+  decodeTelemetryFile,
+  decodePersistedLlmCallRecord,
+  decodePersistedToolInvocationRecord,
+  emptyTelemetryFile,
+  type PersistedLlmCallRecord,
+  type PersistedToolInvocationRecord,
+  type TelemetryFile,
+} from './telemetry-file-schema.js';
 
-type PersistedLlmCallRecord = LlmCallRecord & {
-  id: string;
-  cacheHitInputTokens: number;
-  cacheMissInputTokens: number;
-  cachedInputTokens: number;
-  cacheWriteInputTokens: number;
-  reasoningTokens: number;
-  totalTokens: number;
-  costUsd: number;
-  date: string;
-  ts: number;
-};
+export type {
+  PersistedLlmCallRecord,
+  PersistedToolInvocationRecord,
+} from './telemetry-file-schema.js';
 
-type PersistedToolInvocationRecord = ToolInvocationRecord & {
-  id: string;
-  argsSummary?: string;
-  bytesIn: number;
-  bytesOut: number;
-  date: string;
-  ts: number;
-};
-
-interface TelemetryFile {
-  usageRecords: PersistedLlmCallRecord[];
-  toolInvocations: PersistedToolInvocationRecord[];
-  pricingOverrides: PricingConfig[];
+export interface ToolUsageQuery {
+  readonly range: UsageQuery['range'];
+  readonly toolName?: string;
+  readonly status?: UsageQuery['status'];
 }
 
 export interface TelemetryRepo {
-  insertLlmCall(record: PersistedLlmCallRecord): void;
-  insertToolInvocation(record: PersistedToolInvocationRecord): void;
+  insertLlmCall(record: PersistedLlmCallRecord): Promise<void>;
+  insertToolInvocation(record: PersistedToolInvocationRecord): Promise<void>;
   summary(query: UsageQuery): UsageSummaryV2;
   buckets(query: UsageQuery, groupBy: UsageGroupBy): UsageBucket[];
   logs(query: UsageQuery, offset?: number, limit?: number): { rows: UsageLogRow[]; total: number };
+  toolLogs(
+    query: ToolUsageQuery,
+    offset?: number,
+    limit?: number,
+  ): { rows: PersistedToolInvocationRecord[]; total: number };
   latestLlmRuntimeProbe(connectionSlug: string, modelId?: string): UsageLogRow | undefined;
   listPricingOverrides(): PricingConfig[];
   upsertPricing(pricing: PricingConfig): Promise<void>;
   deletePricing(modelKey: string): Promise<void>;
+  legacyPricingOverrides(): readonly unknown[];
+  publishCanonical(): Promise<void>;
   load(): Promise<void>;
+  flush(): Promise<void>;
+  close(): Promise<void>;
 }
 
-export function createTelemetryRepo(workspaceRoot: string): TelemetryRepo {
-  return new FileTelemetryRepo(workspaceRoot);
+export interface CreateTelemetryRepoOptions {
+  readonly createIfMissing?: boolean;
+  readonly managePricing?: boolean;
+}
+
+export class TelemetryRepoClosedError extends Error {
+  constructor() {
+    super('Telemetry repository is draining or closed');
+    this.name = 'TelemetryRepoClosedError';
+  }
+}
+
+export class TelemetryRepoNotLoadedError extends Error {
+  constructor() {
+    super('Telemetry repository has not been loaded');
+    this.name = 'TelemetryRepoNotLoadedError';
+  }
+}
+
+export class TelemetryQueryValidationError extends Error {
+  constructor(message: string) {
+    super(`Invalid telemetry query: ${message}`);
+    this.name = 'TelemetryQueryValidationError';
+  }
+}
+
+export class TelemetryRepoPublicationError extends Error {
+  readonly domain = 'telemetry_authority';
+
+  constructor(
+    readonly commitUnknown: boolean,
+    options: { cause: unknown },
+  ) {
+    super(
+      commitUnknown
+        ? 'Telemetry publication outcome is unknown; reopen before retrying'
+        : 'Unable to publish telemetry',
+      options,
+    );
+    this.name = 'TelemetryRepoPublicationError';
+  }
+}
+
+export function createTelemetryRepo(
+  workspaceRoot: string,
+  options: CreateTelemetryRepoOptions = {},
+): TelemetryRepo {
+  return new FileTelemetryRepo(
+    workspaceRoot,
+    options.createIfMissing ?? true,
+    options.managePricing ?? true,
+  );
 }
 
 class FileTelemetryRepo implements TelemetryRepo {
   private readonly path: string;
-  private file: TelemetryFile = emptyFile();
+  private file: TelemetryFile = emptyTelemetryFile();
+  private legacyPricing: readonly unknown[] = [];
+  private requiresCanonicalPublication = false;
+  private pricingStore: PricingStore | undefined;
   private loaded = false;
   private queue: Promise<void> = Promise.resolve();
+  private failure: TelemetryRepoPublicationError | undefined;
+  private state: 'open' | 'draining' | 'closed' = 'open';
+  private closePromise: Promise<void> | undefined;
 
-  constructor(workspaceRoot: string) {
+  constructor(
+    workspaceRoot: string,
+    private readonly createIfMissing: boolean,
+    private readonly managePricing: boolean,
+  ) {
     this.path = join(workspaceRoot, 'telemetry.json');
   }
 
   async load(): Promise<void> {
     if (this.loaded) return;
+    this.assertOpen();
+    let missing = false;
     try {
-      const text = await readFile(this.path, 'utf8');
-      this.file = normalizeFile(JSON.parse(text));
+      const decoded = decodeTelemetryFile(JSON.parse(await readFile(this.path, 'utf8')));
+      this.file = decoded.file;
+      this.legacyPricing = decoded.legacyPricingOverrides;
+      this.requiresCanonicalPublication = decoded.requiresCanonicalPublication;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
-      this.file = emptyFile();
-      await this.write();
+      missing = true;
+      this.file = emptyTelemetryFile();
+    }
+
+    if (this.managePricing) {
+      this.pricingStore = createPricingStore(dirname(this.path), {
+        createIfMissing: this.createIfMissing,
+        initialOverrides: this.legacyPricing,
+      });
+      await this.pricingStore.load();
+    }
+    if (
+      this.createIfMissing &&
+      (missing || (this.managePricing && this.requiresCanonicalPublication))
+    ) {
+      await this.publish(this.file);
+      this.requiresCanonicalPublication = false;
     }
     this.loaded = true;
   }
 
-  insertLlmCall(record: PersistedLlmCallRecord): void {
-    this.file.usageRecords = upsertById(this.file.usageRecords, record);
-    void this.enqueueWrite();
+  insertLlmCall(record: PersistedLlmCallRecord): Promise<void> {
+    let admitted: PersistedLlmCallRecord;
+    try {
+      admitted = decodePersistedLlmCallRecord(record);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    return this.enqueueMutation((file) => ({
+      ...file,
+      usageRecords: upsertById(file.usageRecords, admitted),
+    }));
   }
 
-  insertToolInvocation(record: PersistedToolInvocationRecord): void {
-    this.file.toolInvocations = upsertById(this.file.toolInvocations, record);
-    void this.enqueueWrite();
+  insertToolInvocation(record: PersistedToolInvocationRecord): Promise<void> {
+    let admitted: PersistedToolInvocationRecord;
+    try {
+      admitted = decodePersistedToolInvocationRecord(record);
+    } catch (error) {
+      return Promise.reject(error);
+    }
+    return this.enqueueMutation((file) => ({
+      ...file,
+      toolInvocations: upsertById(file.toolInvocations, admitted),
+    }));
   }
 
   summary(query: UsageQuery): UsageSummaryV2 {
+    this.assertReady();
     const { from, to } = resolveRange(query.range);
     const rows = this.filteredUsageRows(query, from, to);
-    const input = sum(rows.map((row) => row.inputTokens));
-    const output = sum(rows.map((row) => row.outputTokens));
-    const cacheMiss = sum(rows.map((row) => row.cacheMissInputTokens));
-    const cacheRead = sum(rows.map((row) => row.cacheHitInputTokens));
-    const cacheWrite = sum(rows.map((row) => row.cacheWriteInputTokens));
-    const reasoning = sum(rows.map((row) => row.reasoningTokens));
-    return {
+    return detached({
       range: { from, to },
       totalRequests: rows.length,
       totalCostUsd: sum(rows.map((row) => row.costUsd)),
       totalTokens: {
-        input,
-        output,
-        cacheMiss,
-        cacheRead,
-        cacheWrite,
-        reasoning,
+        input: sum(rows.map((row) => row.inputTokens)),
+        output: sum(rows.map((row) => row.outputTokens)),
+        cacheMiss: sum(rows.map((row) => row.cacheMissInputTokens)),
+        cacheRead: sum(rows.map((row) => row.cacheHitInputTokens)),
+        cacheWrite: sum(rows.map((row) => row.cacheWriteInputTokens)),
+        reasoning: sum(rows.map((row) => row.reasoningTokens)),
         total: sum(rows.map((row) => row.totalTokens)),
       },
       cacheHitRequests: rows.filter((row) => row.cacheHitInputTokens > 0).length,
       cacheCreateRequests: rows.filter((row) => row.cacheWriteInputTokens > 0).length,
       errorRequests: rows.filter((row) => row.status === 'error').length,
-    };
+    });
   }
 
   buckets(query: UsageQuery, groupBy: UsageGroupBy): UsageBucket[] {
+    this.assertReady();
     const { from, to } = resolveRange(query.range);
-    if (groupBy === 'tool') return toolBuckets(this.filteredToolRows(query, from, to));
-    const rows = this.filteredUsageRows(query, from, to);
-    const groups = new Map<string, PersistedLlmCallRecord[]>();
-    for (const row of rows) {
-      const key = bucketKey(row, groupBy);
-      const list = groups.get(key) ?? [];
-      list.push(row);
-      groups.set(key, list);
+    if (groupBy === 'tool') {
+      return detached(toolBuckets(this.filteredToolRows(query, from, to)));
     }
-    return [...groups.entries()]
-      .map(([key, groupRows]) => usageBucket(key, groupRows))
-      .sort((a, b) => b.requests - a.requests);
+    const groups = new Map<string, PersistedLlmCallRecord[]>();
+    for (const row of this.filteredUsageRows(query, from, to)) {
+      const key = bucketKey(row, groupBy);
+      let group = groups.get(key);
+      if (!group) {
+        group = [];
+        groups.set(key, group);
+      }
+      group.push(row);
+    }
+    return detached(
+      [...groups.entries()]
+        .map(([key, rows]) => usageBucket(key, rows))
+        .sort((left, right) => right.requests - left.requests),
+    );
   }
 
   logs(query: UsageQuery, offset = 0, limit = 100): { rows: UsageLogRow[]; total: number } {
+    this.assertReady();
+    if (query.toolName !== undefined) {
+      throw new TelemetryQueryValidationError('toolName is not applicable to LLM logs');
+    }
     const { from, to } = resolveRange(query.range);
-    const rows = this.filteredUsageRows(query, from, to)
-      .sort((a, b) => b.ts - a.ts)
-      .map(
-        (row) =>
-          ({
-            id: row.id,
-            ts: row.ts,
-            ...(row.callKind ? { callKind: row.callKind } : {}),
-            ...(row.callId ? { callId: row.callId } : {}),
-            ...(row.connectionSlug ? { connectionSlug: row.connectionSlug } : {}),
-            providerId: row.providerId,
-            modelId: row.modelId,
-            inputTokens: row.inputTokens,
-            outputTokens: row.outputTokens,
-            cacheMissTokens: row.cacheMissInputTokens,
-            cacheReadTokens: row.cacheHitInputTokens,
-            cacheWriteTokens: row.cacheWriteInputTokens,
-            ...(row.cacheMissInputSource ? { cacheMissInputSource: row.cacheMissInputSource } : {}),
-            reasoningTokens: row.reasoningTokens,
-            totalTokens: row.totalTokens,
-            costUsd: row.costUsd,
-            latencyMs: row.latencyMs,
-            status: row.status,
-            ...(row.errorClass ? { errorClass: row.errorClass } : {}),
-            ...(row.sessionId ? { sessionId: row.sessionId } : {}),
-            ...(row.turnId ? { turnId: row.turnId } : {}),
-            ...(row.systemPromptHash ? { systemPromptHash: row.systemPromptHash } : {}),
-            ...(row.prefixHash ? { prefixHash: row.prefixHash } : {}),
-            ...(row.prefixChangeReason ? { prefixChangeReason: row.prefixChangeReason } : {}),
-            ...(row.requestShapeHash ? { requestShapeHash: row.requestShapeHash } : {}),
-            ...(row.requestShapeChangeReason
-              ? { requestShapeChangeReason: row.requestShapeChangeReason }
-              : {}),
-            ...(row.toolSchemaChangeReason
-              ? { toolSchemaChangeReason: row.toolSchemaChangeReason }
-              : {}),
-            ...(row.toolAvailability ? { toolAvailability: row.toolAvailability } : {}),
-            ...(row.promptSegments ? { promptSegments: row.promptSegments } : {}),
-            ...(row.contextBudget ? { contextBudget: row.contextBudget } : {}),
-          }) satisfies UsageLogRow,
-      );
-    return { rows: rows.slice(offset, offset + limit), total: rows.length };
+    const rows = this.filteredUsageRows(query, from, to).sort((left, right) => right.ts - left.ts);
+    const total = rows.length;
+    return detached({
+      rows: rows.slice(offset, offset + limit).map(toUsageLogRow),
+      total,
+    });
+  }
+
+  toolLogs(
+    query: ToolUsageQuery,
+    offset = 0,
+    limit = 100,
+  ): { rows: PersistedToolInvocationRecord[]; total: number } {
+    this.assertReady();
+    assertToolUsageQuery(query);
+    const { from, to } = resolveRange(query.range);
+    const rows = this.filteredToolRows(query, from, to).sort((left, right) => right.ts - left.ts);
+    return detached({ rows: rows.slice(offset, offset + limit), total: rows.length });
   }
 
   latestLlmRuntimeProbe(connectionSlug: string, modelId?: string): UsageLogRow | undefined {
-    return this.logs(
-      {
-        range: 'all',
-        connectionSlug,
-        ...(modelId ? { modelId } : {}),
-      },
-      0,
-      1,
-    ).rows[0];
+    return this.logs({ range: 'all', connectionSlug, ...(modelId ? { modelId } : {}) }, 0, 1)
+      .rows[0];
   }
 
   listPricingOverrides(): PricingConfig[] {
-    return [...this.file.pricingOverrides];
+    this.assertReady();
+    if (this.pricingStore)
+      return this.pricingStore.snapshot().overrides.map((item) => ({ ...item }));
+    return [];
   }
 
   async upsertPricing(pricing: PricingConfig): Promise<void> {
-    this.file.pricingOverrides = [
-      ...this.file.pricingOverrides.filter((item) => item.modelKey !== pricing.modelKey),
-      pricing,
-    ].sort((a, b) => a.modelKey.localeCompare(b.modelKey));
-    await this.enqueueWrite();
+    const store = this.requireManagedPricing();
+    const snapshot = store.snapshot();
+    await store.upsert(snapshot.revision, pricing);
   }
 
   async deletePricing(modelKey: string): Promise<void> {
-    this.file.pricingOverrides = this.file.pricingOverrides.filter(
-      (item) => item.modelKey !== modelKey,
-    );
-    await this.enqueueWrite();
+    const store = this.requireManagedPricing();
+    const snapshot = store.snapshot();
+    await store.delete(snapshot.revision, modelKey);
   }
 
-  private filteredUsageRows(query: UsageQuery, from: number, to: number): PersistedLlmCallRecord[] {
+  legacyPricingOverrides(): readonly unknown[] {
+    this.assertReady();
+    return structuredClone(this.legacyPricing);
+  }
+
+  publishCanonical(): Promise<void> {
+    this.assertReady();
+    if (!this.requiresCanonicalPublication) return this.flush();
+    return this.enqueueMutation((file) => file);
+  }
+
+  async flush(): Promise<void> {
+    this.assertLoaded();
+    await this.queue;
+    if (this.failure) throw this.failure;
+  }
+
+  close(): Promise<void> {
+    if (this.closePromise) return this.closePromise;
+    this.state = 'draining';
+    this.closePromise = Promise.allSettled([
+      this.queue.then(() => {
+        if (this.failure) throw this.failure;
+      }),
+      this.pricingStore?.close() ?? Promise.resolve(),
+    ])
+      .then((results) => {
+        const failures = results.flatMap((result) =>
+          result.status === 'rejected' ? [result.reason] : [],
+        );
+        if (failures.length === 1) throw failures[0];
+        if (failures.length > 1) {
+          throw new AggregateError(failures, 'Unable to close telemetry repository');
+        }
+      })
+      .finally(() => {
+        this.state = 'closed';
+      });
+    return this.closePromise;
+  }
+
+  private enqueueMutation(mutate: (file: TelemetryFile) => TelemetryFile): Promise<void> {
+    this.assertReady();
+    const operation = this.queue.then(async () => {
+      if (this.failure) throw this.failure;
+      const candidate = mutate(this.file);
+      try {
+        await this.publish(candidate);
+      } catch (error) {
+        const failure =
+          error instanceof TelemetryRepoPublicationError
+            ? error
+            : new TelemetryRepoPublicationError(false, { cause: error });
+        this.failure = failure;
+        throw failure;
+      }
+      this.file = candidate;
+      this.requiresCanonicalPublication = false;
+    });
+    this.queue = operation.catch(() => undefined);
+    return operation;
+  }
+
+  private async publish(file: TelemetryFile): Promise<void> {
+    await mkdir(dirname(this.path), { recursive: true });
+    const temporaryPath = `${this.path}.${randomUUID()}.tmp`;
+    let handle: Awaited<ReturnType<typeof open>> | undefined;
+    let published = false;
+    try {
+      handle = await open(temporaryPath, 'wx', 0o600);
+      await handle.writeFile(JSON.stringify(file, null, 2) + '\n', 'utf8');
+      await handle.sync();
+      await handle.close();
+      handle = undefined;
+      await rename(temporaryPath, this.path);
+      published = true;
+      await syncDirectory(dirname(this.path));
+    } catch (cause) {
+      throw new TelemetryRepoPublicationError(published, { cause });
+    } finally {
+      await handle?.close().catch(() => undefined);
+      if (!published) await rm(temporaryPath, { force: true }).catch(() => undefined);
+    }
+  }
+
+  private filteredUsageRows(query: UsageQuery, from: number, to: number) {
     return this.file.usageRecords.filter((row) => {
       if (row.ts < from || row.ts > to) return false;
       if (query.connectionSlug && row.connectionSlug !== query.connectionSlug) return false;
@@ -221,11 +378,7 @@ class FileTelemetryRepo implements TelemetryRepo {
     });
   }
 
-  private filteredToolRows(
-    query: UsageQuery,
-    from: number,
-    to: number,
-  ): PersistedToolInvocationRecord[] {
+  private filteredToolRows(query: UsageQuery, from: number, to: number) {
     return this.file.toolInvocations.filter((row) => {
       if (row.ts < from || row.ts > to) return false;
       if (query.toolName && row.toolName !== query.toolName) return false;
@@ -234,90 +387,67 @@ class FileTelemetryRepo implements TelemetryRepo {
     });
   }
 
-  private enqueueWrite(): Promise<void> {
-    const next = this.queue.then(
-      () => this.write(),
-      () => this.write(),
-    );
-    this.queue = next.catch(() => {});
-    return next;
+  private requireManagedPricing(): PricingStore {
+    this.assertReady();
+    if (!this.pricingStore) {
+      throw new Error('Telemetry repository does not own the compatibility pricing facade');
+    }
+    return this.pricingStore;
   }
 
-  private async write(): Promise<void> {
-    await mkdir(dirname(this.path), { recursive: true });
-    const tempPath = `${this.path}.${process.pid}.${Date.now()}.tmp`;
-    await writeFile(tempPath, JSON.stringify(this.file, null, 2) + '\n', 'utf8');
-    await rename(tempPath, this.path);
+  private assertLoaded(): void {
+    if (!this.loaded) throw new TelemetryRepoNotLoadedError();
+  }
+
+  private assertOpen(): void {
+    if (this.state !== 'open') throw new TelemetryRepoClosedError();
+  }
+
+  private assertReady(): void {
+    this.assertOpen();
+    this.assertLoaded();
+    if (this.failure?.commitUnknown) throw this.failure;
   }
 }
 
-function emptyFile(): TelemetryFile {
-  return { usageRecords: [], toolInvocations: [], pricingOverrides: [] };
-}
-
-function normalizeFile(input: unknown): TelemetryFile {
-  if (!input || typeof input !== 'object' || Array.isArray(input)) {
-    throw new Error('Invalid telemetry file: expected an object');
-  }
-  const value = input as Partial<TelemetryFile>;
-  const hasKnownSection =
-    'usageRecords' in value || 'toolInvocations' in value || 'pricingOverrides' in value;
-  if (!hasKnownSection) {
-    throw new Error('Invalid telemetry file: expected known telemetry sections');
-  }
-  assertOptionalArraySection(value, 'usageRecords');
-  assertOptionalArraySection(value, 'toolInvocations');
-  assertOptionalArraySection(value, 'pricingOverrides');
+function toUsageLogRow(row: PersistedLlmCallRecord): UsageLogRow {
   return {
-    usageRecords: value.usageRecords ? value.usageRecords.map(normalizeLlmCallRecord) : [],
-    toolInvocations: value.toolInvocations ?? [],
-    pricingOverrides: value.pricingOverrides ?? [],
+    id: row.id,
+    ts: row.ts,
+    ...(row.callKind ? { callKind: row.callKind } : {}),
+    ...(row.callId ? { callId: row.callId } : {}),
+    ...(row.connectionSlug ? { connectionSlug: row.connectionSlug } : {}),
+    providerId: row.providerId,
+    modelId: row.modelId,
+    inputTokens: row.inputTokens,
+    outputTokens: row.outputTokens,
+    cacheMissTokens: row.cacheMissInputTokens,
+    cacheReadTokens: row.cacheHitInputTokens,
+    cacheWriteTokens: row.cacheWriteInputTokens,
+    ...(row.cacheMissInputSource ? { cacheMissInputSource: row.cacheMissInputSource } : {}),
+    reasoningTokens: row.reasoningTokens,
+    totalTokens: row.totalTokens,
+    costUsd: row.costUsd,
+    latencyMs: row.latencyMs,
+    status: row.status,
+    ...(row.errorClass ? { errorClass: row.errorClass } : {}),
+    ...(row.sessionId ? { sessionId: row.sessionId } : {}),
+    ...(row.turnId ? { turnId: row.turnId } : {}),
+    ...(row.systemPromptHash ? { systemPromptHash: row.systemPromptHash } : {}),
+    ...(row.prefixHash ? { prefixHash: row.prefixHash } : {}),
+    ...(row.prefixChangeReason ? { prefixChangeReason: row.prefixChangeReason } : {}),
+    ...(row.requestShapeHash ? { requestShapeHash: row.requestShapeHash } : {}),
+    ...(row.requestShapeChangeReason
+      ? { requestShapeChangeReason: row.requestShapeChangeReason }
+      : {}),
+    ...(row.toolSchemaChangeReason ? { toolSchemaChangeReason: row.toolSchemaChangeReason } : {}),
+    ...(row.toolAvailability ? { toolAvailability: row.toolAvailability } : {}),
+    ...(row.promptSegments ? { promptSegments: row.promptSegments } : {}),
+    ...(row.contextBudget ? { contextBudget: row.contextBudget } : {}),
   };
 }
 
-function assertOptionalArraySection<T extends object>(value: T, key: keyof T): void {
-  if (key in value && !Array.isArray(value[key])) {
-    throw new Error(`Invalid telemetry file: ${String(key)} must be an array`);
-  }
-}
-
-function normalizeLlmCallRecord(input: unknown): PersistedLlmCallRecord {
-  const row = input as Partial<PersistedLlmCallRecord>;
-  const inputTokens = finiteNumber(row.inputTokens) ?? 0;
-  const outputTokens = finiteNumber(row.outputTokens) ?? 0;
-  const cacheHitInputTokens =
-    finiteNumber(row.cacheHitInputTokens) ?? finiteNumber(row.cachedInputTokens) ?? 0;
-  const cacheWriteInputTokens = finiteNumber(row.cacheWriteInputTokens) ?? 0;
-  const cacheMissInputTokens =
-    finiteNumber(row.cacheMissInputTokens) ??
-    Math.max(0, inputTokens - cacheHitInputTokens - cacheWriteInputTokens);
-  const reasoningTokens = finiteNumber(row.reasoningTokens) ?? 0;
-  return {
-    ...row,
-    id: typeof row.id === 'string' ? row.id : `usage_${row.turnId ?? row.ts ?? 'unknown'}`,
-    providerId: typeof row.providerId === 'string' ? row.providerId : 'unknown',
-    modelId: typeof row.modelId === 'string' ? row.modelId : 'unknown',
-    inputTokens,
-    outputTokens,
-    cacheHitInputTokens,
-    cacheMissInputTokens,
-    cachedInputTokens: cacheHitInputTokens,
-    cacheWriteInputTokens,
-    reasoningTokens,
-    totalTokens: finiteNumber(row.totalTokens) ?? inputTokens + outputTokens + reasoningTokens,
-    costUsd: finiteNumber(row.costUsd) ?? 0,
-    latencyMs: finiteNumber(row.latencyMs) ?? 0,
-    status: row.status === 'error' || row.status === 'aborted' ? row.status : 'success',
-    startedAt: finiteNumber(row.startedAt) ?? finiteNumber(row.ts) ?? 0,
-    date:
-      typeof row.date === 'string'
-        ? row.date
-        : new Date(finiteNumber(row.ts) ?? 0).toISOString().slice(0, 10),
-    ts: finiteNumber(row.ts) ?? 0,
-  };
-}
-
-function upsertById<T extends { id: string }>(rows: T[], row: T): T[] {
+function upsertById<T extends { id: string }>(rows: readonly T[], row: T): T[] {
   return [...rows.filter((current) => current.id !== row.id), row];
 }
 
@@ -351,8 +481,8 @@ function bucketKey(row: PersistedLlmCallRecord, groupBy: UsageGroupBy): string {
   }
 }
 
-function usageBucket(key: string, rows: PersistedLlmCallRecord[]): UsageBucket {
-  const errorCount = rows.filter((row) => row.status === 'error').length;
+function usageBucket(key: string, rows: readonly PersistedLlmCallRecord[]): UsageBucket {
+  const errors = rows.filter((row) => row.status === 'error').length;
   return {
     key,
     label: key,
@@ -366,47 +496,63 @@ function usageBucket(key: string, rows: PersistedLlmCallRecord[]): UsageBucket {
     totalTokens: sum(rows.map((row) => row.totalTokens)),
     costUsd: sum(rows.map((row) => row.costUsd)),
     avgLatencyMs: rows.length ? Math.round(sum(rows.map((row) => row.latencyMs)) / rows.length) : 0,
-    errorRate: rows.length ? errorCount / rows.length : 0,
+    errorRate: rows.length ? errors / rows.length : 0,
   };
 }
 
-function toolBuckets(rows: PersistedToolInvocationRecord[]): UsageBucket[] {
+function toolBuckets(rows: readonly PersistedToolInvocationRecord[]): UsageBucket[] {
   const groups = new Map<string, PersistedToolInvocationRecord[]>();
   for (const row of rows) {
-    const list = groups.get(row.toolName) ?? [];
-    list.push(row);
-    groups.set(row.toolName, list);
+    let group = groups.get(row.toolName);
+    if (!group) {
+      group = [];
+      groups.set(row.toolName, group);
+    }
+    group.push(row);
   }
   return [...groups.entries()]
-    .map(([key, groupRows]) => {
-      const errorCount = groupRows.filter((row) => row.status === 'error').length;
-      const inputBytes = sum(groupRows.map((row) => row.bytesIn));
-      const outputBytes = sum(groupRows.map((row) => row.bytesOut));
+    .map(([key, group]) => {
+      const errors = group.filter((row) => row.status === 'error').length;
+      const bytesIn = sum(group.map((row) => row.bytesIn));
+      const bytesOut = sum(group.map((row) => row.bytesOut));
       return {
         key,
         label: key,
-        requests: groupRows.length,
-        inputTokens: inputBytes,
-        outputTokens: outputBytes,
+        requests: group.length,
+        inputTokens: bytesIn,
+        outputTokens: bytesOut,
         cacheMissTokens: 0,
         cacheReadTokens: 0,
         cacheWriteTokens: 0,
         reasoningTokens: 0,
-        totalTokens: inputBytes + outputBytes,
+        totalTokens: bytesIn + bytesOut,
         costUsd: 0,
-        avgLatencyMs: groupRows.length
-          ? Math.round(sum(groupRows.map((row) => row.durationMs)) / groupRows.length)
+        avgLatencyMs: group.length
+          ? Math.round(sum(group.map((row) => row.durationMs)) / group.length)
           : 0,
-        errorRate: groupRows.length ? errorCount / groupRows.length : 0,
-      } satisfies UsageBucket;
+        errorRate: group.length ? errors / group.length : 0,
+      };
     })
-    .sort((a, b) => b.requests - a.requests);
+    .sort((left, right) => right.requests - left.requests);
 }
 
-function sum(values: number[]): number {
+function sum(values: readonly number[]): number {
   return values.reduce((total, value) => total + value, 0);
 }
 
-function finiteNumber(value: unknown): number | undefined {
-  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined;
+function assertToolUsageQuery(query: ToolUsageQuery): void {
+  const keys = Object.keys(query);
+  if (keys.some((key) => !['range', 'toolName', 'status'].includes(key))) {
+    throw new TelemetryQueryValidationError('tool logs accept only range, toolName, and status');
+  }
+}
+
+function detached<T>(value: T): T {
+  return deepFreeze(structuredClone(value));
+}
+
+function deepFreeze<T>(value: T): T {
+  if (typeof value !== 'object' || value === null || Object.isFrozen(value)) return value;
+  for (const nested of Object.values(value)) deepFreeze(nested);
+  return Object.freeze(value);
 }

--- a/packages/storage/src/telemetry-repo.ts
+++ b/packages/storage/src/telemetry-repo.ts
@@ -9,6 +9,7 @@ import type {
   UsageQuery,
   UsageSummaryV2,
 } from '@maka/core/usage-stats/types';
+import { throwDeduplicatedFailures } from './failure-utils.js';
 import { createPricingStore, type PricingStore } from './pricing-store.js';
 import { syncDirectory } from './stable-storage.js';
 import {
@@ -118,6 +119,7 @@ class FileTelemetryRepo implements TelemetryRepo {
   private queue: Promise<void> = Promise.resolve();
   private failure: TelemetryRepoPublicationError | undefined;
   private state: 'open' | 'draining' | 'closed' = 'open';
+  private loadPromise: Promise<void> | undefined;
   private closePromise: Promise<void> | undefined;
 
   constructor(
@@ -128,35 +130,55 @@ class FileTelemetryRepo implements TelemetryRepo {
     this.path = join(workspaceRoot, 'telemetry.json');
   }
 
-  async load(): Promise<void> {
-    if (this.loaded) return;
+  load(): Promise<void> {
+    if (this.loaded) return Promise.resolve();
     this.assertOpen();
+    if (this.loadPromise) return this.loadPromise;
+    const operation = this.loadFromDisk();
+    this.loadPromise = operation;
+    void operation.catch(() => {
+      if (this.state === 'open' && this.loadPromise === operation) {
+        this.loadPromise = undefined;
+      }
+    });
+    return operation;
+  }
+
+  private async loadFromDisk(): Promise<void> {
     let missing = false;
+    let file: TelemetryFile;
+    let legacyPricing: readonly unknown[];
+    let requiresCanonicalPublication: boolean;
+    let pricingStore: PricingStore | undefined;
     try {
       const decoded = decodeTelemetryFile(JSON.parse(await readFile(this.path, 'utf8')));
-      this.file = decoded.file;
-      this.legacyPricing = decoded.legacyPricingOverrides;
-      this.requiresCanonicalPublication = decoded.requiresCanonicalPublication;
+      file = decoded.file;
+      legacyPricing = decoded.legacyPricingOverrides;
+      requiresCanonicalPublication = decoded.requiresCanonicalPublication;
     } catch (error) {
       if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
       missing = true;
-      this.file = emptyTelemetryFile();
+      file = emptyTelemetryFile();
+      legacyPricing = [];
+      requiresCanonicalPublication = false;
     }
 
     if (this.managePricing) {
-      this.pricingStore = createPricingStore(dirname(this.path), {
+      pricingStore = createPricingStore(dirname(this.path), {
         createIfMissing: this.createIfMissing,
-        initialOverrides: this.legacyPricing,
+        initialOverrides: legacyPricing,
       });
-      await this.pricingStore.load();
+      await pricingStore.load();
     }
-    if (
-      this.createIfMissing &&
-      (missing || (this.managePricing && this.requiresCanonicalPublication))
-    ) {
-      await this.publish(this.file);
-      this.requiresCanonicalPublication = false;
+    if (this.createIfMissing && (missing || (this.managePricing && requiresCanonicalPublication))) {
+      await this.publish(file);
+      requiresCanonicalPublication = false;
     }
+
+    this.file = file;
+    this.legacyPricing = legacyPricing;
+    this.requiresCanonicalPublication = requiresCanonicalPublication;
+    this.pricingStore = pricingStore;
     this.loaded = true;
   }
 
@@ -302,25 +324,26 @@ class FileTelemetryRepo implements TelemetryRepo {
   close(): Promise<void> {
     if (this.closePromise) return this.closePromise;
     this.state = 'draining';
-    this.closePromise = Promise.allSettled([
+    this.closePromise = this.closeResources().finally(() => {
+      this.state = 'closed';
+    });
+    return this.closePromise;
+  }
+
+  private async closeResources(): Promise<void> {
+    const settled = await Promise.allSettled([
+      this.loadPromise ?? Promise.resolve(),
       this.queue.then(() => {
         if (this.failure) throw this.failure;
       }),
+    ]);
+    const pricingResult = await Promise.allSettled([
       this.pricingStore?.close() ?? Promise.resolve(),
-    ])
-      .then((results) => {
-        const failures = results.flatMap((result) =>
-          result.status === 'rejected' ? [result.reason] : [],
-        );
-        if (failures.length === 1) throw failures[0];
-        if (failures.length > 1) {
-          throw new AggregateError(failures, 'Unable to close telemetry repository');
-        }
-      })
-      .finally(() => {
-        this.state = 'closed';
-      });
-    return this.closePromise;
+    ]);
+    throwDeduplicatedFailures('Unable to close telemetry repository', [
+      ...settled.flatMap((result) => (result.status === 'rejected' ? [result.reason] : [])),
+      ...pricingResult.flatMap((result) => (result.status === 'rejected' ? [result.reason] : [])),
+    ]);
   }
 
   private enqueueMutation(mutate: (file: TelemetryFile) => TelemetryFile): Promise<void> {

--- a/packages/storage/src/usage-stores.ts
+++ b/packages/storage/src/usage-stores.ts
@@ -1,0 +1,404 @@
+import type {
+  PricingConfig,
+  UsageBucket,
+  UsageGroupBy,
+  UsageLogRow,
+  UsageQuery,
+  UsageSummaryV2,
+} from '@maka/core/usage-stats/types';
+import {
+  createPricingStore,
+  PricingCommitUnknownError,
+  PricingRevisionConflictError,
+  PricingStoreClosedError,
+  PricingStoreNotLoadedError,
+  PricingStorePublicationError,
+  PricingValidationError,
+  type PricingMutationResult,
+  type PricingSnapshot,
+  type PricingStore,
+} from './pricing-store.js';
+import {
+  runWithStorageRootLease,
+  StorageRootAuthorityError,
+  type StorageRootLease,
+} from './root-authority.js';
+import {
+  createTelemetryRepo,
+  TelemetryQueryValidationError,
+  TelemetryRepoClosedError,
+  TelemetryRepoNotLoadedError,
+  TelemetryRepoPublicationError,
+  type PersistedLlmCallRecord,
+  type PersistedToolInvocationRecord,
+  type TelemetryRepo,
+  type ToolUsageQuery,
+} from './telemetry-repo.js';
+
+const readerBrand: unique symbol = Symbol('InteractiveUsageStoresReader');
+const writerBrand: unique symbol = Symbol('InteractiveUsageStoresWriter');
+const readers = new WeakSet<object>();
+const writers = new WeakSet<object>();
+const writerByLease = new WeakMap<object, InteractiveUsageStoresWriter>();
+const writerOpeningByLease = new WeakMap<object, Promise<InteractiveUsageStoresWriter>>();
+
+export interface TelemetryIndexReader {
+  summary(query: UsageQuery): Promise<UsageSummaryV2>;
+  buckets(query: UsageQuery, groupBy: UsageGroupBy): Promise<UsageBucket[]>;
+  logs(
+    query: UsageQuery,
+    offset?: number,
+    limit?: number,
+  ): Promise<{ rows: UsageLogRow[]; total: number }>;
+  toolLogs(
+    query: ToolUsageQuery,
+    offset?: number,
+    limit?: number,
+  ): Promise<{ rows: PersistedToolInvocationRecord[]; total: number }>;
+  latestLlmRuntimeProbe(connectionSlug: string, modelId?: string): Promise<UsageLogRow | undefined>;
+}
+
+export interface TelemetryIndexWriter extends TelemetryIndexReader {
+  recordLlmCall(record: PersistedLlmCallRecord): Promise<void>;
+  recordToolInvocation(record: PersistedToolInvocationRecord): Promise<void>;
+}
+
+export interface PricingAuthorityReader {
+  snapshot(): Promise<PricingSnapshot>;
+}
+
+export interface PricingAuthorityWriter extends PricingAuthorityReader {
+  upsert(expectedRevision: number, pricing: PricingConfig): Promise<PricingMutationResult>;
+  delete(expectedRevision: number, modelKey: string): Promise<PricingMutationResult>;
+}
+
+export interface InteractiveUsageStoresReader {
+  readonly kind: 'interactive';
+  readonly access: 'read';
+  readonly [readerBrand]: true;
+  readonly telemetry: Readonly<TelemetryIndexReader>;
+  readonly pricing: Readonly<PricingAuthorityReader>;
+  close(): Promise<void>;
+}
+
+export interface InteractiveUsageStoresWriter {
+  readonly kind: 'interactive';
+  readonly access: 'write';
+  readonly [writerBrand]: true;
+  readonly telemetry: Readonly<TelemetryIndexWriter>;
+  readonly pricing: Readonly<PricingAuthorityWriter>;
+  beginDrain(): Promise<void>;
+  flush(): Promise<void>;
+  close(): Promise<void>;
+}
+
+export class InteractiveUsageStoresClosedError extends Error {
+  constructor() {
+    super('Interactive usage stores are draining or closed');
+    this.name = 'InteractiveUsageStoresClosedError';
+  }
+}
+
+export type InteractiveUsageStoresFailureClassification =
+  | { readonly kind: 'lifecycle' }
+  | {
+      readonly kind: 'revision_conflict';
+      readonly expectedRevision: number;
+      readonly actualRevision: number;
+    }
+  | { readonly kind: 'invalid_request' }
+  | { readonly kind: 'commit_outcome_unknown'; readonly needsDrain: true }
+  | { readonly kind: 'persistence_failed'; readonly needsDrain: boolean }
+  | { readonly kind: 'unknown'; readonly error: unknown };
+
+export function classifyInteractiveUsageStoresFailure(
+  error: unknown,
+): InteractiveUsageStoresFailureClassification {
+  if (error instanceof PricingRevisionConflictError) {
+    return {
+      kind: 'revision_conflict',
+      expectedRevision: error.expectedRevision,
+      actualRevision: error.actualRevision,
+    };
+  }
+  if (error instanceof PricingValidationError || error instanceof TelemetryQueryValidationError) {
+    return { kind: 'invalid_request' };
+  }
+  if (
+    error instanceof InteractiveUsageStoresClosedError ||
+    error instanceof PricingStoreClosedError ||
+    error instanceof TelemetryRepoClosedError ||
+    (error instanceof StorageRootAuthorityError &&
+      (error.code === 'invalid_lease' || error.code === 'invalid_owner'))
+  ) {
+    return { kind: 'lifecycle' };
+  }
+  if (
+    error instanceof PricingCommitUnknownError ||
+    (error instanceof TelemetryRepoPublicationError && error.commitUnknown)
+  ) {
+    return { kind: 'commit_outcome_unknown', needsDrain: true };
+  }
+  if (
+    error instanceof PricingStorePublicationError ||
+    error instanceof TelemetryRepoPublicationError
+  ) {
+    return { kind: 'persistence_failed', needsDrain: true };
+  }
+  if (
+    error instanceof PricingStoreNotLoadedError ||
+    error instanceof TelemetryRepoNotLoadedError ||
+    error instanceof StorageRootAuthorityError
+  ) {
+    return { kind: 'persistence_failed', needsDrain: false };
+  }
+  return { kind: 'unknown', error };
+}
+
+export function authenticateInteractiveUsageStoresReader(
+  stores: InteractiveUsageStoresReader,
+): InteractiveUsageStoresReader {
+  if (!readers.has(stores)) throw new TypeError('Expected an authentic interactive usage reader');
+  return stores;
+}
+
+export function authenticateInteractiveUsageStoresWriter(
+  stores: InteractiveUsageStoresWriter,
+): InteractiveUsageStoresWriter {
+  if (!writers.has(stores)) throw new TypeError('Expected an authentic interactive usage writer');
+  return stores;
+}
+
+export async function openInteractiveUsageStoresForRead(
+  lease: StorageRootLease<'interactive', 'read'>,
+): Promise<InteractiveUsageStoresReader> {
+  const repos = await runWithStorageRootLease(lease, 'interactive', 'read', (root) =>
+    openRepos(root, false),
+  );
+  let closed = false;
+  const run = <T>(operation: () => T | Promise<T>): Promise<T> => {
+    if (closed) return Promise.reject(new InteractiveUsageStoresClosedError());
+    return runWithStorageRootLease(lease, 'interactive', 'read', async () => operation());
+  };
+  const stores: InteractiveUsageStoresReader = {
+    kind: 'interactive',
+    access: 'read',
+    [readerBrand]: true,
+    telemetry: telemetryReader(repos.telemetry, run),
+    pricing: pricingReader(repos.pricing, run),
+    close: async () => {
+      if (closed) return;
+      await run(() => closeRepos(repos.telemetry, repos.pricing));
+      closed = true;
+    },
+  };
+  freezeFacade(stores);
+  readers.add(stores);
+  return stores;
+}
+
+export async function openInteractiveUsageStoresForWrite(
+  lease: StorageRootLease<'interactive', 'write'>,
+): Promise<InteractiveUsageStoresWriter> {
+  const existing = writerByLease.get(lease);
+  if (existing) return existing;
+  const opening = writerOpeningByLease.get(lease);
+  if (opening) return opening;
+  const pending = runWithStorageRootLease(lease, 'interactive', 'write', async (root) => {
+    const repos = await openRepos(root, true);
+    const stores = createWriterFacade(lease, repos.telemetry, repos.pricing);
+    writers.add(stores);
+    writerByLease.set(lease, stores);
+    return stores;
+  });
+  writerOpeningByLease.set(lease, pending);
+  try {
+    return await pending;
+  } finally {
+    if (writerOpeningByLease.get(lease) === pending) writerOpeningByLease.delete(lease);
+  }
+}
+
+async function openRepos(
+  root: string,
+  createIfMissing: boolean,
+): Promise<{ telemetry: TelemetryRepo; pricing: PricingStore }> {
+  const telemetry = createTelemetryRepo(root, { createIfMissing, managePricing: false });
+  await telemetry.load();
+  const pricing = createPricingStore(root, {
+    createIfMissing,
+    initialOverrides: telemetry.legacyPricingOverrides(),
+  });
+  try {
+    await pricing.load();
+    if (createIfMissing) await telemetry.publishCanonical();
+    return { telemetry, pricing };
+  } catch (error) {
+    const closed = await Promise.allSettled([telemetry.close(), pricing.close()]);
+    const failures = [error, ...rejectedReasons(closed)];
+    throwFailures('Unable to open interactive usage stores', failures);
+    throw error;
+  }
+}
+
+function createWriterFacade(
+  lease: StorageRootLease<'interactive', 'write'>,
+  telemetry: TelemetryRepo,
+  pricing: PricingStore,
+): InteractiveUsageStoresWriter {
+  const run = <T>(operation: () => T | Promise<T>): Promise<T> =>
+    runWithStorageRootLease(lease, 'interactive', 'write', async () => operation());
+  let state: 'open' | 'draining' | 'closed' = 'open';
+  let barrier: Promise<void> = Promise.resolve();
+  const failures: unknown[] = [];
+  let drainPromise: Promise<void> | undefined;
+  let closePromise: Promise<void> | undefined;
+
+  const assertOpen = () => {
+    if (state !== 'open') throw new InteractiveUsageStoresClosedError();
+  };
+  const admit = <T>(
+    operation: () => Promise<T>,
+    expectedFailure: (error: unknown) => boolean = () => false,
+  ): Promise<T> => {
+    assertOpen();
+    const admitted = Promise.resolve().then(operation);
+    const observed = admitted.then(
+      () => undefined,
+      (error: unknown) => {
+        if (!expectedFailure(error)) failures.push(error);
+      },
+    );
+    barrier = Promise.all([barrier, observed]).then(() => undefined);
+    return admitted;
+  };
+  const read = <T>(operation: () => T): Promise<T> => {
+    assertOpen();
+    return run(operation);
+  };
+
+  const beginDrain = (): Promise<void> => {
+    if (drainPromise) return drainPromise;
+    state = 'draining';
+    const accepted = barrier;
+    drainPromise = accepted.then(() =>
+      throwFailures('Interactive usage store drain failed', failures),
+    );
+    return drainPromise;
+  };
+
+  const flush = async (): Promise<void> => {
+    const accepted = barrier;
+    await accepted;
+    const flushed = await Promise.allSettled([
+      run(() => telemetry.flush()),
+      run(() => pricing.flush()),
+    ]);
+    throwFailures('Interactive usage store flush failed', [
+      ...failures,
+      ...rejectedReasons(flushed),
+    ]);
+  };
+
+  const close = (): Promise<void> => {
+    if (closePromise) return closePromise;
+    state = 'draining';
+    const accepted = barrier;
+    closePromise = accepted
+      .then(async () => {
+        const closed = await Promise.allSettled([
+          run(() => telemetry.close()),
+          run(() => pricing.close()),
+        ]);
+        throwFailures('Interactive usage stores close failed', [
+          ...failures,
+          ...rejectedReasons(closed),
+        ]);
+      })
+      .finally(() => {
+        state = 'closed';
+      });
+    return closePromise;
+  };
+
+  const stores: InteractiveUsageStoresWriter = {
+    kind: 'interactive',
+    access: 'write',
+    [writerBrand]: true,
+    telemetry: {
+      summary: (query) => read(() => telemetry.summary(query)),
+      buckets: (query, groupBy) => read(() => telemetry.buckets(query, groupBy)),
+      logs: (query, offset, limit) => read(() => telemetry.logs(query, offset, limit)),
+      toolLogs: (query, offset, limit) => read(() => telemetry.toolLogs(query, offset, limit)),
+      latestLlmRuntimeProbe: (connectionSlug, modelId) =>
+        read(() => telemetry.latestLlmRuntimeProbe(connectionSlug, modelId)),
+      recordLlmCall: (record) => admit(() => run(() => telemetry.insertLlmCall(record))),
+      recordToolInvocation: (record) =>
+        admit(() => run(() => telemetry.insertToolInvocation(record))),
+    },
+    pricing: {
+      snapshot: () => read(() => pricing.snapshot()),
+      upsert: (expectedRevision, value) =>
+        admit(() => run(() => pricing.upsert(expectedRevision, value)), isExpectedPricingFailure),
+      delete: (expectedRevision, modelKey) =>
+        admit(
+          () => run(() => pricing.delete(expectedRevision, modelKey)),
+          isExpectedPricingFailure,
+        ),
+    },
+    beginDrain,
+    flush,
+    close,
+  };
+  freezeFacade(stores);
+  return stores;
+}
+
+function telemetryReader(
+  repo: TelemetryRepo,
+  run: <T>(operation: () => T | Promise<T>) => Promise<T>,
+): Readonly<TelemetryIndexReader> {
+  return Object.freeze({
+    summary: (query: UsageQuery) => run(() => repo.summary(query)),
+    buckets: (query: UsageQuery, groupBy: UsageGroupBy) => run(() => repo.buckets(query, groupBy)),
+    logs: (query: UsageQuery, offset?: number, limit?: number) =>
+      run(() => repo.logs(query, offset, limit)),
+    toolLogs: (query: ToolUsageQuery, offset?: number, limit?: number) =>
+      run(() => repo.toolLogs(query, offset, limit)),
+    latestLlmRuntimeProbe: (connectionSlug: string, modelId?: string) =>
+      run(() => repo.latestLlmRuntimeProbe(connectionSlug, modelId)),
+  });
+}
+
+function pricingReader(
+  store: PricingStore,
+  run: <T>(operation: () => T | Promise<T>) => Promise<T>,
+): Readonly<PricingAuthorityReader> {
+  return Object.freeze({ snapshot: () => run(() => store.snapshot()) });
+}
+
+function isExpectedPricingFailure(error: unknown): boolean {
+  return error instanceof PricingRevisionConflictError || error instanceof PricingValidationError;
+}
+
+async function closeRepos(telemetry: TelemetryRepo, pricing: PricingStore): Promise<void> {
+  const closed = await Promise.allSettled([telemetry.close(), pricing.close()]);
+  throwFailures('Unable to close interactive usage stores', rejectedReasons(closed));
+}
+
+function rejectedReasons(results: readonly PromiseSettledResult<unknown>[]): unknown[] {
+  return results.flatMap((result) => (result.status === 'rejected' ? [result.reason] : []));
+}
+
+function throwFailures(message: string, failures: readonly unknown[]): void {
+  const unique = [...new Set(failures)];
+  if (unique.length === 0) return;
+  if (unique.length === 1) throw unique[0];
+  throw new AggregateError(unique, message);
+}
+
+function freezeFacade(stores: InteractiveUsageStoresReader | InteractiveUsageStoresWriter): void {
+  Object.freeze(stores.telemetry);
+  Object.freeze(stores.pricing);
+  Object.freeze(stores);
+}

--- a/packages/storage/src/usage-stores.ts
+++ b/packages/storage/src/usage-stores.ts
@@ -6,6 +6,7 @@ import type {
   UsageQuery,
   UsageSummaryV2,
 } from '@maka/core/usage-stats/types';
+import { throwDeduplicatedFailures } from './failure-utils.js';
 import {
   createPricingStore,
   PricingCommitUnknownError,
@@ -21,6 +22,7 @@ import {
 import {
   runWithStorageRootLease,
   StorageRootAuthorityError,
+  type StorageRootAuthorityErrorCode,
   type StorageRootLease,
 } from './root-authority.js';
 import {
@@ -145,14 +147,40 @@ export function classifyInteractiveUsageStoresFailure(
   ) {
     return { kind: 'persistence_failed', needsDrain: true };
   }
-  if (
-    error instanceof PricingStoreNotLoadedError ||
-    error instanceof TelemetryRepoNotLoadedError ||
-    error instanceof StorageRootAuthorityError
-  ) {
+  if (error instanceof PricingStoreNotLoadedError || error instanceof TelemetryRepoNotLoadedError) {
     return { kind: 'persistence_failed', needsDrain: false };
   }
+  if (error instanceof StorageRootAuthorityError) {
+    return {
+      kind: 'persistence_failed',
+      needsDrain: rootAuthorityFailureNeedsDrain(error.code),
+    };
+  }
   return { kind: 'unknown', error };
+}
+
+function rootAuthorityFailureNeedsDrain(code: StorageRootAuthorityErrorCode): boolean {
+  switch (code) {
+    case 'root_unmarked':
+    case 'invalid_marker':
+    case 'root_kind_mismatch':
+    case 'root_identity_collision':
+    case 'root_identity_changed':
+      return true;
+    case 'invalid_root':
+    case 'invalid_root_kind':
+    case 'root_not_found':
+    case 'invalid_repair':
+    case 'invalid_capability':
+    case 'invalid_lease':
+    case 'invalid_owner':
+    case 'invalid_lock_artifact':
+    case 'insecure_control_directory':
+    case 'root_io_failed':
+    case 'control_io_failed':
+    case 'lock_failed':
+      return false;
+  }
 }
 
 export function authenticateInteractiveUsageStoresReader(
@@ -236,7 +264,7 @@ async function openRepos(
   } catch (error) {
     const closed = await Promise.allSettled([telemetry.close(), pricing.close()]);
     const failures = [error, ...rejectedReasons(closed)];
-    throwFailures('Unable to open interactive usage stores', failures);
+    throwDeduplicatedFailures('Unable to open interactive usage stores', failures);
     throw error;
   }
 }
@@ -282,7 +310,7 @@ function createWriterFacade(
     state = 'draining';
     const accepted = barrier;
     drainPromise = accepted.then(() =>
-      throwFailures('Interactive usage store drain failed', failures),
+      throwDeduplicatedFailures('Interactive usage store drain failed', failures),
     );
     return drainPromise;
   };
@@ -294,7 +322,7 @@ function createWriterFacade(
       run(() => telemetry.flush()),
       run(() => pricing.flush()),
     ]);
-    throwFailures('Interactive usage store flush failed', [
+    throwDeduplicatedFailures('Interactive usage store flush failed', [
       ...failures,
       ...rejectedReasons(flushed),
     ]);
@@ -310,7 +338,7 @@ function createWriterFacade(
           run(() => telemetry.close()),
           run(() => pricing.close()),
         ]);
-        throwFailures('Interactive usage stores close failed', [
+        throwDeduplicatedFailures('Interactive usage stores close failed', [
           ...failures,
           ...rejectedReasons(closed),
         ]);
@@ -383,18 +411,11 @@ function isExpectedPricingFailure(error: unknown): boolean {
 
 async function closeRepos(telemetry: TelemetryRepo, pricing: PricingStore): Promise<void> {
   const closed = await Promise.allSettled([telemetry.close(), pricing.close()]);
-  throwFailures('Unable to close interactive usage stores', rejectedReasons(closed));
+  throwDeduplicatedFailures('Unable to close interactive usage stores', rejectedReasons(closed));
 }
 
 function rejectedReasons(results: readonly PromiseSettledResult<unknown>[]): unknown[] {
   return results.flatMap((result) => (result.status === 'rejected' ? [result.reason] : []));
-}
-
-function throwFailures(message: string, failures: readonly unknown[]): void {
-  const unique = [...new Set(failures)];
-  if (unique.length === 0) return;
-  if (unique.length === 1) throw unique[0];
-  throw new AggregateError(unique, message);
 }
 
 function freezeFacade(stores: InteractiveUsageStoresReader | InteractiveUsageStoresWriter): void {


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

This extracts the Usage/Pricing domain as one complete Runtime Host authority slice:

- one lease-bound telemetry and pricing writer per Interactive root;
- awaitable telemetry admission with single-flight loading, flush, drain, close, and observable publication failure;
- an independent pricing revision with compare-and-swap mutation;
- bounded, exact `v0` Host operations for usage projection and pricing query/mutation;
- loss-aware bounded projection for protocol-visible identities;
- lossless, idempotent migration of existing unversioned telemetry, tool invocation, and embedded pricing data;
- Desktop compatibility wiring that keeps the existing product behavior behind the current non-serving Host activation gate.

This is part of the M3 extraction tracked by #1167 and follows the ownership/lifecycle direction in #853.

## Why these belong together

Runtime model and tool execution publish detailed telemetry, while cost projection resolves pricing against the same root-scoped usage history. Splitting the writer lifecycle from pricing mutation would leave either an unowned persistence path or an incomplete execution prerequisite.

The slice still keeps two projections separate:

- `SettingsStore.usageStats()` remains the Session-derived dashboard projection.
- The telemetry authority owns detailed LLM/tool logs, buckets, summaries, and pricing overrides.

Neither projection becomes a compatibility alias for the other.

## Authority and lifecycle

- Authentic Interactive write leases are required to open the writer facade. Reads either re-enter the lease or return detached immutable snapshots.
- The low-level Pricing Store is no longer a public package entry point. Host code reaches telemetry and pricing only through the lease-bound facade.
- Concurrent loads are single-flighted and retryable after a failed attempt. Load state is committed only after the complete attempt succeeds, while close joins every load and mutation admitted before draining.
- Telemetry mutation admission owns and validates its input before returning a `Promise<void>`. Accepted publications participate in the facade barrier, so drain and close cannot silently abandon them.
- Pre-rename publication failure preserves the previous readable state. A post-rename directory-sync failure makes the commit outcome unknown, poisons subsequent reads, and asks the Host to drain.
- A live root whose marker or filesystem identity changes is also treated as poisoned and asks the Host to drain. Transient setup and I/O failures do not trigger that terminal transition.
- Pricing mutations compare an expected revision against the current revision. Exactly one competing mutation can commit; a loser receives the current revision and may query before retrying.
- Host outcomes are classified at the Storage facade boundary. The coordinator does not inspect Store implementation errors or persistence object shapes.

## Existing data

An unversioned `telemetry.json` may contain LLM usage records, tool invocations, and embedded `pricingOverrides`. Opening the authority:

1. validates and normalizes the legacy records without dropping current diagnostics or token aliases;
2. publishes canonical telemetry and a separate revisioned pricing document through atomic filesystem replacement;
3. remains safe to retry after interruption without duplicate records or a second writer.

No compatibility layer is added to the unreleased integer `v0` Host protocol.

## Protocol boundary

The Host exposes only three closed operations:

- `usage.query`
- `pricing.query`
- `pricing.mutate`

Usage pages have item and byte bounds. Pricing pages are pinned to a revision and use a strictly advancing numeric offset. Client-side response correlation rejects a valid-looking response whose source, request kind, revision, or offset does not match the canonical request.

Protocol-visible identity fields preserve ordinary short values. If control-character canonicalization or byte truncation would otherwise make distinct identities collide, the projection keeps a bounded readable prefix and a digest of the original JavaScript identity. Display labels remain plain bounded text.

## Desktop and activation boundary

Desktop continues to host the raw compatibility writer in-process for M3. It resolves and validates the Interactive root before opening the embedded repository, but does not yet acquire the Runtime Host owner/lease. Current production Candidate wiring remains deliberately non-serving and cannot reach the execution composition that opens this authority, so the two writers cannot coexist through a supported product path in this milestone.

Removing this embedded writer and switching surfaces to the Host remain M4/M5 work. Acquiring ownership around the compatibility writer or completing that cutover is a hard gate before a serving production Host may open the same root.

## Validation

- Scoped Biome checks, root typecheck, and the production build pass.
- Storage passes 749 tests with one existing skip; Runtime Host passes all 334 tests.
- Core, Runtime telemetry/cost, and the affected Desktop tests pass.
- Independent correctness and maintainability re-reviews found no remaining P0-P3 issues in this slice.

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 概要

本 PR 将 Usage/Pricing 领域作为一个完整的 Runtime Host authority slice 提取：

- 每个 Interactive root 只有一个受 lease 约束的 telemetry 与 pricing writer；
- telemetry admission 可等待，并具备 single-flight load、flush、drain、close 与可观察的
  publication failure；
- pricing 使用独立 revision 与 compare-and-swap mutation；
- 为 usage projection 与 pricing query/mutation 提供有界、精确的 `v0` Host operation；
- protocol 可见 identity 使用 loss-aware bounded projection；
- 无损、可重入地迁移现有无版本 telemetry、tool invocation 与内嵌 pricing 数据；
- 在当前 non-serving Host 激活门禁下保留 Desktop 产品行为。

本 PR 属于 #1167 追踪的 M3 提取，并遵循 #853 的 ownership/lifecycle 方向。

## 为什么放在同一个 Slice

Runtime 的模型与工具执行会发布细粒度 telemetry，而 cost projection 会针对同一个
root 的 usage history 解析 pricing。若将 writer lifecycle 与 pricing mutation 拆开，
会留下未归属的持久化路径，或一个不完整的 execution 前置。

本 slice 仍明确区分两种 projection：

- `SettingsStore.usageStats()` 继续提供从 Session facts 派生的 dashboard projection。
- telemetry authority 负责详细 LLM/tool logs、buckets、summary 与 pricing overrides。

两者都不会被降格为另一方的兼容别名。

## Authority 与生命周期

- writer facade 只能由真实的 Interactive write lease 打开。read 要么重新进入 lease，
  要么返回已完整复制的 immutable detached snapshot。
- low-level Pricing Store 不再是 package public entry point。Host 只能通过 lease-bound
  facade 访问 telemetry 与 pricing。
- 并发 load 会 single-flight，失败后可以重试。只有完整 load attempt 成功后才提交
  实例状态；close 会等待 draining 前已经接纳的 load 与 mutation。
- Telemetry mutation 在返回 `Promise<void>` 前取得并验证输入所有权。已接纳 publication
  会进入 facade barrier，因此 drain/close 不会静默丢弃它们。
- rename 前 publication 失败仍保留之前可读的状态；rename 后 directory sync 失败表示
  commit outcome unknown，会 poison 后续读取并请求 Host drain。
- live root 的 marker 或 filesystem identity 变化也会被视为 poison 并请求 Host
  drain；瞬态 setup/I/O failure 不会触发这一终态转换。
- Pricing mutation 将 expected revision 与当前 revision 比较。并发 mutation 只有一个
  能提交；失败者取得当前 revision，并可在 query 后重试。
- Host outcome 在 Storage facade 边界分类。coordinator 不再识别具体 Store error 或
  探测 persistence object shape。

## 现有数据

无版本 `telemetry.json` 可能同时包含 LLM usage records、tool invocations 与内嵌
`pricingOverrides`。authority 打开时会：

1. 验证并规范化 legacy records，同时保留现有 diagnostics 与 token alias；
2. 通过原子文件替换发布 canonical telemetry 与独立的 revisioned pricing 文档；
3. 中断后可安全重试，不重复记录，也不会出现第二个 writer。

本 PR 不为尚未发布的整数 `v0` Host protocol 增加兼容层。

## Protocol 边界

Host 只暴露三个封闭 operation：

- `usage.query`
- `pricing.query`
- `pricing.mutate`

Usage page 同时受 item 与 byte 上限约束。Pricing page 绑定 revision，并使用严格前进的
numeric offset。Client response correlation 会拒绝与 canonical request 的 source、
request kind、revision 或 offset 不匹配的“看似有效”回复。

普通短 identity 会原样保留。若 control-character canonicalization 或 byte truncation
可能使不同 identity 发生碰撞，projection 会保留有界、可读的 prefix，并附带原始
JavaScript identity 的 digest。display label 仍使用普通的有界文本投影。

## Desktop 与激活边界

M3 阶段 Desktop 继续在进程内持有 raw 兼容 writer。它会先解析并验证 Interactive
root，再打开 embedded repository，但尚未取得 Runtime Host owner/lease。当前
production Candidate 接线刻意保持 non-serving，无法到达会打开本 authority 的
execution composition，因此本里程碑不存在受支持的双 writer 产品路径。

删除 embedded writer 并让各 surface 切换到 Host 仍属于 M4/M5。在启用 serving
production Host 前，必须先让兼容 writer 取得 owner，或完成 adapter cutover 并删除它。

## 验证

- scoped Biome、根级 typecheck 与 production build 通过。
- Storage 749 项通过、1 项既有 skip；Runtime Host 334 项全部通过。
- Core、Runtime telemetry/cost 与受影响 Desktop 测试通过。
- 独立 correctness 与 maintainability 复审未发现本 slice 剩余 P0-P3 问题。

</details>
