### PR TITLE
fix(runtime): bound agent output projections

### DIFF
--- a/packages/runtime/src/__tests__/graph-mode.test.ts
+++ b/packages/runtime/src/__tests__/graph-mode.test.ts
@@ -14,6 +14,8 @@ describe('Graph Mode shared prompt', () => {
     assert.match(prompt, /committed record ids/);
     assert.match(prompt, /agent_output/);
     assert.match(prompt, /child_session_run.*childSessionId.*currentRunId/);
+    assert.match(prompt, /runtime_events.*max_events.*20.*max_bytes.*32768/);
+    assert.match(prompt, /view=all only for a narrow diagnostic question/);
     assert.match(prompt, /Stay available to the user/);
   });
 });

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -12156,6 +12156,7 @@ describe('SessionManager permission mode updates', () => {
     const output = await manager.readChildAgentOutput(session.id, {
       runId: 'child-run',
       maxEvents: 5,
+      view: 'all',
     });
 
     expect(output.header.runId).toBe('child-run');
@@ -12175,8 +12176,87 @@ describe('SessionManager permission mode updates', () => {
     ]);
     expect(output.truncated.events).toBe(true);
     expect(output.truncated.runtimeEvents).toBe(true);
+    expect(output.budget.view).toBe('all');
+    expect(output.budget.projectedBytes <= output.budget.maxBytes).toBe(true);
     expect('modelReplay' in output).toBe(false);
     expect('projection' in output).toBe(false);
+  });
+
+  test('agent output bounds oversized runtime events by serialized bytes', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(6_849),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+    await runStore.createRun(
+      makeRunHeader({
+        sessionId: session.id,
+        runId: 'child-run',
+        turnId: 'child-turn',
+        status: 'completed',
+        createdAt: 120,
+        updatedAt: 200,
+        completedAt: 200,
+        parentRunId: 'parent-run',
+        agentId: LOCAL_READ_AGENT_ID,
+        agentName: 'Researcher',
+        permissionMode: 'explore',
+      }),
+    );
+    await runStore.appendRuntimeEvent(
+      session.id,
+      'child-run',
+      runtimeEvent({
+        id: 'oversized',
+        sessionId: session.id,
+        runId: 'child-run',
+        turnId: 'child-turn',
+        ts: 130,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'x'.repeat(64 * 1024) },
+      }),
+    );
+    await runStore.appendRuntimeEvent(
+      session.id,
+      'child-run',
+      runtimeEvent({
+        id: 'final',
+        sessionId: session.id,
+        runId: 'child-run',
+        turnId: 'child-turn',
+        ts: 140,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'bounded final result' },
+      }),
+    );
+
+    const output = await manager.readChildAgentOutput(session.id, {
+      runId: 'child-run',
+      maxEvents: 20,
+      maxBytes: 1024,
+    });
+
+    expect(output.events).toEqual([]);
+    expect(output.runtimeEvents.map((event) => event.id)).toEqual(['final']);
+    expect(output.truncated.events).toBe(true);
+    expect(output.truncated.runtimeEvents).toBe(true);
+    expect(output.truncated.bytes).toBe(true);
+    expect(output.budget).toMatchObject({
+      view: 'runtime_events',
+      maxBytes: 1024,
+    });
+    expect(output.budget.projectedBytes <= output.budget.maxBytes).toBe(true);
   });
 
   test('agent output rejects ambiguous child run locators', async () => {

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -1234,6 +1234,8 @@ describe('subagent tools', () => {
         run_id: 'child-run',
         turn_id: 'provider-placeholder',
         max_events: 100,
+        max_bytes: 32_768,
+        view: 'runtime_events',
       },
       {
         sessionId: 'session-1',
@@ -1254,6 +1256,8 @@ describe('subagent tools', () => {
           currentRunId: 'child-run',
         },
         maxEvents: 100,
+        maxBytes: 32_768,
+        view: 'runtime_events',
       },
     });
   });

--- a/packages/runtime/src/graph-mode.ts
+++ b/packages/runtime/src/graph-mode.ts
@@ -11,7 +11,7 @@ export function renderGraphModePrompt(): string {
     'Use operator_id only to send follow-up work to an existing runtime operator id returned by view_agent_graph.',
     'A scheduling update must omit finish. Send finish only in a later terminal update after all selected result_ids are committed.',
     'Stay available to the user while operators execute. Intervene only through the typed graph controls, and explain material supervision decisions.',
-    'Before advancing dependencies or finishing, inspect child output with agent_output like {"locator":"child_session_run","child_session_id":"<childSessionId>","run_id":"<currentRunId>","max_events":100}. Then select committed result ids with update_agent_graph.finish and synthesize those results for the user.',
+    'Before advancing dependencies or finishing, inspect bounded child output with agent_output like {"locator":"child_session_run","child_session_id":"<childSessionId>","run_id":"<currentRunId>","view":"runtime_events","max_events":20,"max_bytes":32768}. Read committed results first; use view=all only for a narrow diagnostic question. Then select committed result ids with update_agent_graph.finish and synthesize those results for the user.',
     'You may continue directly when the request is small or a graph would add ceremony without useful decomposition.',
     '</orchestration_mode>',
   ].join('\n');

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -394,7 +394,11 @@ export interface AgentOutputInput {
   runId?: string;
   turnId?: string;
   maxEvents?: number;
+  maxBytes?: number;
+  view?: AgentOutputView;
 }
+
+export type AgentOutputView = 'events' | 'runtime_events' | 'all';
 
 export interface AgentOutputResult {
   execution: SubagentExecutionRef;
@@ -408,6 +412,13 @@ export interface AgentOutputResult {
     events: boolean;
     runtimeEvents: boolean;
     diagnostics: boolean;
+    artifacts: boolean;
+    bytes: boolean;
+  };
+  budget: {
+    view: AgentOutputView;
+    maxBytes: number;
+    projectedBytes: number;
   };
 }
 
@@ -3424,18 +3435,46 @@ export class SessionManager {
       ? await this.deps.listArtifactsForTurn(header.sessionId, header.turnId)
       : [];
     const maxEvents = normalizeAgentOutputMaxEvents(input.maxEvents);
+    const maxBytes = normalizeAgentOutputMaxBytes(input.maxBytes);
+    const view = input.view ?? 'runtime_events';
+    const bounded = boundAgentOutputCollections(
+      {
+        events: view === 'runtime_events' ? [] : tail(inspected.events, maxEvents),
+        runtimeEvents: view === 'events' ? [] : tail(inspected.runtimeEvents, maxEvents),
+        diagnostics: tail(inspected.diagnostics, maxEvents),
+        artifacts: tail(artifacts, maxEvents),
+      },
+      maxBytes,
+    );
     return {
       execution: located.execution,
       header: inspected.header,
-      events: tail(inspected.events, maxEvents),
-      runtimeEvents: tail(inspected.runtimeEvents, maxEvents),
+      events: bounded.events,
+      runtimeEvents: bounded.runtimeEvents,
       sourceHealth: inspected.sourceHealth,
-      diagnostics: tail(inspected.diagnostics, maxEvents),
-      artifacts,
+      diagnostics: bounded.diagnostics,
+      artifacts: bounded.artifacts,
       truncated: {
-        events: inspected.events.length > maxEvents,
-        runtimeEvents: inspected.runtimeEvents.length > maxEvents,
-        diagnostics: inspected.diagnostics.length > maxEvents,
+        events:
+          view === 'runtime_events' ||
+          inspected.events.length > maxEvents ||
+          bounded.events.length < Math.min(inspected.events.length, maxEvents),
+        runtimeEvents:
+          view === 'events' ||
+          inspected.runtimeEvents.length > maxEvents ||
+          bounded.runtimeEvents.length < Math.min(inspected.runtimeEvents.length, maxEvents),
+        diagnostics:
+          inspected.diagnostics.length > maxEvents ||
+          bounded.diagnostics.length < Math.min(inspected.diagnostics.length, maxEvents),
+        artifacts:
+          artifacts.length > maxEvents ||
+          bounded.artifacts.length < Math.min(artifacts.length, maxEvents),
+        bytes: bounded.truncated,
+      },
+      budget: {
+        view,
+        maxBytes,
+        projectedBytes: bounded.projectedBytes,
       },
     };
   }
@@ -4930,6 +4969,63 @@ function headerLineage(header: AgentRunHeader): AgentRunRecoveryDecision['lineag
 function normalizeAgentOutputMaxEvents(value: number | undefined): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return 20;
   return Math.min(100, Math.max(1, Math.floor(value)));
+}
+
+const DEFAULT_AGENT_OUTPUT_MAX_BYTES = 32 * 1024;
+const MAX_AGENT_OUTPUT_MAX_BYTES = 128 * 1024;
+
+function normalizeAgentOutputMaxBytes(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_AGENT_OUTPUT_MAX_BYTES;
+  }
+  return Math.min(MAX_AGENT_OUTPUT_MAX_BYTES, Math.max(1024, Math.floor(value)));
+}
+
+function boundAgentOutputCollections(
+  input: {
+    events: AgentRunEvent[];
+    runtimeEvents: RuntimeEvent[];
+    diagnostics: AgentRunInspectModel['diagnostics'];
+    artifacts: ArtifactRecord[];
+  },
+  maxBytes: number,
+): {
+  events: AgentRunEvent[];
+  runtimeEvents: RuntimeEvent[];
+  diagnostics: AgentRunInspectModel['diagnostics'];
+  artifacts: ArtifactRecord[];
+  projectedBytes: number;
+  truncated: boolean;
+} {
+  let remaining = maxBytes;
+  let projectedBytes = 0;
+  let truncated = false;
+
+  const takeBoundedTail = <T>(items: readonly T[]): T[] => {
+    const selected: T[] = [];
+    for (let index = items.length - 1; index >= 0; index -= 1) {
+      const item = items[index]!;
+      const bytes = Buffer.byteLength(JSON.stringify(item), 'utf8');
+      if (bytes > remaining) {
+        truncated = true;
+        break;
+      }
+      selected.push(item);
+      projectedBytes += bytes;
+      remaining -= bytes;
+    }
+    selected.reverse();
+    return selected;
+  };
+
+  // RuntimeEvents are the semantic child transcript and therefore receive the
+  // budget first. AgentRun events and diagnostics remain available through
+  // explicit views without duplicating an unbounded second event stream.
+  const runtimeEvents = takeBoundedTail(input.runtimeEvents);
+  const events = takeBoundedTail(input.events);
+  const diagnostics = takeBoundedTail(input.diagnostics);
+  const artifacts = takeBoundedTail(input.artifacts);
+  return { events, runtimeEvents, diagnostics, artifacts, projectedBytes, truncated };
 }
 
 function tail<T>(items: readonly T[], max: number): T[] {

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -289,6 +289,8 @@ export function buildSubagentOutputTool(): MakaTool<
     run_id?: string;
     turn_id?: string;
     max_events?: number;
+    max_bytes?: number;
+    view?: 'events' | 'runtime_events' | 'all';
   },
   unknown
 > {
@@ -296,7 +298,7 @@ export function buildSubagentOutputTool(): MakaTool<
     name: AGENT_OUTPUT_TOOL_NAME,
     displayName: 'Agent Output',
     description:
-      'Inspect child output. Always set locator: child_session_run for a graph childSessionId/currentRunId, child_session_latest for its latest run, or a legacy locator. Unrelated provider-filled optional fields are ignored.',
+      'Inspect bounded child output. Defaults to the semantic runtime_events view with a 32 KiB payload budget. Always set locator: child_session_run for a graph childSessionId/currentRunId, child_session_latest for its latest run, or a legacy locator. Use view=all only for targeted diagnostics.',
     parameters: z
       .object({
         locator: z
@@ -313,6 +315,8 @@ export function buildSubagentOutputTool(): MakaTool<
         run_id: z.string().min(1).optional(),
         turn_id: z.string().min(1).optional(),
         max_events: z.number().int().min(1).max(100).optional(),
+        max_bytes: z.number().int().min(1024).max(128 * 1024).optional(),
+        view: z.enum(['events', 'runtime_events', 'all']).optional(),
       })
       .superRefine((input, ctx) => {
         if (input.locator) {
@@ -402,6 +406,8 @@ export function buildSubagentOutputTool(): MakaTool<
               : {})),
         ...(input.locator === undefined && input.turn_id ? { turnId: input.turn_id } : {}),
         ...(input.max_events !== undefined ? { maxEvents: input.max_events } : {}),
+        ...(input.max_bytes !== undefined ? { maxBytes: input.max_bytes } : {}),
+        ...(input.view !== undefined ? { view: input.view } : {}),
       });
     },
   };

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -315,7 +315,12 @@ export function buildSubagentOutputTool(): MakaTool<
         run_id: z.string().min(1).optional(),
         turn_id: z.string().min(1).optional(),
         max_events: z.number().int().min(1).max(100).optional(),
-        max_bytes: z.number().int().min(1024).max(128 * 1024).optional(),
+        max_bytes: z
+          .number()
+          .int()
+          .min(1024)
+          .max(128 * 1024)
+          .optional(),
         view: z.enum(['events', 'runtime_events', 'all']).optional(),
       })
       .superRefine((input, ctx) => {

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -263,6 +263,8 @@ export interface MakaToolContext {
     runId?: string;
     turnId?: string;
     maxEvents?: number;
+    maxBytes?: number;
+    view?: 'events' | 'runtime_events' | 'all';
   }) => Promise<unknown>;
   askUserQuestion?: (questions: UserQuestion[]) => Promise<UserQuestionResult>;
 }
@@ -412,6 +414,8 @@ export interface ToolRuntimeInput {
     runId?: string;
     turnId?: string;
     maxEvents?: number;
+    maxBytes?: number;
+    view?: 'events' | 'runtime_events' | 'all';
   }) => Promise<unknown>;
   getRunTrace?: () => RunTraceLike | null;
   permissionTimeoutMs?: number;


### PR DESCRIPTION
## What changed

- add explicit `agent_output` views so callers do not receive AgentRun and RuntimeEvent streams together by default
- enforce a 32 KiB default / 128 KiB maximum serialized payload budget across events, runtime events, diagnostics, and artifact references
- expose truncation and budget diagnostics in the tool result
- change the Graph supervisor prompt from `max_events: 100` to a bounded 20-event, 32 KiB runtime-event inspection

## Why

Issue #1593 reproduced Graph supervisor context overflow after four `agent_output` calls returned roughly 479–572 KiB each. The tool only bounded event count, not serialized size, and duplicated two event projections into the root session.

This is PR 1 of 4 in the Graph context-overflow repair stack.

## Impact

Raw child execution history remains durable and inspectable through explicit views, while normal Graph supervision receives a bounded semantic projection.

## Validation

- `npm --workspace @maka/runtime run typecheck`
- `npm --workspace @maka/runtime run build`
- targeted SessionManager agent-output tests: 4/4
- Graph/subagent tool tests: 27/27
- `git diff --check`

The full SessionManager file also exposed an unrelated pre-existing timing-sensitive test failure; the affected agent-output subset passes independently.
