### PR TITLE
fix(graph): recover supervisor context overflow

### DIFF
--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -889,6 +889,15 @@ export async function createMakaCliRuntimeContext(
         }
         return runs[0]?.status ?? 'missing';
       },
+      recoverContextOverflow: async (rootSessionId, { abortSignal }) => {
+        abortSignal.throwIfAborted();
+        for await (const _event of runtime.compactSession(rootSessionId, {
+          turnId: randomUUID(),
+          minRecentTurns: 0,
+        })) {
+          abortSignal.throwIfAborted();
+        }
+      },
       newId: randomUUID,
       onError: (rootSessionId, error) => {
         agentGraphErrors.set(rootSessionId, error);

--- a/packages/core/src/backend-types.ts
+++ b/packages/core/src/backend-types.ts
@@ -162,6 +162,8 @@ export type PermissionDecision = PermissionResponse;
 export interface BackendCompactHistoryInput {
   turnId: string;
   runtimeContext: readonly RuntimeEvent[];
+  /** Override the configured recent-turn tail for an explicit recovery compaction. */
+  minRecentTurns?: number;
 }
 
 export interface BackendCompactHistoryResult {

--- a/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
+++ b/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
@@ -1,7 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { createSqliteSessionMetadataStore } from '@maka/storage';
-import { AgentGraphSupervisorWakeCoordinator } from '../agent-graph-supervisor-wake.js';
+import {
+  AgentGraphSupervisorContextOverflowError,
+  AgentGraphSupervisorWakeCoordinator,
+} from '../agent-graph-supervisor-wake.js';
 import { SessionActivityRegistry, type GoalTurnOutcome } from '../goal-turn-lifecycle.js';
 import type { AgentGraphClientSnapshot } from '../stream-graph-read-model.js';
 import type { AgentGraphScheduleReconciliationResult } from '../stream-graph-schedule-reconcile.js';
@@ -39,6 +42,137 @@ describe('Agent Graph supervisor wake delivery', () => {
           (candidate) => candidate.status,
         ),
         ['retryable_failed', 'retryable_failed', 'delivered'],
+      );
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
+
+  test('aggressively compacts after a context overflow before delivering a fresh turn', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    let turns = 0;
+    const recoveries: string[] = [];
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async () => snapshot(),
+      startTurn: async (_sessionId, input): Promise<GoalTurnOutcome> => {
+        turns += 1;
+        return turns === 1
+          ? { kind: 'errored', turnId: input.turnId, reason: 'Context window exceeded' }
+          : { kind: 'completed', turnId: input.turnId };
+      },
+      inspectAttempt: async () => 'missing',
+      recoverContextOverflow: async (_rootSessionId, input) => {
+        recoveries.push(input.attemptId);
+      },
+      newId: sequentialIds(),
+    });
+    try {
+      coordinator.notify('root-session', reconciliation());
+      await coordinator.waitForIdle();
+
+      const wake = await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1');
+      assert.equal(wake?.status, 'delivered');
+      assert.equal(wake?.attemptCount, 2);
+      assert.equal(recoveries.length, 1);
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
+
+  test('stops after one recovered overflow and reports a bounded durable partial result', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    let turns = 0;
+    let recoveries = 0;
+    let reportedError: unknown;
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async () => ({
+        ...snapshot(),
+        work: [
+          {
+            workId: 'work-1',
+            target: { kind: 'agent', agentId: 'reviewer' },
+            inputIds: [],
+            status: 'requested',
+            instructionPreview: 'review',
+            instructionTruncated: false,
+            revision: 1,
+            committedAt: 1,
+          },
+        ],
+      }),
+      startTurn: async (_sessionId, input): Promise<GoalTurnOutcome> => {
+        turns += 1;
+        return { kind: 'errored', turnId: input.turnId, reason: 'context_overflow' };
+      },
+      inspectAttempt: async () => 'missing',
+      recoverContextOverflow: async () => {
+        recoveries += 1;
+      },
+      newId: sequentialIds(),
+      onError: (_rootSessionId, error) => {
+        reportedError = error;
+      },
+    });
+    try {
+      coordinator.notify('root-session', reconciliation());
+      await coordinator.waitForIdle();
+
+      assert.equal(turns, 2);
+      assert.equal(recoveries, 1);
+      assert.ok(reportedError instanceof AgentGraphSupervisorContextOverflowError);
+      assert.equal(reportedError.recoveryAttempted, true);
+      assert.deepEqual(reportedError.partialResult.work, [
+        {
+          workId: 'work-1',
+          status: 'requested',
+          target: { kind: 'agent', agentId: 'reviewer' },
+        },
+      ]);
+      assert.match(reportedError.message, /graph remains durable and recoverable/);
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.attemptCount,
+        2,
+      );
+    } finally {
+      await coordinator.close();
+      store.close();
+    }
+  });
+
+  test('does not blindly retry an overflow when no recovery path is available', async () => {
+    const store = createSqliteSessionMetadataStore(':memory:');
+    let turns = 0;
+    let reportedError: unknown;
+    const coordinator = new AgentGraphSupervisorWakeCoordinator({
+      activityRegistry: new SessionActivityRegistry(),
+      wakeStore: store,
+      readSnapshot: async () => snapshot(),
+      startTurn: async (_sessionId, input): Promise<GoalTurnOutcome> => {
+        turns += 1;
+        return { kind: 'errored', turnId: input.turnId, reason: 'Context window exceeded' };
+      },
+      inspectAttempt: async () => 'missing',
+      newId: sequentialIds(),
+      onError: (_rootSessionId, error) => {
+        reportedError = error;
+      },
+    });
+    try {
+      coordinator.notify('root-session', reconciliation());
+      await coordinator.waitForIdle();
+
+      assert.equal(turns, 1);
+      assert.ok(reportedError instanceof AgentGraphSupervisorContextOverflowError);
+      assert.equal(reportedError.recoveryAttempted, false);
+      assert.equal(
+        (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.attemptCount,
+        1,
       );
     } finally {
       await coordinator.close();

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -4198,18 +4198,17 @@ describe('AiSdkBackend model history', () => {
       },
     });
 
+    const recentEvent = runtimeTextEvent({
+      id: 'manual-compact-recent',
+      turnId: 'turn-recent',
+      role: 'user',
+      author: 'user',
+      text: 'manual recent retained context',
+    });
+    const runtimeContext = [...oldEvents, recentEvent];
     const result = await backend.compactHistory({
       turnId: 'turn-compact',
-      runtimeContext: [
-        ...oldEvents,
-        runtimeTextEvent({
-          id: 'manual-compact-recent',
-          turnId: 'turn-recent',
-          role: 'user',
-          author: 'user',
-          text: 'manual recent retained context',
-        }),
-      ],
+      runtimeContext,
     });
 
     assert.deepEqual(writeInputs, [
@@ -4222,6 +4221,16 @@ describe('AiSdkBackend model history', () => {
     assert.equal(result.contextBudget?.historyCompactBlocksWritten, 1);
     assert.equal(result.contextBudget?.compactionDecisions?.[0]?.decision, 'replaced');
     assert.equal(result.contextBudget?.compactionDecisions?.[0]?.boundaryKind, 'historyCompact');
+
+    await backend.compactHistory({
+      turnId: 'turn-overflow-recovery',
+      runtimeContext,
+      minRecentTurns: 0,
+    });
+    assert.deepEqual(writeInputs[1], {
+      turnId: 'turn-overflow-recovery',
+      foldedIds: ['manual-compact-old-1', 'manual-compact-old-2', 'manual-compact-recent'],
+    });
   });
 
   test('manual compactHistory still folds small histories with the default automatic compact policy', async () => {

--- a/packages/runtime/src/__tests__/context-budget.test.ts
+++ b/packages/runtime/src/__tests__/context-budget.test.ts
@@ -1295,6 +1295,40 @@ describe('context-budget history compact', () => {
     assert.equal(result.diagnostic.historyCompactedTurns, 4);
   });
 
+  test('overflow recovery may fold the latest complete turn with no raw tail', () => {
+    const events = [
+      toolCall('latest-call', 'turn-latest', 'tool-1'),
+      toolResult('latest-result', 'turn-latest', 'tool-1', {
+        text: 'oversized latest result '.repeat(40),
+      }),
+    ];
+
+    const result = applyRuntimeEventContextBudget(
+      events,
+      {
+        maxHistoryEstimatedTokens: 2000,
+        minRecentTurns: 0,
+        charsPerToken: 1,
+        historyCompact: {
+          enabled: true,
+          highWaterRatio: 0.1,
+          minRecentTurns: 0,
+          maxSummaryEstimatedTokens: 120,
+        },
+      },
+      { historyCompactProtocol: 'checkpoint_v2' },
+    );
+
+    assert.ok(result);
+    assert.deepEqual(
+      result.events
+        .filter((event) => !event.id.startsWith('history-compact:'))
+        .map((event) => event.id),
+      [],
+    );
+    assert.equal(result.diagnostic.historyCompactedTurns, 1);
+  });
+
   test('keeps the complete latest turn as the continuation seam', () => {
     const events = [
       textEvent('old-1', 'turn-1', 'old context '.repeat(30)),

--- a/packages/runtime/src/__tests__/graph-mode.test.ts
+++ b/packages/runtime/src/__tests__/graph-mode.test.ts
@@ -14,6 +14,8 @@ describe('Graph Mode shared prompt', () => {
     assert.match(prompt, /committed record ids/);
     assert.match(prompt, /agent_output/);
     assert.match(prompt, /child_session_run.*childSessionId.*currentRunId/);
+    assert.match(prompt, /runtime_events.*max_events.*20.*max_bytes.*32768/);
+    assert.match(prompt, /view=all only for a narrow diagnostic question/);
     assert.match(prompt, /Stay available to the user/);
   });
 });

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -12156,6 +12156,7 @@ describe('SessionManager permission mode updates', () => {
     const output = await manager.readChildAgentOutput(session.id, {
       runId: 'child-run',
       maxEvents: 5,
+      view: 'all',
     });
 
     expect(output.header.runId).toBe('child-run');
@@ -12175,8 +12176,87 @@ describe('SessionManager permission mode updates', () => {
     ]);
     expect(output.truncated.events).toBe(true);
     expect(output.truncated.runtimeEvents).toBe(true);
+    expect(output.budget.view).toBe('all');
+    expect(output.budget.projectedBytes <= output.budget.maxBytes).toBe(true);
     expect('modelReplay' in output).toBe(false);
     expect('projection' in output).toBe(false);
+  });
+
+  test('agent output bounds oversized runtime events by serialized bytes', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new TestBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(6_849),
+      runtimeSource: 'test',
+    });
+    const session = await manager.createSession(makeInput());
+    await runStore.createRun(
+      makeRunHeader({
+        sessionId: session.id,
+        runId: 'child-run',
+        turnId: 'child-turn',
+        status: 'completed',
+        createdAt: 120,
+        updatedAt: 200,
+        completedAt: 200,
+        parentRunId: 'parent-run',
+        agentId: LOCAL_READ_AGENT_ID,
+        agentName: 'Researcher',
+        permissionMode: 'explore',
+      }),
+    );
+    await runStore.appendRuntimeEvent(
+      session.id,
+      'child-run',
+      runtimeEvent({
+        id: 'oversized',
+        sessionId: session.id,
+        runId: 'child-run',
+        turnId: 'child-turn',
+        ts: 130,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'x'.repeat(64 * 1024) },
+      }),
+    );
+    await runStore.appendRuntimeEvent(
+      session.id,
+      'child-run',
+      runtimeEvent({
+        id: 'final',
+        sessionId: session.id,
+        runId: 'child-run',
+        turnId: 'child-turn',
+        ts: 140,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: 'bounded final result' },
+      }),
+    );
+
+    const output = await manager.readChildAgentOutput(session.id, {
+      runId: 'child-run',
+      maxEvents: 20,
+      maxBytes: 1024,
+    });
+
+    expect(output.events).toEqual([]);
+    expect(output.runtimeEvents.map((event) => event.id)).toEqual(['final']);
+    expect(output.truncated.events).toBe(true);
+    expect(output.truncated.runtimeEvents).toBe(true);
+    expect(output.truncated.bytes).toBe(true);
+    expect(output.budget).toMatchObject({
+      view: 'runtime_events',
+      maxBytes: 1024,
+    });
+    expect(output.budget.projectedBytes <= output.budget.maxBytes).toBe(true);
   });
 
   test('agent output rejects ambiguous child run locators', async () => {

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -1234,6 +1234,8 @@ describe('subagent tools', () => {
         run_id: 'child-run',
         turn_id: 'provider-placeholder',
         max_events: 100,
+        max_bytes: 32_768,
+        view: 'runtime_events',
       },
       {
         sessionId: 'session-1',
@@ -1254,6 +1256,8 @@ describe('subagent tools', () => {
           currentRunId: 'child-run',
         },
         maxEvents: 100,
+        maxBytes: 32_768,
+        view: 'runtime_events',
       },
     });
   });

--- a/packages/runtime/src/agent-graph-supervisor-wake.ts
+++ b/packages/runtime/src/agent-graph-supervisor-wake.ts
@@ -10,10 +10,61 @@ import type {
   SessionActivityLease,
   SessionActivityRegistry,
 } from './goal-turn-lifecycle.js';
+import { isContextOverflowErrorText } from './provider-error-classification.js';
 import type { AgentGraphClientSnapshot } from './stream-graph-read-model.js';
 import type { AgentGraphScheduleReconciliationResult } from './stream-graph-schedule-reconcile.js';
 
 const DEFAULT_MAX_DELIVERY_ATTEMPTS = 3;
+const MAX_PARTIAL_WORK_ITEMS = 32;
+const MAX_PARTIAL_RECORD_IDS = 32;
+
+export interface AgentGraphSupervisorPartialResult {
+  schemaVersion: 1;
+  graphId: string;
+  snapshotVersion: string;
+  status: AgentGraphClientSnapshot['status'];
+  closed: boolean;
+  scheduleRevision: number;
+  work: Array<{
+    workId: string;
+    status: AgentGraphClientSnapshot['work'][number]['status'];
+    target: AgentGraphClientSnapshot['work'][number]['target'];
+    replaces?: string;
+  }>;
+  terminalRecordIds: string[];
+  omitted: {
+    work: number;
+    terminalRecordIds: number;
+  };
+}
+
+export class AgentGraphSupervisorContextOverflowError extends Error {
+  readonly code = 'agent_graph_supervisor_context_overflow';
+  readonly partialResult: AgentGraphSupervisorPartialResult;
+  readonly recoveryAttempted: boolean;
+  readonly recoveryFailure?: string;
+
+  constructor(input: {
+    partialResult: AgentGraphSupervisorPartialResult;
+    recoveryAttempted: boolean;
+    recoveryFailure?: string;
+  }) {
+    const recovery = input.recoveryFailure
+      ? ` Recovery failed: ${input.recoveryFailure}.`
+      : input.recoveryAttempted
+        ? ' Aggressive history compaction did not restore capacity.'
+        : ' No overflow recovery was available.';
+    super(
+      `Agent graph supervisor context overflow; graph remains durable and recoverable.${recovery} Partial result: ${JSON.stringify(
+        input.partialResult,
+      )}`,
+    );
+    this.name = 'AgentGraphSupervisorContextOverflowError';
+    this.partialResult = input.partialResult;
+    this.recoveryAttempted = input.recoveryAttempted;
+    if (input.recoveryFailure !== undefined) this.recoveryFailure = input.recoveryFailure;
+  }
+}
 
 export interface AgentGraphSupervisorWakeInput {
   activityRegistry: SessionActivityRegistry;
@@ -30,6 +81,17 @@ export interface AgentGraphSupervisorWakeInput {
     attemptId: string,
     turnId: string,
   ): Promise<AgentRunHeader['status'] | 'missing'>;
+  recoverContextOverflow?(
+    rootSessionId: string,
+    input: {
+      graphId: string;
+      wakeId: string;
+      attemptId: string;
+      turnId: string;
+      failureReason: string;
+      abortSignal: AbortSignal;
+    },
+  ): Promise<void>;
   newId(): string;
   maxDeliveryAttempts?: number;
   onError?(rootSessionId: string, error: unknown): void | Promise<void>;
@@ -172,7 +234,9 @@ export class AgentGraphSupervisorWakeCoordinator {
     result?: AgentGraphScheduleReconciliationResult,
   ): Promise<void> {
     let lastFailure: string | undefined;
+    let overflowRecoveryAttempted = false;
     for (let index = 0; index < this.#maxDeliveryAttempts; index += 1) {
+      let overflowAttempt: { attemptId: string; turnId: string; failureReason: string } | undefined;
       const activity = await this.#input.activityRegistry.acquire(
         wake.rootSessionId,
         this.#abortController.signal,
@@ -231,12 +295,45 @@ export class AgentGraphSupervisorWakeCoordinator {
           }
           lastFailure = wakeOutcomeFailure(outcome);
           await this.#markRetryable(wake.graphId, wake.wakeId, attemptId, lastFailure);
+          if (isSupervisorContextOverflow(lastFailure)) {
+            overflowAttempt = { attemptId, turnId, failureReason: lastFailure };
+          }
         } catch (error) {
           lastFailure = errorMessage(error);
           await this.#markRetryable(wake.graphId, wake.wakeId, attemptId, lastFailure);
+          if (isSupervisorContextOverflow(lastFailure)) {
+            overflowAttempt = { attemptId, turnId, failureReason: lastFailure };
+          }
         }
       } finally {
         activity.release();
+      }
+      if (this.#closed) return;
+      if (overflowAttempt) {
+        const canRecover =
+          !overflowRecoveryAttempted &&
+          index + 1 < this.#maxDeliveryAttempts &&
+          this.#input.recoverContextOverflow !== undefined;
+        if (!canRecover) {
+          throw await this.#contextOverflowError(wake.rootSessionId, snapshot, {
+            recoveryAttempted: overflowRecoveryAttempted,
+          });
+        }
+        overflowRecoveryAttempted = true;
+        try {
+          await this.#input.recoverContextOverflow!(wake.rootSessionId, {
+            graphId: wake.graphId,
+            wakeId: wake.wakeId,
+            ...overflowAttempt,
+            abortSignal: this.#abortController.signal,
+          });
+        } catch (error) {
+          if (this.#closed || isAbortError(error)) return;
+          throw await this.#contextOverflowError(wake.rootSessionId, snapshot, {
+            recoveryAttempted: true,
+            recoveryFailure: errorMessage(error),
+          });
+        }
       }
       if (this.#closed) return;
     }
@@ -245,6 +342,23 @@ export class AgentGraphSupervisorWakeCoordinator {
         lastFailure ?? 'unknown failure'
       }`,
     );
+  }
+
+  async #contextOverflowError(
+    rootSessionId: string,
+    fallbackSnapshot: AgentGraphClientSnapshot,
+    input: { recoveryAttempted: boolean; recoveryFailure?: string },
+  ): Promise<AgentGraphSupervisorContextOverflowError> {
+    let currentSnapshot = fallbackSnapshot;
+    try {
+      currentSnapshot = await this.#input.readSnapshot(rootSessionId);
+    } catch {
+      // The checkpoint snapshot is already durable and sufficient for a bounded fallback.
+    }
+    return new AgentGraphSupervisorContextOverflowError({
+      partialResult: projectAgentGraphSupervisorPartialResult(currentSnapshot),
+      ...input,
+    });
   }
 
   async #markRetryable(
@@ -352,6 +466,46 @@ function wakeOutcomeFailure(outcome: Exclude<GoalTurnOutcome, { kind: 'completed
     return `${outcome.kind}: ${outcome.reason}`;
   }
   return 'aborted';
+}
+
+function isSupervisorContextOverflow(failureReason: string): boolean {
+  const normalized = failureReason.toLowerCase();
+  return (
+    normalized.includes('context_overflow') ||
+    normalized.includes('context window exceeded') ||
+    normalized.includes('context budget exhausted') ||
+    isContextOverflowErrorText(failureReason)
+  );
+}
+
+function projectAgentGraphSupervisorPartialResult(
+  snapshot: AgentGraphClientSnapshot,
+): AgentGraphSupervisorPartialResult {
+  const work = snapshot.work.slice(0, MAX_PARTIAL_WORK_ITEMS).map((item) => ({
+    workId: item.workId,
+    status: item.status,
+    target: item.target,
+    ...(item.replaces !== undefined ? { replaces: item.replaces } : {}),
+  }));
+  const allTerminalRecordIds = [
+    ...(snapshot.finish?.resultIds ?? []),
+    ...snapshot.terminalHistory.records.map((record) => record.recordId),
+  ].filter((recordId, index, recordIds) => recordIds.indexOf(recordId) === index);
+  const terminalRecordIds = allTerminalRecordIds.slice(0, MAX_PARTIAL_RECORD_IDS);
+  return {
+    schemaVersion: 1,
+    graphId: snapshot.graphId,
+    snapshotVersion: snapshot.snapshotVersion,
+    status: snapshot.status,
+    closed: snapshot.closed,
+    scheduleRevision: snapshot.scheduleRevision,
+    work,
+    terminalRecordIds,
+    omitted: {
+      work: snapshot.omitted.work + Math.max(0, snapshot.work.length - work.length),
+      terminalRecordIds: Math.max(0, allTerminalRecordIds.length - terminalRecordIds.length),
+    },
+  };
 }
 
 function renderAgentGraphSupervisorWakePrompt(

--- a/packages/runtime/src/ai-sdk-compaction.ts
+++ b/packages/runtime/src/ai-sdk-compaction.ts
@@ -719,7 +719,7 @@ export class AiSdkCompaction {
     this.historyCompactAbortController = historyCompactAbortController;
     try {
       const runtimeContext = input.runtimeContext.filter((event) => event.turnId !== input.turnId);
-      const policy = this.buildManualHistoryCompactPolicy(runtimeContext);
+      const policy = this.buildManualHistoryCompactPolicy(runtimeContext, input.minRecentTurns);
       if (!policy) return {};
 
       const contextBudget = policy;
@@ -805,6 +805,7 @@ export class AiSdkCompaction {
 
   private buildManualHistoryCompactPolicy(
     runtimeContext: readonly RuntimeEvent[],
+    minRecentTurnsOverride?: number,
   ): ContextBudgetPolicy | undefined {
     if (runtimeContext.length === 0 || !this.input.contextBudget || !this.hasHistoryCompactWriter())
       return undefined;
@@ -821,7 +822,7 @@ export class AiSdkCompaction {
       name: base.name ?? 'manual-history-compact',
       ...(base.charsPerToken !== undefined ? { charsPerToken: base.charsPerToken } : {}),
       maxHistoryEstimatedTokens,
-      minRecentTurns: current?.minRecentTurns ?? base.minRecentTurns ?? 1,
+      minRecentTurns: minRecentTurnsOverride ?? current?.minRecentTurns ?? base.minRecentTurns ?? 1,
       historyCompact: {
         ...currentWithoutBlocks,
         enabled: true,
@@ -829,7 +830,8 @@ export class AiSdkCompaction {
         highWaterRatio: 0.000001,
         targetRatio: current?.targetRatio ?? 0.2,
         tailEstimatedTokens: 1,
-        minRecentTurns: current?.minRecentTurns ?? base.minRecentTurns ?? 1,
+        minRecentTurns:
+          minRecentTurnsOverride ?? current?.minRecentTurns ?? base.minRecentTurns ?? 1,
         maxBlocks: current?.maxBlocks ?? 1,
         maxEstimatedTokens: current?.maxEstimatedTokens ?? 2048,
         maxBlockEstimatedTokens:

--- a/packages/runtime/src/graph-mode.ts
+++ b/packages/runtime/src/graph-mode.ts
@@ -11,7 +11,7 @@ export function renderGraphModePrompt(): string {
     'Use operator_id only to send follow-up work to an existing runtime operator id returned by view_agent_graph.',
     'A scheduling update must omit finish. Send finish only in a later terminal update after all selected result_ids are committed.',
     'Stay available to the user while operators execute. Intervene only through the typed graph controls, and explain material supervision decisions.',
-    'Before advancing dependencies or finishing, inspect child output with agent_output like {"locator":"child_session_run","child_session_id":"<childSessionId>","run_id":"<currentRunId>","max_events":100}. Then select committed result ids with update_agent_graph.finish and synthesize those results for the user.',
+    'Before advancing dependencies or finishing, inspect bounded child output with agent_output like {"locator":"child_session_run","child_session_id":"<childSessionId>","run_id":"<currentRunId>","view":"runtime_events","max_events":20,"max_bytes":32768}. Read committed results first; use view=all only for a narrow diagnostic question. Then select committed result ids with update_agent_graph.finish and synthesize those results for the user.',
     'You may continue directly when the request is small or a graph would add ceremony without useful decomposition.',
     '</orchestration_mode>',
   ].join('\n');

--- a/packages/runtime/src/history-compact.ts
+++ b/packages/runtime/src/history-compact.ts
@@ -137,7 +137,11 @@ export interface HistoryCompactPolicy {
   targetRatio?: number;
   /** Legacy V1 explicit tail budget. Ignored by the V2 checkpoint protocol. */
   tailEstimatedTokens?: number;
-  /** Legacy V1 recent-turn request. V2 keeps exactly the latest complete turn at turn boundaries. */
+  /**
+   * Recent-turn request. V2 normally keeps exactly the latest complete turn
+   * at turn boundaries; an explicit zero permits a recovery compaction to
+   * fold the failed latest turn as well.
+   */
   minRecentTurns?: number;
   /** Legacy V1 deterministic-summary estimate. Defaults to 768. */
   maxSummaryEstimatedTokens?: number;
@@ -343,7 +347,7 @@ export function applyRuntimeEventHistoryCompact(
   }
 
   const turnGroups = groupEventsByTurn(compactableEvents, charsPerTokenResolved);
-  if (turnGroups.length <= 1) {
+  if (turnGroups.length <= 1 && compactPolicy.minRecentTurns !== 0) {
     increment(skippedReasonCounts, 'insufficient_turns');
     return {
       events: [...events],
@@ -359,13 +363,16 @@ export function applyRuntimeEventHistoryCompact(
 
   const usesCheckpointV2Seam =
     options.historyCompactProtocol === 'checkpoint_v2' || compactPolicy.checkpoint !== undefined;
-  const tailSelection = usesCheckpointV2Seam
-    ? selectLatestCompleteTurnEvents(turnGroups)
-    : selectLegacyHistoryCompactTailEvents(turnGroups, {
-        tailBudget:
-          finitePositive(compactPolicy.tailEstimatedTokens) ??
-          Math.max(1, Math.floor(maxTokens * finiteRatio(compactPolicy.targetRatio, 0.5))),
-      });
+  const tailSelection =
+    compactPolicy.minRecentTurns === 0
+      ? { eventIds: new Set<string>(), turnIds: new Set<string>() }
+      : usesCheckpointV2Seam
+        ? selectLatestCompleteTurnEvents(turnGroups)
+        : selectLegacyHistoryCompactTailEvents(turnGroups, {
+            tailBudget:
+              finitePositive(compactPolicy.tailEstimatedTokens) ??
+              Math.max(1, Math.floor(maxTokens * finiteRatio(compactPolicy.targetRatio, 0.5))),
+          });
   const retainedEventIds = tailSelection.eventIds;
   const tailTurnIds = tailSelection.turnIds;
   const foldedEvents = compactableEvents.filter((event) => !retainedEventIds.has(event.id));

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -131,8 +131,14 @@ export type {
   ReconcileAgentGraphScheduleInput,
   RenderAgentGraphScheduledWorkPromptInput,
 } from './stream-graph-schedule-reconcile.js';
-export { AgentGraphSupervisorWakeCoordinator } from './agent-graph-supervisor-wake.js';
-export type { AgentGraphSupervisorWakeInput } from './agent-graph-supervisor-wake.js';
+export {
+  AgentGraphSupervisorContextOverflowError,
+  AgentGraphSupervisorWakeCoordinator,
+} from './agent-graph-supervisor-wake.js';
+export type {
+  AgentGraphSupervisorPartialResult,
+  AgentGraphSupervisorWakeInput,
+} from './agent-graph-supervisor-wake.js';
 export {
   AGENT_GRAPH_SUPERVISOR_TOOL_NAMES,
   UPDATE_AGENT_GRAPH_TOOL_NAME,

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -729,6 +729,12 @@ export class RuntimeKernel implements RuntimeKernelLike {
     input: CompactSessionInput,
     execution: PendingExecutionClaim,
   ): AsyncIterable<SessionEvent> {
+    if (
+      input.minRecentTurns !== undefined &&
+      (!Number.isSafeInteger(input.minRecentTurns) || input.minRecentTurns < 0)
+    ) {
+      throw new Error('Runtime compaction minRecentTurns must be a non-negative safe integer');
+    }
     if (!this.deps.runStore || !this.deps.runtimeEventStore) {
       throw new Error('Runtime compaction requires AgentRunStore and RuntimeEventStore');
     }
@@ -793,6 +799,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
       const result = await begin.backend.compactHistory({
         turnId: run.turnId,
         runtimeContext: begin.runtimeContext,
+        ...(input.minRecentTurns !== undefined ? { minRecentTurns: input.minRecentTurns } : {}),
       });
       if (run.isStopped()) return;
       const tokenUsageEvent: TokenUsageEvent = {

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -179,6 +179,12 @@ export interface StopSessionInput {
 
 export interface CompactSessionInput {
   turnId?: string;
+  /**
+   * Override the configured recent-turn tail. Supervisor overflow recovery
+   * uses zero because the failed wake turn itself can contain the oversized
+   * tool result that must be folded.
+   */
+  minRecentTurns?: number;
 }
 
 export type PlanSafeBoundaryContinuationInput = Omit<RuntimeContinuationPlannerInput, 'sessionId'>;

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -394,7 +394,11 @@ export interface AgentOutputInput {
   runId?: string;
   turnId?: string;
   maxEvents?: number;
+  maxBytes?: number;
+  view?: AgentOutputView;
 }
+
+export type AgentOutputView = 'events' | 'runtime_events' | 'all';
 
 export interface AgentOutputResult {
   execution: SubagentExecutionRef;
@@ -408,6 +412,13 @@ export interface AgentOutputResult {
     events: boolean;
     runtimeEvents: boolean;
     diagnostics: boolean;
+    artifacts: boolean;
+    bytes: boolean;
+  };
+  budget: {
+    view: AgentOutputView;
+    maxBytes: number;
+    projectedBytes: number;
   };
 }
 
@@ -3424,18 +3435,46 @@ export class SessionManager {
       ? await this.deps.listArtifactsForTurn(header.sessionId, header.turnId)
       : [];
     const maxEvents = normalizeAgentOutputMaxEvents(input.maxEvents);
+    const maxBytes = normalizeAgentOutputMaxBytes(input.maxBytes);
+    const view = input.view ?? 'runtime_events';
+    const bounded = boundAgentOutputCollections(
+      {
+        events: view === 'runtime_events' ? [] : tail(inspected.events, maxEvents),
+        runtimeEvents: view === 'events' ? [] : tail(inspected.runtimeEvents, maxEvents),
+        diagnostics: tail(inspected.diagnostics, maxEvents),
+        artifacts: tail(artifacts, maxEvents),
+      },
+      maxBytes,
+    );
     return {
       execution: located.execution,
       header: inspected.header,
-      events: tail(inspected.events, maxEvents),
-      runtimeEvents: tail(inspected.runtimeEvents, maxEvents),
+      events: bounded.events,
+      runtimeEvents: bounded.runtimeEvents,
       sourceHealth: inspected.sourceHealth,
-      diagnostics: tail(inspected.diagnostics, maxEvents),
-      artifacts,
+      diagnostics: bounded.diagnostics,
+      artifacts: bounded.artifacts,
       truncated: {
-        events: inspected.events.length > maxEvents,
-        runtimeEvents: inspected.runtimeEvents.length > maxEvents,
-        diagnostics: inspected.diagnostics.length > maxEvents,
+        events:
+          view === 'runtime_events' ||
+          inspected.events.length > maxEvents ||
+          bounded.events.length < Math.min(inspected.events.length, maxEvents),
+        runtimeEvents:
+          view === 'events' ||
+          inspected.runtimeEvents.length > maxEvents ||
+          bounded.runtimeEvents.length < Math.min(inspected.runtimeEvents.length, maxEvents),
+        diagnostics:
+          inspected.diagnostics.length > maxEvents ||
+          bounded.diagnostics.length < Math.min(inspected.diagnostics.length, maxEvents),
+        artifacts:
+          artifacts.length > maxEvents ||
+          bounded.artifacts.length < Math.min(artifacts.length, maxEvents),
+        bytes: bounded.truncated,
+      },
+      budget: {
+        view,
+        maxBytes,
+        projectedBytes: bounded.projectedBytes,
       },
     };
   }
@@ -4930,6 +4969,63 @@ function headerLineage(header: AgentRunHeader): AgentRunRecoveryDecision['lineag
 function normalizeAgentOutputMaxEvents(value: number | undefined): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return 20;
   return Math.min(100, Math.max(1, Math.floor(value)));
+}
+
+const DEFAULT_AGENT_OUTPUT_MAX_BYTES = 32 * 1024;
+const MAX_AGENT_OUTPUT_MAX_BYTES = 128 * 1024;
+
+function normalizeAgentOutputMaxBytes(value: number | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return DEFAULT_AGENT_OUTPUT_MAX_BYTES;
+  }
+  return Math.min(MAX_AGENT_OUTPUT_MAX_BYTES, Math.max(1024, Math.floor(value)));
+}
+
+function boundAgentOutputCollections(
+  input: {
+    events: AgentRunEvent[];
+    runtimeEvents: RuntimeEvent[];
+    diagnostics: AgentRunInspectModel['diagnostics'];
+    artifacts: ArtifactRecord[];
+  },
+  maxBytes: number,
+): {
+  events: AgentRunEvent[];
+  runtimeEvents: RuntimeEvent[];
+  diagnostics: AgentRunInspectModel['diagnostics'];
+  artifacts: ArtifactRecord[];
+  projectedBytes: number;
+  truncated: boolean;
+} {
+  let remaining = maxBytes;
+  let projectedBytes = 0;
+  let truncated = false;
+
+  const takeBoundedTail = <T>(items: readonly T[]): T[] => {
+    const selected: T[] = [];
+    for (let index = items.length - 1; index >= 0; index -= 1) {
+      const item = items[index]!;
+      const bytes = Buffer.byteLength(JSON.stringify(item), 'utf8');
+      if (bytes > remaining) {
+        truncated = true;
+        break;
+      }
+      selected.push(item);
+      projectedBytes += bytes;
+      remaining -= bytes;
+    }
+    selected.reverse();
+    return selected;
+  };
+
+  // RuntimeEvents are the semantic child transcript and therefore receive the
+  // budget first. AgentRun events and diagnostics remain available through
+  // explicit views without duplicating an unbounded second event stream.
+  const runtimeEvents = takeBoundedTail(input.runtimeEvents);
+  const events = takeBoundedTail(input.events);
+  const diagnostics = takeBoundedTail(input.diagnostics);
+  const artifacts = takeBoundedTail(input.artifacts);
+  return { events, runtimeEvents, diagnostics, artifacts, projectedBytes, truncated };
 }
 
 function tail<T>(items: readonly T[], max: number): T[] {

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -289,6 +289,8 @@ export function buildSubagentOutputTool(): MakaTool<
     run_id?: string;
     turn_id?: string;
     max_events?: number;
+    max_bytes?: number;
+    view?: 'events' | 'runtime_events' | 'all';
   },
   unknown
 > {
@@ -296,7 +298,7 @@ export function buildSubagentOutputTool(): MakaTool<
     name: AGENT_OUTPUT_TOOL_NAME,
     displayName: 'Agent Output',
     description:
-      'Inspect child output. Always set locator: child_session_run for a graph childSessionId/currentRunId, child_session_latest for its latest run, or a legacy locator. Unrelated provider-filled optional fields are ignored.',
+      'Inspect bounded child output. Defaults to the semantic runtime_events view with a 32 KiB payload budget. Always set locator: child_session_run for a graph childSessionId/currentRunId, child_session_latest for its latest run, or a legacy locator. Use view=all only for targeted diagnostics.',
     parameters: z
       .object({
         locator: z
@@ -313,6 +315,8 @@ export function buildSubagentOutputTool(): MakaTool<
         run_id: z.string().min(1).optional(),
         turn_id: z.string().min(1).optional(),
         max_events: z.number().int().min(1).max(100).optional(),
+        max_bytes: z.number().int().min(1024).max(128 * 1024).optional(),
+        view: z.enum(['events', 'runtime_events', 'all']).optional(),
       })
       .superRefine((input, ctx) => {
         if (input.locator) {
@@ -402,6 +406,8 @@ export function buildSubagentOutputTool(): MakaTool<
               : {})),
         ...(input.locator === undefined && input.turn_id ? { turnId: input.turn_id } : {}),
         ...(input.max_events !== undefined ? { maxEvents: input.max_events } : {}),
+        ...(input.max_bytes !== undefined ? { maxBytes: input.max_bytes } : {}),
+        ...(input.view !== undefined ? { view: input.view } : {}),
       });
     },
   };

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -315,7 +315,12 @@ export function buildSubagentOutputTool(): MakaTool<
         run_id: z.string().min(1).optional(),
         turn_id: z.string().min(1).optional(),
         max_events: z.number().int().min(1).max(100).optional(),
-        max_bytes: z.number().int().min(1024).max(128 * 1024).optional(),
+        max_bytes: z
+          .number()
+          .int()
+          .min(1024)
+          .max(128 * 1024)
+          .optional(),
         view: z.enum(['events', 'runtime_events', 'all']).optional(),
       })
       .superRefine((input, ctx) => {

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -263,6 +263,8 @@ export interface MakaToolContext {
     runId?: string;
     turnId?: string;
     maxEvents?: number;
+    maxBytes?: number;
+    view?: 'events' | 'runtime_events' | 'all';
   }) => Promise<unknown>;
   askUserQuestion?: (questions: UserQuestion[]) => Promise<UserQuestionResult>;
 }
@@ -412,6 +414,8 @@ export interface ToolRuntimeInput {
     runId?: string;
     turnId?: string;
     maxEvents?: number;
+    maxBytes?: number;
+    view?: 'events' | 'runtime_events' | 'all';
   }) => Promise<unknown>;
   getRunTrace?: () => RunTraceLike | null;
   permissionTimeoutMs?: number;


### PR DESCRIPTION
## Summary
- classify supervisor context overflows separately from ordinary retryable failures
- release the failed wake turn, aggressively compact history including the latest oversized turn, then retry once
- stop repeated identical overflows early and surface a bounded durable partial graph result
- preserve the existing three-attempt policy for non-overflow failures

## Stack
- Depends on #1597
- Part 2 of 4 for #1593

## Validation
- runtime and CLI builds
- Agent Graph supervisor wake tests (12/12)
- manual compaction recovery test
- V2 latest-turn folding regression test
- Biome lint and diff check

Closes no issue; #1593 remains open until the full stack lands.