### PR TITLE
test(desktop): wait for new task surface in session e2e

### DIFF
--- a/apps/desktop/e2e/session-management.spec.ts
+++ b/apps/desktop/e2e/session-management.spec.ts
@@ -11,16 +11,16 @@ import { test, expect } from './fixtures';
  * worse than no assertion.
  */
 test('creating a second chat keeps both in the sidebar', async ({ window: page }) => {
-  const firstSend = page.locator('.maka-composer-textarea');
-  await firstSend.fill('alpha-marker');
-  await firstSend.press('Enter');
+  const composer = page.locator('.maka-composer-textarea');
+  await composer.fill('alpha-marker');
+  await composer.press('Enter');
   await expect(page.getByText(/Fake backend received: alpha-marker/)).toBeVisible();
 
   const sessions = page.locator('aside[aria-label="对话列表"] [data-session-id]');
   await expect(sessions).toHaveCount(1);
 
   await page.getByRole('button', { name: '新任务' }).click();
-  const composer = page.locator('.maka-composer textarea');
+  await expect(page.getByRole('region', { name: '开始对话' })).toBeVisible();
   await composer.fill('beta-marker');
   await composer.press('Enter');
   await expect(page.getByText(/Fake backend received: beta-marker/)).toBeVisible();


### PR DESCRIPTION
## Summary

- wait for the user-visible new-task surface before sending the second message
- reuse the canonical composer locator across both sends
- synchronize on application state instead of adding a timeout or retry

## Verification

- `npx playwright test e2e/session-management.spec.ts --config e2e/playwright.config.ts --repeat-each=30` (30 passed)
- built `@maka/core`, `@maka/storage`, `@maka/mcp`, `@maka/runtime`, `@maka/computer-use`, `@maka/ui`, and `@maka/desktop`
- `npm run lint`
- `npm run format:check`

## Root cause

The new-task action awaits project preparation before clearing the active session. The composer exists on both the active-session and new-task surfaces, so the test could fill the previous composer during that transition. The `开始对话` region appears only after the new-task surface is active, making it the stable boundary for the second send.