### PR TITLE
feat(graph): expose committed child results

### DIFF
--- a/docs/architecture/agent-graph-stream-scheduling-draft.md
+++ b/docs/architecture/agent-graph-stream-scheduling-draft.md
@@ -189,7 +189,12 @@ This separation matters:
 - access control and archival stay on the original resource;
 - a read model cannot silently become a competing event store.
 
-When the main Agent needs the actual answer behind a candidate record, it uses `agent_output` with the operator's `childSessionId` and `currentRunId`.
+When the main Agent needs the actual answer behind a candidate record, it uses
+`agent_output` with the operator's `childSessionId`, `currentRunId`, and
+`view=result`. That projection returns only the final committed model text,
+its Graph result/terminal record IDs, and bounded artifact references. Raw
+Runtime events remain an explicit diagnostic view rather than the normal
+supervisor data path.
 
 ### Commit is the stream boundary
 

--- a/docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md
+++ b/docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md
@@ -189,7 +189,10 @@ Parent 不需要维护可变 child ID 数组。反向查询与 Graph topology �
 - access control 与 archive 继续附着在原始 resource 上；
 - read model 不会悄悄变成竞争性的 event store。
 
-主 Agent 需要读取某个 candidate record 背后的真实答案时，使用 operator 的 `childSessionId` 和 `currentRunId` 调用 `agent_output`。
+主 Agent 需要读取某个 candidate record 背后的真实答案时，使用 operator 的
+`childSessionId`、`currentRunId` 和 `view=result` 调用 `agent_output`。这个投影只返回
+最终已提交的模型文本、对应的 Graph result/terminal record ID，以及有界的 artifact
+引用。原始 Runtime events 仍可用于显式诊断，但不再属于 supervisor 的正常数据路径。
 
 ### Commit 是 stream boundary
 

--- a/packages/runtime/src/__tests__/graph-mode.test.ts
+++ b/packages/runtime/src/__tests__/graph-mode.test.ts
@@ -14,8 +14,9 @@ describe('Graph Mode shared prompt', () => {
     assert.match(prompt, /committed record ids/);
     assert.match(prompt, /agent_output/);
     assert.match(prompt, /child_session_run.*childSessionId.*currentRunId/);
-    assert.match(prompt, /runtime_events.*max_events.*20.*max_bytes.*32768/);
-    assert.match(prompt, /view=all only for a narrow diagnostic question/);
+    assert.match(prompt, /view.*result.*max_bytes.*32768/);
+    assert.match(prompt, /result\.resultRecordId/);
+    assert.match(prompt, /runtime_events or view=all only for a narrow diagnostic question/);
     assert.match(prompt, /Stay available to the user/);
   });
 });

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -214,6 +214,111 @@ describe('SessionManager graph operator provisioning', () => {
     expect(await runStore.listSessionRuns(result.header.id)).toEqual([]);
   });
 
+  test('reads a graph activation through the committed-result data plane', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends: new BackendRegistry(),
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(60),
+    });
+    const parent = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    await runStore.createRun(
+      makeRunHeader({
+        sessionId: parent.id,
+        runId: 'supervisor-run',
+        turnId: 'supervisor-turn',
+      }),
+    );
+    const provisioned = await manager.provisionAgentGraphOperator({
+      graphId: 'graph-result',
+      workId: `graph_work_${'6'.repeat(32)}`,
+      agentId: LOCAL_READ_AGENT_ID,
+      operatorId: `graph_operator_${'7'.repeat(32)}`,
+      source: {
+        sessionId: parent.id,
+        runId: 'supervisor-run',
+        turnId: 'supervisor-turn',
+        toolCallId: 'schedule-tool',
+      },
+      edges: [],
+      expectedScheduleRevision: 1,
+    });
+    const run = makeRunHeader({
+      sessionId: provisioned.header.id,
+      runId: provisioned.provision.initialRunId,
+      turnId: provisioned.provision.initialTurnId,
+      status: 'completed',
+      createdAt: 70,
+      updatedAt: 80,
+      completedAt: 80,
+    });
+    const committedText = 'committed child answer '.repeat(200);
+    await seedRuntimeRun(runStore, run, [
+      runtimeEvent({
+        id: 'graph-child-answer',
+        sessionId: run.sessionId,
+        runId: run.runId,
+        turnId: run.turnId,
+        ts: 75,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'text', text: committedText },
+      }),
+      runtimeEvent({
+        id: 'graph-child-complete',
+        sessionId: run.sessionId,
+        runId: run.runId,
+        turnId: run.turnId,
+        ts: 80,
+        role: 'system',
+        author: 'system',
+        status: 'completed',
+        actions: { endInvocation: true },
+      }),
+    ]);
+
+    const output = await manager.readChildAgentOutput(parent.id, {
+      execution: {
+        kind: 'child_session',
+        sessionId: provisioned.header.id,
+        currentRunId: run.runId,
+      },
+      view: 'result',
+      maxBytes: 1024,
+    });
+
+    expect(output.events).toEqual([]);
+    expect(output.runtimeEvents).toEqual([]);
+    expect(output.artifacts).toEqual([]);
+    expect(output.result).toMatchObject({
+      schemaVersion: 1,
+      status: 'completed',
+      graph: {
+        graphId: 'graph-result',
+        workId: `graph_work_${'6'.repeat(32)}`,
+        operatorId: `graph_operator_${'7'.repeat(32)}`,
+      },
+      sourceRuntimeEventId: 'graph-child-answer',
+      terminalRuntimeEventId: 'graph-child-complete',
+      textTruncated: true,
+    });
+    expect(output.result?.text?.startsWith('committed child answer')).toBe(true);
+    expect((output.result?.text?.length ?? 0) < committedText.length).toBe(true);
+    expect(output.result?.resultRecordId).toMatch(/^graph_record_/);
+    expect(output.result?.terminalRecordId).toMatch(/^graph_record_/);
+    expect(output.result?.resultRecordId === output.result?.terminalRecordId).toBe(false);
+    expect(output.budget).toMatchObject({
+      view: 'result',
+      maxBytes: 1024,
+    });
+    expect(output.budget.projectedBytes <= output.budget.maxBytes).toBe(true);
+  });
+
   test('binds implementation operators to a durable project worktree', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/__tests__/subagent-tools.test.ts
+++ b/packages/runtime/src/__tests__/subagent-tools.test.ts
@@ -1098,6 +1098,7 @@ describe('subagent tools', () => {
     const schema = outputTool.parameters as { safeParse(input: unknown): { success: boolean } };
 
     expect(schema.safeParse({ run_id: 'child-run' }).success).toBe(true);
+    expect(schema.safeParse({ run_id: 'child-run', view: 'result' }).success).toBe(true);
     expect(schema.safeParse({ turn_id: 'child-turn' }).success).toBe(true);
     expect(schema.safeParse({ child_session_id: 'child-session' }).success).toBe(true);
     expect(

--- a/packages/runtime/src/agent-graph-supervisor-wake.ts
+++ b/packages/runtime/src/agent-graph-supervisor-wake.ts
@@ -516,7 +516,7 @@ function renderAgentGraphSupervisorWakePrompt(
     '<agent-graph-supervisor-checkpoint>',
     `Graph ${snapshot.graphId} reached a durable supervisor checkpoint.`,
     `Reconciliation status: ${result?.status ?? 'recovered'}. Snapshot: ${snapshot.snapshotVersion}.`,
-    'Inspect the graph with view_agent_graph. Use agent_output for child results when needed.',
+    'Inspect the graph with view_agent_graph. Read child results with agent_output view=result; use raw event views only for narrow diagnostics.',
     'Then either schedule the next work with update_agent_graph or finish the graph with the selected result record IDs.',
     'Report the useful outcome to the user when the graph is complete.',
     '</agent-graph-supervisor-checkpoint>',

--- a/packages/runtime/src/graph-mode.ts
+++ b/packages/runtime/src/graph-mode.ts
@@ -11,7 +11,7 @@ export function renderGraphModePrompt(): string {
     'Use operator_id only to send follow-up work to an existing runtime operator id returned by view_agent_graph.',
     'A scheduling update must omit finish. Send finish only in a later terminal update after all selected result_ids are committed.',
     'Stay available to the user while operators execute. Intervene only through the typed graph controls, and explain material supervision decisions.',
-    'Before advancing dependencies or finishing, inspect bounded child output with agent_output like {"locator":"child_session_run","child_session_id":"<childSessionId>","run_id":"<currentRunId>","view":"runtime_events","max_events":20,"max_bytes":32768}. Read committed results first; use view=all only for a narrow diagnostic question. Then select committed result ids with update_agent_graph.finish and synthesize those results for the user.',
+    'Before advancing dependencies or finishing, read the committed child result with agent_output like {"locator":"child_session_run","child_session_id":"<childSessionId>","run_id":"<currentRunId>","view":"result","max_bytes":32768}. Use result.resultRecordId when selecting a final committed record. Read runtime_events or view=all only for a narrow diagnostic question. Then select committed result ids with update_agent_graph.finish and synthesize those results for the user.',
     'You may continue directly when the request is small or a graph would add ceremony without useful decomposition.',
     '</orchestration_mode>',
   ].join('\n');

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -35,6 +35,7 @@ export type {
   AgentListItem,
   AgentListResult,
   SubagentExecutionListItem,
+  AgentOutputCommittedResult,
   AgentOutputInput,
   AgentOutputResult,
   StopSessionInput,

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -150,6 +150,7 @@ import { fallbackSessionTitle, sessionTitleSource } from './session-title.js';
 import type { HistoryCompactCleanupRequest } from './runtime-kernel.js';
 import { fingerprintAgentGraphRunnableIntent } from './stream-graph-admission.js';
 import type { AgentGraphRunnableIntent } from './stream-graph-readiness.js';
+import { projectAgentGraphRecords } from './stream-graph-projection.js';
 import {
   buildStatusPatch,
   buildTurnStateMessage,
@@ -411,11 +412,32 @@ export interface AgentOutputInput {
   view?: AgentOutputView;
 }
 
-export type AgentOutputView = 'events' | 'runtime_events' | 'all';
+export type AgentOutputView = 'result' | 'events' | 'runtime_events' | 'all';
+
+export interface AgentOutputCommittedResult {
+  schemaVersion: 1;
+  status: AgentRunHeader['status'];
+  graph?: {
+    graphId: string;
+    workId: string;
+    operatorId: string;
+  };
+  /** Committed Graph record containing the final non-partial model text, or the terminal record. */
+  resultRecordId?: string;
+  terminalRecordId?: string;
+  sourceRuntimeEventId?: string;
+  terminalRuntimeEventId?: string;
+  text?: string;
+  textTruncated: boolean;
+  artifactIds: string[];
+  omittedArtifactIds: number;
+  failureClass?: string;
+}
 
 export interface AgentOutputResult {
   execution: SubagentExecutionRef;
   header: AgentRunHeader;
+  result?: AgentOutputCommittedResult;
   events: AgentRunEvent[];
   runtimeEvents: RuntimeEvent[];
   sourceHealth: AgentRunInspectModel['sourceHealth'];
@@ -3627,6 +3649,38 @@ export class SessionManager {
     const maxEvents = normalizeAgentOutputMaxEvents(input.maxEvents);
     const maxBytes = normalizeAgentOutputMaxBytes(input.maxBytes);
     const view = input.view ?? 'runtime_events';
+    if (view === 'result') {
+      const boundedResult = buildAgentOutputCommittedResult({
+        header: inspected.header,
+        runtimeEvents: inspected.runtimeEvents,
+        artifacts,
+        maxArtifacts: maxEvents,
+        maxBytes,
+        ...(located.graph ? { graph: located.graph } : {}),
+      });
+      return {
+        execution: located.execution,
+        header: inspected.header,
+        result: boundedResult.result,
+        events: [],
+        runtimeEvents: [],
+        sourceHealth: inspected.sourceHealth,
+        diagnostics: [],
+        artifacts: [],
+        truncated: {
+          events: inspected.events.length > 0,
+          runtimeEvents: inspected.runtimeEvents.length > 0,
+          diagnostics: inspected.diagnostics.length > 0,
+          artifacts: artifacts.length > 0,
+          bytes: boundedResult.truncated,
+        },
+        budget: {
+          view,
+          maxBytes,
+          projectedBytes: boundedResult.projectedBytes,
+        },
+      };
+    }
     const bounded = boundAgentOutputCollections(
       {
         events: view === 'runtime_events' ? [] : tail(inspected.events, maxEvents),
@@ -4171,7 +4225,11 @@ export class SessionManager {
   private async findChildRunForOutput(
     sessionId: string,
     input: AgentOutputInput,
-  ): Promise<{ header: AgentRunHeader; execution: SubagentExecutionRef }> {
+  ): Promise<{
+    header: AgentRunHeader;
+    execution: SubagentExecutionRef;
+    graph?: NonNullable<SubagentSessionParent['graph']>;
+  }> {
     if (Number(!!input.execution) + Number(!!input.runId) + Number(!!input.turnId) !== 1) {
       throw new Error('agent_output requires exactly one execution, runId, or turnId locator');
     }
@@ -4210,6 +4268,7 @@ export class SessionManager {
           sessionId: child.id,
           currentRunId: header.runId,
         },
+        ...(child.subagentParent.graph ? { graph: child.subagentParent.graph } : {}),
       };
     }
 
@@ -5197,6 +5256,131 @@ function normalizeAgentOutputMaxBytes(value: number | undefined): number {
   return Math.min(MAX_AGENT_OUTPUT_MAX_BYTES, Math.max(1024, Math.floor(value)));
 }
 
+function buildAgentOutputCommittedResult(input: {
+  header: AgentRunHeader;
+  runtimeEvents: readonly RuntimeEvent[];
+  artifacts: readonly ArtifactRecord[];
+  maxArtifacts: number;
+  maxBytes: number;
+  graph?: NonNullable<SubagentSessionParent['graph']>;
+}): {
+  result: AgentOutputCommittedResult;
+  projectedBytes: number;
+  truncated: boolean;
+} {
+  const finalTextEvent = findLastMatching(
+    input.runtimeEvents,
+    (event) =>
+      event.role === 'model' &&
+      event.partial !== true &&
+      event.content?.kind === 'text' &&
+      event.content.text.trim().length > 0,
+  );
+  const graphRecords =
+    input.graph && input.runtimeEvents.length > 0
+      ? projectAgentGraphRecords({
+          graphId: input.graph.graphId,
+          streams: [
+            {
+              operator: {
+                operatorId: input.graph.operatorId,
+                sessionId: input.header.sessionId,
+              },
+              run: input.header,
+              events: input.runtimeEvents,
+            },
+          ],
+        }).records
+      : [];
+  const graphRecordByRuntimeEventId = new Map(
+    graphRecords.map((record) => [record.source.runtimeEventId, record]),
+  );
+  const terminalRecord = findLastMatching(graphRecords, (record) =>
+    record.supervisorSignals.some((signal) => signal.kind === 'terminal'),
+  );
+  const outputRecord = finalTextEvent
+    ? graphRecordByRuntimeEventId.get(finalTextEvent.id)
+    : undefined;
+  let artifactIds = tail(
+    input.artifacts.map((artifact) => artifact.id),
+    input.maxArtifacts,
+  );
+  const base = (): AgentOutputCommittedResult => ({
+    schemaVersion: 1,
+    status: input.header.status,
+    ...(input.graph ? { graph: { ...input.graph } } : {}),
+    ...(outputRecord || terminalRecord
+      ? { resultRecordId: (outputRecord ?? terminalRecord)!.recordId }
+      : {}),
+    ...(terminalRecord ? { terminalRecordId: terminalRecord.recordId } : {}),
+    ...(finalTextEvent ? { sourceRuntimeEventId: finalTextEvent.id } : {}),
+    ...(terminalRecord ? { terminalRuntimeEventId: terminalRecord.source.runtimeEventId } : {}),
+    textTruncated: false,
+    artifactIds,
+    omittedArtifactIds: Math.max(0, input.artifacts.length - artifactIds.length),
+    ...(input.header.failureClass ? { failureClass: input.header.failureClass } : {}),
+  });
+
+  while (artifactIds.length > 0 && serializedBytes(base()) > input.maxBytes) {
+    artifactIds = artifactIds.slice(1);
+  }
+
+  const text = finalTextEvent?.content?.kind === 'text' ? finalTextEvent.content.text : undefined;
+  const withoutText = base();
+  if (text === undefined) {
+    return {
+      result: withoutText,
+      projectedBytes: serializedBytes(withoutText),
+      truncated: withoutText.omittedArtifactIds > 0,
+    };
+  }
+  const fullResult = { ...withoutText, text };
+  const fullBytes = serializedBytes(fullResult);
+  if (fullBytes <= input.maxBytes) {
+    return {
+      result: fullResult,
+      projectedBytes: fullBytes,
+      truncated: withoutText.omittedArtifactIds > 0,
+    };
+  }
+
+  const codePoints = Array.from(text);
+  let low = 0;
+  let high = codePoints.length;
+  let best: AgentOutputCommittedResult = { ...withoutText, textTruncated: true };
+  while (low <= high) {
+    const middle = Math.floor((low + high) / 2);
+    const candidate: AgentOutputCommittedResult = {
+      ...withoutText,
+      text: `${codePoints.slice(0, middle).join('')}…`,
+      textTruncated: true,
+    };
+    if (serializedBytes(candidate) <= input.maxBytes) {
+      best = candidate;
+      low = middle + 1;
+    } else {
+      high = middle - 1;
+    }
+  }
+  return {
+    result: best,
+    projectedBytes: serializedBytes(best),
+    truncated: true,
+  };
+}
+
+function serializedBytes(value: unknown): number {
+  return Buffer.byteLength(JSON.stringify(value), 'utf8');
+}
+
+function findLastMatching<T>(items: readonly T[], predicate: (item: T) => boolean): T | undefined {
+  for (let index = items.length - 1; index >= 0; index -= 1) {
+    const item = items[index]!;
+    if (predicate(item)) return item;
+  }
+  return undefined;
+}
+
 function boundAgentOutputCollections(
   input: {
     events: AgentRunEvent[];
@@ -5221,7 +5405,7 @@ function boundAgentOutputCollections(
     const selected: T[] = [];
     for (let index = items.length - 1; index >= 0; index -= 1) {
       const item = items[index]!;
-      const bytes = Buffer.byteLength(JSON.stringify(item), 'utf8');
+      const bytes = serializedBytes(item);
       if (bytes > remaining) {
         truncated = true;
         break;

--- a/packages/runtime/src/subagent-tools.ts
+++ b/packages/runtime/src/subagent-tools.ts
@@ -288,7 +288,7 @@ export function buildSubagentOutputTool(): MakaTool<
     turn_id?: string;
     max_events?: number;
     max_bytes?: number;
-    view?: 'events' | 'runtime_events' | 'all';
+    view?: 'result' | 'events' | 'runtime_events' | 'all';
   },
   unknown
 > {
@@ -296,7 +296,7 @@ export function buildSubagentOutputTool(): MakaTool<
     name: AGENT_OUTPUT_TOOL_NAME,
     displayName: 'Agent Output',
     description:
-      'Inspect bounded child output. Defaults to the semantic runtime_events view with a 32 KiB payload budget. Always set locator: child_session_run for a graph childSessionId/currentRunId, child_session_latest for its latest run, or a legacy locator. Use view=all only for targeted diagnostics.',
+      'Inspect bounded child output. Use view=result for the final committed model text plus its Graph result record id; runtime_events is the default compatibility view. Always set locator: child_session_run for a graph childSessionId/currentRunId, child_session_latest for its latest run, or a legacy locator. Use view=all only for targeted diagnostics.',
     parameters: z
       .object({
         locator: z
@@ -319,7 +319,7 @@ export function buildSubagentOutputTool(): MakaTool<
           .min(1024)
           .max(128 * 1024)
           .optional(),
-        view: z.enum(['events', 'runtime_events', 'all']).optional(),
+        view: z.enum(['result', 'events', 'runtime_events', 'all']).optional(),
       })
       .superRefine((input, ctx) => {
         if (input.locator) {

--- a/packages/runtime/src/tool-runtime.ts
+++ b/packages/runtime/src/tool-runtime.ts
@@ -226,7 +226,7 @@ export interface MakaToolContext {
     turnId?: string;
     maxEvents?: number;
     maxBytes?: number;
-    view?: 'events' | 'runtime_events' | 'all';
+    view?: 'result' | 'events' | 'runtime_events' | 'all';
   }) => Promise<unknown>;
   askUserQuestion?: (questions: UserQuestion[]) => Promise<UserQuestionResult>;
   requestSandboxBoundary?: (
@@ -385,7 +385,7 @@ export interface ToolRuntimeInput {
     turnId?: string;
     maxEvents?: number;
     maxBytes?: number;
-    view?: 'events' | 'runtime_events' | 'all';
+    view?: 'result' | 'events' | 'runtime_events' | 'all';
   }) => Promise<unknown>;
   getRunTrace?: () => RunTraceLike | null;
   recordToolInvocation?: ToolTelemetryRecorder;


### PR DESCRIPTION
## Summary
- add agent_output view=result for final committed model text and stable Graph record identities
- return result and terminal record IDs plus bounded artifact references without raw event or tool payloads
- enforce the existing serialized byte budget on the result projection, including truncating oversized final text
- route Graph mode and durable supervisor wakes through the committed-result view; raw views remain explicit diagnostics

## Stack
- Depends on #1599 (and transitively #1597)
- Part 3 of 4 for #1593

## Validation
- runtime, headless, and CLI builds
- committed Graph result projection test
- Graph prompt and agent_output schema tests
- Biome lint and diff check

Closes no issue; #1593 remains open until the full stack lands.