### PR TITLE
test(graph): cover large supervisor outputs

### DIFF
--- a/docs/architecture/agent-graph-stream-scheduling-draft.md
+++ b/docs/architecture/agent-graph-stream-scheduling-draft.md
@@ -379,6 +379,12 @@ For each delivery attempt, the host preallocates a root Turn identity and starts
 
 “Prompt persisted” does not mean “wake delivered.” Delivery is complete only when the host observes the root AgentRun complete. A permission suspension is parked explicitly. After restart, the wake coordinator compares stored attempts with AgentRun facts, marks interrupted attempts retryable, and resumes only safe deliveries.
 
+Context overflow is handled separately from an ordinary transient failure. The
+host records an overflow diagnostic, runs at most one aggressive compaction,
+and reports the before/after token estimates and dropped event counts when
+available. A second overflow stops immediately with a bounded durable partial
+result; it is never retried a third time with an identical oversized context.
+
 The Session activity registry serializes this host-created turn with other root Session activity. Multiple clients can observe the same durable Session and Graph state without becoming scheduler owners.
 
 ## Persistence and authority

--- a/docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md
+++ b/docs/architecture/agent-graph-stream-scheduling-draft.zh-CN.md
@@ -377,6 +377,11 @@ pending → running → delivered
 
 “Prompt 已持久化”不等于“wake 已 delivered”。只有 host 观察到 root AgentRun completed，delivery 才完成。Permission suspension 会被显式 parked。重启后，wake coordinator 会对比 stored attempt 与 AgentRun fact，把被中断 attempt 标记为 retryable，只恢复安全的 delivery。
 
+Context overflow 与普通 transient failure 分开处理。Host 会记录 overflow diagnostic，
+最多执行一次 aggressive compaction，并在可用时报告压缩前后 token 估算与 dropped event
+数量。若第二次仍 overflow，会立即返回有界的 durable partial result；不会带着完全相同的
+超长 context 再做第三次重试。
+
 Session activity registry 会把这个 host-created turn 与其它 root Session activity 串行化。多个 client 可以观察同一个持久 Session 与 Graph state，但不会成为 scheduler owner。
 
 ## Persistence 与 authority

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -892,14 +892,43 @@ export async function createMakaCliRuntimeContext(
       },
       recoverContextOverflow: async (rootSessionId, { abortSignal }) => {
         abortSignal.throwIfAborted();
-        for await (const _event of runtime.compactSession(rootSessionId, {
+        let recovery:
+          | {
+              estimatedTokensBefore?: number;
+              estimatedTokensAfter?: number;
+              droppedTurns?: number;
+              droppedEvents?: number;
+              historyCompactedEvents?: number;
+              historyCompactBlocksWritten?: number;
+            }
+          | undefined;
+        for await (const event of runtime.compactSession(rootSessionId, {
           turnId: randomUUID(),
           minRecentTurns: 0,
         })) {
           abortSignal.throwIfAborted();
+          if (event.type === 'token_usage' && event.contextBudget) {
+            const diagnostic = event.contextBudget;
+            recovery = {
+              estimatedTokensBefore: diagnostic.estimatedTokensBefore,
+              estimatedTokensAfter: diagnostic.estimatedTokensAfter,
+              droppedTurns: diagnostic.droppedTurns,
+              droppedEvents: diagnostic.droppedEvents,
+              ...(diagnostic.historyCompactedEvents !== undefined
+                ? { historyCompactedEvents: diagnostic.historyCompactedEvents }
+                : {}),
+              ...(diagnostic.historyCompactBlocksWritten !== undefined
+                ? { historyCompactBlocksWritten: diagnostic.historyCompactBlocksWritten }
+                : {}),
+            };
+          }
         }
+        return recovery;
       },
       newId: randomUUID,
+      onDiagnostic: (diagnostic) => {
+        console.warn('[agent-graph-supervisor-wake]', JSON.stringify(diagnostic));
+      },
       onError: (rootSessionId, error) => {
         agentGraphErrors.set(rootSessionId, error);
       },

--- a/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
+++ b/packages/runtime/src/__tests__/agent-graph-supervisor-wake.test.ts
@@ -4,6 +4,7 @@ import { createSqliteSessionMetadataStore } from '@maka/storage';
 import {
   AgentGraphSupervisorContextOverflowError,
   AgentGraphSupervisorWakeCoordinator,
+  type AgentGraphSupervisorWakeDiagnostic,
 } from '../agent-graph-supervisor-wake.js';
 import { SessionActivityRegistry, type GoalTurnOutcome } from '../goal-turn-lifecycle.js';
 import type { AgentGraphClientSnapshot } from '../stream-graph-read-model.js';
@@ -53,6 +54,7 @@ describe('Agent Graph supervisor wake delivery', () => {
     const store = createSqliteSessionMetadataStore(':memory:');
     let turns = 0;
     const recoveries: string[] = [];
+    const diagnostics: AgentGraphSupervisorWakeDiagnostic[] = [];
     const coordinator = new AgentGraphSupervisorWakeCoordinator({
       activityRegistry: new SessionActivityRegistry(),
       wakeStore: store,
@@ -66,8 +68,18 @@ describe('Agent Graph supervisor wake delivery', () => {
       inspectAttempt: async () => 'missing',
       recoverContextOverflow: async (_rootSessionId, input) => {
         recoveries.push(input.attemptId);
+        return {
+          estimatedTokensBefore: 700_000,
+          estimatedTokensAfter: 12_000,
+          droppedEvents: 80,
+          historyCompactedEvents: 75,
+          historyCompactBlocksWritten: 1,
+        };
       },
       newId: sequentialIds(),
+      onDiagnostic: (diagnostic) => {
+        diagnostics.push(diagnostic);
+      },
     });
     try {
       coordinator.notify('root-session', reconciliation());
@@ -77,6 +89,23 @@ describe('Agent Graph supervisor wake delivery', () => {
       assert.equal(wake?.status, 'delivered');
       assert.equal(wake?.attemptCount, 2);
       assert.equal(recoveries.length, 1);
+      assert.deepEqual(
+        diagnostics.map((diagnostic) => diagnostic.event),
+        ['context_overflow_detected', 'context_overflow_recovery_completed'],
+      );
+      assert.deepEqual(diagnostics[1], {
+        event: 'context_overflow_recovery_completed',
+        graphId: 'graph-1',
+        wakeId: 'graph-1:snapshot-1',
+        attemptId: recoveries[0],
+        recovery: {
+          estimatedTokensBefore: 700_000,
+          estimatedTokensAfter: 12_000,
+          droppedEvents: 80,
+          historyCompactedEvents: 75,
+          historyCompactBlocksWritten: 1,
+        },
+      });
     } finally {
       await coordinator.close();
       store.close();
@@ -88,6 +117,7 @@ describe('Agent Graph supervisor wake delivery', () => {
     let turns = 0;
     let recoveries = 0;
     let reportedError: unknown;
+    const diagnostics: AgentGraphSupervisorWakeDiagnostic[] = [];
     const coordinator = new AgentGraphSupervisorWakeCoordinator({
       activityRegistry: new SessionActivityRegistry(),
       wakeStore: store,
@@ -118,6 +148,9 @@ describe('Agent Graph supervisor wake delivery', () => {
       onError: (_rootSessionId, error) => {
         reportedError = error;
       },
+      onDiagnostic: (diagnostic) => {
+        diagnostics.push(diagnostic);
+      },
     });
     try {
       coordinator.notify('root-session', reconciliation());
@@ -139,6 +172,28 @@ describe('Agent Graph supervisor wake delivery', () => {
         (await store.readAgentGraphSupervisorWake('graph-1', 'graph-1:snapshot-1'))?.attemptCount,
         2,
       );
+      assert.deepEqual(
+        diagnostics.map((diagnostic) => diagnostic.event),
+        [
+          'context_overflow_detected',
+          'context_overflow_recovery_completed',
+          'context_overflow_detected',
+          'context_overflow_exhausted',
+        ],
+      );
+      assert.deepEqual(diagnostics.at(-1), {
+        event: 'context_overflow_exhausted',
+        graphId: 'graph-1',
+        wakeId: 'graph-1:snapshot-1',
+        recoveryAttempted: true,
+        partial: {
+          status: 'waiting',
+          workItems: 1,
+          terminalRecordIds: 0,
+          omittedWorkItems: 0,
+          omittedTerminalRecordIds: 0,
+        },
+      });
     } finally {
       await coordinator.close();
       store.close();

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -319,6 +319,127 @@ describe('SessionManager graph operator provisioning', () => {
     expect(output.budget.projectedBytes <= output.budget.maxBytes).toBe(true);
   });
 
+  test('keeps four large graph branches and a replacement off the supervisor data plane', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends: new BackendRegistry(),
+      childTools: [testTool('Read'), testTool('Glob'), testTool('Grep')],
+      newId: nextId(),
+      now: nextNow(90),
+    });
+    const parent = await manager.createSession(makeInput({ permissionMode: 'ask' }));
+    await runStore.createRun(
+      makeRunHeader({
+        sessionId: parent.id,
+        runId: 'large-supervisor-run',
+        turnId: 'large-supervisor-turn',
+      }),
+    );
+
+    const rawPayloadBytes = 500 * 1024;
+    const oversizedPayload = 'x'.repeat(rawPayloadBytes);
+    const outputs = [];
+    for (let index = 0; index < 5; index += 1) {
+      const identity = String(index + 1).repeat(32);
+      const provisioned = await manager.provisionAgentGraphOperator({
+        graphId: 'graph-large-output',
+        workId: `graph_work_${identity}`,
+        agentId: LOCAL_READ_AGENT_ID,
+        operatorId: `graph_operator_${identity}`,
+        source: {
+          sessionId: parent.id,
+          runId: 'large-supervisor-run',
+          turnId: 'large-supervisor-turn',
+          toolCallId: `schedule-large-${index}`,
+        },
+        edges: [],
+        expectedScheduleRevision: index + 1,
+      });
+      const failed = index === 2;
+      const run = makeRunHeader({
+        sessionId: provisioned.header.id,
+        runId: provisioned.provision.initialRunId,
+        turnId: provisioned.provision.initialTurnId,
+        status: failed ? 'failed' : 'completed',
+        createdAt: 100 + index * 10,
+        updatedAt: 109 + index * 10,
+        completedAt: 109 + index * 10,
+        ...(failed ? { failureClass: 'branch_failed' } : {}),
+      });
+      await seedRuntimeRun(runStore, run, [
+        runtimeEvent({
+          id: `large-tool-result-${index}`,
+          sessionId: run.sessionId,
+          runId: run.runId,
+          turnId: run.turnId,
+          ts: 105 + index * 10,
+          role: 'tool',
+          author: 'tool',
+          content: {
+            kind: 'function_response',
+            id: `large-tool-${index}`,
+            name: 'Read',
+            result: oversizedPayload,
+            isError: false,
+          },
+        }),
+        runtimeEvent({
+          id: `large-final-${index}`,
+          sessionId: run.sessionId,
+          runId: run.runId,
+          turnId: run.turnId,
+          ts: 108 + index * 10,
+          role: 'model',
+          author: 'agent',
+          content: {
+            kind: 'text',
+            text: failed
+              ? 'Branch failed after collecting evidence.'
+              : index === 4
+                ? 'Replacement branch completed with a verified answer.'
+                : `Branch ${index + 1} completed with a verified answer.`,
+          },
+        }),
+        runtimeEvent({
+          id: `large-terminal-${index}`,
+          sessionId: run.sessionId,
+          runId: run.runId,
+          turnId: run.turnId,
+          ts: 109 + index * 10,
+          role: 'system',
+          author: 'system',
+          status: failed ? 'failed' : 'completed',
+          actions: { endInvocation: true },
+        }),
+      ]);
+      outputs.push(
+        await manager.readChildAgentOutput(parent.id, {
+          execution: {
+            kind: 'child_session',
+            sessionId: run.sessionId,
+            currentRunId: run.runId,
+          },
+          view: 'result',
+          maxBytes: 32 * 1024,
+        }),
+      );
+    }
+
+    const serializedOutputs = JSON.stringify(outputs);
+    expect(Buffer.byteLength(oversizedPayload, 'utf8') * outputs.length >= 2_500 * 1024).toBe(true);
+    expect(Buffer.byteLength(serializedOutputs, 'utf8') < 64 * 1024).toBe(true);
+    expect(serializedOutputs.includes(oversizedPayload.slice(0, 1024))).toBe(false);
+    expect(outputs.every((output) => output.runtimeEvents.length === 0)).toBe(true);
+    expect(outputs.every((output) => output.budget.projectedBytes <= 32 * 1024)).toBe(true);
+    expect(outputs[2]?.result?.status).toBe('failed');
+    expect(outputs[2]?.result?.failureClass).toBe('branch_failed');
+    expect(outputs[4]?.result?.text).toBe('Replacement branch completed with a verified answer.');
+  });
+
   test('binds implementation operators to a durable project worktree', async () => {
     const store = new MemorySessionStore();
     const runStore = new MemoryAgentRunStore();

--- a/packages/runtime/src/agent-graph-supervisor-wake.ts
+++ b/packages/runtime/src/agent-graph-supervisor-wake.ts
@@ -66,6 +66,54 @@ export class AgentGraphSupervisorContextOverflowError extends Error {
   }
 }
 
+export interface AgentGraphSupervisorContextRecoveryDiagnostic {
+  estimatedTokensBefore?: number;
+  estimatedTokensAfter?: number;
+  droppedTurns?: number;
+  droppedEvents?: number;
+  historyCompactedEvents?: number;
+  historyCompactBlocksWritten?: number;
+}
+
+export type AgentGraphSupervisorWakeDiagnostic =
+  | {
+      event: 'context_overflow_detected';
+      graphId: string;
+      wakeId: string;
+      attemptId: string;
+      attempt: number;
+      maxAttempts: number;
+      recoveryAvailable: boolean;
+      recoveryAlreadyAttempted: boolean;
+    }
+  | {
+      event: 'context_overflow_recovery_completed';
+      graphId: string;
+      wakeId: string;
+      attemptId: string;
+      recovery?: AgentGraphSupervisorContextRecoveryDiagnostic;
+    }
+  | {
+      event: 'context_overflow_recovery_failed';
+      graphId: string;
+      wakeId: string;
+      attemptId: string;
+      failureReason: string;
+    }
+  | {
+      event: 'context_overflow_exhausted';
+      graphId: string;
+      wakeId: string;
+      recoveryAttempted: boolean;
+      partial: {
+        status: AgentGraphSupervisorPartialResult['status'];
+        workItems: number;
+        terminalRecordIds: number;
+        omittedWorkItems: number;
+        omittedTerminalRecordIds: number;
+      };
+    };
+
 export interface AgentGraphSupervisorWakeInput {
   activityRegistry: SessionActivityRegistry;
   wakeStore: AgentGraphSupervisorWakeStore;
@@ -91,9 +139,10 @@ export interface AgentGraphSupervisorWakeInput {
       failureReason: string;
       abortSignal: AbortSignal;
     },
-  ): Promise<void>;
+  ): Promise<AgentGraphSupervisorContextRecoveryDiagnostic | void>;
   newId(): string;
   maxDeliveryAttempts?: number;
+  onDiagnostic?(diagnostic: AgentGraphSupervisorWakeDiagnostic): void | Promise<void>;
   onError?(rootSessionId: string, error: unknown): void | Promise<void>;
 }
 
@@ -314,25 +363,60 @@ export class AgentGraphSupervisorWakeCoordinator {
           !overflowRecoveryAttempted &&
           index + 1 < this.#maxDeliveryAttempts &&
           this.#input.recoverContextOverflow !== undefined;
+        await emitWakeDiagnostic(this.#input.onDiagnostic, {
+          event: 'context_overflow_detected',
+          graphId: wake.graphId,
+          wakeId: wake.wakeId,
+          attemptId: overflowAttempt.attemptId,
+          attempt: index + 1,
+          maxAttempts: this.#maxDeliveryAttempts,
+          recoveryAvailable: this.#input.recoverContextOverflow !== undefined,
+          recoveryAlreadyAttempted: overflowRecoveryAttempted,
+        });
         if (!canRecover) {
-          throw await this.#contextOverflowError(wake.rootSessionId, snapshot, {
+          const overflowError = await this.#contextOverflowError(wake.rootSessionId, snapshot, {
             recoveryAttempted: overflowRecoveryAttempted,
           });
+          await emitWakeDiagnostic(
+            this.#input.onDiagnostic,
+            exhaustedDiagnostic(wake, overflowError),
+          );
+          throw overflowError;
         }
         overflowRecoveryAttempted = true;
         try {
-          await this.#input.recoverContextOverflow!(wake.rootSessionId, {
+          const recovery = await this.#input.recoverContextOverflow!(wake.rootSessionId, {
             graphId: wake.graphId,
             wakeId: wake.wakeId,
             ...overflowAttempt,
             abortSignal: this.#abortController.signal,
           });
+          await emitWakeDiagnostic(this.#input.onDiagnostic, {
+            event: 'context_overflow_recovery_completed',
+            graphId: wake.graphId,
+            wakeId: wake.wakeId,
+            attemptId: overflowAttempt.attemptId,
+            ...(recovery ? { recovery } : {}),
+          });
         } catch (error) {
           if (this.#closed || isAbortError(error)) return;
-          throw await this.#contextOverflowError(wake.rootSessionId, snapshot, {
-            recoveryAttempted: true,
-            recoveryFailure: errorMessage(error),
+          const failureReason = errorMessage(error);
+          await emitWakeDiagnostic(this.#input.onDiagnostic, {
+            event: 'context_overflow_recovery_failed',
+            graphId: wake.graphId,
+            wakeId: wake.wakeId,
+            attemptId: overflowAttempt.attemptId,
+            failureReason: failureReason.slice(0, 1_000),
           });
+          const overflowError = await this.#contextOverflowError(wake.rootSessionId, snapshot, {
+            recoveryAttempted: true,
+            recoveryFailure: failureReason,
+          });
+          await emitWakeDiagnostic(
+            this.#input.onDiagnostic,
+            exhaustedDiagnostic(wake, overflowError),
+          );
+          throw overflowError;
         }
       }
       if (this.#closed) return;
@@ -540,5 +624,35 @@ async function notifyError(
     await observer?.(rootSessionId, error);
   } catch {
     // Wake diagnostics must not become graph data-path failures.
+  }
+}
+
+function exhaustedDiagnostic(
+  wake: AgentGraphSupervisorWakeRecord,
+  error: AgentGraphSupervisorContextOverflowError,
+): AgentGraphSupervisorWakeDiagnostic {
+  return {
+    event: 'context_overflow_exhausted',
+    graphId: wake.graphId,
+    wakeId: wake.wakeId,
+    recoveryAttempted: error.recoveryAttempted,
+    partial: {
+      status: error.partialResult.status,
+      workItems: error.partialResult.work.length,
+      terminalRecordIds: error.partialResult.terminalRecordIds.length,
+      omittedWorkItems: error.partialResult.omitted.work,
+      omittedTerminalRecordIds: error.partialResult.omitted.terminalRecordIds,
+    },
+  };
+}
+
+async function emitWakeDiagnostic(
+  observer: AgentGraphSupervisorWakeInput['onDiagnostic'],
+  diagnostic: AgentGraphSupervisorWakeDiagnostic,
+): Promise<void> {
+  try {
+    await observer?.(diagnostic);
+  } catch {
+    // Wake diagnostics must never alter delivery or recovery correctness.
   }
 }

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -137,7 +137,9 @@ export {
   AgentGraphSupervisorWakeCoordinator,
 } from './agent-graph-supervisor-wake.js';
 export type {
+  AgentGraphSupervisorContextRecoveryDiagnostic,
   AgentGraphSupervisorPartialResult,
+  AgentGraphSupervisorWakeDiagnostic,
   AgentGraphSupervisorWakeInput,
 } from './agent-graph-supervisor-wake.js';
 export {


### PR DESCRIPTION
## Summary
- add the original failure-shape regression: four 500 KiB graph branches plus a replacement, including one failed branch
- prove roughly 2.5 MiB of raw evidence stays out of the supervisor data plane while all committed-result responses remain under 64 KiB combined
- emit bounded overflow diagnostics for detection, recovery, compaction effect, and exhausted partial fallback
- expose manual-compaction before/after token estimates and dropped event counts in CLI diagnostics

## Stack
- Depends on #1601 (and transitively #1599 and #1597)
- Part 4 of 4 for #1593

## Validation
- runtime, headless, and CLI builds
- supervisor wake suite (12/12)
- large-output failure/replacement regression
- bounded agent_output, committed-result, manual compact, Graph prompt, and schema regressions
- Biome lint and diff check

Closes #1593 when the full stack lands.