### PR TITLE
fix(desktop): complete quote companion lifecycle guarantees

### DIFF
--- a/apps/desktop/e2e/quote-companion.spec.ts
+++ b/apps/desktop/e2e/quote-companion.spec.ts
@@ -1,38 +1,56 @@
 import { test, expect } from './fixtures';
 
-test('quote companion forks, answers, and removes its session on exit', async ({
+test('quote companion removes one staged quote, forks, answers, and cleans up on exit', async ({
   window: page,
 }) => {
   await page.setViewportSize({ width: 1400, height: 900 });
   const mainComposer = page.locator('.maka-composer-textarea');
-  await mainComposer.fill('quote companion source');
+  await mainComposer.fill('quote companion source one');
   await mainComposer.press('Enter');
 
-  const sourceReply = page.getByText(/Fake backend received: quote companion source/);
-  await expect(sourceReply).toBeVisible();
+  const firstSourceReply = page.getByText(/Fake backend received: quote companion source one/);
+  await expect(firstSourceReply).toBeVisible();
+  await mainComposer.fill('quote companion source two');
+  await mainComposer.press('Enter');
+  const secondSourceReply = page.getByText(/Fake backend received: quote companion source two/);
+  await expect(secondSourceReply).toBeVisible();
   const [sourceSession] = await page.evaluate(() => window.maka.sessions.list());
   expect(sourceSession).toBeDefined();
 
   // Create the same real DOM Range a drag selection would produce, then fire
   // mouseup — the selection hook intentionally captures only finalized ranges.
-  await sourceReply.evaluate((element) => {
-    const range = document.createRange();
-    range.selectNodeContents(element);
-    const selection = window.getSelection();
-    selection?.removeAllRanges();
-    selection?.addRange(range);
-    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
-  });
-  await page.getByRole('button', { name: '在侧栏追问' }).click();
+  const stageReply = async (reply: typeof firstSourceReply) => {
+    await reply.evaluate((element) => {
+      const range = document.createRange();
+      range.selectNodeContents(element);
+      const selection = window.getSelection();
+      selection?.removeAllRanges();
+      selection?.addRange(range);
+      document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+    });
+    await page.getByRole('button', { name: '在侧栏追问' }).click();
+  };
+  await stageReply(firstSourceReply);
+  await stageReply(secondSourceReply);
 
   const panel = page.locator('.maka-quote-companion');
   await expect(panel).toBeVisible();
+  await expect(panel.locator('.maka-composer .maka-quote-chip')).toHaveCount(2);
+  await panel.getByRole('button', { name: '移除引用' }).first().click();
+  await expect(panel.locator('.maka-composer .maka-quote-chip')).toHaveCount(1);
+  await expect(panel.locator('.maka-composer .maka-quote-chip')).toContainText(
+    'Fake backend received: quote companion source two',
+  );
   await expect(
     panel.locator('.maka-quote-panel-quote', {
-      hasText: 'Fake backend received: quote companion source',
+      hasText: 'Fake backend received: quote companion source one',
+    }),
+  ).toHaveCount(0);
+  await expect(
+    panel.locator('.maka-quote-panel-quote', {
+      hasText: 'Fake backend received: quote companion source two',
     }),
   ).toBeVisible();
-  await expect(panel.locator('.maka-composer .maka-quote-chip')).toHaveCount(1);
 
   const companionComposer = panel.locator('.maka-composer-textarea');
   await companionComposer.fill('explain this quote');

--- a/apps/desktop/e2e/quote-companion.spec.ts
+++ b/apps/desktop/e2e/quote-companion.spec.ts
@@ -1,0 +1,57 @@
+import { test, expect } from './fixtures';
+
+test('quote companion forks, answers, and removes its session on exit', async ({
+  window: page,
+}) => {
+  await page.setViewportSize({ width: 1400, height: 900 });
+  const mainComposer = page.locator('.maka-composer-textarea');
+  await mainComposer.fill('quote companion source');
+  await mainComposer.press('Enter');
+
+  const sourceReply = page.getByText(/Fake backend received: quote companion source/);
+  await expect(sourceReply).toBeVisible();
+  const [sourceSession] = await page.evaluate(() => window.maka.sessions.list());
+  expect(sourceSession).toBeDefined();
+
+  // Create the same real DOM Range a drag selection would produce, then fire
+  // mouseup — the selection hook intentionally captures only finalized ranges.
+  await sourceReply.evaluate((element) => {
+    const range = document.createRange();
+    range.selectNodeContents(element);
+    const selection = window.getSelection();
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+  });
+  await page.getByRole('button', { name: '在侧栏追问' }).click();
+
+  const panel = page.locator('.maka-quote-companion');
+  await expect(panel).toBeVisible();
+  await expect(
+    panel.locator('.maka-quote-panel-quote', {
+      hasText: 'Fake backend received: quote companion source',
+    }),
+  ).toBeVisible();
+  await expect(panel.locator('.maka-composer .maka-quote-chip')).toHaveCount(1);
+
+  const companionComposer = panel.locator('.maka-composer-textarea');
+  await companionComposer.fill('explain this quote');
+  await companionComposer.press('Enter');
+  await expect(panel.getByText(/Fake backend received: explain this quote/)).toBeVisible();
+  await expect(panel.locator('.maka-composer .maka-quote-chip')).toHaveCount(0);
+
+  await expect
+    .poll(async () => (await page.evaluate(() => window.maka.sessions.list())).length)
+    .toBe(2);
+  const companionSession = (
+    await page.evaluate(() => window.maka.sessions.list())
+  ).find(({ id }) => id !== sourceSession?.id);
+  expect(companionSession?.parentSessionId).toBe(sourceSession?.id);
+  expect(companionSession?.permissionMode).toBe('explore');
+
+  await panel.getByRole('button', { name: '退出' }).click();
+  await expect(panel).toBeHidden();
+  await expect
+    .poll(async () => (await page.evaluate(() => window.maka.sessions.list())).length)
+    .toBe(1);
+});

--- a/apps/desktop/src/main/__tests__/computer-use-capability.test.ts
+++ b/apps/desktop/src/main/__tests__/computer-use-capability.test.ts
@@ -28,8 +28,9 @@ describe('Desktop Computer Use production wiring', () => {
     assert.match(main, /sessions:stop[\s\S]*computerUseOverlay\.clearForSession/);
     assert.match(main, /sessions:archive[\s\S]*computerUseTools\.clearSession/);
     assert.match(main, /sessions:archive[\s\S]*computerUseOverlay\.clearForSession/);
-    assert.match(main, /sessions:remove[\s\S]*computerUseTools\.clearSession/);
-    assert.match(main, /sessions:remove[\s\S]*computerUseOverlay\.clearForSession/);
+    assert.match(main, /const removeSession[\s\S]*computerUseTools\.clearSession/);
+    assert.match(main, /const removeSession[\s\S]*computerUseOverlay\.clearForSession/);
+    assert.match(main, /sessions:remove[\s\S]*await removeSession/);
     assert.match(main, /isTurnStatusChangingSessionEvent[\s\S]*computerUseTools\.clearSession/);
     assert.match(main, /catch \(error\)[\s\S]*computerUseTools\.clearSession/);
     assert.match(main, /Promise\.allSettled\(\[[\s\S]*computerUse\.backend\?\.dispose/);

--- a/apps/desktop/src/main/__tests__/quote-companion-cleanup.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-cleanup.test.ts
@@ -1,0 +1,94 @@
+import { strict as assert } from 'node:assert';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, it } from 'node:test';
+import { createQuoteCompanionCleanupAuthority } from '../quote-companion-cleanup.js';
+
+const roots: string[] = [];
+
+async function createWorkspace(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-quote-companion-cleanup-'));
+  roots.push(root);
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
+});
+
+describe('quote companion cleanup authority', () => {
+  it('persists a failed removal and recovers it through a new authority instance', async () => {
+    const workspaceRoot = await createWorkspace();
+    const first = createQuoteCompanionCleanupAuthority({
+      workspaceRoot,
+      removeSession: async () => {
+        throw new Error('temporary removal failure');
+      },
+    });
+
+    await assert.rejects(first.cleanup('fork-1'), /temporary removal failure/);
+    assert.deepEqual(await readPendingIds(workspaceRoot), ['fork-1']);
+
+    const removed: string[] = [];
+    const afterRestart = createQuoteCompanionCleanupAuthority({
+      workspaceRoot,
+      removeSession: async (sessionId) => {
+        removed.push(sessionId);
+      },
+    });
+    const recovery = await afterRestart.recover();
+
+    assert.deepEqual(removed, ['fork-1']);
+    assert.deepEqual(recovery, { removed: ['fork-1'], failed: [] });
+    assert.deepEqual(await readPendingIds(workspaceRoot), []);
+  });
+
+  it('clears the durable intent only after the complete removal succeeds', async () => {
+    const workspaceRoot = await createWorkspace();
+    let pendingDuringRemoval: string[] = [];
+    const authority = createQuoteCompanionCleanupAuthority({
+      workspaceRoot,
+      removeSession: async () => {
+        pendingDuringRemoval = await readPendingIds(workspaceRoot);
+      },
+    });
+
+    await authority.cleanup('fork-2');
+
+    assert.deepEqual(pendingDuringRemoval, ['fork-2']);
+    assert.deepEqual(await readPendingIds(workspaceRoot), []);
+  });
+
+  it('continues recovering other companions when one removal still fails', async () => {
+    const workspaceRoot = await createWorkspace();
+    const seed = createQuoteCompanionCleanupAuthority({
+      workspaceRoot,
+      removeSession: async () => {
+        throw new Error('offline');
+      },
+    });
+    await assert.rejects(seed.cleanup('fork-a'));
+    await assert.rejects(seed.cleanup('fork-b'));
+
+    const authority = createQuoteCompanionCleanupAuthority({
+      workspaceRoot,
+      removeSession: async (sessionId) => {
+        if (sessionId === 'fork-a') throw new Error('still offline');
+      },
+    });
+    const recovery = await authority.recover();
+
+    assert.deepEqual(recovery.removed, ['fork-b']);
+    assert.deepEqual(
+      recovery.failed.map(({ sessionId }) => sessionId),
+      ['fork-a'],
+    );
+    assert.deepEqual(await readPendingIds(workspaceRoot), ['fork-a']);
+  });
+});
+
+async function readPendingIds(workspaceRoot: string): Promise<string[]> {
+  const raw = await readFile(join(workspaceRoot, 'quote-companion-cleanup.json'), 'utf8');
+  return (JSON.parse(raw) as { pendingSessionIds: string[] }).pendingSessionIds;
+}

--- a/apps/desktop/src/main/__tests__/quote-companion-core.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-core.test.ts
@@ -86,7 +86,7 @@ function makeApi(control: FakeControl = {}) {
       if (control.setModeThrows) throw new Error('setPermissionMode failed');
       return summary(id, control.afterSetMode ?? mode);
     },
-    remove: async (id) => {
+    cleanupQuoteCompanion: async (id) => {
       calls.removed.push(id);
     },
     send: async (id, cmd) => {

--- a/apps/desktop/src/main/__tests__/quote-companion-core.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-core.test.ts
@@ -46,6 +46,7 @@ interface FakeControl {
   /** permissionMode `setPermissionMode` returns (default = the requested mode). */
   afterSetMode?: string;
   setModeThrows?: boolean;
+  cleanupThrows?: boolean;
   sendThrows?: boolean;
   sendResult?: { ok: true } | { ok: false; reason?: string };
   /** Runs right after the fork is created (e.g. to flip `disposed`). */
@@ -88,6 +89,7 @@ function makeApi(control: FakeControl = {}) {
     },
     cleanupQuoteCompanion: async (id) => {
       calls.removed.push(id);
+      if (control.cleanupThrows) throw new Error('cleanup failed');
     },
     send: async (id, cmd) => {
       calls.sent.push({ id, cmd });
@@ -256,6 +258,26 @@ describe('performCompanionTurn', () => {
     assert.deepEqual(calls.removed, ['fork-1']);
     assert.equal(calls.sent.length, 0);
     assert.deepEqual(rec.events, ['created:fork-1']);
+  });
+
+  it('does not release a hidden fork when authoritative cleanup fails', async () => {
+    const { api } = makeApi({ setModeThrows: true, cleanupThrows: true });
+    const events: string[] = [];
+
+    const result = await performCompanionTurn({
+      api,
+      isDisposed: () => false,
+      ...base,
+      onForkCreated: (session) => events.push(`created:${session.id}`),
+      onForkCleanupSucceeded: (sessionId) => events.push(`cleaned:${sessionId}`),
+      onForkCommitted: () => {},
+      onBeforeSend: () => {},
+      onQuotesConsumed: () => {},
+    });
+    await Promise.resolve();
+
+    assert.deepEqual(result, { status: 'error', code: 'permission_pin_failed' });
+    assert.deepEqual(events, ['created:fork-1']);
   });
 
   it('fail-closed: a fork not confirmed `explore` is removed and never sends', async () => {

--- a/apps/desktop/src/main/__tests__/quote-companion-core.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-core.test.ts
@@ -15,6 +15,7 @@ import { describe, it } from 'node:test';
 import type { SessionEvent, SessionSummary, StoredMessage, TurnRecord, TurnStatus } from '@maka/core';
 import {
   applyCompanionInteractionEvent,
+  deriveCompanionComposerState,
   isCompanionTurnTerminal,
   latestSettledTurnId,
   performCompanionTurn,
@@ -125,6 +126,46 @@ describe('latestSettledTurnId', () => {
     );
     assert.equal(latestSettledTurnId([turn('a', 'running')]), undefined);
     assert.equal(latestSettledTurnId([]), undefined);
+  });
+});
+
+describe('deriveCompanionComposerState', () => {
+  it('keeps Stop and Escape available before the first token', () => {
+    assert.deepEqual(
+      deriveCompanionComposerState(true, {
+        turnId: 'waiting-turn',
+        phase: 'waiting',
+        steps: [],
+      }),
+      { streaming: true, processing: true },
+    );
+  });
+
+  it('keeps the turn interruptible after streaming starts without the wait presentation', () => {
+    assert.deepEqual(
+      deriveCompanionComposerState(true, {
+        turnId: 'streaming-turn',
+        phase: 'streamed',
+        steps: [],
+      }),
+      { streaming: true, processing: false },
+    );
+  });
+
+  it('leaves the Composer idle once the turn is terminal or no longer in flight', () => {
+    assert.deepEqual(
+      deriveCompanionComposerState(true, {
+        turnId: 'terminal-turn',
+        phase: 'streamed',
+        terminal: true,
+        steps: [],
+      }),
+      { streaming: false, processing: false },
+    );
+    assert.deepEqual(deriveCompanionComposerState(false, undefined), {
+      streaming: false,
+      processing: false,
+    });
   });
 });
 

--- a/apps/desktop/src/main/__tests__/quote-companion-panel-state.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-panel-state.test.ts
@@ -3,6 +3,7 @@ import { describe, it } from 'node:test';
 import type { QuoteRef } from '@maka/core';
 import {
   consumeCompanionQuoteSnapshot,
+  removeStagedCompanionQuote,
   snapshotCompanionQuotes,
   stageCompanionQuote,
   type QuoteCompanionPanelState,
@@ -52,5 +53,42 @@ describe('quote companion panel ownership', () => {
     });
 
     assert.equal(consumeCompanionQuoteSnapshot(replacement, stale), replacement);
+  });
+
+  it('removes one staged quote by stable panel and quote ids', () => {
+    const newId = ids('quote-a', 'panel-1', 'quote-b');
+    let panel: QuoteCompanionPanelState | null = stageCompanionQuote(null, {
+      sourceSessionId: 'source',
+      quote: quote('A'),
+      newId,
+    });
+    panel = stageCompanionQuote(panel, {
+      sourceSessionId: 'source',
+      quote: quote('B'),
+      newId,
+    });
+
+    panel = removeStagedCompanionQuote(panel, {
+      panelId: panel.id,
+      quoteId: 'quote-a',
+    });
+
+    assert.deepEqual(panel?.quotes, [{ id: 'quote-b', value: quote('B') }]);
+  });
+
+  it('ignores a stale removal from a replaced panel', () => {
+    const replacement = stageCompanionQuote(null, {
+      sourceSessionId: 'source',
+      quote: quote('B'),
+      newId: ids('quote-b', 'panel-2'),
+    });
+
+    assert.equal(
+      removeStagedCompanionQuote(replacement, {
+        panelId: 'panel-1',
+        quoteId: 'quote-b',
+      }),
+      replacement,
+    );
   });
 });

--- a/apps/desktop/src/main/__tests__/quote-companion-panel-state.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-panel-state.test.ts
@@ -1,0 +1,56 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { QuoteRef } from '@maka/core';
+import {
+  consumeCompanionQuoteSnapshot,
+  snapshotCompanionQuotes,
+  stageCompanionQuote,
+  type QuoteCompanionPanelState,
+} from '../../renderer/quote-companion-panel-state.js';
+
+function ids(...values: string[]): () => string {
+  let index = 0;
+  return () => values[index++]!;
+}
+
+function quote(text: string): QuoteRef {
+  return { text };
+}
+
+describe('quote companion panel ownership', () => {
+  it('consumes only the snapshot attached to the accepted send', () => {
+    const newId = ids('quote-a', 'panel-1', 'quote-b');
+    let panel: QuoteCompanionPanelState | null = stageCompanionQuote(null, {
+      sourceSessionId: 'source',
+      quote: quote('A'),
+      newId,
+    });
+    const sent = snapshotCompanionQuotes(panel.id, panel.quotes);
+
+    panel = stageCompanionQuote(panel, {
+      sourceSessionId: 'source',
+      quote: quote('B'),
+      newId,
+    });
+    panel = consumeCompanionQuoteSnapshot(panel, sent);
+
+    assert.deepEqual(panel?.quotes, [{ id: 'quote-b', value: quote('B') }]);
+  });
+
+  it('ignores a late callback from a panel that has been replaced', () => {
+    const firstIds = ids('quote-a', 'panel-1');
+    const first = stageCompanionQuote(null, {
+      sourceSessionId: 'source',
+      quote: quote('A'),
+      newId: firstIds,
+    });
+    const stale = snapshotCompanionQuotes(first.id, first.quotes);
+    const replacement = stageCompanionQuote(null, {
+      sourceSessionId: 'source',
+      quote: quote('B'),
+      newId: ids('quote-b', 'panel-2'),
+    });
+
+    assert.equal(consumeCompanionQuoteSnapshot(replacement, stale), replacement);
+  });
+});

--- a/apps/desktop/src/main/__tests__/quote-companion-visibility.test.ts
+++ b/apps/desktop/src/main/__tests__/quote-companion-visibility.test.ts
@@ -1,0 +1,36 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import {
+  applyCompanionForkVisibilityEvent,
+  reconcileCompanionForkVisibility,
+} from '../../renderer/quote-companion-visibility.js';
+
+describe('quote companion visibility ownership', () => {
+  it('retains every created fork until its own cleanup succeeds', () => {
+    let hidden: ReadonlySet<string> = new Set();
+    hidden = applyCompanionForkVisibilityEvent(hidden, {
+      type: 'fork-created',
+      sessionId: 'fork-a',
+    });
+    hidden = applyCompanionForkVisibilityEvent(hidden, {
+      type: 'fork-created',
+      sessionId: 'fork-b',
+    });
+
+    hidden = applyCompanionForkVisibilityEvent(hidden, {
+      type: 'cleanup-succeeded',
+      sessionId: 'fork-b',
+    });
+
+    assert.deepEqual([...hidden], ['fork-a']);
+  });
+
+  it('releases ids absent from an authoritative session list', () => {
+    const hidden = reconcileCompanionForkVisibility(
+      new Set(['fork-pending', 'fork-removed']),
+      new Set(['fork-pending', 'main-session']),
+    );
+
+    assert.deepEqual([...hidden], ['fork-pending']);
+  });
+});

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1077,6 +1077,7 @@ function registerIpc(): void {
     sendToRenderer: safeSendToRenderer,
   });
   registerSessionsIpc({
+    workspaceRoot,
     runtime,
     store,
     taskLedgerStore,

--- a/apps/desktop/src/main/quote-companion-cleanup.ts
+++ b/apps/desktop/src/main/quote-companion-cleanup.ts
@@ -1,0 +1,155 @@
+import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+const CLEANUP_FILE_VERSION = 1;
+const CLEANUP_FILE_NAME = 'quote-companion-cleanup.json';
+
+interface QuoteCompanionCleanupFile {
+  version: typeof CLEANUP_FILE_VERSION;
+  pendingSessionIds: string[];
+}
+
+interface QuoteCompanionCleanupStore {
+  list(): Promise<string[]>;
+  track(sessionId: string): Promise<void>;
+  forget(sessionId: string): Promise<void>;
+}
+
+export interface QuoteCompanionCleanupRecovery {
+  removed: string[];
+  failed: Array<{ sessionId: string; error: unknown }>;
+}
+
+export interface QuoteCompanionCleanupAuthority {
+  /**
+   * Record the cleanup intent before attempting removal. The record is cleared
+   * only after the complete Desktop session-removal path succeeds.
+   */
+  cleanup(sessionId: string): Promise<void>;
+  /** Retry every cleanup intent left by an earlier failed attempt or app exit. */
+  recover(): Promise<QuoteCompanionCleanupRecovery>;
+}
+
+export function createQuoteCompanionCleanupAuthority(input: {
+  workspaceRoot: string;
+  removeSession: (sessionId: string) => Promise<void>;
+}): QuoteCompanionCleanupAuthority {
+  return new FileQuoteCompanionCleanupAuthority(
+    new FileQuoteCompanionCleanupStore(input.workspaceRoot),
+    input.removeSession,
+  );
+}
+
+class FileQuoteCompanionCleanupAuthority implements QuoteCompanionCleanupAuthority {
+  private readonly inFlight = new Map<string, Promise<void>>();
+
+  constructor(
+    private readonly store: QuoteCompanionCleanupStore,
+    private readonly removeSession: (sessionId: string) => Promise<void>,
+  ) {}
+
+  cleanup(sessionId: string): Promise<void> {
+    const normalized = normalizeSessionId(sessionId);
+    const active = this.inFlight.get(normalized);
+    if (active) return active;
+
+    const operation = this.cleanupOnce(normalized, true).finally(() => {
+      this.inFlight.delete(normalized);
+    });
+    this.inFlight.set(normalized, operation);
+    return operation;
+  }
+
+  async recover(): Promise<QuoteCompanionCleanupRecovery> {
+    const removed: string[] = [];
+    const failed: QuoteCompanionCleanupRecovery['failed'] = [];
+    for (const sessionId of await this.store.list()) {
+      try {
+        await this.cleanup(sessionId);
+        removed.push(sessionId);
+      } catch (error) {
+        failed.push({ sessionId, error });
+      }
+    }
+    return { removed, failed };
+  }
+
+  private async cleanupOnce(sessionId: string, track: boolean): Promise<void> {
+    // This small file is the companion cleanup WAL: once `track` resolves, a
+    // failed removal can be replayed after panel unmount or Desktop restart.
+    if (track) await this.store.track(sessionId);
+    await this.removeSession(sessionId);
+    await this.store.forget(sessionId);
+  }
+}
+
+class FileQuoteCompanionCleanupStore implements QuoteCompanionCleanupStore {
+  private readonly filePath: string;
+  private queue: Promise<void> = Promise.resolve();
+
+  constructor(workspaceRoot: string) {
+    this.filePath = join(workspaceRoot, CLEANUP_FILE_NAME);
+  }
+
+  async list(): Promise<string[]> {
+    await this.queue;
+    return this.read();
+  }
+
+  track(sessionId: string): Promise<void> {
+    return this.mutate((current) =>
+      current.includes(sessionId) ? current : [...current, sessionId],
+    );
+  }
+
+  forget(sessionId: string): Promise<void> {
+    return this.mutate((current) => current.filter((id) => id !== sessionId));
+  }
+
+  private async mutate(update: (current: string[]) => string[]): Promise<void> {
+    const run = async () => {
+      const current = await this.read();
+      await this.write(update(current));
+    };
+    const next = this.queue.then(run, run);
+    this.queue = next.catch(() => {});
+    await next;
+  }
+
+  private async read(): Promise<string[]> {
+    try {
+      const raw = await readFile(this.filePath, 'utf8');
+      const parsed = JSON.parse(raw) as Partial<QuoteCompanionCleanupFile>;
+      if (
+        parsed.version !== CLEANUP_FILE_VERSION ||
+        !Array.isArray(parsed.pendingSessionIds)
+      ) {
+        throw new Error('Invalid quote companion cleanup file');
+      }
+      return [...new Set(parsed.pendingSessionIds.map(normalizeSessionId))];
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+  }
+
+  private async write(pendingSessionIds: string[]): Promise<void> {
+    await mkdir(dirname(this.filePath), { recursive: true });
+    const next: QuoteCompanionCleanupFile = {
+      version: CLEANUP_FILE_VERSION,
+      pendingSessionIds,
+    };
+    const tempPath = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
+    await writeFile(tempPath, `${JSON.stringify(next, null, 2)}\n`, 'utf8');
+    await rename(tempPath, this.filePath);
+  }
+}
+
+function normalizeSessionId(value: unknown): string {
+  if (typeof value !== 'string') throw new Error('Invalid quote companion session id');
+  const normalized = value.trim();
+  if (!normalized || normalized.length > 256) {
+    throw new Error('Invalid quote companion session id');
+  }
+  return normalized;
+}

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -54,6 +54,7 @@ import { handleReviseBeforeTurn } from './session-revision.js';
 import { prepareSessionSendSkillPlan } from './session-send-skill-plan.js';
 import type { DesktopCreateSessionInput } from './new-session-project.js';
 import { registerSessionExecutionIpc } from './session-execution-ipc-main.js';
+import { createQuoteCompanionCleanupAuthority } from './quote-companion-cleanup.js';
 
 type SessionStore = ReturnType<typeof createSessionStore>;
 type ArtifactStore = ReturnType<typeof createArtifactStore>;
@@ -70,6 +71,7 @@ interface SessionToolCleanup {
 }
 
 export interface SessionsIpcDeps {
+  workspaceRoot: string;
   runtime: SessionManager;
   store: SessionStore;
   taskLedgerStore: MainTaskLedgerWiring['store'];
@@ -181,6 +183,7 @@ export function registerSessionsIpc(
   ipcMain: Pick<typeof electronIpcMain, 'handle'> = electronIpcMain,
 ): void {
   const {
+    workspaceRoot,
     runtime,
     store,
     taskLedgerStore,
@@ -216,6 +219,21 @@ export function registerSessionsIpc(
     streamEvents,
     emitModeChanged: (sessionId) => emitSessionsChanged('mode-change', sessionId),
   });
+  const removeSession = async (sessionId: string): Promise<void> => {
+    computerUseOverlay.clearForSession(sessionId);
+    computerUseTools.clearSession(sessionId);
+    await goalWiring.removeSession(sessionId, () => runtime.remove(sessionId));
+    invalidateSessionBindings?.(sessionId);
+    clearSkillHost?.(sessionId);
+    await releaseBrowserSession(sessionId);
+    automationManager.removeAllForSession(sessionId);
+    emitSessionsChanged('deleted', sessionId);
+  };
+  const quoteCompanionCleanup = createQuoteCompanionCleanupAuthority({
+    workspaceRoot,
+    removeSession,
+  });
+
   ipcMain.handle('shell-runs:list', (_event, sessionId: string) => runtime.listShellRunUpdates(sessionId));
   ipcMain.handle('tasks:list', async (_event, sessionId: string) => {
     const tasks = await taskLedgerStore.list(sessionId, {
@@ -226,7 +244,15 @@ export function registerSessionsIpc(
     });
     return tasks.map(sanitizeTaskLedgerTask);
   });
-  ipcMain.handle('sessions:list', (_event, filter?: SessionListFilter) => runtime.listSessions(filter));
+  ipcMain.handle('sessions:list', async (_event, filter?: SessionListFilter) => {
+    // Listing is also a recovery trigger. Await it so an orphaned hidden
+    // companion is removed before it can reappear in the sidebar after restart.
+    const recovery = await quoteCompanionCleanup.recover();
+    const pendingCleanup = new Set(recovery.failed.map(({ sessionId }) => sessionId));
+    return (await runtime.listSessions(filter)).filter(
+      ({ id }) => !pendingCleanup.has(id),
+    );
+  });
   ipcMain.handle('sessions:create', async (_event, input?: CreateSessionRequestInput) => {
     // #1433: `mode` is a product intent, not a session field. What it implies,
     // what the renderer may ask for directly, and what the configured default
@@ -625,15 +651,11 @@ export function registerSessionsIpc(
   });
   ipcMain.handle('sessions:remove', async (_event, sessionId: string, options?: unknown) => {
     for (const id of await resolveSessionActionIds(runtime, sessionId, options)) {
-      computerUseOverlay.clearForSession(id);
-      computerUseTools.clearSession(id);
-      await goalWiring.removeSession(id, () => runtime.remove(id));
-      invalidateSessionBindings?.(id);
-      clearSkillHost?.(id);
-      await releaseBrowserSession(id);
-      automationManager.removeAllForSession(id);
-      emitSessionsChanged('deleted', id);
+      await removeSession(id);
     }
+  });
+  ipcMain.handle('sessions:cleanupQuoteCompanion', async (_event, sessionId: string) => {
+    await quoteCompanionCleanup.cleanup(sessionId);
   });
 }
 

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -316,6 +316,7 @@ export interface MakaBridge {
     setModel(sessionId: string, input: { llmConnectionSlug: string; model: string }): Promise<SessionSummary>;
     setThinkingLevel(sessionId: string, level: ThinkingLevel | undefined | null): Promise<SessionSummary>;
     remove(sessionId: string, options?: { revisionFamily?: boolean }): Promise<void>;
+    cleanupQuoteCompanion(sessionId: string): Promise<void>;
   };
   projects: {
     list(): Promise<ProjectRecord[]>;

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -346,6 +346,9 @@ const makaBridge = {
     remove(sessionId: string, options?: { revisionFamily?: boolean }): Promise<void> {
       return ipcRenderer.invoke('sessions:remove', sessionId, options);
     },
+    cleanupQuoteCompanion(sessionId: string): Promise<void> {
+      return ipcRenderer.invoke('sessions:cleanupQuoteCompanion', sessionId);
+    },
   },
   projects: {
     list(): Promise<ProjectRecord[]> {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -56,6 +56,7 @@ import { ChatComposerRegion } from './chat-composer-region';
 import { ChatWorkbar } from './chat-workbar';
 import {
   consumeCompanionQuoteSnapshot,
+  removeStagedCompanionQuote,
   stageCompanionQuote,
   type QuoteCompanionPanelState,
 } from './quote-companion-panel-state';
@@ -2438,6 +2439,9 @@ function AppShellContent({
                 onClearQuote={() => setQuotePanel(null)}
                 onQuotesConsumed={(snapshot) =>
                   setQuotePanel((prev) => consumeCompanionQuoteSnapshot(prev, snapshot))
+                }
+                onRemoveQuote={(target) =>
+                  setQuotePanel((prev) => removeStagedCompanionQuote(prev, target))
                 }
                 onForkVisibilityChange={onCompanionForkVisibilityChange}
                 sourceSession={activeSessionForView}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -55,6 +55,11 @@ import { AgentGraphPanel } from './agent-graph-panel';
 import { ChatComposerRegion } from './chat-composer-region';
 import { ChatWorkbar } from './chat-workbar';
 import {
+  consumeCompanionQuoteSnapshot,
+  stageCompanionQuote,
+  type QuoteCompanionPanelState,
+} from './quote-companion-panel-state';
+import {
   PlanExecutionPanel,
   PlanProposalCard,
   usePlanModeState,
@@ -454,9 +459,7 @@ function AppShellContent({
   // `quotes` accumulates excerpts staged for the next follow-up — selecting more
   // text adds to the SAME panel rather than opening a new one; `sourceSessionId`
   // pins it to the main session the companion forks from.
-  const [quotePanel, setQuotePanel] = useState<
-    { sourceSessionId: string; quotes: QuoteRef[] } | null
-  >(null);
+  const [quotePanel, setQuotePanel] = useState<QuoteCompanionPanelState | null>(null);
   // The quote companion's ephemeral fork id, while its panel is open — hidden
   // from the main session list (the fork is removed on panel dismiss).
   const [companionForkId, setCompanionForkId] = useState<string | undefined>(undefined);
@@ -2135,9 +2138,11 @@ function AppShellContent({
                         // Accumulate onto the open panel for this session rather
                         // than spawning a new one; otherwise start a fresh panel.
                         setQuotePanel((prev) =>
-                          prev && prev.sourceSessionId === activeId
-                            ? { ...prev, quotes: [...prev.quotes, quote] }
-                            : { sourceSessionId: activeId, quotes: [quote] },
+                          stageCompanionQuote(prev, {
+                            sourceSessionId: activeId,
+                            quote,
+                            newId: () => crypto.randomUUID(),
+                          }),
                         );
                         // Surface it inside the session workbar (as a tab) rather
                         // than a second right column — open the bar on the quote tab.
@@ -2408,8 +2413,8 @@ function AppShellContent({
                   quotePanel && quotePanel.sourceSessionId === activeId ? quotePanel : null
                 }
                 onClearQuote={() => setQuotePanel(null)}
-                onQuotesConsumed={() =>
-                  setQuotePanel((prev) => (prev ? { ...prev, quotes: [] } : prev))
+                onQuotesConsumed={(snapshot) =>
+                  setQuotePanel((prev) => consumeCompanionQuoteSnapshot(prev, snapshot))
                 }
                 onForkChange={setCompanionForkId}
                 sourceSession={activeSessionForView}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -60,6 +60,10 @@ import {
   type QuoteCompanionPanelState,
 } from './quote-companion-panel-state';
 import {
+  applyCompanionForkVisibilityEvent,
+  reconcileCompanionForkVisibility,
+} from './quote-companion-visibility';
+import {
   PlanExecutionPanel,
   PlanProposalCard,
   usePlanModeState,
@@ -211,6 +215,7 @@ function AppShellContent({
   const [appUpdateStatus, setAppUpdateStatus] = useState<AppUpdateStatus | null>(null);
   const {
     sessions,
+    authoritativeSessionIds,
     sessionsRef,
     setSessions,
     refreshSessions,
@@ -460,9 +465,25 @@ function AppShellContent({
   // text adds to the SAME panel rather than opening a new one; `sourceSessionId`
   // pins it to the main session the companion forks from.
   const [quotePanel, setQuotePanel] = useState<QuoteCompanionPanelState | null>(null);
-  // The quote companion's ephemeral fork id, while its panel is open — hidden
-  // from the main session list (the fork is removed on panel dismiss).
-  const [companionForkId, setCompanionForkId] = useState<string | undefined>(undefined);
+  // Created companion forks stay hidden until authoritative cleanup succeeds or
+  // a later authoritative session list confirms they are gone. A set preserves
+  // earlier failed cleanups when another companion opens.
+  const [hiddenCompanionForkIds, setHiddenCompanionForkIds] = useState<ReadonlySet<string>>(
+    () => new Set(),
+  );
+  const onCompanionForkVisibilityChange = useCallback(
+    (event: Parameters<typeof applyCompanionForkVisibilityEvent>[1]) =>
+      setHiddenCompanionForkIds((current) =>
+        applyCompanionForkVisibilityEvent(current, event),
+      ),
+    [],
+  );
+  useEffect(() => {
+    if (!authoritativeSessionIds) return;
+    setHiddenCompanionForkIds((current) =>
+      reconcileCompanionForkVisibility(current, authoritativeSessionIds),
+    );
+  }, [authoritativeSessionIds]);
   const [revisionDraft, setRevisionDraft] = useState<TurnRevisionDraft | null>(null);
   const revisionDraftRef = useRef<TurnRevisionDraft | null>(null);
   const commitRevisionDraft = useCallback((draft: TurnRevisionDraft | null) => {
@@ -518,9 +539,11 @@ function AppShellContent({
       // Exclude the quote companion's ephemeral fork so it stays hidden from the
       // main session list while its panel is open.
       filterLinkedSessionTree(sidebarSessionTree, (session) =>
-        session.id !== companionForkId ? sessionMatchesNavSelection(session, navSelection) : false,
+        !hiddenCompanionForkIds.has(session.id)
+          ? sessionMatchesNavSelection(session, navSelection)
+          : false,
       ),
-    [sidebarSessionTree, navSelection, companionForkId],
+    [sidebarSessionTree, navSelection, hiddenCompanionForkIds],
   );
   const visibleSessions = visibleSessionTree.roots;
   // PR-DAILY-REVIEW-MVP-0: bridge for the main Daily Review module.
@@ -2416,7 +2439,7 @@ function AppShellContent({
                 onQuotesConsumed={(snapshot) =>
                   setQuotePanel((prev) => consumeCompanionQuoteSnapshot(prev, snapshot))
                 }
-                onForkChange={setCompanionForkId}
+                onForkVisibilityChange={onCompanionForkVisibilityChange}
                 sourceSession={activeSessionForView}
                 modelChoices={chatModelChoices}
               />

--- a/apps/desktop/src/renderer/chat-workbar.tsx
+++ b/apps/desktop/src/renderer/chat-workbar.tsx
@@ -1,10 +1,14 @@
 import { lazy, Suspense } from 'react';
 import type { KeyboardEvent, PointerEvent } from 'react';
 import { useUiLocale, type ChatModelChoice } from '@maka/ui';
-import type { QuoteRef, SessionSummary } from '@maka/core';
+import type { SessionSummary } from '@maka/core';
 import type { SessionWorkbarTab } from './session-workbar-layout';
 import { SESSION_WORKBAR_MAX_WIDTH, SESSION_WORKBAR_MIN_WIDTH } from './session-workbar-layout';
 import { getShellCopy } from './locales/shell-copy';
+import type {
+  CompanionQuoteSnapshot,
+  QuoteCompanionPanelState,
+} from './quote-companion-panel-state';
 
 // The session workbar owns the task ledger, embedded browser, and artifact
 // preview. Keep the combined auxiliary surface out of the first chat paint.
@@ -38,9 +42,9 @@ interface ChatWorkbarProps {
   onWorkbarResizeHandleKeyDown: (event: KeyboardEvent<HTMLDivElement>) => void;
   /** Active quote side panel: staged excerpts + source; threads to the workbar's
    *  "追问引用" tab. */
-  quote?: { sourceSessionId: string; quotes: QuoteRef[] } | null;
+  quote?: QuoteCompanionPanelState | null;
   onClearQuote?: () => void;
-  onQuotesConsumed?: () => void;
+  onQuotesConsumed?: (snapshot: CompanionQuoteSnapshot) => void;
   onForkChange?: (forkId: string | undefined) => void;
   sourceSession?: SessionSummary;
   modelChoices?: readonly ChatModelChoice[];

--- a/apps/desktop/src/renderer/chat-workbar.tsx
+++ b/apps/desktop/src/renderer/chat-workbar.tsx
@@ -9,6 +9,7 @@ import type {
   CompanionQuoteSnapshot,
   QuoteCompanionPanelState,
 } from './quote-companion-panel-state';
+import type { CompanionForkVisibilityEvent } from './quote-companion-visibility';
 
 // The session workbar owns the task ledger, embedded browser, and artifact
 // preview. Keep the combined auxiliary surface out of the first chat paint.
@@ -45,7 +46,7 @@ interface ChatWorkbarProps {
   quote?: QuoteCompanionPanelState | null;
   onClearQuote?: () => void;
   onQuotesConsumed?: (snapshot: CompanionQuoteSnapshot) => void;
-  onForkChange?: (forkId: string | undefined) => void;
+  onForkVisibilityChange?: (event: CompanionForkVisibilityEvent) => void;
   sourceSession?: SessionSummary;
   modelChoices?: readonly ChatModelChoice[];
 }
@@ -63,7 +64,7 @@ export function ChatWorkbar({
   quote,
   onClearQuote,
   onQuotesConsumed,
-  onForkChange,
+  onForkVisibilityChange,
   sourceSession,
   modelChoices,
 }: ChatWorkbarProps) {
@@ -95,7 +96,7 @@ export function ChatWorkbar({
           quote={quote}
           onClearQuote={onClearQuote}
           onQuotesConsumed={onQuotesConsumed}
-          onForkChange={onForkChange}
+          onForkVisibilityChange={onForkVisibilityChange}
           sourceSession={sourceSession}
           modelChoices={modelChoices}
         />

--- a/apps/desktop/src/renderer/chat-workbar.tsx
+++ b/apps/desktop/src/renderer/chat-workbar.tsx
@@ -6,6 +6,7 @@ import type { SessionWorkbarTab } from './session-workbar-layout';
 import { SESSION_WORKBAR_MAX_WIDTH, SESSION_WORKBAR_MIN_WIDTH } from './session-workbar-layout';
 import { getShellCopy } from './locales/shell-copy';
 import type {
+  CompanionQuoteTarget,
   CompanionQuoteSnapshot,
   QuoteCompanionPanelState,
 } from './quote-companion-panel-state';
@@ -46,6 +47,7 @@ interface ChatWorkbarProps {
   quote?: QuoteCompanionPanelState | null;
   onClearQuote?: () => void;
   onQuotesConsumed?: (snapshot: CompanionQuoteSnapshot) => void;
+  onRemoveQuote?: (target: CompanionQuoteTarget) => void;
   onForkVisibilityChange?: (event: CompanionForkVisibilityEvent) => void;
   sourceSession?: SessionSummary;
   modelChoices?: readonly ChatModelChoice[];
@@ -64,6 +66,7 @@ export function ChatWorkbar({
   quote,
   onClearQuote,
   onQuotesConsumed,
+  onRemoveQuote,
   onForkVisibilityChange,
   sourceSession,
   modelChoices,
@@ -96,6 +99,7 @@ export function ChatWorkbar({
           quote={quote}
           onClearQuote={onClearQuote}
           onQuotesConsumed={onQuotesConsumed}
+          onRemoveQuote={onRemoveQuote}
           onForkVisibilityChange={onForkVisibilityChange}
           sourceSession={sourceSession}
           modelChoices={modelChoices}

--- a/apps/desktop/src/renderer/quote-companion-core.ts
+++ b/apps/desktop/src/renderer/quote-companion-core.ts
@@ -36,7 +36,7 @@ export interface CompanionSessionApi {
   branchFromTurn(sessionId: string, input: { sourceTurnId: string; name?: string }): Promise<SessionSummary>;
   create(input: Partial<CreateSessionInput>): Promise<SessionSummary>;
   setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary>;
-  remove(sessionId: string): Promise<void>;
+  cleanupQuoteCompanion(sessionId: string): Promise<void>;
   send(
     sessionId: string,
     command: { type: 'send'; turnId: string; text: string; quotes?: QuoteRef[] },
@@ -94,6 +94,16 @@ export function deriveCompanionComposerState(
 }
 
 /**
+ * The main-process cleanup authority durably records the fork before attempting
+ * the complete session-removal path. A rejection here means the intent remains
+ * queued for the next `sessions.list` call or Desktop restart, so renderer
+ * lifecycle paths can remain fire-and-forget without losing recovery.
+ */
+function scheduleCompanionCleanup(api: CompanionSessionApi, sessionId: string): void {
+  void api.cleanupQuoteCompanion(sessionId).catch(() => {});
+}
+
+/**
  * Fork the main session for a companion and return a session that is CONFIRMED
  * read-only (`explore`): reads + local search stay available and web/custom
  * tools follow the normal permission path, but writes / shell / destructive
@@ -139,7 +149,7 @@ export async function ensureCompanionFork(
   }
 
   if (isDisposed()) {
-    void api.remove(created.id).catch(() => {});
+    scheduleCompanionCleanup(api, created.id);
     return { status: 'disposed' };
   }
   // `sessions:branchFromTurn` broadcasts `sessions:changed(created)` before the
@@ -153,15 +163,15 @@ export async function ensureCompanionFork(
   try {
     ready = await api.setPermissionMode(created.id, COMPANION_PERMISSION_MODE);
   } catch {
-    void api.remove(created.id).catch(() => {});
+    scheduleCompanionCleanup(api, created.id);
     return { status: 'error', code: 'permission_pin_failed' };
   }
   if (ready.permissionMode !== COMPANION_PERMISSION_MODE) {
-    void api.remove(created.id).catch(() => {});
+    scheduleCompanionCleanup(api, created.id);
     return { status: 'error', code: 'permission_pin_failed' };
   }
   if (isDisposed()) {
-    void api.remove(created.id).catch(() => {});
+    scheduleCompanionCleanup(api, created.id);
     return { status: 'disposed' };
   }
 

--- a/apps/desktop/src/renderer/quote-companion-core.ts
+++ b/apps/desktop/src/renderer/quote-companion-core.ts
@@ -4,6 +4,7 @@ import {
   dequeueInteractionByToolUseId,
   enqueueInteraction,
   type InteractionQueues,
+  type LiveTurnProjection,
 } from '@maka/ui';
 import type {
   CreateSessionInput,
@@ -73,6 +74,23 @@ export interface EnsureCompanionForkDeps {
  *  A `running` turn is skipped so a fork never branches mid-turn. */
 export function latestSettledTurnId(turns: readonly TurnRecord[]): string | undefined {
   return [...turns].reverse().find((turn) => turn.status !== 'running')?.turnId;
+}
+
+/**
+ * The shared Composer's `streaming` input means "a turn is interruptible", not
+ * merely "a text delta has arrived". Keep the companion interruptible from the
+ * optimistic waiting projection through live output; `processing` only chooses
+ * the quieter pre-first-token presentation inside that same in-flight window.
+ */
+export function deriveCompanionComposerState(
+  turnInFlight: boolean,
+  liveTurn: LiveTurnProjection | undefined,
+): { streaming: boolean; processing: boolean } {
+  const streaming = turnInFlight && liveTurn?.terminal !== true;
+  return {
+    streaming,
+    processing: streaming && (!liveTurn || liveTurn.phase === 'waiting'),
+  };
 }
 
 /**

--- a/apps/desktop/src/renderer/quote-companion-core.ts
+++ b/apps/desktop/src/renderer/quote-companion-core.ts
@@ -68,6 +68,8 @@ export interface EnsureCompanionForkDeps {
   /** Fired as soon as creation returns, before the permission pin round-trip.
    *  The host uses the id to hide this ephemeral child immediately. */
   onForkCreated?: (session: SessionSummary) => void;
+  /** Fired only after the main-process cleanup authority confirms deletion. */
+  onForkCleanupSucceeded?: (sessionId: string) => void;
 }
 
 /** The latest durable (settled) turn of the source session — the fork boundary.
@@ -99,8 +101,11 @@ export function deriveCompanionComposerState(
  * queued for the next `sessions.list` call or Desktop restart, so renderer
  * lifecycle paths can remain fire-and-forget without losing recovery.
  */
-function scheduleCompanionCleanup(api: CompanionSessionApi, sessionId: string): void {
-  void api.cleanupQuoteCompanion(sessionId).catch(() => {});
+function scheduleCompanionCleanup(deps: EnsureCompanionForkDeps, sessionId: string): void {
+  void deps.api
+    .cleanupQuoteCompanion(sessionId)
+    .then(() => deps.onForkCleanupSucceeded?.(sessionId))
+    .catch(() => {});
 }
 
 /**
@@ -149,7 +154,7 @@ export async function ensureCompanionFork(
   }
 
   if (isDisposed()) {
-    scheduleCompanionCleanup(api, created.id);
+    scheduleCompanionCleanup(deps, created.id);
     return { status: 'disposed' };
   }
   // `sessions:branchFromTurn` broadcasts `sessions:changed(created)` before the
@@ -163,15 +168,15 @@ export async function ensureCompanionFork(
   try {
     ready = await api.setPermissionMode(created.id, COMPANION_PERMISSION_MODE);
   } catch {
-    scheduleCompanionCleanup(api, created.id);
+    scheduleCompanionCleanup(deps, created.id);
     return { status: 'error', code: 'permission_pin_failed' };
   }
   if (ready.permissionMode !== COMPANION_PERMISSION_MODE) {
-    scheduleCompanionCleanup(api, created.id);
+    scheduleCompanionCleanup(deps, created.id);
     return { status: 'error', code: 'permission_pin_failed' };
   }
   if (isDisposed()) {
-    scheduleCompanionCleanup(api, created.id);
+    scheduleCompanionCleanup(deps, created.id);
     return { status: 'disposed' };
   }
 

--- a/apps/desktop/src/renderer/quote-companion-panel-state.ts
+++ b/apps/desktop/src/renderer/quote-companion-panel-state.ts
@@ -1,0 +1,66 @@
+import type { QuoteRef } from '@maka/core';
+
+export interface StagedCompanionQuote {
+  id: string;
+  value: QuoteRef;
+}
+
+export interface QuoteCompanionPanelState {
+  id: string;
+  sourceSessionId: string;
+  quotes: StagedCompanionQuote[];
+}
+
+/**
+ * Immutable ownership token for one accepted send. `panelId` prevents a late
+ * callback from an unmounted panel mutating its replacement; `quoteIds` let the
+ * current panel remove exactly what that send attached while preserving quotes
+ * staged later.
+ */
+export interface CompanionQuoteSnapshot {
+  panelId: string;
+  quoteIds: readonly string[];
+  quotes: readonly QuoteRef[];
+}
+
+export function stageCompanionQuote(
+  current: QuoteCompanionPanelState | null,
+  input: {
+    sourceSessionId: string;
+    quote: QuoteRef;
+    newId: () => string;
+  },
+): QuoteCompanionPanelState {
+  const staged = { id: input.newId(), value: input.quote };
+  if (current?.sourceSessionId === input.sourceSessionId) {
+    return { ...current, quotes: [...current.quotes, staged] };
+  }
+  return {
+    id: input.newId(),
+    sourceSessionId: input.sourceSessionId,
+    quotes: [staged],
+  };
+}
+
+export function snapshotCompanionQuotes(
+  panelId: string,
+  quotes: readonly StagedCompanionQuote[],
+): CompanionQuoteSnapshot {
+  return {
+    panelId,
+    quoteIds: quotes.map((quote) => quote.id),
+    quotes: quotes.map((quote) => quote.value),
+  };
+}
+
+export function consumeCompanionQuoteSnapshot(
+  current: QuoteCompanionPanelState | null,
+  snapshot: CompanionQuoteSnapshot,
+): QuoteCompanionPanelState | null {
+  if (!current || current.id !== snapshot.panelId || snapshot.quoteIds.length === 0) {
+    return current;
+  }
+  const consumed = new Set(snapshot.quoteIds);
+  const quotes = current.quotes.filter((quote) => !consumed.has(quote.id));
+  return quotes.length === current.quotes.length ? current : { ...current, quotes };
+}

--- a/apps/desktop/src/renderer/quote-companion-panel-state.ts
+++ b/apps/desktop/src/renderer/quote-companion-panel-state.ts
@@ -23,6 +23,11 @@ export interface CompanionQuoteSnapshot {
   quotes: readonly QuoteRef[];
 }
 
+export interface CompanionQuoteTarget {
+  panelId: string;
+  quoteId: string;
+}
+
 export function stageCompanionQuote(
   current: QuoteCompanionPanelState | null,
   input: {
@@ -62,5 +67,14 @@ export function consumeCompanionQuoteSnapshot(
   }
   const consumed = new Set(snapshot.quoteIds);
   const quotes = current.quotes.filter((quote) => !consumed.has(quote.id));
+  return quotes.length === current.quotes.length ? current : { ...current, quotes };
+}
+
+export function removeStagedCompanionQuote(
+  current: QuoteCompanionPanelState | null,
+  target: CompanionQuoteTarget,
+): QuoteCompanionPanelState | null {
+  if (!current || current.id !== target.panelId) return current;
+  const quotes = current.quotes.filter((quote) => quote.id !== target.quoteId);
   return quotes.length === current.quotes.length ? current : { ...current, quotes };
 }

--- a/apps/desktop/src/renderer/quote-companion-panel.tsx
+++ b/apps/desktop/src/renderer/quote-companion-panel.tsx
@@ -15,6 +15,7 @@ import type {
   CompanionQuoteSnapshot,
   StagedCompanionQuote,
 } from './quote-companion-panel-state';
+import type { CompanionForkVisibilityEvent } from './quote-companion-visibility';
 
 /**
  * The "追问引用" workbar tab: a follow-up thread about the selected excerpt(s).
@@ -35,7 +36,7 @@ export function QuoteCompanionPanel(props: {
   modelChoices: readonly ChatModelChoice[];
   onClear?: () => void;
   onQuotesConsumed: (snapshot: CompanionQuoteSnapshot) => void;
-  onForkChange?: (forkId: string | undefined) => void;
+  onForkVisibilityChange?: (event: CompanionForkVisibilityEvent) => void;
 }) {
   const locale = useUiLocale();
   const copy = getDesktopConversationCopy(locale).quoteCompanion;
@@ -46,7 +47,7 @@ export function QuoteCompanionPanel(props: {
     sourceSession: props.sourceSession,
     locale,
     onQuotesConsumed: props.onQuotesConsumed,
-    onForkChange: props.onForkChange,
+    onForkVisibilityChange: props.onForkVisibilityChange,
   });
 
   // The companion inherits the source model and does not switch it; look up a

--- a/apps/desktop/src/renderer/quote-companion-panel.tsx
+++ b/apps/desktop/src/renderer/quote-companion-panel.tsx
@@ -12,6 +12,7 @@ import type { SessionSummary } from '@maka/core';
 import { useQuoteCompanion } from './use-quote-companion';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
 import type {
+  CompanionQuoteTarget,
   CompanionQuoteSnapshot,
   StagedCompanionQuote,
 } from './quote-companion-panel-state';
@@ -36,6 +37,7 @@ export function QuoteCompanionPanel(props: {
   modelChoices: readonly ChatModelChoice[];
   onClear?: () => void;
   onQuotesConsumed: (snapshot: CompanionQuoteSnapshot) => void;
+  onRemoveQuote?: (target: CompanionQuoteTarget) => void;
   onForkVisibilityChange?: (event: CompanionForkVisibilityEvent) => void;
 }) {
   const locale = useUiLocale();
@@ -111,6 +113,15 @@ export function QuoteCompanionPanel(props: {
         draftKey={companion.companionSession?.id ?? `quote-companion:${props.sourceSession?.id ?? 'none'}`}
         disabled={!props.sourceSession}
         pendingQuotes={props.quotes.map((quote) => quote.value)}
+        onRemoveQuote={(index) => {
+          const quote = props.quotes[index];
+          if (quote) {
+            props.onRemoveQuote?.({
+              panelId: props.panelId,
+              quoteId: quote.id,
+            });
+          }
+        }}
         // No activeSession / onModelChange → the model shows as a read-only chip
         // (the companion has no independent picker; it inherits the source model).
         modelLabel={activeModelLabel}

--- a/apps/desktop/src/renderer/quote-companion-panel.tsx
+++ b/apps/desktop/src/renderer/quote-companion-panel.tsx
@@ -8,9 +8,13 @@ import {
   type ChatModelChoice,
   type ComposerHandle,
 } from '@maka/ui';
-import type { QuoteRef, SessionSummary } from '@maka/core';
+import type { SessionSummary } from '@maka/core';
 import { useQuoteCompanion } from './use-quote-companion';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
+import type {
+  CompanionQuoteSnapshot,
+  StagedCompanionQuote,
+} from './quote-companion-panel-state';
 
 /**
  * The "追问引用" workbar tab: a follow-up thread about the selected excerpt(s).
@@ -23,19 +27,21 @@ import { getDesktopConversationCopy } from './locales/conversation-copy.js';
  * in the main transcript adds another quote chip to THIS thread.
  */
 export function QuoteCompanionPanel(props: {
+  panelId: string;
   /** Excerpts staged for the next send (accumulated as the user adds more). */
-  quotes: readonly QuoteRef[];
+  quotes: readonly StagedCompanionQuote[];
   sourceSession: SessionSummary | undefined;
   /** Shared global choice list, only used to render the inherited model's label. */
   modelChoices: readonly ChatModelChoice[];
   onClear?: () => void;
-  onQuotesConsumed: () => void;
+  onQuotesConsumed: (snapshot: CompanionQuoteSnapshot) => void;
   onForkChange?: (forkId: string | undefined) => void;
 }) {
   const locale = useUiLocale();
   const copy = getDesktopConversationCopy(locale).quoteCompanion;
   const composerRef = useRef<ComposerHandle>(null);
   const companion = useQuoteCompanion({
+    panelId: props.panelId,
     pendingQuotes: props.quotes,
     sourceSession: props.sourceSession,
     locale,
@@ -66,9 +72,9 @@ export function QuoteCompanionPanel(props: {
         activeSession={companion.companionSession}
         emptyOverride={
           <div className="maka-quote-companion-intro">
-            {props.quotes.map((quote, index) => (
-              <blockquote key={`${index}:${quote.text}`} className="maka-quote-panel-quote">
-                {quote.text}
+            {props.quotes.map((quote) => (
+              <blockquote key={quote.id} className="maka-quote-panel-quote">
+                {quote.value.text}
               </blockquote>
             ))}
             <p className="maka-quote-panel-hint">{copy.hint}</p>
@@ -103,7 +109,7 @@ export function QuoteCompanionPanel(props: {
         processing={companion.processing}
         draftKey={companion.companionSession?.id ?? `quote-companion:${props.sourceSession?.id ?? 'none'}`}
         disabled={!props.sourceSession}
-        pendingQuotes={props.quotes}
+        pendingQuotes={props.quotes.map((quote) => quote.value)}
         // No activeSession / onModelChange → the model shows as a read-only chip
         // (the companion has no independent picker; it inherits the source model).
         modelLabel={activeModelLabel}

--- a/apps/desktop/src/renderer/quote-companion-visibility.ts
+++ b/apps/desktop/src/renderer/quote-companion-visibility.ts
@@ -1,0 +1,31 @@
+export type CompanionForkVisibilityEvent =
+  | { type: 'fork-created'; sessionId: string }
+  | { type: 'cleanup-succeeded'; sessionId: string };
+
+/**
+ * The renderer owns transient companion visibility, while the main process owns
+ * deletion. Keep every created fork hidden until that authority confirms cleanup
+ * or a later authoritative session list no longer contains it.
+ */
+export function applyCompanionForkVisibilityEvent(
+  current: ReadonlySet<string>,
+  event: CompanionForkVisibilityEvent,
+): ReadonlySet<string> {
+  if (event.type === 'fork-created') {
+    if (current.has(event.sessionId)) return current;
+    return new Set([...current, event.sessionId]);
+  }
+  if (!current.has(event.sessionId)) return current;
+  const next = new Set(current);
+  next.delete(event.sessionId);
+  return next;
+}
+
+export function reconcileCompanionForkVisibility(
+  current: ReadonlySet<string>,
+  authoritativeSessionIds: ReadonlySet<string>,
+): ReadonlySet<string> {
+  if (current.size === 0) return current;
+  const next = new Set([...current].filter((id) => authoritativeSessionIds.has(id)));
+  return next.size === current.size ? current : next;
+}

--- a/apps/desktop/src/renderer/session-workbar.tsx
+++ b/apps/desktop/src/renderer/session-workbar.tsx
@@ -20,6 +20,7 @@ import type {
   CompanionQuoteSnapshot,
   QuoteCompanionPanelState,
 } from './quote-companion-panel-state';
+import type { CompanionForkVisibilityEvent } from './quote-companion-visibility';
 
 export function SessionWorkbar(props: {
   sessionId: string;
@@ -34,7 +35,7 @@ export function SessionWorkbar(props: {
   quote?: QuoteCompanionPanelState | null;
   onClearQuote?: () => void;
   onQuotesConsumed?: (snapshot: CompanionQuoteSnapshot) => void;
-  onForkChange?: (forkId: string | undefined) => void;
+  onForkVisibilityChange?: (event: CompanionForkVisibilityEvent) => void;
   /** The main session the companion forks from (inherits context + model). */
   sourceSession?: SessionSummary;
   /** Shared global choice list, used to label the companion's inherited model. */
@@ -108,7 +109,7 @@ export function SessionWorkbar(props: {
               modelChoices={props.modelChoices ?? []}
               onClear={props.onClearQuote}
               onQuotesConsumed={props.onQuotesConsumed ?? (() => {})}
-              onForkChange={props.onForkChange}
+              onForkVisibilityChange={props.onForkVisibilityChange}
             />
           </PrimitiveTabsPanel>
         )}

--- a/apps/desktop/src/renderer/session-workbar.tsx
+++ b/apps/desktop/src/renderer/session-workbar.tsx
@@ -17,6 +17,7 @@ import type { SessionWorkbarTab } from './session-workbar-layout';
 import { useSessionTasks } from './use-session-tasks';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
 import type {
+  CompanionQuoteTarget,
   CompanionQuoteSnapshot,
   QuoteCompanionPanelState,
 } from './quote-companion-panel-state';
@@ -35,6 +36,7 @@ export function SessionWorkbar(props: {
   quote?: QuoteCompanionPanelState | null;
   onClearQuote?: () => void;
   onQuotesConsumed?: (snapshot: CompanionQuoteSnapshot) => void;
+  onRemoveQuote?: (target: CompanionQuoteTarget) => void;
   onForkVisibilityChange?: (event: CompanionForkVisibilityEvent) => void;
   /** The main session the companion forks from (inherits context + model). */
   sourceSession?: SessionSummary;
@@ -109,6 +111,7 @@ export function SessionWorkbar(props: {
               modelChoices={props.modelChoices ?? []}
               onClear={props.onClearQuote}
               onQuotesConsumed={props.onQuotesConsumed ?? (() => {})}
+              onRemoveQuote={props.onRemoveQuote}
               onForkVisibilityChange={props.onForkVisibilityChange}
             />
           </PrimitiveTabsPanel>

--- a/apps/desktop/src/renderer/session-workbar.tsx
+++ b/apps/desktop/src/renderer/session-workbar.tsx
@@ -9,13 +9,17 @@ import {
   useUiLocale,
   type ChatModelChoice,
 } from '@maka/ui';
-import type { QuoteRef, SessionSummary } from '@maka/core';
+import type { SessionSummary } from '@maka/core';
 import { ArtifactPane } from './artifact-pane';
 import { BrowserPanel } from './browser-panel';
 import { QuoteCompanionPanel } from './quote-companion-panel';
 import type { SessionWorkbarTab } from './session-workbar-layout';
 import { useSessionTasks } from './use-session-tasks';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
+import type {
+  CompanionQuoteSnapshot,
+  QuoteCompanionPanelState,
+} from './quote-companion-panel-state';
 
 export function SessionWorkbar(props: {
   sessionId: string;
@@ -27,9 +31,9 @@ export function SessionWorkbar(props: {
   onActiveTabChange: (tab: SessionWorkbarTab) => void;
   /** Active quote side panel: staged excerpts for the source session, or null
    *  when no panel is open. Renders a transient "追问引用" tab. */
-  quote?: { sourceSessionId: string; quotes: QuoteRef[] } | null;
+  quote?: QuoteCompanionPanelState | null;
   onClearQuote?: () => void;
-  onQuotesConsumed?: () => void;
+  onQuotesConsumed?: (snapshot: CompanionQuoteSnapshot) => void;
   onForkChange?: (forkId: string | undefined) => void;
   /** The main session the companion forks from (inherits context + model). */
   sourceSession?: SessionSummary;
@@ -97,6 +101,8 @@ export function SessionWorkbar(props: {
             keepMounted
           >
             <QuoteCompanionPanel
+              key={props.quote.id}
+              panelId={props.quote.id}
               quotes={props.quote.quotes}
               sourceSession={props.sourceSession}
               modelChoices={props.modelChoices ?? []}

--- a/apps/desktop/src/renderer/use-app-shell-session-list.ts
+++ b/apps/desktop/src/renderer/use-app-shell-session-list.ts
@@ -21,6 +21,8 @@ export function useAppShellSessionList(toastApi: ToastApi) {
   const uiLocaleRef = useRef(uiLocale);
   uiLocaleRef.current = uiLocale;
   const [sessions, setSessionsState] = useState<SessionSummary[]>([]);
+  const [authoritativeSessionIds, setAuthoritativeSessionIds] =
+    useState<ReadonlySet<string> | null>(null);
   const sessionsRef = useRef<SessionSummary[]>([]);
   const sessionReadBoundariesRef = useRef<SessionReadBoundaries>({});
   const refresherRef = useRef<SessionListRefresher | null>(null);
@@ -43,7 +45,11 @@ export function useAppShellSessionList(toastApi: ToastApi) {
       listSessions: () => window.maka.sessions.list(),
       readBoundaries: () => sessionReadBoundariesRef.current,
       currentSessions: () => sessionsRef.current,
-      commitSessions: (next) => commitSessions(next.map(normalizeSessionSummaryForDisplay)),
+      commitSessions: (next) => {
+        const normalized = next.map(normalizeSessionSummaryForDisplay);
+        commitSessions(normalized);
+        setAuthoritativeSessionIds(new Set(normalized.map(({ id }) => id)));
+      },
       onError: (error) => {
         const locale = uiLocaleRef.current;
         const copy = getDesktopConversationCopy(locale).actions;
@@ -106,6 +112,7 @@ export function useAppShellSessionList(toastApi: ToastApi) {
 
   return {
     sessions,
+    authoritativeSessionIds,
     sessionsRef,
     setSessions,
     refreshSessions,

--- a/apps/desktop/src/renderer/use-quote-companion.ts
+++ b/apps/desktop/src/renderer/use-quote-companion.ts
@@ -172,7 +172,9 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
       unsubscribeRef.current?.();
       const id = companionIdRef.current ?? pendingForkIdRef.current;
       if (id) {
-        window.maka.sessions.remove(id).catch(() => {});
+        // The main-process authority records this intent before attempting the
+        // full removal, and retries it on a later session list / app restart.
+        window.maka.sessions.cleanupQuoteCompanion(id).catch(() => {});
         onForkChangeRef.current?.(undefined);
       }
     };

--- a/apps/desktop/src/renderer/use-quote-companion.ts
+++ b/apps/desktop/src/renderer/use-quote-companion.ts
@@ -28,18 +28,25 @@ import {
 } from './quote-companion-core';
 import { readSettledMessages } from './session-message-settlement';
 import { getDesktopConversationCopy } from './locales/conversation-copy.js';
+import {
+  snapshotCompanionQuotes,
+  type CompanionQuoteSnapshot,
+  type StagedCompanionQuote,
+} from './quote-companion-panel-state';
 
 export interface UseQuoteCompanionInput {
+  /** Stable owner for the currently mounted panel generation. */
+  panelId: string;
   /** Excerpts staged for the next send; accumulates as the user adds more from
    *  the main transcript. Attached to the next turn, then cleared by the host. */
-  pendingQuotes: readonly QuoteRef[];
+  pendingQuotes: readonly StagedCompanionQuote[];
   /** The main session the panel is attached to. The companion FORKS from it (via
    *  branchFromTurn) so it inherits the full conversation context + model / cwd —
    *  Codex `/side` style. */
   sourceSession: SessionSummary | undefined;
   locale: UiLocale;
   /** Called once a send has consumed the staged quotes, so the host clears them. */
-  onQuotesConsumed: () => void;
+  onQuotesConsumed: (snapshot: CompanionQuoteSnapshot) => void;
   /** Reports the companion fork's id (or undefined) so the host can hide it from
    *  the main session list while the panel is open — the fork is ephemeral. */
   onForkChange?: (forkId: string | undefined) => void;
@@ -91,7 +98,7 @@ function requiredAssistantMessageId(projection: LiveTurnProjection | undefined):
  * which removes the ephemeral fork.
  */
 export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompanionResult {
-  const { locale, sourceSession, pendingQuotes, onQuotesConsumed, onForkChange } = input;
+  const { panelId, locale, sourceSession, pendingQuotes, onQuotesConsumed, onForkChange } = input;
   const copy = getDesktopConversationCopy(locale).quoteCompanion;
   const [companion, setCompanion] = useState<SessionSummary | undefined>(undefined);
   const companionIdRef = useRef<string | null>(null);
@@ -177,7 +184,8 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
       if (!trimmed || turnInFlight || !sourceSession) return false;
       setError(null);
       const turnId = crypto.randomUUID();
-      const label = (pendingQuotes[0]?.text ?? trimmed).slice(0, 24);
+      const quoteSnapshot = snapshotCompanionQuotes(panelId, pendingQuotes);
+      const label = (quoteSnapshot.quotes[0]?.text ?? trimmed).slice(0, 24);
       const result = await performCompanionTurn({
         api: window.maka.sessions,
         sourceSession,
@@ -186,7 +194,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
         existingForkId: companionIdRef.current,
         turnId,
         text: trimmed,
-        quotes: pendingQuotes.length > 0 ? [...pendingQuotes] : undefined,
+        quotes: quoteSnapshot.quotes.length > 0 ? [...quoteSnapshot.quotes] : undefined,
         onForkCreated: (session) => {
           pendingForkIdRef.current = session.id;
           onForkChangeRef.current?.(session.id);
@@ -206,7 +214,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
           ownTurnIdsRef.current.add(turnId);
           setOwnTurnTick((tick) => tick + 1);
         },
-        onQuotesConsumed,
+        onQuotesConsumed: () => onQuotesConsumed(quoteSnapshot),
       });
       if (result.status === 'sent') {
         // Surface the just-sent user message immediately, and reflect any
@@ -244,7 +252,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
       // 'disposed' → the panel unmounted mid-create; nothing to update.
       return false;
     },
-    [turnInFlight, sourceSession, pendingQuotes, onQuotesConsumed, subscribeToFork, mountedRef],
+    [turnInFlight, sourceSession, panelId, pendingQuotes, onQuotesConsumed, subscribeToFork, mountedRef],
   );
 
   const stop = useCallback(async (): Promise<void> => {

--- a/apps/desktop/src/renderer/use-quote-companion.ts
+++ b/apps/desktop/src/renderer/use-quote-companion.ts
@@ -33,6 +33,7 @@ import {
   type CompanionQuoteSnapshot,
   type StagedCompanionQuote,
 } from './quote-companion-panel-state';
+import type { CompanionForkVisibilityEvent } from './quote-companion-visibility';
 
 export interface UseQuoteCompanionInput {
   /** Stable owner for the currently mounted panel generation. */
@@ -47,9 +48,9 @@ export interface UseQuoteCompanionInput {
   locale: UiLocale;
   /** Called once a send has consumed the staged quotes, so the host clears them. */
   onQuotesConsumed: (snapshot: CompanionQuoteSnapshot) => void;
-  /** Reports the companion fork's id (or undefined) so the host can hide it from
-   *  the main session list while the panel is open — the fork is ephemeral. */
-  onForkChange?: (forkId: string | undefined) => void;
+  /** Reports creation and authoritative cleanup so the host can keep every
+   *  ephemeral fork hidden for its complete lifetime. */
+  onForkVisibilityChange?: (event: CompanionForkVisibilityEvent) => void;
 }
 
 export interface UseQuoteCompanionResult {
@@ -98,15 +99,22 @@ function requiredAssistantMessageId(projection: LiveTurnProjection | undefined):
  * which removes the ephemeral fork.
  */
 export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompanionResult {
-  const { panelId, locale, sourceSession, pendingQuotes, onQuotesConsumed, onForkChange } = input;
+  const {
+    panelId,
+    locale,
+    sourceSession,
+    pendingQuotes,
+    onQuotesConsumed,
+    onForkVisibilityChange,
+  } = input;
   const copy = getDesktopConversationCopy(locale).quoteCompanion;
   const [companion, setCompanion] = useState<SessionSummary | undefined>(undefined);
   const companionIdRef = useRef<string | null>(null);
   // A created fork is hidden immediately, before its permission pin completes,
   // but is not considered usable until onForkCommitted promotes it.
   const pendingForkIdRef = useRef<string | null>(null);
-  const onForkChangeRef = useRef(onForkChange);
-  onForkChangeRef.current = onForkChange;
+  const onForkVisibilityChangeRef = useRef(onForkVisibilityChange);
+  onForkVisibilityChangeRef.current = onForkVisibilityChange;
   const localeRef = useRef(locale);
   localeRef.current = locale;
   const copyRef = useRef(copy);
@@ -174,8 +182,15 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
       if (id) {
         // The main-process authority records this intent before attempting the
         // full removal, and retries it on a later session list / app restart.
-        window.maka.sessions.cleanupQuoteCompanion(id).catch(() => {});
-        onForkChangeRef.current?.(undefined);
+        void window.maka.sessions
+          .cleanupQuoteCompanion(id)
+          .then(() =>
+            onForkVisibilityChangeRef.current?.({
+              type: 'cleanup-succeeded',
+              sessionId: id,
+            }),
+          )
+          .catch(() => {});
       }
     };
   }, []);
@@ -199,8 +214,16 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
         quotes: quoteSnapshot.quotes.length > 0 ? [...quoteSnapshot.quotes] : undefined,
         onForkCreated: (session) => {
           pendingForkIdRef.current = session.id;
-          onForkChangeRef.current?.(session.id);
+          onForkVisibilityChangeRef.current?.({
+            type: 'fork-created',
+            sessionId: session.id,
+          });
         },
+        onForkCleanupSucceeded: (sessionId) =>
+          onForkVisibilityChangeRef.current?.({
+            type: 'cleanup-succeeded',
+            sessionId,
+          }),
         onForkCommitted: (session) => {
           pendingForkIdRef.current = null;
           companionIdRef.current = session.id;
@@ -245,7 +268,6 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
         };
         if (result.code === 'permission_pin_failed') {
           pendingForkIdRef.current = null;
-          onForkChangeRef.current?.(undefined);
         }
         setError(byCode[result.code]);
         setTurnInFlight(false);

--- a/apps/desktop/src/renderer/use-quote-companion.ts
+++ b/apps/desktop/src/renderer/use-quote-companion.ts
@@ -21,6 +21,7 @@ import type {
 } from '@maka/core';
 import {
   applyCompanionInteractionEvent,
+  deriveCompanionComposerState,
   isCompanionTurnTerminal,
   performCompanionTurn,
   type CompanionErrorCode,
@@ -287,8 +288,7 @@ export function useQuoteCompanion(input: UseQuoteCompanionInput): UseQuoteCompan
   const messages = allMessages.filter(
     (message) => message.turnId !== undefined && ownTurnIdsRef.current.has(message.turnId),
   );
-  const streaming = Boolean(liveTurn && !liveTurn.terminal && liveTurn.phase === 'streamed');
-  const processing = turnInFlight && (!liveTurn || liveTurn.phase === 'waiting');
+  const { streaming, processing } = deriveCompanionComposerState(turnInFlight, liveTurn);
   // Inherited model (read-only): the fork's once created, else the source's.
   const activeModel = companion
     ? { llmConnectionSlug: companion.llmConnectionSlug, model: companion.model }


### PR DESCRIPTION
## Summary

- keep the quote companion Composer interruptible from accepted send through the pre-first-token wait, while preserving the separate processing presentation
- snapshot staged quotes with stable panel and quote identities, so an accepted send consumes only the quotes it attached and late callbacks cannot clear a replacement panel
- route ephemeral fork teardown through a workspace-scoped cleanup authority that records intent before removal, retries failed cleanup on session listing or Desktop restart, and keeps still-pending forks out of the sidebar
- add focused wait-state, quote ownership, cleanup recovery, and quote → fork → answer → exit E2E coverage

Closes #1598

## Verification

- `npm run build:test`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run test:dist` (2955 passed)
- `env -u WAYLAND_DISPLAY XDG_SESSION_TYPE=x11 ELECTRON_OZONE_PLATFORM_HINT=x11 npx playwright test --config e2e/playwright.config.ts e2e/quote-companion.spec.ts` (1 passed)
- `npx biome check <17 changed files>`
- `git diff --check`

## Root cause

The companion used the arrival of a live delta as its interruptibility signal, even though the turn was already accepted and stoppable while waiting for the model. Quote acceptance also called back into whichever panel state happened to be current instead of carrying immutable ownership from the send. Finally, every teardown path called `sessions.remove` best-effort and swallowed a rejection, so a failed compensating removal had no durable retry path.

## Review focus

The cleanup queue is Desktop-private and does not change the public runtime session contract. It is a small per-workspace JSON WAL: cleanup intent is written atomically before the existing complete session-removal path runs and cleared only after that path succeeds. `sessions.list` replays the queue before returning and filters any entry whose retry still fails.
