### PR TITLE
fix(cli): exit Graph runs after root provider failure

### DIFF
--- a/packages/cli/src/__tests__/run-command-fixture.ts
+++ b/packages/cli/src/__tests__/run-command-fixture.ts
@@ -9,6 +9,7 @@ const scenario = process.env.MAKA_RUN_FIXTURE_SCENARIO ?? 'completed';
 let observer: CreateMakaCliRuntimeContextInput['runtimeInvocationObserver'];
 let permissionDenied = false;
 let releaseStop: (() => void) | undefined;
+let releaseGraphWait: (() => void) | undefined;
 let graphActivityReleased = false;
 
 const target = {
@@ -60,6 +61,20 @@ const runtime: MakaRunRuntime = {
       throw new Error(`unexpected sessionId ${sessionId}`);
     }
     if (scenario === 'runtime-error') throw new Error('provider failed after startup');
+    if (scenario === 'graph-runtime-error') {
+      if (input.turnOrchestration?.mode !== 'graph') {
+        throw new Error('expected graph orchestration');
+      }
+      await notify(failedResult('provider_unavailable', 'provider failed before graph creation'));
+      return;
+    }
+    if (scenario === 'graph-wait') {
+      if (input.turnOrchestration?.mode !== 'graph') {
+        throw new Error('expected graph orchestration');
+      }
+      await notify(completedResult('initial graph supervisor output'));
+      return;
+    }
     if (process.env.MAKA_RUN_EXPECT_GRAPH === '1') {
       if (
         input.turnOrchestration?.mode !== 'graph' ||
@@ -164,7 +179,11 @@ async function createContext(input: CreateMakaCliRuntimeContextInput): Promise<M
     }
   }
   observer = input.runtimeInvocationObserver;
-  if (process.env.MAKA_RUN_EXPECT_GRAPH === '1') {
+  if (
+    process.env.MAKA_RUN_EXPECT_GRAPH === '1' ||
+    scenario === 'graph-runtime-error' ||
+    scenario === 'graph-wait'
+  ) {
     if (!input.enableAgentGraph) throw new Error('Graph host was not enabled');
     return {
       runtime,
@@ -177,10 +196,25 @@ async function createContext(input: CreateMakaCliRuntimeContextInput): Promise<M
         }),
         waitForCompletion: async () => {
           if (!graphActivityReleased) throw new Error('Graph activity was not released');
+          if (scenario === 'graph-runtime-error') {
+            process.stderr.write('graph-wait-called\n');
+            throw new Error('unexpected graph wait after failed invocation');
+          }
+          if (scenario === 'graph-wait') {
+            process.stderr.write('fixture-ready\n');
+            const keepAlive = setInterval(() => {}, 1_000);
+            await new Promise<void>((resolve) => {
+              releaseGraphWait = resolve;
+            });
+            clearInterval(keepAlive);
+            return;
+          }
           await notify(completedResult('graph completed'));
         },
       },
-      close: async () => {},
+      close: async () => {
+        releaseGraphWait?.();
+      },
     };
   }
   return { runtime, target, close: async () => {} };

--- a/packages/cli/src/__tests__/run-command.test.ts
+++ b/packages/cli/src/__tests__/run-command.test.ts
@@ -148,6 +148,18 @@ describe('maka run process contract', () => {
     assert.equal(result.stderr, '');
   });
 
+  test('does not wait for Graph completion after the root invocation fails', async () => {
+    const result = await runFixture(['implement it', '--graph'], {
+      scenario: 'graph-runtime-error',
+      input: '',
+    });
+
+    assert.equal(result.code, 1);
+    assert.equal(result.stdout, '');
+    assert.match(result.stderr, /provider failed before graph creation/);
+    assert.doesNotMatch(result.stderr, /graph-wait-called/);
+  });
+
   test('uses stdin as the complete prompt for run -', async () => {
     const result = await runFixture(['-'], { input: 'from stdin\nsecond line' });
     assert.equal(result.code, 0, result.stderr);
@@ -368,6 +380,44 @@ describe('maka run process contract', () => {
 
     assert.equal(signal, null);
     assert.equal(code, 130, stderr);
+    assert.equal(stdout, '');
+  });
+
+  test('returns exit 130 when SIGINT interrupts Graph completion wait', async () => {
+    const child = spawn(process.execPath, [fixturePath, 'implement it', '--graph'], {
+      env: { ...process.env, MAKA_RUN_FIXTURE_SCENARIO: 'graph-wait' },
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    child.stdin.end();
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => {
+      stdout += chunk.toString('utf8');
+    });
+    const ready = new Promise<void>((resolve) => {
+      child.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf8');
+        if (stderr.includes('fixture-ready')) resolve();
+      });
+    });
+    await ready;
+    child.kill('SIGINT');
+
+    let killTimer: ReturnType<typeof setTimeout> | undefined;
+    const exited = once(child, 'exit') as Promise<[number | null, NodeJS.Signals | null]>;
+    const result = await Promise.race([
+      exited.then(([code, signal]) => ({ code, signal })),
+      new Promise<{ code: null; signal: 'SIGKILL' }>((resolve) => {
+        killTimer = setTimeout(() => {
+          child.kill('SIGKILL');
+          resolve({ code: null, signal: 'SIGKILL' });
+        }, 500);
+      }),
+    ]);
+    if (killTimer !== undefined) clearTimeout(killTimer);
+
+    assert.equal(result.signal, null);
+    assert.equal(result.code, 130, stderr);
     assert.equal(stdout, '');
   });
 });

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -316,7 +316,13 @@ export async function runMakaTextCli(
   let timedOut = false;
   let streamFailed = false;
   let stopPromise: Promise<void> | undefined;
+  let resolveStopSignal: (() => void) | undefined;
+  const stopSignal = new Promise<void>((resolve) => {
+    resolveStopSignal = resolve;
+  });
   const stop = (): void => {
+    resolveStopSignal?.();
+    resolveStopSignal = undefined;
     if (stopPromise) return;
     stopPromise = context.runtime.stopSession(session.id, { source: 'stop_button' });
     void stopPromise.catch(() => {});
@@ -356,7 +362,9 @@ export async function runMakaTextCli(
       }
     }
     graphActivity?.release();
-    if (parsed.options.graph) await context.agentGraph!.waitForCompletion(session.id);
+    if (parsed.options.graph && invocation?.status === 'completed') {
+      await Promise.race([context.agentGraph!.waitForCompletion(session.id), stopSignal]);
+    }
     await stopPromise;
   } catch (error) {
     streamFailed = true;

--- a/packages/runtime/src/__tests__/run-trace.test.ts
+++ b/packages/runtime/src/__tests__/run-trace.test.ts
@@ -102,4 +102,33 @@ describe('RunTrace error diagnostics', () => {
     assert.equal(data.redactedErrorMessageTruncated, true);
     assert.match(String(data.redactedErrorMessageSha256), /^sha256:[a-f0-9]{64}$/);
   });
+
+  test('model stream failure diagnostics preserve redacted structured error fields', () => {
+    const events: RunTraceEvent[] = [];
+    const trace = new RunTrace({
+      sessionId: 'session-1',
+      turnId: 'turn-1',
+      connectionSlug: 'sub2api',
+      providerId: 'openai',
+      modelId: 'gpt-test',
+      newId: () => `trace-${events.length + 1}`,
+      now: () => 123,
+      record: (event) => events.push(event),
+    });
+
+    trace.modelStreamFailed('Other', {
+      status: 502,
+      code: 'upstream_reset',
+      message: 'upstream stream reset',
+      apiKey: 'sk-live-secret-token-value',
+    });
+
+    const data = events[0]?.data ?? {};
+    assert.equal(data.rawErrorName, 'object');
+    assert.equal(data.rawErrorType, 'object');
+    assert.match(String(data.redactedErrorMessage), /upstream stream reset/);
+    assert.match(String(data.redactedErrorMessage), /upstream_reset/);
+    assert.match(String(data.redactedErrorMessage), /"apiKey":"\[redacted\]"/);
+    assert.equal(String(data.redactedErrorMessage).includes('sk-live-secret-token-value'), false);
+  });
 });

--- a/packages/runtime/src/run-trace.ts
+++ b/packages/runtime/src/run-trace.ts
@@ -284,6 +284,12 @@ function rawErrorMessage(error: unknown): string {
   if (error instanceof Error) return error.message;
   if (typeof error === 'string') return error;
   try {
+    const serialized = JSON.stringify(error);
+    if (typeof serialized === 'string') return serialized;
+  } catch {
+    // Fall back to string coercion for cyclic or otherwise unserializable values.
+  }
+  try {
     return String(error);
   } catch {
     return '[unprintable error]';


### PR DESCRIPTION
Closes #1604

## What changed

- skip Graph completion waiting when the root invocation is already failed or missing, so a pre-schedule provider failure exits immediately with the durable invocation failure
- race Graph completion against the existing SIGINT/timeout stop path, allowing context teardown instead of trapping the CLI in the wait
- serialize structured non-Error provider failures before secret redaction so diagnostics retain safe status/code/message evidence instead of [object Object]
- cover failed-root, SIGINT-during-Graph-wait, and structured-error redaction regressions

## Validation

- targeted CLI and RunTrace tests: 31 passed
- CLI test suite: 658 passed
- full workspace typecheck: passed
- Biome check on all changed files: passed
- Runtime test suite: 2807 passed, 9 skipped, 1 unrelated environment-sensitive failure in builtin-tools.test.js (the /usr/local sandbox executable-root assertion); that test and implementation are unchanged by this PR