### PR TITLE
fix(desktop): drop the deleted PermissionEngine from a main test

### DIFF
--- a/apps/desktop/src/main/__tests__/session-stream-usage-readiness.test.ts
+++ b/apps/desktop/src/main/__tests__/session-stream-usage-readiness.test.ts
@@ -7,7 +7,6 @@ import type { SessionHeader } from '@maka/core';
 import {
   buildPricingLookup,
   createSandboxDiagnosticsProvider,
-  PermissionEngine,
   type BackendFactoryContext,
 } from '@maka/runtime';
 import {
@@ -66,7 +65,6 @@ test('the first Desktop backend waits for raw telemetry readiness', async () => 
         buildTurnTailPrompt: () => undefined,
       },
       mcpManager: {},
-      permissionEngine: new PermissionEngine({ newId: () => 'permission-1', now: () => 1 }),
       taskLedgerStore: {},
       telemetryRepo,
       ensureUsageReady,


### PR DESCRIPTION
## Summary

`main` is red, and has been since #1581. That PR replaced tool permissions with session sandbox boundaries and removed `PermissionEngine` from `@maka/runtime`, but `apps/desktop/src/main/__tests__/session-stream-usage-readiness.test.ts` still imports it and still passes a `permissionEngine` dependency that the session-stream deps type no longer declares.

`tsc -p tsconfig.main.json` fails with `TS2305: Module '"@maka/runtime"' has no exported member 'PermissionEngine'`, which takes `build:main` down — and with it the `typecheck`, `test`, and `e2e` jobs on every branch, since all three build first. `PermissionEngine` no longer exists anywhere in the repo, and nothing in production code accepts a `permissionEngine`, so the import and the dependency are simply removed. The test's subject is usage readiness; it needs no replacement.

Refs #1581

## Verification

- `npm run build` (all workspaces, from this branch) — clean; it fails on `origin/main` at `build:main`
- `node --test dist/main/__tests__/session-stream-usage-readiness.test.js` — 1 pass, 0 fail
- Latest `main` run for comparison: https://github.com/maka-agent/maka-agent/actions — the tip commit (#1602) is `failure` with this same TS2305