### PR TITLE
fix(runtime): reload completed sessions after sandbox boundary decisions

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -24,6 +24,7 @@ import type { AgentBackend } from '@maka/core/backend-types';
 import { RuntimeRunner } from '../runtime-runner.js';
 import type { InvocationContext } from '../invocation-context.js';
 import { projectRuntimeEventsToStoredMessages } from '../runtime-event-read-model.js';
+import { isNonTerminalErrorRuntimeEvent } from '../agent-run.js';
 import { backfillRuntimeEventsFromStoredMessages } from '../runtime-event-backfill.js';
 
 // ============================================================================
@@ -1039,28 +1040,59 @@ describe('mapSessionEventToRuntimeEvent (pure)', () => {
 // ============================================================================
 
 /**
- * Every backend-mappable SessionEvent variant, with the minimum companion
- * events its own projection needs. The `Record` key type is what makes this
- * exhaustive: a new BackendSessionEvent variant without a sample here fails to
- * compile.
+ * One sample per backend-mappable SessionEvent variant. `subject` is typed to
+ * its own key, so a new variant cannot be satisfied by an empty list or by
+ * some other event that happens to project cleanly; `before` and `after` carry
+ * only the companions that variant's projection needs.
  */
-const PROJECTION_SAMPLES: Record<BackendSessionEvent['type'], SessionEvent[]> = {
-  text_delta: [
-    { type: 'text_delta', id: 'e', turnId: 'turn-1', ts: 1, messageId: 'm1', text: 'h' },
-  ],
-  text_complete: [
-    { type: 'text_complete', id: 'e', turnId: 'turn-1', ts: 1, messageId: 'm1', text: 'hi' },
-  ],
-  thinking_delta: [
-    { type: 'thinking_delta', id: 'e', turnId: 'turn-1', ts: 1, messageId: 'm1', text: 'h' },
-  ],
-  // Thinking is held until the assistant text row that shares its message id.
-  thinking_complete: [
-    { type: 'thinking_complete', id: 'e1', turnId: 'turn-1', ts: 1, messageId: 'm1', text: 'why' },
-    { type: 'text_complete', id: 'e2', turnId: 'turn-1', ts: 2, messageId: 'm1', text: 'hi' },
-  ],
-  tool_start: [
-    {
+type ProjectionSamples = {
+  [K in BackendSessionEvent['type']]: {
+    subject: Extract<BackendSessionEvent, { type: K }>;
+    before?: SessionEvent[];
+    after?: SessionEvent[];
+  };
+};
+
+const PROJECTION_SAMPLES: ProjectionSamples = {
+  text_delta: {
+    subject: { type: 'text_delta', id: 'e', turnId: 'turn-1', ts: 1, messageId: 'm1', text: 'h' },
+  },
+  text_complete: {
+    subject: {
+      type: 'text_complete',
+      id: 'e',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'm1',
+      text: 'hi',
+    },
+  },
+  thinking_delta: {
+    subject: {
+      type: 'thinking_delta',
+      id: 'e',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'm1',
+      text: 'h',
+    },
+  },
+  thinking_complete: {
+    subject: {
+      type: 'thinking_complete',
+      id: 'e1',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'm1',
+      text: 'why',
+    },
+    // Thinking is held until the assistant text row that shares its message id.
+    after: [
+      { type: 'text_complete', id: 'e2', turnId: 'turn-1', ts: 2, messageId: 'm1', text: 'hi' },
+    ],
+  },
+  tool_start: {
+    subject: {
       type: 'tool_start',
       id: 'e',
       turnId: 'turn-1',
@@ -1069,9 +1101,9 @@ const PROJECTION_SAMPLES: Record<BackendSessionEvent['type'], SessionEvent[]> = 
       toolName: 'Read',
       args: { path: '/tmp/a' },
     },
-  ],
-  tool_output_delta: [
-    {
+  },
+  tool_output_delta: {
+    subject: {
       type: 'tool_output_delta',
       id: 'e',
       turnId: 'turn-1',
@@ -1085,22 +1117,19 @@ const PROJECTION_SAMPLES: Record<BackendSessionEvent['type'], SessionEvent[]> = 
       redacted: false,
       createdAt: 1,
     },
-  ],
-  tool_progress: [
-    { type: 'tool_progress', id: 'e', turnId: 'turn-1', ts: 1, toolUseId: 'tool-1', chunk: 'x' },
-  ],
-  // A result carries no tool name of its own; the mapper reads it from the call.
-  tool_result: [
-    {
-      type: 'tool_start',
-      id: 'e1',
+  },
+  tool_progress: {
+    subject: {
+      type: 'tool_progress',
+      id: 'e',
       turnId: 'turn-1',
       ts: 1,
       toolUseId: 'tool-1',
-      toolName: 'Read',
-      args: { path: '/tmp/a' },
+      chunk: 'x',
     },
-    {
+  },
+  tool_result: {
+    subject: {
       type: 'tool_result',
       id: 'e2',
       turnId: 'turn-1',
@@ -1109,9 +1138,21 @@ const PROJECTION_SAMPLES: Record<BackendSessionEvent['type'], SessionEvent[]> = 
       isError: false,
       content: { kind: 'text', text: 'ok' },
     },
-  ],
-  sandbox_boundary_request: [
-    {
+    // A result carries no tool name of its own; the mapper reads it from the call.
+    before: [
+      {
+        type: 'tool_start',
+        id: 'e1',
+        turnId: 'turn-1',
+        ts: 1,
+        toolUseId: 'tool-1',
+        toolName: 'Read',
+        args: { path: '/tmp/a' },
+      },
+    ],
+  },
+  sandbox_boundary_request: {
+    subject: {
       type: 'sandbox_boundary_request',
       id: 'e',
       turnId: 'turn-1',
@@ -1123,9 +1164,9 @@ const PROJECTION_SAMPLES: Record<BackendSessionEvent['type'], SessionEvent[]> = 
         filesystem: { entries: [{ path: '/tmp/outside.txt', access: 'read', scope: 'exact' }] },
       },
     },
-  ],
-  sandbox_boundary_decision_ack: [
-    {
+  },
+  sandbox_boundary_decision_ack: {
+    subject: {
       type: 'sandbox_boundary_decision_ack',
       id: 'e',
       turnId: 'turn-1',
@@ -1136,9 +1177,9 @@ const PROJECTION_SAMPLES: Record<BackendSessionEvent['type'], SessionEvent[]> = 
       status: 'approved',
       revision: 2,
     },
-  ],
-  user_question_request: [
-    {
+  },
+  user_question_request: {
+    subject: {
       type: 'user_question_request',
       id: 'e',
       turnId: 'turn-1',
@@ -1147,9 +1188,9 @@ const PROJECTION_SAMPLES: Record<BackendSessionEvent['type'], SessionEvent[]> = 
       toolUseId: 'tool-1',
       questions: [{ question: 'Which one?', options: [{ label: 'A', description: 'a' }] }],
     },
-  ],
-  user_question_answer_ack: [
-    {
+  },
+  user_question_answer_ack: {
+    subject: {
       type: 'user_question_answer_ack',
       id: 'e',
       turnId: 'turn-1',
@@ -1157,15 +1198,30 @@ const PROJECTION_SAMPLES: Record<BackendSessionEvent['type'], SessionEvent[]> = 
       requestId: 'q-1',
       toolUseId: 'tool-1',
     },
-  ],
-  plan_submitted: [
-    { type: 'plan_submitted', id: 'e', turnId: 'turn-1', ts: 1, planId: 'plan-1', title: 'Plan' },
-  ],
-  token_usage: [
-    { type: 'token_usage', id: 'e', turnId: 'turn-1', ts: 1, input: 10, output: 5, total: 15 },
-  ],
-  steering_message: [
-    {
+  },
+  plan_submitted: {
+    subject: {
+      type: 'plan_submitted',
+      id: 'e',
+      turnId: 'turn-1',
+      ts: 1,
+      planId: 'plan-1',
+      title: 'Plan',
+    },
+  },
+  token_usage: {
+    subject: {
+      type: 'token_usage',
+      id: 'e',
+      turnId: 'turn-1',
+      ts: 1,
+      input: 10,
+      output: 5,
+      total: 15,
+    },
+  },
+  steering_message: {
+    subject: {
       type: 'steering_message',
       id: 'e',
       turnId: 'turn-1',
@@ -1173,9 +1229,9 @@ const PROJECTION_SAMPLES: Record<BackendSessionEvent['type'], SessionEvent[]> = 
       messageId: 'm2',
       content: { text: 'steer' },
     },
-  ],
-  provider_retry: [
-    {
+  },
+  provider_retry: {
+    subject: {
       type: 'provider_retry',
       id: 'e',
       turnId: 'turn-1',
@@ -1185,14 +1241,23 @@ const PROJECTION_SAMPLES: Record<BackendSessionEvent['type'], SessionEvent[]> = 
       maxAttempts: 3,
       reason: 'rate_limit',
     },
-  ],
-  // An error maps to non-terminal error content, which AgentRun deliberately
-  // keeps out of the ledger (see isNonTerminalErrorRuntimeEvent); the trailing
-  // complete(error) is the shape a reader actually finds. The projection's hard
-  // diagnostic for non-terminal error content stays a defensive assertion.
-  error: [{ type: 'complete', id: 'e', turnId: 'turn-1', ts: 1, stopReason: 'error' }],
-  complete: [{ type: 'complete', id: 'e', turnId: 'turn-1', ts: 1, stopReason: 'end_turn' }],
-  abort: [{ type: 'abort', id: 'e', turnId: 'turn-1', ts: 1, reason: 'user_stop' }],
+  },
+  error: {
+    subject: {
+      type: 'error',
+      id: 'e1',
+      turnId: 'turn-1',
+      ts: 1,
+      recoverable: false,
+      message: 'boom',
+    },
+    // An error is always followed by a terminal complete carrying the failure.
+    after: [{ type: 'complete', id: 'e2', turnId: 'turn-1', ts: 2, stopReason: 'error' }],
+  },
+  complete: {
+    subject: { type: 'complete', id: 'e', turnId: 'turn-1', ts: 1, stopReason: 'end_turn' },
+  },
+  abort: { subject: { type: 'abort', id: 'e', turnId: 'turn-1', ts: 1, reason: 'user_stop' } },
 };
 
 const projectionRunHeader: AgentRunHeader = {
@@ -1213,24 +1278,28 @@ const projectionRunHeader: AgentRunHeader = {
 describe('SessionEvent projection coverage', () => {
   // RuntimeReadModel rejects a whole completed-session projection when it sees
   // an `unsupported_event`, so a variant the projection does not claim makes
-  // every session that contains it permanently unreadable.
-  for (const [type, events] of Object.entries(PROJECTION_SAMPLES)) {
+  // every session that contains it permanently unreadable. The contract is
+  // therefore over what a reader can actually meet: every mapped event AgentRun
+  // admits to the ledger has to project.
+  for (const [type, sample] of Object.entries(PROJECTION_SAMPLES)) {
     test(`${type} projects without an unsupported_event diagnostic`, () => {
       let seq = 0;
       const memory = createSessionEventMapMemory();
-      const runtimeEvents = events.map((event) =>
-        mapSessionEventToRuntimeEvent(
-          event,
-          {
-            ...ctx,
-            newId: () => {
-              seq += 1;
-              return `rt-${seq}`;
+      const runtimeEvents = [...(sample.before ?? []), sample.subject, ...(sample.after ?? [])]
+        .map((event) =>
+          mapSessionEventToRuntimeEvent(
+            event,
+            {
+              ...ctx,
+              newId: () => {
+                seq += 1;
+                return `rt-${seq}`;
+              },
             },
-          },
-          memory,
-        ),
-      );
+            memory,
+          ),
+        )
+        .filter((event) => !isNonTerminalErrorRuntimeEvent(event));
 
       const projected = projectRuntimeEventsToStoredMessages(runtimeEvents, {
         runHeaders: [projectionRunHeader],

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -2,9 +2,10 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 
 import { decodeStoredMessageForRecovery, type BackendKind } from '@maka/core/session';
+import type { AgentRunHeader } from '@maka/core';
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
 import type { SessionEvent } from '@maka/core/events';
-import type { BackendSendInput } from '@maka/core/backend-types';
+import type { BackendSendInput, BackendSessionEvent } from '@maka/core/backend-types';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import {
   decodeRuntimeEvent,
@@ -1031,4 +1032,214 @@ describe('mapSessionEventToRuntimeEvent (pure)', () => {
     });
     assert.equal(a.branch, 'agent-b');
   });
+});
+
+// ============================================================================
+// Projection coverage contract
+// ============================================================================
+
+/**
+ * Every backend-mappable SessionEvent variant, with the minimum companion
+ * events its own projection needs. The `Record` key type is what makes this
+ * exhaustive: a new BackendSessionEvent variant without a sample here fails to
+ * compile.
+ */
+const PROJECTION_SAMPLES: Record<BackendSessionEvent['type'], SessionEvent[]> = {
+  text_delta: [
+    { type: 'text_delta', id: 'e', turnId: 'turn-1', ts: 1, messageId: 'm1', text: 'h' },
+  ],
+  text_complete: [
+    { type: 'text_complete', id: 'e', turnId: 'turn-1', ts: 1, messageId: 'm1', text: 'hi' },
+  ],
+  thinking_delta: [
+    { type: 'thinking_delta', id: 'e', turnId: 'turn-1', ts: 1, messageId: 'm1', text: 'h' },
+  ],
+  // Thinking is held until the assistant text row that shares its message id.
+  thinking_complete: [
+    { type: 'thinking_complete', id: 'e1', turnId: 'turn-1', ts: 1, messageId: 'm1', text: 'why' },
+    { type: 'text_complete', id: 'e2', turnId: 'turn-1', ts: 2, messageId: 'm1', text: 'hi' },
+  ],
+  tool_start: [
+    {
+      type: 'tool_start',
+      id: 'e',
+      turnId: 'turn-1',
+      ts: 1,
+      toolUseId: 'tool-1',
+      toolName: 'Read',
+      args: { path: '/tmp/a' },
+    },
+  ],
+  tool_output_delta: [
+    {
+      type: 'tool_output_delta',
+      id: 'e',
+      turnId: 'turn-1',
+      ts: 1,
+      sessionId: 'session-1',
+      toolCallId: 'tool-1',
+      toolUseId: 'tool-1',
+      seq: 1,
+      stream: 'stdout',
+      chunk: 'out',
+      redacted: false,
+      createdAt: 1,
+    },
+  ],
+  tool_progress: [
+    { type: 'tool_progress', id: 'e', turnId: 'turn-1', ts: 1, toolUseId: 'tool-1', chunk: 'x' },
+  ],
+  // A result carries no tool name of its own; the mapper reads it from the call.
+  tool_result: [
+    {
+      type: 'tool_start',
+      id: 'e1',
+      turnId: 'turn-1',
+      ts: 1,
+      toolUseId: 'tool-1',
+      toolName: 'Read',
+      args: { path: '/tmp/a' },
+    },
+    {
+      type: 'tool_result',
+      id: 'e2',
+      turnId: 'turn-1',
+      ts: 2,
+      toolUseId: 'tool-1',
+      isError: false,
+      content: { kind: 'text', text: 'ok' },
+    },
+  ],
+  sandbox_boundary_request: [
+    {
+      type: 'sandbox_boundary_request',
+      id: 'e',
+      turnId: 'turn-1',
+      ts: 1,
+      requestId: 'boundary-1',
+      toolUseId: 'tool-1',
+      justification: 'read a file outside the workspace',
+      expansion: {
+        filesystem: { entries: [{ path: '/tmp/outside.txt', access: 'read', scope: 'exact' }] },
+      },
+    },
+  ],
+  sandbox_boundary_decision_ack: [
+    {
+      type: 'sandbox_boundary_decision_ack',
+      id: 'e',
+      turnId: 'turn-1',
+      ts: 1,
+      requestId: 'boundary-1',
+      toolUseId: 'tool-1',
+      decision: 'allow',
+      status: 'approved',
+      revision: 2,
+    },
+  ],
+  user_question_request: [
+    {
+      type: 'user_question_request',
+      id: 'e',
+      turnId: 'turn-1',
+      ts: 1,
+      requestId: 'q-1',
+      toolUseId: 'tool-1',
+      questions: [{ question: 'Which one?', options: [{ label: 'A', description: 'a' }] }],
+    },
+  ],
+  user_question_answer_ack: [
+    {
+      type: 'user_question_answer_ack',
+      id: 'e',
+      turnId: 'turn-1',
+      ts: 1,
+      requestId: 'q-1',
+      toolUseId: 'tool-1',
+    },
+  ],
+  plan_submitted: [
+    { type: 'plan_submitted', id: 'e', turnId: 'turn-1', ts: 1, planId: 'plan-1', title: 'Plan' },
+  ],
+  token_usage: [
+    { type: 'token_usage', id: 'e', turnId: 'turn-1', ts: 1, input: 10, output: 5, total: 15 },
+  ],
+  steering_message: [
+    {
+      type: 'steering_message',
+      id: 'e',
+      turnId: 'turn-1',
+      ts: 1,
+      messageId: 'm2',
+      content: { text: 'steer' },
+    },
+  ],
+  provider_retry: [
+    {
+      type: 'provider_retry',
+      id: 'e',
+      turnId: 'turn-1',
+      ts: 1,
+      phase: 'started',
+      attempt: 2,
+      maxAttempts: 3,
+      reason: 'rate_limit',
+    },
+  ],
+  // An error maps to non-terminal error content, which AgentRun deliberately
+  // keeps out of the ledger (see isNonTerminalErrorRuntimeEvent); the trailing
+  // complete(error) is the shape a reader actually finds. The projection's hard
+  // diagnostic for non-terminal error content stays a defensive assertion.
+  error: [{ type: 'complete', id: 'e', turnId: 'turn-1', ts: 1, stopReason: 'error' }],
+  complete: [{ type: 'complete', id: 'e', turnId: 'turn-1', ts: 1, stopReason: 'end_turn' }],
+  abort: [{ type: 'abort', id: 'e', turnId: 'turn-1', ts: 1, reason: 'user_stop' }],
+};
+
+const projectionRunHeader: AgentRunHeader = {
+  runId: 'run-1',
+  sessionId: 'session-1',
+  turnId: 'turn-1',
+  status: 'completed',
+  backendKind: 'ai-sdk',
+  llmConnectionSlug: 'anthropic',
+  modelId: 'model-1',
+  cwd: '/tmp',
+  permissionMode: 'ask',
+  createdAt: 1,
+  updatedAt: 2,
+  completedAt: 2,
+};
+
+describe('SessionEvent projection coverage', () => {
+  // RuntimeReadModel rejects a whole completed-session projection when it sees
+  // an `unsupported_event`, so a variant the projection does not claim makes
+  // every session that contains it permanently unreadable.
+  for (const [type, events] of Object.entries(PROJECTION_SAMPLES)) {
+    test(`${type} projects without an unsupported_event diagnostic`, () => {
+      let seq = 0;
+      const memory = createSessionEventMapMemory();
+      const runtimeEvents = events.map((event) =>
+        mapSessionEventToRuntimeEvent(
+          event,
+          {
+            ...ctx,
+            newId: () => {
+              seq += 1;
+              return `rt-${seq}`;
+            },
+          },
+          memory,
+        ),
+      );
+
+      const projected = projectRuntimeEventsToStoredMessages(runtimeEvents, {
+        runHeaders: [projectionRunHeader],
+      });
+
+      assert.deepEqual(
+        projected.diagnostics.filter((diagnostic) => diagnostic.code === 'unsupported_event'),
+        [],
+      );
+    });
+  }
 });

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -983,7 +983,11 @@ describe('projectRuntimeEventsToStoredMessages', () => {
                 requestId: 'boundary-1',
                 toolUseId: 'tool-1',
                 justification: 'read a file outside the workspace',
-                expansion: { readPaths: ['/tmp/outside.txt'] },
+                expansion: {
+                  filesystem: {
+                    entries: [{ path: '/tmp/outside.txt', access: 'read', scope: 'exact' }],
+                  },
+                },
               },
             },
           },
@@ -999,7 +1003,7 @@ describe('projectRuntimeEventsToStoredMessages', () => {
               sandboxBoundaryDecision: {
                 requestId: 'boundary-1',
                 decision: 'allow',
-                status: 'applied',
+                status: 'approved',
                 revision: 2,
               },
             },
@@ -1014,26 +1018,25 @@ describe('projectRuntimeEventsToStoredMessages', () => {
     expect(out.diagnostics).toEqual([]);
   });
 
-  test('an unmapped SessionEvent degrades to a soft diagnostic instead of failing the projection', () => {
-    // AiSdkFlow's exhaustiveness guard turns an unknown SessionEvent into this
-    // shape rather than dropping it. It must stay observable without making a
-    // completed session unreadable.
+  test('a malformed sandbox boundary state delta stays an unsupported event', () => {
+    // Claiming the key alone would let any shape ride in under a control-fact
+    // name. Only a well-formed request or decision is a canonical fact.
     const out = projectRuntimeEventsToStoredMessages(
       [
         ev({
-          id: 'unmapped-session-event',
+          id: 'sandbox-boundary-malformed',
+          ts: ts + 1,
           role: 'system',
           author: 'system',
-          actions: { stateDelta: { unmappedSessionEventType: 'future_event' } },
+          actions: { stateDelta: { sandboxBoundaryRequest: { toolUseId: 'tool-1' } } },
+          refs: { toolCallId: 'tool-1' },
         }),
       ],
       { runHeaders: [header] },
     );
 
     expect(out.messages).toEqual([]);
-    expect(out.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
-      'unmapped_session_event',
-    ]);
+    expect(out.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(['unsupported_event']);
   });
 
   test('model thinking attaches to the assistant text row that shares its step message id', () => {

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -1018,26 +1018,146 @@ describe('projectRuntimeEventsToStoredMessages', () => {
     expect(out.diagnostics).toEqual([]);
   });
 
-  test('a malformed sandbox boundary state delta stays an unsupported event', () => {
-    // Claiming the key alone would let any shape ride in under a control-fact
-    // name. Only a well-formed request or decision is a canonical fact.
-    const out = projectRuntimeEventsToStoredMessages(
-      [
-        ev({
-          id: 'sandbox-boundary-malformed',
-          ts: ts + 1,
-          role: 'system',
-          author: 'system',
-          actions: { stateDelta: { sandboxBoundaryRequest: { toolUseId: 'tool-1' } } },
-          refs: { toolCallId: 'tool-1' },
-        }),
-      ],
-      { runHeaders: [header] },
-    );
+  // Claiming the key alone would let any shape ride in under a control-fact
+  // name. Only what AiSdkFlow actually emits is a canonical fact: every field,
+  // the system/user identity, and the tool-call reference.
+  const wellFormedBoundaryRequest = () =>
+    ev({
+      id: 'sandbox-boundary-request-case',
+      ts: ts + 1,
+      role: 'system',
+      author: 'system',
+      actions: {
+        stateDelta: {
+          sandboxBoundaryRequest: {
+            requestId: 'boundary-1',
+            toolUseId: 'tool-1',
+            justification: 'read a file outside the workspace',
+            expansion: {
+              filesystem: {
+                entries: [{ path: '/tmp/outside.txt', access: 'read', scope: 'exact' }],
+              },
+            },
+          },
+        },
+      },
+      refs: { toolCallId: 'tool-1' },
+    });
 
-    expect(out.messages).toEqual([]);
-    expect(out.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(['unsupported_event']);
-  });
+  const wellFormedBoundaryDecision = () =>
+    ev({
+      id: 'sandbox-boundary-decision-case',
+      ts: ts + 2,
+      role: 'system',
+      author: 'user',
+      actions: {
+        stateDelta: {
+          sandboxBoundaryDecision: {
+            requestId: 'boundary-1',
+            decision: 'allow',
+            status: 'approved',
+            revision: 2,
+          },
+        },
+      },
+      refs: { toolCallId: 'tool-1' },
+    });
+
+  function corruptedBoundaryEvent(
+    base: RuntimeEvent,
+    key: 'sandboxBoundaryRequest' | 'sandboxBoundaryDecision',
+    mutate: (payload: Record<string, unknown>, event: RuntimeEvent) => RuntimeEvent | void,
+  ): RuntimeEvent {
+    const clone = structuredClone(base) as RuntimeEvent;
+    const payload = clone.actions?.stateDelta?.[key] as Record<string, unknown>;
+    return mutate(payload, clone) ?? clone;
+  }
+
+  const malformedBoundaryCases: Array<[string, () => RuntimeEvent]> = [
+    [
+      'request without a justification',
+      () =>
+        corruptedBoundaryEvent(wellFormedBoundaryRequest(), 'sandboxBoundaryRequest', (payload) => {
+          delete payload.justification;
+        }),
+    ],
+    [
+      'request with an unusable expansion',
+      () =>
+        corruptedBoundaryEvent(wellFormedBoundaryRequest(), 'sandboxBoundaryRequest', (payload) => {
+          payload.expansion = {};
+        }),
+    ],
+    [
+      'request that lost its tool-call reference',
+      () =>
+        corruptedBoundaryEvent(
+          wellFormedBoundaryRequest(),
+          'sandboxBoundaryRequest',
+          (_payload, event) => ({ ...event, refs: undefined }),
+        ),
+    ],
+    [
+      'request attributed to someone other than the system',
+      () =>
+        corruptedBoundaryEvent(
+          wellFormedBoundaryRequest(),
+          'sandboxBoundaryRequest',
+          (_payload, event) => ({ ...event, role: 'user', author: 'tool' }),
+        ),
+    ],
+    [
+      'decision without a status',
+      () =>
+        corruptedBoundaryEvent(
+          wellFormedBoundaryDecision(),
+          'sandboxBoundaryDecision',
+          (payload) => {
+            delete payload.status;
+          },
+        ),
+    ],
+    [
+      'decision with a status the boundary never settles to',
+      () =>
+        corruptedBoundaryEvent(
+          wellFormedBoundaryDecision(),
+          'sandboxBoundaryDecision',
+          (payload) => {
+            payload.status = 'pending';
+          },
+        ),
+    ],
+    [
+      'decision without a revision',
+      () =>
+        corruptedBoundaryEvent(
+          wellFormedBoundaryDecision(),
+          'sandboxBoundaryDecision',
+          (payload) => {
+            delete payload.revision;
+          },
+        ),
+    ],
+    [
+      'decision attributed to the agent instead of the user',
+      () =>
+        corruptedBoundaryEvent(
+          wellFormedBoundaryDecision(),
+          'sandboxBoundaryDecision',
+          (_payload, event) => ({ ...event, author: 'agent' }),
+        ),
+    ],
+  ];
+
+  for (const [name, makeEvent] of malformedBoundaryCases) {
+    test(`a sandbox boundary ${name} stays an unsupported event`, () => {
+      const out = projectRuntimeEventsToStoredMessages([makeEvent()], { runHeaders: [header] });
+
+      expect(out.messages).toEqual([]);
+      expect(out.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(['unsupported_event']);
+    });
+  }
 
   test('model thinking attaches to the assistant text row that shares its step message id', () => {
     // Real emission and backfill give a step's thinking and text the same message

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -969,6 +969,73 @@ describe('projectRuntimeEventsToStoredMessages', () => {
     expect(out.diagnostics).toEqual([]);
   });
 
+  test('sandbox boundary request and decision facts are accepted without creating legacy message rows', () => {
+    const out = projectRuntimeEventsToStoredMessages(
+      [
+        ev({
+          id: 'sandbox-boundary-request',
+          ts: ts + 1,
+          role: 'system',
+          author: 'system',
+          actions: {
+            stateDelta: {
+              sandboxBoundaryRequest: {
+                requestId: 'boundary-1',
+                toolUseId: 'tool-1',
+                justification: 'read a file outside the workspace',
+                expansion: { readPaths: ['/tmp/outside.txt'] },
+              },
+            },
+          },
+          refs: { toolCallId: 'tool-1' },
+        }),
+        ev({
+          id: 'sandbox-boundary-decision',
+          ts: ts + 2,
+          role: 'system',
+          author: 'user',
+          actions: {
+            stateDelta: {
+              sandboxBoundaryDecision: {
+                requestId: 'boundary-1',
+                decision: 'allow',
+                status: 'applied',
+                revision: 2,
+              },
+            },
+          },
+          refs: { toolCallId: 'tool-1' },
+        }),
+      ],
+      { runHeaders: [header] },
+    );
+
+    expect(out.messages).toEqual([]);
+    expect(out.diagnostics).toEqual([]);
+  });
+
+  test('an unmapped SessionEvent degrades to a soft diagnostic instead of failing the projection', () => {
+    // AiSdkFlow's exhaustiveness guard turns an unknown SessionEvent into this
+    // shape rather than dropping it. It must stay observable without making a
+    // completed session unreadable.
+    const out = projectRuntimeEventsToStoredMessages(
+      [
+        ev({
+          id: 'unmapped-session-event',
+          role: 'system',
+          author: 'system',
+          actions: { stateDelta: { unmappedSessionEventType: 'future_event' } },
+        }),
+      ],
+      { runHeaders: [header] },
+    );
+
+    expect(out.messages).toEqual([]);
+    expect(out.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'unmapped_session_event',
+    ]);
+  });
+
   test('model thinking attaches to the assistant text row that shares its step message id', () => {
     // Real emission and backfill give a step's thinking and text the same message
     // id (providerEventId / storedMessageId), so the projection pairs by id.

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -13183,6 +13183,40 @@ describe('SessionManager permission mode updates', () => {
     expect((await store.readHeader(session.id)).status).toBe('active');
   });
 
+  test('reads a completed session back after a sandbox boundary decision', async () => {
+    // The boundary request and decision are durable RuntimeEvents. Reopening the
+    // conversation rebuilds the read model from that ledger, so an unclaimed
+    // control fact there makes the whole completed session unreadable.
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new SandboxBoundaryWaitBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(9_500),
+    });
+    const session = await manager.createSession(makeInput());
+
+    const iterator = manager
+      .sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })
+      [Symbol.asyncIterator]();
+    expect((await iterator.next()).value?.type).toBe('sandbox_boundary_request');
+    await manager.respondToSandboxBoundary(session.id, {
+      requestId: 'boundary-1',
+      decision: 'allow',
+    });
+    while (!(await iterator.next()).done) {}
+
+    const messages = await manager.getMessages(session.id);
+    expect(messages.some((message) => message.type === 'user')).toBe(true);
+    const turns = await manager.listTurns(session.id);
+    expect(turns.find((turn) => turn.turnId === 'turn-1')?.status).toBe('completed');
+  });
+
   test('marks backend errors as blocked with a generalized reason', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -13183,39 +13183,39 @@ describe('SessionManager permission mode updates', () => {
     expect((await store.readHeader(session.id)).status).toBe('active');
   });
 
-  test('reads a completed session back after a sandbox boundary decision', async () => {
-    // The boundary request and decision are durable RuntimeEvents. Reopening the
-    // conversation rebuilds the read model from that ledger, so an unclaimed
-    // control fact there makes the whole completed session unreadable.
-    const store = new MemorySessionStore();
-    const runStore = new MemoryAgentRunStore();
-    const backends = new BackendRegistry();
-    backends.register('fake', (ctx) => new SandboxBoundaryWaitBackend(ctx));
-    const manager = new SessionManager({
-      store,
-      runStore,
-      runtimeEventStore: runStore,
-      backends,
-      newId: nextId(),
-      now: nextNow(9_500),
-    });
-    const session = await manager.createSession(makeInput());
+  // The boundary request and decision are durable RuntimeEvents. Reopening the
+  // conversation rebuilds the read model from that ledger, so an unclaimed
+  // control fact there makes the whole completed session unreadable. Both
+  // outcomes write a decision, so both have to survive the round trip.
+  for (const decision of ['allow', 'deny'] as const) {
+    test(`reads a completed session back after a sandbox boundary ${decision}`, async () => {
+      const store = new MemorySessionStore();
+      const runStore = new MemoryAgentRunStore();
+      const backends = new BackendRegistry();
+      backends.register('fake', (ctx) => new SandboxBoundaryWaitBackend(ctx));
+      const manager = new SessionManager({
+        store,
+        runStore,
+        runtimeEventStore: runStore,
+        backends,
+        newId: nextId(),
+        now: nextNow(9_500),
+      });
+      const session = await manager.createSession(makeInput());
 
-    const iterator = manager
-      .sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })
-      [Symbol.asyncIterator]();
-    expect((await iterator.next()).value?.type).toBe('sandbox_boundary_request');
-    await manager.respondToSandboxBoundary(session.id, {
-      requestId: 'boundary-1',
-      decision: 'allow',
-    });
-    while (!(await iterator.next()).done) {}
+      const iterator = manager
+        .sendMessage(session.id, { turnId: 'turn-1', text: 'hello' })
+        [Symbol.asyncIterator]();
+      expect((await iterator.next()).value?.type).toBe('sandbox_boundary_request');
+      await manager.respondToSandboxBoundary(session.id, { requestId: 'boundary-1', decision });
+      while (!(await iterator.next()).done) {}
 
-    const messages = await manager.getMessages(session.id);
-    expect(messages.some((message) => message.type === 'user')).toBe(true);
-    const turns = await manager.listTurns(session.id);
-    expect(turns.find((turn) => turn.turnId === 'turn-1')?.status).toBe('completed');
-  });
+      const messages = await manager.getMessages(session.id);
+      expect(messages.some((message) => message.type === 'user')).toBe(true);
+      const turns = await manager.listTurns(session.id);
+      expect(turns.find((turn) => turn.turnId === 'turn-1')?.status).toBe('completed');
+    });
+  }
 
   test('marks backend errors as blocked with a generalized reason', async () => {
     const store = new MemorySessionStore();

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -1483,7 +1483,12 @@ function isInteractionResumeAck(event: SessionEvent): boolean {
   );
 }
 
-function isNonTerminalErrorRuntimeEvent(event: RuntimeEvent): boolean {
+/**
+ * Non-terminal error content never reaches the ledger: the trailing terminal
+ * event carries the failure. Exported so readers can reason about which mapped
+ * RuntimeEvents a projection will ever be asked to read.
+ */
+export function isNonTerminalErrorRuntimeEvent(event: RuntimeEvent): boolean {
   return event.content?.kind === 'error' && !isTerminalRuntimeEvent(event);
 }
 

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -21,6 +21,7 @@ import { isArchivedToolResultPlaceholder } from './tool-result-archive.js';
 export type RuntimeEventReadModelDiagnosticCode =
   | 'partial_skipped'
   | 'unsupported_event'
+  | 'unmapped_session_event'
   | 'incomplete_event'
   | 'archived_tool_result_placeholder'
   | 'generated_id'
@@ -215,6 +216,30 @@ export function projectRuntimeEventsToStoredMessages(
     if (event.actions?.stateDelta?.continuationStart === true) {
       // Continuation start is a canonical lineage/recovery fact with no
       // legacy chat row. Its following model events own the visible output.
+      projected = true;
+    }
+
+    if (
+      event.actions?.stateDelta?.sandboxBoundaryRequest !== undefined ||
+      event.actions?.stateDelta?.sandboxBoundaryDecision !== undefined
+    ) {
+      // The session sandbox boundary owns enforcement and its own durable
+      // revisions. These are canonical control/audit facts, and the tool call
+      // and response around them own every provider-visible row.
+      projected = true;
+    }
+
+    if (typeof event.actions?.stateDelta?.unmappedSessionEventType === 'string') {
+      // AiSdkFlow's exhaustiveness guard preserves an unknown SessionEvent as
+      // this shape instead of dropping it. Surfacing it stays useful, but a
+      // single unknown event must never make a completed session unreadable.
+      diagnostic(
+        state,
+        event,
+        'unmapped_session_event',
+        'SessionEvent type has no RuntimeEvent mapping',
+        { type: event.actions.stateDelta.unmappedSessionEventType },
+      );
       projected = true;
     }
 

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -21,7 +21,6 @@ import { isArchivedToolResultPlaceholder } from './tool-result-archive.js';
 export type RuntimeEventReadModelDiagnosticCode =
   | 'partial_skipped'
   | 'unsupported_event'
-  | 'unmapped_session_event'
   | 'incomplete_event'
   | 'archived_tool_result_placeholder'
   | 'generated_id'
@@ -219,27 +218,10 @@ export function projectRuntimeEventsToStoredMessages(
       projected = true;
     }
 
-    if (
-      event.actions?.stateDelta?.sandboxBoundaryRequest !== undefined ||
-      event.actions?.stateDelta?.sandboxBoundaryDecision !== undefined
-    ) {
+    if (isSandboxBoundaryStateDelta(event)) {
       // The session sandbox boundary owns enforcement and its own durable
       // revisions. These are canonical control/audit facts, and the tool call
       // and response around them own every provider-visible row.
-      projected = true;
-    }
-
-    if (typeof event.actions?.stateDelta?.unmappedSessionEventType === 'string') {
-      // AiSdkFlow's exhaustiveness guard preserves an unknown SessionEvent as
-      // this shape instead of dropping it. Surfacing it stays useful, but a
-      // single unknown event must never make a completed session unreadable.
-      diagnostic(
-        state,
-        event,
-        'unmapped_session_event',
-        'SessionEvent type has no RuntimeEvent mapping',
-        { type: event.actions.stateDelta.unmappedSessionEventType },
-      );
       projected = true;
     }
 
@@ -1200,6 +1182,33 @@ function isPlanProposalStateDelta(event: RuntimeEvent): boolean {
     typeof stateDelta?.planId === 'string' &&
     typeof stateDelta.title === 'string'
   );
+}
+
+function isSandboxBoundaryStateDelta(event: RuntimeEvent): boolean {
+  const stateDelta = event.actions?.stateDelta;
+  if (!stateDelta) return false;
+  const request = stateDelta.sandboxBoundaryRequest;
+  const decision = stateDelta.sandboxBoundaryDecision;
+  if (request !== undefined) {
+    return (
+      isRecord(request) &&
+      typeof request.requestId === 'string' &&
+      typeof request.toolUseId === 'string' &&
+      isRecord(request.expansion)
+    );
+  }
+  if (decision !== undefined) {
+    return (
+      isRecord(decision) &&
+      typeof decision.requestId === 'string' &&
+      (decision.decision === 'allow' || decision.decision === 'deny')
+    );
+  }
+  return false;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
 
 function diagnostic(

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -9,12 +9,24 @@ import type {
   TurnStatus,
 } from '@maka/core';
 import {
+  SANDBOX_BOUNDARY_REQUEST_STATUSES,
   TOOL_ACTIVITY_KINDS,
   isPartialRuntimeEvent,
   isTerminalRuntimeEvent,
   isTerminalRuntimeEventStatus,
   normalizeToolResultContentForRead,
+  validateSandboxBoundaryExpansion,
 } from '@maka/core';
+
+/** The statuses a settled boundary decision can carry — every status but `pending`. */
+type SettledSandboxBoundaryStatus = Exclude<
+  (typeof SANDBOX_BOUNDARY_REQUEST_STATUSES)[number],
+  'pending'
+>;
+const SETTLED_SANDBOX_BOUNDARY_STATUSES: readonly SettledSandboxBoundaryStatus[] =
+  SANDBOX_BOUNDARY_REQUEST_STATUSES.filter(
+    (status): status is SettledSandboxBoundaryStatus => status !== 'pending',
+  );
 import type { CanonicalPermissionOutcomeRecord } from './interaction-authority.js';
 import { isArchivedToolResultPlaceholder } from './tool-result-archive.js';
 
@@ -1184,27 +1196,38 @@ function isPlanProposalStateDelta(event: RuntimeEvent): boolean {
   );
 }
 
+/**
+ * A boundary fact is canonical only in the exact shape AiSdkFlow emits: every
+ * field of the source SessionEvent, the identity it maps to, and the tool call
+ * it settles. A partial match is worse than none — it would claim a corrupt
+ * ledger as sound while still paying the cost of rejecting a malformed one.
+ */
 function isSandboxBoundaryStateDelta(event: RuntimeEvent): boolean {
   const stateDelta = event.actions?.stateDelta;
   if (!stateDelta) return false;
   const request = stateDelta.sandboxBoundaryRequest;
   const decision = stateDelta.sandboxBoundaryDecision;
+  if (request === undefined && decision === undefined) return false;
+  if (event.role !== 'system' || typeof event.refs?.toolCallId !== 'string') return false;
   if (request !== undefined) {
     return (
+      event.author === 'system' &&
       isRecord(request) &&
       typeof request.requestId === 'string' &&
       typeof request.toolUseId === 'string' &&
-      isRecord(request.expansion)
+      typeof request.justification === 'string' &&
+      validateSandboxBoundaryExpansion(request.expansion).ok
     );
   }
-  if (decision !== undefined) {
-    return (
-      isRecord(decision) &&
-      typeof decision.requestId === 'string' &&
-      (decision.decision === 'allow' || decision.decision === 'deny')
-    );
-  }
-  return false;
+  return (
+    event.author === 'user' &&
+    isRecord(decision) &&
+    typeof decision.requestId === 'string' &&
+    (decision.decision === 'allow' || decision.decision === 'deny') &&
+    SETTLED_SANDBOX_BOUNDARY_STATUSES.includes(decision.status as SettledSandboxBoundaryStatus) &&
+    typeof decision.revision === 'number' &&
+    Number.isFinite(decision.revision)
+  );
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {


### PR DESCRIPTION
## Summary

A completed session that contains a sandbox boundary request and decision could not be reopened. `AiSdkFlow` maps both to control-only `stateDelta` RuntimeEvents (`ai-sdk-flow.ts:303-337`) — no content, no recognised action — and `projectRuntimeEventsToStoredMessages` claimed neither shape, so each produced a hard `unsupported_event` diagnostic and `RuntimeReadModel` rejected the entire projection.

The blast radius is wider than the transcript. `getSessionView` is the sole authority behind `getMessages`, `listTurns`, `branchFromTurn`, `branchBeforeTurn`, `reviseBeforeTurn`, `requireTurnForAction` and `requireUserMessageForTurn`, so an affected session could not be read, branched, revised, or acted on at all.

The projection now claims a well-formed boundary request or decision and produces no message row for it. The claim matches exactly what `AiSdkFlow` emits — every field, the system/user identity, and the tool-call reference, with the expansion checked by `validateSandboxBoundaryExpansion` rather than a local guess. Anything short of that stays an `unsupported_event`: a partial claim would be the worst of both, paying the cost of rejecting a malformed ledger while still admitting one. Sandbox enforcement, settlement, persistence and the boundary schema are untouched.

Beyond the fix itself, `stateDelta` is `Record<string, unknown>` while the projection is a closed whitelist, so nothing forced the two to stay in sync — the actual reason #1581 could introduce this. A projection-coverage contract keyed on `BackendSessionEvent['type']` now fails to compile when a variant has no sample, and fails at runtime when the projection does not claim one.

Fixes #1607

## Verification

- `packages/runtime` full suite: 2767 passed, 0 failed, 9 skipped.
- Each new test was confirmed to fail for the right reason before its fix, and the read-model change was reverted once to confirm all three layers (projection unit, coverage contract, durable `getMessages` round trip) turn red together.
- The coverage table was mutation-tested: a missing entry, an entry without a `subject`, an empty `subject`, and a `subject` borrowed from another variant each fail compilation (TS2741 / TS2322). An earlier revision only caught the first of those.
- `npm run format`, `npm run lint`, `npm run build`, `npm run typecheck` across all workspaces: clean.

## Root cause

Open-ended write side (`stateDelta: Record<string, unknown>`), closed whitelist read side, and a hard failure when they disagree. #1581 replaced the whole permission vocabulary across 30+ commits without touching the projection, and nothing caught it.

The failure was also invisible until after the turn ended: an active run is served from the in-flight projection cache (`runtime-read-model.ts:98-139`) and never re-projects the durable ledger, so approving the boundary, running the tool and rendering the turn all behaved correctly. Only reopening the session hit the ledger path.

## Review focus

Two deliberate scope decisions.

**No Desktop E2E.** The issue suggested one. The `sandbox-boundary` fixture injects `E2eFixtureState` directly and never reaches `RuntimeEventStore` or `RuntimeReadModel`, and the fake backend cannot emit boundary events, so an E2E along that path would re-test the existing UI takeover assertions (`sandbox-boundary-takeover.spec.ts`) rather than the regression. The durable `SessionManager.getMessages` round trip covers it directly, for allow and deny. Making the E2E meaningful would mean building boundary-emission into the fake backend — worth doing on its own terms, not as a smokescreen here.

**Non-terminal `error` content left as is.** The coverage contract surfaced it as a third candidate, but `AgentRun` deliberately keeps non-terminal error RuntimeEvents out of the ledger (`agent-run.ts:487`), verified against a real `SessionManager` round trip whose ledger holds only the user text and one terminal failed event. The projection's hard diagnostic there is the matching defensive assertion, so the contract sample reflects the shape a reader actually finds.

Three related gaps found during the analysis are **not** addressed here and are tracked separately:

1. (#1613) `AiSdkFlow`'s exhaustiveness guard (`ai-sdk-flow.ts:507-521`) emits a control-only `stateDelta` for any unknown `SessionEvent`, which the projection rejects as hard — so that "safe" fallback escalates one ignorable event into an unreadable session. Whether it should degrade is a policy decision about projection failure handling, not part of this fix. The compile-time coverage contract already catches a new variant well before it can reach a ledger.
2. (#1613) A projection hard-failure has no fallback. `backfillMissingRuntimeEvents` only fires on an empty ledger, so an intact 10-message session is discarded wholesale over one unclaimed event. Relaxing this trades against its purpose — preventing silently dropped messages — and deserves a separate decision. Same underlying question as (1).
3. (#1612) A pending boundary request cannot survive a restart. `RuntimeKernel.sandboxBoundaryRequestOwners` is an in-memory map bound to a backend generation (`runtime-kernel.ts:1911`), and `activePermissionOverlayEvent` covers only the permission actions, so the response authority is gone once the host restarts. Recovery then settles every persisted pending request as `deny` with `closureReason: 'host_restarted'` (`session-manager.ts:915-918`) and the turn is marked failed. That is correctly fail-closed, but from the user's side the prompt vanishes and the task is interrupted with no way to resume it.

