### PR TITLE
fix(graph): preserve child worktree lease across branch switches

### DIFF
--- a/packages/core/src/subagent-workspace.ts
+++ b/packages/core/src/subagent-workspace.ts
@@ -19,6 +19,7 @@ export interface SubagentWorkspaceBinding {
   leaseId: string;
   gitCommonDir: string;
   worktreePath: string;
+  /** Host-owned lease branch; the child may check out another branch inside the leased worktree. */
   branch: string;
   baseCommit: string;
 }

--- a/packages/storage/src/__tests__/git-worktree-child-executor.test.ts
+++ b/packages/storage/src/__tests__/git-worktree-child-executor.test.ts
@@ -64,11 +64,26 @@ describe('Git worktree child executor', () => {
     };
     const first = await createGitWorktreeChildExecutor({ storageRoot }).provision(request);
     await writeFile(join(first.worktreePath, 'work.txt'), 'work\n', 'utf8');
+    await git(first.worktreePath, 'switch', '-c', 'maka/issue-3-a-contract');
 
     const restarted = createGitWorktreeChildExecutor({ storageRoot });
     const second = await restarted.provision(request);
     assert.deepEqual(second, first);
     await restarted.ensure(first);
+    assert.equal(
+      await git(first.worktreePath, 'branch', '--show-current'),
+      'maka/issue-3-a-contract',
+    );
+    assert.match(await git(first.worktreePath, 'status', '--short'), /work\.txt/);
+
+    await git(
+      first.worktreePath,
+      'config',
+      '--local',
+      `branch.${first.branch}.maka-worktree-lease`,
+      `subagent_worktree_${'f'.repeat(32)}`,
+    );
+    await assert.rejects(restarted.ensure(first), /worktree lease changed/);
   });
 
   test('fails closed when a fresh lease would omit uncommitted parent work', async () => {

--- a/packages/storage/src/git-worktree-child-executor.ts
+++ b/packages/storage/src/git-worktree-child-executor.ts
@@ -22,10 +22,11 @@ export interface CreateGitWorktreeChildExecutorInput {
 /**
  * Host-owned Git worktree allocator for linked child Sessions.
  *
- * Lease identity, branch, and path are deterministic. A retry therefore
+ * Lease identity, lease branch, and path are deterministic. A retry therefore
  * adopts the same worktree instead of creating a second filesystem side
- * effect. Worktrees intentionally survive terminal child runs so Session
- * resume/follow-up keeps the exact workspace.
+ * effect. The child may check out its own task branch without changing the
+ * host-owned lease identity. Worktrees intentionally survive terminal child
+ * runs so Session resume/follow-up keeps the exact workspace.
  */
 export function createGitWorktreeChildExecutor(
   input: CreateGitWorktreeChildExecutorInput,
@@ -54,18 +55,18 @@ class GitWorktreeChildExecutor implements SubagentWorktreeExecutor {
     if (!isSubagentWorkspaceBinding(binding)) {
       throw new Error('Invalid subagent worktree binding');
     }
-    const inspected = await this.inspectOwnedWorktree(binding.worktreePath, binding.branch);
+    const inspected = await this.inspectOwnedWorktree(binding.worktreePath);
     if (!inspected) {
       throw new Error(`Subagent worktree is unavailable: ${binding.worktreePath}`);
     }
-    if (
-      inspected.gitCommonDir !== normalize(binding.gitCommonDir) ||
-      inspected.baseCommit !== binding.baseCommit
-    ) {
+    if (inspected.gitCommonDir !== normalize(binding.gitCommonDir)) {
       throw new Error(`Subagent worktree binding changed: ${binding.worktreePath}`);
     }
-    const lease = await gitConfigGet(inspected.worktreePath, branchLeaseConfigKey(binding.branch));
-    if (lease !== binding.leaseId) {
+    const [lease, baseCommit] = await Promise.all([
+      gitConfigGet(inspected.worktreePath, branchLeaseConfigKey(binding.branch)),
+      gitConfigGet(inspected.worktreePath, branchBaseConfigKey(binding.branch)),
+    ]);
+    if (lease !== binding.leaseId || baseCommit !== binding.baseCommit) {
       throw new Error(`Subagent worktree lease changed: ${binding.worktreePath}`);
     }
   }
@@ -102,12 +103,12 @@ class GitWorktreeChildExecutor implements SubagentWorktreeExecutor {
     },
   ): Promise<SubagentWorkspaceBinding> {
     const { worktreePath, branch, gitCommonDir } = target;
-    const adopted = await this.inspectOwnedWorktree(worktreePath, branch);
+    const adopted = await this.inspectOwnedWorktree(worktreePath);
     if (adopted) {
       if (adopted.gitCommonDir !== gitCommonDir) {
         throw new Error(`Subagent worktree belongs to another Git repository: ${worktreePath}`);
       }
-      return this.finalizeBinding(leaseId, adopted);
+      return this.finalizeBinding(leaseId, branch, adopted);
     }
 
     const branchCommit = await gitRevParseOptional(sourceWorktreeRoot, branch);
@@ -135,9 +136,13 @@ class GitWorktreeChildExecutor implements SubagentWorktreeExecutor {
       ]);
     }
 
-    const inspected = await this.inspectOwnedWorktree(worktreePath, branch);
+    const inspected = await this.inspectOwnedWorktree(worktreePath);
     if (!inspected || inspected.gitCommonDir !== gitCommonDir) {
       throw new Error(`Git did not create the expected subagent worktree: ${worktreePath}`);
+    }
+    const checkedOutBranch = await gitCurrentBranch(inspected.worktreePath);
+    if (checkedOutBranch !== branch) {
+      throw new Error(`Git did not check out the expected subagent branch: ${worktreePath}`);
     }
     await setBranchLease(worktreePath, branch, leaseId, baseCommit);
     return {
@@ -175,53 +180,40 @@ class GitWorktreeChildExecutor implements SubagentWorktreeExecutor {
 
   private async finalizeBinding(
     leaseId: string,
+    leaseBranch: string,
     inspected: InspectedWorktree,
   ): Promise<SubagentWorkspaceBinding> {
-    const lease = await gitConfigGet(
-      inspected.worktreePath,
-      branchLeaseConfigKey(inspected.branch),
-    );
+    const lease = await gitConfigGet(inspected.worktreePath, branchLeaseConfigKey(leaseBranch));
     if (lease && lease !== leaseId) {
       throw new Error(`Subagent worktree lease changed: ${inspected.worktreePath}`);
     }
+    if (!lease && (await gitCurrentBranch(inspected.worktreePath)) !== leaseBranch) {
+      throw new Error(`Subagent worktree lease is unavailable: ${inspected.worktreePath}`);
+    }
     const baseCommit =
-      (await gitConfigGet(inspected.worktreePath, branchBaseConfigKey(inspected.branch))) ??
-      (await gitRevParse(inspected.worktreePath, inspected.branch));
-    await setBranchLease(inspected.worktreePath, inspected.branch, leaseId, baseCommit);
+      (await gitConfigGet(inspected.worktreePath, branchBaseConfigKey(leaseBranch))) ??
+      (await gitRevParse(inspected.worktreePath, leaseBranch));
+    await setBranchLease(inspected.worktreePath, leaseBranch, leaseId, baseCommit);
     return {
       schemaVersion: SUBAGENT_WORKSPACE_BINDING_SCHEMA_VERSION,
       kind: 'git_worktree',
       leaseId,
       gitCommonDir: inspected.gitCommonDir,
       worktreePath: inspected.worktreePath,
-      branch: inspected.branch,
+      branch: leaseBranch,
       baseCommit,
     };
   }
 
-  private async inspectOwnedWorktree(
-    path: string,
-    expectedBranch: string,
-  ): Promise<InspectedWorktree | undefined> {
+  private async inspectOwnedWorktree(path: string): Promise<InspectedWorktree | undefined> {
     if (!(await isDirectory(path))) return undefined;
     const location = await resolveProjectLocation({ path });
     if (location.kind !== 'git' || !location.git?.isWorktree) {
       throw new Error(`Subagent workspace is not a linked Git worktree: ${path}`);
     }
-    const branch = (
-      await runGit(location.git.worktreeRoot, ['symbolic-ref', '--quiet', '--short', 'HEAD'])
-    ).trim();
-    if (branch !== expectedBranch) {
-      throw new Error(`Subagent worktree branch changed from ${expectedBranch} to ${branch}`);
-    }
-    const baseCommit =
-      (await gitConfigGet(location.git.worktreeRoot, branchBaseConfigKey(branch))) ??
-      (await gitRevParse(location.git.worktreeRoot, branch));
     return {
       worktreePath: normalize(await realpath(location.git.worktreeRoot)),
       gitCommonDir: normalize(location.git.commonDir),
-      branch,
-      baseCommit,
     };
   }
 }
@@ -229,8 +221,6 @@ class GitWorktreeChildExecutor implements SubagentWorktreeExecutor {
 interface InspectedWorktree {
   worktreePath: string;
   gitCommonDir: string;
-  branch: string;
-  baseCommit: string;
 }
 
 async function assertCleanGitWorktree(path: string): Promise<void> {
@@ -284,6 +274,16 @@ async function gitRevParseOptional(cwd: string, ref: string): Promise<string | u
     return await gitRevParse(cwd, ref);
   } catch (error) {
     if (gitExitCode(error) === 128) return undefined;
+    throw error;
+  }
+}
+
+async function gitCurrentBranch(cwd: string): Promise<string | undefined> {
+  try {
+    const branch = await runGit(cwd, ['symbolic-ref', '--quiet', '--short', 'HEAD']);
+    return branch.trim() || undefined;
+  } catch (error) {
+    if (gitExitCode(error) === 1) return undefined;
     throw error;
   }
 }


### PR DESCRIPTION
Closes #1606.

## What changed

- Treat SubagentWorkspaceBinding.branch as the host-owned lease branch instead of requiring it to remain the worktree current checkout.
- Validate ownership from the linked worktree common directory plus lease/base metadata persisted under that lease branch.
- Preserve the original lease identity across executor restarts when a child checks out a task branch.
- Continue to fail closed when lease metadata is missing or tampered with.
- Add regression coverage for a child switching branches while keeping dirty work, restarting the executor, and resuming successfully.

## Root cause

The failed Graph child had legitimately switched from its deterministic Maka lease branch to a task branch, as its prompt requested. Every later same-operator continuation called ensure() before runtime admission. ensure() required the current checkout to equal the original lease branch, so it rejected the valid worktree before a new AgentRun was created. The durable intent therefore stayed claimed; it was not blocked by a stale runtime admission.

## Impact

Graph child sessions can now resume and receive same-operator follow-ups after checking out their own implementation branch, while retaining the existing worktree, context, and uncommitted changes.

## Validation

- npm run build
- npm --workspace @maka/storage run test (786 passed, 1 skipped)
- selected Graph/runtime suites (348 passed)
- node --test packages/storage/dist/__tests__/git-worktree-child-executor.test.js (4 passed)
- live ensure() check against the original failed child worktree while it remained on its task branch