### PR TITLE
fix(storage): import legacy RuntimeEvent permission requests

### DIFF
--- a/packages/core/src/__tests__/runtime-event.test.ts
+++ b/packages/core/src/__tests__/runtime-event.test.ts
@@ -16,6 +16,7 @@ import {
   RUNTIME_EVENT_STATUSES,
   TERMINAL_RUNTIME_EVENT_STATUSES,
   createRuntimeEventId,
+  decodePersistedRuntimeEvent,
   decodeRuntimeEvent,
   isRuntimeEventAuthor,
   isRuntimeEventRole,
@@ -372,6 +373,35 @@ describe('RuntimeEvent content variants', () => {
 });
 
 describe('RuntimeEvent actions', () => {
+  test('normalizes legacy permission requests only for persisted reads', () => {
+    const permissionRequest = {
+      requestId: 'pr-1',
+      toolUseId: 'tc-1',
+      toolName: 'Bash',
+      category: 'shell_unsafe',
+      reason: 'shell_dangerous',
+      args: { command: 'rm foo' },
+    };
+    const legacyEvent = baseEvent({ actions: { permissionRequest } as never });
+    assert.throws(() => decodeRuntimeEvent(legacyEvent), /Invalid RuntimeEvent schema/);
+    assert.deepEqual(decodePersistedRuntimeEvent(legacyEvent).actions?.permissionRequest, {
+      ...permissionRequest,
+      kind: 'tool_permission',
+      rememberForTurnAllowed: false,
+    });
+    assert.throws(
+      () =>
+        decodePersistedRuntimeEvent(
+          baseEvent({
+            actions: {
+              permissionRequest: { ...permissionRequest, kind: 'tool_permission' },
+            } as never,
+          }),
+        ),
+      /Invalid RuntimeEvent schema/,
+    );
+  });
+
   test('a terminal action can carry endInvocation + tokenUsage', () => {
     const actions: RuntimeEventActions = {
       endInvocation: true,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -152,6 +152,7 @@ export {
   isRuntimeEventAuthor,
   isRuntimeEventStatus,
   decodeRuntimeEvent,
+  decodePersistedRuntimeEvent,
   isTerminalRuntimeEventStatus,
   isTerminalRuntimeEvent,
   isPartialRuntimeEvent,

--- a/packages/core/src/runtime-event.ts
+++ b/packages/core/src/runtime-event.ts
@@ -543,6 +543,35 @@ export function decodeRuntimeEvent(value: unknown): RuntimeEvent {
   return value as unknown as RuntimeEvent;
 }
 
+export function decodePersistedRuntimeEvent(value: unknown): RuntimeEvent {
+  return decodeRuntimeEvent(normalizeLegacyPermissionRequest(value));
+}
+
+function normalizeLegacyPermissionRequest(value: unknown): unknown {
+  if (!isRecord(value) || !isRecord(value.actions)) return value;
+  const request = value.actions.permissionRequest;
+  if (
+    !isRecord(request) ||
+    Object.hasOwn(request, 'kind') ||
+    Object.hasOwn(request, 'rememberForTurnAllowed')
+  ) {
+    return value;
+  }
+  const normalized = {
+    ...request,
+    kind: 'tool_permission',
+    rememberForTurnAllowed: false,
+  };
+  if (!isPermissionRequestPayload(normalized)) return value;
+  return {
+    ...value,
+    actions: {
+      ...value.actions,
+      permissionRequest: normalized,
+    },
+  };
+}
+
 function isRuntimeEventContent(value: unknown): value is RuntimeEventContent {
   if (!isRecord(value)) return false;
   switch (value.kind) {

--- a/packages/storage/src/__tests__/runtime-event-transfer.test.ts
+++ b/packages/storage/src/__tests__/runtime-event-transfer.test.ts
@@ -34,6 +34,25 @@ describe('runtime event JSONL compatibility transfer', () => {
           ts: 3,
         }),
       );
+      await appendFile(
+        join(root, 'sessions', 'session-1', 'runs', 'run-1', 'runtime-events.jsonl'),
+        `${JSON.stringify(
+          runtimeEvent('event-4', {
+            ts: 4,
+            content: undefined,
+            actions: {
+              permissionRequest: {
+                requestId: 'pr-1',
+                toolUseId: 'tc-1',
+                toolName: 'Bash',
+                category: 'shell_unsafe',
+                reason: 'shell_dangerous',
+                args: { command: 'rm foo' },
+              },
+            } as never,
+          }),
+        )}\n`,
+      );
 
       const first = await importLegacyRuntimeEventJsonlTree({
         workspaceRoot: root,
@@ -46,8 +65,8 @@ describe('runtime event JSONL compatibility transfer', () => {
 
       assert.deepEqual(first, {
         filesScanned: 2,
-        eventsRead: 3,
-        eventsImported: 3,
+        eventsRead: 4,
+        eventsImported: 4,
         eventsExisting: 0,
       });
       assert.deepEqual(second, {
@@ -58,8 +77,12 @@ describe('runtime event JSONL compatibility transfer', () => {
       });
       assert.deepEqual(
         (await sqlite.readSessionRuntimeEvents('session-1')).map((event) => event.id),
-        ['event-1', 'event-2', 'event-3'],
+        ['event-1', 'event-2', 'event-3', 'event-4'],
       );
+      const importedRequest = (await sqlite.readRuntimeEvents('session-1', 'run-1')).at(-1)?.actions
+        ?.permissionRequest;
+      assert.equal(importedRequest?.kind, 'tool_permission');
+      assert.equal(importedRequest?.rememberForTurnAllowed, false);
     } finally {
       sqlite.close();
       await rm(root, { recursive: true, force: true });
@@ -84,13 +107,16 @@ describe('runtime event JSONL compatibility transfer', () => {
         'run-1',
         'runtime-events.jsonl',
       );
-      const legacyStreamPartial = runtimeEvent('partial-thinking', {
-        ts: 3,
-        partial: true,
-        role: 'model',
-        author: 'agent',
-        content: { kind: 'thinking', text: 'interrupted thought' },
-      });
+      const legacyStreamPartial = {
+        ...runtimeEvent('partial-thinking', {
+          ts: 3,
+          partial: true,
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'thinking', text: 'interrupted thought' },
+        }),
+        unexpectedField: true,
+      };
       const partialRowWithStatus = runtimeEvent('partial-terminal', {
         ts: 4,
         partial: true,

--- a/packages/storage/src/runtime-event-transfer.ts
+++ b/packages/storage/src/runtime-event-transfer.ts
@@ -1,6 +1,6 @@
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
-import type { RuntimeEvent, RuntimeEventStore } from '@maka/core';
+import { decodePersistedRuntimeEvent, type RuntimeEvent, type RuntimeEventStore } from '@maka/core';
 import { createRuntimeEventStore } from './agent-run-store.js';
 import type { SqliteRuntimeStore } from './sqlite-runtime-store.js';
 import { createSqliteRuntimeStore } from './sqlite-runtime-store.js';
@@ -110,11 +110,7 @@ export async function importLegacyRuntimeEventJsonlTree(input: {
       if (!sourceStat) continue;
       const fingerprint = `${sourceStat.size}:${sourceStat.mtimeMs}`;
       if (await input.destination.isRuntimeImportSourceCurrent(sourcePath, fingerprint)) continue;
-      const events = parseLegacyRuntimeEventJsonl(
-        await readFile(sourcePath, 'utf8'),
-        session,
-        run,
-      ).filter((event) => !isLegacyStreamPartialSnapshot(event));
+      const events = parseLegacyRuntimeEventJsonl(await readFile(sourcePath, 'utf8'), session, run);
       report.filesScanned += 1;
       const imported = await importRuntimeEvents(events, session, run, input.destination, {
         path: sourcePath,
@@ -191,7 +187,9 @@ function parseLegacyRuntimeEventJsonl(
     if (!line?.trim()) continue;
     let event: RuntimeEvent;
     try {
-      event = JSON.parse(line) as RuntimeEvent;
+      const parsed: unknown = JSON.parse(line);
+      if (isLegacyStreamPartialSnapshot(parsed)) continue;
+      event = decodePersistedRuntimeEvent(parsed);
     } catch (error) {
       throw new Error(`Invalid legacy RuntimeEvent JSONL line ${index + 1} for run ${runId}`, {
         cause: error,
@@ -223,7 +221,9 @@ function assertRuntimeEventImportIdentity(
 // completed stream leaves a separate durable final event, and a dangling
 // partial is already handled by the replay boundary gates. Legacy tree import
 // skips them; the strict importRuntimeEventsFromJsonl API still rejects them.
-function isLegacyStreamPartialSnapshot(event: RuntimeEvent): boolean {
+function isLegacyStreamPartialSnapshot(value: unknown): boolean {
+  if (!value || typeof value !== 'object') return false;
+  const event = value as Record<string, unknown>;
   return event.partial === true && event.status === undefined && event.actions === undefined;
 }
 


### PR DESCRIPTION
## Summary

TUI startup could fail with `Invalid RuntimeEvent schema` when SQLite canonical persistence scanned RuntimeEvents written before the current permission-request fields became required.

- Add `decodePersistedRuntimeEvent` to upcast only the exact legacy tool-permission shape.
- Apply compatibility only to immutable legacy JSONL rows, after disposable stream partial snapshots are skipped.
- Keep the canonical decoder and every writer strict; SQLite receives only the current shape.
- Cover both the decoder contract and the production JSONL-to-SQLite migration path.

## Verification

- `npm --workspace @maka/core test`: 1,189 passed, 0 failed.
- `npm --workspace @maka/storage test`: 786 passed, 0 failed, 1 skipped.
- `./node_modules/.bin/maka` opened the TUI against the affected local workspace after migration.
- Biome formatting and `git diff --check`: clean.

## Root cause

Older persisted `actions.permissionRequest` payloads omitted `kind` and `rememberForTurnAllowed`. `parseLegacyRuntimeEventJsonl` parsed those rows without decoding them, then `importRuntimeEventsBatch` sent the raw objects through the strict canonical encoder. The first affected row aborted TUI startup.

## Review focus

Compatibility is deliberately narrow: both fields must be absent, partially upgraded or malformed payloads still fail schema validation, and `rememberForTurnAllowed` defaults to `false`. Mutable legacy stream partials remain disposable and are skipped before strict validation. The source JSONL is not rewritten.