### PR TITLE
fix(runtime): isolate an unclaimed control fact from the session view

### DIFF
--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -23,7 +23,10 @@ import { flowSupportsControl } from '../agent-flow.js';
 import type { AgentBackend } from '@maka/core/backend-types';
 import { RuntimeRunner } from '../runtime-runner.js';
 import type { InvocationContext } from '../invocation-context.js';
-import { projectRuntimeEventsToStoredMessages } from '../runtime-event-read-model.js';
+import {
+  isUnclaimedRuntimeEventDiagnostic,
+  projectRuntimeEventsToStoredMessages,
+} from '../runtime-event-read-model.js';
 import { isNonTerminalErrorRuntimeEvent } from '../agent-run.js';
 import { backfillRuntimeEventsFromStoredMessages } from '../runtime-event-backfill.js';
 
@@ -1276,13 +1279,13 @@ const projectionRunHeader: AgentRunHeader = {
 };
 
 describe('SessionEvent projection coverage', () => {
-  // RuntimeReadModel rejects a whole completed-session projection when it sees
-  // an `unsupported_event`, so a variant the projection does not claim makes
-  // every session that contains it permanently unreadable. The contract is
-  // therefore over what a reader can actually meet: every mapped event AgentRun
-  // admits to the ledger has to project.
+  // The contract is over what a reader can actually meet: every mapped event
+  // AgentRun admits to the ledger has to project. It asserts on the unclaimed
+  // codes at either severity, not on the hard one alone — a control fact whose
+  // gap only degrades the view is still a gap, and must be found here rather
+  // than by a user opening the session.
   for (const [type, sample] of Object.entries(PROJECTION_SAMPLES)) {
-    test(`${type} projects without an unsupported_event diagnostic`, () => {
+    test(`${type} projects without an unclaimed-event diagnostic`, () => {
       let seq = 0;
       const memory = createSessionEventMapMemory();
       const runtimeEvents = [...(sample.before ?? []), sample.subject, ...(sample.after ?? [])]
@@ -1305,10 +1308,33 @@ describe('SessionEvent projection coverage', () => {
         runHeaders: [projectionRunHeader],
       });
 
-      assert.deepEqual(
-        projected.diagnostics.filter((diagnostic) => diagnostic.code === 'unsupported_event'),
-        [],
-      );
+      assert.deepEqual(projected.diagnostics.filter(isUnclaimedRuntimeEventDiagnostic), []);
     });
   }
+
+  // The guard's fallback is what a variant added without a claim actually
+  // becomes. It has to stay on the degradable side of the line: control-only,
+  // so the session it lands in still opens, and still reported so the gap the
+  // coverage contract would have caught is not invisible at runtime.
+  test('an unmapped SessionEvent maps to a reported control-only fact', () => {
+    const unmapped = { type: 'not_yet_mapped', id: 'e', turnId: 'turn-1', ts: 1 };
+    const memory = createSessionEventMapMemory();
+    const runtimeEvent = mapSessionEventToRuntimeEvent(
+      unmapped as unknown as SessionEvent,
+      ctx,
+      memory,
+    );
+
+    assert.equal(runtimeEvent.content, undefined);
+    assert.equal(runtimeEvent.actions?.stateDelta?.unmappedSessionEventType, 'not_yet_mapped');
+
+    const projected = projectRuntimeEventsToStoredMessages([runtimeEvent], {
+      runHeaders: [projectionRunHeader],
+    });
+    assert.deepEqual(projected.messages, []);
+    assert.deepEqual(
+      projected.diagnostics.map((diagnostic) => diagnostic.code),
+      ['unclaimed_control_fact'],
+    );
+  });
 });

--- a/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-flow.test.ts
@@ -1332,9 +1332,13 @@ describe('SessionEvent projection coverage', () => {
       runHeaders: [projectionRunHeader],
     });
     assert.deepEqual(projected.messages, []);
+    // Filtered through the predicate the contract above uses, not just compared
+    // to the code string: dropping the soft code from the predicate would
+    // otherwise loosen the contract to `unsupported_event` only, silently.
     assert.deepEqual(
-      projected.diagnostics.map((diagnostic) => diagnostic.code),
+      projected.diagnostics.filter(isUnclaimedRuntimeEventDiagnostic).map((d) => d.code),
       ['unclaimed_control_fact'],
     );
+    assert.equal(projected.diagnostics.length, 1);
   });
 });

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -13,6 +13,7 @@ import { deriveTurnRecords } from '@maka/core';
 import { expect } from '../test-helpers.js';
 import {
   compareRuntimeReadModelMessages,
+  isHardRuntimeEventReadModelDiagnostic,
   projectRuntimeEventsToStoredMessages,
   projectRuntimeEventsToStoredMessagesWithArchiveStatuses,
 } from '../runtime-event-read-model.js';
@@ -1151,11 +1152,17 @@ describe('projectRuntimeEventsToStoredMessages', () => {
   ];
 
   for (const [name, makeEvent] of malformedBoundaryCases) {
-    test(`a sandbox boundary ${name} stays an unsupported event`, () => {
+    // The claim stays exact: a malformed shape is never admitted as a canonical
+    // boundary fact. Its severity is a separate question, and a control fact
+    // owns no chat row, so a broken one costs a reader nothing the session view
+    // would otherwise show.
+    test(`a sandbox boundary ${name} stays unclaimed`, () => {
       const out = projectRuntimeEventsToStoredMessages([makeEvent()], { runHeaders: [header] });
 
       expect(out.messages).toEqual([]);
-      expect(out.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(['unsupported_event']);
+      expect(out.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+        'unclaimed_control_fact',
+      ]);
     });
   }
 
@@ -1310,13 +1317,64 @@ describe('projectRuntimeEventsToStoredMessages', () => {
     );
 
     expect(out.messages).toEqual([]);
+    // The orphaned permission decision carries no content, so its catch-all is
+    // the soft code — but the projector that tried to build its row and failed
+    // still reports `incomplete_event`, which stays hard. Downgrading the
+    // catch-all never downgrades a projector that attempted a message.
     expect(out.diagnostics.map((diag) => diag.code)).toEqual([
       'incomplete_event',
-      'unsupported_event',
+      'unclaimed_control_fact',
       'incomplete_event',
       'unsupported_event',
       'unsupported_event',
     ]);
+  });
+
+  // Where the projection draws the line between a view it can still serve and
+  // one it must refuse: an unclaimed event that carries no content owns no chat
+  // row, so nothing a reader would have seen is missing.
+  test('an unclaimed control-only event is soft and leaves every message intact', () => {
+    const out = projectRuntimeEventsToStoredMessages(
+      [
+        ev({ id: 'evt-user', role: 'user', author: 'user', content: { kind: 'text', text: 'hi' } }),
+        ev({
+          id: 'evt-control',
+          actions: { stateDelta: { somethingTheProjectionWasNeverTaught: true } },
+        }),
+        ev({
+          id: 'evt-assistant',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'text', text: 'hello' },
+        }),
+      ],
+      { runHeaders: [header] },
+    );
+
+    expect(out.messages.map((message) => message.id)).toEqual(['evt-user', 'evt-assistant']);
+    expect(out.diagnostics.map((diagnostic) => diagnostic.code)).toEqual([
+      'unclaimed_control_fact',
+    ]);
+    expect(out.diagnostics.map((diagnostic) => diagnostic.eventId)).toEqual(['evt-control']);
+    expect(out.diagnostics.some(isHardRuntimeEventReadModelDiagnostic)).toBe(false);
+  });
+
+  test('an unclaimed event that carries content stays hard', () => {
+    const out = projectRuntimeEventsToStoredMessages(
+      [
+        ev({
+          id: 'evt-future-content',
+          role: 'model',
+          author: 'agent',
+          content: { kind: 'not_yet_projected', text: 'a reader would have seen this' } as never,
+        }),
+      ],
+      { runHeaders: [header] },
+    );
+
+    expect(out.messages).toEqual([]);
+    expect(out.diagnostics.map((diagnostic) => diagnostic.code)).toEqual(['unsupported_event']);
+    expect(out.diagnostics.every(isHardRuntimeEventReadModelDiagnostic)).toBe(true);
   });
 
   test('failed terminal RuntimeEvent maps to failed turn state when run header carries failure class', () => {

--- a/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
+++ b/packages/runtime/src/__tests__/runtime-event-read-model.test.ts
@@ -3,6 +3,7 @@ import type {
   AgentRunHeader,
   CreateSessionInput,
   RuntimeEvent,
+  RuntimeEventActions,
   SessionHeader,
   SessionListFilter,
   SessionSummary,
@@ -14,6 +15,7 @@ import { expect } from '../test-helpers.js';
 import {
   compareRuntimeReadModelMessages,
   isHardRuntimeEventReadModelDiagnostic,
+  isUnclaimedRuntimeEventDiagnostic,
   projectRuntimeEventsToStoredMessages,
   projectRuntimeEventsToStoredMessagesWithArchiveStatuses,
 } from '../runtime-event-read-model.js';
@@ -1548,6 +1550,122 @@ describe('projectRuntimeEventsToStoredMessages', () => {
       activityKind: 'command',
     });
   });
+});
+
+/**
+ * One reachable event per `RuntimeEventActions` field, each entry typed to its
+ * own key so it cannot drift onto another field or be filled with a placeholder.
+ *
+ * This is the premise the read model's soft path rests on. An unclaimed
+ * content-free event degrades the view instead of withholding it, which is only
+ * safe while every action a reader can meet is claimed — several of them
+ * (`permissionDecision`, `tokenUsage`, the terminal fact) do produce rows, and
+ * `runtime-event-backfill.ts` already writes a content-free event that becomes a
+ * visible `permission_decision`. The SessionEvent contract in ai-sdk-flow.test.ts
+ * only covers events built by `mapSessionEventToRuntimeEvent`; tool-runtime,
+ * terminal-run-commit and the backfill write RuntimeEvents directly. Keying this
+ * table on the action surface itself covers those paths too.
+ */
+type ActionCoverageSamples = {
+  [K in keyof Required<RuntimeEventActions>]: {
+    /** The action value under test, typed to its own key. */
+    action: Required<RuntimeEventActions>[K];
+    /** The rest of the event, as the field's real emitter writes it. */
+    event?: Partial<RuntimeEvent>;
+  };
+};
+
+const ACTION_COVERAGE_SAMPLES: ActionCoverageSamples = {
+  // `stateDelta` is an open record, so only named shapes are claimed and this
+  // entry covers the field, not its contents. A new key inside a state delta is
+  // out of reach of any contract keyed on the action surface.
+  stateDelta: { action: { continuationStart: true } },
+  artifactDelta: { action: { 'artifact-1': 42 } },
+  permissionRequest: {
+    action: {
+      kind: 'tool_permission',
+      requestId: 'coverage-request',
+      toolUseId: 'coverage-tool',
+      toolName: 'Read',
+      category: 'read',
+      reason: 'custom',
+      args: { path: '/tmp/a.txt' },
+      rememberForTurnAllowed: true,
+    },
+    event: { refs: { toolCallId: 'coverage-tool' } },
+  },
+  permissionDecision: {
+    action: { requestId: 'coverage-request', decision: 'allow', toolName: 'Read' },
+    event: { refs: { toolCallId: 'coverage-tool' } },
+  },
+  // The canonical outcome lives in InteractionStore, so a standalone acceptance
+  // reports an `incomplete_event`. That is a completeness diagnostic, not a
+  // coverage gap: the projection still claims the field.
+  permissionAnswerAccepted: {
+    action: { requestId: 'coverage-request' },
+    event: { author: 'user', refs: { toolCallId: 'coverage-tool' } },
+  },
+  permissionClosureAccepted: {
+    action: { requestId: 'coverage-request', reason: 'timed_out' },
+  },
+  userQuestionRequest: {
+    action: {
+      requestId: 'coverage-question',
+      toolUseId: 'coverage-question-tool',
+      questions: [{ question: 'Choose', options: [{ label: 'Extend' }] }],
+    },
+    event: { refs: { toolCallId: 'coverage-question-tool' } },
+  },
+  userQuestionAnswerAccepted: {
+    action: { requestId: 'coverage-question' },
+    event: { author: 'user', refs: { toolCallId: 'coverage-question-tool' } },
+  },
+  transferToAgent: { action: 'agent-b' },
+  // The terminal fact is one of the actions that does own a row.
+  endInvocation: { action: true },
+  tokenUsage: { action: { input: 10, output: 5 } },
+  toolDispatch: {
+    action: {
+      protocol: 't1_after_preflight_v1',
+      operationId: 'coverage-op',
+      providerToolCallId: 'coverage-tool',
+      toolName: 'Bash',
+      canonicalArgsHash: 'sha256:args',
+      recoveryMode: 'reconcile',
+    },
+    event: { refs: { toolCallId: 'coverage-tool', operationId: 'coverage-op' } },
+  },
+  toolRecovery: {
+    action: {
+      kind: 'maka.tool.reconcile_result',
+      version: 1,
+      payload: {
+        protocol: 'tool_reconcile_v1',
+        operationId: 'coverage-op',
+        observation: 'unreadable',
+        observationSchema: 'state_identity_v1',
+        observationDigest:
+          'sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+      },
+    },
+    event: { refs: { toolCallId: 'coverage-tool', operationId: 'coverage-op' } },
+  },
+  runtimeProtocol: { action: { toolBoundary: 't1_after_preflight_v1' } },
+};
+
+describe('RuntimeEventActions projection coverage', () => {
+  for (const [field, sample] of Object.entries(ACTION_COVERAGE_SAMPLES)) {
+    test(`actions.${field} projects without an unclaimed-event diagnostic`, () => {
+      const actions = { [field]: sample.action } as RuntimeEventActions;
+      // Guards an entry that names a field but leaves it absent at runtime.
+      expect(field in actions).toBe(true);
+      const out = projectRuntimeEventsToStoredMessages([ev({ ...sample.event, actions })], {
+        runHeaders: [header],
+      });
+
+      expect(out.diagnostics.filter(isUnclaimedRuntimeEventDiagnostic)).toEqual([]);
+    });
+  }
 });
 
 describe('compareRuntimeReadModelMessages', () => {

--- a/packages/runtime/src/__tests__/runtime-read-model-persisted-compat.test.ts
+++ b/packages/runtime/src/__tests__/runtime-read-model-persisted-compat.test.ts
@@ -6,6 +6,7 @@ import { test } from 'node:test';
 import type { AgentRunHeader } from '@maka/core';
 import { createAgentRunStore, createRuntimeEventStore } from '@maka/storage';
 import { RuntimeReadModel } from '../runtime-read-model.js';
+import { isHardRuntimeEventReadModelDiagnostic } from '../runtime-event-read-model.js';
 
 const sessionId = 'legacy-runtime-event-session';
 const runId = 'legacy-runtime-event-run';
@@ -79,15 +80,7 @@ test('reopens a persisted legacy subagent RuntimeEvent without rewriting it', as
       'waiting_for_user',
     );
 
-    const hardReadDiagnosticCodes = new Set([
-      'incomplete_event',
-      'unsupported_event',
-      'tool_use_id_mismatch',
-    ]);
-    assert.equal(
-      view.diagnostics.some((diagnostic) => hardReadDiagnosticCodes.has(diagnostic.code)),
-      false,
-    );
+    assert.equal(view.diagnostics.some(isHardRuntimeEventReadModelDiagnostic), false);
     const blockingReplayDiagnosticCodes = new Set([
       'unsupported_role',
       'unsupported_content',

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -13260,6 +13260,55 @@ describe('SessionManager permission mode updates', () => {
     ).toBe(1);
   });
 
+  // The counterpart of the soft case, at the caller that enforces the policy:
+  // an unclaimed event that carries content may have cost a reader a row, so
+  // getSessionView must still refuse the view rather than serve a lossy one.
+  test('refuses a session view when an unclaimed event carries content', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new UnmappedSessionEventBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(9_700),
+    });
+    const session = await manager.createSession(makeInput());
+
+    for await (const _event of manager.sendMessage(session.id, {
+      turnId: 'turn-1',
+      text: 'hello',
+    })) {
+      // drain
+    }
+
+    const [run] = await runStore.listSessionRuns(session.id);
+    await runStore.appendRuntimeEvent(
+      session.id,
+      run!.runId,
+      runtimeEvent({
+        id: 'unclaimed-content',
+        sessionId: session.id,
+        runId: run!.runId,
+        turnId: 'turn-1',
+        ts: 4,
+        role: 'model',
+        author: 'agent',
+        content: { kind: 'not_yet_projected', text: 'a reader would have seen this' } as never,
+      }),
+    );
+
+    await assert.rejects(
+      new RuntimeReadModel({ runStore, runtimeEventStore: runStore }).getSessionView(session.id),
+      (error: unknown) =>
+        error instanceof RuntimeReadModelError &&
+        error.diagnostics.some((diagnostic) => diagnostic.code === 'unsupported_event'),
+    );
+  });
+
   test('marks backend errors as blocked with a generalized reason', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();

--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -13217,6 +13217,49 @@ describe('SessionManager permission mode updates', () => {
     });
   }
 
+  // The next unclaimed control fact must not repeat #1607. A complete ledger
+  // with one event the projection was never taught still reads back — messages,
+  // turns and every turn-scoped action — and the unclaimed event is reported as
+  // a diagnostic rather than costing the session that contains it.
+  test('reads a completed session back with an unclaimed control fact in its ledger', async () => {
+    const store = new MemorySessionStore();
+    const runStore = new MemoryAgentRunStore();
+    const backends = new BackendRegistry();
+    backends.register('fake', (ctx) => new UnmappedSessionEventBackend(ctx));
+    const manager = new SessionManager({
+      store,
+      runStore,
+      runtimeEventStore: runStore,
+      backends,
+      newId: nextId(),
+      now: nextNow(9_600),
+    });
+    const session = await manager.createSession(makeInput());
+
+    for await (const _event of manager.sendMessage(session.id, {
+      turnId: 'turn-1',
+      text: 'hello',
+    })) {
+      // drain
+    }
+
+    const messages = await manager.getMessages(session.id);
+    expect(messages.filter((message) => message.type === 'user').length).toBe(1);
+    expect(
+      messages.some((message) => message.type === 'assistant' && message.text === 'hi back'),
+    ).toBe(true);
+    const turns = await manager.listTurns(session.id);
+    expect(turns.find((turn) => turn.turnId === 'turn-1')?.status).toBe('completed');
+
+    const view = await new RuntimeReadModel({
+      runStore,
+      runtimeEventStore: runStore,
+    }).getSessionView(session.id);
+    expect(
+      view.diagnostics.filter((diagnostic) => diagnostic.code === 'unclaimed_control_fact').length,
+    ).toBe(1);
+  });
+
   test('marks backend errors as blocked with a generalized reason', async () => {
     const store = new MemorySessionStore();
     const backends = new BackendRegistry();
@@ -18390,6 +18433,51 @@ class SandboxBoundaryWaitBackend implements AgentBackend {
     this.responses.push(response);
     this.responseGate.release();
   }
+
+  async dispose(): Promise<void> {}
+}
+
+/**
+ * Emits a SessionEvent variant the mapping has never been taught, wrapped in a
+ * turn that produces a real assistant message. That is what a future variant
+ * looks like from the read model's side: AiSdkFlow's exhaustiveness guard turns
+ * it into a control-only RuntimeEvent, and the ledger keeps it.
+ */
+class UnmappedSessionEventBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly sessionId: string;
+
+  constructor(ctx: BackendFactoryContext) {
+    this.sessionId = ctx.sessionId;
+  }
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'text_complete',
+      id: `${input.turnId}-text`,
+      turnId: input.turnId,
+      ts: 1,
+      messageId: `${input.turnId}-message`,
+      text: 'hi back',
+    };
+    yield {
+      type: 'not_yet_mapped',
+      id: `${input.turnId}-unmapped`,
+      turnId: input.turnId,
+      ts: 2,
+    } as unknown as SessionEvent;
+    yield {
+      type: 'complete',
+      id: `${input.turnId}-complete`,
+      turnId: input.turnId,
+      ts: 3,
+      stopReason: 'end_turn',
+    };
+  }
+
+  async stop(): Promise<void> {}
+
+  async respondToSandboxBoundary(): Promise<void> {}
 
   async dispose(): Promise<void> {}
 }

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -506,6 +506,13 @@ function mapBackendSessionEvent(
     default: {
       // Exhaustiveness guard: if SessionEvent grows a new variant, the
       // mapping falls through to a diagnostic event instead of dropping it.
+      //
+      // The fallback carries no `content` on purpose. That is what keeps
+      // "don't drop the event" from escalating into "lose the session": the
+      // read-model projection does not claim this shape, and an unclaimed
+      // event with no message payload degrades to a reported diagnostic
+      // instead of discarding the whole session view. Naming the type in the
+      // state delta is the only user-visible trace an unknown event has left.
       const _exhaustive: never = event;
       void _exhaustive;
       return {

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -40,6 +40,36 @@ export type RuntimeEventReadModelDiagnosticCode =
   | 'missing_legacy_message'
   | 'unexpected_projected_message';
 
+/**
+ * Whether a diagnostic means the projection may have lost user-visible content.
+ *
+ * `hard` — a row a reader would have seen may be missing, so the projection is
+ * not a faithful view of the session and must not be served in place of one.
+ * `soft` — every message survived; the fact is reported, not fatal.
+ *
+ * The table is keyed by code so a new diagnostic cannot exist without deciding
+ * which side of that line it falls on.
+ */
+const RUNTIME_EVENT_READ_MODEL_DIAGNOSTIC_SEVERITY: Record<
+  RuntimeEventReadModelDiagnosticCode,
+  'hard' | 'soft'
+> = {
+  partial_skipped: 'soft',
+  unsupported_event: 'hard',
+  incomplete_event: 'hard',
+  archived_tool_result_placeholder: 'soft',
+  generated_id: 'soft',
+  tool_use_id_mismatch: 'hard',
+  missing_legacy_message: 'soft',
+  unexpected_projected_message: 'soft',
+};
+
+export function isHardRuntimeEventReadModelDiagnostic(diagnostic: {
+  code: RuntimeEventReadModelDiagnosticCode;
+}): boolean {
+  return RUNTIME_EVENT_READ_MODEL_DIAGNOSTIC_SEVERITY[diagnostic.code] === 'hard';
+}
+
 export interface RuntimeEventReadModelDiagnostic {
   code: RuntimeEventReadModelDiagnosticCode;
   eventId?: string;

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -46,7 +46,8 @@ export type RuntimeEventReadModelDiagnosticCode =
  *
  * `hard` — a row a reader would have seen may be missing, so the projection is
  * not a faithful view of the session and must not be served in place of one.
- * `soft` — every message survived; the fact is reported, not fatal.
+ * `soft` — the fact is reported without withholding the view; it does not by
+ * itself mean a row is missing.
  *
  * The table is keyed by code so a new diagnostic cannot exist without deciding
  * which side of that line it falls on.
@@ -274,6 +275,24 @@ export function projectRuntimeEventsToStoredMessages(
       projected = true;
     }
 
+    if (event.actions?.artifactDelta) {
+      // Artifact counters are storage bookkeeping. The tool result that owns the
+      // artifact owns its row; this delta has none of its own.
+      projected = true;
+    }
+
+    if (event.actions?.transferToAgent !== undefined) {
+      // A hand-off is control routing. The receiving agent's own events own
+      // every provider-visible row the transfer leads to.
+      projected = true;
+    }
+
+    if (event.actions?.runtimeProtocol) {
+      // The protocol marker records which runtime contracts were live from a
+      // run's first event. RecoveryResolver reads it; it has no chat row.
+      projected = true;
+    }
+
     if (event.actions?.stateDelta?.continuationStart === true) {
       // Continuation start is a canonical lineage/recovery fact with no
       // legacy chat row. Its following model events own the visible output.
@@ -306,14 +325,12 @@ export function projectRuntimeEventsToStoredMessages(
     }
 
     if (!projected) {
-      // Where the line sits between degrading a view and refusing to serve one:
-      // `content` is the RuntimeEvent's message payload, `actions` its control
-      // intent. Every row this projection emits from an unclaimed shape would
-      // have come from content, so an unclaimed content-bearing event may have
-      // cost a reader a message and the view is no longer faithful. A
-      // control-only fact has no row to lose — report it and keep the session
-      // readable, since discarding the projection would cost every intact
-      // message in it instead.
+      // Content is the only payload an unclaimed shape could still have owed a
+      // row, so its absence is what makes degrading safe here — not a promise
+      // that actions never produce rows (permissionDecision, tokenUsage and the
+      // terminal fact all do). What holds that up is claim coverage: every
+      // action field a reader can meet is claimed above, proven by the
+      // projection-coverage contract, so nothing with a row reaches this branch.
       if (event.content === undefined) {
         diagnostic(
           state,

--- a/packages/runtime/src/runtime-event-read-model.ts
+++ b/packages/runtime/src/runtime-event-read-model.ts
@@ -33,6 +33,7 @@ import { isArchivedToolResultPlaceholder } from './tool-result-archive.js';
 export type RuntimeEventReadModelDiagnosticCode =
   | 'partial_skipped'
   | 'unsupported_event'
+  | 'unclaimed_control_fact'
   | 'incomplete_event'
   | 'archived_tool_result_placeholder'
   | 'generated_id'
@@ -56,6 +57,7 @@ const RUNTIME_EVENT_READ_MODEL_DIAGNOSTIC_SEVERITY: Record<
 > = {
   partial_skipped: 'soft',
   unsupported_event: 'hard',
+  unclaimed_control_fact: 'soft',
   incomplete_event: 'hard',
   archived_tool_result_placeholder: 'soft',
   generated_id: 'soft',
@@ -68,6 +70,24 @@ export function isHardRuntimeEventReadModelDiagnostic(diagnostic: {
   code: RuntimeEventReadModelDiagnosticCode;
 }): boolean {
   return RUNTIME_EVENT_READ_MODEL_DIAGNOSTIC_SEVERITY[diagnostic.code] === 'hard';
+}
+
+/**
+ * Codes that mean the projection did not claim an event, at either severity.
+ *
+ * Severity decides whether a session still opens; this decides whether the
+ * projection has a coverage gap. The projection-coverage contract asserts on
+ * this set, so softening an event's severity never softens the contract.
+ */
+const UNCLAIMED_RUNTIME_EVENT_DIAGNOSTIC_CODES: readonly RuntimeEventReadModelDiagnosticCode[] = [
+  'unsupported_event',
+  'unclaimed_control_fact',
+];
+
+export function isUnclaimedRuntimeEventDiagnostic(diagnostic: {
+  code: RuntimeEventReadModelDiagnosticCode;
+}): boolean {
+  return UNCLAIMED_RUNTIME_EVENT_DIAGNOSTIC_CODES.includes(diagnostic.code);
 }
 
 export interface RuntimeEventReadModelDiagnostic {
@@ -286,12 +306,29 @@ export function projectRuntimeEventsToStoredMessages(
     }
 
     if (!projected) {
-      diagnostic(
-        state,
-        event,
-        'unsupported_event',
-        'RuntimeEvent shape is not supported by the legacy read-model projection',
-      );
+      // Where the line sits between degrading a view and refusing to serve one:
+      // `content` is the RuntimeEvent's message payload, `actions` its control
+      // intent. Every row this projection emits from an unclaimed shape would
+      // have come from content, so an unclaimed content-bearing event may have
+      // cost a reader a message and the view is no longer faithful. A
+      // control-only fact has no row to lose — report it and keep the session
+      // readable, since discarding the projection would cost every intact
+      // message in it instead.
+      if (event.content === undefined) {
+        diagnostic(
+          state,
+          event,
+          'unclaimed_control_fact',
+          'control-only RuntimeEvent is not claimed by the legacy read-model projection',
+        );
+      } else {
+        diagnostic(
+          state,
+          event,
+          'unsupported_event',
+          'RuntimeEvent shape is not supported by the legacy read-model projection',
+        );
+      }
     }
   }
 

--- a/packages/runtime/src/runtime-read-model.ts
+++ b/packages/runtime/src/runtime-read-model.ts
@@ -14,6 +14,7 @@ import type {
 import {
   classifyRuntimeEventTerminalFact,
   compareRuntimeReadModelMessages,
+  isHardRuntimeEventReadModelDiagnostic,
   projectRuntimeEventsToStoredMessages,
   type RuntimeEventReadModelDiagnostic,
   type RuntimeEventTerminalFact,
@@ -447,12 +448,10 @@ function messageTurnId(message: StoredMessage): string | undefined {
 function hasHardProjectionDiagnostic(
   diagnostics: readonly RuntimeEventReadModelDiagnostic[],
 ): boolean {
-  return diagnostics.some(
-    (diagnostic) =>
-      diagnostic.code === 'incomplete_event' ||
-      diagnostic.code === 'unsupported_event' ||
-      diagnostic.code === 'tool_use_id_mismatch',
-  );
+  // The projection owns the hard/soft line: a diagnostic is hard only when a
+  // user-visible row may be missing. Restating the codes here would let the two
+  // drift apart and put half the policy in the caller.
+  return diagnostics.some(isHardRuntimeEventReadModelDiagnostic);
 }
 
 function readModelDiagnostic(

--- a/packages/runtime/src/runtime-read-model.ts
+++ b/packages/runtime/src/runtime-read-model.ts
@@ -293,7 +293,7 @@ export class RuntimeReadModel {
     if (canonicalPermissionRead.diagnostics.length > 0) {
       throw new RuntimeReadModelError('Canonical permission outcome read failed', diagnostics);
     }
-    if (hasHardProjectionDiagnostic(projected.diagnostics)) {
+    if (projected.diagnostics.some(isHardRuntimeEventReadModelDiagnostic)) {
       throw new RuntimeReadModelError('RuntimeEvent read projection is incomplete', diagnostics);
     }
 
@@ -443,15 +443,6 @@ function mergeInFlightProjectionCache(
 
 function messageTurnId(message: StoredMessage): string | undefined {
   return 'turnId' in message && typeof message.turnId === 'string' ? message.turnId : undefined;
-}
-
-function hasHardProjectionDiagnostic(
-  diagnostics: readonly RuntimeEventReadModelDiagnostic[],
-): boolean {
-  // The projection owns the hard/soft line: a diagnostic is hard only when a
-  // user-visible row may be missing. Restating the codes here would let the two
-  // drift apart and put half the policy in the caller.
-  return diagnostics.some(isHardRuntimeEventReadModelDiagnostic);
 }
 
 function readModelDiagnostic(


### PR DESCRIPTION
## Summary

One RuntimeEvent the projection does not claim made an entire session unreadable, even when every message in it was intact. The projection emitted a hard `unsupported_event` for any unrecognised shape, `RuntimeReadModel.buildView` throws on any hard diagnostic, and the whole projection was discarded — failing every `getSessionView` caller, not just the transcript: branching, revising, and every turn-scoped action went with it. #1607 was one instance; #1609 claimed those two shapes but left the amplification in place.

The hard failure is deliberate — it exists so messages are never silently dropped — so this splits it rather than relaxing it wholesale:

- unclaimed **and** content-bearing → a reader may be missing a row, the view is not faithful → stays `unsupported_event`, hard.
- unclaimed **and** control-only → there is no row to lose, while discarding the projection costs every intact message beside it → new `unclaimed_control_fact`, soft.

Severity now lives in one table keyed by code, so a new diagnostic cannot exist without deciding which side it falls on, and `buildView` asks the projection instead of restating the codes.

**What makes the soft side safe is claim coverage, not the absence of `content`.** Actions do own user-visible rows — `permissionDecision`, `tokenUsage`, and the terminal fact all produce one, and `runtime-event-backfill.ts` already writes a content-free event that projects to a visible `permission_decision`. Nothing with a row reaches the degrading branch only because every action field a reader can meet is claimed, so the projection-coverage contract now has to prove exactly that.

The contract previously enumerated `BackendSessionEvent['type']` alone, which left every RuntimeEvent produced outside `mapSessionEventToRuntimeEvent` uncovered — `tool-runtime`, `terminal-run-commit`, and `runtime-event-backfill` all write actions directly. It now also enumerates every field of `RuntimeEventActions`, keyed so a new field cannot compile without a sample and cannot pass without being claimed.

Writing that contract found three action fields the projection had never claimed: `artifactDelta`, `transferToAgent`, and `runtimeProtocol`. The first two have no emitter yet. **`runtimeProtocol` does** — `runtime-runner.ts` writes it, and `RecoveryResolver` reads it; it only ever avoided breaking a session because it has so far always ridden on an already-claimed carrier. All three are now claimed as control facts.

#1609 declined this downgrade because it "would hide a future projection gap". That is answered by keeping the two questions separate: severity decides whether a session opens, the coverage contract decides whether coverage is missing. The contract asserts on the union of both unclaimed codes, so softening a severity cannot soften the contract.

Closes #1613. Refs #1607, #1609.

## Verification

- `@maka/runtime` full suite: 2795 tests, 2786 pass, 0 fail, 9 skipped. `@maka/headless` 1428 pass, CLI 668 pass, 0 fail.
- End-to-end reproduction: a backend emits a `SessionEvent` variant the mapping was never taught, the turn completes through a real `sendMessage`, and the session reads back intact with the unclaimed event reported as one `unclaimed_control_fact`. Reverting the fallback to always-hard makes it fail with the original `RuntimeReadModelError`.
- Its counterpart pins the caller: appending a content-bearing unclaimed event to a completed run's ledger must make `getSessionView` throw. Verified to bite by making the fallback unconditionally soft.
- The coverage contract was checked in both directions: removing the `runtimeProtocol` claim fails it at runtime; removing its table entry fails compilation with `TS2741`.
- The unclaimed predicate is now asserted through itself, so dropping `unclaimed_control_fact` from it can no longer silently narrow both contracts to `unsupported_event`.
- Claim strictness is untouched: #1609's eight malformed-boundary counter-examples still assert the event stays unclaimed; only its severity moved.
- Test-merged with `fix/sandbox-boundary-pending-restart` (#1612), which touches the same file: auto-merges clean, combined suite green.
- `npm run format`, `npm run lint`, `npm run typecheck --workspaces` clean. Not run: desktop E2E — this change does not reach renderer or main.

## Review focus

A malformed control fact — one that half-matches a known shape — is soft alongside a genuinely unknown one. The read model is not the enforcement authority (boundary enforcement has its own durable revisions) and an unopenable session is the worst answer available, but if ledger corruption should outrank forward compatibility that argues for a third severity tier, which this PR does not add.

`stateDelta` is an open record, so the contract can only cover the field's existence, not new keys inside the delta. That limit is recorded in the table rather than papered over.

`artifactDelta` and `transferToAgent` are claimed as silent control facts before either has an emitter. If a hand-off should eventually render as a visible row, that claim is where it has to change.