### PR TITLE
feat: name permission modes and boundaries for what they grant

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -255,6 +255,7 @@ export const test = base.extend<{
   chatChromeWin32Window: Page;
   sidebarLongSessionsWindow: Page;
   sandboxBoundaryWindow: Page;
+  readOnlyBoundaryWindow: Page;
   staleSessionsWindow: Page;
   sessionWorkbarWindow: Page;
   botSettingsWindow: Page;
@@ -326,6 +327,17 @@ export const test = base.extend<{
   sandboxBoundaryWindow: async ({}, use) => {
     await withE2eWindow(
       { seed: false, readinessSelector: '.maka-sandbox-boundary-prompt', e2eFixtureScenario: 'sandbox-boundary', locale: 'zh' },
+      use,
+    );
+  },
+  // Read-only boundary (#1611): the Deep Research fixture session is seeded
+  // with `permissionMode: 'explore'`, so the metadata store derives a genesis
+  // managed read-only boundary for it. That makes this the only window where
+  // the composer's permission label is driven by a real read-only profile
+  // travelling main → IPC → renderer.
+  readOnlyBoundaryWindow: async ({}, use) => {
+    await withE2eWindow(
+      { seed: false, readinessSelector: '.maka-composer-textarea', e2eFixtureScenario: 'deep-research-progress', locale: 'zh' },
       use,
     );
   },

--- a/apps/desktop/e2e/permission-mode-surface.spec.ts
+++ b/apps/desktop/e2e/permission-mode-surface.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from './fixtures';
+
+/**
+ * #1611 + #1616: the composer's permission control is the only place a user
+ * learns what the running session may do. This covers the one journey that
+ * crosses the main/renderer boundary — a session whose stored boundary is a
+ * managed read-only profile — and checks that the surface names it, keeps the
+ * option list intact, and never hands the reader the word "沙箱".
+ */
+test('a read-only session names its boundary and can still be raised to full access', async ({
+  readOnlyBoundaryWindow: page,
+}) => {
+  const trigger = page.locator('.maka-composer-left-controls [data-slot="select-trigger"]');
+  await expect(trigger).toHaveText('只读');
+  await expect(trigger).toHaveAttribute('aria-label', '权限模式：只读');
+  await expect(trigger).toHaveAttribute(
+    'title',
+    '本会话只能读取和搜索工作区里的文件；写入文件或访问网络前会先来问你。',
+  );
+
+  await trigger.click();
+  const options = page.getByRole('option');
+  await expect(options).toHaveCount(2);
+  await expect(options.nth(0)).toContainText('自动');
+  await expect(options.nth(1)).toContainText('完全权限');
+  await expect(page.getByRole('listbox')).not.toContainText('沙箱');
+});

--- a/apps/desktop/e2e/permission-mode-surface.spec.ts
+++ b/apps/desktop/e2e/permission-mode-surface.spec.ts
@@ -1,11 +1,12 @@
 import { expect, test } from './fixtures';
 
+const READ_ONLY_HINT = '只读取和搜索，不写入文件、不访问网络；需要这些权限时会先来问你。';
+
 /**
  * #1611 + #1616: the composer's permission control is the only place a user
- * learns what the running session may do. This covers the one journey that
- * crosses the main/renderer boundary — a session whose stored boundary is a
- * managed read-only profile — and checks that the surface names it, keeps the
- * option list intact, and never hands the reader the word "沙箱".
+ * learns what the running session may do. These cover the journeys that cross
+ * the main/renderer boundary — a session whose stored boundary is a managed
+ * read-only profile, and the moment that boundary is widened.
  */
 test('a read-only session names its boundary and can still be raised to full access', async ({
   readOnlyBoundaryWindow: page,
@@ -13,10 +14,7 @@ test('a read-only session names its boundary and can still be raised to full acc
   const trigger = page.locator('.maka-composer-left-controls [data-slot="select-trigger"]');
   await expect(trigger).toHaveText('只读');
   await expect(trigger).toHaveAttribute('aria-label', '权限模式：只读');
-  await expect(trigger).toHaveAttribute(
-    'title',
-    '本会话只能读取和搜索工作区里的文件；写入文件或访问网络前会先来问你。',
-  );
+  await expect(trigger).toHaveAttribute('title', READ_ONLY_HINT);
 
   await trigger.click();
   const options = page.getByRole('option');
@@ -24,4 +22,55 @@ test('a read-only session names its boundary and can still be raised to full acc
   await expect(options.nth(0)).toContainText('自动');
   await expect(options.nth(1)).toContainText('完全权限');
   await expect(page.getByRole('listbox')).not.toContainText('沙箱');
+
+  // The read-only state is not one of the options, so nothing is selected —
+  // and the control must express that as "no value" rather than by handing the
+  // Select a value it does not know.
+  await expect(options.nth(0)).toHaveAttribute('aria-selected', 'false');
+  await expect(options.nth(1)).toHaveAttribute('aria-selected', 'false');
+
+  // Opening and dismissing the menu is not a choice: no mode may change.
+  await page.keyboard.press('Escape');
+  await expect(page.getByRole('listbox')).toHaveCount(0);
+  await expect(trigger).toHaveText('只读');
+
+  // Full access is one click away from a read-only session, and that click
+  // fires exactly one choice: a single confirmation, and cancelling it leaves
+  // the session where it was.
+  await trigger.click();
+  await page.getByRole('option').nth(1).click();
+  await expect(page.locator('.maka-confirm-modal')).toHaveCount(1);
+  await page.getByRole('button', { name: '保持自动' }).click();
+  await expect(page.locator('.maka-confirm-modal')).toHaveCount(0);
+  await expect(trigger).toHaveText('只读');
+
+  // Keyboard navigation still works with nothing selected, and choosing Auto
+  // is a real permission change.
+  await trigger.click();
+  await page.keyboard.press('ArrowDown');
+  await page.keyboard.press('Enter');
+  await expect(trigger).toHaveText('自动');
+});
+
+test('approving an expansion updates the permission label at once and after a reload', async ({
+  sandboxBoundaryWindow: page,
+}) => {
+  const prompt = page.locator('.maka-sandbox-boundary-prompt');
+  const trigger = page.locator('.maka-composer-left-controls [data-slot="select-trigger"]');
+
+  // The session runs read-only and is asking to write outside the workspace.
+  await expect(prompt).toHaveCount(1);
+
+  await prompt.getByRole('button', { name: '本会话允许' }).click();
+  await expect(prompt).toHaveCount(0);
+
+  // #1611: the grant only bumps the boundary's revision — no session field
+  // moves — so a surface that does not re-read authority would keep telling
+  // the user this session cannot write, right after they let it.
+  await expect(trigger).toHaveText('自动');
+
+  // And it is the boundary saying so, not renderer state: it survives a reload.
+  await page.reload();
+  await expect(page.locator('.maka-composer-textarea')).toBeVisible();
+  await expect(trigger).toHaveText('自动');
 });

--- a/apps/desktop/e2e/sandbox-boundary-takeover.spec.ts
+++ b/apps/desktop/e2e/sandbox-boundary-takeover.spec.ts
@@ -21,7 +21,7 @@ test('sandbox boundary request takes over the composer slot without hiding the w
   await expect(sandboxBoundaryWindow.locator('[role="dialog"]')).toHaveCount(0);
   await expect(sandboxBoundaryWindow.locator('.app')).not.toHaveAttribute('inert', '');
 
-  await expect(prompt.getByRole('heading', { name: '扩大本会话的沙箱边界？' })).toBeVisible();
+  await expect(prompt.getByRole('heading', { name: '允许访问工作区以外的内容？' })).toBeVisible();
   await expect(prompt.getByText('/outside/dist')).toBeVisible();
   await expect(prompt.getByText('写入 · 目录及子目录')).toBeVisible();
   await expect(prompt.getByRole('button', { name: '拒绝' })).toBeFocused();

--- a/apps/desktop/src/main/__tests__/active-execution-boundary-read-model.test.ts
+++ b/apps/desktop/src/main/__tests__/active-execution-boundary-read-model.test.ts
@@ -1,0 +1,104 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createReadOnlyPermissionProfile, createWorkspaceWritePermissionProfile } from '@maka/core';
+import type { SessionEvent } from '@maka/core';
+
+import { createAppShellSessionEventHandlers } from '../../renderer/app-shell-session-events.js';
+import { activeExecutionBoundaryOf } from '../../renderer/use-active-execution-boundary.js';
+import { deriveDesktopExecutionBoundarySurface } from '../../renderer/desktop-execution-boundary-surface.js';
+
+const readOnly = {
+  kind: 'managed',
+  profile: createReadOnlyPermissionProfile(),
+  revision: 0,
+} as const;
+const widened = {
+  kind: 'managed',
+  profile: createWorkspaceWritePermissionProfile(),
+  revision: 1,
+} as const;
+
+describe('Active execution boundary read model', () => {
+  it('never shows one session the boundary read for another', () => {
+    const snapshot = { sessionId: 'session-a', boundary: readOnly };
+
+    assert.equal(activeExecutionBoundaryOf(snapshot, 'session-a'), readOnly);
+    // Switching sessions falls closed until the new session's boundary is read,
+    // rather than briefly attributing the old session's permissions to it.
+    assert.equal(activeExecutionBoundaryOf(snapshot, 'session-b'), undefined);
+    assert.equal(activeExecutionBoundaryOf(snapshot, undefined), undefined);
+    assert.equal(activeExecutionBoundaryOf(undefined, 'session-a'), undefined);
+  });
+
+  it('a stale snapshot would misreport permissions the user just granted (#1611)', () => {
+    // Why the reload below has to exist: the two boundaries differ only in
+    // revision + profile, and they drive different labels.
+    assert.equal(
+      deriveDesktopExecutionBoundarySurface('session-a', readOnly, 'ask').permissionMode,
+      'explore',
+    );
+    assert.equal(
+      deriveDesktopExecutionBoundarySurface('session-a', widened, 'ask').permissionMode,
+      'ask',
+    );
+  });
+});
+
+describe('Boundary decisions notify the read model', () => {
+  function handlersWithRecorder() {
+    const boundaryChanges: string[] = [];
+    const handlers = createAppShellSessionEventHandlers({
+      uiLocale: 'zh',
+      activeIdRef: { current: 'session-a' },
+      liveTurnBySessionRef: { current: {} },
+      refreshMessages: async () => true,
+      refreshSessions: async () => [],
+      setLiveTurnBySession: () => {},
+      setInteractionBySession: () => {},
+      onExecutionBoundaryChanged: (sessionId) => boundaryChanges.push(sessionId),
+      showModelSetupToast: () => {},
+      toastApi: { error: () => {} },
+    });
+    return { handlers, boundaryChanges };
+  }
+
+  it('re-reads authority when a boundary decision is acknowledged', () => {
+    const { handlers, boundaryChanges } = handlersWithRecorder();
+
+    handlers.handleEvent('session-a', {
+      type: 'sandbox_boundary_decision_ack',
+      id: 'event-ack',
+      turnId: 'turn-1',
+      ts: 1,
+      requestId: 'request-1',
+      toolUseId: 'tool-1',
+      decision: 'allow',
+      status: 'approved',
+      revision: 1,
+    } satisfies SessionEvent);
+
+    // Approving an expansion moves only the boundary's revision: no session
+    // field changes, so without this signal the surface would keep rendering
+    // the permissions the session had before the user granted more.
+    assert.deepEqual(boundaryChanges, ['session-a']);
+  });
+
+  it('does not re-read on events that cannot move a boundary', () => {
+    const { handlers, boundaryChanges } = handlersWithRecorder();
+
+    handlers.handleEvent('session-a', {
+      type: 'sandbox_boundary_request',
+      id: 'event-request',
+      turnId: 'turn-1',
+      ts: 1,
+      requestId: 'request-1',
+      toolUseId: 'tool-1',
+      justification: 'write outside the workspace',
+      expansion: {
+        filesystem: { entries: [{ path: '/outside', access: 'write', scope: 'subtree' }] },
+      },
+    } satisfies SessionEvent);
+
+    assert.deepEqual(boundaryChanges, []);
+  });
+});

--- a/apps/desktop/src/main/__tests__/desktop-execution-boundary-surface.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-execution-boundary-surface.test.ts
@@ -1,6 +1,10 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
-import { createWorkspaceWritePermissionProfile } from '@maka/core';
+import {
+  createDangerFullAccessPermissionProfile,
+  createReadOnlyPermissionProfile,
+  createWorkspaceWritePermissionProfile,
+} from '@maka/core';
 
 import { deriveDesktopExecutionBoundarySurface } from '../../renderer/desktop-execution-boundary-surface.js';
 
@@ -29,6 +33,65 @@ describe('Desktop execution boundary surface', () => {
       ),
       {
         permissionMode: 'bypass',
+        localInteractionAvailable: true,
+      },
+    );
+  });
+
+  it('shows a read-only managed boundary as read-only instead of Auto (#1611)', () => {
+    assert.deepEqual(
+      deriveDesktopExecutionBoundarySurface(
+        'read-only',
+        {
+          kind: 'managed',
+          profile: createReadOnlyPermissionProfile(),
+          revision: 0,
+        },
+        'ask',
+      ),
+      {
+        permissionMode: 'explore',
+        localInteractionAvailable: true,
+      },
+    );
+    // Once an approved expansion grants a write, the session is no longer
+    // read-only and must stop claiming to be.
+    assert.deepEqual(
+      deriveDesktopExecutionBoundarySurface(
+        'expanded',
+        {
+          kind: 'managed',
+          profile: {
+            ...createReadOnlyPermissionProfile(),
+            fileSystem: {
+              kind: 'restricted',
+              entries: [
+                { kind: 'special', access: 'read', special: ':workspace_roots' },
+                { kind: 'path', access: 'write', path: '/workspace/out', match: 'subtree' },
+              ],
+            },
+          },
+          revision: 2,
+        },
+        'ask',
+      ),
+      {
+        permissionMode: 'ask',
+        localInteractionAvailable: true,
+      },
+    );
+    assert.deepEqual(
+      deriveDesktopExecutionBoundarySurface(
+        'danger-full-access',
+        {
+          kind: 'managed',
+          profile: createDangerFullAccessPermissionProfile(),
+          revision: 0,
+        },
+        'ask',
+      ),
+      {
+        permissionMode: 'ask',
         localInteractionAvailable: true,
       },
     );

--- a/apps/desktop/src/main/__tests__/desktop-execution-boundary-surface.test.ts
+++ b/apps/desktop/src/main/__tests__/desktop-execution-boundary-surface.test.ts
@@ -80,6 +80,14 @@ describe('Desktop execution boundary surface', () => {
         localInteractionAvailable: true,
       },
     );
+    // An intentional collapse, NOT a claim about this profile: the picker
+    // offers two modes and the product does not hand out `danger-full-access`,
+    // so no third label is invented for it. This is honest only because Auto's
+    // copy never names a specific boundary — it says the session runs inside
+    // Maka's protection layer and asks before going beyond its current
+    // permissions, which is true here too. If Auto's hint ever describes a
+    // concrete boundary again, this mapping turns into a false statement and
+    // has to be revisited.
     assert.deepEqual(
       deriveDesktopExecutionBoundarySurface(
         'danger-full-access',

--- a/apps/desktop/src/main/e2e-fixture/scenarios-chat.ts
+++ b/apps/desktop/src/main/e2e-fixture/scenarios-chat.ts
@@ -315,14 +315,21 @@ export function streamingMessages(now: number): StoredMessage[] {
 }
 
 export function permissionSession(now: number): SessionHeader {
-  return header({
-    id: PERMISSION_SESSION_ID,
-    name: '危险权限确认',
-    connection: 'zai-live',
-    model: 'glm-5.1',
-    now,
-    lastMessageAt: now - 4 * 60_000,
-  });
+  return {
+    ...header({
+      id: PERMISSION_SESSION_ID,
+      name: '危险权限确认',
+      connection: 'zai-live',
+      model: 'glm-5.1',
+      now,
+      lastMessageAt: now - 4 * 60_000,
+    }),
+    // A read-only session asking to write outside the workspace — the shape
+    // #1611 is about. Its genesis boundary is therefore read-only, so the
+    // permission label has something real to report both before the request is
+    // answered and after the expansion widens the boundary.
+    permissionMode: 'explore',
+  };
 }
 
 export function permissionMessages(now: number): StoredMessage[] {

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -13,6 +13,7 @@ import {
 } from '@maka/core';
 import type {
   CreateSessionRequestInput,
+  SandboxBoundaryExpansion,
   SessionEvent,
   SessionChangedEvent,
   SessionChangedReason,
@@ -342,7 +343,16 @@ export function registerSessionsIpc(
   ipcMain.handle('sessions:respondToSandboxBoundary', async (_event, sessionId: string, response) => {
     const normalized = normalizeSandboxBoundaryResponse(response);
     const fixtureRequest = getE2eFixtureState(e2eFixture)?.sandboxBoundaryBySession?.[sessionId];
-    if (fixtureRequest?.requestId === normalized.requestId) return;
+    if (fixtureRequest?.requestId === normalized.requestId) {
+      // The fixture request is synthetic — no runtime turn is waiting on it —
+      // but allowing it must still move the real boundary, or the fixture
+      // would model an "allow" that grants nothing and no surface built on the
+      // boundary could be exercised against it (#1611).
+      if (normalized.decision === 'allow') {
+        await applyFixtureSandboxBoundaryExpansion(store, sessionId, fixtureRequest.expansion);
+      }
+      return;
+    }
     if (normalized.decision === 'allow') {
       await ensureSessionWorkspaceAvailable(sessionId);
     }
@@ -613,5 +623,33 @@ export function registerSessionsIpc(
       automationManager.removeAllForSession(id);
       emitSessionsChanged('deleted', id);
     }
+  });
+}
+
+/**
+ * Apply an e2e-fixture boundary expansion through the real storage authority.
+ *
+ * The fixture's pending request is a synthetic event with no runtime turn
+ * behind it, so it cannot be settled the normal way. Creating and settling a
+ * genuine request with the same expansion keeps the boundary — which every
+ * permission surface reads — honest about what the user just granted, instead
+ * of leaving "allow" as a no-op the UI can silently contradict.
+ */
+async function applyFixtureSandboxBoundaryExpansion(
+  store: SessionStore,
+  sessionId: string,
+  expansion: SandboxBoundaryExpansion,
+): Promise<void> {
+  const created = await store.createSandboxBoundaryRequest?.({
+    sessionId,
+    requestId: randomUUID(),
+    expansion,
+    justification: 'e2e fixture expansion',
+  });
+  if (!created) return;
+  await store.settleSandboxBoundaryRequest?.({
+    sessionId,
+    requestId: created.requestId,
+    decision: 'allow',
   });
 }

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -643,6 +643,10 @@ async function applyFixtureSandboxBoundaryExpansion(
   const created = await store.createSandboxBoundaryRequest?.({
     sessionId,
     requestId: randomUUID(),
+    // Provenance is required so a real producer cannot drop it (#1612). This
+    // request has no turn to point at, so it names itself rather than
+    // borrowing an id that restart recovery could later attribute a closure to.
+    turnId: 'e2e-fixture-expansion',
     expansion,
     justification: 'e2e fixture expansion',
   });

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -139,6 +139,8 @@ export function createAppShellChatActions(deps: {
   setLiveTurnBySession: LiveTurnRecordUpdater;
   setInteractionBySession: InteractionQueueUpdater;
   onSandboxBoundaryInteractionChanged?: (sessionId: string) => void;
+  /** A boundary decision settled: the session's execution boundary may have moved. */
+  onExecutionBoundaryChanged?: (sessionId: string) => void;
   showModelSetupToast: (description: string, reason?: string) => void;
   toastApi: ToastApi;
   upsertSessionSummary: (session: SessionSummary) => void;
@@ -168,6 +170,7 @@ export function createAppShellChatActions(deps: {
     setLiveTurnBySession,
     setInteractionBySession,
     onSandboxBoundaryInteractionChanged,
+    onExecutionBoundaryChanged,
     showModelSetupToast,
     toastApi,
     upsertSessionSummary,
@@ -439,6 +442,11 @@ export function createAppShellChatActions(deps: {
     try {
       await window.maka.sessions.respondToSandboxBoundary(sessionId, response);
       onSandboxBoundaryInteractionChanged?.(sessionId);
+      // #1611: the answer has been applied to the authoritative boundary, so
+      // the permission label must stop describing the pre-decision one. The
+      // ack event covers decisions settled on other surfaces; this covers the
+      // one the user just made here, without waiting for the round trip.
+      onExecutionBoundaryChanged?.(sessionId);
       setInteractionBySession((current) =>
         dequeueInteractionByRequestId(current, sessionId, response.requestId),
       );

--- a/apps/desktop/src/renderer/app-shell-session-events.ts
+++ b/apps/desktop/src/renderer/app-shell-session-events.ts
@@ -41,6 +41,8 @@ export function createAppShellSessionEventHandlers(options: {
   setLiveTurnBySession: StateUpdater<Record<string, LiveTurnProjection>>;
   setInteractionBySession: StateUpdater<InteractionQueues>;
   onSandboxBoundaryInteractionChanged?: (sessionId: string) => void;
+  /** A boundary decision settled: the session's execution boundary may have moved. */
+  onExecutionBoundaryChanged?: (sessionId: string) => void;
   showModelSetupToast: (description: string, reason?: string) => void;
   toastApi: ToastApi;
   notifyRunEnded?: (payload: { kind: 'completed' | 'errored'; sessionId: string; body?: string }) => void;
@@ -54,6 +56,7 @@ export function createAppShellSessionEventHandlers(options: {
     setLiveTurnBySession,
     setInteractionBySession,
     onSandboxBoundaryInteractionChanged,
+    onExecutionBoundaryChanged,
     showModelSetupToast,
     toastApi,
     notifyRunEnded,
@@ -128,6 +131,11 @@ export function createAppShellSessionEventHandlers(options: {
         break;
       case 'sandbox_boundary_decision_ack':
         onSandboxBoundaryInteractionChanged?.(sessionId);
+        // #1611: an approved expansion changes only the boundary's revision —
+        // no session field moves — so the boundary read model has to be told,
+        // or the permission label keeps describing the permissions the session
+        // had before the user granted more.
+        onExecutionBoundaryChanged?.(sessionId);
         setInteractionBySession((current) =>
           dequeueInteractionByRequestId(current, sessionId, event.requestId),
         );

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -11,7 +11,6 @@ import {
   type SetStateAction,
 } from 'react';
 import type {
-  ExecutionBoundary,
   PlanReminder,
   QuoteRef,
   SessionSummary,
@@ -80,6 +79,7 @@ import { readNavigationState, selectNavigation } from './nav-selection';
 import { sessionMatchesNavSelection } from './session-nav-filter';
 import { deriveSessionRevisionNavigation } from './session-revisions';
 import { deriveDesktopExecutionBoundarySurface } from './desktop-execution-boundary-surface';
+import { useActiveExecutionBoundary } from './use-active-execution-boundary';
 import {
   SESSION_LIST_EXPANDED_MAX_WIDTH,
   SESSION_LIST_EXPANDED_MIN_WIDTH,
@@ -999,26 +999,8 @@ function AppShellContent({
     permissionMode: defaultPermissionMode,
         }
       : undefined);
-  const [activeExecutionBoundary, setActiveExecutionBoundary] = useState<
-    ExecutionBoundary | undefined
-  >();
-  useEffect(() => {
-    if (!activeId) {
-      setActiveExecutionBoundary(undefined);
-      return;
-    }
-    let cancelled = false;
-    setActiveExecutionBoundary(undefined);
-    void window.maka.sessions
-      .readExecutionBoundary(activeId)
-      .then((boundary) => {
-        if (!cancelled) setActiveExecutionBoundary(boundary);
-      })
-      .catch(() => {});
-    return () => {
-      cancelled = true;
-    };
-  }, [activeId, activeSessionForView?.permissionMode]);
+  const { boundary: activeExecutionBoundary, reload: reloadActiveExecutionBoundary } =
+    useActiveExecutionBoundary(activeId, activeSessionForView?.permissionMode);
   useEffect(() => {
     if (!activeId) return;
     let cancelled = false;
@@ -1345,6 +1327,7 @@ function AppShellContent({
     setLiveTurnBySession,
     setInteractionBySession,
     onSandboxBoundaryInteractionChanged: markSandboxBoundaryInteractionChanged,
+    onExecutionBoundaryChanged: reloadActiveExecutionBoundary,
     showModelSetupToast,
     toastApi,
     upsertSessionSummary,
@@ -1555,6 +1538,7 @@ function AppShellContent({
     setLiveTurnBySession,
     setInteractionBySession,
     onSandboxBoundaryInteractionChanged: markSandboxBoundaryInteractionChanged,
+    onExecutionBoundaryChanged: reloadActiveExecutionBoundary,
     showModelSetupToast,
     toastApi,
     notifyRunEnded: ({ kind, sessionId, body }) => {

--- a/apps/desktop/src/renderer/desktop-execution-boundary-surface.ts
+++ b/apps/desktop/src/renderer/desktop-execution-boundary-surface.ts
@@ -1,4 +1,5 @@
 import type { ExecutionBoundary, PermissionMode } from '@maka/core';
+import { isReadOnlyPermissionProfile } from '@maka/core';
 
 export interface DesktopExecutionBoundarySurface {
   permissionMode: PermissionMode | undefined;
@@ -22,8 +23,19 @@ export function deriveDesktopExecutionBoundarySurface(
       localInteractionAvailable: false,
     };
   }
+  // #1611: a managed boundary carries the whole profile, so a read-only
+  // session is a distinct fact from a writable one. Collapsing both to `ask`
+  // labelled read-only sessions "Auto" and gave them the Auto hint, which
+  // describes permissions they do not have. `explore` is the existing
+  // read-only display state; the option list is unchanged, so the user can
+  // still switch a read-only session to full access.
   return {
-    permissionMode: boundary.kind === 'bypass' ? 'bypass' : 'ask',
+    permissionMode:
+      boundary.kind === 'bypass'
+        ? 'bypass'
+        : isReadOnlyPermissionProfile(boundary.profile)
+          ? 'explore'
+          : 'ask',
     localInteractionAvailable: true,
   };
 }

--- a/apps/desktop/src/renderer/desktop-execution-boundary-surface.ts
+++ b/apps/desktop/src/renderer/desktop-execution-boundary-surface.ts
@@ -1,5 +1,5 @@
 import type { ExecutionBoundary, PermissionMode } from '@maka/core';
-import { isReadOnlyPermissionProfile } from '@maka/core';
+import { executionBoundaryDisplayMode } from '@maka/core';
 
 export interface DesktopExecutionBoundarySurface {
   permissionMode: PermissionMode | undefined;
@@ -17,25 +17,13 @@ export function deriveDesktopExecutionBoundarySurface(
       localInteractionAvailable: true,
     };
   }
-  if (!boundary || boundary.kind === 'external') {
-    return {
-      permissionMode: undefined,
-      localInteractionAvailable: false,
-    };
-  }
-  // #1611: a managed boundary carries the whole profile, so a read-only
-  // session is a distinct fact from a writable one. Collapsing both to `ask`
-  // labelled read-only sessions "Auto" and gave them the Auto hint, which
-  // describes permissions they do not have. `explore` is the existing
-  // read-only display state; the option list is unchanged, so the user can
-  // still switch a read-only session to full access.
-  return {
-    permissionMode:
-      boundary.kind === 'bypass'
-        ? 'bypass'
-        : isReadOnlyPermissionProfile(boundary.profile)
-          ? 'explore'
-          : 'ask',
-    localInteractionAvailable: true,
-  };
+  // #1611: the boundary is the authority on what the session may do, and
+  // `executionBoundaryDisplayMode` is the single place that maps it to a mode
+  // the user sees — shared with the TUI so the two surfaces cannot drift.
+  // Until it resolves (and permanently, for an externally isolated session)
+  // this surface fails closed: no mode, no local controls.
+  const permissionMode = boundary ? executionBoundaryDisplayMode(boundary) : undefined;
+  return permissionMode
+    ? { permissionMode, localInteractionAvailable: true }
+    : { permissionMode: undefined, localInteractionAvailable: false };
 }

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -914,8 +914,8 @@ const SHELL_COPY_BY_LOCALE = {
         bypass: '完全权限',
       },
       permissionDescriptions: {
-        explore: '只读：可以读取和搜索工作区文件，写入和网络访问会先来问你。',
-        ask: '自动：工作区内可写，网络受限；需要更大范围时会先来问你。',
+        explore: '只读：只读取和搜索，写入文件和访问网络会先来问你。',
+        ask: '自动：在 Maka 的保护层内执行；需要超出当前权限范围时会先来问你。',
         execute: '兼容模式：等同于自动。',
         bypass: '本地工具直接访问你的文件和网络，不经 Maka 的保护层。',
       },
@@ -982,7 +982,7 @@ const SHELL_COPY_BY_LOCALE = {
       settingsSections: ZH_SETTINGS_SECTIONS,
       permissionModes: {
         explore: { label: '权限 · 只读', hint: '读取和搜索直通，写入和网络仍需确认' },
-        ask: { label: '权限 · 自动', hint: '在受保护的环境中运行；需要访问工作区以外的内容时再询问' },
+        ask: { label: '权限 · 自动', hint: '在 Maka 的保护层内运行；需要超出当前权限范围时再询问' },
         execute: {
           label: '权限 · 自动执行',
           hint: '常见工具直通，破坏性操作仍确认',
@@ -1395,8 +1395,8 @@ const SHELL_COPY_BY_LOCALE = {
         bypass: 'Full access',
       },
       permissionDescriptions: {
-        explore: 'Read only: read and search workspace files; writes and network access ask you first.',
-        ask: 'Auto: write within the workspace, restrict network access, and ask before going further.',
+        explore: 'Read only: reads and searches only; writing files and network access ask you first.',
+        ask: "Auto: runs inside Maka's protection layer and asks before anything goes beyond the current permissions.",
         execute: 'Compatibility mode: same as Auto.',
         bypass: "Local tools reach your files and your network directly, outside Maka's protection layer.",
       },
@@ -1468,7 +1468,7 @@ const SHELL_COPY_BY_LOCALE = {
         },
         ask: {
           label: 'Permissions · Auto',
-          hint: 'Run inside a protected environment; ask before reaching outside the workspace',
+          hint: "Run inside Maka's protection layer; ask before going beyond the current permissions",
         },
         execute: {
           label: 'Permissions · Auto execute',

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -911,18 +911,18 @@ const SHELL_COPY_BY_LOCALE = {
     sessionSettingsActions: {
       permissionLabels: {
         ask: '自动',
-        bypass: '绕过沙箱',
+        bypass: '完全权限',
       },
       permissionDescriptions: {
-        explore: '兼容模式：使用只读托管边界。',
-        ask: '自动：工作区内可写，网络受限；需要更大范围时询问。',
-        execute: '兼容模式：映射到自动沙箱边界。',
-        bypass: '绕过 Maka 管理的本地沙箱边界。',
+        explore: '只读：可以读取和搜索工作区文件，写入和网络访问会先来问你。',
+        ask: '自动：工作区内可写，网络受限；需要更大范围时会先来问你。',
+        execute: '兼容模式：等同于自动。',
+        bypass: '本地工具直接访问你的文件和网络，不经 Maka 的保护层。',
       },
-      bypassConfirmTitle: '切换到绕过模式？',
+      bypassConfirmTitle: '切换到完全权限？',
       bypassConfirmDescription:
-        '本地工具将直接访问宿主机文件系统和网络。仅对你完全信任且已由外部环境隔离的任务使用。',
-      bypassConfirmLabel: '进入绕过模式',
+        '本地工具将直接读写你的文件并访问网络，不经 Maka 的保护层。仅用于你完全信任、或已在外部隔离环境中运行的任务。',
+      bypassConfirmLabel: '开启完全权限',
       bypassCancelLabel: '保持自动',
       permissionSwitched: (label: string) => `已切到 ${label}`,
       permissionFailedTitle: '切换权限模式失败',
@@ -981,15 +981,15 @@ const SHELL_COPY_BY_LOCALE = {
       commands: ZH_STATIC_COMMANDS,
       settingsSections: ZH_SETTINGS_SECTIONS,
       permissionModes: {
-        explore: { label: '权限 · 只读', hint: '读取和搜索直通，写入仍确认' },
-        ask: { label: '权限 · 自动', hint: '在会话沙箱内运行；扩大文件或网络边界时再询问' },
+        explore: { label: '权限 · 只读', hint: '读取和搜索直通，写入和网络仍需确认' },
+        ask: { label: '权限 · 自动', hint: '在受保护的环境中运行；需要访问工作区以外的内容时再询问' },
         execute: {
           label: '权限 · 自动执行',
           hint: '常见工具直通，破坏性操作仍确认',
         },
         bypass: {
-          label: '权限 · Bypass',
-          hint: '关闭 Maka 沙箱，开放宿主机文件系统和网络',
+          label: '权限 · 完全权限',
+          hint: '不经 Maka 的保护层，直接访问你的文件和网络',
         },
       },
       settingsCommand: (section: string) => `设置 · ${section}`,
@@ -1392,18 +1392,18 @@ const SHELL_COPY_BY_LOCALE = {
     sessionSettingsActions: {
       permissionLabels: {
         ask: 'Auto',
-        bypass: 'Bypass sandbox',
+        bypass: 'Full access',
       },
       permissionDescriptions: {
-        explore: 'Compatibility mode: use a managed read-only boundary.',
-        ask: 'Auto: write within the workspace, restrict network access, and ask before expanding.',
-        execute: 'Compatibility mode: map to the automatic sandbox boundary.',
-        bypass: 'Bypass the Maka-managed local sandbox boundary.',
+        explore: 'Read only: read and search workspace files; writes and network access ask you first.',
+        ask: 'Auto: write within the workspace, restrict network access, and ask before going further.',
+        execute: 'Compatibility mode: same as Auto.',
+        bypass: "Local tools reach your files and your network directly, outside Maka's protection layer.",
       },
-      bypassConfirmTitle: 'Switch to Bypass?',
+      bypassConfirmTitle: 'Switch to full access?',
       bypassConfirmDescription:
-        'Local tools will access the host filesystem and network directly. Use only for trusted tasks that are isolated externally.',
-      bypassConfirmLabel: 'Enter Bypass',
+        "Local tools will read and write your files and reach the network directly, outside Maka's protection layer. Use only for tasks you fully trust, or ones already isolated by their environment.",
+      bypassConfirmLabel: 'Turn on full access',
       bypassCancelLabel: 'Keep Auto',
       permissionSwitched: (label: string) => `Switched to ${label}`,
       permissionFailedTitle: 'Could not change permission mode',
@@ -1464,19 +1464,19 @@ const SHELL_COPY_BY_LOCALE = {
       permissionModes: {
         explore: {
           label: 'Permissions · Read only',
-          hint: 'Read and search directly; confirm writes',
+          hint: 'Read and search directly; confirm writes and network access',
         },
         ask: {
           label: 'Permissions · Auto',
-          hint: 'Run inside the session sandbox; ask only to expand filesystem or network access',
+          hint: 'Run inside a protected environment; ask before reaching outside the workspace',
         },
         execute: {
           label: 'Permissions · Auto execute',
           hint: 'Run common tools; confirm destructive actions',
         },
         bypass: {
-          label: 'Permissions · Bypass',
-          hint: 'Disable the Maka sandbox and expose host filesystem and network access',
+          label: 'Permissions · Full access',
+          hint: "Reach your files and your network directly, outside Maka's protection layer",
         },
       },
       settingsCommand: (section: string) => `Settings · ${section}`,

--- a/apps/desktop/src/renderer/use-active-execution-boundary.ts
+++ b/apps/desktop/src/renderer/use-active-execution-boundary.ts
@@ -1,0 +1,81 @@
+import type { ExecutionBoundary } from '@maka/core';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * A boundary snapshot together with the session it was read for, so a snapshot
+ * can never be shown against a different session.
+ */
+export interface ActiveExecutionBoundarySnapshot {
+  sessionId: string;
+  boundary: ExecutionBoundary;
+}
+
+/**
+ * The boundary belonging to `activeSessionId`, or `undefined` while none has
+ * been read for it yet. Fails closed on session switches without needing an
+ * explicit clear: a snapshot for another session simply does not match.
+ */
+export function activeExecutionBoundaryOf(
+  snapshot: ActiveExecutionBoundarySnapshot | undefined,
+  activeSessionId: string | undefined,
+): ExecutionBoundary | undefined {
+  if (!activeSessionId || snapshot?.sessionId !== activeSessionId) return undefined;
+  return snapshot.boundary;
+}
+
+/**
+ * The desktop's read model for the active session's execution boundary — the
+ * one place that decides when the renderer's copy of the boundary is stale.
+ *
+ * The boundary is main-process authority, so an Effect synchronising with it is
+ * the right tool; what this hook must never become is a mirror of renderer
+ * state. It therefore keeps exactly one fact (the last snapshot read from main)
+ * and re-reads on the two events that can change it: the active session
+ * changing, and a caller reporting that a boundary decision settled (#1611).
+ *
+ * Before #1611 the surface displayed every managed boundary as Auto, so a stale
+ * snapshot was invisible. Now that the label reports what the session may
+ * actually do, staleness would be an active false statement about permissions:
+ * a read-only session that has just been granted write access would keep
+ * showing "read only". Approving an expansion only bumps the boundary's
+ * revision — no session field changes — so nothing else here can notice it.
+ */
+export function useActiveExecutionBoundary(
+  activeSessionId: string | undefined,
+  /** Re-read when the session's stored permission mode changes under us. */
+  permissionMode: string | undefined,
+): {
+  boundary: ExecutionBoundary | undefined;
+  /** Report that this session's boundary may have changed; re-reads authority. */
+  reload(sessionId: string): void;
+} {
+  const [snapshot, setSnapshot] = useState<ActiveExecutionBoundarySnapshot | undefined>();
+  const [reloadNonce, setReloadNonce] = useState(0);
+  const activeSessionIdRef = useRef(activeSessionId);
+  useEffect(() => {
+    activeSessionIdRef.current = activeSessionId;
+  }, [activeSessionId]);
+
+  useEffect(() => {
+    if (!activeSessionId) return;
+    let cancelled = false;
+    void window.maka.sessions
+      .readExecutionBoundary(activeSessionId)
+      .then((boundary) => {
+        if (!cancelled) setSnapshot({ sessionId: activeSessionId, boundary });
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [activeSessionId, permissionMode, reloadNonce]);
+
+  const reload = useCallback((sessionId: string) => {
+    // Only the active session is read here, so a decision settled on any other
+    // session has nothing to refresh.
+    if (activeSessionIdRef.current !== sessionId) return;
+    setReloadNonce((nonce) => nonce + 1);
+  }, []);
+
+  return { boundary: activeExecutionBoundaryOf(snapshot, activeSessionId), reload };
+}

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1291,7 +1291,7 @@ describe('Maka Pi TUI transcript', () => {
     ).map(stripAnsi);
 
     assert.equal(state.pendingInteraction?.requestId, 'boundary-1');
-    assert.ok(visibleLines.some((line) => line.includes('Sandbox boundary expansion')));
+    assert.ok(visibleLines.some((line) => line.includes('Allow access outside the workspace?')));
     assert.ok(visibleLines.some((line) => line.includes('Read the user-selected file.')));
     assert.ok(visibleLines.some((line) => line.includes('read exact /outside/file.txt')));
     assert.ok(visibleLines.some((line) => line.includes('network enabled')));
@@ -5420,7 +5420,7 @@ describe('transcript entry render memoization', () => {
 });
 
 describe('Maka Pi TUI status line', () => {
-  test('renders managed compatibility modes as Auto and bypass as Bypass', () => {
+  test('renders managed compatibility modes as Auto and bypass as Full access', () => {
     for (const permissionMode of ['ask', 'execute', 'explore']) {
       const line = stripAnsi(renderMakaPiStatusLine({ ...meta(), permissionMode }, 100));
       assert.match(line, /Maka · Auto ·/);
@@ -5428,7 +5428,7 @@ describe('Maka Pi TUI status line', () => {
     }
     assert.match(
       stripAnsi(renderMakaPiStatusLine({ ...meta(), permissionMode: 'bypass' }, 100)),
-      /Maka · Bypass ·/,
+      /Maka · Full access ·/,
     );
   });
 

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -5420,12 +5420,19 @@ describe('transcript entry render memoization', () => {
 });
 
 describe('Maka Pi TUI status line', () => {
-  test('renders managed compatibility modes as Auto and bypass as Full access', () => {
-    for (const permissionMode of ['ask', 'execute', 'explore']) {
+  test('names the boundary the session is in: Read only, Auto, or Full access', () => {
+    // Legacy `execute` has no boundary of its own, so it really does read as
+    // Auto. `explore` is a boundary a resumed session can be in and must be
+    // named — showing it as Auto is the #1611 defect.
+    for (const permissionMode of ['ask', 'execute']) {
       const line = stripAnsi(renderMakaPiStatusLine({ ...meta(), permissionMode }, 100));
       assert.match(line, /Maka · Auto ·/);
       assert.doesNotMatch(line, new RegExp(`· ${permissionMode} ·`));
     }
+    assert.match(
+      stripAnsi(renderMakaPiStatusLine({ ...meta(), permissionMode: 'explore' }, 100)),
+      /Maka · Read only ·/,
+    );
     assert.match(
       stripAnsi(renderMakaPiStatusLine({ ...meta(), permissionMode: 'bypass' }, 100)),
       /Maka · Full access ·/,

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -4583,7 +4583,7 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('/permissions bypass');
     terminal.input('\r');
-    await waitFor(() => terminal.output().includes('Switch to Bypass?'));
+    await waitFor(() => terminal.output().includes('Switch to full access?'));
     assert.deepEqual(driver.permissionModes, []);
 
     terminal.input('\r');
@@ -4612,7 +4612,7 @@ describe('Maka Pi TUI runner', () => {
     await waitFor(() => driver.permissionModes.length === 1);
 
     assert.deepEqual(driver.permissionModes, ['ask']);
-    assert.doesNotMatch(terminal.output(), /Switch to Bypass/);
+    assert.doesNotMatch(terminal.output(), /Switch to full access/);
 
     exitMaka(terminal);
     await run;
@@ -4966,20 +4966,20 @@ describe('Maka Pi TUI runner', () => {
     terminal.input('/permissions');
     terminal.input('\r');
 
-    await waitFor(() => terminal.output().includes('Sandbox Boundary'));
+    await waitFor(() => terminal.output().includes('Permissions'));
     assertBottomPickerPlacement(
       terminal,
-      'Sandbox Boundary',
+      'Permissions',
       'Maka · Auto · claude-sonnet-4-5 · claude-subscription · /repo',
     );
     terminal.input('\x1b[B');
     terminal.input('\r');
-    await waitFor(() => terminal.output().includes('Switch to Bypass?'));
+    await waitFor(() => terminal.output().includes('Switch to full access?'));
     assert.deepEqual(driver.permissionModes, []);
     terminal.input('\x1b[B');
     terminal.input('\r');
     await waitFor(() => driver.permissionModes.length === 1);
-    await waitFor(() => terminal.output().includes('Sandbox boundary: Bypass'));
+    await waitFor(() => terminal.output().includes('Permissions: Full access'));
 
     assert.deepEqual(driver.permissionModes, ['bypass']);
     assert.deepEqual(driver.prompts, []);
@@ -6820,14 +6820,16 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('run');
     terminal.input('\r');
-    await waitFor(() => terminal.output().includes('Sandbox boundary expansion'));
+    await waitFor(() => terminal.output().includes('Allow access outside the workspace?'));
 
     terminal.input('y');
     await waitFor(() => driver.responses.length === 1);
     await delay(20);
 
     // Response rejected: error shows, but the boundary prompt stays and can be retried.
-    assert.ok(plainTerminalOutput(terminal.output()).includes('Sandbox boundary expansion'));
+    assert.ok(
+      plainTerminalOutput(terminal.output()).includes('Allow access outside the workspace?'),
+    );
 
     terminal.input('n');
     await waitFor(() => driver.responses.length === 2);
@@ -7614,13 +7616,13 @@ describe('Maka Pi TUI runner', () => {
 
     terminal.input('run');
     terminal.input('\r');
-    await waitFor(() => terminal.output().includes('Sandbox boundary expansion'));
+    await waitFor(() => terminal.output().includes('Allow access outside the workspace?'));
     driver.continueToError();
     await waitFor(() => terminal.output().includes('turn failed'));
 
     // The turn errored: the boundary prompt must be gone from the screen.
     assert.equal(
-      plainTerminalOutput(terminal.screenOutput()).includes('Sandbox boundary expansion'),
+      plainTerminalOutput(terminal.screenOutput()).includes('Allow access outside the workspace?'),
       false,
     );
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -4993,6 +4993,56 @@ describe('Maka Pi TUI runner', () => {
     ]);
   });
 
+  test('resumes a read-only session as Read only, and never marks Auto as current', async () => {
+    // #1611 in the TUI: the resumed boundary is read-only, so the status line
+    // must name it and the picker must not present Auto as "the option you are
+    // already on" — selecting it replaces a read-only boundary with a writable
+    // one, which is a permission change, not a confirmation.
+    const terminal = new FakeTerminal();
+    const driver = new SlashCommandDriver(
+      [fakeSessionSummary('session-2', '/repo')],
+      new Map(),
+      new Map([['session-2', 'explore' as PermissionMode]]),
+    );
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+      resumeSessionId: 'session-2',
+    });
+
+    await waitFor(() => driver.sessionIds.length === 1);
+    await waitFor(() =>
+      plainTerminalOutput(terminal.screenOutput()).includes('Maka · Read only ·'),
+    );
+
+    terminal.input('/permissions');
+    terminal.input('\r');
+    await waitFor(() => terminal.output().includes('Permissions'));
+    const picker = plainTerminalOutput(terminal.screenOutput());
+    assert.ok(picker.includes('Read only'), 'picker header names the boundary in force');
+    assert.doesNotMatch(picker, /current ·/);
+
+    // Selecting Auto is applied as the permission change it is.
+    terminal.input('\r');
+    await waitFor(() => driver.permissionModes.length === 1);
+    assert.deepEqual(driver.permissionModes, ['ask']);
+    await waitFor(() => terminal.output().includes('Permissions: Auto'));
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Maka · Auto ·'));
+
+    exitMaka(terminal);
+    await Promise.race([
+      run,
+      delay(50).then(() => {
+        throw new Error('TUI did not close during test cleanup');
+      }),
+    ]);
+  });
+
   test('handles /model without sending a prompt', async () => {
     const terminal = new FakeTerminal();
     const driver = new SlashCommandDriver();
@@ -9923,10 +9973,17 @@ class SlashCommandDriver implements MakaSessionDriver {
   resumeCalls = 0;
   protected sessionId = 'session-1';
   protected orchestrationMode: OrchestrationMode = 'default';
+  /**
+   * What the ACTIVE session's boundary says, as the real driver derives it
+   * (#1611). Undefined until a session is resumed, matching a driver that has
+   * no boundary to read yet.
+   */
+  protected activeBoundaryDisplayMode: PermissionMode | undefined;
 
   constructor(
     private readonly sessions: SessionSummary[] = [fakeSessionSummary('session-2', '/repo')],
     private readonly sessionMessages: ReadonlyMap<string, readonly StoredMessage[]> = new Map(),
+    private readonly boundaryDisplayModeBySession: ReadonlyMap<string, PermissionMode> = new Map(),
   ) {}
 
   async listSessions(): Promise<SessionSummary[]> {
@@ -10015,6 +10072,7 @@ class SlashCommandDriver implements MakaSessionDriver {
   }
   async setPermissionMode(mode: PermissionMode): Promise<void> {
     this.permissionModes.push(mode);
+    this.activeBoundaryDisplayMode = mode;
   }
   async setThinkingLevel(level: ThinkingLevel | undefined): Promise<void> {
     this.thinkingLevelUpdates.push(level);
@@ -10029,6 +10087,7 @@ class SlashCommandDriver implements MakaSessionDriver {
     const summary = this.sessions.find((session) => session.id === sessionId);
     const nextSummary = summary ?? fakeSessionSummary(sessionId);
     this.orchestrationMode = nextSummary.orchestrationMode ?? 'default';
+    this.activeBoundaryDisplayMode = this.boundaryDisplayModeBySession.get(nextSummary.id);
     return switchResult(nextSummary, [...(this.sessionMessages.get(nextSummary.id) ?? [])]);
   }
   async listRewindTargets(): Promise<RewindTarget[]> {
@@ -10040,12 +10099,16 @@ class SlashCommandDriver implements MakaSessionDriver {
   startNewSession(): void {
     this.startNewSessionCalls += 1;
     this.sessionId = 'session-new';
+    this.activeBoundaryDisplayMode = undefined;
   }
   getSessionId(): string | null {
     return this.sessionId;
   }
   getOrchestrationMode(): OrchestrationMode {
     return this.orchestrationMode;
+  }
+  getPermissionMode(): PermissionMode {
+    return this.activeBoundaryDisplayMode ?? 'ask';
   }
 }
 

--- a/packages/cli/src/__tests__/run-command.test.ts
+++ b/packages/cli/src/__tests__/run-command.test.ts
@@ -281,6 +281,15 @@ describe('maka run process contract', () => {
     assert.equal(result.stdout, 'prompt=continue this\n');
   });
 
+  test('names the mode the same way the desktop and TUI do (#1616)', async () => {
+    const help = await runFixture(['--help'], { input: '' });
+
+    assert.equal(help.code, 0, help.stderr);
+    assert.match(help.stdout, /--yolo\s+Give this session full access to your files and network/);
+    assert.doesNotMatch(help.stdout, /sandbox/i);
+    assert.doesNotMatch(help.stdout, /bypass/i);
+  });
+
   test('fails closed when resuming a bypass session without --yolo', async () => {
     const cwd = await realpath(process.cwd());
     const resumed = fixtureSession({
@@ -298,7 +307,10 @@ describe('maka run process contract', () => {
     });
 
     assert.equal(result.code, 2);
-    assert.match(result.stderr, /requires --yolo/i);
+    // The session id in this fixture is literally `resume-bypass`, so only the
+    // sentence itself is checked for the old name.
+    assert.match(result.stderr, /resuming a full-access session .* requires --yolo/i);
+    assert.doesNotMatch(result.stderr, /Bypass session/i);
     assert.equal(result.stdout, '');
   });
 

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -14,6 +14,9 @@ import type {
   UserMessageInput,
   UserQuestionResponse,
 } from '@maka/core';
+import { createGenesisExecutionBoundary, createReadOnlyPermissionProfile } from '@maka/core';
+import { permissionModeLabel } from '../pi-transcript.js';
+import { permissionModePickerItems } from '../pi-tui-pickers.js';
 import { createMakaSessionDriver } from '../session-driver.js';
 import type { RuntimeContinuation, SafeBoundaryContinuationPlan } from '@maka/runtime';
 
@@ -514,7 +517,80 @@ describe('Maka session driver', () => {
 
       const resumed = await driver.switchSession('bypass');
 
-      assert.equal(resumed.summary.permissionMode, 'bypass');
+      assert.equal(driver.getPermissionMode?.(), 'bypass');
+      // The summary is the runtime's, reported as-is: the boundary is what the
+      // display is derived from, so there is no reason to rewrite the header.
+      assert.equal(resumed.summary.permissionMode, 'ask');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test('presents a resumed read-only session as read-only, and never as the current Auto', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'maka-read-only-session-'));
+    try {
+      const runtime = new RecordingRuntime();
+      runtime.sessionSummaries = [
+        sessionSummary({ id: 'read-only', cwd: repo, permissionMode: 'ask' }),
+      ];
+      runtime.executionBoundaries.set('read-only', {
+        kind: 'managed',
+        profile: createReadOnlyPermissionProfile(),
+        revision: 4,
+      });
+      const driver = createMakaSessionDriver({
+        runtime,
+        cwd: repo,
+        llmConnectionSlug: 'anthropic',
+        model: 'claude-sonnet-4-5',
+      });
+
+      await driver.switchSession('read-only');
+
+      assert.equal(driver.getPermissionMode?.(), 'explore');
+      assert.equal(permissionModeLabel(driver.getPermissionMode!()), 'Read only');
+      // #1611: marking Auto as `current` here made "select the option I am
+      // already on" silently replace the read-only boundary with a writable
+      // one. Neither option may claim to be in force.
+      assert.deepEqual(
+        permissionModePickerItems(driver.getPermissionMode!()).map((item) => item.description),
+        ['protected', 'your files and network, unprotected'],
+      );
+
+      // Choosing Auto is therefore a real change, and it is applied.
+      await driver.setPermissionMode('ask');
+      assert.deepEqual(runtime.permissionModes, [{ sessionId: 'read-only', mode: 'ask' }]);
+      assert.equal(driver.getPermissionMode?.(), 'ask');
+    } finally {
+      await rm(repo, { recursive: true, force: true });
+    }
+  });
+
+  test('a fresh session does not inherit the resumed session read-only boundary', async () => {
+    const repo = await mkdtemp(join(tmpdir(), 'maka-read-only-new-'));
+    try {
+      const runtime = new RecordingRuntime();
+      runtime.sessionSummaries = [
+        sessionSummary({ id: 'read-only', cwd: repo, permissionMode: 'ask' }),
+      ];
+      runtime.executionBoundaries.set('read-only', {
+        kind: 'managed',
+        profile: createReadOnlyPermissionProfile(),
+        revision: 1,
+      });
+      const driver = createMakaSessionDriver({
+        runtime,
+        cwd: repo,
+        llmConnectionSlug: 'anthropic',
+        model: 'claude-sonnet-4-5',
+      });
+
+      await driver.switchSession('read-only');
+      driver.startNewSession();
+
+      assert.equal(driver.getPermissionMode?.(), 'ask');
+      await collectPrompt(driver, 'fresh session');
+      assert.equal(runtime.created.at(-1)?.permissionMode, 'ask');
     } finally {
       await rm(repo, { recursive: true, force: true });
     }
@@ -1199,6 +1275,9 @@ class RecordingRuntime {
 
   async setPermissionMode(sessionId: string, mode: PermissionMode): Promise<SessionSummary> {
     this.permissionModes.push({ sessionId, mode });
+    // The real runtime replaces the session's execution boundary when the mode
+    // changes; surfaces read that boundary, so the fake must move it too.
+    this.executionBoundaries.set(sessionId, createGenesisExecutionBoundary(mode));
     return {
       id: sessionId,
       name: 'New Chat',

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -664,7 +664,7 @@ export function applyMakaSessionEventToTranscript(
           state.entries.push({
             kind: 'notice',
             level: 'info',
-            text: `Sandbox boundary ${event.decision === 'allow' ? 'expanded' : 'unchanged'}`,
+            text: `Access ${event.decision === 'allow' ? 'expanded' : 'unchanged'}`,
           });
         }
       }
@@ -1229,7 +1229,7 @@ export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width
   const sep = ansi.dim(' · ');
   const parts: string[] = [
     ansi.bold(metadata.title),
-    ansi.dim(metadata.permissionMode === 'bypass' ? 'Bypass' : 'Auto'),
+    ansi.dim(metadata.permissionMode === 'bypass' ? 'Full access' : 'Auto'),
     ansi.dim(metadata.model),
   ];
   // #1064: omit thinking:default — it is noise before the user explicitly
@@ -1613,7 +1613,7 @@ function renderSandboxBoundaryPrompt(
   width: number,
 ): string[] {
   const lines = [
-    fitLine(ansi.yellow('Sandbox boundary expansion'), width),
+    fitLine(ansi.yellow('Allow access outside the workspace?'), width),
     ...renderIndented(request.justification, width, 2),
   ];
   for (const entry of request.expansion.filesystem?.entries ?? []) {

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -1224,12 +1224,25 @@ function transcriptEntrySignature(entry: MakaPiTranscriptEntry, width: number): 
   }
 }
 
+/**
+ * The one CLI label for a permission mode, shared by the status line, the
+ * picker header, and the mode-change notice (#1611). `explore` is a real
+ * boundary a resumed session can be in, so it must be nameable here; legacy
+ * `execute` has no boundary of its own and reads as Auto, as does anything
+ * else this metadata ever carries.
+ */
+export function permissionModeLabel(mode: string): string {
+  if (mode === 'bypass') return 'Full access';
+  if (mode === 'explore') return 'Read only';
+  return 'Auto';
+}
+
 export function renderMakaPiStatusLine(metadata: MakaPiTranscriptMetadata, width: number): string {
   const safeWidth = Math.max(1, width);
   const sep = ansi.dim(' · ');
   const parts: string[] = [
     ansi.bold(metadata.title),
-    ansi.dim(metadata.permissionMode === 'bypass' ? 'Full access' : 'Auto'),
+    ansi.dim(permissionModeLabel(metadata.permissionMode)),
     ansi.dim(metadata.model),
   ];
   // #1064: omit thinking:default — it is noise before the user explicitly

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -690,12 +690,15 @@ export function permissionModePickerItems(currentMode: PermissionMode): SelectIt
     {
       value: 'auto',
       label: 'Auto',
-      description: current === 'ask' ? 'current · sandboxed' : 'sandboxed',
+      description: current === 'ask' ? 'current · protected' : 'protected',
     },
     {
       value: 'bypass',
-      label: 'Bypass',
-      description: current === 'bypass' ? 'current · unrestricted' : 'unrestricted',
+      label: 'Full access',
+      description:
+        current === 'bypass'
+          ? 'current · your files and network, unprotected'
+          : 'your files and network, unprotected',
     },
   ];
 }

--- a/packages/cli/src/pi-tui-pickers.ts
+++ b/packages/cli/src/pi-tui-pickers.ts
@@ -684,19 +684,26 @@ export class ModelSearchOverlay implements Component {
   }
 }
 
+/**
+ * #1611: `current` marks an option that is genuinely in force, so choosing it
+ * is a no-op. A read-only session is neither of these options, and marking
+ * Auto as current there turned "confirm what I already have" into a silent
+ * widening of the boundary. Legacy `execute` has no boundary of its own and
+ * really does resolve to Auto, so it still marks Auto.
+ */
 export function permissionModePickerItems(currentMode: PermissionMode): SelectItem[] {
-  const current = currentMode === 'bypass' ? 'bypass' : 'ask';
+  const autoIsCurrent = currentMode === 'ask' || currentMode === 'execute';
   return [
     {
       value: 'auto',
       label: 'Auto',
-      description: current === 'ask' ? 'current · protected' : 'protected',
+      description: autoIsCurrent ? 'current · protected' : 'protected',
     },
     {
       value: 'bypass',
       label: 'Full access',
       description:
-        current === 'bypass'
+        currentMode === 'bypass'
           ? 'current · your files and network, unprotected'
           : 'your files and network, unprotected',
     },

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -70,6 +70,7 @@ import {
   activeUserQuestionRequest,
   completePendingInteraction,
   applyShellRunViewUpdateToTranscript,
+  permissionModeLabel,
   replaceTranscriptWithStoredMessages,
   submitCompactToTranscript,
   toggleAllThinkingExpansion,
@@ -1147,7 +1148,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     ) {
       modelContextWindow = undefined;
     }
-    permissionMode = summary.permissionMode;
+    // #1611: the driver derives this from the resumed session's execution
+    // boundary; `summary.permissionMode` is only what the header was last set
+    // to and goes stale as soon as an approved expansion widens the boundary.
+    permissionMode = input.driver.getPermissionMode?.() ?? summary.permissionMode;
     orchestrationMode = summary.orchestrationMode ?? 'default';
     thinkingLevel = summary.thinkingLevel;
     thinkingLevels = providerType ? thinkingVariantsForModel(providerType, summary.model) : [];
@@ -1771,6 +1775,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const newSession = () => {
     input.driver.startNewSession();
+    // A fresh session is not bound by the previous one's boundary; re-read the
+    // mode the next session will actually be created with.
+    permissionMode = input.driver.getPermissionMode?.() ?? permissionMode;
     attention.setBaseTitle(input.title);
     shellRunHydration.reset();
     // Fresh transcript for the fresh session; the next prompt creates it on disk.
@@ -1930,11 +1937,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const setPermissionMode = async (mode: PermissionMode) => {
     await input.driver.setPermissionMode(mode);
-    permissionMode = mode;
+    // Report the boundary that resulted, not the one that was requested.
+    permissionMode = input.driver.getPermissionMode?.() ?? mode;
     state.entries.push({
       kind: 'notice',
       level: 'info',
-      text: `Permissions: ${mode === 'bypass' ? 'Full access' : 'Auto'}`,
+      text: `Permissions: ${permissionModeLabel(permissionMode)}`,
     });
     requestRender();
   };
@@ -2141,10 +2149,14 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const showPermissionModeList = () => {
     const items = permissionModePickerItems(permissionMode);
-    const displayedMode = permissionMode === 'bypass' ? 'bypass' : 'auto';
+    // Where the cursor opens. It is NOT a claim about the current state —
+    // `permissionModePickerItems` marks `current` only on an option that is
+    // genuinely in force, so a read-only session marks neither and choosing
+    // Auto reads as the permission change it is.
+    const cursorValue = permissionMode === 'bypass' ? 'bypass' : 'auto';
     showSelectPicker(
       'Permissions',
-      displayedMode,
+      permissionModeLabel(permissionMode),
       items,
       (item) => {
         if (item.value === 'auto' || item.value === 'bypass') {
@@ -2154,7 +2166,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       {
         minPrimaryColumnWidth: 16,
         maxPrimaryColumnWidth: 24,
-        selectedIndex: items.findIndex((item) => item.value === displayedMode),
+        selectedIndex: items.findIndex((item) => item.value === cursorValue),
       },
     );
   };

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -1934,7 +1934,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     state.entries.push({
       kind: 'notice',
       level: 'info',
-      text: `Sandbox boundary: ${mode === 'bypass' ? 'Bypass' : 'Auto'}`,
+      text: `Permissions: ${mode === 'bypass' ? 'Full access' : 'Auto'}`,
     });
     requestRender();
   };
@@ -1948,17 +1948,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       {
         value: 'keep',
         label: 'Keep Auto',
-        description: 'Stay within the session sandbox boundary',
+        description: 'Stay inside the protected environment',
       },
       {
         value: 'bypass',
-        label: 'Enter Bypass',
+        label: 'Turn on full access',
         description:
-          'Expose the host filesystem and network; use only for trusted, externally isolated tasks',
+          'Reach your files and your network directly; use only for trusted or externally isolated tasks',
       },
     ];
     showSelectPicker(
-      'Switch to Bypass?',
+      'Switch to full access?',
       'keep',
       confirmation,
       (choice) => {
@@ -2143,7 +2143,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     const items = permissionModePickerItems(permissionMode);
     const displayedMode = permissionMode === 'bypass' ? 'bypass' : 'auto';
     showSelectPicker(
-      'Sandbox Boundary',
+      'Permissions',
       displayedMode,
       items,
       (item) => {
@@ -2304,7 +2304,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     },
     {
       name: 'permissions',
-      description: 'Set session sandbox boundary',
+      description: 'Set session permissions',
       run: (parts: string[]) => {
         if (parts.length === 1) {
           showPermissionModeList();

--- a/packages/cli/src/run-command.ts
+++ b/packages/cli/src/run-command.ts
@@ -281,7 +281,7 @@ export async function runMakaTextCli(
       if (parsed.options.yolo) {
         await context.runtime.setExecutionBoundaryKind(session.id, 'bypass');
       } else if (boundary.kind === 'bypass') {
-        throw new Error(`resuming Bypass session ${session.id} requires --yolo`);
+        throw new Error(`resuming a full-access session ${session.id} requires --yolo`);
       } else if (boundary.kind === 'external') {
         throw new Error(`cannot resume externally isolated session ${session.id} from maka run`);
       }
@@ -433,7 +433,7 @@ function makaRunHelpText(): string {
     '  --thinking <level>        off|minimal|low|medium|high|xhigh|max|default',
     '  --timeout <seconds>       Invocation timeout',
     '  --max-steps <count>       Tool-step cap',
-    '  --yolo                    Run this session with sandbox bypassed',
+    '  --yolo                    Give this session full access to your files and network',
     '  --resume <session-id>     Continue an explicit compatible session',
     '  --continue                Continue the latest compatible session for cwd',
     '  --graph                   Run this turn in Graph Mode and wait for graph completion',

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -7,6 +7,7 @@ import { resolve } from 'node:path';
 import type { QueueEnqueueOutcome, SessionEvent } from '@maka/core/events';
 import type { PermissionMode } from '@maka/core/permission';
 import type { ExecutionBoundary, SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
+import { executionBoundaryDisplayMode } from '@maka/core/sandbox-boundary';
 import type { UserQuestionResponse } from '@maka/core/user-question';
 import type {
   BranchFromTurnInput,
@@ -170,6 +171,13 @@ export interface MakaSessionDriver {
   stop(): Promise<void>;
   getSessionId(): string | null;
   getOrchestrationMode?(): OrchestrationMode;
+  /**
+   * The permission mode the ACTIVE session should be presented as, derived
+   * from its authoritative execution boundary (#1611). Available on
+   * Runtime-backed drivers; hosts without a boundary to read fall back to the
+   * summary they already hand the caller.
+   */
+  getPermissionMode?(): PermissionMode;
 }
 
 export type SessionResumeAvailability = { available: true } | { available: false; reason: string };
@@ -205,7 +213,16 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
   // /model switch can rebind it; new sessions are created on this connection.
   private llmConnectionSlug: string;
   private thinkingLevel: ThinkingLevel | undefined;
+  /** The mode the NEXT created session is given. */
   private permissionMode: PermissionMode;
+  /**
+   * How the ACTIVE session must be presented (#1611): derived from its
+   * execution boundary, which is the authority on what it may actually do.
+   * Kept apart from `permissionMode` on purpose — a resumed read-only session
+   * must read as read-only without making read-only the default for the next
+   * session started with `/new`.
+   */
+  private activeBoundaryDisplayMode: PermissionMode | undefined;
   private orchestrationMode: OrchestrationMode;
   private readonly newId: () => string;
 
@@ -349,6 +366,11 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     if (this.sessionId) {
       const summary = await this.input.runtime.setPermissionMode(this.sessionId, mode);
       this.permissionMode = summary.permissionMode;
+      // An explicit switch replaces the boundary, so re-derive rather than
+      // assume the requested mode landed exactly as asked.
+      this.activeBoundaryDisplayMode = executionBoundaryDisplayMode(
+        await this.input.runtime.readExecutionBoundary(this.sessionId),
+      );
       return;
     }
     this.permissionMode = mode;
@@ -399,19 +421,24 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
         `Cannot resume externally isolated session ${summary.id} outside its owning harness.`,
       );
     }
-    const effectiveSummary: SessionSummary = {
-      ...summary,
-      permissionMode: boundary.kind === 'bypass' ? 'bypass' : 'ask',
-    };
-    const messages = await this.input.runtime.getMessages(effectiveSummary.id);
-    this.sessionId = effectiveSummary.id;
+    // #1611: the boundary — not the stored header mode — decides how this
+    // session is presented, and the summary is left exactly as the runtime
+    // returned it. Overwriting `summary.permissionMode` here used to label a
+    // read-only session "Auto", which the picker then marked as the current
+    // option; choosing that "current" option silently replaced the read-only
+    // boundary with a writable one.
+    const displayMode = executionBoundaryDisplayMode(boundary);
+    const messages = await this.input.runtime.getMessages(summary.id);
+    this.sessionId = summary.id;
     this.cwd = sessionCwd;
-    this.model = effectiveSummary.model;
-    this.llmConnectionSlug = effectiveSummary.llmConnectionSlug;
-    this.thinkingLevel = effectiveSummary.thinkingLevel;
-    this.permissionMode = effectiveSummary.permissionMode;
-    this.orchestrationMode = effectiveSummary.orchestrationMode ?? 'default';
-    return { summary: effectiveSummary, messages };
+    this.model = summary.model;
+    this.llmConnectionSlug = summary.llmConnectionSlug;
+    this.thinkingLevel = summary.thinkingLevel;
+    this.activeBoundaryDisplayMode = displayMode;
+    // New sessions started after this one still default to a normal mode.
+    this.permissionMode = boundary.kind === 'bypass' ? 'bypass' : 'ask';
+    this.orchestrationMode = summary.orchestrationMode ?? 'default';
+    return { summary, messages };
   }
 
   async listRewindTargets(): Promise<RewindTarget[]> {
@@ -463,6 +490,8 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
     // stay put, so the next prompt lazily creates a fresh session that inherits
     // them (via ensureSession). The old session is left intact on disk.
     this.sessionId = null;
+    // The previous session's boundary says nothing about the next one.
+    this.activeBoundaryDisplayMode = undefined;
   }
 
   getSessionId(): string | null {
@@ -471,6 +500,10 @@ class RuntimeMakaSessionDriver implements MakaSessionDriver {
 
   getOrchestrationMode(): OrchestrationMode {
     return this.orchestrationMode;
+  }
+
+  getPermissionMode(): PermissionMode {
+    return this.activeBoundaryDisplayMode ?? this.permissionMode;
   }
 
   private async ensureSession(): Promise<string> {

--- a/packages/core/src/__tests__/permission-profile.test.ts
+++ b/packages/core/src/__tests__/permission-profile.test.ts
@@ -8,7 +8,9 @@ import {
   createWorkspaceWritePermissionProfile,
   isDeniedPath,
   isProtectedMetadataPath,
+  isReadOnlyPermissionProfile,
   type PermissionProfile,
+  type PermissionProfileManaged,
 } from '../permission-profile.js';
 
 const WORKSPACE_CONTEXT = {
@@ -75,6 +77,40 @@ describe('PermissionProfile factories', () => {
     expect(profile.network.kind).toBe('enabled');
     expect(canReadPath(profile, '/etc/passwd')).toBe(true);
     expect(canWritePath(profile, '/var/log/maka.log')).toBe(true);
+  });
+});
+
+describe('isReadOnlyPermissionProfile', () => {
+  test('separates the read-only profile from every profile that grants more', () => {
+    expect(isReadOnlyPermissionProfile(createReadOnlyPermissionProfile())).toBe(true);
+    expect(isReadOnlyPermissionProfile(createWorkspaceWritePermissionProfile())).toBe(false);
+    expect(isReadOnlyPermissionProfile(createDangerFullAccessPermissionProfile())).toBe(false);
+  });
+
+  test('follows the policy rather than the profile name', () => {
+    const widenedByExpansion: PermissionProfileManaged = {
+      ...createReadOnlyPermissionProfile(),
+      fileSystem: {
+        kind: 'restricted',
+        entries: [
+          { kind: 'special', access: 'read', special: ':workspace_roots' },
+          { kind: 'path', access: 'write', path: '/workspace/out', match: 'subtree' },
+        ],
+      },
+    };
+    expect(isReadOnlyPermissionProfile(widenedByExpansion)).toBe(false);
+
+    const networkEnabled: PermissionProfileManaged = {
+      ...createReadOnlyPermissionProfile(),
+      network: { kind: 'enabled' },
+    };
+    expect(isReadOnlyPermissionProfile(networkEnabled)).toBe(false);
+
+    const renamedButStillReadOnly: PermissionProfileManaged = {
+      ...createReadOnlyPermissionProfile(),
+      name: 'custom',
+    };
+    expect(isReadOnlyPermissionProfile(renamedButStillReadOnly)).toBe(true);
   });
 });
 

--- a/packages/core/src/__tests__/sandbox-boundary.test.ts
+++ b/packages/core/src/__tests__/sandbox-boundary.test.ts
@@ -7,14 +7,67 @@ import {
   createGenesisExecutionBoundary,
   decodeExecutionBoundary,
   executionBoundaryContains,
+  executionBoundaryDisplayMode,
   validateSandboxBoundaryExpansion,
 } from '../sandbox-boundary.js';
 import {
   canReadPath,
   canWritePath,
+  createDangerFullAccessPermissionProfile,
+  createReadOnlyPermissionProfile,
   createWorkspaceWritePermissionProfile,
   type PermissionProfileManaged,
 } from '../permission-profile.js';
+
+describe('executionBoundaryDisplayMode', () => {
+  test('keeps the read-only/writable distinction the boundary carries (#1611)', () => {
+    expect(
+      executionBoundaryDisplayMode({
+        kind: 'managed',
+        profile: createReadOnlyPermissionProfile(),
+        revision: 0,
+      }),
+    ).toBe('explore');
+    expect(
+      executionBoundaryDisplayMode({
+        kind: 'managed',
+        profile: createWorkspaceWritePermissionProfile(),
+        revision: 0,
+      }),
+    ).toBe('ask');
+    expect(executionBoundaryDisplayMode({ kind: 'bypass', revision: 1 })).toBe('bypass');
+  });
+
+  test('an approved expansion that grants a write stops reading as read-only', () => {
+    const widened = applySandboxBoundaryExpansion(createReadOnlyPermissionProfile(), {
+      filesystem: { entries: [{ path: '/outside/dist', access: 'write', scope: 'subtree' }] },
+    });
+
+    expect(executionBoundaryDisplayMode({ kind: 'managed', profile: widened, revision: 1 })).toBe(
+      'ask',
+    );
+  });
+
+  test('under-states danger-full-access as Auto rather than naming a mode for it', () => {
+    // A deliberate collapse, NOT a description of this profile: the picker
+    // offers two modes and no third one is being invented for a profile the
+    // product does not hand out. Auto's copy is written to stay true here —
+    // it never claims a specific boundary — so this under-states rather than
+    // misstates. If Auto's hint ever names a boundary again, this mapping
+    // becomes a lie and has to change with it.
+    expect(
+      executionBoundaryDisplayMode({
+        kind: 'managed',
+        profile: createDangerFullAccessPermissionProfile(),
+        revision: 0,
+      }),
+    ).toBe('ask');
+  });
+
+  test('an externally isolated boundary has no locally controllable mode', () => {
+    expect(executionBoundaryDisplayMode({ kind: 'external', revision: 0 })).toBe(undefined);
+  });
+});
 
 describe('SandboxBoundaryExpansion', () => {
   test('accepts and canonicalizes only additive filesystem and network authority', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -576,6 +576,7 @@ export {
   createManagedExecutionBoundary,
   decodeExecutionBoundary,
   executionBoundaryContains,
+  executionBoundaryDisplayMode,
   isSandboxBoundaryRestartClosure,
   sandboxBoundaryExpansionAllowsPath,
   validateSandboxBoundaryExpansion,

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -533,6 +533,7 @@ export {
   createWorkspaceWritePermissionProfile,
   isDeniedPath,
   isProtectedMetadataPath,
+  isReadOnlyPermissionProfile,
 } from './permission-profile.js';
 
 // sandbox-boundary.ts

--- a/packages/core/src/permission-profile.ts
+++ b/packages/core/src/permission-profile.ts
@@ -117,6 +117,23 @@ export function createReadOnlyPermissionProfile(): PermissionProfileManaged {
   };
 }
 
+/**
+ * True when a managed profile grants nothing beyond reading: no filesystem
+ * entry allows writing and the network stays restricted.
+ *
+ * This is the fact a permission surface needs to tell a read-only session
+ * apart from a writable one (#1611). It is derived from the policy rather
+ * than from `name`, so a profile widened by an approved boundary expansion
+ * stops reading as read-only even when its name never changed.
+ */
+export function isReadOnlyPermissionProfile(profile: PermissionProfileManaged): boolean {
+  return (
+    profile.fileSystem.kind === 'restricted' &&
+    profile.network.kind === 'restricted' &&
+    !profile.fileSystem.entries.some((entry) => entry.access === 'write')
+  );
+}
+
 export function createWorkspaceWritePermissionProfile(): PermissionProfileManaged {
   return {
     type: 'managed',

--- a/packages/core/src/sandbox-boundary.ts
+++ b/packages/core/src/sandbox-boundary.ts
@@ -1,3 +1,4 @@
+import type { PermissionMode } from './permission.js';
 import {
   FILE_SYSTEM_ACCESS_MODES,
   FILE_SYSTEM_PATH_MATCHES,
@@ -5,6 +6,7 @@ import {
   createReadOnlyPermissionProfile,
   createWorkspaceWritePermissionProfile,
   isProtectedMetadataPath,
+  isReadOnlyPermissionProfile,
   type FileSystemPathMatch,
   type FileSystemSandboxEntry,
   type PermissionProfileManaged,
@@ -141,6 +143,33 @@ export type ExecutionBoundary =
     };
 
 export type LegacyPermissionMode = 'ask' | 'execute' | 'explore' | 'bypass';
+
+/**
+ * The permission mode a boundary should be *presented* as (#1611).
+ *
+ * The boundary is the authority on what a session may do; a session header's
+ * stored `permissionMode` is only what it was last set to and goes stale the
+ * moment an approved expansion widens the boundary. Every surface that shows
+ * the user which permissions are in force derives them here, so Desktop and
+ * the TUI cannot drift — and so the read-only/writable distinction the
+ * boundary carries survives all the way to the label.
+ *
+ * `undefined` means the session is not locally controllable at all (an
+ * externally isolated boundary), which each surface fails closed on.
+ *
+ * Everything managed that is not read-only maps to `ask`. That is a
+ * deliberate under-statement, not a description: a workspace-write profile,
+ * a profile widened by approved expansions, and `danger-full-access` all
+ * present as Auto. Auto's copy is therefore written to stay true for any of
+ * them — it never claims a specific boundary.
+ */
+export function executionBoundaryDisplayMode(
+  boundary: ExecutionBoundary,
+): PermissionMode | undefined {
+  if (boundary.kind === 'external') return undefined;
+  if (boundary.kind === 'bypass') return 'bypass';
+  return isReadOnlyPermissionProfile(boundary.profile) ? 'explore' : 'ask';
+}
 
 export function createGenesisExecutionBoundary(mode: LegacyPermissionMode): ExecutionBoundary {
   if (mode === 'bypass') return { kind: 'bypass', revision: 0 };

--- a/packages/ui/src/__tests__/conversation-localization.test.tsx
+++ b/packages/ui/src/__tests__/conversation-localization.test.tsx
@@ -259,12 +259,12 @@ describe('localized conversation journey', () => {
     const zh = render('zh', surface);
     const en = render('en', surface);
 
-    assert.match(zh, /扩大本会话的沙箱边界？/);
+    assert.match(zh, /允许访问工作区以外的内容？/);
     assert.match(zh, /读取 · 仅此路径/);
     assert.match(zh, /写入 · 目录及子目录/);
     assert.match(zh, /网络访问/);
     assert.match(zh, /本会话允许/);
-    assert.match(en, /Expand this session&#x27;s sandbox boundary\?/);
+    assert.match(en, /Allow access outside the workspace\?/);
     assert.match(en, /Read · Exact path/);
     assert.match(en, /Write · Directory subtree/);
     assert.match(en, /Network access/);

--- a/packages/ui/src/__tests__/permission-mode-menu.test.tsx
+++ b/packages/ui/src/__tests__/permission-mode-menu.test.tsx
@@ -1,0 +1,74 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { PermissionMode, UiLocale } from '@maka/core';
+import { PERMISSION_MODES } from '@maka/core';
+import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { getConversationCopy } from '../conversation-copy.js';
+import { LocaleProvider } from '../locale-context.js';
+import { PermissionModeSelect, getPermissionModeMeta } from '../permission-mode-menu.js';
+
+function render(locale: UiLocale, mode: PermissionMode): string {
+  return renderToStaticMarkup(
+    <LocaleProvider locale={locale}>
+      <PermissionModeSelect activeMode={mode} onSelect={() => {}} />
+    </LocaleProvider>,
+  );
+}
+
+describe('Permission mode surface', () => {
+  it('shows a read-only session as read-only, with its own hint (#1611)', () => {
+    for (const locale of ['zh', 'en'] as const) {
+      const meta = getPermissionModeMeta(locale);
+      const markup = render(locale, 'explore');
+
+      assert.match(markup, new RegExp(escapeRegExp(escapeMarkup(meta.explore.label))));
+      assert.match(markup, new RegExp(escapeRegExp(escapeMarkup(meta.explore.hint))));
+      assert.doesNotMatch(markup, new RegExp(escapeRegExp(escapeMarkup(meta.ask.hint))));
+    }
+  });
+
+  it('keeps legacy execute sessions collapsed to Auto', () => {
+    for (const locale of ['zh', 'en'] as const) {
+      const meta = getPermissionModeMeta(locale);
+      const markup = render(locale, 'execute');
+
+      assert.match(markup, new RegExp(escapeRegExp(escapeMarkup(meta.ask.label))));
+      assert.doesNotMatch(markup, new RegExp(escapeRegExp(escapeMarkup(meta.execute.hint))));
+    }
+  });
+
+  it('names the dangerous mode for what it grants, not for the mechanism it turns off (#1616)', () => {
+    const zh = getPermissionModeMeta('zh');
+    const en = getPermissionModeMeta('en');
+
+    assert.equal(zh.bypass.label, '完全权限');
+    assert.equal(en.bypass.label, 'Full access');
+    assert.equal(zh.bypass.tone, 'destructive');
+    assert.equal(en.bypass.tone, 'destructive');
+    assert.match(render('zh', 'bypass'), /完全权限/);
+    assert.match(render('en', 'bypass'), /Full access/);
+  });
+
+  it('never hands the reader the word "sandbox" in a permission label or hint (#1616)', () => {
+    for (const locale of ['zh', 'en'] as const) {
+      const copy = getConversationCopy(locale);
+      for (const mode of PERMISSION_MODES) {
+        const { label, hint } = copy.permissions.mode[mode];
+        assert.doesNotMatch(`${label} ${hint}`, /沙箱|sandbox/i, `${locale} ${mode}`);
+      }
+      assert.doesNotMatch(copy.sandboxBoundary.title, /沙箱|sandbox/i, locale);
+    }
+  });
+});
+
+function escapeMarkup(value: string): string {
+  return value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(
+    /"/g,
+    '&quot;',
+  ).replace(/'/g, '&#x27;');
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/ui/src/__tests__/permission-mode-menu.test.tsx
+++ b/packages/ui/src/__tests__/permission-mode-menu.test.tsx
@@ -39,15 +39,24 @@ describe('Permission mode surface', () => {
   });
 
   it('names the dangerous mode for what it grants, not for the mechanism it turns off (#1616)', () => {
-    const zh = getPermissionModeMeta('zh');
-    const en = getPermissionModeMeta('en');
-
-    assert.equal(zh.bypass.label, '完全权限');
-    assert.equal(en.bypass.label, 'Full access');
-    assert.equal(zh.bypass.tone, 'destructive');
-    assert.equal(en.bypass.tone, 'destructive');
+    assert.equal(getPermissionModeMeta('zh').bypass.label, '完全权限');
+    assert.equal(getPermissionModeMeta('en').bypass.label, 'Full access');
     assert.match(render('zh', 'bypass'), /完全权限/);
     assert.match(render('en', 'bypass'), /Full access/);
+  });
+
+  it('carries no Select value when the display state is not one of the options', () => {
+    // The read-only state has no option to select, which the Select must be
+    // told as "no value". Passing an unmatched value instead would leave the
+    // control depending on Base UI treating it as stale and resetting it.
+    const readOnly = render('zh', 'explore');
+    assert.match(readOnly, /hidden-input[^>]*value=""/);
+    assert.doesNotMatch(readOnly, /hidden-input[^>]*value="explore"/);
+
+    // A state that IS an option still selects it, so the check indicator and
+    // keyboard restore keep working.
+    assert.match(render('zh', 'ask'), /hidden-input[^>]*value="ask"/);
+    assert.match(render('zh', 'bypass'), /hidden-input[^>]*value="bypass"/);
   });
 
   it('never hands the reader the word "sandbox" in a permission label or hint (#1616)', () => {

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -907,12 +907,10 @@ export const Composer = forwardRef<
             {/* PR-MOVE-PERMISSION-MODE: the static "通用" role chip
                 was replaced by the permission-mode dropdown — that
                 spot is where the reference Settings expects users to
-                pick "Ask permissions" / "Auto mode" / "Bypass
-                permissions". Maka exposes the user-facing modes
-                `ask` / `execute` / `bypass`; `explore` collapses to `ask` in the
-                display because Deep Research sessions use it
-                internally but it's not a useful runtime toggle for
-                normal chat. */}
+                pick a permission mode. Maka offers Auto (`ask`) and
+                full access (`bypass`); a session running under a
+                read-only boundary displays as such (#1611) without
+                becoming a third option. */}
             {props.onPermissionModeChange ? (
               <PermissionModeSelect
                 appearance="quiet"

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -197,11 +197,10 @@ export const Composer = forwardRef<
      * PR-MOVE-PERMISSION-MODE (WAWQAQ 47fe0d0e + a667cf6c): the
      * permission mode picker lives inside the composer left-controls
      * instead of the chat header. Composer renders a dropdown labelled
-     * by the current mode (询问权限 / 自动执行 / 跳过确认);
-     * selecting an option fires `onPermissionModeChange`. When the
-     * active session is in the legacy `explore` mode the picker
-     * collapses to display 询问权限 — explore is internal-only now and
-     * won't surface here.
+     * by the mode the session's boundary is actually in (只读 / 自动 /
+     * 完全权限); selecting an option fires `onPermissionModeChange`.
+     * A read-only session displays 只读 without it becoming a third
+     * option (#1611).
      */
     permissionMode?: PermissionMode;
     permissionModePending?: boolean;

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -332,15 +332,15 @@ const CONVERSATION_COPY = {
     },
     permissions: {
       mode: {
-        explore: { label: '只读模式', hint: '读取、列表和搜索直接执行；写入或网络操作仍需明确确认。Deep Research 默认使用此模式。' },
-        ask: { label: '自动', hint: '在会话沙箱内自动执行；需要扩大文件或网络边界时再询问。' },
+        explore: { label: '只读', hint: '本会话只能读取和搜索工作区里的文件；写入文件或访问网络前会先来问你。' },
+        ask: { label: '自动', hint: '在受保护的环境中自动执行；需要访问工作区以外的文件或网络时再来问你。' },
         execute: { label: '自动执行', hint: '常见工具直接执行；破坏性、特权和浏览器操作仍会请求确认。' },
-        bypass: { label: '绕过沙箱', hint: '本会话中的本地工具不受沙箱限制。仅在完全信任任务时使用。' },
+        bypass: { label: '完全权限', hint: '本地工具直接访问你的文件和网络，不经 Maka 的保护层。仅用于你完全信任的任务。' },
       },
       modeAriaLabel: (label) => `权限模式：${label}`,
     },
     sandboxBoundary: {
-      title: '扩大本会话的沙箱边界？',
+      title: '允许访问工作区以外的内容？',
       access: { read: '读取', write: '写入' },
       scope: { exact: '仅此路径', subtree: '目录及子目录' },
       network: '网络访问',
@@ -468,15 +468,15 @@ const CONVERSATION_COPY = {
     },
     permissions: {
       mode: {
-        explore: { label: 'Read only', hint: 'Read, list, and search run directly; writes and network access still require confirmation. Deep Research uses this mode by default.' },
-        ask: { label: 'Auto', hint: 'Run automatically inside the session sandbox; ask only when file or network boundaries must expand.' },
+        explore: { label: 'Read only', hint: 'This conversation can read and search files in the workspace; it asks you before writing a file or reaching the network.' },
+        ask: { label: 'Auto', hint: 'Runs automatically inside a protected environment; asks you before reaching files outside the workspace or the network.' },
         execute: { label: 'Auto execute', hint: 'Common tools run directly; destructive, privileged, and browser actions still require confirmation.' },
-        bypass: { label: 'Bypass sandbox', hint: 'Local tools in this session run without sandbox restrictions. Use only for tasks you fully trust.' },
+        bypass: { label: 'Full access', hint: "Local tools reach your files and your network directly, outside Maka's protection layer. Use only for tasks you fully trust." },
       },
       modeAriaLabel: (label) => `Permission mode: ${label}`,
     },
     sandboxBoundary: {
-      title: "Expand this session's sandbox boundary?",
+      title: 'Allow access outside the workspace?',
       access: { read: 'Read', write: 'Write' },
       scope: { exact: 'Exact path', subtree: 'Directory subtree' },
       network: 'Network access',

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -332,8 +332,8 @@ const CONVERSATION_COPY = {
     },
     permissions: {
       mode: {
-        explore: { label: '只读', hint: '本会话只能读取和搜索工作区里的文件；写入文件或访问网络前会先来问你。' },
-        ask: { label: '自动', hint: '在受保护的环境中自动执行；需要访问工作区以外的文件或网络时再来问你。' },
+        explore: { label: '只读', hint: '只读取和搜索，不写入文件、不访问网络；需要这些权限时会先来问你。' },
+        ask: { label: '自动', hint: '在 Maka 的保护层内自动执行；需要超出当前权限范围时会先来问你。' },
         execute: { label: '自动执行', hint: '常见工具直接执行；破坏性、特权和浏览器操作仍会请求确认。' },
         bypass: { label: '完全权限', hint: '本地工具直接访问你的文件和网络，不经 Maka 的保护层。仅用于你完全信任的任务。' },
       },
@@ -468,8 +468,8 @@ const CONVERSATION_COPY = {
     },
     permissions: {
       mode: {
-        explore: { label: 'Read only', hint: 'This conversation can read and search files in the workspace; it asks you before writing a file or reaching the network.' },
-        ask: { label: 'Auto', hint: 'Runs automatically inside a protected environment; asks you before reaching files outside the workspace or the network.' },
+        explore: { label: 'Read only', hint: 'Reads and searches only — no writing files, no network. Asks you first when it needs either.' },
+        ask: { label: 'Auto', hint: "Runs automatically inside Maka's protection layer; asks you first when something needs to go beyond the current permissions." },
         execute: { label: 'Auto execute', hint: 'Common tools run directly; destructive, privileged, and browser actions still require confirmation.' },
         bypass: { label: 'Full access', hint: "Local tools reach your files and your network directly, outside Maka's protection layer. Use only for tasks you fully trust." },
       },

--- a/packages/ui/src/permission-mode-menu.tsx
+++ b/packages/ui/src/permission-mode-menu.tsx
@@ -17,7 +17,6 @@ import {
 export interface PermissionModeMeta {
   label: string;
   hint: string;
-  tone: 'info' | 'accent' | 'destructive';
 }
 
 /**
@@ -29,19 +28,13 @@ export interface PermissionModeMeta {
  * This module is the one home for the mode table and shared picker: both the
  * composer and Settings render from it so labels, hints, and markup cannot
  * drift between the two surfaces.
+ *
+ * The danger of full access is carried by the words and by the destructive
+ * confirmation dialog that guards the switch — not by a per-mode colour. An
+ * earlier `tone` field here was never read by any renderer.
  */
-const PERMISSION_MODE_TONE: Record<PermissionMode, PermissionModeMeta['tone']> = {
-  explore: 'info', ask: 'accent', execute: 'info', bypass: 'destructive',
-};
-
 export function getPermissionModeMeta(locale: UiLocale): Record<PermissionMode, PermissionModeMeta> {
-  const copy = getConversationCopy(locale).permissions.mode;
-  return {
-    explore: { ...copy.explore, tone: PERMISSION_MODE_TONE.explore },
-    ask: { ...copy.ask, tone: PERMISSION_MODE_TONE.ask },
-    execute: { ...copy.execute, tone: PERMISSION_MODE_TONE.execute },
-    bypass: { ...copy.bypass, tone: PERMISSION_MODE_TONE.bypass },
-  };
+  return getConversationCopy(locale).permissions.mode;
 }
 
 /** User-selectable modes in canonical display order. */
@@ -58,7 +51,9 @@ export const PERMISSION_MODE_ORDER: readonly ChatDefaultPermissionMode[] = CHAT_
  * it does; the selected option carries the standard Select check indicator.
  *
  * Legacy `execute` sessions collapse to Auto for display because that mode
- * no longer maps to a boundary of its own.
+ * no longer maps to a boundary of its own. A read-only (`explore`) session
+ * is a state without a matching option, so the Select carries no value at
+ * all and the trigger is labelled from the display state instead.
  */
 export function PermissionModeSelect(props: {
   activeMode: PermissionMode;
@@ -75,15 +70,24 @@ export function PermissionModeSelect(props: {
   const modeMeta = getPermissionModeMeta(locale);
   // #1611: only legacy `execute` collapses to Auto. `explore` is a real
   // read-only boundary the user is running under, so it shows its own label
-  // and hint instead of borrowing Auto's. Neither option renders as selected
-  // then — which is honest: the current state is neither of them, and both
-  // remain selectable.
+  // and hint instead of borrowing Auto's.
   const displayMode: PermissionMode =
     props.activeMode === 'execute' ? 'ask' : props.activeMode;
   const meta = modeMeta[displayMode];
+  // A display state with no matching option is expressed as "no value", the
+  // supported way to say nothing is selected. Passing an unmatched value
+  // instead would depend on Base UI treating it as stale and trying to reset
+  // it to null — behaviour we would only be surviving, not relying on.
+  // The trigger reads its label from the display state, so it stays correct
+  // whether or not the Select holds a value.
+  const selectedValue: ChatDefaultPermissionMode | null = PERMISSION_MODE_ORDER.includes(
+    displayMode as ChatDefaultPermissionMode,
+  )
+    ? (displayMode as ChatDefaultPermissionMode)
+    : null;
   return (
     <SelectRoot
-      value={displayMode}
+      value={selectedValue}
       items={PERMISSION_MODE_ORDER.map((mode) => ({ value: mode, label: modeMeta[mode].label }))}
       disabled={props.disabled}
       onValueChange={(value) => {
@@ -96,9 +100,7 @@ export function PermissionModeSelect(props: {
         title={props.disabledReason ?? meta.hint}
         className={props.className}
       >
-        <SelectValue>
-          {(value: string) => modeMeta[value as PermissionMode]?.label ?? meta.label}
-        </SelectValue>
+        <SelectValue>{() => meta.label}</SelectValue>
       </SelectTrigger>
       <SelectPortal>
         <SelectPositioner alignItemWithTrigger={false} align={props.align ?? 'start'} sideOffset={6}>

--- a/packages/ui/src/permission-mode-menu.tsx
+++ b/packages/ui/src/permission-mode-menu.tsx
@@ -21,9 +21,10 @@ export interface PermissionModeMeta {
 }
 
 /**
- * Internal sessions still use `explore` and legacy records may contain
- * `execute`, so metadata remains complete for the persisted PermissionMode
- * union. User-facing pickers expose only Auto (`ask`) and Bypass.
+ * Sessions may run under a read-only (`explore`) boundary and legacy records
+ * may contain `execute`, so metadata remains complete for the persisted
+ * PermissionMode union. User-facing pickers offer only Auto (`ask`) and full
+ * access (`bypass`), but any mode can be the state being displayed.
  *
  * This module is the one home for the mode table and shared picker: both the
  * composer and Settings render from it so labels, hints, and markup cannot
@@ -56,8 +57,8 @@ export const PERMISSION_MODE_ORDER: readonly ChatDefaultPermissionMode[] = CHAT_
  * hint in the popup so the user never has to select a mode to learn what
  * it does; the selected option carries the standard Select check indicator.
  *
- * Internal `explore` and legacy `execute` sessions collapse to Auto for
- * display because neither is a user-selectable boundary mode.
+ * Legacy `execute` sessions collapse to Auto for display because that mode
+ * no longer maps to a boundary of its own.
  */
 export function PermissionModeSelect(props: {
   activeMode: PermissionMode;
@@ -72,8 +73,13 @@ export function PermissionModeSelect(props: {
   const locale = useUiLocale();
   const permissionCopy = getConversationCopy(locale).permissions;
   const modeMeta = getPermissionModeMeta(locale);
+  // #1611: only legacy `execute` collapses to Auto. `explore` is a real
+  // read-only boundary the user is running under, so it shows its own label
+  // and hint instead of borrowing Auto's. Neither option renders as selected
+  // then — which is honest: the current state is neither of them, and both
+  // remain selectable.
   const displayMode: PermissionMode =
-    props.activeMode === 'bypass' ? 'bypass' : 'ask';
+    props.activeMode === 'execute' ? 'ask' : props.activeMode;
   const meta = modeMeta[displayMode];
   return (
     <SelectRoot

--- a/packages/ui/stories/chat-surface.stories.tsx
+++ b/packages/ui/stories/chat-surface.stories.tsx
@@ -655,6 +655,26 @@ export const ComposerPendingAndDisabled: Story = {
   ),
 };
 
+// Real path: the three states the permission control can display (#1611 / #1616).
+// `explore` is what a session running under a managed read-only boundary shows —
+// it is never an option in the popup, only a state, so this is the one place the
+// trigger can be reviewed against Auto and full access side by side.
+export const ComposerPermissionModes: Story = {
+  render: () => (
+    <ComposerTray>
+      {(['explore', 'ask', 'bypass'] as const).map((mode) => (
+        <Composer
+          key={mode}
+          {...baseComposerProps}
+          draftKey={`composer-permission-${mode}`}
+          permissionMode={mode}
+          activeSession={session({ permissionMode: mode })}
+        />
+      ))}
+    </ComposerTray>
+  ),
+};
+
 // Real path: 新任务 → ＋ in the composer → the add-context menu, which is where attachment
 // and file import start.
 export const ImportActions: Story = {


### PR DESCRIPTION
## Summary

Two halves of the same question — what the permission surface tells the user — so they land together rather than editing the same copy table twice.

**#1616 — the label says what the mode does.** `绕过沙箱` / "Bypass sandbox" named the mechanism being turned off, not what the user gets. It becomes 完全权限 / **Full access**, with a hint that states the danger in terms of what it grants: local tools reach your files and your network directly, outside Maka's protection layer. The boundary request prompt — the moment a user is actually deciding, and the only one with no styling cue to carry the warning — becomes `允许访问工作区以外的内容？` / "Allow access outside the workspace?".

The tool-failure diagnostic (`可能被沙箱阻止`) is deliberately left alone. There "sandbox" explains why something failed to a reader who is diagnosing, and naming the mechanism helps.

**#1611 — a read-only boundary is shown as read-only.** `ExecutionBoundary`'s managed variant carries the whole `PermissionProfileManaged`, so read-only and writable are distinct facts, but the surfaces flattened them to `ask`. The derivation now lives once in core as `executionBoundaryDisplayMode(boundary)`; Desktop wraps it and the CLI driver calls it directly, so the collapse is gone by construction rather than patched in three places. `isReadOnlyPermissionProfile` derives the fact from policy rather than from `name`, so a profile widened by an approved expansion stops reading as read-only even though its name never changed.

The option list is unchanged — a read-only session can still be raised to full access — and no fourth state was added.

**Neither Auto nor Read only claims a boundary it may not have.** Auto is shown for every managed profile that is not read-only, including ones already widened and `danger-full-access`, so its old hint ("asks before reaching files outside the workspace or the network") was false for exactly the sessions with the most permissions. Read only had the same defect in reverse: it named the workspace, which is wrong once a read expansion is approved. Both now describe the protection without naming a boundary:

- zh 自动 — 在 Maka 的保护层内自动执行；需要超出当前权限范围时会先来问你。
- en Auto — Runs automatically inside Maka's protection layer; asks you first when something needs to go beyond the current permissions.
- zh 只读 — 只读取和搜索，不写入文件、不访问网络；需要这些权限时会先来问你。
- en Read only — Reads and searches only — no writing files, no network. Asks you first when it needs either.

The `danger-full-access → ask` mapping is kept and its test now carries an honest note: a deliberate collapse, not a description, and honest only because Auto never names a boundary — if Auto's hint ever names one again, this mapping becomes a lie and must change with it.

Closes #1611. Closes #1616.

## Review fixes

Codex review raised two P1s, both fixed here.

**The boundary snapshot went stale.** Approving an expansion only bumps the boundary's revision — no session field moves — so a surface that never re-read authority kept telling the user their session could not write, right after they let it. On `main` this was invisible because the label was always Auto; making the label informative is what turned it into an active false statement about permissions. Freshness belongs to the read model, so a new `use-active-execution-boundary` hook owns it: the snapshot is tagged with the session it was read for and matched on that (a boundary can never be attributed to the wrong session, and refreshing no longer blanks the composer mid-flight), and both settle paths report — the ack event for decisions settled elsewhere, and `respondToSandboxBoundary` for the click made here, which does not wait for the round trip.

**The CLI presented a read-only session as the current Auto, and choosing that "current" option silently escalated.** `session-driver` rewrote every managed boundary to `ask` in the summary; the status line then showed Auto, the picker marked Auto as `current`, and selecting it called `setPermissionMode('ask')`, replacing a canonical read-only boundary with a workspace-write profile. An option marked current must be a no-op. The driver no longer touches `summary.permissionMode`; it keeps the two genuinely different facts apart — what the next created session gets, versus what the active session's boundary says — so a resumed read-only session also stops making read-only the default for the next `/new`. The picker marks `current` only when the option is actually in force.

Also: `SelectRoot` now receives `value={null}` when the display state is not one of the options, instead of an unmatched `'explore'` — Base UI 1.5.0 treats an unmatched non-null value as stale and tries to reset it, so the previous behaviour worked by accident, not by contract. The trigger takes its label from the display state rather than the Select's value. `PermissionModeMeta.tone` was dead data (the destructive styling comes from the confirmation dialog's own flag) and is deleted along with its assertions. `maka run --help` and its resume error no longer say "sandbox" or "Bypass session".

## Verification

Rebased onto current `main` (carrying #1618, #1619, #1610) and re-run there: `@maka/core` 1199, `@maka/ui` 263, `maka-agent` 672, `@maka/desktop` main 2950 — 0 failures. `test:checks` (console / a11y / copy) clean. `npm run lint`, `format:check`, `typecheck` including stories clean. **Full Playwright suite 79/79.**

- The read-only E2E journey now matches its name: it opens the menu, asserts both options are `aria-selected="false"`, checks Escape changes nothing, clicks Full access and gets exactly one confirmation dialog, cancels back to read-only, then reaches Auto by keyboard. A double-fire would stack or reopen that dialog.
- A second E2E covers the stale-snapshot fix end to end: approve a pending expansion, the label flips to 自动 immediately, and it survives `page.reload()` — proving it comes from authority, not renderer state. This required the fixture's `allow` to stop being a no-op; it now creates and settles a real request through the storage authority.
- CLI tests drive the real TUI: a resumed read-only session shows `Maka · Read only ·`, `/permissions` marks nothing current, and selecting Auto records one real change.
- A contract test walks every `PermissionMode` and asserts no label or hint — and not the boundary prompt title — hands the reader the word 沙箱/sandbox, in both locales.

## Known gap

The "exactly one callback per click" property is asserted by outcome (one dialog, one state change), not by counting calls. A true call-count assertion needs a DOM test runner in `packages/ui`, which the repo does not have; adding one is a dependency decision, not part of this change.