### PR TITLE
feat(runtime): manage shell process lifecycles

### DIFF
--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -5,6 +5,7 @@ import { wireAppLifecycle } from './app-lifecycle.js';
 import {
   collapseSessionRevisions,
   filterModelVisibleTaskLedgerTasks,
+  isActiveShellRunStatus,
   resolveSystemUiLocale,
   resolveUiLocale,
 } from '@maka/core';
@@ -879,7 +880,7 @@ const runtime = new SessionManager({
         runStore.listSessionRuns(sessionId),
       ]);
       return (
-        shellUpdates.some((update) => update.result.status === 'running') ||
+        shellUpdates.some((update) => isActiveShellRunStatus(update.result.status)) ||
         runs.some(
           (run) =>
             run.parentRunId !== undefined &&

--- a/packages/cli/src/pi-transcript-tools.ts
+++ b/packages/cli/src/pi-transcript-tools.ts
@@ -2,6 +2,7 @@ import type { ToolOutputStream, ToolResultContent } from '@maka/core/events';
 import {
   formatQuietJsonValue,
   formatToolInvocationLine,
+  isActiveShellRunStatus,
   ptyTuiTerminalRows,
   ptyTuiTerminalView,
   readWriteStdinInputPreview,
@@ -232,7 +233,7 @@ function compactToolSummary(entry: MakaPiToolEntry): CompactToolSummary | undefi
     }
     // A settled background run reports its outcome, not its output: the status
     // and exit code are the signal, the stream body lives in the expanded card.
-    if (result.status !== 'running' && result.status !== 'completed') {
+    if (!isActiveShellRunStatus(result.status) && result.status !== 'completed') {
       const parts: string[] = [result.status];
       if (result.exitCode !== undefined) parts.push(`exit ${result.exitCode}`);
       return { text: ansi.red(parts.join(' · ')), protect: true };
@@ -645,7 +646,7 @@ function renderShellRunResult(
     lines.push(...renderIndented(ansi.dim(`$ ${content.cmd}`), width, 2));
   }
   lines.push(...renderIndented(ansi.dim(`cwd: ${content.cwd}`), width, 2));
-  const settled = content.status !== 'running' && content.status !== 'completed';
+  const settled = !isActiveShellRunStatus(content.status) && content.status !== 'completed';
   const parts: string[] = [content.status];
   if (content.exitCode !== undefined) parts.push(`exit ${content.exitCode}`);
   if (content.failureMessage) parts.push(content.failureMessage);

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -15,6 +15,7 @@ import {
 import type { ContextBudgetDiagnostic } from '@maka/core/usage-stats/types';
 import type { ThinkingLevel } from '@maka/core/model-thinking';
 import {
+  isActiveShellRunStatus,
   mergeShellRunStateWithDiagnostics,
   projectToolActivityArgs,
   type ShellRunUpdate,
@@ -276,7 +277,7 @@ export function applyShellRunViewUpdateToTranscript(
     tool.toolName !== 'Bash' ||
     tool.result?.kind !== 'shell_run' ||
     tool.result.ref !== update.result.ref ||
-    tool.result.status !== 'running'
+    !isActiveShellRunStatus(tool.result.status)
   )
     return applied;
   const status =
@@ -879,6 +880,7 @@ function shellRunTranscriptStatus(
   status: Extract<ToolResultContent, { kind: 'shell_run' }>['status'],
 ): MakaPiToolEntry['status'] {
   switch (status) {
+    case 'starting':
     case 'running':
       return 'running';
     case 'completed':
@@ -1484,7 +1486,7 @@ function readArgsRef(args: unknown): string | undefined {
  * and because stored replay never routes through the notice path.
  */
 function isLiveShellRunCard(entry: MakaPiToolEntry | undefined): boolean {
-  return entry?.result?.kind === 'shell_run' && entry.result.status === 'running';
+  return entry?.result?.kind === 'shell_run' && isActiveShellRunStatus(entry.result.status);
 }
 
 /**
@@ -1504,7 +1506,7 @@ function applyLiveShellRunResultToParent(
 }
 
 function isSettledShellRunCard(entry: MakaPiToolEntry): boolean {
-  return entry.result?.kind === 'shell_run' && entry.result.status !== 'running';
+  return entry.result?.kind === 'shell_run' && !isActiveShellRunStatus(entry.result.status);
 }
 
 /**

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -80,7 +80,7 @@ import { resolveStorageRoot } from '@maka/storage/root-authority';
 import { resolveWorkspaceIdentity } from '@maka/storage/workspace-identity';
 import { fetchProviderModels } from '@maka/runtime';
 import { createApiKeyOnboardingSurface, type MakaOnboardingSurface } from './onboarding.js';
-import { resolveModelVisionSupport } from '@maka/core';
+import { isActiveShellRunStatus, resolveModelVisionSupport } from '@maka/core';
 import type { ModelChoice, ReadySessionTarget } from './connection-target.js';
 import {
   listReadyModelChoices,
@@ -797,7 +797,7 @@ export async function createMakaCliRuntimeContext(
           runStore.listSessionRuns(sessionId),
         ]);
         return (
-          shellUpdates.some((update) => update.result.status === 'running') ||
+          shellUpdates.some((update) => isActiveShellRunStatus(update.result.status)) ||
           runs.some(
             (run) =>
               run.parentRunId !== undefined &&

--- a/packages/cli/src/shell-run-hydration.ts
+++ b/packages/cli/src/shell-run-hydration.ts
@@ -1,4 +1,5 @@
 import {
+  isActiveShellRunStatus,
   ShellRunUpdateBuffer,
   mergeShellRunUpdate,
   projectShellRunUpdateForSession,
@@ -41,7 +42,8 @@ export function createShellRunHydrationController(input: {
       'cli.pi-tui-runner',
     );
     const retainOwnerMapping =
-      merged.update.ownership.kind === 'source_owned' && merged.update.result.status === 'running';
+      merged.update.ownership.kind === 'source_owned' &&
+      isActiveShellRunStatus(merged.update.result.status);
     if (index >= 0 && retainOwnerMapping) ownerMappings[index] = merged.update;
     else if (index >= 0) ownerMappings.splice(index, 1);
     else if (retainOwnerMapping) ownerMappings.push(merged.update);

--- a/packages/core/src/__tests__/shell-run-result.test.ts
+++ b/packages/core/src/__tests__/shell-run-result.test.ts
@@ -250,6 +250,7 @@ describe('normalizeShellToolResultContent', () => {
   it('rejects non-canonical nested output and contradictory current state', () => {
     const valid = shellRun();
     assert.equal(normalizeShellToolResultContent(valid).state, 'valid');
+    assert.equal(normalizeShellToolResultContent({ ...valid, status: 'starting' }).state, 'valid');
 
     const invalid = [
       {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -338,6 +338,7 @@ export type {
   ShellRunOperation,
   ShellRunPatch,
   ShellRunRecord,
+  ShellRunActiveStatus,
   ShellRunStatus,
   ShellRunStore,
   ShellRunTerminalStatus,
@@ -391,12 +392,15 @@ export {
 export { redactSecrets as displayRedactSecrets } from './display-redaction.js';
 export {
   SHELL_RUN_ID_MAX_CHARS,
+  SHELL_RUN_ACTIVE_STATUSES,
   SHELL_RUN_STATUSES,
   SHELL_RUN_TERMINAL_STATUSES,
   isShellOutput,
+  isActiveShellRunStatus,
   isShellRunId,
   isShellRunStatus,
   isValidShellRunState,
+  isValidShellRunStatusTransition,
   isTerminalShellRunStatus,
 } from './shell-run.js';
 

--- a/packages/core/src/shell-run-result.ts
+++ b/packages/core/src/shell-run-result.ts
@@ -373,7 +373,7 @@ function legacyPipeOutput(value: Record<string, unknown>): Extract<ShellOutput, 
 
 function isLegacyTerminalStatus(
   value: unknown,
-): value is Exclude<ShellRunStatus, 'running' | 'orphaned'> {
+): value is Exclude<ShellRunStatus, 'starting' | 'running' | 'orphaned'> {
   return (
     value === 'completed' || value === 'failed' || value === 'timed_out' || value === 'cancelled'
   );

--- a/packages/core/src/shell-run.ts
+++ b/packages/core/src/shell-run.ts
@@ -1,4 +1,5 @@
 export const SHELL_RUN_STATUSES = [
+  'starting',
   'running',
   'completed',
   'failed',
@@ -8,6 +9,8 @@ export const SHELL_RUN_STATUSES = [
 ] as const;
 
 export type ShellRunStatus = (typeof SHELL_RUN_STATUSES)[number];
+
+export const SHELL_RUN_ACTIVE_STATUSES = ['starting', 'running'] as const;
 
 export const SHELL_RUN_TERMINAL_STATUSES = [
   'completed',
@@ -44,6 +47,7 @@ const PTY_SHELL_OUTPUT_KEYS = new Set([
 const PTY_CURSOR_KEYS = new Set(['x', 'y', 'visible']);
 
 export type ShellRunTerminalStatus = (typeof SHELL_RUN_TERMINAL_STATUSES)[number];
+export type ShellRunActiveStatus = (typeof SHELL_RUN_ACTIVE_STATUSES)[number];
 export type ShellMode = 'pipes' | 'pty';
 
 export interface PipeShellOutput {
@@ -153,6 +157,21 @@ export function isTerminalShellRunStatus(value: ShellRunStatus): value is ShellR
   return (SHELL_RUN_TERMINAL_STATUSES as readonly string[]).includes(value);
 }
 
+export function isActiveShellRunStatus(value: ShellRunStatus): value is ShellRunActiveStatus {
+  return (SHELL_RUN_ACTIVE_STATUSES as readonly string[]).includes(value);
+}
+
+export function isValidShellRunStatusTransition(
+  current: ShellRunStatus,
+  next: ShellRunStatus,
+): boolean {
+  if (current === next) return true;
+  if (current === 'starting') {
+    return next === 'running' || next === 'failed' || next === 'orphaned';
+  }
+  return current === 'running' && isTerminalShellRunStatus(next);
+}
+
 export function isShellOutput(value: unknown): value is ShellOutput {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return false;
   const output = value as Partial<ShellOutput>;
@@ -200,6 +219,7 @@ export function isValidShellRunState(value: {
   observedAt?: unknown;
 }): boolean {
   switch (value.status) {
+    case 'starting':
     case 'running':
       return (
         value.completedAt === undefined &&

--- a/packages/runtime/src/__tests__/child-process-lifecycle.test.ts
+++ b/packages/runtime/src/__tests__/child-process-lifecycle.test.ts
@@ -1,0 +1,84 @@
+import assert from 'node:assert/strict';
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { PassThrough } from 'node:stream';
+import { test } from 'node:test';
+
+import {
+  manageChildProcessLifecycle,
+  trackCapturedOutputDrain,
+} from '../child-process-lifecycle.js';
+
+test('captured output drain treats premature close and error as incomplete', async () => {
+  const ended = new PassThrough();
+  const closed = new PassThrough();
+  const errored = new PassThrough();
+  const drain = trackCapturedOutputDrain(
+    [
+      { key: 'ended', stream: ended },
+      { key: 'closed', stream: closed },
+      { key: 'errored', stream: errored },
+    ],
+    100,
+  );
+  ended.resume();
+  ended.end('complete');
+  closed.emit('close');
+  errored.emit('error', new Error('capture failed'));
+  drain.startDeadline();
+
+  const result = await drain.completion;
+  assert.deepEqual([...result.incomplete].sort(), ['closed', 'errored']);
+});
+
+test('completion waits for the bounded process-tree signal attempt after root exit', async () => {
+  const child = new EventEmitter() as ChildProcess;
+  let resolveSignal!: (applied: boolean) => void;
+  const signalAttempt = new Promise<boolean>((resolve) => {
+    resolveSignal = resolve;
+  });
+  const lifecycle = manageChildProcessLifecycle(child, [], {
+    killGraceMs: 10,
+    ioDrainTimeoutMs: 10,
+    signalProcessTree: () => signalAttempt,
+  });
+  let completed = false;
+  void lifecycle.completion.then(() => {
+    completed = true;
+  });
+
+  lifecycle.terminate();
+  child.emit('exit', 0, null);
+  await new Promise<void>((resolve) => setImmediate(resolve));
+  assert.equal(completed, false);
+
+  resolveSignal(true);
+  assert.deepEqual(await lifecycle.completion, {
+    exitCode: 0,
+    signal: null,
+    ioDrained: true,
+    incompleteOutputs: new Set(),
+  });
+});
+
+test('forced termination rejects boundedly when the direct root never acknowledges exit', async () => {
+  const child = new EventEmitter() as ChildProcess;
+  const signals: string[] = [];
+  const lifecycle = manageChildProcessLifecycle(child, [], {
+    killGraceMs: 10,
+    exitAcknowledgementMs: 10,
+    ioDrainTimeoutMs: 10,
+    async signalProcessTree(signal) {
+      signals.push(signal);
+      return true;
+    },
+  });
+
+  lifecycle.terminate();
+
+  await assert.rejects(
+    lifecycle.completion,
+    /Child process did not acknowledge exit after forced termination/,
+  );
+  assert.deepEqual(signals, ['SIGTERM', 'SIGKILL', 'SIGKILL']);
+});

--- a/packages/runtime/src/__tests__/filesystem-worker-process-runner.test.ts
+++ b/packages/runtime/src/__tests__/filesystem-worker-process-runner.test.ts
@@ -1,5 +1,7 @@
 import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { test } from 'node:test';
 
 import { runFilesystemWorkerProcess } from '../filesystem-worker/process-runner.js';
@@ -29,4 +31,66 @@ test('filesystem worker process receives inherited fd inputs alongside request s
     fd: [...fdPayload],
     stdin: input.stdin,
   });
+});
+
+test('filesystem worker does not spawn for an already-aborted request', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-worker-pre-abort-'));
+  const marker = join(root, 'spawned');
+  const abort = new AbortController();
+  abort.abort();
+  try {
+    const result = await runFilesystemWorkerProcess({
+      argv: [
+        process.execPath,
+        '-e',
+        `require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'spawned')`,
+      ],
+      cwd: root,
+      env: process.env,
+      stdin: '',
+      abortSignal: abort.signal,
+    });
+
+    assert.equal(result.aborted, true);
+    await assert.rejects(() => readFile(marker, 'utf8'), { code: 'ENOENT' });
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test('filesystem worker rejects boundedly when a detached descendant retains stdout', {
+  skip: process.platform === 'win32' ? 'POSIX detached process-group semantics required' : false,
+}, async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-worker-drain-'));
+  const pidFile = join(root, 'child.pid');
+  let childPid: number | undefined;
+  try {
+    const script = `const {spawn}=require('node:child_process');const {writeFileSync}=require('node:fs');const child=spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{detached:true,stdio:['ignore',process.stdout,'ignore']});child.unref();writeFileSync(${JSON.stringify(pidFile)},String(child.pid));process.stdout.write('{}')`;
+    const startedAt = Date.now();
+    await assert.rejects(
+      runFilesystemWorkerProcess({
+        argv: [process.execPath, '-e', script],
+        cwd: root,
+        env: process.env,
+        stdin: '',
+        ioDrainTimeoutMs: 100,
+      }),
+      /output did not drain before lifecycle deadline/,
+    );
+    childPid = Number.parseInt(await readFile(pidFile, 'utf8'), 10);
+    assert.ok(Date.now() - startedAt < 2_000);
+  } finally {
+    if (childPid) {
+      try {
+        process.kill(-childPid, 'SIGKILL');
+      } catch {
+        try {
+          process.kill(childPid, 'SIGKILL');
+        } catch {
+          /* descendant already exited */
+        }
+      }
+    }
+    await rm(root, { recursive: true, force: true });
+  }
 });

--- a/packages/runtime/src/__tests__/shell-exec.test.ts
+++ b/packages/runtime/src/__tests__/shell-exec.test.ts
@@ -4,7 +4,7 @@ import { existsSync, promises as fs } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { killWindowsTree } from '../process-tree-terminator.js';
-import { runShellWithBoundedTail } from '../shell-exec.js';
+import { runProcessWithBoundedTail, runShellWithBoundedTail } from '../shell-exec.js';
 
 const base = (over: Record<string, unknown> = {}) => ({
   cwd: process.cwd(),
@@ -89,6 +89,61 @@ describe('runShellWithBoundedTail', () => {
     const r = await runShellWithBoundedTail('sleep 5', base({ timeoutMs: 150 }));
     assert.equal(r.timedOut, true);
     assert.equal(r.exitCode, 124);
+  });
+
+  test('does not spawn a process for an already-aborted invocation', async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'shell-exec-pre-abort-'));
+    const marker = join(dir, 'spawned');
+    const abort = new AbortController();
+    abort.abort();
+    try {
+      const result = await runProcessWithBoundedTail(
+        process.execPath,
+        ['-e', `require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'spawned')`],
+        base({ abortSignal: abort.signal }),
+      );
+      assert.equal(result.aborted, true);
+      assert.equal(result.exitCode, 130);
+      await assert.rejects(() => fs.readFile(marker, 'utf8'), { code: 'ENOENT' });
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  test('bounds output drain after the root exits while a detached descendant retains stdout', {
+    skip: process.platform === 'win32' ? 'POSIX detached process-group semantics required' : false,
+  }, async () => {
+    const dir = await fs.mkdtemp(join(tmpdir(), 'shell-exec-drain-'));
+    const pidFile = join(dir, 'child.pid');
+    let childPid: number | undefined;
+    try {
+      const script = `const {spawn}=require('node:child_process');const {writeFileSync}=require('node:fs');const child=spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{detached:true,stdio:['ignore',process.stdout,'ignore']});child.unref();writeFileSync(${JSON.stringify(pidFile)},String(child.pid));process.stdout.write('ROOT\\n')`;
+      const startedAt = Date.now();
+      const result = await runProcessWithBoundedTail(
+        process.execPath,
+        ['-e', script],
+        base({ ioDrainTimeoutMs: 100 }),
+      );
+      childPid = Number.parseInt(await fs.readFile(pidFile, 'utf8'), 10);
+      assert.ok(Date.now() - startedAt < 2_000);
+      assert.equal(result.exitCode, 0);
+      assert.equal(result.stdout, 'ROOT\n');
+      assert.equal(result.stdoutTruncated, true);
+      assert.equal(result.stderrTruncated, false);
+    } finally {
+      if (childPid) {
+        try {
+          process.kill(-childPid, 'SIGKILL');
+        } catch {
+          try {
+            process.kill(childPid, 'SIGKILL');
+          } catch {
+            /* descendant already exited */
+          }
+        }
+      }
+      await fs.rm(dir, { recursive: true, force: true });
+    }
   });
 
   test('on timeout, escalates SIGTERM->SIGKILL and resolves only after the child is actually dead', async () => {

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -106,7 +106,8 @@ describe('ShellRunProcessManager', () => {
 
     await waitUntil(async () => {
       try {
-        return (await store.readShellRun('session-1', 'shell-run-1')).timeoutMs === 120_000;
+        const record = await store.readShellRun('session-1', 'shell-run-1');
+        return record.status === 'running' && record.timeoutMs === 120_000;
       } catch (error) {
         if ((error as NodeJS.ErrnoException).code === 'ENOENT') return false;
         throw error;
@@ -242,6 +243,171 @@ describe('ShellRunProcessManager', () => {
     );
 
     assert.deepEqual(completions, [false, false, false]);
+  });
+
+  test('commits a durable starting identity before the native pipe process spawns', async () => {
+    const cwd = await workspace();
+    const marker = join(cwd, 'spawned');
+    const backingStore = createShellRunStore(cwd);
+    const createCommitted = deferred<void>();
+    const releaseCreate = deferred<void>();
+    const store: ShellRunStore = {
+      async createShellRun(record) {
+        const created = await backingStore.createShellRun(record);
+        createCommitted.resolve(undefined);
+        await releaseCreate.promise;
+        return created;
+      },
+      updateShellRun: (...args) => backingStore.updateShellRun(...args),
+      readShellRun: (...args) => backingStore.readShellRun(...args),
+      listSessionShellRuns: (...args) => backingStore.listSessionShellRuns(...args),
+    };
+    const manager = createManager(store);
+    const startup = manager.runForegroundBash(
+      shellInput({
+        cwd,
+        command: 'write spawn marker',
+        argv: [
+          process.execPath,
+          '-e',
+          `require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'spawned')`,
+        ],
+      }),
+    );
+
+    try {
+      await createCommitted.promise;
+      assert.equal(
+        (await backingStore.readShellRun('session-1', 'shell-run-1')).status,
+        'starting',
+      );
+      assert.equal(await manager.recoverOrphanedSession('session-1'), 0);
+      assert.equal(
+        (await backingStore.readShellRun('session-1', 'shell-run-1')).status,
+        'starting',
+      );
+      await assert.rejects(() => readFile(marker, 'utf8'), { code: 'ENOENT' });
+      releaseCreate.resolve(undefined);
+      assert.equal((await startup).status, 'completed');
+      assert.equal(await readFile(marker, 'utf8'), 'spawned');
+    } finally {
+      releaseCreate.resolve(undefined);
+      await startup.catch(() => undefined);
+      await manager.terminateAll();
+    }
+  });
+
+  test('session close and runtime shutdown fence pipe startups blocked in durable creation', async () => {
+    for (const lifecycle of ['session', 'runtime'] as const) {
+      const cwd = await workspace();
+      const marker = join(cwd, `${lifecycle}-spawned`);
+      const backingStore = createShellRunStore(cwd);
+      const createCommitted = deferred<void>();
+      const releaseCreate = deferred<void>();
+      const store: ShellRunStore = {
+        async createShellRun(record) {
+          const created = await backingStore.createShellRun(record);
+          createCommitted.resolve(undefined);
+          await releaseCreate.promise;
+          return created;
+        },
+        updateShellRun: (...args) => backingStore.updateShellRun(...args),
+        readShellRun: (...args) => backingStore.readShellRun(...args),
+        listSessionShellRuns: (...args) => backingStore.listSessionShellRuns(...args),
+      };
+      const manager = createManager(store);
+      const startup = manager.runForegroundBash(
+        shellInput({
+          cwd,
+          command: `${lifecycle} startup fence`,
+          argv: [
+            process.execPath,
+            '-e',
+            `require('node:fs').writeFileSync(${JSON.stringify(marker)}, 'spawned')`,
+          ],
+        }),
+      );
+      const rejectedStartup = assert.rejects(
+        startup,
+        lifecycle === 'session' ? /session lifecycle changed/ : /shell runtime is shutting down/,
+      );
+      let closing: Promise<void> | undefined;
+      try {
+        await createCommitted.promise;
+        closing =
+          lifecycle === 'session'
+            ? manager.terminateSession('session-1').then((lease) => {
+                manager.rollbackSessionClose(lease);
+              })
+            : manager.terminateAll();
+        await new Promise<void>((resolve) => setImmediate(resolve));
+        await assert.rejects(() => readFile(marker, 'utf8'), { code: 'ENOENT' });
+
+        releaseCreate.resolve(undefined);
+        await rejectedStartup;
+        await closing;
+        const durable = await backingStore.readShellRun('session-1', 'shell-run-1');
+        assert.equal(durable.status, 'failed');
+        assert.ok(durable.observedAt !== undefined);
+        await assert.rejects(() => readFile(marker, 'utf8'), { code: 'ENOENT' });
+        assert.equal(manager.liveCount(), 0);
+      } finally {
+        releaseCreate.resolve(undefined);
+        await startup.catch(() => undefined);
+        await closing?.catch(() => undefined);
+        await manager.terminateAll().catch(() => undefined);
+      }
+    }
+  });
+
+  test('rechecks the session fence after the durable running commit', async () => {
+    const cwd = await workspace();
+    const backingStore = createShellRunStore(cwd);
+    const runningCommitted = deferred<void>();
+    const releaseRunning = deferred<void>();
+    const store: ShellRunStore = {
+      createShellRun: (...args) => backingStore.createShellRun(...args),
+      async updateShellRun(sessionId, shellRunId, patch) {
+        const updated = await backingStore.updateShellRun(sessionId, shellRunId, patch);
+        if (patch.status === 'running') {
+          runningCommitted.resolve(undefined);
+          await releaseRunning.promise;
+        }
+        return updated;
+      },
+      readShellRun: (...args) => backingStore.readShellRun(...args),
+      listSessionShellRuns: (...args) => backingStore.listSessionShellRuns(...args),
+    };
+    const manager = createManager(store);
+    const startup = manager.runForegroundBash(
+      shellInput({
+        cwd,
+        command: waitForeverCommand(),
+      }),
+    );
+    const rejectedStartup = assert.rejects(startup, /session lifecycle changed/);
+    let closing: Promise<void> | undefined;
+
+    try {
+      await runningCommitted.promise;
+      closing = manager.terminateSession('session-1').then((lease) => {
+        manager.rollbackSessionClose(lease);
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      releaseRunning.resolve(undefined);
+
+      await rejectedStartup;
+      await closing;
+      const durable = await backingStore.readShellRun('session-1', 'shell-run-1');
+      assert.equal(durable.status, 'failed');
+      assert.ok(durable.observedAt !== undefined);
+      assert.equal(manager.liveCount(), 0);
+    } finally {
+      releaseRunning.resolve(undefined);
+      await startup.catch(() => undefined);
+      await closing?.catch(() => undefined);
+      await manager.terminateAll().catch(() => undefined);
+    }
   });
 
   test('applies only explicit background timeouts and enforces their upper bound', async () => {
@@ -674,21 +840,71 @@ describe('ShellRunProcessManager', () => {
     assert.match(terminalText(completed.output), /VALUE:resumed/);
   });
 
-  test('recovers a durable running record without a live handle as orphaned', async () => {
+  test('recovers durable starting and running records without live handles as orphaned', async () => {
     const store = createShellRunStore(await workspace());
-    await store.createShellRun(record({ shellRunId: 'orphan-1', status: 'running' }));
+    await store.createShellRun(record({ shellRunId: 'orphan-starting', status: 'starting' }));
+    await store.createShellRun(record({ shellRunId: 'orphan-running', status: 'running' }));
+    await store.createShellRun({
+      ...record({ shellRunId: 'completed-1', status: 'running' }),
+      status: 'completed',
+      exitCode: 0,
+      completedAt: 2,
+    });
     const manager = createManager(store);
 
-    assert.equal(await manager.recoverOrphanedSession('session-1'), 1);
+    assert.equal(await manager.recoverOrphanedSession('session-1'), 2);
+    assert.equal(await manager.recoverOrphanedSession('session-1'), 0);
     const detail = await manager.readRuntimeResource(
       'session-1',
-      'maka://runtime/background-tasks/orphan-1',
+      'maka://runtime/background-tasks/orphan-starting',
       NO_ABORT,
     );
     assertShellRun(detail);
     assert.equal(detail.status, 'orphaned');
     assert.match(detail.failureMessage ?? '', /Runtime restarted/);
     assert.equal(detail.exitCode, undefined);
+    assert.equal((await store.readShellRun('session-1', 'orphan-running')).status, 'orphaned');
+    assert.equal((await store.readShellRun('session-1', 'completed-1')).status, 'completed');
+  });
+
+  test('concurrent orphan observers converge on the same durable terminal record', async () => {
+    const backingStore = createShellRunStore(await workspace());
+    await backingStore.createShellRun(
+      record({ shellRunId: 'concurrent-orphan', status: 'running' }),
+    );
+    const readsReady = deferred<void>();
+    let staleReads = 0;
+    const store: ShellRunStore = {
+      createShellRun: (...args) => backingStore.createShellRun(...args),
+      updateShellRun: (...args) => backingStore.updateShellRun(...args),
+      async readShellRun(...args) {
+        const snapshot = await backingStore.readShellRun(...args);
+        if (snapshot.shellRunId === 'concurrent-orphan' && staleReads < 2) {
+          staleReads += 1;
+          if (staleReads === 2) readsReady.resolve(undefined);
+          await readsReady.promise;
+        }
+        return snapshot;
+      },
+      listSessionShellRuns: (...args) => backingStore.listSessionShellRuns(...args),
+    };
+    const manager = createManager(store);
+    const ref = 'maka://runtime/background-tasks/concurrent-orphan';
+
+    const [detail, stopped] = await Promise.all([
+      manager.readRuntimeResource('session-1', ref, NO_ABORT),
+      manager.stopBackgroundTask('session-1', ref, NO_ABORT),
+    ]);
+
+    assertShellRun(detail);
+    assertShellRun(stopped);
+    assert.equal(detail.status, 'orphaned');
+    assert.equal(stopped.status, 'orphaned');
+    assert.equal(detail.completedAt, stopped.completedAt);
+    assert.equal(detail.failureMessage, stopped.failureMessage);
+    const durable = await backingStore.readShellRun('session-1', 'concurrent-orphan');
+    assert.equal(durable.status, 'orphaned');
+    assert.equal(durable.completedAt, detail.completedAt);
   });
 
   test('keeps unauthorized refs non-disclosing and rejects malformed selectors before storage', async () => {
@@ -1561,6 +1777,49 @@ describe('ShellRunProcessManager', () => {
     assert.doesNotMatch(text, new RegExp(secret));
   });
 
+  test('settles after root exit when a detached descendant retains inherited stdout', {
+    skip: process.platform === 'win32' ? 'POSIX detached process-group semantics required' : false,
+  }, async () => {
+    const cwd = await workspace();
+    const childPidPath = join(cwd, 'escaped-child.pid');
+    const manager = await createTestManager(undefined, { pipeOutputDrainMs: 100 });
+    let childPid: number | undefined;
+    try {
+      const startedAt = Date.now();
+      const result = await manager.runForegroundBash(
+        shellInput({
+          cwd,
+          command: 'root exits while detached child inherits stdout',
+          argv: [
+            process.execPath,
+            '-e',
+            `const {spawn}=require('node:child_process');const {writeFileSync}=require('node:fs');const child=spawn(process.execPath,['-e','setInterval(()=>{},1000)'],{detached:true,stdio:['ignore',process.stdout,'ignore']});child.unref();writeFileSync(${JSON.stringify(childPidPath)},String(child.pid));process.stdout.write('ROOT\\n')`,
+          ],
+        }),
+      );
+      childPid = Number.parseInt(await readFile(childPidPath, 'utf8'), 10);
+      assert.ok(Date.now() - startedAt < 2_000);
+      assert.equal(result.status, 'failed');
+      assert.equal(result.output.mode, 'pipes');
+      if (result.output.mode !== 'pipes') throw new Error('expected pipes output');
+      assert.equal(result.output.stdoutTruncated, true);
+      assert.match(result.failureMessage ?? '', /output pipes drained completely/);
+      assert.equal(manager.liveCount(), 0);
+    } finally {
+      if (childPid && isProcessAlive(childPid)) {
+        try {
+          process.kill(-childPid, 'SIGKILL');
+        } catch {
+          try {
+            process.kill(childPid, 'SIGKILL');
+          } catch {
+            /* descendant already exited */
+          }
+        }
+      }
+    }
+  });
+
   test('stops descendants that detach from the real PTY process group', async () => {
     const cwd = await workspace();
     const childPidPath = join(cwd, 'child.pid');
@@ -1791,6 +2050,7 @@ function createManager(
     maxLivePtyRuns?: number;
     killGraceMs?: number;
     flushIntervalMs?: number;
+    pipeOutputDrainMs?: number;
   } = {},
 ): ShellRunProcessManager {
   let id = 0;
@@ -1814,6 +2074,7 @@ async function createTestManager(
     maxLivePtyRuns?: number;
     killGraceMs?: number;
     flushIntervalMs?: number;
+    pipeOutputDrainMs?: number;
   },
 ): Promise<ShellRunProcessManager> {
   return createManager(createShellRunStore(await workspace()), onShellRunUpdate, options);
@@ -1914,7 +2175,12 @@ function waitForTerminalShellRun(
   ref: string,
   timeoutMs = 3_000,
 ): Promise<ShellRunResult> {
-  return waitForShellRun(manager, ref, (result) => result.status !== 'running', timeoutMs);
+  return waitForShellRun(
+    manager,
+    ref,
+    (result) => result.status !== 'starting' && result.status !== 'running',
+    timeoutMs,
+  );
 }
 
 function waitForPtyText(
@@ -2028,4 +2294,15 @@ function isProcessAlive(pid: number): boolean {
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === 'EPERM';
   }
+}
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve(value: T | PromiseLike<T>): void;
+} {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve;
+  });
+  return { promise, resolve };
 }

--- a/packages/runtime/src/child-process-lifecycle.ts
+++ b/packages/runtime/src/child-process-lifecycle.ts
@@ -1,0 +1,279 @@
+import type { ChildProcess } from 'node:child_process';
+import type { Readable } from 'node:stream';
+
+import {
+  DEFAULT_PROCESS_TERMINATION_GRACE_MS,
+  terminateChildProcessTree,
+} from './process-tree-terminator.js';
+
+export const DEFAULT_PROCESS_IO_DRAIN_TIMEOUT_MS = DEFAULT_PROCESS_TERMINATION_GRACE_MS;
+
+export interface ChildProcessLifecycleResult<OutputKey extends PropertyKey = number> {
+  exitCode: number | null;
+  signal: NodeJS.Signals | null;
+  /** False when local capture streams were destroyed at the I/O deadline. */
+  ioDrained: boolean;
+  incompleteOutputs: ReadonlySet<OutputKey>;
+}
+
+export interface ChildProcessLifecycle<OutputKey extends PropertyKey = number> {
+  completion: Promise<ChildProcessLifecycleResult<OutputKey>>;
+  terminate(): void;
+  forceKill(): void;
+}
+
+export interface CapturedOutput<Key extends PropertyKey> {
+  key: Key;
+  stream: Readable;
+}
+
+export interface CapturedOutputDrainResult<Key extends PropertyKey> {
+  incomplete: ReadonlySet<Key>;
+}
+
+export interface CapturedOutputDrain<Key extends PropertyKey> {
+  completion: Promise<CapturedOutputDrainResult<Key>>;
+  startDeadline(): void;
+  dispose(): void;
+}
+
+interface ChildProcessLifecycleOptions {
+  killGraceMs: number;
+  ioDrainTimeoutMs: number;
+  exitAcknowledgementMs?: number;
+  /** Narrow test seam for an OS outcome that cannot be induced reliably. */
+  signalProcessTree?: (signal: 'SIGTERM' | 'SIGKILL') => Promise<boolean>;
+}
+
+interface CapturedOutputState {
+  stream: Readable;
+  ended: boolean;
+  onEnd: () => void;
+  onClose: () => void;
+  onError: () => void;
+}
+
+/**
+ * Owns the one captured-output completion policy shared by retained and
+ * one-shot child processes. Only a normal `end` is complete; premature
+ * `close`, stream `error`, and deadline destruction are incomplete.
+ */
+export function trackCapturedOutputDrain<Key extends PropertyKey>(
+  outputs: readonly CapturedOutput<Key>[],
+  timeoutMs: number,
+): CapturedOutputDrain<Key> {
+  const states = new Map<Key, CapturedOutputState>();
+  const pending = new Set<Key>();
+  const incomplete = new Set<Key>();
+  let started = false;
+  let completed = false;
+  let timer: NodeJS.Timeout | undefined;
+  let resolveCompletion!: (result: CapturedOutputDrainResult<Key>) => void;
+  const completion = new Promise<CapturedOutputDrainResult<Key>>((resolve) => {
+    resolveCompletion = resolve;
+  });
+
+  for (const { key, stream } of outputs) {
+    const state: CapturedOutputState = {
+      stream,
+      ended: stream.readableEnded,
+      onEnd: () => settleStream(key, 'end'),
+      onClose: () => settleStream(key, 'close'),
+      onError: () => settleStream(key, 'error'),
+    };
+    if (states.has(key)) throw new Error(`Duplicate captured output key: ${String(key)}`);
+    states.set(key, state);
+    if (stream.destroyed && !stream.readableEnded) incomplete.add(key);
+    if (!stream.readableEnded && !stream.destroyed) pending.add(key);
+    stream.on('end', state.onEnd);
+    stream.on('close', state.onClose);
+    stream.on('error', state.onError);
+  }
+
+  function startDeadline(): void {
+    if (completed || started) return;
+    started = true;
+    if (pending.size === 0) {
+      finish();
+      return;
+    }
+    timer = setTimeout(expire, timeoutMs);
+  }
+
+  function settleStream(key: Key, event: 'end' | 'close' | 'error'): void {
+    if (completed) return;
+    const state = states.get(key);
+    if (!state) return;
+    if (event === 'end') state.ended = true;
+    if (event === 'error' || (event === 'close' && !state.ended)) incomplete.add(key);
+    pending.delete(key);
+    if (started && pending.size === 0) finish();
+  }
+
+  function expire(): void {
+    timer = undefined;
+    for (const key of [...pending]) {
+      const state = states.get(key);
+      if (!state) continue;
+      incomplete.add(key);
+      pending.delete(key);
+      state.stream.destroy();
+    }
+    finish();
+  }
+
+  function dispose(): void {
+    if (completed) return;
+    started = true;
+    expire();
+  }
+
+  function finish(): void {
+    if (completed || !started || pending.size > 0) return;
+    completed = true;
+    if (timer) clearTimeout(timer);
+    timer = undefined;
+    for (const state of states.values()) {
+      state.stream.off('end', state.onEnd);
+      state.stream.off('close', state.onClose);
+      state.stream.off('error', state.onError);
+    }
+    resolveCompletion({ incomplete: new Set(incomplete) });
+  }
+
+  return { completion, startDeadline, dispose };
+}
+
+/**
+ * Tracks direct-root exit separately from captured stream drain. An escaped
+ * descendant can retain an inherited writer after the root exits, so
+ * ChildProcess `close` is not a safe completion boundary by itself.
+ */
+export function manageChildProcessLifecycle<OutputKey extends PropertyKey>(
+  child: ChildProcess,
+  outputs: readonly CapturedOutput<OutputKey>[],
+  options: ChildProcessLifecycleOptions,
+): ChildProcessLifecycle<OutputKey> {
+  let exitCode: number | null = null;
+  let signal: NodeJS.Signals | null = null;
+  let rootExited = false;
+  let ioDrainTimedOut = false;
+  let settled = false;
+  let terminationStarted = false;
+  let killSent = false;
+  let signalsInFlight = 0;
+  let killTimer: NodeJS.Timeout | undefined;
+  let exitAcknowledgementTimer: NodeJS.Timeout | undefined;
+  let outputDrainResult: CapturedOutputDrainResult<OutputKey> | undefined;
+  const outputDrain = trackCapturedOutputDrain(outputs, options.ioDrainTimeoutMs);
+
+  let resolveCompletion!: (result: ChildProcessLifecycleResult<OutputKey>) => void;
+  let rejectCompletion!: (error: Error) => void;
+  const completion = new Promise<ChildProcessLifecycleResult<OutputKey>>((resolve, reject) => {
+    resolveCompletion = resolve;
+    rejectCompletion = reject;
+  });
+  void outputDrain.completion.then((result) => {
+    outputDrainResult = result;
+    ioDrainTimedOut = result.incomplete.size > 0;
+    maybeFinish();
+  });
+
+  const onExit = (code: number | null, exitSignal: NodeJS.Signals | null) => {
+    if (settled) return;
+    rootExited = true;
+    exitCode = code;
+    signal = exitSignal;
+    if (exitAcknowledgementTimer) clearTimeout(exitAcknowledgementTimer);
+    outputDrain.startDeadline();
+    maybeFinish();
+  };
+  const onError = (error: Error) => {
+    if (settled) return;
+    outputDrain.dispose();
+    fail(error);
+  };
+
+  child.once('exit', onExit);
+  child.once('error', onError);
+
+  function terminate(): void {
+    if (settled || terminationStarted) return;
+    terminationStarted = true;
+    void runSignal('SIGTERM').then(() => {
+      if (settled || killSent) return;
+      killTimer = setTimeout(forceKill, options.killGraceMs);
+    });
+  }
+
+  function forceKill(): void {
+    if (settled || killSent) return;
+    terminationStarted = true;
+    killSent = true;
+    if (killTimer) clearTimeout(killTimer);
+    void runSignal('SIGKILL').then(() => {
+      if (settled || rootExited) return;
+      exitAcknowledgementTimer = setTimeout(() => {
+        if (settled || rootExited) return;
+        void runSignal('SIGKILL').then(() => {
+          if (settled || rootExited) return;
+          outputDrain.dispose();
+          fail(new Error('Child process did not acknowledge exit after forced termination'));
+        });
+      }, options.exitAcknowledgementMs ?? DEFAULT_PROCESS_TERMINATION_GRACE_MS);
+    });
+  }
+
+  function runSignal(treeSignal: 'SIGTERM' | 'SIGKILL'): Promise<boolean> {
+    signalsInFlight += 1;
+    return signalTree(treeSignal).finally(() => {
+      signalsInFlight -= 1;
+      maybeFinish();
+    });
+  }
+
+  function signalTree(treeSignal: 'SIGTERM' | 'SIGKILL'): Promise<boolean> {
+    try {
+      return (
+        options.signalProcessTree?.(treeSignal) ?? terminateChildProcessTree(child, treeSignal)
+      ).catch(() => false);
+    } catch {
+      return Promise.resolve(false);
+    }
+  }
+
+  function maybeFinish(): void {
+    if (!rootExited || !outputDrainResult || signalsInFlight > 0) return;
+    finish();
+  }
+
+  function finish(): void {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    resolveCompletion({
+      exitCode,
+      signal,
+      ioDrained: !ioDrainTimedOut,
+      incompleteOutputs: new Set(outputDrainResult?.incomplete),
+    });
+  }
+
+  function fail(error: Error): void {
+    if (settled) return;
+    settled = true;
+    cleanup();
+    rejectCompletion(error);
+  }
+
+  function cleanup(): void {
+    if (killTimer) clearTimeout(killTimer);
+    if (exitAcknowledgementTimer) clearTimeout(exitAcknowledgementTimer);
+    outputDrain.dispose();
+    child.off('exit', onExit);
+    child.off('error', onError);
+  }
+
+  maybeFinish();
+  return { completion, terminate, forceKill };
+}

--- a/packages/runtime/src/filesystem-worker/process-runner.ts
+++ b/packages/runtime/src/filesystem-worker/process-runner.ts
@@ -7,10 +7,11 @@ import {
   type ChildFdInput,
   writeChildFdInputs,
 } from '../child-fd-input.js';
+import { DEFAULT_PROCESS_TERMINATION_GRACE_MS } from '../process-tree-terminator.js';
 import {
-  DEFAULT_PROCESS_TERMINATION_GRACE_MS,
-  terminateChildProcessTree,
-} from '../process-tree-terminator.js';
+  DEFAULT_PROCESS_IO_DRAIN_TIMEOUT_MS,
+  manageChildProcessLifecycle,
+} from '../child-process-lifecycle.js';
 
 export const FILESYSTEM_WORKER_MAX_RESPONSE_BYTES = 8 * 1024 * 1024;
 export const FILESYSTEM_WORKER_MAX_STDERR_BYTES = 1024 * 1024;
@@ -27,6 +28,7 @@ export interface FilesystemWorkerProcessRunInput {
   maxResponseBytes?: number;
   maxStderrBytes?: number;
   killGraceMs?: number;
+  ioDrainTimeoutMs?: number;
 }
 
 export interface FilesystemWorkerProcessRunResult {
@@ -49,6 +51,17 @@ export async function runFilesystemWorkerProcess(
 ): Promise<FilesystemWorkerProcessRunResult> {
   const program = input.argv[0];
   if (!program) throw new Error('Filesystem worker argv must include a program.');
+  if (input.abortSignal?.aborted) {
+    closeChildFdSources(input.fdInputs);
+    return {
+      exitCode: 1,
+      stdout: '',
+      stderrTail: '',
+      timedOut: false,
+      aborted: true,
+      responseOverflow: false,
+    };
+  }
   let child: WorkerChildProcess;
   try {
     child = spawn(program, input.argv.slice(1), {
@@ -73,20 +86,13 @@ async function observeWorker(
     const stderrLimit = input.maxStderrBytes ?? FILESYSTEM_WORKER_MAX_STDERR_BYTES;
     const timeoutMs = input.timeoutMs ?? FILESYSTEM_WORKER_DEFAULT_TIMEOUT_MS;
     const killGraceMs = input.killGraceMs ?? DEFAULT_PROCESS_TERMINATION_GRACE_MS;
+    const ioDrainTimeoutMs = input.ioDrainTimeoutMs ?? DEFAULT_PROCESS_IO_DRAIN_TIMEOUT_MS;
     const stdoutChunks: Buffer[] = [];
     let stdoutBytes = 0;
     let stderrTail: Buffer<ArrayBufferLike> = Buffer.alloc(0);
     let responseOverflow = false;
     let termination: 'timeout' | 'abort' | 'overflow' | undefined;
     let settled = false;
-    let killTimer: NodeJS.Timeout | undefined;
-
-    const timeout = setTimeout(() => terminate('timeout'), timeoutMs);
-    const abort = () => terminate('abort');
-    if (input.abortSignal) {
-      if (input.abortSignal.aborted) abort();
-      else input.abortSignal.addEventListener('abort', abort, { once: true });
-    }
     child.stdout.on('data', (chunk: Buffer) => {
       if (responseOverflow) return;
       stdoutBytes += chunk.length;
@@ -101,32 +107,47 @@ async function observeWorker(
     child.stderr.on('data', (chunk: Buffer) => {
       stderrTail = appendBoundedTail(stderrTail, chunk, stderrLimit);
     });
-    child.once('error', (error) => {
+    const lifecycle = manageChildProcessLifecycle(
+      child,
+      [
+        { key: 'stdout', stream: child.stdout },
+        { key: 'stderr', stream: child.stderr },
+      ],
+      {
+        killGraceMs,
+        ioDrainTimeoutMs,
+      },
+    );
+    void lifecycle.completion.then((outcome) => {
       if (settled) return;
-      settled = true;
-      cleanup();
-      reject(error);
-    });
-    child.once('close', (exitCode) => {
-      if (settled) return;
+      if (!outcome.ioDrained) {
+        rejectOnce(new Error('Filesystem worker output did not drain before lifecycle deadline'));
+        return;
+      }
       settled = true;
       cleanup();
       resolvePromise({
-        exitCode: exitCode ?? 1,
+        exitCode: outcome.exitCode ?? 1,
         stdout: responseOverflow ? '' : Buffer.concat(stdoutChunks).toString('utf8'),
         stderrTail: stderrTail.toString('utf8'),
         timedOut: termination === 'timeout',
         aborted: termination === 'abort',
         responseOverflow,
       });
-    });
+    }, rejectOnce);
+    const timeout = setTimeout(() => terminate('timeout'), timeoutMs);
+    const abort = () => terminate('abort');
+    if (input.abortSignal) {
+      if (input.abortSignal.aborted) abort();
+      else input.abortSignal.addEventListener('abort', abort, { once: true });
+    }
     child.stdin.once('error', () => {});
     try {
       writeChildFdInputs(child, input.fdInputs);
     } catch (error) {
       settled = true;
       cleanup();
-      void terminateChildProcessTree(child, 'SIGKILL');
+      lifecycle.forceKill();
       reject(error);
       return;
     }
@@ -135,13 +156,18 @@ async function observeWorker(
     function terminate(reason: 'timeout' | 'abort' | 'overflow'): void {
       if (termination || settled) return;
       termination = reason;
-      terminateChildProcessTree(child, 'SIGTERM');
-      killTimer = setTimeout(() => terminateChildProcessTree(child, 'SIGKILL'), killGraceMs);
+      lifecycle.terminate();
+    }
+
+    function rejectOnce(error: Error): void {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
     }
 
     function cleanup(): void {
       clearTimeout(timeout);
-      if (killTimer) clearTimeout(killTimer);
       input.abortSignal?.removeEventListener('abort', abort);
     }
   });

--- a/packages/runtime/src/pipe-process-driver.ts
+++ b/packages/runtime/src/pipe-process-driver.ts
@@ -8,10 +8,19 @@ import {
   writeChildFdInputs,
   type ChildFdInput,
 } from './child-fd-input.js';
+import {
+  trackCapturedOutputDrain,
+  type CapturedOutputDrain,
+  type CapturedOutputDrainResult,
+} from './child-process-lifecycle.js';
+
+type PipeOutputStream = 'stdout' | 'stderr';
 
 export interface PipeProcessExit {
   exitCode: number | null;
   signal: NodeJS.Signals | null;
+  stdoutTruncated: boolean;
+  stderrTruncated: boolean;
 }
 
 export interface PipeProcessDriverOptions {
@@ -19,7 +28,9 @@ export interface PipeProcessDriverOptions {
   cwd: string;
   env?: NodeJS.ProcessEnv;
   fdInputs?: readonly ChildFdInput[];
+  outputDrainMs: number;
   onData: (stream: 'stdout' | 'stderr', data: string) => void;
+  onRootExit: () => void;
   onExit: (exit: PipeProcessExit) => void;
   onFailure: (error: Error) => void;
 }
@@ -31,8 +42,11 @@ export class PipeProcessDriver {
   private readonly child: ChildProcess;
   private readonly stdout: Readable;
   private readonly stderr: Readable;
+  private readonly outputDrain: CapturedOutputDrain<PipeOutputStream>;
   private disposed = false;
-  private exited = false;
+  private settled = false;
+  private outputDrainResult: CapturedOutputDrainResult<PipeOutputStream> | undefined;
+  private rootExit: Omit<PipeProcessExit, 'stdoutTruncated' | 'stderrTruncated'> | undefined;
 
   constructor(private readonly options: PipeProcessDriverOptions) {
     try {
@@ -57,15 +71,26 @@ export class PipeProcessDriver {
     this.stderr.setEncoding('utf8');
     this.stdout.on('data', this.onStdout);
     this.stderr.on('data', this.onStderr);
-    this.child.on('close', this.onClose);
+    this.outputDrain = trackCapturedOutputDrain(
+      [
+        { key: 'stdout', stream: this.stdout },
+        { key: 'stderr', stream: this.stderr },
+      ],
+      options.outputDrainMs,
+    );
+    void this.outputDrain.completion.then((result) => {
+      if (this.disposed || this.settled) return;
+      this.outputDrainResult = result;
+      this.settleAfterDrain();
+    });
+    this.child.on('exit', this.onRootExit);
+    this.child.on('close', this.onCloseFallback);
     this.child.on('error', this.onError);
     this.ready = waitForSpawn(this.child);
-    try {
-      writeChildFdInputs(this.child, options.fdInputs);
-    } catch (error) {
-      this.child.kill('SIGKILL');
-      throw error;
-    }
+  }
+
+  writeInputs(): void {
+    writeChildFdInputs(this.child, this.options.fdInputs);
   }
 
   kill(signal: 'SIGTERM' | 'SIGKILL'): boolean {
@@ -75,28 +100,56 @@ export class PipeProcessDriver {
   dispose(): void {
     if (this.disposed) return;
     this.disposed = true;
+    this.outputDrain.dispose();
     this.stdout.off('data', this.onStdout);
     this.stderr.off('data', this.onStderr);
-    this.child.off('close', this.onClose);
+    this.child.off('exit', this.onRootExit);
+    this.child.off('close', this.onCloseFallback);
     this.child.off('error', this.onError);
+    this.stdout.destroy();
+    this.stderr.destroy();
   }
 
   private readonly onStdout = (data: string): void => {
-    if (!this.disposed && !this.exited) this.options.onData('stdout', data);
+    if (!this.disposed && !this.settled) this.options.onData('stdout', data);
   };
 
   private readonly onStderr = (data: string): void => {
-    if (!this.disposed && !this.exited) this.options.onData('stderr', data);
+    if (!this.disposed && !this.settled) this.options.onData('stderr', data);
   };
 
-  private readonly onClose = (exitCode: number | null, signal: NodeJS.Signals | null): void => {
-    if (this.disposed || this.exited) return;
-    this.exited = true;
-    this.options.onExit({ exitCode, signal });
+  private readonly onRootExit = (exitCode: number | null, signal: NodeJS.Signals | null): void => {
+    if (this.disposed || this.rootExit) return;
+    this.rootExit = { exitCode, signal };
+    this.options.onRootExit();
+    this.outputDrain.startDeadline();
+    this.settleAfterDrain();
   };
+
+  private readonly onCloseFallback = (
+    exitCode: number | null,
+    signal: NodeJS.Signals | null,
+  ): void => {
+    if (!this.rootExit) this.onRootExit(exitCode, signal);
+  };
+
+  private settleAfterDrain(): void {
+    if (!this.rootExit || !this.outputDrainResult) return;
+    this.settle();
+  }
+
+  private settle(): void {
+    if (this.disposed || this.settled || !this.rootExit || !this.outputDrainResult) return;
+    this.settled = true;
+    this.options.onExit({
+      ...this.rootExit,
+      stdoutTruncated: this.outputDrainResult.incomplete.has('stdout'),
+      stderrTruncated: this.outputDrainResult.incomplete.has('stderr'),
+    });
+  }
 
   private readonly onError = (error: Error): void => {
-    if (!this.disposed && !this.exited) this.options.onFailure(error);
+    if (!this.disposed && !this.settled) this.options.onFailure(error);
   };
 }
 

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -74,6 +74,7 @@ import {
   decodeAgentGraphIntentClaim,
   executionBoundaryContains,
   failureClassFromCompleteStopReason,
+  isActiveShellRunStatus,
   isDeepResearchSession,
   isSessionInlineRun,
   subagentSessionRuntimeSummary,
@@ -842,7 +843,7 @@ export class SessionManager {
         bashToolCalls.has(message.toolUseId) &&
         !ownToolCalls.has(message.toolUseId) &&
         message.content.kind === 'shell_run' &&
-        message.content.status === 'running'
+        isActiveShellRunStatus(message.content.status)
       ) {
         const { operation: _operation, ...result } = message.content;
         inherited.set(message.toolUseId, {

--- a/packages/runtime/src/shell-exec.ts
+++ b/packages/runtime/src/shell-exec.ts
@@ -20,10 +20,12 @@
 import { spawn } from 'node:child_process';
 import { buildShellSpawnPlan, defaultShellPlan, type ShellPlan } from './shell-detect.js';
 import { BashTailBuffer } from './bash-tail-buffer.js';
+import { DEFAULT_PROCESS_TERMINATION_GRACE_MS } from './process-tree-terminator.js';
 import {
-  DEFAULT_PROCESS_TERMINATION_GRACE_MS,
-  terminateChildProcessTree,
-} from './process-tree-terminator.js';
+  DEFAULT_PROCESS_IO_DRAIN_TIMEOUT_MS,
+  manageChildProcessLifecycle,
+  type ChildProcessLifecycleResult,
+} from './child-process-lifecycle.js';
 import { OUTPUT_RECOVERY_HINT } from './tool-output.js';
 import {
   buildSpawnStdio,
@@ -81,6 +83,8 @@ export interface BoundedShellOptions {
   abortSignal?: AbortSignal;
   /** Grace after SIGTERM before SIGKILL on timeout/abort. */
   killGraceMs?: number;
+  /** Maximum wait for stdout/stderr after the direct child exits. */
+  ioDrainTimeoutMs?: number;
   /** Receives every raw chunk live, before tail-bounding. */
   emitOutput?: (stream: 'stdout' | 'stderr', chunk: string) => void;
   /** Shell to run the command with. Defaults to the process-wide detected shell. */
@@ -109,10 +113,9 @@ export interface BoundedShellResult {
  * Run `command` in a shell, streaming output into a memory-bounded tail. Never
  * kills the command for producing too much output — it keeps only the last
  * `maxRetainedChars` per stream. On timeout/abort it SIGTERMs (then SIGKILLs
- * after a grace period) and resolves only once the managed shell has actually
- * exited and its captured streams have closed. Resolves with the result
- * (including timeout / abort flags); rejects
- * only when the process cannot be spawned.
+ * after a grace period) and separately bounds direct-child exit and captured
+ * stream drain. Resolves with the result (including timeout / abort flags);
+ * rejects when spawn or direct-root cleanup cannot be confirmed.
  */
 export function runShellWithBoundedTail(
   command: string,
@@ -140,6 +143,19 @@ function runSpawnedProcessWithBoundedTail(
   const cap = options.maxRetainedChars ?? BASH_MAX_RETAINED_CHARS;
   const liveCap = options.maxLiveEmitChars ?? BASH_MAX_LIVE_EMIT_CHARS;
   const graceMs = options.killGraceMs ?? DEFAULT_PROCESS_TERMINATION_GRACE_MS;
+  const ioDrainTimeoutMs = options.ioDrainTimeoutMs ?? DEFAULT_PROCESS_IO_DRAIN_TIMEOUT_MS;
+  if (options.abortSignal?.aborted) {
+    closeChildFdSources(options.fdInputs);
+    return Promise.resolve({
+      exitCode: 130,
+      stdout: '',
+      stderr: '',
+      stdoutTruncated: false,
+      stderrTruncated: false,
+      timedOut: false,
+      aborted: true,
+    });
+  }
   return new Promise<BoundedShellResult>((resolvePromise, reject) => {
     let child: ReturnType<typeof spawn>;
     try {
@@ -166,29 +182,25 @@ function runSpawnedProcessWithBoundedTail(
     // stream passes liveCap we emit one marker and stop forwarding it live.
     let liveEmitted = { stdout: 0, stderr: 0 };
     let liveSuppressed = { stdout: false, stderr: false };
-    // Set when timeout/abort begins terminating the child. 'close' is the single
-    // resolve point, so this remembers WHY we resolve once the child is gone.
+    // Keep the caller-visible reason after root exit and stream drain settle.
     let termination: { timedOut?: boolean; aborted?: boolean } | null = null;
-    let terminationTask: Promise<unknown> | undefined;
-    let killTimer: NodeJS.Timeout | undefined;
-    let closeStarted = false;
 
     child.stdout?.setEncoding('utf8');
     child.stderr?.setEncoding('utf8');
     child.stdout?.on('data', (chunk: string) => append('stdout', chunk));
     child.stderr?.on('data', (chunk: string) => append('stderr', chunk));
-    child.on('error', (error: Error) => {
-      // The process could not be spawned at all (e.g. the shell binary is
-      // missing). This is exceptional — reject so callers surface it.
-      if (settled || closeStarted) return;
-      settled = true;
-      cleanup();
-      reject(error);
-    });
-    // 'close' fires only after the process has exited AND its stdio has closed,
-    // so resolving here guarantees the child is gone and no further output can
-    // arrive — even when we triggered the kill ourselves.
-    child.on('close', (code, signal) => resolveOnce(code, signal));
+    const lifecycle = manageChildProcessLifecycle(
+      child,
+      [
+        ...(child.stdout ? [{ key: 'stdout' as const, stream: child.stdout }] : []),
+        ...(child.stderr ? [{ key: 'stderr' as const, stream: child.stderr }] : []),
+      ],
+      {
+        killGraceMs: graceMs,
+        ioDrainTimeoutMs,
+      },
+    );
+    void lifecycle.completion.then(resolveOnce, rejectOnce);
 
     const timer = setTimeout(() => beginTermination({ timedOut: true }), options.timeoutMs);
     const abort = () => beginTermination({ aborted: true });
@@ -201,7 +213,7 @@ function runSpawnedProcessWithBoundedTail(
     } catch (error) {
       settled = true;
       cleanup();
-      void terminateChildProcessTree(child, 'SIGKILL');
+      lifecycle.forceKill();
       reject(error);
     }
 
@@ -237,51 +249,49 @@ function runSpawnedProcessWithBoundedTail(
 
     // Begin terminating a still-running child (timeout or abort). SIGTERM first
     // so a well-behaved child can flush and exit; if it ignores SIGTERM, SIGKILL
-    // after a grace period guarantees the managed group is force-signalled. We do
-    // NOT resolve here: 'close' remains the single process/output resolve point.
+    // after a grace period guarantees the managed group is force-signalled.
     function beginTermination(reason: { timedOut?: boolean; aborted?: boolean }): void {
       if (termination || settled) return;
       termination = reason;
-      terminationTask = terminateTree('SIGTERM').then(() => {
-        if (settled || closeStarted) return;
-        killTimer = setTimeout(() => {
-          terminationTask = terminateTree('SIGKILL');
-        }, graceMs);
-      });
+      lifecycle.terminate();
     }
 
-    // Signal the managed process group and any detached descendants identifiable
-    // at the current snapshot. The later SIGKILL call is harmless when gone.
-    function terminateTree(signal: 'SIGTERM' | 'SIGKILL'): Promise<boolean> {
-      return terminateChildProcessTree(child, signal);
+    function rejectOnce(error: Error): void {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(error);
     }
 
-    // Settle once, on 'close'. exitCode reflects how we terminated: 124 timeout,
-    // 130 abort, else the child's own code (or 128+signal when signal-killed).
-    function resolveOnce(code: number | null, signal: NodeJS.Signals | null): void {
-      if (settled || closeStarted) return;
-      closeStarted = true;
-      void (terminationTask ?? Promise.resolve()).then(() => {
-        if (settled) return;
-        settled = true;
-        cleanup();
-        const stdout = shellTailValueWithUnsafeDropMarker(stdoutBuf);
-        const stderr = shellTailValueWithUnsafeDropMarker(stderrBuf);
-        resolvePromise({
-          exitCode: termination ? (termination.timedOut ? 124 : 130) : (code ?? (signal ? 128 : 1)),
-          stdout,
-          stderr,
-          stdoutTruncated: stdoutChars > stdout.length || stdoutBuf.hasDroppedUnsafe(),
-          stderrTruncated: stderrChars > stderr.length || stderrBuf.hasDroppedUnsafe(),
-          timedOut: !!termination?.timedOut,
-          aborted: !!termination?.aborted,
-        });
+    function resolveOnce(outcome: ChildProcessLifecycleResult<'stdout' | 'stderr'>): void {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      const stdout = shellTailValueWithUnsafeDropMarker(stdoutBuf);
+      const stderr = shellTailValueWithUnsafeDropMarker(stderrBuf);
+      resolvePromise({
+        exitCode: termination
+          ? termination.timedOut
+            ? 124
+            : 130
+          : (outcome.exitCode ?? (outcome.signal ? 128 : 1)),
+        stdout,
+        stderr,
+        stdoutTruncated:
+          outcome.incompleteOutputs.has('stdout') ||
+          stdoutChars > stdout.length ||
+          stdoutBuf.hasDroppedUnsafe(),
+        stderrTruncated:
+          outcome.incompleteOutputs.has('stderr') ||
+          stderrChars > stderr.length ||
+          stderrBuf.hasDroppedUnsafe(),
+        timedOut: !!termination?.timedOut,
+        aborted: !!termination?.aborted,
       });
     }
 
     function cleanup(): void {
       clearTimeout(timer);
-      if (killTimer) clearTimeout(killTimer);
       if (options.abortSignal) options.abortSignal.removeEventListener('abort', abort);
     }
   });

--- a/packages/runtime/src/shell-run-contract.ts
+++ b/packages/runtime/src/shell-run-contract.ts
@@ -22,6 +22,7 @@ export const DEFAULT_MAX_LIVE_SHELL_RUNS = 64;
 export const DEFAULT_MAX_LIVE_PTY_RUNS = 8;
 export const DEFAULT_SHELL_RUN_FLUSH_INTERVAL_MS = 1_000;
 export const DEFAULT_SHELL_RUN_FLUSH_BYTES = 64 * 1024;
+export const DEFAULT_PIPE_OUTPUT_DRAIN_MS = 2_000;
 export const SHELL_RUN_CONTEXT_SUMMARY_LIMIT = 8;
 export const SHELL_RUN_RESOURCE_PREFIX = 'maka://runtime/background-tasks';
 export const MAX_SHELL_RUN_RESOURCE_REF_CHARS =
@@ -44,6 +45,7 @@ export interface ShellRunProcessManagerInput {
   maxLiveEmitChars?: number;
   killGraceMs?: number;
   exitAcknowledgementMs?: number;
+  pipeOutputDrainMs?: number;
 }
 
 export interface ShellRunBashInput {

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -1,6 +1,7 @@
 import { constants as osConstants } from 'node:os';
 import { isDeepStrictEqual } from 'node:util';
 import {
+  isActiveShellRunStatus,
   isTerminalShellRunStatus,
   type ShellMode,
   type ShellOutput,
@@ -37,6 +38,7 @@ import {
   DEFAULT_BASH_TIMEOUT_MS,
   DEFAULT_MAX_LIVE_PTY_RUNS,
   DEFAULT_MAX_LIVE_SHELL_RUNS,
+  DEFAULT_PIPE_OUTPUT_DRAIN_MS,
   DEFAULT_SHELL_RUN_FLUSH_BYTES,
   DEFAULT_SHELL_RUN_FLUSH_INTERVAL_MS,
   MAX_FOREGROUND_BASH_TIMEOUT_MS,
@@ -62,6 +64,7 @@ import {
   type TerminalToolResult,
 } from './shell-run-tool-result.js';
 import { CompletionLatch } from './completion-latch.js';
+import { closeChildFdSources } from './child-fd-input.js';
 
 type LifecycleCause = 'timeout' | 'cancel' | 'shutdown';
 type DriverExit =
@@ -110,9 +113,8 @@ interface LiveShellRunBase {
   shellRunId: string;
   sessionId: string;
   mode: ShellMode;
-  startedAt: number;
   timeoutMs?: number;
-  record?: ShellRunRecord;
+  record: ShellRunRecord;
   visibleRef: boolean;
   driverExit?: DriverExit;
   lifecycleCause?: LifecycleCause;
@@ -128,7 +130,8 @@ interface LiveShellRunBase {
   lastSnapshotWallTime: number;
   finalizeOnce?: Promise<ShellRunRecord>;
   slotReservation: ShellRunSlotReservation;
-  nativeExit: CompletionLatch<DriverExit>;
+  rootExited: boolean;
+  nativeRootExit: CompletionLatch<void>;
   startupSettled: CompletionLatch<void>;
   finished: CompletionLatch<ShellRunRecord>;
   onCompletion?: (outcome: { successful: boolean }) => void;
@@ -182,6 +185,8 @@ export class ShellRunProcessManager
   private readonly live = new Map<string, LiveShellRun>();
   private readonly sessionCloseLeases = new Map<string, Set<symbol>>();
   private readonly sessionTerminationEpochs = new Map<string, number>();
+  private readonly pendingStartups = new Map<string, Set<Promise<void>>>();
+  private readonly startupOwners = new Set<string>();
   private readonly maxLiveShellRuns: number;
   private readonly maxLivePtyRuns: number;
   private readonly flushIntervalMs: number;
@@ -190,6 +195,7 @@ export class ShellRunProcessManager
   private readonly maxLiveEmitChars: number;
   private readonly killGraceMs: number;
   private readonly exitAcknowledgementMs: number;
+  private readonly pipeOutputDrainMs: number;
   private reservedShellRuns = 0;
   private reservedPtyRuns = 0;
   private shuttingDown = false;
@@ -204,58 +210,60 @@ export class ShellRunProcessManager
     this.killGraceMs = input.killGraceMs ?? DEFAULT_PROCESS_TERMINATION_GRACE_MS;
     this.exitAcknowledgementMs =
       input.exitAcknowledgementMs ?? DEFAULT_PROCESS_TERMINATION_GRACE_MS;
+    this.pipeOutputDrainMs = input.pipeOutputDrainMs ?? DEFAULT_PIPE_OUTPUT_DRAIN_MS;
   }
 
   async runBackgroundBash(input: ShellRunBashInput): Promise<ShellRunToolResult> {
     const onCompletion = onceShellRunCompletion(input.onCompletion);
     const ownedInput = onCompletion ? { ...input, onCompletion } : input;
-    let live: LiveShellRun;
     try {
-      if (input.abortSignal?.aborted)
-        throw abortError('Command aborted before shell process started');
-      const mode: ShellMode = input.pty ? 'pty' : 'pipes';
-      const timeoutMs = normalizeBackgroundTimeoutMs(input.timeoutMs);
-      live = await this.start(ownedInput, mode, timeoutMs, false);
+      return await this.withPendingStartup(input.sessionId, async () => {
+        if (input.abortSignal?.aborted)
+          throw abortError('Command aborted before shell process started');
+        const mode: ShellMode = input.pty ? 'pty' : 'pipes';
+        const timeoutMs = normalizeBackgroundTimeoutMs(input.timeoutMs);
+        const live = await this.start(ownedInput, mode, timeoutMs, false);
+        const record = await this.persistObservation(live);
+        if (input.abortSignal?.aborted) {
+          this.requestForcedTermination(live, 'cancel');
+          return shellRunContent(await this.markObserved(await live.finished.join()));
+        }
+        live.visibleRef = true;
+        let handoffRecord = live.record.revision >= record.revision ? live.record : record;
+        if (isTerminalShellRunStatus(handoffRecord.status)) {
+          handoffRecord = await this.markObserved(handoffRecord);
+        }
+        this.notifyShellRunUpdate(handoffRecord);
+        return isTerminalShellRunStatus(handoffRecord.status)
+          ? shellRunContent(handoffRecord)
+          : compactShellRunContent(handoffRecord);
+      });
     } catch (error) {
       notifyFailedStartup(onCompletion);
       throw error;
     }
-    const record = await this.persistObservation(live);
-    if (input.abortSignal?.aborted) {
-      this.requestForcedTermination(live, 'cancel');
-      return shellRunContent(await this.markObserved(await live.finished.join()));
-    }
-    live.visibleRef = true;
-    let handoffRecord =
-      live.record && live.record.revision >= record.revision ? live.record : record;
-    if (isTerminalShellRunStatus(handoffRecord.status)) {
-      handoffRecord = await this.markObserved(handoffRecord);
-    }
-    this.notifyShellRunUpdate(handoffRecord);
-    return isTerminalShellRunStatus(handoffRecord.status)
-      ? shellRunContent(handoffRecord)
-      : compactShellRunContent(handoffRecord);
   }
 
   async runForegroundBash(input: ShellRunBashInput): Promise<TerminalToolResult> {
     const onCompletion = onceShellRunCompletion(input.onCompletion);
     const ownedInput = onCompletion ? { ...input, onCompletion } : input;
-    let live: LiveShellRun;
     try {
-      if (input.pty)
-        throw new Error('Foreground Bash does not support PTY mode; set run_in_background=true');
-      if (input.abortSignal?.aborted)
-        throw abortError('Command aborted before shell process started');
-      const timeoutMs = normalizeForegroundTimeoutMs(input.timeoutMs ?? DEFAULT_BASH_TIMEOUT_MS);
-      live = await this.start(ownedInput, 'pipes', timeoutMs, true);
+      return await this.withPendingStartup(input.sessionId, async () => {
+        if (input.pty)
+          throw new Error('Foreground Bash does not support PTY mode; set run_in_background=true');
+        if (input.abortSignal?.aborted)
+          throw abortError('Command aborted before shell process started');
+        const timeoutMs = normalizeForegroundTimeoutMs(input.timeoutMs ?? DEFAULT_BASH_TIMEOUT_MS);
+        const live = await this.start(ownedInput, 'pipes', timeoutMs, true);
+        if ((await live.finished.waitFor(input.abortSignal)) === 'abort') {
+          this.requestForcedTermination(live, 'cancel');
+        }
+        return this.markObservedAndReturnTerminal(await live.finished.join());
+      });
     } catch (error) {
       notifyFailedStartup(onCompletion);
       throw error;
     }
-    if ((await live.finished.waitFor(input.abortSignal)) === 'abort') {
-      this.requestForcedTermination(live, 'cancel');
-    }
-    return this.markObservedAndReturnTerminal(await live.finished.join());
   }
 
   async writeStdin(input: ShellRunWriteInput): Promise<ShellRunToolResult> {
@@ -484,7 +492,12 @@ export class ShellRunProcessManager
     const records = await this.input.store.listSessionShellRuns(sessionId);
     let recovered = 0;
     for (const record of records) {
-      if (record.status !== 'running' || this.live.has(record.shellRunId)) continue;
+      if (
+        !isActiveShellRunStatus(record.status) ||
+        this.live.has(record.shellRunId) ||
+        this.startupOwners.has(record.shellRunId)
+      )
+        continue;
       await this.markOrphaned(record, 'Runtime restarted without a live shell process handle');
       recovered += 1;
     }
@@ -495,9 +508,13 @@ export class ShellRunProcessManager
     const lease = { sessionId, token: Symbol('session-close') };
     this.holdSessionClose(lease);
     this.sessionTerminationEpochs.set(sessionId, this.sessionTerminationEpoch(sessionId) + 1);
-    const targets = [...this.live.values()].filter((live) => live.sessionId === sessionId);
-    await Promise.all(targets.map((live) => this.terminateLive(live, 'shutdown')));
-    return lease;
+    try {
+      await this.settleSessionLives(sessionId);
+      return lease;
+    } catch (error) {
+      this.rollbackSessionClose(lease);
+      throw error;
+    }
   }
 
   async commitSessionClose(lease: SessionCloseLease): Promise<void> {
@@ -508,8 +525,7 @@ export class ShellRunProcessManager
       lease.sessionId,
       this.sessionTerminationEpoch(lease.sessionId) + 1,
     );
-    const targets = [...this.live.values()].filter((live) => live.sessionId === lease.sessionId);
-    await Promise.all(targets.map((live) => this.terminateLive(live, 'shutdown')));
+    await this.settleSessionLives(lease.sessionId);
   }
 
   rollbackSessionClose(lease: SessionCloseLease): void {
@@ -525,7 +541,17 @@ export class ShellRunProcessManager
 
   async terminateAll(): Promise<void> {
     this.shuttingDown = true;
-    await Promise.all([...this.live.values()].map((live) => this.terminateLive(live, 'shutdown')));
+    const failures: unknown[] = [];
+    await this.captureTerminationFailure(
+      this.terminateLives([...this.live.values()], 'shutdown'),
+      failures,
+    );
+    await Promise.all([...this.pendingStartups.values()].flatMap((startups) => [...startups]));
+    await this.captureTerminationFailure(
+      this.terminateLives([...this.live.values()], 'shutdown'),
+      failures,
+    );
+    if (failures.length > 0) throw failures[0];
   }
 
   liveCount(): number {
@@ -550,15 +576,34 @@ export class ShellRunProcessManager
     const slotReservation = this.reserveSlot(mode);
     try {
       const shellRunId = this.input.newId();
-      if (mode === 'pipes') {
-        return await this.startPipe(input, shellRunId, timeoutMs, forwardLive, slotReservation);
-      }
+      this.startupOwners.add(shellRunId);
+      try {
+        if (mode === 'pipes') {
+          return await this.startPipe(
+            input,
+            shellRunId,
+            timeoutMs,
+            forwardLive,
+            slotReservation,
+            sessionEpoch,
+          );
+        }
 
-      const stack = await racePromiseWithAbort(loadPtyStack(), input.abortSignal);
-      this.assertStartAllowed(input.sessionId, sessionEpoch);
-      if (input.abortSignal?.aborted)
-        throw abortError('Command aborted before PTY process started');
-      return await this.startPty(input, shellRunId, timeoutMs, stack, slotReservation);
+        const stack = await racePromiseWithAbort(loadPtyStack(), input.abortSignal);
+        this.assertStartAllowed(input.sessionId, sessionEpoch);
+        if (input.abortSignal?.aborted)
+          throw abortError('Command aborted before PTY process started');
+        return await this.startPty(
+          input,
+          shellRunId,
+          timeoutMs,
+          stack,
+          slotReservation,
+          sessionEpoch,
+        );
+      } finally {
+        this.startupOwners.delete(shellRunId);
+      }
     } catch (error) {
       this.releaseSlot(slotReservation);
       throw error;
@@ -571,58 +616,70 @@ export class ShellRunProcessManager
     timeoutMs: number | undefined,
     forwardLive: boolean,
     slotReservation: ShellRunSlotReservation,
+    sessionEpoch: number,
   ): Promise<LivePipeShellRun> {
+    const collector = new PipeTailCollector(this.maxRetainedChars);
     const pending: Array<(live: LivePipeShellRun) => void> = [];
     let live: LivePipeShellRun | undefined;
+    let startingRecord: ShellRunRecord | undefined;
+    let spawnAttempted = false;
     const dispatch = (callback: (target: LivePipeShellRun) => void): void => {
       if (live) callback(live);
       else pending.push(callback);
     };
-    const collector = new PipeTailCollector(this.maxRetainedChars);
-    const plan = input.argv
-      ? {
-          file: requireProgram(input.argv),
-          args: [...input.argv.slice(1)],
-          useShellOption: false,
-        }
-      : buildShellSpawnPlan(input.shell ?? defaultShellPlan(), input.command);
-    const driver = new PipeProcessDriver({
-      plan,
-      cwd: input.cwd,
-      ...(input.env ? { env: input.env } : {}),
-      ...(input.fdInputs ? { fdInputs: input.fdInputs } : {}),
-      onData: (stream, data) => dispatch((target) => this.onPipeData(target, stream, data)),
-      onExit: (exit) =>
-        dispatch((target) => this.onDriverExit(target, { mode: 'pipes', value: exit })),
-      onFailure: (error) => dispatch((target) => this.handleIntegrityFailure(target, error)),
-    });
-    live = {
-      ...this.createLiveBase(input, shellRunId, 'pipes', timeoutMs, slotReservation),
-      mode: 'pipes',
-      driver,
-      collector,
-      pendingFlushChars: 0,
-      forwardLive,
-      liveEmitted: { stdout: 0, stderr: 0 },
-      liveSuppressed: { stdout: false, stderr: false },
-      emitOutput: input.emitOutput,
-    };
-    this.live.set(shellRunId, live);
     try {
+      const plan = input.argv
+        ? {
+            file: requireProgram(input.argv),
+            args: [...input.argv.slice(1)],
+            useShellOption: false,
+          }
+        : buildShellSpawnPlan(input.shell ?? defaultShellPlan(), input.command);
+      startingRecord = await this.createStartingRecord(
+        input,
+        shellRunId,
+        timeoutMs,
+        collector.snapshot(),
+      );
+      this.assertStartupAllowed(input.sessionId, sessionEpoch, input.abortSignal);
+      spawnAttempted = true;
+      const driver = new PipeProcessDriver({
+        plan,
+        cwd: input.cwd,
+        ...(input.env ? { env: input.env } : {}),
+        ...(input.fdInputs ? { fdInputs: input.fdInputs } : {}),
+        outputDrainMs: this.pipeOutputDrainMs,
+        onData: (stream, data) => dispatch((target) => this.onPipeData(target, stream, data)),
+        onRootExit: () => dispatch((target) => this.onNativeRootExit(target)),
+        onExit: (exit) =>
+          dispatch((target) => this.onDriverExit(target, { mode: 'pipes', value: exit })),
+        onFailure: (error) => dispatch((target) => this.handleIntegrityFailure(target, error)),
+      });
+      live = {
+        ...this.createLiveBase(input, startingRecord, 'pipes', timeoutMs, slotReservation),
+        mode: 'pipes',
+        driver,
+        collector,
+        pendingFlushChars: 0,
+        forwardLive,
+        liveEmitted: { stdout: 0, stderr: 0 },
+        liveSuppressed: { stdout: false, stderr: false },
+        emitOutput: input.emitOutput,
+      };
+      this.live.set(shellRunId, live);
       for (const callback of pending) callback(live);
+      driver.writeInputs();
       await racePromiseWithAbort(driver.ready, input.abortSignal);
-      live.startedAt = this.input.now();
       this.armTimeout(live);
-      await this.createDurableRecord(live, input);
+      this.assertLiveStartupAllowed(live, sessionEpoch, input.abortSignal);
+      await this.markRunning(live);
+      this.assertLiveStillAdmitted(live, sessionEpoch);
       live.startupSettled.resolve();
       return live;
     } catch (error) {
-      try {
-        await this.cleanupUndurable(live);
-      } finally {
-        live.startupSettled.resolve();
-      }
-      throw error;
+      if (!spawnAttempted) closeChildFdSources(input.fdInputs);
+      if (!startingRecord) throw error;
+      throw await this.completeStartupFailure(live, startingRecord, error);
     }
   }
 
@@ -632,6 +689,7 @@ export class ShellRunProcessManager
     timeoutMs: number | undefined,
     stack: PtyStack,
     slotReservation: ShellRunSlotReservation,
+    sessionEpoch: number,
   ): Promise<LivePtyShellRun> {
     const pending: Array<(live: LivePtyShellRun) => void> = [];
     let live: LivePtyShellRun | undefined;
@@ -641,6 +699,7 @@ export class ShellRunProcessManager
       else pending.push(callback);
     };
     let collector: PtyScreenCollector | undefined;
+    let startingRecord: ShellRunRecord | undefined;
     try {
       collector = new PtyScreenCollector({
         stack,
@@ -658,6 +717,13 @@ export class ShellRunProcessManager
         resumeSource: () => driver?.resume(),
       });
       const plan = buildPtyShellSpawnPlan(input.shell ?? defaultShellPlan(), input.command);
+      startingRecord = await this.createStartingRecord(
+        input,
+        shellRunId,
+        timeoutMs,
+        collector.lastGoodSnapshot(),
+      );
+      this.assertStartupAllowed(input.sessionId, sessionEpoch, input.abortSignal);
       driver = new PtyProcessDriver({
         stack,
         file: plan.file,
@@ -667,8 +733,10 @@ export class ShellRunProcessManager
         cols: PTY_INITIAL_COLS,
         rows: PTY_INITIAL_ROWS,
         onData: (data) => dispatch((target) => target.collector.accept(data)),
-        onExit: (exit) =>
-          dispatch((target) => this.onDriverExit(target, { mode: 'pty', value: exit })),
+        onExit: (exit) => {
+          dispatch((target) => this.onNativeRootExit(target));
+          dispatch((target) => this.onDriverExit(target, { mode: 'pty', value: exit }));
+        },
         onInvariantFailure: (error) =>
           dispatch((target) => this.handleIntegrityFailure(target, error)),
       });
@@ -683,55 +751,53 @@ export class ShellRunProcessManager
       } catch {
         /* startup cleanup continues */
       }
-      throw error;
+      if (!startingRecord) throw error;
+      throw await this.completeStartupFailure(undefined, startingRecord, error);
     }
-    if (!driver || !collector) {
+    if (!driver || !collector || !startingRecord) {
       throw new Error('PTY startup completed without a driver and collector');
     }
     live = {
-      ...this.createLiveBase(input, shellRunId, 'pty', timeoutMs, slotReservation),
+      ...this.createLiveBase(input, startingRecord, 'pty', timeoutMs, slotReservation),
       mode: 'pty',
       driver,
       collector,
     };
     this.live.set(shellRunId, live);
     try {
-      for (const callback of pending) callback(live);
-      live.startedAt = this.input.now();
       this.armTimeout(live);
-      await this.createDurableRecord(live, input);
+      for (const callback of pending) callback(live);
+      this.assertLiveStartupAllowed(live, sessionEpoch, input.abortSignal);
+      await this.markRunning(live);
+      this.assertLiveStillAdmitted(live, sessionEpoch);
       live.startupSettled.resolve();
       return live;
     } catch (error) {
-      try {
-        await this.cleanupUndurable(live);
-      } finally {
-        live.startupSettled.resolve();
-      }
-      throw error;
+      throw await this.completeStartupFailure(live, startingRecord, error);
     }
   }
 
   private createLiveBase(
     input: ShellRunBashInput,
-    shellRunId: string,
+    record: ShellRunRecord,
     mode: ShellMode,
     timeoutMs: number | undefined,
     slotReservation: ShellRunSlotReservation,
   ): LiveShellRunBase {
     return {
-      shellRunId,
+      shellRunId: record.shellRunId,
       sessionId: input.sessionId,
       mode,
-      startedAt: 0,
       ...(timeoutMs !== undefined ? { timeoutMs } : {}),
+      record,
       visibleRef: false,
       pendingStops: new Set(),
       persistChain: Promise.resolve(),
       lastPersistedGeneration: 0,
       lastSnapshotWallTime: 0,
       slotReservation,
-      nativeExit: new CompletionLatch<DriverExit>(),
+      rootExited: false,
+      nativeRootExit: new CompletionLatch<void>(),
       startupSettled: new CompletionLatch<void>(),
       finished: new CompletionLatch<ShellRunRecord>(),
       ...(input.onCompletion ? { onCompletion: input.onCompletion } : {}),
@@ -739,19 +805,25 @@ export class ShellRunProcessManager
     };
   }
 
-  private async createDurableRecord(live: LiveShellRun, input: ShellRunBashInput): Promise<void> {
+  private async createStartingRecord(
+    input: ShellRunBashInput,
+    shellRunId: string,
+    timeoutMs: number | undefined,
+    output: ShellOutput,
+  ): Promise<ShellRunRecord> {
+    const startedAt = this.input.now();
     const record: ShellRunRecord = {
-      shellRunId: live.shellRunId,
+      shellRunId,
       sessionId: input.sessionId,
       ...(input.sourceRunId ? { sourceRunId: input.sourceRunId } : {}),
       sourceTurnId: input.sourceTurnId,
       sourceToolCallId: input.sourceToolCallId,
       cwd: input.cwd,
       command: redactSecrets(input.command),
-      status: 'running',
-      startedAt: live.startedAt,
-      updatedAt: live.startedAt,
-      ...(live.timeoutMs !== undefined ? { timeoutMs: live.timeoutMs } : {}),
+      status: 'starting',
+      startedAt,
+      updatedAt: startedAt,
+      ...(timeoutMs !== undefined ? { timeoutMs } : {}),
       ...(input.sandboxType
         ? {
             sandboxExecution: {
@@ -761,9 +833,17 @@ export class ShellRunProcessManager
           }
         : {}),
       revision: 1,
-      output: live.mode === 'pipes' ? live.collector.snapshot() : live.collector.lastGoodSnapshot(),
+      output,
     };
-    live.record = await this.input.store.createShellRun(record);
+    return this.input.store.createShellRun(record);
+  }
+
+  private async markRunning(live: LiveShellRun): Promise<void> {
+    live.record = await this.input.store.updateShellRun(live.sessionId, live.shellRunId, {
+      status: 'running',
+      output: (await this.snapshotAtCut(live, false)).output,
+      updatedAt: this.input.now(),
+    });
     if (live.driverExit) {
       void this.beginFinalize(live).catch(() => {});
     } else if (this.currentGeneration(live) > 0) {
@@ -795,13 +875,7 @@ export class ShellRunProcessManager
   }
 
   private scheduleAutomaticFlush(live: LiveShellRun): void {
-    if (
-      !live.record ||
-      live.finalizeOnce ||
-      live.driverExit ||
-      live.integrityFailure ||
-      live.persistFailure
-    )
+    if (live.finalizeOnce || live.driverExit || live.integrityFailure || live.persistFailure)
       return;
     if (live.flushInFlight || live.flushTimer) return;
     if (live.mode === 'pipes') {
@@ -884,14 +958,12 @@ export class ShellRunProcessManager
       if (!settled.ok) throw settled.error;
       const { snapshot } = settled;
       if (!snapshot) {
-        if (!live.record) throw new Error(`ShellRun ${live.shellRunId} is not durable`);
         if (this.currentGeneration(live) > live.lastPersistedGeneration) {
           this.scheduleAutomaticFlush(live);
         }
         return live.record;
       }
       failureStage = 'persist';
-      if (!live.record) throw new Error(`ShellRun ${live.shellRunId} is not durable`);
       if (live.persistFailure && !options.bestEffort) throw live.persistFailure;
       const current = live.record;
       const candidate: ShellRunRecord = { ...current, ...patch, output: snapshot.output };
@@ -925,8 +997,13 @@ export class ShellRunProcessManager
 
   private snapshotAtCut(live: LiveShellRun, allowLastGood: boolean): Promise<SnapshotAtCut> {
     if (live.mode === 'pipes') {
+      const output = live.collector.snapshot();
+      if (live.driverExit?.mode === 'pipes') {
+        output.stdoutTruncated ||= live.driverExit.value.stdoutTruncated;
+        output.stderrTruncated ||= live.driverExit.value.stderrTruncated;
+      }
       return Promise.resolve({
-        output: live.collector.snapshot(),
+        output,
         generation: live.collector.currentGeneration(),
       });
     }
@@ -938,13 +1015,28 @@ export class ShellRunProcessManager
     }));
   }
 
+  private onNativeRootExit(live: LiveShellRun): void {
+    if (live.rootExited) return;
+    live.rootExited = true;
+    this.settlePendingStops(live, 'exit');
+    live.nativeRootExit.resolve();
+  }
+
   private onDriverExit(live: LiveShellRun, exit: DriverExit): void {
     if (live.driverExit || live.finalizeOnce) return;
     live.driverExit = exit;
-    this.settlePendingStops(live, 'exit');
-    live.nativeExit.resolve(exit);
+    this.onNativeRootExit(live);
+    if (
+      exit.mode === 'pipes' &&
+      (exit.value.stdoutTruncated || exit.value.stderrTruncated) &&
+      !live.integrityFailure
+    ) {
+      live.integrityFailure = new Error(
+        'Shell root exited before inherited output pipes drained completely',
+      );
+    }
     if (live.mode === 'pty') live.collector.closeDataAdmission();
-    if (live.record) void this.beginFinalize(live).catch(() => {});
+    if (live.record.status === 'running') void this.beginFinalize(live).catch(() => {});
   }
 
   private beginFinalize(live: LiveShellRun, abandoned = false): Promise<ShellRunRecord> {
@@ -962,15 +1054,16 @@ export class ShellRunProcessManager
     this.clearLiveTimers(live);
     if (live.mode === 'pty') live.collector.closeDataAdmission();
 
-    let finalRecord: ShellRunRecord | undefined;
-    let completionError: Error | undefined;
+    let finalSnapshot: SnapshotAtCut;
     try {
-      const state = this.finalState(live);
-      finalRecord = await this.queuePersist(live, state, { allowLastGood: true, bestEffort: true });
+      finalSnapshot = await this.snapshotAtCut(live, true);
     } catch (error) {
-      completionError = asError(error, 'ShellRun final persistence failed');
+      live.integrityFailure ??= asError(error, 'ShellRun final snapshot failed');
+      finalSnapshot = {
+        output: live.record.output,
+        generation: live.lastPersistedGeneration,
+      };
     }
-
     let cleanupError: Error | undefined;
     try {
       if (live.mode === 'pty') live.collector.dispose();
@@ -983,27 +1076,17 @@ export class ShellRunProcessManager
       cleanupError ??= asError(error, 'Shell process driver cleanup failed');
     }
 
-    const integrityError = live.integrityFailure ?? cleanupError;
-    if (integrityError && finalRecord) {
-      try {
-        const failureMessage = safeFailureMessage(integrityError);
-        if (
-          finalRecord.status !== 'failed' ||
-          finalRecord.exitCode !== undefined ||
-          finalRecord.failureMessage !== failureMessage
-        ) {
-          finalRecord = await this.input.store.updateShellRun(live.sessionId, live.shellRunId, {
-            status: 'failed',
-            failureMessage,
-            exitCode: undefined,
-            updatedAt: this.input.now(),
-          });
-          live.record = finalRecord;
-          if (live.visibleRef) this.notifyShellRunUpdate(finalRecord);
-        }
-      } catch (error) {
-        completionError ??= asError(error, 'ShellRun failure-state correction failed');
-      }
+    live.integrityFailure ??= cleanupError;
+
+    let finalRecord: ShellRunRecord | undefined;
+    let completionError: Error | undefined;
+    try {
+      finalRecord = await this.queuePersist(live, this.finalState(live), {
+        bestEffort: true,
+        snapshotBarrier: Promise.resolve(finalSnapshot),
+      });
+    } catch (error) {
+      completionError = asError(error, 'ShellRun final persistence failed');
     }
     try {
       if (completionError || !finalRecord) {
@@ -1077,7 +1160,7 @@ export class ShellRunProcessManager
   private handleIntegrityFailure(live: LiveShellRun, error: Error): void {
     live.integrityFailure ??= error;
     if (live.mode === 'pty') live.collector.closeDataAdmission();
-    if (!live.driverExit && !live.termination) this.requestTermination(live);
+    if (!live.rootExited && !live.termination) this.requestTermination(live);
   }
 
   private requestForcedTermination(live: LiveShellRun, cause: LifecycleCause): void {
@@ -1088,12 +1171,12 @@ export class ShellRunProcessManager
     live: LiveShellRun,
     cause?: LifecycleCause,
   ): TerminationLifecycle | undefined {
-    if (live.driverExit || live.finalizeOnce) return live.termination;
+    if (live.rootExited || live.finalizeOnce) return live.termination;
     if (live.termination) return live.termination;
     const lifecycle = createTerminationLifecycle();
     live.termination = lifecycle;
     this.startTermination(live, lifecycle, cause, () => {
-      if (live.termination !== lifecycle || live.driverExit) return false;
+      if (live.termination !== lifecycle || live.rootExited) return false;
       this.settlePendingStops(live, 'termination');
       return true;
     });
@@ -1101,7 +1184,7 @@ export class ShellRunProcessManager
   }
 
   private async beginStopTermination(live: LiveShellRun, pending: PendingStop): Promise<boolean> {
-    if (live.driverExit) {
+    if (live.rootExited) {
       pending.settle('exit');
       return false;
     }
@@ -1112,7 +1195,7 @@ export class ShellRunProcessManager
     const lifecycle = createTerminationLifecycle();
     this.startTermination(live, lifecycle, 'cancel', () => {
       if (pending.current()) return false;
-      if (live.driverExit) {
+      if (live.rootExited) {
         pending.settle('exit');
         return false;
       }
@@ -1158,14 +1241,14 @@ export class ShellRunProcessManager
         if (live.termination !== lifecycle) return;
         live.integrityFailure ??= asError(error, 'Shell process termination failed');
         if (live.mode === 'pty') live.collector.closeDataAdmission();
-        if (live.record) void this.beginFinalize(live, true).catch(() => {});
+        if (live.record.status === 'running') void this.beginFinalize(live, true).catch(() => {});
       })
       .finally(() => {
         lifecycle.initialDecision.resolve();
         lifecycle.initialSignal.resolve(false);
         lifecycle.finished.resolve();
         if (live.termination === lifecycle) {
-          this.settlePendingStops(live, live.driverExit ? 'exit' : 'termination');
+          this.settlePendingStops(live, live.rootExited ? 'exit' : 'termination');
         }
       });
   }
@@ -1190,22 +1273,22 @@ export class ShellRunProcessManager
     }
     if (applied && cause) live.lifecycleCause ??= cause;
     lifecycle.initialSignal.resolve(applied);
-    if (live.driverExit || live.finalizeOnce) return;
+    if (live.rootExited || live.finalizeOnce) return;
 
-    if ((await live.nativeExit.wait(this.killGraceMs)) !== 'delay') return;
+    if ((await live.nativeRootExit.wait(this.killGraceMs)) !== 'delay') return;
     const forced = await this.signalProcessTree(live, 'SIGKILL');
     if (forced && cause) live.lifecycleCause ??= cause;
-    if (live.driverExit || live.finalizeOnce) return;
+    if (live.rootExited || live.finalizeOnce) return;
 
-    if ((await live.nativeExit.wait(this.exitAcknowledgementMs)) !== 'delay') return;
+    if ((await live.nativeRootExit.wait(this.exitAcknowledgementMs)) !== 'delay') return;
     await this.signalProcessTree(live, 'SIGKILL');
-    if (live.driverExit || live.finalizeOnce) return;
+    if (live.rootExited || live.finalizeOnce) return;
 
     this.handleIntegrityFailure(
       live,
       new Error('Shell process did not acknowledge exit after forced termination'),
     );
-    if (live.record) void this.beginFinalize(live, true).catch(() => {});
+    if (live.record.status === 'running') void this.beginFinalize(live, true).catch(() => {});
   }
 
   private signalProcessTree(
@@ -1213,7 +1296,7 @@ export class ShellRunProcessManager
     signal: ProcessTerminationSignal,
     beforeSignal?: () => boolean,
   ): Promise<boolean> {
-    if (live.driverExit) return Promise.resolve(false);
+    if (live.rootExited) return Promise.resolve(false);
     const pid = live.driver.pid;
     if (pid === undefined || pid <= 0) {
       if (beforeSignal && !beforeSignal()) return Promise.resolve(false);
@@ -1227,8 +1310,8 @@ export class ShellRunProcessManager
     return terminateProcessTree({
       pid,
       signal,
-      fallback: () => (live.driverExit ? false : live.driver.kill(signal)),
-      hasExited: () => live.driverExit !== undefined,
+      fallback: () => (live.rootExited ? false : live.driver.kill(signal)),
+      hasExited: () => live.rootExited,
       beforeSignal,
     });
   }
@@ -1236,34 +1319,125 @@ export class ShellRunProcessManager
   private async terminateLive(live: LiveShellRun, cause: LifecycleCause): Promise<void> {
     this.requestForcedTermination(live, cause);
     await live.startupSettled.join();
-    if (live.record) await live.finished.join().catch(() => undefined);
+    await live.finished.join();
   }
 
-  private async cleanupUndurable(live: LiveShellRun): Promise<void> {
-    try {
-      this.clearLiveTimers(live);
-      if (!live.driverExit) {
-        const termination = live.termination ?? this.requestTermination(live);
-        if (termination) await termination.finished.join();
-      }
-      try {
-        if (live.mode === 'pty') {
-          live.collector.closeDataAdmission();
-          live.collector.dispose();
-        }
-      } catch {
-        // Startup already failed; continue releasing native and manager resources.
-      }
-      try {
-        live.driver.dispose();
-      } catch {
-        /* startup cleanup continues */
-      }
-    } finally {
-      this.notifyCompletionOwner(live, false);
-      this.live.delete(live.shellRunId);
-      this.releaseLiveSlot(live);
+  private async terminateLives(lives: LiveShellRun[], cause: LifecycleCause): Promise<void> {
+    const settlements = await Promise.allSettled(
+      lives.map((live) => this.terminateLive(live, cause)),
+    );
+    const failure = settlements.find(
+      (settlement): settlement is PromiseRejectedResult => settlement.status === 'rejected',
+    );
+    if (failure) throw failure.reason;
+  }
+
+  private async cleanupStartupNative(live: LiveShellRun): Promise<void> {
+    this.clearLiveTimers(live);
+    if (!live.rootExited) {
+      const termination = live.termination ?? this.requestTermination(live);
+      if (termination) await termination.finished.join();
     }
+
+    let cleanupError: Error | undefined;
+    if (!live.rootExited) {
+      cleanupError =
+        live.integrityFailure ??
+        new Error('Shell process did not acknowledge exit during startup cleanup');
+    }
+    try {
+      if (live.mode === 'pty') {
+        live.collector.closeDataAdmission();
+        live.collector.dispose();
+      }
+    } catch (error) {
+      cleanupError ??= asError(error, 'PTY collector startup cleanup failed');
+    }
+    try {
+      live.driver.dispose();
+    } catch (error) {
+      cleanupError ??= asError(error, 'Shell process driver startup cleanup failed');
+    }
+    if (cleanupError) throw cleanupError;
+  }
+
+  private assertLiveStartupAllowed(
+    live: LiveShellRun,
+    sessionEpoch: number,
+    abortSignal: AbortSignal | undefined,
+  ): void {
+    if (abortSignal?.aborted) {
+      throw abortError('Command aborted before shell process became ready');
+    }
+    this.assertLiveStillAdmitted(live, sessionEpoch);
+  }
+
+  private assertLiveStillAdmitted(live: LiveShellRun, sessionEpoch: number): void {
+    this.assertStartAllowed(live.sessionId, sessionEpoch);
+    if (live.integrityFailure) throw live.integrityFailure;
+  }
+
+  private assertStartupAllowed(
+    sessionId: string,
+    sessionEpoch: number,
+    abortSignal: AbortSignal | undefined,
+  ): void {
+    if (abortSignal?.aborted) {
+      throw abortError('Command aborted before shell process became ready');
+    }
+    this.assertStartAllowed(sessionId, sessionEpoch);
+  }
+
+  private async completeStartupFailure(
+    live: LiveShellRun | undefined,
+    record: ShellRunRecord,
+    startupFailure: unknown,
+  ): Promise<Error> {
+    const startupError = asError(startupFailure, 'Shell process startup failed');
+    let reportedError = startupError;
+    let cleanupFailed = false;
+    if (live) {
+      try {
+        await this.cleanupStartupNative(live);
+      } catch (error) {
+        cleanupFailed = true;
+        reportedError = startupCleanupError(startupError, error);
+      }
+    }
+
+    try {
+      const terminal = await this.markStartupTerminal(record, reportedError, cleanupFailed);
+      live?.finished.resolve(terminal);
+    } catch (error) {
+      reportedError = startupPersistenceError(reportedError, error);
+      live?.finished.reject(reportedError);
+    } finally {
+      if (live) {
+        live.startupSettled.resolve();
+        this.notifyCompletionOwner(live, false);
+        this.live.delete(live.shellRunId);
+        this.releaseLiveSlot(live);
+      }
+    }
+    return reportedError;
+  }
+
+  private async markStartupTerminal(
+    record: ShellRunRecord,
+    error: Error,
+    orphaned: boolean,
+  ): Promise<ShellRunRecord> {
+    return this.terminalizeActiveRecord(record, () => {
+      const now = this.input.now();
+      return {
+        status: orphaned ? 'orphaned' : 'failed',
+        failureMessage: safeFailureMessage(error),
+        exitCode: undefined,
+        completedAt: now,
+        observedAt: now,
+        updatedAt: now,
+      };
+    });
   }
 
   private async resourceDetail(
@@ -1288,7 +1462,7 @@ export class ShellRunProcessManager
       if (abortSignal.aborted)
         throw abortError('Read aborted before the durable runtime snapshot was read');
       record = await this.readDurableRecord(sessionId, target.shellRunId);
-      if (record.status === 'running') {
+      if (isActiveShellRunStatus(record.status)) {
         record = await this.markOrphaned(
           record,
           'Runtime restarted without a live shell process handle',
@@ -1304,7 +1478,7 @@ export class ShellRunProcessManager
 
   private liveResource(sessionId: string, shellRunId: string): LiveShellRun | undefined {
     const live = this.live.get(shellRunId);
-    return live?.sessionId === sessionId && live.record ? live : undefined;
+    return live?.sessionId === sessionId ? live : undefined;
   }
 
   private async writeStdinWithoutLive(
@@ -1317,7 +1491,7 @@ export class ShellRunProcessManager
     let record = await this.readDurableRecord(input.sessionId, shellRunId);
     if (record.output.mode !== 'pty')
       throw new Error('WriteStdin requires a PTY background task ref');
-    if (record.status === 'running') {
+    if (isActiveShellRunStatus(record.status)) {
       record = await this.markOrphaned(
         record,
         'Runtime restarted without a live shell process handle',
@@ -1346,7 +1520,7 @@ export class ShellRunProcessManager
       throw abortError('StopBackgroundTask aborted before the terminal state was observed');
     }
     let record = await this.readDurableRecord(sessionId, shellRunId);
-    if (record.status === 'running') {
+    if (isActiveShellRunStatus(record.status)) {
       record = await this.markOrphaned(
         record,
         'Runtime restarted without a live shell process handle',
@@ -1384,15 +1558,40 @@ export class ShellRunProcessManager
   }
 
   private async markOrphaned(record: ShellRunRecord, reason: string): Promise<ShellRunRecord> {
-    if (record.status !== 'running') return record;
-    const now = this.input.now();
-    return this.input.store.updateShellRun(record.sessionId, record.shellRunId, {
-      status: 'orphaned',
-      failureMessage: redactSecrets(reason),
-      exitCode: undefined,
-      completedAt: now,
-      updatedAt: now,
+    const failureMessage = redactSecrets(reason);
+    return this.terminalizeActiveRecord(record, () => {
+      const now = this.input.now();
+      return {
+        status: 'orphaned',
+        failureMessage,
+        exitCode: undefined,
+        completedAt: now,
+        updatedAt: now,
+      };
     });
+  }
+
+  private async terminalizeActiveRecord(
+    record: ShellRunRecord,
+    buildPatch: () => ShellRunPatch,
+  ): Promise<ShellRunRecord> {
+    if (!isActiveShellRunStatus(record.status)) return record;
+    try {
+      return await this.input.store.updateShellRun(
+        record.sessionId,
+        record.shellRunId,
+        buildPatch(),
+      );
+    } catch (error) {
+      let current: ShellRunRecord;
+      try {
+        current = await this.input.store.readShellRun(record.sessionId, record.shellRunId);
+      } catch {
+        throw error;
+      }
+      if (!isActiveShellRunStatus(current.status)) return current;
+      return this.input.store.updateShellRun(current.sessionId, current.shellRunId, buildPatch());
+    }
   }
 
   private async actionableRecords(sessionId: string): Promise<ShellRunRecord[]> {
@@ -1400,7 +1599,7 @@ export class ShellRunProcessManager
     return records
       .filter(
         (record) =>
-          record.status === 'running' ||
+          isActiveShellRunStatus(record.status) ||
           (record.observedAt === undefined && isTerminalShellRunStatus(record.status)),
       )
       .sort(compareActionableShellRuns);
@@ -1431,6 +1630,49 @@ export class ShellRunProcessManager
 
   private sessionTerminationEpoch(sessionId: string): number {
     return this.sessionTerminationEpochs.get(sessionId) ?? 0;
+  }
+
+  private async withPendingStartup<T>(sessionId: string, operation: () => Promise<T>): Promise<T> {
+    let resolveStartup!: () => void;
+    const startup = new Promise<void>((resolve) => {
+      resolveStartup = resolve;
+    });
+    const startups = this.pendingStartups.get(sessionId) ?? new Set<Promise<void>>();
+    startups.add(startup);
+    this.pendingStartups.set(sessionId, startups);
+    try {
+      return await operation();
+    } finally {
+      startups.delete(startup);
+      if (startups.size === 0) this.pendingStartups.delete(sessionId);
+      resolveStartup();
+    }
+  }
+
+  private async awaitSessionStartups(sessionId: string): Promise<void> {
+    const startups = this.pendingStartups.get(sessionId);
+    if (startups) await Promise.all([...startups]);
+  }
+
+  private async settleSessionLives(sessionId: string): Promise<void> {
+    const failures: unknown[] = [];
+    const sessionLives = () =>
+      [...this.live.values()].filter((live) => live.sessionId === sessionId);
+    await this.captureTerminationFailure(this.terminateLives(sessionLives(), 'shutdown'), failures);
+    await this.awaitSessionStartups(sessionId);
+    await this.captureTerminationFailure(this.terminateLives(sessionLives(), 'shutdown'), failures);
+    if (failures.length > 0) throw failures[0];
+  }
+
+  private async captureTerminationFailure(
+    termination: Promise<void>,
+    failures: unknown[],
+  ): Promise<void> {
+    try {
+      await termination;
+    } catch (error) {
+      failures.push(error);
+    }
   }
 
   private holdSessionClose(lease: SessionCloseLease): void {
@@ -1509,7 +1751,7 @@ function createTerminationLifecycle(): TerminationLifecycle {
 
 function isPtyControlOpen(live: LivePtyShellRun): boolean {
   return (
-    live.record !== undefined &&
+    live.record.status === 'running' &&
     !hasUndecidedPendingStop(live) &&
     !live.driverExit &&
     !live.termination &&
@@ -1540,8 +1782,27 @@ function safeFailureMessage(error: Error): string {
   return message.length <= 500 ? message : `${message.slice(0, 497)}...`;
 }
 
+function startupPersistenceError(startupError: Error, persistenceFailure: unknown): Error {
+  const persistenceError = asError(
+    persistenceFailure,
+    'ShellRun startup terminal persistence failed',
+  );
+  return new Error(
+    `Shell process startup failed: ${safeFailureMessage(startupError)}; failed to persist terminal ShellRun after retry: ${safeFailureMessage(persistenceError)}`,
+    { cause: new AggregateError([startupError, persistenceError]) },
+  );
+}
+
+function startupCleanupError(startupError: Error, cleanupFailure: unknown): Error {
+  const cleanupError = asError(cleanupFailure, 'Shell process startup cleanup failed');
+  return new Error(
+    `Shell process startup failed: ${safeFailureMessage(startupError)}; startup cleanup failed: ${safeFailureMessage(cleanupError)}`,
+    { cause: new AggregateError([startupError, cleanupError]) },
+  );
+}
+
 function compareActionableShellRuns(a: ShellRunRecord, b: ShellRunRecord): number {
-  const rank = (record: ShellRunRecord) => (record.status === 'running' ? 1 : 0);
+  const rank = (record: ShellRunRecord) => (isActiveShellRunStatus(record.status) ? 1 : 0);
   return (
     rank(a) - rank(b) ||
     b.updatedAt - a.updatedAt ||

--- a/packages/runtime/src/shell-run-tool-result.ts
+++ b/packages/runtime/src/shell-run-tool-result.ts
@@ -10,6 +10,7 @@ import type {
   ShellRunUpdate,
   ToolResultContent,
 } from '@maka/core';
+import { isActiveShellRunStatus } from '@maka/core';
 
 import { shellRunResourceRef, type ShellRunWriteInput } from './shell-run-contract.js';
 import { truncateToolOutput } from './tool-output.js';
@@ -33,7 +34,7 @@ export function shellRunUpdate(record: ShellRunRecord): ShellRunUpdate {
 }
 
 export function terminalContent(record: ShellRunRecord): TerminalToolResult {
-  if (record.status === 'running' || record.status === 'orphaned') {
+  if (isActiveShellRunStatus(record.status) || record.status === 'orphaned') {
     throw new Error(`ShellRun status ${record.status} cannot be returned as a terminal result`);
   }
   return {
@@ -100,6 +101,7 @@ function terminalResultStatus(status: ShellRunStatus): TerminalToolResult['statu
     case 'timed_out':
     case 'cancelled':
       return status;
+    case 'starting':
     case 'running':
     case 'orphaned':
       throw new Error(`ShellRun status ${status} cannot be returned as a terminal result`);

--- a/packages/runtime/src/shell-tools.ts
+++ b/packages/runtime/src/shell-tools.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { isActiveShellRunStatus } from '@maka/core';
 import { redactSecrets } from '@maka/core/redaction';
 import type { ToolResultContent } from '@maka/core/events';
 import type { ToolExecutionFacts } from '@maka/core/permission';
@@ -228,7 +229,7 @@ export function buildManagedBashTool(
           ...(transformed?.sandboxType ? { sandboxType: transformed.sandboxType } : {}),
           ...(onCompletion ? { onCompletion } : {}),
         });
-        if (result.kind === 'terminal' || result.status !== 'running') {
+        if (result.kind === 'terminal' || !isActiveShellRunStatus(result.status)) {
           onCompletion?.({
             successful: result.status === 'completed' && result.exitCode === 0,
           });

--- a/packages/storage/src/__tests__/shell-run-store.test.ts
+++ b/packages/storage/src/__tests__/shell-run-store.test.ts
@@ -61,6 +61,66 @@ describe('ShellRunStore', () => {
     });
   });
 
+  it('preserves forward-only starting, running, and terminal lifecycle transitions', async () => {
+    await withStore(async (store) => {
+      await store.createShellRun(record({ shellRunId: 'shell-1', status: 'starting' }));
+      const running = await store.updateShellRun('session-1', 'shell-1', {
+        status: 'running',
+        updatedAt: 2,
+      });
+      const completed = await store.updateShellRun('session-1', 'shell-1', {
+        status: 'completed',
+        exitCode: 0,
+        completedAt: 3,
+        updatedAt: 3,
+      });
+
+      assert.equal(running.revision, 2);
+      assert.equal(completed.revision, 3);
+      await assert.rejects(
+        () =>
+          store.updateShellRun('session-1', 'shell-1', {
+            status: 'running',
+            completedAt: undefined,
+            exitCode: undefined,
+            updatedAt: 4,
+          }),
+        /Invalid ShellRun status transition: completed -> running/,
+      );
+    });
+  });
+
+  it('terminalizes failed or lost starts and keeps terminal outcomes immutable', async () => {
+    await withStore(async (store) => {
+      await store.createShellRun(record({ shellRunId: 'failed-launch', status: 'starting' }));
+      const failed = await store.updateShellRun('session-1', 'failed-launch', {
+        status: 'failed',
+        failureMessage: 'spawn failed',
+        completedAt: 2,
+        updatedAt: 2,
+      });
+      assert.equal(failed.status, 'failed');
+
+      await store.createShellRun(record({ shellRunId: 'lost-launch', status: 'starting' }));
+      const orphaned = await store.updateShellRun('session-1', 'lost-launch', {
+        status: 'orphaned',
+        failureMessage: 'host restarted before launch outcome was known',
+        completedAt: 2,
+        updatedAt: 2,
+      });
+      assert.equal(orphaned.status, 'orphaned');
+
+      await assert.rejects(
+        () =>
+          store.updateShellRun('session-1', 'failed-launch', {
+            failureMessage: 'different failure',
+            updatedAt: 3,
+          }),
+        /ShellRun terminal outcome is immutable: failed/,
+      );
+    });
+  });
+
   it('round-trips sandbox execution and one-shot escalation audit facts', async () => {
     await withStore(async (store) => {
       const created = await store.createShellRun({

--- a/packages/storage/src/shell-run-store.ts
+++ b/packages/storage/src/shell-run-store.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { access, mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises';
+import { access, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
 import {
@@ -7,11 +7,14 @@ import {
   isShellOutput,
   isShellRunId,
   isShellRunStatus,
+  isTerminalShellRunStatus,
   isValidShellRunState,
+  isValidShellRunStatusTransition,
   type ShellRunRecord,
   type ShellRunPatch,
   type ShellRunStore,
 } from '@maka/core';
+import { syncDirectoryChain, syncFile } from './stable-storage.js';
 import { chainWrite } from './write-queue.js';
 
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
@@ -75,10 +78,12 @@ export function createShellRunStore(workspaceRoot: string): ShellRunStore {
 }
 
 class FileShellRunStore implements ShellRunStore {
+  private readonly durabilityRoot: string;
   private readonly sessionsRoot: string;
   private readonly writeQueues = new Map<string, Promise<void>>();
 
   constructor(workspaceRoot: string) {
+    this.durabilityRoot = workspaceRoot;
     this.sessionsRoot = join(workspaceRoot, 'sessions');
   }
 
@@ -94,6 +99,8 @@ class FileShellRunStore implements ShellRunStore {
       await writeAtomic(
         this.shellRunPath(record.sessionId, record.shellRunId),
         JSON.stringify(normalized, sanitizeJson) + '\n',
+        this.durabilityRoot,
+        true,
       );
     });
     return normalized;
@@ -107,6 +114,7 @@ class FileShellRunStore implements ShellRunStore {
     let next: ShellRunRecord | undefined;
     await this.withQueue(sessionId, shellRunId, async () => {
       assertShellRunPatch(patch);
+      const hasDurableIntent = Object.hasOwn(patch, 'status') || Object.hasOwn(patch, 'observedAt');
       const current = await this.readShellRunUnlocked(sessionId, shellRunId);
       if (patch.output && patch.output.mode !== current.output.mode) {
         throw new Error(`ShellRun output mode is immutable: ${current.output.mode}`);
@@ -120,7 +128,13 @@ class FileShellRunStore implements ShellRunStore {
         sessionId,
         shellRunId,
       );
+      assertShellRunTransition(current, candidate);
       if (isDeepStrictEqual(candidate, current)) {
+        if (hasDurableIntent) {
+          const path = this.shellRunPath(sessionId, shellRunId);
+          await syncFile(path);
+          await syncDirectoryChain(dirname(path), this.durabilityRoot);
+        }
         next = current;
         return;
       }
@@ -132,6 +146,8 @@ class FileShellRunStore implements ShellRunStore {
       await writeAtomic(
         this.shellRunPath(sessionId, shellRunId),
         JSON.stringify(next, sanitizeJson) + '\n',
+        this.durabilityRoot,
+        hasDurableIntent,
       );
     });
     if (!next) throw new Error(`Failed to update shell run ${shellRunId}`);
@@ -204,11 +220,23 @@ class FileShellRunStore implements ShellRunStore {
   }
 }
 
-async function writeAtomic(path: string, content: string): Promise<void> {
+async function writeAtomic(
+  path: string,
+  content: string,
+  durabilityRoot: string,
+  durable: boolean,
+): Promise<void> {
   await mkdir(dirname(path), { recursive: true });
   const tempPath = `${path}.${process.pid}.${Date.now()}.${randomUUID()}.tmp`;
-  await writeFile(tempPath, content, 'utf8');
-  await rename(tempPath, path);
+  try {
+    await writeFile(tempPath, content, 'utf8');
+    if (durable) await syncFile(tempPath);
+    await rename(tempPath, path);
+    if (durable) await syncDirectoryChain(dirname(path), durabilityRoot);
+  } catch (error) {
+    await rm(tempPath, { force: true }).catch(() => undefined);
+    throw error;
+  }
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -389,6 +417,20 @@ function assertShellRunPatch(patch: ShellRunPatch): void {
     if (!SHELL_RUN_PATCH_KEYS.has(key)) {
       throw new Error(`ShellRun field is immutable: ${key}`);
     }
+  }
+}
+
+function assertShellRunTransition(current: ShellRunRecord, candidate: ShellRunRecord): void {
+  if (!isValidShellRunStatusTransition(current.status, candidate.status)) {
+    throw new Error(`Invalid ShellRun status transition: ${current.status} -> ${candidate.status}`);
+  }
+  if (
+    isTerminalShellRunStatus(current.status) &&
+    (candidate.completedAt !== current.completedAt ||
+      candidate.exitCode !== current.exitCode ||
+      candidate.failureMessage !== current.failureMessage)
+  ) {
+    throw new Error(`ShellRun terminal outcome is immutable: ${current.status}`);
   }
 }
 

--- a/packages/ui/src/materialize.ts
+++ b/packages/ui/src/materialize.ts
@@ -1,5 +1,6 @@
 import {
   deriveTurnRecords,
+  isActiveShellRunStatus,
   mergeShellRunStateWithDiagnostics,
   projectToolActivityArgs,
   STEP_LIMIT_NOTICE_TEXT,
@@ -395,7 +396,7 @@ export function overlayShellRunUpdates(
     );
     byToolUseId.set(update.sourceToolCallId, {
       result: merged.result,
-      source: merged.result.status !== 'running' || update.ownership.kind === 'local'
+      source: !isActiveShellRunStatus(merged.result.status) || update.ownership.kind === 'local'
         ? undefined
         : update.ownership.kind === 'source_owned' ? 'owned' : 'unavailable',
     });

--- a/packages/ui/src/tool-activity/tool-result-preview.tsx
+++ b/packages/ui/src/tool-activity/tool-result-preview.tsx
@@ -447,6 +447,7 @@ function ShellRunStatus(props: {
     return <><ShieldAlert size={15} aria-hidden="true" />{activityCopy.status.sandboxBlocked}{suffix}</>;
   }
   switch (props.status) {
+    case 'starting':
     case 'running':
       return <><Loader2 size={15} aria-hidden="true" className="animate-spin" />{copy.running}</>;
     case 'completed':


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

Establish a managed process lifecycle foundation for retained ShellRun processes and shared one-shot Runtime helpers.

A durable `starting` identity now precedes native process creation. Startup, shutdown, process-tree termination, root exit, and captured-output drain are handled as explicit lifecycle boundaries. Restart recovery fails closed when durable active work has no current in-memory owner.

This is part of #1167 and follows the direction established in #853. It does not switch production ownership to Runtime Host.

## What changed

- Add the `starting` ShellRun state and a shared active-state predicate across Core, Storage, Runtime, CLI, UI, and Desktop consumers.
- Persist ShellRun identity before native spawn and reserve startup ownership before durable creation, preventing recovery from orphaning an in-progress local startup.
- Register the native live handle before committing `running`, then recheck session closure, Runtime shutdown, and startup integrity before returning a background reference.
- Make session close and Runtime shutdown wait for in-flight startups and perform a final termination sweep.
- Add one shared captured-output drain policy for one-shot shell execution, filesystem workers, and retained pipe processes.
  - Root exit and output drain have independent bounds.
  - Only normal stream completion counts as fully drained.
  - Premature close, stream error, or deadline expiry is reported as incomplete.
  - stdout and stderr truncation are preserved independently.
- Terminate process trees using TERM, a grace period, KILL escalation, and a bounded acknowledgement wait.
- Recover persisted `starting` and `running` records as `orphaned` when they have neither a live owner nor a current startup owner.
- Preserve forward-only lifecycle transitions and immutable terminal outcomes, including concurrent terminal observations.
- Keep pre-aborted invocations spawn-free and preserve existing file-descriptor input behavior.

## Design boundaries

- Native PID and process-tree identity remain in memory only. Persisted ShellRun records are not treated as process-control authority after restart.
- POSIX process groups and process-table discovery provide the primary tree-control path.
- Windows and ConPTY termination remain bounded best effort.
- This change does not claim containment of arbitrary descendants that deliberately escape the managed process tree.
- This slice does not add Runtime Resource protocol operations, controller leases, Host cutover, Native Provider or Computer Use integration, generic RPC infrastructure, or new dependencies.

## Validation

- Root typecheck passed.
- Production build passed.
- Biome passed for all 26 changed or added files.
- `git diff --check` passed.
- Test suites passed with zero failures:
  - Core: 1,193 passed
  - Storage: 805 passed, 1 platform skip
  - Runtime: 2,798 passed, 9 platform skips
  - UI: 258 passed
  - Desktop: 2,945 passed
  - CLI: 668 passed
- Focused coverage includes:
  - durable identity before spawn
  - startup, recovery, session-close, and Runtime-shutdown races
  - TERM/KILL escalation and acknowledgement
  - descendants retaining inherited output pipes
  - premature stream close and stream error
  - independent stdout/stderr truncation
  - existing file-descriptor inputs

</details>

<details>
<summary><strong>简体中文</strong></summary>

## 摘要

为 retained ShellRun 进程和共享的一次性 Runtime helper 建立受管理的进程生命周期基础。

现在，系统会在创建 native process 之前持久化 `starting` identity。Startup、shutdown、process-tree termination、root exit 和 captured-output drain 都成为明确的生命周期边界。重启恢复时，如果持久化的 active work 没有当前内存 owner，系统会 fail closed。

这是 #1167 的一部分，并遵循 #853 确立的方向。本 PR 不会把生产环境的 ownership 切换到 Runtime Host。

## 改动内容

- 在 Core、Storage、Runtime、CLI、UI 和 Desktop 消费方中加入 `starting` ShellRun 状态和共享的 active-state predicate。
- 在 native spawn 之前持久化 ShellRun identity，并在 durable creation 之前预留 startup ownership，避免 recovery 将正在进行的本地 startup 错误标记为 orphaned。
- 在提交 `running` 之前注册 native live handle；返回 background reference 之前，再次检查 session closure、Runtime shutdown 和 startup integrity。
- Session close 和 Runtime shutdown 现在会等待进行中的 startup，并执行最后一次 termination sweep。
- 为一次性 shell execution、filesystem worker 和 retained pipe process 提供统一的 captured-output drain 策略。
  - Root exit 和 output drain 使用相互独立的时间边界。
  - 只有正常的 stream completion 才视为完整 drain。
  - 提前 close、stream error 或 deadline expiry 会被报告为 incomplete。
  - stdout 和 stderr 的 truncation 状态分别保留。
- 使用 TERM、grace period、KILL escalation 和 bounded acknowledgement wait 终止 process tree。
- Recovery 会将既没有 live owner、也没有当前 startup owner 的持久化 `starting` 和 `running` 记录标记为 `orphaned`。
- 保证 lifecycle transition 只能向前推进，terminal outcome 不可修改，并使并发 terminal observation 收敛到同一结果。
- 保证预先 abort 的调用不会 spawn，同时保留现有 file-descriptor input 行为。

## 设计边界

- Native PID 和 process-tree identity 只保存在内存中。重启后，持久化的 ShellRun record 不会被当作进程控制权威。
- POSIX process group 和 process-table discovery 是主要的 process-tree control 路径。
- Windows 和 ConPTY termination 仍属于 bounded best effort。
- 本 PR 不承诺控制主动逃离 managed process tree 的任意 descendant。
- 本 slice 不新增 Runtime Resource protocol operation、controller lease、Host cutover、Native Provider 或 Computer Use 集成、通用 RPC 基础设施或新依赖。

## 验证

- Root typecheck 通过。
- Production build 通过。
- 全部 26 个改动或新增文件通过 Biome。
- `git diff --check` 通过。
- 所有测试套件零失败：
  - Core：1,193 个通过
  - Storage：805 个通过，1 个 platform skip
  - Runtime：2,798 个通过，9 个 platform skip
  - UI：258 个通过
  - Desktop：2,945 个通过
  - CLI：668 个通过
- 定向覆盖包括：
  - spawn 之前持久化 identity
  - startup、recovery、session close 和 Runtime shutdown 竞态
  - TERM/KILL escalation 与 acknowledgement
  - descendant 持有继承 output pipe
  - stream 提前 close 和 stream error
  - stdout/stderr 独立 truncation
  - 现有 file-descriptor input

</details>
