### PR TITLE
fix(desktop): recover from a failed execution-boundary read

### DIFF
--- a/apps/desktop/e2e/permission-mode-surface.spec.ts
+++ b/apps/desktop/e2e/permission-mode-surface.spec.ts
@@ -69,6 +69,20 @@ test('approving an expansion updates the permission label at once and after a re
   // the user this session cannot write, right after they let it.
   await expect(trigger).toHaveText('自动');
 
+  // The answer has to reach the fixture state itself, not just the active
+  // request list. The renderer seeds its interaction queue straight out of
+  // `e2eFixture:getState` on every boot, bypassing that list entirely, so a
+  // retirement only one exit could see would put the prompt back over the
+  // composer after the reload below — depending on which reply landed last.
+  await expect
+    .poll(() =>
+      page.evaluate(async () => {
+        const state = await window.maka.e2eFixture.getState();
+        return Object.keys(state?.sandboxBoundaryBySession ?? {}).length;
+      }),
+    )
+    .toBe(0);
+
   // And it is the boundary saying so, not renderer state: it survives a reload,
   // where the renderer starts from nothing and has to read the boundary again.
   // The notice assertion adds that the composer came back because that read
@@ -76,13 +90,19 @@ test('approving an expansion updates the permission label at once and after a re
   // the retry — nothing rejects here — which the read model's own tests cover
   // deterministically (#1629).
   //
-  // The composer returning is only a stable expectation because answering the
-  // fixture's request now settles it: while an answered request kept coming
-  // back on every hydration, whether the composer or the prompt won this frame
-  // was a coin flip, and that was the real cause of the CI timeout that #1630
-  // removed this half over.
+  // The boot path reaches the answered request twice: the active-request list,
+  // and the fixture state the renderer seeds its interaction queue from. Both
+  // read one retirement now, so the assertions below are a settled state rather
+  // than a frame they happened to catch — while either could still resurrect
+  // the prompt, whichever reply landed last decided whether the composer or the
+  // prompt owned the slot, and that coin flip is what timed out on CI.
   await page.reload();
   await expect(page.locator('.maka-composer-textarea')).toBeVisible();
   await expect(page.locator('.maka-boundary-unreadable-notice')).toHaveCount(0);
   await expect(trigger).toHaveText('自动');
+
+  // Re-checked after the boot path has had time to run both seeds: a late
+  // resurrection would take the slot back here rather than never happening.
+  await expect(prompt).toHaveCount(0);
+  await expect(page.locator('.maka-composer-textarea')).toBeVisible();
 });

--- a/apps/desktop/e2e/permission-mode-surface.spec.ts
+++ b/apps/desktop/e2e/permission-mode-surface.spec.ts
@@ -52,7 +52,7 @@ test('a read-only session names its boundary and can still be raised to full acc
   await expect(trigger).toHaveText('自动');
 });
 
-test('approving an expansion updates the permission label at once', async ({
+test('approving an expansion updates the permission label at once and after a reload', async ({
   sandboxBoundaryWindow: page,
 }) => {
   const prompt = page.locator('.maka-sandbox-boundary-prompt');
@@ -68,13 +68,15 @@ test('approving an expansion updates the permission label at once', async ({
   // moves — so a surface that does not re-read authority would keep telling
   // the user this session cannot write, right after they let it.
   await expect(trigger).toHaveText('自动');
-});
 
-// A reload assertion used to follow, to show the label came from the boundary
-// rather than renderer state. It could not hold here: after a reload the
-// composer stays hidden until a boundary has been read for the restored
-// session, and that read has no retry — `readExecutionBoundary` rejecting once
-// leaves the snapshot unset for good. On CI the composer never became visible
-// within the timeout. That is a product gap worth its own fix (#1629), not
-// something this journey should encode; the read model's own contract test
-// already covers that the label follows authority and not renderer state.
+  // And it is the boundary saying so, not renderer state: it survives a reload.
+  // #1629: a reload also re-reads the boundary from scratch, and the composer
+  // stays hidden until that read lands. One rejection used to end it there for
+  // good; a failed read is now retried and, if it still cannot be read, says so
+  // instead of leaving an empty window — so the composer coming back with no
+  // notice is the whole recovery path holding.
+  await page.reload();
+  await expect(page.locator('.maka-composer-textarea')).toBeVisible();
+  await expect(page.locator('.maka-boundary-unreadable-notice')).toHaveCount(0);
+  await expect(trigger).toHaveText('自动');
+});

--- a/apps/desktop/e2e/permission-mode-surface.spec.ts
+++ b/apps/desktop/e2e/permission-mode-surface.spec.ts
@@ -47,6 +47,13 @@ test('a read-only session names its boundary and can still be raised to full acc
   // Keyboard navigation still works with nothing selected, and choosing Auto
   // is a real permission change.
   await trigger.click();
+  // The click resolves when it is dispatched, not when the popup exists. Keys
+  // sent before then land on nothing: no option is highlighted, Enter selects
+  // nothing, and the label sits on 只读 until the assertion times out. Waiting
+  // for the listbox the keys are aimed at fixes the sequence rather than
+  // widening the window it is allowed to be wrong in (measured: 2/25 failures
+  // without this line, 25/25 clean with it).
+  await expect(page.getByRole('listbox')).toBeVisible();
   await page.keyboard.press('ArrowDown');
   await page.keyboard.press('Enter');
   await expect(trigger).toHaveText('自动');

--- a/apps/desktop/e2e/permission-mode-surface.spec.ts
+++ b/apps/desktop/e2e/permission-mode-surface.spec.ts
@@ -79,8 +79,10 @@ test('approving an expansion updates the permission label at once and after a re
   // The answer has to reach the fixture state itself, not just the active
   // request list. The renderer seeds its interaction queue straight out of
   // `e2eFixture:getState` on every boot, bypassing that list entirely, so a
-  // retirement only one exit could see would put the prompt back over the
-  // composer after the reload below — depending on which reply landed last.
+  // retirement only the list could see leaves an answered request that the
+  // seed can still put back over the composer. Asserted here directly because
+  // that is the part with hard evidence: this poll fails against a
+  // list-only retirement and passes against a retirement at the shared owner.
   await expect
     .poll(() =>
       page.evaluate(async () => {
@@ -97,12 +99,11 @@ test('approving an expansion updates the permission label at once and after a re
   // the retry — nothing rejects here — which the read model's own tests cover
   // deterministically (#1629).
   //
-  // The boot path reaches the answered request twice: the active-request list,
-  // and the fixture state the renderer seeds its interaction queue from. Both
-  // read one retirement now, so the assertions below are a settled state rather
-  // than a frame they happened to catch — while either could still resurrect
-  // the prompt, whichever reply landed last decided whether the composer or the
-  // prompt owned the slot, and that coin flip is what timed out on CI.
+  // What made this half time out on CI before #1630 removed it is not measured
+  // here — an answered request that stayed active could be resurrected by
+  // either the list or the seed, and the local ordering never reproduced it.
+  // What is measured is that neither path has an answered request to resurrect
+  // any more, which the poll above pins directly.
   await page.reload();
   await expect(page.locator('.maka-composer-textarea')).toBeVisible();
   await expect(page.locator('.maka-boundary-unreadable-notice')).toHaveCount(0);

--- a/apps/desktop/e2e/permission-mode-surface.spec.ts
+++ b/apps/desktop/e2e/permission-mode-surface.spec.ts
@@ -69,12 +69,18 @@ test('approving an expansion updates the permission label at once and after a re
   // the user this session cannot write, right after they let it.
   await expect(trigger).toHaveText('自动');
 
-  // And it is the boundary saying so, not renderer state: it survives a reload.
-  // #1629: a reload also re-reads the boundary from scratch, and the composer
-  // stays hidden until that read lands. One rejection used to end it there for
-  // good; a failed read is now retried and, if it still cannot be read, says so
-  // instead of leaving an empty window — so the composer coming back with no
-  // notice is the whole recovery path holding.
+  // And it is the boundary saying so, not renderer state: it survives a reload,
+  // where the renderer starts from nothing and has to read the boundary again.
+  // The notice assertion adds that the composer came back because that read
+  // landed, not because the surface gave up and fell open. It does NOT exercise
+  // the retry — nothing rejects here — which the read model's own tests cover
+  // deterministically (#1629).
+  //
+  // The composer returning is only a stable expectation because answering the
+  // fixture's request now settles it: while an answered request kept coming
+  // back on every hydration, whether the composer or the prompt won this frame
+  // was a coin flip, and that was the real cause of the CI timeout that #1630
+  // removed this half over.
   await page.reload();
   await expect(page.locator('.maka-composer-textarea')).toBeVisible();
   await expect(page.locator('.maka-boundary-unreadable-notice')).toHaveCount(0);

--- a/apps/desktop/src/main/__tests__/active-execution-boundary-read-model.test.ts
+++ b/apps/desktop/src/main/__tests__/active-execution-boundary-read-model.test.ts
@@ -1,14 +1,16 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { createReadOnlyPermissionProfile, createWorkspaceWritePermissionProfile } from '@maka/core';
-import type { SessionEvent } from '@maka/core';
+import type { ExecutionBoundary, SessionEvent } from '@maka/core';
 
 import { createAppShellSessionEventHandlers } from '../../renderer/app-shell-session-events.js';
 import {
   EXECUTION_BOUNDARY_READ_RETRY_DELAYS_MS,
+  type ActiveExecutionBoundarySnapshot,
   activeExecutionBoundaryOf,
   activeExecutionBoundaryUnreadable,
   readExecutionBoundaryWithRetry,
+  startActiveExecutionBoundaryRead,
 } from '../../renderer/use-active-execution-boundary.js';
 import { deriveDesktopExecutionBoundarySurface } from '../../renderer/desktop-execution-boundary-surface.js';
 import { readRendererShellSource } from './renderer-shell-source-helpers.js';
@@ -115,6 +117,24 @@ describe('A boundary read that fails (#1629)', () => {
     assert.deepEqual(harness.waits, []);
   });
 
+  it('does not report a read that main answered after it was cancelled', async () => {
+    // Cancelling before the first call is the easy half. The half that matters
+    // is cancelling while main is mid-answer: the reply still arrives, and
+    // without a re-check it comes back indistinguishable from a live one.
+    const answer = deferred<ExecutionBoundary>();
+    let cancelled = false;
+    const result = readExecutionBoundaryWithRetry({
+      read: () => answer.promise,
+      wait: async () => {},
+      cancelled: () => cancelled,
+    });
+
+    cancelled = true;
+    answer.resolve(readOnly);
+
+    assert.deepEqual(await result, { outcome: 'cancelled' });
+  });
+
   it('separates "asked and failed" from "not asked yet", and both fail closed', () => {
     const failed = { sessionId: 'session-a', boundary: undefined };
 
@@ -155,6 +175,108 @@ describe('A boundary read that fails (#1629)', () => {
     assert.match(composerRegion, /boundaryUnreadableNotice\.title/);
     assert.match(composerRegion, /boundaryUnreadableNotice\.detail/);
     assert.match(composerRegion, /onClick=\{boundaryUnreadableNotice\.onRetry\}/);
+  });
+});
+
+function deferred<T>(): { promise: Promise<T>; resolve(value: T): void } {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((resolveValue) => {
+    resolve = resolveValue;
+  });
+  return { promise, resolve };
+}
+
+/** Let every pending microtask chain run to completion. */
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+function recordingCommit() {
+  const snapshots: ActiveExecutionBoundarySnapshot[] = [];
+  const readings: boolean[] = [];
+  return {
+    snapshots,
+    readings,
+    setReading: (reading: boolean) => {
+      readings.push(reading);
+    },
+    setSnapshot: (snapshot: ActiveExecutionBoundarySnapshot) => {
+      snapshots.push(snapshot);
+    },
+  };
+}
+
+describe('Only the newest boundary read may commit', () => {
+  it('does not let a session the user left overwrite the one they opened', async () => {
+    const answerA = deferred<ExecutionBoundary>();
+    const answerB = deferred<ExecutionBoundary>();
+    const commit = recordingCommit();
+
+    const retireA = startActiveExecutionBoundaryRead({
+      sessionId: 'session-a',
+      read: () => answerA.promise,
+      commit,
+      retryDelaysMs: [],
+    });
+    // Switching sessions: React runs the previous cleanup before the next
+    // effect body, so B's generation always starts after A's has been retired.
+    retireA();
+    startActiveExecutionBoundaryRead({
+      sessionId: 'session-b',
+      read: () => answerB.promise,
+      commit,
+      retryDelaysMs: [],
+    });
+
+    answerB.resolve(widened);
+    await settle();
+    answerA.resolve(readOnly);
+    await settle();
+
+    // A's late reply would name a session that is no longer active, which the
+    // surface reads as "boundary unknown, and nothing wrong" — composer hidden,
+    // no notice, and no read left in flight to recover it. That is #1629 again.
+    assert.deepEqual(commit.snapshots, [{ sessionId: 'session-b', boundary: widened }]);
+  });
+
+  // The shape CI reproduced from the first cut of this fix: changing the
+  // permission mode re-runs the read (permissionMode is one of its triggers),
+  // and the previous generation's answer landed afterwards and put the old
+  // boundary back. The composer's label then still read 只读 right after the
+  // user chose 自动 — the read model's own state, not anything main said.
+  it('does not let a superseded revision come back after a reload or a mode change', async () => {
+    const staleAnswer = deferred<ExecutionBoundary>();
+    const freshAnswer = deferred<ExecutionBoundary>();
+    const commit = recordingCommit();
+
+    const retireStale = startActiveExecutionBoundaryRead({
+      sessionId: 'session-a',
+      read: () => staleAnswer.promise,
+      commit,
+      retryDelaysMs: [],
+    });
+    // `reload()` after a decision settles, or the stored permission mode moving
+    // under the hook: same session, new generation. The session id matches on
+    // both, so only the generation can tell them apart.
+    retireStale();
+    startActiveExecutionBoundaryRead({
+      sessionId: 'session-a',
+      read: () => freshAnswer.promise,
+      commit,
+      retryDelaysMs: [],
+    });
+
+    freshAnswer.resolve(widened);
+    await settle();
+    staleAnswer.resolve(readOnly);
+    await settle();
+
+    // Otherwise the label tells the user this session cannot write, moments
+    // after they granted it write access — the #1611 staleness, reintroduced
+    // through the back door.
+    assert.deepEqual(commit.snapshots, [{ sessionId: 'session-a', boundary: widened }]);
+    // And a retired read must not report the live one as finished either.
+    assert.deepEqual(commit.readings, [false]);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/active-execution-boundary-read-model.test.ts
+++ b/apps/desktop/src/main/__tests__/active-execution-boundary-read-model.test.ts
@@ -278,34 +278,6 @@ describe('Only the newest boundary read may commit', () => {
     // And a retired read must not report the live one as finished either.
     assert.deepEqual(commit.readings, [false]);
   });
-
-  it('does not commit an answer whose generation was retired one microtask too late', async () => {
-    const answer = deferred<ExecutionBoundary>();
-    const commit = recordingCommit();
-
-    const retire = startActiveExecutionBoundaryRead({
-      sessionId: 'session-a',
-      read: () => answer.promise,
-      commit,
-      retryDelaysMs: [],
-    });
-    // Queued behind the read's own resumption on the same promise, so it lands
-    // in the one-microtask window after the read has decided it has a live
-    // answer and before the commit callback runs. Nothing in the read itself
-    // can see a retirement that arrives in that window — which is why the
-    // commit re-checks rather than trusting the outcome it was handed.
-    //
-    // On the product path that window is occupied by whatever React drains
-    // next: a pending passive-effect flush runs this generation's cleanup, and
-    // the app shell has several in-flight IPC replies whose continuations can
-    // sit between ours and the callback.
-    void answer.promise.then(() => retire());
-    answer.resolve(readOnly);
-    await settle();
-
-    assert.deepEqual(commit.snapshots, []);
-    assert.deepEqual(commit.readings, []);
-  });
 });
 
 describe('Boundary decisions notify the read model', () => {

--- a/apps/desktop/src/main/__tests__/active-execution-boundary-read-model.test.ts
+++ b/apps/desktop/src/main/__tests__/active-execution-boundary-read-model.test.ts
@@ -4,8 +4,14 @@ import { createReadOnlyPermissionProfile, createWorkspaceWritePermissionProfile 
 import type { SessionEvent } from '@maka/core';
 
 import { createAppShellSessionEventHandlers } from '../../renderer/app-shell-session-events.js';
-import { activeExecutionBoundaryOf } from '../../renderer/use-active-execution-boundary.js';
+import {
+  EXECUTION_BOUNDARY_READ_RETRY_DELAYS_MS,
+  activeExecutionBoundaryOf,
+  activeExecutionBoundaryUnreadable,
+  readExecutionBoundaryWithRetry,
+} from '../../renderer/use-active-execution-boundary.js';
 import { deriveDesktopExecutionBoundarySurface } from '../../renderer/desktop-execution-boundary-surface.js';
+import { readRendererShellSource } from './renderer-shell-source-helpers.js';
 
 const readOnly = {
   kind: 'managed',
@@ -41,6 +47,114 @@ describe('Active execution boundary read model', () => {
       deriveDesktopExecutionBoundarySurface('session-a', widened, 'ask').permissionMode,
       'ask',
     );
+  });
+});
+
+describe('A boundary read that fails (#1629)', () => {
+  function retryHarness(read: () => Promise<typeof readOnly>) {
+    const waits: number[] = [];
+    let cancelled = false;
+    return {
+      waits,
+      cancel: () => {
+        cancelled = true;
+      },
+      run: () =>
+        readExecutionBoundaryWithRetry({
+          read,
+          wait: async (delayMs) => {
+            waits.push(delayMs);
+          },
+          cancelled: () => cancelled,
+        }),
+    };
+  }
+
+  it('recovers from a transient failure instead of leaving the boundary unknown', async () => {
+    // The reload race this was found through: main has not settled the restored
+    // session yet, so the first read rejects. One rejection used to be final.
+    let attempts = 0;
+    const harness = retryHarness(async () => {
+      attempts += 1;
+      if (attempts === 1) throw new Error('session not ready');
+      return readOnly;
+    });
+
+    assert.deepEqual(await harness.run(), { outcome: 'read', boundary: readOnly });
+    assert.equal(attempts, 2);
+    assert.deepEqual(harness.waits, [EXECUTION_BOUNDARY_READ_RETRY_DELAYS_MS[0]]);
+  });
+
+  it('gives up after a bounded number of attempts rather than polling', async () => {
+    let attempts = 0;
+    const harness = retryHarness(async () => {
+      attempts += 1;
+      throw new Error('unreachable');
+    });
+
+    assert.deepEqual(await harness.run(), { outcome: 'unreadable' });
+    // One attempt per retry delay, plus the first: a real outage converges on a
+    // state the surface can explain, and never becomes an unbounded loop.
+    assert.equal(attempts, EXECUTION_BOUNDARY_READ_RETRY_DELAYS_MS.length + 1);
+    assert.deepEqual(harness.waits, [...EXECUTION_BOUNDARY_READ_RETRY_DELAYS_MS]);
+    assert.ok(harness.waits.every((delay) => delay > 0));
+  });
+
+  it('stops retrying a session the user has already left', async () => {
+    let attempts = 0;
+    const harness = retryHarness(async () => {
+      attempts += 1;
+      throw new Error('unreachable');
+    });
+    harness.cancel();
+
+    // Cancellation is not an outcome the surface reports: the session it was
+    // asking about is gone, so there is nothing to tell the user about it.
+    assert.deepEqual(await harness.run(), { outcome: 'cancelled' });
+    assert.equal(attempts, 0);
+    assert.deepEqual(harness.waits, []);
+  });
+
+  it('separates "asked and failed" from "not asked yet", and both fail closed', () => {
+    const failed = { sessionId: 'session-a', boundary: undefined };
+
+    assert.equal(activeExecutionBoundaryUnreadable(failed, 'session-a'), true);
+    // Still reading, and a result belonging to another session, are silence -
+    // the surface waits rather than telling the user something is wrong.
+    assert.equal(activeExecutionBoundaryUnreadable(undefined, 'session-a'), false);
+    assert.equal(activeExecutionBoundaryUnreadable(failed, 'session-b'), false);
+    assert.equal(activeExecutionBoundaryUnreadable(failed, undefined), false);
+
+    // Whichever it is, the boundary stays unknown and local execution stays off:
+    // #1629 is about recovering from that state, not opening it up.
+    assert.equal(activeExecutionBoundaryOf(failed, 'session-a'), undefined);
+    assert.deepEqual(
+      deriveDesktopExecutionBoundarySurface(
+        'session-a',
+        activeExecutionBoundaryOf(failed, 'session-a'),
+        'ask',
+      ),
+      { permissionMode: undefined, localInteractionAvailable: false },
+    );
+  });
+
+  it('turns the unreadable state into something on screen, with a way back', async () => {
+    const shell = await readRendererShellSource('app-shell.tsx');
+    const composerRegion = await readRendererShellSource('chat-composer-region.tsx');
+
+    // Only once the read has given up - a read still in flight has nothing to
+    // report - and never over the onboarding surface, which owns the composer.
+    assert.match(
+      shell,
+      /activeId && activeExecutionBoundaryUnreadable && !onboardingComposerHidden/,
+    );
+    assert.match(shell, /onRetry: \(\) => reloadActiveExecutionBoundary\(activeId\)/);
+    assert.match(shell, /boundaryUnreadableNotice=\{boundaryUnreadableNotice\}/);
+    // The notice is the only thing standing between the user and a window with
+    // no input in it, so it must carry both the reason and the retry.
+    assert.match(composerRegion, /boundaryUnreadableNotice\.title/);
+    assert.match(composerRegion, /boundaryUnreadableNotice\.detail/);
+    assert.match(composerRegion, /onClick=\{boundaryUnreadableNotice\.onRetry\}/);
   });
 });
 

--- a/apps/desktop/src/main/__tests__/active-execution-boundary-read-model.test.ts
+++ b/apps/desktop/src/main/__tests__/active-execution-boundary-read-model.test.ts
@@ -278,6 +278,34 @@ describe('Only the newest boundary read may commit', () => {
     // And a retired read must not report the live one as finished either.
     assert.deepEqual(commit.readings, [false]);
   });
+
+  it('does not commit an answer whose generation was retired one microtask too late', async () => {
+    const answer = deferred<ExecutionBoundary>();
+    const commit = recordingCommit();
+
+    const retire = startActiveExecutionBoundaryRead({
+      sessionId: 'session-a',
+      read: () => answer.promise,
+      commit,
+      retryDelaysMs: [],
+    });
+    // Queued behind the read's own resumption on the same promise, so it lands
+    // in the one-microtask window after the read has decided it has a live
+    // answer and before the commit callback runs. Nothing in the read itself
+    // can see a retirement that arrives in that window — which is why the
+    // commit re-checks rather than trusting the outcome it was handed.
+    //
+    // On the product path that window is occupied by whatever React drains
+    // next: a pending passive-effect flush runs this generation's cleanup, and
+    // the app shell has several in-flight IPC replies whose continuations can
+    // sit between ours and the callback.
+    void answer.promise.then(() => retire());
+    answer.resolve(readOnly);
+    await settle();
+
+    assert.deepEqual(commit.snapshots, []);
+    assert.deepEqual(commit.readings, []);
+  });
 });
 
 describe('Boundary decisions notify the read model', () => {

--- a/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
+++ b/apps/desktop/src/main/__tests__/e2e-fixture.test.ts
@@ -6,7 +6,9 @@ import { tmpdir } from 'node:os';
 import { discoverMarkedStorageRoot } from '@maka/storage/root-authority';
 import {
   getE2eFixtureState,
+  resetE2eFixtureSandboxBoundaryRetirement,
   resolveE2eFixture,
+  retireE2eFixtureSandboxBoundaryRequest,
   seedE2eFixture,
 } from '../e2e-fixture.js';
 import { readE2eFixtureCombinedSource } from './e2e-fixture-source-helpers.js';
@@ -307,6 +309,31 @@ describe('e2e-fixture mode', () => {
     assert.deepEqual(request.expansion.filesystem?.entries, [
       { path: '/outside/dist', access: 'write', scope: 'subtree' },
     ]);
+  });
+
+  it('retires an answered boundary request from every reader of fixture state', () => {
+    resetE2eFixtureSandboxBoundaryRetirement();
+    try {
+      const fixture = resolveE2eFixture('sandbox-boundary', false);
+      const request = getE2eFixtureState(fixture)?.sandboxBoundaryBySession?.['e2e-fixture-permission'];
+      assert.ok(request);
+
+      retireE2eFixtureSandboxBoundaryRequest(request.requestId);
+
+      // Both exits read this one state: the sessions IPC serves the active
+      // list from it, and the renderer seeds its interaction queue straight
+      // out of `e2eFixture:getState`. Retiring at either exit alone would just
+      // move the resurrection to the other one — after a reload the seed path
+      // would put the prompt back over the composer for good.
+      const after = getE2eFixtureState(fixture);
+      assert.deepEqual(after?.sandboxBoundaryBySession, {});
+      // The rest of the scenario is untouched: retirement settles one request,
+      // it does not disable the fixture.
+      assert.equal(after?.activeSessionId, 'e2e-fixture-permission');
+      assert.ok(after?.liveTurnBySession?.['e2e-fixture-permission']);
+    } finally {
+      resetE2eFixtureSandboxBoundaryRetirement();
+    }
   });
 
   it('task-ledger fixture seeds the hierarchical desktop read model', async () => {

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -7,7 +7,10 @@ import {
   readRendererShellSource,
   readRendererShellSources,
 } from './renderer-shell-source-helpers.js';
-import { readMainProcessCombinedSource } from './main-process-contract-source-helpers.js';
+import {
+  readMainProcessCombinedSource,
+  readSessionsIpcSource,
+} from './main-process-contract-source-helpers.js';
 
 import {
   normalizeBranchFromTurnInput,
@@ -390,6 +393,33 @@ describe('permission response IPC boundary', () => {
       shell,
       /listPendingSandboxBoundaryRequests/,
       'the renderer must not turn ownerless persisted rows into actionable prompts',
+    );
+  });
+
+  it('retires an answered e2e-fixture boundary request so a reload cannot revive it', async () => {
+    const sessionsIpc = await readSessionsIpcSource();
+    const listHandler =
+      sessionsIpc.match(
+        /ipcMain\.handle\('sessions:listActiveSandboxBoundaryRequests'[\s\S]*?\n  \}\);/,
+      )?.[0] ?? '';
+    const respondHandler =
+      sessionsIpc.match(/ipcMain\.handle\('sessions:respondToSandboxBoundary'[\s\S]*?\n  \}\);/)?.[0] ??
+      '';
+
+    // The fixture request is rebuilt from its scenario on every read, so unless
+    // the answer is remembered the prompt returns on the next hydration and
+    // retakes the composer slot. That made "does the composer come back after a
+    // reload" a coin flip between two in-flight IPC replies.
+    assert.match(respondHandler, /answeredFixtureSandboxBoundaryRequests\.add\(normalized\.requestId\)/);
+    assert.match(
+      listHandler,
+      /!answeredFixtureSandboxBoundaryRequests\.has\(fixtureRequest\.requestId\)/,
+    );
+    // Deny must retire it too: a decision that leaves the request pending is
+    // not a decision.
+    assert.doesNotMatch(
+      respondHandler,
+      /if \(normalized\.decision === 'allow'\) \{\s*answeredFixtureSandboxBoundaryRequests\.add/,
     );
   });
 

--- a/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-response-ipc-boundary.test.ts
@@ -396,30 +396,32 @@ describe('permission response IPC boundary', () => {
     );
   });
 
-  it('retires an answered e2e-fixture boundary request so a reload cannot revive it', async () => {
+  it('retires an answered e2e-fixture boundary request through the one fixture-state owner', async () => {
     const sessionsIpc = await readSessionsIpcSource();
-    const listHandler =
-      sessionsIpc.match(
-        /ipcMain\.handle\('sessions:listActiveSandboxBoundaryRequests'[\s\S]*?\n  \}\);/,
-      )?.[0] ?? '';
     const respondHandler =
       sessionsIpc.match(/ipcMain\.handle\('sessions:respondToSandboxBoundary'[\s\S]*?\n  \}\);/)?.[0] ??
       '';
 
     // The fixture request is rebuilt from its scenario on every read, so unless
-    // the answer is remembered the prompt returns on the next hydration and
-    // retakes the composer slot. That made "does the composer come back after a
-    // reload" a coin flip between two in-flight IPC replies.
-    assert.match(respondHandler, /answeredFixtureSandboxBoundaryRequests\.add\(normalized\.requestId\)/);
-    assert.match(
-      listHandler,
-      /!answeredFixtureSandboxBoundaryRequests\.has\(fixtureRequest\.requestId\)/,
-    );
-    // Deny must retire it too: a decision that leaves the request pending is
-    // not a decision.
+    // the answer is remembered the prompt returns and retakes the composer
+    // slot. It must be remembered at the fixture-state owner, not next to one
+    // of its two exits: the sessions IPC serves the active-request list, and
+    // `e2eFixture:getState` hands the renderer a state it seeds its interaction
+    // queue from directly, bypassing that list entirely.
+    assert.match(respondHandler, /retireE2eFixtureSandboxBoundaryRequest\(normalized\.requestId\)/);
     assert.doesNotMatch(
+      sessionsIpc,
+      /answeredFixtureSandboxBoundaryRequests/,
+      'retirement must not live in a side table only the sessions IPC can see',
+    );
+
+    // Allow retires only after the grant lands, matching the runtime, which
+    // drops an active request on the acknowledged decision rather than the
+    // received one. Deny has nothing to write, so it retires straight away.
+    assert.match(
       respondHandler,
-      /if \(normalized\.decision === 'allow'\) \{\s*answeredFixtureSandboxBoundaryRequests\.add/,
+      /await applyFixtureSandboxBoundaryExpansion\([\s\S]*?\)\;\s*\}\s*retireE2eFixtureSandboxBoundaryRequest/,
+      'a failed expansion must leave the request answerable instead of hiding it',
     );
   });
 

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -367,7 +367,50 @@ function parseReducedMotionFlag(raw: string | undefined): boolean {
   return normalized === '1' || normalized === 'true' || normalized === 'yes';
 }
 
+/**
+ * Sandbox-boundary requests the user has already answered.
+ *
+ * The fixture's requests are rebuilt from the scenario on every read, so
+ * answering one cannot retire it the way a real one is retired — the runtime
+ * drops an active request from its in-memory owner state when the decision is
+ * acknowledged, and the fixture's request has no such owner. Without somewhere
+ * to remember the answer the request keeps coming back, and a decision that
+ * leaves the request pending is not a decision.
+ *
+ * It lives here rather than at either exit because there are two: the sessions
+ * IPC serves the active-request list, and `e2eFixture:getState` hands the
+ * renderer a state it seeds its interaction queue from directly. A retirement
+ * either exit could not see would only move the resurrection to the other one.
+ *
+ * Deliberately not persisted: the answer belongs to the run, and every run
+ * starts from a throwaway userData dir with the request unanswered again.
+ */
+const answeredSandboxBoundaryRequests = new Set<string>();
+
+/** Retire an answered fixture request from every reader of fixture state. */
+export function retireE2eFixtureSandboxBoundaryRequest(requestId: string): void {
+  answeredSandboxBoundaryRequests.add(requestId);
+}
+
+/** Test seam: the retirement set is module state shared across cases. */
+export function resetE2eFixtureSandboxBoundaryRetirement(): void {
+  answeredSandboxBoundaryRequests.clear();
+}
+
 export function getE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState | null {
+  const state = buildE2eFixtureState(fixture);
+  if (!state?.sandboxBoundaryBySession) return state;
+  return {
+    ...state,
+    sandboxBoundaryBySession: Object.fromEntries(
+      Object.entries(state.sandboxBoundaryBySession).filter(
+        ([, request]) => !answeredSandboxBoundaryRequests.has(request.requestId),
+      ),
+    ),
+  };
+}
+
+function buildE2eFixtureState(fixture: E2eFixture | null): E2eFixtureState | null {
   if (!fixture) return null;
   const state: E2eFixtureState = {
     enabled: true,

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -334,9 +334,15 @@ export function registerSessionsIpc(
   ipcMain.handle('sessions:readExecutionBoundary', (_event, sessionId: string) =>
     runtime.readExecutionBoundary(sessionId),
   );
+  // The fixture's synthetic request is recomputed from its scenario on every
+  // read, so answering it cannot retire it the way a real request retires
+  // itself in the store. Without somewhere to remember the answer, the prompt
+  // comes back on the next hydration — after a renderer reload, say — and the
+  // fixture models a request the user is never allowed to finish answering.
+  const answeredFixtureSandboxBoundaryRequests = new Set<string>();
   ipcMain.handle('sessions:listActiveSandboxBoundaryRequests', (_event, sessionId: string) => {
     const fixtureRequest = getE2eFixtureState(e2eFixture)?.sandboxBoundaryBySession?.[sessionId];
-    return fixtureRequest
+    return fixtureRequest && !answeredFixtureSandboxBoundaryRequests.has(fixtureRequest.requestId)
       ? [fixtureRequest]
       : runtime.listActiveSandboxBoundaryRequests(sessionId);
   });
@@ -347,7 +353,10 @@ export function registerSessionsIpc(
       // The fixture request is synthetic — no runtime turn is waiting on it —
       // but allowing it must still move the real boundary, or the fixture
       // would model an "allow" that grants nothing and no surface built on the
-      // boundary could be exercised against it (#1611).
+      // boundary could be exercised against it (#1611). Answering it must also
+      // settle it, for the same reason: a decision that leaves the request
+      // pending is not a decision.
+      answeredFixtureSandboxBoundaryRequests.add(normalized.requestId);
       if (normalized.decision === 'allow') {
         await applyFixtureSandboxBoundaryExpansion(store, sessionId, fixtureRequest.expansion);
       }

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -38,7 +38,11 @@ import {
   normalizeStopSessionInput,
   normalizeUserQuestionResponse,
 } from './permission-response-guard.js';
-import { getE2eFixtureState, type resolveE2eFixture } from './e2e-fixture.js';
+import {
+  getE2eFixtureState,
+  retireE2eFixtureSandboxBoundaryRequest,
+  type resolveE2eFixture,
+} from './e2e-fixture.js';
 import type { requireReadyConnection } from './chat-readiness.js';
 import type { MainTaskLedgerWiring } from './task-ledger-wiring.js';
 import type { MainGoalWiring } from './goal-wiring.js';
@@ -334,15 +338,11 @@ export function registerSessionsIpc(
   ipcMain.handle('sessions:readExecutionBoundary', (_event, sessionId: string) =>
     runtime.readExecutionBoundary(sessionId),
   );
-  // The fixture's synthetic request is recomputed from its scenario on every
-  // read, so answering it cannot retire it the way a real request retires
-  // itself in the store. Without somewhere to remember the answer, the prompt
-  // comes back on the next hydration — after a renderer reload, say — and the
-  // fixture models a request the user is never allowed to finish answering.
-  const answeredFixtureSandboxBoundaryRequests = new Set<string>();
   ipcMain.handle('sessions:listActiveSandboxBoundaryRequests', (_event, sessionId: string) => {
+    // Already filtered by retirement: `getE2eFixtureState` is the one owner of
+    // which fixture requests are still unanswered.
     const fixtureRequest = getE2eFixtureState(e2eFixture)?.sandboxBoundaryBySession?.[sessionId];
-    return fixtureRequest && !answeredFixtureSandboxBoundaryRequests.has(fixtureRequest.requestId)
+    return fixtureRequest
       ? [fixtureRequest]
       : runtime.listActiveSandboxBoundaryRequests(sessionId);
   });
@@ -353,13 +353,15 @@ export function registerSessionsIpc(
       // The fixture request is synthetic — no runtime turn is waiting on it —
       // but allowing it must still move the real boundary, or the fixture
       // would model an "allow" that grants nothing and no surface built on the
-      // boundary could be exercised against it (#1611). Answering it must also
-      // settle it, for the same reason: a decision that leaves the request
-      // pending is not a decision.
-      answeredFixtureSandboxBoundaryRequests.add(normalized.requestId);
+      // boundary could be exercised against it (#1611).
       if (normalized.decision === 'allow') {
+        // Retired only once the grant has landed. The runtime drops an active
+        // request when the decision is acknowledged, not when it is received;
+        // hiding this one before the write succeeds would let the fixture
+        // swallow a settlement failure the renderer is about to be told about.
         await applyFixtureSandboxBoundaryExpansion(store, sessionId, fixtureRequest.expansion);
       }
+      retireE2eFixtureSandboxBoundaryRequest(normalized.requestId);
       return;
     }
     if (normalized.decision === 'allow') {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -999,8 +999,12 @@ function AppShellContent({
     permissionMode: defaultPermissionMode,
         }
       : undefined);
-  const { boundary: activeExecutionBoundary, reload: reloadActiveExecutionBoundary } =
-    useActiveExecutionBoundary(activeId, activeSessionForView?.permissionMode);
+  const {
+    boundary: activeExecutionBoundary,
+    unreadable: activeExecutionBoundaryUnreadable,
+    reading: activeExecutionBoundaryReading,
+    reload: reloadActiveExecutionBoundary,
+  } = useActiveExecutionBoundary(activeId, activeSessionForView?.permissionMode);
   useEffect(() => {
     if (!activeId) return;
     let cancelled = false;
@@ -1121,6 +1125,21 @@ function AppShellContent({
     onboardingState.kind !== 'ready_with_history' &&
     onboardingState.kind !== 'ready_empty';
   const onboardingComposerHidden = isOnboardingLoading || (showOnboardingHero && onboardingState !== undefined);
+  // #1629: hiding the composer because the boundary is unknown is right, but
+  // hiding it silently and forever is not. Once the read has spent its retries
+  // the slot says so and hands the user another attempt; while it is still
+  // reading, or while onboarding owns the surface, there is nothing to say.
+  const boundaryUnreadableNotice =
+    activeId && activeExecutionBoundaryUnreadable && !onboardingComposerHidden
+      ? {
+          title: shellCopy.boundaryUnreadableTitle,
+          detail: shellCopy.boundaryUnreadableDetail,
+          retryLabel: shellCopy.boundaryUnreadableRetry,
+          retryPendingLabel: shellCopy.boundaryUnreadableRetrying,
+          retryPending: activeExecutionBoundaryReading,
+          onRetry: () => reloadActiveExecutionBoundary(activeId),
+        }
+      : undefined;
   const {
     sessionListWidth,
     setSessionListWidth,
@@ -2182,6 +2201,7 @@ function AppShellContent({
                 onboardingComposerHidden={
                   onboardingComposerHidden || !activeBoundarySurface.localInteractionAvailable
                 }
+                boundaryUnreadableNotice={boundaryUnreadableNotice}
                 activeInteraction={activeInteraction}
                 activeId={activeId}
                 stopPendingBySession={stopPendingBySession}

--- a/apps/desktop/src/renderer/chat-composer-region.tsx
+++ b/apps/desktop/src/renderer/chat-composer-region.tsx
@@ -1,10 +1,29 @@
 import type { ComponentProps, Ref } from 'react';
 import {
+  Alert,
+  AlertAction,
+  AlertDescription,
+  AlertTitle,
   Composer,
   SandboxBoundaryPrompt,
   UserQuestionPrompt,
 } from '@maka/ui';
 import type { ComposerHandle, ComposerInteraction } from '@maka/ui';
+
+/**
+ * #1629: what the composer's slot shows when the active session's boundary
+ * could not be read. The composer must stay hidden — without the boundary the
+ * surface cannot know what the session may do — but "hidden" on its own reads
+ * as a broken window, so the slot says what happened and offers another read.
+ */
+export interface BoundaryUnreadableNotice {
+  title: string;
+  detail: string;
+  retryLabel: string;
+  retryPendingLabel: string;
+  retryPending: boolean;
+  onRetry(): void;
+}
 
 /**
  * The composer region of the chat surface (issue #1043): the composer
@@ -33,6 +52,7 @@ interface ChatComposerRegionProps extends Omit<ComponentProps<typeof Composer>, 
   activeQuestion: ComponentProps<typeof UserQuestionPrompt>['request'] | undefined;
   respondToUserQuestion: ComponentProps<typeof UserQuestionPrompt>['onRespond'];
   stop: ComponentProps<typeof UserQuestionPrompt>['onStop'];
+  boundaryUnreadableNotice?: BoundaryUnreadableNotice;
 }
 
 export function ChatComposerRegion({
@@ -47,11 +67,40 @@ export function ChatComposerRegion({
   activeQuestion,
   respondToUserQuestion,
   stop,
+  boundaryUnreadableNotice,
   ...composerRest
 }: ChatComposerRegionProps) {
   return (
     <>
       <div className="maka-composer-interaction-slot">
+        {/* The notice stands in for the composer, so it appears exactly where
+            the composer would have been — and never over a turn-scoped
+            interaction, which already owns the slot and is the more urgent
+            thing to answer. */}
+        {boundaryUnreadableNotice && active && !activeInteraction && (
+          <div className="maka-boundary-unreadable-notice">
+            <Alert
+              className="maka-boundary-unreadable-notice-alert"
+              variant="warning"
+              role="status"
+            >
+              <AlertTitle>{boundaryUnreadableNotice.title}</AlertTitle>
+              <AlertDescription>{boundaryUnreadableNotice.detail}</AlertDescription>
+              <AlertAction>
+                <button
+                  type="button"
+                  className="maka-boundary-unreadable-notice-action"
+                  disabled={boundaryUnreadableNotice.retryPending}
+                  onClick={boundaryUnreadableNotice.onRetry}
+                >
+                  {boundaryUnreadableNotice.retryPending
+                    ? boundaryUnreadableNotice.retryPendingLabel
+                    : boundaryUnreadableNotice.retryLabel}
+                </button>
+              </AlertAction>
+            </Alert>
+          </div>
+        )}
         {activeSandboxBoundary && (
           <SandboxBoundaryPrompt
             request={activeSandboxBoundary}

--- a/apps/desktop/src/renderer/chat-composer-region.tsx
+++ b/apps/desktop/src/renderer/chat-composer-region.tsx
@@ -16,7 +16,7 @@ import type { ComposerHandle, ComposerInteraction } from '@maka/ui';
  * surface cannot know what the session may do — but "hidden" on its own reads
  * as a broken window, so the slot says what happened and offers another read.
  */
-export interface BoundaryUnreadableNotice {
+interface BoundaryUnreadableNotice {
   title: string;
   detail: string;
   retryLabel: string;

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -418,6 +418,10 @@ type ShellCopy = {
     updateOpenManualFallback: string;
     loading: string;
     goToModels: string;
+    boundaryUnreadableTitle: string;
+    boundaryUnreadableDetail: string;
+    boundaryUnreadableRetry: string;
+    boundaryUnreadableRetrying: string;
     permissionModeChanging: string;
     permissionModeStreaming: string;
     permissionModeRunning: string;
@@ -1109,6 +1113,11 @@ const SHELL_COPY_BY_LOCALE = {
       updateOpenManualFallback: '请稍后重试，或前往 GitHub Releases 下载最新版本。',
       loading: '加载中',
       goToModels: '去模型',
+      boundaryUnreadableTitle: '暂时读不到这个对话的权限',
+      boundaryUnreadableDetail:
+        '在读到之前，这里不能输入，以免执行你没有允许的操作。可以重试，或先切换到别的对话。',
+      boundaryUnreadableRetry: '重试',
+      boundaryUnreadableRetrying: '重试中…',
       permissionModeChanging: '权限模式正在切换，完成后再继续操作。',
       permissionModeStreaming: '当前对话正在流式输出，等结束后再切换权限模式。',
       permissionModeRunning: '当前对话正在运行，等结束后再切换权限模式。',
@@ -1629,6 +1638,11 @@ const SHELL_COPY_BY_LOCALE = {
       updateOpenManualFallback: 'Try again later, or download the latest version from GitHub Releases.',
       loading: 'Loading',
       goToModels: 'Go to Models',
+      boundaryUnreadableTitle: 'Could not read this conversation’s permissions',
+      boundaryUnreadableDetail:
+        'Until they are read, you cannot type here, so nothing runs that you have not allowed. Try again, or switch to another conversation.',
+      boundaryUnreadableRetry: 'Try again',
+      boundaryUnreadableRetrying: 'Trying again…',
       permissionModeChanging: 'The permission mode is changing. Wait for it to finish before continuing.',
       permissionModeStreaming:
         'This conversation is streaming. Wait for it to finish before changing the permission mode.',

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -1114,8 +1114,7 @@ const SHELL_COPY_BY_LOCALE = {
       loading: '加载中',
       goToModels: '去模型',
       boundaryUnreadableTitle: '暂时读不到这个对话的权限',
-      boundaryUnreadableDetail:
-        '在读到之前，这里不能输入，以免执行你没有允许的操作。可以重试，或先切换到别的对话。',
+      boundaryUnreadableDetail: '在读到之前，这里暂时不能输入。可以重试，或先切换到别的对话。',
       boundaryUnreadableRetry: '重试',
       boundaryUnreadableRetrying: '重试中…',
       permissionModeChanging: '权限模式正在切换，完成后再继续操作。',
@@ -1640,7 +1639,7 @@ const SHELL_COPY_BY_LOCALE = {
       goToModels: 'Go to Models',
       boundaryUnreadableTitle: 'Could not read this conversation’s permissions',
       boundaryUnreadableDetail:
-        'Until they are read, you cannot type here, so nothing runs that you have not allowed. Try again, or switch to another conversation.',
+        'Until they can be read, you cannot type here. Try again, or switch to another conversation.',
       boundaryUnreadableRetry: 'Try again',
       boundaryUnreadableRetrying: 'Trying again…',
       permissionModeChanging: 'The permission mode is changing. Wait for it to finish before continuing.',

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -71,6 +71,46 @@
   outline-offset: var(--focus-ring-offset);
 }
 
+/* #1629: the boundary-unreadable notice stands in for the composer it replaces,
+   so it resolves to the same box by the same formula as the health notice. */
+.maka-boundary-unreadable-notice {
+  width: min(var(--maka-chat-measure), calc(100% - (2 * var(--space-6))));
+  max-width: var(--maka-chat-measure);
+  margin: 0 auto var(--space-2);
+  -webkit-app-region: no-drag;
+}
+
+.maka-boundary-unreadable-notice-alert {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+.maka-boundary-unreadable-notice-action {
+  appearance: none;
+  border: var(--border-width-hairline) solid oklch(from var(--border) l c h / 0.9);
+  background: var(--background-elevated);
+  color: var(--foreground);
+  border-radius: var(--radius-surface);
+  padding: var(--space-1) var(--space-2);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-semibold);
+  white-space: nowrap;
+  cursor: default;
+}
+
+.maka-boundary-unreadable-notice-action:hover:not(:disabled) {
+  background: var(--state-hover-bg);
+}
+
+.maka-boundary-unreadable-notice-action:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+.maka-boundary-unreadable-notice-action:disabled {
+  opacity: var(--opacity-disabled);
+}
+
 /* PR-REMOVE-CHAT-TAB (WAWQAQ msg d401938d 2026-06-23): the
    browser-style session tab + the duplicate "新建对话" plus button at
    the top-left of the chat header are removed. ~95 LOC of .maka-chat-tab*

--- a/apps/desktop/src/renderer/styles/chat-header.css
+++ b/apps/desktop/src/renderer/styles/chat-header.css
@@ -36,7 +36,14 @@
    composer's own `--space-6` gutters. The old `margin: 0 var(--space-3)` left it
    uncapped, so on a wide window the notice ran the full chat column while the
    composer stayed at 680px — a visibly mismatched edge. Same formula as
-   `.maka-composer-no-model-hint` / `.maka-composer-revision-notice`. */
+   `.maka-composer-no-model-hint` / `.maka-composer-revision-notice`.
+
+   #1629: the boundary-unreadable notice stands in for the composer it replaces,
+   so it is the same kind of peer and shares the formula rather than restating
+   it. `.maka-session-health-notice` stays last in each group — the
+   session-health-notice layout contract reads its rule body by matching the
+   selector immediately before the brace. */
+.maka-boundary-unreadable-notice,
 .maka-session-health-notice {
   width: min(var(--maka-chat-measure), calc(100% - (2 * var(--space-6))));
   max-width: var(--maka-chat-measure);
@@ -44,11 +51,13 @@
   -webkit-app-region: no-drag;
 }
 
+.maka-boundary-unreadable-notice-alert,
 .maka-session-health-notice-alert {
   width: 100%;
   box-sizing: border-box;
 }
 
+.maka-boundary-unreadable-notice-action,
 .maka-session-health-notice-action {
   appearance: none;
   border: var(--border-width-hairline) solid oklch(from var(--border) l c h / 0.9);
@@ -62,51 +71,19 @@
   cursor: default;
 }
 
+.maka-boundary-unreadable-notice-action:hover:not(:disabled),
 .maka-session-health-notice-action:hover {
   background: var(--state-hover-bg);
 }
 
+.maka-boundary-unreadable-notice-action:focus-visible,
 .maka-session-health-notice-action:focus-visible {
   outline: var(--focus-ring-width) solid var(--focus-ring);
   outline-offset: var(--focus-ring-offset);
 }
 
-/* #1629: the boundary-unreadable notice stands in for the composer it replaces,
-   so it resolves to the same box by the same formula as the health notice. */
-.maka-boundary-unreadable-notice {
-  width: min(var(--maka-chat-measure), calc(100% - (2 * var(--space-6))));
-  max-width: var(--maka-chat-measure);
-  margin: 0 auto var(--space-2);
-  -webkit-app-region: no-drag;
-}
-
-.maka-boundary-unreadable-notice-alert {
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.maka-boundary-unreadable-notice-action {
-  appearance: none;
-  border: var(--border-width-hairline) solid oklch(from var(--border) l c h / 0.9);
-  background: var(--background-elevated);
-  color: var(--foreground);
-  border-radius: var(--radius-surface);
-  padding: var(--space-1) var(--space-2);
-  font-size: var(--font-size-caption);
-  font-weight: var(--font-weight-semibold);
-  white-space: nowrap;
-  cursor: default;
-}
-
-.maka-boundary-unreadable-notice-action:hover:not(:disabled) {
-  background: var(--state-hover-bg);
-}
-
-.maka-boundary-unreadable-notice-action:focus-visible {
-  outline: var(--focus-ring-width) solid var(--focus-ring);
-  outline-offset: var(--focus-ring-offset);
-}
-
+/* Only the boundary notice's action has a pending state: it re-reads in place,
+   where the health notice's action navigates away. */
 .maka-boundary-unreadable-notice-action:disabled {
   opacity: var(--opacity-disabled);
 }

--- a/apps/desktop/src/renderer/use-active-execution-boundary.ts
+++ b/apps/desktop/src/renderer/use-active-execution-boundary.ts
@@ -140,9 +140,13 @@ export function startActiveExecutionBoundaryRead(input: {
     cancelled: () => cancelled,
     retryDelaysMs: input.retryDelaysMs,
   }).then((result) => {
-    // Checked here as well as inside the read: this generation can be retired
-    // in the turn between the read resolving and this callback running.
-    if (cancelled || result.outcome === 'cancelled') return;
+    // The read's own re-check is the whole boundary, and it is enough. A
+    // retirement reaches this generation from exactly one place — React's
+    // effect cleanup — which runs from the scheduler, never from the microtask
+    // drain between the read resolving and this callback. Another reply
+    // landing in that drain can only queue a React update behind this callback,
+    // not ahead of it.
+    if (result.outcome === 'cancelled') return;
     input.commit.setReading(false);
     input.commit.setSnapshot({
       sessionId: input.sessionId,

--- a/apps/desktop/src/renderer/use-active-execution-boundary.ts
+++ b/apps/desktop/src/renderer/use-active-execution-boundary.ts
@@ -20,9 +20,10 @@ export type ExecutionBoundaryReadResult =
  * Bounded on purpose. A boundary read fails for two very different reasons: a
  * main process that has not finished settling the session yet — which the next
  * attempt fixes — and something actually broken, which no number of attempts
- * fixes. This schedule rides out the first (converging in under two seconds)
- * and then stops, so the second becomes a state the user is told about rather
- * than a poll that runs until the window closes.
+ * fixes. This schedule rides out the first (four reads, with 1.75s of waiting
+ * spread between them on top of whatever the reads themselves cost) and then
+ * stops, so the second becomes a state the user is told about rather than a
+ * poll that runs until the window closes.
  */
 export const EXECUTION_BOUNDARY_READ_RETRY_DELAYS_MS: readonly number[] = [150, 400, 1200];
 
@@ -42,7 +43,12 @@ export async function readExecutionBoundaryWithRetry(input: {
   for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
     if (input.cancelled()) return { outcome: 'cancelled' };
     try {
-      return { outcome: 'read', boundary: await input.read() };
+      const boundary = await input.read();
+      // A read outlives its caller: main answers whenever it answers, and by
+      // then the session may have been switched away from. Re-check before
+      // claiming a result, or a reply nobody is waiting for any more comes back
+      // looking exactly like a live answer.
+      return input.cancelled() ? { outcome: 'cancelled' } : { outcome: 'read', boundary };
     } catch {
       // Retried below, or reported as unreadable once the schedule runs out.
     }
@@ -91,6 +97,65 @@ export function activeExecutionBoundaryUnreadable(
   return snapshot.boundary === undefined;
 }
 
+/** Where a settled read writes back. Both come straight from `useState`. */
+export interface ActiveExecutionBoundaryReadCommit {
+  setReading(reading: boolean): void;
+  setSnapshot(snapshot: ActiveExecutionBoundarySnapshot): void;
+}
+
+/**
+ * Start one generation of the boundary read and return the call that retires
+ * it. Only a generation that has not been retired may commit.
+ *
+ * That invariant is the whole reason this is a named function rather than an
+ * effect body. A read for session A can still be in flight when the user opens
+ * B; A's reply arrives later and, uncontrolled, overwrites B's snapshot with
+ * A's. The snapshot then names a session that is not active, which reads as
+ * "boundary unknown, and no failure to report" — the exact dead end #1629 is
+ * about, this time with nothing left in flight to recover from it. The same
+ * race puts a superseded revision back on screen after a `reload()`.
+ *
+ * The generation token is the `cancelled` flag closed over below: React runs a
+ * cleanup before the next effect body, so one flag per call is already one flag
+ * per generation, and no separate counter would say anything more.
+ */
+export function startActiveExecutionBoundaryRead(input: {
+  sessionId: string;
+  read(sessionId: string): Promise<ExecutionBoundary>;
+  commit: ActiveExecutionBoundaryReadCommit;
+  retryDelaysMs?: readonly number[];
+}): () => void {
+  let cancelled = false;
+  let waitTimer: ReturnType<typeof setTimeout> | undefined;
+  let releaseWait: (() => void) | undefined;
+  void readExecutionBoundaryWithRetry({
+    read: () => input.read(input.sessionId),
+    // Released on cancel so a retired generation does not sit out the rest of a
+    // backoff before the loop notices.
+    wait: (delayMs) =>
+      new Promise<void>((resolve) => {
+        releaseWait = resolve;
+        waitTimer = setTimeout(resolve, delayMs);
+      }),
+    cancelled: () => cancelled,
+    retryDelaysMs: input.retryDelaysMs,
+  }).then((result) => {
+    // Checked here as well as inside the read: this generation can be retired
+    // in the turn between the read resolving and this callback running.
+    if (cancelled || result.outcome === 'cancelled') return;
+    input.commit.setReading(false);
+    input.commit.setSnapshot({
+      sessionId: input.sessionId,
+      boundary: result.outcome === 'read' ? result.boundary : undefined,
+    });
+  });
+  return () => {
+    cancelled = true;
+    if (waitTimer !== undefined) clearTimeout(waitTimer);
+    releaseWait?.();
+  };
+}
+
 /**
  * The desktop's read model for the active session's execution boundary — the
  * one place that decides when the renderer's copy of the boundary is stale.
@@ -112,7 +177,9 @@ export function activeExecutionBoundaryUnreadable(
  * good. Nothing here re-fires on its own, so the surface fell closed
  * permanently and the composer never came back. A failed read is now retried on
  * a bounded schedule and, when that runs out, reported as `unreadable` so the
- * surface can say so and offer another attempt.
+ * surface can say so and offer another attempt. Every read runs as a generation
+ * that only commits while it is still the current one — see
+ * `startActiveExecutionBoundaryRead` for why a late reply is the same bug.
  */
 export function useActiveExecutionBoundary(
   activeSessionId: string | undefined,
@@ -136,34 +203,16 @@ export function useActiveExecutionBoundary(
   }, [activeSessionId]);
 
   useEffect(() => {
+    // Armed synchronously by every generation and cleared only by one that is
+    // still current, so `reading` needs no generation of its own: a retired
+    // read can no longer report the newest one as finished.
     setReading(activeSessionId !== undefined);
     if (!activeSessionId) return;
-    let cancelled = false;
-    let waitTimer: ReturnType<typeof setTimeout> | undefined;
-    let releaseWait: (() => void) | undefined;
-    void readExecutionBoundaryWithRetry({
-      read: () => window.maka.sessions.readExecutionBoundary(activeSessionId),
-      // Released on cleanup so a session switch or an unmount does not sit out
-      // the rest of a backoff before the loop notices it has been cancelled.
-      wait: (delayMs) =>
-        new Promise<void>((resolve) => {
-          releaseWait = resolve;
-          waitTimer = setTimeout(resolve, delayMs);
-        }),
-      cancelled: () => cancelled,
-    }).then((result) => {
-      if (result.outcome === 'cancelled') return;
-      setReading(false);
-      setSnapshot({
-        sessionId: activeSessionId,
-        boundary: result.outcome === 'read' ? result.boundary : undefined,
-      });
+    return startActiveExecutionBoundaryRead({
+      sessionId: activeSessionId,
+      read: (sessionId) => window.maka.sessions.readExecutionBoundary(sessionId),
+      commit: { setReading, setSnapshot },
     });
-    return () => {
-      cancelled = true;
-      if (waitTimer !== undefined) clearTimeout(waitTimer);
-      releaseWait?.();
-    };
   }, [activeSessionId, permissionMode, reloadNonce]);
 
   const reload = useCallback((sessionId: string) => {

--- a/apps/desktop/src/renderer/use-active-execution-boundary.ts
+++ b/apps/desktop/src/renderer/use-active-execution-boundary.ts
@@ -2,12 +2,66 @@ import type { ExecutionBoundary } from '@maka/core';
 import { useCallback, useEffect, useRef, useState } from 'react';
 
 /**
- * A boundary snapshot together with the session it was read for, so a snapshot
- * can never be shown against a different session.
+ * The outcome of one attempt to learn a session's boundary from main.
+ *
+ * `unreadable` is the fact this read model exists to carry: main was asked,
+ * every attempt failed, and the renderer still does not know what the session
+ * may do. Without it a failed read is indistinguishable from a read that has
+ * not answered yet, and the surface has no honest state to show (#1629).
+ */
+export type ExecutionBoundaryReadResult =
+  | { outcome: 'read'; boundary: ExecutionBoundary }
+  | { outcome: 'unreadable' }
+  | { outcome: 'cancelled' };
+
+/**
+ * Delays before each retry of a failed boundary read.
+ *
+ * Bounded on purpose. A boundary read fails for two very different reasons: a
+ * main process that has not finished settling the session yet — which the next
+ * attempt fixes — and something actually broken, which no number of attempts
+ * fixes. This schedule rides out the first (converging in under two seconds)
+ * and then stops, so the second becomes a state the user is told about rather
+ * than a poll that runs until the window closes.
+ */
+export const EXECUTION_BOUNDARY_READ_RETRY_DELAYS_MS: readonly number[] = [150, 400, 1200];
+
+/**
+ * Read a boundary, retrying a failure on the bounded schedule above.
+ *
+ * Split out of the hook so the failure path is testable without a renderer:
+ * the retry policy is the fix for #1629, so it has to be assertable directly.
+ */
+export async function readExecutionBoundaryWithRetry(input: {
+  read(): Promise<ExecutionBoundary>;
+  wait(delayMs: number): Promise<void>;
+  cancelled(): boolean;
+  retryDelaysMs?: readonly number[];
+}): Promise<ExecutionBoundaryReadResult> {
+  const retryDelaysMs = input.retryDelaysMs ?? EXECUTION_BOUNDARY_READ_RETRY_DELAYS_MS;
+  for (let attempt = 0; attempt <= retryDelaysMs.length; attempt += 1) {
+    if (input.cancelled()) return { outcome: 'cancelled' };
+    try {
+      return { outcome: 'read', boundary: await input.read() };
+    } catch {
+      // Retried below, or reported as unreadable once the schedule runs out.
+    }
+    const delayMs = retryDelaysMs[attempt];
+    if (delayMs === undefined) break;
+    if (input.cancelled()) return { outcome: 'cancelled' };
+    await input.wait(delayMs);
+  }
+  return input.cancelled() ? { outcome: 'cancelled' } : { outcome: 'unreadable' };
+}
+
+/**
+ * A settled boundary read together with the session it was made for, so a
+ * result can never be shown against a different session. `boundary` is
+ * `undefined` when the read gave up — the session is known, the answer is not.
  */
 export interface ActiveExecutionBoundarySnapshot {
   sessionId: string;
-  boundary: ExecutionBoundary;
+  boundary: ExecutionBoundary | undefined;
 }
 
 /**
@@ -24,12 +78,26 @@ export function activeExecutionBoundaryOf(
 }
 
 /**
+ * Whether the boundary read for `activeSessionId` ran out of attempts.
+ *
+ * The boundary alone cannot say this: "still reading" and "asked and failed"
+ * are both `undefined`, and only the second one is something to tell the user.
+ */
+export function activeExecutionBoundaryUnreadable(
+  snapshot: ActiveExecutionBoundarySnapshot | undefined,
+  activeSessionId: string | undefined,
+): boolean {
+  if (!activeSessionId || snapshot?.sessionId !== activeSessionId) return false;
+  return snapshot.boundary === undefined;
+}
+
+/**
  * The desktop's read model for the active session's execution boundary — the
  * one place that decides when the renderer's copy of the boundary is stale.
  *
  * The boundary is main-process authority, so an Effect synchronising with it is
  * the right tool; what this hook must never become is a mirror of renderer
- * state. It therefore keeps exactly one fact (the last snapshot read from main)
+ * state. It therefore keeps exactly one fact (the last settled read from main)
  * and re-reads on the two events that can change it: the active session
  * changing, and a caller reporting that a boundary decision settled (#1611).
  *
@@ -39,6 +107,12 @@ export function activeExecutionBoundaryOf(
  * a read-only session that has just been granted write access would keep
  * showing "read only". Approving an expansion only bumps the boundary's
  * revision — no session field changes — so nothing else here can notice it.
+ *
+ * #1629: a failed read used to be swallowed, leaving the snapshot unset for
+ * good. Nothing here re-fires on its own, so the surface fell closed
+ * permanently and the composer never came back. A failed read is now retried on
+ * a bounded schedule and, when that runs out, reported as `unreadable` so the
+ * surface can say so and offer another attempt.
  */
 export function useActiveExecutionBoundary(
   activeSessionId: string | undefined,
@@ -46,10 +120,15 @@ export function useActiveExecutionBoundary(
   permissionMode: string | undefined,
 ): {
   boundary: ExecutionBoundary | undefined;
+  /** The read for this session ran out of attempts; the boundary is unknown. */
+  unreadable: boolean;
+  /** A read for this session is in flight. */
+  reading: boolean;
   /** Report that this session's boundary may have changed; re-reads authority. */
   reload(sessionId: string): void;
 } {
   const [snapshot, setSnapshot] = useState<ActiveExecutionBoundarySnapshot | undefined>();
+  const [reading, setReading] = useState(false);
   const [reloadNonce, setReloadNonce] = useState(0);
   const activeSessionIdRef = useRef(activeSessionId);
   useEffect(() => {
@@ -57,25 +136,49 @@ export function useActiveExecutionBoundary(
   }, [activeSessionId]);
 
   useEffect(() => {
+    setReading(activeSessionId !== undefined);
     if (!activeSessionId) return;
     let cancelled = false;
-    void window.maka.sessions
-      .readExecutionBoundary(activeSessionId)
-      .then((boundary) => {
-        if (!cancelled) setSnapshot({ sessionId: activeSessionId, boundary });
-      })
-      .catch(() => {});
+    let waitTimer: ReturnType<typeof setTimeout> | undefined;
+    let releaseWait: (() => void) | undefined;
+    void readExecutionBoundaryWithRetry({
+      read: () => window.maka.sessions.readExecutionBoundary(activeSessionId),
+      // Released on cleanup so a session switch or an unmount does not sit out
+      // the rest of a backoff before the loop notices it has been cancelled.
+      wait: (delayMs) =>
+        new Promise<void>((resolve) => {
+          releaseWait = resolve;
+          waitTimer = setTimeout(resolve, delayMs);
+        }),
+      cancelled: () => cancelled,
+    }).then((result) => {
+      if (result.outcome === 'cancelled') return;
+      setReading(false);
+      setSnapshot({
+        sessionId: activeSessionId,
+        boundary: result.outcome === 'read' ? result.boundary : undefined,
+      });
+    });
     return () => {
       cancelled = true;
+      if (waitTimer !== undefined) clearTimeout(waitTimer);
+      releaseWait?.();
     };
   }, [activeSessionId, permissionMode, reloadNonce]);
 
   const reload = useCallback((sessionId: string) => {
     // Only the active session is read here, so a decision settled on any other
-    // session has nothing to refresh.
+    // session has nothing to refresh. This is also the user's way out of an
+    // unreadable boundary: the settled read is left in place, so a re-read that
+    // succeeds replaces it and one that fails leaves the notice where it was.
     if (activeSessionIdRef.current !== sessionId) return;
     setReloadNonce((nonce) => nonce + 1);
   }, []);
 
-  return { boundary: activeExecutionBoundaryOf(snapshot, activeSessionId), reload };
+  return {
+    boundary: activeExecutionBoundaryOf(snapshot, activeSessionId),
+    unreadable: activeExecutionBoundaryUnreadable(snapshot, activeSessionId),
+    reading,
+    reload,
+  };
 }


### PR DESCRIPTION
## Summary

One rejection from `readExecutionBoundary` used to hide the composer for the rest of the session — no error, no retry, no way back short of switching sessions or restarting.

The semantics that were conflated: **"not read yet" and "read and unreadable" were both `snapshot === undefined`**. The read model is the only place holding the fact of whether the renderer's copy of the boundary is fresh, so it owns the distinction and owns converging on the recoverable case. `readExecutionBoundary` is an authority read; it has no business knowing what the UI should do when it fails, and it should not swallow the error for its caller either. IPC and main are unchanged.

Failing closed is kept and pinned by test: when the boundary cannot be read, `localInteractionAvailable` stays `false`. What changes is that a transient failure now converges, and a permanent one says so instead of leaving an empty window.

Retries are bounded: `[150, 400, 1200]`, so at most four reads per effect run, with 1.75s of waiting spread between them. No timers left running, no polling loop. Three terminal states — `read`, `unreadable`, `cancelled` — and the backoff is released in cleanup, so switching sessions never waits one out. The retry button bumps the existing `reload()` nonce and is disabled while a read is in flight, so clicking cannot stack.

When the read is given up, the composer's slot shows a warning notice in the existing session-health layout:

> 暂时读不到这个对话的权限 — 在读到之前，这里暂时不能输入。可以重试，或先切换到别的对话。

It renders only when the read was abandoned, a session is active, onboarding is not showing, and no turn-level interaction owns the slot — a pending sandbox prompt still wins. No implementation words reach the reader.

Closes #1629.

## Only the newest read may commit

The first cut of this fix reintroduced the bug it was fixing, and CI caught it. A read that resolved after its caller had moved on still counted: the retry helper returned `read` without re-checking cancellation after the await, and the hook's callback inspected only that result, never the flag its own generation had been retired with.

So a read for the session the user just left could land after the one they opened and overwrite it. The snapshot then named an inactive session — no boundary, and no failure to report either. Composer hidden, no notice, nothing in flight to recover from it. The same race runs within one session: changing the permission mode or reloading after a decision re-runs the read, and the previous answer landing afterwards puts the old boundary back.

Reads now run as generations through `startActiveExecutionBoundaryRead`, and only a generation that has not been retired may commit. No new state machine: the `cancelled` flag each call closes over is already one per generation, because React runs a cleanup before the next effect body. One check, in the read itself — a retirement only ever arrives from React's effect cleanup, which cannot land between the read resolving and its commit callback, so a second check there would be a branch no product path executes.

## An answered fixture request must settle, at one owner

The reload half of `permission-mode-surface.spec.ts` had a second, unrelated cause. The e2e fixture's synthetic sandbox-boundary request is rebuilt from its scenario on every read, so answering it could not retire it the way a real one is retired — the runtime drops an active request from its in-memory owner state when the decision is acknowledged, and the fixture's request has no such owner.

Retirement belongs at `getE2eFixtureState`, because there are two exits, not one. The sessions IPC serves the active-request list; `e2eFixture:getState` hands the renderer a state it seeds its interaction queue from directly, never consulting that list. A first cut put the retirement next to the sessions IPC only. That leaves the seed holding an answered request it can still put back over the composer — a second resurrection path, found by review rather than by a failing run.

Allow retires only once the grant has landed, matching the runtime's acknowledged-not-received rule; retiring first would let the fixture hide a settlement failure the renderer is about to be told about. Deny has nothing to write, so it retires straight away.

The e2e now asserts the fixture state itself no longer reports the request. That assertion fails against a list-only retirement and passes against the owner-level one, so it pins the invariant directly rather than waiting to see which reply won a boot. Worth being precise about what that does and does not show: the user-visible reload journey passed 40/40 either way locally, so the list-only retirement is a latent resurrection bug this investigation surfaced, not a reproduction of the CI timeout.

## A test that typed into a popup that was not open yet

The CI rerun of this branch failed on the read-only journey with `Expected: "自动" Received: "只读"`, which reads exactly like the boundary race. It is not. `trigger.click()` resolves when the click is dispatched, not when the Select popup exists, and the keystrokes that followed could land before it did: nothing highlighted, Enter selected nothing, the label sat on 只读 until the assertion timed out.

Measured at 2/25 with the keys sent straight after the click and 0/25 once they wait for the listbox they are aimed at — the sequence is fixed, no timeout moves. It predates this branch (same rate with the read model reverted) and is unrelated to the generation invariant it was first read as.

## Verification

**CI, before and after — this is the load-bearing evidence.**

| run | commit | typecheck | test | e2e |
| --- | --- | --- | --- | --- |
| [30472259439](https://github.com/maka-agent/maka-agent/actions/runs/30472259439) | `a4a8379` (generation invariant missing) | OK | OK | **2 failed / 77 passed** |
| [30475335644](https://github.com/maka-agent/maka-agent/actions/runs/30475335644) | `0f424b5` | OK | OK | 79 passed |
| [30479186215](https://github.com/maka-agent/maka-agent/actions/runs/30479186215) | `2703ccd` | OK | OK | **1 failed / 78 passed** (the popup race, twice, on two different specs) |
| [30480759693](https://github.com/maka-agent/maka-agent/actions/runs/30480759693) | `875eba7` | OK | OK | **79 passed** |

The two failures on `a4a8379` looked like one bug and were three. `expect('.maka-composer-textarea').toBeVisible()` after a reload was the fixture request never settling. `expect(trigger).toHaveText('自动')` timing out on 只读 reads like the superseded read putting the old boundary back — but it is the popup race: it reproduces at 4/25 on `0f424b5`, which already carries the generation invariant, and goes to 0/25 once the keystrokes wait for the listbox. The generation race is real and CI-visible, and it is not what that assertion caught. Attributing it there is what let it survive two green runs.

None of the three reproduced in a local full-suite run, which is the point of the deterministic tests below: each invariant is pinned without depending on timing.

**Local.** `@maka/desktop` main: 2963/2963. Playwright: 79/79. `permission-mode-surface` at 25× repeat: 50/50, against 4/25 failures before the popup fix. The fixture-state assertion: 10/10 with retirement at the shared owner, 0/3 with it at the sessions exit alone. `lint`, `format:check`, `typecheck` (4 tsconfigs), `test:checks` clean.

**Tests.** The failure path is tested, not just the happy path. There is one cancellation check, on the product path, in the read itself; removing it turns all three of these red:

- a read main answered *after* cancellation must not come back as `read` (helper contract);
- session A pending → switch to B → B answers → A answers: the snapshot stays B's;
- same session, stale generation pending → `reload()` / mode change → fresh answers → stale answers: the fresh revision stays, and the retired read does not report the live one as finished;

Plus the original set: a first read rejecting then succeeding; every read rejecting and converging to `unreadable` after exactly `delays.length + 1` attempts; a session already switched away from never being read; "not read yet" vs "unreadable" staying distinct while both fail closed. Source contracts pin the app-shell/composer-region wiring and the fixture retirement, and a unit test pins that both fixture-state exits see one retirement.

**The reload assertion removed in #1630 is restored here.** What it proves is that the boundary is re-read across a reload and the composer returns because that read landed — not the retry, since nothing rejects in that journey. The retry is covered deterministically by the read model's own tests. The comment in the spec says exactly that now.

## Review focus

There is no deterministic E2E for an injected read failure. Doing it would mean a permanent production hook in main just to reach an error state, which did not seem worth it; the rendering is covered by a source contract plus a live-app screenshot taken with the handler temporarily forced to reject (that change fully reverted). Say so if you want the hook instead.




