### PR TITLE
fix: let the transcript warm-up finish, and stop three E2E races

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -295,12 +295,26 @@ export const test = base.extend<{
   // fixture, which seeds 60 active sessions and opens the newest one
   // (`...-00`) with the sidebar expanded. Fixture mode seeds its own
   // connections, so no connection is pre-staged here. Readiness = a session
-  // row on screen: the panel grid has mounted, the session list has loaded
-  // from IPC, and the footer sits below the constrained list row. Used by the
-  // sidebar-geometry spec.
+  // row on screen INSIDE AN EXPANDED SIDEBAR: the panel grid has mounted, the
+  // session list has loaded from IPC, and the footer sits below the
+  // constrained list row. Used by the sidebar-geometry and sidebar-navigation
+  // specs.
+  //
+  // The `[data-sidebar-state="expanded"]` part is load-bearing. The shell
+  // boots collapsed (the localStorage default), and `sidebarCollapsed: false`
+  // only lands later, from `applyE2eFixture` — a rAF plus two IPC round trips
+  // after mount. A bare `.maka-list-row` does not gate on it: a collapsed
+  // sidebar keeps the whole list mounted at full width behind `opacity: 0` in
+  // a 0px grid column, which Playwright still reports as visible. Tests then
+  // started against a sidebar that was about to expand under them.
   sidebarLongSessionsWindow: async ({}, use) => {
     await withE2eWindow(
-      { seed: false, readinessSelector: '.maka-list-row', e2eFixtureScenario: 'sidebar-long-sessions', locale: 'zh' },
+      {
+        seed: false,
+        readinessSelector: '[data-sidebar-state="expanded"] .maka-list-row',
+        e2eFixtureScenario: 'sidebar-long-sessions',
+        locale: 'zh',
+      },
       use,
     );
   },

--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -282,12 +282,25 @@ export const test = base.extend<{
   // Long transcript: boots the e2e-fixture `long-transcript` fixture, which
   // seeds a 24-turn (~1300px each) session and opens it as the active
   // session. Fixture mode seeds its own connections, so no connection is
-  // pre-staged here. Readiness = turns on screen: the session is open and
-  // above-viewport turns sit at their content-visibility placeholder size.
-  // Used by the scroll-geometry spec.
+  // pre-staged here. Readiness = turns on screen and RENDERED BY THE REAL
+  // MARKDOWN PIPELINE: the session is open and above-viewport turns sit at
+  // their content-visibility placeholder size. Used by the scroll-geometry
+  // spec.
+  //
+  // `.maka-markdown-pending` is the Suspense fallback for the lazily imported
+  // markdown chunk, and the turn-size warm-up will not start while one is on
+  // screen. Handing the page over before that chunk lands charged the spec's
+  // settle budget for a module load: under 50x CPU throttling the fallback
+  // holds for ~9.6s of a ~19s cold start, most of the spec's 15s, for work
+  // that is boot rather than settling.
   longTranscriptWindow: async ({}, use) => {
     await withE2eWindow(
-      { seed: false, readinessSelector: '.maka-turn', e2eFixtureScenario: 'long-transcript', locale: 'zh' },
+      {
+        seed: false,
+        readinessSelector: '.maka-chatViewport:has(.maka-turn):not(:has(.maka-markdown-pending))',
+        e2eFixtureScenario: 'long-transcript',
+        locale: 'zh',
+      },
       use,
     );
   },

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -22,19 +22,13 @@ const probeScroller = `(() => {
     scrollHeight: scroller.scrollHeight,
     clientHeight: scroller.clientHeight,
     distanceFromBottom: Math.round(scroller.scrollHeight - scroller.scrollTop - scroller.clientHeight),
-    // The warm-up forces inline content-visibility per chunk and clears it on
-    // release; any remaining forced turn means the walk is still in flight.
-    // Guards against a stalled compositor freezing MID-WALK geometry into a
-    // false "settled" (frozen reads are equal reads).
-    warming: Boolean(document.querySelector('.maka-turn[style*="content-visibility"]')),
   };
 })()`;
 
 // The fixture's 24 turns are 60 filler lines each (>1000px real, 250px as a
-// placeholder), so the whole transcript is ~15k px un-warmed vs ~32k warmed.
-// A settle check must first see final-scale height — two early reads agreeing
-// on the PLACEHOLDER height would otherwise declare "settled" before the
-// warm-up even starts (fonts / lazy-markdown gates delay it on slow machines).
+// placeholder), so the whole transcript is ~15k px un-warmed vs ~40k warmed.
+// Asserted once the walk reports itself done, as a guard that it actually
+// rewrote the placeholder geometry rather than finishing over nothing.
 const WARMED_HEIGHT_FLOOR = 24 * 800;
 
 type ColumnGeometry = {
@@ -79,21 +73,32 @@ async function probeColumnGeometry(page: import('@playwright/test').Page): Promi
   });
 }
 
+/**
+ * Wait for the warm-up's own terminal state, which the scroller publishes as
+ * `data-turn-warmup="settled"`.
+ *
+ * This used to be inferred: no chunk currently forced, final-scale height, and
+ * two consecutive 500ms reads agreeing. The walk is chunked and pauses between
+ * chunks, so that describes an idle gap just as well as the end — under 50x CPU
+ * throttling this suite reports two 29068px reads in a row with 8 of 24 turns
+ * still un-warmed and a final height of 40452px, i.e. a "settled" that is a
+ * third short. The same guess fails the other way whenever the sampler keeps
+ * straddling chunk boundaries: every read differs from the last, the predicate
+ * is false for all 30 samples, and the poll dies on its budget while the
+ * warm-up is working normally.
+ *
+ * Neither is a slow machine; both are the criterion. The walk knows when it is
+ * done, so ask it.
+ */
 async function settleGeometry(page: import('@playwright/test').Page, options: { pinned: boolean }): Promise<void> {
-  let previousHeight = -1;
-  await expect.poll(async () => {
-    const current = await page.evaluate(probeScroller) as {
-      scrollHeight: number;
-      distanceFromBottom: number;
-      warming: boolean;
-    };
-    const settled = !current.warming
-      && current.scrollHeight > WARMED_HEIGHT_FLOOR
-      && current.scrollHeight === previousHeight
-      && (!options.pinned || current.distanceFromBottom === 0);
-    previousHeight = current.scrollHeight;
-    return settled;
-  }, { timeout: 15_000, intervals: [500] }).toBe(true);
+  await expect(page.locator('.maka-chatViewport[data-turn-warmup="settled"]')).toBeAttached({ timeout: 15_000 });
+  const settled = await page.evaluate(probeScroller) as { scrollHeight: number };
+  expect(settled.scrollHeight, JSON.stringify(settled)).toBeGreaterThan(WARMED_HEIGHT_FLOOR);
+  // The last chunk's inflation reaches the pinned follower through a
+  // ResizeObserver, one layout after the walk hands back.
+  if (options.pinned) {
+    await expect.poll(async () => (await page.evaluate(probeScroller)).distanceFromBottom).toBe(0);
+  }
 }
 
 test('chat viewport and message column share the composer centerline', async ({ longTranscriptWindow: page }) => {

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -162,8 +162,8 @@ test('long session opens pinned to bottom and stays pinned while geometry settle
   // distance stays 0 while scrollHeight rises to its final value.
   await expect.poll(async () => (await page.evaluate(probeScroller)).distanceFromBottom).toBe(0);
 
-  // Geometry settled = final-scale height and two consecutive reads agreeing
-  // on it while still pinned. A fixed sleep would race the warm-up.
+  // And the pin is still 0 once the walk reports itself done, which is what
+  // makes the poll above a contract rather than a lucky early read.
   await settleGeometry(page, { pinned: true });
 });
 

--- a/apps/desktop/e2e/sidebar-navigation.spec.ts
+++ b/apps/desktop/e2e/sidebar-navigation.spec.ts
@@ -1,10 +1,26 @@
 import type { Page } from '@playwright/test';
 import { test, expect } from './fixtures.js';
 
+/**
+ * Both fixtures used here hand over a SETTLED sidebar state, which is what
+ * makes the toggle read below sound: `window` boots collapsed from the
+ * localStorage default and nothing moves it, and `sidebarLongSessionsWindow`
+ * gates readiness on `[data-sidebar-state="expanded"]` — the state its
+ * e2e-fixture applies asynchronously, several IPC round trips after the first
+ * session rows render.
+ *
+ * Reading the toggle while that flip was still in flight is the
+ * sidebar-navigation flake: the read saw "collapsed", and the click then
+ * either never resolved (the label had become 收起侧边栏) or landed on the
+ * already-expanded sidebar and collapsed it, after which every
+ * `role=complementary` query missed — the collapsed panel is `aria-hidden`.
+ */
 async function expandedSidebar(page: Page) {
   const expand = page.getByRole('button', { name: '展开侧边栏' });
   if (await expand.count()) await expand.click();
-  return page.getByRole('complementary', { name: '对话列表' });
+  const sidebar = page.getByRole('complementary', { name: '对话列表' });
+  await expect(sidebar).toBeVisible();
+  return sidebar;
 }
 
 test('session grouping menu switches between flat conversations and project disclosures', async ({
@@ -12,6 +28,7 @@ test('session grouping menu switches between flat conversations and project disc
 }) => {
   const sidebar = await expandedSidebar(page);
   const grouping = sidebar.getByRole('button', { name: '会话分组方式' });
+  const popup = page.locator('[data-slot="menu-popup"]');
 
   await expect(sidebar.locator('.maka-list-group-label')).toHaveCount(0);
   await expect(sidebar.locator('.maka-list-row').first()).toBeVisible();
@@ -22,7 +39,16 @@ test('session grouping menu switches between flat conversations and project disc
   await byProject.click();
   await expect(sidebar.locator('.maka-list-project-heading').first()).toBeVisible();
 
+  // A radio item does not dismiss the menu, so the single trigger click this
+  // used to do was closing the menu, not reopening it — and the radios below
+  // were read off a popup that was disappearing, which is why they sometimes
+  // resolved and sometimes did not. Close and reopen explicitly, waiting for
+  // the popup to actually leave in between: a trigger click landing while the
+  // old popup is still on screen is swallowed as an outside-press.
   await grouping.click();
+  await expect(popup).toBeHidden();
+  await grouping.click();
+  await expect(popup).toBeVisible();
   await expect(page.getByRole('menuitemradio', { name: '按项目' })).toHaveAttribute('aria-checked', 'true');
   await expect(page.getByRole('menuitemradio', { name: '按时间' })).toHaveAttribute('aria-checked', 'false');
 });

--- a/apps/desktop/e2e/skill-delete-scope.spec.ts
+++ b/apps/desktop/e2e/skill-delete-scope.spec.ts
@@ -28,8 +28,12 @@ test('deletes a user-scope skill from disk and drops it from the list', async ({
   await sidebar.getByRole('button', { name: '扩展', exact: true }).click();
   await page.getByRole('main', { name: '扩展' }).waitFor();
 
-  const installed = page.getByRole('tab', { name: '已安装' });
-  if (await installed.isVisible().catch(() => false)) await installed.click();
+  // The panel always renders all three tabs, and it picks its landing tab from
+  // whatever the skill list happened to be at mount — so click 已安装
+  // unconditionally and let Playwright wait for it. Sampling `isVisible()`
+  // first only added a branch that could skip the click on a slow mount and
+  // then hunt for the row on the wrong tab.
+  await page.getByRole('tab', { name: '已安装' }).click();
 
   const row = page.locator('.maka-skill-library-list li').filter({ hasText: 'User Only' });
   await expect(row).toHaveCount(1);
@@ -55,8 +59,7 @@ test('offers no delete for a project-scope skill', async ({ invocableSkillsWindo
   await sidebar.getByRole('button', { name: '扩展', exact: true }).click();
   await page.getByRole('main', { name: '扩展' }).waitFor();
 
-  const installed = page.getByRole('tab', { name: '已安装' });
-  if (await installed.isVisible().catch(() => false)) await installed.click();
+  await page.getByRole('tab', { name: '已安装' }).click();
 
   const projectRow = page.locator('.maka-skill-library-list li').filter({ hasText: 'Project Only' });
   await expect(projectRow).toHaveCount(1);

--- a/apps/desktop/src/main/connections-ipc-main.ts
+++ b/apps/desktop/src/main/connections-ipc-main.ts
@@ -15,6 +15,7 @@ import { createConnectionStore } from '@maka/storage';
 import {
   ConnectionModelDiscoveryPreconditionError,
   discoverConnectionModels,
+  type ConnectionModelDiscoveryDeps,
 } from './connection-model-discovery.js';
 import { createFileCredentialStore } from './credential-store.js';
 import { createConnectionWithCredential } from './create-connection-with-credential.js';
@@ -33,6 +34,11 @@ interface ConnectionsIpcDeps extends ConnectionInputNormalizerDeps {
   resolveConnectionSecret: (slug: string) => Promise<string | null>;
   hasConnectionSecret: (connection: LlmConnection) => Promise<boolean>;
   emitConnectionListChanged: () => void;
+  /**
+   * Override for remote model discovery. Only E2E supplies this, to keep the
+   * add-provider flow off the public internet (see main.ts).
+   */
+  fetchModels?: ConnectionModelDiscoveryDeps['fetchModels'];
 }
 
 const IPC_CONNECTION_SLUG_MAX_LENGTH = 64;
@@ -135,6 +141,7 @@ export function registerConnectionsIpc(deps: ConnectionsIpcDeps): void {
     resolveConnectionSecret,
     hasConnectionSecret,
     emitConnectionListChanged,
+    fetchModels,
   } = deps;
 
   ipcMain.handle('connections:list', async () => {
@@ -227,6 +234,7 @@ export function registerConnectionsIpc(deps: ConnectionsIpcDeps): void {
       const result = await discoverConnectionModels({
         connectionStore,
         resolveConnectionSecret,
+        ...(fetchModels ? { fetchModels } : {}),
       }, slug);
       emitConnectionListChanged();
       return result;

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -1135,6 +1135,22 @@ function registerIpc(): void {
     resolveConnectionSecret,
     hasConnectionSecret,
     emitConnectionListChanged,
+    // Same seam as the fake-backend override above, for the other IPC that can
+    // leave the machine: adding a catalog provider runs remote model discovery
+    // against the provider's real endpoint. In E2E the key is a placeholder, so
+    // discovery can only fail — but it fails at whatever speed the network
+    // answers, and the add dialog stays open for the whole round trip. The
+    // provider-side budget (10s) is exactly the suite's expect timeout (10s),
+    // so a slow answer flips `await expect(dialog).toBeHidden()` from pass to
+    // fail with no code change. Fail deterministically and offline instead,
+    // which is the outcome a placeholder key produces anyway.
+    ...(isE2e
+      ? {
+          fetchModels: async () => {
+            throw new Error('E2E: remote model discovery is disabled');
+          },
+        }
+      : {}),
   });
   registerOnboardingIpc({ onboardingService });
   registerSessionEntryIpc({

--- a/packages/ui/src/__tests__/turn-size-warmup.test.ts
+++ b/packages/ui/src/__tests__/turn-size-warmup.test.ts
@@ -71,6 +71,53 @@ describe('createTurnSizeWarmup', () => {
     assert.equal(pending(), 0);
   });
 
+  it('reports settled once, after the last chunk is released and not before', () => {
+    const turns = [fakeTurn(), fakeTurn(), fakeTurn()];
+    const { scheduler, flushIdle, flushFrame } = fakeScheduler();
+    let settled = 0;
+    createTurnSizeWarmup({ turns: () => turns, chunkSize: 2, scheduler, onSettled: () => { settled += 1; } });
+
+    flushIdle();
+    flushFrame();
+    flushFrame();
+    // The gap between two chunks looks exactly like the end from outside — no
+    // chunk forced, geometry holding still. It is not the end.
+    assert.deepEqual(forced(turns), []);
+    assert.equal(settled, 0);
+
+    flushIdle();
+    flushFrame();
+    flushFrame();
+    assert.equal(settled, 1);
+    // Nothing left to schedule can fire it a second time.
+    flushIdle();
+    flushFrame();
+    assert.equal(settled, 1);
+  });
+
+  it('settles immediately when there is nothing to walk', () => {
+    const { scheduler, flushIdle } = fakeScheduler();
+    let settled = 0;
+    createTurnSizeWarmup({ turns: () => [], scheduler, onSettled: () => { settled += 1; } });
+
+    flushIdle();
+    assert.equal(settled, 1);
+  });
+
+  it('does not report settled for a cancelled walk', () => {
+    const turns = [fakeTurn(), fakeTurn(), fakeTurn()];
+    const { scheduler, flushIdle, flushFrame } = fakeScheduler();
+    let settled = 0;
+    const stop = createTurnSizeWarmup({ turns: () => turns, chunkSize: 2, scheduler, onSettled: () => { settled += 1; } });
+
+    flushIdle();
+    stop();
+    flushFrame();
+    flushFrame();
+    flushIdle();
+    assert.equal(settled, 0);
+  });
+
   it('skips the live-streaming tail and disconnected turns', () => {
     const turns = [fakeTurn(), fakeTurn({ connected: false }), fakeTurn(), fakeTurn({ live: true })];
     const { scheduler, flushIdle } = fakeScheduler();

--- a/packages/ui/src/__tests__/turn-size-warmup.test.ts
+++ b/packages/ui/src/__tests__/turn-size-warmup.test.ts
@@ -71,25 +71,48 @@ describe('createTurnSizeWarmup', () => {
     assert.equal(pending(), 0);
   });
 
-  it('reports settled once, after the last chunk is released and not before', () => {
-    const turns = [fakeTurn(), fakeTurn(), fakeTurn()];
+  // `onSettled` is the contract the scroll-geometry E2E waits on, and every
+  // way of being early is a way of certifying a transcript that is still a
+  // third short. So these pin the boundary from both sides: the last instant
+  // it must still be silent, and the first instant it must have fired.
+  it('stays silent through the gap between chunks and through the last chunk itself', () => {
+    const turns = [fakeTurn(), fakeTurn(), fakeTurn(), fakeTurn()];
     const { scheduler, flushIdle, flushFrame } = fakeScheduler();
     let settled = 0;
-    createTurnSizeWarmup({ turns: () => turns, chunkSize: 2, scheduler, onSettled: () => { settled += 1; } });
+    // Captured inside the callback, not after the flush: "settled" has to mean
+    // the last chunk is already released, and a release that happens later in
+    // the same frame callback is invisible to an assertion made afterwards.
+    let forcedWhenSettled: number[] | null = null;
+    createTurnSizeWarmup({
+      turns: () => turns,
+      chunkSize: 2,
+      scheduler,
+      onSettled: () => { settled += 1; forcedWhenSettled = forced(turns); },
+    });
 
     flushIdle();
     flushFrame();
     flushFrame();
-    // The gap between two chunks looks exactly like the end from outside — no
-    // chunk forced, geometry holding still. It is not the end.
+    // Between chunks: nothing forced and geometry holding still — the exact
+    // shape of the end, and not the end.
     assert.deepEqual(forced(turns), []);
     assert.equal(settled, 0);
 
+    // Last chunk queued and forced. Its turns have not been laid out yet.
     flushIdle();
+    assert.deepEqual(forced(turns), [0, 1]);
+    assert.equal(settled, 0);
+    // First frame: still before the layout that records the remembered sizes.
     flushFrame();
+    assert.deepEqual(forced(turns), [0, 1]);
+    assert.equal(settled, 0);
+    // Second frame releases the chunk — only now is the geometry final, and
+    // the release must already have happened when the callback runs.
     flushFrame();
     assert.equal(settled, 1);
-    // Nothing left to schedule can fire it a second time.
+    assert.deepEqual(forcedWhenSettled, []);
+
+    // Nothing left to schedule can fire it again.
     flushIdle();
     flushFrame();
     assert.equal(settled, 1);
@@ -104,18 +127,63 @@ describe('createTurnSizeWarmup', () => {
     assert.equal(settled, 1);
   });
 
-  it('does not report settled for a cancelled walk', () => {
+  it('settles once when every remaining turn has been detached mid-walk', () => {
+    // Second chunk's turns leave the DOM while the first chunk is in flight:
+    // the walk drains the queue, finds nothing live, and must report the walk
+    // over exactly once rather than stall waiting for a chunk it cannot build.
+    const live = [fakeTurn(), fakeTurn()];
+    const doomed = [fakeTurn(), fakeTurn()];
+    const turns = [...doomed, ...live];
+    const { scheduler, flushIdle, flushFrame, pending } = fakeScheduler();
+    let settled = 0;
+    createTurnSizeWarmup({ turns: () => turns, chunkSize: 2, scheduler, onSettled: () => { settled += 1; } });
+
+    flushIdle();
+    assert.deepEqual(forced(turns), [2, 3]);
+    for (const turn of doomed) turn.isConnected = false;
+    flushFrame();
+    flushFrame();
+    assert.equal(settled, 0);
+
+    flushIdle();
+    assert.equal(settled, 1);
+    assert.deepEqual(forced(turns), []);
+    assert.equal(pending(), 0);
+  });
+
+  it('does not report settled for a walk cancelled at either end', () => {
     const turns = [fakeTurn(), fakeTurn(), fakeTurn()];
     const { scheduler, flushIdle, flushFrame } = fakeScheduler();
     let settled = 0;
     const stop = createTurnSizeWarmup({ turns: () => turns, chunkSize: 2, scheduler, onSettled: () => { settled += 1; } });
 
+    // Cancelled with the queue still holding work.
     flushIdle();
     stop();
     flushFrame();
     flushFrame();
     flushIdle();
     assert.equal(settled, 0);
+
+    // Cancelled with the LAST chunk forced and the queue already empty — one
+    // frame short of the release that would have settled it.
+    const lateTurns = [fakeTurn(), fakeTurn()];
+    const late = fakeScheduler();
+    let lateSettled = 0;
+    const stopLate = createTurnSizeWarmup({
+      turns: () => lateTurns,
+      chunkSize: 2,
+      scheduler: late.scheduler,
+      onSettled: () => { lateSettled += 1; },
+    });
+    late.flushIdle();
+    late.flushFrame();
+    assert.deepEqual(forced(lateTurns), [0, 1]);
+    stopLate();
+    late.flushFrame();
+    late.flushIdle();
+    assert.equal(lateSettled, 0);
+    assert.deepEqual(forced(lateTurns), []);
   });
 
   it('skips the live-streaming tail and disconnected turns', () => {

--- a/packages/ui/src/turn-size-warmup.ts
+++ b/packages/ui/src/turn-size-warmup.ts
@@ -51,8 +51,15 @@ export function createTurnSizeWarmup(options: {
   chunkSize?: number;
   scheduler?: WarmupScheduler;
   /**
-   * The moment transcript geometry stops moving: the queue has drained and the
-   * last chunk has been released.
+   * The moment this walk is done: the queue has drained and the last chunk has
+   * been released.
+   *
+   * Scoped to the turns `turns()` returned when the walk was created — the
+   * queue is snapshotted once, below. A turn that appears afterwards is not
+   * walked and does not hold this back, so this says "every turn I was given
+   * has its final-layout size", not "the transcript will never move again".
+   * Warming a growing transcript would need a walk per batch, which nothing
+   * asks for: turns that arrive later arrive rendered.
    *
    * The walk is the only thing that knows this. From outside, the end looks
    * exactly like the idle gap between two chunks — no chunk is forced, and the

--- a/packages/ui/src/turn-size-warmup.ts
+++ b/packages/ui/src/turn-size-warmup.ts
@@ -27,12 +27,30 @@ export interface WarmupScheduler {
   requestFrame(callback: () => void): () => void;
 }
 
+/**
+ * Deadline for each chunk's idle slot.
+ *
+ * `requestIdleCallback` with no timeout promises nothing: it runs when the
+ * scheduler finds an idle period, and a thread that stays busy never offers
+ * one. That is not a corner case here — the walk is kicked off from the same
+ * mount that is rendering the transcript, so it asks for idle time exactly
+ * while the renderer is saturated laying out the turns it exists to measure.
+ * On a slow enough machine the first chunk simply never runs and the session
+ * keeps its 250px placeholder geometry for good, which is the bug the warm-up
+ * was written to prevent. Observed directly at 50x CPU throttling: the walk
+ * was created and then sat idle indefinitely without forcing a single chunk.
+ *
+ * A deadline turns "when convenient" into "soon, and no later than this". The
+ * whole walk is a handful of chunks, so it still yields to real work first.
+ */
+const IDLE_CHUNK_DEADLINE_MS = 200;
+
 function defaultScheduler(): WarmupScheduler | undefined {
   if (typeof requestAnimationFrame !== 'function') return undefined;
   return {
     requestIdle: typeof requestIdleCallback === 'function'
       ? (callback) => {
-        const id = requestIdleCallback(callback);
+        const id = requestIdleCallback(callback, { timeout: IDLE_CHUNK_DEADLINE_MS });
         return () => cancelIdleCallback(id);
       }
       : (callback) => {
@@ -50,6 +68,19 @@ export function createTurnSizeWarmup(options: {
   turns: () => ArrayLike<WarmupTurnElement>;
   chunkSize?: number;
   scheduler?: WarmupScheduler;
+  /**
+   * Fires once, when the queue has drained and the last chunk has been
+   * released — the moment transcript geometry stops moving.
+   *
+   * The walk is the only thing that knows this. From the outside it looks
+   * identical to the idle gap between two chunks: no chunk is forced, and the
+   * height holds still until the next one starts. Anything watching from
+   * outside therefore has to guess, and guesses both ways — an observer that
+   * calls a pause "done" stops early at an intermediate height, and one that
+   * waits for quiet longer than a gap can outlive its own budget. Cancelling
+   * the walk does not fire it: nothing settled.
+   */
+  onSettled?: () => void;
 }): () => void {
   const scheduler = options.scheduler ?? defaultScheduler();
   if (!scheduler) return () => {};
@@ -61,6 +92,13 @@ export function createTurnSizeWarmup(options: {
     .reverse();
   let forcedChunk: WarmupTurnElement[] = [];
   let cancelScheduled: (() => void) | undefined;
+  let settled = false;
+
+  const settle = (): void => {
+    if (settled) return;
+    settled = true;
+    options.onSettled?.();
+  };
 
   const release = (): void => {
     for (const turn of forcedChunk) {
@@ -75,7 +113,10 @@ export function createTurnSizeWarmup(options: {
     while (chunk.length === 0 && queue.length > 0) {
       chunk = queue.splice(0, chunkSize).filter((turn) => turn.isConnected);
     }
-    if (chunk.length === 0) return;
+    if (chunk.length === 0) {
+      settle();
+      return;
+    }
     forcedChunk = chunk;
     for (const turn of forcedChunk) {
       turn.style.contentVisibility = 'visible';
@@ -94,6 +135,7 @@ export function createTurnSizeWarmup(options: {
       cancelScheduled = scheduler.requestFrame(() => {
         release();
         if (queue.length > 0) cancelScheduled = scheduler.requestIdle(step);
+        else settle();
       });
     });
   };

--- a/packages/ui/src/turn-size-warmup.ts
+++ b/packages/ui/src/turn-size-warmup.ts
@@ -27,30 +27,12 @@ export interface WarmupScheduler {
   requestFrame(callback: () => void): () => void;
 }
 
-/**
- * Deadline for each chunk's idle slot.
- *
- * `requestIdleCallback` with no timeout promises nothing: it runs when the
- * scheduler finds an idle period, and a thread that stays busy never offers
- * one. That is not a corner case here — the walk is kicked off from the same
- * mount that is rendering the transcript, so it asks for idle time exactly
- * while the renderer is saturated laying out the turns it exists to measure.
- * On a slow enough machine the first chunk simply never runs and the session
- * keeps its 250px placeholder geometry for good, which is the bug the warm-up
- * was written to prevent. Observed directly at 50x CPU throttling: the walk
- * was created and then sat idle indefinitely without forcing a single chunk.
- *
- * A deadline turns "when convenient" into "soon, and no later than this". The
- * whole walk is a handful of chunks, so it still yields to real work first.
- */
-const IDLE_CHUNK_DEADLINE_MS = 200;
-
 function defaultScheduler(): WarmupScheduler | undefined {
   if (typeof requestAnimationFrame !== 'function') return undefined;
   return {
     requestIdle: typeof requestIdleCallback === 'function'
       ? (callback) => {
-        const id = requestIdleCallback(callback, { timeout: IDLE_CHUNK_DEADLINE_MS });
+        const id = requestIdleCallback(callback);
         return () => cancelIdleCallback(id);
       }
       : (callback) => {
@@ -69,16 +51,21 @@ export function createTurnSizeWarmup(options: {
   chunkSize?: number;
   scheduler?: WarmupScheduler;
   /**
-   * Fires once, when the queue has drained and the last chunk has been
-   * released — the moment transcript geometry stops moving.
+   * The moment transcript geometry stops moving: the queue has drained and the
+   * last chunk has been released.
    *
-   * The walk is the only thing that knows this. From the outside it looks
-   * identical to the idle gap between two chunks: no chunk is forced, and the
-   * height holds still until the next one starts. Anything watching from
-   * outside therefore has to guess, and guesses both ways — an observer that
-   * calls a pause "done" stops early at an intermediate height, and one that
-   * waits for quiet longer than a gap can outlive its own budget. Cancelling
-   * the walk does not fire it: nothing settled.
+   * The walk is the only thing that knows this. From outside, the end looks
+   * exactly like the idle gap between two chunks — no chunk is forced, and the
+   * height holds still until the next one starts — so an outside observer has
+   * to guess, and guesses wrong both ways: calling a gap "done" reports an
+   * intermediate height, and waiting out a gap that never ends outlives its own
+   * budget. Both were observed against this module's own E2E.
+   *
+   * Fires exactly once per walk, by control flow rather than by a flag: the two
+   * terminal paths below — a queue that drained with nothing live left in it,
+   * and the release of the last chunk — are mutually exclusive within a step,
+   * and neither schedules further work. Cancelling reaches neither: nothing
+   * settled.
    */
   onSettled?: () => void;
 }): () => void {
@@ -92,13 +79,6 @@ export function createTurnSizeWarmup(options: {
     .reverse();
   let forcedChunk: WarmupTurnElement[] = [];
   let cancelScheduled: (() => void) | undefined;
-  let settled = false;
-
-  const settle = (): void => {
-    if (settled) return;
-    settled = true;
-    options.onSettled?.();
-  };
 
   const release = (): void => {
     for (const turn of forcedChunk) {
@@ -114,7 +94,7 @@ export function createTurnSizeWarmup(options: {
       chunk = queue.splice(0, chunkSize).filter((turn) => turn.isConnected);
     }
     if (chunk.length === 0) {
-      settle();
+      options.onSettled?.();
       return;
     }
     forcedChunk = chunk;
@@ -135,7 +115,7 @@ export function createTurnSizeWarmup(options: {
       cancelScheduled = scheduler.requestFrame(() => {
         release();
         if (queue.length > 0) cancelScheduled = scheduler.requestIdle(step);
-        else settle();
+        else options.onSettled?.();
       });
     });
   };

--- a/packages/ui/src/use-chat-scroll.ts
+++ b/packages/ui/src/use-chat-scroll.ts
@@ -53,9 +53,11 @@ export function useChatScroll(input: {
     const root = viewportRef.current;
     if (!root) return;
     // Publish the walk's phase on the scroller. Until the markdown pipeline
-    // has landed and the warm-up has walked every turn, this scroller's
-    // geometry is still a placeholder-scale estimate, and nothing outside can
-    // tell that apart from a pause between chunks.
+    // has landed and the warm-up has walked the turns it started with, this
+    // scroller's geometry is still a placeholder-scale estimate, and nothing
+    // outside can tell that apart from a pause between chunks. `settled` is
+    // therefore about the transcript the walk was handed, not about turns that
+    // stream in after it — those arrive already rendered.
     //
     // Claimed before the `hasTurns` bail and dropped on teardown, so the only
     // states this element can be observed in are `running`, a `settled` that

--- a/packages/ui/src/use-chat-scroll.ts
+++ b/packages/ui/src/use-chat-scroll.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { StoredMessage } from '@maka/core';
 import { createPinnedBottomFollower } from './pinned-bottom.js';
 import { createTurnSizeWarmup } from './turn-size-warmup.js';
@@ -41,16 +41,28 @@ export function useChatScroll(input: {
   // Replace content-visibility placeholders with final-layout remembered sizes.
   // ChatView itself unmounts outside sessions, so every rebuilt transcript gets
   // a fresh hook lifecycle without depending on navigation state.
-  useEffect(() => {
-    if (!input.hasTurns) return;
+  //
+  // A LAYOUT effect, only for the sake of the marker below. The scroller can
+  // outlive a transcript — switching sessions empties `messages` and refills it
+  // asynchronously on the same element — so `settled` has to be withdrawn in
+  // the same commit that puts a different transcript on screen. A passive
+  // effect withdraws it one paint too late, leaving a window in which the
+  // marker vouches for geometry that has already been replaced. The body
+  // itself only writes an attribute and schedules async work.
+  useLayoutEffect(() => {
     const root = viewportRef.current;
     if (!root) return;
     // Publish the walk's phase on the scroller. Until the markdown pipeline
     // has landed and the warm-up has walked every turn, this scroller's
     // geometry is still a placeholder-scale estimate, and nothing outside can
-    // tell that apart from a pause between chunks. Marked `running` up front
-    // so a rebuilt transcript never shows the previous walk's `settled`.
+    // tell that apart from a pause between chunks.
+    //
+    // Claimed before the `hasTurns` bail and dropped on teardown, so the only
+    // states this element can be observed in are `running`, a `settled` that
+    // belongs to the transcript currently mounted, and absent.
     root.dataset.turnWarmup = 'running';
+    const forget = () => { delete root.dataset.turnWarmup; };
+    if (!input.hasTurns) return forget;
     let disposed = false;
     let cancelWarmup: (() => void) | undefined;
     let pollTimer: number | undefined;
@@ -72,6 +84,7 @@ export function useChatScroll(input: {
     void fontsReady.then(warmOnceSettled);
     return () => {
       disposed = true;
+      forget();
       window.clearTimeout(pollTimer);
       cancelWarmup?.();
     };

--- a/packages/ui/src/use-chat-scroll.ts
+++ b/packages/ui/src/use-chat-scroll.ts
@@ -45,6 +45,12 @@ export function useChatScroll(input: {
     if (!input.hasTurns) return;
     const root = viewportRef.current;
     if (!root) return;
+    // Publish the walk's phase on the scroller. Until the markdown pipeline
+    // has landed and the warm-up has walked every turn, this scroller's
+    // geometry is still a placeholder-scale estimate, and nothing outside can
+    // tell that apart from a pause between chunks. Marked `running` up front
+    // so a rebuilt transcript never shows the previous walk's `settled`.
+    root.dataset.turnWarmup = 'running';
     let disposed = false;
     let cancelWarmup: (() => void) | undefined;
     let pollTimer: number | undefined;
@@ -56,6 +62,9 @@ export function useChatScroll(input: {
       }
       cancelWarmup = createTurnSizeWarmup({
         turns: () => root.querySelectorAll<HTMLElement>('.maka-turn'),
+        onSettled: () => {
+          if (!disposed) root.dataset.turnWarmup = 'settled';
+        },
       });
     };
     const fontsReady: Promise<unknown> =


### PR DESCRIPTION
## Summary

Three intermittent E2E failures, three different root causes. None was fixed by widening a timeout or weakening an assertion.

**`sidebar-navigation.spec.ts` — the fixture handed over a state that was still moving.**
`sidebarLongSessionsWindow` gated readiness on `.maka-list-row`, but the shell boots collapsed (the localStorage default) and `sidebarCollapsed: false` only lands later, from `applyE2eFixture`. A collapsed sidebar keeps the whole list mounted at full width behind `opacity: 0` in a 0px grid column, so Playwright already reports those rows as visible — readiness fired while the expansion was still in flight. The spec's `if (await expand.count()) await expand.click()` then read "collapsed" correctly, and by the time the click ran the sidebar had expanded, so the click *collapsed* it. Every later `role=complementary` query then missed, because the collapsed panel is `aria-hidden`. That is the `.maka-list-row not found` CI has been reporting. Readiness now requires `[data-sidebar-state="expanded"] .maka-list-row`.

Same spec, second race: a Base UI radio item does not dismiss its menu (`closeOnClick` defaults to `false` in 1.5.0), so the single trigger click meant as "reopen" was actually *closing* the menu, and the two `menuitemradio` assertions read off a popup that was disappearing.

**`providers.spec.ts:27` — the E2E add-provider flow really was calling `api.cerebras.ai`.**
`main.ts` already states that no session-creation path may escape the E2E seam and reach a real provider, but model discovery was never covered. `provider-add-form` awaits `fetchModels` before closing the dialog, and the discovery budget (10s) is exactly the suite's `expect.timeout` (10s) — so a slow network answer flips `await expect(dialog).toBeHidden()` from pass to fail with no code change. `registerConnectionsIpc` now takes an injectable `fetchModels`, and `main.ts` supplies an offline failure under the existing `isE2e` gate. Nothing the spec observes changes: the placeholder key could only ever fail, and the model list the spec walks comes from the catalog, not from discovery.

**`scroll-geometry.spec.ts` — a settle criterion that could not be right.**
`settleGeometry` inferred "geometry is final" from *no chunk currently forced + final-scale height + two consecutive 500ms reads agreeing*. The warm-up walk is chunked and pauses between chunks, so that description fits an idle gap exactly as well as it fits the end — and it guesses wrong in both directions. Measured at 50× CPU throttling: two 29068px reads in a row with 8 of 24 turns still un-warmed, i.e. "settled" a third short, after which `climbToTop` watched the document inflate under it (7 distinct heights where the contract allows 1). That is a silent correctness hole, not just a flake. It fails the other way whenever samples keep straddling chunk boundaries — false for all 30 samples, poll dead on its budget, which is exactly how CI reported it.

The walk knows when it is done, so it now says so: `onSettled` fires when the queue drains and the last chunk is released, and `useChatScroll` publishes it as `data-turn-warmup` on the scroller. Exactly once per walk by control flow — the two terminal paths are mutually exclusive within a step and neither schedules further work — and never for a cancelled walk.

Last, `longTranscriptWindow` handed the page over at `.maka-turn`, before the lazily imported markdown chunk had landed — and the warm-up will not start while a Suspense fallback is on screen. The spec's settle budget was paying for a module load: ~9.6s of a ~19s cold start at 50× throttling. Readiness now covers it.

## Verification

| Scenario | Before | After |
|---|---|---|
| `sidebar-navigation.spec.ts --repeat-each=20`, idle | **5/80 failed** | **80/80 passed** (3.8m → 2.1m) |
| same, under 17 saturating CPU processes, `--repeat-each=10` | **9/40 failed** (all three fixture tests) | **40/40 passed** |
| `providers.spec.ts:27 --repeat-each=20`, idle, real network | 20/20 passed (does not reproduce locally) | — |
| `providers.spec.ts:27` with Cerebras pointed at an accept-but-never-answer socket | **3/3 failed**, on `expect(dialog).toBeHidden()` → visible | **5/5 passed** (9.3s → 8.7s; the round trip is gone) |
| `scroll-geometry.spec.ts:239` at 50× CPU throttling, ×5 | **4 failed** — 2× false plateau (`distinctHeights` 7), 1× criterion timeout (the CI signature), 1× frame watchdog | — (see limits below) |
| `scroll-geometry.spec.ts:239` at 4× / 12× / 20× / 25×, ×8 each | not measured — the 50× row above is where the old criterion was characterised | **32/32** |
| `scroll-geometry.spec.ts` unthrottled ×10 (60 test runs) | — | **60/60** (4.7s → 3.3s) |

The amplifiers were CPU saturation, a local blackhole socket, and CDP CPU throttling — no product or test code was modified to provoke the failures, and all were fully reverted.

- `npm --workspace @maka/desktop run e2e` — 79 passed
- `npm --workspace @maka/desktop run test:dist` — 2953 passed; `@maka/ui run test:dist` — 267 passed
- `npm run lint`, `npm run format:check`, desktop + ui `typecheck` — clean

No timeout was lengthened, no retry added, no `waitForTimeout` introduced, and no assertion weakened; the 15s settle budget is unchanged. The added `toBeVisible`/`toBeHidden` assertions are real state transitions the specs were already relying on implicitly.

The `onSettled` boundary is held by tests rather than asserted in prose: they pin the last instant the walk must still be silent (last chunk forced, and again after its first frame), capture the released state from inside the callback rather than after the flush, and cover a cancel one frame short of settling and a queue whose remaining turns all detach mid-walk. Verified by mutation — settling before the release, on the first frame, in every chunk gap, on cancel, or not at all on a drained queue each fail at least one test.

## Limits, stated plainly

**Above ~25× CPU throttling the warm-up can park and never run a chunk.** `requestIdleCallback` is called with no timeout, and a renderer that stays busy never offers an idle period; at 30× this reproduces 4/5 and by 35× it is total, leaving the transcript at 16261px of placeholder geometry against a 40452px final. The old criterion did not see this because its 500ms `page.evaluate` poll was itself waking the renderer.

An earlier revision of this PR gave each chunk's idle slot a 200ms deadline and described the park as a defect users hit on slow machines. **Both are withdrawn.** The deciding measurement: with no deadline, `scroll-geometry.spec.ts:239` runs 8/8 unthrottled and 8/8 at each of 4×, 8×, 12× and 20×, plus 5/5 at 25×. A CI runner does not live past that, and the CI failure this PR fixes is fully explained by the settle criterion alone. What was actually demonstrated is a stall under synthetic throttling far beyond any real machine — not a defect in front of users, and not something to land on the back of a test fix.

The liveness gap is real and deserves its own change, decided on its own evidence: chunk layout cost and input-latency impact measured on a normal window with a real long transcript, which is what should choose a timeout and a chunk size. 200ms came from nothing, the spec is explicit that a timed-out callback runs *outside* an idle period, and the walk has no upper bound on turn count — so the change would force up to 16 full turns into the next frame's layout at exactly the busiest moment. The hidden-window hypothesis was checked and ruled out: forcing the E2E window visible (the CI configuration) does not change the park, and the renderer reports `visibilityState: "visible"` either way.

## Also swept

`skill-delete-scope.spec.ts` had the same conditional-click shape twice. All three tabs always render, so the branch could only ever skip the click on a slow mount and then look for the row on the wrong tab — now an unconditional click that Playwright waits for.

Two lookalikes were checked and deliberately left alone: `window-titlebar.spec.ts:302/308` runs on the settled `window` fixture with a postcondition already in place, and `project-management.spec.ts:16-17` is a structural absence assertion made after the menu is confirmed visible.

## Deliberately not done

`connections:test` also reaches the real network, and no E2E currently exercises it. The seam to plug it is the one this PR adds, so it can be done when a spec needs it rather than pre-emptively.

