### PR TITLE
fix(cu): make an unresolvable app a result the model can act on

### DIFF
--- a/packages/computer-use/src/cua-driver-backend.ts
+++ b/packages/computer-use/src/cua-driver-backend.ts
@@ -864,10 +864,26 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
         ];
       })
       .sort((a, b) => b.zIndex - a.zIndex);
-    if (eligible.length === 0)
+    if (eligible.length === 0) {
+      // Say where the right string comes from. An app is named by the string
+      // `list_apps` reports, which on macOS is the app's *localized* display
+      // name — "计算器", not "Calculator". A model asked to drive Calculator
+      // cannot know that, and this message used to leave it with nothing but
+      // the name it had already tried.
+      //
+      // Measured on the real desktop chain: the model's first call failed here,
+      // it recovered by calling `list_apps` and reading the name off the list,
+      // and the turn cost an extra round trip that the message could have
+      // saved. Matching leniently would be the other fix and is the wrong one —
+      // one string, one namespace, is what keeps `app` and `window_id` from
+      // disagreeing about which window they mean.
+      const named = app ?? windowId ?? 'the current desktop';
       throw new Error(
-        `invalidApp: no visible window matched ${app ?? windowId ?? 'the current desktop'}`,
+        app
+          ? `invalidApp: no visible window matched ${named}. App names come from list_apps and are localized, so they may not be the English name.`
+          : `invalidApp: no visible window matched ${named}`,
       );
+    }
     if (windowId === undefined && app && eligible.length > 1) {
       throw new Error(`ambiguousApp: ${app} matched ${eligible.length} visible windows`);
     }

--- a/packages/computer-use/src/cua-driver-result.ts
+++ b/packages/computer-use/src/cua-driver-result.ts
@@ -66,6 +66,37 @@ function resultText(result: JsonRpcToolResult | undefined, fallback: string): st
   );
 }
 
+/**
+ * `kAXErrorActionUnsupported`. AppKit returns it when an element has no such
+ * action — pressing a text area, for instance, which is not a thing you do to
+ * a text area.
+ */
+const AX_ACTION_UNSUPPORTED = -25206;
+
+/**
+ * A code for a driver error that Maka's enum does not name.
+ *
+ * This used to be `capture_failed` for everything, which is a specific claim —
+ * "the screenshot did not work" — and it was wrong for every error that was not
+ * about capture. Watched on a real desktop chain: `click_element` on a
+ * `AXTextArea` came back "capture_failed: AX action failed:
+ * AXUIElementPerformAction(AXPress) returned -25206". Nothing about capture had
+ * failed. The model spent seven tool calls re-observing and retrying the same
+ * click, because the code told it the failure was transient and the message
+ * that said otherwise was behind it.
+ *
+ * `unsupported_action` is the truthful reading of that one, and it is already
+ * in the enum. Everything still unrecognised stays `capture_failed` rather than
+ * being widened into a second catch-all — a code that means one thing should
+ * not quietly grow to mean anything.
+ */
+function classifyUnmappedDriverError(message: string): 'unsupported_action' | 'capture_failed' {
+  return message.includes(String(AX_ACTION_UNSUPPORTED)) ||
+    /action[ _]?unsupported/i.test(message)
+    ? 'unsupported_action'
+    : 'capture_failed';
+}
+
 export function normalizeCuaDriverOutcome(
   result: JsonRpcToolResult | undefined,
 ): CuDispatchOutcome {
@@ -83,10 +114,13 @@ export function normalizeCuaDriverOutcome(
 
   if (result.isError) {
     const rawError = structuredContent?.error;
+    const message = resultText(result, 'cua-driver reported an error');
     return {
       ok: false,
-      error: isComputerUseErrorCode(rawError) ? rawError : 'capture_failed',
-      message: resultText(result, 'cua-driver reported an error'),
+      error: isComputerUseErrorCode(rawError)
+        ? rawError
+        : classifyUnmappedDriverError(message),
+      message,
       ...(evidence ? { evidence } : {}),
     };
   }

--- a/packages/computer-use/src/cua-driver-result.ts
+++ b/packages/computer-use/src/cua-driver-result.ts
@@ -91,8 +91,7 @@ const AX_ACTION_UNSUPPORTED = -25206;
  * not quietly grow to mean anything.
  */
 function classifyUnmappedDriverError(message: string): 'unsupported_action' | 'capture_failed' {
-  return message.includes(String(AX_ACTION_UNSUPPORTED)) ||
-    /action[ _]?unsupported/i.test(message)
+  return message.includes(String(AX_ACTION_UNSUPPORTED)) || /action[ _]?unsupported/i.test(message)
     ? 'unsupported_action'
     : 'capture_failed';
 }
@@ -117,9 +116,7 @@ export function normalizeCuaDriverOutcome(
     const message = resultText(result, 'cua-driver reported an error');
     return {
       ok: false,
-      error: isComputerUseErrorCode(rawError)
-        ? rawError
-        : classifyUnmappedDriverError(message),
+      error: isComputerUseErrorCode(rawError) ? rawError : classifyUnmappedDriverError(message),
       message,
       ...(evidence ? { evidence } : {}),
     };

--- a/packages/computer-use/src/cua-driver-service.ts
+++ b/packages/computer-use/src/cua-driver-service.ts
@@ -370,19 +370,31 @@ export class CuaDriverService {
     const sessionIds = potentiallyDelivered.flatMap((request) =>
       request.sessionId ? [request.sessionId] : [],
     );
+    // Say why it died. The service has been buffering the child's stderr all
+    // along and then threw it away at the one moment it was worth reading: a
+    // driver that exits mid-request produced "cua-driver action exited after
+    // request delivery", which names the event and not one thing about the
+    // cause. On a real desktop chain that message reached the model, which
+    // concluded Computer Use was unavailable and finished the task by
+    // shelling out to AppleScript instead.
+    //
+    // One line, bounded. The driver's stderr is its own diagnostics, not
+    // application content.
+    const why = this.stderrTail.trim().replace(/\s+/g, ' ').slice(-200);
+    const because = why ? `: ${why}` : '';
     for (const request of requests) {
       request.reject(
         request.stage === 'writing' || request.stage === 'delivered'
           ? new CuaDriverLifecycleError(
               'outcome_unknown',
-              `cua-driver ${this.opts.role} exited after request delivery`,
+              `cua-driver ${this.opts.role} exited after request delivery${because}`,
               this.opts.role,
               this.generation,
               request.stage,
             )
           : new CuaDriverLifecycleError(
               'service_unavailable',
-              `cua-driver ${this.opts.role} exited before request delivery`,
+              `cua-driver ${this.opts.role} exited before request delivery${because}`,
               this.opts.role,
               this.generation,
               request.stage,

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -99,17 +99,17 @@ const computerWireParams = z
       .describe(
         'Operation to perform. Required fields by action: observe/screenshot require app or window_id; click_element requires observation_id and element_id; set_value requires observation_id, element_id, and value; select_text/secondary_action require observation_id, element_id, and text; press_key requires observation_id and text; coordinate actions require observation_id plus their coordinate fields.',
       ),
+    // "Exact" was already in this description and was not enough. On a real
+    // desktop chain the model asked for "Calculator" and got nothing, because
+    // the app is named 计算器 — macOS reports the localized display name and
+    // that name is the identity. It recovered by calling list_apps, at the cost
+    // of a round trip this sentence can save.
     app: z
       .string()
       .min(1)
       .max(512)
       .optional()
       .describe(
-        // "Exact" was already here and was not enough. On a real desktop chain
-        // the model asked for "Calculator" and got nothing, because the app is
-        // named 计算器 — macOS reports the localized display name and that name
-        // is the identity. It recovered by calling list_apps, at the cost of a
-        // round trip this sentence can save.
         'Exact app id/name as list_apps reports it. Names are localized, so the English name may not match. Required for observe unless window_id is supplied.',
       ),
     window_id: z

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -105,7 +105,12 @@ const computerWireParams = z
       .max(512)
       .optional()
       .describe(
-        'Exact app id/name from list_apps. Required for observe unless window_id is supplied.',
+        // "Exact" was already here and was not enough. On a real desktop chain
+        // the model asked for "Calculator" and got nothing, because the app is
+        // named 计算器 — macOS reports the localized display name and that name
+        // is the identity. It recovered by calling list_apps, at the cost of a
+        // round trip this sentence can save.
+        'Exact app id/name as list_apps reports it. Names are localized, so the English name may not match. Required for observe unless window_id is supplied.',
       ),
     window_id: z
       .number()
@@ -923,15 +928,58 @@ export function buildComputerUseTools(deps: {
             if (includeScreenshot && !tcc.screenRecording) {
               return { text: 'maka_computer.observe failed: permission_missing' };
             }
-            const backendObservation = await deps.backend.observeApp(
-              {
-                app: input.app,
-                windowId: input.window_id,
-                includeScreenshot,
-              },
-              abortSignal,
-              runCtx,
-            );
+            // A backend that cannot resolve the target reports it, and the
+            // report belongs in the tool's own result shape.
+            //
+            // Every other way `observe` can fail here — `unsupported_action`,
+            // `permission_missing` — returns text the model reads directly. An
+            // unresolvable app threw instead, so it left through the generic
+            // synthetic-error path and arrived as a different kind of thing
+            // than its siblings. Measured on the real desktop chain: asking for
+            // "Calculator" when the app is named 计算器 produced a thrown
+            // `invalidApp`, and the model read it as "the app is not running"
+            // and launched a second copy rather than looking the name up.
+            let backendObservation;
+            try {
+              backendObservation = await deps.backend.observeApp(
+                {
+                  app: input.app,
+                  windowId: input.window_id,
+                  includeScreenshot,
+                },
+                abortSignal,
+                runCtx,
+              );
+            } catch (error) {
+              const detail = error instanceof Error ? error.message : String(error);
+              // `ambiguousApp` is a different fact than "no such window" and the
+              // enum already distinguishes them; anything else is the target
+              // not being there.
+              const code = /^ambiguous/i.test(detail) ? 'ambiguous_target' : 'target_missing';
+              // Carry the recovery in the failure. The names are the whole
+              // reason this call failed, they are one `list_apps` away, and a
+              // model that has to make that call spends a round trip finding
+              // out something this message already knows. Bounded, because an
+              // error is not a place to paste a hundred app names.
+              let running = '';
+              if (code === 'target_missing' && input.app && deps.backend.listApps) {
+                try {
+                  const apps = await deps.backend.listApps(abortSignal);
+                  const named = apps
+                    .filter((app) => (app.windowCount ?? 0) > 0)
+                    .map((app) => app.appId)
+                    .slice(0, 24);
+                  if (named.length > 0) running = ` Apps with windows: ${named.join(', ')}.`;
+                } catch {
+                  // The list is a courtesy. Failing to fetch it must not turn a
+                  // reportable failure into an unreportable one.
+                }
+              }
+              return {
+                text: `maka_computer.observe failed: ${code} — ${detail}${running}`,
+                error: code,
+              };
+            }
             if (
               !observationLease?.ok ||
               !state.validateObservationLease(observationLease.lease).ok


### PR DESCRIPTION
Asking Computer Use to observe `Calculator` on a Chinese-locale machine fails, because the app is named 计算器 — macOS reports the localized display name and that name is the identity.

Three things were wrong with how that failure arrived, all measured on the real desktop chain rather than reasoned about.

**It threw.** Every other way `observe` can fail returns text the model reads directly (`unsupported_action`, `permission_missing`), but an unresolvable app left through the generic synthetic-error path and arrived as a different kind of thing than its siblings. It now returns `target_missing`, or `ambiguous_target` when the name matched several windows — a distinction the error enum already carried and nothing used.

**It did not say where the right string comes from.** The message was `no visible window matched Calculator`, which is the name the caller had just tried. Watching a real model receive it: it concluded the app was not running and launched a second copy.

**It did not carry the recovery.** The names are the whole reason the call failed and they are one `list_apps` away, so the failure now lists apps that have windows — bounded at 24, and only when a name was given.

Same prompt, same machine, three runs:

| | calls |
|---|---|
| before | fail → `launch_app` → `observe` |
| after the message | fail → `list_apps` → `observe` |
| after the app list | fail → `observe` |

with the model's own narration going from "Calculator might not be running" to "App name is localized to Chinese. Let me use 计算器."

Matching leniently would be the other fix and is the wrong one: one string, one namespace is what keeps `app` and `window_id` from disagreeing about which window they mean.

## Verification

- `npm --workspace @maka/runtime run test:dist` — 2842 tests, 41 pre-existing failures on this machine (`node:sqlite` missing on node 22.11), identical with and without this change.
- Real desktop chain, three runs: the real app, a real model, Calculator in the background. 12/12 checks each time.