### PR TITLE
fix(cu): let a semantic click unlock typing, not only a pixel click

### DIFF
--- a/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
+++ b/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
@@ -2257,6 +2257,52 @@ describe('cua-driver backend', () => {
     );
   });
 
+  it('type after a semantic click on an editable element, without any pixel click', async () => {
+    // The deadlock this removes: `type` refused without a keyboard target, and
+    // only `left_click` — the pixel path — could establish one. So the safest
+    // way to reach a field, the AX path that works on a window behind
+    // something else, was also the only way that could never type into it.
+    //
+    // A semantic click has no meaningful screen point, so the target carries
+    // the element's identity and the fill re-finds it in the fresh snapshot.
+    const { backend, logPath } = makeBackend();
+    const sig = new AbortController().signal;
+    const observation = await backend.observeApp!(
+      { app: 'Fixture', windowId: 77, includeScreenshot: false },
+      sig,
+      DEFAULT_RUN_CONTEXT,
+    );
+    const clicked = await backend.runSemantic!(
+      {
+        type: 'click_element',
+        observationId: observation.observationId,
+        elementId: '7',
+        elementIdentity: observation.elements[0]!.identity,
+      },
+      sig,
+      {
+        ...DEFAULT_RUN_CONTEXT,
+        toolCallId: 'semantic-click',
+        boundAction: boundElementAction(observation, '7'),
+      },
+    );
+    assert.equal(clicked.outcome.ok, true);
+
+    const typed = await backend.run({ type: 'type', text: 'typed via ax' } as CuAction, sig, {
+      ...DEFAULT_RUN_CONTEXT,
+      toolCallId: 'type-after-semantic',
+    });
+    assert.equal(typed.outcome.ok, true, 'the semantic click was enough to establish a target');
+
+    const records = await readRecords(logPath);
+    const call = toolCall(records, 'set_value');
+    assert.ok(call, 'the fill went through AXValue');
+    assert.equal(call!.value, 'typed via ax');
+    // Red line unchanged: no pixel click, and no frontmost lookup.
+    assert.equal(toolCalls(records, 'click').filter((c) => c.x !== undefined).length, 0);
+    assert.ok(!methodTrace(records).includes('tools/call:list_apps'));
+  });
+
   it('parallel click then type waits for the new click target instead of using the old window', async () => {
     const { backend, logPath } = makeBackend({ delayTool: 'click', delayMs: 120 });
     const sig = new AbortController().signal;

--- a/packages/computer-use/src/cua-driver-backend.ts
+++ b/packages/computer-use/src/cua-driver-backend.ts
@@ -305,10 +305,29 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
 
   // Keyboard ownership is session + turn scoped. Only a successful click may
   // establish it; pointer-only scroll/drag actions do not imply text focus.
+  /**
+   * AX roles that take typed text.
+   *
+   * A role not listed here still binds the window — the click happened and the
+   * keyboard now belongs to that window — it just does not claim the target is
+   * something a `type` may fill.
+   */
+  const EDITABLE_AX_ROLES = new Set(['AXTextField', 'AXTextArea', 'AXComboBox', 'AXSearchField']);
+
   interface KeyboardTarget {
     window: CuaResolvedWindow;
     editable: boolean;
     pageTarget?: CuaResolvedPageTextTarget;
+    /**
+     * Which element the click landed on, when a semantic click established
+     * this target.
+     *
+     * The pixel path has a screen point and finds the field under it. A
+     * semantic click has no such point — it addressed an element — so it
+     * carries the element's identity instead and the fill re-finds it in the
+     * fresh snapshot the same way `refetchSemanticElement` does.
+     */
+    element?: { role: string; label?: string };
   }
   const targetsBySession = new Map<string, { turnId: string; target: KeyboardTarget }>();
   const sessionGenerations = new Map<string, number>();
@@ -1076,7 +1095,21 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
       };
     }
     const snapshot = await snapshotTarget(target.window, signal);
-    const element = editableElementAtScreenPoint(snapshot.elements, target.window.screenPoint);
+    // A semantic click named an element; a pixel click named a point. Prefer
+    // the name when there is one — the window's centre, which is what a
+    // semantic target's `screenPoint` holds, is not where the field is.
+    const findEditable = (elements: TargetSnapshot['elements']) =>
+      (target.element
+        ? elements
+            .map(normalizeCuaSnapshotElement)
+            .find(
+              (candidate) =>
+                candidate !== undefined &&
+                candidate.role === target.element?.role &&
+                (target.element.label === undefined || candidate.label === target.element.label),
+            )
+        : undefined) ?? editableElementAtScreenPoint(elements, target.window.screenPoint);
+    const element = findEditable(snapshot.elements);
     if (!element) {
       return {
         ok: false,
@@ -1119,8 +1152,7 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
     } catch {
       return deliveredVerificationFailure('AXValue write', 'ax').outcome;
     }
-    const verified =
-      editableElementAtScreenPoint(after.elements, target.window.screenPoint)?.value === text;
+    const verified = findEditable(after.elements)?.value === text;
     return verified
       ? {
           ok: true,
@@ -1463,6 +1495,9 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
     },
 
     async runSemantic(action: CuSemanticAction, signal, context) {
+      // Read before the dispatch, so a session invalidated while it was in
+      // flight cannot have its keyboard target set by the reply.
+      const semanticGeneration = sessionGenerations.get(context.sessionId) ?? 0;
       try {
         return await withOperationQueue(
           signal,
@@ -1571,6 +1606,34 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
             }
             const outcome = normalizeCuaDriverOutcome(result);
             if (!outcome.ok) return { outcome };
+            // A semantic click binds the keyboard target, the same way a pixel
+            // click does.
+            //
+            // Only `left_click` used to, which is backwards: that is the pixel
+            // path, and the semantic one is the safer of the two — it addresses
+            // an element rather than a coordinate and it reaches a window that
+            // is behind something else. The effect was a deadlock: `type`
+            // refused without a target, and the only gesture that could set one
+            // was the gesture Maka exists to avoid. Clicking a text area
+            // semantically is refused by AppKit anyway
+            // (`AXPress` on `AXTextArea` is `kAXErrorActionUnsupported`), but a
+            // text *field* presses fine, and that is the common case.
+            if (
+              action.type === 'click_element' &&
+              (sessionGenerations.get(context.sessionId) ?? 0) === semanticGeneration
+            ) {
+              const role = String(refetched.role ?? '');
+              targetsBySession.set(context.sessionId, {
+                turnId: context.turnId,
+                target: {
+                  window: validated,
+                  editable: EDITABLE_AX_ROLES.has(role),
+                  ...(role
+                    ? { element: { role, ...(refetched.label ? { label: refetched.label } : {}) } }
+                    : {}),
+                },
+              });
+            }
             let fresh: CuObservation;
             try {
               fresh = await observeResolvedWindow(validated, true, signal, context);


### PR DESCRIPTION
`type` refuses without a keyboard target, and only `left_click` — the pixel path — could establish one.

That is backwards, and on a real desktop chain it is a deadlock:

```
type            → refused: "has no target window yet"
click_element   → does not establish a target
left_click      → does, but it is the pixel path Maka exists to avoid
```

The safest way to reach a field is the AX path: it addresses an element rather than a coordinate, and it works on a window sitting behind something else. That was the one way that could never type into it. Watched on the real chain: a model asked to type into TextEdit spent seven tool calls discovering this before reaching for coordinates.

## What changed

A successful `click_element` now binds the keyboard target the same way a `left_click` does, under the same rules — this turn only, dropped the moment a bound action names a different window, and never from a frontmost lookup.

A semantic click has no meaningful screen point (`screenPoint` on a resolved window is its centre, not where the field is), so the target carries the clicked element's role and label and `fillEditableTarget` re-finds it in the fresh snapshot. The pixel path is untouched: with no element on the target it still looks under the point.

## What this does not fix

`AXPress` on an `AXTextArea` returns `kAXErrorActionUnsupported` — pressing a text area is not a thing you do to a text area — so a document body still has to go through `set_value`. A text *field* presses fine, and that is the common case.

## Verification

New test: observe → `click_element` on the editable element → `type`, asserting the fill went through `AXValue`, that no pixel click was issued, and that no frontmost lookup happened. `@maka/computer-use` suite green (138 on this branch), including the four existing contracts that pin when a keyboard target may and may not be established.