### PR TITLE
fix(runtime): preserve shell timeout cause during process discovery

### DIFF
--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -7,7 +7,7 @@ import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { syncBuiltinESMExports } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { after, describe, test } from 'node:test';
+import { after, describe, test, type TestContext } from 'node:test';
 import type { ShellRunRecord, ShellRunStore, ShellRunUpdate, ToolResultContent } from '@maka/core';
 import { createShellRunStore } from '@maka/storage';
 
@@ -444,30 +444,7 @@ describe('ShellRunProcessManager', () => {
   test('latches timeout while POSIX process discovery is pending', {
     skip: process.platform === 'win32' ? 'POSIX process discovery only' : false,
   }, async (context) => {
-    const originalExecFile = childProcess.execFile;
-    const processTableStarted = deferred<void>();
-    const releaseProcessTable = deferred<void>();
-    childProcess.execFile = ((
-      file: string,
-      args: readonly string[],
-      options: ExecFileOptionsWithStringEncoding,
-      callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
-    ) => {
-      const processTableRead = file === '/bin/ps' || file === '/usr/bin/ps';
-      if (processTableRead) processTableStarted.resolve();
-      return originalExecFile(file, [...args], options, (error, stdout, stderr) => {
-        if (!processTableRead) {
-          callback(error, stdout, stderr);
-          return;
-        }
-        void releaseProcessTable.promise.then(() => callback(error, stdout, stderr));
-      });
-    }) as typeof childProcess.execFile;
-    syncBuiltinESMExports();
-    context.after(() => {
-      childProcess.execFile = originalExecFile;
-      syncBuiltinESMExports();
-    });
+    const processDiscovery = delayPosixProcessDiscovery(context);
 
     const manager = await createTestManager();
     try {
@@ -479,15 +456,46 @@ describe('ShellRunProcessManager', () => {
         }),
       );
       assert.equal(initial.kind, 'shell_run');
-      await processTableStarted.promise;
+      await processDiscovery.started;
       await new Promise<void>((resolve) => setTimeout(resolve, 100));
-      releaseProcessTable.resolve();
+      processDiscovery.release();
 
       const result = await waitForTerminalShellRun(manager, initial.ref);
       assert.equal(result.status, 'timed_out');
       assert.equal(result.exitCode, 124);
     } finally {
-      releaseProcessTable.resolve();
+      processDiscovery.release();
+      await manager.terminateAll().catch(() => undefined);
+    }
+  });
+
+  test('preserves cancellation when timeout fires during POSIX process discovery', {
+    skip: process.platform === 'win32' ? 'POSIX process discovery only' : false,
+  }, async (context) => {
+    const processDiscovery = delayPosixProcessDiscovery(context);
+    const abort = new AbortController();
+    const manager = await createTestManager();
+    const run = manager.runForegroundBash(
+      shellInput({
+        cwd: await workspace(),
+        command: waitForeverCommand('ready'),
+        timeoutMs: 50,
+        abortSignal: abort.signal,
+        emitOutput: () => abort.abort(),
+      }),
+    );
+
+    try {
+      await processDiscovery.started;
+      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+      processDiscovery.release();
+
+      const result = await run;
+      assert.equal(result.status, 'cancelled');
+      assert.equal(result.exitCode, 130);
+    } finally {
+      processDiscovery.release();
+      await run.catch(() => undefined);
       await manager.terminateAll().catch(() => undefined);
     }
   });
@@ -2350,6 +2358,41 @@ function isProcessAlive(pid: number): boolean {
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === 'EPERM';
   }
+}
+
+function delayPosixProcessDiscovery(context: TestContext): {
+  started: Promise<void>;
+  release(): void;
+} {
+  const originalExecFile = childProcess.execFile;
+  const processTableStarted = deferred<void>();
+  const releaseProcessTable = deferred<void>();
+  childProcess.execFile = ((
+    file: string,
+    args: readonly string[],
+    options: ExecFileOptionsWithStringEncoding,
+    callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+  ) => {
+    const processTableRead = file === '/bin/ps' || file === '/usr/bin/ps';
+    if (processTableRead) processTableStarted.resolve();
+    return originalExecFile(file, [...args], options, (error, stdout, stderr) => {
+      if (!processTableRead) {
+        callback(error, stdout, stderr);
+        return;
+      }
+      void releaseProcessTable.promise.then(() => callback(error, stdout, stderr));
+    });
+  }) as typeof childProcess.execFile;
+  syncBuiltinESMExports();
+  context.after(() => {
+    childProcess.execFile = originalExecFile;
+    syncBuiltinESMExports();
+  });
+
+  return {
+    started: processTableStarted.promise,
+    release: () => releaseProcessTable.resolve(),
+  };
 }
 
 function deferred<T>(): {

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -1,5 +1,10 @@
 import assert from 'node:assert/strict';
+import childProcess, {
+  type ExecFileException,
+  type ExecFileOptionsWithStringEncoding,
+} from 'node:child_process';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { syncBuiltinESMExports } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { after, describe, test } from 'node:test';
@@ -434,6 +439,57 @@ describe('ShellRunProcessManager', () => {
         ),
       /Background Bash timeout/,
     );
+  });
+
+  test('latches timeout while POSIX process discovery is pending', {
+    skip: process.platform === 'win32' ? 'POSIX process discovery only' : false,
+  }, async (context) => {
+    const originalExecFile = childProcess.execFile;
+    const processTableStarted = deferred<void>();
+    const releaseProcessTable = deferred<void>();
+    childProcess.execFile = ((
+      file: string,
+      args: readonly string[],
+      options: ExecFileOptionsWithStringEncoding,
+      callback: (error: ExecFileException | null, stdout: string, stderr: string) => void,
+    ) => {
+      const processTableRead = file === '/bin/ps' || file === '/usr/bin/ps';
+      if (processTableRead) processTableStarted.resolve();
+      return originalExecFile(file, [...args], options, (error, stdout, stderr) => {
+        if (!processTableRead) {
+          callback(error, stdout, stderr);
+          return;
+        }
+        void releaseProcessTable.promise.then(() => callback(error, stdout, stderr));
+      });
+    }) as typeof childProcess.execFile;
+    syncBuiltinESMExports();
+    context.after(() => {
+      childProcess.execFile = originalExecFile;
+      syncBuiltinESMExports();
+    });
+
+    const manager = await createTestManager();
+    try {
+      const initial = await manager.runBackgroundBash(
+        shellInput({
+          cwd: await workspace(),
+          command: nodeCommand('setTimeout(() => process.exit(0), 80);'),
+          timeoutMs: 50,
+        }),
+      );
+      assert.equal(initial.kind, 'shell_run');
+      await processTableStarted.promise;
+      await new Promise<void>((resolve) => setTimeout(resolve, 100));
+      releaseProcessTable.resolve();
+
+      const result = await waitForTerminalShellRun(manager, initial.ref);
+      assert.equal(result.status, 'timed_out');
+      assert.equal(result.exitCode, 124);
+    } finally {
+      releaseProcessTable.resolve();
+      await manager.terminateAll().catch(() => undefined);
+    }
   });
 
   test('aborting foreground Bash terminates the process without leaking a ref', async () => {

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -1615,10 +1615,11 @@ export class ShellRunProcessManager
 
   private armTimeout(live: LiveShellRun): void {
     if (live.timeoutMs === undefined) return;
-    live.timeoutTimer = setTimeout(
-      () => this.requestForcedTermination(live, 'timeout'),
-      live.timeoutMs,
-    );
+    live.timeoutTimer = setTimeout(() => {
+      if (live.rootExited || live.finalizeOnce) return;
+      live.lifecycleCause ??= 'timeout';
+      this.requestForcedTermination(live, 'timeout');
+    }, live.timeoutMs);
   }
 
   private clearLiveTimers(live: LiveShellRun): void {

--- a/packages/runtime/src/shell-run-manager.ts
+++ b/packages/runtime/src/shell-run-manager.ts
@@ -1616,7 +1616,7 @@ export class ShellRunProcessManager
   private armTimeout(live: LiveShellRun): void {
     if (live.timeoutMs === undefined) return;
     live.timeoutTimer = setTimeout(() => {
-      if (live.rootExited || live.finalizeOnce) return;
+      if (live.rootExited || live.finalizeOnce || live.termination) return;
       live.lifecycleCause ??= 'timeout';
       this.requestForcedTermination(live, 'timeout');
     }, live.timeoutMs);


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- Latch the timeout lifecycle cause when the deadline fires, before asynchronous POSIX process discovery completes.
- Preserve an existing termination owner before its cause commits, and avoid changing runs that have already exited or started finalizing.
- Add regressions for delayed `ps`, covering both root exit after the timeout deadline and cancellation before the deadline.

## Root cause

The timeout cause was previously recorded only immediately before signaling the process tree. POSIX descendant discovery can wait on `ps`; if the root process exited during that wait, the signal callback was skipped and the run could be classified as a normal completion.

## Validation

- `npm --workspace @maka/runtime test` (2819 passed, 9 skipped)
- `npm run typecheck`
- `npm run build`
- Focused timeout/process-discovery regression test

Follow-up to [the review on #1622](https://github.com/maka-agent/maka-agent/pull/1622#pullrequestreview-4814799419).

</details>

<details>
<summary>中文</summary>

## 概要

- 在超时截止时间触发时立即锁存超时生命周期原因，不再等待异步 POSIX 进程发现完成。
- 当已有 termination lifecycle 但原因尚未提交时，仍保留该 owner，并避免修改已经退出或开始终结的任务。
- 添加 `ps` 延迟回归测试，同时覆盖根进程在超时截止时间后退出，以及在截止时间前取消的时序。

## 根因

此前只有在即将向进程树发送信号时才记录超时原因。POSIX 子进程发现可能等待 `ps`；如果根进程在等待期间退出，发送信号前的回调会被跳过，任务可能被错误归类为正常完成。

## 验证

- `npm --workspace @maka/runtime test`（2819 passed，9 skipped）
- `npm run typecheck`
- `npm run build`
- 超时与进程发现时序的定向回归测试

这是对 [#1622 review](https://github.com/maka-agent/maka-agent/pull/1622#pullrequestreview-4814799419) 的后续修复。

</details>
