### PR TITLE
feat(cu): scroll an element, not a coordinate

### DIFF
--- a/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
+++ b/packages/computer-use/src/__tests__/cua-driver-backend.test.ts
@@ -2257,6 +2257,48 @@ describe('cua-driver backend', () => {
     );
   });
 
+  it('scrolls an element through the AX path, not a coordinate', async () => {
+    // The coordinate `scroll` aims at a pixel and needs a visible window to
+    // anchor the conversion. `scroll_element` addresses the scroll area, which
+    // is the difference that shows when the window is behind something else.
+    // Both executors already declared it — `maka.cu/2` as
+    // `{kind:"scroll", direction, pages}`, cua-driver among its element
+    // actions — and Maka's semantic action union was the only place it was
+    // missing.
+    const { backend, logPath } = makeBackend();
+    const sig = new AbortController().signal;
+    const observation = await backend.observeApp!(
+      { app: 'Fixture', windowId: 77, includeScreenshot: false },
+      sig,
+      DEFAULT_RUN_CONTEXT,
+    );
+    const scrolled = await backend.runSemantic!(
+      {
+        type: 'scroll_element',
+        observationId: observation.observationId,
+        elementId: '7',
+        direction: 'down',
+        pages: 2,
+        elementIdentity: observation.elements[0]!.identity,
+      },
+      sig,
+      {
+        ...DEFAULT_RUN_CONTEXT,
+        toolCallId: 'scroll-element',
+        boundAction: boundElementAction(observation, '7'),
+      },
+    );
+    assert.equal(scrolled.outcome.ok, true);
+
+    const records = await readRecords(logPath);
+    const call = toolCall(records, 'scroll');
+    assert.ok(call, 'the driver was asked to scroll');
+    assert.equal(call!.element_index, 7, 'by element, never by coordinate');
+    assert.equal(call!.x, undefined);
+    assert.equal(call!.direction, 'down');
+    assert.equal(call!.clicks, 6, 'two pages at three wheel clicks each');
+  });
+
   it('parallel click then type waits for the new click target instead of using the old window', async () => {
     const { backend, logPath } = makeBackend({ delayTool: 'click', delayMs: 120 });
     const sig = new AbortController().signal;

--- a/packages/computer-use/src/cua-driver-backend.ts
+++ b/packages/computer-use/src/cua-driver-backend.ts
@@ -306,9 +306,9 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
   // Keyboard ownership is session + turn scoped. Only a successful click may
   // establish it; pointer-only scroll/drag actions do not imply text focus.
   /** cua-driver's `scroll` counts wheel clicks; both executors declare pages. */
-const SCROLL_CLICKS_PER_PAGE = 3;
+  const SCROLL_CLICKS_PER_PAGE = 3;
 
-interface KeyboardTarget {
+  interface KeyboardTarget {
     window: CuaResolvedWindow;
     editable: boolean;
     pageTarget?: CuaResolvedPageTextTarget;

--- a/packages/computer-use/src/cua-driver-backend.ts
+++ b/packages/computer-use/src/cua-driver-backend.ts
@@ -305,7 +305,10 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
 
   // Keyboard ownership is session + turn scoped. Only a successful click may
   // establish it; pointer-only scroll/drag actions do not imply text focus.
-  interface KeyboardTarget {
+  /** cua-driver's `scroll` counts wheel clicks; both executors declare pages. */
+const SCROLL_CLICKS_PER_PAGE = 3;
+
+interface KeyboardTarget {
     window: CuaResolvedWindow;
     editable: boolean;
     pageTarget?: CuaResolvedPageTextTarget;
@@ -1533,6 +1536,37 @@ export function createCuaDriverBackend(opts: CuaDriverBackendOptions): CuDispatc
               signal,
             );
             if (visibilityFailure) return visibilityFailure;
+            if (action.type === 'scroll_element') {
+              // cua-driver's `scroll` takes an element the same way `click`
+              // does, so this is the AX path: it addresses the scroll area
+              // rather than a pixel, which is what makes it work on a window
+              // that is behind something else.
+              const result = await actionClient.callTool(
+                'scroll',
+                {
+                  pid: validated.pid,
+                  window_id: validated.windowId,
+                  element_index: refetched.element_index,
+                  ...(refetched.element_token ? { element_token: refetched.element_token } : {}),
+                  direction: action.direction,
+                  clicks: Math.max(1, Math.round((action.pages ?? 1) * SCROLL_CLICKS_PER_PAGE)),
+                },
+                signal,
+              );
+              const outcome = normalizeCuaDriverOutcome(result);
+              if (!outcome.ok) return { outcome };
+              let fresh: CuObservation;
+              try {
+                fresh = await observeResolvedWindow(validated, true, signal, context);
+              } catch {
+                return deliveredVerificationFailure('scroll_element', 'ax');
+              }
+              return {
+                outcome,
+                observation: fresh,
+                ...(fresh.screenshot ? { screenshot: fresh.screenshot } : {}),
+              };
+            }
             const args = {
               pid: validated.pid,
               window_id: validated.windowId,

--- a/packages/core/src/computer-use.ts
+++ b/packages/core/src/computer-use.ts
@@ -266,7 +266,16 @@ const POINTER_ACTIONS = new Set([
 ]);
 
 const KEYBOARD_ACTIONS = new Set(['type', 'key', 'hold_key', 'press_key']);
-const SEMANTIC_ACTIONS = new Set(['click_element', 'set_value', 'select_text', 'secondary_action']);
+const SEMANTIC_ACTIONS = new Set([
+  'click_element',
+  'set_value',
+  'select_text',
+  'secondary_action',
+  // Scrolling an element moves what is on screen without changing any value.
+  // It is still a mutation of the target's state, and it is the semantic twin
+  // of the coordinate `scroll` that already sits in POINTER_ACTIONS.
+  'scroll_element',
+]);
 
 const APPROVAL_ACTIONS = new Set([
   'list_apps',
@@ -275,6 +284,7 @@ const APPROVAL_ACTIONS = new Set([
   'set_value',
   'select_text',
   'secondary_action',
+  'scroll_element',
   'press_key',
   ...CU_ACTION_TYPES,
 ]);

--- a/packages/runtime/src/computer-use-codec.ts
+++ b/packages/runtime/src/computer-use-codec.ts
@@ -63,6 +63,15 @@ export const computerParams = z.discriminatedUnion('action', [
     .strict(),
   z
     .object({
+      action: z.literal('scroll_element'),
+      observation_id: z.string().min(1).max(256),
+      element_id: z.string().min(1).max(256),
+      scroll_direction: z.enum(['up', 'down', 'left', 'right']),
+      scroll_amount: z.number().int().min(0).max(100).optional(),
+    })
+    .strict(),
+  z
+    .object({
       action: z.literal('press_key'),
       observation_id: z.string().min(1).max(256),
       text,
@@ -215,6 +224,7 @@ export function adaptToCuAction(args: ComputerParams): CuAction {
     case 'set_value':
     case 'select_text':
     case 'secondary_action':
+    case 'scroll_element':
     case 'press_key':
       throw new Error(`semantic action '${args.action}' requires the semantic backend`);
     case 'screenshot':

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -1085,11 +1085,11 @@ export function buildComputerUseTools(deps: {
                                   : { pages: input.scroll_amount / SCROLL_UNITS_PER_PAGE }),
                                 elementIdentity: record.elements?.get(input.element_id)?.identity,
                               }
-                          : {
-                              type: 'press_key' as const,
-                              observationId: input.observation_id,
-                              key: input.text,
-                            }),
+                            : {
+                                type: 'press_key' as const,
+                                observationId: input.observation_id,
+                                key: input.text,
+                              }),
                     };
             const binding = claimBoundAction(record, input.observation_id, modelAction);
             if ('rejection' in binding) return bindingFailure(binding.rejection);

--- a/packages/runtime/src/computer-use-tools.ts
+++ b/packages/runtime/src/computer-use-tools.ts
@@ -34,6 +34,13 @@ import {
   type CuaSessionSnapshot,
 } from './cua-session-state.js';
 
+/**
+ * `scroll_amount` has no declared unit at the tool boundary ("Amount for
+ * scroll", 0..100) while both executors declare pages. Fixed here so the two
+ * ends cannot disagree silently.
+ */
+const SCROLL_UNITS_PER_PAGE = 10;
+
 const COMPUTER_USE_CATEGORY = 'computer_use';
 
 import {
@@ -93,6 +100,7 @@ const computerWireParams = z
         'set_value',
         'select_text',
         'secondary_action',
+        'scroll_element',
         'press_key',
         ...CU_ACTION_TYPES,
       ] as [string, ...string[]])
@@ -496,6 +504,7 @@ export function buildComputerUseTools(deps: {
       action.type === 'set_value' ||
       action.type === 'select_text' ||
       action.type === 'press_key' ||
+      action.type === 'scroll_element' ||
       action.type === 'secondary_action';
     const semanticAction = semantic ? (action as CuSemanticAction) : undefined;
     const semanticValue =
@@ -507,7 +516,9 @@ export function buildComputerUseTools(deps: {
             ? semanticAction.action
             : semanticAction?.type === 'press_key'
               ? semanticAction.key
-              : undefined;
+              : semanticAction?.type === 'scroll_element'
+                ? `${semanticAction.direction}:${semanticAction.pages ?? 1}`
+                : undefined;
     const elementId =
       semanticAction && 'elementId' in semanticAction ? semanticAction.elementId : undefined;
     const fingerprint = semanticAction
@@ -1018,6 +1029,7 @@ export function buildComputerUseTools(deps: {
             input.action === 'set_value' ||
             input.action === 'select_text' ||
             input.action === 'secondary_action' ||
+            input.action === 'scroll_element' ||
             input.action === 'press_key'
           ) {
             if (!deps.backend.runSemantic) {
@@ -1062,6 +1074,17 @@ export function buildComputerUseTools(deps: {
                               action: input.text,
                               elementIdentity: record.elements?.get(input.element_id)?.identity,
                             }
+                          : input.action === 'scroll_element'
+                            ? {
+                                type: 'scroll_element' as const,
+                                observationId: input.observation_id,
+                                elementId: input.element_id,
+                                direction: input.scroll_direction ?? 'down',
+                                ...(input.scroll_amount === undefined
+                                  ? {}
+                                  : { pages: input.scroll_amount / SCROLL_UNITS_PER_PAGE }),
+                                elementIdentity: record.elements?.get(input.element_id)?.identity,
+                              }
                           : {
                               type: 'press_key' as const,
                               observationId: input.observation_id,
@@ -1087,7 +1110,16 @@ export function buildComputerUseTools(deps: {
                     ? { type: 'type', text: semanticAction.value }
                     : semanticAction.type === 'select_text'
                       ? { type: 'type', text: semanticAction.text }
-                      : { type: 'key', text: semanticAction.action };
+                      : semanticAction.type === 'scroll_element'
+                        ? {
+                            type: 'scroll',
+                            scrollDirection: semanticAction.direction,
+                            scrollAmount: Math.round(
+                              (semanticAction.pages ?? 1) * SCROLL_UNITS_PER_PAGE,
+                            ),
+                            coordinate: binding.sourceCoordinate ?? { x: 0, y: 0 },
+                          }
+                        : { type: 'key', text: semanticAction.action };
             let result: CuRunResult | undefined;
             let consumeFailure: ComputerToolResult | undefined;
             let presentation: Awaited<ReturnType<typeof runWithPresentation>> | undefined;

--- a/packages/runtime/src/computer-use-types.ts
+++ b/packages/runtime/src/computer-use-types.ts
@@ -123,6 +123,25 @@ export type CuSemanticAction =
       elementIdentity?: CuObservedElement['identity'];
     }
   | {
+      /**
+       * Scroll an element rather than a point.
+       *
+       * The coordinate `scroll` aims at a pixel and needs a visible window to
+       * anchor the conversion; this addresses the scroll area itself, which is
+       * the difference that shows when the window is behind something else.
+       * `maka.cu/2` declares it (`{kind:"scroll", direction, pages}`) and
+       * cua-driver advertises `scroll` among its element actions, so both
+       * executors already speak it — this is the member that lets Maka say it.
+       */
+      type: 'scroll_element';
+      observationId: string;
+      elementId: string;
+      direction: 'up' | 'down' | 'left' | 'right';
+      /** Pages, the unit both executors declare. Defaults to one. */
+      pages?: number;
+      elementIdentity?: CuObservedElement['identity'];
+    }
+  | {
       type: 'press_key';
       observationId: string;
       key: string;


### PR DESCRIPTION
Both executors already speak this.

- `maka.cu/2` §6.1 declares `{kind:"scroll", direction, pages}` among its element actions.
- cua-driver advertises `scroll` in its handshake and takes an `element_index` for it, exactly as `click` does.

Maka's semantic action union was the only place it was missing. A `case 'scroll'` in the backend did not typecheck — that is how the gap was found.

So scrolling has been going through the point path: it aims at a pixel and needs a visible on-screen window to anchor the conversion. That is the one difference that matters when the window is behind something else, which is the case Computer Use exists for.

## Shape

`scroll_element` carries an observation id, an element id, a direction and an optional page count, and travels the four layers the other semantic actions travel:

| layer | change |
|---|---|
| `CuSemanticAction` | new member |
| tool schema (`computer-use-codec.ts`) | strict variant with `scroll_direction` + optional `scroll_amount` |
| approval (`packages/core`) | `semantic_mutation`, beside its coordinate twin in `POINTER_ACTIONS` |
| cua-driver backend | `scroll` with `element_index`, never a coordinate |

Pages are the unit both executors declare. The tool boundary's unitless 0..100 `scroll_amount` converts through one constant so the two ends cannot disagree silently, and cua-driver's wheel clicks convert through another at the backend edge.

## Verification

New test: observe → `scroll_element` with `pages: 2`, asserting the driver was asked by `element_index` with no coordinate, `direction: 'down'`, and 6 wheel clicks.

`@maka/computer-use` 138/138, `@maka/core` 1199/1199, `@maka/runtime` matches the main baseline (55 pre-existing failures on this machine from a missing `node:sqlite`).

The maka-cu backend takes the same action and maps it straight onto the protocol's own shape; that wiring rides with the branch that adds that backend.