### PR TITLE
fix(runtime): preserve token usage after context compaction

### DIFF
--- a/packages/core/src/__tests__/canonical-runtime-event.test.ts
+++ b/packages/core/src/__tests__/canonical-runtime-event.test.ts
@@ -1,0 +1,96 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { encodeCanonicalRuntimeEvent } from '../canonical-runtime-event.js';
+import type { RuntimeEvent } from '../runtime-event.js';
+
+function baseEvent(overrides: Partial<RuntimeEvent> = {}): RuntimeEvent {
+  return {
+    id: 'evt-1',
+    invocationId: 'inv-1',
+    runId: 'run-1',
+    sessionId: 'sess-1',
+    turnId: 'turn-1',
+    ts: 100,
+    partial: false,
+    role: 'system',
+    author: 'system',
+    ...overrides,
+  };
+}
+
+describe('canonical RuntimeEvent encoding', () => {
+  test('omits undefined optional fields from token-usage diagnostics', () => {
+    const event = baseEvent({
+      actions: {
+        tokenUsage: {
+          input: 226_495,
+          output: 1_080,
+          promptSegments: [
+            {
+              kind: 'prior_history',
+              chars: 65_680,
+              estimatedTokens: 16_420,
+              messageCount: 8,
+              eventCount: 11,
+              toolCount: undefined,
+            },
+          ],
+          contextBudget: {
+            enabled: true,
+            estimatedTokensBefore: 261_636,
+            estimatedTokensAfter: 221,
+            keptTurns: 1,
+            droppedTurns: 7,
+            keptEvents: 3,
+            droppedEvents: 42,
+            policyName: undefined,
+            compactionDecisions: [
+              {
+                stage: 'priorReplay',
+                sourceKind: 'runtimeEvents',
+                decision: 'replaced',
+                phase: 'mid_turn',
+                boundaryKind: 'historyCompact',
+                boundaryIds: ['compact-1'],
+                coverageHashes: ['sha256:compact-1'],
+                estimatedTokensBefore: 261_636,
+                estimatedTokensAfter: 221,
+                estimatedTokensSaved: 261_415,
+                reason: undefined,
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const encoded = encodeCanonicalRuntimeEvent(event);
+
+    const tokenUsage = encoded.event.actions?.tokenUsage;
+    assert.ok(tokenUsage);
+    assert.equal(Object.hasOwn(tokenUsage.promptSegments?.[0] ?? {}, 'toolCount'), false);
+    assert.equal(Object.hasOwn(tokenUsage.contextBudget ?? {}, 'policyName'), false);
+    assert.equal(
+      Object.hasOwn(tokenUsage.contextBudget?.compactionDecisions?.[0] ?? {}, 'reason'),
+      false,
+    );
+  });
+
+  test('still rejects undefined nested in arbitrary JSON payloads', () => {
+    const event = baseEvent({
+      role: 'tool',
+      author: 'tool',
+      content: {
+        kind: 'function_response',
+        id: 'call-1',
+        name: 'example',
+        result: { value: undefined },
+      },
+    });
+
+    assert.throws(
+      () => encodeCanonicalRuntimeEvent(event),
+      /RuntimeEvent is not losslessly serializable/,
+    );
+  });
+});

--- a/packages/core/src/canonical-runtime-event.ts
+++ b/packages/core/src/canonical-runtime-event.ts
@@ -34,14 +34,53 @@ export function encodeCanonicalRuntimeEvent(value: unknown): CanonicalRuntimeEve
 
 function normalizeRuntimeEventEnvelope(event: RuntimeEvent): RuntimeEvent {
   const normalized = omitUndefinedEnvelopeFields(event) as unknown as RuntimeEvent;
-  for (const key of ['content', 'actions', 'refs'] as const) {
+  for (const key of ['content', 'refs'] as const) {
     const nested = normalized[key];
     if (nested && typeof nested === 'object') {
-      Object.defineProperty(normalized, key, {
-        ...Object.getOwnPropertyDescriptor(normalized, key),
-        value: omitUndefinedEnvelopeFields(nested),
-      });
+      replaceDataProperty(normalized, key, omitUndefinedEnvelopeFields(nested));
     }
+  }
+  if (normalized.actions && typeof normalized.actions === 'object') {
+    replaceDataProperty(normalized, 'actions', normalizeRuntimeEventActions(normalized.actions));
+  }
+  return normalized;
+}
+
+function normalizeRuntimeEventActions(value: object): object {
+  const normalized = omitUndefinedEnvelopeFields(value);
+  const tokenUsage = Reflect.get(normalized, 'tokenUsage') as unknown;
+  if (tokenUsage && typeof tokenUsage === 'object' && !Array.isArray(tokenUsage)) {
+    replaceDataProperty(normalized, 'tokenUsage', normalizeTokenUsage(tokenUsage));
+  }
+  return normalized;
+}
+
+function normalizeTokenUsage(value: object): object {
+  const normalized = omitUndefinedEnvelopeFields(value);
+  const promptSegments = Reflect.get(normalized, 'promptSegments') as unknown;
+  if (Array.isArray(promptSegments)) {
+    replaceDataProperty(
+      normalized,
+      'promptSegments',
+      mapArrayElements(promptSegments, omitUndefinedEnvelopeFields),
+    );
+  }
+  const contextBudget = Reflect.get(normalized, 'contextBudget') as unknown;
+  if (contextBudget && typeof contextBudget === 'object' && !Array.isArray(contextBudget)) {
+    replaceDataProperty(normalized, 'contextBudget', normalizeContextBudget(contextBudget));
+  }
+  return normalized;
+}
+
+function normalizeContextBudget(value: object): object {
+  const normalized = omitUndefinedEnvelopeFields(value);
+  const compactionDecisions = Reflect.get(normalized, 'compactionDecisions') as unknown;
+  if (Array.isArray(compactionDecisions)) {
+    replaceDataProperty(
+      normalized,
+      'compactionDecisions',
+      mapArrayElements(compactionDecisions, omitUndefinedEnvelopeFields),
+    );
   }
   return normalized;
 }
@@ -57,4 +96,47 @@ function omitUndefinedEnvelopeFields(value: object): object {
     Object.defineProperty(result, key, descriptor);
   }
   return result;
+}
+
+function mapArrayElements(value: unknown[], map: (item: object) => object): unknown[] {
+  const result: unknown[] = [];
+  Object.setPrototypeOf(result, Object.getPrototypeOf(value));
+  const lengthDescriptor = Object.getOwnPropertyDescriptor(value, 'length');
+  if (!lengthDescriptor || !Object.hasOwn(lengthDescriptor, 'value')) {
+    throw new Error('RuntimeEvent is not losslessly serializable');
+  }
+  for (const key of Reflect.ownKeys(value)) {
+    if (key === 'length') continue;
+    const descriptor = Object.getOwnPropertyDescriptor(value, key);
+    if (!descriptor || !Object.hasOwn(descriptor, 'value')) {
+      throw new Error('RuntimeEvent is not losslessly serializable');
+    }
+    const item = descriptor.value;
+    Object.defineProperty(result, key, {
+      ...descriptor,
+      value:
+        isArrayIndex(key, value.length) &&
+        item !== null &&
+        typeof item === 'object' &&
+        !Array.isArray(item)
+          ? map(item)
+          : item,
+    });
+  }
+  Object.defineProperty(result, 'length', lengthDescriptor);
+  return result;
+}
+
+function isArrayIndex(key: PropertyKey, length: number): boolean {
+  if (typeof key !== 'string' || key.length === 0) return false;
+  const index = Number(key);
+  return Number.isSafeInteger(index) && index >= 0 && index < length && String(index) === key;
+}
+
+function replaceDataProperty(target: object, key: PropertyKey, value: unknown): void {
+  const descriptor = Object.getOwnPropertyDescriptor(target, key);
+  if (!descriptor || !Object.hasOwn(descriptor, 'value')) {
+    throw new Error('RuntimeEvent is not losslessly serializable');
+  }
+  Object.defineProperty(target, key, { ...descriptor, value });
 }


### PR DESCRIPTION
Closes #1643.

## What changed

- Canonicalize explicit `undefined` optional fields in the schema-owned `tokenUsage` diagnostic subtree (`promptSegments`, `contextBudget`, and compaction decisions).
- Preserve the strict lossless boundary for arbitrary nested JSON payloads, custom prototypes, accessors, sparse arrays, and serialization hooks.
- Add a regression test modeled on the failed resumed Graph run after history compaction, plus a negative control for arbitrary tool-result JSON.

## Root cause

The RuntimeEvent decoder accepts explicit `undefined` for optional usage-diagnostic fields. The canonical writer previously removed those fields only from the RuntimeEvent envelope and its immediate children. JSON serialization then omitted deeper optional fields, so the writer's strict round-trip equality check rejected the otherwise valid `token_usage` event and aborted the resumed Graph child.

## Validation

- `npm --workspace @maka/core test` (1202 passed)
- `npm --workspace @maka/storage test` (808 passed, 1 skipped)
- `npm run typecheck`
- `npm run format:check -- packages/core/src/canonical-runtime-event.ts packages/core/src/__tests__/canonical-runtime-event.test.ts`
- `npm run lint -- packages/core/src/canonical-runtime-event.ts packages/core/src/__tests__/canonical-runtime-event.test.ts`
