### PR TITLE
fix(runtime-host): contain stopped interaction admissions

### DIFF
--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -1073,6 +1073,59 @@ test('public turn.stop rejects an admission queued behind its exact-Run closure 
   }
 });
 
+test('public turn.interrupt contains a question admission rejected by its own stop closure', {
+  timeout: 20_000,
+}, async () => {
+  let backend: StopReleasedAdmissionBackend | undefined;
+  const fixture = await createFailureFixture({
+    withInteractions: true,
+    registerBackend: (backends) => {
+      backends.register('fake', (context) => {
+        backend = new StopReleasedAdmissionBackend(context.sessionId);
+        return backend;
+      });
+    },
+  });
+
+  try {
+    const turnId = 'turn-public-interrupt-stop-released-admission';
+    const started = await fixture.coordinator.handlers['turn.start'](
+      {
+        sessionId: fixture.sessionId,
+        turnId,
+        content: { text: 'admit a question only after stop arrives' },
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(started.ok, true);
+    if (!started.ok) return;
+    assert.ok(backend);
+    await backend.ready.promise;
+
+    const interrupted = await fixture.messages.handlers['turn.interrupt'](
+      {
+        originHostEpoch: fixture.hostEpoch,
+        interruptId: 'interrupt-stop-released-admission',
+        sessionId: fixture.sessionId,
+        turnId,
+        runId: started.result.runId,
+      },
+      operationContext(fixture.hostEpoch, fixture.acquireResidency),
+    );
+    assert.equal(interrupted.ok, true);
+    if (!interrupted.ok) return;
+    assert.equal(interrupted.result.turn.status, 'cancelled');
+    assert.equal(fixture.interactions?.isPoisoned(), false);
+    assert.equal(fixture.drainRequested(), false);
+
+    await fixture.coordinator.close();
+    await fixture.messages.close();
+    await fixture.interactions?.close();
+  } finally {
+    await fixture.dispose();
+  }
+});
+
 test('public turn.interrupt releases the Session lane while a queried Run is still starting', {
   timeout: 20_000,
 }, async () => {
@@ -2169,6 +2222,61 @@ class QueuedAdmissionBackend implements AgentBackend {
 
   async dispose(): Promise<void> {
     this.admissionTrigger.resolve();
+  }
+}
+
+class StopReleasedAdmissionBackend implements AgentBackend {
+  readonly kind = 'fake' as const;
+  readonly ready = deferred<void>();
+  private readonly stopped = deferred<void>();
+
+  constructor(readonly sessionId: string) {}
+
+  async *send(input: BackendSendInput): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'text_delta',
+      id: randomUUID(),
+      turnId: input.turnId,
+      ts: Date.now(),
+      messageId: randomUUID(),
+      text: 'running before stop-released admission',
+    };
+    this.ready.resolve();
+    await this.stopped.promise;
+    if (!input.hostedInteraction) {
+      throw new Error('StopReleasedAdmissionBackend requires hosted Interaction authority');
+    }
+    await input.hostedInteraction.admitUserQuestionRequest({
+      request: {
+        type: 'user_question_request',
+        id: randomUUID(),
+        turnId: input.turnId,
+        ts: Date.now(),
+        requestId: randomUUID(),
+        toolUseId: randomUUID(),
+        questions: [
+          {
+            question: 'Continue?',
+            options: [{ label: 'Yes' }, { label: 'No' }],
+          },
+        ],
+      },
+      settlement: {
+        applyAnswer: async () => {},
+        applyClosure: async () => {},
+      },
+    });
+    throw new Error('Question admission unexpectedly crossed the stop closure');
+  }
+
+  async stop(): Promise<void> {
+    this.stopped.resolve();
+  }
+
+  async respondToSandboxBoundary(): Promise<void> {}
+
+  async dispose(): Promise<void> {
+    this.stopped.resolve();
   }
 }
 

--- a/packages/runtime-host/src/server/root-turn-coordinator.ts
+++ b/packages/runtime-host/src/server/root-turn-coordinator.ts
@@ -17,6 +17,7 @@ import {
 import {
   classifyTerminalRuntimeLedger,
   RuntimeHostedRootConflictError,
+  RuntimeInteractionAdmissionRejectedError,
   RuntimeInteractionFailStopError,
   RuntimeInteractionInvariantError,
   RuntimeMessageAuthorityInvariantError,
@@ -1032,9 +1033,12 @@ export class RootTurnCoordinator {
             containedRunFailure =
               executionAuditFailure === undefined &&
               startSettled.phase === 'resolved' &&
-              !active.stopRequested &&
-              snapshot.status === 'failed' &&
-              isContainableRunFailure(error);
+              ((!active.stopRequested &&
+                snapshot.status === 'failed' &&
+                isContainableRunFailure(error)) ||
+                (active.stopRequested &&
+                  snapshot.status === 'cancelled' &&
+                  isStoppedInteractionAdmission(error)));
           }
         } catch {
           // Preserve the execution error unless identity audit found a stronger failure.
@@ -1479,6 +1483,16 @@ function isContainableRunFailure(error: unknown): error is Error {
     !(error instanceof RuntimeMessageAuthorityInvariantError) &&
     !(error instanceof RuntimeInteractionInvariantError) &&
     !(error instanceof RuntimeInteractionFailStopError)
+  );
+}
+
+function isStoppedInteractionAdmission(
+  error: unknown,
+): error is RuntimeInteractionAdmissionRejectedError {
+  return (
+    error instanceof RuntimeInteractionAdmissionRejectedError &&
+    error.reason === 'run_closed' &&
+    error.closureReason === 'turn_stopped'
   );
 }
 

--- a/packages/runtime/src/__tests__/interaction-authority.test.ts
+++ b/packages/runtime/src/__tests__/interaction-authority.test.ts
@@ -76,6 +76,42 @@ describe('Runtime Interaction authority seam', () => {
     assert.deepEqual(log, ['close:turn_terminal', 'release']);
   });
 
+  test('rejects a question registered after stop closure as an exact closed-Run admission', async () => {
+    const binding = await bindRuntimeInteractionRun(authority(), RUN);
+    await binding.close('turn_stopped');
+
+    await assert.rejects(
+      binding.admitUserQuestionRequest({
+        request: {
+          type: 'user_question_request',
+          id: 'question-event-after-stop',
+          turnId: RUN.turnId,
+          ts: 1,
+          requestId: 'question-after-stop',
+          toolUseId: 'tool-after-stop',
+          questions: [
+            {
+              question: 'Continue?',
+              options: [{ label: 'Yes' }, { label: 'No' }],
+            },
+          ],
+        },
+        settlement: {
+          applyAnswer: async () => {},
+          applyClosure: async () => {},
+        },
+      }),
+      (error: unknown) =>
+        error instanceof RuntimeInteractionAdmissionRejectedError &&
+        error.requestId === 'question-after-stop' &&
+        error.reason === 'run_closed' &&
+        error.closureReason === 'turn_stopped',
+    );
+
+    await binding.settleLocalClosures();
+    binding.release();
+  });
+
   test('publishes a hosted question only after admission and resolves only through its continuation', async () => {
     const admission = deferred<void>();
     let question: RuntimeUserQuestionContinuation | undefined;

--- a/packages/runtime/src/interaction-authority.ts
+++ b/packages/runtime/src/interaction-authority.ts
@@ -402,13 +402,16 @@ export class RuntimeInteractionRunBinding implements HostedInteractionBridge {
   }
 
   private assertNewContinuation(request: UserQuestionRequestEvent): void {
-    if (this.closeReason !== undefined || this.publicationsSealed || this.released) {
-      const phase =
-        this.closeReason !== undefined
-          ? `Run ${this.runId} started closing`
-          : `Run ${this.runId} sealed Interaction publication`;
+    if (this.closeReason !== undefined) {
+      throw new RuntimeInteractionAdmissionRejectedError(
+        request.requestId,
+        'run_closed',
+        this.closeReason,
+      );
+    }
+    if (this.publicationsSealed || this.released) {
       throw new RuntimeInteractionInvariantError(
-        `Interaction request ${request.requestId} registered after ${phase}`,
+        `Interaction request ${request.requestId} registered after Run ${this.runId} sealed Interaction publication`,
       );
     }
     if (request.turnId !== this.turnId) {


### PR DESCRIPTION
## Summary

- classify a question admitted after a stop-closed interaction run as `run_closed` / `turn_stopped` instead of an invariant violation
- contain only that exact late-admission race when the root turn has a requested stop and a durable cancelled terminal snapshot
- keep all other interaction authority and cleanup failures fail-stop, with regression coverage at both ownership layers

## Verification

- `npm run build:test`
- `npm run lint`
- `npm run format:check`
- runtime and runtime-host typechecks
- `interaction-authority.test.ts`: 8/8 passed
- `root-turn-coordinator.test.ts`: 15/15 passed
- `execution-host.test.ts`: 28/28 passed
- exact interrupt regression repeated 120 times at parallelism 12: 120/120 passed

## Root cause

The failed CI run interrupted a root turn while the fake backend still had a delayed question registration in flight. Scheduler timing could let that registration reach interaction authority after the run had started closing. The authority then raised either a generic invariant or `run_closed`, and the root-turn coordinator treated both as command failures even though stop ownership had already durably completed the turn as cancelled. The dispatcher consequently exposed a misleading `internal_failure`.

The failure is a product lifecycle race rather than a runner outage: the same commit path passed in later runs, and the regression reproduces locally under parallel load before this fix.