### PR TITLE
fix(ui): preserve pinned scroll through stale events

### DIFF
--- a/packages/ui/src/__tests__/pinned-bottom.test.ts
+++ b/packages/ui/src/__tests__/pinned-bottom.test.ts
@@ -1,6 +1,39 @@
 import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
-import { createPinnedBottomFollower } from '../pinned-bottom.js';
+import {
+  createPinnedBottomFollower,
+  resolvePinnedBottomScroll,
+} from '../pinned-bottom.js';
+
+describe('resolvePinnedBottomScroll', () => {
+  it('re-follows a stale programmatic scroll event after pinned content grows again', () => {
+    assert.deepEqual(
+      resolvePinnedBottomScroll({
+        scrollTop: 500,
+        scrollHeight: 1_100,
+        clientHeight: 100,
+        threshold: 64,
+        wasPinned: true,
+        lastFollowedScrollTop: 500,
+      }),
+      { pinned: true, shouldFollow: true },
+    );
+  });
+
+  it('unpins when the user moves away from the last followed position', () => {
+    assert.deepEqual(
+      resolvePinnedBottomScroll({
+        scrollTop: 400,
+        scrollHeight: 1_100,
+        clientHeight: 100,
+        threshold: 64,
+        wasPinned: true,
+        lastFollowedScrollTop: 500,
+      }),
+      { pinned: false, shouldFollow: false },
+    );
+  });
+});
 
 describe('createPinnedBottomFollower', () => {
   it('follows every observed content growth while pinned', () => {
@@ -9,10 +42,12 @@ describe('createPinnedBottomFollower', () => {
     let notifyContentCommit!: () => void;
     let observed: Element | undefined;
     let disconnected = false;
+    const followed: number[] = [];
     const stop = createPinnedBottomFollower({
       viewport,
       content,
       isPinned: () => true,
+      onFollow: (scrollTop) => { followed.push(scrollTop); },
       createObserver: (callback) => {
         notifyContentCommit = callback;
         return {
@@ -29,6 +64,7 @@ describe('createPinnedBottomFollower', () => {
     viewport.scrollHeight = 320;
     notifyContentCommit();
     assert.equal(viewport.scrollTop, 320);
+    assert.deepEqual(followed, [260, 320]);
     stop();
     assert.equal(disconnected, true);
   });

--- a/packages/ui/src/pinned-bottom.ts
+++ b/packages/ui/src/pinned-bottom.ts
@@ -17,6 +17,25 @@ export interface PinnedBottomSizeObserver {
 
 export type PinnedBottomSizeObserverFactory = (callback: () => void) => PinnedBottomSizeObserver;
 
+export function resolvePinnedBottomScroll(input: {
+  scrollTop: number;
+  scrollHeight: number;
+  clientHeight: number;
+  threshold: number;
+  wasPinned: boolean;
+  lastFollowedScrollTop?: number;
+}): { pinned: boolean; shouldFollow: boolean } {
+  const distanceFromBottom = input.scrollHeight - input.scrollTop - input.clientHeight;
+  const followsLastWrite =
+    input.wasPinned &&
+    input.lastFollowedScrollTop !== undefined &&
+    Math.abs(input.scrollTop - input.lastFollowedScrollTop) <= 1;
+  return {
+    pinned: followsLastWrite || distanceFromBottom <= input.threshold,
+    shouldFollow: followsLastWrite && distanceFromBottom > input.threshold,
+  };
+}
+
 /**
  * Follows the scroll content's actual commit clock. Streaming text is revealed
  * by requestAnimationFrame after raw deltas arrive, while OverlayScrollbars
@@ -35,11 +54,14 @@ export function createPinnedBottomFollower(options: {
   viewport: PinnedBottomViewport;
   content: Element;
   isPinned: () => boolean;
+  onFollow?: (scrollTop: number) => void;
   createObserver?: PinnedBottomObserverFactory;
   createSizeObserver?: PinnedBottomSizeObserverFactory;
 }): () => void {
   const follow = (): void => {
-    if (options.isPinned()) options.viewport.scrollTop = options.viewport.scrollHeight;
+    if (!options.isPinned()) return;
+    options.viewport.scrollTop = options.viewport.scrollHeight;
+    options.onFollow?.(options.viewport.scrollTop);
   };
   const createObserver = options.createObserver
     ?? (typeof MutationObserver === 'function'

--- a/packages/ui/src/use-chat-scroll.ts
+++ b/packages/ui/src/use-chat-scroll.ts
@@ -1,6 +1,6 @@
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { StoredMessage } from '@maka/core';
-import { createPinnedBottomFollower } from './pinned-bottom.js';
+import { createPinnedBottomFollower, resolvePinnedBottomScroll } from './pinned-bottom.js';
 import { createTurnSizeWarmup } from './turn-size-warmup.js';
 
 const SCROLL_BOTTOM_THRESHOLD = 64;
@@ -15,6 +15,7 @@ export function useChatScroll(input: {
   const viewportRef = useRef<HTMLDivElement>(null);
   const [pinnedToBottom, setPinnedToBottom] = useState(true);
   const pinnedToBottomRef = useRef(true);
+  const lastFollowedScrollTopRef = useRef<number | undefined>(undefined);
   const [highlightedTurnId, setHighlightedTurnId] = useState<string | null>(null);
 
   // A session owns one transcript DOM. Reset its initial position to latest.
@@ -22,7 +23,10 @@ export function useChatScroll(input: {
     pinnedToBottomRef.current = true;
     setPinnedToBottom(true);
     const viewport = viewportRef.current;
-    if (viewport) viewport.scrollTop = viewport.scrollHeight;
+    if (viewport) {
+      viewport.scrollTop = viewport.scrollHeight;
+      lastFollowedScrollTopRef.current = viewport.scrollTop;
+    }
   }, [input.sessionId]);
 
   // Follow the content's actual layout clock. Smooth streaming reveals text on
@@ -31,11 +35,18 @@ export function useChatScroll(input: {
     const viewport = viewportRef.current;
     const content = viewport?.querySelector(':scope > [data-overlayscrollbars-content]');
     if (!viewport || !content) return;
-    return createPinnedBottomFollower({
+    const stop = createPinnedBottomFollower({
       viewport,
       content,
       isPinned: () => pinnedToBottomRef.current,
+      onFollow: (scrollTop) => {
+        lastFollowedScrollTopRef.current = scrollTop;
+      },
     });
+    return () => {
+      lastFollowedScrollTopRef.current = undefined;
+      stop();
+    };
   }, [input.sessionId]);
 
   // Replace content-visibility placeholders with final-layout remembered sizes.
@@ -123,8 +134,23 @@ export function useChatScroll(input: {
   function onScroll() {
     const viewport = viewportRef.current;
     if (!viewport) return;
-    const distanceFromBottom = viewport.scrollHeight - viewport.scrollTop - viewport.clientHeight;
-    const pinned = distanceFromBottom <= SCROLL_BOTTOM_THRESHOLD;
+    const lastFollowedScrollTop = lastFollowedScrollTopRef.current;
+    const movedFromLastFollow =
+      lastFollowedScrollTop !== undefined &&
+      Math.abs(viewport.scrollTop - lastFollowedScrollTop) > 1;
+    const { pinned, shouldFollow } = resolvePinnedBottomScroll({
+      scrollTop: viewport.scrollTop,
+      scrollHeight: viewport.scrollHeight,
+      clientHeight: viewport.clientHeight,
+      threshold: SCROLL_BOTTOM_THRESHOLD,
+      wasPinned: pinnedToBottomRef.current,
+      lastFollowedScrollTop,
+    });
+    if (movedFromLastFollow || !pinned) lastFollowedScrollTopRef.current = undefined;
+    if (shouldFollow) {
+      viewport.scrollTop = viewport.scrollHeight;
+      lastFollowedScrollTopRef.current = viewport.scrollTop;
+    }
     pinnedToBottomRef.current = pinned;
     setPinnedToBottom(pinned);
   }


### PR DESCRIPTION
## Summary

- distinguish delayed programmatic scroll notifications from real user movement by remembering the last bottom-follow write
- re-follow content growth when a stale scroll event observes the old followed position against a newer `scrollHeight`
- preserve the existing near-bottom threshold and user-unpin behavior, with deterministic unit coverage for both branches

## Verification

- `npm run format`
- `npm run format:check`
- `npm run lint`
- `npm --workspace @maka/ui run typecheck`
- `npm --workspace @maka/ui run build`
- `pinned-bottom.test.ts`: 7/7 passed
- `npm --workspace @maka/desktop run build`
- full `scroll-geometry.spec.ts`: 6/6 passed
- failed route-return scenario repeated 12 times: 12/12 passed

## Root cause

During transcript warm-up, `ResizeObserver` follows one growth step by assigning `scrollTop`, which queues a programmatic `scroll` event. A later growth step can increase `scrollHeight` before that event is delivered. The handler then sees the still-valid last followed `scrollTop` hundreds of pixels from the new bottom and mistakes it for user scrolling, permanently disabling the follower. Route return rebuilds the transcript DOM and makes those growth steps large enough for the race to surface.

This is an application event-ordering race rather than a runner outage: the same test passed in another run against the same relevant source, while the failed run observed a 494px bottom gap.