### PR TITLE
refactor(ui): normalize the renderer CSS cascade into explicit layers

### DIFF
--- a/apps/desktop/src/main/__tests__/overlay-scrollbars-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/overlay-scrollbars-contract.test.ts
@@ -77,7 +77,7 @@ describe('OverlayScrollbars integration contract', () => {
     const styles = await readRendererContractCss();
     const tokens = await repoFile('apps/desktop/src/renderer/maka-tokens.css');
 
-    assert.match(styles, /@import "overlayscrollbars\/overlayscrollbars\.css";/, 'renderer CSS must load OverlayScrollbars vendor styles');
+    assert.match(styles, /@import "overlayscrollbars\/overlayscrollbars\.css" layer\(maka\.legacy\);/, 'renderer CSS must load OverlayScrollbars vendor styles');
     assert.match(styles, /\.os-theme-maka\s*\{[\s\S]*--os-size:\s*8px/, 'Maka theme must define compact 8px overlay scrollbars');
     assert.match(styles, /\.os-theme-maka\s*\{[\s\S]*--os-handle-bg:\s*var\(--border\)/, 'Maka theme must bind the handle to existing design tokens');
     assert.match(tokens, /Native fallback[\s\S]*OverlayScrollbars/, 'native scrollbar rules must be documented as fallback, not the primary app scroller');

--- a/apps/desktop/src/main/__tests__/renderer-style-layer-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-style-layer-cascade-contract.test.ts
@@ -5,11 +5,13 @@ import { readAllRendererCss, readCssTree, RENDERER_STYLES_DIR, stripCssComments,
 
 /**
  * Returns the number of `@layer` blocks enclosing the first occurrence of
- * `selectorLine` in `styles`. 0 means the rule is unlayered.
+ * `selectorLine` in `styles`. 0 means the rule carries no file-local layer
+ * nesting — its effective layer is whatever the import site assigns
+ * (`layer(maka.legacy)` / `layer(components)` in styles.css).
  *
- * Author rules placed inside `@layer base`/`@layer components` sit BELOW
- * Tailwind v4's `utilities` layer in the cascade, so they lose to any
- * utility class on the same element regardless of specificity.
+ * Author rules placed inside a file-local `@layer base`/`@layer components`
+ * block sit BELOW Tailwind v4's `utilities` layer in the cascade, so they
+ * lose to any utility class on the same element regardless of specificity.
  */
 function enclosingLayerCount(styles: string, selectorLine: string): number {
   const lines = styles.split('\n');
@@ -35,8 +37,107 @@ function enclosingLayerCount(styles: string, selectorLine: string): number {
   return -1; // selector not found
 }
 
+/**
+ * Asserts that styles.css imports `specifier` with layer(maka.legacy).
+ * `layer(components)` sits below utilities, so demoting a file that must
+ * outrank utilities silently reintroduces the #257 class of collapse.
+ */
+async function assertImportedIntoMakaLegacy(specifier: string): Promise<void> {
+  const styles = stripCssComments(await readFile(STYLES_FILE, 'utf8'));
+  const importLine = styles.split('\n').find((line) => line.includes(`"${specifier}"`));
+  assert.ok(importLine, `styles.css must import ${specifier}`);
+  assert.match(
+    importLine,
+    /layer\(maka\.legacy\)/,
+    `${specifier} must be imported with layer(maka.legacy): its rules must outrank Tailwind utilities, ` +
+      'and any other assignment (unlayered or layer(components)) changes their standing.',
+  );
+}
+
 describe('renderer style layer cascade contract', () => {
-  it('keeps feature stylesheets unlayered so renderer author CSS has one cascade model', async () => {
+  /**
+   * Regression guard for #1565 PR 1 (cascade normalization).
+   *
+   * cascade-layers.css is the single owner of the renderer layer order, and
+   * the whole rewrite is order-equivalent only while `maka.legacy` stays
+   * declared after Tailwind's `utilities`: every product rule that used to
+   * win by being unlayered now wins by living in a later-declared layer.
+   * Migration PRs may append layers to the declaration; they must never
+   * reorder these five.
+   */
+  it('declares maka.legacy after the Tailwind layers and establishes the order before any CSS loads', async () => {
+    const layersFile = stripCssComments(await readFile('src/renderer/cascade-layers.css', 'utf8'));
+    const declarations = [...layersFile.matchAll(/@layer\s+([^;{]+);/g)];
+    assert.equal(declarations.length, 1, 'cascade-layers.css must contain exactly one @layer order declaration');
+    const order = declarations[0][1].split(',').map((name) => name.trim());
+    for (const [earlier, later] of [
+      ['theme', 'base'],
+      ['base', 'components'],
+      ['components', 'utilities'],
+      ['utilities', 'maka.legacy'],
+    ]) {
+      assert.ok(
+        order.includes(earlier) && order.indexOf(earlier) < order.indexOf(later),
+        `cascade-layers.css must declare ${earlier} before ${later}; got: ${order.join(', ')}. ` +
+          'Reordering breaks the order-equivalence of the #1565 cascade normalization.',
+      );
+    }
+
+    const styles = stripCssComments(await readFile(STYLES_FILE, 'utf8'));
+    const firstImport = styles
+      .split('\n')
+      .map((line) => line.trim())
+      .find((line) => line.startsWith('@import'));
+    assert.equal(
+      firstImport,
+      '@import "./cascade-layers.css";',
+      'cascade-layers.css must be the first styles.css import so the layer order is established before any CSS loads',
+    );
+  });
+
+  /**
+   * Companion guard: the layer order above only carries the cascade while
+   * every import lands in its contracted layer. An unlayered product import
+   * would silently outrank every layer again (the pre-#1565 model).
+   */
+  it('keeps every styles.css import in its contracted cascade layer', async () => {
+    const styles = stripCssComments(await readFile(STYLES_FILE, 'utf8'));
+    const imports = [...styles.matchAll(/^@import\s+"([^"]+)"(?:\s+layer\(([^)]+)\))?\s*;/gm)].map(
+      ([, specifier, layer]) => ({ specifier, layer: layer ?? null }),
+    );
+    assert.ok(imports.length > 30, `expected the full styles.css import list, found ${imports.length}`);
+
+    // Deliberately unlayered: the order declaration itself, Tailwind (declares
+    // its own top-level layers), fonts (@font-face only), and maka-tokens.css
+    // (declares its own top-level @layer base/utilities/components blocks that
+    // must keep merging into the Tailwind layers).
+    const contractedUnlayered = new Set([
+      './cascade-layers.css',
+      'tailwindcss',
+      '@fontsource-variable/geist',
+      '@fontsource-variable/geist-mono',
+      './maka-tokens.css',
+    ]);
+    const misplaced = imports.filter(({ specifier, layer }) =>
+      contractedUnlayered.has(specifier)
+        ? layer !== null
+        : layer !== 'maka.legacy' && layer !== 'components',
+    );
+    assert.deepEqual(
+      misplaced.map(({ specifier, layer }) => `${specifier} -> ${layer ?? 'unlayered'}`),
+      [],
+      'Every styles.css import must be layer(maka.legacy)/layer(components) or on the contracted ' +
+        'unlayered list. An unlayered product import outranks every layer and reverts to the pre-#1565 cascade.',
+    );
+
+    // overlayscrollbars trades specificity wins with the product CSS in both
+    // directions, so it must share maka.legacy — either splitting it out to
+    // unlayered or demoting it to components flips real outcomes (#1565 PR 1).
+    const overlayScrollbars = imports.find(({ specifier }) => specifier === 'overlayscrollbars/overlayscrollbars.css');
+    assert.equal(overlayScrollbars?.layer, 'maka.legacy', 'overlayscrollbars must share layer(maka.legacy) with the product CSS');
+  });
+
+  it('keeps feature stylesheets free of local @layer blocks so layering happens at the import site', async () => {
     const layeredFiles: string[] = [];
     for (const file of await readCssTree(RENDERER_STYLES_DIR)) {
       const source = stripCssComments(await readFile(file, 'utf8'));
@@ -48,7 +149,8 @@ describe('renderer style layer cascade contract', () => {
     assert.deepEqual(
       layeredFiles,
       [],
-      'Feature stylesheets under apps/desktop/src/renderer/styles must stay unlayered. Keep Tailwind layer integration in maka-tokens.css instead of mixing local @layer blocks with unlayered override rules.',
+      'Feature stylesheets under apps/desktop/src/renderer/styles must not declare local @layer blocks; ' +
+        'they are layered at their styles.css import site. Keep Tailwind layer integration in maka-tokens.css.',
     );
   });
 
@@ -62,19 +164,22 @@ describe('renderer style layer cascade contract', () => {
    * styles.css into `@layer base`/`@layer components`; because Tailwind v4
    * orders `base, components, utilities`, the layered `.maka-nav-row` lost to
    * `inline-flex justify-center`, collapsing every sidebar button (nav rows,
-   * session rows, settings) to flex-centered content. Keep these override
-   * rules unlayered (or in a layer declared AFTER utilities) so they win.
+   * session rows, settings) to flex-centered content. Since #1565 PR 1 these
+   * override rules win by living in `maka.legacy` (declared AFTER utilities);
+   * a file-local layer block would demote them below utilities again.
   */
-  it('keeps .maka-nav-row out of any @layer so it beats Tailwind button utilities', async () => {
+  it('keeps .maka-nav-row directly in maka.legacy so it beats Tailwind button utilities', async () => {
     const styles = await readAllRendererCss();
     const layers = enclosingLayerCount(styles, '.maka-nav-row {');
     assert.notEqual(layers, -1, '.maka-nav-row { rule not found in styles.css');
     assert.equal(
       layers,
       0,
-      `.maka-nav-row is nested in ${layers} @layer block(s); it must stay unlayered to ` +
-        'remain the authoritative semantic navigation-row layout. See #257 regression.',
+      `.maka-nav-row is nested in ${layers} file-local @layer block(s); it must sit directly in its ` +
+        'import-site maka.legacy layer (declared after utilities) to remain the authoritative ' +
+        'semantic navigation-row layout. See #257 regression.',
     );
+    await assertImportedIntoMakaLegacy('./styles/sidebar.css');
   });
 
   it('keeps the composite session target on the same control radius as its row action', async () => {
@@ -139,14 +244,16 @@ describe('renderer style layer cascade contract', () => {
     );
   });
 
-  it('keeps the darwin glass .maka-nav-row color override out of any @layer so it beats quiet Button text utilities', async () => {
+  it('keeps the darwin glass .maka-nav-row color override directly in maka.legacy so it beats quiet Button text utilities', async () => {
     const styles = await readAllRendererCss();
     const layers = enclosingLayerCount(styles, 'html[data-os="darwin"] .maka-nav-row {');
     assert.notEqual(layers, -1, 'darwin .maka-nav-row glass rule not found in renderer CSS');
     assert.equal(
       layers,
       0,
-      'html[data-os="darwin"] .maka-nav-row must stay unlayered because the glass theme needs to override shared quiet Button text utilities on the same element.',
+      'html[data-os="darwin"] .maka-nav-row must sit directly in its import-site maka.legacy layer ' +
+        '(declared after utilities) because the glass theme needs to override shared quiet Button text utilities on the same element.',
     );
+    await assertImportedIntoMakaLegacy('./styles/theme-glass.css');
   });
 });

--- a/apps/desktop/src/main/__tests__/segmented-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/segmented-contract.test.ts
@@ -53,7 +53,7 @@ describe('segmented control chrome contract', () => {
     assert.match(recipe, /\.maka-segmented button:disabled\s*\{[^}]*opacity:\s*var\(--opacity-disabled\)/);
 
     const entry = await readFile(resolve(RENDERER, 'styles.css'), 'utf8');
-    assert.match(entry, /@import "\.\/styles\/segmented\.css";/);
+    assert.match(entry, /@import "\.\/styles\/segmented\.css" layer\(maka\.legacy\);/);
   });
 
   it('keeps the recipe out of every other renderer stylesheet', async () => {

--- a/apps/desktop/src/renderer/cascade-layers.css
+++ b/apps/desktop/src/renderer/cascade-layers.css
@@ -1,0 +1,5 @@
+/* Single owner of the renderer cascade layer order (#1565). Later PRs may
+   append layers; never reorder existing ones. maka.legacy is declared last
+   so legacy product CSS keeps beating components/utilities, exactly as its
+   unlayered form did. */
+@layer theme, base, components, utilities, maka.legacy;

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -15,7 +15,11 @@
 /* maka-tokens.css stays unlayered: it declares its own @layer base/
    utilities/components blocks that must keep merging into the top-level
    Tailwind layers. Wrapping the import would nest them under maka.legacy
-   and raise them above the utilities layer. */
+   and raise them above the utilities layer. Residual asymmetry: its few
+   unlayered non-token rules (.maka-shimmer, the .maka-skeleton family,
+   svg.lucide) now beat all maka.legacy rules unconditionally, no longer
+   by source order — do not add competing declarations for them under
+   styles/. */
 @import "./maka-tokens.css";
 @import "./reference-shell.css" layer(maka.legacy);
 @import "./styles/base.css" layer(maka.legacy);

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -1,48 +1,58 @@
+@import "./cascade-layers.css";
 @import "tailwindcss";
 @source "../../../../packages/ui/src";
 
 /* Bundled Geist fallbacks; maka-tokens.css owns the product font stacks. */
 @import "@fontsource-variable/geist";
 @import "@fontsource-variable/geist-mono";
-@import "overlayscrollbars/overlayscrollbars.css";
+/* overlayscrollbars must share maka.legacy with the product CSS: the two
+   trade wins by specificity in both directions (e.g. the library's
+   viewport reset vs .maka-chatViewport height rules), so splitting them
+   across layer boundaries changes outcomes. Same layer preserves the
+   intra-layer specificity and source-order contests exactly. */
+@import "overlayscrollbars/overlayscrollbars.css" layer(maka.legacy);
 
+/* maka-tokens.css stays unlayered: it declares its own @layer base/
+   utilities/components blocks that must keep merging into the top-level
+   Tailwind layers. Wrapping the import would nest them under maka.legacy
+   and raise them above the utilities layer. */
 @import "./maka-tokens.css";
-@import "./reference-shell.css";
-@import "./styles/base.css";
-@import "./styles/shell-layout.css";
-@import "./styles/sidebar.css";
-@import "./styles/search-modal.css";
-@import "./styles/prompt-suggestions.css";
-@import "./styles/deep-research.css";
-@import "./styles/onboarding.css";
-@import "./styles/empty-state.css";
-@import "./styles/module-pages.css";
-@import "./styles/field-focus.css";
-@import "./styles/settings/select.css";
-@import "./styles/segmented.css";
-@import "./styles/model-switcher.css";
-@import "./styles/chat-header.css";
-@import "./styles/task-ledger.css";
-@import "./styles/plan-mode.css";
-@import "./styles/agent-graph.css";
-@import "./styles/error.css";
-@import "./styles/toast.css";
-@import "./styles/help.css";
-@import "./styles/palette.css";
-@import "./styles/hero.css";
+@import "./reference-shell.css" layer(maka.legacy);
+@import "./styles/base.css" layer(maka.legacy);
+@import "./styles/shell-layout.css" layer(maka.legacy);
+@import "./styles/sidebar.css" layer(maka.legacy);
+@import "./styles/search-modal.css" layer(maka.legacy);
+@import "./styles/prompt-suggestions.css" layer(maka.legacy);
+@import "./styles/deep-research.css" layer(maka.legacy);
+@import "./styles/onboarding.css" layer(maka.legacy);
+@import "./styles/empty-state.css" layer(maka.legacy);
+@import "./styles/module-pages.css" layer(maka.legacy);
+@import "./styles/field-focus.css" layer(maka.legacy);
+@import "./styles/settings/select.css" layer(maka.legacy);
+@import "./styles/segmented.css" layer(maka.legacy);
+@import "./styles/model-switcher.css" layer(maka.legacy);
+@import "./styles/chat-header.css" layer(maka.legacy);
+@import "./styles/task-ledger.css" layer(maka.legacy);
+@import "./styles/plan-mode.css" layer(maka.legacy);
+@import "./styles/agent-graph.css" layer(maka.legacy);
+@import "./styles/error.css" layer(maka.legacy);
+@import "./styles/toast.css" layer(maka.legacy);
+@import "./styles/help.css" layer(maka.legacy);
+@import "./styles/palette.css" layer(maka.legacy);
+@import "./styles/hero.css" layer(maka.legacy);
 @import "./styles/chat-message.css" layer(components);
 @import "./styles/prose.css" layer(components);
-@import "./styles/composer.css";
-@import "./styles/composer-mention.css";
-@import "./styles/chat-detail.css";
-@import "./styles/settings.css";
+@import "./styles/composer.css" layer(maka.legacy);
+@import "./styles/composer-mention.css" layer(maka.legacy);
+@import "./styles/chat-detail.css" layer(maka.legacy);
+@import "./styles/settings.css" layer(maka.legacy);
 @import "./styles/markdown-link.css" layer(components);
-@import "./styles/interaction-prompts.css";
-@import "./styles/daily-review.css";
-@import "./styles/theme-glass.css";
-@import "./styles/prompt-rail.css";
-@import "./styles/quote-chip.css";
-@import "./styles/quote-side-panel.css";
+@import "./styles/interaction-prompts.css" layer(maka.legacy);
+@import "./styles/daily-review.css" layer(maka.legacy);
+@import "./styles/theme-glass.css" layer(maka.legacy);
+@import "./styles/prompt-rail.css" layer(maka.legacy);
+@import "./styles/quote-chip.css" layer(maka.legacy);
+@import "./styles/quote-side-panel.css" layer(maka.legacy);
 
 @theme inline {
   --color-background: var(--background);

--- a/apps/desktop/src/renderer/styles/daily-review.css
+++ b/apps/desktop/src/renderer/styles/daily-review.css
@@ -228,9 +228,9 @@
     padding: var(--space-2) var(--space-1);
   }
 
-/* Unlayered on purpose: the shared `.maka-empty-state` base (onboarding.css)
-   is unlayered `position: absolute` centering, and unlayered rules always beat
-   @layer rules — inside @layer components this override silently never applied,
+/* Must share maka.legacy with the `.maka-empty-state` base (onboarding.css),
+   whose `position: absolute` centering it overrides by specificity — inside
+   @layer components (below maka.legacy) this override silently never applied,
    so the empty card floated as a translucent overlay. Reset it to in-flow. */
 .maka-daily-review-panel .maka-daily-review-summary-empty {
   position: static;

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -86,8 +86,9 @@ html[data-os="darwin"] .maka-session-list,
     color: var(--foreground);
   }
 
-/* Unlayered on purpose: `.maka-nav-row` is a semantic navigation control, so
-   this darwin glass override must outrank the unlayered sidebar default color. */
+/* `.maka-nav-row` is a semantic navigation control, so this darwin glass
+   override must outrank the sidebar default color — same maka.legacy layer,
+   higher specificity. */
 html[data-os="darwin"] .maka-nav-row {
   color: var(--foreground);
 }

--- a/docs/frontend-css-governance.md
+++ b/docs/frontend-css-governance.md
@@ -24,9 +24,9 @@ Maka's frontend styling combines Tailwind v4 with handwritten renderer CSS. Some
 - Do not place `@import` inside an `@layer` block.
 - A selector that must override a shared primitive's Tailwind utility must remain outside `@layer components` until the primitive seam is fixed.
 
-## 3. Required unlayered rules
+## 3. Rules that must outrank Tailwind utilities
 
-These selectors currently depend on appearing after Tailwind utilities and must remain unlayered:
+These selectors depend on beating Tailwind utilities on the same element. Since #1565 PR 1 they do so by living in the `maka.legacy` layer, which `cascade-layers.css` declares after `utilities` (before that they relied on being unlayered). The declaration in `cascade-layers.css` is append-only: later migration PRs may add layers but must never reorder the existing five.
 
 - `.maka-nav-row`
 - `html[data-os="darwin"] .maka-nav-row`

--- a/docs/frontend-css-governance.zh-CN.md
+++ b/docs/frontend-css-governance.zh-CN.md
@@ -31,9 +31,9 @@
 - 不要使用 `@layer { @import ... }` 这种写法。
 - 如果一个 selector 需要覆盖共享 primitive 自带的 Tailwind utility，就不要把它放进 `@layer components`。
 
-## 3. 必须保持 Unlayered 的规则
+## 3. 必须压过 Tailwind Utility 的规则
 
-下面这些选择器当前依赖“比 Tailwind utility 更晚生效”的级联位置，必须保持 unlayered；除非共享 primitive 的实现先改掉，否则不能随便塞进 `@layer components`：
+下面这些选择器依赖在同一元素上压过 Tailwind utility。自 #1565 PR 1 起，它们靠位于 `maka.legacy` 层实现（`cascade-layers.css` 把该层声明在 `utilities` 之后；在此之前靠保持 unlayered）。`cascade-layers.css` 里的层序声明只允许追加：后续迁移 PR 可以增加新层，但绝不能重排既有五层。除非共享 primitive 的实现先改掉，否则不能把这些选择器塞进 `@layer components`：
 
 - `.maka-nav-row`
 - `html[data-os="darwin"] .maka-nav-row`


### PR DESCRIPTION
## Summary

PR 1 of the Astryx renderer migration (#1565, "PR 1 — Cascade normalization"): rewrite the renderer's implicit CSS cascade into an explicit, order-equivalent layered cascade. Refs #1565.

- New `cascade-layers.css` is the single owner of the layer order (`theme, base, components, utilities, maka.legacy`) and becomes `styles.css`'s first import, so the order is established before any CSS loads.
- All Maka-owned unlayered product imports move into `layer(maka.legacy)`, declared after `utilities` — they keep beating Tailwind utilities exactly as unlayered CSS did, and their intra-layer order is the unchanged import order.
- The three imports already in `layer(components)` (`chat-message.css`, `prose.css`, `markdown-link.css`) are untouched.

Two files deviate from the issue's nominal "wrap everything Maka-owned / leave third-party unlayered" rule; both deviations were caught by the zero-diff gate, which is exactly the arbiter role #1565 assigns it:

- `maka-tokens.css` stays **unlayered**: it declares its own `@layer base` / `@layer utilities` / `@layer components` blocks that must keep merging into the top-level Tailwind layers. Wrapping the import nests them under `maka.legacy` and lifts them above the `utilities` layer (observed as button borderColor / segmented-control flips in chat and settings).
- `overlayscrollbars` joins **`maka.legacy`**: the library and the product CSS trade wins by specificity in both directions (e.g. the library's `[data-overlayscrollbars-viewport]:not(...)` reset vs `.maka-chatViewport` height rules), so no unlayered/layered split can preserve today's outcomes. Sharing the layer preserves the intra-layer specificity and source-order contests exactly (observed as a 40px onboarding viewport height shift before the fix).

## Verification

- `check:visual-contract` (PR 0's computed-style snapshot harness + baselines, borrowed locally from the PR 0 worktree): **10/10 captures clean, exact zero diff** — all five routes (chat, settings-general, settings-providers, mcp-hub, onboarding) × light/dark.
- Control run with `main`'s `styles.css` against the same baselines confirmed the baselines represent current `main` on this machine.
- `check:hit-test`: reports the same unhittable-element list on this branch and on an unmodified `main` build (identical elements, e.g. composer controls intercepted by `.maka-overlay-scrollarea-viewport`) — pre-existing behavior of the WIP harness/main, not a regression from this PR; owned by the PR 0 work.
- `npm run format:check`, `npm run typecheck`, `npm run check:release` (includes the dead-CSS gate): all pass.
- Desktop unit suite: 2979/2979 pass. Two pre-existing contract assertions (overlayscrollbars, segmented) hardcoded the unlayered import form and were adapted to the layered one.

## Review follow-up

An independent review pass (subagent + Codex, both verifying the built CSS AST against `main`) confirmed order-equivalence and surfaced one actionable gap: the existing `renderer-style-layer-cascade-contract.test.ts` asserted the pre-#1565 model and stayed green through the rewrite because its helper drops import-site `layer()` semantics. The second commit re-anchors that contract on the new invariants — layer order is append-only with `maka.legacy` after `utilities`, every import sits in its contracted layer, and the `.maka-nav-row` files are pinned to `maka.legacy` — each mutation-checked (reordering the layers or demoting `sidebar.css` to `layer(components)` fails the suite). The CSS governance docs (EN + zh-CN) and the comments whose unlayered rationale the rewrite obsoleted are aligned in the same commit.

## Merge order

Development was parallel to PR 0 (file-disjoint), but merge is serial: **do not merge until PR 0 (visual-contract harness + baselines) is on `main`**, then rebase and re-run `check:visual-contract` as the final gate. The harness scripts and baseline fixtures are deliberately not part of this PR — they ship with PR 0.
