### PR TITLE
storage: make SQLite canonical for runtime events

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,16 +184,15 @@ Current boundaries that matter:
 
 Read [SECURITY.md](./SECURITY.md) for security reporting and policy, and [docs/README.md](./docs/README.md) for current privacy and sandbox contracts.
 
-## Experimental runtime recovery flags
+## Experimental runtime recovery flag
 
-Runtime recovery remains opt-in. Both flags below are disabled by default:
+RuntimeEvent persistence is always canonical in `runtime.sqlite`. On the first
+write, Maka batch-idempotently imports legacy RuntimeEvent JSONL without
+rewriting it. Legacy-only workspaces remain available to read-only inspection
+until that first write.
 
-- `MAKA_RUNTIME_SQLITE_CANONICAL=1` migrates the current workspace's canonical
-  RuntimeEvent store to `runtime.sqlite`. This is a **one-way, sticky migration
-  trigger**, not a reversible backend selector: after `runtime.sqlite` exists,
-  disabling the variable does not switch the workspace back to JSONL. Automatic
-  pre-migration backup and populated v2-to-v4 upgrade coverage are not complete,
-  so back up the workspace before enabling this flag.
+Runtime continuation remains opt-in:
+
 - `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` enables the Desktop interrupted-turn
   **Safe resume** action, CLI/TUI `/resume`, and Desktop startup auto-resume.
   These paths may call the configured model provider and consume tokens. Enable

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -186,13 +186,12 @@ Maka 默认把 workspace 数据放在 Electron `userData` 下：
 
 ## 实验性 Runtime 恢复开关
 
-Runtime 恢复目前仍需显式开启，以下两个开关默认都是关闭的：
+RuntimeEvent 现在始终以 `runtime.sqlite` 为 canonical store。首次写入时，Maka
+会批量、幂等导入 legacy RuntimeEvent JSONL，且不会改写旧文件；在首次写入前，
+仅包含 legacy 数据的 workspace 仍可由只读检查路径读取。
 
-- `MAKA_RUNTIME_SQLITE_CANONICAL=1` 会把当前 workspace 的 canonical
-  RuntimeEvent store 迁移到 `runtime.sqlite`。这是一个**单向、sticky 的迁移触发器**，
-  不是可来回切换的存储开关：一旦 workspace 中出现 `runtime.sqlite`，之后即使
-  关闭环境变量，也不会切回 JSONL。自动迁移前备份和有存量数据的 v2→v4 升级覆盖
-  尚未补齐，开启前请先备份 workspace。
+Runtime continuation 仍需显式开启：
+
 - `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` 会开启 Desktop 中断横幅的“安全恢复”按钮、
   CLI/TUI 的 `/resume` 命令和 Desktop 启动时自动续跑。这些路径都可能调用已配置的模型 provider 并消耗 token，
   只应在你明确需要这一行为时开启。

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -273,7 +273,6 @@ const planStore = createPlanStore(workspaceRoot);
 const runStore = createAgentRunStore(workspaceRoot);
 const runtimePersistence = await openRuntimeEventPersistence({
   workspaceRoot,
-  sqliteCanonical: process.env.MAKA_RUNTIME_SQLITE_CANONICAL === '1',
 });
 const runtimeEventStore = runtimePersistence.runtimeEventStore;
 const shellRunStore = createShellRunStore(workspaceRoot);

--- a/docs/architecture/runtime-resume-architecture.md
+++ b/docs/architecture/runtime-resume-architecture.md
@@ -498,18 +498,21 @@ The local safety inspector:
 
 A path move is diagnostic; marker identity mismatch is a hard gate. This proves the logical workspace identity, not its contents. Content continuity requires a Phase 4 checkpoint.
 
-## Phase 2: SQLite is a durable mode
+## Phase 2: SQLite is the durable RuntimeEvent store
 
 A JSONL host without `RuntimeCommitSink` cannot declare the T1 protocol. Only when the host wires the SQLite store as both `RuntimeEventStore` and `RuntimeCommitSink` may the AiSdk tool path declare `t1_after_preflight_v1` on the first Run event.
 
 ```text
-MAKA_RUNTIME_SQLITE_CANONICAL=1
-  → trigger workspace migration
+open a RuntimeEvent writer
+  → create or migrate runtime.sqlite
   → batch-idempotently import legacy RuntimeEvent JSONL
-  → make SQLite the only canonical RuntimeEvent writer
+  → write RuntimeEvents only to SQLite
 ```
 
-Once `runtime.sqlite` exists, the workspace stays on SQLite even if the environment variable is later removed. This is a sticky migration, not a reversible experiment toggle. JSONL remains for legacy import and explicit export.
+There is no backend-selection flag. Read-only inspection may read a legacy-only
+workspace without creating a database; the first writer performs the one-way
+import. Once `runtime.sqlite` exists, all readers use SQLite and never merge or
+fall back to stale JSONL. JSONL remains for legacy import and explicit export.
 
 ## Phase 3A: atomically commit recovery facts
 
@@ -796,10 +799,12 @@ Start with production-shaped red tests, then land core contract, storage constra
 
 | Flag | Purpose | Rollback meaning |
 |---|---|---|
-| `MAKA_RUNTIME_SQLITE_CANONICAL=1` | Trigger migration to SQLite canonical | Removing the flag cannot return a migrated workspace to JSONL |
 | `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` | Enable Desktop manual/auto resume and CLI `/resume` | May disable visible continuation; does not delete durable facts |
 
-Downgrading to a reader that does not understand the new schema requires explicit, verified export. Migration failure must preserve legacy JSONL. A newer database schema fails closed.
+RuntimeEvent migration is unconditional on the first write. Downgrading to a
+reader that does not understand the new schema requires explicit, verified
+export. Migration failure must preserve legacy JSONL. A newer database schema
+fails closed.
 
 Future recovery/checkpoint modes follow the same rule: select durable mode before T1 or accepted boundary. Never silently fall back to a weaker protocol mid-execution.
 

--- a/docs/architecture/runtime-resume-architecture.zh-CN.md
+++ b/docs/architecture/runtime-resume-architecture.zh-CN.md
@@ -516,20 +516,22 @@ CLI/TUI 的 `/resume` 走同一个 `SessionManager` plan/execute seam，只是�
 
 后一个问题必须由 Phase 4 checkpoint/carrier 解决。当前 safe-boundary continuation 不能被描述成 workspace snapshot restore。
 
-## Phase 2：为什么 SQLite 是 durable mode
+## Phase 2：SQLite 是 RuntimeEvent 的 durable store
 
 没有 `RuntimeCommitSink` 的 JSONL host 不能声明 T1 协议。只有 host 真正把 SQLite store 同时接成 `RuntimeEventStore` 和 `RuntimeCommitSink`，AiSdk tool path 才会在 Run 首事件写入 `t1_after_preflight_v1` marker。
 
 当前启动规则是：
 
 ```text
-MAKA_RUNTIME_SQLITE_CANONICAL=1
-  → 触发当前 workspace 迁移
+打开 RuntimeEvent writer
+  → 创建或迁移 runtime.sqlite
   → 批量、幂等导入 legacy RuntimeEvent JSONL
-  → SQLite 成为唯一 canonical RuntimeEvent writer
+  → RuntimeEvent 只写 SQLite
 ```
 
-一旦 workspace 中存在 `runtime.sqlite`，之后即使环境变量关闭也继续使用 SQLite。这是 sticky migration，不是可以来回切换的实验开关。否则 SQLite-only 事件会在“回退”后静默消失，形成两个事实源。
+这里不再有 backend selection flag。只读检查可以读取尚未创建数据库的 legacy-only
+workspace；第一个 writer 执行单向导入。一旦存在 `runtime.sqlite`，所有 reader
+都只读 SQLite，不会再与过期 JSONL 合并或 fallback。
 
 JSONL 在迁移后只承担 legacy import 和显式 export；Session message JSONL 与 AgentRun operational JSONL 仍保留各自用途，但不与 SQLite 竞争 RuntimeEvent authority。
 
@@ -830,11 +832,10 @@ flowchart TD
 
 ## Feature flags、迁移与回滚
 
-当前两个主要开关含义不同：
+RuntimeEvent 迁移不再由开关控制；首次写入必然迁移。当前恢复行为开关如下：
 
 | 开关 | 作用 | 回滚含义 |
 |---|---|---|
-| `MAKA_RUNTIME_SQLITE_CANONICAL=1` | 触发 workspace 迁移到 SQLite canonical | 不能靠关闭变量回到 JSONL；已迁移 workspace sticky 使用 SQLite |
 | `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` | 开启 Desktop 手动/自动 resume 与 CLI `/resume` | 可关闭用户可见 continuation，但不会删除或改写 durable facts |
 
 真正降级到不理解新 schema 的旧版本前，必须显式 export 并验证。Migration 失败不能删除 legacy JSONL；数据库版本比当前程序新时必须 fail closed。

--- a/docs/runtime-resume-tool-journal-design-draft.zh-CN.md
+++ b/docs/runtime-resume-tool-journal-design-draft.zh-CN.md
@@ -22,7 +22,7 @@ owners:
 - Phase 0 的恢复语义、replay gate 与真实进程 crash harness 已实现；
 - Phase 1 的 safe-boundary continuation 已实现，并由 `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` 控制 Desktop 中断横幅手动恢复、CLI/TUI `/resume` 与 Desktop 自动启动；continuation lineage 会回溯拼装 user-anchored provider history，普通后续 Turn 也会包含 continuation Run；
 - Phase 2 的 SQLite schema、Tool Journal、T1/T2、operationId、CAS、partial snapshot、带 source marker 的批量 JSONL 导入、显式导出及 CLI/Desktop 单一 canonical writer 接线已实现；
-- `MAKA_RUNTIME_SQLITE_CANONICAL=1` 是 workspace 的迁移触发器而非可随意来回切换的读写开关：workspace 一旦存在 `runtime.sqlite`，后续即使关闭环境变量也继续使用 SQLite canonical，避免 SQLite-only 事件突然不可见；系统不会双写两个 RuntimeEvent 真相源；
+- RuntimeEvent writer 无条件使用 `runtime.sqlite`：首次写入会幂等导入 legacy JSONL 且不改写旧文件；只读检查在数据库尚不存在时仍可读取 legacy JSONL，一旦存在数据库就只读 SQLite；系统不会双写两个 RuntimeEvent 真相源；
 - Phase 2 已实现 write-side durable boundary；崩溃留下的 unmatched function call 会沿用 Phase 0 gate 安全 park，但 journal 的 `indeterminate/reconciled/parked` 状态写入与专用 reconciler 属于 Phase 3；
 - Phase 3 的受控恢复、reconciler 与 recovery verification 尚未实现。
 
@@ -966,7 +966,7 @@ compaction_ref_missing
 
 ### Phase 2：SQLite 与事务化 Tool boundary
 
-当前状态：write-side 已实现。CLI/Desktop 通过 `MAKA_RUNTIME_SQLITE_CANONICAL=1` 触发 workspace 迁移；全新且未迁移的 workspace 默认仍使用 JSONL。启用时按 source marker 批量幂等导入旧 RuntimeEvent JSONL，再将 SQLite 同时作为 `RuntimeEventStore` 与 `RuntimeCommitSink`，正常执行不再写 RuntimeEvent JSONL。迁移后选择 sticky SQLite canonical，关闭 flag 也不会让 SQLite-only 历史消失。Session message JSONL 与 AgentRun operational JSONL 仍是兼容投影/运行记录，不构成第二个 RuntimeEvent source of truth。
+当前状态：write-side 已实现。CLI、Desktop、Headless 的 RuntimeEvent writer 无条件打开 `runtime.sqlite`，按 source marker 批量幂等导入旧 RuntimeEvent JSONL，再将 SQLite 同时作为 `RuntimeEventStore` 与 `RuntimeCommitSink`；正常执行不再写 RuntimeEvent JSONL。只读路径仅在数据库不存在时读取 legacy JSONL，一旦数据库存在就只认 SQLite。Session message JSONL 与 AgentRun operational JSONL 仍是兼容投影/运行记录，不构成第二个 RuntimeEvent source of truth。
 
 交付：
 
@@ -1153,11 +1153,10 @@ UI 至少区分：
 
 ## 二十三、发布、回滚与 feature flags
 
-当前实现层对外提供两个环境变量，默认都关闭：
+RuntimeEvent 迁移不再由环境变量控制；首次写入必然迁移。当前实现层保留一个恢复行为开关，默认关闭：
 
 | 环境变量 | 当前语义 | 为什么默认关闭 |
 | --- | --- | --- |
-| `MAKA_RUNTIME_SQLITE_CANONICAL=1` | 触发当前 workspace 迁移到 SQLite canonical；`runtime.sqlite` 一旦存在便 sticky | 它是不可通过关闭 flag 回退的数据迁移；自动备份和有存量数据的 v2→v4 升级测试尚未补齐 |
 | `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` | 开启 Desktop 中断横幅“安全恢复”、CLI/TUI `/resume` 与 Desktop 启动自动续跑 | 会产生用户可见行为，并可能自动调用 provider、消耗 token；后续应拆分手动与自动开关，先灰度手动路径 |
 
 当前 Phase 2 已知限制（不阻断写侧地基评审）：
@@ -1180,7 +1179,7 @@ runtimeFileReconcile
 发布顺序：
 
 1. shadow import/read，对比 SQLite projection 与 JSONL；
-2. 测试环境切 SQLite canonical；
+2. 测试环境验证 SQLite canonical；
 3. 内部 workspace 灰度；
 4. safe-boundary resume；
 5. 文件 reconcile；

--- a/packages/cli/src/inspect-command.ts
+++ b/packages/cli/src/inspect-command.ts
@@ -248,9 +248,13 @@ export async function withInspectCommandStores<T>(
   const capability = await discoverMarkedStorageRoot({ path: storageRoot });
   if (capability.kind === 'headless') {
     const storage = await openHeadlessStorageForRead(capability);
-    return operation(
-      inspectStoresFromExecutionReader(storage.executionStores, storage.taskRunStore),
-    );
+    try {
+      return await operation(
+        inspectStoresFromExecutionReader(storage.executionStores, storage.taskRunStore),
+      );
+    } finally {
+      await storage.executionStores.sessionStore.close?.();
+    }
   }
 
   const reader = await tryAcquireInteractiveRootReader(capability);
@@ -262,7 +266,11 @@ export async function withInspectCommandStores<T>(
   }
   try {
     const executionStores = await openInteractiveExecutionStoresForRead(reader.lease);
-    return await operation(inspectStoresFromExecutionReader(executionStores));
+    try {
+      return await operation(inspectStoresFromExecutionReader(executionStores));
+    } finally {
+      await executionStores.sessionStore.close?.();
+    }
   } finally {
     await reader.close();
   }

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -225,10 +225,6 @@ export async function createMakaCliRuntimeContext(
   const runStore = createAgentRunStore(stateRoot);
   const runtimePersistence = await openRuntimeEventPersistence({
     workspaceRoot: stateRoot,
-    // Graph execution can dispatch durable tools from both the supervisor and
-    // child agents. Those tool facts must cross the SQLite atomic boundary;
-    // the legacy JSONL event store intentionally rejects them.
-    sqliteCanonical: agentGraphEnabled || process.env.MAKA_RUNTIME_SQLITE_CANONICAL === '1',
   });
   const runtimeEventStore = runtimePersistence.runtimeEventStore;
   const shellRunStore = createShellRunStore(stateRoot);

--- a/packages/headless/src/__tests__/runner.test.ts
+++ b/packages/headless/src/__tests__/runner.test.ts
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
@@ -15,7 +15,7 @@ import {
 import type { BackendKind, SessionEvent, SessionHeader } from '@maka/core';
 import type { BackendSendInput } from '@maka/core/backend-types';
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
-import { createSessionStore } from '@maka/storage';
+import { createSessionStore, openRuntimeEventReadPersistence } from '@maka/storage';
 import type { Config, Task } from '../contracts.js';
 import type { HeadlessBackendContext } from '../isolation.js';
 import { runExperiment } from '../runner.js';
@@ -203,18 +203,6 @@ const piConfig: Config = {
   model: 'pi-test',
 };
 
-async function fileExistsRecursive(root: string, name: string): Promise<boolean> {
-  for (const entry of await readdir(root, { withFileTypes: true })) {
-    const full = join(root, entry.name);
-    if (entry.isDirectory()) {
-      if (await fileExistsRecursive(full, name)) return true;
-    } else if (entry.name === name) {
-      return true;
-    }
-  }
-  return false;
-}
-
 async function withDirs<T>(
   fn: (fixtureDir: string, storageRoot: string) => Promise<T>,
 ): Promise<T> {
@@ -254,11 +242,24 @@ describe('runExperiment (walking skeleton)', () => {
       assert.equal(result.agentSwarmAuthorization, 'none');
       // The agent run produced a trajectory...
       assert.ok(result.steps > 0, 'expected a non-empty trajectory');
-      // ...persisted as the canonical runtime-events.jsonl.
-      assert.ok(
-        await fileExistsRecursive(storageRoot, 'runtime-events.jsonl'),
-        'expected runtime-events.jsonl under the storage root',
-      );
+      // ...persisted in the canonical SQLite RuntimeEvent ledger.
+      const runtimePersistence = await openRuntimeEventReadPersistence({
+        workspaceRoot: storageRoot,
+      });
+      try {
+        assert.equal(runtimePersistence.kind, 'sqlite');
+        assert.ok(
+          (
+            await runtimePersistence.runtimeEventStore.readRuntimeEvents(
+              result.sessionId,
+              result.runId,
+            )
+          ).length > 0,
+          'expected RuntimeEvents in runtime.sqlite',
+        );
+      } finally {
+        runtimePersistence.close();
+      }
     });
   });
 

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -21,7 +21,7 @@ import {
 } from '@maka/core';
 import type { BackendSendInput } from '@maka/core/backend-types';
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
-import { createSessionStore } from '@maka/storage';
+import { createSessionStore, openRuntimeEventReadPersistence } from '@maka/storage';
 import { StorageRootAuthorityError } from '@maka/storage/root-authority';
 import type { Config, Task } from '../contracts.js';
 import { openHeadlessStorageForWrite } from '../headless-storage.js';
@@ -640,15 +640,17 @@ class ProgressToolBackend implements AgentBackend {
     assert.ok(todoUpdate);
     assert.ok(selfCheckPlanSubmit);
     assert.ok(selfCheckSubmit);
+    const bashToolCallId = `bash-tool-call-${input.turnId}`;
+    const progressToolCallId = `progress-tool-call-${input.turnId}`;
     const toolCtx = {
       sessionId: this.sessionId,
       turnId: input.turnId,
       cwd: this.ctx.header.cwd,
-      toolCallId: 'progress-tool-call',
+      toolCallId: progressToolCallId,
       abortSignal: new AbortController().signal,
       emitOutput: () => {},
     };
-    await bash.impl({ command: 'npm test' }, { ...toolCtx, toolCallId: 'bash-tool-call' });
+    await bash.impl({ command: 'npm test' }, { ...toolCtx, toolCallId: bashToolCallId });
     await inventorySubmit.impl(
       {
         summary: 'Inspected public files.',
@@ -715,43 +717,43 @@ class ProgressToolBackend implements AgentBackend {
     const ts = Date.now();
     yield {
       type: 'tool_start',
-      id: 'progress-bash-start',
+      id: `progress-bash-start-${input.turnId}`,
       turnId: input.turnId,
       ts,
-      toolUseId: 'bash-tool-call',
+      toolUseId: bashToolCallId,
       toolName: 'Bash',
       args: { command: 'npm test' },
     };
     yield {
       type: 'tool_result',
-      id: 'progress-bash-result',
+      id: `progress-bash-result-${input.turnId}`,
       turnId: input.turnId,
       ts,
-      toolUseId: 'bash-tool-call',
+      toolUseId: bashToolCallId,
       isError: false,
       content: { kind: 'text', text: 'tests passed' },
     };
     yield {
       type: 'tool_start',
-      id: 'progress-self-check-start',
+      id: `progress-self-check-start-${input.turnId}`,
       turnId: input.turnId,
       ts,
-      toolUseId: 'progress-tool-call',
+      toolUseId: progressToolCallId,
       toolName: 'self_check_submit',
       args: { status: 'pass' },
     };
     yield {
       type: 'tool_result',
-      id: 'progress-self-check-result',
+      id: `progress-self-check-result-${input.turnId}`,
       turnId: input.turnId,
       ts,
-      toolUseId: 'progress-tool-call',
+      toolUseId: progressToolCallId,
       isError: false,
       content: { kind: 'text', text: 'self-check accepted' },
     };
     yield {
       type: 'complete',
-      id: 'progress-complete',
+      id: `progress-complete-${input.turnId}`,
       turnId: input.turnId,
       ts,
       stopReason: 'end_turn',
@@ -1142,20 +1144,15 @@ async function readRuntimeEventLedger(
   sessionId: string,
   runId: string,
 ): Promise<RuntimeEvent[]> {
-  const runtimeEventsPath = join(
-    storageRoot,
-    'sessions',
-    sessionId,
-    'runs',
-    runId,
-    'runtime-events.jsonl',
-  );
-  const content = await readFile(runtimeEventsPath, 'utf8');
-  return content
-    .trim()
-    .split('\n')
-    .filter(Boolean)
-    .map((line) => JSON.parse(line) as RuntimeEvent);
+  const runtimePersistence = await openRuntimeEventReadPersistence({
+    workspaceRoot: storageRoot,
+  });
+  try {
+    assert.equal(runtimePersistence.kind, 'sqlite');
+    return await runtimePersistence.runtimeEventStore.readRuntimeEvents(sessionId, runId);
+  } finally {
+    runtimePersistence.close();
+  }
 }
 
 async function readAgentRunHeader(
@@ -2730,17 +2727,13 @@ describe('runTaskOnce', () => {
         feedback.details.artifactRefs,
       );
 
-      const runtimeEventsPath = join(
+      const runtimeEvents = await readRuntimeEventLedger(
         storageRoot,
-        'sessions',
         latestInvocation(result).sessionId,
-        'runs',
         latestInvocation(result).runId,
-        'runtime-events.jsonl',
       );
-      const runtimeEvents = await readFile(runtimeEventsPath, 'utf8');
-      assert.match(runtimeEvents, /report-usage/);
-      assert.match(runtimeEvents, /report-artifact/);
+      assert.ok(runtimeEvents.some((event) => event.id === 'report-usage'));
+      assert.ok(runtimeEvents.some((event) => event.id === 'report-artifact'));
     });
   });
 

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -1063,7 +1063,7 @@ test('startup recovery rejects claimed graph Run lineage drift', async () => {
   });
 });
 
-test('startup recovery repairs a truncated RuntimeEvent tail before terminalizing the Run', async () => {
+test('startup recovery imports past a truncated legacy RuntimeEvent tail without rewriting it', async () => {
   await withExecutionRoot(async (fixture) => {
     const turnId = randomUUID();
     const { runId } = await fixture.seedRunWithoutUserMessage(
@@ -1086,9 +1086,7 @@ test('startup recovery repairs a truncated RuntimeEvent tail before terminalizin
     await client.close();
     await fixture.stopHost(host);
 
-    const bytes = await readFile(runtimeEventsPath, 'utf8');
-    assert.doesNotMatch(bytes, /truncated/);
-    assertJsonLines(bytes);
+    assert.equal(await readFile(runtimeEventsPath, 'utf8'), '{"id":"truncated"');
     const ledger = await fixture.readTurn(turnId);
     assert.equal(ledger.terminalEvents.length, 1);
   });

--- a/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/root-turn-coordinator.test.ts
@@ -717,8 +717,8 @@ test('successor admission failure retains the terminal transition and its confir
   let backend: LinkedChildAuthorityBackend | undefined;
   const fixture = await createFailureFixture({
     registerBackend: (backends) => {
-      backends.register('fake', () => {
-        backend = new LinkedChildAuthorityBackend('terminal-admission-failure');
+      backends.register('fake', (context) => {
+        backend = new LinkedChildAuthorityBackend(context.sessionId);
         return backend;
       });
     },

--- a/packages/storage/src/__tests__/execution-stores.test.ts
+++ b/packages/storage/src/__tests__/execution-stores.test.ts
@@ -23,6 +23,7 @@ import {
 } from '@maka/core';
 import {
   createAgentRunStore,
+  createRuntimeEventStore,
   ROOT_TURN_ADMISSION_MAX_CONTENT_BYTES,
   ROOT_TURN_ADMISSION_MAX_RECORD_BYTES,
   ROOT_TURN_ADMISSION_SCHEMA_VERSION,
@@ -109,6 +110,62 @@ describe('execution stores', () => {
         );
       } finally {
         await owner.close();
+      }
+    });
+  });
+
+  test('routes Headless RuntimeEvents through SQLite after importing legacy JSONL once', async () => {
+    await withRoot(async ({ root }) => {
+      const capability = await resolveStorageRoot({
+        path: root,
+        kind: 'headless',
+      });
+      const sessionId = 'legacy-session';
+      const runId = 'legacy-run';
+      await createAgentRunStore(root).createRun(runHeader(sessionId, runId));
+      const legacy = createRuntimeEventStore(root);
+      await legacy.appendRuntimeEvent(
+        sessionId,
+        runId,
+        runtimeEvent(sessionId, runId, 'legacy-event', 1),
+      );
+      const legacyPath = join(root, 'sessions', sessionId, 'runs', runId, 'runtime-events.jsonl');
+      const legacyBytes = await readFile(legacyPath);
+
+      const writer = await openHeadlessExecutionStoresForWrite(
+        createHeadlessRootLease(capability, 'write'),
+      );
+      try {
+        assert.deepEqual(
+          (await writer.runtimeEventStore.readRuntimeEvents(sessionId, runId)).map(
+            (event) => event.id,
+          ),
+          ['legacy-event'],
+        );
+        await writer.runtimeEventStore.appendRuntimeEvent(
+          sessionId,
+          runId,
+          runtimeEvent(sessionId, runId, 'sqlite-event', 2),
+        );
+
+        const reader = await openHeadlessExecutionStoresForRead(
+          createHeadlessRootLease(capability, 'read'),
+        );
+        try {
+          assert.deepEqual(
+            (await reader.runtimeEventStore.readRuntimeEvents(sessionId, runId)).map(
+              (event) => event.id,
+            ),
+            ['legacy-event', 'sqlite-event'],
+          );
+        } finally {
+          await reader.sessionStore.close?.();
+        }
+
+        assert.ok((await stat(join(root, 'runtime.sqlite'))).isFile());
+        assert.deepEqual(await readFile(legacyPath), legacyBytes);
+      } finally {
+        await writer.sessionStore.close?.();
       }
     });
   });
@@ -1291,7 +1348,7 @@ describe('execution stores', () => {
     });
   });
 
-  test('repairs only an unterminated JSONL tail before the next durable append', async () => {
+  test('repairs JSONL stores without rewriting the retired RuntimeEvent JSONL', async () => {
     await withRoot(async ({ root }) => {
       const capability = await resolveStorageRoot({
         path: root,
@@ -1364,6 +1421,7 @@ describe('execution stores', () => {
           ),
           ['runtime-1'],
         );
+        assert.equal(await readFile(runtimeEventsPath, 'utf8'), '{"id":"truncated"');
         const steering = {
           ...runtimeEvent(session.id, header.runId, 'runtime-steering', 16),
           content: { kind: 'text' as const, text: 'steer', steering: true as const },
@@ -1376,22 +1434,6 @@ describe('execution stores', () => {
             'message-steering',
           ),
           { event: steering },
-        );
-        const steeringProofPath = join(
-          root,
-          'sessions',
-          session.id,
-          'message-proofs',
-          'steering',
-          'message-steering.json',
-        );
-        await rm(steeringProofPath);
-        assert.equal(
-          await stores.runtimeEventStore.readImmutableSteeringMessageProof(
-            session.id,
-            'message-steering',
-          ),
-          undefined,
         );
         await stores.runtimeEventStore.repairImmutableSteeringMessageProofsForRecovery(session.id);
         assert.deepEqual(
@@ -1409,10 +1451,11 @@ describe('execution stores', () => {
           undefined,
         );
 
-        for (const path of [sessionPath, eventsPath, runtimeEventsPath]) {
+        for (const path of [sessionPath, eventsPath]) {
           const lines = (await readFile(path, 'utf8')).split('\n').filter(Boolean);
           for (const line of lines) assert.doesNotThrow(() => JSON.parse(line));
         }
+        assert.equal(await readFile(runtimeEventsPath, 'utf8'), '{"id":"truncated"');
       } finally {
         await owner.close();
       }

--- a/packages/storage/src/__tests__/runtime-event-transfer.test.ts
+++ b/packages/storage/src/__tests__/runtime-event-transfer.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { appendFile, mkdtemp, rm } from 'node:fs/promises';
+import { appendFile, mkdtemp, readFile, rm, stat } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, it } from 'node:test';
@@ -11,6 +11,7 @@ import {
   importLegacyRuntimeEventJsonlTree,
   importRuntimeEventsFromJsonl,
   openRuntimeEventPersistence,
+  openRuntimeEventReadPersistence,
 } from '../runtime-event-transfer.js';
 
 describe('runtime event JSONL compatibility transfer', () => {
@@ -212,16 +213,64 @@ describe('runtime event JSONL compatibility transfer', () => {
     }
   });
 
-  it('selects exactly one canonical writer and imports before returning SQLite mode', async () => {
+  it('imports the stable prefix of a crash-truncated legacy tail without rewriting it', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-runtime-truncated-import-'));
+    const sqlite = createSqliteRuntimeStore(join(root, 'runtime.sqlite'));
+    const sourcePath = join(root, 'sessions', 'session-1', 'runs', 'run-1', 'runtime-events.jsonl');
+    try {
+      await createAgentRunStore(root).createRun(runHeader());
+      const legacy = createRuntimeEventStore(root);
+      await legacy.appendRuntimeEvent('session-1', 'run-1', runtimeEvent('event-1'));
+      await appendFile(sourcePath, '{"id":"truncated"', 'utf8');
+      const before = await readFile(sourcePath);
+
+      const report = await importLegacyRuntimeEventJsonlTree({
+        workspaceRoot: root,
+        destination: sqlite,
+      });
+
+      assert.deepEqual(report, {
+        filesScanned: 1,
+        eventsRead: 1,
+        eventsImported: 1,
+        eventsExisting: 0,
+      });
+      assert.deepEqual(
+        (await sqlite.readImmutableRuntimeEvents('session-1', 'run-1')).map((event) => event.id),
+        ['event-1'],
+      );
+      assert.deepEqual(await readFile(sourcePath), before);
+
+      await appendFile(sourcePath, '\n', 'utf8');
+      await assert.rejects(
+        importLegacyRuntimeEventJsonlTree({ workspaceRoot: root, destination: sqlite }),
+        /Invalid legacy RuntimeEvent JSONL line 2/,
+      );
+    } finally {
+      sqlite.close();
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('always selects the SQLite writer, imports first, and leaves legacy JSONL unchanged', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-runtime-persistence-'));
     const legacy = createRuntimeEventStore(root);
     try {
       await createAgentRunStore(root).createRun(runHeader());
       await legacy.appendRuntimeEvent('session-1', 'run-1', runtimeEvent('event-1'));
+      const legacyPath = join(
+        root,
+        'sessions',
+        'session-1',
+        'runs',
+        'run-1',
+        'runtime-events.jsonl',
+      );
+      const legacyBytes = await readFile(legacyPath);
+      const legacyMtime = (await stat(legacyPath)).mtimeMs;
 
       const opened = await openRuntimeEventPersistence({
         workspaceRoot: root,
-        sqliteCanonical: true,
       });
       try {
         assert.equal(opened.kind, 'sqlite');
@@ -242,30 +291,87 @@ describe('runtime event JSONL compatibility transfer', () => {
       } finally {
         opened.close();
       }
+      assert.deepEqual(await readFile(legacyPath), legacyBytes);
+      assert.equal((await stat(legacyPath)).mtimeMs, legacyMtime);
 
-      const stickyCanonical = await openRuntimeEventPersistence({
+      const reopened = await openRuntimeEventPersistence({
         workspaceRoot: root,
-        sqliteCanonical: false,
       });
       try {
-        assert.equal(stickyCanonical.kind, 'sqlite');
+        assert.equal(reopened.kind, 'sqlite');
         assert.deepEqual(
-          (await stickyCanonical.runtimeEventStore.readRuntimeEvents('session-1', 'run-1')).map(
+          (await reopened.runtimeEventStore.readRuntimeEvents('session-1', 'run-1')).map(
             (event) => event.id,
           ),
           ['event-1', 'sqlite-only-event'],
         );
       } finally {
-        stickyCanonical.close();
+        reopened.close();
       }
 
-      const legacyOnly = await openRuntimeEventPersistence({
+      const fresh = await openRuntimeEventPersistence({
         workspaceRoot: join(root, 'legacy-only'),
-        sqliteCanonical: false,
       });
-      assert.equal(legacyOnly.kind, 'jsonl');
-      assert.equal(legacyOnly.runtimeCommitStore, undefined);
-      legacyOnly.close();
+      assert.equal(fresh.kind, 'sqlite');
+      assert.strictEqual(fresh.runtimeEventStore, fresh.runtimeCommitStore);
+      fresh.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('keeps legacy-only roots read-only until a writer performs the canonical import', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-runtime-reader-'));
+    try {
+      await createAgentRunStore(root).createRun(runHeader());
+      const legacy = createRuntimeEventStore(root);
+      await legacy.appendRuntimeEvent('session-1', 'run-1', runtimeEvent('event-1'));
+
+      const legacyReader = await openRuntimeEventReadPersistence({ workspaceRoot: root });
+      try {
+        assert.equal(legacyReader.kind, 'jsonl');
+        assert.deepEqual(
+          (await legacyReader.runtimeEventStore.readRuntimeEvents('session-1', 'run-1')).map(
+            (event) => event.id,
+          ),
+          ['event-1'],
+        );
+      } finally {
+        legacyReader.close();
+      }
+      await assert.rejects(stat(join(root, 'runtime.sqlite')), { code: 'ENOENT' });
+
+      const writer = await openRuntimeEventPersistence({ workspaceRoot: root });
+      try {
+        await writer.runtimeEventStore.appendRuntimeEvent(
+          'session-1',
+          'run-1',
+          runtimeEvent('event-2', { ts: 2 }),
+        );
+      } finally {
+        writer.close();
+      }
+
+      const sqliteReader = await openRuntimeEventReadPersistence({ workspaceRoot: root });
+      try {
+        assert.equal(sqliteReader.kind, 'sqlite');
+        assert.deepEqual(
+          (await sqliteReader.runtimeEventStore.readRuntimeEvents('session-1', 'run-1')).map(
+            (event) => event.id,
+          ),
+          ['event-1', 'event-2'],
+        );
+        await assert.rejects(
+          sqliteReader.runtimeEventStore.appendRuntimeEvent(
+            'session-1',
+            'run-1',
+            runtimeEvent('read-only-write', { ts: 3 }),
+          ),
+          /read-?only|readonly/u,
+        );
+      } finally {
+        sqliteReader.close();
+      }
     } finally {
       await rm(root, { recursive: true, force: true });
     }

--- a/packages/storage/src/__tests__/sqlite-runtime-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-runtime-store.test.ts
@@ -404,6 +404,41 @@ describe('SqliteRuntimeStore', () => {
       assert.equal((await store.readImmutableRuntimeEvents('session-1', 'run-1')).length, 3);
     });
   });
+
+  it('uses the immutable SQLite event as the steering-message recovery proof', async () => {
+    await withStore(async (store) => {
+      const steering = functionCallEvent({
+        id: 'steering-event-1',
+        content: { kind: 'text', text: 'steer', steering: true },
+        refs: { providerEventId: 'message-steering' },
+      });
+
+      await store.appendRuntimeEvent('session-1', 'run-1', steering, { durable: true });
+      await store.appendRuntimeEvent('session-1', 'run-1', steering, { durable: true });
+
+      assert.deepEqual(
+        await store.readImmutableSteeringMessageProof('session-1', 'message-steering'),
+        { event: steering },
+      );
+      await store.repairImmutableSteeringMessageProofsForRecovery('session-1');
+      await assert.rejects(
+        store.appendRuntimeEvent(
+          'session-1',
+          'run-2',
+          functionCallEvent({
+            id: 'steering-event-conflict',
+            invocationId: 'invocation-2',
+            runId: 'run-2',
+            turnId: 'turn-2',
+            content: { kind: 'text', text: 'different', steering: true },
+            refs: { providerEventId: 'message-steering' },
+          }),
+        ),
+        /Immutable steering message identity conflict: message-steering/,
+      );
+      assert.deepEqual(await store.readImmutableRuntimeEvents('session-1', 'run-2'), []);
+    });
+  });
 });
 
 type Store = ReturnType<typeof createSqliteRuntimeStore>;

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -20,6 +20,7 @@ import {
   decodeRuntimeEvent,
 } from './execution-record-codec.js';
 import { classifyJsonRecord } from './json-prefix.js';
+import { immutableSteeringMessageId } from './runtime-event-invariants.js';
 import { syncDirectory, syncDirectoryChain, syncFile } from './stable-storage.js';
 import { chainWrite } from './write-queue.js';
 import {
@@ -1410,17 +1411,6 @@ function completedPartialRuntimeStreamKey(event: RuntimeEvent): string | undefin
     identity = `tool:call:${event.refs.toolCallId}`;
   }
   return identity ? runtimePartialStreamKey(identity, event) : undefined;
-}
-
-function immutableSteeringMessageId(event: RuntimeEvent): string | undefined {
-  const messageId = event.refs?.providerEventId;
-  return event.partial === false &&
-    typeof messageId === 'string' &&
-    isSafeId(messageId) &&
-    event.content?.kind === 'text' &&
-    event.content.steering === true
-    ? messageId
-    : undefined;
 }
 
 function runtimePartialStreamKey(identity: string, event: RuntimeEvent): string {

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -11,7 +11,6 @@ import type {
 } from '@maka/core';
 import {
   createAgentRunStore,
-  createRuntimeEventStore,
   type AdmitRootTurnInput,
   type AdmitRootTurnResult,
   type DurableAgentRunStore,
@@ -34,12 +33,17 @@ import {
   type InteractiveInteractionStoreReaderFacade,
   type InteractiveInteractionStoreWriterFacade,
 } from './interaction-store.js';
+import {
+  openRuntimeEventPersistence,
+  openRuntimeEventReadPersistence,
+} from './runtime-event-transfer.js';
 
 const executionStoresWriterBrand: unique symbol = Symbol('ExecutionStoresWriter');
 const executionStoresReaderBrand: unique symbol = Symbol('ExecutionStoresReader');
 const executionStoresWriterKinds = new WeakMap<object, StorageRootKind>();
 const executionStoresReaderKinds = new WeakMap<object, StorageRootKind>();
 const executionStoresWritersByLease = new WeakMap<object, object>();
+const executionStoresWritersOpeningByLease = new WeakMap<object, Promise<void>>();
 
 export { normalizeRootTurnAdmissionPayload } from './agent-run-store.js';
 export { isSessionNotFoundError } from './session-store.js';
@@ -91,6 +95,7 @@ export interface ExecutionSessionReader {
   readHeader(sessionId: string): Promise<SessionHeader>;
   readMessages(sessionId: string): Promise<StoredMessage[]>;
   listTurns(sessionId: string): Promise<TurnRecord[]>;
+  close?(): Promise<void>;
 }
 
 export interface ExecutionAgentRunReader {
@@ -177,9 +182,39 @@ async function openExecutionStoresForWrite<K extends StorageRootKind, E extends 
   const existing = executionStoresWritersByLease.get(lease);
   if (existing) return existing as ExecutionStoresWriterBase<K> & E;
 
+  const opening = executionStoresWritersOpeningByLease.get(lease);
+  if (opening) {
+    await opening;
+    return openExecutionStoresForWrite(lease, kind, extension);
+  }
+
+  let releaseOpening!: () => void;
+  const openingGate = new Promise<void>((resolve) => {
+    releaseOpening = resolve;
+  });
+  executionStoresWritersOpeningByLease.set(lease, openingGate);
+  try {
+    return await createExecutionStoresForWrite(lease, kind, extension);
+  } finally {
+    executionStoresWritersOpeningByLease.delete(lease);
+    releaseOpening();
+  }
+}
+
+async function createExecutionStoresForWrite<K extends StorageRootKind, E extends object>(
+  lease: StorageRootLease<K, 'write'>,
+  kind: K,
+  extension: E,
+): Promise<ExecutionStoresWriterBase<K> & E> {
   const sessionStore = createSessionStore(lease.canonicalPath);
   const agentRunStore = createAgentRunStore(lease.canonicalPath);
-  const runtimeEventStore = createRuntimeEventStore(lease.canonicalPath);
+  const runtimePersistence = await openRuntimeEventPersistence({
+    workspaceRoot: lease.canonicalPath,
+  }).catch(async (error) => {
+    await sessionStore.close?.().catch(() => {});
+    throw error;
+  });
+  const runtimeEventStore = runtimePersistence.runtimeEventStore;
   const messageReceiptStore = createMessageReceiptStore(lease.canonicalPath);
   const run = <T>(operation: () => Promise<T>) =>
     runWithStorageRootLease(lease, kind, 'write', operation);
@@ -234,9 +269,7 @@ async function openExecutionStoresForWrite<K extends StorageRootKind, E extends 
       setGeneratedTitleIfAbsent: (sessionId, title) =>
         run(() => sessionStore.setGeneratedTitleIfAbsent(sessionId, title)),
       remove: (sessionId) => run(() => sessionStore.remove(sessionId)),
-      close: async () => {
-        await sessionStore.close?.();
-      },
+      close: () => closeExecutionStorePersistence(sessionStore, runtimePersistence),
     },
     agentRunStore: {
       createRun: (header, options) => run(() => agentRunStore.createRun(header, options)),
@@ -267,6 +300,7 @@ async function openExecutionStoresForWrite<K extends StorageRootKind, E extends 
         run(() => agentRunStore.listRootTurnAdmissionsForRecovery(sessionId)),
     },
     runtimeEventStore: {
+      durability: runtimeEventStore.durability,
       appendRuntimeEvent: (sessionId, runId, event, options) =>
         run(() => runtimeEventStore.appendRuntimeEvent(sessionId, runId, event, options)),
       ensureTerminalRuntimeEventDurable: (sessionId, runId, event) =>
@@ -319,7 +353,13 @@ async function openExecutionStoresForRead<K extends StorageRootKind, E extends o
   await assertStorageRootLease(lease, kind, 'read');
   const sessionStore = createSessionStore(lease.canonicalPath);
   const agentRunStore = createAgentRunStore(lease.canonicalPath);
-  const runtimeEventStore = createRuntimeEventStore(lease.canonicalPath);
+  const runtimePersistence = await openRuntimeEventReadPersistence({
+    workspaceRoot: lease.canonicalPath,
+  }).catch(async (error) => {
+    await sessionStore.close?.().catch(() => {});
+    throw error;
+  });
+  const runtimeEventStore = runtimePersistence.runtimeEventStore;
   const run = <T>(operation: () => Promise<T>) =>
     runWithStorageRootLease(lease, kind, 'read', operation);
 
@@ -332,6 +372,7 @@ async function openExecutionStoresForRead<K extends StorageRootKind, E extends o
       readHeader: (sessionId) => run(() => sessionStore.readHeaderSnapshot(sessionId)),
       readMessages: (sessionId) => run(() => sessionStore.readMessagesSnapshot(sessionId)),
       listTurns: (sessionId) => run(() => sessionStore.listTurnsSnapshot(sessionId)),
+      close: () => closeExecutionStorePersistence(sessionStore, runtimePersistence),
     },
     agentRunStore: {
       readRun: (sessionId, runId) => run(() => agentRunStore.readRun(sessionId, runId)),
@@ -369,6 +410,26 @@ function freezeExecutionStoresFacade(stores: {
   Object.freeze(stores.runtimeEventStore);
   if (stores.messageReceiptStore) Object.freeze(stores.messageReceiptStore);
   Object.freeze(stores);
+}
+
+async function closeExecutionStorePersistence(
+  sessionStore: Pick<SessionStore, 'close'>,
+  runtimePersistence: { close(): void },
+): Promise<void> {
+  const errors: unknown[] = [];
+  try {
+    runtimePersistence.close();
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    await sessionStore.close?.();
+  } catch (error) {
+    errors.push(error);
+  }
+  if (errors.length > 0) {
+    throw new AggregateError(errors, 'Unable to close execution store persistence');
+  }
 }
 
 function invalidExecutionStores(

--- a/packages/storage/src/runtime-event-invariants.ts
+++ b/packages/storage/src/runtime-event-invariants.ts
@@ -1,0 +1,18 @@
+import type { RuntimeEvent } from '@maka/core';
+
+const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
+
+export function isRuntimeStorageSafeId(value: string): boolean {
+  return SAFE_ID_PATTERN.test(value);
+}
+
+export function immutableSteeringMessageId(event: RuntimeEvent): string | undefined {
+  const messageId = event.refs?.providerEventId;
+  return event.partial === false &&
+    typeof messageId === 'string' &&
+    isRuntimeStorageSafeId(messageId) &&
+    event.content?.kind === 'text' &&
+    event.content.steering === true
+    ? messageId
+    : undefined;
+}

--- a/packages/storage/src/runtime-event-transfer.ts
+++ b/packages/storage/src/runtime-event-transfer.ts
@@ -1,7 +1,8 @@
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
 import { decodePersistedRuntimeEvent, type RuntimeEvent, type RuntimeEventStore } from '@maka/core';
-import { createRuntimeEventStore } from './agent-run-store.js';
+import { createRuntimeEventStore, type DurableRuntimeEventStore } from './agent-run-store.js';
+import { classifyJsonRecord } from './json-prefix.js';
 import type { SqliteRuntimeStore } from './sqlite-runtime-store.js';
 import { createSqliteRuntimeStore } from './sqlite-runtime-store.js';
 
@@ -9,10 +10,16 @@ export const SQLITE_RUNTIME_DATABASE_NAME = 'runtime.sqlite';
 const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 
 export type RuntimeEventPersistence = {
-  kind: 'jsonl' | 'sqlite';
-  runtimeEventStore: RuntimeEventStore;
-  runtimeCommitStore?: SqliteRuntimeStore;
+  kind: 'sqlite';
+  runtimeEventStore: SqliteRuntimeStore;
+  runtimeCommitStore: SqliteRuntimeStore;
   importReport?: LegacyRuntimeEventImportReport;
+  close(): void;
+};
+
+export type RuntimeEventReadPersistence = {
+  kind: 'jsonl' | 'sqlite';
+  runtimeEventStore: DurableRuntimeEventStore;
   close(): void;
 };
 
@@ -28,16 +35,8 @@ export interface LegacyRuntimeEventImportReport extends RuntimeEventImportReport
 
 export async function openRuntimeEventPersistence(input: {
   workspaceRoot: string;
-  sqliteCanonical: boolean;
 }): Promise<RuntimeEventPersistence> {
   const databasePath = join(input.workspaceRoot, SQLITE_RUNTIME_DATABASE_NAME);
-  if (!input.sqliteCanonical && !(await pathExists(databasePath))) {
-    return {
-      kind: 'jsonl',
-      runtimeEventStore: createRuntimeEventStore(input.workspaceRoot),
-      close: () => {},
-    };
-  }
   const store = createSqliteRuntimeStore(databasePath);
   try {
     const importReport = await importLegacyRuntimeEventJsonlTree({
@@ -55,6 +54,32 @@ export async function openRuntimeEventPersistence(input: {
     store.close();
     throw error;
   }
+}
+
+/**
+ * Open the canonical RuntimeEvent read model without mutating the storage root.
+ *
+ * A legacy-only root remains readable until a writer performs the one-way
+ * import. Once runtime.sqlite exists, readers never merge or fall back to
+ * JSONL, so SQLite-only facts cannot disappear behind a stale file projection.
+ */
+export async function openRuntimeEventReadPersistence(input: {
+  workspaceRoot: string;
+}): Promise<RuntimeEventReadPersistence> {
+  const databasePath = join(input.workspaceRoot, SQLITE_RUNTIME_DATABASE_NAME);
+  if (!(await pathExists(databasePath))) {
+    return {
+      kind: 'jsonl',
+      runtimeEventStore: createRuntimeEventStore(input.workspaceRoot),
+      close: () => {},
+    };
+  }
+  const store = createSqliteRuntimeStore(databasePath, { readOnly: true });
+  return {
+    kind: 'sqlite',
+    runtimeEventStore: store,
+    close: () => store.close(),
+  };
 }
 
 async function pathExists(path: string): Promise<boolean> {
@@ -182,6 +207,14 @@ function parseLegacyRuntimeEventJsonl(
 ): RuntimeEvent[] {
   const events: RuntimeEvent[] = [];
   const lines = jsonl.split('\n');
+  let lastNonEmptyIndex = -1;
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    if (lines[index]?.trim()) {
+      lastNonEmptyIndex = index;
+      break;
+    }
+  }
+  const endsWithNewline = jsonl.endsWith('\n');
   for (let index = 0; index < lines.length; index += 1) {
     const line = lines[index];
     if (!line?.trim()) continue;
@@ -191,6 +224,13 @@ function parseLegacyRuntimeEventJsonl(
       if (isLegacyStreamPartialSnapshot(parsed)) continue;
       event = decodePersistedRuntimeEvent(parsed);
     } catch (error) {
+      if (
+        !endsWithNewline &&
+        index === lastNonEmptyIndex &&
+        classifyJsonRecord(line) === 'incomplete-prefix'
+      ) {
+        continue;
+      }
       throw new Error(`Invalid legacy RuntimeEvent JSONL line ${index + 1} for run ${runId}`, {
         cause: error,
       });

--- a/packages/storage/src/sqlite-runtime-store.ts
+++ b/packages/storage/src/sqlite-runtime-store.ts
@@ -31,7 +31,10 @@ import {
   readUserVersion,
   RUNTIME_RECOVERY_AUTHORITY_CAPABILITY,
   RUNTIME_RECOVERY_AUTHORITY_CAPABILITY_VERSION,
+  SQLITE_RUNTIME_SCHEMA_VERSION,
 } from './sqlite-runtime-schema.js';
+import type { ImmutableSteeringMessageProof } from './agent-run-store.js';
+import { immutableSteeringMessageId, isRuntimeStorageSafeId } from './runtime-event-invariants.js';
 
 export { SQLITE_RUNTIME_SCHEMA_VERSION } from './sqlite-runtime-schema.js';
 
@@ -41,6 +44,12 @@ const require = createRequire(import.meta.url);
 
 function loadDatabaseSync(): typeof import('node:sqlite').DatabaseSync {
   return (require('node:sqlite') as typeof import('node:sqlite')).DatabaseSync;
+}
+
+function configureSqliteRuntimeReadOnlyDatabase(db: DatabaseSync): void {
+  db.exec('PRAGMA busy_timeout = 5000');
+  db.exec('PRAGMA foreign_keys = ON');
+  db.exec('PRAGMA query_only = ON');
 }
 
 export type ToolJournalState =
@@ -59,6 +68,7 @@ export type SqliteRuntimeStoreFailpoint =
 
 export interface SqliteRuntimeStoreOptions {
   failpoint?: (point: SqliteRuntimeStoreFailpoint) => void;
+  readOnly?: boolean;
 }
 
 export interface CommitToolPreparedInput {
@@ -144,12 +154,24 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     path: string,
     private readonly options: SqliteRuntimeStoreOptions = {},
   ) {
-    if (path !== ':memory:') mkdirSync(dirname(path), { recursive: true });
+    if (path !== ':memory:' && !options.readOnly) mkdirSync(dirname(path), { recursive: true });
     const DatabaseSync = loadDatabaseSync();
-    this.db = new DatabaseSync(path);
+    this.db = options.readOnly
+      ? new DatabaseSync(path, { readOnly: true })
+      : new DatabaseSync(path);
     try {
-      configureSqliteRuntimeDatabase(this.db);
-      migrateSqliteRuntimeDatabase(this.db);
+      if (options.readOnly) {
+        configureSqliteRuntimeReadOnlyDatabase(this.db);
+        const version = readUserVersion(this.db);
+        if (version !== SQLITE_RUNTIME_SCHEMA_VERSION) {
+          throw new Error(
+            `SQLite runtime schema ${version} cannot be read without upgrading to ${SQLITE_RUNTIME_SCHEMA_VERSION}`,
+          );
+        }
+      } else {
+        configureSqliteRuntimeDatabase(this.db);
+        migrateSqliteRuntimeDatabase(this.db);
+      }
       assertRecoveryAuthorityCapability(this.db);
     } catch (error) {
       this.db.close();
@@ -182,7 +204,12 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     this.db.close();
   }
 
-  async appendRuntimeEvent(sessionId: string, runId: string, event: RuntimeEvent): Promise<void> {
+  async appendRuntimeEvent(
+    sessionId: string,
+    runId: string,
+    event: RuntimeEvent,
+    _options: { durable?: boolean } = {},
+  ): Promise<void> {
     const canonicalEvent = canonicalizeRuntimeEventForStorage(event);
     assertNoReservedToolLedgerFact(canonicalEvent);
     await this.importRuntimeEvent(sessionId, runId, canonicalEvent);
@@ -330,6 +357,35 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     `)
       .all(sessionId, runId) as unknown as RuntimeEventStorageRow[];
     return rows.map(decodeRuntimeEventStorageRow);
+  }
+
+  async readImmutableSteeringMessageProof(
+    sessionId: string,
+    messageId: string,
+  ): Promise<ImmutableSteeringMessageProof | undefined> {
+    assertRuntimeStorageSafeId(sessionId, 'Invalid session id');
+    assertRuntimeStorageSafeId(messageId, 'Invalid message id');
+    const matches = this.readImmutableSessionRuntimeEvents(sessionId).filter(
+      (event) => immutableSteeringMessageId(event) === messageId,
+    );
+    if (matches.length > 1) {
+      throw new Error(`Immutable steering message identity conflict: ${messageId}`);
+    }
+    return matches[0] ? Object.freeze({ event: matches[0] }) : undefined;
+  }
+
+  async repairImmutableSteeringMessageProofsForRecovery(sessionId: string): Promise<void> {
+    assertRuntimeStorageSafeId(sessionId, 'Invalid session id');
+    const messages = new Map<string, RuntimeEvent>();
+    for (const event of this.readImmutableSessionRuntimeEvents(sessionId)) {
+      const messageId = immutableSteeringMessageId(event);
+      if (!messageId) continue;
+      const existing = messages.get(messageId);
+      if (existing && !isDeepStrictEqual(existing, event)) {
+        throw new Error(`Immutable steering message identity conflict: ${messageId}`);
+      }
+      messages.set(messageId, event);
+    }
   }
 
   async readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]> {
@@ -956,6 +1012,29 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     return !existing;
   }
 
+  private assertImmutableSteeringMessageIdentity(event: RuntimeEvent): void {
+    const messageId = immutableSteeringMessageId(event);
+    if (!messageId) return;
+    const matches = this.readImmutableSessionRuntimeEvents(event.sessionId).filter(
+      (candidate) => immutableSteeringMessageId(candidate) === messageId,
+    );
+    if (matches.some((candidate) => !isDeepStrictEqual(candidate, event))) {
+      throw new Error(`Immutable steering message identity conflict: ${messageId}`);
+    }
+  }
+
+  private readImmutableSessionRuntimeEvents(sessionId: string): RuntimeEvent[] {
+    const rows = this.db
+      .prepare(`
+      SELECT event_id, session_id, invocation_id, run_id, turn_id, payload_json
+      FROM runtime_events
+      WHERE session_id = ?
+      ORDER BY committed_at ASC, event_id ASC
+    `)
+      .all(sessionId) as unknown as RuntimeEventStorageRow[];
+    return rows.map(decodeRuntimeEventStorageRow);
+  }
+
   private insertRuntimeEvent(
     event: RuntimeEvent,
     committedAt: number,
@@ -965,6 +1044,7 @@ export class SqliteRuntimeStore implements RuntimeRecoveryBundleStore {
     const canonicalEvent = encoding.event;
     this.assertInvocationIdentity([canonicalEvent]);
     assertRuntimeEventIdentity(canonicalEvent);
+    this.assertImmutableSteeringMessageIdentity(canonicalEvent);
     const existingJson = this.readRuntimeEventJson(canonicalEvent.id);
     if (existingJson !== undefined) {
       assertStoredRuntimeEventEquals(canonicalEvent, existingJson);
@@ -1400,6 +1480,10 @@ function assertRecoveryAuthorityCapability(db: DatabaseSync): void {
       `SQLite runtime recovery capability ${RUNTIME_RECOVERY_AUTHORITY_CAPABILITY}@${RUNTIME_RECOVERY_AUTHORITY_CAPABILITY_VERSION} is unavailable`,
     );
   }
+}
+
+function assertRuntimeStorageSafeId(value: string, message: string): void {
+  if (!isRuntimeStorageSafeId(value)) throw new Error(message);
 }
 
 interface RuntimeEventStorageRow {


### PR DESCRIPTION
## Summary

- make `runtime.sqlite` the unconditional canonical RuntimeEvent writer for CLI, Desktop, Headless, and Runtime Host execution paths
- batch-import legacy RuntimeEvent JSONL idempotently on the first write-side open without rewriting legacy bytes; keep legacy-only roots available to read-only inspection until then
- preserve steering proof and recovery invariants, reject complete malformed records, and tolerate only a crash-truncated final JSONL prefix
- remove the obsolete `MAKA_RUNTIME_SQLITE_CANONICAL` switch and update the runtime recovery docs

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm test --workspace=@maka/storage` (812 passed, 1 skipped)
- `npm test --workspace=@maka/runtime-host`
- `npm test --workspace=maka-agent` (677 passed)
- `npm test --workspace=@maka/desktop` (2977 passed)

The repository-level `npm test` script tests passed except for the license-contract environment check, which reports pre-existing extraneous packages in the local `node_modules`; package-level affected suites above are green.

Refs #1649