### PR TITLE
fix(desktop): harden OS permission flows

### DIFF
--- a/apps/desktop/build/entitlements.mac.plist
+++ b/apps/desktop/build/entitlements.mac.plist
@@ -6,5 +6,7 @@
   <true/>
   <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
   <true/>
+  <key>com.apple.security.automation.apple-events</key>
+  <true/>
 </dict>
 </plist>

--- a/apps/desktop/src/main/__tests__/main-window-permission-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/main-window-permission-policy.test.ts
@@ -1,0 +1,158 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import type { WebContents } from 'electron';
+import {
+  allowsMainWindowPermissionCheck,
+  allowsMainWindowPermissionRequest,
+  installMainWindowPermissionPolicy,
+  matchesTrustedRendererUrl,
+} from '../main-window-permission-policy.js';
+
+describe('main window Chromium permission policy', () => {
+  it('allows only top-level microphone audio from the product renderer', () => {
+    assert.equal(allowsMainWindowPermissionCheck({
+      ownerMatches: true,
+      rendererUrlMatches: true,
+      permission: 'media',
+      isMainFrame: true,
+      mediaType: 'audio',
+    }), true);
+    assert.equal(allowsMainWindowPermissionRequest({
+      ownerMatches: true,
+      rendererUrlMatches: true,
+      permission: 'media',
+      isMainFrame: true,
+      mediaTypes: ['audio'],
+    }), true);
+  });
+
+  it('denies camera, mixed media, subframes, auxiliary windows, and unrelated permissions', () => {
+    assert.equal(allowsMainWindowPermissionCheck({
+      ownerMatches: true,
+      rendererUrlMatches: true,
+      permission: 'media',
+      isMainFrame: true,
+      mediaType: 'video',
+    }), false);
+    assert.equal(allowsMainWindowPermissionRequest({
+      ownerMatches: true,
+      rendererUrlMatches: true,
+      permission: 'media',
+      isMainFrame: true,
+      mediaTypes: ['audio', 'video'],
+    }), false);
+    assert.equal(allowsMainWindowPermissionRequest({
+      ownerMatches: true,
+      rendererUrlMatches: true,
+      permission: 'media',
+      isMainFrame: false,
+      mediaTypes: ['audio'],
+    }), false);
+    assert.equal(allowsMainWindowPermissionRequest({
+      ownerMatches: false,
+      rendererUrlMatches: true,
+      permission: 'media',
+      isMainFrame: true,
+      mediaTypes: ['audio'],
+    }), false);
+    assert.equal(allowsMainWindowPermissionRequest({
+      ownerMatches: true,
+      rendererUrlMatches: false,
+      permission: 'media',
+      isMainFrame: true,
+      mediaTypes: ['audio'],
+    }), false);
+    assert.equal(allowsMainWindowPermissionRequest({
+      ownerMatches: true,
+      rendererUrlMatches: true,
+      permission: 'notifications',
+      isMainFrame: true,
+    }), false);
+    assert.equal(allowsMainWindowPermissionRequest({
+      ownerMatches: true,
+      rendererUrlMatches: true,
+      permission: 'media',
+      isMainFrame: true,
+    }), false);
+  });
+
+  it('trusts the dev origin and exact packaged entry without trusting arbitrary files', () => {
+    assert.equal(
+      matchesTrustedRendererUrl('http://localhost:5173/settings', 'http://localhost:5173/'),
+      true,
+    );
+    assert.equal(
+      matchesTrustedRendererUrl('https://example.com/', 'http://localhost:5173/'),
+      false,
+    );
+    assert.equal(
+      matchesTrustedRendererUrl(
+        'file:///Applications/Maka.app/Contents/Resources/app.asar/apps/desktop/dist-renderer/index.html#settings',
+        'file:///Applications/Maka.app/Contents/Resources/app.asar/apps/desktop/dist-renderer/index.html',
+      ),
+      true,
+    );
+    assert.equal(
+      matchesTrustedRendererUrl(
+        'file:///Users/example/Downloads/untrusted.html',
+        'file:///Applications/Maka.app/Contents/Resources/app.asar/apps/desktop/dist-renderer/index.html',
+      ),
+      false,
+    );
+  });
+
+  it('installs both Electron handlers on the renderer session', () => {
+    type CheckHandler = (
+      requester: WebContents | null,
+      permission: string,
+      origin: string,
+      details: { isMainFrame: boolean; mediaType?: string; requestingUrl?: string },
+    ) => boolean;
+    type RequestHandler = (
+      requester: WebContents,
+      permission: string,
+      callback: (granted: boolean) => void,
+      details: {
+        isMainFrame: boolean;
+        mediaTypes?: Array<'audio' | 'video'>;
+        requestingUrl: string;
+      },
+    ) => void;
+    let checkHandler: CheckHandler | undefined;
+    let requestHandler: RequestHandler | undefined;
+    const session = {
+      setPermissionCheckHandler(handler: CheckHandler) {
+        checkHandler = handler;
+      },
+      setPermissionRequestHandler(handler: RequestHandler) {
+        requestHandler = handler;
+      },
+    };
+    const owner = { session } as unknown as WebContents;
+    const other = { session } as unknown as WebContents;
+
+    installMainWindowPermissionPolicy(owner, 'file:///Applications/Maka.app/index.html');
+    assert.ok(checkHandler);
+    assert.ok(requestHandler);
+    assert.equal(checkHandler(owner, 'media', 'file://', {
+      isMainFrame: true,
+      mediaType: 'audio',
+      requestingUrl: 'file:///Applications/Maka.app/index.html',
+    }), true);
+    assert.equal(checkHandler(other, 'media', 'file://', {
+      isMainFrame: true,
+      mediaType: 'audio',
+      requestingUrl: 'file:///Applications/Maka.app/index.html',
+    }), false);
+
+    let granted: boolean | undefined;
+    requestHandler(owner, 'media', (next) => {
+      granted = next;
+    }, {
+      isMainFrame: true,
+      mediaTypes: ['audio'],
+      requestingUrl: 'file:///Applications/Maka.app/index.html',
+    });
+    assert.equal(granted, true);
+  });
+});

--- a/apps/desktop/src/main/__tests__/os-permission-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/os-permission-policy.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  mapMediaAccessStatus,
+  mediaPermissionActions,
+  planPermissionRequest,
+  supportsMediaPermissionProbe,
+} from '../os-permission-policy.js';
+
+describe('OS permission platform policy', () => {
+  it('normalizes Electron media states without treating restrictions as requestable', () => {
+    assert.equal(mapMediaAccessStatus('granted'), 'granted');
+    assert.equal(mapMediaAccessStatus('not-determined'), 'not_determined');
+    assert.equal(mapMediaAccessStatus('denied'), 'denied');
+    assert.equal(mapMediaAccessStatus('restricted'), 'denied');
+    assert.equal(mapMediaAccessStatus('unexpected'), 'unknown');
+  });
+
+  it('only probes media statuses on platforms where Electron exposes them', () => {
+    assert.equal(supportsMediaPermissionProbe('screen_recording', 'darwin'), true);
+    assert.equal(supportsMediaPermissionProbe('screen_recording', 'win32'), false);
+    assert.equal(supportsMediaPermissionProbe('microphone', 'darwin'), true);
+    assert.equal(supportsMediaPermissionProbe('microphone', 'win32'), true);
+    assert.equal(supportsMediaPermissionProbe('microphone', 'linux'), false);
+  });
+
+  it('never advertises a request button that the main-process action cannot perform', () => {
+    assert.deepEqual(mediaPermissionActions({
+      id: 'microphone',
+      platform: 'darwin',
+      status: 'not_determined',
+    }), { canOpenSettings: true, canRequest: true });
+    assert.deepEqual(mediaPermissionActions({
+      id: 'microphone',
+      platform: 'win32',
+      status: 'not_determined',
+    }), { canOpenSettings: false, canRequest: false });
+    assert.deepEqual(mediaPermissionActions({
+      id: 'microphone',
+      platform: 'linux',
+      status: 'unsupported',
+    }), { canOpenSettings: false, canRequest: false });
+  });
+
+  it('routes stale denied requests to System Settings and never fakes notification success', () => {
+    assert.equal(planPermissionRequest({
+      id: 'microphone',
+      platform: 'darwin',
+      microphoneStatus: 'not-determined',
+    }), 'request_microphone');
+    assert.equal(planPermissionRequest({
+      id: 'microphone',
+      platform: 'darwin',
+      microphoneStatus: 'denied',
+    }), 'open_settings');
+    assert.equal(planPermissionRequest({
+      id: 'microphone',
+      platform: 'darwin',
+      microphoneStatus: 'restricted',
+    }), 'open_settings');
+    assert.equal(planPermissionRequest({
+      id: 'microphone',
+      platform: 'darwin',
+      microphoneStatus: 'unknown',
+    }), 'open_settings');
+    assert.equal(planPermissionRequest({
+      id: 'microphone',
+      platform: 'darwin',
+      microphoneStatus: 'granted',
+    }), 'already_granted');
+    assert.equal(planPermissionRequest({
+      id: 'notifications',
+      platform: 'darwin',
+    }), 'open_settings');
+    assert.equal(planPermissionRequest({
+      id: 'microphone',
+      platform: 'linux',
+    }), 'unsupported_platform');
+  });
+});

--- a/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
+++ b/apps/desktop/src/main/__tests__/permission-overlay-controller.test.ts
@@ -9,6 +9,8 @@
  */
 
 import { strict as assert } from 'node:assert';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
 import { describe, it } from 'node:test';
 import {
   GIVE_UP_MS,
@@ -132,8 +134,8 @@ describe('drag-to-grant permission overlay', () => {
   it('only recognises the two drag-to-grant permissions', () => {
     assert.equal(isDragGrantPermission('accessibility'), true);
     assert.equal(isDragGrantPermission('screen_recording'), true);
-    // Microphone and notifications have real programmatic consent dialogs;
-    // routing them through a drag card would be theatre.
+    // Microphone has a real consent dialog; notifications and Automation
+    // have ordinary System Settings rows. None belongs in a drag card.
     assert.equal(isDragGrantPermission('microphone'), false);
     assert.equal(isDragGrantPermission('notifications'), false);
     assert.equal(isDragGrantPermission('automation'), false);
@@ -292,6 +294,19 @@ describe('drag-to-grant permission overlay', () => {
 });
 
 describe('app bundle resolution for the drag', () => {
+  it('asks macOS for the bundle icon instead of trying to decode .icns directly', async () => {
+    const source = await readFile(
+      resolve(
+        process.cwd().endsWith('apps/desktop') ? process.cwd() : resolve(process.cwd(), 'apps/desktop'),
+        'src/main/permission-overlay/permission-overlay-main.ts',
+      ),
+      'utf8',
+    );
+    assert.match(source, /app\.getFileIcon\(bundlePath, \{ size: 'large' \}\)/);
+    assert.match(source, /app\.getFileIcon\(resolved\.bundlePath, \{ size: 'large' \}\)/);
+    assert.doesNotMatch(source, /nativeImage\.createFromPath\([^)]*\.icns/);
+  });
+
   it('walks three levels up from the executable to the .app', () => {
     assert.deepEqual(
       resolveAppBundle({

--- a/apps/desktop/src/main/__tests__/preload-bridge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/preload-bridge-contract.test.ts
@@ -28,7 +28,10 @@ describe('preload bridge contract', () => {
     assert.match(bridge, /export interface MakaBridge \{/);
     assert.match(bridge, /attachmentItems\?: RendererIngestInput\[\]/);
     assert.match(bridge, /export type PermissionActionResult =/);
-    assert.match(bridge, /reason: 'invalid_id' \| 'unsupported_platform' \| 'unsupported_permission' \| 'failed'/);
+    assert.match(
+      bridge,
+      /\| 'invalid_id'[\s\S]*\| 'unsupported_platform'[\s\S]*\| 'unsupported_permission'[\s\S]*\| 'open_settings_failed'[\s\S]*\| 'denied'[\s\S]*\| 'failed'/,
+    );
     assert.match(bridge, /openSystemSettings\(permId: string\): Promise<PermissionActionResult>/);
     assert.match(bridge, /requestAccess\(permId: string\): Promise<PermissionActionResult>/);
     assert.match(preload, /openSystemSettings\(permId: string\): Promise<PermissionActionResult>/);

--- a/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
@@ -281,7 +281,16 @@ describe('Settings coming-soon cleanup contract', () => {
       'Permission Center must release only the action it owns and avoid state writes after unmount',
     );
     assert.match(permissionPage, /busy=\{pendingPermAction !== null\}/);
-    assert.match(permissionPage, /pendingKey=\{pendingPermAction === `\$\{id\}:request` \? 'request'/);
+    assert.match(
+      permissionPage,
+      /pendingKey=\{[\s\S]*pendingPermAction === `\$\{id\}:request`[\s\S]*pendingPermAction === `\$\{id\}:dragGrant`[\s\S]*\? 'dragGrant'/,
+      'all three permission actions must expose their reachable pending label and aria-busy state',
+    );
+    assert.match(
+      permissionPage,
+      /window\.addEventListener\('focus', refreshAfterSystemSettings\)/,
+      'Permission Center must re-read TCC after the user returns from System Settings',
+    );
   });
 
   it('keeps bot readiness waiting states action-oriented', async () => {

--- a/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
@@ -78,6 +78,40 @@ describe('voice capture smoke Settings contract', () => {
       /try \{[\s\S]*const result = await query\.call\(navigator\.permissions, \{ name: 'microphone' \}\);[\s\S]*\} catch \{[\s\S]*return 'unknown';[\s\S]*\}/,
       'permission query rejection must degrade to unknown instead of surfacing an unhandled rejection',
     );
+    assert.match(
+      src,
+      /async function readMicrophonePermission[\s\S]*window\.maka\.permissions\.getSnapshot\(\)[\s\S]*readBrowserMicrophonePermission\(\)/,
+      'Voice must prefer the main-process OS permission snapshot and use the browser probe only as a fallback',
+    );
+    assert.match(
+      src,
+      /window\.addEventListener\('focus', refreshWhenVisible\)/,
+      'Voice must re-read microphone permission after the user returns from System Settings',
+    );
+    assert.match(
+      src,
+      /let permissionReadRevision = 0;[\s\S]*const revision = \+\+permissionReadRevision;[\s\S]*revision === permissionReadRevision/,
+      'an older microphone probe must not overwrite a newer focus-triggered permission read',
+    );
+  });
+
+  it('routes microphone consent through the typed permission bridge before capture', async () => {
+    const src = await readFile(
+      join(REPO_ROOT, 'apps/desktop/src/renderer/settings/voice-settings-page.tsx'),
+      'utf8',
+    );
+    const run = src.match(/async function runCaptureSmoke\(\)[\s\S]*?(?=\n  return \()/)?.[0] ?? '';
+    assert.match(run, /window\.maka\.permissions\.getSnapshot\(\)/);
+    assert.match(
+      run,
+      /systemMicrophone\.status !== 'granted'[\s\S]*systemMicrophone\.status !== 'not_determined'[\s\S]*openSystemSettings\('microphone'\)[\s\S]*systemMicrophone\.status === 'denied'/,
+      'denied and unknown macOS microphone states must fail closed into System Settings instead of triggering renderer capture',
+    );
+    assert.match(
+      run,
+      /systemMicrophone\?\.status === 'not_determined'[\s\S]*requestAccess\('microphone'\)[\s\S]*if \(!voicePageMountedRef\.current\) return;[\s\S]*navigator\.mediaDevices\.getUserMedia/,
+      'first-use consent must settle before the renderer starts capture',
+    );
   });
 
   it('gates voice capture smoke with a synchronous pending owner', async () => {
@@ -243,7 +277,11 @@ describe('voice capture smoke Settings contract', () => {
     const snapshot = await readFile(CAPABILITY_SNAPSHOT, 'utf8');
     assert.match(snapshot, /未配置平台凭据/, 'bot missing credentials state must be localized');
     assert.match(snapshot, /macOS 不区分辅助功能权限是未授权还是未申请/, 'Accessibility TCC limitation must be localized');
-    assert.match(snapshot, /主进程暂时无法读取通知授权状态/, 'notification unknown state must be localized');
+    assert.match(
+      snapshot,
+      /Electron 无法可靠读取 macOS 通知授权状态，请在系统设置中确认/,
+      'notification unknown state must be honest, localized, and actionable',
+    );
     assert.match(snapshot, /Electron 暂不支持读取逐 App 的 Apple Events 授权状态/, 'Automation TCC limitation must be localized');
     assert.doesNotMatch(
       snapshot,

--- a/apps/desktop/src/main/capability-snapshot.ts
+++ b/apps/desktop/src/main/capability-snapshot.ts
@@ -15,11 +15,15 @@ import {
   type CapabilitySnapshotCollection,
   type OsPermissionId,
   type OsPermissionSnapshot,
-  type OsPermissionState,
   type PermissionSnapshot,
 } from '@maka/core';
 import type { BotStatus } from '@maka/runtime';
 import type { computerUseServiceHealth } from './computer-use-host.js';
+import {
+  mapMediaAccessStatus,
+  mediaPermissionActions,
+  supportsMediaPermissionProbe,
+} from './os-permission-policy.js';
 
 const MAC_TCC_PERMISSIONS: OsPermissionId[] = ['accessibility', 'screen_recording', 'microphone', 'automation'];
 
@@ -310,18 +314,24 @@ function mediaPermissionSnapshot(
   now: number,
   platform: NodeJS.Platform,
 ): OsPermissionSnapshot {
-  if (platform !== 'darwin' && id === 'screen_recording') {
-    return unsupportedPermission(id, now, '仅 macOS TCC 权限适用');
+  if (!supportsMediaPermissionProbe(id, platform)) {
+    return unsupportedPermission(
+      id,
+      now,
+      id === 'screen_recording'
+        ? '屏幕录制权限状态仅能在 macOS 上读取'
+        : '当前平台无法读取麦克风系统权限状态',
+    );
   }
   try {
     const status = mapMediaAccessStatus(systemPreferences.getMediaAccessStatus(mediaType));
+    const actions = mediaPermissionActions({ id, platform, status });
     return {
       id,
       status,
       source: 'electron',
       checkedAt: now,
-      canOpenSettings: platform === 'darwin',
-      canRequest: id === 'microphone' && status === 'not_determined',
+      ...actions,
     };
   } catch (error) {
     return unknownPermission(id, now, generalizedReason(error), platform === 'darwin');
@@ -329,14 +339,22 @@ function mediaPermissionSnapshot(
 }
 
 function notificationSnapshot(now: number, platform: NodeJS.Platform): OsPermissionSnapshot {
+  const supported = Notification.isSupported();
   return {
     id: 'notifications',
-    status: Notification.isSupported() ? 'unknown' : 'unsupported',
+    status: supported ? 'unknown' : 'unsupported',
     source: 'electron',
     checkedAt: now,
-    reason: Notification.isSupported() ? '主进程暂时无法读取通知授权状态' : 'Electron 通知能力不可用',
+    reason: supported
+      ? platform === 'darwin'
+        ? 'Electron 无法可靠读取 macOS 通知授权状态，请在系统设置中确认'
+        : 'Electron 无法可靠读取当前系统的通知授权状态'
+      : 'Electron 通知能力不可用',
     canOpenSettings: platform === 'darwin',
-    canRequest: Notification.isSupported(),
+    // Showing a Notification is not an authorization API and does not report
+    // whether macOS delivered or suppressed it. Never present that probe as a
+    // successful permission request.
+    canRequest: false,
   };
 }
 
@@ -380,20 +398,6 @@ function unknownPermission(
     canOpenSettings,
     canRequest: false,
   };
-}
-
-function mapMediaAccessStatus(status: string): OsPermissionState {
-  switch (status) {
-    case 'granted':
-      return 'granted';
-    case 'denied':
-    case 'restricted':
-      return 'denied';
-    case 'not-determined':
-      return 'not_determined';
-    default:
-      return 'unknown';
-  }
 }
 
 function generalizedReason(error: unknown): string {

--- a/apps/desktop/src/main/main-window-permission-policy.ts
+++ b/apps/desktop/src/main/main-window-permission-policy.ts
@@ -1,0 +1,93 @@
+import type { WebContents } from 'electron';
+
+export interface MainWindowPermissionCheck {
+  ownerMatches: boolean;
+  rendererUrlMatches: boolean;
+  permission: string;
+  isMainFrame: boolean;
+  mediaType?: string;
+}
+
+export interface MainWindowPermissionRequest {
+  ownerMatches: boolean;
+  rendererUrlMatches: boolean;
+  permission: string;
+  isMainFrame: boolean;
+  mediaTypes?: readonly string[];
+}
+
+/**
+ * The product renderer only needs one Chromium permission: microphone audio
+ * for the local Voice capture check. Keep this policy explicit because
+ * Electron otherwise leaves a session's permission behavior to permissive
+ * defaults, and the default session is also shared by auxiliary windows.
+ */
+export function allowsMainWindowPermissionCheck(input: MainWindowPermissionCheck): boolean {
+  return (
+    input.ownerMatches
+    && input.rendererUrlMatches
+    && input.isMainFrame
+    && input.permission === 'media'
+    && input.mediaType === 'audio'
+  );
+}
+
+export function allowsMainWindowPermissionRequest(input: MainWindowPermissionRequest): boolean {
+  return (
+    input.ownerMatches
+    && input.rendererUrlMatches
+    && input.isMainFrame
+    && input.permission === 'media'
+    && input.mediaTypes?.length === 1
+    && input.mediaTypes[0] === 'audio'
+  );
+}
+
+/**
+ * Dev serves the renderer over HTTP, where same-origin routes are trusted.
+ * Packaged builds use file://, whose URL origin is always "null", so the
+ * exact entry document path is the trust boundary there.
+ */
+export function matchesTrustedRendererUrl(
+  requestingUrl: string,
+  trustedRendererUrl: string,
+): boolean {
+  try {
+    const requesting = new URL(requestingUrl);
+    const trusted = new URL(trustedRendererUrl);
+    if (trusted.protocol === 'file:') {
+      return requesting.protocol === 'file:' && requesting.pathname === trusted.pathname;
+    }
+    return requesting.origin === trusted.origin;
+  } catch {
+    return false;
+  }
+}
+
+export function installMainWindowPermissionPolicy(
+  owner: WebContents,
+  trustedRendererUrl: string,
+): void {
+  const rendererSession = owner.session;
+  rendererSession.setPermissionCheckHandler((requester, permission, _origin, details) =>
+    allowsMainWindowPermissionCheck({
+      ownerMatches: requester === owner,
+      rendererUrlMatches: matchesTrustedRendererUrl(
+        details.requestingUrl ?? '',
+        trustedRendererUrl,
+      ),
+      permission,
+      isMainFrame: details.isMainFrame,
+      mediaType: details.mediaType,
+    }));
+  rendererSession.setPermissionRequestHandler((requester, permission, callback, details) => {
+    const mediaTypes = 'mediaTypes' in details ? details.mediaTypes : undefined;
+    callback(allowsMainWindowPermissionRequest({
+      ownerMatches: requester === owner,
+      rendererUrlMatches: matchesTrustedRendererUrl(details.requestingUrl, trustedRendererUrl),
+      permission,
+      isMainFrame: details.isMainFrame,
+      mediaTypes,
+    }));
+  });
+}

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -1,6 +1,7 @@
 import { app, BrowserWindow, dialog, Menu, nativeTheme, screen, shell } from 'electron';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import type { AppSettings } from '@maka/core';
 import { isExternalUrl } from './external-link-guard.js';
 import { errorMessage } from './chat-readiness.js';
@@ -8,6 +9,7 @@ import { readSavedBounds, writeSavedBounds, SAFE_MIN_HEIGHT, SAFE_MIN_WIDTH, typ
 import { BrowserViewController } from './browser/controller.js';
 import { BrowserViewManager } from './browser/view-manager.js';
 import type { E2eFixture } from './e2e-fixture.js';
+import { installMainWindowPermissionPolicy } from './main-window-permission-policy.js';
 import { isThemePreference, toNativeThemeSource } from './theme-source.js';
 import { createWindowRevealGate } from './window-reveal.js';
 
@@ -185,6 +187,16 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     // disagrees with the persisted in-app preference.
     nativeTheme.themeSource = toNativeThemeSource(themePref);
 
+    const rendererEntryPath = join(
+      import.meta.dirname,
+      '..',
+      '..',
+      'dist-renderer',
+      'index.html',
+    );
+    const rendererEntryUrl = process.env.VITE_DEV_SERVER_URL
+      ?? pathToFileURL(rendererEntryPath).href;
+
     // Re-arm the reveal gate for this window's lifecycle (macOS keeps the app
     // alive after close-all; the next createWindow starts hidden again and a
     // stale ready/pending-focus state must not reveal it early).
@@ -279,6 +291,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
         allowRunningInsecureContent: false,
       },
     });
+    installMainWindowPermissionPolicy(mainWindow.webContents, rendererEntryUrl);
 
     // Two-layer external-link hygiene: assistant markdown often emits `<a href>`
     // links to docs / GitHub / provider sign-up pages. Without these guards
@@ -376,9 +389,9 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
     });
 
     if (process.env.VITE_DEV_SERVER_URL) {
-      await mainWindow.loadURL(process.env.VITE_DEV_SERVER_URL);
+      await mainWindow.loadURL(rendererEntryUrl);
     } else {
-      await mainWindow.loadFile(join(import.meta.dirname, '..', '..', 'dist-renderer', 'index.html'));
+      await mainWindow.loadFile(rendererEntryPath);
     }
 
     // PR-SHOW-AFTER-FIRST-COMMIT: reveal fallback. Start this budget only once

--- a/apps/desktop/src/main/os-permission-policy.ts
+++ b/apps/desktop/src/main/os-permission-policy.ts
@@ -1,0 +1,55 @@
+import type { OsPermissionId, OsPermissionState } from '@maka/core';
+
+export function mapMediaAccessStatus(status: string): OsPermissionState {
+  switch (status) {
+    case 'granted':
+      return 'granted';
+    case 'denied':
+    case 'restricted':
+      return 'denied';
+    case 'not-determined':
+      return 'not_determined';
+    default:
+      return 'unknown';
+  }
+}
+
+export function supportsMediaPermissionProbe(
+  id: 'screen_recording' | 'microphone',
+  platform: NodeJS.Platform,
+): boolean {
+  if (id === 'screen_recording') return platform === 'darwin';
+  return platform === 'darwin' || platform === 'win32';
+}
+
+export function mediaPermissionActions(input: {
+  id: 'screen_recording' | 'microphone';
+  platform: NodeJS.Platform;
+  status: OsPermissionState;
+}): { canOpenSettings: boolean; canRequest: boolean } {
+  return {
+    canOpenSettings: input.platform === 'darwin',
+    canRequest:
+      input.platform === 'darwin'
+      && input.id === 'microphone'
+      && input.status === 'not_determined',
+  };
+}
+
+export type PermissionRequestPlan =
+  | 'unsupported_platform'
+  | 'already_granted'
+  | 'request_microphone'
+  | 'open_settings';
+
+export function planPermissionRequest(input: {
+  id: OsPermissionId;
+  platform: NodeJS.Platform;
+  microphoneStatus?: string;
+}): PermissionRequestPlan {
+  if (input.platform !== 'darwin') return 'unsupported_platform';
+  if (input.id !== 'microphone') return 'open_settings';
+  if (input.microphoneStatus === 'granted') return 'already_granted';
+  if (input.microphoneStatus === 'not-determined') return 'request_microphone';
+  return 'open_settings';
+}

--- a/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
+++ b/apps/desktop/src/main/permission-overlay/permission-overlay-main.ts
@@ -68,8 +68,9 @@ export function createPermissionOverlayMain(
   deps: PermissionOverlayMainDeps,
 ): PermissionOverlayController {
   let locale: UiLocale = 'en';
+  let iconDataUrl: string | null = null;
   const electron = requireElectron('electron') as Electron;
-  const { BrowserWindow, app, nativeImage, screen, systemPreferences } = electron;
+  const { BrowserWindow, app, screen, systemPreferences } = electron;
 
   function isGranted(id: DragGrantPermissionId): boolean {
     if (process.platform !== 'darwin') return false;
@@ -79,16 +80,18 @@ export function createPermissionOverlayMain(
     return systemPreferences.getMediaAccessStatus('screen') === 'granted';
   }
 
-  function appIconDataUrl(bundlePath: string | null): string | null {
+  async function resolveAppIconDataUrl(bundlePath: string | null): Promise<string | null> {
     if (!bundlePath) return null;
-    for (const name of ['icon.icns', 'electron.icns']) {
-      const candidate = join(bundlePath, 'Contents', 'Resources', name);
-      if (!existsSync(candidate)) continue;
-      const image = nativeImage.createFromPath(candidate);
-      if (image.isEmpty()) continue;
-      return image.resize({ width: 64, height: 64 }).toDataURL();
+    try {
+      // nativeImage.createFromPath does not decode .icns reliably. Asking
+      // macOS for the bundle icon returns the same image Finder and the TCC
+      // list display, and works for both Maka.app and Electron.app in dev.
+      const icon = await app.getFileIcon(bundlePath, { size: 'large' });
+      if (icon.isEmpty()) return null;
+      return icon.resize({ width: 64, height: 64 }).toDataURL();
+    } catch {
+      return null;
     }
-    return null;
   }
 
   const controller = createPermissionOverlayController({
@@ -101,7 +104,7 @@ export function createPermissionOverlayMain(
     },
     openSystemSettings: async (id) => {
       const result = await openSystemPermissionPane(id);
-      return result.ok ? { ok: true } : { ok: false, message: result.message ?? result.reason };
+      return result.ok ? { ok: true } : { ok: false, message: result.message };
     },
     isGranted,
     setInterval: (fn, ms) => setInterval(fn, ms),
@@ -118,7 +121,7 @@ export function createPermissionOverlayMain(
       return {
         permission: id,
         appName: app.getName(),
-        iconDataUrl: appIconDataUrl(bundlePath),
+        iconDataUrl,
         draggable: bundlePath !== null,
         copy: serializeCopy(locale, id, app.getName()),
       };
@@ -192,6 +195,12 @@ export function createPermissionOverlayMain(
       } catch (error) {
         console.warn('[permission-overlay] locale lookup failed, keeping', locale, error);
       }
+      const bundle = resolveAppBundle({
+        executablePath: app.getPath('exe'),
+        platform: process.platform,
+        exists: existsSync,
+      });
+      iconDataUrl = await resolveAppIconDataUrl(bundle.ok ? bundle.bundlePath : null);
       return controller.start(id);
     },
   };
@@ -231,7 +240,7 @@ function attachCardGestures(win: import('electron').BrowserWindow): void {
       exists: existsSync,
     });
 
-  win.webContents.on('ipc-message', (_event, channel, payload: unknown) => {
+  win.webContents.on('ipc-message', async (_event, channel, payload: unknown) => {
     if (channel === 'permission-overlay:dismiss') {
       if (!win.isDestroyed()) win.close();
       return;
@@ -272,10 +281,12 @@ function attachCardGestures(win: import('electron').BrowserWindow): void {
       if (!fromRenderer.isEmpty()) icon = fromRenderer;
     }
     if (icon.isEmpty()) {
-      const fallback = nativeImage.createFromPath(
-        join(resolved.bundlePath, 'Contents', 'Resources', 'icon.icns'),
-      );
-      if (!fallback.isEmpty()) icon = fallback.resize({ width: 64, height: 64 });
+      try {
+        const fallback = await app.getFileIcon(resolved.bundlePath, { size: 'large' });
+        if (!fallback.isEmpty()) icon = fallback.resize({ width: 64, height: 64 });
+      } catch {
+        // The file drag still works without a decorative drag image.
+      }
     }
 
     if (!win.isDestroyed()) win.webContents.startDrag({ file: resolved.bundlePath, icon });

--- a/apps/desktop/src/main/permissions-actions.ts
+++ b/apps/desktop/src/main/permissions-actions.ts
@@ -9,23 +9,34 @@
  *     Settings → Privacy & Security at the right pane. On non-macOS
  *     platforms the request resolves with a structured "unsupported"
  *     failure so the renderer can hide the button.
- *   - `requestPermissionAccess(id)` — when the OS exposes a programmatic
- *     consent dialog (microphone, notifications) we ask directly;
- *     otherwise we fall back to the same deep-link path so the user is
- *     still moved one step closer to granting.
+ *   - `requestPermissionAccess(id)` — when the OS exposes a real,
+ *     result-bearing consent dialog (microphone) we ask directly;
+ *     otherwise we deep-link to System Settings. Merely showing a
+ *     notification is not treated as proof that notifications are allowed.
  *
- * No state is persisted here — the renderer refreshes the snapshot
- * after either action, so the new status comes back through the
- * existing read path.
+ * No state is persisted here. The renderer refreshes after a direct
+ * request resolves, and again when the app regains focus after a
+ * System Settings deep link.
  */
 
-import { Notification, shell, systemPreferences } from 'electron';
+import { shell, systemPreferences } from 'electron';
 import type { OsPermissionId } from '@maka/core';
 import { OS_PERMISSION_IDS } from '@maka/core';
+import { planPermissionRequest } from './os-permission-policy.js';
 
 export type PermissionActionResult =
   | { ok: true }
-  | { ok: false; reason: 'invalid_id' | 'unsupported_platform' | 'unsupported_permission' | 'failed'; message?: string };
+  | {
+      ok: false;
+      reason:
+        | 'invalid_id'
+        | 'unsupported_platform'
+        | 'unsupported_permission'
+        | 'open_settings_failed'
+        | 'denied'
+        | 'failed';
+      message?: string;
+    };
 
 /**
  * macOS x-apple.systempreferences deep-link targets. The format changed
@@ -61,41 +72,35 @@ export async function openSystemPermissionPane(input: unknown): Promise<Permissi
     await shell.openExternal(url);
     return { ok: true };
   } catch (err) {
-    return { ok: false, reason: 'failed', message: errorMessage(err) };
+    return { ok: false, reason: 'open_settings_failed', message: errorMessage(err) };
   }
 }
 
 export async function requestPermissionAccess(input: unknown): Promise<PermissionActionResult> {
   const id = normalizePermissionId(input);
   if (!id) return { ok: false, reason: 'invalid_id' };
-  if (process.platform !== 'darwin') {
-    return { ok: false, reason: 'unsupported_platform' };
-  }
   try {
-    switch (id) {
-      case 'microphone': {
+    const plan = planPermissionRequest({
+      id,
+      platform: process.platform,
+      microphoneStatus:
+        id === 'microphone' && process.platform === 'darwin'
+          ? systemPreferences.getMediaAccessStatus('microphone')
+          : undefined,
+    });
+    switch (plan) {
+      case 'unsupported_platform':
+        return { ok: false, reason: 'unsupported_platform' };
+      case 'already_granted':
+        return { ok: true };
+      case 'open_settings':
+        return openSystemPermissionPane(id);
+      case 'request_microphone': {
         const granted = await systemPreferences.askForMediaAccess('microphone');
         return granted
           ? { ok: true }
-          : { ok: false, reason: 'failed', message: '用户拒绝了麦克风访问。' };
+          : { ok: false, reason: 'denied' };
       }
-      case 'notifications': {
-        if (!Notification.isSupported()) {
-          return { ok: false, reason: 'unsupported_permission', message: '当前 Electron 不支持通知。' };
-        }
-        // macOS shows the consent prompt the first time a Notification
-        // is created; sending a silent ping is the supported pattern.
-        const probe = new Notification({ title: 'Maka 通知权限自检', body: '已尝试请求通知权限。' });
-        probe.show();
-        return { ok: true };
-      }
-      case 'accessibility':
-      case 'screen_recording':
-      case 'automation':
-        // macOS does not expose a programmatic consent dialog for these
-        // three; we deep-link into the relevant System Settings pane
-        // instead so the action button is never inert.
-        return openSystemPermissionPane(id);
     }
   } catch (err) {
     return { ok: false, reason: 'failed', message: errorMessage(err) };

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -166,7 +166,13 @@ export type PermissionActionResult =
   | { ok: true }
   | {
       ok: false;
-      reason: 'invalid_id' | 'unsupported_platform' | 'unsupported_permission' | 'failed';
+      reason:
+        | 'invalid_id'
+        | 'unsupported_platform'
+        | 'unsupported_permission'
+        | 'open_settings_failed'
+        | 'denied'
+        | 'failed';
       message?: string;
     };
 

--- a/apps/desktop/src/renderer/locales/permission-center-copy.ts
+++ b/apps/desktop/src/renderer/locales/permission-center-copy.ts
@@ -19,7 +19,16 @@ export type PermissionCenterCopy = {
   noData: string;
   readAgain: string;
   actionFailed: string;
-  actionFailures: Record<'invalid_id' | 'unsupported_platform' | 'unsupported_permission' | 'failed', string>;
+  actionFailures: Record<
+    | 'invalid_id'
+    | 'unsupported_platform'
+    | 'unsupported_permission'
+    | 'denied'
+    | 'already_open'
+    | 'open_settings_failed'
+    | 'failed',
+    string
+  >;
   title: string;
   subtitle: string;
   lastRead: string;
@@ -89,7 +98,15 @@ const PERMISSION_CENTER_COPY = {
     },
     loading: '正在加载权限快照', readFailed: '无法读取权限快照', noData: '权限服务未返回数据。', readAgain: '重新读取',
     actionFailed: '权限操作失败',
-    actionFailures: { invalid_id: '内部错误：权限 id 无法识别。', unsupported_platform: '当前操作系统不支持这个权限操作。', unsupported_permission: '当前平台没有提供这个权限的直接入口。', failed: '权限操作未成功，请稍后重试。' },
+    actionFailures: {
+      invalid_id: '内部错误：权限 id 无法识别。',
+      unsupported_platform: '当前操作系统不支持这个权限操作。',
+      unsupported_permission: '当前平台没有提供这个权限的直接入口。',
+      denied: '你没有授予这项权限；可以前往系统设置重新开启。',
+      already_open: '另一个权限引导仍在进行，请先完成或关闭它。',
+      open_settings_failed: '无法打开系统设置，请手动前往「隐私与安全性」。',
+      failed: '权限操作未成功，请稍后重试。',
+    },
     title: '权限与能力', subtitle: '查看 Maka 需要的系统权限和当前授权状态，直接从这里前往「系统设置 → 隐私与安全性」完成授权或撤销，不必自己翻菜单。',
     lastRead: '最近读取：', detectAgain: '重新检测', summaryAria: '权限概览', granted: '已授权', pending: '等待授权', denied: '已拒绝', other: '未知 / 不支持',
     osSection: '系统权限', osSectionHelp: 'Maka 读到的 OS 级权限状态。点击右侧按钮可以直接前往「系统设置 → 隐私与安全性」对应分区。', osListAria: '系统权限列表',
@@ -129,7 +146,15 @@ const PERMISSION_CENTER_COPY = {
     },
     loading: 'Loading permission snapshot', readFailed: 'Could not read permission snapshot', noData: 'The permission service returned no data.', readAgain: 'Read again',
     actionFailed: 'Permission action failed',
-    actionFailures: { invalid_id: 'Internal error: the permission ID was not recognized.', unsupported_platform: 'This operating system does not support the permission action.', unsupported_permission: 'This platform does not provide a direct entry point for the permission.', failed: 'The permission action did not succeed. Try again later.' },
+    actionFailures: {
+      invalid_id: 'Internal error: the permission ID was not recognized.',
+      unsupported_platform: 'This operating system does not support the permission action.',
+      unsupported_permission: 'This platform does not provide a direct entry point for the permission.',
+      denied: 'Permission was not granted. You can enable it in System Settings.',
+      already_open: 'Another permission guide is still open. Finish or close it first.',
+      open_settings_failed: 'Could not open System Settings. Open Privacy & Security manually.',
+      failed: 'The permission action did not succeed. Try again later.',
+    },
     title: 'Permissions and capabilities', subtitle: 'Review the system permissions Maka needs and their current state. Open the matching Privacy & Security section directly to grant or revoke access.',
     lastRead: 'Last read: ', detectAgain: 'Check again', summaryAria: 'Permission overview', granted: 'Granted', pending: 'Waiting', denied: 'Denied', other: 'Unknown / unsupported',
     osSection: 'System permissions', osSectionHelp: 'OS-level permission states reported to Maka. Use the action on the right to open the matching Privacy & Security section in System Settings.', osListAria: 'System permission list',

--- a/apps/desktop/src/renderer/settings/permission-center-page.tsx
+++ b/apps/desktop/src/renderer/settings/permission-center-page.tsx
@@ -89,6 +89,20 @@ export function PermissionCenterPage() {
     };
   }, [locale, refreshTick]);
 
+  useEffect(() => {
+    const refreshAfterSystemSettings = () => {
+      if (document.visibilityState === 'visible') {
+        setRefreshTick((tick) => tick + 1);
+      }
+    };
+    window.addEventListener('focus', refreshAfterSystemSettings);
+    document.addEventListener('visibilitychange', refreshAfterSystemSettings);
+    return () => {
+      window.removeEventListener('focus', refreshAfterSystemSettings);
+      document.removeEventListener('visibilitychange', refreshAfterSystemSettings);
+    };
+  }, []);
+
   async function runPermissionAction(
     permId: OsPermissionId,
     kind: 'request' | 'openSettings' | 'dragGrant',
@@ -104,9 +118,12 @@ export function PermissionCenterPage() {
             ? await window.maka.permissions.startDragOnboarding(permId)
             : await window.maka.permissions.openSystemSettings(permId);
       if (result.ok) {
-        // Refresh snapshot so the user sees the new state when they
-        // return from System Settings.
-        if (mountedRef.current) setRefreshTick((tick) => tick + 1);
+        // A direct request resolves after the user has answered, so refresh
+        // now. Deep links and the drag guide resolve as soon as System
+        // Settings opens; those refresh when Maka regains focus instead.
+        if (kind === 'request' && mountedRef.current) {
+          setRefreshTick((tick) => tick + 1);
+        }
       } else if (mountedRef.current) {
         toast.error(copy.actionFailed, permissionActionFailureCopy(result.reason, result.message, copy));
       }
@@ -190,7 +207,15 @@ export function PermissionCenterPage() {
               copy={copy}
               locale={locale}
               busy={pendingPermAction !== null}
-              pendingKey={pendingPermAction === `${id}:request` ? 'request' : pendingPermAction === `${id}:openSettings` ? 'openSettings' : null}
+              pendingKey={
+                pendingPermAction === `${id}:request`
+                  ? 'request'
+                  : pendingPermAction === `${id}:openSettings`
+                    ? 'openSettings'
+                    : pendingPermAction === `${id}:dragGrant`
+                      ? 'dragGrant'
+                      : null
+              }
               onRequest={() => void runPermissionAction(id, 'request')}
               onOpenSettings={() => void runPermissionAction(id, 'openSettings')}
               onDragGrant={() => void runPermissionAction(id, 'dragGrant')}
@@ -285,6 +310,12 @@ function permissionActionFailureCopy(reason: string, message: string | undefined
       return copy.actionFailures.unsupported_platform;
     case 'unsupported_permission':
       return copy.actionFailures.unsupported_permission;
+    case 'denied':
+      return copy.actionFailures.denied;
+    case 'already_open':
+      return copy.actionFailures.already_open;
+    case 'open_settings_failed':
+      return copy.actionFailures.open_settings_failed;
     case 'failed':
       return message ?? copy.actionFailures.failed;
     default:

--- a/apps/desktop/src/renderer/settings/voice-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/voice-settings-page.tsx
@@ -35,11 +35,23 @@ export function VoiceModelsSettingsPage() {
 
   useEffect(() => {
     let cancelled = false;
-    void readBrowserMicrophonePermission().then((next) => {
-      if (!cancelled) setPermission(next);
-    });
+    let permissionReadRevision = 0;
+    const refreshPermission = () => {
+      const revision = ++permissionReadRevision;
+      void readMicrophonePermission().then((next) => {
+        if (!cancelled && revision === permissionReadRevision) setPermission(next);
+      });
+    };
+    const refreshWhenVisible = () => {
+      if (document.visibilityState === 'visible') refreshPermission();
+    };
+    refreshPermission();
+    window.addEventListener('focus', refreshWhenVisible);
+    document.addEventListener('visibilitychange', refreshWhenVisible);
     return () => {
       cancelled = true;
+      window.removeEventListener('focus', refreshWhenVisible);
+      document.removeEventListener('visibilitychange', refreshWhenVisible);
     };
   }, []);
 
@@ -61,6 +73,39 @@ export function VoiceModelsSettingsPage() {
     setSmoke({ status: 'checking' });
     let stream: MediaStream | null = null;
     try {
+      const systemSnapshot = await window.maka.permissions.getSnapshot().catch(() => null);
+      const systemMicrophone = systemSnapshot?.permissions.microphone;
+      if (
+        systemSnapshot?.platform === 'darwin'
+        && systemMicrophone
+        && systemMicrophone.status !== 'granted'
+        && systemMicrophone.status !== 'not_determined'
+      ) {
+        const opened = await window.maka.permissions.openSystemSettings('microphone');
+        if (voicePageMountedRef.current) {
+          const denied = systemMicrophone.status === 'denied';
+          setPermission(denied ? 'denied' : 'unknown');
+          setSmoke({ status: 'error', reason: denied ? 'denied' : 'failed' });
+          if (!opened.ok) toast.error(copy.failedTitle, copy.failed);
+        }
+        return;
+      }
+      if (
+        systemSnapshot?.platform === 'darwin'
+        && systemMicrophone?.status === 'not_determined'
+      ) {
+        const requested = await window.maka.permissions.requestAccess('microphone');
+        if (!requested.ok) {
+          if (voicePageMountedRef.current) {
+            const denied = requested.reason === 'denied';
+            setPermission(denied ? 'denied' : 'unknown');
+            setSmoke({ status: 'error', reason: denied ? 'denied' : 'failed' });
+            toast.error(copy.failedTitle, denied ? copy.denied : copy.failed);
+          }
+          return;
+        }
+      }
+      if (!voicePageMountedRef.current) return;
       stream = await navigator.mediaDevices.getUserMedia({
         audio: {
           channelCount: caps.maxChannels,
@@ -193,6 +238,18 @@ export function VoiceModelsSettingsPage() {
       </ul>
     </section>
   );
+}
+
+async function readMicrophonePermission(): Promise<VoicePermissionStatus> {
+  try {
+    const snapshot = await window.maka.permissions.getSnapshot();
+    const status = snapshot.permissions.microphone.status;
+    if (status !== 'unknown' && status !== 'unsupported') return status;
+  } catch {
+    // Fall through to the renderer probe. It is useful on platforms where
+    // Electron cannot expose an OS-level microphone status.
+  }
+  return readBrowserMicrophonePermission();
 }
 
 async function readBrowserMicrophonePermission(): Promise<VoicePermissionStatus> {

--- a/packages/core/src/capabilities.ts
+++ b/packages/core/src/capabilities.ts
@@ -13,8 +13,8 @@ export type OsPermissionId = (typeof OS_PERMISSION_IDS)[number];
  * The macOS permissions granted by dragging the app bundle onto the
  * Privacy list, rather than through a consent dialog.
  *
- * These two are the ones the OS exposes no programmatic prompt for, so
- * the stock path is: open System Settings, find the pane, press `+`,
+ * These two are the ones whose normal setup requires adding the app to a
+ * System Settings list, so the stock path is: open System Settings, press `+`,
  * navigate a file picker to /Applications, pick the app, tick the box.
  * Dropping the bundle satisfies the same explicit-consent intent in one
  * gesture, which is what the drag-to-grant onboarding automates.

--- a/scripts/macos-arm64-release.test.mjs
+++ b/scripts/macos-arm64-release.test.mjs
@@ -41,6 +41,20 @@ test('desktop packager has signed macOS arm64 install and update targets', async
   assert.ok(config.files.includes('!**/__tests__/**'));
 });
 
+test('macOS release declares the privacy copy and hardened-runtime permissions it uses', async () => {
+  const [{ default: config }, entitlements] = await Promise.all([
+    import(new URL('electron-builder.config.mjs', desktopRoot)),
+    readFile(new URL('build/entitlements.mac.plist', desktopRoot), 'utf8'),
+  ]);
+
+  assert.match(config.mac.extendInfo.NSMicrophoneUsageDescription, /microphone/i);
+  assert.match(config.mac.extendInfo.NSAppleEventsUsageDescription, /automate other applications/i);
+  assert.match(
+    entitlements,
+    /<key>com\.apple\.security\.automation\.apple-events<\/key>\s*<true\/>/,
+  );
+});
+
 test('Electron is a build tool rather than a packaged application dependency', async () => {
   assert.equal(desktopManifest.dependencies.electron, undefined);
   assert.match(desktopManifest.devDependencies.electron, /^\d+\.\d+\.\d+$/);


### PR DESCRIPTION
## Summary

- enforce a fail-closed Chromium media permission policy for the trusted main renderer
- make microphone and Permission Center flows reflect real OS state and recovery paths
- harden macOS drag-to-grant icons, entitlements, and release privacy contracts

## Verification

- Desktop typecheck
- targeted permission tests: 55/55
- Desktop suite: 2987/2987
- permission Playwright E2E: 5/5
- macOS release tests: 14/14
- real-window programmatic smoke
- Biome, console, a11y, copy, and diff checks