### PR TITLE
fix(headless): keep provider proxy upstream on HTTP/1.1

### DIFF
--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -1,10 +1,12 @@
 import assert from 'node:assert/strict';
 import { createServer, request as httpRequest } from 'node:http';
+import { createSecureServer as http2CreateSecureServer } from 'node:http2';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import {
+  createProviderUpstreamDispatcher,
   listenProviderAuthProxyServer,
   startProviderAuthProxy,
   startProviderAuthProxyHub,
@@ -1068,5 +1070,85 @@ test('proxy listen removes its bind-error listener so later socket errors stay l
     assert.equal(server.listenerCount('error'), 0);
   } finally {
     await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+// Throwaway self-signed localhost keypair for the ALPN test upstream below.
+// Generated for this test only; it protects nothing and is not a secret.
+const TEST_TLS_KEY = `-----BEGIN PRIVATE KEY-----
+MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQgY/Gn4UXA4CkakyTU
+KH7HnQuoCm+oijhMxnJbUn3HfPOhRANCAARcPHil4Wicklox28LLlCyOwgbCnPMT
+0MCUE+IIO1FQ0R2Kf9jNkrLDap94ZVfX+rqL/IS9YwlK3D71yoRuc5Dt
+-----END PRIVATE KEY-----
+`;
+const TEST_TLS_CERT = `-----BEGIN CERTIFICATE-----
+MIIBmzCCAUGgAwIBAgIURwBeV0GMeaqMHreWbCO4eKNJyHkwCgYIKoZIzj0EAwIw
+FDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTI2MDczMDExNDAwNFoYDzIxMjYwNzA2
+MTE0MDA0WjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwWTATBgcqhkjOPQIBBggqhkjO
+PQMBBwNCAARcPHil4Wicklox28LLlCyOwgbCnPMT0MCUE+IIO1FQ0R2Kf9jNkrLD
+ap94ZVfX+rqL/IS9YwlK3D71yoRuc5Dto28wbTAdBgNVHQ4EFgQUtk79/6lCuMrN
+XPtVzMqcpPRz34QwHwYDVR0jBBgwFoAUtk79/6lCuMrNXPtVzMqcpPRz34QwDwYD
+VR0TAQH/BAUwAwEB/zAaBgNVHREEEzARgglsb2NhbGhvc3SHBH8AAAEwCgYIKoZI
+zj0EAwIDSAAwRQIhALT3Bbd5MAAF9FiqGe01guMcQeYKTnTuT3PSGxHUyoz8AiBp
+5VIucZiXGvcT4yv/bEddde8Ql2N7bI+YerEXJR3dsg==
+-----END CERTIFICATE-----
+`;
+
+test('proxy keeps upstream on HTTP/1.1 and forwards concurrent streams in parallel', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-'));
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, 'provider-secret-key\n', 'utf8');
+  // An upstream that offers h2 via ALPN, like real provider gateways. If the
+  // upstream dispatcher ever negotiates h2, undici services one request at a
+  // time per connection: the second request below would never reach the
+  // upstream while the first stream is held open, and requests would report
+  // httpVersion 2.0.
+  const seenHttpVersions: string[] = [];
+  let releaseBoth: () => void = () => {};
+  const bothArrived = new Promise<void>((resolve) => {
+    releaseBoth = resolve;
+  });
+  const upstream = http2CreateSecureServer(
+    { key: TEST_TLS_KEY, cert: TEST_TLS_CERT, allowHTTP1: true },
+    (request, response) => {
+      seenHttpVersions.push(request.httpVersion);
+      response.writeHead(200, { 'content-type': 'text/event-stream' });
+      response.write('data: {"choices":[{"delta":{"content":"x"}}]}\n\n');
+      if (seenHttpVersions.length >= 2) releaseBoth();
+      // Hold every stream open until both requests have arrived, so a
+      // serialized upstream path deadlocks instead of passing by luck.
+      void bothArrived.then(() => response.end('data: [DONE]\n\n'));
+    },
+  );
+  await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const upstreamAddress = upstream.address();
+  assert.ok(upstreamAddress && typeof upstreamAddress !== 'string');
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: `https://127.0.0.1:${upstreamAddress.port}/api/v4/`,
+    apiKeyFile: keyFile,
+    advertisedHost: '127.0.0.1',
+    upstreamDispatcher: createProviderUpstreamDispatcher({
+      connect: { ca: TEST_TLS_CERT },
+    }),
+  });
+  try {
+    const one = async () => {
+      const response = await fetch(`${proxy.baseUrl}/chat/completions`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${proxy.token}`, 'content-type': 'application/json' },
+        body: '{}',
+        signal: AbortSignal.timeout(10_000),
+      });
+      assert.equal(response.status, 200);
+      return response.text();
+    };
+    const [first, second] = await Promise.all([one(), one()]);
+    assert.match(first, /\[DONE\]/);
+    assert.match(second, /\[DONE\]/);
+    assert.deepEqual(seenHttpVersions, ['1.1', '1.1']);
+  } finally {
+    await proxy.close();
+    upstream.close();
+    await rm(dir, { recursive: true, force: true });
   }
 });

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -1159,3 +1159,94 @@ test('proxy keeps upstream on HTTP/1.1 and forwards concurrent streams in parall
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test('proxy telemetry separates dispatcher queue time from upstream wait', async () => {
+  const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-'));
+  const keyFile = join(dir, 'provider-key');
+  await writeFile(keyFile, 'provider-secret-key\n', 'utf8');
+  // The injected clock makes every recorded timestamp exact, so the
+  // assertions below are equalities, not wall-clock thresholds.
+  let clock = 0;
+  let releaseFirst: () => void = () => {};
+  let firstArrived: () => void = () => {};
+  const firstUpstream = new Promise<void>((resolve) => {
+    firstArrived = resolve;
+  });
+  const upstream = http2CreateSecureServer(
+    { key: TEST_TLS_KEY, cert: TEST_TLS_CERT, allowHTTP1: true },
+    (request, response) => {
+      if (request.url === '/api/v4/first') {
+        response.writeHead(200, { 'content-type': 'text/plain' });
+        response.write('held');
+        releaseFirst = () => response.end('done');
+        firstArrived();
+        return;
+      }
+      // The queued request reaches the wire only after the held one ends;
+      // advance the clock before answering so pure upstream wait shows up as
+      // responseHeadersMs minus upstreamStartMs.
+      clock = 7000;
+      response.writeHead(200, { 'content-type': 'text/plain' });
+      response.end('ok');
+    },
+  );
+  await new Promise<void>((resolve) => upstream.listen(0, '127.0.0.1', resolve));
+  const upstreamAddress = upstream.address();
+  assert.ok(upstreamAddress && typeof upstreamAddress !== 'string');
+  // A single upstream connection forces the second request to sit in the
+  // dispatcher queue until the first stream ends. The compose counter is the
+  // deterministic gate that it entered the pool before the clock advances.
+  let dispatches = 0;
+  let secondQueued: () => void = () => {};
+  const secondInPool = new Promise<void>((resolve) => {
+    secondQueued = resolve;
+  });
+  const upstreamDispatcher = createProviderUpstreamDispatcher({
+    connections: 1,
+    connect: { ca: TEST_TLS_CERT },
+  }).compose((dispatch) => (options, handler) => {
+    const dispatched = dispatch(options, handler);
+    dispatches += 1;
+    if (dispatches === 2) secondQueued();
+    return dispatched;
+  });
+  const proxy = await startProviderAuthProxy({
+    upstreamBaseUrl: `https://127.0.0.1:${upstreamAddress.port}/api/v4/`,
+    apiKeyFile: keyFile,
+    advertisedHost: '127.0.0.1',
+    now: () => clock,
+    upstreamDispatcher,
+  });
+  try {
+    const request = (path: string) =>
+      fetch(`${proxy.baseUrl}/${path}`, {
+        method: 'POST',
+        headers: { authorization: `Bearer ${proxy.token}`, 'content-type': 'application/json' },
+        body: '{}',
+        signal: AbortSignal.timeout(10_000),
+      });
+    const first = request('first');
+    await firstUpstream;
+    clock = 1000;
+    const second = request('second');
+    await secondInPool;
+    clock = 6000;
+    releaseFirst();
+    const [firstResponse, secondResponse] = await Promise.all([first, second]);
+    assert.equal(firstResponse.status, 200);
+    assert.equal(secondResponse.status, 200);
+    await Promise.all([firstResponse.text(), secondResponse.text()]);
+    const byPath = new Map(proxy.telemetry().map((entry) => [entry.path, entry]));
+    assert.equal(byPath.get('/api/v4/first')?.upstreamStartMs, 0);
+    // Started at 1000, left the dispatcher queue at 6000 when the held
+    // connection freed, got upstream headers at 7000. A stamp taken before
+    // dispatch reads 0; one taken at response headers reads 6000; a dropped
+    // stamp reads undefined. Only queue-exit semantics yield 5000.
+    assert.equal(byPath.get('/api/v4/second')?.upstreamStartMs, 5000);
+    assert.equal(byPath.get('/api/v4/second')?.responseHeadersMs, 6000);
+  } finally {
+    await proxy.close();
+    upstream.close();
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -1146,6 +1146,13 @@ test('proxy keeps upstream on HTTP/1.1 and forwards concurrent streams in parall
     assert.match(first, /\[DONE\]/);
     assert.match(second, /\[DONE\]/);
     assert.deepEqual(seenHttpVersions, ['1.1', '1.1']);
+    const telemetry = proxy.telemetry();
+    assert.equal(telemetry.length, 2);
+    for (const request of telemetry) {
+      assert.ok(request.upstreamStartMs !== undefined);
+      assert.ok(request.responseHeadersMs !== undefined);
+      assert.ok(request.upstreamStartMs <= request.responseHeadersMs);
+    }
   } finally {
     await proxy.close();
     upstream.close();

--- a/packages/headless/src/__tests__/provider-auth-proxy.test.ts
+++ b/packages/headless/src/__tests__/provider-auth-proxy.test.ts
@@ -1098,11 +1098,11 @@ test('proxy keeps upstream on HTTP/1.1 and forwards concurrent streams in parall
   const dir = await mkdtemp(join(tmpdir(), 'maka-provider-proxy-'));
   const keyFile = join(dir, 'provider-key');
   await writeFile(keyFile, 'provider-secret-key\n', 'utf8');
-  // An upstream that offers h2 via ALPN, like real provider gateways. If the
-  // upstream dispatcher ever negotiates h2, undici services one request at a
-  // time per connection: the second request below would never reach the
-  // upstream while the first stream is held open, and requests would report
-  // httpVersion 2.0.
+  // An upstream that offers h2 via ALPN, like real provider gateways. The
+  // httpVersion assertion is the regression lock: an h2-negotiating
+  // dispatcher reports 2.0 regardless of timing. The held-open streams
+  // additionally deadlock the staggered-dispatch path of undici <= 8.7,
+  // which refuses to multiplex non-empty fetch bodies on a busy h2 session.
   const seenHttpVersions: string[] = [];
   let releaseBoth: () => void = () => {};
   const bothArrived = new Promise<void>((resolve) => {

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -7,6 +7,18 @@ import {
   type ServerResponse,
 } from 'node:http';
 import type { Socket } from 'node:net';
+import { Agent, type Dispatcher, Headers, fetch as upstreamFetch } from 'undici';
+
+/** Upstream connections must stay on HTTP/1.1. Providers negotiate h2 via
+ * ALPN, and undici's HTTP/2 client runs one request at a time per origin
+ * connection, so concurrent streaming completions from parallel cells
+ * serialize behind each other's full generation streams — observed as
+ * multi-minute first-token waits attributed to the provider. */
+export function createProviderUpstreamDispatcher(options: Agent.Options = {}): Dispatcher {
+  return new Agent({ ...options, allowH2: false });
+}
+
+const defaultUpstreamDispatcher = createProviderUpstreamDispatcher();
 
 export interface ProviderAuthProxy {
   baseUrl: string;
@@ -153,6 +165,9 @@ type ProviderAuthProxyRouteConfig = {
   usageProtocol?: ProviderUsageProtocol;
   /** Injectable monotonic clock for deterministic tests. */
   now?: () => number;
+  /** Injectable upstream dispatcher for tests (e.g. to trust a test CA).
+   * Build it with createProviderUpstreamDispatcher to keep h2 disabled. */
+  upstreamDispatcher?: Dispatcher;
 } & (
   | { apiKeyFile: string; resolveUpstreamCredential?: never }
   | { apiKeyFile?: never; resolveUpstreamCredential: ProviderUpstreamCredentialResolver }
@@ -208,6 +223,7 @@ interface ProviderAuthProxyRoute {
   readonly usage: ProviderUsageAccumulator;
   readonly telemetry: ProviderTelemetryAccumulator;
   readonly now: () => number;
+  readonly upstreamDispatcher: Dispatcher;
   readonly activeRequests: Set<AbortController>;
   readonly activeResponses: Set<ServerResponse>;
   readonly activeForwards: Set<Promise<void>>;
@@ -248,6 +264,7 @@ export async function startProviderAuthProxyHub(
       usage: route.usage,
       telemetry: route.telemetry,
       now: route.now,
+      upstreamDispatcher: route.upstreamDispatcher,
       signal: controller.signal,
     }).finally(() => {
       request.off('aborted', abortOnRequest);
@@ -335,6 +352,7 @@ function providerAuthProxyRoute(input: ProviderAuthProxyRouteInput): ProviderAut
     usage: new ProviderUsageAccumulator(),
     telemetry: new ProviderTelemetryAccumulator(),
     now: input.now ?? performance.now.bind(performance),
+    upstreamDispatcher: input.upstreamDispatcher ?? defaultUpstreamDispatcher,
     activeRequests: new Set<AbortController>(),
     activeResponses: new Set<ServerResponse>(),
     activeForwards: new Set<Promise<void>>(),
@@ -373,6 +391,7 @@ async function forwardProviderRequest(input: {
   usage: ProviderUsageAccumulator;
   telemetry: ProviderTelemetryAccumulator;
   now: () => number;
+  upstreamDispatcher: Dispatcher;
   signal: AbortSignal;
 }): Promise<void> {
   let requestTelemetry: MutableProviderRequestTelemetry | null = null;
@@ -423,10 +442,11 @@ async function forwardProviderRequest(input: {
       input.request.method === 'GET' || input.request.method === 'HEAD'
         ? undefined
         : await readRequestBody(input.request);
-    const upstreamResponse = await fetch(upstreamUrl, {
+    const upstreamResponse = await upstreamFetch(upstreamUrl, {
       method: input.request.method,
       headers,
       signal: input.signal,
+      dispatcher: input.upstreamDispatcher,
       ...(body ? { body: new Uint8Array(body) } : {}),
     });
     requestTelemetry.status = upstreamResponse.status;

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -10,10 +10,14 @@ import type { Socket } from 'node:net';
 import { Agent, type Dispatcher, Headers, fetch as upstreamFetch } from 'undici';
 
 /** Upstream connections must stay on HTTP/1.1. Providers negotiate h2 via
- * ALPN, and undici's HTTP/2 client runs one request at a time per origin
- * connection, so concurrent streaming completions from parallel cells
- * serialize behind each other's full generation streams — observed as
- * multi-minute first-token waits attributed to the provider. */
+ * ALPN, and undici <= 8.7 (bundled in Node 26) refuses to multiplex
+ * stream/async-iterable request bodies on an h2 session with requests in
+ * flight, while its fetch wraps every non-empty body into an async iterable —
+ * so concurrent streaming completions from parallel cells serialized behind
+ * each other's full generation streams, recorded as provider first-token
+ * latency. undici 8.8 removed that gate, but forcing h1 keeps the proxy
+ * independent of which undici build serves the fetch: h1 pools sidestep the
+ * whole class by dialing parallel connections. */
 export function createProviderUpstreamDispatcher(options: Agent.Options = {}): Dispatcher {
   return new Agent({ ...options, allowH2: false });
 }

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -547,9 +547,11 @@ function upstreamStartTimedDispatcher(
 ): Dispatcher {
   return dispatcher.compose((dispatch) => (options, handler) => {
     const timed: Dispatcher.DispatchHandler = Object.create(handler);
-    timed.onRequestStart = (controller, context) => {
+    timed.onRequestStart = function (controller, context) {
       requestTelemetry.upstreamStartMs ??= elapsedMs(startedAt, now());
-      return handler.onRequestStart?.(controller, context);
+      // Keep `this` = the wrapper for the delegated call too, so handler state
+      // written across callbacks always lands on one object.
+      return handler.onRequestStart?.call(this, controller, context);
     };
     return dispatch(options, timed);
   });

--- a/packages/headless/src/provider-auth-proxy.ts
+++ b/packages/headless/src/provider-auth-proxy.ts
@@ -54,6 +54,12 @@ export interface ProviderRequestTelemetry {
   protocol?: ProviderUsageProtocol;
   status?: number;
   outcome: 'completed' | 'interrupted' | 'failed' | 'aborted';
+  /** When the dispatcher started writing the request to an upstream
+   * connection. Time before this is credential resolution, request-body read,
+   * and the dispatcher's connection queue; `responseHeadersMs` minus this is
+   * pure upstream wait. The h2 serialization defect hid inside this interval
+   * while `responseHeadersMs` alone read as provider latency. */
+  upstreamStartMs?: number;
   responseHeadersMs?: number;
   firstBodyChunkMs?: number;
   firstOutputTokenMs?: number;
@@ -450,7 +456,12 @@ async function forwardProviderRequest(input: {
       method: input.request.method,
       headers,
       signal: input.signal,
-      dispatcher: input.upstreamDispatcher,
+      dispatcher: upstreamStartTimedDispatcher(
+        input.upstreamDispatcher,
+        requestTelemetry,
+        startedAt,
+        input.now,
+      ),
       ...(body ? { body: new Uint8Array(body) } : {}),
     });
     requestTelemetry.status = upstreamResponse.status;
@@ -523,6 +534,25 @@ async function forwardProviderRequest(input: {
     if (!input.response.headersSent) input.response.writeHead(502);
     input.response.end('provider proxy request failed');
   }
+}
+
+/** Stamp `upstreamStartMs` when the dispatcher begins writing the request to
+ * an upstream connection, so connection-queue time is separable from upstream
+ * wait in the recorded telemetry. */
+function upstreamStartTimedDispatcher(
+  dispatcher: Dispatcher,
+  requestTelemetry: MutableProviderRequestTelemetry,
+  startedAt: number,
+  now: () => number,
+): Dispatcher {
+  return dispatcher.compose((dispatch) => (options, handler) => {
+    const timed: Dispatcher.DispatchHandler = Object.create(handler);
+    timed.onRequestStart = (controller, context) => {
+      requestTelemetry.upstreamStartMs ??= elapsedMs(startedAt, now());
+      return handler.onRequestStart?.(controller, context);
+    };
+    return dispatch(options, timed);
+  });
 }
 
 async function resolveUpstreamCredentialUntilAborted(


### PR DESCRIPTION
## Summary

All proxied harness cells (`opencode` / `kimi-code` / `codex` arms, and any Maka arm configured through the proxy) share one Node process, and the proxy forwarded upstream requests with the global `fetch`. Provider gateways (`api.z.ai`, `api.kimi.com`) negotiate HTTP/2 via ALPN, and once one h2 session existed, every concurrent cell's streaming completion serialized behind the full generation streams of the others (root cause below). The queueing happened between proxy receipt and upstream dispatch, so telemetry recorded it as provider first-token latency.

Measured impact in existing runs (same key, same windows, direct-connect arms unaffected at ~1.5–4.5 s):

| run | proxied arm first-token wait | share of wall clock |
|---|---|---|
| TB 2.1 GLM-5.2 Maka vs OpenCode (3 rounds) | p50 12.5 s, mean 32.8 s, max 628 s | 57.8% of the OpenCode arm |
| TB 2.1 K3 Maka vs Kimi Code v11 | p50 13.7 s, mean 35.1 s, max 1,023 s | — |

The fix routes upstream fetches through an explicit undici `Agent` with `allowH2` disabled (HTTP/1.1 pools dial parallel connections), injectable per route so tests can trust a local CA. Switching to the npm `undici@8.8.0` fetch also independently removes the gate; forcing h1 keeps the proxy safe regardless of which undici build serves the fetch.

Existing A/B timing conclusions drawn from proxied arms need re-examination; report corrections are tracked separately.

## Root cause

Node 26.5.0 bundles undici 8.7.0. Its `fetch` wraps every non-empty request body into an async iterable (`lib/web/fetch/index.js`), and its h2 client refuses to multiplex stream/async-iterable bodies on a session with requests in flight (`lib/dispatcher/client-h2.js` `busy()`: `bodyLength !== 0 && (isStream || isAsyncIterable || isFormDataLike)` → busy), because such bodies cannot be retried after a mid-flight session error. The queued request stays in the h2 client's queue — the pool never dials a second connection. Net effect: every streaming POST to the same origin from one process runs strictly one-at-a-time. undici 8.8.0 removed this gate and multiplexes up to `maxConcurrentStreams`.

Differential confirmation (local ALPN-h2 upstream, zero network): staggered POSTs via built-in fetch serialize on one session; staggered GETs (empty body) multiplex on the same session; staggered POSTs via npm undici 8.8.0 with h2 enabled multiplex. Against the real provider: 4 staggered streaming requests + 1 tiny request from one process serialized strictly (tiny request waited 30.8 s); the same schedule from separate processes ran fully parallel (3.65 s).

## Verification

- `npm run test --workspace @maka/headless` — 1432 tests, 0 failures.
- New regression test drives two concurrent held-open SSE streams through the proxy against a local ALPN-h2 upstream. The `httpVersion === '1.1'` assertion is the timing-independent lock; the upstream additionally refuses to end either stream until both have arrived, so the undici ≤ 8.7 staggered-dispatch path deadlocks instead of passing by luck. Mutation check: flipping `allowH2: true` in the built dispatcher makes exactly this test fail.
- End-to-end against the real provider through the fixed proxy in one process: 4 concurrent long streams got response headers in 3.7–4.0 s in parallel, and a fifth request injected mid-stream got headers in 5.5 s (previously 30.8 s under the same schedule).
- Independent external review (Codex) confirmed the root-cause chain against undici 8.7/8.8 sources and Node 26.5.0's embedded snapshot, found no P0/P1, and prompted the comment narrowing in the follow-up commit.
- `npm run format` / `npm run lint` clean.

## Observability

`responseHeadersMs` starts at proxy receipt, so dispatcher connection-queue time was indistinguishable from upstream wait — the interval where the serialization hid for two benchmark campaigns. The new `upstreamStartMs` telemetry field stamps the moment undici begins writing the request to an upstream connection (per-request composed dispatcher wrapping `onRequestStart`); `responseHeadersMs − upstreamStartMs` is now pure upstream wait. Live check through the fixed proxy: `upstreamStartMs` 231–403 ms across 5 concurrent requests while headers took 1.9–4.7 s — under the old defect this field would have read 10–30 s and exposed the queue on day one.

## Review focus

- Known bypasses left as-is: Codex OAuth token refresh uses global fetch (single refresh under a credential-store lease; not a completion path), and the Copilot model probe is a bodyless GET that does not hit the gate.
- `proxy.close()` intentionally does not close the module-level shared dispatcher; idle h1 sockets are unref'd and do not hold the process open.


## Post-review hardening

Two independent optimality reviews (Codex CLI and a separate Claude subagent, same criteria: first principles / Occam / test lock enumeration / refactor-to-optimal) both reported no P0/P1 and recommended merging. Accepted findings landed as the last two commits:

- `onRequestStart` delegation now binds `this` to the wrapper (`.call(this, ...)`), removing a latent dependency on which side of the `Object.create` prototype split undici handler callbacks write their state to.
- A deterministic injected-clock test locks `upstreamStartMs` to dispatcher queue-exit semantics: one upstream connection holds the first stream while the second request provably enters the pool queue (compose-counter gate, no wall-clock waits), then exact equalities distinguish queue-exit (5000) from a pre-dispatch stamp (0), a response-headers stamp (6000), or a dropped stamp (undefined). Mutation-verified.

Recorded as accepted residual risk (both reviews concur): the default-singleton fallback path (`?? defaultUpstreamDispatcher`) has no direct test — the injected-dispatcher mutation lock plus `Agent`'s own `allowH2: false` default keep the invariant — and the inline test PEM pair is a throwaway localhost self-signed keypair, not a secret.
