### PR TITLE
feat: mount the Astryx substrate behind the legacy cascade

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -38,6 +38,8 @@
     "smoke:browser": "npm --workspace @maka/core run build && npm --workspace @maka/runtime run build && npm --workspace @maka/computer-use run build && npm run build:main && electron scripts/browser-observe-act-smoke.mjs"
   },
   "dependencies": {
+    "@astryxdesign/core": "0.1.9",
+    "@astryxdesign/theme-neutral": "0.1.9",
     "@base-ui/react": "^1.5.0",
     "@jackwener/opencli": "1.8.4",
     "@maka/computer-use": "0.1.0",

--- a/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
+++ b/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
@@ -403,6 +403,66 @@ SOFTWARE.
 
 ================================================================================
 
+Package: @astryxdesign/core@0.1.9
+Declared license: MIT
+Selected license: MIT
+Repository: git+https://github.com/facebook/astryx.git#packages/core
+
+--- VERSION-PINNED LICENSE TEXT OVERRIDE ---
+MIT License
+
+Copyright (c) 2026 Meta Platforms, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================================
+
+Package: @astryxdesign/theme-neutral@0.1.9
+Declared license: MIT
+Selected license: MIT
+Repository: git+https://github.com/facebook/astryx.git#packages/themes/neutral
+
+--- LICENSE ---
+MIT License
+
+Copyright (c) 2026 Meta Platforms, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================================
+
 Package: @babel/runtime@7.29.7
 Declared license: MIT
 Selected license: MIT
@@ -882,6 +942,60 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
+Package: @formatjs/fast-memoize@3.1.7
+Declared license: MIT
+Selected license: MIT
+Repository: formatjs/formatjs.git
+
+--- LICENSE.md ---
+MIT License
+
+Copyright (c) 2023 FormatJS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
+Package: @formatjs/icu-messageformat-parser@3.5.15
+Declared license: MIT
+Selected license: MIT
+Repository: https://github.com/formatjs/formatjs.git#packages/icu-messageformat-parser
+
+--- LICENSE.md ---
+MIT License
+
+Copyright (c) 2023 FormatJS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
+Package: @formatjs/icu-skeleton-parser@2.1.11
+Declared license: MIT
+Selected license: MIT
+Repository: https://github.com/formatjs/formatjs.git#packages/icu-skeleton-parser
+
+--- LICENSE.md ---
+MIT License
+
+Copyright (c) 2023 FormatJS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
@@ -1756,6 +1870,36 @@ Repository: https://github.com/standard-schema/standard-schema
 MIT License
 
 Copyright (c) 2024 Colin McDonnell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================================
+
+Package: @stylexjs/stylex@0.19.0
+Declared license: MIT
+Selected license: MIT
+Repository: git+https://github.com/facebook/stylex.git
+
+--- VERSION-PINNED LICENSE TEXT OVERRIDE ---
+MIT License
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -5713,6 +5857,42 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+================================================================================
+
+Package: css-mediaquery@0.1.2
+Declared license: BSD-3-Clause
+Selected license: BSD-3-Clause
+Repository: git://github.com/ericf/css-mediaquery.git
+
+--- LICENSE ---
+Copyright 2014 Yahoo! Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+
+    * Neither the name of the Yahoo! Inc. nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL YAHOO! INC. BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ================================================================================
 
@@ -9787,6 +9967,78 @@ THIS SOFTWARE.
 
 ================================================================================
 
+Package: intl-messageformat@11.2.12
+Declared license: BSD-3-Clause
+Selected license: BSD-3-Clause
+Repository: git@github.com:formatjs/formatjs.git
+
+--- LICENSE.md ---
+Copyright (c) 2023, Oath Inc.
+
+Licensed under the terms of the New BSD license. See below for terms.
+
+Redistribution and use of this software in source and binary forms,
+with or without modification, are permitted provided that the following
+conditions are met:
+
+- Redistributions of source code must retain the above
+  copyright notice, this list of conditions and the
+  following disclaimer.
+
+- Redistributions in binary form must reproduce the above
+  copyright notice, this list of conditions and the
+  following disclaimer in the documentation and/or other
+  materials provided with the distribution.
+
+- Neither the name of Oath Inc. nor the names of its
+  contributors may be used to endorse or promote products
+  derived from this software without specific prior
+  written permission of Oath Inc.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS
+IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+================================================================================
+
+Package: invariant@2.2.4
+Declared license: MIT
+Selected license: MIT
+Repository: https://github.com/zertosh/invariant
+
+--- LICENSE ---
+MIT License
+
+Copyright (c) 2013-present, Facebook, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================================
+
 Package: ip-address@10.2.0
 Declared license: MIT
 Selected license: MIT
@@ -10130,6 +10382,36 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
+
+================================================================================
+
+Package: js-tokens@4.0.0
+Declared license: MIT
+Selected license: MIT
+Repository: lydell/js-tokens
+
+--- LICENSE ---
+The MIT License (MIT)
+
+Copyright (c) 2014, 2015, 2016, 2017, 2018 Simon Lydell
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
 
 ================================================================================
 
@@ -11207,6 +11489,36 @@ SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ================================================================================
 
+Package: loose-envify@1.4.0
+Declared license: MIT
+Selected license: MIT
+Repository: git://github.com/zertosh/loose-envify.git
+
+--- LICENSE ---
+The MIT License (MIT)
+
+Copyright (c) 2015 Andres Suarez <zertosh@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+================================================================================
+
 Package: lowlight@3.3.0
 Declared license: MIT
 Selected license: MIT
@@ -11265,6 +11577,58 @@ OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 The MIT License (MIT) (for portions derived from Feather)
 
 Copyright (c) 2013-2026 Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+================================================================================
+
+Package: lucide-react@1.28.0
+Declared license: ISC
+Selected license: ISC
+Repository: https://github.com/lucide-icons/lucide.git#packages/lucide-react
+
+--- LICENSE ---
+ISC License
+
+Copyright (c) 2026 Lucide Icons and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+---
+
+The following Lucide icons are derived from the Feather project:
+
+airplay, alert-circle, alert-octagon, alert-triangle, aperture, arrow-down-circle, arrow-down-left, arrow-down-right, arrow-down, arrow-left-circle, arrow-left, arrow-right-circle, arrow-right, arrow-up-circle, arrow-up-left, arrow-up-right, arrow-up, at-sign, calendar, cast, check, chevron-down, chevron-left, chevron-right, chevron-up, chevrons-down, chevrons-left, chevrons-right, chevrons-up, circle, clipboard, clock, code, columns, command, compass, corner-down-left, corner-down-right, corner-left-down, corner-left-up, corner-right-down, corner-right-up, corner-up-left, corner-up-right, crosshair, database, divide-circle, divide-square, dollar-sign, download, external-link, feather, frown, hash, headphones, help-circle, info, italic, key, layout, life-buoy, link-2, link, loader, lock, log-in, log-out, maximize, meh, minimize, minimize-2, minus-circle, minus-square, minus, monitor, moon, more-horizontal, more-vertical, move, music, navigation-2, navigation, octagon, pause-circle, percent, plus-circle, plus-square, plus, power, radio, rss, search, server, share, shopping-bag, sidebar, smartphone, smile, square, table-2, tablet, target, terminal, trash-2, trash, triangle, tv, type, upload, x-circle, x-octagon, x-square, x, zoom-in, zoom-out
+
+The MIT License (MIT) (for the icons listed above)
+
+Copyright (c) 2013-present Cole Bemis
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -15589,6 +15953,36 @@ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
+Package: styleq@0.2.1
+Declared license: MIT
+Selected license: MIT
+Repository: https://github.com/necolas/styleq
+
+--- LICENSE ---
+MIT License
+
+Copyright (c) Nicolas Gallagher
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ================================================================================
 

--- a/apps/desktop/src/main/__tests__/renderer-style-layer-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-style-layer-cascade-contract.test.ts
@@ -70,9 +70,28 @@ describe('renderer style layer cascade contract', () => {
     const declarations = [...layersFile.matchAll(/@layer\s+([^;{]+);/g)];
     assert.equal(declarations.length, 1, 'cascade-layers.css must contain exactly one @layer order declaration');
     const order = declarations[0][1].split(',').map((name) => name.trim());
+    // The astryx layers must be TOP-LEVEL names. A sub-layer sits at its
+    // parent's position, and a parent is ordered by its FIRST occurrence —
+    // `astryx.reset, …, base, astryx.components` would collapse every
+    // astryx.* layer to the astryx.reset slot below `base`, and Tailwind
+    // preflight would beat every Astryx component rule (#1565 PR 2 review).
+    // maka.legacy is exempt: it is the sole maka.* layer, so it has no
+    // sibling sub-layer to mis-order against.
+    const nested = order.filter((name) => name.includes('.') && name !== 'maka.legacy');
+    assert.deepEqual(
+      nested,
+      [],
+      'cascade-layers.css must not use dotted sub-layers: a sub-layer collapses to its parent layer’s ' +
+        'first-occurrence position, which silently breaks the intended interleaving',
+    );
     for (const [earlier, later] of [
+      ['astryx-reset', 'astryx-tokens'],
+      ['astryx-tokens', 'theme'],
       ['theme', 'base'],
-      ['base', 'components'],
+      // Astryx component rules must beat Tailwind preflight's element resets,
+      // and product CSS must keep beating Astryx until a slice removes it.
+      ['base', 'astryx-components'],
+      ['astryx-components', 'components'],
       ['components', 'utilities'],
       ['utilities', 'maka.legacy'],
     ]) {
@@ -119,16 +138,16 @@ describe('renderer style layer cascade contract', () => {
       './maka-tokens.css',
     ]);
     // Astryx ships its sheets unlayered; each import must be pinned into its
-    // astryx.* layer or it outranks maka.legacy and repaints the app (#1565
-    // PR 2). Exact layer per file, not "any astryx.*": reset above components
+    // astryx-* layer or it outranks maka.legacy and repaints the app (#1565
+    // PR 2). Exact layer per file, not "any astryx-*": reset above components
     // would flip Astryx's own internal cascade. reset.css (PR 12, with the
     // Tailwind-preflight retirement) and theme.css (PR 3, with the first
     // component consumer) are not imported yet; their entries pin the layer
     // each must land in when it arrives.
     const contractedAstryx = new Map([
-      ['@astryxdesign/core/reset.css', 'astryx.reset'],
-      ['@astryxdesign/core/astryx.css', 'astryx.components'],
-      ['@astryxdesign/theme-neutral/theme.css', 'astryx.tokens'],
+      ['@astryxdesign/core/reset.css', 'astryx-reset'],
+      ['@astryxdesign/core/astryx.css', 'astryx-components'],
+      ['@astryxdesign/theme-neutral/theme.css', 'astryx-tokens'],
     ]);
     const misplaced = imports.filter(({ specifier, layer }) => {
       if (contractedUnlayered.has(specifier)) return layer !== null;

--- a/apps/desktop/src/main/__tests__/renderer-style-layer-cascade-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-style-layer-cascade-contract.test.ts
@@ -118,11 +118,23 @@ describe('renderer style layer cascade contract', () => {
       '@fontsource-variable/geist-mono',
       './maka-tokens.css',
     ]);
-    const misplaced = imports.filter(({ specifier, layer }) =>
-      contractedUnlayered.has(specifier)
-        ? layer !== null
-        : layer !== 'maka.legacy' && layer !== 'components',
-    );
+    // Astryx ships its sheets unlayered; each import must be pinned into its
+    // astryx.* layer or it outranks maka.legacy and repaints the app (#1565
+    // PR 2). Exact layer per file, not "any astryx.*": reset above components
+    // would flip Astryx's own internal cascade. reset.css (PR 12, with the
+    // Tailwind-preflight retirement) and theme.css (PR 3, with the first
+    // component consumer) are not imported yet; their entries pin the layer
+    // each must land in when it arrives.
+    const contractedAstryx = new Map([
+      ['@astryxdesign/core/reset.css', 'astryx.reset'],
+      ['@astryxdesign/core/astryx.css', 'astryx.components'],
+      ['@astryxdesign/theme-neutral/theme.css', 'astryx.tokens'],
+    ]);
+    const misplaced = imports.filter(({ specifier, layer }) => {
+      if (contractedUnlayered.has(specifier)) return layer !== null;
+      if (contractedAstryx.has(specifier)) return layer !== contractedAstryx.get(specifier);
+      return layer !== 'maka.legacy' && layer !== 'components';
+    });
     assert.deepEqual(
       misplaced.map(({ specifier, layer }) => `${specifier} -> ${layer ?? 'unlayered'}`),
       [],

--- a/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
+++ b/apps/desktop/src/renderer/app-shell-chrome-actions.tsx
@@ -34,7 +34,7 @@ export function AppShellTopbarActions(props: {
   const locale = useUiLocale();
   const copy = getShellCopy(locale).chrome;
   return (
-    <div className="maka-shell-topbar-rail" aria-label={copy.windowActions}>
+    <div className="maka-shell-topbar-rail" data-maka-contract="shell-topbar-rail" aria-label={copy.windowActions}>
       <Tooltip>
         <TooltipTrigger
           render={<UiButton variant="quiet" size="icon-sm" />}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -33,6 +33,7 @@ import {
   type ComposerHandle,
   type MakaUriDest,
   MakaUriContext,
+  AstryxLocaleProvider,
   LocaleProvider,
   ModuleHubSelector,
   ToastProvider,
@@ -184,17 +185,23 @@ export function AppShell({ initialOnboardingSnapshot = null }: AppShellProps = {
 
   return (
     <LocaleProvider locale={uiLocale} override={uiLocaleOverride}>
-      <ToastProvider>
-        <ErrorBoundary locale={uiLocale}>
-          <AppShellContent
-            initialOnboardingSnapshot={initialOnboardingSnapshot}
-            uiLocale={uiLocale}
-            uiLocaleOverride={uiLocaleOverride}
-            setUiLocaleOverride={setUiLocaleOverride}
-            setUiLocalePreference={setUiLocalePreference}
-          />
-        </ErrorBoundary>
-      </ToastProvider>
+      {/* #1565: Astryx's message catalog is keyed off OUR locale context, so it
+          must sit inside LocaleProvider — not at the `<Theme>` level, where
+          `useUiLocale()` throws before anything renders. Still above every
+          Astryx subtree. */}
+      <AstryxLocaleProvider>
+        <ToastProvider>
+          <ErrorBoundary locale={uiLocale}>
+            <AppShellContent
+              initialOnboardingSnapshot={initialOnboardingSnapshot}
+              uiLocale={uiLocale}
+              uiLocaleOverride={uiLocaleOverride}
+              setUiLocaleOverride={setUiLocaleOverride}
+              setUiLocalePreference={setUiLocalePreference}
+            />
+          </ErrorBoundary>
+        </ToastProvider>
+      </AstryxLocaleProvider>
     </LocaleProvider>
   );
 }

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -1,5 +1,8 @@
 import { StrictMode, useEffect } from 'react';
+import { Theme } from '@astryxdesign/core/theme';
+import { neutralTheme } from '@astryxdesign/theme-neutral/built';
 import { AppShell } from './app-shell';
+import { useAstryxThemeMode } from './astryx-theme-mode';
 import type { OnboardingSnapshot } from '../preload/bridge-contract.js';
 
 export function App({
@@ -32,9 +35,15 @@ export function App({
       if (secondFrame) cancelAnimationFrame(secondFrame);
     };
   }, []);
+  // Astryx owns the component/design system (issue #1565). It sits inside
+  // StrictMode and follows our already-resolved color mode; see
+  // astryx-theme-mode.ts for why we don't hand it `mode="system"`.
+  const astryxMode = useAstryxThemeMode();
   return (
     <StrictMode>
-      <AppShell initialOnboardingSnapshot={initialOnboardingSnapshot} />
+      <Theme theme={neutralTheme} mode={astryxMode}>
+        <AppShell initialOnboardingSnapshot={initialOnboardingSnapshot} />
+      </Theme>
     </StrictMode>
   );
 }

--- a/apps/desktop/src/renderer/astryx-theme-mode.ts
+++ b/apps/desktop/src/renderer/astryx-theme-mode.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react';
+import type { ThemeMode } from '@astryxdesign/core/theme';
+
+const DARK_CLASS = 'dark';
+
+function readMode(): ThemeMode {
+  return document.documentElement.classList.contains(DARK_CLASS) ? 'dark' : 'light';
+}
+
+/**
+ * Astryx follows OUR resolved color mode instead of running its own
+ * `mode="system"` resolution.
+ *
+ * `<html class="dark">` is already the single source of truth for the resolved
+ * mode: `applyCachedThemeBeforeMount` sets it before React mounts (FOUC
+ * prevention) and `applyTheme` maintains it afterwards, including the `auto`
+ * preference's matchMedia subscription, the palette attribute and the Electron
+ * titlebar-overlay sync. Letting Astryx resolve `system` independently would
+ * create a second source of truth that can disagree with ours for a frame — so
+ * we observe the class and hand Astryx an already-resolved `light`/`dark`.
+ */
+export function useAstryxThemeMode(): ThemeMode {
+  const [mode, setMode] = useState<ThemeMode>(readMode);
+
+  useEffect(() => {
+    const sync = () => {
+      setMode((current) => {
+        const next = readMode();
+        return current === next ? current : next;
+      });
+    };
+    sync();
+    const observer = new MutationObserver(sync);
+    observer.observe(document.documentElement, { attributes: true, attributeFilter: ['class'] });
+    return () => observer.disconnect();
+  }, []);
+
+  return mode;
+}

--- a/apps/desktop/src/renderer/cascade-layers.css
+++ b/apps/desktop/src/renderer/cascade-layers.css
@@ -1,5 +1,14 @@
 /* Single owner of the renderer cascade layer order (#1565). Later PRs may
    append layers; never reorder existing ones. maka.legacy is declared last
    so legacy product CSS keeps beating components/utilities, exactly as its
-   unlayered form did. */
-@layer theme, base, components, utilities, maka.legacy;
+   unlayered form did.
+
+   The astryx.* layers (PR 2) hold Astryx's own sheets. Astryx ships them
+   UNLAYERED, and unlayered CSS beats every layer — importing them without a
+   layer() wrapper would put Astryx above maka.legacy and repaint the app on
+   mount. Wrapped, they sit at the bottom: buried by legacy CSS until a slice
+   deletes the legacy rule, at which point Astryx takes over exactly there.
+   astryx.components sits above base (its component rules must beat our
+   element resets) but below components/utilities/maka.legacy (product CSS
+   keeps winning until its slice removes it). */
+@layer astryx.reset, astryx.tokens, theme, base, astryx.components, components, utilities, maka.legacy;

--- a/apps/desktop/src/renderer/cascade-layers.css
+++ b/apps/desktop/src/renderer/cascade-layers.css
@@ -3,12 +3,20 @@
    so legacy product CSS keeps beating components/utilities, exactly as its
    unlayered form did.
 
-   The astryx.* layers (PR 2) hold Astryx's own sheets. Astryx ships them
+   The astryx-* layers (PR 2) hold Astryx's own sheets. Astryx ships them
    UNLAYERED, and unlayered CSS beats every layer — importing them without a
    layer() wrapper would put Astryx above maka.legacy and repaint the app on
-   mount. Wrapped, they sit at the bottom: buried by legacy CSS until a slice
-   deletes the legacy rule, at which point Astryx takes over exactly there.
-   astryx.components sits above base (its component rules must beat our
-   element resets) but below components/utilities/maka.legacy (product CSS
-   keeps winning until its slice removes it). */
-@layer astryx.reset, astryx.tokens, theme, base, astryx.components, components, utilities, maka.legacy;
+   mount. Wrapped, they sit below maka.legacy: buried by legacy CSS until a
+   slice deletes the legacy rule, at which point Astryx takes over exactly
+   there. astryx-components sits above base (its component rules must beat
+   Tailwind preflight's element resets) but below components/utilities/
+   maka.legacy (product CSS keeps winning until its slice removes it).
+
+   These are deliberately top-level names, NOT astryx.* sub-layers: a
+   sub-layer's position is its parent's, and a parent layer is ordered by its
+   FIRST occurrence — `astryx.reset, theme, base, astryx.components` would
+   collapse every astryx.* layer to the `astryx.reset` slot at the bottom,
+   and Tailwind preflight in `base` would beat every Astryx component rule.
+   The dot in maka.legacy is safe only because it is the sole maka.* layer,
+   so there is no second sub-layer to mis-order against. */
+@layer astryx-reset, astryx-tokens, theme, base, astryx-components, components, utilities, maka.legacy;

--- a/apps/desktop/src/renderer/chat-message-surface.tsx
+++ b/apps/desktop/src/renderer/chat-message-surface.tsx
@@ -62,7 +62,7 @@ export function ChatMessageSurface({
   );
   const emptyOverride: ReactNode =
     showOnboardingHero && onboardingState ? (
-      <div className="maka-onboarding-surface">
+      <div className="maka-onboarding-surface" data-maka-contract="onboarding-surface">
         <OnboardingHero
           state={onboardingState}
           onOpenSettings={onOpenSettings}

--- a/apps/desktop/src/renderer/chat-workbar.tsx
+++ b/apps/desktop/src/renderer/chat-workbar.tsx
@@ -19,7 +19,7 @@ const SessionWorkbar = lazy(() => import('./session-workbar').then((m) => ({ def
 function SessionWorkbarFallback() {
   const copy = getShellCopy(useUiLocale()).app;
   return (
-    <aside className="maka-session-workbar" role="status" aria-busy="true" aria-label={copy.loadingWorkbarLabel}>
+    <aside className="maka-session-workbar" data-maka-contract="session-workbar" role="status" aria-busy="true" aria-label={copy.loadingWorkbarLabel}>
       <div className="maka-lazy-fallback" data-surface="panel">{copy.loadingWorkbar}</div>
     </aside>
   );

--- a/apps/desktop/src/renderer/mcp-page.tsx
+++ b/apps/desktop/src/renderer/mcp-page.tsx
@@ -264,7 +264,7 @@ export function McpPage(props: { hubHeader?: ModuleHubHeader }) {
   }
 
   return (
-    <main className="maka-main detailPane maka-module-main maka-mcp-page agents-chat-panel" data-module="mcp" aria-label={props.hubHeader?.title ?? 'MCP'}>
+    <main className="maka-main detailPane maka-module-main maka-mcp-page agents-chat-panel" data-maka-contract="module-main" data-module="mcp" aria-label={props.hubHeader?.title ?? 'MCP'}>
       <PageHeader
         className="maka-module-main-header"
         as="h2"

--- a/apps/desktop/src/renderer/session-workbar.tsx
+++ b/apps/desktop/src/renderer/session-workbar.tsx
@@ -61,6 +61,7 @@ export function SessionWorkbar(props: {
   return (
     <aside
       className="maka-session-workbar"
+      data-maka-contract="session-workbar"
       aria-label={copy.ariaLabel}
       style={{ '--maka-session-workbar-width': `${props.width}px` } as CSSProperties}
     >
@@ -68,14 +69,14 @@ export function SessionWorkbar(props: {
         <PrimitiveTabsList variant="underline" className="maka-session-workbar-tab-list" aria-label={copy.sectionsAriaLabel}>
           <PrimitiveTabsTrigger value="tasks">
             <span>{copy.tasks}</span>
-            <span className="maka-session-workbar-count">{taskCount}</span>
+            <span className="maka-session-workbar-count" data-maka-contract="session-workbar-count">{taskCount}</span>
           </PrimitiveTabsTrigger>
           <PrimitiveTabsTrigger value="browser" disabled={!props.browserLive}>
             <span>{copy.browser}</span>
           </PrimitiveTabsTrigger>
           <PrimitiveTabsTrigger value="files">
             <span>{copy.files}</span>
-            <span className="maka-session-workbar-count">{artifactCount}</span>
+            <span className="maka-session-workbar-count" data-maka-contract="session-workbar-count">{artifactCount}</span>
           </PrimitiveTabsTrigger>
           {props.quote && (
             <PrimitiveTabsTrigger value="quote">

--- a/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
+++ b/apps/desktop/src/renderer/settings/ProvidersPanel.tsx
@@ -181,7 +181,7 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
 
   if (loading) {
     return (
-      <div className="providersPanel providersLoading" aria-busy="true" aria-label={copy.loadingAria}>
+      <div className="providersPanel providersLoading" data-maka-contract="providers-panel" aria-busy="true" aria-label={copy.loadingAria}>
         <div className="providersLoadingStrip">
           <div className="maka-skeleton maka-skeleton-line" data-size="lg" style={{ width: '34%' }} />
           <div className="maka-skeleton maka-skeleton-line" data-size="sm" style={{ width: '52%' }} />
@@ -196,7 +196,7 @@ export function ProvidersPanel({ bridge, initialPage = 'connections', initialCon
   const createType = dialogState?.kind === 'create' ? dialogState.providerType : null;
 
   return (
-    <div ref={providersPanelRef} className="providersPanel providersMarketPanel">
+    <div ref={providersPanelRef} className="providersPanel providersMarketPanel" data-maka-contract="providers-panel">
       <section className="providerMarket">
         <div className="enabledStrip" aria-label={copy.connectionsAria}>
           <SectionHeader

--- a/apps/desktop/src/renderer/settings/settings-rows.tsx
+++ b/apps/desktop/src/renderer/settings/settings-rows.tsx
@@ -3,7 +3,7 @@ import { Card } from '@maka/ui';
 
 export function SettingsRows({ className, children }: { className?: string; children: ReactNode }) {
   return (
-    <Card className={className ? `settingsRows ${className}` : 'settingsRows'}>
+    <Card className={className ? `settingsRows ${className}` : 'settingsRows'} data-maka-contract="settings-rows">
       {children}
     </Card>
   );

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -229,7 +229,7 @@ export function SettingsSurface(props: {
 
   return (
     <main className="settingsSurface agents-layout-body" data-modal="true" aria-label={copy.contentLabel}>
-      <aside className="settingsSidebar agents-sidebar" data-settings-nav-column aria-label={copy.sidebarLabel}>
+      <aside className="settingsSidebar agents-sidebar" data-maka-contract="settings-sidebar" data-settings-nav-column aria-label={copy.sidebarLabel}>
         <div className="settingsSidebarInner">
           {/* PR-SETTINGS-NO-PANE-BORDER-0 (WAWQAQ msg `8effe691`):
               reference sidebar has just `← 返回应用` then straight

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -2,6 +2,27 @@
 @import "tailwindcss";
 @source "../../../../packages/ui/src";
 
+/* Astryx substrate (#1565 PR 2). Each import is wrapped in its astryx.*
+   layer — see cascade-layers.css for why unlayered Astryx would invert the
+   whole cascade.
+
+   Three Astryx sheets are deliberately NOT imported yet — each targets bare
+   elements or shadows product tokens, which no layer order can bury (a rule
+   wins wherever no product rule competes; a custom property on the Theme
+   wrapper wins by tree distance):
+   - reset.css (cursor on buttons, small/code sizing) replaces Tailwind
+     preflight and lands with the slice that removes it (PR 12).
+   - theme-neutral/theme.css declares its tokens on the Theme wrapper AND
+     ships @scope'd element typography (:where(p), :where(h1..h6) take the
+     Astryx font). It lands with the first component consumer (PR 3) —
+     preferably as an `astryx theme build` of a Maka-named theme so the
+     element-typography block is dropped at the source, not neutralized
+     downstream.
+   - tailwind-theme.css: the existing @theme inline bridge below stays the
+     single source for utility tokens until Tailwind leaves in PR 12.
+   Layer slots for all of them are already reserved in cascade-layers.css. */
+@import "@astryxdesign/core/astryx.css" layer(astryx.components);
+
 /* Bundled Geist fallbacks; maka-tokens.css owns the product font stacks. */
 @import "@fontsource-variable/geist";
 @import "@fontsource-variable/geist-mono";
@@ -57,6 +78,7 @@
 @import "./styles/prompt-rail.css" layer(maka.legacy);
 @import "./styles/quote-chip.css" layer(maka.legacy);
 @import "./styles/quote-side-panel.css" layer(maka.legacy);
+@import "./styles/astryx-mount.css" layer(maka.legacy);
 
 @theme inline {
   --color-background: var(--background);

--- a/apps/desktop/src/renderer/styles.css
+++ b/apps/desktop/src/renderer/styles.css
@@ -2,9 +2,10 @@
 @import "tailwindcss";
 @source "../../../../packages/ui/src";
 
-/* Astryx substrate (#1565 PR 2). Each import is wrapped in its astryx.*
+/* Astryx substrate (#1565 PR 2). Each import is wrapped in its astryx-*
    layer — see cascade-layers.css for why unlayered Astryx would invert the
-   whole cascade.
+   whole cascade, and why the layers are top-level names rather than
+   astryx.* sub-layers.
 
    Three Astryx sheets are deliberately NOT imported yet — each targets bare
    elements or shadows product tokens, which no layer order can bury (a rule
@@ -21,7 +22,7 @@
    - tailwind-theme.css: the existing @theme inline bridge below stays the
      single source for utility tokens until Tailwind leaves in PR 12.
    Layer slots for all of them are already reserved in cascade-layers.css. */
-@import "@astryxdesign/core/astryx.css" layer(astryx.components);
+@import "@astryxdesign/core/astryx.css" layer(astryx-components);
 
 /* Bundled Geist fallbacks; maka-tokens.css owns the product font stacks. */
 @import "@fontsource-variable/geist";

--- a/apps/desktop/src/renderer/styles/astryx-mount.css
+++ b/apps/desktop/src/renderer/styles/astryx-mount.css
@@ -13,8 +13,14 @@
    legacy layer exists, and is deleted with it in PR 11 — at which point
    Astryx is supposed to own the inheritance baseline. color-scheme is left
    alone: the wrapper's mode comes from the same resolved `.dark` source as
-   the product's, so the values always agree. */
-[data-astryx-theme] {
+   the product's, so the values always agree.
+
+   Scoped under #root: Theme also mirrors data-astryx-theme (and data-theme)
+   onto <html>, and a bare [data-astryx-theme] would quietly pin html-level
+   text properties too. Product CSS has retired html[data-theme] selectors
+   and astryx.css has no [data-theme] rules, so those html attributes stay
+   inert until reset.css lands — PR 12 should re-check that assumption. */
+#root [data-astryx-theme] {
   color: inherit;
   font-family: inherit;
   /* theme.css declares its tokens ON the wrapper (@scope root), so a name

--- a/apps/desktop/src/renderer/styles/astryx-mount.css
+++ b/apps/desktop/src/renderer/styles/astryx-mount.css
@@ -1,0 +1,29 @@
+/* #1565 PR 2 — keep the Astryx Theme wrapper visually inert while legacy CSS
+   owns the screen.
+
+   The root <Theme> renders a display:contents wrapper that establishes
+   Astryx's inheritance baseline: color: var(--color-text-primary) and
+   font-family: var(--font-family-body). It paints nothing itself, but every
+   descendant that inherits text color or font from body would inherit
+   Astryx's values instead — a global repaint smuggled in through
+   inheritance, which the layer order alone cannot stop (the rule targets the
+   wrapper, and nothing else competes on that element).
+
+   Living in maka.legacy is the point: this neutralizer wins only while the
+   legacy layer exists, and is deleted with it in PR 11 — at which point
+   Astryx is supposed to own the inheritance baseline. color-scheme is left
+   alone: the wrapper's mode comes from the same resolved `.dark` source as
+   the product's, so the values always agree. */
+[data-astryx-theme] {
+  color: inherit;
+  font-family: inherit;
+  /* theme.css declares its tokens ON the wrapper (@scope root), so a name
+     both sides define is shadowed for the entire subtree no matter what the
+     layer order says — custom properties resolve by tree distance, not by
+     layer. The only name both maka-tokens.css and the Astryx theme define
+     AND product CSS consumes is --font-size-base (13px vs 0.875rem);
+     `inherit` reopens the path to the product's :root value. Re-derive this
+     list (astryx theme defs ∩ product defs ∩ product var() usage) whenever
+     the Astryx pin moves. */
+  --font-size-base: inherit;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,8 @@
       "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@astryxdesign/core": "0.1.9",
+        "@astryxdesign/theme-neutral": "0.1.9",
         "@base-ui/react": "^1.5.0",
         "@jackwener/opencli": "1.8.4",
         "@maka/computer-use": "0.1.0",
@@ -310,14 +312,51 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/@astryxdesign/core": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@astryxdesign/core/-/core-0.1.9.tgz",
+      "integrity": "sha512-2ZNypZFfujMPxdU8M9Jbe77vwFPP1FYvA0Pk/3L3OLxEIzi98qLbRJjhDEHLbrflANSFVB4l5+qYpJjYtFFXMQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "intl-messageformat": "^11.2.9"
+      },
+      "peerDependencies": {
+        "@stylexjs/stylex": "^0.19.0",
+        "react": ">=19.0.0",
+        "react-dom": ">=19.0.0"
+      }
+    },
+    "node_modules/@astryxdesign/theme-neutral": {
+      "version": "0.1.9",
+      "resolved": "https://registry.npmjs.org/@astryxdesign/theme-neutral/-/theme-neutral-0.1.9.tgz",
+      "integrity": "sha512-HZPJmzg0S+aKuxUBGJ1L9O+bBZzwzWlROey/7VilM8kUzHA4lYrFcIPzRixoiXs/qyR5sSfJE8YG7jsXuAuywA==",
+      "license": "MIT",
+      "dependencies": {
+        "lucide-react": "^1.18.0"
+      },
+      "peerDependencies": {
+        "@astryxdesign/core": "0.1.9",
+        "react": ">=19"
+      }
+    },
+    "node_modules/@astryxdesign/theme-neutral/node_modules/lucide-react": {
+      "version": "1.28.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
+      "integrity": "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -367,14 +406,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -401,9 +440,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -411,29 +450,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -443,9 +482,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -453,9 +492,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -463,9 +502,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -487,13 +526,13 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
-      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -512,33 +551,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -546,14 +585,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -1762,6 +1801,27 @@
       "funding": {
         "url": "https://github.com/sponsors/ayuhito"
       }
+    },
+    "node_modules/@formatjs/fast-memoize": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-3.1.7.tgz",
+      "integrity": "sha512-zXfhLpvA6T7+efdt9JLbBwZ00tT7NsBMDVnDu8rpHeNNv8KfRZAMo2gkG0k9lK/Nzc//3kJ9pImsfuJxk3KhUA==",
+      "license": "MIT"
+    },
+    "node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "3.5.15",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-3.5.15.tgz",
+      "integrity": "sha512-5o4grXKotAB3JqQuisLApHG43g17N+paoRTa92Jiz35Zvfemq0cVf4EDvuxyHAzmsJji7igaEowicLO/VmfJ8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/icu-skeleton-parser": "2.1.11"
+      }
+    },
+    "node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-2.1.11.tgz",
+      "integrity": "sha512-j8cUmOJzVgkHuS0QiQ6ga76UIoLOFSAMWhs7aZJztH3aAdCOAE6vpC8KVvFB4cU10ON0y2/5oOVmPJ43s2lTwA==",
+      "license": "MIT"
     },
     "node_modules/@hono/node-server": {
       "version": "1.19.15",
@@ -3395,6 +3455,18 @@
         "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
         "storybook": "^10.4.6",
         "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/@stylexjs/stylex": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/@stylexjs/stylex/-/stylex-0.19.0.tgz",
+      "integrity": "sha512-CnUFp7YMaDLDeemsWOfJgoC/gKM5P/yBNMcpJaE6ChJmXr7s0DJwSeGTTlHJcqqwN9OW1qGtmARWLFhGZN1pTA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "css-mediaquery": "^0.1.2",
+        "invariant": "^2.2.4",
+        "styleq": "0.2.1"
       }
     },
     "node_modules/@szmarczak/http-timer": {
@@ -5970,6 +6042,13 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/css-mediaquery": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
+      "integrity": "sha512-COtn4EROW5dBGlE/4PiKnh6rZpAPxDeFLaEEwt4i10jpDMFt2EhQGS79QmmrO+iKCHv0PU/HrOWEhijFd1x99Q==",
+      "license": "BSD",
+      "peer": true
     },
     "node_modules/css.escape": {
       "version": "1.5.1",
@@ -8626,6 +8705,26 @@
         "node": ">=12"
       }
     },
+    "node_modules/intl-messageformat": {
+      "version": "11.2.12",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-11.2.12.tgz",
+      "integrity": "sha512-KW70Xxfcvy7vV3qODfvShWkFDPMqKDAa4N+hSyVBWGNtVhTUFYaqlD/l88DaYPKiVcPP4rPQ3qnH7i5K82Mg7g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/fast-memoize": "3.1.7",
+        "@formatjs/icu-messageformat-parser": "3.5.15"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/ip-address": {
       "version": "10.2.0",
       "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
@@ -8860,7 +8959,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -9791,6 +9889,19 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
       }
     },
     "node_modules/loupe": {
@@ -13136,6 +13247,13 @@
         "inline-style-parser": "0.2.7"
       }
     },
+    "node_modules/styleq": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/styleq/-/styleq-0.2.1.tgz",
+      "integrity": "sha512-L0TR0NQb+X4/ktDEKmjWyp27gla+LUYi/by5k5SjKXf6/pvZP7wbwEB5J+tqxdFVPgzbsuz+d4RTScO/QZquBw==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/stylis": {
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.4.0.tgz",
@@ -14264,6 +14382,7 @@
       "version": "0.1.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@astryxdesign/core": "0.1.9",
         "@base-ui/react": "^1.5.0",
         "@maka/core": "0.1.0",
         "class-variance-authority": "^0.7.1",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -22,6 +22,7 @@
     "test:dist": "node --test \"dist/**/*.test.js\""
   },
   "dependencies": {
+    "@astryxdesign/core": "0.1.9",
     "@base-ui/react": "^1.5.0",
     "@maka/core": "0.1.0",
     "class-variance-authority": "^0.7.1",

--- a/packages/ui/src/astryx-i18n.tsx
+++ b/packages/ui/src/astryx-i18n.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { useMemo, type ReactNode } from 'react';
 import { InternationalizationProvider } from '@astryxdesign/core/i18n';
 import { getSharedUiCopy } from './shared-ui-copy.js';
 import { getConversationCopy } from './conversation-copy.js';
@@ -26,8 +26,12 @@ import type { UiLocale } from './locale-helpers.js';
  */
 export function AstryxLocaleProvider({ children }: { children: ReactNode }) {
   const locale = useUiLocale();
+  // Referentially stable per locale: the provider memoises its context value
+  // on the overrides object, so a fresh map every render would re-render
+  // every Astryx i18n consumer on every AppShell render.
+  const overrides = useMemo(() => astryxMessageOverrides(locale), [locale]);
   return (
-    <InternationalizationProvider locale={locale} overrides={astryxMessageOverrides(locale)}>
+    <InternationalizationProvider locale={locale} overrides={overrides}>
       {children}
     </InternationalizationProvider>
   );

--- a/packages/ui/src/astryx-i18n.tsx
+++ b/packages/ui/src/astryx-i18n.tsx
@@ -1,0 +1,58 @@
+import type { ReactNode } from 'react';
+import { InternationalizationProvider } from '@astryxdesign/core/i18n';
+import { getSharedUiCopy } from './shared-ui-copy.js';
+import { getConversationCopy } from './conversation-copy.js';
+import { useUiLocale } from './locale-context.js';
+import type { UiLocale } from './locale-helpers.js';
+
+/**
+ * Astryx ships no `zh` message catalog: its built-in strings ("Copy code",
+ * "Task list", "(opens in new tab)", checkbox/table ARIA names) render in
+ * English. On a Chinese-first product every Astryx component we adopt would
+ * otherwise leak English into the accessibility tree.
+ *
+ * This provider sits at the renderer root so EVERY Astryx subtree inherits the
+ * catalog — scoping it per feature does not scale: each new slice would have
+ * to remember to re-wrap. Overrides are keyed off our own shared copy
+ * catalogue, so translations keep one home.
+ *
+ * The map covers the components whose copy sources exist today. A slice that
+ * adopts a new Astryx surface appends its `@astryx.*` keys here in the same
+ * PR that adds the copy they resolve from (the Markdown catalog lands with
+ * PR 7, for example) — an override for a component nothing renders is dead
+ * config, not coverage.
+ *
+ * `en` needs no overrides — it resolves to Astryx's shipped defaults.
+ */
+export function AstryxLocaleProvider({ children }: { children: ReactNode }) {
+  const locale = useUiLocale();
+  return (
+    <InternationalizationProvider locale={locale} overrides={astryxMessageOverrides(locale)}>
+      {children}
+    </InternationalizationProvider>
+  );
+}
+
+export function astryxMessageOverrides(locale: UiLocale) {
+  if (locale === 'en') return undefined;
+  const shared = getSharedUiCopy(locale);
+  const conversation = getConversationCopy(locale);
+  return {
+    [locale]: {
+      '@astryx.codeBlock.copyCode': shared.markdown.copyCode,
+      '@astryx.codeBlock.copied': shared.markdown.copiedCode,
+      '@astryx.dialog.close': shared.primitives.close,
+      '@astryx.popover.close': shared.primitives.close,
+      '@astryx.lightbox.close': shared.primitives.close,
+      '@astryx.toast.dismiss': shared.toast.closeNotification,
+      '@astryx.toast.viewport': shared.toast.notifications,
+      '@astryx.selector.searchOptions': shared.modelPicker.searchAriaLabel,
+      '@astryx.selector.searchPlaceholder': shared.modelPicker.searchPlaceholder,
+      '@astryx.chat.composer.placeholder': conversation.composer.placeholder,
+      '@astryx.chat.composerInput.label': conversation.composer.textareaAriaLabel,
+      '@astryx.chatLayoutScrollButton.scrollToBottom': conversation.chat.jumpLatest,
+      '@astryx.chatSendButton.stop': conversation.composer.stopLabel,
+      '@astryx.chatSendButton.send': conversation.composer.sendLabel,
+    },
+  };
+}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -674,6 +674,7 @@ export const Composer = forwardRef<
     >
       <div
         className="maka-composer-inner composerInner agents-parchment-paper-surface"
+        data-maka-contract="composer-inner"
         data-streaming={props.streaming ? 'true' : undefined}
       >
         {/* No px on the chip row: `.maka-composer-inner` already pads the card,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -172,3 +172,6 @@ export {
   type FadeRingState,
   type FadeBatch,
 } from './stream-fade.js';
+
+// #1565 PR 2: Astryx i18n adapter — appended, never reordered (barrel freeze).
+export * from './astryx-i18n.js';

--- a/packages/ui/src/search-modal.tsx
+++ b/packages/ui/src/search-modal.tsx
@@ -230,6 +230,7 @@ export function SearchModal(props: {
     >
       <DialogContent
         className="maka-modal maka-search-modal w-[min(92vw,640px)] p-0"
+        data-maka-contract="search-modal"
         aria-labelledby="maka-search-modal-title"
         showClose={false}
         initialFocus={inputRef}

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -809,6 +809,7 @@ const SessionRow = memo(function SessionRow(props: {
   return (
     <div
       className="maka-list-row"
+      data-maka-contract="list-row"
       data-active={active}
       data-editing={editing}
       data-menu-open={menuOpen ? 'true' : undefined}
@@ -861,7 +862,7 @@ const SessionRow = memo(function SessionRow(props: {
               autoComplete="off"
               spellCheck={false}
             />
-            <div className="maka-list-row-meta">{formatSessionMeta(session, locale)}</div>
+            <div className="maka-list-row-meta" data-maka-contract="list-row-meta">{formatSessionMeta(session, locale)}</div>
           </div>
         </form>
       ) : (
@@ -963,7 +964,7 @@ const SessionRow = memo(function SessionRow(props: {
           {shouldShowSessionUnreadDot(session, Boolean(streaming), active) ? (
             <span className="maka-list-row-unread" aria-label={copy.unreadAriaLabel} />
           ) : (
-            <span className="maka-list-row-meta">{formatSessionMeta(session, locale)}</span>
+            <span className="maka-list-row-meta" data-maka-contract="list-row-meta">{formatSessionMeta(session, locale)}</span>
           )}
         </BaseButton>
       )}

--- a/scripts/check-hit-test.mjs
+++ b/scripts/check-hit-test.mjs
@@ -26,15 +26,8 @@
 //
 // Migration-only scaffolding: not in CI, removed in PR 14.
 import { pathToFileURL } from 'node:url';
+import { ROUTES, hook } from './contract-routes.mjs';
 import { withFixtureWindow } from './fixture-window.mjs';
-
-const ROUTES = [
-  { id: 'chat', scenario: 'turn-narrative', ready: '.maka-session-workbar' },
-  { id: 'settings-general', scenario: 'settings-general', ready: '.settingsRows' },
-  { id: 'settings-providers', scenario: 'provider-workspace', ready: '.providersPanel' },
-  { id: 'mcp-hub', scenario: 'module-mcp', ready: '.maka-module-main-header' },
-  { id: 'onboarding', scenario: 'first-run', ready: '.maka-onboarding-surface' },
-];
 
 // #1565's selector list.
 const INTERACTIVE_SELECTOR =
@@ -98,7 +91,7 @@ const PROBE_EXPR = `(() => {
   // migration in a way a class name does not.
   const overlay = [
     ...document.querySelectorAll(
-      '[data-modal="true"], [role=dialog], [role=alertdialog], dialog[open], [role=menu], .maka-search-modal',
+      '[data-modal="true"], [role=dialog], [role=alertdialog], dialog[open], [role=menu], ${hook('search-modal')}',
     ),
   ].find((el) => {
     const box = rectOf(el);

--- a/scripts/check-visual-contract.mjs
+++ b/scripts/check-visual-contract.mjs
@@ -3,6 +3,7 @@
 //   node scripts/check-visual-contract.mjs                  # compare main → working tree
 //   node scripts/check-visual-contract.mjs --against <ref>  # a different base
 //   node scripts/check-visual-contract.mjs --route chat --theme dark --platform win32
+//   node scripts/check-visual-contract.mjs --scopes <file>  # declared-subtree mode
 //
 // One command captures BOTH sides and diffs them in memory: the base ref is
 // checked out into a cached temporary worktree with its own `npm ci` (see
@@ -56,32 +57,10 @@ import { access, mkdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { dirname, join } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { CONTRACT_HOOK, PLATFORMS, ROUTES, THEMES } from './contract-routes.mjs';
 import { withFixtureWindow } from './fixture-window.mjs';
 
 const ROOT = join(dirname(fileURLToPath(import.meta.url)), '..');
-
-// The five representative routes from #1565. The issue names product routes;
-// these are the MAKA_E2E_FIXTURE scenarios that actually open them on main —
-// there is no scenario literally named "settings-providers" or "chat".
-// `ready` is the element that means "this surface has rendered". Without it
-// the only alternative is a fixed sleep, which captures a half-mounted route
-// as a clean one on a slow machine — and writes that into the baseline.
-const ROUTES = [
-  // Chat session with the task workbar open.
-  { id: 'chat', scenario: 'turn-narrative', ready: '.maka-session-workbar' },
-  { id: 'settings-general', scenario: 'settings-general', ready: '.settingsRows' },
-  // Providers live under the 模型 settings section.
-  { id: 'settings-providers', scenario: 'provider-workspace', ready: '.providersPanel' },
-  { id: 'mcp-hub', scenario: 'module-mcp', ready: '.maka-module-main-header' },
-  // Empty profile, first launch.
-  { id: 'onboarding', scenario: 'first-run', ready: '.maka-onboarding-surface' },
-];
-const THEMES = ['light', 'dark'];
-// #1565 asks for darwin AND win32: the per-OS CSS is keyed off
-// `html[data-os]`, so a regression under the win32 cascade is invisible in a
-// darwin-only capture for the whole migration. The fixture platform override
-// flips `data-os` through the production path on any host.
-const PLATFORMS = ['darwin', 'win32'];
 
 // #1565 mandates the alignment properties (alignItems/justifyContent/gap/
 // gridArea) alongside the usual box and paint set: flex and grid misalignment
@@ -202,10 +181,58 @@ export const INHERITED_PROPERTIES = [
   'textAlign',
 ];
 
-const CAPTURE_EXPR = `(() => {
+// The capture is generated per run: declared scopes are embedded so both
+// sides mark each element with the migration scope that owns it. A scope
+// declares selectors for BOTH sides of a swap — the legacy element it
+// replaces (matched in the base capture) and the migrated element it lands
+// (matched in the current capture) — which is what lets removed, added and
+// changed records all be attributed to the scope that claimed them.
+const captureExpr = (scopes = []) => `(() => {
   const PROPERTIES = ${JSON.stringify(PROPERTIES)};
   const INITIAL_VALUES = ${JSON.stringify(INITIAL_VALUES)};
   const INHERITED = new Set(${JSON.stringify(INHERITED_PROPERTIES)});
+  const SCOPES = ${JSON.stringify(scopes)};
+  const CONTRACT_HOOK = ${JSON.stringify(CONTRACT_HOOK)};
+  // A scope that matches the app root would "declare" the entire UI, which
+  // is indistinguishable from disabling the contract. #1565 allows the
+  // chrome slice to declare only titlebar / sidebar / rail, never the shell
+  // root; this is the mechanical floor under that rule. Invalid selectors
+  // are violations too — a typo must not silently declare nothing.
+  const scopeViolations = [];
+  const rootTargets = [
+    document.documentElement,
+    document.body,
+    document.getElementById('root'),
+  ].filter(Boolean);
+  for (const scope of SCOPES) {
+    for (const selector of scope.selectors) {
+      let valid = true;
+      try {
+        document.documentElement.matches(selector);
+      } catch {
+        valid = false;
+      }
+      if (!valid) {
+        scopeViolations.push({ scope: scope.name, selector, reason: 'invalid selector' });
+        continue;
+      }
+      if (rootTargets.some((el) => el.matches(selector))) {
+        scopeViolations.push({ scope: scope.name, selector, reason: 'matches the app root' });
+      }
+    }
+  }
+  const scopeOf = (el) => {
+    for (const scope of SCOPES) {
+      for (const selector of scope.selectors) {
+        try {
+          if (el.matches(selector)) return scope.name;
+        } catch {
+          // Already reported in scopeViolations.
+        }
+      }
+    }
+    return null;
+  };
   // Stop the clock before reading a single style. transform is sampled, and a
   // running spinner serialises a different matrix at every phase — the two
   // sides are captured seconds apart, so animated values would diff on time,
@@ -287,8 +314,13 @@ const CAPTURE_EXPR = `(() => {
   // cannot see: flip that wrapper's color and the child really repaints while
   // the capture stays byte-identical. Comparing against the nearest recorded
   // ancestor keeps every omission recoverable by a reader of the file.
-  const walk = (el, path, inherited) => {
+  const walk = (el, path, inherited, scope) => {
     if (el.matches(DECORATION)) return;
+    // The nearest ancestor-or-self that a declared scope claims. Portal
+    // content is attributed the same way: a portal root that carries the
+    // scope's identity hook claims its whole subtree, even though that
+    // subtree is nowhere near the trigger in the DOM.
+    const ownScope = scopeOf(el) ?? scope;
     const rect = el.getBoundingClientRect();
     const style = getComputedStyle(el);
     // Opacity multiplies down the tree and is not inherited: every descendant
@@ -328,6 +360,11 @@ const CAPTURE_EXPR = `(() => {
         .filter((name) => name.startsWith('maka-') || /[A-Z]/.test(name))
         .slice(0, 3);
       if (named.length > 0) record.classes = named.join(' ');
+      // Harness bookkeeping, not visual properties: diffRecords skips both
+      // keys, so adding or renaming a hook is never itself a visual diff.
+      const contract = el.getAttribute(CONTRACT_HOOK);
+      if (contract) record.contract = contract;
+      if (ownScope) record.scope = ownScope;
       writeStyles(style, record, inherited);
       out.push(record);
       // Painted pseudo-elements. A cascade migration can flip a decoration
@@ -341,6 +378,7 @@ const CAPTURE_EXPR = `(() => {
         if (ps.visibility === 'hidden' || Number.parseFloat(ps.opacity) === 0) continue;
         const pseudoRecord = { path: path + pseudo };
         if (ps.content !== '""') pseudoRecord.content = ps.content.slice(0, 40);
+        if (ownScope) pseudoRecord.scope = ownScope;
         writeStyles(ps, pseudoRecord, ownInherited);
         out.push(pseudoRecord);
       }
@@ -349,17 +387,64 @@ const CAPTURE_EXPR = `(() => {
     // hold visible children (common for absolutely positioned overlays). Only
     // a recorded element updates the inherited baseline (see walk above).
     const nextInherited = visible ? ownInherited : inherited;
-    const children = el.children;
-    const counts = new Map();
-    for (const child of children) {
+    walkChildren(el, path, nextInherited, ownScope, new Map());
+  };
+  // Path identity follows the BOX tree, not the DOM tree. A display:contents
+  // element generates no box: inserting one moves nothing on screen, so it
+  // must not re-key every descendant path into a wall of removed/added pairs
+  // (Astryx's Theme mounts exactly such a wrapper). Its children number among
+  // their layout siblings; the wrapper itself has no rect and no record. Any
+  // inherited value it changes still shows up honestly — each child's own
+  // computed style is compared against the nearest RECORDED ancestor, which
+  // sits above the boxless wrapper.
+  const walkChildren = (el, path, inherited, scope, counts) => {
+    for (const child of el.children) {
+      if (getComputedStyle(child).display === 'contents') {
+        const childScope = scopeOf(child) ?? scope;
+        walkChildren(child, path, inherited, childScope, counts);
+        continue;
+      }
       const tag = child.tagName.toLowerCase();
       const index = (counts.get(tag) ?? 0) + 1;
       counts.set(tag, index);
-      walk(child, path + '>' + tag + (index > 1 ? ':' + index : ''), nextInherited);
+      walk(child, path + '>' + tag + (index > 1 ? ':' + index : ''), inherited, scope);
     }
   };
-  walk(document.body, 'body', {});
-  return JSON.stringify({ records: out, omission: { sampled, hits } });
+  walk(document.body, 'body', {}, null);
+  // Non-vacuous mount proof (#1565 PR 2): count the rules that actually sit
+  // in an astryx.* cascade layer. Zero means Astryx CSS never loaded — and a
+  // zero-diff pass in that state proves nothing, because the thing being
+  // buried under maka.legacy is not there. Counted via CSSOM so a bundler
+  // that drops the layer() wrapper (which would ALSO invert the cascade)
+  // fails this probe instead of passing it harder.
+  let astryxLayerRules = 0;
+  const countLayers = (rules) => {
+    for (const rule of rules) {
+      let inner;
+      try {
+        inner = rule.cssRules;
+      } catch {
+        continue;
+      }
+      if (rule instanceof CSSLayerBlockRule && /^astryx(\\.|$)/.test(rule.name)) {
+        astryxLayerRules += inner ? inner.length : 0;
+      }
+      if (inner) countLayers(inner);
+    }
+  };
+  for (const sheet of document.styleSheets) {
+    try {
+      countLayers(sheet.cssRules);
+    } catch {
+      // Cross-origin sheet: nothing of ours lives there.
+    }
+  }
+  return JSON.stringify({
+    records: out,
+    omission: { sampled, hits },
+    scopeViolations,
+    astryxLayerRules,
+  });
 })()`;
 
 // #1565 asks for the mega-branch's late "fix cascade / fix click" commits to
@@ -380,18 +465,22 @@ const CAPTURE_EXPR = `(() => {
 //
 // One is only partly covered: fd38a37ce (composer frame jumping on focus) is
 // a focus-state regression, and this harness captures the resting state.
+// Anchors are `data-maka-contract` hook names, not product classes: the
+// classes these regressions happened on are exactly what the slices delete,
+// and an anchor that dies with the class it watches reports "the harness
+// stopped watching" for every migration that behaves correctly.
 const SALVAGED_ANCHORS = [
   {
     commit: 'be5e69584',
     regression: 'titlebar clusters wrapped onto a second row',
     route: 'chat',
-    anchor: 'maka-shell-topbar-rail',
+    anchor: 'shell-topbar-rail',
   },
   {
     commit: 'fd38a37ce',
     regression: 'composer frame jumped when focused (resting state only)',
     route: 'chat',
-    anchor: 'maka-composer-inner',
+    anchor: 'composer-inner',
   },
   // Route mcp-hub, not chat: the chat fixture keeps the session panel
   // collapsed, where these rows sit under an opacity:0 ancestor. Before the
@@ -402,39 +491,36 @@ const SALVAGED_ANCHORS = [
     commit: '9aad59740',
     regression: 'every session timestamp stacked above its title',
     route: 'mcp-hub',
-    anchor: 'maka-list-row-meta',
+    anchor: 'list-row-meta',
   },
   {
     commit: '3dbd68ca7',
     regression: 'sidebar nav rows had two competing styling authorities',
     route: 'mcp-hub',
-    anchor: 'maka-list-row',
+    anchor: 'list-row',
   },
   {
     commit: '9d20a9396',
     regression: "task ledger's recent-count collided with its label",
     route: 'chat',
-    anchor: 'maka-session-workbar-count',
+    anchor: 'session-workbar-count',
   },
   {
     commit: 'be1406705',
     regression: 'settings content column painted over the nav rail',
     route: 'settings-general',
-    anchor: 'settingsSidebar',
+    anchor: 'settings-sidebar',
   },
 ];
 
-// Exact class-token match, not substring: `maka-list-row` as a substring is
-// satisfied by `maka-list-row-meta`, so a loose check would report an anchor
-// as watched by an element that is not the one the regression happened on.
+// Exact hook match: `list-row` must not be satisfied by `list-row-meta`,
+// which is a different element than the one the regression happened on.
 export function checkSalvagedAnchors(captures, anchors = SALVAGED_ANCHORS) {
   const missing = [];
   for (const entry of anchors) {
     const records = captures.get(`${entry.route}.light.darwin`);
     if (!records) continue;
-    const present = records.some((record) =>
-      (record.classes ?? '').split(' ').includes(entry.anchor),
-    );
+    const present = records.some((record) => record.contract === entry.anchor);
     if (!present) missing.push(entry);
   }
   return missing;
@@ -461,7 +547,14 @@ export function findDeadOmissionRules(omission, initialValues = INITIAL_VALUES) 
 }
 
 export function parseArgs(argv) {
-  const args = { against: 'main', routes: null, themes: null, platforms: null, help: false };
+  const args = {
+    against: 'main',
+    routes: null,
+    themes: null,
+    platforms: null,
+    scopes: null,
+    help: false,
+  };
   const value = (index, flag) => {
     const next = argv[index];
     if (next === undefined || next.startsWith('--')) {
@@ -486,6 +579,7 @@ export function parseArgs(argv) {
   for (let i = 2; i < argv.length; i += 1) {
     const arg = argv[i];
     if (arg === '--against') args.against = value(++i, arg);
+    else if (arg === '--scopes') args.scopes = value(++i, arg);
     else if (arg === '--route') (args.routes ??= []).push(oneOf(++i, arg, routeIds));
     else if (arg === '--theme') (args.themes ??= []).push(oneOf(++i, arg, THEMES));
     else if (arg === '--platform') (args.platforms ??= []).push(oneOf(++i, arg, PLATFORMS));
@@ -632,31 +726,62 @@ export function diffRecords(baseline, current) {
   const before = byPath(baseline);
   const after = byPath(current);
   const changes = [];
+  // Harness bookkeeping, not visual properties: `contract` names the hook,
+  // `scope` names the migration scope that claimed the element. Adding a hook
+  // or declaring a scope must never itself read as a visual diff.
+  const BOOKKEEPING = new Set(['path', 'contract', 'scope']);
   for (const [path, record] of before) {
     const next = after.get(path);
     if (!next) {
-      changes.push({ kind: 'removed', path, label: record.label });
+      changes.push({ kind: 'removed', path, label: record.label, scope: record.scope });
       continue;
     }
     const properties = [];
     for (const key of new Set([...Object.keys(record), ...Object.keys(next)])) {
-      if (key === 'path') continue;
+      if (BOOKKEEPING.has(key)) continue;
       const a = JSON.stringify(record[key]);
       const b = JSON.stringify(next[key]);
       if (a !== b) properties.push({ property: key, before: record[key], after: next[key] });
     }
     if (properties.length > 0) {
-      changes.push({ kind: 'changed', path, label: record.label ?? next.label, properties });
+      changes.push({
+        kind: 'changed',
+        path,
+        label: record.label ?? next.label,
+        // The current side's attribution wins: a swapped element is claimed
+        // by the scope that landed it, not the one that used to own it.
+        scope: next.scope ?? record.scope,
+        properties,
+      });
     }
   }
   for (const [path, record] of after) {
-    if (!before.has(path)) changes.push({ kind: 'added', path, label: record.label });
+    if (!before.has(path)) {
+      changes.push({ kind: 'added', path, label: record.label, scope: record.scope });
+    }
   }
   // `changed` first: those are diffs on elements that still exist, which is
   // the signal. A structural edit produces a flood of removed/added that would
   // otherwise push every real property change past the print limit.
   const rank = { changed: 0, removed: 1, added: 2 };
   return changes.sort((a, b) => rank[a.kind] - rank[b.kind]);
+}
+
+/**
+ * Split a diff into the changes a slice declared and the ones it did not.
+ * The declared side is judged against the design package by a reviewer; the
+ * undeclared side fails the run. Zero-diff is the special case where the
+ * declared set is empty — then every change is out of scope, which is
+ * exactly the PR 1/PR 2 gate.
+ */
+export function partitionChanges(changes, declaredNames) {
+  const declared = new Set(declaredNames);
+  const inScope = [];
+  const outOfScope = [];
+  for (const change of changes) {
+    (change.scope && declared.has(change.scope) ? inScope : outOfScope).push(change);
+  }
+  return { inScope, outOfScope };
 }
 
 /**
@@ -693,9 +818,14 @@ async function main() {
   const args = parseArgs(process.argv);
   if (args.help) {
     console.log(
-      `Usage: check-visual-contract.mjs [--against ref] [--route id]... [--theme light|dark]... [--platform darwin|win32]...\n\n` +
+      `Usage: check-visual-contract.mjs [--against ref] [--scopes file] [--route id]... [--theme light|dark]... [--platform darwin|win32]...\n\n` +
         `Builds the base ref (cached, temp worktree) and the working tree, captures\n` +
         `every route x theme x platform from both builds, and diffs them in memory.\n\n` +
+        `--scopes points at a JSON file declaring the subtrees a slice migrates:\n` +
+        `  { "slice": "pr3-atoms", "scopes": [ { "name": "button", "selectors": ["..."] } ] }\n` +
+        `Each scope lists selectors for the legacy element it replaces AND the\n` +
+        `migrated element it lands. Diffs inside a declared scope are reported for\n` +
+        `review; any diff outside them fails. Without --scopes the gate is zero diff.\n\n` +
         `Routes: ${ROUTES.map((route) => route.id).join(', ')}\n`,
     );
     return;
@@ -703,6 +833,32 @@ async function main() {
   const routes = args.routes ? ROUTES.filter((route) => args.routes.includes(route.id)) : ROUTES;
   const themes = args.themes ?? THEMES;
   const platforms = args.platforms ?? PLATFORMS;
+  // Fail closed on a malformed scope file: a scope that silently loads as
+  // empty would demote the run to zero-diff mode and fail on every declared
+  // change, which at least errs loud — but a scope missing its selectors
+  // would declare nothing and fail the same way for a confusing reason.
+  let scopes = null;
+  if (args.scopes) {
+    const parsed = JSON.parse(await readFile(args.scopes, 'utf8'));
+    if (
+      !Array.isArray(parsed.scopes) ||
+      parsed.scopes.length === 0 ||
+      parsed.scopes.some(
+        (scope) =>
+          typeof scope.name !== 'string' ||
+          !Array.isArray(scope.selectors) ||
+          scope.selectors.length === 0 ||
+          scope.selectors.some((selector) => typeof selector !== 'string'),
+      )
+    ) {
+      console.error(
+        `[visual-contract] ${args.scopes} must be { "slice": string, "scopes": [{ "name": string, "selectors": [string, ...] }, ...] }`,
+      );
+      process.exit(2);
+    }
+    scopes = parsed.scopes;
+  }
+  const expr = captureExpr(scopes ?? []);
   const base = await ensureBaseBuild(args.against);
   console.log('building the working tree');
   await buildDesktop(ROOT);
@@ -733,7 +889,7 @@ async function main() {
                     `renderer never reached data-os=${platform} theme=${theme}; the capture would have measured the wrong cascade`,
                   );
                 });
-              return JSON.parse(await evaluate(CAPTURE_EXPR));
+              return JSON.parse(await evaluate(expr));
             },
           );
         let base;
@@ -754,6 +910,14 @@ async function main() {
         const baseRecords = base.records;
         const records = current.records;
         captures.set(`${route.id}.${theme}.${platform}`, records);
+        // Current side only: the base predates the Astryx mount. From PR 2 on,
+        // a working tree with zero astryx-layer rules is a vacuous pass.
+        if (current.astryxLayerRules === 0) {
+          failures += 1;
+          console.log(
+            `FAIL ${key}: no rules under any astryx.* cascade layer — Astryx CSS is not loaded, so a zero diff here is vacuous`,
+          );
+        }
         // An omission rule that never matches silently inflates every record.
         for (const dead of findDeadOmissionRules(current.omission)) {
           failures += 1;
@@ -761,21 +925,47 @@ async function main() {
             `FAIL ${key}: "${dead.property}" never matched its INITIAL_VALUES entry across ${dead.sampled} sampled elements — the entry does not match what Chromium serialises`,
           );
         }
+        // Both sides run the same capture, but the DOMs differ; a scope that
+        // reaches the app root on either side has declared the whole UI.
+        const violations = new Map(
+          [...(base.scopeViolations ?? []), ...(current.scopeViolations ?? [])].map((violation) => [
+            `${violation.scope} ${violation.selector}`,
+            violation,
+          ]),
+        );
+        for (const violation of violations.values()) {
+          failures += 1;
+          console.log(
+            `FAIL ${key}: scope "${violation.scope}" selector ${violation.selector}: ${violation.reason}`,
+          );
+        }
         const changes = diffRecords(baseRecords, records);
-        if (changes.length === 0) {
-          console.log(`ok   ${key} (${records.length} elements)`);
+        const declared = scopes
+          ? partitionChanges(
+              changes,
+              scopes.map((scope) => scope.name),
+            )
+          : null;
+        const failing = declared ? declared.outOfScope : changes;
+        const scopedNote = declared?.inScope.length
+          ? ` (${declared.inScope.length} declared change(s) for review)`
+          : '';
+        if (failing.length === 0) {
+          console.log(`ok   ${key} (${records.length} elements)${scopedNote}`);
           continue;
         }
         failures += 1;
-        const { text, structural } = summarise(changes, baseRecords.length);
-        console.log(`FAIL ${key}: ${text}`);
+        const { text, structural } = summarise(failing, baseRecords.length);
+        console.log(
+          `FAIL ${key}: ${text}${declared ? ' outside the declared scopes' : ''}${scopedNote}`,
+        );
         if (structural) {
           console.log(
             '  note: most of the base capture was replaced rather than changed, which is what inserting or removing a wrapper element looks like — element identity is the path through the tree, so everything below the edit is re-keyed. Compare the surviving `changed` entries; the removed/added pairs are the same elements under new paths.',
           );
         }
-        for (const change of changes.slice(0, 40)) console.log(formatChange(change));
-        if (changes.length > 40) console.log(`  … ${changes.length - 40} more`);
+        for (const change of failing.slice(0, 40)) console.log(formatChange(change));
+        if (failing.length > 40) console.log(`  … ${failing.length - 40} more`);
       }
     }
   }

--- a/scripts/check-visual-contract.mjs
+++ b/scripts/check-visual-contract.mjs
@@ -412,11 +412,14 @@ const captureExpr = (scopes = []) => `(() => {
   };
   walk(document.body, 'body', {}, null);
   // Non-vacuous mount proof (#1565 PR 2): count the rules that actually sit
-  // in an astryx.* cascade layer. Zero means Astryx CSS never loaded — and a
-  // zero-diff pass in that state proves nothing, because the thing being
-  // buried under maka.legacy is not there. Counted via CSSOM so a bundler
-  // that drops the layer() wrapper (which would ALSO invert the cascade)
-  // fails this probe instead of passing it harder.
+  // in one of the contracted astryx-* cascade layers. Zero means Astryx CSS
+  // never loaded — and a zero-diff pass in that state proves nothing, because
+  // the thing being buried under maka.legacy is not there. Counted via CSSOM
+  // so a bundler that drops the layer() wrapper (which would ALSO invert the
+  // cascade) fails this probe instead of passing it harder. Exact names, not
+  // a prefix: astryx.css nests its own @layer astryx-base inside the import
+  // layer, and a prefix match would double-count it.
+  const ASTRYX_LAYERS = new Set(['astryx-reset', 'astryx-tokens', 'astryx-components']);
   let astryxLayerRules = 0;
   const countLayers = (rules) => {
     for (const rule of rules) {
@@ -426,7 +429,7 @@ const captureExpr = (scopes = []) => `(() => {
       } catch {
         continue;
       }
-      if (rule instanceof CSSLayerBlockRule && /^astryx(\\.|$)/.test(rule.name)) {
+      if (rule instanceof CSSLayerBlockRule && ASTRYX_LAYERS.has(rule.name)) {
         astryxLayerRules += inner ? inner.length : 0;
       }
       if (inner) countLayers(inner);
@@ -748,9 +751,13 @@ export function diffRecords(baseline, current) {
         kind: 'changed',
         path,
         label: record.label ?? next.label,
-        // The current side's attribution wins: a swapped element is claimed
-        // by the scope that landed it, not the one that used to own it.
-        scope: next.scope ?? record.scope,
+        // Current side ONLY — never the base side's claim. A changed element
+        // still exists after the swap, so the migrated selectors must match
+        // what actually landed there; falling back to the base attribution
+        // would let a mistyped migrated selector waive every change inside
+        // the old legacy subtree (fail-open). Removed records keep the base
+        // claim (they have no current side), added records the current one.
+        scope: next.scope,
         properties,
       });
     }
@@ -782,6 +789,32 @@ export function partitionChanges(changes, declaredNames) {
     (change.scope && declared.has(change.scope) ? inScope : outOfScope).push(change);
   }
   return { inScope, outOfScope };
+}
+
+/**
+ * Mechanical ceiling under "a scope declares a component, not the app".
+ * The in-browser floor rejects selectors that match html/body/#root, but a
+ * selector like `#root *` or a top-level frame class declares essentially
+ * everything without touching those roots — which is indistinguishable from
+ * disabling the gate. #1565 scopes are components (a workbar, a panel, a
+ * rail); none of them legitimately claims most of a route's boxes, on either
+ * side of the comparison.
+ */
+export const SCOPE_COVERAGE_LIMIT = 0.5;
+
+export function checkScopeCoverage(records, limit = SCOPE_COVERAGE_LIMIT) {
+  if (records.length === 0) return [];
+  const claimed = new Map();
+  for (const record of records) {
+    if (record.scope) claimed.set(record.scope, (claimed.get(record.scope) ?? 0) + 1);
+  }
+  const violations = [];
+  for (const [scope, count] of claimed) {
+    if (count > records.length * limit) {
+      violations.push({ scope, claimed: count, total: records.length });
+    }
+  }
+  return violations;
 }
 
 /**
@@ -915,7 +948,7 @@ async function main() {
         if (current.astryxLayerRules === 0) {
           failures += 1;
           console.log(
-            `FAIL ${key}: no rules under any astryx.* cascade layer — Astryx CSS is not loaded, so a zero diff here is vacuous`,
+            `FAIL ${key}: no rules under any astryx-* cascade layer — Astryx CSS is not loaded, so a zero diff here is vacuous`,
           );
         }
         // An omission rule that never matches silently inflates every record.
@@ -938,6 +971,19 @@ async function main() {
           console.log(
             `FAIL ${key}: scope "${violation.scope}" selector ${violation.selector}: ${violation.reason}`,
           );
+        }
+        // Same rationale, one level up: a selector that avoids the roots but
+        // claims most of a side's boxes has still declared the app.
+        for (const side of [
+          { name: 'base', records: baseRecords },
+          { name: 'current', records },
+        ]) {
+          for (const violation of checkScopeCoverage(side.records)) {
+            failures += 1;
+            console.log(
+              `FAIL ${key}: scope "${violation.scope}" claims ${violation.claimed} of ${violation.total} captured elements on the ${side.name} side — a scope declares a component, not the app`,
+            );
+          }
         }
         const changes = diffRecords(baseRecords, records);
         const declared = scopes

--- a/scripts/check-visual-contract.test.mjs
+++ b/scripts/check-visual-contract.test.mjs
@@ -13,6 +13,7 @@ import {
   findDeadOmissionRules,
   INHERITED_PROPERTIES,
   INITIAL_VALUES,
+  partitionChanges,
   PROPERTIES,
   summarise,
 } from './check-visual-contract.mjs';
@@ -187,23 +188,82 @@ describe('findDeadOmissionRules', () => {
 });
 
 describe('checkSalvagedAnchors', () => {
-  const anchors = [{ commit: 'abc', regression: 'r', route: 'chat', anchor: 'maka-list-row' }];
+  const anchors = [{ commit: 'abc', regression: 'r', route: 'chat', anchor: 'list-row' }];
   const captureKey = 'chat.light.darwin';
 
-  it('accepts an exact class token', () => {
-    const captures = new Map([[captureKey, [record('a', { classes: 'maka-list-row other' })]]]);
+  it('accepts a record carrying the exact hook', () => {
+    const captures = new Map([[captureKey, [record('a', { contract: 'list-row' })]]]);
     assert.deepEqual(checkSalvagedAnchors(captures, anchors), []);
   });
 
-  it('rejects a longer class that merely contains the anchor', () => {
-    // `maka-list-row-meta` is a different element; a substring match would
-    // report the anchor as watched by something that is not the element the
+  it('rejects a different hook that merely contains the anchor', () => {
+    // `list-row-meta` is a different element; a substring match would report
+    // the anchor as watched by something that is not the element the
     // regression happened on.
-    const captures = new Map([[captureKey, [record('a', { classes: 'maka-list-row-meta' })]]]);
+    const captures = new Map([[captureKey, [record('a', { contract: 'list-row-meta' })]]]);
+    assert.equal(checkSalvagedAnchors(captures, anchors).length, 1);
+  });
+
+  it('does not accept a product class in place of the hook', () => {
+    // Anchors moved off product classes on purpose: the class dies with the
+    // slice that migrates the component, the hook survives it.
+    const captures = new Map([[captureKey, [record('a', { classes: 'maka-list-row' })]]]);
     assert.equal(checkSalvagedAnchors(captures, anchors).length, 1);
   });
 
   it('skips routes that were not captured this run', () => {
     assert.deepEqual(checkSalvagedAnchors(new Map(), anchors), []);
+  });
+});
+
+describe('declared scopes', () => {
+  it('never reports harness bookkeeping as a visual diff', () => {
+    // PR 2 adds the hooks while `main` has none: if `contract` or `scope`
+    // were compared, the hook rollout itself would break the zero-diff gate.
+    const before = [record('body>div'), record('body>div>span')];
+    const after = [
+      record('body>div', { contract: 'session-workbar', scope: 'workbar' }),
+      record('body>div>span', { scope: 'workbar' }),
+    ];
+    assert.deepEqual(diffRecords(before, after), []);
+  });
+
+  it('attributes a changed element to the scope that landed it', () => {
+    const before = [record('body>div', { color: 'red', scope: 'legacy-button' })];
+    const after = [record('body>div', { color: 'blue', scope: 'button' })];
+    const changes = diffRecords(before, after);
+    assert.equal(changes[0].scope, 'button');
+  });
+
+  it('keeps the base attribution for a removed element', () => {
+    // The migrated side no longer has the element, so only the base capture
+    // knows which scope claimed it — the legacy selector the slice declared.
+    const changes = diffRecords([record('body>div', { scope: 'button' })], []);
+    assert.equal(changes[0].kind, 'removed');
+    assert.equal(changes[0].scope, 'button');
+  });
+
+  it('splits declared changes from undeclared ones', () => {
+    const changes = [
+      { kind: 'changed', path: 'a', scope: 'button' },
+      { kind: 'added', path: 'b', scope: 'badge' },
+      { kind: 'changed', path: 'c' },
+    ];
+    const { inScope, outOfScope } = partitionChanges(changes, ['button']);
+    assert.deepEqual(
+      inScope.map((change) => change.path),
+      ['a'],
+    );
+    assert.deepEqual(
+      outOfScope.map((change) => change.path),
+      ['b', 'c'],
+    );
+  });
+
+  it('treats an empty declaration as the zero-diff gate', () => {
+    const changes = [{ kind: 'changed', path: 'a', scope: 'button' }];
+    const { inScope, outOfScope } = partitionChanges(changes, []);
+    assert.equal(inScope.length, 0);
+    assert.equal(outOfScope.length, 1);
   });
 });

--- a/scripts/check-visual-contract.test.mjs
+++ b/scripts/check-visual-contract.test.mjs
@@ -9,6 +9,7 @@ import { strict as assert } from 'node:assert';
 import { describe, it } from 'node:test';
 import {
   checkSalvagedAnchors,
+  checkScopeCoverage,
   diffRecords,
   findDeadOmissionRules,
   INHERITED_PROPERTIES,
@@ -235,6 +236,16 @@ describe('declared scopes', () => {
     assert.equal(changes[0].scope, 'button');
   });
 
+  it('fails closed when only the base side claimed a changed element', () => {
+    // A mistyped migrated selector leaves the current side unclaimed. The
+    // base side's legacy claim must NOT carry over, or every change inside
+    // the old subtree would be silently waived (external review finding).
+    const before = [record('body>div', { color: 'red', scope: 'legacy-button' })];
+    const after = [record('body>div', { color: 'blue' })];
+    const { outOfScope } = partitionChanges(diffRecords(before, after), ['legacy-button']);
+    assert.equal(outOfScope.length, 1);
+  });
+
   it('keeps the base attribution for a removed element', () => {
     // The migrated side no longer has the element, so only the base capture
     // knows which scope claimed it — the legacy selector the slice declared.
@@ -265,5 +276,25 @@ describe('declared scopes', () => {
     const { inScope, outOfScope } = partitionChanges(changes, []);
     assert.equal(inScope.length, 0);
     assert.equal(outOfScope.length, 1);
+  });
+});
+
+describe('checkScopeCoverage', () => {
+  const claimed = (n, scope) => Array.from({ length: n }, (_, i) => record(`p${i}`, { scope }));
+
+  it('fails a scope that claims most of a capture', () => {
+    // `#root *` avoids the in-browser root floor (it matches no root element)
+    // but still declares essentially the whole UI (external review finding).
+    const records = [...claimed(6, 'frame'), ...claimed(4, undefined)];
+    assert.deepEqual(checkScopeCoverage(records), [{ scope: 'frame', claimed: 6, total: 10 }]);
+  });
+
+  it('accepts component-sized scopes', () => {
+    const records = [...claimed(3, 'workbar'), ...claimed(2, 'panel'), ...claimed(5, undefined)];
+    assert.deepEqual(checkScopeCoverage(records), []);
+  });
+
+  it('says nothing about an empty capture', () => {
+    assert.deepEqual(checkScopeCoverage([]), []);
   });
 });

--- a/scripts/contract-routes.mjs
+++ b/scripts/contract-routes.mjs
@@ -1,0 +1,78 @@
+// Shared route manifest for the #1565 migration harnesses.
+//
+// check-visual-contract.mjs and check-hit-test.mjs used to carry their own
+// copies of this table. Two copies of "what the five representative routes
+// are" is exactly the kind of duplication the surface slices (PR 8–10) would
+// have had to edit twice, in the same commit, without a conflict to warn
+// them — so the table lives here and both scripts import it.
+//
+// Ready selectors are structural hooks, not product classes. A product class
+// is what the migration deletes: keying the harness on `.settingsRows` means
+// the slice that replaces settings rows must edit the harness in the same
+// breath, re-coupling surfaces through test infrastructure. `data-maka-contract`
+// carries no styling and no behavior; it exists only so the harness can find
+// the same element on both sides of a migration.
+//
+// Migration-only scaffolding: removed in PR 11 with the rest of the harness.
+
+/** The attribute the harness owns. Product CSS must never key on it. */
+export const CONTRACT_HOOK = 'data-maka-contract';
+
+/** Selector for a named contract hook. */
+export const hook = (name) => `[${CONTRACT_HOOK}="${name}"]`;
+
+// The five representative routes from #1565. The issue names product routes;
+// these are the MAKA_E2E_FIXTURE scenarios that actually open them on main —
+// there is no scenario literally named "settings-providers" or "chat".
+// `ready` is the element that means "this surface has rendered". Without it
+// the only alternative is a fixed sleep, which captures a half-mounted route
+// as a clean one on a slow machine — and writes that into the baseline.
+//
+// Each ready selector is `hook, legacy-class`: the visual contract boots the
+// BASE ref with the same selector, and a base that predates the hook rollout
+// (main before PR 2) only has the class. The compound is self-healing in both
+// directions — after PR 2 merges the hook matches every base, and when a
+// slice later deletes the legacy class the hook keeps matching.
+const ready = (name, legacy) => `${hook(name)}, ${legacy}`;
+export const ROUTES = [
+  // Chat session with the task workbar open.
+  {
+    id: 'chat',
+    scenario: 'turn-narrative',
+    ready: ready('session-workbar', '.maka-session-workbar'),
+  },
+  {
+    id: 'settings-general',
+    scenario: 'settings-general',
+    ready: ready('settings-rows', '.settingsRows'),
+  },
+  // Providers live under the 模型 settings section.
+  {
+    id: 'settings-providers',
+    scenario: 'provider-workspace',
+    ready: ready('providers-panel', '.providersPanel'),
+  },
+  // The hook sits on the module <main>, not the PageHeader inside it —
+  // PageHeader takes an explicit prop list and forwarding a harness attribute
+  // through a shared primitive is not worth the API change; the <main>
+  // renders in the same commit as its header.
+  {
+    id: 'mcp-hub',
+    scenario: 'module-mcp',
+    ready: ready('module-main', '.maka-module-main-header'),
+  },
+  // Empty profile, first launch.
+  {
+    id: 'onboarding',
+    scenario: 'first-run',
+    ready: ready('onboarding-surface', '.maka-onboarding-surface'),
+  },
+];
+
+export const THEMES = ['light', 'dark'];
+
+// #1565 asks for darwin AND win32: the per-OS CSS is keyed off
+// `html[data-os]`, so a regression under the win32 cascade is invisible in a
+// darwin-only capture for the whole migration. The fixture platform override
+// flips `data-os` through the production path on any host.
+export const PLATFORMS = ['darwin', 'win32'];

--- a/scripts/generate-third-party-notices.mjs
+++ b/scripts/generate-third-party-notices.mjs
@@ -42,9 +42,17 @@ const LICENSE_SELECTIONS = new Map([
   ['(AFL-2.1 OR BSD-3-Clause)', 'BSD-3-Clause'],
   ['(MPL-2.0 OR Apache-2.0)', 'Apache-2.0'],
 ]);
-const LICENSE_METADATA_OVERRIDES = new Map([['khroma@2.1.0', 'MIT']]);
+const LICENSE_METADATA_OVERRIDES = new Map([
+  ['khroma@2.1.0', 'MIT'],
+  // Declares the ambiguous legacy "BSD"; the shipped LICENSE is BSD-3-Clause.
+  ['css-mediaquery@0.1.2', 'BSD-3-Clause'],
+]);
 const APACHE_TEXT_OVERRIDE_KEYS = new Set(['@ai-sdk/provider-utils@5.0.11']);
 const MIT_COPYRIGHT_OVERRIDES = new Map([
+  // The published tarball omits the repository LICENSE; sibling @astryxdesign
+  // packages ship it verbatim with this notice.
+  ['@astryxdesign/core@0.1.9', 'Copyright (c) 2026 Meta Platforms, Inc.'],
+  ['@stylexjs/stylex@0.19.0', 'Copyright (c) Meta Platforms, Inc. and affiliates.'],
   ['@wecom/aibot-node-sdk@1.0.7', 'Copyright (c) WeComTeam contributors'],
   [
     '@xterm/headless@6.0.0',
@@ -191,10 +199,12 @@ function renderNotice() {
     if (!candidates?.length) throw new Error(`${packageKey}: missing from package-lock.json`);
     const directory = packageDirectory(packageKey, candidates);
     const manifest = readJson(join(directory, 'package.json'));
+    // Overrides go first: they also correct a PRESENT-but-wrong declaration
+    // (css-mediaquery ships the ambiguous legacy "BSD"), not only a missing one.
     const declaredLicense =
+      LICENSE_METADATA_OVERRIDES.get(packageKey) ??
       manifest.license ??
-      candidates.find((candidate) => candidate.metadata.license)?.metadata.license ??
-      LICENSE_METADATA_OVERRIDES.get(packageKey);
+      candidates.find((candidate) => candidate.metadata.license)?.metadata.license;
     if (typeof declaredLicense !== 'string' || declaredLicense.trim().length === 0) {
       throw new Error(`${packageKey}: missing SPDX license metadata`);
     }


### PR DESCRIPTION
## Summary

Slice PR 2 of the Astryx migration (Refs #1565): everything the parallel fan-out depends on, gated on strict zero visual diff.

**Mount Astryx behind the legacy cascade.** Pinned `@astryxdesign/core` / `@astryxdesign/theme-neutral` 0.1.9 (`@astryxdesign/cli` arrives with its consumer in PR 3 — knip rightly rejects a dep nothing uses); versions, provider mount, and import strategy from the retired integration branch. `Theme` sits at the renderer root and follows our already-resolved `.dark` mode through a MutationObserver (`astryx-theme-mode.ts`) — no second theme source. `AstryxLocaleProvider` sits inside `LocaleProvider` (mounting it at the `Theme` level throws before first render) with the zh override map restricted to copy that exists today. The cascade order is extended to `astryx-reset, astryx-tokens, theme, base, astryx-components, components, utilities, maka.legacy`; Astryx ships its sheets **unlayered**, so each import is pinned into its `astryx-*` layer — unwrapped, Astryx would outrank `maka.legacy` and repaint the app on mount. The astryx layers are deliberately top-level names, not `astryx.*` sub-layers: a sub-layer collapses to its parent's first-occurrence position, which would silently drop `astryx-components` below `base` and let Tailwind preflight beat every Astryx component rule from PR 3 on (caught in review; the contract test now pins the effective order and rejects dotted sub-layers). The cascade contract test pins the exact layer per Astryx file, including files not imported yet.

Two inertness measures the zero-diff gate forced, both instructive about what layer order *cannot* do:

- `styles/astryx-mount.css` neutralizes the `Theme` wrapper's inheritance baseline (`color`/`font-family` from Astryx tokens) and re-inherits `--font-size-base`: custom properties resolve by tree distance, not layer order, so a token declared on the wrapper shadows the product's `:root` token for the whole app. The neutralizer lives in `maka.legacy` and dies with it in PR 11.
- Only `astryx.css` (class-scoped, zero product reach) is imported now. `reset.css` and `theme-neutral/theme.css` both style bare elements (`theme.css` additionally ships `@scope`'d element typography — `:where(p)`, `:where(h1..h6)` take the Astryx font), and an element rule wins wherever no product rule competes, regardless of layers. `theme.css` lands with the first component consumer (PR 3) — preferably as an `astryx theme build` of a Maka-named theme so the typography block is dropped at the source; `reset.css` lands with the Tailwind-preflight retirement (PR 12). Layer slots for both are reserved and contract-tested.

**Harness upgrade — the fan-out blocker.** Without this, slices 8–10 would all edit the same harness files and re-couple through test infrastructure:

- `scripts/contract-routes.mjs` is the single route manifest for both harnesses.
- Ready/anchor selectors moved from product classes to `data-maka-contract` structural hooks (12 attribute-only product edits). Ready selectors are `hook, legacy-class` compounds so the base side of a comparison keeps working across the hook rollout and later class deletions.
- Element identity is now box-tree paths: `display: contents` wrappers (what `Theme` renders) generate no box and contribute no path segment, so mounting a provider does not re-key every element under it.
- Declared-subtree mode (`--scopes <file>`): a slice declares selectors for the legacy element it replaces and the migrated element it lands; diffs inside declared scopes are reported for review, any diff outside fails, and zero diff stays the default gate. The mode fails closed: a changed element must be claimed by the *current* side (a mistyped migrated selector cannot ride on the base side's legacy claim), a scope matching `html`/`body`/`#root` fails the run, and so does a scope claiming most of a side's captured boxes (`#root *` cannot dodge the root floor).
- Non-vacuous mount proof: the capture counts rules under `astryx.*` layers via CSSOM and fails when zero, so a zero-diff pass cannot mean "Astryx never loaded".

**Deliberate deviations from the issue text, with reasons:**

- `LayerProvider` is not mounted here: it renders a portal host/toast viewport, which would change the DOM under `body` and break the zero-diff gate. It lands with PR 5, which owns Layer behavior.
- `theme.css` is deferred to PR 3 (above): the token sheet is inseparable from its element-typography block, which repaints unowned text on every route.
- The i18n override map covers only `@astryx.*` keys whose copy sources exist on `main`; the Markdown catalog keys land with PR 7 together with their copy.
- `tailwind-theme.css` is not imported (the issue already allows this): the `@theme inline` bridge stays the utility-token source until PR 12.

Third-party notices: regenerated; `@astryxdesign/core` and `@stylexjs/stylex` ship no LICENSE file and use version-pinned MIT text overrides; `css-mediaquery` declares legacy "BSD" and is pinned to its shipped BSD-3-Clause. Metadata overrides now take precedence over a present-but-wrong declaration.

## Verification

- `npm run check:visual-contract` against `main`: 20/20 comparisons (5 routes × light/dark × darwin/win32) zero diff, salvaged anchors present, Astryx-loaded probe non-zero. The gate caught four real leak classes during development (hook-only ready selectors, the `Theme` wrapper's box-tree/inheritance effects, `reset.css` bare-element reach, wrapper token shadowing) — it is doing the job the fan-out relies on.
- `npm run check:hit-test`: 5 routes clean.
- Harness unit tests: 27 pass (including the new declared-scope, fail-closed attribution, scope-coverage, and hook-anchor suites — the synthetic-scope demonstration required by the issue).
- `@maka/desktop` main tests 2993 pass (cascade contract 9/9), `@maka/ui` 269 pass.
- `npm run lint`, `npm run format:check`, workspace typecheck, `npm run check:third-party-notices` all clean.
