### PR TITLE
feat(voice): add model-routed input and realtime coordination

### DIFF
--- a/apps/desktop/src/main/__tests__/claude-subscription-cloak-flag.test.ts
+++ b/apps/desktop/src/main/__tests__/claude-subscription-cloak-flag.test.ts
@@ -82,7 +82,7 @@ describe('cloaked request module isolation (xuan G-X4)', () => {
   });
 
   it('main delegates Codex OAuth request construction to runtime', async () => {
-    const src = await readMainProcessCombinedSource();
+    const src = await readFile(SUBSCRIPTION_MODEL_FETCH_SOURCE, 'utf8');
     assert.match(src, /providerType === 'openai-codex'[\s\S]*buildRuntimeSubscriptionModelFetch\(\{[\s\S]*connection[\s\S]*sessionId[\s\S]*modelId/);
     assert.doesNotMatch(src, /function buildOpenAiCodexFetch/, 'desktop must not duplicate the Codex fetch adapter');
     assert.doesNotMatch(src, /codexInstructionsFromBody/, 'Codex instruction mapping belongs in runtime');

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -96,6 +96,7 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/tool-assembly.ts',
   'apps/desktop/src/main/tool-artifact-persistence.ts',
   'apps/desktop/src/main/usage-ipc-main.ts',
+  'apps/desktop/src/main/voice-ipc-main.ts',
   'apps/desktop/src/main/web-search-ipc-main.ts',
   'apps/desktop/src/main/workspace-instructions-ipc-main.ts',
   'apps/desktop/src/main/workspace-resources-ipc-main.ts',

--- a/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-roadmap-cleanup-contract.test.ts
@@ -121,7 +121,7 @@ describe('Settings coming-soon cleanup contract', () => {
 
   it('keeps Voice settings boundary copy in current-policy language', async () => {
     const settings = await readSettingsCombinedSource();
-    const voicePage = settings.match(/function VoiceModelsSettingsPage\(\)[\s\S]*?async function readBrowserMicrophonePermission/);
+    const voicePage = settings.match(/function VoiceModelsSettingsPage\([\s\S]*?async function readBrowserMicrophonePermission/);
     const voiceCopy = getVoiceSettingsCopy('zh');
 
     assert.ok(voicePage, 'Voice settings page block must exist');

--- a/apps/desktop/src/main/__tests__/voice-audio-capture.test.ts
+++ b/apps/desktop/src/main/__tests__/voice-audio-capture.test.ts
@@ -1,0 +1,106 @@
+import assert from 'node:assert/strict';
+import { afterEach, describe, it } from 'node:test';
+import { startVoiceCapture } from '../../renderer/voice-audio-capture.js';
+
+const originalNavigator = globalThis.navigator;
+const originalMediaRecorder = globalThis.MediaRecorder;
+const originalWindow = globalThis.window;
+
+afterEach(() => {
+  defineGlobal('navigator', originalNavigator);
+  defineGlobal('MediaRecorder', originalMediaRecorder);
+  defineGlobal('window', originalWindow);
+});
+
+describe('voice audio capture lifecycle', () => {
+  it('releases the microphone and reports a fatal recorder error immediately', async () => {
+    let trackStops = 0;
+    let activeRecorder: FakeMediaRecorder | undefined;
+    const track = { stop: () => { trackStops += 1; } };
+    const stream = { getTracks: () => [track] };
+
+    class CapturingMediaRecorder extends FakeMediaRecorder {
+      constructor(input: MediaStream) {
+        super(input);
+        activeRecorder = this;
+      }
+    }
+
+    installBrowserFakes(stream as unknown as MediaStream, CapturingMediaRecorder);
+    let reported: Error | undefined;
+    const capture = await startVoiceCapture({
+      onError: (error) => {
+        reported = error;
+      },
+    });
+
+    activeRecorder?.dispatchEvent(new Event('error'));
+
+    assert.equal(reported?.message, 'voice_recording_failed');
+    assert.equal(trackStops, 1);
+    assert.equal(activeRecorder?.state, 'inactive');
+    await assert.rejects(() => capture.stop(), /voice_capture_already_finished/);
+  });
+
+  it('releases the microphone when recorder construction fails', async () => {
+    let trackStops = 0;
+    const stream = {
+      getTracks: () => [{ stop: () => { trackStops += 1; } }],
+    };
+    class FailingMediaRecorder extends FakeMediaRecorder {
+      constructor(input: MediaStream) {
+        super(input);
+        throw new Error('recorder_construction_failed');
+      }
+    }
+    installBrowserFakes(stream as unknown as MediaStream, FailingMediaRecorder);
+
+    await assert.rejects(() => startVoiceCapture(), /recorder_construction_failed/);
+    assert.equal(trackStops, 1);
+  });
+});
+
+class FakeMediaRecorder extends EventTarget {
+  static isTypeSupported(): boolean {
+    return true;
+  }
+
+  readonly mimeType = 'audio/webm';
+  state: RecordingState = 'inactive';
+
+  constructor(_stream: MediaStream, _options?: MediaRecorderOptions) {
+    super();
+  }
+
+  start(): void {
+    this.state = 'recording';
+  }
+
+  stop(): void {
+    if (this.state === 'inactive') return;
+    this.state = 'inactive';
+    this.dispatchEvent(new Event('stop'));
+  }
+}
+
+function installBrowserFakes(
+  stream: MediaStream,
+  Recorder: typeof FakeMediaRecorder,
+): void {
+  defineGlobal('navigator', {
+    mediaDevices: { getUserMedia: async () => stream },
+  });
+  defineGlobal('MediaRecorder', Recorder);
+  defineGlobal('window', {
+    setTimeout: globalThis.setTimeout.bind(globalThis),
+    clearTimeout: globalThis.clearTimeout.bind(globalThis),
+  });
+}
+
+function defineGlobal(name: string, value: unknown): void {
+  Object.defineProperty(globalThis, name, {
+    configurable: true,
+    writable: true,
+    value,
+  });
+}

--- a/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
@@ -21,7 +21,7 @@ describe('voice capture smoke Settings contract', () => {
     const gatewayNav = src.match(/\{\s*id:\s*'open-gateway'[\s\S]*?\},/);
     assert.ok(gatewayNav, 'open-gateway nav item must exist');
     assert.doesNotMatch(gatewayNav![0], /comingSoon:\s*true/, 'open-gateway nav must not be tagged as coming soon');
-    assert.match(src, /case\s+'voice':\s*\n[\s\S]*?<VoiceModelsSettingsPage\s*\/>/);
+    assert.match(src, /case\s+'voice':\s*\n[\s\S]*?<VoiceModelsSettingsPage\b/);
     assert.match(src, /case\s+'open-gateway':\s*\n[\s\S]*?<OpenGatewaySettingsPage\b/);
     assert.doesNotMatch(src, /'voice':\s*\{[\s\S]*当前尚未实现/, 'voice must not keep stale roadmap copy');
   });
@@ -37,6 +37,33 @@ describe('voice capture smoke Settings contract', () => {
     assert.match(zhCopy.idle, /等待运行本机录音自检/, 'voice idle state should read as an actionable local check');
     assert.doesNotMatch(zhCopy.idle, /尚未运行本机录音自检/, 'voice idle state should not read like unfinished implementation copy');
     assert.doesNotMatch(src, /localStorage\.setItem\([^)]*voice/i, 'voice smoke must not persist audio state in localStorage');
+  });
+
+  it('creates a recognition connection in Voice and selects its ASR model', async () => {
+    const src = await readFile(
+      join(REPO_ROOT, 'apps/desktop/src/renderer/settings/voice-settings-page.tsx'),
+      'utf8',
+    );
+    const zhCopy = getVoiceSettingsCopy('zh');
+
+    assert.match(src, /<AddProviderForm[\s\S]*providerType="openai-compatible"/);
+    assert.match(
+      src,
+      /onClick=\{\(\) => setCreatingRecognitionConnection\(true\)\}/,
+      'Voice must expose the create-recognition-connection action in place',
+    );
+    assert.match(
+      src,
+      /const created = connections\.find\(\(connection\) => connection\.slug === slug\);[\s\S]*recognition:\s*\{[\s\S]*connectionSlug: created\.slug,[\s\S]*model: created\.defaultModel/,
+      'a newly created connection must become the selected recognition connection and model',
+    );
+    assert.match(
+      src,
+      /await props\.onRefreshConnections\(\);[\s\S]*setCreatingRecognitionConnection\(false\)/,
+      'Voice must refresh the shared connection list before closing the create dialog',
+    );
+    assert.equal(zhCopy.createRecognitionConnection, '新建识别连接');
+    assert.match(zhCopy.createRecognitionConnectionSubtitle, /ASR 模型 ID/);
   });
 
   it('keeps success and permission states as deterministic stories', async () => {

--- a/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
@@ -107,6 +107,55 @@ describe('voice capture smoke Settings contract', () => {
     assert.match(zhCopy.recognitionConnectionApiKeyHelp, /只有填写新值时才会替换/);
   });
 
+  it('keeps realtime secrets in main and binds coordinator calls to their own task session', async () => {
+    const hookSource = await readFile(
+      join(REPO_ROOT, 'apps/desktop/src/renderer/use-voice-input.ts'),
+      'utf8',
+    );
+    const shellSource = await readFile(
+      join(REPO_ROOT, 'apps/desktop/src/renderer/app-shell.tsx'),
+      'utf8',
+    );
+    const preloadSource = await readFile(
+      join(REPO_ROOT, 'apps/desktop/src/preload/preload.ts'),
+      'utf8',
+    );
+
+    assert.match(
+      hookSource,
+      /createRealtimeSession\(offer\.sdp \?\? ''\)/,
+      'renderer must send only its SDP offer through the trusted bridge',
+    );
+    assert.match(hookSource, /sdp:\s*session\.answerSdp/);
+    assert.doesNotMatch(hookSource, /session\.(?:clientSecret|endpoint)/);
+    assert.doesNotMatch(hookSource, /fetch\(session\./);
+    assert.match(
+      preloadSource,
+      /createRealtimeSession\(offerSdp: string\)[\s\S]*ipcRenderer\.invoke\('voice:createRealtimeSession', offerSdp\)/,
+      'preload must not expose the endpoint or ephemeral credential',
+    );
+    assert.match(hookSource, /taskSessionId\?: string/);
+    assert.match(
+      hookSource,
+      /inputRef\.current\.runCoordinatorTool\(call,\s*\{[\s\S]*taskSessionId: active\.taskSessionId/,
+      'the live DataChannel handler must use current callbacks and its voice-session-owned task',
+    );
+
+    const coordinatorBlock = shellSource.slice(
+      shellSource.indexOf('runCoordinatorTool: async'),
+      shellSource.indexOf('onBlocked:', shellSource.indexOf('runCoordinatorTool: async')),
+    );
+    assert.match(coordinatorBlock, /onSessionResolved/);
+    assert.match(coordinatorBlock, /const sessionId = context\.taskSessionId/);
+    assert.match(coordinatorBlock, /window\.maka\.sessions\.list\(\)/);
+    assert.match(coordinatorBlock, /window\.maka\.sessions\.readMessages\(sessionId\)/);
+    assert.doesNotMatch(
+      coordinatorBlock,
+      /sessions\.find|const lastAssistant = \[\.\.\.messages\]/,
+      'status and summaries must not read the render that opened the DataChannel',
+    );
+  });
+
   it('keeps success and permission states as deterministic stories', async () => {
     const stories = await readFile(
       join(REPO_ROOT, 'apps/desktop/stories/settings/settings-pages.stories.tsx'),

--- a/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
@@ -66,6 +66,47 @@ describe('voice capture smoke Settings contract', () => {
     assert.match(zhCopy.createRecognitionConnectionSubtitle, /ASR 模型 ID/);
   });
 
+  it('edits the selected recognition connection in Voice without exposing its saved API key', async () => {
+    const pageSource = await readFile(
+      join(REPO_ROOT, 'apps/desktop/src/renderer/settings/voice-settings-page.tsx'),
+      'utf8',
+    );
+    const formSource = await readFile(
+      join(REPO_ROOT, 'apps/desktop/src/renderer/settings/voice-recognition-connection-form.tsx'),
+      'utf8',
+    );
+    const zhCopy = getVoiceSettingsCopy('zh');
+
+    assert.match(
+      pageSource,
+      /const selectedRecognitionConnection = enabledConnections\.find\([\s\S]*settings\.voice\.recognition\.connectionSlug/,
+      'the edit action must target the currently selected recognition connection',
+    );
+    assert.match(
+      pageSource,
+      /disabled=\{saving \|\| isBusy \|\| !selectedRecognitionConnection\}[\s\S]*copy\.editRecognitionConnection/,
+      'Voice must disable the edit action until a recognition connection is selected',
+    );
+    assert.match(pageSource, /<VoiceRecognitionConnectionForm[\s\S]*onSaved=\{finishEditingRecognitionConnection\}/);
+    assert.match(
+      formSource,
+      /bridge\.update\(props\.connection\.slug,\s*\{[\s\S]*baseUrl: normalizedBaseUrl,[\s\S]*defaultModel: normalizedModel,[\s\S]*apiKey: apiKey\.trim\(\)/,
+      'the editor must save endpoint, ASR model, and an explicitly entered replacement key',
+    );
+    assert.match(
+      formSource,
+      /apiKey\.trim\(\) \? \{ apiKey: apiKey\.trim\(\) \} : \{\}/,
+      'an empty API key field must preserve the stored secret',
+    );
+    assert.doesNotMatch(
+      formSource,
+      /resolveConnectionSecret|credentialStore|apiKey:\s*props\.connection/,
+      'the renderer editor must never read the stored API key back',
+    );
+    assert.match(zhCopy.recognitionConnectionEndpointHelp, /不要包含 \/audio\/transcriptions/);
+    assert.match(zhCopy.recognitionConnectionApiKeyHelp, /只有填写新值时才会替换/);
+  });
+
   it('keeps success and permission states as deterministic stories', async () => {
     const stories = await readFile(
       join(REPO_ROOT, 'apps/desktop/stories/settings/settings-pages.stories.tsx'),

--- a/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/voice-capture-smoke-contract.test.ts
@@ -82,11 +82,6 @@ describe('voice capture smoke Settings contract', () => {
       /const selectedRecognitionConnection = enabledConnections\.find\([\s\S]*settings\.voice\.recognition\.connectionSlug/,
       'the edit action must target the currently selected recognition connection',
     );
-    assert.match(
-      pageSource,
-      /disabled=\{saving \|\| isBusy \|\| !selectedRecognitionConnection\}[\s\S]*copy\.editRecognitionConnection/,
-      'Voice must disable the edit action until a recognition connection is selected',
-    );
     assert.match(pageSource, /<VoiceRecognitionConnectionForm[\s\S]*onSaved=\{finishEditingRecognitionConnection\}/);
     assert.match(
       formSource,
@@ -147,7 +142,11 @@ describe('voice capture smoke Settings contract', () => {
     );
     assert.match(coordinatorBlock, /onSessionResolved/);
     assert.match(coordinatorBlock, /const sessionId = context\.taskSessionId/);
-    assert.match(coordinatorBlock, /window\.maka\.sessions\.list\(\)/);
+    assert.match(
+      coordinatorBlock,
+      /const authoritativeSessions = await refreshSessions\(\)/,
+      'coordinator status checks must refresh through the session workspace owner',
+    );
     assert.match(coordinatorBlock, /window\.maka\.sessions\.readMessages\(sessionId\)/);
     assert.doesNotMatch(
       coordinatorBlock,

--- a/apps/desktop/src/main/__tests__/voice-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/voice-ipc-main.test.ts
@@ -1,0 +1,223 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { createDefaultSettings, type AppSettings, type LlmConnection } from '@maka/core';
+import { createVoiceIpcService } from '../voice-ipc-main.js';
+
+function connection(models: string[]): LlmConnection {
+  return {
+    slug: 'openai',
+    name: 'OpenAI',
+    providerType: 'openai',
+    enabled: true,
+    baseUrl: 'https://api.openai.test/v1',
+    defaultModel: models[0] ?? 'gpt-4.1',
+    enabledModelIds: models,
+    models: models.map((id) => ({ id })),
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function settings(patch?: Partial<AppSettings['voice']>): AppSettings {
+  const value = createDefaultSettings();
+  return {
+    ...value,
+    voice: {
+      recognition: {
+        ...value.voice.recognition,
+        ...patch?.recognition,
+      },
+      realtime: {
+        ...value.voice.realtime,
+        ...patch?.realtime,
+      },
+    },
+  };
+}
+
+function service(input: {
+  settings: AppSettings;
+  connection: LlmConnection;
+  fetch?: typeof fetch;
+}) {
+  return createVoiceIpcService({
+    settingsStore: { get: async () => input.settings } as never,
+    connectionStore: {
+      get: async (slug: string) => (slug === input.connection.slug ? input.connection : null),
+    } as never,
+    resolveConnectionSecret: async () => 'server-secret',
+    ...(input.fetch ? { fetch: input.fetch } : {}),
+  });
+}
+
+const audio = {
+  bytes: new Uint8Array([82, 73, 70, 70]),
+  mediaType: 'audio/wav',
+  format: 'wav' as const,
+  durationMs: 500,
+  sampleRate: 16_000,
+  channels: 1,
+};
+
+describe('voice IPC service', () => {
+  it('fails closed when speech recognition is not configured', async () => {
+    const voice = service({
+      settings: settings(),
+      connection: connection(['gpt-4.1']),
+    });
+    assert.deepEqual(await voice.begin({ intent: 'dictate' }), {
+      ok: false,
+      reason: 'recognition_not_configured',
+    });
+  });
+
+  it('rejects malformed begin requests at the trusted IPC boundary', async () => {
+    const voice = service({
+      settings: settings(),
+      connection: connection(['gpt-4.1']),
+    });
+    await assert.rejects(() => voice.begin(null as never), /voice_begin_invalid/);
+    await assert.rejects(
+      () => voice.begin({ intent: 'send_task', currentAgent: { connectionSlug: '', model: '' } }),
+      /voice_begin_invalid/,
+    );
+  });
+
+  it('transcribes through the configured connection and never returns its key', async () => {
+    let request: { url: string; authorization?: string; body?: FormData };
+    const fetchMock: typeof fetch = async (url, init) => {
+      request = {
+        url: String(url),
+        authorization: new Headers(init?.headers).get('authorization') ?? undefined,
+        body: init?.body as FormData,
+      };
+      return new Response(JSON.stringify({ text: '  hello from voice  ' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
+    };
+    const voice = service({
+      settings: settings({
+        recognition: {
+          connectionSlug: 'openai',
+          model: 'gpt-4o-mini-transcribe',
+          language: 'en',
+          prompt: 'Maka',
+        },
+      }),
+      connection: connection(['gpt-4o-mini-transcribe']),
+      fetch: fetchMock,
+    });
+    const begin = await voice.begin({ intent: 'dictate' });
+    assert.equal(begin.ok, true);
+    if (!begin.ok) return;
+    const result = await voice.finishCapture(begin.operationId, audio);
+    assert.deepEqual(result, {
+      kind: 'transcript',
+      operationId: begin.operationId,
+      text: 'hello from voice',
+      providerLabel: 'OpenAI',
+    });
+    assert.equal(request!.url, 'https://api.openai.test/v1/audio/transcriptions');
+    assert.equal(request!.authorization, 'Bearer server-secret');
+    assert.equal(request!.body?.get('model'), 'gpt-4o-mini-transcribe');
+    assert.equal(JSON.stringify(result).includes('server-secret'), false);
+  });
+
+  it('aborts an in-flight transcription when the operation is cancelled', async () => {
+    const fetchMock: typeof fetch = async (_url, init) =>
+      new Promise<Response>((_resolve, reject) => {
+        if (init?.signal?.aborted) {
+          reject(init.signal.reason ?? new Error('aborted'));
+          return;
+        }
+        init?.signal?.addEventListener(
+          'abort',
+          () => reject(init.signal?.reason ?? new Error('aborted')),
+          { once: true },
+        );
+      });
+    const voice = service({
+      settings: settings({
+        recognition: {
+          connectionSlug: 'openai',
+          model: 'gpt-4o-mini-transcribe',
+          language: '',
+          prompt: '',
+        },
+      }),
+      connection: connection(['gpt-4o-mini-transcribe']),
+      fetch: fetchMock,
+    });
+    const begin = await voice.begin({ intent: 'dictate' });
+    assert.equal(begin.ok, true);
+    if (!begin.ok) return;
+    const pending = voice.finishCapture(begin.operationId, audio);
+    voice.cancel(begin.operationId);
+    await assert.rejects(() => pending);
+  });
+
+  it('stages native audio once and binds it to the selected connection/model', async () => {
+    const voice = service({
+      settings: settings(),
+      connection: connection(['gpt-audio']),
+    });
+    const begin = await voice.begin({
+      intent: 'send_task',
+      currentAgent: { connectionSlug: 'openai', model: 'gpt-audio' },
+    });
+    assert.equal(begin.ok, true);
+    if (!begin.ok) return;
+    assert.equal((await voice.finishCapture(begin.operationId, audio)).kind, 'native_audio_ready');
+    assert.throws(() =>
+      voice.consumeNativeAudioOperation({
+        operationId: begin.operationId,
+        connectionSlug: 'openai',
+        model: 'gpt-audio-mini',
+      }),
+    );
+    const consumed = voice.consumeNativeAudioOperation({
+      operationId: begin.operationId,
+      connectionSlug: 'openai',
+      model: 'gpt-audio',
+    });
+    assert.equal(consumed.retention, 'operation_memory');
+    assert.throws(() =>
+      voice.consumeNativeAudioOperation({
+        operationId: begin.operationId,
+        connectionSlug: 'openai',
+        model: 'gpt-audio',
+      }),
+    );
+  });
+
+  it('returns only an ephemeral realtime token and enforces one active lease', async () => {
+    const fetchMock: typeof fetch = async (_url, init) => {
+      assert.equal(
+        new Headers(init?.headers).get('authorization'),
+        'Bearer server-secret',
+      );
+      return new Response(
+        JSON.stringify({ value: 'ephemeral-client-secret', expires_at: 123 }),
+        { status: 200 },
+      );
+    };
+    const voice = service({
+      settings: settings({
+        realtime: {
+          connectionSlug: 'openai',
+          model: 'gpt-realtime',
+          voice: 'marin',
+        },
+      }),
+      connection: connection(['gpt-realtime']),
+      fetch: fetchMock,
+    });
+    const session = await voice.createRealtimeSession();
+    assert.equal(session.clientSecret, 'ephemeral-client-secret');
+    assert.equal(JSON.stringify(session).includes('server-secret'), false);
+    await assert.rejects(() => voice.createRealtimeSession());
+    voice.closeRealtimeSession(session.sessionId);
+    assert.equal((await voice.createRealtimeSession()).clientSecret, 'ephemeral-client-secret');
+  });
+});

--- a/apps/desktop/src/main/__tests__/voice-ipc-main.test.ts
+++ b/apps/desktop/src/main/__tests__/voice-ipc-main.test.ts
@@ -191,16 +191,25 @@ describe('voice IPC service', () => {
     );
   });
 
-  it('returns only an ephemeral realtime token and enforces one active lease', async () => {
-    const fetchMock: typeof fetch = async (_url, init) => {
-      assert.equal(
-        new Headers(init?.headers).get('authorization'),
-        'Bearer server-secret',
-      );
-      return new Response(
-        JSON.stringify({ value: 'ephemeral-client-secret', expires_at: 123 }),
-        { status: 200 },
-      );
+  it('exchanges realtime SDP in main without exposing credentials and enforces one active lease', async () => {
+    const requests: Array<{
+      url: string;
+      authorization: string | null;
+      body: BodyInit | null | undefined;
+    }> = [];
+    const fetchMock: typeof fetch = async (url, init) => {
+      requests.push({
+        url: String(url),
+        authorization: new Headers(init?.headers).get('authorization'),
+        body: init?.body,
+      });
+      if (String(url).endsWith('/realtime/client_secrets')) {
+        return new Response(
+          JSON.stringify({ value: 'ephemeral-client-secret', expires_at: 123 }),
+          { status: 200 },
+        );
+      }
+      return new Response('v=0\r\no=answer', { status: 200 });
     };
     const voice = service({
       settings: settings({
@@ -213,11 +222,32 @@ describe('voice IPC service', () => {
       connection: connection(['gpt-realtime']),
       fetch: fetchMock,
     });
-    const session = await voice.createRealtimeSession();
-    assert.equal(session.clientSecret, 'ephemeral-client-secret');
+    const offerSdp = 'v=0\r\no=offer';
+    const session = await voice.createRealtimeSession(offerSdp);
+    assert.equal(session.answerSdp, 'v=0\r\no=answer');
     assert.equal(JSON.stringify(session).includes('server-secret'), false);
-    await assert.rejects(() => voice.createRealtimeSession());
+    assert.equal(JSON.stringify(session).includes('ephemeral-client-secret'), false);
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0]?.url, 'https://api.openai.test/v1/realtime/client_secrets');
+    assert.equal(requests[0]?.authorization, 'Bearer server-secret');
+    assert.match(String(requests[0]?.body), /"model":"gpt-realtime"/);
+    assert.deepEqual(requests[1], {
+      url: 'https://api.openai.test/v1/realtime/calls',
+      authorization: 'Bearer ephemeral-client-secret',
+      body: offerSdp,
+    });
+    await assert.rejects(
+      () => voice.createRealtimeSession(offerSdp),
+      /voice_realtime_session_already_active/,
+    );
     voice.closeRealtimeSession(session.sessionId);
-    assert.equal((await voice.createRealtimeSession()).clientSecret, 'ephemeral-client-secret');
+    assert.equal((await voice.createRealtimeSession(offerSdp)).answerSdp, 'v=0\r\no=answer');
+    await assert.rejects(
+      () => service({
+        settings: settings(),
+        connection: connection(['gpt-realtime']),
+      }).createRealtimeSession('not-sdp'),
+      /voice_realtime_offer_invalid/,
+    );
   });
 });

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -143,6 +143,7 @@ import {
 import { registerGatewayIpc } from './gateway-ipc-main.js';
 import { registerSessionsIpc } from './sessions-ipc-main.js';
 import { registerAgentGraphIpc } from './agent-graph-ipc-main.js';
+import { createVoiceIpcService, registerVoiceIpc } from './voice-ipc-main.js';
 import {
   assertSessionCanSendFromHeader,
   isSessionLifecycleError,
@@ -373,6 +374,12 @@ function disconnectManagedOAuthConnection(connection: LlmConnection): Promise<vo
 function resolveConnectionSecret(slug: string): Promise<string | null> {
   return oauthModelConnections.resolveConnectionSecret(slug);
 }
+
+const voiceIpcService = createVoiceIpcService({
+  settingsStore,
+  connectionStore,
+  resolveConnectionSecret,
+});
 
 /**
  * Read-only credential-presence check for status paths (onboarding's
@@ -1105,6 +1112,7 @@ function registerIpc(): void {
     coordinator: agentGraphCoordinator,
     sendToRenderer: safeSendToRenderer,
   });
+  registerVoiceIpc({ ipcMain, service: voiceIpcService });
   registerSessionsIpc({
     workspaceRoot,
     runtime,
@@ -1138,6 +1146,8 @@ function registerIpc(): void {
     streamEvents,
     getWorkspacePrivacyContext,
     canCreateFakeSession: canCreateFakeSessionFromRenderer,
+    consumeNativeAudioOperation: (input) =>
+      voiceIpcService.consumeNativeAudioOperation(input),
   });
   registerSubscriptionIpc({
     connectionStore,

--- a/apps/desktop/src/main/permission-response-guard.ts
+++ b/apps/desktop/src/main/permission-response-guard.ts
@@ -21,6 +21,8 @@ interface NormalizedSendSessionCommand {
   type: 'send';
   turnId?: string;
   text: string;
+  displayText?: string;
+  voiceOperationId?: string;
   skillIds?: string[];
   attachmentItems?: unknown;
   turnOrchestration?: TurnOrchestration;
@@ -106,12 +108,22 @@ export function normalizeSessionSendCommand(input: unknown): NormalizedSendSessi
   const value = requireObject(input, 'Invalid session command');
   if (value.type !== 'send') return undefined;
   const text = normalizeSendText(value.text);
+  const displayText =
+    value.displayText === undefined ? undefined : normalizeSendText(value.displayText);
+  const voiceOperationId =
+    value.voiceOperationId === undefined
+      ? undefined
+      : normalizeVoiceOperationId(value.voiceOperationId);
   const skillIds = normalizeSessionSkillIds(value.skillIds);
-  if (!text.trim() && skillIds.length === 0) throw new Error('Invalid send text');
+  if (!text.trim() && skillIds.length === 0 && !voiceOperationId) {
+    throw new Error('Invalid send text');
+  }
   return {
     type: 'send',
     ...normalizeOptionalSendTurnId(value.turnId),
     text,
+    ...(displayText !== undefined ? { displayText } : {}),
+    ...(voiceOperationId ? { voiceOperationId } : {}),
     ...(skillIds.length > 0 ? { skillIds } : {}),
     ...(value.attachmentItems !== undefined ? { attachmentItems: value.attachmentItems } : {}),
     ...(value.turnOrchestration !== undefined
@@ -119,6 +131,17 @@ export function normalizeSessionSendCommand(input: unknown): NormalizedSendSessi
       : {}),
     ...normalizeOptionalQuotes(value.quotes),
   };
+}
+
+function normalizeVoiceOperationId(input: unknown): string {
+  if (
+    typeof input !== 'string' ||
+    input.length > 64 ||
+    !/^[0-9a-f]{8}-[0-9a-f-]{27,36}$/i.test(input)
+  ) {
+    throw new Error('Invalid voice operation id');
+  }
+  return input;
 }
 
 function normalizeTurnOrchestration(input: unknown): TurnOrchestration {

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -20,6 +20,7 @@ import type {
   SessionListFilter,
   StoredMessage,
   ThinkingLevel,
+  EphemeralVoiceAudio,
 } from '@maka/core';
 import type { ProviderType } from '@maka/core/llm-connections';
 import type { WorkspacePrivacyContext } from '@maka/core/incognito';
@@ -116,6 +117,11 @@ export interface SessionsIpcDeps {
   ) => Promise<{ turnId: string; ok: boolean; error?: string }>;
   getWorkspacePrivacyContext: () => Promise<WorkspacePrivacyContext>;
   canCreateFakeSession: () => boolean;
+  consumeNativeAudioOperation?: (input: {
+    operationId: string;
+    connectionSlug: string;
+    model: string;
+  }) => EphemeralVoiceAudio;
 }
 
 function latestStoredMessageTs(messages: readonly StoredMessage[]): number | undefined {
@@ -210,6 +216,7 @@ export function registerSessionsIpc(
     streamEvents,
     getWorkspacePrivacyContext,
     canCreateFakeSession,
+    consumeNativeAudioOperation,
   } = deps;
   registerSessionExecutionIpc({
     ipcMain,
@@ -430,17 +437,35 @@ export function registerSessionsIpc(
     const skillInvocation = sendPlan.preparation;
     const { turnId, attachments } = sendPlan.resolved;
     const displayText =
-      sendCommand.text.trim().length > 0
+      sendCommand.displayText ??
+      (sendCommand.text.trim().length > 0
         ? sendCommand.text
         : skillInvocation.skillInvocation.loaded
             .map((skill) => `/skill:${skill.id}`)
-            .join(' ');
+            .join(' '));
+    const voiceTargetHeader = sendCommand.voiceOperationId
+      ? await store.readHeader(sessionId)
+      : undefined;
+    const voiceAudio =
+      sendCommand.voiceOperationId && voiceTargetHeader
+        ? consumeNativeAudioOperation?.({
+            operationId: sendCommand.voiceOperationId,
+            connectionSlug: voiceTargetHeader.llmConnectionSlug,
+            model: voiceTargetHeader.model,
+          })
+        : undefined;
+    if (sendCommand.voiceOperationId && !voiceAudio) {
+      throw new Error('voice_operation_unavailable');
+    }
     const iterator = runtime.sendMessage(
       sessionId,
       {
         turnId,
         text: skillInvocation.sendText,
-        ...(skillInvocation.disposition === 'ready' ? { displayText } : {}),
+        ...(voiceAudio ? { voiceAudio } : {}),
+        ...(skillInvocation.disposition === 'ready' || sendCommand.displayText !== undefined
+          ? { displayText }
+          : {}),
         ...(sendCommand.turnOrchestration
           ? { turnOrchestration: sendCommand.turnOrchestration }
           : {}),
@@ -462,6 +487,13 @@ export function registerSessionsIpc(
       attachments,
       skillInvocation: skillInvocation.skillInvocation,
     };
+  });
+  ipcMain.handle('sessions:steer', async (_event, sessionId: string, text: unknown) => {
+    if (typeof text !== 'string' || text.trim().length === 0 || text.length > 128_000) {
+      throw new Error('Invalid steering text');
+    }
+    await store.readHeader(sessionId);
+    return runtime.steer(sessionId, text.trim());
   });
   ipcMain.handle(
     'attachments:pickFiles',

--- a/apps/desktop/src/main/voice-ipc-main.ts
+++ b/apps/desktop/src/main/voice-ipc-main.ts
@@ -1,0 +1,602 @@
+import { randomUUID } from 'node:crypto';
+import type { IpcMain } from 'electron';
+import {
+  PROVIDER_DEFAULTS,
+  connectionEnabledModelIds,
+  effectiveBaseUrl,
+  normalizeVoiceCoordinatorToolCall,
+  normalizeVoiceTranscriptText,
+  resolveModelVoiceMetadata,
+  resolveVoiceRoute,
+  validateVoiceCaptureRequest,
+  type EphemeralVoiceAudio,
+  type LlmConnection,
+  type VoiceBeginRequest,
+  type VoiceBeginResult,
+  type VoiceCapturedAudio,
+  type VoiceCoordinatorToolCall,
+  type VoiceFinishCaptureResult,
+  type VoiceModelRouteCapability,
+  type VoiceRealtimeClientSession,
+  type VoiceRoutePlan,
+} from '@maka/core';
+import { providerAuthRequiresSecret } from '@maka/core/llm-connections';
+import type { ConnectionStore, SettingsStore } from '@maka/storage';
+
+const OPERATION_TTL_MS = 5 * 60_000;
+const MAX_ACTIVE_OPERATIONS = 32;
+const MAX_PROVIDER_RESPONSE_BYTES = 256 * 1024;
+const TRANSCRIPTION_TIMEOUT_MS = 90_000;
+const REALTIME_TOKEN_TIMEOUT_MS = 20_000;
+const AUDIO_MIME_TYPES = new Set([
+  'audio/wav',
+  'audio/wave',
+  'audio/x-wav',
+  'audio/webm',
+  'audio/mpeg',
+  'audio/mp4',
+  'audio/x-m4a',
+]);
+
+interface VoiceOperation {
+  id: string;
+  createdAt: number;
+  expiresAt: number;
+  route: Exclude<VoiceRoutePlan, { kind: 'blocked' | 'realtime_voice' }>;
+  recognitionOptions: {
+    language: string;
+    prompt: string;
+  };
+  abortController: AbortController;
+  audio?: EphemeralVoiceAudio;
+}
+
+export interface VoiceIpcService {
+  begin(input: VoiceBeginRequest): Promise<VoiceBeginResult>;
+  finishCapture(operationId: unknown, input: unknown): Promise<VoiceFinishCaptureResult>;
+  cancel(operationId: unknown): void;
+  createRealtimeSession(): Promise<VoiceRealtimeClientSession>;
+  closeRealtimeSession(sessionId: unknown): void;
+  validateCoordinatorToolCall(input: unknown): VoiceCoordinatorToolCall;
+  consumeNativeAudioOperation(input: {
+    operationId: string;
+    connectionSlug: string;
+    model: string;
+  }): EphemeralVoiceAudio;
+}
+
+export function createVoiceIpcService(deps: {
+  settingsStore: SettingsStore;
+  connectionStore: ConnectionStore;
+  resolveConnectionSecret(slug: string): Promise<string | null>;
+  fetch?: typeof fetch;
+  now?: () => number;
+}): VoiceIpcService {
+  const operations = new Map<string, VoiceOperation>();
+  const fetchImpl = deps.fetch ?? fetch;
+  const now = deps.now ?? Date.now;
+  let realtimeLease: { sessionId: string; expiresAt: number } | undefined;
+
+  async function begin(input: VoiceBeginRequest): Promise<VoiceBeginResult> {
+    sweepExpired();
+    const resolved = await resolveConfiguredRoute(normalizeBeginRequest(input));
+    if (resolved.plan.kind === 'blocked') {
+      return { ok: false, reason: resolved.plan.reason };
+    }
+    if (resolved.plan.kind === 'realtime_voice') {
+      return { ok: false, reason: 'adapter_unsupported' };
+    }
+    if (operations.size >= MAX_ACTIVE_OPERATIONS) {
+      const oldest = operations.keys().next().value as string | undefined;
+      if (oldest) {
+        operations.get(oldest)?.abortController.abort();
+        operations.delete(oldest);
+      }
+    }
+    const operationId = randomUUID();
+    const expiresAt = now() + OPERATION_TTL_MS;
+    operations.set(operationId, {
+      id: operationId,
+      createdAt: now(),
+      expiresAt,
+      route: resolved.plan,
+      recognitionOptions: resolved.recognitionOptions,
+      abortController: new AbortController(),
+    });
+    return { ok: true, operationId, route: resolved.plan, expiresAt };
+  }
+
+  async function finishCapture(
+    operationIdInput: unknown,
+    input: unknown,
+  ): Promise<VoiceFinishCaptureResult> {
+    sweepExpired();
+    const operationId = normalizeOperationId(operationIdInput);
+    const operation = operations.get(operationId);
+    if (!operation) throw new Error('voice_operation_expired');
+    if (operation.audio) throw new Error('voice_operation_already_staged');
+    const audio = normalizeCapturedAudio(input);
+
+    if (operation.route.kind === 'native_audio_task') {
+      operation.audio = audio;
+      return {
+        kind: 'native_audio_ready',
+        operationId,
+        providerLabel:
+          operation.route.target.providerLabel ?? operation.route.target.connectionSlug,
+      };
+    }
+
+    try {
+      const text = await transcribe(
+        operation.route.target,
+        audio,
+        operation.recognitionOptions,
+        operation.abortController.signal,
+      );
+      return {
+        kind: 'transcript',
+        operationId,
+        text,
+        providerLabel:
+          operation.route.target.providerLabel ?? operation.route.target.connectionSlug,
+      };
+    } finally {
+      if (operations.get(operationId) === operation) operations.delete(operationId);
+    }
+  }
+
+  function cancel(operationIdInput: unknown): void {
+    const operationId = normalizeOperationId(operationIdInput);
+    operations.get(operationId)?.abortController.abort();
+    operations.delete(operationId);
+  }
+
+  function consumeNativeAudioOperation(input: {
+    operationId: string;
+    connectionSlug: string;
+    model: string;
+  }): EphemeralVoiceAudio {
+    sweepExpired();
+    const operationId = normalizeOperationId(input.operationId);
+    const operation = operations.get(operationId);
+    if (!operation || operation.route.kind !== 'native_audio_task' || !operation.audio) {
+      throw new Error('voice_operation_not_ready');
+    }
+    if (
+      operation.route.target.connectionSlug !== input.connectionSlug ||
+      operation.route.target.modelId !== input.model
+    ) {
+      throw new Error('voice_operation_target_changed');
+    }
+    operations.delete(operationId);
+    return operation.audio;
+  }
+
+  async function createRealtimeSession(): Promise<VoiceRealtimeClientSession> {
+    if (realtimeLease && realtimeLease.expiresAt > now()) {
+      throw new Error('voice_realtime_session_already_active');
+    }
+    realtimeLease = undefined;
+    const { plan } = await resolveConfiguredRoute({ intent: 'voice_chat' });
+    if (plan.kind === 'blocked') throw new Error(`voice_route_blocked:${plan.reason}`);
+    if (plan.kind !== 'realtime_voice') throw new Error('voice_realtime_not_ready');
+    const connection = await requireConnection(plan.target.connectionSlug);
+    const secret = await deps.resolveConnectionSecret(connection.slug);
+    if (providerAuthRequiresSecret(connection.providerType) && !secret) {
+      throw new Error('voice_connection_secret_missing');
+    }
+    const baseUrl = effectiveBaseUrl(connection);
+    const tokenUrl = endpointUrl(baseUrl, 'realtime/client_secrets');
+    const endpoint = endpointUrl(baseUrl, 'realtime/calls');
+    const response = await fetchImpl(tokenUrl, {
+      method: 'POST',
+      headers: requestHeaders(secret),
+      body: JSON.stringify({
+        session: {
+          type: 'realtime',
+          model: plan.target.modelId,
+          instructions:
+            'You are Maka Voice Coordinator. Keep responses concise. Use only the four coordination tools for work; never claim a task changed unless the tool output confirms it.',
+          audio: {
+            output: {
+              voice: (await deps.settingsStore.get()).voice.realtime.voice,
+            },
+          },
+          tools: realtimeCoordinatorTools(),
+          tool_choice: 'auto',
+        },
+      }),
+      signal: AbortSignal.timeout(REALTIME_TOKEN_TIMEOUT_MS),
+    });
+    const payload = parseJsonObject(await readBoundedResponse(response));
+    if (!response.ok) throw providerHttpError('realtime_session', response.status);
+    const nested =
+      payload.client_secret && typeof payload.client_secret === 'object'
+        ? (payload.client_secret as Record<string, unknown>)
+        : {};
+    const clientSecret =
+      typeof payload.value === 'string'
+        ? payload.value
+        : typeof nested.value === 'string'
+          ? nested.value
+          : '';
+    if (!clientSecret) throw new Error('voice_realtime_secret_missing');
+    const expiresAtRaw = payload.expires_at ?? nested.expires_at;
+    const sessionId = randomUUID();
+    const expiresAt =
+      typeof expiresAtRaw === 'number' ? expiresAtRaw * 1_000 : now() + 60_000;
+    realtimeLease = { sessionId, expiresAt: now() + 24 * 60 * 60_000 };
+    return {
+      sessionId,
+      clientSecret,
+      endpoint,
+      model: plan.target.modelId,
+      providerLabel: plan.target.providerLabel ?? plan.target.connectionSlug,
+      expiresAt,
+    };
+  }
+
+  function closeRealtimeSession(sessionIdInput: unknown): void {
+    const sessionId = normalizeOperationId(sessionIdInput);
+    if (realtimeLease?.sessionId === sessionId) realtimeLease = undefined;
+  }
+
+  async function resolveConfiguredRoute(input: VoiceBeginRequest): Promise<{
+    plan: VoiceRoutePlan;
+    recognitionOptions: { language: string; prompt: string };
+  }> {
+    const settings = await deps.settingsStore.get();
+    const recognition = await configuredCapability(
+      settings.voice.recognition.connectionSlug,
+      settings.voice.recognition.model,
+      'transcription',
+    );
+    const realtime = await configuredCapability(
+      settings.voice.realtime.connectionSlug,
+      settings.voice.realtime.model,
+      'realtime_voice',
+    );
+    const currentAgent = input.currentAgent
+      ? await configuredCapability(
+          input.currentAgent.connectionSlug,
+          input.currentAgent.model,
+          'current_agent',
+        )
+      : undefined;
+    return {
+      plan: resolveVoiceRoute({
+        intent: input.intent,
+        ...(currentAgent ? { currentAgent } : {}),
+        ...(recognition ? { recognition } : {}),
+        ...(realtime ? { realtime } : {}),
+      }),
+      recognitionOptions: {
+        language: settings.voice.recognition.language,
+        prompt: settings.voice.recognition.prompt,
+      },
+    };
+  }
+
+  async function configuredCapability(
+    connectionSlug: string,
+    model: string,
+    roleHint: 'transcription' | 'realtime_voice' | 'current_agent',
+  ): Promise<VoiceModelRouteCapability | undefined> {
+    if (!connectionSlug || !model) return undefined;
+    const connection = await deps.connectionStore.get(connectionSlug);
+    if (!connection || !connection.enabled || !configuredModelExists(connection, model)) {
+      return undefined;
+    }
+    const metadata = resolveModelVoiceMetadata(connection.providerType, connection.models, model);
+    const adapterKind = PROVIDER_DEFAULTS[connection.providerType]?.runtimeAdapter.kind;
+    const openAiWire = adapterKind === 'openai' || adapterKind === 'openai-compatible';
+    const secret = await deps.resolveConnectionSecret(connection.slug).catch(() => null);
+    const credentialReady =
+      !providerAuthRequiresSecret(connection.providerType) || Boolean(secret);
+
+    const endpointRoles = [...(metadata.endpointRoles ?? [])];
+    const transports = [...(metadata.transports ?? [])];
+    let modalities = metadata.modalities ?? { input: ['text' as const], output: ['text' as const] };
+    if (roleHint === 'transcription') {
+      if (!endpointRoles.includes('transcription')) endpointRoles.push('transcription');
+      if (!transports.includes('openai_audio_transcriptions')) {
+        transports.push('openai_audio_transcriptions');
+      }
+      modalities = { input: ['audio'], output: ['text'] };
+    } else if (roleHint === 'realtime_voice') {
+      if (!endpointRoles.includes('realtime_voice')) endpointRoles.push('realtime_voice');
+      if (!transports.includes('openai_realtime')) transports.push('openai_realtime');
+      modalities = { input: ['text', 'audio'], output: ['text', 'audio'] };
+    }
+    return {
+      connectionSlug,
+      modelId: model,
+      providerLabel: connection.name,
+      modalities,
+      endpointRoles,
+      transports,
+      transcriptOutput: metadata.transcriptOutput === true,
+      adapterReady: openAiWire && credentialReady,
+    };
+  }
+
+  async function transcribe(
+    target: VoiceModelRouteCapability,
+    audio: EphemeralVoiceAudio,
+    options: { language: string; prompt: string },
+    abortSignal: AbortSignal,
+  ): Promise<string> {
+    const connection = await requireConnection(target.connectionSlug);
+    const secret = await deps.resolveConnectionSecret(connection.slug);
+    if (providerAuthRequiresSecret(connection.providerType) && !secret) {
+      throw new Error('voice_connection_secret_missing');
+    }
+    const form = new FormData();
+    form.set(
+      'file',
+      new Blob([Uint8Array.from(audio.bytes)], { type: audio.mediaType }),
+      `voice-input.${audio.format}`,
+    );
+    form.set('model', target.modelId);
+    form.set('response_format', 'json');
+    if (options.language) form.set('language', options.language);
+    if (options.prompt) form.set('prompt', options.prompt);
+    const response = await fetchImpl(endpointUrl(effectiveBaseUrl(connection), 'audio/transcriptions'), {
+      method: 'POST',
+      headers: secret ? { Authorization: `Bearer ${secret}` } : undefined,
+      body: form,
+      signal: AbortSignal.any([
+        abortSignal,
+        AbortSignal.timeout(TRANSCRIPTION_TIMEOUT_MS),
+      ]),
+    });
+    const body = await readBoundedResponse(response);
+    if (!response.ok) throw providerHttpError('transcription', response.status);
+    let rawText = '';
+    try {
+      const value = JSON.parse(body) as { text?: unknown };
+      rawText = typeof value.text === 'string' ? value.text : '';
+    } catch {
+      rawText = body;
+    }
+    const normalized = normalizeVoiceTranscriptText(rawText);
+    if (!normalized.ok) throw new Error(`voice_transcript_invalid:${normalized.reason}`);
+    return normalized.value;
+  }
+
+  async function requireConnection(slug: string): Promise<LlmConnection> {
+    const connection = await deps.connectionStore.get(slug);
+    if (!connection || !connection.enabled) throw new Error('voice_connection_not_ready');
+    return connection;
+  }
+
+  function sweepExpired(): void {
+    const current = now();
+    for (const [id, operation] of operations) {
+      if (operation.expiresAt <= current) {
+        operation.abortController.abort();
+        operations.delete(id);
+      }
+    }
+  }
+
+  return {
+    begin,
+    finishCapture,
+    cancel,
+    createRealtimeSession,
+    closeRealtimeSession,
+    validateCoordinatorToolCall: normalizeVoiceCoordinatorToolCall,
+    consumeNativeAudioOperation,
+  };
+}
+
+export function registerVoiceIpc(input: {
+  ipcMain: IpcMain;
+  service: VoiceIpcService;
+}): void {
+  input.ipcMain.handle('voice:begin', (_event, request) => input.service.begin(request));
+  input.ipcMain.handle('voice:finishCapture', (_event, operationId, audio) =>
+    input.service.finishCapture(operationId, audio),
+  );
+  input.ipcMain.handle('voice:cancel', (_event, operationId) =>
+    input.service.cancel(operationId),
+  );
+  input.ipcMain.handle('voice:createRealtimeSession', () =>
+    input.service.createRealtimeSession(),
+  );
+  input.ipcMain.handle('voice:closeRealtimeSession', (_event, sessionId) =>
+    input.service.closeRealtimeSession(sessionId),
+  );
+  input.ipcMain.handle('voice:validateCoordinatorToolCall', (_event, call) =>
+    input.service.validateCoordinatorToolCall(call),
+  );
+}
+
+function configuredModelExists(connection: LlmConnection, model: string): boolean {
+  return (
+    connectionEnabledModelIds(connection).includes(model) ||
+    connection.models?.some((entry) => entry.id === model) === true
+  );
+}
+
+function normalizeBeginRequest(input: unknown): VoiceBeginRequest {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('voice_begin_invalid');
+  }
+  const value = input as { intent?: unknown; currentAgent?: unknown };
+  if (
+    value.intent !== 'send_task' &&
+    value.intent !== 'dictate' &&
+    value.intent !== 'voice_chat'
+  ) {
+    throw new Error('voice_begin_invalid');
+  }
+  if (value.currentAgent === undefined) return { intent: value.intent };
+  if (
+    !value.currentAgent ||
+    typeof value.currentAgent !== 'object' ||
+    Array.isArray(value.currentAgent)
+  ) {
+    throw new Error('voice_begin_invalid');
+  }
+  const currentAgent = value.currentAgent as {
+    connectionSlug?: unknown;
+    model?: unknown;
+  };
+  if (
+    typeof currentAgent.connectionSlug !== 'string' ||
+    currentAgent.connectionSlug.length === 0 ||
+    currentAgent.connectionSlug.length > 64 ||
+    typeof currentAgent.model !== 'string' ||
+    currentAgent.model.length === 0 ||
+    currentAgent.model.length > 256
+  ) {
+    throw new Error('voice_begin_invalid');
+  }
+  return {
+    intent: value.intent,
+    currentAgent: {
+      connectionSlug: currentAgent.connectionSlug,
+      model: currentAgent.model,
+    },
+  };
+}
+
+function normalizeCapturedAudio(input: unknown): EphemeralVoiceAudio {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('voice_audio_invalid');
+  }
+  const value = input as Partial<VoiceCapturedAudio>;
+  const bytes =
+    value.bytes instanceof Uint8Array
+      ? new Uint8Array(value.bytes.buffer, value.bytes.byteOffset, value.bytes.byteLength)
+      : undefined;
+  if (!bytes || !AUDIO_MIME_TYPES.has(value.mediaType ?? '')) {
+    throw new Error('voice_audio_invalid');
+  }
+  if (
+    value.format !== 'wav' &&
+    value.format !== 'webm' &&
+    value.format !== 'mp3' &&
+    value.format !== 'm4a'
+  ) {
+    throw new Error('voice_audio_invalid');
+  }
+  const validated = validateVoiceCaptureRequest({
+    mode: 'push_to_talk',
+    permission: 'granted',
+    durationMs: value.durationMs,
+    audioBytes: bytes.byteLength,
+    sampleRate: value.sampleRate,
+    channels: value.channels,
+  });
+  if (!validated.ok) throw new Error(`voice_audio_invalid:${validated.reason}`);
+  return {
+    bytes,
+    mediaType: value.mediaType!,
+    format: value.format,
+    durationMs: value.durationMs!,
+    sampleRate: value.sampleRate!,
+    channels: value.channels!,
+    retention: 'operation_memory',
+  };
+}
+
+function normalizeOperationId(input: unknown): string {
+  if (
+    typeof input !== 'string' ||
+    input.length > 64 ||
+    !/^[0-9a-f]{8}-[0-9a-f-]{27,36}$/i.test(input)
+  ) {
+    throw new Error('voice_operation_invalid');
+  }
+  return input;
+}
+
+function endpointUrl(baseUrl: string, suffix: string): string {
+  if (!baseUrl) throw new Error('voice_connection_base_url_missing');
+  return new URL(suffix, `${baseUrl.replace(/\/+$/, '')}/`).toString();
+}
+
+function requestHeaders(secret: string | null): Record<string, string> {
+  return {
+    'Content-Type': 'application/json',
+    'OpenAI-Beta': 'realtime=v1',
+    ...(secret ? { Authorization: `Bearer ${secret}` } : {}),
+  };
+}
+
+async function readBoundedResponse(response: Response): Promise<string> {
+  const declared = Number(response.headers.get('content-length'));
+  if (Number.isFinite(declared) && declared > MAX_PROVIDER_RESPONSE_BYTES) {
+    throw new Error('voice_provider_response_too_large');
+  }
+  const bytes = new Uint8Array(await response.arrayBuffer());
+  if (bytes.byteLength > MAX_PROVIDER_RESPONSE_BYTES) {
+    throw new Error('voice_provider_response_too_large');
+  }
+  return new TextDecoder().decode(bytes);
+}
+
+function parseJsonObject(input: string): Record<string, unknown> {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(input);
+  } catch {
+    throw new Error('voice_provider_response_invalid');
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    throw new Error('voice_provider_response_invalid');
+  }
+  return parsed as Record<string, unknown>;
+}
+
+function providerHttpError(stage: string, status: number): Error {
+  if (status === 401 || status === 403) return new Error(`voice_${stage}_auth`);
+  if (status === 404) return new Error(`voice_${stage}_unsupported`);
+  if (status === 413) return new Error(`voice_${stage}_too_large`);
+  if (status === 429) return new Error(`voice_${stage}_rate_limited`);
+  if (status >= 500) return new Error(`voice_${stage}_unavailable`);
+  return new Error(`voice_${stage}_failed`);
+}
+
+function realtimeCoordinatorTools(): Array<Record<string, unknown>> {
+  return [
+    {
+      type: 'function',
+      name: 'start_task',
+      description: 'Start a concrete Maka agent task.',
+      parameters: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { task: { type: 'string' } },
+        required: ['task'],
+      },
+    },
+    {
+      type: 'function',
+      name: 'steer_task',
+      description: 'Add guidance to the currently running Maka task.',
+      parameters: {
+        type: 'object',
+        additionalProperties: false,
+        properties: { guidance: { type: 'string' } },
+        required: ['guidance'],
+      },
+    },
+    {
+      type: 'function',
+      name: 'check_task',
+      description: 'Check the status of the active Maka task.',
+      parameters: { type: 'object', additionalProperties: false, properties: {} },
+    },
+    {
+      type: 'function',
+      name: 'summarize_task',
+      description: 'Summarize the latest durable output of the active Maka task.',
+      parameters: { type: 'object', additionalProperties: false, properties: {} },
+    },
+  ];
+}

--- a/apps/desktop/src/main/voice-ipc-main.ts
+++ b/apps/desktop/src/main/voice-ipc-main.ts
@@ -28,6 +28,8 @@ const MAX_ACTIVE_OPERATIONS = 32;
 const MAX_PROVIDER_RESPONSE_BYTES = 256 * 1024;
 const TRANSCRIPTION_TIMEOUT_MS = 90_000;
 const REALTIME_TOKEN_TIMEOUT_MS = 20_000;
+const REALTIME_CONNECT_TIMEOUT_MS = 30_000;
+const MAX_REALTIME_SDP_BYTES = 256 * 1024;
 const AUDIO_MIME_TYPES = new Set([
   'audio/wav',
   'audio/wave',
@@ -55,7 +57,7 @@ export interface VoiceIpcService {
   begin(input: VoiceBeginRequest): Promise<VoiceBeginResult>;
   finishCapture(operationId: unknown, input: unknown): Promise<VoiceFinishCaptureResult>;
   cancel(operationId: unknown): void;
-  createRealtimeSession(): Promise<VoiceRealtimeClientSession>;
+  createRealtimeSession(offerSdp: unknown): Promise<VoiceRealtimeClientSession>;
   closeRealtimeSession(sessionId: unknown): void;
   validateCoordinatorToolCall(input: unknown): VoiceCoordinatorToolCall;
   consumeNativeAudioOperation(input: {
@@ -173,68 +175,91 @@ export function createVoiceIpcService(deps: {
     return operation.audio;
   }
 
-  async function createRealtimeSession(): Promise<VoiceRealtimeClientSession> {
+  async function createRealtimeSession(offerSdpInput: unknown): Promise<VoiceRealtimeClientSession> {
     if (realtimeLease && realtimeLease.expiresAt > now()) {
       throw new Error('voice_realtime_session_already_active');
     }
     realtimeLease = undefined;
-    const { plan } = await resolveConfiguredRoute({ intent: 'voice_chat' });
-    if (plan.kind === 'blocked') throw new Error(`voice_route_blocked:${plan.reason}`);
-    if (plan.kind !== 'realtime_voice') throw new Error('voice_realtime_not_ready');
-    const connection = await requireConnection(plan.target.connectionSlug);
-    const secret = await deps.resolveConnectionSecret(connection.slug);
-    if (providerAuthRequiresSecret(connection.providerType) && !secret) {
-      throw new Error('voice_connection_secret_missing');
-    }
-    const baseUrl = effectiveBaseUrl(connection);
-    const tokenUrl = endpointUrl(baseUrl, 'realtime/client_secrets');
-    const endpoint = endpointUrl(baseUrl, 'realtime/calls');
-    const response = await fetchImpl(tokenUrl, {
-      method: 'POST',
-      headers: requestHeaders(secret),
-      body: JSON.stringify({
-        session: {
-          type: 'realtime',
-          model: plan.target.modelId,
-          instructions:
-            'You are Maka Voice Coordinator. Keep responses concise. Use only the four coordination tools for work; never claim a task changed unless the tool output confirms it.',
-          audio: {
-            output: {
-              voice: (await deps.settingsStore.get()).voice.realtime.voice,
-            },
-          },
-          tools: realtimeCoordinatorTools(),
-          tool_choice: 'auto',
-        },
-      }),
-      signal: AbortSignal.timeout(REALTIME_TOKEN_TIMEOUT_MS),
-    });
-    const payload = parseJsonObject(await readBoundedResponse(response));
-    if (!response.ok) throw providerHttpError('realtime_session', response.status);
-    const nested =
-      payload.client_secret && typeof payload.client_secret === 'object'
-        ? (payload.client_secret as Record<string, unknown>)
-        : {};
-    const clientSecret =
-      typeof payload.value === 'string'
-        ? payload.value
-        : typeof nested.value === 'string'
-          ? nested.value
-          : '';
-    if (!clientSecret) throw new Error('voice_realtime_secret_missing');
-    const expiresAtRaw = payload.expires_at ?? nested.expires_at;
+    const offerSdp = normalizeRealtimeOfferSdp(offerSdpInput);
     const sessionId = randomUUID();
-    const expiresAt =
-      typeof expiresAtRaw === 'number' ? expiresAtRaw * 1_000 : now() + 60_000;
-    realtimeLease = { sessionId, expiresAt: now() + 24 * 60 * 60_000 };
-    return {
-      sessionId,
-      clientSecret,
-      endpoint,
-      model: plan.target.modelId,
-      providerLabel: plan.target.providerLabel ?? plan.target.connectionSlug,
-      expiresAt,
-    };
+    realtimeLease = { sessionId, expiresAt: now() + REALTIME_CONNECT_TIMEOUT_MS };
+    try {
+      const { plan } = await resolveConfiguredRoute({ intent: 'voice_chat' });
+      if (plan.kind === 'blocked') throw new Error(`voice_route_blocked:${plan.reason}`);
+      if (plan.kind !== 'realtime_voice') throw new Error('voice_realtime_not_ready');
+      const connection = await requireConnection(plan.target.connectionSlug);
+      const secret = await deps.resolveConnectionSecret(connection.slug);
+      if (providerAuthRequiresSecret(connection.providerType) && !secret) {
+        throw new Error('voice_connection_secret_missing');
+      }
+      const baseUrl = effectiveBaseUrl(connection);
+      const tokenUrl = endpointUrl(baseUrl, 'realtime/client_secrets');
+      const endpoint = endpointUrl(baseUrl, 'realtime/calls');
+      const tokenResponse = await fetchImpl(tokenUrl, {
+        method: 'POST',
+        headers: requestHeaders(secret),
+        body: JSON.stringify({
+          session: {
+            type: 'realtime',
+            model: plan.target.modelId,
+            instructions:
+              'You are Maka Voice Coordinator. Keep responses concise. Use only the four coordination tools for work; never claim a task changed unless the tool output confirms it.',
+            audio: {
+              output: {
+                voice: (await deps.settingsStore.get()).voice.realtime.voice,
+              },
+            },
+            tools: realtimeCoordinatorTools(),
+            tool_choice: 'auto',
+          },
+        }),
+        signal: AbortSignal.timeout(REALTIME_TOKEN_TIMEOUT_MS),
+      });
+      const payload = parseJsonObject(await readBoundedResponse(tokenResponse));
+      if (!tokenResponse.ok) {
+        throw providerHttpError('realtime_session', tokenResponse.status);
+      }
+      const nested =
+        payload.client_secret && typeof payload.client_secret === 'object'
+          ? (payload.client_secret as Record<string, unknown>)
+          : {};
+      const clientSecret =
+        typeof payload.value === 'string'
+          ? payload.value
+          : typeof nested.value === 'string'
+            ? nested.value
+            : '';
+      if (!clientSecret) throw new Error('voice_realtime_secret_missing');
+      const expiresAtRaw = payload.expires_at ?? nested.expires_at;
+      const expiresAt =
+        typeof expiresAtRaw === 'number' ? expiresAtRaw * 1_000 : now() + 60_000;
+      const callResponse = await fetchImpl(endpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${clientSecret}`,
+          'Content-Type': 'application/sdp',
+          'OpenAI-Beta': 'realtime=v1',
+        },
+        body: offerSdp,
+        signal: AbortSignal.timeout(REALTIME_CONNECT_TIMEOUT_MS),
+      });
+      const answerSdp = await readBoundedResponse(callResponse);
+      if (!callResponse.ok) {
+        throw providerHttpError('realtime_connect', callResponse.status);
+      }
+      if (!answerSdp.trim()) throw new Error('voice_realtime_answer_invalid');
+      realtimeLease = { sessionId, expiresAt: now() + 24 * 60 * 60_000 };
+      return {
+        sessionId,
+        answerSdp,
+        model: plan.target.modelId,
+        providerLabel: plan.target.providerLabel ?? plan.target.connectionSlug,
+        expiresAt,
+      };
+    } catch (error) {
+      if (realtimeLease?.sessionId === sessionId) realtimeLease = undefined;
+      throw error;
+    }
   }
 
   function closeRealtimeSession(sessionIdInput: unknown): void {
@@ -403,8 +428,8 @@ export function registerVoiceIpc(input: {
   input.ipcMain.handle('voice:cancel', (_event, operationId) =>
     input.service.cancel(operationId),
   );
-  input.ipcMain.handle('voice:createRealtimeSession', () =>
-    input.service.createRealtimeSession(),
+  input.ipcMain.handle('voice:createRealtimeSession', (_event, offerSdp) =>
+    input.service.createRealtimeSession(offerSdp),
   );
   input.ipcMain.handle('voice:closeRealtimeSession', (_event, sessionId) =>
     input.service.closeRealtimeSession(sessionId),
@@ -419,6 +444,18 @@ function configuredModelExists(connection: LlmConnection, model: string): boolea
     connectionEnabledModelIds(connection).includes(model) ||
     connection.models?.some((entry) => entry.id === model) === true
   );
+}
+
+function normalizeRealtimeOfferSdp(input: unknown): string {
+  if (typeof input !== 'string') throw new Error('voice_realtime_offer_invalid');
+  const offerSdp = input.trim();
+  if (
+    !offerSdp.startsWith('v=0') ||
+    new TextEncoder().encode(offerSdp).byteLength > MAX_REALTIME_SDP_BYTES
+  ) {
+    throw new Error('voice_realtime_offer_invalid');
+  }
+  return offerSdp;
 }
 
 function normalizeBeginRequest(input: unknown): VoiceBeginRequest {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -411,7 +411,7 @@ export interface MakaBridge {
       audio: VoiceCapturedAudio,
     ): Promise<VoiceFinishCaptureResult>;
     cancel(operationId: string): Promise<void>;
-    createRealtimeSession(): Promise<VoiceRealtimeClientSession>;
+    createRealtimeSession(offerSdp: string): Promise<VoiceRealtimeClientSession>;
     closeRealtimeSession(sessionId: string): Promise<void>;
     validateCoordinatorToolCall(input: unknown): Promise<VoiceCoordinatorToolCall>;
   };

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -58,6 +58,13 @@ import type {
   PlanReminderDeliveryTarget,
   PlanReminderRecurrence,
   DailyReviewArchive,
+  QueueEnqueueOutcome,
+  VoiceBeginRequest,
+  VoiceBeginResult,
+  VoiceCapturedAudio,
+  VoiceCoordinatorToolCall,
+  VoiceFinishCaptureResult,
+  VoiceRealtimeClientSession,
   DailyReviewArchiveSummary,
   DailyReviewConfig,
   DailyReviewMode,
@@ -252,6 +259,8 @@ export interface MakaBridge {
             type: 'send';
             turnId: string;
             text: string;
+            displayText?: string;
+            voiceOperationId?: string;
             skillIds?: string[];
             attachmentItems?: RendererIngestInput[];
             turnOrchestration?: TurnOrchestration;
@@ -271,6 +280,7 @@ export interface MakaBridge {
         }
     >;
     stop(sessionId: string, input?: { source?: 'stop_button' }): Promise<void>;
+    steer(sessionId: string, text: string): Promise<QueueEnqueueOutcome>;
     readMessages(sessionId: string): Promise<StoredMessage[]>;
     readExecutionBoundary(sessionId: string): Promise<ExecutionBoundary>;
     listActiveSandboxBoundaryRequests(
@@ -393,6 +403,17 @@ export interface MakaBridge {
         openInBrowser(sessionId: string): Promise<Result<void>>;
       };
     };
+  };
+  voice: {
+    begin(input: VoiceBeginRequest): Promise<VoiceBeginResult>;
+    finishCapture(
+      operationId: string,
+      audio: VoiceCapturedAudio,
+    ): Promise<VoiceFinishCaptureResult>;
+    cancel(operationId: string): Promise<void>;
+    createRealtimeSession(): Promise<VoiceRealtimeClientSession>;
+    closeRealtimeSession(sessionId: string): Promise<void>;
+    validateCoordinatorToolCall(input: unknown): Promise<VoiceCoordinatorToolCall>;
   };
   notifications: {
     /** Fire-and-forget: report that an agent turn reached a terminal

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -73,6 +73,13 @@ import type {
   PlanReminderRecurrence,
   DailyReviewArchive,
   DailyReviewArchiveSummary,
+  QueueEnqueueOutcome,
+  VoiceBeginRequest,
+  VoiceBeginResult,
+  VoiceCapturedAudio,
+  VoiceCoordinatorToolCall,
+  VoiceFinishCaptureResult,
+  VoiceRealtimeClientSession,
   DailyReviewConfig,
   DailyReviewMode,
   DailyReviewSummary,
@@ -197,6 +204,8 @@ const makaBridge = {
             type: 'send';
             turnId: string;
             text: string;
+            displayText?: string;
+            voiceOperationId?: string;
             skillIds?: string[];
             attachmentItems?: RendererIngestInput[];
             turnOrchestration?: TurnOrchestration;
@@ -232,6 +241,9 @@ const makaBridge = {
     },
     stop(sessionId: string, input?: { source?: 'stop_button' }): Promise<void> {
       return ipcRenderer.invoke('sessions:stop', sessionId, input);
+    },
+    steer(sessionId: string, text: string): Promise<QueueEnqueueOutcome> {
+      return ipcRenderer.invoke('sessions:steer', sessionId, text);
     },
     readMessages(sessionId: string): Promise<StoredMessage[]> {
       return ipcRenderer.invoke('sessions:readMessages', sessionId);
@@ -899,6 +911,29 @@ const makaBridge = {
           return ipcRenderer.invoke('settings:bots:onboarding:open', sessionId);
         },
       },
+    },
+  },
+  voice: {
+    begin(input: VoiceBeginRequest): Promise<VoiceBeginResult> {
+      return ipcRenderer.invoke('voice:begin', input);
+    },
+    finishCapture(
+      operationId: string,
+      audio: VoiceCapturedAudio,
+    ): Promise<VoiceFinishCaptureResult> {
+      return ipcRenderer.invoke('voice:finishCapture', operationId, audio);
+    },
+    cancel(operationId: string): Promise<void> {
+      return ipcRenderer.invoke('voice:cancel', operationId);
+    },
+    createRealtimeSession(): Promise<VoiceRealtimeClientSession> {
+      return ipcRenderer.invoke('voice:createRealtimeSession');
+    },
+    closeRealtimeSession(sessionId: string): Promise<void> {
+      return ipcRenderer.invoke('voice:closeRealtimeSession', sessionId);
+    },
+    validateCoordinatorToolCall(input: unknown): Promise<VoiceCoordinatorToolCall> {
+      return ipcRenderer.invoke('voice:validateCoordinatorToolCall', input);
     },
   },
   notifications: {

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -926,8 +926,8 @@ const makaBridge = {
     cancel(operationId: string): Promise<void> {
       return ipcRenderer.invoke('voice:cancel', operationId);
     },
-    createRealtimeSession(): Promise<VoiceRealtimeClientSession> {
-      return ipcRenderer.invoke('voice:createRealtimeSession');
+    createRealtimeSession(offerSdp: string): Promise<VoiceRealtimeClientSession> {
+      return ipcRenderer.invoke('voice:createRealtimeSession', offerSdp);
     },
     closeRealtimeSession(sessionId: string): Promise<void> {
       return ipcRenderer.invoke('voice:closeRealtimeSession', sessionId);

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -84,6 +84,8 @@ export interface AppShellChatActions {
       skillIds?: readonly string[];
       turnOrchestration?: TurnOrchestration;
       quotes?: readonly QuoteRef[];
+      displayText?: string;
+      voiceOperationId?: string;
     },
   ): Promise<boolean>;
   respondToSandboxBoundary(response: SandboxBoundaryResponse): Promise<void>;
@@ -259,6 +261,8 @@ export function createAppShellChatActions(deps: {
       skillIds?: readonly string[];
       turnOrchestration?: TurnOrchestration;
       quotes?: readonly QuoteRef[];
+      displayText?: string;
+      voiceOperationId?: string;
     } = {},
   ): Promise<boolean> {
     const skillIds = options.skillIds;
@@ -319,6 +323,8 @@ export function createAppShellChatActions(deps: {
           type: 'send',
           turnId,
           text,
+          ...(options.displayText ? { displayText: options.displayText } : {}),
+          ...(options.voiceOperationId ? { voiceOperationId: options.voiceOperationId } : {}),
           ...(options.turnOrchestration ? { turnOrchestration: options.turnOrchestration } : {}),
           ...(skillIds && skillIds.length > 0 ? { skillIds: [...skillIds] } : {}),
           ...(attachmentItems ? { attachmentItems } : {}),
@@ -344,7 +350,8 @@ export function createAppShellChatActions(deps: {
           showOptimisticUserMessage(
             session.id,
             turnId,
-            skillInvocationDisplayText(text, sendResult.skillInvocation),
+            options.displayText ??
+              skillInvocationDisplayText(text, sendResult.skillInvocation),
             sendResult.attachments,
             {
               replaceCurrentMessages: true,
@@ -368,6 +375,8 @@ export function createAppShellChatActions(deps: {
         type: 'send',
         turnId,
         text,
+        ...(options.displayText ? { displayText: options.displayText } : {}),
+        ...(options.voiceOperationId ? { voiceOperationId: options.voiceOperationId } : {}),
         ...(options.turnOrchestration ? { turnOrchestration: options.turnOrchestration } : {}),
         ...(skillIds && skillIds.length > 0 ? { skillIds: [...skillIds] } : {}),
         ...(attachmentItems ? { attachmentItems } : {}),
@@ -388,7 +397,8 @@ export function createAppShellChatActions(deps: {
       showOptimisticUserMessage(
         sessionId,
         turnId,
-        skillInvocationDisplayText(text, sendResult.skillInvocation),
+        options.displayText ??
+          skillInvocationDisplayText(text, sendResult.skillInvocation),
         sendResult.attachments,
         { ...(quotes && quotes.length > 0 ? { quotes } : {}) },
       );

--- a/apps/desktop/src/renderer/app-shell-chat-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-chat-actions.ts
@@ -86,6 +86,7 @@ export interface AppShellChatActions {
       quotes?: readonly QuoteRef[];
       displayText?: string;
       voiceOperationId?: string;
+      onSessionResolved?: (sessionId: string) => void;
     },
   ): Promise<boolean>;
   respondToSandboxBoundary(response: SandboxBoundaryResponse): Promise<void>;
@@ -263,6 +264,7 @@ export function createAppShellChatActions(deps: {
       quotes?: readonly QuoteRef[];
       displayText?: string;
       voiceOperationId?: string;
+      onSessionResolved?: (sessionId: string) => void;
     } = {},
   ): Promise<boolean> {
     const skillIds = options.skillIds;
@@ -341,6 +343,7 @@ export function createAppShellChatActions(deps: {
           return false;
         }
         unsentSessionId = undefined;
+        options.onSessionResolved?.(session.id);
         if (newChatOwner && isNewChatSendSurfaceActive(newChatOwner)) {
           showSkillInvocationFeedback(uiLocale, toastApi, sendResult.skillInvocation);
         }
@@ -391,6 +394,7 @@ export function createAppShellChatActions(deps: {
         restoreOptimisticStatus = undefined;
         return false;
       }
+      options.onSessionResolved?.(sessionId);
       if (activeIdRef.current === sessionId) {
         showSkillInvocationFeedback(uiLocale, toastApi, sendResult.skillInvocation);
       }

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -348,6 +348,7 @@ function AppShellContent({
     setUiLocalePreference,
   });
   const shellCopy = getShellCopy(uiLocale).app;
+  const voiceCopy = getDesktopConversationCopy(uiLocale).voice;
   useEffect(() => {
     let cancelled = false;
     const refreshUpdateStatus = () => {
@@ -1421,7 +1422,7 @@ function AppShellContent({
         undefined,
         {
           voiceOperationId: operationId,
-          displayText: uiLocale === 'zh' ? '🎙️ 语音任务' : '🎙️ Voice task',
+          displayText: voiceCopy.taskDisplayText,
         },
       ),
     runCoordinatorTool: async (call, context) => {
@@ -1472,7 +1473,7 @@ function AppShellContent({
         };
       }
       if (call.name === 'check_task') {
-        const authoritativeSessions = await window.maka.sessions.list();
+        const authoritativeSessions = await refreshSessions();
         const session = authoritativeSessions.find((candidate) => candidate.id === sessionId);
         return {
           output: session
@@ -1492,9 +1493,7 @@ function AppShellContent({
           summary:
             lastAssistant?.type === 'assistant'
               ? lastAssistant.text.slice(-4_000)
-              : uiLocale === 'zh'
-                ? '当前任务还没有可总结的回复。'
-                : 'The current task has no response to summarize yet.',
+              : voiceCopy.noTaskResponse,
         },
         taskSessionId: sessionId,
       };
@@ -1504,21 +1503,19 @@ function AppShellContent({
         reason === 'recognition_not_configured' ||
         reason === 'realtime_not_configured';
       toastApi.error(
-        uiLocale === 'zh' ? '语音不可用' : 'Voice unavailable',
+        voiceCopy.unavailableTitle,
         configure
-          ? uiLocale === 'zh'
-            ? '请先在设置 · 语音中配置识别或实时语音模型。'
-            : 'Configure a recognition or realtime voice model in Settings · Voice.'
+          ? voiceCopy.configureDescription
           : reason,
       );
       if (configure) openSettingsSection('voice');
     },
     onError: (error) => {
       toastApi.error(
-        uiLocale === 'zh' ? '语音操作失败' : 'Voice operation failed',
+        voiceCopy.operationFailedTitle,
         localizedShellErrorMessage(
           error,
-          uiLocale === 'zh' ? '请检查麦克风、模型配置和网络连接。' : 'Check the microphone, model configuration, and network.',
+          voiceCopy.operationFailedFallback,
           uiLocale,
         ),
       );

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -1424,42 +1424,79 @@ function AppShellContent({
           displayText: uiLocale === 'zh' ? '🎙️ 语音任务' : '🎙️ Voice task',
         },
       ),
-    runCoordinatorTool: async (call) => {
+    runCoordinatorTool: async (call, context) => {
       if (call.name === 'start_task') {
         if (!call.arguments.task) throw new Error('voice_task_missing');
-        return { ok: await send(call.arguments.task) };
+        let taskSessionId: string | undefined;
+        const ok = await send(call.arguments.task, undefined, {
+          onSessionResolved: (sessionId) => {
+            taskSessionId = sessionId;
+          },
+        });
+        return {
+          output: {
+            ok,
+            ...(taskSessionId ? { sessionId: taskSessionId } : {}),
+          },
+          ...(ok && taskSessionId ? { taskSessionId } : {}),
+        };
+      }
+      const sessionId = context.taskSessionId;
+      if (!sessionId) {
+        return { output: { ok: false, status: 'no_active_task' } };
       }
       if (call.name === 'steer_task') {
         if (!call.arguments.guidance) throw new Error('voice_guidance_missing');
-        const sessionId = activeIdRef.current;
-        if (!sessionId) return { ok: await send(call.arguments.guidance) };
         const outcome = await window.maka.sessions.steer(
           sessionId,
           call.arguments.guidance,
         );
         if (outcome.kind === 'fallback') {
-          return { ok: await send(call.arguments.guidance), fallback: true };
+          const sendResult = await window.maka.sessions.send(sessionId, {
+            type: 'send',
+            turnId: crypto.randomUUID(),
+            text: call.arguments.guidance,
+          });
+          await refreshSessions();
+          if (activeIdRef.current === sessionId) {
+            await refreshMessages(sessionId);
+          }
+          return {
+            output: { ok: sendResult.ok, fallback: true, sessionId },
+            taskSessionId: sessionId,
+          };
         }
-        return { ok: true, queued: true };
+        return {
+          output: { ok: true, queued: true, sessionId },
+          taskSessionId: sessionId,
+        };
       }
       if (call.name === 'check_task') {
-        const sessionId = activeIdRef.current;
-        const session = sessions.find((candidate) => candidate.id === sessionId);
-        return session
-          ? { ok: true, sessionId: session.id, status: session.status }
-          : { ok: false, status: 'no_active_task' };
+        const authoritativeSessions = await window.maka.sessions.list();
+        const session = authoritativeSessions.find((candidate) => candidate.id === sessionId);
+        return {
+          output: session
+            ? { ok: true, sessionId: session.id, status: session.status }
+            : { ok: false, sessionId, status: 'task_not_found' },
+          ...(session ? { taskSessionId: sessionId } : {}),
+        };
       }
-      const lastAssistant = [...messages]
+      const taskMessages = await window.maka.sessions.readMessages(sessionId);
+      const lastAssistant = [...taskMessages]
         .reverse()
         .find((message) => message.type === 'assistant');
       return {
-        ok: true,
-        summary:
-          lastAssistant?.type === 'assistant'
-            ? lastAssistant.text.slice(-4_000)
-            : uiLocale === 'zh'
-              ? '当前任务还没有可总结的回复。'
-              : 'The current task has no response to summarize yet.',
+        output: {
+          ok: true,
+          sessionId,
+          summary:
+            lastAssistant?.type === 'assistant'
+              ? lastAssistant.text.slice(-4_000)
+              : uiLocale === 'zh'
+                ? '当前任务还没有可总结的回复。'
+                : 'The current task has no response to summarize yet.',
+        },
+        taskSessionId: sessionId,
       };
     },
     onBlocked: (reason) => {

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -119,6 +119,7 @@ import { createAppShellSessionRowActions } from './app-shell-session-row-actions
 import { createAppShellSessionSettingsActions } from './app-shell-session-settings-actions';
 import { createAppShellStopAction } from './app-shell-stop-action';
 import { useStableActions } from './use-stable-actions';
+import { useVoiceInput } from './use-voice-input';
 import {
   useActiveSessionEvents,
   useAppShellBootstrapSubscriptions,
@@ -1395,6 +1396,98 @@ function AppShellContent({
     newChatProjectId: selectedProjectId,
   });
 
+  const voiceInput = useVoiceInput({
+    getDraftKey: () => activeIdRef.current ?? 'new-session',
+    getCurrentAgent: () => {
+      if (activeIdRef.current && activeSessionForView) {
+        return {
+          connectionSlug: activeSessionForView.llmConnectionSlug,
+          model: activeSessionForView.model,
+        };
+      }
+      return newChatModel
+        ? {
+            connectionSlug: newChatModel.llmConnectionSlug,
+            model: newChatModel.model,
+          }
+        : undefined;
+    },
+    appendTranscript: (draftKey, text) => {
+      composerRef.current?.appendDraft?.(draftKey, text);
+    },
+    sendNativeVoice: (operationId) =>
+      send(
+        'Listen to the attached audio and carry out the user request. The audio is authoritative.',
+        undefined,
+        {
+          voiceOperationId: operationId,
+          displayText: uiLocale === 'zh' ? '🎙️ 语音任务' : '🎙️ Voice task',
+        },
+      ),
+    runCoordinatorTool: async (call) => {
+      if (call.name === 'start_task') {
+        if (!call.arguments.task) throw new Error('voice_task_missing');
+        return { ok: await send(call.arguments.task) };
+      }
+      if (call.name === 'steer_task') {
+        if (!call.arguments.guidance) throw new Error('voice_guidance_missing');
+        const sessionId = activeIdRef.current;
+        if (!sessionId) return { ok: await send(call.arguments.guidance) };
+        const outcome = await window.maka.sessions.steer(
+          sessionId,
+          call.arguments.guidance,
+        );
+        if (outcome.kind === 'fallback') {
+          return { ok: await send(call.arguments.guidance), fallback: true };
+        }
+        return { ok: true, queued: true };
+      }
+      if (call.name === 'check_task') {
+        const sessionId = activeIdRef.current;
+        const session = sessions.find((candidate) => candidate.id === sessionId);
+        return session
+          ? { ok: true, sessionId: session.id, status: session.status }
+          : { ok: false, status: 'no_active_task' };
+      }
+      const lastAssistant = [...messages]
+        .reverse()
+        .find((message) => message.type === 'assistant');
+      return {
+        ok: true,
+        summary:
+          lastAssistant?.type === 'assistant'
+            ? lastAssistant.text.slice(-4_000)
+            : uiLocale === 'zh'
+              ? '当前任务还没有可总结的回复。'
+              : 'The current task has no response to summarize yet.',
+      };
+    },
+    onBlocked: (reason) => {
+      const configure =
+        reason === 'recognition_not_configured' ||
+        reason === 'realtime_not_configured';
+      toastApi.error(
+        uiLocale === 'zh' ? '语音不可用' : 'Voice unavailable',
+        configure
+          ? uiLocale === 'zh'
+            ? '请先在设置 · 语音中配置识别或实时语音模型。'
+            : 'Configure a recognition or realtime voice model in Settings · Voice.'
+          : reason,
+      );
+      if (configure) openSettingsSection('voice');
+    },
+    onError: (error) => {
+      toastApi.error(
+        uiLocale === 'zh' ? '语音操作失败' : 'Voice operation failed',
+        localizedShellErrorMessage(
+          error,
+          uiLocale === 'zh' ? '请检查麦克风、模型配置和网络连接。' : 'Check the microphone, model configuration, and network.',
+          uiLocale,
+        ),
+      );
+    },
+  });
+
   const { handleTurnFooterAction } = useStableActions(createAppShellTurnActions, {
     uiLocale,
     activeIdRef,
@@ -2266,6 +2359,12 @@ function AppShellContent({
                 // "Maka 继续中…". Both are mutually exclusive with activeStreamingLive.
                 processing={showProcessingIndicator && !activeStreamingLive}
                 continuing={showContinuingIndicator && !activeStreamingLive}
+                voiceCaptureState={voiceInput.captureState}
+                realtimeVoiceState={voiceInput.realtimeState}
+                voiceProviderLabel={voiceInput.providerLabel}
+                onToggleVoiceCapture={voiceInput.toggleCapture}
+                onCancelVoiceCapture={voiceInput.cancelCapture}
+                onToggleRealtimeVoice={voiceInput.toggleRealtime}
                 onSend={sendWithAttachments}
                 onStop={stop}
                 revisionNotice={

--- a/apps/desktop/src/renderer/locales/conversation-copy.ts
+++ b/apps/desktop/src/renderer/locales/conversation-copy.ts
@@ -88,6 +88,14 @@ export interface DesktopConversationCopy {
     reauth: { label: string; tooltip: string };
     testError: { label: string; tooltip: string };
   };
+  voice: {
+    taskDisplayText: string;
+    noTaskResponse: string;
+    unavailableTitle: string;
+    configureDescription: string;
+    operationFailedTitle: string;
+    operationFailedFallback: string;
+  };
   turnError: {
     unknown: string;
     contextOverflow: string;
@@ -160,6 +168,14 @@ const COPY = {
       reauth: { label: '上次连接测试鉴权失败', tooltip: '最近一次连接测试返回鉴权失败（401 / 403），密钥可能已过期或被吊销。这不会拦截发送，但若发送失败请到 设置 · 模型 重新登录。' },
       testError: { label: '上次连接测试失败', tooltip: '最近一次连接测试因网络 / 超时 / 5xx 失败。这不会拦截发送，但若问题持续请到 设置 · 模型 检查 Base URL / 代理。' },
     },
+    voice: {
+      taskDisplayText: '🎙️ 语音任务',
+      noTaskResponse: '当前任务还没有可总结的回复。',
+      unavailableTitle: '语音不可用',
+      configureDescription: '请先在设置 · 语音中配置识别或实时语音模型。',
+      operationFailedTitle: '语音操作失败',
+      operationFailedFallback: '请检查麦克风、模型配置和网络连接。',
+    },
     turnError: { unknown: '未知错误', contextOverflow: '上下文窗口已超出限制', timeout: '请求超时', auth: '鉴权失败', providerBilling: '模型服务计费受限', rateLimit: '触发模型速率限制', network: '网络错误', provider: '模型服务返回错误', stepCap: '达到工具步骤上限', tool: '工具调用失败', permission: '等待权限确认', restarted: '本地应用重启，上一轮没有完成', sandboxBoundaryClosed: '本地应用重启，等待确认的「允许访问工作区以外的内容」请求已按拒绝关闭', recovery: { safeResume: '检查当前状态后，可尝试安全恢复', stepCap: '任务可能尚未完成，可以继续', toolError: '先检查工具结果，再决定是否重试', connection: '先检查模型连接或登录状态', partial: '已保留部分输出，可从这里继续', toolRecord: '工具记录已保留，重试前先看结果', retry: '没有执行工具，可直接重试', sandboxBoundaryClosed: '访问范围没有放开，重试本轮后可重新决定' } },
   },
   en: {
@@ -214,6 +230,14 @@ const COPY = {
       },
       reauth: { label: 'Last connection test failed authentication', tooltip: 'The latest test returned 401 / 403. Sending is not blocked, but sign in again under Settings · Models if it fails.' },
       testError: { label: 'Last connection test failed', tooltip: 'The latest test failed because of a network, timeout, or 5xx error. Sending is not blocked; check Base URL or proxy settings if it persists.' },
+    },
+    voice: {
+      taskDisplayText: '🎙️ Voice task',
+      noTaskResponse: 'The current task has no response to summarize yet.',
+      unavailableTitle: 'Voice unavailable',
+      configureDescription: 'Configure a recognition or realtime voice model in Settings · Voice.',
+      operationFailedTitle: 'Voice operation failed',
+      operationFailedFallback: 'Check the microphone, model configuration, and network.',
     },
     turnError: { unknown: 'Unknown error', contextOverflow: 'Context window exceeded', timeout: 'Request timed out', auth: 'Authentication failed', providerBilling: 'Provider billing required', rateLimit: 'Model rate limit reached', network: 'Network error', provider: 'Model service error', stepCap: 'Tool-step limit reached', tool: 'Tool call failed', permission: 'Waiting for permission', restarted: 'The app restarted before the previous turn completed', sandboxBoundaryClosed: 'The app restarted, so the pending request to reach outside the workspace was closed as denied', recovery: { safeResume: 'Inspect the current state, then try safe recovery', stepCap: 'The task may be incomplete; continue from here', toolError: 'Inspect the tool result before retrying', connection: 'Check the model connection or sign-in status', partial: 'Partial output was retained; continue from here', toolRecord: 'Tool history was retained; inspect it before retrying', retry: 'No tools ran; retry directly', sandboxBoundaryClosed: 'Access was not widened; retry the turn to decide again' } },
   },

--- a/apps/desktop/src/renderer/locales/settings-voice-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-voice-copy.ts
@@ -47,6 +47,13 @@ export type VoiceSettingsCopy = {
   recognitionTesting: string;
   recognitionSuccess: string;
   recognitionFailed: string;
+  createRecognitionConnection: string;
+  createRecognitionConnectionTitle: string;
+  createRecognitionConnectionSubtitle: string;
+  recognitionConnectionCreated: string;
+  recognitionConnectionCreatedDetail(connection: string, model: string): string;
+  recognitionConnectionCreateFailed: string;
+  recognitionConnectionModelMissing: string;
   saveFailed: string;
 };
 
@@ -115,6 +122,13 @@ const SETTINGS_VOICE_COPY = {
     recognitionTesting: '正在录音并调用所配置的识别模型…',
     recognitionSuccess: '语音识别测试通过',
     recognitionFailed: '语音识别测试失败',
+    createRecognitionConnection: '新建识别连接',
+    createRecognitionConnectionTitle: '新建语音识别连接',
+    createRecognitionConnectionSubtitle: '填写 OpenAI 兼容的语音识别服务地址、API Key 和 ASR 模型 ID。创建后会自动选中该连接和模型。',
+    recognitionConnectionCreated: '语音识别连接已创建',
+    recognitionConnectionCreatedDetail: (connection, model) => `已选择 ${connection} · ${model}`,
+    recognitionConnectionCreateFailed: '新建语音识别连接失败',
+    recognitionConnectionModelMissing: '新连接缺少默认 ASR 模型 ID。',
     saveFailed: '保存语音设置失败',
   },
   en: {
@@ -181,6 +195,13 @@ const SETTINGS_VOICE_COPY = {
     recognitionTesting: 'Recording and calling the configured recognition model…',
     recognitionSuccess: 'Speech recognition test passed',
     recognitionFailed: 'Speech recognition test failed',
+    createRecognitionConnection: 'New recognition connection',
+    createRecognitionConnectionTitle: 'New speech recognition connection',
+    createRecognitionConnectionSubtitle: 'Enter an OpenAI-compatible speech recognition endpoint, API key, and ASR model ID. The new connection and model will be selected automatically.',
+    recognitionConnectionCreated: 'Speech recognition connection created',
+    recognitionConnectionCreatedDetail: (connection, model) => `Selected ${connection} · ${model}`,
+    recognitionConnectionCreateFailed: 'Could not create speech recognition connection',
+    recognitionConnectionModelMissing: 'The new connection is missing a default ASR model ID.',
     saveFailed: 'Could not save voice settings',
   },
 } satisfies UiCatalog<VoiceSettingsCopy>;

--- a/apps/desktop/src/renderer/locales/settings-voice-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-voice-copy.ts
@@ -54,6 +54,23 @@ export type VoiceSettingsCopy = {
   recognitionConnectionCreatedDetail(connection: string, model: string): string;
   recognitionConnectionCreateFailed: string;
   recognitionConnectionModelMissing: string;
+  editRecognitionConnection: string;
+  editRecognitionConnectionTitle: string;
+  editRecognitionConnectionSubtitle(connection: string): string;
+  recognitionConnectionEndpoint: string;
+  recognitionConnectionEndpointHelp: string;
+  recognitionConnectionEndpointMissing: string;
+  recognitionConnectionApiKey: string;
+  recognitionConnectionApiKeyPlaceholder: string;
+  recognitionConnectionApiKeyHelp: string;
+  recognitionConnectionModel: string;
+  recognitionConnectionModelPlaceholder: string;
+  recognitionConnectionSave: string;
+  recognitionConnectionSaving: string;
+  recognitionConnectionUpdated: string;
+  recognitionConnectionUpdatedDetail(connection: string, model: string): string;
+  recognitionConnectionUpdateFailed: string;
+  cancel: string;
   saveFailed: string;
 };
 
@@ -128,7 +145,24 @@ const SETTINGS_VOICE_COPY = {
     recognitionConnectionCreated: '语音识别连接已创建',
     recognitionConnectionCreatedDetail: (connection, model) => `已选择 ${connection} · ${model}`,
     recognitionConnectionCreateFailed: '新建语音识别连接失败',
-    recognitionConnectionModelMissing: '新连接缺少默认 ASR 模型 ID。',
+    recognitionConnectionModelMissing: 'ASR 模型 ID 不能为空。',
+    editRecognitionConnection: '修改当前配置',
+    editRecognitionConnectionTitle: '修改语音识别连接',
+    editRecognitionConnectionSubtitle: (connection) => `直接修改 ${connection} 的服务地址、API Key 和 ASR 模型；保存后继续使用该连接。`,
+    recognitionConnectionEndpoint: '服务地址',
+    recognitionConnectionEndpointHelp: '填写 API 根地址，例如 https://api.siliconflow.cn/v1；不要包含 /audio/transcriptions。',
+    recognitionConnectionEndpointMissing: '服务地址不能为空。',
+    recognitionConnectionApiKey: 'API Key',
+    recognitionConnectionApiKeyPlaceholder: '留空则保留现有 API Key',
+    recognitionConnectionApiKeyHelp: '只有填写新值时才会替换现有 API Key。',
+    recognitionConnectionModel: 'ASR 模型 ID',
+    recognitionConnectionModelPlaceholder: '例如 FunAudioLLM/SenseVoiceSmall',
+    recognitionConnectionSave: '保存配置',
+    recognitionConnectionSaving: '保存中…',
+    recognitionConnectionUpdated: '语音识别配置已更新',
+    recognitionConnectionUpdatedDetail: (connection, model) => `${connection} · ${model}`,
+    recognitionConnectionUpdateFailed: '修改语音识别连接失败',
+    cancel: '取消',
     saveFailed: '保存语音设置失败',
   },
   en: {
@@ -201,7 +235,24 @@ const SETTINGS_VOICE_COPY = {
     recognitionConnectionCreated: 'Speech recognition connection created',
     recognitionConnectionCreatedDetail: (connection, model) => `Selected ${connection} · ${model}`,
     recognitionConnectionCreateFailed: 'Could not create speech recognition connection',
-    recognitionConnectionModelMissing: 'The new connection is missing a default ASR model ID.',
+    recognitionConnectionModelMissing: 'The ASR model ID is required.',
+    editRecognitionConnection: 'Edit current configuration',
+    editRecognitionConnectionTitle: 'Edit speech recognition connection',
+    editRecognitionConnectionSubtitle: (connection) => `Edit the endpoint, API key, and ASR model for ${connection}. This connection remains selected after saving.`,
+    recognitionConnectionEndpoint: 'Endpoint',
+    recognitionConnectionEndpointHelp: 'Enter the API root, such as https://api.siliconflow.cn/v1. Do not include /audio/transcriptions.',
+    recognitionConnectionEndpointMissing: 'The endpoint is required.',
+    recognitionConnectionApiKey: 'API Key',
+    recognitionConnectionApiKeyPlaceholder: 'Leave blank to keep the existing API key',
+    recognitionConnectionApiKeyHelp: 'The existing API key is replaced only when a new value is entered.',
+    recognitionConnectionModel: 'ASR model ID',
+    recognitionConnectionModelPlaceholder: 'For example, FunAudioLLM/SenseVoiceSmall',
+    recognitionConnectionSave: 'Save configuration',
+    recognitionConnectionSaving: 'Saving…',
+    recognitionConnectionUpdated: 'Speech recognition configuration updated',
+    recognitionConnectionUpdatedDetail: (connection, model) => `${connection} · ${model}`,
+    recognitionConnectionUpdateFailed: 'Could not update speech recognition connection',
+    cancel: 'Cancel',
     saveFailed: 'Could not save voice settings',
   },
 } satisfies UiCatalog<VoiceSettingsCopy>;

--- a/apps/desktop/src/renderer/locales/settings-voice-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-voice-copy.ts
@@ -31,6 +31,23 @@ export type VoiceSettingsCopy = {
   permissions: Record<VoicePermissionStatus, string>;
   validation: Record<'duration_exceeded' | 'audio_too_large' | 'invalid_audio_shape' | 'permission_not_granted' | 'default', string>;
   duration(seconds: string): string;
+  recognitionTitle: string;
+  realtimeTitle: string;
+  connection: string;
+  model: string;
+  language: string;
+  prompt: string;
+  voice: string;
+  notConfigured: string;
+  recognitionConnectionAria: string;
+  recognitionModelAria: string;
+  realtimeConnectionAria: string;
+  realtimeModelAria: string;
+  testRecognition: string;
+  recognitionTesting: string;
+  recognitionSuccess: string;
+  recognitionFailed: string;
+  saveFailed: string;
 };
 
 const SETTINGS_VOICE_COPY = {
@@ -82,6 +99,23 @@ const SETTINGS_VOICE_COPY = {
       default: '语音采集自检未通过。',
     },
     duration: (seconds) => `${seconds} 秒`,
+    recognitionTitle: '语音识别',
+    realtimeTitle: '实时语音协调器',
+    connection: '模型连接',
+    model: '模型 ID',
+    language: '语言（可选）',
+    prompt: '识别提示词（可选）',
+    voice: '音色',
+    notConfigured: '未配置',
+    recognitionConnectionAria: '语音识别模型连接',
+    recognitionModelAria: '语音识别模型 ID',
+    realtimeConnectionAria: '实时语音模型连接',
+    realtimeModelAria: '实时语音模型 ID',
+    testRecognition: '录音 4 秒并测试识别',
+    recognitionTesting: '正在录音并调用所配置的识别模型…',
+    recognitionSuccess: '语音识别测试通过',
+    recognitionFailed: '语音识别测试失败',
+    saveFailed: '保存语音设置失败',
   },
   en: {
     idle: 'Ready to run a local recording check.',
@@ -131,6 +165,23 @@ const SETTINGS_VOICE_COPY = {
       default: 'The voice capture check did not pass.',
     },
     duration: (seconds) => `${seconds} seconds`,
+    recognitionTitle: 'Speech recognition',
+    realtimeTitle: 'Realtime voice coordinator',
+    connection: 'Model connection',
+    model: 'Model ID',
+    language: 'Language (optional)',
+    prompt: 'Recognition prompt (optional)',
+    voice: 'Voice',
+    notConfigured: 'Not configured',
+    recognitionConnectionAria: 'Speech recognition connection',
+    recognitionModelAria: 'Speech recognition model ID',
+    realtimeConnectionAria: 'Realtime voice connection',
+    realtimeModelAria: 'Realtime voice model ID',
+    testRecognition: 'Record for four seconds and test',
+    recognitionTesting: 'Recording and calling the configured recognition model…',
+    recognitionSuccess: 'Speech recognition test passed',
+    recognitionFailed: 'Speech recognition test failed',
+    saveFailed: 'Could not save voice settings',
   },
 } satisfies UiCatalog<VoiceSettingsCopy>;
 

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -427,7 +427,13 @@ function SettingsPage(props: {
       // 语音 + 网关 是两套独立的功能（一个是本地麦克风/转写管线，
       // 一个是远程 SSE/HTTP 网关），合在一页里读起来既挤又混。
       // 拆成两个独立的 nav 项各自独立呈现。
-      return <VoiceModelsSettingsPage />;
+      return (
+        <VoiceModelsSettingsPage
+          settings={props.settings}
+          connections={props.connections}
+          onUpdate={props.onUpdateSettings}
+        />
+      );
     case 'open-gateway':
       return <OpenGatewaySettingsPage settings={props.settings} onUpdate={props.onUpdateSettings} />;
     case 'search':

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -432,6 +432,7 @@ function SettingsPage(props: {
           settings={props.settings}
           connections={props.connections}
           onUpdate={props.onUpdateSettings}
+          onRefreshConnections={props.onRefreshConnections}
         />
       );
     case 'open-gateway':

--- a/apps/desktop/src/renderer/settings/voice-recognition-connection-form.tsx
+++ b/apps/desktop/src/renderer/settings/voice-recognition-connection-form.tsx
@@ -1,0 +1,127 @@
+import { useState } from 'react';
+import {
+  PROVIDER_DEFAULTS,
+  effectiveBaseUrl,
+  type LlmConnection,
+} from '@maka/core';
+import {
+  providerAuthSupportsApiKey,
+} from '@maka/core/llm-connections';
+import { Button, Input, useMountedRef, useUiLocale } from '@maka/ui';
+import { getVoiceSettingsCopy } from '../locales/settings-voice-copy';
+import { PasswordInput } from './password-input';
+import {
+  providerPanelActionErrorMessage,
+  type ConnectionsBridge,
+} from './provider-panel-shared';
+import { useActionGuard } from './use-action-guard';
+
+export function VoiceRecognitionConnectionForm(props: {
+  bridge: ConnectionsBridge;
+  connection: LlmConnection;
+  model: string;
+  onCancel(): void;
+  onSaved(connection: LlmConnection, model: string): Promise<void>;
+}) {
+  const locale = useUiLocale();
+  const copy = getVoiceSettingsCopy(locale);
+  const [baseUrl, setBaseUrl] = useState(() => effectiveBaseUrl(props.connection));
+  const [apiKey, setApiKey] = useState('');
+  const [model, setModel] = useState(props.model || props.connection.defaultModel);
+  const [error, setError] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const submitGuard = useActionGuard<'submit'>();
+  const mountedRef = useMountedRef();
+  const supportsApiKey = providerAuthSupportsApiKey(props.connection.providerType);
+  const endpointPlaceholder =
+    PROVIDER_DEFAULTS[props.connection.providerType]?.baseUrl || 'https://…/v1';
+
+  async function save(): Promise<void> {
+    if (!submitGuard.begin('submit')) return;
+    setError(null);
+    const normalizedBaseUrl = baseUrl.trim();
+    const normalizedModel = model.trim();
+    if (!normalizedBaseUrl) {
+      submitGuard.finish();
+      setError(copy.recognitionConnectionEndpointMissing);
+      return;
+    }
+    if (!normalizedModel) {
+      submitGuard.finish();
+      setError(copy.recognitionConnectionModelMissing);
+      return;
+    }
+    setBusy(true);
+    try {
+      const updated = await props.bridge.update(props.connection.slug, {
+        baseUrl: normalizedBaseUrl,
+        defaultModel: normalizedModel,
+        ...(apiKey.trim() ? { apiKey: apiKey.trim() } : {}),
+      });
+      await props.onSaved(updated, normalizedModel);
+    } catch (saveError) {
+      if (!mountedRef.current) return;
+      setError(providerPanelActionErrorMessage(saveError, locale));
+    } finally {
+      submitGuard.finish();
+      if (mountedRef.current) setBusy(false);
+    }
+  }
+
+  return (
+    <div className="providerEditor">
+      <label>
+        <span>{copy.recognitionConnectionEndpoint}</span>
+        <Input
+          value={baseUrl}
+          onChange={(event) => {
+            setBaseUrl(event.currentTarget.value);
+            if (error) setError(null);
+          }}
+          placeholder={endpointPlaceholder}
+          disabled={busy}
+          aria-label={copy.recognitionConnectionEndpoint}
+        />
+        <small>{copy.recognitionConnectionEndpointHelp}</small>
+      </label>
+      {supportsApiKey ? (
+        <label>
+          <span>{copy.recognitionConnectionApiKey}</span>
+          <PasswordInput
+            value={apiKey}
+            onChange={(next) => {
+              setApiKey(next);
+              if (error) setError(null);
+            }}
+            placeholder={copy.recognitionConnectionApiKeyPlaceholder}
+            ariaLabel={copy.recognitionConnectionApiKey}
+            disabled={busy}
+          />
+          <small>{copy.recognitionConnectionApiKeyHelp}</small>
+        </label>
+      ) : null}
+      <label>
+        <span>{copy.recognitionConnectionModel}</span>
+        <Input
+          value={model}
+          onChange={(event) => {
+            setModel(event.currentTarget.value);
+            if (error) setError(null);
+          }}
+          placeholder={copy.recognitionConnectionModelPlaceholder}
+          disabled={busy}
+          aria-label={copy.recognitionConnectionModel}
+        />
+      </label>
+      {error ? <p className="providerError" role="alert">{error}</p> : null}
+      <div className="providerActions">
+        <Button variant="ghost" type="button" disabled={busy} onClick={props.onCancel}>
+          {copy.cancel}
+        </Button>
+        <Button type="button" disabled={busy} onClick={() => void save()}>
+          {busy ? copy.recognitionConnectionSaving : copy.recognitionConnectionSave}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/renderer/settings/voice-recognition-connection-form.tsx
+++ b/apps/desktop/src/renderer/settings/voice-recognition-connection-form.tsx
@@ -115,12 +115,20 @@ export function VoiceRecognitionConnectionForm(props: {
       </label>
       {error ? <p className="providerError" role="alert">{error}</p> : null}
       <div className="providerActions">
-        <Button variant="ghost" type="button" disabled={busy} onClick={props.onCancel}>
-          {copy.cancel}
-        </Button>
-        <Button type="button" disabled={busy} onClick={() => void save()}>
-          {busy ? copy.recognitionConnectionSaving : copy.recognitionConnectionSave}
-        </Button>
+        <Button
+          variant="ghost"
+          type="button"
+          isDisabled={busy}
+          onClick={props.onCancel}
+          label={copy.cancel}
+        />
+        <Button
+          variant="primary"
+          type="button"
+          isDisabled={busy}
+          onClick={() => void save()}
+          label={busy ? copy.recognitionConnectionSaving : copy.recognitionConnectionSave}
+        />
       </div>
     </div>
   );

--- a/apps/desktop/src/renderer/settings/voice-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/voice-settings-page.tsx
@@ -26,6 +26,7 @@ import { AddProviderForm } from './provider-add-form';
 import { ProviderConnectionDialog } from './provider-connection-dialog';
 import { providerPanelActionErrorMessage } from './provider-panel-shared';
 import { useActionGuard } from './use-action-guard';
+import { VoiceRecognitionConnectionForm } from './voice-recognition-connection-form';
 import { startVoiceCapture } from '../voice-audio-capture';
 
 type VoiceSmokeState =
@@ -50,15 +51,20 @@ export function VoiceModelsSettingsPage(props: {
   const [isBusy, setIsBusy] = useState(false);
   const [recognitionTest, setRecognitionTest] = useState<string>();
   const [creatingRecognitionConnection, setCreatingRecognitionConnection] = useState(false);
+  const [editingRecognitionConnection, setEditingRecognitionConnection] = useState(false);
   const [saving, setSaving] = useState(false);
   const captureSmokeGuard = useActionGuard<'smoke'>();
   const voicePageMountedRef = useMountedRef();
   const activeVoiceCaptureStreamRef = useRef<MediaStream | null>(null);
   const createRecognitionConnectionButtonRef = useRef<HTMLElement | null>(null);
+  const editRecognitionConnectionButtonRef = useRef<HTMLElement | null>(null);
   const toast = useToast();
   const caps = defaultVoiceCaptureCaps();
   const smokeStatusId = useId();
   const enabledConnections = props.connections.filter((connection) => connection.enabled);
+  const selectedRecognitionConnection = enabledConnections.find(
+    (connection) => connection.slug === props.settings.voice.recognition.connectionSlug,
+  );
   const connectionOptions = [
     ['', copy.notConfigured],
     ...enabledConnections.map(
@@ -123,6 +129,28 @@ export function VoiceModelsSettingsPage(props: {
         providerPanelActionErrorMessage(error, locale),
       );
     }
+  }
+
+  async function finishEditingRecognitionConnection(
+    connection: LlmConnection,
+    model: string,
+  ): Promise<void> {
+    const saved = await updateVoice({
+      recognition: {
+        connectionSlug: connection.slug,
+        model,
+      },
+    });
+    if (!saved || !voicePageMountedRef.current) {
+      throw new Error(copy.recognitionConnectionUpdateFailed);
+    }
+    await props.onRefreshConnections();
+    if (!voicePageMountedRef.current) return;
+    setEditingRecognitionConnection(false);
+    toast.success(
+      copy.recognitionConnectionUpdated,
+      copy.recognitionConnectionUpdatedDetail(connection.name, model),
+    );
   }
 
   async function runRecognitionTest(): Promise<void> {
@@ -378,6 +406,15 @@ export function VoiceModelsSettingsPage(props: {
           {copy.createRecognitionConnection}
         </Button>
         <Button
+          ref={editRecognitionConnectionButtonRef}
+          variant="secondary"
+          type="button"
+          disabled={saving || isBusy || !selectedRecognitionConnection}
+          onClick={() => setEditingRecognitionConnection(true)}
+        >
+          {copy.editRecognitionConnection}
+        </Button>
+        <Button
           type="button"
           disabled={saving || isBusy}
           onClick={() => void runRecognitionTest()}
@@ -407,6 +444,24 @@ export function VoiceModelsSettingsPage(props: {
             onCreated={async (slug) => {
               await finishCreatingRecognitionConnection(slug);
             }}
+          />
+        </ProviderConnectionDialog>
+      ) : null}
+
+      {editingRecognitionConnection && selectedRecognitionConnection ? (
+        <ProviderConnectionDialog
+          title={copy.editRecognitionConnectionTitle}
+          subtitle={copy.editRecognitionConnectionSubtitle(selectedRecognitionConnection.name)}
+          providerType={selectedRecognitionConnection.providerType}
+          onClose={() => setEditingRecognitionConnection(false)}
+          finalFocus={() => editRecognitionConnectionButtonRef.current}
+        >
+          <VoiceRecognitionConnectionForm
+            bridge={window.maka.connections}
+            connection={selectedRecognitionConnection}
+            model={props.settings.voice.recognition.model}
+            onCancel={() => setEditingRecognitionConnection(false)}
+            onSaved={finishEditingRecognitionConnection}
           />
         </ProviderConnectionDialog>
       ) : null}

--- a/apps/desktop/src/renderer/settings/voice-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/voice-settings-page.tsx
@@ -22,6 +22,9 @@ import {
   useUiLocale,
 } from '@maka/ui';
 import { getVoiceSettingsCopy, type VoiceSettingsCopy } from '../locales/settings-voice-copy';
+import { AddProviderForm } from './provider-add-form';
+import { ProviderConnectionDialog } from './provider-connection-dialog';
+import { providerPanelActionErrorMessage } from './provider-panel-shared';
 import { useActionGuard } from './use-action-guard';
 import { startVoiceCapture } from '../voice-audio-capture';
 
@@ -38,6 +41,7 @@ export function VoiceModelsSettingsPage(props: {
   onUpdate(
     patch: Parameters<typeof window.maka.settings.update>[0],
   ): Promise<UpdateAppSettingsResult>;
+  onRefreshConnections(): Promise<void>;
 }) {
   const locale = useUiLocale();
   const copy = getVoiceSettingsCopy(locale);
@@ -45,10 +49,12 @@ export function VoiceModelsSettingsPage(props: {
   const [smoke, setSmoke] = useState<VoiceSmokeState>({ status: 'idle' });
   const [isBusy, setIsBusy] = useState(false);
   const [recognitionTest, setRecognitionTest] = useState<string>();
+  const [creatingRecognitionConnection, setCreatingRecognitionConnection] = useState(false);
   const [saving, setSaving] = useState(false);
   const captureSmokeGuard = useActionGuard<'smoke'>();
   const voicePageMountedRef = useMountedRef();
   const activeVoiceCaptureStreamRef = useRef<MediaStream | null>(null);
+  const createRecognitionConnectionButtonRef = useRef<HTMLElement | null>(null);
   const toast = useToast();
   const caps = defaultVoiceCaptureCaps();
   const smokeStatusId = useId();
@@ -65,7 +71,7 @@ export function VoiceModelsSettingsPage(props: {
       recognition?: Partial<AppSettings['voice']['recognition']>;
       realtime?: Partial<AppSettings['voice']['realtime']>;
     },
-  ): Promise<void> {
+  ): Promise<boolean> {
     setSaving(true);
     try {
       await props.onUpdate({
@@ -80,10 +86,42 @@ export function VoiceModelsSettingsPage(props: {
           },
         },
       });
+      return true;
     } catch (error) {
       toast.error(copy.saveFailed, error instanceof Error ? error.message : copy.failed);
+      return false;
     } finally {
       if (voicePageMountedRef.current) setSaving(false);
+    }
+  }
+
+  async function finishCreatingRecognitionConnection(slug: string): Promise<void> {
+    try {
+      const connections = await window.maka.connections.list();
+      const created = connections.find((connection) => connection.slug === slug);
+      if (!created?.defaultModel.trim()) {
+        throw new Error(copy.recognitionConnectionModelMissing);
+      }
+      const saved = await updateVoice({
+        recognition: {
+          connectionSlug: created.slug,
+          model: created.defaultModel,
+        },
+      });
+      if (!saved || !voicePageMountedRef.current) return;
+      await props.onRefreshConnections();
+      if (!voicePageMountedRef.current) return;
+      setCreatingRecognitionConnection(false);
+      toast.success(
+        copy.recognitionConnectionCreated,
+        copy.recognitionConnectionCreatedDetail(created.name, created.defaultModel),
+      );
+    } catch (error) {
+      if (!voicePageMountedRef.current) return;
+      toast.error(
+        copy.recognitionConnectionCreateFailed,
+        providerPanelActionErrorMessage(error, locale),
+      );
     }
   }
 
@@ -331,6 +369,15 @@ export function VoiceModelsSettingsPage(props: {
       </div>
       <div className="settingsActionRow">
         <Button
+          ref={createRecognitionConnectionButtonRef}
+          variant="secondary"
+          type="button"
+          disabled={saving || isBusy}
+          onClick={() => setCreatingRecognitionConnection(true)}
+        >
+          {copy.createRecognitionConnection}
+        </Button>
+        <Button
           type="button"
           disabled={saving || isBusy}
           onClick={() => void runRecognitionTest()}
@@ -342,6 +389,26 @@ export function VoiceModelsSettingsPage(props: {
         <Alert variant="passive" role="status">
           <AlertDescription>{recognitionTest}</AlertDescription>
         </Alert>
+      ) : null}
+
+      {creatingRecognitionConnection ? (
+        <ProviderConnectionDialog
+          title={copy.createRecognitionConnectionTitle}
+          subtitle={copy.createRecognitionConnectionSubtitle}
+          providerType="openai-compatible"
+          onClose={() => setCreatingRecognitionConnection(false)}
+          finalFocus={() => createRecognitionConnectionButtonRef.current}
+        >
+          <AddProviderForm
+            bridge={window.maka.connections}
+            providerType="openai-compatible"
+            existingSlugs={props.connections.map((connection) => connection.slug)}
+            onCancel={() => setCreatingRecognitionConnection(false)}
+            onCreated={async (slug) => {
+              await finishCreatingRecognitionConnection(slug);
+            }}
+          />
+        </ProviderConnectionDialog>
       ) : null}
 
       <div className="settingsFeatureStatusHeroHeading">

--- a/apps/desktop/src/renderer/settings/voice-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/voice-settings-page.tsx
@@ -27,7 +27,7 @@ import { ProviderConnectionDialog } from './provider-connection-dialog';
 import { providerPanelActionErrorMessage } from './provider-panel-shared';
 import { useActionGuard } from './use-action-guard';
 import { VoiceRecognitionConnectionForm } from './voice-recognition-connection-form';
-import { startVoiceCapture } from '../voice-audio-capture';
+import { startVoiceCapture, type ActiveVoiceCapture } from '../voice-audio-capture';
 
 type VoiceSmokeState =
   | { status: 'idle' }
@@ -50,12 +50,18 @@ export function VoiceModelsSettingsPage(props: {
   const [smoke, setSmoke] = useState<VoiceSmokeState>({ status: 'idle' });
   const [isBusy, setIsBusy] = useState(false);
   const [recognitionTest, setRecognitionTest] = useState<string>();
+  const [recognitionTesting, setRecognitionTesting] = useState(false);
   const [creatingRecognitionConnection, setCreatingRecognitionConnection] = useState(false);
   const [editingRecognitionConnection, setEditingRecognitionConnection] = useState(false);
   const [saving, setSaving] = useState(false);
   const captureSmokeGuard = useActionGuard<'smoke'>();
+  const recognitionTestGuard = useActionGuard<'recognition'>();
   const voicePageMountedRef = useMountedRef();
   const activeVoiceCaptureStreamRef = useRef<MediaStream | null>(null);
+  const activeRecognitionTestRef = useRef<{
+    operationId: string;
+    capture?: ActiveVoiceCapture;
+  } | undefined>(undefined);
   const createRecognitionConnectionButtonRef = useRef<HTMLElement | null>(null);
   const editRecognitionConnectionButtonRef = useRef<HTMLElement | null>(null);
   const toast = useToast();
@@ -81,16 +87,7 @@ export function VoiceModelsSettingsPage(props: {
     setSaving(true);
     try {
       await props.onUpdate({
-        voice: {
-          recognition: {
-            ...props.settings.voice.recognition,
-            ...patch.recognition,
-          },
-          realtime: {
-            ...props.settings.voice.realtime,
-            ...patch.realtime,
-          },
-        },
+        voice: patch,
       });
       return true;
     } catch (error) {
@@ -154,30 +151,66 @@ export function VoiceModelsSettingsPage(props: {
   }
 
   async function runRecognitionTest(): Promise<void> {
+    if (!recognitionTestGuard.begin('recognition')) return;
+    setRecognitionTesting(true);
     setRecognitionTest(copy.recognitionTesting);
     let operationId: string | undefined;
     try {
       const begin = await window.maka.voice.begin({ intent: 'dictate' });
       if (!begin.ok) throw new Error(begin.reason);
       operationId = begin.operationId;
+      activeRecognitionTestRef.current = { operationId };
+      if (!voicePageMountedRef.current) {
+        await window.maka.voice.cancel(operationId).catch(() => {});
+        operationId = undefined;
+        return;
+      }
       const capture = await startVoiceCapture({ maxDurationMs: 4_000 });
+      if (
+        !voicePageMountedRef.current ||
+        activeRecognitionTestRef.current?.operationId !== operationId
+      ) {
+        capture.cancel();
+        await window.maka.voice.cancel(operationId).catch(() => {});
+        operationId = undefined;
+        return;
+      }
+      activeRecognitionTestRef.current.capture = capture;
       await waitMs(4_000);
       const audio = await capture.stop();
+      if (activeRecognitionTestRef.current?.operationId === operationId) {
+        activeRecognitionTestRef.current.capture = undefined;
+      }
       const result = await window.maka.voice.finishCapture(begin.operationId, audio);
       if (result.kind !== 'transcript') throw new Error('recognition_test_no_transcript');
       operationId = undefined;
+      activeRecognitionTestRef.current = undefined;
+      if (!voicePageMountedRef.current) return;
       setRecognitionTest(result.text);
       toast.success(copy.recognitionSuccess, result.text);
     } catch (error) {
       if (operationId) await window.maka.voice.cancel(operationId).catch(() => {});
+      if (activeRecognitionTestRef.current?.operationId === operationId) {
+        activeRecognitionTestRef.current = undefined;
+      }
+      if (!voicePageMountedRef.current) return;
       const message = error instanceof Error ? error.message : copy.failed;
       setRecognitionTest(message);
       toast.error(copy.recognitionFailed, message);
+    } finally {
+      recognitionTestGuard.finish();
+      if (voicePageMountedRef.current) setRecognitionTesting(false);
     }
   }
 
   useEffect(() => {
     return () => {
+      const recognitionTest = activeRecognitionTestRef.current;
+      activeRecognitionTestRef.current = undefined;
+      recognitionTest?.capture?.cancel();
+      if (recognitionTest) {
+        void window.maka.voice.cancel(recognitionTest.operationId).catch(() => {});
+      }
       activeVoiceCaptureStreamRef.current?.getTracks().forEach((track) => track.stop());
       activeVoiceCaptureStreamRef.current = null;
     };
@@ -416,7 +449,7 @@ export function VoiceModelsSettingsPage(props: {
         </Button>
         <Button
           type="button"
-          disabled={saving || isBusy}
+          disabled={saving || isBusy || recognitionTesting}
           onClick={() => void runRecognitionTest()}
         >
           {copy.testRecognition}

--- a/apps/desktop/src/renderer/settings/voice-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/voice-settings-page.tsx
@@ -1,10 +1,29 @@
 import { useEffect, useId, useRef, useState } from 'react';
 import { Volume2 } from '@maka/ui/icons';
-import type { VoicePermissionStatus } from '@maka/core';
+import type {
+  AppSettings,
+  LlmConnection,
+  UpdateAppSettingsResult,
+  VoicePermissionStatus,
+} from '@maka/core';
 import { defaultVoiceCaptureCaps, validateVoiceCaptureRequest } from '@maka/core';
-import { Alert, AlertDescription, Badge, Button, PageHeader, formatBytes, useMountedRef, useToast, useUiLocale } from '@maka/ui';
+import {
+  Alert,
+  AlertDescription,
+  Badge,
+  Button,
+  Input,
+  PageHeader,
+  SettingsSelect,
+  Textarea,
+  formatBytes,
+  useMountedRef,
+  useToast,
+  useUiLocale,
+} from '@maka/ui';
 import { getVoiceSettingsCopy, type VoiceSettingsCopy } from '../locales/settings-voice-copy';
 import { useActionGuard } from './use-action-guard';
+import { startVoiceCapture } from '../voice-audio-capture';
 
 type VoiceSmokeState =
   | { status: 'idle' }
@@ -13,18 +32,83 @@ type VoiceSmokeState =
   | { status: 'ok'; durationMs: number; audioBytes: number }
   | { status: 'error'; reason: 'unsupported_media' | 'unsupported_recorder' | 'denied' | 'failed' | string };
 
-export function VoiceModelsSettingsPage() {
+export function VoiceModelsSettingsPage(props: {
+  settings: AppSettings;
+  connections: LlmConnection[];
+  onUpdate(
+    patch: Parameters<typeof window.maka.settings.update>[0],
+  ): Promise<UpdateAppSettingsResult>;
+}) {
   const locale = useUiLocale();
   const copy = getVoiceSettingsCopy(locale);
   const [permission, setPermission] = useState<VoicePermissionStatus>('unknown');
   const [smoke, setSmoke] = useState<VoiceSmokeState>({ status: 'idle' });
   const [isBusy, setIsBusy] = useState(false);
+  const [recognitionTest, setRecognitionTest] = useState<string>();
+  const [saving, setSaving] = useState(false);
   const captureSmokeGuard = useActionGuard<'smoke'>();
   const voicePageMountedRef = useMountedRef();
   const activeVoiceCaptureStreamRef = useRef<MediaStream | null>(null);
   const toast = useToast();
   const caps = defaultVoiceCaptureCaps();
   const smokeStatusId = useId();
+  const enabledConnections = props.connections.filter((connection) => connection.enabled);
+  const connectionOptions = [
+    ['', copy.notConfigured],
+    ...enabledConnections.map(
+      (connection) => [connection.slug, connection.name] as const,
+    ),
+  ] as Array<readonly [string, string]>;
+
+  async function updateVoice(
+    patch: {
+      recognition?: Partial<AppSettings['voice']['recognition']>;
+      realtime?: Partial<AppSettings['voice']['realtime']>;
+    },
+  ): Promise<void> {
+    setSaving(true);
+    try {
+      await props.onUpdate({
+        voice: {
+          recognition: {
+            ...props.settings.voice.recognition,
+            ...patch.recognition,
+          },
+          realtime: {
+            ...props.settings.voice.realtime,
+            ...patch.realtime,
+          },
+        },
+      });
+    } catch (error) {
+      toast.error(copy.saveFailed, error instanceof Error ? error.message : copy.failed);
+    } finally {
+      if (voicePageMountedRef.current) setSaving(false);
+    }
+  }
+
+  async function runRecognitionTest(): Promise<void> {
+    setRecognitionTest(copy.recognitionTesting);
+    let operationId: string | undefined;
+    try {
+      const begin = await window.maka.voice.begin({ intent: 'dictate' });
+      if (!begin.ok) throw new Error(begin.reason);
+      operationId = begin.operationId;
+      const capture = await startVoiceCapture({ maxDurationMs: 4_000 });
+      await waitMs(4_000);
+      const audio = await capture.stop();
+      const result = await window.maka.voice.finishCapture(begin.operationId, audio);
+      if (result.kind !== 'transcript') throw new Error('recognition_test_no_transcript');
+      operationId = undefined;
+      setRecognitionTest(result.text);
+      toast.success(copy.recognitionSuccess, result.text);
+    } catch (error) {
+      if (operationId) await window.maka.voice.cancel(operationId).catch(() => {});
+      const message = error instanceof Error ? error.message : copy.failed;
+      setRecognitionTest(message);
+      toast.error(copy.recognitionFailed, message);
+    }
+  }
 
   useEffect(() => {
     return () => {
@@ -189,6 +273,120 @@ export function VoiceModelsSettingsPage() {
         badge={<Badge variant="neutral" label={copy.badge} />}
         subtitle={copy.subtitle}
       />
+
+      <div className="settingsFeatureStatusHeroHeading">
+        <h3>{copy.recognitionTitle}</h3>
+      </div>
+      <div className="settingsFormGrid settingsFormGridProxy">
+        <label>
+          <span>{copy.connection}</span>
+          <SettingsSelect
+            value={props.settings.voice.recognition.connectionSlug}
+            ariaLabel={copy.recognitionConnectionAria}
+            options={connectionOptions}
+            disabled={saving}
+            onChange={(connectionSlug) =>
+              void updateVoice({ recognition: { connectionSlug } })
+            }
+          />
+        </label>
+        <label>
+          <span>{copy.model}</span>
+          <Input
+            key={`recognition-model:${props.settings.voice.recognition.model}`}
+            defaultValue={props.settings.voice.recognition.model}
+            disabled={saving}
+            placeholder="gpt-4o-mini-transcribe"
+            aria-label={copy.recognitionModelAria}
+            onBlur={(event) =>
+              void updateVoice({ recognition: { model: event.currentTarget.value } })
+            }
+          />
+        </label>
+        <label>
+          <span>{copy.language}</span>
+          <Input
+            key={`recognition-language:${props.settings.voice.recognition.language}`}
+            defaultValue={props.settings.voice.recognition.language}
+            disabled={saving}
+            placeholder="zh"
+            aria-label={copy.language}
+            onBlur={(event) =>
+              void updateVoice({ recognition: { language: event.currentTarget.value } })
+            }
+          />
+        </label>
+        <label>
+          <span>{copy.prompt}</span>
+          <Textarea
+            key={`recognition-prompt:${props.settings.voice.recognition.prompt}`}
+            defaultValue={props.settings.voice.recognition.prompt}
+            disabled={saving}
+            aria-label={copy.prompt}
+            onBlur={(event) =>
+              void updateVoice({ recognition: { prompt: event.currentTarget.value } })
+            }
+          />
+        </label>
+      </div>
+      <div className="settingsActionRow">
+        <Button
+          type="button"
+          disabled={saving || isBusy}
+          onClick={() => void runRecognitionTest()}
+        >
+          {copy.testRecognition}
+        </Button>
+      </div>
+      {recognitionTest ? (
+        <Alert variant="passive" role="status">
+          <AlertDescription>{recognitionTest}</AlertDescription>
+        </Alert>
+      ) : null}
+
+      <div className="settingsFeatureStatusHeroHeading">
+        <h3>{copy.realtimeTitle}</h3>
+      </div>
+      <div className="settingsFormGrid settingsFormGridProxy">
+        <label>
+          <span>{copy.connection}</span>
+          <SettingsSelect
+            value={props.settings.voice.realtime.connectionSlug}
+            ariaLabel={copy.realtimeConnectionAria}
+            options={connectionOptions}
+            disabled={saving}
+            onChange={(connectionSlug) =>
+              void updateVoice({ realtime: { connectionSlug } })
+            }
+          />
+        </label>
+        <label>
+          <span>{copy.model}</span>
+          <Input
+            key={`realtime-model:${props.settings.voice.realtime.model}`}
+            defaultValue={props.settings.voice.realtime.model}
+            disabled={saving}
+            placeholder="gpt-realtime"
+            aria-label={copy.realtimeModelAria}
+            onBlur={(event) =>
+              void updateVoice({ realtime: { model: event.currentTarget.value } })
+            }
+          />
+        </label>
+        <label>
+          <span>{copy.voice}</span>
+          <Input
+            key={`realtime-voice:${props.settings.voice.realtime.voice}`}
+            defaultValue={props.settings.voice.realtime.voice}
+            disabled={saving}
+            placeholder="marin"
+            aria-label={copy.voice}
+            onBlur={(event) =>
+              void updateVoice({ realtime: { voice: event.currentTarget.value } })
+            }
+          />
+        </label>
+      </div>
 
       <dl className="settingsBotStatusGrid" aria-label={copy.statusAria}>
         <div>

--- a/apps/desktop/src/renderer/settings/voice-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/voice-settings-page.tsx
@@ -62,8 +62,8 @@ export function VoiceModelsSettingsPage(props: {
     operationId: string;
     capture?: ActiveVoiceCapture;
   } | undefined>(undefined);
-  const createRecognitionConnectionButtonRef = useRef<HTMLElement | null>(null);
-  const editRecognitionConnectionButtonRef = useRef<HTMLElement | null>(null);
+  const createRecognitionConnectionButtonRef = useRef<HTMLButtonElement | null>(null);
+  const editRecognitionConnectionButtonRef = useRef<HTMLButtonElement | null>(null);
   const toast = useToast();
   const caps = defaultVoiceCaptureCaps();
   const smokeStatusId = useId();
@@ -433,27 +433,25 @@ export function VoiceModelsSettingsPage(props: {
           ref={createRecognitionConnectionButtonRef}
           variant="secondary"
           type="button"
-          disabled={saving || isBusy}
+          isDisabled={saving || isBusy}
           onClick={() => setCreatingRecognitionConnection(true)}
-        >
-          {copy.createRecognitionConnection}
-        </Button>
+          label={copy.createRecognitionConnection}
+        />
         <Button
           ref={editRecognitionConnectionButtonRef}
           variant="secondary"
           type="button"
-          disabled={saving || isBusy || !selectedRecognitionConnection}
+          isDisabled={saving || isBusy || !selectedRecognitionConnection}
           onClick={() => setEditingRecognitionConnection(true)}
-        >
-          {copy.editRecognitionConnection}
-        </Button>
+          label={copy.editRecognitionConnection}
+        />
         <Button
+          variant="primary"
           type="button"
-          disabled={saving || isBusy || recognitionTesting}
+          isDisabled={saving || isBusy || recognitionTesting}
           onClick={() => void runRecognitionTest()}
-        >
-          {copy.testRecognition}
-        </Button>
+          label={copy.testRecognition}
+        />
       </div>
       {recognitionTest ? (
         <Alert variant="passive" role="status">

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -49,6 +49,28 @@
   justify-content: flex-end;
 }
 
+.maka-composer-voice-button[data-state="recording"] {
+  color: var(--status-danger, var(--destructive));
+  background: color-mix(in srgb, currentColor 10%, transparent);
+  animation: maka-voice-pulse 1.2s ease-in-out infinite;
+}
+
+.maka-composer-voice-button[data-state="native_ready"],
+.maka-composer-realtime-voice-button[data-state="connected"] {
+  color: var(--status-running);
+  background: color-mix(in srgb, currentColor 10%, transparent);
+}
+
+@keyframes maka-voice-pulse {
+  50% { opacity: 0.55; }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .maka-composer-voice-button[data-state="recording"] {
+    animation: none;
+  }
+}
+
 .maka-composer-status-slot {
   min-width: 0;
   flex: 1 1 auto;

--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -52,23 +52,12 @@
 .maka-composer-voice-button[data-state="recording"] {
   color: var(--status-danger, var(--destructive));
   background: color-mix(in srgb, currentColor 10%, transparent);
-  animation: maka-voice-pulse 1.2s ease-in-out infinite;
 }
 
 .maka-composer-voice-button[data-state="native_ready"],
 .maka-composer-realtime-voice-button[data-state="connected"] {
   color: var(--status-running);
   background: color-mix(in srgb, currentColor 10%, transparent);
-}
-
-@keyframes maka-voice-pulse {
-  50% { opacity: 0.55; }
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .maka-composer-voice-button[data-state="recording"] {
-    animation: none;
-  }
 }
 
 .maka-composer-status-slot {

--- a/apps/desktop/src/renderer/use-voice-input.ts
+++ b/apps/desktop/src/renderer/use-voice-input.ts
@@ -1,0 +1,339 @@
+import { useEffect, useRef, useState } from 'react';
+import type {
+  VoiceCoordinatorToolCall,
+  VoiceRoutePlan,
+} from '@maka/core';
+import { startVoiceCapture, type ActiveVoiceCapture } from './voice-audio-capture.js';
+
+export type ComposerVoiceCaptureState =
+  | 'idle'
+  | 'requesting'
+  | 'recording'
+  | 'processing'
+  | 'native_ready'
+  | 'sending';
+
+export type ComposerRealtimeVoiceState =
+  | 'idle'
+  | 'connecting'
+  | 'connected';
+
+export interface VoiceInputController {
+  captureState: ComposerVoiceCaptureState;
+  realtimeState: ComposerRealtimeVoiceState;
+  providerLabel?: string;
+  routeKind?: Exclude<VoiceRoutePlan['kind'], 'blocked'>;
+  toggleCapture(input?: { dictate?: boolean }): Promise<void>;
+  cancelCapture(): void;
+  toggleRealtime(): Promise<void>;
+}
+
+export function useVoiceInput(input: {
+  getDraftKey(): string;
+  getCurrentAgent(): { connectionSlug: string; model: string } | undefined;
+  appendTranscript(draftKey: string, text: string): void;
+  sendNativeVoice(operationId: string): Promise<boolean>;
+  runCoordinatorTool(call: VoiceCoordinatorToolCall): Promise<unknown>;
+  onBlocked(reason: string): void;
+  onError(error: unknown): void;
+}): VoiceInputController {
+  const [captureState, setCaptureState] =
+    useState<ComposerVoiceCaptureState>('idle');
+  const [realtimeState, setRealtimeState] =
+    useState<ComposerRealtimeVoiceState>('idle');
+  const [providerLabel, setProviderLabel] = useState<string>();
+  const [routeKind, setRouteKind] =
+    useState<Exclude<VoiceRoutePlan['kind'], 'blocked'>>();
+  const activeCaptureRef = useRef<ActiveVoiceCapture | undefined>(undefined);
+  const operationRef = useRef<{
+    id: string;
+    draftKey: string;
+    route: Exclude<VoiceRoutePlan, { kind: 'blocked' }>;
+  } | undefined>(undefined);
+  const realtimeRef = useRef<{
+    sessionId: string;
+    peer: RTCPeerConnection;
+    stream: MediaStream;
+    audio: HTMLAudioElement;
+    channel: RTCDataChannel;
+  } | undefined>(undefined);
+  const realtimeRevisionRef = useRef(0);
+
+  useEffect(() => {
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || !operationRef.current) return;
+      event.preventDefault();
+      cancelCapture();
+    };
+    window.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      window.removeEventListener('keydown', onKeyDown, true);
+      cancelCapture();
+      closeRealtime();
+    };
+  }, []);
+
+  async function toggleCapture(options: { dictate?: boolean } = {}): Promise<void> {
+    if (captureState === 'recording') {
+      await finishCapture();
+      return;
+    }
+    if (captureState === 'native_ready') {
+      await sendNative();
+      return;
+    }
+    if (captureState !== 'idle') return;
+    setCaptureState('requesting');
+    try {
+      const begin = await window.maka.voice.begin({
+        intent: options.dictate ? 'dictate' : 'send_task',
+        ...(input.getCurrentAgent() ? { currentAgent: input.getCurrentAgent() } : {}),
+      });
+      if (!begin.ok) {
+        setCaptureState('idle');
+        input.onBlocked(begin.reason);
+        return;
+      }
+      if (begin.route.kind === 'blocked' || begin.route.kind === 'realtime_voice') {
+        await window.maka.voice.cancel(begin.operationId).catch(() => {});
+        setCaptureState('idle');
+        input.onBlocked('adapter_unsupported');
+        return;
+      }
+      operationRef.current = {
+        id: begin.operationId,
+        draftKey: input.getDraftKey(),
+        route: begin.route,
+      };
+      setProviderLabel(begin.route.target.providerLabel ?? begin.route.target.connectionSlug);
+      setRouteKind(begin.route.kind);
+      const capture = await startVoiceCapture({
+        onAutoStop: () => {
+          window.queueMicrotask(() => {
+            void finishCapture();
+          });
+        },
+      });
+      activeCaptureRef.current = capture;
+      setCaptureState('recording');
+    } catch (error) {
+      const operation = operationRef.current;
+      operationRef.current = undefined;
+      activeCaptureRef.current?.cancel();
+      activeCaptureRef.current = undefined;
+      if (operation) await window.maka.voice.cancel(operation.id).catch(() => {});
+      setCaptureState('idle');
+      input.onError(error);
+    }
+  }
+
+  async function finishCapture(): Promise<void> {
+    const operation = operationRef.current;
+    const capture = activeCaptureRef.current;
+    if (!operation || !capture) return;
+    activeCaptureRef.current = undefined;
+    setCaptureState('processing');
+    try {
+      const audio = await capture.stop();
+      const result = await window.maka.voice.finishCapture(operation.id, audio);
+      if (result.kind === 'transcript') {
+        input.appendTranscript(operation.draftKey, result.text);
+        operationRef.current = undefined;
+        setCaptureState('idle');
+        return;
+      }
+      setCaptureState('native_ready');
+    } catch (error) {
+      operationRef.current = undefined;
+      await window.maka.voice.cancel(operation.id).catch(() => {});
+      setCaptureState('idle');
+      input.onError(error);
+    }
+  }
+
+  async function sendNative(): Promise<void> {
+    const operation = operationRef.current;
+    if (!operation || operation.route.kind !== 'native_audio_task') return;
+    setCaptureState('sending');
+    try {
+      const sent = await input.sendNativeVoice(operation.id);
+      if (!sent) {
+        setCaptureState('native_ready');
+        return;
+      }
+      operationRef.current = undefined;
+      setCaptureState('idle');
+    } catch (error) {
+      setCaptureState('native_ready');
+      input.onError(error);
+    }
+  }
+
+  function cancelCapture(): void {
+    const operation = operationRef.current;
+    operationRef.current = undefined;
+    activeCaptureRef.current?.cancel();
+    activeCaptureRef.current = undefined;
+    if (operation) void window.maka.voice.cancel(operation.id).catch(() => {});
+    setCaptureState('idle');
+  }
+
+  async function toggleRealtime(): Promise<void> {
+    if (realtimeRef.current || realtimeState !== 'idle') {
+      closeRealtime();
+      return;
+    }
+    const revision = realtimeRevisionRef.current + 1;
+    realtimeRevisionRef.current = revision;
+    setRealtimeState('connecting');
+    let sessionId: string | undefined;
+    let peer: RTCPeerConnection | undefined;
+    let stream: MediaStream | undefined;
+    let audio: HTMLAudioElement | undefined;
+    try {
+      const session = await window.maka.voice.createRealtimeSession();
+      sessionId = session.sessionId;
+      if (revision !== realtimeRevisionRef.current) {
+        await window.maka.voice.closeRealtimeSession(session.sessionId);
+        return;
+      }
+      stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          channelCount: 1,
+          echoCancellation: true,
+          noiseSuppression: true,
+          autoGainControl: true,
+        },
+      });
+      peer = new RTCPeerConnection();
+      for (const track of stream.getTracks()) peer.addTrack(track, stream);
+      audio = document.createElement('audio');
+      audio.autoplay = true;
+      audio.dataset.makaVoiceAudio = 'true';
+      audio.hidden = true;
+      document.body.append(audio);
+      peer.addEventListener('track', (event) => {
+        if (audio) audio.srcObject = event.streams[0] ?? new MediaStream([event.track]);
+      });
+      const channel = peer.createDataChannel('oai-events');
+      channel.addEventListener('message', (event) => {
+        void handleRealtimeEvent(channel, event.data);
+      });
+      const offer = await peer.createOffer();
+      await peer.setLocalDescription(offer);
+      const response = await fetch(session.endpoint, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${session.clientSecret}`,
+          'Content-Type': 'application/sdp',
+          'OpenAI-Beta': 'realtime=v1',
+        },
+        body: offer.sdp ?? '',
+      });
+      if (!response.ok) throw new Error('voice_realtime_connect_failed');
+      await peer.setRemoteDescription({
+        type: 'answer',
+        sdp: await response.text(),
+      });
+      if (revision !== realtimeRevisionRef.current) {
+        peer.close();
+        stream.getTracks().forEach((track) => track.stop());
+        audio.remove();
+        await window.maka.voice.closeRealtimeSession(session.sessionId);
+        return;
+      }
+      realtimeRef.current = {
+        sessionId: session.sessionId,
+        peer,
+        stream,
+        audio,
+        channel,
+      };
+      peer.addEventListener('connectionstatechange', () => {
+        if (peer?.connectionState === 'failed' || peer?.connectionState === 'closed') {
+          closeRealtime();
+        }
+      });
+      setProviderLabel(session.providerLabel);
+      setRouteKind('realtime_voice');
+      setRealtimeState('connected');
+    } catch (error) {
+      peer?.close();
+      stream?.getTracks().forEach((track) => track.stop());
+      audio?.remove();
+      if (sessionId) await window.maka.voice.closeRealtimeSession(sessionId).catch(() => {});
+      if (revision === realtimeRevisionRef.current) setRealtimeState('idle');
+      input.onError(error);
+    }
+  }
+
+  function closeRealtime(): void {
+    realtimeRevisionRef.current += 1;
+    const active = realtimeRef.current;
+    realtimeRef.current = undefined;
+    active?.channel.close();
+    active?.peer.close();
+    active?.stream.getTracks().forEach((track) => track.stop());
+    active?.audio.remove();
+    if (active) void window.maka.voice.closeRealtimeSession(active.sessionId).catch(() => {});
+    setRealtimeState('idle');
+  }
+
+  async function handleRealtimeEvent(channel: RTCDataChannel, raw: unknown): Promise<void> {
+    if (typeof raw !== 'string') return;
+    let event: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(raw);
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return;
+      event = parsed as Record<string, unknown>;
+    } catch {
+      return;
+    }
+    if (event.type !== 'response.function_call_arguments.done') return;
+    const callId = typeof event.call_id === 'string' ? event.call_id : '';
+    const name = typeof event.name === 'string' ? event.name : '';
+    let args: unknown = {};
+    if (typeof event.arguments === 'string') {
+      try {
+        args = JSON.parse(event.arguments);
+      } catch {
+        args = {};
+      }
+    }
+    let output: unknown;
+    try {
+      const call = await window.maka.voice.validateCoordinatorToolCall({
+        name,
+        arguments: args,
+      });
+      output = await input.runCoordinatorTool(call);
+    } catch (error) {
+      output = {
+        ok: false,
+        error: error instanceof Error ? error.message : 'voice_coordinator_tool_failed',
+      };
+    }
+    if (channel.readyState !== 'open' || !callId) return;
+    channel.send(
+      JSON.stringify({
+        type: 'conversation.item.create',
+        item: {
+          type: 'function_call_output',
+          call_id: callId,
+          output: JSON.stringify(output),
+        },
+      }),
+    );
+    channel.send(JSON.stringify({ type: 'response.create' }));
+  }
+
+  return {
+    captureState,
+    realtimeState,
+    providerLabel,
+    routeKind,
+    toggleCapture,
+    cancelCapture,
+    toggleRealtime,
+  };
+}

--- a/apps/desktop/src/renderer/use-voice-input.ts
+++ b/apps/desktop/src/renderer/use-voice-input.ts
@@ -28,12 +28,25 @@ export interface VoiceInputController {
   toggleRealtime(): Promise<void>;
 }
 
+export interface VoiceCoordinatorToolContext {
+  realtimeSessionId: string;
+  taskSessionId?: string;
+}
+
+export interface VoiceCoordinatorToolExecution {
+  output: unknown;
+  taskSessionId?: string;
+}
+
 export function useVoiceInput(input: {
   getDraftKey(): string;
   getCurrentAgent(): { connectionSlug: string; model: string } | undefined;
   appendTranscript(draftKey: string, text: string): void;
   sendNativeVoice(operationId: string): Promise<boolean>;
-  runCoordinatorTool(call: VoiceCoordinatorToolCall): Promise<unknown>;
+  runCoordinatorTool(
+    call: VoiceCoordinatorToolCall,
+    context: VoiceCoordinatorToolContext,
+  ): Promise<VoiceCoordinatorToolExecution>;
   onBlocked(reason: string): void;
   onError(error: unknown): void;
 }): VoiceInputController {
@@ -44,6 +57,8 @@ export function useVoiceInput(input: {
   const [providerLabel, setProviderLabel] = useState<string>();
   const [routeKind, setRouteKind] =
     useState<Exclude<VoiceRoutePlan['kind'], 'blocked'>>();
+  const inputRef = useRef(input);
+  inputRef.current = input;
   const activeCaptureRef = useRef<ActiveVoiceCapture | undefined>(undefined);
   const operationRef = useRef<{
     id: string;
@@ -56,6 +71,7 @@ export function useVoiceInput(input: {
     stream: MediaStream;
     audio: HTMLAudioElement;
     channel: RTCDataChannel;
+    taskSessionId?: string;
   } | undefined>(undefined);
   const realtimeRevisionRef = useRef(0);
 
@@ -191,12 +207,6 @@ export function useVoiceInput(input: {
     let stream: MediaStream | undefined;
     let audio: HTMLAudioElement | undefined;
     try {
-      const session = await window.maka.voice.createRealtimeSession();
-      sessionId = session.sessionId;
-      if (revision !== realtimeRevisionRef.current) {
-        await window.maka.voice.closeRealtimeSession(session.sessionId);
-        return;
-      }
       stream = await navigator.mediaDevices.getUserMedia({
         audio: {
           channelCount: 1,
@@ -216,24 +226,22 @@ export function useVoiceInput(input: {
         if (audio) audio.srcObject = event.streams[0] ?? new MediaStream([event.track]);
       });
       const channel = peer.createDataChannel('oai-events');
-      channel.addEventListener('message', (event) => {
-        void handleRealtimeEvent(channel, event.data);
-      });
       const offer = await peer.createOffer();
       await peer.setLocalDescription(offer);
-      const response = await fetch(session.endpoint, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${session.clientSecret}`,
-          'Content-Type': 'application/sdp',
-          'OpenAI-Beta': 'realtime=v1',
-        },
-        body: offer.sdp ?? '',
+      if (revision !== realtimeRevisionRef.current) {
+        peer.close();
+        stream.getTracks().forEach((track) => track.stop());
+        audio.remove();
+        return;
+      }
+      const session = await window.maka.voice.createRealtimeSession(offer.sdp ?? '');
+      sessionId = session.sessionId;
+      channel.addEventListener('message', (event) => {
+        void handleRealtimeEvent(channel, session.sessionId, event.data);
       });
-      if (!response.ok) throw new Error('voice_realtime_connect_failed');
       await peer.setRemoteDescription({
         type: 'answer',
-        sdp: await response.text(),
+        sdp: session.answerSdp,
       });
       if (revision !== realtimeRevisionRef.current) {
         peer.close();
@@ -263,7 +271,7 @@ export function useVoiceInput(input: {
       audio?.remove();
       if (sessionId) await window.maka.voice.closeRealtimeSession(sessionId).catch(() => {});
       if (revision === realtimeRevisionRef.current) setRealtimeState('idle');
-      input.onError(error);
+      inputRef.current.onError(error);
     }
   }
 
@@ -279,7 +287,11 @@ export function useVoiceInput(input: {
     setRealtimeState('idle');
   }
 
-  async function handleRealtimeEvent(channel: RTCDataChannel, raw: unknown): Promise<void> {
+  async function handleRealtimeEvent(
+    channel: RTCDataChannel,
+    realtimeSessionId: string,
+    raw: unknown,
+  ): Promise<void> {
     if (typeof raw !== 'string') return;
     let event: Record<string, unknown>;
     try {
@@ -302,11 +314,24 @@ export function useVoiceInput(input: {
     }
     let output: unknown;
     try {
+      const active = realtimeRef.current;
+      if (!active || active.sessionId !== realtimeSessionId) return;
       const call = await window.maka.voice.validateCoordinatorToolCall({
         name,
         arguments: args,
       });
-      output = await input.runCoordinatorTool(call);
+      const execution = await inputRef.current.runCoordinatorTool(call, {
+        realtimeSessionId,
+        ...(active.taskSessionId ? { taskSessionId: active.taskSessionId } : {}),
+      });
+      const current = realtimeRef.current;
+      if (
+        execution.taskSessionId &&
+        current?.sessionId === realtimeSessionId
+      ) {
+        current.taskSessionId = execution.taskSessionId;
+      }
+      output = execution.output;
     } catch (error) {
       output = {
         ok: false,

--- a/apps/desktop/src/renderer/use-voice-input.ts
+++ b/apps/desktop/src/renderer/use-voice-input.ts
@@ -66,7 +66,7 @@ export function useVoiceInput(input: {
     route: Exclude<VoiceRoutePlan, { kind: 'blocked' }>;
   } | undefined>(undefined);
   const realtimeRef = useRef<{
-    sessionId: string;
+    sessionId?: string;
     peer: RTCPeerConnection;
     stream: MediaStream;
     audio: HTMLAudioElement;
@@ -77,9 +77,11 @@ export function useVoiceInput(input: {
 
   useEffect(() => {
     const onKeyDown = (event: KeyboardEvent) => {
-      if (event.key !== 'Escape' || !operationRef.current) return;
+      if (event.key !== 'Escape') return;
+      if (!operationRef.current && !realtimeRef.current) return;
       event.preventDefault();
-      cancelCapture();
+      if (operationRef.current) cancelCapture();
+      else closeRealtime();
     };
     window.addEventListener('keydown', onKeyDown, true);
     return () => {
@@ -129,7 +131,19 @@ export function useVoiceInput(input: {
             void finishCapture();
           });
         },
+        onError: (error) => {
+          const operation = operationRef.current;
+          operationRef.current = undefined;
+          activeCaptureRef.current = undefined;
+          if (operation) void window.maka.voice.cancel(operation.id).catch(() => {});
+          setCaptureState('idle');
+          inputRef.current.onError(error);
+        },
       });
+      if (operationRef.current?.id !== begin.operationId) {
+        capture.cancel();
+        return;
+      }
       activeCaptureRef.current = capture;
       setCaptureState('recording');
     } catch (error) {
@@ -215,6 +229,10 @@ export function useVoiceInput(input: {
           autoGainControl: true,
         },
       });
+      if (revision !== realtimeRevisionRef.current) {
+        stream.getTracks().forEach((track) => track.stop());
+        return;
+      }
       peer = new RTCPeerConnection();
       for (const track of stream.getTracks()) peer.addTrack(track, stream);
       audio = document.createElement('audio');
@@ -226,6 +244,12 @@ export function useVoiceInput(input: {
         if (audio) audio.srcObject = event.streams[0] ?? new MediaStream([event.track]);
       });
       const channel = peer.createDataChannel('oai-events');
+      realtimeRef.current = {
+        peer,
+        stream,
+        audio,
+        channel,
+      };
       const offer = await peer.createOffer();
       await peer.setLocalDescription(offer);
       if (revision !== realtimeRevisionRef.current) {
@@ -250,13 +274,12 @@ export function useVoiceInput(input: {
         await window.maka.voice.closeRealtimeSession(session.sessionId);
         return;
       }
-      realtimeRef.current = {
-        sessionId: session.sessionId,
-        peer,
-        stream,
-        audio,
-        channel,
-      };
+      const active = realtimeRef.current;
+      if (!active) {
+        await window.maka.voice.closeRealtimeSession(session.sessionId);
+        return;
+      }
+      active.sessionId = session.sessionId;
       peer.addEventListener('connectionstatechange', () => {
         if (peer?.connectionState === 'failed' || peer?.connectionState === 'closed') {
           closeRealtime();
@@ -270,8 +293,11 @@ export function useVoiceInput(input: {
       stream?.getTracks().forEach((track) => track.stop());
       audio?.remove();
       if (sessionId) await window.maka.voice.closeRealtimeSession(sessionId).catch(() => {});
-      if (revision === realtimeRevisionRef.current) setRealtimeState('idle');
-      inputRef.current.onError(error);
+      if (revision === realtimeRevisionRef.current) {
+        realtimeRef.current = undefined;
+        setRealtimeState('idle');
+        inputRef.current.onError(error);
+      }
     }
   }
 
@@ -283,7 +309,9 @@ export function useVoiceInput(input: {
     active?.peer.close();
     active?.stream.getTracks().forEach((track) => track.stop());
     active?.audio.remove();
-    if (active) void window.maka.voice.closeRealtimeSession(active.sessionId).catch(() => {});
+    if (active?.sessionId) {
+      void window.maka.voice.closeRealtimeSession(active.sessionId).catch(() => {});
+    }
     setRealtimeState('idle');
   }
 

--- a/apps/desktop/src/renderer/voice-audio-capture.ts
+++ b/apps/desktop/src/renderer/voice-audio-capture.ts
@@ -1,0 +1,199 @@
+import {
+  VOICE_MAX_AUDIO_BYTES,
+  VOICE_MAX_CAPTURE_DURATION_MS,
+  type VoiceCapturedAudio,
+} from '@maka/core';
+
+const TARGET_SAMPLE_RATE = 16_000;
+const SILENCE_RMS_THRESHOLD = 0.0005;
+
+export interface ActiveVoiceCapture {
+  stop(): Promise<VoiceCapturedAudio>;
+  cancel(): void;
+}
+
+export async function startVoiceCapture(input: {
+  maxDurationMs?: number;
+  onAutoStop?(): void;
+} = {}): Promise<ActiveVoiceCapture> {
+  if (!navigator.mediaDevices?.getUserMedia) throw new Error('voice_media_unsupported');
+  if (typeof MediaRecorder === 'undefined') throw new Error('voice_recorder_unsupported');
+  const maxDurationMs = Math.min(
+    input.maxDurationMs ?? VOICE_MAX_CAPTURE_DURATION_MS,
+    VOICE_MAX_CAPTURE_DURATION_MS,
+  );
+  const stream = await navigator.mediaDevices.getUserMedia({
+    audio: {
+      channelCount: 1,
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    },
+  });
+  const recorder = createRecorder(stream);
+  const chunks: Blob[] = [];
+  let chunkBytes = 0;
+  let settled = false;
+  let cancelled = false;
+  let rejectStopped: ((error: Error) => void) | undefined;
+  const startedAt = performance.now();
+  const stopped = new Promise<Blob>((resolve, reject) => {
+    rejectStopped = reject;
+    recorder.addEventListener('dataavailable', (event) => {
+      if (event.data.size <= 0) return;
+      chunkBytes += event.data.size;
+      if (chunkBytes > VOICE_MAX_AUDIO_BYTES) {
+        reject(new Error('voice_audio_too_large'));
+        if (recorder.state !== 'inactive') recorder.stop();
+        return;
+      }
+      chunks.push(event.data);
+    });
+    recorder.addEventListener(
+      'error',
+      () => reject(new Error('voice_recording_failed')),
+      { once: true },
+    );
+    recorder.addEventListener(
+      'stop',
+      () => {
+        if (cancelled) {
+          reject(new Error('voice_capture_cancelled'));
+          return;
+        }
+        resolve(new Blob(chunks, { type: recorder.mimeType || 'audio/webm' }));
+      },
+      { once: true },
+    );
+  });
+  recorder.start(250);
+  const timer = window.setTimeout(() => {
+    if (settled || recorder.state === 'inactive') return;
+    input.onAutoStop?.();
+    recorder.stop();
+  }, maxDurationMs);
+
+  const release = () => {
+    window.clearTimeout(timer);
+    stream.getTracks().forEach((track) => track.stop());
+  };
+
+  return {
+    async stop() {
+      if (settled) throw new Error('voice_capture_already_finished');
+      settled = true;
+      if (recorder.state !== 'inactive') recorder.stop();
+      try {
+        const blob = await stopped;
+        const durationMs = Math.max(1, Math.round(performance.now() - startedAt));
+        return await convertToMonoWav(blob, durationMs);
+      } finally {
+        release();
+      }
+    },
+    cancel() {
+      if (settled) return;
+      settled = true;
+      cancelled = true;
+      rejectStopped?.(new Error('voice_capture_cancelled'));
+      if (recorder.state !== 'inactive') recorder.stop();
+      release();
+    },
+  };
+}
+
+function createRecorder(stream: MediaStream): MediaRecorder {
+  for (const mimeType of [
+    'audio/webm;codecs=opus',
+    'audio/webm',
+    'audio/mp4',
+  ]) {
+    if (MediaRecorder.isTypeSupported(mimeType)) {
+      return new MediaRecorder(stream, { mimeType });
+    }
+  }
+  return new MediaRecorder(stream);
+}
+
+async function convertToMonoWav(
+  input: Blob,
+  measuredDurationMs: number,
+): Promise<VoiceCapturedAudio> {
+  const AudioContextConstructor =
+    window.AudioContext ??
+    (window as typeof window & { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!AudioContextConstructor || typeof OfflineAudioContext === 'undefined') {
+    throw new Error('voice_audio_conversion_unsupported');
+  }
+  const context = new AudioContextConstructor();
+  let decoded: AudioBuffer;
+  try {
+    decoded = await context.decodeAudioData(await input.arrayBuffer());
+  } finally {
+    await context.close().catch(() => {});
+  }
+  const durationMs = Math.min(
+    VOICE_MAX_CAPTURE_DURATION_MS,
+    Math.max(measuredDurationMs, Math.round(decoded.duration * 1_000)),
+  );
+  const frameCount = Math.max(1, Math.ceil((durationMs / 1_000) * TARGET_SAMPLE_RATE));
+  const offline = new OfflineAudioContext(1, frameCount, TARGET_SAMPLE_RATE);
+  const source = offline.createBufferSource();
+  source.buffer = decoded;
+  source.connect(offline.destination);
+  source.start(0);
+  const rendered = await offline.startRendering();
+  const samples = rendered.getChannelData(0);
+  if (rootMeanSquare(samples) < SILENCE_RMS_THRESHOLD) {
+    throw new Error('voice_no_speech');
+  }
+  const bytes = encodePcm16Wav(samples, TARGET_SAMPLE_RATE);
+  if (bytes.byteLength > VOICE_MAX_AUDIO_BYTES) throw new Error('voice_audio_too_large');
+  return {
+    bytes,
+    mediaType: 'audio/wav',
+    format: 'wav',
+    durationMs,
+    sampleRate: TARGET_SAMPLE_RATE,
+    channels: 1,
+  };
+}
+
+function rootMeanSquare(samples: Float32Array): number {
+  if (samples.length === 0) return 0;
+  let sum = 0;
+  for (let index = 0; index < samples.length; index += 1) {
+    const sample = samples[index] ?? 0;
+    sum += sample * sample;
+  }
+  return Math.sqrt(sum / samples.length);
+}
+
+function encodePcm16Wav(samples: Float32Array, sampleRate: number): Uint8Array {
+  const buffer = new ArrayBuffer(44 + samples.length * 2);
+  const view = new DataView(buffer);
+  writeAscii(view, 0, 'RIFF');
+  view.setUint32(4, 36 + samples.length * 2, true);
+  writeAscii(view, 8, 'WAVE');
+  writeAscii(view, 12, 'fmt ');
+  view.setUint32(16, 16, true);
+  view.setUint16(20, 1, true);
+  view.setUint16(22, 1, true);
+  view.setUint32(24, sampleRate, true);
+  view.setUint32(28, sampleRate * 2, true);
+  view.setUint16(32, 2, true);
+  view.setUint16(34, 16, true);
+  writeAscii(view, 36, 'data');
+  view.setUint32(40, samples.length * 2, true);
+  for (let index = 0; index < samples.length; index += 1) {
+    const sample = Math.max(-1, Math.min(1, samples[index] ?? 0));
+    view.setInt16(44 + index * 2, sample < 0 ? sample * 0x8000 : sample * 0x7fff, true);
+  }
+  return new Uint8Array(buffer);
+}
+
+function writeAscii(view: DataView, offset: number, value: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    view.setUint8(offset + index, value.charCodeAt(index));
+  }
+}

--- a/apps/desktop/src/renderer/voice-audio-capture.ts
+++ b/apps/desktop/src/renderer/voice-audio-capture.ts
@@ -15,6 +15,7 @@ export interface ActiveVoiceCapture {
 export async function startVoiceCapture(input: {
   maxDurationMs?: number;
   onAutoStop?(): void;
+  onError?(error: Error): void;
 } = {}): Promise<ActiveVoiceCapture> {
   if (!navigator.mediaDevices?.getUserMedia) throw new Error('voice_media_unsupported');
   if (typeof MediaRecorder === 'undefined') throw new Error('voice_recorder_unsupported');
@@ -30,28 +31,46 @@ export async function startVoiceCapture(input: {
       autoGainControl: true,
     },
   });
-  const recorder = createRecorder(stream);
+  let recorder: MediaRecorder;
+  try {
+    recorder = createRecorder(stream);
+  } catch (error) {
+    stream.getTracks().forEach((track) => track.stop());
+    throw error;
+  }
   const chunks: Blob[] = [];
   let chunkBytes = 0;
   let settled = false;
   let cancelled = false;
   let rejectStopped: ((error: Error) => void) | undefined;
+  let timer: number | undefined;
   const startedAt = performance.now();
+  const release = () => {
+    if (timer !== undefined) window.clearTimeout(timer);
+    stream.getTracks().forEach((track) => track.stop());
+  };
+  const fail = (error: Error) => {
+    rejectStopped?.(error);
+    if (settled) return;
+    settled = true;
+    if (recorder.state !== 'inactive') recorder.stop();
+    release();
+    input.onError?.(error);
+  };
   const stopped = new Promise<Blob>((resolve, reject) => {
     rejectStopped = reject;
     recorder.addEventListener('dataavailable', (event) => {
       if (event.data.size <= 0) return;
       chunkBytes += event.data.size;
       if (chunkBytes > VOICE_MAX_AUDIO_BYTES) {
-        reject(new Error('voice_audio_too_large'));
-        if (recorder.state !== 'inactive') recorder.stop();
+        fail(new Error('voice_audio_too_large'));
         return;
       }
       chunks.push(event.data);
     });
     recorder.addEventListener(
       'error',
-      () => reject(new Error('voice_recording_failed')),
+      () => fail(new Error('voice_recording_failed')),
       { once: true },
     );
     recorder.addEventListener(
@@ -66,17 +85,22 @@ export async function startVoiceCapture(input: {
       { once: true },
     );
   });
-  recorder.start(250);
-  const timer = window.setTimeout(() => {
+  // Fatal recorder events own their cleanup and UI notification. Attach a
+  // handler immediately so the promise cannot reject unobserved while the
+  // caller is still in the recording state.
+  void stopped.catch(() => {});
+  try {
+    recorder.start(250);
+  } catch (error) {
+    settled = true;
+    release();
+    throw error;
+  }
+  timer = window.setTimeout(() => {
     if (settled || recorder.state === 'inactive') return;
     input.onAutoStop?.();
     recorder.stop();
   }, maxDurationMs);
-
-  const release = () => {
-    window.clearTimeout(timer);
-    stream.getTracks().forEach((track) => track.stop());
-  };
 
   return {
     async stop() {

--- a/docs/architecture/voice-input-routing-design.zh-CN.md
+++ b/docs/architecture/voice-input-routing-design.zh-CN.md
@@ -1,0 +1,486 @@
+---
+doc_id: architecture.voice-input-routing
+title: "Voice 输入：模型能力路由与 Codex 式语音协调器"
+language: zh-CN
+implementation_status: implemented
+document_status: active
+last_verified: 2026-07-30
+owners:
+  - maka-desktop
+---
+
+# Voice 输入：模型能力路由与 Codex 式语音协调器
+
+> 本文取代原先“所有语音先经过本地 whisper.cpp”的方案。Voice 不是单一 STT
+> 功能，而是三种不同产品能力：把原始音频直接交给 Agent 模型、把语音转成
+> Composer 草稿，以及持续的实时语音协调会话。
+
+## 1. 结论
+
+Maka 应按模型能力和用户配置选择语音链路：
+
+1. **原生音频 Agent**：当前 Agent 模型和实际 provider adapter 都支持音频输入时，
+   将本次录音作为用户消息直接交给该模型，不在 Maka 前置转写。
+2. **配置式语音识别**：当前 Agent 模型不能接收音频时，调用用户显式配置的识别
+   connection/model，把结果放进 Composer 草稿，用户确认后发送。
+3. **Realtime Voice Coordinator**：提供独立的实时语音会话。语音模型负责对话、
+   打断和任务协调，实际长任务仍由 Maka Agent Runtime 执行。
+
+路由必须 fail closed：
+
+- 不使用 macOS 听写或系统 Speech Framework 作为隐式 fallback；
+- 不内置、静默下载或自动选择本地 Whisper；
+- 未配置识别模型时，不假装录音成功，直接展示可操作错误；
+- 不能仅根据 model id 猜测能力；模型声明和当前 provider wire 都必须支持；
+- 不在失败后静默切换到另一个会上传音频的 provider。
+
+三条链路在同一功能提交中交付，但保持彼此独立的运行时状态机和安全边界。
+
+## 2. 产品模式
+
+### 2.1 原生音频 Agent（Native Audio Task）
+
+适用于一次有明确起止的语音任务：
+
+```text
+按下 Composer 麦克风
+  → 录制有界音频
+  → 当前 Agent 模型能力检查
+  → 原始音频作为本次 user turn 直接发给当前模型
+  → 模型理解语音、调用现有工具并继续 Agent loop
+```
+
+该模式保留语气、停顿等转写可能损失的信息。用户停止录音并确认发送后才创建
+用户消息；Maka 不先把音频变成文字再冒充原始指令。
+
+“模型支持 audio”还不够。直接路线的最低能力是：
+
+- input modality 包含 `audio`；
+- endpoint/协议允许在 chat/agent turn 中发送 audio；
+- 支持文本输出；
+- Maka 对该 provider 的 adapter 已实现对应 wire format；
+- 若该 Agent 要工作，仍需满足现有 tool/function calling 约束；
+- 会话中持久化明确的“语音任务”标记，原始音频只在本次 operation 内存中存在。
+
+当前 request/response adapter 不保证能从原生 audio turn 取回逐字 transcript，因此不伪造
+文本投影；可审计记录使用语音任务标记，模型实际收到的仍是原始音频。
+
+### 2.2 配置式识别（Dictation/STT）
+
+适用于当前 Agent 模型不接受音频，或者用户明确选择“听写到输入框”：
+
+```text
+按下 Composer 麦克风
+  → 录制有界音频
+  → 调用已配置的 recognition connection/model
+  → 得到 transcript
+  → 追加到原会话的 Composer 草稿
+  → 用户编辑并手动发送
+```
+
+识别模型是 Voice 设置中的显式依赖，不从当前聊天模型名称推断，也不从操作系统
+能力兜底。没有配置时返回：
+
+```text
+尚未配置语音识别模型
+[前往 Voice 设置] [取消]
+```
+
+认证信息复用现有 connection 的安全存储。设置里选择的是 connection、model 和
+adapter/endpoint role，而不是任意字符串。
+
+### 2.3 Realtime Voice Coordinator
+
+这是独立产品面，不与一次性 Composer 录音混在同一个状态机里：
+
+```text
+麦克风 ⇄ Realtime Voice Model
+                 │
+                 ├─ start_task
+                 ├─ steer_task
+                 ├─ check_task
+                 └─ summarize_task
+                         │
+                  Maka Agent Runtime
+```
+
+Voice Coordinator 负责自然对话、插话、追问和播报进度；复杂任务通过受限协调工具
+交给正常 Maka Agent。任务继续遵守原 Agent 的权限、审批、工作区和会话规则。
+
+首版约束：
+
+- 同一 Maka 实例只允许一个 realtime voice session；
+- Voice 断开不取消已经启动的后台 Agent 任务；
+- Coordinator 不直接获得无限制 filesystem/shell 工具；
+- 语音会话只拿到用于启动、查询和引导任务的窄工具面；
+- Realtime 模型、输出声音和 connection 必须显式配置。
+
+## 3. Codex / ChatGPT Voice 的参考结论
+
+OpenAI 当前产品将两件事分开：
+
+- **Voice chat** 是持续的双向语音会话，可自然打断、追问，并能启动、检查和引导
+  Codex 任务；
+- **Voice dictation** 只把语音转成 Composer 中可编辑的文字。
+
+产品架构上，实时语音模型维护低延迟对话，较深的研究、推理和 Agent 工作可委派给
+另一个 frontier model。这个结构说明 Maka 不应把“听写输入”和“持续 Voice Agent”
+做成一个模糊按钮，也不应让实时模型直接接管所有长任务。
+
+API 层也有三条对应能力：
+
+- request-based audio：处理一次有界录音；
+- transcription endpoint：只返回转写文本；
+- Realtime API：维护低延迟、多轮、可调用工具的音频 session。
+
+浏览器/renderer 连接 Realtime 时优先使用 WebRTC；长期 API key 留在可信主进程，
+renderer 只获得主进程临时签发的短期 token。
+
+参考资料：
+
+- <https://learn.chatgpt.com/docs/features/voice>
+- <https://openai.com/index/introducing-gpt-live/>
+- <https://developers.openai.com/api/docs/guides/audio>
+- <https://developers.openai.com/api/docs/guides/realtime>
+- <https://developers.openai.com/api/docs/guides/realtime-webrtc>
+- <https://developers.openai.com/api/docs/guides/speech-to-text>
+
+## 4. Maka 当前实现缺口
+
+### 4.1 模型元数据丢失 audio 能力
+
+`packages/core/src/llm-connections.ts` 的 `ModelInfo.capabilities` 当前只有：
+
+```ts
+chat
+vision
+reasoning
+functionCalling
+imageGeneration
+```
+
+没有 audio input/output、transcription、realtime voice 或 endpoint role。
+
+`scripts/sync-model-metadata.mjs` 虽然读到上游 `modalities.input`，目前只把 `image`
+映射成 `vision`，会丢弃 `audio`。因此仓库里即使出现 `gpt-audio`、ASR 等 model id，
+运行时也无法可靠选路。
+
+### 4.2 Agent 协议没有明确 AudioPart
+
+`packages/runtime/src/model-protocol.ts` 的 `UserContent` 目前支持 text、image 和通用
+file。通用 file 可以装下某些音频 MIME，但不能表达：
+
+- 这是要作为模型原生音频输入，而不是普通附件；
+- provider 需要 `input_audio`、multipart transcription 或 realtime event 中的哪一种；
+- 音频格式、时长、transcript 和 retention；
+- 当前消息是否能在 tool loop 和崩溃恢复中重放。
+
+因此不能只在 UI 塞一个音频文件并期待所有 provider 自动工作。
+
+### 4.3 Voice 目前只是麦克风自检
+
+现有 Settings Voice 链路为：
+
+```text
+getUserMedia → MediaRecorder 录制约 2 秒 → 检查大小/时长 → 丢弃
+```
+
+它可继续作为硬件测试，但不能与 Composer voice route 共用“成功”语义。
+
+## 5. 能力模型
+
+### 5.1 不再增加一组松散布尔值
+
+建议把模型能力拆成三个维度：
+
+```ts
+type ModelModalities = {
+  input: Array<'text' | 'image' | 'audio'>;
+  output: Array<'text' | 'image' | 'audio'>;
+};
+
+type ModelEndpointRole =
+  | 'agent_chat'
+  | 'audio_chat'
+  | 'transcription'
+  | 'realtime_voice'
+  | 'speech_generation';
+
+type ModelTransport =
+  | 'openai_chat_audio'
+  | 'openai_audio_transcriptions'
+  | 'openai_realtime'
+  | 'provider_native';
+
+type ModelVoiceCapabilities = {
+  modalities: ModelModalities;
+  endpointRoles: ModelEndpointRole[];
+  transports: ModelTransport[];
+  transcriptOutput: boolean;
+};
+```
+
+已有 `functionCalling` 等能力保留。Voice 路由同时检查：
+
+```text
+model metadata ∩ connection/provider capability ∩ implemented adapter capability
+```
+
+三者缺一不可。
+
+### 5.2 元数据来源
+
+- 同步脚本保留上游 input/output modalities；
+- endpoint role 和 transport 不能仅凭 model id 猜，优先来自 provider discovery；
+- discovery 不完整时使用仓库内可评审的 curated override；
+- 用户自定义模型允许手动声明，但首次使用前运行 capability probe；
+- probe 失败只标记该 route 不可用，不自动换 provider。
+
+## 6. 路由器
+
+新增纯函数 `resolveVoiceRoute`，由 Core 持有决策规则：
+
+```ts
+type VoiceIntent = 'send_task' | 'dictate' | 'voice_chat';
+
+type VoiceRoutePlan =
+  | { kind: 'native_audio_task'; modelId: string; adapter: string }
+  | { kind: 'transcription_to_draft'; modelId: string; adapter: string }
+  | { kind: 'realtime_voice'; modelId: string; transport: 'webrtc' }
+  | {
+      kind: 'blocked';
+      reason:
+        | 'recognition_not_configured'
+        | 'realtime_not_configured'
+        | 'model_not_ready'
+        | 'adapter_unsupported'
+        | 'permission_denied';
+    };
+```
+
+决策顺序：
+
+```text
+intent == voice_chat
+  → 要求已配置且 adapter 已实现的 realtime voice model
+
+intent == dictate
+  → 要求已配置且 adapter 已实现的 transcription model
+
+intent == send_task
+  → 当前 Agent 模型支持 native audio 且 adapter 已实现
+      → native_audio_task
+  → 否则 recognition model 已配置且可用
+      → transcription_to_draft
+  → 否则
+      → blocked(recognition_not_configured)
+```
+
+`send_task` 走 STT fallback 后只进入草稿，不自动提交。用户需确认识别结果后再次发送。
+这是因为原始音频未到当前 Agent 模型，语义已经发生了一次转换。
+
+## 7. 设置与 Composer UX
+
+### 7.1 Voice 设置
+
+新增三个清晰分组：
+
+1. **Agent 原生音频**
+   - 使用当前会话 Agent 模型；
+   - 展示当前模型是否支持；
+   - 不另配“默认 audio model”替换 Agent。
+2. **语音识别**
+   - recognition connection；
+   - transcription model；
+   - language/keywords 等 provider 可选项；
+   - “测试识别”按钮。
+3. **Realtime Voice**
+   - realtime connection/model；
+   - 输出 voice；
+   - “测试会话”按钮。
+
+模型选择器按 endpoint role 和 adapter readiness 过滤，并解释为什么某个模型不可用。
+
+### 7.2 Composer
+
+麦克风按钮根据路由预检显示状态：
+
+- 当前模型原生支持：提示“录音将直接发送给当前 Agent 模型”；
+- 将使用识别模型：提示“录音将由 X 转写到输入框”；
+- 无可用路线：按钮仍可聚焦，但点击后展示配置错误和设置入口；
+- 不用绿色成功状态掩盖“只录了音但没有可处理模型”。
+
+录音交互：
+
+- 点击开始、点击停止；`Esc` 取消；
+- 60 秒和 16 MB 双重上限；
+- 停止后 `send_task` 原生路线展示发送确认；
+- STT 路线处理完成后按 `draftKey` 追加到原会话最新草稿；
+- 切换会话时不把结果写进新会话；
+- 所有失败都保留原有草稿。
+
+## 8. 数据协议与持久化
+
+### 8.1 明确 AudioPart
+
+扩展运行时协议：
+
+```ts
+type AudioPart = {
+  type: 'audio';
+  data: DataContent;
+  mediaType: string;
+  format: 'wav' | 'webm' | 'mp3' | 'm4a';
+  durationMs: number;
+  transcript?: string;
+  retention: 'operation_memory';
+};
+```
+
+provider adapter 负责 lowering：
+
+- audio chat adapter → provider 原生音频 content part；
+- transcription adapter → multipart audio/transcriptions 请求；
+- realtime adapter → 独立 session events，不复用普通 Agent backend。
+
+adapter 未明确实现时，通用 `FilePart` 不得自动升级成原生音频。
+
+### 8.2 原始音频生命周期
+
+默认保持现有隐私方向：
+
+- 录音前明确显示将访问的 provider；
+- 原始音频只在 renderer 和当前 operation-owned runtime 内存中存在；
+- 不写入日志、遥测、Memory、普通附件目录或长期缓存；
+- tool loop 运行期间保留音频，以便同一模型调用能重建当前 turn；
+- turn 完成、失败或取消后立即释放；
+- 只持久化 provider 返回并经过用户可见处理的 transcript 及最小元数据。
+
+原生音频模型必须能提供 transcript，或者使用同一显式配置的识别路线补齐投影。
+如果无法得到 transcript，该模型首版不标记为 Maka native audio compatible。
+
+崩溃发生在原生音频 turn 中途时，该 turn 标记为不可自动恢复；有 transcript 时允许用户
+以文字重新发送。为了恢复而静默落盘原始音频不在首版范围。
+
+### 8.3 认证边界
+
+- 长期 provider credential 只存在于现有安全 connection store；
+- 普通 request-based audio 由可信 runtime 发起；
+- Realtime WebRTC 由 main 使用长期 key 请求 ephemeral token；
+- renderer 永远不获得长期 API key；
+- IPC 校验 origin、窗口、operation id、MIME、字节数和时长。
+
+## 9. Adapter 设计
+
+### 9.1 `NativeAudioAdapter`
+
+```ts
+interface NativeAudioAdapter {
+  supports(model: ModelInfo, connection: ConnectionInfo): boolean;
+  lower(part: AudioPart): ProviderContentPart;
+}
+```
+
+首个实现可针对 OpenAI-compatible audio chat，但必须按实际 endpoint 验证，不能认为
+所有 OpenAI-compatible 服务都接受同样的 audio content part。
+
+### 9.2 `VoiceRecognitionAdapter`
+
+```ts
+interface VoiceRecognitionAdapter {
+  probe(connection: ConnectionInfo, model: ModelInfo): Promise<Readiness>;
+  transcribe(input: BoundedAudio, signal: AbortSignal): Promise<Transcript>;
+}
+```
+
+当前实现支持标准 `/v1/audio/transcriptions` 风格：
+
+- multipart/form-data；
+- base URL、API key、headers 来自 connection；
+- model 来自 Voice 设置；
+- 强制 timeout、响应体上限和 transcript schema 校验；
+- 不记录音频、authorization header 或完整 provider 错误体；
+- 支持语言和 prompt/keywords，但不把它们写死为 OpenAI 专属字段。
+
+本地识别将来可以作为一种显式安装的 adapter，而不是默认行为。
+
+### 9.3 `RealtimeVoiceAdapter`
+
+独立于普通 request backend：
+
+- main 创建 session/ephemeral token；
+- renderer 用 WebRTC 传音频和接收音频；
+- data channel 承载 transcript、tool call、interruption 和 session state；
+- Coordinator tool call 经 main 校验后映射到 Maka 内部任务 API；
+- 断线、重新连接、barge-in 和单 session 互斥由独立状态机负责。
+
+## 10. 安全与失败语义
+
+- 麦克风权限仍只允许可信主窗口顶层 renderer 请求 audio；
+- 任何 route 在开始录音前完成 provider/模型预检；
+- 明确展示音频会发给哪个 provider；
+- route 选定后固定到 operation，录音途中改设置不改变目标；
+- provider 失败后不自动改发另一 provider；
+- 取消会终止录音、网络请求、tool loop 起点和 realtime session；
+- 服务端 401/403 映射为 connection 配置错误；
+- 404/unsupported 映射为 adapter/model 不兼容；
+- 413/客户端超限映射为录音过长；
+- 429/5xx 可重试，但重试前再次提示会重新上传同一段音频；
+- 错误日志只保留 route、模型匿名标识、阶段和结构化错误码。
+
+## 11. 一次性交付范围
+
+本实现一次完成以下能力：
+
+- 模型 modalities、endpoint roles、transports、curated metadata 和 adapter readiness；
+- `resolveVoiceRoute` 的 native / STT / Realtime 三路 fail-closed 路由；
+- Composer 有界录音、无声检测、16 kHz 单声道 WAV、`draftKey` 归属和取消状态机；
+- 标准 OpenAI-compatible `/v1/audio/transcriptions` 识别到可编辑草稿；
+- `AudioPart` 从 Core/Runtime 贯穿到 provider adapter 边界，原生音频直接进入 Agent loop；
+- Voice 设置中的 recognition 和 realtime connection/model 配置及真实识别自检；
+- main 侧 Realtime ephemeral token broker、renderer WebRTC/data channel；
+- `start_task/steer_task/check_task/summarize_task` 四个窄协调工具；
+- 单 Realtime session 互斥、operation 过期与一次性消费、长期密钥不出 main；
+- 路由、模型边界、音频 lowering、STT multipart、Realtime secret 和 lease 测试。
+
+验收语义：支持音频的 Agent 模型收到原始音频；不支持时只使用显式配置的 STT；
+未配置立即报错；Realtime 长任务仍由普通 Maka Runtime 和原权限边界执行。
+
+## 12. 测试矩阵
+
+必须覆盖：
+
+- 模型 metadata 声称 audio、adapter 不支持 → blocked；
+- adapter 支持、模型 metadata 不支持 → blocked；
+- native agent audio 完整成功路径；
+- native route 无 transcript → 保存语音任务标记，不伪造文本；
+- Agent 不支持 audio + STT 已配置 → transcript 到草稿；
+- Agent 不支持 audio + STT 未配置 → 设置错误；
+- 用户明确选择 dictate，即使 Agent 支持 audio 也走 STT；
+- route 固定后修改设置不改变上传目标；
+- 录音中取消、上传中取消、tool loop 开始前取消；
+- 60 秒、16 MB、无声音、非法 MIME；
+- 401、403、404、413、429、5xx 和 timeout；
+- 转写期间切会话、编辑原草稿、删除会话；
+- provider 失败不静默 fallback；
+- raw audio 不进入日志、遥测、Memory 和附件；
+- Realtime renderer 不获得长期 API key；
+- Voice Coordinator 只能调用任务协调工具；
+- 同一实例第二个 realtime session 被拒绝。
+
+## 13. 暂不做
+
+- macOS 系统听写或 Speech Framework fallback；
+- 默认 whisper.cpp、本地模型下载和打包；
+- 常驻监听、唤醒词、后台偷录；
+- STT 完成后自动提交；
+- 模型 id 字符串启发式选路；
+- 未实现 adapter 的通用 audio file 自动发送；
+- 默认保存原始录音或提供录音历史；
+- Realtime Coordinator 直接拥有不受限 shell/filesystem 权限。
+
+## 14. 已采用的产品取舍
+
+原生音频 turn 的 raw audio 仅在本次 operation 内存中保留，完成后只保存明确的语音
+任务标记；中途崩溃不自动恢复。加密保存原始音频未采用，因为它会改变
+`persistAudio: false` 隐私契约，并引入独立保留期、删除和用户 consent 设计。

--- a/packages/core/src/__tests__/voice.test.ts
+++ b/packages/core/src/__tests__/voice.test.ts
@@ -6,9 +6,14 @@ import {
   VOICE_MAX_CAPTURE_DURATION_MS,
   defaultVoiceCapabilitySnapshot,
   defaultVoicePrivacyFlags,
+  defaultVoiceSettings,
+  normalizeVoiceCoordinatorToolCall,
   normalizeVoiceInputMode,
+  normalizeVoiceSettings,
   normalizeVoiceTranscriptText,
   normalizeVoiceTtsPolicy,
+  resolveVoiceRoute,
+  type VoiceModelRouteCapability,
   validateVoiceCaptureRequest,
   validateVoiceTranscriptResult,
   validateVoiceTtsRequest,
@@ -121,6 +126,132 @@ describe('voice capture validation', () => {
   it('accepts a bounded push-to-talk capture request', () => {
     const result = validateVoiceCaptureRequest(validCapture);
     assert.equal(result.ok, true);
+  });
+
+  it('rejects zero and negative duration/byte values', () => {
+    assert.equal(validateVoiceCaptureRequest({ ...validCapture, durationMs: 0 }).ok, false);
+    assert.equal(validateVoiceCaptureRequest({ ...validCapture, durationMs: -1 }).ok, false);
+    assert.equal(validateVoiceCaptureRequest({ ...validCapture, audioBytes: 0 }).ok, false);
+    assert.equal(validateVoiceCaptureRequest({ ...validCapture, audioBytes: -1 }).ok, false);
+  });
+});
+
+describe('voice route resolver', () => {
+  const capability = (
+    kind: 'native' | 'transcription' | 'realtime',
+  ): VoiceModelRouteCapability => ({
+    connectionSlug: 'openai',
+    modelId:
+      kind === 'native'
+        ? 'gpt-audio'
+        : kind === 'transcription'
+          ? 'gpt-4o-mini-transcribe'
+          : 'gpt-realtime',
+    modalities:
+      kind === 'transcription'
+        ? { input: ['audio'], output: ['text'] }
+        : { input: ['text', 'audio'], output: ['text', 'audio'] },
+    endpointRoles: [
+      kind === 'native'
+        ? 'audio_chat'
+        : kind === 'transcription'
+          ? 'transcription'
+          : 'realtime_voice',
+    ],
+    transports: [
+      kind === 'native'
+        ? 'openai_chat_audio'
+        : kind === 'transcription'
+          ? 'openai_audio_transcriptions'
+          : 'openai_realtime',
+    ],
+    transcriptOutput: kind === 'native',
+    adapterReady: true,
+  });
+
+  it('sends raw audio to a capable current agent before considering STT', () => {
+    const result = resolveVoiceRoute({
+      intent: 'send_task',
+      currentAgent: capability('native'),
+      recognition: capability('transcription'),
+    });
+    assert.equal(result.kind, 'native_audio_task');
+    assert.equal(result.kind === 'native_audio_task' && result.transcriptProjection, 'marker_only');
+  });
+
+  it('routes dictation and unsupported agent models through configured STT', () => {
+    assert.equal(
+      resolveVoiceRoute({
+        intent: 'dictate',
+        currentAgent: capability('native'),
+        recognition: capability('transcription'),
+      }).kind,
+      'transcription_to_draft',
+    );
+    assert.equal(
+      resolveVoiceRoute({
+        intent: 'send_task',
+        recognition: capability('transcription'),
+      }).kind,
+      'transcription_to_draft',
+    );
+  });
+
+  it('fails closed without explicit recognition or realtime configuration', () => {
+    assert.deepEqual(resolveVoiceRoute({ intent: 'dictate' }), {
+      kind: 'blocked',
+      reason: 'recognition_not_configured',
+    });
+    assert.deepEqual(resolveVoiceRoute({ intent: 'voice_chat' }), {
+      kind: 'blocked',
+      reason: 'realtime_not_configured',
+    });
+  });
+
+  it('requires a ready transport adapter instead of trusting modality alone', () => {
+    const native = capability('native');
+    native.adapterReady = false;
+    assert.deepEqual(resolveVoiceRoute({ intent: 'send_task', currentAgent: native }), {
+      kind: 'blocked',
+      reason: 'recognition_not_configured',
+    });
+    const realtime = capability('realtime');
+    realtime.adapterReady = false;
+    assert.deepEqual(resolveVoiceRoute({ intent: 'voice_chat', realtime }), {
+      kind: 'blocked',
+      reason: 'adapter_unsupported',
+    });
+  });
+});
+
+describe('voice settings and coordinator input', () => {
+  it('normalizes bounded voice settings and preserves safe defaults', () => {
+    assert.deepEqual(normalizeVoiceSettings(undefined), defaultVoiceSettings());
+    const normalized = normalizeVoiceSettings({
+      recognition: { connectionSlug: ' openai ', model: ' transcribe ', language: ' zh ' },
+      realtime: { connectionSlug: ' openai ', model: ' realtime ', voice: '' },
+    });
+    assert.equal(normalized.recognition.connectionSlug, 'openai');
+    assert.equal(normalized.recognition.model, 'transcribe');
+    assert.equal(normalized.recognition.language, 'zh');
+    assert.equal(normalized.realtime.voice, 'marin');
+  });
+
+  it('accepts only the four narrow coordinator tools with bounded arguments', () => {
+    assert.deepEqual(
+      normalizeVoiceCoordinatorToolCall({
+        name: 'start_task',
+        arguments: { task: '  inspect the repository  ' },
+      }),
+      { name: 'start_task', arguments: { task: 'inspect the repository' } },
+    );
+    assert.throws(() =>
+      normalizeVoiceCoordinatorToolCall({
+        name: 'run_shell',
+        arguments: { command: 'rm -rf /' },
+      }),
+    );
+    assert.throws(() => normalizeVoiceCoordinatorToolCall({ name: 'steer_task', arguments: {} }));
   });
 });
 

--- a/packages/core/src/backend-types.ts
+++ b/packages/core/src/backend-types.ts
@@ -22,6 +22,7 @@ import type { StoredMessage, BackendKind } from './session.js';
 import type { UserQuestionResponse } from './user-question.js';
 import type { ContextBudgetDiagnostic } from './usage-stats/types.js';
 import type { EffectiveOrchestration } from './orchestration.js';
+import type { EphemeralVoiceAudio } from './voice.js';
 
 export interface RuntimeContinuationMetadata {
   sourceInvocationId: string;
@@ -46,6 +47,12 @@ export interface BackendSendInput {
    */
   headAnchorRuntimeEvent?: RuntimeEvent;
   text: string;
+  /**
+   * Operation-owned raw audio for the current turn. It is deliberately absent
+   * from MessageContent/RuntimeEvent/StoredMessage so no persistence or replay
+   * path can retain the bytes.
+   */
+  voiceAudio?: EphemeralVoiceAudio;
   attachments?: AttachmentRef[];
   /** Inline quoted excerpts folded into the model-facing user content. */
   quotes?: QuoteRef[];

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1219,6 +1219,22 @@ export type {
   VoiceTtsPolicy,
   VoiceTtsProvider,
   VoiceTtsRequest,
+  VoiceIntent,
+  VoiceAudioFormat,
+  EphemeralVoiceAudio,
+  VoiceModelRouteCapability,
+  VoiceRecognitionConfig,
+  VoiceRealtimeConfig,
+  VoiceSettings,
+  VoiceRoutePlan,
+  ResolveVoiceRouteInput,
+  VoiceBeginRequest,
+  VoiceBeginResult,
+  VoiceCapturedAudio,
+  VoiceFinishCaptureResult,
+  VoiceRealtimeClientSession,
+  VoiceCoordinatorToolName,
+  VoiceCoordinatorToolCall,
 } from './voice.js';
 export {
   VOICE_MAX_AUDIO_BYTES,
@@ -1230,6 +1246,10 @@ export {
   defaultVoiceCapabilitySnapshot,
   defaultVoiceCaptureCaps,
   defaultVoicePrivacyFlags,
+  defaultVoiceSettings,
+  normalizeVoiceSettings,
+  resolveVoiceRoute,
+  normalizeVoiceCoordinatorToolCall,
   normalizeVoiceInputMode,
   normalizeVoiceTranscriptText,
   normalizeVoiceTtsPolicy,
@@ -1412,7 +1432,7 @@ export {
 } from './model-catalog.js';
 
 // model-metadata.ts
-export { resolveModelVisionSupport } from './model-metadata.js';
+export { resolveModelVisionSupport, resolveModelVoiceMetadata } from './model-metadata.js';
 
 // settings.ts
 export type {

--- a/packages/core/src/llm-connections.ts
+++ b/packages/core/src/llm-connections.ts
@@ -57,6 +57,23 @@ export interface ModelInfo {
     functionCalling?: boolean;
     imageGeneration?: boolean;
   };
+  /**
+   * Voice is transport-sensitive: an `audio` modality alone does not prove
+   * that the configured provider wire can carry it. These fields are kept
+   * separate from the legacy chat capability booleans so routing can require
+   * metadata, endpoint role, and an implemented adapter at the same time.
+   */
+  modalities?: {
+    input: Array<'text' | 'image' | 'audio'>;
+    output: Array<'text' | 'image' | 'audio'>;
+  };
+  endpointRoles?: Array<
+    'agent_chat' | 'audio_chat' | 'transcription' | 'realtime_voice' | 'speech_generation'
+  >;
+  transports?: Array<
+    'openai_chat_audio' | 'openai_audio_transcriptions' | 'openai_realtime' | 'provider_native'
+  >;
+  transcriptOutput?: boolean;
 }
 
 export type ModelDiscoverySource = 'fetched' | 'fallback';

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -12,6 +12,10 @@ export interface ModelMetadata {
   contextWindow?: number;
   maxOutputTokens?: number;
   capabilities?: ModelInfo['capabilities'];
+  modalities?: ModelInfo['modalities'];
+  endpointRoles?: ModelInfo['endpointRoles'];
+  transports?: ModelInfo['transports'];
+  transcriptOutput?: boolean;
   /**
    * Per-model reasoning controls, mirroring models.dev `reasoning_options`.
    * Omitted on models with no declarable thinking knob (miss → no menu).
@@ -38,6 +42,10 @@ export function lookupModelMetadata(providerType: ProviderType, modelId: string)
     ...generated,
     ...override,
     capabilities: { ...generated.capabilities, ...override.capabilities },
+    modalities: override.modalities ?? generated.modalities,
+    endpointRoles: override.endpointRoles ?? generated.endpointRoles,
+    transports: override.transports ?? generated.transports,
+    transcriptOutput: override.transcriptOutput ?? generated.transcriptOutput,
   };
 }
 
@@ -144,7 +152,70 @@ const GOOGLE_MODEL_OVERRIDES: Record<string, ModelMetadata> = {
 const OPENAI_MODEL_OVERRIDES: Record<string, ModelMetadata> = {
   'gpt-5.5': { thinkingOptions: { efforts: ['none', 'low', 'medium', 'high', 'xhigh'] } },
   'gpt-5': { thinkingOptions: { efforts: ['minimal', 'low', 'medium', 'high'] } },
+  'gpt-audio': openAiAudioChatModel(),
+  'gpt-audio-mini': openAiAudioChatModel(),
+  'gpt-4o-audio-preview': openAiAudioChatModel(),
+  'gpt-4o-mini-audio-preview': openAiAudioChatModel(),
+  'gpt-4o-transcribe': openAiTranscriptionModel(),
+  'gpt-4o-mini-transcribe': openAiTranscriptionModel(),
+  'gpt-4o-mini-transcribe-2025-12-15': openAiTranscriptionModel(),
+  'whisper-1': openAiTranscriptionModel(),
+  'gpt-realtime': openAiRealtimeModel(),
+  'gpt-realtime-mini': openAiRealtimeModel(),
+  'gpt-realtime-1.5': openAiRealtimeModel(),
+  'gpt-realtime-2': openAiRealtimeModel(),
+  'gpt-realtime-2.1': openAiRealtimeModel(),
 };
+
+function openAiAudioChatModel(): ModelMetadata {
+  return {
+    modalities: { input: ['text', 'audio'], output: ['text', 'audio'] },
+    endpointRoles: ['agent_chat', 'audio_chat'],
+    transports: ['openai_chat_audio'],
+    transcriptOutput: true,
+  };
+}
+
+function openAiTranscriptionModel(): ModelMetadata {
+  return {
+    modalities: { input: ['audio'], output: ['text'] },
+    endpointRoles: ['transcription'],
+    transports: ['openai_audio_transcriptions'],
+    transcriptOutput: true,
+  };
+}
+
+function openAiRealtimeModel(): ModelMetadata {
+  return {
+    modalities: { input: ['text', 'audio'], output: ['text', 'audio'] },
+    endpointRoles: ['realtime_voice'],
+    transports: ['openai_realtime'],
+    transcriptOutput: true,
+  };
+}
+
+export function resolveModelVoiceMetadata(
+  providerType: ProviderType,
+  models: readonly ModelInfo[] | undefined,
+  modelId: string,
+): Pick<ModelInfo, 'modalities' | 'endpointRoles' | 'transports' | 'transcriptOutput'> {
+  const stored = models?.find((entry) => entry.id === modelId);
+  const metadata = lookupModelMetadata(providerType, modelId);
+  return {
+    ...((stored?.modalities ?? metadata.modalities)
+      ? { modalities: stored?.modalities ?? metadata.modalities }
+      : {}),
+    ...((stored?.endpointRoles ?? metadata.endpointRoles)
+      ? { endpointRoles: stored?.endpointRoles ?? metadata.endpointRoles }
+      : {}),
+    ...((stored?.transports ?? metadata.transports)
+      ? { transports: stored?.transports ?? metadata.transports }
+      : {}),
+    ...((stored?.transcriptOutput ?? metadata.transcriptOutput)
+      ? { transcriptOutput: stored?.transcriptOutput ?? metadata.transcriptOutput }
+      : {}),
+  };
+}
 
 const OPENAI_OAUTH_MODEL_METADATA: Record<string, ModelMetadata> = {
   'gpt-5.6-sol': {

--- a/packages/core/src/runtime-inputs.ts
+++ b/packages/core/src/runtime-inputs.ts
@@ -17,6 +17,7 @@ import type { CollaborationMode } from './collaboration.js';
 import type { OrchestrationMode, TurnOrchestration } from './orchestration.js';
 import type { SessionStartMode } from './explore-agent.js';
 import type { SubagentWorkspaceBinding } from './subagent-workspace.js';
+import type { EphemeralVoiceAudio } from './voice.js';
 
 export type { TurnOrchestration } from './orchestration.js';
 
@@ -77,6 +78,8 @@ export interface UserMessageInput extends MessageContent {
   /** Caller-generated uuid. Same id used in the UserMessage.turnId and in
    *  every event emitted by this turn. */
   turnId: string;
+  /** Raw audio exists only for the live operation and is never persisted. */
+  voiceAudio?: EphemeralVoiceAudio;
   /** Trusted host-supplied orchestration override for this turn only. */
   turnOrchestration?: TurnOrchestration;
   parentRunId?: string;

--- a/packages/core/src/settings.ts
+++ b/packages/core/src/settings.ts
@@ -20,6 +20,7 @@ import {
   isUiLocalePreference,
   type UiLocalePreference,
 } from './ui-locale.js';
+import { defaultVoiceSettings, normalizeVoiceSettings, type VoiceSettings } from './voice.js';
 
 export { UI_LOCALE_PREFERENCES, isUiLocalePreference } from './ui-locale.js';
 export type { UiLocalePreference } from './ui-locale.js';
@@ -303,6 +304,7 @@ export interface AppSettings {
   chatDefaults: ChatDefaultsSettings;
   notifications: NotificationSettings;
   system: SystemSettings;
+  voice: VoiceSettings;
 }
 
 export interface UsageRequestLog {
@@ -380,6 +382,10 @@ export type UpdateAppSettingsInput = Partial<{
   chatDefaults: Partial<ChatDefaultsSettings>;
   notifications: Partial<NotificationSettings>;
   system: Partial<SystemSettings>;
+  voice: Partial<{
+    recognition: Partial<VoiceSettings['recognition']>;
+    realtime: Partial<VoiceSettings['realtime']>;
+  }>;
   webSearch: WebSearchSettingsPatch;
 }>;
 
@@ -463,6 +469,7 @@ export function createDefaultSettings(): AppSettings {
       // battery-affecting opt-in, not a silent default.
       keepSystemAwake: false,
     },
+    voice: defaultVoiceSettings(),
   };
 }
 
@@ -523,6 +530,16 @@ export function mergeSettings(current: AppSettings, patch: UpdateAppSettingsInpu
       ...current.system,
       ...(patch.system ?? {}),
     },
+    voice: normalizeVoiceSettings({
+      recognition: {
+        ...current.voice.recognition,
+        ...(patch.voice?.recognition ?? {}),
+      },
+      realtime: {
+        ...current.voice.realtime,
+        ...(patch.voice?.realtime ?? {}),
+      },
+    }),
     webSearch: mergeWebSearchSettings(current.webSearch, patch.webSearch),
   };
 }
@@ -545,6 +562,7 @@ export function normalizeSettings(input: unknown): AppSettings {
     chatDefaults: value.chatDefaults,
     notifications: value.notifications,
     system: value.system,
+    voice: value.voice,
   });
   // PR110b: milestones bypass the generic patch surface so we can
   // sanitize them with the closed-enum + at-most-one validator on
@@ -621,6 +639,7 @@ export function normalizeSettings(input: unknown): AppSettings {
       keepSystemAwake:
         typeof base.system.keepSystemAwake === 'boolean' ? base.system.keepSystemAwake : false,
     },
+    voice: normalizeVoiceSettings(base.voice),
   };
 }
 

--- a/packages/core/src/voice.ts
+++ b/packages/core/src/voice.ts
@@ -163,8 +163,7 @@ export type VoiceFinishCaptureResult =
 
 export interface VoiceRealtimeClientSession {
   sessionId: string;
-  clientSecret: string;
-  endpoint: string;
+  answerSdp: string;
   model: string;
   providerLabel: string;
   expiresAt?: number;

--- a/packages/core/src/voice.ts
+++ b/packages/core/src/voice.ts
@@ -43,6 +43,147 @@ export type VoiceReadinessReason =
   | 'raw_audio_persistence_forbidden'
   | 'telemetry_forbidden';
 
+export type VoiceIntent = 'send_task' | 'dictate' | 'voice_chat';
+
+export type VoiceAudioFormat = 'wav' | 'webm' | 'mp3' | 'm4a';
+
+export interface EphemeralVoiceAudio {
+  bytes: Uint8Array;
+  mediaType: string;
+  format: VoiceAudioFormat;
+  durationMs: number;
+  sampleRate: number;
+  channels: number;
+  transcript?: string;
+  retention: 'operation_memory';
+}
+
+export interface VoiceModelRouteCapability {
+  connectionSlug: string;
+  modelId: string;
+  providerLabel?: string;
+  modalities: {
+    input: Array<'text' | 'image' | 'audio'>;
+    output: Array<'text' | 'image' | 'audio'>;
+  };
+  endpointRoles: Array<
+    'agent_chat' | 'audio_chat' | 'transcription' | 'realtime_voice' | 'speech_generation'
+  >;
+  transports: Array<
+    'openai_chat_audio' | 'openai_audio_transcriptions' | 'openai_realtime' | 'provider_native'
+  >;
+  transcriptOutput: boolean;
+  adapterReady: boolean;
+}
+
+export interface VoiceRecognitionConfig {
+  connectionSlug: string;
+  model: string;
+  language: string;
+  prompt: string;
+}
+
+export interface VoiceRealtimeConfig {
+  connectionSlug: string;
+  model: string;
+  voice: string;
+}
+
+export interface VoiceSettings {
+  recognition: VoiceRecognitionConfig;
+  realtime: VoiceRealtimeConfig;
+}
+
+export type VoiceRoutePlan =
+  | {
+      kind: 'native_audio_task';
+      target: VoiceModelRouteCapability;
+      transcriptProjection: 'provider' | 'configured_recognition' | 'marker_only';
+    }
+  | { kind: 'transcription_to_draft'; target: VoiceModelRouteCapability }
+  | { kind: 'realtime_voice'; target: VoiceModelRouteCapability; transport: 'webrtc' }
+  | {
+      kind: 'blocked';
+      reason:
+        | 'recognition_not_configured'
+        | 'realtime_not_configured'
+        | 'model_not_ready'
+        | 'adapter_unsupported'
+        | 'permission_denied';
+    };
+
+export interface ResolveVoiceRouteInput {
+  intent: VoiceIntent;
+  currentAgent?: VoiceModelRouteCapability;
+  recognition?: VoiceModelRouteCapability;
+  realtime?: VoiceModelRouteCapability;
+}
+
+export interface VoiceBeginRequest {
+  intent: VoiceIntent;
+  currentAgent?: {
+    connectionSlug: string;
+    model: string;
+  };
+}
+
+export type VoiceBeginResult =
+  | {
+      ok: true;
+      operationId: string;
+      route: VoiceRoutePlan;
+      expiresAt: number;
+    }
+  | {
+      ok: false;
+      reason: Extract<VoiceRoutePlan, { kind: 'blocked' }>['reason'];
+    };
+
+export interface VoiceCapturedAudio {
+  bytes: Uint8Array;
+  mediaType: string;
+  format: VoiceAudioFormat;
+  durationMs: number;
+  sampleRate: number;
+  channels: number;
+}
+
+export type VoiceFinishCaptureResult =
+  | {
+      kind: 'transcript';
+      operationId: string;
+      text: string;
+      providerLabel: string;
+    }
+  | {
+      kind: 'native_audio_ready';
+      operationId: string;
+      providerLabel: string;
+    };
+
+export interface VoiceRealtimeClientSession {
+  sessionId: string;
+  clientSecret: string;
+  endpoint: string;
+  model: string;
+  providerLabel: string;
+  expiresAt?: number;
+}
+
+export type VoiceCoordinatorToolName =
+  | 'start_task'
+  | 'steer_task'
+  | 'check_task'
+  | 'summarize_task';
+
+export interface VoiceCoordinatorToolCall {
+  name: VoiceCoordinatorToolName;
+  arguments: {
+    task?: string;
+    guidance?: string;
+  };
+}
+
 export interface VoiceCaptureCaps {
   maxDurationMs: number;
   maxAudioBytes: number;
@@ -147,6 +288,128 @@ export function defaultVoicePrivacyFlags(): VoicePrivacyFlags {
   };
 }
 
+export function defaultVoiceSettings(): VoiceSettings {
+  return {
+    recognition: {
+      connectionSlug: '',
+      model: '',
+      language: '',
+      prompt: '',
+    },
+    realtime: {
+      connectionSlug: '',
+      model: '',
+      voice: 'marin',
+    },
+  };
+}
+
+export function normalizeVoiceSettings(input: unknown): VoiceSettings {
+  const defaults = defaultVoiceSettings();
+  if (!input || typeof input !== 'object' || Array.isArray(input)) return defaults;
+  const value = input as {
+    recognition?: unknown;
+    realtime?: unknown;
+  };
+  const recognition =
+    value.recognition && typeof value.recognition === 'object' && !Array.isArray(value.recognition)
+      ? (value.recognition as Record<string, unknown>)
+      : {};
+  const realtime =
+    value.realtime && typeof value.realtime === 'object' && !Array.isArray(value.realtime)
+      ? (value.realtime as Record<string, unknown>)
+      : {};
+  return {
+    recognition: {
+      connectionSlug: boundedSettingString(recognition.connectionSlug, 64),
+      model: boundedSettingString(recognition.model, 256),
+      language: boundedSettingString(recognition.language, 32),
+      prompt: boundedSettingString(recognition.prompt, 1_000),
+    },
+    realtime: {
+      connectionSlug: boundedSettingString(realtime.connectionSlug, 64),
+      model: boundedSettingString(realtime.model, 256),
+      voice: boundedSettingString(realtime.voice, 64) || defaults.realtime.voice,
+    },
+  };
+}
+
+export function resolveVoiceRoute(input: ResolveVoiceRouteInput): VoiceRoutePlan {
+  if (input.intent === 'voice_chat') {
+    if (!input.realtime) return { kind: 'blocked', reason: 'realtime_not_configured' };
+    if (!hasEndpoint(input.realtime, 'realtime_voice')) {
+      return { kind: 'blocked', reason: 'model_not_ready' };
+    }
+    if (!hasTransport(input.realtime, 'openai_realtime') || !input.realtime.adapterReady) {
+      return { kind: 'blocked', reason: 'adapter_unsupported' };
+    }
+    return { kind: 'realtime_voice', target: input.realtime, transport: 'webrtc' };
+  }
+
+  if (input.intent === 'send_task' && input.currentAgent) {
+    const native = input.currentAgent;
+    if (
+      native.modalities.input.includes('audio') &&
+      native.modalities.output.includes('text') &&
+      hasEndpoint(native, 'audio_chat') &&
+      hasTransport(native, 'openai_chat_audio') &&
+      native.adapterReady
+    ) {
+      return {
+        kind: 'native_audio_task',
+        target: native,
+        transcriptProjection: 'marker_only',
+      };
+    }
+  }
+
+  if (!input.recognition) return { kind: 'blocked', reason: 'recognition_not_configured' };
+  if (!hasEndpoint(input.recognition, 'transcription')) {
+    return { kind: 'blocked', reason: 'model_not_ready' };
+  }
+  if (
+    !hasTransport(input.recognition, 'openai_audio_transcriptions') ||
+    !input.recognition.adapterReady
+  ) {
+    return { kind: 'blocked', reason: 'adapter_unsupported' };
+  }
+  return { kind: 'transcription_to_draft', target: input.recognition };
+}
+
+export function normalizeVoiceCoordinatorToolCall(input: unknown): VoiceCoordinatorToolCall {
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    throw new Error('Invalid voice coordinator tool call');
+  }
+  const value = input as { name?: unknown; arguments?: unknown };
+  if (
+    value.name !== 'start_task' &&
+    value.name !== 'steer_task' &&
+    value.name !== 'check_task' &&
+    value.name !== 'summarize_task'
+  ) {
+    throw new Error('Unsupported voice coordinator tool');
+  }
+  const args =
+    value.arguments && typeof value.arguments === 'object' && !Array.isArray(value.arguments)
+      ? (value.arguments as Record<string, unknown>)
+      : {};
+  const task = boundedCoordinatorText(args.task);
+  const guidance = boundedCoordinatorText(args.guidance);
+  if (value.name === 'start_task' && !task) {
+    throw new Error('Voice start_task requires a task');
+  }
+  if (value.name === 'steer_task' && !guidance) {
+    throw new Error('Voice steer_task requires guidance');
+  }
+  return {
+    name: value.name,
+    arguments: {
+      ...(task ? { task } : {}),
+      ...(guidance ? { guidance } : {}),
+    },
+  };
+}
+
 export function normalizeVoiceInputMode(input: unknown): VoiceNormalizeResult<VoiceInputMode> {
   if (input === undefined || input === null || input === '') {
     return { ok: true, value: 'off' };
@@ -231,7 +494,7 @@ export function validateVoiceCaptureRequest(
     'Capture duration must be a finite number',
   );
   if (!duration.ok) return duration;
-  if (duration.value > VOICE_MAX_CAPTURE_DURATION_MS) {
+  if (duration.value <= 0 || duration.value > VOICE_MAX_CAPTURE_DURATION_MS) {
     return {
       ok: false,
       reason: 'duration_exceeded',
@@ -245,7 +508,7 @@ export function validateVoiceCaptureRequest(
     'Audio size must be a finite number',
   );
   if (!bytes.ok) return bytes;
-  if (bytes.value > VOICE_MAX_AUDIO_BYTES) {
+  if (bytes.value <= 0 || bytes.value > VOICE_MAX_AUDIO_BYTES) {
     return {
       ok: false,
       reason: 'audio_too_large',
@@ -450,4 +713,33 @@ function finiteNumber(
     return { ok: false, reason, error };
   }
   return { ok: true, value: input };
+}
+
+function hasEndpoint(
+  capability: VoiceModelRouteCapability,
+  endpoint: VoiceModelRouteCapability['endpointRoles'][number],
+): boolean {
+  return capability.endpointRoles.includes(endpoint);
+}
+
+function hasTransport(
+  capability: VoiceModelRouteCapability,
+  transport: VoiceModelRouteCapability['transports'][number],
+): boolean {
+  return capability.transports.includes(transport);
+}
+
+function boundedSettingString(input: unknown, maxLength: number): string {
+  if (typeof input !== 'string') return '';
+  return input.replace(CONTROL_CHARS_REGEX, '').trim().slice(0, maxLength);
+}
+
+function boundedCoordinatorText(input: unknown): string {
+  if (typeof input !== 'string') return '';
+  const text = input
+    .normalize('NFC')
+    .replace(CONTROL_CHARS_REGEX, ' ')
+    .replace(WHITESPACE_REGEX, ' ')
+    .trim();
+  return Array.from(text).slice(0, VOICE_MAX_TRANSCRIPT_CHARS).join('');
 }

--- a/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
+++ b/packages/runtime/src/__tests__/ai-sdk-backend.test.ts
@@ -77,6 +77,61 @@ import type {
 import { createTestAiSdkBackend } from './execution-boundary-test-helpers.js';
 
 describe('AiSdkBackend model history', () => {
+  test('preserves operation-owned audio through the durable request path and redacts its capture', async () => {
+    const model = completionModel();
+    const captures: ProviderRequestCaptureRecord[] = [];
+    const durable = durableTurnHarness('turn-voice', 'follow the attached audio');
+    const backend = createTestAiSdkBackend({
+      sessionId: 'session-1',
+      header: header(),
+      appendMessage: async () => {},
+      connection: connection(),
+      apiKey: 'sk-test',
+      modelId: 'mock-model-id',
+      modelFactory: () => model,
+      tools: [],
+      loadTurnRuntimeEvents: durable.loadTurnRuntimeEvents,
+      recordProviderRequestCapture: async (capture) => {
+        captures.push(capture);
+        return { artifactId: 'artifact-voice-capture' };
+      },
+      newId: idGenerator(),
+      now: monotonicClock(),
+    });
+
+    await drainDurably(
+      backend.send(
+        durable.input({
+          voiceAudio: {
+            bytes: new Uint8Array([222, 173, 190, 239]),
+            mediaType: 'audio/wav',
+            format: 'wav',
+            durationMs: 500,
+            sampleRate: 16_000,
+            channels: 1,
+            retention: 'operation_memory',
+          },
+        }),
+      ),
+      durable,
+    );
+
+    const providerPrompt = model.doStreamCalls[0]?.prompt ?? [];
+    const currentUser = providerPrompt.find((message) => message.role === 'user');
+    assert.ok(currentUser && Array.isArray(currentUser.content));
+    const audioFile = currentUser.content.find(
+      (part) => part.type === 'file' && part.filename === 'voice-input.wav',
+    );
+    assert.ok(audioFile, 'the durable first provider call must retain native audio');
+    assert.equal(audioFile.type, 'file');
+    if (audioFile.type !== 'file') return;
+    assert.equal(audioFile.mediaType, 'audio/wav');
+
+    assert.equal(captures.length, 1);
+    assert.match(captures[0]!.serializedRequest, /\[redacted:operation-memory-audio\]/);
+    assert.doesNotMatch(captures[0]!.serializedRequest, /3q2\+7w==|"222"/);
+  });
+
   test('exposes one active sandbox snapshot to the model and durable run trace', async () => {
     const model = completionModel();
     const traces: RunTraceEvent[] = [];

--- a/packages/runtime/src/__tests__/model-adapter.test.ts
+++ b/packages/runtime/src/__tests__/model-adapter.test.ts
@@ -2,10 +2,47 @@ import assert from 'node:assert/strict';
 import { describe, test } from 'node:test';
 import { RetryError } from 'ai';
 
-import { ModelAdapter, normalizeAiSdkUsage } from '../model-adapter.js';
+import { ModelAdapter, lowerNativeAudioMessages, normalizeAiSdkUsage } from '../model-adapter.js';
 import type { ModelStreamEvent } from '../model-protocol.js';
 
 describe('ModelAdapter stream and error normalization', () => {
+  test('lowers explicit audio only at the provider boundary without copying bytes', () => {
+    const bytes = new Uint8Array([1, 2, 3]);
+    const [message] = lowerNativeAudioMessages([
+      {
+        role: 'user',
+        content: [
+          { type: 'text', text: 'follow the voice request' },
+          {
+            type: 'audio',
+            data: bytes,
+            mediaType: 'audio/wav',
+            format: 'wav',
+            durationMs: 500,
+            retention: 'operation_memory',
+          },
+        ],
+      },
+    ]);
+    assert.equal(message?.role, 'user');
+    assert.notEqual(typeof message?.content, 'string');
+    if (!message || message.role !== 'user' || typeof message.content === 'string') return;
+    const file = message.content.find((part) => part.type === 'file');
+    assert.equal(file?.type, 'file');
+    if (
+      file?.type !== 'file' ||
+      typeof file.data !== 'object' ||
+      file.data === null ||
+      !('type' in file.data) ||
+      file.data.type !== 'data'
+    ) {
+      return;
+    }
+    assert.equal(file.data.data, bytes);
+    assert.equal(file.mediaType, 'audio/wav');
+    assert.equal(file.filename, 'voice-input.wav');
+  });
+
   test('resolves optional-key LocalAI without fabricating a credential', () => {
     const model = {};
     let observedApiKey: string | undefined;

--- a/packages/runtime/src/agent-flow.ts
+++ b/packages/runtime/src/agent-flow.ts
@@ -37,6 +37,7 @@ import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { RuntimeContinuationMetadata } from '@maka/core/backend-types';
 import type { EffectiveOrchestration } from '@maka/core/orchestration';
 import type { InvocationContext } from './invocation-context.js';
+import type { EphemeralVoiceAudio } from '@maka/core/voice';
 
 export type { InvocationContext } from './invocation-context.js';
 
@@ -61,6 +62,8 @@ export interface FlowInput {
   orchestration?: EffectiveOrchestration;
   /** User turn text. */
   text: string;
+  /** Operation-owned raw audio, valid only for this live flow. */
+  voiceAudio?: EphemeralVoiceAudio;
   /** Optional attachments bound to the user message. */
   attachments?: AttachmentRef[];
   /** Optional inline quoted excerpts bound to the user message. */

--- a/packages/runtime/src/agent-run.ts
+++ b/packages/runtime/src/agent-run.ts
@@ -409,6 +409,7 @@ export class AgentRun {
         turnId: this.turnId,
         orchestration: this.effectiveOrchestration,
         text: this.input.userInput.text,
+        ...(this.input.userInput.voiceAudio ? { voiceAudio: this.input.userInput.voiceAudio } : {}),
         ...(this.input.userInput.attachments
           ? { attachments: this.input.userInput.attachments }
           : {}),

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -57,6 +57,7 @@ import type { AgentSpec } from '@maka/core/runtime-inputs';
 import type { RuntimeEvent } from '@maka/core/runtime-event';
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
 import type { UserQuestionResponse } from '@maka/core/user-question';
+import type { EphemeralVoiceAudio } from '@maka/core/voice';
 import {
   resolveEffectiveOrchestration,
   type EffectiveOrchestration,
@@ -918,6 +919,7 @@ export class AiSdkBackend implements AgentBackend {
           ? undefined
           : await this.buildCurrentUserContent(
               input.text,
+              input.voiceAudio,
               input.attachments,
               input.quotes,
               input.headAnchorRuntimeEvent?.id,
@@ -2775,11 +2777,12 @@ export class AiSdkBackend implements AgentBackend {
 
   private async buildCurrentUserContent(
     text: string,
+    voiceAudio?: EphemeralVoiceAudio,
     attachments?: AttachmentRef[],
     quotes?: QuoteRef[],
     runtimeEventId?: string,
   ): Promise<UserContent> {
-    return this.appendImageParts(
+    const content = await this.appendImageParts(
       formatTextWithInlineRefs(text, {
         ...(attachments !== undefined ? { attachments } : {}),
         ...(quotes !== undefined ? { quotes } : {}),
@@ -2787,6 +2790,19 @@ export class AiSdkBackend implements AgentBackend {
       attachments,
       runtimeEventId === undefined ? undefined : `runtime-event:${runtimeEventId}`,
     );
+    if (!voiceAudio) return content;
+    const parts: Exclude<UserContent, string> =
+      typeof content === 'string' ? [{ type: 'text', text: content }] : [...content];
+    parts.push({
+      type: 'audio',
+      data: voiceAudio.bytes,
+      mediaType: voiceAudio.mediaType,
+      format: voiceAudio.format,
+      durationMs: voiceAudio.durationMs,
+      ...(voiceAudio.transcript ? { transcript: voiceAudio.transcript } : {}),
+      retention: 'operation_memory',
+    });
+    return parts;
   }
 
   private async resolveSystemPrompt(turnId: string): Promise<string | undefined> {

--- a/packages/runtime/src/ai-sdk-backend.ts
+++ b/packages/runtime/src/ai-sdk-backend.ts
@@ -75,6 +75,7 @@ import type {
 } from '@maka/core/usage-stats/types';
 import type { ContextBudgetDiagnostic, PromptSegmentEstimate } from '@maka/core/usage-stats/types';
 import type {
+  AudioPart,
   JSONValue,
   ModelFinishReason,
   ModelMessage,
@@ -959,26 +960,35 @@ export class AiSdkBackend implements AgentBackend {
           }
           const anchorEventId = input.headAnchorRuntimeEvent?.id;
           let decoratedCurrentUser = false;
+          let currentUserOrdinal = -1;
+          let userOrdinal = 0;
           const replayItems = replayPlan.items.map((item) => {
+            if (item.kind !== 'text' || item.role !== 'user') {
+              return item;
+            }
+            const ordinal = userOrdinal++;
             if (
-              item.kind !== 'text' ||
-              item.role !== 'user' ||
-              (anchorEventId !== undefined ? item.eventId !== anchorEventId : decoratedCurrentUser)
+              anchorEventId !== undefined ? item.eventId !== anchorEventId : decoratedCurrentUser
             ) {
               return item;
             }
             decoratedCurrentUser = true;
+            currentUserOrdinal = ordinal;
             return {
               ...item,
               content: this.appendTurnTailPrompt(item.content, turnTailPrompt) as string,
             };
           });
+          const currentTurnMessages = await this.materializeRuntimeReplayPlan(
+            { ...replayPlan, items: replayItems },
+            settledModelOutputs,
+          );
+          const operationAudio = input.voiceAudio ? voiceAudioPart(input.voiceAudio) : undefined;
           return [
             ...priorReplay.messages,
-            ...(await this.materializeRuntimeReplayPlan(
-              { ...replayPlan, items: replayItems },
-              settledModelOutputs,
-            )),
+            ...(operationAudio && currentUserOrdinal >= 0
+              ? attachAudioToUserOrdinal(currentTurnMessages, currentUserOrdinal, operationAudio)
+              : currentTurnMessages),
           ];
         };
         const activeCompactionHeadAnchor =
@@ -2793,15 +2803,7 @@ export class AiSdkBackend implements AgentBackend {
     if (!voiceAudio) return content;
     const parts: Exclude<UserContent, string> =
       typeof content === 'string' ? [{ type: 'text', text: content }] : [...content];
-    parts.push({
-      type: 'audio',
-      data: voiceAudio.bytes,
-      mediaType: voiceAudio.mediaType,
-      format: voiceAudio.format,
-      durationMs: voiceAudio.durationMs,
-      ...(voiceAudio.transcript ? { transcript: voiceAudio.transcript } : {}),
-      retention: 'operation_memory',
-    });
+    parts.push(voiceAudioPart(voiceAudio));
     return parts;
   }
 
@@ -3104,6 +3106,36 @@ function sumOptionalCounts<K extends keyof ActiveToolResultPruneDiagnosticPatch>
 ): Pick<ActiveToolResultPruneDiagnosticPatch, K> | Record<string, never> {
   const total = (left[key] ?? 0) + (right[key] ?? 0);
   return total > 0 ? ({ [key]: total } as Pick<ActiveToolResultPruneDiagnosticPatch, K>) : {};
+}
+
+function voiceAudioPart(voiceAudio: EphemeralVoiceAudio): AudioPart {
+  return {
+    type: 'audio',
+    data: voiceAudio.bytes,
+    mediaType: voiceAudio.mediaType,
+    format: voiceAudio.format,
+    durationMs: voiceAudio.durationMs,
+    ...(voiceAudio.transcript ? { transcript: voiceAudio.transcript } : {}),
+    retention: 'operation_memory',
+  };
+}
+
+function attachAudioToUserOrdinal(
+  messages: readonly ModelMessage[],
+  targetOrdinal: number,
+  audio: AudioPart,
+): ModelMessage[] {
+  let userOrdinal = 0;
+  return messages.map((message) => {
+    if (message.role !== 'user') return message;
+    const ordinal = userOrdinal++;
+    if (ordinal !== targetOrdinal) return message;
+    const content =
+      typeof message.content === 'string'
+        ? [{ type: 'text' as const, text: message.content }, audio]
+        : [...message.content.filter((part) => part.type !== 'audio'), audio];
+    return { ...message, content };
+  });
 }
 
 function contextBudgetWithActiveProjectionDiagnostics(

--- a/packages/runtime/src/ai-sdk-flow.ts
+++ b/packages/runtime/src/ai-sdk-flow.ts
@@ -672,6 +672,7 @@ export class AiSdkFlow implements AgentFlow, AgentFlowControl {
           ? { headAnchorRuntimeEvent: ctx.request.initialRuntimeEvent }
           : {}),
         text: input.text,
+        ...(input.voiceAudio !== undefined ? { voiceAudio: input.voiceAudio } : {}),
         ...(input.attachments !== undefined ? { attachments: input.attachments } : {}),
         ...(input.quotes !== undefined ? { quotes: input.quotes } : {}),
         context: input.context,

--- a/packages/runtime/src/invocation-context.ts
+++ b/packages/runtime/src/invocation-context.ts
@@ -18,6 +18,7 @@ import type { RuntimeEvent, RuntimeEventStatus } from '@maka/core/runtime-event'
 import type { StoredMessage } from '@maka/core/session';
 import type { RuntimeContinuationMetadata } from '@maka/core/backend-types';
 import type { EffectiveOrchestration } from '@maka/core/orchestration';
+import type { EphemeralVoiceAudio } from '@maka/core/voice';
 
 // ============================================================================
 // InvocationSource
@@ -80,6 +81,8 @@ export interface InvocationRequest {
   /** Trusted effective orchestration snapshot for this invocation. */
   orchestration?: EffectiveOrchestration;
   text: string;
+  /** Operation-owned raw audio, excluded from every durable projection. */
+  voiceAudio?: EphemeralVoiceAudio;
   /** Optional attachments bound to this user turn. */
   attachments?: AttachmentRef[];
   /** Optional inline quoted excerpts bound to this user turn. */

--- a/packages/runtime/src/model-adapter.ts
+++ b/packages/runtime/src/model-adapter.ts
@@ -191,7 +191,7 @@ export class ModelAdapter {
     );
     const sdkResult = streamText({
       model: trackedModel,
-      messages: input.messages,
+      messages: lowerNativeAudioMessages(input.messages),
       tools: schemaOnlyTools,
       activeTools: input.activeTools,
       repairToolCall: input.repairToolCall,
@@ -344,6 +344,31 @@ export class ModelAdapter {
         return 'end_turn';
     }
   }
+}
+
+/**
+ * AI SDK exposes native audio through its file content part. Keep Maka's
+ * explicit AudioPart until the one adapter boundary, then lower it without
+ * copying the bytes or allowing ordinary file attachments to opt into audio.
+ */
+export function lowerNativeAudioMessages(messages: readonly ModelMessage[]): ModelMessage[] {
+  return messages.map((message) => {
+    if (message.role !== 'user' || typeof message.content === 'string') return message;
+    if (!message.content.some((part) => part.type === 'audio')) return message;
+    return {
+      ...message,
+      content: message.content.map((part) =>
+        part.type === 'audio'
+          ? {
+              type: 'file' as const,
+              data: { type: 'data' as const, data: part.data },
+              filename: `voice-input.${part.format}`,
+              mediaType: part.mediaType,
+            }
+          : part,
+      ),
+    };
+  });
 }
 
 function selectedModelMaxOutputTokens(

--- a/packages/runtime/src/model-protocol.ts
+++ b/packages/runtime/src/model-protocol.ts
@@ -102,6 +102,21 @@ export interface FilePart {
   providerOptions?: ProviderOptions;
 }
 
+/**
+ * Explicit native-audio intent. ModelAdapter lowers this only for a route that
+ * was admitted by the voice capability router; a generic FilePart is never
+ * promoted into audio by MIME sniffing.
+ */
+export interface AudioPart {
+  type: 'audio';
+  data: DataContent;
+  mediaType: string;
+  format: 'wav' | 'webm' | 'mp3' | 'm4a';
+  durationMs: number;
+  transcript?: string;
+  retention: 'operation_memory';
+}
+
 export interface ReasoningPart {
   type: 'reasoning';
   text: string;
@@ -263,7 +278,7 @@ export type AssistantContent =
       | ToolResultPart
       | ToolApprovalRequest
     >;
-export type UserContent = string | Array<TextPart | ImagePart | FilePart>;
+export type UserContent = string | Array<TextPart | ImagePart | FilePart | AudioPart>;
 export type ToolContent = Array<ToolResultPart | ToolApprovalResponse>;
 
 export interface SystemModelMessage {

--- a/packages/runtime/src/provider-request-telemetry.ts
+++ b/packages/runtime/src/provider-request-telemetry.ts
@@ -355,7 +355,8 @@ function preparedCapture(
   modelId: string,
   params: Record<string, unknown>,
 ): PreparedProviderRequestCapture {
-  const prompt = Array.isArray(params.prompt) ? params.prompt : [];
+  const safeParams = secretFreeParams(params);
+  const prompt = Array.isArray(safeParams.prompt) ? safeParams.prompt : [];
   const instructions: unknown[] = [];
   const messages: unknown[] = [];
   for (const item of prompt) {
@@ -363,8 +364,8 @@ function preparedCapture(
     if (record?.role === 'system') instructions.push(record.content);
     else messages.push(item);
   }
-  const tools = Array.isArray(params.tools) ? params.tools : [];
-  const providerOptions = asRecord(params.providerOptions);
+  const tools = Array.isArray(safeParams.tools) ? safeParams.tools : [];
+  const providerOptions = asRecord(safeParams.providerOptions);
   return capturePreparedProviderRequest({
     providerId,
     modelId,
@@ -372,13 +373,34 @@ function preparedCapture(
     messages,
     tools,
     ...(providerOptions ? { providerOptions } : {}),
-    requestPayload: secretFreeParams(params),
+    requestPayload: safeParams,
   });
 }
 
 function secretFreeParams(params: Record<string, unknown>): Record<string, unknown> {
   const { abortSignal: _abortSignal, headers: _headers, ...safe } = params;
-  return safe;
+  return redactOperationMemoryAudio(safe) as Record<string, unknown>;
+}
+
+const OPERATION_MEMORY_AUDIO_REDACTION = '[redacted:operation-memory-audio]';
+
+function redactOperationMemoryAudio(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(redactOperationMemoryAudio);
+  const record = asRecord(value);
+  if (!record) return value;
+  if (
+    typeof record.filename === 'string' &&
+    record.filename.startsWith('voice-input.') &&
+    typeof record.mediaType === 'string' &&
+    record.mediaType.startsWith('audio/') &&
+    'data' in record
+  ) {
+    return { ...record, data: OPERATION_MEMORY_AUDIO_REDACTION };
+  }
+  if (ArrayBuffer.isView(value)) return value;
+  return Object.fromEntries(
+    Object.entries(record).map(([key, entry]) => [key, redactOperationMemoryAudio(entry)]),
+  );
 }
 
 function abortStatus(signal: AbortSignal | undefined, error: unknown): 'failed' | 'aborted' {

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -1371,6 +1371,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
           ? { orchestration: begin.backendInput.orchestration }
           : {}),
         text: input.text,
+        ...(input.voiceAudio ? { voiceAudio: input.voiceAudio } : {}),
         ...(begin.backendInput.attachments ? { attachments: begin.backendInput.attachments } : {}),
         ...(begin.backendInput.quotes ? { quotes: begin.backendInput.quotes } : {}),
         context: begin.backendInput.context,

--- a/packages/runtime/src/runtime-runner.ts
+++ b/packages/runtime/src/runtime-runner.ts
@@ -193,6 +193,7 @@ export class RuntimeRunner {
       }
       if (
         request.text.length > 0 ||
+        request.voiceAudio !== undefined ||
         request.attachments !== undefined ||
         request.quotes !== undefined
       ) {
@@ -533,6 +534,7 @@ function buildFlowInput(request: InvocationRequest): FlowInput {
     ...(request.lineage?.parentRunId ? { parentRunId: request.lineage.parentRunId } : {}),
     ...(request.orchestration !== undefined ? { orchestration: request.orchestration } : {}),
     text: request.text,
+    ...(request.voiceAudio !== undefined ? { voiceAudio: request.voiceAudio } : {}),
     context: request.context ?? [],
     ...(request.runtimeContext !== undefined ? { runtimeContext: request.runtimeContext } : {}),
     ...(continuation !== undefined ? { continuation } : {}),

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -1087,13 +1087,17 @@ export const Composer = forwardRef<
                     type="button"
                     className="maka-composer-realtime-voice-button"
                     data-state={props.realtimeVoiceState ?? 'idle'}
-                    disabled={props.disabled || props.realtimeVoiceState === 'connecting'}
+                    disabled={props.disabled}
                     aria-label={
-                      props.realtimeVoiceState === 'connected'
+                      props.realtimeVoiceState !== 'idle'
                         ? copy.voiceRealtimeStop
                         : copy.voiceRealtimeStart
                     }
-                    title={copy.voiceRealtimeStart}
+                    title={
+                      props.realtimeVoiceState !== 'idle'
+                        ? copy.voiceRealtimeStop
+                        : copy.voiceRealtimeStart
+                    }
                     onClick={() => {
                       void props.onToggleRealtimeVoice?.();
                     }}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -11,7 +11,7 @@ import {
   type ReactNode,
 } from 'react';
 import { useMountedRef } from './use-mounted-ref.js';
-import { ArrowUp, Blocks, Paperclip, Pencil, Plus, X } from './icons.js';
+import { ArrowUp, Blocks, Mic, Paperclip, Pencil, Plus, Volume2, X } from './icons.js';
 import { ChatModelSwitcher, ModelChipStatic, NewChatModelPicker } from './chat-model-switcher.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
@@ -65,6 +65,8 @@ export interface ComposerHandle {
   clearDraft(draftKey: string): void;
   /** Write a specific session draft before navigation changes the active key. */
   setDraft(draftKey: string, text: string): void;
+  /** Append to a specific session draft without replacing newer text. */
+  appendDraft?(draftKey: string, text: string): void;
   /** Replace structured Skills under an explicit session draft key. */
   setSkillDraft(
     draftKey: string,
@@ -223,6 +225,12 @@ export const Composer = forwardRef<
     graphModePending?: boolean;
     graphModeDisabledReason?: string;
     onGraphModeChange?(active: boolean): void | Promise<void>;
+    voiceCaptureState?: 'idle' | 'requesting' | 'recording' | 'processing' | 'native_ready' | 'sending';
+    realtimeVoiceState?: 'idle' | 'connecting' | 'connected';
+    voiceProviderLabel?: string;
+    onToggleVoiceCapture?(input?: { dictate?: boolean }): void | Promise<void>;
+    onCancelVoiceCapture?(): void;
+    onToggleRealtimeVoice?(): void | Promise<void>;
     /**
      * Composer mention popups. Both are optional and the whole feature no-ops
      * when absent (SSR contracts render Composer with minimal props):
@@ -254,7 +262,14 @@ export const Composer = forwardRef<
   // (issue #1044). `resetPromptHistoryNavigation` is a hoisted wrapper so the
   // draft hook's swap effect can reset history navigation even though the
   // history hook is created one line below it.
-  const { hasDraftText, saveCurrentDraft, clearDraft, setDraft, activeDraftKey } = useComposerDraft({
+  const {
+    hasDraftText,
+    saveCurrentDraft,
+    clearDraft,
+    setDraft,
+    appendDraft,
+    activeDraftKey,
+  } = useComposerDraft({
     textareaRef,
     draftKey: props.draftKey,
     autoResize,
@@ -360,6 +375,16 @@ export const Composer = forwardRef<
         if (!el) return;
         resetPromptHistoryNavigation();
         el.value = text;
+        autoResize();
+        focusTextInputAtEnd(el);
+      },
+      appendDraft(draftKey: string, text: string) {
+        const next = appendDraft(draftKey, text);
+        if (activeDraftKey() !== draftKey) return;
+        const el = textareaRef.current;
+        if (!el) return;
+        resetPromptHistoryNavigation();
+        el.value = next;
         autoResize();
         focusTextInputAtEnd(el);
       },
@@ -469,6 +494,15 @@ export const Composer = forwardRef<
         closeMention();
         return;
       }
+    }
+    if (
+      event.key === 'Escape' &&
+      props.voiceCaptureState &&
+      props.voiceCaptureState !== 'idle'
+    ) {
+      event.preventDefault();
+      props.onCancelVoiceCapture?.();
+      return;
     }
     if (
       event.key === 'Backspace' &&
@@ -982,6 +1016,20 @@ export const Composer = forwardRef<
                 <span className="maka-composer-permission-dot" aria-hidden="true" />
                 {copy.awaitingPermission}
               </span>
+            ) : props.voiceCaptureState === 'recording' ? (
+              copy.voiceRecording
+            ) : props.voiceCaptureState === 'requesting' ? (
+              copy.voiceRequesting
+            ) : props.voiceCaptureState === 'processing' ? (
+              copy.voiceProcessing
+            ) : props.voiceCaptureState === 'native_ready' ? (
+              copy.voiceReady
+            ) : props.voiceCaptureState === 'sending' ? (
+              copy.voiceSending
+            ) : props.realtimeVoiceState === 'connecting' ? (
+              copy.voiceConnecting
+            ) : props.realtimeVoiceState === 'connected' ? (
+              copy.voiceConnected
             ) : sendPending ? (
               copy.sending
             ) : importActionBusy ? (
@@ -1002,6 +1050,57 @@ export const Composer = forwardRef<
           <div className="maka-composer-right-controls">
             {!props.streaming && (
               <>
+                {props.onToggleVoiceCapture ? (
+                  <UiButton
+                    variant="quiet"
+                    size="icon-sm"
+                    shape="pill"
+                    type="button"
+                    className="maka-composer-voice-button"
+                    data-state={props.voiceCaptureState ?? 'idle'}
+                    disabled={
+                      props.disabled ||
+                      props.voiceCaptureState === 'requesting' ||
+                      props.voiceCaptureState === 'processing' ||
+                      props.voiceCaptureState === 'sending'
+                    }
+                    aria-label={
+                      props.voiceCaptureState === 'recording'
+                        ? copy.voiceStopRecording
+                        : props.voiceCaptureState === 'native_ready'
+                          ? copy.voiceSend
+                          : copy.voiceStart
+                    }
+                    title={`${copy.voiceStart}${props.voiceProviderLabel ? ` · ${props.voiceProviderLabel}` : ''}`}
+                    onClick={(event) => {
+                      void props.onToggleVoiceCapture?.({ dictate: event.shiftKey });
+                    }}
+                  >
+                    <Mic size={15} aria-hidden="true" />
+                  </UiButton>
+                ) : null}
+                {props.onToggleRealtimeVoice ? (
+                  <UiButton
+                    variant="quiet"
+                    size="icon-sm"
+                    shape="pill"
+                    type="button"
+                    className="maka-composer-realtime-voice-button"
+                    data-state={props.realtimeVoiceState ?? 'idle'}
+                    disabled={props.disabled || props.realtimeVoiceState === 'connecting'}
+                    aria-label={
+                      props.realtimeVoiceState === 'connected'
+                        ? copy.voiceRealtimeStop
+                        : copy.voiceRealtimeStart
+                    }
+                    title={copy.voiceRealtimeStart}
+                    onClick={() => {
+                      void props.onToggleRealtimeVoice?.();
+                    }}
+                  >
+                    <Volume2 size={15} aria-hidden="true" />
+                  </UiButton>
+                ) : null}
                 {props.activeSession ? (
                   <ChatModelSwitcher
                     activeSession={props.activeSession}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -308,6 +308,14 @@ export const Composer = forwardRef<
   // PR-UI-15: locale-aware copy for placeholder + toolbar states. We
   const locale = useUiLocale();
   const copy = getConversationCopy(locale).composer;
+  const voiceCaptureLabel = props.voiceCaptureState === 'recording'
+    ? copy.voiceStopRecording
+    : props.voiceCaptureState === 'native_ready'
+      ? copy.voiceSend
+      : copy.voiceStart;
+  const realtimeVoiceLabel = props.realtimeVoiceState !== 'idle'
+    ? copy.voiceRealtimeStop
+    : copy.voiceRealtimeStart;
 
   useEffect(() => {
     return () => {
@@ -1051,59 +1059,41 @@ export const Composer = forwardRef<
             {!props.streaming && (
               <>
                 {props.onToggleVoiceCapture ? (
-                  <UiButton
-                    variant="quiet"
-                    size="icon-sm"
-                    shape="pill"
+                  <IconButton
+                    variant="ghost"
+                    size="sm"
                     type="button"
                     className="maka-composer-voice-button"
                     data-state={props.voiceCaptureState ?? 'idle'}
-                    disabled={
+                    isDisabled={
                       props.disabled ||
                       props.voiceCaptureState === 'requesting' ||
                       props.voiceCaptureState === 'processing' ||
                       props.voiceCaptureState === 'sending'
                     }
-                    aria-label={
-                      props.voiceCaptureState === 'recording'
-                        ? copy.voiceStopRecording
-                        : props.voiceCaptureState === 'native_ready'
-                          ? copy.voiceSend
-                          : copy.voiceStart
-                    }
-                    title={`${copy.voiceStart}${props.voiceProviderLabel ? ` · ${props.voiceProviderLabel}` : ''}`}
+                    label={voiceCaptureLabel}
+                    tooltip={`${voiceCaptureLabel}${props.voiceProviderLabel ? ` · ${props.voiceProviderLabel}` : ''}`}
                     onClick={(event) => {
                       void props.onToggleVoiceCapture?.({ dictate: event.shiftKey });
                     }}
-                  >
-                    <Mic size={15} aria-hidden="true" />
-                  </UiButton>
+                    icon={<Mic size={15} aria-hidden="true" />}
+                  />
                 ) : null}
                 {props.onToggleRealtimeVoice ? (
-                  <UiButton
-                    variant="quiet"
-                    size="icon-sm"
-                    shape="pill"
+                  <IconButton
+                    variant="ghost"
+                    size="sm"
                     type="button"
                     className="maka-composer-realtime-voice-button"
                     data-state={props.realtimeVoiceState ?? 'idle'}
-                    disabled={props.disabled}
-                    aria-label={
-                      props.realtimeVoiceState !== 'idle'
-                        ? copy.voiceRealtimeStop
-                        : copy.voiceRealtimeStart
-                    }
-                    title={
-                      props.realtimeVoiceState !== 'idle'
-                        ? copy.voiceRealtimeStop
-                        : copy.voiceRealtimeStart
-                    }
+                    isDisabled={props.disabled}
+                    label={realtimeVoiceLabel}
+                    tooltip={realtimeVoiceLabel}
                     onClick={() => {
                       void props.onToggleRealtimeVoice?.();
                     }}
-                  >
-                    <Volume2 size={15} aria-hidden="true" />
-                  </UiButton>
+                    icon={<Volume2 size={15} aria-hidden="true" />}
+                  />
                 ) : null}
                 {props.activeSession ? (
                   <ChatModelSwitcher

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -98,6 +98,18 @@ export interface ConversationCopy {
     noModelAction: string;
     /** Explanatory title on the disabled Send button in the no-model state. */
     noModelSendTitle: string;
+    voiceStart: string;
+    voiceStopRecording: string;
+    voiceSend: string;
+    voiceRecording: string;
+    voiceRequesting: string;
+    voiceProcessing: string;
+    voiceReady: string;
+    voiceSending: string;
+    voiceRealtimeStart: string;
+    voiceRealtimeStop: string;
+    voiceConnecting: string;
+    voiceConnected: string;
   };
   model: {
     thinkingLevel: string;
@@ -320,6 +332,11 @@ const CONVERSATION_COPY = {
       graphModeLabel: 'Graph', enableGraphMode: '开启 Graph Mode', disableGraphMode: '退出 Graph Mode',
       graphModeOnTitle: 'Graph 模式已启用，点击关闭',
       noModelHint: '还没有可用的模型连接，无法发送。', noModelAction: '前往模型设置', noModelSendTitle: '先添加一个模型连接才能发送。',
+      voiceStart: '语音输入（Shift 点击强制转写）', voiceStopRecording: '停止录音', voiceSend: '发送语音任务',
+      voiceRecording: '正在录音，点击麦克风结束 · Esc 取消', voiceRequesting: '正在准备语音模型…', voiceProcessing: '正在处理语音…',
+      voiceReady: '语音已就绪，再次点击发送', voiceSending: '正在发送语音任务…',
+      voiceRealtimeStart: '开始实时语音协作', voiceRealtimeStop: '结束实时语音协作',
+      voiceConnecting: '正在连接实时语音…', voiceConnected: '实时语音已连接',
     },
     model: {
       thinkingLevel: '思考级别', thinkingUnsupported: '当前模型不支持思考级别切换', changeThinkingLevel: '切换当前模型的思考级别', defaultLevel: '默认',
@@ -456,6 +473,11 @@ const CONVERSATION_COPY = {
       graphModeLabel: 'Graph', enableGraphMode: 'Enable Graph Mode', disableGraphMode: 'Disable Graph Mode',
       graphModeOnTitle: 'Graph mode is on — click to turn off',
       noModelHint: 'No model connection yet, so sending is unavailable.', noModelAction: 'Go to model settings', noModelSendTitle: 'Add a model connection before sending.',
+      voiceStart: 'Voice input (Shift-click to force transcription)', voiceStopRecording: 'Stop recording', voiceSend: 'Send voice task',
+      voiceRecording: 'Recording; click the microphone to stop · Esc to cancel', voiceRequesting: 'Preparing the voice model…', voiceProcessing: 'Processing voice…',
+      voiceReady: 'Voice is ready; click again to send', voiceSending: 'Sending voice task…',
+      voiceRealtimeStart: 'Start realtime voice collaboration', voiceRealtimeStop: 'Stop realtime voice collaboration',
+      voiceConnecting: 'Connecting realtime voice…', voiceConnected: 'Realtime voice connected',
     },
     model: {
       thinkingLevel: 'Thinking level', thinkingUnsupported: 'This model does not support thinking-level changes', changeThinkingLevel: 'Change the current model thinking level', defaultLevel: 'Default',

--- a/packages/ui/src/use-composer-draft.ts
+++ b/packages/ui/src/use-composer-draft.ts
@@ -18,7 +18,11 @@
  */
 
 import { useEffect, useRef, useState, type RefObject } from 'react';
-import { readComposerDraft, rememberComposerDraft } from './composer-helpers.js';
+import {
+  appendPromptContextDraft,
+  readComposerDraft,
+  rememberComposerDraft,
+} from './composer-helpers.js';
 
 export interface ComposerDraftApi {
   /** True while the active draft holds non-whitespace text (gates Send). */
@@ -36,6 +40,8 @@ export interface ComposerDraftApi {
   clearDraft(key: string | undefined): void;
   /** Persist text under an explicit session key before the host switches it. */
   setDraft(key: string | undefined, value: string): void;
+  /** Append text under an explicit session key without overwriting its draft. */
+  appendDraft(key: string | undefined, value: string): string;
   /** The key the current textarea content is persisted under. */
   activeDraftKey(): string | undefined;
 }
@@ -68,6 +74,16 @@ export function useComposerDraft(input: {
     if (activeDraftKeyRef.current === key) setHasDraftText(Boolean(value.trim()));
   }
 
+  function appendDraft(key: string | undefined, value: string) {
+    const current =
+      activeDraftKeyRef.current === key
+        ? (input.textareaRef.current?.value ?? '')
+        : readComposerDraft(draftStoreRef.current, key);
+    const next = appendPromptContextDraft(current, value);
+    setDraft(key, next);
+    return next;
+  }
+
   function activeDraftKey() {
     return activeDraftKeyRef.current;
   }
@@ -92,5 +108,12 @@ export function useComposerDraft(input: {
     }
   }, [input.draftKey]);
 
-  return { hasDraftText, saveCurrentDraft, clearDraft, setDraft, activeDraftKey };
+  return {
+    hasDraftText,
+    saveCurrentDraft,
+    clearDraft,
+    setDraft,
+    appendDraft,
+    activeDraftKey,
+  };
 }

--- a/scripts/sync-model-metadata.mjs
+++ b/scripts/sync-model-metadata.mjs
@@ -137,6 +137,18 @@ function toMetadata(providerId, modelId, provider, model) {
       reasoning: model.reasoning === true,
       functionCalling: model.tool_call === true,
     },
+    ...(model.modalities
+      ? {
+          modalities: {
+            input: model.modalities.input.filter(
+              (value) => value === 'text' || value === 'image' || value === 'audio',
+            ),
+            output: (Array.isArray(model.modalities.output) ? model.modalities.output : []).filter(
+              (value) => value === 'text' || value === 'image' || value === 'audio',
+            ),
+          },
+        }
+      : {}),
   };
 }
 

--- a/scripts/sync-model-metadata.test.mjs
+++ b/scripts/sync-model-metadata.test.mjs
@@ -124,6 +124,7 @@ test('sync-model-metadata maps models.dev modalities into Maka metadata', async 
 
   const generated = await readFile(output, 'utf8');
   assert.match(generated, /"vision":true,"reasoning":true,"functionCalling":true/);
+  assert.match(generated, /"modalities":\{"input":\["text","image"\],"output":\["text"\]\}/);
   assert.match(generated, /"text-model".*"lifecycle":"deprecated".*"vision":false/);
   assert.match(
     generated,


### PR DESCRIPTION
## Summary

- add model-routed voice input: send audio directly to audio-capable agent models, otherwise transcribe through an explicitly configured speech-recognition model
- add Composer recording, cancellation, transcription-to-draft, clear missing-configuration errors, and Voice settings/self-test flows
- add WebRTC realtime voice coordination for starting, guiding, checking, and summarizing agent tasks
- keep raw audio operation-scoped in memory and prevent long-lived provider credentials from entering the renderer
- add model/audio capability metadata, runtime transport support, architecture documentation, and focused tests

## Validation

- full workspace typecheck
- full workspace lint
- production build
- 59 focused Voice tests
- `git diff --check`

## Note

The Runtime Host suite completed its assertions but retained an existing idle Node handle, so the waiting process was terminated manually after completion.