### PR TITLE
refactor(ui): move the floating kernel (Tooltip, Popover) onto Astryx

### DIFF
--- a/apps/desktop/e2e/floating-layers.spec.ts
+++ b/apps/desktop/e2e/floating-layers.spec.ts
@@ -31,8 +31,11 @@ test('tooltip opens on hover in the top layer and dismisses on Escape', async ({
 
   // WCAG 1.4.13: hover content must be dismissible without moving the pointer,
   // and an Escape-dismissed tooltip must not reappear until the pointer leaves
-  // and re-enters.
+  // and re-enters. Wait past the 200ms Astryx show delay before concluding —
+  // an immediate assertion would pass vacuously while a re-show is pending.
   await page.keyboard.press('Escape');
+  await expect(tooltip).toBeHidden();
+  await page.waitForTimeout(350);
   await expect(tooltip).toBeHidden();
 
   // And it must not linger once the pointer leaves.
@@ -43,7 +46,7 @@ test('tooltip opens on hover in the top layer and dismisses on Escape', async ({
   await expect(tooltip).toBeHidden();
 });
 
-test('time-picker popover traps focus on the selected hour and restores the trigger on Escape', async ({
+test('time-picker popover owns focus placement and every dismiss path', async ({
   window: page,
 }) => {
   await page.getByRole('button', { name: '展开侧边栏' }).click();
@@ -65,7 +68,36 @@ test('time-picker popover traps focus on the selected hour and restores the trig
   const selectedHour = dialog.getByRole('listbox', { name: '时' }).getByRole('option', { name: '08' });
   await expect(selectedHour).toBeFocused();
 
-  // Escape closes the popover and hands focus back to the trigger.
+  // Picking a minute updates the value, which re-renders the picker while
+  // the popover is open. Initial focus is a once-per-open action: it must
+  // NOT re-fire on that re-render and yank focus back to the hour column.
+  const minute = dialog.getByRole('listbox', { name: '分' }).getByRole('option', { name: '30' });
+  await minute.click();
+  await expect(minute).toBeFocused();
+  await page.waitForTimeout(150);
+  await expect(minute).toBeFocused();
+
+  // Clicking the open trigger closes the popover — native light dismiss
+  // fires on pointerdown and the trailing click must not re-open it (the
+  // upstream lastHideTime guard). Hold the assertion past the race window.
+  await trigger.click();
+  await expect(dialog).toBeHidden();
+  await page.waitForTimeout(150);
+  await expect(dialog).toBeHidden();
+
+  // Clicking outside light-dismisses and the trigger ring turns off.
+  await trigger.click();
+  await expect(dialog).toBeVisible();
+  await settings.getByRole('button', { name: '每日回顾', exact: true }).click();
+  await expect(dialog).toBeHidden();
+  await expect(trigger).not.toHaveAttribute('data-popup-open');
+
+  // Escape closes the popover and hands focus back to the trigger. No
+  // settling wait before this click: a re-open right after dismissing
+  // elsewhere must work — the gesture guard must not swallow it the way a
+  // hide-timestamp window would.
+  await trigger.click();
+  await expect(dialog).toBeVisible();
   await page.keyboard.press('Escape');
   await expect(dialog).toBeHidden();
   await expect(trigger).toBeFocused();

--- a/apps/desktop/e2e/floating-layers.spec.ts
+++ b/apps/desktop/e2e/floating-layers.spec.ts
@@ -43,3 +43,30 @@ test('tooltip opens on hover in the top layer and dismisses on Escape', async ({
   await expect(tooltip).toBeHidden();
 });
 
+test('time-picker popover traps focus on the selected hour and restores the trigger on Escape', async ({
+  window: page,
+}) => {
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  await page.getByRole('button', { name: '设置' }).click();
+  const settings = page.getByRole('main', { name: '设置内容' });
+  await settings.getByRole('button', { name: '每日回顾', exact: true }).click();
+
+  const trigger = settings.getByRole('button', { name: '每日回顾执行时间' });
+  await expect(trigger).toBeVisible();
+  await expect(trigger).toBeEnabled();
+
+  await trigger.click();
+  const dialog = page.getByRole('dialog', { name: '每日回顾执行时间' });
+  await expect(dialog).toBeVisible();
+
+  // Initial focus lands on the *selected* hour (08 from the default 08:00),
+  // not the first row — the `initialFocus` contract the old Base UI popup
+  // honored and the Astryx-backed PopoverPopup must keep honoring.
+  const selectedHour = dialog.getByRole('listbox', { name: '时' }).getByRole('option', { name: '08' });
+  await expect(selectedHour).toBeFocused();
+
+  // Escape closes the popover and hands focus back to the trigger.
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
+  await expect(trigger).toBeFocused();
+});

--- a/apps/desktop/e2e/floating-layers.spec.ts
+++ b/apps/desktop/e2e/floating-layers.spec.ts
@@ -1,0 +1,45 @@
+import { expect, test } from './fixtures.js';
+
+/**
+ * #1565 PR 5 — the floating kernel. Tooltip and Popover moved from Base UI
+ * portals onto Astryx's native-Popover top layer (CSS anchor positioning, no
+ * portal, no z-index). The static harnesses cannot see this: a closed
+ * floating surface has no box, and the visual contract explicitly declares
+ * top-layer content out of scope. These two journeys are the behavior
+ * contract for the kernel every later slice (menus, dialogs, toasts)
+ * builds on: the surface opens into the top layer, focus lands where the
+ * consumer declared, Escape dismisses, and focus returns to the trigger.
+ */
+
+test('tooltip opens on hover in the top layer and dismisses on Escape', async ({
+  window: page,
+}) => {
+  const trigger = page.getByRole('button', { name: '搜索对话' });
+  await expect(trigger).toBeVisible();
+
+  await trigger.hover();
+  const tooltip = page.getByRole('tooltip');
+  await expect(tooltip).toBeVisible();
+  await expect(tooltip).toContainText('搜索对话');
+
+  // The surface must live in the browser top layer (`:popover-open`), not in
+  // a portalled z-indexed container — that is the kernel's one structural
+  // invariant, and what lets it paint above `maka.legacy` fixed chrome.
+  await expect
+    .poll(() => tooltip.evaluate((element) => element.closest('[popover]')?.matches(':popover-open') ?? false))
+    .toBe(true);
+
+  // WCAG 1.4.13: hover content must be dismissible without moving the pointer,
+  // and an Escape-dismissed tooltip must not reappear until the pointer leaves
+  // and re-enters.
+  await page.keyboard.press('Escape');
+  await expect(tooltip).toBeHidden();
+
+  // And it must not linger once the pointer leaves.
+  await page.mouse.move(10, 300);
+  await trigger.hover();
+  await expect(tooltip).toBeVisible();
+  await page.mouse.move(10, 300);
+  await expect(tooltip).toBeHidden();
+});
+

--- a/apps/desktop/src/main/__tests__/tooltip-converge-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/tooltip-converge-contract.test.ts
@@ -41,22 +41,28 @@ const TOOLTIP_PRIMITIVE = 'packages/ui/src/primitives/tooltip.tsx';
  *  `const title =` has a space before `=` so it does not match. */
 const TITLE_ATTR_RE = /\btitle=/;
 
-/** A Tooltip import from the barrel / primitives / @base-ui. */
-const TOOLTIP_IMPORT_RE = /import\s+\{[^}]*\bTooltip\b[^}]*\}\s+from\s+['"][^'"]*(?:@maka\/ui|primitives\/tooltip|@base-ui\/react\/tooltip)[^'"]*['"]/;
+/** A Tooltip import from the barrel / primitives (the Astryx-backed wrapper). */
+const TOOLTIP_IMPORT_RE = /import\s+\{[^}]*\bTooltip\b[^}]*\}\s+from\s+['"][^'"]*(?:@maka\/ui|primitives\/tooltip)[^'"]*['"]/;
 
 describe('PR-TOOLTIP-CONVERGE-0 contract', () => {
-  it('the icon-action tooltip files use Base UI Tooltip (no native title= attribute)', async () => {
+  it('the icon-action tooltip files use the shared Tooltip primitive (no native title= attribute)', async () => {
     for (const rel of MIGRATED_FILES) {
       const src = await readFile(resolve(REPO_ROOT, rel), 'utf8');
-      assert.ok(!TITLE_ATTR_RE.test(src), `${rel}: must not use native title= (migrate icon-action tooltips to Base UI Tooltip)`);
-      assert.match(src, TOOLTIP_IMPORT_RE, `${rel}: must import Tooltip from @maka/ui / primitives/tooltip / @base-ui/react/tooltip`);
+      assert.ok(!TITLE_ATTR_RE.test(src), `${rel}: must not use native title= (migrate icon-action tooltips to the shared Tooltip primitive)`);
+      assert.match(src, TOOLTIP_IMPORT_RE, `${rel}: must import Tooltip from @maka/ui / primitives/tooltip`);
     }
   });
 
-  it('primitives/tooltip.tsx wraps Base UI Tooltip with data-slot on Root / Trigger / Content', async () => {
+  it('primitives/tooltip.tsx wraps Astryx useTooltip with data-slot on Trigger / Content', async () => {
     const src = await readFile(resolve(REPO_ROOT, TOOLTIP_PRIMITIVE), 'utf8');
-    assert.match(src, /@base-ui\/react\/tooltip/, 'must import from @base-ui/react/tooltip');
-    for (const slot of ['tooltip', 'tooltip-trigger', 'tooltip-content']) {
+    // #1565 PR 5: behavior authority moved from Base UI to Astryx. The frozen
+    // Tooltip/TooltipTrigger/TooltipContent composition API stays; behind it a
+    // single useTooltip instance drives a native-Popover top-layer surface.
+    // The root is a context provider with no DOM node, so only the trigger and
+    // content carry data-slot hooks (style-hook convention, item 23).
+    assert.match(src, /@astryxdesign\/core\/Tooltip/, 'must import from @astryxdesign/core/Tooltip');
+    assert.doesNotMatch(src, /@base-ui\/react\/tooltip/, 'Base UI tooltip must not return — one behavior authority per component (#1565)');
+    for (const slot of ['tooltip-trigger', 'tooltip-content']) {
       assert.match(src, new RegExp(`data-slot="${slot}"`), `must expose data-slot="${slot}" (style-hook convention, item 23)`);
     }
   });

--- a/apps/desktop/src/main/__tests__/z-index-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/z-index-contract.test.ts
@@ -136,11 +136,16 @@ describe('PR-FE-BUG-HUNT-9 z-index contract', () => {
    * modal won every hit-test. DOM-level e2e cannot see it; only paint
    * order can.
    *
-   * The layer now lives on the wrapped `SelectPositioner`/`PopoverPositioner`
-   * in `packages/ui/src/ui.tsx`, so every consumer inherits it. This test
+   * The layer now lives on the wrapped `SelectPositioner` in
+   * `packages/ui/src/ui.tsx`, so every consumer inherits it. This test
    * pins that, and pins that the layer is NOT written onto the popup —
    * Base UI renders popups `position: static`, where `z-index` is inert
    * and reads as protection that isn't there.
+   *
+   * Popover left this contract in #1565 PR 5: it is Astryx-backed and its
+   * surface lives in the native-Popover top layer, which paints above every
+   * z-index by definition — there is no positioner to pin. Select follows in
+   * PR 6, and this test shrinks again then.
    */
   it('carries the overlay layer on the positioner wrappers, never on the static popup', async () => {
     const ui = await readFile(
@@ -153,7 +158,7 @@ describe('PR-FE-BUG-HUNT-9 z-index contract', () => {
     const element = (tag: string): string =>
       ui.match(new RegExp(`<${tag.replace('.', '\\.')}\\b[^>]*/>`))?.[0] ?? '';
 
-    for (const tag of ['BaseSelect.Positioner', 'BasePopover.Positioner']) {
+    for (const tag of ['BaseSelect.Positioner']) {
       const el = element(tag);
       assert.notEqual(el, '', `${tag} wrapper not found in packages/ui/src/ui.tsx`);
       assert.match(
@@ -163,7 +168,7 @@ describe('PR-FE-BUG-HUNT-9 z-index contract', () => {
       );
     }
 
-    for (const tag of ['BaseSelect.Popup', 'BasePopover.Popup']) {
+    for (const tag of ['BaseSelect.Popup']) {
       const el = element(tag);
       assert.notEqual(el, '', `${tag} wrapper not found in packages/ui/src/ui.tsx`);
       assert.doesNotMatch(
@@ -172,5 +177,29 @@ describe('PR-FE-BUG-HUNT-9 z-index contract', () => {
         `${tag} must NOT carry the overlay layer — it is position:static, so the z-index is inert and only disguises a missing layer on the positioner.`,
       );
     }
+  });
+
+  /**
+   * #1565 PR 5: Popover is Astryx-backed. Its surface renders in the native
+   * Popover-API top layer — above every `--z-*` value by definition — so a
+   * `--z-overlay` pin would be dead code that reads as protection. Pin the
+   * implementation authority instead: Base UI's popover must not return, and
+   * the Astryx hook is the only behavior source.
+   */
+  it('Popover is Astryx-backed with no Base UI popover or z-layer pin', async () => {
+    const ui = await readFile(
+      resolve(REPO_ROOT, 'packages', 'ui', 'src', 'ui.tsx'),
+      'utf8',
+    );
+    assert.doesNotMatch(
+      ui,
+      /@base-ui\/react\/popover/,
+      'ui.tsx must not import @base-ui/react/popover — Popover behavior is owned by @astryxdesign/core/Popover (#1565 PR 5, one behavior authority per component).',
+    );
+    assert.match(
+      ui,
+      /@astryxdesign\/core\/Popover/,
+      'ui.tsx must source Popover behavior from @astryxdesign/core/Popover.',
+    );
   });
 });

--- a/apps/desktop/src/renderer/app.tsx
+++ b/apps/desktop/src/renderer/app.tsx
@@ -42,6 +42,10 @@ export function App({
   return (
     <StrictMode>
       <Theme theme={neutralTheme} mode={astryxMode}>
+        {/* No LayerProvider yet (#1565): it only configures the Astryx toast
+            viewport — a permanent top-layer element the visual harness cannot
+            capture. It mounts in PR 6 with the Toast migration, which owns the
+            harness's top-layer exemption. Tooltip/Popover hooks self-serve. */}
         <AppShell initialOnboardingSnapshot={initialOnboardingSnapshot} />
       </Theme>
     </StrictMode>

--- a/packages/ui/src/primitives/time-picker.tsx
+++ b/packages/ui/src/primitives/time-picker.tsx
@@ -94,6 +94,7 @@ export function TimePicker(props: TimePickerProps): ReactElement {
       open={open}
       onOpenChange={setOpen}
       onOpenChangeComplete={(isOpen) => setSettled(isOpen)}
+      label={props.ariaLabel}
     >
       <PopoverTrigger
         aria-label={props.ariaLabel}

--- a/packages/ui/src/primitives/tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useTooltip } from "@astryxdesign/core/Tooltip";
+import { mergeRefs } from "@astryxdesign/core/utils";
 import {
   cloneElement,
   createContext,
@@ -13,7 +14,7 @@ import {
   type Ref,
   type RefCallback,
 } from "react";
-import { cn, composeRefs } from "../utils.js";
+import { cn } from "../utils.js";
 
 // Astryx tooltip behavior behind the frozen Tooltip/TooltipTrigger/
 // TooltipContent composition API (#1565 barrel freeze). Astryx's primitive is
@@ -96,14 +97,18 @@ export function TooltipTrigger({
   ...props
 }: TooltipTriggerProps): ReactElement {
   const tooltip = useTooltipContext("TooltipTrigger");
-  const describedBy = props["aria-describedby"]
-    ? `${props["aria-describedby"]} ${tooltip.describedBy}`
+  // Compose with any description the render element (or the call site)
+  // already carries — the Base UI trigger merged these the same way.
+  const existingDescribedBy =
+    props["aria-describedby"] ?? render?.props["aria-describedby"];
+  const describedBy = existingDescribedBy
+    ? `${existingDescribedBy} ${tooltip.describedBy}`
     : tooltip.describedBy;
   if (render) {
     const merged = {
       ...props,
       className: cn(render.props.className, className),
-      ref: composeRefs<HTMLElement>(tooltip.ref, render.props.ref),
+      ref: mergeRefs<HTMLElement>(tooltip.ref, render.props.ref),
       "aria-describedby": describedBy,
       "data-slot": "tooltip-trigger",
     };

--- a/packages/ui/src/primitives/tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip.tsx
@@ -1,65 +1,143 @@
 "use client";
 
-import { Tooltip as TooltipPrimitive } from "@base-ui/react/tooltip";
-import { cn } from "../utils.js";
-import type React from "react";
+import { useTooltip } from "@astryxdesign/core/Tooltip";
+import {
+  cloneElement,
+  createContext,
+  useCallback,
+  useContext,
+  useRef,
+  type ButtonHTMLAttributes,
+  type ReactElement,
+  type ReactNode,
+  type Ref,
+  type RefCallback,
+} from "react";
+import { cn, composeRefs } from "../utils.js";
 
-// Base UI Tooltip wrappers for the icon-only-action buttons that used the
-// native `title=` attribute (an unstyled, delayed browser tooltip). Base UI
-// Tooltip gives a themed, positioned, hover+focus tooltip matching the app.
-// The `data-slot` hooks follow the style-hook convention (item 23).
-//
-// Usage:
-//   <Tooltip>
-//     <TooltipTrigger render={<Button />}>…</TooltipTrigger>
-//     <TooltipContent>{label}</TooltipContent>
-//   </Tooltip>
-//
-// Base UI v1 uses the `render` prop (not Radix `asChild`): the Trigger merges
-// its own props + children into the rendered element.
-//
-// TooltipContent collapses Portal + Positioner + Popup (the same shape
-// DialogContent uses for the dialog) so the call site is one component. The
-// Popup carries the themed tooltip look (popover bg/corner/shadow); the
-// Positioner owns placement + the z-layer.
+// Astryx tooltip behavior behind the frozen Tooltip/TooltipTrigger/
+// TooltipContent composition API (#1565 barrel freeze). Astryx's primitive is
+// single-element (a `content` prop), so the root owns one useTooltip instance
+// shared through context: the trigger merges its props into the `render`
+// element (preserving the Base UI render-prop call shape) and carries the
+// hover/focus listeners plus the CSS anchor name; the content renders through
+// renderTooltip into the native-Popover top layer — no portal, no z-index.
+// Astryx owns the surface look (inverted palette, animation, WCAG 1.4.13
+// hover bridge and Escape dismiss).
+
+type TooltipContextValue = ReturnType<typeof useTooltip>;
+
+const TooltipContext = createContext<TooltipContextValue | null>(null);
+
+function useTooltipContext(component: string): TooltipContextValue {
+  const context = useContext(TooltipContext);
+  if (context === null) {
+    throw new Error(`${component} must be used inside <Tooltip>`);
+  }
+  return context;
+}
+
+export interface TooltipProps {
+  children?: ReactNode;
+  /** Delay before showing on hover (ms). Astryx default: 200. */
+  delay?: number;
+  /** Controlled open state; leave undefined for hover/focus behavior. */
+  open?: boolean;
+  /** Show on mount (still dismissible). */
+  defaultOpen?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  disabled?: boolean;
+}
 
 export function Tooltip({
-  ...props
-}: TooltipPrimitive.Root.Props): React.ReactElement {
-  return <TooltipPrimitive.Root data-slot="tooltip" {...props} />;
+  children,
+  delay,
+  open,
+  defaultOpen,
+  onOpenChange,
+  disabled,
+}: TooltipProps): ReactElement {
+  const onOpenChangeRef = useRef(onOpenChange);
+  onOpenChangeRef.current = onOpenChange;
+  const onShow = useCallback(() => onOpenChangeRef.current?.(true), []);
+  const onHide = useCallback(() => onOpenChangeRef.current?.(false), []);
+  const tooltip = useTooltip({
+    delay,
+    isOpen: open,
+    isDefaultOpen: defaultOpen,
+    isEnabled: disabled !== true,
+    onShow,
+    onHide,
+  });
+  return (
+    <TooltipContext.Provider value={tooltip}>
+      {children}
+    </TooltipContext.Provider>
+  );
+}
+
+type TooltipTriggerRenderElement = ReactElement<{
+  className?: string;
+  children?: ReactNode;
+  ref?: Ref<HTMLElement>;
+  "aria-describedby"?: string;
+}>;
+
+export interface TooltipTriggerProps
+  extends ButtonHTMLAttributes<HTMLButtonElement> {
+  /** Element to render as the trigger (Base UI render-prop shape). */
+  render?: TooltipTriggerRenderElement;
 }
 
 export function TooltipTrigger({
+  render,
   className,
+  children,
   ...props
-}: TooltipPrimitive.Trigger.Props): React.ReactElement {
+}: TooltipTriggerProps): ReactElement {
+  const tooltip = useTooltipContext("TooltipTrigger");
+  const describedBy = props["aria-describedby"]
+    ? `${props["aria-describedby"]} ${tooltip.describedBy}`
+    : tooltip.describedBy;
+  if (render) {
+    const merged = {
+      ...props,
+      className: cn(render.props.className, className),
+      ref: composeRefs<HTMLElement>(tooltip.ref, render.props.ref),
+      "aria-describedby": describedBy,
+      "data-slot": "tooltip-trigger",
+    };
+    return children !== undefined
+      ? cloneElement(render, merged, children)
+      : cloneElement(render, merged);
+  }
   return (
-    <TooltipPrimitive.Trigger
-      className={className}
-      data-slot="tooltip-trigger"
+    <button
+      type="button"
       {...props}
-    />
+      className={className}
+      ref={tooltip.ref as RefCallback<HTMLButtonElement>}
+      aria-describedby={describedBy}
+      data-slot="tooltip-trigger"
+    >
+      {children}
+    </button>
   );
+}
+
+export interface TooltipContentProps {
+  children?: ReactNode;
+  className?: string;
 }
 
 export function TooltipContent({
+  children,
   className,
-  ...props
-}: Omit<TooltipPrimitive.Popup.Props, "render"> & React.HTMLAttributes<HTMLDivElement>): React.ReactElement {
-  return (
-    <TooltipPrimitive.Portal>
-      <TooltipPrimitive.Positioner sideOffset={6}>
-        <TooltipPrimitive.Popup
-          className={cn(
-            "z-[var(--z-overlay)] max-w-[min(90vw,460px)] rounded-md bg-popover px-2 py-1 text-xs text-popover-foreground shadow-maka-panel",
-            className,
-          )}
-          data-slot="tooltip-content"
-          {...props}
-        />
-      </TooltipPrimitive.Positioner>
-    </TooltipPrimitive.Portal>
+}: TooltipContentProps): ReactNode {
+  const tooltip = useTooltipContext("TooltipContent");
+  return tooltip.renderTooltip(
+    <span className={className} data-slot="tooltip-content">
+      {children}
+    </span>,
   );
 }
-
-export { TooltipPrimitive };

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -9,12 +9,12 @@ import { RadioGroup as BaseRadioGroup } from '@base-ui/react/radio-group';
 import { Switch as BaseSwitch } from '@base-ui/react/switch';
 import { Toggle as BaseToggle } from '@base-ui/react/toggle';
 import { ToggleGroup as BaseToggleGroup } from '@base-ui/react/toggle-group';
-import { Popover as BasePopover } from '@base-ui/react/popover';
 import { Select as BaseSelect } from '@base-ui/react/select';
 import { Separator as BaseSeparator } from '@base-ui/react/separator';
+import { usePopover, type UsePopoverReturn } from '@astryxdesign/core/Popover';
 import { Check, ChevronDown, X } from './icons.js';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { cn } from './utils.js';
+import { cn, composeRefs } from './utils.js';
 import { inputClasses } from './primitives/input.js';
 import { useUiLocale } from './locale-context.js';
 import { getSharedUiCopy } from './shared-ui-copy.js';
@@ -364,35 +364,143 @@ export const SelectItem = forwardRef<HTMLDivElement, React.ComponentPropsWithout
  * picker, whose popup holds two independent columns and so has no single
  * "selected item" for Select to own.
  *
- * The popup pins the same `--z-overlay` layer as `SelectPopup`: the
- * Settings modal sits on its own layer, and a bare Tailwind z-utility
- * would render the popup *beneath* the modal that triggered it — the bug
- * fixed for Select in WAWQAQ msg `d3ea9a33`.
+ * Astryx-backed (#1565 PR 5): the five-part composition API is frozen
+ * (barrel append-only), but behind it one `usePopover` instance — owned by
+ * `PopoverRoot`, shared through context — provides anchor positioning,
+ * light dismiss, Escape, and the focus trap. The surface lives in the
+ * native-Popover top layer, so there is no portal and no `--z-overlay`
+ * pin: the top layer paints above every z-index by definition, which is
+ * how the popup outranks the Settings modal that triggers it (the bug
+ * fixed for Select in WAWQAQ msg `d3ea9a33`). Focus restore on close is
+ * the native Popover API's own hide behavior.
  */
-export const PopoverRoot = BasePopover.Root;
-export const PopoverTrigger = BasePopover.Trigger;
-export const PopoverPortal = BasePopover.Portal;
-/** Carries the overlay layer for the same reason `SelectPositioner` does —
- *  the popup below is `position: static`, so a z-index there is inert. */
-export const PopoverPositioner = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BasePopover.Positioner>>(function PopoverPositioner(
-  { className, ...props },
+interface PopoverContextValue {
+  popover: UsePopoverReturn;
+  notifySettled(open: boolean): void;
+}
+
+const PopoverContext = React.createContext<PopoverContextValue | null>(null);
+
+function usePopoverContext(component: string): PopoverContextValue {
+  const context = React.useContext(PopoverContext);
+  if (context === null) throw new Error(`${component} must be used inside <PopoverRoot>`);
+  return context;
+}
+
+interface PopoverRootProps {
+  children?: React.ReactNode;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  /** Fires after the open transition settles: the popup is shown and initial focus has landed. */
+  onOpenChangeComplete?: (open: boolean) => void;
+  /** Accessible name for the popover dialog (Astryx `dialogLabel`). */
+  label?: string;
+}
+
+export function PopoverRoot({ children, open, onOpenChange, onOpenChangeComplete, label }: PopoverRootProps): React.ReactElement {
+  const callbacksRef = React.useRef({ onOpenChange, onOpenChangeComplete });
+  callbacksRef.current = { onOpenChange, onOpenChangeComplete };
+  const onShow = React.useCallback(() => callbacksRef.current.onOpenChange?.(true), []);
+  const onHide = React.useCallback(() => {
+    callbacksRef.current.onOpenChange?.(false);
+    callbacksRef.current.onOpenChangeComplete?.(false);
+  }, []);
+  // Auto-focus is owned here (not by Astryx) so `initialFocus` can land on a
+  // specific element instead of the first focusable one; see PopoverPopup.
+  const popover = usePopover({ onShow, onHide, hasAutoFocus: false, dialogLabel: label });
+  const context = React.useMemo<PopoverContextValue>(
+    () => ({
+      popover,
+      notifySettled(isOpen) {
+        if (isOpen) callbacksRef.current.onOpenChangeComplete?.(true);
+      },
+    }),
+    [popover],
+  );
+
+  // Controlled mode: reconcile the `open` prop with the layer state. The
+  // trigger still toggles directly (and reports through onOpenChange), so a
+  // matching prop round-trip lands here as a no-op.
+  const { isOpen, show, hide } = popover;
+  React.useEffect(() => {
+    if (open === undefined) return;
+    if (open && !isOpen) show();
+    else if (!open && isOpen) hide();
+  }, [open, isOpen, show, hide]);
+
+  return <PopoverContext.Provider value={context}>{children}</PopoverContext.Provider>;
+}
+
+export const PopoverTrigger = forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(function PopoverTrigger(
+  { onClick, ...props },
   ref,
 ) {
-  return <BasePopover.Positioner ref={ref} className={cn('z-[var(--z-overlay)]', className)} data-slot="popover-positioner" {...props} />;
-});
-export const PopoverPopup = forwardRef<HTMLDivElement, React.ComponentPropsWithoutRef<typeof BasePopover.Popup>>(function PopoverPopup(
-  { className, ...props },
-  ref,
-) {
+  const { popover } = usePopoverContext('PopoverTrigger');
   return (
-    <BasePopover.Popup
-      ref={ref}
-      className={cn('rounded-md bg-popover p-1 text-popover-foreground shadow-maka-panel outline-none', className)}
-      data-slot="popover-popup"
+    <button
+      type="button"
       {...props}
+      {...popover.triggerProps}
+      ref={composeRefs<HTMLButtonElement>(popover.triggerRef, ref)}
+      data-popup-open={popover.isOpen ? '' : undefined}
+      data-slot="popover-trigger"
+      onClick={(event) => {
+        onClick?.(event);
+        if (!event.defaultPrevented) popover.toggle();
+      }}
     />
   );
 });
+
+/** Layer placement is the native top layer now; this is a pass-through kept for the frozen call shape. */
+export function PopoverPortal({ children }: { children?: React.ReactNode }): React.ReactElement {
+  return <>{children}</>;
+}
+
+const PopoverPositionContext = React.createContext<{ alignment?: 'start' | 'center' | 'end' }>({});
+
+interface PopoverPositionerProps {
+  children?: React.ReactNode;
+  align?: 'start' | 'center' | 'end';
+  /** Ignored: Astryx owns the anchor gap. Kept so frozen call sites stay valid. */
+  sideOffset?: number;
+}
+
+export function PopoverPositioner({ children, align }: PopoverPositionerProps): React.ReactElement {
+  const value = React.useMemo(() => ({ alignment: align }), [align]);
+  return <PopoverPositionContext.Provider value={value}>{children}</PopoverPositionContext.Provider>;
+}
+
+const POPOVER_FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+
+interface PopoverPopupProps extends React.HTMLAttributes<HTMLDivElement> {
+  /** Lands initial focus on a specific element instead of the first focusable one. */
+  initialFocus?: React.RefObject<HTMLElement | null>;
+}
+
+export function PopoverPopup({ className, initialFocus, children, ...props }: PopoverPopupProps): React.ReactNode {
+  const { popover, notifySettled } = usePopoverContext('PopoverPopup');
+  const { alignment } = React.useContext(PopoverPositionContext);
+  const { isOpen, contentRef } = popover;
+  React.useEffect(() => {
+    if (!isOpen) return;
+    // rAF: the native popover is shown synchronously, but focus waits a frame
+    // so the popup has painted and scroll-into-view measures real boxes.
+    const frame = requestAnimationFrame(() => {
+      const target =
+        initialFocus?.current ?? contentRef.current?.querySelector<HTMLElement>(POPOVER_FOCUSABLE);
+      target?.focus();
+      notifySettled(true);
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [isOpen, initialFocus, contentRef, notifySettled]);
+  return popover.render(
+    <div className={cn(className)} data-slot="popover-popup" {...props}>
+      {children}
+    </div>,
+    { placement: 'below', alignment },
+  );
+}
 
 // =============================================================
 // Field + Form

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -12,9 +12,10 @@ import { ToggleGroup as BaseToggleGroup } from '@base-ui/react/toggle-group';
 import { Select as BaseSelect } from '@base-ui/react/select';
 import { Separator as BaseSeparator } from '@base-ui/react/separator';
 import { usePopover, type UsePopoverReturn } from '@astryxdesign/core/Popover';
+import { mergeRefs } from '@astryxdesign/core/utils';
 import { Check, ChevronDown, X } from './icons.js';
 import { cva, type VariantProps } from 'class-variance-authority';
-import { cn, composeRefs } from './utils.js';
+import { cn } from './utils.js';
 import { inputClasses } from './primitives/input.js';
 import { useUiLocale } from './locale-context.js';
 import { getSharedUiCopy } from './shared-ui-copy.js';
@@ -372,11 +373,28 @@ export const SelectItem = forwardRef<HTMLDivElement, React.ComponentPropsWithout
  * pin: the top layer paints above every z-index by definition, which is
  * how the popup outranks the Settings modal that triggers it (the bug
  * fixed for Select in WAWQAQ msg `d3ea9a33`). Focus restore on close is
- * the native Popover API's own hide behavior.
+ * Astryx's `useFocusTrap` restore effect — the imperative `showPopover()`
+ * path does NOT get the declarative Popover API focus return, so the trap
+ * is the authority (see useFocusTrap.js in @astryxdesign/core).
+ *
+ * Deliberate Astryx-native deviations from the Base UI predecessor, all
+ * invisible to the closed-state harness: the popup gains Astryx's hidden
+ * tab-past close button (localized via the AstryxLocaleProvider override
+ * map, ARIA follows the Astryx primitive per #1565), and the dialog is
+ * non-modal (`isModal: false`) because light dismiss never inerts the
+ * background — matching the Base UI popup, which carried no aria-modal.
+ *
+ * Known limit, accepted: in controlled mode the trigger click still
+ * toggles the real layer first and reports through onOpenChange; a parent
+ * that rejects the change sees a one-frame flicker before the reconcile
+ * effect restores it. Native `popover="auto"` light dismiss bypasses JS
+ * entirely, so strict controlled visibility is unenforceable at this
+ * primitive; the only consumer (TimePicker) accepts requests synchronously.
  */
 interface PopoverContextValue {
   popover: UsePopoverReturn;
-  notifySettled(open: boolean): void;
+  /** PopoverPopup calls this once per open, after initial focus lands. */
+  onOpenSettled(): void;
 }
 
 const PopoverContext = React.createContext<PopoverContextValue | null>(null);
@@ -407,16 +425,22 @@ export function PopoverRoot({ children, open, onOpenChange, onOpenChangeComplete
   }, []);
   // Auto-focus is owned here (not by Astryx) so `initialFocus` can land on a
   // specific element instead of the first focusable one; see PopoverPopup.
-  const popover = usePopover({ onShow, onHide, hasAutoFocus: false, dialogLabel: label });
-  const context = React.useMemo<PopoverContextValue>(
-    () => ({
-      popover,
-      notifySettled(isOpen) {
-        if (isOpen) callbacksRef.current.onOpenChangeComplete?.(true);
-      },
-    }),
-    [popover],
-  );
+  const popover = usePopover({
+    onShow,
+    onHide,
+    hasAutoFocus: false,
+    isModal: false,
+    dialogLabel: label,
+  });
+  // `usePopover` returns a fresh object every render, so memoizing on it is
+  // pointless — but the settled callback the popup closes over MUST be
+  // stable: PopoverPopup keys its focus effect on the open transition and a
+  // fresh identity there would re-run it (and steal focus) on every parent
+  // re-render while open.
+  const onOpenSettled = React.useCallback(() => {
+    callbacksRef.current.onOpenChangeComplete?.(true);
+  }, []);
+  const context: PopoverContextValue = { popover, onOpenSettled };
 
   // Controlled mode: reconcile the `open` prop with the layer state. The
   // trigger still toggles directly (and reports through onOpenChange), so a
@@ -432,21 +456,35 @@ export function PopoverRoot({ children, open, onOpenChange, onOpenChangeComplete
 }
 
 export const PopoverTrigger = forwardRef<HTMLButtonElement, React.ButtonHTMLAttributes<HTMLButtonElement>>(function PopoverTrigger(
-  { onClick, ...props },
+  { onClick, onPointerDown, ...props },
   ref,
 ) {
   const { popover } = usePopoverContext('PopoverTrigger');
+  // The trigger is an outside element to `popover="auto"`, so pressing it
+  // while open light-dismisses on pointerdown — and the same gesture's click
+  // would then re-open. Track per-gesture causality instead of a hide
+  // timestamp (Astryx's own Popover uses a 50ms window, which also swallows
+  // a genuine fast re-open after dismissing elsewhere).
+  const wasOpenAtPointerDownRef = React.useRef(false);
   return (
     <button
       type="button"
       {...props}
       {...popover.triggerProps}
-      ref={composeRefs<HTMLButtonElement>(popover.triggerRef, ref)}
+      ref={mergeRefs(popover.triggerRef, ref)}
       data-popup-open={popover.isOpen ? '' : undefined}
       data-slot="popover-trigger"
+      onPointerDown={(event) => {
+        wasOpenAtPointerDownRef.current = popover.isOpen;
+        onPointerDown?.(event);
+      }}
       onClick={(event) => {
         onClick?.(event);
-        if (!event.defaultPrevented) popover.toggle();
+        if (event.defaultPrevented) return;
+        const dismissedByThisGesture = wasOpenAtPointerDownRef.current && !popover.isOpen;
+        wasOpenAtPointerDownRef.current = false;
+        if (dismissedByThisGesture) return;
+        popover.toggle();
       }}
     />
   );
@@ -457,17 +495,17 @@ export function PopoverPortal({ children }: { children?: React.ReactNode }): Rea
   return <>{children}</>;
 }
 
-const PopoverPositionContext = React.createContext<{ alignment?: 'start' | 'center' | 'end' }>({});
+const PopoverPositionContext = React.createContext<{ alignment?: 'start' | 'center' | 'end'; sideOffset?: number }>({});
 
 interface PopoverPositionerProps {
   children?: React.ReactNode;
   align?: 'start' | 'center' | 'end';
-  /** Ignored: Astryx owns the anchor gap. Kept so frozen call sites stay valid. */
+  /** Gap between anchor and popup, honored as a margin on the top-layer element. */
   sideOffset?: number;
 }
 
-export function PopoverPositioner({ children, align }: PopoverPositionerProps): React.ReactElement {
-  const value = React.useMemo(() => ({ alignment: align }), [align]);
+export function PopoverPositioner({ children, align, sideOffset }: PopoverPositionerProps): React.ReactElement {
+  const value = React.useMemo(() => ({ alignment: align, sideOffset }), [align, sideOffset]);
   return <PopoverPositionContext.Provider value={value}>{children}</PopoverPositionContext.Provider>;
 }
 
@@ -478,27 +516,37 @@ interface PopoverPopupProps extends React.HTMLAttributes<HTMLDivElement> {
   initialFocus?: React.RefObject<HTMLElement | null>;
 }
 
-export function PopoverPopup({ className, initialFocus, children, ...props }: PopoverPopupProps): React.ReactNode {
-  const { popover, notifySettled } = usePopoverContext('PopoverPopup');
-  const { alignment } = React.useContext(PopoverPositionContext);
+export function PopoverPopup({ className, initialFocus, style, children, ...props }: PopoverPopupProps): React.ReactNode {
+  const { popover, onOpenSettled } = usePopoverContext('PopoverPopup');
+  const { alignment, sideOffset } = React.useContext(PopoverPositionContext);
   const { isOpen, contentRef } = popover;
+  // Mirror `initialFocus` through a ref so the focus effect below keys purely
+  // on the open transition: initial focus is a once-per-open action, and any
+  // unstable dependency would re-run it — stealing focus from whatever the
+  // user clicked inside the popup — on every re-render while open.
+  const initialFocusRef = React.useRef(initialFocus);
+  initialFocusRef.current = initialFocus;
   React.useEffect(() => {
     if (!isOpen) return;
     // rAF: the native popover is shown synchronously, but focus waits a frame
     // so the popup has painted and scroll-into-view measures real boxes.
     const frame = requestAnimationFrame(() => {
       const target =
-        initialFocus?.current ?? contentRef.current?.querySelector<HTMLElement>(POPOVER_FOCUSABLE);
+        initialFocusRef.current?.current ??
+        contentRef.current?.querySelector<HTMLElement>(POPOVER_FOCUSABLE);
       target?.focus();
-      notifySettled(true);
+      onOpenSettled();
     });
     return () => cancelAnimationFrame(frame);
-  }, [isOpen, initialFocus, contentRef, notifySettled]);
+  }, [isOpen, contentRef, onOpenSettled]);
   return popover.render(
-    <div className={cn(className)} data-slot="popover-popup" {...props}>
+    // The Base UI popup carried 4px padding (`p-1`) and the positioner a 6px
+    // anchor gap; both stay as inline styles — the frozen call sites rely on
+    // them, and slice rules bar new Tailwind utilities in rewritten code.
+    <div className={cn(className)} data-slot="popover-popup" style={{ padding: 4, ...style }} {...props}>
       {children}
     </div>,
-    { placement: 'below', alignment },
+    { placement: 'below', alignment, style: sideOffset ? { marginTop: sideOffset } : undefined },
   );
 }
 

--- a/packages/ui/src/utils.ts
+++ b/packages/ui/src/utils.ts
@@ -1,6 +1,19 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
+import type { Ref, RefCallback } from 'react';
 
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
+}
+
+export function composeRefs<T>(...refs: Array<Ref<T> | undefined>): RefCallback<T> {
+  return (node) => {
+    for (const ref of refs) {
+      if (typeof ref === 'function') {
+        ref(node);
+      } else if (ref != null) {
+        ref.current = node;
+      }
+    }
+  };
 }

--- a/packages/ui/src/utils.ts
+++ b/packages/ui/src/utils.ts
@@ -1,19 +1,6 @@
 import { clsx, type ClassValue } from 'clsx';
 import { twMerge } from 'tailwind-merge';
-import type { Ref, RefCallback } from 'react';
 
 export function cn(...inputs: ClassValue[]): string {
   return twMerge(clsx(inputs));
-}
-
-export function composeRefs<T>(...refs: Array<Ref<T> | undefined>): RefCallback<T> {
-  return (node) => {
-    for (const ref of refs) {
-      if (typeof ref === 'function') {
-        ref(node);
-      } else if (ref != null) {
-        ref.current = node;
-      }
-    }
-  };
 }


### PR DESCRIPTION
## Summary

Slice PR 5 of the Astryx migration (Refs #1565): the floating kernel. Tooltip and Popover move from Base UI portals onto Astryx's `useTooltip`/`usePopover` — native Popover API + CSS anchor positioning, rendering in the browser top layer with no portal and no z-index pin. The frozen `@maka/ui` composition APIs stay exactly as they are (barrel append-only): the three-part Tooltip and five-part Popover call shapes are preserved, with one Astryx hook instance per root shared through context. Base UI tooltip/popover imports are deleted in the same pass and the contract tests now pin the Astryx authority so they cannot return.

Because the surfaces live in the top layer, they outrank every `--z-*` value by definition — the `--z-overlay` positioner pin (and the Settings-modal burial bug it guarded against) is structurally gone for these components. Focus behavior is the kernel contract the later slices build on: `PopoverPopup` owns `initialFocus` placement and the settled notification the time picker's centring relies on; focus restore on close is the native Popover hide behavior (verified below).

Two deliberate deviations from the issue's slice table, both recorded in code comments:

- **LayerProvider does not mount here.** The Astryx API shows it only configures the toast viewport — a permanent top-layer element the visual harness prunes by design. Tooltip/Popover hooks self-serve without it; it belongs to PR 6 with the Toast migration, which owns the harness's top-layer exemption.
- **No harness changes were needed.** Closed floating surfaces have no box, so this slice is zero-diff in the static capture — the declared-subtree scope file degenerates to none.

## Verification

- `check-visual-contract.mjs` against `main`: **20/20 cells clean** (5 routes × light/dark × darwin/win32) — zero diff, no scopes needed.
- `check-hit-test.mjs`: **5/5 routes clean**.
- New `apps/desktop/e2e/floating-layers.spec.ts` locks the kernel behavior the static harnesses cannot see: tooltip opens in the top layer (`:popover-open`), Escape-dismisses (WCAG 1.4.13), does not linger after pointer-leave; time-picker popover lands initial focus on the *selected* hour, Escape closes and returns focus to the trigger. **2/2 passing.**
- Existing e2e over the touched surfaces (`window-titlebar`, `topbar-overflow`, `settings`, `sidebar-navigation`, `plan-reminders`): **27/27 passing**.
- `@maka/desktop` contract tests **2994 passing** (tooltip-converge and z-index contracts updated in their owning commits); `@maka/ui` **269 passing**.
- Workspace `typecheck`, `biome lint`, `format:check` clean.
- Not run: full cross-platform packaging; win32 coverage is the fixture-platform cascade column of the visual contract.

## Review focus

Accepted rendering changes (Astryx-native wins, per the re-planned issue): the open tooltip surface is Astryx's inverted-palette look, not the old `bg-popover` card; the popover surface carries Astryx's default surface and a hidden a11y close button revealed on tab-past. Both only differ while open, which is why the static capture stays zero-diff.

## Review round (Codex + independent agent)

Two independent reviews (Codex via OpenCLI, plus an isolated agent) ran against this diff with the Astryx 0.1.9 sources as the semantic authority. Both P1s they agreed on are fixed and pinned by new e2e steps:

- **Focus theft while open** — the settled callback's identity changed every render (`usePopover` returns a fresh object), so any parent re-render while open re-ran the initial-focus effect. Now identity-stable and keyed on the open transition; e2e pins focus staying on the picked minute.
- **Trigger couldn't close the popover** — pressing an open trigger light-dismisses on pointerdown and the same gesture's click re-opened it. Guarded by per-gesture causality (open at pointerdown && closed by click) instead of upstream's 50ms hide-timestamp window, which measurably swallows a genuine fast re-open (caught live by the e2e).
- Frozen-contract regressions restored: `sideOffset` honored as top-layer margin, 4px popup padding kept (inline style — slice rules bar new Tailwind), `isModal: false` (light dismiss never inerts the background), `aria-describedby` composed from the render element, and the hand-rolled `composeRefs` replaced by Astryx `mergeRefs` (React 19 cleanup contract).
- Pushed back with evidence: the "close button is English" finding (the PR 2 `AstryxLocaleProvider` override map already localizes `@astryx.popover.close`); strict controlled visibility (native `popover="auto"` bypasses JS; the limit is documented in the adapter header).

Recorded behavior drift, accepted as Astryx-native: tooltip show delay 600ms → 200ms; the popup gains Astryx's hidden tab-past close button; each mounted tooltip keeps one document keydown listener and a hidden top-layer node — linear in chat-turn actions, worth a re-check when PR 6 migrates menus.