### PR TITLE
refactor(ui): declare Markdown migration subtree

### DIFF
--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -43,6 +43,7 @@ const MARKDOWN_BODY = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'markdown-body
 const CHAT_MESSAGE_CSS = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'styles', 'chat-message.css');
 const TOKENS_CSS = resolve(REPO_ROOT, 'apps', 'desktop', 'src', 'renderer', 'maka-tokens.css');
 const CHAT_PRIMITIVE = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'primitives', 'chat.tsx');
+const CHAT_TURN = resolve(REPO_ROOT, 'packages', 'ui', 'src', 'chat-turn.tsx');
 
 /** Markdown block + inline elements whose typography the prose layer owns. */
 const PROSE_ELEMENTS = [
@@ -71,6 +72,12 @@ function leafSelectors(css: string): string[] {
 }
 
 describe('MARKDOWN-PROSE-CONVERGE-0 contract (#546 PR4)', () => {
+  it('declares the turn reflow boundary for the Markdown migration harness', async () => {
+    const src = await readFile(CHAT_TURN, 'utf8');
+    assert.match(src, /data-maka-contract="markdown-flow"/);
+    assert.doesNotMatch(src, /\[data-maka-contract(?:=|])/);
+  });
+
   it('every Markdown prose element has a rule scoped under .maka-prose', async () => {
     const css = await readFile(PROSE_CSS, 'utf8');
     const selectors = leafSelectors(css);

--- a/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/markdown-prose-contract.test.ts
@@ -345,6 +345,16 @@ describe('PROSE-POLISH-13PX-0 contract (#546 Phase B)', () => {
       /\.maka-prose\s*>\s*\.maka-markdown-root\s*>\s*:last-child\s*\{[^}]*margin-bottom:\s*0/,
       'the Streamdown root must forward the trailing edge trim to its last Markdown block',
     );
+    assert.match(
+      css,
+      /\.maka-prose\s*>\s*\[data-maka-contract="markdown"\]\s*>\s*\.maka-markdown-root\s*>\s*:first-child\s*\{[^}]*margin-top:\s*0/,
+      'the boxless migration hook must preserve the Streamdown leading edge trim',
+    );
+    assert.match(
+      css,
+      /\.maka-prose\s*>\s*\[data-maka-contract="markdown"\]\s*>\s*\.maka-markdown-root\s*>\s*:last-child\s*\{[^}]*margin-bottom:\s*0/,
+      'the boxless migration hook must preserve the Streamdown trailing edge trim',
+    );
     // One home: the shell keeps only container geometry (padding). Duplicated
     // typography on the shell would silently drift from the prose layer.
     const chat = stripCssComments(await readFile(CHAT_MESSAGE_CSS, 'utf8'));

--- a/apps/desktop/src/renderer/styles/prose.css
+++ b/apps/desktop/src/renderer/styles/prose.css
@@ -538,3 +538,7 @@
 .maka-prose > :last-child { margin-bottom: 0; }
 .maka-prose > .maka-markdown-root > :first-child { margin-top: 0; }
 .maka-prose > .maka-markdown-root > :last-child { margin-bottom: 0; }
+/* #1565 migration hook: display:contents keeps the box tree flat, while this
+   bridge preserves the legacy direct-child trims until PR 7 removes prose.css. */
+.maka-prose > [data-maka-contract="markdown"] > .maka-markdown-root > :first-child { margin-top: 0; }
+.maka-prose > [data-maka-contract="markdown"] > .maka-markdown-root > :last-child { margin-bottom: 0; }

--- a/packages/ui/src/__tests__/markdown-body.test.ts
+++ b/packages/ui/src/__tests__/markdown-body.test.ts
@@ -15,12 +15,13 @@ it('keeps raw HTML inert instead of expanding the Markdown trust surface', () =>
   assert.doesNotMatch(markup, /<details/);
 });
 
-it('exposes one stable Maka root around rendered Markdown blocks', () => {
+it('declares the Markdown migration subtree around the stable product root', () => {
   const markup = renderToStaticMarkup(createElement(MarkdownBody, {
     text: '# Heading\n\nparagraph',
   }));
 
-  assert.match(markup, /^<div class="[^"]*\bmaka-markdown-root\b[^"]*">/);
+  assert.match(markup, /^<div[^>]*data-maka-contract="markdown"/);
+  assert.match(markup, /<div class="[^"]*\bmaka-markdown-root\b[^"]*">/);
 });
 
 it('preserves allowlisted Maka navigation links through sanitization', () => {

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -393,6 +393,7 @@ export const TurnView = memo(function TurnView(props: {
   return (
     <section
       className="maka-turn"
+      data-maka-contract="markdown-flow"
       data-turn-id={turn.turnId}
       data-live-streaming={props.liveStreaming ? 'true' : undefined}
       data-search-highlight={props.searchHighlighted ? 'true' : undefined}

--- a/packages/ui/src/markdown-body.tsx
+++ b/packages/ui/src/markdown-body.tsx
@@ -93,16 +93,22 @@ function bareElement<K extends keyof React.JSX.IntrinsicElements>(Tag: K) {
 
 export function MarkdownBody(props: { text: string; streaming?: boolean }) {
   return (
-    <Streamdown
-      className="maka-markdown-root"
-      mode={props.streaming ? 'streaming' : 'static'}
-      parseIncompleteMarkdown={props.streaming}
-      controls={false}
-      lineNumbers={false}
-      remarkPlugins={MARKDOWN_REMARK_PLUGINS}
-      rehypePlugins={MARKDOWN_REHYPE_PLUGINS}
-      urlTransform={markdownUrlTransform}
-      components={{
+    <div
+      data-maka-contract="markdown"
+      // Contract identity only: the box-tree-aware visual harness flattens
+      // display:contents wrappers, so adding this hook is a zero-pixel change.
+      style={{ display: 'contents' }}
+    >
+      <Streamdown
+        className="maka-markdown-root"
+        mode={props.streaming ? 'streaming' : 'static'}
+        parseIncompleteMarkdown={props.streaming}
+        controls={false}
+        lineNumbers={false}
+        remarkPlugins={MARKDOWN_REMARK_PLUGINS}
+        rehypePlugins={MARKDOWN_REHYPE_PLUGINS}
+        urlTransform={markdownUrlTransform}
+        components={{
         // PR-UI-RENDER-2: route `maka://` links through the internal
         // URI parser so the assistant can drop in-app navigation
         // affordances ("用账号登录 Settings → Account"). The parser
@@ -179,10 +185,11 @@ export function MarkdownBody(props: { text: string; streaming?: boolean }) {
         tr: bareElement('tr'),
         th: bareElement('th'),
         td: bareElement('td'),
-      }}
-    >
-      {props.text}
-    </Streamdown>
+        }}
+      >
+        {props.text}
+      </Streamdown>
+    </div>
   );
 }
 


### PR DESCRIPTION
## Summary

Add the stable `data-maka-contract="markdown"` identity hook required before #1565 PR 7 can replace the Markdown renderer without using product classes in the declared-subtree harness. The wrapper is boxless, and the temporary legacy edge-trim bridge keeps this prerequisite at zero visual diff.

Refs #1565.

## Verification

- `npm --workspace @maka/ui test` — 269 passed
- Markdown prose contract — 26 passed
- `npm run check:visual-contract` — 20 route/theme/platform comparisons clean against `main`
- `npm run check:hit-test` — 5 routes clean
- `npm run lint`
- `npm run format:check`
- `npm run typecheck`
- `git diff --check`

No screenshot attached: this is a zero-pixel contract-only prerequisite, verified by the computed-style comparison above.