### PR TITLE
fix(ui): harden the Astryx floating kernel (PR 5 review round 2)

### DIFF
--- a/apps/desktop/e2e/floating-layers.spec.ts
+++ b/apps/desktop/e2e/floating-layers.spec.ts
@@ -44,6 +44,24 @@ test('tooltip opens on hover in the top layer and dismisses on Escape', async ({
   await expect(tooltip).toBeVisible();
   await page.mouse.move(10, 300);
   await expect(tooltip).toBeHidden();
+
+  // Activating the trigger dismisses the tooltip (Base UI closeOnClick
+  // parity): clicking a chrome button must not leave its hint floating under
+  // the pointer. The one-shot check right after the click is what pins the
+  // fix — every other hide path (hover bridge, focusout) is delayed by at
+  // least 100ms, while the trigger's own dismissal is synchronous. The held
+  // re-check catches a show still pending its 200ms delay popping in late.
+  // The new-task button is the right subject: it resets only the main pane —
+  // no modal to inert the tooltip out of the role tree (the search trigger)
+  // and no chrome layout shift that could slide a neighboring trigger under
+  // the stationary pointer (the sidebar toggle).
+  const newTask = page.getByRole('button', { name: '新任务' });
+  await newTask.hover();
+  await expect(tooltip).toBeVisible();
+  await newTask.click();
+  expect(await tooltip.isHidden()).toBe(true);
+  await page.waitForTimeout(350);
+  await expect(tooltip).toBeHidden();
 });
 
 test('time-picker popover owns focus placement and every dismiss path', async ({

--- a/apps/desktop/e2e/floating-layers.spec.ts
+++ b/apps/desktop/e2e/floating-layers.spec.ts
@@ -78,8 +78,9 @@ test('time-picker popover owns focus placement and every dismiss path', async ({
   await expect(minute).toBeFocused();
 
   // Clicking the open trigger closes the popover — native light dismiss
-  // fires on pointerdown and the trailing click must not re-open it (the
-  // upstream lastHideTime guard). Hold the assertion past the race window.
+  // fires during the press (on pointerup per the HTML spec) and the same
+  // gesture's trailing click must not re-open it. Hold the assertion past
+  // the race window.
   await trigger.click();
   await expect(dialog).toBeHidden();
   await page.waitForTimeout(150);
@@ -93,12 +94,40 @@ test('time-picker popover owns focus placement and every dismiss path', async ({
   await expect(trigger).not.toHaveAttribute('data-popup-open');
 
   // Escape closes the popover and hands focus back to the trigger. No
-  // settling wait before this click: a re-open right after dismissing
-  // elsewhere must work — the gesture guard must not swallow it the way a
-  // hide-timestamp window would.
+  // settling wait before this click: a fast re-open right after dismissing
+  // elsewhere must work. (Best-effort pin on the hide-timestamp regression —
+  // it caught the real ~40ms gap in practice, but Playwright cannot bound
+  // the inter-action gap below 50ms, so the gesture guard's real contract is
+  // the aborted-press journey below.)
   await trigger.click();
   await expect(dialog).toBeVisible();
   await page.keyboard.press('Escape');
   await expect(dialog).toBeHidden();
   await expect(trigger).toBeFocused();
+
+  // An aborted press must not poison the next keyboard activation: press on
+  // the open trigger (light dismiss closes the popover), drag off and
+  // release elsewhere — no click ever reaches the trigger, so a naive
+  // per-gesture flag would linger. The next Enter has no paired pointerdown
+  // and must still toggle the popover open. The release point sits beside
+  // the trigger, clear of the popup anchored below it: the spec's light
+  // dismiss deliberately ignores gestures whose down/up straddle a popover
+  // boundary (drag-out protection), so releasing inside would not dismiss.
+  await trigger.press('Enter');
+  await expect(dialog).toBeVisible();
+  const triggerBox = await trigger.boundingBox();
+  if (!triggerBox) throw new Error('trigger has no box');
+  await page.mouse.move(triggerBox.x + triggerBox.width / 2, triggerBox.y + triggerBox.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(triggerBox.x + triggerBox.width + 160, triggerBox.y + triggerBox.height / 2);
+  await page.mouse.up();
+  await expect(dialog).toBeHidden();
+  // `toBeHidden` tracks the DOM (`:popover-open` gone); the attribute tracks
+  // React state, which syncs through the layer's queued `toggle` task. Wait
+  // for it so Enter lands after the close fully settled.
+  await expect(trigger).not.toHaveAttribute('data-popup-open');
+  await trigger.press('Enter');
+  await expect(dialog).toBeVisible();
+  await page.keyboard.press('Escape');
+  await expect(dialog).toBeHidden();
 });

--- a/packages/ui/src/primitives/tooltip.tsx
+++ b/packages/ui/src/primitives/tooltip.tsx
@@ -9,6 +9,8 @@ import {
   useContext,
   useRef,
   type ButtonHTMLAttributes,
+  type MouseEvent as ReactMouseEvent,
+  type MouseEventHandler,
   type ReactElement,
   type ReactNode,
   type Ref,
@@ -81,6 +83,7 @@ type TooltipTriggerRenderElement = ReactElement<{
   className?: string;
   children?: ReactNode;
   ref?: Ref<HTMLElement>;
+  onClick?: MouseEventHandler<HTMLElement>;
   "aria-describedby"?: string;
 }>;
 
@@ -104,6 +107,19 @@ export function TooltipTrigger({
   const describedBy = existingDescribedBy
     ? `${existingDescribedBy} ${tooltip.describedBy}`
     : tooltip.describedBy;
+  // The Base UI trigger dismissed the tooltip on activation (closeOnClick
+  // default): clicking a button must not leave its hint floating under the
+  // pointer. Astryx's useTooltip returns no hide(), so this goes through its
+  // own seams — hidePopover() on the layer element (whose `toggle` listener
+  // syncs React state back) plus a synthetic mouseleave on the trigger,
+  // which cancels a show still pending its delay so the hint cannot pop in
+  // after the click. Astryx re-shows only on a real mouseenter, so the
+  // tooltip stays away until the pointer re-enters — closeOnClick semantics.
+  const hideOnActivate = (event: ReactMouseEvent<HTMLElement>) => {
+    const surface = document.getElementById(tooltip.describedBy);
+    if (surface?.matches(":popover-open")) surface.hidePopover();
+    event.currentTarget.dispatchEvent(new MouseEvent("mouseleave"));
+  };
   if (render) {
     const merged = {
       ...props,
@@ -111,6 +127,13 @@ export function TooltipTrigger({
       ref: mergeRefs<HTMLElement>(tooltip.ref, render.props.ref),
       "aria-describedby": describedBy,
       "data-slot": "tooltip-trigger",
+      onClick: (event: ReactMouseEvent<HTMLElement>) => {
+        render.props.onClick?.(event);
+        // Call-site props are button-typed but land on the render element —
+        // the same widening the prop spread below already performs.
+        (props.onClick as MouseEventHandler<HTMLElement> | undefined)?.(event);
+        hideOnActivate(event);
+      },
     };
     return children !== undefined
       ? cloneElement(render, merged, children)
@@ -124,6 +147,10 @@ export function TooltipTrigger({
       ref={tooltip.ref as RefCallback<HTMLButtonElement>}
       aria-describedby={describedBy}
       data-slot="tooltip-trigger"
+      onClick={(event) => {
+        props.onClick?.(event);
+        hideOnActivate(event);
+      }}
     >
       {children}
     </button>

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -418,9 +418,19 @@ interface PopoverRootProps {
 export function PopoverRoot({ children, open, onOpenChange, onOpenChangeComplete, label }: PopoverRootProps): React.ReactElement {
   const callbacksRef = React.useRef({ onOpenChange, onOpenChangeComplete });
   callbacksRef.current = { onOpenChange, onOpenChangeComplete };
-  const onShow = React.useCallback(() => callbacksRef.current.onOpenChange?.(true), []);
+  // Prop-driven reconcile transitions stay silent on `onOpenChange`: the
+  // parent initiated them, so echoing them back would double-report (with
+  // `open` held true, Escape reports false and the reconcile show() would
+  // otherwise report a spurious true). `useLayer` fires these callbacks
+  // synchronously inside show()/hide(), so a flag around the calls suffices.
+  // `onOpenChangeComplete` still fires — a settle is a settle no matter who
+  // initiated the transition, and TimePicker keys its settled state on it.
+  const reconcilingRef = React.useRef(false);
+  const onShow = React.useCallback(() => {
+    if (!reconcilingRef.current) callbacksRef.current.onOpenChange?.(true);
+  }, []);
   const onHide = React.useCallback(() => {
-    callbacksRef.current.onOpenChange?.(false);
+    if (!reconcilingRef.current) callbacksRef.current.onOpenChange?.(false);
     callbacksRef.current.onOpenChangeComplete?.(false);
   }, []);
   // Auto-focus is owned here (not by Astryx) so `initialFocus` can land on a
@@ -448,8 +458,13 @@ export function PopoverRoot({ children, open, onOpenChange, onOpenChangeComplete
   const { isOpen, show, hide } = popover;
   React.useEffect(() => {
     if (open === undefined) return;
-    if (open && !isOpen) show();
-    else if (!open && isOpen) hide();
+    reconcilingRef.current = true;
+    try {
+      if (open && !isOpen) show();
+      else if (!open && isOpen) hide();
+    } finally {
+      reconcilingRef.current = false;
+    }
   }, [open, isOpen, show, hide]);
 
   return <PopoverContext.Provider value={context}>{children}</PopoverContext.Provider>;

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -529,7 +529,8 @@ export function PopoverPositioner({ children, align, sideOffset }: PopoverPositi
   return <PopoverPositionContext.Provider value={value}>{children}</PopoverPositionContext.Provider>;
 }
 
-const POPOVER_FOCUSABLE = 'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])';
+const POPOVER_FOCUSABLE =
+  'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
 interface PopoverPopupProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Lands initial focus on a specific element instead of the first focusable one. */

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -373,9 +373,12 @@ export const SelectItem = forwardRef<HTMLDivElement, React.ComponentPropsWithout
  * pin: the top layer paints above every z-index by definition, which is
  * how the popup outranks the Settings modal that triggers it (the bug
  * fixed for Select in WAWQAQ msg `d3ea9a33`). Focus restore on close is
- * Astryx's `useFocusTrap` restore effect — the imperative `showPopover()`
- * path does NOT get the declarative Popover API focus return, so the trap
- * is the authority (see useFocusTrap.js in @astryxdesign/core).
+ * native first: the show-popover algorithm records the previously focused
+ * element even for imperative `showPopover()`, and `hidePopover()` returns
+ * focus to it. Light dismiss deliberately skips that return (focus follows
+ * the user's click), and Astryx's `useFocusTrap` restore effect backstops
+ * whatever the browser leaves behind (its guard no-ops when focus already
+ * went home — see useFocusTrap.js in @astryxdesign/core).
  *
  * Deliberate Astryx-native deviations from the Base UI predecessor, all
  * invisible to the closed-state harness: the popup gains Astryx's hidden

--- a/packages/ui/src/ui.tsx
+++ b/packages/ui/src/ui.tsx
@@ -461,10 +461,14 @@ export const PopoverTrigger = forwardRef<HTMLButtonElement, React.ButtonHTMLAttr
 ) {
   const { popover } = usePopoverContext('PopoverTrigger');
   // The trigger is an outside element to `popover="auto"`, so pressing it
-  // while open light-dismisses on pointerdown — and the same gesture's click
-  // would then re-open. Track per-gesture causality instead of a hide
-  // timestamp (Astryx's own Popover uses a 50ms window, which also swallows
-  // a genuine fast re-open after dismissing elsewhere).
+  // while open light-dismisses during the press (on pointerup per the HTML
+  // spec) — and the same gesture's click would then re-open. Track
+  // per-gesture causality instead of a hide timestamp (Astryx's own Popover
+  // uses a 50ms window, which also swallows a genuine fast re-open after
+  // dismissing elsewhere). The guard judges only pointer-sourced clicks
+  // (`event.detail > 0`): a keyboard activation has no paired pointerdown,
+  // so a flag left behind by an aborted press (drag off, pointercancel —
+  // gestures that end without a click on the trigger) must not swallow it.
   const wasOpenAtPointerDownRef = React.useRef(false);
   return (
     <button
@@ -479,10 +483,11 @@ export const PopoverTrigger = forwardRef<HTMLButtonElement, React.ButtonHTMLAttr
         onPointerDown?.(event);
       }}
       onClick={(event) => {
+        const dismissedByThisGesture =
+          event.detail > 0 && wasOpenAtPointerDownRef.current && !popover.isOpen;
+        wasOpenAtPointerDownRef.current = false;
         onClick?.(event);
         if (event.defaultPrevented) return;
-        const dismissedByThisGesture = wasOpenAtPointerDownRef.current && !popover.isOpen;
-        wasOpenAtPointerDownRef.current = false;
         if (dismissedByThisGesture) return;
         popover.toggle();
       }}


### PR DESCRIPTION
## Summary

Refs #1565. PR #1665 merged while its second review round was still landing; these are the adjudicated round-2 fixes (Codex fix-verification pass + an independent fresh-eye pass, both PASS with no P0/P1), cherry-picked onto current `main` content-identical to the validated tree.

- **Aborted press swallowed the next keyboard activation** (both reviewers independently): the popover trigger's per-gesture guard cleared its flag only inside a completed click, so a press that light-dismissed the popover and ended off the trigger left the flag set — the next Enter/Space was silently swallowed. The guard now judges only pointer-sourced clicks (`event.detail > 0`) and clears before the `defaultPrevented` early return.
- **Tooltip no longer lingered after activating its trigger**: Base UI's trigger closed the tooltip on activation (`closeOnClick` default); the Astryx adapter dropped that. Restored through Astryx's own seams — `hidePopover()` on the layer element (its `toggle` listener syncs state back) plus a synthetic `mouseleave` that cancels a show still pending its delay.
- **Controlled reconcile echoed `onOpenChange`**: with `open` held and the layer moving natively (Escape), the reconcile effect re-reported the parent's own instruction as a new request. Prop-driven reconcile is now silent on `onOpenChange`; `onOpenChangeComplete` still fires (lifecycle, and TimePicker keys its settled state on it).
- **Popover focus fallback could pick a disabled control**; the selector now mirrors Astryx's own exclusion.
- Comment truth-ups: light dismiss lands on pointerup per the HTML spec (not pointerdown), and focus return on close is native-first with `useFocusTrap` as backstop.

## Verification

- `@maka/ui`: typecheck clean, unit 280/280, Biome format:check clean (all on this branch, post-#1668 base).
- `floating-layers` e2e on this branch: 2/2, including the two new behavior pins (aborted-press → Enter reopens; one-shot tooltip-hidden right after trigger click). Both pins were red-verified against a pre-fix build (each fails at exactly the guarded assertion) before landing.
- Pre-merge-race, on the content-identical tree: visual contract 20/20 zero-diff, hit-test 5/5, tooltip-converge + z-index contracts 10/10, floating-layers 6/6 across 3 repeats.
- Not run here: the full desktop e2e suite (a run on the old worktree was interrupted at 2/37 by the PR #1665 merge cleanup); CI should cover it.

## Review focus

The tooltip dismissal goes through native `hidePopover()` + a synthetic `mouseleave` because Astryx's `useTooltip` exposes no `hide()`; if upstream grows one, the adapter should switch to it.