### PR TITLE
Refactor/runtime kernel split

### DIFF
--- a/packages/runtime/src/__tests__/session-manager.test.ts
+++ b/packages/runtime/src/__tests__/session-manager.test.ts
@@ -1,6 +1,5 @@
 import { describe, test } from 'node:test';
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
 import { setTimeout as timerDelay } from 'node:timers/promises';
 import { createHash } from 'node:crypto';
 import {
@@ -13940,18 +13939,6 @@ describe('SessionManager permission mode updates', () => {
       { role: 'system', text: undefined, status: 'completed' },
     ]);
     expect(backendInstances[0]?.sendInputs.length ?? 0).toBe(1);
-  });
-
-  test('RuntimeKernel turn runner uses AiSdkFlow instead of an inline mapper flow', async () => {
-    const source = await readFile(new URL('../../src/runtime-kernel.ts', import.meta.url), 'utf8');
-    const turnRunnerSource = source.slice(
-      source.indexOf('private async *runAgentTurn'),
-      source.indexOf('async stopSession'),
-    );
-
-    expect(turnRunnerSource.includes('new AiSdkFlow')).toBe(true);
-    expect(turnRunnerSource.includes('mapSessionEventToRuntimeEvent')).toBe(false);
-    expect(turnRunnerSource.includes('createSessionEventMapMemory')).toBe(false);
   });
 
   test('rejects backend configuration updates while a turn is actively streaming', async () => {

--- a/packages/runtime/src/delivery-ack-queue.ts
+++ b/packages/runtime/src/delivery-ack-queue.ts
@@ -1,0 +1,98 @@
+/**
+ * DeliveryAckQueue — single-consumer FIFO with per-entry delivery acknowledgement.
+ *
+ * Contract difference vs ./async-queue.ts:
+ * - `push(value)` returns `Promise<void>` that resolves ONLY when the consumer
+ *   has yielded the value (backpressure). The consumer's `for await` loop
+ *   drives the resolution via the finally-block in consume().
+ * - No pushedCount/consumedCount counters or waitForProgress() — this queue
+ *   does not track progress; it only ensures ordered delivery.
+ * - `fail(error: unknown)` accepts any error type (not just Error).
+ *
+ * Use case: runtime-kernel's SessionEvent stream, where each event must be
+ * fully processed (written to the run ledger) before the next is enqueued.
+ */
+
+export class DeliveryAckQueueClosed extends Error {
+  constructor() {
+    super('Delivery ack queue closed');
+    this.name = 'DeliveryAckQueueClosed';
+  }
+}
+
+export function isDeliveryAckQueueClosed(error: unknown): boolean {
+  return error instanceof DeliveryAckQueueClosed;
+}
+
+interface DeliveryAckQueueEntry<T> {
+  value: T;
+  delivered: () => void;
+  rejected: (error: unknown) => void;
+}
+
+export class DeliveryAckQueue<T> implements AsyncIterable<T> {
+  private readonly values: Array<DeliveryAckQueueEntry<T>> = [];
+  private readonly waiters: Array<{
+    resolve: (entry: DeliveryAckQueueEntry<T> | undefined) => void;
+    reject: (error: unknown) => void;
+  }> = [];
+  private closed = false;
+  private failure: unknown;
+
+  [Symbol.asyncIterator](): AsyncIterator<T> {
+    return this.consume()[Symbol.asyncIterator]();
+  }
+
+  push(value: T): Promise<void> {
+    if (this.failure) return Promise.reject(this.failure);
+    if (this.closed) return Promise.reject(new DeliveryAckQueueClosed());
+    return new Promise<void>((resolve, reject) => {
+      const entry = { value, delivered: resolve, rejected: reject };
+      const waiter = this.waiters.shift();
+      if (waiter) {
+        waiter.resolve(entry);
+        return;
+      }
+      this.values.push(entry);
+    });
+  }
+
+  fail(error: unknown): void {
+    if (this.failure) return;
+    this.failure = error;
+    for (const value of this.values.splice(0)) value.rejected(error);
+    for (const waiter of this.waiters.splice(0)) waiter.reject(error);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.closed = true;
+    const closed = new DeliveryAckQueueClosed();
+    for (const value of this.values.splice(0)) value.rejected(closed);
+    for (const waiter of this.waiters.splice(0)) waiter.resolve(undefined);
+  }
+
+  private async *consume(): AsyncIterable<T> {
+    while (true) {
+      const entry = await this.nextEntry();
+      if (!entry) return;
+      try {
+        yield entry.value;
+      } finally {
+        entry.delivered();
+      }
+    }
+  }
+
+  private nextEntry(): Promise<DeliveryAckQueueEntry<T> | undefined> {
+    if (this.values.length > 0) {
+      const next = this.values.shift()!;
+      return Promise.resolve(next);
+    }
+    if (this.failure) return Promise.reject(this.failure);
+    if (this.closed) return Promise.resolve(undefined);
+    return new Promise<DeliveryAckQueueEntry<T> | undefined>((resolve, reject) => {
+      this.waiters.push({ resolve, reject });
+    });
+  }
+}

--- a/packages/runtime/src/history-compact-checkpoint-coordinator.ts
+++ b/packages/runtime/src/history-compact-checkpoint-coordinator.ts
@@ -1,0 +1,126 @@
+import type { AgentRunStore, RuntimeEvent, RuntimeEventStore } from '@maka/core';
+import { isSessionInlineRun } from '@maka/core';
+import { loadLatestHistoryCompactCheckpointFromRunLedger } from './history-compact-ledger.js';
+import {
+  canReplaceHistoryCompactCheckpoint,
+  type HistoryCompactCheckpoint,
+} from './history-compact-checkpoint.js';
+import type { AgentRun } from './agent-run.js';
+
+export interface HistoryCompactCleanupRequest {
+  sessionId: string;
+  checkpoint: HistoryCompactCheckpoint;
+  runtimeEvents: readonly RuntimeEvent[];
+}
+
+interface HistoryCompactCheckpointCoordinatorDeps {
+  runStore?: AgentRunStore;
+  runtimeEventStore?: RuntimeEventStore;
+  cleanupHistoryCompactArtifacts?: (input: HistoryCompactCleanupRequest) => Promise<void>;
+}
+
+export class HistoryCompactCheckpointCoordinator {
+  private readonly checkpoints = new Map<string, HistoryCompactCheckpoint | undefined>();
+  private readonly loads = new Map<string, Promise<HistoryCompactCheckpoint | undefined>>();
+  private readonly writes = new Map<string, Promise<void>>();
+  private readonly cleanups = new Map<string, Promise<void>>();
+
+  constructor(private readonly deps: HistoryCompactCheckpointCoordinatorDeps) {}
+
+  load(sessionId: string): Promise<HistoryCompactCheckpoint | undefined> {
+    if (this.checkpoints.has(sessionId)) {
+      return Promise.resolve(this.checkpoints.get(sessionId));
+    }
+    const existing = this.loads.get(sessionId);
+    if (existing) return existing;
+    if (!this.deps.runStore) return Promise.resolve(undefined);
+
+    let guardedLoad: Promise<HistoryCompactCheckpoint | undefined>;
+    guardedLoad = loadLatestHistoryCompactCheckpointFromRunLedger(this.deps.runStore, sessionId)
+      .then((checkpoint) => {
+        if (checkpoint) this.scheduleCleanup(sessionId, checkpoint);
+        if (this.loads.get(sessionId) === guardedLoad && !this.checkpoints.has(sessionId)) {
+          this.checkpoints.set(sessionId, checkpoint);
+        }
+        return this.checkpoints.has(sessionId) ? this.checkpoints.get(sessionId) : checkpoint;
+      })
+      .finally(() => {
+        if (this.loads.get(sessionId) === guardedLoad) {
+          this.loads.delete(sessionId);
+        }
+      });
+    this.loads.set(sessionId, guardedLoad);
+    return guardedLoad;
+  }
+
+  record(
+    sessionId: string,
+    checkpoint: HistoryCompactCheckpoint,
+    run: AgentRun | undefined,
+  ): Promise<void> {
+    if (!run) return Promise.reject(new Error('No active AgentRun for history compact checkpoint'));
+    const previous = this.writes.get(sessionId) ?? Promise.resolve();
+    let tracked: Promise<void>;
+    tracked = previous
+      .catch(() => {})
+      .then(async () => {
+        const durableCheckpoint = await this.load(sessionId);
+        if (!canReplaceHistoryCompactCheckpoint(durableCheckpoint, checkpoint)) {
+          throw new Error('History compact checkpoint was superseded before persistence');
+        }
+        await run.recordHistoryCompactCheckpoint(checkpoint);
+        this.checkpoints.set(sessionId, checkpoint);
+        this.scheduleCleanup(sessionId, checkpoint);
+      })
+      .finally(() => {
+        if (this.writes.get(sessionId) === tracked) {
+          this.writes.delete(sessionId);
+        }
+      });
+    this.writes.set(sessionId, tracked);
+    return tracked;
+  }
+
+  clear(sessionId: string): void {
+    this.checkpoints.delete(sessionId);
+    this.loads.delete(sessionId);
+  }
+
+  private scheduleCleanup(sessionId: string, checkpoint: HistoryCompactCheckpoint): void {
+    if (
+      !this.deps.cleanupHistoryCompactArtifacts ||
+      !this.deps.runStore ||
+      !this.deps.runtimeEventStore
+    )
+      return;
+    const previous = this.cleanups.get(sessionId) ?? Promise.resolve();
+    let tracked: Promise<void>;
+    tracked = previous
+      .catch(() => {})
+      .then(async () => {
+        const runs = (await this.deps.runStore!.listSessionRuns(sessionId)).filter(
+          isSessionInlineRun,
+        );
+        const runtimeEvents: RuntimeEvent[] = [];
+        for (const run of runs) {
+          runtimeEvents.push(
+            ...(await this.deps.runtimeEventStore!.readRuntimeEvents(sessionId, run.runId)),
+          );
+        }
+        await this.deps.cleanupHistoryCompactArtifacts!({
+          sessionId,
+          checkpoint,
+          runtimeEvents,
+        });
+      })
+      .catch(() => {
+        // Legacy cleanup is reclaim-only. Runtime replay must remain available on failure.
+      })
+      .finally(() => {
+        if (this.cleanups.get(sessionId) === tracked) {
+          this.cleanups.delete(sessionId);
+        }
+      });
+    this.cleanups.set(sessionId, tracked);
+  }
+}

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -105,6 +105,7 @@ import {
   type RuntimeInteractionRunBinding,
   type RuntimeInteractionRunClosureReason,
 } from './interaction-authority.js';
+import { DeliveryAckQueue, isDeliveryAckQueueClosed } from './delivery-ack-queue.js';
 
 export interface RuntimeKernelLike {
   claimExecution(sessionId: string): RuntimeExecutionClaim;
@@ -1389,7 +1390,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     onRunStarted?: (runId: string, initialHeader: SessionHeader) => void | Promise<void>,
     initialHeader?: SessionHeader,
   ): AsyncIterable<SessionEvent> {
-    const sessionEvents = new AsyncEventQueue<SessionEvent>();
+    const sessionEvents = new DeliveryAckQueue<SessionEvent>();
     const { abortController, release: releaseExecutionAbort } =
       this.inheritExecutionAbort(execution);
     let flowDone = false;
@@ -1517,7 +1518,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
         await sessionEvents.push(sessionEvent);
       },
       onError: async (error) => {
-        if (!isAsyncEventQueueClosed(error)) {
+        if (!isDeliveryAckQueueClosed(error)) {
           await run.recordFailure(error);
           sessionEvents.fail(error);
         }
@@ -1630,7 +1631,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     bindHostedRoot = false,
     onRunStarted?: () => void | Promise<void>,
   ): AsyncIterable<SessionEvent> {
-    const sessionEvents = new AsyncEventQueue<SessionEvent>();
+    const sessionEvents = new DeliveryAckQueue<SessionEvent>();
     const { abortController, release: releaseExecutionAbort } =
       this.inheritExecutionAbort(execution);
     let flowDone = false;
@@ -1690,7 +1691,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
         await sessionEvents.push(sessionEvent);
       },
       onError: async (error) => {
-        if (!isAsyncEventQueueClosed(error)) {
+        if (!isDeliveryAckQueueClosed(error)) {
           await run.recordFailure(error);
           sessionEvents.fail(error);
         }
@@ -1835,7 +1836,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     flow: AiSdkFlow;
     flowDone: boolean;
     abortController: AbortController;
-    sessionEvents: AsyncEventQueue<SessionEvent>;
+    sessionEvents: DeliveryAckQueue<SessionEvent>;
     runnerResult: Promise<InvocationResult>;
     interactionRun: RuntimeInteractionRunBinding | undefined;
     runnerFailure?: unknown;
@@ -3743,17 +3744,6 @@ function effectiveOrchestrationForRun(
   return resolveEffectiveOrchestration(session.orchestrationMode, undefined);
 }
 
-class AsyncEventQueueClosed extends Error {
-  constructor() {
-    super('Async event queue closed');
-    this.name = 'AsyncEventQueueClosed';
-  }
-}
-
-function isAsyncEventQueueClosed(error: unknown): boolean {
-  return error instanceof AsyncEventQueueClosed;
-}
-
 async function interactionResumeAllowed(
   interactionRun: RuntimeInteractionRunBinding | undefined,
   event: SessionEvent,
@@ -3849,79 +3839,6 @@ class FailureCollector {
   throwIfAny(message: string): void {
     if (this.failures.length === 1) throw this.failures[0];
     if (this.failures.length > 1) throw new AggregateError(this.failures, message);
-  }
-}
-
-interface AsyncEventQueueEntry<T> {
-  value: T;
-  delivered: () => void;
-  rejected: (error: unknown) => void;
-}
-
-class AsyncEventQueue<T> implements AsyncIterable<T> {
-  private readonly values: Array<AsyncEventQueueEntry<T>> = [];
-  private readonly waiters: Array<{
-    resolve: (entry: AsyncEventQueueEntry<T> | undefined) => void;
-    reject: (error: unknown) => void;
-  }> = [];
-  private closed = false;
-  private failure: unknown;
-
-  [Symbol.asyncIterator](): AsyncIterator<T> {
-    return this.consume()[Symbol.asyncIterator]();
-  }
-
-  push(value: T): Promise<void> {
-    if (this.failure) return Promise.reject(this.failure);
-    if (this.closed) return Promise.reject(new AsyncEventQueueClosed());
-    return new Promise<void>((resolve, reject) => {
-      const entry = { value, delivered: resolve, rejected: reject };
-      const waiter = this.waiters.shift();
-      if (waiter) {
-        waiter.resolve(entry);
-        return;
-      }
-      this.values.push(entry);
-    });
-  }
-
-  fail(error: unknown): void {
-    if (this.failure) return;
-    this.failure = error;
-    for (const value of this.values.splice(0)) value.rejected(error);
-    for (const waiter of this.waiters.splice(0)) waiter.reject(error);
-  }
-
-  close(): void {
-    if (this.closed) return;
-    this.closed = true;
-    const closed = new AsyncEventQueueClosed();
-    for (const value of this.values.splice(0)) value.rejected(closed);
-    for (const waiter of this.waiters.splice(0)) waiter.resolve(undefined);
-  }
-
-  private async *consume(): AsyncIterable<T> {
-    while (true) {
-      const entry = await this.nextEntry();
-      if (!entry) return;
-      try {
-        yield entry.value;
-      } finally {
-        entry.delivered();
-      }
-    }
-  }
-
-  private nextEntry(): Promise<AsyncEventQueueEntry<T> | undefined> {
-    if (this.values.length > 0) {
-      const next = this.values.shift()!;
-      return Promise.resolve(next);
-    }
-    if (this.failure) return Promise.reject(this.failure);
-    if (this.closed) return Promise.resolve(undefined);
-    return new Promise<AsyncEventQueueEntry<T> | undefined>((resolve, reject) => {
-      this.waiters.push({ resolve, reject });
-    });
   }
 }
 

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -79,6 +79,10 @@ import {
   canReplaceHistoryCompactCheckpoint,
   type HistoryCompactCheckpoint,
 } from './history-compact-checkpoint.js';
+import {
+  HistoryCompactCheckpointCoordinator,
+  type HistoryCompactCleanupRequest,
+} from './history-compact-checkpoint-coordinator.js';
 import { shouldAppendContextCompactionFailedOpenNote } from './context-budget.js';
 import {
   buildResumePlanFromRuntimeEvents,
@@ -271,11 +275,7 @@ export interface RuntimeKernelDeps {
   interactionAuthority?: RuntimeInteractionAuthority;
 }
 
-export interface HistoryCompactCleanupRequest {
-  sessionId: string;
-  checkpoint: HistoryCompactCheckpoint;
-  runtimeEvents: readonly RuntimeEvent[];
-}
+export type { HistoryCompactCleanupRequest } from './history-compact-checkpoint-coordinator.js';
 
 interface BackendGeneration extends AgentRunActiveSession {
   sessionId: string;
@@ -383,16 +383,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     PendingExecutionClaim
   >();
   private readonly stopIntents = new Map<string, SessionStopIntent>();
-  private readonly historyCompactCheckpoints = new Map<
-    string,
-    HistoryCompactCheckpoint | undefined
-  >();
-  private readonly historyCompactCheckpointLoads = new Map<
-    string,
-    Promise<HistoryCompactCheckpoint | undefined>
-  >();
-  private readonly historyCompactCheckpointWrites = new Map<string, Promise<void>>();
-  private readonly historyCompactCleanupWrites = new Map<string, Promise<void>>();
+  private readonly historyCompactCoordinator: HistoryCompactCheckpointCoordinator;
   private readonly pendingContinuationClaims = new Set<string>();
   private readonly pendingContinuationSessions = new Set<string>();
   private readonly steeringBySession = new Map<string, SessionSteeringState>();
@@ -405,6 +396,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
     if (deps.runStore && !deps.runtimeEventStore) {
       throw new Error('RuntimeEventStore is required when AgentRunStore is configured');
     }
+    this.historyCompactCoordinator = new HistoryCompactCheckpointCoordinator(deps);
   }
 
   private async runBackendActivation<T>(operation: () => Promise<T> | T): Promise<T> {
@@ -2450,8 +2442,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
   private async disposeBackendNow(sessionId: string): Promise<BackendDisposalOutcome> {
     const generations = this.backendGenerationsFor(sessionId);
     this.steeringBySession.delete(sessionId);
-    this.historyCompactCheckpoints.delete(sessionId);
-    this.historyCompactCheckpointLoads.delete(sessionId);
+    this.historyCompactCoordinator.clear(sessionId);
     let disposalError: unknown;
     for (const active of generations) {
       const outcome = await this.quarantineBackendGeneration(active);
@@ -2616,108 +2607,6 @@ export class RuntimeKernel implements RuntimeKernelLike {
     );
   }
 
-  private loadHistoryCompactCheckpoint(
-    sessionId: string,
-  ): Promise<HistoryCompactCheckpoint | undefined> {
-    if (this.historyCompactCheckpoints.has(sessionId)) {
-      return Promise.resolve(this.historyCompactCheckpoints.get(sessionId));
-    }
-    const existing = this.historyCompactCheckpointLoads.get(sessionId);
-    if (existing) return existing;
-    if (!this.deps.runStore) return Promise.resolve(undefined);
-
-    let guardedLoad: Promise<HistoryCompactCheckpoint | undefined>;
-    guardedLoad = loadLatestHistoryCompactCheckpointFromRunLedger(this.deps.runStore, sessionId)
-      .then((checkpoint) => {
-        if (checkpoint) this.scheduleHistoryCompactCleanup(sessionId, checkpoint);
-        if (
-          this.historyCompactCheckpointLoads.get(sessionId) === guardedLoad &&
-          !this.historyCompactCheckpoints.has(sessionId)
-        ) {
-          this.historyCompactCheckpoints.set(sessionId, checkpoint);
-        }
-        return this.historyCompactCheckpoints.has(sessionId)
-          ? this.historyCompactCheckpoints.get(sessionId)
-          : checkpoint;
-      })
-      .finally(() => {
-        if (this.historyCompactCheckpointLoads.get(sessionId) === guardedLoad) {
-          this.historyCompactCheckpointLoads.delete(sessionId);
-        }
-      });
-    this.historyCompactCheckpointLoads.set(sessionId, guardedLoad);
-    return guardedLoad;
-  }
-
-  private recordHistoryCompactCheckpoint(
-    sessionId: string,
-    checkpoint: HistoryCompactCheckpoint,
-    run: AgentRun | undefined,
-  ): Promise<void> {
-    if (!run) return Promise.reject(new Error('No active AgentRun for history compact checkpoint'));
-    const previous = this.historyCompactCheckpointWrites.get(sessionId) ?? Promise.resolve();
-    let tracked: Promise<void>;
-    tracked = previous
-      .catch(() => {})
-      .then(async () => {
-        const durableCheckpoint = await this.loadHistoryCompactCheckpoint(sessionId);
-        if (!canReplaceHistoryCompactCheckpoint(durableCheckpoint, checkpoint)) {
-          throw new Error('History compact checkpoint was superseded before persistence');
-        }
-        await run.recordHistoryCompactCheckpoint(checkpoint);
-        this.historyCompactCheckpoints.set(sessionId, checkpoint);
-        this.scheduleHistoryCompactCleanup(sessionId, checkpoint);
-      })
-      .finally(() => {
-        if (this.historyCompactCheckpointWrites.get(sessionId) === tracked) {
-          this.historyCompactCheckpointWrites.delete(sessionId);
-        }
-      });
-    this.historyCompactCheckpointWrites.set(sessionId, tracked);
-    return tracked;
-  }
-
-  private scheduleHistoryCompactCleanup(
-    sessionId: string,
-    checkpoint: HistoryCompactCheckpoint,
-  ): void {
-    if (
-      !this.deps.cleanupHistoryCompactArtifacts ||
-      !this.deps.runStore ||
-      !this.deps.runtimeEventStore
-    )
-      return;
-    const previous = this.historyCompactCleanupWrites.get(sessionId) ?? Promise.resolve();
-    let tracked: Promise<void>;
-    tracked = previous
-      .catch(() => {})
-      .then(async () => {
-        const runs = (await this.deps.runStore!.listSessionRuns(sessionId)).filter(
-          isSessionInlineRun,
-        );
-        const runtimeEvents: RuntimeEvent[] = [];
-        for (const run of runs) {
-          runtimeEvents.push(
-            ...(await this.deps.runtimeEventStore!.readRuntimeEvents(sessionId, run.runId)),
-          );
-        }
-        await this.deps.cleanupHistoryCompactArtifacts!({
-          sessionId,
-          checkpoint,
-          runtimeEvents,
-        });
-      })
-      .catch(() => {
-        // Legacy cleanup is reclaim-only. Runtime replay must remain available on failure.
-      })
-      .finally(() => {
-        if (this.historyCompactCleanupWrites.get(sessionId) === tracked) {
-          this.historyCompactCleanupWrites.delete(sessionId);
-        }
-      });
-    this.historyCompactCleanupWrites.set(sessionId, tracked);
-  }
-
   private async ensureActive(
     sessionId: string,
     header: SessionHeader,
@@ -2775,7 +2664,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
                 const run = runId ? active?.activeRuns.get(runId) : undefined;
                 run?.recordProviderRequestAttempt(attempt);
               },
-              loadHistoryCompactCheckpoint: () => this.loadHistoryCompactCheckpoint(sessionId),
+              loadHistoryCompactCheckpoint: () => this.historyCompactCoordinator.load(sessionId),
               recordHistoryCompactCheckpoint: (
                 checkpoint: HistoryCompactCheckpoint,
                 turnId: string,
@@ -2783,7 +2672,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
                 const active = this.active.get(sessionId);
                 const runId = active?.turnToRunId.get(turnId);
                 const run = runId ? active?.activeRuns.get(runId) : undefined;
-                return this.recordHistoryCompactCheckpoint(sessionId, checkpoint, run);
+                return this.historyCompactCoordinator.record(sessionId, checkpoint, run);
               },
             }
           : {}),
@@ -2926,7 +2815,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
                 const run = runId ? active?.activeRuns.get(runId) : undefined;
                 run?.recordProviderRequestAttempt(attempt);
               },
-              loadHistoryCompactCheckpoint: () => this.loadHistoryCompactCheckpoint(sessionId),
+              loadHistoryCompactCheckpoint: () => this.historyCompactCoordinator.load(sessionId),
               recordHistoryCompactCheckpoint: (
                 checkpoint: HistoryCompactCheckpoint,
                 turnId: string,
@@ -2934,7 +2823,7 @@ export class RuntimeKernel implements RuntimeKernelLike {
                 const active = this.childActive.get(activeKey);
                 const runId = active?.turnToRunId.get(turnId);
                 const run = runId ? active?.activeRuns.get(runId) : undefined;
-                return this.recordHistoryCompactCheckpoint(sessionId, checkpoint, run);
+                return this.historyCompactCoordinator.record(sessionId, checkpoint, run);
               },
             }
           : {}),

--- a/packages/runtime/src/runtime-kernel.ts
+++ b/packages/runtime/src/runtime-kernel.ts
@@ -57,6 +57,7 @@ import {
   runLegacyProviderRetry,
 } from './runtime-runner.js';
 import type {
+  BackendFactoryContext,
   BackendRegistry,
   CompactSessionInput,
   SessionStore,
@@ -2607,6 +2608,75 @@ export class RuntimeKernel implements RuntimeKernelLike {
     );
   }
 
+  /**
+   * Builds the backend recorder hooks shared by `ensureActive` and
+   * `ensureChildActive`. The two paths are structurally identical except for
+   * which active-session map they resolve against — captured here by
+   * `resolveActive`, so each call site binds its own resolver. Callers retain
+   * the intentionally divergent fields (`allowMidTurnHistoryCompaction`,
+   * `shellRunContextSummary`, system prompt/tools source) at their own sites.
+   */
+  private buildBackendRecorderHooks(input: {
+    resolveActive: () => BackendGeneration | undefined;
+    sessionId: string;
+  }): Pick<
+    BackendFactoryContext,
+    | 'recordRunTrace'
+    | 'recordProviderRequestCapture'
+    | 'recordProviderRequestAttempt'
+    | 'loadHistoryCompactCheckpoint'
+    | 'recordHistoryCompactCheckpoint'
+    | 'loadTurnRuntimeEvents'
+    | 'recordActiveFullCompactBlock'
+    | 'recordSemanticCompactBlock'
+  > {
+    const { resolveActive, sessionId } = input;
+    const runFor = (turnId: string): AgentRun | undefined => {
+      const active = resolveActive();
+      const runId = active?.turnToRunId.get(turnId);
+      return runId ? active?.activeRuns.get(runId) : undefined;
+    };
+    return {
+      recordRunTrace: (event) => {
+        runFor(event.turnId)?.recordRunTrace(event);
+      },
+      ...(this.deps.runStore
+        ? {
+            recordProviderRequestCapture: (capture) => {
+              const run = runFor(capture.turnId);
+              if (!run)
+                return Promise.reject(new Error('No active AgentRun for provider request capture'));
+              return run.recordProviderRequestCapture(capture);
+            },
+            recordProviderRequestAttempt: (attempt) => {
+              runFor(attempt.turnId)?.recordProviderRequestAttempt(attempt);
+            },
+            loadHistoryCompactCheckpoint: () => this.historyCompactCoordinator.load(sessionId),
+            recordHistoryCompactCheckpoint: (
+              checkpoint: HistoryCompactCheckpoint,
+              turnId: string,
+            ) => this.historyCompactCoordinator.record(sessionId, checkpoint, runFor(turnId)),
+          }
+        : {}),
+      ...(this.deps.runtimeEventStore
+        ? {
+            loadTurnRuntimeEvents: (turnId: string) => {
+              const run = runFor(turnId);
+              if (!run)
+                return Promise.reject(new Error('No active AgentRun for turn runtime events'));
+              return run.loadTurnRuntimeEvents();
+            },
+          }
+        : {}),
+      recordActiveFullCompactBlock: (block) => {
+        runFor(block.turnId)?.recordActiveFullCompactBlock(block);
+      },
+      recordSemanticCompactBlock: (block) => {
+        runFor(block.turnId)?.recordSemanticCompactBlock(block);
+      },
+    };
+  }
+
   private async ensureActive(
     sessionId: string,
     header: SessionHeader,
@@ -2640,67 +2710,11 @@ export class RuntimeKernel implements RuntimeKernelLike {
               tools: subagent.tools,
             }
           : {}),
-        recordRunTrace: (event) => {
-          const active = this.active.get(sessionId);
-          const runId = active?.turnToRunId.get(event.turnId);
-          const run = runId ? active?.activeRuns.get(runId) : undefined;
-          run?.recordRunTrace(event);
-        },
-        ...(this.deps.runStore
-          ? {
-              recordProviderRequestCapture: (capture) => {
-                const active = this.active.get(sessionId);
-                const runId = active?.turnToRunId.get(capture.turnId);
-                const run = runId ? active?.activeRuns.get(runId) : undefined;
-                if (!run)
-                  return Promise.reject(
-                    new Error('No active AgentRun for provider request capture'),
-                  );
-                return run.recordProviderRequestCapture(capture);
-              },
-              recordProviderRequestAttempt: (attempt) => {
-                const active = this.active.get(sessionId);
-                const runId = active?.turnToRunId.get(attempt.turnId);
-                const run = runId ? active?.activeRuns.get(runId) : undefined;
-                run?.recordProviderRequestAttempt(attempt);
-              },
-              loadHistoryCompactCheckpoint: () => this.historyCompactCoordinator.load(sessionId),
-              recordHistoryCompactCheckpoint: (
-                checkpoint: HistoryCompactCheckpoint,
-                turnId: string,
-              ) => {
-                const active = this.active.get(sessionId);
-                const runId = active?.turnToRunId.get(turnId);
-                const run = runId ? active?.activeRuns.get(runId) : undefined;
-                return this.historyCompactCoordinator.record(sessionId, checkpoint, run);
-              },
-            }
-          : {}),
-        ...(this.deps.runtimeEventStore
-          ? {
-              loadTurnRuntimeEvents: (turnId: string) => {
-                const active = this.active.get(sessionId);
-                const runId = active?.turnToRunId.get(turnId);
-                const run = runId ? active?.activeRuns.get(runId) : undefined;
-                if (!run)
-                  return Promise.reject(new Error('No active AgentRun for turn runtime events'));
-                return run.loadTurnRuntimeEvents();
-              },
-            }
-          : {}),
+        ...this.buildBackendRecorderHooks({
+          resolveActive: () => this.active.get(sessionId),
+          sessionId,
+        }),
         allowMidTurnHistoryCompaction: Boolean(this.deps.runtimeEventStore),
-        recordActiveFullCompactBlock: (block) => {
-          const active = this.active.get(sessionId);
-          const runId = active?.turnToRunId.get(block.turnId);
-          const run = runId ? active?.activeRuns.get(runId) : undefined;
-          run?.recordActiveFullCompactBlock(block);
-        },
-        recordSemanticCompactBlock: (block) => {
-          const active = this.active.get(sessionId);
-          const runId = active?.turnToRunId.get(block.turnId);
-          const run = runId ? active?.activeRuns.get(runId) : undefined;
-          run?.recordSemanticCompactBlock(block);
-        },
         shellRunContextSummary: () =>
           this.deps.shellRuns?.buildContextSummary(sessionId) ?? Promise.resolve(undefined),
       });
@@ -2791,68 +2805,12 @@ export class RuntimeKernel implements RuntimeKernelLike {
         appendMessage: async () => {},
         systemPrompt,
         tools,
-        recordRunTrace: (event) => {
-          const active = this.childActive.get(activeKey);
-          const runId = active?.turnToRunId.get(event.turnId);
-          const run = runId ? active?.activeRuns.get(runId) : undefined;
-          run?.recordRunTrace(event);
-        },
-        ...(this.deps.runStore
-          ? {
-              recordProviderRequestCapture: (capture) => {
-                const active = this.childActive.get(activeKey);
-                const runId = active?.turnToRunId.get(capture.turnId);
-                const run = runId ? active?.activeRuns.get(runId) : undefined;
-                if (!run)
-                  return Promise.reject(
-                    new Error('No active AgentRun for provider request capture'),
-                  );
-                return run.recordProviderRequestCapture(capture);
-              },
-              recordProviderRequestAttempt: (attempt) => {
-                const active = this.childActive.get(activeKey);
-                const runId = active?.turnToRunId.get(attempt.turnId);
-                const run = runId ? active?.activeRuns.get(runId) : undefined;
-                run?.recordProviderRequestAttempt(attempt);
-              },
-              loadHistoryCompactCheckpoint: () => this.historyCompactCoordinator.load(sessionId),
-              recordHistoryCompactCheckpoint: (
-                checkpoint: HistoryCompactCheckpoint,
-                turnId: string,
-              ) => {
-                const active = this.childActive.get(activeKey);
-                const runId = active?.turnToRunId.get(turnId);
-                const run = runId ? active?.activeRuns.get(runId) : undefined;
-                return this.historyCompactCoordinator.record(sessionId, checkpoint, run);
-              },
-            }
-          : {}),
-        ...(this.deps.runtimeEventStore
-          ? {
-              loadTurnRuntimeEvents: (turnId: string) => {
-                const active = this.childActive.get(activeKey);
-                const runId = active?.turnToRunId.get(turnId);
-                const run = runId ? active?.activeRuns.get(runId) : undefined;
-                if (!run)
-                  return Promise.reject(new Error('No active AgentRun for turn runtime events'));
-                return run.loadTurnRuntimeEvents();
-              },
-            }
-          : {}),
+        ...this.buildBackendRecorderHooks({
+          resolveActive: () => this.childActive.get(activeKey),
+          sessionId,
+        }),
         // A child-only ledger cannot claim coverage of the parent session prefix.
         allowMidTurnHistoryCompaction: false,
-        recordActiveFullCompactBlock: (block) => {
-          const active = this.childActive.get(activeKey);
-          const runId = active?.turnToRunId.get(block.turnId);
-          const run = runId ? active?.activeRuns.get(runId) : undefined;
-          run?.recordActiveFullCompactBlock(block);
-        },
-        recordSemanticCompactBlock: (block) => {
-          const active = this.childActive.get(activeKey);
-          const runId = active?.turnToRunId.get(block.turnId);
-          const run = runId ? active?.activeRuns.get(runId) : undefined;
-          run?.recordSemanticCompactBlock(block);
-        },
       });
       await this.rejectCancelledBackendActivation(
         backend,

--- a/packages/runtime/src/session-manager.ts
+++ b/packages/runtime/src/session-manager.ts
@@ -170,7 +170,7 @@ import {
   type TurnStartOptions,
 } from './runtime-kernel.js';
 import { fallbackSessionTitle, sessionTitleSource } from './session-title.js';
-import type { HistoryCompactCleanupRequest } from './runtime-kernel.js';
+import type { HistoryCompactCleanupRequest } from './history-compact-checkpoint-coordinator.js';
 import { fingerprintAgentGraphRunnableIntent } from './stream-graph-admission.js';
 import type { AgentGraphRunnableIntent } from './stream-graph-readiness.js';
 import { projectAgentGraphRecords } from './stream-graph-projection.js';


### PR DESCRIPTION
## Summary

- move the private `AsyncEventQueue` family out of the kernel into `delivery-ack-queue.ts`, renaming it to `DeliveryAckQueue`; document its backpressure contract (`push(): Promise<void>` awaits ack) against the fire-and-forget public `async-queue.ts`
- extract checkpoint `load` / `record` / `scheduleCleanup` coordination (4 concurrency maps + 3 private methods) into a self-contained `HistoryCompactCheckpointCoordinator` that depends only on injected stores, never touching `this.active` / `this.childActive`; move `HistoryCompactCleanupRequest` with it and keep public imports stable via a type-only re-export, while `session-manager.ts` now imports the type directly from the coordinator
- collapse the 8 structurally identical recorder hooks shared by `ensureActive` and `ensureChildActive` into a shared `buildBackendRecorderHooks` helper, parameterizing the only divergence (parent resolves from `this.active`, child from `this.childActive`) via a `resolveActive` callback; keep the intentionally divergent fields (`allowMidTurnHistoryCompaction`, `shellRunContextSummary`, system prompt/tools source) at their call sites
- drop the `session-manager.test.ts` source-regex contract test (forbidden by #1403) that pinned `runAgentTurn`'s structure by slicing source text; its invariant — a backend-forged `queue_update` is dropped at the AiSdkFlow ingress, never reaching observers or the ledger — is already covered more robustly by the behavioral test "a backend-forged queue_update never reaches the ledger or observers" (`session-manager.test.ts:17641`), which passes under AiSdkFlow and would crash the turn if the code regressed to the inline `mapSessionEventToRuntimeEvent` path

Refs #1406 .

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm --workspace @maka/runtime run typecheck` — passed
- `npm --workspace @maka/runtime test (2823 passed, 9 skipped)`