### PR TITLE
feat(cli): add Runtime Host-backed TUI client adapter

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -15,6 +15,7 @@
     "build": "tsc -p tsconfig.json && node scripts/chmod-bin.mjs",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "pretest": "npm --workspace @maka/core run build && npm --workspace @maka/storage run build && npm --workspace @maka/runtime run build && npm --workspace @maka/runtime-host run build",
+    "harness:runtime-host-tui": "node dist/runtime-host-tui-harness.js",
     "test": "npm run clean && npm run build && npm run test:dist",
     "test:dist": "node --test \"dist/**/*.test.js\""
   },

--- a/packages/cli/src/__tests__/host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/host-session-driver.test.ts
@@ -1,0 +1,677 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import type { InteractionPendingSnapshot } from '@maka/runtime-host/protocol';
+import type { StoredMessage } from '@maka/core/session';
+import type {
+  RuntimeHostConnection,
+  RuntimeHostSessionTranscript,
+  RuntimeHostSessionSubscription,
+} from '@maka/runtime-host/client';
+import type {
+  OperationKey,
+  SessionCatalogProjection,
+  SessionContinuitySnapshot,
+  SubscriptionFrame,
+  TurnSnapshot,
+} from '@maka/runtime-host/protocol';
+import { createHostMakaSessionDriver } from '../host-session-driver.js';
+
+describe('HostMakaSessionDriver', () => {
+  test('starts lazily, projects bounded live events, and reloads the durable transcript', async () => {
+    const session = sessionProjection();
+    const transcriptMessages: StoredMessage[] = [
+      { type: 'user', id: 'user-1', turnId: 'turn-1', ts: 1, text: 'hello' },
+      {
+        type: 'assistant',
+        id: 'assistant-1',
+        turnId: 'turn-1',
+        ts: 2,
+        text: 'world',
+        modelId: 'model-1',
+      },
+    ];
+    const calls: string[] = [];
+    const connection = fakeConnection({
+      calls,
+      session,
+      transcript: {
+        revision: 2,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: transcriptMessages,
+      },
+      frames: [
+        {
+          kind: 'subscription.session_delta',
+          hostEpoch: 'host-1',
+          subscriptionId: 'subscription-1',
+          sequence: 1,
+          sessionId: session.id,
+          delta: {
+            kind: 'text',
+            turnId: 'turn-1',
+            runId: 'run-1',
+            messageId: 'assistant-1',
+            text: 'world',
+          },
+        },
+        {
+          kind: 'subscription.session_event',
+          hostEpoch: 'host-1',
+          subscriptionId: 'subscription-1',
+          sequence: 2,
+          sessionId: session.id,
+          runId: 'run-1',
+          event: {
+            type: 'tool_start',
+            id: 'tool-start-1',
+            turnId: 'turn-1',
+            ts: 2,
+            toolUseId: 'tool-1',
+            toolName: 'Read',
+          },
+        },
+        {
+          kind: 'subscription.session_projection',
+          hostEpoch: 'host-1',
+          subscriptionId: 'subscription-1',
+          sequence: 3,
+          snapshot: snapshot({
+            ...runningTurn(),
+            status: 'completed',
+            terminalEventId: 'terminal-1',
+          }),
+        },
+      ],
+    });
+    let id = 0;
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+      newId: () => (id++ === 0 ? 'session-1' : id === 2 ? 'turn-1' : `id-${id}`),
+    });
+
+    const prepared = await driver.preparePrompt('hello');
+    assert.deepEqual(calls, ['session.create']);
+    const events = [];
+    for await (const event of prepared.events) events.push(event);
+
+    assert.deepEqual(
+      events.map((event) => event.type),
+      ['queue_update', 'text_delta', 'tool_start', 'complete'],
+    );
+    const toolStart = events.find((event) => event.type === 'tool_start');
+    assert.equal(toolStart?.type === 'tool_start' ? toolStart.args : null, undefined);
+    assert.deepEqual(calls, [
+      'session.create',
+      'subscription.open',
+      'turn.start',
+      'subscription.close',
+    ]);
+    assert.deepEqual(await driver.reloadTranscript?.(), transcriptMessages);
+    assert.equal(driver.getSessionId(), 'session-1');
+    assert.equal(driver.getPermissionMode?.(), 'ask');
+  });
+
+  test('maps Host-owned turn_started queue placement to accepted delivery', async () => {
+    const session = sessionProjection();
+    const calls: string[] = [];
+    const connection = fakeConnection({
+      calls,
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'bypass', revision: 0, displayMode: 'bypass' },
+        messages: [],
+      },
+      frames: [],
+      requestResult: (operation) =>
+        operation === 'turn.message.submit'
+          ? { disposition: 'turn_started', turnId: 'turn-2' }
+          : undefined,
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+      newId: sequenceIds('session-1', 'turn-1', 'message-1'),
+    });
+    await driver.preparePrompt('hello');
+
+    assert.deepEqual(await driver.steer?.('redirected'), { kind: 'queued' });
+    assert.ok(calls.includes('turn.message.submit'));
+  });
+
+  test('keeps observing a Host-started followup instead of ending at the previous turn', async () => {
+    const session = sessionProjection();
+    const calls: string[] = [];
+    const nextTurn = turnSnapshot('turn-2', 'run-2');
+    const connection = fakeConnection({
+      calls,
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: [],
+      },
+      frames: [
+        projectionFrame(1, terminalTurn(runningTurn())),
+        projectionFrame(2, nextTurn),
+        {
+          kind: 'subscription.session_delta',
+          hostEpoch: 'host-1',
+          subscriptionId: 'subscription-1',
+          sequence: 3,
+          sessionId: session.id,
+          delta: {
+            kind: 'text',
+            turnId: nextTurn.turnId,
+            runId: nextTurn.runId,
+            messageId: 'assistant-2',
+            text: 'followup',
+          },
+        },
+        projectionFrame(4, terminalTurn(nextTurn, 'terminal-2')),
+      ],
+      requestResult: (operation) =>
+        operation === 'turn.message.submit'
+          ? { disposition: 'turn_started', turnId: 'turn-2' }
+          : undefined,
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+      newId: sequenceIds('session-1', 'turn-1', 'message-1', 'event-1'),
+    });
+
+    const prepared = await driver.preparePrompt('hello');
+    const events = prepared.events[Symbol.asyncIterator]();
+    assert.equal((await events.next()).value?.type, 'queue_update');
+    assert.deepEqual(await driver.queueMessage?.('followup'), { kind: 'queued' });
+
+    const delta = await events.next();
+    assert.equal(delta.value?.type, 'text_delta');
+    assert.equal(delta.value?.turnId, 'turn-2');
+    const terminal = await events.next();
+    assert.equal(terminal.value?.type, 'complete');
+    assert.equal(terminal.value?.turnId, 'turn-2');
+    assert.equal((await events.next()).done, true);
+  });
+
+  test('projects and answers Host-owned permission interactions', async () => {
+    const session = sessionProjection();
+    const requests: Array<{ operation: OperationKey; input: unknown }> = [];
+    const permission = pendingPermission();
+    if (permission.request.kind !== 'permission') throw new Error('Expected permission request');
+    const connection = fakeConnection({
+      calls: [],
+      requests,
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: [],
+      },
+      snapshot: snapshot(null, [permission]),
+      frames: [projectionFrame(1, terminalTurn(runningTurn()))],
+      requestResult: (operation) =>
+        operation === 'interaction.answer'
+          ? {
+              ...permission,
+              revision: 2,
+              status: 'answered',
+              outcome: {
+                kind: 'permission_answer',
+                reviewer: 'user',
+                decision: 'allow',
+                rememberForTurn: false,
+                committedAt: 2,
+              },
+            }
+          : undefined,
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+      newId: sequenceIds('session-1', 'turn-1'),
+    });
+
+    const prepared = await driver.preparePrompt('hello');
+    const events = [];
+    for await (const event of prepared.events) events.push(event);
+    assert.deepEqual(
+      events.map((event) => event.type),
+      [
+        'queue_update',
+        'host_interaction_permission_request',
+        'host_interaction_resolved',
+        'complete',
+      ],
+    );
+    const projected = events.find((event) => event.type === 'host_interaction_permission_request');
+    assert.deepEqual(projected, {
+      id: 'interaction-interaction-1',
+      type: 'host_interaction_permission_request',
+      turnId: 'turn-1',
+      ts: projected?.ts,
+      requestId: 'interaction-1',
+      toolUseId: 'tool-1',
+      prompt: permission.request.prompt,
+    });
+
+    await driver.respondToPermission?.({
+      requestId: 'interaction-1',
+      kind: 'permission',
+      decision: 'allow',
+      rememberForTurn: false,
+    });
+    assert.deepEqual(
+      requests.find((request) => request.operation === 'interaction.answer')?.input,
+      {
+        interactionId: 'interaction-1',
+        answer: {
+          kind: 'permission',
+          decision: 'allow',
+          rememberForTurn: false,
+        },
+      },
+    );
+  });
+
+  test('observes a turn started by another Client and marks its durable boundaries', async () => {
+    const session = sessionProjection();
+    const connection = fakeConnection({
+      calls: [],
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: [],
+      },
+      frames: [
+        projectionFrame(1, runningTurn()),
+        {
+          kind: 'subscription.session_delta',
+          hostEpoch: 'host-1',
+          subscriptionId: 'subscription-1',
+          sequence: 2,
+          sessionId: session.id,
+          delta: {
+            kind: 'text',
+            turnId: 'turn-1',
+            runId: 'run-1',
+            messageId: 'assistant-1',
+            text: 'remote output',
+          },
+        },
+        projectionFrame(3, terminalTurn(runningTurn())),
+      ],
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+      newId: sequenceIds('event-1'),
+    });
+    const observations: Array<{
+      eventTypes: string[];
+      reloadTranscript: boolean;
+      activeTurn: boolean;
+    }> = [];
+    let finish!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const unsubscribe = driver.subscribeSessionObservations?.((observation) => {
+      observations.push({
+        eventTypes: observation.events.map((event) => event.type),
+        reloadTranscript: observation.reloadTranscript,
+        activeTurn: observation.activeTurn,
+      });
+      if (
+        observation.reloadTranscript &&
+        !observation.activeTurn &&
+        observation.events.some((event) => event.type === 'complete')
+      ) {
+        finish();
+      }
+    });
+
+    await driver.switchSession(session.id);
+    await finished;
+    unsubscribe?.();
+
+    assert.ok(
+      observations.some((observation) => observation.reloadTranscript && observation.activeTurn),
+    );
+    assert.ok(observations.some((observation) => observation.eventTypes.includes('text_delta')));
+    assert.ok(
+      observations.some(
+        (observation) =>
+          observation.reloadTranscript &&
+          !observation.activeTurn &&
+          observation.eventTypes.includes('complete'),
+      ),
+    );
+  });
+
+  test('projects catch-up frames when joining a Turn that is already running', async () => {
+    const session = sessionProjection();
+    const connection = fakeConnection({
+      calls: [],
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: [],
+      },
+      snapshot: snapshot(runningTurn()),
+      frames: [
+        {
+          kind: 'subscription.session_delta',
+          hostEpoch: 'host-1',
+          subscriptionId: 'subscription-1',
+          sequence: 1,
+          sessionId: session.id,
+          delta: {
+            kind: 'text',
+            turnId: 'turn-1',
+            runId: 'run-1',
+            messageId: 'assistant-1',
+            text: 'output before this Client joined',
+          },
+        },
+        {
+          kind: 'subscription.session_delta',
+          hostEpoch: 'host-1',
+          subscriptionId: 'subscription-1',
+          sequence: 2,
+          sessionId: session.id,
+          delta: {
+            kind: 'text',
+            turnId: 'turn-1',
+            runId: 'run-1',
+            messageId: 'assistant-1',
+            text: ' and output after it joined',
+          },
+        },
+        projectionFrame(3, terminalTurn(runningTurn())),
+      ],
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+      newId: sequenceIds('event-1', 'event-2'),
+    });
+    const observedText: string[] = [];
+    const activeStates: boolean[] = [];
+    let finish!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const unsubscribe = driver.subscribeSessionObservations?.((observation) => {
+      activeStates.push(observation.activeTurn);
+      for (const event of observation.events) {
+        if (event.type === 'text_delta') observedText.push(event.text);
+      }
+      if (!observation.activeTurn) finish();
+    });
+
+    await driver.switchSession(session.id);
+    await finished;
+    unsubscribe?.();
+
+    assert.equal(activeStates[0], true);
+    assert.deepEqual(observedText, [
+      'output before this Client joined',
+      ' and output after it joined',
+    ]);
+  });
+
+  test('requests a durable reload when the initial subscription cut is terminal', async () => {
+    const session = sessionProjection();
+    const connection = fakeConnection({
+      calls: [],
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: [],
+      },
+      snapshot: snapshot(terminalTurn(runningTurn())),
+      frames: [],
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+    });
+    let initial:
+      | {
+          reloadTranscript: boolean;
+          activeTurn: boolean;
+        }
+      | undefined;
+    let observed!: () => void;
+    const observation = new Promise<void>((resolve) => {
+      observed = resolve;
+    });
+    const unsubscribe = driver.subscribeSessionObservations?.((value) => {
+      initial ??= {
+        reloadTranscript: value.reloadTranscript,
+        activeTurn: value.activeTurn,
+      };
+      observed();
+    });
+
+    await driver.switchSession(session.id);
+    await observation;
+    unsubscribe?.();
+
+    assert.deepEqual(initial, { reloadTranscript: true, activeTurn: false });
+  });
+
+  test('fails closed when a resumed Session belongs to an external harness', async () => {
+    const session = sessionProjection();
+    const connection = fakeConnection({
+      calls: [],
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'external', revision: 0, displayMode: null },
+        messages: [],
+      },
+      frames: [],
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+    });
+
+    await assert.rejects(
+      driver.switchSession('session-1'),
+      /externally isolated session session-1/,
+    );
+    assert.equal(driver.getSessionId(), null);
+  });
+});
+
+interface FakeConnectionInput {
+  readonly calls: string[];
+  readonly requests?: Array<{ operation: OperationKey; input: unknown }>;
+  readonly session: SessionCatalogProjection;
+  readonly transcript: RuntimeHostSessionTranscript;
+  readonly snapshot?: SessionContinuitySnapshot;
+  readonly frames: readonly SubscriptionFrame[];
+  readonly requestResult?: (operation: OperationKey) => unknown;
+}
+
+function fakeConnection(input: FakeConnectionInput): RuntimeHostConnection {
+  const subscription: RuntimeHostSessionSubscription = {
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    snapshot: input.snapshot ?? snapshot(null),
+    async *[Symbol.asyncIterator]() {
+      yield* input.frames;
+    },
+    async close() {
+      input.calls.push('subscription.close');
+    },
+  };
+  return {
+    hostEpoch: 'host-1',
+    connectionId: 'connection-1',
+    selectedProtocol: 0,
+    closed: new Promise(() => {}),
+    async request(operation: OperationKey, operationInput: unknown) {
+      input.calls.push(operation);
+      input.requests?.push({ operation, input: operationInput });
+      const override = input.requestResult?.(operation);
+      if (override !== undefined) return override;
+      if (operation === 'session.create') return input.session;
+      if (operation === 'session.catalog.query') {
+        return { kind: 'session', session: input.session };
+      }
+      throw new Error(`Unexpected operation: ${operation}`);
+    },
+    async status() {
+      throw new Error('not used');
+    },
+    async startTurn() {
+      input.calls.push('turn.start');
+      return runningTurn();
+    },
+    async queryTurn() {
+      throw new Error('not used');
+    },
+    async stopTurn() {
+      throw new Error('not used');
+    },
+    async readSessionTranscript() {
+      return input.transcript;
+    },
+    async openSessionSubscription() {
+      input.calls.push('subscription.open');
+      return subscription;
+    },
+    async close() {},
+  } as RuntimeHostConnection;
+}
+
+function sessionProjection(): SessionCatalogProjection {
+  return {
+    id: 'session-1',
+    revision: 1,
+    cwd: '/tmp',
+    createdAt: 1,
+    lastUsedAt: 1,
+    name: 'Session',
+    isFlagged: false,
+    isArchived: false,
+    labels: [],
+    labelsTruncated: false,
+    hasUnread: false,
+    status: 'active',
+    backend: 'ai-sdk',
+    llmConnectionSlug: 'connection-1',
+    connectionLocked: false,
+    model: 'model-1',
+    permissionMode: 'ask',
+    collaborationMode: 'agent',
+    orchestrationMode: 'default',
+  };
+}
+
+function snapshot(
+  rootTurn: TurnSnapshot | null,
+  interactions: readonly InteractionPendingSnapshot[] = [],
+): SessionContinuitySnapshot {
+  return {
+    schemaVersion: 2,
+    session: {
+      sessionId: 'session-1',
+      metadataRevision: 1,
+      status: rootTurn && !isTerminal(rootTurn) ? 'running' : 'active',
+      createdAt: 1,
+      lastUsedAt: 1,
+      isArchived: false,
+    },
+    projectionRevision: rootTurn ? 2 : 1,
+    rootTurn,
+    queue: {
+      hostEpoch: 'host-1',
+      queueRevision: 0,
+      steering: [],
+      followup: [],
+    },
+    interactions: { pending: interactions },
+  };
+}
+
+function runningTurn(): TurnSnapshot {
+  return turnSnapshot('turn-1', 'run-1');
+}
+
+function turnSnapshot(turnId: string, runId: string): TurnSnapshot {
+  return { sessionId: 'session-1', turnId, runId, status: 'running' };
+}
+
+function terminalTurn(turn: TurnSnapshot, terminalEventId = 'terminal-1'): TurnSnapshot {
+  return { ...turn, status: 'completed', terminalEventId };
+}
+
+function projectionFrame(sequence: number, rootTurn: TurnSnapshot): SubscriptionFrame {
+  return {
+    kind: 'subscription.session_projection',
+    hostEpoch: 'host-1',
+    subscriptionId: 'subscription-1',
+    sequence,
+    snapshot: snapshot(rootTurn),
+  };
+}
+
+function pendingPermission(): InteractionPendingSnapshot {
+  return {
+    schemaVersion: 1,
+    interactionId: 'interaction-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    runId: 'run-1',
+    revision: 1,
+    request: {
+      kind: 'permission',
+      toolUseId: 'tool-1',
+      prompt: {
+        kind: 'tool_permission',
+        toolName: 'Bash',
+        category: 'shell_unsafe',
+        reason: 'shell_dangerous',
+        review: { kind: 'command', command: 'npm test', cwd: '/tmp' },
+        rememberForTurnAllowed: true,
+      },
+    },
+    status: 'pending',
+    outcome: null,
+  };
+}
+
+function isTerminal(turn: TurnSnapshot): boolean {
+  return turn.status === 'completed' || turn.status === 'failed' || turn.status === 'cancelled';
+}
+
+function sequenceIds(...ids: string[]): () => string {
+  let index = 0;
+  return () => ids[index++] ?? `id-${index}`;
+}

--- a/packages/cli/src/__tests__/host-session-driver.test.ts
+++ b/packages/cli/src/__tests__/host-session-driver.test.ts
@@ -7,14 +7,18 @@ import type {
   RuntimeHostSessionTranscript,
   RuntimeHostSessionSubscription,
 } from '@maka/runtime-host/client';
+import { RuntimeHostOperationError, RuntimeHostSubscriptionError } from '@maka/runtime-host/client';
 import type {
   OperationKey,
   SessionCatalogProjection,
   SessionContinuitySnapshot,
   SubscriptionFrame,
+  TurnStartInput,
+  TurnStopInput,
   TurnSnapshot,
 } from '@maka/runtime-host/protocol';
 import { createHostMakaSessionDriver } from '../host-session-driver.js';
+import type { MakaSessionObservation } from '../session-driver.js';
 
 describe('HostMakaSessionDriver', () => {
   test('starts lazily, projects bounded live events, and reloads the durable transcript', async () => {
@@ -109,7 +113,7 @@ describe('HostMakaSessionDriver', () => {
       'turn.start',
       'subscription.close',
     ]);
-    assert.deepEqual(await driver.reloadTranscript?.(), transcriptMessages);
+    assert.deepEqual(await driver.sessionObservation?.reloadTranscript(), transcriptMessages);
     assert.equal(driver.getSessionId(), 'session-1');
     assert.equal(driver.getPermissionMode?.(), 'ask');
   });
@@ -142,6 +146,263 @@ describe('HostMakaSessionDriver', () => {
 
     assert.deepEqual(await driver.steer?.('redirected'), { kind: 'queued' });
     assert.ok(calls.includes('turn.message.submit'));
+  });
+
+  test('forwards trusted per-turn orchestration to Host admission', async () => {
+    const session = sessionProjection();
+    const turnStarts: TurnStartInput[] = [];
+    const connection = fakeConnection({
+      calls: [],
+      turnStarts,
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: [],
+      },
+      frames: [projectionFrame(1, terminalTurn(runningTurn()))],
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+      newId: sequenceIds('session-1', 'turn-1'),
+    });
+
+    const prepared = await driver.preparePrompt('coordinate this', {
+      turnOrchestration: { mode: 'graph', source: 'slash_command' },
+    });
+    for await (const _event of prepared.events) {
+      // Drain the Host-owned turn.
+    }
+
+    assert.deepEqual(turnStarts, [
+      {
+        sessionId: 'session-1',
+        turnId: 'turn-1',
+        content: { text: 'coordinate this' },
+        turnOrchestration: { mode: 'graph', source: 'slash_command' },
+      },
+    ]);
+  });
+
+  test('interrupt waits for an admitted turn identity while turn.start is pending', async () => {
+    const session = sessionProjection();
+    const calls: string[] = [];
+    const requests: Array<{ operation: OperationKey; input: unknown }> = [];
+    const start = deferred<TurnSnapshot>();
+    const connection = fakeConnection({
+      calls,
+      requests,
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: [],
+      },
+      frames: [],
+      startTurnResult: start.promise,
+      requestResult: (operation) =>
+        operation === 'turn.interrupt'
+          ? {
+              queueRevision: 1,
+              retracted: [],
+              turn: {
+                ...runningTurn(),
+                status: 'cancelled',
+                terminalEventId: 'terminal-1',
+                abortSource: 'user_stop',
+              },
+            }
+          : undefined,
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+      newId: sequenceIds('session-1', 'turn-1', 'interrupt-1'),
+    });
+
+    const prepared = await driver.preparePrompt('hello');
+    const events = prepared.events[Symbol.asyncIterator]();
+    const firstEvent = events.next();
+    while (!calls.includes('turn.start')) await new Promise((resolve) => setImmediate(resolve));
+
+    const interrupted = driver.interrupt?.();
+    await Promise.resolve();
+    assert.ok(!calls.includes('turn.interrupt'));
+
+    start.resolve(runningTurn());
+    assert.equal(await interrupted, '');
+    assert.equal((await firstEvent).value?.type, 'queue_update');
+    await events.return?.();
+    assert.deepEqual(
+      requests.filter((request) => request.operation === 'turn.interrupt'),
+      [
+        {
+          operation: 'turn.interrupt',
+          input: {
+            originHostEpoch: 'host-1',
+            sessionId: 'session-1',
+            interruptId: 'interrupt-1',
+            turnId: 'turn-1',
+            runId: 'run-1',
+          },
+        },
+      ],
+    );
+  });
+
+  test('stop waits for an admitted turn identity while turn.start is pending', async () => {
+    const session = sessionProjection();
+    const calls: string[] = [];
+    const turnStops: TurnStopInput[] = [];
+    const start = deferred<TurnSnapshot>();
+    const connection = fakeConnection({
+      calls,
+      turnStops,
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: [],
+      },
+      frames: [],
+      startTurnResult: start.promise,
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+      newId: sequenceIds('session-1', 'turn-1'),
+    });
+    const prepared = await driver.preparePrompt('hello');
+    const events = prepared.events[Symbol.asyncIterator]();
+    const firstEvent = events.next();
+    await waitFor(() => calls.includes('turn.start'));
+
+    const stopped = driver.stop();
+    await Promise.resolve();
+    assert.ok(!calls.includes('turn.stop'));
+
+    start.resolve(runningTurn());
+    await stopped;
+    assert.equal((await firstEvent).value?.type, 'queue_update');
+    await events.return?.();
+    assert.deepEqual(turnStops, [{ sessionId: 'session-1', turnId: 'turn-1', runId: 'run-1' }]);
+  });
+
+  test('keeps a newly observed remote turn identity when the local stream closes', async () => {
+    const session = sessionProjection();
+    const calls: string[] = [];
+    const requests: Array<{ operation: OperationKey; input: unknown }> = [];
+    const publishRemote = deferred<void>();
+    const remoteConsumed = deferred<void>();
+    const localCloseStarted = deferred<void>();
+    const releaseLocalClose = deferred<void>();
+    const remoteTurn = turnSnapshot('turn-remote', 'run-remote');
+    const initialObservation: RuntimeHostSessionSubscription = {
+      hostEpoch: 'host-1',
+      subscriptionId: 'observation-1',
+      snapshot: snapshot(null),
+      async *[Symbol.asyncIterator]() {
+        await publishRemote.promise;
+        yield projectionFrame(1, remoteTurn);
+        remoteConsumed.resolve();
+        await new Promise(() => {});
+      },
+      async close() {},
+    };
+    const localTurn: RuntimeHostSessionSubscription = {
+      hostEpoch: 'host-1',
+      subscriptionId: 'local-turn',
+      snapshot: snapshot(null),
+      async *[Symbol.asyncIterator]() {
+        yield projectionFrame(1, terminalTurn(runningTurn()));
+      },
+      async close() {
+        localCloseStarted.resolve();
+        await releaseLocalClose.promise;
+      },
+    };
+    const reconciledObservation: RuntimeHostSessionSubscription = {
+      hostEpoch: 'host-1',
+      subscriptionId: 'observation-2',
+      snapshot: snapshot(remoteTurn),
+      async *[Symbol.asyncIterator]() {
+        await new Promise(() => {});
+      },
+      async close() {},
+    };
+    const connection = fakeConnection({
+      calls,
+      requests,
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: [],
+      },
+      frames: [],
+      subscriptions: [initialObservation, localTurn, reconciledObservation],
+      requestResult: (operation) =>
+        operation === 'turn.interrupt'
+          ? {
+              queueRevision: 1,
+              retracted: [],
+              turn: {
+                ...remoteTurn,
+                status: 'cancelled',
+                terminalEventId: 'terminal-remote',
+                abortSource: 'user_stop',
+              },
+            }
+          : undefined,
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+      newId: sequenceIds('turn-1', 'interrupt-remote'),
+    });
+    let observeRemote!: () => void;
+    const remoteObserved = new Promise<void>((resolve) => {
+      observeRemote = resolve;
+    });
+    const unsubscribe = driver.sessionObservation?.subscribe((observation) => {
+      if (observation.cut === 'active') observeRemote();
+    });
+
+    await driver.switchSession(session.id);
+    await waitFor(() => calls.filter((call) => call === 'subscription.open').length === 1);
+    const prepared = await driver.preparePrompt('local prompt');
+    const drain = (async () => {
+      for await (const _event of prepared.events) {
+        // Drain through local subscription cleanup.
+      }
+    })();
+    await localCloseStarted.promise;
+    publishRemote.resolve();
+    await remoteConsumed.promise;
+    releaseLocalClose.resolve();
+    await drain;
+    await remoteObserved;
+
+    await driver.interrupt?.();
+    unsubscribe?.();
+
+    const interrupt = requests.find((request) => request.operation === 'turn.interrupt');
+    assert.deepEqual(interrupt?.input, {
+      originHostEpoch: 'host-1',
+      sessionId: 'session-1',
+      interruptId: 'interrupt-remote',
+      turnId: 'turn-remote',
+      runId: 'run-remote',
+    });
   });
 
   test('keeps observing a Host-started followup instead of ending at the previous turn', async () => {
@@ -323,21 +584,21 @@ describe('HostMakaSessionDriver', () => {
     const observations: Array<{
       eventTypes: string[];
       reloadTranscript: boolean;
-      activeTurn: boolean;
+      cut: MakaSessionObservation['cut'];
     }> = [];
     let finish!: () => void;
     const finished = new Promise<void>((resolve) => {
       finish = resolve;
     });
-    const unsubscribe = driver.subscribeSessionObservations?.((observation) => {
+    const unsubscribe = driver.sessionObservation?.subscribe((observation) => {
       observations.push({
         eventTypes: observation.events.map((event) => event.type),
         reloadTranscript: observation.reloadTranscript,
-        activeTurn: observation.activeTurn,
+        cut: observation.cut,
       });
       if (
         observation.reloadTranscript &&
-        !observation.activeTurn &&
+        observation.cut === 'idle' &&
         observation.events.some((event) => event.type === 'complete')
       ) {
         finish();
@@ -349,14 +610,16 @@ describe('HostMakaSessionDriver', () => {
     unsubscribe?.();
 
     assert.ok(
-      observations.some((observation) => observation.reloadTranscript && observation.activeTurn),
+      observations.some(
+        (observation) => observation.reloadTranscript && observation.cut === 'active',
+      ),
     );
     assert.ok(observations.some((observation) => observation.eventTypes.includes('text_delta')));
     assert.ok(
       observations.some(
         (observation) =>
           observation.reloadTranscript &&
-          !observation.activeTurn &&
+          observation.cut === 'idle' &&
           observation.eventTypes.includes('complete'),
       ),
     );
@@ -413,28 +676,211 @@ describe('HostMakaSessionDriver', () => {
       newId: sequenceIds('event-1', 'event-2'),
     });
     const observedText: string[] = [];
-    const activeStates: boolean[] = [];
+    const cuts: MakaSessionObservation['cut'][] = [];
     let finish!: () => void;
     const finished = new Promise<void>((resolve) => {
       finish = resolve;
     });
-    const unsubscribe = driver.subscribeSessionObservations?.((observation) => {
-      activeStates.push(observation.activeTurn);
+    const unsubscribe = driver.sessionObservation?.subscribe((observation) => {
+      cuts.push(observation.cut);
       for (const event of observation.events) {
         if (event.type === 'text_delta') observedText.push(event.text);
       }
-      if (!observation.activeTurn) finish();
+      if (observation.cut === 'idle') finish();
     });
 
     await driver.switchSession(session.id);
     await finished;
     unsubscribe?.();
 
-    assert.equal(activeStates[0], true);
+    assert.equal(cuts[0], 'active');
     assert.deepEqual(observedText, [
       'output before this Client joined',
       ' and output after it joined',
     ]);
+  });
+
+  test('reopens a slow-consumer observation from a fresh durable cut', {
+    timeout: 2_000,
+  }, async () => {
+    const session = sessionProjection();
+    const calls: string[] = [];
+    const slowConsumer: RuntimeHostSessionSubscription = {
+      hostEpoch: 'host-1',
+      subscriptionId: 'subscription-1',
+      snapshot: snapshot(runningTurn()),
+      async *[Symbol.asyncIterator]() {
+        throw new RuntimeHostSubscriptionError(
+          'slow_consumer',
+          'Session subscription consumer exceeded its local queue bound',
+        );
+      },
+      async close() {},
+    };
+    const recovered: RuntimeHostSessionSubscription = {
+      hostEpoch: 'host-1',
+      subscriptionId: 'subscription-2',
+      snapshot: snapshot(runningTurn()),
+      async *[Symbol.asyncIterator]() {
+        yield {
+          ...projectionFrame(1, terminalTurn(runningTurn())),
+          subscriptionId: 'subscription-2',
+        };
+      },
+      async close() {},
+    };
+    const connection = fakeConnection({
+      calls,
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: [],
+      },
+      frames: [],
+      subscriptions: [slowConsumer, recovered],
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+    });
+    const observations: MakaSessionObservation[] = [];
+    let finish!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const unsubscribe = driver.sessionObservation?.subscribe((observation) => {
+      observations.push(observation);
+      if (observation.events.some((event) => event.type === 'complete')) finish();
+    });
+
+    await driver.switchSession(session.id);
+    await finished;
+    unsubscribe?.();
+
+    assert.equal(calls.filter((call) => call === 'subscription.open').length, 2);
+    assert.ok(
+      observations.some(
+        (observation) => observation.reloadTranscript && observation.cut === 'active',
+      ),
+    );
+    assert.ok(
+      observations.some(
+        (observation) =>
+          observation.cut === 'idle' &&
+          observation.events.some((event) => event.type === 'complete'),
+      ),
+    );
+  });
+
+  test('stops observation after the Session disappears instead of reopening forever', async () => {
+    const session = sessionProjection();
+    const calls: string[] = [];
+    const connection = fakeConnection({
+      calls,
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: [],
+      },
+      frames: [],
+      openSessionSubscription: async () => {
+        throw new RuntimeHostOperationError(
+          'subscription.open',
+          'not_found',
+          'Session was not found',
+        );
+      },
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+      newId: sequenceIds('session-removed-1'),
+    });
+    let failure: MakaSessionObservation | undefined;
+    let finish!: () => void;
+    const failed = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const unsubscribe = driver.sessionObservation?.subscribe((observation) => {
+      if (observation.events.some((event) => event.type === 'error')) {
+        failure = observation;
+        finish();
+      }
+    });
+
+    await driver.switchSession(session.id);
+    await failed;
+    await new Promise((resolve) => setTimeout(resolve, 80));
+    unsubscribe?.();
+
+    assert.equal(calls.filter((call) => call === 'subscription.open').length, 1);
+    assert.equal(failure?.cut, 'unavailable');
+    const error = failure?.events.find((event) => event.type === 'error');
+    assert.equal(error?.type === 'error' ? error.code : undefined, 'runtime_host_session_removed');
+  });
+
+  test('reports a closed Host connection and clears remote turn activity', async () => {
+    const session = sessionProjection();
+    const closed = deferred<void>();
+    const releaseStream = deferred<void>();
+    const subscription: RuntimeHostSessionSubscription = {
+      hostEpoch: 'host-1',
+      subscriptionId: 'subscription-1',
+      snapshot: snapshot(runningTurn()),
+      async *[Symbol.asyncIterator]() {
+        await releaseStream.promise;
+      },
+      async close() {},
+    };
+    const connection = fakeConnection({
+      calls: [],
+      session,
+      transcript: {
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: 'ask' },
+        messages: [],
+      },
+      frames: [],
+      closed: closed.promise,
+      subscriptions: [subscription],
+    });
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: '/tmp',
+      llmConnectionSlug: 'connection-1',
+      model: 'model-1',
+      newId: sequenceIds('connection-error-1'),
+    });
+    let failure: MakaSessionObservation | undefined;
+    let finish!: () => void;
+    const finished = new Promise<void>((resolve) => {
+      finish = resolve;
+    });
+    const unsubscribe = driver.sessionObservation?.subscribe((observation) => {
+      if (observation.events.some((event) => event.type === 'error')) {
+        failure = observation;
+        finish();
+      }
+    });
+
+    await driver.switchSession(session.id);
+    closed.resolve();
+    await finished;
+    unsubscribe?.();
+    releaseStream.resolve();
+
+    assert.equal(failure?.cut, 'unavailable');
+    const error = failure?.events.find((event) => event.type === 'error');
+    assert.equal(
+      error?.type === 'error' ? error.code : undefined,
+      'runtime_host_connection_closed',
+    );
   });
 
   test('requests a durable reload when the initial subscription cut is terminal', async () => {
@@ -459,17 +905,17 @@ describe('HostMakaSessionDriver', () => {
     let initial:
       | {
           reloadTranscript: boolean;
-          activeTurn: boolean;
+          cut: MakaSessionObservation['cut'];
         }
       | undefined;
     let observed!: () => void;
     const observation = new Promise<void>((resolve) => {
       observed = resolve;
     });
-    const unsubscribe = driver.subscribeSessionObservations?.((value) => {
+    const unsubscribe = driver.sessionObservation?.subscribe((value) => {
       initial ??= {
         reloadTranscript: value.reloadTranscript,
-        activeTurn: value.activeTurn,
+        cut: value.cut,
       };
       observed();
     });
@@ -478,7 +924,7 @@ describe('HostMakaSessionDriver', () => {
     await observation;
     unsubscribe?.();
 
-    assert.deepEqual(initial, { reloadTranscript: true, activeTurn: false });
+    assert.deepEqual(initial, { reloadTranscript: true, cut: 'idle' });
   });
 
   test('fails closed when a resumed Session belongs to an external harness', async () => {
@@ -510,15 +956,22 @@ describe('HostMakaSessionDriver', () => {
 
 interface FakeConnectionInput {
   readonly calls: string[];
+  readonly closed?: Promise<void>;
   readonly requests?: Array<{ operation: OperationKey; input: unknown }>;
+  readonly turnStarts?: TurnStartInput[];
+  readonly turnStops?: TurnStopInput[];
   readonly session: SessionCatalogProjection;
   readonly transcript: RuntimeHostSessionTranscript;
   readonly snapshot?: SessionContinuitySnapshot;
   readonly frames: readonly SubscriptionFrame[];
+  readonly subscriptions?: readonly RuntimeHostSessionSubscription[];
+  readonly openSessionSubscription?: () => Promise<RuntimeHostSessionSubscription>;
+  readonly startTurnResult?: Promise<TurnSnapshot>;
   readonly requestResult?: (operation: OperationKey) => unknown;
 }
 
 function fakeConnection(input: FakeConnectionInput): RuntimeHostConnection {
+  let subscriptionIndex = 0;
   const subscription: RuntimeHostSessionSubscription = {
     hostEpoch: 'host-1',
     subscriptionId: 'subscription-1',
@@ -534,7 +987,7 @@ function fakeConnection(input: FakeConnectionInput): RuntimeHostConnection {
     hostEpoch: 'host-1',
     connectionId: 'connection-1',
     selectedProtocol: 0,
-    closed: new Promise(() => {}),
+    closed: input.closed ?? new Promise(() => {}),
     async request(operation: OperationKey, operationInput: unknown) {
       input.calls.push(operation);
       input.requests?.push({ operation, input: operationInput });
@@ -549,22 +1002,37 @@ function fakeConnection(input: FakeConnectionInput): RuntimeHostConnection {
     async status() {
       throw new Error('not used');
     },
-    async startTurn() {
+    async startTurn(turn: TurnStartInput) {
       input.calls.push('turn.start');
-      return runningTurn();
+      input.turnStarts?.push(turn);
+      return input.startTurnResult ?? runningTurn();
     },
     async queryTurn() {
       throw new Error('not used');
     },
-    async stopTurn() {
-      throw new Error('not used');
+    async stopTurn(stop: TurnStopInput) {
+      input.calls.push('turn.stop');
+      input.turnStops?.push(stop);
+      return {
+        ...runningTurn(),
+        status: 'cancelled',
+        terminalEventId: 'terminal-stop',
+        abortSource: 'user_stop',
+      };
     },
     async readSessionTranscript() {
       return input.transcript;
     },
     async openSessionSubscription() {
       input.calls.push('subscription.open');
-      return subscription;
+      if (input.openSessionSubscription) return input.openSessionSubscription();
+      return input.subscriptions?.[subscriptionIndex++] ?? subscription;
+    },
+    async replaceClientCapabilities() {
+      throw new Error('not used');
+    },
+    async unregisterClientCapabilities() {
+      throw new Error('not used');
     },
     async close() {},
   } as RuntimeHostConnection;
@@ -599,7 +1067,7 @@ function snapshot(
   interactions: readonly InteractionPendingSnapshot[] = [],
 ): SessionContinuitySnapshot {
   return {
-    schemaVersion: 2,
+    schemaVersion: 3,
     session: {
       sessionId: 'session-1',
       metadataRevision: 1,
@@ -610,6 +1078,7 @@ function snapshot(
     },
     projectionRevision: rootTurn ? 2 : 1,
     rootTurn,
+    goal: null,
     queue: {
       hostEpoch: 'host-1',
       queueRevision: 0,
@@ -674,4 +1143,20 @@ function isTerminal(turn: TurnSnapshot): boolean {
 function sequenceIds(...ids: string[]): () => string {
   let index = 0;
   return () => ids[index++] ?? `id-${index}`;
+}
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+async function waitFor(predicate: () => boolean): Promise<void> {
+  for (let attempt = 0; attempt < 100; attempt += 1) {
+    if (predicate()) return;
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+  throw new Error('Condition was not met');
 }

--- a/packages/cli/src/__tests__/pi-transcript.test.ts
+++ b/packages/cli/src/__tests__/pi-transcript.test.ts
@@ -1186,6 +1186,45 @@ describe('Maka Pi TUI transcript', () => {
     assert.deepEqual(state.queuedInteractions, []);
   });
 
+  test('renders a Host-projected permission review without raw tool arguments', () => {
+    const state = createMakaPiTranscriptState();
+    applyMakaSessionEventToTranscript(state, {
+      type: 'host_interaction_permission_request',
+      id: 'host-interaction-id',
+      turnId: 'turn-1',
+      ts: 1,
+      requestId: 'interaction-1',
+      toolUseId: 'tool-1',
+      prompt: {
+        kind: 'tool_permission',
+        toolName: 'Bash',
+        category: 'shell_unsafe',
+        reason: 'shell_dangerous',
+        review: {
+          kind: 'command',
+          command: 'npm test',
+          cwd: '/workspace',
+        },
+        rememberForTurnAllowed: true,
+      },
+    });
+
+    const visible = renderMakaPiTranscript(
+      state,
+      {
+        title: 'Maka',
+        cwd: '/workspace',
+        model: 'model-1',
+        connectionSlug: 'connection-1',
+        permissionMode: 'ask',
+      },
+      120,
+    ).map(stripAnsi);
+    assert.ok(visible.some((line) => line.includes('Allow Bash?')));
+    assert.ok(visible.some((line) => line.includes('npm test')));
+    assert.ok(visible.some((line) => line.includes('allow once')));
+  });
+
   test('renders an unboxed session sandbox boundary request with exact scopes', () => {
     const state = createMakaPiTranscriptState();
     applyMakaSessionEventToTranscript(

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -127,10 +127,12 @@ function createTestGoalLifecycle(
 
 function deferred<T>() {
   let resolve!: (value: T | PromiseLike<T>) => void;
-  const promise = new Promise<T>((done) => {
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((done, fail) => {
     resolve = done;
+    reject = fail;
   });
-  return { promise, resolve };
+  return { promise, resolve, reject };
 }
 
 /** Catalog API-key providers as wizard entries with no existing connection —
@@ -1142,7 +1144,7 @@ describe('Maka Pi TUI runner', () => {
       sessionId: 'session-1',
       events: [],
       reloadTranscript: true,
-      activeTurn: true,
+      cut: 'active',
     });
     await waitFor(
       () =>
@@ -1163,7 +1165,7 @@ describe('Maka Pi TUI runner', () => {
         },
       ],
       reloadTranscript: false,
-      activeTurn: true,
+      cut: 'active',
     });
     await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('remote reply'));
 
@@ -1190,7 +1192,7 @@ describe('Maka Pi TUI runner', () => {
         },
       ],
       reloadTranscript: true,
-      activeTurn: false,
+      cut: 'idle',
     });
     await waitFor(() => terminal.progressStates.at(-1) === false);
 
@@ -1228,7 +1230,7 @@ describe('Maka Pi TUI runner', () => {
         },
       ],
       reloadTranscript: true,
-      activeTurn: true,
+      cut: 'active',
     });
     await reloadStarted.promise;
     driver.adoptSessionForTest('session-2');
@@ -1237,6 +1239,334 @@ describe('Maka Pi TUI runner', () => {
     await delay(10);
 
     assert.ok(!plainTerminalOutput(terminal.screenOutput()).includes('STALE-REMOTE-OBSERVATION'));
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('does not let a stale remote reload overwrite a local turn that starts while it waits', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new DeferredLocalTurnObservationDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'model-1',
+      connectionSlug: 'connection-1',
+      permissionMode: 'ask',
+      terminal,
+    });
+    await driver.emit({
+      sessionId: 'session-1',
+      events: [],
+      reloadTranscript: false,
+      cut: 'active',
+    });
+    const reloadStarted = deferred<void>();
+    const releaseReload = deferred<StoredMessage[]>();
+    driver.deferNextReload(reloadStarted.resolve, releaseReload.promise);
+    const terminalObservation = driver.emit({
+      sessionId: 'session-1',
+      events: [
+        {
+          type: 'complete',
+          id: 'remote-complete',
+          turnId: 'remote-turn',
+          ts: 2,
+          stopReason: 'end_turn',
+        },
+      ],
+      reloadTranscript: true,
+      cut: 'idle',
+    });
+    await reloadStarted.promise;
+
+    terminal.input('local prompt');
+    terminal.input('\r');
+    await driver.turnStarted.promise;
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('LOCAL-LIVE-REPLY'));
+
+    releaseReload.resolve([
+      {
+        type: 'user',
+        id: 'stale-user',
+        turnId: 'remote-turn',
+        ts: 1,
+        text: 'STALE-REMOTE-TRANSCRIPT',
+      },
+    ]);
+    await terminalObservation;
+    await delay(10);
+
+    const output = plainTerminalOutput(terminal.screenOutput());
+    assert.ok(output.includes('local prompt'));
+    assert.ok(output.includes('LOCAL-LIVE-REPLY'));
+    assert.ok(!output.includes('STALE-REMOTE-TRANSCRIPT'));
+    assert.equal(terminal.progressStates.at(-1), true);
+
+    const localReloadStarted = deferred<void>();
+    driver.deferNextReload(localReloadStarted.resolve, Promise.resolve([]));
+    driver.releaseTurn.resolve();
+    await localReloadStarted.promise;
+    await driver.emit({
+      sessionId: 'session-1',
+      events: [],
+      reloadTranscript: false,
+      cut: 'idle',
+    });
+    await waitFor(() => terminal.progressStates.at(-1) === false);
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('adopts a remote turn that appears while the local terminal reload is pending', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new DeferredLocalTurnObservationDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'model-1',
+      connectionSlug: 'connection-1',
+      permissionMode: 'ask',
+      terminal,
+    });
+    terminal.input('local prompt');
+    terminal.input('\r');
+    await driver.turnStarted.promise;
+    terminal.input('fallback text');
+    terminal.input('\r');
+    await waitFor(() => driver.steerAttempts === 1);
+
+    const reloadStarted = deferred<void>();
+    const releaseReload = deferred<StoredMessage[]>();
+    driver.deferNextReload(reloadStarted.resolve, releaseReload.promise);
+    driver.releaseTurn.resolve();
+    await reloadStarted.promise;
+
+    driver.acceptSteering = true;
+    await driver.emit({
+      sessionId: 'session-1',
+      events: [],
+      reloadTranscript: false,
+      cut: 'active',
+    });
+    assert.equal(terminal.progressStates.at(-1), true);
+
+    releaseReload.resolve([]);
+    await waitFor(() => driver.deliveredSteering.includes('fallback text'));
+    assert.equal(terminal.progressStates.at(-1), true);
+    assert.deepEqual(driver.prompts, ['local prompt']);
+
+    await driver.emit({
+      sessionId: 'session-1',
+      events: [],
+      reloadTranscript: false,
+      cut: 'idle',
+    });
+    await waitFor(() => terminal.progressStates.at(-1) === false);
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('preserves fallback when the local reload completes before remote takeover is observed', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new DeferredLocalTurnObservationDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'model-1',
+      connectionSlug: 'connection-1',
+      permissionMode: 'ask',
+      terminal,
+    });
+    terminal.input('local prompt');
+    terminal.input('\r');
+    await driver.turnStarted.promise;
+    terminal.input('fallback text');
+    terminal.input('\r');
+    await waitFor(() => driver.steerAttempts === 1);
+
+    const reloadStarted = deferred<void>();
+    driver.deferNextReload(reloadStarted.resolve, Promise.resolve([]));
+    driver.releaseTurn.resolve();
+    await reloadStarted.promise;
+    await delay(10);
+    assert.deepEqual(driver.prompts, ['local prompt']);
+    assert.ok(plainTerminalOutput(terminal.screenOutput()).includes('fallback text'));
+
+    driver.acceptSteering = true;
+    await driver.emit({
+      sessionId: 'session-1',
+      events: [],
+      reloadTranscript: false,
+      cut: 'active',
+    });
+    await waitFor(() => driver.deliveredSteering.includes('fallback text'));
+    assert.deepEqual(driver.prompts, ['local prompt']);
+
+    await driver.emit({
+      sessionId: 'session-1',
+      events: [],
+      reloadTranscript: false,
+      cut: 'idle',
+    });
+    await waitFor(() => terminal.progressStates.at(-1) === false);
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('refills fallback instead of opening a turn when the post-local cut is unavailable', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new DeferredLocalTurnObservationDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'model-1',
+      connectionSlug: 'connection-1',
+      permissionMode: 'ask',
+      terminal,
+    });
+    terminal.input('local prompt');
+    terminal.input('\r');
+    await driver.turnStarted.promise;
+    terminal.input('fallback text');
+    terminal.input('\r');
+    await waitFor(() => driver.steerAttempts === 1);
+
+    const localReloadStarted = deferred<void>();
+    const releaseLocalReload = deferred<StoredMessage[]>();
+    const observationReloadStarted = deferred<void>();
+    const releaseObservationReload = deferred<StoredMessage[]>();
+    driver.deferNextReload(localReloadStarted.resolve, releaseLocalReload.promise);
+    driver.deferNextReload(observationReloadStarted.resolve, releaseObservationReload.promise);
+    driver.releaseTurn.resolve();
+    await localReloadStarted.promise;
+    const idleObservation = driver.emit({
+      sessionId: 'session-1',
+      events: [],
+      reloadTranscript: true,
+      cut: 'idle',
+    });
+    await observationReloadStarted.promise;
+    const unavailableObservation = driver.emit({
+      sessionId: 'session-1',
+      events: [
+        {
+          type: 'error',
+          id: 'connection-error',
+          turnId: 'local-turn',
+          ts: 2,
+          recoverable: true,
+          code: 'runtime_host_connection_closed',
+          reason: 'runtime_host_connection_closed',
+          message: 'Runtime Host connection closed; live Session updates are unavailable.',
+        },
+      ],
+      reloadTranscript: false,
+      cut: 'unavailable',
+    });
+    releaseLocalReload.resolve([]);
+    releaseObservationReload.resolve([
+      {
+        type: 'user',
+        id: 'stale-idle-user',
+        turnId: 'stale-idle-turn',
+        ts: 3,
+        text: 'STALE-IDLE-RELOAD',
+      },
+    ]);
+    await Promise.all([idleObservation, unavailableObservation]);
+    await waitFor(() => {
+      const output = plainTerminalOutput(terminal.screenOutput());
+      return output.includes('fallback text') && !output.includes('Steering: fallback text');
+    });
+    assert.deepEqual(driver.prompts, ['local prompt']);
+    assert.deepEqual(driver.deliveredSteering, []);
+    assert.ok(!plainTerminalOutput(terminal.screenOutput()).includes('STALE-IDLE-RELOAD'));
+
+    terminal.input('\x03');
+    terminal.input('/exit');
+    terminal.input('\r');
+    await run;
+  });
+
+  test('clears remote turn activity even when its terminal transcript reload fails', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new RemoteObservationDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'model-1',
+      connectionSlug: 'connection-1',
+      permissionMode: 'ask',
+      terminal,
+    });
+    await driver.emit({
+      sessionId: 'session-1',
+      events: [],
+      reloadTranscript: false,
+      cut: 'active',
+    });
+    assert.equal(terminal.progressStates.at(-1), true);
+
+    const reloadStarted = deferred<void>();
+    const failedReload = deferred<StoredMessage[]>();
+    driver.deferNextReload(reloadStarted.resolve, failedReload.promise);
+    const terminalObservation = driver.emit({
+      sessionId: 'session-1',
+      events: [],
+      reloadTranscript: true,
+      cut: 'idle',
+    });
+    await reloadStarted.promise;
+    failedReload.reject(new Error('durable reload failed'));
+    await terminalObservation;
+
+    assert.equal(terminal.progressStates.at(-1), false);
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('keeps a control activity busy when an overlapping remote turn settles', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new DeferredRemoteObservationDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'model-1',
+      connectionSlug: 'connection-1',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('/model model-2');
+    terminal.input('\r');
+    await waitFor(() => driver.models.length === 1);
+
+    await driver.emit({
+      sessionId: 'session-1',
+      events: [],
+      reloadTranscript: false,
+      cut: 'active',
+    });
+    await driver.emit({
+      sessionId: 'session-1',
+      events: [],
+      reloadTranscript: false,
+      cut: 'idle',
+    });
+    assert.equal(terminal.progressStates.at(-1), true);
+
+    driver.releaseSetModel();
+    await waitFor(() => terminal.progressStates.at(-1) === false);
 
     exitMaka(terminal);
     await run;
@@ -7894,41 +8224,91 @@ class RemoteObservationDriver extends SlashCommandDriver {
   transcript: StoredMessage[] = [];
   observerClosed = false;
   private listener: MakaSessionObservationListener | undefined;
-  private nextReload:
-    | {
-        readonly started: () => void;
-        readonly messages: Promise<StoredMessage[]>;
+  private readonly deferredReloads: Array<{
+    readonly started: () => void;
+    readonly messages: Promise<StoredMessage[]>;
+  }> = [];
+
+  readonly sessionObservation = {
+    subscribe: (listener: MakaSessionObservationListener): (() => void) => {
+      this.listener = listener;
+      return () => {
+        if (this.listener === listener) this.listener = undefined;
+        this.observerClosed = true;
+      };
+    },
+    reloadTranscript: async (): Promise<StoredMessage[]> => {
+      const deferredReload = this.deferredReloads.shift();
+      if (deferredReload) {
+        deferredReload.started();
+        return deferredReload.messages;
       }
-    | undefined;
-
-  subscribeSessionObservations(listener: MakaSessionObservationListener): () => void {
-    this.listener = listener;
-    return () => {
-      if (this.listener === listener) this.listener = undefined;
-      this.observerClosed = true;
-    };
-  }
-
-  async reloadTranscript(): Promise<StoredMessage[]> {
-    const deferredReload = this.nextReload;
-    if (deferredReload) {
-      this.nextReload = undefined;
-      deferredReload.started();
-      return deferredReload.messages;
-    }
-    return [...this.transcript];
-  }
+      return [...this.transcript];
+    },
+  };
 
   async emit(observation: MakaSessionObservation): Promise<void> {
     await this.listener?.(observation);
   }
 
   deferNextReload(started: () => void, messages: Promise<StoredMessage[]>): void {
-    this.nextReload = { started, messages };
+    this.deferredReloads.push({ started, messages });
   }
 
   adoptSessionForTest(sessionId: string): void {
     this.sessionId = sessionId;
+  }
+}
+
+class DeferredLocalTurnObservationDriver extends RemoteObservationDriver {
+  readonly turnStarted = deferred<void>();
+  readonly releaseTurn = deferred<void>();
+  readonly deliveredSteering: string[] = [];
+  steerAttempts = 0;
+  acceptSteering = false;
+
+  steer(text: string): QueueEnqueueOutcome {
+    this.steerAttempts += 1;
+    if (!this.acceptSteering) return { kind: 'fallback' };
+    this.deliveredSteering.push(text);
+    return { kind: 'queued' };
+  }
+
+  override async *promptEvents(_prompt: string, turnId = 'turn-1'): AsyncIterable<SessionEvent> {
+    yield {
+      type: 'text_delta',
+      id: 'local-delta',
+      turnId,
+      ts: 1,
+      messageId: 'local-assistant',
+      text: 'LOCAL-LIVE-REPLY',
+    };
+    this.turnStarted.resolve();
+    await this.releaseTurn.promise;
+    yield {
+      type: 'complete',
+      id: 'local-complete',
+      turnId,
+      ts: 2,
+      stopReason: 'end_turn',
+    };
+  }
+}
+
+class DeferredRemoteObservationDriver extends RemoteObservationDriver {
+  readonly models: string[] = [];
+  private resolveSetModel: (() => void) | undefined;
+
+  override async setModel(model: string): Promise<void> {
+    this.models.push(model);
+    await new Promise<void>((resolve) => {
+      this.resolveSetModel = resolve;
+    });
+  }
+
+  releaseSetModel(): void {
+    this.resolveSetModel?.();
+    this.resolveSetModel = undefined;
   }
 }
 

--- a/packages/cli/src/__tests__/pi-tui-runner.test.ts
+++ b/packages/cli/src/__tests__/pi-tui-runner.test.ts
@@ -9,6 +9,7 @@ import { before, describe, test } from 'node:test';
 import { visibleWidth } from '@earendil-works/pi-tui';
 import {
   SHELL_RUN_UPDATE_BUFFER_MAX_ENTRIES,
+  type InteractionPermissionAnswer,
   type PermissionMode,
   type OrchestrationMode,
   type QueueEnqueueOutcome,
@@ -29,6 +30,9 @@ import {
 import type {
   MakaPreparePromptOptions,
   MakaPreparedSessionTurn,
+  MakaSessionDriverEvent,
+  MakaSessionObservation,
+  MakaSessionObservationListener,
   MakaSessionMoveResult,
   MakaSessionDriver,
   MakaSessionRewindResult,
@@ -84,7 +88,7 @@ function runMakaPiTui(input: TestMakaPiTuiInput): Promise<void> {
 
 interface TestPromptDriver {
   getSessionId(): string | null;
-  promptEvents(prompt: string): AsyncIterable<SessionEvent>;
+  promptEvents(prompt: string): AsyncIterable<MakaSessionDriverEvent>;
 }
 
 function prepareTestPrompt(
@@ -1078,6 +1082,197 @@ describe('Maka Pi TUI runner', () => {
         throw new Error('TUI did not close during test cleanup');
       }),
     ]);
+  });
+
+  test('answers a Host-projected permission request from the terminal', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new HostPermissionPromptDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'model-1',
+      connectionSlug: 'connection-1',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('run');
+    terminal.input('\r');
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('Allow Bash?'));
+    terminal.input('y');
+    await waitFor(() => driver.responses.length === 1);
+
+    assert.deepEqual(driver.responses, [
+      {
+        requestId: 'interaction-1',
+        kind: 'permission',
+        decision: 'allow',
+        rememberForTurn: false,
+      },
+    ]);
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('renders and settles a turn observed from another Client', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new RemoteObservationDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'model-1',
+      connectionSlug: 'connection-1',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    driver.transcript = [
+      {
+        type: 'user',
+        id: 'remote-user',
+        turnId: 'remote-turn',
+        ts: 1,
+        text: 'remote prompt',
+      },
+    ];
+    await driver.emit({
+      sessionId: 'session-1',
+      events: [],
+      reloadTranscript: true,
+      activeTurn: true,
+    });
+    await waitFor(
+      () =>
+        plainTerminalOutput(terminal.screenOutput()).includes('remote prompt') &&
+        terminal.progressStates.at(-1) === true,
+    );
+
+    await driver.emit({
+      sessionId: 'session-1',
+      events: [
+        {
+          type: 'text_delta',
+          id: 'remote-delta',
+          turnId: 'remote-turn',
+          ts: 2,
+          messageId: 'remote-assistant',
+          text: 'remote reply',
+        },
+      ],
+      reloadTranscript: false,
+      activeTurn: true,
+    });
+    await waitFor(() => plainTerminalOutput(terminal.screenOutput()).includes('remote reply'));
+
+    driver.transcript = [
+      ...driver.transcript,
+      {
+        type: 'assistant',
+        id: 'remote-assistant',
+        turnId: 'remote-turn',
+        ts: 2,
+        modelId: 'model-1',
+        text: 'remote reply',
+      },
+    ];
+    await driver.emit({
+      sessionId: 'session-1',
+      events: [
+        {
+          type: 'complete',
+          id: 'remote-complete',
+          turnId: 'remote-turn',
+          ts: 3,
+          stopReason: 'end_turn',
+        },
+      ],
+      reloadTranscript: true,
+      activeTurn: false,
+    });
+    await waitFor(() => terminal.progressStates.at(-1) === false);
+
+    exitMaka(terminal);
+    await run;
+    assert.equal(driver.observerClosed, true);
+  });
+
+  test('discards a remote observation when its Session changes during transcript reload', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new RemoteObservationDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'model-1',
+      connectionSlug: 'connection-1',
+      permissionMode: 'ask',
+      terminal,
+    });
+    const reloadStarted = deferred<void>();
+    const releaseReload = deferred<StoredMessage[]>();
+    driver.deferNextReload(reloadStarted.resolve, releaseReload.promise);
+
+    const emission = driver.emit({
+      sessionId: 'session-1',
+      events: [
+        {
+          type: 'text_delta',
+          id: 'stale-delta',
+          turnId: 'stale-turn',
+          ts: 1,
+          messageId: 'stale-message',
+          text: 'STALE-REMOTE-OBSERVATION',
+        },
+      ],
+      reloadTranscript: true,
+      activeTurn: true,
+    });
+    await reloadStarted.promise;
+    driver.adoptSessionForTest('session-2');
+    releaseReload.resolve([]);
+    await emission;
+    await delay(10);
+
+    assert.ok(!plainTerminalOutput(terminal.screenOutput()).includes('STALE-REMOTE-OBSERVATION'));
+
+    exitMaka(terminal);
+    await run;
+  });
+
+  test('allows a pending sandbox boundary request with Enter', async () => {
+    const terminal = new FakeTerminal();
+    const driver = new SandboxBoundaryPromptDriver();
+    const run = runMakaPiTui({
+      title: 'Maka',
+      driver,
+      cwd: '/repo',
+      model: 'claude-sonnet-4-5',
+      connectionSlug: 'claude-subscription',
+      permissionMode: 'ask',
+      terminal,
+    });
+
+    terminal.input('r');
+    terminal.input('u');
+    terminal.input('n');
+    terminal.input('\r');
+    await waitFor(() => driver.boundaryRequests === 1);
+    await delay(20);
+    terminal.input('\r');
+    await waitFor(() => driver.boundaryResponses.length === 1);
+
+    assert.deepEqual(driver.boundaryResponses, [
+      {
+        requestId: 'boundary-1',
+        decision: 'allow',
+      },
+    ]);
+
+    exitMaka(terminal);
+    await run;
   });
 
   test('freezes and preserves the editor draft while a boundary request owns input', async () => {
@@ -6461,6 +6656,80 @@ class SandboxBoundaryPromptDriver implements MakaSessionDriver {
   }
 }
 
+class HostPermissionPromptDriver implements MakaSessionDriver {
+  readonly responses: Array<InteractionPermissionAnswer & { readonly requestId: string }> = [];
+  private release: (() => void) | undefined;
+
+  async listSessions(): Promise<SessionSummary[]> {
+    return [];
+  }
+
+  preparePrompt(prompt: string): Promise<MakaPreparedSessionTurn> {
+    return prepareTestPrompt(this, prompt);
+  }
+
+  async *compactSession(): AsyncIterable<never> {}
+
+  async *promptEvents(_prompt: string): AsyncIterable<MakaSessionDriverEvent> {
+    yield {
+      type: 'host_interaction_permission_request',
+      id: 'event-permission',
+      turnId: 'turn-1',
+      ts: 1,
+      requestId: 'interaction-1',
+      toolUseId: 'tool-1',
+      prompt: {
+        kind: 'tool_permission',
+        toolName: 'Bash',
+        category: 'shell_unsafe',
+        reason: 'shell_dangerous',
+        review: { kind: 'command', command: 'npm test', cwd: '/repo' },
+        rememberForTurnAllowed: true,
+      },
+    };
+    await new Promise<void>((resolve) => {
+      this.release = resolve;
+    });
+    yield {
+      type: 'complete',
+      id: 'event-complete',
+      turnId: 'turn-1',
+      ts: 2,
+      stopReason: 'end_turn',
+    };
+  }
+
+  async respondToPermission(
+    response: InteractionPermissionAnswer & { readonly requestId: string },
+  ): Promise<void> {
+    this.responses.push(response);
+    this.release?.();
+  }
+
+  async stop(): Promise<void> {
+    this.release?.();
+  }
+
+  async respondToSandboxBoundary(_response: SandboxBoundaryResponse): Promise<void> {}
+  async renameSession(): Promise<void> {}
+  async setModel(): Promise<void> {}
+  async setPermissionMode(): Promise<void> {}
+  async setThinkingLevel(): Promise<void> {}
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    return switchResult(fakeSessionSummary(sessionId));
+  }
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    return [];
+  }
+  async rewindToTurn(): Promise<MakaSessionRewindResult> {
+    throw new Error('rewind not supported');
+  }
+  startNewSession(): void {}
+  getSessionId(): string {
+    return 'session-1';
+  }
+}
+
 class UserQuestionPromptDriver implements MakaSessionDriver {
   readonly responses: UserQuestionResponse[] = [];
   stopCalls = 0;
@@ -7618,6 +7887,48 @@ class SlashCommandDriver implements MakaSessionDriver {
   }
   getPermissionMode(): PermissionMode {
     return this.activeBoundaryDisplayMode ?? 'ask';
+  }
+}
+
+class RemoteObservationDriver extends SlashCommandDriver {
+  transcript: StoredMessage[] = [];
+  observerClosed = false;
+  private listener: MakaSessionObservationListener | undefined;
+  private nextReload:
+    | {
+        readonly started: () => void;
+        readonly messages: Promise<StoredMessage[]>;
+      }
+    | undefined;
+
+  subscribeSessionObservations(listener: MakaSessionObservationListener): () => void {
+    this.listener = listener;
+    return () => {
+      if (this.listener === listener) this.listener = undefined;
+      this.observerClosed = true;
+    };
+  }
+
+  async reloadTranscript(): Promise<StoredMessage[]> {
+    const deferredReload = this.nextReload;
+    if (deferredReload) {
+      this.nextReload = undefined;
+      deferredReload.started();
+      return deferredReload.messages;
+    }
+    return [...this.transcript];
+  }
+
+  async emit(observation: MakaSessionObservation): Promise<void> {
+    await this.listener?.(observation);
+  }
+
+  deferNextReload(started: () => void, messages: Promise<StoredMessage[]>): void {
+    this.nextReload = { started, messages };
+  }
+
+  adoptSessionForTest(sessionId: string): void {
+    this.sessionId = sessionId;
   }
 }
 

--- a/packages/cli/src/__tests__/session-driver.test.ts
+++ b/packages/cli/src/__tests__/session-driver.test.ts
@@ -17,7 +17,7 @@ import type {
 import { createGenesisExecutionBoundary, createReadOnlyPermissionProfile } from '@maka/core';
 import { permissionModeLabel } from '../pi-transcript.js';
 import { permissionModePickerItems } from '../pi-tui-pickers.js';
-import { createMakaSessionDriver } from '../session-driver.js';
+import { createMakaSessionDriver, type MakaSessionDriverEvent } from '../session-driver.js';
 import type {
   ContextDiagnostics,
   RuntimeContinuation,
@@ -1517,6 +1517,6 @@ async function collect<T>(iterable: AsyncIterable<T>): Promise<T[]> {
 async function collectPrompt(
   driver: ReturnType<typeof createMakaSessionDriver>,
   prompt: string,
-): Promise<SessionEvent[]> {
+): Promise<MakaSessionDriverEvent[]> {
   return collect((await driver.preparePrompt(prompt)).events);
 }

--- a/packages/cli/src/__tests__/tui-attention.test.ts
+++ b/packages/cli/src/__tests__/tui-attention.test.ts
@@ -70,6 +70,18 @@ describe('AttentionController title', () => {
     assert.equal(terminal.bells, 0);
   });
 
+  test('keeps the busy marker until overlapping turn and control activity both end', () => {
+    const { terminal, controller } = makeController();
+    controller.controlStarted();
+    controller.promptTurnStarted();
+
+    controller.promptTurnEnded();
+    assert.equal(terminal.title, BUSY);
+
+    controller.controlEnded();
+    assert.equal(terminal.title, 'Maka');
+  });
+
   test('reset clears the busy marker and goes inert', () => {
     const { terminal, controller } = makeController(8000);
     controller.focusChanged(false);

--- a/packages/cli/src/host-session-driver.ts
+++ b/packages/cli/src/host-session-driver.ts
@@ -15,6 +15,7 @@ import type {
   RuntimeHostConnection,
   RuntimeHostSessionSubscription,
 } from '@maka/runtime-host/client';
+import { RuntimeHostOperationError, RuntimeHostSubscriptionError } from '@maka/runtime-host/client';
 import type {
   InteractionPendingSnapshot,
   SessionCatalogItem,
@@ -30,6 +31,7 @@ import type {
   MakaSessionDriver,
   MakaSessionDriverEvent,
   MakaSessionObservation,
+  MakaSessionObservationCapability,
   MakaSessionObservationListener,
   MakaSessionMoveResult,
   MakaSessionRewindResult,
@@ -54,6 +56,7 @@ export function createHostMakaSessionDriver(input: HostMakaSessionDriverInput): 
 }
 
 class HostMakaSessionDriver implements MakaSessionDriver {
+  readonly sessionObservation: MakaSessionObservationCapability;
   readonly #connection: RuntimeHostConnection;
   readonly #newId: () => string;
   #sessionId: string | null = null;
@@ -66,6 +69,7 @@ class HostMakaSessionDriver implements MakaSessionDriver {
   #catalog: SessionCatalogProjection | undefined;
   #transcriptRevision: number | undefined;
   #activeTurn: TurnSnapshot | undefined;
+  #pendingTurnStart: Promise<TurnSnapshot> | undefined;
   #streamToken: symbol | undefined;
   #observationToken: symbol | undefined;
   #observationSubscription: RuntimeHostSessionSubscription | undefined;
@@ -81,6 +85,10 @@ class HostMakaSessionDriver implements MakaSessionDriver {
     this.#model = input.model;
     this.#permissionMode = input.permissionMode ?? 'ask';
     this.#orchestrationMode = input.orchestrationMode ?? 'default';
+    this.sessionObservation = {
+      reloadTranscript: () => this.#reloadTranscript(),
+      subscribe: (listener) => this.#subscribeSessionObservations(listener),
+    };
   }
 
   async listSessions(): Promise<SessionSummary[]> {
@@ -139,19 +147,21 @@ class HostMakaSessionDriver implements MakaSessionDriver {
     prompt: string,
     options: MakaPreparePromptOptions = {},
   ): Promise<MakaPreparedSessionTurn> {
-    if (options.turnOrchestration !== undefined) {
-      throw new Error('Per-turn orchestration is unavailable through Runtime Host');
-    }
     const sessionId = await this.#ensureSession();
     const turnId = options.turnId ?? this.#newId();
     const modelText = options.modelText ?? prompt;
     return {
       sessionId,
       turnId,
-      events: this.#observeTurn(sessionId, turnId, {
-        text: modelText,
-        ...(modelText === prompt ? {} : { displayText: prompt }),
-      }),
+      events: this.#observeTurn(
+        sessionId,
+        turnId,
+        {
+          text: modelText,
+          ...(modelText === prompt ? {} : { displayText: prompt }),
+        },
+        options.turnOrchestration,
+      ),
     };
   }
 
@@ -181,11 +191,13 @@ class HostMakaSessionDriver implements MakaSessionDriver {
 
   interrupt(): Promise<string> {
     return this.#serializeMessageOperation(async () => {
-      const active = this.#activeTurn;
-      if (!this.#sessionId || !active || isTerminalTurn(active)) return '';
+      const sessionId = this.#sessionId;
+      const active = await this.#activeTurnForControl();
+      if (!sessionId || !active || active.sessionId !== sessionId || isTerminalTurn(active))
+        return '';
       const result = await this.#connection.request('turn.interrupt', {
         originHostEpoch: this.#connection.hostEpoch,
-        sessionId: this.#sessionId,
+        sessionId,
         interruptId: this.#newId(),
         turnId: active.turnId,
         runId: active.runId,
@@ -300,7 +312,7 @@ class HostMakaSessionDriver implements MakaSessionDriver {
     return { summary, messages: decodeTranscriptMessages(transcript.messages) };
   }
 
-  async reloadTranscript(): Promise<StoredMessage[]> {
+  async #reloadTranscript(): Promise<StoredMessage[]> {
     if (!this.#sessionId) return [];
     const transcript = await this.#connection.readSessionTranscript(this.#sessionId);
     if (transcript.boundary.kind === 'external') {
@@ -311,7 +323,7 @@ class HostMakaSessionDriver implements MakaSessionDriver {
     return decodeTranscriptMessages(transcript.messages);
   }
 
-  subscribeSessionObservations(listener: MakaSessionObservationListener): () => void {
+  #subscribeSessionObservations(listener: MakaSessionObservationListener): () => void {
     const shouldStart = this.#observationListeners.size === 0;
     this.#observationListeners.add(listener);
     if (shouldStart) this.#restartSessionObservation();
@@ -378,10 +390,11 @@ class HostMakaSessionDriver implements MakaSessionDriver {
   }
 
   async stop(): Promise<void> {
-    const active = this.#activeTurn;
-    if (!this.#sessionId || !active || isTerminalTurn(active)) return;
+    const sessionId = this.#sessionId;
+    const active = await this.#activeTurnForControl();
+    if (!sessionId || !active || active.sessionId !== sessionId || isTerminalTurn(active)) return;
     this.#activeTurn = await this.#connection.stopTurn({
-      sessionId: this.#sessionId,
+      sessionId,
       turnId: active.turnId,
       runId: active.runId,
     });
@@ -397,6 +410,11 @@ class HostMakaSessionDriver implements MakaSessionDriver {
 
   getPermissionMode(): PermissionMode {
     return this.#permissionMode;
+  }
+
+  async #activeTurnForControl(): Promise<TurnSnapshot | undefined> {
+    if (this.#activeTurn && !isTerminalTurn(this.#activeTurn)) return this.#activeTurn;
+    return (await this.#pendingTurnStart) ?? this.#activeTurn;
   }
 
   async #ensureSession(): Promise<string> {
@@ -426,18 +444,35 @@ class HostMakaSessionDriver implements MakaSessionDriver {
     sessionId: string,
     turnId: string,
     content: { text: string; displayText?: string },
+    turnOrchestration?: MakaPreparePromptOptions['turnOrchestration'],
   ): AsyncIterable<MakaSessionDriverEvent> {
     const token = Symbol('HostMakaSessionDriver stream');
     this.#streamToken = token;
     this.#expectedNextTurnIds.clear();
-    const subscription = await this.#connection.openSessionSubscription({ sessionId });
+    let subscription: RuntimeHostSessionSubscription | undefined;
+    const pendingStart = (async () => {
+      subscription = await this.#connection.openSessionSubscription({ sessionId });
+      return this.#connection.startTurn({
+        sessionId,
+        turnId,
+        content,
+        ...(turnOrchestration === undefined ? {} : { turnOrchestration }),
+      });
+    })();
+    this.#pendingTurnStart = pendingStart;
     const chainTurnIds = new Set([turnId]);
     const projectedInteractions = new Set<string>();
     let queueRevision = -1;
     let waitingForFollowup = false;
     try {
-      const started = await this.#connection.startTurn({ sessionId, turnId, content });
+      let started: TurnSnapshot;
+      try {
+        started = await pendingStart;
+      } finally {
+        if (this.#pendingTurnStart === pendingStart) this.#pendingTurnStart = undefined;
+      }
       this.#activeTurn = started;
+      if (!subscription) throw new Error('Runtime Host Session subscription did not open');
       yield* projectSnapshotState(
         subscription.snapshot,
         turnId,
@@ -497,11 +532,14 @@ class HostMakaSessionDriver implements MakaSessionDriver {
       }
       throw new Error('Runtime Host Session subscription ended before the turn became terminal');
     } finally {
-      await subscription.close().catch(() => {});
+      await subscription?.close().catch(() => {});
       if (this.#streamToken === token) {
         this.#streamToken = undefined;
-        this.#activeTurn = undefined;
+        if (this.#activeTurn && chainTurnIds.has(this.#activeTurn.turnId)) {
+          this.#activeTurn = undefined;
+        }
         this.#expectedNextTurnIds.clear();
+        this.#restartSessionObservation();
       }
     }
   }
@@ -518,15 +556,78 @@ class HostMakaSessionDriver implements MakaSessionDriver {
     // view. The Host replay covers anything emitted during this one-tick gap.
     setImmediate(() => {
       if (this.#observationToken !== token) return;
-      void this.#observeSession(sessionId, token).catch(() => {});
+      void this.#observeSessionLoop(sessionId, token);
     });
   }
 
-  async #observeSession(sessionId: string, token: symbol): Promise<void> {
+  async #observeSessionLoop(sessionId: string, token: symbol): Promise<void> {
+    let retryDelayMs = 25;
+    let forceReload = false;
+    while (
+      this.#observationToken === token &&
+      this.#sessionId === sessionId &&
+      this.#observationListeners.size > 0
+    ) {
+      const attempt = this.#observeSession(sessionId, token, forceReload).then(
+        (result) => ({ kind: 'completed' as const, result }),
+        (error: unknown) => ({ kind: 'failed' as const, error }),
+      );
+      const outcome = await Promise.race([
+        attempt,
+        this.#connection.closed.then(
+          () => ({ kind: 'connection_closed' as const }),
+          () => ({ kind: 'connection_closed' as const }),
+        ),
+      ]);
+      if (
+        this.#observationToken !== token ||
+        this.#sessionId !== sessionId ||
+        this.#observationListeners.size === 0
+      ) {
+        return;
+      }
+      if (
+        outcome.kind === 'connection_closed' ||
+        (outcome.kind === 'failed' &&
+          outcome.error instanceof RuntimeHostSubscriptionError &&
+          outcome.error.reason === 'connection_closed')
+      ) {
+        await this.#publishObservationFailure(
+          sessionId,
+          'runtime_host_connection_closed',
+          'Runtime Host connection closed; live Session updates are unavailable.',
+        );
+        return;
+      }
+      if (outcome.kind === 'completed' && outcome.result === 'stop') return;
+      if (outcome.kind === 'failed' && !isRecoverableObservationFailure(outcome.error)) {
+        const sessionRemoved =
+          outcome.error instanceof RuntimeHostOperationError && outcome.error.code === 'not_found';
+        await this.#publishObservationFailure(
+          sessionId,
+          sessionRemoved ? 'runtime_host_session_removed' : 'runtime_host_observation_failed',
+          sessionRemoved
+            ? 'Runtime Host Session no longer exists; live Session updates stopped.'
+            : 'Runtime Host Session observation stopped after an unrecoverable subscription failure.',
+        );
+        return;
+      }
+
+      forceReload = true;
+      await new Promise((resolve) => setTimeout(resolve, retryDelayMs));
+      retryDelayMs = Math.min(retryDelayMs * 2, 250);
+    }
+  }
+
+  async #observeSession(
+    sessionId: string,
+    token: symbol,
+    forceReload: boolean,
+  ): Promise<'retry' | 'stop'> {
     const subscription = await this.#connection.openSessionSubscription({ sessionId });
     if (this.#observationToken !== token) {
       await subscription.close().catch(() => {});
-      return;
+      return 'stop';
     }
     this.#observationSubscription = subscription;
     const projectedInteractions = new Set<string>();
@@ -543,16 +644,27 @@ class HostMakaSessionDriver implements MakaSessionDriver {
           queueRevision,
         ),
         reloadTranscript:
+          forceReload ||
           (subscription.snapshot.rootTurn !== null &&
             isTerminalTurn(subscription.snapshot.rootTurn)) ||
           subscription.snapshot.session.metadataRevision !== this.#transcriptRevision,
-        activeTurn: isRunningTurn(subscription.snapshot.rootTurn),
+        cut: isRunningTurn(subscription.snapshot.rootTurn) ? 'active' : 'idle',
       });
       queueRevision = subscription.snapshot.queue.queueRevision;
 
       for await (const frame of subscription) {
-        if (this.#observationToken !== token) return;
-        if (frame.kind === 'subscription.closed') return;
+        if (this.#observationToken !== token) return 'stop';
+        if (frame.kind === 'subscription.closed') {
+          if (frame.reason === 'session_removed') {
+            await this.#publishObservationFailure(
+              sessionId,
+              'runtime_host_session_removed',
+              'Runtime Host Session no longer exists; live Session updates stopped.',
+            );
+            return 'stop';
+          }
+          return 'retry';
+        }
         if (frame.kind === 'subscription.session_delta') {
           await this.#publishObservation({
             sessionId,
@@ -567,7 +679,7 @@ class HostMakaSessionDriver implements MakaSessionDriver {
               },
             ],
             reloadTranscript: false,
-            activeTurn: true,
+            cut: 'active',
           });
           continue;
         }
@@ -576,7 +688,7 @@ class HostMakaSessionDriver implements MakaSessionDriver {
             sessionId,
             events: [projectToolEvent(sessionId, frame.event)],
             reloadTranscript: false,
-            activeTurn: true,
+            cut: 'active',
           });
           continue;
         }
@@ -603,15 +715,45 @@ class HostMakaSessionDriver implements MakaSessionDriver {
           sessionId,
           events,
           reloadTranscript: rootFingerprint !== previousFingerprint,
-          activeTurn: isRunningTurn(snapshot.rootTurn),
+          cut: isRunningTurn(snapshot.rootTurn) ? 'active' : 'idle',
         });
       }
+      return 'retry';
     } finally {
       if (this.#observationSubscription === subscription) {
         this.#observationSubscription = undefined;
       }
       await subscription.close().catch(() => {});
     }
+  }
+
+  async #publishObservationFailure(
+    sessionId: string,
+    code:
+      | 'runtime_host_connection_closed'
+      | 'runtime_host_observation_failed'
+      | 'runtime_host_session_removed',
+    message: string,
+  ): Promise<void> {
+    const turnId = this.#activeTurn?.turnId ?? `session-observation-${sessionId}`;
+    this.#activeTurn = undefined;
+    await this.#publishObservation({
+      sessionId,
+      events: [
+        {
+          id: this.#newId(),
+          type: 'error',
+          turnId,
+          ts: Date.now(),
+          recoverable: true,
+          code,
+          reason: code,
+          message,
+        },
+      ],
+      reloadTranscript: false,
+      cut: 'unavailable',
+    });
   }
 
   async #publishObservation(observation: MakaSessionObservation): Promise<void> {
@@ -717,6 +859,13 @@ class HostMakaSessionDriver implements MakaSessionDriver {
     this.#orchestrationMode = session.orchestrationMode;
     if (previousSessionId !== session.id) this.#restartSessionObservation();
   }
+}
+
+function isRecoverableObservationFailure(error: unknown): boolean {
+  return (
+    error instanceof RuntimeHostSubscriptionError &&
+    (error.reason === 'slow_consumer' || error.reason === 'sequence_gap')
+  );
 }
 
 function projectSnapshotState(

--- a/packages/cli/src/host-session-driver.ts
+++ b/packages/cli/src/host-session-driver.ts
@@ -1,0 +1,962 @@
+import { randomUUID } from 'node:crypto';
+import { realpath } from 'node:fs/promises';
+import { setImmediate } from 'node:timers';
+import type { QueueEnqueueOutcome, SessionEvent, ToolResultContent } from '@maka/core/events';
+import type { OrchestrationMode } from '@maka/core/orchestration';
+import type { InteractionPermissionAnswer } from '@maka/core/interaction';
+import type { PermissionMode } from '@maka/core/permission';
+import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
+import type { SessionSummary, StoredMessage } from '@maka/core/session';
+import { decodeStoredMessageForRead, userFacingText } from '@maka/core/session';
+import type { ThinkingLevel } from '@maka/core/model-thinking';
+import type { UserQuestionResponse } from '@maka/core/user-question';
+import { DEFAULT_SESSION_NAME } from '@maka/core';
+import type {
+  RuntimeHostConnection,
+  RuntimeHostSessionSubscription,
+} from '@maka/runtime-host/client';
+import type {
+  InteractionPendingSnapshot,
+  SessionCatalogItem,
+  SessionCatalogProjection,
+  SessionCatalogQueryResult,
+  SessionContinuitySnapshot,
+  SessionToolEvent,
+  TurnSnapshot,
+} from '@maka/runtime-host/protocol';
+import type {
+  MakaPreparePromptOptions,
+  MakaPreparedSessionTurn,
+  MakaSessionDriver,
+  MakaSessionDriverEvent,
+  MakaSessionObservation,
+  MakaSessionObservationListener,
+  MakaSessionMoveResult,
+  MakaSessionRewindResult,
+  MakaSessionSwitchResult,
+  RewindTarget,
+  SessionResumeAvailability,
+} from './session-driver.js';
+import { inspectSessionResumeAvailability } from './session-driver.js';
+
+export interface HostMakaSessionDriverInput {
+  readonly connection: RuntimeHostConnection;
+  readonly cwd: string;
+  readonly llmConnectionSlug: string;
+  readonly model: string;
+  readonly permissionMode?: PermissionMode;
+  readonly orchestrationMode?: OrchestrationMode;
+  readonly newId?: () => string;
+}
+
+export function createHostMakaSessionDriver(input: HostMakaSessionDriverInput): MakaSessionDriver {
+  return new HostMakaSessionDriver(input);
+}
+
+class HostMakaSessionDriver implements MakaSessionDriver {
+  readonly #connection: RuntimeHostConnection;
+  readonly #newId: () => string;
+  #sessionId: string | null = null;
+  #cwd: string;
+  #llmConnectionSlug: string;
+  #model: string;
+  #thinkingLevel: ThinkingLevel | undefined;
+  #permissionMode: PermissionMode;
+  #orchestrationMode: OrchestrationMode;
+  #catalog: SessionCatalogProjection | undefined;
+  #transcriptRevision: number | undefined;
+  #activeTurn: TurnSnapshot | undefined;
+  #streamToken: symbol | undefined;
+  #observationToken: symbol | undefined;
+  #observationSubscription: RuntimeHostSessionSubscription | undefined;
+  readonly #observationListeners = new Set<MakaSessionObservationListener>();
+  #expectedNextTurnIds = new Set<string>();
+  #messageOperations: Promise<void> = Promise.resolve();
+
+  constructor(input: HostMakaSessionDriverInput) {
+    this.#connection = input.connection;
+    this.#newId = input.newId ?? randomUUID;
+    this.#cwd = input.cwd;
+    this.#llmConnectionSlug = input.llmConnectionSlug;
+    this.#model = input.model;
+    this.#permissionMode = input.permissionMode ?? 'ask';
+    this.#orchestrationMode = input.orchestrationMode ?? 'default';
+  }
+
+  async listSessions(): Promise<SessionSummary[]> {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const sessions: SessionSummary[] = [];
+      const initial = await this.#connection.request('session.catalog.query', {
+        kind: 'list_start',
+        filter: { isArchived: false },
+      });
+      if (initial.kind !== 'page') throw new Error('Runtime Host returned an invalid Session page');
+      let page: Extract<SessionCatalogQueryResult, { kind: 'page' }> = initial;
+      const revision = page.revision;
+      let restart = false;
+      while (true) {
+        for (const item of page.sessions)
+          sessions.push(projectSessionSummary(requireSession(item)));
+        if (page.nextCursor === null) {
+          return sessions
+            .map((session, index) => ({ session, index }))
+            .sort((left, right) => {
+              const cwdDelta =
+                (left.session.cwd === this.#cwd ? 0 : 1) -
+                (right.session.cwd === this.#cwd ? 0 : 1);
+              return cwdDelta !== 0 ? cwdDelta : left.index - right.index;
+            })
+            .map(({ session }) => session);
+        }
+        const continuation: SessionCatalogQueryResult = await this.#connection.request(
+          'session.catalog.query',
+          {
+            kind: 'list_continue',
+            filter: { isArchived: false },
+            revision,
+            cursor: page.nextCursor,
+          },
+        );
+        if (continuation.kind === 'revision_changed') {
+          restart = true;
+          break;
+        }
+        if (continuation.kind !== 'page') {
+          throw new Error('Runtime Host returned an invalid Session continuation');
+        }
+        page = continuation;
+      }
+      if (!restart) break;
+    }
+    throw new Error('Session catalog kept changing while it was read');
+  }
+
+  getSessionResumeAvailability(session: SessionSummary): Promise<SessionResumeAvailability> {
+    return inspectSessionResumeAvailability(session);
+  }
+
+  async preparePrompt(
+    prompt: string,
+    options: MakaPreparePromptOptions = {},
+  ): Promise<MakaPreparedSessionTurn> {
+    if (options.turnOrchestration !== undefined) {
+      throw new Error('Per-turn orchestration is unavailable through Runtime Host');
+    }
+    const sessionId = await this.#ensureSession();
+    const turnId = options.turnId ?? this.#newId();
+    const modelText = options.modelText ?? prompt;
+    return {
+      sessionId,
+      turnId,
+      events: this.#observeTurn(sessionId, turnId, {
+        text: modelText,
+        ...(modelText === prompt ? {} : { displayText: prompt }),
+      }),
+    };
+  }
+
+  async *compactSession(): AsyncIterable<SessionEvent> {
+    throw new Error('Session compaction is not yet available through Runtime Host');
+  }
+
+  steer(text: string): Promise<QueueEnqueueOutcome> {
+    return this.#submitQueuedMessage(text, 'current_turn');
+  }
+
+  queueMessage(text: string): Promise<QueueEnqueueOutcome> {
+    return this.#submitQueuedMessage(text, 'next_turn');
+  }
+
+  retractQueued(): Promise<string> {
+    return this.#serializeMessageOperation(async () => {
+      if (!this.#sessionId) return '';
+      const result = await this.#connection.request('queue.retract', {
+        originHostEpoch: this.#connection.hostEpoch,
+        sessionId: this.#sessionId,
+        retractId: this.#newId(),
+      });
+      return joinRetractedMessages(result.retracted);
+    });
+  }
+
+  interrupt(): Promise<string> {
+    return this.#serializeMessageOperation(async () => {
+      const active = this.#activeTurn;
+      if (!this.#sessionId || !active || isTerminalTurn(active)) return '';
+      const result = await this.#connection.request('turn.interrupt', {
+        originHostEpoch: this.#connection.hostEpoch,
+        sessionId: this.#sessionId,
+        interruptId: this.#newId(),
+        turnId: active.turnId,
+        runId: active.runId,
+      });
+      this.#activeTurn = result.turn;
+      return joinRetractedMessages(result.retracted);
+    });
+  }
+
+  async respondToSandboxBoundary(response: SandboxBoundaryResponse): Promise<void> {
+    await this.#connection.request('interaction.answer', {
+      interactionId: response.requestId,
+      answer: {
+        kind: 'permission',
+        decision: response.decision,
+        rememberForTurn: false,
+      },
+    });
+  }
+
+  async respondToPermission(
+    response: InteractionPermissionAnswer & { readonly requestId: string },
+  ): Promise<void> {
+    await this.#connection.request('interaction.answer', {
+      interactionId: response.requestId,
+      answer:
+        response.decision === 'allow'
+          ? {
+              kind: 'permission',
+              decision: 'allow',
+              rememberForTurn: response.rememberForTurn,
+            }
+          : {
+              kind: 'permission',
+              decision: 'deny',
+              rememberForTurn: false,
+            },
+    });
+  }
+
+  async respondToUserQuestion(response: UserQuestionResponse): Promise<void> {
+    await this.#connection.request('interaction.answer', {
+      interactionId: response.requestId,
+      answer: { kind: 'question', answers: response.answers },
+    });
+  }
+
+  async setModel(model: string, connectionSlug?: string): Promise<void> {
+    this.#model = model;
+    if (connectionSlug) this.#llmConnectionSlug = connectionSlug;
+    this.#thinkingLevel = undefined;
+    await this.#commitConfiguration();
+  }
+
+  async setThinkingLevel(level: ThinkingLevel | undefined): Promise<void> {
+    this.#thinkingLevel = level;
+    await this.#commitConfiguration();
+  }
+
+  async setPermissionMode(mode: PermissionMode): Promise<void> {
+    this.#permissionMode = mode;
+    await this.#commitConfiguration();
+  }
+
+  async setOrchestrationMode(mode: OrchestrationMode): Promise<void> {
+    this.#orchestrationMode = mode;
+    await this.#commitConfiguration();
+  }
+
+  async renameSession(name: string): Promise<string> {
+    if (!this.#sessionId) throw new Error('Cannot rename before a session starts.');
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const current = await this.#requireCurrentCatalog();
+      const result = await this.#connection.request('session.metadata.update', {
+        sessionId: current.id,
+        expectedRevision: current.revision,
+        patch: { name },
+      });
+      if (result.kind === 'revision_conflict') {
+        this.#catalog = undefined;
+        continue;
+      }
+      const committed = requireSession(result.session);
+      this.#adoptCatalog(committed);
+      return committed.name;
+    }
+    throw new Error('Session metadata kept changing while it was updated');
+  }
+
+  async moveSession(): Promise<MakaSessionMoveResult> {
+    throw new Error('Changing Session cwd is not yet available through Runtime Host');
+  }
+
+  async switchSession(sessionId: string): Promise<MakaSessionSwitchResult> {
+    const session = await this.#readCatalog(sessionId);
+    if (!session) throw new Error(`Session not found: ${sessionId}`);
+    const summary = projectSessionSummary(session);
+    const availability = await inspectSessionResumeAvailability(summary);
+    if (!availability.available) {
+      if (!summary.cwd) throw new Error('Session has no working directory and cannot be resumed.');
+      throw new Error(`Session cwd no longer exists: ${summary.cwd}`);
+    }
+    const transcript = await this.#connection.readSessionTranscript(sessionId);
+    if (transcript.boundary.kind === 'external') {
+      throw new Error(
+        `Cannot resume externally isolated session ${sessionId} outside its owning harness.`,
+      );
+    }
+    this.#transcriptRevision = transcript.revision;
+    this.#adoptCatalog(session);
+    this.#permissionMode = requireBoundaryDisplayMode(transcript.boundary.displayMode);
+    return { summary, messages: decodeTranscriptMessages(transcript.messages) };
+  }
+
+  async reloadTranscript(): Promise<StoredMessage[]> {
+    if (!this.#sessionId) return [];
+    const transcript = await this.#connection.readSessionTranscript(this.#sessionId);
+    if (transcript.boundary.kind === 'external') {
+      throw new Error('Active Session execution boundary became externally isolated');
+    }
+    this.#transcriptRevision = transcript.revision;
+    this.#permissionMode = requireBoundaryDisplayMode(transcript.boundary.displayMode);
+    return decodeTranscriptMessages(transcript.messages);
+  }
+
+  subscribeSessionObservations(listener: MakaSessionObservationListener): () => void {
+    const shouldStart = this.#observationListeners.size === 0;
+    this.#observationListeners.add(listener);
+    if (shouldStart) this.#restartSessionObservation();
+    let subscribed = true;
+    return () => {
+      if (!subscribed) return;
+      subscribed = false;
+      this.#observationListeners.delete(listener);
+      if (this.#observationListeners.size === 0) this.#restartSessionObservation();
+    };
+  }
+
+  async listRewindTargets(): Promise<RewindTarget[]> {
+    if (!this.#sessionId) return [];
+    const messages = decodeTranscriptMessages(
+      (await this.#connection.readSessionTranscript(this.#sessionId)).messages,
+    );
+    const promptByTurn = new Map<string, string>();
+    const order: string[] = [];
+    for (const message of messages) {
+      if (message.type !== 'user' || promptByTurn.has(message.turnId)) continue;
+      promptByTurn.set(message.turnId, userFacingText(message));
+      order.push(message.turnId);
+    }
+    return order
+      .reverse()
+      .map((turnId) => ({ turnId, label: firstLine(promptByTurn.get(turnId) ?? '') }));
+  }
+
+  async rewindToTurn(turnId: string): Promise<MakaSessionRewindResult> {
+    if (!this.#sessionId) throw new Error('Cannot rewind before a session starts.');
+    const sourceSessionId = this.#sessionId;
+    const transcript = await this.#connection.readSessionTranscript(sourceSessionId);
+    const userMessage = decodeTranscriptMessages(transcript.messages).find(
+      (message): message is Extract<StoredMessage, { type: 'user' }> =>
+        message.type === 'user' && message.turnId === turnId,
+    );
+    if (!userMessage) throw new Error(`Cannot rewind to turn ${turnId}: no user prompt.`);
+    const source = await this.#readCatalog(sourceSessionId);
+    if (!source) throw new Error(`Session not found: ${sourceSessionId}`);
+    const targetSessionId = this.#newId();
+    const revised = await this.#connection.request('session.revision.create', {
+      sourceSessionId,
+      targetSessionId,
+      sourceTurnId: turnId,
+      expectedSourceRevision: source.revision,
+    });
+    if (revised.kind === 'source_revision_conflict') {
+      throw new Error('Session changed while the rewind target was prepared');
+    }
+    return {
+      ...(await this.switchSession(targetSessionId)),
+      prompt: userFacingText(userMessage),
+    };
+  }
+
+  startNewSession(): void {
+    this.#sessionId = null;
+    this.#catalog = undefined;
+    this.#transcriptRevision = undefined;
+    this.#activeTurn = undefined;
+    this.#expectedNextTurnIds.clear();
+    this.#restartSessionObservation();
+  }
+
+  async stop(): Promise<void> {
+    const active = this.#activeTurn;
+    if (!this.#sessionId || !active || isTerminalTurn(active)) return;
+    this.#activeTurn = await this.#connection.stopTurn({
+      sessionId: this.#sessionId,
+      turnId: active.turnId,
+      runId: active.runId,
+    });
+  }
+
+  getSessionId(): string | null {
+    return this.#sessionId;
+  }
+
+  getOrchestrationMode(): OrchestrationMode {
+    return this.#orchestrationMode;
+  }
+
+  getPermissionMode(): PermissionMode {
+    return this.#permissionMode;
+  }
+
+  async #ensureSession(): Promise<string> {
+    if (this.#sessionId) return this.#sessionId;
+    const sessionId = this.#newId();
+    const created = requireSession(
+      await this.#connection.request('session.create', {
+        sessionId,
+        cwd: await realpath(this.#cwd),
+        name: DEFAULT_SESSION_NAME,
+        modelTarget: {
+          kind: 'explicit',
+          connectionSlug: this.#llmConnectionSlug,
+          model: this.#model,
+        },
+        ...(this.#thinkingLevel === undefined ? {} : { thinkingLevel: this.#thinkingLevel }),
+        permissionMode: this.#permissionMode,
+        orchestrationMode: this.#orchestrationMode,
+      }),
+    );
+    this.#transcriptRevision = created.revision;
+    this.#adoptCatalog(created);
+    return created.id;
+  }
+
+  async *#observeTurn(
+    sessionId: string,
+    turnId: string,
+    content: { text: string; displayText?: string },
+  ): AsyncIterable<MakaSessionDriverEvent> {
+    const token = Symbol('HostMakaSessionDriver stream');
+    this.#streamToken = token;
+    this.#expectedNextTurnIds.clear();
+    const subscription = await this.#connection.openSessionSubscription({ sessionId });
+    const chainTurnIds = new Set([turnId]);
+    const projectedInteractions = new Set<string>();
+    let queueRevision = -1;
+    let waitingForFollowup = false;
+    try {
+      const started = await this.#connection.startTurn({ sessionId, turnId, content });
+      this.#activeTurn = started;
+      yield* projectSnapshotState(
+        subscription.snapshot,
+        turnId,
+        projectedInteractions,
+        queueRevision,
+      );
+      queueRevision = subscription.snapshot.queue.queueRevision;
+      waitingForFollowup = subscription.snapshot.queue.followup.length > 0;
+
+      for await (const frame of subscription) {
+        if (frame.kind === 'subscription.closed') {
+          throw new Error(`Runtime Host Session subscription closed: ${frame.reason}`);
+        }
+        if (frame.kind === 'subscription.session_delta') {
+          if (!chainTurnIds.has(frame.delta.turnId)) continue;
+          yield {
+            id: this.#newId(),
+            type: frame.delta.kind === 'text' ? 'text_delta' : 'thinking_delta',
+            turnId: frame.delta.turnId,
+            ts: Date.now(),
+            messageId: frame.delta.messageId,
+            text: frame.delta.text,
+          };
+          continue;
+        }
+        if (frame.kind === 'subscription.session_event') {
+          if (!chainTurnIds.has(frame.event.turnId)) continue;
+          yield projectToolEvent(sessionId, frame.event);
+          continue;
+        }
+
+        const snapshot = frame.snapshot;
+        const rootTurn = snapshot.rootTurn;
+        if (rootTurn && !chainTurnIds.has(rootTurn.turnId)) {
+          if (this.#expectedNextTurnIds.delete(rootTurn.turnId) || waitingForFollowup) {
+            chainTurnIds.add(rootTurn.turnId);
+          }
+        }
+        if (rootTurn && chainTurnIds.has(rootTurn.turnId)) this.#activeTurn = rootTurn;
+        yield* projectSnapshotState(
+          snapshot,
+          rootTurn?.turnId ?? turnId,
+          projectedInteractions,
+          queueRevision,
+        );
+        queueRevision = snapshot.queue.queueRevision;
+
+        if (rootTurn && chainTurnIds.has(rootTurn.turnId) && isTerminalTurn(rootTurn)) {
+          if (snapshot.queue.followup.length > 0 || this.#expectedNextTurnIds.size > 0) {
+            waitingForFollowup = true;
+            continue;
+          }
+          yield* projectTerminalTurn(rootTurn);
+          return;
+        }
+        waitingForFollowup = snapshot.queue.followup.length > 0;
+      }
+      throw new Error('Runtime Host Session subscription ended before the turn became terminal');
+    } finally {
+      await subscription.close().catch(() => {});
+      if (this.#streamToken === token) {
+        this.#streamToken = undefined;
+        this.#activeTurn = undefined;
+        this.#expectedNextTurnIds.clear();
+      }
+    }
+  }
+
+  #restartSessionObservation(): void {
+    const token = Symbol('HostMakaSessionDriver observation');
+    this.#observationToken = token;
+    const previous = this.#observationSubscription;
+    this.#observationSubscription = undefined;
+    if (previous) void previous.close().catch(() => {});
+    const sessionId = this.#sessionId;
+    if (!sessionId || this.#observationListeners.size === 0) return;
+    // Let switchSession return its durable cut before catch-up can reach the
+    // view. The Host replay covers anything emitted during this one-tick gap.
+    setImmediate(() => {
+      if (this.#observationToken !== token) return;
+      void this.#observeSession(sessionId, token).catch(() => {});
+    });
+  }
+
+  async #observeSession(sessionId: string, token: symbol): Promise<void> {
+    const subscription = await this.#connection.openSessionSubscription({ sessionId });
+    if (this.#observationToken !== token) {
+      await subscription.close().catch(() => {});
+      return;
+    }
+    this.#observationSubscription = subscription;
+    const projectedInteractions = new Set<string>();
+    let queueRevision = -1;
+    let rootFingerprint = turnFingerprint(subscription.snapshot.rootTurn);
+    try {
+      this.#activeTurn = subscription.snapshot.rootTurn ?? undefined;
+      await this.#publishObservation({
+        sessionId,
+        events: projectSnapshotState(
+          subscription.snapshot,
+          observationTurnId(subscription.snapshot, sessionId),
+          projectedInteractions,
+          queueRevision,
+        ),
+        reloadTranscript:
+          (subscription.snapshot.rootTurn !== null &&
+            isTerminalTurn(subscription.snapshot.rootTurn)) ||
+          subscription.snapshot.session.metadataRevision !== this.#transcriptRevision,
+        activeTurn: isRunningTurn(subscription.snapshot.rootTurn),
+      });
+      queueRevision = subscription.snapshot.queue.queueRevision;
+
+      for await (const frame of subscription) {
+        if (this.#observationToken !== token) return;
+        if (frame.kind === 'subscription.closed') return;
+        if (frame.kind === 'subscription.session_delta') {
+          await this.#publishObservation({
+            sessionId,
+            events: [
+              {
+                id: this.#newId(),
+                type: frame.delta.kind === 'text' ? 'text_delta' : 'thinking_delta',
+                turnId: frame.delta.turnId,
+                ts: Date.now(),
+                messageId: frame.delta.messageId,
+                text: frame.delta.text,
+              },
+            ],
+            reloadTranscript: false,
+            activeTurn: true,
+          });
+          continue;
+        }
+        if (frame.kind === 'subscription.session_event') {
+          await this.#publishObservation({
+            sessionId,
+            events: [projectToolEvent(sessionId, frame.event)],
+            reloadTranscript: false,
+            activeTurn: true,
+          });
+          continue;
+        }
+
+        const snapshot = frame.snapshot;
+        const previousFingerprint = rootFingerprint;
+        rootFingerprint = turnFingerprint(snapshot.rootTurn);
+        this.#activeTurn = snapshot.rootTurn ?? undefined;
+        const events = projectSnapshotState(
+          snapshot,
+          observationTurnId(snapshot, sessionId),
+          projectedInteractions,
+          queueRevision,
+        );
+        queueRevision = snapshot.queue.queueRevision;
+        if (
+          snapshot.rootTurn &&
+          isTerminalTurn(snapshot.rootTurn) &&
+          rootFingerprint !== previousFingerprint
+        ) {
+          events.push(...projectTerminalTurn(snapshot.rootTurn));
+        }
+        await this.#publishObservation({
+          sessionId,
+          events,
+          reloadTranscript: rootFingerprint !== previousFingerprint,
+          activeTurn: isRunningTurn(snapshot.rootTurn),
+        });
+      }
+    } finally {
+      if (this.#observationSubscription === subscription) {
+        this.#observationSubscription = undefined;
+      }
+      await subscription.close().catch(() => {});
+    }
+  }
+
+  async #publishObservation(observation: MakaSessionObservation): Promise<void> {
+    if (this.#streamToken) return;
+    await Promise.all(
+      [...this.#observationListeners].map(async (listener) => {
+        try {
+          await listener(observation);
+        } catch {
+          // One view must not terminate the shared Host subscription.
+        }
+      }),
+    );
+  }
+
+  #submitQueuedMessage(
+    text: string,
+    placement: 'current_turn' | 'next_turn',
+  ): Promise<QueueEnqueueOutcome> {
+    return this.#serializeMessageOperation(async () => {
+      if (!this.#sessionId) return { kind: 'fallback' };
+      const result = await this.#connection.request('turn.message.submit', {
+        originHostEpoch: this.#connection.hostEpoch,
+        sessionId: this.#sessionId,
+        messageId: this.#newId(),
+        content: { text },
+        placement,
+      });
+      if (result.disposition === 'turn_started') {
+        this.#expectedNextTurnIds.add(result.turnId);
+      }
+      return { kind: 'queued' };
+    });
+  }
+
+  #serializeMessageOperation<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.#messageOperations.then(operation, operation);
+    this.#messageOperations = result.then(
+      () => {},
+      () => {},
+    );
+    return result;
+  }
+
+  async #commitConfiguration(): Promise<void> {
+    if (!this.#sessionId) return;
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const current = await this.#requireCurrentCatalog();
+      const result = await this.#connection.request('session.configuration.update', {
+        sessionId: current.id,
+        expectedRevision: current.revision,
+        configuration: {
+          modelTarget: {
+            kind: 'explicit',
+            connectionSlug: this.#llmConnectionSlug,
+            model: this.#model,
+          },
+          thinkingLevel: this.#thinkingLevel ?? null,
+          permissionMode: this.#permissionMode,
+          collaborationMode: current.collaborationMode,
+          orchestrationMode: this.#orchestrationMode,
+        },
+      });
+      if (result.kind === 'revision_conflict') {
+        this.#catalog = undefined;
+        continue;
+      }
+      this.#adoptCatalog(requireSession(result.session));
+      return;
+    }
+    throw new Error('Session configuration kept changing while it was updated');
+  }
+
+  async #requireCurrentCatalog(): Promise<SessionCatalogProjection> {
+    if (!this.#sessionId) throw new Error('No active Session');
+    if (this.#catalog?.id === this.#sessionId) return this.#catalog;
+    const session = await this.#readCatalog(this.#sessionId);
+    if (!session) throw new Error(`Session not found: ${this.#sessionId}`);
+    this.#catalog = session;
+    return session;
+  }
+
+  async #readCatalog(sessionId: string): Promise<SessionCatalogProjection | null> {
+    const result = await this.#connection.request('session.catalog.query', {
+      kind: 'get',
+      sessionId,
+    });
+    if (result.kind !== 'session') {
+      throw new Error('Runtime Host returned an invalid Session catalog result');
+    }
+    return result.session === null ? null : requireSession(result.session);
+  }
+
+  #adoptCatalog(session: SessionCatalogProjection): void {
+    const previousSessionId = this.#sessionId;
+    this.#catalog = session;
+    this.#sessionId = session.id;
+    this.#cwd = session.cwd;
+    this.#llmConnectionSlug = session.llmConnectionSlug;
+    this.#model = session.model;
+    this.#thinkingLevel = session.thinkingLevel;
+    this.#permissionMode = session.permissionMode;
+    this.#orchestrationMode = session.orchestrationMode;
+    if (previousSessionId !== session.id) this.#restartSessionObservation();
+  }
+}
+
+function projectSnapshotState(
+  snapshot: SessionContinuitySnapshot,
+  turnId: string,
+  projectedInteractions: Set<string>,
+  previousQueueRevision: number,
+): MakaSessionDriverEvent[] {
+  const events: MakaSessionDriverEvent[] = [];
+  if (snapshot.queue.queueRevision !== previousQueueRevision) {
+    events.push({
+      id: `queue-${snapshot.queue.hostEpoch}-${snapshot.queue.queueRevision}`,
+      type: 'queue_update',
+      turnId,
+      ts: Date.now(),
+      steering: snapshot.queue.steering.map((entry) => entry.content.text),
+      followup: snapshot.queue.followup.map((entry) => entry.content.text),
+    });
+  }
+  const pendingInteractionIds = new Set(
+    snapshot.interactions.pending.map((interaction) => interaction.interactionId),
+  );
+  for (const interactionId of projectedInteractions) {
+    if (pendingInteractionIds.has(interactionId)) continue;
+    projectedInteractions.delete(interactionId);
+    events.push({
+      id: `interaction-resolved-${interactionId}`,
+      type: 'host_interaction_resolved',
+      turnId,
+      ts: Date.now(),
+      requestId: interactionId,
+    });
+  }
+  for (const interaction of snapshot.interactions.pending) {
+    if (projectedInteractions.has(interaction.interactionId)) continue;
+    projectedInteractions.add(interaction.interactionId);
+    const event = projectInteraction(interaction);
+    if (event) events.push(event);
+  }
+  return events;
+}
+
+function projectInteraction(
+  interaction: InteractionPendingSnapshot,
+): MakaSessionDriverEvent | undefined {
+  if (interaction.request.kind === 'permission') {
+    return {
+      id: `interaction-${interaction.interactionId}`,
+      type: 'host_interaction_permission_request',
+      turnId: interaction.turnId,
+      ts: Date.now(),
+      requestId: interaction.interactionId,
+      toolUseId: interaction.request.toolUseId,
+      prompt: interaction.request.prompt,
+    };
+  }
+  return {
+    id: `interaction-${interaction.interactionId}`,
+    type: 'user_question_request',
+    turnId: interaction.turnId,
+    ts: Date.now(),
+    requestId: interaction.interactionId,
+    toolUseId: interaction.request.toolUseId,
+    questions: interaction.request.questions.map((question) => ({
+      question: question.question,
+      options: question.options.map((option) => ({ ...option })),
+    })),
+  };
+}
+
+function projectToolEvent(sessionId: string, event: SessionToolEvent): SessionEvent {
+  switch (event.type) {
+    case 'tool_start':
+      return {
+        ...event,
+        args: undefined,
+      };
+    case 'tool_output_delta':
+      return {
+        ...event,
+        sessionId,
+        toolCallId: event.toolUseId,
+      };
+    case 'tool_progress':
+      return event;
+    case 'tool_result':
+      return {
+        id: event.id,
+        type: event.type,
+        turnId: event.turnId,
+        ts: event.ts,
+        toolUseId: event.toolUseId,
+        ...(event.operationId === undefined ? {} : { operationId: event.operationId }),
+        isError: event.status === 'errored',
+        content: projectedToolResultContent(event.status),
+        ...(event.durationMs === undefined ? {} : { durationMs: event.durationMs }),
+      };
+  }
+}
+
+function projectedToolResultContent(
+  status: Extract<SessionToolEvent, { type: 'tool_result' }>['status'],
+): ToolResultContent {
+  return {
+    kind: 'text',
+    text:
+      status === 'errored'
+        ? 'Tool failed. The complete result will load from the durable transcript.'
+        : 'Tool completed. The complete result will load from the durable transcript.',
+  };
+}
+
+function projectTerminalTurn(turn: TurnSnapshot): SessionEvent[] {
+  if (turn.status === 'completed') {
+    return [
+      {
+        id: turn.terminalEventId,
+        type: 'complete',
+        turnId: turn.turnId,
+        ts: Date.now(),
+        stopReason: 'end_turn',
+      },
+    ];
+  }
+  if (turn.status === 'cancelled') {
+    return [
+      {
+        id: turn.terminalEventId,
+        type: 'abort',
+        turnId: turn.turnId,
+        ts: Date.now(),
+        reason: turn.abortSource === 'redirect' ? 'redirect' : 'user_stop',
+      },
+    ];
+  }
+  if (turn.status === 'failed') {
+    return [
+      {
+        id: turn.terminalEventId,
+        type: 'error',
+        turnId: turn.turnId,
+        ts: Date.now(),
+        recoverable: false,
+        reason: turn.failureClass,
+        message: `Turn failed: ${turn.failureClass}`,
+      },
+    ];
+  }
+  return [];
+}
+
+function observationTurnId(snapshot: SessionContinuitySnapshot, sessionId: string): string {
+  return snapshot.rootTurn?.turnId ?? `session-observation-${sessionId}`;
+}
+
+function turnFingerprint(turn: TurnSnapshot | null): string {
+  if (!turn) return 'idle';
+  return `${turn.turnId}:${turn.runId}:${turn.status}:${
+    isTerminalTurn(turn) ? turn.terminalEventId : ''
+  }`;
+}
+
+function isRunningTurn(turn: TurnSnapshot | null): boolean {
+  return turn !== null && !isTerminalTurn(turn);
+}
+
+function requireSession(item: SessionCatalogItem): SessionCatalogProjection {
+  if ('kind' in item) {
+    throw new Error(`Session ${item.id} cannot be represented by this Runtime Host client`);
+  }
+  return item;
+}
+
+function projectSessionSummary(session: SessionCatalogProjection): SessionSummary {
+  return {
+    id: session.id,
+    cwd: session.cwd,
+    ...(session.projectId !== undefined ? { projectId: session.projectId } : {}),
+    name: session.name,
+    isFlagged: session.isFlagged,
+    isArchived: session.isArchived,
+    labels: [...session.labels],
+    hasUnread: session.hasUnread,
+    ...(session.lastMessageAt === undefined ? {} : { lastMessageAt: session.lastMessageAt }),
+    ...(session.lastMessagePreview === undefined
+      ? {}
+      : { lastMessagePreview: session.lastMessagePreview }),
+    status: session.status,
+    ...(session.blockedReason === undefined ? {} : { blockedReason: session.blockedReason }),
+    ...(session.statusUpdatedAt === undefined ? {} : { statusUpdatedAt: session.statusUpdatedAt }),
+    ...(session.parentSessionId === undefined ? {} : { parentSessionId: session.parentSessionId }),
+    ...(session.branchOfTurnId === undefined ? {} : { branchOfTurnId: session.branchOfTurnId }),
+    ...(session.revisionRootSessionId === undefined
+      ? {}
+      : { revisionRootSessionId: session.revisionRootSessionId }),
+    ...(session.revisionParentSessionId === undefined
+      ? {}
+      : { revisionParentSessionId: session.revisionParentSessionId }),
+    ...(session.revisionOfTurnId === undefined
+      ? {}
+      : { revisionOfTurnId: session.revisionOfTurnId }),
+    ...(session.revisionIndex === undefined ? {} : { revisionIndex: session.revisionIndex }),
+    ...(session.revisionState === undefined ? {} : { revisionState: session.revisionState }),
+    backend: session.backend,
+    llmConnectionSlug: session.llmConnectionSlug,
+    connectionLocked: session.connectionLocked,
+    model: session.model,
+    ...(session.thinkingLevel === undefined ? {} : { thinkingLevel: session.thinkingLevel }),
+    permissionMode: session.permissionMode,
+    collaborationMode: session.collaborationMode,
+    orchestrationMode: session.orchestrationMode,
+  };
+}
+
+function joinRetractedMessages(
+  messages: readonly { readonly content: { readonly text: string } }[],
+): string {
+  return messages.map((message) => message.content.text).join('\n\n');
+}
+
+function isTerminalTurn(
+  turn: TurnSnapshot,
+): turn is Extract<TurnSnapshot, { status: 'completed' | 'failed' | 'cancelled' }> {
+  return turn.status === 'completed' || turn.status === 'failed' || turn.status === 'cancelled';
+}
+
+function requireBoundaryDisplayMode(mode: PermissionMode | null): PermissionMode {
+  if (mode === null) throw new Error('Externally isolated Session has no local permission mode');
+  return mode;
+}
+
+function firstLine(text: string): string {
+  return (
+    text
+      .split('\n')
+      .map((part) => part.trim())
+      .find((part) => part.length > 0) ?? '(empty prompt)'
+  );
+}
+
+function decodeTranscriptMessages(records: readonly unknown[]): StoredMessage[] {
+  return records.map((record) => decodeStoredMessageForRead(record));
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -6,6 +6,10 @@ export {
   type SessionResumeAvailability,
 } from './session-driver.js';
 export {
+  createHostMakaSessionDriver,
+  type HostMakaSessionDriverInput,
+} from './host-session-driver.js';
+export {
   parseMakaCliArgs,
   type MakaCliCommand,
 } from './cli.js';

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -94,9 +94,10 @@ export interface MakaPiTranscriptState {
   /**
    * Messages whose enqueue hit the no-live-owner fallback while a turn was
    * running (the begin window). CLI-owned, NOT a runtime mirror: the runner
-   * retries the original enqueue until it lands and flushes any remainder
-   * into the next turn at the turn boundary, so the text is never dropped.
-   * Rendered in the pending bar alongside the mirror.
+   * retries the original enqueue while an owner exists. At a healthy idle
+   * boundary, any remainder becomes the next turn; abort, failure, or an
+   * unavailable Session returns it to the editor. Rendered in the pending bar
+   * alongside the mirror until one of those paths takes ownership.
    */
   pendingFallback: Array<{ text: string; enqueue: 'steer' | 'queue' }>;
   /** Current non-durable provider retry progress for the activity strip. */
@@ -336,10 +337,11 @@ export function replaceTranscriptWithStoredMessages(
   // keeps its viewport and so does the estimate.
   state.renderGeometry.entryFirstLine = undefined;
   state.usage = { costUsd: 0, cacheHitInput: 0, cacheMissInput: 0 };
-  // Queues are per-active-run; a switched/reset session has none pending.
+  // These are runtime projections and must converge with the durable cut.
+  // `pendingFallback` is CLI-owned delivery state, so ordinary transcript
+  // reloads must preserve it. Session switch/reset paths clear it explicitly.
   state.steering = [];
   state.followup = [];
-  state.pendingFallback = [];
   for (const msg of messages) {
     if (msg.type === 'token_usage') accumulateUsage(state.usage, msg);
   }

--- a/packages/cli/src/pi-transcript.ts
+++ b/packages/cli/src/pi-transcript.ts
@@ -22,7 +22,11 @@ import {
 } from '@maka/core';
 import { homedir } from 'node:os';
 import { materializeSession, type ChatItem, type ToolActivityItem } from '@maka/runtime';
-import type { MakaSessionDriver } from './session-driver.js';
+import type {
+  HostInteractionPermissionRequestEvent,
+  MakaSessionDriver,
+  MakaSessionDriverEvent,
+} from './session-driver.js';
 import { BoundedChunkBuffer } from './bounded-chunk-buffer.js';
 import { ansi } from './tui-ansi.js';
 import {
@@ -99,7 +103,10 @@ export interface MakaPiTranscriptState {
   providerRetry?: ProviderRetryEvent;
 }
 
-export type MakaPiPendingInteraction = SandboxBoundaryRequestEvent | UserQuestionRequestEvent;
+export type MakaPiPendingInteraction =
+  | SandboxBoundaryRequestEvent
+  | HostInteractionPermissionRequestEvent
+  | UserQuestionRequestEvent;
 
 export interface MakaPiRenderGeometry {
   /**
@@ -460,7 +467,7 @@ export async function submitCompactToTranscript(input: {
 
 export function applyMakaSessionEventToTranscript(
   state: MakaPiTranscriptState,
-  event: SessionEvent,
+  event: MakaSessionDriverEvent,
 ): void {
   if (
     event.type === 'text_delta' ||
@@ -652,6 +659,12 @@ export function applyMakaSessionEventToTranscript(
 
     case 'sandbox_boundary_request':
       enqueuePendingInteraction(state, event);
+      break;
+    case 'host_interaction_permission_request':
+      enqueuePendingInteraction(state, event);
+      break;
+    case 'host_interaction_resolved':
+      completePendingInteraction(state, event.requestId);
       break;
     case 'user_question_request':
       enqueuePendingInteraction(state, event);
@@ -1071,6 +1084,9 @@ export function renderMakaPiTranscript(
   if (state.pendingInteraction?.type === 'sandbox_boundary_request') {
     lines.push('');
     lines.push(...renderSandboxBoundaryPrompt(state.pendingInteraction, safeWidth));
+  } else if (state.pendingInteraction?.type === 'host_interaction_permission_request') {
+    lines.push('');
+    lines.push(...renderInteractionPermissionPrompt(state.pendingInteraction, safeWidth));
   }
 
   return lines;
@@ -1094,6 +1110,14 @@ export function activeSandboxBoundaryRequest(
   state: MakaPiTranscriptState,
 ): SandboxBoundaryRequestEvent | undefined {
   return state.pendingInteraction?.type === 'sandbox_boundary_request'
+    ? state.pendingInteraction
+    : undefined;
+}
+
+export function activeInteractionPermissionRequest(
+  state: MakaPiTranscriptState,
+): HostInteractionPermissionRequestEvent | undefined {
+  return state.pendingInteraction?.type === 'host_interaction_permission_request'
     ? state.pendingInteraction
     : undefined;
 }
@@ -1640,6 +1664,28 @@ function renderSandboxBoundaryPrompt(
   lines.push(
     fitLine(
       `${ansi.bold('y')}${ansi.dim('/Enter allow for session')}  ${ansi.bold('n')}${ansi.dim('/Esc deny')}`,
+      width,
+    ),
+  );
+  return lines;
+}
+
+function renderInteractionPermissionPrompt(
+  request: HostInteractionPermissionRequestEvent,
+  width: number,
+): string[] {
+  const lines = [
+    fitLine(ansi.yellow(`Allow ${request.prompt.toolName}?`), width),
+    ...renderIndented(formatUnknown(request.prompt.review), width, 2),
+  ];
+  if (request.prompt.kind === 'sandbox_escalation') {
+    lines.push(...renderIndented('This command will run outside the sandbox.', width, 2));
+  } else if (request.prompt.kind === 'additional_permissions') {
+    lines.push(...renderIndented('This tool needs additional workspace access.', width, 2));
+  }
+  lines.push(
+    fitLine(
+      `${ansi.bold('y')}${ansi.dim('/Enter allow once')}  ${ansi.bold('n')}${ansi.dim('/Esc deny')}`,
       width,
     ),
   );

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -59,6 +59,7 @@ import type { CliGoalTurnHost } from './cli-goal-continuation.js';
 import {
   inspectSessionResumeAvailability,
   type MakaSessionDriver,
+  type MakaSessionDriverEvent,
   type MakaSessionSwitchResult,
 } from './session-driver.js';
 import {
@@ -66,6 +67,7 @@ import {
   appendUserPrompt,
   applyMakaSessionEventToTranscript,
   createMakaPiTranscriptState,
+  activeInteractionPermissionRequest,
   activeSandboxBoundaryRequest,
   activeUserQuestionRequest,
   completePendingInteraction,
@@ -248,6 +250,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       }
     | undefined;
   let turnRunning = false;
+  let remoteTurnRunning = false;
+  let permissionAlerted = false;
   let turnStartedAt: number | undefined;
   let interruptRequested = false;
   let lastTurnEscapeAt = 0;
@@ -470,6 +474,29 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     requestRender();
   };
 
+  const applyDriverEventToUi = (event: MakaSessionDriverEvent): void => {
+    applyMakaSessionEventToTranscript(state, event);
+    if (event.type === 'error') attention.attentionNeeded();
+    if (
+      permissionResponseInFlightRequestId !== null &&
+      activeSandboxBoundaryRequest(state)?.requestId !== permissionResponseInFlightRequestId &&
+      activeInteractionPermissionRequest(state)?.requestId !== permissionResponseInFlightRequestId
+    ) {
+      permissionResponseInFlightRequestId = null;
+    }
+    if (state.pendingInteraction) {
+      if (!permissionAlerted) {
+        permissionAlerted = true;
+        attention.attentionNeeded();
+      }
+    } else {
+      permissionAlerted = false;
+    }
+    shellRunElapsedTicker.sync();
+    syncUserQuestionOverlay();
+    requestRender();
+  };
+
   // Control commands (model/session/permission switches) mutate session state.
   // Run them through a single serial lock so a prompt submitted mid-switch can
   // not race the switch and land on the old session/model/permission mode.
@@ -502,6 +529,43 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     }
   };
 
+  let observationTail = Promise.resolve();
+  const unsubscribeSessionObservations =
+    input.driver.subscribeSessionObservations?.((observation) => {
+      observationTail = observationTail
+        .then(async () => {
+          if (closed || input.driver.getSessionId() !== observation.sessionId) return;
+          if (observation.reloadTranscript && input.driver.reloadTranscript) {
+            const messages = await input.driver.reloadTranscript();
+            if (closed || input.driver.getSessionId() !== observation.sessionId) return;
+            replaceTranscriptWithStoredMessages(state, messages);
+          }
+          for (const event of observation.events) applyDriverEventToUi(event);
+          if (observation.activeTurn && !turnRunning) {
+            remoteTurnRunning = true;
+            turnRunning = true;
+            busy = true;
+            turnStartedAt = Date.now();
+            startTurnElapsedTicker();
+            terminal.setProgress(true);
+            attention.promptTurnStarted();
+            requestRender();
+          } else if (!observation.activeTurn && remoteTurnRunning) {
+            remoteTurnRunning = false;
+            turnRunning = false;
+            busy = false;
+            turnStartedAt = undefined;
+            stopTurnElapsedTicker();
+            terminal.setProgress(false);
+            attention.promptTurnEnded();
+            lastActivityAt = Date.now();
+            requestRender();
+          }
+        })
+        .catch(reportError);
+      return observationTail;
+    }) ?? (() => {});
+
   const removeProcessHandlers = () => {
     process.off('SIGINT', handleSigint);
     process.off('SIGTERM', handleSigterm);
@@ -515,6 +579,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     unbindGoalHost?.();
     unbindGoalHost = undefined;
     unsubscribeSessionTitleChanges();
+    unsubscribeSessionObservations();
     shellRunHydration.dispose();
     shellRunElapsedTicker.dispose();
     stopTurnElapsedTicker();
@@ -594,6 +659,32 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     return true;
   };
 
+  const respondToPendingInteractionPermission = (decision: 'allow' | 'deny'): boolean => {
+    const request = activeInteractionPermissionRequest(state);
+    const respond = input.driver.respondToPermission;
+    if (!request || !respond || permissionResponseInFlightRequestId !== null) return false;
+    permissionResponseInFlightRequestId = request.requestId;
+    void respond
+      .call(input.driver, {
+        requestId: request.requestId,
+        kind: 'permission',
+        decision,
+        rememberForTurn: false,
+      })
+      .then(() => {
+        if (activeInteractionPermissionRequest(state)?.requestId === request.requestId) {
+          completePendingInteraction(state, request.requestId);
+        }
+        permissionResponseInFlightRequestId = null;
+        requestRender();
+      })
+      .catch((error) => {
+        permissionResponseInFlightRequestId = null;
+        reportError(error);
+      });
+    return true;
+  };
+
   // Refill the editor from a retract result, prepended to any current draft.
   // Shared by the interrupt path and the alt+↑ path. The text always comes
   // from `driver.retractQueued()` — a synchronous in-process read of the
@@ -616,15 +707,23 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // just cancelled. The normal turn finally restores submit; a rejected
     // stop restores it here.
     editor.disableSubmit = true;
-    // Retract synchronously from the authoritative queue before stop() clears
-    // it: only messages still queued come back for re-editing; anything the
-    // turn already consumed stays consumed (it is in the transcript/ledger).
-    // CLI-held fallback texts (never reached the runtime) come back too.
-    refillEditorFromQueues(
-      [takePendingFallback(), input.driver.retractQueued?.() ?? ''].filter(Boolean).join('\n\n'),
-    );
-    requestRender();
-    void input.driver.stop().catch((error) => {
+    // Host-backed drivers combine retraction and stop in one command. Embedded
+    // drivers keep the legacy in-process sequence, but both paths refill only
+    // from the authoritative result rather than the potentially stale mirror.
+    void (async () => {
+      const fallback = takePendingFallback();
+      let retracted: string;
+      if (input.driver.interrupt) {
+        retracted = await input.driver.interrupt();
+      } else {
+        const retractResult = input.driver.retractQueued?.() ?? '';
+        retracted =
+          typeof retractResult === 'string' ? retractResult : await Promise.resolve(retractResult);
+        await input.driver.stop();
+      }
+      refillEditorFromQueues([fallback, retracted].filter(Boolean).join('\n\n'));
+      requestRender();
+    })().catch((error) => {
       interruptRequested = false;
       editor.disableSubmit = false;
       reportError(error);
@@ -738,6 +837,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // a normal turn outlives any fixed budget and the text must not vanish.
   const FALLBACK_RETRY_MS = 100;
   let fallbackRetryTimer: ReturnType<typeof setInterval> | null = null;
+  let fallbackRetryInFlight = false;
 
   const stopFallbackRetry = () => {
     if (fallbackRetryTimer === null) return;
@@ -745,30 +845,40 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     fallbackRetryTimer = null;
   };
 
-  const retryPendingFallback = () => {
+  const retryPendingFallback = async () => {
+    if (fallbackRetryInFlight) return;
     if (closed || !turnRunning || state.pendingFallback.length === 0) {
       stopFallbackRetry();
       return;
     }
-    const remaining: typeof state.pendingFallback = [];
-    for (const entry of state.pendingFallback) {
-      const outcome =
-        entry.enqueue === 'steer'
-          ? input.driver.steer?.(entry.text)
-          : input.driver.queueMessage?.(entry.text);
-      if (outcome?.kind !== 'queued') remaining.push(entry);
+    fallbackRetryInFlight = true;
+    try {
+      const remaining: typeof state.pendingFallback = [];
+      for (const entry of state.pendingFallback) {
+        const outcome = await Promise.resolve(
+          entry.enqueue === 'steer'
+            ? input.driver.steer?.(entry.text)
+            : input.driver.queueMessage?.(entry.text),
+        );
+        if (outcome?.kind !== 'queued') remaining.push(entry);
+      }
+      if (remaining.length === state.pendingFallback.length) return;
+      state.pendingFallback = remaining;
+      if (remaining.length === 0) stopFallbackRetry();
+      // The queue mirror updates only from `queue_update` events (single path);
+      // this render just drops the delivered entries from the fallback list.
+      requestRender();
+    } catch (error) {
+      stopFallbackRetry();
+      reportError(error);
+    } finally {
+      fallbackRetryInFlight = false;
     }
-    if (remaining.length === state.pendingFallback.length) return;
-    state.pendingFallback = remaining;
-    if (remaining.length === 0) stopFallbackRetry();
-    // The queue mirror updates only from `queue_update` events (single path);
-    // this render just drops the delivered entries from the fallback list.
-    requestRender();
   };
 
   const deferFallback = (text: string, enqueue: 'steer' | 'queue') => {
     state.pendingFallback.push({ text, enqueue });
-    fallbackRetryTimer ??= setInterval(retryPendingFallback, FALLBACK_RETRY_MS);
+    fallbackRetryTimer ??= setInterval(() => void retryPendingFallback(), FALLBACK_RETRY_MS);
     requestRender();
   };
 
@@ -783,20 +893,31 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   // Enter during a turn steers it (inject at the next step boundary); the
   // runtime falls back to a fresh turn if the run already ended.
+  const enqueueDuringTurn = async (text: string, enqueue: 'steer' | 'queue') => {
+    try {
+      const outcome = await Promise.resolve(
+        enqueue === 'steer' ? input.driver.steer?.(text) : input.driver.queueMessage?.(text),
+      );
+      if (outcome?.kind === 'queued') {
+        requestRender();
+        return;
+      }
+      if (turnRunning || busy) deferFallback(text, enqueue);
+      else submitPrompt(text);
+    } catch (error) {
+      const draft = editor.getText();
+      editor.setText(draft ? `${text}\n\n${draft}` : text);
+      reportError(error);
+    }
+  };
+
   const steerRunningTurn = (text: string) => {
     if (!text.trim()) {
       requestRender();
       return;
     }
     editor.addToHistory(text);
-    const outcome = input.driver.steer?.(text);
-    if (!outcome || outcome.kind === 'fallback') {
-      if (turnRunning) deferFallback(text, 'steer');
-      else submitPrompt(text);
-      return;
-    }
-    // Queued: the runtime's `queue_update` event refreshes the mirror.
-    requestRender();
+    void enqueueDuringTurn(text, 'steer');
   };
 
   // Alt+Enter: during a turn, queue the text to open the next turn; when idle,
@@ -817,23 +938,19 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       return;
     }
     editor.addToHistory(text);
-    const outcome = input.driver.queueMessage?.(text);
-    if (!outcome || outcome.kind === 'fallback') {
-      if (turnRunning) deferFallback(text, 'queue');
-      else submitPrompt(text);
-      return;
-    }
-    // Queued: the runtime's `queue_update` event refreshes the mirror.
-    requestRender();
+    void enqueueDuringTurn(text, 'queue');
   };
 
   // Alt+↑: take back every queued message (both queues plus CLI-held fallback
   // texts), joined and prepended to the current draft for re-editing.
   const retractQueuedMessages = () => {
-    refillEditorFromQueues(
-      [takePendingFallback(), input.driver.retractQueued?.() ?? ''].filter(Boolean).join('\n\n'),
-    );
-    requestRender();
+    const fallback = takePendingFallback();
+    void Promise.resolve(input.driver.retractQueued?.() ?? '')
+      .then((retracted) => {
+        refillEditorFromQueues([fallback, retracted].filter(Boolean).join('\n\n'));
+        requestRender();
+      })
+      .catch(reportError);
   };
 
   // Onboarding wizard (#1098 UX redesign): one overlay spans provider search
@@ -919,7 +1036,6 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     attention.promptTurnStarted();
     requestRender();
 
-    let permissionAlerted = false;
     const finishTurnUi = () => {
       turnRunning = false;
       turnStartedAt = undefined;
@@ -942,30 +1058,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         appendUserPrompt(state, request.prompt);
         requestRender();
       },
-      onEvent: (event) => {
-        applyMakaSessionEventToTranscript(state, event);
-        if (event.type === 'error') attention.attentionNeeded();
-        if (
-          permissionResponseInFlightRequestId !== null &&
-          activeSandboxBoundaryRequest(state)?.requestId !== permissionResponseInFlightRequestId
-        ) {
-          permissionResponseInFlightRequestId = null;
-        }
-        // A pending decision blocks the turn; ring an unfocused terminal once when
-        // the prompt first appears (not on every render) so the user is not left
-        // waiting on a prompt they cannot see.
-        if (state.pendingInteraction) {
-          if (!permissionAlerted) {
-            permissionAlerted = true;
-            attention.attentionNeeded();
-          }
-        } else {
-          permissionAlerted = false;
-        }
-        shellRunElapsedTicker.sync();
-        syncUserQuestionOverlay();
-        requestRender();
-      },
+      onEvent: applyDriverEventToUi,
       // A turn failing is worth pulling the user back, regardless of how long it
       // ran — a quick failure in a background tab would otherwise stay silent.
       onFailure: (error) => {
@@ -976,7 +1069,14 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         requestRender();
       },
     }).then(
-      (outcome) => {
+      async (outcome) => {
+        if (input.driver.reloadTranscript) {
+          try {
+            replaceTranscriptWithStoredMessages(state, await input.driver.reloadTranscript());
+          } catch (error) {
+            reportError(error);
+          }
+        }
         finishTurnUi();
         if (closed) {
           busy = false;
@@ -2509,6 +2609,18 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       return { consume: true };
     }
     if (tui.hasOverlay()) return undefined;
+    const pendingInteractionPermission = activeInteractionPermissionRequest(state);
+    if (pendingInteractionPermission && !matchesKey(data, Key.ctrl('c'))) {
+      if (
+        !isKeyRepeat(data) &&
+        (matchesKey(data, 'y') || matchesKey(data, Key.enter) || matchesKey(data, Key.return))
+      ) {
+        respondToPendingInteractionPermission('allow');
+      } else if (!isKeyRepeat(data) && (matchesKey(data, 'n') || matchesKey(data, Key.escape))) {
+        respondToPendingInteractionPermission('deny');
+      }
+      return { consume: true };
+    }
     const pendingSandboxBoundary = activeSandboxBoundaryRequest(state);
     if (pendingSandboxBoundary && !matchesKey(data, Key.ctrl('c'))) {
       if (

--- a/packages/cli/src/pi-tui-runner.ts
+++ b/packages/cli/src/pi-tui-runner.ts
@@ -14,6 +14,7 @@ import {
   type Terminal,
 } from '@earendil-works/pi-tui';
 import type { PermissionMode } from '@maka/core/permission';
+import type { StoredMessage } from '@maka/core/session';
 import {
   isThinkingLevel,
   thinkingVariantsForModel,
@@ -60,6 +61,7 @@ import {
   inspectSessionResumeAvailability,
   type MakaSessionDriver,
   type MakaSessionDriverEvent,
+  type MakaSessionObservation,
   type MakaSessionSwitchResult,
 } from './session-driver.js';
 import {
@@ -210,6 +212,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let busy = false;
   let closed = false;
   let currentActivityCompletion: Promise<void> | undefined;
+  let resolveActivitiesIdle: (() => void) | undefined;
+  let activeActivityCount = 0;
+  let syncActivityUi = () => {};
   let permissionResponseInFlightRequestId: string | null = null;
   // Session recap (issue #1055): an in-flight lock shared by manual and
   // automatic recap calls, an activity clock for idle-return detection, a
@@ -225,18 +230,28 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let recapWatermark: { sessionId: string; mainTurnCount: number } | null = null;
   let promptSeq = 0;
   const beginActivity = () => {
-    let finish!: () => void;
-    const completion = new Promise<void>((resolve) => {
-      finish = resolve;
-    });
-    currentActivityCompletion = completion;
+    if (activeActivityCount === 0) {
+      currentActivityCompletion = new Promise<void>((resolve) => {
+        resolveActivitiesIdle = resolve;
+      });
+    }
+    activeActivityCount += 1;
+    busy = true;
+    syncActivityUi();
     let finished = false;
     return {
       finish: () => {
         if (finished) return;
         finished = true;
-        if (currentActivityCompletion === completion) currentActivityCompletion = undefined;
-        finish();
+        activeActivityCount -= 1;
+        if (activeActivityCount === 0) {
+          busy = false;
+          currentActivityCompletion = undefined;
+          const resolve = resolveActivitiesIdle;
+          resolveActivitiesIdle = undefined;
+          resolve?.();
+        }
+        syncActivityUi();
       },
     };
   };
@@ -249,11 +264,17 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         answers: Array<string | null>;
       }
     | undefined;
-  let turnRunning = false;
-  let remoteTurnRunning = false;
+  let turnOwner: 'local' | 'remote' | undefined;
+  let turnUiGeneration = 0;
+  let observedRemoteTurnActive = false;
+  let localTurnSettlementPending = false;
+  let syncObservedRemoteTurn = () => {};
+  let ensureFallbackRetry = () => {};
+  const turnIsRunning = () => turnOwner !== undefined;
   let permissionAlerted = false;
   let turnStartedAt: number | undefined;
   let interruptRequested = false;
+  let interruptTask: Promise<void> | undefined;
   let lastTurnEscapeAt = 0;
   let lastIdleEscapeAt = 0;
   let lastIdleCtrlCAt = 0;
@@ -318,6 +339,10 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   const requestRender = () => {
     transcript.invalidate();
     tui.requestRender();
+  };
+  syncActivityUi = () => {
+    terminal.setProgress(busy);
+    requestRender();
   };
   const unsubscribeSessionTitleChanges =
     input.subscribeSessionTitleChanges?.((sessionId) => {
@@ -450,6 +475,33 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       turnElapsedInterval = undefined;
     }
   };
+  const beginTurnUi = (owner: 'local' | 'remote') => {
+    if (turnOwner === owner) return;
+    if (turnOwner !== undefined) {
+      throw new Error(`Cannot start a ${owner} turn while a ${turnOwner} turn owns the TUI`);
+    }
+    turnOwner = owner;
+    turnUiGeneration += 1;
+    turnStartedAt = Date.now();
+    startTurnElapsedTicker();
+    interruptRequested = false;
+    lastTurnEscapeAt = 0;
+    attention.promptTurnStarted();
+    requestRender();
+  };
+  const finishTurnUi = (owner: 'local' | 'remote') => {
+    if (turnOwner !== owner) return;
+    turnOwner = undefined;
+    turnUiGeneration += 1;
+    turnStartedAt = undefined;
+    stopTurnElapsedTicker();
+    interruptRequested = false;
+    editor.disableSubmit = activeActivityCount > 1;
+    attention.promptTurnEnded();
+    lastActivityAt = Date.now();
+    requestRender();
+    if (owner === 'local') syncObservedRemoteTurn();
+  };
   const shellRunHydration = createShellRunHydrationController({
     driver: input.driver,
     applyToTranscript: (update, options) =>
@@ -504,10 +556,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // Refuse nested control actions: an overlay onSelect bypasses editor.onSubmit,
     // so without this guard a switch could start while a prompt is still running.
     if (busy) return;
-    busy = true;
     const activity = beginActivity();
     editor.disableSubmit = true;
-    terminal.setProgress(true);
     attention.controlStarted();
     requestRender();
     let sessionActivity: SessionActivityLease | undefined;
@@ -520,47 +570,91 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       reportError(error);
     } finally {
       sessionActivity?.release();
-      busy = false;
-      activity.finish();
       editor.disableSubmit = false;
-      terminal.setProgress(false);
       attention.controlEnded();
-      requestRender();
+      activity.finish();
     }
   };
 
   let observationTail = Promise.resolve();
+  let observationCut = 0;
+  let latestObservationCut: MakaSessionObservation['cut'] = 'unavailable';
+  const observationCutWaiters = new Set<{
+    readonly after: number;
+    readonly resolve: () => void;
+  }>();
+  const publishObservationCut = (cut: MakaSessionObservation['cut']) => {
+    latestObservationCut = cut;
+    observationCut += 1;
+    for (const waiter of observationCutWaiters) {
+      if (observationCut <= waiter.after) continue;
+      observationCutWaiters.delete(waiter);
+      waiter.resolve();
+    }
+  };
+  const waitForObservationAfter = (after: number): Promise<void> => {
+    if (closed || observationCut > after) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      observationCutWaiters.add({ after, resolve });
+    });
+  };
+  const releaseObservationWaiters = () => {
+    for (const waiter of observationCutWaiters) waiter.resolve();
+    observationCutWaiters.clear();
+  };
+  let remoteTurnActivity: ReturnType<typeof beginActivity> | undefined;
+  syncObservedRemoteTurn = () => {
+    if (observedRemoteTurnActive && turnOwner === undefined) {
+      remoteTurnActivity = beginActivity();
+      beginTurnUi('remote');
+      if (localTurnSettlementPending) editor.disableSubmit = false;
+      ensureFallbackRetry();
+    } else if (!observedRemoteTurnActive && turnOwner === 'remote') {
+      finishTurnUi('remote');
+      remoteTurnActivity?.finish();
+      remoteTurnActivity = undefined;
+    }
+  };
+  const sessionObservation = input.driver.sessionObservation;
   const unsubscribeSessionObservations =
-    input.driver.subscribeSessionObservations?.((observation) => {
+    sessionObservation?.subscribe((observation) => {
+      if (closed || input.driver.getSessionId() !== observation.sessionId) return;
+      observedRemoteTurnActive = observation.cut === 'active';
+      syncObservedRemoteTurn();
+      publishObservationCut(observation.cut);
+      const observationGeneration = turnUiGeneration;
+      const observationCutAtArrival = observationCut;
       observationTail = observationTail
         .then(async () => {
           if (closed || input.driver.getSessionId() !== observation.sessionId) return;
-          if (observation.reloadTranscript && input.driver.reloadTranscript) {
-            const messages = await input.driver.reloadTranscript();
-            if (closed || input.driver.getSessionId() !== observation.sessionId) return;
-            replaceTranscriptWithStoredMessages(state, messages);
+          let reloadResult:
+            | { readonly kind: 'success'; readonly messages: readonly StoredMessage[] }
+            | { readonly kind: 'failure'; readonly error: unknown }
+            | undefined;
+          if (observation.reloadTranscript) {
+            try {
+              reloadResult = {
+                kind: 'success',
+                messages: await sessionObservation.reloadTranscript(),
+              };
+            } catch (error) {
+              reloadResult = { kind: 'failure', error };
+            }
+          }
+          if (
+            closed ||
+            input.driver.getSessionId() !== observation.sessionId ||
+            turnUiGeneration !== observationGeneration ||
+            observationCut !== observationCutAtArrival
+          ) {
+            return;
+          }
+          if (reloadResult?.kind === 'success') {
+            replaceTranscriptWithStoredMessages(state, reloadResult.messages);
+          } else if (reloadResult?.kind === 'failure') {
+            reportError(reloadResult.error);
           }
           for (const event of observation.events) applyDriverEventToUi(event);
-          if (observation.activeTurn && !turnRunning) {
-            remoteTurnRunning = true;
-            turnRunning = true;
-            busy = true;
-            turnStartedAt = Date.now();
-            startTurnElapsedTicker();
-            terminal.setProgress(true);
-            attention.promptTurnStarted();
-            requestRender();
-          } else if (!observation.activeTurn && remoteTurnRunning) {
-            remoteTurnRunning = false;
-            turnRunning = false;
-            busy = false;
-            turnStartedAt = undefined;
-            stopTurnElapsedTicker();
-            terminal.setProgress(false);
-            attention.promptTurnEnded();
-            lastActivityAt = Date.now();
-            requestRender();
-          }
         })
         .catch(reportError);
       return observationTail;
@@ -580,6 +674,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     unbindGoalHost = undefined;
     unsubscribeSessionTitleChanges();
     unsubscribeSessionObservations();
+    releaseObservationWaiters();
     shellRunHydration.dispose();
     shellRunElapsedTicker.dispose();
     stopTurnElapsedTicker();
@@ -597,11 +692,16 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     if (closed) return;
     closed = true;
     restoreTerminal();
-    if (error) rejectClosed(error);
-    else resolveClosed();
-    // Runtime stop is best-effort after the shell has its terminal back. A
-    // double-Escape/Ctrl-C interrupt may already have one in flight; reuse it.
-    if (!interruptRequested) void input.driver.stop().catch(() => {});
+    // The shell gets its terminal back before Runtime cleanup starts, while
+    // callers retain the connection until an exact stop/interrupt settles or
+    // the bounded drain expires.
+    const drain = interruptRequested
+      ? interruptTask
+      : Promise.resolve().then(() => input.driver.stop());
+    void waitForCloseDrain(drain).then(() => {
+      if (error) rejectClosed(error);
+      else resolveClosed();
+    });
   };
 
   const handleProcessExit = (exitCode: number, error?: Error): void => {
@@ -685,12 +785,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     return true;
   };
 
-  // Refill the editor from a retract result, prepended to any current draft.
-  // Shared by the interrupt path and the alt+↑ path. The text always comes
-  // from `driver.retractQueued()` — a synchronous in-process read of the
-  // runtime's authoritative queues — never from the render mirror, which can
-  // lag a step-boundary consumption and would resurrect an already-consumed
-  // steering message for a double execution. Clears the local mirror.
+  // Refill the editor from authoritative runtime retraction and/or CLI-owned
+  // fallback/follow-up state, prepended to any current draft. Never read the
+  // render mirror: it can lag step-boundary consumption and resurrect an
+  // already-consumed steering message for a double execution. Clears that
+  // mirror after the caller transfers the owned text here.
   const refillEditorFromQueues = (joined: string) => {
     state.steering = [];
     state.followup = [];
@@ -710,7 +809,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // Host-backed drivers combine retraction and stop in one command. Embedded
     // drivers keep the legacy in-process sequence, but both paths refill only
     // from the authoritative result rather than the potentially stale mirror.
-    void (async () => {
+    const task = (async () => {
       const fallback = takePendingFallback();
       let retracted: string;
       if (input.driver.interrupt) {
@@ -723,11 +822,18 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       }
       refillEditorFromQueues([fallback, retracted].filter(Boolean).join('\n\n'));
       requestRender();
-    })().catch((error) => {
-      interruptRequested = false;
-      editor.disableSubmit = false;
-      reportError(error);
-    });
+    })();
+    interruptTask = task;
+    void task
+      .catch((error) => {
+        if (closed) return;
+        interruptRequested = false;
+        editor.disableSubmit = false;
+        reportError(error);
+      })
+      .finally(() => {
+        if (interruptTask === task) interruptTask = undefined;
+      });
   };
 
   // Open a fresh turn from a submitted prompt (idle path). Control actions hold
@@ -779,10 +885,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // `editor.disableSubmit` for the async prep window: pi-tui clears the draft
   // before onSubmit, so a second Enter during prep must not be accepted (it
   // would be dropped by the busy guard with the draft already gone).
-  // runAgentTurn re-asserts busy for the turn itself and re-enables submit so
+  // runAgentTurn opens the turn activity and re-enables submit so
   // mid-turn Enter can still steer.
   const submitPreparedUserPrompt = async (prompt: string) => {
-    busy = true;
     const preparationActivity = beginActivity();
     editor.disableSubmit = true;
     let handedOff = false;
@@ -819,7 +924,6 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       reportError(error);
     } finally {
       if (!handedOff) {
-        busy = false;
         editor.disableSubmit = false;
         requestRender();
       }
@@ -832,12 +936,19 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // Fallback handoff owner. A `fallback` outcome while the turn is running
   // means the runtime has no live steering owner YET (the begin window) or
   // just lost it; the runtime keeps no record of the text, so the CLI owns
-  // delivery: retry the SAME enqueue until the owner appears, and flush any
-  // remainder into the next turn at the turn boundary. Never a bounded wait —
-  // a normal turn outlives any fixed budget and the text must not vanish.
+  // delivery. Retry the SAME enqueue while a turn owner exists. Once the
+  // post-local observation cut is known, a healthy idle boundary opens the
+  // next turn; abort, failure, or unavailability restores the text to the
+  // editor. Never use a bounded retry: a normal turn can outlive any fixed
+  // budget and the text must not vanish.
   const FALLBACK_RETRY_MS = 100;
   let fallbackRetryTimer: ReturnType<typeof setInterval> | null = null;
   let fallbackRetryInFlight = false;
+
+  ensureFallbackRetry = () => {
+    if (!turnIsRunning() || state.pendingFallback.length === 0) return;
+    fallbackRetryTimer ??= setInterval(() => void retryPendingFallback(), FALLBACK_RETRY_MS);
+  };
 
   const stopFallbackRetry = () => {
     if (fallbackRetryTimer === null) return;
@@ -847,7 +958,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const retryPendingFallback = async () => {
     if (fallbackRetryInFlight) return;
-    if (closed || !turnRunning || state.pendingFallback.length === 0) {
+    if (closed || !turnIsRunning() || state.pendingFallback.length === 0) {
       stopFallbackRetry();
       return;
     }
@@ -878,7 +989,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
 
   const deferFallback = (text: string, enqueue: 'steer' | 'queue') => {
     state.pendingFallback.push({ text, enqueue });
-    fallbackRetryTimer ??= setInterval(() => void retryPendingFallback(), FALLBACK_RETRY_MS);
+    ensureFallbackRetry();
     requestRender();
   };
 
@@ -902,7 +1013,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         requestRender();
         return;
       }
-      if (turnRunning || busy) deferFallback(text, enqueue);
+      if (turnIsRunning() || busy) deferFallback(text, enqueue);
       else submitPrompt(text);
     } catch (error) {
       const draft = editor.getText();
@@ -926,14 +1037,14 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // Mirror Enter's control-busy guard BEFORE touching the editor: during a
     // control action (busy without a running turn) submitPrompt would drop the
     // prompt, so keep the draft in place instead of clearing it into the void.
-    if (busy && !turnRunning) return;
+    if (busy && !turnIsRunning()) return;
     // Interrupt convergence window: the turn is being stopped, so nothing may
     // be queued onto it and no fresh turn may open — keep the draft.
     if (interruptRequested) return;
     const text = editor.getExpandedText().trim();
     if (!text) return;
     editor.setText('');
-    if (!turnRunning) {
+    if (!turnIsRunning()) {
       submitPrompt(text);
       return;
     }
@@ -975,9 +1086,9 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   let wizardAttempt = 0;
 
   editor.onSubmit = (prompt) => {
-    if (turnRunning) {
+    if (turnIsRunning()) {
       // A quit/exit form typed while a turn is running must close the TUI, not
-      // steer it into the model as prompt text (review finding on turnRunning
+      // steer it into the model as prompt text (review finding on running-turn
       // input routing): check it before handing off to steering.
       if (isExitPrompt(prompt)) {
         beginGracefulClose();
@@ -1022,32 +1133,16 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // Runs one agent turn through the shared activity/drain lifecycle. Shared by
   // user submits, queued follow-ups, and coordinator-owned goal injections.
   function runAgentTurn(request: MakaPiTuiTurnRequest): Promise<GoalTurnOutcome> {
-    busy = true;
     const activity = beginActivity();
-    turnRunning = true;
-    turnStartedAt = Date.now();
-    startTurnElapsedTicker();
-    interruptRequested = false;
-    lastTurnEscapeAt = 0;
+    try {
+      beginTurnUi('local');
+    } catch (error) {
+      activity.finish();
+      throw error;
+    }
     // Re-enable submit after skill-prep's disableSubmit hold: Enter must steer
     // a running turn (see editor.onSubmit) instead of being swallowed.
     editor.disableSubmit = false;
-    terminal.setProgress(true);
-    attention.promptTurnStarted();
-    requestRender();
-
-    const finishTurnUi = () => {
-      turnRunning = false;
-      turnStartedAt = undefined;
-      stopTurnElapsedTicker();
-      interruptRequested = false;
-      editor.disableSubmit = false;
-      terminal.setProgress(false);
-      attention.promptTurnEnded();
-      // A turn ending is activity too — resets the idle clock the next
-      // submission's auto-recap check measures against.
-      lastActivityAt = Date.now();
-    };
 
     return runMakaPiTuiTurn({
       driver: input.driver,
@@ -1070,16 +1165,58 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       },
     }).then(
       async (outcome) => {
-        if (input.driver.reloadTranscript) {
+        finishTurnUi('local');
+        if (closed) {
+          activity.finish();
+          return outcome;
+        }
+        let postLocalCut: MakaSessionObservation['cut'] | undefined;
+        if (sessionObservation && turnOwner === undefined) {
+          const reloadSessionId = input.driver.getSessionId();
+          const reloadGeneration = turnUiGeneration;
+          const postLocalObservation = waitForObservationAfter(observationCut);
+          localTurnSettlementPending = true;
+          editor.disableSubmit = true;
           try {
-            replaceTranscriptWithStoredMessages(state, await input.driver.reloadTranscript());
-          } catch (error) {
-            reportError(error);
+            let reloadResult:
+              | { readonly kind: 'success'; readonly messages: readonly StoredMessage[] }
+              | { readonly kind: 'failure'; readonly error: unknown };
+            try {
+              reloadResult = {
+                kind: 'success',
+                messages: await sessionObservation.reloadTranscript(),
+              };
+            } catch (error) {
+              reloadResult = { kind: 'failure', error };
+            }
+            await postLocalObservation;
+            postLocalCut = latestObservationCut;
+            const current =
+              !closed &&
+              input.driver.getSessionId() === reloadSessionId &&
+              turnUiGeneration === reloadGeneration;
+            if (current) {
+              if (reloadResult.kind === 'success') {
+                replaceTranscriptWithStoredMessages(state, reloadResult.messages);
+              } else if (postLocalCut !== 'unavailable') reportError(reloadResult.error);
+            }
+          } finally {
+            localTurnSettlementPending = false;
+            if (turnOwner === undefined) editor.disableSubmit = false;
           }
         }
-        finishTurnUi();
         if (closed) {
-          busy = false;
+          activity.finish();
+          return outcome;
+        }
+        if (turnOwner === 'remote') {
+          ensureFallbackRetry();
+          activity.finish();
+          return outcome;
+        }
+        if (postLocalCut === 'unavailable') {
+          const fallbackText = takePendingFallback();
+          if (fallbackText) refillEditorFromQueues(fallbackText);
           activity.finish();
           return outcome;
         }
@@ -1114,16 +1251,12 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
           }
         }
 
-        busy = false;
         activity.finish();
-        requestRender();
         return outcome;
       },
       (error) => {
-        finishTurnUi();
-        busy = false;
+        finishTurnUi('local');
         activity.finish();
-        requestRender();
         throw error;
       },
     );
@@ -1256,6 +1389,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     thinkingLevel = summary.thinkingLevel;
     thinkingLevels = providerType ? thinkingVariantsForModel(providerType, summary.model) : [];
     refreshEditorCwd?.(cwd);
+    stopFallbackRetry();
+    state.pendingFallback = [];
     replaceTranscriptWithStoredMessages(state, messages);
     shellRunHydration.reset();
     if (input.listShellRunUpdates) {
@@ -1885,6 +2020,8 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // same welcome block as a cold start — the welcome block is the "fresh
     // session, send a prompt to begin" cue. A notice here would make entries
     // non-empty and suppress it.
+    stopFallbackRetry();
+    state.pendingFallback = [];
     replaceTranscriptWithStoredMessages(state, []);
     shellRunElapsedTicker.sync();
     requestRender();
@@ -1895,12 +2032,11 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
   // envelope. Mirrors submitPreparedUserPrompt: claim `busy` + an activity lease
   // SYNCHRONOUSLY before the async read so no other turn (a Goal auto-
   // continuation, or a user Enter) can start during it and make the import a
-  // silent no-op. runAgentTurn re-asserts busy for the turn; on any failure the
+  // silent no-op. runAgentTurn opens the turn activity; on any failure the
   // finally releases the lease. The handoff is the model-facing `sendText`; a
   // short line shows in the transcript.
   const importForeignSession = async (summary: ForeignSessionSummary): Promise<void> => {
     if (busy || input.foreignSessions === undefined) return;
-    busy = true;
     const activity = beginActivity();
     editor.disableSubmit = true;
     let handedOff = false;
@@ -1920,7 +2056,6 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       reportError(error);
     } finally {
       if (!handedOff) {
-        busy = false;
         editor.disableSubmit = false;
         requestRender();
       }
@@ -2600,7 +2735,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     if (isKeyRelease(data)) return undefined;
     if (
       activeUserQuestionRequest(state) &&
-      turnRunning &&
+      turnIsRunning() &&
       matchesKey(data, Key.ctrl('c')) &&
       !isKeyRepeat(data)
     ) {
@@ -2668,7 +2803,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
         return { consume: true };
       }
     }
-    if (turnRunning && matchesKey(data, Key.ctrl('c'))) {
+    if (turnIsRunning() && matchesKey(data, Key.ctrl('c'))) {
       if (interruptRequested) handleProcessExit(0);
       else requestTurnInterrupt();
       return { consume: true };
@@ -2676,7 +2811,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
     // Double Escape interrupts the running turn. This must sit below the
     // boundary branch so Escape keeps meaning "deny" while a prompt is
     // pending, and it only arms while a prompt turn is actually running.
-    if (turnRunning && matchesKey(data, Key.escape)) {
+    if (turnIsRunning() && matchesKey(data, Key.escape)) {
       // Once an interrupt is issued, swallow further Escapes until the turn
       // ends so a still-settling stop is not requested twice. A rejected stop
       // re-arms interruption so the user can retry within the same turn.
@@ -2691,13 +2826,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       return { consume: true };
     }
     // Idle double Escape opens the rewind picker (the same gesture that
-    // interrupts a running turn). This sits below the turnRunning branch, so it
+    // interrupts a running turn). This sits below the running-turn branch, so it
     // only arms when nothing is running. It engages only when the editor has no
     // Escape work of its own — empty draft, no autocomplete popup — so the
     // editor keeps owning Escape for clearing input and closing autocomplete.
     // The first Escape falls through to the editor; only the second, within the
     // window, consumes and opens the picker.
-    if (!busy && !turnRunning && matchesKey(data, Key.escape)) {
+    if (!busy && !turnIsRunning() && matchesKey(data, Key.escape)) {
       const editorNeutral = editor.getText().length === 0 && !editor.isShowingAutocomplete();
       if (!editorNeutral) {
         lastIdleEscapeAt = 0;
@@ -2712,13 +2847,13 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       lastIdleEscapeAt = now;
       return undefined;
     }
-    if (!turnRunning && matchesKey(data, Key.ctrl('c')) && editor.getText().length > 0) {
+    if (!turnIsRunning() && matchesKey(data, Key.ctrl('c')) && editor.getText().length > 0) {
       lastIdleCtrlCAt = 0;
       editor.setText('');
       requestRender();
       return { consume: true };
     }
-    if (!turnRunning && matchesKey(data, Key.ctrl('c'))) {
+    if (!turnIsRunning() && matchesKey(data, Key.ctrl('c'))) {
       const now = Date.now();
       if (lastIdleCtrlCAt && now - lastIdleCtrlCAt <= DOUBLE_CTRL_C_EXIT_WINDOW_MS) {
         lastIdleCtrlCAt = 0;
@@ -2731,7 +2866,7 @@ export async function runMakaPiTui(input: MakaPiTuiInput): Promise<void> {
       return { consume: true };
     }
     if (matchesKey(data, Key.ctrl('d'))) {
-      if (busy || turnRunning) return { consume: true };
+      if (busy || turnIsRunning()) return { consume: true };
       if (editor.getText().length === 0) {
         beginGracefulClose();
         return { consume: true };
@@ -2909,3 +3044,19 @@ function isExitPrompt(prompt: string): boolean {
 // Two Escapes this close together read as one deliberate "stop the turn".
 const DOUBLE_ESCAPE_INTERRUPT_WINDOW_MS = 600;
 const DOUBLE_CTRL_C_EXIT_WINDOW_MS = 1_000;
+const CLOSE_DRIVER_DRAIN_TIMEOUT_MS = 5_000;
+
+async function waitForCloseDrain(task: Promise<void> | undefined): Promise<void> {
+  if (!task) return;
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    await Promise.race([
+      task.catch(() => {}),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, CLOSE_DRIVER_DRAIN_TIMEOUT_MS);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}

--- a/packages/cli/src/pi-tui-turn.ts
+++ b/packages/cli/src/pi-tui-turn.ts
@@ -8,7 +8,11 @@ import {
   type SessionActivityLease,
   type SessionActivityRegistry,
 } from '@maka/runtime';
-import type { MakaSessionDriver } from './session-driver.js';
+import type {
+  MakaSessionDriver,
+  MakaSessionDriverAuxiliaryEvent,
+  MakaSessionDriverEvent,
+} from './session-driver.js';
 
 export interface MakaPiTuiTurnLifecycle {
   activities: SessionActivityRegistry;
@@ -39,7 +43,7 @@ export interface RunMakaPiTuiTurnInput {
   request: MakaPiTuiTurnRequest;
   shouldAbort: () => boolean;
   onStart?: () => void;
-  onEvent?: (event: SessionEvent) => void | Promise<void>;
+  onEvent?: (event: MakaSessionDriverEvent) => void | Promise<void>;
   onFailure?: (error: unknown) => void | Promise<void>;
 }
 
@@ -106,7 +110,7 @@ export async function runMakaPiTuiTurn(input: RunMakaPiTuiTurnInput): Promise<Go
     let sawTerminalEvent = false;
     let failureProjected = false;
     const outcome = await drainGoalTurn({
-      events: turn.events,
+      events: projectDriverEvents(turn.events, input.onEvent),
       turnId: turn.turnId,
       activity,
       onEvent: async (event) => {
@@ -144,6 +148,28 @@ export async function runMakaPiTuiTurn(input: RunMakaPiTuiTurnInput): Promise<Go
       reason: errorMessage(reportedError),
     });
   }
+}
+
+async function* projectDriverEvents(
+  events: AsyncIterable<MakaSessionDriverEvent>,
+  onEvent: RunMakaPiTuiTurnInput['onEvent'],
+): AsyncIterable<SessionEvent> {
+  for await (const event of events) {
+    if (isDriverAuxiliaryEvent(event)) {
+      await onEvent?.(event);
+      continue;
+    }
+    yield event;
+  }
+}
+
+function isDriverAuxiliaryEvent(
+  event: MakaSessionDriverEvent,
+): event is MakaSessionDriverAuxiliaryEvent {
+  return (
+    event.type === 'host_interaction_permission_request' ||
+    event.type === 'host_interaction_resolved'
+  );
 }
 
 function abortedOutcome(turnId: string | undefined): GoalTurnOutcome {

--- a/packages/cli/src/runtime-host-tui-harness.ts
+++ b/packages/cli/src/runtime-host-tui-harness.ts
@@ -170,7 +170,7 @@ async function resolveHarnessTarget(
 function createHarnessGoalLifecycle(): MakaPiTuiGoalLifecycle {
   return {
     activities: new SessionActivityRegistry(),
-    beginExternalTurn: () => ({ kind: 'registered', settle: async () => {} }),
+    beginObservedTurn: () => ({ kind: 'registered', settle: async () => {} }),
     bindHost: () => () => {},
   };
 }

--- a/packages/cli/src/runtime-host-tui-harness.ts
+++ b/packages/cli/src/runtime-host-tui-harness.ts
@@ -1,0 +1,245 @@
+#!/usr/bin/env node
+
+import { realpathSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import type { PermissionMode } from '@maka/core/permission';
+import type { ProviderType } from '@maka/core/llm-connections';
+import { SessionActivityRegistry } from '@maka/runtime';
+import {
+  connectOrSpawnExecutionRuntimeHostHarness,
+  type RuntimeHostConnection,
+} from '@maka/runtime-host/client';
+import {
+  RUNTIME_HOST_PROTOCOL_VERSION,
+  type ConnectionCatalogHeaderItem,
+  type ConnectionCatalogQueryResult,
+} from '@maka/runtime-host/protocol';
+import { createHostMakaSessionDriver } from './host-session-driver.js';
+import { runMakaPiTui, type MakaPiTuiGoalLifecycle } from './pi-tui-runner.js';
+
+interface HarnessOptions {
+  readonly rootPath: string;
+  readonly cwd: string;
+  readonly connectionSlug?: string;
+  readonly model?: string;
+  readonly resumeSessionId?: string;
+  readonly permissionMode: PermissionMode;
+}
+
+interface HarnessTarget {
+  readonly connectionSlug: string;
+  readonly model: string;
+  readonly providerType?: ProviderType;
+}
+
+export async function runRuntimeHostTuiHarness(
+  argv: readonly string[] = process.argv.slice(2),
+): Promise<void> {
+  const options = parseHarnessOptions(argv);
+  const connected = await connectOrSpawnExecutionRuntimeHostHarness({
+    rootPath: options.rootPath,
+    surface: 'tui',
+    protocol: {
+      min: RUNTIME_HOST_PROTOCOL_VERSION,
+      max: RUNTIME_HOST_PROTOCOL_VERSION,
+    },
+  });
+  if (connected.kind !== 'connected') {
+    throw new Error(`Unable to connect to the isolated Runtime Host: ${connected.kind}`);
+  }
+  const { connection } = connected;
+  try {
+    await waitForRuntimeHostReady(connection);
+    const target = await resolveHarnessTarget(connection, options);
+    const driver = createHostMakaSessionDriver({
+      connection,
+      cwd: options.cwd,
+      llmConnectionSlug: target.connectionSlug,
+      model: target.model,
+      permissionMode: options.permissionMode,
+    });
+    await runMakaPiTui({
+      driver,
+      title: 'Maka Runtime Host Harness',
+      cwd: options.cwd,
+      model: target.model,
+      connectionSlug: target.connectionSlug,
+      providerType: target.providerType,
+      permissionMode: options.permissionMode,
+      goalLifecycle: createHarnessGoalLifecycle(),
+      ...(options.resumeSessionId === undefined
+        ? {}
+        : { resumeSessionId: options.resumeSessionId }),
+    });
+  } finally {
+    await connection.close();
+  }
+}
+
+async function waitForRuntimeHostReady(connection: RuntimeHostConnection): Promise<void> {
+  const deadline = Date.now() + 45_000;
+  while (true) {
+    const status = await connection.status(5_000);
+    if (status.state === 'ready') return;
+    if (status.state === 'draining') {
+      throw new Error('The isolated Runtime Host began draining before it became ready');
+    }
+    if (Date.now() >= deadline) {
+      throw new Error('Timed out waiting for the isolated Runtime Host to become ready');
+    }
+    await new Promise((resolve) => setTimeout(resolve, 25));
+  }
+}
+
+async function resolveHarnessTarget(
+  connection: RuntimeHostConnection,
+  options: HarnessOptions,
+): Promise<HarnessTarget> {
+  if (options.resumeSessionId) {
+    const result = await connection.request('session.catalog.query', {
+      kind: 'get',
+      sessionId: options.resumeSessionId,
+    });
+    if (result.kind !== 'session' || result.session === null || 'kind' in result.session) {
+      throw new Error(`Resume Session is unavailable: ${options.resumeSessionId}`);
+    }
+    return {
+      connectionSlug: result.session.llmConnectionSlug,
+      model: result.session.model,
+    };
+  }
+  if (options.connectionSlug && options.model) {
+    return {
+      connectionSlug: options.connectionSlug,
+      model: options.model,
+    };
+  }
+  if (options.connectionSlug || options.model) {
+    throw new Error('--connection and --model must be provided together');
+  }
+
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    const initial = await connection.request('connection.catalog.query', { kind: 'start' });
+    if (initial.kind !== 'page') {
+      throw new Error('Runtime Host returned an invalid Connection catalog start');
+    }
+    const revision = initial.revision;
+    const defaultTarget = initial.defaultTarget;
+    if (!defaultTarget) {
+      throw new Error('The isolated Runtime Host root has no default model target');
+    }
+    const headers = new Map<number, ConnectionCatalogHeaderItem>();
+    let page: Extract<ConnectionCatalogQueryResult, { kind: 'page' }> = initial;
+    let restart = false;
+    while (true) {
+      for (const item of page.items) {
+        if (item.kind === 'connection') headers.set(item.connectionIndex, item);
+      }
+      const target = [...headers.values()].find(
+        (header) => header.connectionId === defaultTarget.connectionId,
+      );
+      if (target) {
+        return {
+          connectionSlug: target.slug,
+          model: defaultTarget.modelId,
+          providerType: target.providerType,
+        };
+      }
+      if (page.nextCursor === null) {
+        throw new Error('Default Runtime Host connection is absent from its catalog');
+      }
+      const continuation: ConnectionCatalogQueryResult = await connection.request(
+        'connection.catalog.query',
+        {
+          kind: 'continue',
+          revision,
+          cursor: page.nextCursor,
+        },
+      );
+      if (continuation.kind === 'revision_changed') {
+        restart = true;
+        break;
+      }
+      page = continuation;
+    }
+    if (!restart) break;
+  }
+  throw new Error('Connection catalog kept changing while it was read');
+}
+
+function createHarnessGoalLifecycle(): MakaPiTuiGoalLifecycle {
+  return {
+    activities: new SessionActivityRegistry(),
+    beginExternalTurn: () => ({ kind: 'registered', settle: async () => {} }),
+    bindHost: () => () => {},
+  };
+}
+
+function parseHarnessOptions(argv: readonly string[]): HarnessOptions {
+  let rootPath: string | undefined;
+  let cwd = process.cwd();
+  let connectionSlug: string | undefined;
+  let model: string | undefined;
+  let resumeSessionId: string | undefined;
+  let permissionMode: PermissionMode = 'ask';
+  for (let index = 0; index < argv.length; index += 1) {
+    const key = argv[index];
+    const value = argv[index + 1];
+    if (
+      key !== '--root' &&
+      key !== '--cwd' &&
+      key !== '--connection' &&
+      key !== '--model' &&
+      key !== '--resume' &&
+      key !== '--permission'
+    ) {
+      throw new Error(`Unknown Runtime Host TUI harness option: ${key ?? ''}`);
+    }
+    if (!value || value.startsWith('--')) throw new Error(`${key} requires a value`);
+    index += 1;
+    if (key === '--root') rootPath = value;
+    else if (key === '--cwd') cwd = value;
+    else if (key === '--connection') connectionSlug = value;
+    else if (key === '--model') model = value;
+    else if (key === '--resume') resumeSessionId = value;
+    else permissionMode = requirePermissionMode(value);
+  }
+  if (!rootPath) {
+    throw new Error(
+      'Runtime Host TUI harness requires --root <isolated-root>; it never targets the production CLI root implicitly',
+    );
+  }
+  return {
+    rootPath,
+    cwd,
+    ...(connectionSlug === undefined ? {} : { connectionSlug }),
+    ...(model === undefined ? {} : { model }),
+    ...(resumeSessionId === undefined ? {} : { resumeSessionId }),
+    permissionMode,
+  };
+}
+
+function requirePermissionMode(value: string): PermissionMode {
+  if (value === 'ask' || value === 'execute' || value === 'explore' || value === 'bypass') {
+    return value;
+  }
+  throw new Error(`Invalid --permission mode: ${value}`);
+}
+
+function isMainModule(): boolean {
+  if (!process.argv[1]) return false;
+  try {
+    return realpathSync(process.argv[1]) === realpathSync(fileURLToPath(import.meta.url));
+  } catch {
+    return false;
+  }
+}
+
+if (isMainModule()) {
+  runRuntimeHostTuiHarness().catch((error: unknown) => {
+    process.stderr.write(
+      `${error instanceof Error ? (error.stack ?? error.message) : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });
+}

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -10,6 +10,10 @@ import type { ExecutionBoundary, SandboxBoundaryResponse } from '@maka/core/sand
 import { executionBoundaryDisplayMode } from '@maka/core/sandbox-boundary';
 import type { UserQuestionResponse } from '@maka/core/user-question';
 import type {
+  InteractionPermissionAnswer,
+  InteractionPermissionPrompt,
+} from '@maka/core/interaction';
+import type {
   BranchFromTurnInput,
   CreateSessionInput,
   TurnOrchestration,
@@ -110,8 +114,48 @@ export interface MakaSessionSwitchResult {
 export interface MakaPreparedSessionTurn {
   sessionId: string;
   turnId: string;
-  events: AsyncIterable<SessionEvent>;
+  events: AsyncIterable<MakaSessionDriverEvent>;
 }
+
+/**
+ * A bounded permission projection owned by a remote Runtime Host. It stays
+ * local to the CLI adapter because embedded runtimes never emit this event.
+ */
+export interface HostInteractionPermissionRequestEvent {
+  readonly type: 'host_interaction_permission_request';
+  readonly id: string;
+  readonly turnId: string;
+  readonly ts: number;
+  readonly requestId: string;
+  readonly toolUseId: string;
+  readonly prompt: InteractionPermissionPrompt;
+}
+
+/** A previously projected Host Interaction left the canonical pending set. */
+export interface HostInteractionResolvedEvent {
+  readonly type: 'host_interaction_resolved';
+  readonly id: string;
+  readonly turnId: string;
+  readonly ts: number;
+  readonly requestId: string;
+}
+
+export type MakaSessionDriverAuxiliaryEvent =
+  | HostInteractionPermissionRequestEvent
+  | HostInteractionResolvedEvent;
+
+export type MakaSessionDriverEvent = SessionEvent | MakaSessionDriverAuxiliaryEvent;
+
+export interface MakaSessionObservation {
+  readonly sessionId: string;
+  readonly events: readonly MakaSessionDriverEvent[];
+  readonly reloadTranscript: boolean;
+  readonly activeTurn: boolean;
+}
+
+export type MakaSessionObservationListener = (
+  observation: MakaSessionObservation,
+) => void | Promise<void>;
 
 export interface MakaPreparePromptOptions {
   /** Caller-owned identity used when Goal admission reserves a turn synchronously. */
@@ -141,14 +185,22 @@ export interface MakaSessionDriver {
    * should open a fresh turn with the text instead so it is never dropped.
    * Optional so existing driver stubs need not implement the steering surface.
    */
-  steer?(text: string): QueueEnqueueOutcome;
+  steer?(text: string): QueueEnqueueOutcome | Promise<QueueEnqueueOutcome>;
   /** Queue the text to open the turn after the current one finishes. */
-  queueMessage?(text: string): QueueEnqueueOutcome;
+  queueMessage?(text: string): QueueEnqueueOutcome | Promise<QueueEnqueueOutcome>;
   /** Drain the followup queue into one `\n\n`-joined prompt, or null if empty. */
   takePendingFollowup?(): string | null;
   /** Take back every queued message as one `\n\n`-joined string (clears both queues). */
-  retractQueued?(): string;
+  retractQueued?(): string | Promise<string>;
+  /**
+   * Atomically retract queued messages and stop the active turn. Host-backed
+   * drivers use this to avoid a retract/stop race across the wire.
+   */
+  interrupt?(): Promise<string>;
   respondToSandboxBoundary(response: SandboxBoundaryResponse): Promise<void>;
+  respondToPermission?(
+    response: InteractionPermissionAnswer & { readonly requestId: string },
+  ): Promise<void>;
   respondToUserQuestion?(response: UserQuestionResponse): Promise<void>;
   /**
    * Switch the active session's model, optionally rebinding it to another
@@ -163,6 +215,17 @@ export interface MakaSessionDriver {
   renameSession(name: string): Promise<string | void>;
   moveSession?(cwd: string): Promise<MakaSessionMoveResult>;
   switchSession(sessionId: string): Promise<MakaSessionSwitchResult>;
+  /**
+   * Reload the active Session from its durable authority after a live turn.
+   * Host-backed drivers use this to replace bounded live projections with the
+   * complete transcript at the turn boundary.
+   */
+  reloadTranscript?(): Promise<StoredMessage[]>;
+  /**
+   * Observe turns owned by another client while this driver is idle. Host-backed
+   * drivers use this to keep multiple TUI clients on one Session converged.
+   */
+  subscribeSessionObservations?(listener: MakaSessionObservationListener): () => void;
   /** Every prompted turn the user can rewind to, newest first. */
   listRewindTargets(): Promise<RewindTarget[]>;
   /**

--- a/packages/cli/src/session-driver.ts
+++ b/packages/cli/src/session-driver.ts
@@ -150,12 +150,18 @@ export interface MakaSessionObservation {
   readonly sessionId: string;
   readonly events: readonly MakaSessionDriverEvent[];
   readonly reloadTranscript: boolean;
-  readonly activeTurn: boolean;
+  /** The authoritative Session state at this observation cut. */
+  readonly cut: 'active' | 'idle' | 'unavailable';
 }
 
 export type MakaSessionObservationListener = (
   observation: MakaSessionObservation,
 ) => void | Promise<void>;
+
+export interface MakaSessionObservationCapability {
+  reloadTranscript(): Promise<StoredMessage[]>;
+  subscribe(listener: MakaSessionObservationListener): () => void;
+}
 
 export interface MakaPreparePromptOptions {
   /** Caller-owned identity used when Goal admission reserves a turn synchronously. */
@@ -216,16 +222,11 @@ export interface MakaSessionDriver {
   moveSession?(cwd: string): Promise<MakaSessionMoveResult>;
   switchSession(sessionId: string): Promise<MakaSessionSwitchResult>;
   /**
-   * Reload the active Session from its durable authority after a live turn.
-   * Host-backed drivers use this to replace bounded live projections with the
-   * complete transcript at the turn boundary.
+   * Observe turns owned by another client and reload their durable boundaries.
+   * The paired methods prevent a live projection from being exposed without
+   * its authoritative convergence path.
    */
-  reloadTranscript?(): Promise<StoredMessage[]>;
-  /**
-   * Observe turns owned by another client while this driver is idle. Host-backed
-   * drivers use this to keep multiple TUI clients on one Session converged.
-   */
-  subscribeSessionObservations?(listener: MakaSessionObservationListener): () => void;
+  readonly sessionObservation?: MakaSessionObservationCapability;
   /** Every prompted turn the user can rewind to, newest first. */
   listRewindTargets(): Promise<RewindTarget[]>;
   /**

--- a/packages/cli/src/tui-attention.ts
+++ b/packages/cli/src/tui-attention.ts
@@ -76,7 +76,8 @@ export class AttentionController {
   // reports focus (no 1004 support) is treated as always-watching and stays
   // silent, rather than ringing on every turn.
   private focused = true;
-  private busy = false;
+  private promptTurnActive = false;
+  private activeControls = 0;
   // Latched when something the user has not yet acknowledged is waiting; drives
   // the attention title marker until they engage (focus, answer, or a new turn).
   private attention = false;
@@ -127,7 +128,7 @@ export class AttentionController {
     if (this.stopped) return;
     this.turnStartedAt = this.now();
     this.attention = false;
-    this.busy = true;
+    this.promptTurnActive = true;
     this.refreshTitle();
   }
 
@@ -139,7 +140,7 @@ export class AttentionController {
    */
   promptTurnEnded(): void {
     if (this.stopped) return;
-    this.busy = false;
+    this.promptTurnActive = false;
     if (this.now() - this.turnStartedAt >= this.longTurnThresholdMs) {
       this.raiseAttention();
     } else {
@@ -151,14 +152,14 @@ export class AttentionController {
   controlStarted(): void {
     if (this.stopped) return;
     this.attention = false;
-    this.busy = true;
+    this.activeControls += 1;
     this.refreshTitle();
   }
 
   /** A control action ended. */
   controlEnded(): void {
     if (this.stopped) return;
-    this.busy = false;
+    this.activeControls = Math.max(0, this.activeControls - 1);
     this.refreshTitle();
   }
 
@@ -183,7 +184,8 @@ export class AttentionController {
    */
   reset(): void {
     this.stopped = true;
-    this.busy = false;
+    this.promptTurnActive = false;
+    this.activeControls = 0;
     this.attention = false;
     this.refreshTitle();
   }
@@ -219,7 +221,7 @@ export class AttentionController {
     // is only ever set while unfocused, so a normal running turn still shows busy.
     const title = this.attention
       ? `${ATTENTION_TITLE_MARKER}${this.baseTitle}`
-      : this.busy
+      : this.isBusy()
         ? `${this.busySpinnerFrames[this.spinnerFrame] ?? ''} ${this.baseTitle}`
         : this.baseTitle;
     // Only write on a real change so the title stream stays quiet between turns
@@ -234,7 +236,7 @@ export class AttentionController {
   // currently shown (busy, not overridden by attention, session still live).
   private syncSpinner(): void {
     const shouldRun =
-      this.busy && !this.attention && !this.stopped && this.busySpinnerFrames.length > 0;
+      this.isBusy() && !this.attention && !this.stopped && this.busySpinnerFrames.length > 0;
     if (shouldRun && !this.cancelSpinner) {
       this.cancelSpinner = this.scheduleSpinnerInterval(() => {
         this.spinnerFrame = (this.spinnerFrame + 1) % this.busySpinnerFrames.length;
@@ -246,5 +248,9 @@ export class AttentionController {
       // Reset so the next busy episode opens on the first frame, not mid-cycle.
       this.spinnerFrame = 0;
     }
+  }
+
+  private isBusy(): boolean {
+    return this.promptTurnActive || this.activeControls > 0;
   }
 }

--- a/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
+++ b/packages/runtime-host/src/__tests__/dependency-boundary.test.ts
@@ -42,6 +42,7 @@ const allowedServerExternalImports = new Set([
   '@maka/core/runtime-policy',
   '@maka/core/runtime-event',
   '@maka/core/runtime-inputs',
+  '@maka/core/sandbox-boundary',
   '@maka/core/session',
   '@maka/core/session-name',
   '@maka/core/shell-run',
@@ -126,6 +127,7 @@ test('protocol and client stay within their subpaths and the root-authority boun
       const topLevelArea = localPath.split(sep)[0];
       if (
         localPath === 'candidate-main.ts' ||
+        localPath === 'execution-candidate-main.ts' ||
         topLevelArea === 'server' ||
         (area === 'protocol' && topLevelArea !== 'protocol')
       ) {
@@ -176,6 +178,7 @@ test('the production Candidate dependency graph remains non-serving', () => {
   const publicEntrypoints = new Map<string, string>();
   const reached = reachableModules(join(sourceRoot, 'candidate-main.ts'), publicEntrypoints);
   const forbiddenLocalModules = new Set([
+    'execution-candidate-main.ts',
     'server/execution-candidate.ts',
     'server/execution-composition.ts',
     'server/root-turn-coordinator.ts',

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -793,6 +793,59 @@ test('subscribed Clients share one canonical queue and ordered root handoff', as
   });
 });
 
+test('a Client joining an active Turn receives prior live output before future deltas', async () => {
+  await withExecutionRoot(async (fixture) => {
+    const host = await fixture.startHost();
+    const origin = await connectClient(fixture.root, 'tui');
+    const originSubscription = await origin.openSessionSubscription({
+      sessionId: fixture.sessionId,
+    });
+    const originProbe = new SubscriptionProbe(originSubscription);
+    const turnId = randomUUID();
+    const started = await origin.startTurn({
+      sessionId: fixture.sessionId,
+      turnId,
+      content: { text: `late join ${'x'.repeat(540)}` },
+    });
+    const first = await originProbe.waitFor(
+      (frame) => frame.kind === 'subscription.session_delta' && frame.delta.turnId === turnId,
+      'origin Client did not receive the first live delta',
+    );
+    assert.equal(first.kind, 'subscription.session_delta');
+    if (first.kind !== 'subscription.session_delta') return;
+
+    const late = await connectClient(fixture.root, 'tui');
+    const lateSubscription = await late.openSessionSubscription({
+      sessionId: fixture.sessionId,
+    });
+    assert.equal(lateSubscription.snapshot.rootTurn?.turnId, turnId);
+    assert.equal(lateSubscription.snapshot.rootTurn?.runId, started.runId);
+    const lateProbe = new SubscriptionProbe(lateSubscription);
+    const catchUp = await lateProbe.waitFor(
+      (frame) => frame.kind === 'subscription.session_delta' && frame.delta.turnId === turnId,
+      'late Client did not receive live Turn catch-up',
+    );
+    assert.equal(catchUp.kind, 'subscription.session_delta');
+    if (catchUp.kind !== 'subscription.session_delta') return;
+    assert.ok(catchUp.delta.text.startsWith(first.delta.text));
+
+    await lateProbe.waitFor(
+      (frame) =>
+        frame.kind === 'subscription.session_projection' &&
+        frame.snapshot.rootTurn?.turnId === turnId &&
+        frame.snapshot.rootTurn.status === 'completed',
+      'late Client did not receive the terminal Turn projection',
+    );
+    await lateSubscription.close();
+    await lateProbe.done;
+    await late.close();
+    await originSubscription.close();
+    await originProbe.done;
+    await origin.close();
+    await fixture.stopHost(host);
+  });
+});
+
 test('concurrent root admission for one Session has a single winner', async () => {
   await withExecutionRoot(async (fixture) => {
     const host = await fixture.startHost();

--- a/packages/runtime-host/src/__tests__/live-assistant-replay-buffer.test.ts
+++ b/packages/runtime-host/src/__tests__/live-assistant-replay-buffer.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { LiveAssistantReplayBuffer } from '../server/live-assistant-replay-buffer.js';
+
+test('live assistant replay coalesces tiny deltas while retaining a bounded tail', () => {
+  const buffer = new LiveAssistantReplayBuffer({
+    maxRawBytes: 64,
+    maxWireBytes: 80,
+    maxChunkRawBytes: 8,
+    maxChunkWireBytes: 10,
+  });
+
+  for (let index = 0; index < 1_000; index += 1) buffer.append('x');
+
+  assert.equal(buffer.value(), 'x'.repeat(64));
+  assert.ok(buffer.retainedChunkCount <= 8);
+});
+
+test('live assistant replay trims escaped Unicode text at code-point boundaries', () => {
+  const buffer = new LiveAssistantReplayBuffer({
+    maxRawBytes: 8,
+    maxWireBytes: 9,
+    maxChunkRawBytes: 8,
+    maxChunkWireBytes: 9,
+  });
+
+  buffer.append('prefix\n🙂x');
+
+  assert.equal(buffer.value(), 'ix\n🙂x');
+  assert.equal(Buffer.byteLength(buffer.value(), 'utf8'), 8);
+  assert.equal(buffer.wireBytes, 9);
+});

--- a/packages/runtime-host/src/__tests__/protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/protocol.test.ts
@@ -92,6 +92,7 @@ describe('Runtime Host bootstrap protocol', () => {
       'session.read_marker.set',
       'session.remove',
       'session.revision.create',
+      'session.transcript.query',
       'skill.catalog.mutate',
       'skill.catalog.preview-update',
       'skill.catalog.query',

--- a/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/session-catalog-two-client-uds.test.ts
@@ -1,4 +1,5 @@
 import assert from 'node:assert/strict';
+import { decodeStoredMessageForRead } from '@maka/core/session';
 import { fork, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
 import { readdir, mkdtemp, rm } from 'node:fs/promises';
@@ -344,6 +345,21 @@ test('two UDS Clients share stable Session creation, CAS configuration, and cata
       const readFromTui = await querySession(tui, unreadSessionId);
       assert.equal(readFromTui.hasUnread, false);
       assert.equal(readFromTui.lastReadMessageId, 'message-2');
+      const transcript = await tui.readSessionTranscript(unreadSessionId);
+      const transcriptMessages = transcript.messages.map((message) =>
+        decodeStoredMessageForRead(message),
+      );
+      assert.equal(transcript.revision, readFromTui.revision);
+      assert.deepEqual(transcript.boundary, {
+        kind: 'managed',
+        revision: 0,
+        displayMode: 'ask',
+      });
+      assert.equal(transcriptMessages.length, 3);
+      assert.equal(
+        transcriptMessages[0]?.type === 'user' ? transcriptMessages[0].text.length : 0,
+        72 * 1024,
+      );
 
       const bulk = (
         await Promise.all(
@@ -693,7 +709,13 @@ async function seedAuthority(
       permissionMode: 'ask',
     });
     await execution.sessionStore.appendMessages(unread.id, [
-      { type: 'user', id: 'message-1', turnId: 'turn-1', ts: 1, text: 'one' },
+      {
+        type: 'user',
+        id: 'message-1',
+        turnId: 'turn-1',
+        ts: 1,
+        text: 'x'.repeat(72 * 1024),
+      },
       {
         type: 'assistant',
         id: 'message-2',

--- a/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-continuity-coordinator.test.ts
@@ -62,6 +62,109 @@ test('open is an inactive publication barrier and live sequence starts at nextSe
   coordinator.close();
 });
 
+test('a late subscriber replays the active Turn before newer live frames', async () => {
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+  );
+  const originConnection = coordinator.attachConnection('connection-origin', new RecordingSink());
+  const origin = await open(coordinator, 'connection-origin');
+  originConnection.activate(origin.subscriptionId);
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(1));
+  originConnection.abort(origin.subscriptionId);
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(2));
+
+  const lateSink = new RecordingSink();
+  const lateConnection = coordinator.attachConnection('connection-late', lateSink);
+  const late = await open(coordinator, 'connection-late');
+  assert.equal(late.nextSequence, 1);
+  assert.equal(lateSink.frames.length, 0);
+
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(3));
+  lateConnection.activate(late.subscriptionId);
+  await waitFor(() => lateSink.frames.length === 2);
+
+  assert.deepEqual(
+    lateSink.frames.map((frame) => frame.sequence),
+    [1, 2],
+  );
+  assert.deepEqual(
+    lateSink.frames.map((frame) =>
+      frame.kind === 'subscription.session_delta' ? frame.delta.text : undefined,
+    ),
+    ['chunk-1chunk-2', 'chunk-3'],
+  );
+  coordinator.close();
+});
+
+test('live Turn replay stays bounded without evicting a late subscriber', async () => {
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+  );
+  const originConnection = coordinator.attachConnection('connection-origin', new RecordingSink());
+  const origin = await open(coordinator, 'connection-origin');
+  originConnection.abort(origin.subscriptionId);
+  for (let index = 1; index <= 20; index += 1) {
+    await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', {
+      ...textEvent(index),
+      text: `${index}:${'x'.repeat(8 * 1024)}:END-${index}`,
+    });
+  }
+
+  const lateSink = new RecordingSink();
+  const lateConnection = coordinator.attachConnection('connection-late', lateSink);
+  const late = await open(coordinator, 'connection-late');
+  lateConnection.activate(late.subscriptionId);
+  await waitFor(() =>
+    lateSink.frames
+      .map((frame) => (frame.kind === 'subscription.session_delta' ? frame.delta.text : ''))
+      .join('')
+      .endsWith('END-20'),
+  );
+
+  assert.ok(lateSink.frames.every((frame) => frame.kind === 'subscription.session_delta'));
+  const replayed = lateSink.frames
+    .map((frame) => (frame.kind === 'subscription.session_delta' ? frame.delta.text : ''))
+    .join('');
+  assert.ok(Buffer.byteLength(replayed, 'utf8') <= 64 * 1024);
+  assert.ok(replayed.endsWith('END-20'));
+  coordinator.close();
+});
+
+test('live Turn replay accounts for JSON wire expansion', async () => {
+  const coordinator = new SessionContinuityCoordinator(
+    HOST_EPOCH,
+    async () => canonical(),
+    new SessionAdmissionGate(),
+  );
+  const originConnection = coordinator.attachConnection('connection-origin', new RecordingSink());
+  const origin = await open(coordinator, 'connection-origin');
+  originConnection.abort(origin.subscriptionId);
+  for (let index = 1; index <= 20; index += 1) {
+    await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', {
+      ...textEvent(index),
+      text: `${'\u0000'.repeat(8 * 1024)}:END-${index}`,
+    });
+  }
+
+  const lateSink = new RecordingSink();
+  const lateConnection = coordinator.attachConnection('connection-late', lateSink);
+  const late = await open(coordinator, 'connection-late');
+  lateConnection.activate(late.subscriptionId);
+  await waitFor(() =>
+    lateSink.frames
+      .map((frame) => (frame.kind === 'subscription.session_delta' ? frame.delta.text : ''))
+      .join('')
+      .endsWith('END-20'),
+  );
+
+  assert.ok(lateSink.frames.every((frame) => frame.kind === 'subscription.session_delta'));
+  coordinator.close();
+});
+
 test('open snapshot includes pending Interactions from the canonical projection', async () => {
   const pending = pendingInteraction();
   const coordinator = new SessionContinuityCoordinator(
@@ -91,6 +194,9 @@ test('terminal fence suppresses ordinary refresh until the exact terminal cut pu
   const connection = coordinator.attachConnection('connection-1', sink);
   const opened = await open(coordinator, 'connection-1');
   connection.activate(opened.subscriptionId);
+  await coordinator.acceptRuntimeEvent(SESSION_ID, 'run-1', textEvent(1));
+  await waitFor(() => sink.frames.length === 1);
+  sink.frames.length = 0;
 
   await coordinator.holdTerminalPublication(SESSION_ID, 'turn-1', 'run-1');
   projection = canonical({
@@ -111,10 +217,17 @@ test('terminal fence suppresses ordinary refresh until the exact terminal cut pu
   const frame = sink.frames[0];
   assert.equal(frame?.kind, 'subscription.session_projection');
   if (frame?.kind === 'subscription.session_projection') {
-    assert.equal(frame.sequence, 1);
+    assert.equal(frame.sequence, 2);
     assert.equal(frame.snapshot.projectionRevision, 2);
     assert.equal(frame.snapshot.rootTurn?.status, 'completed');
   }
+  const lateSink = new RecordingSink();
+  const lateConnection = coordinator.attachConnection('connection-late', lateSink);
+  const late = await open(coordinator, 'connection-late');
+  lateConnection.activate(late.subscriptionId);
+  await delayImmediate();
+  assert.equal(late.snapshot.rootTurn?.status, 'completed');
+  assert.equal(lateSink.frames.length, 0);
   coordinator.close();
 });
 

--- a/packages/runtime-host/src/__tests__/session-transcript-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-transcript-coordinator.test.ts
@@ -1,0 +1,70 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { createReadOnlyPermissionProfile } from '@maka/core';
+import { HostSessionTranscriptCoordinator } from '../server/session-transcript-coordinator.js';
+import { SessionAdmissionGate } from '../server/session-admission-gate.js';
+
+test('Session transcript continuation detects an execution-boundary-only change', async () => {
+  let boundaryRevision = 0;
+  const coordinator = new HostSessionTranscriptCoordinator({
+    store: {
+      async readHeaderRecordSnapshot() {
+        return {
+          revision: 1,
+          committedAt: 1,
+          header: {} as never,
+        };
+      },
+      async readMessagesSnapshot() {
+        return [
+          {
+            type: 'user' as const,
+            id: 'message-1',
+            turnId: 'turn-1',
+            ts: 1,
+            text: 'hello',
+          },
+        ];
+      },
+      async readExecutionBoundary() {
+        return {
+          kind: 'managed' as const,
+          profile: createReadOnlyPermissionProfile(),
+          revision: boundaryRevision,
+        };
+      },
+    },
+    admission: new SessionAdmissionGate(),
+  });
+
+  const initial = await coordinator.handlers['session.transcript.query'](
+    { kind: 'start', sessionId: 'session-1' },
+    {} as never,
+  );
+  assert.equal(initial.ok, true);
+  if (!initial.ok || initial.result.kind !== 'chunk') return;
+  assert.equal(initial.result.boundary.revision, 0);
+
+  boundaryRevision = 1;
+  const continuation = await coordinator.handlers['session.transcript.query'](
+    {
+      kind: 'continue',
+      sessionId: 'session-1',
+      revision: initial.result.revision,
+      boundaryRevision: initial.result.boundary.revision,
+      messageIndex: 0,
+      byteOffset: 1,
+    },
+    {} as never,
+  );
+  assert.deepEqual(continuation, {
+    ok: true,
+    result: {
+      kind: 'revision_changed',
+      expectedRevision: 1,
+      actualRevision: 1,
+      expectedBoundaryRevision: 0,
+      actualBoundaryRevision: 1,
+    },
+  });
+});

--- a/packages/runtime-host/src/__tests__/session-transcript-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/session-transcript-coordinator.test.ts
@@ -1,7 +1,11 @@
 import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import { createReadOnlyPermissionProfile } from '@maka/core';
-import { HostSessionTranscriptCoordinator } from '../server/session-transcript-coordinator.js';
+import { SESSION_TRANSCRIPT_CHUNK_MAX_BYTES } from '../protocol/index.js';
+import {
+  HostSessionTranscriptCoordinator,
+  MAX_TRANSCRIPT_SNAPSHOT_BYTES,
+} from '../server/session-transcript-coordinator.js';
 import { SessionAdmissionGate } from '../server/session-admission-gate.js';
 
 test('Session transcript continuation detects an execution-boundary-only change', async () => {
@@ -50,6 +54,7 @@ test('Session transcript continuation detects an execution-boundary-only change'
     {
       kind: 'continue',
       sessionId: 'session-1',
+      snapshotId: initial.result.snapshotId,
       revision: initial.result.revision,
       boundaryRevision: initial.result.boundary.revision,
       messageIndex: 0,
@@ -67,4 +72,214 @@ test('Session transcript continuation detects an execution-boundary-only change'
       actualBoundaryRevision: 1,
     },
   });
+});
+
+test('Session transcript continuations reuse one immutable message snapshot', async () => {
+  let messageReads = 0;
+  const coordinator = new HostSessionTranscriptCoordinator({
+    store: {
+      async readHeaderRecordSnapshot() {
+        return { revision: 1, committedAt: 1, header: {} as never };
+      },
+      async readMessagesSnapshot() {
+        messageReads += 1;
+        return [
+          {
+            type: 'user' as const,
+            id: 'message-1',
+            turnId: 'turn-1',
+            ts: 1,
+            text: 'x'.repeat(SESSION_TRANSCRIPT_CHUNK_MAX_BYTES),
+          },
+        ];
+      },
+      async readExecutionBoundary() {
+        return {
+          kind: 'managed' as const,
+          profile: createReadOnlyPermissionProfile(),
+          revision: 0,
+        };
+      },
+    },
+    admission: new SessionAdmissionGate(),
+  });
+
+  const initial = await coordinator.handlers['session.transcript.query'](
+    { kind: 'start', sessionId: 'session-1' },
+    {} as never,
+  );
+  assert.equal(initial.ok, true);
+  if (!initial.ok || initial.result.kind !== 'chunk' || initial.result.next === null) return;
+
+  const continuation = await coordinator.handlers['session.transcript.query'](
+    {
+      kind: 'continue',
+      sessionId: 'session-1',
+      snapshotId: initial.result.snapshotId,
+      revision: initial.result.revision,
+      boundaryRevision: initial.result.boundary.revision,
+      ...initial.result.next,
+    },
+    {} as never,
+  );
+
+  assert.equal(continuation.ok, true);
+  assert.equal(messageReads, 1);
+});
+
+test('Session transcript snapshot leases evict the oldest continuation', async () => {
+  const coordinator = new HostSessionTranscriptCoordinator({
+    store: {
+      async readHeaderRecordSnapshot() {
+        return { revision: 1, committedAt: 1, header: {} as never };
+      },
+      async readMessagesSnapshot() {
+        return [
+          {
+            type: 'user' as const,
+            id: 'message-1',
+            turnId: 'turn-1',
+            ts: 1,
+            text: 'x'.repeat(SESSION_TRANSCRIPT_CHUNK_MAX_BYTES),
+          },
+        ];
+      },
+      async readExecutionBoundary() {
+        return {
+          kind: 'managed' as const,
+          profile: createReadOnlyPermissionProfile(),
+          revision: 0,
+        };
+      },
+    },
+    admission: new SessionAdmissionGate(),
+  });
+  const starts = await Promise.all(
+    Array.from({ length: 9 }, () =>
+      coordinator.handlers['session.transcript.query'](
+        { kind: 'start', sessionId: 'session-1' },
+        {} as never,
+      ),
+    ),
+  );
+  const first = starts[0];
+  assert.equal(first?.ok, true);
+  if (!first?.ok || first.result.kind !== 'chunk' || first.result.next === null) return;
+
+  const continuation = await coordinator.handlers['session.transcript.query'](
+    {
+      kind: 'continue',
+      sessionId: 'session-1',
+      snapshotId: first.result.snapshotId,
+      revision: first.result.revision,
+      boundaryRevision: first.result.boundary.revision,
+      ...first.result.next,
+    },
+    {} as never,
+  );
+
+  assert.deepEqual(continuation, {
+    ok: true,
+    result: { kind: 'snapshot_expired', snapshotId: first.result.snapshotId },
+  });
+});
+
+test('Session transcript rejects a snapshot that exceeds the retained byte bound', async () => {
+  const coordinator = new HostSessionTranscriptCoordinator({
+    store: {
+      async readHeaderRecordSnapshot() {
+        return { revision: 1, committedAt: 1, header: {} as never };
+      },
+      async readMessagesSnapshot() {
+        return [
+          {
+            type: 'user' as const,
+            id: 'message-1',
+            turnId: 'turn-1',
+            ts: 1,
+            text: 'x'.repeat(MAX_TRANSCRIPT_SNAPSHOT_BYTES),
+          },
+        ];
+      },
+      async readExecutionBoundary() {
+        return {
+          kind: 'managed' as const,
+          profile: createReadOnlyPermissionProfile(),
+          revision: 0,
+        };
+      },
+    },
+    admission: new SessionAdmissionGate(),
+  });
+
+  const result = await coordinator.handlers['session.transcript.query'](
+    { kind: 'start', sessionId: 'session-1' },
+    {} as never,
+  );
+
+  assert.deepEqual(result, {
+    ok: false,
+    error: {
+      code: 'operation_unavailable',
+      message: 'Session transcript exceeds the live snapshot byte limit',
+    },
+  });
+});
+
+test('Session transcript expires an abandoned continuation without another query', async (t) => {
+  t.mock.timers.enable({ apis: ['Date', 'setTimeout'], now: 0 });
+  try {
+    const coordinator = new HostSessionTranscriptCoordinator({
+      store: {
+        async readHeaderRecordSnapshot() {
+          return { revision: 1, committedAt: 1, header: {} as never };
+        },
+        async readMessagesSnapshot() {
+          return [
+            {
+              type: 'user' as const,
+              id: 'message-1',
+              turnId: 'turn-1',
+              ts: 1,
+              text: 'x'.repeat(SESSION_TRANSCRIPT_CHUNK_MAX_BYTES),
+            },
+          ];
+        },
+        async readExecutionBoundary() {
+          return {
+            kind: 'managed' as const,
+            profile: createReadOnlyPermissionProfile(),
+            revision: 0,
+          };
+        },
+      },
+      admission: new SessionAdmissionGate(),
+    });
+    const initial = await coordinator.handlers['session.transcript.query'](
+      { kind: 'start', sessionId: 'session-1' },
+      {} as never,
+    );
+    assert.equal(initial.ok, true);
+    if (!initial.ok || initial.result.kind !== 'chunk' || initial.result.next === null) return;
+
+    t.mock.timers.tick(60_000);
+    const continuation = await coordinator.handlers['session.transcript.query'](
+      {
+        kind: 'continue',
+        sessionId: 'session-1',
+        snapshotId: initial.result.snapshotId,
+        revision: initial.result.revision,
+        boundaryRevision: initial.result.boundary.revision,
+        ...initial.result.next,
+      },
+      {} as never,
+    );
+
+    assert.deepEqual(continuation, {
+      ok: true,
+      result: { kind: 'snapshot_expired', snapshotId: initial.result.snapshotId },
+    });
+  } finally {
+    t.mock.timers.reset();
+  }
 });

--- a/packages/runtime-host/src/__tests__/session-transcript-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-transcript-protocol.test.ts
@@ -21,6 +21,7 @@ describe('Session transcript protocol', () => {
       request({
         kind: 'continue',
         sessionId: 'session-1',
+        snapshotId: 'snapshot-1',
         revision: 2,
         boundaryRevision: 4,
         messageIndex: 1,
@@ -33,6 +34,7 @@ describe('Session transcript protocol', () => {
     const data = Buffer.alloc(SESSION_TRANSCRIPT_CHUNK_MAX_BYTES, 1).toString('base64');
     const decoded = response({
       kind: 'chunk',
+      snapshotId: 'snapshot-1',
       revision: 2,
       boundary: { kind: 'managed', revision: 4, displayMode: 'explore' },
       messageCount: 3,
@@ -46,6 +48,7 @@ describe('Session transcript protocol', () => {
     assert.doesNotThrow(() =>
       response({
         kind: 'chunk',
+        snapshotId: 'snapshot-1',
         revision: 1,
         boundary: { kind: 'external', revision: 0, displayMode: null },
         messageCount: 0,
@@ -65,6 +68,7 @@ describe('Session transcript protocol', () => {
     for (const result of [
       {
         kind: 'chunk',
+        snapshotId: 'snapshot-1',
         revision: 1,
         boundary: { kind: 'managed', revision: 0, displayMode: null },
         messageCount: 1,
@@ -75,6 +79,7 @@ describe('Session transcript protocol', () => {
       },
       {
         kind: 'chunk',
+        snapshotId: 'snapshot-1',
         revision: 1,
         boundary: { kind: 'bypass', revision: 0, displayMode: 'bypass' },
         messageCount: 1,
@@ -85,6 +90,7 @@ describe('Session transcript protocol', () => {
       },
       {
         kind: 'chunk',
+        snapshotId: 'snapshot-1',
         revision: 1,
         boundary: { kind: 'bypass', revision: 0, displayMode: 'bypass' },
         messageCount: 0,
@@ -102,6 +108,7 @@ describe('Session transcript protocol', () => {
     const input = {
       kind: 'continue' as const,
       sessionId: 'session-1',
+      snapshotId: 'snapshot-1',
       revision: 3,
       boundaryRevision: 4,
       messageIndex: 2,
@@ -133,6 +140,7 @@ describe('Session transcript protocol', () => {
       () =>
         HOST_OPERATION_SPECS['session.transcript.query'].assertOutputForInput?.(input, {
           kind: 'chunk',
+          snapshotId: 'snapshot-1',
           revision: 3,
           boundary: { kind: 'bypass', revision: 4, displayMode: 'bypass' },
           messageCount: 3,
@@ -142,6 +150,20 @@ describe('Session transcript protocol', () => {
           next: null,
         }),
       isInvalidFrame,
+    );
+    assert.throws(
+      () =>
+        HOST_OPERATION_SPECS['session.transcript.query'].assertOutputForInput?.(input, {
+          kind: 'snapshot_expired',
+          snapshotId: 'snapshot-2',
+        }),
+      isInvalidFrame,
+    );
+    assert.doesNotThrow(() =>
+      HOST_OPERATION_SPECS['session.transcript.query'].assertOutputForInput?.(input, {
+        kind: 'snapshot_expired',
+        snapshotId: 'snapshot-1',
+      }),
     );
   });
 });

--- a/packages/runtime-host/src/__tests__/session-transcript-protocol.test.ts
+++ b/packages/runtime-host/src/__tests__/session-transcript-protocol.test.ts
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import {
+  decodeClientFrame,
+  decodeHostFrame,
+  HOST_OPERATION_SPECS,
+  SESSION_TRANSCRIPT_CHUNK_MAX_BYTES,
+  RuntimeHostProtocolError,
+} from '../protocol/index.js';
+
+describe('Session transcript protocol', () => {
+  test('declares one revision-pinned ready query', () => {
+    assert.deepEqual(
+      Object.keys(HOST_OPERATION_SPECS).filter((key) => key.startsWith('session.transcript.')),
+      ['session.transcript.query'],
+    );
+    assert.equal(HOST_OPERATION_SPECS['session.transcript.query'].mode, 'query');
+    assert.equal(HOST_OPERATION_SPECS['session.transcript.query'].availability, 'ready');
+    assert.doesNotThrow(() => request({ kind: 'start', sessionId: 'session-1' }));
+    assert.doesNotThrow(() =>
+      request({
+        kind: 'continue',
+        sessionId: 'session-1',
+        revision: 2,
+        boundaryRevision: 4,
+        messageIndex: 1,
+        byteOffset: 1024,
+      }),
+    );
+  });
+
+  test('preserves bounded chunks and an authoritative boundary projection', () => {
+    const data = Buffer.alloc(SESSION_TRANSCRIPT_CHUNK_MAX_BYTES, 1).toString('base64');
+    const decoded = response({
+      kind: 'chunk',
+      revision: 2,
+      boundary: { kind: 'managed', revision: 4, displayMode: 'explore' },
+      messageCount: 3,
+      messageIndex: 1,
+      byteOffset: 0,
+      data,
+      next: { messageIndex: 1, byteOffset: SESSION_TRANSCRIPT_CHUNK_MAX_BYTES },
+    });
+    assert.equal('ok' in decoded && decoded.ok, true);
+
+    assert.doesNotThrow(() =>
+      response({
+        kind: 'chunk',
+        revision: 1,
+        boundary: { kind: 'external', revision: 0, displayMode: null },
+        messageCount: 0,
+        messageIndex: 0,
+        byteOffset: 0,
+        data: '',
+        next: null,
+      }),
+    );
+  });
+
+  test('rejects widened cursors, invalid base64, and inconsistent boundary display', () => {
+    assert.throws(
+      () => request({ kind: 'start', sessionId: 'session-1', cursor: 0 }),
+      isInvalidFrame,
+    );
+    for (const result of [
+      {
+        kind: 'chunk',
+        revision: 1,
+        boundary: { kind: 'managed', revision: 0, displayMode: null },
+        messageCount: 1,
+        messageIndex: 0,
+        byteOffset: 0,
+        data: 'eA==',
+        next: null,
+      },
+      {
+        kind: 'chunk',
+        revision: 1,
+        boundary: { kind: 'bypass', revision: 0, displayMode: 'bypass' },
+        messageCount: 1,
+        messageIndex: 0,
+        byteOffset: 0,
+        data: 'not base64',
+        next: null,
+      },
+      {
+        kind: 'chunk',
+        revision: 1,
+        boundary: { kind: 'bypass', revision: 0, displayMode: 'bypass' },
+        messageCount: 0,
+        messageIndex: 0,
+        byteOffset: 0,
+        data: 'eA==',
+        next: null,
+      },
+    ]) {
+      assert.throws(() => response(result), isInvalidFrame);
+    }
+  });
+
+  test('correlates continuations and revision conflicts with their request', () => {
+    const input = {
+      kind: 'continue' as const,
+      sessionId: 'session-1',
+      revision: 3,
+      boundaryRevision: 4,
+      messageIndex: 2,
+      byteOffset: 8,
+    };
+    assert.throws(
+      () =>
+        HOST_OPERATION_SPECS['session.transcript.query'].assertOutputForInput?.(input, {
+          kind: 'revision_changed',
+          expectedRevision: 2,
+          actualRevision: 4,
+          expectedBoundaryRevision: 4,
+          actualBoundaryRevision: 5,
+        }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () =>
+        HOST_OPERATION_SPECS['session.transcript.query'].assertOutputForInput?.(input, {
+          kind: 'revision_changed',
+          expectedRevision: 3,
+          actualRevision: 3,
+          expectedBoundaryRevision: 3,
+          actualBoundaryRevision: 5,
+        }),
+      isInvalidFrame,
+    );
+    assert.throws(
+      () =>
+        HOST_OPERATION_SPECS['session.transcript.query'].assertOutputForInput?.(input, {
+          kind: 'chunk',
+          revision: 3,
+          boundary: { kind: 'bypass', revision: 4, displayMode: 'bypass' },
+          messageCount: 3,
+          messageIndex: 2,
+          byteOffset: 9,
+          data: 'eA==',
+          next: null,
+        }),
+      isInvalidFrame,
+    );
+  });
+});
+
+function request(input: unknown): unknown {
+  return decodeClientFrame({
+    requestId: 'request-1',
+    operation: 'session.transcript.query',
+    input,
+  });
+}
+
+function response(result: unknown) {
+  return decodeHostFrame({
+    requestId: 'request-1',
+    operation: 'session.transcript.query',
+    ok: true,
+    result,
+  });
+}
+
+function isInvalidFrame(error: unknown): boolean {
+  return error instanceof RuntimeHostProtocolError && error.code === 'invalid_frame';
+}

--- a/packages/runtime-host/src/candidate-options.ts
+++ b/packages/runtime-host/src/candidate-options.ts
@@ -1,0 +1,50 @@
+export interface RuntimeHostCandidateCommandOptions {
+  readonly rootPath: string;
+  readonly expectedRootId: string;
+  readonly idleGraceMs?: number;
+  readonly handshakeTimeoutMs?: number;
+}
+
+export function parseRuntimeHostCandidateArguments(
+  args: readonly string[],
+): RuntimeHostCandidateCommandOptions {
+  const allowedKeys = new Set([
+    'root',
+    'expected-root-id',
+    'idle-grace-ms',
+    'handshake-timeout-ms',
+  ]);
+  const values = new Map<string, string>();
+  for (let index = 0; index < args.length; index += 2) {
+    const key = args[index];
+    const value = args[index + 1];
+    if (!key?.startsWith('--') || value === undefined) {
+      throw new Error('Invalid Runtime Host candidate arguments');
+    }
+    const name = key.slice(2);
+    if (!allowedKeys.has(name) || values.has(name)) {
+      throw new Error(`Invalid Runtime Host candidate argument: ${key}`);
+    }
+    values.set(name, value);
+  }
+  const rootPath = values.get('root');
+  if (!rootPath) throw new Error('Runtime Host candidate requires --root');
+  const expectedRootId = values.get('expected-root-id');
+  if (!expectedRootId || !/^[a-f0-9]{64}$/.test(expectedRootId)) {
+    throw new Error('Runtime Host candidate requires a valid --expected-root-id');
+  }
+  return {
+    rootPath,
+    expectedRootId,
+    idleGraceMs: readOptionalInteger(values, 'idle-grace-ms'),
+    handshakeTimeoutMs: readOptionalInteger(values, 'handshake-timeout-ms'),
+  };
+}
+
+function readOptionalInteger(values: ReadonlyMap<string, string>, key: string): number | undefined {
+  const raw = values.get(key);
+  if (raw === undefined) return undefined;
+  const value = Number(raw);
+  if (!Number.isSafeInteger(value)) throw new Error(`Invalid --${key}`);
+  return value;
+}

--- a/packages/runtime-host/src/client/connect-or-spawn-execution-harness.ts
+++ b/packages/runtime-host/src/client/connect-or-spawn-execution-harness.ts
@@ -1,0 +1,23 @@
+import {
+  connectOrSpawnRuntimeHostWithDependencies,
+  type ConnectOrSpawnRuntimeHostInput,
+  type ConnectOrSpawnRuntimeHostResult,
+} from './connect-or-spawn.js';
+import { launchDetachedRuntimeHostCandidate } from './launcher.js';
+
+/**
+ * Starts the explicit execution composition used by vertical-slice harnesses.
+ * Production clients must use connectOrSpawnRuntimeHost instead.
+ */
+export function connectOrSpawnExecutionRuntimeHostHarness(
+  input: ConnectOrSpawnRuntimeHostInput,
+): Promise<ConnectOrSpawnRuntimeHostResult> {
+  return connectOrSpawnRuntimeHostWithDependencies(input, {
+    launchCandidate: (candidate) =>
+      launchDetachedRuntimeHostCandidate({
+        ...candidate,
+        entrypoint: new URL('../execution-candidate-main.js', import.meta.url),
+      }),
+    random: Math.random,
+  });
+}

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'node:crypto';
 import { connect } from 'node:net';
 import { performance } from 'node:perf_hooks';
+import { TextDecoder } from 'node:util';
 import {
   discoverMarkedStorageRoot,
   prepareStorageRootControlDirectory,
@@ -29,6 +30,7 @@ import {
   type ResponseFrame,
   type SubscriptionFrame,
   type SubscriptionOpenInput,
+  type SessionExecutionBoundaryProjection,
   type TurnQueryInput,
   type TurnSnapshot,
   type TurnStartInput,
@@ -49,6 +51,7 @@ import type { ClientCapabilityProvider } from './client-capability.js';
 const DEFAULT_CONNECT_TIMEOUT_MS = 500;
 const DEFAULT_HANDSHAKE_TIMEOUT_MS = 2_000;
 const DEFAULT_REQUEST_TIMEOUT_MS = 2_000;
+const SESSION_TRANSCRIPT_REQUEST_TIMEOUT_MS = 30_000;
 
 export interface ConnectRuntimeHostInput {
   rootPath: string;
@@ -121,6 +124,10 @@ export interface RuntimeHostConnection {
   startTurn(input: TurnStartInput, timeoutMs?: number): Promise<TurnSnapshot>;
   queryTurn(input: TurnQueryInput, timeoutMs?: number): Promise<TurnSnapshot>;
   stopTurn(input: TurnStopInput, timeoutMs?: number): Promise<TurnSnapshot>;
+  readSessionTranscript(
+    sessionId: string,
+    timeoutMs?: number,
+  ): Promise<RuntimeHostSessionTranscript>;
   openSessionSubscription(
     input: SubscriptionOpenInput,
     timeoutMs?: number,
@@ -131,6 +138,16 @@ export interface RuntimeHostConnection {
     timeoutMs?: number,
   ): Promise<ClientCapabilityReplaceResult>;
   unregisterClientCapabilities(timeoutMs?: number): Promise<ClientCapabilityUnregisterResult>;
+}
+
+export interface RuntimeHostSessionTranscript {
+  readonly revision: number;
+  readonly boundary: SessionExecutionBoundaryProjection;
+  /**
+   * Parsed JSON records. Domain clients must validate them before use; the
+   * transport layer deliberately does not depend on Session storage schemas.
+   */
+  readonly messages: readonly unknown[];
 }
 
 export type DirectRequestOperationKey = Exclude<
@@ -292,6 +309,89 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
 
   stopTurn(input: TurnStopInput, timeoutMs?: number): Promise<TurnSnapshot> {
     return this.request('turn.stop', input, timeoutMs);
+  }
+
+  async readSessionTranscript(
+    sessionId: string,
+    timeoutMs?: number,
+  ): Promise<RuntimeHostSessionTranscript> {
+    for (let attempt = 0; attempt < 3; attempt += 1) {
+      const transcript = await this.#readSessionTranscriptAttempt(sessionId, timeoutMs);
+      if (transcript !== undefined) return transcript;
+    }
+    throw new Error('Session transcript kept changing while it was read');
+  }
+
+  async #readSessionTranscriptAttempt(
+    sessionId: string,
+    timeoutMs: number | undefined,
+  ): Promise<RuntimeHostSessionTranscript | undefined> {
+    const initial = await this.request(
+      'session.transcript.query',
+      { kind: 'start', sessionId },
+      timeoutMs,
+    );
+    if (initial.kind === 'revision_changed') {
+      throw new Error('Runtime Host returned a revision change for a transcript start');
+    }
+    let chunk = initial;
+    const revision = chunk.revision;
+    const boundary = chunk.boundary;
+    const messageCount = chunk.messageCount;
+    const messages: unknown[] = [];
+    let encodedChunks: Buffer[] = [];
+    let encodedByteLength = 0;
+
+    while (true) {
+      if (
+        chunk.revision !== revision ||
+        chunk.messageCount !== messageCount ||
+        !sameBoundaryProjection(chunk.boundary, boundary)
+      ) {
+        throw new Error('Session transcript projection changed without a revision conflict');
+      }
+      if (messageCount === 0) return { revision, boundary, messages };
+      if (chunk.messageIndex !== messages.length || chunk.byteOffset !== encodedByteLength) {
+        throw new Error('Runtime Host returned a non-contiguous Session transcript chunk');
+      }
+      const data = Buffer.from(chunk.data, 'base64');
+      encodedChunks.push(data);
+      encodedByteLength += data.byteLength;
+      const next = chunk.next;
+      if (next === null || next.messageIndex !== chunk.messageIndex) {
+        messages.push(decodeTranscriptRecord(Buffer.concat(encodedChunks, encodedByteLength)));
+        encodedChunks = [];
+        encodedByteLength = 0;
+      }
+      if (next === null) {
+        if (messages.length !== messageCount) {
+          throw new Error('Runtime Host ended the Session transcript before every message');
+        }
+        return { revision, boundary, messages };
+      }
+      if (
+        (next.messageIndex === chunk.messageIndex &&
+          next.byteOffset !== chunk.byteOffset + data.byteLength) ||
+        (next.messageIndex === chunk.messageIndex + 1 && next.byteOffset !== 0) ||
+        (next.messageIndex !== chunk.messageIndex && next.messageIndex !== chunk.messageIndex + 1)
+      ) {
+        throw new Error('Runtime Host returned an invalid Session transcript cursor');
+      }
+      const continuation = await this.request(
+        'session.transcript.query',
+        {
+          kind: 'continue',
+          sessionId,
+          revision,
+          boundaryRevision: boundary.revision,
+          messageIndex: next.messageIndex,
+          byteOffset: next.byteOffset,
+        },
+        timeoutMs,
+      );
+      if (continuation.kind === 'revision_changed') return undefined;
+      chunk = continuation;
+    }
   }
 
   openSessionSubscription(
@@ -726,6 +826,11 @@ function defaultRequestTimeoutMs(operation: DirectRequestOperationKey): number |
     case 'connection.test.run':
       // Completion effects own provider deadlines and may wait behind same-connection FIFO work.
       return undefined;
+    case 'session.transcript.query':
+      // A durable transcript can span many records and each chunk requires a
+      // storage snapshot. Keep the ordinary control-plane timeout strict while
+      // allowing slow filesystems enough time to serve one chunk.
+      return SESSION_TRANSCRIPT_REQUEST_TIMEOUT_MS;
     default:
       return DEFAULT_REQUEST_TIMEOUT_MS;
   }
@@ -776,4 +881,24 @@ function readRegistrationBeforeDeadline(
 
 function asError(error: unknown): Error {
   return error instanceof Error ? error : new Error(String(error));
+}
+
+function decodeTranscriptRecord(encoded: Buffer): unknown {
+  try {
+    const json = new TextDecoder('utf-8', { fatal: true }).decode(encoded);
+    return JSON.parse(json) as unknown;
+  } catch {
+    throw new Error('Runtime Host returned an invalid encoded Session transcript message');
+  }
+}
+
+function sameBoundaryProjection(
+  left: SessionExecutionBoundaryProjection,
+  right: SessionExecutionBoundaryProjection,
+): boolean {
+  return (
+    left.kind === right.kind &&
+    left.revision === right.revision &&
+    left.displayMode === right.displayMode
+  );
 }

--- a/packages/runtime-host/src/client/connection.ts
+++ b/packages/runtime-host/src/client/connection.ts
@@ -334,7 +334,11 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
     if (initial.kind === 'revision_changed') {
       throw new Error('Runtime Host returned a revision change for a transcript start');
     }
+    if (initial.kind === 'snapshot_expired') {
+      throw new Error('Runtime Host returned an expired transcript snapshot for a start');
+    }
     let chunk = initial;
+    const snapshotId = chunk.snapshotId;
     const revision = chunk.revision;
     const boundary = chunk.boundary;
     const messageCount = chunk.messageCount;
@@ -344,6 +348,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
 
     while (true) {
       if (
+        chunk.snapshotId !== snapshotId ||
         chunk.revision !== revision ||
         chunk.messageCount !== messageCount ||
         !sameBoundaryProjection(chunk.boundary, boundary)
@@ -382,6 +387,7 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
         {
           kind: 'continue',
           sessionId,
+          snapshotId,
           revision,
           boundaryRevision: boundary.revision,
           messageIndex: next.messageIndex,
@@ -389,7 +395,9 @@ class RuntimeHostConnectionImpl implements RuntimeHostConnection {
         },
         timeoutMs,
       );
-      if (continuation.kind === 'revision_changed') return undefined;
+      if (continuation.kind === 'revision_changed' || continuation.kind === 'snapshot_expired') {
+        return undefined;
+      }
       chunk = continuation;
     }
   }

--- a/packages/runtime-host/src/client/index.ts
+++ b/packages/runtime-host/src/client/index.ts
@@ -5,6 +5,7 @@ export {
   type ConnectRuntimeHostInput,
   type ConnectRuntimeHostResult,
   type RuntimeHostConnection,
+  type RuntimeHostSessionTranscript,
   type RuntimeHostUnavailableReason,
   type DirectRequestOperationKey,
 } from './connection.js';
@@ -25,3 +26,4 @@ export {
   OAUTH_PRESENTATION_SERVICE_VERSION,
   type OAuthPresentationBackend,
 } from './oauth-presentation.js';
+export { connectOrSpawnExecutionRuntimeHostHarness } from './connect-or-spawn-execution-harness.js';

--- a/packages/runtime-host/src/execution-candidate-main.ts
+++ b/packages/runtime-host/src/execution-candidate-main.ts
@@ -1,10 +1,10 @@
 #!/usr/bin/env node
 import { parseRuntimeHostCandidateArguments } from './candidate-options.js';
-import { startRuntimeHostCandidate } from './server/candidate.js';
+import { startExecutionRuntimeHostCandidate } from './server/execution-candidate.js';
 import { runRuntimeHostProcessLifecycle } from './server/process-lifecycle.js';
 
 const options = parseRuntimeHostCandidateArguments(process.argv.slice(2));
-const result = await startRuntimeHostCandidate(options);
+const result = await startExecutionRuntimeHostCandidate(options);
 if (result.kind === 'loser') process.exit(2);
 
 try {

--- a/packages/runtime-host/src/protocol/index.ts
+++ b/packages/runtime-host/src/protocol/index.ts
@@ -34,6 +34,7 @@ export * from './operations.js';
 export * from './runtime-resource.js';
 export * from './session-continuity.js';
 export * from './session-retirement.js';
+export * from './session-transcript.js';
 export * from './task-ledger.js';
 
 export const RUNTIME_HOST_REGISTRATION_SCHEMA_VERSION = 1 as const;

--- a/packages/runtime-host/src/protocol/operations.ts
+++ b/packages/runtime-host/src/protocol/operations.ts
@@ -23,6 +23,7 @@ import { SESSION_CATALOG_OPERATION_SPECS } from './session-catalog.js';
 import { SESSION_CONTINUITY_OPERATION_SPECS } from './session-continuity.js';
 import { SESSION_REVISION_OPERATION_SPECS } from './session-revision.js';
 import { SESSION_RETIREMENT_OPERATION_SPECS } from './session-retirement.js';
+import { SESSION_TRANSCRIPT_OPERATION_SPECS } from './session-transcript.js';
 import { SKILL_CATALOG_OPERATION_SPECS } from './skill-catalog.js';
 import { TASK_LEDGER_OPERATION_SPECS } from './task-ledger.js';
 import { TURN_OPERATION_SPECS } from './turn.js';
@@ -118,6 +119,7 @@ export const HOST_OPERATION_SPECS = composeOperationSpecMaps(
   SESSION_CATALOG_OPERATION_SPECS,
   SESSION_REVISION_OPERATION_SPECS,
   SESSION_RETIREMENT_OPERATION_SPECS,
+  SESSION_TRANSCRIPT_OPERATION_SPECS,
   ARTIFACT_OPERATION_SPECS,
   SKILL_CATALOG_OPERATION_SPECS,
   USAGE_PRICING_OPERATION_SPECS,

--- a/packages/runtime-host/src/protocol/session-transcript.ts
+++ b/packages/runtime-host/src/protocol/session-transcript.ts
@@ -1,0 +1,267 @@
+import type { PermissionMode } from '@maka/core/permission';
+import { requireCount, requireEntityId, requireExactRecord, requireRecord } from './codec.js';
+import { invalidProtocolFrame } from './errors.js';
+import { defineOperation } from './operation-spec.js';
+
+export const SESSION_TRANSCRIPT_CHUNK_MAX_BYTES = 24 * 1024;
+export const SESSION_TRANSCRIPT_RESULT_MAX_BYTES = 48 * 1024;
+
+const QUERY_ERRORS = [
+  'host_not_ready',
+  'host_draining',
+  'operation_unavailable',
+  'invalid_request',
+  'not_found',
+  'persistence_failed',
+  'internal_failure',
+] as const;
+
+export type SessionTranscriptQueryInput =
+  | {
+      readonly kind: 'start';
+      readonly sessionId: string;
+    }
+  | {
+      readonly kind: 'continue';
+      readonly sessionId: string;
+      readonly revision: number;
+      readonly boundaryRevision: number;
+      readonly messageIndex: number;
+      readonly byteOffset: number;
+    };
+
+export interface SessionExecutionBoundaryProjection {
+  readonly kind: 'managed' | 'bypass' | 'external';
+  readonly revision: number;
+  readonly displayMode: PermissionMode | null;
+}
+
+export interface SessionTranscriptCursor {
+  readonly messageIndex: number;
+  readonly byteOffset: number;
+}
+
+export type SessionTranscriptQueryResult =
+  | {
+      readonly kind: 'chunk';
+      readonly revision: number;
+      readonly boundary: SessionExecutionBoundaryProjection;
+      readonly messageCount: number;
+      readonly messageIndex: number;
+      readonly byteOffset: number;
+      readonly data: string;
+      readonly next: SessionTranscriptCursor | null;
+    }
+  | {
+      readonly kind: 'revision_changed';
+      readonly expectedRevision: number;
+      readonly actualRevision: number;
+      readonly expectedBoundaryRevision: number;
+      readonly actualBoundaryRevision: number;
+    };
+
+export const SESSION_TRANSCRIPT_OPERATION_SPECS = {
+  'session.transcript.query': defineOperation<
+    SessionTranscriptQueryInput,
+    SessionTranscriptQueryResult,
+    (typeof QUERY_ERRORS)[number]
+  >({
+    mode: 'query',
+    availability: 'ready',
+    errors: QUERY_ERRORS,
+    decodeInput: decodeSessionTranscriptQueryInput,
+    decodeOutput: decodeSessionTranscriptQueryResult,
+    assertOutputForInput: assertSessionTranscriptOutput,
+  }),
+} as const;
+
+export function decodeSessionTranscriptQueryInput(value: unknown): SessionTranscriptQueryInput {
+  const input = requireRecord(value, 'Session transcript query input');
+  if (input.kind === 'start') {
+    const exact = requireExactRecord(input, 'Session transcript start input', [
+      'kind',
+      'sessionId',
+    ]);
+    return {
+      kind: 'start',
+      sessionId: requireEntityId(exact.sessionId, 'sessionId'),
+    };
+  }
+  if (input.kind === 'continue') {
+    const exact = requireExactRecord(input, 'Session transcript continuation input', [
+      'kind',
+      'sessionId',
+      'revision',
+      'boundaryRevision',
+      'messageIndex',
+      'byteOffset',
+    ]);
+    return {
+      kind: 'continue',
+      sessionId: requireEntityId(exact.sessionId, 'sessionId'),
+      revision: requirePositiveRevision(exact.revision, 'Session transcript revision'),
+      boundaryRevision: requireCount(
+        exact.boundaryRevision,
+        'Session transcript boundary revision',
+      ),
+      messageIndex: requireCount(exact.messageIndex, 'Session transcript message index'),
+      byteOffset: requireCount(exact.byteOffset, 'Session transcript byte offset'),
+    };
+  }
+  throw invalidProtocolFrame('Invalid Session transcript query kind');
+}
+
+export function decodeSessionTranscriptQueryResult(value: unknown): SessionTranscriptQueryResult {
+  const result = requireRecord(value, 'Session transcript query result');
+  if (result.kind === 'revision_changed') {
+    const exact = requireExactRecord(result, 'Session transcript revision change', [
+      'kind',
+      'expectedRevision',
+      'actualRevision',
+      'expectedBoundaryRevision',
+      'actualBoundaryRevision',
+    ]);
+    return {
+      kind: 'revision_changed',
+      expectedRevision: requirePositiveRevision(
+        exact.expectedRevision,
+        'expected Session transcript revision',
+      ),
+      actualRevision: requirePositiveRevision(
+        exact.actualRevision,
+        'actual Session transcript revision',
+      ),
+      expectedBoundaryRevision: requireCount(
+        exact.expectedBoundaryRevision,
+        'expected Session transcript boundary revision',
+      ),
+      actualBoundaryRevision: requireCount(
+        exact.actualBoundaryRevision,
+        'actual Session transcript boundary revision',
+      ),
+    };
+  }
+  if (result.kind !== 'chunk') {
+    throw invalidProtocolFrame('Invalid Session transcript query result kind');
+  }
+  const exact = requireExactRecord(result, 'Session transcript chunk', [
+    'kind',
+    'revision',
+    'boundary',
+    'messageCount',
+    'messageIndex',
+    'byteOffset',
+    'data',
+    'next',
+  ]);
+  const messageCount = requireCount(exact.messageCount, 'Session transcript message count');
+  const messageIndex = requireCount(exact.messageIndex, 'Session transcript message index');
+  const byteOffset = requireCount(exact.byteOffset, 'Session transcript byte offset');
+  const data = requireBase64Chunk(exact.data);
+  const next = exact.next === null ? null : decodeSessionTranscriptCursor(exact.next);
+  if (messageCount === 0) {
+    if (messageIndex !== 0 || byteOffset !== 0 || data.length !== 0 || next !== null) {
+      throw invalidProtocolFrame('Invalid empty Session transcript chunk');
+    }
+  } else if (messageIndex >= messageCount || data.length === 0) {
+    throw invalidProtocolFrame('Invalid Session transcript chunk position');
+  }
+  const decoded: SessionTranscriptQueryResult = {
+    kind: 'chunk',
+    revision: requirePositiveRevision(exact.revision, 'Session transcript revision'),
+    boundary: decodeBoundaryProjection(exact.boundary),
+    messageCount,
+    messageIndex,
+    byteOffset,
+    data,
+    next,
+  };
+  if (Buffer.byteLength(JSON.stringify(decoded), 'utf8') > SESSION_TRANSCRIPT_RESULT_MAX_BYTES) {
+    throw invalidProtocolFrame('Session transcript result exceeds byte limit');
+  }
+  return decoded;
+}
+
+function decodeBoundaryProjection(value: unknown): SessionExecutionBoundaryProjection {
+  const boundary = requireExactRecord(value, 'Session execution boundary projection', [
+    'kind',
+    'revision',
+    'displayMode',
+  ]);
+  if (boundary.kind !== 'managed' && boundary.kind !== 'bypass' && boundary.kind !== 'external') {
+    throw invalidProtocolFrame('Invalid Session execution boundary kind');
+  }
+  const displayMode = boundary.displayMode;
+  if (
+    displayMode !== null &&
+    displayMode !== 'ask' &&
+    displayMode !== 'execute' &&
+    displayMode !== 'explore' &&
+    displayMode !== 'bypass'
+  ) {
+    throw invalidProtocolFrame('Invalid Session execution boundary display mode');
+  }
+  if ((boundary.kind === 'external') !== (displayMode === null)) {
+    throw invalidProtocolFrame('Session execution boundary display mode does not match its kind');
+  }
+  return {
+    kind: boundary.kind,
+    revision: requireCount(boundary.revision, 'Session execution boundary revision'),
+    displayMode,
+  };
+}
+
+function decodeSessionTranscriptCursor(value: unknown): SessionTranscriptCursor {
+  const cursor = requireExactRecord(value, 'Session transcript cursor', [
+    'messageIndex',
+    'byteOffset',
+  ]);
+  return {
+    messageIndex: requireCount(cursor.messageIndex, 'Session transcript cursor message index'),
+    byteOffset: requireCount(cursor.byteOffset, 'Session transcript cursor byte offset'),
+  };
+}
+
+function requireBase64Chunk(value: unknown): string {
+  if (typeof value !== 'string')
+    throw invalidProtocolFrame('Invalid Session transcript chunk data');
+  if (value.length === 0) return value;
+  if (!/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/.test(value)) {
+    throw invalidProtocolFrame('Invalid Session transcript chunk encoding');
+  }
+  const bytes = Buffer.from(value, 'base64');
+  if (bytes.byteLength > SESSION_TRANSCRIPT_CHUNK_MAX_BYTES || bytes.toString('base64') !== value) {
+    throw invalidProtocolFrame('Invalid Session transcript chunk data');
+  }
+  return value;
+}
+
+function assertSessionTranscriptOutput(
+  input: SessionTranscriptQueryInput,
+  output: SessionTranscriptQueryResult,
+): void {
+  if (
+    input.kind === 'continue' &&
+    output.kind === 'revision_changed' &&
+    (output.expectedRevision !== input.revision ||
+      output.expectedBoundaryRevision !== input.boundaryRevision)
+  ) {
+    throw invalidProtocolFrame('Session transcript revision change does not match request');
+  }
+  if (
+    input.kind === 'continue' &&
+    output.kind === 'chunk' &&
+    (output.revision !== input.revision ||
+      output.boundary.revision !== input.boundaryRevision ||
+      output.messageIndex !== input.messageIndex ||
+      output.byteOffset !== input.byteOffset)
+  ) {
+    throw invalidProtocolFrame('Session transcript chunk does not match request');
+  }
+}
+
+function requirePositiveRevision(value: unknown, label: string): number {
+  const revision = requireCount(value, label);
+  if (revision < 1) throw invalidProtocolFrame(`Invalid ${label}`);
+  return revision;
+}

--- a/packages/runtime-host/src/protocol/session-transcript.ts
+++ b/packages/runtime-host/src/protocol/session-transcript.ts
@@ -24,6 +24,7 @@ export type SessionTranscriptQueryInput =
   | {
       readonly kind: 'continue';
       readonly sessionId: string;
+      readonly snapshotId: string;
       readonly revision: number;
       readonly boundaryRevision: number;
       readonly messageIndex: number;
@@ -44,6 +45,7 @@ export interface SessionTranscriptCursor {
 export type SessionTranscriptQueryResult =
   | {
       readonly kind: 'chunk';
+      readonly snapshotId: string;
       readonly revision: number;
       readonly boundary: SessionExecutionBoundaryProjection;
       readonly messageCount: number;
@@ -51,6 +53,10 @@ export type SessionTranscriptQueryResult =
       readonly byteOffset: number;
       readonly data: string;
       readonly next: SessionTranscriptCursor | null;
+    }
+  | {
+      readonly kind: 'snapshot_expired';
+      readonly snapshotId: string;
     }
   | {
       readonly kind: 'revision_changed';
@@ -91,6 +97,7 @@ export function decodeSessionTranscriptQueryInput(value: unknown): SessionTransc
     const exact = requireExactRecord(input, 'Session transcript continuation input', [
       'kind',
       'sessionId',
+      'snapshotId',
       'revision',
       'boundaryRevision',
       'messageIndex',
@@ -99,6 +106,7 @@ export function decodeSessionTranscriptQueryInput(value: unknown): SessionTransc
     return {
       kind: 'continue',
       sessionId: requireEntityId(exact.sessionId, 'sessionId'),
+      snapshotId: requireEntityId(exact.snapshotId, 'Session transcript snapshotId'),
       revision: requirePositiveRevision(exact.revision, 'Session transcript revision'),
       boundaryRevision: requireCount(
         exact.boundaryRevision,
@@ -113,6 +121,16 @@ export function decodeSessionTranscriptQueryInput(value: unknown): SessionTransc
 
 export function decodeSessionTranscriptQueryResult(value: unknown): SessionTranscriptQueryResult {
   const result = requireRecord(value, 'Session transcript query result');
+  if (result.kind === 'snapshot_expired') {
+    const exact = requireExactRecord(result, 'expired Session transcript snapshot', [
+      'kind',
+      'snapshotId',
+    ]);
+    return {
+      kind: 'snapshot_expired',
+      snapshotId: requireEntityId(exact.snapshotId, 'Session transcript snapshotId'),
+    };
+  }
   if (result.kind === 'revision_changed') {
     const exact = requireExactRecord(result, 'Session transcript revision change', [
       'kind',
@@ -146,6 +164,7 @@ export function decodeSessionTranscriptQueryResult(value: unknown): SessionTrans
   }
   const exact = requireExactRecord(result, 'Session transcript chunk', [
     'kind',
+    'snapshotId',
     'revision',
     'boundary',
     'messageCount',
@@ -168,6 +187,7 @@ export function decodeSessionTranscriptQueryResult(value: unknown): SessionTrans
   }
   const decoded: SessionTranscriptQueryResult = {
     kind: 'chunk',
+    snapshotId: requireEntityId(exact.snapshotId, 'Session transcript snapshotId'),
     revision: requirePositiveRevision(exact.revision, 'Session transcript revision'),
     boundary: decodeBoundaryProjection(exact.boundary),
     messageCount,
@@ -242,6 +262,13 @@ function assertSessionTranscriptOutput(
 ): void {
   if (
     input.kind === 'continue' &&
+    output.kind === 'snapshot_expired' &&
+    output.snapshotId !== input.snapshotId
+  ) {
+    throw invalidProtocolFrame('Expired Session transcript snapshot does not match request');
+  }
+  if (
+    input.kind === 'continue' &&
     output.kind === 'revision_changed' &&
     (output.expectedRevision !== input.revision ||
       output.expectedBoundaryRevision !== input.boundaryRevision)
@@ -251,7 +278,8 @@ function assertSessionTranscriptOutput(
   if (
     input.kind === 'continue' &&
     output.kind === 'chunk' &&
-    (output.revision !== input.revision ||
+    (output.snapshotId !== input.snapshotId ||
+      output.revision !== input.revision ||
       output.boundary.revision !== input.boundaryRevision ||
       output.messageIndex !== input.messageIndex ||
       output.byteOffset !== input.byteOffset)

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -66,6 +66,7 @@ import { SessionAdmissionGate } from './session-admission-gate.js';
 import { HostSessionCatalogCoordinator } from './session-catalog-coordinator.js';
 import { HostSessionRetirementCoordinator } from './session-retirement-coordinator.js';
 import { HostSessionRevisionCoordinator } from './session-revision-coordinator.js';
+import { HostSessionTranscriptCoordinator } from './session-transcript-coordinator.js';
 import { SessionContinuityCoordinator } from './session-continuity-coordinator.js';
 import { HostSkillCatalogCoordinator } from './skill-catalog-coordinator.js';
 import { SkillCatalogRepository } from './skill-catalog-repository.js';
@@ -564,6 +565,10 @@ export async function createExecutionRuntimeHostComposition(
       worktrees: worktreeChildExecutor,
       requestDrain: context.requestDrain,
     });
+    const sessionTranscript = new HostSessionTranscriptCoordinator({
+      store: stores.sessionStore,
+      admission: sessionAdmission,
+    });
     const artifacts = new HostArtifactCoordinator(
       openedArtifactStore,
       context.requestDrain,
@@ -577,6 +582,7 @@ export async function createExecutionRuntimeHostComposition(
       ...executionInspect.handlers,
       ...sessionRevisions.handlers,
       ...sessionRetirement.handlers,
+      ...sessionTranscript.handlers,
       ...messages.handlers,
       ...interactions.handlers,
       ...runtimePolicy.handlers,

--- a/packages/runtime-host/src/server/live-assistant-replay-buffer.ts
+++ b/packages/runtime-host/src/server/live-assistant-replay-buffer.ts
@@ -1,0 +1,133 @@
+export interface LiveAssistantReplayBufferOptions {
+  readonly maxRawBytes: number;
+  readonly maxWireBytes: number;
+  readonly maxChunkRawBytes: number;
+  readonly maxChunkWireBytes: number;
+}
+
+/** Bounded text tail with a bounded number of coarse chunks. */
+export class LiveAssistantReplayBuffer {
+  readonly #chunks: string[] = [];
+  readonly #options: LiveAssistantReplayBufferOptions;
+  #rawBytes = 0;
+  #wireBytes = 0;
+
+  constructor(options: LiveAssistantReplayBufferOptions, text = '') {
+    this.#options = options;
+    this.append(text);
+  }
+
+  get wireBytes(): number {
+    return this.#wireBytes;
+  }
+
+  get retainedChunkCount(): number {
+    return this.#chunks.length;
+  }
+
+  append(text: string): void {
+    let chunk = this.#chunks.pop() ?? '';
+    let chunkRawBytes = Buffer.byteLength(chunk, 'utf8');
+    let chunkWireBytes = jsonStringContentBytes(chunk);
+    for (const character of text) {
+      const rawBytes = Buffer.byteLength(character, 'utf8');
+      const wireBytes = jsonStringContentBytes(character);
+      if (
+        chunk.length > 0 &&
+        (chunkRawBytes + rawBytes > this.#options.maxChunkRawBytes ||
+          chunkWireBytes + wireBytes > this.#options.maxChunkWireBytes)
+      ) {
+        this.#chunks.push(chunk);
+        chunk = '';
+        chunkRawBytes = 0;
+        chunkWireBytes = 0;
+      }
+      chunk += character;
+      chunkRawBytes += rawBytes;
+      chunkWireBytes += wireBytes;
+      this.#rawBytes += rawBytes;
+      this.#wireBytes += wireBytes;
+    }
+    if (chunk.length > 0) this.#chunks.push(chunk);
+    this.#trim();
+  }
+
+  value(): string {
+    return this.#chunks.join('');
+  }
+
+  #trim(): void {
+    while (
+      this.#rawBytes > this.#options.maxRawBytes ||
+      this.#wireBytes > this.#options.maxWireBytes
+    ) {
+      const first = this.#chunks[0];
+      if (first === undefined) {
+        this.#rawBytes = 0;
+        this.#wireBytes = 0;
+        return;
+      }
+      const firstRawBytes = Buffer.byteLength(first, 'utf8');
+      const firstWireBytes = jsonStringContentBytes(first);
+      const rawExcess = Math.max(0, this.#rawBytes - this.#options.maxRawBytes);
+      const wireExcess = Math.max(0, this.#wireBytes - this.#options.maxWireBytes);
+      if (firstRawBytes <= rawExcess || firstWireBytes <= wireExcess) {
+        this.#chunks.shift();
+        this.#rawBytes -= firstRawBytes;
+        this.#wireBytes -= firstWireBytes;
+        continue;
+      }
+      const bounded = boundedJsonTextTail(
+        first,
+        firstRawBytes - rawExcess,
+        firstWireBytes - wireExcess,
+      );
+      this.#chunks[0] = bounded;
+      this.#rawBytes += Buffer.byteLength(bounded, 'utf8') - firstRawBytes;
+      this.#wireBytes += jsonStringContentBytes(bounded) - firstWireBytes;
+    }
+  }
+}
+
+export function jsonStringContentBytes(value: string): number {
+  const encoded = JSON.stringify(value);
+  return Buffer.byteLength(encoded.slice(1, -1), 'utf8');
+}
+
+export function boundedJsonTextTail(
+  value: string,
+  maxRawBytes: number,
+  maxWireBytes: number,
+): string {
+  if (
+    Buffer.byteLength(value, 'utf8') <= maxRawBytes &&
+    jsonStringContentBytes(value) <= maxWireBytes
+  ) {
+    return value;
+  }
+  const reversed: string[] = [];
+  let rawBytes = 0;
+  let wireBytes = 0;
+  for (let index = value.length; index > 0; ) {
+    let start = index - 1;
+    const trailing = value.charCodeAt(start);
+    if (trailing >= 0xdc00 && trailing <= 0xdfff && start > 0) {
+      const leading = value.charCodeAt(start - 1);
+      if (leading >= 0xd800 && leading <= 0xdbff) start -= 1;
+    }
+    const character = value.slice(start, index);
+    const characterRawBytes = Buffer.byteLength(character, 'utf8');
+    const characterWireBytes = jsonStringContentBytes(character);
+    if (
+      rawBytes + characterRawBytes > maxRawBytes ||
+      wireBytes + characterWireBytes > maxWireBytes
+    ) {
+      break;
+    }
+    reversed.push(character);
+    rawBytes += characterRawBytes;
+    wireBytes += characterWireBytes;
+    index = start;
+  }
+  return reversed.reverse().join('');
+}

--- a/packages/runtime-host/src/server/operation-dispatcher.ts
+++ b/packages/runtime-host/src/server/operation-dispatcher.ts
@@ -62,9 +62,10 @@ export type SessionRetirementOperationKey = Extract<
   OperationKey,
   'session.lifecycle.set' | 'session.remove'
 >;
+export type SessionTranscriptOperationKey = Extract<OperationKey, 'session.transcript.query'>;
 export type SessionCatalogOperationKey = Exclude<
   Extract<OperationKey, `session.${string}`>,
-  SessionRevisionOperationKey | SessionRetirementOperationKey
+  SessionRevisionOperationKey | SessionRetirementOperationKey | SessionTranscriptOperationKey
 >;
 export type TaskLedgerOperationKey = Extract<OperationKey, 'task.ledger.query'>;
 export type ArtifactOperationKey = Extract<OperationKey, `artifact.${string}`>;
@@ -104,6 +105,10 @@ export type SessionRevisionOperationHandlerMap = Pick<
 export type SessionRetirementOperationHandlerMap = Pick<
   OperationHandlerMap,
   SessionRetirementOperationKey
+>;
+export type SessionTranscriptOperationHandlerMap = Pick<
+  OperationHandlerMap,
+  SessionTranscriptOperationKey
 >;
 export type TaskLedgerOperationHandlerMap = Pick<OperationHandlerMap, TaskLedgerOperationKey>;
 export type ArtifactOperationHandlerMap = Pick<OperationHandlerMap, ArtifactOperationKey>;

--- a/packages/runtime-host/src/server/session-continuity-coordinator.ts
+++ b/packages/runtime-host/src/server/session-continuity-coordinator.ts
@@ -30,6 +30,10 @@ import type {
 const MAX_CONNECTION_SUBSCRIPTIONS = 16;
 const MAX_SUBSCRIBER_QUEUED_FRAMES = 32;
 const MAX_SUBSCRIBER_QUEUED_BYTES = 256 * 1024;
+const MAX_LIVE_REPLAY_ITEMS = 8;
+const MAX_LIVE_REPLAY_RETAINED_BYTES = 96 * 1024;
+const MAX_LIVE_REPLAY_ASSISTANT_BYTES = 64 * 1024;
+const MAX_LIVE_REPLAY_ASSISTANT_WIRE_BYTES = 80 * 1024;
 
 export type { CanonicalSessionProjection } from './canonical-session-projection.js';
 
@@ -54,7 +58,25 @@ interface SessionProjectionState {
   canonical: CanonicalSessionProjection;
   revision: number;
   subscribers: Map<string, Subscriber>;
+  liveReplay?: LiveTurnReplay;
   terminalPublicationFence?: TerminalPublicationFence;
+}
+
+type LiveReplayItem =
+  | {
+      readonly kind: 'assistant_delta';
+      readonly delta: Omit<SessionAssistantDelta, 'text'>;
+      chunks: string[];
+      textBytes: number;
+      wireTextBytes: number;
+    }
+  | { readonly kind: 'tool_event'; readonly event: SessionToolEvent };
+
+interface LiveTurnReplay {
+  readonly turnId: string;
+  readonly runId: string;
+  items: LiveReplayItem[];
+  retainedBytes: number;
 }
 
 interface TerminalPublicationFence {
@@ -271,6 +293,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
         const snapshot = createSessionContinuitySnapshot(canonical, nextRevision);
         state.canonical = canonical;
         state.revision = nextRevision;
+        delete state.liveReplay;
         delete state.terminalPublicationFence;
         this.#broadcastProjection(state, snapshot);
         if (state.subscribers.size === 0) this.#sessions.delete(sessionId);
@@ -299,7 +322,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     }
     await this.sessionAdmission.run(sessionId, () => {
       const state = this.#sessions.get(sessionId);
-      if (!state || state.subscribers.size === 0) return;
+      if (!state) return;
       const rootTurn = state.canonical.rootTurn;
       if (
         !rootTurn ||
@@ -312,14 +335,37 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
         throw new Error('Runtime event does not belong to the canonical active root Turn');
       }
       if (event.type === 'text_delta' || event.type === 'thinking_delta') {
-        const kind: SessionAssistantDelta['kind'] =
-          event.type === 'text_delta' ? 'text' : 'thinking';
+        const delta: SessionAssistantDelta = {
+          kind: event.type === 'text_delta' ? 'text' : 'thinking',
+          turnId: event.turnId,
+          runId,
+          messageId: event.messageId,
+          text: event.text,
+        };
+        const replayText = boundedJsonTextTail(
+          delta.text,
+          MAX_LIVE_REPLAY_ASSISTANT_BYTES,
+          MAX_LIVE_REPLAY_ASSISTANT_WIRE_BYTES,
+        );
+        this.#recordLiveReplay(state, rootTurn, {
+          kind: 'assistant_delta',
+          delta: {
+            kind: delta.kind,
+            turnId: delta.turnId,
+            runId: delta.runId,
+            messageId: delta.messageId,
+          },
+          chunks: [replayText],
+          textBytes: Buffer.byteLength(replayText, 'utf8'),
+          wireTextBytes: jsonStringContentBytes(replayText),
+        });
         for (const subscriber of state.subscribers.values()) {
-          this.#enqueueAssistantDelta(subscriber, sessionId, runId, event, kind);
+          this.#enqueueAssistantDelta(subscriber, sessionId, delta);
         }
         return;
       }
       const projected = projectToolEvent(event);
+      this.#recordLiveReplay(state, rootTurn, { kind: 'tool_event', event: projected });
       for (const subscriber of state.subscribers.values()) {
         const frame: SessionEventFrame = {
           kind: 'subscription.session_event',
@@ -425,12 +471,14 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
         committed.state.subscribers.set(subscriptionId, subscriber);
         this.#subscriptions.set(subscriptionId, subscriber);
         connection.subscriptionIds.add(subscriptionId);
+        const nextSequence = subscriber.nextSequence;
+        this.#enqueueLiveReplay(subscriber, committed.state.liveReplay);
         return {
           ok: true as const,
           value: {
             hostEpoch: this.#hostEpoch,
             subscriptionId,
-            nextSequence: subscriber.nextSequence,
+            nextSequence,
             snapshot: committed.value,
           },
         };
@@ -529,9 +577,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
   #enqueueAssistantDelta(
     subscriber: Subscriber,
     sessionId: string,
-    runId: string,
-    event: Extract<RuntimeSessionTransientEvent, { type: 'text_delta' | 'thinking_delta' }>,
-    kind: SessionAssistantDelta['kind'],
+    delta: SessionAssistantDelta,
   ): void {
     let chunk = '';
     let rawBytes = 0;
@@ -542,10 +588,10 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
       subscriptionId: subscriber.subscriptionId,
       sequence: subscriber.nextSequence,
       sessionId,
-      delta: { kind, turnId: event.turnId, runId, messageId: event.messageId, text },
+      delta: { ...delta, text },
     });
     let wireLimit = wireTextByteLimit(frame(''));
-    for (const character of event.text) {
+    for (const character of delta.text) {
       const rawCharacterBytes = Buffer.byteLength(character, 'utf8');
       const wireCharacterBytes = jsonStringContentBytes(character);
       if (
@@ -591,6 +637,56 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
     subscriber.nextSequence += 1;
     subscriber.terminalQueued = true;
     if (subscriber.activated) this.#pump(subscriber);
+  }
+
+  #enqueueLiveReplay(subscriber: Subscriber, replay: LiveTurnReplay | undefined): void {
+    if (!replay) return;
+    for (const item of replay.items) {
+      if (item.kind === 'assistant_delta') {
+        this.#enqueueAssistantDelta(subscriber, subscriber.sessionId, {
+          ...item.delta,
+          text: item.chunks.join(''),
+        });
+      } else {
+        this.#enqueue(subscriber, {
+          kind: 'subscription.session_event',
+          hostEpoch: this.#hostEpoch,
+          subscriptionId: subscriber.subscriptionId,
+          sequence: subscriber.nextSequence,
+          sessionId: subscriber.sessionId,
+          runId: replay.runId,
+          event: item.event,
+        });
+      }
+      if (subscriber.phase !== 'open') return;
+    }
+  }
+
+  #recordLiveReplay(
+    state: SessionProjectionState,
+    rootTurn: TurnSnapshot,
+    item: LiveReplayItem,
+  ): void {
+    let replay = state.liveReplay;
+    if (!replay || replay.turnId !== rootTurn.turnId || replay.runId !== rootTurn.runId) {
+      replay = {
+        turnId: rootTurn.turnId,
+        runId: rootTurn.runId,
+        items: [],
+        retainedBytes: 0,
+      };
+      state.liveReplay = replay;
+    }
+    const previous = replay.items.at(-1);
+    if (!previous || !mergeLiveReplayItems(previous, item)) replay.items.push(item);
+    replay.retainedBytes = liveReplayBytes(replay.items);
+    while (
+      replay.items.length > MAX_LIVE_REPLAY_ITEMS ||
+      replay.retainedBytes > MAX_LIVE_REPLAY_RETAINED_BYTES
+    ) {
+      replay.items.shift();
+      replay.retainedBytes = liveReplayBytes(replay.items);
+    }
   }
 
   #pump(subscriber: Subscriber): void {
@@ -653,7 +749,8 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
       if (
         this.#sessions.get(sessionId) === state &&
         state.subscribers.size === 0 &&
-        !state.terminalPublicationFence
+        !state.terminalPublicationFence &&
+        !isActiveTurn(state.canonical.rootTurn)
       ) {
         this.#sessions.delete(sessionId);
       }
@@ -696,6 +793,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
       const value = createSessionContinuitySnapshot(canonical, nextRevision);
       state.canonical = canonical;
       state.revision = nextRevision;
+      if (!sameActiveTurn(state.liveReplay, canonical.rootTurn)) delete state.liveReplay;
       return { changed, state, value };
     }
     return {
@@ -759,6 +857,74 @@ function deepFreeze<T>(value: T): T {
   if (!value || typeof value !== 'object' || Object.isFrozen(value)) return value;
   for (const child of Object.values(value)) deepFreeze(child);
   return Object.freeze(value);
+}
+
+function mergeLiveReplayItems(previous: LiveReplayItem, next: LiveReplayItem): boolean {
+  if (
+    previous.kind !== 'assistant_delta' ||
+    next.kind !== 'assistant_delta' ||
+    previous.delta.kind !== next.delta.kind ||
+    previous.delta.turnId !== next.delta.turnId ||
+    previous.delta.runId !== next.delta.runId ||
+    previous.delta.messageId !== next.delta.messageId
+  ) {
+    return false;
+  }
+  previous.chunks.push(...next.chunks);
+  previous.textBytes += next.textBytes;
+  previous.wireTextBytes += next.wireTextBytes;
+  trimLiveAssistantReplay(previous);
+  return true;
+}
+
+function liveReplayBytes(items: readonly LiveReplayItem[]): number {
+  return items.reduce((total, item) => {
+    if (item.kind === 'assistant_delta') {
+      return total + item.wireTextBytes + Buffer.byteLength(JSON.stringify(item.delta), 'utf8');
+    }
+    return total + Buffer.byteLength(JSON.stringify(item.event), 'utf8');
+  }, 0);
+}
+
+function trimLiveAssistantReplay(item: Extract<LiveReplayItem, { kind: 'assistant_delta' }>): void {
+  while (
+    item.textBytes > MAX_LIVE_REPLAY_ASSISTANT_BYTES ||
+    item.wireTextBytes > MAX_LIVE_REPLAY_ASSISTANT_WIRE_BYTES
+  ) {
+    const first = item.chunks[0];
+    if (first === undefined) {
+      item.textBytes = 0;
+      item.wireTextBytes = 0;
+      return;
+    }
+    const firstBytes = Buffer.byteLength(first, 'utf8');
+    const firstWireBytes = jsonStringContentBytes(first);
+    const rawExcess = Math.max(0, item.textBytes - MAX_LIVE_REPLAY_ASSISTANT_BYTES);
+    const wireExcess = Math.max(0, item.wireTextBytes - MAX_LIVE_REPLAY_ASSISTANT_WIRE_BYTES);
+    if (firstBytes <= rawExcess || firstWireBytes <= wireExcess) {
+      item.chunks.shift();
+      item.textBytes -= firstBytes;
+      item.wireTextBytes -= firstWireBytes;
+      continue;
+    }
+    const bounded = boundedJsonTextTail(first, firstBytes - rawExcess, firstWireBytes - wireExcess);
+    item.chunks[0] = bounded;
+    item.textBytes += Buffer.byteLength(bounded, 'utf8') - firstBytes;
+    item.wireTextBytes += jsonStringContentBytes(bounded) - firstWireBytes;
+  }
+}
+
+function sameActiveTurn(replay: LiveTurnReplay | undefined, turn: TurnSnapshot | null): boolean {
+  return (
+    replay !== undefined &&
+    isActiveTurn(turn) &&
+    replay.turnId === turn.turnId &&
+    replay.runId === turn.runId
+  );
+}
+
+function isActiveTurn(turn: TurnSnapshot | null): turn is TurnSnapshot {
+  return turn !== null && !isTerminalTurn(turn);
 }
 
 function requirePublicationFenceIdentity(
@@ -855,4 +1021,30 @@ function boundedUtf8(value: string, maxBytes: number): string {
     bytes += characterBytes;
   }
   return bounded;
+}
+
+function boundedJsonTextTail(value: string, maxRawBytes: number, maxWireBytes: number): string {
+  if (
+    Buffer.byteLength(value, 'utf8') <= maxRawBytes &&
+    jsonStringContentBytes(value) <= maxWireBytes
+  ) {
+    return value;
+  }
+  const characters: string[] = [];
+  let rawBytes = 0;
+  let wireBytes = 0;
+  for (const character of Array.from(value).reverse()) {
+    const rawCharacterBytes = Buffer.byteLength(character, 'utf8');
+    const wireCharacterBytes = jsonStringContentBytes(character);
+    if (
+      rawBytes + rawCharacterBytes > maxRawBytes ||
+      wireBytes + wireCharacterBytes > maxWireBytes
+    ) {
+      break;
+    }
+    characters.push(character);
+    rawBytes += rawCharacterBytes;
+    wireBytes += wireCharacterBytes;
+  }
+  return characters.reverse().join('');
 }

--- a/packages/runtime-host/src/server/session-continuity-coordinator.ts
+++ b/packages/runtime-host/src/server/session-continuity-coordinator.ts
@@ -26,6 +26,11 @@ import type {
   SessionContinuityFrameSink,
   SessionContinuityService,
 } from './session-continuity-service.js';
+import {
+  boundedJsonTextTail,
+  jsonStringContentBytes,
+  LiveAssistantReplayBuffer,
+} from './live-assistant-replay-buffer.js';
 
 const MAX_CONNECTION_SUBSCRIPTIONS = 16;
 const MAX_SUBSCRIBER_QUEUED_FRAMES = 32;
@@ -34,6 +39,8 @@ const MAX_LIVE_REPLAY_ITEMS = 8;
 const MAX_LIVE_REPLAY_RETAINED_BYTES = 96 * 1024;
 const MAX_LIVE_REPLAY_ASSISTANT_BYTES = 64 * 1024;
 const MAX_LIVE_REPLAY_ASSISTANT_WIRE_BYTES = 80 * 1024;
+const MAX_LIVE_REPLAY_CHUNK_BYTES = 4 * 1024;
+const MAX_LIVE_REPLAY_CHUNK_WIRE_BYTES = 5 * 1024;
 
 export type { CanonicalSessionProjection } from './canonical-session-projection.js';
 
@@ -66,9 +73,7 @@ type LiveReplayItem =
   | {
       readonly kind: 'assistant_delta';
       readonly delta: Omit<SessionAssistantDelta, 'text'>;
-      chunks: string[];
-      textBytes: number;
-      wireTextBytes: number;
+      readonly text: LiveAssistantReplayBuffer;
     }
   | { readonly kind: 'tool_event'; readonly event: SessionToolEvent };
 
@@ -355,9 +360,15 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
             runId: delta.runId,
             messageId: delta.messageId,
           },
-          chunks: [replayText],
-          textBytes: Buffer.byteLength(replayText, 'utf8'),
-          wireTextBytes: jsonStringContentBytes(replayText),
+          text: new LiveAssistantReplayBuffer(
+            {
+              maxRawBytes: MAX_LIVE_REPLAY_ASSISTANT_BYTES,
+              maxWireBytes: MAX_LIVE_REPLAY_ASSISTANT_WIRE_BYTES,
+              maxChunkRawBytes: MAX_LIVE_REPLAY_CHUNK_BYTES,
+              maxChunkWireBytes: MAX_LIVE_REPLAY_CHUNK_WIRE_BYTES,
+            },
+            replayText,
+          ),
         });
         for (const subscriber of state.subscribers.values()) {
           this.#enqueueAssistantDelta(subscriber, sessionId, delta);
@@ -645,7 +656,7 @@ export class SessionContinuityCoordinator implements SessionContinuityService {
       if (item.kind === 'assistant_delta') {
         this.#enqueueAssistantDelta(subscriber, subscriber.sessionId, {
           ...item.delta,
-          text: item.chunks.join(''),
+          text: item.text.value(),
         });
       } else {
         this.#enqueue(subscriber, {
@@ -870,48 +881,17 @@ function mergeLiveReplayItems(previous: LiveReplayItem, next: LiveReplayItem): b
   ) {
     return false;
   }
-  previous.chunks.push(...next.chunks);
-  previous.textBytes += next.textBytes;
-  previous.wireTextBytes += next.wireTextBytes;
-  trimLiveAssistantReplay(previous);
+  previous.text.append(next.text.value());
   return true;
 }
 
 function liveReplayBytes(items: readonly LiveReplayItem[]): number {
   return items.reduce((total, item) => {
     if (item.kind === 'assistant_delta') {
-      return total + item.wireTextBytes + Buffer.byteLength(JSON.stringify(item.delta), 'utf8');
+      return total + item.text.wireBytes + Buffer.byteLength(JSON.stringify(item.delta), 'utf8');
     }
     return total + Buffer.byteLength(JSON.stringify(item.event), 'utf8');
   }, 0);
-}
-
-function trimLiveAssistantReplay(item: Extract<LiveReplayItem, { kind: 'assistant_delta' }>): void {
-  while (
-    item.textBytes > MAX_LIVE_REPLAY_ASSISTANT_BYTES ||
-    item.wireTextBytes > MAX_LIVE_REPLAY_ASSISTANT_WIRE_BYTES
-  ) {
-    const first = item.chunks[0];
-    if (first === undefined) {
-      item.textBytes = 0;
-      item.wireTextBytes = 0;
-      return;
-    }
-    const firstBytes = Buffer.byteLength(first, 'utf8');
-    const firstWireBytes = jsonStringContentBytes(first);
-    const rawExcess = Math.max(0, item.textBytes - MAX_LIVE_REPLAY_ASSISTANT_BYTES);
-    const wireExcess = Math.max(0, item.wireTextBytes - MAX_LIVE_REPLAY_ASSISTANT_WIRE_BYTES);
-    if (firstBytes <= rawExcess || firstWireBytes <= wireExcess) {
-      item.chunks.shift();
-      item.textBytes -= firstBytes;
-      item.wireTextBytes -= firstWireBytes;
-      continue;
-    }
-    const bounded = boundedJsonTextTail(first, firstBytes - rawExcess, firstWireBytes - wireExcess);
-    item.chunks[0] = bounded;
-    item.textBytes += Buffer.byteLength(bounded, 'utf8') - firstBytes;
-    item.wireTextBytes += jsonStringContentBytes(bounded) - firstWireBytes;
-  }
 }
 
 function sameActiveTurn(replay: LiveTurnReplay | undefined, turn: TurnSnapshot | null): boolean {
@@ -951,11 +931,6 @@ function isTerminalTurn(turn: TurnSnapshot): boolean {
 
 function wireTextByteLimit(frame: SessionDeltaFrame): number {
   return RUNTIME_HOST_MAX_FRAME_BYTES - encodeProtocolFrame(frame).byteLength;
-}
-
-function jsonStringContentBytes(value: string): number {
-  const encoded = JSON.stringify(value);
-  return Buffer.byteLength(encoded.slice(1, -1), 'utf8');
 }
 
 function projectToolEvent(
@@ -1021,30 +996,4 @@ function boundedUtf8(value: string, maxBytes: number): string {
     bytes += characterBytes;
   }
   return bounded;
-}
-
-function boundedJsonTextTail(value: string, maxRawBytes: number, maxWireBytes: number): string {
-  if (
-    Buffer.byteLength(value, 'utf8') <= maxRawBytes &&
-    jsonStringContentBytes(value) <= maxWireBytes
-  ) {
-    return value;
-  }
-  const characters: string[] = [];
-  let rawBytes = 0;
-  let wireBytes = 0;
-  for (const character of Array.from(value).reverse()) {
-    const rawCharacterBytes = Buffer.byteLength(character, 'utf8');
-    const wireCharacterBytes = jsonStringContentBytes(character);
-    if (
-      rawBytes + rawCharacterBytes > maxRawBytes ||
-      wireBytes + wireCharacterBytes > maxWireBytes
-    ) {
-      break;
-    }
-    characters.push(character);
-    rawBytes += rawCharacterBytes;
-    wireBytes += wireCharacterBytes;
-  }
-  return characters.reverse().join('');
 }

--- a/packages/runtime-host/src/server/session-transcript-coordinator.ts
+++ b/packages/runtime-host/src/server/session-transcript-coordinator.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from 'node:crypto';
 import { isSessionNotFoundError, type ExecutionStoresWriter } from '@maka/storage/execution-stores';
 import {
   decodeExecutionBoundary,
@@ -19,6 +20,20 @@ type SessionTranscriptStore = Pick<
   ExecutionStoresWriter<'interactive'>['sessionStore'],
   'readExecutionBoundary' | 'readHeaderRecordSnapshot' | 'readMessagesSnapshot'
 >;
+
+const MAX_TRANSCRIPT_SNAPSHOTS = 8;
+export const MAX_TRANSCRIPT_SNAPSHOT_BYTES = 16 * 1024 * 1024;
+const TRANSCRIPT_SNAPSHOT_IDLE_MS = 60_000;
+
+interface TranscriptSnapshot {
+  readonly id: string;
+  readonly sessionId: string;
+  readonly revision: number;
+  readonly boundaryRevision: number;
+  readonly messages: readonly Buffer[];
+  readonly encodedBytes: number;
+  lastAccessAt: number;
+}
 
 export interface HostSessionTranscriptCoordinatorOptions {
   readonly store: SessionTranscriptStore;
@@ -44,6 +59,8 @@ export class HostSessionTranscriptCoordinator {
   };
 
   readonly #options: HostSessionTranscriptCoordinatorOptions;
+  readonly #snapshots = new Map<string, TranscriptSnapshot>();
+  #snapshotCleanupTimer: NodeJS.Timeout | undefined;
 
   constructor(options: HostSessionTranscriptCoordinatorOptions) {
     this.#options = options;
@@ -61,6 +78,7 @@ export class HostSessionTranscriptCoordinator {
         input.kind === 'continue' &&
         (record.revision !== input.revision || boundary.revision !== input.boundaryRevision)
       ) {
+        this.#snapshots.delete(input.snapshotId);
         return success({
           kind: 'revision_changed',
           expectedRevision: input.revision,
@@ -69,20 +87,63 @@ export class HostSessionTranscriptCoordinator {
           actualBoundaryRevision: boundary.revision,
         });
       }
-      const messages = await this.#options.store.readMessagesSnapshot(input.sessionId);
+      let snapshot: TranscriptSnapshot;
+      if (input.kind === 'start') {
+        const messages = await this.#options.store.readMessagesSnapshot(input.sessionId);
+        const encodedMessages: Buffer[] = [];
+        let encodedBytes = 0;
+        for (const message of messages) {
+          const encoded = Buffer.from(JSON.stringify(message), 'utf8');
+          encodedBytes += encoded.byteLength;
+          if (encodedBytes > MAX_TRANSCRIPT_SNAPSHOT_BYTES) {
+            return {
+              ok: false,
+              error: {
+                code: 'operation_unavailable',
+                message: 'Session transcript exceeds the live snapshot byte limit',
+              },
+            };
+          }
+          encodedMessages.push(encoded);
+        }
+        snapshot = {
+          id: randomUUID(),
+          sessionId: input.sessionId,
+          revision: record.revision,
+          boundaryRevision: boundary.revision,
+          messages: encodedMessages,
+          encodedBytes,
+          lastAccessAt: Date.now(),
+        };
+        this.#retainSnapshot(snapshot);
+      } else {
+        const retained = this.#snapshots.get(input.snapshotId);
+        if (
+          !retained ||
+          retained.sessionId !== input.sessionId ||
+          retained.revision !== input.revision ||
+          retained.boundaryRevision !== input.boundaryRevision
+        ) {
+          return success({ kind: 'snapshot_expired', snapshotId: input.snapshotId });
+        }
+        retained.lastAccessAt = Date.now();
+        snapshot = retained;
+      }
       const cursor: SessionTranscriptCursor =
         input.kind === 'start'
           ? { messageIndex: 0, byteOffset: 0 }
           : { messageIndex: input.messageIndex, byteOffset: input.byteOffset };
       if (
-        cursor.messageIndex > messages.length ||
-        (cursor.messageIndex === messages.length && cursor.byteOffset !== 0)
+        cursor.messageIndex > snapshot.messages.length ||
+        (cursor.messageIndex === snapshot.messages.length && cursor.byteOffset !== 0)
       ) {
         return invalidQuery('Session transcript cursor is invalid');
       }
-      if (messages.length === 0) {
+      if (snapshot.messages.length === 0) {
+        this.#snapshots.delete(snapshot.id);
         return success({
           kind: 'chunk',
+          snapshotId: snapshot.id,
           revision: record.revision,
           boundary: projectSessionExecutionBoundary(boundary),
           messageCount: 0,
@@ -92,11 +153,12 @@ export class HostSessionTranscriptCoordinator {
           next: null,
         });
       }
-      if (cursor.messageIndex === messages.length) {
+      if (cursor.messageIndex === snapshot.messages.length) {
         return invalidQuery('Session transcript cursor is exhausted');
       }
 
-      const encoded = Buffer.from(JSON.stringify(messages[cursor.messageIndex]), 'utf8');
+      const encoded = snapshot.messages[cursor.messageIndex];
+      if (!encoded) return invalidQuery('Session transcript cursor is invalid');
       if (cursor.byteOffset >= encoded.byteLength) {
         return invalidQuery('Session transcript cursor is invalid');
       }
@@ -107,20 +169,23 @@ export class HostSessionTranscriptCoordinator {
       const next =
         end < encoded.byteLength
           ? { messageIndex: cursor.messageIndex, byteOffset: end }
-          : cursor.messageIndex + 1 < messages.length
+          : cursor.messageIndex + 1 < snapshot.messages.length
             ? { messageIndex: cursor.messageIndex + 1, byteOffset: 0 }
             : null;
+      if (next === null) this.#snapshots.delete(snapshot.id);
       return success({
         kind: 'chunk',
+        snapshotId: snapshot.id,
         revision: record.revision,
         boundary: projectSessionExecutionBoundary(boundary),
-        messageCount: messages.length,
+        messageCount: snapshot.messages.length,
         messageIndex: cursor.messageIndex,
         byteOffset: cursor.byteOffset,
         data: encoded.subarray(cursor.byteOffset, end).toString('base64'),
         next,
       });
     } catch (error) {
+      if (input.kind === 'continue') this.#snapshots.delete(input.snapshotId);
       if (isSessionNotFoundError(error)) {
         return {
           ok: false,
@@ -135,6 +200,54 @@ export class HostSessionTranscriptCoordinator {
         },
       };
     }
+  }
+
+  #retainSnapshot(snapshot: TranscriptSnapshot): void {
+    this.#pruneExpiredSnapshots();
+    this.#snapshots.set(snapshot.id, snapshot);
+    while (
+      this.#snapshots.size > MAX_TRANSCRIPT_SNAPSHOTS ||
+      this.#retainedSnapshotBytes() > MAX_TRANSCRIPT_SNAPSHOT_BYTES
+    ) {
+      const oldest = [...this.#snapshots.values()]
+        .filter((candidate) => candidate.id !== snapshot.id)
+        .sort((left, right) => left.lastAccessAt - right.lastAccessAt)[0];
+      if (!oldest) break;
+      this.#snapshots.delete(oldest.id);
+    }
+    this.#scheduleSnapshotCleanup();
+  }
+
+  #retainedSnapshotBytes(): number {
+    let total = 0;
+    for (const snapshot of this.#snapshots.values()) total += snapshot.encodedBytes;
+    return total;
+  }
+
+  #pruneExpiredSnapshots(): void {
+    const now = Date.now();
+    for (const [id, retained] of this.#snapshots) {
+      if (now - retained.lastAccessAt >= TRANSCRIPT_SNAPSHOT_IDLE_MS) this.#snapshots.delete(id);
+    }
+  }
+
+  #scheduleSnapshotCleanup(): void {
+    if (this.#snapshotCleanupTimer) clearTimeout(this.#snapshotCleanupTimer);
+    this.#snapshotCleanupTimer = undefined;
+    let expiresAt = Number.POSITIVE_INFINITY;
+    for (const snapshot of this.#snapshots.values()) {
+      expiresAt = Math.min(expiresAt, snapshot.lastAccessAt + TRANSCRIPT_SNAPSHOT_IDLE_MS);
+    }
+    if (!Number.isFinite(expiresAt)) return;
+    this.#snapshotCleanupTimer = setTimeout(
+      () => {
+        this.#snapshotCleanupTimer = undefined;
+        this.#pruneExpiredSnapshots();
+        this.#scheduleSnapshotCleanup();
+      },
+      Math.max(0, expiresAt - Date.now()),
+    );
+    this.#snapshotCleanupTimer.unref();
   }
 }
 

--- a/packages/runtime-host/src/server/session-transcript-coordinator.ts
+++ b/packages/runtime-host/src/server/session-transcript-coordinator.ts
@@ -1,0 +1,149 @@
+import { isSessionNotFoundError, type ExecutionStoresWriter } from '@maka/storage/execution-stores';
+import {
+  decodeExecutionBoundary,
+  executionBoundaryDisplayMode,
+  type ExecutionBoundary,
+} from '@maka/core/sandbox-boundary';
+import {
+  SESSION_TRANSCRIPT_CHUNK_MAX_BYTES,
+  type OperationOutcome,
+  type SessionExecutionBoundaryProjection,
+  type SessionTranscriptCursor,
+  type SessionTranscriptQueryInput,
+  type SessionTranscriptQueryResult,
+} from '../protocol/index.js';
+import type { SessionTranscriptOperationHandlerMap } from './operation-dispatcher.js';
+import { SessionAdmissionGate } from './session-admission-gate.js';
+
+type SessionTranscriptStore = Pick<
+  ExecutionStoresWriter<'interactive'>['sessionStore'],
+  'readExecutionBoundary' | 'readHeaderRecordSnapshot' | 'readMessagesSnapshot'
+>;
+
+export interface HostSessionTranscriptCoordinatorOptions {
+  readonly store: SessionTranscriptStore;
+  readonly admission: SessionAdmissionGate;
+}
+
+function projectSessionExecutionBoundary(
+  boundary: ExecutionBoundary,
+): SessionExecutionBoundaryProjection {
+  const decoded = decodeExecutionBoundary(boundary);
+  return {
+    kind: decoded.kind,
+    revision: decoded.revision,
+    displayMode: executionBoundaryDisplayMode(decoded) ?? null,
+  };
+}
+
+/** Host-owned, revision-pinned projection of the durable Session transcript. */
+export class HostSessionTranscriptCoordinator {
+  readonly handlers: SessionTranscriptOperationHandlerMap = {
+    'session.transcript.query': (input) =>
+      this.#options.admission.run(input.sessionId, () => this.#query(input)),
+  };
+
+  readonly #options: HostSessionTranscriptCoordinatorOptions;
+
+  constructor(options: HostSessionTranscriptCoordinatorOptions) {
+    this.#options = options;
+  }
+
+  async #query(
+    input: SessionTranscriptQueryInput,
+  ): Promise<OperationOutcome<'session.transcript.query'>> {
+    try {
+      const [record, boundary] = await Promise.all([
+        this.#options.store.readHeaderRecordSnapshot(input.sessionId),
+        this.#options.store.readExecutionBoundary(input.sessionId),
+      ]);
+      if (
+        input.kind === 'continue' &&
+        (record.revision !== input.revision || boundary.revision !== input.boundaryRevision)
+      ) {
+        return success({
+          kind: 'revision_changed',
+          expectedRevision: input.revision,
+          actualRevision: record.revision,
+          expectedBoundaryRevision: input.boundaryRevision,
+          actualBoundaryRevision: boundary.revision,
+        });
+      }
+      const messages = await this.#options.store.readMessagesSnapshot(input.sessionId);
+      const cursor: SessionTranscriptCursor =
+        input.kind === 'start'
+          ? { messageIndex: 0, byteOffset: 0 }
+          : { messageIndex: input.messageIndex, byteOffset: input.byteOffset };
+      if (
+        cursor.messageIndex > messages.length ||
+        (cursor.messageIndex === messages.length && cursor.byteOffset !== 0)
+      ) {
+        return invalidQuery('Session transcript cursor is invalid');
+      }
+      if (messages.length === 0) {
+        return success({
+          kind: 'chunk',
+          revision: record.revision,
+          boundary: projectSessionExecutionBoundary(boundary),
+          messageCount: 0,
+          messageIndex: 0,
+          byteOffset: 0,
+          data: '',
+          next: null,
+        });
+      }
+      if (cursor.messageIndex === messages.length) {
+        return invalidQuery('Session transcript cursor is exhausted');
+      }
+
+      const encoded = Buffer.from(JSON.stringify(messages[cursor.messageIndex]), 'utf8');
+      if (cursor.byteOffset >= encoded.byteLength) {
+        return invalidQuery('Session transcript cursor is invalid');
+      }
+      const end = Math.min(
+        encoded.byteLength,
+        cursor.byteOffset + SESSION_TRANSCRIPT_CHUNK_MAX_BYTES,
+      );
+      const next =
+        end < encoded.byteLength
+          ? { messageIndex: cursor.messageIndex, byteOffset: end }
+          : cursor.messageIndex + 1 < messages.length
+            ? { messageIndex: cursor.messageIndex + 1, byteOffset: 0 }
+            : null;
+      return success({
+        kind: 'chunk',
+        revision: record.revision,
+        boundary: projectSessionExecutionBoundary(boundary),
+        messageCount: messages.length,
+        messageIndex: cursor.messageIndex,
+        byteOffset: cursor.byteOffset,
+        data: encoded.subarray(cursor.byteOffset, end).toString('base64'),
+        next,
+      });
+    } catch (error) {
+      if (isSessionNotFoundError(error)) {
+        return {
+          ok: false,
+          error: { code: 'not_found', message: 'Session does not exist' },
+        };
+      }
+      return {
+        ok: false,
+        error: {
+          code: 'persistence_failed',
+          message: 'Session transcript is unavailable',
+        },
+      };
+    }
+  }
+}
+
+function success(
+  result: SessionTranscriptQueryResult,
+): OperationOutcome<'session.transcript.query'> {
+  return { ok: true, result };
+}
+
+function invalidQuery(message: string): OperationOutcome<'session.transcript.query'> {
+  return { ok: false, error: { code: 'invalid_request', message } };
+}


### PR DESCRIPTION
<details open>
<summary><strong>English</strong></summary>

## Summary

Add a Runtime Host-backed TUI adapter and an isolated executable harness, allowing the CLI to act as an independent client of shared Session authority.

The adapter maps TUI operations onto Runtime Host protocols, projects durable transcripts and live observations into the existing CLI model, and preserves local TUI behavior while another client is driving the same Session.

## Shared Session behavior

- Observe and render turns started by another client.
- Join an active turn through a bounded semantic replay followed by live frames, with an atomic cut that avoids gaps and duplicates.
- Converge explicitly across active, idle, and unavailable observation states so a local fallback is not silently lost during handoff or failure.
- Keep stop, interrupt, and activity state coherent across overlapping local, remote, and control operations.

## Runtime Host transcript and replay

- Add a bounded v0 transcript query with revision-pinned continuation leases.
- Bound replay by both UTF-8 content and encoded wire size while preserving Unicode code points.
- Provide an isolated, execution-capable harness for integration and multi-client testing.

## Boundaries

- This does not cut the normal CLI over to Runtime Host yet.
- Compaction and working-directory changes are not exposed through this adapter yet.
- Desktop activation remains a separate slice.
- The wire protocol remains v0 before the first public release.

## Validation

- Runtime Host tests: 566/566 passed.
- CLI tests: 493/493 passed.
- Workspace build and typecheck passed.
- Biome format and lint checks passed.
- Diff and credential hygiene checks passed.
- A real three-TUI `openrouter/free` scenario verified mid-stream joining from the replayed start through the live terminal frame.

Part of #1167 and #853.

</details>

<details>
<summary><strong>中文</strong></summary>

## 概要

新增基于 Runtime Host 的 TUI 适配器和隔离的可执行测试入口，使 CLI 可以作为共享 Session 权威状态的独立客户端运行。

该适配器把 TUI 操作映射到 Runtime Host 协议，将持久 transcript 和实时 observation 投影到现有 CLI 模型；当另一个客户端正在驱动同一 Session 时，也能保持本地 TUI 行为一致。

## 共享 Session 行为

- 观察并渲染由其他客户端发起的 turn。
- 在 turn 执行期间加入时，先接收有界的语义回放，再衔接实时帧；通过原子切点避免缺失或重复。
- 明确区分 active、idle 和 unavailable 状态，避免客户端交接或 observation 故障时静默丢失本地 fallback。
- 在本地、远端和控制操作重叠时，保持 stop、interrupt 和 activity 状态一致。

## Runtime Host transcript 与回放

- 新增有界的 v0 transcript 查询和固定 revision 的 continuation lease。
- 同时按 UTF-8 内容和编码后 wire 大小限制回放，并保持 Unicode code point 完整。
- 提供隔离、可执行的 harness，用于集成和多客户端测试。

## 边界

- 本 PR 尚未把常规 CLI 切换到 Runtime Host。
- 该适配器暂未暴露 compaction 和工作目录切换。
- Desktop 激活仍是独立 slice。
- 首次公开发布前，wire protocol 继续保持 v0。

## 验证

- Runtime Host 测试：566/566 通过。
- CLI 测试：493/493 通过。
- Workspace build 与 typecheck 通过。
- Biome format 与 lint 检查通过。
- Diff 与凭据卫生检查通过。
- 使用 `openrouter/free` 的真实三 TUI 场景验证了执行中途加入：从回放起点连续显示到实时终止帧。

属于 #1167 和 #853 的一部分。

</details>
