### PR TITLE
storage: migrate core execution state to SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ Start with [ARCHITECTURE.md](./ARCHITECTURE.md). It provides the system map, cod
 apps/desktop/       Electron main / preload / React renderer
 
 packages/core/      Pure contracts for Sessions, Events, Permissions, and Connections
-packages/storage/   File-backed stores and run ledgers
+packages/storage/   SQLite operational state, legacy importers, and payload stores
 packages/runtime/   AgentRun, model adapters, tools, context, and recovery
 packages/headless/  TaskRun, Autonomous Loop, Self-check, eval, and AHE
 packages/cli/       TUI and non-interactive CLI
@@ -184,7 +184,7 @@ Current boundaries that matter:
 
 Read [SECURITY.md](./SECURITY.md) for security reporting and policy, and [docs/README.md](./docs/README.md) for current privacy and sandbox contracts.
 
-## Experimental runtime recovery flag
+## Runtime storage and recovery
 
 RuntimeEvent persistence is always canonical in `runtime.sqlite`. On the first
 write, Maka batch-idempotently imports legacy RuntimeEvent JSONL without
@@ -199,6 +199,16 @@ and result in `cutover_journal`. An interrupted copy resumes without partial
 rows; a legacy database changed after cutover fails closed. The old database is
 retained as migration evidence but is no longer a production writer. Session
 transcript bodies remain append-only JSONL.
+
+Core execution state now shares that authority too: AgentRun headers and event
+ledgers, event projections, root-turn admissions and source proofs,
+Interactions, Host Epoch message receipts, and ShellRun records are canonical
+in `runtime.sqlite` across CLI, Desktop, Runtime Host, and Headless. Each legacy
+file store is fingerprinted and imported through its own durable
+`cutover_journal` entry before the corresponding repository opens. Copy and
+validation are one SQLite transaction, retries are idempotent, and a changed
+legacy source after cutover fails closed. The legacy files are retained only as
+migration evidence; new execution writes do not modify them.
 
 Runtime continuation remains opt-in:
 

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -8,7 +8,7 @@ import {
   createConnectionStore,
   createFileCredentialStore,
   createSessionStore,
-  createShellRunStore,
+  createSqliteShellRunStore,
 } from '@maka/storage';
 import {
   BackendRegistry,
@@ -592,10 +592,10 @@ describe('Maka CLI runtime bootstrap', () => {
         assert.equal(detail.output?.stdout, 'start');
 
         await context.close();
-        const record = await createShellRunStore(workspaceRoot).readShellRun(
-          'session-1',
-          backgroundTaskId(result.ref),
-        );
+        const shellRuns = createSqliteShellRunStore(workspaceRoot);
+        await shellRuns.ready();
+        const record = await shellRuns.readShellRun('session-1', backgroundTaskId(result.ref));
+        shellRuns.close();
         assert.equal(record.status, 'cancelled');
         assert.equal(record.exitCode, 130);
       } finally {
@@ -744,10 +744,10 @@ describe('Maka CLI runtime bootstrap', () => {
           return snapshot?.result.status === 'completed' ? snapshot : undefined;
         });
         assert.equal(hydrated.result.status, 'completed');
-        const stored = await createShellRunStore(workspaceRoot).readShellRun(
-          'session-1',
-          backgroundTaskId(started.ref),
-        );
+        const shellRuns = createSqliteShellRunStore(workspaceRoot);
+        await shellRuns.ready();
+        const stored = await shellRuns.readShellRun('session-1', backgroundTaskId(started.ref));
+        shellRuns.close();
         assert.equal(stored.observedAt, undefined);
       } finally {
         await context.close();

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -58,7 +58,7 @@ import {
   type ModelMessage,
 } from '@maka/runtime';
 import {
-  createAgentRunStore,
+  createSqliteAgentRunStore,
   createAttachmentByteReader,
   createArtifactStore,
   createAutomationStore,
@@ -70,7 +70,7 @@ import {
   createReadImageSnapshotter,
   createSessionStore,
   createSettingsStore,
-  createShellRunStore,
+  createSqliteShellRunStore,
   assertSessionBundleRootLayout,
   type ForeignSessionStore,
   persistProviderRequestCaptureArtifact,
@@ -222,12 +222,19 @@ export async function createMakaCliRuntimeContext(
   }
   await resolveStorageRoot({ path: stateRoot, kind: 'interactive' });
   const store = createSessionStore(stateRoot);
-  const runStore = createAgentRunStore(stateRoot);
+  const runStore = createSqliteAgentRunStore(stateRoot);
   const runtimePersistence = await openRuntimeEventPersistence({
     workspaceRoot: stateRoot,
   });
   const runtimeEventStore = runtimePersistence.runtimeEventStore;
-  const shellRunStore = createShellRunStore(stateRoot);
+  const shellRunStore = createSqliteShellRunStore(stateRoot);
+  await Promise.all([runStore.ready?.(), shellRunStore.ready()]).catch(async (error) => {
+    await store.close?.().catch(() => {});
+    runtimePersistence.close();
+    runStore.close?.();
+    shellRunStore.close();
+    throw error;
+  });
   const artifactStore = createArtifactStore(stateRoot);
   const agentGraphControlStore = agentGraphEnabled
     ? createAgentGraphControlStore(stateRoot)
@@ -1093,6 +1100,8 @@ export async function createMakaCliRuntimeContext(
       shellRunListeners.clear();
       await store.close?.();
       runtimePersistence.close();
+      runStore.close?.();
+      shellRunStore.close();
     },
   };
 }

--- a/packages/headless/src/__tests__/provider-request-trace.test.ts
+++ b/packages/headless/src/__tests__/provider-request-trace.test.ts
@@ -5,6 +5,7 @@ import { test } from 'node:test';
 import assert from 'node:assert/strict';
 import type { AgentRunEvent, AgentRunHeader } from '@maka/core';
 import type { InvocationResult } from '@maka/runtime';
+import { acquireOperationalStateDatabase } from '@maka/storage';
 
 import { writeHarborTaskRunTrace } from '../harbor-cell.js';
 import { openHeadlessStorageForWrite } from '../headless-storage.js';
@@ -263,11 +264,7 @@ test('exports a torn AgentRun tail as incomplete provider-request evidence', asy
     await runStore.createRun(header);
     await runStore.appendEvent(identity.sessionId, identity.runId, capture as AgentRunEvent);
     await runStore.appendEvent(identity.sessionId, identity.runId, attempt as AgentRunEvent);
-    await writeFile(
-      join(storageRoot, 'sessions', identity.sessionId, 'runs', identity.runId, 'events.jsonl'),
-      '{"type":"provider_request_attempt_recorded"',
-      { flag: 'a' },
-    );
+    corruptAgentRunEvent(storageRoot, identity.sessionId, identity.runId, 1);
 
     const traceEventsPath = await writeHarborTaskRunTrace({
       outputDir,
@@ -322,10 +319,14 @@ test('also diagnoses missing provider evidence when the only run event is corrup
       updatedAt: 4,
       completedAt: 4,
     });
-    await writeFile(
-      join(storageRoot, 'sessions', identity.sessionId, 'runs', identity.runId, 'events.jsonl'),
-      '{"type":"tool_failed"',
-    );
+    await storage.executionStores.agentRunStore.appendEvent(identity.sessionId, identity.runId, {
+      type: 'tool_failed',
+      id: 'corrupt-event',
+      ...identity,
+      ts: 2,
+      message: 'will be corrupted',
+    });
+    corruptAgentRunEvent(storageRoot, identity.sessionId, identity.runId, 0);
 
     const traceEventsPath = await writeHarborTaskRunTrace({
       outputDir,
@@ -346,6 +347,27 @@ test('also diagnoses missing provider evidence when the only run event is corrup
     await rm(root, { recursive: true, force: true });
   }
 });
+
+function corruptAgentRunEvent(
+  storageRoot: string,
+  sessionId: string,
+  runId: string,
+  sequence: number,
+): void {
+  const lease = acquireOperationalStateDatabase(storageRoot);
+  try {
+    const result = lease.database
+      .prepare(`
+        UPDATE core_agent_run_events
+        SET record_json = ?
+        WHERE session_id = ? AND run_id = ? AND sequence = ?
+      `)
+      .run('{"type":"corrupt"', sessionId, runId, sequence);
+    assert.equal(result.changes, 1);
+  } finally {
+    lease.close();
+  }
+}
 
 test('exports missing provider-request evidence for every continuation invocation', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-provider-trace-export-'));

--- a/packages/headless/src/__tests__/task-agent-controller.test.ts
+++ b/packages/headless/src/__tests__/task-agent-controller.test.ts
@@ -21,7 +21,11 @@ import {
 } from '@maka/core';
 import type { BackendSendInput } from '@maka/core/backend-types';
 import type { SandboxBoundaryResponse } from '@maka/core/sandbox-boundary';
-import { createSessionStore, openRuntimeEventReadPersistence } from '@maka/storage';
+import {
+  createSessionStore,
+  createSqliteAgentRunStore,
+  openRuntimeEventReadPersistence,
+} from '@maka/storage';
 import { StorageRootAuthorityError } from '@maka/storage/root-authority';
 import type { Config, Task } from '../contracts.js';
 import { openHeadlessStorageForWrite } from '../headless-storage.js';
@@ -1160,8 +1164,13 @@ async function readAgentRunHeader(
   sessionId: string,
   runId: string,
 ): Promise<AgentRunHeader> {
-  const runPath = join(storageRoot, 'sessions', sessionId, 'runs', runId, 'run.json');
-  return JSON.parse(await readFile(runPath, 'utf8')) as AgentRunHeader;
+  const store = createSqliteAgentRunStore(storageRoot);
+  try {
+    await store.ready?.();
+    return await store.readRun(sessionId, runId);
+  } finally {
+    store.close?.();
+  }
 }
 
 describe('runTaskOnce', () => {

--- a/packages/runtime-host/src/__tests__/canonical-session-projection.test.ts
+++ b/packages/runtime-host/src/__tests__/canonical-session-projection.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -9,6 +9,7 @@ import {
   type ExecutionStoresWriter,
 } from '@maka/storage/execution-stores';
 import type { StoredInteractionRequest } from '@maka/storage/interaction-store';
+import { acquireOperationalStateDatabase } from '@maka/storage';
 import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '@maka/storage/root-authority';
 import { type SessionMessageQueueProjection } from '../protocol/index.js';
 import {
@@ -311,11 +312,26 @@ test('fails closed when the owned tip durable identity changes', async () => {
       sourceMessages: [],
       admittedAt: 10,
     });
-    const admissionPath = join(root, 'sessions', session.id, 'turn-admissions', 'turn-1.json');
-    const original = await readFile(admissionPath, 'utf8');
-    const durable = JSON.parse(original) as Record<string, unknown>;
+    const database = acquireOperationalStateDatabase(root);
+    const row = database.database
+      .prepare(`
+        SELECT admitted_at, record_json
+        FROM core_root_turn_admissions
+        WHERE session_id = ? AND turn_id = 'turn-1'
+      `)
+      .get(session.id) as { admitted_at?: unknown; record_json?: unknown } | undefined;
+    assert.equal(typeof row?.admitted_at, 'number');
+    assert.equal(typeof row?.record_json, 'string');
+    const durable = JSON.parse(row!.record_json as string) as Record<string, unknown>;
 
-    await rm(admissionPath);
+    database.transaction('write', () => {
+      database.database
+        .prepare(`
+          DELETE FROM core_root_turn_admissions
+          WHERE session_id = ? AND turn_id = 'turn-1'
+        `)
+        .run(session.id);
+    });
     const missingReader = new CanonicalSessionProjectionReader({
       stores,
       rootAdmissions,
@@ -323,7 +339,20 @@ test('fails closed when the owned tip durable identity changes', async () => {
     });
     await assert.rejects(() => missingReader.read(session.id), /missing from durable storage/);
 
-    await writeFile(admissionPath, `${JSON.stringify({ ...durable, runId: 'run-drifted' })}\n`);
+    database.transaction('write', () => {
+      database.database
+        .prepare(`
+          INSERT INTO core_root_turn_admissions(
+            session_id, turn_id, admitted_at, record_json
+          ) VALUES (?, 'turn-1', ?, ?)
+        `)
+        .run(
+          session.id,
+          row!.admitted_at as number,
+          JSON.stringify({ ...durable, runId: 'run-drifted' }),
+        );
+    });
+    database.close();
 
     const reader = new CanonicalSessionProjectionReader({
       stores,

--- a/packages/runtime-host/src/__tests__/execution-host.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-host.test.ts
@@ -1,11 +1,20 @@
 import assert from 'node:assert/strict';
 import { fork, type ChildProcess } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { appendFile, chmod, mkdtemp, readFile, readdir, rm, writeFile } from 'node:fs/promises';
+import {
+  appendFile,
+  chmod,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
 import { createServer, type Server } from 'node:http';
 import { connect, type Socket } from 'node:net';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { dirname, join } from 'node:path';
 import { test } from 'node:test';
 import type { AgentRunHeader } from '@maka/core/agent-run';
 import type { MessageContent } from '@maka/core/events';
@@ -1071,6 +1080,7 @@ test('startup recovery imports past a truncated legacy RuntimeEvent tail without
       'recover after a partial RuntimeEvent write',
     );
     const runtimeEventsPath = fixture.runtimeEventsPath(runId);
+    await mkdir(dirname(runtimeEventsPath), { recursive: true });
     await writeFile(runtimeEventsPath, '{"id":"truncated"', 'utf8');
 
     const host = await fixture.startHost();
@@ -1101,6 +1111,7 @@ test('startup recovery fails closed on a complete malformed RuntimeEvent record'
     );
     const runtimeEventsPath = fixture.runtimeEventsPath(runId);
     const malformed = '{"id":"malformed"\n';
+    await mkdir(dirname(runtimeEventsPath), { recursive: true });
     await writeFile(runtimeEventsPath, malformed, 'utf8');
 
     await fixture.expectHostStartupFailure();
@@ -1134,6 +1145,7 @@ test('startup recovery fails closed on a complete malformed AgentRun record', as
     );
     const eventsPath = fixture.eventsPath(runId);
     const malformed = '{"type":"run_started"\n';
+    await mkdir(dirname(eventsPath), { recursive: true });
     await writeFile(eventsPath, malformed, 'utf8');
 
     await fixture.expectHostStartupFailure();

--- a/packages/storage/src/__tests__/execution-stores.test.ts
+++ b/packages/storage/src/__tests__/execution-stores.test.ts
@@ -325,10 +325,11 @@ describe('execution stores', () => {
           'root',
           'source-1.json',
         );
-        await rm(rootProofPath);
+        await assert.rejects(() => stat(rootProofPath), { code: 'ENOENT' });
         assert.equal(
-          await stores.agentRunStore.readRootTurnSourceMessageReceipt(session.id, 'source-1'),
-          undefined,
+          (await stores.agentRunStore.readRootTurnSourceMessageReceipt(session.id, 'source-1'))
+            ?.admission.turnId,
+          'turn-1',
         );
         await stores.agentRunStore.listRootTurnAdmissionsForRecovery(session.id);
         assert.equal(
@@ -343,6 +344,9 @@ describe('execution stores', () => {
           'turn-admissions',
           'not-an-admission',
         );
+        await mkdir(join(root, 'sessions', session.id, 'turn-admissions'), {
+          recursive: true,
+        });
         await writeFile(unrelatedAdmissionEntry, 'unrelated');
         assert.equal(
           (await stores.agentRunStore.readRootTurnSourceMessageReceipt(session.id, 'source-1'))
@@ -428,21 +432,21 @@ describe('execution stores', () => {
 
         const header = runHeader(session.id, first.admission.runId);
         await stores.agentRunStore.createRun(header);
-        const bytes = await readFile(
-          join(root, 'sessions', session.id, 'runs', first.admission.runId, 'run.json'),
-          'utf8',
+        const legacyRunPath = join(
+          root,
+          'sessions',
+          session.id,
+          'runs',
+          first.admission.runId,
+          'run.json',
         );
+        await assert.rejects(() => stat(legacyRunPath), { code: 'ENOENT' });
         await assert.rejects(
           () => stores.agentRunStore.createRun({ ...header, updatedAt: 99 }),
           /Agent run already exists/,
         );
-        assert.equal(
-          await readFile(
-            join(root, 'sessions', session.id, 'runs', first.admission.runId, 'run.json'),
-            'utf8',
-          ),
-          bytes,
-        );
+        assert.deepEqual(await stores.agentRunStore.readRun(session.id, header.runId), header);
+        await assert.rejects(() => stat(legacyRunPath), { code: 'ENOENT' });
       } finally {
         await owner.close();
       }
@@ -1017,8 +1021,12 @@ describe('execution stores', () => {
         );
         assert.equal(first, second);
 
-        await rm(
-          join(root, 'sessions', session.id, 'message-proofs', 'root', `source-${winner}.json`),
+        await assert.rejects(
+          () =>
+            stat(
+              join(root, 'sessions', session.id, 'message-proofs', 'root', `source-${winner}.json`),
+            ),
+          { code: 'ENOENT' },
         );
       } finally {
         await owner.close();
@@ -1348,7 +1356,7 @@ describe('execution stores', () => {
     });
   });
 
-  test('repairs JSONL stores without rewriting the retired RuntimeEvent JSONL', async () => {
+  test('keeps AgentRun and RuntimeEvent legacy JSONL read-only after SQLite cutover', async () => {
     await withRoot(async ({ root }) => {
       const capability = await resolveStorageRoot({
         path: root,
@@ -1378,6 +1386,9 @@ describe('execution stores', () => {
         );
 
         const eventsPath = join(root, 'sessions', session.id, 'runs', header.runId, 'events.jsonl');
+        await mkdir(join(root, 'sessions', session.id, 'runs', header.runId), {
+          recursive: true,
+        });
         await writeFile(
           eventsPath,
           JSON.stringify(runEvent(session.id, header.runId, 'event-1', 12)),
@@ -1398,7 +1409,11 @@ describe('execution stores', () => {
           (await stores.agentRunStore.readEvents(session.id, header.runId)).map(
             (event) => event.id,
           ),
-          ['event-1', 'event-2', 'event-3'],
+          ['event-2', 'event-3'],
+        );
+        assert.equal(
+          await readFile(eventsPath, 'utf8'),
+          `${JSON.stringify(runEvent(session.id, header.runId, 'event-1', 12))}{"type":"run_started"`,
         );
 
         const runtimeEventsPath = join(
@@ -1451,7 +1466,7 @@ describe('execution stores', () => {
           undefined,
         );
 
-        for (const path of [sessionPath, eventsPath]) {
+        for (const path of [sessionPath]) {
           const lines = (await readFile(path, 'utf8')).split('\n').filter(Boolean);
           for (const line of lines) assert.doesNotThrow(() => JSON.parse(line));
         }
@@ -1524,7 +1539,7 @@ describe('execution stores', () => {
     });
   });
 
-  test('strict recovery removes recognizable uncommitted exclusive-create staging', async () => {
+  test('SQLite recovery ignores and preserves retired file-store staging artifacts', async () => {
     await withRoot(async ({ root }) => {
       const capability = await resolveStorageRoot({
         path: root,
@@ -1551,6 +1566,7 @@ describe('execution stores', () => {
         const suffix = '123.00000000-0000-4000-8000-000000000000.tmp';
         const admissionsRoot = join(root, 'sessions', session.id, 'turn-admissions');
         const admissionTemp = join(admissionsRoot, `turn-1.json.${suffix}`);
+        await mkdir(admissionsRoot, { recursive: true });
         await writeFile(admissionTemp, 'staging', 'utf8');
         const runDirectory = join(root, 'sessions', session.id, 'runs', 'run-staging');
         await mkdir(runDirectory, { recursive: true });
@@ -1562,8 +1578,8 @@ describe('execution stores', () => {
           ['turn-1'],
         );
         assert.deepEqual(await stores.agentRunStore.listSessionRunsForRecovery(session.id), []);
-        await assert.rejects(() => stat(admissionTemp), { code: 'ENOENT' });
-        await assert.rejects(() => stat(runDirectory), { code: 'ENOENT' });
+        assert.ok((await stat(admissionTemp)).isFile());
+        assert.ok((await stat(runDirectory)).isDirectory());
       } finally {
         await owner.close();
       }
@@ -1654,7 +1670,7 @@ describe('execution stores', () => {
     });
   });
 
-  test('strict recovery enumeration fails on malformed durable entities', async () => {
+  test('SQLite recovery is isolated from post-cutover legacy file corruption', async () => {
     await withRoot(async ({ root }) => {
       const capability = await resolveStorageRoot({
         path: root,
@@ -1677,22 +1693,22 @@ describe('execution stores', () => {
           sourceMessages: [],
           admittedAt: 10,
         });
-        await writeFile(
-          join(root, 'sessions', session.id, 'turn-admissions', 'turn-1.json'),
-          '{"turnId":"wrong"}\n',
-          'utf8',
-        );
-        await assert.rejects(() =>
-          stores.agentRunStore.listRootTurnAdmissionsForRecovery(session.id),
+        const admissionRoot = join(root, 'sessions', session.id, 'turn-admissions');
+        await mkdir(admissionRoot, { recursive: true });
+        await writeFile(join(admissionRoot, 'turn-1.json'), '{"turnId":"wrong"}\n', 'utf8');
+        assert.equal(
+          (await stores.agentRunStore.listRootTurnAdmissionsForRecovery(session.id))[0]?.turnId,
+          'turn-1',
         );
 
         await stores.agentRunStore.createRun(runHeader(session.id, 'run-1'));
-        await writeFile(
-          join(root, 'sessions', session.id, 'runs', 'run-1', 'run.json'),
-          '{"runId":"wrong"}\n',
-          'utf8',
+        const runRoot = join(root, 'sessions', session.id, 'runs', 'run-1');
+        await mkdir(runRoot, { recursive: true });
+        await writeFile(join(runRoot, 'run.json'), '{"runId":"wrong"}\n', 'utf8');
+        assert.equal(
+          (await stores.agentRunStore.listSessionRunsForRecovery(session.id))[0]?.runId,
+          'run-1',
         );
-        await assert.rejects(() => stores.agentRunStore.listSessionRunsForRecovery(session.id));
 
         await writeFile(
           join(root, 'sessions', session.id, 'session.jsonl'),

--- a/packages/storage/src/__tests__/operational-state-store.test.ts
+++ b/packages/storage/src/__tests__/operational-state-store.test.ts
@@ -40,6 +40,7 @@ describe('operational state database cutover', () => {
           .all()
           .map((row) => ({ ...row })),
         [
+          { scope: 'core_execution', version: 1 },
           { scope: 'operational', version: 1 },
           { scope: 'runtime', version: 5 },
           { scope: 'session_metadata', version: SQLITE_SESSION_METADATA_SCHEMA_VERSION },

--- a/packages/storage/src/__tests__/sqlite-core-execution-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-core-execution-store.test.ts
@@ -1,0 +1,307 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import type {
+  AgentRunEvent,
+  AgentRunHeader,
+  InteractionCanonicalOutcome,
+  InteractionRequest,
+  ShellRunRecord,
+} from '@maka/core';
+import { createAgentRunStore, createSqliteAgentRunStore } from '../agent-run-store.js';
+import {
+  closeSqliteInteractionStoreFacade,
+  interactionLocator,
+  openInteractiveInteractionStoreForWrite,
+  openSqliteInteractiveInteractionStoreForWrite,
+  type StoredInteractionRequest,
+} from '../interaction-store.js';
+import {
+  createMessageReceiptStore,
+  createSqliteMessageReceiptStore,
+} from '../message-receipt-store.js';
+import {
+  acquireOperationalStateDatabase,
+  OPERATIONAL_STATE_DATABASE_NAME,
+} from '../operational-state-store.js';
+import { createShellRunStore, createSqliteShellRunStore } from '../shell-run-store.js';
+import { resolveStorageRoot, tryAcquireInteractiveRootOwner } from '../root-authority.js';
+
+describe('SQLite core execution cutover', () => {
+  test('imports AgentRun state once and never appends to legacy files', async () => {
+    await withRoot(async (root) => {
+      const legacy = createAgentRunStore(root);
+      const header = runHeader();
+      const firstEvent = runEvent('event-1', 1);
+      await legacy.createRun(header);
+      await legacy.appendEvent(header.sessionId, header.runId, firstEvent);
+      await legacy.admitRootTurn({
+        sessionId: header.sessionId,
+        turnId: header.turnId,
+        proposedRunId: header.runId,
+        proposedUserMessageId: 'message-1',
+        execution: { kind: 'external_message' },
+        previousRootTurnId: null,
+        normalizedInput: { text: 'hello' },
+        sourceMessages: [],
+        admittedAt: 1,
+      });
+      const legacyEventsPath = join(
+        root,
+        'sessions',
+        header.sessionId,
+        'runs',
+        header.runId,
+        'events.jsonl',
+      );
+      const legacyBytes = await readFile(legacyEventsPath);
+
+      const sqlite = createSqliteAgentRunStore(root);
+      await sqlite.ready?.();
+      assert.deepEqual(await sqlite.readRun(header.sessionId, header.runId), header);
+      assert.deepEqual(await sqlite.readEvents(header.sessionId, header.runId), [firstEvent]);
+      assert.equal(
+        (await sqlite.listRootTurnAdmissionsForRecovery(header.sessionId))[0]?.turnId,
+        header.turnId,
+      );
+      await sqlite.appendEvent(header.sessionId, header.runId, runEvent('event-2', 2));
+      assert.deepEqual(
+        (await sqlite.readEvents(header.sessionId, header.runId)).map((event) => event.id),
+        ['event-1', 'event-2'],
+      );
+      assert.deepEqual(await readFile(legacyEventsPath), legacyBytes);
+      sqlite.close?.();
+
+      const reopened = createSqliteAgentRunStore(root);
+      await reopened.ready?.();
+      assert.deepEqual(
+        (await reopened.readEvents(header.sessionId, header.runId)).map((event) => event.id),
+        ['event-1', 'event-2'],
+      );
+      reopened.close?.();
+    });
+  });
+
+  test('rolls back copied AgentRun rows and resumes a started cutover', async () => {
+    await withRoot(async (root) => {
+      const legacy = createAgentRunStore(root);
+      await legacy.createRun(runHeader());
+      await legacy.appendEvent('session-1', 'run-1', runEvent('event-1', 1));
+
+      const interrupted = createSqliteAgentRunStore(root, {
+        failpoint: (point) => {
+          if (point === 'after_cutover_rows_copied') throw new Error('simulated crash');
+        },
+      });
+      assert.ok(interrupted.ready);
+      await assert.rejects(interrupted.ready(), /simulated crash/);
+      interrupted.close?.();
+
+      const inspection = acquireOperationalStateDatabase(root);
+      const journal = inspection.database
+        .prepare(`
+          SELECT state
+          FROM cutover_journal
+          WHERE store_name = 'agent_runs'
+        `)
+        .get() as { state?: unknown } | undefined;
+      const count = inspection.database
+        .prepare('SELECT COUNT(*) AS count FROM core_agent_runs')
+        .get() as { count?: unknown };
+      assert.equal(journal?.state, 'started');
+      assert.equal(count.count, 0);
+      inspection.close();
+
+      const resumed = createSqliteAgentRunStore(root);
+      await resumed.ready?.();
+      assert.equal((await resumed.readRun('session-1', 'run-1')).runId, 'run-1');
+      resumed.close?.();
+    });
+  });
+
+  test('imports ShellRun state and keeps payload files unchanged', async () => {
+    await withRoot(async (root) => {
+      const legacy = createShellRunStore(root);
+      await legacy.createShellRun(shellRun());
+      const legacyPath = join(
+        root,
+        'sessions',
+        'session-1',
+        'shell-runs',
+        'shell-1',
+        'shell-run.json',
+      );
+      const before = await readFile(legacyPath);
+
+      const sqlite = createSqliteShellRunStore(root);
+      await sqlite.ready();
+      assert.equal((await sqlite.readShellRun('session-1', 'shell-1')).status, 'running');
+      const updated = await sqlite.updateShellRun('session-1', 'shell-1', {
+        status: 'completed',
+        completedAt: 2,
+        exitCode: 0,
+        updatedAt: 2,
+      });
+      assert.equal(updated.revision, 2);
+      assert.deepEqual(await readFile(legacyPath), before);
+      sqlite.close();
+    });
+  });
+
+  test('imports receipts and interactions while new writes stay SQLite-only', async () => {
+    await withRoot(async (root) => {
+      const receipts = createMessageReceiptStore(root);
+      await receipts.beginHostEpoch('epoch-1');
+      await receipts.commit('epoch-1', 'submit', 'session-1', 'operation-1', {
+        payload: { text: 'hello' },
+        result: { accepted: true },
+      });
+
+      const capability = await resolveStorageRoot({ path: root, kind: 'interactive' });
+      const legacyOwner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(legacyOwner);
+      if (!legacyOwner) return;
+      const legacyInteractions = await openInteractiveInteractionStoreForWrite(legacyOwner.lease);
+      const request = storedQuestion('request-1', 1);
+      assert.equal((await legacyInteractions.establishRequest(request)).status, 'stable');
+      assert.equal(
+        (await legacyInteractions.commitOutcome('request-1', questionOutcome('First', 2))).status,
+        'stable',
+      );
+      await legacyOwner.close();
+
+      const sqliteReceipts = createSqliteMessageReceiptStore(root);
+      await sqliteReceipts.ready();
+      assert.deepEqual(await sqliteReceipts.read('epoch-1', 'submit', 'session-1', 'operation-1'), {
+        payload: { text: 'hello' },
+        result: { accepted: true },
+      });
+      await sqliteReceipts.commit('epoch-1', 'interrupt', 'session-1', 'operation-2', {
+        payload: { reason: 'stop' },
+        result: { interrupted: true },
+      });
+      await assert.rejects(
+        () =>
+          stat(
+            join(root, 'message-receipts', 'epoch-1', 'interrupt', 'session-1', 'operation-2.json'),
+          ),
+        { code: 'ENOENT' },
+      );
+      sqliteReceipts.close();
+
+      const sqliteOwner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(sqliteOwner);
+      if (!sqliteOwner) return;
+      const sqliteInteractions = await openSqliteInteractiveInteractionStoreForWrite(
+        sqliteOwner.lease,
+      );
+      assert.equal(
+        (await sqliteInteractions.readInteraction('request-1'))?.outcome?.outcome.kind,
+        'question_answer',
+      );
+      const sqliteOnly = storedQuestion('request-2', 3);
+      assert.equal((await sqliteInteractions.establishRequest(sqliteOnly)).status, 'stable');
+      await assert.rejects(
+        () => stat(join(root, 'interactions', interactionLocator(sqliteOnly.requestId))),
+        { code: 'ENOENT' },
+      );
+      closeSqliteInteractionStoreFacade(sqliteInteractions);
+      await sqliteOwner.close();
+
+      assert.ok((await stat(join(root, OPERATIONAL_STATE_DATABASE_NAME))).isFile());
+    });
+  });
+});
+
+async function withRoot(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-sqlite-core-execution-'));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+function runHeader(): AgentRunHeader {
+  return {
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    status: 'created',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/tmp/cwd',
+    permissionMode: 'ask',
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function runEvent(id: string, ts: number): AgentRunEvent {
+  return {
+    type: 'run_started',
+    id,
+    runId: 'run-1',
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    ts,
+  };
+}
+
+function shellRun(): ShellRunRecord {
+  return {
+    shellRunId: 'shell-1',
+    sessionId: 'session-1',
+    sourceRunId: 'run-1',
+    sourceTurnId: 'turn-1',
+    sourceToolCallId: 'tool-1',
+    cwd: '/workspace',
+    command: 'printf "ok"',
+    status: 'running',
+    startedAt: 1,
+    updatedAt: 1,
+    revision: 1,
+    output: {
+      mode: 'pipes',
+      stdout: '',
+      stderr: '',
+      stdoutTruncated: false,
+      stderrTruncated: false,
+      redacted: false,
+    },
+  };
+}
+
+function storedQuestion(requestId: string, createdAt: number): StoredInteractionRequest {
+  return {
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    runId: 'run-1',
+    requestId,
+    createdAt,
+    request: {
+      kind: 'question',
+      toolUseId: 'tool-1',
+      questions: [
+        {
+          question: 'Choose',
+          options: [
+            { label: 'First', description: 'First' },
+            { label: 'Second', description: 'Second' },
+          ],
+        },
+      ],
+    } as InteractionRequest,
+  };
+}
+
+function questionOutcome(answer: string, committedAt: number): InteractionCanonicalOutcome {
+  return {
+    kind: 'question_answer',
+    answers: [answer],
+    committedAt,
+  } as InteractionCanonicalOutcome;
+}

--- a/packages/storage/src/agent-run-store.ts
+++ b/packages/storage/src/agent-run-store.ts
@@ -13,6 +13,7 @@ import {
 } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
+import type { DatabaseSync } from 'node:sqlite';
 import { appendJsonl } from './jsonl-append.js';
 import {
   decodeAgentRunEvent,
@@ -23,6 +24,12 @@ import { classifyJsonRecord } from './json-prefix.js';
 import { immutableSteeringMessageId } from './runtime-event-invariants.js';
 import { syncDirectory, syncDirectoryChain, syncFile } from './stable-storage.js';
 import { chainWrite } from './write-queue.js';
+import {
+  acquireOperationalStateDatabase,
+  completeOperationalStoreCutover,
+  type OperationalStateDatabaseLease,
+  type OperationalStoreCutoverFailpoint,
+} from './operational-state-store.js';
 import {
   DurableStoreWriteError,
   decodeAgentGraphIntentClaim,
@@ -127,6 +134,8 @@ export interface DurableAgentRunStore extends AgentRunStore, RootTurnAdmissionSt
     event: AgentRunEvent | null,
     options?: { replaceEventId?: string },
   ): Promise<void>;
+  ready?(): Promise<void>;
+  close?(): void;
 }
 
 export interface DurableRuntimeEventStore extends RuntimeEventStore {
@@ -159,8 +168,335 @@ export function createAgentRunStore(workspaceRoot: string): DurableAgentRunStore
   return new FileAgentRunStore(workspaceRoot);
 }
 
+export interface SqliteAgentRunStoreOptions {
+  readonly failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
+}
+
+export function createSqliteAgentRunStore(
+  workspaceRoot: string,
+  options: SqliteAgentRunStoreOptions = {},
+): DurableAgentRunStore {
+  return new SqliteAgentRunStore(workspaceRoot, options);
+}
+
 export function createRuntimeEventStore(workspaceRoot: string): DurableRuntimeEventStore {
   return new FileRuntimeEventStore(workspaceRoot);
+}
+
+class SqliteAgentRunStore implements DurableAgentRunStore {
+  readonly #root: string;
+  readonly #lease: OperationalStateDatabaseLease;
+  readonly #ready: Promise<void>;
+
+  constructor(workspaceRoot: string, options: SqliteAgentRunStoreOptions) {
+    this.#root = resolve(workspaceRoot);
+    this.#lease = acquireOperationalStateDatabase(this.#root);
+    this.#ready = importLegacyAgentRuns(this.#root, this.#lease, options);
+  }
+
+  ready(): Promise<void> {
+    return this.#ready;
+  }
+
+  async createRun(
+    header: AgentRunHeader,
+    _options: { durable?: boolean } = {},
+  ): Promise<AgentRunHeader> {
+    const normalized = normalizeAgentRunHeader(header, header.sessionId, header.runId);
+    await this.#ready;
+    this.#lease.transaction('write', () => {
+      const inserted = this.#lease.database
+        .prepare(`
+          INSERT OR IGNORE INTO core_agent_runs(
+            session_id, run_id, created_at, record_json
+          ) VALUES (?, ?, ?, ?)
+        `)
+        .run(
+          normalized.sessionId,
+          normalized.runId,
+          normalized.createdAt,
+          JSON.stringify(normalized, sanitizeJson),
+        );
+      if (inserted.changes !== 1) {
+        throw new Error(`Agent run already exists: ${normalized.runId}`);
+      }
+      const count = this.#lease.database
+        .prepare('SELECT COUNT(*) AS count FROM core_agent_runs WHERE session_id = ?')
+        .get(normalized.sessionId) as { count?: unknown };
+      const projection = this.#lease.database
+        .prepare(`
+          SELECT 1 AS present
+          FROM core_agent_run_projections
+          WHERE session_id = ? AND event_type = 'history_compact_checkpoint_recorded'
+        `)
+        .get(normalized.sessionId);
+      if (count.count === 1 && !projection) {
+        this.#lease.database
+          .prepare(`
+            INSERT INTO core_agent_run_projections(session_id, event_type, event_json)
+            VALUES (?, 'history_compact_checkpoint_recorded', NULL)
+          `)
+          .run(normalized.sessionId);
+      }
+    });
+    return normalized;
+  }
+
+  async updateRun(
+    sessionId: string,
+    runId: string,
+    patch: Partial<AgentRunHeader>,
+    _options: { durable?: boolean } = {},
+  ): Promise<AgentRunHeader> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    await this.#ready;
+    return this.#lease.transaction('write', () => {
+      const current = readSqliteAgentRun(this.#lease.database, sessionId, runId);
+      const next = normalizeAgentRunHeader(
+        { ...current, ...patch, sessionId, runId },
+        sessionId,
+        runId,
+      );
+      const result = this.#lease.database
+        .prepare(`
+          UPDATE core_agent_runs
+          SET created_at = ?, record_json = ?
+          WHERE session_id = ? AND run_id = ?
+        `)
+        .run(next.createdAt, JSON.stringify(next, sanitizeJson), sessionId, runId);
+      if (result.changes !== 1) throw new Error(`Failed to update run ${runId}`);
+      return next;
+    });
+  }
+
+  async readRun(sessionId: string, runId: string): Promise<AgentRunHeader> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    await this.#ready;
+    return readSqliteAgentRun(this.#lease.database, sessionId, runId);
+  }
+
+  async listSessionRuns(sessionId: string): Promise<AgentRunHeader[]> {
+    return this.listSessionRunsForRecovery(sessionId);
+  }
+
+  async listSessionRunsForRecovery(sessionId: string): Promise<AgentRunHeader[]> {
+    assertSafeId(sessionId, 'Invalid session id');
+    await this.#ready;
+    const rows = this.#lease.database
+      .prepare(`
+        SELECT run_id, record_json
+        FROM core_agent_runs
+        WHERE session_id = ?
+        ORDER BY created_at, run_id
+      `)
+      .all(sessionId) as Array<{ run_id?: unknown; record_json?: unknown }>;
+    return rows.map((row) => {
+      if (typeof row.run_id !== 'string' || typeof row.record_json !== 'string') {
+        throw new Error('Invalid SQLite AgentRun row');
+      }
+      return normalizeAgentRunHeader(JSON.parse(row.record_json), sessionId, row.run_id);
+    });
+  }
+
+  async appendEvent(
+    sessionId: string,
+    runId: string,
+    event: AgentRunEvent,
+    _options: { durable?: boolean } = {},
+  ): Promise<void> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    await this.#ready;
+    this.#lease.transaction('write', () => {
+      const header = readSqliteAgentRun(this.#lease.database, sessionId, runId);
+      const normalized = decodeAgentRunEvent(JSON.parse(JSON.stringify(event, sanitizeJson)), {
+        sessionId,
+        runId,
+        turnId: header.turnId,
+      });
+      const projection =
+        normalized.type === 'history_compact_checkpoint_recorded'
+          ? readSqliteAgentRunProjection(this.#lease.database, sessionId, normalized.type)
+          : undefined;
+      insertAgentRunEvent(this.#lease.database, normalized);
+      if (normalized.type === 'history_compact_checkpoint_recorded') {
+        const projected = shouldPreserveCheckpointProjectionDuringAppend(projection, normalized)
+          ? projection!
+          : normalized;
+        writeSqliteAgentRunProjection(this.#lease.database, sessionId, normalized.type, projected);
+      }
+    });
+  }
+
+  async readEvents(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
+    return this.readEventsForRecovery(sessionId, runId);
+  }
+
+  async readEventsForRecovery(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    await this.#ready;
+    return readSqliteAgentRunEvents(this.#lease.database, sessionId, runId);
+  }
+
+  async readEventsForEvidence(sessionId: string, runId: string): Promise<AgentRunEvent[]> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(runId, 'Invalid run id');
+    await this.#ready;
+    return readSqliteAgentRunEventsForEvidence(this.#lease.database, sessionId, runId);
+  }
+
+  async readEventProjection(
+    sessionId: string,
+    type: AgentRunEventType,
+  ): Promise<AgentRunEvent | null | undefined> {
+    assertSafeId(sessionId, 'Invalid session id');
+    await this.#ready;
+    return readSqliteAgentRunProjection(this.#lease.database, sessionId, type);
+  }
+
+  async repairEventProjection(
+    sessionId: string,
+    type: AgentRunEventType,
+    event: AgentRunEvent | null,
+    options: { replaceEventId?: string } = {},
+  ): Promise<void> {
+    assertSafeId(sessionId, 'Invalid session id');
+    if (event !== null && !isProjectedAgentRunEvent(event, sessionId, type)) {
+      throw new Error(`Invalid AgentRun event projection repair for ${type}`);
+    }
+    await this.#ready;
+    this.#lease.transaction('write', () => {
+      const current = readSqliteAgentRunProjection(this.#lease.database, sessionId, type);
+      if (
+        current?.id !== options.replaceEventId &&
+        shouldPreserveProjectionDuringRepair(current, event, type)
+      ) {
+        return;
+      }
+      writeSqliteAgentRunProjection(this.#lease.database, sessionId, type, event);
+    });
+  }
+
+  async admitRootTurn(input: AdmitRootTurnInput): Promise<AdmitRootTurnResult> {
+    const admission = normalizeAdmitRootTurnInput(input);
+    await this.#ready;
+    return this.#lease.transaction('write', () => {
+      const existing = readSqliteRootTurnAdmission(
+        this.#lease.database,
+        admission.sessionId,
+        admission.turnId,
+      );
+      if (existing) {
+        return existing.previousRootTurnId === input.previousRootTurnId &&
+          rootTurnAdmissionPayloadsEqual(existing, admission)
+          ? { kind: 'existing', admission: existing }
+          : { kind: 'conflict', admission: existing };
+      }
+      for (const source of admission.sourceMessages) {
+        const proof = this.#lease.database
+          .prepare(`
+            SELECT turn_id
+            FROM core_root_source_message_proofs
+            WHERE session_id = ? AND message_id = ?
+          `)
+          .get(admission.sessionId, source.messageId) as { turn_id?: unknown } | undefined;
+        if (proof && proof.turn_id !== admission.turnId) {
+          throw new Error(
+            `Root source message identity belongs to both ${String(proof.turn_id)} and ${admission.turnId}`,
+          );
+        }
+      }
+      this.#lease.database
+        .prepare(`
+          INSERT INTO core_root_turn_admissions(
+            session_id, turn_id, admitted_at, record_json
+          ) VALUES (?, ?, ?, ?)
+        `)
+        .run(
+          admission.sessionId,
+          admission.turnId,
+          admission.admittedAt,
+          JSON.stringify(admission),
+        );
+      for (const source of admission.sourceMessages) {
+        this.#lease.database
+          .prepare(`
+            INSERT INTO core_root_source_message_proofs(session_id, message_id, turn_id)
+            VALUES (?, ?, ?)
+          `)
+          .run(admission.sessionId, source.messageId, admission.turnId);
+      }
+      return { kind: 'admitted', admission };
+    });
+  }
+
+  async readRootTurnAdmission(
+    sessionId: string,
+    turnId: string,
+  ): Promise<RootTurnAdmission | undefined> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(turnId, 'Invalid turn id');
+    await this.#ready;
+    return readSqliteRootTurnAdmission(this.#lease.database, sessionId, turnId);
+  }
+
+  async readRootTurnSourceMessageReceipt(
+    sessionId: string,
+    sourceMessageId: string,
+  ): Promise<RootTurnSourceMessageReceipt | undefined> {
+    assertSafeId(sessionId, 'Invalid session id');
+    assertSafeId(sourceMessageId, 'Invalid source message id');
+    await this.#ready;
+    const row = this.#lease.database
+      .prepare(`
+        SELECT turn_id
+        FROM core_root_source_message_proofs
+        WHERE session_id = ? AND message_id = ?
+      `)
+      .get(sessionId, sourceMessageId) as { turn_id?: unknown } | undefined;
+    if (!row) return undefined;
+    if (typeof row.turn_id !== 'string') throw new Error('Invalid root source message proof row');
+    const admission = readSqliteRootTurnAdmission(this.#lease.database, sessionId, row.turn_id);
+    if (!admission) {
+      throw new Error(`Root source message proof references missing Turn ${row.turn_id}`);
+    }
+    const matches = admission.sourceMessages.filter(
+      (source) => source.messageId === sourceMessageId,
+    );
+    if (matches.length !== 1) {
+      throw new Error(
+        `Root source message proof does not identify exactly one source: ${sourceMessageId}`,
+      );
+    }
+    return Object.freeze({ admission, sourceMessage: matches[0]! });
+  }
+
+  async listRootTurnAdmissionsForRecovery(sessionId: string): Promise<RootTurnAdmission[]> {
+    assertSafeId(sessionId, 'Invalid session id');
+    await this.#ready;
+    const rows = this.#lease.database
+      .prepare(`
+        SELECT turn_id, record_json
+        FROM core_root_turn_admissions
+        WHERE session_id = ?
+        ORDER BY admitted_at, turn_id
+      `)
+      .all(sessionId) as Array<{ turn_id?: unknown; record_json?: unknown }>;
+    const admissions = rows.map((row) => {
+      if (typeof row.turn_id !== 'string' || typeof row.record_json !== 'string') {
+        throw new Error('Invalid SQLite root turn admission row');
+      }
+      return normalizeRootTurnAdmission(JSON.parse(row.record_json), sessionId, row.turn_id);
+    });
+    return orderRootTurnAdmissionChain(sessionId, admissions);
+  }
+
+  close(): void {
+    this.#lease.close();
+  }
 }
 
 class FileAgentRunStore implements DurableAgentRunStore {
@@ -787,6 +1123,538 @@ class FileAgentRunStore implements DurableAgentRunStore {
         return;
       }
       await this.writeEventProjectionUnlocked(sessionId, type, null);
+    }
+  }
+}
+
+interface LegacyAgentRunProjection {
+  readonly sessionId: string;
+  readonly type: AgentRunEventType;
+  readonly event: AgentRunEvent | null;
+}
+
+interface LegacyAgentRunSnapshot {
+  readonly runs: readonly AgentRunHeader[];
+  readonly events: readonly {
+    readonly sessionId: string;
+    readonly runId: string;
+    readonly records: readonly AgentRunEvent[];
+  }[];
+  readonly projections: readonly LegacyAgentRunProjection[];
+  readonly admissions: readonly RootTurnAdmission[];
+}
+
+async function importLegacyAgentRuns(
+  root: string,
+  lease: OperationalStateDatabaseLease,
+  options: SqliteAgentRunStoreOptions,
+): Promise<void> {
+  const snapshot = await readLegacyAgentRunSnapshot(root);
+  const fingerprint = createHash('sha256')
+    .update(JSON.stringify(snapshot, sanitizeJson))
+    .digest('hex');
+  completeOperationalStoreCutover(lease, {
+    storeName: 'agent_runs',
+    sourcePath: join(root, 'sessions'),
+    sourceFingerprint: `sha256:${fingerprint}`,
+    failpoint: options.failpoint,
+    importAndValidate: (db) => {
+      for (const run of snapshot.runs) insertOrValidateAgentRun(db, run);
+      for (const stream of snapshot.events) {
+        stream.records.forEach((event, sequence) => {
+          insertOrValidateAgentRunEvent(db, event, sequence);
+        });
+      }
+      for (const projection of snapshot.projections) {
+        insertOrValidateAgentRunProjection(db, projection);
+      }
+      for (const admission of snapshot.admissions) {
+        insertOrValidateRootTurnAdmission(db, admission);
+      }
+      return {
+        agent_runs: snapshot.runs.length,
+        agent_run_events: snapshot.events.reduce(
+          (count, stream) => count + stream.records.length,
+          0,
+        ),
+        agent_run_projections: snapshot.projections.length,
+        root_turn_admissions: snapshot.admissions.length,
+        root_source_message_proofs: snapshot.admissions.reduce(
+          (count, admission) => count + admission.sourceMessages.length,
+          0,
+        ),
+      };
+    },
+  });
+}
+
+async function readLegacyAgentRunSnapshot(root: string): Promise<LegacyAgentRunSnapshot> {
+  const sessionsRoot = join(root, 'sessions');
+  let sessions;
+  try {
+    sessions = await readdir(sessionsRoot, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { runs: [], events: [], projections: [], admissions: [] };
+    }
+    throw error;
+  }
+  const legacy = new FileAgentRunStore(root);
+  const runs: AgentRunHeader[] = [];
+  const events: Array<{
+    sessionId: string;
+    runId: string;
+    records: AgentRunEvent[];
+  }> = [];
+  const projections: LegacyAgentRunProjection[] = [];
+  const admissions: RootTurnAdmission[] = [];
+  for (const session of sessions.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!session.isDirectory() || !isSafeId(session.name)) continue;
+    const sessionRuns = await readLegacyAgentRunsForSession(root, legacy, session.name);
+    runs.push(...sessionRuns.runs);
+    events.push(...sessionRuns.events);
+    const sessionAdmissions = await legacy.listRootTurnAdmissionsForRecovery(session.name);
+    admissions.push(...sessionAdmissions);
+    await assertLegacyRootProofClosure(root, session.name, sessionAdmissions);
+    projections.push(...(await readLegacyAgentRunProjections(root, session.name)));
+  }
+  return { runs, events, projections, admissions };
+}
+
+async function readLegacyAgentRunsForSession(
+  root: string,
+  legacy: FileAgentRunStore,
+  sessionId: string,
+): Promise<{
+  runs: AgentRunHeader[];
+  events: Array<{ sessionId: string; runId: string; records: AgentRunEvent[] }>;
+}> {
+  const runsRoot = join(root, 'sessions', sessionId, 'runs');
+  let entries;
+  try {
+    entries = await readdir(runsRoot, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return { runs: [], events: [] };
+    throw error;
+  }
+  const runs: AgentRunHeader[] = [];
+  const events: Array<{ sessionId: string; runId: string; records: AgentRunEvent[] }> = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isDirectory() || !isSafeId(entry.name)) {
+      throw new Error(`Invalid AgentRun entry for session ${sessionId}: ${entry.name}`);
+    }
+    const runRoot = join(runsRoot, entry.name);
+    const runEntries = await readdir(runRoot, { withFileTypes: true });
+    const hasHeader = runEntries.some(
+      (candidate) => candidate.isFile() && candidate.name === 'run.json',
+    );
+    if (!hasHeader) {
+      const runtimeOnly = runEntries.every(
+        (candidate) =>
+          (candidate.isFile() && candidate.name === 'runtime-events.jsonl') ||
+          (candidate.isDirectory() && candidate.name === 'runtime-partials') ||
+          (candidate.isFile() && isExclusiveWriteTemp(candidate.name, 'run.json')),
+      );
+      if (runtimeOnly) continue;
+      throw Object.assign(new Error(`AgentRun ${entry.name} has no durable header`), {
+        code: 'ENOENT',
+      });
+    }
+    const run = await legacy.readRun(sessionId, entry.name);
+    runs.push(run);
+    events.push({
+      sessionId,
+      runId: run.runId,
+      records: await legacy.readEventsForRecovery(sessionId, run.runId),
+    });
+  }
+  return { runs, events };
+}
+
+async function readLegacyAgentRunProjections(
+  root: string,
+  sessionId: string,
+): Promise<LegacyAgentRunProjection[]> {
+  const projectionRoot = join(root, 'sessions', sessionId, 'projections');
+  let entries;
+  try {
+    entries = await readdir(projectionRoot, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+  const result: LegacyAgentRunProjection[] = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) {
+      throw new Error(`Invalid AgentRun projection entry: ${entry.name}`);
+    }
+    const type = entry.name.slice(0, -'.json'.length) as AgentRunEventType;
+    const parsed = JSON.parse(await readFile(join(projectionRoot, entry.name), 'utf8')) as {
+      version?: unknown;
+      event?: unknown;
+    };
+    if (parsed.version !== 1 || !Object.hasOwn(parsed, 'event')) {
+      throw new Error(`Invalid AgentRun event projection for ${type}`);
+    }
+    if (parsed.event !== null && !isProjectedAgentRunEvent(parsed.event, sessionId, type)) {
+      throw new Error(`Invalid AgentRun event projection for ${type}`);
+    }
+    result.push({
+      sessionId,
+      type,
+      event: parsed.event as AgentRunEvent | null,
+    });
+  }
+  return result;
+}
+
+async function assertLegacyRootProofClosure(
+  root: string,
+  sessionId: string,
+  admissions: readonly RootTurnAdmission[],
+): Promise<void> {
+  const expected = new Map<string, string>();
+  for (const admission of admissions) {
+    for (const source of admission.sourceMessages) {
+      expected.set(source.messageId, admission.turnId);
+    }
+  }
+  const proofRoot = join(root, 'sessions', sessionId, 'message-proofs', 'root');
+  let entries;
+  try {
+    entries = await readdir(proofRoot, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      if (expected.size === 0) return;
+      throw new Error(`Missing root source message proofs for session ${sessionId}`);
+    }
+    throw error;
+  }
+  const seen = new Set<string>();
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith('.json')) {
+      throw new Error(`Invalid root source message proof entry: ${entry.name}`);
+    }
+    const messageId = entry.name.slice(0, -'.json'.length);
+    assertSafeId(messageId, 'Invalid root source message proof identity');
+    const pointer = decodeRootSourceMessageProofPointer(
+      JSON.parse(await readFile(join(proofRoot, entry.name), 'utf8')),
+      sessionId,
+      messageId,
+    );
+    if (expected.get(messageId) !== pointer.turnId) {
+      throw new Error(`Orphan root source message proof: ${messageId}`);
+    }
+    seen.add(messageId);
+  }
+  if (seen.size !== expected.size) {
+    throw new Error(`Missing root source message proofs for session ${sessionId}`);
+  }
+}
+
+function normalizeAgentRunHeader(value: unknown, sessionId: string, runId: string): AgentRunHeader {
+  assertSafeId(sessionId, 'Invalid session id');
+  assertSafeId(runId, 'Invalid run id');
+  return decodeAgentRunHeader(JSON.parse(JSON.stringify(value, sanitizeJson)), {
+    sessionId,
+    runId,
+  });
+}
+
+function readSqliteAgentRun(db: DatabaseSync, sessionId: string, runId: string): AgentRunHeader {
+  const row = db
+    .prepare(`
+      SELECT record_json
+      FROM core_agent_runs
+      WHERE session_id = ? AND run_id = ?
+    `)
+    .get(sessionId, runId) as { record_json?: unknown } | undefined;
+  if (!row) {
+    const error = new Error(`Agent run does not exist: ${runId}`) as NodeJS.ErrnoException;
+    error.code = 'ENOENT';
+    throw error;
+  }
+  if (typeof row.record_json !== 'string') throw new Error('Invalid SQLite AgentRun row');
+  return normalizeAgentRunHeader(JSON.parse(row.record_json), sessionId, runId);
+}
+
+function readSqliteAgentRunEvents(
+  db: DatabaseSync,
+  sessionId: string,
+  runId: string,
+): AgentRunEvent[] {
+  const rows = db
+    .prepare(`
+      SELECT record_json
+      FROM core_agent_run_events
+      WHERE session_id = ? AND run_id = ?
+      ORDER BY sequence
+    `)
+    .all(sessionId, runId) as Array<{ record_json?: unknown }>;
+  if (rows.length === 0) return [];
+  const header = readSqliteAgentRun(db, sessionId, runId);
+  return rows.map((row) => {
+    if (typeof row.record_json !== 'string') {
+      throw new Error('Invalid SQLite AgentRun event row');
+    }
+    return decodeAgentRunEvent(JSON.parse(row.record_json), {
+      sessionId,
+      runId,
+      turnId: header.turnId,
+    });
+  });
+}
+
+function readSqliteAgentRunEventsForEvidence(
+  db: DatabaseSync,
+  sessionId: string,
+  runId: string,
+): AgentRunEvent[] {
+  const rows = db
+    .prepare(`
+      SELECT sequence, record_json
+      FROM core_agent_run_events
+      WHERE session_id = ? AND run_id = ?
+      ORDER BY sequence
+    `)
+    .all(sessionId, runId) as Array<{ sequence?: unknown; record_json?: unknown }>;
+  if (rows.length === 0) return [];
+  const header = readSqliteAgentRun(db, sessionId, runId);
+  return rows.map((row) => {
+    const lineNumber =
+      typeof row.sequence === 'number' && Number.isSafeInteger(row.sequence) ? row.sequence + 1 : 0;
+    try {
+      if (typeof row.record_json !== 'string') {
+        throw new Error('Invalid SQLite AgentRun event row');
+      }
+      return decodeAgentRunEvent(JSON.parse(row.record_json), {
+        sessionId,
+        runId,
+        turnId: header.turnId,
+      });
+    } catch (error) {
+      return {
+        type: 'event_corrupt',
+        id: `run-event-corrupt-${lineNumber}`,
+        runId,
+        sessionId,
+        turnId: header.turnId,
+        ts: header.updatedAt,
+        message: error instanceof Error ? error.message : 'Invalid SQLite AgentRun event row',
+        data: { lineNumber },
+      };
+    }
+  });
+}
+
+function insertAgentRunEvent(db: DatabaseSync, event: AgentRunEvent): void {
+  const row = db
+    .prepare(`
+      SELECT COALESCE(MAX(sequence), -1) + 1 AS sequence
+      FROM core_agent_run_events
+      WHERE session_id = ? AND run_id = ?
+    `)
+    .get(event.sessionId, event.runId) as { sequence?: unknown };
+  if (typeof row.sequence !== 'number' || !Number.isSafeInteger(row.sequence)) {
+    throw new Error('Invalid next AgentRun event sequence');
+  }
+  db.prepare(`
+    INSERT INTO core_agent_run_events(
+      session_id, run_id, sequence, event_id, event_type, event_ts, record_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    event.sessionId,
+    event.runId,
+    row.sequence,
+    event.id,
+    event.type,
+    event.ts,
+    JSON.stringify(event, sanitizeJson),
+  );
+}
+
+function readSqliteAgentRunProjection(
+  db: DatabaseSync,
+  sessionId: string,
+  type: AgentRunEventType,
+): AgentRunEvent | null | undefined {
+  const row = db
+    .prepare(`
+      SELECT event_json
+      FROM core_agent_run_projections
+      WHERE session_id = ? AND event_type = ?
+    `)
+    .get(sessionId, type) as { event_json?: unknown } | undefined;
+  if (!row) return undefined;
+  if (row.event_json === null) return null;
+  if (typeof row.event_json !== 'string') {
+    throw new Error(`Invalid AgentRun event projection for ${type}`);
+  }
+  const event = JSON.parse(row.event_json);
+  if (!isProjectedAgentRunEvent(event, sessionId, type)) {
+    throw new Error(`Invalid AgentRun event projection for ${type}`);
+  }
+  return event;
+}
+
+function writeSqliteAgentRunProjection(
+  db: DatabaseSync,
+  sessionId: string,
+  type: AgentRunEventType,
+  event: AgentRunEvent | null,
+): void {
+  db.prepare(`
+    INSERT INTO core_agent_run_projections(session_id, event_type, event_json)
+    VALUES (?, ?, ?)
+    ON CONFLICT(session_id, event_type) DO UPDATE SET event_json = excluded.event_json
+  `).run(sessionId, type, event === null ? null : JSON.stringify(event, sanitizeJson));
+}
+
+function readSqliteRootTurnAdmission(
+  db: DatabaseSync,
+  sessionId: string,
+  turnId: string,
+): RootTurnAdmission | undefined {
+  const row = db
+    .prepare(`
+      SELECT record_json
+      FROM core_root_turn_admissions
+      WHERE session_id = ? AND turn_id = ?
+    `)
+    .get(sessionId, turnId) as { record_json?: unknown } | undefined;
+  if (!row) return undefined;
+  if (typeof row.record_json !== 'string') throw new Error('Invalid root turn admission row');
+  return normalizeRootTurnAdmission(JSON.parse(row.record_json), sessionId, turnId);
+}
+
+function normalizeAdmitRootTurnInput(input: AdmitRootTurnInput): RootTurnAdmission {
+  assertSafeId(input.sessionId, 'Invalid session id');
+  assertSafeId(input.turnId, 'Invalid turn id');
+  assertSafeId(input.proposedRunId, 'Invalid run id');
+  if (input.proposedUserMessageId !== null) {
+    assertSafeId(input.proposedUserMessageId, 'Invalid user message id');
+  }
+  if (input.previousRootTurnId !== null) {
+    assertSafeId(input.previousRootTurnId, 'Invalid previous root turn id');
+    if (input.previousRootTurnId === input.turnId) {
+      throw new Error('Root turn admission cannot reference itself');
+    }
+  }
+  if (!Number.isSafeInteger(input.admittedAt) || input.admittedAt < 0) {
+    throw new Error('Invalid root turn admission timestamp');
+  }
+  const { normalizedInput, sourceMessages } = normalizeRootTurnAdmissionPayload(
+    input.normalizedInput,
+    input.sourceMessages,
+  );
+  const admission: RootTurnAdmission = {
+    schemaVersion: ROOT_TURN_ADMISSION_SCHEMA_VERSION,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    runId: input.proposedRunId,
+    userMessageId: input.proposedUserMessageId,
+    execution: normalizeRootExecutionDescriptor(input.execution),
+    previousRootTurnId: input.previousRootTurnId,
+    normalizedInput,
+    sourceMessages,
+    admittedAt: input.admittedAt,
+  };
+  assertRootTurnAdmissionContract(admission);
+  assertRootTurnAdmissionRecordSize(admission);
+  return deepFreezeRootTurnAdmission(admission);
+}
+
+function insertOrValidateAgentRun(db: DatabaseSync, run: AgentRunHeader): void {
+  const encoded = JSON.stringify(run, sanitizeJson);
+  const result = db
+    .prepare(`
+      INSERT OR IGNORE INTO core_agent_runs(session_id, run_id, created_at, record_json)
+      VALUES (?, ?, ?, ?)
+    `)
+    .run(run.sessionId, run.runId, run.createdAt, encoded);
+  if (result.changes !== 0) return;
+  if (!isDeepStrictEqual(readSqliteAgentRun(db, run.sessionId, run.runId), run)) {
+    throw new Error(`AgentRun cutover conflict: ${run.runId}`);
+  }
+}
+
+function insertOrValidateAgentRunEvent(
+  db: DatabaseSync,
+  event: AgentRunEvent,
+  sequence: number,
+): void {
+  const encoded = JSON.stringify(event, sanitizeJson);
+  const result = db
+    .prepare(`
+      INSERT OR IGNORE INTO core_agent_run_events(
+        session_id, run_id, sequence, event_id, event_type, event_ts, record_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `)
+    .run(event.sessionId, event.runId, sequence, event.id, event.type, event.ts, encoded);
+  if (result.changes !== 0) return;
+  const row = db
+    .prepare(`
+      SELECT record_json
+      FROM core_agent_run_events
+      WHERE session_id = ? AND run_id = ? AND sequence = ?
+    `)
+    .get(event.sessionId, event.runId, sequence) as { record_json?: unknown } | undefined;
+  if (typeof row?.record_json !== 'string' || row.record_json !== encoded) {
+    throw new Error(`AgentRun event cutover conflict: ${event.runId}:${sequence}`);
+  }
+}
+
+function insertOrValidateAgentRunProjection(
+  db: DatabaseSync,
+  projection: LegacyAgentRunProjection,
+): void {
+  const encoded = projection.event === null ? null : JSON.stringify(projection.event, sanitizeJson);
+  const result = db
+    .prepare(`
+      INSERT OR IGNORE INTO core_agent_run_projections(session_id, event_type, event_json)
+      VALUES (?, ?, ?)
+    `)
+    .run(projection.sessionId, projection.type, encoded);
+  if (result.changes !== 0) return;
+  const existing = readSqliteAgentRunProjection(db, projection.sessionId, projection.type);
+  if (!isDeepStrictEqual(existing, projection.event)) {
+    throw new Error(`AgentRun projection cutover conflict: ${projection.type}`);
+  }
+}
+
+function insertOrValidateRootTurnAdmission(db: DatabaseSync, admission: RootTurnAdmission): void {
+  const result = db
+    .prepare(`
+      INSERT OR IGNORE INTO core_root_turn_admissions(
+        session_id, turn_id, admitted_at, record_json
+      ) VALUES (?, ?, ?, ?)
+    `)
+    .run(admission.sessionId, admission.turnId, admission.admittedAt, JSON.stringify(admission));
+  if (
+    result.changes === 0 &&
+    !isDeepStrictEqual(
+      readSqliteRootTurnAdmission(db, admission.sessionId, admission.turnId),
+      admission,
+    )
+  ) {
+    throw new Error(`Root turn admission cutover conflict: ${admission.turnId}`);
+  }
+  for (const source of admission.sourceMessages) {
+    const proof = db
+      .prepare(`
+        SELECT turn_id
+        FROM core_root_source_message_proofs
+        WHERE session_id = ? AND message_id = ?
+      `)
+      .get(admission.sessionId, source.messageId) as { turn_id?: unknown } | undefined;
+    if (proof && proof.turn_id !== admission.turnId) {
+      throw new Error(`Root source message proof cutover conflict: ${source.messageId}`);
+    }
+    if (!proof) {
+      db.prepare(`
+        INSERT INTO core_root_source_message_proofs(session_id, message_id, turn_id)
+        VALUES (?, ?, ?)
+      `).run(admission.sessionId, source.messageId, admission.turnId);
     }
   }
 }

--- a/packages/storage/src/execution-stores.ts
+++ b/packages/storage/src/execution-stores.ts
@@ -10,7 +10,7 @@ import type {
   TurnRecord,
 } from '@maka/core';
 import {
-  createAgentRunStore,
+  createSqliteAgentRunStore,
   type AdmitRootTurnInput,
   type AdmitRootTurnResult,
   type DurableAgentRunStore,
@@ -18,7 +18,10 @@ import {
   type RootTurnAdmission,
   type RootTurnSourceMessageReceipt,
 } from './agent-run-store.js';
-import { createMessageReceiptStore, type MessageReceiptStore } from './message-receipt-store.js';
+import {
+  createSqliteMessageReceiptStore,
+  type MessageReceiptStore,
+} from './message-receipt-store.js';
 import { createSessionStore, type SessionAuthorityStore } from './session-store.js';
 import {
   assertStorageRootLease,
@@ -28,8 +31,9 @@ import {
   type StorageRootLease,
 } from './root-authority.js';
 import {
-  openInteractiveInteractionStoreForRead,
-  openInteractiveInteractionStoreForWrite,
+  closeSqliteInteractionStoreFacade,
+  openSqliteInteractiveInteractionStoreForRead,
+  openSqliteInteractiveInteractionStoreForWrite,
   type InteractiveInteractionStoreReaderFacade,
   type InteractiveInteractionStoreWriterFacade,
 } from './interaction-store.js';
@@ -175,7 +179,7 @@ export function authenticateExecutionStoresReader<K extends StorageRootKind>(
 export async function openInteractiveExecutionStoresForWrite(
   lease: StorageRootLease<'interactive', 'write'>,
 ): Promise<ExecutionStoresWriter<'interactive'>> {
-  const interactionStore = await openInteractiveInteractionStoreForWrite(lease);
+  const interactionStore = await openSqliteInteractiveInteractionStoreForWrite(lease);
   return openExecutionStoresForWrite(lease, 'interactive', { interactionStore });
 }
 
@@ -219,15 +223,29 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
   extension: E,
 ): Promise<ExecutionStoresWriterBase<K> & E> {
   const sessionStore = createSessionStore(lease.canonicalPath);
-  const agentRunStore = createAgentRunStore(lease.canonicalPath);
+  const agentRunStore = createSqliteAgentRunStore(lease.canonicalPath);
+  const interactionStore =
+    'interactionStore' in extension
+      ? (extension.interactionStore as InteractiveInteractionStoreWriterFacade)
+      : undefined;
   const runtimePersistence = await openRuntimeEventPersistence({
     workspaceRoot: lease.canonicalPath,
   }).catch(async (error) => {
     await sessionStore.close?.().catch(() => {});
+    agentRunStore.close?.();
+    if (interactionStore) closeSqliteInteractionStoreFacade(interactionStore);
     throw error;
   });
   const runtimeEventStore = runtimePersistence.runtimeEventStore;
-  const messageReceiptStore = createMessageReceiptStore(lease.canonicalPath);
+  const messageReceiptStore = createSqliteMessageReceiptStore(lease.canonicalPath);
+  await Promise.all([agentRunStore.ready?.(), messageReceiptStore.ready()]).catch(async (error) => {
+    await closeExecutionStorePersistence(sessionStore, runtimePersistence, {
+      agentRunStore,
+      messageReceiptStore,
+      interactionStore,
+    }).catch(() => {});
+    throw error;
+  });
   const run = <T>(operation: () => Promise<T>) =>
     runWithStorageRootLease(lease, kind, 'write', operation);
 
@@ -296,7 +314,12 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
       setGeneratedTitleIfAbsent: (sessionId, title) =>
         run(() => sessionStore.setGeneratedTitleIfAbsent(sessionId, title)),
       remove: (sessionId) => run(() => sessionStore.remove(sessionId)),
-      close: () => closeExecutionStorePersistence(sessionStore, runtimePersistence),
+      close: () =>
+        closeExecutionStorePersistence(sessionStore, runtimePersistence, {
+          agentRunStore,
+          messageReceiptStore,
+          interactionStore,
+        }),
     },
     agentRunStore: {
       createRun: (header, options) => run(() => agentRunStore.createRun(header, options)),
@@ -362,7 +385,7 @@ async function createExecutionStoresForWrite<K extends StorageRootKind, E extend
 export async function openInteractiveExecutionStoresForRead(
   lease: StorageRootLease<'interactive', 'read'>,
 ): Promise<ExecutionStoresReader<'interactive'>> {
-  const interactionStore = await openInteractiveInteractionStoreForRead(lease);
+  const interactionStore = await openSqliteInteractiveInteractionStoreForRead(lease);
   return openExecutionStoresForRead(lease, 'interactive', { interactionStore });
 }
 
@@ -379,11 +402,23 @@ async function openExecutionStoresForRead<K extends StorageRootKind, E extends o
 ): Promise<ExecutionStoresReaderBase<K> & E> {
   await assertStorageRootLease(lease, kind, 'read');
   const sessionStore = createSessionStore(lease.canonicalPath);
-  const agentRunStore = createAgentRunStore(lease.canonicalPath);
+  const agentRunStore = createSqliteAgentRunStore(lease.canonicalPath);
+  const interactionStore =
+    'interactionStore' in extension
+      ? (extension.interactionStore as InteractiveInteractionStoreReaderFacade)
+      : undefined;
+  await agentRunStore.ready?.().catch(async (error) => {
+    await sessionStore.close?.().catch(() => {});
+    agentRunStore.close?.();
+    if (interactionStore) closeSqliteInteractionStoreFacade(interactionStore);
+    throw error;
+  });
   const runtimePersistence = await openRuntimeEventReadPersistence({
     workspaceRoot: lease.canonicalPath,
   }).catch(async (error) => {
     await sessionStore.close?.().catch(() => {});
+    agentRunStore.close?.();
+    if (interactionStore) closeSqliteInteractionStoreFacade(interactionStore);
     throw error;
   });
   const runtimeEventStore = runtimePersistence.runtimeEventStore;
@@ -399,7 +434,11 @@ async function openExecutionStoresForRead<K extends StorageRootKind, E extends o
       readHeader: (sessionId) => run(() => sessionStore.readHeaderSnapshot(sessionId)),
       readMessages: (sessionId) => run(() => sessionStore.readMessagesSnapshot(sessionId)),
       listTurns: (sessionId) => run(() => sessionStore.listTurnsSnapshot(sessionId)),
-      close: () => closeExecutionStorePersistence(sessionStore, runtimePersistence),
+      close: () =>
+        closeExecutionStorePersistence(sessionStore, runtimePersistence, {
+          agentRunStore,
+          interactionStore,
+        }),
     },
     agentRunStore: {
       readRun: (sessionId, runId) => run(() => agentRunStore.readRun(sessionId, runId)),
@@ -442,6 +481,13 @@ function freezeExecutionStoresFacade(stores: {
 async function closeExecutionStorePersistence(
   sessionStore: { close?(): Promise<void> },
   runtimePersistence: { close(): void },
+  extras: {
+    agentRunStore?: Pick<DurableAgentRunStore, 'close'>;
+    messageReceiptStore?: { close(): void };
+    interactionStore?:
+      | InteractiveInteractionStoreReaderFacade
+      | InteractiveInteractionStoreWriterFacade;
+  } = {},
 ): Promise<void> {
   const errors: unknown[] = [];
   try {
@@ -451,6 +497,23 @@ async function closeExecutionStorePersistence(
   }
   try {
     await sessionStore.close?.();
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    extras.agentRunStore?.close?.();
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    extras.messageReceiptStore?.close();
+  } catch (error) {
+    errors.push(error);
+  }
+  try {
+    if (extras.interactionStore) {
+      closeSqliteInteractionStoreFacade(extras.interactionStore);
+    }
   } catch (error) {
     errors.push(error);
   }

--- a/packages/storage/src/interaction-store.ts
+++ b/packages/storage/src/interaction-store.ts
@@ -25,6 +25,12 @@ import {
   runInteractionStoreOperation,
   type InteractionStoreOperationRunner,
 } from './interaction-locator-lane.js';
+import {
+  acquireOperationalStateDatabase,
+  completeOperationalStoreCutover,
+  type OperationalStateDatabaseLease,
+  type OperationalStoreCutoverFailpoint,
+} from './operational-state-store.js';
 
 const SAFE_ID = /^[A-Za-z0-9_-]{1,128}$/;
 const REMEMBER_SCOPE_ID = /^[0-9a-f]{64}$/;
@@ -135,6 +141,12 @@ const writerOpeningsByLease = new WeakMap<
 >();
 const readers = new WeakSet<object>();
 const writers = new WeakSet<object>();
+const sqliteWritersByLease = new WeakMap<object, InteractiveInteractionStoreWriterFacade>();
+const sqliteWriterOpeningsByLease = new WeakMap<
+  object,
+  Promise<InteractiveInteractionStoreWriterFacade>
+>();
+const sqliteFacadeClosers = new WeakMap<object, () => void>();
 
 export function authenticateInteractionStoreReader(
   store: InteractiveInteractionStoreReaderFacade,
@@ -212,6 +224,235 @@ export async function openInteractiveInteractionStoreForWrite(
   }
 }
 
+export interface SqliteInteractionStoreOptions {
+  readonly failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
+}
+
+export async function openSqliteInteractiveInteractionStoreForRead(
+  lease: StorageRootLease<'interactive', 'read'>,
+  options: SqliteInteractionStoreOptions = {},
+): Promise<InteractiveInteractionStoreReaderFacade> {
+  await assertStorageRootLease(lease, 'interactive', 'read');
+  const store = new SqliteInteractionStore(lease.canonicalPath, options);
+  await store.ready();
+  const run = <T>(operation: () => Promise<T>) =>
+    runWithStorageRootLease(lease, 'interactive', 'read', operation);
+  const facade = Object.freeze({
+    kind: 'interactive' as const,
+    access: 'read' as const,
+    readInteraction: (requestId: string) => run(() => store.readInteraction(requestId)),
+    listSessionPending: (sessionId: string) => run(() => store.listSessionPending(sessionId)),
+    listPending: (filter?: PendingInteractionFilter) => run(() => store.listPending(filter)),
+  });
+  readers.add(facade);
+  sqliteFacadeClosers.set(facade, () => store.close());
+  return facade;
+}
+
+export async function openSqliteInteractiveInteractionStoreForWrite(
+  lease: StorageRootLease<'interactive', 'write'>,
+  options: SqliteInteractionStoreOptions = {},
+): Promise<InteractiveInteractionStoreWriterFacade> {
+  await assertStorageRootLease(lease, 'interactive', 'write');
+  const existing = sqliteWritersByLease.get(lease);
+  if (existing) return existing;
+  const opening = sqliteWriterOpeningsByLease.get(lease);
+  if (opening) return opening;
+  const pending = Promise.resolve().then(async () => {
+    const store = new SqliteInteractionStore(lease.canonicalPath, options);
+    await store.ready();
+    const run = <T>(operation: () => Promise<T>) =>
+      runWithStorageRootLease(lease, 'interactive', 'write', operation);
+    const recoveredExisting = sqliteWritersByLease.get(lease);
+    if (recoveredExisting) {
+      store.close();
+      return recoveredExisting;
+    }
+    const facade = Object.freeze({
+      kind: 'interactive' as const,
+      access: 'write' as const,
+      readInteraction: (requestId: string) => run(() => store.readInteraction(requestId)),
+      listSessionPending: (sessionId: string) => run(() => store.listSessionPending(sessionId)),
+      listPending: (filter?: PendingInteractionFilter) => run(() => store.listPending(filter)),
+      establishRequest: (input: StoredInteractionRequest) =>
+        run(() => store.establishRequest(input)),
+      commitOutcome: (requestId: string, outcome: InteractionCanonicalOutcome) =>
+        run(() => store.commitOutcome(requestId, outcome)),
+    });
+    writers.add(facade);
+    sqliteWritersByLease.set(lease, facade);
+    sqliteFacadeClosers.set(facade, () => store.close());
+    return facade;
+  });
+  sqliteWriterOpeningsByLease.set(lease, pending);
+  try {
+    return await pending;
+  } finally {
+    if (sqliteWriterOpeningsByLease.get(lease) === pending) {
+      sqliteWriterOpeningsByLease.delete(lease);
+    }
+  }
+}
+
+export function closeSqliteInteractionStoreFacade(
+  store: InteractiveInteractionStoreReaderFacade | InteractiveInteractionStoreWriterFacade,
+): void {
+  const close = sqliteFacadeClosers.get(store);
+  if (!close) return;
+  sqliteFacadeClosers.delete(store);
+  close();
+}
+
+class SqliteInteractionStore implements InteractionStoreWriter {
+  readonly #root: string;
+  readonly #lease: OperationalStateDatabaseLease;
+  readonly #ready: Promise<void>;
+
+  constructor(root: string, options: SqliteInteractionStoreOptions) {
+    this.#root = resolve(root);
+    this.#lease = acquireOperationalStateDatabase(this.#root);
+    this.#ready = importLegacyInteractions(this.#root, this.#lease, options);
+  }
+
+  ready(): Promise<void> {
+    return this.#ready;
+  }
+
+  async establishRequest(
+    input: StoredInteractionRequest,
+  ): Promise<EstablishInteractionRequestResult> {
+    const candidate = normalizeRequest(input, 'input');
+    const encoded = encode(candidate, STORED_INTERACTION_REQUEST_MAX_BYTES).toString('utf8').trim();
+    await this.#ready;
+    try {
+      return this.#lease.transaction('write', () => {
+        const existing = readSqliteInteraction(this.#lease, candidate.requestId);
+        if (existing) {
+          return {
+            status: 'stable',
+            matches: isDeepStrictEqual(existing.request, candidate),
+            record: existing,
+          };
+        }
+        this.#lease.database
+          .prepare(`
+            INSERT INTO core_interaction_requests(
+              request_id, session_id, turn_id, run_id, request_kind, created_at, record_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+          `)
+          .run(
+            candidate.requestId,
+            candidate.sessionId,
+            candidate.turnId,
+            candidate.runId,
+            candidate.request.kind,
+            candidate.createdAt,
+            encoded,
+          );
+        return {
+          status: 'stable',
+          matches: true,
+          record: deepFreeze({ request: candidate }),
+        };
+      });
+    } catch (error) {
+      return {
+        status: 'unresolved',
+        failure: failure(error, 'Request publication could not be stabilized'),
+      };
+    }
+  }
+
+  async commitOutcome(
+    requestId: string,
+    outcome: InteractionCanonicalOutcome,
+  ): Promise<CommitInteractionOutcomeResult> {
+    assertId(requestId);
+    await this.#ready;
+    return this.#lease.transaction('write', () => {
+      const record = readSqliteInteraction(this.#lease, requestId);
+      if (!record) {
+        throw new InteractionStoreError(
+          'request_not_found',
+          `Interaction request '${requestId}' does not exist`,
+        );
+      }
+      let canonical: InteractionCanonicalOutcome;
+      try {
+        canonical = decodeInteractionCanonicalOutcome(outcome);
+      } catch (error) {
+        decodeFailure('input', 'Invalid Interaction outcome', error);
+      }
+      if (!isInteractionCanonicalOutcomeValidForRequest(record.request.request, canonical)) {
+        throw new InteractionStoreError('invalid_input', 'Outcome is not valid for its request');
+      }
+      const candidate: StoredInteractionOutcome = {
+        ...identity(record.request),
+        outcome: canonical,
+      };
+      const encoded = encode(candidate, STORED_INTERACTION_OUTCOME_MAX_BYTES)
+        .toString('utf8')
+        .trim();
+      this.#lease.database
+        .prepare(`
+          INSERT OR IGNORE INTO core_interaction_outcomes(request_id, record_json)
+          VALUES (?, ?)
+        `)
+        .run(requestId, encoded);
+      const settled = readSqliteInteraction(this.#lease, requestId);
+      if (!settled?.outcome) {
+        throw new InteractionStoreError('io_failed', 'Outcome publication produced no record');
+      }
+      return {
+        status: 'stable',
+        matches: interactionCanonicalOutcomesEquivalent(settled.outcome.outcome, canonical),
+        record: settled as InteractionRecord & { readonly outcome: StoredInteractionOutcome },
+      };
+    });
+  }
+
+  async readInteraction(requestId: string): Promise<InteractionRecord | undefined> {
+    assertId(requestId);
+    await this.#ready;
+    return readSqliteInteraction(this.#lease, requestId);
+  }
+
+  async listSessionPending(sessionId: string): Promise<StoredInteractionRequest[]> {
+    return this.listPending({ sessionId });
+  }
+
+  async listPending(filter: PendingInteractionFilter = {}): Promise<StoredInteractionRequest[]> {
+    normalizeFilter(filter);
+    await this.#ready;
+    const rows = this.#lease.database
+      .prepare(`
+        SELECT request_id
+        FROM core_interaction_requests AS request
+        WHERE NOT EXISTS (
+          SELECT 1 FROM core_interaction_outcomes AS outcome
+          WHERE outcome.request_id = request.request_id
+        )
+        ORDER BY request.created_at, request.request_id
+      `)
+      .all() as Array<{ request_id?: unknown }>;
+    const requests: StoredInteractionRequest[] = [];
+    for (const row of rows) {
+      if (typeof row.request_id !== 'string') {
+        throw new InteractionStoreError('invalid_record', 'Invalid SQLite Interaction identity');
+      }
+      const record = readSqliteInteraction(this.#lease, row.request_id);
+      if (record && !record.outcome && matches(record.request, filter)) {
+        requests.push(record.request);
+      }
+    }
+    return sortPending(requests);
+  }
+
+  close(): void {
+    this.#lease.close();
+  }
+}
+
 class FileInteractionStore {
   private readonly root: string;
   private readonly interactionsRoot: string;
@@ -251,6 +492,33 @@ class FileInteractionStore {
     }
     await sessionPendingDirectoryPolicy.assert(indexRoot);
     await this.reconcileSessionPendingIndex(expectedPending);
+  }
+
+  async listRecordsForMigration(): Promise<InteractionRecord[]> {
+    let rootEntries;
+    try {
+      rootEntries = await readdir(this.interactionsRoot, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+      throw error;
+    }
+    for (const entry of rootEntries) {
+      if (entry.name === 'pending' && entry.isDirectory()) continue;
+      if (!entry.isDirectory() || !LOCATOR.test(entry.name)) invalidInteractionLocator();
+    }
+    const records: InteractionRecord[] = [];
+    for (const locator of await this.locators()) {
+      const bindings = await this.bindExistingLocator(locator);
+      if (!bindings) invalidInteractionLocator();
+      const record = await this.readBoundLocatorUnlocked(bindings);
+      if (!record) invalidInteractionLocator();
+      records.push(record);
+    }
+    return records.sort(
+      (left, right) =>
+        left.request.createdAt - right.request.createdAt ||
+        left.request.requestId.localeCompare(right.request.requestId),
+    );
   }
 
   async establishRequest(
@@ -791,6 +1059,89 @@ class FileInteractionStore {
   ): Promise<T> {
     return this.locatorLane.run(locator, authorize, operation);
   }
+}
+
+async function importLegacyInteractions(
+  root: string,
+  lease: OperationalStateDatabaseLease,
+  options: SqliteInteractionStoreOptions,
+): Promise<void> {
+  const records = await new FileInteractionStore(root, false).listRecordsForMigration();
+  const fingerprint = createHash('sha256').update(JSON.stringify(records)).digest('hex');
+  completeOperationalStoreCutover(lease, {
+    storeName: 'interactions',
+    sourcePath: join(root, 'interactions'),
+    sourceFingerprint: `sha256:${fingerprint}`,
+    failpoint: options.failpoint,
+    importAndValidate: (db) => {
+      for (const record of records) insertOrValidateInteraction(db, record);
+      return {
+        interaction_requests: records.length,
+        interaction_outcomes: records.filter((record) => record.outcome !== undefined).length,
+      };
+    },
+  });
+}
+
+function insertOrValidateInteraction(
+  db: import('node:sqlite').DatabaseSync,
+  record: InteractionRecord,
+): void {
+  const request = normalizeRequest(record.request, 'record');
+  db.prepare(`
+    INSERT OR IGNORE INTO core_interaction_requests(
+      request_id, session_id, turn_id, run_id, request_kind, created_at, record_json
+    ) VALUES (?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    request.requestId,
+    request.sessionId,
+    request.turnId,
+    request.runId,
+    request.request.kind,
+    request.createdAt,
+    JSON.stringify(request),
+  );
+  if (record.outcome) {
+    const outcome = normalizeOutcome(record.outcome, request);
+    db.prepare(`
+      INSERT OR IGNORE INTO core_interaction_outcomes(request_id, record_json)
+      VALUES (?, ?)
+    `).run(request.requestId, JSON.stringify(outcome));
+  }
+  const leaseLike = { database: db } as OperationalStateDatabaseLease;
+  const existing = readSqliteInteraction(leaseLike, request.requestId);
+  if (!existing || !isDeepStrictEqual(existing, deepFreeze(record))) {
+    throw new Error(`Interaction cutover conflict: ${request.requestId}`);
+  }
+}
+
+function readSqliteInteraction(
+  lease: Pick<OperationalStateDatabaseLease, 'database'>,
+  requestId: string,
+): InteractionRecord | undefined {
+  const row = lease.database
+    .prepare(`
+      SELECT request.record_json AS request_json, outcome.record_json AS outcome_json
+      FROM core_interaction_requests AS request
+      LEFT JOIN core_interaction_outcomes AS outcome ON outcome.request_id = request.request_id
+      WHERE request.request_id = ?
+    `)
+    .get(requestId) as { request_json?: unknown; outcome_json?: unknown } | undefined;
+  if (!row) return undefined;
+  if (typeof row.request_json !== 'string') {
+    throw new InteractionStoreError('invalid_record', 'Invalid SQLite Interaction request');
+  }
+  const request = normalizeRequest(JSON.parse(row.request_json), 'record');
+  if (request.requestId !== requestId) {
+    throw new InteractionStoreError('invalid_record', 'Request identity does not match row');
+  }
+  const outcome =
+    row.outcome_json === null || row.outcome_json === undefined
+      ? undefined
+      : typeof row.outcome_json === 'string'
+        ? normalizeOutcome(JSON.parse(row.outcome_json), request)
+        : decodeFailure('record', 'Invalid SQLite Interaction outcome');
+  return deepFreeze({ request, ...(outcome ? { outcome } : {}) });
 }
 
 function addPendingLocator(

--- a/packages/storage/src/message-receipt-store.ts
+++ b/packages/storage/src/message-receipt-store.ts
@@ -1,7 +1,14 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { link, mkdir, open, readFile, readdir, rm, unlink } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
+import type { DatabaseSync } from 'node:sqlite';
+import {
+  acquireOperationalStateDatabase,
+  completeOperationalStoreCutover,
+  type OperationalStateDatabaseLease,
+  type OperationalStoreCutoverFailpoint,
+} from './operational-state-store.js';
 import { syncDirectory, syncDirectoryChain } from './stable-storage.js';
 import { chainWrite } from './write-queue.js';
 
@@ -45,6 +52,127 @@ interface StoredMessageOperationReceipt {
 
 export function createMessageReceiptStore(workspaceRoot: string): MessageReceiptStore {
   return new FileMessageReceiptStore(workspaceRoot);
+}
+
+export interface SqliteMessageReceiptStoreOptions {
+  readonly failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
+}
+
+export interface ClosableMessageReceiptStore extends MessageReceiptStore {
+  ready(): Promise<void>;
+  close(): void;
+}
+
+export function createSqliteMessageReceiptStore(
+  workspaceRoot: string,
+  options: SqliteMessageReceiptStoreOptions = {},
+): ClosableMessageReceiptStore {
+  return new SqliteMessageReceiptStore(workspaceRoot, options);
+}
+
+class SqliteMessageReceiptStore implements ClosableMessageReceiptStore {
+  readonly #root: string;
+  readonly #lease: OperationalStateDatabaseLease;
+  readonly #ready: Promise<void>;
+
+  constructor(workspaceRoot: string, options: SqliteMessageReceiptStoreOptions) {
+    this.#root = resolve(workspaceRoot);
+    this.#lease = acquireOperationalStateDatabase(this.#root);
+    this.#ready = importLegacyMessageReceipts(this.#root, this.#lease, options);
+  }
+
+  ready(): Promise<void> {
+    return this.#ready;
+  }
+
+  async beginHostEpoch(hostEpoch: string): Promise<void> {
+    validateHostEpoch(hostEpoch);
+    await this.#ready;
+    this.#lease.transaction('write', () => {
+      this.#lease.database
+        .prepare('INSERT OR IGNORE INTO core_message_host_epochs(host_epoch) VALUES (?)')
+        .run(hostEpoch);
+      this.#lease.database
+        .prepare('DELETE FROM core_message_host_epochs WHERE host_epoch <> ?')
+        .run(hostEpoch);
+    });
+  }
+
+  async read(
+    hostEpoch: string,
+    operation: MessageReceiptOperation,
+    sessionId: string,
+    operationId: string,
+  ): Promise<MessageOperationReceipt | undefined> {
+    validateIdentity(hostEpoch, operation, sessionId, operationId);
+    await this.#ready;
+    const row = this.#lease.database
+      .prepare(`
+        SELECT payload_json, result_json
+        FROM core_message_receipts
+        WHERE host_epoch = ? AND operation = ? AND session_id = ? AND operation_id = ?
+      `)
+      .get(hostEpoch, operation, sessionId, operationId) as
+      | { payload_json?: unknown; result_json?: unknown }
+      | undefined;
+    if (!row) return undefined;
+    if (typeof row.payload_json !== 'string' || typeof row.result_json !== 'string') {
+      throw new Error('Invalid SQLite message operation receipt');
+    }
+    return Object.freeze({
+      payload: JSON.parse(row.payload_json),
+      result: JSON.parse(row.result_json),
+    });
+  }
+
+  async commit(
+    hostEpoch: string,
+    operation: MessageReceiptOperation,
+    sessionId: string,
+    operationId: string,
+    receipt: MessageOperationReceipt,
+  ): Promise<MessageOperationReceipt> {
+    validateIdentity(hostEpoch, operation, sessionId, operationId);
+    const stored = normalizeReceipt(hostEpoch, operation, sessionId, operationId, receipt);
+    await this.#ready;
+    return this.#lease.transaction('write', () => {
+      this.#lease.database
+        .prepare('INSERT OR IGNORE INTO core_message_host_epochs(host_epoch) VALUES (?)')
+        .run(hostEpoch);
+      const inserted = this.#lease.database
+        .prepare(`
+          INSERT OR IGNORE INTO core_message_receipts(
+            host_epoch, operation, session_id, operation_id, payload_json, result_json
+          ) VALUES (?, ?, ?, ?, ?, ?)
+        `)
+        .run(
+          hostEpoch,
+          operation,
+          sessionId,
+          operationId,
+          JSON.stringify(stored.payload),
+          JSON.stringify(stored.result),
+        );
+      if (inserted.changes === 0) {
+        const existing = readSqliteReceipt(
+          this.#lease.database,
+          hostEpoch,
+          operation,
+          sessionId,
+          operationId,
+        );
+        if (!existing || !isDeepStrictEqual(existing, stored)) {
+          throw new Error('Message operation receipt identity conflict');
+        }
+        return existing;
+      }
+      return stored;
+    });
+  }
+
+  close(): void {
+    this.#lease.close();
+  }
 }
 
 class FileMessageReceiptStore implements MessageReceiptStore {
@@ -162,6 +290,210 @@ class FileMessageReceiptStore implements MessageReceiptStore {
     operationId: string,
   ): string {
     return join(this.#epochsRoot, hostEpoch, operation, sessionId, `${operationId}.json`);
+  }
+}
+
+interface LegacyMessageReceiptSnapshot {
+  readonly epochs: readonly string[];
+  readonly records: readonly StoredMessageOperationReceipt[];
+}
+
+async function importLegacyMessageReceipts(
+  root: string,
+  lease: OperationalStateDatabaseLease,
+  options: SqliteMessageReceiptStoreOptions,
+): Promise<void> {
+  const snapshot = await readLegacyMessageReceiptSnapshot(root);
+  const fingerprint = createHash('sha256').update(JSON.stringify(snapshot)).digest('hex');
+  completeOperationalStoreCutover(lease, {
+    storeName: 'message_receipts',
+    sourcePath: join(root, 'message-receipts'),
+    sourceFingerprint: `sha256:${fingerprint}`,
+    failpoint: options.failpoint,
+    importAndValidate: (db) => {
+      for (const epoch of snapshot.epochs) {
+        db.prepare('INSERT OR IGNORE INTO core_message_host_epochs(host_epoch) VALUES (?)').run(
+          epoch,
+        );
+      }
+      for (const record of snapshot.records) {
+        insertOrValidateReceipt(db, record);
+      }
+      return {
+        host_epochs: snapshot.epochs.length,
+        message_receipts: snapshot.records.length,
+      };
+    },
+  });
+}
+
+async function readLegacyMessageReceiptSnapshot(
+  root: string,
+): Promise<LegacyMessageReceiptSnapshot> {
+  const epochsRoot = join(root, 'message-receipts');
+  let epochEntries;
+  try {
+    epochEntries = await readdir(epochsRoot, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { epochs: [], records: [] };
+    }
+    throw error;
+  }
+  const legacy = new FileMessageReceiptStore(root);
+  const epochs: string[] = [];
+  const records: StoredMessageOperationReceipt[] = [];
+  for (const epochEntry of epochEntries.sort((a, b) => a.name.localeCompare(b.name))) {
+    validateHostEpochEntry(epochEntry.name, epochEntry.isDirectory());
+    epochs.push(epochEntry.name);
+    const epochRoot = join(epochsRoot, epochEntry.name);
+    for (const operation of ['interrupt', 'retract', 'submit'] as const) {
+      const operationRoot = join(epochRoot, operation);
+      let sessionEntries;
+      try {
+        sessionEntries = await readdir(operationRoot, { withFileTypes: true });
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw error;
+      }
+      for (const sessionEntry of sessionEntries.sort((a, b) => a.name.localeCompare(b.name))) {
+        if (!sessionEntry.isDirectory() || !SAFE_ID_PATTERN.test(sessionEntry.name)) {
+          throw new Error(`Invalid message receipt Session entry: ${sessionEntry.name}`);
+        }
+        const sessionRoot = join(operationRoot, sessionEntry.name);
+        const receiptEntries = await readdir(sessionRoot, { withFileTypes: true });
+        for (const receiptEntry of receiptEntries.sort((a, b) => a.name.localeCompare(b.name))) {
+          if (!receiptEntry.isFile() || !receiptEntry.name.endsWith('.json')) {
+            throw new Error(`Invalid message receipt entry: ${receiptEntry.name}`);
+          }
+          const operationId = receiptEntry.name.slice(0, -'.json'.length);
+          validateIdentity(epochEntry.name, operation, sessionEntry.name, operationId);
+          const receipt = await legacy.read(
+            epochEntry.name,
+            operation,
+            sessionEntry.name,
+            operationId,
+          );
+          if (!receipt) throw new Error('Legacy message operation receipt disappeared');
+          records.push({
+            schemaVersion: RECEIPT_SCHEMA_VERSION,
+            hostEpoch: epochEntry.name,
+            operation,
+            sessionId: sessionEntry.name,
+            operationId,
+            payload: receipt.payload,
+            result: receipt.result,
+          });
+        }
+      }
+    }
+    const unexpected = (await readdir(epochRoot, { withFileTypes: true })).filter(
+      (entry) =>
+        !entry.isDirectory() ||
+        (entry.name !== 'submit' && entry.name !== 'retract' && entry.name !== 'interrupt'),
+    );
+    if (unexpected.length > 0) {
+      throw new Error(`Invalid message receipt Operation entry: ${unexpected[0]!.name}`);
+    }
+  }
+  return { epochs, records };
+}
+
+function insertOrValidateReceipt(db: DatabaseSync, record: StoredMessageOperationReceipt): void {
+  db.prepare('INSERT OR IGNORE INTO core_message_host_epochs(host_epoch) VALUES (?)').run(
+    record.hostEpoch,
+  );
+  const inserted = db
+    .prepare(`
+      INSERT OR IGNORE INTO core_message_receipts(
+        host_epoch, operation, session_id, operation_id, payload_json, result_json
+      ) VALUES (?, ?, ?, ?, ?, ?)
+    `)
+    .run(
+      record.hostEpoch,
+      record.operation,
+      record.sessionId,
+      record.operationId,
+      JSON.stringify(record.payload),
+      JSON.stringify(record.result),
+    );
+  if (inserted.changes !== 0) return;
+  const existing = readSqliteReceipt(
+    db,
+    record.hostEpoch,
+    record.operation,
+    record.sessionId,
+    record.operationId,
+  );
+  if (
+    !existing ||
+    !isDeepStrictEqual(existing, { payload: record.payload, result: record.result })
+  ) {
+    throw new Error('Message receipt cutover conflict');
+  }
+}
+
+function readSqliteReceipt(
+  db: DatabaseSync,
+  hostEpoch: string,
+  operation: MessageReceiptOperation,
+  sessionId: string,
+  operationId: string,
+): MessageOperationReceipt | undefined {
+  const row = db
+    .prepare(`
+      SELECT payload_json, result_json
+      FROM core_message_receipts
+      WHERE host_epoch = ? AND operation = ? AND session_id = ? AND operation_id = ?
+    `)
+    .get(hostEpoch, operation, sessionId, operationId) as
+    | { payload_json?: unknown; result_json?: unknown }
+    | undefined;
+  if (!row) return undefined;
+  if (typeof row.payload_json !== 'string' || typeof row.result_json !== 'string') {
+    throw new Error('Invalid SQLite message operation receipt');
+  }
+  return Object.freeze({
+    payload: JSON.parse(row.payload_json),
+    result: JSON.parse(row.result_json),
+  });
+}
+
+function normalizeReceipt(
+  hostEpoch: string,
+  operation: MessageReceiptOperation,
+  sessionId: string,
+  operationId: string,
+  receipt: MessageOperationReceipt,
+): MessageOperationReceipt {
+  const encoded = JSON.stringify({
+    schemaVersion: RECEIPT_SCHEMA_VERSION,
+    hostEpoch,
+    operation,
+    sessionId,
+    operationId,
+    payload: receipt.payload,
+    result: receipt.result,
+  });
+  if (Buffer.byteLength(`${encoded}\n`, 'utf8') > RECEIPT_MAX_BYTES) {
+    throw new Error('Message operation receipt exceeds size limit');
+  }
+  const decoded = decodeStoredReceipt(JSON.parse(encoded), {
+    hostEpoch,
+    operation,
+    sessionId,
+    operationId,
+  });
+  return Object.freeze({ payload: decoded.payload, result: decoded.result });
+}
+
+function validateHostEpoch(hostEpoch: string): void {
+  assertSafeId(hostEpoch, 'Invalid Host Epoch');
+}
+
+function validateHostEpochEntry(name: string, directory: boolean): void {
+  if (!directory || !SAFE_ID_PATTERN.test(name)) {
+    throw new Error(`Invalid message receipt Epoch entry: ${name}`);
   }
 }
 

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -12,6 +12,10 @@ import {
   migrateSqliteSessionMetadataDatabase,
   SQLITE_SESSION_METADATA_SCHEMA_VERSION,
 } from './sqlite-session-metadata-schema.js';
+import {
+  migrateSqliteCoreExecutionDatabase,
+  SQLITE_CORE_EXECUTION_SCHEMA_VERSION,
+} from './sqlite-core-execution-schema.js';
 
 export const OPERATIONAL_STATE_DATABASE_NAME = 'runtime.sqlite';
 export const LEGACY_SESSION_METADATA_DATABASE_NAME = 'sessions.sqlite';
@@ -53,6 +57,20 @@ export interface OperationalStateDatabaseLease {
   readonly databasePath: string;
   transaction<T>(mode: 'read' | 'write', operation: () => T): T;
   close(): void;
+}
+
+export type OperationalStoreCutoverFailpoint =
+  | 'after_cutover_started'
+  | 'after_cutover_rows_copied'
+  | 'after_cutover_validated';
+
+export interface OperationalStoreCutoverInput {
+  readonly storeName: string;
+  readonly sourcePath: string;
+  readonly sourceFingerprint: string;
+  readonly importAndValidate: (database: DatabaseSync) => Readonly<Record<string, number>>;
+  readonly now?: () => number;
+  readonly failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
 }
 
 interface CutoverJournalRow {
@@ -102,6 +120,7 @@ class OperationalStateDatabaseOwner {
       configureSqliteRuntimeDatabase(this.database);
       migrateSqliteRuntimeDatabase(this.database);
       migrateSqliteSessionMetadataDatabase(this.database);
+      migrateSqliteCoreExecutionDatabase(this.database);
       migrateOperationalStateDatabase(this.database, options.now ?? Date.now);
       cutoverLegacySessionMetadata({
         destination: this.database,
@@ -178,12 +197,85 @@ function migrateOperationalStateDatabase(db: DatabaseSync, now: () => number): v
     const appliedAt = now();
     registerSchema(db, 'runtime', SQLITE_RUNTIME_SCHEMA_VERSION, appliedAt);
     registerSchema(db, 'session_metadata', SQLITE_SESSION_METADATA_SCHEMA_VERSION, appliedAt);
+    registerSchema(db, 'core_execution', SQLITE_CORE_EXECUTION_SCHEMA_VERSION, appliedAt);
     registerSchema(db, 'operational', OPERATIONAL_STATE_SCHEMA_VERSION, appliedAt);
     db.exec('COMMIT');
   } catch (error) {
     rollback(db);
     throw error;
   }
+}
+
+/**
+ * Complete one logical legacy-store cutover under the operational owner.
+ *
+ * The durable `started` row intentionally commits before the data transaction.
+ * A crash therefore resumes against the same source fingerprint, while copied
+ * rows and the completed marker commit atomically.
+ */
+export function completeOperationalStoreCutover(
+  lease: OperationalStateDatabaseLease,
+  input: OperationalStoreCutoverInput,
+): void {
+  const journal = lease.database
+    .prepare(`
+      SELECT source_fingerprint, state
+      FROM cutover_journal
+      WHERE store_name = ?
+    `)
+    .get(input.storeName) as CutoverJournalRow | undefined;
+  if (journal?.state === 'completed') {
+    if (journal.source_fingerprint !== input.sourceFingerprint) {
+      throw new Error(`Legacy ${input.storeName} source changed after cutover completed`);
+    }
+    return;
+  }
+  if (journal && journal.source_fingerprint !== input.sourceFingerprint) {
+    throw new Error(`Legacy ${input.storeName} source changed after cutover started`);
+  }
+  if (!journal) {
+    lease.transaction('write', () => {
+      lease.database
+        .prepare(`
+          INSERT INTO cutover_journal(
+            store_name,
+            source_path,
+            source_fingerprint,
+            state,
+            started_at
+          ) VALUES (?, ?, ?, 'started', ?)
+        `)
+        .run(input.storeName, input.sourcePath, input.sourceFingerprint, (input.now ?? Date.now)());
+    });
+  }
+  input.failpoint?.('after_cutover_started');
+  lease.transaction('write', () => {
+    const validation = input.importAndValidate(lease.database);
+    input.failpoint?.('after_cutover_rows_copied');
+    for (const [name, count] of Object.entries(validation)) {
+      if (!Number.isSafeInteger(count) || count < 0) {
+        throw new Error(`Invalid ${input.storeName} cutover validation count for ${name}`);
+      }
+    }
+    input.failpoint?.('after_cutover_validated');
+    const result = lease.database
+      .prepare(`
+        UPDATE cutover_journal
+        SET state = 'completed', completed_at = ?, validation_json = ?
+        WHERE store_name = ?
+          AND source_fingerprint = ?
+          AND state = 'started'
+      `)
+      .run(
+        (input.now ?? Date.now)(),
+        JSON.stringify(validation),
+        input.storeName,
+        input.sourceFingerprint,
+      );
+    if (result.changes !== 1) {
+      throw new Error(`Unable to complete ${input.storeName} cutover journal`);
+    }
+  });
 }
 
 function registerSchema(db: DatabaseSync, scope: string, version: number, appliedAt: number): void {

--- a/packages/storage/src/shell-run-store.ts
+++ b/packages/storage/src/shell-run-store.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import { access, mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname, join } from 'node:path';
 import { isDeepStrictEqual } from 'node:util';
@@ -16,6 +16,12 @@ import {
 } from '@maka/core';
 import { syncDirectoryChain, syncFile } from './stable-storage.js';
 import { chainWrite } from './write-queue.js';
+import {
+  acquireOperationalStateDatabase,
+  completeOperationalStoreCutover,
+  type OperationalStateDatabaseLease,
+  type OperationalStoreCutoverFailpoint,
+} from './operational-state-store.js';
 
 const SESSION_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 const SHELL_RUN_PATCH_KEYS = new Set([
@@ -75,6 +81,135 @@ const LEGACY_SHELL_RUN_RECORD_KEYS = new Set([
 
 export function createShellRunStore(workspaceRoot: string): ShellRunStore {
   return new FileShellRunStore(workspaceRoot);
+}
+
+export interface SqliteShellRunStoreOptions {
+  readonly failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
+}
+
+export interface ClosableShellRunStore extends ShellRunStore {
+  ready(): Promise<void>;
+  close(): void;
+}
+
+export function createSqliteShellRunStore(
+  workspaceRoot: string,
+  options: SqliteShellRunStoreOptions = {},
+): ClosableShellRunStore {
+  return new SqliteShellRunStore(workspaceRoot, options);
+}
+
+class SqliteShellRunStore implements ClosableShellRunStore {
+  readonly #root: string;
+  readonly #lease: OperationalStateDatabaseLease;
+  readonly #ready: Promise<void>;
+
+  constructor(workspaceRoot: string, options: SqliteShellRunStoreOptions) {
+    this.#root = workspaceRoot;
+    this.#lease = acquireOperationalStateDatabase(workspaceRoot);
+    this.#ready = importLegacyShellRuns(workspaceRoot, this.#lease, options);
+  }
+
+  ready(): Promise<void> {
+    return this.#ready;
+  }
+
+  async createShellRun(record: ShellRunRecord): Promise<ShellRunRecord> {
+    assertSessionId(record.sessionId);
+    assertShellRunId(record.shellRunId);
+    const normalized = normalizeShellRunRecord(record, record.sessionId, record.shellRunId);
+    await this.#ready;
+    this.#lease.transaction('write', () => {
+      const result = this.#lease.database
+        .prepare(`
+          INSERT OR IGNORE INTO core_shell_runs(
+            session_id, shell_run_id, started_at, record_json
+          ) VALUES (?, ?, ?, ?)
+        `)
+        .run(
+          normalized.sessionId,
+          normalized.shellRunId,
+          normalized.startedAt,
+          JSON.stringify(normalized, sanitizeJson),
+        );
+      if (result.changes !== 1) {
+        throw new Error(`ShellRun already exists: ${normalized.shellRunId}`);
+      }
+    });
+    return normalized;
+  }
+
+  async updateShellRun(
+    sessionId: string,
+    shellRunId: string,
+    patch: ShellRunPatch,
+  ): Promise<ShellRunRecord> {
+    assertSessionId(sessionId);
+    assertShellRunId(shellRunId);
+    assertShellRunPatch(patch);
+    await this.#ready;
+    return this.#lease.transaction('write', () => {
+      const current = readSqliteShellRun(this.#lease.database, sessionId, shellRunId);
+      if (patch.output && patch.output.mode !== current.output.mode) {
+        throw new Error(`ShellRun output mode is immutable: ${current.output.mode}`);
+      }
+      const effectivePatch =
+        current.observedAt !== undefined && Object.hasOwn(patch, 'observedAt')
+          ? { ...patch, observedAt: current.observedAt }
+          : patch;
+      const candidate = normalizeShellRunRecord(
+        { ...current, ...effectivePatch, sessionId, shellRunId, revision: current.revision },
+        sessionId,
+        shellRunId,
+      );
+      assertShellRunTransition(current, candidate);
+      if (isDeepStrictEqual(candidate, current)) return current;
+      const next = normalizeShellRunRecord(
+        { ...candidate, revision: current.revision + 1 },
+        sessionId,
+        shellRunId,
+      );
+      const result = this.#lease.database
+        .prepare(`
+          UPDATE core_shell_runs
+          SET started_at = ?, record_json = ?
+          WHERE session_id = ? AND shell_run_id = ?
+        `)
+        .run(next.startedAt, JSON.stringify(next, sanitizeJson), sessionId, shellRunId);
+      if (result.changes !== 1) throw new Error(`Failed to update shell run ${shellRunId}`);
+      return next;
+    });
+  }
+
+  async readShellRun(sessionId: string, shellRunId: string): Promise<ShellRunRecord> {
+    assertSessionId(sessionId);
+    assertShellRunId(shellRunId);
+    await this.#ready;
+    return readSqliteShellRun(this.#lease.database, sessionId, shellRunId);
+  }
+
+  async listSessionShellRuns(sessionId: string): Promise<ShellRunRecord[]> {
+    assertSessionId(sessionId);
+    await this.#ready;
+    const rows = this.#lease.database
+      .prepare(`
+        SELECT shell_run_id, record_json
+        FROM core_shell_runs
+        WHERE session_id = ?
+        ORDER BY started_at, shell_run_id
+      `)
+      .all(sessionId) as Array<{ shell_run_id?: unknown; record_json?: unknown }>;
+    return rows.map((row) => {
+      if (typeof row.shell_run_id !== 'string' || typeof row.record_json !== 'string') {
+        throw new Error('Invalid SQLite ShellRun row');
+      }
+      return normalizeShellRunRecord(JSON.parse(row.record_json), sessionId, row.shell_run_id);
+    });
+  }
+
+  close(): void {
+    this.#lease.close();
+  }
 }
 
 class FileShellRunStore implements ShellRunStore {
@@ -218,6 +353,92 @@ class FileShellRunStore implements ShellRunStore {
     const key = `${sessionId}:${shellRunId}`;
     return chainWrite(this.writeQueues, key, operation);
   }
+}
+
+async function importLegacyShellRuns(
+  root: string,
+  lease: OperationalStateDatabaseLease,
+  options: SqliteShellRunStoreOptions,
+): Promise<void> {
+  const records = await readLegacyShellRuns(root);
+  const fingerprint = createHash('sha256').update(JSON.stringify(records)).digest('hex');
+  completeOperationalStoreCutover(lease, {
+    storeName: 'shell_runs',
+    sourcePath: join(root, 'sessions'),
+    sourceFingerprint: `sha256:${fingerprint}`,
+    failpoint: options.failpoint,
+    importAndValidate: (db) => {
+      for (const record of records) insertOrValidateShellRun(db, record);
+      return { shell_runs: records.length };
+    },
+  });
+}
+
+async function readLegacyShellRuns(root: string): Promise<ShellRunRecord[]> {
+  const sessionsRoot = join(root, 'sessions');
+  let sessions;
+  try {
+    sessions = await readdir(sessionsRoot, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+  const legacy = new FileShellRunStore(root);
+  const records: ShellRunRecord[] = [];
+  for (const session of sessions.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (!session.isDirectory() || !SESSION_ID_PATTERN.test(session.name)) continue;
+    const shellRunsRoot = join(sessionsRoot, session.name, 'shell-runs');
+    let entries;
+    try {
+      entries = await readdir(shellRunsRoot, { withFileTypes: true });
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw error;
+    }
+    for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+      if (!entry.isDirectory() || !isShellRunId(entry.name)) {
+        throw new Error(`Invalid ShellRun entry for session ${session.name}: ${entry.name}`);
+      }
+      records.push(await legacy.readShellRun(session.name, entry.name));
+    }
+  }
+  return records;
+}
+
+function insertOrValidateShellRun(
+  db: import('node:sqlite').DatabaseSync,
+  record: ShellRunRecord,
+): void {
+  const encoded = JSON.stringify(record, sanitizeJson);
+  const result = db
+    .prepare(`
+      INSERT OR IGNORE INTO core_shell_runs(
+        session_id, shell_run_id, started_at, record_json
+      ) VALUES (?, ?, ?, ?)
+    `)
+    .run(record.sessionId, record.shellRunId, record.startedAt, encoded);
+  if (result.changes !== 0) return;
+  const existing = readSqliteShellRun(db, record.sessionId, record.shellRunId);
+  if (!isDeepStrictEqual(existing, record)) {
+    throw new Error(`ShellRun cutover conflict: ${record.shellRunId}`);
+  }
+}
+
+function readSqliteShellRun(
+  db: import('node:sqlite').DatabaseSync,
+  sessionId: string,
+  shellRunId: string,
+): ShellRunRecord {
+  const row = db
+    .prepare(`
+      SELECT record_json
+      FROM core_shell_runs
+      WHERE session_id = ? AND shell_run_id = ?
+    `)
+    .get(sessionId, shellRunId) as { record_json?: unknown } | undefined;
+  if (!row) throw new Error(`ShellRun does not exist: ${shellRunId}`);
+  if (typeof row.record_json !== 'string') throw new Error('Invalid SQLite ShellRun row');
+  return normalizeShellRunRecord(JSON.parse(row.record_json), sessionId, shellRunId);
 }
 
 async function writeAtomic(

--- a/packages/storage/src/sqlite-core-execution-schema.ts
+++ b/packages/storage/src/sqlite-core-execution-schema.ts
@@ -1,0 +1,112 @@
+import type { DatabaseSync } from 'node:sqlite';
+
+export const SQLITE_CORE_EXECUTION_SCHEMA_VERSION = 1;
+
+export function migrateSqliteCoreExecutionDatabase(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS core_agent_runs (
+      session_id TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      record_json TEXT NOT NULL,
+      PRIMARY KEY (session_id, run_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS core_agent_runs_session_order
+      ON core_agent_runs(session_id, created_at, run_id);
+
+    CREATE TABLE IF NOT EXISTS core_agent_run_events (
+      session_id TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      sequence INTEGER NOT NULL CHECK (sequence >= 0),
+      event_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      event_ts INTEGER NOT NULL,
+      record_json TEXT NOT NULL,
+      PRIMARY KEY (session_id, run_id, sequence),
+      FOREIGN KEY (session_id, run_id)
+        REFERENCES core_agent_runs(session_id, run_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE INDEX IF NOT EXISTS core_agent_run_events_identity
+      ON core_agent_run_events(session_id, run_id, event_id);
+
+    CREATE TABLE IF NOT EXISTS core_agent_run_projections (
+      session_id TEXT NOT NULL,
+      event_type TEXT NOT NULL,
+      event_json TEXT,
+      PRIMARY KEY (session_id, event_type)
+    );
+
+    CREATE TABLE IF NOT EXISTS core_root_turn_admissions (
+      session_id TEXT NOT NULL,
+      turn_id TEXT NOT NULL,
+      admitted_at INTEGER NOT NULL,
+      record_json TEXT NOT NULL,
+      PRIMARY KEY (session_id, turn_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS core_root_turn_admissions_order
+      ON core_root_turn_admissions(session_id, admitted_at, turn_id);
+
+    CREATE TABLE IF NOT EXISTS core_root_source_message_proofs (
+      session_id TEXT NOT NULL,
+      message_id TEXT NOT NULL,
+      turn_id TEXT NOT NULL,
+      PRIMARY KEY (session_id, message_id),
+      FOREIGN KEY (session_id, turn_id)
+        REFERENCES core_root_turn_admissions(session_id, turn_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS core_interaction_requests (
+      request_id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      turn_id TEXT NOT NULL,
+      run_id TEXT NOT NULL,
+      request_kind TEXT NOT NULL,
+      created_at INTEGER NOT NULL,
+      record_json TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS core_interaction_pending
+      ON core_interaction_requests(session_id, created_at, request_id);
+
+    CREATE TABLE IF NOT EXISTS core_interaction_outcomes (
+      request_id TEXT PRIMARY KEY,
+      record_json TEXT NOT NULL,
+      FOREIGN KEY (request_id)
+        REFERENCES core_interaction_requests(request_id)
+        ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS core_message_host_epochs (
+      host_epoch TEXT PRIMARY KEY
+    );
+
+    CREATE TABLE IF NOT EXISTS core_message_receipts (
+      host_epoch TEXT NOT NULL,
+      operation TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      operation_id TEXT NOT NULL,
+      payload_json TEXT NOT NULL,
+      result_json TEXT NOT NULL,
+      PRIMARY KEY (host_epoch, operation, session_id, operation_id),
+      FOREIGN KEY (host_epoch)
+        REFERENCES core_message_host_epochs(host_epoch)
+        ON DELETE CASCADE
+    );
+
+    CREATE TABLE IF NOT EXISTS core_shell_runs (
+      session_id TEXT NOT NULL,
+      shell_run_id TEXT NOT NULL,
+      started_at INTEGER NOT NULL,
+      record_json TEXT NOT NULL,
+      PRIMARY KEY (session_id, shell_run_id)
+    );
+
+    CREATE INDEX IF NOT EXISTS core_shell_runs_session_order
+      ON core_shell_runs(session_id, started_at, shell_run_id);
+  `);
+}


### PR DESCRIPTION
## Summary

Implements Stage 3 of #1649 after #1677.

- make `runtime.sqlite` canonical for AgentRun headers/events/projections, root-turn admissions/proofs, interactions, message receipts/Host epochs, and ShellRun metadata
- import legacy JSON/JSONL state once through per-store cutover journal entries, with logical fingerprints, atomic copy+validation, crash failpoints, restart resume, and fail-closed source drift detection
- wire CLI, Desktop/Runtime Host, and Headless execution facades to the shared SQLite repositories and close their database leases with the existing persistence lifecycle
- preserve recovery/evidence semantics, including `ENOENT` behavior and `event_corrupt` projection for damaged AgentRun evidence
- keep transcript JSONL and payload/artifact files unchanged; task ledger, plan, deep research, pricing, and artifact metadata remain Stage 4

Planning: https://github.com/maka-agent/maka-agent/issues/1649#issuecomment-5128734811

## Verification

- `npm --workspace @maka/storage run test` — 836 passed, 0 failed, 1 skipped
- `npm --workspace @maka/runtime-host run test` — passed
- `npm --workspace maka-agent run test` — passed
- `npm --workspace @maka/headless run test:dist` — passed
- storage, Runtime Host, Headless, and CLI typechecks passed
- Biome and `git diff --check` passed
