### PR TITLE
feat(desktop): add high-freedom skin runtime

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -48,6 +48,7 @@
     "@maka/ui": "0.1.0",
     "ai": "^7.0.31",
     "electron-updater": "^6.8.9",
+    "fflate": "^0.8.2",
     "qrcode": "^1.5.4",
     "react": "^19.2.1",
     "react-dom": "^19.2.1",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -39,6 +39,7 @@
   },
   "dependencies": {
     "@base-ui/react": "^1.5.0",
+    "@babel/parser": "^7.29.3",
     "@jackwener/opencli": "1.8.4",
     "@maka/computer-use": "0.1.0",
     "@maka/core": "0.1.0",
@@ -57,7 +58,6 @@
   },
   "devDependencies": {
     "@ant-design/icons-svg": "4.5.0",
-    "@babel/parser": "^7.29.3",
     "@fontsource-variable/geist": "^5.2.9",
     "@fontsource-variable/geist-mono": "^5.2.8",
     "@playwright/test": "^1.61.1",

--- a/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
+++ b/apps/desktop/resources/licenses/npm/THIRD_PARTY_NOTICES.txt
@@ -403,10 +403,131 @@ SOFTWARE.
 
 ================================================================================
 
+Package: @babel/helper-string-parser@7.27.1
+Declared license: MIT
+Selected license: MIT
+Repository: https://github.com/babel/babel.git#packages/babel-helper-string-parser
+
+--- LICENSE ---
+MIT License
+
+Copyright (c) 2014-present Sebastian McKenzie and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
+Package: @babel/helper-validator-identifier@7.28.5
+Declared license: MIT
+Selected license: MIT
+Repository: https://github.com/babel/babel.git#packages/babel-helper-validator-identifier
+
+--- LICENSE ---
+MIT License
+
+Copyright (c) 2014-present Sebastian McKenzie and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
+Package: @babel/parser@7.29.3
+Declared license: MIT
+Selected license: MIT
+Repository: https://github.com/babel/babel.git#packages/babel-parser
+
+--- LICENSE ---
+Copyright (C) 2012-2014 by various contributors (see AUTHORS)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+================================================================================
+
 Package: @babel/runtime@7.29.7
 Declared license: MIT
 Selected license: MIT
 Repository: https://github.com/babel/babel.git#packages/babel-runtime
+
+--- LICENSE ---
+MIT License
+
+Copyright (c) 2014-present Sebastian McKenzie and other contributors
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+================================================================================
+
+Package: @babel/types@7.29.0
+Declared license: MIT
+Selected license: MIT
+Repository: https://github.com/babel/babel.git#packages/babel-types
 
 --- LICENSE ---
 MIT License
@@ -8361,6 +8482,36 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 The complete list of contributors can be found at:
 - https://github.com/garycourt/uri-js/graphs/contributors
+
+================================================================================
+
+Package: fflate@0.8.3
+Declared license: MIT
+Selected license: MIT
+Repository: https://github.com/101arrowz/fflate
+
+--- LICENSE ---
+MIT License
+
+Copyright (c) 2026 Arjun Barrett
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
 
 ================================================================================
 

--- a/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
+++ b/apps/desktop/src/main/__tests__/main-process-contract-source-helpers.ts
@@ -88,6 +88,7 @@ export const MAIN_PROCESS_SOURCE_REPO_PATHS: readonly string[] = [
   'apps/desktop/src/main/session-revision.ts',
   'apps/desktop/src/main/session-stream.ts',
   'apps/desktop/src/main/settings-runtime-effects.ts',
+  'apps/desktop/src/main/skin-ipc-main.ts',
   'apps/desktop/src/main/sessions-ipc-main.ts',
   'apps/desktop/src/main/settings-ipc-main.ts',
   'apps/desktop/src/main/subscription-model-fetch.ts',

--- a/apps/desktop/src/main/__tests__/skin-renderer-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/skin-renderer-contract.test.ts
@@ -17,6 +17,18 @@ test('stable skin parts and formal extension slots are mounted by real renderer 
     resolve(REPO_ROOT, 'apps/desktop/src/renderer/chat-composer-region.tsx'),
     'utf8',
   );
+  const sessionPanel = await readFile(
+    resolve(REPO_ROOT, 'packages/ui/src/session-list-panel.tsx'),
+    'utf8',
+  );
+  const sessionHistory = await readFile(
+    resolve(REPO_ROOT, 'packages/ui/src/session-history-list.tsx'),
+    'utf8',
+  );
+  const toolActivity = await readFile(
+    resolve(REPO_ROOT, 'packages/ui/src/tool-activity.tsx'),
+    'utf8',
+  );
 
   for (const part of ['chat', 'chat-header', 'transcript']) {
     assert.match(
@@ -38,6 +50,14 @@ test('stable skin parts and formal extension slots are mounted by real renderer 
   for (const slot of ['composer-before', 'composer-after']) {
     assert.match(composerRegion, new RegExp(`data-maka-slot="${slot}"`));
   }
+  assert.match(sessionPanel, /data-maka-part="session-list"/);
+  assert.match(sessionHistory, /data-maka-part="session-row"/);
+  assert.match(chatView, /data-maka-part="message"/);
+  assert.match(toolActivity, /data-maka-part="tool-card"/);
+  assert.match(composerRegion, /data-maka-part="interaction"/);
+  for (const source of [sessionPanel, sessionHistory, chatView, toolActivity, composerRegion]) {
+    assert.match(source, /data-maka-slot=/);
+  }
 });
 
 test('skin action requests are routed through the permission and trusted-gesture host', async () => {
@@ -49,4 +69,30 @@ test('skin action requests are routed through the permission and trusted-gesture
   assert.match(host, /authorizeAction\(\s*action,/);
   assert.match(host, /One trusted gesture authorizes at most one action request/);
   assert.match(host, /pending user content|owns staged user content/);
+  assert.match(host, /composer\.set-draft/);
+  assert.match(host, /interaction\.answer-question/);
+  const ipcHost = await readFile(
+    resolve(REPO_ROOT, 'apps/desktop/src/main/skin-ipc-main.ts'),
+    'utf8',
+  );
+  assert.match(ipcHost, /composer\.set-permission-mode/);
+  assert.match(ipcHost, /Allow skin to change the permission mode/);
+});
+
+test('permissioned rich projections support initial snapshot replay', async () => {
+  const semanticHost = await readFile(
+    resolve(REPO_ROOT, 'apps/desktop/src/renderer/use-skin-semantic-events.ts'),
+    'utf8',
+  );
+  for (const event of [
+    'sessions.changed',
+    'conversation.changed',
+    'tools.detail.changed',
+    'interaction.detail.changed',
+    'composer.changed',
+  ]) {
+    assert.match(semanticHost, new RegExp(event.replace('.', '\\.')));
+  }
+  assert.match(semanticHost, /maka:skin-snapshot-request/);
+  assert.match(semanticHost, /displayRedactSecrets/);
 });

--- a/apps/desktop/src/main/__tests__/skin-renderer-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/skin-renderer-contract.test.ts
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import test from 'node:test';
+import { REPO_ROOT } from './main-process-contract-source-helpers.js';
+
+test('stable skin parts and formal extension slots are mounted by real renderer components', async () => {
+  const chatView = await readFile(
+    resolve(REPO_ROOT, 'packages/ui/src/chat-view.tsx'),
+    'utf8',
+  );
+  const composer = await readFile(
+    resolve(REPO_ROOT, 'packages/ui/src/composer.tsx'),
+    'utf8',
+  );
+  const composerRegion = await readFile(
+    resolve(REPO_ROOT, 'apps/desktop/src/renderer/chat-composer-region.tsx'),
+    'utf8',
+  );
+
+  for (const part of ['chat', 'chat-header', 'transcript']) {
+    assert.match(
+      chatView,
+      new RegExp(`data-maka-part="${part}"`),
+      `ChatView must expose the stable ${part} part`,
+    );
+  }
+  assert.match(composer, /data-maka-part="composer"/);
+
+  for (const slot of [
+    'chat-header-before',
+    'chat-header-after',
+    'transcript-before',
+    'transcript-after',
+  ]) {
+    assert.match(chatView, new RegExp(`data-maka-slot="${slot}"`));
+  }
+  for (const slot of ['composer-before', 'composer-after']) {
+    assert.match(composerRegion, new RegExp(`data-maka-slot="${slot}"`));
+  }
+});
+
+test('skin action requests are routed through the permission and trusted-gesture host', async () => {
+  const host = await readFile(
+    resolve(REPO_ROOT, 'apps/desktop/src/renderer/use-skin-action-host.ts'),
+    'utf8',
+  );
+  assert.match(host, /event\.isTrusted/);
+  assert.match(host, /authorizeAction\(\s*action,/);
+  assert.match(host, /One trusted gesture authorizes at most one action request/);
+  assert.match(host, /pending user content|owns staged user content/);
+});

--- a/apps/desktop/src/main/__tests__/skin-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/skin-runtime.test.ts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import { strToU8, zipSync } from 'fflate';
+import {
+  createSkinRuntime,
+  inlineStylesheetAssets,
+  normalizeArchiveFiles,
+  parseSkinManifest,
+  SkinRuntimeError,
+  type SkinWebContents,
+} from '../skin-runtime.js';
+
+class FakeWebContents implements SkinWebContents {
+  readonly listeners = new Map<string, Array<() => void>>();
+  readonly insertedCss: string[] = [];
+  readonly isolatedScripts: string[] = [];
+  readonly removedCss: string[] = [];
+
+  insertCSS(css: string): Promise<string> {
+    this.insertedCss.push(css);
+    return Promise.resolve(`css-${this.insertedCss.length}`);
+  }
+
+  removeInsertedCSS(key: string): Promise<void> {
+    this.removedCss.push(key);
+    return Promise.resolve();
+  }
+
+  executeJavaScriptInIsolatedWorld(
+    _worldId: number,
+    scripts: Array<{ code: string }>,
+  ): Promise<unknown> {
+    this.isolatedScripts.push(...scripts.map((script) => script.code));
+    return Promise.resolve({ ok: true });
+  }
+
+  isDestroyed(): boolean {
+    return false;
+  }
+
+  on(event: 'did-finish-load' | 'destroyed', listener: () => void): this {
+    const listeners = this.listeners.get(event) ?? [];
+    listeners.push(listener);
+    this.listeners.set(event, listeners);
+    return this;
+  }
+}
+
+const validManifest = {
+  schemaVersion: 1,
+  id: 'test.neon',
+  name: 'Test Neon',
+  version: '1.0.0',
+  styles: 'theme.css',
+  entry: 'entry.mjs',
+  permissions: ['dom', 'canvas', 'storage'],
+};
+
+test('parseSkinManifest validates the package contract', () => {
+  const manifest = parseSkinManifest(validManifest);
+  assert.equal(manifest.id, 'test.neon');
+  assert.deepEqual(manifest.permissions, ['dom', 'canvas', 'storage']);
+  assert.throws(
+    () => parseSkinManifest({ ...validManifest, id: '../escape' }),
+    (error: unknown) =>
+      error instanceof SkinRuntimeError && error.code === 'invalid-manifest',
+  );
+});
+
+test('normalizeArchiveFiles strips one wrapper and rejects traversal', () => {
+  const wrapped = normalizeArchiveFiles({
+    'skin/manifest.json': strToU8('{}'),
+    'skin/theme.css': strToU8(':root{}'),
+  });
+  assert.deepEqual([...wrapped.keys()], ['manifest.json', 'theme.css']);
+  assert.throws(
+    () => normalizeArchiveFiles({
+      'manifest.json': strToU8('{}'),
+      '../outside.txt': strToU8('no'),
+    }),
+    /unsafe path/,
+  );
+});
+
+test('inlineStylesheetAssets converts local asset URLs to data URLs', () => {
+  assert.equal(
+    inlineStylesheetAssets(
+      '.hero { background: url("./assets/bg.png"); }',
+      'theme.css',
+      { 'assets/bg.png': 'data:image/png;base64,AAAA' },
+    ),
+    '.hero { background: url("data:image/png;base64,AAAA"); }',
+  );
+});
+
+test('runtime installs, activates, and disables a high-freedom skin', async () => {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'maka-skin-test-'));
+  try {
+    const archivePath = join(temporaryRoot, 'neon.maka-skin');
+    await writeFile(archivePath, zipSync({
+      'manifest.json': strToU8(JSON.stringify(validManifest)),
+      'theme.css': strToU8('.hero { background: url("./assets/bg.svg"); }'),
+      'entry.mjs': strToU8('export function activate(api) { api.log("ready"); return () => {}; }'),
+      'assets/bg.svg': strToU8('<svg xmlns="http://www.w3.org/2000/svg"/>'),
+    }));
+    const runtime = createSkinRuntime({ rootDir: join(temporaryRoot, 'runtime') });
+    const webContents = new FakeWebContents();
+    runtime.attach(webContents);
+
+    const installed = await runtime.installFromFile(archivePath);
+    assert.equal(installed.installed[0]?.manifest.id, 'test.neon');
+
+    const active = await runtime.activate('test.neon');
+    assert.equal(active.activeSkinId, 'test.neon');
+    assert.match(webContents.insertedCss[0] ?? '', /data:image\/svg\+xml;base64/);
+    assert.match(webContents.isolatedScripts.at(-1) ?? '', /Test Neon/);
+
+    const state = JSON.parse(
+      await readFile(join(temporaryRoot, 'runtime', 'state.json'), 'utf8'),
+    ) as { activationPending: boolean };
+    assert.equal(state.activationPending, false);
+
+    const disabled = await runtime.disable();
+    assert.equal(disabled.activeSkinId, null);
+    assert.deepEqual(webContents.removedCss, ['css-1']);
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test('runtime recovers from an activation interrupted by a crash', async () => {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'maka-skin-recovery-'));
+  try {
+    await writeFile(
+      join(temporaryRoot, 'state.json'),
+      JSON.stringify({
+        activeSkinId: 'test.neon',
+        activationPending: true,
+        lastError: null,
+      }),
+    );
+    const runtime = createSkinRuntime({ rootDir: temporaryRoot });
+    const snapshot = await runtime.list();
+    assert.equal(snapshot.activeSkinId, null);
+    assert.equal(snapshot.recoveredFromFailedActivation, true);
+    assert.match(snapshot.lastError ?? '', /disabled the previous skin/);
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});

--- a/apps/desktop/src/main/__tests__/skin-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/skin-runtime.test.ts
@@ -6,6 +6,7 @@ import test from 'node:test';
 import { strToU8, zipSync } from 'fflate';
 import {
   createSkinRuntime,
+  assertSelfContainedSkinModule,
   buildSkinActivationScript,
   inlineStylesheetAssets,
   normalizeArchiveFiles,
@@ -56,24 +57,35 @@ class FakeWebContents implements SkinWebContents {
 }
 
 const validManifest: SkinManifest = {
-  schemaVersion: 1,
+  schemaVersion: 2,
   id: 'test.neon',
   name: 'Test Neon',
   version: '1.0.0',
   styles: 'theme.css',
   entry: 'entry.mjs',
   permissions: ['dom', 'canvas', 'storage'],
+  minimumApiVersion: 2,
+  requiredCapabilities: ['appearance.v1', 'parts.v1'],
 };
 
 test('parseSkinManifest validates the package contract', () => {
   const manifest = parseSkinManifest(validManifest);
   assert.equal(manifest.id, 'test.neon');
   assert.deepEqual(manifest.permissions, ['dom', 'canvas', 'storage']);
+  assert.equal(manifest.minimumApiVersion, 2);
   assert.throws(
     () => parseSkinManifest({ ...validManifest, id: '../escape' }),
     (error: unknown) =>
       error instanceof SkinRuntimeError && error.code === 'invalid-manifest',
   );
+  const legacy = parseSkinManifest({
+    ...validManifest,
+    schemaVersion: 1,
+    minimumApiVersion: undefined,
+    requiredCapabilities: undefined,
+  });
+  assert.equal(legacy.minimumApiVersion, 1);
+  assert.deepEqual(legacy.requiredCapabilities, []);
 });
 
 test('normalizeArchiveFiles strips one wrapper and rejects traversal', () => {
@@ -102,7 +114,7 @@ test('inlineStylesheetAssets converts local asset URLs to data URLs', () => {
   );
 });
 
-test('activation API exposes host appearance, state, environment, tokens, parts, styles, and lifecycle', () => {
+test('activation API exposes versioned capabilities, slots, semantic events, and controlled actions', () => {
   const script = buildSkinActivationScript(
     validManifest,
     'export function activate(api) { api.log(api.apiVersion); }',
@@ -110,11 +122,17 @@ test('activation API exposes host appearance, state, environment, tokens, parts,
   );
   for (const contract of [
     'appearance:',
+    'capabilities:',
+    'permissions:',
     'state:',
     'environment:',
     'tokens: tokenApi',
     'observe(name, handler)',
     'wait(name, timeoutMs = 5000)',
+    'slots:',
+    'mount(name)',
+    'actions:',
+    'invoke(name, input = {})',
     'styles:',
     'lifecycle:',
   ]) {
@@ -122,12 +140,31 @@ test('activation API exposes host appearance, state, environment, tokens, parts,
   }
 });
 
+test('module validation ignores import text in comments and strings but rejects real imports', () => {
+  assert.doesNotThrow(() => assertSelfContainedSkinModule(`
+    // import('comment-only')
+    const example = "import('string-only')";
+    export function activate() {}
+  `));
+  assert.throws(
+    () => assertSelfContainedSkinModule('import value from "module"; export function activate() {}'),
+    /cannot import/,
+  );
+  assert.throws(
+    () => assertSelfContainedSkinModule('export async function activate() { await import("module"); }'),
+    /cannot import/,
+  );
+});
+
 test('runtime installs, activates, and disables a high-freedom skin', async () => {
   const temporaryRoot = await mkdtemp(join(tmpdir(), 'maka-skin-test-'));
   try {
     const archivePath = join(temporaryRoot, 'neon.maka-skin');
     await writeFile(archivePath, zipSync({
-      'manifest.json': strToU8(JSON.stringify(validManifest)),
+      'manifest.json': strToU8(JSON.stringify({
+        ...validManifest,
+        permissions: [...validManifest.permissions, 'actions.stop'],
+      })),
       'theme.css': strToU8('.hero { background: url("./assets/bg.svg"); }'),
       'entry.mjs': strToU8('export function activate(api) { api.log("ready"); return () => {}; }'),
       'assets/bg.svg': strToU8('<svg xmlns="http://www.w3.org/2000/svg"/>'),
@@ -136,18 +173,33 @@ test('runtime installs, activates, and disables a high-freedom skin', async () =
     const webContents = new FakeWebContents();
     runtime.attach(webContents);
 
-    const installed = await runtime.installFromFile(archivePath);
+    const inspection = await runtime.inspectFile(archivePath);
+    assert.equal(inspection.manifest.id, 'test.neon');
+    assert.match(inspection.archiveDigest, /^[a-f0-9]{64}$/);
+    const installed = await runtime.installFromFile(archivePath, inspection.archiveDigest);
     assert.equal(installed.installed[0]?.manifest.id, 'test.neon');
 
     const active = await runtime.activate('test.neon');
     assert.equal(active.activeSkinId, 'test.neon');
     assert.match(webContents.insertedCss[0] ?? '', /data:image\/svg\+xml;base64/);
     assert.match(webContents.isolatedScripts.at(-1) ?? '', /Test Neon/);
+    assert.equal(await runtime.authorizeAction('composer.submit'), false);
+    assert.equal(await runtime.authorizeAction('generation.stop'), true);
 
     const state = JSON.parse(
       await readFile(join(temporaryRoot, 'runtime', 'state.json'), 'utf8'),
     ) as { activationPending: boolean };
     assert.equal(state.activationPending, false);
+
+    await writeFile(archivePath, zipSync({
+      'manifest.json': strToU8(JSON.stringify(validManifest)),
+      'theme.css': strToU8(':root { --changed-after-review: true; }'),
+      'entry.mjs': strToU8('export function activate() {}'),
+    }));
+    await assert.rejects(
+      runtime.installFromFile(archivePath, inspection.archiveDigest),
+      /changed after its permissions were reviewed/,
+    );
 
     const disabled = await runtime.disable();
     assert.equal(disabled.activeSkinId, null);

--- a/apps/desktop/src/main/__tests__/skin-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/skin-runtime.test.ts
@@ -130,7 +130,9 @@ test('activation API exposes versioned capabilities, slots, semantic events, and
     'observe(name, handler)',
     'wait(name, timeoutMs = 5000)',
     'slots:',
-    'mount(name)',
+    'mount(name, ownerId)',
+    'all(name, ownerId)',
+    'snapshot(type)',
     'actions:',
     'invoke(name, input = {})',
     'styles:',
@@ -163,7 +165,7 @@ test('runtime installs, activates, and disables a high-freedom skin', async () =
     await writeFile(archivePath, zipSync({
       'manifest.json': strToU8(JSON.stringify({
         ...validManifest,
-        permissions: [...validManifest.permissions, 'actions.stop'],
+        permissions: [...validManifest.permissions, 'actions.stop', 'actions.composer'],
       })),
       'theme.css': strToU8('.hero { background: url("./assets/bg.svg"); }'),
       'entry.mjs': strToU8('export function activate(api) { api.log("ready"); return () => {}; }'),
@@ -185,6 +187,7 @@ test('runtime installs, activates, and disables a high-freedom skin', async () =
     assert.match(webContents.isolatedScripts.at(-1) ?? '', /Test Neon/);
     assert.equal(await runtime.authorizeAction('composer.submit'), false);
     assert.equal(await runtime.authorizeAction('generation.stop'), true);
+    assert.equal(await runtime.authorizeAction('composer.focus'), true);
 
     const state = JSON.parse(
       await readFile(join(temporaryRoot, 'runtime', 'state.json'), 'utf8'),

--- a/apps/desktop/src/main/__tests__/skin-runtime.test.ts
+++ b/apps/desktop/src/main/__tests__/skin-runtime.test.ts
@@ -6,10 +6,12 @@ import test from 'node:test';
 import { strToU8, zipSync } from 'fflate';
 import {
   createSkinRuntime,
+  buildSkinActivationScript,
   inlineStylesheetAssets,
   normalizeArchiveFiles,
   parseSkinManifest,
   SkinRuntimeError,
+  type SkinManifest,
   type SkinWebContents,
 } from '../skin-runtime.js';
 
@@ -18,6 +20,7 @@ class FakeWebContents implements SkinWebContents {
   readonly insertedCss: string[] = [];
   readonly isolatedScripts: string[] = [];
   readonly removedCss: string[] = [];
+  failurePattern: RegExp | null = null;
 
   insertCSS(css: string): Promise<string> {
     this.insertedCss.push(css);
@@ -34,6 +37,9 @@ class FakeWebContents implements SkinWebContents {
     scripts: Array<{ code: string }>,
   ): Promise<unknown> {
     this.isolatedScripts.push(...scripts.map((script) => script.code));
+    if (this.failurePattern && scripts.some((script) => this.failurePattern?.test(script.code))) {
+      return Promise.resolve({ ok: false, error: 'simulated activation failure' });
+    }
     return Promise.resolve({ ok: true });
   }
 
@@ -49,7 +55,7 @@ class FakeWebContents implements SkinWebContents {
   }
 }
 
-const validManifest = {
+const validManifest: SkinManifest = {
   schemaVersion: 1,
   id: 'test.neon',
   name: 'Test Neon',
@@ -94,6 +100,26 @@ test('inlineStylesheetAssets converts local asset URLs to data URLs', () => {
     ),
     '.hero { background: url("data:image/png;base64,AAAA"); }',
   );
+});
+
+test('activation API exposes host appearance, state, environment, tokens, parts, styles, and lifecycle', () => {
+  const script = buildSkinActivationScript(
+    validManifest,
+    'export function activate(api) { api.log(api.apiVersion); }',
+    {},
+  );
+  for (const contract of [
+    'appearance:',
+    'state:',
+    'environment:',
+    'tokens: tokenApi',
+    'observe(name, handler)',
+    'wait(name, timeoutMs = 5000)',
+    'styles:',
+    'lifecycle:',
+  ]) {
+    assert.match(script, new RegExp(contract.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
 });
 
 test('runtime installs, activates, and disables a high-freedom skin', async () => {
@@ -147,6 +173,57 @@ test('runtime recovers from an activation interrupted by a crash', async () => {
     assert.equal(snapshot.activeSkinId, null);
     assert.equal(snapshot.recoveredFromFailedActivation, true);
     assert.match(snapshot.lastError ?? '', /disabled the previous skin/);
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+});
+
+test('runtime updates, reloads, and uninstalls a skin without restarting', async () => {
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'maka-skin-update-test-'));
+  try {
+    const archivePath = join(temporaryRoot, 'neon.maka-skin');
+    const writeArchive = (
+      version: string,
+      color: string,
+      entry = 'export function activate() {}',
+    ) =>
+      writeFile(archivePath, zipSync({
+        'manifest.json': strToU8(JSON.stringify({ ...validManifest, version, preview: 'preview.svg' })),
+        'theme.css': strToU8(`:root { --accent: ${color}; }`),
+        'entry.mjs': strToU8(entry),
+        'preview.svg': strToU8('<svg xmlns="http://www.w3.org/2000/svg"/>'),
+      }));
+    await writeArchive('1.0.0', 'red');
+
+    const runtime = createSkinRuntime({ rootDir: join(temporaryRoot, 'runtime') });
+    const webContents = new FakeWebContents();
+    runtime.attach(webContents);
+    await runtime.installFromFile(archivePath);
+    await runtime.activate('test.neon');
+
+    await writeArchive('1.1.0', 'blue');
+    const updated = await runtime.installFromFile(archivePath);
+    assert.equal(updated.installed[0]?.manifest.version, '1.1.0');
+    assert.match(updated.installed[0]?.previewDataUrl ?? '', /^data:image\/svg\+xml;base64,/);
+    assert.match(webContents.insertedCss.at(-1) ?? '', /blue/);
+
+    await runtime.reload();
+    assert.equal(webContents.insertedCss.length, 3);
+
+    webContents.failurePattern = /BROKEN_SKIN/;
+    await writeArchive('2.0.0', 'orange', 'export function activate() { /* BROKEN_SKIN */ }');
+    await assert.rejects(
+      runtime.installFromFile(archivePath),
+      (error: unknown) =>
+        error instanceof SkinRuntimeError && error.code === 'activation-failed',
+    );
+    const rolledBack = await runtime.list();
+    assert.equal(rolledBack.installed[0]?.manifest.version, '1.1.0');
+    assert.equal(rolledBack.activeSkinId, 'test.neon');
+
+    const uninstalled = await runtime.uninstall('test.neon');
+    assert.equal(uninstalled.activeSkinId, null);
+    assert.deepEqual(uninstalled.installed, []);
   } finally {
     await rm(temporaryRoot, { recursive: true, force: true });
   }

--- a/apps/desktop/src/main/main-window.ts
+++ b/apps/desktop/src/main/main-window.ts
@@ -12,6 +12,7 @@ import type { E2eFixture } from './e2e-fixture.js';
 import { installMainWindowPermissionPolicy } from './main-window-permission-policy.js';
 import { isThemePreference, toNativeThemeSource } from './theme-source.js';
 import { createWindowRevealGate } from './window-reveal.js';
+import type { SkinRuntime } from './skin-runtime.js';
 
 type SettingsReader = {
   get(): Promise<AppSettings>;
@@ -45,6 +46,7 @@ interface MainWindowControllerDeps {
   // main.ts computes this from the same isE2e gate that also guards userData
   // and the fake backend, so main-window.ts owns no env policy of its own.
   startHidden: boolean;
+  skinRuntime?: Pick<SkinRuntime, 'attach'>;
   onClose?: () => void;
 }
 
@@ -291,6 +293,7 @@ export function createMainWindowController(deps: MainWindowControllerDeps): Main
         allowRunningInsecureContent: false,
       },
     });
+    deps.skinRuntime?.attach(mainWindow.webContents);
     installMainWindowPermissionPolicy(mainWindow.webContents, rendererEntryUrl);
 
     // Two-layer external-link hygiene: assistant markdown often emits `<a href>`

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -97,6 +97,8 @@ import { createAttachmentApprovalRegistry } from './attachment-approval.js';
 import { cleanupLegacyHistoryCompactArtifacts } from '@maka/runtime';
 import { computerUseServiceHealth } from './computer-use-host.js';
 import { createMainWindowController } from './main-window.js';
+import { createSkinRuntime } from './skin-runtime.js';
+import { registerSkinIpc } from './skin-ipc-main.js';
 import { createDailyReviewMainService } from './daily-review-main.js';
 import { createPlanReminderMainService } from './plan-reminders-main.js';
 import { createBotIncomingMainService } from './bot-incoming-main.js';
@@ -591,12 +593,19 @@ const resolveDesktopSkillHost: HostCapabilitiesResolver = ({ sessionId }) =>
 // that opts into a visible window also opts back into Dock and Cmd+Tab.
 const startHidden = (Boolean(e2eFixture) || isIsolatedE2e)
   && process.env.MAKA_E2E_SHOW_WINDOW !== '1';
+const skinRuntime = createSkinRuntime({
+  rootDir: join(workspaceRoot, 'skins'),
+  safeMode:
+    process.env.MAKA_DISABLE_SKINS === '1' ||
+    process.argv.includes('--disable-skins'),
+});
 let onMainWindowClose = (): void => {};
 const mainWindowController = createMainWindowController({
   workspaceRoot,
   e2eFixture,
   settingsStore,
   startHidden,
+  skinRuntime,
   onClose: () => onMainWindowClose(),
 });
 // Shared by 'second-instance' and 'activate': focus the existing window, or
@@ -1057,6 +1066,11 @@ function registerIpc(): void {
     buildInfo,
     e2eFixture,
     projectManagement,
+  });
+  registerSkinIpc({
+    runtime: skinRuntime,
+    mainWindowController,
+    sendToRenderer: safeSendToRenderer,
   });
   registerMemoryIpc({ localMemory });
   registerConfigIpc({ connectionStore, settingsStore, credentialStore, workspaceRoot });

--- a/apps/desktop/src/main/skin-ipc-main.ts
+++ b/apps/desktop/src/main/skin-ipc-main.ts
@@ -1,0 +1,60 @@
+import { dialog, ipcMain, shell } from 'electron';
+import type { MainWindowController } from './main-window.js';
+import type { SkinRuntime, SkinRuntimeSnapshot } from './skin-runtime.js';
+
+export function registerSkinIpc(options: {
+  runtime: SkinRuntime;
+  mainWindowController: MainWindowController;
+  sendToRenderer(channel: string, ...args: unknown[]): void;
+}): void {
+  const { runtime, mainWindowController, sendToRenderer } = options;
+  const publish = (snapshot: SkinRuntimeSnapshot): SkinRuntimeSnapshot => {
+    sendToRenderer('skins:changed', snapshot);
+    return snapshot;
+  };
+
+  ipcMain.handle('skins:list', () => runtime.list());
+  ipcMain.handle('skins:install', async (): Promise<{
+    canceled: boolean;
+    snapshot: SkinRuntimeSnapshot;
+  }> => {
+    const selection = await mainWindowController.showOpenDialog({
+      title: 'Install Maka skin',
+      properties: ['openFile'],
+      filters: [
+        { name: 'Maka Skin', extensions: ['maka-skin'] },
+        { name: 'Zip archive', extensions: ['zip'] },
+      ],
+    });
+    const archivePath = selection.filePaths[0];
+    if (selection.canceled || !archivePath) {
+      return { canceled: true, snapshot: await runtime.list() };
+    }
+
+    const confirmation = await dialog.showMessageBox({
+      type: 'warning',
+      title: 'Install a full-access skin?',
+      message: 'Maka skins can restyle and modify the entire app interface.',
+      detail: 'Only install skins you trust. Skin JavaScript runs without Node.js or the Maka preload bridge, but it can read and change visible page content. Use --disable-skins if a skin prevents the app from opening normally.',
+      buttons: ['Cancel', 'Install'],
+      defaultId: 0,
+      cancelId: 0,
+      noLink: true,
+    });
+    if (confirmation.response !== 1) {
+      return { canceled: true, snapshot: await runtime.list() };
+    }
+
+    const snapshot = publish(await runtime.installFromFile(archivePath));
+    return { canceled: false, snapshot };
+  });
+  ipcMain.handle('skins:activate', async (_event, id: unknown) => {
+    if (typeof id !== 'string') throw new Error('Invalid skin id.');
+    return publish(await runtime.activate(id));
+  });
+  ipcMain.handle('skins:disable', async () => publish(await runtime.disable()));
+  ipcMain.handle('skins:openFolder', async () => {
+    const error = await shell.openPath(runtime.rootDir);
+    if (error) throw new Error(error);
+  });
+}

--- a/apps/desktop/src/main/skin-ipc-main.ts
+++ b/apps/desktop/src/main/skin-ipc-main.ts
@@ -53,6 +53,24 @@ export function registerSkinIpc(options: {
     return publish(await runtime.activate(id));
   });
   ipcMain.handle('skins:disable', async () => publish(await runtime.disable()));
+  ipcMain.handle('skins:reload', async () => publish(await runtime.reload()));
+  ipcMain.handle('skins:uninstall', async (_event, id: unknown) => {
+    if (typeof id !== 'string') throw new Error('Invalid skin id.');
+    const installed = (await runtime.list()).installed.find(({ manifest }) => manifest.id === id);
+    if (!installed) throw new Error('Skin is not installed.');
+    const confirmation = await dialog.showMessageBox({
+      type: 'warning',
+      title: 'Remove Maka skin?',
+      message: `Remove “${installed.manifest.name}” from this device?`,
+      detail: 'The installed skin files will be deleted. You can import the .maka-skin package again later.',
+      buttons: ['Cancel', 'Remove'],
+      defaultId: 0,
+      cancelId: 0,
+      noLink: true,
+    });
+    if (confirmation.response !== 1) return runtime.list();
+    return publish(await runtime.uninstall(id));
+  });
   ipcMain.handle('skins:openFolder', async () => {
     const error = await shell.openPath(runtime.rootDir);
     if (error) throw new Error(error);

--- a/apps/desktop/src/main/skin-ipc-main.ts
+++ b/apps/desktop/src/main/skin-ipc-main.ts
@@ -1,6 +1,22 @@
 import { dialog, ipcMain, shell } from 'electron';
 import type { MainWindowController } from './main-window.js';
-import type { SkinRuntime, SkinRuntimeSnapshot } from './skin-runtime.js';
+import type {
+  SkinActionName,
+  SkinPermission,
+  SkinRuntime,
+  SkinRuntimeSnapshot,
+} from './skin-runtime.js';
+
+const SKIN_PERMISSION_DESCRIPTIONS: Record<SkinPermission, string> = {
+  dom: 'Read and modify visible Maka page content',
+  canvas: 'Render Canvas or WebGL graphics',
+  audio: 'Play or process audio',
+  storage: 'Persist skin-owned settings',
+  'actions.navigation': 'Switch the visible conversation after a skin UI click',
+  'actions.task': 'Open a new-task surface after a skin UI click',
+  'actions.submit': 'Submit a new prompt after a skin UI click',
+  'actions.stop': 'Stop the active generation after a skin UI click',
+};
 
 export function registerSkinIpc(options: {
   runtime: SkinRuntime;
@@ -31,11 +47,32 @@ export function registerSkinIpc(options: {
       return { canceled: true, snapshot: await runtime.list() };
     }
 
+    const inspection = await runtime.inspectFile(archivePath);
+    const { manifest } = inspection;
+    const permissions = manifest.permissions
+      .map((permission) => `• ${SKIN_PERMISSION_DESCRIPTIONS[permission]}`)
+      .join('\n');
     const confirmation = await dialog.showMessageBox({
       type: 'warning',
-      title: 'Install a full-access skin?',
-      message: 'Maka skins can restyle and modify the entire app interface.',
-      detail: 'Only install skins you trust. Skin JavaScript runs without Node.js or the Maka preload bridge, but it can read and change visible page content. Use --disable-skins if a skin prevents the app from opening normally.',
+      title: manifest.permissions.includes('dom')
+        ? 'Install a full-access skin?'
+        : 'Install this skin?',
+      message: `Install “${manifest.name}” by ${manifest.author ?? 'an unknown author'}?`,
+      detail: [
+        manifest.entry
+          ? 'Skin JavaScript runs without Node.js or the Maka preload bridge, but DOM access can still read and change all visible page content.'
+          : 'This package contains CSS only and does not run skin JavaScript.',
+        '',
+        permissions || 'This package declares no optional permissions.',
+        '',
+        manifest.permissions.includes('dom')
+          ? 'FULL UI TRUST: DOM-enabled skin code can imitate page interaction. Granular action permissions govern the stable Skin API, but they cannot turn arbitrary DOM JavaScript into a strict sandbox.'
+          : 'Controlled actions are checked by the host and only run after a trusted click in skin-owned UI.',
+        '',
+        manifest.permissions.includes('actions.submit')
+          ? 'Every composer.submit request also requires a native Maka confirmation. Only install packages you trust.'
+          : 'Only install packages you trust.',
+      ].join('\n'),
       buttons: ['Cancel', 'Install'],
       defaultId: 0,
       cancelId: 0,
@@ -45,7 +82,9 @@ export function registerSkinIpc(options: {
       return { canceled: true, snapshot: await runtime.list() };
     }
 
-    const snapshot = publish(await runtime.installFromFile(archivePath));
+    const snapshot = publish(
+      await runtime.installFromFile(archivePath, inspection.archiveDigest),
+    );
     return { canceled: false, snapshot };
   });
   ipcMain.handle('skins:activate', async (_event, id: unknown) => {
@@ -74,5 +113,42 @@ export function registerSkinIpc(options: {
   ipcMain.handle('skins:openFolder', async () => {
     const error = await shell.openPath(runtime.rootDir);
     if (error) throw new Error(error);
+  });
+  ipcMain.handle('skins:authorizeAction', async (
+    _event,
+    action: unknown,
+    context: unknown,
+  ) => {
+    if (
+      action !== 'navigation.switch-session' &&
+      action !== 'task.new' &&
+      action !== 'composer.submit' &&
+      action !== 'generation.stop'
+    ) {
+      return false;
+    }
+    if (!(await runtime.authorizeAction(action satisfies SkinActionName))) return false;
+    if (action !== 'composer.submit') return true;
+    const textPreview = (
+      context &&
+      typeof context === 'object' &&
+      'textPreview' in context &&
+      typeof context.textPreview === 'string'
+    )
+      ? context.textPreview.slice(0, 240)
+      : '';
+    const confirmation = await dialog.showMessageBox({
+      type: 'warning',
+      title: 'Allow skin to submit a prompt?',
+      message: 'A skin is asking Maka to start model generation.',
+      detail: textPreview
+        ? `Prompt preview:\n\n${textPreview}`
+        : 'The prompt preview is unavailable.',
+      buttons: ['Cancel', 'Submit'],
+      defaultId: 0,
+      cancelId: 0,
+      noLink: true,
+    });
+    return confirmation.response === 1;
   });
 }

--- a/apps/desktop/src/main/skin-ipc-main.ts
+++ b/apps/desktop/src/main/skin-ipc-main.ts
@@ -12,10 +12,17 @@ const SKIN_PERMISSION_DESCRIPTIONS: Record<SkinPermission, string> = {
   canvas: 'Render Canvas or WebGL graphics',
   audio: 'Play or process audio',
   storage: 'Persist skin-owned settings',
+  'data.sessions': 'Read the visible session list and session metadata',
+  'data.conversation': 'Read visible user and assistant conversation text',
+  'data.tools': 'Read redacted tool arguments, streamed output, status, and duration',
+  'data.interactions': 'Read user questions and answer choices (not permission details)',
+  'data.composer': 'Read the current composer draft, attachments, model, and skills',
   'actions.navigation': 'Switch the visible conversation after a skin UI click',
   'actions.task': 'Open a new-task surface after a skin UI click',
   'actions.submit': 'Submit a new prompt after a skin UI click',
   'actions.stop': 'Stop the active generation after a skin UI click',
+  'actions.composer': 'Modify composer state after a skin UI click',
+  'actions.answer': 'Answer a visible user question after a skin UI click',
 };
 
 export function registerSkinIpc(options: {
@@ -123,11 +130,40 @@ export function registerSkinIpc(options: {
       action !== 'navigation.switch-session' &&
       action !== 'task.new' &&
       action !== 'composer.submit' &&
-      action !== 'generation.stop'
+      action !== 'generation.stop' &&
+      action !== 'composer.set-draft' &&
+      action !== 'composer.focus' &&
+      action !== 'composer.pick-attachments' &&
+      action !== 'composer.remove-attachment' &&
+      action !== 'composer.set-model' &&
+      action !== 'composer.set-skills' &&
+      action !== 'composer.set-permission-mode' &&
+      action !== 'interaction.answer-question'
     ) {
       return false;
     }
     if (!(await runtime.authorizeAction(action satisfies SkinActionName))) return false;
+    if (action === 'composer.set-permission-mode') {
+      const permissionMode = (
+        context &&
+        typeof context === 'object' &&
+        'permissionMode' in context &&
+        typeof context.permissionMode === 'string' &&
+        ['explore', 'ask', 'execute', 'bypass'].includes(context.permissionMode)
+      ) ? context.permissionMode : '';
+      if (!permissionMode) return false;
+      const confirmation = await dialog.showMessageBox({
+        type: 'warning',
+        title: 'Allow skin to change the permission mode?',
+        message: 'A skin is asking Maka to change the active session security boundary.',
+        detail: `Requested permission mode: ${permissionMode}`,
+        buttons: ['Cancel', 'Change mode'],
+        defaultId: 0,
+        cancelId: 0,
+        noLink: true,
+      });
+      return confirmation.response === 1;
+    }
     if (action !== 'composer.submit') return true;
     const textPreview = (
       context &&

--- a/apps/desktop/src/main/skin-runtime.ts
+++ b/apps/desktop/src/main/skin-runtime.ts
@@ -1,0 +1,691 @@
+import { randomUUID } from 'node:crypto';
+import {
+  mkdir,
+  readFile,
+  readdir,
+  rename,
+  rm,
+  writeFile,
+} from 'node:fs/promises';
+import { dirname, extname, join, posix } from 'node:path';
+import { unzipSync } from 'fflate';
+
+const SKIN_SCHEMA_VERSION = 1;
+const SKIN_WORLD_ID = 1004;
+const MAX_ARCHIVE_BYTES = 32 * 1024 * 1024;
+const MAX_EXPANDED_BYTES = 64 * 1024 * 1024;
+const MAX_ARCHIVE_ENTRIES = 128;
+const MAX_SCRIPT_BYTES = 2 * 1024 * 1024;
+const MAX_STYLESHEET_BYTES = 4 * 1024 * 1024;
+const STATE_FILE = 'state.json';
+
+const ALLOWED_PERMISSIONS = new Set([
+  'dom',
+  'canvas',
+  'audio',
+  'storage',
+]);
+
+export type SkinPermission = 'dom' | 'canvas' | 'audio' | 'storage';
+
+export interface SkinManifest {
+  schemaVersion: 1;
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  author?: string;
+  styles?: string;
+  entry?: string;
+  preview?: string;
+  permissions: SkinPermission[];
+}
+
+export interface InstalledSkin {
+  manifest: SkinManifest;
+  active: boolean;
+}
+
+export interface SkinRuntimeSnapshot {
+  activeSkinId: string | null;
+  installed: InstalledSkin[];
+  safeMode: boolean;
+  recoveredFromFailedActivation: boolean;
+  lastError: string | null;
+}
+
+interface SkinRuntimeState {
+  activeSkinId: string | null;
+  activationPending: boolean;
+  lastError: string | null;
+}
+
+export interface SkinWebContents {
+  insertCSS(css: string, options?: { cssOrigin?: 'author' | 'user' }): Promise<string>;
+  removeInsertedCSS(key: string): Promise<void>;
+  executeJavaScriptInIsolatedWorld(
+    worldId: number,
+    scripts: Array<{ code: string; url?: string }>,
+    userGesture?: boolean,
+  ): Promise<unknown>;
+  isDestroyed(): boolean;
+  on(event: 'did-finish-load' | 'destroyed', listener: () => void): this;
+}
+
+export interface SkinRuntime {
+  readonly rootDir: string;
+  attach(webContents: SkinWebContents): void;
+  list(): Promise<SkinRuntimeSnapshot>;
+  installFromFile(archivePath: string): Promise<SkinRuntimeSnapshot>;
+  activate(id: string): Promise<SkinRuntimeSnapshot>;
+  disable(): Promise<SkinRuntimeSnapshot>;
+}
+
+export class SkinRuntimeError extends Error {
+  constructor(
+    readonly code:
+      | 'invalid-archive'
+      | 'invalid-manifest'
+      | 'already-installed'
+      | 'not-installed'
+      | 'activation-failed',
+    message: string,
+  ) {
+    super(message);
+    this.name = 'SkinRuntimeError';
+  }
+}
+
+export function createSkinRuntime(options: {
+  rootDir: string;
+  safeMode?: boolean;
+}): SkinRuntime {
+  const rootDir = options.rootDir;
+  const installedDir = join(rootDir, 'installed');
+  const safeMode = options.safeMode === true;
+  let webContents: SkinWebContents | null = null;
+  let insertedCssKey: string | null = null;
+  let initialized = false;
+  let recoveredFromFailedActivation = false;
+  let state: SkinRuntimeState = {
+    activeSkinId: null,
+    activationPending: false,
+    lastError: null,
+  };
+  let mutation = Promise.resolve();
+
+  async function initialize(): Promise<void> {
+    if (initialized) return;
+    await mkdir(installedDir, { recursive: true });
+    try {
+      const parsed = JSON.parse(await readFile(join(rootDir, STATE_FILE), 'utf8')) as Partial<SkinRuntimeState>;
+      state = {
+        activeSkinId: typeof parsed.activeSkinId === 'string' ? parsed.activeSkinId : null,
+        activationPending: parsed.activationPending === true,
+        lastError: typeof parsed.lastError === 'string' ? parsed.lastError : null,
+      };
+    } catch {
+      // First launch and corrupt state both fall back to the safe empty state.
+    }
+    if (state.activationPending) {
+      recoveredFromFailedActivation = true;
+      state = {
+        activeSkinId: null,
+        activationPending: false,
+        lastError: 'Maka disabled the previous skin because its activation did not finish.',
+      };
+      await persistState();
+    }
+    initialized = true;
+  }
+
+  async function persistState(): Promise<void> {
+    await mkdir(rootDir, { recursive: true });
+    const path = join(rootDir, STATE_FILE);
+    const temporaryPath = `${path}.${randomUUID()}.tmp`;
+    await writeFile(temporaryPath, `${JSON.stringify(state, null, 2)}\n`, 'utf8');
+    await rename(temporaryPath, path);
+  }
+
+  async function readInstalledManifests(): Promise<SkinManifest[]> {
+    await initialize();
+    const entries = await readdir(installedDir, { withFileTypes: true });
+    const manifests = await Promise.all(entries
+      .filter((entry) => entry.isDirectory())
+      .map(async (entry) => {
+        try {
+          const value = JSON.parse(
+            await readFile(join(installedDir, entry.name, 'manifest.json'), 'utf8'),
+          );
+          return parseSkinManifest(value);
+        } catch {
+          return null;
+        }
+      }));
+    return manifests
+      .filter((manifest): manifest is SkinManifest => manifest !== null)
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  async function snapshot(): Promise<SkinRuntimeSnapshot> {
+    const manifests = await readInstalledManifests();
+    return {
+      activeSkinId: safeMode ? null : state.activeSkinId,
+      installed: manifests.map((manifest) => ({
+        manifest,
+        active: !safeMode && manifest.id === state.activeSkinId,
+      })),
+      safeMode,
+      recoveredFromFailedActivation,
+      lastError: state.lastError,
+    };
+  }
+
+  async function clearRendererSkin(): Promise<void> {
+    const target = webContents;
+    if (!target || target.isDestroyed()) {
+      insertedCssKey = null;
+      return;
+    }
+    await target.executeJavaScriptInIsolatedWorld(SKIN_WORLD_ID, [{
+      code: `(() => {
+        const current = globalThis.__makaSkinRuntime;
+        try { current?.dispose?.(); } catch (error) { console.error('[maka-skin] dispose failed', error); }
+        delete globalThis.__makaSkinRuntime;
+        document.documentElement.removeAttribute('data-maka-skin');
+      })()`,
+      url: 'maka-skin://runtime/deactivate.js',
+    }]).catch(() => undefined);
+    if (insertedCssKey) {
+      const key = insertedCssKey;
+      insertedCssKey = null;
+      await target.removeInsertedCSS(key).catch(() => undefined);
+    }
+  }
+
+  async function applyActiveSkin(): Promise<void> {
+    await initialize();
+    await clearRendererSkin();
+    if (safeMode || !state.activeSkinId) return;
+    const target = webContents;
+    if (!target || target.isDestroyed()) return;
+
+    const skinDir = join(installedDir, state.activeSkinId);
+    const manifest = parseSkinManifest(
+      JSON.parse(await readFile(join(skinDir, 'manifest.json'), 'utf8')),
+    );
+    state.activationPending = true;
+    state.lastError = null;
+    await persistState();
+
+    try {
+      const assets = await readSkinAssets(skinDir);
+      if (manifest.styles) {
+        const stylesheet = await readBoundedText(
+          join(skinDir, manifest.styles),
+          MAX_STYLESHEET_BYTES,
+          'Skin stylesheet',
+        );
+        insertedCssKey = await target.insertCSS(
+          inlineStylesheetAssets(stylesheet, manifest.styles, assets),
+          { cssOrigin: 'user' },
+        );
+      }
+      if (manifest.entry) {
+        const source = await readBoundedText(
+          join(skinDir, manifest.entry),
+          MAX_SCRIPT_BYTES,
+          'Skin script',
+        );
+        const result = await target.executeJavaScriptInIsolatedWorld(
+          SKIN_WORLD_ID,
+          [{
+            code: buildSkinActivationScript(manifest, source, assets),
+            url: `maka-skin://${manifest.id}/${manifest.entry}`,
+          }],
+        ) as { ok?: boolean; error?: string } | undefined;
+        if (!result?.ok) {
+          throw new Error(result?.error ?? 'Skin entry did not finish activation.');
+        }
+      } else {
+        await target.executeJavaScriptInIsolatedWorld(SKIN_WORLD_ID, [{
+          code: `document.documentElement.setAttribute('data-maka-skin', ${JSON.stringify(manifest.id)}); ({ ok: true })`,
+          url: `maka-skin://${manifest.id}/activate.js`,
+        }]);
+      }
+      state.activationPending = false;
+      state.lastError = null;
+      await persistState();
+    } catch (error) {
+      await clearRendererSkin();
+      const message = errorMessage(error);
+      state = {
+        activeSkinId: null,
+        activationPending: false,
+        lastError: message,
+      };
+      await persistState();
+      throw new SkinRuntimeError('activation-failed', message);
+    }
+  }
+
+  function serialize<T>(operation: () => Promise<T>): Promise<T> {
+    const next = mutation.then(operation, operation);
+    mutation = next.then(() => undefined, () => undefined);
+    return next;
+  }
+
+  return {
+    rootDir,
+    attach(target) {
+      webContents = target;
+      target.on('did-finish-load', () => {
+        void serialize(applyActiveSkin).catch((error) => {
+          console.error('[maka-skin] failed to apply after renderer load:', error);
+        });
+      });
+      target.on('destroyed', () => {
+        if (webContents === target) webContents = null;
+        insertedCssKey = null;
+      });
+    },
+    list: () => serialize(snapshot),
+    installFromFile: (archivePath) => serialize(async () => {
+      await initialize();
+      const archive = await readFile(archivePath);
+      if (archive.byteLength > MAX_ARCHIVE_BYTES) {
+        throw new SkinRuntimeError('invalid-archive', 'Skin archive is larger than 32 MiB.');
+      }
+      let files: Record<string, Uint8Array>;
+      try {
+        files = unzipSync(new Uint8Array(archive));
+      } catch {
+        throw new SkinRuntimeError('invalid-archive', 'The selected file is not a valid .maka-skin archive.');
+      }
+      const normalizedFiles = normalizeArchiveFiles(files);
+      const manifestBytes = normalizedFiles.get('manifest.json');
+      if (!manifestBytes) {
+        throw new SkinRuntimeError('invalid-manifest', 'Skin archive does not contain manifest.json.');
+      }
+      let manifestValue: unknown;
+      try {
+        manifestValue = JSON.parse(new TextDecoder().decode(manifestBytes));
+      } catch {
+        throw new SkinRuntimeError('invalid-manifest', 'Skin manifest is not valid JSON.');
+      }
+      const manifest = parseSkinManifest(manifestValue);
+      assertManifestFiles(manifest, normalizedFiles);
+      const destination = join(installedDir, manifest.id);
+      try {
+        await readFile(join(destination, 'manifest.json'));
+        throw new SkinRuntimeError('already-installed', `Skin “${manifest.name}” is already installed.`);
+      } catch (error) {
+        if (error instanceof SkinRuntimeError) throw error;
+      }
+
+      const staging = join(rootDir, `.install-${randomUUID()}`);
+      await mkdir(staging, { recursive: true });
+      try {
+        for (const [relativePath, bytes] of normalizedFiles) {
+          const output = join(staging, ...relativePath.split('/'));
+          await mkdir(dirname(output), { recursive: true });
+          await writeFile(output, bytes);
+        }
+        await rename(staging, destination);
+      } catch (error) {
+        await rm(staging, { recursive: true, force: true });
+        throw error;
+      }
+      return snapshot();
+    }),
+    activate: (id) => serialize(async () => {
+      await initialize();
+      if (safeMode) {
+        throw new SkinRuntimeError('activation-failed', 'Skins are disabled by safe mode.');
+      }
+      if (!/^[a-z0-9][a-z0-9._-]{1,63}$/.test(id)) {
+        throw new SkinRuntimeError('not-installed', 'Invalid skin id.');
+      }
+      try {
+        await readFile(join(installedDir, id, 'manifest.json'));
+      } catch {
+        throw new SkinRuntimeError('not-installed', `Skin “${id}” is not installed.`);
+      }
+      state.activeSkinId = id;
+      await persistState();
+      await applyActiveSkin();
+      return snapshot();
+    }),
+    disable: () => serialize(async () => {
+      await initialize();
+      state = {
+        activeSkinId: null,
+        activationPending: false,
+        lastError: null,
+      };
+      await persistState();
+      await clearRendererSkin();
+      return snapshot();
+    }),
+  };
+}
+
+export function parseSkinManifest(value: unknown): SkinManifest {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new SkinRuntimeError('invalid-manifest', 'Skin manifest must be an object.');
+  }
+  const candidate = value as Record<string, unknown>;
+  if (candidate.schemaVersion !== SKIN_SCHEMA_VERSION) {
+    throw new SkinRuntimeError('invalid-manifest', 'Unsupported skin manifest schemaVersion.');
+  }
+  const id = readRequiredString(candidate.id, 'id');
+  if (!/^[a-z0-9][a-z0-9._-]{1,63}$/.test(id)) {
+    throw new SkinRuntimeError('invalid-manifest', 'Skin id must contain 2–64 lowercase letters, numbers, dots, dashes, or underscores.');
+  }
+  const name = readRequiredString(candidate.name, 'name', 80);
+  const version = readRequiredString(candidate.version, 'version', 40);
+  const styles = readOptionalSafePath(candidate.styles, 'styles');
+  const entry = readOptionalSafePath(candidate.entry, 'entry');
+  const preview = readOptionalSafePath(candidate.preview, 'preview');
+  if (!styles && !entry) {
+    throw new SkinRuntimeError('invalid-manifest', 'Skin manifest must define styles or entry.');
+  }
+  const rawPermissions = candidate.permissions ?? [];
+  if (!Array.isArray(rawPermissions) || rawPermissions.some((item) => typeof item !== 'string' || !ALLOWED_PERMISSIONS.has(item))) {
+    throw new SkinRuntimeError('invalid-manifest', 'Skin permissions contain an unsupported capability.');
+  }
+  const permissions = [...new Set(rawPermissions)] as SkinPermission[];
+  return {
+    schemaVersion: 1,
+    id,
+    name,
+    version,
+    ...(readOptionalString(candidate.description, 240) ? { description: readOptionalString(candidate.description, 240) } : {}),
+    ...(readOptionalString(candidate.author, 80) ? { author: readOptionalString(candidate.author, 80) } : {}),
+    ...(styles ? { styles } : {}),
+    ...(entry ? { entry } : {}),
+    ...(preview ? { preview } : {}),
+    permissions,
+  };
+}
+
+export function normalizeArchiveFiles(files: Record<string, Uint8Array>): Map<string, Uint8Array> {
+  const entries = Object.entries(files).filter(([name]) => !name.endsWith('/'));
+  if (entries.length === 0 || entries.length > MAX_ARCHIVE_ENTRIES) {
+    throw new SkinRuntimeError('invalid-archive', 'Skin archive has an invalid number of files.');
+  }
+  let expandedBytes = 0;
+  const safeEntries = entries.map(([rawPath, bytes]) => {
+    expandedBytes += bytes.byteLength;
+    if (expandedBytes > MAX_EXPANDED_BYTES) {
+      throw new SkinRuntimeError('invalid-archive', 'Skin archive expands beyond 64 MiB.');
+    }
+    const slashPath = rawPath.replaceAll('\\', '/');
+    if (
+      slashPath.startsWith('/') ||
+      /^[a-z]:/i.test(slashPath) ||
+      slashPath.split('/').some((part) => part === '..')
+    ) {
+      throw new SkinRuntimeError('invalid-archive', 'Skin archive contains an unsafe path.');
+    }
+    const normalized = posix.normalize(slashPath).replace(/^\.\//, '');
+    if (!normalized || normalized === '.' || normalized.startsWith('../')) {
+      throw new SkinRuntimeError('invalid-archive', 'Skin archive contains an unsafe path.');
+    }
+    return [normalized, bytes] as const;
+  });
+
+  const directManifest = safeEntries.some(([path]) => path === 'manifest.json');
+  const manifestPaths = safeEntries.filter(([path]) => path.endsWith('/manifest.json'));
+  let wrapper = '';
+  if (!directManifest) {
+    if (manifestPaths.length !== 1) {
+      throw new SkinRuntimeError('invalid-manifest', 'Skin archive must contain one manifest.json.');
+    }
+    wrapper = manifestPaths[0]![0].slice(0, -'manifest.json'.length);
+    if (wrapper.slice(0, -1).includes('/')) {
+      throw new SkinRuntimeError('invalid-manifest', 'manifest.json must be at the archive root or one wrapper folder deep.');
+    }
+  }
+
+  const normalized = new Map<string, Uint8Array>();
+  for (const [path, bytes] of safeEntries) {
+    if (wrapper && !path.startsWith(wrapper)) {
+      if (path === '.DS_Store' || path.startsWith('__MACOSX/')) continue;
+      throw new SkinRuntimeError('invalid-archive', 'Skin archive mixes files outside its wrapper folder.');
+    }
+    const stripped = wrapper ? path.slice(wrapper.length) : path;
+    if (!stripped || stripped === '.DS_Store' || stripped.startsWith('__MACOSX/')) continue;
+    if (normalized.has(stripped)) {
+      throw new SkinRuntimeError('invalid-archive', 'Skin archive contains duplicate file paths.');
+    }
+    normalized.set(stripped, bytes);
+  }
+  return normalized;
+}
+
+function assertManifestFiles(manifest: SkinManifest, files: Map<string, Uint8Array>): void {
+  for (const [label, path] of [
+    ['stylesheet', manifest.styles],
+    ['entry', manifest.entry],
+    ['preview', manifest.preview],
+  ] as const) {
+    if (path && !files.has(path)) {
+      throw new SkinRuntimeError('invalid-manifest', `Skin ${label} file “${path}” is missing.`);
+    }
+  }
+  if (manifest.styles && files.get(manifest.styles)!.byteLength > MAX_STYLESHEET_BYTES) {
+    throw new SkinRuntimeError('invalid-manifest', 'Skin stylesheet is larger than 4 MiB.');
+  }
+  if (manifest.entry) {
+    const entry = files.get(manifest.entry)!;
+    if (entry.byteLength > MAX_SCRIPT_BYTES) {
+      throw new SkinRuntimeError('invalid-manifest', 'Skin entry is larger than 2 MiB.');
+    }
+    const source = new TextDecoder().decode(entry);
+    if (/^\s*import\s/m.test(source) || /\bimport\s*\(/.test(source)) {
+      throw new SkinRuntimeError('invalid-manifest', 'Skin entry must be self-contained and cannot import modules.');
+    }
+  }
+}
+
+async function readSkinAssets(skinDir: string): Promise<Record<string, string>> {
+  const assetsDir = join(skinDir, 'assets');
+  const result: Record<string, string> = {};
+  let entries;
+  try {
+    entries = await readdir(assetsDir, { recursive: true, withFileTypes: true });
+  } catch {
+    return result;
+  }
+  for (const entry of entries) {
+    if (!entry.isFile()) continue;
+    const parentPath = 'parentPath' in entry && typeof entry.parentPath === 'string'
+      ? entry.parentPath
+      : assetsDir;
+    const absolutePath = join(parentPath, entry.name);
+    const relativePath = posix.join(
+      'assets',
+      absolutePath.slice(assetsDir.length + 1).split('\\').join('/'),
+    );
+    const bytes = await readFile(absolutePath);
+    result[relativePath] = `data:${mimeType(relativePath)};base64,${bytes.toString('base64')}`;
+  }
+  return result;
+}
+
+export function inlineStylesheetAssets(
+  stylesheet: string,
+  stylesheetPath: string,
+  assets: Record<string, string>,
+): string {
+  const baseDir = posix.dirname(stylesheetPath);
+  return stylesheet.replace(
+    /url\(\s*(['"]?)(?!data:|https?:|maka-skin:|#)([^'")]+)\1\s*\)/gi,
+    (match, _quote: string, rawPath: string) => {
+      const resolved = posix.normalize(posix.join(baseDir, rawPath.trim())).replace(/^\.\//, '');
+      const asset = assets[resolved];
+      return asset ? `url("${asset}")` : match;
+    },
+  );
+}
+
+export function buildSkinActivationScript(
+  manifest: SkinManifest,
+  entrySource: string,
+  assets: Record<string, string>,
+): string {
+  const transformed = transformSkinModule(entrySource);
+  return `(async () => {
+    try {
+      const previous = globalThis.__makaSkinRuntime;
+      try { previous?.dispose?.(); } catch (error) { console.error('[maka-skin] previous dispose failed', error); }
+
+      const manifest = Object.freeze(${JSON.stringify(manifest)});
+      const assetTable = Object.freeze(${JSON.stringify(assets)});
+      const disposers = [];
+      const overlay = document.createElement('div');
+      overlay.dataset.makaSkinOverlay = manifest.id;
+      overlay.setAttribute('aria-hidden', 'true');
+      document.body.appendChild(overlay);
+      disposers.push(() => overlay.remove());
+
+      const api = Object.freeze({
+        manifest,
+        overlay,
+        assets: Object.freeze({
+          url(path) {
+            const normalized = String(path).replace(/^\\.\\//, '');
+            return assetTable[normalized] ?? null;
+          },
+          list() { return Object.keys(assetTable); },
+        }),
+        parts: Object.freeze({
+          one(name) { return document.querySelector('[data-maka-part="' + CSS.escape(String(name)) + '"]'); },
+          all(name) { return [...document.querySelectorAll('[data-maka-part="' + CSS.escape(String(name)) + '"]')]; },
+        }),
+        events: Object.freeze({
+          on(type, handler) {
+            const eventName = 'maka:' + String(type);
+            const listener = (event) => handler(event.detail, event);
+            window.addEventListener(eventName, listener);
+            const off = () => window.removeEventListener(eventName, listener);
+            disposers.push(off);
+            return off;
+          },
+        }),
+        storage: Object.freeze({
+          get(key, fallback = null) {
+            try {
+              const raw = localStorage.getItem('maka-skin:' + manifest.id + ':' + String(key));
+              return raw === null ? fallback : JSON.parse(raw);
+            } catch { return fallback; }
+          },
+          set(key, value) {
+            localStorage.setItem('maka-skin:' + manifest.id + ':' + String(key), JSON.stringify(value));
+          },
+          remove(key) {
+            localStorage.removeItem('maka-skin:' + manifest.id + ':' + String(key));
+          },
+        }),
+        log(...args) { console.info('[maka-skin:' + manifest.id + ']', ...args); },
+      });
+
+      const activate = (() => {
+        ${transformed}
+        return typeof activate === 'function' ? activate : null;
+      })();
+      if (!activate) throw new Error('entry.mjs must export an activate(api) function.');
+      const skinDispose = await activate(api);
+      if (typeof skinDispose === 'function') disposers.push(skinDispose);
+      const dispose = () => {
+        for (const disposer of disposers.splice(0).reverse()) {
+          try { disposer(); } catch (error) { console.error('[maka-skin] dispose failed', error); }
+        }
+      };
+      globalThis.__makaSkinRuntime = { dispose };
+      document.documentElement.setAttribute('data-maka-skin', manifest.id);
+      return { ok: true };
+    } catch (error) {
+      return { ok: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  })()`;
+}
+
+function transformSkinModule(source: string): string {
+  if (/^\s*import\s/m.test(source) || /\bimport\s*\(/.test(source)) {
+    throw new SkinRuntimeError('invalid-manifest', 'Skin entry must be self-contained and cannot import modules.');
+  }
+  if (/\bexport\s+default\b/.test(source)) {
+    throw new SkinRuntimeError('invalid-manifest', 'Skin entry must use a named activate export.');
+  }
+  return source
+    .replace(/\bexport\s+(async\s+function\s+activate\b)/g, '$1')
+    .replace(/\bexport\s+(function\s+activate\b)/g, '$1')
+    .replace(/\bexport\s+((?:const|let|var)\s+activate\b)/g, '$1')
+    .replace(/\bexport\s*\{\s*activate\s*(?:as\s+activate\s*)?\}\s*;?/g, '');
+}
+
+function readRequiredString(value: unknown, field: string, maxLength = 64): string {
+  if (typeof value !== 'string' || !value.trim() || value.length > maxLength) {
+    throw new SkinRuntimeError('invalid-manifest', `Skin manifest field “${field}” is invalid.`);
+  }
+  return value.trim();
+}
+
+function readOptionalString(value: unknown, maxLength: number): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string' || value.length > maxLength) {
+    throw new SkinRuntimeError('invalid-manifest', 'Skin manifest contains an invalid optional string.');
+  }
+  return value.trim() || undefined;
+}
+
+function readOptionalSafePath(value: unknown, field: string): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== 'string') {
+    throw new SkinRuntimeError('invalid-manifest', `Skin manifest field “${field}” must be a path.`);
+  }
+  const slashPath = value.replaceAll('\\', '/');
+  if (
+    !slashPath ||
+    slashPath.startsWith('/') ||
+    /^[a-z]:/i.test(slashPath) ||
+    slashPath.split('/').some((part) => part === '..')
+  ) {
+    throw new SkinRuntimeError('invalid-manifest', `Skin manifest field “${field}” contains an unsafe path.`);
+  }
+  const normalized = posix.normalize(slashPath).replace(/^\.\//, '');
+  if (!normalized || normalized === '.' || normalized.startsWith('../')) {
+    throw new SkinRuntimeError('invalid-manifest', `Skin manifest field “${field}” contains an unsafe path.`);
+  }
+  return normalized;
+}
+
+async function readBoundedText(path: string, maxBytes: number, label: string): Promise<string> {
+  const bytes = await readFile(path);
+  if (bytes.byteLength > maxBytes) throw new Error(`${label} exceeds its size limit.`);
+  return bytes.toString('utf8');
+}
+
+function mimeType(path: string): string {
+  switch (extname(path).toLowerCase()) {
+    case '.avif': return 'image/avif';
+    case '.gif': return 'image/gif';
+    case '.jpg':
+    case '.jpeg': return 'image/jpeg';
+    case '.png': return 'image/png';
+    case '.svg': return 'image/svg+xml';
+    case '.webp': return 'image/webp';
+    case '.woff': return 'font/woff';
+    case '.woff2': return 'font/woff2';
+    case '.mp3': return 'audio/mpeg';
+    case '.ogg': return 'audio/ogg';
+    case '.wav': return 'audio/wav';
+    default: return 'application/octet-stream';
+  }
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/apps/desktop/src/main/skin-runtime.ts
+++ b/apps/desktop/src/main/skin-runtime.ts
@@ -38,6 +38,11 @@ export const SKIN_PART_NAMES = [
   'settings-sidebar',
   'settings-content',
   'command-palette',
+  'session-list',
+  'session-row',
+  'message',
+  'tool-card',
+  'interaction',
 ] as const;
 
 export const SKIN_SLOT_NAMES = [
@@ -47,6 +52,18 @@ export const SKIN_SLOT_NAMES = [
   'transcript-after',
   'composer-before',
   'composer-after',
+  'session-list-before',
+  'session-list-after',
+  'session-row-before',
+  'session-row-after',
+  'message-before',
+  'message-after',
+  'tool-before',
+  'tool-after',
+  'interaction-before',
+  'interaction-after',
+  'settings-content-before',
+  'settings-content-after',
 ] as const;
 
 export const SKIN_CAPABILITIES = [
@@ -58,6 +75,13 @@ export const SKIN_CAPABILITIES = [
   'actions.task.v1',
   'actions.submit.v1',
   'actions.stop.v1',
+  'sessions.v1',
+  'conversation.v1',
+  'tools.detail.v1',
+  'interactions.question.v1',
+  'composer.control.v1',
+  'navigation.lifecycle.v1',
+  'slots.items.v1',
 ] as const;
 
 const ALLOWED_PERMISSIONS = new Set([
@@ -65,10 +89,17 @@ const ALLOWED_PERMISSIONS = new Set([
   'canvas',
   'audio',
   'storage',
+  'data.sessions',
+  'data.conversation',
+  'data.tools',
+  'data.interactions',
+  'data.composer',
   'actions.navigation',
   'actions.task',
   'actions.submit',
   'actions.stop',
+  'actions.composer',
+  'actions.answer',
 ]);
 
 const CAPABILITY_SET = new Set<string>(SKIN_CAPABILITIES);
@@ -78,16 +109,31 @@ export type SkinPermission =
   | 'canvas'
   | 'audio'
   | 'storage'
+  | 'data.sessions'
+  | 'data.conversation'
+  | 'data.tools'
+  | 'data.interactions'
+  | 'data.composer'
   | 'actions.navigation'
   | 'actions.task'
   | 'actions.submit'
-  | 'actions.stop';
+  | 'actions.stop'
+  | 'actions.composer'
+  | 'actions.answer';
 
 export type SkinActionName =
   | 'navigation.switch-session'
   | 'task.new'
   | 'composer.submit'
-  | 'generation.stop';
+  | 'generation.stop'
+  | 'composer.set-draft'
+  | 'composer.focus'
+  | 'composer.pick-attachments'
+  | 'composer.remove-attachment'
+  | 'composer.set-model'
+  | 'composer.set-skills'
+  | 'composer.set-permission-mode'
+  | 'interaction.answer-question';
 
 export type SkinCapability = (typeof SKIN_CAPABILITIES)[number];
 
@@ -554,6 +600,15 @@ function actionPermission(action: SkinActionName): SkinPermission | null {
     case 'task.new': return 'actions.task';
     case 'composer.submit': return 'actions.submit';
     case 'generation.stop': return 'actions.stop';
+    case 'composer.set-draft':
+    case 'composer.focus':
+    case 'composer.pick-attachments':
+    case 'composer.remove-attachment':
+    case 'composer.set-model':
+    case 'composer.set-skills':
+    case 'composer.set-permission-mode':
+      return 'actions.composer';
+    case 'interaction.answer-question': return 'actions.answer';
     default: return null;
   }
 }
@@ -801,6 +856,21 @@ export function buildSkinActivationScript(
         'task.new': 'actions.task',
         'composer.submit': 'actions.submit',
         'generation.stop': 'actions.stop',
+        'composer.set-draft': 'actions.composer',
+        'composer.focus': 'actions.composer',
+        'composer.pick-attachments': 'actions.composer',
+        'composer.remove-attachment': 'actions.composer',
+        'composer.set-model': 'actions.composer',
+        'composer.set-skills': 'actions.composer',
+        'composer.set-permission-mode': 'actions.composer',
+        'interaction.answer-question': 'actions.answer',
+      });
+      const eventPermissions = Object.freeze({
+        'sessions.changed': 'data.sessions',
+        'conversation.changed': 'data.conversation',
+        'tools.detail.changed': 'data.tools',
+        'interaction.detail.changed': 'data.interactions',
+        'composer.changed': 'data.composer',
       });
       const accessibilityQueries = Object.freeze({
         forcedColors: matchMedia('(forced-colors: active)'),
@@ -845,6 +915,37 @@ export function buildSkinActivationScript(
         if (immediate) queueMicrotask(immediate);
         return off;
       };
+      const requestSnapshot = (type) => new Promise((resolve, reject) => {
+        const request = document.createElement('span');
+        request.hidden = true;
+        request.dataset.makaSkinSnapshotType = String(type);
+        request.dataset.makaSkinSnapshotId =
+          globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+        overlay.appendChild(request);
+        let settled = false;
+        let timer;
+        const finish = () => {
+          if (settled) return;
+          settled = true;
+          clearTimeout(timer);
+          request.removeEventListener('maka:skin-snapshot-response', onResponse);
+          const raw = request.dataset.makaSkinSnapshotResult;
+          const error = request.dataset.makaSkinSnapshotError;
+          request.remove();
+          if (error) reject(new Error(error));
+          else {
+            try { resolve(raw ? JSON.parse(raw) : null); }
+            catch { reject(new Error('Maka skin snapshot was invalid.')); }
+          }
+        };
+        const onResponse = () => finish();
+        request.addEventListener('maka:skin-snapshot-response', onResponse);
+        timer = setTimeout(() => {
+          request.dataset.makaSkinSnapshotError = 'Maka skin snapshot timed out.';
+          finish();
+        }, 10000);
+        request.dispatchEvent(new Event('maka:skin-snapshot-request', { bubbles: true }));
+      });
       const onMediaChanges = (handler) => {
         for (const query of Object.values(accessibilityQueries)) query.addEventListener('change', handler);
         const off = () => {
@@ -890,9 +991,10 @@ export function buildSkinActivationScript(
       const partSelector = (name) =>
         '[data-maka-part="' + CSS.escape(String(name)) + '"]';
       const findPart = (name) => document.querySelector(partSelector(name));
-      const slotSelector = (name) =>
-        '[data-maka-slot="' + CSS.escape(String(name)) + '"]';
-      const findSlot = (name) => document.querySelector(slotSelector(name));
+      const slotSelector = (name, ownerId) =>
+        '[data-maka-slot="' + CSS.escape(String(name)) + '"]'
+        + (ownerId === undefined ? '' : '[data-maka-owner-id="' + CSS.escape(String(ownerId)) + '"]');
+      const findSlot = (name, ownerId) => document.querySelector(slotSelector(name, ownerId));
       const signalAppearanceChange = () => {
         root.dataset.makaSkinAppearanceRevision =
           String((Number(root.dataset.makaSkinAppearanceRevision) || 0) + 1);
@@ -998,6 +1100,7 @@ export function buildSkinActivationScript(
         slots: Object.freeze({
           names: slotNames,
           one: findSlot,
+          all(name, ownerId) { return [...document.querySelectorAll(slotSelector(name, ownerId))]; },
           observe(name, handler) {
             if (typeof handler !== 'function') throw new TypeError('Slot observer must be a function.');
             const selector = slotSelector(name);
@@ -1038,12 +1141,13 @@ export function buildSkinActivationScript(
               });
             });
           },
-          mount(name) {
-            const slot = findSlot(name);
+          mount(name, ownerId) {
+            const slot = findSlot(name, ownerId);
             if (!slot) throw new Error('Maka slot is not currently available: ' + String(name));
             const mount = document.createElement('div');
             mount.dataset.makaSkinMount = manifest.id;
             mount.dataset.makaSkinSlot = String(name);
+            if (ownerId !== undefined) mount.dataset.makaSkinOwnerId = String(ownerId);
             slot.appendChild(mount);
             disposers.push(() => mount.remove());
             return mount;
@@ -1118,7 +1222,33 @@ export function buildSkinActivationScript(
         }),
         events: Object.freeze({
           on(type, handler) {
-            return onHostEvent(type, handler);
+            const eventType = String(type);
+            const permission = eventPermissions[eventType];
+            if (permission && !permissionNames.includes(permission)) {
+              throw new Error('Skin data permission was not granted: ' + permission);
+            }
+            const off = onHostEvent(eventType, handler);
+            queueMicrotask(() => {
+              const initial = eventType === 'state'
+                ? Promise.resolve(readState())
+                : eventType === 'appearance'
+                  ? Promise.resolve(readAppearance())
+                  : requestSnapshot(eventType);
+              initial
+                .then((detail) => handler(detail, new CustomEvent('maka:' + eventType, { detail })))
+                .catch((error) => console.warn('[maka-skin] initial event snapshot failed', error));
+            });
+            return off;
+          },
+          snapshot(type) {
+            const eventType = String(type);
+            const permission = eventPermissions[eventType];
+            if (permission && !permissionNames.includes(permission)) {
+              return Promise.reject(new Error('Skin data permission was not granted: ' + permission));
+            }
+            if (eventType === 'state') return Promise.resolve(readState());
+            if (eventType === 'appearance') return Promise.resolve(readAppearance());
+            return requestSnapshot(eventType);
           },
         }),
         actions: Object.freeze({

--- a/apps/desktop/src/main/skin-runtime.ts
+++ b/apps/desktop/src/main/skin-runtime.ts
@@ -17,7 +17,26 @@ const MAX_EXPANDED_BYTES = 64 * 1024 * 1024;
 const MAX_ARCHIVE_ENTRIES = 128;
 const MAX_SCRIPT_BYTES = 2 * 1024 * 1024;
 const MAX_STYLESHEET_BYTES = 4 * 1024 * 1024;
+const MAX_PREVIEW_BYTES = 4 * 1024 * 1024;
 const STATE_FILE = 'state.json';
+
+export const SKIN_PART_NAMES = [
+  'app',
+  'shell',
+  'titlebar',
+  'sidebar',
+  'main',
+  'detail-panel',
+  'chat',
+  'chat-header',
+  'transcript',
+  'composer',
+  'composer-interactions',
+  'settings',
+  'settings-sidebar',
+  'settings-content',
+  'command-palette',
+] as const;
 
 const ALLOWED_PERMISSIONS = new Set([
   'dom',
@@ -44,6 +63,7 @@ export interface SkinManifest {
 export interface InstalledSkin {
   manifest: SkinManifest;
   active: boolean;
+  previewDataUrl?: string;
 }
 
 export interface SkinRuntimeSnapshot {
@@ -79,6 +99,8 @@ export interface SkinRuntime {
   installFromFile(archivePath: string): Promise<SkinRuntimeSnapshot>;
   activate(id: string): Promise<SkinRuntimeSnapshot>;
   disable(): Promise<SkinRuntimeSnapshot>;
+  reload(): Promise<SkinRuntimeSnapshot>;
+  uninstall(id: string): Promise<SkinRuntimeSnapshot>;
 }
 
 export class SkinRuntimeError extends Error {
@@ -171,10 +193,11 @@ export function createSkinRuntime(options: {
     const manifests = await readInstalledManifests();
     return {
       activeSkinId: safeMode ? null : state.activeSkinId,
-      installed: manifests.map((manifest) => ({
+      installed: await Promise.all(manifests.map(async (manifest) => ({
         manifest,
         active: !safeMode && manifest.id === state.activeSkinId,
-      })),
+        previewDataUrl: await readSkinPreview(join(installedDir, manifest.id), manifest),
+      }))),
       safeMode,
       recoveredFromFailedActivation,
       lastError: state.lastError,
@@ -316,14 +339,17 @@ export function createSkinRuntime(options: {
       const manifest = parseSkinManifest(manifestValue);
       assertManifestFiles(manifest, normalizedFiles);
       const destination = join(installedDir, manifest.id);
+      let replacing = false;
       try {
         await readFile(join(destination, 'manifest.json'));
-        throw new SkinRuntimeError('already-installed', `Skin “${manifest.name}” is already installed.`);
-      } catch (error) {
-        if (error instanceof SkinRuntimeError) throw error;
-      }
+        replacing = true;
+      } catch {}
 
       const staging = join(rootDir, `.install-${randomUUID()}`);
+      const backup = join(rootDir, `.backup-${randomUUID()}`);
+      const wasActive = state.activeSkinId === manifest.id;
+      let backedUp = false;
+      let installedNewVersion = false;
       await mkdir(staging, { recursive: true });
       try {
         for (const [relativePath, bytes] of normalizedFiles) {
@@ -331,9 +357,41 @@ export function createSkinRuntime(options: {
           await mkdir(dirname(output), { recursive: true });
           await writeFile(output, bytes);
         }
-        await rename(staging, destination);
+        if (replacing) {
+          await rename(destination, backup);
+          backedUp = true;
+        }
+        try {
+          await rename(staging, destination);
+          installedNewVersion = true;
+          if (wasActive) await applyActiveSkin();
+        } catch (error) {
+          if (backedUp) {
+            if (installedNewVersion) {
+              await clearRendererSkin();
+              await rm(destination, { recursive: true, force: true });
+            }
+            await rename(backup, destination);
+            backedUp = false;
+            if (wasActive) {
+              state = {
+                activeSkinId: manifest.id,
+                activationPending: false,
+                lastError: null,
+              };
+              await persistState();
+              await applyActiveSkin().catch(() => undefined);
+            }
+          }
+          throw error;
+        }
+        if (backedUp) {
+          await rm(backup, { recursive: true, force: true }).catch(() => undefined);
+          backedUp = false;
+        }
       } catch (error) {
         await rm(staging, { recursive: true, force: true });
+        if (backedUp) await rename(backup, destination).catch(() => undefined);
         throw error;
       }
       return snapshot();
@@ -365,6 +423,33 @@ export function createSkinRuntime(options: {
       };
       await persistState();
       await clearRendererSkin();
+      return snapshot();
+    }),
+    reload: () => serialize(async () => {
+      await applyActiveSkin();
+      return snapshot();
+    }),
+    uninstall: (id) => serialize(async () => {
+      await initialize();
+      if (!/^[a-z0-9][a-z0-9._-]{1,63}$/.test(id)) {
+        throw new SkinRuntimeError('not-installed', 'Invalid skin id.');
+      }
+      const destination = join(installedDir, id);
+      try {
+        await readFile(join(destination, 'manifest.json'));
+      } catch {
+        throw new SkinRuntimeError('not-installed', `Skin “${id}” is not installed.`);
+      }
+      if (state.activeSkinId === id) {
+        state = {
+          activeSkinId: null,
+          activationPending: false,
+          lastError: null,
+        };
+        await persistState();
+        await clearRendererSkin();
+      }
+      await rm(destination, { recursive: true, force: true });
       return snapshot();
     }),
   };
@@ -514,6 +599,20 @@ async function readSkinAssets(skinDir: string): Promise<Record<string, string>> 
   return result;
 }
 
+async function readSkinPreview(
+  skinDir: string,
+  manifest: SkinManifest,
+): Promise<string | undefined> {
+  if (!manifest.preview) return undefined;
+  try {
+    const bytes = await readFile(join(skinDir, manifest.preview));
+    if (bytes.byteLength > MAX_PREVIEW_BYTES) return undefined;
+    return `data:${mimeType(manifest.preview)};base64,${bytes.toString('base64')}`;
+  } catch {
+    return undefined;
+  }
+}
+
 export function inlineStylesheetAssets(
   stylesheet: string,
   stylesheetPath: string,
@@ -550,7 +649,126 @@ export function buildSkinActivationScript(
       document.body.appendChild(overlay);
       disposers.push(() => overlay.remove());
 
+      const root = document.documentElement;
+      const partNames = Object.freeze(${JSON.stringify(SKIN_PART_NAMES)});
+      const accessibilityQueries = Object.freeze({
+        forcedColors: matchMedia('(forced-colors: active)'),
+        prefersContrast: matchMedia('(prefers-contrast: more)'),
+        reducedMotion: matchMedia('(prefers-reduced-motion: reduce)'),
+        reducedTransparency: matchMedia('(prefers-reduced-transparency: reduce)'),
+      });
+      const readAppearance = () => Object.freeze({
+        preference: ['light', 'dark', 'auto'].includes(root.dataset.makaThemePreference)
+          ? root.dataset.makaThemePreference
+          : 'auto',
+        resolvedTheme: root.classList.contains('dark') ? 'dark' : 'light',
+        palette: root.getAttribute('data-maka-theme') || 'default',
+        colorScheme: root.classList.contains('dark') ? 'dark' : 'light',
+        forcedColors: accessibilityQueries.forcedColors.matches,
+        prefersContrast: accessibilityQueries.prefersContrast.matches,
+        reducedMotion: accessibilityQueries.reducedMotion.matches,
+        reducedTransparency: accessibilityQueries.reducedTransparency.matches,
+      });
+      const readState = () => Object.freeze({
+        section: root.dataset.makaSection || 'sessions',
+        module: root.dataset.makaModule || undefined,
+        hasActiveSession: root.dataset.makaHasActiveSession === 'true',
+        streaming: root.dataset.makaStreaming === 'true',
+        modalOpen: root.dataset.makaModalOpen === 'true',
+      });
+      const readEnvironment = () => Object.freeze({
+        locale: document.documentElement.lang || navigator.language,
+        platform: navigator.platform,
+        viewport: Object.freeze({ width: innerWidth, height: innerHeight }),
+        devicePixelRatio,
+        touch: navigator.maxTouchPoints > 0,
+        ...readAppearance(),
+      });
+      const onHostEvent = (type, handler, immediate) => {
+        if (typeof handler !== 'function') throw new TypeError('Skin event handler must be a function.');
+        const eventName = 'maka:' + String(type);
+        const listener = (event) => handler(event.detail, event);
+        window.addEventListener(eventName, listener);
+        const off = () => window.removeEventListener(eventName, listener);
+        disposers.push(off);
+        if (immediate) queueMicrotask(immediate);
+        return off;
+      };
+      const onMediaChanges = (handler) => {
+        for (const query of Object.values(accessibilityQueries)) query.addEventListener('change', handler);
+        const off = () => {
+          for (const query of Object.values(accessibilityQueries)) query.removeEventListener('change', handler);
+        };
+        disposers.push(off);
+        return off;
+      };
+      const normalizeTokenName = (name) => {
+        const normalized = String(name);
+        if (!/^--[a-z0-9][a-z0-9_-]{0,127}$/i.test(normalized)) {
+          throw new TypeError('Theme token names must be CSS custom properties.');
+        }
+        return normalized;
+      };
+      const changedInlineTokens = new Map();
+      const rememberInlineToken = (name) => {
+        if (!changedInlineTokens.has(name)) {
+          changedInlineTokens.set(name, {
+            value: root.style.getPropertyValue(name),
+            priority: root.style.getPropertyPriority(name),
+          });
+        }
+      };
+      const resetToken = (name) => {
+        const normalized = normalizeTokenName(name);
+        const previous = changedInlineTokens.get(normalized);
+        if (!previous) return;
+        if (previous.value) root.style.setProperty(normalized, previous.value, previous.priority);
+        else root.style.removeProperty(normalized);
+        changedInlineTokens.delete(normalized);
+      };
+      const resetAllTokens = () => {
+        for (const name of [...changedInlineTokens.keys()]) resetToken(name);
+      };
+      const setToken = (name, value) => {
+        const normalized = normalizeTokenName(name);
+        const next = String(value);
+        if (!next || next.length > 4096) throw new TypeError('Theme token value is invalid.');
+        rememberInlineToken(normalized);
+        root.style.setProperty(normalized, next);
+      };
+      const partSelector = (name) =>
+        '[data-maka-part="' + CSS.escape(String(name)) + '"]';
+      const findPart = (name) => document.querySelector(partSelector(name));
+      const signalAppearanceChange = () => {
+        root.dataset.makaSkinAppearanceRevision =
+          String((Number(root.dataset.makaSkinAppearanceRevision) || 0) + 1);
+      };
+      disposers.push(resetAllTokens);
+
+      const tokenApi = Object.freeze({
+        get(name) {
+          return getComputedStyle(root).getPropertyValue(normalizeTokenName(name)).trim();
+        },
+        all() {
+          const computed = getComputedStyle(root);
+          const values = {};
+          for (let index = 0; index < computed.length; index += 1) {
+            const name = computed.item(index);
+            if (name.startsWith('--')) values[name] = computed.getPropertyValue(name).trim();
+          }
+          return Object.freeze(values);
+        },
+        set: setToken,
+        setAll(values) {
+          if (!values || typeof values !== 'object') throw new TypeError('Theme token map is invalid.');
+          for (const [name, value] of Object.entries(values)) setToken(name, value);
+        },
+        reset(name) { resetToken(name); },
+        resetAll() { resetAllTokens(); },
+      });
+
       const api = Object.freeze({
+        apiVersion: 1,
         manifest,
         overlay,
         assets: Object.freeze({
@@ -561,17 +779,130 @@ export function buildSkinActivationScript(
           list() { return Object.keys(assetTable); },
         }),
         parts: Object.freeze({
-          one(name) { return document.querySelector('[data-maka-part="' + CSS.escape(String(name)) + '"]'); },
-          all(name) { return [...document.querySelectorAll('[data-maka-part="' + CSS.escape(String(name)) + '"]')]; },
+          names: partNames,
+          one: findPart,
+          all(name) { return [...document.querySelectorAll(partSelector(name))]; },
+          observe(name, handler) {
+            if (typeof handler !== 'function') throw new TypeError('Part observer must be a function.');
+            const selector = partSelector(name);
+            let previous = null;
+            const publish = () => {
+              const next = [...document.querySelectorAll(selector)];
+              if (previous && next.length === previous.length && next.every((node, index) => node === previous[index])) return;
+              previous = next;
+              handler(Object.freeze([...next]));
+            };
+            const observer = new MutationObserver(publish);
+            observer.observe(document.documentElement, { childList: true, subtree: true });
+            const off = () => observer.disconnect();
+            disposers.push(off);
+            queueMicrotask(publish);
+            return off;
+          },
+          wait(name, timeoutMs = 5000) {
+            const current = findPart(name);
+            if (current) return Promise.resolve(current);
+            return new Promise((resolve, reject) => {
+              const selector = partSelector(name);
+              const observer = new MutationObserver(() => {
+                const match = document.querySelector(selector);
+                if (!match) return;
+                observer.disconnect();
+                clearTimeout(timer);
+                resolve(match);
+              });
+              const timer = setTimeout(() => {
+                observer.disconnect();
+                reject(new Error('Timed out waiting for Maka part “' + String(name) + '”.'));
+              }, Math.max(0, Math.min(Number(timeoutMs) || 0, 60000)));
+              observer.observe(document.documentElement, { childList: true, subtree: true });
+              disposers.push(() => {
+                observer.disconnect();
+                clearTimeout(timer);
+              });
+            });
+          },
+        }),
+        appearance: Object.freeze({
+          current: readAppearance,
+          tokens: tokenApi,
+          onDidChange(handler) {
+            if (typeof handler !== 'function') throw new TypeError('Appearance handler must be a function.');
+            const notify = () => handler(readAppearance());
+            const offEvent = onHostEvent('appearance', notify, notify);
+            const observer = new MutationObserver(notify);
+            observer.observe(root, {
+              attributes: true,
+              attributeFilter: ['class', 'style', 'data-maka-theme', 'data-maka-theme-preference', 'data-maka-color-scheme'],
+            });
+            const offMedia = onMediaChanges(notify);
+            const off = () => {
+              offEvent();
+              offMedia();
+              observer.disconnect();
+            };
+            disposers.push(off);
+            return off;
+          },
+        }),
+        state: Object.freeze({
+          current: readState,
+          onDidChange(handler) {
+            return onHostEvent('state', handler, () => handler(readState()));
+          },
+        }),
+        environment: Object.freeze({
+          current: readEnvironment,
+          onDidChange(handler) {
+            if (typeof handler !== 'function') throw new TypeError('Environment handler must be a function.');
+            const notify = () => handler(readEnvironment());
+            addEventListener('resize', notify);
+            addEventListener('languagechange', notify);
+            const offMedia = onMediaChanges(notify);
+            const off = () => {
+              removeEventListener('resize', notify);
+              removeEventListener('languagechange', notify);
+              offMedia();
+            };
+            disposers.push(off);
+            queueMicrotask(notify);
+            return off;
+          },
+        }),
+        styles: Object.freeze({
+          add(css, id = '') {
+            const style = document.createElement('style');
+            style.dataset.makaSkinStyle = manifest.id + (id ? ':' + String(id) : '');
+            style.textContent = String(css);
+            document.head.appendChild(style);
+            signalAppearanceChange();
+            const handle = Object.freeze({
+              update(nextCss) {
+                style.textContent = String(nextCss);
+                signalAppearanceChange();
+              },
+              dispose() {
+                style.remove();
+                signalAppearanceChange();
+              },
+            });
+            disposers.push(handle.dispose);
+            return handle;
+          },
         }),
         events: Object.freeze({
           on(type, handler) {
-            const eventName = 'maka:' + String(type);
-            const listener = (event) => handler(event.detail, event);
-            window.addEventListener(eventName, listener);
-            const off = () => window.removeEventListener(eventName, listener);
-            disposers.push(off);
-            return off;
+            return onHostEvent(type, handler);
+          },
+        }),
+        lifecycle: Object.freeze({
+          onDispose(handler) {
+            if (typeof handler !== 'function') throw new TypeError('Dispose handler must be a function.');
+            disposers.push(handler);
+            return () => {
+              const index = disposers.indexOf(handler);
+              if (index >= 0) disposers.splice(index, 1);
+            };
           },
         }),
         storage: Object.freeze({

--- a/apps/desktop/src/main/skin-runtime.ts
+++ b/apps/desktop/src/main/skin-runtime.ts
@@ -1,4 +1,4 @@
-import { randomUUID } from 'node:crypto';
+import { createHash, randomUUID } from 'node:crypto';
 import {
   mkdir,
   readFile,
@@ -8,9 +8,11 @@ import {
   writeFile,
 } from 'node:fs/promises';
 import { dirname, extname, join, posix } from 'node:path';
+import { parse } from '@babel/parser';
 import { unzipSync } from 'fflate';
 
-const SKIN_SCHEMA_VERSION = 1;
+export const SKIN_API_VERSION = 2;
+const SKIN_SCHEMA_VERSION = 2;
 const SKIN_WORLD_ID = 1004;
 const MAX_ARCHIVE_BYTES = 32 * 1024 * 1024;
 const MAX_EXPANDED_BYTES = 64 * 1024 * 1024;
@@ -38,17 +40,59 @@ export const SKIN_PART_NAMES = [
   'command-palette',
 ] as const;
 
+export const SKIN_SLOT_NAMES = [
+  'chat-header-before',
+  'chat-header-after',
+  'transcript-before',
+  'transcript-after',
+  'composer-before',
+  'composer-after',
+] as const;
+
+export const SKIN_CAPABILITIES = [
+  'appearance.v1',
+  'parts.v1',
+  'slots.v1',
+  'events.semantic.v1',
+  'actions.navigation.v1',
+  'actions.task.v1',
+  'actions.submit.v1',
+  'actions.stop.v1',
+] as const;
+
 const ALLOWED_PERMISSIONS = new Set([
   'dom',
   'canvas',
   'audio',
   'storage',
+  'actions.navigation',
+  'actions.task',
+  'actions.submit',
+  'actions.stop',
 ]);
 
-export type SkinPermission = 'dom' | 'canvas' | 'audio' | 'storage';
+const CAPABILITY_SET = new Set<string>(SKIN_CAPABILITIES);
+
+export type SkinPermission =
+  | 'dom'
+  | 'canvas'
+  | 'audio'
+  | 'storage'
+  | 'actions.navigation'
+  | 'actions.task'
+  | 'actions.submit'
+  | 'actions.stop';
+
+export type SkinActionName =
+  | 'navigation.switch-session'
+  | 'task.new'
+  | 'composer.submit'
+  | 'generation.stop';
+
+export type SkinCapability = (typeof SKIN_CAPABILITIES)[number];
 
 export interface SkinManifest {
-  schemaVersion: 1;
+  schemaVersion: 1 | 2;
   id: string;
   name: string;
   version: string;
@@ -58,6 +102,8 @@ export interface SkinManifest {
   entry?: string;
   preview?: string;
   permissions: SkinPermission[];
+  minimumApiVersion: number;
+  requiredCapabilities: SkinCapability[];
 }
 
 export interface InstalledSkin {
@@ -96,11 +142,16 @@ export interface SkinRuntime {
   readonly rootDir: string;
   attach(webContents: SkinWebContents): void;
   list(): Promise<SkinRuntimeSnapshot>;
-  installFromFile(archivePath: string): Promise<SkinRuntimeSnapshot>;
+  inspectFile(archivePath: string): Promise<{
+    manifest: SkinManifest;
+    archiveDigest: string;
+  }>;
+  installFromFile(archivePath: string, expectedDigest?: string): Promise<SkinRuntimeSnapshot>;
   activate(id: string): Promise<SkinRuntimeSnapshot>;
   disable(): Promise<SkinRuntimeSnapshot>;
   reload(): Promise<SkinRuntimeSnapshot>;
   uninstall(id: string): Promise<SkinRuntimeSnapshot>;
+  authorizeAction(action: SkinActionName): Promise<boolean>;
 }
 
 export class SkinRuntimeError extends Error {
@@ -116,6 +167,41 @@ export class SkinRuntimeError extends Error {
     super(message);
     this.name = 'SkinRuntimeError';
   }
+}
+
+async function readSkinPackage(archivePath: string): Promise<{
+  files: Map<string, Uint8Array>;
+  manifest: SkinManifest;
+  archiveDigest: string;
+}> {
+  const archive = await readFile(archivePath);
+  if (archive.byteLength > MAX_ARCHIVE_BYTES) {
+    throw new SkinRuntimeError('invalid-archive', 'Skin archive is larger than 32 MiB.');
+  }
+  let files: Record<string, Uint8Array>;
+  try {
+    files = unzipSync(new Uint8Array(archive));
+  } catch {
+    throw new SkinRuntimeError('invalid-archive', 'The selected file is not a valid .maka-skin archive.');
+  }
+  const normalizedFiles = normalizeArchiveFiles(files);
+  const manifestBytes = normalizedFiles.get('manifest.json');
+  if (!manifestBytes) {
+    throw new SkinRuntimeError('invalid-manifest', 'Skin archive does not contain manifest.json.');
+  }
+  let manifestValue: unknown;
+  try {
+    manifestValue = JSON.parse(new TextDecoder().decode(manifestBytes));
+  } catch {
+    throw new SkinRuntimeError('invalid-manifest', 'Skin manifest is not valid JSON.');
+  }
+  const manifest = parseSkinManifest(manifestValue);
+  assertManifestFiles(manifest, normalizedFiles);
+  return {
+    files: normalizedFiles,
+    manifest,
+    archiveDigest: createHash('sha256').update(archive).digest('hex'),
+  };
 }
 
 export function createSkinRuntime(options: {
@@ -216,6 +302,7 @@ export function createSkinRuntime(options: {
         try { current?.dispose?.(); } catch (error) { console.error('[maka-skin] dispose failed', error); }
         delete globalThis.__makaSkinRuntime;
         document.documentElement.removeAttribute('data-maka-skin');
+        document.documentElement.removeAttribute('data-maka-skin-api-version');
       })()`,
       url: 'maka-skin://runtime/deactivate.js',
     }]).catch(() => undefined);
@@ -272,7 +359,7 @@ export function createSkinRuntime(options: {
         }
       } else {
         await target.executeJavaScriptInIsolatedWorld(SKIN_WORLD_ID, [{
-          code: `document.documentElement.setAttribute('data-maka-skin', ${JSON.stringify(manifest.id)}); ({ ok: true })`,
+          code: `document.documentElement.setAttribute('data-maka-skin', ${JSON.stringify(manifest.id)}); document.documentElement.setAttribute('data-maka-skin-api-version', ${JSON.stringify(String(SKIN_API_VERSION))}); ({ ok: true })`,
           url: `maka-skin://${manifest.id}/activate.js`,
         }]);
       }
@@ -313,31 +400,23 @@ export function createSkinRuntime(options: {
       });
     },
     list: () => serialize(snapshot),
-    installFromFile: (archivePath) => serialize(async () => {
+    inspectFile: (archivePath) => serialize(async () => {
+      const { manifest, archiveDigest } = await readSkinPackage(archivePath);
+      return { manifest, archiveDigest };
+    }),
+    installFromFile: (archivePath, expectedDigest) => serialize(async () => {
       await initialize();
-      const archive = await readFile(archivePath);
-      if (archive.byteLength > MAX_ARCHIVE_BYTES) {
-        throw new SkinRuntimeError('invalid-archive', 'Skin archive is larger than 32 MiB.');
+      const {
+        files: normalizedFiles,
+        manifest,
+        archiveDigest,
+      } = await readSkinPackage(archivePath);
+      if (expectedDigest && archiveDigest !== expectedDigest) {
+        throw new SkinRuntimeError(
+          'invalid-archive',
+          'The skin package changed after its permissions were reviewed. Import it again.',
+        );
       }
-      let files: Record<string, Uint8Array>;
-      try {
-        files = unzipSync(new Uint8Array(archive));
-      } catch {
-        throw new SkinRuntimeError('invalid-archive', 'The selected file is not a valid .maka-skin archive.');
-      }
-      const normalizedFiles = normalizeArchiveFiles(files);
-      const manifestBytes = normalizedFiles.get('manifest.json');
-      if (!manifestBytes) {
-        throw new SkinRuntimeError('invalid-manifest', 'Skin archive does not contain manifest.json.');
-      }
-      let manifestValue: unknown;
-      try {
-        manifestValue = JSON.parse(new TextDecoder().decode(manifestBytes));
-      } catch {
-        throw new SkinRuntimeError('invalid-manifest', 'Skin manifest is not valid JSON.');
-      }
-      const manifest = parseSkinManifest(manifestValue);
-      assertManifestFiles(manifest, normalizedFiles);
       const destination = join(installedDir, manifest.id);
       let replacing = false;
       try {
@@ -452,7 +531,31 @@ export function createSkinRuntime(options: {
       await rm(destination, { recursive: true, force: true });
       return snapshot();
     }),
+    authorizeAction: (action) => serialize(async () => {
+      await initialize();
+      if (safeMode || !state.activeSkinId) return false;
+      const requiredPermission = actionPermission(action);
+      if (!requiredPermission) return false;
+      try {
+        const manifest = parseSkinManifest(
+          JSON.parse(await readFile(join(installedDir, state.activeSkinId, 'manifest.json'), 'utf8')),
+        );
+        return manifest.permissions.includes(requiredPermission);
+      } catch {
+        return false;
+      }
+    }),
   };
+}
+
+function actionPermission(action: SkinActionName): SkinPermission | null {
+  switch (action) {
+    case 'navigation.switch-session': return 'actions.navigation';
+    case 'task.new': return 'actions.task';
+    case 'composer.submit': return 'actions.submit';
+    case 'generation.stop': return 'actions.stop';
+    default: return null;
+  }
 }
 
 export function parseSkinManifest(value: unknown): SkinManifest {
@@ -460,9 +563,10 @@ export function parseSkinManifest(value: unknown): SkinManifest {
     throw new SkinRuntimeError('invalid-manifest', 'Skin manifest must be an object.');
   }
   const candidate = value as Record<string, unknown>;
-  if (candidate.schemaVersion !== SKIN_SCHEMA_VERSION) {
+  if (candidate.schemaVersion !== 1 && candidate.schemaVersion !== SKIN_SCHEMA_VERSION) {
     throw new SkinRuntimeError('invalid-manifest', 'Unsupported skin manifest schemaVersion.');
   }
+  const schemaVersion = candidate.schemaVersion;
   const id = readRequiredString(candidate.id, 'id');
   if (!/^[a-z0-9][a-z0-9._-]{1,63}$/.test(id)) {
     throw new SkinRuntimeError('invalid-manifest', 'Skin id must contain 2–64 lowercase letters, numbers, dots, dashes, or underscores.');
@@ -480,8 +584,36 @@ export function parseSkinManifest(value: unknown): SkinManifest {
     throw new SkinRuntimeError('invalid-manifest', 'Skin permissions contain an unsupported capability.');
   }
   const permissions = [...new Set(rawPermissions)] as SkinPermission[];
+  if (entry && !permissions.includes('dom') && schemaVersion === 2) {
+    throw new SkinRuntimeError(
+      'invalid-manifest',
+      'Skin JavaScript requires the “dom” permission because it can read and modify visible page content.',
+    );
+  }
+  if (entry && !permissions.includes('dom')) permissions.push('dom');
+  const minimumApiVersion = schemaVersion === 1
+    ? 1
+    : readApiVersion(candidate.minimumApiVersion);
+  if (minimumApiVersion > SKIN_API_VERSION) {
+    throw new SkinRuntimeError(
+      'invalid-manifest',
+      `Skin requires Maka Skin API ${minimumApiVersion}, but this host provides ${SKIN_API_VERSION}.`,
+    );
+  }
+  const rawCapabilities = candidate.requiredCapabilities ?? [];
+  if (!Array.isArray(rawCapabilities) || rawCapabilities.some((item) => typeof item !== 'string')) {
+    throw new SkinRuntimeError('invalid-manifest', 'Skin requiredCapabilities must be an array of capability names.');
+  }
+  const unsupportedCapabilities = rawCapabilities.filter((item) => !CAPABILITY_SET.has(item as string));
+  if (unsupportedCapabilities.length > 0) {
+    throw new SkinRuntimeError(
+      'invalid-manifest',
+      `Skin requires unsupported capabilities: ${unsupportedCapabilities.join(', ')}.`,
+    );
+  }
+  const requiredCapabilities = [...new Set(rawCapabilities)] as SkinCapability[];
   return {
-    schemaVersion: 1,
+    schemaVersion,
     id,
     name,
     version,
@@ -491,7 +623,19 @@ export function parseSkinManifest(value: unknown): SkinManifest {
     ...(entry ? { entry } : {}),
     ...(preview ? { preview } : {}),
     permissions,
+    minimumApiVersion,
+    requiredCapabilities,
   };
+}
+
+function readApiVersion(value: unknown): number {
+  if (!Number.isInteger(value) || (value as number) < 1 || (value as number) > 1_000) {
+    throw new SkinRuntimeError(
+      'invalid-manifest',
+      'Skin manifest minimumApiVersion must be a positive integer.',
+    );
+  }
+  return value as number;
 }
 
 export function normalizeArchiveFiles(files: Record<string, Uint8Array>): Map<string, Uint8Array> {
@@ -568,9 +712,7 @@ function assertManifestFiles(manifest: SkinManifest, files: Map<string, Uint8Arr
       throw new SkinRuntimeError('invalid-manifest', 'Skin entry is larger than 2 MiB.');
     }
     const source = new TextDecoder().decode(entry);
-    if (/^\s*import\s/m.test(source) || /\bimport\s*\(/.test(source)) {
-      throw new SkinRuntimeError('invalid-manifest', 'Skin entry must be self-contained and cannot import modules.');
-    }
+    assertSelfContainedSkinModule(source);
   }
 }
 
@@ -651,6 +793,15 @@ export function buildSkinActivationScript(
 
       const root = document.documentElement;
       const partNames = Object.freeze(${JSON.stringify(SKIN_PART_NAMES)});
+      const slotNames = Object.freeze(${JSON.stringify(SKIN_SLOT_NAMES)});
+      const capabilityNames = Object.freeze(${JSON.stringify(SKIN_CAPABILITIES)});
+      const permissionNames = Object.freeze([...manifest.permissions]);
+      const actionPermissions = Object.freeze({
+        'navigation.switch-session': 'actions.navigation',
+        'task.new': 'actions.task',
+        'composer.submit': 'actions.submit',
+        'generation.stop': 'actions.stop',
+      });
       const accessibilityQueries = Object.freeze({
         forcedColors: matchMedia('(forced-colors: active)'),
         prefersContrast: matchMedia('(prefers-contrast: more)'),
@@ -739,6 +890,9 @@ export function buildSkinActivationScript(
       const partSelector = (name) =>
         '[data-maka-part="' + CSS.escape(String(name)) + '"]';
       const findPart = (name) => document.querySelector(partSelector(name));
+      const slotSelector = (name) =>
+        '[data-maka-slot="' + CSS.escape(String(name)) + '"]';
+      const findSlot = (name) => document.querySelector(slotSelector(name));
       const signalAppearanceChange = () => {
         root.dataset.makaSkinAppearanceRevision =
           String((Number(root.dataset.makaSkinAppearanceRevision) || 0) + 1);
@@ -768,9 +922,27 @@ export function buildSkinActivationScript(
       });
 
       const api = Object.freeze({
-        apiVersion: 1,
+        apiVersion: ${SKIN_API_VERSION},
         manifest,
         overlay,
+        capabilities: Object.freeze({
+          all: capabilityNames,
+          has(name) { return capabilityNames.includes(String(name)); },
+          require(name) {
+            if (!capabilityNames.includes(String(name))) {
+              throw new Error('Maka Skin capability is unavailable: ' + String(name));
+            }
+          },
+        }),
+        permissions: Object.freeze({
+          all: permissionNames,
+          has(name) { return permissionNames.includes(String(name)); },
+          require(name) {
+            if (!permissionNames.includes(String(name))) {
+              throw new Error('Skin permission was not granted: ' + String(name));
+            }
+          },
+        }),
         assets: Object.freeze({
           url(path) {
             const normalized = String(path).replace(/^\\.\\//, '');
@@ -821,6 +993,60 @@ export function buildSkinActivationScript(
                 clearTimeout(timer);
               });
             });
+          },
+        }),
+        slots: Object.freeze({
+          names: slotNames,
+          one: findSlot,
+          observe(name, handler) {
+            if (typeof handler !== 'function') throw new TypeError('Slot observer must be a function.');
+            const selector = slotSelector(name);
+            let previous = null;
+            const publish = () => {
+              const next = document.querySelector(selector);
+              if (next === previous) return;
+              previous = next;
+              handler(next);
+            };
+            const observer = new MutationObserver(publish);
+            observer.observe(document.documentElement, { childList: true, subtree: true });
+            const off = () => observer.disconnect();
+            disposers.push(off);
+            queueMicrotask(publish);
+            return off;
+          },
+          wait(name, timeoutMs = 5000) {
+            const current = findSlot(name);
+            if (current) return Promise.resolve(current);
+            return new Promise((resolve, reject) => {
+              const selector = slotSelector(name);
+              const observer = new MutationObserver(() => {
+                const match = document.querySelector(selector);
+                if (!match) return;
+                observer.disconnect();
+                clearTimeout(timer);
+                resolve(match);
+              });
+              const timer = setTimeout(() => {
+                observer.disconnect();
+                reject(new Error('Timed out waiting for Maka slot “' + String(name) + '”.'));
+              }, Math.max(0, Math.min(Number(timeoutMs) || 0, 60000)));
+              observer.observe(document.documentElement, { childList: true, subtree: true });
+              disposers.push(() => {
+                observer.disconnect();
+                clearTimeout(timer);
+              });
+            });
+          },
+          mount(name) {
+            const slot = findSlot(name);
+            if (!slot) throw new Error('Maka slot is not currently available: ' + String(name));
+            const mount = document.createElement('div');
+            mount.dataset.makaSkinMount = manifest.id;
+            mount.dataset.makaSkinSlot = String(name);
+            slot.appendChild(mount);
+            disposers.push(() => mount.remove());
+            return mount;
           },
         }),
         appearance: Object.freeze({
@@ -895,6 +1121,62 @@ export function buildSkinActivationScript(
             return onHostEvent(type, handler);
           },
         }),
+        actions: Object.freeze({
+          can(name) {
+            const permission = actionPermissions[String(name)];
+            return Boolean(permission && permissionNames.includes(permission));
+          },
+          invoke(name, input = {}) {
+            const action = String(name);
+            const permission = actionPermissions[action];
+            if (!permission || !permissionNames.includes(permission)) {
+              return Promise.reject(new Error('Skin action permission was not granted: ' + action));
+            }
+            let payload;
+            try {
+              payload = JSON.stringify(input ?? {});
+            } catch {
+              return Promise.reject(new TypeError('Skin action input must be JSON serializable.'));
+            }
+            if (payload.length > 16384) {
+              return Promise.reject(new TypeError('Skin action input is too large.'));
+            }
+            return new Promise((resolve, reject) => {
+              const request = document.createElement('span');
+              request.hidden = true;
+              request.dataset.makaSkinAction = action;
+              request.dataset.makaSkinActionInput = payload;
+              request.dataset.makaSkinActionId =
+                globalThis.crypto?.randomUUID?.() ?? Math.random().toString(36).slice(2);
+              overlay.appendChild(request);
+              let settled = false;
+              let timer;
+              const finish = () => {
+                if (settled) return;
+                settled = true;
+                clearTimeout(timer);
+                request.removeEventListener('maka:skin-action-response', onResponse);
+                const ok = request.dataset.makaSkinActionOk === 'true';
+                const raw = request.dataset.makaSkinActionResult;
+                const error = request.dataset.makaSkinActionError || 'Skin action was rejected.';
+                request.remove();
+                if (!ok) {
+                  reject(new Error(error));
+                  return;
+                }
+                try { resolve(raw ? JSON.parse(raw) : undefined); }
+                catch { resolve(undefined); }
+              };
+              const onResponse = () => finish();
+              request.addEventListener('maka:skin-action-response', onResponse);
+              timer = setTimeout(() => {
+                request.dataset.makaSkinActionError = 'Skin action timed out.';
+                finish();
+              }, 10000);
+              request.dispatchEvent(new Event('maka:skin-action-request', { bubbles: true }));
+            });
+          },
+        }),
         lifecycle: Object.freeze({
           onDispose(handler) {
             if (typeof handler !== 'function') throw new TypeError('Dispose handler must be a function.');
@@ -907,15 +1189,24 @@ export function buildSkinActivationScript(
         }),
         storage: Object.freeze({
           get(key, fallback = null) {
+            if (!permissionNames.includes('storage')) {
+              throw new Error('Skin permission was not granted: storage');
+            }
             try {
               const raw = localStorage.getItem('maka-skin:' + manifest.id + ':' + String(key));
               return raw === null ? fallback : JSON.parse(raw);
             } catch { return fallback; }
           },
           set(key, value) {
+            if (!permissionNames.includes('storage')) {
+              throw new Error('Skin permission was not granted: storage');
+            }
             localStorage.setItem('maka-skin:' + manifest.id + ':' + String(key), JSON.stringify(value));
           },
           remove(key) {
+            if (!permissionNames.includes('storage')) {
+              throw new Error('Skin permission was not granted: storage');
+            }
             localStorage.removeItem('maka-skin:' + manifest.id + ':' + String(key));
           },
         }),
@@ -936,6 +1227,7 @@ export function buildSkinActivationScript(
       };
       globalThis.__makaSkinRuntime = { dispose };
       document.documentElement.setAttribute('data-maka-skin', manifest.id);
+      document.documentElement.setAttribute('data-maka-skin-api-version', String(${SKIN_API_VERSION}));
       return { ok: true };
     } catch (error) {
       return { ok: false, error: error instanceof Error ? error.message : String(error) };
@@ -944,9 +1236,7 @@ export function buildSkinActivationScript(
 }
 
 function transformSkinModule(source: string): string {
-  if (/^\s*import\s/m.test(source) || /\bimport\s*\(/.test(source)) {
-    throw new SkinRuntimeError('invalid-manifest', 'Skin entry must be self-contained and cannot import modules.');
-  }
+  assertSelfContainedSkinModule(source);
   if (/\bexport\s+default\b/.test(source)) {
     throw new SkinRuntimeError('invalid-manifest', 'Skin entry must use a named activate export.');
   }
@@ -955,6 +1245,50 @@ function transformSkinModule(source: string): string {
     .replace(/\bexport\s+(function\s+activate\b)/g, '$1')
     .replace(/\bexport\s+((?:const|let|var)\s+activate\b)/g, '$1')
     .replace(/\bexport\s*\{\s*activate\s*(?:as\s+activate\s*)?\}\s*;?/g, '');
+}
+
+export function assertSelfContainedSkinModule(source: string): void {
+  let program: ReturnType<typeof parse>;
+  try {
+    program = parse(source, {
+      sourceType: 'module',
+      createImportExpressions: true,
+      allowAwaitOutsideFunction: true,
+    });
+  } catch (error) {
+    throw new SkinRuntimeError(
+      'invalid-manifest',
+      `Skin entry is not valid JavaScript: ${errorMessage(error)}`,
+    );
+  }
+
+  const visit = (value: unknown): boolean => {
+    if (!value || typeof value !== 'object') return false;
+    if (Array.isArray(value)) return value.some(visit);
+    const node = value as Record<string, unknown>;
+    if (
+      node.type === 'ImportDeclaration' ||
+      node.type === 'ImportExpression' ||
+      node.type === 'ExportAllDeclaration' ||
+      ((node.type === 'ExportNamedDeclaration' || node.type === 'ExportDefaultDeclaration') && node.source)
+    ) {
+      return true;
+    }
+    return Object.entries(node).some(([key, child]) => (
+      key !== 'loc' &&
+      key !== 'start' &&
+      key !== 'end' &&
+      key !== 'extra' &&
+      visit(child)
+    ));
+  };
+
+  if (visit(program.program)) {
+    throw new SkinRuntimeError(
+      'invalid-manifest',
+      'Skin entry must be self-contained and cannot import or re-export modules.',
+    );
+  }
 }
 
 function readRequiredString(value: unknown, field: string, maxLength = 64): string {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -216,8 +216,37 @@ export type AppUpdateStatus =
     }
   | { state: 'error'; currentVersion: string; message: string; latestVersion?: string };
 
+export interface SkinManifest {
+  schemaVersion: 1;
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  author?: string;
+  styles?: string;
+  entry?: string;
+  preview?: string;
+  permissions: Array<'dom' | 'canvas' | 'audio' | 'storage'>;
+}
+
+export interface SkinRuntimeSnapshot {
+  activeSkinId: string | null;
+  installed: Array<{ manifest: SkinManifest; active: boolean }>;
+  safeMode: boolean;
+  recoveredFromFailedActivation: boolean;
+  lastError: string | null;
+}
+
 export interface MakaBridge {
 
+  skins: {
+    list(): Promise<SkinRuntimeSnapshot>;
+    install(): Promise<{ canceled: boolean; snapshot: SkinRuntimeSnapshot }>;
+    activate(id: string): Promise<SkinRuntimeSnapshot>;
+    disable(): Promise<SkinRuntimeSnapshot>;
+    openFolder(): Promise<void>;
+    subscribeChanges(handler: (snapshot: SkinRuntimeSnapshot) => void): () => void;
+  };
   tasks: {
     list(sessionId: string): Promise<Task[]>;
     subscribeChanges(handler: (event: TaskLedgerChangedEvent) => void): () => void;

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -217,7 +217,7 @@ export type AppUpdateStatus =
   | { state: 'error'; currentVersion: string; message: string; latestVersion?: string };
 
 export interface SkinManifest {
-  schemaVersion: 1;
+  schemaVersion: 1 | 2;
   id: string;
   name: string;
   version: string;
@@ -226,8 +226,25 @@ export interface SkinManifest {
   styles?: string;
   entry?: string;
   preview?: string;
-  permissions: Array<'dom' | 'canvas' | 'audio' | 'storage'>;
+  permissions: Array<
+    | 'dom'
+    | 'canvas'
+    | 'audio'
+    | 'storage'
+    | 'actions.navigation'
+    | 'actions.task'
+    | 'actions.submit'
+    | 'actions.stop'
+  >;
+  minimumApiVersion: number;
+  requiredCapabilities: string[];
 }
+
+export type SkinActionName =
+  | 'navigation.switch-session'
+  | 'task.new'
+  | 'composer.submit'
+  | 'generation.stop';
 
 export interface SkinRuntimeSnapshot {
   activeSkinId: string | null;
@@ -247,6 +264,10 @@ export interface MakaBridge {
     reload(): Promise<SkinRuntimeSnapshot>;
     uninstall(id: string): Promise<SkinRuntimeSnapshot>;
     openFolder(): Promise<void>;
+    authorizeAction(
+      action: SkinActionName,
+      context?: Readonly<{ textPreview?: string }>,
+    ): Promise<boolean>;
     subscribeChanges(handler: (snapshot: SkinRuntimeSnapshot) => void): () => void;
   };
   tasks: {

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -231,10 +231,17 @@ export interface SkinManifest {
     | 'canvas'
     | 'audio'
     | 'storage'
+    | 'data.sessions'
+    | 'data.conversation'
+    | 'data.tools'
+    | 'data.interactions'
+    | 'data.composer'
     | 'actions.navigation'
     | 'actions.task'
     | 'actions.submit'
     | 'actions.stop'
+    | 'actions.composer'
+    | 'actions.answer'
   >;
   minimumApiVersion: number;
   requiredCapabilities: string[];
@@ -244,7 +251,15 @@ export type SkinActionName =
   | 'navigation.switch-session'
   | 'task.new'
   | 'composer.submit'
-  | 'generation.stop';
+  | 'generation.stop'
+  | 'composer.set-draft'
+  | 'composer.focus'
+  | 'composer.pick-attachments'
+  | 'composer.remove-attachment'
+  | 'composer.set-model'
+  | 'composer.set-skills'
+  | 'composer.set-permission-mode'
+  | 'interaction.answer-question';
 
 export interface SkinRuntimeSnapshot {
   activeSkinId: string | null;
@@ -266,7 +281,7 @@ export interface MakaBridge {
     openFolder(): Promise<void>;
     authorizeAction(
       action: SkinActionName,
-      context?: Readonly<{ textPreview?: string }>,
+      context?: Readonly<{ textPreview?: string; permissionMode?: string }>,
     ): Promise<boolean>;
     subscribeChanges(handler: (snapshot: SkinRuntimeSnapshot) => void): () => void;
   };

--- a/apps/desktop/src/preload/bridge-contract.d.ts
+++ b/apps/desktop/src/preload/bridge-contract.d.ts
@@ -231,7 +231,7 @@ export interface SkinManifest {
 
 export interface SkinRuntimeSnapshot {
   activeSkinId: string | null;
-  installed: Array<{ manifest: SkinManifest; active: boolean }>;
+  installed: Array<{ manifest: SkinManifest; active: boolean; previewDataUrl?: string }>;
   safeMode: boolean;
   recoveredFromFailedActivation: boolean;
   lastError: string | null;
@@ -244,6 +244,8 @@ export interface MakaBridge {
     install(): Promise<{ canceled: boolean; snapshot: SkinRuntimeSnapshot }>;
     activate(id: string): Promise<SkinRuntimeSnapshot>;
     disable(): Promise<SkinRuntimeSnapshot>;
+    reload(): Promise<SkinRuntimeSnapshot>;
+    uninstall(id: string): Promise<SkinRuntimeSnapshot>;
     openFolder(): Promise<void>;
     subscribeChanges(handler: (snapshot: SkinRuntimeSnapshot) => void): () => void;
   };

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -9,6 +9,7 @@ import type {
   PermissionOverlayStartResult,
   RendererIngestInput,
   AppUpdateStatus,
+  SkinRuntimeSnapshot,
   WorkspaceInstructionsState,
 } from './bridge-contract.js';
 import type {
@@ -125,6 +126,29 @@ type LocalMemoryMutationResult =
   | { ok: false; state: LocalMemoryState; reason: string; message: string };
 
 const makaBridge = {
+  skins: {
+    list(): Promise<SkinRuntimeSnapshot> {
+      return ipcRenderer.invoke('skins:list');
+    },
+    install(): Promise<{ canceled: boolean; snapshot: SkinRuntimeSnapshot }> {
+      return ipcRenderer.invoke('skins:install');
+    },
+    activate(id: string): Promise<SkinRuntimeSnapshot> {
+      return ipcRenderer.invoke('skins:activate', id);
+    },
+    disable(): Promise<SkinRuntimeSnapshot> {
+      return ipcRenderer.invoke('skins:disable');
+    },
+    openFolder(): Promise<void> {
+      return ipcRenderer.invoke('skins:openFolder');
+    },
+    subscribeChanges(handler: (snapshot: SkinRuntimeSnapshot) => void): () => void {
+      const listener = (_event: Electron.IpcRendererEvent, snapshot: SkinRuntimeSnapshot) =>
+        handler(snapshot);
+      ipcRenderer.on('skins:changed', listener);
+      return () => ipcRenderer.off('skins:changed', listener);
+    },
+  },
   tasks: {
     list(sessionId: string): Promise<Task[]> {
       return ipcRenderer.invoke('tasks:list', sessionId);

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -150,7 +150,7 @@ const makaBridge = {
     },
     authorizeAction(
       action: import('./bridge-contract.js').SkinActionName,
-      context?: Readonly<{ textPreview?: string }>,
+      context?: Readonly<{ textPreview?: string; permissionMode?: string }>,
     ): Promise<boolean> {
       return ipcRenderer.invoke('skins:authorizeAction', action, context);
     },

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -139,6 +139,12 @@ const makaBridge = {
     disable(): Promise<SkinRuntimeSnapshot> {
       return ipcRenderer.invoke('skins:disable');
     },
+    reload(): Promise<SkinRuntimeSnapshot> {
+      return ipcRenderer.invoke('skins:reload');
+    },
+    uninstall(id: string): Promise<SkinRuntimeSnapshot> {
+      return ipcRenderer.invoke('skins:uninstall', id);
+    },
     openFolder(): Promise<void> {
       return ipcRenderer.invoke('skins:openFolder');
     },

--- a/apps/desktop/src/preload/preload.ts
+++ b/apps/desktop/src/preload/preload.ts
@@ -148,6 +148,12 @@ const makaBridge = {
     openFolder(): Promise<void> {
       return ipcRenderer.invoke('skins:openFolder');
     },
+    authorizeAction(
+      action: import('./bridge-contract.js').SkinActionName,
+      context?: Readonly<{ textPreview?: string }>,
+    ): Promise<boolean> {
+      return ipcRenderer.invoke('skins:authorizeAction', action, context);
+    },
     subscribeChanges(handler: (snapshot: SkinRuntimeSnapshot) => void): () => void {
       const listener = (_event: Electron.IpcRendererEvent, snapshot: SkinRuntimeSnapshot) =>
         handler(snapshot);

--- a/apps/desktop/src/renderer/app-shell-detail-panel.tsx
+++ b/apps/desktop/src/renderer/app-shell-detail-panel.tsx
@@ -17,6 +17,7 @@ export function AppShellDetailPanel({
       {...props}
       className="maka-panel maka-panel-detail maka-floating-panel agents-content-area agents-parchment-paper-surface"
       data-agents-view={agentsView}
+      data-maka-part="detail-panel"
     >
       {children}
     </div>

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -138,6 +138,7 @@ import { useShellExpertTeams } from './use-shell-expert-teams';
 import { useShellMemoryPill } from './use-shell-memory-pill';
 import { useShellConnections } from './use-shell-connections';
 import { useShellChatModel } from './use-shell-chat-model';
+import { publishMakaSkinEvent } from './skin-events';
 import { useShellLiveTurn } from './use-shell-live-turn';
 import { useShellLayout } from './use-shell-layout';
 import { useShellResume } from './use-shell-resume';
@@ -1630,6 +1631,20 @@ function AppShellContent({
   }, [activeId, activeStreamingComplete, activeStreamingMessageId, messages, settleAssistantStreaming]);
 
   const hasModalOpen = helpOpen || paletteOpen || searchModalOpen;
+  useEffect(() => {
+    publishMakaSkinEvent('state', {
+      section: navSelection.section,
+      module: 'module' in navSelection ? navSelection.module : undefined,
+      hasActiveSession: Boolean(activeId),
+      streaming: activeStreamingLive,
+      modalOpen: hasModalOpen,
+    });
+  }, [
+    activeId,
+    activeStreamingLive,
+    hasModalOpen,
+    navSelection,
+  ]);
 
   useAppShellNavRefSync({
     navSelection,
@@ -1909,9 +1924,10 @@ function AppShellContent({
         : 'im_hub';
 
   return (
-      <div className="appFrame agents-layout-root" data-agents-page>
+      <div className="appFrame agents-layout-root" data-agents-page data-maka-part="app">
       <div
         className="app maka-shell-2col agents-layout-body"
+        data-maka-part="shell"
         aria-hidden={hasModalOpen ? 'true' : undefined}
         inert={hasModalOpen ? true : undefined}
         data-modal-background-hidden={hasModalOpen ? 'true' : undefined}
@@ -1935,7 +1951,7 @@ function AppShellContent({
             after it can carve itself back out), and it OCCUPIES a row rather
             than floating over one, so content below can never land inside it.
             Locked by e2e/window-titlebar.spec.ts. */}
-        <header className="maka-window-titlebar">
+        <header className="maka-window-titlebar" data-maka-part="titlebar">
           <AppShellTopbarActions
             sidebarCollapsed={sessionListCollapsed}
             onOpenSearchModal={() => {
@@ -1964,6 +1980,7 @@ function AppShellContent({
         </header>
         <div
           className="maka-panel maka-panel-list maka-floating-panel"
+          data-maka-part="sidebar"
           aria-hidden={sessionListCollapsed ? 'true' : undefined}
           inert={sessionListCollapsed ? true : undefined}
         >
@@ -2017,7 +2034,7 @@ function AppShellContent({
               navigation entry point. */}
           <MakaUriContext.Provider value={dispatchMakaUri}>
           <div className="maka-detail-with-artifacts">
-            <div className="mainColumn" data-home-surface={homeSurfaceActive ? 'true' : undefined}>
+            <div className="mainColumn" data-maka-part="main" data-home-surface={homeSurfaceActive ? 'true' : undefined}>
               {navSelection.section === 'extensions' && navSelection.module === 'skills' ? (
                 <SkillsPage
                   hubHeader={extensionsHubHeader}

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -78,6 +78,8 @@ import { getShellCopy, localizedShellErrorMessage } from './locales/shell-copy';
 import { getDesktopConversationCopy } from './locales/conversation-copy';
 import { ErrorBoundary } from './error-boundary';
 import { useShellAppearance } from './use-shell-appearance';
+import { useSkinSemanticEvents } from './use-skin-semantic-events';
+import { useSkinActionHost } from './use-skin-action-host';
 import { useShellSearch } from './use-shell-search';
 import { useSessionGoal } from './use-session-goal';
 import { deriveStaleSessionIds } from './stale-sessions';
@@ -591,6 +593,15 @@ function AppShellContent({
     liveTurnBySession,
     shellRunUpdatesBySession,
     activeSession,
+  });
+  useSkinSemanticEvents({
+    sessionId: activeId,
+    messages,
+    streaming: activeStreamingLive,
+    turnInFlight,
+    hasInFlightTools: hasInFlightLiveTools,
+    interaction: activeInteraction,
+    tools: liveTools,
   });
   // Surface a credential-lifecycle alert directly in the chat header when
   // the active session's connection is in `needs_reauth` / `error` or has
@@ -1787,6 +1798,25 @@ function AppShellContent({
   async function createSessionInProject(projectId: string) {
     if (await prepareProject(projectId)) openNewTaskSurface();
   }
+
+  useSkinActionHost({
+    sessionIds: new Set(
+      sessions
+        .filter((session) => !session.isArchived)
+        .map((session) => session.id),
+    ),
+    canSubmit:
+      !activeInteraction &&
+      !turnInFlight &&
+      !revisionDraft &&
+      pendingAttachments.length === 0 &&
+      pendingQuotes.length === 0,
+    canStop: turnInFlight || activeStreamingLive,
+    switchSession: openSessionInChat,
+    createTask: createSession,
+    submit: (text) => sendWithAttachments(text, []),
+    stop,
+  });
 
   function openPlanReminderForm() {
     setNavSelection({ section: 'automations', module: 'plan-reminders' });

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -281,12 +281,17 @@ function AppShellContent({
   const [navigationState, setNavigationState] = useState(() => readNavigationState());
   const navSelection = navigationState.selection;
   const setNavSelection = useCallback<Dispatch<SetStateAction<NavSelection>>>((nextSelection) => {
-    setNavigationState((current) => selectNavigation(
-      current,
-      typeof nextSelection === 'function' ? nextSelection(current.selection) : nextSelection,
-    ));
+    const current = navSelectionRef.current;
+    const next = typeof nextSelection === 'function' ? nextSelection(current) : nextSelection;
+    publishMakaSkinEvent('navigation.will-change', {
+      from: { section: current.section, ...('module' in current ? { module: current.module } : {}) },
+      to: { section: next.section, ...('module' in next ? { module: next.module } : {}) },
+    });
+    navSelectionRef.current = next;
+    setNavigationState((state) => selectNavigation(state, next));
   }, []);
   const navSelectionRef = useRef<NavSelection>(navSelection);
+  const skinPreviousNavSelectionRef = useRef<NavSelection>(navSelection);
   const {
     messageLoadErrorBySession,
     messageRetryPendingBySession,
@@ -463,6 +468,7 @@ function AppShellContent({
   const [paletteOpen, openPalette, closePalette] = useCommandPalette();
   const [viewMode, setViewMode] = useState<SessionViewMode>('conversation');
   const composerRef = useRef<ComposerHandle>(null);
+  const [skinComposerRevision, setSkinComposerRevision] = useState(0);
   // Codex-style quote side panel: a companion (fork of the main session) opened
   // from text selections in the transcript, surfaced as a transient workbar tab.
   // `quotes` accumulates excerpts staged for the next follow-up — selecting more
@@ -596,12 +602,27 @@ function AppShellContent({
   });
   useSkinSemanticEvents({
     sessionId: activeId,
+    sessions,
     messages,
+    liveTurn: activeLiveTurn,
     streaming: activeStreamingLive,
     turnInFlight,
     hasInFlightTools: hasInFlightLiveTools,
     interaction: activeInteraction,
     tools: liveTools,
+    navigation: {
+      section: navSelection.section,
+      ...('module' in navSelection ? { module: navSelection.module } : {}),
+    },
+    composer: {
+      readDraft: () => composerRef.current?.getText() ?? '',
+      readSkills: () => composerRef.current?.getSkills() ?? [],
+      attachments: pendingAttachments,
+      model: activeSession?.model,
+      permissionMode: activeSession?.permissionMode,
+      busy: Boolean(activeInteraction || turnInFlight || activeStreamingLive),
+      revision: skinComposerRevision,
+    },
   });
   // Surface a credential-lifecycle alert directly in the chat header when
   // the active session's connection is in `needs_reauth` / `error` or has
@@ -1656,6 +1677,26 @@ function AppShellContent({
     hasModalOpen,
     navSelection,
   ]);
+  useEffect(() => {
+    const previous = skinPreviousNavSelectionRef.current;
+    if (
+      previous.section !== navSelection.section ||
+      ('module' in previous ? previous.module : undefined) !==
+        ('module' in navSelection ? navSelection.module : undefined)
+    ) {
+      publishMakaSkinEvent('navigation.did-change', {
+        from: {
+          section: previous.section,
+          ...('module' in previous ? { module: previous.module } : {}),
+        },
+        to: {
+          section: navSelection.section,
+          ...('module' in navSelection ? { module: navSelection.module } : {}),
+        },
+      });
+      skinPreviousNavSelectionRef.current = navSelection;
+    }
+  }, [navSelection]);
 
   useAppShellNavRefSync({
     navSelection,
@@ -1816,6 +1857,39 @@ function AppShellContent({
     createTask: createSession,
     submit: (text) => sendWithAttachments(text, []),
     stop,
+    composer: {
+      setDraft: (text, mode) => {
+        if (mode === 'append') composerRef.current?.appendText(text);
+        else composerRef.current?.setText(text);
+      },
+      focus: () => composerRef.current?.focus(),
+      pickAttachments: async () => {
+        if (revisionDraft && activeId === revisionDraft.draftSessionId) {
+          throw new Error('Attachments are unavailable while editing a previous turn.');
+        }
+        await pickAttachments();
+      },
+      removeAttachment,
+      setModel: setSessionModel,
+      setSkills: (skillRefs) => {
+        const selected = skillRefs.map((requested) => {
+          const skill = mentionSkills.find((candidate) =>
+            candidate.ref === requested || candidate.id === requested,
+          );
+          if (!skill) throw new Error(`Unknown or unavailable skill: ${requested}`);
+          return { id: skill.id, ...(skill.ref ? { ref: skill.ref } : {}), name: skill.name };
+        });
+        composerRef.current?.setSkills(selected);
+        setSkinComposerRevision((revision) => revision + 1);
+      },
+      setPermissionMode,
+    },
+    answerQuestion: async (response) => {
+      if (!activeQuestion || response.requestId !== activeQuestion.requestId) {
+        throw new Error('The requested user question is no longer active.');
+      }
+      await respondToUserQuestion(response);
+    },
   });
 
   function openPlanReminderForm() {
@@ -2307,6 +2381,7 @@ function AppShellContent({
                 processing={showProcessingIndicator && !activeStreamingLive}
                 continuing={showContinuingIndicator && !activeStreamingLive}
                 onSend={sendWithAttachments}
+                onDraftChange={() => setSkinComposerRevision((revision) => revision + 1)}
                 onStop={stop}
                 revisionNotice={
                   revisionDraft && activeId === revisionDraft.draftSessionId

--- a/apps/desktop/src/renderer/cached-theme-bootstrap.ts
+++ b/apps/desktop/src/renderer/cached-theme-bootstrap.ts
@@ -12,6 +12,12 @@ export function applyCachedThemeBeforeMount(): void {
   const shouldApplyDarkTheme =
     cachedThemePreference === 'dark' ||
     (cachedThemePreference !== 'light' && window.matchMedia('(prefers-color-scheme: dark)').matches);
+  document.documentElement.dataset.makaThemePreference =
+    cachedThemePreference === 'light' || cachedThemePreference === 'dark'
+      ? cachedThemePreference
+      : 'auto';
+  document.documentElement.dataset.makaColorScheme =
+    shouldApplyDarkTheme ? 'dark' : 'light';
   if (shouldApplyDarkTheme) {
     document.documentElement.classList.add('dark');
     document.documentElement.style.colorScheme = 'dark';

--- a/apps/desktop/src/renderer/chat-composer-region.tsx
+++ b/apps/desktop/src/renderer/chat-composer-region.tsx
@@ -72,7 +72,7 @@ export function ChatComposerRegion({
 }: ChatComposerRegionProps) {
   return (
     <>
-      <div className="maka-composer-interaction-slot">
+      <div className="maka-composer-interaction-slot" data-maka-part="composer-interactions">
         {/* The notice stands in for the composer, so it appears exactly where
             the composer would have been — and never over a turn-scoped
             interaction, which already owns the slot and is the more urgent

--- a/apps/desktop/src/renderer/chat-composer-region.tsx
+++ b/apps/desktop/src/renderer/chat-composer-region.tsx
@@ -70,10 +70,16 @@ export function ChatComposerRegion({
   boundaryUnreadableNotice,
   ...composerRest
 }: ChatComposerRegionProps) {
+  const interactionOwnerId = activeInteraction && 'requestId' in activeInteraction
+    ? activeInteraction.requestId
+    : undefined;
   return (
     <>
       <div className="maka-skin-slot" data-maka-slot="composer-before" />
       <div className="maka-composer-interaction-slot" data-maka-part="composer-interactions">
+        {activeInteraction && (
+          <div className="maka-skin-slot" data-maka-slot="interaction-before" data-maka-owner-id={interactionOwnerId} />
+        )}
         {/* The notice stands in for the composer, so it appears exactly where
             the composer would have been — and never over a turn-scoped
             interaction, which already owns the slot and is the more urgent
@@ -103,18 +109,25 @@ export function ChatComposerRegion({
           </div>
         )}
         {activeSandboxBoundary && (
-          <SandboxBoundaryPrompt
-            request={activeSandboxBoundary}
-            onRespond={respondToSandboxBoundary}
-          />
+          <div data-maka-part="interaction" data-maka-owner-id={activeSandboxBoundary.requestId}>
+            <SandboxBoundaryPrompt
+              request={activeSandboxBoundary}
+              onRespond={respondToSandboxBoundary}
+            />
+          </div>
         )}
         {activeQuestion && (
-          <UserQuestionPrompt
-            request={activeQuestion}
-            onRespond={respondToUserQuestion}
-            onStop={stop}
-            stopPending={activeId ? stopPendingBySession[activeId] === true : false}
-          />
+          <div data-maka-part="interaction" data-maka-owner-id={activeQuestion.requestId}>
+            <UserQuestionPrompt
+              request={activeQuestion}
+              onRespond={respondToUserQuestion}
+              onStop={stop}
+              stopPending={activeId ? stopPendingBySession[activeId] === true : false}
+            />
+          </div>
+        )}
+        {activeInteraction && (
+          <div className="maka-skin-slot" data-maka-slot="interaction-after" data-maka-owner-id={interactionOwnerId} />
         )}
       </div>
       <Composer

--- a/apps/desktop/src/renderer/chat-composer-region.tsx
+++ b/apps/desktop/src/renderer/chat-composer-region.tsx
@@ -72,6 +72,7 @@ export function ChatComposerRegion({
 }: ChatComposerRegionProps) {
   return (
     <>
+      <div className="maka-skin-slot" data-maka-slot="composer-before" />
       <div className="maka-composer-interaction-slot" data-maka-part="composer-interactions">
         {/* The notice stands in for the composer, so it appears exactly where
             the composer would have been — and never over a turn-scoped
@@ -123,6 +124,7 @@ export function ChatComposerRegion({
         draftKey={activeId ?? 'new-session'}
         stopPending={activeId ? stopPendingBySession[activeId] === true : false}
       />
+      <div className="maka-skin-slot" data-maka-slot="composer-after" />
     </>
   );
 }

--- a/apps/desktop/src/renderer/command-palette.tsx
+++ b/apps/desktop/src/renderer/command-palette.tsx
@@ -173,6 +173,7 @@ export function CommandPalette(props: {
     >
       <DialogContent
         className="maka-modal maka-palette-modal top-[12vh] -translate-y-0"
+        data-maka-part="command-palette"
         aria-label={copy.label}
         initialFocus={inputRef}
         showClose={false}

--- a/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
@@ -30,6 +30,18 @@ export type SettingsPreferencesCopy = {
     paletteHelp: Record<ThemePalette, string>;
     paletteGroups: { editor: string; product: string };
     persistenceHelp: string;
+    skins: {
+      title: string;
+      help: string;
+      import: string;
+      openFolder: string;
+      activate: string;
+      disable: string;
+      active: string;
+      empty: string;
+      safeMode: string;
+      actionFailed: string;
+    };
   };
   general: {
     incognito: string;
@@ -123,6 +135,11 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
       paletteLabels: { default: '默认', onedark: 'One Dark', 'catppuccin-mocha': 'Catppuccin Mocha', 'tokyo-night': 'Tokyo Night', nord: 'Nord', coral: '珊瑚', azure: '湖蓝', forest: '森林', dusk: '暮光', sand: '沙金', mono: '极简灰' },
       paletteHelp: { default: 'Maka 品牌蓝强调色', onedark: '编辑器经典深色', 'catppuccin-mocha': '紫调柔和深色', 'tokyo-night': '深蓝主题', nord: '北欧冷色', coral: '暖粉 / 珊瑚强调色', azure: '湖蓝强调色，干净冷静', forest: '深苔绿与暖蜂蜜强调色', dusk: '深紫罗兰与冷调画布', sand: '琥珀沙金与暖奶白', mono: '纯灰阶，无彩色干扰' },
       paletteGroups: { editor: '编辑器主题', product: '产品色调' }, persistenceHelp: '切换会立即生效，并保存在本地外观设置里供下次启动使用。',
+      skins: {
+        title: '界面皮肤', help: '导入 .maka-skin，可使用完整 CSS 和隔离世界 JavaScript 改造整个界面。皮肤能读取并修改可见页面，只安装你信任的包。',
+        import: '导入皮肤', openFolder: '打开目录', activate: '启用', disable: '停用', active: '使用中', empty: '还没有安装皮肤。',
+        safeMode: '安全模式已开启；所有皮肤暂时停用。移除 --disable-skins 后重启可恢复。', actionFailed: '皮肤操作失败',
+      },
     },
     general: {
       incognito: '隐身模式', incognitoHelp: '开启后暂停本地记忆读写、联网搜索和计划提醒触发。', enableIncognito: '启用隐身模式', incognitoFailed: '隐身模式切换失败', notifications: '完成时发送系统通知', notificationsHelp: '窗口不在前台时，在回答完成或出错后发送桌面通知。', notificationsFailed: '通知设置切换失败', updateFailed: '设置未生效，请稍后重试。',
@@ -140,6 +157,11 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
     },
     appearance: {
       saveFailed: 'Could not save appearance settings', theme: 'Theme', palette: 'Color palette', themeOptions: { light: { label: 'Light', help: 'Always use the light interface.' }, dark: { label: 'Dark', help: 'Always use the dark interface.' }, auto: { label: 'Follow system', help: 'Match the current system appearance.' } }, paletteLabels: { default: 'Default', onedark: 'One Dark', 'catppuccin-mocha': 'Catppuccin Mocha', 'tokyo-night': 'Tokyo Night', nord: 'Nord', coral: 'Coral', azure: 'Azure', forest: 'Forest', dusk: 'Dusk', sand: 'Sand', mono: 'Monochrome' }, paletteHelp: { default: 'Maka brand-blue accent', onedark: 'Classic dark editor theme', 'catppuccin-mocha': 'Soft purple dark theme', 'tokyo-night': 'Deep-blue editor theme', nord: 'Cool Nordic colors', coral: 'Warm pink and coral accent', azure: 'Clean, calm blue accent', forest: 'Deep moss and warm honey', dusk: 'Deep violet on a cool canvas', sand: 'Amber sand and warm ivory', mono: 'Pure grayscale without color distraction' }, paletteGroups: { editor: 'Editor themes', product: 'Product colors' }, persistenceHelp: 'Changes apply immediately and are saved locally for the next launch.',
+      skins: {
+        title: 'Interface skins', help: 'Import a .maka-skin package with full CSS and isolated-world JavaScript. Skins can read and modify visible page content, so install only packages you trust.',
+        import: 'Import skin', openFolder: 'Open folder', activate: 'Activate', disable: 'Disable', active: 'Active', empty: 'No skins are installed yet.',
+        safeMode: 'Safe mode is active and all skins are disabled. Restart without --disable-skins to restore them.', actionFailed: 'Skin action failed',
+      },
     },
     general: {
       incognito: 'Incognito mode', incognitoHelp: 'Pause local memory, web search, and scheduled reminder triggers.', enableIncognito: 'Enable incognito mode', incognitoFailed: 'Could not change incognito mode', notifications: 'Send a system notification when finished', notificationsHelp: 'Notify when a response finishes or fails while the window is in the background.', notificationsFailed: 'Could not change notification settings', updateFailed: 'The setting was not applied. Try again later.', defaultModel: 'Default model', defaultModelHelp: 'Model used by new conversations.', notSet: 'Not set', saveDefaultModelFailed: 'Could not save the default model', defaultPermission: 'Default permission mode', defaultPermissionHelp: 'Initial permission mode for new conversations; it can be changed at any time.', saveDefaultPermissionFailed: 'Could not save the default permission mode', proxy: 'Proxy server', proxyHelp: 'Configure a network proxy for AI model requests', enableProxy: 'Enable proxy server', saveNetworkFailed: 'Could not save network settings', proxyProtocol: 'Proxy protocol', serverAddress: 'Server address', proxyServerAddress: 'Proxy server address', port: 'Port', proxyPort: 'Proxy port', proxyAuth: 'Proxy authentication', proxyAuthHelp: 'Enable this when a username and password are required.', enableProxyAuth: 'Enable proxy authentication', username: 'Username', proxyUsername: 'Proxy username', password: 'Password', proxyPassword: 'Proxy password', bypassList: 'Proxy bypass list', bypassHelp: 'These domains connect directly. Separate multiple domains with commas.', autoBypass: (count) => `${count} ${count === 1 ? 'domain was' : 'domains were'} added automatically. The proxy applies to AI model requests only.`, testing: 'Testing…', testCurrent: 'Test current configuration', proxyReachable: 'Proxy is reachable', proxyTestFailed: 'Proxy test failed', proxyTestError: 'Could not test proxy',

--- a/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
@@ -37,6 +37,8 @@ export type SettingsPreferencesCopy = {
       openFolder: string;
       activate: string;
       disable: string;
+      reload: string;
+      remove: string;
       active: string;
       empty: string;
       safeMode: string;
@@ -137,7 +139,7 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
       paletteGroups: { editor: '编辑器主题', product: '产品色调' }, persistenceHelp: '切换会立即生效，并保存在本地外观设置里供下次启动使用。',
       skins: {
         title: '界面皮肤', help: '导入 .maka-skin，可使用完整 CSS 和隔离世界 JavaScript 改造整个界面。皮肤能读取并修改可见页面，只安装你信任的包。',
-        import: '导入皮肤', openFolder: '打开目录', activate: '启用', disable: '停用', active: '使用中', empty: '还没有安装皮肤。',
+        import: '导入或更新', openFolder: '打开目录', activate: '启用', disable: '停用', reload: '重新加载', remove: '移除', active: '使用中', empty: '还没有安装皮肤。',
         safeMode: '安全模式已开启；所有皮肤暂时停用。移除 --disable-skins 后重启可恢复。', actionFailed: '皮肤操作失败',
       },
     },
@@ -159,7 +161,7 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
       saveFailed: 'Could not save appearance settings', theme: 'Theme', palette: 'Color palette', themeOptions: { light: { label: 'Light', help: 'Always use the light interface.' }, dark: { label: 'Dark', help: 'Always use the dark interface.' }, auto: { label: 'Follow system', help: 'Match the current system appearance.' } }, paletteLabels: { default: 'Default', onedark: 'One Dark', 'catppuccin-mocha': 'Catppuccin Mocha', 'tokyo-night': 'Tokyo Night', nord: 'Nord', coral: 'Coral', azure: 'Azure', forest: 'Forest', dusk: 'Dusk', sand: 'Sand', mono: 'Monochrome' }, paletteHelp: { default: 'Maka brand-blue accent', onedark: 'Classic dark editor theme', 'catppuccin-mocha': 'Soft purple dark theme', 'tokyo-night': 'Deep-blue editor theme', nord: 'Cool Nordic colors', coral: 'Warm pink and coral accent', azure: 'Clean, calm blue accent', forest: 'Deep moss and warm honey', dusk: 'Deep violet on a cool canvas', sand: 'Amber sand and warm ivory', mono: 'Pure grayscale without color distraction' }, paletteGroups: { editor: 'Editor themes', product: 'Product colors' }, persistenceHelp: 'Changes apply immediately and are saved locally for the next launch.',
       skins: {
         title: 'Interface skins', help: 'Import a .maka-skin package with full CSS and isolated-world JavaScript. Skins can read and modify visible page content, so install only packages you trust.',
-        import: 'Import skin', openFolder: 'Open folder', activate: 'Activate', disable: 'Disable', active: 'Active', empty: 'No skins are installed yet.',
+        import: 'Import or update', openFolder: 'Open folder', activate: 'Activate', disable: 'Disable', reload: 'Reload', remove: 'Remove', active: 'Active', empty: 'No skins are installed yet.',
         safeMode: 'Safe mode is active and all skins are disabled. Restart without --disable-skins to restore them.', actionFailed: 'Skin action failed',
       },
     },

--- a/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
+++ b/apps/desktop/src/renderer/locales/settings-preferences-copy.ts
@@ -43,6 +43,8 @@ export type SettingsPreferencesCopy = {
       empty: string;
       safeMode: string;
       actionFailed: string;
+      permissions: string;
+      permissionLabels: Readonly<Record<string, string>>;
     };
   };
   general: {
@@ -141,6 +143,12 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
         title: '界面皮肤', help: '导入 .maka-skin，可使用完整 CSS 和隔离世界 JavaScript 改造整个界面。皮肤能读取并修改可见页面，只安装你信任的包。',
         import: '导入或更新', openFolder: '打开目录', activate: '启用', disable: '停用', reload: '重新加载', remove: '移除', active: '使用中', empty: '还没有安装皮肤。',
         safeMode: '安全模式已开启；所有皮肤暂时停用。移除 --disable-skins 后重启可恢复。', actionFailed: '皮肤操作失败',
+        permissions: '权限',
+        permissionLabels: {
+          dom: '读取与修改可见界面', canvas: 'Canvas / WebGL', audio: '音频', storage: '皮肤存储',
+          'actions.navigation': '切换会话', 'actions.task': '新建任务',
+          'actions.submit': '提交提示词', 'actions.stop': '停止生成',
+        },
       },
     },
     general: {
@@ -163,6 +171,12 @@ const SETTINGS_PREFERENCES_COPY_BY_LOCALE = {
         title: 'Interface skins', help: 'Import a .maka-skin package with full CSS and isolated-world JavaScript. Skins can read and modify visible page content, so install only packages you trust.',
         import: 'Import or update', openFolder: 'Open folder', activate: 'Activate', disable: 'Disable', reload: 'Reload', remove: 'Remove', active: 'Active', empty: 'No skins are installed yet.',
         safeMode: 'Safe mode is active and all skins are disabled. Restart without --disable-skins to restore them.', actionFailed: 'Skin action failed',
+        permissions: 'Permissions',
+        permissionLabels: {
+          dom: 'Read and modify visible UI', canvas: 'Canvas / WebGL', audio: 'Audio', storage: 'Skin storage',
+          'actions.navigation': 'Switch conversations', 'actions.task': 'Create tasks',
+          'actions.submit': 'Submit prompts', 'actions.stop': 'Stop generation',
+        },
       },
     },
     general: {

--- a/apps/desktop/src/renderer/settings/SettingsModal.tsx
+++ b/apps/desktop/src/renderer/settings/SettingsModal.tsx
@@ -84,6 +84,7 @@ export function SettingsModal(props: {
       aria-label={copy.modalLabel}
       className="settingsModal settingsPage agents-layout-root"
       data-agents-page
+      data-maka-part="settings"
     >
       <SettingsSurface
         connections={props.connections}

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -8,7 +8,7 @@ import type {
   UiLocalePreference,
   UpdateAppSettingsResult,
 } from '@maka/core';
-import { ChoiceCard, ChoiceCardGroup, Input, Segmented, Textarea, useMountedRef, useToast, useUiLocale } from '@maka/ui';
+import { Button, ChoiceCard, ChoiceCardGroup, Input, Segmented, Textarea, useMountedRef, useToast, useUiLocale } from '@maka/ui';
 import { settingsActionErrorMessage } from './settings-error-copy';
 import { getSettingsPreferencesCopy } from '../locales/settings-preferences-copy.js';
 
@@ -281,6 +281,111 @@ const PALETTE_GROUPS: ReadonlyArray<{ id: 'editor' | 'product'; palettes: Readon
   { id: 'product', palettes: ['coral', 'azure', 'forest', 'dusk', 'sand', 'mono'] },
 ];
 
+type SkinSnapshot = Awaited<ReturnType<typeof window.maka.skins.list>>;
+
+function SkinSettingsSection() {
+  const locale = useUiLocale();
+  const copy = getSettingsPreferencesCopy(locale).appearance.skins;
+  const toast = useToast();
+  const mountedRef = useMountedRef();
+  const [snapshot, setSnapshot] = useState<SkinSnapshot | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  useEffect(() => {
+    void window.maka.skins.list()
+      .then((next) => {
+        if (mountedRef.current) setSnapshot(next);
+      })
+      .catch((error) => {
+        if (mountedRef.current) toast.error(copy.actionFailed, settingsActionErrorMessage(error, locale));
+      });
+    return window.maka.skins.subscribeChanges((next) => {
+      if (mountedRef.current) setSnapshot(next);
+    });
+  }, [copy.actionFailed, locale, mountedRef, toast]);
+
+  async function run(action: () => Promise<SkinSnapshot | { snapshot: SkinSnapshot }>) {
+    setBusy(true);
+    try {
+      const result = await action();
+      if (!mountedRef.current) return;
+      setSnapshot('snapshot' in result ? result.snapshot : result);
+    } catch (error) {
+      if (mountedRef.current) {
+        toast.error(copy.actionFailed, settingsActionErrorMessage(error, locale));
+      }
+    } finally {
+      if (mountedRef.current) setBusy(false);
+    }
+  }
+
+  return (
+    <>
+      <h3 className="settingsSubheading">{copy.title}</h3>
+      <SettingsRows>
+        <div className="settingsFormRow" data-orient="vertical">
+          <div>
+            <strong>{copy.title}</strong>
+            <small>{copy.help}</small>
+          </div>
+          <div className="settingsActionRow" role="group" aria-label={copy.title}>
+            <Button type="button" variant="secondary" size="sm" disabled={busy} onClick={() => void run(() => window.maka.skins.install())}>
+              {copy.import}
+            </Button>
+            <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={() => void window.maka.skins.openFolder()}>
+              {copy.openFolder}
+            </Button>
+            {snapshot?.activeSkinId ? (
+              <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={() => void run(() => window.maka.skins.disable())}>
+                {copy.disable}
+              </Button>
+            ) : null}
+          </div>
+        </div>
+        {snapshot?.safeMode ? (
+          <div className="settingsFormRow">
+            <div><strong>{copy.safeMode}</strong></div>
+          </div>
+        ) : null}
+        {snapshot?.lastError ? (
+          <div className="settingsFormRow">
+            <div>
+              <strong>{copy.actionFailed}</strong>
+              <small>{snapshot.lastError}</small>
+            </div>
+          </div>
+        ) : null}
+        {snapshot && snapshot.installed.length === 0 ? (
+          <div className="settingsFormRow">
+            <div><small>{copy.empty}</small></div>
+          </div>
+        ) : null}
+        {snapshot?.installed.map(({ manifest, active }) => (
+          <div className="settingsFormRow" key={manifest.id}>
+            <div>
+              <strong>{manifest.name}</strong>
+              <small>
+                {manifest.author ? `${manifest.author} · ` : ''}
+                v{manifest.version}
+                {active ? ` · ${copy.active}` : ''}
+              </small>
+            </div>
+            {active ? (
+              <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={() => void run(() => window.maka.skins.disable())}>
+                {copy.disable}
+              </Button>
+            ) : (
+              <Button type="button" variant="secondary" size="sm" disabled={busy || snapshot.safeMode} onClick={() => void run(() => window.maka.skins.activate(manifest.id))}>
+                {copy.activate}
+              </Button>
+            )}
+          </div>
+        ))}
+      </SettingsRows>
+    </>
+  );
+}
+
 function ThemeSettingsPage(props: {
   themePref: ThemePreference;
   themePalette: ThemePalette;
@@ -399,6 +504,7 @@ function ThemeSettingsPage(props: {
       <p className="settingsHelpText">
         {copy.persistenceHelp}
       </p>
+      <SkinSettingsSection />
     </div>
   );
 }

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -378,6 +378,11 @@ function SkinSettingsSection() {
                   v{manifest.version}
                   {active ? ` · ${copy.active}` : ''}
                 </small>
+                <small>
+                  {copy.permissions}: {manifest.permissions
+                    .map((permission) => copy.permissionLabels[permission] ?? permission)
+                    .join(' · ') || '—'}
+                </small>
               </div>
             </div>
             <div className="settingsActionRow">

--- a/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
+++ b/apps/desktop/src/renderer/settings/appearance-settings-page.tsx
@@ -336,9 +336,14 @@ function SkinSettingsSection() {
               {copy.openFolder}
             </Button>
             {snapshot?.activeSkinId ? (
-              <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={() => void run(() => window.maka.skins.disable())}>
-                {copy.disable}
-              </Button>
+              <>
+                <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={() => void run(() => window.maka.skins.reload())}>
+                  {copy.reload}
+                </Button>
+                <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={() => void run(() => window.maka.skins.disable())}>
+                  {copy.disable}
+                </Button>
+              </>
             ) : null}
           </div>
         </div>
@@ -360,25 +365,35 @@ function SkinSettingsSection() {
             <div><small>{copy.empty}</small></div>
           </div>
         ) : null}
-        {snapshot?.installed.map(({ manifest, active }) => (
+        {snapshot?.installed.map(({ manifest, active, previewDataUrl }) => (
           <div className="settingsFormRow" key={manifest.id}>
-            <div>
-              <strong>{manifest.name}</strong>
-              <small>
-                {manifest.author ? `${manifest.author} · ` : ''}
-                v{manifest.version}
-                {active ? ` · ${copy.active}` : ''}
-              </small>
+            <div className="settingsSkinIdentity">
+              {previewDataUrl ? (
+                <img className="settingsSkinPreview" src={previewDataUrl} alt="" />
+              ) : null}
+              <div>
+                <strong>{manifest.name}</strong>
+                <small>
+                  {manifest.author ? `${manifest.author} · ` : ''}
+                  v{manifest.version}
+                  {active ? ` · ${copy.active}` : ''}
+                </small>
+              </div>
             </div>
-            {active ? (
-              <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={() => void run(() => window.maka.skins.disable())}>
-                {copy.disable}
+            <div className="settingsActionRow">
+              {active ? (
+                <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={() => void run(() => window.maka.skins.disable())}>
+                  {copy.disable}
+                </Button>
+              ) : (
+                <Button type="button" variant="secondary" size="sm" disabled={busy || snapshot.safeMode} onClick={() => void run(() => window.maka.skins.activate(manifest.id))}>
+                  {copy.activate}
+                </Button>
+              )}
+              <Button type="button" variant="ghost" size="sm" disabled={busy} onClick={() => void run(() => window.maka.skins.uninstall(manifest.id))}>
+                {copy.remove}
               </Button>
-            ) : (
-              <Button type="button" variant="secondary" size="sm" disabled={busy || snapshot.safeMode} onClick={() => void run(() => window.maka.skins.activate(manifest.id))}>
-                {copy.activate}
-              </Button>
-            )}
+            </div>
           </div>
         ))}
       </SettingsRows>

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -229,7 +229,7 @@ export function SettingsSurface(props: {
 
   return (
     <main className="settingsSurface agents-layout-body" data-modal="true" aria-label={copy.contentLabel}>
-      <aside className="settingsSidebar agents-sidebar" data-settings-nav-column aria-label={copy.sidebarLabel}>
+      <aside className="settingsSidebar agents-sidebar" data-settings-nav-column data-maka-part="settings-sidebar" aria-label={copy.sidebarLabel}>
         <div className="settingsSidebarInner">
           {/* PR-SETTINGS-NO-PANE-BORDER-0 (WAWQAQ msg `8effe691`):
               reference sidebar has just `← 返回应用` then straight
@@ -275,7 +275,7 @@ export function SettingsSurface(props: {
         </div>
       </aside>
 
-      <section className="settingsMainPane agents-content-area" data-agents-view="settings">
+      <section className="settingsMainPane agents-content-area" data-agents-view="settings" data-maka-part="settings-content">
         <header className="settingsPageHeader">
           <div className="settingsPageHeaderTitleStack">
             <h2>{headerCopy.label}</h2>

--- a/apps/desktop/src/renderer/settings/settings-surface.tsx
+++ b/apps/desktop/src/renderer/settings/settings-surface.tsx
@@ -275,7 +275,8 @@ export function SettingsSurface(props: {
         </div>
       </aside>
 
-      <section className="settingsMainPane agents-content-area" data-agents-view="settings" data-maka-part="settings-content">
+      <section className="settingsMainPane agents-content-area" data-agents-view="settings" data-maka-part="settings-content" data-maka-owner-id={section}>
+        <div className="maka-skin-slot" data-maka-slot="settings-content-before" data-maka-owner-id={section} />
         <header className="settingsPageHeader">
           <div className="settingsPageHeaderTitleStack">
             <h2>{headerCopy.label}</h2>
@@ -316,6 +317,7 @@ export function SettingsSurface(props: {
             />
           )}
         </OverlayScrollArea>
+        <div className="maka-skin-slot" data-maka-slot="settings-content-after" data-maka-owner-id={section} />
       </section>
     </main>
   );

--- a/apps/desktop/src/renderer/skin-events.ts
+++ b/apps/desktop/src/renderer/skin-events.ts
@@ -1,0 +1,19 @@
+/**
+ * Public, versionable renderer events for high-freedom Maka skins.
+ *
+ * Event payloads deliberately expose UI state, not session content. A skin
+ * already has DOM access in its isolated world; this channel gives it stable
+ * lifecycle signals without coupling to React internals.
+ */
+export function publishMakaSkinEvent(
+  type: 'state',
+  detail: {
+    section: string;
+    module?: string;
+    hasActiveSession: boolean;
+    streaming: boolean;
+    modalOpen: boolean;
+  },
+): void {
+  window.dispatchEvent(new CustomEvent(`maka:${type}`, { detail }));
+}

--- a/apps/desktop/src/renderer/skin-events.ts
+++ b/apps/desktop/src/renderer/skin-events.ts
@@ -38,6 +38,74 @@ export interface MakaSkinSemanticEventMap {
     kind: 'permission' | 'question' | null;
     waiting: boolean;
   };
+  'sessions.changed': {
+    currentSessionId: string | null;
+    sessions: ReadonlyArray<Readonly<{
+      id: string;
+      name: string;
+      status: string;
+      flagged: boolean;
+      archived: boolean;
+      unread: boolean;
+      lastMessageAt?: number;
+      lastMessagePreview?: string;
+    }>>;
+  };
+  'conversation.changed': {
+    sessionId: string | null;
+    messages: ReadonlyArray<Readonly<{
+      id: string;
+      turnId: string;
+      role: 'user' | 'assistant';
+      text: string;
+      timestamp?: number;
+      streaming: boolean;
+      truncated?: boolean;
+    }>>;
+  };
+  'tools.detail.changed': {
+    sessionId: string | null;
+    tools: ReadonlyArray<Readonly<{
+      id: string;
+      turnId?: string;
+      name: string;
+      displayName?: string;
+      status: string;
+      argsText?: string;
+      outputText?: string;
+      durationMs?: number;
+      truncated?: boolean;
+    }>>;
+  };
+  'interaction.detail.changed': {
+    sessionId: string | null;
+    interaction: null | Readonly<{
+      kind: 'permission' | 'question';
+      requestId?: string;
+      toolUseId?: string;
+      questions?: ReadonlyArray<Readonly<{
+        question: string;
+        options: ReadonlyArray<Readonly<{ label: string; description?: string }>>;
+      }>>;
+    }>;
+  };
+  'composer.changed': {
+    sessionId: string | null;
+    draft: string;
+    skills: ReadonlyArray<Readonly<{ id: string; ref?: string; name: string }>>;
+    attachments: ReadonlyArray<Readonly<{ index: number; name: string; kind: string; size: number; mimeType?: string }>>;
+    model?: string;
+    permissionMode?: string;
+    busy: boolean;
+  };
+  'navigation.will-change': {
+    from: Readonly<{ section: string; module?: string }>;
+    to: Readonly<{ section: string; module?: string }>;
+  };
+  'navigation.did-change': {
+    from: Readonly<{ section: string; module?: string }>;
+    to: Readonly<{ section: string; module?: string }>;
+  };
 }
 
 export function publishMakaSkinEvent<Type extends keyof MakaSkinSemanticEventMap>(

--- a/apps/desktop/src/renderer/skin-events.ts
+++ b/apps/desktop/src/renderer/skin-events.ts
@@ -5,22 +5,54 @@
  * already has DOM access in its isolated world; this channel gives it stable
  * lifecycle signals without coupling to React internals.
  */
-export function publishMakaSkinEvent(
-  type: 'state',
-  detail: {
+export interface MakaSkinSemanticEventMap {
+  state: {
     section: string;
     module?: string;
     hasActiveSession: boolean;
     streaming: boolean;
     modalOpen: boolean;
-  },
+  };
+  'session.changed': {
+    sessionId: string | null;
+  };
+  'messages.changed': {
+    sessionId: string | null;
+    count: number;
+    lastMessage?: Readonly<{ id: string; type: string }>;
+  };
+  'generation.changed': {
+    sessionId: string | null;
+    state: 'idle' | 'processing' | 'streaming' | 'tool' | 'waiting';
+  };
+  'tools.changed': {
+    sessionId: string | null;
+    tools: ReadonlyArray<Readonly<{
+      id: string;
+      name: string;
+      status: string;
+    }>>;
+  };
+  'interaction.changed': {
+    sessionId: string | null;
+    kind: 'permission' | 'question' | null;
+    waiting: boolean;
+  };
+}
+
+export function publishMakaSkinEvent<Type extends keyof MakaSkinSemanticEventMap>(
+  type: Type,
+  detail: MakaSkinSemanticEventMap[Type],
 ): void {
   const root = document.documentElement;
-  root.dataset.makaSection = detail.section;
-  if (detail.module) root.dataset.makaModule = detail.module;
-  else root.removeAttribute('data-maka-module');
-  root.dataset.makaHasActiveSession = String(detail.hasActiveSession);
-  root.dataset.makaStreaming = String(detail.streaming);
-  root.dataset.makaModalOpen = String(detail.modalOpen);
+  if (type === 'state') {
+    const state = detail as MakaSkinSemanticEventMap['state'];
+    root.dataset.makaSection = state.section;
+    if (state.module) root.dataset.makaModule = state.module;
+    else root.removeAttribute('data-maka-module');
+    root.dataset.makaHasActiveSession = String(state.hasActiveSession);
+    root.dataset.makaStreaming = String(state.streaming);
+    root.dataset.makaModalOpen = String(state.modalOpen);
+  }
   window.dispatchEvent(new CustomEvent(`maka:${type}`, { detail }));
 }

--- a/apps/desktop/src/renderer/skin-events.ts
+++ b/apps/desktop/src/renderer/skin-events.ts
@@ -15,5 +15,12 @@ export function publishMakaSkinEvent(
     modalOpen: boolean;
   },
 ): void {
+  const root = document.documentElement;
+  root.dataset.makaSection = detail.section;
+  if (detail.module) root.dataset.makaModule = detail.module;
+  else root.removeAttribute('data-maka-module');
+  root.dataset.makaHasActiveSession = String(detail.hasActiveSession);
+  root.dataset.makaStreaming = String(detail.streaming);
+  root.dataset.makaModalOpen = String(detail.modalOpen);
   window.dispatchEvent(new CustomEvent(`maka:${type}`, { detail }));
 }

--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -118,3 +118,6 @@ button {
     transition-duration: 0.01ms !important;
     caret-color: transparent !important;
   }
+.maka-skin-slot {
+  display: contents;
+}

--- a/apps/desktop/src/renderer/styles/settings/theme-preview.css
+++ b/apps/desktop/src/renderer/styles/settings/theme-preview.css
@@ -1,4 +1,27 @@
 /* Appearance theme and palette previews. */
+
+.settingsSkinIdentity {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: var(--space-3);
+}
+
+.settingsSkinIdentity > div {
+  display: grid;
+  min-width: 0;
+  gap: var(--space-0-5);
+}
+
+.settingsSkinPreview {
+  width: 64px;
+  aspect-ratio: 16 / 10;
+  flex: none;
+  border: var(--border-width-hairline) solid var(--border);
+  border-radius: var(--radius-control);
+  object-fit: cover;
+  background: var(--surface-canvas);
+}
 .settingsThemeOptions {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));

--- a/apps/desktop/src/renderer/theme.ts
+++ b/apps/desktop/src/renderer/theme.ts
@@ -9,8 +9,63 @@ import type { ThemePalette, ThemePreference } from '@maka/core';
 import { safeLocalStorageSet } from './browser-storage';
 
 const DARK_CLASS = 'dark';
+const APPEARANCE_EVENT = 'maka:appearance';
 
 let unsubscribeMediaQuery: (() => void) | null = null;
+let appearanceObserver: MutationObserver | null = null;
+let activeThemePreference: ThemePreference = 'auto';
+let activeThemePalette: ThemePalette = 'default';
+
+export interface MakaAppearanceSnapshot {
+  preference: ThemePreference;
+  resolvedTheme: 'light' | 'dark';
+  palette: ThemePalette;
+  colorScheme: 'light' | 'dark';
+  forcedColors: boolean;
+  prefersContrast: boolean;
+  reducedMotion: boolean;
+  reducedTransparency: boolean;
+}
+
+export function readMakaAppearance(): MakaAppearanceSnapshot {
+  const root = document.documentElement;
+  const resolvedTheme = root.classList.contains(DARK_CLASS) ? 'dark' : 'light';
+  return {
+    preference: activeThemePreference,
+    resolvedTheme,
+    palette: activeThemePalette,
+    colorScheme: resolvedTheme,
+    forcedColors: window.matchMedia('(forced-colors: active)').matches,
+    prefersContrast: window.matchMedia('(prefers-contrast: more)').matches,
+    reducedMotion: window.matchMedia('(prefers-reduced-motion: reduce)').matches,
+    reducedTransparency: window.matchMedia('(prefers-reduced-transparency: reduce)').matches,
+  };
+}
+
+function publishAppearance(): void {
+  window.dispatchEvent(new CustomEvent(APPEARANCE_EVENT, {
+    detail: readMakaAppearance(),
+  }));
+}
+
+function ensureAppearanceObserver(): void {
+  if (appearanceObserver) return;
+  const root = document.documentElement;
+  appearanceObserver = new MutationObserver(() => {
+    syncTitleBarOverlay(root);
+    publishAppearance();
+  });
+  appearanceObserver.observe(root, {
+    attributes: true,
+    attributeFilter: [
+      'class',
+      'style',
+      'data-maka-theme',
+      'data-maka-skin',
+      'data-maka-skin-appearance-revision',
+    ],
+  });
+}
 
 /**
  * Apply a theme preference to <html>. Returns an unsubscribe function for the
@@ -24,6 +79,9 @@ let unsubscribeMediaQuery: (() => void) | null = null;
 export function applyTheme(pref: ThemePreference): () => void {
   unsubscribeMediaQuery?.();
   unsubscribeMediaQuery = null;
+  activeThemePreference = pref;
+  document.documentElement.dataset.makaThemePreference = pref;
+  ensureAppearanceObserver();
 
   // Cache the user-facing preference (not the resolved light/dark). The
   // pre-React paint reapplies the auto → system-matchMedia branch itself.
@@ -53,10 +111,12 @@ export function applyTheme(pref: ThemePreference): () => void {
 function setDarkClass(isDark: boolean): void {
   const root = document.documentElement;
   root.classList.toggle(DARK_CLASS, isDark);
+  root.dataset.makaColorScheme = isDark ? 'dark' : 'light';
   // Lets native form controls and scrollbars pick up the right base colors per
   // the Vercel Web Interface Guidelines dark-mode rule.
   root.style.colorScheme = isDark ? 'dark' : 'light';
   syncTitleBarOverlay(root);
+  publishAppearance();
 }
 
 /**
@@ -70,6 +130,7 @@ function setDarkClass(isDark: boolean): void {
  */
 export function applyThemePalette(palette: ThemePalette): void {
   const root = document.documentElement;
+  activeThemePalette = palette;
   if (palette === 'default') {
     root.removeAttribute('data-maka-theme');
   } else {
@@ -80,6 +141,7 @@ export function applyThemePalette(palette: ThemePalette): void {
   // Re-sync after changing the attribute so the native Windows controls never
   // retain the previous palette's titlebar color.
   syncTitleBarOverlay(root);
+  publishAppearance();
 }
 
 function syncTitleBarOverlay(root: HTMLElement): void {

--- a/apps/desktop/src/renderer/use-skin-action-host.ts
+++ b/apps/desktop/src/renderer/use-skin-action-host.ts
@@ -1,0 +1,150 @@
+import { useEffect, useEffectEvent, useRef } from 'react';
+import type { SkinActionName } from '../preload/bridge-contract';
+
+const TRUSTED_GESTURE_WINDOW_MS = 2_500;
+const MAX_SUBMIT_TEXT_LENGTH = 32_000;
+const SKIN_OWNER_SELECTOR = '[data-maka-skin-overlay], [data-maka-skin-mount]';
+
+function isSkinOwnedTarget(target: EventTarget | null): boolean {
+  return target instanceof Element && Boolean(target.closest(SKIN_OWNER_SELECTOR));
+}
+
+function respond(
+  request: HTMLElement,
+  result: { ok: true; value?: unknown } | { ok: false; error: string },
+): void {
+  request.dataset.makaSkinActionOk = String(result.ok);
+  if (result.ok) {
+    if (result.value !== undefined) {
+      request.dataset.makaSkinActionResult = JSON.stringify(result.value);
+    }
+  } else {
+    request.dataset.makaSkinActionError = result.error;
+  }
+  request.dispatchEvent(new Event('maka:skin-action-response'));
+}
+
+export function useSkinActionHost(options: {
+  sessionIds: ReadonlySet<string>;
+  canSubmit: boolean;
+  canStop: boolean;
+  switchSession(sessionId: string): void;
+  createTask(): void | Promise<void>;
+  submit(text: string): void | Promise<unknown>;
+  stop(): void | Promise<void>;
+}): void {
+  const lastTrustedGestureAtRef = useRef(0);
+
+  const handleRequest = useEffectEvent(async (request: HTMLElement) => {
+    const action = request.dataset.makaSkinAction as SkinActionName | undefined;
+    if (
+      action !== 'navigation.switch-session' &&
+      action !== 'task.new' &&
+      action !== 'composer.submit' &&
+      action !== 'generation.stop'
+    ) {
+      respond(request, { ok: false, error: 'Unknown skin action.' });
+      return;
+    }
+    if (Date.now() - lastTrustedGestureAtRef.current > TRUSTED_GESTURE_WINDOW_MS) {
+      respond(request, {
+        ok: false,
+        error: 'This action requires a recent trusted click or key press in skin-owned UI.',
+      });
+      return;
+    }
+    // One trusted gesture authorizes at most one action request. A skin cannot
+    // turn one click into a burst of navigation, submissions, or stops.
+    lastTrustedGestureAtRef.current = 0;
+
+    let input: Record<string, unknown>;
+    try {
+      const parsed = JSON.parse(request.dataset.makaSkinActionInput ?? '{}') as unknown;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) throw new Error();
+      input = parsed as Record<string, unknown>;
+    } catch {
+      respond(request, { ok: false, error: 'Skin action input is invalid.' });
+      return;
+    }
+    const submitText = action === 'composer.submit' && typeof input.text === 'string'
+      ? input.text.trim()
+      : '';
+    if (
+      action === 'composer.submit' &&
+      (!submitText || submitText.length > MAX_SUBMIT_TEXT_LENGTH)
+    ) {
+      respond(request, { ok: false, error: 'Prompt text is empty or too large.' });
+      return;
+    }
+    if (
+      action === 'navigation.switch-session' &&
+      (typeof input.sessionId !== 'string' || !options.sessionIds.has(input.sessionId))
+    ) {
+      respond(request, { ok: false, error: 'The requested session is not available.' });
+      return;
+    }
+    if (action === 'composer.submit' && !options.canSubmit) {
+      respond(request, {
+        ok: false,
+        error: 'Prompt submission is unavailable while the composer is busy or owns staged user content.',
+      });
+      return;
+    }
+    if (action === 'generation.stop' && !options.canStop) {
+      respond(request, { ok: false, error: 'There is no active generation to stop.' });
+      return;
+    }
+    if (!(await window.maka.skins.authorizeAction(
+      action,
+      action === 'composer.submit' ? { textPreview: submitText } : undefined,
+    ))) {
+      respond(request, { ok: false, error: 'This skin action was not permitted.' });
+      return;
+    }
+
+    try {
+      switch (action) {
+        case 'navigation.switch-session': {
+          options.switchSession(input.sessionId as string);
+          break;
+        }
+        case 'task.new':
+          await options.createTask();
+          break;
+        case 'composer.submit': {
+          await options.submit(submitText);
+          break;
+        }
+        case 'generation.stop':
+          await options.stop();
+          break;
+      }
+      respond(request, { ok: true });
+    } catch (error) {
+      respond(request, {
+        ok: false,
+        error: error instanceof Error ? error.message : 'Skin action failed.',
+      });
+    }
+  });
+
+  useEffect(() => {
+    const rememberTrustedGesture = (event: Event) => {
+      if (event.isTrusted && isSkinOwnedTarget(event.target)) {
+        lastTrustedGestureAtRef.current = Date.now();
+      }
+    };
+    const receiveRequest = (event: Event) => {
+      if (!(event.target instanceof HTMLElement) || !isSkinOwnedTarget(event.target)) return;
+      void handleRequest(event.target);
+    };
+    window.addEventListener('pointerdown', rememberTrustedGesture, true);
+    window.addEventListener('keydown', rememberTrustedGesture, true);
+    window.addEventListener('maka:skin-action-request', receiveRequest);
+    return () => {
+      window.removeEventListener('pointerdown', rememberTrustedGesture, true);
+      window.removeEventListener('keydown', rememberTrustedGesture, true);
+      window.removeEventListener('maka:skin-action-request', receiveRequest);
+    };
+  }, []);
+}

--- a/apps/desktop/src/renderer/use-skin-action-host.ts
+++ b/apps/desktop/src/renderer/use-skin-action-host.ts
@@ -1,4 +1,5 @@
 import { useEffect, useEffectEvent, useRef } from 'react';
+import type { PermissionMode, UserQuestionResponse } from '@maka/core';
 import type { SkinActionName } from '../preload/bridge-contract';
 
 const TRUSTED_GESTURE_WINDOW_MS = 2_500;
@@ -32,6 +33,16 @@ export function useSkinActionHost(options: {
   createTask(): void | Promise<void>;
   submit(text: string): void | Promise<unknown>;
   stop(): void | Promise<void>;
+  composer: {
+    setDraft(text: string, mode: 'replace' | 'append'): void;
+    focus(): void;
+    pickAttachments(): void | Promise<void>;
+    removeAttachment(index: number): void;
+    setModel(input: { llmConnectionSlug: string; model: string }): void | Promise<void>;
+    setSkills(skillRefs: readonly string[]): void;
+    setPermissionMode(mode: PermissionMode): void | Promise<void>;
+  };
+  answerQuestion(response: UserQuestionResponse): void | Promise<void>;
 }): void {
   const lastTrustedGestureAtRef = useRef(0);
 
@@ -41,7 +52,15 @@ export function useSkinActionHost(options: {
       action !== 'navigation.switch-session' &&
       action !== 'task.new' &&
       action !== 'composer.submit' &&
-      action !== 'generation.stop'
+      action !== 'generation.stop' &&
+      action !== 'composer.set-draft' &&
+      action !== 'composer.focus' &&
+      action !== 'composer.pick-attachments' &&
+      action !== 'composer.remove-attachment' &&
+      action !== 'composer.set-model' &&
+      action !== 'composer.set-skills' &&
+      action !== 'composer.set-permission-mode' &&
+      action !== 'interaction.answer-question'
     ) {
       respond(request, { ok: false, error: 'Unknown skin action.' });
       return;
@@ -94,9 +113,57 @@ export function useSkinActionHost(options: {
       respond(request, { ok: false, error: 'There is no active generation to stop.' });
       return;
     }
+    if (
+      action === 'composer.set-draft' &&
+      (typeof input.text !== 'string' || input.text.length > MAX_SUBMIT_TEXT_LENGTH ||
+        (input.mode !== undefined && input.mode !== 'replace' && input.mode !== 'append'))
+    ) {
+      respond(request, { ok: false, error: 'Composer draft input is invalid.' });
+      return;
+    }
+    if (
+      action === 'composer.remove-attachment' &&
+      (!Number.isInteger(input.index) || (input.index as number) < 0)
+    ) {
+      respond(request, { ok: false, error: 'Attachment index is invalid.' });
+      return;
+    }
+    if (
+      action === 'composer.set-model' &&
+      (typeof input.llmConnectionSlug !== 'string' || typeof input.model !== 'string')
+    ) {
+      respond(request, { ok: false, error: 'Composer model input is invalid.' });
+      return;
+    }
+    if (
+      action === 'composer.set-skills' &&
+      (!Array.isArray(input.skillRefs) || input.skillRefs.some((ref) => typeof ref !== 'string'))
+    ) {
+      respond(request, { ok: false, error: 'Composer skills input is invalid.' });
+      return;
+    }
+    if (
+      action === 'composer.set-permission-mode' &&
+      !['explore', 'ask', 'execute', 'bypass'].includes(String(input.mode))
+    ) {
+      respond(request, { ok: false, error: 'Composer permission mode is invalid.' });
+      return;
+    }
+    if (
+      action === 'interaction.answer-question' &&
+      (typeof input.requestId !== 'string' || !Array.isArray(input.answers) ||
+        input.answers.some((answer) => answer !== null && typeof answer !== 'string'))
+    ) {
+      respond(request, { ok: false, error: 'Question response is invalid.' });
+      return;
+    }
     if (!(await window.maka.skins.authorizeAction(
       action,
-      action === 'composer.submit' ? { textPreview: submitText } : undefined,
+      action === 'composer.submit'
+        ? { textPreview: submitText }
+        : action === 'composer.set-permission-mode'
+          ? { permissionMode: input.mode as string }
+          : undefined,
     ))) {
       respond(request, { ok: false, error: 'This skin action was not permitted.' });
       return;
@@ -117,6 +184,39 @@ export function useSkinActionHost(options: {
         }
         case 'generation.stop':
           await options.stop();
+          break;
+        case 'composer.set-draft':
+          options.composer.setDraft(
+            input.text as string,
+            input.mode === 'append' ? 'append' : 'replace',
+          );
+          break;
+        case 'composer.focus':
+          options.composer.focus();
+          break;
+        case 'composer.pick-attachments':
+          await options.composer.pickAttachments();
+          break;
+        case 'composer.remove-attachment':
+          options.composer.removeAttachment(input.index as number);
+          break;
+        case 'composer.set-model':
+          await options.composer.setModel({
+            llmConnectionSlug: input.llmConnectionSlug as string,
+            model: input.model as string,
+          });
+          break;
+        case 'composer.set-skills':
+          options.composer.setSkills(input.skillRefs as string[]);
+          break;
+        case 'composer.set-permission-mode':
+          await options.composer.setPermissionMode(input.mode as PermissionMode);
+          break;
+        case 'interaction.answer-question':
+          await options.answerQuestion({
+            requestId: input.requestId as string,
+            answers: input.answers as Array<string | null>,
+          });
           break;
       }
       respond(request, { ok: true });

--- a/apps/desktop/src/renderer/use-skin-semantic-events.ts
+++ b/apps/desktop/src/renderer/use-skin-semantic-events.ts
@@ -1,74 +1,325 @@
-import { useEffect } from 'react';
-import { publishMakaSkinEvent } from './skin-events';
+import { useEffect, useRef } from 'react';
+import { displayRedactSecrets, type SessionSummary, type StoredMessage } from '@maka/core';
+import type { LiveTurnProjection, ToolActivityItem } from '@maka/ui';
+import {
+  publishMakaSkinEvent,
+  type MakaSkinSemanticEventMap,
+} from './skin-events';
+
+const MAX_DETAIL_TEXT = 12_000;
+const SKIN_OWNER_SELECTOR = '[data-maka-skin-overlay], [data-maka-skin-mount]';
+
+function boundedDisplayText(value: unknown): string | undefined {
+  if (value === undefined) return undefined;
+  let text: string;
+  try {
+    text = typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+  } catch {
+    text = String(value);
+  }
+  const redacted = displayRedactSecrets(text);
+  return redacted.length > MAX_DETAIL_TEXT
+    ? `${redacted.slice(0, MAX_DETAIL_TEXT)}\n…[truncated]`
+    : redacted;
+}
+
+function projectConversation(messages: readonly StoredMessage[], liveTurn: LiveTurnProjection | undefined) {
+  const projected = new Map<string, {
+    id: string;
+    turnId: string;
+    role: 'user' | 'assistant';
+    text: string;
+    timestamp?: number;
+    streaming: boolean;
+    truncated?: boolean;
+  }>();
+  for (const message of messages) {
+    if (message.type === 'user') {
+      projected.set(message.id, {
+        id: message.id,
+        turnId: message.turnId,
+        role: 'user',
+        text: displayRedactSecrets(message.displayText ?? message.text),
+        timestamp: message.ts,
+        streaming: false,
+      });
+    } else if (message.type === 'assistant') {
+      projected.set(message.id, {
+        id: message.id,
+        turnId: message.turnId,
+        role: 'assistant',
+        text: displayRedactSecrets(message.text),
+        timestamp: message.ts,
+        streaming: false,
+      });
+    }
+  }
+  if (liveTurn) {
+    for (const step of liveTurn.steps) {
+      if (!step.text) continue;
+      projected.set(step.stepId, {
+        id: step.stepId,
+        turnId: liveTurn.turnId,
+        role: 'assistant',
+        text: displayRedactSecrets(step.text.text),
+        streaming: step.text.complete !== true,
+        ...(step.text.truncated ? { truncated: true } : {}),
+      });
+    }
+  }
+  return [...projected.values()];
+}
+
+function projectTools(
+  messages: readonly StoredMessage[],
+  liveTools: readonly ToolActivityItem[],
+) {
+  const projected = new Map<string, {
+    id: string;
+    turnId?: string;
+    name: string;
+    displayName?: string;
+    status: string;
+    argsText?: string;
+    outputText?: string;
+    durationMs?: number;
+    truncated?: boolean;
+  }>();
+  for (const message of messages) {
+    if (message.type === 'tool_call') {
+      projected.set(message.id, {
+        id: message.id,
+        turnId: message.turnId,
+        name: message.toolName,
+        ...(message.displayName ? { displayName: message.displayName } : {}),
+        status: 'completed',
+        ...(boundedDisplayText(message.args) ? { argsText: boundedDisplayText(message.args) } : {}),
+      });
+    } else if (message.type === 'tool_result') {
+      const existing = projected.get(message.toolUseId);
+      projected.set(message.toolUseId, {
+        id: message.toolUseId,
+        turnId: message.turnId,
+        name: existing?.name ?? 'Tool',
+        ...(existing?.displayName ? { displayName: existing.displayName } : {}),
+        status: message.isError ? 'errored' : 'completed',
+        ...(existing?.argsText ? { argsText: existing.argsText } : {}),
+        ...(boundedDisplayText(message.content) ? { outputText: boundedDisplayText(message.content) } : {}),
+        ...(message.durationMs !== undefined ? { durationMs: message.durationMs } : {}),
+      });
+    }
+  }
+  for (const tool of liveTools) {
+    const existing = projected.get(tool.toolUseId);
+    const outputText = tool.outputChunks?.map((chunk) => chunk.text).join('')
+      ?? boundedDisplayText(tool.result);
+    projected.set(tool.toolUseId, {
+      id: tool.toolUseId,
+      ...(existing?.turnId ? { turnId: existing.turnId } : {}),
+      name: tool.toolName === 'Tool' ? existing?.name ?? tool.toolName : tool.toolName,
+      ...(tool.displayName || existing?.displayName
+        ? { displayName: tool.displayName ?? existing?.displayName }
+        : {}),
+      status: tool.status,
+      ...(boundedDisplayText(tool.args) || existing?.argsText
+        ? { argsText: boundedDisplayText(tool.args) ?? existing?.argsText }
+        : {}),
+      ...(outputText ? { outputText: boundedDisplayText(outputText) } : {}),
+      ...(tool.durationMs !== undefined ? { durationMs: tool.durationMs } : {}),
+      ...(tool.outputTruncated ? { truncated: true } : {}),
+    });
+  }
+  return [...projected.values()];
+}
+
+function navigationProjection(selection: { section: string; module?: string }) {
+  return {
+    section: selection.section,
+    ...('module' in selection && selection.module ? { module: selection.module } : {}),
+  };
+}
 
 export function useSkinSemanticEvents(options: {
   sessionId: string | undefined;
-  messages: ReadonlyArray<{ id: string; type: string }>;
+  sessions: readonly SessionSummary[];
+  messages: readonly StoredMessage[];
+  liveTurn?: LiveTurnProjection;
   streaming: boolean;
   turnInFlight: boolean;
   hasInFlightTools: boolean;
-  interaction: { type: string } | undefined;
-  tools: ReadonlyArray<{ toolUseId: string; toolName: string; status: string }>;
+  interaction: {
+    type: string;
+    requestId?: string;
+    toolUseId?: string;
+    questions?: ReadonlyArray<{
+      question: string;
+      options: ReadonlyArray<{ label: string; description?: string }>;
+    }>;
+  } | undefined;
+  tools: readonly ToolActivityItem[];
+  navigation: { section: string; module?: string };
+  composer: {
+    readDraft(): string;
+    readSkills(): ReadonlyArray<{ id: string; ref?: string; name: string }>;
+    attachments: ReadonlyArray<{ displayName: string; kind: string; size: number; mimeType?: string }>;
+    model?: string;
+    permissionMode?: string;
+    busy: boolean;
+    revision: number;
+  };
 }): void {
   const {
     sessionId,
+    sessions,
     messages,
+    liveTurn,
     streaming,
     turnInFlight,
     hasInFlightTools,
     interaction,
     tools,
+    navigation,
+    composer,
   } = options;
-
-  useEffect(() => {
-    publishMakaSkinEvent('session.changed', { sessionId: sessionId ?? null });
-  }, [sessionId]);
-
-  useEffect(() => {
-    const last = messages.at(-1);
-    publishMakaSkinEvent('messages.changed', {
+  const generationState = interaction
+    ? 'waiting'
+    : streaming
+      ? 'streaming'
+      : hasInFlightTools
+        ? 'tool'
+        : turnInFlight
+          ? 'processing'
+          : 'idle';
+  const interactionKind = interaction?.type === 'sandbox_boundary_request'
+    ? 'permission'
+    : interaction?.type === 'user_question_request'
+      ? 'question'
+      : null;
+  const readComposerSnapshot = (): MakaSkinSemanticEventMap['composer.changed'] => ({
+    sessionId: sessionId ?? null,
+    draft: composer.readDraft(),
+    skills: composer.readSkills(),
+    attachments: composer.attachments.map((attachment, index) => ({
+      index,
+      name: attachment.displayName,
+      kind: attachment.kind,
+      size: attachment.size,
+      ...(attachment.mimeType ? { mimeType: attachment.mimeType } : {}),
+    })),
+    ...(composer.model ? { model: composer.model } : {}),
+    ...(composer.permissionMode ? { permissionMode: composer.permissionMode } : {}),
+    busy: composer.busy,
+  });
+  const snapshotsRef = useRef<Partial<MakaSkinSemanticEventMap>>({});
+  const latestComposerRef = useRef(composer);
+  latestComposerRef.current = composer;
+  snapshotsRef.current = {
+    ...snapshotsRef.current,
+    'session.changed': { sessionId: sessionId ?? null },
+    'messages.changed': {
       sessionId: sessionId ?? null,
       count: messages.length,
-      ...(last ? { lastMessage: { id: last.id, type: last.type } } : {}),
-    });
-  }, [messages, sessionId]);
-
-  useEffect(() => {
-    const state = interaction
-      ? 'waiting'
-      : streaming
-        ? 'streaming'
-        : hasInFlightTools
-          ? 'tool'
-          : turnInFlight
-            ? 'processing'
-            : 'idle';
-    publishMakaSkinEvent('generation.changed', {
+      ...(messages.at(-1)
+        ? { lastMessage: { id: messages.at(-1)!.id, type: messages.at(-1)!.type } }
+        : {}),
+    },
+    'generation.changed': { sessionId: sessionId ?? null, state: generationState },
+    'tools.changed': {
       sessionId: sessionId ?? null,
-      state,
-    });
-  }, [hasInFlightTools, interaction, sessionId, streaming, turnInFlight]);
-
-  useEffect(() => {
-    publishMakaSkinEvent('tools.changed', {
+      tools: tools.map((tool) => ({ id: tool.toolUseId, name: tool.toolName, status: tool.status })),
+    },
+    'interaction.changed': {
       sessionId: sessionId ?? null,
-      tools: tools.map((tool) => ({
-        id: tool.toolUseId,
-        name: tool.toolName,
-        status: tool.status,
-      })),
-    });
-  }, [sessionId, tools]);
-
-  useEffect(() => {
-    publishMakaSkinEvent('interaction.changed', {
-      sessionId: sessionId ?? null,
-      kind: interaction?.type === 'sandbox_boundary_request'
-        ? 'permission'
-        : interaction?.type === 'user_question_request'
-          ? 'question'
-          : null,
+      kind: interactionKind,
       waiting: Boolean(interaction),
-    });
+    },
+    'sessions.changed': {
+      currentSessionId: sessionId ?? null,
+      sessions: sessions.map((session) => ({
+        id: session.id,
+        name: session.name,
+        status: session.status,
+        flagged: session.isFlagged,
+        archived: session.isArchived,
+        unread: session.hasUnread,
+        ...(session.lastMessageAt !== undefined ? { lastMessageAt: session.lastMessageAt } : {}),
+        ...(session.lastMessagePreview ? { lastMessagePreview: displayRedactSecrets(session.lastMessagePreview) } : {}),
+      })),
+    },
+    'conversation.changed': {
+      sessionId: sessionId ?? null,
+      messages: projectConversation(messages, liveTurn),
+    },
+    'tools.detail.changed': {
+      sessionId: sessionId ?? null,
+      tools: projectTools(messages, tools),
+    },
+    'interaction.detail.changed': {
+      sessionId: sessionId ?? null,
+      interaction: interactionKind
+        ? {
+            kind: interactionKind,
+            ...(interaction?.requestId ? { requestId: interaction.requestId } : {}),
+            ...(interaction?.toolUseId ? { toolUseId: interaction.toolUseId } : {}),
+            ...(interactionKind === 'question' && interaction?.questions
+              ? { questions: interaction.questions }
+              : {}),
+          }
+        : null,
+    },
+    'composer.changed': readComposerSnapshot(),
+    'navigation.did-change': {
+      from: navigationProjection(navigation),
+      to: navigationProjection(navigation),
+    },
+    'navigation.will-change': {
+      from: navigationProjection(navigation),
+      to: navigationProjection(navigation),
+    },
+  };
+
+  useEffect(() => {
+    const receiveRequest = (event: Event) => {
+      const request = event.target;
+      if (!(request instanceof HTMLElement) || !request.closest(SKIN_OWNER_SELECTOR)) return;
+      const type = request.dataset.makaSkinSnapshotType as keyof MakaSkinSemanticEventMap | undefined;
+      if (!type) return;
+      const storedSnapshot = snapshotsRef.current[type];
+      const snapshot = type === 'composer.changed' && storedSnapshot
+        ? {
+            ...storedSnapshot,
+            draft: latestComposerRef.current.readDraft(),
+            skills: latestComposerRef.current.readSkills(),
+          }
+        : storedSnapshot;
+      if (snapshot === undefined) request.dataset.makaSkinSnapshotError = `Unknown skin snapshot: ${type}`;
+      else request.dataset.makaSkinSnapshotResult = JSON.stringify(snapshot);
+      request.dispatchEvent(new Event('maka:skin-snapshot-response'));
+    };
+    window.addEventListener('maka:skin-snapshot-request', receiveRequest);
+    return () => window.removeEventListener('maka:skin-snapshot-request', receiveRequest);
+  }, []);
+
+  useEffect(() => {
+    publishMakaSkinEvent('session.changed', snapshotsRef.current['session.changed']!);
+    publishMakaSkinEvent('sessions.changed', snapshotsRef.current['sessions.changed']!);
+  }, [sessionId, sessions]);
+  useEffect(() => {
+    publishMakaSkinEvent('messages.changed', snapshotsRef.current['messages.changed']!);
+    publishMakaSkinEvent('conversation.changed', snapshotsRef.current['conversation.changed']!);
+  }, [liveTurn, messages, sessionId]);
+  useEffect(() => {
+    publishMakaSkinEvent('generation.changed', snapshotsRef.current['generation.changed']!);
+  }, [generationState, sessionId]);
+  useEffect(() => {
+    publishMakaSkinEvent('tools.changed', snapshotsRef.current['tools.changed']!);
+    publishMakaSkinEvent('tools.detail.changed', snapshotsRef.current['tools.detail.changed']!);
+  }, [messages, sessionId, tools]);
+  useEffect(() => {
+    publishMakaSkinEvent('interaction.changed', snapshotsRef.current['interaction.changed']!);
+    publishMakaSkinEvent('interaction.detail.changed', snapshotsRef.current['interaction.detail.changed']!);
   }, [interaction, sessionId]);
+  useEffect(() => {
+    publishMakaSkinEvent('composer.changed', readComposerSnapshot());
+  }, [composer.attachments, composer.busy, composer.model, composer.permissionMode, composer.revision, sessionId]);
 }

--- a/apps/desktop/src/renderer/use-skin-semantic-events.ts
+++ b/apps/desktop/src/renderer/use-skin-semantic-events.ts
@@ -1,0 +1,74 @@
+import { useEffect } from 'react';
+import { publishMakaSkinEvent } from './skin-events';
+
+export function useSkinSemanticEvents(options: {
+  sessionId: string | undefined;
+  messages: ReadonlyArray<{ id: string; type: string }>;
+  streaming: boolean;
+  turnInFlight: boolean;
+  hasInFlightTools: boolean;
+  interaction: { type: string } | undefined;
+  tools: ReadonlyArray<{ toolUseId: string; toolName: string; status: string }>;
+}): void {
+  const {
+    sessionId,
+    messages,
+    streaming,
+    turnInFlight,
+    hasInFlightTools,
+    interaction,
+    tools,
+  } = options;
+
+  useEffect(() => {
+    publishMakaSkinEvent('session.changed', { sessionId: sessionId ?? null });
+  }, [sessionId]);
+
+  useEffect(() => {
+    const last = messages.at(-1);
+    publishMakaSkinEvent('messages.changed', {
+      sessionId: sessionId ?? null,
+      count: messages.length,
+      ...(last ? { lastMessage: { id: last.id, type: last.type } } : {}),
+    });
+  }, [messages, sessionId]);
+
+  useEffect(() => {
+    const state = interaction
+      ? 'waiting'
+      : streaming
+        ? 'streaming'
+        : hasInFlightTools
+          ? 'tool'
+          : turnInFlight
+            ? 'processing'
+            : 'idle';
+    publishMakaSkinEvent('generation.changed', {
+      sessionId: sessionId ?? null,
+      state,
+    });
+  }, [hasInFlightTools, interaction, sessionId, streaming, turnInFlight]);
+
+  useEffect(() => {
+    publishMakaSkinEvent('tools.changed', {
+      sessionId: sessionId ?? null,
+      tools: tools.map((tool) => ({
+        id: tool.toolUseId,
+        name: tool.toolName,
+        status: tool.status,
+      })),
+    });
+  }, [sessionId, tools]);
+
+  useEffect(() => {
+    publishMakaSkinEvent('interaction.changed', {
+      sessionId: sessionId ?? null,
+      kind: interaction?.type === 'sandbox_boundary_request'
+        ? 'permission'
+        : interaction?.type === 'user_question_request'
+          ? 'question'
+          : null,
+      waiting: Boolean(interaction),
+    });
+  }, [interaction, sessionId]);
+}

--- a/docs/skin-api.d.ts
+++ b/docs/skin-api.d.ts
@@ -1,0 +1,123 @@
+export type MakaThemePreference = 'light' | 'dark' | 'auto';
+export type MakaResolvedTheme = 'light' | 'dark';
+
+export interface MakaSkinManifest {
+  schemaVersion: 1;
+  id: string;
+  name: string;
+  version: string;
+  description?: string;
+  author?: string;
+  styles?: string;
+  entry?: string;
+  preview?: string;
+  permissions: Array<'dom' | 'canvas' | 'audio' | 'storage'>;
+}
+
+export interface MakaAppearanceSnapshot {
+  preference: MakaThemePreference;
+  resolvedTheme: MakaResolvedTheme;
+  palette: string;
+  colorScheme: MakaResolvedTheme;
+  forcedColors: boolean;
+  prefersContrast: boolean;
+  reducedMotion: boolean;
+  reducedTransparency: boolean;
+}
+
+export interface MakaStateSnapshot {
+  section: string;
+  module?: string;
+  hasActiveSession: boolean;
+  streaming: boolean;
+  modalOpen: boolean;
+}
+
+export interface MakaEnvironmentSnapshot extends MakaAppearanceSnapshot {
+  locale: string;
+  platform: string;
+  viewport: Readonly<{ width: number; height: number }>;
+  devicePixelRatio: number;
+  touch: boolean;
+}
+
+export type MakaSkinPart =
+  | 'app'
+  | 'shell'
+  | 'titlebar'
+  | 'sidebar'
+  | 'main'
+  | 'detail-panel'
+  | 'chat'
+  | 'chat-header'
+  | 'transcript'
+  | 'composer'
+  | 'composer-interactions'
+  | 'settings'
+  | 'settings-sidebar'
+  | 'settings-content'
+  | 'command-palette';
+
+export interface MakaSkinStyleHandle {
+  update(css: string): void;
+  dispose(): void;
+}
+
+export interface MakaSkinApi {
+  readonly apiVersion: 1;
+  readonly manifest: Readonly<MakaSkinManifest>;
+  readonly overlay: HTMLDivElement;
+  readonly assets: {
+    url(path: string): string | null;
+    list(): string[];
+  };
+  readonly parts: {
+    readonly names: readonly MakaSkinPart[];
+    one(name: MakaSkinPart | string): Element | null;
+    all(name: MakaSkinPart | string): Element[];
+    observe(
+      name: MakaSkinPart | string,
+      handler: (elements: readonly Element[]) => void,
+    ): () => void;
+    wait(name: MakaSkinPart | string, timeoutMs?: number): Promise<Element>;
+  };
+  readonly appearance: {
+    current(): MakaAppearanceSnapshot;
+    onDidChange(handler: (snapshot: MakaAppearanceSnapshot) => void): () => void;
+    readonly tokens: {
+      get(name: `--${string}`): string;
+      all(): Readonly<Record<`--${string}`, string>>;
+      set(name: `--${string}`, value: string): void;
+      setAll(values: Partial<Record<`--${string}`, string>>): void;
+      reset(name: `--${string}`): void;
+      resetAll(): void;
+    };
+  };
+  readonly state: {
+    current(): MakaStateSnapshot;
+    onDidChange(handler: (snapshot: MakaStateSnapshot) => void): () => void;
+  };
+  readonly environment: {
+    current(): MakaEnvironmentSnapshot;
+    onDidChange(handler: (snapshot: MakaEnvironmentSnapshot) => void): () => void;
+  };
+  readonly styles: {
+    add(css: string, id?: string): MakaSkinStyleHandle;
+  };
+  readonly events: {
+    on(type: string, handler: (detail: unknown, event: Event) => void): () => void;
+  };
+  readonly lifecycle: {
+    onDispose(handler: () => void): () => void;
+  };
+  readonly storage: {
+    get<T>(key: string, fallback?: T): T;
+    set(key: string, value: unknown): void;
+    remove(key: string): void;
+  };
+  log(...args: unknown[]): void;
+}
+
+export type MakaSkinActivate = (
+  api: MakaSkinApi,
+) => void | (() => void) | Promise<void | (() => void)>;

--- a/docs/skin-api.d.ts
+++ b/docs/skin-api.d.ts
@@ -2,7 +2,7 @@ export type MakaThemePreference = 'light' | 'dark' | 'auto';
 export type MakaResolvedTheme = 'light' | 'dark';
 
 export interface MakaSkinManifest {
-  schemaVersion: 1;
+  schemaVersion: 1 | 2;
   id: string;
   name: string;
   version: string;
@@ -11,8 +11,30 @@ export interface MakaSkinManifest {
   styles?: string;
   entry?: string;
   preview?: string;
-  permissions: Array<'dom' | 'canvas' | 'audio' | 'storage'>;
+  permissions: MakaSkinPermission[];
+  minimumApiVersion: number;
+  requiredCapabilities: MakaSkinCapability[];
 }
+
+export type MakaSkinPermission =
+  | 'dom'
+  | 'canvas'
+  | 'audio'
+  | 'storage'
+  | 'actions.navigation'
+  | 'actions.task'
+  | 'actions.submit'
+  | 'actions.stop';
+
+export type MakaSkinCapability =
+  | 'appearance.v1'
+  | 'parts.v1'
+  | 'slots.v1'
+  | 'events.semantic.v1'
+  | 'actions.navigation.v1'
+  | 'actions.task.v1'
+  | 'actions.submit.v1'
+  | 'actions.stop.v1';
 
 export interface MakaAppearanceSnapshot {
   preference: MakaThemePreference;
@@ -58,15 +80,76 @@ export type MakaSkinPart =
   | 'settings-content'
   | 'command-palette';
 
+export type MakaSkinSlot =
+  | 'chat-header-before'
+  | 'chat-header-after'
+  | 'transcript-before'
+  | 'transcript-after'
+  | 'composer-before'
+  | 'composer-after';
+
+export interface MakaSkinEventMap {
+  'session.changed': { sessionId: string | null };
+  'messages.changed': {
+    sessionId: string | null;
+    count: number;
+    lastMessage?: Readonly<{ id: string; type: string }>;
+  };
+  'generation.changed': {
+    sessionId: string | null;
+    state: 'idle' | 'processing' | 'streaming' | 'tool' | 'waiting';
+  };
+  'tools.changed': {
+    sessionId: string | null;
+    tools: ReadonlyArray<Readonly<{ id: string; name: string; status: string }>>;
+  };
+  'interaction.changed': {
+    sessionId: string | null;
+    kind: 'permission' | 'question' | null;
+    waiting: boolean;
+  };
+  state: MakaStateSnapshot;
+  appearance: MakaAppearanceSnapshot;
+}
+
+export interface MakaSkinActionMap {
+  'navigation.switch-session': {
+    input: { sessionId: string };
+    output: void;
+  };
+  'task.new': {
+    input: Record<string, never>;
+    output: void;
+  };
+  'composer.submit': {
+    input: { text: string };
+    output: void;
+  };
+  'generation.stop': {
+    input: Record<string, never>;
+    output: void;
+  };
+}
+
 export interface MakaSkinStyleHandle {
   update(css: string): void;
   dispose(): void;
 }
 
 export interface MakaSkinApi {
-  readonly apiVersion: 1;
+  readonly apiVersion: 2;
   readonly manifest: Readonly<MakaSkinManifest>;
   readonly overlay: HTMLDivElement;
+  readonly capabilities: {
+    readonly all: readonly MakaSkinCapability[];
+    has(name: MakaSkinCapability | string): boolean;
+    require(name: MakaSkinCapability | string): void;
+  };
+  readonly permissions: {
+    readonly all: readonly MakaSkinPermission[];
+    has(name: MakaSkinPermission | string): boolean;
+    require(name: MakaSkinPermission | string): void;
+  };
   readonly assets: {
     url(path: string): string | null;
     list(): string[];
@@ -80,6 +163,13 @@ export interface MakaSkinApi {
       handler: (elements: readonly Element[]) => void,
     ): () => void;
     wait(name: MakaSkinPart | string, timeoutMs?: number): Promise<Element>;
+  };
+  readonly slots: {
+    readonly names: readonly MakaSkinSlot[];
+    one(name: MakaSkinSlot | string): Element | null;
+    observe(name: MakaSkinSlot | string, handler: (slot: Element | null) => void): () => void;
+    wait(name: MakaSkinSlot | string, timeoutMs?: number): Promise<Element>;
+    mount(name: MakaSkinSlot | string): HTMLDivElement;
   };
   readonly appearance: {
     current(): MakaAppearanceSnapshot;
@@ -105,7 +195,18 @@ export interface MakaSkinApi {
     add(css: string, id?: string): MakaSkinStyleHandle;
   };
   readonly events: {
+    on<Type extends keyof MakaSkinEventMap>(
+      type: Type,
+      handler: (detail: MakaSkinEventMap[Type], event: Event) => void,
+    ): () => void;
     on(type: string, handler: (detail: unknown, event: Event) => void): () => void;
+  };
+  readonly actions: {
+    can<Type extends keyof MakaSkinActionMap>(name: Type): boolean;
+    invoke<Type extends keyof MakaSkinActionMap>(
+      name: Type,
+      input: MakaSkinActionMap[Type]['input'],
+    ): Promise<MakaSkinActionMap[Type]['output']>;
   };
   readonly lifecycle: {
     onDispose(handler: () => void): () => void;

--- a/docs/skin-api.d.ts
+++ b/docs/skin-api.d.ts
@@ -21,10 +21,17 @@ export type MakaSkinPermission =
   | 'canvas'
   | 'audio'
   | 'storage'
+  | 'data.sessions'
+  | 'data.conversation'
+  | 'data.tools'
+  | 'data.interactions'
+  | 'data.composer'
   | 'actions.navigation'
   | 'actions.task'
   | 'actions.submit'
-  | 'actions.stop';
+  | 'actions.stop'
+  | 'actions.composer'
+  | 'actions.answer';
 
 export type MakaSkinCapability =
   | 'appearance.v1'
@@ -34,7 +41,14 @@ export type MakaSkinCapability =
   | 'actions.navigation.v1'
   | 'actions.task.v1'
   | 'actions.submit.v1'
-  | 'actions.stop.v1';
+  | 'actions.stop.v1'
+  | 'sessions.v1'
+  | 'conversation.v1'
+  | 'tools.detail.v1'
+  | 'interactions.question.v1'
+  | 'composer.control.v1'
+  | 'navigation.lifecycle.v1'
+  | 'slots.items.v1';
 
 export interface MakaAppearanceSnapshot {
   preference: MakaThemePreference;
@@ -78,7 +92,12 @@ export type MakaSkinPart =
   | 'settings'
   | 'settings-sidebar'
   | 'settings-content'
-  | 'command-palette';
+  | 'command-palette'
+  | 'session-list'
+  | 'session-row'
+  | 'message'
+  | 'tool-card'
+  | 'interaction';
 
 export type MakaSkinSlot =
   | 'chat-header-before'
@@ -86,7 +105,19 @@ export type MakaSkinSlot =
   | 'transcript-before'
   | 'transcript-after'
   | 'composer-before'
-  | 'composer-after';
+  | 'composer-after'
+  | 'session-list-before'
+  | 'session-list-after'
+  | 'session-row-before'
+  | 'session-row-after'
+  | 'message-before'
+  | 'message-after'
+  | 'tool-before'
+  | 'tool-after'
+  | 'interaction-before'
+  | 'interaction-after'
+  | 'settings-content-before'
+  | 'settings-content-after';
 
 export interface MakaSkinEventMap {
   'session.changed': { sessionId: string | null };
@@ -108,6 +139,84 @@ export interface MakaSkinEventMap {
     kind: 'permission' | 'question' | null;
     waiting: boolean;
   };
+  'sessions.changed': {
+    currentSessionId: string | null;
+    sessions: ReadonlyArray<
+      Readonly<{
+        id: string;
+        name: string;
+        status: string;
+        flagged: boolean;
+        archived: boolean;
+        unread: boolean;
+        lastMessageAt?: number;
+        lastMessagePreview?: string;
+      }>
+    >;
+  };
+  'conversation.changed': {
+    sessionId: string | null;
+    messages: ReadonlyArray<
+      Readonly<{
+        id: string;
+        turnId: string;
+        role: 'user' | 'assistant';
+        text: string;
+        timestamp?: number;
+        streaming: boolean;
+        truncated?: boolean;
+      }>
+    >;
+  };
+  'tools.detail.changed': {
+    sessionId: string | null;
+    tools: ReadonlyArray<
+      Readonly<{
+        id: string;
+        turnId?: string;
+        name: string;
+        displayName?: string;
+        status: string;
+        argsText?: string;
+        outputText?: string;
+        durationMs?: number;
+      truncated?: boolean;
+      }>
+    >;
+  };
+  'interaction.detail.changed': {
+    sessionId: string | null;
+    interaction: null | Readonly<{
+      kind: 'permission' | 'question';
+      requestId?: string;
+      toolUseId?: string;
+      questions?: ReadonlyArray<
+        Readonly<{
+          question: string;
+          options: ReadonlyArray<Readonly<{ label: string; description?: string }>>;
+        }>
+      >;
+    }>;
+  };
+  'composer.changed': {
+    sessionId: string | null;
+    draft: string;
+    skills: ReadonlyArray<Readonly<{ id: string; ref?: string; name: string }>>;
+    attachments: ReadonlyArray<
+      Readonly<{ index: number; name: string; kind: string; size: number; mimeType?: string }>
+    >;
+    model?: string;
+    permissionMode?: string;
+    busy: boolean;
+  };
+  'navigation.will-change': {
+    from: Readonly<{ section: string; module?: string }>;
+    to: Readonly<{ section: string; module?: string }>;
+  };
+  'navigation.did-change': {
+    from: Readonly<{ section: string; module?: string }>;
+    to: Readonly<{ section: string; module?: string }>;
+  };
   state: MakaStateSnapshot;
   appearance: MakaAppearanceSnapshot;
 }
@@ -127,6 +236,23 @@ export interface MakaSkinActionMap {
   };
   'generation.stop': {
     input: Record<string, never>;
+    output: void;
+  };
+  'composer.set-draft': {
+    input: { text: string; mode?: 'replace' | 'append' };
+    output: void;
+  };
+  'composer.focus': { input: Record<string, never>; output: void };
+  'composer.pick-attachments': { input: Record<string, never>; output: void };
+  'composer.remove-attachment': { input: { index: number }; output: void };
+  'composer.set-model': { input: { llmConnectionSlug: string; model: string }; output: void };
+  'composer.set-skills': { input: { skillRefs: string[] }; output: void };
+  'composer.set-permission-mode': {
+    input: { mode: 'explore' | 'ask' | 'execute' | 'bypass' };
+    output: void;
+  };
+  'interaction.answer-question': {
+    input: { requestId: string; answers: Array<string | null> };
     output: void;
   };
 }
@@ -166,10 +292,11 @@ export interface MakaSkinApi {
   };
   readonly slots: {
     readonly names: readonly MakaSkinSlot[];
-    one(name: MakaSkinSlot | string): Element | null;
+    one(name: MakaSkinSlot | string, ownerId?: string): Element | null;
+    all(name: MakaSkinSlot | string, ownerId?: string): Element[];
     observe(name: MakaSkinSlot | string, handler: (slot: Element | null) => void): () => void;
     wait(name: MakaSkinSlot | string, timeoutMs?: number): Promise<Element>;
-    mount(name: MakaSkinSlot | string): HTMLDivElement;
+    mount(name: MakaSkinSlot | string, ownerId?: string): HTMLDivElement;
   };
   readonly appearance: {
     current(): MakaAppearanceSnapshot;
@@ -200,6 +327,8 @@ export interface MakaSkinApi {
       handler: (detail: MakaSkinEventMap[Type], event: Event) => void,
     ): () => void;
     on(type: string, handler: (detail: unknown, event: Event) => void): () => void;
+    snapshot<Type extends keyof MakaSkinEventMap>(type: Type): Promise<MakaSkinEventMap[Type]>;
+    snapshot(type: string): Promise<unknown>;
   };
   readonly actions: {
     can<Type extends keyof MakaSkinActionMap>(name: Type): boolean;

--- a/docs/skin-manifest.schema.json
+++ b/docs/skin-manifest.schema.json
@@ -1,12 +1,16 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://maka.dev/schemas/skin-manifest-v1.json",
+  "$id": "https://maka.dev/schemas/skin-manifest-v2.json",
   "title": "Maka Skin Manifest",
   "type": "object",
   "additionalProperties": false,
-  "required": ["schemaVersion", "id", "name", "version", "permissions"],
+  "required": ["schemaVersion", "id", "name", "version", "minimumApiVersion", "permissions"],
   "properties": {
-    "schemaVersion": { "const": 1 },
+    "schemaVersion": { "const": 2 },
+    "minimumApiVersion": {
+      "type": "integer",
+      "minimum": 1
+    },
     "id": {
       "type": "string",
       "pattern": "^[a-z0-9][a-z0-9._-]{1,63}$"
@@ -45,12 +49,44 @@
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "enum": ["dom", "canvas", "audio", "storage"]
+        "enum": [
+          "dom",
+          "canvas",
+          "audio",
+          "storage",
+          "actions.navigation",
+          "actions.task",
+          "actions.submit",
+          "actions.stop"
+        ]
+      }
+    },
+    "requiredCapabilities": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": [
+          "appearance.v1",
+          "parts.v1",
+          "slots.v1",
+          "events.semantic.v1",
+          "actions.navigation.v1",
+          "actions.task.v1",
+          "actions.submit.v1",
+          "actions.stop.v1"
+        ]
       }
     }
   },
-  "anyOf": [
-    { "required": ["styles"] },
-    { "required": ["entry"] }
-  ]
+  "allOf": [
+    {
+      "if": { "required": ["entry"] },
+      "then": {
+        "properties": {
+          "permissions": { "contains": { "const": "dom" } }
+        }
+      }
+    }
+  ],
+  "anyOf": [{ "required": ["styles"] }, { "required": ["entry"] }]
 }

--- a/docs/skin-manifest.schema.json
+++ b/docs/skin-manifest.schema.json
@@ -54,10 +54,17 @@
           "canvas",
           "audio",
           "storage",
+          "data.sessions",
+          "data.conversation",
+          "data.tools",
+          "data.interactions",
+          "data.composer",
           "actions.navigation",
           "actions.task",
           "actions.submit",
-          "actions.stop"
+          "actions.stop",
+          "actions.composer",
+          "actions.answer"
         ]
       }
     },
@@ -73,7 +80,14 @@
           "actions.navigation.v1",
           "actions.task.v1",
           "actions.submit.v1",
-          "actions.stop.v1"
+          "actions.stop.v1",
+          "sessions.v1",
+          "conversation.v1",
+          "tools.detail.v1",
+          "interactions.question.v1",
+          "composer.control.v1",
+          "navigation.lifecycle.v1",
+          "slots.items.v1"
         ]
       }
     }

--- a/docs/skin-manifest.schema.json
+++ b/docs/skin-manifest.schema.json
@@ -1,0 +1,56 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://maka.dev/schemas/skin-manifest-v1.json",
+  "title": "Maka Skin Manifest",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schemaVersion", "id", "name", "version", "permissions"],
+  "properties": {
+    "schemaVersion": { "const": 1 },
+    "id": {
+      "type": "string",
+      "pattern": "^[a-z0-9][a-z0-9._-]{1,63}$"
+    },
+    "name": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 64
+    },
+    "version": {
+      "type": "string",
+      "minLength": 1,
+      "maxLength": 32
+    },
+    "description": {
+      "type": "string",
+      "maxLength": 512
+    },
+    "author": {
+      "type": "string",
+      "maxLength": 128
+    },
+    "styles": {
+      "type": "string",
+      "pattern": "^[^\\\\]*\\.css$"
+    },
+    "entry": {
+      "type": "string",
+      "pattern": "^[^\\\\]*\\.m?js$"
+    },
+    "preview": {
+      "type": "string",
+      "pattern": "^[^\\\\]*\\.(png|jpe?g|webp|gif|svg)$"
+    },
+    "permissions": {
+      "type": "array",
+      "uniqueItems": true,
+      "items": {
+        "enum": ["dom", "canvas", "audio", "storage"]
+      }
+    }
+  },
+  "anyOf": [
+    { "required": ["styles"] },
+    { "required": ["entry"] }
+  ]
+}

--- a/docs/skin-runtime.md
+++ b/docs/skin-runtime.md
@@ -1,0 +1,63 @@
+# Maka Skin Runtime
+
+Maka skins are trusted local UI mods packaged as ZIP-compatible
+`.maka-skin` files. They can combine global CSS with JavaScript running in a
+dedicated Chromium isolated world.
+
+## Package
+
+```text
+my-skin.maka-skin
+├── manifest.json
+├── theme.css
+├── entry.mjs
+├── preview.webp
+└── assets/
+```
+
+`manifest.json` uses schema version 1:
+
+```json
+{
+  "schemaVersion": 1,
+  "id": "author.skin-name",
+  "name": "Skin name",
+  "version": "1.0.0",
+  "styles": "theme.css",
+  "entry": "entry.mjs",
+  "permissions": ["dom", "canvas", "storage"]
+}
+```
+
+The entry module must be self-contained and export
+`activate(api)`. It may return a cleanup function. Static or dynamic imports
+are rejected in schema version 1.
+
+## Runtime API
+
+- `api.manifest`: validated manifest metadata.
+- `api.overlay`: a skin-owned, automatically removed overlay element.
+- `api.assets.url(path)`: data URL for a file under `assets/`.
+- `api.assets.list()`: available asset paths.
+- `api.parts.one(name)` / `all(name)`: stable `[data-maka-part]` anchors.
+- `api.events.on('state', handler)`: navigation, streaming, and modal state.
+- `api.storage`: JSON `get`, `set`, and `remove`, namespaced by skin id.
+- `api.log(...)`: namespaced development logging.
+
+The isolated world can access the DOM and browser APIs such as Canvas, WebGL,
+Web Audio, observers, and animations. It cannot access Node.js or Maka's
+`window.maka` preload bridge.
+
+## Recovery and trust
+
+Skins are intentionally powerful and should be treated like local plugins.
+The installer displays a full-access warning. If activation does not finish,
+the next launch disables the skin automatically. Launching Maka with
+`--disable-skins` (or `MAKA_DISABLE_SKINS=1`) bypasses all skins.
+
+To package the included example:
+
+```sh
+cd examples/skins/neon-orbit
+zip -r ../neon-orbit.maka-skin manifest.json theme.css entry.mjs
+```

--- a/docs/skin-runtime.md
+++ b/docs/skin-runtime.md
@@ -66,6 +66,9 @@ are rejected in every supported schema version.
 - `api.styles.add(css, id)`: add, update, and dispose runtime-generated CSS.
 - `api.events.on(type, handler)`: subscribe to redacted semantic session,
   message-count, generation, tool-status, and interaction lifecycle events.
+- `api.events.snapshot(type)`: request the latest value of an event projection;
+  `on` also replays this snapshot once after subscribing, so activation never
+  waits for the next host change.
 - `api.actions.can(name)` / `invoke(name, input)`: request a controlled host
   action. Every action requires its matching manifest permission and one recent
   trusted click or key press in skin-owned UI; one gesture authorizes one
@@ -92,7 +95,8 @@ Schema version 1 exposes:
 
 `app`, `shell`, `titlebar`, `sidebar`, `main`, `detail-panel`, `chat`,
 `chat-header`, `transcript`, `composer`, `composer-interactions`, `settings`,
-`settings-sidebar`, `settings-content`, and `command-palette`.
+`settings-sidebar`, `settings-content`, `command-palette`, `session-list`,
+`session-row`, `message`, `tool-card`, and `interaction`.
 
 Use `observe` or `wait` for conditional surfaces such as Settings and the
 command palette. Do not depend on private class names when a stable part exists.
@@ -101,8 +105,31 @@ command palette. Do not depend on private class names when a stable part exists.
 
 API version 2 exposes `chat-header-before`, `chat-header-after`,
 `transcript-before`, `transcript-after`, `composer-before`, and
-`composer-after`. A slot is a host-owned location, while the element returned
-by `mount` belongs to the skin.
+`composer-after`, plus before/after item slots for the session list, session
+rows, messages, tool cards, interactions, and Settings content. Repeated item
+slots carry `data-maka-owner-id`; pass that id to `slots.one` or `slots.mount`,
+or use `slots.all` to enumerate them. A slot is a host-owned location, while
+the element returned by `mount` belongs to the skin.
+
+### Permissioned data projections
+
+Rich UI data is opt-in and only describes host-visible content:
+
+- `data.sessions` → `sessions.changed`: visible session metadata and ids.
+- `data.conversation` → `conversation.changed`: visible user/assistant text,
+  including the active streamed answer; system prompts and thinking are never
+  included.
+- `data.tools` → `tools.detail.changed`: display-redacted argument/output text,
+  status, duration, and truncation state.
+- `data.interactions` → `interaction.detail.changed`: user questions and
+  choices. Permission-review details and approve/deny controls remain native.
+- `data.composer` → `composer.changed`: draft, selected skills, attachments,
+  model, permission mode, and busy state.
+
+All detail text is display-redacted and bounded before it crosses the formal
+Skin API. DOM-enabled skins remain full-trust UI mods and can inspect visible
+page content outside this contract; these permissions are explicit review and
+compatibility boundaries, not a process sandbox.
 
 ### Controlled actions
 
@@ -112,11 +139,20 @@ The action permissions are deliberately granular:
 - `actions.task` → `task.new`
 - `actions.submit` → `composer.submit`
 - `actions.stop` → `generation.stop`
+- `actions.composer` → draft replace/append, focus, attachment picker/removal,
+  model, Skills, and permission-mode controls
+- `actions.answer` → answer the currently visible user question
 
 `composer.submit` is rejected while the composer is busy or owns staged user
 attachments, quotes, a revision, or a permission/question interaction. Skins
 never receive the Maka preload bridge, and Maka shows a native confirmation
 with a prompt preview before every `composer.submit` request.
+Changing the active permission mode also requires a native Maka confirmation.
+Permission approvals are intentionally not available as skin actions.
+
+`navigation.will-change` and `navigation.did-change` provide stable transition
+lifecycle signals without allowing a skin to replace Maka routing or security
+surfaces.
 
 ### Normal appearance path
 

--- a/docs/skin-runtime.md
+++ b/docs/skin-runtime.md
@@ -35,14 +35,64 @@ are rejected in schema version 1.
 
 ## Runtime API
 
+- `api.apiVersion`: host API contract version (`1`).
 - `api.manifest`: validated manifest metadata.
 - `api.overlay`: a skin-owned, automatically removed overlay element.
 - `api.assets.url(path)`: data URL for a file under `assets/`.
 - `api.assets.list()`: available asset paths.
+- `api.appearance.current()` / `onDidChange(handler)`: theme preference,
+  resolved mode, palette, forced colors, contrast, reduced motion, and reduced
+  transparency.
+- `api.appearance.tokens`: read all resolved Maka design tokens, set dynamic
+  per-skin overrides, and reset them. Overrides are restored automatically
+  when the skin is disabled.
 - `api.parts.one(name)` / `all(name)`: stable `[data-maka-part]` anchors.
-- `api.events.on('state', handler)`: navigation, streaming, and modal state.
+- `api.parts.observe(name, handler)`: follow anchors across React remounts.
+- `api.parts.wait(name)`: wait for a lazy or conditional surface.
+- `api.state.current()` / `onDidChange(handler)`: navigation, streaming,
+  active-session, and modal state. The first callback receives the current
+  snapshot immediately.
+- `api.environment.current()` / `onDidChange(handler)`: locale, platform,
+  viewport, pixel ratio, touch input, and appearance accessibility preferences.
+- `api.styles.add(css, id)`: add, update, and dispose runtime-generated CSS.
+- `api.lifecycle.onDispose(handler)`: register cleanup without returning one
+  combined function from `activate`.
 - `api.storage`: JSON `get`, `set`, and `remove`, namespaced by skin id.
 - `api.log(...)`: namespaced development logging.
+
+The authoring declaration is [`skin-api.d.ts`](./skin-api.d.ts). Editors can
+use it from JavaScript with:
+
+```js
+/** @param {import("../../../docs/skin-api").MakaSkinApi} api */
+export function activate(api) {}
+```
+
+The manifest schema is
+[`skin-manifest.schema.json`](./skin-manifest.schema.json).
+
+### Stable parts
+
+Schema version 1 exposes:
+
+`app`, `shell`, `titlebar`, `sidebar`, `main`, `detail-panel`, `chat`,
+`chat-header`, `transcript`, `composer`, `composer-interactions`, `settings`,
+`settings-sidebar`, `settings-content`, and `command-palette`.
+
+Use `observe` or `wait` for conditional surfaces such as Settings and the
+command palette. Do not depend on private class names when a stable part exists.
+
+### Normal appearance path
+
+Maka remains the authority for the user's `light` / `dark` / `auto`
+preference and base palette. A skin observes the resolved host appearance and
+overrides semantic CSS custom properties. Host changes continue to update the
+native Electron theme, title-bar overlay, startup cache, and persisted
+settings; skins should not replace those mechanisms.
+
+The authoritative token surface includes colors, typography, spacing, radii,
+elevation, motion, layout, and z-index variables from `maka-tokens.css`.
+`api.appearance.tokens.all()` returns the resolved catalog at runtime.
 
 The isolated world can access the DOM and browser APIs such as Canvas, WebGL,
 Web Audio, observers, and animations. It cannot access Node.js or Maka's
@@ -55,9 +105,13 @@ The installer displays a full-access warning. If activation does not finish,
 the next launch disables the skin automatically. Launching Maka with
 `--disable-skins` (or `MAKA_DISABLE_SKINS=1`) bypasses all skins.
 
+Importing a package with the same skin id updates it in place. The Appearance
+settings page can reload the active package immediately or remove an installed
+package. These actions do not require rebuilding or restarting Maka.
+
 To package the included example:
 
 ```sh
 cd examples/skins/neon-orbit
-zip -r ../neon-orbit.maka-skin manifest.json theme.css entry.mjs
+zip -r ../neon-orbit.maka-skin manifest.json theme.css entry.mjs preview.svg
 ```

--- a/docs/skin-runtime.md
+++ b/docs/skin-runtime.md
@@ -15,11 +15,14 @@ my-skin.maka-skin
 └── assets/
 ```
 
-`manifest.json` uses schema version 1:
+New packages should use schema version 2. The runtime remains compatible with
+schema version 1 packages:
 
 ```json
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
+  "minimumApiVersion": 2,
+  "requiredCapabilities": ["appearance.v1", "parts.v1", "slots.v1"],
   "id": "author.skin-name",
   "name": "Skin name",
   "version": "1.0.0",
@@ -31,11 +34,13 @@ my-skin.maka-skin
 
 The entry module must be self-contained and export
 `activate(api)`. It may return a cleanup function. Static or dynamic imports
-are rejected in schema version 1.
+are rejected in every supported schema version.
 
 ## Runtime API
 
-- `api.apiVersion`: host API contract version (`1`).
+- `api.apiVersion`: host API contract version (`2`).
+- `api.capabilities`: detect stable host features without probing private DOM.
+- `api.permissions`: inspect the permissions granted by the installed manifest.
 - `api.manifest`: validated manifest metadata.
 - `api.overlay`: a skin-owned, automatically removed overlay element.
 - `api.assets.url(path)`: data URL for a file under `assets/`.
@@ -49,12 +54,22 @@ are rejected in schema version 1.
 - `api.parts.one(name)` / `all(name)`: stable `[data-maka-part]` anchors.
 - `api.parts.observe(name, handler)`: follow anchors across React remounts.
 - `api.parts.wait(name)`: wait for a lazy or conditional surface.
+- `api.slots.one(name)` / `wait(name)`: find formal extension surfaces around
+  the chat header, transcript, and composer.
+- `api.slots.mount(name)`: create a skin-owned mount that survives React
+  rerenders and is removed automatically when the skin is disabled.
 - `api.state.current()` / `onDidChange(handler)`: navigation, streaming,
   active-session, and modal state. The first callback receives the current
   snapshot immediately.
 - `api.environment.current()` / `onDidChange(handler)`: locale, platform,
   viewport, pixel ratio, touch input, and appearance accessibility preferences.
 - `api.styles.add(css, id)`: add, update, and dispose runtime-generated CSS.
+- `api.events.on(type, handler)`: subscribe to redacted semantic session,
+  message-count, generation, tool-status, and interaction lifecycle events.
+- `api.actions.can(name)` / `invoke(name, input)`: request a controlled host
+  action. Every action requires its matching manifest permission and one recent
+  trusted click or key press in skin-owned UI; one gesture authorizes one
+  action only.
 - `api.lifecycle.onDispose(handler)`: register cleanup without returning one
   combined function from `activate`.
 - `api.storage`: JSON `get`, `set`, and `remove`, namespaced by skin id.
@@ -82,6 +97,27 @@ Schema version 1 exposes:
 Use `observe` or `wait` for conditional surfaces such as Settings and the
 command palette. Do not depend on private class names when a stable part exists.
 
+### Stable slots
+
+API version 2 exposes `chat-header-before`, `chat-header-after`,
+`transcript-before`, `transcript-after`, `composer-before`, and
+`composer-after`. A slot is a host-owned location, while the element returned
+by `mount` belongs to the skin.
+
+### Controlled actions
+
+The action permissions are deliberately granular:
+
+- `actions.navigation` → `navigation.switch-session`
+- `actions.task` → `task.new`
+- `actions.submit` → `composer.submit`
+- `actions.stop` → `generation.stop`
+
+`composer.submit` is rejected while the composer is busy or owns staged user
+attachments, quotes, a revision, or a permission/question interaction. Skins
+never receive the Maka preload bridge, and Maka shows a native confirmation
+with a prompt preview before every `composer.submit` request.
+
 ### Normal appearance path
 
 Maka remains the authority for the user's `light` / `dark` / `auto`
@@ -96,12 +132,20 @@ elevation, motion, layout, and z-index variables from `maka-tokens.css`.
 
 The isolated world can access the DOM and browser APIs such as Canvas, WebGL,
 Web Audio, observers, and animations. It cannot access Node.js or Maka's
-`window.maka` preload bridge.
+`window.maka` preload bridge. Because DOM, Canvas, and Web Audio are browser
+capabilities of the same isolated world, their manifest entries describe the
+skin's declared intent for installation review; they are not separate process
+sandboxes. Controlled host actions are separately enforced in the main
+process. A DOM-enabled skin is nevertheless a full-trust UI mod: arbitrary DOM
+JavaScript can imitate page interaction outside the stable Skin API, so the
+installer labels that permission explicitly instead of presenting action
+permissions as an absolute sandbox.
 
 ## Recovery and trust
 
 Skins are intentionally powerful and should be treated like local plugins.
-The installer displays a full-access warning. If activation does not finish,
+The installer previews the exact requested permissions before writing the
+package. If activation does not finish,
 the next launch disables the skin automatically. Launching Maka with
 `--disable-skins` (or `MAKA_DISABLE_SKINS=1`) bypasses all skins.
 

--- a/examples/skins/neon-orbit/entry.mjs
+++ b/examples/skins/neon-orbit/entry.mjs
@@ -1,0 +1,58 @@
+export function activate(api) {
+  const canvas = document.createElement('canvas');
+  const context = canvas.getContext('2d', { alpha: true });
+  api.overlay.appendChild(canvas);
+
+  const reducedMotion = matchMedia('(prefers-reduced-motion: reduce)');
+  const storedDensity = Number(api.storage.get('density', 72));
+  const starCount = Math.max(24, Math.min(160, Number.isFinite(storedDensity) ? storedDensity : 72));
+  const stars = Array.from({ length: starCount }, (_, index) => ({
+    x: ((index * 83) % 101) / 101,
+    y: ((index * 47) % 97) / 97,
+    radius: 0.45 + ((index * 13) % 11) / 8,
+    phase: (index * 0.71) % (Math.PI * 2),
+  }));
+
+  let frame = 0;
+  let animationFrame = 0;
+  let disposed = false;
+
+  function resize() {
+    const scale = Math.min(devicePixelRatio, 2);
+    canvas.width = Math.max(1, Math.floor(innerWidth * scale));
+    canvas.height = Math.max(1, Math.floor(innerHeight * scale));
+    context?.setTransform(scale, 0, 0, scale, 0, 0);
+  }
+
+  function render(time = 0) {
+    if (!context || disposed) return;
+    context.clearRect(0, 0, innerWidth, innerHeight);
+    for (const star of stars) {
+      const alpha = reducedMotion.matches
+        ? 0.32
+        : 0.2 + (Math.sin(time / 900 + star.phase) + 1) * 0.18;
+      context.beginPath();
+      context.fillStyle = `rgba(188, 224, 255, ${alpha})`;
+      context.arc(star.x * innerWidth, star.y * innerHeight, star.radius, 0, Math.PI * 2);
+      context.fill();
+    }
+    frame += 1;
+    if (!reducedMotion.matches || frame === 1) animationFrame = requestAnimationFrame(render);
+  }
+
+  const stopState = api.events.on('state', (state) => {
+    document.documentElement.dataset.makaSkinStreaming = String(state.streaming);
+  });
+  addEventListener('resize', resize);
+  resize();
+  render();
+  api.log('Neon Orbit activated with', starCount, 'stars');
+
+  return () => {
+    disposed = true;
+    cancelAnimationFrame(animationFrame);
+    removeEventListener('resize', resize);
+    stopState();
+    document.documentElement.removeAttribute('data-maka-skin-streaming');
+  };
+}

--- a/examples/skins/neon-orbit/entry.mjs
+++ b/examples/skins/neon-orbit/entry.mjs
@@ -1,9 +1,11 @@
+/** @param {import("../../../docs/skin-api").MakaSkinApi} api */
 export function activate(api) {
   const canvas = document.createElement('canvas');
   const context = canvas.getContext('2d', { alpha: true });
   api.overlay.appendChild(canvas);
 
-  const reducedMotion = matchMedia('(prefers-reduced-motion: reduce)');
+  let reducedMotion = api.environment.current().reducedMotion;
+  let starColor = api.appearance.tokens.get('--foreground');
   const storedDensity = Number(api.storage.get('density', 72));
   const starCount = Math.max(24, Math.min(160, Number.isFinite(storedDensity) ? storedDensity : 72));
   const stars = Array.from({ length: starCount }, (_, index) => ({
@@ -28,20 +30,31 @@ export function activate(api) {
     if (!context || disposed) return;
     context.clearRect(0, 0, innerWidth, innerHeight);
     for (const star of stars) {
-      const alpha = reducedMotion.matches
+      const alpha = reducedMotion
         ? 0.32
         : 0.2 + (Math.sin(time / 900 + star.phase) + 1) * 0.18;
       context.beginPath();
-      context.fillStyle = `rgba(188, 224, 255, ${alpha})`;
+      context.globalAlpha = alpha;
+      context.fillStyle = starColor;
       context.arc(star.x * innerWidth, star.y * innerHeight, star.radius, 0, Math.PI * 2);
       context.fill();
     }
+    context.globalAlpha = 1;
     frame += 1;
-    if (!reducedMotion.matches || frame === 1) animationFrame = requestAnimationFrame(render);
+    if (!reducedMotion || frame === 1) animationFrame = requestAnimationFrame(render);
   }
 
-  const stopState = api.events.on('state', (state) => {
+  const stopState = api.state.onDidChange((state) => {
     document.documentElement.dataset.makaSkinStreaming = String(state.streaming);
+  });
+  const stopAppearance = api.appearance.onDidChange(() => {
+    starColor = api.appearance.tokens.get('--foreground');
+    frame = 0;
+    cancelAnimationFrame(animationFrame);
+    render();
+  });
+  const stopEnvironment = api.environment.onDidChange((environment) => {
+    reducedMotion = environment.reducedMotion;
   });
   addEventListener('resize', resize);
   resize();
@@ -53,6 +66,8 @@ export function activate(api) {
     cancelAnimationFrame(animationFrame);
     removeEventListener('resize', resize);
     stopState();
+    stopAppearance();
+    stopEnvironment();
     document.documentElement.removeAttribute('data-maka-skin-streaming');
   };
 }

--- a/examples/skins/neon-orbit/manifest.json
+++ b/examples/skins/neon-orbit/manifest.json
@@ -1,0 +1,11 @@
+{
+  "schemaVersion": 1,
+  "id": "maka.neon-orbit",
+  "name": "Neon Orbit",
+  "version": "0.1.0",
+  "description": "Animated glass panels, a canvas star field, and state-aware ambient effects.",
+  "author": "Maka",
+  "styles": "theme.css",
+  "entry": "entry.mjs",
+  "permissions": ["dom", "canvas", "storage"]
+}

--- a/examples/skins/neon-orbit/manifest.json
+++ b/examples/skins/neon-orbit/manifest.json
@@ -1,5 +1,7 @@
 {
-  "schemaVersion": 1,
+  "schemaVersion": 2,
+  "minimumApiVersion": 2,
+  "requiredCapabilities": ["appearance.v1", "parts.v1"],
   "id": "maka.neon-orbit",
   "name": "Neon Orbit",
   "version": "0.1.0",

--- a/examples/skins/neon-orbit/manifest.json
+++ b/examples/skins/neon-orbit/manifest.json
@@ -7,5 +7,6 @@
   "author": "Maka",
   "styles": "theme.css",
   "entry": "entry.mjs",
+  "preview": "preview.svg",
   "permissions": ["dom", "canvas", "storage"]
 }

--- a/examples/skins/neon-orbit/preview.svg
+++ b/examples/skins/neon-orbit/preview.svg
@@ -1,0 +1,25 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 400">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="1" y2="1">
+      <stop stop-color="#151229"/>
+      <stop offset="1" stop-color="#15314a"/>
+    </linearGradient>
+    <radialGradient id="glow">
+      <stop stop-color="#bb74ff" stop-opacity=".75"/>
+      <stop offset="1" stop-color="#bb74ff" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <rect width="640" height="400" rx="24" fill="url(#bg)"/>
+  <circle cx="118" cy="94" r="150" fill="url(#glow)"/>
+  <circle cx="535" cy="322" r="180" fill="#58d8ff" opacity=".16"/>
+  <rect x="28" y="28" width="166" height="344" rx="18" fill="#302b51" fill-opacity=".72" stroke="#bb8cff" stroke-opacity=".3"/>
+  <rect x="214" y="28" width="398" height="344" rx="18" fill="#24223f" fill-opacity=".72" stroke="#78dfff" stroke-opacity=".28"/>
+  <g fill="#eef4ff" opacity=".8">
+    <circle cx="58" cy="70" r="4"/><circle cx="110" cy="124" r="3"/><circle cx="170" cy="82" r="2"/>
+    <circle cx="250" cy="72" r="3"/><circle cx="405" cy="55" r="2"/><circle cx="566" cy="96" r="4"/>
+    <circle cx="350" cy="170" r="2"/><circle cx="520" cy="220" r="3"/><circle cx="280" cy="315" r="4"/>
+  </g>
+  <rect x="242" y="302" width="342" height="44" rx="14" fill="#393553" stroke="#8de6ff" stroke-opacity=".35"/>
+  <rect x="260" y="319" width="176" height="8" rx="4" fill="#cdd7ee" opacity=".7"/>
+  <circle cx="558" cy="324" r="12" fill="#b76dff"/>
+</svg>

--- a/examples/skins/neon-orbit/theme.css
+++ b/examples/skins/neon-orbit/theme.css
@@ -1,0 +1,65 @@
+html[data-maka-skin="maka.neon-orbit"] {
+  --background: oklch(0.16 0.035 274);
+  --foreground: oklch(0.95 0.02 255);
+  --card: oklch(0.24 0.045 274 / 0.72);
+  --card-foreground: oklch(0.96 0.02 255);
+  --border: oklch(0.72 0.14 286 / 0.28);
+  --primary: oklch(0.76 0.18 202);
+  --primary-foreground: oklch(0.14 0.03 270);
+  --accent: oklch(0.68 0.24 306);
+  --accent-foreground: white;
+}
+
+html[data-maka-skin="maka.neon-orbit"] body {
+  background:
+    radial-gradient(circle at 15% 20%, oklch(0.54 0.23 300 / 0.24), transparent 34%),
+    radial-gradient(circle at 82% 76%, oklch(0.65 0.18 203 / 0.2), transparent 38%),
+    linear-gradient(145deg, oklch(0.13 0.035 276), oklch(0.2 0.055 260));
+}
+
+html[data-maka-skin="maka.neon-orbit"] [data-maka-part="sidebar"],
+html[data-maka-skin="maka.neon-orbit"] [data-maka-part="detail-panel"] {
+  background: oklch(0.22 0.045 270 / 0.62) !important;
+  border-color: oklch(0.72 0.14 286 / 0.28) !important;
+  box-shadow:
+    0 24px 70px rgb(0 0 0 / 0.28),
+    inset 0 1px 0 rgb(255 255 255 / 0.08);
+  backdrop-filter: blur(22px) saturate(1.25);
+}
+
+html[data-maka-skin="maka.neon-orbit"][data-maka-skin-streaming="true"]
+  [data-maka-part="detail-panel"] {
+  animation: maka-neon-orbit-pulse 2.2s ease-in-out infinite;
+}
+
+[data-maka-skin-overlay="maka.neon-orbit"] {
+  position: fixed;
+  inset: 0;
+  z-index: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+[data-maka-skin-overlay="maka.neon-orbit"] canvas {
+  width: 100%;
+  height: 100%;
+  opacity: 0.72;
+}
+
+html[data-maka-skin="maka.neon-orbit"] [data-maka-part="shell"] {
+  position: relative;
+  z-index: 1;
+  background: transparent;
+}
+
+@keyframes maka-neon-orbit-pulse {
+  0%, 100% { box-shadow: 0 24px 70px rgb(0 0 0 / 0.28), inset 0 1px 0 rgb(255 255 255 / 0.08); }
+  50% { box-shadow: 0 24px 82px oklch(0.7 0.2 292 / 0.2), inset 0 1px 0 rgb(255 255 255 / 0.13); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  html[data-maka-skin="maka.neon-orbit"] * {
+    animation-duration: 0.001ms !important;
+    animation-iteration-count: 1 !important;
+  }
+}

--- a/examples/skins/neon-orbit/theme.css
+++ b/examples/skins/neon-orbit/theme.css
@@ -1,16 +1,39 @@
 html[data-maka-skin="maka.neon-orbit"] {
+  --background: oklch(0.98 0.014 260);
+  --background-elevated: oklch(1 0 0 / 0.76);
+  --surface-canvas: oklch(0.94 0.035 272);
+  --foreground: oklch(0.22 0.035 274);
+  --accent: oklch(0.58 0.22 306);
+  --info: oklch(0.62 0.17 232);
+  --success: oklch(0.58 0.16 158);
+  --destructive: oklch(0.58 0.22 25);
+  --border: oklch(0.45 0.12 282 / 0.24);
+  --border-strong: oklch(0.45 0.14 282 / 0.38);
+  --shadow-blur-opacity: 0.12;
+}
+
+html.dark[data-maka-skin="maka.neon-orbit"] {
   --background: oklch(0.16 0.035 274);
+  --background-elevated: oklch(0.24 0.045 274 / 0.72);
+  --surface-canvas: oklch(0.13 0.035 276);
   --foreground: oklch(0.95 0.02 255);
-  --card: oklch(0.24 0.045 274 / 0.72);
-  --card-foreground: oklch(0.96 0.02 255);
-  --border: oklch(0.72 0.14 286 / 0.28);
-  --primary: oklch(0.76 0.18 202);
-  --primary-foreground: oklch(0.14 0.03 270);
   --accent: oklch(0.68 0.24 306);
-  --accent-foreground: white;
+  --info: oklch(0.76 0.18 202);
+  --success: oklch(0.72 0.15 158);
+  --destructive: oklch(0.7 0.2 25);
+  --border: oklch(0.72 0.14 286 / 0.28);
+  --border-strong: oklch(0.72 0.14 286 / 0.42);
+  --shadow-blur-opacity: 0.2;
 }
 
 html[data-maka-skin="maka.neon-orbit"] body {
+  background:
+    radial-gradient(circle at 15% 20%, oklch(0.68 0.16 300 / 0.2), transparent 34%),
+    radial-gradient(circle at 82% 76%, oklch(0.72 0.14 203 / 0.2), transparent 38%),
+    linear-gradient(145deg, oklch(0.96 0.025 276), oklch(0.92 0.045 260));
+}
+
+html.dark[data-maka-skin="maka.neon-orbit"] body {
   background:
     radial-gradient(circle at 15% 20%, oklch(0.54 0.23 300 / 0.24), transparent 34%),
     radial-gradient(circle at 82% 76%, oklch(0.65 0.18 203 / 0.2), transparent 38%),
@@ -19,8 +42,8 @@ html[data-maka-skin="maka.neon-orbit"] body {
 
 html[data-maka-skin="maka.neon-orbit"] [data-maka-part="sidebar"],
 html[data-maka-skin="maka.neon-orbit"] [data-maka-part="detail-panel"] {
-  background: oklch(0.22 0.045 270 / 0.62) !important;
-  border-color: oklch(0.72 0.14 286 / 0.28) !important;
+  background: color-mix(in oklab, var(--background-elevated) 78%, transparent) !important;
+  border-color: var(--border) !important;
   box-shadow:
     0 24px 70px rgb(0 0 0 / 0.28),
     inset 0 1px 0 rgb(255 255 255 / 0.08);

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "@maka/ui": "0.1.0",
         "ai": "^7.0.31",
         "electron-updater": "^6.8.9",
+        "fflate": "^0.8.2",
         "qrcode": "^1.5.4",
         "react": "^19.2.1",
         "react-dom": "^19.2.1",
@@ -7671,6 +7672,12 @@
           "optional": true
         }
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "license": "MIT"
     },
     "node_modules/filelist": {
       "version": "1.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
       "version": "0.1.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "@babel/parser": "^7.29.3",
         "@base-ui/react": "^1.5.0",
         "@jackwener/opencli": "1.8.4",
         "@maka/computer-use": "0.1.0",
@@ -54,7 +55,6 @@
       },
       "devDependencies": {
         "@ant-design/icons-svg": "4.5.0",
-        "@babel/parser": "^7.29.3",
         "@fontsource-variable/geist": "^5.2.9",
         "@fontsource-variable/geist-mono": "^5.2.8",
         "@playwright/test": "^1.61.1",
@@ -447,7 +447,6 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
       "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -457,7 +456,6 @@
       "version": "7.28.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
       "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -491,7 +489,6 @@
       "version": "7.29.3",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
       "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.29.0"
@@ -550,7 +547,6 @@
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
       "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-string-parser": "^7.27.1",

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -502,36 +502,40 @@ export function ChatView(props: {
           {turns.map((turn) => {
             return (
               <Fragment key={turn.turnId}>
-                <TurnView
-                  turn={turn}
-                  userLabel={props.userLabel}
-                  footerActions={props.turnFooterActionsByTurn?.[turn.turnId]}
-                  onFooterAction={stableTurnFooterAction}
-                  onEditUserMessage={props.onEditUserMessage ? stableEditUserMessage : undefined}
-                  editUserMessageTransformed={transformedUserTurnIds.has(turn.turnId)}
-                  editUserMessageDisabled={
-                    streamingActive || props.activeSession?.status === 'running'
-                  }
-                  failedReasonLabel={props.turnFailedReasonLabels?.[turn.turnId]}
-                  failedRecoveryLabel={props.turnFailedRecoveryLabels?.[turn.turnId]}
-                  safeResumeAction={props.safeResumeAction?.turnId === turn.turnId
-                    ? props.safeResumeAction
-                    : undefined}
-                  lineageBadges={props.turnLineageBadgesByTurn?.[turn.turnId]}
-                  onLineageBadgeClick={stableLineageBadgeClick}
-                  onReadAttachmentBytes={props.onReadAttachmentBytes}
-                  searchHighlighted={highlightedTurnId === turn.turnId}
-                  liveStreaming={
-                    turn.turnId === tailTurnId
-                      ? {
-                          onStreamingSettled: props.onStreamingSettled,
-                          processingIndicator: props.processingIndicator,
-                          continuingIndicator: props.continuingIndicator,
-                          providerRetry: props.liveTurn?.providerRetry,
-                        }
-                      : undefined
-                  }
-                />
+                <div className="maka-skin-slot" data-maka-slot="message-before" data-maka-owner-id={turn.turnId} />
+                <div data-maka-part="message" data-maka-owner-id={turn.turnId}>
+                  <TurnView
+                    turn={turn}
+                    userLabel={props.userLabel}
+                    footerActions={props.turnFooterActionsByTurn?.[turn.turnId]}
+                    onFooterAction={stableTurnFooterAction}
+                    onEditUserMessage={props.onEditUserMessage ? stableEditUserMessage : undefined}
+                    editUserMessageTransformed={transformedUserTurnIds.has(turn.turnId)}
+                    editUserMessageDisabled={
+                      streamingActive || props.activeSession?.status === 'running'
+                    }
+                    failedReasonLabel={props.turnFailedReasonLabels?.[turn.turnId]}
+                    failedRecoveryLabel={props.turnFailedRecoveryLabels?.[turn.turnId]}
+                    safeResumeAction={props.safeResumeAction?.turnId === turn.turnId
+                      ? props.safeResumeAction
+                      : undefined}
+                    lineageBadges={props.turnLineageBadgesByTurn?.[turn.turnId]}
+                    onLineageBadgeClick={stableLineageBadgeClick}
+                    onReadAttachmentBytes={props.onReadAttachmentBytes}
+                    searchHighlighted={highlightedTurnId === turn.turnId}
+                    liveStreaming={
+                      turn.turnId === tailTurnId
+                        ? {
+                            onStreamingSettled: props.onStreamingSettled,
+                            processingIndicator: props.processingIndicator,
+                            continuingIndicator: props.continuingIndicator,
+                            providerRetry: props.liveTurn?.providerRetry,
+                          }
+                        : undefined
+                    }
+                  />
+                </div>
+                <div className="maka-skin-slot" data-maka-slot="message-after" data-maka-owner-id={turn.turnId} />
                 {conversationItemsByTurn.get(turn.turnId)?.map((item) => (
                   <Fragment key={item.id}>{item.content}</Fragment>
                 ))}

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -356,7 +356,7 @@ export function ChatView(props: {
 
   if (!props.activeSession) {
     return (
-      <main className="maka-main detailPane agents-chat-panel agents-chat-view-root">
+      <main className="maka-main detailPane agents-chat-panel agents-chat-view-root" data-maka-part="chat">
         {/* PR-REMOVE-CHAT-TAB (WAWQAQ msg d401938d 2026-06-23): the
             browser-style session tab + the duplicate "新建对话" plus
             button were removed. The session name lives in the sidebar;
@@ -376,6 +376,7 @@ export function ChatView(props: {
           className="maka-chat messages"
           viewportClassName="maka-chatViewport"
           contentClassName="maka-chatContent"
+          data-maka-part="transcript"
         >
           {props.emptyOverride ?? <EmptyChatHero onPromptSuggestion={props.onPromptSuggestion} userLabel={props.userLabel} />}
           {props.conversationItems?.map((item) => <Fragment key={item.id}>{item.content}</Fragment>)}
@@ -387,14 +388,14 @@ export function ChatView(props: {
   const deepResearchActive = isDeepResearchSession(props.activeSession.labels);
 
   return (
-    <main className="maka-main detailPane agents-chat-panel agents-chat-view-root">
+    <main className="maka-main detailPane agents-chat-panel agents-chat-view-root" data-maka-part="chat">
       {/* PR-REMOVE-CHAT-TAB (WAWQAQ msg d401938d): no more browser-style
           session tab in the chat header. Session name + model live in
           the sidebar; the new-task button at the top of the sidebar is
           the canonical create-session entry. The chat header is now
           just a thin chrome strip carrying the permission-mode
           switcher and the per-session memory/mode chips. */}
-      <header className="maka-chat-header">
+      <header className="maka-chat-header" data-maka-part="chat-header">
         {props.memoryActive && (
           /* This status pill is a semantic header control rather than a
              shared Button size or neutral variant. */
@@ -466,6 +467,7 @@ export function ChatView(props: {
           className="maka-chat messages"
           viewportClassName="maka-chatViewport"
           contentClassName="maka-chatContent"
+          data-maka-part="transcript"
           onScroll={onScroll}
         >
           {chat.length === 0 && !streamingActive && (

--- a/packages/ui/src/chat-view.tsx
+++ b/packages/ui/src/chat-view.tsx
@@ -357,6 +357,7 @@ export function ChatView(props: {
   if (!props.activeSession) {
     return (
       <main className="maka-main detailPane agents-chat-panel agents-chat-view-root" data-maka-part="chat">
+        <div className="maka-skin-slot" data-maka-slot="chat-header-before" />
         {/* PR-REMOVE-CHAT-TAB (WAWQAQ msg d401938d 2026-06-23): the
             browser-style session tab + the duplicate "新建对话" plus
             button were removed. The session name lives in the sidebar;
@@ -372,6 +373,8 @@ export function ChatView(props: {
             header used to be rendered here anyway, holding a lone spacer, to
             occupy the window titlebar line — which the shell's titlebar row now
             owns. */}
+        <div className="maka-skin-slot" data-maka-slot="chat-header-after" />
+        <div className="maka-skin-slot" data-maka-slot="transcript-before" />
         <OverlayScrollArea
           className="maka-chat messages"
           viewportClassName="maka-chatViewport"
@@ -381,6 +384,7 @@ export function ChatView(props: {
           {props.emptyOverride ?? <EmptyChatHero onPromptSuggestion={props.onPromptSuggestion} userLabel={props.userLabel} />}
           {props.conversationItems?.map((item) => <Fragment key={item.id}>{item.content}</Fragment>)}
         </OverlayScrollArea>
+        <div className="maka-skin-slot" data-maka-slot="transcript-after" />
       </main>
     );
   }
@@ -389,6 +393,7 @@ export function ChatView(props: {
 
   return (
     <main className="maka-main detailPane agents-chat-panel agents-chat-view-root" data-maka-part="chat">
+      <div className="maka-skin-slot" data-maka-slot="chat-header-before" />
       {/* PR-REMOVE-CHAT-TAB (WAWQAQ msg d401938d): no more browser-style
           session tab in the chat header. Session name + model live in
           the sidebar; the new-task button at the top of the sidebar is
@@ -442,6 +447,7 @@ export function ChatView(props: {
             composer left-controls. Header keeps the per-session status
             chips only. */}
       </header>
+      <div className="maka-skin-slot" data-maka-slot="chat-header-after" />
       {deepResearchActive && props.deepResearchRun && (
         <DeepResearchProgressPanel
           run={props.deepResearchRun}
@@ -462,6 +468,7 @@ export function ChatView(props: {
             onClick={props.onBranchBannerClick}
           />
         )}
+        <div className="maka-skin-slot" data-maka-slot="transcript-before" />
         <OverlayScrollArea
           ref={scrollRef}
           className="maka-chat messages"
@@ -563,6 +570,7 @@ export function ChatView(props: {
               folds these into the `__loose` turn, so this is normally a
               no-op. */}
         </OverlayScrollArea>
+        <div className="maka-skin-slot" data-maka-slot="transcript-after" />
         <PromptAnchorRail turns={promptRailTurns} scrollRef={scrollRef} />
         {!pinnedToBottom && (
           <BaseButton

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -664,6 +664,7 @@ export const Composer = forwardRef<
       <form
       ref={formRef}
       className="maka-composer composer"
+      data-maka-part="composer"
       hidden={props.hidden}
       data-drag-active={dragActive ? 'true' : undefined}
       data-maka-file-drop-target={canAcceptDroppedFiles() ? 'true' : undefined}

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -112,6 +112,8 @@ export const Composer = forwardRef<
       text: string,
       skillIds: readonly string[],
     ): boolean | void | Promise<boolean | void>;
+    /** Reports user and host-driven draft mutations to stable extension hosts. */
+    onDraftChange?(text: string): void;
     onStop(): void | Promise<void>;
     onPickAttachments?(): void | Promise<void>;
     onAttachFilePaths?(files: File[]): void | Promise<void>;
@@ -325,6 +327,7 @@ export const Composer = forwardRef<
         resetPromptHistoryNavigation();
         el.value = text;
         saveCurrentDraft(text);
+        props.onDraftChange?.(text);
         autoResize();
         // Move caret to end so the user can keep typing.
         focusTextInputAtEnd(el);
@@ -335,6 +338,7 @@ export const Composer = forwardRef<
         resetPromptHistoryNavigation();
         el.value = appendPromptContextDraft(el.value, text);
         saveCurrentDraft(el.value);
+        props.onDraftChange?.(el.value);
         autoResize();
         focusTextInputAtEnd(el);
       },
@@ -351,6 +355,7 @@ export const Composer = forwardRef<
         const el = textareaRef.current;
         if (el) el.value = '';
         saveCurrentDraft('');
+        props.onDraftChange?.('');
         autoResize();
       },
       setDraft(draftKey: string, text: string) {
@@ -360,6 +365,7 @@ export const Composer = forwardRef<
         if (!el) return;
         resetPromptHistoryNavigation();
         el.value = text;
+        props.onDraftChange?.(text);
         autoResize();
         focusTextInputAtEnd(el);
       },
@@ -411,6 +417,7 @@ export const Composer = forwardRef<
     // revision branch, or user navigation). Never erase a foreign draft.
     if (activeDraftKey() !== submittedDraftKey) return;
     saveCurrentDraft('');
+    props.onDraftChange?.('');
     skillDraft.clear(skillDraft.activeDraftKey());
     form?.reset();
     // form.reset() empties the textarea but doesn't fire input — collapse
@@ -513,6 +520,7 @@ export const Composer = forwardRef<
     resetPromptHistoryNavigation();
     autoResize();
     saveCurrentDraft();
+    props.onDraftChange?.(textareaRef.current?.value ?? '');
     recomputeMention();
   }
 

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -809,6 +809,8 @@ const SessionRow = memo(function SessionRow(props: {
   return (
     <div
       className="maka-list-row"
+      data-maka-part="session-row"
+      data-maka-owner-id={session.id}
       data-active={active}
       data-editing={editing}
       data-menu-open={menuOpen ? 'true' : undefined}
@@ -823,6 +825,7 @@ const SessionRow = memo(function SessionRow(props: {
       onFocus={() => setActionsVisible(true)}
       onBlur={handleRowBlur}
     >
+      <div className="maka-skin-slot" data-maka-slot="session-row-before" data-maka-owner-id={session.id} />
       {editing ? (
         <form
           className="maka-list-row-main"
@@ -967,6 +970,7 @@ const SessionRow = memo(function SessionRow(props: {
           )}
         </BaseButton>
       )}
+      <div className="maka-skin-slot" data-maka-slot="session-row-after" data-maka-owner-id={session.id} />
       {actions && !editing && (
         <Menu open={menuOpen} onOpenChange={setMenuOpen}>
           <MenuTrigger

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -48,6 +48,7 @@ export function SessionListPanel(props: {
     <aside
       className="maka-session-panel agents-sidebar"
       aria-label={copy.listAriaLabel}
+      data-maka-part="session-list"
     >
       <SessionSidebarNav
         selection={props.selection}
@@ -77,6 +78,7 @@ export function SessionListPanel(props: {
           </Menu>
         </div>
       )}
+      <div className="maka-skin-slot" data-maka-slot="session-list-before" />
       <SessionHistoryList
         sessions={props.sessions}
         activeId={props.activeId}
@@ -90,6 +92,7 @@ export function SessionListPanel(props: {
         onSelectSession={props.onSelectSession}
         rowActions={props.rowActions}
       />
+      <div className="maka-skin-slot" data-maka-slot="session-list-after" />
       <SessionSidebarFooter
         updateReminder={props.updateReminder}
         onOpenSettings={props.onOpenSettings}

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -216,11 +216,14 @@ function ToolActivityCard({ item, open: openProp }: { item: ToolActivityItem; op
   return (
     <Collapsible
       data-slot="tool"
+      data-maka-part="tool-card"
+      data-maka-owner-id={item.toolUseId}
       className={toolVariants({ part: 'item' })}
       data-status={visualStatus}
       open={open}
       onOpenChange={disclosure.setOpen}
     >
+      <div className="maka-skin-slot" data-maka-slot="tool-before" data-maka-owner-id={item.toolUseId} />
       <CollapsibleTrigger className={toolVariants({ part: 'header' })}>
         <span className={toolVariants({ part: 'dot' })} data-status={visualStatus} aria-hidden="true" />
         <span className={toolVariants({ part: 'name' })}>{resolveToolDisplayName(item, locale)}</span>
@@ -232,6 +235,7 @@ function ToolActivityCard({ item, open: openProp }: { item: ToolActivityItem; op
       <CollapsiblePanel>
         <ToolCardBody item={item} />
       </CollapsiblePanel>
+      <div className="maka-skin-slot" data-maka-slot="tool-after" data-maka-owner-id={item.toolUseId} />
     </Collapsible>
   );
 }
@@ -483,7 +487,11 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
       </CollapsibleTrigger>
       <CollapsiblePanel>
         {items.length === 1 ? (
-          <ToolCardBody item={items[0]!} />
+          <div data-maka-part="tool-card" data-maka-owner-id={items[0]!.toolUseId}>
+            <div className="maka-skin-slot" data-maka-slot="tool-before" data-maka-owner-id={items[0]!.toolUseId} />
+            <ToolCardBody item={items[0]!} />
+            <div className="maka-skin-slot" data-maka-slot="tool-after" data-maka-owner-id={items[0]!.toolUseId} />
+          </div>
         ) : (
           <div className="mt-0.5 ml-2 flex flex-col gap-0.5 border-l border-[var(--border)] pl-2.5">
             {items.map((item) => (
@@ -529,42 +537,46 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
   // spell out whether the operation failed or the sandbox blocked it.
   const rowLabel = item.intent ? formatToolIntent(item.intent) : resolveToolDisplayName(item, locale);
   return (
-    <Collapsible className="flex flex-col" data-trow="row" data-status={sandboxBlocked ? 'blocked' : item.status} data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
-      <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">
-        <ToolKindIcon
-          kind={presentation.kind}
-          size={16}
-          aria-hidden="true"
-          className={cn('shrink-0', summaryTone)}
-        />
-        {running ? (
-          <TextShimmer active delayed className="min-w-0 truncate text-[length:var(--font-size-base)]">{presentation.summary}</TextShimmer>
-        ) : (
-          <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone)}>
-            {errored
-              ? `${rowLabel} · ${getToolActivityCopy(locale).group.failedSuffix}`
-              : sandboxBlocked
-                ? `${rowLabel} · ${getToolActivityCopy(locale).group.sandboxBlockedSuffix}`
-                : rowLabel}
-          </span>
-        )}
-        {/* Quiet meta sits right after the label (near the text, not pinned to
-            the far edge): duration + chevron ride in on hover / open, matching
-            the multi-tool summary row — status is carried by the shimmer /
-            destructive tint, so no always-on status word. */}
-        <span className="inline-flex shrink-0 items-center gap-2 text-[length:var(--font-size-caption)] text-[color:var(--muted-foreground)] opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover:opacity-100 group-data-[panel-open]:opacity-100">
-          {duration && <span className="[font-variant-numeric:tabular-nums]">{duration}</span>}
-          <ChevronRight
-            size={14}
+    <div className="flex flex-col" data-maka-part="tool-card" data-maka-owner-id={item.toolUseId}>
+      <div className="maka-skin-slot" data-maka-slot="tool-before" data-maka-owner-id={item.toolUseId} />
+      <Collapsible className="flex flex-col" data-trow="row" data-status={sandboxBlocked ? 'blocked' : item.status} data-settled={settled ? 'true' : undefined} open={disclosure.open} onOpenChange={disclosure.setOpen}>
+        <CollapsibleTrigger className="group flex w-full items-center gap-2 py-0.5 text-left">
+          <ToolKindIcon
+            kind={presentation.kind}
+            size={16}
             aria-hidden="true"
-            className="[transition:transform_var(--duration-quick)_var(--ease-out-strong)] group-data-[panel-open]:rotate-90"
+            className={cn('shrink-0', summaryTone)}
           />
-        </span>
-      </CollapsibleTrigger>
-      <CollapsiblePanel>
-        <ToolCardBody item={item} />
-      </CollapsiblePanel>
-    </Collapsible>
+          {running ? (
+            <TextShimmer active delayed className="min-w-0 truncate text-[length:var(--font-size-base)]">{presentation.summary}</TextShimmer>
+          ) : (
+            <span className={cn('min-w-0 truncate text-[length:var(--font-size-base)]', summaryTone)}>
+              {errored
+                ? `${rowLabel} · ${getToolActivityCopy(locale).group.failedSuffix}`
+                : sandboxBlocked
+                  ? `${rowLabel} · ${getToolActivityCopy(locale).group.sandboxBlockedSuffix}`
+                  : rowLabel}
+            </span>
+          )}
+          {/* Quiet meta sits right after the label (near the text, not pinned to
+              the far edge): duration + chevron ride in on hover / open, matching
+              the multi-tool summary row — status is carried by the shimmer /
+              destructive tint, so no always-on status word. */}
+          <span className="inline-flex shrink-0 items-center gap-2 text-[length:var(--font-size-caption)] text-[color:var(--muted-foreground)] opacity-0 [transition:opacity_var(--duration-quick)_var(--ease-out-strong)] group-hover:opacity-100 group-data-[panel-open]:opacity-100">
+            {duration && <span className="[font-variant-numeric:tabular-nums]">{duration}</span>}
+            <ChevronRight
+              size={14}
+              aria-hidden="true"
+              className="[transition:transform_var(--duration-quick)_var(--ease-out-strong)] group-data-[panel-open]:rotate-90"
+            />
+          </span>
+        </CollapsibleTrigger>
+        <CollapsiblePanel>
+          <ToolCardBody item={item} />
+        </CollapsiblePanel>
+      </Collapsible>
+      <div className="maka-skin-slot" data-maka-slot="tool-after" data-maka-owner-id={item.toolUseId} />
+    </div>
   );
 }
 

--- a/scripts/check-console.mjs
+++ b/scripts/check-console.mjs
@@ -52,6 +52,10 @@ const ALLOW = new Map([
     'real-window smoke diagnostics are dev/test gated and stdout-parsed by capture tooling.',
   ],
   [
+    'apps/desktop/src/main/skin-runtime.ts',
+    'skin lifecycle diagnostics and the explicit skin development log API; isolated renderer output contains no Node or preload-bridge data.',
+  ],
+  [
     'apps/desktop/src/main/permission-overlay/permission-overlay-main.ts',
     '#1515 drag-grant diagnostics (locale fallback, missing .app bundle, controller log sink); main-process only, paths not secrets.',
   ],


### PR DESCRIPTION
## Summary

- add a native `.maka-skin` runtime for importing, updating, activating, reloading, disabling, and removing high-freedom desktop skins without rebuilding Maka
- support full CSS plus isolated-world JavaScript for DOM anchors, Canvas/WebGL, packaged assets, namespaced storage, and runtime-generated styles
- expose versioned host APIs for appearance snapshots, resolved design tokens, accessibility preferences, environment changes, UI state, lifecycle cleanup, and conditional React surfaces
- keep the normal Maka appearance path authoritative so light/dark/auto, palette persistence, startup cache, Electron native theme, and Windows title-bar colors stay synchronized
- publish stable `data-maka-part` anchors for shell, chat, transcript, composer, settings, and command palette surfaces
- add atomic in-place skin updates with rollback on activation failure, manual reload, uninstall confirmation, preview rendering, crash-loop circuit breaking, and `--disable-skins` safe mode
- include authoring TypeScript declarations, a JSON manifest schema, expanded documentation, and an adaptive Neon Orbit example skin

## Verification

- desktop TypeScript check passed
- desktop production build with dependencies passed
- dedicated skin runtime tests passed (7/7), including update rollback
- full desktop test suite passed (3000/3000)
- console, accessibility, visible-copy, and third-party-notice checks passed

## Review focus

- isolated-world/full-DOM trust boundary and the long-term permission model
- stability and versioning policy for the host API and `data-maka-part` catalog
- atomic package update, crash recovery, and safe-mode behavior
- whether signed distribution should remain a follow-up or be required before release

## Follow-up work

- [ ] decide the signed-skin trust and distribution model
- [ ] add skin marketplace / online sharing separately
