### PR TITLE
storage: migrate workflow state to SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,28 @@ validation are one SQLite transaction, retries are idempotent, and a changed
 legacy source after cutover fails closed. The legacy files are retained only as
 migration evidence; new execution writes do not modify them.
 
+Workflow state is migrating in reviewable slices. Task Ledger events and
+projections, Plan events and projections, Deep Research events, Agent Mailbox
+messages, and Plan Reminder records are now canonical in `runtime.sqlite`.
+Desktop and Runtime Host production wiring opens these SQLite repositories;
+their JSON/JSONL predecessors are read only during a fingerprinted, crash-safe
+cutover and are never updated by later mutations.
+
+The remaining structured operational stores are deliberately classified rather
+than implied complete:
+
+- usage telemetry and pricing authority move in the next workflow-metadata
+  slice;
+- artifact metadata and lifecycle state move with a recoverable
+  metadata/payload publication protocol, while payload bytes remain files;
+- StoredMessage transcript bodies remain append-only JSONL;
+- automation, connections, credentials, settings, MCP configuration, skills,
+  and device identity are configuration state and stay outside this operational
+  migration;
+- Headless TaskRun evaluation ledgers, imported foreign-session caches, Daily
+  Review archives, and quote-cleanup bookkeeping are separate product/evaluation
+  domains and are not part of issue #1649.
+
 Runtime continuation remains opt-in:
 
 - `MAKA_RUNTIME_SAFE_BOUNDARY_RESUME=1` enables the Desktop interrupted-turn

--- a/apps/desktop/src/main/__tests__/agent-team-collaboration-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-team-collaboration-contract.test.ts
@@ -11,7 +11,7 @@ describe('desktop agent-team collaboration wiring', () => {
   it('shares one durable mailbox/task ledger across lead and child tools', async () => {
     const main = await readMainProcessCombinedSource();
 
-    assert.match(main, /const agentMailboxStore = createAgentMailboxStore\(workspaceRoot\)/);
+    assert.match(main, /const agentMailboxStore = createSqliteAgentMailboxStore\(workspaceRoot\)/);
     assert.match(
       main,
       /buildAgentTeamLeadTools\(\{[\s\S]*?mailbox: agentMailboxStore,[\s\S]*?taskLedger: taskLedgerStore/,

--- a/apps/desktop/src/main/__tests__/deep-research-workspace-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/deep-research-workspace-contract.test.ts
@@ -28,7 +28,7 @@ describe('Deep Research durable workspace wiring', () => {
       'utf8',
     );
 
-    assert.match(main, /const deepResearchStore = createDeepResearchStore\(workspaceRoot\)/);
+    assert.match(main, /const deepResearchStore = createSqliteDeepResearchStore\(workspaceRoot\)/);
     assert.match(main, /const deepResearchTools = buildDeepResearchTools\(\{/);
     assert.match(main, /onArtifactCreated: \(event\) => safeSendToRenderer\('artifacts:changed', event\)/);
     assert.match(

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -70,6 +70,7 @@ export interface AppLifecycleDeps {
   shellRuns: ShellRunProcessManager;
   mcpManager: McpClientManager;
   runtimePersistence: Awaited<ReturnType<typeof openRuntimeEventPersistence>>;
+  closeWorkflowStores: () => Promise<void>;
   mainWindowController: ReturnType<typeof createMainWindowController>;
   runtime: SessionManager;
   agentGraphCoordinator: AgentGraphCoordinator;
@@ -123,6 +124,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     shellRuns,
     mcpManager,
     runtimePersistence,
+    closeWorkflowStores,
     mainWindowController,
     runtime,
     agentGraphCoordinator,
@@ -349,6 +351,11 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     ]);
     for (const result of results) {
       if (result.status === 'rejected') console.error('[shutdown] cleanup failed:', result.reason);
+    }
+    try {
+      await closeWorkflowStores();
+    } catch (error) {
+      console.error('[shutdown] cleanup failed:', error);
     }
     runtimePersistence.close();
     agentGraphControlStore.close();

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -59,14 +59,14 @@ import type {
 import type { LlmConnection } from '@maka/core/llm-connections';
 import {
   createAgentRunStore,
-  createAgentMailboxStore,
+  createSqliteAgentMailboxStore,
   createArtifactStore,
-  createDeepResearchStore,
+  createSqliteDeepResearchStore,
   createReadImageSnapshotter,
   createConnectionStore,
   createGitWorktreeChildExecutor,
-  createPlanReminderStore,
-  createPlanStore,
+  createSqlitePlanReminderStore,
+  createSqlitePlanStore,
   createProjectCatalog,
   openRuntimeEventPersistence,
   createSessionStore,
@@ -269,7 +269,7 @@ const store = createSessionStore(workspaceRoot);
 const agentGraphControlStore = createAgentGraphControlStore(workspaceRoot);
 const projectCatalog = createProjectCatalog(workspaceRoot);
 const worktreeChildExecutor = createGitWorktreeChildExecutor({ storageRoot: workspaceRoot });
-const planStore = createPlanStore(workspaceRoot);
+const planStore = createSqlitePlanStore(workspaceRoot);
 const runStore = createAgentRunStore(workspaceRoot);
 const runtimePersistence = await openRuntimeEventPersistence({
   workspaceRoot,
@@ -294,7 +294,7 @@ function ensureMcpReady(): Promise<void> {
 const telemetryRepo = createTelemetryRepo(workspaceRoot);
 const dailyReviewArchiveStore = createDailyReviewArchiveStore(workspaceRoot);
 const artifactStore = createArtifactStore(workspaceRoot);
-const deepResearchStore = createDeepResearchStore(workspaceRoot);
+const deepResearchStore = createSqliteDeepResearchStore(workspaceRoot);
 const storeReadImage = createReadImageSnapshotter(artifactStore);
 const attachmentApprovals = createAttachmentApprovalRegistry();
 // PR-OAUTH-SUBSCRIPTION-0: Claude subscription OAuth service.
@@ -397,10 +397,32 @@ const antigravitySubscription = new AntigravitySubscriptionService({
   credentialStore,
 });
 
-const planReminderStore = createPlanReminderStore(workspaceRoot);
+const planReminderStore = createSqlitePlanReminderStore(workspaceRoot);
 const taskLedgerWiring = createMainTaskLedgerWiring(workspaceRoot);
 const taskLedgerStore = taskLedgerWiring.store;
-const agentMailboxStore = createAgentMailboxStore(workspaceRoot);
+const agentMailboxStore = createSqliteAgentMailboxStore(workspaceRoot);
+
+async function closeWorkflowStores(): Promise<void> {
+  const stores = [
+    planStore,
+    deepResearchStore,
+    planReminderStore,
+    taskLedgerStore,
+    agentMailboxStore,
+  ];
+  const errors: unknown[] = [];
+  for (const result of await Promise.allSettled(stores.map((workflowStore) => workflowStore.ready()))) {
+    if (result.status === 'rejected') errors.push(result.reason);
+  }
+  for (const workflowStore of stores) {
+    try {
+      workflowStore.close();
+    } catch (error) {
+      errors.push(error);
+    }
+  }
+  if (errors.length > 0) throw new AggregateError(errors, 'Unable to close workflow stores');
+}
 
 const sessionActivities = new SessionActivityRegistry();
 
@@ -1430,6 +1452,7 @@ wireAppLifecycle({
   shellRuns,
   mcpManager,
   runtimePersistence,
+  closeWorkflowStores,
   mainWindowController,
   runtime,
   agentGraphCoordinator,

--- a/apps/desktop/src/main/task-ledger-wiring.ts
+++ b/apps/desktop/src/main/task-ledger-wiring.ts
@@ -1,5 +1,8 @@
 import type { TaskLedgerStore } from '@maka/core';
-import { createTaskLedgerStore } from '@maka/storage';
+import {
+  createSqliteTaskLedgerStore,
+  type SqliteTaskLedgerStore,
+} from '@maka/storage';
 import { buildTaskLedgerTools, isTaskLedgerToolsEnabled, type MakaTool } from '@maka/runtime';
 
 /**
@@ -12,13 +15,13 @@ import { buildTaskLedgerTools, isTaskLedgerToolsEnabled, type MakaTool } from '@
  */
 export interface MainTaskLedgerWiring {
   /** Per-session task ledger store; shared by tools (mutate) and turn tail (read). */
-  store: TaskLedgerStore;
+  store: TaskLedgerStore & SqliteTaskLedgerStore;
   /** task_create/task_update/task_list/task_get bound to {@link store}. */
   tools: MakaTool[];
 }
 
 export function createMainTaskLedgerWiring(workspaceRoot: string): MainTaskLedgerWiring {
-  const store = createTaskLedgerStore(workspaceRoot);
+  const store = createSqliteTaskLedgerStore(workspaceRoot);
   return {
     store,
     tools: isTaskLedgerToolsEnabled()

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -43,13 +43,16 @@ export async function createExecutionRuntimeHostComposition(
 ): Promise<RuntimeHostComposition> {
   const stores = await openInteractiveExecutionStoresForWrite(context.owner.lease);
   let graphControlStore: ReturnType<typeof createAgentGraphControlStore> | undefined;
+  let taskLedgerStore:
+    | Awaited<ReturnType<typeof openInteractiveTaskLedgerStoreForWrite>>
+    | undefined;
   let usageStores: Awaited<ReturnType<typeof openInteractiveUsageStoresForWrite>> | undefined;
   try {
     const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
       context.owner.lease,
     );
     const memoryStore = await openInteractiveMemoryBundleStoreForWrite(context.owner.lease);
-    const taskLedgerStore = await openInteractiveTaskLedgerStoreForWrite(context.owner.lease);
+    taskLedgerStore = await openInteractiveTaskLedgerStoreForWrite(context.owner.lease);
     const openedArtifactStore = await openInteractiveArtifactStoreForWrite(context.owner.lease);
     const openedUsageStores = await openInteractiveUsageStoresForWrite(context.owner.lease);
     usageStores = openedUsageStores;
@@ -388,6 +391,11 @@ export async function createExecutionRuntimeHostComposition(
           errors.push(error);
         }
         try {
+          taskLedgerStore?.close();
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
           await stores.sessionStore.close?.();
         } catch (error) {
           errors.push(error);
@@ -420,6 +428,11 @@ export async function createExecutionRuntimeHostComposition(
     }
     try {
       await usageStores?.close();
+    } catch (closeError) {
+      errors.push(closeError);
+    }
+    try {
+      taskLedgerStore?.close();
     } catch (closeError) {
       errors.push(closeError);
     }

--- a/packages/storage/src/__tests__/operational-state-store.test.ts
+++ b/packages/storage/src/__tests__/operational-state-store.test.ts
@@ -44,6 +44,7 @@ describe('operational state database cutover', () => {
           { scope: 'operational', version: 1 },
           { scope: 'runtime', version: 5 },
           { scope: 'session_metadata', version: SQLITE_SESSION_METADATA_SCHEMA_VERSION },
+          { scope: 'workflow', version: 1 },
         ],
       );
       assert.deepEqual(

--- a/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
@@ -195,10 +195,7 @@ describe('SQLite workflow cutover', () => {
         reopenedReminders.ready(),
       ]);
       assert.equal((await reopenedTasks.get(SESSION_ID, legacyTask.id))?.status, 'in_progress');
-      assert.equal(
-        (await reopenedPlan.readState(SESSION_ID)).proposals[0]?.status,
-        'stale',
-      );
+      assert.equal((await reopenedPlan.readState(SESSION_ID)).proposals[0]?.status, 'stale');
       assert.equal((await reopenedResearch.readEvents(SESSION_ID)).length, 2);
       assert.equal(
         (

--- a/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-workflow-store.test.ts
@@ -1,0 +1,282 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { describe, test } from 'node:test';
+import { createAgentMailboxStore, createSqliteAgentMailboxStore } from '../agent-mailbox-store.js';
+import { createDeepResearchStore, createSqliteDeepResearchStore } from '../deep-research-store.js';
+import { createPlanReminderStore, createSqlitePlanReminderStore } from '../plan-reminder-store.js';
+import { createPlanStore, createSqlitePlanStore } from '../plan-store.js';
+import { createSqliteTaskLedgerStore, createTaskLedgerStore } from '../task-ledger-store.js';
+import { acquireOperationalStateDatabase } from '../operational-state-store.js';
+
+const SESSION_ID = 'session-workflow';
+
+describe('SQLite workflow cutover', () => {
+  test('imports every workflow ledger once and keeps later writes SQLite-only', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-sqlite-workflow-'));
+    let planId = 0;
+    let researchId = 0;
+    let mailboxId = 0;
+    try {
+      const legacyTasks = createTaskLedgerStore(root);
+      const {
+        created: [legacyTask],
+      } = await legacyTasks.create(SESSION_ID, [{ subject: 'Migrate workflow state' }]);
+      assert.ok(legacyTask);
+
+      const legacyPlan = createPlanStore(root, {
+        newId: () => `plan-id-${++planId}`,
+        now: () => 100 + planId,
+      });
+      const submitted = await legacyPlan.submitProposal({
+        sessionId: SESSION_ID,
+        turnId: 'turn-plan',
+        title: 'Workflow migration',
+        steps: [{ id: 'migrate', title: 'Migrate state', description: 'Move state to SQLite' }],
+      });
+
+      const legacyResearch = createDeepResearchStore(root, {
+        newId: () => `research-id-${++researchId}`,
+        now: () => 200 + researchId,
+      });
+      await legacyResearch.start(SESSION_ID, 'Map the workflow stores', 'deep');
+
+      const legacyMailbox = createAgentMailboxStore(root, {
+        newId: () => `mail-${++mailboxId}`,
+        now: () => 300 + mailboxId,
+      });
+      await legacyMailbox.send(SESSION_ID, {
+        teamId: 'workflow-team',
+        parentRunId: 'parent-run',
+        kind: 'message',
+        from: {
+          role: 'member',
+          agentId: 'worker-a',
+          runId: 'run-a',
+          turnId: 'turn-a',
+        },
+        to: { role: 'member', agentId: 'worker-b' },
+        content: 'Legacy mailbox row',
+      });
+
+      const legacyReminders = createPlanReminderStore(root);
+      const legacyReminder = await legacyReminders.create({
+        title: 'Review migration',
+        runAt: Date.now() + 60_000,
+      });
+
+      const legacyPaths = [
+        join(root, 'sessions', SESSION_ID, 'task-events.jsonl'),
+        join(root, 'sessions', SESSION_ID, 'tasks.json'),
+        join(root, 'sessions', SESSION_ID, 'plan-events.jsonl'),
+        join(root, 'sessions', SESSION_ID, 'plans.json'),
+        join(root, 'sessions', SESSION_ID, 'deep-research', 'events.jsonl'),
+        join(root, 'sessions', SESSION_ID, 'agent-mailbox.jsonl'),
+        join(root, 'plan-reminders.json'),
+      ];
+      const before = await Promise.all(legacyPaths.map((path) => readFile(path, 'utf8')));
+
+      const tasks = createSqliteTaskLedgerStore(root);
+      const plan = createSqlitePlanStore(root, {
+        newId: () => `sqlite-plan-${++planId}`,
+        now: () => 400 + planId,
+      });
+      const research = createSqliteDeepResearchStore(root, {
+        newId: () => `sqlite-research-${++researchId}`,
+        now: () => 500 + researchId,
+      });
+      const mailbox = createSqliteAgentMailboxStore(root, {
+        newId: () => `sqlite-mail-${++mailboxId}`,
+        now: () => 600 + mailboxId,
+      });
+      const reminders = createSqlitePlanReminderStore(root);
+      await Promise.all([
+        tasks.ready(),
+        plan.ready(),
+        research.ready(),
+        mailbox.ready(),
+        reminders.ready(),
+      ]);
+
+      assert.equal((await tasks.get(SESSION_ID, legacyTask.id))?.subject, legacyTask.subject);
+      assert.equal(
+        (await plan.readState(SESSION_ID)).latestProposalId,
+        submitted.state.latestProposalId,
+      );
+      assert.equal((await research.read(SESSION_ID))?.objective, 'Map the workflow stores');
+      assert.equal(
+        (
+          await mailbox.list(SESSION_ID, {
+            teamId: 'workflow-team',
+            parentRunId: 'parent-run',
+            recipientAgentId: 'worker-b',
+          })
+        ).messages.length,
+        1,
+      );
+      assert.equal((await reminders.list())[0]?.id, legacyReminder.id);
+
+      await tasks.update(SESSION_ID, legacyTask.id, { status: 'in_progress' });
+      await plan.requestRevision({
+        sessionId: SESSION_ID,
+        proposalId: submitted.state.latestProposalId!,
+      });
+      await research.recordArtifact(SESSION_ID, {
+        artifactId: 'artifact-1',
+        role: 'source',
+        name: 'source.md',
+        createdAt: 501,
+        locator: 'https://example.com/source',
+        contentHash: `sha256:${'a'.repeat(64)}`,
+        sourceArtifactIds: [],
+      });
+      await mailbox.send(SESSION_ID, {
+        teamId: 'workflow-team',
+        parentRunId: 'parent-run',
+        kind: 'broadcast',
+        from: {
+          role: 'member',
+          agentId: 'worker-a',
+          runId: 'run-a',
+          turnId: 'turn-a',
+        },
+        content: 'SQLite mailbox row',
+      });
+      await reminders.setEnabled(legacyReminder.id, false);
+
+      assert.deepEqual(
+        await Promise.all(legacyPaths.map((path) => readFile(path, 'utf8'))),
+        before,
+      );
+
+      const lease = acquireOperationalStateDatabase(root);
+      try {
+        const counts = lease.database
+          .prepare(`
+            SELECT
+              (SELECT COUNT(*) FROM workflow_task_ledger_events) AS tasks,
+              (SELECT COUNT(*) FROM workflow_plan_events) AS plans,
+              (SELECT COUNT(*) FROM workflow_deep_research_events) AS research,
+              (SELECT COUNT(*) FROM workflow_agent_mailbox_messages) AS mailbox,
+              (SELECT COUNT(*) FROM workflow_plan_reminders) AS reminders
+          `)
+          .get() as Record<string, number>;
+        assert.deepEqual(
+          { ...counts },
+          {
+            tasks: 2,
+            plans: 2,
+            research: 2,
+            mailbox: 2,
+            reminders: 1,
+          },
+        );
+      } finally {
+        lease.close();
+      }
+
+      tasks.close();
+      plan.close();
+      research.close();
+      mailbox.close();
+      reminders.close();
+
+      const reopenedTasks = createSqliteTaskLedgerStore(root);
+      const reopenedPlan = createSqlitePlanStore(root);
+      const reopenedResearch = createSqliteDeepResearchStore(root);
+      const reopenedMailbox = createSqliteAgentMailboxStore(root);
+      const reopenedReminders = createSqlitePlanReminderStore(root);
+      await Promise.all([
+        reopenedTasks.ready(),
+        reopenedPlan.ready(),
+        reopenedResearch.ready(),
+        reopenedMailbox.ready(),
+        reopenedReminders.ready(),
+      ]);
+      assert.equal((await reopenedTasks.get(SESSION_ID, legacyTask.id))?.status, 'in_progress');
+      assert.equal(
+        (await reopenedPlan.readState(SESSION_ID)).proposals[0]?.status,
+        'stale',
+      );
+      assert.equal((await reopenedResearch.readEvents(SESSION_ID)).length, 2);
+      assert.equal(
+        (
+          await reopenedMailbox.list(SESSION_ID, {
+            teamId: 'workflow-team',
+            parentRunId: 'parent-run',
+            recipientAgentId: 'worker-b',
+          })
+        ).messages.length,
+        2,
+      );
+      assert.equal(
+        (await reopenedReminders.list()).find((reminder) => reminder.id === legacyReminder.id)
+          ?.enabled,
+        false,
+      );
+      reopenedTasks.close();
+      reopenedPlan.close();
+      reopenedResearch.close();
+      reopenedMailbox.close();
+      reopenedReminders.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('rolls back a copied workflow ledger and resumes the same cutover', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-sqlite-workflow-crash-'));
+    try {
+      await createTaskLedgerStore(root).create(SESSION_ID, [{ subject: 'Crash-safe import' }]);
+      const interrupted = createSqliteTaskLedgerStore(root, {
+        failpoint: (point) => {
+          if (point === 'after_cutover_rows_copied') throw new Error('simulated crash');
+        },
+      });
+      await assert.rejects(interrupted.ready(), /simulated crash/);
+      interrupted.close();
+
+      const resumed = createSqliteTaskLedgerStore(root);
+      await resumed.ready();
+      assert.equal((await resumed.list(SESSION_ID)).length, 1);
+      const lease = acquireOperationalStateDatabase(root);
+      try {
+        const row = lease.database
+          .prepare(`
+            SELECT state
+            FROM cutover_journal
+            WHERE store_name = 'workflow_task_ledger'
+          `)
+          .get() as { state?: unknown };
+        assert.equal(row.state, 'completed');
+      } finally {
+        lease.close();
+      }
+      resumed.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test('fails closed if a legacy workflow ledger changes after cutover', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'maka-sqlite-workflow-fingerprint-'));
+    try {
+      const legacy = createTaskLedgerStore(root);
+      await legacy.create(SESSION_ID, [{ subject: 'Imported task' }]);
+      const migrated = createSqliteTaskLedgerStore(root);
+      await migrated.ready();
+      migrated.close();
+
+      await legacy.create(SESSION_ID, [{ subject: 'Unexpected legacy write' }]);
+      const reopened = createSqliteTaskLedgerStore(root);
+      await assert.rejects(
+        reopened.ready(),
+        /Legacy workflow_task_ledger source changed after cutover completed/,
+      );
+      reopened.close();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+});

--- a/packages/storage/src/__tests__/task-ledger-authority.test.ts
+++ b/packages/storage/src/__tests__/task-ledger-authority.test.ts
@@ -39,6 +39,13 @@ describe('interactive task ledger authority', () => {
 
         assert.equal(changes.length, 1);
         assert.deepEqual(changes[0], [result.created[0]?.id]);
+
+        first.close();
+        assert.throws(() => authenticateInteractiveTaskLedgerWriter(first), isInvalidLease);
+        const reopened = await openInteractiveTaskLedgerStoreForWrite(owner.lease);
+        assert.notEqual(reopened, first);
+        assert.equal((await reopened.list(SESSION_ID)).length, 1);
+        reopened.close();
       } finally {
         if (!owner.closed) await owner.close();
       }
@@ -46,32 +53,35 @@ describe('interactive task ledger authority', () => {
   });
 
   test('reads a current legacy tasks.json as canonical when no event ledger exists', async () => {
-    await withInteractiveOwner(async ({ root, writer }) => {
-      await mkdir(join(root, 'sessions', SESSION_ID), { recursive: true });
-      await writeFile(
-        tasksPath(root),
-        JSON.stringify([
-          {
-            id: 'legacy-task',
-            subject: 'legacy canonical task',
-            status: 'pending',
-            createdAt: 1,
-            updatedAt: 1,
-          },
-        ]),
-        'utf8',
-      );
-
-      const listed = await writer.list(SESSION_ID);
-      assert.equal(listed.length, 1);
-      assert.equal(listed[0]?.id, 'legacy-task');
-      assert.equal(listed[0]?.key, 'T1');
-      assert.equal((await writer.get(SESSION_ID, 'T1'))?.subject, 'legacy canonical task');
-    });
+    await withInteractiveOwner(
+      async ({ writer }) => {
+        const listed = await writer.list(SESSION_ID);
+        assert.equal(listed.length, 1);
+        assert.equal(listed[0]?.id, 'legacy-task');
+        assert.equal(listed[0]?.key, 'T1');
+        assert.equal((await writer.get(SESSION_ID, 'T1'))?.subject, 'legacy canonical task');
+      },
+      async (root) => {
+        await mkdir(join(root, 'sessions', SESSION_ID), { recursive: true });
+        await writeFile(
+          tasksPath(root),
+          JSON.stringify([
+            {
+              id: 'legacy-task',
+              subject: 'legacy canonical task',
+              status: 'pending',
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ]),
+          'utf8',
+        );
+      },
+    );
   });
 
   test('fails closed on a corrupt event ledger even when a legacy cache exists', async () => {
-    await withInteractiveOwner(async ({ root, writer }) => {
+    await withInteractiveRoot(async ({ root, capability }) => {
       await mkdir(join(root, 'sessions', SESSION_ID), { recursive: true });
       await writeFile(
         tasksPath(root),
@@ -87,13 +97,17 @@ describe('interactive task ledger authority', () => {
         'utf8',
       );
       await writeFile(eventsPath(root), '{"not":"a task event"}\n', 'utf8');
-
-      await assert.rejects(() => writer.list(SESSION_ID), /Invalid task event JSONL line/);
-      await assert.rejects(() => writer.get(SESSION_ID, 'cached-task'), /Invalid task event JSONL/);
-      await assert.rejects(
-        () => writer.create(SESSION_ID, [{ subject: 'must not overwrite' }]),
-        /Invalid task event JSONL/,
-      );
+      const owner = await tryAcquireInteractiveRootOwner(capability);
+      assert.ok(owner);
+      if (!owner) return;
+      try {
+        await assert.rejects(
+          () => openInteractiveTaskLedgerStoreForWrite(owner.lease),
+          /Invalid task event JSONL line/,
+        );
+      } finally {
+        if (!owner.closed) await owner.close();
+      }
     });
   });
 
@@ -111,6 +125,7 @@ describe('interactive task ledger authority', () => {
         () => writer.create(SESSION_ID, [{ subject: 'after close' }]),
         isInvalidLease,
       );
+      writer.close();
     });
   });
 
@@ -146,17 +161,22 @@ describe('interactive task ledger authority', () => {
 
 async function withInteractiveOwner(
   run: (input: { root: string; writer: InteractiveTaskLedgerWriter }) => Promise<void>,
+  prepare?: (root: string) => Promise<void>,
 ): Promise<void> {
   await withInteractiveRoot(async ({ root, capability }) => {
+    await prepare?.(root);
     const owner = await tryAcquireInteractiveRootOwner(capability);
     assert.ok(owner);
     if (!owner) return;
+    let writer: InteractiveTaskLedgerWriter | undefined;
     try {
+      writer = await openInteractiveTaskLedgerStoreForWrite(owner.lease);
       await run({
         root,
-        writer: await openInteractiveTaskLedgerStoreForWrite(owner.lease),
+        writer,
       });
     } finally {
+      writer?.close();
       if (!owner.closed) await owner.close();
     }
   });

--- a/packages/storage/src/agent-mailbox-store.ts
+++ b/packages/storage/src/agent-mailbox-store.ts
@@ -1,6 +1,7 @@
-import { appendFile, mkdir, readFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { randomUUID } from 'node:crypto';
+import { appendFile, mkdir, readFile, readdir } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+import type { DatabaseSync } from 'node:sqlite';
 import {
   AGENT_MAILBOX_LIST_MAX,
   AGENT_MAILBOX_MAX_MESSAGES_PER_TEAM_RUN,
@@ -17,6 +18,12 @@ import {
 } from '@maka/core/agent-mailbox';
 import { assertSafeSessionId } from './session-store.js';
 import { chainWrite } from './write-queue.js';
+import {
+  acquireOperationalStateDatabase,
+  completeOperationalStoreCutover,
+  type OperationalStateDatabaseLease,
+  type OperationalStoreCutoverFailpoint,
+} from './operational-state-store.js';
 
 export interface AgentMailboxStoreDeps {
   newId?: () => string;
@@ -28,6 +35,22 @@ export function createAgentMailboxStore(
   deps: AgentMailboxStoreDeps = {},
 ): AgentMailboxStore {
   return new FileAgentMailboxStore(workspaceRoot, deps);
+}
+
+export interface SqliteAgentMailboxStore extends AgentMailboxStore {
+  ready(): Promise<void>;
+  close(): void;
+}
+
+export interface SqliteAgentMailboxStoreDeps extends AgentMailboxStoreDeps {
+  failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
+}
+
+export function createSqliteAgentMailboxStore(
+  workspaceRoot: string,
+  deps: SqliteAgentMailboxStoreDeps = {},
+): SqliteAgentMailboxStore {
+  return new SqliteAgentMailboxStoreImpl(workspaceRoot, deps);
 }
 
 class FileAgentMailboxStore implements AgentMailboxStore {
@@ -84,9 +107,7 @@ class FileAgentMailboxStore implements AgentMailboxStore {
       };
       if (!isAgentMailboxMessage(message))
         throw new Error('Generated agent mailbox message is invalid');
-      const path = this.filePath(sessionId);
-      await mkdir(dirname(path), { recursive: true });
-      await appendFile(path, `${JSON.stringify(message)}\n`, 'utf8');
+      await this.appendMessage(sessionId, message);
       total = scope.length + 1;
     });
     if (!message) throw new Error('Agent mailbox write did not produce a message');
@@ -120,7 +141,9 @@ class FileAgentMailboxStore implements AgentMailboxStore {
     return join(this.sessionsRoot, sessionId, 'agent-mailbox.jsonl');
   }
 
-  private async readAll(sessionId: string): Promise<AgentMailboxMessage[]> {
+  protected async readAll(sessionId: string): Promise<AgentMailboxMessage[]> {
+    const canonical = await this.readCanonicalMessages(sessionId);
+    if (canonical) return canonical;
     let text: string;
     try {
       text = await readFile(this.filePath(sessionId), 'utf8');
@@ -156,6 +179,226 @@ class FileAgentMailboxStore implements AgentMailboxStore {
     }
     return messages;
   }
+
+  protected async readCanonicalMessages(
+    _sessionId: string,
+  ): Promise<AgentMailboxMessage[] | undefined> {
+    return undefined;
+  }
+
+  protected async appendMessage(sessionId: string, message: AgentMailboxMessage): Promise<void> {
+    const path = this.filePath(sessionId);
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, `${JSON.stringify(message)}\n`, 'utf8');
+  }
+}
+
+class SqliteAgentMailboxStoreImpl extends FileAgentMailboxStore implements SqliteAgentMailboxStore {
+  readonly #lease: OperationalStateDatabaseLease;
+  readonly #ready: Promise<void>;
+
+  constructor(workspaceRoot: string, deps: SqliteAgentMailboxStoreDeps) {
+    super(workspaceRoot, deps);
+    const root = resolve(workspaceRoot);
+    this.#lease = acquireOperationalStateDatabase(root);
+    this.#ready = importLegacyAgentMailboxState(root, this.#lease, deps.failpoint);
+  }
+
+  ready(): Promise<void> {
+    return this.#ready;
+  }
+
+  close(): void {
+    this.#lease.close();
+  }
+
+  protected override async readCanonicalMessages(
+    sessionId: string,
+  ): Promise<AgentMailboxMessage[]> {
+    await this.#ready;
+    return readSqliteAgentMailboxMessages(this.#lease.database, sessionId);
+  }
+
+  protected override async appendMessage(
+    sessionId: string,
+    message: AgentMailboxMessage,
+  ): Promise<void> {
+    await this.#ready;
+    this.#lease.transaction('write', () => {
+      insertAgentMailboxMessage(this.#lease.database, sessionId, message);
+    });
+  }
+}
+
+interface LegacyAgentMailbox {
+  sessionId: string;
+  messages: AgentMailboxMessage[];
+}
+
+async function importLegacyAgentMailboxState(
+  root: string,
+  lease: OperationalStateDatabaseLease,
+  failpoint?: (point: OperationalStoreCutoverFailpoint) => void,
+): Promise<void> {
+  const ledgers = await readLegacyAgentMailboxes(root);
+  const fingerprint = `sha256:${createHash('sha256')
+    .update(JSON.stringify(ledgers))
+    .digest('hex')}`;
+  completeOperationalStoreCutover(lease, {
+    storeName: 'workflow_agent_mailbox',
+    sourcePath: join(root, 'sessions'),
+    sourceFingerprint: fingerprint,
+    failpoint,
+    importAndValidate: (database) => {
+      let messageCount = 0;
+      for (const ledger of ledgers) {
+        for (const message of ledger.messages) {
+          insertOrValidateAgentMailboxMessage(database, ledger.sessionId, message);
+          messageCount += 1;
+        }
+      }
+      const persisted = database
+        .prepare('SELECT COUNT(*) AS count FROM workflow_agent_mailbox_messages')
+        .get() as { count?: unknown };
+      if (persisted.count !== messageCount) {
+        throw new Error('Agent mailbox cutover row-count validation failed');
+      }
+      return { sessions: ledgers.length, messages: messageCount };
+    },
+  });
+}
+
+async function readLegacyAgentMailboxes(root: string): Promise<LegacyAgentMailbox[]> {
+  const sessionsRoot = join(root, 'sessions');
+  let entries;
+  try {
+    entries = await readdir(sessionsRoot, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+  const result: LegacyAgentMailbox[] = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isDirectory()) continue;
+    assertSafeSessionId(entry.name);
+    let text: string;
+    try {
+      text = await readFile(join(sessionsRoot, entry.name, 'agent-mailbox.jsonl'), 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw error;
+    }
+    result.push({
+      sessionId: entry.name,
+      messages: decodeAgentMailboxText(text, entry.name),
+    });
+  }
+  return result;
+}
+
+function decodeAgentMailboxText(text: string, sessionId: string): AgentMailboxMessage[] {
+  const messages: AgentMailboxMessage[] = [];
+  const seen = new Set<string>();
+  const lastByScope = new Map<string, number>();
+  for (const [index, line] of text.split(/\n/).entries()) {
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (error) {
+      throw new Error(`Invalid agent mailbox JSONL line ${index + 1}: ${String(error)}`);
+    }
+    if (!isAgentMailboxMessage(parsed) || parsed.sessionId !== sessionId || seen.has(parsed.id)) {
+      throw new Error(`Invalid agent mailbox JSONL line ${index + 1}: unexpected message shape`);
+    }
+    const scope = `${parsed.teamId}\u0000${parsed.parentRunId}`;
+    if (parsed.seq <= (lastByScope.get(scope) ?? 0)) {
+      throw new Error(`Invalid agent mailbox JSONL line ${index + 1}: non-monotonic sequence`);
+    }
+    seen.add(parsed.id);
+    lastByScope.set(scope, parsed.seq);
+    messages.push(parsed);
+  }
+  return messages;
+}
+
+function readSqliteAgentMailboxMessages(
+  database: DatabaseSync,
+  sessionId: string,
+): AgentMailboxMessage[] {
+  assertSafeSessionId(sessionId);
+  const rows = database
+    .prepare(`
+      SELECT record_json
+      FROM workflow_agent_mailbox_messages
+      WHERE session_id = ?
+      ORDER BY sequence
+    `)
+    .all(sessionId) as Array<{ record_json?: unknown }>;
+  return rows.map((row, index) => {
+    if (typeof row.record_json !== 'string') {
+      throw new Error(`Invalid SQLite agent mailbox message at sequence ${index}`);
+    }
+    const parsed = JSON.parse(row.record_json);
+    if (!isAgentMailboxMessage(parsed) || parsed.sessionId !== sessionId) {
+      throw new Error(`Invalid SQLite agent mailbox message at sequence ${index}`);
+    }
+    return parsed;
+  });
+}
+
+function insertAgentMailboxMessage(
+  database: DatabaseSync,
+  sessionId: string,
+  message: AgentMailboxMessage,
+): void {
+  const row = database
+    .prepare(`
+      SELECT COALESCE(MAX(sequence), -1) + 1 AS sequence
+      FROM workflow_agent_mailbox_messages
+      WHERE session_id = ?
+    `)
+    .get(sessionId) as { sequence?: unknown };
+  if (typeof row.sequence !== 'number' || !Number.isSafeInteger(row.sequence)) {
+    throw new Error('Invalid next agent mailbox sequence');
+  }
+  database
+    .prepare(`
+      INSERT INTO workflow_agent_mailbox_messages(
+        session_id, sequence, message_id, team_id, parent_run_id,
+        scope_sequence, record_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?)
+    `)
+    .run(
+      sessionId,
+      row.sequence,
+      message.id,
+      message.teamId,
+      message.parentRunId,
+      message.seq,
+      JSON.stringify(message),
+    );
+}
+
+function insertOrValidateAgentMailboxMessage(
+  database: DatabaseSync,
+  sessionId: string,
+  message: AgentMailboxMessage,
+): void {
+  const existing = database
+    .prepare(`
+      SELECT record_json
+      FROM workflow_agent_mailbox_messages
+      WHERE session_id = ? AND message_id = ?
+    `)
+    .get(sessionId, message.id) as { record_json?: unknown } | undefined;
+  if (existing) {
+    if (existing.record_json !== JSON.stringify(message)) {
+      throw new Error(`Agent mailbox cutover conflict: ${message.id}`);
+    }
+    return;
+  }
+  insertAgentMailboxMessage(database, sessionId, message);
 }
 
 function validateSendInput(input: AgentMailboxSendInput): void {

--- a/packages/storage/src/deep-research-store.ts
+++ b/packages/storage/src/deep-research-store.ts
@@ -1,6 +1,7 @@
-import { randomUUID } from 'node:crypto';
-import { mkdir, readFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, readFile, readdir } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
 import {
   isDeepResearchEvent,
   isDeepResearchScopeLevel,
@@ -22,6 +23,12 @@ import {
 import { assertSafeSessionId } from './session-store.js';
 import { appendJsonl } from './jsonl-append.js';
 import { chainWrite } from './write-queue.js';
+import {
+  acquireOperationalStateDatabase,
+  completeOperationalStoreCutover,
+  type OperationalStateDatabaseLease,
+  type OperationalStoreCutoverFailpoint,
+} from './operational-state-store.js';
 
 export type { DeepResearchStore } from '@maka/core/deep-research-run';
 
@@ -39,6 +46,22 @@ export function createDeepResearchStore(
     options.newId ?? randomUUID,
     options.now ?? Date.now,
   );
+}
+
+export interface SqliteDeepResearchStore extends DeepResearchStore {
+  ready(): Promise<void>;
+  close(): void;
+}
+
+export interface CreateSqliteDeepResearchStoreOptions extends CreateDeepResearchStoreOptions {
+  failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
+}
+
+export function createSqliteDeepResearchStore(
+  workspaceRoot: string,
+  options: CreateSqliteDeepResearchStoreOptions = {},
+): SqliteDeepResearchStore {
+  return new SqliteDeepResearchStoreImpl(workspaceRoot, options);
 }
 
 class FileDeepResearchStore implements DeepResearchStore {
@@ -63,6 +86,8 @@ class FileDeepResearchStore implements DeepResearchStore {
 
   async readEvents(sessionId: string): Promise<DeepResearchEvent[]> {
     assertSafeSessionId(sessionId);
+    const canonical = await this.readCanonicalEvents(sessionId);
+    if (canonical) return canonical;
     let text: string;
     try {
       text = await readFile(this.eventsPath(sessionId), 'utf8');
@@ -352,6 +377,7 @@ class FileDeepResearchStore implements DeepResearchStore {
   }
 
   private async appendEvent(sessionId: string, event: DeepResearchEvent): Promise<void> {
+    if (await this.appendCanonicalEvent(sessionId, event)) return;
     const path = this.eventsPath(sessionId);
     await mkdir(dirname(path), { recursive: true });
     await appendJsonl(path, `${JSON.stringify(event)}\n`, {
@@ -360,9 +386,225 @@ class FileDeepResearchStore implements DeepResearchStore {
     });
   }
 
+  protected async readCanonicalEvents(
+    _sessionId: string,
+  ): Promise<DeepResearchEvent[] | undefined> {
+    return undefined;
+  }
+
+  protected async appendCanonicalEvent(
+    _sessionId: string,
+    _event: DeepResearchEvent,
+  ): Promise<boolean> {
+    return false;
+  }
+
   private eventsPath(sessionId: string): string {
     return join(this.sessionsRoot, sessionId, 'deep-research', 'events.jsonl');
   }
+}
+
+class SqliteDeepResearchStoreImpl extends FileDeepResearchStore implements SqliteDeepResearchStore {
+  readonly #lease: OperationalStateDatabaseLease;
+  readonly #ready: Promise<void>;
+
+  constructor(workspaceRoot: string, options: CreateSqliteDeepResearchStoreOptions) {
+    super(workspaceRoot, options.newId ?? randomUUID, options.now ?? Date.now);
+    const root = resolve(workspaceRoot);
+    this.#lease = acquireOperationalStateDatabase(root);
+    this.#ready = importLegacyDeepResearchState(root, this.#lease, options.failpoint);
+  }
+
+  ready(): Promise<void> {
+    return this.#ready;
+  }
+
+  close(): void {
+    this.#lease.close();
+  }
+
+  protected override async readCanonicalEvents(sessionId: string): Promise<DeepResearchEvent[]> {
+    await this.#ready;
+    return readSqliteDeepResearchEvents(this.#lease.database, sessionId);
+  }
+
+  protected override async appendCanonicalEvent(
+    sessionId: string,
+    event: DeepResearchEvent,
+  ): Promise<boolean> {
+    await this.#ready;
+    this.#lease.transaction('write', () => {
+      insertDeepResearchEvent(this.#lease.database, sessionId, event);
+    });
+    return true;
+  }
+}
+
+interface LegacyDeepResearchLedger {
+  sessionId: string;
+  events: DeepResearchEvent[];
+}
+
+async function importLegacyDeepResearchState(
+  root: string,
+  lease: OperationalStateDatabaseLease,
+  failpoint?: (point: OperationalStoreCutoverFailpoint) => void,
+): Promise<void> {
+  const ledgers = await readLegacyDeepResearchLedgers(root);
+  const fingerprint = `sha256:${createHash('sha256')
+    .update(JSON.stringify(ledgers))
+    .digest('hex')}`;
+  completeOperationalStoreCutover(lease, {
+    storeName: 'workflow_deep_research',
+    sourcePath: join(root, 'sessions'),
+    sourceFingerprint: fingerprint,
+    failpoint,
+    importAndValidate: (database) => {
+      let eventCount = 0;
+      for (const ledger of ledgers) {
+        for (const event of ledger.events) {
+          insertOrValidateDeepResearchEvent(database, ledger.sessionId, event);
+          eventCount += 1;
+        }
+      }
+      const persisted = database
+        .prepare('SELECT COUNT(*) AS count FROM workflow_deep_research_events')
+        .get() as { count?: unknown };
+      if (persisted.count !== eventCount) {
+        throw new Error('Deep Research cutover row-count validation failed');
+      }
+      return { sessions: ledgers.length, events: eventCount };
+    },
+  });
+}
+
+async function readLegacyDeepResearchLedgers(root: string): Promise<LegacyDeepResearchLedger[]> {
+  const sessionsRoot = join(root, 'sessions');
+  let entries;
+  try {
+    entries = await readdir(sessionsRoot, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+  const ledgers: LegacyDeepResearchLedger[] = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isDirectory()) continue;
+    assertSafeSessionId(entry.name);
+    let text: string;
+    try {
+      text = await readFile(
+        join(sessionsRoot, entry.name, 'deep-research', 'events.jsonl'),
+        'utf8',
+      );
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+      throw error;
+    }
+    const events = decodeLegacyDeepResearchEvents(text, entry.name);
+    const projection = projectDeepResearchEvents(events);
+    if (projection.diagnostics.length > 0) {
+      throw new Error(
+        `Deep Research ledger projection failed: ${projection.diagnostics.join('; ')}`,
+      );
+    }
+    ledgers.push({ sessionId: entry.name, events });
+  }
+  return ledgers;
+}
+
+function decodeLegacyDeepResearchEvents(text: string, sessionId: string): DeepResearchEvent[] {
+  const events: DeepResearchEvent[] = [];
+  for (const [index, line] of text.split(/\r?\n/).entries()) {
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (error) {
+      throw new Error(
+        `Invalid deep research event JSONL line ${index + 1}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    if (!isDeepResearchEvent(parsed) || parsed.sessionId !== sessionId) {
+      throw new Error(
+        `Invalid deep research event JSONL line ${index + 1}: unexpected event shape`,
+      );
+    }
+    events.push(parsed);
+  }
+  return events;
+}
+
+function readSqliteDeepResearchEvents(
+  database: DatabaseSync,
+  sessionId: string,
+): DeepResearchEvent[] {
+  assertSafeSessionId(sessionId);
+  const rows = database
+    .prepare(`
+      SELECT record_json
+      FROM workflow_deep_research_events
+      WHERE session_id = ?
+      ORDER BY sequence
+    `)
+    .all(sessionId) as Array<{ record_json?: unknown }>;
+  return rows.map((row, index) => {
+    if (typeof row.record_json !== 'string') {
+      throw new Error(`Invalid SQLite Deep Research event at sequence ${index}`);
+    }
+    const parsed = JSON.parse(row.record_json);
+    if (!isDeepResearchEvent(parsed) || parsed.sessionId !== sessionId) {
+      throw new Error(`Invalid SQLite Deep Research event at sequence ${index}`);
+    }
+    return parsed;
+  });
+}
+
+function insertDeepResearchEvent(
+  database: DatabaseSync,
+  sessionId: string,
+  event: DeepResearchEvent,
+): void {
+  const row = database
+    .prepare(`
+      SELECT COALESCE(MAX(sequence), -1) + 1 AS sequence
+      FROM workflow_deep_research_events
+      WHERE session_id = ?
+    `)
+    .get(sessionId) as { sequence?: unknown };
+  if (typeof row.sequence !== 'number' || !Number.isSafeInteger(row.sequence)) {
+    throw new Error('Invalid next Deep Research event sequence');
+  }
+  database
+    .prepare(`
+      INSERT INTO workflow_deep_research_events(
+        session_id, sequence, event_id, record_json
+      ) VALUES (?, ?, ?, ?)
+    `)
+    .run(sessionId, row.sequence, event.eventId, JSON.stringify(event));
+}
+
+function insertOrValidateDeepResearchEvent(
+  database: DatabaseSync,
+  sessionId: string,
+  event: DeepResearchEvent,
+): void {
+  const existing = database
+    .prepare(`
+      SELECT record_json
+      FROM workflow_deep_research_events
+      WHERE session_id = ? AND event_id = ?
+    `)
+    .get(sessionId, event.eventId) as { record_json?: unknown } | undefined;
+  if (existing) {
+    if (existing.record_json !== JSON.stringify(event)) {
+      throw new Error(`Deep Research cutover conflict: ${event.eventId}`);
+    }
+    return;
+  }
+  insertDeepResearchEvent(database, sessionId, event);
 }
 
 function refsFromContext(context: DeepResearchMutationContext): { refs?: DeepResearchEventRefs } {

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -16,6 +16,10 @@ import {
   migrateSqliteCoreExecutionDatabase,
   SQLITE_CORE_EXECUTION_SCHEMA_VERSION,
 } from './sqlite-core-execution-schema.js';
+import {
+  migrateSqliteWorkflowDatabase,
+  SQLITE_WORKFLOW_SCHEMA_VERSION,
+} from './sqlite-workflow-schema.js';
 
 export const OPERATIONAL_STATE_DATABASE_NAME = 'runtime.sqlite';
 export const LEGACY_SESSION_METADATA_DATABASE_NAME = 'sessions.sqlite';
@@ -121,6 +125,7 @@ class OperationalStateDatabaseOwner {
       migrateSqliteRuntimeDatabase(this.database);
       migrateSqliteSessionMetadataDatabase(this.database);
       migrateSqliteCoreExecutionDatabase(this.database);
+      migrateSqliteWorkflowDatabase(this.database);
       migrateOperationalStateDatabase(this.database, options.now ?? Date.now);
       cutoverLegacySessionMetadata({
         destination: this.database,
@@ -198,6 +203,7 @@ function migrateOperationalStateDatabase(db: DatabaseSync, now: () => number): v
     registerSchema(db, 'runtime', SQLITE_RUNTIME_SCHEMA_VERSION, appliedAt);
     registerSchema(db, 'session_metadata', SQLITE_SESSION_METADATA_SCHEMA_VERSION, appliedAt);
     registerSchema(db, 'core_execution', SQLITE_CORE_EXECUTION_SCHEMA_VERSION, appliedAt);
+    registerSchema(db, 'workflow', SQLITE_WORKFLOW_SCHEMA_VERSION, appliedAt);
     registerSchema(db, 'operational', OPERATIONAL_STATE_SCHEMA_VERSION, appliedAt);
     db.exec('COMMIT');
   } catch (error) {

--- a/packages/storage/src/plan-reminder-store.ts
+++ b/packages/storage/src/plan-reminder-store.ts
@@ -1,6 +1,7 @@
 import { mkdir, readFile, rename, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { randomUUID } from 'node:crypto';
+import { dirname, join, resolve } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+import type { DatabaseSync } from 'node:sqlite';
 import {
   createPlanReminderSchedule,
   isPlanReminderDue,
@@ -14,6 +15,12 @@ import {
   type PlanReminder,
   type PlanReminderRunRecord,
 } from '@maka/core/plan-reminders';
+import {
+  acquireOperationalStateDatabase,
+  completeOperationalStoreCutover,
+  type OperationalStateDatabaseLease,
+  type OperationalStoreCutoverFailpoint,
+} from './operational-state-store.js';
 
 export interface PlanReminderStore {
   list(): Promise<PlanReminder[]>;
@@ -36,6 +43,22 @@ export interface PlanReminderStore {
 
 export function createPlanReminderStore(workspaceRoot: string): PlanReminderStore {
   return new FilePlanReminderStore(workspaceRoot);
+}
+
+export interface SqlitePlanReminderStore extends PlanReminderStore {
+  ready(): Promise<void>;
+  close(): void;
+}
+
+export interface CreateSqlitePlanReminderStoreOptions {
+  failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
+}
+
+export function createSqlitePlanReminderStore(
+  workspaceRoot: string,
+  options: CreateSqlitePlanReminderStoreOptions = {},
+): SqlitePlanReminderStore {
+  return new SqlitePlanReminderStoreImpl(workspaceRoot, options);
 }
 
 class FilePlanReminderStore implements PlanReminderStore {
@@ -276,6 +299,8 @@ class FilePlanReminderStore implements PlanReminderStore {
   }
 
   private async read(): Promise<PlanReminder[]> {
+    const canonical = await this.readCanonical();
+    if (canonical) return canonical;
     try {
       const text = await readFile(this.filePath, 'utf8');
       const parsed = JSON.parse(text) as unknown;
@@ -300,11 +325,130 @@ class FilePlanReminderStore implements PlanReminderStore {
   }
 
   private async write(reminders: PlanReminder[]): Promise<void> {
+    if (await this.writeCanonical(reminders)) return;
     await mkdir(dirname(this.filePath), { recursive: true });
     const tempPath = `${this.filePath}.${process.pid}.${Date.now()}.tmp`;
     await writeFile(tempPath, JSON.stringify(reminders, null, 2) + '\n', 'utf8');
     await rename(tempPath, this.filePath);
   }
+
+  protected async readCanonical(): Promise<PlanReminder[] | undefined> {
+    return undefined;
+  }
+
+  protected async writeCanonical(_reminders: PlanReminder[]): Promise<boolean> {
+    return false;
+  }
+}
+
+class SqlitePlanReminderStoreImpl extends FilePlanReminderStore implements SqlitePlanReminderStore {
+  readonly #lease: OperationalStateDatabaseLease;
+  readonly #ready: Promise<void>;
+
+  constructor(workspaceRoot: string, options: CreateSqlitePlanReminderStoreOptions) {
+    super(workspaceRoot);
+    const root = resolve(workspaceRoot);
+    this.#lease = acquireOperationalStateDatabase(root);
+    this.#ready = importLegacyPlanReminders(root, this.#lease, options.failpoint);
+  }
+
+  ready(): Promise<void> {
+    return this.#ready;
+  }
+
+  close(): void {
+    this.#lease.close();
+  }
+
+  protected override async readCanonical(): Promise<PlanReminder[]> {
+    await this.#ready;
+    return readSqlitePlanReminders(this.#lease.database);
+  }
+
+  protected override async writeCanonical(reminders: PlanReminder[]): Promise<boolean> {
+    await this.#ready;
+    this.#lease.transaction('write', () => {
+      this.#lease.database.prepare('DELETE FROM workflow_plan_reminders').run();
+      for (const reminder of reminders) insertPlanReminder(this.#lease.database, reminder);
+    });
+    return true;
+  }
+}
+
+async function importLegacyPlanReminders(
+  root: string,
+  lease: OperationalStateDatabaseLease,
+  failpoint?: (point: OperationalStoreCutoverFailpoint) => void,
+): Promise<void> {
+  let reminders: PlanReminder[] = [];
+  const sourcePath = join(root, 'plan-reminders.json');
+  try {
+    const parsed = JSON.parse(await readFile(sourcePath, 'utf8')) as unknown;
+    if (!Array.isArray(parsed)) {
+      throw new Error('Invalid plan reminders file: expected an array');
+    }
+    reminders = parsed.map((value, index) => normalizePersistedPlanReminder(value, index));
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  const fingerprint = `sha256:${createHash('sha256')
+    .update(JSON.stringify(reminders))
+    .digest('hex')}`;
+  completeOperationalStoreCutover(lease, {
+    storeName: 'workflow_plan_reminders',
+    sourcePath,
+    sourceFingerprint: fingerprint,
+    failpoint,
+    importAndValidate: (database) => {
+      for (const reminder of reminders) insertOrValidatePlanReminder(database, reminder);
+      const persisted = database
+        .prepare('SELECT COUNT(*) AS count FROM workflow_plan_reminders')
+        .get() as { count?: unknown };
+      if (persisted.count !== reminders.length) {
+        throw new Error('Plan reminder cutover row-count validation failed');
+      }
+      return { reminders: reminders.length };
+    },
+  });
+}
+
+function readSqlitePlanReminders(database: DatabaseSync): PlanReminder[] {
+  const rows = database
+    .prepare(`
+      SELECT record_json
+      FROM workflow_plan_reminders
+      ORDER BY created_at, reminder_id
+    `)
+    .all() as Array<{ record_json?: unknown }>;
+  return rows.map((row, index) => {
+    if (typeof row.record_json !== 'string') {
+      throw new Error(`Invalid SQLite plan reminder at row ${index + 1}`);
+    }
+    return normalizePersistedPlanReminder(JSON.parse(row.record_json), index);
+  });
+}
+
+function insertPlanReminder(database: DatabaseSync, reminder: PlanReminder): void {
+  database
+    .prepare(`
+      INSERT INTO workflow_plan_reminders(
+        reminder_id, created_at, updated_at, record_json
+      ) VALUES (?, ?, ?, ?)
+    `)
+    .run(reminder.id, reminder.createdAt, reminder.updatedAt, JSON.stringify(reminder));
+}
+
+function insertOrValidatePlanReminder(database: DatabaseSync, reminder: PlanReminder): void {
+  const existing = database
+    .prepare('SELECT record_json FROM workflow_plan_reminders WHERE reminder_id = ?')
+    .get(reminder.id) as { record_json?: unknown } | undefined;
+  if (existing) {
+    if (existing.record_json !== JSON.stringify(reminder)) {
+      throw new Error(`Plan reminder cutover conflict: ${reminder.id}`);
+    }
+    return;
+  }
+  insertPlanReminder(database, reminder);
 }
 
 function comparePlanRemindersForList(a: PlanReminder, b: PlanReminder): number {

--- a/packages/storage/src/plan-store.ts
+++ b/packages/storage/src/plan-store.ts
@@ -1,6 +1,7 @@
-import { randomUUID } from 'node:crypto';
-import { mkdir, readFile, rename, rm, writeFile } from 'node:fs/promises';
+import { createHash, randomUUID } from 'node:crypto';
+import { mkdir, readFile, readdir, rename, rm, writeFile } from 'node:fs/promises';
 import { dirname, join, resolve } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
 import {
   PlanConflictError,
   activePlanExecution,
@@ -24,6 +25,12 @@ import {
 import { appendJsonl } from './jsonl-append.js';
 import { classifyJsonRecord } from './json-prefix.js';
 import { chainWrite } from './write-queue.js';
+import {
+  acquireOperationalStateDatabase,
+  completeOperationalStoreCutover,
+  type OperationalStateDatabaseLease,
+  type OperationalStoreCutoverFailpoint,
+} from './operational-state-store.js';
 
 const SAFE_ID_PATTERN = /^[A-Za-z0-9_-]{1,128}$/;
 
@@ -37,6 +44,22 @@ export function createPlanStore(
   options: CreatePlanStoreOptions = {},
 ): PlanStore {
   return new FilePlanStore(workspaceRoot, options);
+}
+
+export interface SqlitePlanStore extends PlanStore {
+  ready(): Promise<void>;
+  close(): void;
+}
+
+export interface CreateSqlitePlanStoreOptions extends CreatePlanStoreOptions {
+  failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
+}
+
+export function createSqlitePlanStore(
+  workspaceRoot: string,
+  options: CreateSqlitePlanStoreOptions = {},
+): SqlitePlanStore {
+  return new SqlitePlanStoreImpl(workspaceRoot, options);
 }
 
 class FilePlanStore implements PlanStore {
@@ -323,15 +346,8 @@ class FilePlanStore implements PlanStore {
       const ledger = await this.readLedger(sessionId);
       const event = await build(ledger.state, ledger.events);
       if (!event) return;
-      await mkdir(this.sessionDir(sessionId), { recursive: true });
-      await appendJsonl(this.eventsPath(sessionId), `${JSON.stringify(event)}\n`, {
-        durable: true,
-        durabilityRoot: this.durabilityRoot,
-      });
       const state = applyPlanEvent(ledger.state, event);
-      await this.writeProjection(sessionId, state).catch(() => {
-        // Derived cache only. The append-only event ledger remains authoritative.
-      });
+      await this.appendCanonicalEvent(sessionId, event, state);
       result = { event, state };
     });
     return result;
@@ -341,6 +357,8 @@ class FilePlanStore implements PlanStore {
     sessionId: string,
   ): Promise<{ events: PlanEvent[]; state: PlanSessionState }> {
     assertSafeId(sessionId);
+    const canonical = await this.readCanonicalLedger(sessionId);
+    if (canonical) return canonical;
     let text: string;
     try {
       text = await readFile(this.eventsPath(sessionId), 'utf8');
@@ -370,6 +388,27 @@ class FilePlanStore implements PlanStore {
     return { events, state };
   }
 
+  protected async readCanonicalLedger(
+    _sessionId: string,
+  ): Promise<{ events: PlanEvent[]; state: PlanSessionState } | undefined> {
+    return undefined;
+  }
+
+  protected async appendCanonicalEvent(
+    sessionId: string,
+    event: PlanEvent,
+    state: PlanSessionState,
+  ): Promise<void> {
+    await mkdir(this.sessionDir(sessionId), { recursive: true });
+    await appendJsonl(this.eventsPath(sessionId), `${JSON.stringify(event)}\n`, {
+      durable: true,
+      durabilityRoot: this.durabilityRoot,
+    });
+    await this.writeProjection(sessionId, state).catch(() => {
+      // Derived cache only. The append-only event ledger remains authoritative.
+    });
+  }
+
   private async writeProjection(sessionId: string, state: PlanSessionState): Promise<void> {
     const path = this.projectionPath(sessionId);
     await mkdir(dirname(path), { recursive: true });
@@ -393,6 +432,218 @@ class FilePlanStore implements PlanStore {
   private projectionPath(sessionId: string): string {
     return join(this.sessionDir(sessionId), 'plans.json');
   }
+}
+
+class SqlitePlanStoreImpl extends FilePlanStore implements SqlitePlanStore {
+  readonly #root: string;
+  readonly #lease: OperationalStateDatabaseLease;
+  readonly #ready: Promise<void>;
+
+  constructor(workspaceRoot: string, options: CreateSqlitePlanStoreOptions) {
+    super(workspaceRoot, options);
+    this.#root = resolve(workspaceRoot);
+    this.#lease = acquireOperationalStateDatabase(this.#root);
+    this.#ready = importLegacyPlanState(this.#root, this.#lease, options.failpoint);
+  }
+
+  ready(): Promise<void> {
+    return this.#ready;
+  }
+
+  close(): void {
+    this.#lease.close();
+  }
+
+  protected override async appendCanonicalEvent(
+    sessionId: string,
+    event: PlanEvent,
+    state: PlanSessionState,
+  ): Promise<void> {
+    await this.#ready;
+    this.#lease.transaction('write', () => {
+      insertPlanEvent(this.#lease.database, event);
+      writePlanProjection(this.#lease.database, sessionId, state);
+    });
+  }
+
+  protected override async readCanonicalLedger(
+    sessionId: string,
+  ): Promise<{ events: PlanEvent[]; state: PlanSessionState } | undefined> {
+    await this.#ready;
+    return readSqlitePlanLedger(this.#lease.database, sessionId);
+  }
+}
+
+interface LegacyPlanLedger {
+  sessionId: string;
+  events: PlanEvent[];
+  state: PlanSessionState;
+}
+
+async function importLegacyPlanState(
+  root: string,
+  lease: OperationalStateDatabaseLease,
+  failpoint?: (point: OperationalStoreCutoverFailpoint) => void,
+): Promise<void> {
+  const ledgers = await readLegacyPlanLedgers(root);
+  const fingerprint = `sha256:${createHash('sha256')
+    .update(JSON.stringify(ledgers))
+    .digest('hex')}`;
+  completeOperationalStoreCutover(lease, {
+    storeName: 'workflow_plan',
+    sourcePath: join(root, 'sessions'),
+    sourceFingerprint: fingerprint,
+    failpoint,
+    importAndValidate: (database) => {
+      let eventCount = 0;
+      for (const ledger of ledgers) {
+        for (const event of ledger.events) {
+          insertOrValidatePlanEvent(database, event);
+          eventCount += 1;
+        }
+        writePlanProjection(database, ledger.sessionId, ledger.state);
+      }
+      const persisted = database
+        .prepare('SELECT COUNT(*) AS count FROM workflow_plan_events')
+        .get() as { count?: unknown };
+      if (persisted.count !== eventCount) {
+        throw new Error('Plan cutover row-count validation failed');
+      }
+      return { sessions: ledgers.length, events: eventCount };
+    },
+  });
+}
+
+async function readLegacyPlanLedgers(root: string): Promise<LegacyPlanLedger[]> {
+  const sessionsRoot = join(root, 'sessions');
+  let entries;
+  try {
+    entries = await readdir(sessionsRoot, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+  const result: LegacyPlanLedger[] = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isDirectory() || !SAFE_ID_PATTERN.test(entry.name)) continue;
+    const eventsPath = join(sessionsRoot, entry.name, 'plan-events.jsonl');
+    let text: string | undefined;
+    try {
+      text = await readFile(eventsPath, 'utf8');
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    const events = text === undefined ? [] : decodeLegacyPlanEventText(text, entry.name);
+    let state = emptyPlanSessionState(entry.name);
+    for (const event of events) state = applyPlanEvent(state, event);
+    const projectionPath = join(sessionsRoot, entry.name, 'plans.json');
+    try {
+      const projection = JSON.parse(await readFile(projectionPath, 'utf8')) as PlanSessionState;
+      if (JSON.stringify(projection) !== JSON.stringify(state)) {
+        throw new Error(`Plan projection does not match its event ledger for ${entry.name}`);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    if (events.length > 0) result.push({ sessionId: entry.name, events, state });
+  }
+  return result;
+}
+
+function decodeLegacyPlanEventText(text: string, sessionId: string): PlanEvent[] {
+  const lines = text.split('\n');
+  const events: PlanEvent[] = [];
+  for (let index = 0; index < lines.length; index += 1) {
+    const line = lines[index]!;
+    if (!line.trim()) continue;
+    try {
+      events.push(decodePlanEvent(JSON.parse(line), sessionId));
+    } catch (error) {
+      const isLast = index === lines.length - 1;
+      if (isLast && !text.endsWith('\n') && classifyJsonRecord(line) === 'incomplete-prefix') {
+        continue;
+      }
+      throw new Error(`Invalid Plan event at line ${index + 1}`, { cause: error });
+    }
+  }
+  return events;
+}
+
+function readSqlitePlanLedger(
+  database: DatabaseSync,
+  sessionId: string,
+): { events: PlanEvent[]; state: PlanSessionState } {
+  assertSafeId(sessionId);
+  const rows = database
+    .prepare(`
+      SELECT record_json
+      FROM workflow_plan_events
+      WHERE session_id = ?
+      ORDER BY sequence
+    `)
+    .all(sessionId) as Array<{ record_json?: unknown }>;
+  const events = rows.map((row, index) => {
+    if (typeof row.record_json !== 'string') {
+      throw new Error(`Invalid SQLite Plan event at sequence ${index}`);
+    }
+    return decodePlanEvent(JSON.parse(row.record_json), sessionId);
+  });
+  let state = emptyPlanSessionState(sessionId);
+  for (const event of events) state = applyPlanEvent(state, event);
+  return { events, state };
+}
+
+function insertPlanEvent(database: DatabaseSync, event: PlanEvent): void {
+  const row = database
+    .prepare(`
+      SELECT COALESCE(MAX(sequence), -1) + 1 AS sequence
+      FROM workflow_plan_events
+      WHERE session_id = ?
+    `)
+    .get(event.sessionId) as { sequence?: unknown };
+  if (typeof row.sequence !== 'number' || !Number.isSafeInteger(row.sequence)) {
+    throw new Error('Invalid next Plan event sequence');
+  }
+  database
+    .prepare(`
+      INSERT INTO workflow_plan_events(
+        session_id, sequence, event_id, store_version, record_json
+      ) VALUES (?, ?, ?, ?, ?)
+    `)
+    .run(event.sessionId, row.sequence, event.id, event.storeVersion, JSON.stringify(event));
+}
+
+function insertOrValidatePlanEvent(database: DatabaseSync, event: PlanEvent): void {
+  const existing = database
+    .prepare(`
+      SELECT record_json
+      FROM workflow_plan_events
+      WHERE session_id = ? AND store_version = ?
+    `)
+    .get(event.sessionId, event.storeVersion) as { record_json?: unknown } | undefined;
+  if (existing) {
+    if (existing.record_json !== JSON.stringify(event)) {
+      throw new Error(`Plan cutover conflict: ${event.sessionId}:${event.storeVersion}`);
+    }
+    return;
+  }
+  insertPlanEvent(database, event);
+}
+
+function writePlanProjection(
+  database: DatabaseSync,
+  sessionId: string,
+  state: PlanSessionState,
+): void {
+  database
+    .prepare(`
+      INSERT INTO workflow_plan_projections(session_id, store_version, record_json)
+      VALUES (?, ?, ?)
+      ON CONFLICT(session_id) DO UPDATE SET
+        store_version = excluded.store_version,
+        record_json = excluded.record_json
+    `)
+    .run(sessionId, state.storeVersion, JSON.stringify(state));
 }
 
 export function applyPlanEvent(state: PlanSessionState, event: PlanEvent): PlanSessionState {

--- a/packages/storage/src/sqlite-workflow-schema.ts
+++ b/packages/storage/src/sqlite-workflow-schema.ts
@@ -1,0 +1,75 @@
+import type { DatabaseSync } from 'node:sqlite';
+
+export const SQLITE_WORKFLOW_SCHEMA_VERSION = 1;
+
+export function migrateSqliteWorkflowDatabase(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS workflow_task_ledger_events (
+      session_id TEXT NOT NULL,
+      sequence INTEGER NOT NULL CHECK (sequence >= 0),
+      event_id TEXT NOT NULL,
+      record_json TEXT NOT NULL,
+      PRIMARY KEY (session_id, sequence),
+      UNIQUE (session_id, event_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS workflow_task_ledger_projections (
+      session_id TEXT PRIMARY KEY,
+      record_json TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS workflow_plan_events (
+      session_id TEXT NOT NULL,
+      sequence INTEGER NOT NULL CHECK (sequence >= 0),
+      event_id TEXT NOT NULL,
+      store_version INTEGER NOT NULL CHECK (store_version > 0),
+      record_json TEXT NOT NULL,
+      PRIMARY KEY (session_id, sequence),
+      UNIQUE (session_id, event_id),
+      UNIQUE (session_id, store_version)
+    );
+
+    CREATE TABLE IF NOT EXISTS workflow_plan_projections (
+      session_id TEXT PRIMARY KEY,
+      store_version INTEGER NOT NULL CHECK (store_version >= 0),
+      record_json TEXT NOT NULL
+    );
+
+    CREATE TABLE IF NOT EXISTS workflow_deep_research_events (
+      session_id TEXT NOT NULL,
+      sequence INTEGER NOT NULL CHECK (sequence >= 0),
+      event_id TEXT NOT NULL,
+      record_json TEXT NOT NULL,
+      PRIMARY KEY (session_id, sequence),
+      UNIQUE (session_id, event_id)
+    );
+
+    CREATE TABLE IF NOT EXISTS workflow_agent_mailbox_messages (
+      session_id TEXT NOT NULL,
+      sequence INTEGER NOT NULL CHECK (sequence >= 0),
+      message_id TEXT NOT NULL,
+      team_id TEXT NOT NULL,
+      parent_run_id TEXT NOT NULL,
+      scope_sequence INTEGER NOT NULL CHECK (scope_sequence > 0),
+      record_json TEXT NOT NULL,
+      PRIMARY KEY (session_id, sequence),
+      UNIQUE (session_id, message_id),
+      UNIQUE (session_id, team_id, parent_run_id, scope_sequence)
+    );
+
+    CREATE INDEX IF NOT EXISTS workflow_agent_mailbox_scope
+      ON workflow_agent_mailbox_messages(
+        session_id, team_id, parent_run_id, scope_sequence
+      );
+
+    CREATE TABLE IF NOT EXISTS workflow_plan_reminders (
+      reminder_id TEXT PRIMARY KEY,
+      created_at INTEGER NOT NULL,
+      updated_at INTEGER NOT NULL,
+      record_json TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS workflow_plan_reminders_order
+      ON workflow_plan_reminders(created_at, reminder_id);
+  `);
+}

--- a/packages/storage/src/task-ledger-authority.ts
+++ b/packages/storage/src/task-ledger-authority.ts
@@ -5,7 +5,7 @@ import {
   StorageRootAuthorityError,
   type StorageRootLease,
 } from './root-authority.js';
-import { createTaskLedgerStore } from './task-ledger-store.js';
+import { createSqliteTaskLedgerStore, type SqliteTaskLedgerStore } from './task-ledger-store.js';
 import {
   getTaskLedgerCanonicalReader,
   type TaskLedgerCanonicalReader,
@@ -22,6 +22,7 @@ export interface InteractiveTaskLedgerWriter extends TaskLedgerStore, TaskLedger
   readonly kind: 'interactive';
   readonly access: 'write';
   readonly [writerBrand]: true;
+  close(): void;
 }
 
 export function authenticateInteractiveTaskLedgerWriter(
@@ -46,16 +47,36 @@ export async function openInteractiveTaskLedgerStoreForWrite(
   if (opening) return opening;
 
   const pending = Promise.resolve().then(async () => {
-    const store = await runWithStorageRootLease(lease, 'interactive', 'write', async (root) =>
-      createTaskLedgerStore(root),
-    );
-    await assertStorageRootLease(lease, 'interactive', 'write');
-    const recoveredExisting = writerByLease.get(lease);
-    if (recoveredExisting) return recoveredExisting;
-    const writer = createInteractiveWriterFacade(lease, store, getTaskLedgerCanonicalReader(store));
-    writers.add(writer);
-    writerByLease.set(lease, writer);
-    return writer;
+    let store: SqliteTaskLedgerStore | undefined;
+    try {
+      store = await runWithStorageRootLease(lease, 'interactive', 'write', async (root) => {
+        const opened = createSqliteTaskLedgerStore(root);
+        try {
+          await opened.ready();
+          return opened;
+        } catch (error) {
+          opened.close();
+          throw error;
+        }
+      });
+      await assertStorageRootLease(lease, 'interactive', 'write');
+      const recoveredExisting = writerByLease.get(lease);
+      if (recoveredExisting) {
+        store.close();
+        return recoveredExisting;
+      }
+      const writer = createInteractiveWriterFacade(
+        lease,
+        store,
+        getTaskLedgerCanonicalReader(store),
+      );
+      writers.add(writer);
+      writerByLease.set(lease, writer);
+      return writer;
+    } catch (error) {
+      store?.close();
+      throw error;
+    }
   });
   writerOpeningByLease.set(lease, pending);
   try {
@@ -67,11 +88,18 @@ export async function openInteractiveTaskLedgerStoreForWrite(
 
 function createInteractiveWriterFacade(
   lease: StorageRootLease<'interactive', 'write'>,
-  store: TaskLedgerStore,
+  store: SqliteTaskLedgerStore,
   canonicalReader: TaskLedgerCanonicalReader,
 ): InteractiveTaskLedgerWriter {
-  const run = <T>(operation: () => Promise<T>) =>
-    runWithStorageRootLease(lease, 'interactive', 'write', async () => operation());
+  let closed = false;
+  const run = <T>(operation: () => Promise<T>) => {
+    if (closed) {
+      return Promise.reject(
+        new StorageRootAuthorityError('invalid_lease', 'Task ledger writer is closed'),
+      );
+    }
+    return runWithStorageRootLease(lease, 'interactive', 'write', async () => operation());
+  };
   const writer: InteractiveTaskLedgerWriter = {
     kind: 'interactive',
     access: 'write',
@@ -87,6 +115,13 @@ function createInteractiveWriterFacade(
     settleAgentOutcome: (sessionId, id, outcome, context) =>
       run(() => store.settleAgentOutcome(sessionId, id, outcome, context)),
     subscribe: (listener) => store.subscribe(listener),
+    close: () => {
+      if (closed) return;
+      closed = true;
+      if (writerByLease.get(lease) === writer) writerByLease.delete(lease);
+      writers.delete(writer);
+      store.close();
+    },
   };
   Object.freeze(writer);
   return writer;

--- a/packages/storage/src/task-ledger-store.ts
+++ b/packages/storage/src/task-ledger-store.ts
@@ -1,6 +1,7 @@
-import { appendFile, mkdir, readFile, rename, writeFile } from 'node:fs/promises';
-import { dirname, join } from 'node:path';
-import { randomUUID } from 'node:crypto';
+import { appendFile, mkdir, readFile, readdir, rename, writeFile } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+import { createHash, randomUUID } from 'node:crypto';
+import type { DatabaseSync } from 'node:sqlite';
 import {
   TASK_LEDGER_MAX_TASKS,
   TASK_ARCHIVE_AFTER_MS,
@@ -35,11 +36,33 @@ import {
 import { chainWrite } from './write-queue.js';
 import { assertSafeSessionId } from './session-store.js';
 import { registerTaskLedgerCanonicalReader } from './task-ledger-store-internal.js';
+import {
+  acquireOperationalStateDatabase,
+  completeOperationalStoreCutover,
+  type OperationalStateDatabaseLease,
+  type OperationalStoreCutoverFailpoint,
+} from './operational-state-store.js';
 
 export type { TaskLedgerStore } from '@maka/core/task-ledger';
 
 export function createTaskLedgerStore(workspaceRoot: string): TaskLedgerStore {
   return new FileTaskLedgerStore(workspaceRoot);
+}
+
+export interface SqliteTaskLedgerStore extends TaskLedgerStore {
+  ready(): Promise<void>;
+  close(): void;
+}
+
+export interface CreateSqliteTaskLedgerStoreOptions {
+  failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
+}
+
+export function createSqliteTaskLedgerStore(
+  workspaceRoot: string,
+  options: CreateSqliteTaskLedgerStoreOptions = {},
+): SqliteTaskLedgerStore {
+  return new SqliteTaskLedgerStoreImpl(workspaceRoot, options);
 }
 
 class FileTaskLedgerStore implements TaskLedgerStore {
@@ -452,6 +475,7 @@ class FileTaskLedgerStore implements TaskLedgerStore {
     try {
       return (await this.readProjected(sessionId)).tasks;
     } catch (eventError) {
+      if (this.usesCanonicalEventStore()) throw eventError;
       try {
         await readFile(this.eventsPath(sessionId), 'utf8');
         return await this.readUntrustedCache(sessionId);
@@ -500,6 +524,7 @@ class FileTaskLedgerStore implements TaskLedgerStore {
         backfilledTaskIds: projected.backfilledTaskIds,
       };
     } catch (eventError) {
+      if (this.usesCanonicalEventStore()) throw eventError;
       try {
         await readFile(this.eventsPath(sessionId), 'utf8');
         throw eventError;
@@ -551,6 +576,8 @@ class FileTaskLedgerStore implements TaskLedgerStore {
   }
 
   private async readTaskEvents(sessionId: string): Promise<TaskLedgerEvent[]> {
+    const canonical = await this.readCanonicalTaskEvents(sessionId);
+    if (canonical) return canonical;
     const text = await readFile(this.eventsPath(sessionId), 'utf8');
     const events: TaskLedgerEvent[] = [];
     const lines = text.split(/\n/);
@@ -626,6 +653,7 @@ class FileTaskLedgerStore implements TaskLedgerStore {
 
   private async appendEvents(sessionId: string, events: TaskLedgerEvent[]): Promise<void> {
     if (events.length === 0) return;
+    if (await this.appendCanonicalTaskEvents(sessionId, events)) return;
     const filePath = this.eventsPath(sessionId);
     await mkdir(dirname(filePath), { recursive: true });
     await appendFile(
@@ -636,11 +664,36 @@ class FileTaskLedgerStore implements TaskLedgerStore {
   }
 
   private async write(sessionId: string, tasks: Task[]): Promise<void> {
+    if (await this.writeCanonicalTaskProjection(sessionId, tasks)) return;
     const filePath = this.filePath(sessionId);
     await mkdir(dirname(filePath), { recursive: true });
     const tempPath = `${filePath}.${process.pid}.${Date.now()}.tmp`;
     await writeFile(tempPath, JSON.stringify(tasks, null, 2) + '\n', 'utf8');
     await rename(tempPath, filePath);
+  }
+
+  protected usesCanonicalEventStore(): boolean {
+    return false;
+  }
+
+  protected async readCanonicalTaskEvents(
+    _sessionId: string,
+  ): Promise<TaskLedgerEvent[] | undefined> {
+    return undefined;
+  }
+
+  protected async appendCanonicalTaskEvents(
+    _sessionId: string,
+    _events: TaskLedgerEvent[],
+  ): Promise<boolean> {
+    return false;
+  }
+
+  protected async writeCanonicalTaskProjection(
+    _sessionId: string,
+    _tasks: Task[],
+  ): Promise<boolean> {
+    return false;
   }
 
   private applyListOptions(tasks: Task[], options: TaskLedgerListOptions): Task[] {
@@ -673,6 +726,251 @@ class FileTaskLedgerStore implements TaskLedgerStore {
       }
     }
   }
+}
+
+class SqliteTaskLedgerStoreImpl extends FileTaskLedgerStore implements SqliteTaskLedgerStore {
+  readonly #lease: OperationalStateDatabaseLease;
+  readonly #ready: Promise<void>;
+
+  constructor(workspaceRoot: string, options: CreateSqliteTaskLedgerStoreOptions) {
+    super(workspaceRoot);
+    const root = resolve(workspaceRoot);
+    this.#lease = acquireOperationalStateDatabase(root);
+    this.#ready = importLegacyTaskLedgerState(root, this.#lease, options.failpoint);
+  }
+
+  ready(): Promise<void> {
+    return this.#ready;
+  }
+
+  close(): void {
+    this.#lease.close();
+  }
+
+  protected override usesCanonicalEventStore(): boolean {
+    return true;
+  }
+
+  protected override async readCanonicalTaskEvents(sessionId: string): Promise<TaskLedgerEvent[]> {
+    await this.#ready;
+    return readSqliteTaskLedgerEvents(this.#lease.database, sessionId);
+  }
+
+  protected override async appendCanonicalTaskEvents(
+    sessionId: string,
+    events: TaskLedgerEvent[],
+  ): Promise<boolean> {
+    await this.#ready;
+    this.#lease.transaction('write', () => {
+      for (const event of events) insertTaskLedgerEvent(this.#lease.database, sessionId, event);
+    });
+    return true;
+  }
+
+  protected override async writeCanonicalTaskProjection(
+    sessionId: string,
+    tasks: Task[],
+  ): Promise<boolean> {
+    await this.#ready;
+    this.#lease.transaction('write', () => {
+      writeTaskLedgerProjection(this.#lease.database, sessionId, tasks);
+    });
+    return true;
+  }
+}
+
+interface LegacyTaskLedger {
+  sessionId: string;
+  events: TaskLedgerEvent[];
+  tasks: Task[];
+}
+
+async function importLegacyTaskLedgerState(
+  root: string,
+  lease: OperationalStateDatabaseLease,
+  failpoint?: (point: OperationalStoreCutoverFailpoint) => void,
+): Promise<void> {
+  const ledgers = await readLegacyTaskLedgers(root);
+  const fingerprint = `sha256:${createHash('sha256')
+    .update(JSON.stringify(ledgers))
+    .digest('hex')}`;
+  completeOperationalStoreCutover(lease, {
+    storeName: 'workflow_task_ledger',
+    sourcePath: join(root, 'sessions'),
+    sourceFingerprint: fingerprint,
+    failpoint,
+    importAndValidate: (database) => {
+      let eventCount = 0;
+      for (const ledger of ledgers) {
+        for (const event of ledger.events) {
+          insertOrValidateTaskLedgerEvent(database, ledger.sessionId, event);
+          eventCount += 1;
+        }
+        writeTaskLedgerProjection(database, ledger.sessionId, ledger.tasks);
+      }
+      const persisted = database
+        .prepare('SELECT COUNT(*) AS count FROM workflow_task_ledger_events')
+        .get() as { count?: unknown };
+      if (persisted.count !== eventCount) {
+        throw new Error('Task ledger cutover row-count validation failed');
+      }
+      return { sessions: ledgers.length, events: eventCount };
+    },
+  });
+}
+
+async function readLegacyTaskLedgers(root: string): Promise<LegacyTaskLedger[]> {
+  const sessionsRoot = join(root, 'sessions');
+  let entries;
+  try {
+    entries = await readdir(sessionsRoot, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return [];
+    throw error;
+  }
+  const result: LegacyTaskLedger[] = [];
+  for (const entry of entries.sort((left, right) => left.name.localeCompare(right.name))) {
+    if (!entry.isDirectory()) continue;
+    assertSafeSessionId(entry.name);
+    const eventsPath = join(sessionsRoot, entry.name, 'task-events.jsonl');
+    let events: TaskLedgerEvent[] | undefined;
+    try {
+      events = decodeLegacyTaskLedgerEvents(await readFile(eventsPath, 'utf8'), entry.name);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+    }
+    if (!events) {
+      const tasksPath = join(sessionsRoot, entry.name, 'tasks.json');
+      let snapshots: TaskLedgerEventTaskSnapshot[];
+      try {
+        snapshots = decodeTaskSnapshots(await readFile(tasksPath, 'utf8'));
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') continue;
+        throw error;
+      }
+      const projected = projectLegacySnapshots(snapshots);
+      events = projected.tasks.map(
+        (task, index): TaskLedgerEvent => ({
+          eventId: `legacy-import-${index}`,
+          type: 'task_imported',
+          ts: task.createdAt,
+          sessionId: entry.name,
+          taskId: task.id,
+          nextStatus: task.status,
+          task,
+          source: 'import',
+          actor: 'system',
+        }),
+      );
+    }
+    const projection = projectTaskLedgerEvents(events);
+    if (projection.diagnostics.length > 0) {
+      throw new Error(
+        `task event ledger has projection diagnostics: ${projection.diagnostics.join('; ')}`,
+      );
+    }
+    result.push({ sessionId: entry.name, events, tasks: projection.tasks });
+  }
+  return result;
+}
+
+function decodeLegacyTaskLedgerEvents(text: string, sessionId: string): TaskLedgerEvent[] {
+  const events: TaskLedgerEvent[] = [];
+  for (const [index, line] of text.split(/\n/).entries()) {
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (error) {
+      throw new Error(
+        `Invalid task event JSONL line ${index + 1}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+    if (!isTaskLedgerEvent(parsed) || parsed.sessionId !== sessionId) {
+      throw new Error(`Invalid task event JSONL line ${index + 1}: unexpected event shape`);
+    }
+    events.push(parsed);
+  }
+  return events;
+}
+
+function readSqliteTaskLedgerEvents(database: DatabaseSync, sessionId: string): TaskLedgerEvent[] {
+  assertSafeSessionId(sessionId);
+  const rows = database
+    .prepare(`
+      SELECT record_json
+      FROM workflow_task_ledger_events
+      WHERE session_id = ?
+      ORDER BY sequence
+    `)
+    .all(sessionId) as Array<{ record_json?: unknown }>;
+  return rows.map((row, index) => {
+    if (typeof row.record_json !== 'string') {
+      throw new Error(`Invalid SQLite task event at sequence ${index}`);
+    }
+    const parsed = JSON.parse(row.record_json);
+    if (!isTaskLedgerEvent(parsed) || parsed.sessionId !== sessionId) {
+      throw new Error(`Invalid SQLite task event at sequence ${index}`);
+    }
+    return parsed;
+  });
+}
+
+function insertTaskLedgerEvent(
+  database: DatabaseSync,
+  sessionId: string,
+  event: TaskLedgerEvent,
+): void {
+  const row = database
+    .prepare(`
+      SELECT COALESCE(MAX(sequence), -1) + 1 AS sequence
+      FROM workflow_task_ledger_events
+      WHERE session_id = ?
+    `)
+    .get(sessionId) as { sequence?: unknown };
+  if (typeof row.sequence !== 'number' || !Number.isSafeInteger(row.sequence)) {
+    throw new Error('Invalid next task event sequence');
+  }
+  database
+    .prepare(`
+      INSERT INTO workflow_task_ledger_events(
+        session_id, sequence, event_id, record_json
+      ) VALUES (?, ?, ?, ?)
+    `)
+    .run(sessionId, row.sequence, event.eventId, JSON.stringify(event));
+}
+
+function insertOrValidateTaskLedgerEvent(
+  database: DatabaseSync,
+  sessionId: string,
+  event: TaskLedgerEvent,
+): void {
+  const existing = database
+    .prepare(`
+      SELECT record_json
+      FROM workflow_task_ledger_events
+      WHERE session_id = ? AND event_id = ?
+    `)
+    .get(sessionId, event.eventId) as { record_json?: unknown } | undefined;
+  if (existing) {
+    if (existing.record_json !== JSON.stringify(event)) {
+      throw new Error(`Task ledger cutover conflict: ${event.eventId}`);
+    }
+    return;
+  }
+  insertTaskLedgerEvent(database, sessionId, event);
+}
+
+function writeTaskLedgerProjection(database: DatabaseSync, sessionId: string, tasks: Task[]): void {
+  database
+    .prepare(`
+      INSERT INTO workflow_task_ledger_projections(session_id, record_json)
+      VALUES (?, ?)
+      ON CONFLICT(session_id) DO UPDATE SET record_json = excluded.record_json
+    `)
+    .run(sessionId, JSON.stringify(tasks));
 }
 
 function decodeTaskSnapshots(text: string): TaskLedgerEventTaskSnapshot[] {


### PR DESCRIPTION
## Summary

Stage 4a of #1649 moves the workflow ledgers that currently have active production writers into the shared runtime.sqlite authority:

- Task Ledger events and projections
- Plan events and projections
- Deep Research events
- Agent Mailbox messages
- Plan Reminder records

Desktop and Runtime Host now open the SQLite-backed stores, wait for cutover before serving mutations, and release their database leases during orderly shutdown and initialization failures.

## Migration guarantees

- Legacy JSON/JSONL is decoded and validated before cutover.
- Every source set has a deterministic fingerprint recorded in cutover_journal.
- Row copy, validation, and the completed marker commit in one SQLite transaction.
- A failpoint/crash after rows are copied rolls back cleanly and the next open resumes.
- Once cutover completes, mutations are SQLite-only; legacy bytes remain unchanged as migration evidence.
- A later legacy-file change fails closed instead of silently merging two authorities.
- Event ledgers remain canonical; projections are reconstructable.

## Scope boundary

This is deliberately Stage 4a, not a claim that all Stage 4 state is complete. A follow-up Stage 4b will handle usage/pricing and artifact metadata/lifecycle. Artifact payload bytes remain files and need their own recoverable metadata/payload publication protocol.

StoredMessage transcripts remain append-only JSONL. Configuration stores and the separate product/evaluation domains listed in the README are outside #1649.

## Verification

- npm --workspace @maka/storage run test:dist — 839 passed, 1 skipped
- npm --workspace @maka/runtime-host run test:dist — passed
- Runtime Host execution-host suite — 25 passed
- npm --workspace @maka/desktop run build:main — passed
- Desktop workflow wiring contract tests — 3 passed
- Biome lint on changed files and git diff --check — passed

The local full Desktop pretest could not rebuild @maka/ui because this checkout is missing the declared @astryxdesign/core package in node_modules. The affected Desktop main build and migration-specific contracts pass; CI will run from a clean dependency install.