### PR TITLE
fix(runtime-host): arm process lifecycle before readiness

### DIFF
--- a/packages/runtime-host/src/__tests__/fixtures/execution-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/execution-host.ts
@@ -37,16 +37,19 @@ if (recoverySessionId && recoveryRunId) {
   }
 }
 
-process.send?.({
-  type: 'ready',
-  hostEpoch: result.host.hostEpoch,
-  endpoint: result.host.endpoint,
-  ...(recoveryOutcome ? { recoveryOutcome } : {}),
-});
-
 try {
-  await runRuntimeHostProcessLifecycle(result.host, { closeOnDisconnect: true });
-} catch {
+  await runRuntimeHostProcessLifecycle(result.host, {
+    closeOnDisconnect: true,
+    onReady: () =>
+      process.send?.({
+        type: 'ready',
+        hostEpoch: result.host.hostEpoch,
+        endpoint: result.host.endpoint,
+        ...(recoveryOutcome ? { recoveryOutcome } : {}),
+      }),
+  });
+} catch (error) {
+  console.error(error);
   process.exitCode = 1;
 } finally {
   if (process.connected) process.disconnect?.();

--- a/packages/runtime-host/src/__tests__/fixtures/uncooperative-host.ts
+++ b/packages/runtime-host/src/__tests__/fixtures/uncooperative-host.ts
@@ -92,10 +92,12 @@ process.on('message', (message: unknown) => {
     process.send?.({ type: 'shutdown-requested' });
   }
 });
-process.send?.({ type: 'ready', hostEpoch: host.hostEpoch, endpoint: host.endpoint });
-
 try {
-  await runRuntimeHostProcessLifecycle(host, { closeOnDisconnect: true });
+  await runRuntimeHostProcessLifecycle(host, {
+    closeOnDisconnect: true,
+    onReady: () =>
+      process.send?.({ type: 'ready', hostEpoch: host.hostEpoch, endpoint: host.endpoint }),
+  });
 } catch {
   process.exitCode = 1;
 }

--- a/packages/runtime-host/src/__tests__/process-lifecycle.test.ts
+++ b/packages/runtime-host/src/__tests__/process-lifecycle.test.ts
@@ -1,0 +1,33 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import { runRuntimeHostProcessLifecycle } from '../server/process-lifecycle.js';
+
+test('process lifecycle owns termination signals before publishing readiness', async () => {
+  const signalListeners = new Set(process.listeners('SIGTERM'));
+  let closeCalls = 0;
+  let resolveClosed!: () => void;
+  const closed = new Promise<void>((resolve) => {
+    resolveClosed = resolve;
+  });
+  const host = {
+    closed,
+    close: () => {
+      closeCalls += 1;
+      resolveClosed();
+      return closed;
+    },
+  };
+
+  await runRuntimeHostProcessLifecycle(host, {
+    onReady: () => {
+      const terminationHandler = process
+        .listeners('SIGTERM')
+        .find((listener) => !signalListeners.has(listener));
+      assert.ok(terminationHandler);
+      terminationHandler('SIGTERM');
+    },
+  });
+
+  assert.equal(closeCalls, 1);
+  assert.deepEqual(new Set(process.listeners('SIGTERM')), signalListeners);
+});

--- a/packages/runtime-host/src/server/process-lifecycle.ts
+++ b/packages/runtime-host/src/server/process-lifecycle.ts
@@ -5,10 +5,11 @@ import {
 
 export interface RuntimeHostProcessLifecycleOptions {
   closeOnDisconnect?: boolean;
+  onReady?: () => void;
 }
 
 export async function runRuntimeHostProcessLifecycle(
-  host: RuntimeHostKernel,
+  host: Pick<RuntimeHostKernel, 'close' | 'closed'>,
   options: RuntimeHostProcessLifecycleOptions = {},
 ): Promise<void> {
   let closing = false;
@@ -22,6 +23,7 @@ export async function runRuntimeHostProcessLifecycle(
   process.once('SIGTERM', close);
   if (options.closeOnDisconnect) process.once('disconnect', close);
   try {
+    options.onReady?.();
     await host.closed;
   } catch (error) {
     if (error instanceof RuntimeHostProcessTerminationRequiredError) process.exit(1);


### PR DESCRIPTION
<details open>
<summary>English</summary>

## Summary

- install Runtime Host termination and disconnect handlers before a child process publishes readiness
- make execution-host cleanup failures print their underlying error instead of reporting only exit code 1
- cover the readiness ordering and listener cleanup contract with a focused regression test

## Root cause

The test Host fixtures published their `ready` IPC message before entering the process lifecycle helper. A parent that stopped the child immediately after readiness could therefore deliver `SIGTERM` before the child installed its graceful-shutdown handler, producing intermittent CI failures in otherwise unrelated pull requests.

## Validation

- `npm --workspace @maka/runtime-host run typecheck`
- `npx biome lint` on all changed files
- full Runtime Host test suite: 416 passed, 0 failed

</details>

<details>
<summary>中文</summary>

## 概要

- 在子进程发布就绪状态前安装 Runtime Host 的终止和断连处理器
- 在 execution-host 清理失败时输出底层异常，避免只报告退出码 1
- 使用聚焦的回归测试覆盖就绪顺序与监听器清理契约

## 根因

测试 Host fixture 在进入进程生命周期辅助函数之前就发布了 `ready` IPC 消息。父进程若在收到就绪消息后立即停止子进程，可能会在子进程安装优雅关闭处理器之前发送 `SIGTERM`，从而使无关 PR 的 CI 间歇失败。

## 验证

- `npm --workspace @maka/runtime-host run typecheck`
- 对全部改动文件运行 `npx biome lint`
- 完整 Runtime Host 测试套件：416 通过，0 失败

</details>
