### PR TITLE
fix(cli): align readiness fixtures with enabled-model gate

### DIFF
--- a/packages/cli/src/__tests__/connection-target.test.ts
+++ b/packages/cli/src/__tests__/connection-target.test.ts
@@ -826,6 +826,8 @@ describe('default session target resolver', () => {
       slug: 'local',
       providerType: 'ollama',
       defaultModel: 'qwen2.5-coder',
+      // Requested model must be user-enabled; discovered catalog alone is not enough.
+      enabledModelIds: ['qwen2.5-coder', 'llama3.2'],
       models: [{ id: 'qwen2.5-coder' }, { id: 'llama3.2' }],
     });
 

--- a/packages/cli/src/__tests__/runtime-bootstrap.test.ts
+++ b/packages/cli/src/__tests__/runtime-bootstrap.test.ts
@@ -184,7 +184,12 @@ describe('Maka CLI runtime bootstrap', () => {
         defaultModel: 'selected-model',
       });
       await connectionStore.update('selected-local', {
-        models: [{ id: 'requested-model', capabilities: { vision: true } }],
+        // Requested model must be user-enabled; discovered catalog alone is not enough.
+        enabledModelIds: ['selected-model', 'requested-model'],
+        models: [
+          { id: 'selected-model' },
+          { id: 'requested-model', capabilities: { vision: true } },
+        ],
       });
       const observed: unknown[] = [];
       const observer = (result: unknown): void => {


### PR DESCRIPTION
## Summary

Main CI has been red since #1691: `isConnectionReady` now requires the effective model to be in `connectionEnabledModelIds` (user-enabled set), not merely present in the discovered `models` catalog. Two CLI fixtures still requested models that were only in the catalog, so they failed with `NO_REAL_CONNECTION:model_not_enabled`.

This updates those fixtures to match the product contract. No production code change.

Refs #1691

## Verification

- `npm --workspace maka-agent run build`
- `npm --workspace maka-agent run test:dist` — 689 pass / 0 fail (covers both previously failing cases)
- Biome format on the two edited test files

Did not re-run full monorepo CI or e2e locally; those remain on the PR check suite.