### PR TITLE
storage: migrate artifact metadata to SQLite

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,11 +223,20 @@ fingerprinted before their rows and pricing revision are committed atomically.
 After cutover, Desktop and Runtime Host write only `runtime.sqlite`; the source
 files remain unchanged as migration evidence.
 
+Artifact metadata and lifecycle state now follow the same rule. Payload bytes
+remain files, but their records are canonical in `runtime.sqlite` after a
+fingerprinted `metadata.jsonl` cutover. Payload publication keeps its durable
+staging/link protocol: recovery removes bytes whose metadata transaction did not
+commit and preserves committed bytes while cleaning staging residue. Purge
+intent recovery likewise completes against the SQLite metadata authority.
+
 The remaining storage work is deliberately classified rather than implied
 complete:
 
-- artifact metadata and lifecycle state move with a recoverable
-  metadata/payload publication protocol, while payload bytes remain files;
+- session bundle, backup, restore, and trajectory export paths must consume the
+  SQLite artifact metadata authority while preserving payload files;
+- legacy operational writers and compatibility-only JSONL code can be removed
+  only after the migration/cutover matrix is complete;
 - StoredMessage transcript bodies remain append-only JSONL;
 - automation, connections, credentials, settings, MCP configuration, skills,
   and device identity are configuration state and stay outside this operational

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -15,6 +15,7 @@ import type {
   createProjectCatalog,
   createSessionStore,
   createSettingsStore,
+  createSqliteArtifactStore,
   createSqliteTelemetryRepo,
   openRuntimeEventPersistence,
 } from '@maka/storage';
@@ -57,6 +58,7 @@ export interface AppLifecycleDeps {
   connectionStore: ReturnType<typeof createConnectionStore>;
   settingsStore: ReturnType<typeof createSettingsStore>;
   telemetryRepo: ReturnType<typeof createSqliteTelemetryRepo>;
+  artifactStore: ReturnType<typeof createSqliteArtifactStore>;
   ensureUsageReady: () => Promise<void>;
   keepSystemAwake: KeepSystemAwakeController;
   botRegistry: BotRegistry;
@@ -111,6 +113,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     connectionStore,
     settingsStore,
     telemetryRepo,
+    artifactStore,
     ensureUsageReady,
     keepSystemAwake,
     botRegistry,
@@ -391,6 +394,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
       agentGraphCoordinator.close(),
       agentGraphSupervisorWakeCoordinator.close(),
       telemetryRepo.close(),
+      Promise.resolve().then(() => artifactStore.close?.()),
     ]);
     for (const result of results) {
       if (result.status === 'rejected') console.error('[shutdown] cleanup failed:', result.reason);

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -60,7 +60,7 @@ import type { LlmConnection } from '@maka/core/llm-connections';
 import {
   createAgentRunStore,
   createSqliteAgentMailboxStore,
-  createArtifactStore,
+  createSqliteArtifactStore,
   createSqliteDeepResearchStore,
   createReadImageSnapshotter,
   createConnectionStore,
@@ -294,7 +294,7 @@ function ensureMcpReady(): Promise<void> {
 }
 const telemetryRepo = createSqliteTelemetryRepo(workspaceRoot);
 const dailyReviewArchiveStore = createDailyReviewArchiveStore(workspaceRoot);
-const artifactStore = createArtifactStore(workspaceRoot);
+const artifactStore = createSqliteArtifactStore(workspaceRoot);
 const deepResearchStore = createSqliteDeepResearchStore(workspaceRoot);
 const storeReadImage = createReadImageSnapshotter(artifactStore);
 const attachmentApprovals = createAttachmentApprovalRegistry();
@@ -1454,6 +1454,7 @@ wireAppLifecycle({
   connectionStore,
   settingsStore,
   telemetryRepo,
+  artifactStore,
   ensureUsageReady,
   keepSystemAwake,
   botRegistry,

--- a/packages/cli/src/runtime-bootstrap.ts
+++ b/packages/cli/src/runtime-bootstrap.ts
@@ -60,7 +60,7 @@ import {
 import {
   createSqliteAgentRunStore,
   createAttachmentByteReader,
-  createArtifactStore,
+  createSqliteArtifactStore,
   createAutomationStore,
   createConnectionStore,
   createFileCredentialStore,
@@ -235,7 +235,7 @@ export async function createMakaCliRuntimeContext(
     shellRunStore.close();
     throw error;
   });
-  const artifactStore = createArtifactStore(stateRoot);
+  const artifactStore = createSqliteArtifactStore(stateRoot);
   const agentGraphControlStore = agentGraphEnabled
     ? createAgentGraphControlStore(stateRoot)
     : undefined;
@@ -1102,6 +1102,7 @@ export async function createMakaCliRuntimeContext(
       runtimePersistence.close();
       runStore.close?.();
       shellRunStore.close();
+      artifactStore.close?.();
     },
   };
 }

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -739,18 +739,42 @@ class MakaAgent(BaseInstalledAgent):
         runtime_events_path = self._resolve_runtime_events_path()
         if runtime_events_path is None:
             return
-        local_artifact_root = self._trajectory_artifact_store_root() / "artifacts"
+        local_store_root = self._trajectory_artifact_store_root()
+        local_artifact_root = local_store_root / "artifacts"
+        database_path = local_store_root / "runtime.sqlite"
         metadata_path = local_artifact_root / "metadata.jsonl"
-        if metadata_path.is_file():
+        if database_path.is_file() or metadata_path.is_file():
             return
-        remote_artifact_root = EnvironmentPaths.agent_dir / "maka-storage" / "artifacts"
+        remote_store_root = EnvironmentPaths.agent_dir / "maka-storage"
+        remote_artifact_root = remote_store_root / "artifacts"
         try:
             metadata_path.parent.mkdir(parents=True, exist_ok=True)
-            await environment.download_file(
-                (remote_artifact_root / "metadata.jsonl").as_posix(), metadata_path
-            )
+            try:
+                await environment.download_file(
+                    (remote_store_root / "runtime.sqlite").as_posix(), database_path
+                )
+                try:
+                    await environment.download_file(
+                        (remote_store_root / "runtime.sqlite-wal").as_posix(),
+                        Path(f"{database_path}-wal"),
+                    )
+                except Exception:  # noqa: BLE001 - WAL may not exist after checkpoint.
+                    pass
+                try:
+                    await environment.download_file(
+                        (remote_artifact_root / "metadata.jsonl").as_posix(),
+                        metadata_path,
+                    )
+                except Exception:  # noqa: BLE001 - absent after SQLite-native creation.
+                    pass
+            except Exception:  # noqa: BLE001 - support pre-SQLite artifact stores.
+                database_path.unlink(missing_ok=True)
+                Path(f"{database_path}-wal").unlink(missing_ok=True)
+                await environment.download_file(
+                    (remote_artifact_root / "metadata.jsonl").as_posix(), metadata_path
+                )
             for relative_path in referenced_image_artifact_paths(
-                runtime_events_path, metadata_path
+                runtime_events_path, local_store_root
             ):
                 local = local_artifact_root / relative_path
                 local.parent.mkdir(parents=True, exist_ok=True)

--- a/packages/headless/harbor/maka_trajectory.py
+++ b/packages/headless/harbor/maka_trajectory.py
@@ -8,6 +8,7 @@ import math
 import os
 import re
 import shutil
+import sqlite3
 import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -470,25 +471,8 @@ class _ImageArtifactResolver:
     def _artifact_records(self) -> dict[str, dict[str, Any]]:
         if self._records is not None:
             return self._records
-        metadata_path = self.artifact_root / "metadata.jsonl"
-        try:
-            raw = metadata_path.read_text(encoding="utf-8")
-        except (OSError, UnicodeError):
-            raise _IncompleteTrajectoryEvidence("image_artifact_metadata_missing") from None
-        records: dict[str, dict[str, Any]] = {}
-        try:
-            for line in raw.splitlines():
-                if not line.strip():
-                    continue
-                record = json.loads(line)
-                artifact_id = record.get("id") if isinstance(record, dict) else None
-                if not isinstance(artifact_id, str) or not artifact_id or artifact_id in records:
-                    raise ValueError
-                records[artifact_id] = record
-        except (json.JSONDecodeError, ValueError):
-            raise _IncompleteTrajectoryEvidence("image_artifact_metadata_invalid") from None
-        self._records = records
-        return records
+        self._records = _read_artifact_records(self.artifact_root.parent)
+        return self._records
 
 
 def load_runtime_trajectory(
@@ -1932,7 +1916,7 @@ def _observation_content(
 
 def referenced_image_artifact_paths(
     runtime_events_path: Path,
-    metadata_path: Path,
+    artifact_store_root: Path,
 ) -> list[str]:
     """Return validated artifact-root-relative paths needed by image RuntimeEvents."""
     references: dict[str, tuple[str, str]] = {}
@@ -1964,15 +1948,7 @@ def referenced_image_artifact_paths(
                 raise ValueError
             references[artifact_id] = reference
 
-        records: dict[str, dict[str, Any]] = {}
-        for line in metadata_path.read_text(encoding="utf-8").splitlines():
-            if not line.strip():
-                continue
-            record = json.loads(line)
-            artifact_id = record.get("id") if isinstance(record, dict) else None
-            if not isinstance(artifact_id, str) or not artifact_id or artifact_id in records:
-                raise ValueError
-            records[artifact_id] = record
+        records = _read_artifact_records(artifact_store_root)
     except (OSError, UnicodeError, json.JSONDecodeError, ValueError, AttributeError):
         return []
 
@@ -1991,6 +1967,55 @@ def referenced_image_artifact_paths(
             return []
         paths.append(relative_path)
     return paths
+
+
+def _read_artifact_records(artifact_store_root: Path) -> dict[str, dict[str, Any]]:
+    database_path = artifact_store_root / "runtime.sqlite"
+    metadata_path = artifact_store_root / "artifacts" / "metadata.jsonl"
+    serialized_records: Optional[list[str]] = None
+    if database_path.is_file():
+        connection: Optional[sqlite3.Connection] = None
+        try:
+            connection = sqlite3.connect(
+                f"{database_path.resolve().as_uri()}?mode=ro",
+                uri=True,
+            )
+            table = connection.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'artifact_records'"
+            ).fetchone()
+            if table is not None:
+                serialized_records = [
+                    row[0]
+                    for row in connection.execute(
+                        "SELECT record_json FROM artifact_records ORDER BY created_at, storage_key"
+                    )
+                ]
+        except (OSError, sqlite3.Error, TypeError):
+            raise _IncompleteTrajectoryEvidence("image_artifact_metadata_invalid") from None
+        finally:
+            if connection is not None:
+                connection.close()
+    if serialized_records is None:
+        try:
+            serialized_records = [
+                line
+                for line in metadata_path.read_text(encoding="utf-8").splitlines()
+                if line.strip()
+            ]
+        except (OSError, UnicodeError):
+            raise _IncompleteTrajectoryEvidence("image_artifact_metadata_missing") from None
+
+    records: dict[str, dict[str, Any]] = {}
+    try:
+        for serialized in serialized_records:
+            record = json.loads(serialized)
+            artifact_id = record.get("id") if isinstance(record, dict) else None
+            if not isinstance(artifact_id, str) or not artifact_id or artifact_id in records:
+                raise ValueError
+            records[artifact_id] = record
+    except (json.JSONDecodeError, TypeError, ValueError):
+        raise _IncompleteTrajectoryEvidence("image_artifact_metadata_invalid") from None
+    return records
 
 
 def _is_safe_artifact_path(value: str) -> bool:

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -3171,6 +3171,7 @@ function pythonTrajectoryHarborContractScript(root: string): string {
   return String.raw`
 import asyncio
 import json
+import sqlite3
 import sys
 import tempfile
 from pathlib import Path
@@ -3382,9 +3383,24 @@ with tempfile.TemporaryDirectory() as tmp:
 
     class ArtifactDownloadEnvironment:
         async def download_file(self, remote, local):
-            if remote == "/logs/agent/maka-storage/artifacts/metadata.jsonl":
-                Path(local).write_text(downloaded_metadata, encoding="utf-8")
+            if remote == "/logs/agent/maka-storage/runtime.sqlite":
+                database = sqlite3.connect(local)
+                database.execute("""
+                    CREATE TABLE artifact_records (
+                        storage_key TEXT PRIMARY KEY,
+                        created_at INTEGER NOT NULL,
+                        record_json TEXT NOT NULL
+                    )
+                """)
+                database.execute(
+                    "INSERT INTO artifact_records(storage_key, created_at, record_json) VALUES (?, ?, ?)",
+                    ("downloaded-image", 1200, downloaded_metadata.strip()),
+                )
+                database.commit()
+                database.close()
                 return
+            if remote == "/logs/agent/maka-storage/runtime.sqlite-wal":
+                raise FileNotFoundError(remote)
             assert remote == f"/logs/agent/maka-storage/artifacts/{downloaded_relative_path}", remote
             Path(local).write_bytes(b"\x89PNG\r\n\x1a\nfixture")
 

--- a/packages/runtime-host/src/__tests__/artifact-coordinator.test.ts
+++ b/packages/runtime-host/src/__tests__/artifact-coordinator.test.ts
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdir, mkdtemp, rm } from 'node:fs/promises';
+import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
@@ -34,9 +34,7 @@ test('Artifact mutation failure requests Host drain and fails closed', async () 
       now: 1,
     });
 
-    const metadataPath = join(root, 'artifacts', 'metadata.jsonl');
-    await rm(metadataPath);
-    await mkdir(metadataPath);
+    store.close();
     let drainRequests = 0;
     const coordinator = new HostArtifactCoordinator(store, () => {
       drainRequests += 1;

--- a/packages/runtime-host/src/__tests__/artifact-two-client-uds.test.ts
+++ b/packages/runtime-host/src/__tests__/artifact-two-client-uds.test.ts
@@ -165,8 +165,6 @@ test('production Host recovers Artifact publication and preserves deletes across
       const protectedBefore = await Promise.all(
         PROTECTED_ARTIFACTS.map(({ id }) => getArtifact(desktop, sessionId, id)),
       );
-      const metadataPath = join(root, 'artifacts', 'metadata.jsonl');
-      const metadataBefore = await readFile(metadataPath, 'utf8');
       for (const [index, artifact] of PROTECTED_ARTIFACTS.entries()) {
         const client = index % 2 === 0 ? desktop : tui;
         await assert.rejects(
@@ -174,7 +172,6 @@ test('production Host recovers Artifact publication and preserves deletes across
           operationError('operation_conflict'),
         );
       }
-      assert.equal(await readFile(metadataPath, 'utf8'), metadataBefore);
       const protectedAfter = await Promise.all(
         PROTECTED_ARTIFACTS.map(({ id }) => getArtifact(tui, sessionId, id)),
       );

--- a/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
+++ b/packages/runtime-host/src/__tests__/execution-model-composition.test.ts
@@ -582,8 +582,7 @@ test('production Host executes a canonical ai-sdk Session against a real provide
     assert.equal(summaryCaptureFound, true);
 
     const requestsBeforeArtifactFailure = provider.requests.length;
-    await rm(join(root, 'artifacts', 'metadata.jsonl'));
-    await mkdir(join(root, 'artifacts', 'metadata.jsonl'));
+    artifacts.close();
     const failedTurnId = randomUUID();
     const failedStart = await startTurn(
       composition,

--- a/packages/runtime-host/src/server/execution-composition.ts
+++ b/packages/runtime-host/src/server/execution-composition.ts
@@ -47,6 +47,7 @@ export async function createExecutionRuntimeHostComposition(
     | Awaited<ReturnType<typeof openInteractiveTaskLedgerStoreForWrite>>
     | undefined;
   let usageStores: Awaited<ReturnType<typeof openInteractiveUsageStoresForWrite>> | undefined;
+  let artifactStore: Awaited<ReturnType<typeof openInteractiveArtifactStoreForWrite>> | undefined;
   try {
     const runtimePolicyStores = await openInteractiveRuntimePolicyStoresForWrite(
       context.owner.lease,
@@ -54,6 +55,7 @@ export async function createExecutionRuntimeHostComposition(
     const memoryStore = await openInteractiveMemoryBundleStoreForWrite(context.owner.lease);
     taskLedgerStore = await openInteractiveTaskLedgerStoreForWrite(context.owner.lease);
     const openedArtifactStore = await openInteractiveArtifactStoreForWrite(context.owner.lease);
+    artifactStore = openedArtifactStore;
     const openedUsageStores = await openInteractiveUsageStoresForWrite(context.owner.lease);
     usageStores = openedUsageStores;
     await stores.messageReceiptStore.beginHostEpoch(context.hostEpoch);
@@ -391,6 +393,11 @@ export async function createExecutionRuntimeHostComposition(
           errors.push(error);
         }
         try {
+          openedArtifactStore.close();
+        } catch (error) {
+          errors.push(error);
+        }
+        try {
           taskLedgerStore?.close();
         } catch (error) {
           errors.push(error);
@@ -428,6 +435,11 @@ export async function createExecutionRuntimeHostComposition(
     }
     try {
       await usageStores?.close();
+    } catch (closeError) {
+      errors.push(closeError);
+    }
+    try {
+      artifactStore?.close();
     } catch (closeError) {
       errors.push(closeError);
     }

--- a/packages/storage/src/__tests__/artifact-stores.test.ts
+++ b/packages/storage/src/__tests__/artifact-stores.test.ts
@@ -73,6 +73,11 @@ describe('interactive artifact store authority', () => {
         reason: 'not_found',
       });
       await assert.rejects(() => stat(join(root, ARTIFACT_WRITER_LOCK_FILE)), { code: 'ENOENT' });
+
+      first.close();
+      const reopened = await openInteractiveArtifactStoreForWrite(owner.lease);
+      assert.notStrictEqual(reopened, first);
+      assert.equal((await reopened.getInSession('session-1', 'deleted')).record?.status, 'deleted');
     });
   });
 

--- a/packages/storage/src/__tests__/operational-state-store.test.ts
+++ b/packages/storage/src/__tests__/operational-state-store.test.ts
@@ -40,6 +40,7 @@ describe('operational state database cutover', () => {
           .all()
           .map((row) => ({ ...row })),
         [
+          { scope: 'artifact', version: 1 },
           { scope: 'core_execution', version: 1 },
           { scope: 'operational', version: 1 },
           { scope: 'runtime', version: 5 },

--- a/packages/storage/src/__tests__/sqlite-artifact-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-artifact-store.test.ts
@@ -1,0 +1,258 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { link, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, dirname, join } from 'node:path';
+import { describe, test } from 'node:test';
+import {
+  createArtifactStore,
+  createSqliteArtifactStore,
+  createSqliteArtifactStoreWriteAuthority,
+} from '../artifact-store.js';
+import { withArtifactWriterLock } from '../artifact-writer-lock.js';
+
+describe('SQLite artifact metadata', () => {
+  test('cuts over legacy metadata once and makes SQLite canonical without rewriting JSONL', async () => {
+    await withWorkspace(async (root) => {
+      const legacy = createArtifactStore(root);
+      const migrated = await legacy.create(artifactInput('migrated', 'legacy bytes', 1));
+      const metadataPath = join(root, 'artifacts', 'metadata.jsonl');
+      const legacyMetadata = await readFile(metadataPath);
+
+      const store = createSqliteArtifactStore(root);
+      try {
+        assert.deepEqual(await store.get(migrated.id), migrated);
+        const created = await store.create(artifactInput('sqlite', 'canonical bytes', 2));
+        await store.delete(migrated.id);
+
+        assert.deepEqual(await readFile(metadataPath), legacyMetadata);
+        assert.ok((await stat(join(root, 'runtime.sqlite'))).isFile());
+        assert.deepEqual(await store.readText(created.id), {
+          ok: true,
+          text: 'canonical bytes',
+        });
+      } finally {
+        store.close?.();
+      }
+
+      const reopened = createSqliteArtifactStore(root);
+      try {
+        assert.equal((await reopened.get(migrated.id))?.status, 'deleted');
+        assert.equal((await reopened.get('sqlite'))?.status, 'live');
+      } finally {
+        reopened.close?.();
+      }
+    });
+  });
+
+  test('resumes an interrupted cutover atomically', async () => {
+    await withWorkspace(async (root) => {
+      const legacy = createArtifactStore(root);
+      const record = await legacy.create(artifactInput('legacy', 'durable', 1));
+      const interrupted = createSqliteArtifactStore(root, {
+        failpoint: (point) => {
+          if (point === 'after_cutover_rows_copied') {
+            throw new Error('simulated cutover crash');
+          }
+        },
+      });
+      await assert.rejects(() => interrupted.list('session-1'), /simulated cutover crash/);
+      interrupted.close?.();
+
+      const recovered = createSqliteArtifactStore(root);
+      try {
+        assert.deepEqual(await recovered.list('session-1'), [record]);
+        assert.deepEqual(await recovered.readText(record.id), { ok: true, text: 'durable' });
+      } finally {
+        recovered.close?.();
+      }
+    });
+  });
+
+  test('runs the first legacy cutover under the artifact writer lock', async () => {
+    await withWorkspace(async (root) => {
+      await createArtifactStore(root).create(artifactInput('legacy', 'durable', 1));
+      const held = await holdArtifactWriterLock(root);
+      const store = createSqliteArtifactStore(root);
+      let settled = false;
+      const opening = store.list('session-1').finally(() => {
+        settled = true;
+      });
+      await new Promise<void>((resolve) => setImmediate(resolve));
+      assert.equal(settled, false);
+
+      held.release();
+      await held.finished;
+      assert.equal((await opening)[0]?.id, 'legacy');
+      store.close?.();
+    });
+  });
+
+  test('fails closed when an old writer changes JSONL after cutover', async () => {
+    await withWorkspace(async (root) => {
+      const legacy = createArtifactStore(root);
+      await legacy.create(artifactInput('legacy', 'durable', 1));
+      const store = createSqliteArtifactStore(root);
+      await store.list('session-1');
+      store.close?.();
+
+      await createArtifactStore(root).create(artifactInput('old-writer', 'stale', 2));
+      const reopened = createSqliteArtifactStore(root);
+      try {
+        await assert.rejects(
+          () => reopened.list('session-1'),
+          /Legacy artifact_metadata source changed after cutover completed/,
+        );
+      } finally {
+        reopened.close?.();
+      }
+    });
+  });
+
+  test('recovery removes a payload whose SQLite metadata transaction did not commit', async () => {
+    await withWorkspace(async (root) => {
+      const residue = await createPublicationResidue(
+        root,
+        'uncommitted',
+        'uncommitted.txt',
+        'not committed',
+      );
+      const authority = createSqliteArtifactStoreWriteAuthority(root);
+      try {
+        await authority.recover();
+        await assert.rejects(() => stat(residue.stagingPath), { code: 'ENOENT' });
+        await assert.rejects(() => stat(residue.targetPath), { code: 'ENOENT' });
+        assert.equal(await authority.store.get('uncommitted'), null);
+      } finally {
+        authority.close();
+      }
+    });
+  });
+
+  test('recovery keeps a committed payload and removes its publication staging file', async () => {
+    await withWorkspace(async (root) => {
+      const initial = createSqliteArtifactStore(root);
+      const record = await initial.create(artifactInput('committed', 'durable', 1));
+      initial.close?.();
+
+      const targetPath = join(root, 'artifacts', record.relativePath);
+      const stagingPath = publicationStagingPath(targetPath);
+      await writeFile(stagingPath, await readFile(targetPath));
+
+      const authority = createSqliteArtifactStoreWriteAuthority(root);
+      try {
+        await authority.recover();
+        await assert.rejects(() => stat(stagingPath), { code: 'ENOENT' });
+        assert.equal(await readFile(targetPath, 'utf8'), 'durable');
+        assert.deepEqual(await authority.store.readText(record.id), {
+          ok: true,
+          text: 'durable',
+        });
+      } finally {
+        authority.close();
+      }
+    });
+  });
+
+  test('recovery completes a purge interrupted before the SQLite metadata commit', async () => {
+    await withWorkspace(async (root) => {
+      const authority = createSqliteArtifactStoreWriteAuthority(root);
+      try {
+        await authority.recover();
+        const record = await authority.store.create(artifactInput('purge-retry', 'remove me', 1));
+        const payloadPath = join(root, 'artifacts', record.relativePath);
+        const purgeIntentPath = join(root, 'artifacts', '.artifact-purge-intent.json');
+        await rm(payloadPath);
+        await writeFile(
+          purgeIntentPath,
+          JSON.stringify({ schemaVersion: 1, artifactIds: [record.id] }),
+          'utf8',
+        );
+
+        await authority.recover();
+        assert.equal(await authority.store.get(record.id), null);
+        await assert.rejects(() => stat(purgeIntentPath), { code: 'ENOENT' });
+      } finally {
+        authority.close();
+      }
+    });
+  });
+
+  test('does not create legacy metadata for a new SQLite-backed store', async () => {
+    await withWorkspace(async (root) => {
+      const store = createSqliteArtifactStore(root);
+      try {
+        const record = await store.create(artifactInput('sqlite-only', 'bytes', 1));
+        assert.equal(await readFile(join(root, 'artifacts', record.relativePath), 'utf8'), 'bytes');
+        await assert.rejects(() => stat(join(root, 'artifacts', 'metadata.jsonl')), {
+          code: 'ENOENT',
+        });
+      } finally {
+        store.close?.();
+      }
+    });
+  });
+});
+
+function artifactInput(id: string, content: string, now: number) {
+  return {
+    id,
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    name: `${id}.txt`,
+    kind: 'file' as const,
+    content,
+    source: 'fixture' as const,
+    now,
+  };
+}
+
+async function createPublicationResidue(
+  root: string,
+  id: string,
+  name: string,
+  content: string,
+): Promise<{ stagingPath: string; targetPath: string }> {
+  const targetPath = join(root, 'artifacts', 'session-1', `${id}-${name}`);
+  const stagingPath = publicationStagingPath(targetPath);
+  await mkdir(dirname(targetPath), { recursive: true });
+  await writeFile(stagingPath, content, { flag: 'wx' });
+  await link(stagingPath, targetPath);
+  return { stagingPath, targetPath };
+}
+
+function publicationStagingPath(targetPath: string): string {
+  const hash = createHash('sha256').update(basename(targetPath)).digest('hex');
+  return join(
+    dirname(targetPath),
+    `.artifact-publish.${hash}.00000000-0000-4000-8000-000000000000.tmp`,
+  );
+}
+
+async function withWorkspace(run: (root: string) => Promise<void>): Promise<void> {
+  const root = await mkdtemp(join(tmpdir(), 'maka-sqlite-artifact-'));
+  try {
+    await run(root);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+async function holdArtifactWriterLock(
+  root: string,
+): Promise<{ release: () => void; finished: Promise<void> }> {
+  let release!: () => void;
+  let acquired!: () => void;
+  const gate = new Promise<void>((resolve) => {
+    release = resolve;
+  });
+  const entered = new Promise<void>((resolve) => {
+    acquired = resolve;
+  });
+  const finished = withArtifactWriterLock(root, async () => {
+    acquired();
+    await gate;
+  });
+  await entered;
+  return { release, finished };
+}

--- a/packages/storage/src/artifact-metadata-repository.ts
+++ b/packages/storage/src/artifact-metadata-repository.ts
@@ -1,0 +1,8 @@
+import type { ArtifactRecord } from '@maka/core/artifacts';
+
+export interface ArtifactMetadataRepository {
+  ready(): Promise<void>;
+  readAll(): ArtifactRecord[];
+  replaceAll(records: readonly ArtifactRecord[]): void;
+  close(): void;
+}

--- a/packages/storage/src/artifact-store.ts
+++ b/packages/storage/src/artifact-store.ts
@@ -51,6 +51,11 @@ import {
 } from './artifact-writer-lock.js';
 import type { ArtifactWriterLockAuthority } from './root-authority.js';
 import { syncDirectory, syncDirectoryChain, syncFile } from './stable-storage.js';
+import type { ArtifactMetadataRepository } from './artifact-metadata-repository.js';
+import {
+  createSqliteArtifactMetadataRepository,
+  type CreateSqliteArtifactMetadataOptions,
+} from './sqlite-artifact-metadata.js';
 
 export { isSafeRelativeArtifactPath } from './artifact-metadata-codec.js';
 
@@ -156,6 +161,7 @@ export interface ArtifactStore extends ArtifactStoreReader, DurableArtifactAttac
   create(input: CreateArtifactInput): Promise<ArtifactRecord>;
   delete(artifactId: string): Promise<void>;
   purge(artifactIds: readonly string[]): Promise<void>;
+  close?(): void;
 }
 
 export type ArtifactUserDeleteResult =
@@ -188,10 +194,24 @@ export interface ArtifactAuthorityStore extends ArtifactStore {
 export interface ArtifactStoreWriteAuthority {
   readonly store: ArtifactAuthorityStore;
   recover(): Promise<void>;
+  close(): void;
 }
 
 export function createArtifactStore(workspaceRoot: string): ArtifactStore {
   return new FileArtifactStore(workspaceRoot, 'legacy');
+}
+
+export function createSqliteArtifactStore(
+  workspaceRoot: string,
+  options: CreateSqliteArtifactMetadataOptions = {},
+): ArtifactStore {
+  return new FileArtifactStore(
+    workspaceRoot,
+    'legacy',
+    undefined,
+    undefined,
+    createSqliteArtifactMetadataRepository(workspaceRoot, options),
+  );
 }
 
 export function createArtifactStoreWriteAuthority(
@@ -210,6 +230,29 @@ export function createArtifactStoreWriteAuthority(
   return Object.freeze({
     store,
     recover: () => store.recoverForWriteWithAuthority(),
+    close: () => store.close(),
+  });
+}
+
+export function createSqliteArtifactStoreWriteAuthority(
+  workspaceRoot: string,
+  options: {
+    assertAuthority?: () => Promise<void>;
+    leaseBoundWriterLockAuthority?: ArtifactWriterLockAuthority;
+    cutover?: CreateSqliteArtifactMetadataOptions;
+  } = {},
+): ArtifactStoreWriteAuthority {
+  const store = new FileArtifactStore(
+    workspaceRoot,
+    'authority',
+    options.assertAuthority,
+    options.leaseBoundWriterLockAuthority,
+    createSqliteArtifactMetadataRepository(workspaceRoot, options.cutover),
+  );
+  return Object.freeze({
+    store,
+    recover: () => store.recoverForWriteWithAuthority(),
+    close: () => store.close(),
   });
 }
 
@@ -220,6 +263,7 @@ class FileArtifactStore implements ArtifactAuthorityStore {
   private records: ArtifactRecord[] = [];
   private sessionSnapshots = new Map<string, ArtifactSessionSnapshot>();
   private loaded = false;
+  private metadataReady = false;
   private recoveryRequired: boolean;
   private legacyRecoveryRequired: boolean;
   private recoverableOrphans = new Map<string, RecoverableOrphan>();
@@ -231,12 +275,17 @@ class FileArtifactStore implements ArtifactAuthorityStore {
     private readonly recoveryMode: 'legacy' | 'authority',
     private readonly assertAuthority?: () => Promise<void>,
     private readonly leaseBoundWriterLockAuthority?: ArtifactWriterLockAuthority,
+    private readonly metadataRepository?: ArtifactMetadataRepository,
   ) {
     this.artifactRoot = join(workspaceRoot, 'artifacts');
     this.metadataPath = join(this.artifactRoot, 'metadata.jsonl');
     this.purgeIntentPath = join(this.artifactRoot, ARTIFACT_PURGE_INTENT_FILE);
     this.recoveryRequired = recoveryMode === 'authority';
     this.legacyRecoveryRequired = recoveryMode === 'legacy';
+  }
+
+  close(): void {
+    this.metadataRepository?.close();
   }
 
   async create(input: CreateArtifactInput): Promise<ArtifactRecord> {
@@ -731,6 +780,13 @@ class FileArtifactStore implements ArtifactAuthorityStore {
   }
 
   private async load(): Promise<void> {
+    if (this.metadataRepository) {
+      await this.metadataRepository.ready();
+      this.metadataReady = true;
+      this.replaceRecords(this.metadataRepository.readAll());
+      this.loaded = true;
+      return;
+    }
     let handle;
     try {
       handle = await open(this.metadataPath, 'r');
@@ -758,6 +814,13 @@ class FileArtifactStore implements ArtifactAuthorityStore {
   }
 
   private async writeMetadataUnlocked(records: readonly ArtifactRecord[]): Promise<void> {
+    if (this.metadataRepository) {
+      await this.metadataRepository.ready();
+      this.metadataReady = true;
+      this.metadataRepository.replaceAll(records);
+      this.loaded = true;
+      return;
+    }
     const metadataDirectory = dirname(this.metadataPath);
     const createdDirectory = await mkdir(metadataDirectory, { recursive: true });
     if (createdDirectory !== undefined) {
@@ -839,6 +902,13 @@ class FileArtifactStore implements ArtifactAuthorityStore {
   }
 
   private async reloadForMutationUnlocked(): Promise<void> {
+    if (this.metadataRepository) {
+      await this.metadataRepository.ready();
+      this.metadataReady = true;
+      this.replaceRecords(this.metadataRepository.readAll());
+      this.loaded = true;
+      return;
+    }
     try {
       const handle = await open(this.metadataPath, 'r');
       try {
@@ -1334,25 +1404,36 @@ class FileArtifactStore implements ArtifactAuthorityStore {
 
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
     return this.enqueueSerialized(async () => {
+      if (this.metadataRepository && !this.metadataReady) {
+        return this.runWithWriterLock(async () => {
+          await this.assertAuthority?.();
+          await this.metadataRepository?.ready();
+          this.metadataReady = true;
+          return operation();
+        });
+      }
       await this.assertAuthority?.();
       return operation();
     });
   }
 
   private enqueueMutation<T>(operation: () => Promise<T>): Promise<T> {
-    return this.enqueueSerialized(() => {
-      const leaseBoundWriterLockAuthority = this.leaseBoundWriterLockAuthority;
-      if (leaseBoundWriterLockAuthority) {
-        return withLeaseBoundArtifactWriterLock(leaseBoundWriterLockAuthority, async () => {
-          await this.assertAuthority?.();
-          return operation();
-        });
-      }
-      return withArtifactWriterLock(this.workspaceRoot, async (canonicalRoot) => {
-        this.bindLegacyMutationRoot(canonicalRoot);
+    return this.enqueueSerialized(() =>
+      this.runWithWriterLock(async () => {
         await this.assertAuthority?.();
         return operation();
-      });
+      }),
+    );
+  }
+
+  private runWithWriterLock<T>(operation: () => Promise<T>): Promise<T> {
+    const leaseBoundWriterLockAuthority = this.leaseBoundWriterLockAuthority;
+    if (leaseBoundWriterLockAuthority) {
+      return withLeaseBoundArtifactWriterLock(leaseBoundWriterLockAuthority, operation);
+    }
+    return withArtifactWriterLock(this.workspaceRoot, async (canonicalRoot) => {
+      this.bindLegacyMutationRoot(canonicalRoot);
+      return operation();
     });
   }
 }

--- a/packages/storage/src/artifact-stores.ts
+++ b/packages/storage/src/artifact-stores.ts
@@ -1,6 +1,6 @@
 import type { ArtifactRecord } from '@maka/core/artifacts';
 import {
-  createArtifactStoreWriteAuthority,
+  createSqliteArtifactStoreWriteAuthority,
   type ArtifactAuthorityStore,
   type ArtifactStoreWriteAuthority,
   type CreateArtifactInput,
@@ -36,13 +36,14 @@ export interface InteractiveArtifactStoreWriter extends DurableArtifactAttachmen
   readTextInSession: ArtifactAuthorityStore['readTextInSession'];
   readBinaryInSession: ArtifactAuthorityStore['readBinaryInSession'];
   deleteUserArtifactInSession: ArtifactAuthorityStore['deleteUserArtifactInSession'];
+  close(): void;
 }
 
 export type HeadlessArtifactStoreWriter = Readonly<
   Pick<
     ArtifactAuthorityStore,
     'create' | 'list' | 'get' | 'readText' | 'readBinary' | 'readDurableAttachmentBinary'
-  >
+  > & { close(): void }
 >;
 
 export function authenticateInteractiveArtifactStoreWriter(
@@ -67,7 +68,7 @@ export async function openInteractiveArtifactStoreForWrite(
       'interactive',
     );
     const assertAuthority = createStorageRootLeaseIdentityGuard(lease, 'interactive', 'write');
-    const authority = createArtifactStoreWriteAuthority(lease.canonicalPath, {
+    const authority = createSqliteArtifactStoreWriteAuthority(lease.canonicalPath, {
       assertAuthority,
       leaseBoundWriterLockAuthority,
     });
@@ -102,7 +103,7 @@ export async function openHeadlessArtifactStoreForWrite(
       'headless',
     );
     const assertAuthority = createStorageRootLeaseIdentityGuard(lease, 'headless', 'write');
-    const authority = createArtifactStoreWriteAuthority(lease.canonicalPath, {
+    const authority = createSqliteArtifactStoreWriteAuthority(lease.canonicalPath, {
       assertAuthority,
       leaseBoundWriterLockAuthority,
     });
@@ -132,7 +133,7 @@ function createHeadlessWriterFacade(
   const { store } = authority;
   const run = <T>(operation: () => Promise<T>) =>
     runWithStorageRootLease(lease, 'headless', 'write', operation);
-  return Object.freeze({
+  const facade: HeadlessArtifactStoreWriter = Object.freeze({
     create: (input) => {
       const acceptedInput = snapshotCreateInput(input);
       return run(() => store.create(acceptedInput));
@@ -142,7 +143,12 @@ function createHeadlessWriterFacade(
     readText: (artifactId, options) => run(() => store.readText(artifactId, options)),
     readBinary: (artifactId, options) => run(() => store.readBinary(artifactId, options)),
     readDurableAttachmentBinary: (input) => run(() => store.readDurableAttachmentBinary(input)),
+    close: () => {
+      if (headlessWriterByLease.get(lease) === facade) headlessWriterByLease.delete(lease);
+      authority.close();
+    },
   });
+  return facade;
 }
 
 function createWriterFacade(
@@ -170,6 +176,10 @@ function createWriterFacade(
     },
     deleteUserArtifactInSession: (sessionId, artifactId) =>
       run(() => store.deleteUserArtifactInSession(sessionId, artifactId)),
+    close: () => {
+      if (writerByLease.get(lease) === facade) writerByLease.delete(lease);
+      authority.close();
+    },
   };
   return Object.freeze(facade);
 }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -28,6 +28,7 @@ export {
   ARTIFACT_BINARY_PREVIEW_LIMIT_BYTES,
   ARTIFACT_TEXT_PREVIEW_LIMIT_BYTES,
   createArtifactStore,
+  createSqliteArtifactStore,
   isSafeRelativeArtifactPath,
   resolveArtifactPath,
   sanitizeArtifactName,

--- a/packages/storage/src/operational-state-store.ts
+++ b/packages/storage/src/operational-state-store.ts
@@ -21,6 +21,10 @@ import {
   SQLITE_WORKFLOW_SCHEMA_VERSION,
 } from './sqlite-workflow-schema.js';
 import { migrateSqliteUsageDatabase, SQLITE_USAGE_SCHEMA_VERSION } from './sqlite-usage-schema.js';
+import {
+  migrateSqliteArtifactDatabase,
+  SQLITE_ARTIFACT_SCHEMA_VERSION,
+} from './sqlite-artifact-schema.js';
 
 export const OPERATIONAL_STATE_DATABASE_NAME = 'runtime.sqlite';
 export const LEGACY_SESSION_METADATA_DATABASE_NAME = 'sessions.sqlite';
@@ -128,6 +132,7 @@ class OperationalStateDatabaseOwner {
       migrateSqliteCoreExecutionDatabase(this.database);
       migrateSqliteWorkflowDatabase(this.database);
       migrateSqliteUsageDatabase(this.database);
+      migrateSqliteArtifactDatabase(this.database);
       migrateOperationalStateDatabase(this.database, options.now ?? Date.now);
       cutoverLegacySessionMetadata({
         destination: this.database,
@@ -207,6 +212,7 @@ function migrateOperationalStateDatabase(db: DatabaseSync, now: () => number): v
     registerSchema(db, 'core_execution', SQLITE_CORE_EXECUTION_SCHEMA_VERSION, appliedAt);
     registerSchema(db, 'workflow', SQLITE_WORKFLOW_SCHEMA_VERSION, appliedAt);
     registerSchema(db, 'usage', SQLITE_USAGE_SCHEMA_VERSION, appliedAt);
+    registerSchema(db, 'artifact', SQLITE_ARTIFACT_SCHEMA_VERSION, appliedAt);
     registerSchema(db, 'operational', OPERATIONAL_STATE_SCHEMA_VERSION, appliedAt);
     db.exec('COMMIT');
   } catch (error) {

--- a/packages/storage/src/sqlite-artifact-metadata.ts
+++ b/packages/storage/src/sqlite-artifact-metadata.ts
@@ -1,0 +1,181 @@
+import { createHash } from 'node:crypto';
+import { readFile } from 'node:fs/promises';
+import { join, resolve } from 'node:path';
+import type { ArtifactRecord } from '@maka/core/artifacts';
+import type { ArtifactMetadataRepository } from './artifact-metadata-repository.js';
+import { decodeArtifactMetadata } from './artifact-metadata-codec.js';
+import {
+  acquireOperationalStateDatabase,
+  completeOperationalStoreCutover,
+  type OperationalStateDatabaseLease,
+  type OperationalStoreCutoverFailpoint,
+} from './operational-state-store.js';
+
+export interface CreateSqliteArtifactMetadataOptions {
+  readonly failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
+}
+
+export function createSqliteArtifactMetadataRepository(
+  workspaceRoot: string,
+  options: CreateSqliteArtifactMetadataOptions = {},
+): ArtifactMetadataRepository {
+  return new SqliteArtifactMetadataRepository(workspaceRoot, options.failpoint);
+}
+
+class SqliteArtifactMetadataRepository implements ArtifactMetadataRepository {
+  readonly #root: string;
+  readonly #lease: OperationalStateDatabaseLease;
+  readonly #failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
+  #ready: Promise<void> | undefined;
+  #closed = false;
+
+  constructor(
+    workspaceRoot: string,
+    failpoint?: (point: OperationalStoreCutoverFailpoint) => void,
+  ) {
+    this.#root = resolve(workspaceRoot);
+    this.#lease = acquireOperationalStateDatabase(this.#root);
+    this.#failpoint = failpoint;
+  }
+
+  ready(): Promise<void> {
+    this.assertOpen();
+    this.#ready ??= importLegacyArtifactMetadata(this.#root, this.#lease, this.#failpoint);
+    return this.#ready;
+  }
+
+  readAll(): ArtifactRecord[] {
+    this.assertOpen();
+    const rows = this.#lease.database
+      .prepare(`
+        SELECT record_json
+        FROM artifact_records
+        ORDER BY created_at, storage_key
+      `)
+      .all() as Array<{ record_json: string }>;
+    return decodeRows(rows);
+  }
+
+  replaceAll(records: readonly ArtifactRecord[]): void {
+    this.assertOpen();
+    this.#lease.transaction('write', () => {
+      this.#lease.database.prepare('DELETE FROM artifact_records').run();
+      const insert = this.#lease.database.prepare(`
+        INSERT INTO artifact_records(
+          storage_key,
+          artifact_id,
+          session_id,
+          created_at,
+          status,
+          relative_path,
+          record_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+      `);
+      for (const record of records) {
+        insert.run(
+          artifactIdentityKey(record.id),
+          record.id,
+          record.sessionId,
+          record.createdAt,
+          record.status,
+          record.relativePath,
+          JSON.stringify(record),
+        );
+      }
+    });
+  }
+
+  close(): void {
+    if (this.#closed) return;
+    this.#closed = true;
+    this.#lease.close();
+  }
+
+  private assertOpen(): void {
+    if (this.#closed) throw new Error('Artifact metadata repository is closed');
+  }
+}
+
+async function importLegacyArtifactMetadata(
+  root: string,
+  lease: OperationalStateDatabaseLease,
+  failpoint?: (point: OperationalStoreCutoverFailpoint) => void,
+): Promise<void> {
+  const sourcePath = join(root, 'artifacts', 'metadata.jsonl');
+  const source = await readOptionalText(sourcePath);
+  const records = source === undefined ? [] : decodeArtifactMetadata(source);
+  const fingerprint = `sha256:${createHash('sha256')
+    .update(source === undefined ? 'missing' : source)
+    .digest('hex')}`;
+  completeOperationalStoreCutover(lease, {
+    storeName: 'artifact_metadata',
+    sourcePath,
+    sourceFingerprint: fingerprint,
+    failpoint,
+    importAndValidate: (database) => {
+      const insert = database.prepare(`
+        INSERT INTO artifact_records(
+          storage_key,
+          artifact_id,
+          session_id,
+          created_at,
+          status,
+          relative_path,
+          record_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(storage_key) DO UPDATE SET
+          artifact_id = excluded.artifact_id,
+          session_id = excluded.session_id,
+          created_at = excluded.created_at,
+          status = excluded.status,
+          relative_path = excluded.relative_path,
+          record_json = excluded.record_json
+      `);
+      for (const record of records) {
+        insert.run(
+          artifactIdentityKey(record.id),
+          record.id,
+          record.sessionId,
+          record.createdAt,
+          record.status,
+          record.relativePath,
+          JSON.stringify(record),
+        );
+      }
+      const persisted = database
+        .prepare('SELECT record_json FROM artifact_records ORDER BY created_at, storage_key')
+        .all() as Array<{ record_json: string }>;
+      const decoded = decodeRows(persisted);
+      if (decoded.length !== records.length || !sameRecordSet(decoded, records)) {
+        throw new Error('Artifact metadata cutover validation failed');
+      }
+      return { records: records.length };
+    },
+  });
+}
+
+function decodeRows(rows: readonly { record_json: string }[]): ArtifactRecord[] {
+  const text = rows.map((row) => row.record_json).join('\n');
+  return decodeArtifactMetadata(text ? `${text}\n` : '');
+}
+
+function sameRecordSet(left: readonly ArtifactRecord[], right: readonly ArtifactRecord[]): boolean {
+  const canonical = (records: readonly ArtifactRecord[]) =>
+    [...records].map((record) => JSON.stringify(record)).sort((a, b) => a.localeCompare(b));
+  const leftRecords = canonical(left);
+  const rightRecords = canonical(right);
+  return leftRecords.every((record, index) => record === rightRecords[index]);
+}
+
+function artifactIdentityKey(id: string): string {
+  return createHash('sha256').update(JSON.stringify(id)).digest('hex');
+}
+
+async function readOptionalText(path: string): Promise<string | undefined> {
+  try {
+    return await readFile(path, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+}

--- a/packages/storage/src/sqlite-artifact-schema.ts
+++ b/packages/storage/src/sqlite-artifact-schema.ts
@@ -1,0 +1,23 @@
+import type { DatabaseSync } from 'node:sqlite';
+
+export const SQLITE_ARTIFACT_SCHEMA_VERSION = 1;
+
+export function migrateSqliteArtifactDatabase(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS artifact_records (
+      storage_key TEXT PRIMARY KEY,
+      artifact_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      created_at INTEGER NOT NULL CHECK (created_at >= 0),
+      status TEXT NOT NULL CHECK (status IN ('live', 'deleted')),
+      relative_path TEXT NOT NULL,
+      record_json TEXT NOT NULL
+    );
+
+    CREATE INDEX IF NOT EXISTS artifact_records_session_order
+      ON artifact_records(session_id, created_at, storage_key);
+
+    CREATE UNIQUE INDEX IF NOT EXISTS artifact_records_relative_path
+      ON artifact_records(relative_path);
+  `);
+}


### PR DESCRIPTION
## Summary

- add the artifact schema and metadata repository to the shared `runtime.sqlite` operational authority
- cut over legacy `artifacts/metadata.jsonl` once under the artifact writer lock, with fingerprinted journal validation and fail-closed old-writer detection
- keep payload bytes as files while reusing the durable staging/link and purge-intent recovery protocol against SQLite metadata transactions
- wire CLI, Desktop, Runtime Host, and Headless artifact writers to the SQLite-backed store and close their database leases
- teach Harbor trajectory image collection to read `artifact_records` from `runtime.sqlite`, with legacy JSONL fallback

## Crash and migration guarantees

- interrupted legacy import rolls back and resumes idempotently
- payload linked without a committed metadata row is removed during recovery
- committed metadata preserves the payload and removes publication staging residue
- interrupted purge completes payload and SQLite metadata cleanup from the durable purge intent
- a changed legacy JSONL source after completed cutover fails closed
- a new workspace does not create `metadata.jsonl`

## Verification

- `npm --workspace @maka/storage test` — 849 passed, 1 skipped
- `npm --workspace @maka/runtime-host test` — 414 passed
- Storage, Runtime Host, Headless, CLI typechecks
- Desktop main build
- Biome checks and Python `py_compile`
- direct SQLite trajectory metadata smoke

The full local Harbor adapter file also encountered two unrelated environment-sensitive Python 3.9 failures in the Kimi/Codex adapter tests; the modified trajectory path was validated separately.

Part of #1649. The selected-session bundle / backup relational-closure work remains the next planned PR (Stage 5).