### PR TITLE
fix(desktop): keep swarm parents visible

### DIFF
--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -420,6 +420,36 @@ describe('sidebar project view mode', () => {
     );
   });
 
+  it('keeps a running parent visible when preview metadata is temporarily unavailable', () => {
+    const parent = makeSessionSummary({
+      id: 'running-parent',
+      name: 'Running parent',
+      status: 'running',
+      lastMessageAt: undefined,
+    });
+    const child = makeSessionSummary({
+      id: 'completed-child',
+      name: 'Completed child',
+      status: 'active',
+      lastMessageAt: 50,
+      subagentParent: childRelation(parent.id),
+    });
+    const tree = filterLinkedSessionTree(
+      projectLinkedSessionTree([parent, child]),
+      (session) =>
+        sessionMatchesNavSelection(session, { section: 'sessions', filter: 'chats' }),
+    );
+
+    assert.deepEqual(
+      tree.roots.map((session) => session.id),
+      [parent.id],
+    );
+    assert.deepEqual(
+      tree.childrenByParentId.get(parent.id)?.map((session) => session.id),
+      [child.id],
+    );
+  });
+
   it('AppShell derives only project groups and lets conversation mode use the flat list', async () => {
     const appShell = await readRepo('apps/desktop/src/renderer/app-shell.tsx');
     const panel = await readRepo('packages/ui/src/session-list-panel.tsx');

--- a/apps/desktop/src/renderer/session-nav-filter.ts
+++ b/apps/desktop/src/renderer/session-nav-filter.ts
@@ -8,10 +8,10 @@ export function sessionMatchesNavSelection(
   const filter = selection.section === 'sessions' ? selection.filter : 'chats';
   switch (filter) {
     case 'flagged':
-      return Boolean(session.isFlagged && !session.isArchived && session.lastMessageAt);
+      return session.isFlagged && !session.isArchived;
     case 'archived':
       return session.isArchived;
     case 'chats':
-      return Boolean(!session.isArchived && session.lastMessageAt);
+      return !session.isArchived;
   }
 }


### PR DESCRIPTION
## Summary

- derive Chats and Flagged membership from session lifecycle state instead of optional preview metadata
- keep Swarm parents visible while transcript preview metadata is temporarily unavailable
- preserve the parent-child tree instead of promoting children to roots

## Root cause

`lastMessageAt` is optional presentation metadata, but the navigation filter treated it as proof that a session exists in Chats. A running parent could therefore disappear during a transient preview gap even though its child sessions remained visible.

## Validation

- regression test reproduces a running parent without `lastMessageAt` and a completed child with preview metadata
- affected contract suite: 16/16 passed
- Desktop TypeScript typecheck passed
- Biome check passed
- full Desktop suite previously passed: 2803/2803
- production build and Electron session-management E2E previously passed