### PR TITLE
storage: define session bundle codec contract

### DIFF
--- a/packages/storage/src/__tests__/root-authority-dependency.test.ts
+++ b/packages/storage/src/__tests__/root-authority-dependency.test.ts
@@ -11,6 +11,16 @@ const projectConfig = join(process.cwd(), 'tsconfig.json');
 const compilerSnapshot = compilerApi.updateSnapshot({ openProjects: [projectConfig] });
 const compilerProject = loadCompilerProject();
 const allowedAuthorityLocalModules = new Set(['marker-file.ts', 'root-authority.ts']);
+const sessionBundleCodecEntrypoints = [
+  join(sourceRoot, 'session-bundle-contract.ts'),
+  join(sourceRoot, 'session-bundle-manifest.ts'),
+  join(sourceRoot, 'session-bundle-canonical-tree.ts'),
+];
+const allowedSessionBundleCodecLocalModules = new Set([
+  'session-bundle-contract.ts',
+  'session-bundle-manifest.ts',
+  'session-bundle-canonical-tree.ts',
+]);
 const allowedAuthorityExternalImports = new Set([
   'fs-native-extensions',
   'node:crypto',
@@ -19,6 +29,7 @@ const allowedAuthorityExternalImports = new Set([
   'node:os',
   'node:path',
 ]);
+const allowedSessionBundleCodecExternalImports = new Set(['node:buffer', 'node:crypto']);
 
 async function dependencyScannerFixture(target: string): Promise<void> {
   await import(`node:url`);
@@ -61,6 +72,28 @@ test('root authority cannot transitively reach domain Stores or Runtime composit
       }
       if (allowedAuthorityExternalImports.has(specifier)) continue;
       violations.push(`${localPath}: ${specifier}`);
+    }
+  }
+  assert.deepEqual(violations, []);
+});
+
+test('Session Bundle codec primitives cannot transitively reach Maka state semantics', () => {
+  const violations: string[] = [];
+  for (const entrypoint of sessionBundleCodecEntrypoints) {
+    for (const path of reachableModules(entrypoint)) {
+      const localPath = relative(sourceRoot, path);
+      if (!allowedSessionBundleCodecLocalModules.has(localPath)) {
+        violations.push(`Session Bundle codec reaches ${localPath}`);
+      }
+      for (const specifier of moduleSpecifiers(path)) {
+        if (isRelativeSpecifier(specifier)) {
+          const target = sourcePathForSpecifier(path, specifier);
+          if (!isInside(sourceRoot, target)) violations.push(`${localPath}: ${specifier}`);
+          continue;
+        }
+        if (allowedSessionBundleCodecExternalImports.has(specifier)) continue;
+        violations.push(`${localPath}: ${specifier}`);
+      }
     }
   }
   assert.deepEqual(violations, []);

--- a/packages/storage/src/__tests__/session-bundle-canonical-tree.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-canonical-tree.test.ts
@@ -1,0 +1,311 @@
+import assert from 'node:assert/strict';
+import { createHash } from 'node:crypto';
+import { test } from 'node:test';
+import {
+  compareSessionBundleCanonicalPaths,
+  computeSessionBundleCanonicalTreeDigest,
+  encodeSessionBundleCanonicalTree,
+  SessionBundleCanonicalTreeDigestBuilder,
+  SessionBundleFileError,
+  type SessionBundleCanonicalTreeEntry,
+  type Sha256Digest,
+} from '../index.js';
+
+const identityDigest: Sha256Digest =
+  'sha256:0e9561cfb83d50990a103b3896fe249a11fe27fa28985448187f93ec12116d72';
+const executableDigest: Sha256Digest =
+  'sha256:b4d644d4279594903f1a9911956432d9473041f2984fc6014c14d7402c7d126c';
+const emptyDigest = `sha256:${createHash('sha256').update('').digest('hex')}` as Sha256Digest;
+
+const canonicalEntries: readonly SessionBundleCanonicalTreeEntry[] = [
+  {
+    kind: 'file',
+    path: 'state-identity.json',
+    mode: 0o644,
+    size: 19,
+    contentDigest: identityDigest,
+  },
+  { kind: 'directory', path: 'state/' },
+  { kind: 'directory', path: 'state/empty/' },
+  { kind: 'directory', path: 'workspace/' },
+  {
+    kind: 'file',
+    path: 'workspace/run.sh',
+    mode: 0o755,
+    size: 18,
+    contentDigest: executableDigest,
+  },
+];
+
+const unsortedEntries: readonly SessionBundleCanonicalTreeEntry[] = [
+  canonicalEntries[3],
+  canonicalEntries[0],
+  canonicalEntries[2],
+  canonicalEntries[4],
+  canonicalEntries[1],
+];
+
+const expectedTreeHex = [
+  '4d414b415f53455353494f4e5f42554e444c455f5452454500',
+  '00000001',
+  '0000000000000005',
+  '02',
+  '00000013',
+  '73746174652d6964656e746974792e6a736f6e',
+  '01a4',
+  '0000000000000013',
+  '0e9561cfb83d50990a103b3896fe249a11fe27fa28985448187f93ec12116d72',
+  '01',
+  '00000006',
+  '73746174652f',
+  '01ed',
+  '0000000000000000',
+  '0000000000000000000000000000000000000000000000000000000000000000',
+  '01',
+  '0000000c',
+  '73746174652f656d7074792f',
+  '01ed',
+  '0000000000000000',
+  '0000000000000000000000000000000000000000000000000000000000000000',
+  '01',
+  '0000000a',
+  '776f726b73706163652f',
+  '01ed',
+  '0000000000000000',
+  '0000000000000000000000000000000000000000000000000000000000000000',
+  '02',
+  '00000010',
+  '776f726b73706163652f72756e2e7368',
+  '01ed',
+  '0000000000000012',
+  'b4d644d4279594903f1a9911956432d9473041f2984fc6014c14d7402c7d126c',
+].join('');
+
+const expectedTreeDigest =
+  'sha256:429f57cded2f9a22620adc7da0ad9d33eb1c690f8ded102042e7c6904c70d0df';
+
+test('pins exact canonical tree-record bytes and SHA-256 digest', () => {
+  const encoded = encodeSessionBundleCanonicalTree(unsortedEntries);
+  assert.equal(Buffer.from(encoded).toString('hex'), expectedTreeHex);
+  assert.equal(encoded.byteLength, 335);
+  assert.equal(`sha256:${createHash('sha256').update(encoded).digest('hex')}`, expectedTreeDigest);
+  assert.deepEqual(computeSessionBundleCanonicalTreeDigest(unsortedEntries), {
+    treeDigest: expectedTreeDigest,
+    payloadBytes: 37,
+    entryCount: 5,
+  });
+});
+
+test('incrementally hashes the same stream without retaining file bytes', () => {
+  const builder = new SessionBundleCanonicalTreeDigestBuilder(canonicalEntries.length);
+  for (const entry of canonicalEntries) builder.add(entry);
+  assert.deepEqual(builder.finish(), {
+    treeDigest: expectedTreeDigest,
+    payloadBytes: 37,
+    entryCount: 5,
+  });
+  assert.deepEqual(builder.finish(), {
+    treeDigest: expectedTreeDigest,
+    payloadBytes: 37,
+    entryCount: 5,
+  });
+  assertBundleError(() => builder.add(canonicalEntries[0]), 'integrity_mismatch');
+
+  const incomplete = new SessionBundleCanonicalTreeDigestBuilder(canonicalEntries.length + 1);
+  for (const entry of canonicalEntries) incomplete.add(entry);
+  assertBundleError(() => incomplete.finish(), 'integrity_mismatch');
+});
+
+test('preserves raw UTF-8 path bytes without Unicode normalization', () => {
+  const decomposed = 'state/e\u0301.txt';
+  const composed = 'state/é.txt';
+  assert.ok(compareSessionBundleCanonicalPaths(decomposed, composed) < 0);
+
+  const result = computeSessionBundleCanonicalTreeDigest([
+    ...canonicalEntries.filter((entry) => entry.path !== 'state/empty/'),
+    {
+      kind: 'file',
+      path: composed,
+      mode: 0o644,
+      size: 0,
+      contentDigest: emptyDigest,
+    },
+    {
+      kind: 'file',
+      path: decomposed,
+      mode: 0o644,
+      size: 0,
+      contentDigest: emptyDigest,
+    },
+  ]);
+  assert.equal(result.entryCount, 6);
+  assert.notEqual(result.treeDigest, expectedTreeDigest);
+});
+
+test('makes empty directories and executable semantics digest-significant', () => {
+  const withoutEmptyDirectory = canonicalEntries.filter((entry) => entry.path !== 'state/empty/');
+  const nonExecutable = canonicalEntries.map((entry) =>
+    entry.kind === 'file' && entry.path === 'workspace/run.sh'
+      ? { ...entry, mode: 0o644 as const }
+      : entry,
+  );
+  assert.notEqual(
+    computeSessionBundleCanonicalTreeDigest(withoutEmptyDirectory).treeDigest,
+    expectedTreeDigest,
+  );
+  assert.notEqual(
+    computeSessionBundleCanonicalTreeDigest(nonExecutable).treeDigest,
+    expectedTreeDigest,
+  );
+});
+
+test('rejects traversal, host path syntax, invalid Unicode, and paths outside V1 roots', () => {
+  for (const path of [
+    '/state/file',
+    'C:/state/file',
+    'state\\file',
+    'state/../secret',
+    'state/./file',
+    'state//file',
+    'state/\ud800',
+    'other/file',
+  ]) {
+    assertBundleError(
+      () =>
+        computeSessionBundleCanonicalTreeDigest([
+          ...canonicalEntries,
+          {
+            kind: 'file',
+            path,
+            mode: 0o644,
+            size: 0,
+            contentDigest: emptyDigest,
+          },
+        ]),
+      'unsafe_path',
+    );
+  }
+});
+
+test('rejects duplicate, conflicting, orphaned, and incomplete payload trees', () => {
+  assertBundleError(
+    () => computeSessionBundleCanonicalTreeDigest([...canonicalEntries, canonicalEntries[1]]),
+    'unsafe_path',
+  );
+  assertBundleError(
+    () =>
+      computeSessionBundleCanonicalTreeDigest([
+        ...canonicalEntries,
+        {
+          kind: 'file',
+          path: 'state/empty',
+          mode: 0o644,
+          size: 0,
+          contentDigest: emptyDigest,
+        },
+      ]),
+    'unsafe_path',
+  );
+  assertBundleError(
+    () =>
+      computeSessionBundleCanonicalTreeDigest([
+        ...canonicalEntries,
+        {
+          kind: 'file',
+          path: 'state/missing/file',
+          mode: 0o644,
+          size: 0,
+          contentDigest: emptyDigest,
+        },
+      ]),
+    'unsafe_path',
+  );
+  assertBundleError(
+    () =>
+      computeSessionBundleCanonicalTreeDigest(
+        canonicalEntries.filter((entry) => entry.path !== 'workspace/'),
+      ),
+    'unsafe_path',
+  );
+});
+
+test('rejects non-normalized file metadata and an out-of-order streaming source', () => {
+  for (const entry of [
+    {
+      kind: 'file',
+      path: 'state/private',
+      mode: 0o600,
+      size: 0,
+      contentDigest: emptyDigest,
+    },
+    {
+      kind: 'file',
+      path: 'state/bad-digest',
+      mode: 0o644,
+      size: 0,
+      contentDigest: `sha256:${'AB'.repeat(32)}`,
+    },
+    {
+      kind: 'file',
+      path: 'state-identity.json',
+      mode: 0o755,
+      size: 19,
+      contentDigest: identityDigest,
+    },
+  ]) {
+    assertBundleError(
+      () =>
+        computeSessionBundleCanonicalTreeDigest([
+          ...canonicalEntries.filter(
+            (candidate) =>
+              candidate.path !== (entry.path === 'state-identity.json' ? entry.path : ''),
+          ),
+          entry as unknown as SessionBundleCanonicalTreeEntry,
+        ]),
+      'unsupported_entry',
+    );
+  }
+
+  const builder = new SessionBundleCanonicalTreeDigestBuilder(canonicalEntries.length);
+  builder.add(canonicalEntries[1]);
+  assertBundleError(() => builder.add(canonicalEntries[0]), 'unsafe_path');
+  assertBundleError(() => builder.finish(), 'integrity_mismatch');
+});
+
+test('fails closed after aggregate payload size overflows', () => {
+  const builder = new SessionBundleCanonicalTreeDigestBuilder(4);
+  builder.add({
+    kind: 'file',
+    path: 'state-identity.json',
+    mode: 0o644,
+    size: Number.MAX_SAFE_INTEGER,
+    contentDigest: identityDigest,
+  });
+  builder.add({ kind: 'directory', path: 'state/' });
+
+  assertBundleError(
+    () =>
+      builder.add({
+        kind: 'file',
+        path: 'state/file',
+        mode: 0o644,
+        size: 1,
+        contentDigest: emptyDigest,
+      }),
+    'unsupported_entry',
+  );
+
+  assertBundleError(
+    () => builder.add({ kind: 'directory', path: 'workspace/' }),
+    'integrity_mismatch',
+  );
+  assertBundleError(() => builder.finish(), 'integrity_mismatch');
+});
+
+function assertBundleError(action: () => unknown, code: SessionBundleFileError['code']): void {
+  assert.throws(action, (error) => {
+    assert.ok(error instanceof SessionBundleFileError);
+    assert.equal(error.code, code);
+    return true;
+  });
+}

--- a/packages/storage/src/__tests__/session-bundle-contract.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-contract.test.ts
@@ -1,0 +1,129 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  assertSessionBundleLimits,
+  copyOpaqueStateIdentityDescriptor,
+  isSha256Digest,
+  isValidUnicodeString,
+  SESSION_BUNDLE_LIMIT_NAMES,
+  SessionBundleFileError,
+  type SessionBundleLimits,
+} from '../index.js';
+
+const limits: SessionBundleLimits = {
+  maxCompressedBytes: 0,
+  maxDecompressedTarBytes: 0,
+  maxPayloadBytes: 0,
+  maxFileBytes: 0,
+  maxEntryCount: 0,
+  maxManifestBytes: 0,
+  maxStateIdentityBytes: 0,
+  maxPathBytes: 0,
+  maxPathDepth: 0,
+};
+
+test('exposes strict lowercase SHA-256 digest validation', () => {
+  const digest = `sha256:${'ab'.repeat(32)}`;
+  assert.equal(isSha256Digest(digest), true);
+  assert.equal(isSha256Digest(`sha256:${'AB'.repeat(32)}`), false);
+  assert.equal(isSha256Digest(`sha256:${'ab'.repeat(31)}`), false);
+  assert.equal(isSha256Digest(`sha512:${'ab'.repeat(32)}`), false);
+  assert.equal(isSha256Digest(42), false);
+});
+
+test('validates Unicode strings safely at the runtime boundary', () => {
+  assert.equal(isValidUnicodeString('session-🚀'), true);
+  assert.equal(isValidUnicodeString('\ud800'), false);
+  assert.equal(isValidUnicodeString('\udc00'), false);
+  assert.equal(isValidUnicodeString(42), false);
+  assert.equal(isValidUnicodeString(null), false);
+  assert.equal(isValidUnicodeString({}), false);
+});
+
+test('requires every explicit quota while permitting a fail-closed zero budget', () => {
+  assert.doesNotThrow(() => assertSessionBundleLimits(limits));
+  assert.deepEqual([...SESSION_BUNDLE_LIMIT_NAMES].sort(), Object.keys(limits).sort());
+
+  const missing = { ...limits } as Record<string, number>;
+  delete missing.maxPathDepth;
+  assert.throws(
+    () => assertSessionBundleLimits(missing as unknown as SessionBundleLimits),
+    TypeError,
+  );
+  assert.throws(
+    () =>
+      assertSessionBundleLimits({
+        ...limits,
+        maxPathDepth: -1,
+      }),
+    RangeError,
+  );
+  assert.throws(
+    () =>
+      assertSessionBundleLimits({
+        ...limits,
+        maxPathDepth: 1.5,
+      }),
+    RangeError,
+  );
+  assert.throws(
+    () =>
+      assertSessionBundleLimits({
+        ...limits,
+        unexpected: 1,
+      } as SessionBundleLimits),
+    TypeError,
+  );
+});
+
+test('copies opaque state identity bytes without interpreting or aliasing them', () => {
+  const source = new Uint8Array([0, 255, 123, 34, 0, 10]);
+  const copied = copyOpaqueStateIdentityDescriptor({
+    mediaType: 'application/vnd.maka.session-state-identity+json;version=1',
+    bytes: source,
+  });
+
+  assert.equal(copied.mediaType, 'application/vnd.maka.session-state-identity+json;version=1');
+  assert.deepEqual(copied.bytes, source);
+  assert.notEqual(copied.bytes, source);
+
+  source[0] = 99;
+  assert.equal(copied.bytes[0], 0);
+
+  assert.throws(
+    () => copyOpaqueStateIdentityDescriptor(null as unknown as typeof copied),
+    TypeError,
+  );
+  assert.throws(
+    () =>
+      copyOpaqueStateIdentityDescriptor({
+        mediaType: '\ud800',
+        bytes: new Uint8Array(),
+      }),
+    TypeError,
+  );
+});
+
+test('keeps stable bundle failures bounded and preserves their causes', () => {
+  const cause = new Error('filesystem failure');
+  const error = new SessionBundleFileError('io_failure', 'Session bundle I/O failed', {
+    cause,
+    details: {
+      operation: 'inspect',
+      quota: 'maxCompressedBytes',
+      limit: 10,
+      observed: 11,
+    },
+  });
+
+  assert.equal(error.name, 'SessionBundleFileError');
+  assert.equal(error.code, 'io_failure');
+  assert.equal(error.cause, cause);
+  assert.deepEqual(error.details, {
+    operation: 'inspect',
+    quota: 'maxCompressedBytes',
+    limit: 10,
+    observed: 11,
+  });
+  assert.equal(Object.isFrozen(error.details), true);
+});

--- a/packages/storage/src/__tests__/session-bundle-manifest.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-manifest.test.ts
@@ -1,0 +1,185 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import {
+  decodeSessionBundleManifestV1,
+  encodeSessionBundleManifestV1,
+  SessionBundleFileError,
+  type SessionBundleManifestV1,
+} from '../index.js';
+
+const manifest: SessionBundleManifestV1 = {
+  schemaVersion: 1,
+  codec: {
+    name: 'maka-session-bundle',
+    version: 1,
+    canonicalizationVersion: 1,
+    archive: 'ustar',
+    compression: 'zstd',
+    compressionLevel: 3,
+  },
+  envelope: {
+    sessionId: 'cloud-session-α',
+    lastCommittedActivationId: 'activation-7',
+  },
+  stateIdentity: {
+    path: 'state-identity.json',
+    mediaType: 'application/vnd.maka.session-state-identity+json;version=1',
+  },
+  payload: {
+    statePath: 'state/',
+    workspacePath: 'workspace/',
+    treeDigest: `sha256:${'ab'.repeat(32)}`,
+    payloadBytes: 37,
+    entryCount: 5,
+  },
+};
+
+const canonicalManifestText =
+  `{"codec":{"archive":"ustar","canonicalizationVersion":1,"compression":"zstd",` +
+  `"compressionLevel":3,"name":"maka-session-bundle","version":1},` +
+  `"envelope":{"lastCommittedActivationId":"activation-7","sessionId":"cloud-session-α"},` +
+  `"payload":{"entryCount":5,"payloadBytes":37,"statePath":"state/",` +
+  `"treeDigest":"sha256:${'ab'.repeat(32)}","workspacePath":"workspace/"},` +
+  `"schemaVersion":1,"stateIdentity":{"mediaType":` +
+  `"application/vnd.maka.session-state-identity+json;version=1","path":"state-identity.json"}}`;
+
+test('pins canonical Manifest V1 UTF-8 bytes and round-trips them', () => {
+  const encoded = encodeSessionBundleManifestV1(manifest);
+  assert.equal(new TextDecoder().decode(encoded), canonicalManifestText);
+  assert.equal(encoded[0], '{'.charCodeAt(0));
+  assert.equal(encoded.at(-1), '}'.charCodeAt(0));
+  assert.deepEqual(decodeSessionBundleManifestV1(encoded), manifest);
+});
+
+test('omits optional Activation provenance instead of inventing authority', () => {
+  const withoutActivation: SessionBundleManifestV1 = {
+    ...manifest,
+    envelope: { sessionId: manifest.envelope.sessionId },
+  };
+  const text = new TextDecoder().decode(encodeSessionBundleManifestV1(withoutActivation));
+  assert.match(text, /"envelope":\{"sessionId":"cloud-session-α"\}/);
+  assert.doesNotMatch(text, /lastCommittedActivationId/);
+});
+
+test('rejects parseable but non-canonical manifest bytes', () => {
+  const nonCanonical = new TextEncoder().encode(JSON.stringify(manifest));
+  assertBundleError(() => decodeSessionBundleManifestV1(nonCanonical), 'invalid_manifest');
+  assertBundleError(
+    () => decodeSessionBundleManifestV1(new TextEncoder().encode(`${canonicalManifestText}\n`)),
+    'invalid_manifest',
+  );
+  assertBundleError(
+    () =>
+      decodeSessionBundleManifestV1(
+        Uint8Array.from([0xef, 0xbb, 0xbf, ...new TextEncoder().encode(canonicalManifestText)]),
+      ),
+    'invalid_manifest',
+  );
+  assertBundleError(
+    () =>
+      decodeSessionBundleManifestV1(
+        new TextEncoder().encode(
+          canonicalManifestText.replace('"schemaVersion":1', '"schemaVersion":1,"schemaVersion":1'),
+        ),
+      ),
+    'invalid_manifest',
+  );
+});
+
+test('does not expose attacker-controlled parser diagnostics', () => {
+  assert.throws(
+    () =>
+      decodeSessionBundleManifestV1(
+        new TextEncoder().encode('SECRET_SESSION_TOKEN is not a JSON manifest'),
+      ),
+    (error) => {
+      assert.ok(error instanceof SessionBundleFileError);
+      assert.equal(error.code, 'invalid_manifest');
+      assert.equal(error.cause, undefined);
+      assert.doesNotMatch(error.message, /SECRET_SESSION_TOKEN/);
+      return true;
+    },
+  );
+});
+
+test('rejects control-plane revision and fork authority fields', () => {
+  for (const extra of [
+    { revision: 'r7' },
+    { head: 'r7' },
+    { forkedFrom: { sessionId: 'source', revision: 'r6' } },
+  ]) {
+    assertBundleError(
+      () =>
+        encodeSessionBundleManifestV1({
+          ...manifest,
+          ...extra,
+        } as SessionBundleManifestV1),
+      'invalid_manifest',
+    );
+  }
+});
+
+test('distinguishes unsupported schema and codec versions from malformed manifests', () => {
+  assertBundleError(
+    () =>
+      encodeSessionBundleManifestV1({
+        ...manifest,
+        schemaVersion: 2,
+      } as unknown as SessionBundleManifestV1),
+    'unsupported_schema',
+  );
+  assertBundleError(
+    () =>
+      encodeSessionBundleManifestV1({
+        ...manifest,
+        codec: { ...manifest.codec, version: 2 },
+      } as unknown as SessionBundleManifestV1),
+    'unsupported_codec',
+  );
+  assertBundleError(
+    () =>
+      encodeSessionBundleManifestV1({
+        ...manifest,
+        payload: {
+          ...manifest.payload,
+          treeDigest: `sha256:${'AB'.repeat(32)}`,
+        },
+      } as SessionBundleManifestV1),
+    'invalid_manifest',
+  );
+});
+
+test('rejects unknown nested fields, invalid Unicode, and incomplete layouts', () => {
+  assertBundleError(
+    () =>
+      encodeSessionBundleManifestV1({
+        ...manifest,
+        payload: { ...manifest.payload, revision: 'r7' },
+      } as SessionBundleManifestV1),
+    'invalid_manifest',
+  );
+  assertBundleError(
+    () =>
+      encodeSessionBundleManifestV1({
+        ...manifest,
+        envelope: { sessionId: '\ud800' },
+      }),
+    'invalid_manifest',
+  );
+  assertBundleError(
+    () =>
+      encodeSessionBundleManifestV1({
+        ...manifest,
+        payload: { ...manifest.payload, entryCount: 2 },
+      }),
+    'invalid_manifest',
+  );
+});
+
+function assertBundleError(action: () => unknown, code: SessionBundleFileError['code']): void {
+  assert.throws(action, (error) => {
+    assert.ok(error instanceof SessionBundleFileError);
+    assert.equal(error.code, code);
+    return true;
+  });
+}

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -59,3 +59,6 @@ export * from './project-catalog.js';
 export * from './git-worktree-child-executor.js';
 export * from './project-session-migration.js';
 export * from './session-bundle-policy.js';
+export * from './session-bundle-contract.js';
+export * from './session-bundle-manifest.js';
+export * from './session-bundle-canonical-tree.js';

--- a/packages/storage/src/session-bundle-canonical-tree.ts
+++ b/packages/storage/src/session-bundle-canonical-tree.ts
@@ -1,0 +1,371 @@
+import { Buffer } from 'node:buffer';
+import { createHash, type Hash } from 'node:crypto';
+import {
+  isSha256Digest,
+  isValidUnicodeString,
+  SESSION_BUNDLE_CANONICALIZATION_VERSION,
+  SESSION_BUNDLE_STATE_IDENTITY_PATH,
+  SESSION_BUNDLE_STATE_PATH,
+  SESSION_BUNDLE_WORKSPACE_PATH,
+  SessionBundleFileError,
+  type Sha256Digest,
+} from './session-bundle-contract.js';
+
+const TREE_MAGIC = Buffer.from('MAKA_SESSION_BUNDLE_TREE\0', 'ascii');
+const TREE_HEADER_BYTES = TREE_MAGIC.byteLength + 4 + 8;
+const TREE_ENTRY_FIXED_BYTES = 1 + 4 + 2 + 8 + 32;
+const MAX_UINT32 = 0xffff_ffff;
+const DIRECTORY_ENTRY_TYPE = 0x01;
+const REGULAR_FILE_ENTRY_TYPE = 0x02;
+const DIRECTORY_MODE = 0o755;
+const REGULAR_FILE_MODES = new Set([0o644, 0o755]);
+const DIRECTORY_DIGEST = Buffer.alloc(32);
+
+export interface SessionBundleCanonicalDirectoryEntry {
+  kind: 'directory';
+  path: string;
+}
+
+export interface SessionBundleCanonicalFileEntry {
+  kind: 'file';
+  path: string;
+  mode: 0o644 | 0o755;
+  size: number;
+  contentDigest: Sha256Digest;
+}
+
+export type SessionBundleCanonicalTreeEntry =
+  | SessionBundleCanonicalDirectoryEntry
+  | SessionBundleCanonicalFileEntry;
+
+export interface SessionBundleCanonicalTreeDigest {
+  treeDigest: Sha256Digest;
+  payloadBytes: number;
+  entryCount: number;
+}
+
+interface ValidatedCanonicalTreeEntry {
+  entry: SessionBundleCanonicalTreeEntry;
+  pathBytes: Buffer;
+  logicalPath: string;
+  parentDirectory?: string;
+}
+
+/**
+ * Encode the exact canonical tree-record stream defined by codec V1.
+ *
+ * Input order is irrelevant. Entries are validated and sorted by raw UTF-8
+ * path bytes before encoding.
+ */
+export function encodeSessionBundleCanonicalTree(
+  entries: readonly SessionBundleCanonicalTreeEntry[],
+): Uint8Array {
+  const sorted = validateAndSortEntries(entries);
+  const builder = new SessionBundleCanonicalTreeDigestBuilder(sorted.length);
+  const chunks: Buffer[] = [encodeTreeHeader(sorted.length)];
+  for (const validated of sorted) {
+    builder.add(validated.entry);
+    chunks.push(encodeTreeEntry(validated));
+  }
+  builder.finish();
+  return Buffer.concat(chunks);
+}
+
+export function computeSessionBundleCanonicalTreeDigest(
+  entries: readonly SessionBundleCanonicalTreeEntry[],
+): SessionBundleCanonicalTreeDigest {
+  const sorted = validateAndSortEntries(entries);
+  const builder = new SessionBundleCanonicalTreeDigestBuilder(sorted.length);
+  for (const validated of sorted) builder.add(validated.entry);
+  return builder.finish();
+}
+
+/**
+ * Incremental digest builder for PR 2's streaming USTAR reader.
+ *
+ * The caller supplies the entry count from the validated manifest, then adds
+ * payload entries in canonical raw-UTF-8 order after each regular file's
+ * content digest is known. The builder enforces ordering, parent directories,
+ * layout, normalized modes, and the final count without retaining file bytes.
+ */
+export class SessionBundleCanonicalTreeDigestBuilder {
+  readonly #expectedEntryCount: number;
+  readonly #hash: Hash;
+  readonly #logicalPaths = new Set<string>();
+  readonly #directories = new Set<string>();
+  #previousPathBytes?: Buffer;
+  #entryCount = 0;
+  #payloadBytes = 0;
+  #sawStateIdentity = false;
+  #sawStateRoot = false;
+  #sawWorkspaceRoot = false;
+  #failed = false;
+  #result?: SessionBundleCanonicalTreeDigest;
+
+  constructor(expectedEntryCount: number) {
+    if (!Number.isSafeInteger(expectedEntryCount) || expectedEntryCount < 0) {
+      throw new RangeError('Canonical tree entry count must be a non-negative safe integer');
+    }
+    this.#expectedEntryCount = expectedEntryCount;
+    this.#hash = createHash('sha256');
+    this.#hash.update(encodeTreeHeader(expectedEntryCount));
+  }
+
+  add(value: SessionBundleCanonicalTreeEntry): void {
+    if (this.#result !== undefined) {
+      throw integrityError('Canonical tree digest is already finalized');
+    }
+    if (this.#failed) {
+      throw integrityError('Canonical tree digest builder previously rejected an entry');
+    }
+
+    try {
+      if (this.#entryCount >= this.#expectedEntryCount) {
+        throw integrityError('Canonical tree contains more entries than declared');
+      }
+
+      const validated = validateEntry(value);
+      if (
+        this.#previousPathBytes !== undefined &&
+        Buffer.compare(this.#previousPathBytes, validated.pathBytes) >= 0
+      ) {
+        throw unsafePath('Canonical tree paths are duplicated or out of order');
+      }
+      if (this.#logicalPaths.has(validated.logicalPath)) {
+        throw unsafePath('Canonical tree contains a file and directory path conflict');
+      }
+      if (
+        validated.parentDirectory !== undefined &&
+        !this.#directories.has(validated.parentDirectory)
+      ) {
+        throw unsafePath('Canonical tree entry is missing its explicit parent directory');
+      }
+
+      const layout = classifyPayloadPath(validated.entry);
+      const nextPayloadBytes =
+        validated.entry.kind === 'file'
+          ? this.#payloadBytes + validated.entry.size
+          : this.#payloadBytes;
+      if (!Number.isSafeInteger(nextPayloadBytes)) {
+        throw unsupportedEntry('Canonical tree payload byte count exceeds safe integer range');
+      }
+      const record = encodeTreeEntry(validated);
+
+      // Commit only after every validation and encoding step has succeeded.
+      this.#hash.update(record);
+      this.#logicalPaths.add(validated.logicalPath);
+      if (validated.entry.kind === 'directory') this.#directories.add(validated.entry.path);
+      this.#previousPathBytes = validated.pathBytes;
+      this.#entryCount += 1;
+      this.#payloadBytes = nextPayloadBytes;
+      if (layout === 'state_identity') this.#sawStateIdentity = true;
+      if (layout === 'state_root') this.#sawStateRoot = true;
+      if (layout === 'workspace_root') this.#sawWorkspaceRoot = true;
+    } catch (error) {
+      this.#failed = true;
+      throw error;
+    }
+  }
+
+  finish(): SessionBundleCanonicalTreeDigest {
+    if (this.#result !== undefined) return { ...this.#result };
+    if (this.#failed) {
+      throw integrityError('Canonical tree digest builder previously rejected an entry');
+    }
+    if (this.#entryCount !== this.#expectedEntryCount) {
+      throw integrityError('Canonical tree entry count does not match the declared count');
+    }
+    if (!this.#sawStateIdentity || !this.#sawStateRoot || !this.#sawWorkspaceRoot) {
+      throw integrityError('Canonical tree is missing a required V1 payload root');
+    }
+    this.#result = Object.freeze({
+      treeDigest: `sha256:${this.#hash.digest('hex')}` as Sha256Digest,
+      payloadBytes: this.#payloadBytes,
+      entryCount: this.#entryCount,
+    });
+    return { ...this.#result };
+  }
+}
+
+export function compareSessionBundleCanonicalPaths(left: string, right: string): number {
+  if (!isValidUnicodeString(left) || !isValidUnicodeString(right)) {
+    throw unsafePath('Canonical tree path is not valid Unicode');
+  }
+  return Buffer.compare(Buffer.from(left, 'utf8'), Buffer.from(right, 'utf8'));
+}
+
+function validateAndSortEntries(
+  entries: readonly SessionBundleCanonicalTreeEntry[],
+): ValidatedCanonicalTreeEntry[] {
+  if (!Array.isArray(entries)) {
+    throw new TypeError('Canonical tree entries must be an array');
+  }
+  return entries
+    .map((entry) => validateEntry(entry))
+    .sort((left, right) => Buffer.compare(left.pathBytes, right.pathBytes));
+}
+
+function validateEntry(value: unknown): ValidatedCanonicalTreeEntry {
+  if (!isRecord(value) || typeof value.kind !== 'string' || typeof value.path !== 'string') {
+    throw unsupportedEntry('Canonical tree entry has an invalid shape');
+  }
+
+  let entry: SessionBundleCanonicalTreeEntry;
+  if (value.kind === 'directory') {
+    if (!hasExactKeys(value, ['kind', 'path'])) {
+      throw unsupportedEntry('Canonical directory entry has unsupported metadata');
+    }
+    entry = { kind: 'directory', path: value.path };
+  } else if (value.kind === 'file') {
+    if (
+      !hasExactKeys(value, ['contentDigest', 'kind', 'mode', 'path', 'size']) ||
+      typeof value.mode !== 'number' ||
+      !REGULAR_FILE_MODES.has(value.mode) ||
+      typeof value.size !== 'number' ||
+      !Number.isSafeInteger(value.size) ||
+      value.size < 0 ||
+      !isSha256Digest(value.contentDigest)
+    ) {
+      throw unsupportedEntry('Canonical regular file entry has unsupported metadata');
+    }
+    entry = {
+      kind: 'file',
+      path: value.path,
+      mode: value.mode as 0o644 | 0o755,
+      size: value.size,
+      contentDigest: value.contentDigest,
+    };
+  } else {
+    throw unsupportedEntry('Canonical tree entry type is not supported');
+  }
+
+  const path = validateCanonicalPath(entry.path, entry.kind);
+  return {
+    entry,
+    pathBytes: path.pathBytes,
+    logicalPath: path.logicalPath,
+    ...(path.parentDirectory === undefined ? {} : { parentDirectory: path.parentDirectory }),
+  };
+}
+
+function validateCanonicalPath(
+  path: string,
+  kind: SessionBundleCanonicalTreeEntry['kind'],
+): {
+  pathBytes: Buffer;
+  logicalPath: string;
+  parentDirectory?: string;
+} {
+  if (!path || !isValidUnicodeString(path) || path.includes('\0') || path.includes('\\')) {
+    throw unsafePath('Canonical tree path contains unsupported characters');
+  }
+  if (path.startsWith('/') || /^[A-Za-z]:/.test(path)) {
+    throw unsafePath('Canonical tree path must be relative');
+  }
+
+  const isDirectory = kind === 'directory';
+  if (isDirectory !== path.endsWith('/')) {
+    throw unsafePath('Canonical tree directory marker does not match its entry type');
+  }
+  const logicalPath = isDirectory ? path.slice(0, -1) : path;
+  const segments = logicalPath.split('/');
+  if (
+    logicalPath.length === 0 ||
+    segments.some((segment) => segment.length === 0 || segment === '.' || segment === '..')
+  ) {
+    throw unsafePath('Canonical tree path contains an unsafe segment');
+  }
+
+  const pathBytes = Buffer.from(path, 'utf8');
+  if (pathBytes.byteLength > MAX_UINT32) {
+    throw unsafePath('Canonical tree path exceeds the record encoding limit');
+  }
+
+  const lastSlash = logicalPath.lastIndexOf('/');
+  const parentDirectory = lastSlash < 0 ? undefined : `${logicalPath.slice(0, lastSlash)}/`;
+  return {
+    pathBytes,
+    logicalPath,
+    ...(parentDirectory === undefined ? {} : { parentDirectory }),
+  };
+}
+
+function classifyPayloadPath(
+  entry: SessionBundleCanonicalTreeEntry,
+): 'state_identity' | 'state_root' | 'workspace_root' | 'payload' {
+  if (entry.path === SESSION_BUNDLE_STATE_IDENTITY_PATH) {
+    if (entry.kind !== 'file' || entry.mode !== 0o644) {
+      throw unsupportedEntry('State identity must be a non-executable regular file');
+    }
+    return 'state_identity';
+  }
+  if (entry.path === SESSION_BUNDLE_STATE_PATH) {
+    if (entry.kind !== 'directory') throw unsupportedEntry('State root must be a directory');
+    return 'state_root';
+  }
+  if (entry.path === SESSION_BUNDLE_WORKSPACE_PATH) {
+    if (entry.kind !== 'directory') throw unsupportedEntry('Workspace root must be a directory');
+    return 'workspace_root';
+  }
+  if (
+    entry.path.startsWith(SESSION_BUNDLE_STATE_PATH) ||
+    entry.path.startsWith(SESSION_BUNDLE_WORKSPACE_PATH)
+  ) {
+    return 'payload';
+  }
+  throw unsafePath('Canonical tree path is outside the V1 payload roots');
+}
+
+function encodeTreeHeader(entryCount: number): Buffer {
+  const header = Buffer.alloc(TREE_HEADER_BYTES);
+  TREE_MAGIC.copy(header, 0);
+  header.writeUInt32BE(SESSION_BUNDLE_CANONICALIZATION_VERSION, TREE_MAGIC.byteLength);
+  header.writeBigUInt64BE(BigInt(entryCount), TREE_MAGIC.byteLength + 4);
+  return header;
+}
+
+function encodeTreeEntry(validated: ValidatedCanonicalTreeEntry): Buffer {
+  const { entry, pathBytes } = validated;
+  const record = Buffer.alloc(TREE_ENTRY_FIXED_BYTES + pathBytes.byteLength);
+  let offset = 0;
+  record.writeUInt8(
+    entry.kind === 'directory' ? DIRECTORY_ENTRY_TYPE : REGULAR_FILE_ENTRY_TYPE,
+    offset,
+  );
+  offset += 1;
+  record.writeUInt32BE(pathBytes.byteLength, offset);
+  offset += 4;
+  pathBytes.copy(record, offset);
+  offset += pathBytes.byteLength;
+  record.writeUInt16BE(entry.kind === 'directory' ? DIRECTORY_MODE : entry.mode, offset);
+  offset += 2;
+  record.writeBigUInt64BE(BigInt(entry.kind === 'directory' ? 0 : entry.size), offset);
+  offset += 8;
+  if (entry.kind === 'directory') {
+    DIRECTORY_DIGEST.copy(record, offset);
+  } else {
+    Buffer.from(entry.contentDigest.slice('sha256:'.length), 'hex').copy(record, offset);
+  }
+  return record;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function hasExactKeys(value: Record<string, unknown>, keys: readonly string[]): boolean {
+  const actual = Object.keys(value);
+  return actual.length === keys.length && actual.every((key) => keys.includes(key));
+}
+
+function unsafePath(message: string): SessionBundleFileError {
+  return new SessionBundleFileError('unsafe_path', message);
+}
+
+function unsupportedEntry(message: string): SessionBundleFileError {
+  return new SessionBundleFileError('unsupported_entry', message);
+}
+
+function integrityError(message: string): SessionBundleFileError {
+  return new SessionBundleFileError('integrity_mismatch', message);
+}

--- a/packages/storage/src/session-bundle-contract.ts
+++ b/packages/storage/src/session-bundle-contract.ts
@@ -1,0 +1,277 @@
+/**
+ * Filesystem-facing contract for portable Session Bundles.
+ *
+ * This boundary deliberately treats Maka state as opaque bytes and files. It
+ * must not acquire dependencies on Session, SQLite, JSONL, RuntimeEvent, or
+ * Artifact schemas. State preparation and semantic identity validation happen
+ * before this codec is called; state migration and re-keying happen after
+ * hydration in the state-owning layer.
+ */
+
+export const SESSION_BUNDLE_SCHEMA_VERSION = 1 as const;
+export const SESSION_BUNDLE_CODEC_NAME = 'maka-session-bundle' as const;
+export const SESSION_BUNDLE_CODEC_VERSION = 1 as const;
+export const SESSION_BUNDLE_CANONICALIZATION_VERSION = 1 as const;
+export const SESSION_BUNDLE_ARCHIVE_FORMAT = 'ustar' as const;
+export const SESSION_BUNDLE_COMPRESSION_FORMAT = 'zstd' as const;
+export const SESSION_BUNDLE_COMPRESSION_LEVEL = 3 as const;
+
+export const SESSION_BUNDLE_MANIFEST_PATH = 'manifest.json' as const;
+export const SESSION_BUNDLE_STATE_IDENTITY_PATH = 'state-identity.json' as const;
+export const SESSION_BUNDLE_STATE_PATH = 'state/' as const;
+export const SESSION_BUNDLE_WORKSPACE_PATH = 'workspace/' as const;
+
+export type Sha256Digest = `sha256:${string}`;
+
+const SHA256_DIGEST_PATTERN = /^sha256:[0-9a-f]{64}$/;
+
+export function isSha256Digest(value: unknown): value is Sha256Digest {
+  return typeof value === 'string' && SHA256_DIGEST_PATTERN.test(value);
+}
+
+/**
+ * State identity is produced and semantically validated by the state layer.
+ * The filesystem codec preserves these bytes exactly and never parses them.
+ */
+export interface OpaqueStateIdentityDescriptor {
+  mediaType: string;
+  bytes: Uint8Array;
+}
+
+export function copyOpaqueStateIdentityDescriptor(
+  descriptor: OpaqueStateIdentityDescriptor,
+): OpaqueStateIdentityDescriptor {
+  if (!isRecord(descriptor)) {
+    throw new TypeError('State identity descriptor must be an object');
+  }
+  if (!isNonEmptyUnicodeString(descriptor.mediaType)) {
+    throw new TypeError('State identity mediaType must be a non-empty Unicode string');
+  }
+  if (!(descriptor.bytes instanceof Uint8Array)) {
+    throw new TypeError('State identity bytes must be a Uint8Array');
+  }
+  return {
+    mediaType: descriptor.mediaType,
+    bytes: Uint8Array.from(descriptor.bytes),
+  };
+}
+
+export interface PreparedSessionBundleSnapshot {
+  stateRoot: string;
+  workspaceRoot: string;
+  stateIdentity: OpaqueStateIdentityDescriptor;
+}
+
+export interface SessionBundleSource {
+  path: string;
+  /**
+   * Optional for standalone inspection, but required when the source was
+   * resolved through SessionRepository.
+   */
+  expectedArchiveDigest?: Sha256Digest;
+}
+
+export interface SessionBundleLimits {
+  maxCompressedBytes: number;
+  maxDecompressedTarBytes: number;
+  maxPayloadBytes: number;
+  maxFileBytes: number;
+  maxEntryCount: number;
+  maxManifestBytes: number;
+  maxStateIdentityBytes: number;
+  maxPathBytes: number;
+  maxPathDepth: number;
+}
+
+export type SessionBundleQuotaName = keyof SessionBundleLimits;
+
+export const SESSION_BUNDLE_LIMIT_NAMES = [
+  'maxCompressedBytes',
+  'maxDecompressedTarBytes',
+  'maxPayloadBytes',
+  'maxFileBytes',
+  'maxEntryCount',
+  'maxManifestBytes',
+  'maxStateIdentityBytes',
+  'maxPathBytes',
+  'maxPathDepth',
+] as const satisfies readonly SessionBundleQuotaName[];
+
+/**
+ * Limits are caller-owned policy and intentionally have no defaults. Zero is a
+ * valid fail-closed budget; negative, fractional, missing, or unsafe integers
+ * are programmer/configuration errors rather than errors in an input Bundle.
+ */
+export function assertSessionBundleLimits(
+  limits: SessionBundleLimits,
+): asserts limits is SessionBundleLimits {
+  if (!isRecord(limits)) throw new TypeError('Session bundle limits must be an object');
+  const actualKeys = Object.keys(limits);
+  if (
+    actualKeys.length !== SESSION_BUNDLE_LIMIT_NAMES.length ||
+    actualKeys.some((key) => !SESSION_BUNDLE_LIMIT_NAMES.includes(key as SessionBundleQuotaName))
+  ) {
+    throw new TypeError('Session bundle limits must contain exactly the supported quota keys');
+  }
+  for (const name of SESSION_BUNDLE_LIMIT_NAMES) {
+    const value = limits[name];
+    if (!Number.isSafeInteger(value) || value < 0) {
+      throw new RangeError(`Session bundle limit ${name} must be a non-negative safe integer`);
+    }
+  }
+}
+
+export interface SessionBundleEnvelopeInput {
+  /**
+   * Cloud identity allocated by the control plane. Hydration verifies this
+   * binding and never silently rebinds a Bundle.
+   */
+  sessionId: string;
+  /**
+   * Optional provenance only. Activation deduplication and terminal outcomes
+   * remain authoritative in the control plane's Activation store.
+   */
+  lastCommittedActivationId?: string;
+}
+
+export interface SessionBundlePackInput {
+  snapshot: PreparedSessionBundleSnapshot;
+  envelope: SessionBundleEnvelopeInput;
+  destination: string;
+  limits: SessionBundleLimits;
+}
+
+export interface SessionBundleReadInput {
+  source: SessionBundleSource;
+  limits: SessionBundleLimits;
+}
+
+export interface SessionBundleHydrateInput extends SessionBundleReadInput {
+  expectedSessionId: string;
+  destinationRoot: string;
+}
+
+export interface SessionBundleManifestV1 {
+  schemaVersion: 1;
+  codec: {
+    name: 'maka-session-bundle';
+    version: 1;
+    canonicalizationVersion: 1;
+    archive: 'ustar';
+    compression: 'zstd';
+    compressionLevel: 3;
+  };
+  envelope: {
+    sessionId: string;
+    lastCommittedActivationId?: string;
+  };
+  stateIdentity: {
+    path: 'state-identity.json';
+    mediaType: string;
+  };
+  payload: {
+    statePath: 'state/';
+    workspacePath: 'workspace/';
+    treeDigest: Sha256Digest;
+    payloadBytes: number;
+    entryCount: number;
+  };
+}
+
+export interface SessionBundleArtifact {
+  path: string;
+  archiveDigest: Sha256Digest;
+  compressedBytes: number;
+  decompressedTarBytes: number;
+  payloadBytes: number;
+  entryCount: number;
+}
+
+export interface SessionBundleInspection {
+  manifest: SessionBundleManifestV1;
+  stateIdentity: OpaqueStateIdentityDescriptor;
+  archiveDigest: Sha256Digest;
+  verified: true;
+}
+
+export interface SessionBundleHydration extends SessionBundleInspection {
+  destinationRoot: string;
+  stateRoot: string;
+  workspaceRoot: string;
+}
+
+export interface SessionBundleFileService {
+  pack(input: SessionBundlePackInput): Promise<SessionBundleArtifact>;
+  inspect(input: SessionBundleReadInput): Promise<SessionBundleInspection>;
+  hydrate(input: SessionBundleHydrateInput): Promise<SessionBundleHydration>;
+}
+
+export type SessionBundleFileErrorCode =
+  | 'invalid_manifest'
+  | 'unsupported_schema'
+  | 'unsupported_codec'
+  | 'identity_mismatch'
+  | 'integrity_mismatch'
+  | 'quota_exceeded'
+  | 'unsafe_path'
+  | 'unsupported_entry'
+  | 'destination_exists'
+  | 'source_changed'
+  | 'io_failure';
+
+export type SessionBundleFileOperation = 'pack' | 'inspect' | 'hydrate';
+
+/**
+ * Bounded diagnostic facts only. Raw attacker-controlled paths and strings do
+ * not belong in stable error details.
+ */
+export interface SessionBundleFileErrorDetails {
+  operation?: SessionBundleFileOperation;
+  quota?: SessionBundleQuotaName;
+  limit?: number;
+  observed?: number;
+  entryIndex?: number;
+  pathDepth?: number;
+}
+
+export interface SessionBundleFileErrorOptions extends ErrorOptions {
+  details?: SessionBundleFileErrorDetails;
+}
+
+export class SessionBundleFileError extends Error {
+  readonly details?: Readonly<SessionBundleFileErrorDetails>;
+
+  constructor(
+    readonly code: SessionBundleFileErrorCode,
+    message: string,
+    options: SessionBundleFileErrorOptions = {},
+  ) {
+    super(message, options.cause === undefined ? undefined : { cause: options.cause });
+    this.name = 'SessionBundleFileError';
+    if (options.details !== undefined) this.details = Object.freeze({ ...options.details });
+  }
+}
+
+export function isValidUnicodeString(value: unknown): value is string {
+  if (typeof value !== 'string') return false;
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      if (index + 1 >= value.length) return false;
+      const next = value.charCodeAt(index + 1);
+      if (next < 0xdc00 || next > 0xdfff) return false;
+      index += 1;
+      continue;
+    }
+    if (code >= 0xdc00 && code <= 0xdfff) return false;
+  }
+  return true;
+}
+
+export function isNonEmptyUnicodeString(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && isValidUnicodeString(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/packages/storage/src/session-bundle-manifest.ts
+++ b/packages/storage/src/session-bundle-manifest.ts
@@ -1,0 +1,234 @@
+import {
+  isNonEmptyUnicodeString,
+  isSha256Digest,
+  SESSION_BUNDLE_ARCHIVE_FORMAT,
+  SESSION_BUNDLE_CANONICALIZATION_VERSION,
+  SESSION_BUNDLE_CODEC_NAME,
+  SESSION_BUNDLE_CODEC_VERSION,
+  SESSION_BUNDLE_COMPRESSION_FORMAT,
+  SESSION_BUNDLE_COMPRESSION_LEVEL,
+  SESSION_BUNDLE_SCHEMA_VERSION,
+  SESSION_BUNDLE_STATE_IDENTITY_PATH,
+  SESSION_BUNDLE_STATE_PATH,
+  SESSION_BUNDLE_WORKSPACE_PATH,
+  SessionBundleFileError,
+  type SessionBundleManifestV1,
+} from './session-bundle-contract.js';
+
+const MANIFEST_KEYS = ['codec', 'envelope', 'payload', 'schemaVersion', 'stateIdentity'] as const;
+const CODEC_KEYS = [
+  'archive',
+  'canonicalizationVersion',
+  'compression',
+  'compressionLevel',
+  'name',
+  'version',
+] as const;
+const ENVELOPE_KEYS = ['lastCommittedActivationId', 'sessionId'] as const;
+const STATE_IDENTITY_KEYS = ['mediaType', 'path'] as const;
+const PAYLOAD_KEYS = [
+  'entryCount',
+  'payloadBytes',
+  'statePath',
+  'treeDigest',
+  'workspacePath',
+] as const;
+
+/**
+ * Encode Manifest V1 as RFC 8785/JCS UTF-8 with no BOM or trailing newline.
+ *
+ * The serializer is intentionally schema-specific: the validated Manifest V1
+ * value contains only objects, strings, and non-negative safe integers. This
+ * keeps the portable codec independent of a general-purpose JSON dependency
+ * while retaining the exact JCS ordering and ECMAScript primitive encoding
+ * rules required by the format.
+ */
+export function encodeSessionBundleManifestV1(manifest: SessionBundleManifestV1): Uint8Array {
+  const validated = decodeManifestValue(manifest);
+  return new TextEncoder().encode(canonicalJson(validated));
+}
+
+/**
+ * Decode and validate a canonical Manifest V1.
+ *
+ * Non-canonical JSON is rejected even when it would parse to the same value.
+ * That rejects duplicate keys, insignificant whitespace, alternate numeric
+ * spellings, BOMs, and reordered object members before an archive is trusted.
+ */
+export function decodeSessionBundleManifestV1(bytes: Uint8Array): SessionBundleManifestV1 {
+  if (!(bytes instanceof Uint8Array) || bytes.byteLength === 0) throw invalidManifest();
+
+  let text: string;
+  let parsed: unknown;
+  try {
+    text = new TextDecoder('utf-8', { fatal: true }).decode(bytes);
+    parsed = JSON.parse(text);
+  } catch {
+    // JSON.parse diagnostics can contain attacker-controlled input excerpts.
+    // Preserve the stable public error code without retaining the raw parser
+    // failure as a cause.
+    throw invalidManifest();
+  }
+
+  const manifest = decodeManifestValue(parsed);
+  const canonical = encodeSessionBundleManifestV1(manifest);
+  if (!equalBytes(bytes, canonical)) throw invalidManifest();
+  return manifest;
+}
+
+function decodeManifestValue(value: unknown): SessionBundleManifestV1 {
+  if (!isRecord(value) || !hasExactKeys(value, MANIFEST_KEYS)) throw invalidManifest();
+
+  if (value.schemaVersion !== SESSION_BUNDLE_SCHEMA_VERSION) {
+    if (typeof value.schemaVersion === 'number' && Number.isSafeInteger(value.schemaVersion)) {
+      throw new SessionBundleFileError(
+        'unsupported_schema',
+        'Session bundle schema version is not supported',
+      );
+    }
+    throw invalidManifest();
+  }
+
+  const codec = decodeCodec(value.codec);
+  const envelope = decodeEnvelope(value.envelope);
+  const stateIdentity = decodeStateIdentity(value.stateIdentity);
+  const payload = decodePayload(value.payload);
+
+  return {
+    schemaVersion: SESSION_BUNDLE_SCHEMA_VERSION,
+    codec,
+    envelope,
+    stateIdentity,
+    payload,
+  };
+}
+
+function decodeCodec(value: unknown): SessionBundleManifestV1['codec'] {
+  if (!isRecord(value) || !hasExactKeys(value, CODEC_KEYS)) throw invalidManifest();
+  if (
+    value.name !== SESSION_BUNDLE_CODEC_NAME ||
+    value.version !== SESSION_BUNDLE_CODEC_VERSION ||
+    value.canonicalizationVersion !== SESSION_BUNDLE_CANONICALIZATION_VERSION ||
+    value.archive !== SESSION_BUNDLE_ARCHIVE_FORMAT ||
+    value.compression !== SESSION_BUNDLE_COMPRESSION_FORMAT ||
+    value.compressionLevel !== SESSION_BUNDLE_COMPRESSION_LEVEL
+  ) {
+    throw new SessionBundleFileError(
+      'unsupported_codec',
+      'Session bundle codec settings are not supported',
+    );
+  }
+  return {
+    name: SESSION_BUNDLE_CODEC_NAME,
+    version: SESSION_BUNDLE_CODEC_VERSION,
+    canonicalizationVersion: SESSION_BUNDLE_CANONICALIZATION_VERSION,
+    archive: SESSION_BUNDLE_ARCHIVE_FORMAT,
+    compression: SESSION_BUNDLE_COMPRESSION_FORMAT,
+    compressionLevel: SESSION_BUNDLE_COMPRESSION_LEVEL,
+  };
+}
+
+function decodeEnvelope(value: unknown): SessionBundleManifestV1['envelope'] {
+  if (
+    !isRecord(value) ||
+    !hasOnlyKeys(value, ENVELOPE_KEYS) ||
+    !Object.hasOwn(value, 'sessionId') ||
+    !isNonEmptyUnicodeString(value.sessionId)
+  ) {
+    throw invalidManifest();
+  }
+  if (
+    Object.hasOwn(value, 'lastCommittedActivationId') &&
+    !isNonEmptyUnicodeString(value.lastCommittedActivationId)
+  ) {
+    throw invalidManifest();
+  }
+  return {
+    sessionId: value.sessionId,
+    ...(typeof value.lastCommittedActivationId === 'string'
+      ? { lastCommittedActivationId: value.lastCommittedActivationId }
+      : {}),
+  };
+}
+
+function decodeStateIdentity(value: unknown): SessionBundleManifestV1['stateIdentity'] {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, STATE_IDENTITY_KEYS) ||
+    value.path !== SESSION_BUNDLE_STATE_IDENTITY_PATH ||
+    !isNonEmptyUnicodeString(value.mediaType)
+  ) {
+    throw invalidManifest();
+  }
+  return {
+    path: SESSION_BUNDLE_STATE_IDENTITY_PATH,
+    mediaType: value.mediaType,
+  };
+}
+
+function decodePayload(value: unknown): SessionBundleManifestV1['payload'] {
+  if (
+    !isRecord(value) ||
+    !hasExactKeys(value, PAYLOAD_KEYS) ||
+    value.statePath !== SESSION_BUNDLE_STATE_PATH ||
+    value.workspacePath !== SESSION_BUNDLE_WORKSPACE_PATH ||
+    !isSha256Digest(value.treeDigest) ||
+    !isNonNegativeSafeInteger(value.payloadBytes) ||
+    !isNonNegativeSafeInteger(value.entryCount) ||
+    value.entryCount < 3
+  ) {
+    throw invalidManifest();
+  }
+  return {
+    statePath: SESSION_BUNDLE_STATE_PATH,
+    workspacePath: SESSION_BUNDLE_WORKSPACE_PATH,
+    treeDigest: value.treeDigest,
+    payloadBytes: value.payloadBytes,
+    entryCount: value.entryCount,
+  };
+}
+
+function canonicalJson(value: unknown): string {
+  if (value === null) return 'null';
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'number') {
+    if (!Number.isFinite(value)) throw invalidManifest();
+    return JSON.stringify(value);
+  }
+  if (typeof value === 'boolean') return value ? 'true' : 'false';
+  if (Array.isArray(value)) return `[${value.map((item) => canonicalJson(item)).join(',')}]`;
+  if (!isRecord(value)) throw invalidManifest();
+  return `{${Object.keys(value)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonicalJson(value[key])}`)
+    .join(',')}}`;
+}
+
+function hasExactKeys(value: Record<string, unknown>, expected: readonly string[]): boolean {
+  const actual = Object.keys(value);
+  return actual.length === expected.length && actual.every((key) => expected.includes(key));
+}
+
+function hasOnlyKeys(value: Record<string, unknown>, allowed: readonly string[]): boolean {
+  return Object.keys(value).every((key) => allowed.includes(key));
+}
+
+function equalBytes(left: Uint8Array, right: Uint8Array): boolean {
+  if (left.byteLength !== right.byteLength) return false;
+  return left.every((byte, index) => byte === right[index]);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isNonNegativeSafeInteger(value: unknown): value is number {
+  return typeof value === 'number' && Number.isSafeInteger(value) && value >= 0;
+}
+
+function invalidManifest(): SessionBundleFileError {
+  return new SessionBundleFileError(
+    'invalid_manifest',
+    'Session bundle manifest is invalid or non-canonical',
+  );
+}


### PR DESCRIPTION
## Summary

Implements PR 1 of the Session Bundle filesystem codec defined in #1528.

This establishes the portable, state-schema-independent contract and deterministic canonicalization primitives that the streaming archive implementation will build on.

## What changed

- define the public Session Bundle service, input, result, quota, manifest, digest, and stable error contracts
- define the opaque state-identity descriptor boundary without interpreting Maka state semantics
- encode and decode Manifest V1 as canonical RFC 8785/JCS UTF-8 and reject non-canonical or authority-bearing fields
- define the exact canonical payload tree-record encoding and SHA-256 digest
- support incremental tree hashing for the future streaming reader
- validate raw UTF-8 path ordering, required payload roots, explicit parents, normalized file modes, entry metadata, and aggregate sizes
- fail closed after any rejected incremental entry
- prevent parser diagnostics from exposing attacker-controlled manifest input
- add a dependency boundary test that prevents codec primitives from reaching Maka state schemas
- export the new primitives from the storage package

## Tests

- golden fixtures pin the exact canonical Manifest V1 bytes
- golden fixtures pin exact tree-record bytes and the expected SHA-256 digest
- coverage includes empty directories, executable semantics, invalid Unicode, traversal, duplicates, path conflicts, missing parents, invalid metadata, out-of-order streams, payload overflow, and bounded errors
- npm --workspace @maka/storage test
- npm run lint
- npm run format:check
- npm run build
- npm run typecheck

All checks pass on the latest main.

Part of #1528.