### PR TITLE
chore(release): prepare 0.1.2

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -2,7 +2,7 @@
   "name": "@maka/desktop",
   "productName": "Maka",
   "description": "A local-first agent workspace built for real work.",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "author": "The Maka Authors",
   "license": "Apache-2.0",
   "private": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "maka",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "maka",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "workspaces": [
         "packages/core",
@@ -33,7 +33,7 @@
     },
     "apps/desktop": {
       "name": "@maka/desktop",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@astryxdesign/core": "0.1.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "maka",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "license": "Apache-2.0",
   "private": true,
   "engines": {

--- a/scripts/check-dead-css.mjs
+++ b/scripts/check-dead-css.mjs
@@ -49,6 +49,11 @@ const DYNAMIC_STYLE_HOOKS = new Set([
   'is-untested',
   'is-verified',
   'is-warn',
+  // Astryx renders these stable component classes through themeProps at
+  // runtime. Responsive page CSS targets them for layout overrides, but they
+  // do not appear as className literals in Maka source.
+  'astryx-button',
+  'astryx-badge',
   // Appearance palette swatches — composed at runtime via
   // `settingsPaletteSwatch-${palette}` in settings/appearance-settings-page.tsx
   // (#308), so the per-palette variants never appear as string literals in


### PR DESCRIPTION
## Summary

- bump the root and Desktop release version to `0.1.2`
- keep package-lock release authorities synchronized
- recognize Astryx runtime-generated component classes in the dead-CSS release gate

## Why the gate fix belongs here

A clean release preflight on current `main` exposed `.astryx-button` and `.astryx-badge` as false dead-CSS positives. The renderer pruning contract already documents both as stable runtime-generated Astryx hooks; the standalone release checker had not copied those two entries. No CSS or product behavior changes.

## Validation

- `npm run rebuild`
- `npm run check:release`
- `node --test scripts/macos-arm64-release.test.mjs` (14/14)
- `npm audit --omit=dev --audit-level=high` (passes; 2 moderate findings only)
- Biome check on changed source/manifest files
- verified `v0.1.2` tag and GitHub Release do not exist