### PR TITLE
fix(release): install Electron distribution before packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "apps/desktop"
   ],
   "scripts": {
+    "postinstall": "install-electron",
     "lint": "biome lint .",
     "format": "biome format --write .",
     "format:check": "biome format .",

--- a/scripts/macos-arm64-release.test.mjs
+++ b/scripts/macos-arm64-release.test.mjs
@@ -4,6 +4,7 @@ import test from 'node:test';
 
 const repoRoot = new URL('../', import.meta.url);
 const desktopRoot = new URL('../apps/desktop/', import.meta.url);
+const rootManifest = JSON.parse(await readFile(new URL('package.json', repoRoot), 'utf8'));
 const desktopManifest = JSON.parse(await readFile(new URL('package.json', desktopRoot), 'utf8'));
 const signingEnvironment = {
   CSC_LINK: 'base64-certificate',
@@ -58,6 +59,7 @@ test('macOS release declares the privacy copy and hardened-runtime permissions i
 test('Electron is a build tool rather than a packaged application dependency', async () => {
   assert.equal(desktopManifest.dependencies.electron, undefined);
   assert.match(desktopManifest.devDependencies.electron, /^\d+\.\d+\.\d+$/);
+  assert.equal(rootManifest.scripts.postinstall, 'install-electron');
 });
 
 test('renderer build inputs are not duplicated in the packaged Node runtime', async () => {
@@ -187,6 +189,8 @@ test('release package script runs the single arm64 pipeline in order', async () 
   assert.deepEqual(
     asserted.map((path) => path.replaceAll('\\', '/')),
     [
+      `${repoRoot.pathname.replace(/\/$/, '')}/node_modules/electron/dist/LICENSE`,
+      `${repoRoot.pathname.replace(/\/$/, '')}/node_modules/electron/dist/LICENSES.chromium.html`,
       `${desktopRoot.pathname.replace(/\/$/, '')}/release/Maka-${desktopManifest.version}-mac-arm64.dmg`,
       `${desktopRoot.pathname.replace(/\/$/, '')}/release/Maka-${desktopManifest.version}-mac-arm64.zip`,
       `${desktopRoot.pathname.replace(/\/$/, '')}/release/latest-mac.yml`,

--- a/scripts/package-macos-arm64.mjs
+++ b/scripts/package-macos-arm64.mjs
@@ -6,6 +6,11 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 const repoRoot = dirname(dirname(fileURLToPath(import.meta.url)));
 const desktopRoot = join(repoRoot, 'apps', 'desktop');
 const releaseDirectory = join(desktopRoot, 'release');
+const electronDistributionDirectory = join(repoRoot, 'node_modules', 'electron', 'dist');
+const requiredElectronLicensePaths = [
+  join(electronDistributionDirectory, 'LICENSE'),
+  join(electronDistributionDirectory, 'LICENSES.chromium.html'),
+];
 const requiredSigningEnvironment = [
   'CSC_LINK',
   'CSC_KEY_PASSWORD',
@@ -60,6 +65,10 @@ export async function packageMacosArm64({
   const dmgPath = join(releaseDirectory, `Maka-${manifest.version}-mac-arm64.dmg`);
   const zipPath = join(releaseDirectory, `Maka-${manifest.version}-mac-arm64.zip`);
   const updateMetadataPath = join(releaseDirectory, 'latest-mac.yml');
+
+  for (const path of requiredElectronLicensePaths) {
+    await assertFile(path);
+  }
 
   await run('npm', ['run', 'clean']);
   await run('npm', ['run', 'build']);


### PR DESCRIPTION
## Summary

- restore Electron distribution installation after Electron 42 removed its package postinstall
- fail fast before release packaging when the required Electron/Chromium license inputs are missing
- cover the install and release preflight contracts with the existing macOS release regression test

## Root cause

Electron 43 ships `install-electron` but no longer runs it automatically. `npm ci` therefore installed the JS package without `node_modules/electron/dist`, while electron-builder silently skipped the configured license resources and produced a DMG that failed final verification.

## Verification

- fresh `npm ci` produced both Electron license inputs
- `node --test scripts/macos-arm64-release.test.mjs`
- `npm run rebuild`
- `npm run check:release`
- unsigned arm64 app packaging; both license files were present under `Maka.app/Contents/Resources/licenses/electron`