### PR TITLE
feat(settings): add confirmed agent self-configuration tools

### DIFF
--- a/apps/desktop/src/main/__tests__/agent-settings-tools.test.ts
+++ b/apps/desktop/src/main/__tests__/agent-settings-tools.test.ts
@@ -1,0 +1,194 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import { createDefaultSettings, mergeSettings, type AppSettings } from '@maka/core';
+import type { MakaTool, MakaToolContext } from '@maka/runtime';
+import type { z } from 'zod';
+import {
+  buildAgentSettingsTools,
+  MAKA_SETTINGS_GET_TOOL_NAME,
+  MAKA_SETTINGS_UPDATE_TOOL_NAME,
+} from '../agent-settings-tools.js';
+
+function fixture() {
+  let settings = createDefaultSettings();
+  const patches: unknown[] = [];
+  const tools = buildAgentSettingsTools({
+    settingsStore: { get: async () => settings },
+    updateSettings: async (patch) => {
+      patches.push(structuredClone(patch));
+      settings = mergeSettings(settings, patch);
+      return settings;
+    },
+  });
+  return {
+    tools,
+    patches,
+    readSettings: () => settings,
+    replaceSettings: (next: AppSettings) => {
+      settings = next;
+    },
+  };
+}
+
+function toolByName(tools: MakaTool[], name: string): MakaTool {
+  const tool = tools.find((candidate) => candidate.name === name);
+  if (!tool) throw new Error(`Missing tool ${name}`);
+  return tool;
+}
+
+function context(
+  answer?: string | null,
+  capture?: { questions?: unknown },
+): MakaToolContext {
+  return {
+    sessionId: 'session-1',
+    turnId: 'turn-1',
+    cwd: '/tmp',
+    toolCallId: 'tool-call-1',
+    abortSignal: new AbortController().signal,
+    emitOutput: () => {},
+    ...(answer !== undefined
+      ? {
+          askUserQuestion: async (questions) => {
+            if (capture) capture.questions = questions;
+            return {
+              answers: questions.map((question) => ({
+                question: question.question,
+                answer,
+              })),
+            };
+          },
+        }
+      : {}),
+  };
+}
+
+describe('Agent settings tools', () => {
+  it('registers a replay-safe read tool and an exclusive confirmed update tool', () => {
+    const { tools } = fixture();
+    const getTool = toolByName(tools, MAKA_SETTINGS_GET_TOOL_NAME);
+    const updateTool = toolByName(tools, MAKA_SETTINGS_UPDATE_TOOL_NAME);
+
+    assert.equal(getTool.categoryHint, 'read');
+    assert.equal(getTool.recoveryMode, 'replay_safe');
+    assert.equal(updateTool.categoryHint, 'custom_tool');
+    assert.equal(updateTool.recoveryMode, 'never_auto_retry');
+    assert.equal(updateTool.executionSemantics, 'exclusive_step');
+  });
+
+  it('returns only the non-secret settings projection', async () => {
+    const h = fixture();
+    h.replaceSettings(
+      mergeSettings(h.readSettings(), {
+        network: { proxy: { password: 'proxy-secret' } },
+        openGateway: { token: 'gateway-secret' },
+        webSearch: { providers: { tavily: { apiKey: 'tavily-secret' } } },
+        personalization: { displayName: 'cc', assistantTone: 'concise' },
+      }),
+    );
+    const getTool = toolByName(h.tools, MAKA_SETTINGS_GET_TOOL_NAME);
+    const result = await getTool.impl({}, context());
+    const serialized = JSON.stringify(result);
+
+    assert.deepEqual((result as { personalization: unknown }).personalization, {
+      displayName: 'cc',
+      assistantTone: 'concise',
+      uiLocale: 'auto',
+    });
+    assert.doesNotMatch(serialized, /proxy-secret|gateway-secret|tavily-secret/);
+    assert.doesNotMatch(serialized, /apiKey|token|password|openGateway|network/);
+  });
+
+  it('rejects non-allowlisted sections at the schema boundary', () => {
+    const updateTool = toolByName(fixture().tools, MAKA_SETTINGS_UPDATE_TOOL_NAME);
+    const schema = updateTool.parameters as z.ZodType;
+
+    assert.equal(schema.safeParse({ openGateway: { enabled: true } }).success, false);
+    assert.equal(schema.safeParse({ chatDefaults: { permissionMode: 'bypass' } }).success, false);
+    assert.equal(schema.safeParse({ webSearch: { apiKey: 'secret' } }).success, false);
+  });
+
+  it('asks for confirmation, then persists the exact allowlisted patch', async () => {
+    const h = fixture();
+    const capture: { questions?: unknown } = {};
+    const updateTool = toolByName(h.tools, MAKA_SETTINGS_UPDATE_TOOL_NAME);
+    const result = (await updateTool.impl(
+      {
+        appearance: { theme: 'dark' },
+        personalization: { assistantTone: 'Be direct.' },
+        system: { keepSystemAwake: true },
+      },
+      context('Apply changes', capture),
+    )) as { ok: boolean; applied: boolean; changes: string[] };
+
+    assert.equal(result.ok, true);
+    assert.equal(result.applied, true);
+    assert.deepEqual(h.patches, [
+      {
+        appearance: { theme: 'dark' },
+        personalization: { assistantTone: 'Be direct.' },
+        system: { keepSystemAwake: true },
+      },
+    ]);
+    assert.equal(h.readSettings().appearance.theme, 'dark');
+    assert.equal(h.readSettings().personalization.assistantTone, 'Be direct.');
+    assert.equal(h.readSettings().system.keepSystemAwake, true);
+    assert.match(JSON.stringify(capture.questions), /appearance\.theme/);
+    assert.match(JSON.stringify(capture.questions), /system\.keepSystemAwake/);
+  });
+
+  it('does not write when the user cancels', async () => {
+    const h = fixture();
+    const updateTool = toolByName(h.tools, MAKA_SETTINGS_UPDATE_TOOL_NAME);
+    const result = (await updateTool.impl(
+      { notifications: { runComplete: false } },
+      context('Cancel'),
+    )) as { ok: boolean; applied: boolean; reason: string };
+
+    assert.deepEqual(result, {
+      kind: 'maka_settings_update',
+      ok: true,
+      applied: false,
+      reason: 'cancelled',
+      message: 'Maka settings were not changed.',
+      settings: {
+        appearance: { theme: 'auto', palette: 'default' },
+        personalization: { displayName: '', assistantTone: '', uiLocale: 'auto' },
+        localMemory: { enabled: true, agentReadEnabled: false },
+        workspaceInstructions: { enabled: true },
+        privacy: { incognitoActive: false },
+        notifications: { runComplete: true },
+        system: { keepSystemAwake: false },
+        webSearch: { enabled: false },
+      },
+    });
+    assert.deepEqual(h.patches, []);
+  });
+
+  it('skips confirmation and writing when every requested value is unchanged', async () => {
+    const h = fixture();
+    const updateTool = toolByName(h.tools, MAKA_SETTINGS_UPDATE_TOOL_NAME);
+    const result = (await updateTool.impl(
+      { appearance: { theme: 'auto' }, notifications: { runComplete: true } },
+      context(),
+    )) as { ok: boolean; applied: boolean };
+
+    assert.equal(result.ok, true);
+    assert.equal(result.applied, false);
+    assert.deepEqual(h.patches, []);
+  });
+
+  it('fails closed when the current surface cannot ask for confirmation', async () => {
+    const h = fixture();
+    const updateTool = toolByName(h.tools, MAKA_SETTINGS_UPDATE_TOOL_NAME);
+    const result = (await updateTool.impl(
+      { webSearch: { enabled: true } },
+      context(),
+    )) as { ok: boolean; applied: boolean; reason: string };
+
+    assert.equal(result.ok, false);
+    assert.equal(result.applied, false);
+    assert.equal(result.reason, 'confirmation_unavailable');
+    assert.deepEqual(h.patches, []);
+  });
+});

--- a/apps/desktop/src/main/agent-settings-tools.ts
+++ b/apps/desktop/src/main/agent-settings-tools.ts
@@ -1,0 +1,293 @@
+import { z } from 'zod';
+import {
+  THEME_PALETTES,
+  UI_LOCALE_PREFERENCES,
+  type AppSettings,
+  type UpdateAppSettingsInput,
+} from '@maka/core';
+import type { MakaTool } from '@maka/runtime';
+import type { SettingsStore } from '@maka/storage';
+
+export const MAKA_SETTINGS_GET_TOOL_NAME = 'MakaSettingsGet';
+export const MAKA_SETTINGS_UPDATE_TOOL_NAME = 'MakaSettingsUpdate';
+
+const appearancePatchSchema = z
+  .object({
+    theme: z.enum(['light', 'dark', 'auto']).optional(),
+    palette: z.enum(THEME_PALETTES).optional(),
+  })
+  .strict();
+
+const personalizationPatchSchema = z
+  .object({
+    displayName: z.string().max(80).optional(),
+    assistantTone: z.string().max(500).optional(),
+    uiLocale: z.enum(UI_LOCALE_PREFERENCES).optional(),
+  })
+  .strict();
+
+const localMemoryPatchSchema = z
+  .object({
+    enabled: z.boolean().optional(),
+    agentReadEnabled: z.boolean().optional(),
+  })
+  .strict();
+
+const enabledPatchSchema = z.object({ enabled: z.boolean().optional() }).strict();
+
+const privacyPatchSchema = z.object({ incognitoActive: z.boolean().optional() }).strict();
+const notificationsPatchSchema = z.object({ runComplete: z.boolean().optional() }).strict();
+const systemPatchSchema = z.object({ keepSystemAwake: z.boolean().optional() }).strict();
+
+const agentSettingsPatchSchema = z
+  .object({
+    appearance: appearancePatchSchema.optional(),
+    personalization: personalizationPatchSchema.optional(),
+    localMemory: localMemoryPatchSchema.optional(),
+    workspaceInstructions: enabledPatchSchema.optional(),
+    privacy: privacyPatchSchema.optional(),
+    notifications: notificationsPatchSchema.optional(),
+    system: systemPatchSchema.optional(),
+    webSearch: enabledPatchSchema.optional(),
+  })
+  .strict();
+
+export type AgentSettingsPatch = z.infer<typeof agentSettingsPatchSchema>;
+
+export interface AgentSettingsSnapshot {
+  appearance: Pick<AppSettings['appearance'], 'theme' | 'palette'>;
+  personalization: Pick<
+    AppSettings['personalization'],
+    'displayName' | 'assistantTone' | 'uiLocale'
+  >;
+  localMemory: Pick<AppSettings['localMemory'], 'enabled' | 'agentReadEnabled'>;
+  workspaceInstructions: Pick<AppSettings['workspaceInstructions'], 'enabled'>;
+  privacy: Pick<AppSettings['privacy'], 'incognitoActive'>;
+  notifications: Pick<AppSettings['notifications'], 'runComplete'>;
+  system: Pick<AppSettings['system'], 'keepSystemAwake'>;
+  webSearch: Pick<AppSettings['webSearch'], 'enabled'>;
+}
+
+export interface AgentSettingsToolsDeps {
+  settingsStore: Pick<SettingsStore, 'get'>;
+  updateSettings(patch: UpdateAppSettingsInput): Promise<AppSettings>;
+}
+
+export function buildAgentSettingsTools(deps: AgentSettingsToolsDeps): MakaTool[] {
+  const getTool: MakaTool<Record<string, never>, AgentSettingsSnapshot> = {
+    name: MAKA_SETTINGS_GET_TOOL_NAME,
+    displayName: '读取 Maka 设置',
+    description:
+      'Read the safe, non-secret subset of Maka application settings that the assistant may help configure. ' +
+      'This never returns API keys, tokens, model credentials, proxy credentials, Bot settings, or Gateway settings.',
+    parameters: z.object({}).strict(),
+    categoryHint: 'read',
+    recoveryMode: 'replay_safe',
+    impl: async () => projectAgentSettings(await deps.settingsStore.get()),
+  };
+
+  const updateTool: MakaTool<AgentSettingsPatch, AgentSettingsUpdateResult> = {
+    name: MAKA_SETTINGS_UPDATE_TOOL_NAME,
+    displayName: '修改 Maka 设置',
+    description:
+      'Update a small allowlisted subset of Maka application settings. ' +
+      'Use only when the user explicitly asks to change Maka itself. ' +
+      'Every effective change requires an in-app confirmation before it is persisted. ' +
+      'Secrets, provider/model configuration, network proxy, Bot/Gateway settings, and permission defaults are not supported.',
+    parameters: agentSettingsPatchSchema,
+    categoryHint: 'custom_tool',
+    recoveryMode: 'never_auto_retry',
+    executionSemantics: 'exclusive_step',
+    impl: async (input, context) => {
+      const current = await deps.settingsStore.get();
+      const patch = toSettingsPatch(input);
+      const changes = describeChanges(current, patch);
+      if (changes.length === 0) {
+        return {
+          kind: 'maka_settings_update',
+          ok: true,
+          applied: false,
+          message: 'The requested Maka settings already have those values.',
+          settings: projectAgentSettings(current),
+        };
+      }
+      if (!context.askUserQuestion) {
+        return {
+          kind: 'maka_settings_update',
+          ok: false,
+          applied: false,
+          reason: 'confirmation_unavailable',
+          message: 'Maka settings were not changed because confirmation is unavailable.',
+          settings: projectAgentSettings(current),
+        };
+      }
+
+      const answer = await context.askUserQuestion([
+        {
+          question: `Apply these Maka setting changes?\n${changes.map((change) => `• ${change}`).join('\n')}`,
+          options: [
+            {
+              label: 'Apply changes',
+              description: 'Persist the listed Maka settings now.',
+            },
+            {
+              label: 'Cancel',
+              description: 'Leave every setting unchanged.',
+            },
+          ],
+        },
+      ]);
+      if (answer.answers[0]?.answer !== 'Apply changes') {
+        return {
+          kind: 'maka_settings_update',
+          ok: true,
+          applied: false,
+          reason: 'cancelled',
+          message: 'Maka settings were not changed.',
+          settings: projectAgentSettings(await deps.settingsStore.get()),
+        };
+      }
+
+      const updated = await deps.updateSettings(patch);
+      return {
+        kind: 'maka_settings_update',
+        ok: true,
+        applied: true,
+        changes,
+        message: `Updated ${changes.length} Maka setting${changes.length === 1 ? '' : 's'}.`,
+        settings: projectAgentSettings(updated),
+      };
+    },
+  };
+
+  return [getTool, updateTool];
+}
+
+type AgentSettingsUpdateResult =
+  | {
+      kind: 'maka_settings_update';
+      ok: true;
+      applied: boolean;
+      reason?: 'cancelled';
+      changes?: string[];
+      message: string;
+      settings: AgentSettingsSnapshot;
+    }
+  | {
+      kind: 'maka_settings_update';
+      ok: false;
+      applied: false;
+      reason: 'confirmation_unavailable';
+      message: string;
+      settings: AgentSettingsSnapshot;
+    };
+
+export function projectAgentSettings(settings: AppSettings): AgentSettingsSnapshot {
+  return {
+    appearance: {
+      theme: settings.appearance.theme,
+      palette: settings.appearance.palette,
+    },
+    personalization: {
+      displayName: settings.personalization.displayName,
+      assistantTone: settings.personalization.assistantTone,
+      uiLocale: settings.personalization.uiLocale,
+    },
+    localMemory: {
+      enabled: settings.localMemory.enabled,
+      agentReadEnabled: settings.localMemory.agentReadEnabled,
+    },
+    workspaceInstructions: { enabled: settings.workspaceInstructions.enabled },
+    privacy: { incognitoActive: settings.privacy.incognitoActive },
+    notifications: { runComplete: settings.notifications.runComplete },
+    system: { keepSystemAwake: settings.system.keepSystemAwake },
+    webSearch: { enabled: settings.webSearch.enabled },
+  };
+}
+
+function toSettingsPatch(input: AgentSettingsPatch): UpdateAppSettingsInput {
+  return {
+    ...(input.appearance ? { appearance: input.appearance } : {}),
+    ...(input.personalization ? { personalization: input.personalization } : {}),
+    ...(input.localMemory ? { localMemory: input.localMemory } : {}),
+    ...(input.workspaceInstructions
+      ? { workspaceInstructions: input.workspaceInstructions }
+      : {}),
+    ...(input.privacy ? { privacy: input.privacy } : {}),
+    ...(input.notifications ? { notifications: input.notifications } : {}),
+    ...(input.system ? { system: input.system } : {}),
+    ...(input.webSearch ? { webSearch: input.webSearch } : {}),
+  };
+}
+
+function describeChanges(current: AppSettings, patch: UpdateAppSettingsInput): string[] {
+  const changes: string[] = [];
+  addChange(changes, 'appearance.theme', current.appearance.theme, patch.appearance?.theme);
+  addChange(changes, 'appearance.palette', current.appearance.palette, patch.appearance?.palette);
+  addChange(
+    changes,
+    'personalization.displayName',
+    current.personalization.displayName,
+    patch.personalization?.displayName,
+  );
+  addChange(
+    changes,
+    'personalization.assistantTone',
+    current.personalization.assistantTone,
+    patch.personalization?.assistantTone,
+  );
+  addChange(
+    changes,
+    'personalization.uiLocale',
+    current.personalization.uiLocale,
+    patch.personalization?.uiLocale,
+  );
+  addChange(changes, 'localMemory.enabled', current.localMemory.enabled, patch.localMemory?.enabled);
+  addChange(
+    changes,
+    'localMemory.agentReadEnabled',
+    current.localMemory.agentReadEnabled,
+    patch.localMemory?.agentReadEnabled,
+  );
+  addChange(
+    changes,
+    'workspaceInstructions.enabled',
+    current.workspaceInstructions.enabled,
+    patch.workspaceInstructions?.enabled,
+  );
+  addChange(
+    changes,
+    'privacy.incognitoActive',
+    current.privacy.incognitoActive,
+    patch.privacy?.incognitoActive,
+  );
+  addChange(
+    changes,
+    'notifications.runComplete',
+    current.notifications.runComplete,
+    patch.notifications?.runComplete,
+  );
+  addChange(
+    changes,
+    'system.keepSystemAwake',
+    current.system.keepSystemAwake,
+    patch.system?.keepSystemAwake,
+  );
+  addChange(changes, 'webSearch.enabled', current.webSearch.enabled, patch.webSearch?.enabled);
+  return changes;
+}
+
+function addChange(
+  changes: string[],
+  path: string,
+  current: string | boolean | undefined,
+  requested: string | boolean | undefined,
+): void {
+  if (requested === undefined || Object.is(current, requested)) return;
+  changes.push(`${path}: ${displayValue(current)} → ${displayValue(requested)}`);
+}
+
+function displayValue(value: string | boolean | undefined): string {
+  if (value === undefined) return '(unset)';
+  return JSON.stringify(value);
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -10,12 +10,14 @@ import {
   resolveUiLocale,
 } from '@maka/core';
 import type {
+  AppSettings,
   BotProvider,
   ConnectionEvent,
   SessionChangedEvent,
   SessionChangedReason,
   SessionEvent,
   SessionHeader,
+  UpdateAppSettingsInput,
 } from '@maka/core';
 import { deriveBotStatusPersistenceUpdate } from './bot-status-persistence.js';
 import { runThreadSearch } from './search/thread-search.js';
@@ -715,6 +717,7 @@ const {
   goalWiring,
   agentMailboxStore,
   settingsStore,
+  updateAgentSettings,
   shellRuns,
   snapshotReadImage,
   readArchivedToolResultResource,
@@ -1274,6 +1277,14 @@ const { normalizeSettingsPatch, applySettingsRuntimeEffects, handleExternalSetti
     keepSystemAwake,
     safeSendToRenderer,
   });
+
+async function updateAgentSettings(patch: UpdateAppSettingsInput): Promise<AppSettings> {
+  const normalizedPatch = await normalizeSettingsPatch(patch);
+  const next = await settingsStore.update(normalizedPatch);
+  await applySettingsRuntimeEffects(next, patch);
+  safeSendToRenderer('settings:externalChanged', { ts: Date.now() });
+  return next;
+}
 
 const streamEvents = createSessionStreamer({
   sessionActivities,

--- a/apps/desktop/src/main/tool-assembly.ts
+++ b/apps/desktop/src/main/tool-assembly.ts
@@ -17,10 +17,12 @@ import {
   ShellRunProcessManager,
 } from '@maka/runtime';
 import type { HostCapabilitiesResolver, MakaTool } from '@maka/runtime';
+import type { AppSettings, UpdateAppSettingsInput } from '@maka/core';
 import type { WorkspacePrivacyContext } from '@maka/core/incognito';
 import { createAgentMailboxStore, createSettingsStore } from '@maka/storage';
 import { createComputerUseOverlayHook } from '@maka/computer-use';
 import { buildWebSearchAgentTool } from './web-search/agent-tool.js';
+import { buildAgentSettingsTools } from './agent-settings-tools.js';
 import { buildRiveWorkflowTool } from './rive-workflow-tool.js';
 import { buildExploreAgentTool } from './explore-agent-tool.js';
 import { buildBrowserTools } from './browser/browser-tools.js';
@@ -58,6 +60,7 @@ export interface DesktopToolAssemblyDeps {
   goalWiring: GoalWiring;
   agentMailboxStore: AgentMailboxStore;
   settingsStore: SettingsStore;
+  updateAgentSettings: (patch: UpdateAppSettingsInput) => Promise<AppSettings>;
   shellRuns: ShellRunProcessManager;
   snapshotReadImage: ToolArtifactPersistence['snapshotReadImage'];
   readArchivedToolResultResource: ToolArtifactPersistence['readArchivedToolResultResource'];
@@ -86,6 +89,7 @@ export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
     goalWiring,
     agentMailboxStore,
     settingsStore,
+    updateAgentSettings,
     shellRuns,
     snapshotReadImage,
     readArchivedToolResultResource,
@@ -193,6 +197,10 @@ export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
     settingsStore,
     getPrivacyContext: getWorkspacePrivacyContext,
   });
+  const agentSettingsTools = buildAgentSettingsTools({
+    settingsStore,
+    updateSettings: updateAgentSettings,
+  });
   // Assemble product tools first, then derive skill host + deferred groups from
   // the shared catalog ∩ this binding (#1099 S2). Skill listing uses the same host.
   const toolsBeforeSkill: MakaTool[] = [
@@ -222,6 +230,9 @@ export function assembleDesktopTools(deps: DesktopToolAssemblyDeps) {
     // permission engine routes it through the `web_read` policy which
     // prompts the user in explore / ask modes.
     webSearchTool,
+    // Safe self-configuration surface: read a redacted projection and update
+    // only an explicit non-secret allowlist after an in-app confirmation.
+    ...agentSettingsTools,
     // Session task ledger: model manages a flat task list; the current list is
     // re-injected each turn tail. Pure local state, so no permission gate.
     ...taskLedgerWiring.tools,

--- a/packages/core/src/tool-catalog.ts
+++ b/packages/core/src/tool-catalog.ts
@@ -97,6 +97,8 @@ export const MAKA_CATALOG_TOOLS: readonly CatalogToolDef[] = Object.freeze(
     { name: 'Skill' },
     { name: 'SkillSearch' },
     { name: 'WebSearch' },
+    { name: 'MakaSettingsGet', effects: ['read'] as const },
+    { name: 'MakaSettingsUpdate', effects: ['write'] as const },
     { name: 'ExploreAgent' },
     { name: 'Automation' },
     { name: 'GoalSet' },


### PR DESCRIPTION
## Summary

Maka did not previously expose a supported way for an agent to inspect or update application-level settings. Agents could only modify files indirectly, which bypassed validation, secret handling, persistence behavior, and runtime side effects.

This PR adds two first-class desktop tools:

- `MakaSettingsGet` returns a safe, non-secret projection of supported settings.
- `MakaSettingsUpdate` applies an allowlisted patch only after the user confirms the exact effective changes in the app.

Accepted updates reuse the existing settings normalization, persistence, runtime-effects, and renderer-refresh path.

## Supported settings

- appearance: theme and palette
- personalization: display name, assistant tone, and UI locale
- local memory: enabled state and agent read access
- workspace instructions: enabled state
- privacy: incognito state
- notifications: run-complete notification
- system: keep-awake behavior
- web search: enabled state

## Safety model

- strict Zod schemas reject every non-allowlisted section and field
- reads never expose API keys, tokens, provider/model credentials, proxy credentials, Bot/Open Gateway settings, or permission defaults
- effective writes require an in-app confirmation and are marked as exclusive, never-auto-retry operations
- no-op requests skip confirmation and persistence
- updates fail closed when confirmation is unavailable

## Verification

- desktop suite: 2,821 tests passed
- core suite: 1,237 tests passed
- TypeScript checks passed
- Biome formatting and lint checks passed
- PR CI: typecheck, test, and e2e passed

## Follow-ups

Review identified three non-blocking hardening items for subsequent work:

- persist only the effective patch shown in the confirmation prompt, or detect concurrent settings changes and reconfirm
- explicitly suppress the update tool in non-interactive Cron/Bot sessions
- refresh memory/privacy header indicators immediately after agent-originated updates
