### PR TITLE
fix(release): align filesystem worker smoke protocol

### DIFF
--- a/scripts/macos-arm64-release.test.mjs
+++ b/scripts/macos-arm64-release.test.mjs
@@ -1,6 +1,9 @@
 import assert from 'node:assert/strict';
-import { readFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import test from 'node:test';
+import { fileURLToPath } from 'node:url';
 
 const repoRoot = new URL('../', import.meta.url);
 const desktopRoot = new URL('../apps/desktop/', import.meta.url);
@@ -218,6 +221,24 @@ test('release package script refuses an unsupported host or incomplete signing i
     }),
     /CSC_LINK/,
   );
+});
+
+test('release filesystem smoke uses the current bundled worker protocol', async () => {
+  const { smokePackagedFilesystemWorker } = await import(
+    new URL('verify-macos-arm64-dmg.mjs', import.meta.url)
+  );
+  const workspace = await mkdtemp(join(tmpdir(), 'maka-release-worker-smoke-'));
+  const worker = fileURLToPath(
+    new URL('../packages/runtime/dist/workers/filesystem-worker.js', import.meta.url),
+  );
+
+  try {
+    await smokePackagedFilesystemWorker(process.execPath, worker, {
+      workingDirectory: workspace,
+    });
+  } finally {
+    await rm(workspace, { recursive: true, force: true });
+  }
 });
 
 test('packaged app verification proves identity, notarization, resources, PTY, and renderer launch', async () => {

--- a/scripts/verify-macos-arm64-dmg.mjs
+++ b/scripts/verify-macos-arm64-dmg.mjs
@@ -220,20 +220,16 @@ export async function smokePackagedFilesystemWorker(
   const workspace = await realpath(workingDirectory);
   const target = join(workspace, 'filesystem-worker-smoke.txt');
   const content = 'maka-filesystem-worker-ok';
-  const operationPermission = {
-    fileSystem: {
+  const operationBoundary = {
+    filesystem: {
       entries: [{ path: target, access: 'write', scope: 'exact' }],
     },
   };
-  const permissionsHash = `sha256:${createHash('sha256')
-    .update(JSON.stringify(operationPermission))
-    .digest('hex')}`;
   const request = {
-    version: 2,
+    version: 4,
     requestId: 'release-filesystem-worker-smoke',
     operation: { kind: 'write', cwd: workspace, path: target, content },
-    operationPermission,
-    permissionsHash,
+    operationBoundary,
     expectedTarget: {
       enforcementPath: target,
       access: 'write',


### PR DESCRIPTION
## Summary

- update the final DMG filesystem smoke from the retired worker protocol v2 request to the current v4 `operationBoundary` contract
- add a regression test that launches the real bundled worker, rather than only mocking the release verifier callback

## Root cause

The runtime worker moved to protocol v4 in #1581, but the release verifier still emitted the old v2 `operationPermission` and `permissionsHash` fields. The signed and notarized app was valid; only the stale smoke request was rejected as `invalid_request`.

## Verification

- `npm run rebuild`
- `npm run check:release`
- `node --test scripts/macos-arm64-release.test.mjs`
- fixed smoke executed successfully against an actual packaged `Maka.app` worker