### PR TITLE
storage: export artifact metadata in SQLite session bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,10 +230,17 @@ staging/link protocol: recovery removes bytes whose metadata transaction did not
 commit and preserves committed bytes while cleaning staging residue. Purge
 intent recovery likewise completes against the SQLite metadata authority.
 
+Selected-session bundle export now reads that SQLite authority through a
+WAL-consistent snapshot, verifies that retained legacy evidence still matches
+its completed cutover, and writes only the selected Artifact rows into the
+bundle's `runtime.sqlite`. Payload bytes are copied under the Artifact writer
+lock, cross-session rows and payloads are excluded, and bundles no longer emit
+`artifacts/metadata.jsonl`.
+
 The remaining storage work is deliberately classified rather than implied
 complete:
 
-- session bundle, backup, restore, and trajectory export paths must consume the
+- full operational backup/restore and trajectory export paths must consume the
   SQLite artifact metadata authority while preserving payload files;
 - legacy operational writers and compatibility-only JSONL code can be removed
   only after the migration/cutover matrix is complete;

--- a/packages/storage/src/__tests__/artifact-writer-lock.test.ts
+++ b/packages/storage/src/__tests__/artifact-writer-lock.test.ts
@@ -18,7 +18,11 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { test } from 'node:test';
 import type { ArtifactRecord } from '@maka/core/artifacts';
 import { openHeadlessArtifactStoreForWrite } from '../artifact-stores.js';
-import { createArtifactStore, type CreateArtifactInput } from '../artifact-store.js';
+import {
+  createArtifactStore,
+  createSqliteArtifactStore,
+  type CreateArtifactInput,
+} from '../artifact-store.js';
 import { withArtifactWriterLock } from '../artifact-writer-lock.js';
 import { createHeadlessRootLease, resolveStorageRoot } from '../root-authority.js';
 import { exportSessionBundleState } from '../session-bundle-policy.js';
@@ -344,10 +348,15 @@ test('bundle export excludes a mutation queued behind the same child-held writer
       await withTimeout(bundleExport, OPERATION_TIMEOUT_MS, 'bundle export');
       await withTimeout(mutation, OPERATION_TIMEOUT_MS, 'Store mutation');
 
-      assert.deepEqual(
-        (await createArtifactStore(destinationRoot).list(session.id)).map((record) => record.id),
-        ['seed'],
-      );
+      const exportedStore = createSqliteArtifactStore(destinationRoot);
+      try {
+        assert.deepEqual(
+          (await exportedStore.list(session.id)).map((record) => record.id),
+          ['seed'],
+        );
+      } finally {
+        exportedStore.close?.();
+      }
       assert.deepEqual(
         (await createArtifactStore(stateRoot).list(session.id)).map((record) => record.id).sort(),
         ['after-export', 'seed'],

--- a/packages/storage/src/__tests__/session-bundle-policy.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-policy.test.ts
@@ -22,7 +22,11 @@ import {
   planSessionBundleExport,
   type SessionBundleExportError,
 } from '../session-bundle-policy.js';
-import { createArtifactStore, createArtifactStoreWriteAuthority } from '../artifact-store.js';
+import {
+  createArtifactStore,
+  createArtifactStoreWriteAuthority,
+  createSqliteArtifactStore,
+} from '../artifact-store.js';
 import { createSessionStore } from '../session-store.js';
 import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
 
@@ -60,7 +64,7 @@ test('exports one session only and excludes credential/config canaries', async (
       await mkdir(dirname(path), { recursive: true });
       await writeFile(path, contents);
     }
-    const artifacts = createArtifactStore(stateRoot);
+    const artifacts = createSqliteArtifactStore(stateRoot);
     const selectedArtifact = await artifacts.create({
       id: 'selected-output',
       sessionId: selected.id,
@@ -115,6 +119,8 @@ test('exports one session only and excludes credential/config canaries', async (
         'credentials.json',
         'llm-connections.json',
         `artifacts/${other.id}`,
+        'runtime.sqlite-shm',
+        'runtime.sqlite-wal',
         `sessions/${other.id}`,
       ].sort(),
     );
@@ -139,21 +145,34 @@ test('exports one session only and excludes credential/config canaries', async (
     await assert.rejects(readFile(join(destinationRoot, 'sessions', other.id, 'session.jsonl')));
     await assert.rejects(readFile(join(destinationRoot, 'sessions.sqlite')));
     await assert.rejects(readFile(join(destinationRoot, 'artifacts', otherArtifact.relativePath)));
-    assert.match(
-      await readFile(join(destinationRoot, 'artifacts', 'metadata.jsonl'), 'utf8'),
-      new RegExp(`"sessionId":"${selected.id}"`),
-    );
-    assert.doesNotMatch(
-      await readFile(join(destinationRoot, 'artifacts', 'metadata.jsonl'), 'utf8'),
-      new RegExp(other.id),
-    );
-    const reopenedArtifacts = createArtifactStore(destinationRoot);
-    assert.deepEqual(await reopenedArtifacts.list(selected.id), [selectedArtifact]);
-    assert.deepEqual(await reopenedArtifacts.list(other.id), []);
-    assert.deepEqual(await reopenedArtifacts.readText(selectedArtifact.id), {
-      ok: true,
-      text: 'session output\n',
+    await assert.rejects(lstat(join(destinationRoot, 'artifacts', 'metadata.jsonl')), {
+      code: 'ENOENT',
     });
+    const reopenedArtifacts = createSqliteArtifactStore(destinationRoot);
+    try {
+      assert.deepEqual(await reopenedArtifacts.list(selected.id), [selectedArtifact]);
+      assert.deepEqual(await reopenedArtifacts.list(other.id), []);
+      assert.deepEqual(await reopenedArtifacts.readText(selectedArtifact.id), {
+        ok: true,
+        text: 'session output\n',
+      });
+      const createdAfterRestore = await reopenedArtifacts.create({
+        id: 'restored-write',
+        sessionId: selected.id,
+        turnId: 'turn-2',
+        name: 'restored.txt',
+        kind: 'file',
+        content: 'restored write\n',
+        now: 12,
+      });
+      assert.deepEqual(await reopenedArtifacts.readText(createdAfterRestore.id), {
+        ok: true,
+        text: 'restored write\n',
+      });
+    } finally {
+      reopenedArtifacts.close?.();
+      artifacts.close?.();
+    }
     const exportedRuntime = createSqliteRuntimeStore(join(destinationRoot, 'runtime.sqlite'));
     try {
       assert.equal((await exportedRuntime.readSessionRuntimeEvents(selected.id)).length, 1);
@@ -227,6 +246,86 @@ test('exports while the operational DB remains open and protects its sidecars', 
     } finally {
       await sessions.close?.();
     }
+  });
+});
+
+test('exports legacy Artifact metadata into SQLite regardless of source record order', async () => {
+  await withBundleRoots(async ({ stateRoot, configRoot, destinationRoot }) => {
+    const sessionId = await createSelectedSession(stateRoot);
+    const artifacts = createArtifactStore(stateRoot);
+    const later = await artifacts.create({
+      id: 'later-artifact',
+      sessionId,
+      turnId: 'turn-1',
+      name: 'later.txt',
+      kind: 'file',
+      content: 'later\n',
+      now: 2,
+    });
+    const earlier = await artifacts.create({
+      id: 'earlier-artifact',
+      sessionId,
+      turnId: 'turn-1',
+      name: 'earlier.txt',
+      kind: 'file',
+      content: 'earlier\n',
+      now: 1,
+    });
+
+    await exportSessionBundleState({ stateRoot, configRoot, destinationRoot, sessionId });
+
+    await assert.rejects(lstat(join(destinationRoot, 'artifacts', 'metadata.jsonl')), {
+      code: 'ENOENT',
+    });
+    const reopened = createSqliteArtifactStore(destinationRoot);
+    try {
+      assert.deepEqual(await reopened.list(sessionId), [later, earlier]);
+    } finally {
+      reopened.close?.();
+    }
+  });
+});
+
+test('fails closed when legacy Artifact evidence changes after SQLite cutover', async () => {
+  await withBundleRoots(async ({ stateRoot, configRoot, destinationRoot }) => {
+    const sessionId = await createSelectedSession(stateRoot);
+    const legacy = createArtifactStore(stateRoot);
+    await legacy.create({
+      id: 'before-cutover',
+      sessionId,
+      turnId: 'turn-1',
+      name: 'before.txt',
+      kind: 'file',
+      content: 'before\n',
+      now: 1,
+    });
+    const sqlite = createSqliteArtifactStore(stateRoot);
+    try {
+      assert.equal((await sqlite.list(sessionId)).length, 1);
+    } finally {
+      sqlite.close?.();
+    }
+
+    await legacy.create({
+      id: 'stale-writer',
+      sessionId,
+      turnId: 'turn-2',
+      name: 'stale.txt',
+      kind: 'file',
+      content: 'stale\n',
+      now: 2,
+    });
+
+    await assert.rejects(
+      exportSessionBundleState({ stateRoot, configRoot, destinationRoot, sessionId }),
+      (error: unknown) => {
+        const exportError = error as SessionBundleExportError;
+        assert.equal(exportError.code, 'unsupported_entry');
+        assert.match(exportError.message, /Artifact metadata changed during session bundle export/);
+        return true;
+      },
+    );
+    await assert.rejects(readdir(destinationRoot), { code: 'ENOENT' });
   });
 });
 
@@ -461,11 +560,16 @@ test('authority recovery removes canonical root temps before bundle export', asy
       destinationRoot,
       sessionId,
     });
-    assert.deepEqual(await createArtifactStore(destinationRoot).list(sessionId), [record]);
-    assert.deepEqual(await createArtifactStore(destinationRoot).readText(record.id), {
-      ok: true,
-      text: 'canonical payload\n',
-    });
+    const reopened = createSqliteArtifactStore(destinationRoot);
+    try {
+      assert.deepEqual(await reopened.list(sessionId), [record]);
+      assert.deepEqual(await reopened.readText(record.id), {
+        ok: true,
+        text: 'canonical payload\n',
+      });
+    } finally {
+      reopened.close?.();
+    }
   });
 });
 

--- a/packages/storage/src/session-bundle-policy.ts
+++ b/packages/storage/src/session-bundle-policy.ts
@@ -10,7 +10,9 @@ import {
   writeFile,
 } from 'node:fs/promises';
 import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { basename, dirname, isAbsolute, relative, resolve, sep } from 'node:path';
+import type { DatabaseSync } from 'node:sqlite';
 import type { RuntimeEvent } from '@maka/core';
 import type { ArtifactRecord } from '@maka/core/artifacts';
 import {
@@ -33,6 +35,10 @@ import {
 import { createSqliteSessionMetadataStore } from './sqlite-session-metadata-store.js';
 import type { SessionAuthoritySnapshot } from './sqlite-session-metadata-store.js';
 import { createSqliteRuntimeStore } from './sqlite-runtime-store.js';
+import {
+  artifactMetadataSourceFingerprint,
+  createSqliteArtifactMetadataRepository,
+} from './sqlite-artifact-metadata.js';
 
 /**
  * The first bundle slice is deliberately an uncompressed state-tree export.
@@ -88,6 +94,7 @@ const allowedEntries = new Set<string>(SESSION_BUNDLE_STATE_ENTRIES);
 const protectedEntries = new Set<string>(SESSION_BUNDLE_PROTECTED_ENTRIES);
 const portableSessionDirectories = new Set<string>(SESSION_BUNDLE_PORTABLE_SESSION_DIRECTORIES);
 const portableSessionFiles = new Set<string>(SESSION_BUNDLE_PORTABLE_SESSION_FILES);
+const require = createRequire(import.meta.url);
 
 export type SessionBundleExportErrorCode =
   | 'invalid_root'
@@ -123,7 +130,6 @@ export interface SessionBundleExportPlanEntry {
     | 'copy'
     | 'selected_session_metadata'
     | 'selected_session_boundary'
-    | 'filtered_artifact_metadata'
     | 'filtered_runtime_sqlite';
 }
 
@@ -147,7 +153,6 @@ interface ArtifactMetadataSnapshot {
   metadataExists: boolean;
   canonicalText: string;
   selectedRecords: ArtifactRecord[];
-  filteredText: string;
 }
 
 interface PreparedSessionBundleExport {
@@ -203,6 +208,12 @@ async function prepareSessionBundleExport(
   const excludedEntries: string[] = [];
   const entries: SessionBundleExportPlanEntry[] = [];
   const artifactMetadata = await readArtifactMetadataSnapshot(stateRoot, input.sessionId);
+  if (!artifactMetadata.artifactRootExists && artifactMetadata.selectedRecords.length > 0) {
+    throw new SessionBundleExportError(
+      'invalid_root',
+      `Artifact metadata references a missing artifacts root for session ${input.sessionId}`,
+    );
+  }
   let sessionsClassified = false;
   let artifactsClassified = false;
   const topLevelEntries = await readdir(stateRoot, { withFileTypes: true });
@@ -330,7 +341,7 @@ export async function exportSessionBundleState(
     await assertSessionBundleRootIdentity(preflight.stateRoot, preflight.stateRootIdentity);
     await exportPreparedArtifactState(current);
     await assertSessionBundleRootIdentity(preflight.stateRoot, preflight.stateRootIdentity);
-    await exportPreparedNonArtifactState(current.plan);
+    await exportPreparedNonArtifactState(current.plan, current.artifactMetadata);
     await assertSessionBundleRootIdentity(preflight.stateRoot, preflight.stateRootIdentity);
     return current.plan;
   });
@@ -350,16 +361,14 @@ async function exportPreparedArtifactState(prepared: PreparedSessionBundleExport
     await mkdir(dirname(destinationPath), { recursive: true });
     await copyCheckedFile(sourcePath, destinationPath, plan.stateRoot, entry.relativePath);
   }
-  for (const entry of artifactEntries) {
-    if (entry.source === 'filtered_artifact_metadata') {
-      await exportFilteredArtifactMetadata(plan, entry, artifactMetadata);
-    }
-  }
   await assertNoCanonicalArtifactTransactionResidue(plan.stateRoot);
   await assertArtifactMetadataSnapshotUnchanged(plan.stateRoot, artifactMetadata);
 }
 
-async function exportPreparedNonArtifactState(plan: SessionBundleExportPlan): Promise<void> {
+async function exportPreparedNonArtifactState(
+  plan: SessionBundleExportPlan,
+  artifactMetadata: ArtifactMetadataSnapshot,
+): Promise<void> {
   const entries = plan.entries.filter((entry) => !isArtifactEntry(entry));
   const directories = entries.filter((entry) => entry.kind === 'directory');
   const files = entries.filter((entry) => entry.kind === 'file' && entry.source === 'copy');
@@ -387,6 +396,7 @@ async function exportPreparedNonArtifactState(plan: SessionBundleExportPlan): Pr
       await exportFilteredRuntimeSqlite(plan, entry);
     }
   }
+  await exportSqliteArtifactMetadata(plan.destinationRoot, artifactMetadata.selectedRecords);
 }
 
 function isArtifactEntry(entry: SessionBundleExportPlanEntry): boolean {
@@ -584,11 +594,7 @@ async function planSelectedArtifactTree(
     if (entry.name === 'metadata.jsonl') {
       metadataClassified = true;
       if (!artifactMetadata.metadataExists) throw artifactMetadataChanged();
-      entries.push({
-        relativePath: 'artifacts/metadata.jsonl',
-        kind: 'file',
-        source: 'filtered_artifact_metadata',
-      });
+      excludedEntries.push('artifacts/metadata.jsonl');
       continue;
     }
     if (
@@ -755,14 +761,23 @@ async function readArtifactMetadataSnapshot(
   return {
     ...source,
     selectedRecords,
-    filteredText:
-      selectedRecords.length > 0
-        ? `${selectedRecords.map((record) => JSON.stringify(record)).join('\n')}\n`
-        : '',
   };
 }
 
 async function readArtifactMetadataSource(
+  stateRoot: string,
+): Promise<
+  Pick<ArtifactMetadataSnapshot, 'artifactRootExists' | 'metadataExists' | 'canonicalText'>
+> {
+  const legacy = await readLegacyArtifactMetadataSource(stateRoot);
+  const canonicalText = await readCanonicalSqliteArtifactMetadata(
+    stateRoot,
+    legacy.metadataExists ? legacy.canonicalText : undefined,
+  );
+  return canonicalText === undefined ? legacy : { ...legacy, canonicalText };
+}
+
+async function readLegacyArtifactMetadataSource(
   stateRoot: string,
 ): Promise<
   Pick<ArtifactMetadataSnapshot, 'artifactRootExists' | 'metadataExists' | 'canonicalText'>
@@ -809,6 +824,94 @@ async function readArtifactMetadataSource(
     metadataExists: true,
     canonicalText: await readFile(metadataPath, 'utf8'),
   };
+}
+
+async function readCanonicalSqliteArtifactMetadata(
+  stateRoot: string,
+  legacySource: string | undefined,
+): Promise<string | undefined> {
+  const databasePath = resolve(stateRoot, OPERATIONAL_STATE_DATABASE_NAME);
+  let metadata;
+  try {
+    metadata = await lstat(databasePath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return undefined;
+    throw error;
+  }
+  assertNoSymlink(metadata.isSymbolicLink(), OPERATIONAL_STATE_DATABASE_NAME);
+  await assertCanonicalPathInside(databasePath, stateRoot, OPERATIONAL_STATE_DATABASE_NAME);
+  if (!metadata.isFile()) {
+    throw new SessionBundleExportError(
+      'unsupported_entry',
+      `Session bundle runtime SQLite is not a regular file: ${databasePath}`,
+    );
+  }
+
+  const Database = loadDatabaseSync();
+  const database = new Database(databasePath, { readOnly: true });
+  let snapshotOpen = false;
+  try {
+    database.exec('PRAGMA busy_timeout = 5000; PRAGMA query_only = ON');
+    database.exec('BEGIN');
+    snapshotOpen = true;
+    if (!sqliteTableExists(database, 'cutover_journal')) return undefined;
+    const journal = database
+      .prepare(`
+        SELECT source_fingerprint, state
+        FROM cutover_journal
+        WHERE store_name = 'artifact_metadata'
+      `)
+      .get() as { source_fingerprint?: unknown; state?: unknown } | undefined;
+    if (!journal) {
+      if (sqliteTableExists(database, 'artifact_records')) {
+        const row = database.prepare('SELECT COUNT(*) AS count FROM artifact_records').get() as {
+          count?: unknown;
+        };
+        if (row.count !== 0) {
+          throw new SessionBundleExportError(
+            'unsupported_entry',
+            'Artifact SQLite rows exist without a completed cutover journal',
+          );
+        }
+      }
+      return undefined;
+    }
+    if (journal.state !== 'completed' || typeof journal.source_fingerprint !== 'string') {
+      throw new SessionBundleExportError(
+        'unsupported_entry',
+        'Artifact metadata cutover must complete before session bundle export',
+      );
+    }
+    if (journal.source_fingerprint !== artifactMetadataSourceFingerprint(legacySource)) {
+      throw artifactMetadataChanged();
+    }
+    if (!sqliteTableExists(database, 'artifact_records')) {
+      throw new SessionBundleExportError(
+        'unsupported_entry',
+        'Completed Artifact metadata cutover is missing artifact_records',
+      );
+    }
+    const rows = database
+      .prepare(`
+        SELECT record_json
+        FROM artifact_records
+        ORDER BY created_at, storage_key
+      `)
+      .all() as Array<{ record_json?: unknown }>;
+    if (rows.some((row) => typeof row.record_json !== 'string')) {
+      throw new SessionBundleExportError(
+        'unsupported_entry',
+        'Artifact SQLite metadata contains an invalid record',
+      );
+    }
+    return rows.length > 0 ? `${rows.map((row) => row.record_json as string).join('\n')}\n` : '';
+  } finally {
+    try {
+      if (snapshotOpen) database.exec('ROLLBACK');
+    } finally {
+      database.close();
+    }
+  }
 }
 
 async function assertArtifactMetadataSnapshotUnchanged(
@@ -938,16 +1041,6 @@ async function copyCheckedFile(
   await copyFile(sourcePath, destinationPath);
 }
 
-async function exportFilteredArtifactMetadata(
-  plan: SessionBundleExportPlan,
-  entry: SessionBundleExportPlanEntry,
-  snapshot: ArtifactMetadataSnapshot,
-): Promise<void> {
-  const destinationPath = resolve(plan.destinationRoot, entry.relativePath);
-  await mkdir(dirname(destinationPath), { recursive: true });
-  await writeFile(destinationPath, snapshot.filteredText);
-}
-
 async function exportFilteredRuntimeSqlite(
   plan: SessionBundleExportPlan,
   entry: SessionBundleExportPlanEntry,
@@ -983,6 +1076,38 @@ async function exportFilteredRuntimeSqlite(
     source.close();
   }
   await rename(filteredPath, destinationPath);
+}
+
+async function exportSqliteArtifactMetadata(
+  destinationRoot: string,
+  records: readonly ArtifactRecord[],
+): Promise<void> {
+  const repository = createSqliteArtifactMetadataRepository(destinationRoot);
+  try {
+    await repository.ready();
+    repository.replaceAll(records);
+    const reopened = repository.readAll();
+    if (!sameArtifactRecordSet(reopened, records)) {
+      throw new SessionBundleExportError(
+        'unsupported_entry',
+        'Exported Artifact SQLite metadata failed validation',
+      );
+    }
+  } finally {
+    repository.close();
+  }
+}
+
+function sameArtifactRecordSet(
+  left: readonly ArtifactRecord[],
+  right: readonly ArtifactRecord[],
+): boolean {
+  if (left.length !== right.length) return false;
+  const canonical = (records: readonly ArtifactRecord[]) =>
+    records.map((record) => JSON.stringify(record)).sort((a, b) => a.localeCompare(b));
+  const leftRecords = canonical(left);
+  const rightRecords = canonical(right);
+  return leftRecords.every((record, index) => record === rightRecords[index]);
 }
 
 async function ensureEmptyDestination(requestedPath: string, canonicalPath: string): Promise<void> {
@@ -1218,4 +1343,15 @@ export function isArtifactPathForSession(relativePath: string, sessionId: string
 function isPathInside(root: string, candidate: string): boolean {
   const path = relative(root, candidate);
   return path === '' || (!path.startsWith(`..${sep}`) && path !== '..' && !isAbsolute(path));
+}
+
+function sqliteTableExists(database: DatabaseSync, table: string): boolean {
+  return (
+    database.prepare(`SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?`).get(table) !==
+    undefined
+  );
+}
+
+function loadDatabaseSync(): typeof import('node:sqlite').DatabaseSync {
+  return (require('node:sqlite') as typeof import('node:sqlite')).DatabaseSync;
 }

--- a/packages/storage/src/sqlite-artifact-metadata.ts
+++ b/packages/storage/src/sqlite-artifact-metadata.ts
@@ -15,6 +15,12 @@ export interface CreateSqliteArtifactMetadataOptions {
   readonly failpoint?: (point: OperationalStoreCutoverFailpoint) => void;
 }
 
+export function artifactMetadataSourceFingerprint(source: string | undefined): string {
+  return `sha256:${createHash('sha256')
+    .update(source === undefined ? 'missing' : source)
+    .digest('hex')}`;
+}
+
 export function createSqliteArtifactMetadataRepository(
   workspaceRoot: string,
   options: CreateSqliteArtifactMetadataOptions = {},
@@ -104,9 +110,7 @@ async function importLegacyArtifactMetadata(
   const sourcePath = join(root, 'artifacts', 'metadata.jsonl');
   const source = await readOptionalText(sourcePath);
   const records = source === undefined ? [] : decodeArtifactMetadata(source);
-  const fingerprint = `sha256:${createHash('sha256')
-    .update(source === undefined ? 'missing' : source)
-    .digest('hex')}`;
+  const fingerprint = artifactMetadataSourceFingerprint(source);
   completeOperationalStoreCutover(lease, {
     storeName: 'artifact_metadata',
     sourcePath,


### PR DESCRIPTION
## Summary

- read canonical `artifact_records` from a read-only WAL snapshot and require a completed cutover whose retained legacy fingerprint still matches
- retain legacy JSONL input only for pre-cutover compatibility, while omitting `artifacts/metadata.jsonl` from every exported bundle
- filter Artifact rows and payload files to the selected session, then seed those rows into the destination `runtime.sqlite`
- keep the Artifact writer lock across snapshot, payload copy, and selected-session projection so queued mutations cannot leak into the bundle
- validate the destination through the SQLite Artifact store and cover continued writes after restore

## Migration guarantees

- cross-session Artifact rows and payloads are excluded
- live WAL rows remain visible while the operational database is open
- changed legacy evidence after completed cutover fails closed before destination creation
- canonical publication/purge residue continues to require authority recovery
- legacy metadata order does not affect relational export validation
- restored bundles reopen and accept new Artifact writes without recreating metadata JSONL

## Verification

- Biome checks on all changed files
- `npm --workspace @maka/storage run typecheck`
- 41 focused session-bundle and Artifact writer-lock tests
- full Storage suite: 854 passed, 1 skipped
- session-bundle measurement suite: 26 passed

Part of #1649. This is the selected-session relational-closure slice of Stage 5; full operational backup/restore remains separate follow-up work.