### PR TITLE
headless: export trajectory artifacts from frozen SQLite state

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,11 +246,17 @@ sets, transcript decodability, and the exact manifested file tree before
 atomically publishing a new state root. Interrupted backup or restore staging
 is removed and can be retried without changing either source.
 
+Headless trajectory hydration now consumes a frozen selected-session export
+from that SQLite Artifact authority. The cell publishes `trajectory-state`
+only when RuntimeEvents reference image Artifacts; Harbor downloads its
+standalone `runtime.sqlite` first and then only the payloads referenced by the
+validated snapshot. It does not copy a live WAL or fall back to
+`artifacts/metadata.jsonl`. Missing, corrupt, unsupported, or mismatched
+evidence fails closed to a summary trajectory instead of mixing authorities.
+
 The remaining storage work is deliberately classified rather than implied
 complete:
 
-- remaining trajectory export paths must consume the SQLite artifact metadata
-  authority while preserving payload files;
 - legacy operational writers and compatibility-only JSONL code can be removed
   only after the migration/cutover matrix is complete;
 - StoredMessage transcript bodies remain append-only JSONL;

--- a/packages/headless/harbor/maka_agent.py
+++ b/packages/headless/harbor/maka_agent.py
@@ -10,6 +10,7 @@ import os
 import re
 import secrets
 import shlex
+import shutil
 import threading
 import time
 from datetime import datetime, timezone
@@ -742,37 +743,16 @@ class MakaAgent(BaseInstalledAgent):
         local_store_root = self._trajectory_artifact_store_root()
         local_artifact_root = local_store_root / "artifacts"
         database_path = local_store_root / "runtime.sqlite"
-        metadata_path = local_artifact_root / "metadata.jsonl"
-        if database_path.is_file() or metadata_path.is_file():
+        if database_path.is_file():
             return
-        remote_store_root = EnvironmentPaths.agent_dir / "maka-storage"
+        shutil.rmtree(local_store_root, ignore_errors=True)
+        remote_store_root = EnvironmentPaths.agent_dir / "trajectory-state"
         remote_artifact_root = remote_store_root / "artifacts"
         try:
-            metadata_path.parent.mkdir(parents=True, exist_ok=True)
-            try:
-                await environment.download_file(
-                    (remote_store_root / "runtime.sqlite").as_posix(), database_path
-                )
-                try:
-                    await environment.download_file(
-                        (remote_store_root / "runtime.sqlite-wal").as_posix(),
-                        Path(f"{database_path}-wal"),
-                    )
-                except Exception:  # noqa: BLE001 - WAL may not exist after checkpoint.
-                    pass
-                try:
-                    await environment.download_file(
-                        (remote_artifact_root / "metadata.jsonl").as_posix(),
-                        metadata_path,
-                    )
-                except Exception:  # noqa: BLE001 - absent after SQLite-native creation.
-                    pass
-            except Exception:  # noqa: BLE001 - support pre-SQLite artifact stores.
-                database_path.unlink(missing_ok=True)
-                Path(f"{database_path}-wal").unlink(missing_ok=True)
-                await environment.download_file(
-                    (remote_artifact_root / "metadata.jsonl").as_posix(), metadata_path
-                )
+            database_path.parent.mkdir(parents=True, exist_ok=True)
+            await environment.download_file(
+                (remote_store_root / "runtime.sqlite").as_posix(), database_path
+            )
             for relative_path in referenced_image_artifact_paths(
                 runtime_events_path, local_store_root
             ):
@@ -782,6 +762,7 @@ class MakaAgent(BaseInstalledAgent):
                     (remote_artifact_root / relative_path).as_posix(), local
                 )
         except Exception as exc:  # noqa: BLE001 - trajectory builder fails closed.
+            shutil.rmtree(local_store_root, ignore_errors=True)
             self.logger.debug("Could not download Maka runtime artifacts: %s", exc)
 
     def _write_trajectory(self, output: dict[str, Any]) -> None:
@@ -993,7 +974,7 @@ class MakaAgent(BaseInstalledAgent):
         if isinstance(configured, Path):
             return configured
         if self._harbor_mode() == "task-run":
-            return self.logs_dir / "maka-task-run" / "runs"
+            return self.logs_dir / "maka-task-run" / "trajectory-state"
         return self.logs_dir / "maka-storage"
 
     async def _run_task_run_host(
@@ -1031,7 +1012,7 @@ class MakaAgent(BaseInstalledAgent):
             storage_root = host_repo_root / storage_root
         env["MAKA_OUTPUT_DIR"] = str(output_dir)
         env["MAKA_STORAGE_ROOT"] = str(storage_root)
-        self._trajectory_storage_root = storage_root
+        self._trajectory_storage_root = output_dir / "trajectory-state"
         env["MAKA_CELL_SOFT_TIMEOUT_MS"] = str(self._cell_soft_timeout_ms(env))
 
         task_workdir, workdir_probe = await self._resolve_task_workdir(environment)

--- a/packages/headless/harbor/maka_trajectory.py
+++ b/packages/headless/harbor/maka_trajectory.py
@@ -433,7 +433,19 @@ class _ImageArtifactResolver:
             source.relative_to(artifact_root)
         except (OSError, RuntimeError, ValueError):
             raise _IncompleteTrajectoryEvidence("image_artifact_unavailable") from None
-        if not source.is_file() or _sniff_image_media_type(source) != mime_type:
+        size_bytes = record.get("sizeBytes")
+        try:
+            content_matches = (
+                source.is_file()
+                and isinstance(size_bytes, int)
+                and not isinstance(size_bytes, bool)
+                and size_bytes >= 0
+                and source.stat().st_size == size_bytes
+                and _sniff_image_media_type(source) == mime_type
+            )
+        except OSError:
+            content_matches = False
+        if not content_matches:
             raise _IncompleteTrajectoryEvidence("image_artifact_content_mismatch")
         try:
             assets_root = self.trajectory_root / "trajectory-assets"
@@ -1971,48 +1983,65 @@ def referenced_image_artifact_paths(
 
 def _read_artifact_records(artifact_store_root: Path) -> dict[str, dict[str, Any]]:
     database_path = artifact_store_root / "runtime.sqlite"
-    metadata_path = artifact_store_root / "artifacts" / "metadata.jsonl"
-    serialized_records: Optional[list[str]] = None
-    if database_path.is_file():
-        connection: Optional[sqlite3.Connection] = None
-        try:
-            connection = sqlite3.connect(
-                f"{database_path.resolve().as_uri()}?mode=ro",
-                uri=True,
-            )
-            table = connection.execute(
-                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'artifact_records'"
-            ).fetchone()
-            if table is not None:
-                serialized_records = [
-                    row[0]
-                    for row in connection.execute(
-                        "SELECT record_json FROM artifact_records ORDER BY created_at, storage_key"
-                    )
-                ]
-        except (OSError, sqlite3.Error, TypeError):
-            raise _IncompleteTrajectoryEvidence("image_artifact_metadata_invalid") from None
-        finally:
-            if connection is not None:
-                connection.close()
-    if serialized_records is None:
-        try:
-            serialized_records = [
-                line
-                for line in metadata_path.read_text(encoding="utf-8").splitlines()
-                if line.strip()
-            ]
-        except (OSError, UnicodeError):
-            raise _IncompleteTrajectoryEvidence("image_artifact_metadata_missing") from None
+    if not database_path.exists():
+        raise _IncompleteTrajectoryEvidence("image_artifact_metadata_missing")
+    if database_path.is_symlink() or not database_path.is_file():
+        raise _IncompleteTrajectoryEvidence("image_artifact_metadata_invalid")
+
+    connection: Optional[sqlite3.Connection] = None
+    try:
+        canonical_root = artifact_store_root.resolve(strict=True)
+        canonical_database = database_path.resolve(strict=True)
+        canonical_database.relative_to(canonical_root)
+        connection = sqlite3.connect(
+            f"{canonical_database.as_uri()}?mode=ro&immutable=1",
+            uri=True,
+        )
+        integrity = connection.execute("PRAGMA integrity_check").fetchall()
+        if integrity != [("ok",)]:
+            raise ValueError
+        if connection.execute("PRAGMA foreign_key_check").fetchone() is not None:
+            raise ValueError
+        schema = connection.execute(
+            "SELECT version FROM operational_schema_migrations WHERE scope = 'artifact'"
+        ).fetchone()
+        if schema != (1,):
+            raise ValueError
+        cutover = connection.execute(
+            "SELECT state FROM cutover_journal WHERE store_name = 'artifact_metadata'"
+        ).fetchone()
+        if cutover != ("completed",):
+            raise ValueError
+        rows = connection.execute(
+            """
+            SELECT artifact_id, session_id, created_at, status, relative_path, record_json
+            FROM artifact_records
+            ORDER BY created_at, storage_key
+            """
+        ).fetchall()
+    except (OSError, sqlite3.Error, TypeError, ValueError):
+        raise _IncompleteTrajectoryEvidence("image_artifact_metadata_invalid") from None
+    finally:
+        if connection is not None:
+            connection.close()
 
     records: dict[str, dict[str, Any]] = {}
     try:
-        for serialized in serialized_records:
+        for artifact_id, session_id, created_at, status, relative_path, serialized in rows:
             record = json.loads(serialized)
-            artifact_id = record.get("id") if isinstance(record, dict) else None
-            if not isinstance(artifact_id, str) or not artifact_id or artifact_id in records:
+            record_id = record.get("id") if isinstance(record, dict) else None
+            if (
+                not isinstance(record_id, str)
+                or not record_id
+                or record_id in records
+                or artifact_id != record_id
+                or session_id != record.get("sessionId")
+                or created_at != record.get("createdAt")
+                or status != record.get("status")
+                or relative_path != record.get("relativePath")
+            ):
                 raise ValueError
-            records[artifact_id] = record
+            records[record_id] = record
     except (json.JSONDecodeError, TypeError, ValueError):
         raise _IncompleteTrajectoryEvidence("image_artifact_metadata_invalid") from None
     return records

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -2623,10 +2623,11 @@ with tempfile.TemporaryDirectory() as tmp:
         relative_task_run_env = captured_host_process["kwargs"]["env"]
         expected_task_run_out = host_repo_root / "relative-task-run"
         expected_storage_root = expected_task_run_out / "runs"
+        expected_trajectory_root = expected_task_run_out / "trajectory-state"
         assert relative_task_run_env["MAKA_TASK_RUN_OUT_DIR"] == str(expected_task_run_out), relative_task_run_env
         assert relative_task_run_env["MAKA_OUTPUT_DIR"] == str(expected_task_run_out), relative_task_run_env
         assert relative_task_run_env["MAKA_STORAGE_ROOT"] == str(expected_storage_root), relative_task_run_env
-        assert relative_task_run_agent._trajectory_artifact_store_root() == expected_storage_root
+        assert relative_task_run_agent._trajectory_artifact_store_root() == expected_trajectory_root
         assert captured_host_process["kwargs"]["cwd"] == str(host_repo_root)
 
         runner_env_path = Path(tmp) / "task-run.env"
@@ -3207,6 +3208,65 @@ def event(event_id, ts, role, author, content=None, refs=None, status=None, acti
     return value
 
 
+def write_artifact_database(store_root, records, artifact_schema_version=1):
+    store_root.mkdir(parents=True, exist_ok=True)
+    database_path = store_root / "runtime.sqlite"
+    database_path.unlink(missing_ok=True)
+    connection = sqlite3.connect(database_path)
+    connection.executescript("""
+        CREATE TABLE operational_schema_migrations (
+            scope TEXT PRIMARY KEY,
+            version INTEGER NOT NULL,
+            applied_at INTEGER NOT NULL
+        );
+        CREATE TABLE cutover_journal (
+            store_name TEXT PRIMARY KEY,
+            source_path TEXT NOT NULL,
+            source_fingerprint TEXT NOT NULL,
+            state TEXT NOT NULL,
+            started_at INTEGER NOT NULL,
+            completed_at INTEGER,
+            validation_json TEXT
+        );
+        CREATE TABLE artifact_records (
+            storage_key TEXT PRIMARY KEY,
+            artifact_id TEXT NOT NULL,
+            session_id TEXT NOT NULL,
+            created_at INTEGER NOT NULL,
+            status TEXT NOT NULL,
+            relative_path TEXT NOT NULL,
+            record_json TEXT NOT NULL
+        );
+    """)
+    connection.execute(
+        "INSERT INTO operational_schema_migrations(scope, version, applied_at) VALUES ('artifact', ?, 1)",
+        (artifact_schema_version,),
+    )
+    connection.execute(
+        "INSERT INTO cutover_journal(store_name, source_path, source_fingerprint, state, started_at, completed_at, validation_json) VALUES ('artifact_metadata', 'artifacts/metadata.jsonl', 'none', 'completed', 1, 1, '{}')"
+    )
+    for record in records:
+        connection.execute(
+            """
+            INSERT INTO artifact_records(
+                storage_key, artifact_id, session_id, created_at, status, relative_path, record_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                record["id"],
+                record["id"],
+                record["sessionId"],
+                record["createdAt"],
+                record["status"],
+                record["relativePath"],
+                json.dumps(record),
+            ),
+        )
+    connection.commit()
+    connection.close()
+    return database_path
+
+
 events = [
     event("user", 1000, "user", "user", {"kind": "text", "text": "Solve the task"}),
     event("call", 1100, "model", "agent", {"kind": "function_call", "id": "tool-1", "name": "Bash", "args": {"command": "echo ok", "password": "private-password"}}, {"stepId": "step-1"}),
@@ -3252,8 +3312,7 @@ with tempfile.TemporaryDirectory() as tmp:
     image_path = artifact_root / "session-1" / "artifact-image-shot.png"
     image_path.parent.mkdir(parents=True)
     image_path.write_bytes(b"\x89PNG\r\n\x1a\nfixture")
-    metadata_path = artifact_root / "metadata.jsonl"
-    metadata_path.write_text(json.dumps({
+    image_record = {
         "id": "artifact-image",
         "sessionId": "session-1",
         "turnId": "turn-1",
@@ -3265,7 +3324,8 @@ with tempfile.TemporaryDirectory() as tmp:
         "mimeType": "image/png",
         "source": "tool_result",
         "status": "live",
-    }) + "\n", encoding="utf-8")
+    }
+    database_path = write_artifact_database(artifact_root.parent, [image_record])
     agent._apply_cell_output(context, {
         "status": "completed",
         "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
@@ -3281,6 +3341,30 @@ with tempfile.TemporaryDirectory() as tmp:
     assert image_content[0].source.path.endswith(".png"), image_content
     assert (logs_dir / image_content[0].source.path).is_file(), image_content
 
+    database_path.unlink()
+    metadata_path = artifact_root / "metadata.jsonl"
+    metadata_path.write_text(json.dumps(image_record) + "\n", encoding="utf-8")
+    agent._apply_cell_output(context, {
+        "status": "completed",
+        "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
+    })
+    legacy_payload = json.loads((logs_dir / "trajectory.json").read_text(encoding="utf-8"))
+    assert legacy_payload["extra"]["maka_artifact_kind"] == "summary", legacy_payload
+    assert legacy_payload["extra"]["maka_summary_reason"] == "image_artifact_metadata_missing", legacy_payload
+    metadata_path.unlink()
+
+    write_artifact_database(artifact_root.parent, [image_record], artifact_schema_version=2)
+    agent._apply_cell_output(context, {
+        "status": "completed",
+        "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
+    })
+    newer_schema_payload = json.loads((logs_dir / "trajectory.json").read_text(encoding="utf-8"))
+    assert newer_schema_payload["extra"]["maka_artifact_kind"] == "summary", newer_schema_payload
+    assert newer_schema_payload["extra"]["maka_summary_reason"] == "image_artifact_metadata_invalid", newer_schema_payload
+    database_path = write_artifact_database(artifact_root.parent, [image_record])
+
     materialized_path = logs_dir / image_content[0].source.path
     protected_path = logs_dir / "protected-image-target"
     materialized_path.unlink()
@@ -3294,6 +3378,16 @@ with tempfile.TemporaryDirectory() as tmp:
     assert not materialized_path.is_symlink(), materialized_path
     assert protected_path.read_bytes() == b"protected", protected_path
 
+    image_path.write_bytes(b"\x89PNG\r\n\x1a\nfixture-tampered")
+    agent._apply_cell_output(context, {
+        "status": "completed",
+        "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
+        "runtimeRefs": {"invocationId": "inv-1", "runId": "run-1", "sessionId": "session-1", "turnId": "turn-1"},
+    })
+    mismatched_image_payload = json.loads((logs_dir / "trajectory.json").read_text(encoding="utf-8"))
+    assert mismatched_image_payload["extra"]["maka_artifact_kind"] == "summary", mismatched_image_payload
+    assert mismatched_image_payload["extra"]["maka_summary_reason"] == "image_artifact_content_mismatch", mismatched_image_payload
+
     image_path.unlink()
     agent._apply_cell_output(context, {
         "status": "completed",
@@ -3304,9 +3398,15 @@ with tempfile.TemporaryDirectory() as tmp:
     assert missing_image_payload["extra"]["maka_artifact_kind"] == "summary", missing_image_payload
     assert missing_image_payload["extra"]["maka_summary_reason"] == "image_artifact_unavailable", missing_image_payload
 
-    escaping_metadata = json.loads(metadata_path.read_text(encoding="utf-8"))
+    escaping_metadata = dict(image_record)
     escaping_metadata["relativePath"] = "../outside.png"
-    metadata_path.write_text(json.dumps(escaping_metadata) + "\n", encoding="utf-8")
+    connection = sqlite3.connect(database_path)
+    connection.execute(
+        "UPDATE artifact_records SET relative_path = ?, record_json = ? WHERE artifact_id = ?",
+        (escaping_metadata["relativePath"], json.dumps(escaping_metadata), escaping_metadata["id"]),
+    )
+    connection.commit()
+    connection.close()
     agent._apply_cell_output(context, {
         "status": "completed",
         "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",
@@ -3367,7 +3467,7 @@ with tempfile.TemporaryDirectory() as tmp:
         encoding="utf-8",
     )
     downloaded_relative_path = "session-1/downloaded-image-shot.png"
-    downloaded_metadata = json.dumps({
+    downloaded_record = {
         "id": "downloaded-image",
         "sessionId": "session-1",
         "turnId": "turn-1",
@@ -3379,29 +3479,14 @@ with tempfile.TemporaryDirectory() as tmp:
         "mimeType": "image/png",
         "source": "tool_result",
         "status": "live",
-    }) + "\n"
+    }
 
     class ArtifactDownloadEnvironment:
         async def download_file(self, remote, local):
-            if remote == "/logs/agent/maka-storage/runtime.sqlite":
-                database = sqlite3.connect(local)
-                database.execute("""
-                    CREATE TABLE artifact_records (
-                        storage_key TEXT PRIMARY KEY,
-                        created_at INTEGER NOT NULL,
-                        record_json TEXT NOT NULL
-                    )
-                """)
-                database.execute(
-                    "INSERT INTO artifact_records(storage_key, created_at, record_json) VALUES (?, ?, ?)",
-                    ("downloaded-image", 1200, downloaded_metadata.strip()),
-                )
-                database.commit()
-                database.close()
+            if remote == "/logs/agent/trajectory-state/runtime.sqlite":
+                write_artifact_database(Path(local).parent, [downloaded_record])
                 return
-            if remote == "/logs/agent/maka-storage/runtime.sqlite-wal":
-                raise FileNotFoundError(remote)
-            assert remote == f"/logs/agent/maka-storage/artifacts/{downloaded_relative_path}", remote
+            assert remote == f"/logs/agent/trajectory-state/artifacts/{downloaded_relative_path}", remote
             Path(local).write_bytes(b"\x89PNG\r\n\x1a\nfixture")
 
     asyncio.run(download_agent._download_runtime_artifacts(ArtifactDownloadEnvironment()))
@@ -3414,12 +3499,12 @@ with tempfile.TemporaryDirectory() as tmp:
     task_run_runtime_path.write_text(
         "\n".join(json.dumps(event) for event in image_events) + "\n", encoding="utf-8"
     )
-    task_run_artifact_root = task_run_logs / "maka-task-run" / "runs" / "artifacts"
+    task_run_store_root = task_run_logs / "maka-task-run" / "trajectory-state"
+    task_run_artifact_root = task_run_store_root / "artifacts"
     task_run_image_path = task_run_artifact_root / "session-1" / "task-run-shot.png"
     task_run_image_path.parent.mkdir(parents=True)
     task_run_image_path.write_bytes(b"\x89PNG\r\n\x1a\nfixture")
-    (task_run_artifact_root / "metadata.jsonl").parent.mkdir(parents=True, exist_ok=True)
-    (task_run_artifact_root / "metadata.jsonl").write_text(json.dumps({
+    task_run_record = {
         "id": "artifact-image",
         "sessionId": "session-1",
         "turnId": "turn-1",
@@ -3431,7 +3516,8 @@ with tempfile.TemporaryDirectory() as tmp:
         "mimeType": "image/png",
         "source": "tool_result",
         "status": "live",
-    }) + "\n", encoding="utf-8")
+    }
+    write_artifact_database(task_run_store_root, [task_run_record])
     task_run_agent._apply_cell_output(AgentContext(), {
         "status": "completed",
         "runtimeEventsPath": "/logs/agent/runtime-events.jsonl",

--- a/packages/headless/src/__tests__/harbor-cell.test.ts
+++ b/packages/headless/src/__tests__/harbor-cell.test.ts
@@ -1,9 +1,10 @@
 import assert from 'node:assert/strict';
 import { createHash } from 'node:crypto';
-import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { chmod, lstat, mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import { DatabaseSync } from 'node:sqlite';
 import { describe, test } from 'node:test';
 import type {
   BackendKind,
@@ -51,6 +52,7 @@ import {
   HARBOR_CELL_CONTEXT_ENV_KEYS,
   HARBOR_CELL_OUTPUT_FILENAME,
   HARBOR_CELL_RUNTIME_EVENTS_FILENAME,
+  HARBOR_CELL_TRAJECTORY_STATE_DIRECTORY,
   HARBOR_CELL_USAGE_CHECKPOINT_FILENAME,
   resolveHarborCellAiSdkEnv,
   runHarborCellFromEnv,
@@ -937,6 +939,96 @@ describe('runHarborCell', () => {
         JSON.parse(await readFile(result.outputPath, 'utf8')).tokenSummary,
         result.output.tokenSummary,
       );
+    });
+  });
+
+  test('publishes image trajectory evidence from a frozen SQLite session export', async () => {
+    await withDirs(async ({ outputDir, storageRoot, workspaceDir, artifactStore }) => {
+      const sessions = createSessionStore(storageRoot);
+      const session = await sessions.create({
+        cwd: workspaceDir,
+        backend: config.backend,
+        llmConnectionSlug: config.llmConnectionSlug,
+        model: config.model,
+        permissionMode: 'execute',
+        name: 'trajectory-session',
+      });
+      await sessions.close?.();
+      await mkdir(join(storageRoot, 'task-runs'));
+      await writeFile(join(storageRoot, 'task-runs', 'headless-ledger.jsonl'), 'excluded\n');
+      const image = await artifactStore.create({
+        id: 'trajectory-image',
+        sessionId: session.id,
+        turnId: 'turn-1',
+        name: 'screen.png',
+        kind: 'image',
+        content: Buffer.from('\x89PNG\r\n\x1a\nfixture'),
+        mimeType: 'image/png',
+        source: 'tool_result',
+        now: 100,
+      });
+      const imageEvent: RuntimeEvent = {
+        id: 'image-result',
+        invocationId: 'invocation-1',
+        runId: 'run-1',
+        sessionId: session.id,
+        turnId: 'turn-1',
+        ts: 100,
+        partial: false,
+        role: 'tool',
+        author: 'tool',
+        content: {
+          kind: 'function_response',
+          id: 'read-image',
+          name: 'Read',
+          result: {
+            kind: 'image',
+            mimeType: 'image/png',
+            ref: { kind: 'session_file', sessionId: session.id, relativePath: image.id },
+          },
+        },
+      };
+      const invocation: InvocationResult = {
+        invocationId: 'invocation-1',
+        sessionId: session.id,
+        runId: 'run-1',
+        turnId: 'turn-1',
+        status: 'completed',
+        events: [imageEvent],
+        startedAt: 100,
+        finishedAt: 200,
+      };
+
+      await writeHarborCellArtifacts({ invocation, outputDir, storageRoot });
+
+      const trajectoryRoot = join(outputDir, HARBOR_CELL_TRAJECTORY_STATE_DIRECTORY);
+      await assert.rejects(lstat(join(trajectoryRoot, 'artifacts', 'metadata.jsonl')), {
+        code: 'ENOENT',
+      });
+      await assert.rejects(lstat(join(trajectoryRoot, 'runtime.sqlite-wal')), { code: 'ENOENT' });
+      await assert.rejects(lstat(join(trajectoryRoot, 'task-runs')), { code: 'ENOENT' });
+      const database = new DatabaseSync(join(trajectoryRoot, 'runtime.sqlite'), {
+        readOnly: true,
+      });
+      try {
+        const row = database
+          .prepare('SELECT record_json FROM artifact_records WHERE artifact_id = ?')
+          .get(image.id) as { record_json?: unknown } | undefined;
+        assert.equal(row?.record_json, JSON.stringify(image));
+      } finally {
+        database.close();
+      }
+      assert.deepEqual(
+        await readFile(join(trajectoryRoot, 'artifacts', image.relativePath)),
+        Buffer.from('\x89PNG\r\n\x1a\nfixture'),
+      );
+
+      await writeHarborCellArtifacts({
+        invocation: { ...invocation, events: [] },
+        outputDir,
+        storageRoot,
+      });
+      await assert.rejects(lstat(trajectoryRoot), { code: 'ENOENT' });
     });
   });
 

--- a/packages/headless/src/harbor-cell.ts
+++ b/packages/headless/src/harbor-cell.ts
@@ -35,6 +35,7 @@ import {
 import {
   createAttachmentByteReader,
   createReadImageSnapshotter,
+  exportSessionBundleState,
   persistProviderRequestCaptureArtifact,
 } from '@maka/storage';
 import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
@@ -127,6 +128,7 @@ export const HARBOR_CELL_RUNTIME_EVENTS_FILENAME = 'runtime-events.jsonl';
 export const HARBOR_CELL_TRACE_EVENTS_FILENAME = 'trace-events.jsonl';
 export const HARBOR_CELL_EXECUTION_IDENTITY_FILENAME = 'maka-cell-execution-identity.json';
 export const HARBOR_CELL_USAGE_CHECKPOINT_FILENAME = 'maka-cell-usage-checkpoint.json';
+export const HARBOR_CELL_TRAJECTORY_STATE_DIRECTORY = 'trajectory-state';
 
 export interface RunHarborCellInput {
   config: Config;
@@ -189,6 +191,7 @@ export interface RunHarborCellResult {
 export interface WriteHarborCellArtifactsInput {
   invocation: InvocationResult;
   outputDir: string;
+  storageRoot?: string;
   promptHash?: string;
   executionIdentity?: HarborCellExecutionIdentity;
   deadlineSettlement?: HarborCellDeadlineSettlement;
@@ -537,6 +540,7 @@ export async function runHarborCellWithStorage(
   const artifacts = await writeHarborCellArtifacts({
     invocation: combinedInvocation,
     outputDir: input.outputDir,
+    storageRoot: input.storageRoot,
     executionIdentity,
     ...(settledByDeadline
       ? {
@@ -576,6 +580,18 @@ export async function writeHarborCellArtifacts(
   input: WriteHarborCellArtifactsInput,
 ): Promise<WriteHarborCellArtifactsResult> {
   await mkdir(input.outputDir, { recursive: true });
+  if (input.storageRoot) {
+    await exportHarborCellTrajectoryState({
+      invocation: input.invocation,
+      outputDir: input.outputDir,
+      storageRoot: input.storageRoot,
+    }).catch(async () => {
+      await rm(join(input.outputDir, HARBOR_CELL_TRAJECTORY_STATE_DIRECTORY), {
+        recursive: true,
+        force: true,
+      });
+    });
+  }
   const runtimeEventsPath = join(input.outputDir, HARBOR_CELL_RUNTIME_EVENTS_FILENAME);
   const outputPath = join(input.outputDir, HARBOR_CELL_OUTPUT_FILENAME);
   await writeHarborCellArtifact(runtimeEventsPath, runtimeEventsJsonl(input.invocation));
@@ -601,6 +617,41 @@ export async function writeHarborCellArtifacts(
       : rawOutput;
   await writeHarborCellArtifact(outputPath, `${JSON.stringify(output, null, 2)}\n`);
   return { output, outputPath, runtimeEventsPath };
+}
+
+export async function exportHarborCellTrajectoryState(input: {
+  invocation: InvocationResult;
+  outputDir: string;
+  storageRoot: string;
+}): Promise<string | undefined> {
+  const destinationRoot = join(input.outputDir, HARBOR_CELL_TRAJECTORY_STATE_DIRECTORY);
+  await rm(destinationRoot, { recursive: true, force: true });
+  if (!hasSessionImageArtifactReference(input.invocation.events)) return undefined;
+  await exportSessionBundleState({
+    stateRoot: input.storageRoot,
+    configRoot: input.storageRoot,
+    destinationRoot,
+    sessionId: input.invocation.sessionId,
+    allowShared: true,
+  });
+  return destinationRoot;
+}
+
+function hasSessionImageArtifactReference(events: readonly RuntimeEvent[]): boolean {
+  return events.some((event) => {
+    if (event.content?.kind !== 'function_response') return false;
+    const result = event.content.result;
+    if (typeof result !== 'object' || result === null || Array.isArray(result)) return false;
+    const record = result as Record<string, unknown>;
+    const ref = record.ref;
+    return (
+      record.kind === 'image' &&
+      typeof ref === 'object' &&
+      ref !== null &&
+      !Array.isArray(ref) &&
+      (ref as Record<string, unknown>).kind === 'session_file'
+    );
+  });
 }
 
 async function readHarborCellUsageCheckpoint(

--- a/packages/storage/src/__tests__/session-bundle-policy.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-policy.test.ts
@@ -102,6 +102,8 @@ test('exports one session only and excludes credential/config canaries', async (
     await writeFile(join(stateRoot, 'credentials.json'), 'super-secret-api-key');
     await writeFile(join(stateRoot, 'llm-connections.json'), 'host-provider-config');
     await writeFile(join(stateRoot, '.maka_cli_claude_device_id'), 'device-identity');
+    await mkdir(join(stateRoot, 'task-runs'));
+    await writeFile(join(stateRoot, 'task-runs', 'headless-ledger.jsonl'), 'headless-only\n');
     await writeFile(join(configRoot, 'credentials.json'), 'config-secret-canary');
 
     const plan = await exportSessionBundleState({
@@ -122,6 +124,7 @@ test('exports one session only and excludes credential/config canaries', async (
         'runtime.sqlite-shm',
         'runtime.sqlite-wal',
         `sessions/${other.id}`,
+        'task-runs',
       ].sort(),
     );
     const exportedTranscript = await readFile(
@@ -148,6 +151,7 @@ test('exports one session only and excludes credential/config canaries', async (
     await assert.rejects(lstat(join(destinationRoot, 'artifacts', 'metadata.jsonl')), {
       code: 'ENOENT',
     });
+    await assert.rejects(lstat(join(destinationRoot, 'task-runs')), { code: 'ENOENT' });
     const reopenedArtifacts = createSqliteArtifactStore(destinationRoot);
     try {
       assert.deepEqual(await reopenedArtifacts.list(selected.id), [selectedArtifact]);

--- a/packages/storage/src/session-bundle-policy.ts
+++ b/packages/storage/src/session-bundle-policy.ts
@@ -79,6 +79,7 @@ export const SESSION_BUNDLE_PROTECTED_ENTRIES = [
   'log',
   'activation.json',
   'activation-input.json',
+  'task-runs',
   '.maka',
   ARTIFACT_WRITER_LOCK_FILE,
   LEGACY_SESSION_METADATA_DATABASE_NAME,


### PR DESCRIPTION
## Summary

- publish a frozen selected-session `trajectory-state` snapshot after Harbor cell runs that reference image Artifacts
- hydrate trajectories from the standalone SQLite snapshot and only its referenced payloads
- remove trajectory fallback to `artifacts/metadata.jsonl` and live `runtime.sqlite-wal` copying
- fail closed on invalid SQLite integrity/schema/cutover state, index/JSON mismatches, and payload size/MIME mismatches

This completes the trajectory/export slice of the SQLite operational-state migration. After this PR, issue #1649 can move to the compatibility-writer removal stage.

## Verification

- `npm --workspace @maka/storage run build`
- full Storage test suite: pass
- `npm --workspace @maka/headless run build`
- full `harbor-cell.test.js`: pass
- trajectory builder + Maka adapter hydration contracts: pass
- `python3 -m py_compile packages/headless/harbor/maka_agent.py packages/headless/harbor/maka_trajectory.py`
- `npx biome check` on changed TypeScript files
- `git diff --check`

Local full Headless run: 1427 passed, 5 skipped, and 2 unchanged Python 3.9 CLI smoke failures (`kimi_code_agent.py` timeout and `codex_agent.py` event-loop initialization). Neither failing test or implementation is touched by this patch.

Part of #1649