### PR TITLE
storage: remove legacy artifact metadata writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,8 +257,10 @@ evidence fails closed to a summary trajectory instead of mixing authorities.
 The remaining storage work is deliberately classified rather than implied
 complete:
 
-- legacy operational writers and compatibility-only JSONL code can be removed
-  only after the migration/cutover matrix is complete;
+- Artifact metadata no longer exposes a production JSONL writer;
+  `artifacts/metadata.jsonl` is accepted only as fingerprinted, read-only
+  cutover evidence, and can be removed after the migration/cutover matrix is
+  complete;
 - StoredMessage transcript bodies remain append-only JSONL;
 - automation, connections, credentials, settings, MCP configuration, skills,
   and device identity are configuration state and stay outside this operational

--- a/apps/desktop/src/main/__tests__/attachment-ingest.test.ts
+++ b/apps/desktop/src/main/__tests__/attachment-ingest.test.ts
@@ -3,14 +3,14 @@ import { mkdtemp, rm, symlink, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { createArtifactStore } from '@maka/storage';
+import { createSqliteArtifactStore } from '@maka/storage';
 import { ingestAttachments } from '../attachment-ingest.js';
 
 describe('ingestAttachments', () => {
   test('image: resizes, snapshots to ArtifactStore, returns session_file ref', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'att-img-'));
     try {
-      const store = createArtifactStore(dir);
+      const store = createSqliteArtifactStore(dir);
       const imagePath = join(dir, 'screen.png');
       const imageBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
       await writeFile(imagePath, imageBytes);
@@ -38,7 +38,7 @@ describe('ingestAttachments', () => {
   test('pasted image blob without a file path snapshots from provided bytes', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'att-clip-'));
     try {
-      const store = createArtifactStore(dir);
+      const store = createSqliteArtifactStore(dir);
       const imageBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
       let resizeCalls = 0;
       const refs = await ingestAttachments({
@@ -71,7 +71,7 @@ describe('ingestAttachments', () => {
   test('workspace non-image: returns workspace_file ref without copying or resizing', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'att-ws-'));
     try {
-      const store = createArtifactStore(dir);
+      const store = createSqliteArtifactStore(dir);
       const codePath = join(dir, 'main.ts');
       const codeBytes = Buffer.from('const x = 1;');
       await writeFile(codePath, codeBytes);
@@ -106,7 +106,7 @@ describe('ingestAttachments', () => {
   test('external non-image: snapshots to ArtifactStore without resizing', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'att-ext-'));
     try {
-      const store = createArtifactStore(dir);
+      const store = createSqliteArtifactStore(dir);
       const externalPath = join(tmpdir(), `external-${Date.now()}.pdf`);
       const pdfBytes = Buffer.from('%PDF-1.4 fake');
       await writeFile(externalPath, pdfBytes);
@@ -134,7 +134,7 @@ describe('ingestAttachments', () => {
     const dir = await mkdtemp(join(tmpdir(), 'att-sym-'));
     const outsideDir = await mkdtemp(join(tmpdir(), 'att-sym-out-'));
     try {
-      const store = createArtifactStore(dir);
+      const store = createSqliteArtifactStore(dir);
       const outsideFile = join(outsideDir, 'secret.md');
       await writeFile(outsideFile, 'secret');
       // symlink inside the workspace that resolves to a file outside it
@@ -162,7 +162,7 @@ describe('ingestAttachments', () => {
     const dir = await mkdtemp(join(tmpdir(), 'att-cap-'));
     const externalPath = join(tmpdir(), `grew-${Date.now()}.bin`);
     try {
-      const store = createArtifactStore(dir);
+      const store = createSqliteArtifactStore(dir);
       // real file is 11 bytes; files[].size lies small (TOCTOU: stat said 5)
       await writeFile(externalPath, Buffer.alloc(11));
       let storeCreates = 0;

--- a/apps/desktop/src/main/__tests__/history-compact-artifacts.test.ts
+++ b/apps/desktop/src/main/__tests__/history-compact-artifacts.test.ts
@@ -14,7 +14,7 @@ import {
   type HistoryCompactWriteInput,
 } from '@maka/runtime';
 import {
-  createArtifactStore,
+  createSqliteArtifactStore,
   type ArtifactStore,
 } from '@maka/storage';
 import {
@@ -113,8 +113,9 @@ describe('desktop history compact artifact lifecycle', () => {
           { code: 'ENOENT' },
         );
       }
-      const metadata = await readFile(join(workspaceRoot, 'artifacts', 'metadata.jsonl'), 'utf8');
-      assert.equal(metadata, '');
+      await assert.rejects(() => readFile(join(workspaceRoot, 'artifacts', 'metadata.jsonl')), {
+        code: 'ENOENT',
+      });
     });
   });
 
@@ -474,7 +475,7 @@ async function withStore(
 ): Promise<void> {
   const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-history-compact-artifacts-'));
   try {
-    await fn(createArtifactStore(workspaceRoot), workspaceRoot);
+    await fn(createSqliteArtifactStore(workspaceRoot), workspaceRoot);
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
   }

--- a/apps/desktop/src/main/__tests__/session-send-resolve.test.ts
+++ b/apps/desktop/src/main/__tests__/session-send-resolve.test.ts
@@ -3,7 +3,7 @@ import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { createArtifactStore } from '@maka/storage';
+import { createSqliteArtifactStore } from '@maka/storage';
 import { createAttachmentApprovalRegistry } from '../attachment-approval.js';
 import { resolveSessionSend } from '../session-send-resolve.js';
 import type { SessionHeader } from '@maka/core';
@@ -69,7 +69,7 @@ describe('resolveSessionSend', () => {
   test('readiness ok with items resolves and ingests attachments, consuming the token', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'send-ok-'));
     try {
-      const store = createArtifactStore(dir);
+      const store = createSqliteArtifactStore(dir);
       const approvals = createAttachmentApprovalRegistry();
       const file = join(dir, 'note.txt');
       await writeFile(file, 'hello');

--- a/apps/desktop/src/main/__tests__/tool-result-archive-artifacts.test.ts
+++ b/apps/desktop/src/main/__tests__/tool-result-archive-artifacts.test.ts
@@ -4,7 +4,7 @@ import { mkdtemp, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
-import { createArtifactStore, type ArtifactStore } from '@maka/storage';
+import { createSqliteArtifactStore, type ArtifactStore } from '@maka/storage';
 import type { ToolResultArchiveRecorderInput } from '@maka/runtime';
 import {
   persistArchivedToolResultToArtifacts,
@@ -84,7 +84,7 @@ function archiveEvent(): ToolResultArchiveRecorderInput {
 async function withStore(fn: (store: ArtifactStore) => Promise<void>): Promise<void> {
   const workspaceRoot = await mkdtemp(join(tmpdir(), 'maka-tool-result-archive-'));
   try {
-    await fn(createArtifactStore(workspaceRoot));
+    await fn(createSqliteArtifactStore(workspaceRoot));
   } finally {
     await rm(workspaceRoot, { recursive: true, force: true });
   }

--- a/apps/desktop/src/main/session-stream.ts
+++ b/apps/desktop/src/main/session-stream.ts
@@ -31,7 +31,7 @@ import type {
   buildPricingLookup,
 } from '@maka/runtime';
 import {
-  createArtifactStore,
+  type ArtifactStore,
   createAttachmentByteReader,
   createTelemetryRepo,
   openRuntimeEventPersistence,
@@ -54,7 +54,6 @@ type AssembledTools = ReturnType<typeof assembleDesktopTools>;
 type SystemPromptMainService = ReturnType<typeof createSystemPromptMainService>;
 type SubscriptionModelFetchBuilder = ReturnType<typeof createSubscriptionModelFetch>;
 type GoalWiring = ReturnType<typeof createMainGoalWiring>;
-type ArtifactStore = ReturnType<typeof createArtifactStore>;
 type TelemetryRepo = ReturnType<typeof createTelemetryRepo>;
 type PricingLookup = ReturnType<typeof buildPricingLookup>;
 type RuntimeCommitStore = Awaited<ReturnType<typeof openRuntimeEventPersistence>>['runtimeCommitStore'];

--- a/apps/desktop/src/main/sessions-ipc-main.ts
+++ b/apps/desktop/src/main/sessions-ipc-main.ts
@@ -25,7 +25,7 @@ import type {
 import type { ProviderType } from '@maka/core/llm-connections';
 import type { WorkspacePrivacyContext } from '@maka/core/incognito';
 import type { PreparedSkillInvocationMessage, SessionManager } from '@maka/runtime';
-import type { createArtifactStore, createSessionStore } from '@maka/storage';
+import type { ArtifactStore, createSessionStore } from '@maka/storage';
 import type { ConnectionStore, SettingsStore } from '@maka/storage';
 import { runThreadSearch } from './search/thread-search.js';
 import { resolveSessionSend } from './session-send-resolve.js';
@@ -58,7 +58,6 @@ import { registerSessionExecutionIpc } from './session-execution-ipc-main.js';
 import { createQuoteCompanionCleanupAuthority } from './quote-companion-cleanup.js';
 
 type SessionStore = ReturnType<typeof createSessionStore>;
-type ArtifactStore = ReturnType<typeof createArtifactStore>;
 type MainWindowController = ReturnType<typeof createMainWindowController>;
 type E2eFixture = ReturnType<typeof resolveE2eFixture>;
 

--- a/apps/desktop/src/main/tool-artifact-persistence.ts
+++ b/apps/desktop/src/main/tool-artifact-persistence.ts
@@ -7,14 +7,13 @@ import type {
   ToolResultArchiveRecorderInput,
   ToolResultArchiveResourceReadInput,
 } from '@maka/runtime';
-import type { createArtifactStore, createReadImageSnapshotter } from '@maka/storage';
+import type { ArtifactStore, createReadImageSnapshotter } from '@maka/storage';
 import {
   persistArchivedToolResultToArtifacts,
   readArchivedToolResultFromArtifacts,
   readArchivedToolResultResourceFromArtifacts,
 } from './tool-result-archive-artifacts.js';
 
-type ArtifactStore = ReturnType<typeof createArtifactStore>;
 type ReadImageSnapshotter = ReturnType<typeof createReadImageSnapshotter>;
 
 export interface ToolArtifactPersistenceDeps {

--- a/apps/desktop/src/main/workspace-resources-ipc-main.ts
+++ b/apps/desktop/src/main/workspace-resources-ipc-main.ts
@@ -11,7 +11,7 @@ import type {
   InvocableSkillEntry,
   SkillSelectionReport,
 } from '@maka/runtime';
-import { createArtifactStore, resolveArtifactPath } from '@maka/storage';
+import { type ArtifactStore, resolveArtifactPath } from '@maka/storage';
 import type { createMainWindowController } from './main-window.js';
 import {
   createStarterSkill,
@@ -34,7 +34,6 @@ import {
   toManagedSkillSourceEntry,
 } from './managed-skill-sources.js';
 
-type ArtifactStore = ReturnType<typeof createArtifactStore>;
 type MainWindowController = ReturnType<typeof createMainWindowController>;
 
 export interface NewSessionSkillContext {

--- a/packages/storage/src/__tests__/artifact-attachments.test.ts
+++ b/packages/storage/src/__tests__/artifact-attachments.test.ts
@@ -5,7 +5,7 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import { MAX_ATTACHMENT_BYTES, type StorageRef } from '@maka/core';
 import { createAttachmentByteReader, createReadImageSnapshotter } from '../artifact-attachments.js';
-import { createArtifactStore } from '../artifact-store.js';
+import { createSqliteArtifactStore as createArtifactStore } from '../artifact-store.js';
 
 const png = Uint8Array.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a]);
 

--- a/packages/storage/src/__tests__/artifact-store.test.ts
+++ b/packages/storage/src/__tests__/artifact-store.test.ts
@@ -23,15 +23,15 @@ import {
 import {
   ARTIFACT_TEXT_PREVIEW_LIMIT_BYTES,
   type CreateArtifactInput,
-  createArtifactStore,
-  createArtifactStoreWriteAuthority,
+  createSqliteArtifactStore as createArtifactStore,
+  createSqliteArtifactStoreWriteAuthority as createArtifactStoreWriteAuthority,
   isSafeRelativeArtifactPath,
   resolveArtifactPath,
   sanitizeArtifactName,
 } from '../artifact-store.js';
 import { withArtifactWriterLock } from '../artifact-writer-lock.js';
 
-describe('FileArtifactStore', () => {
+describe('SQLite Artifact store', () => {
   test('creates a missing workspace root before acquiring the writer lock', async () => {
     const parent = await mkdtemp(join(tmpdir(), 'maka-artifact-missing-root-'));
     const root = join(parent, 'nested', 'workspace');
@@ -452,11 +452,11 @@ describe('FileArtifactStore', () => {
       const input = deepResearchArtifactInput('stable-replay', '# Durable result');
       const first = await createArtifactStore(root).create(input);
       const metadataPath = join(root, 'artifacts', 'metadata.jsonl');
-      const metadataBefore = await readFile(metadataPath, 'utf8');
+      await assert.rejects(() => stat(metadataPath), { code: 'ENOENT' });
 
       const replayed = await createArtifactStore(root).create(input);
       assert.deepEqual(replayed, first);
-      assert.equal(await readFile(metadataPath, 'utf8'), metadataBefore);
+      await assert.rejects(() => stat(metadataPath), { code: 'ENOENT' });
       assert.deepEqual(await createArtifactStore(root).readText(first.id), {
         ok: true,
         text: '# Durable result',
@@ -479,7 +479,7 @@ describe('FileArtifactStore', () => {
           }),
         /already exists with different metadata or content/,
       );
-      assert.equal(await readFile(metadataPath, 'utf8'), metadataBefore);
+      await assert.rejects(() => stat(metadataPath), { code: 'ENOENT' });
     });
   });
 
@@ -511,30 +511,6 @@ describe('FileArtifactStore', () => {
     });
   });
 
-  test('failed tombstone revival leaves the durable tombstone recoverable', async () => {
-    await withWorkspace(async (root) => {
-      const input = deepResearchArtifactInput('stable-revive-retry', '# Revivable');
-      const store = createArtifactStore(root);
-      const first = await store.create(input);
-      await store.delete(first.id);
-      const metadataPath = join(root, 'artifacts', 'metadata.jsonl');
-      const deletedMetadata = await readFile(metadataPath, 'utf8');
-      await rm(metadataPath);
-      await mkdir(metadataPath);
-
-      await assert.rejects(() => store.create(input));
-      await assert.rejects(() => store.get(first.id), { code: 'EISDIR' });
-
-      await rm(metadataPath, { recursive: true });
-      await writeFile(metadataPath, deletedMetadata, 'utf8');
-      const reopened = createArtifactStore(root);
-      assert.equal((await reopened.get(first.id))?.status, 'deleted');
-      const revived = await reopened.create(input);
-      assert.equal(revived.status, 'live');
-      assert.equal(revived.createdAt, first.createdAt);
-    });
-  });
-
   test('serializes concurrent creates without dropping metadata', async () => {
     await withWorkspace(async (root) => {
       const store = createArtifactStore(root);
@@ -544,12 +520,13 @@ describe('FileArtifactStore', () => {
       const reopened = createArtifactStore(root);
       const rows = await reopened.list('session-1', { includeDeleted: true });
       assert.deepEqual(rows.map((record) => record.id).sort(), ids.sort());
-      const metadata = await readFile(join(root, 'artifacts', 'metadata.jsonl'), 'utf8');
-      assert.equal(metadata.trim().split('\n').length, ids.length);
+      await assert.rejects(() => stat(join(root, 'artifacts', 'metadata.jsonl')), {
+        code: 'ENOENT',
+      });
     });
   });
 
-  test('serializes independent legacy stores without dropping metadata', async () => {
+  test('serializes independent SQLite stores without dropping metadata', async () => {
     await withWorkspace(async (root) => {
       const first = createArtifactStore(root);
       const second = createArtifactStore(root);
@@ -637,7 +614,7 @@ describe('FileArtifactStore', () => {
     });
   });
 
-  test('refreshes a loaded legacy store after another instance commits metadata', async () => {
+  test('refreshes a loaded SQLite store after another instance commits metadata', async () => {
     await withWorkspace(async (root) => {
       const stale = createArtifactStore(root);
       const writer = createArtifactStore(root);
@@ -655,26 +632,6 @@ describe('FileArtifactStore', () => {
       );
       assert.equal((await stale.get('second'))?.id, 'second');
       assert.deepEqual(await stale.readText('second'), { ok: true, text: 'second' });
-    });
-  });
-
-  test('refreshes metadata changed in place without an inode or size change', async () => {
-    await withWorkspace(async (root) => {
-      const store = createArtifactStore(root);
-      await store.create(artifactInput('stable-inode', 'payload', 1));
-      assert.equal((await store.get('stable-inode'))?.turnId, 'turn-1');
-
-      const metadataPath = join(root, 'artifacts', 'metadata.jsonl');
-      const before = await stat(metadataPath);
-      const original = await readFile(metadataPath, 'utf8');
-      const changed = original.replace('"turnId":"turn-1"', '"turnId":"turn-2"');
-      assert.equal(Buffer.byteLength(changed), Buffer.byteLength(original));
-      await writeFile(metadataPath, changed, { flag: 'r+' });
-      const after = await stat(metadataPath);
-      assert.equal(after.ino, before.ino);
-      assert.equal(after.size, before.size);
-
-      assert.equal((await store.get('stable-inode'))?.turnId, 'turn-2');
     });
   });
 
@@ -698,24 +655,22 @@ describe('FileArtifactStore', () => {
     });
   });
 
-  test('does not publish a payload when metadata publication fails', async () => {
+  test('does not publish a payload after the SQLite metadata repository closes', async () => {
     await withWorkspace(async (root) => {
       const store = createArtifactStore(root);
       await store.create(artifactInput('published', 'kept', 1));
-      const metadataPath = join(root, 'artifacts', 'metadata.jsonl');
-      const metadata = await readFile(metadataPath, 'utf8');
-      await rm(metadataPath);
-      await mkdir(metadataPath);
+      store.close?.();
 
-      await assert.rejects(() => store.create(artifactInput('rejected', 'not durable', 2)));
+      await assert.rejects(
+        () => store.create(artifactInput('rejected', 'not durable', 2)),
+        /Artifact metadata repository is closed/,
+      );
       await assert.rejects(
         () => readFile(join(root, 'artifacts', 'session-1', 'rejected-rejected.txt')),
         { code: 'ENOENT' },
       );
-      await assert.rejects(() => store.get('rejected'), { code: 'EISDIR' });
-
-      await rm(metadataPath, { recursive: true });
-      await writeFile(metadataPath, metadata, 'utf8');
+      const reopened = createArtifactStore(root);
+      assert.equal(await reopened.get('rejected'), null);
     });
   });
 
@@ -770,7 +725,7 @@ describe('FileArtifactStore', () => {
     });
   });
 
-  test('legacy mutation adopts an exact stable-id target-only orphan', async () => {
+  test('self-managed SQLite mutation adopts an exact stable-id target-only orphan', async () => {
     await withWorkspace(async (root) => {
       const input = {
         ...artifactInput('legacy-orphan', 'orphan bytes', 1),
@@ -791,7 +746,7 @@ describe('FileArtifactStore', () => {
     });
   });
 
-  test('legacy mutations recover target-local publications without rescanning unrelated sessions', async () => {
+  test('self-managed SQLite mutations recover target-local publications without rescanning unrelated sessions', async () => {
     await withWorkspace(async (root) => {
       const store = createArtifactStore(root);
       await store.create(artifactInput('delete-me', 'delete', 1));
@@ -1246,7 +1201,7 @@ describe('FileArtifactStore', () => {
       await authority.recover();
 
       assert.equal(await store.get(record.id), null);
-      assert.equal(await readFile(metadataPath, 'utf8'), '');
+      await assert.rejects(() => stat(metadataPath), { code: 'ENOENT' });
       await assert.rejects(() => stat(purgeIntentPath), { code: 'ENOENT' });
       await store.purge([record.id]);
 
@@ -1256,12 +1211,12 @@ describe('FileArtifactStore', () => {
         'utf8',
       );
       await createArtifactStoreWriteAuthority(root).recover();
-      assert.equal(await readFile(metadataPath, 'utf8'), '');
+      await assert.rejects(() => stat(metadataPath), { code: 'ENOENT' });
       await assert.rejects(() => stat(purgeIntentPath), { code: 'ENOENT' });
     });
   });
 
-  test('legacy production stores recover their own interrupted purge before the next write', async () => {
+  test('self-managed SQLite stores recover an interrupted purge before the next write', async () => {
     await withWorkspace(async (root) => {
       const store = createArtifactStore(root);
       const record = await store.create(artifactInput('legacy-purge', 'remove me', 1));

--- a/packages/storage/src/__tests__/artifact-writer-lock.test.ts
+++ b/packages/storage/src/__tests__/artifact-writer-lock.test.ts
@@ -18,11 +18,7 @@ import { setTimeout as delay } from 'node:timers/promises';
 import { test } from 'node:test';
 import type { ArtifactRecord } from '@maka/core/artifacts';
 import { openHeadlessArtifactStoreForWrite } from '../artifact-stores.js';
-import {
-  createArtifactStore,
-  createSqliteArtifactStore,
-  type CreateArtifactInput,
-} from '../artifact-store.js';
+import { createSqliteArtifactStore, type CreateArtifactInput } from '../artifact-store.js';
 import { withArtifactWriterLock } from '../artifact-writer-lock.js';
 import { createHeadlessRootLease, resolveStorageRoot } from '../root-authority.js';
 import { exportSessionBundleState } from '../session-bundle-policy.js';
@@ -31,6 +27,7 @@ import { createSessionStore } from '../session-store.js';
 const TEST_TIMEOUT_MS = 15_000;
 const OPERATION_TIMEOUT_MS = 5_000;
 const COMPETING_PAYLOAD_BYTES = 4 * 1024 * 1024;
+const createArtifactStore = createSqliteArtifactStore;
 
 test('public Store mutation waits for a child-held writer lock and preserves metadata', {
   timeout: TEST_TIMEOUT_MS,
@@ -65,8 +62,8 @@ test('public Store mutations in separate processes reload and publish under one 
 
     const parentStore = createArtifactStore(stateRoot);
     await parentStore.list('session-1');
-    const holder = await spawnLockHolder(stateRoot);
     const child = await spawnPublicWriter(stateRoot, 'session-1');
+    const holder = await spawnLockHolder(stateRoot);
     try {
       const childInput = artifactInput('child-public', undefined, 3);
       const childPayload = repeatedPayload('child-public:', COMPETING_PAYLOAD_BYTES);

--- a/packages/storage/src/__tests__/fixtures/artifact-writer-lock-holder.ts
+++ b/packages/storage/src/__tests__/fixtures/artifact-writer-lock-holder.ts
@@ -1,7 +1,10 @@
 import { createHash } from 'node:crypto';
 import { mkdir, rm, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
-import { createArtifactStore, type CreateArtifactInput } from '../../artifact-store.js';
+import {
+  createSqliteArtifactStore as createArtifactStore,
+  type CreateArtifactInput,
+} from '../../artifact-store.js';
 import {
   withArtifactWriterLock,
   withLeaseBoundArtifactWriterLock,
@@ -74,16 +77,20 @@ async function runAuthorityLockHolder(workspaceRoot: string, rootId: string): Pr
 
 async function runPublicWriter(workspaceRoot: string, sessionId: string): Promise<void> {
   const store = createArtifactStore(workspaceRoot);
-  await store.list(sessionId);
-  await send({ type: 'ready' });
-  const command = await waitForCreateCommand();
-  const mutation = store.create({
-    ...command.input,
-    content: repeatedPayload(command.payloadUnit, command.payloadBytes),
-  });
-  await new Promise<void>((resolve) => setImmediate(resolve));
-  await send({ type: 'queued' });
-  await send({ type: 'created', record: await mutation });
+  try {
+    await store.list(sessionId);
+    await send({ type: 'ready' });
+    const command = await waitForCreateCommand();
+    const mutation = store.create({
+      ...command.input,
+      content: repeatedPayload(command.payloadUnit, command.payloadBytes),
+    });
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    await send({ type: 'queued' });
+    await send({ type: 'created', record: await mutation });
+  } finally {
+    store.close?.();
+  }
 }
 
 function waitForRelease(): Promise<void> {

--- a/packages/storage/src/__tests__/operational-state-backup.test.ts
+++ b/packages/storage/src/__tests__/operational-state-backup.test.ts
@@ -23,7 +23,7 @@ import {
   restoreOperationalStateBackup,
   validateOperationalStateBackup,
 } from '../operational-state-backup.js';
-import { createArtifactStore, createSqliteArtifactStore } from '../artifact-store.js';
+import { createSqliteArtifactStore } from '../artifact-store.js';
 import { createSessionStore } from '../session-store.js';
 
 test('backs up live WAL state and restores a writable relational closure', async () => {
@@ -414,15 +414,20 @@ test('fails closed when retained legacy Artifact evidence changes after cutover'
     } finally {
       artifacts.close?.();
     }
-    await createArtifactStore(stateRoot).create({
-      id: 'stale-writer-artifact',
-      sessionId,
-      turnId: 'turn-2',
-      name: 'stale.txt',
-      kind: 'file',
-      content: 'stale\n',
-      now: 2,
-    });
+    await writeFile(
+      join(stateRoot, 'artifacts', 'metadata.jsonl'),
+      `${JSON.stringify({
+        id: 'stale-writer-artifact',
+        sessionId,
+        turnId: 'turn-2',
+        createdAt: 2,
+        name: 'stale.txt',
+        kind: 'file',
+        relativePath: `${sessionId}/stale-writer-artifact-stale.txt`,
+        sizeBytes: 6,
+        status: 'live',
+      })}\n`,
+    );
 
     await assert.rejects(
       createOperationalStateBackup({ stateRoot, destinationRoot: backupRoot }),

--- a/packages/storage/src/__tests__/provider-request-capture-artifact.test.ts
+++ b/packages/storage/src/__tests__/provider-request-capture-artifact.test.ts
@@ -4,7 +4,7 @@ import { join } from 'node:path';
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
 
-import { createArtifactStore } from '../artifact-store.js';
+import { createSqliteArtifactStore as createArtifactStore } from '../artifact-store.js';
 import * as storage from '../index.js';
 
 test('persists the exact prepared request as a private artifact', async () => {

--- a/packages/storage/src/__tests__/session-bundle-policy.test.ts
+++ b/packages/storage/src/__tests__/session-bundle-policy.test.ts
@@ -15,7 +15,11 @@ import {
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { test } from 'node:test';
-import { MAX_SANDBOX_BOUNDARY_SERIALIZED_BYTES, type RuntimeEvent } from '@maka/core';
+import {
+  MAX_SANDBOX_BOUNDARY_SERIALIZED_BYTES,
+  type ArtifactRecord,
+  type RuntimeEvent,
+} from '@maka/core';
 import {
   assertSessionBundleRootLayout,
   exportSessionBundleState,
@@ -23,12 +27,14 @@ import {
   type SessionBundleExportError,
 } from '../session-bundle-policy.js';
 import {
-  createArtifactStore,
-  createArtifactStoreWriteAuthority,
   createSqliteArtifactStore,
+  createSqliteArtifactStoreWriteAuthority,
 } from '../artifact-store.js';
 import { createSessionStore } from '../session-store.js';
 import { createSqliteRuntimeStore } from '../sqlite-runtime-store.js';
+
+const createArtifactStore = createSqliteArtifactStore;
+const createArtifactStoreWriteAuthority = createSqliteArtifactStoreWriteAuthority;
 
 test('exports one session only and excludes credential/config canaries', async () => {
   await withBundleRoots(async ({ stateRoot, configRoot, destinationRoot }) => {
@@ -293,8 +299,7 @@ test('exports legacy Artifact metadata into SQLite regardless of source record o
 test('fails closed when legacy Artifact evidence changes after SQLite cutover', async () => {
   await withBundleRoots(async ({ stateRoot, configRoot, destinationRoot }) => {
     const sessionId = await createSelectedSession(stateRoot);
-    const legacy = createArtifactStore(stateRoot);
-    await legacy.create({
+    await seedLegacyArtifact(stateRoot, {
       id: 'before-cutover',
       sessionId,
       turnId: 'turn-1',
@@ -310,7 +315,7 @@ test('fails closed when legacy Artifact evidence changes after SQLite cutover', 
       sqlite.close?.();
     }
 
-    await legacy.create({
+    await seedLegacyArtifact(stateRoot, {
       id: 'stale-writer',
       sessionId,
       turnId: 'turn-2',
@@ -545,8 +550,8 @@ test('authority recovery removes canonical root temps before bundle export', asy
       join(artifactRoot, 'metadata.jsonl.123.1700000000000.tmp'),
       join(artifactRoot, `.artifact-purge-intent.json.123.${uuid}.tmp`),
     ];
-    await writeFile(tempPaths[0]!, await readFile(join(artifactRoot, 'metadata.jsonl')));
-    await writeFile(tempPaths[1]!, await readFile(join(artifactRoot, 'metadata.jsonl')));
+    await writeFile(tempPaths[0]!, 'retired metadata writer residue\n');
+    await writeFile(tempPaths[1]!, 'retired metadata writer residue\n');
     await writeFile(tempPaths[2]!, JSON.stringify({ schemaVersion: 1, artifactIds: [record.id] }));
 
     await assertArtifactRecoveryRequired(
@@ -678,8 +683,7 @@ test('rejects every Artifact metadata file that the Artifact store cannot reopen
       await withBundleRoots(async ({ stateRoot, configRoot, destinationRoot }) => {
         const selectedSessionId = await createSelectedSession(stateRoot);
         const otherSessionId = await createSelectedSession(stateRoot);
-        const artifacts = createArtifactStore(stateRoot);
-        await artifacts.create({
+        const selectedRecord = await seedLegacyArtifact(stateRoot, {
           id: 'selected-artifact',
           sessionId: selectedSessionId,
           turnId: 'turn-1',
@@ -688,7 +692,7 @@ test('rejects every Artifact metadata file that the Artifact store cannot reopen
           content: 'selected\n',
           now: 1,
         });
-        await artifacts.create({
+        const otherRecord = await seedLegacyArtifact(stateRoot, {
           id: 'other-artifact',
           sessionId: otherSessionId,
           turnId: 'turn-1',
@@ -699,10 +703,7 @@ test('rejects every Artifact metadata file that the Artifact store cannot reopen
         });
 
         const metadataPath = join(stateRoot, 'artifacts', 'metadata.jsonl');
-        const records = (await readFile(metadataPath, 'utf8'))
-          .trim()
-          .split('\n')
-          .map((line) => JSON.parse(line) as Record<string, unknown>);
+        const records: Array<Record<string, unknown>> = [{ ...selectedRecord }, { ...otherRecord }];
         const corrupted = corruption.apply(records);
         await writeFile(
           metadataPath,
@@ -949,6 +950,44 @@ async function createArtifactTransactionResidue(
   const purgeIntentTempName = `.artifact-purge-intent.json.123.${uuid}.tmp`;
   await writeFile(join(artifactRoot, purgeIntentTempName), purgeIntent);
   return `artifacts/${purgeIntentTempName}`;
+}
+
+async function seedLegacyArtifact(
+  stateRoot: string,
+  input: {
+    id: string;
+    sessionId: string;
+    turnId: string;
+    name: string;
+    kind: 'file';
+    content: string;
+    now: number;
+  },
+): Promise<ArtifactRecord> {
+  const relativePath = `${input.sessionId}/${input.id}-${input.name}`;
+  const payloadPath = join(stateRoot, 'artifacts', relativePath);
+  const metadataPath = join(stateRoot, 'artifacts', 'metadata.jsonl');
+  await mkdir(dirname(payloadPath), { recursive: true });
+  await writeFile(payloadPath, input.content);
+  const record: ArtifactRecord = {
+    id: input.id,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    createdAt: input.now,
+    name: input.name,
+    kind: input.kind,
+    relativePath,
+    sizeBytes: Buffer.byteLength(input.content),
+    status: 'live',
+  };
+  let existing = '';
+  try {
+    existing = await readFile(metadataPath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  await writeFile(metadataPath, `${existing}${JSON.stringify(record)}\n`);
+  return record;
 }
 
 function escapeRegExp(value: string): string {

--- a/packages/storage/src/__tests__/sqlite-artifact-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-artifact-store.test.ts
@@ -4,18 +4,23 @@ import { link, mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/pro
 import { tmpdir } from 'node:os';
 import { basename, dirname, join } from 'node:path';
 import { describe, test } from 'node:test';
+import type { ArtifactRecord } from '@maka/core/artifacts';
 import {
-  createArtifactStore,
   createSqliteArtifactStore,
   createSqliteArtifactStoreWriteAuthority,
 } from '../artifact-store.js';
+import * as artifactStoreModule from '../artifact-store.js';
 import { withArtifactWriterLock } from '../artifact-writer-lock.js';
 
 describe('SQLite artifact metadata', () => {
+  test('does not expose the retired JSONL Artifact writer', () => {
+    assert.equal(Reflect.has(artifactStoreModule, 'createArtifactStore'), false);
+    assert.equal(Reflect.has(artifactStoreModule, 'createArtifactStoreWriteAuthority'), false);
+  });
+
   test('cuts over legacy metadata once and makes SQLite canonical without rewriting JSONL', async () => {
     await withWorkspace(async (root) => {
-      const legacy = createArtifactStore(root);
-      const migrated = await legacy.create(artifactInput('migrated', 'legacy bytes', 1));
+      const migrated = await seedLegacyArtifact(root, artifactInput('migrated', 'legacy bytes', 1));
       const metadataPath = join(root, 'artifacts', 'metadata.jsonl');
       const legacyMetadata = await readFile(metadataPath);
 
@@ -47,8 +52,7 @@ describe('SQLite artifact metadata', () => {
 
   test('resumes an interrupted cutover atomically', async () => {
     await withWorkspace(async (root) => {
-      const legacy = createArtifactStore(root);
-      const record = await legacy.create(artifactInput('legacy', 'durable', 1));
+      const record = await seedLegacyArtifact(root, artifactInput('legacy', 'durable', 1));
       const interrupted = createSqliteArtifactStore(root, {
         failpoint: (point) => {
           if (point === 'after_cutover_rows_copied') {
@@ -71,7 +75,7 @@ describe('SQLite artifact metadata', () => {
 
   test('runs the first legacy cutover under the artifact writer lock', async () => {
     await withWorkspace(async (root) => {
-      await createArtifactStore(root).create(artifactInput('legacy', 'durable', 1));
+      await seedLegacyArtifact(root, artifactInput('legacy', 'durable', 1));
       const held = await holdArtifactWriterLock(root);
       const store = createSqliteArtifactStore(root);
       let settled = false;
@@ -90,13 +94,12 @@ describe('SQLite artifact metadata', () => {
 
   test('fails closed when an old writer changes JSONL after cutover', async () => {
     await withWorkspace(async (root) => {
-      const legacy = createArtifactStore(root);
-      await legacy.create(artifactInput('legacy', 'durable', 1));
+      await seedLegacyArtifact(root, artifactInput('legacy', 'durable', 1));
       const store = createSqliteArtifactStore(root);
       await store.list('session-1');
       store.close?.();
 
-      await createArtifactStore(root).create(artifactInput('old-writer', 'stale', 2));
+      await seedLegacyArtifact(root, artifactInput('old-writer', 'stale', 2));
       const reopened = createSqliteArtifactStore(root);
       try {
         await assert.rejects(
@@ -205,6 +208,37 @@ function artifactInput(id: string, content: string, now: number) {
     source: 'fixture' as const,
     now,
   };
+}
+
+async function seedLegacyArtifact(
+  root: string,
+  input: ReturnType<typeof artifactInput>,
+): Promise<ArtifactRecord> {
+  const relativePath = `${input.sessionId}/${input.id}-${input.name}`;
+  const payloadPath = join(root, 'artifacts', relativePath);
+  const metadataPath = join(root, 'artifacts', 'metadata.jsonl');
+  await mkdir(dirname(payloadPath), { recursive: true });
+  await writeFile(payloadPath, input.content);
+  const record: ArtifactRecord = {
+    id: input.id,
+    sessionId: input.sessionId,
+    turnId: input.turnId,
+    createdAt: input.now,
+    name: input.name,
+    kind: input.kind,
+    relativePath,
+    sizeBytes: Buffer.byteLength(input.content),
+    source: input.source,
+    status: 'live',
+  };
+  let existing = '';
+  try {
+    existing = await readFile(metadataPath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+  }
+  await writeFile(metadataPath, `${existing}${JSON.stringify(record)}\n`);
+  return record;
 }
 
 async function createPublicationResidue(

--- a/packages/storage/src/artifact-store.ts
+++ b/packages/storage/src/artifact-store.ts
@@ -10,7 +10,6 @@ import {
   readFile,
   readdir,
   realpath,
-  rename,
   rm,
   stat,
   unlink,
@@ -41,7 +40,6 @@ import {
   isCanonicalArtifactRecoveryTempName,
 } from './artifact-storage-layout.js';
 import {
-  decodeArtifactMetadata,
   isSafeRelativeArtifactPath,
   validateCanonicalArtifactTargetName,
   validateRelativeArtifactPath,
@@ -73,15 +71,6 @@ const EMPTY_SESSION_SNAPSHOT: ArtifactSessionSnapshot = {
 interface ArtifactSessionSnapshot {
   readonly records: readonly ArtifactRecord[];
   readonly revision: ArtifactListRevision;
-}
-
-interface MetadataFileIdentity {
-  readonly dev: bigint;
-  readonly ino: bigint;
-  readonly size: bigint;
-  readonly mtimeNs: bigint;
-  readonly ctimeNs: bigint;
-  readonly birthtimeNs: bigint;
 }
 
 type ArtifactReadFailure = {
@@ -215,41 +204,17 @@ export interface ArtifactStoreWriteAuthority {
   close(): void;
 }
 
-export function createArtifactStore(workspaceRoot: string): ArtifactStore {
-  return new FileArtifactStore(workspaceRoot, 'legacy');
-}
-
 export function createSqliteArtifactStore(
   workspaceRoot: string,
   options: CreateSqliteArtifactMetadataOptions = {},
 ): ArtifactStore {
-  return new FileArtifactStore(
+  return new SqliteArtifactStore(
     workspaceRoot,
-    'legacy',
-    undefined,
-    undefined,
+    'self_managed',
     createSqliteArtifactMetadataRepository(workspaceRoot, options),
+    undefined,
+    undefined,
   );
-}
-
-export function createArtifactStoreWriteAuthority(
-  workspaceRoot: string,
-  options: {
-    assertAuthority?: () => Promise<void>;
-    leaseBoundWriterLockAuthority?: ArtifactWriterLockAuthority;
-  } = {},
-): ArtifactStoreWriteAuthority {
-  const store = new FileArtifactStore(
-    workspaceRoot,
-    'authority',
-    options.assertAuthority,
-    options.leaseBoundWriterLockAuthority,
-  );
-  return Object.freeze({
-    store,
-    recover: () => store.recoverForWriteWithAuthority(),
-    close: () => store.close(),
-  });
 }
 
 export function createSqliteArtifactStoreWriteAuthority(
@@ -260,12 +225,12 @@ export function createSqliteArtifactStoreWriteAuthority(
     cutover?: CreateSqliteArtifactMetadataOptions;
   } = {},
 ): ArtifactStoreWriteAuthority {
-  const store = new FileArtifactStore(
+  const store = new SqliteArtifactStore(
     workspaceRoot,
     'authority',
+    createSqliteArtifactMetadataRepository(workspaceRoot, options.cutover),
     options.assertAuthority,
     options.leaseBoundWriterLockAuthority,
-    createSqliteArtifactMetadataRepository(workspaceRoot, options.cutover),
   );
   return Object.freeze({
     store,
@@ -274,36 +239,32 @@ export function createSqliteArtifactStoreWriteAuthority(
   });
 }
 
-class FileArtifactStore implements ArtifactAuthorityStore {
+class SqliteArtifactStore implements ArtifactAuthorityStore {
   private artifactRoot: string;
-  private metadataPath: string;
   private purgeIntentPath: string;
   private records: ArtifactRecord[] = [];
   private sessionSnapshots = new Map<string, ArtifactSessionSnapshot>();
-  private loaded = false;
   private metadataReady = false;
   private recoveryRequired: boolean;
-  private legacyRecoveryRequired: boolean;
+  private selfManagedRecoveryRequired: boolean;
   private recoverableOrphans = new Map<string, RecoverableOrphan>();
-  private metadataIdentity: MetadataFileIdentity | null | undefined;
   private queue: Promise<void> = Promise.resolve();
 
   constructor(
     private workspaceRoot: string,
-    private readonly recoveryMode: 'legacy' | 'authority',
+    private readonly recoveryMode: 'self_managed' | 'authority',
+    private readonly metadataRepository: ArtifactMetadataRepository,
     private readonly assertAuthority?: () => Promise<void>,
     private readonly leaseBoundWriterLockAuthority?: ArtifactWriterLockAuthority,
-    private readonly metadataRepository?: ArtifactMetadataRepository,
   ) {
     this.artifactRoot = join(workspaceRoot, 'artifacts');
-    this.metadataPath = join(this.artifactRoot, 'metadata.jsonl');
     this.purgeIntentPath = join(this.artifactRoot, ARTIFACT_PURGE_INTENT_FILE);
     this.recoveryRequired = recoveryMode === 'authority';
-    this.legacyRecoveryRequired = recoveryMode === 'legacy';
+    this.selfManagedRecoveryRequired = recoveryMode === 'self_managed';
   }
 
   close(): void {
-    this.metadataRepository?.close();
+    this.metadataRepository.close();
   }
 
   async create(input: CreateArtifactInput): Promise<ArtifactRecord> {
@@ -509,10 +470,7 @@ class FileArtifactStore implements ArtifactAuthorityStore {
         await syncDirectory(targetDirectory);
         await this.writeMetadataUnlocked(nextRecords);
       } catch (error) {
-        if (targetLinked && isPublishedMetadataError(error)) {
-          preserveStaging = true;
-          this.invalidateWriterState();
-        } else if (targetLinked) {
+        if (targetLinked) {
           try {
             await removeFileDurably(target, targetDirectory);
           } catch (cleanupError) {
@@ -906,91 +864,15 @@ class FileArtifactStore implements ArtifactAuthorityStore {
   }
 
   private async load(): Promise<void> {
-    if (this.metadataRepository) {
-      await this.metadataRepository.ready();
-      this.metadataReady = true;
-      this.replaceRecords(this.metadataRepository.readAll());
-      this.loaded = true;
-      return;
-    }
-    let handle;
-    try {
-      handle = await open(this.metadataPath, 'r');
-    } catch (error) {
-      if (!isNotFound(error)) throw error;
-      if (!this.loaded || this.metadataIdentity !== null) {
-        this.replaceRecords([]);
-        this.metadataIdentity = null;
-        this.loaded = true;
-      }
-      return;
-    }
-    try {
-      const metadataStat = await handle.stat({ bigint: true });
-      if (!metadataStat.isFile()) throw artifactMetadataNotFile();
-      const identity = metadataFileIdentity(metadataStat);
-      if (this.loaded && sameMetadataIdentity(this.metadataIdentity, identity)) return;
-      const text = await handle.readFile({ encoding: 'utf8' });
-      this.replaceRecords(decodeArtifactMetadata(text));
-      this.metadataIdentity = identity;
-      this.loaded = true;
-    } finally {
-      await handle.close();
-    }
+    await this.metadataRepository.ready();
+    this.metadataReady = true;
+    this.replaceRecords(this.metadataRepository.readAll());
   }
 
   private async writeMetadataUnlocked(records: readonly ArtifactRecord[]): Promise<void> {
-    if (this.metadataRepository) {
-      await this.metadataRepository.ready();
-      this.metadataReady = true;
-      this.metadataRepository.replaceAll(records);
-      this.loaded = true;
-      return;
-    }
-    const metadataDirectory = dirname(this.metadataPath);
-    const createdDirectory = await mkdir(metadataDirectory, { recursive: true });
-    if (createdDirectory !== undefined) {
-      await syncDirectoryChain(metadataDirectory, this.workspaceRoot);
-    }
-    const tempPath = `${this.metadataPath}.${process.pid}.${randomUUID()}.tmp`;
-    const payload = records.map((record) => JSON.stringify(record)).join('\n');
-    let published = false;
-    let publishedIdentity: MetadataFileIdentity | undefined;
-    let publicationError: MetadataPublicationError | undefined;
-    try {
-      await writeFile(tempPath, payload ? `${payload}\n` : '', {
-        encoding: 'utf8',
-        flag: 'wx',
-      });
-      await syncFile(tempPath);
-      const tempStat = await stat(tempPath, { bigint: true });
-      publishedIdentity = metadataFileIdentity(tempStat);
-      await rename(tempPath, this.metadataPath);
-      published = true;
-      await syncDirectory(metadataDirectory);
-    } catch (error) {
-      this.invalidateWriterState();
-      publicationError = new MetadataPublicationError(error, published);
-    }
-    if (!published) {
-      try {
-        await removeFileDurably(tempPath, metadataDirectory);
-      } catch (cleanupError) {
-        this.invalidateWriterState();
-        if (publicationError) {
-          throw new AggregateError(
-            [publicationError, cleanupError],
-            'Artifact metadata publication and temp cleanup both failed',
-          );
-        }
-        throw cleanupError;
-      }
-    }
-    if (publicationError) throw publicationError;
-    if (!publishedIdentity)
-      throw new Error('Artifact metadata publication identity is unavailable');
-    this.metadataIdentity = publishedIdentity;
-    this.loaded = true;
+    await this.metadataRepository.ready();
+    this.metadataReady = true;
+    this.metadataRepository.replaceAll(records);
   }
 
   private async prepareMutationUnlocked(
@@ -1007,11 +889,11 @@ class FileArtifactStore implements ArtifactAuthorityStore {
         }
       | { readonly kind: 'delete' | 'purge' },
   ): Promise<void> {
-    if (this.recoveryMode === 'legacy') {
+    if (this.recoveryMode === 'self_managed') {
       this.recoverableOrphans.clear();
-      if (this.legacyRecoveryRequired) {
+      if (this.selfManagedRecoveryRequired) {
         await this.prepareRecoveryUnlocked();
-        this.legacyRecoveryRequired = false;
+        this.selfManagedRecoveryRequired = false;
       } else {
         await this.reloadForMutationUnlocked();
         await this.recoverPurgeIntentUnlocked();
@@ -1035,30 +917,9 @@ class FileArtifactStore implements ArtifactAuthorityStore {
   }
 
   private async reloadForMutationUnlocked(): Promise<void> {
-    if (this.metadataRepository) {
-      await this.metadataRepository.ready();
-      this.metadataReady = true;
-      this.replaceRecords(this.metadataRepository.readAll());
-      this.loaded = true;
-      return;
-    }
-    try {
-      const handle = await open(this.metadataPath, 'r');
-      try {
-        const metadataStat = await handle.stat({ bigint: true });
-        if (!metadataStat.isFile()) throw artifactMetadataNotFile();
-        const text = await handle.readFile({ encoding: 'utf8' });
-        this.replaceRecords(decodeArtifactMetadata(text));
-        this.metadataIdentity = metadataFileIdentity(metadataStat);
-      } finally {
-        await handle.close();
-      }
-    } catch (error) {
-      if (!isNotFound(error)) throw error;
-      this.replaceRecords([]);
-      this.metadataIdentity = null;
-    }
-    this.loaded = true;
+    await this.metadataRepository.ready();
+    this.metadataReady = true;
+    this.replaceRecords(this.metadataRepository.readAll());
   }
 
   private async hasCanonicalRecoveryResidueUnlocked(): Promise<boolean> {
@@ -1320,20 +1181,17 @@ class FileArtifactStore implements ArtifactAuthorityStore {
 
   private invalidateWriterState(): void {
     if (this.recoveryMode === 'authority') this.recoveryRequired = true;
-    else this.legacyRecoveryRequired = true;
+    else this.selfManagedRecoveryRequired = true;
   }
 
-  private bindLegacyMutationRoot(canonicalRoot: string): void {
-    if (this.recoveryMode !== 'legacy' || this.workspaceRoot === canonicalRoot) return;
+  private bindMutationRoot(canonicalRoot: string): void {
+    if (this.workspaceRoot === canonicalRoot) return;
     this.workspaceRoot = canonicalRoot;
     this.artifactRoot = join(canonicalRoot, 'artifacts');
-    this.metadataPath = join(this.artifactRoot, 'metadata.jsonl');
     this.purgeIntentPath = join(this.artifactRoot, ARTIFACT_PURGE_INTENT_FILE);
     this.replaceRecords([]);
-    this.loaded = false;
-    this.metadataIdentity = undefined;
     this.recoverableOrphans.clear();
-    this.legacyRecoveryRequired = true;
+    if (this.recoveryMode === 'self_managed') this.selfManagedRecoveryRequired = true;
   }
 
   private replaceRecords(records: ArtifactRecord[]): void {
@@ -1537,10 +1395,10 @@ class FileArtifactStore implements ArtifactAuthorityStore {
 
   private enqueue<T>(operation: () => Promise<T>): Promise<T> {
     return this.enqueueSerialized(async () => {
-      if (this.metadataRepository && !this.metadataReady) {
+      if (!this.metadataReady) {
         return this.runWithWriterLock(async () => {
           await this.assertAuthority?.();
-          await this.metadataRepository?.ready();
+          await this.metadataRepository.ready();
           this.metadataReady = true;
           return operation();
         });
@@ -1565,7 +1423,7 @@ class FileArtifactStore implements ArtifactAuthorityStore {
       return withLeaseBoundArtifactWriterLock(leaseBoundWriterLockAuthority, operation);
     }
     return withArtifactWriterLock(this.workspaceRoot, async (canonicalRoot) => {
-      this.bindLegacyMutationRoot(canonicalRoot);
+      this.bindMutationRoot(canonicalRoot);
       return operation();
     });
   }
@@ -1573,33 +1431,6 @@ class FileArtifactStore implements ArtifactAuthorityStore {
 
 function publicationStagingName(targetBasename: string): string {
   return `.artifact-publish.${artifactTargetHash(targetBasename)}.${randomUUID()}.tmp`;
-}
-
-function sameMetadataIdentity(
-  left: MetadataFileIdentity | null | undefined,
-  right: MetadataFileIdentity,
-): boolean {
-  return (
-    left !== null &&
-    left !== undefined &&
-    left.dev === right.dev &&
-    left.ino === right.ino &&
-    left.size === right.size &&
-    left.mtimeNs === right.mtimeNs &&
-    left.ctimeNs === right.ctimeNs &&
-    left.birthtimeNs === right.birthtimeNs
-  );
-}
-
-function metadataFileIdentity(fileStat: BigIntStats): MetadataFileIdentity {
-  return {
-    dev: fileStat.dev,
-    ino: fileStat.ino,
-    size: fileStat.size,
-    mtimeNs: fileStat.mtimeNs,
-    ctimeNs: fileStat.ctimeNs,
-    birthtimeNs: fileStat.birthtimeNs,
-  };
 }
 
 async function openRealTarget(path: string) {
@@ -1665,12 +1496,6 @@ function conversationCopyArtifactId(
 
 function artifactWriteRecoveryRequired(): Error {
   return new Error('Artifact write recovery is required before another mutation');
-}
-
-function artifactMetadataNotFile(): NodeJS.ErrnoException {
-  const error = new Error('Artifact metadata path is not a regular file') as NodeJS.ErrnoException;
-  error.code = 'EISDIR';
-  return error;
 }
 
 function optionalCanonicalText(value: string | undefined): string | undefined {
@@ -1774,19 +1599,6 @@ function truncateWithoutSplittingSurrogate(value: string, maxCodeUnits: number):
   const truncated = value.slice(0, maxCodeUnits);
   const last = truncated.charCodeAt(truncated.length - 1);
   return last >= 0xd800 && last <= 0xdbff ? truncated.slice(0, -1) : truncated;
-}
-
-class MetadataPublicationError extends Error {
-  constructor(
-    cause: unknown,
-    readonly published: boolean,
-  ) {
-    super('Artifact metadata publication failed', { cause });
-  }
-}
-
-function isPublishedMetadataError(error: unknown): boolean {
-  return error instanceof MetadataPublicationError && error.published;
 }
 
 async function removeFileDurably(path: string, directory: string): Promise<boolean> {

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -27,7 +27,6 @@ export * from './usage-stores.js';
 export {
   ARTIFACT_BINARY_PREVIEW_LIMIT_BYTES,
   ARTIFACT_TEXT_PREVIEW_LIMIT_BYTES,
-  createArtifactStore,
   createSqliteArtifactStore,
   isSafeRelativeArtifactPath,
   resolveArtifactPath,

--- a/scripts/deepseek-live-cost-baseline.mjs
+++ b/scripts/deepseek-live-cost-baseline.mjs
@@ -21,7 +21,7 @@ import {
 } from '../packages/runtime/dist/index.js';
 import {
   createAgentRunStore,
-  createArtifactStore,
+  createSqliteArtifactStore,
   createRuntimeEventStore,
   createSessionStore,
 } from '../packages/storage/dist/index.js';
@@ -111,7 +111,7 @@ if (
 const sessionStore = createSessionStore(workspaceRoot);
 const runStore = createAgentRunStore(workspaceRoot);
 const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
-const artifactStore = createArtifactStore(workspaceRoot);
+const artifactStore = createSqliteArtifactStore(workspaceRoot);
 const backends = new BackendRegistry();
 const llmRecords = [];
 const runTraceEvents = [];
@@ -510,7 +510,7 @@ async function runPhase7ToolScenario(input) {
   const sessionStore = createSessionStore(workspaceRoot);
   const runStore = createAgentRunStore(workspaceRoot);
   const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
-  const artifactStore = createArtifactStore(workspaceRoot);
+  const artifactStore = createSqliteArtifactStore(workspaceRoot);
   const backends = new BackendRegistry();
   const llmRecords = [];
   const runTraceEvents = [];
@@ -1198,7 +1198,7 @@ async function runPhase10HistoryCompactScenario(input) {
   const sessionStore = createSessionStore(workspaceRoot);
   const runStore = createAgentRunStore(workspaceRoot);
   const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
-  const artifactStore = createArtifactStore(workspaceRoot);
+  const artifactStore = createSqliteArtifactStore(workspaceRoot);
   const backends = new BackendRegistry();
   const llmRecords = [];
   const runTraceEvents = [];
@@ -1451,7 +1451,7 @@ async function runPhase8SynthesisScenario(input) {
   const sessionStore = createSessionStore(workspaceRoot);
   const runStore = createAgentRunStore(workspaceRoot);
   const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
-  const artifactStore = createArtifactStore(workspaceRoot);
+  const artifactStore = createSqliteArtifactStore(workspaceRoot);
   const backends = new BackendRegistry();
   const llmRecords = [];
   const runTraceEvents = [];


### PR DESCRIPTION
## Summary

- remove the production `createArtifactStore` and legacy Artifact write-authority constructors
- require every Artifact store instance to use the SQLite metadata repository
- delete the `metadata.jsonl` publication/reload path while preserving payload-file recovery against SQLite commits
- migrate Desktop tests, storage tests, and the DeepSeek baseline script to the SQLite factory
- keep `metadata.jsonl` only as fingerprinted, read-only cutover evidence

## Why

The bundle, backup, and Headless trajectory slices now consume SQLite as the canonical Artifact authority. Keeping a callable JSONL metadata writer would preserve a production dual-writer path and allow post-cutover legacy evidence to drift. This PR removes that writer surface while retaining the fail-closed importer needed for existing workspaces.

## Verification

- `npm --workspace @maka/core run build`
- `npm --workspace @maka/storage run build`
- full Storage suite: 896 tests, 895 passed, 1 skipped, 0 failed
- affected Desktop Artifact suites: 19 passed, 0 failed
- `npm --workspace @maka/headless run build`
- `npm --workspace maka-agent run build`
- Headless storage dependency boundary: 2 passed
- `npx biome check` on the changed migration surfaces
- `git diff --check`

A local full Desktop main compile is currently blocked by the base workspace's missing `@astryxdesign/core/Selector` dependency. That unrelated module-resolution error is the only Desktop compile error; all four affected Desktop suites pass.

Part of #1649
