### PR TITLE
test: restore proxy settings contracts

### DIFF
--- a/apps/desktop/src/main/__tests__/session-startup-recovery-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-startup-recovery-contract.test.ts
@@ -77,10 +77,9 @@ describe('session startup recovery contract', () => {
     assert.doesNotMatch(main, /^await migrateSessionProjects\(/m);
     // The test's own name is "keeps startup fail-soft", and a bare `await` in a
     // sequence is the opposite of that: the first rejection skips every step
-    // after it. That is not hypothetical — one unreadable telemetry record took
-    // session recovery, the Open Gateway sync, plan reminders, the daily review
-    // scheduler, the config watcher and the automation scheduler with it, and
-    // said nothing.
+    // after it. That is not hypothetical — one unreadable telemetry record
+    // stopped session recovery, schedulers, and the config watcher, and said
+    // nothing.
     //
     // So assert the property rather than the shape: the migration still runs in
     // background startup, and it runs through the wrapper that logs its own

--- a/apps/desktop/src/main/__tests__/settings-network-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/settings-network-contract.test.ts
@@ -10,14 +10,27 @@ const networkBlock = settingsSource.match(
 )?.[0] ?? '';
 
 describe('Settings network persistence contract', () => {
-  it('keeps proxy edits responsive while persisting through the shared draft owner', () => {
+  it('keeps parent and proxy drafts last-write-wins with visible save failures', () => {
+    assert.match(
+      settingsSource,
+      /const ticket = settingsUpdateTicketRef\.current \+ 1;[\s\S]*settingsUpdateTicketRef\.current = ticket;[\s\S]*await window\.maka\.settings\.update\(patch\);[\s\S]*settingsModalMountedRef\.current && ticket === settingsUpdateTicketRef\.current/,
+    );
     assert.match(
       networkBlock,
       /useOptimisticSettingsDraft<NetworkProxySettings>\([\s\S]*persistedProxy,[\s\S]*\(patch\) => props\.onUpdate\(\{ network: \{ proxy: patch \} \}\)\.then\(\(result\) => result\.settings\.network\.proxy\)/,
     );
     assert.match(networkBlock, /draftRef: proxyDraftRef,[\s\S]*mountedRef: networkPageMountedRef,[\s\S]*update,/);
+    assert.match(
+      networkBlock,
+      /onError: \(error\) => toast\.error\(copy\.saveNetworkFailed, settingsActionErrorMessage\(error, locale\)\)/,
+    );
+    assert.match(networkBlock, /onChange=\{\(enabled\) => void updateProxy\(\{ enabled \}\)\}/);
     assert.match(networkBlock, /onChange=\{\(value\) => void updateProxy\(\{ host: value \}\)\}/);
     assert.match(networkBlock, /onChange=\{\(value\) => void updateProxy\(\{ port: value \?\? 0 \}\)\}/);
+    assert.match(
+      networkBlock,
+      /value=\{proxyDraft\.bypassList\.join\(', '\)\}[\s\S]*onChange=\{\(value\) => void updateProxy\(\{ bypassList: csvList\(value\) \}\)\}/,
+    );
   });
 
   it('tests the latest proxy draft once and localizes failures at the IPC boundary', () => {
@@ -26,8 +39,13 @@ describe('Settings network persistence contract', () => {
     );
 
     assert.ok(helper, 'main must normalize proxy test failures at the IPC boundary');
+    assert.match(helper[0], /proxy disabled[\s\S]*代理未启用，请先打开代理开关/);
+    assert.match(helper[0], /proxy host\/port required[\s\S]*请填写代理服务器地址和端口后再测试/);
     assert.match(helper[0], /proxy test timeout[\s\S]*代理测试超时，请检查代理服务是否可达/);
+    assert.match(helper[0], /result\.status[\s\S]*代理测试返回 HTTP \$\{result\.status\}/);
     assert.match(helper[0], /redactSecrets\(result\.error \?\? ''\)/);
+    assert.match(helper[0], /generalizedErrorMessageChinese\(raw, ''\)/);
+    assert.match(mainSource, /message: proxyTestFailureMessage\(result\)/);
     assert.match(networkBlock, /const proxyTestGuard = useActionGuard<'test'>\(\)/);
     assert.match(
       networkBlock,
@@ -35,5 +53,23 @@ describe('Settings network persistence contract', () => {
     );
     assert.match(networkBlock, /proxyTestGuard\.finish\(\)/);
     assert.match(networkBlock, /settingsActionErrorMessage\(error, locale\)/);
+  });
+
+  it('exposes pending state and drops late proxy-test UI writes after unmount', () => {
+    assert.match(networkBlock, /aria-busy=\{testing\}/);
+    assert.match(networkBlock, /data-pending=\{testing \? 'true' : undefined\}/);
+    assert.match(networkBlock, /onClick=\{\(\) => void testProxy\(\)\}/);
+    assert.match(
+      networkBlock,
+      /if \(result\.ok && networkPageMountedRef\.current\)[\s\S]*else if \(networkPageMountedRef\.current\)/,
+    );
+    assert.match(
+      networkBlock,
+      /catch \(error\) \{[\s\S]*if \(networkPageMountedRef\.current\)[\s\S]*settingsActionErrorMessage\(error, locale\)/,
+    );
+    assert.match(
+      networkBlock,
+      /finally \{[\s\S]*proxyTestGuard\.finish\(\);[\s\S]*if \(networkPageMountedRef\.current\) \{[\s\S]*setTesting\(false\)/,
+    );
   });
 });

--- a/apps/desktop/src/main/config-transfer-service.ts
+++ b/apps/desktop/src/main/config-transfer-service.ts
@@ -67,7 +67,7 @@ export async function gatherConfigExport(
   if (selected.has('settings')) {
     const settings = await deps.settingsStore.get();
     // When credentials are included, settings keeps its embedded secrets
-    // (proxy password, bot tokens, gateway token, Tavily key); otherwise strip.
+    // (proxy password, bot tokens, Tavily key); otherwise strip.
     data.settings = selected.has('credentials') ? settings : stripSettingsSecretsForExport(settings);
   }
 

--- a/apps/desktop/src/main/credential-store.ts
+++ b/apps/desktop/src/main/credential-store.ts
@@ -28,8 +28,8 @@ export { CREDENTIAL_SCHEMA_VERSION, createFileCredentialStore } from '@maka/stor
  * then reads.
  *
  * Scope — this migrates EVERY secret in `credentials.json`, not just API keys:
- * bot tokens, bot app secrets, the proxy password, the gateway token, and the
- * Tavily key all decrypt to plaintext too. That is required, not incidental —
+ * bot tokens, bot app secrets, the proxy password, and the Tavily key all
+ * decrypt to plaintext too. That is required, not incidental —
  * the desktop abandons `safeStorage` entirely (the live store is now the
  * pure-Node `FileCredentialStore`), so any value left encrypted would become
  * permanently unreadable. The accepted at-rest posture for all of them is

--- a/apps/desktop/src/renderer/settings/password-input.tsx
+++ b/apps/desktop/src/renderer/settings/password-input.tsx
@@ -17,8 +17,8 @@ import { getSettingsPreferencesCopy } from '../locales/settings-preferences-copy
  * PR-SETTINGS-PASSWORD-INPUT-REACH-0 (WAWQAQ msg `51c7b4ff` screenshots):
  * masked text input with a trailing Eye / EyeOff toggle and an
  * optional Copy button. Shared across Settings credential surfaces
- * (bot tokens / app secrets, provider API keys, Open Gateway token,
- * network proxy password, web search API key) so the visibility +
+ * (bot tokens / app secrets, provider API keys, network proxy password,
+ * web search API key) so the visibility +
  * clipboard affordance is consistent.
  *
  * Initial state is masked. Toggle and copy are both real focusable

--- a/apps/desktop/src/renderer/settings/use-optimistic-settings-draft.ts
+++ b/apps/desktop/src/renderer/settings/use-optimistic-settings-draft.ts
@@ -9,8 +9,7 @@ import {
 /**
  * Shared optimistic last-write-wins draft for Settings pages.
  *
- * Three Settings pages (network proxy, open gateway, and usage)
- * had each hand-copied the same block: a local draft mirrored on a ref, a
+ * Several Settings pages need the same block: a local draft mirrored on a ref, a
  * `persistedRef`, a `pendingSaveCount`, a monotonic `saveTicket`, a
  * `commitDraft` helper, and a prop→state sync effect. This hook owns that
  * machinery once (via `createOptimisticDraftController`) so no page reinvents

--- a/apps/desktop/src/renderer/styles/settings/health.css
+++ b/apps/desktop/src/renderer/styles/settings/health.css
@@ -30,7 +30,7 @@
     /* #1361: was `repeat(5, minmax(0, 1fr))`. Five hard tracks kept dividing
        whatever width they were given, so at the 480px window floor each tile
        collapsed to ~30px — 4px of content box after padding, which even a
-       single digit overflows. That is the sibling of the #1304 Open Gateway
+       single digit overflows. This is the same family as earlier metric-card
        overflow: #1335 taught StatTile to wrap its own text, but a tile squeezed
        below one character wide has nothing left to wrap into. `auto-fit` still
        yields five even tracks at full width (only five tiles exist, and 1fr

--- a/packages/core/src/__tests__/settings.test.ts
+++ b/packages/core/src/__tests__/settings.test.ts
@@ -523,26 +523,7 @@ describe('removed UI density settings contract', () => {
   });
 });
 
-describe('settings normalization compatibility', () => {
-  test('ignores retired persisted sections without resetting active settings', () => {
-    const normalized = normalizeSettings({
-      appearance: {
-        theme: 'dark',
-      },
-      // Simulates a settings.json written before Open Gateway was retired.
-      openGateway: {
-        enabled: true,
-        host: '0.0.0.0',
-        port: 4939,
-        token: 'local-dev-token',
-      },
-    } as unknown);
-
-    expect(normalized.appearance.theme).toBe('dark');
-    expect('density' in normalized.appearance).toBe(false);
-    expect('openGateway' in normalized).toBe(false);
-  });
-
+describe('settings normalization boundaries', () => {
   test('delegates web search patches and persisted normalization to the web-search owner', () => {
     const patched = mergeSettings(createDefaultSettings(), {
       webSearch: {

--- a/packages/ui/stories/stat-tile.stories.tsx
+++ b/packages/ui/stories/stat-tile.stories.tsx
@@ -25,7 +25,7 @@ export const LongUnbrokenValue: Story = {
       />
       <StatTile
         emphasis="outline"
-        label="Gateway token"
+        label="Access token"
         value="maka_live_token_4f61127a1e66b49c97a1d1c45b0df9f6b28df69c"
         detail="Long unbroken strings wrap inside the tile"
       />


### PR DESCRIPTION
## Summary

- restore focused proxy Settings contracts removed with #1709
- cover last-write-wins persistence, localized failures, pending state, and unmount safety
- remove stale Open Gateway comments and the retired compatibility-only normalization test

## Validation

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm run check:release`
- `npm --workspace @maka/core run build`
- `npm --workspace @maka/core run test:dist` (1233 tests)
- `npm --workspace @maka/desktop run build:main`
- focused Desktop contract tests (6 tests)
- Open Gateway residual audit (no matches)