### PR TITLE
fix(ui): restore classic padding on Astryx dialog headers

### DIFF
--- a/apps/desktop/src/renderer/keyboard-help.tsx
+++ b/apps/desktop/src/renderer/keyboard-help.tsx
@@ -72,7 +72,6 @@ export function KeyboardHelpModal(props: {
       className="maka-help-modal"
       width={560}
       maxHeight="calc(100dvh - 96px)"
-      padding={0}
       purpose="info"
     >
       <Layout

--- a/apps/desktop/src/renderer/mcp-page.tsx
+++ b/apps/desktop/src/renderer/mcp-page.tsx
@@ -643,7 +643,6 @@ function McpEditorDialog(props: {
       className="maka-mcp-editor-dialog"
       width="min(92vw, var(--maka-chat-measure))"
       maxHeight="85dvh"
-      padding={0}
       purpose="form"
     >
       <Layout

--- a/apps/desktop/src/renderer/settings/bot-onboarding-modal.tsx
+++ b/apps/desktop/src/renderer/settings/bot-onboarding-modal.tsx
@@ -151,7 +151,6 @@ export function BotOnboardingModal(props: {
       className="settingsBotOnboardingModal"
       width={520}
       aria-label={copy.ariaLabel}
-      padding={0}
       purpose="form"
     >
       <Layout

--- a/apps/desktop/src/renderer/settings/bot-wechat-login.tsx
+++ b/apps/desktop/src/renderer/settings/bot-wechat-login.tsx
@@ -160,7 +160,6 @@ export function WechatQrLoginModal(props: {
       onOpenChange={props.onOpenChange}
       className="settingsWechatQrModal"
       width={360}
-      padding={0}
       purpose="info"
     >
       <Layout

--- a/apps/desktop/src/renderer/settings/provider-connection-dialog.tsx
+++ b/apps/desktop/src/renderer/settings/provider-connection-dialog.tsx
@@ -22,7 +22,6 @@ export function ProviderConnectionDialog(props: {
       className="providerConnectionDialog"
       width={520}
       maxHeight="calc(100dvh - 80px)"
-      padding={0}
       purpose="form"
     >
       <Layout


### PR DESCRIPTION
## Summary

   Closes #1713.

   The Astryx modal migration (#1674) dropped the dialog header inset and
   the follow-up adapter removal (#1688) moved `padding={0}` into the five
   dialog call sites. Astryx's `DialogHeader` derives its padding from the
   dialog container's `--layout-padding-*` variables, so with `padding={0}`
   the provider icon, title, subtitle and close button render flush against
   the modal edges in every dialog.

   This removes `padding={0}` from the five `<Dialog>` call sites
   (provider connection, bot onboarding, WeChat QR, MCP editor, keyboard
   help). The header now picks up the Astryx theme default
   (`--astryx-dialog-padding`, 16px).

   Why call sites instead of a shared default: #1688 removed the
   `@maka/ui` compatibility layer, so the padding decision now lives at
   the call sites — there is no adapter left to fix. Each dialog keeps
   `LayoutContent padding={0}` and its own body inset, so no body spacing
   changes; scoping the fix to the header leaves every other inset
   identical.

<!-- The problem this solves and the outcome it produces. If the approach
is not the obvious one, say why. Link issues: "Closes #N" when this PR
completes the issue, "Refs #N" for context only. -->

## Verification

   - `npm run lint` — clean (2423 files)
   - `npm run format:check` — clean (1321 files)
   - `npm run typecheck` — all 10 workspaces pass. 
   - `npm --workspace @maka/ui run build` — pass

<!-- The checks you actually ran and their results. Name relevant checks
you did not run. For user-visible changes, attach the lightest evidence
that demonstrates the behavior (screenshot, recording, or command output). -->

<!--
Add a section only when it changes how this PR should be reviewed,
released, or operated, and name it after the real risk: e.g.
Breaking change, Migration, Rollout, Root cause, Security, Review focus.
If work intentionally remains, open as a draft and track it with a
task list under its own section.
-->

<img width="2476" height="1626" alt="image" src="https://github.com/user-attachments/assets/32e6fe6d-358f-4cc2-b739-0c95981d0988" />
