### PR TITLE
feat(ui): split the composer add menu into upload, modes and skills

### DIFF
--- a/apps/desktop/e2e/composer-mode-indicator.spec.ts
+++ b/apps/desktop/e2e/composer-mode-indicator.spec.ts
@@ -28,7 +28,7 @@ async function enableMode(
   mode: 'plan' | 'swarm',
   label: 'Plan' | 'Swarm',
 ): Promise<Locator> {
-  await page.getByRole('button', { name: '添加' }).click();
+  await page.getByRole('button', { name: '模式' }).click();
   await page.getByRole('menuitemcheckbox', { name: label }).click();
   await page.keyboard.press('Escape');
   const indicator = page.locator(

--- a/apps/desktop/e2e/composer-toolbar-controls.spec.ts
+++ b/apps/desktop/e2e/composer-toolbar-controls.spec.ts
@@ -25,7 +25,7 @@ test('the Skills picker writes the same chips the slash popup does', async ({
   const trigger = page.getByRole('button', { name: '技能' });
   await trigger.click();
 
-  const panel = page.getByRole('dialog', { name: '技能选择' });
+  const panel = page.getByRole('group', { name: '技能选择' });
   await expect(panel).toBeVisible();
   // Search narrows the catalog; the picker filters by name/id/description.
   await panel.getByRole('textbox', { name: '搜索技能…' }).fill('Project Only');

--- a/apps/desktop/e2e/composer-toolbar-controls.spec.ts
+++ b/apps/desktop/e2e/composer-toolbar-controls.spec.ts
@@ -1,0 +1,54 @@
+import { expect, test } from './fixtures';
+
+/**
+ * PR-COMPOSER-TOOLBAR-SPLIT: the composer's single ＋ menu became three named
+ * controls — upload / modes+expert teams / skills. The mode menu itself is
+ * covered by composer-mode-indicator.spec.ts; this spec pins the two surfaces
+ * that menu never had: the standalone upload trigger, and the Skills picker
+ * writing into the SAME structured draft the `/` popup owns
+ * (composer-skill-invocation.spec.ts covers the `/` side).
+ */
+test('the toolbar exposes upload, modes and skills as separate triggers', async ({
+  invocableSkillsWindow: page,
+}) => {
+  const controls = page.locator('.maka-composer-left-controls');
+  await expect(controls.getByRole('button', { name: '添加文件或目录' })).toBeVisible();
+  await expect(controls.getByRole('button', { name: '模式' })).toBeVisible();
+  await expect(controls.getByRole('button', { name: '技能' })).toBeVisible();
+  // The retired ＋ trigger must not linger beside them.
+  await expect(controls.getByRole('button', { name: '添加', exact: true })).toHaveCount(0);
+});
+
+test('the Skills picker writes the same chips the slash popup does', async ({
+  invocableSkillsWindow: page,
+}) => {
+  const trigger = page.getByRole('button', { name: '技能' });
+  await trigger.click();
+
+  const panel = page.getByRole('dialog', { name: '技能选择' });
+  await expect(panel).toBeVisible();
+  // Search narrows the catalog; the picker filters by name/id/description.
+  await panel.getByRole('textbox', { name: '搜索技能…' }).fill('Project Only');
+  const option = panel.getByRole('checkbox', { name: /Project Only/ });
+  await expect(option).toHaveAttribute('aria-checked', 'false');
+  await option.click();
+  await expect(option).toHaveAttribute('aria-checked', 'true');
+
+  // Selecting produces the same chip the `/` popup produces, and the trigger
+  // carries the count so an active selection is legible with the panel closed.
+  const chip = page.locator('.maka-composer-skill-chip');
+  await expect(chip).toContainText('Project Only');
+  await expect(page.locator('.maka-composer-skill-trigger-count')).toHaveText('1');
+
+  // Esc closes the panel and returns focus to the trigger it came from.
+  await page.keyboard.press('Escape');
+  await expect(panel).toHaveCount(0);
+  await expect(trigger).toBeFocused();
+  await expect(chip).toContainText('Project Only');
+
+  // 清除全部 drops the whole selection, chips included.
+  await trigger.click();
+  await page.getByRole('button', { name: '清除全部' }).click();
+  await expect(chip).toHaveCount(0);
+  await expect(page.locator('.maka-composer-skill-trigger-count')).toHaveCount(0);
+});

--- a/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/renderer-utility-primitives-contract.test.ts
@@ -323,9 +323,17 @@ describe('renderer utility surfaces use shared UI primitives', () => {
       );
     }
 
+    // PR-COMPOSER-TOOLBAR-SPLIT: the ＋ menu became three named triggers.
+    // The import-pending state moved onto the standalone upload IconButton,
+    // and the modes menu keeps the governed icon-only ghost/sm trigger shape
+    // the ＋ menu used to carry.
     assert.match(
       composer,
-      /button=\{\{[\s\S]*?pendingImportAction === 'pick'[\s\S]*?isIconOnly:\s*true,[\s\S]*?variant:\s*'ghost',[\s\S]*?size:\s*'sm'/,
+      /<IconButton[\s\S]*?className="maka-composer-upload-button"[\s\S]*?pendingImportAction === 'pick'/,
+    );
+    assert.match(
+      composer,
+      /button=\{\{[\s\S]*?label:\s*copy\.modesLabel,[\s\S]*?isIconOnly:\s*true,[\s\S]*?variant:\s*'ghost',[\s\S]*?size:\s*'sm'/,
     );
     assert.match(
       composer,

--- a/apps/desktop/src/renderer/styles/composer-mention.css
+++ b/apps/desktop/src/renderer/styles/composer-mention.css
@@ -84,6 +84,230 @@
   text-align: center;
 }
 
+/* PR-COMPOSER-TOOLBAR-SPLIT Skills picker — the toolbar button + its panel. Same overlay
+   discipline as the mention popup above: an ABSOLUTE layer anchored to the
+   trigger wrapper and bottom-anchored, so opening it never grows the composer
+   box (composer-constant-footprint-contract). The wrapper is the positioning
+   context so the panel tracks the button rather than the whole card. */
+.maka-composer-skill-picker {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+}
+
+.maka-composer-skill-trigger[data-selected="true"],
+.maka-composer-skill-trigger[data-open="true"] {
+  color: var(--foreground);
+  background: var(--state-selected-bg);
+}
+
+/* Selection count rides the trigger's top-right corner so an active skill
+   selection is legible without opening the panel. Pointer-events off: the
+   badge must never swallow a click meant for the button underneath it. */
+.maka-composer-skill-trigger-count {
+  position: absolute;
+  top: -2px;
+  right: -2px;
+  min-width: 14px;
+  height: 14px;
+  padding: 0 3px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: var(--radius-pill);
+  background: var(--control);
+  color: var(--control-foreground);
+  font-size: var(--font-size-2xs, 0.5rem);
+  font-weight: var(--font-weight-semibold);
+  line-height: 1;
+  pointer-events: none;
+}
+
+.maka-composer-skill-panel {
+  position: absolute;
+  left: 0;
+  bottom: calc(100% + var(--space-2));
+  width: min(340px, calc(100vw - var(--space-8)));
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-1);
+  padding: var(--space-1-5);
+}
+
+.maka-composer-skill-panel-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-2);
+  padding: 0 var(--space-1);
+}
+
+.maka-composer-skill-panel-hint {
+  min-width: 0;
+  flex: 1 1 auto;
+  color: var(--muted-foreground);
+  font-size: var(--font-size-caption);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.maka-composer-skill-panel-actions {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-0-5);
+}
+
+.maka-composer-skill-panel-action {
+  appearance: none;
+  height: 20px;
+  padding: 0 var(--space-1-5);
+  border: none;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--link);
+  font-size: var(--font-size-caption);
+  font-weight: var(--font-weight-medium);
+  white-space: nowrap;
+  transition: background var(--duration-base) var(--ease-out-strong);
+}
+
+.maka-composer-skill-panel-action:hover:not(:disabled) {
+  background: var(--state-hover-bg);
+}
+
+.maka-composer-skill-panel-action:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: var(--focus-ring-offset);
+}
+
+.maka-composer-skill-panel-action:disabled {
+  color: var(--muted-foreground);
+  opacity: var(--opacity-disabled);
+}
+
+.maka-composer-skill-panel-search {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1-5);
+  padding: 0 var(--space-2);
+  height: 28px;
+  border: var(--border-width-hairline) solid var(--border);
+  border-radius: var(--radius-control);
+  color: var(--muted-foreground);
+}
+
+.maka-composer-skill-panel-search:focus-within {
+  border-color: oklch(from var(--focus-ring) l c h / 0.45);
+}
+
+.maka-composer-skill-panel-search-input {
+  min-width: 0;
+  flex: 1 1 auto;
+  appearance: none;
+  border: none;
+  outline: none;
+  background: transparent;
+  color: var(--foreground);
+  font-family: var(--font-default);
+  font-size: var(--font-size-ui);
+}
+
+.maka-composer-skill-panel-search-input::placeholder {
+  color: var(--muted-foreground);
+}
+
+.maka-composer-skill-panel-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: var(--space-0-5);
+  max-height: 240px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+}
+
+.maka-composer-skill-panel-option {
+  appearance: none;
+  width: 100%;
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-2);
+  padding: var(--space-1-5) var(--space-2);
+  border: none;
+  border-radius: var(--radius-control);
+  background: transparent;
+  color: var(--foreground);
+  text-align: left;
+  transition: background var(--duration-base) var(--ease-out-strong);
+}
+
+.maka-composer-skill-panel-option:hover {
+  background: var(--muted);
+}
+
+.maka-composer-skill-panel-option:focus-visible {
+  outline: var(--focus-ring-width) solid var(--focus-ring);
+  outline-offset: calc(var(--focus-ring-offset) * -1);
+}
+
+.maka-composer-skill-panel-box {
+  flex: 0 0 auto;
+  width: 14px;
+  height: 14px;
+  margin-top: 1px;
+  display: grid;
+  place-items: center;
+  border: var(--border-width-hairline) solid var(--border-strong, var(--border));
+  /* One step tighter than --radius-control so a 14px box reads as a checkbox
+     rather than a radio, matching the Astryx checkbox items in the modes menu
+     next to it. */
+  border-radius: calc(var(--radius-control) - 2px);
+  color: var(--control-foreground);
+}
+
+.maka-composer-skill-panel-option[data-checked="true"] .maka-composer-skill-panel-box {
+  border-color: transparent;
+  background: var(--control);
+}
+
+.maka-composer-skill-panel-text {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.maka-composer-skill-panel-name {
+  min-width: 0;
+  font-size: var(--font-size-ui);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.maka-composer-skill-panel-secondary {
+  min-width: 0;
+  color: var(--muted-foreground);
+  font-size: var(--font-size-caption);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.maka-composer-skill-panel-secondary:empty {
+  display: none;
+}
+
+.maka-composer-skill-panel-status {
+  padding: var(--space-3) var(--space-2);
+  color: var(--muted-foreground);
+  font-size: var(--font-size-caption);
+  text-align: center;
+}
+
 .maka-composer-skill-chips {
   display: flex;
   flex-wrap: wrap;

--- a/apps/desktop/src/renderer/styles/composer-mention.css
+++ b/apps/desktop/src/renderer/styles/composer-mention.css
@@ -108,18 +108,20 @@
   position: absolute;
   top: -2px;
   right: -2px;
-  min-width: 14px;
-  height: 14px;
-  padding: 0 3px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 var(--space-0-5);
   display: inline-flex;
   align-items: center;
   justify-content: center;
   border-radius: var(--radius-pill);
   background: var(--control);
   color: var(--control-foreground);
-  font-size: var(--font-size-2xs, 0.5rem);
+  /* --font-size-caption is the smallest governed size (typography-converge
+     contract), so the pill is sized to fit it rather than the reverse. */
+  font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
-  line-height: 1;
+  line-height: var(--leading-none);
   pointer-events: none;
 }
 
@@ -248,9 +250,12 @@
   background: var(--muted);
 }
 
+/* The row fills the panel's inner width, so the focus ring sits on the row
+   itself with the shared offset — a negative inset would clip against the
+   panel edge and diverges from the focus-ring recipe. */
 .maka-composer-skill-panel-option:focus-visible {
   outline: var(--focus-ring-width) solid var(--focus-ring);
-  outline-offset: calc(var(--focus-ring-offset) * -1);
+  outline-offset: var(--focus-ring-offset);
 }
 
 .maka-composer-skill-panel-box {

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -191,16 +191,21 @@ const baseComposerProps: ComposerProps = {
   permissionMode: 'ask',
   onPermissionModeChange: noop,
   // Fidelity: production app-shell always wires these (app-shell.tsx
-  // ~1851-1960), so the daily composer renders the ＋ menu, the Plan
-  // switch, and the Swarm switch. Omitting them here understated the
-  // persistent element count in every shell story. expertTeams stays
-  // empty — most users have none configured; the ＋ menu shows just the
-  // attachment item then, as it does for them.
+  // ~1851-1960), so the daily composer renders the upload button, the
+  // modes menu (Plan / Swarm), and the Skills picker. Omitting them here
+  // understated the persistent element count in every shell story.
+  // expertTeams stays empty — most users have none configured; the modes
+  // menu then shows just the switches, as it does for them.
   onPickAttachments: noop,
   planModeActive: false,
   onPlanModeChange: noop,
   swarmModeActive: false,
   onSwarmModeChange: noop,
+  mentionSkills: [
+    { ref: 'user:pdf', id: 'pdf', name: 'PDF 工具', description: '读取、拆分与合并 PDF' },
+    { ref: 'user:commit', id: 'commit', name: 'Commit', description: '生成提交信息' },
+    { ref: 'project:review', id: 'review', name: 'Code Review', description: '按仓库规范审查改动' },
+  ],
   workspacePicker: {
     label: 'maka-agent',
     branch: 'opencode/storybook-surface-coverage',

--- a/packages/ui/src/__tests__/composer-skill-picker.test.tsx
+++ b/packages/ui/src/__tests__/composer-skill-picker.test.tsx
@@ -1,0 +1,78 @@
+import { strict as assert } from 'node:assert';
+import { describe, it } from 'node:test';
+import type { ReactNode } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { UiLocale } from '@maka/core';
+import { LocaleProvider } from '../locale-context.js';
+import {
+  ComposerSkillPicker,
+  composerSkillKey,
+  filterComposerSkills,
+} from '../composer-skill-picker.js';
+
+function render(locale: UiLocale, children: ReactNode): string {
+  return renderToStaticMarkup(<LocaleProvider locale={locale}>{children}</LocaleProvider>);
+}
+
+const skills = [
+  { ref: 'user:pdf', id: 'pdf', name: 'PDF 工具', description: '读取与拆分 PDF' },
+  { id: 'docx', name: 'Word 文档', description: 'Create and edit .docx files' },
+  { id: 'commit', name: 'Commit' },
+];
+
+describe('composer skill picker', () => {
+  it('keys a selection by its scope-aware ref, falling back to the id', () => {
+    assert.equal(composerSkillKey({ ref: 'User:PDF', id: 'pdf' }), 'user:pdf');
+    assert.equal(composerSkillKey({ id: 'Commit' }), 'commit');
+  });
+
+  it('filters case-insensitively across id, name and description', () => {
+    assert.deepEqual(
+      filterComposerSkills(skills, 'DOCX').map((skill) => skill.id),
+      ['docx'],
+    );
+    assert.deepEqual(
+      filterComposerSkills(skills, '拆分').map((skill) => skill.id),
+      ['pdf'],
+    );
+    // A blank query is not a filter — it returns the full catalog.
+    assert.equal(filterComposerSkills(skills, '  ').length, skills.length);
+    assert.equal(filterComposerSkills(skills, 'nothing-matches').length, 0);
+  });
+
+  it('renders a closed trigger with the selection count and no panel', () => {
+    const markup = render(
+      'zh',
+      <ComposerSkillPicker
+        skills={skills}
+        selected={[{ ref: 'user:pdf', id: 'pdf', name: 'PDF 工具' }]}
+        onToggle={() => {}}
+        onSelectAll={() => {}}
+        onClearAll={() => {}}
+      />,
+    );
+    assert.match(markup, /maka-composer-skill-trigger/);
+    assert.match(markup, /aria-label="技能"/);
+    assert.match(markup, /data-selected="true"/);
+    assert.match(markup, /maka-composer-skill-trigger-count[^>]*>1</);
+    // Closed by default: the panel must not ship in the resting markup, so it
+    // cannot contribute to the composer's constant footprint.
+    assert.doesNotMatch(markup, /maka-composer-skill-panel/);
+    assert.match(markup, /aria-expanded="false"/);
+  });
+
+  it('localizes the trigger', () => {
+    const en = render(
+      'en',
+      <ComposerSkillPicker
+        skills={skills}
+        selected={[]}
+        onToggle={() => {}}
+        onSelectAll={() => {}}
+        onClearAll={() => {}}
+      />,
+    );
+    assert.match(en, /aria-label="Skills"/);
+    assert.doesNotMatch(en, /maka-composer-skill-trigger-count/);
+  });
+});

--- a/packages/ui/src/__tests__/conversation-localization.test.tsx
+++ b/packages/ui/src/__tests__/conversation-localization.test.tsx
@@ -133,21 +133,79 @@ describe('localized conversation journey', () => {
     assert.match(en, /Go to model settings/);
   });
 
-  it('keeps Plan Mode out of the toolbar and reachable from the ＋ menu (#1433)', () => {
+  it('keeps Plan Mode out of the toolbar and reachable from the modes menu (#1433)', () => {
     const markup = render(
       'zh',
       <Composer onSend={() => {}} onStop={() => {}} onPickAttachments={() => {}} onPlanModeChange={() => {}} />,
     );
     // The toolbar no longer carries a standalone Plan switch…
     assert.doesNotMatch(markup, /maka-composer-plan-mode-control/);
-    // …but the ＋ trigger is present so the mode stays reachable from the menu.
-    assert.match(markup, /aria-label="添加"/);
+    // …but the modes trigger is present so the mode stays reachable.
+    assert.match(markup, /aria-label="模式"/);
   });
 
-  it('keeps the ＋ menu available when only mode switches are wired', () => {
+  it('keeps the modes menu available when only mode switches are wired', () => {
     const markup = render('zh', <Composer onSend={() => {}} onStop={() => {}} onPlanModeChange={() => {}} />);
-    assert.match(markup, /aria-label="添加"/);
+    assert.match(markup, /aria-label="模式"/);
     assert.doesNotMatch(markup, /maka-composer-plan-mode-control/);
+  });
+
+  it('splits upload, modes and skills into three named toolbar buttons (PR-COMPOSER-TOOLBAR-SPLIT)', () => {
+    const markup = render(
+      'zh',
+      <Composer
+        onSend={() => {}}
+        onStop={() => {}}
+        onPickAttachments={() => {}}
+        onPlanModeChange={() => {}}
+        mentionSkills={[{ id: 'skill-a', name: '技能 A', description: '描述 A' }]}
+      />,
+    );
+    // Upload is its own control with an upload mark — no longer an item
+    // buried in a generic ＋ menu.
+    assert.match(markup, /maka-composer-upload-button/);
+    assert.match(markup, /aria-label="添加文件或目录"/);
+    assert.match(markup, /class="lucide lucide-upload"/);
+    // Modes + expert teams keep one menu of their own.
+    assert.match(markup, /aria-label="模式"/);
+    assert.match(markup, /class="lucide lucide-workflow"/);
+    // Skills get a dedicated trigger; the panel itself opens on click.
+    assert.match(markup, /maka-composer-skill-trigger/);
+    assert.match(markup, /aria-label="技能"/);
+    assert.doesNotMatch(markup, /maka-composer-skill-panel/);
+    // The retired ＋ trigger is gone.
+    assert.doesNotMatch(markup, /aria-label="添加"[^>]*>/);
+
+    const en = render(
+      'en',
+      <Composer
+        onSend={() => {}}
+        onStop={() => {}}
+        onPickAttachments={() => {}}
+        onPlanModeChange={() => {}}
+        mentionSkills={[]}
+      />,
+    );
+    assert.match(en, /aria-label="Add file or directory"/);
+    assert.match(en, /aria-label="Modes"/);
+    assert.match(en, /aria-label="Skills"/);
+  });
+
+  it('hides the upload button while a turn is streaming but keeps modes reachable', () => {
+    const markup = render(
+      'zh',
+      <Composer
+        onSend={() => {}}
+        onStop={() => {}}
+        streaming
+        onPickAttachments={() => {}}
+        onPlanModeChange={() => {}}
+      />,
+    );
+    // Import no-ops mid-turn, so upload is disabled rather than removed…
+    assert.match(markup, /maka-composer-upload-button[^>]*aria-disabled="true"|aria-disabled="true"[^>]*maka-composer-upload-button/);
+    // …while the modes menu stays usable (#1444).
+    assert.match(markup, /aria-label="模式"/);
   });
 
   it('shows a quiet Plan indicator next to permission mode only while Plan is active', () => {
@@ -215,7 +273,7 @@ describe('localized conversation journey', () => {
     assert.match(en, /Graph mode is on/);
   });
 
-  it('keeps the ＋ menu reachable while streaming (#1444)', () => {
+  it('keeps the modes menu reachable while streaming (#1444)', () => {
     const markup = render(
       'zh',
       <Composer
@@ -229,10 +287,10 @@ describe('localized conversation journey', () => {
         onSwarmModeChange={() => {}}
       />,
     );
-    // Menu trigger must stay mounted mid-turn so attachments, expert teams,
-    // and Plan/Swarm remain reachable from the ＋ menu (import itself stays
-    // blocked mid-stream by runImportAction / the disabled attach item).
-    assert.match(markup, /aria-label="添加"/);
+    // The modes trigger must stay mounted mid-turn so expert teams and
+    // Plan/Swarm remain reachable (import itself stays blocked mid-stream by
+    // runImportAction / the disabled upload button).
+    assert.match(markup, /aria-label="模式"/);
   });
 
   it('keeps Swarm Mode out of the toolbar (#1433)', () => {
@@ -241,7 +299,7 @@ describe('localized conversation journey', () => {
       <Composer onSend={() => {}} onStop={() => {}} onPickAttachments={() => {}} onSwarmModeChange={() => {}} />,
     );
     assert.doesNotMatch(markup, /maka-composer-swarm-mode-control/);
-    assert.match(markup, /aria-label="添加"/);
+    assert.match(markup, /aria-label="模式"/);
   });
 
   it('localizes question chrome while preserving raw values', () => {

--- a/packages/ui/src/composer-skill-picker.tsx
+++ b/packages/ui/src/composer-skill-picker.tsx
@@ -1,0 +1,215 @@
+/**
+ * Composer Skills button (PR-COMPOSER-TOOLBAR-SPLIT) — the standalone toolbar
+ * affordance for choosing Skills. Until now Skills were reachable only by
+ * typing `/` in the textarea, which is discoverable once you know it exists
+ * and invisible otherwise. This button surfaces the same structured selection
+ * the `/` popup produces (`useComposerSkillDraft` chips), so both paths
+ * converge on one draft state instead of a second selection model.
+ *
+ * The panel is an ABSOLUTE overlay anchored to its own trigger wrapper and
+ * bottom-anchored above it, so it never grows the composer box
+ * (composer-constant-footprint-contract), same discipline as the mention popup.
+ *
+ * Interaction: click the trigger to open, type to filter, click a row to
+ * toggle, Esc or an outside click to close. Rows are `role="checkbox"`
+ * buttons — multi-select with no implicit send, matching the human-in-the-loop
+ * rule the `/` popup already follows.
+ */
+
+import { useEffect, useId, useMemo, useRef, useState } from 'react';
+import { IconButton } from '@astryxdesign/core';
+import { Check, Search, Sparkles } from './icons.js';
+import { useUiLocale } from './locale-context.js';
+import { getConversationCopy } from './conversation-copy.js';
+
+export interface ComposerSkillOption {
+  /** Stable scope-aware ref; falls back to `id` for older catalog entries. */
+  ref?: string;
+  id: string;
+  name: string;
+  description?: string;
+}
+
+/** Selection identity — the same `ref ?? id` key the skill draft dedupes on. */
+export function composerSkillKey(skill: { ref?: string; id: string }): string {
+  return (skill.ref ?? skill.id).toLowerCase();
+}
+
+/** Case-insensitive id/name/description filter for the panel's search field. */
+export function filterComposerSkills<T extends ComposerSkillOption>(
+  skills: readonly T[],
+  query: string,
+): T[] {
+  const needle = query.trim().toLowerCase();
+  if (!needle) return [...skills];
+  return skills.filter((skill) =>
+    `${skill.id} ${skill.name} ${skill.description ?? ''}`.toLowerCase().includes(needle),
+  );
+}
+
+export function ComposerSkillPicker(props: {
+  skills: readonly ComposerSkillOption[];
+  selected: readonly { ref?: string; id: string; name: string }[];
+  disabled?: boolean;
+  onToggle(skill: ComposerSkillOption, selected: boolean): void;
+  /** Select every skill currently visible under the search filter. */
+  onSelectAll(skills: readonly ComposerSkillOption[]): void;
+  onClearAll(): void;
+}) {
+  const copy = getConversationCopy(useUiLocale()).composer.skillPicker;
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const panelId = useId();
+
+  useEffect(() => {
+    if (props.disabled) setOpen(false);
+  }, [props.disabled]);
+
+  useEffect(() => {
+    if (!open) return undefined;
+    const frame = window.requestAnimationFrame(() => searchRef.current?.focus());
+    function onPointerDown(event: MouseEvent) {
+      if (!rootRef.current?.contains(event.target as Node | null)) setOpen(false);
+    }
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== 'Escape') return;
+      // Stop here so Esc closing the panel can't also interrupt a stream or
+      // clear an unrelated overlay behind it.
+      event.stopPropagation();
+      setOpen(false);
+      // Focus came from the trigger and must go back to it — otherwise a
+      // keyboard user lands at the top of the document after dismissing.
+      triggerRef.current?.focus();
+    }
+    document.addEventListener('mousedown', onPointerDown);
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => {
+      window.cancelAnimationFrame(frame);
+      document.removeEventListener('mousedown', onPointerDown);
+      document.removeEventListener('keydown', onKeyDown, true);
+    };
+  }, [open]);
+
+  const selectedKeys = useMemo(
+    () => new Set(props.selected.map(composerSkillKey)),
+    [props.selected],
+  );
+  const visible = useMemo(
+    () => filterComposerSkills(props.skills, query),
+    [props.skills, query],
+  );
+  const selectedCount = props.selected.length;
+  const allVisibleSelected =
+    visible.length > 0 && visible.every((skill) => selectedKeys.has(composerSkillKey(skill)));
+
+  return (
+    <div className="maka-composer-skill-picker" ref={rootRef}>
+      <IconButton
+        ref={triggerRef}
+        variant="ghost"
+        type="button"
+        size="sm"
+        className="maka-composer-skill-trigger"
+        data-open={open ? 'true' : undefined}
+        data-selected={selectedCount > 0 ? 'true' : undefined}
+        isDisabled={props.disabled}
+        label={copy.label}
+        tooltip={selectedCount > 0 ? copy.selectedCount(selectedCount) : copy.title}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-controls={open ? panelId : undefined}
+        onClick={() => setOpen((value) => !value)}
+        icon={<Sparkles size={15} aria-hidden="true" />}
+      />
+      {selectedCount > 0 ? (
+        <span className="maka-composer-skill-trigger-count" aria-hidden="true">
+          {selectedCount}
+        </span>
+      ) : null}
+      {open ? (
+        <div
+          id={panelId}
+          role="dialog"
+          aria-label={copy.panelAriaLabel}
+          className="maka-composer-skill-panel z-[var(--z-overlay)] rounded-md bg-popover text-popover-foreground shadow-maka-panel"
+        >
+          <div className="maka-composer-skill-panel-header">
+            <span className="maka-composer-skill-panel-hint">{copy.autoHint}</span>
+            <div className="maka-composer-skill-panel-actions">
+              <button
+                type="button"
+                className="maka-composer-skill-panel-action"
+                disabled={visible.length === 0 || allVisibleSelected}
+                onClick={() => props.onSelectAll(visible)}
+              >
+                {copy.selectAll}
+              </button>
+              <button
+                type="button"
+                className="maka-composer-skill-panel-action"
+                disabled={selectedCount === 0}
+                onClick={() => props.onClearAll()}
+              >
+                {copy.clearAll}
+              </button>
+            </div>
+          </div>
+          <div className="maka-composer-skill-panel-search">
+            <Search size={13} aria-hidden="true" />
+            <input
+              ref={searchRef}
+              type="text"
+              value={query}
+              className="maka-composer-skill-panel-search-input"
+              placeholder={copy.searchPlaceholder}
+              aria-label={copy.searchPlaceholder}
+              autoComplete="off"
+              spellCheck={false}
+              onChange={(event) => setQuery(event.currentTarget.value)}
+            />
+          </div>
+          {/* The list carries no aria-label of its own — the dialog above
+              already names the region, and a second identical label doubles
+              the announcement on entry. */}
+          {visible.length === 0 ? (
+            <div className="maka-composer-skill-panel-status">
+              {props.skills.length === 0 ? copy.empty : copy.noMatches}
+            </div>
+          ) : (
+            <ul className="maka-composer-skill-panel-list">
+              {visible.map((skill) => {
+                const key = composerSkillKey(skill);
+                const checked = selectedKeys.has(key);
+                return (
+                  <li key={key}>
+                    <button
+                      type="button"
+                      role="checkbox"
+                      aria-checked={checked}
+                      data-checked={checked ? 'true' : undefined}
+                      className="maka-composer-skill-panel-option"
+                      onClick={() => props.onToggle(skill, !checked)}
+                    >
+                      <span className="maka-composer-skill-panel-box" aria-hidden="true">
+                        {checked ? <Check size={11} aria-hidden="true" /> : null}
+                      </span>
+                      <span className="maka-composer-skill-panel-text">
+                        <span className="maka-composer-skill-panel-name">{skill.name}</span>
+                        <span className="maka-composer-skill-panel-secondary">
+                          {skill.description ?? skill.id}
+                        </span>
+                      </span>
+                    </button>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/packages/ui/src/composer-skill-picker.tsx
+++ b/packages/ui/src/composer-skill-picker.tsx
@@ -118,7 +118,6 @@ export function ComposerSkillPicker(props: {
         isDisabled={props.disabled}
         label={copy.label}
         tooltip={selectedCount > 0 ? copy.selectedCount(selectedCount) : copy.title}
-        aria-haspopup="dialog"
         aria-expanded={open}
         aria-controls={open ? panelId : undefined}
         onClick={() => setOpen((value) => !value)}
@@ -132,7 +131,11 @@ export function ComposerSkillPicker(props: {
       {open ? (
         <div
           id={panelId}
-          role="dialog"
+          // A labelled group, NOT role="dialog": dialog semantics belong to
+          // the Astryx Dialog primitive that owns focus trapping, Escape and
+          // the top layer (dialog-source-contract). This is a disclosure the
+          // trigger's aria-expanded/aria-controls already describe.
+          role="group"
           aria-label={copy.panelAriaLabel}
           className="maka-composer-skill-panel z-[var(--z-overlay)] rounded-md bg-popover text-popover-foreground shadow-maka-panel"
         >
@@ -171,7 +174,7 @@ export function ComposerSkillPicker(props: {
               onChange={(event) => setQuery(event.currentTarget.value)}
             />
           </div>
-          {/* The list carries no aria-label of its own — the dialog above
+          {/* The list carries no aria-label of its own — the group above
               already names the region, and a second identical label doubles
               the announcement on entry. */}
           {visible.length === 0 ? (

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -11,7 +11,7 @@ import {
   type ReactNode,
 } from 'react';
 import { useMountedRef } from './use-mounted-ref.js';
-import { ArrowUp, Blocks, Mic, Paperclip, Pencil, Plus, Volume2, X } from './icons.js';
+import { ArrowUp, Blocks, Mic, Pencil, Upload, Volume2, Workflow, X } from './icons.js';
 import { ChatModelSwitcher, ModelChipStatic, NewChatModelPicker } from './chat-model-switcher.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
@@ -45,6 +45,7 @@ import { AttachmentFileCard } from './attachment-file-card.js';
 import { QuoteRefChip } from './quote-ref-chip.js';
 import { Kbd } from './primitives/kbd.js';
 import { PermissionModeSelect } from './permission-mode-menu.js';
+import { ComposerSkillPicker, type ComposerSkillOption } from './composer-skill-picker.js';
 
 const COMPOSER_MAX_HEIGHT = 240;
 
@@ -92,8 +93,9 @@ export const Composer = forwardRef<
     /**
      * When true, a turn is in flight — live output OR (with `processing`) the
      * pre-first-token wait. Toolbar swaps to a working hint ("Maka 正在回答…" or
-     * "正在处理…") and Send becomes Stop. The ＋ menu stays reachable (#1444);
-     * import actions remain blocked mid-turn until the runtime accepts them.
+     * "正在处理…") and Send becomes Stop. The modes menu and Skills picker stay
+     * reachable (#1444); import stays blocked mid-turn, so the upload button is
+     * disabled until the runtime accepts it again.
      */
     streaming?: boolean;
     /**
@@ -132,9 +134,9 @@ export const Composer = forwardRef<
      * case a large paste behaves like any other paste.
      */
     onPasteAsQuote?(input: { text: string; label?: string }): void;
-    /** Built-in expert teams offered under 专家团 in the "+" menu. */
+    /** Built-in expert teams offered under 专家团 in the modes menu. */
     expertTeams?: readonly { id: string; name: string; description?: string }[];
-    /** Start a new expert-team session from the "+" menu. */
+    /** Start a new expert-team session from the modes menu. */
     onStartExpertTeam?(teamId: string): void;
     modelLabel?: string;
     activeSession?: SessionSummary;
@@ -238,9 +240,10 @@ export const Composer = forwardRef<
     /**
      * Composer mention popups. Both are optional and the whole feature no-ops
      * when absent (SSR contracts render Composer with minimal props):
-     *   - `mentionSkills` powers the `/` popup — pass only ENABLED skills; the
-     *     composer filters them client-side by id/name and creates a structured
-     *     Skill Chip (human-in-the-loop, never auto-send).
+     *   - `mentionSkills` powers the `/` popup AND the toolbar Skills picker
+     *     (PR-COMPOSER-TOOLBAR-SPLIT) — pass only ENABLED skills; the composer
+     *     filters them client-side by id/name and creates a structured Skill
+     *     Chip (human-in-the-loop, never auto-send).
      *   - `onSearchMentionFiles` powers the `@` popup — the composer debounces
      *     the query, and selecting a file inserts `@<relativePath> `.
      */
@@ -815,114 +818,142 @@ export const Composer = forwardRef<
         )}
         <div className="maka-composer-toolbar composerActions" data-streaming={props.streaming ? 'true' : undefined}>
           <div className="maka-composer-left-controls">
-            {/* #1444: keep the ＋ menu reachable while streaming. Import
-                actions still no-op mid-turn (`runImportAction` / drop
-                target), so the attach item is disabled rather than
-                vanishing the whole menu (and Plan/Swarm / expert teams). */}
-            {(props.onPickAttachments || (props.expertTeams?.length ?? 0) > 0 || props.onPlanModeChange || props.onSwarmModeChange || props.onGraphModeChange) ? (
+            {/* PR-COMPOSER-TOOLBAR-SPLIT: the single ＋ menu is split into
+                three named controls — upload / modes+expert teams / skills —
+                so each is one click away and readable at rest instead of
+                hidden behind a generic plus. Import still no-ops mid-turn
+                (`runImportAction` / drop target), so the upload button is
+                disabled while streaming rather than vanishing. */}
+            {props.onPickAttachments ? (
+              <IconButton
+                variant="ghost"
+                type="button"
+                size="sm"
+                className="maka-composer-upload-button"
+                isDisabled={props.disabled || props.streaming === true || importActionBusy}
+                aria-busy={pendingImportAction === 'pick' ? 'true' : undefined}
+                data-pending={pendingImportAction === 'pick' ? 'true' : undefined}
+                label={
+                  pendingImportAction === 'pick' ? copy.addingAttachment : copy.addFileOrDirectory
+                }
+                tooltip={
+                  pendingImportAction === 'pick' ? copy.addingAttachment : copy.uploadTitle
+                }
+                onClick={() => void runImportAction('pick', props.onPickAttachments)}
+                icon={<Upload size={15} aria-hidden="true" />}
+              />
+            ) : null}
+            {/* #1444 still holds for the modes menu: it stays reachable
+                mid-turn so Plan/Swarm/Graph and the expert teams never
+                disappear while a turn is in flight. */}
+            {(props.onPlanModeChange
+              || props.onSwarmModeChange
+              || props.onGraphModeChange
+              || (props.expertTeams?.length ?? 0) > 0) ? (
               <DropdownMenu
                 placement="above"
                 button={{
-                  label:
-                    pendingImportAction === 'pick'
-                      ? copy.addingAttachment
-                      : copy.add,
-                  icon: <Plus size={15} aria-hidden="true" />,
+                  label: copy.modesLabel,
+                  icon: <Workflow size={15} aria-hidden="true" />,
                   isIconOnly: true,
                   variant: 'ghost',
                   size: 'sm',
-                  isDisabled: props.disabled || importActionBusy,
-                  'aria-busy': importActionBusy ? 'true' : undefined,
-                  'data-pending': importActionBusy ? 'true' : undefined,
-                  tooltip: copy.addTitle,
+                  isDisabled: props.disabled,
+                  tooltip: copy.modesTitle,
                 }}
-                className="maka-composer-context-menu"
+                className="maka-composer-modes-menu"
               >
-                  {props.onPickAttachments ? (
-                    <DropdownMenuItem
-                      isDisabled={props.disabled || props.streaming === true || importActionBusy}
-                      onClick={() => void runImportAction('pick', props.onPickAttachments)}
-                      icon={<Paperclip size={13} aria-hidden="true" />}
-                      label={copy.addFileOrDirectory}
+                  {/* #1433 subtraction still applies: Plan/Swarm/Graph are
+                      switch items, not standalone toolbar switches — the
+                      toolbar keeps one named trigger per capability. */}
+                  {props.onPlanModeChange ? (
+                    <DropdownMenuCheckboxItem
+                      label={copy.planModeLabel}
+                      value={props.planModeActive === true}
+                      isDisabled={
+                        props.disabled
+                        || props.planModePending === true
+                        || Boolean(props.planModeDisabledReason)
+                      }
+                      onChange={(checked) => {
+                        void props.onPlanModeChange?.(checked);
+                      }}
+                      aria-description={props.planModeDisabledReason
+                        ?? (props.planModeActive ? copy.disablePlanMode : copy.enablePlanMode)}
+                    />
+                  ) : null}
+                  {props.onSwarmModeChange ? (
+                    <DropdownMenuCheckboxItem
+                      label={copy.swarmModeLabel}
+                      value={props.swarmModeActive === true}
+                      isDisabled={
+                        props.disabled
+                        || props.swarmModePending === true
+                        || Boolean(props.swarmModeDisabledReason)
+                      }
+                      onChange={(checked) => {
+                        void props.onSwarmModeChange?.(checked);
+                      }}
+                      aria-description={props.swarmModeDisabledReason
+                        ?? (props.swarmModeActive ? copy.disableSwarmMode : copy.enableSwarmMode)}
+                    />
+                  ) : null}
+                  {props.onGraphModeChange ? (
+                    <DropdownMenuCheckboxItem
+                      label={copy.graphModeLabel}
+                      value={props.graphModeActive === true}
+                      isDisabled={
+                        props.disabled
+                        || props.graphModePending === true
+                        || Boolean(props.graphModeDisabledReason)
+                      }
+                      onChange={(checked) => {
+                        void props.onGraphModeChange?.(checked);
+                      }}
+                      aria-description={props.graphModeDisabledReason
+                        ?? (props.graphModeActive ? copy.disableGraphMode : copy.enableGraphMode)}
                     />
                   ) : null}
                   {(props.expertTeams?.length ?? 0) > 0 ? (
                     <>
-                      <Divider orientation="horizontal" label={copy.expertTeam} />
-                        {props.expertTeams?.map((team) => (
-                          <DropdownMenuItem
-                            key={team.id}
-                            isDisabled={props.disabled}
-                            onClick={() => props.onStartExpertTeam?.(team.id)}
-                            icon={<Blocks size={13} aria-hidden="true" />}
-                            label={team.name}
-                            description={team.description}
-                          />
-                        ))}
-                    </>
-                  ) : null}
-                  {/* #1433 subtraction: Plan/Swarm live here as switch
-                      items instead of standalone toolbar switches — the
-                      toolbar keeps only add / permission / model / send. */}
-                  {props.onPlanModeChange || props.onSwarmModeChange || props.onGraphModeChange ? (
-                    <>
-                      {/* Separator only when an attachment/expert-team group
-                          precedes it — a modes-only menu must not lead with
-                          a divider (review P3). */}
-                      {props.onPickAttachments || (props.expertTeams?.length ?? 0) > 0 ? (
-                        <Divider orientation="horizontal" />
+                      {/* Heading only when a mode group precedes it — a
+                          teams-only menu must not lead with a divider. */}
+                      {props.onPlanModeChange || props.onSwarmModeChange || props.onGraphModeChange ? (
+                        <Divider orientation="horizontal" label={copy.expertTeam} />
                       ) : null}
-                      {props.onPlanModeChange ? (
-                        <DropdownMenuCheckboxItem
-                          label={copy.planModeLabel}
-                          value={props.planModeActive === true}
-                          isDisabled={
-                            props.disabled
-                            || props.planModePending === true
-                            || Boolean(props.planModeDisabledReason)
-                          }
-                          onChange={(checked) => {
-                            void props.onPlanModeChange?.(checked);
-                          }}
-                          aria-description={props.planModeDisabledReason
-                            ?? (props.planModeActive ? copy.disablePlanMode : copy.enablePlanMode)}
+                      {props.expertTeams?.map((team) => (
+                        <DropdownMenuItem
+                          key={team.id}
+                          isDisabled={props.disabled}
+                          onClick={() => props.onStartExpertTeam?.(team.id)}
+                          icon={<Blocks size={13} aria-hidden="true" />}
+                          label={team.name}
+                          description={team.description}
                         />
-                      ) : null}
-                      {props.onSwarmModeChange ? (
-                        <DropdownMenuCheckboxItem
-                          label={copy.swarmModeLabel}
-                          value={props.swarmModeActive === true}
-                          isDisabled={
-                            props.disabled
-                            || props.swarmModePending === true
-                            || Boolean(props.swarmModeDisabledReason)
-                          }
-                          onChange={(checked) => {
-                            void props.onSwarmModeChange?.(checked);
-                          }}
-                          aria-description={props.swarmModeDisabledReason
-                            ?? (props.swarmModeActive ? copy.disableSwarmMode : copy.enableSwarmMode)}
-                        />
-                      ) : null}
-                      {props.onGraphModeChange ? (
-                        <DropdownMenuCheckboxItem
-                          label={copy.graphModeLabel}
-                          value={props.graphModeActive === true}
-                          isDisabled={
-                            props.disabled
-                            || props.graphModePending === true
-                            || Boolean(props.graphModeDisabledReason)
-                          }
-                          onChange={(checked) => {
-                            void props.onGraphModeChange?.(checked);
-                          }}
-                          aria-description={props.graphModeDisabledReason
-                            ?? (props.graphModeActive ? copy.disableGraphMode : copy.enableGraphMode)}
-                        />
-                      ) : null}
+                      ))}
                     </>
                   ) : null}
               </DropdownMenu>
+            ) : null}
+            {/* PR-COMPOSER-TOOLBAR-SPLIT: Skills used to be reachable only by
+                typing `/`. The picker writes the same structured chips, so the
+                two paths share one draft instead of a second selection model.
+                Focus stays in the panel across toggles — unlike the `/` popup,
+                which returns to the textarea because it splices text there. */}
+            {props.mentionSkills ? (
+              <ComposerSkillPicker
+                skills={props.mentionSkills}
+                selected={skillDraft.skills}
+                disabled={props.disabled}
+                onToggle={(skill, selected) => {
+                  if (selected) skillDraft.add(skill);
+                  else skillDraft.remove(skill.ref ?? skill.id);
+                }}
+                onSelectAll={(skills: readonly ComposerSkillOption[]) => {
+                  for (const skill of skills) skillDraft.add(skill);
+                }}
+                onClearAll={() => skillDraft.clear(skillDraft.activeDraftKey())}
+              />
             ) : null}
             {/* PR-MOVE-PERMISSION-MODE: the static "通用" role chip
                 was replaced by the permission-mode dropdown — that
@@ -944,7 +975,7 @@ export const Composer = forwardRef<
               />
             ) : null}
             {/* #1433: active-mode indicators. The Plan/Swarm toggles live in
-                the ＋ menu (subtraction), so an ON mode would otherwise be
+                the modes menu (subtraction), so an ON mode would otherwise be
                 easy to miss without opening the menu. The indicator uses the
                 same quiet-text-button language as the permission select next
                 to it, WITHOUT a chevron: it cannot drop down. Clicking turns

--- a/packages/ui/src/conversation-copy.ts
+++ b/packages/ui/src/conversation-copy.ts
@@ -74,9 +74,25 @@ export interface ConversationCopy {
     selectModel: string;
     dropToImport: string;
     addingAttachment: string;
-    add: string;
-    addTitle: string;
     addFileOrDirectory: string;
+    /** Standalone upload button in the composer toolbar (PR-COMPOSER-TOOLBAR-SPLIT). */
+    uploadTitle: string;
+    /** Standalone Plan/Swarm/Graph + expert-team button in the toolbar (PR-COMPOSER-TOOLBAR-SPLIT). */
+    modesLabel: string;
+    modesTitle: string;
+    /** Standalone Skills picker button + its panel (PR-COMPOSER-TOOLBAR-SPLIT). */
+    skillPicker: {
+      label: string;
+      title: string;
+      panelAriaLabel: string;
+      searchPlaceholder: string;
+      autoHint: string;
+      selectAll: string;
+      clearAll: string;
+      empty: string;
+      noMatches: string;
+      selectedCount: (count: number) => string;
+    };
     switchDisabledStreaming: string;
     switchDisabledRunning: string;
     switchDisabledPermission: string;
@@ -323,7 +339,14 @@ const CONVERSATION_COPY = {
       sending: '正在发送…', importing: '正在导入…', sendLabel: '发送', stopLabel: '停止', stopping: '停止中…',
       streaming: 'Maka 正在回答…', processing: 'Maka 正在处理…', continuing: 'Maka 继续中…',
       interruptHint: '或点停止中断', addContext: '添加上下文', importText: '导入文本文件', attachFile: '附加文件', expertTeam: '专家团',
-      selectModel: '选择模型', dropToImport: '松开以导入文件内容', addingAttachment: '正在添加附件', add: '添加', addTitle: '添加文件、专家团…', addFileOrDirectory: '添加文件或目录',
+      selectModel: '选择模型', dropToImport: '松开以导入文件内容', addingAttachment: '正在添加附件', addFileOrDirectory: '添加文件或目录',
+      uploadTitle: '上传文件或目录', modesLabel: '模式', modesTitle: '协作模式与专家团',
+      skillPicker: {
+        label: '技能', title: '选择技能', panelAriaLabel: '技能选择', searchPlaceholder: '搜索技能…',
+        autoHint: '不选择时，Maka 自动匹配相关技能', selectAll: '全选', clearAll: '清除全部',
+        empty: '当前没有可用技能', noMatches: '没有匹配的技能',
+        selectedCount: (count) => `已选 ${count} 个技能`,
+      },
       switchDisabledStreaming: '当前对话正在流式输出，等结束后再切换模型。', switchDisabledRunning: '当前对话正在运行，等结束后再切换模型。', switchDisabledPermission: '当前有工具调用正在等待确认，处理后再切换模型。',
       planModeLabel: 'Plan', enablePlanMode: '开启 Plan Mode', disablePlanMode: '退出 Plan Mode',
       planModeOnTitle: 'Plan 模式已启用，点击关闭',
@@ -464,7 +487,14 @@ const CONVERSATION_COPY = {
       sending: 'Sending…', importing: 'Importing…', sendLabel: 'Send', stopLabel: 'Stop', stopping: 'Stopping…',
       streaming: 'Maka is responding…', processing: 'Maka is working…', continuing: 'Maka is continuing…',
       interruptHint: 'or click Stop to interrupt', addContext: 'Add context', importText: 'Import text file', attachFile: 'Attach file', expertTeam: 'Expert team',
-      selectModel: 'Choose model', dropToImport: 'Drop to import file contents', addingAttachment: 'Adding attachment', add: 'Add', addTitle: 'Add files or an expert team…', addFileOrDirectory: 'Add file or directory',
+      selectModel: 'Choose model', dropToImport: 'Drop to import file contents', addingAttachment: 'Adding attachment', addFileOrDirectory: 'Add file or directory',
+      uploadTitle: 'Upload a file or directory', modesLabel: 'Modes', modesTitle: 'Collaboration modes and expert teams',
+      skillPicker: {
+        label: 'Skills', title: 'Choose skills', panelAriaLabel: 'Skill selection', searchPlaceholder: 'Search skills…',
+        autoHint: 'Leave empty and Maka picks the relevant skills', selectAll: 'Select all', clearAll: 'Clear all',
+        empty: 'No skills available', noMatches: 'No matching skills',
+        selectedCount: (count) => `${count} skill${count === 1 ? '' : 's'} selected`,
+      },
       switchDisabledStreaming: 'Wait for the current response to finish before switching models.', switchDisabledRunning: 'Wait for the current run to finish before switching models.', switchDisabledPermission: 'Resolve the pending tool permission before switching models.',
       planModeLabel: 'Plan', enablePlanMode: 'Enable Plan Mode', disablePlanMode: 'Disable Plan Mode',
       planModeOnTitle: 'Plan mode is on — click to turn off',

--- a/packages/ui/src/icons.tsx
+++ b/packages/ui/src/icons.tsx
@@ -108,8 +108,10 @@ export {
   TextQuote,
   Timer,
   Trash2,
+  Upload,
   User,
   Volume2,
   Wifi,
+  Workflow,
   X,
 } from 'lucide-react';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -17,6 +17,7 @@ export * from './tool-activity/copy.js';
 export * from './tool-activity/sandbox-denial.js';
 export * from './chat-input-behavior.js';
 export * from './composer-mention-popup.js';
+export * from './composer-skill-picker.js';
 export * from './use-composer-skill-draft.js';
 export * from './use-mention-popup.js';
 export * from './runtime-resume-copy.js';


### PR DESCRIPTION
## Summary

The composer hid three unrelated capabilities behind one ＋ menu: file import, the Plan/Swarm/Graph switches with the 专家团 group, and — for Skills — nothing at all. Skills were reachable only by typing `/`, which is discoverable once you know it exists and invisible otherwise.

Each capability now gets its own named trigger in the composer toolbar:

- **Upload** — a direct button (Upload mark) that opens the file picker in one click instead of two. Import still no-ops mid-turn (`runImportAction` / drop target), so it disables while streaming rather than vanishing.
- **Modes** — one menu holding Plan / Swarm / Graph plus the 专家团 group. It stays reachable mid-turn (#1444), and #1433's subtraction still holds: the switches are menu items, not standalone toolbar switches. The active-mode indicator chips are unchanged.
- **Skills** — a picker panel with a search field, 全选 / 清除全部, and checkbox rows carrying name + description, plus a selection count on the trigger. It writes the **same** structured selection the `/` popup produces (`useComposerSkillDraft`), so both paths share one draft instead of a second selection model.

The panel is an absolute overlay anchored to its own trigger, so opening it never grows the composer box (composer-constant-footprint-contract) — the same discipline the mention popup follows. Esc / outside click dismiss it, and Esc returns focus to the trigger.

Copy is locale-aware in both zh and en; `composer.add` / `composer.addTitle` retire with the ＋ trigger they labelled.

## Verification

- `npm --workspace @maka/ui run typecheck` + clean build + `test:dist` — 290 passed, including the new `composer-skill-picker.test.ts` (key/filter helpers, closed-trigger markup, localization) and the updated `conversation-localization` contracts.
- Desktop `tsc -p tsconfig.renderer.json` and `tsconfig.storybook.json` — clean.
- Electron e2e (Playwright): new `e2e/composer-toolbar-controls.spec.ts` (2 tests — three separate triggers present with no ＋ left over; picker → chip → count badge → Esc focus return → 清除全部) and the existing `composer-mode-indicator.spec.ts` + `composer-skill-invocation.spec.ts` (7 tests, proving the `/` path still shares the same draft) — **9 passed**.
- `biome lint`, `check-a11y`, `check-copy`, `check-console` — clean.
- Renderer production build (`build:renderer`) — clean.

### Review focus

The Skills picker is new UI surface: the panel geometry (340px, list capped at 240px with its own scroll) and the checkbox row semantics (`role="checkbox"` buttons inside the labelled dialog) are the parts most worth a second opinion.