### PR TITLE
fix(headless): harden benchmark failure boundaries

### DIFF
--- a/packages/headless/harbor/maka_verifier.py
+++ b/packages/headless/harbor/maka_verifier.py
@@ -7,6 +7,7 @@ whole Harbor trial would violate Pass@1.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import math
 import re
@@ -50,6 +51,11 @@ class _TimedVerifierEnvironment:
         self._environment = environment
         self._timeout_sec = timeout_sec
         self.timed_out = False
+        self.recovery_budget_limited = False
+
+    def set_timeout(self, timeout_sec: float, *, recovery_budget_limited: bool) -> None:
+        self._timeout_sec = timeout_sec
+        self.recovery_budget_limited = recovery_budget_limited
 
     def __getattr__(self, name: str) -> Any:
         return getattr(self._environment, name)
@@ -77,17 +83,30 @@ class MakaVerifier(Verifier):
         self,
         *args: Any,
         attempt_timeout_sec: float | None = None,
-        max_attempts: int = 2,
+        max_attempts: int = 3,
+        retry_backoff_sec: float = 1,
+        total_timeout_sec: float | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        native_timeout = attempt_timeout_sec or self.task.config.verifier.timeout_sec
+        native_timeout = (
+            self.task.config.verifier.timeout_sec
+            if attempt_timeout_sec is None
+            else attempt_timeout_sec
+        )
         if not math.isfinite(native_timeout) or native_timeout <= 0:
             raise ValueError("attempt_timeout_sec must be a positive finite number")
-        if max_attempts != 2:
-            raise ValueError("Maka verifier policy requires exactly two attempts")
+        if max_attempts != 3:
+            raise ValueError("Maka verifier policy requires exactly three attempts")
+        if not math.isfinite(retry_backoff_sec) or retry_backoff_sec < 0:
+            raise ValueError("retry_backoff_sec must be a non-negative finite number")
+        total_timeout = native_timeout * 2 if total_timeout_sec is None else total_timeout_sec
+        if not math.isfinite(total_timeout) or total_timeout < native_timeout:
+            raise ValueError("total_timeout_sec must cover at least one verifier attempt")
         self._attempt_timeout_sec = float(native_timeout)
         self._max_attempts = max_attempts
+        self._retry_backoff_sec = float(retry_backoff_sec)
+        self._total_timeout_sec = float(total_timeout)
         self._base_environment = self.environment
         self._timed_environment = _TimedVerifierEnvironment(
             self._base_environment,
@@ -98,8 +117,17 @@ class MakaVerifier(Verifier):
     async def verify(self) -> VerifierResult:
         attempts: list[dict[str, Any]] = []
         last_error: Exception | None = None
+        deadline = time.monotonic() + self._total_timeout_sec
         for attempt in range(1, self._max_attempts + 1):
             await self._clear_attempt_outputs()
+            remaining_sec = deadline - time.monotonic()
+            if remaining_sec <= 0:
+                self._raise_infrastructure_exhausted(attempts, last_error)
+            attempt_timeout_sec = min(self._attempt_timeout_sec, remaining_sec)
+            self._timed_environment.set_timeout(
+                attempt_timeout_sec,
+                recovery_budget_limited=attempt_timeout_sec < self._attempt_timeout_sec,
+            )
             self._timed_environment.timed_out = False
             started = time.monotonic()
             result: VerifierResult | None = None
@@ -131,22 +159,36 @@ class MakaVerifier(Verifier):
                 self._write_outcome("candidate_timeout", attempts)
                 return VerifierResult(rewards={"reward": 0})
             if attempt < self._max_attempts:
-                last_error = None
+                backoff_sec = self._retry_backoff_sec * (2 ** (attempt - 1))
+                if backoff_sec >= deadline - time.monotonic():
+                    self._raise_infrastructure_exhausted(attempts, last_error)
+                await asyncio.sleep(backoff_sec)
                 continue
 
-            self._write_outcome("infra_failed", attempts)
-            raise MakaVerifierInfrastructureError(
-                "verifier infrastructure failed after two attempts"
-            ) from last_error
+            self._raise_infrastructure_exhausted(attempts, last_error)
 
         raise AssertionError("unreachable verifier attempt state")
+
+    def _raise_infrastructure_exhausted(
+        self,
+        attempts: list[dict[str, Any]],
+        last_error: Exception | None,
+    ) -> None:
+        self._write_outcome("infra_failed", attempts)
+        raise MakaVerifierInfrastructureError(
+            f"verifier infrastructure recovery exhausted after {len(attempts)} attempts"
+        ) from last_error
 
     def _classify_attempt(
         self,
         result: VerifierResult | None,
     ) -> str:
         if self._timed_environment.timed_out:
-            return "timeout"
+            return (
+                "infra_failed"
+                if self._timed_environment.recovery_budget_limited
+                else "timeout"
+            )
         reward = _reward(result)
         if reward is not None and reward > 0:
             return "passed"

--- a/packages/headless/harbor/process_scope.py
+++ b/packages/headless/harbor/process_scope.py
@@ -39,16 +39,22 @@ async def cleanup_process_scope(
 def scoped_command(command: str, scope: str, command_id: str) -> str:
     scope_dir = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}")
     pgid_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.pgid")
+    wrapper_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.wrapper")
+    stdout_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.stdout")
+    stderr_path = shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.stderr")
     return (
-        f"mkdir -p -- {scope_dir}; set -m; "
+        f"mkdir -p -- {scope_dir}; printf '%s\\n' \"$$\" > {wrapper_path}; set -m; "
         f"env {COMMAND_SCOPE_ENV}={shlex.quote(scope)} "
         f"{COMMAND_ID_ENV}={shlex.quote(command_id)} "
-        f"bash -lc {shlex.quote(command)} & "
+        f"bash -lc {shlex.quote(command)} > {stdout_path} 2> {stderr_path} & "
         "command_pid=$!; "
         "set +m; "
         f"printf '%s\\n' \"$command_pid\" > {pgid_path}; "
         "wait \"$command_pid\" 2>/dev/null; command_status=$?; "
+        f"cat -- {stdout_path}; cat -- {stderr_path} >&2; "
+        f"rm -f -- {stdout_path} {stderr_path}; "
         f"kill -0 -- \"-$command_pid\" 2>/dev/null || rm -f -- {pgid_path}; "
+        f"rm -f -- {wrapper_path}; "
         "exit \"$command_status\""
     )
 
@@ -65,6 +71,8 @@ def scoped_process_cleanup_command(scope: str, signal: str) -> str:
         f"kill -{signal} -- \"-$pgid\" 2>/dev/null || true; "
         "done; "
         + _marked_process_cleanup_command(scope, signal)
+        + "; "
+        + _wrapper_cleanup_command(f"{scope_dir}/*.wrapper", signal)
         + (f"; rm -rf -- {scope_dir}" if signal == "KILL" else "")
     )
 
@@ -81,6 +89,15 @@ def scoped_command_cleanup_command(
     if not pgid_paths:
         return ":"
     paths = " ".join(pgid_paths)
+    wrapper_paths = " ".join(
+        shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.wrapper")
+        for command_id in command_ids
+    )
+    artifact_paths = " ".join(
+        shlex.quote(f"{COMMAND_SCOPE_ROOT}/{scope}/{command_id}.{suffix}")
+        for command_id in command_ids
+        for suffix in ("pgid", "wrapper", "stdout", "stderr")
+    )
     command = (
         f"for pgid_file in {paths}; do "
         "[ -r \"$pgid_file\" ] || continue; "
@@ -89,8 +106,21 @@ def scoped_command_cleanup_command(
         f"kill -{signal} -- \"-$pgid\" 2>/dev/null || true; "
         "done; "
         + _marked_process_cleanup_command(scope, signal, command_ids)
+        + "; "
+        + _wrapper_cleanup_command(wrapper_paths, signal)
     )
-    return command + (f"; rm -f -- {paths}" if signal == "KILL" else "")
+    return command + (f"; rm -f -- {artifact_paths}" if signal == "KILL" else "")
+
+
+def _wrapper_cleanup_command(wrapper_paths: str, signal: str) -> str:
+    return (
+        f"for wrapper_file in {wrapper_paths}; do "
+        "[ -r \"$wrapper_file\" ] || continue; "
+        "wrapper_pid=$(cat -- \"$wrapper_file\"); "
+        "case $wrapper_pid in ''|*[!0-9]*) continue;; esac; "
+        f"kill -{signal} \"$wrapper_pid\" 2>/dev/null || true; "
+        "done"
+    )
 
 
 def _marked_process_cleanup_command(

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -5,7 +5,9 @@ import { syncBuiltinESMExports } from 'node:module';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
+import type { RuntimeEvent } from '@maka/core';
 import type { Config } from '../contracts.js';
+import { buildHarborCellOutput } from '../cell-output.js';
 import { tokenSummary } from './helpers/cell-output-fixtures.js';
 import { contextBudgetSummary } from './helpers/ab-summary-fixtures.js';
 import {
@@ -1562,8 +1564,15 @@ describe('fixed prompt controller', () => {
           calls.push(task.id);
           return harborOutput({
             taskId: task.id,
+            reward: 0,
             status: 'failed',
             errorClass: 'provider_billing',
+            omitTokenSummary: true,
+            steps: 0,
+            verifier: {
+              outcome: 'failed',
+              attempts: [{ attempt: 1, classification: 'failed', durationMs: 20, reward: 0 }],
+            },
           });
         },
         now: () => 100,
@@ -1574,6 +1583,50 @@ describe('fixed prompt controller', () => {
       assert.equal(String(result.stopReason), 'systemic_provider_failure');
       assert.equal(result.events[0]?.type, 'task_infra_failed');
       assert.equal(String(result.events[0]?.errorClass), 'provider_billing');
+      assert.equal(result.events[0]?.scored, false);
+    });
+  });
+
+  test('stops immediately on a pre-execution authentication failure', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const calls: string[] = [];
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [
+          { id: 'task-a', path: '/bench/task-a' },
+          { id: 'task-b', path: '/bench/task-b' },
+        ],
+        maxConcurrency: 1,
+        taskRunner: async ({ task }) => {
+          calls.push(task.id);
+          return harborOutput({
+            taskId: task.id,
+            reward: 0,
+            status: 'failed',
+            errorClass: 'auth',
+            omitTokenSummary: true,
+            steps: 0,
+            verifier: {
+              outcome: 'failed',
+              attempts: [{ attempt: 1, classification: 'failed', durationMs: 20, reward: 0 }],
+            },
+          });
+        },
+        now: () => 100,
+        newId: idFactory(),
+      });
+
+      assert.deepEqual(calls, ['task-a']);
+      assert.equal(result.stopReason, 'systemic_provider_failure');
+      assert.equal(result.events[0]?.type, 'task_infra_failed');
+      assert.equal(result.events[0]?.errorClass, 'auth');
       assert.equal(result.events[0]?.scored, false);
     });
   });
@@ -2189,6 +2242,41 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('keeps a verifier-graded deadline scored when the model completed but chose no workspace tool', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireFinalUsage: true,
+        taskRunner: async () =>
+          harborOutput({
+            taskId: 'task-a',
+            reward: 0,
+            status: 'failed',
+            errorClass: 'aborted',
+            deadlineSettlement: { source: 'benchmark.deadline', mode: 'immediate' },
+            verifier: {
+              outcome: 'failed',
+              attempts: [{ attempt: 1, classification: 'failed', durationMs: 20, reward: 0 }],
+            },
+          }),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_completed');
+      assert.equal(result.events[0]?.passed, false);
+      assert.equal(result.events[0]?.scored, true);
+      assert.equal(result.events[0]?.eligible, true);
+      assert.equal(result.events[0]?.errorClass, 'budget_exhausted');
+    });
+  });
+
   test('classifies provider rate limits as infrastructure failures', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -2461,7 +2549,47 @@ describe('fixed prompt controller', () => {
     });
   });
 
-  test('excludes a deadline-settled workspace attempt when no provider usage completed', async () => {
+  test('rejects a verifier-graded failed result when required final usage is missing', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireFinalUsage: true,
+        taskRunner: async () =>
+          harborOutput({
+            taskId: 'task-a',
+            reward: 0,
+            status: 'failed',
+            errorClass: 'runtime_error',
+            omitTokenSummary: true,
+            toolSummary: {
+              providerVisibleToolCount: 1,
+              actualToolCalls: 1,
+              actualToolNames: ['Bash'],
+              actualToolCallCounts: { Bash: 1 },
+            },
+            verifier: {
+              outcome: 'failed',
+              attempts: [{ attempt: 1, classification: 'failed', durationMs: 20, reward: 0 }],
+            },
+          }),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'missing_token_usage');
+      assert.equal(result.events[0]?.scored, false);
+      assert.equal(result.events[0]?.eligible, false);
+    });
+  });
+
+  test('rejects a deadline-settled workspace attempt when required provider usage is missing', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
@@ -2493,8 +2621,8 @@ describe('fixed prompt controller', () => {
         newId: idFactory(),
       });
 
-      assert.equal(result.events[0]?.type, 'task_infra_failed');
-      assert.equal(result.events[0]?.errorClass, 'infra_error');
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'missing_token_usage');
       assert.equal(result.events[0]?.eligible, false);
       assert.equal(result.events[0]?.scored, false);
     });
@@ -2774,6 +2902,40 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('keeps a verifier failure scored after a completed model step without usage', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const cell = failedCellAfterCompletedModelStepWithoutUsage('runtime_error');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        taskRunner: async () => ({
+          harbor: {
+            reward: 0,
+            verifier: {
+              outcome: 'failed',
+              attempts: [{ attempt: 1, classification: 'failed', durationMs: 20, reward: 0 }],
+            },
+          },
+          cell: { ...cell, traceEventsPath: '/logs/task-a/events.jsonl' },
+        }),
+      });
+
+      assert.equal(cell.steps, 1);
+      assert.equal(cell.tokenSummary, undefined);
+      assert.equal(result.events[0]?.type, 'task_completed');
+      assert.equal(result.events[0]?.passed, false);
+      assert.equal(result.events[0]?.scored, true);
+      assert.equal(result.events[0]?.eligible, true);
+    });
+  });
+
   test('excludes a verifier failure when the agent never completed a model step or reported usage', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -2808,10 +2970,14 @@ describe('fixed prompt controller', () => {
     });
   });
 
-  test('excludes a deadline verifier failure when no provider step completed or workspace tool ran', async () => {
+  test('rejects missing required usage after a completed model step', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+      const cell = failedCellAfterCompletedModelStepWithoutUsage('aborted', {
+        source: 'benchmark.deadline',
+        mode: 'immediate',
+      });
 
       const result = await runFixedPromptController({
         runId: 'run-1',
@@ -2821,24 +2987,22 @@ describe('fixed prompt controller', () => {
         resultsJsonlPath: join(dir, 'results.jsonl'),
         tasks: [{ id: 'task-a', path: '/bench/task-a' }],
         requireFinalUsage: true,
-        taskRunner: async () =>
-          harborOutput({
-            taskId: 'task-a',
+        taskRunner: async () => ({
+          harbor: {
             reward: 0,
-            status: 'failed',
-            errorClass: 'aborted',
-            deadlineSettlement: { source: 'benchmark.deadline', mode: 'immediate' },
-            steps: 1,
-            omitTokenSummary: true,
             verifier: {
               outcome: 'failed',
               attempts: [{ attempt: 1, classification: 'failed', durationMs: 20, reward: 0 }],
             },
-          }),
+          },
+          cell: { ...cell, traceEventsPath: '/logs/task-a/events.jsonl' },
+        }),
       });
 
-      assert.equal(result.events[0]?.type, 'task_infra_failed');
-      assert.equal(result.events[0]?.status, 'infra_failed');
+      assert.equal(cell.steps, 1);
+      assert.equal(cell.tokenSummary, undefined);
+      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
+      assert.equal(result.events[0]?.errorClass, 'missing_token_usage');
       assert.equal(result.events[0]?.scored, false);
       assert.equal(result.events[0]?.eligible, false);
     });
@@ -3188,6 +3352,44 @@ function harborOutput(input: {
 function idFactory(): () => string {
   let i = 0;
   return () => `id-${++i}`;
+}
+
+function completedModelEventWithoutUsage(): RuntimeEvent {
+  return {
+    id: 'model-final',
+    sessionId: 'session-task-a',
+    invocationId: 'inv-task-a',
+    runId: 'run-task-a',
+    turnId: 'turn-task-a',
+    ts: 30,
+    partial: false,
+    role: 'model',
+    author: 'agent',
+    refs: { stepId: 'step-1' },
+    content: { kind: 'text', text: 'candidate response' },
+  };
+}
+
+function failedCellAfterCompletedModelStepWithoutUsage(
+  errorClass: string,
+  deadlineSettlement?: TaskRunOutput['cell']['deadlineSettlement'],
+) {
+  return buildHarborCellOutput({
+    invocation: {
+      invocationId: 'inv-task-a',
+      sessionId: 'session-task-a',
+      runId: 'run-task-a',
+      turnId: 'turn-task-a',
+      status: 'failed',
+      failure: { class: errorClass },
+      events: [completedModelEventWithoutUsage()],
+      startedAt: 20,
+      finishedAt: 60,
+    },
+    runtimeEventsPath: '/logs/task-a/runtime-events.jsonl',
+    promptHash: hashSystemPrompt('fixed prompt\n'),
+    ...(deadlineSettlement ? { deadlineSettlement } : {}),
+  });
 }
 
 async function delay(ms: number): Promise<void> {

--- a/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
+++ b/packages/headless/src/__tests__/fixed-prompt-controller.test.ts
@@ -2140,7 +2140,7 @@ describe('fixed prompt controller', () => {
     });
   });
 
-  test('keeps verifier-graded deadline settlements as scored benchmark outcomes', async () => {
+  test('keeps verifier-graded deadlines scored after completed model and workspace steps', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
@@ -2150,6 +2150,16 @@ describe('fixed prompt controller', () => {
         status: 'failed',
         errorClass: 'aborted',
         deadlineSettlement: { source: 'benchmark.deadline', mode: 'immediate' },
+        toolSummary: {
+          providerVisibleToolCount: 1,
+          actualToolCalls: 1,
+          actualToolNames: ['Bash'],
+          actualToolCallCounts: { Bash: 1 },
+        },
+        verifier: {
+          outcome: 'failed',
+          attempts: [{ attempt: 1, classification: 'failed', durationMs: 20, reward: 0 }],
+        },
       });
       let taskRuns = 0;
 
@@ -2451,7 +2461,7 @@ describe('fixed prompt controller', () => {
     });
   });
 
-  test('rejects a deadline-settled result when required final usage is missing', async () => {
+  test('excludes a deadline-settled workspace attempt when no provider usage completed', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
       await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
@@ -2472,13 +2482,19 @@ describe('fixed prompt controller', () => {
             errorClass: 'aborted',
             deadlineSettlement: { source: 'benchmark.deadline', mode: 'immediate' },
             omitTokenSummary: true,
+            toolSummary: {
+              providerVisibleToolCount: 1,
+              actualToolCalls: 1,
+              actualToolNames: ['Bash'],
+              actualToolCallCounts: { Bash: 1 },
+            },
           }),
         now: () => 100,
         newId: idFactory(),
       });
 
-      assert.equal(result.events[0]?.type, 'task_plumbing_failed');
-      assert.equal(result.events[0]?.errorClass, 'missing_token_usage');
+      assert.equal(result.events[0]?.type, 'task_infra_failed');
+      assert.equal(result.events[0]?.errorClass, 'infra_error');
       assert.equal(result.events[0]?.eligible, false);
       assert.equal(result.events[0]?.scored, false);
     });
@@ -2758,6 +2774,76 @@ describe('fixed prompt controller', () => {
     });
   });
 
+  test('excludes a verifier failure when the agent never completed a model step or reported usage', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        taskRunner: async () =>
+          harborOutput({
+            taskId: 'task-a',
+            reward: 0,
+            status: 'failed',
+            errorClass: 'runtime_error',
+            steps: 0,
+            omitTokenSummary: true,
+            verifier: {
+              outcome: 'failed',
+              attempts: [{ attempt: 1, classification: 'failed', durationMs: 20, reward: 0 }],
+            },
+          }),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_infra_failed');
+      assert.equal(result.events[0]?.status, 'infra_failed');
+      assert.equal(result.events[0]?.scored, false);
+      assert.equal(result.events[0]?.eligible, false);
+    });
+  });
+
+  test('excludes a deadline verifier failure when no provider step completed or workspace tool ran', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        requireFinalUsage: true,
+        taskRunner: async () =>
+          harborOutput({
+            taskId: 'task-a',
+            reward: 0,
+            status: 'failed',
+            errorClass: 'aborted',
+            deadlineSettlement: { source: 'benchmark.deadline', mode: 'immediate' },
+            steps: 1,
+            omitTokenSummary: true,
+            verifier: {
+              outcome: 'failed',
+              attempts: [{ attempt: 1, classification: 'failed', durationMs: 20, reward: 0 }],
+            },
+          }),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_infra_failed');
+      assert.equal(result.events[0]?.status, 'infra_failed');
+      assert.equal(result.events[0]?.scored, false);
+      assert.equal(result.events[0]?.eligible, false);
+    });
+  });
+
   test('keeps a structured verifier failure authoritative after an agent failure', async () => {
     await withDir(async (dir) => {
       const systemPromptPath = join(dir, 'system_prompt.md');
@@ -2788,8 +2874,51 @@ describe('fixed prompt controller', () => {
         assert.equal(result.events[0]?.passed, false);
         assert.equal(result.events[0]?.scored, true);
         assert.equal(result.events[0]?.eligible, true);
-        assert.equal(result.events[0]?.errorClass, errorClass);
+        assert.equal(
+          result.events[0]?.errorClass,
+          errorClass === 'infra_failed' ? 'runtime_error' : errorClass,
+        );
       }
+    });
+  });
+
+  test('keeps candidate resource exhaustion scored after normal workspace execution', async () => {
+    await withDir(async (dir) => {
+      const systemPromptPath = join(dir, 'system_prompt.md');
+      await writeFile(systemPromptPath, 'fixed prompt\n', 'utf8');
+
+      const result = await runFixedPromptController({
+        runId: 'run-1',
+        roundId: 'round-1',
+        config,
+        systemPromptPath,
+        resultsJsonlPath: join(dir, 'results.jsonl'),
+        tasks: [{ id: 'task-a', path: '/bench/task-a' }],
+        taskRunner: async () =>
+          harborOutput({
+            taskId: 'task-a',
+            reward: 0,
+            status: 'failed',
+            errorClass: 'infra_failed',
+            steps: 64,
+            toolSummary: {
+              providerVisibleToolCount: 1,
+              actualToolCalls: 32,
+              actualToolNames: ['Bash'],
+              actualToolCallCounts: { Bash: 32 },
+            },
+            verifier: {
+              outcome: 'failed',
+              attempts: [{ attempt: 1, classification: 'failed', durationMs: 20, reward: 0 }],
+            },
+          }),
+      });
+
+      assert.equal(result.events[0]?.type, 'task_completed');
+      assert.equal(result.events[0]?.passed, false);
+      assert.equal(result.events[0]?.scored, true);
+      assert.equal(result.events[0]?.eligible, true);
+      assert.equal(result.events[0]?.errorClass, 'runtime_error');
     });
   });
 
@@ -2993,6 +3122,7 @@ function harborOutput(input: {
   contextBudgetSummary?: TaskRunOutput['cell']['contextBudgetSummary'];
   continuationSummary?: TaskRunOutput['cell']['continuationSummary'];
   taskToolSummary?: TaskRunOutput['cell']['taskToolSummary'];
+  toolSummary?: TaskRunOutput['cell']['toolSummary'];
   errorClass?: string;
   status?: TaskRunOutput['cell']['status'];
   executionIdentity?: TaskRunOutput['cell']['executionIdentity'];
@@ -3000,6 +3130,8 @@ function harborOutput(input: {
   deadlineSettlement?: TaskRunOutput['cell']['deadlineSettlement'];
   verifier?: TaskRunOutput['harbor']['verifier'];
   providerTelemetryPath?: string;
+  steps?: number;
+  durationMs?: number;
 }): TaskRunOutput {
   return {
     harbor: { reward: input.reward ?? 1, ...(input.verifier ? { verifier: input.verifier } : {}) },
@@ -3033,14 +3165,14 @@ function harborOutput(input: {
       ...(input.contextBudgetSummary ? { contextBudgetSummary: input.contextBudgetSummary } : {}),
       ...(input.continuationSummary ? { continuationSummary: input.continuationSummary } : {}),
       ...(input.taskToolSummary ? { taskToolSummary: input.taskToolSummary } : {}),
-      toolSummary: {
+      toolSummary: input.toolSummary ?? {
         providerVisibleToolCount: 0,
         actualToolCalls: 0,
         actualToolNames: [],
         actualToolCallCounts: {},
       },
-      steps: 2,
-      durationMs: 40,
+      steps: input.steps ?? 2,
+      durationMs: input.durationMs ?? 40,
       startedAt: 20,
       finishedAt: 60,
       runtimeRefs: {

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -4801,17 +4801,19 @@ verifier_mod.Verifier = Verifier
 verifier_mod.RewardFileNotFoundError = RewardFileNotFoundError
 
 sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
-from maka_verifier import MakaVerifier
+import maka_verifier as verifier_impl
+from maka_verifier import MakaVerifier, MakaVerifierInfrastructureError
 
 class FakeEnvironment:
     os = "linux"
     capabilities = types.SimpleNamespace(mounted=True)
     default_user = None
 
-    def __init__(self, trial_paths, outcomes):
+    def __init__(self, trial_paths, outcomes, clock=None):
         self.trial_paths = trial_paths
         self.outcomes = list(outcomes)
         self.commands = []
+        self.clock = clock
 
     async def exec(self, command, **kwargs):
         self.commands.append(command)
@@ -4821,6 +4823,9 @@ class FakeEnvironment:
             return types.SimpleNamespace(return_code=0, stdout="", stderr="")
         assert "timeout --signal=KILL" in command, command
         outcome = self.outcomes.pop(0)
+        if isinstance(outcome, tuple):
+            outcome, duration = outcome
+            self.clock[0] += duration
         if outcome == "infra":
             self.trial_paths.test_stdout_path.write_text("E: Failed to fetch https://deb.example.invalid/pkg.deb 502 Bad Gateway", encoding="utf-8")
             return types.SimpleNamespace(return_code=0, stdout="", stderr="")
@@ -4876,7 +4881,7 @@ class FakeEnvironment:
         self.trial_paths.reward_text_path.write_text("1\n", encoding="utf-8")
         return types.SimpleNamespace(return_code=0, stdout="", stderr="")
 
-async def run_case(outcomes):
+async def run_case(outcomes, retry_backoff_sec=0, total_timeout_sec=2, clock=None):
     temp = tempfile.TemporaryDirectory()
     trial = Path(temp.name)
     verifier_dir = trial / "verifier"
@@ -4887,15 +4892,20 @@ async def run_case(outcomes):
         reward_json_path=verifier_dir / "reward.json",
         test_stdout_path=verifier_dir / "test-stdout.txt",
     )
-    environment = FakeEnvironment(paths, outcomes)
+    environment = FakeEnvironment(paths, outcomes, clock)
     verifier = MakaVerifier(
         task=types.SimpleNamespace(config=types.SimpleNamespace(verifier=types.SimpleNamespace(env={})), paths=None),
         trial_paths=paths,
         environment=environment,
         attempt_timeout_sec=1,
-        max_attempts=2,
+        max_attempts=3,
+        retry_backoff_sec=retry_backoff_sec,
+        total_timeout_sec=total_timeout_sec,
     )
-    result = await verifier.verify()
+    try:
+        result = await verifier.verify()
+    except MakaVerifierInfrastructureError as error:
+        result = error
     outcome = json.loads((verifier_dir / "maka-verifier-outcome.json").read_text(encoding="utf-8"))
     temp.cleanup()
     return result, outcome, environment.commands
@@ -4906,6 +4916,57 @@ assert outcome["outcome"] == "passed", outcome
 assert [item["classification"] for item in outcome["attempts"]] == ["infra_setup_failed", "passed"], outcome
 assert len([command for command in commands if "timeout --signal=KILL" in command]) == 2, commands
 assert all("bash -lc" in command for command in commands if "timeout --signal=KILL" in command), commands
+
+result, outcome, commands = asyncio.run(run_case(["infra", "infra", "pass"]))
+assert result.rewards == {"reward": 1.0}, result.rewards
+assert outcome["outcome"] == "passed", outcome
+assert [item["classification"] for item in outcome["attempts"]] == [
+    "infra_setup_failed",
+    "infra_setup_failed",
+    "passed",
+], outcome
+assert len([command for command in commands if "timeout --signal=KILL" in command]) == 3, commands
+
+delays = []
+original_sleep = verifier_impl.asyncio.sleep
+async def record_sleep(delay):
+    delays.append(delay)
+verifier_impl.asyncio.sleep = record_sleep
+try:
+    result, outcome, commands = asyncio.run(
+        run_case(["infra", "infra", "pass"], retry_backoff_sec=2, total_timeout_sec=10)
+    )
+finally:
+    verifier_impl.asyncio.sleep = original_sleep
+assert result.rewards == {"reward": 1.0}, result.rewards
+assert delays == [2, 4], delays
+
+result, outcome, commands = asyncio.run(run_case(["infra", "infra", "infra"]))
+assert isinstance(result, MakaVerifierInfrastructureError), result
+assert outcome["outcome"] == "infra_failed", outcome
+assert [item["classification"] for item in outcome["attempts"]] == [
+    "infra_setup_failed",
+    "infra_setup_failed",
+    "infra_setup_failed",
+], outcome
+assert len([command for command in commands if "timeout --signal=KILL" in command]) == 3, commands
+
+clock = [0.0]
+original_monotonic = verifier_impl.time.monotonic
+verifier_impl.time.monotonic = lambda: clock[0]
+try:
+    result, outcome, commands = asyncio.run(
+        run_case([("infra", 0.6), ("infra", 0.6), "timeout"], clock=clock)
+    )
+finally:
+    verifier_impl.time.monotonic = original_monotonic
+assert isinstance(result, MakaVerifierInfrastructureError), result
+assert outcome["outcome"] == "infra_failed", outcome
+assert [item["classification"] for item in outcome["attempts"]] == [
+    "infra_setup_failed",
+    "infra_setup_failed",
+    "infra_failed",
+], outcome
 
 result, outcome, commands = asyncio.run(run_case(["infra_with_fail_reward", "pass"]))
 assert result.rewards == {"reward": 1.0}, result.rewards

--- a/packages/headless/src/__tests__/harbor-adapter.test.ts
+++ b/packages/headless/src/__tests__/harbor-adapter.test.ts
@@ -1059,6 +1059,33 @@ describe('Harbor adapter contract', () => {
     ]);
   });
 
+  test('process scope isolates transport descriptors from background descendants', (t) => {
+    const result = spawnSync('python3', ['-c', pythonBackgroundDescriptorSmokeScript(repoRoot)], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: 5_000,
+    });
+    if (result.error && 'code' in result.error && result.error.code === 'ENOENT') {
+      t.skip('python3 is not available');
+      return;
+    }
+    assert.equal(result.status, 0, result.stderr || String(result.error ?? ''));
+    assert.equal(result.stdout, 'foreground\n');
+  });
+
+  test('process scope cleanup settles buffered transport wrappers', (t) => {
+    const result = spawnSync('python3', ['-c', pythonBufferedWrapperCleanupSmokeScript(repoRoot)], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      timeout: 5_000,
+    });
+    if (result.error && 'code' in result.error && result.error.code === 'ENOENT') {
+      t.skip('python3 is not available');
+      return;
+    }
+    assert.equal(result.status, 0, result.stderr || String(result.error ?? ''));
+  });
+
   test('opencode_agent.py bridges credentials and estimates trial cost without Harbor installed', (t: TestContext) => {
     const result = spawnSync('python3', ['-c', pythonOpenCodeAdapterSmokeScript(repoRoot)], {
       cwd: repoRoot,
@@ -1671,6 +1698,97 @@ finally:
         scope_dir.rmdir()
 
 print(json.dumps(results))
+`;
+}
+
+function pythonBackgroundDescriptorSmokeScript(root: string): string {
+  return String.raw`
+import contextlib
+import os
+import signal
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+root = Path(${JSON.stringify(root)})
+sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
+
+from process_scope import COMMAND_SCOPE_ROOT, scoped_command, scoped_process_cleanup_command
+
+scope = f"background-descriptor-test-{os.getpid()}"
+scope_dir = Path(COMMAND_SCOPE_ROOT) / scope
+with tempfile.TemporaryDirectory() as tmp:
+    child_pid_path = Path(tmp) / "child.pid"
+    command = (
+        f"printf 'foreground\\n'; sleep 30 & "
+        f"printf '%s\\n' $! > {child_pid_path}"
+    )
+    process = subprocess.Popen(
+        ["bash", "-lc", scoped_command(command, scope, "command")],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        stdout, stderr = process.communicate(timeout=1)
+        assert process.returncode == 0, (process.returncode, stderr)
+        child_pid = int(child_pid_path.read_text(encoding="utf-8").strip())
+        os.kill(child_pid, 0)
+        assert stdout == "foreground" + chr(10), repr(stdout)
+        assert stderr == "", stderr
+        print("foreground")
+    finally:
+        subprocess.run(
+            ["bash", "-lc", scoped_process_cleanup_command(scope, "KILL")],
+            check=False,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if process.poll() is None:
+            process.kill()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            process.communicate(timeout=1)
+`;
+}
+
+function pythonBufferedWrapperCleanupSmokeScript(root: string): string {
+  return String.raw`
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+root = Path(${JSON.stringify(root)})
+sys.path.insert(0, str(root / "packages" / "headless" / "harbor"))
+
+from process_scope import COMMAND_SCOPE_ROOT, scoped_command, scoped_process_cleanup_command
+
+scope = f"buffered-wrapper-cleanup-{os.getpid()}"
+scope_dir = Path(COMMAND_SCOPE_ROOT) / scope
+process = subprocess.Popen(
+    ["bash", "-lc", scoped_command("head -c 1048576 /dev/zero; sleep 30", scope, "command")],
+    stdout=subprocess.PIPE,
+    stderr=subprocess.PIPE,
+)
+try:
+    stdout_path = scope_dir / "command.stdout"
+    deadline = time.time() + 2
+    while (not stdout_path.exists() or stdout_path.stat().st_size < 1048576) and time.time() < deadline:
+        time.sleep(0.01)
+    assert stdout_path.exists() and stdout_path.stat().st_size == 1048576
+    subprocess.run(
+        ["bash", "-lc", scoped_process_cleanup_command(scope, "KILL")],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    process.wait(timeout=1)
+finally:
+    if process.poll() is None:
+        process.kill()
+        process.wait()
 `;
 }
 

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1432,6 +1432,12 @@ describe('createHarborTaskRunner', () => {
       const output = await runner(runInput());
       assert.equal(output.harbor.reward, 1);
       assert.equal(output.harbor.verifier?.outcome, 'passed');
+      assert.equal(output.cell.status, 'failed');
+      assert.equal(output.cell.errorClass, 'budget_exhausted');
+      assert.deepEqual(output.cell.deadlineSettlement, {
+        source: 'benchmark.deadline',
+        mode: 'immediate',
+      });
       assert.deepEqual(output.cell.tokenSummary, timedCell.tokenSummary);
       assert.deepEqual(output.cell.executionIdentity, timedCell.executionIdentity);
     });

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1855,32 +1855,39 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
-  test('accepts a passing verifier outcome recovered after an infrastructure attempt', async () => {
+  test('accepts recovery after multiple verifier infra attempts without rerunning the Agent', async () => {
     await withRun(async ({ jobsDir, repo }) => {
+      let agentRuns = 0;
+      const runTrial = fakeRunner({
+        reward: '1\n',
+        verifierOutcome: {
+          schemaVersion: 1,
+          outcome: 'passed',
+          attempts: [
+            { attempt: 1, classification: 'infra_setup_failed', durationMs: 15, reward: 0 },
+            { attempt: 2, classification: 'infra_setup_failed', durationMs: 25, reward: 0 },
+            { attempt: 3, classification: 'passed', durationMs: 12, reward: 1 },
+          ],
+        },
+      });
       const runner = createHarborTaskRunner({
         makaRepoPath: repo,
         jobsDir,
         model: 'deepseek/deepseek-v4-flash',
-        runHarbor: fakeRunner({
-          reward: '1\n',
-          verifierOutcome: {
-            schemaVersion: 1,
-            outcome: 'passed',
-            attempts: [
-              { attempt: 1, classification: 'infra_setup_failed', durationMs: 15, reward: 0 },
-              { attempt: 2, classification: 'passed', durationMs: 12, reward: 1 },
-            ],
-          },
-        }),
+        runHarbor: async (request) => {
+          agentRuns += 1;
+          return runTrial(request);
+        },
       });
 
       const output = await runner(runInput());
 
       assert.equal(output.harbor.reward, 1);
+      assert.equal(agentRuns, 1);
       assert.equal(output.harbor.verifier?.outcome, 'passed');
       assert.deepEqual(
         output.harbor.verifier?.attempts.map((attempt) => attempt.classification),
-        ['infra_setup_failed', 'passed'],
+        ['infra_setup_failed', 'infra_setup_failed', 'passed'],
       );
     });
   });
@@ -2161,7 +2168,12 @@ describe('buildHarborJobConfig', () => {
       '/repo/packages/headless/harbor/docker-compose-linux-amd64.yaml',
     ]);
     assert.equal(verifier.import_path, 'maka_verifier:MakaVerifier');
-    assert.deepEqual(verifier.kwargs, { attempt_timeout_sec: 600, max_attempts: 2 });
+    assert.deepEqual(verifier.kwargs, {
+      attempt_timeout_sec: 600,
+      max_attempts: 3,
+      retry_backoff_sec: 2,
+      total_timeout_sec: 1_200,
+    });
     assert.equal(verifier.override_timeout_sec, 1_320);
     assert.equal(env.ZAI_API_KEY, undefined);
     assert.equal(env.ZAI_API_KEY_FILE, undefined);

--- a/packages/headless/src/__tests__/harbor-task-runner.test.ts
+++ b/packages/headless/src/__tests__/harbor-task-runner.test.ts
@@ -1437,6 +1437,54 @@ describe('createHarborTaskRunner', () => {
     });
   });
 
+  test('propagates an authoritative Harbor agent timeout into a failed graded cell', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          reward: '0\n',
+          cell: cellOutput({ status: 'completed', errorClass: undefined }),
+          trialResult: {
+            exception_info: {
+              exception_type: 'AgentTimeoutError',
+              exception_message: 'Agent execution timed out after 900.0 seconds',
+            },
+          },
+        }),
+      });
+
+      const output = await runner(runInput());
+      assert.equal(output.harbor.reward, 0);
+      assert.equal(output.cell.status, 'failed');
+      assert.equal(output.cell.errorClass, 'budget_exhausted');
+      assert.deepEqual(output.cell.deadlineSettlement, {
+        source: 'benchmark.deadline',
+        mode: 'immediate',
+      });
+    });
+  });
+
+  test('does not infer a benchmark deadline from an ordinary verifier failure', async () => {
+    await withRun(async ({ jobsDir, repo }) => {
+      const runner = createHarborTaskRunner({
+        makaRepoPath: repo,
+        jobsDir,
+        model: 'deepseek/deepseek-v4-flash',
+        runHarbor: fakeRunner({
+          reward: '0\n',
+          cell: cellOutput({ status: 'completed', errorClass: undefined }),
+        }),
+      });
+
+      const output = await runner(runInput());
+      assert.equal(output.cell.status, 'completed');
+      assert.equal(output.cell.errorClass, undefined);
+      assert.equal(output.cell.deadlineSettlement, undefined);
+    });
+  });
+
   test('hydrates missing deadline usage from the trial checkpoint', async () => {
     await withRun(async ({ jobsDir, repo }) => {
       const usageCheckpoint = tokenSummary({

--- a/packages/headless/src/__tests__/harness-ab-run.test.ts
+++ b/packages/headless/src/__tests__/harness-ab-run.test.ts
@@ -257,13 +257,16 @@ describe('runHarnessAbComparison', () => {
             JSON.parse(line) as {
               taskId: string;
               type: string;
+              scored?: boolean;
+              eligible?: boolean;
             },
         );
-      assert.equal(
-        terminalEvents.find((event) => event.taskId === 'b' && event.type === 'task_infra_failed')
-          ?.type,
-        'task_infra_failed',
+      const terminalInfra = terminalEvents.find(
+        (event) => event.taskId === 'b' && event.type === 'task_infra_failed',
       );
+      assert.equal(terminalInfra?.type, 'task_infra_failed');
+      assert.equal(terminalInfra?.scored, false);
+      assert.equal(terminalInfra?.eligible, false);
       assert.equal(
         terminalEvents.filter((event) => event.taskId === 'c' && event.type === 'task_completed')
           .length,

--- a/packages/headless/src/__tests__/harness-oracle-registry.test.ts
+++ b/packages/headless/src/__tests__/harness-oracle-registry.test.ts
@@ -16,7 +16,10 @@ import {
   planHarnessOracleRegistryAudit,
   resolveHarnessOracleAnnotations,
 } from '../harness-oracle-registry.js';
-import { buildHarnessOracleExecutionPolicyFingerprint } from '../harness-oracle-policy.js';
+import {
+  buildHarnessOracleExecutionPolicyFingerprint,
+  HARBOR_ORACLE_MAX_ATTEMPTS,
+} from '../harness-oracle-policy.js';
 
 describe('harness Oracle evidence registry', () => {
   test('binds qualification to controlled Oracle policy sources instead of host runtime versions', () => {
@@ -304,7 +307,7 @@ describe('harness Oracle evidence registry', () => {
     );
 
     const excessiveAttempts = structuredClone(baseline.snapshot);
-    excessiveAttempts.entries[0]!.oracle!.attempts = 3;
+    excessiveAttempts.entries[0]!.oracle!.attempts = HARBOR_ORACLE_MAX_ATTEMPTS + 1;
     excessiveAttempts.entries[0]!.fingerprint = fingerprintFixture(
       withoutFingerprint(excessiveAttempts.entries[0]!),
     );

--- a/packages/headless/src/__tests__/pier-task-runner.test.ts
+++ b/packages/headless/src/__tests__/pier-task-runner.test.ts
@@ -750,10 +750,11 @@ test('pier-graded failed cells stay scored through the fixed-prompt controller',
   });
 });
 
-test('pier and harbor outputs drive identical controller events for an infra-failed graded cell', async () => {
+test('pier and harbor normalize an infra-labeled graded cell to the same runtime outcome', async () => {
   // Cross-runner parity lock: once either harness produces a valid structured
   // pass/fail grade, the verifier is authoritative even if the agent cell
-  // exited with an infrastructure error.
+  // exited with an infrastructure label. Once the candidate had an execution
+  // opportunity, that label describes its runtime outcome, not harness infra.
   await withDirs(async ({ jobsDir, repo }) => {
     const dir = await mkdtemp(join(tmpdir(), 'maka-pier-parity-'));
     try {
@@ -827,7 +828,7 @@ test('pier and harbor outputs drive identical controller events for an infra-fai
         assert.equal(normalizedEvents[0]?.passed, reward > 0);
         assert.equal(normalizedEvents[0]?.scored, true);
         assert.equal(normalizedEvents[0]?.eligible, true);
-        assert.equal(normalizedEvents[0]?.errorClass, reward > 0 ? undefined : 'infra_failed');
+        assert.equal(normalizedEvents[0]?.errorClass, reward > 0 ? undefined : 'runtime_error');
       }
     } finally {
       await rm(dir, { recursive: true, force: true });

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -1157,7 +1157,7 @@ function structuredVerifierGrade(harbor: unknown): 'passed' | 'failed' | undefin
     !isRecord(verifier) ||
     !Array.isArray(verifier.attempts) ||
     verifier.attempts.length < 1 ||
-    verifier.attempts.length > 2
+    verifier.attempts.length > 3
   )
     return undefined;
   if (

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -595,10 +595,13 @@ function taskEventFromOutput(input: {
     });
   }
   if (isPreExecutionAgentFailure(input.output) && verifierGrade !== 'passed') {
+    const errorClass = isProviderInfraFailure(input.output.cell.errorClass)
+      ? input.output.cell.errorClass
+      : 'infra_error';
     return taskInfraFailedEvent({
       ...input,
-      errorClass: 'infra_error',
-      error: 'Harbor cell failed before completing a model step or reporting token usage',
+      errorClass,
+      error: `Harbor cell failed with ${errorClass} before completing a model step or reporting token usage`,
     });
   }
   if (isProviderInfraFailure(input.output.cell.errorClass) && verifierGrade === undefined) {
@@ -629,17 +632,14 @@ function taskEventFromOutput(input: {
 
 function isPreExecutionAgentFailure(output: TaskRunOutput): boolean {
   if (output.cell.status !== 'failed') return false;
-  const completedProviderStep = output.cell.tokenSummary !== undefined;
+  const completedProviderStep = output.cell.steps > 0 || output.cell.tokenSummary !== undefined;
   const executedWorkspaceTool = output.cell.toolSummary.actualToolCalls > 0;
-  if (output.cell.deadlineSettlement?.source === 'benchmark.deadline') {
-    return !completedProviderStep || !executedWorkspaceTool;
-  }
+  if (completedProviderStep || executedWorkspaceTool) return false;
   return (
-    !completedProviderStep &&
-    !executedWorkspaceTool &&
-    (output.cell.errorClass === 'runtime_error' ||
-      output.cell.errorClass === 'aborted' ||
-      isProviderInfraFailure(output.cell.errorClass))
+    output.cell.deadlineSettlement?.source === 'benchmark.deadline' ||
+    output.cell.errorClass === 'runtime_error' ||
+    output.cell.errorClass === 'aborted' ||
+    isProviderInfraFailure(output.cell.errorClass)
   );
 }
 
@@ -826,12 +826,7 @@ function classifyPlumbingFailure(
       error: `Harbor cell prompt hash ${output.cell.promptHash} did not match ${expectedPromptHash}`,
     };
   }
-  if (
-    requireFinalUsage &&
-    (output.cell.status === 'completed' ||
-      output.cell.deadlineSettlement?.source === 'benchmark.deadline') &&
-    output.cell.tokenSummary === undefined
-  ) {
+  if (requireFinalUsage && output.cell.tokenSummary === undefined) {
     return {
       errorClass: 'missing_token_usage',
       error: 'Harbor cell did not report final token usage',

--- a/packages/headless/src/fixed-prompt-controller.ts
+++ b/packages/headless/src/fixed-prompt-controller.ts
@@ -594,6 +594,13 @@ function taskEventFromOutput(input: {
       error: identityMismatch.error,
     });
   }
+  if (isPreExecutionAgentFailure(input.output) && verifierGrade !== 'passed') {
+    return taskInfraFailedEvent({
+      ...input,
+      errorClass: 'infra_error',
+      error: 'Harbor cell failed before completing a model step or reporting token usage',
+    });
+  }
   if (isProviderInfraFailure(input.output.cell.errorClass) && verifierGrade === undefined) {
     return taskInfraFailedEvent({
       ...input,
@@ -620,6 +627,22 @@ function taskEventFromOutput(input: {
   return taskCompletedEvent(input);
 }
 
+function isPreExecutionAgentFailure(output: TaskRunOutput): boolean {
+  if (output.cell.status !== 'failed') return false;
+  const completedProviderStep = output.cell.tokenSummary !== undefined;
+  const executedWorkspaceTool = output.cell.toolSummary.actualToolCalls > 0;
+  if (output.cell.deadlineSettlement?.source === 'benchmark.deadline') {
+    return !completedProviderStep || !executedWorkspaceTool;
+  }
+  return (
+    !completedProviderStep &&
+    !executedWorkspaceTool &&
+    (output.cell.errorClass === 'runtime_error' ||
+      output.cell.errorClass === 'aborted' ||
+      isProviderInfraFailure(output.cell.errorClass))
+  );
+}
+
 function taskCompletedEvent(input: {
   output: TaskRunOutput;
   taskId: string;
@@ -642,11 +665,14 @@ function taskCompletedEvent(input: {
       output.cell.errorClass === 'policy_denied') &&
       output.harbor.verifier !== undefined);
   const passed = verifierGraded && output.harbor.reward > 0;
+  const rawErrorClass = output.cell.errorClass ?? 'verification_failed';
   const errorClass = passed
     ? undefined
     : deadlineSettled
       ? 'budget_exhausted'
-      : (output.cell.errorClass ?? 'verification_failed');
+      : verifierGrade === 'failed' && isUnscoredCellFailure(rawErrorClass)
+        ? 'runtime_error'
+        : rawErrorClass;
   const scored =
     verifierGraded && (verifierGrade !== undefined || !isUnscoredCellFailure(errorClass));
   const agentFailure = output.cell.status === 'failed' && errorClass === 'tool_step_cap_reached';

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -782,7 +782,11 @@ async function readVerifierOutcome(
   if (outcome !== 'passed' && outcome !== 'failed' && outcome !== 'candidate_timeout') {
     throw new HarborInfraError(`verifier outcome is malformed for task ${taskId}`);
   }
-  if (!Array.isArray(value.attempts) || value.attempts.length < 1 || value.attempts.length > 2) {
+  if (
+    !Array.isArray(value.attempts) ||
+    value.attempts.length < 1 ||
+    value.attempts.length > HARBOR_ORACLE_MAX_ATTEMPTS
+  ) {
     throw new HarborInfraError(`verifier outcome attempts are malformed for task ${taskId}`);
   }
   const attempts = value.attempts.map((attempt, index) =>
@@ -1093,6 +1097,8 @@ function harborVerifierConfig(verifier: ReturnType<typeof verifierPolicy>) {
     kwargs: {
       attempt_timeout_sec: verifier.attemptTimeoutSec,
       max_attempts: HARBOR_ORACLE_MAX_ATTEMPTS,
+      retry_backoff_sec: HARBOR_ORACLE_EXECUTION_POLICY.verifier.retryBackoffSec,
+      total_timeout_sec: verifier.totalTimeoutSec,
     },
     override_timeout_sec: verifier.outerTimeoutSec,
   };
@@ -1100,16 +1106,18 @@ function harborVerifierConfig(verifier: ReturnType<typeof verifierPolicy>) {
 
 function verifierPolicy(task: TaskRunInput['task']): {
   attemptTimeoutSec: number;
+  totalTimeoutSec: number;
   outerTimeoutSec: number;
 } {
   const attemptTimeoutSec =
     task.metadata?.verifierTimeoutSec ??
     HARBOR_ORACLE_EXECUTION_POLICY.verifier.defaultAttemptTimeoutSec;
+  const totalTimeoutSec =
+    attemptTimeoutSec * HARBOR_ORACLE_EXECUTION_POLICY.verifier.totalAttemptBudgetMultiplier;
   return {
     attemptTimeoutSec,
-    outerTimeoutSec:
-      attemptTimeoutSec * HARBOR_ORACLE_MAX_ATTEMPTS +
-      HARBOR_ORACLE_EXECUTION_POLICY.verifier.retryGraceSec,
+    totalTimeoutSec,
+    outerTimeoutSec: totalTimeoutSec + HARBOR_ORACLE_EXECUTION_POLICY.verifier.retryGraceSec,
   };
 }
 

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -384,13 +384,25 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
         selectedUsage && selectedUsage !== rawCell.tokenSummary
           ? { ...rawCell, tokenSummary: selectedUsage }
           : rawCell;
-      const cell =
+      const usageCell =
         checkpointedCell.tokenSummary || !providerUsage || !runnerOptions.pricing
           ? checkpointedCell
           : {
               ...checkpointedCell,
               tokenSummary: providerTokenSummary(providerUsage, runnerOptions.pricing),
             };
+      const cell =
+        completeTimedOutTrial && reward <= 0
+          ? {
+              ...usageCell,
+              status: 'failed' as const,
+              errorClass: 'budget_exhausted',
+              deadlineSettlement: {
+                source: 'benchmark.deadline' as const,
+                mode: 'immediate' as const,
+              },
+            }
+          : usageCell;
       const verifierStdout = await readOptionalText(join(trialDir, TRIAL_VERIFIER_STDOUT));
       const verifier = await readVerifierOutcome(
         join(trialDir, TRIAL_VERIFIER_OUTCOME),

--- a/packages/headless/src/harbor-task-runner.ts
+++ b/packages/headless/src/harbor-task-runner.ts
@@ -391,18 +391,17 @@ export function createHarborTaskRunner(options: HarborTaskRunnerOptions): TaskRu
               ...checkpointedCell,
               tokenSummary: providerTokenSummary(providerUsage, runnerOptions.pricing),
             };
-      const cell =
-        completeTimedOutTrial && reward <= 0
-          ? {
-              ...usageCell,
-              status: 'failed' as const,
-              errorClass: 'budget_exhausted',
-              deadlineSettlement: {
-                source: 'benchmark.deadline' as const,
-                mode: 'immediate' as const,
-              },
-            }
-          : usageCell;
+      const cell = completeTimedOutTrial
+        ? {
+            ...usageCell,
+            status: 'failed' as const,
+            errorClass: 'budget_exhausted',
+            deadlineSettlement: {
+              source: 'benchmark.deadline' as const,
+              mode: 'immediate' as const,
+            },
+          }
+        : usageCell;
       const verifierStdout = await readOptionalText(join(trialDir, TRIAL_VERIFIER_STDOUT));
       const verifier = await readVerifierOutcome(
         join(trialDir, TRIAL_VERIFIER_OUTCOME),

--- a/packages/headless/src/harness-oracle-policy.ts
+++ b/packages/headless/src/harness-oracle-policy.ts
@@ -20,8 +20,10 @@ export const HARBOR_ORACLE_EXECUTION_POLICY = {
   },
   verifier: {
     importPath: 'maka_verifier:MakaVerifier',
-    maxAttempts: 2,
+    maxAttempts: 3,
     defaultAttemptTimeoutSec: 600,
+    totalAttemptBudgetMultiplier: 2,
+    retryBackoffSec: 2,
     retryGraceSec: 120,
     timeoutPolicy: 'candidate_timeout_without_replay',
   },


### PR DESCRIPTION
## Summary

Harden the shared headless benchmark path around failure boundaries discovered during the DeepSeek Flash harness A/B run:

- establish real execution opportunity before applying verifier grades, using completed model steps, provider usage, or workspace tool execution as independent evidence;
- preserve authoritative provider failure classes and enforce required final usage independently from execution opportunity;
- propagate Harbor `AgentTimeoutError` into deadline settlement regardless of verifier reward;
- isolate command transport descriptors from background descendants and reclaim abnormal wrappers;
- retry verifier-only infrastructure failures in the same live post-Agent workspace, without resampling the Agent.

The verifier recovery policy is deliberately bounded. It allows up to three attempts with 2s/4s exponential backoff inside the existing two-attempt command budget (1,200s by default), plus the existing 120s outer grace. A full native verifier timeout remains a terminal candidate failure and is never replayed. If infrastructure recovery exhausts its attempts or shared deadline, the structured outcome remains unscored infrastructure.

These changes extend the existing fixed-prompt controller, Harbor task runner, process-scope helper, and `MakaVerifier`; they do not add a parallel harness or candidate replay path.

This PR intentionally excludes DeepSeek experiment configuration, reports, WAL/sidecar data, run artifacts, manual adjudication, and task-specific recovery rules.

Refs #1680.

## Verification

- TDD: a completed final model event without usage remains a scored verifier failure when final usage is optional, and becomes `missing_token_usage` when final usage is required.
- TDD: pre-execution auth/billing failures preserve their provider class, remain unscored, and stop later cells.
- TDD: failed cells cannot bypass `requireFinalUsage`; provider-only deadline attempts remain scored agent outcomes.
- TDD: reward 0 and reward > 0 Harbor agent timeouts both retain deadline provenance.
- TDD: background descendants cannot retain command transport descriptors.
- TDD: two verifier infrastructure failures can recover on the third attempt with one Harbor trial/Agent run; final exhaustion remains unscored infrastructure.
- TDD: verifier retries use 2s/4s backoff and a shortened final attempt that exhausts the shared deadline remains infrastructure.
- `npm run build:test`
- `npm --workspace @maka/headless run test:dist` — 1,445 passed, 0 failed
- `npm --workspace @maka/headless run typecheck`
- `npm run lint`
- `npm run format:check`
- `git diff --check origin/main...HEAD`
- Fresh-eye independent final review: no findings; GO and stop.
- GitHub CI: `test` and `typecheck` pass.

## Base CI failure

GitHub `e2e` fails four `first-run.spec.ts` cases because the latest `main` renders zero recommended-provider rows. This branch does not change desktop, provider-registry, or first-run code. The base-introducing PR #1720 has the same four failures and 93 passing E2E cases; rerunning this branch reproduced that exact base failure.

## Compatibility

No public API or persisted manifest schema changes. The Oracle execution-policy fingerprint changes intentionally, so stored qualifications under the previous two-attempt verifier policy must be re-audited. Existing candidate pass/fail authority is unchanged; only incomplete evidence, authoritative provider/deadline failures, verifier infrastructure recovery, and abnormal command cleanup change behavior.
