### PR TITLE
feat: add opencode-free as a zero-credential default provider

### DIFF
--- a/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/icon-governance-contract.test.ts
@@ -943,7 +943,7 @@ describe('icon + typography governance contract', () => {
     );
   });
 
-  it('vendors one byte-exact upstream OpenCode mark for both plans', async () => {
+  it('vendors one byte-exact upstream OpenCode mark for all OpenCode plans', async () => {
     const [componentSrc, asset, notices] = await Promise.all([
       readFile(PROVIDER_BRAND_MARKS_FILE, 'utf8'),
       readFile(OPENCODE_BRAND_ASSET_FILE),
@@ -958,8 +958,8 @@ describe('icon + typography governance contract', () => {
     assert.match(componentSrc, /import opencodeBrandMark from '\.\.\/assets\/provider-brands\/opencode\.svg';/);
     assert.match(
       componentSrc,
-      /case 'opencode':\s*case 'opencode-go':\s*return <ProviderAssetMask src=\{opencodeBrandMark\} \/>/,
-      'Zen and Go must share the single upstream monochrome mark through the governed currentColor seam',
+      /case 'opencode':\s*case 'opencode-go':\s*case 'opencode-free':\s*return <ProviderAssetMask src=\{opencodeBrandMark\} \/>/,
+      'Zen, Go, and Free must share the single upstream monochrome mark through the governed currentColor seam',
     );
     assert.match(
       notices,

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -2,6 +2,7 @@ import { app, nativeImage, safeStorage } from 'electron';
 import { mkdir } from 'node:fs/promises';
 import { join } from 'node:path';
 import { setActiveProxy } from '@maka/runtime';
+import { resolveBootstrapConnections } from '@maka/core';
 import type {
   AgentGraphCoordinator,
   AgentGraphSupervisorWakeCoordinator,
@@ -173,36 +174,34 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     await mkdir(workspaceRoot, { recursive: true });
     if ((await connectionStore.list()).length > 0) return;
 
-    if (process.env.ANTHROPIC_API_KEY) {
-      const slug = 'env-anthropic';
+    // opencode-free is seeded unconditionally so a fresh install is usable with
+    // zero credentials; env-keyed providers layer on top and take the default
+    // when present (Anthropic before OpenAI). See resolveBootstrapConnections.
+    const seeds = resolveBootstrapConnections({
+      ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY,
+      OPENAI_API_KEY: process.env.OPENAI_API_KEY,
+    });
+    for (const seed of seeds) {
       await connectionStore.create({
-        slug,
-        name: 'Anthropic (env)',
-        providerType: 'anthropic',
-        defaultModel: 'claude-sonnet-4-5-20250929',
+        slug: seed.slug,
+        name: seed.name,
+        providerType: seed.providerType,
+        defaultModel: seed.defaultModel,
       });
-      await credentialStore.setSecret(slug, 'api_key', process.env.ANTHROPIC_API_KEY);
-      await connectionStore.setDefault(slug);
-      // Bootstrap runs in BACKGROUND startup (#456): the renderer may have
-      // already seeded its connection list from the onboarding snapshot,
-      // so push the change or the model picker stays empty until an
-      // unrelated action refreshes it.
-      emitConnectionListChanged();
-      return;
+      const envApiKey =
+        seed.providerType === 'anthropic'
+          ? process.env.ANTHROPIC_API_KEY
+          : seed.providerType === 'openai'
+            ? process.env.OPENAI_API_KEY
+            : undefined;
+      if (envApiKey) await credentialStore.setSecret(seed.slug, 'api_key', envApiKey);
+      if (seed.isDefault) await connectionStore.setDefault(seed.slug);
     }
-
-    if (process.env.OPENAI_API_KEY) {
-      const slug = 'env-openai';
-      await connectionStore.create({
-        slug,
-        name: 'OpenAI (env)',
-        providerType: 'openai',
-        defaultModel: 'gpt-4o-mini',
-      });
-      await credentialStore.setSecret(slug, 'api_key', process.env.OPENAI_API_KEY);
-      await connectionStore.setDefault(slug);
-      emitConnectionListChanged();
-    }
+    // Bootstrap runs in BACKGROUND startup (#456): the renderer may have
+    // already seeded its connection list from the onboarding snapshot,
+    // so push the change or the model picker stays empty until an
+    // unrelated action refreshes it.
+    if (seeds.length > 0) emitConnectionListChanged();
   }
 
   app.whenReady().then(async () => {

--- a/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
+++ b/apps/desktop/src/renderer/settings/provider-brand-marks.tsx
@@ -388,6 +388,7 @@ export function ProviderBrandMark({ type }: { type: ProviderType }): ReactElemen
       return <ProviderAssetMask src={vercelBrandMark} />;
     case 'opencode':
     case 'opencode-go':
+    case 'opencode-free':
       return <ProviderAssetMask src={opencodeBrandMark} />;
     case 'anthropic':
     case 'anthropic-compatible':

--- a/apps/desktop/src/renderer/settings/provider-display-copy.ts
+++ b/apps/desktop/src/renderer/settings/provider-display-copy.ts
@@ -220,6 +220,10 @@ export const PROVIDER_DISPLAY_COPY = {
     zh: { name: 'OpenCode Go', description: '低价订阅制的开源编码模型精选', badge: 'Plan' },
     en: { name: 'OpenCode Go', description: 'Low-cost subscription to curated open coding models.', badge: 'Plan' },
   },
+  'opencode-free': {
+    zh: { name: 'OpenCode Free', description: '免费匿名 OpenCode Zen 模型，无需密钥，按 IP 限速', badge: 'Free' },
+    en: { name: 'OpenCode Free', description: 'Free anonymous OpenCode Zen models — no API key, IP-limited.', badge: 'Free' },
+  },
   groq: {
     zh: { name: 'Groq', description: 'LPU 高速推理托管开源模型', badge: 'API' },
     en: { name: 'Groq', description: 'Ultra-fast LPU-hosted open models.', badge: 'API' },

--- a/packages/core/src/__tests__/bootstrap-connections.test.ts
+++ b/packages/core/src/__tests__/bootstrap-connections.test.ts
@@ -1,0 +1,55 @@
+/**
+ * resolveBootstrapConnections — zero-credential default seed decision.
+ *
+ * A fresh Maka install must be usable out of the box. The bootstrap seeds an
+ * `opencode-free` connection (no secret, anonymous OpenCode Zen free models)
+ * so a user with no provider keys can send a message immediately. Env-keyed
+ * providers (ANTHROPIC_API_KEY / OPENAI_API_KEY) layer on top and take the
+ * default, mirroring the pre-existing env-bootstrap behavior; opencode-free
+ * stays seeded as a fallback.
+ *
+ * Pure & sync — the caller (app-lifecycle) performs the connectionStore
+ * writes and emits the change event. This module only decides what to seed
+ * and which one is the default, so the decision is testable without Electron.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import { resolveBootstrapConnections } from '../bootstrap-connections.js';
+
+describe('resolveBootstrapConnections — zero-credential default seed', () => {
+  it('seeds opencode-free as the default when no env provider key is present', () => {
+    const seeds = resolveBootstrapConnections({});
+    const free = seeds.find((s) => s.slug === 'opencode-free');
+    assert.ok(free, 'opencode-free must always be seeded');
+    assert.equal(free?.providerType, 'opencode-free');
+    assert.equal(free?.defaultModel, 'big-pickle');
+    assert.equal(seeds.filter((s) => s.isDefault).length, 1, 'exactly one default');
+    assert.equal(seeds.find((s) => s.isDefault)?.slug, 'opencode-free');
+  });
+
+  it('defaults to the Anthropic env connection when ANTHROPIC_API_KEY is set, keeping opencode-free seeded', () => {
+    const seeds = resolveBootstrapConnections({ ANTHROPIC_API_KEY: 'sk-x' });
+    assert.ok(
+      seeds.some((s) => s.slug === 'opencode-free'),
+      'opencode-free stays seeded as a fallback',
+    );
+    assert.ok(!seeds.find((s) => s.slug === 'opencode-free')?.isDefault);
+    assert.equal(seeds.find((s) => s.isDefault)?.slug, 'env-anthropic');
+    assert.equal(seeds.find((s) => s.slug === 'env-anthropic')?.providerType, 'anthropic');
+  });
+
+  it('does not seed the OpenAI env connection when Anthropic is already present', () => {
+    const seeds = resolveBootstrapConnections({
+      ANTHROPIC_API_KEY: 'sk-x',
+      OPENAI_API_KEY: 'sk-y',
+    });
+    assert.ok(!seeds.some((s) => s.slug === 'env-openai'));
+  });
+
+  it('defaults to the OpenAI env connection when only OPENAI_API_KEY is set', () => {
+    const seeds = resolveBootstrapConnections({ OPENAI_API_KEY: 'sk-y' });
+    assert.ok(seeds.some((s) => s.slug === 'opencode-free'));
+    assert.equal(seeds.find((s) => s.isDefault)?.slug, 'env-openai');
+  });
+});

--- a/packages/core/src/__tests__/llm-connections.test.ts
+++ b/packages/core/src/__tests__/llm-connections.test.ts
@@ -71,6 +71,7 @@ describe('provider compatibility contract', () => {
       'zenmux',
       'opencode',
       'opencode-go',
+      'opencode-free',
       'togetherai',
       'fireworks-ai',
       'nvidia',
@@ -102,6 +103,7 @@ describe('provider compatibility contract', () => {
       'gemini-cli',
     ]);
     assert.deepEqual(READY_PROVIDER_TYPES, [
+      'opencode-free',
       'anthropic',
       'openai',
       'google',
@@ -158,6 +160,7 @@ describe('provider compatibility contract', () => {
       'alibaba-token-plan',
     ]);
     assert.deepEqual(CATALOG_PROVIDER_TYPES, [
+      'opencode-free',
       'kimi-coding-plan',
       'minimax-coding-plan',
       'deepseek',
@@ -229,6 +232,7 @@ describe('provider compatibility contract', () => {
       'the compatibility export must not copy registry state',
     );
     assert.deepEqual(RECOMMENDED_PROVIDER_TYPES, [
+      'opencode-free',
       'siliconflow',
       'anthropic',
       'openai',

--- a/packages/core/src/__tests__/opencode-free-provider.test.ts
+++ b/packages/core/src/__tests__/opencode-free-provider.test.ts
@@ -1,0 +1,69 @@
+/**
+ * opencode-free provider — first-class free anonymous default.
+ *
+ * Maka must be usable out of the box with zero credentials. opencode-free is a
+ * first-class provider that exposes OpenCode Zen's free, anonymous, IP-limited
+ * models over the same `https://opencode.ai/zen/v1` endpoint, with no API key
+ * (the runtime sends a placeholder that the OpenCode server treats as
+ * anonymous). It reuses the opencode (Zen) model metadata — same endpoint,
+ * same model ids — without duplicating snapshot entries.
+ *
+ * This contract pins the observable shape that makes "open Maka, send a
+ * message, pay nothing" work: the provider is registered, needs no secret,
+ * ships only active tool-capable free models, resolves their metadata via the
+ * opencode snapshot, and leads the recommended providers.
+ */
+
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+import {
+  PROVIDER_REGISTRY,
+  RECOMMENDED_PROVIDER_TYPES,
+  isWiredOAuthProvider,
+} from '../provider-registry.js';
+import { providerAuthRequiresSecret } from '../llm-connections.js';
+import { lookupModelMetadata } from '../model-metadata.js';
+
+describe('opencode-free provider — first-class free anonymous default', () => {
+  it('is registered as a ready anonymous overseas provider on the Zen endpoint', () => {
+    const def = PROVIDER_REGISTRY['opencode-free'];
+    assert.ok(def, 'opencode-free must be registered');
+    assert.equal(def.authKind, 'none');
+    assert.equal(def.baseUrl, 'https://opencode.ai/zen/v1');
+    assert.equal(def.status, 'ready');
+    assert.equal(def.category, 'overseas');
+    assert.equal(def.protocol, 'openai');
+  });
+
+  it('does not require a secret and is not an OAuth provider', () => {
+    assert.equal(providerAuthRequiresSecret('opencode-free'), false);
+    assert.equal(isWiredOAuthProvider('opencode-free'), false);
+  });
+
+  it('ships only active, tool-capable free models as its default catalog', () => {
+    const def = PROVIDER_REGISTRY['opencode-free'];
+    assert.ok(def.fallbackModels.length > 0, 'opencode-free must ship a non-empty free model set');
+    for (const id of def.fallbackModels) {
+      const meta = lookupModelMetadata('opencode-free', id);
+      assert.equal(
+        meta.capabilities?.functionCalling,
+        true,
+        `${id} must be tool-capable (free agents need function calling)`,
+      );
+      assert.equal(meta.lifecycle, 'active', `${id} must be an active (non-deprecated) free model`);
+    }
+  });
+
+  it('reuses the opencode Zen model metadata without duplicating entries', () => {
+    // big-pickle is an active free model that lives under the opencode (Zen)
+    // snapshot. opencode-free must resolve it through modelsDevId: 'opencode',
+    // not by carrying its own copy.
+    const viaFree = lookupModelMetadata('opencode-free', 'big-pickle');
+    const viaZen = lookupModelMetadata('opencode', 'big-pickle');
+    assert.deepEqual(viaFree, viaZen);
+  });
+
+  it('leads the recommended providers so Maka is usable out of the box', () => {
+    assert.equal(RECOMMENDED_PROVIDER_TYPES[0], 'opencode-free');
+  });
+});

--- a/packages/core/src/__tests__/opencode-free-provider.test.ts
+++ b/packages/core/src/__tests__/opencode-free-provider.test.ts
@@ -4,7 +4,8 @@
  * Maka must be usable out of the box with zero credentials. opencode-free is a
  * first-class provider that exposes OpenCode Zen's free, anonymous, IP-limited
  * models over the same `https://opencode.ai/zen/v1` endpoint, with no API key
- * (the runtime sends a placeholder that the OpenCode server treats as
+ * (the runtime passes an empty key and @ai-sdk/openai-compatible omits the
+ * Authorization header, so the OpenCode server treats the request as
  * anonymous). It reuses the opencode (Zen) model metadata — same endpoint,
  * same model ids — without duplicating snapshot entries.
  *

--- a/packages/core/src/bootstrap-connections.ts
+++ b/packages/core/src/bootstrap-connections.ts
@@ -1,0 +1,74 @@
+/**
+ * Bootstrap connection seed decision.
+ *
+ * Decides which provider connections a fresh Maka install seeds before the
+ * user configures anything, and which one is the default. Pure & sync — the
+ * caller owns the connectionStore writes and the change event.
+ *
+ * `opencode-free` is seeded unconditionally so Maka is usable out of the box
+ * with zero credentials: it is an anonymous OpenCode Zen free-tier provider
+ * (no API key; the runtime omits Authorization and the server treats the
+ * request as anonymous, matching the upstream OpenCode client). Env-keyed
+ * providers layer on top and take the default when present, preserving the
+ * prior env-bootstrap precedence (Anthropic before OpenAI).
+ */
+
+import type { ProviderType } from './llm-connections.js';
+
+export interface BootstrapConnectionSeed {
+  readonly slug: string;
+  readonly name: string;
+  readonly providerType: ProviderType;
+  readonly defaultModel: string;
+  readonly isDefault: boolean;
+}
+
+export interface BootstrapEnv {
+  readonly ANTHROPIC_API_KEY?: string;
+  readonly OPENAI_API_KEY?: string;
+}
+
+const OPENCODE_FREE_SEED: Omit<BootstrapConnectionSeed, 'isDefault'> = {
+  slug: 'opencode-free',
+  name: 'OpenCode Free',
+  providerType: 'opencode-free',
+  defaultModel: 'big-pickle',
+};
+
+const ANTHROPIC_ENV_SEED: Omit<BootstrapConnectionSeed, 'isDefault'> = {
+  slug: 'env-anthropic',
+  name: 'Anthropic (env)',
+  providerType: 'anthropic',
+  defaultModel: 'claude-sonnet-4-5-20250929',
+};
+
+const OPENAI_ENV_SEED: Omit<BootstrapConnectionSeed, 'isDefault'> = {
+  slug: 'env-openai',
+  name: 'OpenAI (env)',
+  providerType: 'openai',
+  defaultModel: 'gpt-4o-mini',
+};
+
+/**
+ * Resolve the bootstrap connection seeds for a fresh install.
+ *
+ * `opencode-free` is always seeded as the zero-credential fallback. When an
+ * env provider key is present that provider is added and takes the default
+ * (Anthropic wins over OpenAI, and OpenAI is not seeded when Anthropic is
+ * present — matching the original bootstrap's `return` after Anthropic).
+ */
+export function resolveBootstrapConnections(env: BootstrapEnv): readonly BootstrapConnectionSeed[] {
+  const seeds: BootstrapConnectionSeed[] = [];
+
+  const freeDefault = !env.ANTHROPIC_API_KEY && !env.OPENAI_API_KEY;
+  seeds.push({ ...OPENCODE_FREE_SEED, isDefault: freeDefault });
+
+  if (env.ANTHROPIC_API_KEY) {
+    seeds.push({ ...ANTHROPIC_ENV_SEED, isDefault: true });
+    return seeds;
+  }
+  if (env.OPENAI_API_KEY) {
+    seeds.push({ ...OPENAI_ENV_SEED, isDefault: true });
+  }
+  return seeds;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1438,6 +1438,13 @@ export {
   sanitizeOnboardingMilestones,
 } from './onboarding.js';
 
+// bootstrap-connections.ts
+export type {
+  BootstrapConnectionSeed,
+  BootstrapEnv,
+} from './bootstrap-connections.js';
+export { resolveBootstrapConnections } from './bootstrap-connections.js';
+
 // model-catalog.ts
 export type {
   BuildModelCatalogInput,

--- a/packages/core/src/model-metadata.ts
+++ b/packages/core/src/model-metadata.ts
@@ -31,11 +31,20 @@ const generatedModelProviderOverrides: Partial<
 
 export function lookupModelMetadata(providerType: ProviderType, modelId: string): ModelMetadata {
   const id = modelId.trim();
-  const metadataProviderType = providerType === 'xai-oauth' ? 'xai' : providerType;
+  const metadataProviderType =
+    providerType === 'xai-oauth'
+      ? 'xai'
+      : providerType === 'opencode-free'
+        ? 'opencode'
+        : providerType;
   const generated = generatedMetadata[metadataProviderType]?.[id];
   const override =
     STATIC_MODEL_METADATA[providerType]?.[id] ??
-    (providerType === 'xai-oauth' ? STATIC_MODEL_METADATA.xai?.[id] : undefined);
+    (providerType === 'xai-oauth'
+      ? STATIC_MODEL_METADATA.xai?.[id]
+      : providerType === 'opencode-free'
+        ? STATIC_MODEL_METADATA.opencode?.[id]
+        : undefined);
   if (!generated) return override ?? {};
   if (!override) return generated;
   return {

--- a/packages/core/src/provider-registry.ts
+++ b/packages/core/src/provider-registry.ts
@@ -549,6 +549,28 @@ const opencodeGoModelIds = toolCallingModelIds(
   GENERATED_MODELS_DEV_METADATA['opencode-go'],
   ['minimax-m3'],
 ).filter((id) => GENERATED_MODELS_DEV_METADATA['opencode-go'][id]?.lifecycle !== 'deprecated');
+// opencode-free is Maka's first-class free anonymous default. It shares the
+// OpenCode Zen endpoint and model ids, but exposes only the active free
+// (cost.input === 0) models from the models.dev opencode snapshot. The
+// snapshot carries no cost field, so the free set is pinned here; each id is
+// validated against the opencode snapshot for active + tool-capable, mirroring
+// the bootstrap validation every other opencode plan entry performs.
+const opencodeFreeModelIds = [
+  'big-pickle',
+  'mimo-v2.5-free',
+  'nemotron-3-ultra-free',
+  'deepseek-v4-flash-free',
+  'north-mini-code-free',
+  'hy3-free',
+] as const;
+for (const id of opencodeFreeModelIds) {
+  const model = GENERATED_MODELS_DEV_METADATA.opencode[id];
+  if (!model?.capabilities?.functionCalling || model.lifecycle === 'deprecated') {
+    throw new Error(
+      `models.dev opencode snapshot is missing an active tool-capable free model ${id} for opencode-free`,
+    );
+  }
+}
 const githubCopilot = GENERATED_MODELS_DEV_PROVIDER_FACTS['github-copilot'];
 if (githubCopilot.id !== 'github-copilot') {
   throw new Error('models.dev GitHub Copilot provider facts are missing stable id github-copilot');
@@ -1177,6 +1199,30 @@ const providerRegistry = {
     modelsDevId: opencodeGo.id,
     readyOrder: 38,
     catalogOrder: 38,
+  },
+  'opencode-free': {
+    label: 'OpenCode Free',
+    description: 'Free anonymous OpenCode Zen models — no API key required, usage limited by IP.',
+    baseUrl: opencode.api,
+    authKind: 'none',
+    backendKind: 'ai-sdk',
+    fallbackModels: [...opencodeFreeModelIds],
+    status: 'ready',
+    protocol: 'openai',
+    runtimeAdapter: { kind: 'openai-compatible', name: 'provider' },
+    modelDiscovery: {
+      kind: 'fallback',
+      reason:
+        'OpenCode Free anonymous access serves a fixed set of free models; the inference endpoint has no anonymous model-list contract.',
+    },
+    category: 'overseas',
+    catalogGroup: 'plans',
+    catalogBadge: 'Free',
+    signupUrl: 'https://opencode.ai/zen',
+    modelsDevId: opencode.id,
+    readyOrder: 0,
+    catalogOrder: 0,
+    recommendedOrder: 0,
   },
   togetherai: {
     label: together.name,

--- a/packages/runtime/src/__tests__/opencode-free-anonymous.test.ts
+++ b/packages/runtime/src/__tests__/opencode-free-anonymous.test.ts
@@ -1,0 +1,81 @@
+/**
+ * opencode-free anonymous runtime — the invariant the free tier depends on.
+ *
+ * opencode-free is Maka's zero-credential default. Its free-tier access works
+ * ONLY because the request carries no Authorization header and the OpenCode
+ * Zen server treats that as anonymous (per-IP rate-limited). This invariant is
+ * the whole point of the provider, so it must be locked directly against
+ * opencode-free, not inferred from "the code path looks like Ollama's".
+ *
+ * If @ai-sdk/openai-compatible ever stops omitting the header on an empty key,
+ * or someone later "improves" opencode-free by injecting a placeholder key,
+ * this test must fail before the anonymous free path silently breaks.
+ */
+import assert from 'node:assert/strict';
+import { describe, test } from 'node:test';
+import { generateText } from 'ai';
+import { PROVIDER_DEFAULTS, type LlmConnection } from '@maka/core';
+import { getAIModel } from '@maka/runtime';
+
+describe('opencode-free anonymous runtime', () => {
+  test('omits Authorization and posts to zen/v1 with the model id (empty key, no secret)', async () => {
+    const baseUrl = PROVIDER_DEFAULTS['opencode-free'].baseUrl;
+    const connection: LlmConnection = {
+      slug: 'opencode-free',
+      name: 'OpenCode Free',
+      providerType: 'opencode-free',
+      baseUrl,
+      defaultModel: 'big-pickle',
+      enabled: true,
+      createdAt: 0,
+      updatedAt: 0,
+    };
+
+    let captured: { url: string; authorization: string | null; model: unknown } | undefined;
+    const fakeFetch: typeof globalThis.fetch = async (input, init) => {
+      const request = new Request(input, init);
+      const body = JSON.parse(await request.text()) as Record<string, unknown>;
+      captured = {
+        url: request.url,
+        authorization: request.headers.get('authorization'),
+        model: body.model,
+      };
+      return new Response(
+        JSON.stringify({
+          id: 'chatcmpl-opencode-free',
+          object: 'chat.completion',
+          created: 1,
+          model: 'big-pickle',
+          choices: [
+            {
+              index: 0,
+              message: { role: 'assistant', content: 'ok' },
+              finish_reason: 'stop',
+            },
+          ],
+          usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    };
+
+    const model = getAIModel({
+      connection,
+      apiKey: '',
+      modelId: 'big-pickle',
+      fetch: fakeFetch,
+    });
+
+    const result = await generateText({ model, prompt: 'hi' });
+
+    assert.ok(captured, 'opencode-free request was issued');
+    assert.equal(
+      captured?.authorization,
+      null,
+      'opencode-free must send NO Authorization header (anonymous free tier)',
+    );
+    assert.equal(captured?.url, `${baseUrl}/chat/completions`);
+    assert.equal(captured?.model, 'big-pickle');
+    assert.equal(result.text, 'ok');
+  });
+});


### PR DESCRIPTION
## Summary

Maka now works out of the box with zero credentials. This adds `opencode-free` as a first-class provider exposing OpenCode Zen's free, anonymous, IP-limited models over `https://opencode.ai/zen/v1` with no API key, and seeds it as the default connection on first launch.

The free tier is **not** an OAuth account login. The mechanism is: the client omits `Authorization` entirely, the OpenCode server treats the request as anonymous, and models flagged `allowAnonymous` are served subject to per-IP rate limiting (`FreeUsageLimitError` on overflow). This matches the upstream OpenCode client's free-tier behavior. `opencode-go` (Go subscription) stays `api_key` — its models are all `cost > 0`.

- New `opencode-free` provider (`authKind: 'none'`, `recommendedOrder: 0`): 6 active, tool-capable, `cost=0` models pinned from the models.dev opencode snapshot (`big-pickle`, `mimo-v2.5-free`, `nemotron-3-ultra-free`, `deepseek-v4-flash-free`, `north-mini-code-free`, `hy3-free`). Model metadata is reused via `modelsDevId: 'opencode'` (mirroring `xai-oauth -> xai`), so no model entries are duplicated.
- `resolveBootstrapConnections` (pure, sync, in `@maka/core`, testable without Electron) decides the first-launch seed: `opencode-free` is always seeded; env-keyed providers (`ANTHROPIC_API_KEY` / `OPENAI_API_KEY`) layer on top and take the default when present, preserving the prior Anthropic-before-OpenAI precedence. `app-lifecycle.ensureBootstrapConnection` drives the connectionStore from this decision.
- `opencode-free` `authKind: 'none'` bypasses the secret readiness gate, so the seeded connection is ready immediately. Runtime uses the existing `openai-compatible` path (same as Ollama) with an empty apiKey, so no runtime changes are needed.

## Verification

- `@maka/core`: 1223 tests pass (`npx tsx --test`), build + tsc clean.
- `apps/desktop`: `tsc -p tsconfig.main/renderer/preload` clean; icon-governance 35, provider-display-copy-contract 2, and 117 provider/onboarding contract tests pass.
- `npm run format:check` (1339 files), `npm run lint` (2421 files), and `npm run typecheck` (all workspaces) clean.
- Rebased onto latest `main` (`80792ec8c`, #1711) with no conflicts.
- Live endpoint check against `https://opencode.ai/zen/v1`: both "no Authorization" and `Authorization: Bearer public` return `200` for `GET /v1/models` and `POST /v1/chat/completions` (model `big-pickle`), with `cost:"0"` — confirming the empty-apiKey runtime path is anonymously admitted.

Not done (intentionally deferred):
- `FreeUsageLimitError` / `GoUsageLimitError` upgrade-guidance UI.
- A dedicated runtime wire test for `opencode-free` (it shares the Ollama `openai-compatible` path, which is already covered).