### PR TITLE
fix(ui): restore plan-reminder menu focus before opening the edit dialog

### DIFF
--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -109,6 +109,16 @@ export function PlanReminderPanel(props: {
   const refreshPendingRef = useRef(false);
   const pendingActionKeysRef = useRef<Set<string>>(new Set());
   const pendingReminderMenuIntentRef = useRef<(() => void) | null>(null);
+  // A reminder row's menu trigger button, keyed by reminder id. When a
+  // deferred menu intent (edit/duplicate/clear-runs/delete) opens a dialog
+  // after the menu closes, Astryx Dialog restores focus on Esc to whatever
+  // was `document.activeElement` when it opened. The menu's own close-focus-
+  // return and the deferred dialog open sit two `requestAnimationFrame`s
+  // apart, so on a loaded runner the captured element can land on <body>
+  // instead of the trigger and Esc strands focus away from the row. The
+  // deferred intent re-focuses the trigger right before opening the dialog,
+  // making that capture deterministic. See plan-reminders E2E.
+  const reminderMenuTriggerRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
   // Issue #1044: all create/edit form fields + submit moved into
   // PlanReminderFormDialog. The panel owns its open state and seed;
   // `formNonce` remounts a closed form session before Astryx opens it.
@@ -234,7 +244,13 @@ export function PlanReminderPanel(props: {
     pendingReminderMenuIntentRef.current = null;
     if (intent) {
       window.requestAnimationFrame(() => {
-        if (planReminderMountedRef.current) intent();
+        if (!planReminderMountedRef.current) return;
+        // Re-establish the trigger as the active element before the intent
+        // opens a dialog, so the dialog captures and later restores focus to
+        // the row's menu trigger instead of whatever drifted to <body> during
+        // the menu-close → deferred-open window.
+        reminderMenuTriggerRefs.current.get(reminderId)?.focus();
+        intent();
       });
     }
   }
@@ -494,6 +510,10 @@ export function PlanReminderPanel(props: {
                             isIconOnly: true,
                             variant: 'ghost',
                             size: 'sm',
+                            ref: (el) => {
+                              if (el) reminderMenuTriggerRefs.current.set(reminder.id, el);
+                              else reminderMenuTriggerRefs.current.delete(reminder.id);
+                            },
                           }}
                           className="maka-plan-card-menu"
                         >


### PR DESCRIPTION
## Summary

The plan-reminder edit/duplicate flow defers opening the Astryx form dialog by two `requestAnimationFrame`s after the row menu closes: the menu stashes an intent, runs it on close, then `openReminderDialog` remounts a closed form session before Astryx observes a false→true transition. Astryx `Dialog` restores focus on Escape to whatever was `document.activeElement` when it opened, and the menu's own close-focus-return sits in that same window. On a loaded CI runner the captured element can land on `<body>` instead of the menu trigger, so Escape strands focus away from the row and `expect(menu).toBeFocused()` times out.

This made the `plan-reminders` E2E flaky: on docs-only PR #1719 the same code tree (b1a0004e) passed on #1714 and failed on #1719, and a rerun went green. The suite runs with `retries: 0`, so the flake blocks unrelated PRs.

Keep a ref to each row's menu trigger (via the Astryx `DropdownMenu` `button.ref`) and re-focus it inside the deferred intent, right before the dialog opens, so the dialog captures and later restores focus to the row's trigger deterministically — independent of the menu-close vs deferred-open micro-timing.

## Verification

- `packages/ui` typecheck + `@maka/ui` build (tsc): clean
- `@maka/ui` contract tests: 296 passed, 0 failed
- `biome lint packages/ui/src/plan-reminder-panel.tsx`: clean
- `plan-reminders` E2E (`apps/desktop`), `--repeat-each 6`: 12/12 passed, including `closes a reminder menu before opening its edit dialog` (the previously flaky case)
- CI on this branch: `typecheck` and `test` green; `e2e` — the two `plan-reminders` tests pass, but 4 `e2e/first-run.spec.ts` tests fail. Those 4 fail with an identical pattern (4 failed, 93 passed) on at least three unrelated branches at the same time (codex/remove-expert-mode, feat/opencode-free-default-models, chore/prune-static-contract-tests), so they are a pre-existing active flaky cluster in the first-run boot flow, not a regression from this change (which only touches `packages/ui/src/plan-reminder-panel.tsx`).

## Root cause

`apps/desktop/e2e/plan-reminders.spec.ts:75 › closes a reminder menu before opening its edit dialog` asserted `expect(menu).toBeFocused()` after Escape closed the edit dialog. Astryx `Dialog` restores focus to the element it captured as `document.activeElement` at open time (`triggerElementRef.current = document.activeElement` in its open effect). The edit flow deferred the dialog open two rAFs past the menu close, so the menu's close-focus-return and the dialog's capture raced; under CI load the capture landed on `<body>`, so Escape restored to `<body>` and the trigger stayed `inactive` for the full 10s timeout.