### PR TITLE
refactor: migrate shell navigation to Astryx

### DIFF
--- a/apps/desktop/e2e/fixtures.ts
+++ b/apps/desktop/e2e/fixtures.ts
@@ -290,7 +290,7 @@ export const test = base.extend<{
   // The `[data-sidebar-state="expanded"]` part is load-bearing. The shell
   // boots collapsed (the localStorage default), and `sidebarCollapsed: false`
   // only lands later, from `applyE2eFixture` — a rAF plus two IPC round trips
-  // after mount. A bare `.maka-list-row` does not gate on it: a collapsed
+  // after mount. A bare `.maka-session-list-item` does not gate on it: a collapsed
   // sidebar keeps the whole list mounted at full width behind `opacity: 0` in
   // a 0px grid column, which Playwright still reports as visible. Tests then
   // started against a sidebar that was about to expand under them.
@@ -298,7 +298,7 @@ export const test = base.extend<{
     await withE2eWindow(
       {
         seed: false,
-        readinessSelector: '[data-sidebar-state="expanded"] .maka-list-row',
+        readinessSelector: '[data-sidebar-state="expanded"] .maka-session-list-item',
         e2eFixtureScenario: 'sidebar-long-sessions',
         locale: 'zh',
       },

--- a/apps/desktop/e2e/project-management.spec.ts
+++ b/apps/desktop/e2e/project-management.spec.ts
@@ -28,5 +28,5 @@ test('project picker keeps fixed actions outside the scroll region and can creat
   const sidebar = page.locator('.maka-session-panel');
   await sidebar.getByRole('button', { name: '会话分组方式' }).click();
   await page.getByRole('menuitemradio', { name: '按项目' }).click();
-  await expect(sidebar.locator('.maka-list-project-heading').filter({ hasText: '未归属项目' })).toBeVisible();
+  await expect(sidebar.getByRole('treeitem').filter({ hasText: '未归属项目' }).last()).toBeVisible();
 });

--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -2,11 +2,23 @@ import { test, expect } from './fixtures';
 
 test('session tools share one user-controlled workbar', async ({ sessionWorkbarWindow: page }) => {
   const workbar = page.getByRole('complementary', { name: '会话工作栏' });
-  const tabs = workbar.getByRole('tablist', { name: '会话工作栏栏目' });
+  const sections = workbar.getByRole('navigation', { name: '会话工作栏栏目' });
+  const tasks = sections.getByRole('button', { name: /任务/ });
+  const browser = sections.getByRole('button', { name: /浏览器/ });
+  const files = sections.getByRole('button', { name: /文件/ });
 
-  await expect(tabs.getByRole('tab', { name: /任务/ })).toHaveAttribute('aria-selected', 'true');
-  await expect(tabs.getByRole('tab', { name: /浏览器/ })).toBeDisabled();
-  await expect(tabs.getByRole('tab', { name: /文件/ })).toBeEnabled();
+  await expect(workbar.getByRole('tablist')).toHaveCount(0);
+  await expect(sections).toHaveClass(/astryx-tab-list/);
+  await expect(tasks).toHaveAttribute('aria-current', 'page');
+  await expect(browser).toHaveAttribute('aria-disabled', 'true');
+  await expect(files).not.toHaveAttribute('aria-current');
+
+  await tasks.focus();
+  await tasks.press('ArrowRight');
+  await expect(files).toBeFocused();
+  await files.press('Enter');
+  await expect(files).toHaveAttribute('aria-current', 'page');
+  await tasks.click();
   await expect(
     workbar.getByRole('tree', { name: '活跃会话任务' }).getByText('完成会话任务台账升级'),
   ).toBeVisible();
@@ -55,7 +67,7 @@ test('session tools share one user-controlled workbar', async ({ sessionWorkbarW
 
   await page.getByRole('button', { name: '展开会话工作栏' }).click();
   await expect(workbar).toBeVisible();
-  await tabs.getByRole('tab', { name: /文件/ }).click();
+  await files.click();
   await expect(workbar.getByText('暂无生成文件')).toBeVisible();
 
   await page.setViewportSize({ width: 480, height: 320 });
@@ -66,7 +78,7 @@ test('session tools share one user-controlled workbar', async ({ sessionWorkbarW
   expect(narrowLayout.height).toBeLessThanOrEqual(narrowLayout.viewportHeight * 0.42 + 1);
 
   await page.locator('button[aria-label="展开侧边栏"]').dispatchEvent('click');
-  await page.locator('button[aria-label="扩展"]').dispatchEvent('click');
+  await page.getByRole('button', { name: '扩展', exact: true }).dispatchEvent('click');
   await expect(workbar).toBeHidden();
   await expect(page.getByRole('main', { name: '扩展' })).toBeVisible();
 });

--- a/apps/desktop/e2e/sidebar-geometry.spec.ts
+++ b/apps/desktop/e2e/sidebar-geometry.spec.ts
@@ -222,26 +222,26 @@ test('keyboard sidebar resize bypasses drawer motion without disabling collapse 
 
   await handle.focus();
   await expect(handle).toBeFocused();
-  expect(await shell.evaluate((element) => getComputedStyle(element).transitionDuration)).toBe('0s');
+  const sidebarSlot = shell.locator('.maka-shell-sidebar-slot');
+  expect(await sidebarSlot.evaluate((element) => getComputedStyle(element).transitionDuration)).toBe('0s');
 
   const beforeWidth = Number(await handle.getAttribute('aria-valuenow'));
   await handle.press('ArrowRight');
   const after = await shell.evaluate((element) => {
     const handle = element.querySelector('.maka-resize-handle');
-    const firstTrack = getComputedStyle(element).gridTemplateColumns.split(' ')[0];
+    const slot = element.querySelector('.maka-shell-sidebar-slot');
     return {
       ariaWidth: Number(handle?.getAttribute('aria-valuenow')),
-      trackWidth: Number.parseFloat(firstTrack ?? ''),
+      slotWidth: slot?.getBoundingClientRect().width ?? 0,
     };
   });
 
   expect(after.ariaWidth).toBe(beforeWidth + 10);
-  expect(after.trackWidth).toBe(after.ariaWidth);
+  expect(after.slotWidth).toBe(after.ariaWidth);
 
   await handle.blur();
   await expect
-    .poll(() => shell.evaluate((element) => getComputedStyle(element).transitionDuration))
+    .poll(() => sidebarSlot.evaluate((element) => getComputedStyle(element).transitionDuration))
     .toBe('0.28s');
-  expect(await shell.evaluate((element) => getComputedStyle(element).transitionProperty))
-    .toContain('grid-template-columns');
+  expect(await sidebarSlot.evaluate((element) => getComputedStyle(element).transitionProperty)).toContain('width');
 });

--- a/apps/desktop/e2e/sidebar-geometry.spec.ts
+++ b/apps/desktop/e2e/sidebar-geometry.spec.ts
@@ -161,7 +161,7 @@ test('sidebar list scrolls independently and keeps the footer in view with 60 se
   // handful of baseline chat sessions; their exact count is not this
   // contract's concern — the 60-row pin alone proves the overflow
   // precondition the geometry assertions depend on.
-  await expect(page.locator('.maka-list-row-main[title^="会话 "]')).toHaveCount(60);
+  await expect(page.locator('.maka-session-item-label').filter({ hasText: /^会话 \d{2}$/ })).toHaveCount(60);
 
   // The list scroller and the chat scroller are distinct elements.
   await expect(page.locator(LIST_VIEWPORT)).toHaveCount(1);

--- a/apps/desktop/e2e/sidebar-navigation.spec.ts
+++ b/apps/desktop/e2e/sidebar-navigation.spec.ts
@@ -118,7 +118,9 @@ test('session heading stays singular and the default list has no redundant headi
 }) => {
   const sidebar = await expandedSidebar(page);
   const panelHeading = sidebar.locator('.maka-session-list-heading');
-  const navLabel = sidebar.locator('.maka-nav-row span:nth-child(2)').first();
+  const navLabel = sidebar.getByRole('button', { name: '新任务', exact: true }).getByText('新任务', {
+    exact: true,
+  });
 
   await expect(sidebar.getByText('会话', { exact: true })).toHaveCount(1);
   await expect(sidebar.locator('.maka-list-group-label')).toHaveCount(0);

--- a/apps/desktop/e2e/sidebar-navigation.spec.ts
+++ b/apps/desktop/e2e/sidebar-navigation.spec.ts
@@ -31,13 +31,14 @@ test('session grouping menu switches between flat conversations and project disc
   const popup = page.getByRole('menu', { name: '会话分组方式' });
 
   await expect(sidebar.locator('.maka-list-group-label')).toHaveCount(0);
-  await expect(sidebar.locator('.maka-list-row').first()).toBeVisible();
+  await expect(sidebar.locator('.maka-session-list-item').first()).toBeVisible();
   await grouping.click();
   const byTime = page.getByRole('menuitemradio', { name: '按时间' });
   const byProject = page.getByRole('menuitemradio', { name: '按项目' });
   await expect(byTime).toHaveAttribute('aria-checked', 'true');
   await byProject.click();
-  await expect(sidebar.locator('.maka-list-project-heading').first()).toBeVisible();
+  await expect(sidebar.getByRole('tree')).toBeVisible();
+  await expect(sidebar.getByRole('treeitem').first()).toBeVisible();
 
   // A radio item does not dismiss the menu, so the single trigger click this
   // used to do was closing the menu, not reopening it — and the radios below
@@ -69,9 +70,8 @@ test('session delete intent opens only after its menu closes and restores the tr
   sidebarLongSessionsWindow: page,
 }) => {
   const sidebar = await expandedSidebar(page);
-  const row = sidebar.locator('.maka-list-row').filter({ hasText: '会话 00' }).first();
-  const rowButton = row.locator('[data-session-id]').first();
-  await rowButton.focus();
+  const row = sidebar.locator('.maka-session-list-item').filter({ hasText: '会话 00' }).first();
+  await row.getByRole('button').first().focus();
 
   const trigger = row.getByRole('button', { name: '对话操作' });
   await trigger.press('Enter');
@@ -86,6 +86,31 @@ test('session delete intent opens only after its menu closes and restores the tr
   await page.keyboard.press('Escape');
   await expect(confirm).toBeHidden();
   await expect(trigger).toBeFocused();
+});
+
+test('session rename keeps text-navigation keys inside the native tree item input', async ({
+  sidebarLongSessionsWindow: page,
+}) => {
+  const sidebar = await expandedSidebar(page);
+  await sidebar.getByRole('button', { name: '会话分组方式' }).click();
+  await page.getByRole('menuitemradio', { name: '按项目' }).click();
+
+  const tree = sidebar.getByRole('tree');
+  const initialRow = tree
+    .getByRole('button', { name: '会话 00', exact: true })
+    .locator('xpath=ancestor::li[@role="treeitem"][1]');
+  const treeId = await initialRow.getAttribute('data-tree-id');
+  if (!treeId) throw new Error('Expected the session tree item to expose its native tree id');
+  const row = tree.locator(`[role="treeitem"][data-tree-id="${treeId}"]`);
+  await row.getByRole('button', { name: '对话操作' }).click();
+  await page.getByRole('menuitem', { name: '重命名', exact: true }).click();
+
+  const input = row.getByRole('textbox', { name: '重命名对话' });
+  await expect(input).toBeFocused();
+  for (const key of ['Home', 'End', 'ArrowLeft', 'ArrowRight', 'ArrowUp', 'ArrowDown']) {
+    await input.press(key);
+    await expect(input).toBeFocused();
+  }
 });
 
 test('session heading stays singular and the default list has no redundant heading', async ({

--- a/apps/desktop/e2e/window-titlebar.spec.ts
+++ b/apps/desktop/e2e/window-titlebar.spec.ts
@@ -313,6 +313,10 @@ async function collapseSidebar(page: Page): Promise<void> {
 test('the window titlebar owns its row across surfaces, sidebar states, and the narrow breakpoint', async ({
   window: page,
 }) => {
+  const appShell = page.locator(`${SHELL} > .maka-astryx-app-shell`);
+  await expect(appShell).toHaveClass(/astryx-app-shell/);
+  await expect(appShell.locator('.astryx-app-shell-sidenav')).toBeAttached();
+
   const wide = { width: 1280, height: 900 };
   const narrow = { width: 760, height: 900 };
 

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -131,7 +131,7 @@ describe('sidebar project view mode', () => {
     });
 
     assert.match(markup, />Active project</);
-    assert.match(markup, /maka-list-project-count[^>]*>1</);
+    assert.match(markup, /maka-project-tree-count[^>]*>1</);
     assert.match(markup, />Missing project</);
     assert.match(markup, /aria-label="Active project 项目操作"/);
     assert.match(markup, /aria-label="Missing project 项目操作"/);
@@ -146,7 +146,7 @@ describe('sidebar project view mode', () => {
     assert.match(list, /copy\.projectRestore/);
   });
 
-  it('keeps collapsed project rows on the same vertical rhythm as conversation rows', async () => {
+  it('renders empty projects on the native balanced Astryx tree rhythm', () => {
     const projects = [
       project('project-a', 'Project A', [{ path: '/work/a', isWorktree: false }]),
       project('project-b', 'Project B', [{ path: '/work/b', isWorktree: false }]),
@@ -156,34 +156,10 @@ describe('sidebar project view mode', () => {
       groups: deriveProjectGroups([], projects, 'zh'),
       viewMode: 'project',
     });
-    const css = await readRepo('apps/desktop/src/renderer/styles/sidebar.css');
-
-    assert.equal(
-      (markup.match(/data-variant="project" data-expanded="false"/g) ?? []).length,
-      2,
-      'empty project groups should expose their collapsed state to the layout',
-    );
-    assert.match(
-      ruleBody(
-        css,
-        '.maka-list-group[data-variant="project"] + .maka-list-group[data-variant="project"]',
-      ),
-      /margin-top:\s*0/,
-      'adjacent collapsed projects should not add spacing beyond the list stack gap',
-    );
-    assert.match(
-      ruleBody(
-        css,
-        '.maka-list-group[data-variant="project"][data-expanded="true"] + .maka-list-group[data-variant="project"]',
-      ),
-      /margin-top:\s*var\(--space-3\)/,
-      'an expanded project may keep a group break before the next project',
-    );
-    assert.match(
-      ruleBody(css, '.maka-list-project-heading'),
-      /min-height:\s*var\(--h-control-lg\)/,
-    );
-    assert.match(ruleBody(css, '.maka-list-row'), /min-height:\s*var\(--h-control-lg\)/);
+    assert.match(markup, /class="[^"]*astryx-tree-list[^"]*balanced[^"]*"/);
+    assert.match(markup, /role="tree"/);
+    assert.equal((markup.match(/role="treeitem"/g) ?? []).length, 2);
+    assert.doesNotMatch(markup, /maka-list-project-heading|maka-list-row/);
   });
 
   it('renders project groups, the unassigned bucket, and keeps the conversation fallback path', () => {
@@ -290,7 +266,7 @@ describe('sidebar project view mode', () => {
     );
   });
 
-  it('renders project groups as folder headers with an initial four-session preview', () => {
+  it('renders every project session through the native expanded tree branch', () => {
     const sessions = Array.from({ length: 5 }, (_, index) => makeSessionSummary({
       id: `project-session-${index + 1}`,
       name: `Project chat ${index + 1}`,
@@ -309,34 +285,21 @@ describe('sidebar project view mode', () => {
       viewMode: 'project',
     });
 
-    // The heading is a UiButton (Base UI <button>); BaseButton reorders props
-    // so class is not guaranteed to precede aria-*. Assert the disclosure
-    // contract on the matched opening tag without assuming attribute order.
-    const headingTag = markup.match(/<button[^>]*maka-list-project-heading[^>]*>/)?.[0];
-    assert.ok(headingTag, 'project heading button must render');
-    assert.match(headingTag, /aria-expanded="true"/);
-    assert.match(headingTag, /aria-controls="maka-list-group-body-project:[^"]+"/);
+    const projectItem = markup.match(/<li(?=[^>]*data-tree-id="project:project-testzcode")[^>]*>/)?.[0];
+    assert.ok(projectItem, 'project tree item must render');
+    assert.match(projectItem, /aria-expanded="true"/);
     assert.match(markup, /lucide-folder-open/);
     assert.match(markup, />testzcode</);
     assert.match(markup, /Project chat 1/);
     assert.match(markup, /Project chat 4/);
-    assert.doesNotMatch(markup, /Project chat 5/);
-    assert.match(markup, /显示更多/);
+    assert.match(markup, /Project chat 5/);
+    assert.doesNotMatch(markup, /显示更多/);
   });
 
-  it('does not reopen a manually collapsed project when only session data refreshes', async () => {
+  it('delegates expansion persistence to Astryx TreeList instead of syncing active routes', async () => {
     const list = await readRepo('packages/ui/src/session-history-list.tsx');
-    const projectGroup =
-      list.match(
-        /function ProjectSessionGroup\([\s\S]*?\nfunction SessionTreeRow/,
-      )?.[0] ?? '';
-
-    assert.doesNotMatch(
-      projectGroup,
-      /useEffect\(\(\) => \{[\s\S]*setExpanded\(true\)[\s\S]*props\.sessions/,
-    );
-    assert.match(projectGroup, /observedActiveSessionId/);
-    assert.match(projectGroup, /activeSessionId !== disclosure\.observedActiveSessionId/);
+    assert.match(list, /<TreeList[\s\S]*density="balanced"[\s\S]*variant="lineGuides"/);
+    assert.doesNotMatch(list, /setDisclosure|observedActiveSessionId/);
   });
 
   it('renders linked child sessions directly beneath their parent as normal selectable rows', () => {
@@ -517,20 +480,17 @@ describe('sidebar project view mode', () => {
     assert.ok(groups.some((g) => g.label === 'repo-a'), 'expected a repo-a label');
     assert.ok(groups.some((g) => g.label === 'x'), 'expected an x label');
 
-    // Rendered markup: group body ids and aria-controls stay whitespace-free and pair up.
+    // Rendered markup: Astryx TreeList receives the same stable project identity.
     const markup = renderSessionListPanel({
       sessions,
       groups,
       viewMode: 'project',
     });
-    const bodyIds = [...markup.matchAll(/id="maka-list-group-body-([^"]*)"/g)].map((m) => m[1]);
-    const controls = [...markup.matchAll(/aria-controls="maka-list-group-body-([^"]*)"/g)].map((m) => m[1]);
-    assert.ok(bodyIds.length >= 3, `expected at least 3 group body ids, got ${bodyIds.length}`);
-    for (const id of [...bodyIds, ...controls]) {
-      assert.match(id, /^[A-Za-z0-9:_-]+$/, `rendered group id must be DOM-safe, got: ${id}`);
-    }
-    for (const control of controls) {
-      assert.ok(bodyIds.includes(control), `aria-controls references a missing body id: ${control}`);
+    const treeIds = [...markup.matchAll(/data-tree-id="(project:[^"]*)"/g)].map((m) => m[1]);
+    assert.equal(treeIds.length, 3);
+    assert.equal(new Set(treeIds).size, treeIds.length);
+    for (const id of treeIds) {
+      assert.match(id, /^[A-Za-z0-9:_-]+$/, `rendered tree id must be DOM-safe, got: ${id}`);
     }
   });
 });

--- a/apps/desktop/src/main/__tests__/stale-sessions.test.ts
+++ b/apps/desktop/src/main/__tests__/stale-sessions.test.ts
@@ -122,13 +122,13 @@ describe('stale session CSS contract (@kenji review gate)', () => {
     // Inactive stale dimming rule must exist.
     assert.match(
       css,
-      /\.maka-list-row\[data-stale="true"\]\s*\{[\s\S]*?opacity:\s*var\(--opacity-muted\)/,
-      'expected `.maka-list-row[data-stale="true"]` opacity dim rule (var(--opacity-muted) per PR2)',
+      /\.maka-session-list-item\[data-stale="true"\]\s*\{[\s\S]*?opacity:\s*var\(--opacity-muted\)/,
+      'expected the Astryx session list item stale-state dim rule',
     );
     // Active stale restoration rule must exist.
     assert.match(
       css,
-      /\.maka-list-row\[data-stale="true"\]\[data-active="true"\]\s*\{[\s\S]*?opacity:\s*1/,
+      /\.maka-session-list-item\[data-stale="true"\]\[aria-current="true"\][\s\S]*?\{[\s\S]*?opacity:\s*1/,
       'expected active-stale opacity restore rule',
     );
   });

--- a/apps/desktop/src/main/e2e-fixture.ts
+++ b/apps/desktop/src/main/e2e-fixture.ts
@@ -186,7 +186,7 @@ const E2E_FIXTURE_SCENARIOS = new Set<E2eFixtureScenario>([
   // kenji `b3d156e9`): same 60-session seed; differs in
   // `focusActiveRow: true`, which programmatically focuses the
   // active row's button after mount so `:focus-within` triggers
-  // and the `.maka-list-row-menu-trigger` becomes visible.
+  // and the `.maka-session-item-menu-trigger` becomes visible.
   // Captures the overflow-trigger state so reviewers can verify
   // the time meta + unread dot are hidden underneath (no overlap).
   'sidebar-row-actions-visible',

--- a/apps/desktop/src/renderer/app-shell-e2e-fixture.ts
+++ b/apps/desktop/src/renderer/app-shell-e2e-fixture.ts
@@ -179,7 +179,7 @@ export function createAppShellE2eFixtureActions(options: {
     // PR-SIDEBAR-IA-0 Phase 3 P0 fixup v4 (WAWQAQ msg `5dd1c348`,
     // kenji `b3d156e9`): when the fixture sets `focusActiveRow`,
     // focus the active row's button after the next paint so the
-    // row's `:focus-within` triggers and the `.maka-list-row-menu-trigger`
+    // item's `:focus-within` triggers and the `.maka-session-item-menu-trigger`
     // becomes visible. The fixture then shows the overflow
     // trigger against the slim row, proving the time meta
     // + unread dot are hidden underneath (no overlap with the
@@ -189,7 +189,7 @@ export function createAppShellE2eFixtureActions(options: {
       requestAnimationFrame(() => {
         requestAnimationFrame(() => {
           const activeRowButton = document.querySelector<HTMLButtonElement>(
-            '.maka-list-row[data-active="true"] .maka-list-row-main',
+            '.maka-session-list-item[aria-current="true"] button',
           );
           activeRowButton?.focus({ preventScroll: true });
         });

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -2088,7 +2088,7 @@ function AppShellContent({
           variant="elevated"
           height="fill"
           contentPadding={0}
-          mobileNav={false}
+          mobileNav={{ breakpoint: 'none', hasToggle: false }}
           sideNav={(
             <div
               className="maka-shell-sidebar-slot"

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -17,6 +17,7 @@ import type {
   UiLocale,
   UiLocalePreference,
 } from '@maka/core';
+import { AppShell as AstryxAppShell } from '@astryxdesign/core/AppShell';
 import {
   buildDeepResearchImplementationPrompt,
   collapseSessionRevisions,
@@ -2082,48 +2083,63 @@ function AppShellContent({
             />
           )}
         </header>
-        <div
-          className="maka-panel maka-panel-list maka-floating-panel"
-          aria-hidden={sessionListCollapsed ? 'true' : undefined}
-          inert={sessionListCollapsed ? true : undefined}
+        <AstryxAppShell
+          className="maka-astryx-app-shell"
+          variant="elevated"
+          height="fill"
+          contentPadding={0}
+          mobileNav={false}
+          sideNav={(
+            <div
+              className="maka-shell-sidebar-slot"
+              data-sidebar-state={sessionListCollapsed ? 'collapsed' : 'expanded'}
+              style={{ width: sessionListCollapsed ? 0 : sessionListWidth }}
+            >
+              <div
+                className="maka-panel maka-panel-list maka-floating-panel"
+                aria-hidden={sessionListCollapsed ? 'true' : undefined}
+                inert={sessionListCollapsed ? true : undefined}
+              >
+                <SessionListPanel
+                  selection={navSelection}
+                  sessions={visibleSessions}
+                  activeId={activeId}
+                  planReminders={planReminders}
+                  streamingSessionIds={streamingSessionIds}
+                  staleSessionIds={staleSessionIds}
+                  viewMode={viewMode}
+                  onViewModeChange={setViewMode}
+                  groups={viewMode === 'project' ? sessionProjectGroups : undefined}
+                  childSessionsByParentId={visibleSessionTree.childrenByParentId}
+                  worktreeSessionIds={worktreeSessionIds}
+                  moduleMemory={navigationState.moduleMemory}
+                  onSelect={setNavSelection}
+                  onSelectSession={sessionListSelectSession}
+                  onOpenSettings={openSettings}
+                  updateReminder={updateReminder}
+                  onOpenUpdate={openUpdateDownload}
+                  onNew={createSession}
+                  rowActions={sessionRowActions}
+                  projectActions={projectRowActions}
+                />
+              </div>
+              <div
+                className="maka-resize-handle"
+                role="separator"
+                aria-label={sessionListCollapsed ? shellCopy.sidebarCollapsed : shellCopy.resizeConversationList}
+                aria-orientation="vertical"
+                aria-valuemin={SESSION_LIST_EXPANDED_MIN_WIDTH}
+                aria-valuemax={SESSION_LIST_EXPANDED_MAX_WIDTH}
+                aria-valuenow={sessionListWidth}
+                aria-hidden={sessionListCollapsed ? 'true' : undefined}
+                tabIndex={sessionListCollapsed ? -1 : 0}
+                onPointerDown={startColumnResize}
+                onKeyDown={onResizeHandleKeyDown}
+              />
+            </div>
+          )}
         >
-          <SessionListPanel
-            selection={navSelection}
-            sessions={visibleSessions}
-            activeId={activeId}
-            planReminders={planReminders}
-            streamingSessionIds={streamingSessionIds}
-            staleSessionIds={staleSessionIds}
-            viewMode={viewMode}
-            onViewModeChange={setViewMode}
-            groups={viewMode === 'project' ? sessionProjectGroups : undefined}
-            childSessionsByParentId={visibleSessionTree.childrenByParentId}
-            worktreeSessionIds={worktreeSessionIds}
-            moduleMemory={navigationState.moduleMemory}
-            onSelect={setNavSelection}
-            onSelectSession={sessionListSelectSession}
-            onOpenSettings={openSettings}
-            updateReminder={updateReminder}
-            onOpenUpdate={openUpdateDownload}
-            onNew={createSession}
-            rowActions={sessionRowActions}
-            projectActions={projectRowActions}
-          />
-        </div>
-        <div
-          className="maka-resize-handle"
-          role="separator"
-          aria-label={sessionListCollapsed ? shellCopy.sidebarCollapsed : shellCopy.resizeConversationList}
-          aria-orientation="vertical"
-          aria-valuemin={SESSION_LIST_EXPANDED_MIN_WIDTH}
-          aria-valuemax={SESSION_LIST_EXPANDED_MAX_WIDTH}
-          aria-valuenow={sessionListWidth}
-          aria-hidden={sessionListCollapsed ? 'true' : undefined}
-          tabIndex={sessionListCollapsed ? -1 : 0}
-          onPointerDown={startColumnResize}
-          onKeyDown={onResizeHandleKeyDown}
-        />
-        <AppShellDetailPanel
+          <AppShellDetailPanel
           data-sidebar-state={sessionListCollapsed ? 'collapsed' : 'expanded'}
           agentsView={agentsView}
         >
@@ -2574,7 +2590,8 @@ function AppShellContent({
             )}
           </div>
           </MakaUriContext.Provider>
-        </AppShellDetailPanel>
+          </AppShellDetailPanel>
+        </AstryxAppShell>
       </div>
       <AppShellOverlays
         settingsOpen={settingsOpen}

--- a/apps/desktop/src/renderer/session-workbar.tsx
+++ b/apps/desktop/src/renderer/session-workbar.tsx
@@ -1,9 +1,6 @@
 import { useEffect, useState, type CSSProperties } from 'react';
+import { Tab, TabList } from '@astryxdesign/core/TabList';
 import {
-  PrimitiveTabs,
-  PrimitiveTabsList,
-  PrimitiveTabsPanel,
-  PrimitiveTabsTrigger,
   TaskLedgerPanel,
   deriveTaskLedgerPanelModel,
   useUiLocale,
@@ -65,44 +62,67 @@ export function SessionWorkbar(props: {
       aria-label={copy.ariaLabel}
       style={{ '--maka-session-workbar-width': `${props.width}px` } as CSSProperties}
     >
-      <PrimitiveTabs value={props.activeTab} onValueChange={(value) => props.onActiveTabChange(value as SessionWorkbarTab)} className="maka-session-workbar-tabs">
-        <PrimitiveTabsList variant="underline" className="maka-session-workbar-tab-list" aria-label={copy.sectionsAriaLabel}>
-          <PrimitiveTabsTrigger value="tasks">
-            <span>{copy.tasks}</span>
-            <span className="maka-session-workbar-count" data-maka-contract="session-workbar-count">{taskCount}</span>
-          </PrimitiveTabsTrigger>
-          <PrimitiveTabsTrigger value="browser" disabled={!props.browserLive}>
-            <span>{copy.browser}</span>
-          </PrimitiveTabsTrigger>
-          <PrimitiveTabsTrigger value="files">
-            <span>{copy.files}</span>
-            <span className="maka-session-workbar-count" data-maka-contract="session-workbar-count">{artifactCount}</span>
-          </PrimitiveTabsTrigger>
-          {props.quote && (
-            <PrimitiveTabsTrigger value="quote">
-              <span>{copy.quoteTab}</span>
-            </PrimitiveTabsTrigger>
-          )}
-        </PrimitiveTabsList>
-        <PrimitiveTabsPanel value="tasks" className="maka-session-workbar-panel" keepMounted>
+      <div className="maka-session-workbar-tabs">
+        <TabList
+          value={props.activeTab}
+          onChange={(value) => props.onActiveTabChange(value as SessionWorkbarTab)}
+          size="sm"
+          layout="fill"
+          hasDivider
+          className="maka-session-workbar-tab-list"
+          aria-label={copy.sectionsAriaLabel}
+        >
+          <Tab
+            value="tasks"
+            label={copy.tasks}
+            endContent={(
+              <span className="maka-session-workbar-count" data-maka-contract="session-workbar-count">
+                {taskCount}
+              </span>
+            )}
+          />
+          <Tab
+            value="browser"
+            label={copy.browser}
+            className="maka-session-workbar-tab"
+            aria-disabled={!props.browserLive ? 'true' : undefined}
+            onClick={(event) => {
+              if (!props.browserLive) {
+                event.preventDefault();
+                return;
+              }
+              props.onActiveTabChange('browser');
+            }}
+          />
+          <Tab
+            value="files"
+            label={copy.files}
+            endContent={(
+              <span className="maka-session-workbar-count" data-maka-contract="session-workbar-count">
+                {artifactCount}
+              </span>
+            )}
+          />
+          {props.quote && <Tab value="quote" label={copy.quoteTab} />}
+        </TabList>
+        <div className="maka-session-workbar-panel" hidden={props.activeTab !== 'tasks'}>
           <TaskLedgerPanel
             tasks={sessionTasks.tasks}
             loading={sessionTasks.loading}
             error={sessionTasks.error}
             onRetry={sessionTasks.retry}
           />
-        </PrimitiveTabsPanel>
-        <PrimitiveTabsPanel value="browser" className="maka-session-workbar-panel" keepMounted>
+        </div>
+        <div className="maka-session-workbar-panel" hidden={props.activeTab !== 'browser'}>
           {props.browserLive && <BrowserPanel sessionId={props.sessionId} hidden={props.hidden || props.activeTab !== 'browser'} />}
-        </PrimitiveTabsPanel>
-        <PrimitiveTabsPanel value="files" className="maka-session-workbar-panel" keepMounted>
+        </div>
+        <div className="maka-session-workbar-panel" hidden={props.activeTab !== 'files'}>
           <ArtifactPane sessionId={props.sessionId} onCountChange={setArtifactCount} onDismiss={props.onDismiss} />
-        </PrimitiveTabsPanel>
+        </div>
         {props.quote && (
-          <PrimitiveTabsPanel
-            value="quote"
+          <div
             className="maka-session-workbar-panel maka-quote-workbar-panel"
-            keepMounted
+            hidden={props.activeTab !== 'quote'}
           >
             <QuoteCompanionPanel
               key={props.quote.id}
@@ -115,9 +135,9 @@ export function SessionWorkbar(props: {
               onRemoveQuote={props.onRemoveQuote}
               onForkVisibilityChange={props.onForkVisibilityChange}
             />
-          </PrimitiveTabsPanel>
+          </div>
         )}
-      </PrimitiveTabs>
+      </div>
     </aside>
   );
 }

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -61,6 +61,8 @@
 }
 
 .maka-session-workbar-tabs {
+  display: flex;
+  flex-direction: column;
   height: 100%;
   min-height: 0;
   gap: 0;
@@ -69,10 +71,12 @@
 .maka-session-workbar-tab-list {
   width: 100%;
   flex: 0 0 auto;
-  border-bottom: var(--border-width-hairline) solid var(--border);
 }
 
-.maka-session-workbar-tab-list > [data-slot="tabs-tab"] { flex: 1 1 0; }
+.maka-session-workbar-tab[aria-disabled="true"] {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
 
 .maka-session-workbar-count {
   min-width: var(--space-4);
@@ -85,6 +89,7 @@
 }
 
 .maka-session-workbar-panel {
+  flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
 }

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -49,7 +49,6 @@
   align-items: stretch;
   gap: 0;
   overflow: hidden;
-  transition: grid-template-columns var(--duration-large) var(--ease-drawer);
   /* PR-CHAT-CHROME-FIX-0 (WAWQAQ msg `1e693dee` + `486b5611`):
      the shell used to carry a 172deg gradient from `--foreground-3`
      to `--background`. The session sidebar is transparent and
@@ -62,17 +61,38 @@
 }
 
 .app.maka-shell-2col {
-  grid-template-columns:
-    var(--maka-session-list-expanded-width)
-    var(--maka-resize-handle-width, 0px)
-    minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
 }
 
 .app.maka-shell-2col[data-sidebar-state="collapsed"] {
-  grid-template-columns:
-    0px
-    var(--maka-resize-handle-width, 0px)
-    minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.maka-astryx-app-shell {
+  grid-column: 1;
+  grid-row: 2;
+  min-width: 0;
+  min-height: 0;
+  height: 100%;
+  overflow: hidden;
+}
+
+.maka-astryx-app-shell > [data-testid="skip-to-content"] {
+  -webkit-app-region: no-drag;
+}
+
+.maka-astryx-app-shell .astryx-app-shell-sidenav,
+.maka-astryx-app-shell .astryx-layout-content {
+  overflow: hidden;
+}
+
+.maka-shell-sidebar-slot {
+  position: relative;
+  flex: 0 0 auto;
+  height: 100%;
+  min-width: 0;
+  overflow: visible;
+  transition: width var(--duration-large) var(--ease-drawer);
 }
 
 .maka-panel {
@@ -89,6 +109,8 @@
 }
 
 .maka-panel-list.maka-floating-panel {
+  width: 100%;
+  height: 100%;
   border-right: 0;
   background: transparent;
   opacity: 1;
@@ -99,7 +121,7 @@
 }
 
 .maka-shell-2col .maka-panel-list > .maka-session-panel {
-  width: var(--maka-session-list-expanded-width);
+  width: 100%;
 }
 
 .maka-panel-detail.maka-floating-panel {
@@ -176,7 +198,17 @@
      on the right; Linux: neither, so the design floor stands). */
   padding-left: max(var(--space-6), var(--maka-titlebar-area-x));
   padding-right: calc(var(--space-6) + var(--maka-titlebar-overlay-right-width));
+  background:
+    linear-gradient(
+      to right,
+      var(--surface-canvas) 0 var(--maka-session-list-expanded-width),
+      var(--background) var(--maka-session-list-expanded-width) 100%
+    );
   -webkit-app-region: drag;
+}
+
+.maka-shell-2col[data-sidebar-state="collapsed"] .maka-window-titlebar {
+  background: var(--background);
 }
 
 .maka-shell-topbar-rail {
@@ -193,7 +225,10 @@
 }
 
 .maka-resize-handle {
-  position: relative;
+  position: absolute;
+  z-index: 2;
+  inset-block: 0;
+  inset-inline-end: 0;
   width: var(--maka-resize-handle-width, 0px);
   box-sizing: content-box;
   padding-inline: var(--space-1);
@@ -248,11 +283,11 @@
   user-select: none;
 }
 
-.isResizingColumns .maka-shell-2col {
+.isResizingColumns .maka-shell-sidebar-slot {
   transition: none;
 }
 
-.maka-shell-2col:has(> .maka-resize-handle:focus) {
+.maka-shell-2col:has(.maka-resize-handle:focus) .maka-shell-sidebar-slot {
   transition: none;
 }
 

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -3,16 +3,35 @@
   min-width: 0;
   min-height: 0;
   height: 100%;
-  display: grid;
-  /* 4 rows: hub nav / session-list heading / list / footer. The panel used to
-     carry a fifth leading row holding an empty `<header>` whose only job was to
-     host a blank drag strip, and after that a `padding-top` clearing the drag
-     band. Both are gone: the titlebar is its own grid row in the shell, so this
-     panel starts below it and has nothing to clear. */
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
+  display: flex;
+  flex-direction: column;
   overflow: hidden;
   background: transparent;
   contain: layout paint style;
+}
+
+.maka-session-panel > div:has(> .maka-session-panel-scroll-region) {
+  display: flex;
+  min-height: 0;
+  overflow: hidden;
+  padding: 0;
+}
+
+.maka-session-panel > div:has(> .maka-sidebar-modules),
+.maka-session-panel > div:has(> .maka-session-panel-footer) {
+  padding-inline: var(--space-2);
+}
+
+.maka-session-panel > div:has(> .maka-session-panel-footer) {
+  padding-block: 0;
+  border-block-start: 0;
+}
+
+.maka-session-panel-scroll-region {
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
+  width: 100%;
+  min-height: 0;
 }
 
 .maka-session-list {
@@ -51,14 +70,6 @@
 /* Sidebar footer — Settings affordance only. The earlier "Free Plan" account
    widget was removed (WAWQAQ msg cad3dec4: "现在左下角怎么还有 账户部分,
    我们没有账户"). About / version still reachable via Settings → 关于. */
-.maka-sidebar-settings-button {
-  display: inline-grid;
-  /* Same glyph column as .maka-nav-row so the gear shares the nav rows'
-     icon axis and 16px chrome size (icon-system contract). */
-  grid-template-columns: var(--icon-size) minmax(0, 1fr);
-  align-items: center;
-}
-
 .maka-sidebar-update-button {
   position: relative;
   min-width: 0;
@@ -139,27 +150,19 @@
   gap: 1px;
   /* #546 PR7: left/right padding aligned with .maka-list-stackContent
      (var(--space-2)) so nav rows and session rows share the same inset. */
-  padding: var(--space-1) var(--space-2);
-}
-
-.maka-nav-row {
-  width: 100%;
-  display: grid;
-  grid-template-columns: var(--icon-size) minmax(0, 1fr) auto;
-  align-items: center;
+  padding: 0;
   -webkit-app-region: no-drag;
-  text-align: left;
 }
 
-.maka-nav-row span:nth-child(2) {
-  min-width: 0;
+.maka-nav-pending-copy {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
   overflow: hidden;
-  text-overflow: ellipsis;
+  clip-path: inset(50%);
   white-space: nowrap;
-}
-
-.maka-nav-row small {
-  font-variant-numeric: tabular-nums;
 }
 
 .maka-nav-count {

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -187,350 +187,125 @@
 .maka-list-stackContent {
   align-content: start;
   display: grid;
-  gap: 1px;
+  gap: var(--space-2-5);
   padding: var(--space-0-5) var(--space-2) var(--space-1-5);
 }
 
-.maka-list-group {
-  display: grid;
-  gap: 0;
-}
-
-/* Sidebar group separator. Each group beyond
-   the first is preceded by a 1px hairline divider that reads as a
-   "data section break" rather than a card-like edge. */
-.maka-list-group + .maka-list-group {
-  margin-top: var(--space-2-5);
-  padding-top: var(--space-2);
-  border-top: var(--border-width-hairline) solid oklch(from var(--foreground) l c h / 0.05);
-}
-
-.maka-list-group[data-variant="project"] + .maka-list-group[data-variant="project"] {
-  margin-top: 0;
-  padding-top: 0;
-  border-top: 0;
-}
-
-.maka-list-group[data-variant="project"][data-expanded="true"] + .maka-list-group[data-variant="project"] {
-  margin-top: var(--space-3);
-}
-
-/* Group label — a quiet, non-interactive divider for flat conversations.
-   Project disclosures use their own heading control below. */
 .maka-list-group-label {
   display: flex;
   align-items: baseline;
   gap: var(--space-0-5);
-  padding: 0 var(--space-1-5) var(--space-0-5);
+  padding: var(--space-1) var(--space-2) 0;
   color: var(--muted-foreground);
   font-size: var(--font-size-ui);
   font-weight: var(--font-weight-medium);
   font-variant-numeric: tabular-nums;
 }
 
-.maka-list-project-heading {
-  display: flex;
-  align-items: center;
-  justify-content: flex-start;
-  gap: var(--space-1-5);
-  width: 100%;
-  min-height: var(--h-control-lg);
-  padding: 0 var(--space-1-5);
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--muted-foreground);
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-medium);
-  text-align: left;
-}
-
-.maka-list-project-header {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) var(--h-control-lg);
-  align-items: center;
+.maka-session-history-group,
+.maka-project-history-tree {
   min-width: 0;
+  width: 100%;
 }
 
-.maka-list-project-heading:disabled {
-  cursor: default;
+.maka-session-list-item {
+  min-width: 0;
+  width: 100%;
+}
+
+.maka-session-list-item[data-subagent="true"] {
+  margin-inline-start: var(--space-4);
+  width: calc(100% - var(--space-4));
+}
+
+.maka-session-list-item[data-stale="true"] {
+  opacity: var(--opacity-muted);
+}
+
+.maka-session-list-item[data-stale="true"][aria-current="true"],
+.maka-session-item-label[data-stale="true"][data-active="true"] {
   opacity: 1;
 }
 
-.maka-list-project-name {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+.maka-session-item-label[data-stale="true"] {
+  opacity: var(--opacity-muted);
 }
 
-.maka-list-project-count {
+.maka-session-item-label,
+.maka-project-tree-label {
+  display: flex;
+  align-items: flex-start;
+  gap: var(--space-1-5);
+  min-width: 0;
+  white-space: normal;
+}
+
+.maka-session-item-label > svg,
+.maka-session-item-label > .maka-list-row-streaming-dot {
   flex: 0 0 auto;
+  margin-top: 0.2em;
+}
+
+.maka-session-item-label > span:not(.maka-list-row-streaming-dot, .maka-list-row-status-icon, .maka-list-row-stale-pill) {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.maka-session-item-end,
+.maka-project-tree-actions {
+  display: flex;
+  align-items: center;
+  gap: var(--space-1);
+  min-width: 0;
+}
+
+.maka-session-item-meta,
+.maka-project-tree-count {
   color: var(--muted-foreground);
   font-size: var(--font-size-caption);
   font-variant-numeric: tabular-nums;
+  white-space: nowrap;
 }
 
-.maka-list-project-menu-trigger {
-  justify-self: end;
-}
-
-.maka-list-group[data-unavailable="true"] .maka-list-project-heading {
-  color: var(--muted-foreground);
-}
-
-.maka-list-group[data-unavailable="true"] .maka-list-project-heading [aria-label] {
-  color: var(--warning-foreground, var(--muted-foreground));
-}
-
-.maka-list-project-rename input {
-  min-width: 0;
-  width: 100%;
-  height: var(--h-control-sm);
-  border: var(--border-width-hairline) solid var(--border-strong);
-  border-radius: var(--radius-control);
-  outline: none;
-  background: var(--background);
-  color: var(--foreground);
-  font: inherit;
-  padding: 0 var(--space-1);
-}
-
-.maka-list-project-rename input:focus-visible {
-  border-color: var(--focus-ring);
-  box-shadow: 0 0 0 var(--focus-ring-width) color-mix(in srgb, var(--focus-ring) 24%, transparent);
-}
-
-.maka-list-archived-projects {
-  margin-top: var(--space-3);
-  padding-top: var(--space-2);
-  border-top: var(--border-width-hairline) solid var(--border);
-}
-
-.maka-list-archived-projects-heading {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1-5);
-  width: 100%;
-  min-height: var(--h-control-lg);
-  padding: 0 var(--space-1-5);
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--muted-foreground);
-  font-size: var(--font-size-ui);
-  text-align: left;
-}
-
-.maka-list-archived-projects-heading .maka-list-project-count {
-  margin-left: auto;
-}
-
-.maka-list-archived-projects-heading[aria-expanded="true"] > svg {
-  transform: rotate(90deg);
-}
-
-.maka-list-row-worktree-icon {
-  flex: 0 0 auto;
-  color: var(--muted-foreground);
-}
-
-/* The semantic project heading owns its composite row states. Only the
-   folder-glyph tint + flex-shrink guard remain heading-specific here. */
-.maka-list-project-heading svg {
-  color: var(--muted-foreground);
-  flex: 0 0 auto;
-}
-
-
-.maka-list-project-more {
-  min-height: var(--h-control-lg);
-  display: inline-flex;
-  align-items: center;
-  justify-content: flex-start;
-  border: 0;
-  background: transparent;
-  color: var(--muted-foreground);
-  font-size: var(--font-size-ui);
-  padding: 0 var(--space-1-5) 0 var(--space-8);
-  text-align: left;
-}
-
-
-/* PR-SIDEBAR-IA-0 Phase 3 (WAWQAQ msgs `14ed98b5`, `761141c5` —
- * "list 很丑、很肥很臃肿"; xuan `6b28984e` sign-off + "32-40px 薄行";
- * kenji `2b20c73c`): slim row.
- *
- * Before Phase 3: each row was a 56-72px card (border + radius +
- * shadow) showing title + snippet + meta stacked over three lines.
- * That made 9-10 rows visible in a 990px viewport — far too few for
- * a sidebar of 60 sessions.
- *
- * After Phase 3:
- *   - 32px min-height, single line: status indicator + name + time.
- *   - Flat list (no border, no radius, no shadow); the surrounding
- *     `.maka-list-stackContent` provides the row stack, so rows just need
- *     to read as a list, not a stack of cards.
- *   - Snippet drops out of the default DOM (lives only in a native
- *     `title=` tooltip on hover) — see SessionRow render path.
- *   - A single overflow trigger replaces the time/unread slot on hover or focus.
- *   - Active row uses a neutral flat fill instead of the old accent rail.
- */
-.maka-list-row {
-  position: relative;
-  width: 100%;
-  min-height: var(--h-control-lg);
-  display: flex;
-  align-items: stretch;
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--foreground);
-  overflow: hidden;
-  transition: background-color var(--duration-base) var(--ease-out-strong);
-}
-
-.maka-list-session-children {
-  margin-inline-start: var(--space-2);
-  padding-inline-start: var(--space-1);
-  border-inline-start: var(--border-width-hairline) solid var(--border);
-}
-
-.maka-list-row[data-subagent="true"] {
-  background: var(--selection);
-}
-
-.maka-list-row-subagent-icon {
-  flex: 0 0 auto;
-  color: var(--muted-foreground);
-}
-
-.maka-list-row:hover {
-  background: var(--state-hover-bg);
-}
-
-.maka-list-row:active {
-  background: var(--state-selected-bg);
-}
-
-/* Active session row: slightly stronger than hover so the current
-   session is distinguishable from hover, but lighter than nav-row
-   active (0.09) so the main navigation reads as the primary surface. */
-.maka-list-row[data-active="true"] {
-  background: var(--state-selected-bg);
-}
-
-.maka-list-row[data-active="true"] .maka-list-row-name {
-  color: var(--foreground);
-  font-weight: var(--font-weight-semibold);
-}
-
-.maka-list-row-main {
-  flex: 1;
-  min-width: 0;
-  display: grid;
-  /* Phase 3: single-row layout — name takes the flex column, time
-   * sits in the auto column at the inline-end. Snippet drops out of
-   * the default DOM entirely (replaced by native title= tooltip on
-   * the button). */
-  grid-template-columns: minmax(0, 1fr) auto;
-  align-items: center;
-  gap: var(--space-1-5);
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: inherit;
-  padding: var(--space-0-5) var(--space-2) var(--space-0-5) var(--space-2-5);
-  text-align: left;
-}
-
-.maka-list-row-menu-trigger {
-  position: absolute;
-  top: 0;
-  right: var(--space-1);
-  width: var(--h-control-lg);
-  height: var(--h-control-lg);
-  display: grid;
-  place-items: center;
-  padding: 0;
-  border: 0;
-  border-radius: var(--radius-control);
-  background: transparent;
-  color: var(--foreground-secondary);
+.maka-session-item-menu-trigger,
+.maka-project-tree-menu-trigger {
   opacity: 0;
-  transform: translateX(var(--space-1));
-  transition:
-    opacity var(--duration-base) var(--ease-out-strong),
-    transform var(--duration-base) var(--ease-out-strong),
-    background-color var(--duration-base) var(--ease-out-strong),
-    color var(--duration-base) var(--ease-out-strong);
-  pointer-events: none;
+  transition: opacity var(--duration-base) var(--ease-out-strong);
 }
 
-.maka-list-row-menu-trigger:hover,
-.maka-list-row-menu-trigger:focus-visible,
-.maka-list-row-menu-trigger[aria-expanded="true"] {
-  background: var(--state-hover-bg);
-  color: var(--foreground);
-}
-
-.maka-list-row-menu-trigger:focus-visible {
-  outline: var(--focus-ring-width) solid var(--focus-ring);
-  outline-offset: var(--focus-ring-offset);
-}
-
-.maka-list-row:hover .maka-list-row-menu-trigger,
-.maka-list-row:focus-within .maka-list-row-menu-trigger,
-.maka-list-row-menu-trigger[data-visible="true"] {
+.maka-session-list-item:hover .maka-session-item-menu-trigger,
+.maka-session-list-item:focus-within .maka-session-item-menu-trigger,
+.maka-session-item-menu-trigger[aria-expanded="true"],
+.maka-project-history-tree [role="treeitem"]:hover .maka-project-tree-menu-trigger,
+.maka-project-history-tree [role="treeitem"]:focus-within .maka-project-tree-menu-trigger,
+.maka-project-tree-menu-trigger[aria-expanded="true"] {
   opacity: 1;
-  transform: translateX(0);
-  pointer-events: auto;
 }
 
-.maka-list-row:hover .maka-list-row-meta,
-.maka-list-row:hover .maka-list-row-unread,
-.maka-list-row:focus-within .maka-list-row-meta,
-.maka-list-row:focus-within .maka-list-row-unread,
-.maka-list-row[data-menu-open="true"] .maka-list-row-meta,
-.maka-list-row[data-menu-open="true"] .maka-list-row-unread {
-  visibility: hidden;
+.maka-session-list-item:hover .maka-session-item-meta,
+.maka-session-list-item:focus-within .maka-session-item-meta {
+  display: none;
 }
 
-.maka-list-row-rename-input {
+.maka-session-inline-rename {
+  box-sizing: border-box;
   width: 100%;
+  min-width: 0;
   border: 0;
+  border-bottom: var(--border-width-hairline) solid var(--focus-ring);
+  outline: 0;
   background: transparent;
   color: var(--foreground);
   font: inherit;
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-semibold);
-  outline: 0;
-  padding: 1px 0;
-  border-bottom: var(--border-width-hairline) solid oklch(from var(--focus-ring) l c h / 0.4);
 }
 
-.maka-list-row-rename-input:focus {
-  border-bottom-color: var(--focus-ring);
+.maka-project-tree-label {
+  align-items: baseline;
 }
 
-.maka-list-row[data-editing="true"] {
-  border-color: oklch(from var(--focus-ring) l c h / 0.45);
-  background: var(--background);
+.maka-project-tree-count {
+  flex: 0 0 auto;
 }
-
-.maka-list-row[data-editing="true"] .maka-list-row-main {
-  cursor: text;
-}
-
-.maka-list-row-main:focus-visible {
-  outline: 0;
-}
-
-.maka-list-row:has(.maka-list-row-main:focus-visible) {
-  border-color: oklch(from var(--focus-ring) l c h / 0.4);
-  box-shadow: 0 0 0 var(--focus-ring-width) oklch(from var(--focus-ring) l c h / 0.18);
-}
-
 
 /* The session-list heading carries grouping as a quiet menu action. The
    selected mode is already visible in the groups below, so the previous
@@ -551,23 +326,6 @@
 }
 
 /* List-row status family — merged back from onboarding.css — issue #546 PR3. */
-.maka-list-row-name {
-  display: flex;
-  align-items: center;
-  gap: var(--space-1-5);
-  overflow: hidden;
-  font-size: var(--font-size-ui);
-  font-weight: var(--font-weight-medium);
-  min-width: 0;
-}
-
-.maka-list-row-name > span {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  min-width: 0;
-}
-
 /* Small pulsing accent dot rendered when a session has live streaming
  * delta in flight. Replaces the unread halo for streaming sessions so the
  * indicator hierarchy is: streaming > unread > inactive. Respects
@@ -599,50 +357,6 @@
   }
 }
 
-.maka-list-row[data-streaming="true"] .maka-list-row-name > span {
-  color: var(--foreground);
-}
-
-/* PR-SIDEBAR-IA-0 Phase 3: meta (relative time) now sits inline at
- * the row's inline-end instead of stacked below the name. Color +
- * size kept muted so it reads as secondary info, not a competing
- * label. `margin-top` from the old stacked layout is removed. */
-.maka-list-row-meta {
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--muted-foreground);
-  font-size: var(--font-size-caption);
-  font-weight: var(--font-weight-medium);
-  font-variant-numeric: tabular-nums;
-  flex-shrink: 0;
-}
-
-/* PR-SIDEBAR-IA-0 Phase 3: `.maka-list-row-text` collapses to a single
- * row (name on the inline-start). The previous stack-of-three
- * layout (name / preview / meta) is gone — preview drops out of the
- * default DOM, meta moves inline to the row's right column. */
-.maka-list-row-text {
-  min-width: 0;
-  display: flex;
-  align-items: center;
-}
-
-/* PR-SIDEBAR-IA-0 Phase 3: `.maka-list-row-preview` is no longer
- * rendered in the default DOM — preview text is exposed via the row
- * button's native `title=` tooltip on hover so users can still peek
- * at the last message without paying the layout cost of a second
- * stacked line. This rule intentionally remains DELETED (no fallback
- * style). The `sidebar-row-density-contract.test.ts` gate asserts
- * the rule is gone so a future "let's bring snippet back" patch
- * lands as an explicit design discussion, not a silent regression.
- */
-
-/* PR-SIDEBAR-IA-0 Phase 3: `.maka-list-row-preview` is no longer
- * rendered in the default DOM (see comment above). The
- * `[data-active]` variant of that rule is therefore dead and
- * removed. */
-
 .maka-list-row-unread {
   width: var(--space-2);
   height: var(--space-2);
@@ -662,14 +376,6 @@
  *   muted-warning tone, not destructive, because @xuan's send-path silent
  *   rebind makes these sessions still functional.
  */
-.maka-list-row[data-stale="true"] {
-  opacity: var(--opacity-muted);
-}
-
-.maka-list-row[data-stale="true"][data-active="true"] {
-  opacity: 1;
-}
-
 /* PR109b: SessionStatusIcon — small inline icon next to session name
  * representing lifecycle status. Tone-based color from the
  * design-system token vocabulary; running spins via `animation`
@@ -732,32 +438,6 @@
   animation: none;
 }
 
-:is(.maka-list-project-heading, .maka-list-project-more) {
-  transition:
-    background-color var(--duration-base) var(--ease-out-strong),
-    color var(--duration-base) var(--ease-out-strong),
-    opacity var(--duration-base) var(--ease-out-strong);
-}
-:is(.maka-list-project-heading, .maka-list-project-more):hover {
-  background: var(--state-hover-bg);
-  color: var(--foreground);
-}
-:is(.maka-list-project-heading, .maka-list-project-more):active {
-  background: var(--state-selected-bg);
-}
-:is(.maka-list-project-heading, .maka-list-project-more):focus-visible {
-  outline: var(--focus-ring-width) solid var(--focus-ring);
-  outline-offset: var(--focus-ring-offset);
-  border-radius: var(--radius-control);
-}
-:is(.maka-list-project-heading, .maka-list-project-more):disabled {
-  cursor: not-allowed;
-  opacity: var(--opacity-disabled);
-}
-:is(.maka-list-project-heading, .maka-list-project-more):disabled:hover {
-  background: transparent;
-  color: var(--muted-foreground);
-}
 .maka-list-row-stale-pill {
   flex-shrink: 0;
   /* PR-UI-3: drop margin-left, let parent's gap (6px) handle spacing
@@ -773,10 +453,6 @@
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
   line-height: var(--leading-snug);
-}
-
-.maka-list-row:hover .maka-list-row-name {
-  color: var(--foreground);
 }
 
 /* ⌘N hint on the 新任务 row — quiet kbd chip pushed to the right rail,

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -86,10 +86,9 @@ html[data-os="darwin"] .maka-session-list,
     color: var(--foreground);
   }
 
-/* `.maka-nav-row` is a semantic navigation control, so this darwin glass
-   override must outrank the sidebar default color — same maka.legacy layer,
-   higher specificity. */
-html[data-os="darwin"] .maka-nav-row {
+/* Astryx SideNav items are the semantic navigation controls, so this darwin
+   glass override must outrank the sidebar material inheritance. */
+html[data-os="darwin"] .maka-session-panel .astryx-side-nav-item {
   color: var(--foreground);
 }
 
@@ -125,7 +124,7 @@ html[data-os="darwin"] .maka-session-panel-footer {
 
 .maka-session-panel,
   .maka-session-panel-footer,
-  .maka-nav-row,
+  .maka-session-panel .astryx-side-nav-item,
   .maka-session-list-item,
   .maka-project-history-tree,
   .maka-module-main-header,

--- a/apps/desktop/src/renderer/styles/theme-glass.css
+++ b/apps/desktop/src/renderer/styles/theme-glass.css
@@ -82,7 +82,7 @@ html[data-os="darwin"] .maka-list-group-label {
    foreground @ full alpha; nav rows / list rows / settings button all
    inherit. */
 html[data-os="darwin"] .maka-session-list,
-  html[data-os="darwin"] .maka-list-row {
+  html[data-os="darwin"] .maka-session-list-item {
     color: var(--foreground);
   }
 
@@ -126,7 +126,8 @@ html[data-os="darwin"] .maka-session-panel-footer {
 .maka-session-panel,
   .maka-session-panel-footer,
   .maka-nav-row,
-  .maka-list-row,
+  .maka-session-list-item,
+  .maka-project-history-tree,
   .maka-module-main-header,
   .maka-plan-heading,
   .maka-skill-tab,

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -2,6 +2,7 @@ import type { Meta, StoryObj } from '@storybook/react-vite';
 import { useState, type ReactNode } from 'react';
 import type { ComponentProps } from 'react';
 import type { ProjectRecord, SessionSummary, StoredMessage } from '@maka/core';
+import { AppShell as AstryxAppShell } from '@astryxdesign/core/AppShell';
 import { ChatView, Composer, SessionListPanel } from '@maka/ui';
 import type { ChatModelChoice, SessionViewMode } from '@maka/ui';
 import { AppShellTopbarActions, AppShellWorkspaceTopActions } from '../src/renderer/app-shell-chrome-actions';
@@ -134,7 +135,7 @@ const conversation: StoredMessage[] = [
   user('msg-1', 'turn-1', 14, '帮我把这轮 Storybook 覆盖的风险列出来，只保留真正会影响 review 的部分。'),
   assistant('msg-2', 'turn-1', 12, '现在最值得先固定的是几个高频但还没有 story 的页面：权限弹窗、顶层布局、首次启动引导。把它们的可见状态摆出来，reviewer 就能在 Storybook 里逐个看，不用手动把 app 驱动到这些路径。'),
   user('msg-3', 'turn-2', 6, '顶层布局怎么处理？它依赖很多 IPC。'),
-  assistant('msg-4', 'turn-2', 4, '不整体挂载 AppShell，改为用真实的子组件（侧栏、聊天区、顶栏）拼出布局。能稳定反映页面长什么样，又不被 IPC 耦合拖住。'),
+  assistant('msg-4', 'turn-2', 4, '挂载真实 Astryx AppShell，再用产品子组件填入侧栏、聊天区和标题栏。这样既保留 shell 几何，也不用伪造桌面 IPC 根。'),
 ];
 
 const markdownCoreConversation: StoredMessage[] = [
@@ -227,10 +228,10 @@ function ShellFrame(props: { children: ReactNode; motionEnabled?: boolean }) {
   );
 }
 
-// Composition smoke: mounts the real SessionListPanel + ChatView + Composer
-// + topbar chrome pieces side-by-side. Does NOT mount the monolithic
-// AppShell (1442 lines, heavy IPC coupling). When AppShell's internal
-// layout shifts, this story may drift — it owns its own 2-col scaffold.
+// Composition smoke: mounts the real Astryx AppShell with Maka's real
+// SessionListPanel, ChatView, Composer, and titlebar chrome. It deliberately
+// avoids only the IPC-heavy product AppShell state root; shell geometry and
+// component ownership match the production composition.
 function ComposedShell(props: {
   sidebarCollapsed?: boolean;
   initialViewMode?: SessionViewMode;
@@ -282,47 +283,14 @@ function ComposedShell(props: {
           height: '100%',
         }}
       >
-        <AppShellTopbarActions
-          sidebarCollapsed={collapsed}
-          onOpenSearchModal={noop}
-          onCollapseSidebar={() => setCollapsed(true)}
-          onExpandSidebar={() => setCollapsed(false)}
-          onCreateSession={noop}
-        />
-        {/* Grid is 3 columns (sidebar / handle / detail): the handle must
-            always render or the detail panel falls into the 0px handle
-            column. When collapsed, keep the sidebar mounted (production
-            hides it via the data-sidebar-state CSS) so auto-placement
-            stays aligned. */}
-        <div
-          className="maka-panel maka-panel-list maka-floating-panel"
-          aria-hidden={collapsed ? 'true' : undefined}
-          inert={collapsed ? true : undefined}
-        >
-          <SessionListPanel
-            selection={{ section: 'sessions', filter: 'chats' }}
-            sessions={sessions}
-            activeId={active.id}
-            groups={viewMode === 'project' ? projectGroups : undefined}
-            streamingSessionIds={streamingIds}
-            viewMode={viewMode}
-            onViewModeChange={setViewMode}
-            onSelect={noop}
-            onSelectSession={noop}
-            onOpenSettings={noop}
-            onNew={noop}
-            rowActions={sidebarRowActions}
-            projectActions={projectRowActions}
-            worktreeSessionIds={new Set(['session-active'])}
+        <header className="maka-window-titlebar">
+          <AppShellTopbarActions
+            sidebarCollapsed={collapsed}
+            onOpenSearchModal={noop}
+            onCollapseSidebar={() => setCollapsed(true)}
+            onExpandSidebar={() => setCollapsed(false)}
+            onCreateSession={noop}
           />
-        </div>
-        <div className="maka-resize-handle" aria-hidden="true" />
-        <div
-          className="maka-panel maka-panel-detail maka-floating-panel agents-content-area agents-parchment-paper-surface"
-          data-sidebar-state={collapsed ? 'collapsed' : 'expanded'}
-          data-agents-view="im_hub"
-          style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}
-        >
           <AppShellWorkspaceTopActions
             workbarAvailable
             workbarCollapsed={false}
@@ -332,20 +300,66 @@ function ComposedShell(props: {
             onOpenHelp={noop}
             onOpenHealth={noop}
           />
-          {props.detailChildren ?? (
-            <div style={{ display: 'flex', minHeight: 0, width: '100%', flexDirection: 'column', flex: 1 }}>
-              <ChatView {...baseChatProps} activeSession={active} {...props.chat} />
-              <div style={{ padding: '0 24px 24px' }}>
-                <Composer
-                  {...baseComposerProps}
-                  activeSession={active}
-                  streaming={props.session?.streaming ?? false}
-                  {...props.composer}
+        </header>
+        <AstryxAppShell
+          className="maka-astryx-app-shell"
+          variant="elevated"
+          height="fill"
+          contentPadding={0}
+          mobileNav={{ breakpoint: 'none', hasToggle: false }}
+          sideNav={(
+            <div
+              className="maka-shell-sidebar-slot"
+              data-sidebar-state={collapsed ? 'collapsed' : 'expanded'}
+              style={{ width: collapsed ? 0 : sidebarWidth }}
+            >
+              <div
+                className="maka-panel maka-panel-list maka-floating-panel"
+                aria-hidden={collapsed ? 'true' : undefined}
+                inert={collapsed ? true : undefined}
+              >
+                <SessionListPanel
+                  selection={{ section: 'sessions', filter: 'chats' }}
+                  sessions={sessions}
+                  activeId={active.id}
+                  groups={viewMode === 'project' ? projectGroups : undefined}
+                  streamingSessionIds={streamingIds}
+                  viewMode={viewMode}
+                  onViewModeChange={setViewMode}
+                  onSelect={noop}
+                  onSelectSession={noop}
+                  onOpenSettings={noop}
+                  onNew={noop}
+                  rowActions={sidebarRowActions}
+                  projectActions={projectRowActions}
+                  worktreeSessionIds={new Set(['session-active'])}
                 />
               </div>
+              <div className="maka-resize-handle" aria-hidden="true" />
             </div>
           )}
-        </div>
+        >
+          <div
+            className="maka-panel maka-panel-detail maka-floating-panel agents-content-area agents-parchment-paper-surface"
+            data-sidebar-state={collapsed ? 'collapsed' : 'expanded'}
+            data-agents-view="im_hub"
+            style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}
+          >
+            {props.detailChildren ?? (
+              <div style={{ display: 'flex', minHeight: 0, width: '100%', flexDirection: 'column', flex: 1 }}>
+                <ChatView {...baseChatProps} activeSession={active} {...props.chat} />
+                <div style={{ padding: '0 24px 24px' }}>
+                  <Composer
+                    {...baseComposerProps}
+                    activeSession={active}
+                    streaming={props.session?.streaming ?? false}
+                    {...props.composer}
+                  />
+                </div>
+              </div>
+            )}
+          </div>
+        </AstryxAppShell>
       </div>
     </ShellFrame>
   );
@@ -407,7 +421,7 @@ export const StreamingTurn: Story = {
         liveTurn: {
           turnId: 'turn-s', phase: 'streamed', steps: [{
             stepId: 'msg-assistant-s',
-            text: { text: '用真实的子组件拼出 2 栏布局，不整体挂载 AppShell，避开 IPC 耦合。', truncated: false, complete: false },
+            text: { text: '用真实 Astryx AppShell 承接布局，再把 IPC 留在产品状态根。', truncated: false, complete: false },
             tools: [],
           }],
         },

--- a/packages/ui/src/__tests__/sidebar-subtraction.test.tsx
+++ b/packages/ui/src/__tests__/sidebar-subtraction.test.tsx
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import { describe, it } from 'node:test';
 import { renderToStaticMarkup } from 'react-dom/server';
-import type { PlanReminder, SessionSummary } from '@maka/core';
+import type { PlanReminder, ProjectRecord, SessionSummary } from '@maka/core';
 import { LocaleProvider } from '../locale-context.js';
 import { ModuleHubSelector } from '../module-hub-selector.js';
 import { SessionListPanel } from '../session-list-panel.js';
@@ -208,5 +208,87 @@ describe('sidebar subtraction', () => {
     assert.ok(markup.indexOf('最近置顶') < markup.indexOf('较早置顶'));
     assert.ok(markup.indexOf('最近会话') < markup.indexOf('较早会话'));
     assert.doesNotMatch(markup, /maka-list-group-toggle|maka-list-group-count/);
+  });
+
+  it('renders the time-grouped conversation history as an Astryx list', () => {
+    const session: SessionSummary = {
+      id: 'session-1',
+      name: '整理 Storybook 表面覆盖',
+      status: 'active',
+      isFlagged: false,
+      isArchived: false,
+      labels: [],
+      hasUnread: false,
+      lastMessageAt: 1,
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'anthropic-main',
+      connectionLocked: false,
+      model: 'claude-sonnet-4-5',
+      permissionMode: 'ask',
+    };
+    const markup = renderToStaticMarkup(
+      <LocaleProvider locale="zh">
+        <SessionListPanel
+          selection={{ section: 'sessions', filter: 'chats' }}
+          sessions={[session]}
+          viewMode="conversation"
+          onViewModeChange={() => {}}
+          onSelectSession={() => {}}
+          onSelect={() => {}}
+          onOpenSettings={() => {}}
+          onNew={() => {}}
+        />
+      </LocaleProvider>,
+    );
+
+    assert.match(markup, /class="[^"]*astryx-list[^"]*"/);
+    assert.match(markup, /role="list"/);
+    assert.doesNotMatch(markup, /maka-list-row/);
+  });
+
+  it('renders project navigation as the native balanced Astryx tree with line guides', () => {
+    const project: ProjectRecord = {
+      id: 'project-1',
+      name: 'Maka Agent',
+      locations: [{ path: '/workspace/maka-agent', isWorktree: false }],
+      available: true,
+    };
+    const session: SessionSummary = {
+      id: 'session-1',
+      name: '迁移 Shell 导航',
+      status: 'active',
+      isFlagged: false,
+      isArchived: false,
+      labels: [],
+      hasUnread: false,
+      lastMessageAt: 1,
+      backend: 'ai-sdk',
+      llmConnectionSlug: 'anthropic-main',
+      connectionLocked: false,
+      model: 'claude-sonnet-4-5',
+      permissionMode: 'ask',
+    };
+    const markup = renderToStaticMarkup(
+      <LocaleProvider locale="zh">
+        <SessionListPanel
+          selection={{ section: 'sessions', filter: 'chats' }}
+          sessions={[session]}
+          groups={[{ id: project.id, label: project.name, project, sessions: [session] }]}
+          viewMode="project"
+          onViewModeChange={() => {}}
+          onSelectSession={() => {}}
+          onSelect={() => {}}
+          onOpenSettings={() => {}}
+          onNew={() => {}}
+        />
+      </LocaleProvider>,
+    );
+
+    assert.match(markup, /class="[^"]*astryx-tree-list[^"]*balanced[^"]*"/);
+    assert.match(markup, /role="tree"/);
+    assert.match(markup, /role="treeitem"/);
+    assert.match(markup, /data-tree-level="1"/);
+    assert.match(markup, /data-tree-level="2"/);
+    assert.doesNotMatch(markup, /maka-list-project-header/);
   });
 });

--- a/packages/ui/src/__tests__/sidebar-subtraction.test.tsx
+++ b/packages/ui/src/__tests__/sidebar-subtraction.test.tsx
@@ -26,6 +26,7 @@ describe('sidebar subtraction', () => {
     assert.match(markup, />新任务</);
     assert.match(markup, />扩展</);
     assert.match(markup, />定时任务</);
+    assert.equal((markup.match(/astryx-side-nav-item/g) ?? []).length, 3);
     assert.doesNotMatch(markup, />技能</);
     assert.doesNotMatch(markup, />MCP</);
     assert.doesNotMatch(markup, />每日回顾</);
@@ -57,7 +58,8 @@ describe('sidebar subtraction', () => {
       </LocaleProvider>,
     );
 
-    assert.match(markup, /aria-label="Scheduled tasks, 1 unfinished reminder"/);
+    assert.match(markup, />Scheduled tasks</);
+    assert.match(markup, /class="maka-nav-pending-copy">, 1 unfinished reminder</);
     assert.match(markup, />Scheduled tasks</);
     assert.doesNotMatch(markup, /aria-label="Automations,/);
   });
@@ -242,6 +244,7 @@ describe('sidebar subtraction', () => {
     );
 
     assert.match(markup, /class="[^"]*astryx-list[^"]*"/);
+    assert.match(markup, /class="[^"]*astryx-side-nav[^"]*maka-session-panel[^"]*"/);
     assert.match(markup, /role="list"/);
     assert.doesNotMatch(markup, /maka-list-row/);
   });

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -1,4 +1,4 @@
-import { memo, useEffect, useRef, useState, type FocusEvent, type KeyboardEvent } from 'react';
+import { memo, useEffect, useRef, useState } from 'react';
 import { useMountedRef } from './use-mounted-ref.js';
 import type { ProjectRecord, SessionSummary, UiLocale } from '@maka/core';
 import { formatCompactTimestamp } from '@maka/core';
@@ -8,7 +8,6 @@ import {
   ArchiveRestore,
   Ban,
   Bot,
-  ChevronRight,
   CircleCheckBig,
   Eye,
   FolderGit2,
@@ -31,14 +30,14 @@ import {
   DropdownMenuItem,
 } from '@astryxdesign/core/DropdownMenu';
 import { Divider } from '@astryxdesign/core/Divider';
-import { Button as BaseButton } from '@base-ui/react/button';
+import { List, ListItem } from '@astryxdesign/core/List';
+import { TreeList, type TreeListItemData } from '@astryxdesign/core/TreeList';
 import { describeBlockedReason, presentSessionStatus } from './session-status-presentation.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
 
 type SessionRowActionId = 'flag' | 'archive' | 'rename' | 'delete';
 type SessionHistoryGroupVariant = 'conversation' | 'project';
-const PROJECT_GROUP_PREVIEW_LIMIT = 4;
 
 export interface SessionRowActions {
   /** Flag (pin) state toggle. */
@@ -111,57 +110,6 @@ export function SessionHistoryList(props: {
   // `props.sessions` — group rendering downstream still partitions
   // by status / time / filter.
 
-  function handleListKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-    // PR-SIDEBAR-IA-0 Phase 2 fixup (xuan `71687cc7`): the
-    // ArrowLeft/ArrowRight filter cycle was REMOVED. Hidden state
-    // without visible UI is harder for users to discover and harder
-    // for review to verify. If we re-introduce Pinned/Archived
-    // access in the future it will be a deliberate, visible,
-    // lightweight control (per kenji `9f683ea8`).
-    if (event.key === 'Delete' || event.key === 'Backspace') {
-      // Delete on a focused row opens the App-level confirmation (which
-      // toast.confirm()s); we do not delete silently per the lifecycle
-      // contract.
-      const active = document.activeElement as HTMLElement | null;
-      const row = active?.closest('.maka-list-row');
-      const sessionId = row?.querySelector<HTMLButtonElement>('.maka-list-row-main')?.dataset.sessionId;
-      if (sessionId && props.rowActions) {
-        event.preventDefault();
-        void props.rowActions.onDelete(sessionId);
-      }
-      return;
-    }
-    if (event.key !== 'ArrowUp' && event.key !== 'ArrowDown' && event.key !== 'Home' && event.key !== 'End') {
-      return;
-    }
-    const list = event.currentTarget;
-    const focusables = Array.from(
-      list.querySelectorAll<HTMLButtonElement>('.maka-list-row-main'),
-    );
-    if (focusables.length === 0) return;
-    const active = document.activeElement as HTMLElement | null;
-    const currentIndex = active ? focusables.indexOf(active as HTMLButtonElement) : -1;
-    let nextIndex = currentIndex;
-    switch (event.key) {
-      case 'ArrowDown':
-        nextIndex = currentIndex < 0 ? 0 : Math.min(focusables.length - 1, currentIndex + 1);
-        break;
-      case 'ArrowUp':
-        nextIndex = currentIndex <= 0 ? 0 : currentIndex - 1;
-        break;
-      case 'Home':
-        nextIndex = 0;
-        break;
-      case 'End':
-        nextIndex = focusables.length - 1;
-        break;
-    }
-    if (nextIndex === currentIndex) return;
-    event.preventDefault();
-    focusables[nextIndex]?.focus({ preventScroll: false });
-    focusables[nextIndex]?.scrollIntoView({ block: 'nearest' });
-  }
-
   return (
     <section className="maka-session-list" aria-label={sessionListTitle}>
       {props.sessions.length === 0 &&
@@ -182,7 +130,6 @@ export function SessionHistoryList(props: {
           className="maka-list-stack"
           viewportClassName="maka-list-stackViewport"
           contentClassName="maka-list-stackContent"
-          onKeyDown={handleListKeyDown}
         >
           <SessionListGroups
             groups={
@@ -234,41 +181,10 @@ function SessionListGroups(props: {
   projectActions?: ProjectRowActions;
 }) {
   if (props.groupVariant === 'project') {
-    const activeGroups = props.groups.filter((group) => group.project?.archivedAt === undefined);
-    const archivedGroups = props.groups.filter((group) => group.project?.archivedAt !== undefined);
     return (
-      <>
-        {activeGroups.map((group) => (
-          <ProjectSessionGroup
-            key={group.key}
-            groupKey={group.key}
-            label={group.label}
-            sessions={group.sessions}
-            project={group.project}
-            activeId={props.activeId}
-            streamingSessionIds={props.streamingSessionIds}
-            staleSessionIds={props.staleSessionIds}
-            childSessionsByParentId={props.childSessionsByParentId}
-            worktreeSessionIds={props.worktreeSessionIds}
-            onSelectSession={props.onSelectSession}
-            rowActions={props.rowActions}
-            projectActions={props.projectActions}
-          />
-        ))}
-        {archivedGroups.length > 0 && (
-          <ArchivedProjectGroups
-            groups={archivedGroups}
-            activeId={props.activeId}
-            streamingSessionIds={props.streamingSessionIds}
-            staleSessionIds={props.staleSessionIds}
-            childSessionsByParentId={props.childSessionsByParentId}
-            worktreeSessionIds={props.worktreeSessionIds}
-            onSelectSession={props.onSelectSession}
-            rowActions={props.rowActions}
-            projectActions={props.projectActions}
-          />
-        )}
-      </>
+      <ProjectHistoryTree
+        {...props}
+      />
     );
   }
 
@@ -276,295 +192,16 @@ function SessionListGroups(props: {
     <>
       {props.groups.map((group) => {
         return (
-          <div key={group.key} className="maka-list-group" data-variant="conversation">
-            {group.label ? (
-              <div className="maka-list-group-label">
-                <span>{group.label}</span>
-              </div>
-            ) : null}
-            <div>
-              {group.sessions.map((session) => (
-                <SessionTreeRow
-                  key={session.id}
-                  session={session}
-                  activeId={props.activeId}
-                  streamingSessionIds={props.streamingSessionIds}
-                  staleSessionIds={props.staleSessionIds}
-                  childSessionsByParentId={props.childSessionsByParentId}
-                  worktreeSessionIds={props.worktreeSessionIds}
-                  onSelectSession={props.onSelectSession}
-                  rowActions={props.rowActions}
-                />
-              ))}
-            </div>
-          </div>
-        );
-      })}
-    </>
-  );
-}
-
-interface ProjectGroupSharedProps {
-  activeId?: string;
-  streamingSessionIds?: Set<string>;
-  staleSessionIds?: Set<string>;
-  childSessionsByParentId?: ReadonlyMap<string, readonly SessionSummary[]>;
-  worktreeSessionIds?: ReadonlySet<string>;
-  onSelectSession(sessionId: string): void;
-  rowActions?: SessionRowActions;
-  projectActions?: ProjectRowActions;
-}
-
-function ArchivedProjectGroups(
-  props: ProjectGroupSharedProps & {
-    groups: ReadonlyArray<{
-      key: string;
-      label: string;
-      sessions: SessionSummary[];
-      project?: ProjectRecord;
-    }>;
-  },
-) {
-  const copy = getConversationCopy(useUiLocale()).sessions;
-  const [expanded, setExpanded] = useState(false);
-  return (
-    <div className="maka-list-archived-projects">
-      <BaseButton
-        type="button"
-        className="maka-list-archived-projects-heading"
-        onClick={() => setExpanded((current) => !current)}
-        aria-expanded={expanded}
-        aria-label={copy.archivedProjectsAriaLabel}
-      >
-        <ChevronRight size={13} aria-hidden="true" />
-        <span>{copy.archivedProjects}</span>
-        <span className="maka-list-project-count">{props.groups.length}</span>
-      </BaseButton>
-      {expanded &&
-        props.groups.map((group) => (
-          <ProjectSessionGroup
+          <List
             key={group.key}
-            {...props}
-            groupKey={group.key}
-            label={group.label}
-            sessions={group.sessions}
-            project={group.project}
-          />
-        ))}
-    </div>
-  );
-}
-
-function ProjectSessionGroup(props: ProjectGroupSharedProps & {
-  groupKey: string;
-  label: string;
-  sessions: SessionSummary[];
-  project?: ProjectRecord;
-}) {
-  const copy = getConversationCopy(useUiLocale()).sessions;
-  const [revealed, setRevealed] = useState(false);
-  const activeSessionId = props.sessions.some((session) => session.id === props.activeId)
-    ? props.activeId
-    : undefined;
-  const [disclosure, setDisclosure] = useState({
-    expanded: props.sessions.length > 0,
-    observedActiveSessionId: activeSessionId,
-  });
-  if (activeSessionId !== disclosure.observedActiveSessionId) {
-    setDisclosure({
-      expanded: activeSessionId ? true : disclosure.expanded,
-      observedActiveSessionId: activeSessionId,
-    });
-  }
-  const expanded = disclosure.expanded;
-  const [editing, setEditing] = useState(false);
-  const [pendingAction, setPendingAction] = useState<string | null>(null);
-  const mountedRef = useMountedRef();
-  const pendingActionRef = useRef<string | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const escapeCancelledRef = useRef(false);
-  const activeIsHidden = props.activeId
-    ? props.sessions.findIndex((session) => session.id === props.activeId) >= PROJECT_GROUP_PREVIEW_LIMIT
-    : false;
-  const showAll = revealed || activeIsHidden;
-  const visibleSessions = showAll
-    ? props.sessions
-    : props.sessions.slice(0, PROJECT_GROUP_PREVIEW_LIMIT);
-  const hiddenCount = props.sessions.length - visibleSessions.length;
-  const project = props.project;
-  const canExpand = props.sessions.length > 0;
-
-  useEffect(() => {
-    if (!editing) return;
-    inputRef.current?.focus();
-    inputRef.current?.select();
-  }, [editing]);
-
-  useEffect(() => {
-    return () => {
-      pendingActionRef.current = null;
-    };
-  }, []);
-
-  function runProjectAction(actionId: string, action: () => void | Promise<void>) {
-    if (pendingActionRef.current) return;
-    pendingActionRef.current = actionId;
-    setPendingAction(actionId);
-    void (async () => {
-      try {
-        await action();
-      } catch {
-        // AppShell owns visible project-action failure feedback.
-      } finally {
-        pendingActionRef.current = null;
-        if (mountedRef.current) setPendingAction(null);
-      }
-    })();
-  }
-
-  function commitRename(value: string) {
-    const name = value.trim();
-    setEditing(false);
-    if (!project || !props.projectActions || !name || name === project.name) return;
-    runProjectAction('rename', () => props.projectActions!.onRename(project.id, name));
-  }
-
-  return (
-    <div
-      className="maka-list-group"
-      data-variant="project"
-      data-unavailable={project && !project.available ? 'true' : undefined}
-      data-expanded={expanded ? 'true' : 'false'}
-    >
-      <div className="maka-list-project-header">
-        {editing ? (
-          <form
-            className="maka-list-project-heading maka-list-project-rename"
-            onSubmit={(event) => {
-              event.preventDefault();
-              commitRename(inputRef.current?.value ?? '');
-            }}
+            className="maka-session-history-group"
+            density="compact"
+            header={group.label ? (
+              <div className="maka-list-group-label"><span>{group.label}</span></div>
+            ) : undefined}
           >
-            <FolderOpen size={14} aria-hidden="true" />
-            <input
-              ref={inputRef}
-              defaultValue={props.label}
-              maxLength={80}
-              aria-label={copy.projectRename}
-              onBlur={(event) => {
-                if (escapeCancelledRef.current) {
-                  escapeCancelledRef.current = false;
-                  return;
-                }
-                commitRename(event.currentTarget.value);
-              }}
-              onKeyDown={(event) => {
-                if (event.nativeEvent.isComposing || event.key === 'Process') return;
-                if (event.key === 'Escape') {
-                  event.preventDefault();
-                  escapeCancelledRef.current = true;
-                  setEditing(false);
-                }
-              }}
-            />
-          </form>
-        ) : (
-          <BaseButton
-            type="button"
-            className="maka-list-project-heading"
-            onClick={() => {
-              if (canExpand) {
-                setDisclosure((current) => ({
-                  ...current,
-                  expanded: !current.expanded,
-                }));
-              }
-            }}
-            disabled={!canExpand}
-            aria-expanded={canExpand ? expanded : false}
-            aria-controls={canExpand ? `maka-list-group-body-${props.groupKey}` : undefined}
-          >
-            <FolderOpen size={14} aria-hidden="true" />
-            <span className="maka-list-project-name">{props.label}</span>
-            {project && !project.available && (
-              <AlertTriangle
-                size={12}
-                aria-label={copy.projectUnavailable}
-              />
-            )}
-            <span className="maka-list-project-count">{props.sessions.length}</span>
-          </BaseButton>
-        )}
-        {project && props.projectActions && !editing && (
-          <DropdownMenu
-            button={{
-              label: copy.projectActionsAriaLabel(project.name),
-              icon: pendingAction ? (
-                <Loader2 size={14} aria-hidden="true" />
-              ) : (
-                <MoreHorizontal size={14} aria-hidden="true" />
-              ),
-              isIconOnly: true,
-              variant: 'ghost',
-              size: 'sm',
-              className: 'maka-list-project-menu-trigger',
-              isDisabled: pendingAction !== null,
-            }}
-          >
-              {project.archivedAt !== undefined ? (
-                <DropdownMenuItem
-                  onClick={() =>
-                    runProjectAction('restore', () => props.projectActions!.onRestore(project.id))
-                  }
-                  icon={<ArchiveRestore size={15} aria-hidden="true" />}
-                  label={copy.projectRestore}
-                />
-              ) : (
-                <>
-                  {project.available ? (
-                    <DropdownMenuItem
-                      onClick={() =>
-                        runProjectAction('new', () => props.projectActions!.onNew(project.id))
-                      }
-                      icon={<Plus size={15} aria-hidden="true" />}
-                      label={copy.projectNewTask}
-                    />
-                  ) : (
-                    <DropdownMenuItem
-                      onClick={() =>
-                        runProjectAction('relink', () =>
-                          props.projectActions!.onRelink(project.id))
-                      }
-                      icon={<FolderOpen size={15} aria-hidden="true" />}
-                      label={copy.projectRelink}
-                    />
-                  )}
-                  <Divider orientation="horizontal" />
-                  <DropdownMenuItem
-                    onClick={() => {
-                      if (!pendingActionRef.current) setEditing(true);
-                    }}
-                    icon={<Pencil size={15} aria-hidden="true" />}
-                    label={copy.projectRename}
-                  />
-                  <DropdownMenuItem
-                    onClick={() =>
-                      runProjectAction('archive', () =>
-                        props.projectActions!.onArchive(project.id))
-                    }
-                    icon={<Archive size={15} aria-hidden="true" />}
-                    label={copy.projectArchive}
-                  />
-                </>
-              )}
-          </DropdownMenu>
-        )}
-      </div>
-      {expanded && (
-        <>
-          <div id={`maka-list-group-body-${props.groupKey}`}>
-            {visibleSessions.map((session) => (
-              <SessionTreeRow
+            {group.sessions.map((session) => (
+              <SessionListBranch
                 key={session.id}
                 session={session}
                 activeId={props.activeId}
@@ -576,25 +213,20 @@ function ProjectSessionGroup(props: ProjectGroupSharedProps & {
                 rowActions={props.rowActions}
               />
             ))}
-          </div>
-          {hiddenCount > 0 && (
-            <BaseButton
-              type="button"
-              className="maka-list-project-more"
-              onClick={() => setRevealed(true)}
-              aria-label={copy.showMoreAriaLabel(hiddenCount)}
-            >
-              {copy.showMore}
-            </BaseButton>
-          )}
-        </>
-      )}
-    </div>
+          </List>
+        );
+      })}
+    </>
   );
 }
 
-function SessionTreeRow(props: {
-  session: SessionSummary;
+interface HistoryTreeProps {
+  groups: ReadonlyArray<{
+    key: string;
+    label: string;
+    sessions: SessionSummary[];
+    project?: ProjectRecord;
+  }>;
   activeId?: string;
   streamingSessionIds?: Set<string>;
   staleSessionIds?: Set<string>;
@@ -602,38 +234,172 @@ function SessionTreeRow(props: {
   worktreeSessionIds?: ReadonlySet<string>;
   onSelectSession(sessionId: string): void;
   rowActions?: SessionRowActions;
-  depth?: number;
-}) {
-  const depth = props.depth ?? 0;
-  const children = props.childSessionsByParentId?.get(props.session.id) ?? [];
-  return (
-    <div
-      className="maka-list-session-tree"
-      data-depth={depth > 0 ? String(depth) : undefined}
-    >
-      <SessionRow
-        session={props.session}
-        active={props.session.id === props.activeId}
-        streaming={props.streamingSessionIds?.has(props.session.id) ?? false}
-        stale={props.staleSessionIds?.has(props.session.id) ?? false}
-        worktree={props.worktreeSessionIds?.has(props.session.id) ?? false}
-        nested={depth > 0}
-        onSelect={props.onSelectSession}
-        actions={props.rowActions}
-      />
-      {children.length > 0 && (
-        <div className="maka-list-session-children">
-          {children.map((child) => (
-            <SessionTreeRow
-              key={child.id}
-              {...props}
-              session={child}
-              depth={depth + 1}
+  projectActions?: ProjectRowActions;
+}
+
+function ProjectHistoryTree(props: HistoryTreeProps) {
+  const locale = useUiLocale();
+  const copy = getConversationCopy(locale).sessions;
+  const [editingSessionId, setEditingSessionId] = useState<string>();
+  const [editingProjectId, setEditingProjectId] = useState<string>();
+
+  function sessionItem(session: SessionSummary, nested = false): TreeListItemData {
+    const children = props.childSessionsByParentId?.get(session.id) ?? [];
+    const editing = editingSessionId === session.id;
+    return {
+      id: `session:${session.id}`,
+      label: editing ? (
+        <InlineRenameInput
+          value={session.name}
+          ariaLabel={copy.renameAriaLabel}
+          onCancel={() => setEditingSessionId(undefined)}
+          onCommit={(name) => {
+            setEditingSessionId(undefined);
+            if (name && name !== session.name) void props.rowActions?.onRename(session.id, name);
+          }}
+        />
+      ) : (
+        <SessionItemLabel
+          session={session}
+          active={session.id === props.activeId}
+          streaming={props.streamingSessionIds?.has(session.id)}
+          stale={props.staleSessionIds?.has(session.id)}
+          worktree={props.worktreeSessionIds?.has(session.id)}
+          nested={nested}
+        />
+      ),
+      description: editing ? formatSessionMeta(session, locale) : undefined,
+      endContent: editing ? undefined : (
+        <SessionItemEnd
+          session={session}
+          active={session.id === props.activeId}
+          streaming={props.streamingSessionIds?.has(session.id)}
+          actions={props.rowActions}
+          onRename={() => setEditingSessionId(session.id)}
+        />
+      ),
+      onClick: editing ? undefined : () => props.onSelectSession(session.id),
+      isSelected: session.id === props.activeId,
+      children: children.map((child) => sessionItem(child, true)),
+    };
+  }
+
+  function projectItem(group: HistoryTreeProps['groups'][number]): TreeListItemData {
+    const project = group.project;
+    const editing = project != null && editingProjectId === project.id;
+    return {
+      id: project ? `project:${project.id}` : group.key,
+      label: editing && project ? (
+        <InlineRenameInput
+          value={project.name}
+          ariaLabel={copy.projectRename}
+          onCancel={() => setEditingProjectId(undefined)}
+          onCommit={(name) => {
+            setEditingProjectId(undefined);
+            if (name && name !== project.name) void props.projectActions?.onRename(project.id, name);
+          }}
+        />
+      ) : (
+        <span className="maka-project-tree-label">
+          <span>{group.label}</span>
+          <span className="maka-project-tree-count">{group.sessions.length}</span>
+        </span>
+      ),
+      startContent: <FolderOpen size={14} aria-hidden="true" />,
+      endContent: project && !editing ? (
+        <span className="maka-project-tree-actions">
+          {!project.available && <AlertTriangle size={12} aria-label={copy.projectUnavailable} />}
+          {props.projectActions && (
+            <ProjectActionsMenu
+              project={project}
+              actions={props.projectActions}
+              onRename={() => setEditingProjectId(project.id)}
             />
-          ))}
-        </div>
-      )}
-    </div>
+          )}
+        </span>
+      ) : undefined,
+      isExpanded: group.sessions.length > 0,
+      children: group.sessions.map((session) => sessionItem(session)),
+    };
+  }
+
+  const active = props.groups.filter((group) => group.project?.archivedAt === undefined);
+  const archived = props.groups.filter((group) => group.project?.archivedAt !== undefined);
+  const items: TreeListItemData[] = active.map(projectItem);
+  if (archived.length > 0) {
+    items.push({
+      id: 'archived-projects',
+      label: copy.archivedProjects,
+      startContent: <Archive size={14} aria-hidden="true" />,
+      endContent: <span className="maka-project-tree-count">{archived.length}</span>,
+      children: archived.map(projectItem),
+    });
+  }
+
+  return (
+    <TreeList
+      className="maka-project-history-tree"
+      density="balanced"
+      variant="lineGuides"
+      items={items}
+      onKeyDown={(event) => {
+        if (event.key !== 'Delete' && event.key !== 'Backspace') return;
+        if ((event.target as HTMLElement).closest('input, [data-session-actions]')) return;
+        const item = (event.target as HTMLElement).closest<HTMLElement>('[role="treeitem"]');
+        const sessionId = item?.dataset.treeId?.startsWith('session:')
+          ? item.dataset.treeId.slice('session:'.length)
+          : undefined;
+        if (!sessionId || !props.rowActions) return;
+        event.preventDefault();
+        void props.rowActions.onDelete(sessionId);
+      }}
+    />
+  );
+}
+
+function InlineRenameInput(props: {
+  value: string;
+  ariaLabel: string;
+  onCommit(value: string): void;
+  onCancel(): void;
+}) {
+  const ref = useRef<HTMLInputElement>(null);
+  const cancelledRef = useRef(false);
+  useEffect(() => {
+    ref.current?.focus();
+    ref.current?.select();
+  }, []);
+  return (
+    <input
+      ref={ref}
+      className="maka-session-inline-rename"
+      defaultValue={props.value}
+      maxLength={80}
+      aria-label={props.ariaLabel}
+      autoComplete="off"
+      spellCheck={false}
+      onBlur={(event) => {
+        if (cancelledRef.current) return;
+        props.onCommit(event.currentTarget.value.trim());
+      }}
+      onKeyDown={(event) => {
+        if (event.nativeEvent.isComposing || event.key === 'Process') return;
+        if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+          event.stopPropagation();
+          return;
+        }
+        if (event.key === 'Enter') {
+          event.preventDefault();
+          event.stopPropagation();
+          props.onCommit(event.currentTarget.value.trim());
+        } else if (event.key === 'Escape') {
+          event.preventDefault();
+          event.stopPropagation();
+          cancelledRef.current = true;
+          props.onCancel();
+        }
+      }}
+    />
   );
 }
 
@@ -710,332 +476,270 @@ const STATUS_ICON_BY_STATUS = {
   aborted: Ban,
 } as const;
 
-const SessionRow = memo(function SessionRow(props: {
+function SessionListBranch(props: {
+  session: SessionSummary;
+  activeId?: string;
+  streamingSessionIds?: Set<string>;
+  staleSessionIds?: Set<string>;
+  childSessionsByParentId?: ReadonlyMap<string, readonly SessionSummary[]>;
+  worktreeSessionIds?: ReadonlySet<string>;
+  onSelectSession(sessionId: string): void;
+  rowActions?: SessionRowActions;
+  depth?: number;
+}) {
+  const depth = props.depth ?? 0;
+  const children = props.childSessionsByParentId?.get(props.session.id) ?? [];
+  return (
+    <>
+      <SessionListItem
+        session={props.session}
+        active={props.session.id === props.activeId}
+        streaming={props.streamingSessionIds?.has(props.session.id)}
+        stale={props.staleSessionIds?.has(props.session.id)}
+        worktree={props.worktreeSessionIds?.has(props.session.id)}
+        nested={depth > 0}
+        onSelect={props.onSelectSession}
+        actions={props.rowActions}
+      />
+      {children.map((child) => (
+        <SessionListBranch key={child.id} {...props} session={child} depth={depth + 1} />
+      ))}
+    </>
+  );
+}
+
+const SessionListItem = memo(function SessionListItem(props: {
   session: SessionSummary;
   active: boolean;
-  /** This session has a live streaming delta in flight. */
   streaming?: boolean;
-  /**
-   * This session's backend / connection is stale (FakeBackend or a removed
-   * connection slug). Dims the row + renders a small "已过期" pill so the
-   * user can spot broken sessions in the list before clicking in.
-   */
   stale?: boolean;
-  /** This session runs from a linked Git worktree. */
   worktree?: boolean;
-  /** Render this linked child as an indented nested Session row. */
   nested?: boolean;
   onSelect(sessionId: string): void;
   actions?: SessionRowActions;
 }) {
-  const { session, active, streaming, stale, worktree, nested, actions, onSelect } = props;
+  const { session, active, streaming, stale, worktree, nested, actions } = props;
   const locale = useUiLocale();
   const copy = getConversationCopy(locale).sessions;
   const [editing, setEditing] = useState(false);
-  const [actionsVisible, setActionsVisible] = useState(false);
+  return (
+    <ListItem
+      className="maka-session-list-item"
+      data-session-id={session.id}
+      data-subagent={nested ? 'true' : undefined}
+      data-stale={stale ? 'true' : undefined}
+      isSelected={active}
+      label={editing ? (
+        <InlineRenameInput
+          value={session.name}
+          ariaLabel={copy.renameAriaLabel}
+          onCancel={() => setEditing(false)}
+          onCommit={(name) => {
+            setEditing(false);
+            if (name && name !== session.name) void actions?.onRename(session.id, name);
+          }}
+        />
+      ) : (
+        <SessionItemLabel
+          session={session}
+          active={active}
+          streaming={streaming}
+          stale={stale}
+          worktree={worktree}
+          nested={nested}
+        />
+      )}
+      description={editing ? formatSessionMeta(session, locale) : undefined}
+      endContent={editing ? undefined : (
+        <SessionItemEnd
+          session={session}
+          active={active}
+          streaming={streaming}
+          actions={actions}
+          onRename={() => setEditing(true)}
+        />
+      )}
+      onClick={editing ? undefined : () => props.onSelect(session.id)}
+      onKeyDown={(event) => {
+        if (event.key !== 'Delete' && event.key !== 'Backspace') return;
+        if ((event.target as HTMLElement).closest('input, [data-session-actions]')) return;
+        if (!actions) return;
+        event.preventDefault();
+        void actions.onDelete(session.id);
+      }}
+    />
+  );
+});
+
+function SessionItemLabel(props: {
+  session: SessionSummary;
+  active: boolean;
+  streaming?: boolean;
+  stale?: boolean;
+  worktree?: boolean;
+  nested?: boolean;
+}) {
+  const copy = getConversationCopy(useUiLocale()).sessions;
+  return (
+    <span
+      className="maka-session-item-label"
+      data-active={props.active ? 'true' : undefined}
+      data-stale={props.stale ? 'true' : undefined}
+    >
+      {props.nested && <Bot size={12} aria-hidden="true" />}
+      {props.worktree && <FolderGit2 size={12} aria-label={copy.worktreeAriaLabel} />}
+      {props.streaming && (
+        <span className="maka-list-row-streaming-dot" aria-label={copy.respondingAriaLabel} title={copy.respondingTitle} />
+      )}
+      <SessionStatusIcon session={props.session} />
+      <span>{props.session.name}</span>
+      {props.stale && (
+        <span className="maka-list-row-stale-pill" title={copy.staleTitle} aria-label={copy.staleAriaLabel}>
+          {copy.stale}
+        </span>
+      )}
+    </span>
+  );
+}
+
+function SessionItemEnd(props: {
+  session: SessionSummary;
+  active: boolean;
+  streaming?: boolean;
+  actions?: SessionRowActions;
+  onRename(): void;
+}) {
+  const locale = useUiLocale();
+  const copy = getConversationCopy(locale).sessions;
+  return (
+    <span className="maka-session-item-end">
+      {shouldShowSessionUnreadDot(props.session, Boolean(props.streaming), props.active) ? (
+        <span className="maka-list-row-unread" aria-label={copy.unreadAriaLabel} />
+      ) : (
+        <span className="maka-session-item-meta">{formatSessionMeta(props.session, locale)}</span>
+      )}
+      {props.actions && (
+        <SessionActionsMenu session={props.session} actions={props.actions} onRename={props.onRename} />
+      )}
+    </span>
+  );
+}
+
+function SessionActionsMenu(props: {
+  session: SessionSummary;
+  actions: SessionRowActions;
+  onRename(): void;
+}) {
+  const copy = getConversationCopy(useUiLocale()).sessions;
   const [menuOpen, setMenuOpen] = useState(false);
-  const [pendingAction, setPendingAction] = useState<SessionRowActionId | null>(null);
-  const rowMountedRef = useMountedRef();
-  const pendingActionRef = useRef<SessionRowActionId | null>(null);
-  const pendingMenuIntentRef = useRef<(() => void) | null>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  // PR-FE-BUG-HUNT-11: Escape on the rename input has to suppress the
-  // blur-fires-on-unmount commit. Without this ref, the sequence
-  //   type → Escape → setEditing(false) → input unmounts → blur fires
-  //   with the typed value → commitRename(typed) → rename happens
-  // would silently commit the user's typed value despite the cancel.
-  const escapeCancelledRef = useRef(false);
-  const actionBusy = pendingAction !== null;
-  const actionTriggerVisible = actionsVisible || menuOpen;
+  const [pendingAction, setPendingAction] = useState<SessionRowActionId>();
+  const mountedRef = useMountedRef();
+  const pendingRef = useRef<SessionRowActionId | undefined>(undefined);
+  const deleteAfterCloseRef = useRef(false);
+  useEffect(() => () => { pendingRef.current = undefined; }, []);
 
-  useEffect(() => {
-    return () => {
-      pendingActionRef.current = null;
-    };
-  }, []);
-
-  // Auto-focus + select-all when the row enters edit mode so the user can
-  // overwrite the current name without an extra Cmd+A.
-  useEffect(() => {
-    if (!editing) return;
-    const input = inputRef.current;
-    if (!input) return;
-    input.focus();
-    input.select();
-  }, [editing]);
-
-  function startRename() {
-    if (!actions || pendingActionRef.current) return;
-    setEditing(true);
-  }
-
-  function runRowAction(actionId: SessionRowActionId, action: () => void | Promise<void>) {
-    if (pendingActionRef.current) return;
-    pendingActionRef.current = actionId;
+  function run(actionId: SessionRowActionId, action: () => void | Promise<void>) {
+    if (pendingRef.current) return;
+    pendingRef.current = actionId;
     setPendingAction(actionId);
-    void (async () => {
-      try {
-        await action();
-      } catch {
-        // The AppShell row-action owner reports the visible failure toast.
-      } finally {
-        pendingActionRef.current = null;
-        if (rowMountedRef.current) setPendingAction(null);
-      }
-    })();
-  }
-
-  function commitRename(rawValue: string) {
-    const trimmed = rawValue.trim();
-    setEditing(false);
-    if (!trimmed || trimmed === session.name) return;
-    if (!actions) return;
-    runRowAction('rename', () => actions.onRename(session.id, trimmed));
-  }
-
-  function handleDelete() {
-    if (!actions) return;
-    // Delegation: the App-level handler owns the confirmation flow via the
-    // toast system (PR24), so SessionRow stays presentation-only.
-    runRowAction('delete', () => actions.onDelete(session.id));
-  }
-
-  function handleMenuOpenChange(open: boolean) {
-    setMenuOpen(open);
-    if (open) return;
-    const intent = pendingMenuIntentRef.current;
-    pendingMenuIntentRef.current = null;
-    if (intent) {
-      window.requestAnimationFrame(() => {
-        if (rowMountedRef.current) intent();
-      });
-    }
-  }
-
-  function handleRowBlur(event: FocusEvent<HTMLDivElement>) {
-    if (event.currentTarget.contains(event.relatedTarget as Node | null)) return;
-    setActionsVisible(false);
+    void Promise.resolve(action()).catch(() => {}).finally(() => {
+      pendingRef.current = undefined;
+      if (mountedRef.current) setPendingAction(undefined);
+    });
   }
 
   return (
-    <div
-      className="maka-list-row"
-      data-maka-contract="list-row"
-      data-active={active}
-      data-editing={editing}
-      data-menu-open={menuOpen ? 'true' : undefined}
-      data-streaming={streaming ? 'true' : undefined}
-      data-stale={stale ? 'true' : undefined}
-      data-subagent={nested ? 'true' : undefined}
-      onMouseEnter={() => setActionsVisible(true)}
-      onMouseLeave={(event) => {
-        if (event.currentTarget.contains(document.activeElement)) return;
-        setActionsVisible(false);
-      }}
-      onFocus={() => setActionsVisible(true)}
-      onBlur={handleRowBlur}
-    >
-      {editing ? (
-        <form
-          className="maka-list-row-main"
-          onSubmit={(event) => {
-            event.preventDefault();
-            commitRename(inputRef.current?.value ?? '');
-          }}
-        >
-          <div>
-            <input
-              ref={inputRef}
-              className="maka-list-row-rename-input"
-              defaultValue={session.name}
-              maxLength={80}
-              aria-label={copy.renameAriaLabel}
-              onBlur={(event) => {
-                // PR-FE-BUG-HUNT-11: skip the commit when the blur was
-                // caused by Escape cancelling edit mode (input unmounts
-                // → blur fires with the typed value otherwise).
-                if (escapeCancelledRef.current) {
-                  escapeCancelledRef.current = false;
-                  return;
-                }
-                commitRename(event.currentTarget.value);
-              }}
-              onKeyDown={(event) => {
-                // IME guard so committing CJK characters with Enter doesn't
-                // submit the rename before the user is done.
-                if (event.nativeEvent.isComposing || event.key === 'Process') return;
-                if (event.key === 'Escape') {
-                  event.preventDefault();
-                  escapeCancelledRef.current = true;
-                  setEditing(false);
-                }
-              }}
-              autoComplete="off"
-              spellCheck={false}
-            />
-            <div className="maka-list-row-meta" data-maka-contract="list-row-meta">{formatSessionMeta(session, locale)}</div>
-          </div>
-        </form>
-      ) : (
-        // PR-SIDEBAR-IA-0 Phase 3 (WAWQAQ `14ed98b5` "list 很丑、很肥很
-        // 臃肿"; xuan `6b28984e` Phase 2 sign-off + Phase 3 32-40px
-        // target; xuan `2d4526b5` tightening: NO native title= snippet,
-        // title is ONLY for name truncation): slim row.
-        //
-        // The button is the row's hit target. The native `title=`
-        // attribute carries ONLY the session name so it serves as a
-        // truncation tooltip when the name overflows the row. The
-        // `lastMessagePreview` snippet is intentionally NOT exposed
-        // here — per xuan `2d4526b5`, snippet visibility is a
-        // separate, deliberate design (future PR), not a Phase 3
-        // afterthought via native tooltip.
-        //
-        // `data-active` on the row controls the active-state accent
-        // rail + bg tint via CSS; the row's `name` cluster also
-        // recolors to accent on selected so the row reads as
-        // "current" without a heavy full-bg pill.
-        /* PR-SESSION-ROW-MAIN-PRIMITIVE-0 (round 14/30): the
-           single most-clicked button in the app — every session
-           row's main click target. This composite navigation row keeps its
-           grid layout and multi-line density in the semantic row seam rather
-           than masquerading as a shared Button size. */
-        <BaseButton
-          className="maka-list-row-main"
-          type="button"
-          data-session-id={session.id}
-          aria-current={active ? 'true' : undefined}
-          title={session.name}
-          onClick={() => onSelect(session.id)}
-          onDoubleClick={(event) => {
-            event.stopPropagation();
-            if (actions && !pendingActionRef.current) setEditing(true);
-          }}
-        >
-          {/*
-            PR-SIDEBAR-IA-0 Phase 3 layout (xuan `2d4526b5`):
-              [.maka-list-row-text  (col 1: minmax(0,1fr))] [meta/unread  (col 2: auto)]
-            The text container holds the name cluster (status icons +
-            name + stale pill) and truncates via min-width: 0. The
-            meta column sits at the inline-end with a clear gap so
-            "会话 02" doesn't run into "0m ago".
-          */}
-          <div className="maka-list-row-text">
-            <div className="maka-list-row-name">
-              {nested && (
-                <Bot
-                  size={12}
-                  aria-hidden="true"
-                  className="maka-list-row-subagent-icon"
-                />
-              )}
-              {worktree && (
-                <FolderGit2
-                  size={12}
-                  aria-label={copy.worktreeAriaLabel}
-                  className="maka-list-row-worktree-icon"
-                />
-              )}
-              {streaming && (
-                <span
-                  className="maka-list-row-streaming-dot"
-                  aria-label={copy.respondingAriaLabel}
-                  title={copy.respondingTitle}
-                />
-              )}
-              <SessionStatusIcon session={session} />
-              <span>{session.name}</span>
-              {stale && (
-                <span
-                  className="maka-list-row-stale-pill"
-                  // The pill semantics match the chat-header banner: the
-                  // session uses a backend / connection that no longer exists,
-                  // but @xuan's send-path silent rebind will swap to the
-                  // default on send. Tooltip explains why.
-                  title={copy.staleTitle}
-                  aria-label={copy.staleAriaLabel}
-                >
-                  {copy.stale}
-                </span>
-              )}
-            </div>
-          </div>
-          {/*
-            PR-SIDEBAR-IA-0 Phase 3 (xuan `2d4526b5`): snippet preview
-            (`.maka-list-row-preview`) is no longer rendered in the
-            default DOM AND is no longer exposed via native `title=`
-            tooltip. Snippet visibility is deliberately deferred to a
-            future PR with its own hover/focus detail design.
-            `formatSessionMeta` shows the relative time inline in the
-            row's `auto` grid column (sibling of `.maka-list-row-text`,
-            not nested inside it — required for proper gap + alignment).
-            The unread dot replaces the time only when no higher-priority
-            row state is active. Borrowed from PawWork's sidebar priority:
-            asking/busy/error outrank unread; unread outranks plain time.
-          */}
-          {shouldShowSessionUnreadDot(session, Boolean(streaming), active) ? (
-            <span className="maka-list-row-unread" aria-label={copy.unreadAriaLabel} />
-          ) : (
-            <span className="maka-list-row-meta" data-maka-contract="list-row-meta">{formatSessionMeta(session, locale)}</span>
-          )}
-        </BaseButton>
-      )}
-      {actions && !editing && (
-        <DropdownMenu
-          isMenuOpen={menuOpen}
-          onOpenChange={handleMenuOpenChange}
-          button={{
-            label: copy.actionsAriaLabel,
-            icon: <MoreHorizontal size={16} aria-hidden="true" />,
-            isIconOnly: true,
-            variant: 'ghost',
-            size: 'sm',
-            className: 'maka-list-row-menu-trigger',
-            'aria-hidden': actionTriggerVisible ? undefined : 'true',
-            'data-visible': actionTriggerVisible ? 'true' : undefined,
-            tabIndex: actionTriggerVisible ? 0 : -1,
-          }}
-        >
-            <DropdownMenuItem
-              isDisabled={actionBusy}
-              onClick={() => runRowAction('flag', () => actions.onToggleFlag(session.id, !session.isFlagged))}
-              icon={session.isFlagged
-                ? <PinOff size={16} aria-hidden="true" />
-                : <Pin size={16} aria-hidden="true" />}
-              label={session.isFlagged ? copy.unpin : copy.pin}
-            />
-            <DropdownMenuItem
-              isDisabled={actionBusy}
-              onClick={startRename}
-              icon={<Pencil size={16} aria-hidden="true" />}
-              label={copy.rename}
-            />
-            <DropdownMenuItem
-              isDisabled={actionBusy}
-              onClick={() => runRowAction('archive', () => (
-                session.isArchived
-                  ? actions.onUnarchive(session.id)
-                  : actions.onArchive(session.id)
-              ))}
-              icon={session.isArchived
-                ? <ArchiveRestore size={16} aria-hidden="true" />
-                : <Archive size={16} aria-hidden="true" />}
-              label={session.isArchived ? copy.unarchive : copy.archive}
-            />
-            <Divider orientation="horizontal" />
-            <DropdownMenuItem
-              isDisabled={actionBusy}
-              onClick={() => {
-                pendingMenuIntentRef.current = handleDelete;
-              }}
-              icon={<Trash2 size={16} aria-hidden="true" />}
-              label={copy.delete}
-              style={{ color: 'var(--destructive-text)' }}
-            />
-        </DropdownMenu>
-      )}
-    </div>
+    <span data-session-actions="" className="maka-session-item-actions">
+      <DropdownMenu
+        isMenuOpen={menuOpen}
+        onOpenChange={(open) => {
+          setMenuOpen(open);
+          if (!open && deleteAfterCloseRef.current) {
+            deleteAfterCloseRef.current = false;
+            window.requestAnimationFrame(() => run('delete', () => props.actions.onDelete(props.session.id)));
+          }
+        }}
+        button={{
+          label: copy.actionsAriaLabel,
+          icon: pendingAction ? <Loader2 size={14} aria-hidden="true" /> : <MoreHorizontal size={16} aria-hidden="true" />,
+          isIconOnly: true,
+          variant: 'ghost',
+          size: 'sm',
+          className: 'maka-session-item-menu-trigger',
+        }}
+      >
+        <DropdownMenuItem
+          isDisabled={pendingAction !== undefined}
+          onClick={() => run('flag', () => props.actions.onToggleFlag(props.session.id, !props.session.isFlagged))}
+          icon={props.session.isFlagged ? <PinOff size={16} aria-hidden="true" /> : <Pin size={16} aria-hidden="true" />}
+          label={props.session.isFlagged ? copy.unpin : copy.pin}
+        />
+        <DropdownMenuItem isDisabled={pendingAction !== undefined} onClick={props.onRename} icon={<Pencil size={16} aria-hidden="true" />} label={copy.rename} />
+        <DropdownMenuItem
+          isDisabled={pendingAction !== undefined}
+          onClick={() => run('archive', () => props.session.isArchived ? props.actions.onUnarchive(props.session.id) : props.actions.onArchive(props.session.id))}
+          icon={props.session.isArchived ? <ArchiveRestore size={16} aria-hidden="true" /> : <Archive size={16} aria-hidden="true" />}
+          label={props.session.isArchived ? copy.unarchive : copy.archive}
+        />
+        <Divider orientation="horizontal" />
+        <DropdownMenuItem
+          isDisabled={pendingAction !== undefined}
+          onClick={() => { deleteAfterCloseRef.current = true; }}
+          icon={<Trash2 size={16} aria-hidden="true" />}
+          label={copy.delete}
+          style={{ color: 'var(--destructive-text)' }}
+        />
+      </DropdownMenu>
+    </span>
   );
-});
+}
+
+function ProjectActionsMenu(props: {
+  project: ProjectRecord;
+  actions: ProjectRowActions;
+  onRename(): void;
+}) {
+  const copy = getConversationCopy(useUiLocale()).sessions;
+  const [pending, setPending] = useState<string>();
+  const mountedRef = useMountedRef();
+  const pendingRef = useRef<string | undefined>(undefined);
+  useEffect(() => () => { pendingRef.current = undefined; }, []);
+  function run(id: string, action: () => void | Promise<void>) {
+    if (pendingRef.current) return;
+    pendingRef.current = id;
+    setPending(id);
+    void Promise.resolve(action()).catch(() => {}).finally(() => {
+      pendingRef.current = undefined;
+      if (mountedRef.current) setPending(undefined);
+    });
+  }
+  return (
+    <DropdownMenu button={{
+      label: copy.projectActionsAriaLabel(props.project.name),
+      icon: pending ? <Loader2 size={14} aria-hidden="true" /> : <MoreHorizontal size={14} aria-hidden="true" />,
+      isIconOnly: true,
+      variant: 'ghost',
+      size: 'sm',
+      className: 'maka-project-tree-menu-trigger',
+      isDisabled: pending !== undefined,
+    }}>
+      {props.project.archivedAt !== undefined ? (
+        <DropdownMenuItem onClick={() => run('restore', () => props.actions.onRestore(props.project.id))} icon={<ArchiveRestore size={15} aria-hidden="true" />} label={copy.projectRestore} />
+      ) : (
+        <>
+          {props.project.available ? (
+            <DropdownMenuItem onClick={() => run('new', () => props.actions.onNew(props.project.id))} icon={<Plus size={15} aria-hidden="true" />} label={copy.projectNewTask} />
+          ) : (
+            <DropdownMenuItem onClick={() => run('relink', () => props.actions.onRelink(props.project.id))} icon={<FolderOpen size={15} aria-hidden="true" />} label={copy.projectRelink} />
+          )}
+          <Divider orientation="horizontal" />
+          <DropdownMenuItem onClick={props.onRename} icon={<Pencil size={15} aria-hidden="true" />} label={copy.projectRename} />
+          <DropdownMenuItem onClick={() => run('archive', () => props.actions.onArchive(props.project.id))} icon={<Archive size={15} aria-hidden="true" />} label={copy.projectArchive} />
+        </>
+      )}
+    </DropdownMenu>
+  );
+}
 
 interface SessionGroup {
   id: 'pinned' | 'unpinned';

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -4,6 +4,7 @@ import {
   DropdownMenuRadioGroup,
   DropdownMenuRadioItem,
 } from '@astryxdesign/core/DropdownMenu';
+import { SideNav } from '@astryxdesign/core/SideNav';
 import type { NavModuleMemory, NavSelection } from './nav-selection.js';
 import {
   SessionHistoryList,
@@ -48,59 +49,63 @@ export function SessionListPanel(props: {
   } = props;
 
   return (
-    <aside
+    <SideNav
       className="maka-session-panel agents-sidebar"
+      role="complementary"
       aria-label={copy.listAriaLabel}
-    >
-      <SessionSidebarNav
+      style={{ width: '100%' }}
+      topContent={<SessionSidebarNav
         selection={props.selection}
         planReminders={props.planReminders}
         moduleMemory={props.moduleMemory}
         onSelect={props.onSelect}
         onNew={props.onNew}
-      />
-      {onViewModeChange && (
-        <div className="maka-session-list-toolbar">
-          <span className="maka-session-list-heading">{copy.title}</span>
-          <DropdownMenu
-            button={{
-              label: copy.groupingAriaLabel,
-              icon: <ListTodo size={15} aria-hidden="true" />,
-              isIconOnly: true,
-              variant: 'ghost',
-              size: 'sm',
-              tooltip: copy.groupingAriaLabel,
-            }}
-          >
-              <DropdownMenuRadioGroup
-                value={viewMode}
-                onChange={(mode) => onViewModeChange(mode as SessionViewMode)}
-                aria-label={copy.groupingAriaLabel}
-              >
-                <DropdownMenuRadioItem value="conversation" label={copy.groupByTime} />
-                <DropdownMenuRadioItem value="project" label={copy.groupByProject} />
-              </DropdownMenuRadioGroup>
-          </DropdownMenu>
-        </div>
-      )}
-      <SessionHistoryList
-        sessions={props.sessions}
-        activeId={props.activeId}
-        streamingSessionIds={props.streamingSessionIds}
-        staleSessionIds={props.staleSessionIds}
-        groupVariant={viewMode}
-        groups={groups}
-        worktreeSessionIds={props.worktreeSessionIds}
-        projectActions={props.projectActions}
-        childSessionsByParentId={props.childSessionsByParentId}
-        onSelectSession={props.onSelectSession}
-        rowActions={props.rowActions}
-      />
-      <SessionSidebarFooter
+      />}
+      footer={<SessionSidebarFooter
         updateReminder={props.updateReminder}
         onOpenSettings={props.onOpenSettings}
         onOpenUpdate={props.onOpenUpdate}
-      />
-    </aside>
+      />}
+    >
+      <div className="maka-session-panel-scroll-region">
+        {onViewModeChange && (
+          <div className="maka-session-list-toolbar">
+            <span className="maka-session-list-heading">{copy.title}</span>
+            <DropdownMenu
+              button={{
+                label: copy.groupingAriaLabel,
+                icon: <ListTodo size={15} aria-hidden="true" />,
+                isIconOnly: true,
+                variant: 'ghost',
+                size: 'sm',
+                tooltip: copy.groupingAriaLabel,
+              }}
+            >
+                <DropdownMenuRadioGroup
+                  value={viewMode}
+                  onChange={(mode) => onViewModeChange(mode as SessionViewMode)}
+                  aria-label={copy.groupingAriaLabel}
+                >
+                  <DropdownMenuRadioItem value="conversation" label={copy.groupByTime} />
+                  <DropdownMenuRadioItem value="project" label={copy.groupByProject} />
+                </DropdownMenuRadioGroup>
+            </DropdownMenu>
+          </div>
+        )}
+        <SessionHistoryList
+          sessions={props.sessions}
+          activeId={props.activeId}
+          streamingSessionIds={props.streamingSessionIds}
+          staleSessionIds={props.staleSessionIds}
+          groupVariant={viewMode}
+          groups={groups}
+          worktreeSessionIds={props.worktreeSessionIds}
+          projectActions={props.projectActions}
+          childSessionsByParentId={props.childSessionsByParentId}
+          onSelectSession={props.onSelectSession}
+          rowActions={props.rowActions}
+        />
+      </div>
+    </SideNav>
   );
 }

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -2,47 +2,10 @@ import type { PlanReminder } from '@maka/core';
 import type { CSSProperties } from 'react';
 import { Blocks, Settings, SquarePen, Timer } from './icons.js';
 import type { NavModuleMemory, NavSelection } from './nav-selection.js';
-import { cn } from './ui.js';
-import { cva } from 'class-variance-authority';
 import { Button as BaseButton } from '@base-ui/react/button';
+import { SideNavItem } from '@astryxdesign/core/SideNav';
 import { useUiLocale } from './locale-context.js';
 import { getShellControlsCopy } from './shell-controls-copy.js';
-
-const navRowVariants = cva(
-  [
-    'min-h-[var(--h-control-lg)] gap-2 rounded-sm border-0 bg-transparent px-1.5 py-0.5',
-    'text-left text-sm font-medium text-[var(--foreground-secondary)]',
-    // Glyphs pin to the 80%-ink chrome tone (same as titlebar icon actions)
-    // instead of inheriting: the darwin glass override forces row TEXT to
-    // full foreground, and icons must not follow it.
-    '[&_.maka-nav-icon]:text-[var(--foreground-secondary)]',
-    'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)]',
-    'hover:bg-[var(--state-hover-bg)] hover:text-foreground',
-    'data-[active=true]:bg-[var(--state-selected-bg)] data-[active=true]:font-semibold data-[active=true]:text-foreground data-[active=true]:shadow-none',
-    'data-[active=true]:[&_.maka-nav-icon]:text-foreground',
-    '[&_.maka-nav-count]:bg-[var(--state-hover-bg)] [&_.maka-nav-count]:text-[var(--muted-foreground)]',
-    'data-[active=true]:[&_.maka-nav-count]:bg-[var(--state-selected-bg)] data-[active=true]:[&_.maka-nav-count]:text-foreground',
-    'aria-disabled:cursor-not-allowed aria-disabled:opacity-55 aria-disabled:hover:bg-transparent',
-    'data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-55 data-[disabled=true]:hover:bg-transparent',
-  ],
-  {
-    variants: {
-      tone: {
-        default: '',
-        newTask: 'text-foreground',
-      },
-    },
-    defaultVariants: {
-      tone: 'default',
-    },
-  },
-);
-
-const settingsButtonClass =
-  'w-full min-w-0 gap-2 rounded-sm border-0 bg-transparent px-1.5 py-1.5 ' +
-  'text-left text-sm font-medium text-[var(--foreground-secondary)] ' +
-  'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)] ' +
-  'hover:bg-[var(--state-hover-bg)] hover:text-foreground';
 
 export function SessionSidebarNav(props: {
   selection: NavSelection;
@@ -61,47 +24,37 @@ export function SessionSidebarNav(props: {
   ).length;
 
   return (
-    <nav className="maka-sidebar-modules" aria-label={copy.mainLabel}>
-      <BaseButton
-        className={cn('maka-nav-row maka-nav-new-task', navRowVariants({ tone: 'newTask' }))}
-        aria-label={copy.newTask}
-        type="button"
+    <div className="maka-sidebar-modules" role="navigation" aria-label={copy.mainLabel}>
+      <SideNavItem
+        label={copy.newTask}
+        icon={<SquarePen aria-hidden="true" />}
+        endContent={<kbd className="maka-nav-kbd" aria-hidden="true">⌘ N</kbd>}
+        size="sm"
         onClick={props.onNew}
-      >
-        <SquarePen className="maka-nav-icon" aria-hidden="true" />
-        <span>{copy.newTask}</span>
-        <kbd className="maka-nav-kbd" aria-hidden="true">
-          ⌘ N
-        </kbd>
-      </BaseButton>
-      <BaseButton
-        className={cn('maka-nav-row', navRowVariants())}
-        data-active={extensionsActive}
-        aria-current={extensionsActive ? 'page' : undefined}
-        aria-label={copy.extensions}
-        type="button"
+      />
+      <SideNavItem
+        label={copy.extensions}
+        icon={<Blocks aria-hidden="true" />}
+        isSelected={extensionsActive}
+        size="sm"
         onClick={() => props.onSelect({ section: 'extensions', module: moduleMemory.extensions })}
-      >
-        <Blocks className="maka-nav-icon" aria-hidden="true" />
-        <span>{copy.extensions}</span>
-      </BaseButton>
-      <BaseButton
-        className={cn('maka-nav-row', navRowVariants())}
-        data-active={automationsActive}
-        aria-current={automationsActive ? 'page' : undefined}
-        type="button"
+      />
+      <SideNavItem
+        label={copy.automations}
+        icon={<Timer aria-hidden="true" />}
+        isSelected={automationsActive}
+        size="sm"
         onClick={() => props.onSelect({ section: 'automations', module: moduleMemory.automations })}
-        aria-label={activePlanReminderCount > 0 ? copy.pendingReminders(activePlanReminderCount) : copy.automations}
-      >
-        <Timer className="maka-nav-icon" aria-hidden="true" />
-        <span>{copy.automations}</span>
-        {activePlanReminderCount > 0 && (
-          <small className="maka-nav-count" aria-hidden="true">
-            {activePlanReminderCount}
-          </small>
-        )}
-      </BaseButton>
-    </nav>
+        endContent={activePlanReminderCount > 0 ? (
+          <>
+            <small className="maka-nav-count" aria-hidden="true">{activePlanReminderCount}</small>
+            <span className="maka-nav-pending-copy">
+              {copy.pendingReminders(activePlanReminderCount).slice(copy.automations.length)}
+            </span>
+          </>
+        ) : undefined}
+      />
+    </div>
   );
 }
 
@@ -133,16 +86,12 @@ export function SessionSidebarFooter(props: {
         : copy.update;
   return (
     <footer className="maka-session-panel-footer">
-      <BaseButton
-        className={cn('maka-sidebar-settings-button', settingsButtonClass)}
-        type="button"
+      <SideNavItem
+        label={copy.settings}
+        icon={<Settings aria-hidden="true" />}
+        size="sm"
         onClick={props.onOpenSettings}
-        aria-label={copy.settings}
-        title={copy.settings}
-      >
-        <Settings className="maka-nav-icon" aria-hidden="true" />
-        <span>{copy.settings}</span>
-      </BaseButton>
+      />
       {props.updateReminder && props.onOpenUpdate && (
         <BaseButton
           className="maka-sidebar-update-button"

--- a/packages/ui/stories/interaction-states.stories.tsx
+++ b/packages/ui/stories/interaction-states.stories.tsx
@@ -106,7 +106,9 @@ export const ListRowStates: Story = {
     </StoryFrame>
   ),
   play: async ({ canvasElement }) => {
-    const hoverTarget = canvasElement.querySelector<HTMLButtonElement>('.maka-nav-row:not([data-active="true"])');
+    const hoverTarget = canvasElement.querySelector<HTMLButtonElement>(
+      '.astryx-side-nav-item:not([aria-current="page"])',
+    );
     hoverTarget?.setAttribute('data-state-target', 'hover');
     const focusTarget = canvasElement.querySelector<HTMLButtonElement>('.maka-list-row[data-active="true"] .maka-list-row-main');
     focusTarget?.setAttribute('data-state-target', 'focus');


### PR DESCRIPTION
## Summary

- Compose the Electron shell directly with Astryx `AppShell` and `SideNav` while preserving Maka's titlebar drag regions, resize/collapse behavior, routing, and narrow-window controls.
- Migrate chronological session navigation to Astryx `List`/`Item` and project navigation to `TreeList`, removing parallel arrow-key and expansion ownership. Session rename remains menu-owned and now contains Home/End/Arrow keys inside the editor.
- Reclassify the workspace workbar as Astryx `TabList`/`Tab` navigation while preserving dock persistence, browser keep-alive, disabled-state guards, and responsive right/bottom placement.
- Replace the drifting app-shell Storybook scaffold with the real shell composition and representative session/project fixtures. No shared Tabs/Item/Empty/Spinner barrel authority, Settings content, or Conversation composition is changed.

## Verification

- `npm run format:check`
- `npm run lint`
- `npm run typecheck`
- `npm test --workspace @maka/ui`
- `npm test --workspace @maka/desktop` (2012 tests passed)
- `npm test --workspace @maka/runtime` (full suite passed, including the POSIX cancellation timing case)
- `npm run build`
- `npm run build-storybook --workspace @maka/desktop`
- `npm run smoke:storybook --workspace @maka/desktop` (27 renderer/play checks passed)
- `npx playwright test --config e2e/playwright.config.ts e2e/project-management.spec.ts e2e/sidebar-geometry.spec.ts e2e/sidebar-navigation.spec.ts e2e/session-workbar.spec.ts e2e/topbar-overflow.spec.ts e2e/window-titlebar.spec.ts` (13 passed)

## Review focus

- Astryx owns generic shell/list/tree/tab interaction semantics; Maka continues to own product data, session identity, routing, persistence, Electron security, and window behavior.
- `mobileNav.breakpoint` is explicitly `none`: Astryx 0.1.9 otherwise applies its default responsive breakpoint even when `mobileNav` is false, which would bypass Maka's existing narrow sidebar controls.
- Workbar panels remain mounted and use `hidden`, preserving terminal/browser state when switching tabs.
