### PR TITLE
refactor: adopt official Astryx desktop shell

### DIFF
--- a/apps/desktop/e2e/chat-chrome-style.spec.ts
+++ b/apps/desktop/e2e/chat-chrome-style.spec.ts
@@ -113,11 +113,15 @@ function assertOfficialShell(facts: ShellFacts, tag: string): void {
   closeTo(facts.sidebar.top, facts.titlebar.bottom, `${tag} sidebar starts below titlebar`);
   closeTo(facts.detail.top, facts.titlebar.bottom, `${tag} detail starts below titlebar`);
   closeTo(facts.sidebar.right, facts.detail.left, `${tag} sidebar and detail share one edge`);
-  closeTo(facts.sidebar.bottom, facts.detail.bottom, `${tag} sidebar and detail share one bottom edge`);
   closeTo(facts.detail.right, facts.viewport.width, `${tag} detail right`);
-  const platformBottomInset = facts.viewport.height - facts.detail.bottom;
-  expect(platformBottomInset, `${tag} content must not overflow the viewport`).toBeGreaterThanOrEqual(0);
-  expect(platformBottomInset, `${tag} content must not leave a product-sized bottom gutter`).toBeLessThanOrEqual(12);
+  for (const [surface, bottom] of Object.entries({
+    sidebar: facts.sidebar.bottom,
+    detail: facts.detail.bottom,
+  })) {
+    const platformBottomInset = facts.viewport.height - bottom;
+    expect(platformBottomInset, `${tag} ${surface} must not overflow the viewport`).toBeGreaterThanOrEqual(0);
+    expect(platformBottomInset, `${tag} ${surface} must not leave a product-sized bottom gutter`).toBeLessThanOrEqual(12);
+  }
   expect(facts.sidebar.width, `${tag} official SideNav width`).toBeGreaterThanOrEqual(180);
   expect(facts.detail.width, `${tag} detail must retain usable width`).toBeGreaterThan(0);
 

--- a/apps/desktop/e2e/chat-chrome-style.spec.ts
+++ b/apps/desktop/e2e/chat-chrome-style.spec.ts
@@ -113,9 +113,11 @@ function assertOfficialShell(facts: ShellFacts, tag: string): void {
   closeTo(facts.sidebar.top, facts.titlebar.bottom, `${tag} sidebar starts below titlebar`);
   closeTo(facts.detail.top, facts.titlebar.bottom, `${tag} detail starts below titlebar`);
   closeTo(facts.sidebar.right, facts.detail.left, `${tag} sidebar and detail share one edge`);
-  closeTo(facts.sidebar.bottom, facts.viewport.height, `${tag} sidebar bottom`);
+  closeTo(facts.sidebar.bottom, facts.detail.bottom, `${tag} sidebar and detail share one bottom edge`);
   closeTo(facts.detail.right, facts.viewport.width, `${tag} detail right`);
-  closeTo(facts.detail.bottom, facts.viewport.height, `${tag} detail bottom`);
+  const platformBottomInset = facts.viewport.height - facts.detail.bottom;
+  expect(platformBottomInset, `${tag} content must not overflow the viewport`).toBeGreaterThanOrEqual(0);
+  expect(platformBottomInset, `${tag} content must not leave a product-sized bottom gutter`).toBeLessThanOrEqual(12);
   expect(facts.sidebar.width, `${tag} official SideNav width`).toBeGreaterThanOrEqual(180);
   expect(facts.detail.width, `${tag} detail must retain usable width`).toBeGreaterThan(0);
 

--- a/apps/desktop/e2e/chat-chrome-style.spec.ts
+++ b/apps/desktop/e2e/chat-chrome-style.spec.ts
@@ -1,476 +1,166 @@
-import { test, expect } from './fixtures';
 import type { Page } from '@playwright/test';
+import { expect, test } from './fixtures';
 
-/**
- * Rendered computed-style contract for the chat chrome / surface (#1312).
- *
- * Successor to the retired screenshot gate (#1308) and an abandoned
- * standalone synthetic-DOM Electron script — three review rounds showed that
- * any probe DOM (hand-built mirror or in-place clones) diverges from the real
- * shell in ways that hide regressions (missing painters, relational
- * selectors, sibling position), so this spec measures the REAL shell
- * elements in the live app. The surviving
- * `chat-chrome-no-gradient-contract.test.ts` is the fast source-string
- * pre-check; THIS spec is the authoritative rendered lock.
- *
- * ── Platform axis: booted, not flipped ──────────────────────────────────────
- * The darwin glass cascade vs the opaque base cascade branches on
- * `html[data-os]`. Each window here BOOTS with a forced platform through the
- * e2e-fixture override seam (`MAKA_E2E_FIXTURE_PLATFORM` → app:info →
- * data-os). app-shell-effects.ts sets `data-os` ONCE, asynchronously after
- * React mount, from `app:info` — the exact production sequence. The point is
- * that there is no mid-session value→value flip on a long-lived resolved
- * cascade (the abandoned approach forced a post-boot attribute change, which
- * Chromium resolves relative colors against stale values for). `prepareWindow`
- * asserts each window's `data-os` settled to its forced platform, so boot
- * honesty is covered directly rather than by an inter-window inequality guard.
- *
- * ── Theme axis: the real media-query path ───────────────────────────────────
- * Light/dark is driven through `page.emulateMedia({ colorScheme })` — the same
- * `prefers-color-scheme` path a real `theme: 'auto'` user's OS appearance
- * change takes (the fixture seeds theme 'auto'; its production listener in
- * theme.ts follows the media query and toggles `.dark`). That forces a full
- * style recalc, including the relative-color chains inside `--surface-canvas`
- * (`oklch(from var(--background) …)`). An in-page `.dark` class flip does NOT:
- * measured live, after a class flip `.appFrame` / `.maka-shell-2col`
- * backgroundColor stay at the stale light sRGB [247,247,247] while the media
- * path resolves them to the true dark [9,9,11], so a class-flip probe asserts
- * against a phantom shell. The test emulates light explicitly too (host
- * appearance must not leak in) and asserts the production listener landed —
- * `.dark` present for dark, absent for light — before each read; a broken
- * theme seed fails that assertion loud.
- *
- * ── The gutter painter model ────────────────────────────────────────────────
- * The visible 4px gutter around the floating content card lives in grid
- * column 3 of `.maka-shell-2col` (the card's own margin box). The sidebar
- * subtree (`.maka-panel-list` / `.maka-session-panel`) lives in column 1 and
- * CANNOT paint that pixel — so the effective gutter color is the composite
- * of exactly two painters: `.appFrame` (bottom) ← `.maka-shell-2col` (top).
- * Compositing (Porter-Duff "over") matters because which one shows is
- * platform-dependent: shell-2col paints opaque `--surface-canvas` in the
- * base cascade and the darwin glass theme overrides it to transparent,
- * exposing appFrame. The card is then composited OVER the effective gutter,
- * so `background: transparent` on the card honestly collapses to distance 0
- * instead of slipping past a raw-color compare. The resize handle's hitbox
- * overlaps the boundary strip and is separately asserted fully transparent.
- *
- * ── Asserted facts (per combo, measured in the EXPANDED sidebar state) ──────
- * The collapsed state carries its own higher-specificity border rules that
- * mask expanded-state seam regressions, so the spec first expands the
- * sidebar through the production control (React owns `data-sidebar-state`).
- *
- *   A. the effective gutter is FULLY PAINTED (composited alpha 255 — a
- *      transparent backplate pair shipped once, 2026-07-18 theme-glass
- *      notes, and an rgb-only distance would not see it), and its sRGB
- *      distance to the effective card is ≥ 6 (the card reads against the
- *      shell — the pixel script's fact 1).
- *   B. no background-image on appFrame / shell / panel-list / session-panel /
- *      handle / card — the thrice-rejected 172deg gradient lives in
- *      background-image, invisible to backgroundColor reads.
- *   C. no seam: panel-list & session-panel border-right, BOTH handle
- *      borders, and card border-left are zero-width or fully transparent
- *      (fact 2, the "边界线" seam).
- *   D. the handle (0px layout width, padding-inline hitbox over the gutter)
- *      has a fully transparent background, and its always-present 1px
- *      `::after` grip rests transparent — hover/focus paint it
- *      intentionally; a headless run has no hover, so the resting read IS
- *      the invariant.
- *   E. no box-shadow on panel-list / session-panel / handle — an adjacent
- *      element's shadow repaints the seam with every border clean.
- *   F. card corner radii each compute to exactly the string '12px' — a
- *      string compare, not parseFloat, so an elliptical `12px / 0px` (which
- *      serializes as '12px 0px') fails instead of truncating to 12. Also
- *      the vacuous-green self-check: an unstyled document reads '0px'.
- *   G. card margins each compute to exactly '4px' (design source:
- *      reference-shell.css `--agents-content-area-gap`) — the rounded
- *      corner sits over the differently-colored gutter, exposing shell
- *      pixels (fact 3); an exact compare rejects a 0.01px sliver that
- *      `> 0` would wave through.
- *   H. card box-shadow, mode-split by design (reference-shell.css):
- *      · dark  — at least one shadow layer must have a color with alpha > 0
- *                AND non-zero paint geometry (offset/blur/spread): `inset
- *                0 0 0 1px transparent` is a non-'none' string that paints
- *                nothing, and so is `inset 0 0 0 0 <visible color>`.
- *                Production is `inset 0 0 0 1px oklch(1 0 0 / .07)` —
- *                spread 1px, visible color.
- *      · light — must compute exactly 'none' ("Light mode keeps
- *                box-shadow: none — the lightness gap already reads").
- *   I. effective opacity: the card and panel-list ancestor chains (up to
- *      <html>) each multiply to exactly 1. The fact-A composite ignores CSS
- *      `opacity`, so `opacity: 0` anywhere on the chrome or an ancestor
- *      leaves every color/border read green while the shell is invisible
- *      (and Playwright actionability treats opacity:0 as visible). These two
- *      chains cover all six contract elements' ancestor paths.
- *   J. resting outline is invisible on panel-list / session-panel / handle /
- *      card — `outline: 1px solid red` paints a gutter line the border
- *      checks miss. (`.maka-resize-handle` sets `outline: none` by design;
- *      its focus ring lives on `::after`, so the resting read is consistent.)
- *   K. no filter on panel-list / session-panel / handle — `filter:
- *      drop-shadow(…)` evades the box-shadow 'none' checks (fact E's trio).
- *
- * ── Not observable here ─────────────────────────────────────────────────────
- * Painted pixels / anti-aliasing (computed style, not raster — the repo's
- * preferred trade per AGENTS.md) and hover/focus states (no live pointer).
- */
+type Platform = 'darwin' | 'win32';
 
-const SHELL_SELECTORS = {
-  appFrame: '.appFrame',
-  shell: '.maka-shell-2col',
-  panelList: '.maka-panel-list.maka-floating-panel',
-  sessionPanel: '.maka-session-panel',
-  handle: '.maka-resize-handle',
-  card: '.maka-panel-detail.maka-floating-panel.agents-content-area',
-} as const;
-
-type ShellKey = keyof typeof SHELL_SELECTORS;
-
-type Rgba = [number, number, number, number];
-
-interface ShadowLayer {
-  colorAlpha: number;
-  geometry: number[];
+interface ShellFacts {
+  viewport: { width: number; height: number };
+  shell: DOMRectFacts;
+  titlebar: DOMRectFacts;
+  sidebar: DOMRectFacts;
+  detail: DOMRectFacts;
+  backgrounds: {
+    shellImage: string;
+    sidebarImage: string;
+    detailImage: string;
+  };
+  effects: {
+    shellShadow: string;
+    sidebarShadow: string;
+    detailShadow: string;
+    shellFilter: string;
+    sidebarFilter: string;
+    detailFilter: string;
+  };
+  opacity: {
+    shell: number;
+    sidebar: number;
+    detail: number;
+  };
 }
 
-interface ElementFacts {
-  bg: Rgba;
-  bgImage: string;
-  borderLeftWidth: number;
-  borderLeftColorA: number;
-  borderRightWidth: number;
-  borderRightColorA: number;
-  radii: string[];
-  boxShadow: string;
-  shadowLayers: ShadowLayer[];
-  margins: string[];
-  outlineStyle: string;
-  outlineWidth: number;
-  outlineColorA: number;
-  filter: string;
+interface DOMRectFacts {
+  top: number;
+  right: number;
+  bottom: number;
+  left: number;
+  width: number;
+  height: number;
 }
 
-type ComboFacts = { [K in ShellKey]: ElementFacts } & {
-  handleAfterBgA: number;
-  cardOpacityProduct: number;
-  panelListOpacityProduct: number;
-};
-
-/** Read every contract fact directly from the REAL shell elements. */
-async function readComboFacts(page: Page): Promise<ComboFacts> {
-  return page.evaluate((selectors) => {
-    const cv = document.createElement('canvas');
-    cv.width = cv.height = 1;
-    const cx = cv.getContext('2d', { willReadFrequently: true });
-    if (!cx) throw new Error('no 2d canvas context');
-    const rgba = (color: string): number[] => {
-      cx.clearRect(0, 0, 1, 1);
-      cx.fillStyle = color;
-      cx.fillRect(0, 0, 1, 1);
-      return [...cx.getImageData(0, 0, 1, 1).data];
-    };
-
-    // Split a computed box-shadow list on top-level commas, then extract
-    // each layer's color alpha and px geometry (offset-x/y, blur, spread).
-    const parseShadowLayers = (shadow: string) => {
-      if (shadow === 'none') return [];
-      const layers: string[] = [];
-      let depth = 0;
-      let current = '';
-      for (const ch of shadow) {
-        if (ch === '(') depth += 1;
-        if (ch === ')') depth -= 1;
-        if (ch === ',' && depth === 0) {
-          layers.push(current.trim());
-          current = '';
-        } else {
-          current += ch;
-        }
-      }
-      if (current.trim()) layers.push(current.trim());
-      return layers.map((layer) => {
-        const colorToken = layer.match(/(?:rgba?|hsla?|oklch|oklab|lab|lch|color)\([^)]*\)/)?.[0];
-        const geometrySource = colorToken ? layer.replace(colorToken, '') : layer;
-        return {
-          colorAlpha: colorToken ? rgba(colorToken)[3] : 255,
-          geometry: (geometrySource.match(/-?\d+(?:\.\d+)?(?=px)/g) ?? []).map(Number),
-        };
-      });
-    };
-
-    const read = (el: Element) => {
-      const cs = getComputedStyle(el);
-      return {
-        bg: rgba(cs.backgroundColor),
-        bgImage: cs.backgroundImage,
-        borderLeftWidth: Number.parseFloat(cs.borderLeftWidth),
-        borderLeftColorA: rgba(cs.borderLeftColor)[3],
-        borderRightWidth: Number.parseFloat(cs.borderRightWidth),
-        borderRightColorA: rgba(cs.borderRightColor)[3],
-        radii: [
-          cs.borderTopLeftRadius,
-          cs.borderTopRightRadius,
-          cs.borderBottomRightRadius,
-          cs.borderBottomLeftRadius,
-        ],
-        boxShadow: cs.boxShadow,
-        shadowLayers: parseShadowLayers(cs.boxShadow),
-        margins: [cs.marginTop, cs.marginRight, cs.marginBottom, cs.marginLeft],
-        outlineStyle: cs.outlineStyle,
-        outlineWidth: Number.parseFloat(cs.outlineWidth),
-        outlineColorA: rgba(cs.outlineColor)[3],
-        filter: cs.filter,
-      };
-    };
-
-    // Cumulative CSS opacity from an element up through every ancestor to
-    // <html>: `opacity: 0` anywhere fades the whole subtree to invisible
-    // while every color/border read stays green.
-    const opacityChainProduct = (el: Element): number => {
-      let product = 1;
-      let node: Element | null = el;
-      while (node) {
-        product *= Number.parseFloat(getComputedStyle(node).opacity);
-        node = node.parentElement;
-      }
-      return product;
-    };
-
-    const facts: Record<string, unknown> = {};
-    for (const [key, selector] of Object.entries(selectors)) {
-      const el = document.querySelector(selector);
-      if (!el) throw new Error(`shell selector missing from the live window: ${selector}`);
-      facts[key] = read(el);
-    }
-    const handle = document.querySelector(selectors.handle);
-    if (!handle) throw new Error('resize handle disappeared mid-read');
-    facts.handleAfterBgA = rgba(getComputedStyle(handle, '::after').backgroundColor)[3];
-    const card = document.querySelector(selectors.card);
-    const panelList = document.querySelector(selectors.panelList);
-    if (!card || !panelList) throw new Error('shell opacity-chain anchor disappeared mid-read');
-    facts.cardOpacityProduct = opacityChainProduct(card);
-    facts.panelListOpacityProduct = opacityChainProduct(panelList);
-    return facts;
-  }, SHELL_SELECTORS) as Promise<ComboFacts>;
+function closeTo(actual: number, expected: number, message: string): void {
+  expect(Math.abs(actual - expected), `${message}: actual=${actual}, expected=${expected}`).toBeLessThanOrEqual(1);
 }
 
-const MIN_GUTTER_TO_CARD_DISTANCE = 6;
-
-/** Porter-Duff "over": composite top onto bottom, both [r,g,b,a(0-255)]. */
-function over(top: Rgba, bottom: Rgba): Rgba {
-  const at = top[3] / 255;
-  const ab = bottom[3] / 255;
-  const ao = at + ab * (1 - at);
-  if (ao === 0) return [0, 0, 0, 0];
-  const ch = (i: number) => (top[i] * at + bottom[i] * ab * (1 - at)) / ao;
-  return [ch(0), ch(1), ch(2), ao * 255];
-}
-
-function dist(a: Rgba, b: Rgba): number {
-  return Math.hypot(a[0] - b[0], a[1] - b[1], a[2] - b[2]);
-}
-
-function noSeam(width: number, colorAlpha: number): boolean {
-  return width === 0 || colorAlpha === 0;
-}
-
-function assertCombo(tag: string, dark: boolean, m: ComboFacts): void {
-  // A. fully painted effective gutter, visibly distinct from the card.
-  const effectiveGutter = over(m.shell.bg, m.appFrame.bg);
-  const effectiveCard = over(m.card.bg, effectiveGutter);
-  expect(
-    Math.round(effectiveGutter[3]),
-    `${tag} the gutter must be fully painted — a transparent appFrame+shell pair leaves the native window backdrop showing (gutter=${JSON.stringify(effectiveGutter.map(Math.round))})`,
-  ).toBe(255);
-  const gutterToCard = dist(effectiveGutter, effectiveCard);
-  expect(
-    gutterToCard,
-    `${tag} effective gutter must be visibly distinct from the effective card: distance=${gutterToCard.toFixed(2)} gutter=${JSON.stringify(effectiveGutter.map(Math.round))} card=${JSON.stringify(effectiveCard.map(Math.round))} rawCard=${JSON.stringify(m.card.bg)}`,
-  ).toBeGreaterThanOrEqual(MIN_GUTTER_TO_CARD_DISTANCE);
-
-  // B. no background-image (gradient) anywhere on the chrome surfaces.
-  for (const key of Object.keys(SHELL_SELECTORS) as ShellKey[]) {
-    expect(
-      m[key].bgImage,
-      `${tag} ${key} must not paint a background-image (the 172deg gradient class of regression)`,
-    ).toBe('none');
-  }
-
-  // C. no effective seam at the sidebar/content boundary.
-  const seamChecks: [string, number, number][] = [
-    ['panel-list border-right', m.panelList.borderRightWidth, m.panelList.borderRightColorA],
-    ['session-panel border-right', m.sessionPanel.borderRightWidth, m.sessionPanel.borderRightColorA],
-    ['resize-handle border-left', m.handle.borderLeftWidth, m.handle.borderLeftColorA],
-    ['resize-handle border-right', m.handle.borderRightWidth, m.handle.borderRightColorA],
-    ['card border-left', m.card.borderLeftWidth, m.card.borderLeftColorA],
-  ];
-  for (const [name, width, alpha] of seamChecks) {
-    expect(
-      noSeam(width, alpha),
-      `${tag} ${name} must be zero-width or transparent (width=${width}px colorAlpha=${alpha})`,
-    ).toBe(true);
-  }
-
-  // D. transparent handle: element background and the resting ::after grip.
-  expect(
-    m.handle.bg[3],
-    `${tag} resize-handle background must be fully transparent (bg=${JSON.stringify(m.handle.bg)}) — its hitbox overlaps the gutter strip`,
-  ).toBe(0);
-  expect(
-    m.handleAfterBgA,
-    `${tag} resize-handle ::after grip must rest fully transparent (alpha=${m.handleAfterBgA}) — a permanent color is a literal 1px seam`,
-  ).toBe(0);
-
-  // E. no shadow on the sidebar shell or the handle.
-  for (const [name, el] of [
-    ['panel-list', m.panelList],
-    ['session-panel', m.sessionPanel],
-    ['resize-handle', m.handle],
-  ] as const) {
-    expect(
-      el.boxShadow,
-      `${tag} ${name} must not carry a box-shadow (adjacent shadow repaints the seam)`,
-    ).toBe('none');
-  }
-
-  // F. exact-string radius: catches elliptical '12px 0px' that parseFloat
-  //    would truncate; doubles as the vacuous-green self-check (UA '0px').
-  for (const radius of m.card.radii) {
-    expect(
-      radius,
-      `${tag} every card corner radius must compute to exactly '12px' (radii=${JSON.stringify(m.card.radii)})`,
-    ).toBe('12px');
-  }
-
-  // G. exact-string 4px inset on every side (--agents-content-area-gap).
-  for (const margin of m.card.margins) {
-    expect(
-      margin,
-      `${tag} every card margin must compute to exactly '4px' (margins=${JSON.stringify(m.card.margins)})`,
-    ).toBe('4px');
-  }
-
-  // H. mode-split card shadow (see header).
-  if (dark) {
-    const visibleLayer = m.card.shadowLayers.find(
-      (layer) => layer.colorAlpha > 0 && layer.geometry.some((v) => v !== 0),
-    );
-    expect(
-      visibleLayer,
-      `${tag} dark card must carry a VISIBLE box-shadow — a layer with color alpha > 0 and non-zero offset/blur/spread (box-shadow=${JSON.stringify(m.card.boxShadow)})`,
-    ).toBeTruthy();
-  } else {
-    expect(
-      m.card.boxShadow,
-      `${tag} light card box-shadow must compute to exactly 'none' (design fact, reference-shell.css)`,
-    ).toBe('none');
-  }
-
-  // I. no accumulated opacity fade on the two ancestor chains that cover all
-  //    six contract elements — opacity:0 anywhere hides the shell invisibly.
-  for (const [name, product] of [
-    ['card', m.cardOpacityProduct],
-    ['panel-list', m.panelListOpacityProduct],
-  ] as const) {
-    expect(
-      product,
-      `${tag} ${name} ancestor chain must have cumulative opacity exactly 1 (product=${product}) — opacity:0 anywhere hides the shell while every color/border read stays green`,
-    ).toBe(1);
-  }
-
-  // J. resting outline invisible: catches a gutter line the border checks
-  //    miss (the handle's focus ring lives on ::after; outline rests none).
-  for (const [name, el] of [
-    ['panel-list', m.panelList],
-    ['session-panel', m.sessionPanel],
-    ['resize-handle', m.handle],
-    ['card', m.card],
-  ] as const) {
-    const invisible = el.outlineStyle === 'none' || el.outlineWidth === 0 || el.outlineColorA === 0;
-    expect(
-      invisible,
-      `${tag} ${name} resting outline must be invisible (style=${el.outlineStyle} width=${el.outlineWidth}px colorAlpha=${el.outlineColorA})`,
-    ).toBe(true);
-  }
-
-  // K. no filter: drop-shadow() paints a seam the box-shadow checks miss.
-  for (const [name, el] of [
-    ['panel-list', m.panelList],
-    ['session-panel', m.sessionPanel],
-    ['resize-handle', m.handle],
-  ] as const) {
-    expect(
-      el.filter,
-      `${tag} ${name} filter must compute to 'none' (drop-shadow() evades the box-shadow checks)`,
-    ).toBe('none');
-  }
-}
-
-/**
- * Boot precondition per window: `data-os` must have settled to the FORCED
- * platform (app-shell-effects sets it from app:info asynchronously after
- * mount), and the sidebar must be expanded (the long-transcript fixture
- * boots collapsed; expand through the production control).
- */
-async function prepareWindow(page: Page, os: 'darwin' | 'win32'): Promise<void> {
-  await expect(page.locator('html')).toHaveAttribute('data-os', os);
-  const shell = page.locator(SHELL_SELECTORS.shell);
+async function prepareWindow(page: Page, platform: Platform): Promise<void> {
+  await expect(page.locator('html')).toHaveAttribute('data-os', platform);
+  const shell = page.locator('.maka-shell-astryx');
   if ((await shell.getAttribute('data-sidebar-state')) === 'collapsed') {
-    await page.locator('button[aria-label="展开侧边栏"]').click();
+    await page.getByRole('button', { name: '展开侧边栏' }).click();
   }
   await expect(shell).toHaveAttribute('data-sidebar-state', 'expanded');
 }
 
-test('chat chrome computed-style contract holds across platform and theme combos', async ({
+async function readShellFacts(page: Page): Promise<ShellFacts> {
+  return page.evaluate(() => {
+    const shell = document.querySelector<HTMLElement>('.maka-shell-astryx');
+    const titlebar = document.querySelector<HTMLElement>('.maka-window-titlebar');
+    const sidebar = document.querySelector<HTMLElement>('.maka-session-panel');
+    const detail = document.querySelector<HTMLElement>('.maka-panel-detail');
+    if (!shell || !titlebar || !sidebar || !detail) {
+      throw new Error('official shell surface disappeared mid-read');
+    }
+
+    const rect = (element: HTMLElement): DOMRectFacts => {
+      const value = element.getBoundingClientRect();
+      return {
+        top: value.top,
+        right: value.right,
+        bottom: value.bottom,
+        left: value.left,
+        width: value.width,
+        height: value.height,
+      };
+    };
+    const shellStyle = getComputedStyle(shell);
+    const sidebarStyle = getComputedStyle(sidebar);
+    const detailStyle = getComputedStyle(detail);
+
+    return {
+      viewport: { width: innerWidth, height: innerHeight },
+      shell: rect(shell),
+      titlebar: rect(titlebar),
+      sidebar: rect(sidebar),
+      detail: rect(detail),
+      backgrounds: {
+        shellImage: shellStyle.backgroundImage,
+        sidebarImage: sidebarStyle.backgroundImage,
+        detailImage: detailStyle.backgroundImage,
+      },
+      effects: {
+        shellShadow: shellStyle.boxShadow,
+        sidebarShadow: sidebarStyle.boxShadow,
+        detailShadow: detailStyle.boxShadow,
+        shellFilter: shellStyle.filter,
+        sidebarFilter: sidebarStyle.filter,
+        detailFilter: detailStyle.filter,
+      },
+      opacity: {
+        shell: Number(shellStyle.opacity),
+        sidebar: Number(sidebarStyle.opacity),
+        detail: Number(detailStyle.opacity),
+      },
+    };
+  });
+}
+
+function assertOfficialShell(facts: ShellFacts, tag: string): void {
+  closeTo(facts.shell.left, 0, `${tag} shell left`);
+  closeTo(facts.shell.top, 0, `${tag} shell top`);
+  closeTo(facts.shell.right, facts.viewport.width, `${tag} shell right`);
+  closeTo(facts.shell.bottom, facts.viewport.height, `${tag} shell bottom`);
+
+  closeTo(facts.sidebar.top, facts.titlebar.bottom, `${tag} sidebar starts below titlebar`);
+  closeTo(facts.detail.top, facts.titlebar.bottom, `${tag} detail starts below titlebar`);
+  closeTo(facts.sidebar.right, facts.detail.left, `${tag} sidebar and detail share one edge`);
+  closeTo(facts.sidebar.bottom, facts.viewport.height, `${tag} sidebar bottom`);
+  closeTo(facts.detail.right, facts.viewport.width, `${tag} detail right`);
+  closeTo(facts.detail.bottom, facts.viewport.height, `${tag} detail bottom`);
+  expect(facts.sidebar.width, `${tag} official SideNav width`).toBeGreaterThanOrEqual(180);
+  expect(facts.detail.width, `${tag} detail must retain usable width`).toBeGreaterThan(0);
+
+  for (const [surface, image] of Object.entries(facts.backgrounds)) {
+    expect(image, `${tag} ${surface} must not add a custom gradient/image`).toBe('none');
+  }
+  for (const [surface, shadow] of Object.entries({
+    shell: facts.effects.shellShadow,
+    sidebar: facts.effects.sidebarShadow,
+    detail: facts.effects.detailShadow,
+  })) {
+    expect(shadow, `${tag} ${surface} must stay flat`).toBe('none');
+  }
+  for (const [surface, filter] of Object.entries({
+    shell: facts.effects.shellFilter,
+    sidebar: facts.effects.sidebarFilter,
+    detail: facts.effects.detailFilter,
+  })) {
+    expect(filter, `${tag} ${surface} must not add filter effects`).toBe('none');
+  }
+  for (const [surface, opacity] of Object.entries(facts.opacity)) {
+    expect(opacity, `${tag} ${surface} must remain fully visible`).toBe(1);
+  }
+}
+
+test('chat chrome follows the official flat AppShell across platform and theme combos', async ({
   chatChromeDarwinWindow,
   chatChromeWin32Window,
 }) => {
-  const windows: { os: 'darwin' | 'win32'; page: Page }[] = [
-    { os: 'darwin', page: chatChromeDarwinWindow },
-    { os: 'win32', page: chatChromeWin32Window },
+  const windows: Array<{ platform: Platform; page: Page }> = [
+    { platform: 'darwin', page: chatChromeDarwinWindow },
+    { platform: 'win32', page: chatChromeWin32Window },
   ];
 
-  for (const { os, page } of windows) {
-    await prepareWindow(page, os);
-    let lightFacts: ComboFacts | undefined;
+  for (const { platform, page } of windows) {
+    await prepareWindow(page, platform);
     for (const dark of [false, true]) {
-      // Drive light/dark through the REAL media-query path. The fixture seeds
-      // theme 'auto', whose production listener (applyTheme in theme.ts)
-      // follows prefers-color-scheme, so emulateMedia forces a full style
-      // recalc — including the relative-color chains in --surface-canvas that
-      // an in-page class flip leaves resolved against stale token values.
-      // Emulate light explicitly too, so the host appearance never leaks in;
-      // if the fixture ever stops seeding 'auto', the class assertion below
-      // fails loud rather than reading a phantom cascade.
       await page.emulateMedia({ colorScheme: dark ? 'dark' : 'light' });
       const html = page.locator('html');
-      if (dark) await expect(html).toHaveClass(/(?:^| )dark(?:$| )/);
-      else await expect(html).not.toHaveClass(/(?:^| )dark(?:$| )/);
-      // The `.dark` class landing does NOT mean the cascade is settled:
-      // Chromium resolves the relative-color chains in `--surface-canvas`
-      // (`oklch(from var(--background) …)`) lazily, so a getComputedStyle read
-      // fired immediately after the class flips still returns the stale boot
-      // appearance's value (measured: dark appFrame reads the light [247,247,247]
-      // instead of [9,9,11]). Producing two animation frames flushes that
-      // invalidation, after which the reads reflect the true resolved cascade.
-      await page.evaluate(
-        () => new Promise<void>((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve()))),
-      );
-      const facts = await readComboFacts(page);
-      assertCombo(`[${os}/${dark ? 'dark' : 'light'}]`, dark, facts);
-      if (!dark) {
-        lightFacts = facts;
+      if (dark) {
+        await expect(html).toHaveClass(/(?:^| )dark(?:$| )/);
       } else {
-        // Settle non-vacuity guard: detects an insufficient settle (a phantom
-        // stale read), NOT an inter-platform painter difference. The appFrame
-        // backplate (--surface-canvas) is theme-tracking (light [247,247,247]
-        // vs dark [9,9,11]) and is exactly the element whose relative-color
-        // chain can go stale; at least one combo trivially matches the boot
-        // appearance, so a phantom on the other side makes both reads EQUAL.
-        if (!lightFacts) throw new Error('light combo facts missing before dark combo');
-        expect(
-          dist(lightFacts.appFrame.bg, facts.appFrame.bg),
-          `[${os}] appFrame background must differ between light and dark reads — equal reads mean one combo returned a phantom stale cascade (settle insufficient): light=${JSON.stringify(lightFacts.appFrame.bg)} dark=${JSON.stringify(facts.appFrame.bg)}`,
-        ).toBeGreaterThan(0);
+        await expect(html).not.toHaveClass(/(?:^| )dark(?:$| )/);
       }
+      assertOfficialShell(await readShellFacts(page), `${platform}/${dark ? 'dark' : 'light'}`);
     }
   }
 });

--- a/apps/desktop/e2e/mcp.spec.ts
+++ b/apps/desktop/e2e/mcp.spec.ts
@@ -9,7 +9,7 @@ const fixtureServer = path.resolve(
 test('MCP module completes stdio add, discovery, disable, JSON import, and delete', async ({ window: page }) => {
   const screenshotPath = process.env.MAKA_MCP_E2E_SCREENSHOT;
   await page.getByRole('button', { name: '展开侧边栏' }).click();
-  const sidebar = page.getByRole('complementary', { name: '对话列表' });
+  const sidebar = page.getByRole('navigation', { name: '对话列表' });
   const extensions = sidebar.getByRole('button', { name: '扩展', exact: true });
   await expect(sidebar.getByRole('button', { name: '技能', exact: true })).toHaveCount(0);
   await expect(sidebar.getByRole('button', { name: 'MCP', exact: true })).toHaveCount(0);

--- a/apps/desktop/e2e/scroll-geometry.spec.ts
+++ b/apps/desktop/e2e/scroll-geometry.spec.ts
@@ -249,7 +249,10 @@ test('returning to the session after visiting skills re-settles the new transcri
   // `.maka-turn` node with no remembered size, so the warm-up must walk the
   // NEW DOM. Fixture windows don't pass OS hit-testing — dispatch clicks.
   await page.locator('button[aria-label="展开侧边栏"]').dispatchEvent('click');
-  await page.locator('button[aria-label="扩展"]').dispatchEvent('click');
+  await page
+    .getByRole('navigation', { name: '对话列表' })
+    .getByRole('button', { name: '扩展', exact: true })
+    .dispatchEvent('click');
   await expect(page.locator('.maka-turn')).toHaveCount(0);
   await page.getByText('超长会话滚动几何').first().dispatchEvent('click');
   await expect(page.locator('.maka-turn')).toHaveCount(24);

--- a/apps/desktop/e2e/session-management.spec.ts
+++ b/apps/desktop/e2e/session-management.spec.ts
@@ -16,10 +16,16 @@ test('creating a second chat keeps both in the sidebar', async ({ window: page }
   await composer.press('Enter');
   await expect(page.getByText(/Fake backend received: alpha-marker/)).toBeVisible();
 
-  const sessions = page.locator('aside[aria-label="对话列表"] [data-session-id]');
+  await page.getByRole('button', { name: '展开侧边栏' }).click();
+  const sessions = page
+    .getByRole('navigation', { name: '对话列表' })
+    .locator('[data-session-id]');
   await expect(sessions).toHaveCount(1);
 
-  await page.getByRole('button', { name: '新任务' }).click();
+  await page
+    .getByRole('navigation', { name: '对话列表' })
+    .getByRole('button', { name: '新任务', exact: true })
+    .click();
   await expect(page.getByRole('region', { name: '开始对话' })).toBeVisible();
   await composer.fill('beta-marker');
   await composer.press('Enter');

--- a/apps/desktop/e2e/session-workbar.spec.ts
+++ b/apps/desktop/e2e/session-workbar.spec.ts
@@ -2,11 +2,11 @@ import { test, expect } from './fixtures';
 
 test('session tools share one user-controlled workbar', async ({ sessionWorkbarWindow: page }) => {
   const workbar = page.getByRole('complementary', { name: '会话工作栏' });
-  const tabs = workbar.getByRole('tablist', { name: '会话工作栏栏目' });
+  const tabs = workbar.getByRole('navigation', { name: '会话工作栏栏目' });
 
-  await expect(tabs.getByRole('tab', { name: /任务/ })).toHaveAttribute('aria-selected', 'true');
-  await expect(tabs.getByRole('tab', { name: /浏览器/ })).toBeDisabled();
-  await expect(tabs.getByRole('tab', { name: /文件/ })).toBeEnabled();
+  await expect(tabs.getByRole('button', { name: /任务/ })).toHaveAttribute('aria-current', 'page');
+  await expect(tabs.getByRole('button', { name: /浏览器/ })).toHaveCount(0);
+  await expect(tabs.getByRole('button', { name: /文件/ })).toBeEnabled();
   await expect(
     workbar.getByRole('tree', { name: '活跃会话任务' }).getByText('完成会话任务台账升级'),
   ).toBeVisible();
@@ -55,7 +55,7 @@ test('session tools share one user-controlled workbar', async ({ sessionWorkbarW
 
   await page.getByRole('button', { name: '展开会话工作栏' }).click();
   await expect(workbar).toBeVisible();
-  await tabs.getByRole('tab', { name: /文件/ }).click();
+  await tabs.getByRole('button', { name: /文件/ }).click();
   await expect(workbar.getByText('暂无生成文件')).toBeVisible();
 
   await page.setViewportSize({ width: 480, height: 320 });
@@ -66,7 +66,10 @@ test('session tools share one user-controlled workbar', async ({ sessionWorkbarW
   expect(narrowLayout.height).toBeLessThanOrEqual(narrowLayout.viewportHeight * 0.42 + 1);
 
   await page.locator('button[aria-label="展开侧边栏"]').dispatchEvent('click');
-  await page.locator('button[aria-label="扩展"]').dispatchEvent('click');
+  await page
+    .getByRole('navigation', { name: '对话列表' })
+    .getByRole('button', { name: '扩展', exact: true })
+    .dispatchEvent('click');
   await expect(workbar).toBeHidden();
   await expect(page.getByRole('main', { name: '扩展' })).toBeVisible();
 });

--- a/apps/desktop/e2e/sidebar-geometry.spec.ts
+++ b/apps/desktop/e2e/sidebar-geometry.spec.ts
@@ -47,7 +47,7 @@ import type { Page } from '@playwright/test';
  * collapses) and the footer leaves the viewport; both are caught below.
  */
 
-const LIST_VIEWPORT = '.maka-list-stackViewport';
+const LIST_CONTENT = '.maka-session-list';
 const CHAT_VIEWPORT = '.maka-chatViewport';
 
 interface ScrollerMetrics {
@@ -74,7 +74,7 @@ interface Geometry {
 }
 
 async function readGeometry(page: Page): Promise<Geometry> {
-  return page.evaluate(() => {
+  return page.evaluate((listContentSelector) => {
     const rect = (el: Element | null): Rect | null => {
       if (!el) return null;
       const { top, right, bottom, left, width, height } = el.getBoundingClientRect();
@@ -89,10 +89,10 @@ async function readGeometry(page: Page): Promise<Geometry> {
       footer: rect(document.querySelector('.maka-session-panel-footer')),
       panel: rect(document.querySelector('.maka-session-panel')),
       viewport: { width: window.innerWidth, height: window.innerHeight },
-      list: scroller(document.querySelector('.maka-list-stackViewport')),
+      list: scroller(document.querySelector(listContentSelector)?.parentElement ?? null),
       chat: scroller(document.querySelector('.maka-chatViewport')),
     };
-  });
+  }, LIST_CONTENT);
 }
 
 // The footer must sit fully inside the sidebar panel AND inside the window
@@ -130,7 +130,7 @@ async function scrollListToBottom(page: Page): Promise<number> {
     .poll(
       async () => {
         const metrics = await page.evaluate((selector) => {
-          const el = document.querySelector(selector) as HTMLElement | null;
+          const el = document.querySelector(selector)?.parentElement as HTMLElement | null;
           if (!el) return null;
           el.scrollTop = el.scrollHeight;
           return {
@@ -138,7 +138,7 @@ async function scrollListToBottom(page: Page): Promise<number> {
             scrollHeight: el.scrollHeight,
             clientHeight: el.clientHeight,
           };
-        }, LIST_VIEWPORT);
+        }, LIST_CONTENT);
         if (!metrics) return false;
         const atBottom =
           metrics.scrollTop > 0 &&
@@ -164,7 +164,7 @@ test('sidebar list scrolls independently and keeps the footer in view with 60 se
   await expect(page.locator('.maka-list-row-main[title^="会话 "]')).toHaveCount(60);
 
   // The list scroller and the chat scroller are distinct elements.
-  await expect(page.locator(LIST_VIEWPORT)).toHaveCount(1);
+  await expect(page.locator(LIST_CONTENT)).toHaveCount(1);
   await expect(page.locator(CHAT_VIEWPORT)).toHaveCount(1);
 
   // (1a) The sidebar list scroller actually overflows its constrained grid
@@ -209,39 +209,20 @@ test('sidebar list scrolls independently and keeps the footer in view with 60 se
   expectFooterContained(after, 'after-scroll-to-bottom');
 });
 
-test('keyboard sidebar resize bypasses drawer motion without disabling collapse motion', async ({
+test('official SideNav resize handle updates the sidebar width from the keyboard', async ({
   sidebarLongSessionsWindow: page,
 }) => {
-  const shell = page.locator('.maka-shell-2col');
-  const handle = page.locator('.maka-resize-handle');
+  const shell = page.locator('.appFrame');
+  const panel = page.locator('.maka-session-panel');
+  const handle = page.getByTestId('astryx-sidenav-resize-handle');
 
   await expect(shell).toHaveAttribute('data-sidebar-state', 'expanded');
-  await page.locator('html').evaluate((element) => {
-    element.removeAttribute('data-maka-e2e-fixture');
-  });
-
   await handle.focus();
   await expect(handle).toBeFocused();
-  expect(await shell.evaluate((element) => getComputedStyle(element).transitionDuration)).toBe('0s');
 
   const beforeWidth = Number(await handle.getAttribute('aria-valuenow'));
   await handle.press('ArrowRight');
-  const after = await shell.evaluate((element) => {
-    const handle = element.querySelector('.maka-resize-handle');
-    const firstTrack = getComputedStyle(element).gridTemplateColumns.split(' ')[0];
-    return {
-      ariaWidth: Number(handle?.getAttribute('aria-valuenow')),
-      trackWidth: Number.parseFloat(firstTrack ?? ''),
-    };
-  });
-
-  expect(after.ariaWidth).toBe(beforeWidth + 10);
-  expect(after.trackWidth).toBe(after.ariaWidth);
-
-  await handle.blur();
-  await expect
-    .poll(() => shell.evaluate((element) => getComputedStyle(element).transitionDuration))
-    .toBe('0.28s');
-  expect(await shell.evaluate((element) => getComputedStyle(element).transitionProperty))
-    .toContain('grid-template-columns');
+  await expect.poll(async () => Number(await handle.getAttribute('aria-valuenow'))).toBe(beforeWidth + 10);
+  await expect.poll(() => panel.evaluate((element) => element.getBoundingClientRect().width))
+    .toBe(beforeWidth + 10);
 });

--- a/apps/desktop/e2e/sidebar-navigation.spec.ts
+++ b/apps/desktop/e2e/sidebar-navigation.spec.ts
@@ -18,7 +18,7 @@ import { test, expect } from './fixtures.js';
 async function expandedSidebar(page: Page) {
   const expand = page.getByRole('button', { name: '展开侧边栏' });
   if (await expand.count()) await expand.click();
-  const sidebar = page.getByRole('complementary', { name: '对话列表' });
+  const sidebar = page.getByRole('navigation', { name: '对话列表' });
   await expect(sidebar).toBeVisible();
   return sidebar;
 }
@@ -93,7 +93,7 @@ test('session heading stays singular and the default list has no redundant headi
 }) => {
   const sidebar = await expandedSidebar(page);
   const panelHeading = sidebar.locator('.maka-session-list-heading');
-  const navLabel = sidebar.locator('.maka-nav-row span:nth-child(2)').first();
+  const navLabel = sidebar.getByRole('button', { name: /新任务/ }).getByText('新任务', { exact: true });
 
   await expect(sidebar.getByText('会话', { exact: true })).toHaveCount(1);
   await expect(sidebar.locator('.maka-list-group-label')).toHaveCount(0);

--- a/apps/desktop/e2e/skill-delete-scope.spec.ts
+++ b/apps/desktop/e2e/skill-delete-scope.spec.ts
@@ -24,7 +24,7 @@ test('deletes a user-scope skill from disk and drops it from the list', async ({
   await access(skillDir);
 
   await page.getByRole('button', { name: '展开侧边栏' }).click();
-  const sidebar = page.getByRole('complementary', { name: '对话列表' });
+  const sidebar = page.getByRole('navigation', { name: '对话列表' });
   await sidebar.getByRole('button', { name: '扩展', exact: true }).click();
   await page.getByRole('main', { name: '扩展' }).waitFor();
 
@@ -55,7 +55,7 @@ test('offers no delete for a project-scope skill', async ({ invocableSkillsWindo
   // refuses them with `blocked_scope`, and the panel must not offer a button
   // that cannot work.
   await page.getByRole('button', { name: '展开侧边栏' }).click();
-  const sidebar = page.getByRole('complementary', { name: '对话列表' });
+  const sidebar = page.getByRole('navigation', { name: '对话列表' });
   await sidebar.getByRole('button', { name: '扩展', exact: true }).click();
   await page.getByRole('main', { name: '扩展' }).waitFor();
 

--- a/apps/desktop/e2e/window-titlebar.spec.ts
+++ b/apps/desktop/e2e/window-titlebar.spec.ts
@@ -41,7 +41,7 @@ import type { Page } from '@playwright/test';
  * without removing it, so the drag rect is still underneath them.
  */
 
-const SHELL = '.maka-shell-2col';
+const SHELL = '.maka-shell-astryx';
 
 const INTERACTIVE_SELECTOR = [
   'button',
@@ -80,7 +80,7 @@ interface TitlebarReport {
 
 async function readTitlebar(page: Page, interactiveSelector: string): Promise<TitlebarReport> {
   return page.evaluate((selector) => {
-    const shell = document.querySelector('.maka-shell-2col');
+    const shell = document.querySelector('.maka-shell-astryx');
     const titlebar = document.querySelector('.maka-window-titlebar');
     if (!shell || !titlebar) throw new Error('shell or titlebar missing from the rendered tree');
     const band = titlebar.getBoundingClientRect();
@@ -212,14 +212,16 @@ async function readTitlebar(page: Page, interactiveSelector: string): Promise<Ti
       });
     }
 
-    const contentTops = [...shell.children]
-      .filter((child) => child !== titlebar)
+    const contentElements = [...shell.querySelectorAll('.maka-session-panel, .maka-panel-detail')];
+    const contentTops = contentElements
       .map((child) => child.getBoundingClientRect())
       .filter((rect) => rect.width > 0 && rect.height > 0)
       .map((rect) => rect.top);
 
     return {
-      isFirstElementChild: shell.firstElementChild === titlebar,
+      isFirstElementChild: contentElements.every(
+        (content) => Boolean(titlebar.compareDocumentPosition(content) & Node.DOCUMENT_POSITION_FOLLOWING),
+      ),
       band: {
         top: Math.round(band.top),
         left: Math.round(band.left),
@@ -323,7 +325,7 @@ test('the window titlebar owns its row across surfaces, sidebar states, and the 
   await openSidebar(page);
   await assertTitlebarIsWellFormed(page, 'chat surface, sidebar expanded, wide');
 
-  const sidebar = page.getByRole('complementary', { name: '对话列表' });
+  const sidebar = page.getByRole('navigation', { name: '对话列表' });
   for (const destination of ['扩展', '定时任务'] as const) {
     await sidebar.getByRole('button', { name: destination, exact: true }).click();
     await expect(page.getByRole('main', { name: destination })).toBeVisible();

--- a/apps/desktop/src/main/__tests__/app-shell-layout-actions.test.ts
+++ b/apps/desktop/src/main/__tests__/app-shell-layout-actions.test.ts
@@ -17,32 +17,9 @@ function keyboardEvent(key: string, shiftKey = false) {
 }
 
 describe('app shell layout actions', () => {
-  it('keeps the existing left sidebar ArrowRight behavior', () => {
-    let width = 210;
-    const actions = createAppShellLayoutActions({
-      sessionListCollapsed: false,
-      sessionListWidth: width,
-      setSessionListWidth: (next) => {
-        width = next;
-      },
-      workbarCollapsed: true,
-      workbarWidth: 400,
-      setWorkbarWidth: () => {},
-    });
-    const input = keyboardEvent('ArrowRight');
-
-    actions.onResizeHandleKeyDown(input.event as never);
-
-    assert.equal(width, 220);
-    assert.equal(input.prevented(), true);
-  });
-
   it('ArrowLeft gives more width to the right workbar', () => {
     let width = 400;
     const actions = createAppShellLayoutActions({
-      sessionListCollapsed: false,
-      sessionListWidth: 210,
-      setSessionListWidth: () => {},
       workbarCollapsed: false,
       workbarWidth: width,
       setWorkbarWidth: (next: number) => {

--- a/apps/desktop/src/main/__tests__/astryx-shell-authority-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/astryx-shell-authority-contract.test.ts
@@ -1,0 +1,54 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { resolve } from 'node:path';
+import test from 'node:test';
+
+const REPO_ROOT = resolve(import.meta.dirname, '../../../../..');
+const source = (path: string) => readFile(resolve(REPO_ROOT, path), 'utf8');
+
+test('the desktop shell composes the official Astryx AppShell directly', async () => {
+  const shell = await source('apps/desktop/src/renderer/app-shell.tsx');
+
+  assert.match(shell, /AppShell as AstryxAppShell/);
+  assert.match(shell, /<AstryxAppShell/);
+  assert.match(shell, /variant="surface"/);
+  assert.match(shell, /height="fill"/);
+  assert.match(shell, /contentPadding=\{0\}/);
+  assert.match(shell, /topNav=\{/);
+  assert.match(shell, /sideNav=\{/);
+  assert.doesNotMatch(shell, /maka-shell-2col/);
+  assert.doesNotMatch(shell, /maka-resize-handle/);
+});
+
+test('the session sidebar delegates geometry and collapse to official SideNav', async () => {
+  const panel = await source('packages/ui/src/session-list-panel.tsx');
+  const navigation = await source('packages/ui/src/session-sidebar-nav.tsx');
+
+  assert.match(panel, /@astryxdesign\/core\/SideNav/);
+  assert.match(panel, /<SideNav/);
+  assert.match(panel, /topContent=\{/);
+  assert.match(panel, /footer=\{/);
+  assert.match(panel, /collapsible=\{/);
+  assert.match(panel, /resizable=\{/);
+  assert.match(navigation, /SideNavItem/);
+  assert.match(navigation, /size="md"/);
+  assert.doesNotMatch(navigation, /BaseButton/);
+  assert.doesNotMatch(navigation, /\bcva\b/);
+});
+
+test('history and workbar use Astryx navigation taxonomy without shared wrappers', async () => {
+  const history = await source('packages/ui/src/session-history-list.tsx');
+  const workbar = await source('apps/desktop/src/renderer/session-workbar.tsx');
+
+  assert.match(history, /@astryxdesign\/core\/List/);
+  assert.match(history, /@astryxdesign\/core\/TreeList/);
+  const renameNavigationGuards = history.match(
+    /\['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'\]\.includes\(event\.key\)\)\s*\{\s*event\.stopPropagation\(\);/g,
+  );
+  assert.equal(renameNavigationGuards?.length, 2);
+  assert.match(workbar, /@astryxdesign\/core\/Toolbar/);
+  assert.match(workbar, /@astryxdesign\/core\/TabList/);
+  assert.match(workbar, /<Toolbar/);
+  assert.match(workbar, /<TabList/);
+  assert.doesNotMatch(workbar, /PrimitiveTabs/);
+});

--- a/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
+++ b/apps/desktop/src/main/__tests__/session-project-view-contract.test.ts
@@ -146,7 +146,7 @@ describe('sidebar project view mode', () => {
     assert.match(list, /copy\.projectRestore/);
   });
 
-  it('keeps collapsed project rows on the same vertical rhythm as conversation rows', async () => {
+  it('keeps empty project rows on Astryx compact TreeList geometry', async () => {
     const projects = [
       project('project-a', 'Project A', [{ path: '/work/a', isWorktree: false }]),
       project('project-b', 'Project B', [{ path: '/work/b', isWorktree: false }]),
@@ -156,34 +156,9 @@ describe('sidebar project view mode', () => {
       groups: deriveProjectGroups([], projects, 'zh'),
       viewMode: 'project',
     });
-    const css = await readRepo('apps/desktop/src/renderer/styles/sidebar.css');
-
-    assert.equal(
-      (markup.match(/data-variant="project" data-expanded="false"/g) ?? []).length,
-      2,
-      'empty project groups should expose their collapsed state to the layout',
-    );
-    assert.match(
-      ruleBody(
-        css,
-        '.maka-list-group[data-variant="project"] + .maka-list-group[data-variant="project"]',
-      ),
-      /margin-top:\s*0/,
-      'adjacent collapsed projects should not add spacing beyond the list stack gap',
-    );
-    assert.match(
-      ruleBody(
-        css,
-        '.maka-list-group[data-variant="project"][data-expanded="true"] + .maka-list-group[data-variant="project"]',
-      ),
-      /margin-top:\s*var\(--space-3\)/,
-      'an expanded project may keep a group break before the next project',
-    );
-    assert.match(
-      ruleBody(css, '.maka-list-project-heading'),
-      /min-height:\s*var\(--h-control-lg\)/,
-    );
-    assert.match(ruleBody(css, '.maka-list-row'), /min-height:\s*var\(--h-control-lg\)/);
+    assert.match(markup, /class="astryx-tree-list compact/);
+    assert.equal((markup.match(/data-variant="project"/g) ?? []).length, 2);
+    assert.equal((markup.match(/role="treeitem"/g) ?? []).length, 2);
   });
 
   it('renders project groups, the unassigned bucket, and keeps the conversation fallback path', () => {
@@ -290,7 +265,7 @@ describe('sidebar project view mode', () => {
     );
   });
 
-  it('renders project groups as folder headers with an initial four-session preview', () => {
+  it('renders project groups as expanded Astryx trees without a parallel preview state', () => {
     const sessions = Array.from({ length: 5 }, (_, index) => makeSessionSummary({
       id: `project-session-${index + 1}`,
       name: `Project chat ${index + 1}`,
@@ -309,34 +284,26 @@ describe('sidebar project view mode', () => {
       viewMode: 'project',
     });
 
-    // The heading is a UiButton (Base UI <button>); BaseButton reorders props
-    // so class is not guaranteed to precede aria-*. Assert the disclosure
-    // contract on the matched opening tag without assuming attribute order.
-    const headingTag = markup.match(/<button[^>]*maka-list-project-heading[^>]*>/)?.[0];
-    assert.ok(headingTag, 'project heading button must render');
-    assert.match(headingTag, /aria-expanded="true"/);
-    assert.match(headingTag, /aria-controls="maka-list-group-body-project:[^"]+"/);
+    assert.match(markup, /class="astryx-tree-list compact/);
+    assert.match(markup, /role="treeitem" aria-expanded="true"/);
+    assert.match(markup, /data-tree-id="project:[^"]+"/);
     assert.match(markup, /lucide-folder-open/);
     assert.match(markup, />testzcode</);
     assert.match(markup, /Project chat 1/);
     assert.match(markup, /Project chat 4/);
-    assert.doesNotMatch(markup, /Project chat 5/);
-    assert.match(markup, /显示更多/);
+    assert.match(markup, /Project chat 5/);
+    assert.doesNotMatch(markup, /显示更多/);
   });
 
-  it('does not reopen a manually collapsed project when only session data refreshes', async () => {
+  it('delegates project expansion state to Astryx TreeList', async () => {
     const list = await readRepo('packages/ui/src/session-history-list.tsx');
     const projectGroup =
       list.match(
         /function ProjectSessionGroup\([\s\S]*?\nfunction SessionTreeRow/,
       )?.[0] ?? '';
 
-    assert.doesNotMatch(
-      projectGroup,
-      /useEffect\(\(\) => \{[\s\S]*setExpanded\(true\)[\s\S]*props\.sessions/,
-    );
-    assert.match(projectGroup, /observedActiveSessionId/);
-    assert.match(projectGroup, /activeSessionId !== disclosure\.observedActiveSessionId/);
+    assert.doesNotMatch(projectGroup, /disclosure|setExpanded|PROJECT_GROUP_PREVIEW_LIMIT/);
+    assert.match(list, /<TreeList items=\{items\} density="compact" variant="lineGuides" \/>/);
   });
 
   it('renders linked child sessions directly beneath their parent as normal selectable rows', () => {
@@ -517,20 +484,16 @@ describe('sidebar project view mode', () => {
     assert.ok(groups.some((g) => g.label === 'repo-a'), 'expected a repo-a label');
     assert.ok(groups.some((g) => g.label === 'x'), 'expected an x label');
 
-    // Rendered markup: group body ids and aria-controls stay whitespace-free and pair up.
+    // Astryx TreeList uses the stable group id as its tree identity.
     const markup = renderSessionListPanel({
       sessions,
       groups,
       viewMode: 'project',
     });
-    const bodyIds = [...markup.matchAll(/id="maka-list-group-body-([^"]*)"/g)].map((m) => m[1]);
-    const controls = [...markup.matchAll(/aria-controls="maka-list-group-body-([^"]*)"/g)].map((m) => m[1]);
-    assert.ok(bodyIds.length >= 3, `expected at least 3 group body ids, got ${bodyIds.length}`);
-    for (const id of [...bodyIds, ...controls]) {
-      assert.match(id, /^[A-Za-z0-9:_-]+$/, `rendered group id must be DOM-safe, got: ${id}`);
-    }
-    for (const control of controls) {
-      assert.ok(bodyIds.includes(control), `aria-controls references a missing body id: ${control}`);
+    const treeIds = [...markup.matchAll(/data-tree-id="([^"]*)"/g)].map((m) => m[1]);
+    assert.ok(treeIds.length >= 3, `expected at least 3 tree ids, got ${treeIds.length}`);
+    for (const id of treeIds) {
+      assert.match(id, /^[A-Za-z0-9:_-]+$/, `rendered tree id must be DOM-safe, got: ${id}`);
     }
   });
 });

--- a/apps/desktop/src/renderer/app-shell-detail-panel.tsx
+++ b/apps/desktop/src/renderer/app-shell-detail-panel.tsx
@@ -15,7 +15,7 @@ export function AppShellDetailPanel({
   return (
     <div
       {...props}
-      className="maka-panel maka-panel-detail maka-floating-panel agents-content-area agents-parchment-paper-surface"
+      className="maka-panel maka-panel-detail agents-parchment-paper-surface"
       data-agents-view={agentsView}
     >
       {children}

--- a/apps/desktop/src/renderer/app-shell-layout-actions.ts
+++ b/apps/desktop/src/renderer/app-shell-layout-actions.ts
@@ -1,10 +1,5 @@
 import type { KeyboardEvent, PointerEvent } from 'react';
 import {
-  clampSessionListWidth,
-  SESSION_LIST_EXPANDED_MAX_WIDTH,
-  SESSION_LIST_EXPANDED_MIN_WIDTH,
-} from './session-list-layout.js';
-import {
   clampSessionWorkbarWidth,
   SESSION_WORKBAR_MAX_WIDTH,
   SESSION_WORKBAR_MIN_WIDTH,
@@ -13,87 +8,20 @@ import {
 type NumberStateUpdater = (next: number) => void;
 
 export interface AppShellLayoutActions {
-  startColumnResize(event: PointerEvent<HTMLDivElement>): void;
-  onResizeHandleKeyDown(event: KeyboardEvent<HTMLDivElement>): void;
   startWorkbarResize(event: PointerEvent<HTMLDivElement>): void;
   onWorkbarResizeHandleKeyDown(event: KeyboardEvent<HTMLDivElement>): void;
 }
 
 export function createAppShellLayoutActions(deps: {
-  sessionListCollapsed: boolean;
-  sessionListWidth: number;
-  setSessionListWidth: NumberStateUpdater;
   workbarCollapsed: boolean;
   workbarWidth: number;
   setWorkbarWidth: NumberStateUpdater;
 }): AppShellLayoutActions {
   const {
-    sessionListCollapsed,
-    sessionListWidth,
-    setSessionListWidth,
     workbarCollapsed,
     workbarWidth,
     setWorkbarWidth,
   } = deps;
-
-  function startColumnResize(event: PointerEvent<HTMLDivElement>) {
-    if (sessionListCollapsed) return;
-    event.preventDefault();
-    try {
-      event.currentTarget.setPointerCapture(event.pointerId);
-    } catch {
-      /* pointer capture can fail if the target is detached mid-drag */
-    }
-    const startX = event.clientX;
-    const start = sessionListWidth;
-    document.body.classList.add('isResizingColumns');
-    let cleaned = false;
-
-    function onMove(moveEvent: globalThis.PointerEvent) {
-      const delta = moveEvent.clientX - startX;
-      setSessionListWidth(clampSessionListWidth(start + delta));
-    }
-
-    function cleanupResize() {
-      if (cleaned) return;
-      cleaned = true;
-      document.body.classList.remove('isResizingColumns');
-      window.removeEventListener('pointermove', onMove);
-      window.removeEventListener('pointerup', cleanupResize);
-      window.removeEventListener('pointercancel', cleanupResize);
-      window.removeEventListener('blur', cleanupResize);
-    }
-
-    window.addEventListener('pointermove', onMove);
-    window.addEventListener('pointerup', cleanupResize);
-    window.addEventListener('pointercancel', cleanupResize);
-    window.addEventListener('blur', cleanupResize);
-  }
-
-  function onResizeHandleKeyDown(event: KeyboardEvent<HTMLDivElement>) {
-    if (sessionListCollapsed) return;
-    const SMALL = 10;
-    const LARGE = 50;
-    let next = sessionListWidth;
-    switch (event.key) {
-      case 'ArrowLeft':
-        next = sessionListWidth - (event.shiftKey ? LARGE : SMALL);
-        break;
-      case 'ArrowRight':
-        next = sessionListWidth + (event.shiftKey ? LARGE : SMALL);
-        break;
-      case 'Home':
-        next = SESSION_LIST_EXPANDED_MIN_WIDTH;
-        break;
-      case 'End':
-        next = SESSION_LIST_EXPANDED_MAX_WIDTH;
-        break;
-      default:
-        return;
-    }
-    event.preventDefault();
-    setSessionListWidth(clampSessionListWidth(next));
-  }
 
   function startWorkbarResize(event: PointerEvent<HTMLDivElement>) {
     if (workbarCollapsed) return;
@@ -154,8 +82,6 @@ export function createAppShellLayoutActions(deps: {
   }
 
   return {
-    startColumnResize,
-    onResizeHandleKeyDown,
     startWorkbarResize,
     onWorkbarResizeHandleKeyDown,
   };

--- a/apps/desktop/src/renderer/app-shell.tsx
+++ b/apps/desktop/src/renderer/app-shell.tsx
@@ -148,6 +148,7 @@ import {
   isSessionWorkspaceUnavailableError,
   showSessionWorkspaceUnavailableToast,
 } from './session-workspace-errors';
+import { AppShell as AstryxAppShell } from '@astryxdesign/core/AppShell';
 
 type ComposerImportOwner = {
   sessionId: string | undefined;
@@ -1176,10 +1177,7 @@ function AppShellContent({
     workbarTab,
     setWorkbarTab,
   } = useShellLayout();
-  const { startColumnResize, onResizeHandleKeyDown, startWorkbarResize, onWorkbarResizeHandleKeyDown } = useStableActions(createAppShellLayoutActions, {
-    sessionListCollapsed,
-    sessionListWidth,
-    setSessionListWidth,
+  const { startWorkbarResize, onWorkbarResizeHandleKeyDown } = useStableActions(createAppShellLayoutActions, {
     workbarCollapsed,
     workbarWidth,
     setWorkbarWidth,
@@ -2030,64 +2028,51 @@ function AppShellContent({
         : 'im_hub';
 
   return (
-      <div className="appFrame agents-layout-root" data-agents-page>
-      <div
-        className="app maka-shell-2col agents-layout-body"
+    <div
+      className="appFrame agents-layout-root"
+      data-agents-page
+      data-sidebar-state={sessionListCollapsed ? 'collapsed' : 'expanded'}
+    >
+      <AstryxAppShell
+        className="app maka-shell-astryx agents-layout-body"
+        variant="surface"
+        height="fill"
+        contentPadding={0}
+        mobileNav={{ breakpoint: 'none', hasToggle: false }}
         aria-hidden={hasModalOpen ? 'true' : undefined}
         inert={hasModalOpen ? true : undefined}
         data-modal-background-hidden={hasModalOpen ? 'true' : undefined}
         data-sidebar-state={sessionListCollapsed ? 'collapsed' : 'expanded'}
-        style={
-          {
-            '--maka-session-list-expanded-width': `${sessionListWidth}px`,
-            '--maka-resize-handle-width': '0px',
-          } as CSSProperties
-        }
-      >
-        {/* The window's titlebar: the shell's first grid row, spanning every
-            column, and the only element that declares `-webkit-app-region:
-            drag`. Its action clusters are ordinary in-flow children that each
-            declare `no-drag`, so the OS draggable region is whatever the row
-            has left over — no container has to reserve space for a sibling.
-            Two properties make that work and must hold together:
-            it is the FIRST child (Chromium builds the draggable region by
-            walking annotated elements in DOCUMENT ORDER, adding `drag` rects
-            and subtracting `no-drag` ones, so only a `no-drag` element declared
-            after it can carve itself back out), and it OCCUPIES a row rather
-            than floating over one, so content below can never land inside it.
-            Locked by e2e/window-titlebar.spec.ts. */}
-        <header className="maka-window-titlebar">
-          <AppShellTopbarActions
-            sidebarCollapsed={sessionListCollapsed}
-            onOpenSearchModal={() => {
-              setSearchModalOpen(true);
-            }}
-            onCollapseSidebar={() => setSessionListCollapsed(true)}
-            onExpandSidebar={() => setSessionListCollapsed(false)}
-            onCreateSession={createSession}
-          />
-          {/* The module surfaces that own their whole column show no workspace
-              toolbar. That used to be a `display: none` override reaching in
-              from the detail panel's `data-agents-view`; now that the toolbar
-              lives in the titlebar it is simply not rendered. */}
-          {!VIEWS_WITHOUT_WORKSPACE_ACTIONS.has(agentsView) && (
-            <AppShellWorkspaceTopActions
-              workbarAvailable={navSelection.section === 'sessions' && Boolean(activeId)}
-              workbarCollapsed={workbarCollapsed}
-              onToggleWorkbar={() => setWorkbarCollapsed((current) => !current)}
-              onOpenFeedback={() => openSettingsSection('about')}
-              onOpenPalette={openPalette}
-              onOpenHelp={openHelp}
-              onOpenHealth={() => openSettingsSection('health')}
+        topNav={
+          <header className="maka-window-titlebar">
+            <AppShellTopbarActions
+              sidebarCollapsed={sessionListCollapsed}
+              onOpenSearchModal={() => setSearchModalOpen(true)}
+              onCollapseSidebar={() => setSessionListCollapsed(true)}
+              onExpandSidebar={() => setSessionListCollapsed(false)}
+              onCreateSession={createSession}
             />
-          )}
-        </header>
-        <div
-          className="maka-panel maka-panel-list maka-floating-panel"
-          aria-hidden={sessionListCollapsed ? 'true' : undefined}
-          inert={sessionListCollapsed ? true : undefined}
-        >
+            {!VIEWS_WITHOUT_WORKSPACE_ACTIONS.has(agentsView) && (
+              <AppShellWorkspaceTopActions
+                workbarAvailable={navSelection.section === 'sessions' && Boolean(activeId)}
+                workbarCollapsed={workbarCollapsed}
+                onToggleWorkbar={() => setWorkbarCollapsed((current) => !current)}
+                onOpenFeedback={() => openSettingsSection('about')}
+                onOpenPalette={openPalette}
+                onOpenHelp={openHelp}
+                onOpenHealth={() => openSettingsSection('health')}
+              />
+            )}
+          </header>
+        }
+        sideNav={
           <SessionListPanel
+            collapsed={sessionListCollapsed}
+            onCollapsedChange={setSessionListCollapsed}
+            width={sessionListWidth}
+            onWidthChange={setSessionListWidth}
+            minWidth={SESSION_LIST_EXPANDED_MIN_WIDTH}
+            maxWidth={SESSION_LIST_EXPANDED_MAX_WIDTH}
             selection={navSelection}
             sessions={visibleSessions}
             activeId={activeId}
@@ -2109,20 +2094,8 @@ function AppShellContent({
             rowActions={sessionRowActions}
             projectActions={projectRowActions}
           />
-        </div>
-        <div
-          className="maka-resize-handle"
-          role="separator"
-          aria-label={sessionListCollapsed ? shellCopy.sidebarCollapsed : shellCopy.resizeConversationList}
-          aria-orientation="vertical"
-          aria-valuemin={SESSION_LIST_EXPANDED_MIN_WIDTH}
-          aria-valuemax={SESSION_LIST_EXPANDED_MAX_WIDTH}
-          aria-valuenow={sessionListWidth}
-          aria-hidden={sessionListCollapsed ? 'true' : undefined}
-          tabIndex={sessionListCollapsed ? -1 : 0}
-          onPointerDown={startColumnResize}
-          onKeyDown={onResizeHandleKeyDown}
-        />
+        }
+      >
         <AppShellDetailPanel
           data-sidebar-state={sessionListCollapsed ? 'collapsed' : 'expanded'}
           agentsView={agentsView}
@@ -2575,7 +2548,7 @@ function AppShellContent({
           </div>
           </MakaUriContext.Provider>
         </AppShellDetailPanel>
-      </div>
+      </AstryxAppShell>
       <AppShellOverlays
         settingsOpen={settingsOpen}
         connections={connections}
@@ -2611,6 +2584,6 @@ function AppShellContent({
         closePalette={closePalette}
         commandOptions={commandOptions}
       />
-      </div>
+    </div>
   );
 }

--- a/apps/desktop/src/renderer/session-list-layout.ts
+++ b/apps/desktop/src/renderer/session-list-layout.ts
@@ -1,8 +1,8 @@
 import { safeLocalStorageGet } from './browser-storage.js';
 
-export const SESSION_LIST_EXPANDED_DEFAULT_WIDTH = 210;
-export const SESSION_LIST_EXPANDED_MIN_WIDTH = 210;
-export const SESSION_LIST_EXPANDED_MAX_WIDTH = 280;
+export const SESSION_LIST_EXPANDED_DEFAULT_WIDTH = 260;
+export const SESSION_LIST_EXPANDED_MIN_WIDTH = 180;
+export const SESSION_LIST_EXPANDED_MAX_WIDTH = 480;
 
 export function readSessionListWidth(): number {
   const stored = Number(safeLocalStorageGet('maka-chat-list-width-v1'));

--- a/apps/desktop/src/renderer/session-workbar.tsx
+++ b/apps/desktop/src/renderer/session-workbar.tsx
@@ -1,14 +1,12 @@
 import { useEffect, useState, type CSSProperties } from 'react';
 import {
-  PrimitiveTabs,
-  PrimitiveTabsList,
-  PrimitiveTabsPanel,
-  PrimitiveTabsTrigger,
   TaskLedgerPanel,
   deriveTaskLedgerPanelModel,
   useUiLocale,
   type ChatModelChoice,
 } from '@maka/ui';
+import { Tab, TabList } from '@astryxdesign/core/TabList';
+import { Toolbar } from '@astryxdesign/core/Toolbar';
 import type { SessionSummary } from '@maka/core';
 import { ArtifactPane } from './artifact-pane';
 import { BrowserPanel } from './browser-panel';
@@ -65,44 +63,54 @@ export function SessionWorkbar(props: {
       aria-label={copy.ariaLabel}
       style={{ '--maka-session-workbar-width': `${props.width}px` } as CSSProperties}
     >
-      <PrimitiveTabs value={props.activeTab} onValueChange={(value) => props.onActiveTabChange(value as SessionWorkbarTab)} className="maka-session-workbar-tabs">
-        <PrimitiveTabsList variant="underline" className="maka-session-workbar-tab-list" aria-label={copy.sectionsAriaLabel}>
-          <PrimitiveTabsTrigger value="tasks">
-            <span>{copy.tasks}</span>
-            <span className="maka-session-workbar-count" data-maka-contract="session-workbar-count">{taskCount}</span>
-          </PrimitiveTabsTrigger>
-          <PrimitiveTabsTrigger value="browser" disabled={!props.browserLive}>
-            <span>{copy.browser}</span>
-          </PrimitiveTabsTrigger>
-          <PrimitiveTabsTrigger value="files">
-            <span>{copy.files}</span>
-            <span className="maka-session-workbar-count" data-maka-contract="session-workbar-count">{artifactCount}</span>
-          </PrimitiveTabsTrigger>
-          {props.quote && (
-            <PrimitiveTabsTrigger value="quote">
-              <span>{copy.quoteTab}</span>
-            </PrimitiveTabsTrigger>
-          )}
-        </PrimitiveTabsList>
-        <PrimitiveTabsPanel value="tasks" className="maka-session-workbar-panel" keepMounted>
+      <div className="maka-session-workbar-tabs">
+        <Toolbar
+          className="maka-session-workbar-toolbar"
+          label={copy.sectionsAriaLabel}
+          size="sm"
+          dividers={['bottom']}
+          startContent={
+            <TabList
+              className="maka-session-workbar-tab-list"
+              value={props.activeTab}
+              onChange={(value) => props.onActiveTabChange(value as SessionWorkbarTab)}
+              size="sm"
+              layout="fill"
+              aria-label={copy.sectionsAriaLabel}
+            >
+              <Tab
+                value="tasks"
+                label={copy.tasks}
+                endContent={<span className="maka-session-workbar-count" data-maka-contract="session-workbar-count">{taskCount}</span>}
+              />
+              {props.browserLive && <Tab value="browser" label={copy.browser} />}
+              <Tab
+                value="files"
+                label={copy.files}
+                endContent={<span className="maka-session-workbar-count" data-maka-contract="session-workbar-count">{artifactCount}</span>}
+              />
+              {props.quote && <Tab value="quote" label={copy.quoteTab} />}
+            </TabList>
+          }
+        />
+        <div hidden={props.activeTab !== 'tasks'} className="maka-session-workbar-panel">
           <TaskLedgerPanel
             tasks={sessionTasks.tasks}
             loading={sessionTasks.loading}
             error={sessionTasks.error}
             onRetry={sessionTasks.retry}
           />
-        </PrimitiveTabsPanel>
-        <PrimitiveTabsPanel value="browser" className="maka-session-workbar-panel" keepMounted>
+        </div>
+        <div hidden={props.activeTab !== 'browser'} className="maka-session-workbar-panel">
           {props.browserLive && <BrowserPanel sessionId={props.sessionId} hidden={props.hidden || props.activeTab !== 'browser'} />}
-        </PrimitiveTabsPanel>
-        <PrimitiveTabsPanel value="files" className="maka-session-workbar-panel" keepMounted>
+        </div>
+        <div hidden={props.activeTab !== 'files'} className="maka-session-workbar-panel">
           <ArtifactPane sessionId={props.sessionId} onCountChange={setArtifactCount} onDismiss={props.onDismiss} />
-        </PrimitiveTabsPanel>
+        </div>
         {props.quote && (
-          <PrimitiveTabsPanel
-            value="quote"
+          <div
+            hidden={props.activeTab !== 'quote'}
             className="maka-session-workbar-panel maka-quote-workbar-panel"
-            keepMounted
           >
             <QuoteCompanionPanel
               key={props.quote.id}
@@ -115,9 +123,9 @@ export function SessionWorkbar(props: {
               onRemoveQuote={props.onRemoveQuote}
               onForkVisibilityChange={props.onForkVisibilityChange}
             />
-          </PrimitiveTabsPanel>
+          </div>
         )}
-      </PrimitiveTabs>
+      </div>
     </aside>
   );
 }

--- a/apps/desktop/src/renderer/styles/chat-detail.css
+++ b/apps/desktop/src/renderer/styles/chat-detail.css
@@ -63,16 +63,19 @@
 .maka-session-workbar-tabs {
   height: 100%;
   min-height: 0;
+  display: grid;
+  grid-template-rows: auto minmax(0, 1fr);
   gap: 0;
+}
+
+.maka-session-workbar-toolbar {
+  min-width: 0;
 }
 
 .maka-session-workbar-tab-list {
   width: 100%;
   flex: 0 0 auto;
-  border-bottom: var(--border-width-hairline) solid var(--border);
 }
-
-.maka-session-workbar-tab-list > [data-slot="tabs-tab"] { flex: 1 1 0; }
 
 .maka-session-workbar-count {
   min-width: var(--space-4);

--- a/apps/desktop/src/renderer/styles/shell-layout.css
+++ b/apps/desktop/src/renderer/styles/shell-layout.css
@@ -33,6 +33,25 @@
   height: 100%;
 }
 
+/* Astryx AppShell is the shell authority. Maka only supplies the native
+   Electron titlebar and product surfaces through its public slots. */
+.maka-shell-astryx {
+  width: 100%;
+  min-width: 0;
+  min-height: 0;
+  overflow: hidden;
+}
+
+.maka-shell-astryx .maka-panel-detail {
+  width: 100%;
+  height: 100%;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  background: var(--background);
+}
+
 .maka-shell-2col {
   --maka-sidebar-exit-offset: calc(var(--space-2) * -1);
   position: relative;
@@ -163,8 +182,10 @@
    places to keep the clusters at an exact pixel — which is the habit this whole
    change exists to remove. */
 .maka-window-titlebar {
-  grid-column: 1 / -1;
-  grid-row: 1;
+  width: auto;
+  height: calc(var(--h-titlebar) - var(--maka-window-resize-edge));
+  min-height: calc(var(--h-titlebar) - var(--maka-window-resize-edge));
+  box-sizing: border-box;
   margin: var(--maka-window-resize-edge) var(--maka-window-resize-edge) 0;
   display: flex;
   align-items: center;

--- a/apps/desktop/src/renderer/styles/sidebar.css
+++ b/apps/desktop/src/renderer/styles/sidebar.css
@@ -3,16 +3,6 @@
   min-width: 0;
   min-height: 0;
   height: 100%;
-  display: grid;
-  /* 4 rows: hub nav / session-list heading / list / footer. The panel used to
-     carry a fifth leading row holding an empty `<header>` whose only job was to
-     host a blank drag strip, and after that a `padding-top` clearing the drag
-     band. Both are gone: the titlebar is its own grid row in the shell, so this
-     panel starts below it and has nothing to clear. */
-  grid-template-rows: auto auto minmax(0, 1fr) auto;
-  overflow: hidden;
-  background: transparent;
-  contain: layout paint style;
 }
 
 .maka-session-list {
@@ -30,12 +20,9 @@
    * footer stay visible. See the e2e-fixture `sidebar-long-sessions`
    * scenario.
    */
-  min-height: 0;
+  min-width: 0;
   position: relative;
-  overflow: hidden;
   border-top: 0;
-  display: grid;
-  grid-template-rows: auto minmax(0, 1fr);
   padding-top: var(--space-1);
 }
 
@@ -133,22 +120,11 @@
    styles restored, then tightened after task #98 so active rows read
    as slim target-layout like nav rows instead of full-width pills. */
 .maka-sidebar-modules {
-  align-self: start;
-  align-content: start;
-  display: grid;
-  gap: 1px;
-  /* #546 PR7: left/right padding aligned with .maka-list-stackContent
-     (var(--space-2)) so nav rows and session rows share the same inset. */
-  padding: var(--space-1) var(--space-2);
+  -webkit-app-region: no-drag;
 }
 
 .maka-nav-row {
-  width: 100%;
-  display: grid;
-  grid-template-columns: var(--icon-size) minmax(0, 1fr) auto;
-  align-items: center;
   -webkit-app-region: no-drag;
-  text-align: left;
 }
 
 .maka-nav-row span:nth-child(2) {

--- a/apps/desktop/stories/app-shell.stories.tsx
+++ b/apps/desktop/stories/app-shell.stories.tsx
@@ -5,6 +5,7 @@ import type { ProjectRecord, SessionSummary, StoredMessage } from '@maka/core';
 import { ChatView, Composer, SessionListPanel } from '@maka/ui';
 import type { ChatModelChoice, SessionViewMode } from '@maka/ui';
 import { AppShellTopbarActions, AppShellWorkspaceTopActions } from '../src/renderer/app-shell-chrome-actions';
+import { AppShell as AstryxAppShell } from '@astryxdesign/core/AppShell';
 
 const NOW = Date.UTC(2026, 6, 1, 9, 30, 0);
 
@@ -12,7 +13,7 @@ const NOW = Date.UTC(2026, 6, 1, 9, 30, 0);
 // that reaches it. See apps/desktop/stories/FIDELITY.md.
 
 const meta = {
-  title: 'Product/Shell Child Composition',
+  title: 'Product/Shell Official AppShell',
   parameters: {
     layout: 'fullscreen',
   },
@@ -134,7 +135,7 @@ const conversation: StoredMessage[] = [
   user('msg-1', 'turn-1', 14, '帮我把这轮 Storybook 覆盖的风险列出来，只保留真正会影响 review 的部分。'),
   assistant('msg-2', 'turn-1', 12, '现在最值得先固定的是几个高频但还没有 story 的页面：权限弹窗、顶层布局、首次启动引导。把它们的可见状态摆出来，reviewer 就能在 Storybook 里逐个看，不用手动把 app 驱动到这些路径。'),
   user('msg-3', 'turn-2', 6, '顶层布局怎么处理？它依赖很多 IPC。'),
-  assistant('msg-4', 'turn-2', 4, '不整体挂载 AppShell，改为用真实的子组件（侧栏、聊天区、顶栏）拼出布局。能稳定反映页面长什么样，又不被 IPC 耦合拖住。'),
+  assistant('msg-4', 'turn-2', 4, '直接挂载 Astryx AppShell，并通过官方 topNav、sideNav 和 content 插槽组合真实侧栏、聊天区与标题栏。Story 只隔离 IPC，布局 authority 与产品保持一致。'),
 ];
 
 const markdownCoreConversation: StoredMessage[] = [
@@ -227,10 +228,9 @@ function ShellFrame(props: { children: ReactNode; motionEnabled?: boolean }) {
   );
 }
 
-// Composition smoke: mounts the real SessionListPanel + ChatView + Composer
-// + topbar chrome pieces side-by-side. Does NOT mount the monolithic
-// AppShell (1442 lines, heavy IPC coupling). When AppShell's internal
-// layout shifts, this story may drift — it owns its own 2-col scaffold.
+// Production-faithful shell composition: Astryx AppShell owns the frame,
+// SideNav owns sidebar geometry, and Maka supplies only Electron chrome and
+// product content through their public slots.
 function ComposedShell(props: {
   sidebarCollapsed?: boolean;
   initialViewMode?: SessionViewMode;
@@ -273,33 +273,41 @@ function ComposedShell(props: {
 
   return (
     <ShellFrame motionEnabled={props.motionEnabled}>
-      <div
-        className="app maka-shell-2col agents-layout-body"
+      <AstryxAppShell
+        className="app maka-shell-astryx agents-layout-body"
+        variant="surface"
+        height="fill"
+        contentPadding={0}
+        mobileNav={{ breakpoint: 'none', hasToggle: false }}
         data-sidebar-state={collapsed ? 'collapsed' : 'expanded'}
-        style={{
-          ['--maka-session-list-expanded-width' as string]: `${sidebarWidth}px`,
-          ['--maka-resize-handle-width' as string]: '0px',
-          height: '100%',
-        }}
-      >
-        <AppShellTopbarActions
-          sidebarCollapsed={collapsed}
-          onOpenSearchModal={noop}
-          onCollapseSidebar={() => setCollapsed(true)}
-          onExpandSidebar={() => setCollapsed(false)}
-          onCreateSession={noop}
-        />
-        {/* Grid is 3 columns (sidebar / handle / detail): the handle must
-            always render or the detail panel falls into the 0px handle
-            column. When collapsed, keep the sidebar mounted (production
-            hides it via the data-sidebar-state CSS) so auto-placement
-            stays aligned. */}
-        <div
-          className="maka-panel maka-panel-list maka-floating-panel"
-          aria-hidden={collapsed ? 'true' : undefined}
-          inert={collapsed ? true : undefined}
-        >
+        topNav={
+          <header className="maka-window-titlebar">
+            <AppShellTopbarActions
+              sidebarCollapsed={collapsed}
+              onOpenSearchModal={noop}
+              onCollapseSidebar={() => setCollapsed(true)}
+              onExpandSidebar={() => setCollapsed(false)}
+              onCreateSession={noop}
+            />
+            <AppShellWorkspaceTopActions
+              workbarAvailable
+              workbarCollapsed={false}
+              onToggleWorkbar={noop}
+              onOpenFeedback={noop}
+              onOpenPalette={noop}
+              onOpenHelp={noop}
+              onOpenHealth={noop}
+            />
+          </header>
+        }
+        sideNav={
           <SessionListPanel
+            collapsed={collapsed}
+            onCollapsedChange={setCollapsed}
+            width={sidebarWidth}
+            onWidthChange={noop}
+            minWidth={180}
+            maxWidth={480}
             selection={{ section: 'sessions', filter: 'chats' }}
             sessions={sessions}
             activeId={active.id}
@@ -315,23 +323,14 @@ function ComposedShell(props: {
             projectActions={projectRowActions}
             worktreeSessionIds={new Set(['session-active'])}
           />
-        </div>
-        <div className="maka-resize-handle" aria-hidden="true" />
+        }
+      >
         <div
-          className="maka-panel maka-panel-detail maka-floating-panel agents-content-area agents-parchment-paper-surface"
+          className="maka-panel maka-panel-detail agents-parchment-paper-surface"
           data-sidebar-state={collapsed ? 'collapsed' : 'expanded'}
           data-agents-view="im_hub"
           style={{ display: 'flex', flexDirection: 'column', minHeight: 0 }}
         >
-          <AppShellWorkspaceTopActions
-            workbarAvailable
-            workbarCollapsed={false}
-            onToggleWorkbar={noop}
-            onOpenFeedback={noop}
-            onOpenPalette={noop}
-            onOpenHelp={noop}
-            onOpenHealth={noop}
-          />
           {props.detailChildren ?? (
             <div style={{ display: 'flex', minHeight: 0, width: '100%', flexDirection: 'column', flex: 1 }}>
               <ChatView {...baseChatProps} activeSession={active} {...props.chat} />
@@ -346,7 +345,7 @@ function ComposedShell(props: {
             </div>
           )}
         </div>
-      </div>
+      </AstryxAppShell>
     </ShellFrame>
   );
 }
@@ -407,7 +406,7 @@ export const StreamingTurn: Story = {
         liveTurn: {
           turnId: 'turn-s', phase: 'streamed', steps: [{
             stepId: 'msg-assistant-s',
-            text: { text: '用真实的子组件拼出 2 栏布局，不整体挂载 AppShell，避开 IPC 耦合。', truncated: false, complete: false },
+            text: { text: '直接挂载 Astryx AppShell，通过官方插槽组合真实产品子组件，只隔离 IPC。', truncated: false, complete: false },
             tools: [],
           }],
         },

--- a/packages/ui/src/__tests__/sidebar-subtraction.test.tsx
+++ b/packages/ui/src/__tests__/sidebar-subtraction.test.tsx
@@ -57,8 +57,7 @@ describe('sidebar subtraction', () => {
       </LocaleProvider>,
     );
 
-    assert.match(markup, /aria-label="Scheduled tasks, 1 unfinished reminder"/);
-    assert.match(markup, />Scheduled tasks</);
+    assert.match(markup, />Scheduled tasks<\/span>.*>1<\/small>/);
     assert.doesNotMatch(markup, /aria-label="Automations,/);
   });
 

--- a/packages/ui/src/plan-reminder-panel.tsx
+++ b/packages/ui/src/plan-reminder-panel.tsx
@@ -108,16 +108,17 @@ export function PlanReminderPanel(props: {
   const planReminderMountedRef = useMountedRef();
   const refreshPendingRef = useRef(false);
   const pendingActionKeysRef = useRef<Set<string>>(new Set());
-  const pendingReminderMenuIntentRef = useRef<(() => void) | null>(null);
+  const pendingReminderMenuIntentRef = useRef<((trigger?: HTMLButtonElement) => void) | null>(null);
   // A reminder row's menu trigger button, keyed by reminder id. When a
   // deferred menu intent (edit/duplicate/clear-runs/delete) opens a dialog
   // after the menu closes, Astryx Dialog restores focus on Esc to whatever
   // was `document.activeElement` when it opened. The menu's own close-focus-
-  // return and the deferred dialog open sit two `requestAnimationFrame`s
-  // apart, so on a loaded runner the captured element can land on <body>
-  // instead of the trigger and Esc strands focus away from the row. The
-  // deferred intent re-focuses the trigger right before opening the dialog,
-  // making that capture deterministic. See plan-reminders E2E.
+  // return and the deferred dialog open sit across animation frames, so on a
+  // loaded runner the captured element can land on <body> instead of the
+  // trigger and Esc strands focus away from the row. The trigger is passed to
+  // the deferred dialog intent and focused in the same frame that opens the
+  // dialog, making Astryx Dialog's own capture deterministic. See the
+  // plan-reminders E2E.
   const reminderMenuTriggerRefs = useRef<Map<string, HTMLButtonElement>>(new Map());
   // Issue #1044: all create/edit form fields + submit moved into
   // PlanReminderFormDialog. The panel owns its open state and seed;
@@ -212,12 +213,14 @@ export function PlanReminderPanel(props: {
     }
   }
 
-  function openReminderDialog(seed: PlanReminderFormSeed) {
+  function openReminderDialog(seed: PlanReminderFormSeed, trigger?: HTMLButtonElement) {
     setFormDialogOpen(false);
     setFormSeed(seed);
     setFormNonce((nonce) => nonce + 1);
     window.requestAnimationFrame(() => {
-      if (planReminderMountedRef.current) setFormDialogOpen(true);
+      if (!planReminderMountedRef.current) return;
+      trigger?.focus();
+      setFormDialogOpen(true);
     });
   }
 
@@ -225,15 +228,15 @@ export function PlanReminderPanel(props: {
     openReminderDialog(createPlanReminderFormSeed());
   }
 
-  function editReminder(reminder: PlanReminder) {
-    openReminderDialog(planReminderEditSeed(reminder));
+  function editReminder(reminder: PlanReminder, trigger?: HTMLButtonElement) {
+    openReminderDialog(planReminderEditSeed(reminder), trigger);
   }
 
-  function duplicateReminder(reminder: PlanReminder) {
-    openReminderDialog(planReminderDuplicateSeed(reminder, locale));
+  function duplicateReminder(reminder: PlanReminder, trigger?: HTMLButtonElement) {
+    openReminderDialog(planReminderDuplicateSeed(reminder, locale), trigger);
   }
 
-  function runReminderMenuIntentAfterClose(intent: () => void) {
+  function runReminderMenuIntentAfterClose(intent: (trigger?: HTMLButtonElement) => void) {
     pendingReminderMenuIntentRef.current = intent;
   }
 
@@ -245,12 +248,7 @@ export function PlanReminderPanel(props: {
     if (intent) {
       window.requestAnimationFrame(() => {
         if (!planReminderMountedRef.current) return;
-        // Re-establish the trigger as the active element before the intent
-        // opens a dialog, so the dialog captures and later restores focus to
-        // the row's menu trigger instead of whatever drifted to <body> during
-        // the menu-close → deferred-open window.
-        reminderMenuTriggerRefs.current.get(reminderId)?.focus();
-        intent();
+        intent(reminderMenuTriggerRefs.current.get(reminderId));
       });
     }
   }
@@ -519,7 +517,7 @@ export function PlanReminderPanel(props: {
                         >
                             <DropdownMenuItem
                               onClick={() =>
-                                runReminderMenuIntentAfterClose(() => editReminder(reminder))
+                                runReminderMenuIntentAfterClose((trigger) => editReminder(reminder, trigger))
                               }
                               isDisabled={reminderActionPending || reminder.status === 'completed'}
                               icon={<Pencil size={14} aria-hidden="true" />}
@@ -527,7 +525,7 @@ export function PlanReminderPanel(props: {
                             />
                             <DropdownMenuItem
                               onClick={() =>
-                                runReminderMenuIntentAfterClose(() => duplicateReminder(reminder))
+                                runReminderMenuIntentAfterClose((trigger) => duplicateReminder(reminder, trigger))
                               }
                               isDisabled={reminderActionPending}
                               icon={<Copy size={14} aria-hidden="true" />}

--- a/packages/ui/src/session-history-list.tsx
+++ b/packages/ui/src/session-history-list.tsx
@@ -8,7 +8,6 @@ import {
   ArchiveRestore,
   Ban,
   Bot,
-  ChevronRight,
   CircleCheckBig,
   Eye,
   FolderGit2,
@@ -25,20 +24,20 @@ import {
   Trash2,
 } from './icons.js';
 import { EmptyState } from './empty-state.js';
-import { OverlayScrollArea } from './overlay-scroll-area.js';
 import {
   DropdownMenu,
   DropdownMenuItem,
 } from '@astryxdesign/core/DropdownMenu';
 import { Divider } from '@astryxdesign/core/Divider';
 import { Button as BaseButton } from '@base-ui/react/button';
+import { List, ListItem } from '@astryxdesign/core/List';
+import { TreeList, type TreeListItemData } from '@astryxdesign/core/TreeList';
 import { describeBlockedReason, presentSessionStatus } from './session-status-presentation.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
 
 type SessionRowActionId = 'flag' | 'archive' | 'rename' | 'delete';
 type SessionHistoryGroupVariant = 'conversation' | 'project';
-const PROJECT_GROUP_PREVIEW_LIMIT = 4;
 
 export interface SessionRowActions {
   /** Flag (pin) state toggle. */
@@ -163,7 +162,7 @@ export function SessionHistoryList(props: {
   }
 
   return (
-    <section className="maka-session-list" aria-label={sessionListTitle}>
+    <section className="maka-session-list" aria-label={sessionListTitle} onKeyDown={handleListKeyDown}>
       {props.sessions.length === 0 &&
       !(props.groupVariant === 'project' && (props.groups?.length ?? 0) > 0) ? (
         // WAWQAQ msg `f56f38c1` (2026-06-20): the create-session CTA
@@ -178,12 +177,7 @@ export function SessionHistoryList(props: {
           extraClassName="maka-session-empty-state"
         />
       ) : (
-        <OverlayScrollArea
-          className="maka-list-stack"
-          viewportClassName="maka-list-stackViewport"
-          contentClassName="maka-list-stackContent"
-          onKeyDown={handleListKeyDown}
-        >
+        <div className="maka-list-stackContent">
           <SessionListGroups
             groups={
               props.groups
@@ -209,7 +203,7 @@ export function SessionHistoryList(props: {
             rowActions={props.rowActions}
             projectActions={props.projectActions}
           />
-        </OverlayScrollArea>
+        </div>
       )}
     </section>
   );
@@ -233,42 +227,52 @@ function SessionListGroups(props: {
   rowActions?: SessionRowActions;
   projectActions?: ProjectRowActions;
 }) {
+  const copy = getConversationCopy(useUiLocale()).sessions;
   if (props.groupVariant === 'project') {
     const activeGroups = props.groups.filter((group) => group.project?.archivedAt === undefined);
     const archivedGroups = props.groups.filter((group) => group.project?.archivedAt !== undefined);
+    function sessionItem(session: SessionSummary): TreeListItemData {
+      return {
+        id: session.id,
+        label: (
+          <SessionRow
+            session={session}
+            active={session.id === props.activeId}
+            streaming={props.streamingSessionIds?.has(session.id) ?? false}
+            stale={props.staleSessionIds?.has(session.id) ?? false}
+            worktree={props.worktreeSessionIds?.has(session.id) ?? false}
+            nested
+            onSelect={props.onSelectSession}
+            actions={props.rowActions}
+          />
+        ),
+        isSelected: session.id === props.activeId,
+        children: (props.childSessionsByParentId?.get(session.id) ?? []).map(sessionItem),
+      };
+    }
+    const projectItem = (group: (typeof props.groups)[number]): TreeListItemData => ({
+      id: group.key,
+      label: (
+        <ProjectSessionGroup
+          {...props}
+          label={group.label}
+          sessions={group.sessions}
+          project={group.project}
+        />
+      ),
+      isExpanded: group.sessions.length > 0,
+      children: group.sessions.map(sessionItem),
+    });
+    const items = activeGroups.map(projectItem);
+    if (archivedGroups.length > 0) {
+      items.push({
+        id: 'archived-projects',
+        label: copy.archivedProjects,
+        children: archivedGroups.map(projectItem),
+      });
+    }
     return (
-      <>
-        {activeGroups.map((group) => (
-          <ProjectSessionGroup
-            key={group.key}
-            groupKey={group.key}
-            label={group.label}
-            sessions={group.sessions}
-            project={group.project}
-            activeId={props.activeId}
-            streamingSessionIds={props.streamingSessionIds}
-            staleSessionIds={props.staleSessionIds}
-            childSessionsByParentId={props.childSessionsByParentId}
-            worktreeSessionIds={props.worktreeSessionIds}
-            onSelectSession={props.onSelectSession}
-            rowActions={props.rowActions}
-            projectActions={props.projectActions}
-          />
-        ))}
-        {archivedGroups.length > 0 && (
-          <ArchivedProjectGroups
-            groups={archivedGroups}
-            activeId={props.activeId}
-            streamingSessionIds={props.streamingSessionIds}
-            staleSessionIds={props.staleSessionIds}
-            childSessionsByParentId={props.childSessionsByParentId}
-            worktreeSessionIds={props.worktreeSessionIds}
-            onSelectSession={props.onSelectSession}
-            rowActions={props.rowActions}
-            projectActions={props.projectActions}
-          />
-        )}
-      </>
+      <TreeList items={items} density="compact" variant="lineGuides" />
     );
   }
 
@@ -276,28 +280,31 @@ function SessionListGroups(props: {
     <>
       {props.groups.map((group) => {
         return (
-          <div key={group.key} className="maka-list-group" data-variant="conversation">
-            {group.label ? (
-              <div className="maka-list-group-label">
-                <span>{group.label}</span>
-              </div>
-            ) : null}
-            <div>
+          <List
+            key={group.key}
+            className="maka-list-group"
+            density="compact"
+            header={group.label ? <div className="maka-list-group-label"><span>{group.label}</span></div> : undefined}
+          >
               {group.sessions.map((session) => (
-                <SessionTreeRow
+                <ListItem
                   key={session.id}
-                  session={session}
-                  activeId={props.activeId}
-                  streamingSessionIds={props.streamingSessionIds}
-                  staleSessionIds={props.staleSessionIds}
-                  childSessionsByParentId={props.childSessionsByParentId}
-                  worktreeSessionIds={props.worktreeSessionIds}
-                  onSelectSession={props.onSelectSession}
-                  rowActions={props.rowActions}
+                  isSelected={session.id === props.activeId}
+                  label={
+                    <SessionTreeRow
+                      session={session}
+                      activeId={props.activeId}
+                      streamingSessionIds={props.streamingSessionIds}
+                      staleSessionIds={props.staleSessionIds}
+                      childSessionsByParentId={props.childSessionsByParentId}
+                      worktreeSessionIds={props.worktreeSessionIds}
+                      onSelectSession={props.onSelectSession}
+                      rowActions={props.rowActions}
+                    />
+                  }
                 />
               ))}
-            </div>
-          </div>
+          </List>
         );
       })}
     </>
@@ -315,84 +322,19 @@ interface ProjectGroupSharedProps {
   projectActions?: ProjectRowActions;
 }
 
-function ArchivedProjectGroups(
-  props: ProjectGroupSharedProps & {
-    groups: ReadonlyArray<{
-      key: string;
-      label: string;
-      sessions: SessionSummary[];
-      project?: ProjectRecord;
-    }>;
-  },
-) {
-  const copy = getConversationCopy(useUiLocale()).sessions;
-  const [expanded, setExpanded] = useState(false);
-  return (
-    <div className="maka-list-archived-projects">
-      <BaseButton
-        type="button"
-        className="maka-list-archived-projects-heading"
-        onClick={() => setExpanded((current) => !current)}
-        aria-expanded={expanded}
-        aria-label={copy.archivedProjectsAriaLabel}
-      >
-        <ChevronRight size={13} aria-hidden="true" />
-        <span>{copy.archivedProjects}</span>
-        <span className="maka-list-project-count">{props.groups.length}</span>
-      </BaseButton>
-      {expanded &&
-        props.groups.map((group) => (
-          <ProjectSessionGroup
-            key={group.key}
-            {...props}
-            groupKey={group.key}
-            label={group.label}
-            sessions={group.sessions}
-            project={group.project}
-          />
-        ))}
-    </div>
-  );
-}
-
 function ProjectSessionGroup(props: ProjectGroupSharedProps & {
-  groupKey: string;
   label: string;
   sessions: SessionSummary[];
   project?: ProjectRecord;
 }) {
   const copy = getConversationCopy(useUiLocale()).sessions;
-  const [revealed, setRevealed] = useState(false);
-  const activeSessionId = props.sessions.some((session) => session.id === props.activeId)
-    ? props.activeId
-    : undefined;
-  const [disclosure, setDisclosure] = useState({
-    expanded: props.sessions.length > 0,
-    observedActiveSessionId: activeSessionId,
-  });
-  if (activeSessionId !== disclosure.observedActiveSessionId) {
-    setDisclosure({
-      expanded: activeSessionId ? true : disclosure.expanded,
-      observedActiveSessionId: activeSessionId,
-    });
-  }
-  const expanded = disclosure.expanded;
   const [editing, setEditing] = useState(false);
   const [pendingAction, setPendingAction] = useState<string | null>(null);
   const mountedRef = useMountedRef();
   const pendingActionRef = useRef<string | null>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const escapeCancelledRef = useRef(false);
-  const activeIsHidden = props.activeId
-    ? props.sessions.findIndex((session) => session.id === props.activeId) >= PROJECT_GROUP_PREVIEW_LIMIT
-    : false;
-  const showAll = revealed || activeIsHidden;
-  const visibleSessions = showAll
-    ? props.sessions
-    : props.sessions.slice(0, PROJECT_GROUP_PREVIEW_LIMIT);
-  const hiddenCount = props.sessions.length - visibleSessions.length;
   const project = props.project;
-  const canExpand = props.sessions.length > 0;
 
   useEffect(() => {
     if (!editing) return;
@@ -434,7 +376,6 @@ function ProjectSessionGroup(props: ProjectGroupSharedProps & {
       className="maka-list-group"
       data-variant="project"
       data-unavailable={project && !project.available ? 'true' : undefined}
-      data-expanded={expanded ? 'true' : 'false'}
     >
       <div className="maka-list-project-header">
         {editing ? (
@@ -459,6 +400,9 @@ function ProjectSessionGroup(props: ProjectGroupSharedProps & {
                 commitRename(event.currentTarget.value);
               }}
               onKeyDown={(event) => {
+                if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+                  event.stopPropagation();
+                }
                 if (event.nativeEvent.isComposing || event.key === 'Process') return;
                 if (event.key === 'Escape') {
                   event.preventDefault();
@@ -469,31 +413,14 @@ function ProjectSessionGroup(props: ProjectGroupSharedProps & {
             />
           </form>
         ) : (
-          <BaseButton
-            type="button"
-            className="maka-list-project-heading"
-            onClick={() => {
-              if (canExpand) {
-                setDisclosure((current) => ({
-                  ...current,
-                  expanded: !current.expanded,
-                }));
-              }
-            }}
-            disabled={!canExpand}
-            aria-expanded={canExpand ? expanded : false}
-            aria-controls={canExpand ? `maka-list-group-body-${props.groupKey}` : undefined}
-          >
+          <div className="maka-list-project-heading">
             <FolderOpen size={14} aria-hidden="true" />
             <span className="maka-list-project-name">{props.label}</span>
             {project && !project.available && (
-              <AlertTriangle
-                size={12}
-                aria-label={copy.projectUnavailable}
-              />
+              <AlertTriangle size={12} aria-label={copy.projectUnavailable} />
             )}
             <span className="maka-list-project-count">{props.sessions.length}</span>
-          </BaseButton>
+          </div>
         )}
         {project && props.projectActions && !editing && (
           <DropdownMenu
@@ -560,35 +487,6 @@ function ProjectSessionGroup(props: ProjectGroupSharedProps & {
           </DropdownMenu>
         )}
       </div>
-      {expanded && (
-        <>
-          <div id={`maka-list-group-body-${props.groupKey}`}>
-            {visibleSessions.map((session) => (
-              <SessionTreeRow
-                key={session.id}
-                session={session}
-                activeId={props.activeId}
-                streamingSessionIds={props.streamingSessionIds}
-                staleSessionIds={props.staleSessionIds}
-                childSessionsByParentId={props.childSessionsByParentId}
-                worktreeSessionIds={props.worktreeSessionIds}
-                onSelectSession={props.onSelectSession}
-                rowActions={props.rowActions}
-              />
-            ))}
-          </div>
-          {hiddenCount > 0 && (
-            <BaseButton
-              type="button"
-              className="maka-list-project-more"
-              onClick={() => setRevealed(true)}
-              aria-label={copy.showMoreAriaLabel(hiddenCount)}
-            >
-              {copy.showMore}
-            </BaseButton>
-          )}
-        </>
-      )}
     </div>
   );
 }
@@ -861,6 +759,9 @@ const SessionRow = memo(function SessionRow(props: {
                 commitRename(event.currentTarget.value);
               }}
               onKeyDown={(event) => {
+                if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'Home', 'End'].includes(event.key)) {
+                  event.stopPropagation();
+                }
                 // IME guard so committing CJK characters with Enter doesn't
                 // submit the rename before the user is done.
                 if (event.nativeEvent.isComposing || event.key === 'Process') return;

--- a/packages/ui/src/session-list-panel.tsx
+++ b/packages/ui/src/session-list-panel.tsx
@@ -15,10 +15,17 @@ import { SessionSidebarFooter, SessionSidebarNav, type SidebarUpdateReminder } f
 import { ListTodo } from './icons.js';
 import { useUiLocale } from './locale-context.js';
 import { getConversationCopy } from './conversation-copy.js';
+import { SideNav } from '@astryxdesign/core/SideNav';
 
 export type SessionViewMode = 'conversation' | 'project';
 
 export function SessionListPanel(props: {
+  collapsed?: boolean;
+  onCollapsedChange?(collapsed: boolean): void;
+  width?: number;
+  onWidthChange?(width: number): void;
+  minWidth?: number;
+  maxWidth?: number;
   selection: NavSelection;
   sessions: SessionSummary[];
   activeId?: string;
@@ -42,24 +49,50 @@ export function SessionListPanel(props: {
 }) {
   const copy = getConversationCopy(useUiLocale()).sessions;
   const {
+    collapsed = false,
+    onCollapsedChange = () => {},
+    width = 260,
+    onWidthChange = () => {},
+    minWidth = 180,
+    maxWidth = 480,
     viewMode = 'conversation',
     onViewModeChange,
     groups,
   } = props;
 
   return (
-    <aside
+    <SideNav
       className="maka-session-panel agents-sidebar"
       aria-label={copy.listAriaLabel}
+      collapsible={{
+        isCollapsed: collapsed,
+        onCollapsedChange,
+        hasButton: false,
+      }}
+      resizable={{
+        defaultWidth: width,
+        minWidth,
+        maxWidth,
+        onWidthChange,
+      }}
+      topContent={
+        <SessionSidebarNav
+          selection={props.selection}
+          planReminders={props.planReminders}
+          moduleMemory={props.moduleMemory}
+          onSelect={props.onSelect}
+          onNew={props.onNew}
+        />
+      }
+      footer={
+        <SessionSidebarFooter
+          updateReminder={props.updateReminder}
+          onOpenSettings={props.onOpenSettings}
+          onOpenUpdate={props.onOpenUpdate}
+        />
+      }
     >
-      <SessionSidebarNav
-        selection={props.selection}
-        planReminders={props.planReminders}
-        moduleMemory={props.moduleMemory}
-        onSelect={props.onSelect}
-        onNew={props.onNew}
-      />
-      {onViewModeChange && (
+      {onViewModeChange && !collapsed && (
         <div className="maka-session-list-toolbar">
           <span className="maka-session-list-heading">{copy.title}</span>
           <DropdownMenu
@@ -83,24 +116,21 @@ export function SessionListPanel(props: {
           </DropdownMenu>
         </div>
       )}
-      <SessionHistoryList
-        sessions={props.sessions}
-        activeId={props.activeId}
-        streamingSessionIds={props.streamingSessionIds}
-        staleSessionIds={props.staleSessionIds}
-        groupVariant={viewMode}
-        groups={groups}
-        worktreeSessionIds={props.worktreeSessionIds}
-        projectActions={props.projectActions}
-        childSessionsByParentId={props.childSessionsByParentId}
-        onSelectSession={props.onSelectSession}
-        rowActions={props.rowActions}
-      />
-      <SessionSidebarFooter
-        updateReminder={props.updateReminder}
-        onOpenSettings={props.onOpenSettings}
-        onOpenUpdate={props.onOpenUpdate}
-      />
-    </aside>
+      {!collapsed && (
+        <SessionHistoryList
+          sessions={props.sessions}
+          activeId={props.activeId}
+          streamingSessionIds={props.streamingSessionIds}
+          staleSessionIds={props.staleSessionIds}
+          groupVariant={viewMode}
+          groups={groups}
+          worktreeSessionIds={props.worktreeSessionIds}
+          projectActions={props.projectActions}
+          childSessionsByParentId={props.childSessionsByParentId}
+          onSelectSession={props.onSelectSession}
+          rowActions={props.rowActions}
+        />
+      )}
+    </SideNav>
   );
 }

--- a/packages/ui/src/session-sidebar-nav.tsx
+++ b/packages/ui/src/session-sidebar-nav.tsx
@@ -2,47 +2,10 @@ import type { PlanReminder } from '@maka/core';
 import type { CSSProperties } from 'react';
 import { Blocks, Settings, SquarePen, Timer } from './icons.js';
 import type { NavModuleMemory, NavSelection } from './nav-selection.js';
-import { cn } from './ui.js';
-import { cva } from 'class-variance-authority';
-import { Button as BaseButton } from '@base-ui/react/button';
 import { useUiLocale } from './locale-context.js';
 import { getShellControlsCopy } from './shell-controls-copy.js';
-
-const navRowVariants = cva(
-  [
-    'min-h-[var(--h-control-lg)] gap-2 rounded-sm border-0 bg-transparent px-1.5 py-0.5',
-    'text-left text-sm font-medium text-[var(--foreground-secondary)]',
-    // Glyphs pin to the 80%-ink chrome tone (same as titlebar icon actions)
-    // instead of inheriting: the darwin glass override forces row TEXT to
-    // full foreground, and icons must not follow it.
-    '[&_.maka-nav-icon]:text-[var(--foreground-secondary)]',
-    'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)]',
-    'hover:bg-[var(--state-hover-bg)] hover:text-foreground',
-    'data-[active=true]:bg-[var(--state-selected-bg)] data-[active=true]:font-semibold data-[active=true]:text-foreground data-[active=true]:shadow-none',
-    'data-[active=true]:[&_.maka-nav-icon]:text-foreground',
-    '[&_.maka-nav-count]:bg-[var(--state-hover-bg)] [&_.maka-nav-count]:text-[var(--muted-foreground)]',
-    'data-[active=true]:[&_.maka-nav-count]:bg-[var(--state-selected-bg)] data-[active=true]:[&_.maka-nav-count]:text-foreground',
-    'aria-disabled:cursor-not-allowed aria-disabled:opacity-55 aria-disabled:hover:bg-transparent',
-    'data-[disabled=true]:cursor-not-allowed data-[disabled=true]:opacity-55 data-[disabled=true]:hover:bg-transparent',
-  ],
-  {
-    variants: {
-      tone: {
-        default: '',
-        newTask: 'text-foreground',
-      },
-    },
-    defaultVariants: {
-      tone: 'default',
-    },
-  },
-);
-
-const settingsButtonClass =
-  'w-full min-w-0 gap-2 rounded-sm border-0 bg-transparent px-1.5 py-1.5 ' +
-  'text-left text-sm font-medium text-[var(--foreground-secondary)] ' +
-  'transition-[background-color,color] duration-[var(--duration-base)] ease-[var(--ease-out-strong)] ' +
-  'hover:bg-[var(--state-hover-bg)] hover:text-foreground';
+import { Button } from '@astryxdesign/core/Button';
+import { SideNavItem } from '@astryxdesign/core/SideNav';
 
 export function SessionSidebarNav(props: {
   selection: NavSelection;
@@ -62,45 +25,31 @@ export function SessionSidebarNav(props: {
 
   return (
     <nav className="maka-sidebar-modules" aria-label={copy.mainLabel}>
-      <BaseButton
-        className={cn('maka-nav-row maka-nav-new-task', navRowVariants({ tone: 'newTask' }))}
-        aria-label={copy.newTask}
-        type="button"
+      <SideNavItem
+        className="maka-nav-row maka-nav-new-task"
+        label={copy.newTask}
+        icon={SquarePen}
+        size="md"
         onClick={props.onNew}
-      >
-        <SquarePen className="maka-nav-icon" aria-hidden="true" />
-        <span>{copy.newTask}</span>
-        <kbd className="maka-nav-kbd" aria-hidden="true">
-          ⌘ N
-        </kbd>
-      </BaseButton>
-      <BaseButton
-        className={cn('maka-nav-row', navRowVariants())}
-        data-active={extensionsActive}
-        aria-current={extensionsActive ? 'page' : undefined}
-        aria-label={copy.extensions}
-        type="button"
+        endContent={<kbd className="maka-nav-kbd" aria-hidden="true">⌘ N</kbd>}
+      />
+      <SideNavItem
+        className="maka-nav-row"
+        label={copy.extensions}
+        icon={Blocks}
+        size="md"
+        isSelected={extensionsActive}
         onClick={() => props.onSelect({ section: 'extensions', module: moduleMemory.extensions })}
-      >
-        <Blocks className="maka-nav-icon" aria-hidden="true" />
-        <span>{copy.extensions}</span>
-      </BaseButton>
-      <BaseButton
-        className={cn('maka-nav-row', navRowVariants())}
-        data-active={automationsActive}
-        aria-current={automationsActive ? 'page' : undefined}
-        type="button"
+      />
+      <SideNavItem
+        className="maka-nav-row"
+        label={copy.automations}
+        icon={Timer}
+        size="md"
+        isSelected={automationsActive}
         onClick={() => props.onSelect({ section: 'automations', module: moduleMemory.automations })}
-        aria-label={activePlanReminderCount > 0 ? copy.pendingReminders(activePlanReminderCount) : copy.automations}
-      >
-        <Timer className="maka-nav-icon" aria-hidden="true" />
-        <span>{copy.automations}</span>
-        {activePlanReminderCount > 0 && (
-          <small className="maka-nav-count" aria-hidden="true">
-            {activePlanReminderCount}
-          </small>
-        )}
-      </BaseButton>
+        endContent={activePlanReminderCount > 0 ? <small className="maka-nav-count">{activePlanReminderCount}</small> : undefined}
+      />
     </nav>
   );
 }
@@ -133,30 +82,28 @@ export function SessionSidebarFooter(props: {
         : copy.update;
   return (
     <footer className="maka-session-panel-footer">
-      <BaseButton
-        className={cn('maka-sidebar-settings-button', settingsButtonClass)}
-        type="button"
+      <SideNavItem
+        className="maka-sidebar-settings-button"
+        label={copy.settings}
+        icon={Settings}
+        size="md"
         onClick={props.onOpenSettings}
-        aria-label={copy.settings}
-        title={copy.settings}
-      >
-        <Settings className="maka-nav-icon" aria-hidden="true" />
-        <span>{copy.settings}</span>
-      </BaseButton>
+      />
       {props.updateReminder && props.onOpenUpdate && (
-        <BaseButton
+        <Button
           className="maka-sidebar-update-button"
           data-update-state={props.updateReminder.state}
           style={{ '--maka-update-progress': String(Math.max(0, Math.min(100, props.updateReminder.progressPercent ?? 0)) / 100) } as CSSProperties}
-          type="button"
+          label={updateTitle}
+          size="sm"
+          variant="ghost"
+          width="100%"
           onClick={props.onOpenUpdate}
-          disabled={props.updateReminder.state === 'downloading'}
-          aria-label={updateTitle}
-          title={updateTitle}
+          isDisabled={props.updateReminder.state === 'downloading'}
         >
           {props.updateReminder.state === 'downloading' && <span className="maka-sidebar-update-progress" aria-hidden="true" />}
           <span>{updateLabel}</span>
-        </BaseButton>
+        </Button>
       )}
     </footer>
   );


### PR DESCRIPTION
## Summary

- replace the custom two-column desktop frame and duplicate sidebar resize path with Astryx AppShell and SideNav public composition
- render shell navigation and session history with SideNavItem, List, and TreeList while preserving product routing, session actions, and native rename-input keyboard behavior
- reclassify the workspace workbar with Astryx Toolbar and TabList, and update the real shell Storybook and Electron geometry contracts
- make the existing reminder-menu deferred edit path seed Astryx Dialog focus capture in the same frame, without adding a parallel focus-restoration authority
- leave shared Tabs, Item, Empty, Spinner, and package index authorities unchanged

## Verification

- `npm --workspace @maka/ui test` — 296 passed
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop test` — 2014 passed
- `npm --workspace @maka/desktop run build-storybook`
- `npm --workspace @maka/desktop run smoke:storybook` — 27 story render/play checks passed
- `npm --workspace @maka/desktop run e2e` — 93 passed
- GitHub CI — typecheck, test, E2E, and alignment audit passed

## Review focus

- SideNav owns collapse, scrolling, and the 180–480 px resize boundary; Maka retains only the controlled persisted width and collapsed state.
- TreeList owns project expansion. Active project roots start expanded and the archived-project root starts collapsed; the removed four-item preview path is not retained in parallel.
- The browser workbar tab is omitted while unavailable because Astryx 0.1.9 Tab has no disabled public prop; browser runtime state remains Maka-owned.
- Linux gives the official SideNav and detail surface independent 0–10 px bottom insets; the computed-style contract checks containment and product-sized gaps instead of forcing the removed custom shell geometry.