### PR TITLE
fix(ui): redesign keyboard shortcuts dialog

### DIFF
--- a/apps/desktop/e2e/floating-layers.spec.ts
+++ b/apps/desktop/e2e/floating-layers.spec.ts
@@ -203,7 +203,7 @@ test('model and adjacent thinking Selectors persist one real Electron journey', 
   await expect(modelTrigger).toContainText('claude-e2e-1');
 });
 
-test('keyboard help lets Astryx restore its opener on close', async ({
+test('keyboard help keeps its shortcut grid and lets Astryx restore its opener on close', async ({
   window: page,
 }) => {
   const opener = page.getByRole('button', { name: '搜索对话' });
@@ -212,6 +212,39 @@ test('keyboard help lets Astryx restore its opener on close', async ({
 
   const dialog = page.getByRole('dialog', { name: '键盘快捷键' });
   await expect(dialog).toBeVisible();
+
+  const helpBody = dialog.locator('.maka-help-body');
+  const firstSection = helpBody.locator('.maka-help-section').first();
+  const firstShortcutList = firstSection.locator('dl');
+  await expect(helpBody).toHaveCSS('column-count', '2');
+  await expect(firstShortcutList).toHaveCSS('display', 'grid');
+  await expect(firstShortcutList).toHaveCSS(
+    'grid-template-columns',
+    /\d+(\.\d+)?px \d+(\.\d+)?px/,
+  );
+  await expect(firstSection.locator('dd').first()).toHaveCSS(
+    'justify-self',
+    'end',
+  );
+  await expect(dialog).toHaveCSS('border-radius', '16px');
+  await expect(dialog).not.toHaveCSS('box-shadow', 'none');
+  await expect(firstSection).toHaveCSS('border-radius', '12px');
+  await expect(
+    dialog.getByRole('heading', { name: '键盘快捷键' }),
+  ).toHaveCSS('box-shadow', 'none');
+  await expect(
+    dialog.getByRole('img', { name: /(Command|Control) \+ K/ }),
+  ).toBeVisible();
+  await expect(
+    dialog.getByRole('img', { name: 'Left arrow' }).first(),
+  ).toBeVisible();
+  await expect(
+    dialog.getByRole('img', { name: 'Right arrow' }).first(),
+  ).toBeVisible();
+  await page.setViewportSize({ width: 640, height: 800 });
+  await expect(helpBody).toHaveCSS('column-count', '1');
+  expect((await dialog.boundingBox())?.width).toBeLessThanOrEqual(608);
+
   await page.keyboard.press('Escape');
 
   await expect(dialog).toBeHidden();

--- a/apps/desktop/src/renderer/keyboard-help.tsx
+++ b/apps/desktop/src/renderer/keyboard-help.tsx
@@ -7,11 +7,12 @@
 
 import { useEffect, useState } from 'react';
 import { Keyboard } from '@maka/ui/icons';
-import { Kbd, useUiLocale } from '@maka/ui';
+import { useUiLocale } from '@maka/ui';
 import {
   Dialog,
   DialogHeader,
 } from '@astryxdesign/core/Dialog';
+import { Kbd } from '@astryxdesign/core/Kbd';
 import { Layout, LayoutContent } from '@astryxdesign/core/Layout';
 import { getShellCopy } from './locales/shell-copy';
 
@@ -70,14 +71,15 @@ export function KeyboardHelpModal(props: {
       isOpen={props.isOpen}
       onOpenChange={props.onOpenChange}
       className="maka-help-modal"
-      width={560}
-      maxHeight="calc(100dvh - 96px)"
-      padding={0}
+      width="min(720px, calc(100vw - 32px))"
+      maxHeight="min(760px, calc(100dvh - 64px))"
       purpose="info"
     >
       <Layout
+        height="auto"
         header={
           <DialogHeader
+            className="maka-help-header"
             startContent={<Keyboard aria-hidden="true" />}
             title={copy.title}
             onOpenChange={props.onOpenChange}
@@ -86,30 +88,28 @@ export function KeyboardHelpModal(props: {
         content={
           <LayoutContent padding={0}>
             <div className="maka-help-body">
-          {copy.sections.map((section) => (
-            <section key={section.heading} className="maka-help-section">
-              <h3>{section.heading}</h3>
-              <dl>
-                {section.rows.map((row) => (
-                  <div key={row.description}>
-                    <dt>{row.description}</dt>
-                    <dd>
-                      {row.keys.map((key, index) => (
-                        <span key={`${row.description}:${key}:${index}`}>
-                          {index > 0 && (
-                            <span className="maka-help-plus" aria-hidden="true">
-                              +
-                            </span>
-                          )}
-                          <Kbd>{key}</Kbd>
-                        </span>
-                      ))}
-                    </dd>
-                  </div>
-                ))}
-              </dl>
-            </section>
-          ))}
+              {copy.sections.map((section) => (
+                <section key={section.heading} className="maka-help-section">
+                  <h3>{section.heading}</h3>
+                  <dl>
+                    {section.rows.map((row) => (
+                      <div key={row.description}>
+                        <dt>{row.description}</dt>
+                        <dd>
+                          <span className="maka-help-shortcuts">
+                            {row.shortcuts.map((shortcut) => (
+                              <Kbd
+                                key={`${row.description}:${shortcut}`}
+                                keys={shortcut}
+                              />
+                            ))}
+                          </span>
+                        </dd>
+                      </div>
+                    ))}
+                  </dl>
+                </section>
+              ))}
             </div>
           </LayoutContent>
         }

--- a/apps/desktop/src/renderer/locales/shell-copy.ts
+++ b/apps/desktop/src/renderer/locales/shell-copy.ts
@@ -368,7 +368,7 @@ type ShellCopy = {
     title: string;
     sections: Array<{
       heading: string;
-      rows: Array<{ keys: string[]; description: string }>;
+      rows: Array<{ shortcuts: string[]; description: string }>;
     }>;
   };
   chrome: {
@@ -1011,52 +1011,52 @@ const SHELL_COPY_BY_LOCALE = {
           heading: '通用',
           rows: [
             {
-              keys: ['⌘', 'K'],
+              shortcuts: ['mod+k'],
               description: '打开命令面板（跳会话 / 设置 / 主题等）',
             },
-            { keys: ['?'], description: '打开 / 关闭此快捷键面板' },
-            { keys: ['⌘', 'N'], description: '新建任务' },
-            { keys: ['⌘', ','], description: '打开设置' },
-            { keys: ['Esc'], description: '关闭当前模态框' },
+            { shortcuts: ['?'], description: '打开 / 关闭此快捷键面板' },
+            { shortcuts: ['mod+n'], description: '新建任务' },
+            { shortcuts: ['mod+,'], description: '打开设置' },
+            { shortcuts: ['escape'], description: '关闭当前模态框' },
           ],
         },
         {
           heading: 'Composer 输入',
           rows: [
-            { keys: ['Enter'], description: '发送消息' },
-            { keys: ['Shift', 'Enter'], description: '插入换行' },
-            { keys: ['Alt', 'Enter'], description: '插入换行（备用）' },
+            { shortcuts: ['enter'], description: '发送消息' },
+            { shortcuts: ['shift+enter'], description: '插入换行' },
+            { shortcuts: ['alt+enter'], description: '插入换行（备用）' },
           ],
         },
         {
           heading: '会话列表',
           rows: [
-            { keys: ['Tab'], description: '在会话与导航之间移动焦点' },
-            { keys: ['↑', '↓'], description: '上下移动聚焦的会话' },
-            { keys: ['Home', 'End'], description: '跳到列表顶部 / 底部' },
+            { shortcuts: ['tab'], description: '在会话与导航之间移动焦点' },
+            { shortcuts: ['up', 'down'], description: '上下移动聚焦的会话' },
+            { shortcuts: ['home', 'end'], description: '跳到列表顶部 / 底部' },
             {
-              keys: ['←', '→'],
+              shortcuts: ['left', 'right'],
               description: '在会话 / 已标记 / 已归档之间循环切换',
             },
-            { keys: ['Enter'], description: '打开聚焦的会话' },
-            { keys: ['Delete'], description: '弹出删除确认（永远不静默删除）' },
-            { keys: ['F'], description: '聚焦会话列表搜索框（按 Esc 清空）' },
+            { shortcuts: ['enter'], description: '打开聚焦的会话' },
+            { shortcuts: ['delete'], description: '弹出删除确认（永远不静默删除）' },
+            { shortcuts: ['f'], description: '聚焦会话列表搜索框（按 Esc 清空）' },
           ],
         },
         {
           heading: '聊天区',
           rows: [
-            { keys: ['Tab'], description: '聚焦工具活动 / 复制按钮' },
-            { keys: ['Space', 'Enter'], description: '展开 / 折叠工具调用' },
+            { shortcuts: ['tab'], description: '聚焦工具活动 / 复制按钮' },
+            { shortcuts: ['space', 'enter'], description: '展开 / 折叠工具调用' },
           ],
         },
         {
           heading: '面板调整',
           rows: [
-            { keys: ['Tab'], description: '聚焦左右分割条' },
-            { keys: ['←', '→'], description: '微调会话列表宽度（±10 px）' },
-            { keys: ['Shift', '←', '→'], description: '快速调整（±50 px）' },
-            { keys: ['Home', 'End'], description: '直接拉到最小 / 最大宽度' },
+            { shortcuts: ['tab'], description: '聚焦左右分割条' },
+            { shortcuts: ['left', 'right'], description: '微调会话列表宽度（±10 px）' },
+            { shortcuts: ['shift+left', 'shift+right'], description: '快速调整（±50 px）' },
+            { shortcuts: ['home', 'end'], description: '直接拉到最小 / 最大宽度' },
           ],
         },
       ],
@@ -1499,22 +1499,22 @@ const SHELL_COPY_BY_LOCALE = {
           heading: 'General',
           rows: [
             {
-              keys: ['⌘', 'K'],
+              shortcuts: ['mod+k'],
               description: 'Open the command palette (conversations, Settings, themes, and more)',
             },
-            { keys: ['?'], description: 'Open or close this shortcuts panel' },
-            { keys: ['⌘', 'N'], description: 'Create a new task' },
-            { keys: ['⌘', ','], description: 'Open Settings' },
-            { keys: ['Esc'], description: 'Close the current dialog' },
+            { shortcuts: ['?'], description: 'Open or close this shortcuts panel' },
+            { shortcuts: ['mod+n'], description: 'Create a new task' },
+            { shortcuts: ['mod+,'], description: 'Open Settings' },
+            { shortcuts: ['escape'], description: 'Close the current dialog' },
           ],
         },
         {
           heading: 'Composer',
           rows: [
-            { keys: ['Enter'], description: 'Send the message' },
-            { keys: ['Shift', 'Enter'], description: 'Insert a line break' },
+            { shortcuts: ['enter'], description: 'Send the message' },
+            { shortcuts: ['shift+enter'], description: 'Insert a line break' },
             {
-              keys: ['Alt', 'Enter'],
+              shortcuts: ['alt+enter'],
               description: 'Insert a line break (alternative)',
             },
           ],
@@ -1523,28 +1523,28 @@ const SHELL_COPY_BY_LOCALE = {
           heading: 'Conversation list',
           rows: [
             {
-              keys: ['Tab'],
+              shortcuts: ['tab'],
               description: 'Move focus between conversations and navigation',
             },
             {
-              keys: ['↑', '↓'],
+              shortcuts: ['up', 'down'],
               description: 'Move through focused conversations',
             },
             {
-              keys: ['Home', 'End'],
+              shortcuts: ['home', 'end'],
               description: 'Jump to the top or bottom of the list',
             },
             {
-              keys: ['←', '→'],
+              shortcuts: ['left', 'right'],
               description: 'Cycle through Conversations, Flagged, and Archived',
             },
-            { keys: ['Enter'], description: 'Open the focused conversation' },
+            { shortcuts: ['enter'], description: 'Open the focused conversation' },
             {
-              keys: ['Delete'],
+              shortcuts: ['delete'],
               description: 'Open the delete confirmation (never delete silently)',
             },
             {
-              keys: ['F'],
+              shortcuts: ['f'],
               description: 'Focus conversation search (press Esc to clear)',
             },
           ],
@@ -1553,11 +1553,11 @@ const SHELL_COPY_BY_LOCALE = {
           heading: 'Chat',
           rows: [
             {
-              keys: ['Tab'],
+              shortcuts: ['tab'],
               description: 'Focus tool activity and Copy buttons',
             },
             {
-              keys: ['Space', 'Enter'],
+              shortcuts: ['space', 'enter'],
               description: 'Expand or collapse a tool call',
             },
           ],
@@ -1565,17 +1565,17 @@ const SHELL_COPY_BY_LOCALE = {
         {
           heading: 'Panel sizing',
           rows: [
-            { keys: ['Tab'], description: 'Focus the left or right splitter' },
+            { shortcuts: ['tab'], description: 'Focus the left or right splitter' },
             {
-              keys: ['←', '→'],
+              shortcuts: ['left', 'right'],
               description: 'Adjust conversation-list width (±10 px)',
             },
             {
-              keys: ['Shift', '←', '→'],
+              shortcuts: ['shift+left', 'shift+right'],
               description: 'Adjust quickly (±50 px)',
             },
             {
-              keys: ['Home', 'End'],
+              shortcuts: ['home', 'end'],
               description: 'Jump directly to minimum or maximum width',
             },
           ],

--- a/apps/desktop/src/renderer/styles/help.css
+++ b/apps/desktop/src/renderer/styles/help.css
@@ -1,30 +1,57 @@
 /* ============================================================================
    Help modal
    ----------------------------------------------------------------------------
-   Split out of chat-header.css (#546 PR2, relocate — zero visual change).
-   The keyboard-shortcut help content (`.maka-help-*`) previously lived
-   in chat-header.css. Astryx owns the surrounding dialog surface.       */
+   Astryx owns the dialog and keyboard-key primitives. Maka owns only the
+   product-specific responsive cheat-sheet layout.                       */
+
+.maka-help-modal {
+  overflow: clip;
+  border: 1px solid var(--border-strong);
+  border-radius: calc(var(--radius-modal) + var(--space-1));
+  background: var(--background-elevated);
+  box-shadow:
+    var(--shadow-modal),
+    0 24px 72px -24px oklch(from var(--foreground) l c h / 0.26);
+}
+
+.maka-help-modal::backdrop {
+  background: oklch(from var(--foreground) l c h / 0.3);
+  backdrop-filter: blur(8px) saturate(0.82);
+}
+
+.maka-help-header h2:focus-visible {
+  box-shadow: none;
+}
 
 .maka-help-body {
-  display: grid;
-  gap: var(--space-2-5);
-  padding: var(--space-2) var(--space-3) var(--space-3);
+  columns: 2 280px;
+  column-gap: var(--space-3);
+  padding: var(--space-3);
   overflow-y: auto;
+  background: var(--foreground-3);
+}
+
+.maka-help-section {
+  break-inside: avoid;
+  margin: 0 0 var(--space-3);
+  padding: var(--space-3);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-modal);
+  background: var(--background);
 }
 
 .maka-help-section h3 {
-  margin: 0 0 var(--space-1);
-  color: var(--foreground-secondary);
+  margin: 0 0 var(--space-2);
+  color: var(--foreground);
   font-size: var(--font-size-caption);
   font-weight: var(--font-weight-semibold);
-  letter-spacing: var(--tracking-normal);
-  text-transform: none;
+  letter-spacing: var(--tracking-wide);
 }
 
 .maka-help-section dl {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
-  gap: var(--space-0-5) var(--space-3);
+  gap: var(--space-1-5) var(--space-3);
   margin: 0;
 }
 
@@ -34,7 +61,7 @@
 
 .maka-help-section dt {
   color: var(--foreground-secondary);
-  font-size: var(--font-size-caption);
+  font-size: var(--font-size-ui);
   line-height: var(--leading-normal);
 }
 
@@ -42,17 +69,17 @@
   margin: 0;
   display: inline-flex;
   align-items: center;
-  gap: var(--space-1);
   justify-self: end;
 }
 
-.maka-help-section dd > span {
+.maka-help-shortcuts {
   display: inline-flex;
   align-items: center;
-  gap: var(--space-1);
+  gap: var(--space-1-5);
 }
 
-.maka-help-plus {
-  color: var(--muted-foreground);
-  font-size: var(--font-size-caption);
+@media (max-width: 680px) {
+  .maka-help-body {
+    columns: 1;
+  }
 }


### PR DESCRIPTION
## Summary

Closes #1689.
Refs #1715.

- Redesign the keyboard-shortcuts dialog as a responsive two-column cheat sheet with grouped cards, a clearer elevated surface, and a single-column narrow-window fallback.
- Restore Astryx's default dialog header inset by removing `padding={0}`, while keeping `LayoutContent padding={0}` so the product body layout remains explicitly controlled.
- Replace display-only shortcut glyph arrays with semantic shortcut definitions and Astryx `Kbd`, so Windows renders `Ctrl`, macOS renders `⌘`, and alternative keys are no longer presented as key combinations.
- Remove the non-interactive title's inherited Maka focus shadow without changing Astryx's programmatic heading focus or accessible dialog naming.
- Extend the real Electron test to cover layout, modal elevation and radii, platform-aware shortcuts, narrow-window behavior, and focus restoration.

## Root cause

The modal migration preserved the legacy help-sheet content while moving its shell to Astryx. The help dialog still passed `padding={0}`, which zeroed the layout padding variables consumed by `DialogHeader` and left the icon, title, and close action visually flush against the edge. The old shortcut data also encoded rendered glyphs instead of shortcut semantics, so Windows displayed macOS symbols and alternative keys looked like combinations.

## Screenshot

![Updated keyboard shortcuts dialog](https://raw.githubusercontent.com/sunheyi6/maka-agent/codex/pr-assets-keyboard-help/.github/pr-assets/keyboard-help-dialog.png)

## Verification

- `npx biome check apps/desktop/src/renderer/keyboard-help.tsx apps/desktop/src/renderer/locales/shell-copy.ts apps/desktop/src/renderer/styles/help.css apps/desktop/e2e/floating-layers.spec.ts`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run build:renderer`
- `npx playwright test --config e2e/playwright.config.ts e2e/floating-layers.spec.ts --grep "keyboard help keeps"` — 1 passed in real Electron
- `git diff --check`

<details>
<summary>中文说明</summary>

## 概要

关闭 #1689。
参考 #1715。

- 将键盘快捷键弹窗重新设计为响应式双列速查表，使用分组卡片、更清晰的悬浮表面，并在窄窗口下自动回退为单列。
- 移除 `padding={0}` 以恢复 Astryx 默认的弹窗标题栏内边距，同时保留 `LayoutContent padding={0}`，让产品内容区布局继续由自身明确控制。
- 将仅用于显示的快捷键字符数组替换为语义化快捷键定义和 Astryx `Kbd`，使 Windows 显示 `Ctrl`、macOS 显示 `⌘`，并避免把候选按键错误呈现为组合键。
- 清除非交互标题继承到的 Maka 焦点阴影，同时保留 Astryx 的程序化标题聚焦和无障碍弹窗命名。
- 扩展真实 Electron 测试，覆盖布局、弹窗层级与圆角、平台感知快捷键、窄窗口行为和焦点恢复。

## 根因

弹窗迁移在将外壳切换到 Astryx 时保留了旧版帮助速查表内容。帮助弹窗仍然传入 `padding={0}`，这会把 `DialogHeader` 使用的布局内边距变量清零，导致图标、标题和关闭操作在视觉上紧贴边缘。旧快捷键数据还直接编码了渲染字符而不是快捷键语义，因此 Windows 会显示 macOS 符号，并且候选按键看起来像组合键。

## 截图

![修改后的键盘快捷键弹窗](https://raw.githubusercontent.com/sunheyi6/maka-agent/codex/pr-assets-keyboard-help/.github/pr-assets/keyboard-help-dialog.png)

## 验证

- `npx biome check apps/desktop/src/renderer/keyboard-help.tsx apps/desktop/src/renderer/locales/shell-copy.ts apps/desktop/src/renderer/styles/help.css apps/desktop/e2e/floating-layers.spec.ts`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run build:renderer`
- `npx playwright test --config e2e/playwright.config.ts e2e/floating-layers.spec.ts --grep "keyboard help keeps"` — 在真实 Electron 中 1 项通过
- `git diff --check`

</details>
