### PR TITLE
fix(ui): polish command palette modal chrome

### DIFF
--- a/apps/desktop/e2e/command-palette.spec.ts
+++ b/apps/desktop/e2e/command-palette.spec.ts
@@ -15,9 +15,27 @@ test('command palette follows the Astryx keyboard journey and dismisses', async 
 
   await openPalette();
   await expect(dialog).toBeVisible();
+  await expect(dialog).toHaveClass(/maka-command-palette/);
+  await expect(dialog).toHaveCSS('border-radius', '16px');
+  await expect(dialog).not.toHaveCSS('box-shadow', 'none');
+  const backdrop = await dialog.evaluate((element) => {
+    const style = getComputedStyle(element, '::backdrop');
+    return {
+      backgroundColor: style.backgroundColor,
+      backdropFilter: style.backdropFilter,
+    };
+  });
+  expect(backdrop.backgroundColor).not.toBe('rgba(0, 0, 0, 0)');
+  expect(backdrop.backdropFilter).toContain('blur(8px)');
   const input = dialog.getByRole('combobox', {
     name: '命令面板搜索',
   });
+  await expect(input).toHaveClass(/maka-command-palette-search/);
+  await expect(input).toHaveCSS('appearance', 'none');
+  await expect(input).toHaveCSS('border-style', 'none');
+  await expect(input).toHaveCSS('outline-style', 'none');
+  await expect(input).toHaveCSS('background-color', 'rgba(0, 0, 0, 0)');
+  await expect(input).toHaveCSS('box-shadow', 'none');
   await expect(
     dialog.getByRole('listbox', { name: '命令面板结果' }),
   ).toBeVisible();

--- a/apps/desktop/src/renderer/command-palette.tsx
+++ b/apps/desktop/src/renderer/command-palette.tsx
@@ -148,13 +148,6 @@ export function CommandPalette(props: {
         input={(
           <CommandPaletteInput
             className="maka-command-palette-search"
-            style={{
-              appearance: 'none',
-              border: 0,
-              outline: 0,
-              background: 'transparent',
-              boxShadow: 'none',
-            }}
             placeholder={copy.placeholder}
             label={copy.searchLabel}
           />

--- a/apps/desktop/src/renderer/command-palette.tsx
+++ b/apps/desktop/src/renderer/command-palette.tsx
@@ -138,6 +138,7 @@ export function CommandPalette(props: {
   return (
     <AstryxLocaleProvider overrides={astryxOverrides}>
       <AstryxCommandPalette
+        className="maka-command-palette"
         isOpen={props.isOpen}
         onOpenChange={props.onOpenChange}
         searchSource={searchSource}
@@ -146,6 +147,14 @@ export function CommandPalette(props: {
         maxHeight="min(620px, 68vh)"
         input={(
           <CommandPaletteInput
+            className="maka-command-palette-search"
+            style={{
+              appearance: 'none',
+              border: 0,
+              outline: 0,
+              background: 'transparent',
+              boxShadow: 'none',
+            }}
             placeholder={copy.placeholder}
             label={copy.searchLabel}
           />

--- a/apps/desktop/src/renderer/styles/palette.css
+++ b/apps/desktop/src/renderer/styles/palette.css
@@ -1,6 +1,43 @@
 /* Astryx owns the command palette surface, input, listbox, rows, states, and
  * footer. Maka styles only product content rendered inside those slots. */
 
+/* Match the elevated modal treatment established by the keyboard-shortcuts
+ * dialog. The native Windows titlebar controls are synchronized separately in
+ * theme.ts because a CSS ::backdrop cannot cover Electron's native overlay. */
+.maka-command-palette {
+  overflow: clip;
+  border: 1px solid var(--border-strong);
+  border-radius: calc(var(--radius-modal) + var(--space-1));
+  background: var(--background-elevated);
+  box-shadow:
+    var(--shadow-modal),
+    0 24px 72px -24px oklch(from var(--foreground) l c h / 0.26);
+}
+
+.maka-command-palette::backdrop {
+  background: oklch(from var(--foreground) l c h / 0.3);
+  backdrop-filter: blur(8px) saturate(0.82);
+}
+
+/* The input is auto-focused when the palette opens. Replace the global
+ * element-sized focus box with a quiet full-row cue so the search field does
+ * not look like a second rectangular control nested inside the header. */
+.maka-command-palette .astryx-command-palette-input:focus-within {
+  background: oklch(from var(--focus-ring) l c h / 0.025);
+  box-shadow: inset 0 -1px 0 oklch(from var(--focus-ring) l c h / 0.28);
+}
+
+.maka-command-palette input[role="combobox"],
+.maka-command-palette input[role="combobox"]:focus,
+.maka-command-palette input[role="combobox"]:focus-visible {
+  appearance: none !important;
+  border: 0 !important;
+  border-radius: 0 !important;
+  outline: 0 !important;
+  background: transparent !important;
+  box-shadow: none !important;
+}
+
 .maka-palette-icon {
   display: grid;
   place-items: center;

--- a/apps/desktop/src/renderer/theme.ts
+++ b/apps/desktop/src/renderer/theme.ts
@@ -11,6 +11,8 @@ import { safeLocalStorageSet } from './browser-storage';
 const DARK_CLASS = 'dark';
 
 let unsubscribeMediaQuery: (() => void) | null = null;
+let titleBarOverlayObserver: MutationObserver | null = null;
+let titleBarOverlayFrame: number | null = null;
 
 /**
  * Apply a theme preference to <html>. Returns an unsubscribe function for the
@@ -83,13 +85,15 @@ export function applyThemePalette(palette: ThemePalette): void {
 }
 
 function syncTitleBarOverlay(root: HTMLElement): void {
+  observeModalBackdrops(root);
   // The native Windows overlay sits on top of the renderer's content surface.
   // Sample the actual resolved --background color instead of approximating it
   // with one hard-coded light and dark pair; this also follows every palette.
-  const backgroundColor = cssColorToHex(
+  const baseColor = cssColorToHex(
     getComputedStyle(root).getPropertyValue('--background'),
     root.classList.contains(DARK_CLASS) ? '#1c1d21' : '#ffffff',
   );
+  const backgroundColor = compositeActiveModalBackdrop(baseColor);
   void window.maka?.appWindow
     ?.setTitleBarOverlayTheme?.({
       isDark: root.classList.contains(DARK_CLASS),
@@ -98,19 +102,89 @@ function syncTitleBarOverlay(root: HTMLElement): void {
     .catch(() => {});
 }
 
+/**
+ * Native Windows caption controls live above Chromium, so a dialog's
+ * `::backdrop` cannot dim their titlebar strip. Watch the native dialog open
+ * state and re-sync that strip to the same composited backdrop color.
+ */
+function observeModalBackdrops(root: HTMLElement): void {
+  if (titleBarOverlayObserver || typeof MutationObserver === 'undefined') return;
+
+  titleBarOverlayObserver = new MutationObserver((mutations) => {
+    const modalStateChanged = mutations.some((mutation) => {
+      if (mutation.type === 'attributes') return true;
+      return [...mutation.addedNodes, ...mutation.removedNodes].some(
+        (node) =>
+          node instanceof Element &&
+          (node.matches('dialog[open]') || node.querySelector('dialog[open]')),
+      );
+    });
+    if (!modalStateChanged || titleBarOverlayFrame !== null) return;
+    titleBarOverlayFrame = window.requestAnimationFrame(() => {
+      titleBarOverlayFrame = null;
+      syncTitleBarOverlay(root);
+    });
+  });
+  titleBarOverlayObserver.observe(root, {
+    attributes: true,
+    attributeFilter: ['open'],
+    childList: true,
+    subtree: true,
+  });
+}
+
+function compositeActiveModalBackdrop(baseColor: string): string {
+  const openDialogs = document.querySelectorAll<HTMLDialogElement>('dialog[open]');
+  const activeDialog = openDialogs.item(openDialogs.length - 1);
+  if (!activeDialog) return baseColor;
+
+  const backdropStyle = getComputedStyle(activeDialog, '::backdrop');
+  const backdrop = cssColorToRgba(backdropStyle.backgroundColor);
+  const base = cssColorToRgba(baseColor);
+  if (!backdrop || !base) return baseColor;
+
+  const backdropOpacity = Number.parseFloat(backdropStyle.opacity);
+  const alpha = backdrop.alpha *
+    (Number.isFinite(backdropOpacity) ? backdropOpacity : 1);
+  return rgbaToHex({
+    red: backdrop.red * alpha + base.red * (1 - alpha),
+    green: backdrop.green * alpha + base.green * (1 - alpha),
+    blue: backdrop.blue * alpha + base.blue * (1 - alpha),
+    alpha: 1,
+  });
+}
+
+type RgbaColor = {
+  red: number;
+  green: number;
+  blue: number;
+  alpha: number;
+};
+
 function cssColorToHex(value: string, fallback: string): string {
+  const rgba = cssColorToRgba(value);
+  if (!rgba || rgba.alpha !== 1) return fallback;
+  return rgbaToHex(rgba);
+}
+
+function cssColorToRgba(value: string): RgbaColor | null {
   const color = value.trim();
-  if (!color || !CSS.supports('color', color)) return fallback;
+  if (!color || !CSS.supports('color', color)) return null;
 
   const canvas = document.createElement('canvas');
   canvas.width = 1;
   canvas.height = 1;
   const context = canvas.getContext('2d', { willReadFrequently: true });
-  if (!context) return fallback;
+  if (!context) return null;
 
   context.fillStyle = color;
   context.fillRect(0, 0, 1, 1);
   const [red, green, blue, alpha] = context.getImageData(0, 0, 1, 1).data;
-  if (alpha !== 255) return fallback;
-  return `#${[red, green, blue].map((channel) => channel.toString(16).padStart(2, '0')).join('')}`;
+  return { red, green, blue, alpha: alpha / 255 };
+}
+
+function rgbaToHex(color: RgbaColor): string {
+  return `#${[color.red, color.green, color.blue]
+    .map((channel) => Math.round(channel).toString(16).padStart(2, '0'))
+    .join('')}`;
 }

--- a/apps/desktop/src/renderer/theme.ts
+++ b/apps/desktop/src/renderer/theme.ts
@@ -112,10 +112,14 @@ function observeModalBackdrops(root: HTMLElement): void {
 
   titleBarOverlayObserver = new MutationObserver((mutations) => {
     const modalStateChanged = mutations.some((mutation) => {
-      if (mutation.type === 'attributes') return true;
+      if (mutation.type === 'attributes') {
+        // `<details open>` toggles also land here; only dialogs matter.
+        return mutation.target instanceof Element && mutation.target.nodeName === 'DIALOG';
+      }
       return [...mutation.addedNodes, ...mutation.removedNodes].some(
         (node) =>
           node instanceof Element &&
+          node.nodeName === 'DIALOG' &&
           (node.matches('dialog[open]') || node.querySelector('dialog[open]')),
       );
     });


### PR DESCRIPTION
## Summary

Refs #1735.

- Give the command palette the same elevated modal treatment as the redesigned keyboard-shortcuts dialog: a stronger surface, 16 px radius, deeper shadow, and an 8 px blurred backdrop.
- Remove the nested rectangular chrome around the auto-focused search input while retaining a subtle full-row focus cue.
- Keep the native Windows caption-button strip visually inside the modal backdrop by compositing the active `dialog::backdrop` over the resolved theme surface and reusing the existing titlebar-overlay bridge.
- Extend the command-palette Electron assertions and titlebar source-contract coverage for the new visual and native-overlay behavior.

## Root cause

The command palette still used Astryx's generic dialog treatment while the keyboard-shortcuts dialog had moved to the stronger Maka modal treatment. The globally applied focus ring also painted a second rectangular control around the auto-focused search input. On Windows, Chromium's `::backdrop` cannot cover Electron's native caption controls, so the top-right control strip stayed at the undimmed theme color while the renderer behind the dialog was blurred and darkened.

## Screenshot

![Fixed command palette modal on Windows](https://raw.githubusercontent.com/sunheyi6/maka-agent/agent/pr-assets-command-palette-modal/.github/pr-assets/command-palette-modal.png)

## Verification

- `npx biome check apps/desktop/e2e/command-palette.spec.ts apps/desktop/src/renderer/command-palette.tsx apps/desktop/src/renderer/styles/palette.css apps/desktop/src/renderer/theme.ts apps/desktop/src/main/__tests__/theme-source.test.ts`
- `npm --workspace @maka/desktop run typecheck`
- `npm --workspace @maka/desktop run build:main`
- `node --test apps/desktop/dist/main/__tests__/theme-source.test.js` — 11 passed
- `npm --workspace @maka/desktop run build:renderer`
- `git diff --check`
- Verified the rebuilt renderer in the real Windows Electron window, including the native caption-button backdrop and borderless search input.

The targeted Playwright command-palette run was attempted locally but the harness currently stops while loading `@slack/socket-mode` / `@slack/web-api`, before discovering tests. CI remains the authoritative Electron E2E run.

<details>
<summary>中文说明</summary>

## 概要

- 让命令面板复用键盘快捷键弹窗的高层级视觉：16 px 圆角、更深阴影和 8 px 模糊遮罩。
- 移除自动聚焦搜索框内部多余的矩形边框，同时保留整行的轻量聚焦提示。
- 根据当前 `dialog::backdrop` 与主题背景的实际合成颜色同步 Windows 原生标题栏按钮区域，避免右上角出现未变暗的色块。
- 补充命令面板真实 Electron 断言与标题栏契约测试。

</details>
