### PR TITLE
fix(ui): show project picker only for new chats

### DIFF
--- a/apps/desktop/src/renderer/styles/composer.css
+++ b/apps/desktop/src/renderer/styles/composer.css
@@ -272,7 +272,7 @@
   justify-content: flex-start;
   gap: var(--space-1);
   box-sizing: border-box;
-  margin: var(--space-2) auto 0;
+  margin: 0 auto var(--space-2);
 }
 
 .maka-composer-workspace-picker {

--- a/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
+++ b/packages/ui/src/__tests__/composer-quiet-chrome.test.tsx
@@ -146,4 +146,43 @@ describe('composer quiet chrome', () => {
     const formIdx = markup.indexOf('maka-composer composer');
     assert.ok(dockIdx >= 0 && formIdx > dockIdx);
   });
+
+  /**
+   * The project and branch decide where a NEW chat starts; once a session
+   * exists they no longer move it. Leaving the row on screen in an open chat
+   * reads as "you can still change this session's context here", which is
+   * false — so the same wired picker must render nothing.
+   */
+  it('drops the workspace picker once a session is active', () => {
+    const workspacePicker = {
+      projects: [],
+      onAdd: () => {},
+      onSelectProject: () => {},
+      onRelink: () => {},
+      onSelectNoProject: () => {},
+    };
+    const markup = render(
+      <Composer
+        onSend={() => true}
+        onStop={() => {}}
+        modelLabel="demo"
+        workspacePicker={workspacePicker}
+        activeSession={{
+          id: 'session-1',
+          name: 'Test',
+          isFlagged: false,
+          isArchived: false,
+          labels: [],
+          hasUnread: false,
+          status: 'done',
+          backend: 'fake',
+          llmConnectionSlug: 'fake',
+          connectionLocked: false,
+          model: 'fake',
+          permissionMode: 'ask',
+        }}
+      />,
+    );
+    assert.doesNotMatch(markup, /maka-composer-workspace-dock/);
+  });
 });

--- a/packages/ui/src/composer-workspace-row.tsx
+++ b/packages/ui/src/composer-workspace-row.tsx
@@ -1,6 +1,6 @@
 /**
  * Composer workspace row (issue #1044) — the workspace picker + git branch
- * picker rendered below the composer card. Extracted from `composer.tsx`;
+ * picker rendered above the composer card. Extracted from `composer.tsx`;
  * purely presentational: both pickers are standard compact menu triggers fed
  * by host-injected props. Shared Button owns their visual and interaction
  * states; local classes only constrain layout and label truncation.

--- a/packages/ui/src/composer.tsx
+++ b/packages/ui/src/composer.tsx
@@ -738,7 +738,7 @@ export const Composer = forwardRef<
         </div>
       )}
       {/* New-chat project/branch bar sits above the card (quiet chrome). */}
-      {props.workspacePicker ? (
+      {!props.activeSession && props.workspacePicker ? (
         <div className="maka-composer-workspace-dock" hidden={props.hidden}>
           <ComposerWorkspaceRow workspacePicker={props.workspacePicker} branchPicker={props.branchPicker} />
         </div>


### PR DESCRIPTION
## Summary

- move the project and Git branch pickers above the composer card
- show the picker row only while creating a new chat
- hide the row after a session exists and in all existing chats
- update the project picker contract test to cover placement and visibility

## Why

The project and branch choose where a new chat starts. Keeping those controls below the input made that setup easy to miss, while continuing to show them in existing chats suggested that the active session context could still be changed there.

## Impact

New chats expose project and branch selection directly above the input. Once the first message creates a session, the row disappears. Existing chat behavior and project assignment remain unchanged.

## Validation

- `npm exec biome check -- packages/ui/src/composer.tsx packages/ui/src/composer-workspace-row.tsx apps/desktop/src/main/__tests__/project-context-badge.test.ts`
- `npm --workspace @maka/ui run typecheck`
- `npm --workspace @maka/desktop run build:main`
- `node --test apps/desktop/dist/main/__tests__/project-context-badge.test.js` (9 tests passed)
- `npm --workspace @maka/desktop run build:renderer`
- `git diff --check`

<details>
<summary>中文说明</summary>

## 概要

- 将项目和 Git 分支选择器移到输入框上方
- 仅在创建新对话时显示选择栏
- 会话创建后以及打开任何已有对话时隐藏选择栏
- 更新项目选择器契约测试，覆盖显示位置和可见条件

## 原因

项目和分支决定新对话从哪里开始。原先这些控件位于输入框下方，容易被忽略；在已有对话中继续显示，也容易让用户误以为仍可在这里改变当前会话的上下文。

## 影响

新建对话时，项目和分支选择会直接显示在输入框上方。首条消息创建会话后，选择栏会自动隐藏。已有对话的行为和项目归属保持不变。

## 验证

- `npm exec biome check -- packages/ui/src/composer.tsx packages/ui/src/composer-workspace-row.tsx apps/desktop/src/main/__tests__/project-context-badge.test.ts`
- `npm --workspace @maka/ui run typecheck`
- `npm --workspace @maka/desktop run build:main`
- `node --test apps/desktop/dist/main/__tests__/project-context-badge.test.js`（9 项测试通过）
- `npm --workspace @maka/desktop run build:renderer`
- `git diff --check`

</details>
