### PR TITLE
storage: route Desktop execution stores through SQLite

### DIFF
--- a/apps/desktop/src/main/__tests__/execution-store-wiring.test.ts
+++ b/apps/desktop/src/main/__tests__/execution-store-wiring.test.ts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import { mkdtemp, readFile, rm, stat } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+import type { AgentRunEvent, AgentRunHeader, ShellRunRecord } from '@maka/core';
+import { createAgentRunStore, createShellRunStore } from '@maka/storage';
+import { openDesktopExecutionStoreWiring } from '../execution-store-wiring.js';
+
+test('Desktop cuts legacy execution state over before use and keeps later writes SQLite-only', async () => {
+  const root = await mkdtemp(join(tmpdir(), 'maka-desktop-execution-stores-'));
+  try {
+    const legacyRuns = createAgentRunStore(root);
+    const firstRun = runHeader('run-1', 'turn-1');
+    await legacyRuns.createRun(firstRun);
+    await legacyRuns.appendEvent('session-1', 'run-1', runEvent('event-1', 'run-1', 'turn-1', 1));
+    const legacyRunEventsPath = join(
+      root,
+      'sessions',
+      'session-1',
+      'runs',
+      'run-1',
+      'events.jsonl',
+    );
+    const legacyRunBytes = await readFile(legacyRunEventsPath);
+
+    const legacyShellRuns = createShellRunStore(root);
+    await legacyShellRuns.createShellRun(shellRun('shell-1'));
+    const legacyShellPath = join(
+      root,
+      'sessions',
+      'session-1',
+      'shell-runs',
+      'shell-1',
+      'shell-run.json',
+    );
+    const legacyShellBytes = await readFile(legacyShellPath);
+
+    const wiring = await openDesktopExecutionStoreWiring(root);
+    assert.equal((await wiring.runStore.readRun('session-1', 'run-1')).runId, 'run-1');
+    assert.equal(
+      (await wiring.shellRunStore.readShellRun('session-1', 'shell-1')).shellRunId,
+      'shell-1',
+    );
+
+    await wiring.runStore.appendEvent(
+      'session-1',
+      'run-1',
+      runEvent('event-2', 'run-1', 'turn-1', 2),
+    );
+    await wiring.runStore.createRun(runHeader('run-2', 'turn-2'));
+    await wiring.shellRunStore.updateShellRun('session-1', 'shell-1', {
+      status: 'completed',
+      completedAt: 2,
+      exitCode: 0,
+      updatedAt: 2,
+    });
+    await wiring.shellRunStore.createShellRun(shellRun('shell-2'));
+
+    assert.deepEqual(await readFile(legacyRunEventsPath), legacyRunBytes);
+    assert.deepEqual(await readFile(legacyShellPath), legacyShellBytes);
+    await assert.rejects(
+      () => stat(join(root, 'sessions', 'session-1', 'runs', 'run-2', 'run.json')),
+      { code: 'ENOENT' },
+    );
+    await assert.rejects(
+      () =>
+        stat(
+          join(root, 'sessions', 'session-1', 'shell-runs', 'shell-2', 'shell-run.json'),
+        ),
+      { code: 'ENOENT' },
+    );
+    wiring.close();
+    wiring.close();
+
+    const reopened = await openDesktopExecutionStoreWiring(root);
+    try {
+      assert.deepEqual(
+        (await reopened.runStore.readEvents('session-1', 'run-1')).map((event) => event.id),
+        ['event-1', 'event-2'],
+      );
+      assert.equal((await reopened.runStore.readRun('session-1', 'run-2')).turnId, 'turn-2');
+      assert.equal(
+        (await reopened.shellRunStore.readShellRun('session-1', 'shell-1')).status,
+        'completed',
+      );
+      assert.equal(
+        (await reopened.shellRunStore.readShellRun('session-1', 'shell-2')).status,
+        'running',
+      );
+    } finally {
+      reopened.close();
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+function runHeader(runId: string, turnId: string): AgentRunHeader {
+  return {
+    runId,
+    sessionId: 'session-1',
+    turnId,
+    status: 'created',
+    backendKind: 'fake',
+    llmConnectionSlug: 'fake',
+    modelId: 'fake-model',
+    cwd: '/tmp/cwd',
+    permissionMode: 'ask',
+    createdAt: 1,
+    updatedAt: 1,
+  };
+}
+
+function runEvent(
+  id: string,
+  runId: string,
+  turnId: string,
+  ts: number,
+): AgentRunEvent {
+  return {
+    type: 'run_started',
+    id,
+    runId,
+    sessionId: 'session-1',
+    turnId,
+    ts,
+  };
+}
+
+function shellRun(shellRunId: string): ShellRunRecord {
+  return {
+    shellRunId,
+    sessionId: 'session-1',
+    sourceRunId: 'run-1',
+    sourceTurnId: 'turn-1',
+    sourceToolCallId: `tool-${shellRunId}`,
+    cwd: '/workspace',
+    command: 'printf "ok"',
+    status: 'running',
+    startedAt: 1,
+    updatedAt: 1,
+    revision: 1,
+    output: {
+      mode: 'pipes',
+      stdout: '',
+      stderr: '',
+      stdoutTruncated: false,
+      stderrTruncated: false,
+      redacted: false,
+    },
+  };
+}

--- a/apps/desktop/src/main/app-lifecycle.ts
+++ b/apps/desktop/src/main/app-lifecycle.ts
@@ -33,6 +33,7 @@ import type { createDailyReviewMainService } from './daily-review-main.js';
 import type { createMainAutomationWiring } from './automation-wiring.js';
 import type { createMainGoalWiring } from './goal-wiring.js';
 import type { createMainWindowController } from './main-window.js';
+import type { DesktopExecutionStoreWiring } from './execution-store-wiring.js';
 import type { assembleDesktopTools } from './tool-assembly.js';
 import type { StreamEvents } from './session-stream.js';
 import type { SettingsIpcHandle } from './settings-ipc-main.js';
@@ -71,6 +72,7 @@ export interface AppLifecycleDeps {
   shellRuns: ShellRunProcessManager;
   mcpManager: McpClientManager;
   runtimePersistence: Awaited<ReturnType<typeof openRuntimeEventPersistence>>;
+  executionStoreWiring: DesktopExecutionStoreWiring;
   closeWorkflowStores: () => Promise<void>;
   mainWindowController: ReturnType<typeof createMainWindowController>;
   runtime: SessionManager;
@@ -125,6 +127,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
     shellRuns,
     mcpManager,
     runtimePersistence,
+    executionStoreWiring,
     closeWorkflowStores,
     mainWindowController,
     runtime,
@@ -399,6 +402,7 @@ export function wireAppLifecycle(deps: AppLifecycleDeps): void {
       console.error('[shutdown] cleanup failed:', error);
     }
     runtimePersistence.close();
+    executionStoreWiring.close();
     agentGraphControlStore.close();
     await sessionStore.close?.();
   }

--- a/apps/desktop/src/main/execution-store-wiring.ts
+++ b/apps/desktop/src/main/execution-store-wiring.ts
@@ -1,0 +1,43 @@
+import {
+  createSqliteAgentRunStore,
+  createSqliteShellRunStore,
+} from '@maka/storage';
+
+export interface DesktopExecutionStoreWiring {
+  readonly runStore: ReturnType<typeof createSqliteAgentRunStore>;
+  readonly shellRunStore: ReturnType<typeof createSqliteShellRunStore>;
+  close(): void;
+}
+
+/**
+ * Open the two core execution stores only after their legacy cutovers finish.
+ * Keeping this boundary explicit prevents Desktop services from observing a
+ * partially imported root and gives shutdown one owner for both database
+ * leases.
+ */
+export async function openDesktopExecutionStoreWiring(
+  workspaceRoot: string,
+): Promise<DesktopExecutionStoreWiring> {
+  const runStore = createSqliteAgentRunStore(workspaceRoot);
+  let shellRunStore: ReturnType<typeof createSqliteShellRunStore> | undefined;
+  try {
+    shellRunStore = createSqliteShellRunStore(workspaceRoot);
+    await Promise.all([runStore.ready?.(), shellRunStore.ready()]);
+  } catch (error) {
+    shellRunStore?.close();
+    runStore.close?.();
+    throw error;
+  }
+
+  let closed = false;
+  return Object.freeze({
+    runStore,
+    shellRunStore,
+    close: () => {
+      if (closed) return;
+      closed = true;
+      shellRunStore.close();
+      runStore.close?.();
+    },
+  });
+}

--- a/apps/desktop/src/main/main.ts
+++ b/apps/desktop/src/main/main.ts
@@ -58,7 +58,6 @@ import type {
 } from '@maka/runtime';
 import type { LlmConnection } from '@maka/core/llm-connections';
 import {
-  createAgentRunStore,
   createSqliteArtifactStore,
   createSqliteDeepResearchStore,
   createReadImageSnapshotter,
@@ -71,7 +70,6 @@ import {
   createSessionStore,
   createSettingsStore,
   createMcpConfigStore,
-  createShellRunStore,
   createSqliteTelemetryRepo,
 } from '@maka/storage';
 import { createAgentGraphControlStore } from '@maka/storage/agent-graph-control-store';
@@ -158,6 +156,7 @@ import {
   resolveProjectContextRoot,
 } from './project-context-root.js';
 import { resolveDesktopStorageRoot } from './storage-root-startup.js';
+import { openDesktopExecutionStoreWiring } from './execution-store-wiring.js';
 
 // E2E switches must never fire in a packaged build, and must never run against
 // the real user data: a stray MAKA_E2E on a build/dev machine would otherwise
@@ -267,12 +266,12 @@ const agentGraphControlStore = createAgentGraphControlStore(workspaceRoot);
 const projectCatalog = createProjectCatalog(workspaceRoot);
 const worktreeChildExecutor = createGitWorktreeChildExecutor({ storageRoot: workspaceRoot });
 const planStore = createSqlitePlanStore(workspaceRoot);
-const runStore = createAgentRunStore(workspaceRoot);
+const executionStoreWiring = await openDesktopExecutionStoreWiring(workspaceRoot);
+const { runStore, shellRunStore } = executionStoreWiring;
 const runtimePersistence = await openRuntimeEventPersistence({
   workspaceRoot,
 });
 const runtimeEventStore = runtimePersistence.runtimeEventStore;
-const shellRunStore = createShellRunStore(workspaceRoot);
 const connectionStore = createConnectionStore(workspaceRoot);
 const settingsStore = createSettingsStore(workspaceRoot);
 const mcpConfigStore = createMcpConfigStore(workspaceRoot);
@@ -1414,6 +1413,7 @@ wireAppLifecycle({
   shellRuns,
   mcpManager,
   runtimePersistence,
+  executionStoreWiring,
   closeWorkflowStores,
   mainWindowController,
   runtime,

--- a/packages/storage/src/__tests__/sqlite-core-execution-store.test.ts
+++ b/packages/storage/src/__tests__/sqlite-core-execution-store.test.ts
@@ -180,6 +180,44 @@ describe('SQLite core execution cutover', () => {
     });
   });
 
+  test('fails closed when retired AgentRun or ShellRun writers change cutover evidence', async () => {
+    await withRoot(async (root) => {
+      const legacyRuns = createAgentRunStore(root);
+      await legacyRuns.createRun(runHeader());
+      const legacyShellRuns = createShellRunStore(root);
+      await legacyShellRuns.createShellRun(shellRun());
+
+      const sqliteRuns = createSqliteAgentRunStore(root);
+      const sqliteShellRuns = createSqliteShellRunStore(root);
+      await Promise.all([sqliteRuns.ready?.(), sqliteShellRuns.ready()]);
+      sqliteRuns.close?.();
+      sqliteShellRuns.close();
+
+      await legacyRuns.appendEvent('session-1', 'run-1', runEvent('stale-event', 2));
+      await legacyShellRuns.updateShellRun('session-1', 'shell-1', {
+        status: 'completed',
+        completedAt: 2,
+        exitCode: 0,
+        updatedAt: 2,
+      });
+
+      const rejectedRuns = createSqliteAgentRunStore(root);
+      assert.ok(rejectedRuns.ready);
+      await assert.rejects(
+        rejectedRuns.ready(),
+        /Legacy agent_runs source changed after cutover completed/,
+      );
+      rejectedRuns.close?.();
+
+      const rejectedShellRuns = createSqliteShellRunStore(root);
+      await assert.rejects(
+        rejectedShellRuns.ready(),
+        /Legacy shell_runs source changed after cutover completed/,
+      );
+      rejectedShellRuns.close();
+    });
+  });
+
   test('imports receipts and interactions while new writes stay SQLite-only', async () => {
     await withRoot(async (root) => {
       const receipts = createMessageReceiptStore(root);

--- a/scripts/cu-real-model-launcher.mjs
+++ b/scripts/cu-real-model-launcher.mjs
@@ -15,9 +15,9 @@ import {
   sanitizeCuTrace,
 } from './cu-report-sanitize.mjs';
 import {
-  createAgentRunStore,
   createConnectionStore,
   createFileCredentialStore,
+  createSqliteAgentRunStore,
 } from '../packages/storage/dist/index.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
@@ -556,8 +556,14 @@ async function run() {
       .filter((toolCallId) => typeof toolCallId === 'string');
     const driverTraces = await waitForTraceFlush(tracePath, expectedDispatchToolCallIds);
     const actions = bindActionTargets(rawActions, driverTraces, fixtureIdentity);
-    const runStore = createAgentRunStore(workspace);
-    const runHeader = await waitForRunHeader(runStore, runResult.sessionId, runResult.turnId);
+    const runStore = createSqliteAgentRunStore(workspace);
+    await runStore.ready?.();
+    let runHeader;
+    try {
+      runHeader = await waitForRunHeader(runStore, runResult.sessionId, runResult.turnId);
+    } finally {
+      runStore.close?.();
+    }
     const qualifyingActions = actions.filter(
       (action) =>
         action.success === true &&

--- a/scripts/cu-real-model-launcher.test.mjs
+++ b/scripts/cu-real-model-launcher.test.mjs
@@ -47,7 +47,8 @@ test('real-model launcher owns a synthetic fixture and emits only sanitized evid
   assert.match(launcher, /sanitizeCuReport/);
   assert.match(launcher, /sanitizeCuTrace/);
   assert.match(launcher, /evaluateCuE2eScenarioState/);
-  assert.match(launcher, /createAgentRunStore/);
+  assert.match(launcher, /createSqliteAgentRunStore/);
+  assert.match(launcher, /await runStore\.ready\?\.\(\)/);
   assert.match(launcher, /safeFailureMetadata\(runHeader\.failureMessage\)/);
   assert.doesNotMatch(launcher, /failureMessage:\s*runHeader\.failureMessage/);
   assert.match(launcher, /minimumActionsPassed/);

--- a/scripts/deepseek-live-cost-baseline.mjs
+++ b/scripts/deepseek-live-cost-baseline.mjs
@@ -20,10 +20,10 @@ import {
   validateSynthesisCacheBlockShape,
 } from '../packages/runtime/dist/index.js';
 import {
-  createAgentRunStore,
+  createSqliteAgentRunStore,
   createSqliteArtifactStore,
-  createRuntimeEventStore,
   createSessionStore,
+  openRuntimeEventPersistence,
 } from '../packages/storage/dist/index.js';
 
 const apiKey = process.env.DEEPSEEK_API_KEY;
@@ -49,6 +49,21 @@ const cwd = resolve(process.env.MAKA_COST_BASELINE_CWD ?? repoRoot);
 const contextBudget = buildContextBudgetPolicy();
 const stablePolicyLines = parsePositiveInt(process.env.MAKA_COST_BASELINE_STABLE_POLICY_LINES, 140);
 const payloadLines = parsePositiveInt(process.env.MAKA_COST_BASELINE_PAYLOAD_LINES, 70);
+
+async function openCanonicalExecutionStores(root) {
+  const runStore = createSqliteAgentRunStore(root);
+  try {
+    await runStore.ready?.();
+    const runtimePersistence = await openRuntimeEventPersistence({ workspaceRoot: root });
+    return {
+      runStore,
+      runtimeEventStore: runtimePersistence.runtimeEventStore,
+    };
+  } catch (error) {
+    runStore.close?.();
+    throw error;
+  }
+}
 
 if (process.env.MAKA_COST_BASELINE_PHASE7_TOOL_MATRIX === 'on') {
   const exitCode = await runPhase7ToolMatrix({
@@ -109,8 +124,7 @@ if (
 }
 
 const sessionStore = createSessionStore(workspaceRoot);
-const runStore = createAgentRunStore(workspaceRoot);
-const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
+const { runStore, runtimeEventStore } = await openCanonicalExecutionStores(workspaceRoot);
 const artifactStore = createSqliteArtifactStore(workspaceRoot);
 const backends = new BackendRegistry();
 const llmRecords = [];
@@ -508,8 +522,7 @@ async function runPhase7ToolScenario(input) {
   const workspaceRoot = join(input.matrixOutputRoot, input.mode, 'workspace');
   await mkdir(workspaceRoot, { recursive: true });
   const sessionStore = createSessionStore(workspaceRoot);
-  const runStore = createAgentRunStore(workspaceRoot);
-  const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
+  const { runStore, runtimeEventStore } = await openCanonicalExecutionStores(workspaceRoot);
   const artifactStore = createSqliteArtifactStore(workspaceRoot);
   const backends = new BackendRegistry();
   const llmRecords = [];
@@ -1196,8 +1209,7 @@ async function runPhase10HistoryCompactScenario(input) {
   const workspaceRoot = join(input.matrixOutputRoot, input.mode, 'workspace');
   await mkdir(workspaceRoot, { recursive: true });
   const sessionStore = createSessionStore(workspaceRoot);
-  const runStore = createAgentRunStore(workspaceRoot);
-  const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
+  const { runStore, runtimeEventStore } = await openCanonicalExecutionStores(workspaceRoot);
   const artifactStore = createSqliteArtifactStore(workspaceRoot);
   const backends = new BackendRegistry();
   const llmRecords = [];
@@ -1449,8 +1461,7 @@ async function runPhase8SynthesisScenario(input) {
   const workspaceRoot = join(input.matrixOutputRoot, input.mode, 'workspace');
   await mkdir(workspaceRoot, { recursive: true });
   const sessionStore = createSessionStore(workspaceRoot);
-  const runStore = createAgentRunStore(workspaceRoot);
-  const runtimeEventStore = createRuntimeEventStore(workspaceRoot);
+  const { runStore, runtimeEventStore } = await openCanonicalExecutionStores(workspaceRoot);
   const artifactStore = createSqliteArtifactStore(workspaceRoot);
   const backends = new BackendRegistry();
   const llmRecords = [];


### PR DESCRIPTION
Part of #1649.

## Summary

- open Desktop AgentRun and ShellRun stores through the canonical SQLite implementations and await legacy cutover before use
- give Desktop shutdown one idempotent owner for both SQLite store leases
- move the DeepSeek live-cost harness off the retired AgentRun and RuntimeEvent JSONL writers
- make the real-model CU launcher read AgentRun evidence from SQLite
- fail closed when completed AgentRun or ShellRun cutover evidence changes

## Migration invariants

- legacy AgentRun and ShellRun state is imported before Desktop services can observe the stores
- post-cutover writes do not modify or create legacy JSON/JSONL files
- a changed legacy source after completed cutover is rejected on the next open
- existing runtime-event legacy fallback remains read-only compatibility work for the next cleanup slice

## Verification

- npm --workspace @maka/storage run test:dist
- npm --workspace @maka/desktop run test:dist (2013 tests)
- npm --workspace @maka/storage run typecheck
- npm --workspace @maka/desktop run typecheck
- node --test scripts/cu-real-model-launcher.test.mjs
- node --check scripts/deepseek-live-cost-baseline.mjs
- node --check scripts/cu-real-model-launcher.mjs