### PR TITLE
storage: retire legacy execution writer exports

### DIFF
--- a/apps/desktop/src/main/__tests__/execution-store-wiring.test.ts
+++ b/apps/desktop/src/main/__tests__/execution-store-wiring.test.ts
@@ -4,13 +4,16 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import type { AgentRunEvent, AgentRunHeader, ShellRunRecord } from '@maka/core';
-import { createAgentRunStore, createShellRunStore } from '@maka/storage';
+import {
+  createLegacyAgentRunStoreForTest,
+  createLegacyShellRunStoreForTest,
+} from '@maka/storage/legacy-execution-test-support';
 import { openDesktopExecutionStoreWiring } from '../execution-store-wiring.js';
 
 test('Desktop cuts legacy execution state over before use and keeps later writes SQLite-only', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-desktop-execution-stores-'));
   try {
-    const legacyRuns = createAgentRunStore(root);
+    const legacyRuns = createLegacyAgentRunStoreForTest(root);
     const firstRun = runHeader('run-1', 'turn-1');
     await legacyRuns.createRun(firstRun);
     await legacyRuns.appendEvent('session-1', 'run-1', runEvent('event-1', 'run-1', 'turn-1', 1));
@@ -24,7 +27,7 @@ test('Desktop cuts legacy execution state over before use and keeps later writes
     );
     const legacyRunBytes = await readFile(legacyRunEventsPath);
 
-    const legacyShellRuns = createShellRunStore(root);
+    const legacyShellRuns = createLegacyShellRunStoreForTest(root);
     await legacyShellRuns.createShellRun(shellRun('shell-1'));
     const legacyShellPath = join(
       root,

--- a/packages/cli/src/__tests__/inspect-command.test.ts
+++ b/packages/cli/src/__tests__/inspect-command.test.ts
@@ -5,7 +5,11 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { AgentRunHeader } from '@maka/core';
 import { createInMemoryTaskRunStore, runTaskOnce } from '@maka/headless';
-import { createAgentRunStore, createRuntimeEventStore, createSessionStore } from '@maka/storage';
+import { createSessionStore } from '@maka/storage';
+import {
+  createLegacyAgentRunStoreForTest,
+  createLegacyRuntimeEventStoreForTest,
+} from '@maka/storage/legacy-execution-test-support';
 import {
   openHeadlessExecutionStoresForWrite,
   openInteractiveExecutionStoresForWrite,
@@ -241,8 +245,8 @@ describe('inspect CLI storage authority boundary', () => {
 
 type InspectCommandTestStores = {
   sessionStore: ReturnType<typeof createSessionStore>;
-  agentRunStore: ReturnType<typeof createAgentRunStore>;
-  runtimeEventStore: ReturnType<typeof createRuntimeEventStore>;
+  agentRunStore: ReturnType<typeof createLegacyAgentRunStoreForTest>;
+  runtimeEventStore: ReturnType<typeof createLegacyRuntimeEventStoreForTest>;
   taskRunStore: ReturnType<typeof createInMemoryTaskRunStore>;
 };
 
@@ -283,8 +287,8 @@ async function withStores(run: (stores: InspectCommandTestStores) => Promise<voi
   try {
     await run({
       sessionStore: createSessionStore(root),
-      agentRunStore: createAgentRunStore(root),
-      runtimeEventStore: createRuntimeEventStore(root),
+      agentRunStore: createLegacyAgentRunStoreForTest(root),
+      runtimeEventStore: createLegacyRuntimeEventStoreForTest(root),
       taskRunStore: createInMemoryTaskRunStore(),
     });
   } finally {

--- a/packages/headless/src/__tests__/task-run-inspect.test.ts
+++ b/packages/headless/src/__tests__/task-run-inspect.test.ts
@@ -5,7 +5,10 @@ import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { AgentRunEvent, AgentRunHeader, RuntimeEvent } from '@maka/core';
 import { buildHistoryCompactCheckpoint } from '@maka/runtime';
-import { createAgentRunStore, createRuntimeEventStore } from '@maka/storage';
+import {
+  createLegacyAgentRunStoreForTest,
+  createLegacyRuntimeEventStoreForTest,
+} from '@maka/storage/legacy-execution-test-support';
 import type { HeavyTaskSemanticSelfCheckState, TaskEvent } from '../task-contracts.js';
 import { taskAttemptExecutionEvidence } from '../task-execution-lineage.js';
 import { createInMemoryTaskRunStore } from '../task-run-store.js';
@@ -350,16 +353,16 @@ const TURN_ID = 'turn-1';
 async function withStores(
   run: (stores: {
     taskRunStore: ReturnType<typeof createInMemoryTaskRunStore>;
-    agentRunStore: ReturnType<typeof createAgentRunStore>;
-    runtimeEventStore: ReturnType<typeof createRuntimeEventStore>;
+    agentRunStore: ReturnType<typeof createLegacyAgentRunStoreForTest>;
+    runtimeEventStore: ReturnType<typeof createLegacyRuntimeEventStoreForTest>;
   }) => Promise<void>,
 ): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), 'maka-task-run-inspect-'));
   try {
     await run({
       taskRunStore: createInMemoryTaskRunStore(),
-      agentRunStore: createAgentRunStore(root),
-      runtimeEventStore: createRuntimeEventStore(root),
+      agentRunStore: createLegacyAgentRunStoreForTest(root),
+      runtimeEventStore: createLegacyRuntimeEventStoreForTest(root),
     });
   } finally {
     await rm(root, { recursive: true, force: true });

--- a/packages/runtime-host/src/__tests__/root-admission-owner.test.ts
+++ b/packages/runtime-host/src/__tests__/root-admission-owner.test.ts
@@ -4,11 +4,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import {
-  createAgentRunStore,
   type RootTurnAdmission,
   type RootTurnAdmissionStore,
   type RootTurnSourceMessage,
 } from '@maka/storage';
+import { createLegacyAgentRunStoreForTest } from '@maka/storage/legacy-execution-test-support';
 import { RootAdmissionOwner } from '../server/root-admission-owner.js';
 import { SessionAdmissionGate } from '../server/session-admission-gate.js';
 
@@ -379,11 +379,11 @@ function mutableAdmission(): RootTurnAdmission {
 }
 
 async function withStore(
-  run: (store: ReturnType<typeof createAgentRunStore>) => Promise<void>,
+  run: (store: ReturnType<typeof createLegacyAgentRunStoreForTest>) => Promise<void>,
 ): Promise<void> {
   const root = await mkdtemp(join(tmpdir(), 'maka-root-admission-owner-'));
   try {
-    await run(createAgentRunStore(root));
+    await run(createLegacyAgentRunStoreForTest(root));
   } finally {
     await rm(root, { recursive: true, force: true });
   }

--- a/packages/runtime/src/__tests__/agent-run-steering-recovery.test.ts
+++ b/packages/runtime/src/__tests__/agent-run-steering-recovery.test.ts
@@ -5,11 +5,11 @@ import assert from 'node:assert/strict';
 import { test } from 'node:test';
 import type { AgentRunHeader, RuntimeEvent } from '@maka/core';
 import type { SessionEvent } from '@maka/core/events';
+import { createLegacyFileSessionStore } from '@maka/storage';
 import {
-  createAgentRunStore,
-  createLegacyFileSessionStore,
-  createRuntimeEventStore,
-} from '@maka/storage';
+  createLegacyAgentRunStoreForTest,
+  createLegacyRuntimeEventStoreForTest,
+} from '@maka/storage/legacy-execution-test-support';
 import { AgentRun } from '../agent-run.js';
 import { buildStatusPatch } from '../session-projection-helpers.js';
 
@@ -24,7 +24,7 @@ test('does not re-append atomically committed tool facts through the generic eve
       model: 'fake-model',
       permissionMode: 'ask',
     });
-    const runtimeEventStore = createRuntimeEventStore(root);
+    const runtimeEventStore = createLegacyRuntimeEventStoreForTest(root);
     const runId = 'run-atomic-tool';
     const turnId = 'turn-atomic-tool';
     const run = new AgentRun({
@@ -99,8 +99,8 @@ test('acks a steering event whose canonical append preceded proof publication fa
       model: 'fake-model',
       permissionMode: 'ask',
     });
-    const runStore = createAgentRunStore(root);
-    const runtimeEventStore = createRuntimeEventStore(root);
+    const runStore = createLegacyAgentRunStoreForTest(root);
+    const runtimeEventStore = createLegacyRuntimeEventStoreForTest(root);
     const runId = 'run-1';
     const turnId = 'turn-1';
     await runStore.createRun(makeRunHeader(session.id, runId, turnId));
@@ -154,7 +154,7 @@ test('acks a steering event whose canonical append preceded proof publication fa
 
     await chmod(proofDirectory, 0o700);
     await rm(proofDirectory, { recursive: true });
-    const recovered = createRuntimeEventStore(root);
+    const recovered = createLegacyRuntimeEventStoreForTest(root);
     await recovered.repairImmutableSteeringMessageProofsForRecovery(session.id);
     assert.deepEqual(await recovered.readImmutableRuntimeEvents(session.id, runId), [runtimeEvent]);
     assert.deepEqual(
@@ -177,8 +177,8 @@ test('awaits canonical Run status persistence before accepting an interaction re
       model: 'fake-model',
       permissionMode: 'ask',
     });
-    const runStore = createAgentRunStore(root);
-    const runtimeEventStore = createRuntimeEventStore(root);
+    const runStore = createLegacyAgentRunStoreForTest(root);
+    const runtimeEventStore = createLegacyRuntimeEventStoreForTest(root);
     const runId = 'run-status-barrier';
     const turnId = 'turn-status-barrier';
     await store.updateHeader(session.id, buildStatusPatch('waiting_for_user', 1));
@@ -257,8 +257,8 @@ test('required interaction resume recovers a failed best-effort Run Store latch 
       model: 'fake-model',
       permissionMode: 'ask',
     });
-    const runStore = createAgentRunStore(root);
-    const runtimeEventStore = createRuntimeEventStore(root);
+    const runStore = createLegacyAgentRunStoreForTest(root);
+    const runtimeEventStore = createLegacyRuntimeEventStoreForTest(root);
     const runId = 'run-status-latch';
     const turnId = 'turn-status-latch';
     await store.updateHeader(session.id, buildStatusPatch('waiting_for_user', 1));
@@ -372,8 +372,8 @@ test('required interaction resume stays fail-closed until a later required write
       model: 'fake-model',
       permissionMode: 'ask',
     });
-    const runStore = createAgentRunStore(root);
-    const runtimeEventStore = createRuntimeEventStore(root);
+    const runStore = createLegacyAgentRunStoreForTest(root);
+    const runtimeEventStore = createLegacyRuntimeEventStoreForTest(root);
     const runId = 'run-status-latch-failure';
     const turnId = 'turn-status-latch-failure';
     await store.updateHeader(session.id, buildStatusPatch('waiting_for_user', 1));

--- a/packages/runtime/src/__tests__/context-diagnostics.test.ts
+++ b/packages/runtime/src/__tests__/context-diagnostics.test.ts
@@ -4,7 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import type { AgentRunEvent, AgentRunHeader, AgentRunStore } from '@maka/core';
-import { createAgentRunStore } from '@maka/storage';
+import { createLegacyAgentRunStoreForTest } from '@maka/storage/legacy-execution-test-support';
 import { readLatestContextDiagnostics } from '../context-diagnostics.js';
 
 test('reads the latest completed provider request instead of a later failed attempt', async () => {
@@ -159,7 +159,7 @@ test('reports the latest history compaction that preceded the displayed request'
 test('reads the same diagnostics after reopening the durable run ledger', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-context-diagnostics-'));
   try {
-    const writer = createAgentRunStore(root);
+    const writer = createLegacyAgentRunStoreForTest(root);
     const header = runHeader('run-1', 1);
     await writer.createRun(header);
     await writer.appendEvent(
@@ -168,7 +168,10 @@ test('reads the same diagnostics after reopening the durable run ledger', async 
       attemptEvent('run-1', 'attempt-1', 10, 'completed', 'model', 40, 200),
     );
 
-    const diagnostics = await readLatestContextDiagnostics(createAgentRunStore(root), 'session-1');
+    const diagnostics = await readLatestContextDiagnostics(
+      createLegacyAgentRunStoreForTest(root),
+      'session-1',
+    );
 
     assert.equal(diagnostics.status, 'available');
     if (diagnostics.status !== 'available') return;

--- a/packages/runtime/src/__tests__/conversation-copy.test.ts
+++ b/packages/runtime/src/__tests__/conversation-copy.test.ts
@@ -15,12 +15,11 @@ import {
   decodeCanonicalToolResultContent,
   isSessionInlineRun,
 } from '@maka/core';
+import { createSqliteAgentRunStore, createSqliteRuntimeStore } from '@maka/storage';
 import {
-  createAgentRunStore,
-  createRuntimeEventStore,
-  createSqliteAgentRunStore,
-  createSqliteRuntimeStore,
-} from '@maka/storage';
+  createLegacyAgentRunStoreForTest,
+  createLegacyRuntimeEventStoreForTest,
+} from '@maka/storage/legacy-execution-test-support';
 import {
   archivedToolResultContainsConversationOwnedReferences,
   cloneConversationRuntimeLedger,
@@ -412,8 +411,8 @@ test('conversation copy turn closure includes legacy children but excludes later
 test('conversation copy rejects a retained AgentRun without RuntimeEvent facts', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-conversation-missing-runtime-copy-'));
   try {
-    const runStore = createAgentRunStore(root);
-    const runtimeEventStore = createRuntimeEventStore(root);
+    const runStore = createLegacyAgentRunStoreForTest(root);
+    const runtimeEventStore = createLegacyRuntimeEventStoreForTest(root);
     const rootRun = agentRunHeader({
       runId: 'run-root',
       invocationId: 'invocation-root',
@@ -693,8 +692,8 @@ test('conversation copy rewrites a complete tool recovery bundle atomically', as
 test('conversation copy validates operational events before persisting target ledgers', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-conversation-copy-preflight-'));
   try {
-    const runStore = createAgentRunStore(root);
-    const runtimeEventStore = createRuntimeEventStore(root);
+    const runStore = createLegacyAgentRunStoreForTest(root);
+    const runtimeEventStore = createLegacyRuntimeEventStoreForTest(root);
     await runStore.createRun(
       agentRunHeader({
         runId: 'run-source',
@@ -763,8 +762,8 @@ test('conversation copy validates operational events before persisting target le
 test('conversation copy clones one terminal Runtime ledger with new owned identities', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-conversation-runtime-copy-'));
   try {
-    const runStore = createAgentRunStore(root);
-    const runtimeEventStore = createRuntimeEventStore(root);
+    const runStore = createLegacyAgentRunStoreForTest(root);
+    const runtimeEventStore = createLegacyRuntimeEventStoreForTest(root);
     const sourceRun: AgentRunHeader = {
       runId: 'run-source',
       invocationId: 'invocation-source',
@@ -1130,8 +1129,8 @@ test('conversation copy clones one terminal Runtime ledger with new owned identi
 test('conversation copy rebuilds an inline checkpoint without legacy child events in its prefix', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-conversation-checkpoint-copy-'));
   try {
-    const runStore = createAgentRunStore(root);
-    const runtimeEventStore = createRuntimeEventStore(root);
+    const runStore = createLegacyAgentRunStoreForTest(root);
+    const runtimeEventStore = createLegacyRuntimeEventStoreForTest(root);
     const firstRun = agentRunHeader({
       runId: 'run-1',
       invocationId: 'invocation-1',
@@ -1306,8 +1305,8 @@ test('conversation copy rebuilds an inline checkpoint without legacy child event
 test('conversation copy rebuilds a resumed child checkpoint over its child run chain', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-conversation-child-checkpoint-copy-'));
   try {
-    const runStore = createAgentRunStore(root);
-    const runtimeEventStore = createRuntimeEventStore(root);
+    const runStore = createLegacyAgentRunStoreForTest(root);
+    const runtimeEventStore = createLegacyRuntimeEventStoreForTest(root);
     const rootRun = agentRunHeader({
       runId: 'run-root',
       invocationId: 'invocation-root',

--- a/packages/runtime/src/__tests__/execution-inspect.test.ts
+++ b/packages/runtime/src/__tests__/execution-inspect.test.ts
@@ -4,7 +4,11 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { describe, test } from 'node:test';
 import type { AgentRunEvent, AgentRunHeader, RuntimeEvent } from '@maka/core';
-import { createAgentRunStore, createRuntimeEventStore, createSessionStore } from '@maka/storage';
+import { createSessionStore } from '@maka/storage';
+import {
+  createLegacyAgentRunStoreForTest,
+  createLegacyRuntimeEventStoreForTest,
+} from '@maka/storage/legacy-execution-test-support';
 import {
   AGENT_RUN_INSPECT_DOCUMENT_VERSION,
   SESSION_INSPECT_DOCUMENT_VERSION,
@@ -18,8 +22,8 @@ describe('versioned execution inspect documents', () => {
   test('reports unknown tool outcomes without copying Runtime payloads', async () => {
     await withWorkspace(async (root) => {
       const sessionStore = createSessionStore(root);
-      const runStore = createAgentRunStore(root);
-      const runtimeStore = createRuntimeEventStore(root);
+      const runStore = createLegacyAgentRunStoreForTest(root);
+      const runtimeStore = createLegacyRuntimeEventStoreForTest(root);
       const session = await sessionStore.create({
         cwd: '/tmp/workspace',
         backend: 'fake',
@@ -86,8 +90,8 @@ describe('versioned execution inspect documents', () => {
   test('projects a Session as bounded AgentRun documents without reading messages', async () => {
     await withWorkspace(async (root) => {
       const sessionStore = createSessionStore(root);
-      const runStore = createAgentRunStore(root);
-      const runtimeStore = createRuntimeEventStore(root);
+      const runStore = createLegacyAgentRunStoreForTest(root);
+      const runtimeStore = createLegacyRuntimeEventStoreForTest(root);
       const session = await sessionStore.create({
         cwd: '/tmp/workspace',
         name: 'Inspectable session',

--- a/packages/runtime/src/__tests__/runtime-continuation-crash.test.ts
+++ b/packages/runtime/src/__tests__/runtime-continuation-crash.test.ts
@@ -8,7 +8,8 @@ import { fileURLToPath } from 'node:url';
 import { describe, test } from 'node:test';
 
 import type { AgentRunHeader, RuntimeEvent } from '@maka/core';
-import { createAgentRunStore, createSessionStore, createSqliteRuntimeStore } from '@maka/storage';
+import { createSessionStore, createSqliteRuntimeStore } from '@maka/storage';
+import { createLegacyAgentRunStoreForTest } from '@maka/storage/legacy-execution-test-support';
 
 import { type RuntimeContinuationFailpoint } from '../agent-run.js';
 import { BackendRegistry, SessionManager } from '../session-manager.js';
@@ -37,7 +38,7 @@ if (process.env[CRASH_CHILD_ENV] === '1') {
           await crashContinuationAt(workspaceRoot, failpoint);
 
           const store = createSessionStore(workspaceRoot);
-          const runStore = createAgentRunStore(workspaceRoot);
+          const runStore = createLegacyAgentRunStoreForTest(workspaceRoot);
           const runtimeEventStore = createCrashRuntimeStore(workspaceRoot);
           const [session] = await store.list();
           assert.ok(session, `${failpoint} did not persist a session`);
@@ -122,7 +123,7 @@ async function runCrashChild(): Promise<void> {
     'MAKA_RUNTIME_CONTINUATION_FAILPOINT',
   ) as RuntimeContinuationFailpoint;
   const store = createSessionStore(workspaceRoot);
-  const runStore = createAgentRunStore(workspaceRoot);
+  const runStore = createLegacyAgentRunStoreForTest(workspaceRoot);
   const runtimeEventStore = createCrashRuntimeStore(workspaceRoot);
   const backends = new BackendRegistry();
   backends.register(
@@ -215,7 +216,7 @@ function createManager(workspaceRoot: string): {
   sessionStore: ReturnType<typeof createSessionStore>;
 } {
   const store = createSessionStore(workspaceRoot);
-  const runStore = createAgentRunStore(workspaceRoot);
+  const runStore = createLegacyAgentRunStoreForTest(workspaceRoot);
   const runtimeEventStore = createCrashRuntimeStore(workspaceRoot);
   const backends = new BackendRegistry();
   backends.register(

--- a/packages/runtime/src/__tests__/runtime-read-model-persisted-compat.test.ts
+++ b/packages/runtime/src/__tests__/runtime-read-model-persisted-compat.test.ts
@@ -4,7 +4,10 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { test } from 'node:test';
 import type { AgentRunHeader } from '@maka/core';
-import { createAgentRunStore, createRuntimeEventStore } from '@maka/storage';
+import {
+  createLegacyAgentRunStoreForTest,
+  createLegacyRuntimeEventStoreForTest,
+} from '@maka/storage/legacy-execution-test-support';
 import { RuntimeReadModel } from '../runtime-read-model.js';
 import { isHardRuntimeEventReadModelDiagnostic } from '../runtime-event-read-model.js';
 
@@ -36,14 +39,14 @@ const header: AgentRunHeader = {
 test('reopens a persisted legacy subagent RuntimeEvent without rewriting it', async () => {
   const root = await mkdtemp(join(tmpdir(), 'maka-runtime-persisted-compat-'));
   try {
-    await createAgentRunStore(root).createRun(header);
+    await createLegacyAgentRunStoreForTest(root).createRun(header);
     const ledgerPath = join(root, 'sessions', sessionId, 'runs', runId, 'runtime-events.jsonl');
     await copyFile(fixtureUrl, ledgerPath);
     const originalBytes = await readFile(ledgerPath);
 
     const view = await new RuntimeReadModel({
-      runStore: createAgentRunStore(root),
-      runtimeEventStore: createRuntimeEventStore(root),
+      runStore: createLegacyAgentRunStoreForTest(root),
+      runtimeEventStore: createLegacyRuntimeEventStoreForTest(root),
     }).getSessionView(sessionId);
 
     const persistedResponse = view.events.find(

--- a/packages/runtime/src/__tests__/runtime-resume-crash.test.ts
+++ b/packages/runtime/src/__tests__/runtime-resume-crash.test.ts
@@ -8,7 +8,10 @@ import { spawn } from 'node:child_process';
 import { describe, test } from 'node:test';
 
 import type { RuntimeEvent } from '@maka/core/runtime-event';
-import { createAgentRunStore, createRuntimeEventStore } from '@maka/storage';
+import {
+  createLegacyAgentRunStoreForTest,
+  createLegacyRuntimeEventStoreForTest,
+} from '@maka/storage/legacy-execution-test-support';
 
 import {
   RUNTIME_RESUME_FAILPOINTS,
@@ -41,7 +44,7 @@ if (process.env[CRASH_CHILD_ENV] === '1') {
           // Production creates the run header before any RuntimeEvent append. Keep the
           // crash boundary focused on the child event writer while preserving the
           // storage identity contract used when the ledger is reopened.
-          await createAgentRunStore(workspaceRoot).createRun({
+          await createLegacyAgentRunStoreForTest(workspaceRoot).createRun({
             runId,
             invocationId: `invocation-${runId}`,
             sessionId,
@@ -69,7 +72,7 @@ if (process.env[CRASH_CHILD_ENV] === '1') {
             false,
             `${failpoint.id} unexpectedly ran finally`,
           );
-          const reopened = createRuntimeEventStore(workspaceRoot);
+          const reopened = createLegacyRuntimeEventStoreForTest(workspaceRoot);
           const recoveredEvents = await reopened.readRuntimeEvents(sessionId, runId);
           assert.deepEqual(
             recoveredEvents.map((event) => event.id),
@@ -102,7 +105,7 @@ async function runCrashChild(): Promise<void> {
   const events = JSON.parse(
     Buffer.from(requiredEnv('MAKA_RUNTIME_RESUME_EVENTS'), 'base64').toString('utf8'),
   ) as RuntimeEvent[];
-  const store = createRuntimeEventStore(workspaceRoot);
+  const store = createLegacyRuntimeEventStoreForTest(workspaceRoot);
 
   try {
     for (const event of events) {

--- a/packages/runtime/src/__tests__/sandbox-boundary-restart-recovery.test.ts
+++ b/packages/runtime/src/__tests__/sandbox-boundary-restart-recovery.test.ts
@@ -11,21 +11,23 @@ import type {
   StoredMessage,
 } from '@maka/core';
 import {
-  createAgentRunStore,
-  createRuntimeEventStore,
   createSessionStore,
   type DurableAgentRunStore,
   type DurableRuntimeEventStore,
   type SessionAuthorityStore,
 } from '@maka/storage';
+import {
+  createLegacyAgentRunStoreForTest,
+  createLegacyRuntimeEventStoreForTest,
+} from '@maka/storage/legacy-execution-test-support';
 import { BackendRegistry, SessionManager } from '../session-manager.js';
 
 /**
- * Restart behaviour against the real durable stores the desktop host uses:
- * SQLite session metadata plus the JSONL agent-run ledger. Memory stores can
- * model the shapes but not the ordering that makes this bug reachable — the
- * request row commits before its RuntimeEvent, and a recovery pass can die
- * between settling the row and committing the run's terminal fact.
+ * Restart behaviour against the retired JSONL execution stores retained for
+ * compatibility coverage. Memory stores can model the shapes but not the
+ * ordering that makes this bug reachable — the request row commits before its
+ * RuntimeEvent, and a recovery pass can die between settling the row and
+ * committing the run's terminal fact.
  */
 describe('sandbox boundary restart recovery on durable stores', () => {
   it('attributes a closure whose RuntimeEvent never reached the ledger', async () => {
@@ -162,8 +164,8 @@ async function withStores<T>(
   body: (stores: DurableStores) => Promise<T>,
 ): Promise<T> {
   const sessions = createSessionStore(root);
-  const runs = createAgentRunStore(root);
-  const runtimeEvents = createRuntimeEventStore(root);
+  const runs = createLegacyAgentRunStoreForTest(root);
+  const runtimeEvents = createLegacyRuntimeEventStoreForTest(root);
   try {
     return await body({ sessions, runs, runtimeEvents });
   } finally {

--- a/packages/runtime/src/__tests__/shell-run-manager.test.ts
+++ b/packages/runtime/src/__tests__/shell-run-manager.test.ts
@@ -9,7 +9,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { after, describe, test, type TestContext } from 'node:test';
 import type { ShellRunRecord, ShellRunStore, ShellRunUpdate, ToolResultContent } from '@maka/core';
-import { createShellRunStore } from '@maka/storage';
+import { createLegacyShellRunStoreForTest } from '@maka/storage/legacy-execution-test-support';
 
 import { ShellRunProcessManager } from '../shell-run-manager.js';
 import { defaultShellPlan, type ShellPlan } from '../shell-detect.js';
@@ -27,7 +27,7 @@ after(async () => {
 describe('ShellRunProcessManager', () => {
   test('keeps the default pipe path separated, durable, redacted, and observed', async () => {
     const cwd = await workspace();
-    const store = createShellRunStore(cwd);
+    const store = createLegacyShellRunStoreForTest(cwd);
     const manager = createManager(store);
     const result = await manager.runForegroundBash(
       shellInput({
@@ -98,7 +98,7 @@ describe('ShellRunProcessManager', () => {
 
   test('keeps foreground execution bounded and rejects PTY promotion', async () => {
     const cwd = await workspace();
-    const store = createShellRunStore(await workspace());
+    const store = createLegacyShellRunStoreForTest(await workspace());
     const manager = createManager(store);
     const abort = new AbortController();
     const running = manager.runForegroundBash(
@@ -132,7 +132,7 @@ describe('ShellRunProcessManager', () => {
 
   test('hands off a long pipe command without output and publishes monotonic revisions', async () => {
     const updates: ShellRunUpdate[] = [];
-    const store = createShellRunStore(await workspace());
+    const store = createLegacyShellRunStoreForTest(await workspace());
     const manager = createManager(store, (update) => updates.push(update));
     const initial = await manager.runBackgroundBash(
       shellInput({
@@ -175,7 +175,7 @@ describe('ShellRunProcessManager', () => {
   });
 
   test('notifies resource owners when foreground and background commands reach terminal state', async () => {
-    const store = createShellRunStore(await workspace());
+    const store = createLegacyShellRunStoreForTest(await workspace());
     const manager = createManager(store);
     const completions: boolean[] = [];
     await manager.runForegroundBash(
@@ -253,7 +253,7 @@ describe('ShellRunProcessManager', () => {
   test('commits a durable starting identity before the native pipe process spawns', async () => {
     const cwd = await workspace();
     const marker = join(cwd, 'spawned');
-    const backingStore = createShellRunStore(cwd);
+    const backingStore = createLegacyShellRunStoreForTest(cwd);
     const createCommitted = deferred<void>();
     const releaseCreate = deferred<void>();
     const store: ShellRunStore = {
@@ -306,7 +306,7 @@ describe('ShellRunProcessManager', () => {
     for (const lifecycle of ['session', 'runtime'] as const) {
       const cwd = await workspace();
       const marker = join(cwd, `${lifecycle}-spawned`);
-      const backingStore = createShellRunStore(cwd);
+      const backingStore = createLegacyShellRunStoreForTest(cwd);
       const createCommitted = deferred<void>();
       const releaseCreate = deferred<void>();
       const store: ShellRunStore = {
@@ -367,7 +367,7 @@ describe('ShellRunProcessManager', () => {
 
   test('rechecks the session fence after the durable running commit', async () => {
     const cwd = await workspace();
-    const backingStore = createShellRunStore(cwd);
+    const backingStore = createLegacyShellRunStoreForTest(cwd);
     const runningCommitted = deferred<void>();
     const releaseRunning = deferred<void>();
     const store: ShellRunStore = {
@@ -905,7 +905,7 @@ describe('ShellRunProcessManager', () => {
   });
 
   test('recovers durable starting and running records without live handles as orphaned', async () => {
-    const store = createShellRunStore(await workspace());
+    const store = createLegacyShellRunStoreForTest(await workspace());
     await store.createShellRun(record({ shellRunId: 'orphan-starting', status: 'starting' }));
     await store.createShellRun(record({ shellRunId: 'orphan-running', status: 'running' }));
     await store.createShellRun({
@@ -932,7 +932,7 @@ describe('ShellRunProcessManager', () => {
   });
 
   test('concurrent orphan observers converge on the same durable terminal record', async () => {
-    const backingStore = createShellRunStore(await workspace());
+    const backingStore = createLegacyShellRunStoreForTest(await workspace());
     await backingStore.createShellRun(
       record({ shellRunId: 'concurrent-orphan', status: 'running' }),
     );
@@ -972,7 +972,7 @@ describe('ShellRunProcessManager', () => {
   });
 
   test('keeps unauthorized refs non-disclosing and rejects malformed selectors before storage', async () => {
-    const store = createShellRunStore(await workspace());
+    const store = createLegacyShellRunStoreForTest(await workspace());
     await store.createShellRun({
       ...record({ shellRunId: 'owned-by-another-session', status: 'running' }),
       sessionId: 'session-2',
@@ -1275,7 +1275,7 @@ describe('ShellRunProcessManager', () => {
 
   test('keeps concurrent PTY control and Read persistence in parser-cut order', async () => {
     const updates: ShellRunUpdate[] = [];
-    const store = createShellRunStore(await workspace());
+    const store = createLegacyShellRunStoreForTest(await workspace());
     const manager = createManager(store, (update) => updates.push(update));
     const initial = await manager.runBackgroundBash(
       shellInput({
@@ -1348,7 +1348,7 @@ describe('ShellRunProcessManager', () => {
     const dsrSeen = join(cwd, 'dsr-seen');
     const exitGate = join(cwd, 'exit-gate');
     const sizeBeforeExit = join(cwd, 'size-before-exit');
-    const store = createShellRunStore(await workspace());
+    const store = createLegacyShellRunStoreForTest(await workspace());
     const manager = createManager(store);
     const initial = await manager.runBackgroundBash(
       shellInput({
@@ -1495,7 +1495,7 @@ describe('ShellRunProcessManager', () => {
   test('restores the trailing PTY flush after a queued control aborts before commit', async () => {
     const cwd = await workspace();
     const dirtyWritten = join(cwd, 'dirty-written');
-    const store = createShellRunStore(await workspace());
+    const store = createLegacyShellRunStoreForTest(await workspace());
     const manager = createManager(store, undefined, { flushIntervalMs: 1_000 });
     const initial = await manager.runBackgroundBash(
       shellInput({
@@ -1993,7 +1993,7 @@ describe('ShellRunProcessManager', () => {
     const storageRoot = await workspace();
     const sessionsPath = join(storageRoot, 'sessions');
     await writeFile(sessionsPath, 'blocks durable ShellRun creation', 'utf8');
-    const store = createShellRunStore(storageRoot);
+    const store = createLegacyShellRunStoreForTest(storageRoot);
     const manager = createManager(store, undefined, { maxLiveShellRuns: 2, maxLivePtyRuns: 1 });
     try {
       await assert.rejects(() =>
@@ -2141,7 +2141,11 @@ async function createTestManager(
     pipeOutputDrainMs?: number;
   },
 ): Promise<ShellRunProcessManager> {
-  return createManager(createShellRunStore(await workspace()), onShellRunUpdate, options);
+  return createManager(
+    createLegacyShellRunStoreForTest(await workspace()),
+    onShellRunUpdate,
+    options,
+  );
 }
 
 function shellInput(input: {

--- a/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
+++ b/packages/runtime/src/__tests__/stream-graph-coordinator.test.ts
@@ -6,12 +6,14 @@ import { describe, test } from 'node:test';
 import { randomUUID } from 'node:crypto';
 import { z } from 'zod';
 import {
-  createAgentRunStore,
-  createRuntimeEventStore,
   createSessionStore,
   createSqliteSessionMetadataStore,
   SQLITE_SESSION_METADATA_DATABASE_NAME,
 } from '@maka/storage';
+import {
+  createLegacyAgentRunStoreForTest,
+  createLegacyRuntimeEventStoreForTest,
+} from '@maka/storage/legacy-execution-test-support';
 import { FakeBackend } from '../fake-backend.js';
 import { BackendRegistry, SessionManager } from '../session-manager.js';
 import { SessionActivityRegistry } from '../goal-turn-lifecycle.js';
@@ -28,8 +30,8 @@ describe('host-managed agent graph coordinator', () => {
   test('boots an empty graph from agent work and recovers it without duplicate topology', async () => {
     const root = await mkdtemp(join(tmpdir(), 'maka-graph-coordinator-'));
     const sessionStore = createSessionStore(root);
-    const runStore = createAgentRunStore(root);
-    const runtimeEventStore = createRuntimeEventStore(root);
+    const runStore = createLegacyAgentRunStoreForTest(root);
+    const runtimeEventStore = createLegacyRuntimeEventStoreForTest(root);
     let graphRuntimeHistoryReads = 0;
     const countedRuntimeEventStore = new Proxy(runtimeEventStore, {
       get(target, property) {
@@ -570,8 +572,8 @@ describe('host-managed agent graph coordinator', () => {
 
 function createCoordinator(input: {
   sessionStore: ReturnType<typeof createSessionStore>;
-  runStore: ReturnType<typeof createAgentRunStore>;
-  runtimeEventStore: ReturnType<typeof createRuntimeEventStore>;
+  runStore: ReturnType<typeof createLegacyAgentRunStoreForTest>;
+  runtimeEventStore: ReturnType<typeof createLegacyRuntimeEventStoreForTest>;
   controlStore: ReturnType<typeof createSqliteSessionMetadataStore>;
   manager: SessionManager;
   onReconciliation?: AgentGraphCoordinatorInput['onReconciliation'];

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -12,6 +12,7 @@
     "./execution-stores": "./dist/execution-stores.js",
     "./agent-graph-control-store": "./dist/agent-graph-control-store.js",
     "./interaction-store": "./dist/interaction-store.js",
+    "./legacy-execution-test-support": "./dist/legacy-execution-test-support.js",
     "./memory-bundle-store": "./dist/memory-bundle-store.js",
     "./root-authority": "./dist/root-authority.js",
     "./runtime-policy-stores": "./dist/runtime-policy-stores.js",

--- a/packages/storage/src/__tests__/legacy-execution-public-surface.test.ts
+++ b/packages/storage/src/__tests__/legacy-execution-public-surface.test.ts
@@ -1,0 +1,20 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+import * as publicStorage from '../index.js';
+import * as legacyTestSupport from '../legacy-execution-test-support.js';
+
+test('retired execution file writers are absent from the production storage entrypoint', () => {
+  assert.equal('createAgentRunStore' in publicStorage, false);
+  assert.equal('createRuntimeEventStore' in publicStorage, false);
+  assert.equal('createShellRunStore' in publicStorage, false);
+  assert.equal(typeof publicStorage.createSqliteAgentRunStore, 'function');
+  assert.equal(typeof publicStorage.createSqliteShellRunStore, 'function');
+});
+
+test('legacy execution writers are isolated behind explicit test support names', () => {
+  assert.deepEqual(Object.keys(legacyTestSupport).sort(), [
+    'createLegacyAgentRunStoreForTest',
+    'createLegacyRuntimeEventStoreForTest',
+    'createLegacyShellRunStoreForTest',
+  ]);
+});

--- a/packages/storage/src/__tests__/runtime-event-transfer.test.ts
+++ b/packages/storage/src/__tests__/runtime-event-transfer.test.ts
@@ -336,6 +336,7 @@ describe('runtime event JSONL compatibility transfer', () => {
           ),
           ['event-1'],
         );
+        assert.equal('appendRuntimeEvent' in legacyReader.runtimeEventStore, false);
       } finally {
         legacyReader.close();
       }
@@ -361,14 +362,7 @@ describe('runtime event JSONL compatibility transfer', () => {
           ),
           ['event-1', 'event-2'],
         );
-        await assert.rejects(
-          sqliteReader.runtimeEventStore.appendRuntimeEvent(
-            'session-1',
-            'run-1',
-            runtimeEvent('read-only-write', { ts: 3 }),
-          ),
-          /read-?only|readonly/u,
-        );
+        assert.equal('appendRuntimeEvent' in sqliteReader.runtimeEventStore, false);
       } finally {
         sqliteReader.close();
       }

--- a/packages/storage/src/index.ts
+++ b/packages/storage/src/index.ts
@@ -3,8 +3,32 @@ export * from './session-transcript.js';
 export * from './sqlite-session-metadata-store.js';
 export * from './session-metadata-transfer.js';
 export * from './session-metadata-maintenance.js';
-export * from './agent-run-store.js';
-export * from './shell-run-store.js';
+export {
+  ROOT_TURN_ADMISSION_MAX_CONTENT_BYTES,
+  ROOT_TURN_ADMISSION_MAX_RECORD_BYTES,
+  ROOT_TURN_ADMISSION_MAX_SOURCE_MESSAGES,
+  ROOT_TURN_ADMISSION_SCHEMA_VERSION,
+  createSqliteAgentRunStore,
+  normalizeRootTurnAdmissionPayload,
+} from './agent-run-store.js';
+export type {
+  AdmitRootTurnInput,
+  AdmitRootTurnResult,
+  ConversationCopyRuntimeEventBatch,
+  DurableAgentRunStore,
+  DurableRuntimeEventStore,
+  ImmutableSteeringMessageProof,
+  RootTurnAdmission,
+  RootTurnAdmissionStore,
+  RootTurnSourceMessage,
+  RootTurnSourceMessageReceipt,
+  SqliteAgentRunStoreOptions,
+} from './agent-run-store.js';
+export { createSqliteShellRunStore } from './shell-run-store.js';
+export type {
+  ClosableShellRunStore,
+  SqliteShellRunStoreOptions,
+} from './shell-run-store.js';
 export * from './connection-store.js';
 // Narrow public surface: only the typed store + the one-time migration. The
 // file lock and atomic writer stay internal so callers can't bypass the

--- a/packages/storage/src/legacy-execution-test-support.ts
+++ b/packages/storage/src/legacy-execution-test-support.ts
@@ -1,0 +1,13 @@
+/**
+ * Test-only constructors for seeding and exercising retired execution files.
+ *
+ * Production callers must use the canonical SQLite factories from
+ * `@maka/storage`. Keeping these behind an explicit subpath prevents an
+ * accidental root import from reviving a JSON/JSONL writer while preserving
+ * legacy import and compatibility coverage.
+ */
+export {
+  createAgentRunStore as createLegacyAgentRunStoreForTest,
+  createRuntimeEventStore as createLegacyRuntimeEventStoreForTest,
+} from './agent-run-store.js';
+export { createShellRunStore as createLegacyShellRunStoreForTest } from './shell-run-store.js';

--- a/packages/storage/src/runtime-event-transfer.ts
+++ b/packages/storage/src/runtime-event-transfer.ts
@@ -1,7 +1,7 @@
 import { readFile, readdir, stat } from 'node:fs/promises';
 import { join } from 'node:path';
-import { decodePersistedRuntimeEvent, type RuntimeEvent, type RuntimeEventStore } from '@maka/core';
-import { createRuntimeEventStore, type DurableRuntimeEventStore } from './agent-run-store.js';
+import { decodePersistedRuntimeEvent, type RuntimeEvent } from '@maka/core';
+import { createRuntimeEventStore } from './agent-run-store.js';
 import { classifyJsonRecord } from './json-prefix.js';
 import type { SqliteRuntimeStore } from './sqlite-runtime-store.js';
 import { createSqliteRuntimeStore } from './sqlite-runtime-store.js';
@@ -23,9 +23,19 @@ export type RuntimeEventPersistence = {
 
 export type RuntimeEventReadPersistence = {
   kind: 'jsonl' | 'sqlite';
-  runtimeEventStore: DurableRuntimeEventStore;
+  runtimeEventStore: RuntimeEventReadStore;
   close(): void;
 };
+
+export interface RuntimeEventExportSource {
+  readRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
+  readImmutableRuntimeEvents?(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
+}
+
+export interface RuntimeEventReadStore extends RuntimeEventExportSource {
+  readImmutableRuntimeEvents(sessionId: string, runId: string): Promise<RuntimeEvent[]>;
+  readSessionRuntimeEvents(sessionId: string): Promise<RuntimeEvent[]>;
+}
 
 export interface RuntimeEventImportReport {
   eventsRead: number;
@@ -75,14 +85,14 @@ export async function openRuntimeEventReadPersistence(input: {
   if (!(await pathExists(databasePath))) {
     return {
       kind: 'jsonl',
-      runtimeEventStore: createRuntimeEventStore(input.workspaceRoot),
+      runtimeEventStore: asRuntimeEventReader(createRuntimeEventStore(input.workspaceRoot)),
       close: () => {},
     };
   }
   const store = createSqliteRuntimeStore(databasePath, { readOnly: true });
   return {
     kind: 'sqlite',
-    runtimeEventStore: store,
+    runtimeEventStore: asRuntimeEventReader(store),
     close: () => store.close(),
   };
 }
@@ -98,7 +108,7 @@ async function pathExists(path: string): Promise<boolean> {
 }
 
 export async function exportRuntimeEventsToJsonl(
-  source: RuntimeEventStore,
+  source: RuntimeEventExportSource,
   sessionId: string,
   runId: string,
 ): Promise<string> {
@@ -106,6 +116,16 @@ export async function exportRuntimeEventsToJsonl(
     ? await source.readImmutableRuntimeEvents(sessionId, runId)
     : await source.readRuntimeEvents(sessionId, runId);
   return events.length === 0 ? '' : `${events.map((event) => JSON.stringify(event)).join('\n')}\n`;
+}
+
+function asRuntimeEventReader(store: RuntimeEventReadStore): RuntimeEventReadStore {
+  return Object.freeze({
+    readRuntimeEvents: (sessionId: string, runId: string) =>
+      store.readRuntimeEvents(sessionId, runId),
+    readImmutableRuntimeEvents: (sessionId: string, runId: string) =>
+      store.readImmutableRuntimeEvents(sessionId, runId),
+    readSessionRuntimeEvents: (sessionId: string) => store.readSessionRuntimeEvents(sessionId),
+  });
 }
 
 export async function importRuntimeEventsFromJsonl(input: {


### PR DESCRIPTION
Part of #1649.

## Summary

- remove the retired AgentRun, RuntimeEvent, and ShellRun file-writer constructors from the production @maka/storage entrypoint
- isolate legacy writer construction behind an explicitly named test-support subpath for import and compatibility fixtures
- expose RuntimeEvent compatibility readers through a frozen read-only facade for both legacy JSONL and SQLite
- update cross-package compatibility tests to use the explicit legacy fixture boundary

## Invariants

- production imports cannot obtain createAgentRunStore, createRuntimeEventStore, or createShellRunStore from @maka/storage
- legacy codecs and file implementations remain internal so existing state can still be imported and compatibility-tested
- RuntimeEvent readers do not expose appendRuntimeEvent, even when backed by a read-only SQLite connection
- no production source imports the legacy test-support subpath

## Verification

- npm run build:test
- npm run typecheck
- npm run lint
- npm run format:check
- full @maka/storage test suite
- 84/84 affected @maka/runtime tests with test concurrency 1
- 5/5 affected @maka/headless tests with test concurrency 1
- focused CLI, Desktop, Runtime Host, RuntimeEvent transfer, and public-surface tests