### PR TITLE
fix(desktop): allow clipboard writes in trusted renderer

### DIFF
--- a/apps/desktop/src/main/__tests__/main-window-permission-policy.test.ts
+++ b/apps/desktop/src/main/__tests__/main-window-permission-policy.test.ts
@@ -9,7 +9,7 @@ import {
 } from '../main-window-permission-policy.js';
 
 describe('main window Chromium permission policy', () => {
-  it('allows only top-level microphone audio from the product renderer', () => {
+  it('allows top-level microphone audio and clipboard writes from the product renderer', () => {
     assert.equal(allowsMainWindowPermissionCheck({
       ownerMatches: true,
       rendererUrlMatches: true,
@@ -24,6 +24,20 @@ describe('main window Chromium permission policy', () => {
       isMainFrame: true,
       mediaTypes: ['audio'],
     }), true);
+    for (const permission of ['clipboard-sanitized-write', 'clipboard-write']) {
+      assert.equal(allowsMainWindowPermissionCheck({
+        ownerMatches: true,
+        rendererUrlMatches: true,
+        permission,
+        isMainFrame: true,
+      }), true);
+      assert.equal(allowsMainWindowPermissionRequest({
+        ownerMatches: true,
+        rendererUrlMatches: true,
+        permission,
+        isMainFrame: true,
+      }), true);
+    }
   });
 
   it('denies camera, mixed media, subframes, auxiliary windows, and unrelated permissions', () => {
@@ -72,6 +86,49 @@ describe('main window Chromium permission policy', () => {
       ownerMatches: true,
       rendererUrlMatches: true,
       permission: 'media',
+      isMainFrame: true,
+    }), false);
+  });
+
+  it('keeps clipboard writes gated to the trusted top-level renderer frame', () => {
+    // Wrong frame.
+    assert.equal(allowsMainWindowPermissionCheck({
+      ownerMatches: true,
+      rendererUrlMatches: true,
+      permission: 'clipboard-sanitized-write',
+      isMainFrame: false,
+    }), false);
+    assert.equal(allowsMainWindowPermissionRequest({
+      ownerMatches: true,
+      rendererUrlMatches: true,
+      permission: 'clipboard-sanitized-write',
+      isMainFrame: false,
+    }), false);
+    // Not our window.
+    assert.equal(allowsMainWindowPermissionRequest({
+      ownerMatches: false,
+      rendererUrlMatches: true,
+      permission: 'clipboard-write',
+      isMainFrame: true,
+    }), false);
+    // Untrusted URL.
+    assert.equal(allowsMainWindowPermissionRequest({
+      ownerMatches: true,
+      rendererUrlMatches: false,
+      permission: 'clipboard-write',
+      isMainFrame: true,
+    }), false);
+    // Reading from the clipboard stays denied.
+    assert.equal(allowsMainWindowPermissionCheck({
+      ownerMatches: true,
+      rendererUrlMatches: true,
+      permission: 'clipboard-read',
+      isMainFrame: true,
+    }), false);
+    assert.equal(allowsMainWindowPermissionRequest({
+      ownerMatches: true,
+      rendererUrlMatches: true,
+      permission: 'clipboard-read',
       isMainFrame: true,
     }), false);
   });
@@ -144,6 +201,10 @@ describe('main window Chromium permission policy', () => {
       mediaType: 'audio',
       requestingUrl: 'file:///Applications/Maka.app/index.html',
     }), false);
+    assert.equal(checkHandler(owner, 'clipboard-sanitized-write', 'file://', {
+      isMainFrame: true,
+      requestingUrl: 'file:///Applications/Maka.app/index.html',
+    }), true);
 
     let granted: boolean | undefined;
     requestHandler(owner, 'media', (next) => {
@@ -154,5 +215,14 @@ describe('main window Chromium permission policy', () => {
       requestingUrl: 'file:///Applications/Maka.app/index.html',
     });
     assert.equal(granted, true);
+
+    let clipboardGranted: boolean | undefined;
+    requestHandler(owner, 'clipboard-sanitized-write', (next) => {
+      clipboardGranted = next;
+    }, {
+      isMainFrame: true,
+      requestingUrl: 'file:///Applications/Maka.app/index.html',
+    });
+    assert.equal(clipboardGranted, true);
   });
 });

--- a/apps/desktop/src/main/main-window-permission-policy.ts
+++ b/apps/desktop/src/main/main-window-permission-policy.ts
@@ -17,30 +17,37 @@ export interface MainWindowPermissionRequest {
 }
 
 /**
- * The product renderer only needs one Chromium permission: microphone audio
- * for the local Voice capture check. Keep this policy explicit because
- * Electron otherwise leaves a session's permission behavior to permissive
- * defaults, and the default session is also shared by auxiliary windows.
+ * The product renderer needs exactly two Chromium permissions:
+ * - microphone audio for the local Voice capture check;
+ * - clipboard writes so the code-block / message / settings copy buttons
+ *   (`navigator.clipboard.writeText`) can reach the OS clipboard.
+ *
+ * Keep this policy explicit because Electron otherwise leaves a session's
+ * permission behavior to permissive defaults, and the default session is also
+ * shared by auxiliary windows. Clipboard write is granted only when
+ * `navigator.clipboard.writeText` asks for it (Chromium reports the sanitized
+ * text path as `clipboard-sanitized-write`; the unsanitized name is accepted
+ * too so the exact version never regresses copy).
  */
-export function allowsMainWindowPermissionCheck(input: MainWindowPermissionCheck): boolean {
+function isAllowedPermission(permission: string): boolean {
   return (
-    input.ownerMatches
-    && input.rendererUrlMatches
-    && input.isMainFrame
-    && input.permission === 'media'
-    && input.mediaType === 'audio'
+    permission === 'clipboard-sanitized-write'
+    || permission === 'clipboard-write'
   );
 }
 
+export function allowsMainWindowPermissionCheck(input: MainWindowPermissionCheck): boolean {
+  if (!(input.ownerMatches && input.rendererUrlMatches && input.isMainFrame)) return false;
+  if (input.permission === 'media') return input.mediaType === 'audio';
+  return isAllowedPermission(input.permission);
+}
+
 export function allowsMainWindowPermissionRequest(input: MainWindowPermissionRequest): boolean {
-  return (
-    input.ownerMatches
-    && input.rendererUrlMatches
-    && input.isMainFrame
-    && input.permission === 'media'
-    && input.mediaTypes?.length === 1
-    && input.mediaTypes[0] === 'audio'
-  );
+  if (!(input.ownerMatches && input.rendererUrlMatches && input.isMainFrame)) return false;
+  if (input.permission === 'media') {
+    return input.mediaTypes?.length === 1 && input.mediaTypes[0] === 'audio';
+  }
+  return isAllowedPermission(input.permission);
 }
 
 /**


### PR DESCRIPTION
## What changed

- allow `clipboard-sanitized-write` and `clipboard-write` for the trusted top-level product renderer
- keep clipboard reads, subframes, auxiliary windows, and untrusted renderer URLs denied
- cover both Electron permission check and request handlers with focused tests

## Why

Copy buttons use `navigator.clipboard.writeText`, but the explicit Electron session permission policy only admitted microphone audio. Chromium therefore denied the clipboard-write path before it could reach the OS clipboard.

## Impact

Code-block, message, and settings copy actions can write text to the system clipboard without broadening access to clipboard reads or untrusted frames.

## Validation

- `npm --workspace @maka/desktop run build:main`
- `node --test apps/desktop/dist/main/__tests__/main-window-permission-policy.test.js`
- `git diff --check`

---

## 中文说明

### 修改内容

- 允许可信顶层产品渲染进程申请 `clipboard-sanitized-write` 和 `clipboard-write`
- 继续拒绝剪贴板读取、子框架、辅助窗口和不可信渲染地址
- 为 Electron 权限检查与权限请求处理器补充针对性测试

### 修改原因

代码块、消息和设置页面的复制按钮通过 `navigator.clipboard.writeText` 写入系统剪贴板，但现有 Electron 会话权限策略只允许麦克风音频，导致 Chromium 在写入操作到达系统剪贴板之前便拒绝了剪贴板写入权限。

### 影响

复制按钮现在可以正常把文本写入系统剪贴板，同时不会扩大到剪贴板读取权限，也不会向子框架或不可信窗口开放权限。

### 验证

- `npm --workspace @maka/desktop run build:main`
- `node --test apps/desktop/dist/main/__tests__/main-window-permission-policy.test.js`
- `git diff --check`
