### PR TITLE
fix(ui): hide redundant chat disclosure chevrons

### DIFF
--- a/apps/desktop/src/renderer/styles/base.css
+++ b/apps/desktop/src/renderer/styles/base.css
@@ -2,6 +2,14 @@
   body {
     margin: 0;
   }
+  /* Chat disclosures already pair their full-row trigger with a semantic
+     activity icon and aria-expanded. Astryx's trailing chevron lands at the
+     far edge of the reading column, where repeated rows look like a stray
+     vertical control rail. Keep the disclosure interaction and semantics,
+     but suppress that redundant decorative indicator on chat rows only. */
+  .maka-chat-disclosure > button > span:last-child {
+    display: none;
+  }
 .detailPane {
     min-width: 0;
     min-height: 0;

--- a/packages/ui/src/__tests__/processing-block.test.tsx
+++ b/packages/ui/src/__tests__/processing-block.test.tsx
@@ -43,6 +43,7 @@ describe('ProcessingBlock disclosure wiring (#1307)', () => {
     }));
 
     assert.match(markup, /class="[^"]*astryx-collapsible[^"]*"/);
+    assert.match(markup, /class="[^"]*maka-chat-disclosure[^"]*"/);
     assert.match(markup, /<button[^>]*aria-expanded="false"[^>]*aria-controls="[^"]+"/);
     assert.match(markup, /class="[^"]*astryx-collapsible-content[^"]*"/);
     assert.doesNotMatch(markup, /data-trow="row"/);
@@ -116,6 +117,7 @@ describe('deep-thinking disclosure', () => {
     }));
 
     assert.match(markup, /class="[^"]*astryx-collapsible[^"]*"/);
+    assert.match(markup, /class="[^"]*maka-chat-disclosure[^"]*"/);
     assert.match(markup, /<button[^>]*aria-expanded="false"[^>]*aria-controls="[^"]+"/);
     const trigger = markup.match(/(<button[^>]*aria-expanded="false"[\s\S]*?<\/button>)/)?.[1];
     assert.ok(trigger, 'deep-thinking disclosure must expose a collapsed trigger');

--- a/packages/ui/src/chat-turn.tsx
+++ b/packages/ui/src/chat-turn.tsx
@@ -1001,7 +1001,7 @@ function ProcessingBlock(props: { entries: FoldedTimelineChild[] }) {
   const summary = summarizeProcessing(entries, { live: running, locale });
   return (
     <AstryxCollapsible
-      className="flex flex-col"
+      className="maka-chat-disclosure flex flex-col"
       data-processing="block"
       data-settled={settled ? 'true' : undefined}
       isOpen={disclosure.open}
@@ -1075,7 +1075,7 @@ function DeepThinking(props: { text: string; live: boolean; truncated?: boolean 
   }, [displayed, props.live, open]);
   return (
     <AstryxCollapsible
-      className="flex flex-col"
+      className="maka-chat-disclosure flex flex-col"
       data-deep-thinking={props.live ? 'live' : undefined}
       isOpen={open}
       onOpenChange={setOpen}

--- a/packages/ui/src/tool-activity.tsx
+++ b/packages/ui/src/tool-activity.tsx
@@ -466,7 +466,7 @@ function ToolTrowGroup({ items }: { items: ToolActivityItem[] }) {
     : summarizeTrowTools(items, { locale });
   return (
     <AstryxCollapsible
-      className="flex flex-col"
+      className="maka-chat-disclosure flex flex-col"
       data-trow="group"
       data-settled={settled ? 'true' : undefined}
       isOpen={disclosure.open}
@@ -531,7 +531,7 @@ function ToolTrowRow({ item }: { item: ToolActivityItem }) {
   const rowLabel = item.intent ? formatToolIntent(item.intent) : resolveToolDisplayName(item, locale);
   return (
     <AstryxCollapsible
-      className="flex flex-col"
+      className="maka-chat-disclosure flex flex-col"
       data-trow="row"
       data-status={sandboxBlocked ? 'blocked' : item.status}
       data-settled={settled ? 'true' : undefined}


### PR DESCRIPTION
## Summary

- hide the redundant trailing chevron on chat processing, reasoning, and tool disclosures
- preserve full-row disclosure interaction, keyboard behavior, and `aria-expanded` semantics
- scope the visual override to chat disclosures so other collapsible surfaces are unchanged

## Why

Astryx Collapsible always appends a chevron to the far edge of its full-width trigger. In a conversation with many processing and tool rows, those repeated chevrons form a detached visual rail beside the actual scrollbar even though each row already has a semantic activity icon and a full-row click target.

## Validation

- `npm run test --workspace=@maka/ui` (296 tests passed)
- `npm run build:workspace-deps --workspace=@maka/desktop`
- `npm run build:renderer --workspace=@maka/desktop`
- `git diff --check`

<details>
<summary>中文说明</summary>

### 改动内容

- 隐藏聊天区域中“处理过程”“深度思考”和工具记录右侧重复的小箭头。
- 保留整行点击展开/收起、键盘操作以及 `aria-expanded` 无障碍语义。
- 样式仅作用于聊天折叠项，不影响设置页等其他折叠组件。

### 原因

Astryx 折叠组件会在全宽触发区域末尾自动添加箭头。聊天记录中连续出现多个折叠项时，这些箭头会在正文最右侧形成一列孤立的视觉轨道，并与真正的滚动条争抢注意力；而每行已经具有明确的业务图标和整行点击区域，因此该箭头属于冗余装饰。

### 验证

- UI 测试全部通过（296/296）。
- 工作区依赖构建通过。
- 桌面端 renderer 生产构建通过。
- `git diff --check` 通过。

</details>
